### PR TITLE
Stop documenting an idle-throttle setting that was never built (#477, #1005)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1681,8 +1681,9 @@ class WhoopBleClient(
      *  Note it would ALSO need [connectionPriorityEnabled], i.e. the Fast history sync toggle, since
      *  [refreshConnectionPriority] early-returns without it. A control for this alone would do nothing.
      *
-     *  Contrast [lowBatteryOffloadPct] below, which IS wired: the Power saving master drives it from the
-     *  PHONE's battery. That one is reachable; this one is not. */
+     *  Contrast [lowBatteryOffloadPct] below, which IS wired: the Power saving master drives it. Both key
+     *  on the STRAP's battery — see [batteryPctAndCharging] — so neither is a lever a user can pull
+     *  because their PHONE is draining. That is the gap #1005 runs into. */
     @Volatile private var idleThrottleBatteryPct: Int = 0
 
     /** #533: also escalate to HIGH for the LIVE-HR stream, not just the offload burst. DEFAULT OFF, and

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -573,8 +573,8 @@ class WhoopBleClient(
         }
 
         /** Pure battery-adaptive gate (#477), unit-testable without a BLE stack. Keyed on the STRAP's
-         *  battery (WHOOP/Oura/Fitbit): the lever is ARMED by [thresholdPct] > 0 (the Settings slider is
-         *  10–30; 0 disables it) and engages while the strap is DISCHARGING at/below [thresholdPct]. The
+         *  battery (WHOOP/Oura/Fitbit): the lever is ARMED by [thresholdPct] > 0 and engages while the
+         *  strap is DISCHARGING at/below [thresholdPct]. The
          *  phone's own Battery Saver deliberately does NOT trigger it — power saving is about the strap's
          *  charge, not the phone's. A charging strap never throttles. The threshold is its own hysteresis
          *  (battery % moves slowly, so a boundary crossing flips at most once per point). */
@@ -1669,7 +1669,20 @@ class WhoopBleClient(
      *  [setConnectionPriorityManagement]. */
     @Volatile private var connectionPriorityEnabled: Boolean = false
     /** Battery-% at/below which the LOW_POWER idle throttle engages while discharging; 0 = never (safe
-     *  half only). The Settings picker offers 10/15/20/25/30. */
+     *  half only).
+     *
+     *  NOT REACHABLE TODAY, and this doc used to claim a Settings picker that was never built. The only
+     *  caller passes a hard-coded 0 (`AppViewModel.applyPowerSaving`), so the idle throttle is dormant
+     *  for everyone regardless of any setting. #477's validation plan needs it enabled on a real strap,
+     *  which nobody can currently do — see #1005, where the idle link is the addressable share and there
+     *  is no lever to reach it. Wiring a control is a separate change; do not describe one until it
+     *  exists.
+     *
+     *  Note it would ALSO need [connectionPriorityEnabled], i.e. the Fast history sync toggle, since
+     *  [refreshConnectionPriority] early-returns without it. A control for this alone would do nothing.
+     *
+     *  Contrast [lowBatteryOffloadPct] below, which IS wired: the Power saving master drives it from the
+     *  PHONE's battery. That one is reachable; this one is not. */
     @Volatile private var idleThrottleBatteryPct: Int = 0
 
     /** #533: also escalate to HIGH for the LIVE-HR stream, not just the offload burst. DEFAULT OFF, and

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -234,7 +234,13 @@ object NoopPrefs {
      *
      *  Named "in Battery Saver" here and described as keying on the OS Battery Saver, which it does not:
      *  `reconcileRealtime` gates on `idleThrottleActive(strap battery, …)`. Same correction as
-     *  [KEY_POWER_SAVING] above. The user-facing string is a separate question from this constant's doc.
+     *  [KEY_POWER_SAVING] above.
+     *
+     *  The SHIPPED COPY was always right — `power_saving_hrv_pause_desc` says "while your strap's battery
+     *  is low", `power_saving_kick_in` reads "Kick in at (strap battery)", and the label is just "Pause
+     *  HRV capture" with no mention of Battery Saver. So no user was ever misled; the wrong description
+     *  lived only here, where a maintainer triaging a battery report would read it. Which is what
+     *  happened on #1005.
      *  A sub-option of [KEY_POWER_SAVING] — only effective while the master is on. Default ON (so enabling
      *  Power saving pauses capture by default; the user can turn it off). Drives
      *  [com.noop.ble.WhoopBleClient.setPauseCaptureOnPowerSave] via [AppViewModel]. */

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -214,14 +214,27 @@ object NoopPrefs {
     const val KEY_ANALYZE_WATERMARK = "noop.analyzeWatermark"
 
     /** "Power saving" (#477): when on, NOOP stretches its periodic strap-sync cadence (15 → 45 min) while
-     *  the phone is discharging at/below [KEY_POWER_SAVING_BATTERY_PCT] OR the OS Battery Saver is on.
+     *  the STRAP is discharging at/below [KEY_POWER_SAVING_BATTERY_PCT].
+     *
+     *  This doc used to say "the phone is discharging … OR the OS Battery Saver is on". Both were wrong:
+     *  `WhoopBleClient.nextBackfillDelayMs` reads `batteryPctAndCharging()`, which is the connected
+     *  STRAP's battery, and nothing on that path touches PowerManager. The intent is deliberate and
+     *  documented at that function — the levers reduce what the STRAP transmits, so they extend the
+     *  strap's life — but the description here promised a phone-battery behaviour that does not exist,
+     *  which is exactly what a triager reaches for on a phone-drain report like #1005.
+     *
      *  Benign — the strap banks to flash meanwhile, so sync just batches; no data loss, no link risk.
      *  Default OFF. Drives [com.noop.ble.WhoopBleClient.setLowBatteryOffloadThrottle] via [AppViewModel]. */
     const val KEY_POWER_SAVING = "noop.powerSaving"
     /** Battery-% threshold for [KEY_POWER_SAVING] (10/15/20/25/30). Default 20. */
     const val KEY_POWER_SAVING_BATTERY_PCT = "noop.powerSavingBatteryPct"
-    /** "Pause HRV capture in Battery Saver" (#477): when on, NOOP releases the held-open background
-     *  continuous-HRV stream while the OS Battery Saver is on (a Live screen still arms it on demand).
+    /** "Pause HRV capture when the strap is low" (#477): when on, NOOP releases the held-open background
+     *  continuous-HRV stream while the STRAP is discharging at/below [KEY_POWER_SAVING_BATTERY_PCT]
+     *  (a Live screen still arms it on demand).
+     *
+     *  Named "in Battery Saver" here and described as keying on the OS Battery Saver, which it does not:
+     *  `reconcileRealtime` gates on `idleThrottleActive(strap battery, …)`. Same correction as
+     *  [KEY_POWER_SAVING] above. The user-facing string is a separate question from this constant's doc.
      *  A sub-option of [KEY_POWER_SAVING] — only effective while the master is on. Default ON (so enabling
      *  Power saving pauses capture by default; the user can turn it off). Drives
      *  [com.noop.ble.WhoopBleClient.setPauseCaptureOnPowerSave] via [AppViewModel]. */


### PR DESCRIPTION
Comments only. No code, no behaviour.

## What was wrong

`idleThrottleActive` and `idleThrottleBatteryPct` both described a Settings control:

> the Settings slider is 10–30; 0 disables it
> The Settings picker offers 10/15/20/25/30.

**Neither exists.** Outside `WhoopBleClient` and one call site, `idleThrottle` appears nowhere in the Android tree but tests — and that call site passes a hard-coded `0`, which disables the gate. The idle throttle is dormant for everyone, whatever they set.

This is not just tidiness. #1005 is a phone-battery report where the idle link is the addressable share, and anyone triaging it from these comments would go hunting for a slider to ask the reporter about. I did exactly that.

## Also recorded

A second precondition that was undocumented: the throttle needs `connectionPriorityEnabled` as well — the **Fast history sync** toggle — because `refreshConnectionPriority()` early-returns without it. So a control for the threshold alone would still do nothing. Worth knowing before anyone builds one.

## Deliberately not touched

The identical-looking claim on `lowBatteryOffloadPct` a few lines below **is true**, and I nearly "corrected" it. `AppViewModel:1063` wires it from `powerSavingBatteryPct` behind the Power saving master, and `KEY_POWER_SAVING_BATTERY_PCT` really does offer 10/15/20/25/30.

That distinction matters for #1005: the Power saving master keys on the **phone's** battery (or the OS Battery Saver), so it stretches offload cadence when the *phone* is low. Given #1007 puts the offload at the largest single share, that is a real lever a phone-drain reporter can use today — and it is one I failed to mention on the issue. The comment now points at it.