### PR TITLE
Give classifyCoverage a floor, so a night missing beats stops reading as clean (#977)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -353,6 +353,12 @@ public enum HRVAnalyzer {
     public enum RrCoverageVerdict: String, Equatable, Sendable {
         /// At or near 1.0 — the beat-time fits the wall clock. Nothing to explain.
         case plausible
+        /// Materially BELOW 1.0: beat-time is missing from the window. Not a clean night, and not an
+        /// over-count either — the analysis window silently is not the window it appears to be, because
+        /// beats that never arrived cannot be distinguished from beats that were never there. Same
+        /// principle as `unmeasurable` below: claiming a capture was fine when a seventh of it is absent
+        /// is the opposite of what this verdict exists to do. (#977)
+        case underCovered
         /// Over-covered, but collapsing same-second duplicates brings it back in range: the extra beats
         /// share a timestamp, so a de-dup at that granularity would fix it.
         case sameSecondOverCount
@@ -364,6 +370,17 @@ public enum HRVAnalyzer {
         /// when nothing was measurable, which is the opposite of what this verdict exists to do.
         case unmeasurable
     }
+
+    /// Tolerance BELOW 1.0 treated as "fits", the mirror of `coveragePlausibleCeiling`. Same allowance,
+    /// same caveat: a ROUNDING allowance rather than a tuned threshold, because whole-second timestamps
+    /// under-report as easily as they over-report. Where the real boundary sits still needs coverage
+    /// figures from several wearers — `IntelligenceEngine` already logs `coverage` in the `hrv diag`
+    /// line, so that distribution can be gathered from traces that already exist. (#977)
+    ///
+    /// Deliberately symmetric rather than fitted: picking a number between the reported 0.859 and the
+    /// 0.89 of #803's capture would be choosing a threshold to match one corpus, which is what the
+    /// ceiling's own comment warns against.
+    public static let coveragePlausibleFloor: Double = 1.0 - (coveragePlausibleCeiling - 1.0)
 
     /// Tolerance above 1.0 treated as "fits". R-R timestamps are whole seconds while beats are not, so a
     /// clean night can round fractionally over. This is a ROUNDING allowance, deliberately not a tuned
@@ -377,6 +394,9 @@ public enum HRVAnalyzer {
     /// the twins would otherwise disagree. NaN falls to `.unmeasurable` on both.
     public static func classifyCoverage(coverage: Double, collapsed: Double) -> RrCoverageVerdict {
         guard coverage > 0 else { return .unmeasurable }
+        // #977: the floor is tested BEFORE the ceiling so the negated-`>` NaN convention above still
+        // holds — a non-finite coverage has already left via `unmeasurable` and cannot reach here.
+        guard coverage >= coveragePlausibleFloor else { return .underCovered }
         guard coverage > coveragePlausibleCeiling else { return .plausible }
         return collapsed > coveragePlausibleCeiling ? .crossSecondOverCount : .sameSecondOverCount
     }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -380,6 +380,12 @@ public enum HRVAnalyzer {
     /// Deliberately symmetric rather than fitted: picking a number between the reported 0.859 and the
     /// 0.89 of #803's capture would be choosing a threshold to match one corpus, which is what the
     /// ceiling's own comment warns against.
+    ///
+    /// DERIVED rather than written as 0.90 so it cannot drift if the ceiling moves. IEEE-754 makes the
+    /// result 0.8999999999999999, not exactly 0.90, because 1.10 - 1.0 is not exactly 0.10 — harmless
+    /// (a night at exactly 0.90 is still above it) and identical on both platforms, since both fold the
+    /// same double arithmetic. Symmetry with the ceiling is the property worth keeping; the last bit is
+    /// not.
     public static let coveragePlausibleFloor: Double = 1.0 - (coveragePlausibleCeiling - 1.0)
 
     /// Tolerance above 1.0 treated as "fits". R-R timestamps are whole seconds while beats are not, so a

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrCoverageVerdictTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrCoverageVerdictTests.swift
@@ -95,7 +95,12 @@ final class RrCoverageVerdictTests: XCTestCase {
 
     /// The verdict is only ever a function of the pair, never of which is larger — a collapse can never
     /// exceed the raw coverage in practice, but the classifier must not depend on that holding.
+    ///
+    /// #977: this expected `.plausible` before the floor existed, which was the bug rather than the
+    /// intent — half the beat-time is missing at 0.5. The property under test is unchanged and is now
+    /// shown more sharply: `collapsed` at 9.9 screams over-count and the verdict still follows
+    /// `coverage`.
     func testCollapsedAboveCoverageStillClassifiesOnCoverageFirst() {
-        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: 0.5, collapsed: 9.9), .plausible)
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: 0.5, collapsed: 9.9), .underCovered)
     }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrCoverageVerdictTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrCoverageVerdictTests.swift
@@ -8,9 +8,51 @@ import XCTest
 /// evidence either way on whether the same-second de-dup scoped in #550 would be sufficient. It would not.
 final class RrCoverageVerdictTests: XCTestCase {
 
-    /// A night whose beat-time fits the wall clock. #803's 2026-07-15.
-    func testCleanNightIsPlausible() {
-        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: 0.89, collapsed: 0.88), .plausible)
+    /// #803's 2026-07-15, which this file used to call "a night whose beat-time fits the wall clock".
+    /// It does not: at 0.89 an eighth of the beat-time is missing. That label was written when the
+    /// classifier only looked upward, so `.plausible` was the ONLY verdict this night could receive —
+    /// it recorded the absence of an over-count, not the presence of a clean capture. With a floor it
+    /// reads as what it is. (#977)
+    ///
+    /// It lands 0.01 outside the symmetric allowance, so it is also the first case worth re-examining
+    /// if real coverage distributions ever say a WHOOP 4.0 night simply runs near 0.89.
+    func testNineTenthsOfANightIsNotAFitAnyMore() {
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: 0.89, collapsed: 0.88), .underCovered)
+    }
+
+    /// The reported case (#977): 0.859, measured on one wearer's WHOOP 5 corpus. Previously `.plausible`,
+    /// documented as "nothing to explain", for a night missing 14% of its beat-time.
+    func testTheReportedUnderCoveredNightIsNamed() {
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: 0.859, collapsed: 0.85), .underCovered)
+    }
+
+    /// The floor mirrors the ceiling exactly: 1.10 above, 0.90 below. Not fitted to any corpus — a
+    /// number chosen to sit between 0.859 and 0.89 would be tuned to one capture, which is what the
+    /// ceiling's own comment warns against.
+    func testFloorMirrorsCeiling() {
+        XCTAssertEqual(HRVAnalyzer.coveragePlausibleFloor, 0.90, accuracy: 1e-12)
+        XCTAssertEqual(1.0 - HRVAnalyzer.coveragePlausibleFloor,
+                       HRVAnalyzer.coveragePlausibleCeiling - 1.0, accuracy: 1e-12)
+    }
+
+    /// Symmetric with `testCeilingIsInclusive`: exactly at the floor still reads as fitting, a hair under
+    /// does not. Both boundaries are inclusive of the "fits" band.
+    func testFloorIsInclusive() {
+        let floor = HRVAnalyzer.coveragePlausibleFloor
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: floor, collapsed: floor), .plausible)
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: floor - 0.01, collapsed: 0.5), .underCovered)
+    }
+
+    /// A night that is almost entirely absent must not read as fitting either — the old classifier
+    /// returned `.plausible` for 0.01 as readily as for 1.00.
+    func testAnAlmostEmptyNightIsUnderCovered() {
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: 0.01, collapsed: 0.01), .underCovered)
+    }
+
+    /// A genuinely clean night still reads as one — the guard that this did not simply invert the bug.
+    func testACleanNightIsStillPlausible() {
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: 0.99, collapsed: 0.98), .plausible)
+        XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: 1.00, collapsed: 1.00), .plausible)
     }
 
     /// The night that prompted the report. #803's 2026-07-16: collapsing same-second duplicates drops it

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -354,7 +354,13 @@ object HrvAnalyzer {
      *
      * Deliberately symmetric rather than fitted: picking a number between the reported 0.859 and the
      * 0.89 of #803's capture would be choosing a threshold to match one corpus, which is what the
-     * ceiling's own comment warns against. Byte-parity twin of Swift `coveragePlausibleFloor`.
+     * ceiling's own comment warns against.
+     *
+     * DERIVED rather than written as 0.90 so it cannot drift if the ceiling moves. IEEE-754 makes the
+     * result 0.8999999999999999, not exactly 0.90, because 1.10 - 1.0 is not exactly 0.10 - harmless
+     * (a night at exactly 0.90 is still above it) and identical on both platforms, since both fold the
+     * same double arithmetic. Symmetry with the ceiling is the property worth keeping; the last bit is
+     * not. Byte-parity twin of Swift `coveragePlausibleFloor`.
      */
     const val COVERAGE_PLAUSIBLE_FLOOR: Double = 1.0 - (COVERAGE_PLAUSIBLE_CEILING - 1.0)
 

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -321,6 +321,12 @@ object HrvAnalyzer {
     enum class RrCoverageVerdict(val raw: String) {
         /** At or near 1.0 — the beat-time fits the wall clock. Nothing to explain. */
         PLAUSIBLE("plausible"),
+        /** Materially BELOW 1.0: beat-time is missing from the window. Not a clean night, and not an
+         *  over-count either — the analysis window silently is not the window it appears to be, because
+         *  beats that never arrived cannot be distinguished from beats that were never there. Same
+         *  principle as [UNMEASURABLE] below: claiming a capture was fine when a seventh of it is absent
+         *  is the opposite of what this verdict exists to do. (#977) */
+        UNDER_COVERED("underCovered"),
         /** Over-covered, but collapsing same-second duplicates brings it back in range: the extra beats
          *  share a timestamp, so a de-dup at that granularity would fix it. */
         SAME_SECOND_OVER_COUNT("sameSecondOverCount"),
@@ -339,6 +345,19 @@ object HrvAnalyzer {
      *  point of logging the verdict in the first place. Twin of Swift `coveragePlausibleCeiling`. */
     const val COVERAGE_PLAUSIBLE_CEILING: Double = 1.10
 
+    /**
+     * Tolerance BELOW 1.0 treated as "fits", the mirror of [COVERAGE_PLAUSIBLE_CEILING]. Same allowance,
+     * same caveat: a ROUNDING allowance rather than a tuned threshold, because whole-second timestamps
+     * under-report as easily as they over-report. Where the real boundary sits still needs coverage
+     * figures from several wearers — IntelligenceEngine already logs `coverage` in the `hrv diag` line,
+     * so that distribution can be gathered from traces that already exist. (#977)
+     *
+     * Deliberately symmetric rather than fitted: picking a number between the reported 0.859 and the
+     * 0.89 of #803's capture would be choosing a threshold to match one corpus, which is what the
+     * ceiling's own comment warns against. Byte-parity twin of Swift `coveragePlausibleFloor`.
+     */
+    const val COVERAGE_PLAUSIBLE_FLOOR: Double = 1.0 - (COVERAGE_PLAUSIBLE_CEILING - 1.0)
+
     /** Classify a night from its coverage pair. Pure. Byte-parity twin of Swift `classifyCoverage`.
      *
      *  Both platforms use the NEGATED `>` form rather than `<=` so a non-finite input lands identically:
@@ -346,6 +365,9 @@ object HrvAnalyzer {
      *  the twins would otherwise disagree. NaN falls to UNMEASURABLE on both. */
     fun classifyCoverage(coverage: Double, collapsed: Double): RrCoverageVerdict {
         if (!(coverage > 0.0)) return RrCoverageVerdict.UNMEASURABLE
+        // #977: the floor is tested BEFORE the ceiling so the negated-`>` NaN convention above still
+        // holds — a non-finite coverage has already left via UNMEASURABLE and cannot reach here.
+        if (!(coverage >= COVERAGE_PLAUSIBLE_FLOOR)) return RrCoverageVerdict.UNDER_COVERED
         if (!(coverage > COVERAGE_PLAUSIBLE_CEILING)) return RrCoverageVerdict.PLAUSIBLE
         return if (collapsed > COVERAGE_PLAUSIBLE_CEILING) RrCoverageVerdict.CROSS_SECOND_OVER_COUNT
         else RrCoverageVerdict.SAME_SECOND_OVER_COUNT

--- a/android/app/src/test/java/com/noop/analytics/RrCoverageVerdictTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RrCoverageVerdictTest.kt
@@ -12,13 +12,68 @@ import org.junit.Test
  */
 class RrCoverageVerdictTest {
 
-    /** A night whose beat-time fits the wall clock. #803's 2026-07-15. */
+    /**
+     * #803's 2026-07-15, which this file used to call "a night whose beat-time fits the wall clock".
+     * It does not: at 0.89 an eighth of the beat-time is missing. That label was written when the
+     * classifier only looked upward, so PLAUSIBLE was the ONLY verdict this night could receive — it
+     * recorded the absence of an over-count, not the presence of a clean capture. (#977)
+     *
+     * It lands 0.01 outside the symmetric allowance, so it is also the first case worth re-examining if
+     * real coverage distributions ever say a WHOOP 4.0 night simply runs near 0.89.
+     */
     @Test
-    fun cleanNightIsPlausible() {
+    fun nineTenthsOfANightIsNotAFitAnyMore() {
         assertEquals(
-            HrvAnalyzer.RrCoverageVerdict.PLAUSIBLE,
+            HrvAnalyzer.RrCoverageVerdict.UNDER_COVERED,
             HrvAnalyzer.classifyCoverage(0.89, 0.88),
         )
+    }
+
+    /** The reported case (#977): 0.859 on one wearer's WHOOP 5 corpus, previously "nothing to explain". */
+    @Test
+    fun theReportedUnderCoveredNightIsNamed() {
+        assertEquals(
+            HrvAnalyzer.RrCoverageVerdict.UNDER_COVERED,
+            HrvAnalyzer.classifyCoverage(0.859, 0.85),
+        )
+    }
+
+    /** The floor mirrors the ceiling exactly: 1.10 above, 0.90 below. Not fitted to any corpus. */
+    @Test
+    fun floorMirrorsCeiling() {
+        assertEquals(0.90, HrvAnalyzer.COVERAGE_PLAUSIBLE_FLOOR, 1e-12)
+        assertEquals(
+            HrvAnalyzer.COVERAGE_PLAUSIBLE_CEILING - 1.0,
+            1.0 - HrvAnalyzer.COVERAGE_PLAUSIBLE_FLOOR,
+            1e-12,
+        )
+    }
+
+    /** Symmetric with the ceiling test: exactly at the floor fits, a hair under does not. */
+    @Test
+    fun floorIsInclusive() {
+        val floor = HrvAnalyzer.COVERAGE_PLAUSIBLE_FLOOR
+        assertEquals(HrvAnalyzer.RrCoverageVerdict.PLAUSIBLE, HrvAnalyzer.classifyCoverage(floor, floor))
+        assertEquals(
+            HrvAnalyzer.RrCoverageVerdict.UNDER_COVERED,
+            HrvAnalyzer.classifyCoverage(floor - 0.01, 0.5),
+        )
+    }
+
+    /** An almost entirely absent night must not read as fitting either. */
+    @Test
+    fun anAlmostEmptyNightIsUnderCovered() {
+        assertEquals(
+            HrvAnalyzer.RrCoverageVerdict.UNDER_COVERED,
+            HrvAnalyzer.classifyCoverage(0.01, 0.01),
+        )
+    }
+
+    /** A genuinely clean night still reads as one — the guard that this did not invert the bug. */
+    @Test
+    fun aCleanNightIsStillPlausible() {
+        assertEquals(HrvAnalyzer.RrCoverageVerdict.PLAUSIBLE, HrvAnalyzer.classifyCoverage(0.99, 0.98))
+        assertEquals(HrvAnalyzer.RrCoverageVerdict.PLAUSIBLE, HrvAnalyzer.classifyCoverage(1.00, 1.00))
     }
 
     /**

--- a/android/app/src/test/java/com/noop/analytics/RrCoverageVerdictTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RrCoverageVerdictTest.kt
@@ -141,11 +141,17 @@ class RrCoverageVerdictTest {
         )
     }
 
-    /** The verdict keys on coverage first; it must not depend on collapsed <= coverage holding. */
+    /**
+     * The verdict keys on coverage first; it must not depend on collapsed <= coverage holding.
+     *
+     * #977: this expected PLAUSIBLE before the floor existed, which was the bug rather than the intent —
+     * half the beat-time is missing at 0.5. The property under test is unchanged and is now shown more
+     * sharply: `collapsed` at 9.9 screams over-count and the verdict still follows `coverage`.
+     */
     @Test
     fun collapsedAboveCoverageStillClassifiesOnCoverageFirst() {
         assertEquals(
-            HrvAnalyzer.RrCoverageVerdict.PLAUSIBLE,
+            HrvAnalyzer.RrCoverageVerdict.UNDER_COVERED,
             HrvAnalyzer.classifyCoverage(0.5, 9.9),
         )
     }


### PR DESCRIPTION
Fixes #977.

The other half of that issue — #1032 fixed the RSA splicing, this fixes the classifier — and the reason I said this half was blocked turned out to be wrong.

## The bug

`classifyCoverage` has a ceiling and no floor, so **every** coverage from `0.000001` to `1.10` returns `.plausible` — which is documented as:

> At or near 1.0 — the beat-time fits the wall clock. **Nothing to explain.**

The code does not implement its own documentation. A night missing 14 % of its beat-time reported "nothing to explain", and so would one missing 99 %.

This was never considered and rejected — it was never in frame. #257 and #550 were both *over*-count reports ("HRV reads ~2× high"), so the classifier was built to explain coverage above 1.0. `.unmeasurable` already states the governing principle in the file:

> Absence of evidence, NOT a clean night: reporting those as `plausible` would claim the capture was fine when nothing was measurable, which is the opposite of what this verdict exists to do.

Under-coverage makes the same false claim.

## The floor is derived, not chosen

```
coveragePlausibleFloor = 1.0 - (coveragePlausibleCeiling - 1.0) = 0.90
```

The ceiling's own rounding allowance, mirrored. Whole-second timestamps under-report exactly as easily as they over-report, so the same tolerance applies in both directions.

I deliberately did **not** pick a number between the reported 0.859 and #803's 0.89. A threshold chosen to separate two specific captures is fitted to one corpus, which is precisely what the ceiling's comment warns against.

## What I got wrong first time

I originally argued this was unbuildable because `testCleanNightIsPlausible` pins `0.89` as a clean night from a real capture, 0.03 above the reported 0.859 — so any floor between them would reclassify real data on a hunch.

That reasoning does not hold. **The fixture is not evidence that 0.89 is a healthy night.** With only a ceiling, `.plausible` was the *sole* verdict that night could receive; the test recorded the absence of an over-count, not the presence of a clean capture. Its own file header says the class exists to pin "WHICH over-count a night has". Someone wrote "fits the wall clock" while reasoning about one direction, and 0.89 means an eighth of the beat-time is missing.

So the fixture changes to `.underCovered`, and its comment now says why it was mislabelled — and flags it as the first case to revisit if real distributions ever show a WHOOP 4.0 night simply runs near 0.89. It sits 0.01 outside the allowance, which is close enough to deserve that note.

## Scope

Both platforms, byte-parity. The floor is tested **before** the ceiling so the file's negated-`>` NaN convention still holds — a non-finite coverage has already left via `.unmeasurable`.

No consumer switches on the verdict; it reaches the `hrv diag` line as a string, so the new case cannot break an exhaustive match. Six tests per platform, including a guard that a genuinely clean night (0.99, 1.00) still reads `.plausible` — this must not simply invert the bug.

Nothing is scored differently. This changes what the diagnostic *says*, which is the instrument the reporter needed to see under-coverage at all.
