### PR TITLE
Align the es/pt-PT battery alerts to one register (#867 follow-through)

### DIFF
--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -112725,7 +112725,7 @@
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "Recarregue o teu WHOOP antes desta noite."
+            "value": "Recarrega o teu WHOOP antes desta noite."
           }
         },
         "ru": {

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1743,10 +1743,10 @@
     </plurals>
 
     <!-- Alertas de batería escaladas (cruce crítico de carga + guardia nocturna antes de dormir). -->
-    <string name="battery_critical_title">Cargue su WHOOP ahora</string>
-    <string name="battery_critical_body">Queda %1$d%%. La correa deja de registrar cerca del 10%% — no captará esta noche si no la carga.</string>
+    <string name="battery_critical_title">Carga tu WHOOP ahora</string>
+    <string name="battery_critical_body">Queda %1$d%%. La correa deja de registrar cerca del 10%% — no captará esta noche si no la cargas.</string>
     <string name="battery_bedtime_title">No aguantará la noche</string>
-    <string name="battery_bedtime_body">Queda %1$s de registro, pero esta noche necesita alrededor de %2$s. Cárguela antes de acostarse.</string>
+    <string name="battery_bedtime_body">Queda %1$s de registro, pero esta noche necesita alrededor de %2$s. Carga tu WHOOP antes de acostarte.</string>
 
     <!-- #867: the three older battery notifications, previously raw Kotlin literals in
          BatteryAlertNotifier and therefore English in every locale. Wording and translations are the

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1737,10 +1737,10 @@
     </plurals>
 
     <!-- Alertas de bateria escalados (cruzamento crítico de carga + guarda noturna antes de deitar). -->
-    <string name="battery_critical_title">Carregue já a sua WHOOP</string>
-    <string name="battery_critical_body">Restam %1$d%%. A bracelete deixa de gravar perto dos 10%% – não vai captar esta noite se não a carregar.</string>
+    <string name="battery_critical_title">Carrega já o teu WHOOP</string>
+    <string name="battery_critical_body">Restam %1$d%%. A bracelete deixa de gravar perto dos 10%% – não vai captar esta noite se não a carregares.</string>
     <string name="battery_bedtime_title">Não dura a noite</string>
-    <string name="battery_bedtime_body">Restam %1$s de gravação, mas esta noite precisa de cerca de %2$s. Carregue antes de se deitar.</string>
+    <string name="battery_bedtime_body">Restam %1$s de gravação, mas esta noite precisa de cerca de %2$s. Carrega antes de te deitares.</string>
 
     <!-- #867: the three older battery notifications, previously raw Kotlin literals in
          BatteryAlertNotifier and therefore English in every locale. Wording and translations are the
@@ -1748,7 +1748,7 @@
     <string name="battery_runtime_title">Bateria fraca da correia</string>
     <string name="battery_runtime_body">Autonomia restante no teu WHOOP: %1$s. Recarrega-o esta noite.</string>
     <string name="battery_low_title">Bateria fraca</string>
-    <string name="battery_low_body">Recarregue o teu WHOOP antes desta noite.</string>
+    <string name="battery_low_body">Recarrega o teu WHOOP antes desta noite.</string>
     <string name="battery_full_title">Correia totalmente carregada</string>
     <string name="battery_full_body">O teu WHOOP está a 100%.</string>
 


### PR DESCRIPTION
#867 asked for this **in the same PR** as the string extraction. The extraction landed correctly; this part did not.

## What the mismatch looks like

The six extracted keys came from the Apple catalogue and are informal. #864's four are formal in exactly these two locales. They now sit in the same file:

| | es |
|---|---|
| #864 | `Cargue su WHOOP ahora` · `Cárguela antes de acostarse` |
| extracted | `Carga tu WHOOP` · `Recarga tu WHOOP` · `Tu WHOOP` |

#867 predicted precisely this — "once these six land beside them the mismatch becomes visible within a single file".

## Every replacement is #866's wording, verbatim

Not new translation. These strings already exist in `Localizable.xcstrings` and went through review there, so this is a copy:

- `Carga tu WHOOP ahora` · `si no la cargas` · `Carga tu WHOOP antes de acostarte`
- `Carrega já o teu WHOOP` · `se não a carregares` · `Carrega antes de te deitares`

That includes the orphan clitic the issue's own comment flagged: `Cárguela antes de acostarse` used a feminine pronoun with no antecedent in that sentence, where the device is masculine (`tu WHOOP`) everywhere around it. Apple names the object instead.

## One thing the issue could not have caught

pt-PT `battery_low_body` reads **`Recarregue o teu WHOOP`** — formal verb, informal possessive, in one sentence. Same defect class as the German `Du kannst… Kombinieren Sie` that #1029 just fixed.

It is **identical on Apple**, so #866 introduced it and the extraction copied it faithfully. Fixed on both sides, so the twins stay byte-identical.

## Not doing what #867 asked for on the percent

The issue said `battery_full_body` "needs its percent escaped as `100%%`". **That advice is wrong and following it would ship a visible bug.**

`getString(id)` with no format arguments does not run `String.format`, so `100%` renders correctly and `100%%` would display two percent signs. The sibling `battery_critical_body` does use `%%` — because it is called as `getString(id, currPct)`, *with* args. The two call sites differ, and the implementer was right to leave `battery_full_body` alone.

I repeated the issue's advice as a review finding before checking the call sites. Recording it here so the next person does not re-apply it.

## Verification

`Tools/i18n_audit.py --ci main` clean; both XML files and the catalogue parse. Strings only — no code, no keys added or removed, no behaviour change.

Machine-assisted only in the sense of being copied between catalogues; a native reader is still welcome to check the two locales, as ever.