### PR TITLE
Make the idle→LOW_POWER throttle reachable so #477 can be validated

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1097,15 +1097,6 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         applyPowerSaving()
     }
 
-    /** #477: opt into the idle->LOW_POWER throttle at [pct] strap-battery %, 0 to disable. Re-applies
-     *  immediately rather than at next launch, and NoopPrefs clamps the value. No UI drives this yet -
-     *  it exists so validating #477 does not require a relaunch, and so a Test Centre or Settings
-     *  control can be added later without touching the BLE layer. */
-    fun setIdleThrottleBatteryPct(pct: Int) {
-        NoopPrefs.setIdleThrottleBatteryPct(appContext, pct)
-        applyPowerSaving()
-    }
-
     /** Flip the experimental LE 2M PHY preference (#533). Persists + pushes it to the client; it applies
      *  at the next offload burst, and switching it off releases an already-2M link back to 1M. */
     fun setFastLinkPhy(enabled: Boolean) {

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1052,9 +1052,12 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         // for the bounded offload burst (faster backlog drain). The RISKY idle→LOW_POWER half stays at 0
         // (still dormant, #478), and live-HR does not escalate (see WhoopBleClient.escalateForLiveHr) —
         // realtimeArmed covers the overnight capture window, which would otherwise hold HIGH for hours.
+        // #477/#1005: the RISKY idle->LOW_POWER half was hard-coded to 0 here, so it was dormant for
+        // everyone and its own validation plan could never run. Reads the pref now; still 0 by default,
+        // so this changes nothing for anyone who has not deliberately set it.
         ble.setConnectionPriorityManagement(
             enabled = NoopPrefs.fastHistorySync(appContext),
-            idleThrottleBatteryPct = 0,
+            idleThrottleBatteryPct = NoopPrefs.idleThrottleBatteryPct(appContext),
         )
         // #533: the second, orthogonal sync-speed lever — prefer LE 2M around the offload burst. Also
         // independent of the Power-saving master, and its own toggle so a field report can tell the two
@@ -1091,6 +1094,15 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
      *  offload burst uses the new priority without waiting for a reconnect. */
     fun setFastHistorySync(enabled: Boolean) {
         NoopPrefs.setFastHistorySync(appContext, enabled)
+        applyPowerSaving()
+    }
+
+    /** #477: opt into the idle->LOW_POWER throttle at [pct] strap-battery %, 0 to disable. Re-applies
+     *  immediately rather than at next launch, and NoopPrefs clamps the value. No UI drives this yet -
+     *  it exists so validating #477 does not require a relaunch, and so a Test Centre or Settings
+     *  control can be added later without touching the BLE layer. */
+    fun setIdleThrottleBatteryPct(pct: Int) {
+        NoopPrefs.setIdleThrottleBatteryPct(appContext, pct)
         applyPowerSaving()
     }
 

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -271,6 +271,37 @@ object NoopPrefs {
         of(context).edit().putBoolean(KEY_FAST_HISTORY_SYNC, enabled).apply()
     }
 
+    /** EXPERIMENTAL (#477): strap-battery % at/below which an IDLE link drops to LOW_POWER while the
+     *  strap is discharging. 0 = off, which is the default and today's behaviour for everyone.
+     *
+     *  Two preconditions, both easy to miss. It needs [KEY_FAST_HISTORY_SYNC] on as well, because
+     *  `refreshConnectionPriority` early-returns without connection-priority management; and it keys on
+     *  the STRAP's battery, not the phone's, so a healthy strap never trips it however low the phone is.
+     *  Neither is a bug, but a value set here alone will look like it does nothing.
+     *
+     *  Deliberately has NO Settings control yet. #477's validation plan needs the throttle enabled on a
+     *  real strap and nobody could do that while the caller passed a hard-coded 0; this makes it
+     *  reachable, without shipping a user-facing row whose two preconditions are invisible. LOW_POWER
+     *  lengthens the connection interval, which can drop a link, so it stays opt-in until a field report
+     *  says otherwise.
+     *
+     *  CLAMPED to 0 or 10..30 on read: settable out-of-band on a debug build, and an unclamped 95 would
+     *  engage the throttle at essentially all times, which is a foot-gun rather than a test. */
+    const val KEY_IDLE_THROTTLE_BATTERY_PCT = "noop.idleThrottleBatteryPct"
+
+    fun idleThrottleBatteryPct(context: Context): Int =
+        clampIdleThrottlePct(of(context).getInt(KEY_IDLE_THROTTLE_BATTERY_PCT, 0))
+
+    fun setIdleThrottleBatteryPct(context: Context, pct: Int) {
+        of(context).edit().putInt(KEY_IDLE_THROTTLE_BATTERY_PCT, clampIdleThrottlePct(pct)).apply()
+    }
+
+    /** 0 (off) or 10..30, the range every other battery threshold in this file offers. Anything else is
+     *  out of range rather than a smaller/larger preference, so it reads as OFF - failing closed, because
+     *  the failure mode of the alternative is a link that keeps dropping. Pure, so it is testable
+     *  without a Context. */
+    internal fun clampIdleThrottlePct(raw: Int): Int = if (raw in 10..30) raw else 0
+
     /** EXPERIMENTAL (#533): prefer the LE 2M PHY around the historical offload. LE 2M doubles the symbol
      *  rate, so the same bytes spend half the air-time — it should cost LESS radio energy per byte, not
      *  more (unlike [KEY_FAST_HISTORY_SYNC]'s connection-interval lever). NOOP has never called

--- a/android/app/src/test/java/com/noop/ui/IdleThrottlePrefTest.kt
+++ b/android/app/src/test/java/com/noop/ui/IdleThrottlePrefTest.kt
@@ -1,0 +1,56 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #477/#1005 — the clamp on the idle-throttle threshold.
+ *
+ * The throttle drops an IDLE link to LOW_POWER, which lengthens the connection interval and can drop the
+ * link outright. It has no Settings control on purpose, so the only way to set it is out-of-band on a
+ * debug build — which is exactly the situation where a typo'd 95 would arm it at essentially all times
+ * rather than at the low-battery edge it is meant for.
+ *
+ * So the clamp fails CLOSED: anything outside 0 or 10..30 reads as OFF. Failing open would mean a
+ * mistyped value quietly degrades the link for as long as it is set.
+ */
+class IdleThrottlePrefTest {
+
+    /** The offered range passes through unchanged — these are the values every sibling threshold uses. */
+    @Test fun inRangeValuesSurvive() {
+        for (pct in listOf(10, 15, 20, 25, 30)) {
+            assertEquals(pct, NoopPrefs.clampIdleThrottlePct(pct))
+        }
+        assertEquals(11, NoopPrefs.clampIdleThrottlePct(11))
+        assertEquals(29, NoopPrefs.clampIdleThrottlePct(29))
+    }
+
+    /** 0 is OFF and must stay 0 rather than being clamped up into the armed range. */
+    @Test fun zeroStaysOff() {
+        assertEquals(0, NoopPrefs.clampIdleThrottlePct(0))
+    }
+
+    /** The foot-gun: a high value would engage the throttle whenever the strap is discharging at all. */
+    @Test fun aHighValueReadsAsOffNotAsAlwaysOn() {
+        assertEquals(0, NoopPrefs.clampIdleThrottlePct(95))
+        assertEquals(0, NoopPrefs.clampIdleThrottlePct(100))
+        assertEquals(0, NoopPrefs.clampIdleThrottlePct(31))
+    }
+
+    /** Below the range is off too — 5% of strap battery is close enough to flat that throttling then
+     *  buys nothing, and negative values are simply nonsense. */
+    @Test fun belowRangeAndNegativeReadAsOff() {
+        assertEquals(0, NoopPrefs.clampIdleThrottlePct(9))
+        assertEquals(0, NoopPrefs.clampIdleThrottlePct(5))
+        assertEquals(0, NoopPrefs.clampIdleThrottlePct(-1))
+        assertEquals(0, NoopPrefs.clampIdleThrottlePct(Int.MIN_VALUE))
+    }
+
+    /** The boundaries themselves, stated once so a future range change has to touch this line. */
+    @Test fun boundariesAreInclusive() {
+        assertEquals(10, NoopPrefs.clampIdleThrottlePct(10))
+        assertEquals(30, NoopPrefs.clampIdleThrottlePct(30))
+        assertEquals(0, NoopPrefs.clampIdleThrottlePct(9))
+        assertEquals(0, NoopPrefs.clampIdleThrottlePct(31))
+    }
+}


### PR DESCRIPTION
The minimal wiring discussed on #1005. Three files, no UI, no new strings.

## Why

#477's risky half — drop an **idle** link to `LOW_POWER`, the long interval that is the real all-day saving — shipped dormant and stayed that way. `AppViewModel.applyPowerSaving` passed a hard-coded `0`, and `0` disables the gate, so **nobody could arm it however they configured the app**. Its own validation plan says it "must be validated on a real strap"; that was impossible.

Same catch-22 #1027 broke for the offload: the thing could not be validated because it could not be reached.

## What changes

A pref, clamped, read where the `0` used to be. **Default `0`, so behaviour is byte-identical for anyone who does not deliberately set it.** `setConnectionPriorityManagement` already restores BALANCED when the value returns to 0 — that edge was handled in #533 — so it is reversible without waiting for a reconnect.

## No Settings control, deliberately

The throttle has two preconditions that would be invisible in a Settings row:

1. It needs **Fast history sync** on as well, because `refreshConnectionPriority()` early-returns without connection-priority management.
2. It keys on the **strap's** battery, so a healthy strap never trips it however low the phone is.

A row that silently does nothing in either case generates "this setting is broken" reports rather than the field data #477 wants. A Test Centre control is a small follow-up if validators would rather not use adb; it would call `NoopPrefs.setIdleThrottleBatteryPct` (which applies the write clamp) and then `applyPowerSaving()`, with no BLE-layer change. I first added a passthrough on `AppViewModel` for that and removed it on re-review — nothing called it, so the relaunch it claimed to avoid was not actually avoided.

## Fails closed

Clamped to `0` or `10..30` on read. With no UI the only way to set it is out-of-band on a debug build, which is exactly where a typo'd `95` would arm the throttle at essentially all times rather than at the low-battery edge. Anything out of range reads as OFF, because a link that keeps dropping is the worse failure. Five tests cover it.

## What this does NOT do

**It does not address #1005**, and should not be read as doing so. That is a phone-battery report; this keys on the strap's. The lever a phone-drain user can already reach is the **Power saving** master, which stretches offload cadence from the *phone's* battery — a point I missed on that issue and have corrected in #1034.
