### PR TITLE
Android: complete 16 half-English paragraphs from the Swift catalogue (#557)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/CaffeineLog.kt
+++ b/android/app/src/main/java/com/noop/ui/CaffeineLog.kt
@@ -163,8 +163,7 @@ fun CaffeineLogCard() {
         NoopCard {
             Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
                 Text(
-                    uiString(R.string.l10n_caffeine_log_log_a_coffee_tea_or_energy_982bde5b) +
-                        "still be active. It's a guide based on a typical 5 to 6 hour half-life, not a measurement.",
+                    uiString(R.string.l10n_caffeine_log_log_a_coffee_tea_or_energy_982bde5b),
                     style = NoopType.footnote,
                     color = Palette.textTertiary,
                 )

--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -768,8 +768,7 @@ fun DataSourcesScreen(vm: AppViewModel) {
                 Column(modifier = Modifier.weight(1f)) {
                     Text(uiString(R.string.l10n_data_sources_screen_broadcast_hr_from_this_phone_10e5605c), style = NoopType.subhead, color = Palette.textPrimary)
                     Text(
-                        uiString(R.string.l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439) +
-                            "bike or app to see your strap's heart rate there.",
+                        uiString(R.string.l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439),
                         style = NoopType.footnote,
                         color = Palette.textTertiary,
                     )
@@ -852,8 +851,7 @@ fun DataSourcesScreen(vm: AppViewModel) {
             },
             text = {
                 Text(
-                    uiString(R.string.l10n_data_sources_screen_this_permanently_deletes_everything_imported_from_f42e760e) +
-                        "sleep, steps, workouts and more. Your live strap data is untouched. This can't be undone.",
+                    uiString(R.string.l10n_data_sources_screen_this_permanently_deletes_everything_imported_from_f42e760e),
                     style = NoopType.subhead,
                     color = Palette.textSecondary,
                 )

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -1328,8 +1328,7 @@ private fun PickActiveDialog(
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 Text(
-                    uiString(R.string.l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48) +
-                        "leave none active and pair one later.",
+                    uiString(R.string.l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48),
                     style = NoopType.subhead,
                     color = Palette.textSecondary,
                 )
@@ -1560,8 +1559,7 @@ private fun OuraLocalStateNote() {
     ) {
         Icon(Icons.Filled.Info, contentDescription = null, tint = Palette.statusWarning, modifier = Modifier.size(14.dp))
         Text(
-            uiString(R.string.l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190) +
-                "up in the Oura app, NOOP no longer owns it and you would re-add it to take it over.",
+            uiString(R.string.l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190),
             style = NoopType.caption,
             color = Palette.statusWarning,
         )

--- a/android/app/src/main/java/com/noop/ui/HowNoopWorksScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HowNoopWorksScreen.kt
@@ -259,8 +259,7 @@ private fun PrimerCard(section: PrimerSection) {
 @Composable
 private fun FooterNote() {
     Text(
-        uiString(R.string.l10n_how_noop_works_screen_noop_never_makes_up_a_number_da29aca5) +
-            "what's missing and what to do, rather than showing a fake value.",
+        uiString(R.string.l10n_how_noop_works_screen_noop_never_makes_up_a_number_da29aca5),
         style = NoopType.footnote,
         color = Palette.textTertiary,
         modifier = Modifier

--- a/android/app/src/main/java/com/noop/ui/HrvSnapshotScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HrvSnapshotScreen.kt
@@ -463,8 +463,7 @@ private fun NotBondedHint() {
     ) {
         Icon(Icons.Filled.MonitorHeart, contentDescription = null, tint = Palette.statusWarning)
         Text(
-            uiString(R.string.l10n_hrv_snapshot_screen_an_hrv_reading_needs_the_live_11b70bff) +
-                "then come back.",
+            uiString(R.string.l10n_hrv_snapshot_screen_an_hrv_reading_needs_the_live_11b70bff),
             style = NoopType.footnote, color = Palette.textSecondary,
         )
     }

--- a/android/app/src/main/java/com/noop/ui/InsightsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/InsightsScreen.kt
@@ -576,8 +576,7 @@ private fun WhatMovesYouLink(onOpen: () -> Unit) {
                 // glyph (mirrors the iOS "WHAT MOVES YOU ›" overline). The descriptive line sits beneath.
                 Overline("What moves you ›", color = Palette.textPrimary)
                 Text(
-                    uiString(R.string.l10n_insights_screen_ranked_lag_aware_which_of_your_e0e91b39) +
-                        "personal alcohol/caffeine dose-response.",
+                    uiString(R.string.l10n_insights_screen_ranked_lag_aware_which_of_your_e0e91b39),
                     style = NoopType.footnote,
                     color = Palette.textTertiary,
                 )

--- a/android/app/src/main/java/com/noop/ui/LabBookScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/LabBookScreen.kt
@@ -199,8 +199,7 @@ fun LabBookScreen(vm: AppViewModel) {
                     }
                 }
                 Text(
-                    uiString(R.string.l10n_lab_book_screen_it_s_a_notebook_not_a_45835e98) +
-                        "read, or judge them. Not medical advice.",
+                    uiString(R.string.l10n_lab_book_screen_it_s_a_notebook_not_a_45835e98),
                     style = NoopType.subhead,
                     color = Palette.textSecondary,
                 )
@@ -473,8 +472,7 @@ private fun MarkerDetailSheet(
             }
 
             Text(
-                uiString(R.string.l10n_lab_book_screen_these_are_your_own_numbers_shown_7667508d) +
-                    "normal, high or low.",
+                uiString(R.string.l10n_lab_book_screen_these_are_your_own_numbers_shown_7667508d),
                 style = NoopType.footnote,
                 color = Palette.textTertiary,
             )

--- a/android/app/src/main/java/com/noop/ui/ScoringGuideScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/ScoringGuideScreen.kt
@@ -451,8 +451,7 @@ private fun ConfidenceCard() {
 @Composable
 private fun FooterNote() {
     Text(
-        uiString(R.string.l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed) +
-            "medical advice, and not WHOOP's official scores.",
+        uiString(R.string.l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed),
         style = NoopType.footnote,
         color = Palette.textTertiary,
         modifier = Modifier

--- a/android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt
@@ -234,8 +234,7 @@ private fun ExplainerCard() {
                 Text(uiString(R.string.l10n_steps_calibration_screen_how_this_works_b895a8c3), style = NoopType.headline, color = Palette.textPrimary)
             }
             Text(
-                uiString(R.string.l10n_steps_calibration_screen_noop_estimates_your_steps_from_your_d569bc31) +
-                    "count. It's an estimate, not a step counter. A WHOOP 4.0 doesn't transmit steps.",
+                uiString(R.string.l10n_steps_calibration_screen_noop_estimates_your_steps_from_your_d569bc31),
                 style = NoopType.subhead,
                 color = Palette.textSecondary,
             )
@@ -319,8 +318,7 @@ private fun CurrentFitCard(profile: ProfileStore, matchedDays: Int) {
                     color = Palette.accent,
                 )
                 Text(
-                    uiString(R.string.l10n_steps_calibration_screen_these_are_the_days_where_your_ae5c9c2c) +
-                        "motion maps to steps. Or set the coefficient manually below.",
+                    uiString(R.string.l10n_steps_calibration_screen_these_are_the_days_where_your_ae5c9c2c),
                     style = NoopType.footnote,
                     color = Palette.textTertiary,
                 )
@@ -373,8 +371,7 @@ private fun ComparisonCard(rows: List<StepsComparisonRow>) {
                     }
                 }
                 Text(
-                    uiString(R.string.l10n_steps_calibration_screen_these_days_are_excluded_from_the_6bedabbf) +
-                        "They're here only so you can judge the estimate's accuracy.",
+                    uiString(R.string.l10n_steps_calibration_screen_these_days_are_excluded_from_the_6bedabbf),
                     style = NoopType.caption,
                     color = Palette.textTertiary,
                 )

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -448,8 +448,7 @@ private fun StressAdvancedCard(
             }
 
             Text(
-                uiString(R.string.l10n_stress_screen_these_are_extra_on_demand_hrv_9303f1de) +
-                    "are informational and do not change the stress score above.",
+                uiString(R.string.l10n_stress_screen_these_are_extra_on_demand_hrv_9303f1de),
                 style = NoopType.footnote,
                 color = Palette.textTertiary,
             )

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1409,8 +1409,7 @@ fun TodayScreen(
                                         modifier = Modifier.size(Metrics.iconSmall),
                                     )
                                     Text(
-                                        uiString(R.string.l10n_today_screen_no_cardio_load_yet_effort_builds_e952006c) +
-                                            "zone (around 50% of your heart-rate reserve). A calm day honestly reads near zero.",
+                                        uiString(R.string.l10n_today_screen_no_cardio_load_yet_effort_builds_e952006c),
                                         style = NoopType.footnote,
                                         color = Palette.textTertiary,
                                     )

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -308,7 +308,7 @@
     <string name="l10n_caffeine_log_had_it_8576ac66">Gehabt</string>
     <string name="l10n_caffeine_log_have_your_last_caffeine_by_about_16b09033">Haben Sie Ihr letztes Koffein von etwa %1$s, um das meiste davon zu löschen</string>
     <string name="l10n_caffeine_log_late_caffeine_nudge_6b2ff690">Late-Coffein-Nudge</string>
-    <string name="l10n_caffeine_log_log_a_coffee_tea_or_energy_982bde5b">Loggen Sie einen Kaffee, Tee oder Energy-Drink und NOOP zeigt eine grobe Schätzung, wie viel kann</string>
+    <string name="l10n_caffeine_log_log_a_coffee_tea_or_energy_982bde5b">Erfasse einen Kaffee, Tee oder Energydrink, und NOOP zeigt eine grobe Schätzung, wie viel noch wirken könnte. Es ist ein Anhaltspunkt auf Basis einer typischen Halbwertszeit von 5 bis 6 Stunden, keine Messung.</string>
     <string name="l10n_caffeine_log_logged_today_0071a46c">Heute erfasst</string>
     <string name="l10n_caffeine_log_remove_e963907d">Entfernen</string>
     <string name="l10n_coach_screen_api_key_hidden_f3cde531">API-Schlüssel (versteckt)</string>
@@ -356,7 +356,7 @@
     <string name="l10n_coupled_screen_no_sleep_tracked_last_night_cd0dd79e">Letzte Nacht kein Schlaf erfasst</string>
     <string name="l10n_coupled_screen_recovery_b668d988">ERHOLUNG</string>
     <string name="l10n_coupled_screen_sleep_performance_4611539f">SCHLAFLEISTUNG</string>
-    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">Agiert als Standard-Bluetooth-Herzfrequenzband. Paar NOOP von Ihrem Laufband,</string>
+    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">Verhält sich wie ein Standard-Bluetooth-Herzfrequenzgurt. Kopple NOOP von deinem Laufband, Rad oder deiner App aus, um dort die Herzfrequenz deines Straps zu sehen.</string>
     <string name="l10n_data_sources_screen_apple_health_b19b87da">Apple Health</string>
     <string name="l10n_data_sources_screen_auto_sync_health_connect_periodically_6f3f4d92">Auto-Sync Health Connect regelmäßig</string>
     <string name="l10n_data_sources_screen_auto_sync_periodically_5f3041e8">Auto-Sync periodisch</string>
@@ -387,7 +387,7 @@
     <string name="l10n_data_sources_screen_remove_imported_data_813e4695">Importierte Daten entfernen</string>
     <string name="l10n_data_sources_screen_share_back_to_health_connect_1d578f4a">Teilen Sie zurück zu Health Connect</string>
     <string name="l10n_data_sources_screen_share_computed_metrics_back_to_health_c11f5d70">Teile berechnete Metriken zurück zu Health Connect</string>
-    <string name="l10n_data_sources_screen_this_permanently_deletes_everything_imported_from_f42e760e">Dies löscht dauerhaft alles, was von Apple Health importiert wurde: Herzfrequenz, HRV,</string>
+    <string name="l10n_data_sources_screen_this_permanently_deletes_everything_imported_from_f42e760e">Das löscht dauerhaft alles, was aus Apple Health importiert wurde: Herzfrequenz, HRV, Schlaf, Schritte, Workouts und mehr. Deine Live-Strap-Daten bleiben unberührt. Das kann nicht rückgängig gemacht werden.</string>
     <string name="l10n_data_sources_screen_whoop_history_db101974">WHOOP Geschichte</string>
     <string name="l10n_data_sources_screen_whoop_strap_live_ble_217f7df6">WHOOP-Strap (Live-BLE)</string>
     <string name="l10n_data_sources_screen_workout_file_gpx_tcx_fit_5469c068">Workout-Datei (GPX / TCX / FIT)</string>
@@ -426,7 +426,7 @@
     <string name="l10n_devices_screen_leave_none_active_b5c858cb">Keins aktiv lassen</string>
     <string name="l10n_devices_screen_name_709a2322">Name</string>
     <string name="l10n_devices_screen_pack_voltage_9af3c3ff">%1$.2f V</string>
-    <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Lokal gepaart. NOOP besitzt diesen Ring, während er den Schlüssel hält. Wenn Sie es erneut zurücksetzen oder einstellen</string>
+    <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Lokal gekoppelt. NOOP besitzt diesen Ring, solange es den Schlüssel hält. Wenn du ihn erneut zurücksetzt oder in der Oura-App einrichtest, besitzt NOOP ihn nicht mehr, und du müsstest ihn zum Übernehmen neu hinzufügen.</string>
     <string name="l10n_devices_screen_pick_a_new_active_strap_edd73542">Neuen aktiven Strap auswählen</string>
     <string name="l10n_devices_screen_rename_device_ee233604">Gerät umbenennen</string>
     <string name="l10n_devices_screen_send_probe_read_only_36b318bc">Test senden (nur lesen)</string>
@@ -435,7 +435,7 @@
     <string name="l10n_devices_screen_waiting_for_the_straps_reply_5a06e7ac">Warte auf die Antwort des Bands…</string>
     <string name="l10n_devices_screen_whoop_4_0_reboot_probe_b51fb50f">WHOOP 4.0-Reboot-Sonde</string>
     <string name="l10n_devices_screen_whoop_is_noop_s_primary_fully_1c9e67fd">WHOOP ist das primäre, vollständig unterstützte Band von NOOP. Andere Herzfrequenzbänder sind eine frühe,</string>
-    <string name="l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48">Du hast deinen aktiven Riemen entfernt. Wählen Sie aus, welches gepaarte Band Ihre Live-Daten bereitstellt, oder</string>
+    <string name="l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48">Du hast deinen aktiven Strap entfernt. Wähle, welches gekoppelte Band deine Live-Daten liefert, oder lass keins aktiv und kopple später eins.</string>
     <string name="l10n_fused_record_screen_contrib_source_displayname_fusionformat_value_contrib_d182dd7f">%1$s, %2$s</string>
     <string name="l10n_fused_record_screen_done_e9b450d1">Fertig</string>
     <string name="l10n_fused_record_screen_fused_on_devicenoun_nothing_leaves_it_8a1e6a3d">Fused auf %1$s. Nichts verlässt es: kein Konto, keine Cloud.</string>
@@ -480,11 +480,11 @@
     <string name="l10n_how_noop_works_screen_close_bbfa773e">Schließen</string>
     <string name="l10n_how_noop_works_screen_got_it_5b8027fa">Verstanden</string>
     <string name="l10n_how_noop_works_screen_how_noop_works_3396b27a">So funktioniert NOOP</string>
-    <string name="l10n_how_noop_works_screen_noop_never_makes_up_a_number_da29aca5">NOOP macht nie eine Zahl. Wenn es einen nicht ehrlich berechnen kann, sagt es dir</string>
+    <string name="l10n_how_noop_works_screen_noop_never_makes_up_a_number_da29aca5">NOOP erfindet nie eine Zahl. Wenn es eine nicht ehrlich berechnen kann, sagt es dir, was fehlt und was zu tun ist, statt einen falschen Wert zu zeigen.</string>
     <string name="l10n_how_noop_works_screen_noop_never_shows_you_a_number_d1db9958">NOOP zeigt Ihnen nie eine Zahl, die es erfinden musste. Wenn ein Score nicht fertig ist,</string>
     <string name="l10n_how_noop_works_screen_section_title_section_body_efb1a999">%1$s. %2$s</string>
     <string name="l10n_how_noop_works_screen_sleep_scores_recording_where_your_numbers_1b3e981f">Schlaf · Werte · Aufzeichnung · woher deine Zahlen kommen</string>
-    <string name="l10n_hrv_snapshot_screen_an_hrv_reading_needs_the_live_11b70bff">Eine HRV-Lesung benötigt den Live-R-R-Stream. Öffnen Sie den Live-Bildschirm und verbinden Sie Ihren Gurt,</string>
+    <string name="l10n_hrv_snapshot_screen_an_hrv_reading_needs_the_live_11b70bff">Eine HRV-Messung braucht den Live-R-R-Stream. Öffne den Live-Bildschirm und verbinde deinen Strap, dann komm zurück.</string>
     <string name="l10n_hrv_snapshot_screen_beats_12aafda0">Schläge</string>
     <string name="l10n_hrv_snapshot_screen_hrvdial_4c244c45">hrvDial</string>
     <string name="l10n_hrv_snapshot_screen_mean_hr_6c9272dd">Mittlere HF</string>
@@ -537,7 +537,7 @@
     <string name="l10n_insights_screen_not_enough_overlap_between_your_journal_0ebdd7a2">Nicht genug Überlappungen zwischen Ihren Journal Antworten und</string>
     <string name="l10n_insights_screen_not_enough_overlapping_history_to_correlate_a552dbd4">Noch nicht genug überlappender Verlauf, um deine Metriken zu korrelieren.</string>
     <string name="l10n_insights_screen_pick_one_behaviour_you_log_one_bd34090e">Wählen Sie ein Verhalten, das Sie protokollieren, ein Ergebnis und ein kurzes Fenster. NOOP</string>
-    <string name="l10n_insights_screen_ranked_lag_aware_which_of_your_e0e91b39">Ranked, lag-aware: welche Ihrer Gewohnheiten tatsächlich Ihre Ladung bewegen, plus Ihre</string>
+    <string name="l10n_insights_screen_ranked_lag_aware_which_of_your_e0e91b39">Eingestuft, mit Zeitversatz: welche deiner Gewohnheiten deine Ladung wirklich bewegen, plus deine persönliche Alkohol-/Koffein-Dosis-Wirkung.</string>
     <string name="l10n_insights_screen_rest_baseline_b3ac52a5">Ruhe-Basislinie</string>
     <string name="l10n_insights_screen_run_a_clean_personal_test_4da69781">Führe einen sauberen persönlichen Test durch</string>
     <string name="l10n_insights_screen_sessions_e11e37a9">Sitzungen</string>
@@ -588,7 +588,7 @@
     <string name="l10n_lab_book_screen_clear_719ea396">Löschen</string>
     <string name="l10n_lab_book_screen_delete_this_reading_b5c92bda">Diesen Messwert löschen</string>
     <string name="l10n_lab_book_screen_import_readings_7ad0d28f">Messwerte importieren</string>
-    <string name="l10n_lab_book_screen_it_s_a_notebook_not_a_45835e98">Es ist ein Notizbuch, kein Labor. NOOP ordnet die von Ihnen eingegebenen Zahlen an. Es testet nicht,</string>
+    <string name="l10n_lab_book_screen_it_s_a_notebook_not_a_45835e98">Es ist ein Notizbuch, kein Labor. NOOP stellt die Zahlen, die du eingibst, nebeneinander. Es testet, liest oder beurteilt sie nicht. Kein medizinischer Rat.</string>
     <string name="l10n_lab_book_screen_keep_your_own_numbers_here_1ca6c8ed">Bewahre deine eigenen Werte hier auf</string>
     <string name="l10n_lab_book_screen_lab_book_f966c140">Laborbuch</string>
     <string name="l10n_lab_book_screen_lab_book_is_a_private_notebook_d07380ca">Lab Book ist ein privates Notizbuch, kein medizinischer Dienst. NOOP speichert und ordnet die Zahlen</string>
@@ -601,7 +601,7 @@
     <string name="l10n_lab_book_screen_read_the_full_lab_book_note_3a250750">Den vollständigen Laborbuch-Hinweis lesen</string>
     <string name="l10n_lab_book_screen_read_the_full_note_3fd0e4d1">Den vollständigen Hinweis lesen</string>
     <string name="l10n_lab_book_screen_reading_your_logbook_e31992b0">Dein Logbuch wird gelesen…</string>
-    <string name="l10n_lab_book_screen_these_are_your_own_numbers_shown_7667508d">Dies sind Ihre eigenen Zahlen, die Ihnen angezeigt werden. NOOP entscheidet nicht, ob ein Wert</string>
+    <string name="l10n_lab_book_screen_these_are_your_own_numbers_shown_7667508d">Das sind deine eigenen Zahlen, dir zurückgespiegelt. NOOP entscheidet nicht, ob ein Wert normal, hoch oder niedrig ist.</string>
     <string name="l10n_lab_book_screen_type_in_a_blood_pressure_reading_c276d418">Geben Sie eine Blutdruckmessung oder einen Cholesterinwert von Ihrem letzten Termin ein.</string>
     <string name="l10n_lab_book_screen_what_lab_book_is_and_isn_f28686df">Was das Laborbuch ist (und was nicht)</string>
     <string name="l10n_live_screen_manage_devices_e5c277ff">Geräte verwalten</string>
@@ -751,7 +751,7 @@
     <string name="l10n_scoring_guide_screen_how_your_scores_work_21a0e2be">So funktionieren deine Werte</string>
     <string name="l10n_scoring_guide_screen_noop_gives_you_three_daily_scores_36244209">NOOP bietet Ihnen drei tägliche Ergebnisse (Charge, Effort und Rest), jeweils auf einer 0-100</string>
     <string name="l10n_scoring_guide_screen_scorecardhighlight_4af6985c">scoreCardHighlight</string>
-    <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">Dies sind unabhängige Annäherungen an ein Verbraucherband, die auf Open Science aufbauen: nicht</string>
+    <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">Das sind unabhängige Näherungen von einem Consumer-Strap, gebaut auf offener Wissenschaft: kein medizinischer Rat und nicht WHOOPs offizielle Werte.</string>
     <string name="l10n_scoring_guide_screen_vs_whoop_9a8126a7">VS WHOOP</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">AdvancedChevron</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
@@ -840,7 +840,7 @@
     <string name="l10n_steps_calibration_screen_how_this_works_b895a8c3">Wie das funktioniert</string>
     <string name="l10n_steps_calibration_screen_no_days_yet_where_both_noop_71d6005b">Noch keine Tage, an denen sowohl NOOP als auch Ihr Telefon Schritte gezählt haben. Sobald Ihr Telefon protokolliert a</string>
     <string name="l10n_steps_calibration_screen_no_motion_synced_yet_65106670">Noch keine Bewegung synchronisiert</string>
-    <string name="l10n_steps_calibration_screen_noop_estimates_your_steps_from_your_d569bc31">NOOP schätzt Ihre Schritte aus der Bewegung Ihres WHOOP, kalibriert auf den Schritt Ihres Telefons</string>
+    <string name="l10n_steps_calibration_screen_noop_estimates_your_steps_from_your_d569bc31">NOOP schätzt deine Schritte aus der Bewegung deines WHOOP, kalibriert an der Schrittzahl deines Telefons. Es ist eine Schätzung, kein Schrittzähler. Ein WHOOP 4.0 überträgt keine Schritte.</string>
     <string name="l10n_steps_calibration_screen_not_calibrated_yet_30abe0d0">Noch nicht kalibriert</string>
     <string name="l10n_steps_calibration_screen_on_the_days_your_phone_also_2f65a14c">An den Tagen, an denen Ihr Telefon auch Schritte gezählt hat, erfährt NOOP, wie viel Ihre Motion Maps</string>
     <string name="l10n_steps_calibration_screen_open_noop_near_your_strap_and_e08ddd6d">Öffnen Sie NOOP in der Nähe Ihres Riemens und lassen Sie es aufholen (eine vollständige Historiensynchronisierung kann eine Weile dauern)</string>
@@ -849,8 +849,8 @@
     <string name="l10n_steps_calibration_screen_shortday_row_day_estimated_row_estimated_f2d71597">%1$s: geschätzte %2$s-Schritte, Telefon %3$s</string>
     <string name="l10n_steps_calibration_screen_steps_per_motion_unit_a2c2ac56">Schritte pro Bewegungseinheit</string>
     <string name="l10n_steps_calibration_screen_takes_effect_on_the_next_analytics_13205327">Wirkt beim nächsten Analysedurchlauf (nach der nächsten Synchronisierung).</string>
-    <string name="l10n_steps_calibration_screen_these_are_the_days_where_your_ae5c9c2c">Dies sind die Tage, an denen Ihr Telefon auch Schritte gezählt hat, so dass NOOP erfahren kann, wie Ihre</string>
-    <string name="l10n_steps_calibration_screen_these_days_are_excluded_from_the_6bedabbf">Diese Tage sind von der Schätzung ausgeschlossen (die tatsächliche Anzahl Ihres Telefons wird stattdessen angezeigt).</string>
+    <string name="l10n_steps_calibration_screen_these_are_the_days_where_your_ae5c9c2c">Das sind die Tage, an denen dein Telefon ebenfalls Schritte gezählt hat, damit NOOP lernen kann, wie deine Bewegung auf Schritte abbildet. Oder lege den Koeffizienten unten manuell fest.</string>
+    <string name="l10n_steps_calibration_screen_these_days_are_excluded_from_the_6bedabbf">Diese Tage sind von der Schätzung ausgenommen (stattdessen wird die echte Zählung deines Telefons gezeigt). Sie stehen hier nur, damit du die Genauigkeit der Schätzung beurteilen kannst.</string>
     <string name="l10n_steps_calibration_screen_we_re_not_seeing_any_motion_6ac8e092">Wir sehen noch keine Bewegung von Ihrem Riemen. Schritte werden von Ihrem WHOOP geschätzt</string>
     <string name="l10n_steps_calibration_screen_whoop_4_0_motion_steps_a63239dc">WHOOP 4.0 · Bewegung → Schritte</string>
     <string name="l10n_strand_components_next_day_38f859dd">Nächster Tag</string>
@@ -1600,7 +1600,7 @@
     <string name="l10n_stress_screen_on_demand_today_s_r_r_17d716e1">auf Abruf · heutige R-R</string>
     <string name="l10n_stress_screen_on_the_0_3_autonomic_load_8a0d5107">auf der Skala 0-3 autonome Last</string>
     <string name="l10n_stress_screen_the_line_traces_your_autonomic_load_804f4028">Die Linie verfolgt Ihre autonome Last über den wachen Tag, erzielt</string>
-    <string name="l10n_stress_screen_these_are_extra_on_demand_hrv_9303f1de">Dies sind zusätzliche, bedarfsgesteuerte HRV-Objektive, die aus den heutigen R-R-Intervallen berechnet werden. Sie</string>
+    <string name="l10n_stress_screen_these_are_extra_on_demand_hrv_9303f1de">Das sind zusätzliche HRV-Blickwinkel auf Abruf, berechnet aus den heutigen R-R-Intervallen. Sie sind informativ und ändern den Stresswert oben nicht.</string>
     <string name="l10n_stress_screen_we_compare_today_s_resting_heart_a9cd0955">Wir vergleichen die heutige Ruheherzfrequenz und HRV mit Ihrer eigenen 30-tägigen</string>
     <string name="l10n_test_centre_screen_bug_report_5a7ee5ac">Fehlerbericht</string>
     <string name="l10n_today_screen_arrange_cfdd099c">Anordnung</string>
@@ -1626,7 +1626,7 @@
     <string name="l10n_today_screen_move_item_metric_title_down_890afe60">%1$s nach unten verschieben</string>
     <string name="l10n_today_screen_move_item_metric_title_up_52d2104c">%1$s nach oben verschieben</string>
     <string name="l10n_today_screen_new_data_added_e59345b4">Neue Daten hinzugefügt</string>
-    <string name="l10n_today_screen_no_cardio_load_yet_effort_builds_e952006c">Noch keine Cardio-Last. Anstrengung baut auf, sobald Ihre Herzfrequenz in Ihre Anstrengung steigt</string>
+    <string name="l10n_today_screen_no_cardio_load_yet_effort_builds_e952006c">Noch keine Cardio-Last. Anstrengung baut sich auf, sobald deine Herzfrequenz in deine Anstrengungszone steigt (etwa 50 % deiner Herzfrequenzreserve). Ein ruhiger Tag liest sich ehrlich nahe null.</string>
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">Profil und Einstellungen</string>
     <string name="l10n_today_screen_recovery_ea924f72">Erholung</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -138,7 +138,7 @@
     <string name="l10n_caffeine_log_had_it_8576ac66">La tuve</string>
     <string name="l10n_caffeine_log_have_your_last_caffeine_by_about_16b09033">Tenga su última cafeína por alrededor de %1$s para limpiar la mayoría de ella</string>
     <string name="l10n_caffeine_log_late_caffeine_nudge_6b2ff690">Late-caffeine nudge</string>
-    <string name="l10n_caffeine_log_log_a_coffee_tea_or_energy_982bde5b">Lograr un café, té o bebida energética y NOOP muestra una estimación aproximada de cuánto puede</string>
+    <string name="l10n_caffeine_log_log_a_coffee_tea_or_energy_982bde5b">Registra un café, un té o una bebida energética y NOOP muestra una estimación aproximada de cuánta cafeína puede seguir activa. Es una guía basada en una semivida típica de 5 a 6 horas, no una medición.</string>
     <string name="l10n_caffeine_log_logged_today_0071a46c">Registrado hoy</string>
     <string name="l10n_caffeine_log_remove_e963907d">Eliminar</string>
     <string name="l10n_coach_screen_api_key_hidden_f3cde531">Clave de API (hidden)</string>
@@ -186,7 +186,7 @@
     <string name="l10n_coupled_screen_no_sleep_tracked_last_night_cd0dd79e">No hay sueño rastreado anoche</string>
     <string name="l10n_coupled_screen_recovery_b668d988">RECOVERY</string>
     <string name="l10n_coupled_screen_sleep_performance_4611539f">SLEEP PERFORMANCE</string>
-    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">Actúa como una correa de frecuencia cardíaca Bluetooth estándar. Par NOOP de su cinta de correr,</string>
+    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">Actúa como una banda de frecuencia cardíaca Bluetooth estándar. Empareja NOOP desde tu cinta, bici o app para ver ahí la frecuencia cardíaca de tu pulsera.</string>
     <string name="l10n_data_sources_screen_apple_health_b19b87da">Apple Health</string>
     <string name="l10n_data_sources_screen_auto_sync_health_connect_periodically_6f3f4d92">Auto-sync Health Connect periodic</string>
     <string name="l10n_data_sources_screen_auto_sync_periodically_5f3041e8">Auto-sinc periódicamente</string>
@@ -217,7 +217,7 @@
     <string name="l10n_data_sources_screen_remove_imported_data_813e4695">Eliminar datos importados</string>
     <string name="l10n_data_sources_screen_share_back_to_health_connect_1d578f4a">Compartir de nuevo a Health Connect</string>
     <string name="l10n_data_sources_screen_share_computed_metrics_back_to_health_c11f5d70">Compartir métricas computadas volver a Health Connect</string>
-    <string name="l10n_data_sources_screen_this_permanently_deletes_everything_imported_from_f42e760e">Esto elimina permanentemente todo lo importado de Apple Health: frecuencia cardíaca, HRV,</string>
+    <string name="l10n_data_sources_screen_this_permanently_deletes_everything_imported_from_f42e760e">Esto elimina permanentemente todo lo importado desde Apple Health: frecuencia cardíaca, VFC, sueño, pasos, entrenamientos y más. Los datos en vivo de tu pulsera quedan intactos. No se puede deshacer.</string>
     <string name="l10n_data_sources_screen_whoop_history_db101974">Historia WHOOP</string>
     <string name="l10n_data_sources_screen_whoop_strap_live_ble_217f7df6">Pulsera WHOOP (BLE en vivo)</string>
     <string name="l10n_data_sources_screen_workout_file_gpx_tcx_fit_5469c068">Archivo de entrenamiento (GPX / TCX / FIT)</string>
@@ -256,7 +256,7 @@
     <string name="l10n_devices_screen_leave_none_active_b5c858cb">No dejar ninguna activa</string>
     <string name="l10n_devices_screen_name_709a2322">Nombre</string>
     <string name="l10n_devices_screen_pack_voltage_9af3c3ff">%1$.2f V</string>
-    <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">En pareja. NOOP posee este anillo mientras mantiene la llave. Si lo vuelves a restablecer o lo estableces</string>
+    <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Emparejado localmente. NOOP es propietario de este anillo mientras conserva la clave. Si lo restableces de nuevo o lo configuras en la app de Oura, NOOP deja de ser propietario y tendrías que volver a añadirlo para retomar el control.</string>
     <string name="l10n_devices_screen_pick_a_new_active_strap_edd73542">Elige una nueva pulsera activa</string>
     <string name="l10n_devices_screen_rename_device_ee233604">Renombrar dispositivo</string>
     <string name="l10n_devices_screen_send_probe_read_only_36b318bc">Enviar sonda (solo lectura)</string>
@@ -265,7 +265,7 @@
     <string name="l10n_devices_screen_waiting_for_the_straps_reply_5a06e7ac">Esperando la respuesta de la banda…</string>
     <string name="l10n_devices_screen_whoop_4_0_reboot_probe_b51fb50f">WHOOP 4.0 sonda de reinicio</string>
     <string name="l10n_devices_screen_whoop_is_noop_s_primary_fully_1c9e67fd">WHOOP es la banda primaria y totalmente apoyada de NOOP. Otras correas de corazón son tempranas,</string>
-    <string name="l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48">Te quitaste la correa activa. Elija qué banda pareada proporciona sus datos en vivo, o</string>
+    <string name="l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48">Quitaste tu pulsera activa. Elige qué banda emparejada proporciona tus datos en vivo, o no dejes ninguna activa y empareja una después.</string>
     <string name="l10n_fused_record_screen_contrib_source_displayname_fusionformat_value_contrib_d182dd7f">%1$s, %2$s</string>
     <string name="l10n_fused_record_screen_done_e9b450d1">Listo</string>
     <string name="l10n_fused_record_screen_fused_on_devicenoun_nothing_leaves_it_8a1e6a3d">Fused on %1$s. Nada lo deja: sin cuenta, sin nube.</string>
@@ -310,11 +310,11 @@
     <string name="l10n_how_noop_works_screen_close_bbfa773e">Cerrar</string>
     <string name="l10n_how_noop_works_screen_got_it_5b8027fa">Entendido</string>
     <string name="l10n_how_noop_works_screen_how_noop_works_3396b27a">Cómo funciona NOOP</string>
-    <string name="l10n_how_noop_works_screen_noop_never_makes_up_a_number_da29aca5">NOOP nunca hace un número. Cuando no se puede calcular uno honestamente te dice</string>
+    <string name="l10n_how_noop_works_screen_noop_never_makes_up_a_number_da29aca5">NOOP nunca inventa un número. Cuando no puede calcularlo honestamente, te dice qué falta y qué hacer, en lugar de mostrar un valor falso.</string>
     <string name="l10n_how_noop_works_screen_noop_never_shows_you_a_number_d1db9958">NOOP nunca muestra un número que tenía que inventar. Si una puntuación no está lista,</string>
     <string name="l10n_how_noop_works_screen_section_title_section_body_efb1a999">%1$s. %2$s</string>
     <string name="l10n_how_noop_works_screen_sleep_scores_recording_where_your_numbers_1b3e981f">Sueño · puntuaciones · registro · de dónde vienen tus números</string>
-    <string name="l10n_hrv_snapshot_screen_an_hrv_reading_needs_the_live_11b70bff">Una lectura HRV necesita el flujo R-R en vivo. Abra la pantalla Live y conecte su correa,</string>
+    <string name="l10n_hrv_snapshot_screen_an_hrv_reading_needs_the_live_11b70bff">Una lectura de VFC necesita el flujo R-R en vivo. Abre la pantalla En vivo y conecta tu pulsera, luego vuelve.</string>
     <string name="l10n_hrv_snapshot_screen_beats_12aafda0">Latidos</string>
     <string name="l10n_hrv_snapshot_screen_hrvdial_4c244c45">hrvDial</string>
     <string name="l10n_hrv_snapshot_screen_mean_hr_6c9272dd">FC media</string>
@@ -367,7 +367,7 @@
     <string name="l10n_insights_screen_not_enough_overlap_between_your_journal_0ebdd7a2">No hay suficiente solapamiento entre las respuestas de su diario y</string>
     <string name="l10n_insights_screen_not_enough_overlapping_history_to_correlate_a552dbd4">Aún no hay suficiente historial solapado para correlacionar tus métricas.</string>
     <string name="l10n_insights_screen_pick_one_behaviour_you_log_one_bd34090e">Escoge un comportamiento que registras, un resultado y una ventana corta. NOOP</string>
-    <string name="l10n_insights_screen_ranked_lag_aware_which_of_your_e0e91b39">Ranked, lag-aware: cuál de tus hábitos realmente mueve tu Carga, más tu</string>
+    <string name="l10n_insights_screen_ranked_lag_aware_which_of_your_e0e91b39">Clasificado y con retardo en cuenta: qué hábitos realmente mueven tu Carga, más tu respuesta personal a la dosis de alcohol y cafeína.</string>
     <string name="l10n_insights_screen_rest_baseline_b3ac52a5">Línea base de Descanso</string>
     <string name="l10n_insights_screen_run_a_clean_personal_test_4da69781">Haz una prueba personal limpia</string>
     <string name="l10n_insights_screen_sessions_e11e37a9">Sesiones</string>
@@ -418,7 +418,7 @@
     <string name="l10n_lab_book_screen_clear_719ea396">Borrar</string>
     <string name="l10n_lab_book_screen_delete_this_reading_b5c92bda">Eliminar esta lectura</string>
     <string name="l10n_lab_book_screen_import_readings_7ad0d28f">Importar lecturas</string>
-    <string name="l10n_lab_book_screen_it_s_a_notebook_not_a_45835e98">Es un cuaderno, no un laboratorio. NOOP alinea los números que entras. No prueba,</string>
+    <string name="l10n_lab_book_screen_it_s_a_notebook_not_a_45835e98">Es un cuaderno, no un laboratorio. NOOP alinea los números que introduces. No los analiza, interpreta ni juzga. No es consejo médico.</string>
     <string name="l10n_lab_book_screen_keep_your_own_numbers_here_1ca6c8ed">Guarda tus propios números aquí</string>
     <string name="l10n_lab_book_screen_lab_book_f966c140">Cuaderno de laboratorio</string>
     <string name="l10n_lab_book_screen_lab_book_is_a_private_notebook_d07380ca">Lab Book es un cuaderno privado, no un servicio médico. NOOP almacena y alinea los números</string>
@@ -431,7 +431,7 @@
     <string name="l10n_lab_book_screen_read_the_full_lab_book_note_3a250750">Leer la nota completa del Lab Book</string>
     <string name="l10n_lab_book_screen_read_the_full_note_3fd0e4d1">Leer la nota completa</string>
     <string name="l10n_lab_book_screen_reading_your_logbook_e31992b0">Leyendo tu registro…</string>
-    <string name="l10n_lab_book_screen_these_are_your_own_numbers_shown_7667508d">Estos son tus propios números que se te muestran. NOOP no decide si hay valor</string>
+    <string name="l10n_lab_book_screen_these_are_your_own_numbers_shown_7667508d">Son tus propios números mostrados de vuelta. NOOP no decide si algún valor es normal, alto o bajo.</string>
     <string name="l10n_lab_book_screen_type_in_a_blood_pressure_reading_c276d418">Introduzca una lectura de presión arterial o un valor de colesterol de su última cita.</string>
     <string name="l10n_lab_book_screen_what_lab_book_is_and_isn_f28686df">Qué es Lab Book (y qué no)</string>
     <string name="l10n_live_screen_manage_devices_e5c277ff">Gestionar dispositivos</string>
@@ -581,7 +581,7 @@
     <string name="l10n_scoring_guide_screen_how_your_scores_work_21a0e2be">Cómo funcionan tus puntuaciones</string>
     <string name="l10n_scoring_guide_screen_noop_gives_you_three_daily_scores_36244209">NOOP le da tres puntuaciones diarias (Capítulo, Effort y Descanso), cada una en un 0-100</string>
     <string name="l10n_scoring_guide_screen_scorecardhighlight_4af6985c">puntuaciónCardHighlight</string>
-    <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">Estas son aproximaciones independientes de una correa de consumo, construida sobre ciencia abierta: no</string>
+    <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">Son aproximaciones independientes de una pulsera de consumo, construidas sobre ciencia abierta: no son consejo médico ni las puntuaciones oficiales de WHOOP.</string>
     <string name="l10n_scoring_guide_screen_vs_whoop_9a8126a7">VS WHOOP</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">avanzadoChevron</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
@@ -670,7 +670,7 @@
     <string name="l10n_steps_calibration_screen_how_this_works_b895a8c3">Cómo funciona esto</string>
     <string name="l10n_steps_calibration_screen_no_days_yet_where_both_noop_71d6005b">Todavía no hay días donde NOOP y su teléfono cuentan pasos. Una vez que el teléfono inicie sesión a</string>
     <string name="l10n_steps_calibration_screen_no_motion_synced_yet_65106670">Aún no hay movimiento sincronizado</string>
-    <string name="l10n_steps_calibration_screen_noop_estimates_your_steps_from_your_d569bc31">NOOP calcula sus pasos desde el movimiento de su WHOOP, calibrado al paso de su teléfono</string>
+    <string name="l10n_steps_calibration_screen_noop_estimates_your_steps_from_your_d569bc31">NOOP estima tus pasos a partir del movimiento de tu WHOOP, calibrado con el recuento de pasos de tu teléfono. Es una estimación, no un podómetro. Una WHOOP 4.0 no transmite pasos.</string>
     <string name="l10n_steps_calibration_screen_not_calibrated_yet_30abe0d0">Aún sin calibrar</string>
     <string name="l10n_steps_calibration_screen_on_the_days_your_phone_also_2f65a14c">En los días que su teléfono también cuenta pasos, NOOP aprende cuánto sus mapas de movimiento a</string>
     <string name="l10n_steps_calibration_screen_open_noop_near_your_strap_and_e08ddd6d">Abrir NOOP cerca de su correa y dejar que se ponga al día (una sincronización de historia completa puede tomar un tiempo en</string>
@@ -679,8 +679,8 @@
     <string name="l10n_steps_calibration_screen_shortday_row_day_estimated_row_estimated_f2d71597">%1$s: pasos %2$s estimados, teléfono %3$s</string>
     <string name="l10n_steps_calibration_screen_steps_per_motion_unit_a2c2ac56">pasos por unidad de movimiento</string>
     <string name="l10n_steps_calibration_screen_takes_effect_on_the_next_analytics_13205327">Surte efecto en el próximo pase de análisis (tras la próxima sincronización).</string>
-    <string name="l10n_steps_calibration_screen_these_are_the_days_where_your_ae5c9c2c">Estos son los días en que su teléfono también cuenta pasos, por lo que NOOP puede aprender cómo su teléfono</string>
-    <string name="l10n_steps_calibration_screen_these_days_are_excluded_from_the_6bedabbf">Estos días están excluidos de la estimación (la cuenta real de su teléfono se muestra en su lugar).</string>
+    <string name="l10n_steps_calibration_screen_these_are_the_days_where_your_ae5c9c2c">Estos son los días en los que tu teléfono también contó pasos, así NOOP puede aprender cómo tu movimiento se traduce en pasos. O ajusta el coeficiente manualmente abajo.</string>
+    <string name="l10n_steps_calibration_screen_these_days_are_excluded_from_the_6bedabbf">Estos días quedan excluidos de la estimación (se muestra el conteo real de tu teléfono en su lugar). Están aquí solo para que juzgues la precisión de la estimación.</string>
     <string name="l10n_steps_calibration_screen_we_re_not_seeing_any_motion_6ac8e092">Aún no estamos viendo ningún movimiento de tu correa. Los pasos son estimados de su WHOOP</string>
     <string name="l10n_steps_calibration_screen_whoop_4_0_motion_steps_a63239dc">WHOOP 4.0 · movimiento → pasos</string>
     <string name="l10n_strand_components_next_day_38f859dd">Día siguiente</string>
@@ -1430,7 +1430,7 @@
     <string name="l10n_stress_screen_on_demand_today_s_r_r_17d716e1">bajo demanda · R-R de hoy</string>
     <string name="l10n_stress_screen_on_the_0_3_autonomic_load_8a0d5107">en la escala de carga autonómica 0-3</string>
     <string name="l10n_stress_screen_the_line_traces_your_autonomic_load_804f4028">La línea traza su carga autonómica a lo largo del día de despertar, marcado</string>
-    <string name="l10n_stress_screen_these_are_extra_on_demand_hrv_9303f1de">Estos son lentes HRV extra a demanda calculadas a partir de intervalos R-R de hoy. Ellos</string>
+    <string name="l10n_stress_screen_these_are_extra_on_demand_hrv_9303f1de">Son lentes de VFC adicionales, bajo demanda, calculadas a partir de los intervalos R-R de hoy. Son informativas y no cambian la puntuación de estrés de arriba.</string>
     <string name="l10n_stress_screen_we_compare_today_s_resting_heart_a9cd0955">Comparamos la frecuencia cardíaca de reposo de hoy y el HRV a tus propios 30 días</string>
     <string name="l10n_test_centre_screen_bug_report_5a7ee5ac">Informe de error</string>
     <string name="l10n_today_screen_arrange_cfdd099c">Arreglar</string>
@@ -1456,7 +1456,7 @@
     <string name="l10n_today_screen_move_item_metric_title_down_890afe60">Mover %1$s abajo</string>
     <string name="l10n_today_screen_move_item_metric_title_up_52d2104c">Mover %1$s</string>
     <string name="l10n_today_screen_new_data_added_e59345b4">Nuevos datos añadidos</string>
-    <string name="l10n_today_screen_no_cardio_load_yet_effort_builds_e952006c">Todavía no hay carga cardio. El esfuerzo se acumula una vez que su ritmo cardíaco se sube a su esfuerzo</string>
+    <string name="l10n_today_screen_no_cardio_load_yet_effort_builds_e952006c">Aún no hay carga cardiovascular. El Esfuerzo se acumula cuando tu frecuencia cardíaca sube a tu zona de esfuerzo (alrededor del 50% de tu reserva de frecuencia cardíaca). Un día tranquilo, honestamente, marca cerca de cero.</string>
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">Perfil y ajustes</string>
     <string name="l10n_today_screen_recovery_ea924f72">Recuperación</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -138,7 +138,7 @@
     <string name="l10n_caffeine_log_had_it_8576ac66">Fait</string>
     <string name="l10n_caffeine_log_have_your_last_caffeine_by_about_16b09033">Avoir votre dernière caféine par environ %1$s pour effacer la plupart de lui</string>
     <string name="l10n_caffeine_log_late_caffeine_nudge_6b2ff690">Poudre de caféine tardive</string>
-    <string name="l10n_caffeine_log_log_a_coffee_tea_or_energy_982bde5b">Loger un café, un thé ou une boisson énergétique et NOOP montre une estimation approximative de la quantité</string>
+    <string name="l10n_caffeine_log_log_a_coffee_tea_or_energy_982bde5b">Enregistrez un café, un thé ou une boisson énergisante, et NOOP affiche une estimation approximative de la quantité encore active. C\'est un repère basé sur une demi-vie typique de 5 à 6 heures, pas une mesure.</string>
     <string name="l10n_caffeine_log_logged_today_0071a46c">Enregistré aujourd\'hui</string>
     <string name="l10n_caffeine_log_remove_e963907d">Supprimer</string>
     <string name="l10n_coach_screen_api_key_hidden_f3cde531">Clé API (cachée)</string>
@@ -186,7 +186,7 @@
     <string name="l10n_coupled_screen_no_sleep_tracked_last_night_cd0dd79e">Pas de sommeil suivi hier soir</string>
     <string name="l10n_coupled_screen_recovery_b668d988">RÉCUPÉRATION</string>
     <string name="l10n_coupled_screen_sleep_performance_4611539f">PERFORMANCE DOUCE</string>
-    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">Fonctionne comme un bracelet de fréquence cardiaque Bluetooth standard. Associez NOOP depuis votre tapis roulant, </string>
+    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">Se comporte comme un capteur de fréquence cardiaque Bluetooth standard. Associez NOOP depuis votre tapis de course, vélo ou application pour y voir la fréquence cardiaque de votre bracelet.</string>
     <string name="l10n_data_sources_screen_apple_health_b19b87da">Apple Santé</string>
     <string name="l10n_data_sources_screen_auto_sync_health_connect_periodically_6f3f4d92">Auto-sync Health Connect périodiquement</string>
     <string name="l10n_data_sources_screen_auto_sync_periodically_5f3041e8">Auto-sync périodiquement</string>
@@ -217,7 +217,7 @@
     <string name="l10n_data_sources_screen_remove_imported_data_813e4695">Supprimer les données importées</string>
     <string name="l10n_data_sources_screen_share_back_to_health_connect_1d578f4a">Partager dans Health Connect</string>
     <string name="l10n_data_sources_screen_share_computed_metrics_back_to_health_c11f5d70">Partager les mesures calculées retour à Health Connect</string>
-    <string name="l10n_data_sources_screen_this_permanently_deletes_everything_imported_from_f42e760e">Ceci supprime définitivement tout ce qui est importé de Apple Health: fréquence cardiaque, VFC,</string>
+    <string name="l10n_data_sources_screen_this_permanently_deletes_everything_imported_from_f42e760e">Cela supprime définitivement tout ce qui a été importé depuis Apple Santé : fréquence cardiaque, VFC, sommeil, pas, entraînements et plus encore. Les données en direct de votre bracelet restent intactes. Cette action est irréversible.</string>
     <string name="l10n_data_sources_screen_whoop_history_db101974">WHOOP Historique</string>
     <string name="l10n_data_sources_screen_whoop_strap_live_ble_217f7df6">Bracelet WHOOP (BLE en direct)</string>
     <string name="l10n_data_sources_screen_workout_file_gpx_tcx_fit_5469c068">Fichier d\'entraînement (GPX / TCX / FIT)</string>
@@ -256,7 +256,7 @@
     <string name="l10n_devices_screen_leave_none_active_b5c858cb">N\'en laisser aucune active</string>
     <string name="l10n_devices_screen_name_709a2322">Nom</string>
     <string name="l10n_devices_screen_pack_voltage_9af3c3ff">%1$.2f V</string>
-    <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Jumelé localement. NOOP possède cette bague pendant qu\'elle tient la clé. Si vous le réinitialisez ou le définissez</string>
+    <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Associée localement. NOOP possède cette bague tant qu\'il détient la clé. Si vous la réinitialisez à nouveau ou la configurez dans l\'app Oura, NOOP ne la possède plus et vous devrez la rajouter pour en reprendre le contrôle.</string>
     <string name="l10n_devices_screen_pick_a_new_active_strap_edd73542">Choisir un nouveau bracelet actif</string>
     <string name="l10n_devices_screen_rename_device_ee233604">Renommer l\'appareil</string>
     <string name="l10n_devices_screen_send_probe_read_only_36b318bc">Envoyer la sonde (lecture seule)</string>
@@ -265,7 +265,7 @@
     <string name="l10n_devices_screen_waiting_for_the_straps_reply_5a06e7ac">En attente de la réponse du bracelet…</string>
     <string name="l10n_devices_screen_whoop_4_0_reboot_probe_b51fb50f">Sonde de redémarrage WHOOP 4.0</string>
     <string name="l10n_devices_screen_whoop_is_noop_s_primary_fully_1c9e67fd">WHOOP est le bracelet principal et entièrement pris en charge par NOOP. D\'autres bracelets de fréquence cardiaque sont un ajout précoce, </string>
-    <string name="l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48">Vous avez enlevé votre bracelet actif. Choisissez quel bracelet associé fournit vos données en direct, ou </string>
+    <string name="l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48">Vous avez retiré votre bracelet actif. Choisissez quelle bande associée fournit vos données en direct, ou n\'en laissez aucune active et associez-en une plus tard.</string>
     <string name="l10n_fused_record_screen_contrib_source_displayname_fusionformat_value_contrib_d182dd7f">%1$s, %2$s</string>
     <string name="l10n_fused_record_screen_done_e9b450d1">Terminé</string>
     <string name="l10n_fused_record_screen_fused_on_devicenoun_nothing_leaves_it_8a1e6a3d">Fumé sur %1$s. Rien ne le laisse : pas de compte, pas de nuage.</string>
@@ -310,11 +310,11 @@
     <string name="l10n_how_noop_works_screen_close_bbfa773e">Fermer</string>
     <string name="l10n_how_noop_works_screen_got_it_5b8027fa">Compris</string>
     <string name="l10n_how_noop_works_screen_how_noop_works_3396b27a">Comment NOOP fonctionne</string>
-    <string name="l10n_how_noop_works_screen_noop_never_makes_up_a_number_da29aca5">NOOP n\'invente jamais de numéro. Quand il ne peut pas calculer un honnêtement il vous dit</string>
+    <string name="l10n_how_noop_works_screen_noop_never_makes_up_a_number_da29aca5">NOOP n\'invente jamais de chiffre. Quand il ne peut pas en calculer un honnêtement, il vous indique ce qui manque et quoi faire, plutôt que d\'afficher une valeur fictive.</string>
     <string name="l10n_how_noop_works_screen_noop_never_shows_you_a_number_d1db9958">NOOP ne vous montre jamais un numéro qu\'il a dû rattraper. Si un score n\'est pas prêt,</string>
     <string name="l10n_how_noop_works_screen_section_title_section_body_efb1a999">%1$s. %2$s</string>
     <string name="l10n_how_noop_works_screen_sleep_scores_recording_where_your_numbers_1b3e981f">Sommeil · scores · enregistrement · d\'où viennent vos chiffres</string>
-    <string name="l10n_hrv_snapshot_screen_an_hrv_reading_needs_the_live_11b70bff">Une lecture VFC a besoin du flux R-R en direct. Ouvrez l\'écran Live et connectez votre bracelet, </string>
+    <string name="l10n_hrv_snapshot_screen_an_hrv_reading_needs_the_live_11b70bff">Une lecture de VFC nécessite le flux R-R en direct. Ouvrez l\'écran En direct et connectez votre bracelet, puis revenez.</string>
     <string name="l10n_hrv_snapshot_screen_beats_12aafda0">Battements</string>
     <string name="l10n_hrv_snapshot_screen_hrvdial_4c244c45">hrvDial</string>
     <string name="l10n_hrv_snapshot_screen_mean_hr_6c9272dd">FC moyenne</string>
@@ -367,7 +367,7 @@
     <string name="l10n_insights_screen_not_enough_overlap_between_your_journal_0ebdd7a2">Pas assez de chevauchement entre les réponses de votre journal et</string>
     <string name="l10n_insights_screen_not_enough_overlapping_history_to_correlate_a552dbd4">Pas encore assez d\'historique chevauchant pour corréler vos métriques.</string>
     <string name="l10n_insights_screen_pick_one_behaviour_you_log_one_bd34090e">Choisissez un comportement que vous enregistrez, un résultat, et une fenêtre courte. NOOP</string>
-    <string name="l10n_insights_screen_ranked_lag_aware_which_of_your_e0e91b39">Classé, lag-aware: lequel de vos habitudes réellement déplacer votre charge, plus votre</string>
+    <string name="l10n_insights_screen_ranked_lag_aware_which_of_your_e0e91b39">Classé, avec prise en compte du décalage : quelles habitudes influencent réellement votre Charge, plus votre réponse personnelle à la dose d\'alcool/caféine.</string>
     <string name="l10n_insights_screen_rest_baseline_b3ac52a5">Ligne de base du Repos</string>
     <string name="l10n_insights_screen_run_a_clean_personal_test_4da69781">Effectuer un test personnel propre</string>
     <string name="l10n_insights_screen_sessions_e11e37a9">Séances</string>
@@ -418,7 +418,7 @@
     <string name="l10n_lab_book_screen_clear_719ea396">Effacer</string>
     <string name="l10n_lab_book_screen_delete_this_reading_b5c92bda">Supprimer cette lecture</string>
     <string name="l10n_lab_book_screen_import_readings_7ad0d28f">Importer des lectures</string>
-    <string name="l10n_lab_book_screen_it_s_a_notebook_not_a_45835e98">C\'est un carnet, pas un labo. NOOP line les numéros que vous entrez. Ça ne teste pas.</string>
+    <string name="l10n_lab_book_screen_it_s_a_notebook_not_a_45835e98">C\'est un carnet, pas un laboratoire. NOOP aligne les chiffres que vous saisissez. Il ne les analyse, ne les lit ni ne les juge. Pas un avis médical.</string>
     <string name="l10n_lab_book_screen_keep_your_own_numbers_here_1ca6c8ed">Gardez vos propres chiffres ici</string>
     <string name="l10n_lab_book_screen_lab_book_f966c140">Carnet de laboratoire</string>
     <string name="l10n_lab_book_screen_lab_book_is_a_private_notebook_d07380ca">Lab Book est un cahier privé, pas un service médical. NOOP stocke et range les numéros</string>
@@ -431,7 +431,7 @@
     <string name="l10n_lab_book_screen_read_the_full_lab_book_note_3a250750">Lire la note complète du Lab Book</string>
     <string name="l10n_lab_book_screen_read_the_full_note_3fd0e4d1">Lire la note complète</string>
     <string name="l10n_lab_book_screen_reading_your_logbook_e31992b0">Lecture de votre journal…</string>
-    <string name="l10n_lab_book_screen_these_are_your_own_numbers_shown_7667508d">Ce sont vos propres chiffres qui vous sont montrés. NOOP ne décide pas si une valeur est</string>
+    <string name="l10n_lab_book_screen_these_are_your_own_numbers_shown_7667508d">Ce sont vos propres chiffres qui vous sont restitués. NOOP ne décide pas si une valeur est normale, haute ou basse.</string>
     <string name="l10n_lab_book_screen_type_in_a_blood_pressure_reading_c276d418">Tapez une valeur de pression artérielle ou de cholestérol depuis votre dernier rendez-vous.</string>
     <string name="l10n_lab_book_screen_what_lab_book_is_and_isn_f28686df">Ce qu\'est le Carnet de laboratoire (et ce qu\'il n\'est pas)</string>
     <string name="l10n_live_screen_manage_devices_e5c277ff">Gérer les appareils</string>
@@ -581,7 +581,7 @@
     <string name="l10n_scoring_guide_screen_how_your_scores_work_21a0e2be">Comment fonctionnent vos scores</string>
     <string name="l10n_scoring_guide_screen_noop_gives_you_three_daily_scores_36244209">NOOP vous donne trois scores quotidiens (charge, effort et repos), chacun sur un 0-100</string>
     <string name="l10n_scoring_guide_screen_scorecardhighlight_4af6985c">scoreCardHighlight</string>
-    <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">Il s\'agit d\'approximations indépendantes d\'un bracelet grand public, fondées sur la science ouverte: </string>
+    <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">Ce sont des approximations indépendantes issues d\'un bracelet grand public, fondées sur la science ouverte : ni un conseil médical, ni les scores officiels de WHOOP.</string>
     <string name="l10n_scoring_guide_screen_vs_whoop_9a8126a7">VS WHOOP</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">avancéChevron</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
@@ -670,7 +670,7 @@
     <string name="l10n_steps_calibration_screen_how_this_works_b895a8c3">Comment ça fonctionne</string>
     <string name="l10n_steps_calibration_screen_no_days_yet_where_both_noop_71d6005b">Pas encore de jours où NOOP et votre téléphone ont compté les étapes. Une fois que votre téléphone enregistre un</string>
     <string name="l10n_steps_calibration_screen_no_motion_synced_yet_65106670">Aucun mouvement synchronisé pour l\'instant</string>
-    <string name="l10n_steps_calibration_screen_noop_estimates_your_steps_from_your_d569bc31">NOOP évalue vos étapes à partir du mouvement de votre WHOOP, calibré à l\'étape de votre téléphone</string>
+    <string name="l10n_steps_calibration_screen_noop_estimates_your_steps_from_your_d569bc31">NOOP estime vos pas à partir du mouvement de votre WHOOP, calibré sur le nombre de pas de votre téléphone. C\'est une estimation, pas un podomètre. Un WHOOP 4.0 ne transmet pas de pas.</string>
     <string name="l10n_steps_calibration_screen_not_calibrated_yet_30abe0d0">Pas encore calibré</string>
     <string name="l10n_steps_calibration_screen_on_the_days_your_phone_also_2f65a14c">Les jours où votre téléphone a également compté les étapes, NOOP apprend combien votre carte de mouvement à</string>
     <string name="l10n_steps_calibration_screen_open_noop_near_your_strap_and_e08ddd6d">Ouvrez NOOP près de votre bracelet et laissez-le rattraper (une synchronisation d\'historique complète peut prendre un certain temps sur </string>
@@ -679,8 +679,8 @@
     <string name="l10n_steps_calibration_screen_shortday_row_day_estimated_row_estimated_f2d71597">%1$s: étapes %2$s estimées, téléphone %3$s</string>
     <string name="l10n_steps_calibration_screen_steps_per_motion_unit_a2c2ac56">pas par unité de mouvement</string>
     <string name="l10n_steps_calibration_screen_takes_effect_on_the_next_analytics_13205327">Prend effet lors de la prochaine analyse (après la prochaine synchronisation).</string>
-    <string name="l10n_steps_calibration_screen_these_are_the_days_where_your_ae5c9c2c">Ce sont les jours où votre téléphone a également compté les étapes, de sorte que NOOP peut apprendre comment votre</string>
-    <string name="l10n_steps_calibration_screen_these_days_are_excluded_from_the_6bedabbf">Ces jours sont exclus de l\'estimation (le nombre réel de votre téléphone est affiché à la place).</string>
+    <string name="l10n_steps_calibration_screen_these_are_the_days_where_your_ae5c9c2c">Ce sont les jours où votre téléphone a aussi compté les pas, afin que NOOP apprenne comment votre mouvement se traduit en pas. Ou définissez le coefficient manuellement ci-dessous.</string>
+    <string name="l10n_steps_calibration_screen_these_days_are_excluded_from_the_6bedabbf">Ces jours sont exclus de l\'estimation (le comptage réel de votre téléphone est affiché à la place). Ils figurent ici uniquement pour que vous puissiez juger de la précision de l\'estimation.</string>
     <string name="l10n_steps_calibration_screen_we_re_not_seeing_any_motion_6ac8e092">On ne voit aucun mouvement de votre bracelet. Les étapes sont estimées à partir de votre WHOOP </string>
     <string name="l10n_steps_calibration_screen_whoop_4_0_motion_steps_a63239dc">WHOOP 4.0 · mouvement → pas</string>
     <string name="l10n_strand_components_next_day_38f859dd">Jour suivant</string>
@@ -1430,7 +1430,7 @@
     <string name="l10n_stress_screen_on_demand_today_s_r_r_17d716e1">à la demande · R-R du jour</string>
     <string name="l10n_stress_screen_on_the_0_3_autonomic_load_8a0d5107">sur l\'échelle de charge autonome 0-3</string>
     <string name="l10n_stress_screen_the_line_traces_your_autonomic_load_804f4028">La ligne trace votre charge autonome tout au long de la journée de réveil, marqué</string>
-    <string name="l10n_stress_screen_these_are_extra_on_demand_hrv_9303f1de">Ce sont des lentilles HRV supplémentaires sur demande calculées à partir des intervalles R-R d\'aujourd\'hui. Ils</string>
+    <string name="l10n_stress_screen_these_are_extra_on_demand_hrv_9303f1de">Ce sont des angles d\'analyse VFC supplémentaires, à la demande, calculés à partir des intervalles R-R d\'aujourd\'hui. Ils sont informatifs et ne modifient pas le score de stress ci-dessus.</string>
     <string name="l10n_stress_screen_we_compare_today_s_resting_heart_a9cd0955">Nous comparons la fréquence cardiaque au repos d\'aujourd\'hui à votre propre 30 jours</string>
     <string name="l10n_test_centre_screen_bug_report_5a7ee5ac">Rapport de bug</string>
     <string name="l10n_today_screen_arrange_cfdd099c">Régler</string>
@@ -1456,7 +1456,7 @@
     <string name="l10n_today_screen_move_item_metric_title_down_890afe60">Déplacer %1$s vers le bas</string>
     <string name="l10n_today_screen_move_item_metric_title_up_52d2104c">Déplacer %1$s vers le haut</string>
     <string name="l10n_today_screen_new_data_added_e59345b4">Nouvelles données ajoutées</string>
-    <string name="l10n_today_screen_no_cardio_load_yet_effort_builds_e952006c">Pas encore de charge cardio. Effort construit une fois que votre rythme cardiaque monte dans votre effort</string>
+    <string name="l10n_today_screen_no_cardio_load_yet_effort_builds_e952006c">Pas encore de charge cardio. L\'Effort s\'accumule une fois que votre fréquence cardiaque grimpe dans votre zone d\'effort (environ 50 % de votre réserve de fréquence cardiaque). Une journée calme affiche honnêtement une valeur proche de zéro.</string>
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">Profil et réglages</string>
     <string name="l10n_today_screen_recovery_ea924f72">Récupération</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -291,7 +291,7 @@
     <string name="l10n_caffeine_log_had_it_8576ac66">Tinha</string>
     <string name="l10n_caffeine_log_have_your_last_caffeine_by_about_16b09033">Tome a tua última cafeína por volta das %1$s para eliminar a maior parte </string>
     <string name="l10n_caffeine_log_late_caffeine_nudge_6b2ff690">Empurrãozinho de cafeína tardia</string>
-    <string name="l10n_caffeine_log_log_a_coffee_tea_or_energy_982bde5b">Registe um café, chá ou bebida energética e o NOOP mostra uma estimativa aproximada de quanto pode </string>
+    <string name="l10n_caffeine_log_log_a_coffee_tea_or_energy_982bde5b">Registe um café, chá ou bebida energética e o NOOP mostra uma estimativa aproximada de quanto ainda pode estar ativo. É um guia baseado numa meia-vida típica de 5 a 6 horas, e não numa medição.</string>
     <string name="l10n_caffeine_log_logged_today_0071a46c">Registado hoje</string>
     <string name="l10n_caffeine_log_remove_e963907d">Remover</string>
     <string name="l10n_coach_screen_api_key_hidden_f3cde531">Chave API (oculta)</string>
@@ -339,7 +339,7 @@
     <string name="l10n_coupled_screen_no_sleep_tracked_last_night_cd0dd79e">Nenhum sono monitorizado na noite passada</string>
     <string name="l10n_coupled_screen_recovery_b668d988">RECOVERY</string>
     <string name="l10n_coupled_screen_sleep_performance_4611539f">SLEEP PERFORMANCE</string>
-    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">Atua como uma bracelete de frequência cardíaca Bluetooth padrão. Emparelhe o NOOP da tua passadeira, </string>
+    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">Atua como uma bracelete de frequência cardíaca Bluetooth padrão. Emparelhe o NOOP da tua passadeira, bicicleta ou aplicação para ver o frequência cardíaca da tua bracelete.</string>
     <string name="l10n_data_sources_screen_apple_health_b19b87da">Apple Health</string>
     <string name="l10n_data_sources_screen_auto_sync_health_connect_periodically_6f3f4d92">Sincronizar automaticamente o Health Connect periodicamente</string>
     <string name="l10n_data_sources_screen_auto_sync_periodically_5f3041e8">Sincronizar automaticamente periodicamente</string>
@@ -370,7 +370,7 @@
     <string name="l10n_data_sources_screen_remove_imported_data_813e4695">Remover dados importados</string>
     <string name="l10n_data_sources_screen_share_back_to_health_connect_1d578f4a">Partilhe de volta no Health Connect</string>
     <string name="l10n_data_sources_screen_share_computed_metrics_back_to_health_c11f5d70">Partilhe métricas computadas de volta para o Health Connect</string>
-    <string name="l10n_data_sources_screen_this_permanently_deletes_everything_imported_from_f42e760e">Isto exclui permanentemente tudo o que é importado do Apple Health: frequência cardíaca, VFC, </string>
+    <string name="l10n_data_sources_screen_this_permanently_deletes_everything_imported_from_f42e760e">Isto exclui permanentemente tudo o que é importado do Apple Health: frequência cardíaca, VFC, sono, passos, treinos e muito mais. Os dados da tua bracelete em direto permanecem intactos. Isso não pode ser desfeito.</string>
     <string name="l10n_data_sources_screen_whoop_history_db101974">Histórico do WHOOP</string>
     <string name="l10n_data_sources_screen_whoop_strap_live_ble_217f7df6">Correia WHOOP (BLE em direto)</string>
     <string name="l10n_data_sources_screen_workout_file_gpx_tcx_fit_5469c068">Ficheiro de treino (GPX/TCX/FIT)</string>
@@ -409,7 +409,7 @@
     <string name="l10n_devices_screen_leave_none_active_b5c858cb">Não deixe nenhum ativo</string>
     <string name="l10n_devices_screen_name_709a2322">Nome</string>
     <string name="l10n_devices_screen_pack_voltage_9af3c3ff">%1$.2f V</string>
-    <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Emparelhado localmente. NOOP possui este anel enquanto detém a chave. Se o repor novamente ou configurá-lo </string>
+    <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Emparelhado localmente. NOOP possui este anel enquanto detém a chave. Se o repor novamente ou o configurar na aplicação Oura, o NOOP já não será o proprietário e irá adicioná-lo novamente para o assumir.</string>
     <string name="l10n_devices_screen_pick_a_new_active_strap_edd73542">Escolha uma nova bracelete ativa</string>
     <string name="l10n_devices_screen_rename_device_ee233604">Renomear dispositivo</string>
     <string name="l10n_devices_screen_send_probe_read_only_36b318bc">Enviar sonda (apenas leitura)</string>
@@ -418,7 +418,7 @@
     <string name="l10n_devices_screen_waiting_for_the_straps_reply_5a06e7ac">Aguardo a resposta da bracelete…</string>
     <string name="l10n_devices_screen_whoop_4_0_reboot_probe_b51fb50f">Sonda de reinicialização do WHOOP 4.0</string>
     <string name="l10n_devices_screen_whoop_is_noop_s_primary_fully_1c9e67fd">WHOOP é a banda principal e totalmente suportada do NOOP. Outras tiras de frequência cardíaca são precoces, </string>
-    <string name="l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48">Retirou a tua bracelete ativa. Escolha qual a banda emparelhada que fornece os teus dados em direto ou </string>
+    <string name="l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48">Retirou a tua bracelete ativa. Escolha qual a banda emparelhada que fornece os teus dados em direto ou não deixe nenhuma ativa e emparelhe uma mais tarde.</string>
     <string name="l10n_fused_record_screen_contrib_source_displayname_fusionformat_value_contrib_d182dd7f">%1$s, %2$s</string>
     <string name="l10n_fused_record_screen_done_e9b450d1">Concluído</string>
     <string name="l10n_fused_record_screen_fused_on_devicenoun_nothing_leaves_it_8a1e6a3d">Fundido em %1$s. Não sai nada: nenhuma conta, nenhuma nuvem.</string>
@@ -463,11 +463,11 @@
     <string name="l10n_how_noop_works_screen_close_bbfa773e">Fechar</string>
     <string name="l10n_how_noop_works_screen_got_it_5b8027fa">Entendi</string>
     <string name="l10n_how_noop_works_screen_how_noop_works_3396b27a">Como funciona o NOOP</string>
-    <string name="l10n_how_noop_works_screen_noop_never_makes_up_a_number_da29aca5">O NOOP nunca inventa um número. Quando não consegue calcular honestamente, diz-lhe </string>
+    <string name="l10n_how_noop_works_screen_noop_never_makes_up_a_number_da29aca5">O NOOP nunca inventa um número. Quando não consegue computar um valor honestamente, diz-lhe o que está em falta e o que fazer, em vez de mostrar um valor falso.</string>
     <string name="l10n_how_noop_works_screen_noop_never_shows_you_a_number_d1db9958">O NOOP nunca mostra um número que precisava de ser inventado. Se uma pontuação não estiver pronta, </string>
     <string name="l10n_how_noop_works_screen_section_title_section_body_efb1a999">%1$s. %2$s</string>
     <string name="l10n_how_noop_works_screen_sleep_scores_recording_where_your_numbers_1b3e981f">Dormir · pontuações · registar · de onde vêm os teus números</string>
-    <string name="l10n_hrv_snapshot_screen_an_hrv_reading_needs_the_live_11b70bff">Uma leitura HRV precisa da transmissão RR em direto. Abra o ecrã em direto e ligue a tua bracelete, </string>
+    <string name="l10n_hrv_snapshot_screen_an_hrv_reading_needs_the_live_11b70bff">Uma leitura HRV precisa da transmissão RR em direto. Abra o ecrã em direto, ligue a tua bracelete e volte.</string>
     <string name="l10n_hrv_snapshot_screen_beats_12aafda0">Batidas</string>
     <string name="l10n_hrv_snapshot_screen_hrvdial_4c244c45">hrvDial</string>
     <string name="l10n_hrv_snapshot_screen_mean_hr_6c9272dd">RH médio</string>
@@ -520,7 +520,7 @@
     <string name="l10n_insights_screen_not_enough_overlap_between_your_journal_0ebdd7a2">Não há sobreposição suficiente entre as respostas do teu diário e </string>
     <string name="l10n_insights_screen_not_enough_overlapping_history_to_correlate_a552dbd4">Ainda não há histórico de sobreposição suficiente para correlacionar as tuas métricas.</string>
     <string name="l10n_insights_screen_pick_one_behaviour_you_log_one_bd34090e">Escolha um comportamento registado, um resultado e uma janela curta. NOOP </string>
-    <string name="l10n_insights_screen_ranked_lag_aware_which_of_your_e0e91b39">Classificado, ciente do atraso: quais dos teus hábitos movem realmente a tua carga, mais o teu </string>
+    <string name="l10n_insights_screen_ranked_lag_aware_which_of_your_e0e91b39">Classificado, ciente do atraso: quais dos teus hábitos realmente movem a tua carga, para além da tua resposta pessoal à dose de álcool/cafeína.</string>
     <string name="l10n_insights_screen_rest_baseline_b3ac52a5">Linha de base de descanso</string>
     <string name="l10n_insights_screen_run_a_clean_personal_test_4da69781">Execute um teste pessoal limpo</string>
     <string name="l10n_insights_screen_sessions_e11e37a9">Sessões</string>
@@ -571,7 +571,7 @@
     <string name="l10n_lab_book_screen_clear_719ea396">Claro</string>
     <string name="l10n_lab_book_screen_delete_this_reading_b5c92bda">Apagar esta leitura</string>
     <string name="l10n_lab_book_screen_import_readings_7ad0d28f">Importar leituras</string>
-    <string name="l10n_lab_book_screen_it_s_a_notebook_not_a_45835e98">É um caderno, não é um laboratório. O NOOP alinha os números introduzidos. Não testa, </string>
+    <string name="l10n_lab_book_screen_it_s_a_notebook_not_a_45835e98">É um caderno, não é um laboratório. O NOOP alinha os números introduzidos. Não os testa, lê ou julga. Não é aconselhamento médico.</string>
     <string name="l10n_lab_book_screen_keep_your_own_numbers_here_1ca6c8ed">Mantenha aqui os teus próprios números</string>
     <string name="l10n_lab_book_screen_lab_book_f966c140">Caderno de laboratório</string>
     <string name="l10n_lab_book_screen_lab_book_is_a_private_notebook_d07380ca">O Lab Book é um caderno privado, não um serviço médico. O NOOP armazena e alinha os números </string>
@@ -584,7 +584,7 @@
     <string name="l10n_lab_book_screen_read_the_full_lab_book_note_3a250750">Leia a nota completa do Lab Book</string>
     <string name="l10n_lab_book_screen_read_the_full_note_3fd0e4d1">Leia a nota completa</string>
     <string name="l10n_lab_book_screen_reading_your_logbook_e31992b0">A ler o teu diário de bordo…</string>
-    <string name="l10n_lab_book_screen_these_are_your_own_numbers_shown_7667508d">Estes são os teus próprios números que lhe são mostrados. O NOOP não decide se algum valor é </string>
+    <string name="l10n_lab_book_screen_these_are_your_own_numbers_shown_7667508d">Estes são os teus próprios números que lhe são mostrados. O NOOP não decide se algum valor é normal, alto ou baixo.</string>
     <string name="l10n_lab_book_screen_type_in_a_blood_pressure_reading_c276d418">Introduza a leitura da pressão arterial ou o valor do colesterol da tua última consulta. </string>
     <string name="l10n_lab_book_screen_what_lab_book_is_and_isn_f28686df">O que Lab Book é (e não é)</string>
     <string name="l10n_live_screen_manage_devices_e5c277ff">Gerir dispositivos</string>
@@ -734,7 +734,7 @@
     <string name="l10n_scoring_guide_screen_how_your_scores_work_21a0e2be">Como funcionam as tuas pontuações</string>
     <string name="l10n_scoring_guide_screen_noop_gives_you_three_daily_scores_36244209">O NOOP oferece três pontuações diárias (carga, esforço e descanso), cada uma de 0 a 100 </string>
     <string name="l10n_scoring_guide_screen_scorecardhighlight_4af6985c">pontuaçãoCardHighlight</string>
-    <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">Trata-se de aproximações independentes de uma faixa de consumo, construídas com base na ciência aberta: não </string>
+    <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">Trata-se de aproximações independentes de um intervalo de consumo, construídas com base na ciência aberta: não nos conselhos médicos, nem nas pontuações oficiais do WHOOP.</string>
     <string name="l10n_scoring_guide_screen_vs_whoop_9a8126a7">VS GRUPO</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">avançadoChevron</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
@@ -823,7 +823,7 @@
     <string name="l10n_steps_calibration_screen_how_this_works_b895a8c3">Como funciona</string>
     <string name="l10n_steps_calibration_screen_no_days_yet_where_both_noop_71d6005b">Ainda não há dias em que o NOOP e o teu telemóvel contem passos. Depois de o teu telemóvel registar um </string>
     <string name="l10n_steps_calibration_screen_no_motion_synced_yet_65106670">Nenhum movimento sincronizado ainda</string>
-    <string name="l10n_steps_calibration_screen_noop_estimates_your_steps_from_your_d569bc31">O NOOP estima os teus passos a partir do movimento do teu WHOOP, calibrado para o passo do teu telemóvel </string>
+    <string name="l10n_steps_calibration_screen_noop_estimates_your_steps_from_your_d569bc31">O NOOP estima os teus passos a partir do movimento do WHOOP, calibrado para a contagem de passos do teu telemóvel. É uma estimativa, não um contador de passos. Um WHOOP 4.0 não transmite passos.</string>
     <string name="l10n_steps_calibration_screen_not_calibrated_yet_30abe0d0">Ainda não calibrado</string>
     <string name="l10n_steps_calibration_screen_on_the_days_your_phone_also_2f65a14c">Nos dias em que o teu telemóvel também contava passos, o NOOP fica a saber quanto o teu movimento mapeia </string>
     <string name="l10n_steps_calibration_screen_open_noop_near_your_strap_and_e08ddd6d">Abra o NOOP junto à sua bracelete e deixe-o acompanhar (uma sincronização completa do histórico pode demorar um pouco </string>
@@ -832,8 +832,8 @@
     <string name="l10n_steps_calibration_screen_shortday_row_day_estimated_row_estimated_f2d71597">%1$s: etapas estimadas de %2$s, telefone %3$s </string>
     <string name="l10n_steps_calibration_screen_steps_per_motion_unit_a2c2ac56">passos por unidade de movimento</string>
     <string name="l10n_steps_calibration_screen_takes_effect_on_the_next_analytics_13205327">Entra em vigor na passagem de análise seguinte (após a sincronização seguinte).</string>
-    <string name="l10n_steps_calibration_screen_these_are_the_days_where_your_ae5c9c2c">Estes são os dias em que o teu telemóvel também contava passos, pelo que o NOOP pode aprender como o teu </string>
-    <string name="l10n_steps_calibration_screen_these_days_are_excluded_from_the_6bedabbf">Estes dias são excluídos da estimativa (em vez disso, é mostrada a contagem real do teu telemóvel). </string>
+    <string name="l10n_steps_calibration_screen_these_are_the_days_where_your_ae5c9c2c">Estes são os dias em que o teu telemóvel também contava passos, pelo que o NOOP pode aprender como o teu movimento é mapeado para passos. Ou defina o coeficiente manualmente abaixo.</string>
+    <string name="l10n_steps_calibration_screen_these_days_are_excluded_from_the_6bedabbf">Estes dias são excluídos da estimativa (em vez disso, é mostrada a contagem real do teu telemóvel). Estão aqui apenas para que possa avaliar a precisão da estimativa.</string>
     <string name="l10n_steps_calibration_screen_we_re_not_seeing_any_motion_6ac8e092">Ainda não estamos a ver nenhum movimento da tua bracelete. As etapas são estimadas a partir do teu WHOOP </string>
     <string name="l10n_steps_calibration_screen_whoop_4_0_motion_steps_a63239dc">WHOOP 4.0 · movimento → passos</string>
     <string name="l10n_strand_components_next_day_38f859dd">Dia seguinte</string>
@@ -1581,7 +1581,7 @@
     <string name="l10n_stress_screen_on_demand_today_s_r_r_17d716e1">on demand · R-R de hoje</string>
     <string name="l10n_stress_screen_on_the_0_3_autonomic_load_8a0d5107">na escala de carga autónoma 0-3</string>
     <string name="l10n_stress_screen_the_line_traces_your_autonomic_load_804f4028">A linha acompanha a tua carga autónoma ao longo do dia, pontuada </string>
-    <string name="l10n_stress_screen_these_are_extra_on_demand_hrv_9303f1de">Estas são lentes HRV extra a pedido, calculadas a partir dos intervalos RR atuais. Eles </string>
+    <string name="l10n_stress_screen_these_are_extra_on_demand_hrv_9303f1de">Estas são lentes HRV extra a pedido, calculadas a partir dos intervalos RR atuais. São informativos e não alteram a pontuação de stress acima.</string>
     <string name="l10n_stress_screen_we_compare_today_s_resting_heart_a9cd0955">Comparámos a frequência cardíaca em repouso e a VFC de hoje com a tua frequência cardíaca de 30 dias </string>
     <string name="l10n_test_centre_screen_bug_report_5a7ee5ac">Relatório de erro</string>
     <string name="l10n_today_screen_arrange_cfdd099c">Organizar</string>
@@ -1607,7 +1607,7 @@
     <string name="l10n_today_screen_move_item_metric_title_down_890afe60">Desloque %1$s para baixo</string>
     <string name="l10n_today_screen_move_item_metric_title_up_52d2104c">Mover %1$s para cima</string>
     <string name="l10n_today_screen_new_data_added_e59345b4">Novos dados adicionados</string>
-    <string name="l10n_today_screen_no_cardio_load_yet_effort_builds_e952006c">Sem carga cardiovascular ainda. O esforço aumenta quando a frequência cardíaca aumenta com o esforço </string>
+    <string name="l10n_today_screen_no_cardio_load_yet_effort_builds_e952006c">Sem carga cardiovascular ainda. O esforço aumenta quando a frequência cardíaca atinge a zona de esforço (cerca de 50% da reserva de frequência cardíaca). Um dia calmo parece honestamente próximo de zero.</string>
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">Perfil e definições</string>
     <string name="l10n_today_screen_recovery_ea924f72">Recuperação</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -289,7 +289,7 @@
     <string name="l10n_caffeine_log_had_it_8576ac66">已摄入</string>
     <string name="l10n_caffeine_log_have_your_last_caffeine_by_about_16b09033">请在 %1$s 左右完成最后一次咖啡因摄入，以确保它能代谢掉大部分</string>
     <string name="l10n_caffeine_log_late_caffeine_nudge_6b2ff690">深夜咖啡因提醒</string>
-    <string name="l10n_caffeine_log_log_a_coffee_tea_or_energy_982bde5b">记录一杯咖啡、茶或能量饮料，NOOP 将会为您粗略估算有多少咖啡因会残留到...</string>
+    <string name="l10n_caffeine_log_log_a_coffee_tea_or_energy_982bde5b">记录一杯咖啡、茶或能量饮料，NOOP 会大致估算还有多少可能仍在起作用。这是基于典型的 5 到 6 小时半衰期的一个参考，而非测量值。</string>
     <string name="l10n_caffeine_log_logged_today_0071a46c">今日已记录</string>
     <string name="l10n_caffeine_log_remove_e963907d">移除</string>
     <string name="l10n_coach_screen_api_key_hidden_f3cde531">API Key (已隐藏)</string>
@@ -337,7 +337,7 @@
     <string name="l10n_coupled_screen_no_sleep_tracked_last_night_cd0dd79e">昨晚未追踪到睡眠</string>
     <string name="l10n_coupled_screen_recovery_b668d988">身体恢复</string>
     <string name="l10n_coupled_screen_sleep_performance_4611539f">睡眠表现</string>
-    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">可作为标准蓝牙心率带使用。您可以将 NOOP 与跑步机等设备配对，...</string>
+    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">作为标准的蓝牙心率手环使用。从你的跑步机、单车或应用中配对 NOOP，即可在那里看到手环的心率。</string>
     <string name="l10n_data_sources_screen_apple_health_b19b87da">Apple Health</string>
     <string name="l10n_data_sources_screen_auto_sync_health_connect_periodically_6f3f4d92">定期自动同步 Health Connect</string>
     <string name="l10n_data_sources_screen_auto_sync_periodically_5f3041e8">定期自动同步</string>
@@ -368,7 +368,7 @@
     <string name="l10n_data_sources_screen_remove_imported_data_813e4695">移除导入的数据</string>
     <string name="l10n_data_sources_screen_share_back_to_health_connect_1d578f4a">回传至 Health Connect</string>
     <string name="l10n_data_sources_screen_share_computed_metrics_back_to_health_c11f5d70">将计算出的健康指标回传至 Health Connect</string>
-    <string name="l10n_data_sources_screen_this_permanently_deletes_everything_imported_from_f42e760e">这将永久删除从 Apple Health 导入的所有内容：心率、HRV、...</string>
+    <string name="l10n_data_sources_screen_this_permanently_deletes_everything_imported_from_f42e760e">这将永久删除从 Apple 健康导入的一切，心率、HRV、睡眠、步数、锻炼等。你的实时手环数据不受影响。此操作无法撤销。</string>
     <string name="l10n_data_sources_screen_whoop_history_db101974">WHOOP 历史数据</string>
     <string name="l10n_data_sources_screen_whoop_strap_live_ble_217f7df6">WHOOP 手环 (实时蓝牙连线)</string>
     <string name="l10n_data_sources_screen_workout_file_gpx_tcx_fit_5469c068">运动轨迹文件 (GPX / TCX / FIT)</string>
@@ -398,14 +398,14 @@
     <string name="l10n_devices_screen_give_device_brand_device_model_a_7a15585c">为您的 %1$s %2$s 起一个好记的名字。</string>
     <string name="l10n_devices_screen_leave_none_active_b5c858cb">不激活任何设备</string>
     <string name="l10n_devices_screen_name_709a2322">名称</string>
-    <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">已在本地配对。当 NOOP 掌握密钥时，它就完全接管了这枚戒指。如果您重置戒指，或者用其他App将其连接...</string>
+    <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">已在本地配对。只要 NOOP 持有密钥，它就是这枚戒指的持有者。如果你再次重置它，或在 Oura 应用中设置它，NOOP 便不再持有它，你需要重新添加它以再次接管。</string>
     <string name="l10n_devices_screen_pick_a_new_active_strap_edd73542">选择新的主数据手环</string>
     <string name="l10n_devices_screen_rename_device_ee233604">重命名设备</string>
     <string name="l10n_devices_screen_save_efc007a3">保存</string>
     <string name="l10n_devices_screen_the_whoop_4_0_reboot_frame_690a8ff2">WHOOP 4.0 的重启指令包尚未破译验证 — 目前常规的重启指令可能被它忽略 (#235)。</string>
     <string name="l10n_devices_screen_whoop_4_0_reboot_probe_b51fb50f">尝试重启 WHOOP 4.0</string>
     <string name="l10n_devices_screen_whoop_is_noop_s_primary_fully_1c9e67fd">WHOOP 是 NOOP 首要且完全支持的核心手环。其他心率带只能提供早期测试版的...</string>
-    <string name="l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48">您已移除了正在活跃的手环。请选择用哪条已配对的手环来提供实时数据，或者...</string>
+    <string name="l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48">你移除了你的活跃手环。请选择哪一个已配对的手环来提供你的实时数据，或者不设置任何活跃项，稍后再配对一个。</string>
     <string name="l10n_fused_record_screen_contrib_source_displayname_fusionformat_value_contrib_d182dd7f">%1$s, %2$s</string>
     <string name="l10n_fused_record_screen_done_e9b450d1">完成</string>
     <string name="l10n_fused_record_screen_fused_on_devicenoun_nothing_leaves_it_8a1e6a3d">所有数据仅在%1$s本地融合。没有数据会离开设备：不绑定账号，不上云。</string>
@@ -450,11 +450,11 @@
     <string name="l10n_how_noop_works_screen_close_bbfa773e">关闭</string>
     <string name="l10n_how_noop_works_screen_got_it_5b8027fa">明白了</string>
     <string name="l10n_how_noop_works_screen_how_noop_works_3396b27a">NOOP 是如何运作的</string>
-    <string name="l10n_how_noop_works_screen_noop_never_makes_up_a_number_da29aca5">NOOP 从不凭空捏造数据。如果缺乏足够的信息去得出一个严谨的结果，它会如实告知您，而不是靠猜测填充。</string>
+    <string name="l10n_how_noop_works_screen_noop_never_makes_up_a_number_da29aca5">NOOP 绝不编造数字。当它无法诚实地计算出一个数字时，它会告诉你缺少什么以及该怎么做，而不是显示一个虚假的数值。</string>
     <string name="l10n_how_noop_works_screen_noop_never_shows_you_a_number_d1db9958">NOOP 从不会给您看一个为了图表好看而凑出来的数字。如果某项评分还没准备好，那它就是还没准备好。</string>
     <string name="l10n_how_noop_works_screen_section_title_section_body_efb1a999">%1$s · %2$s</string>
     <string name="l10n_how_noop_works_screen_sleep_scores_recording_where_your_numbers_1b3e981f">睡眠 · 评分 · 记录 · 数据来源详解</string>
-    <string name="l10n_hrv_snapshot_screen_an_hrv_reading_needs_the_live_11b70bff">HRV 快照需要从手环获取实时的 R-R 间期数据流。请打开“实时心率”界面并保持手环连接。</string>
+    <string name="l10n_hrv_snapshot_screen_an_hrv_reading_needs_the_live_11b70bff">HRV 读数需要实时 R-R 数据流。请打开「实时」界面并连接你的手环，然后再返回。</string>
     <string name="l10n_hrv_snapshot_screen_beats_12aafda0">心跳数</string>
     <string name="l10n_hrv_snapshot_screen_hrvdial_4c244c45">HRV 表盘</string>
     <string name="l10n_hrv_snapshot_screen_mean_hr_6c9272dd">平均心率</string>
@@ -507,7 +507,7 @@
     <string name="l10n_insights_screen_not_enough_overlap_between_your_journal_0ebdd7a2">您的日记回答与此项指标之间重叠的数据点不足</string>
     <string name="l10n_insights_screen_not_enough_overlapping_history_to_correlate_a552dbd4">暂时还没有足够多的重叠历史数据，无法将您的各项指标进行关联分析。</string>
     <string name="l10n_insights_screen_pick_one_behaviour_you_log_one_bd34090e">挑选一项您记录的习惯行为、一项期望的指标结果，以及一个短的时间窗口。NOOP 将...</string>
-    <string name="l10n_insights_screen_ranked_lag_aware_which_of_your_e0e91b39">经过排名的、包含时间滞后效应的分析：到底哪些习惯真正影响了您的充能分数？</string>
+    <string name="l10n_insights_screen_ranked_lag_aware_which_of_your_e0e91b39">已排名、考虑滞后：你的哪些习惯真正影响你的能量，外加你个人对酒精/咖啡因的剂量反应。</string>
     <string name="l10n_insights_screen_rest_baseline_b3ac52a5">恢复基线</string>
     <string name="l10n_insights_screen_run_a_clean_personal_test_4da69781">运行个人习惯对照测试</string>
     <string name="l10n_insights_screen_sessions_e11e37a9">记录次数</string>
@@ -558,7 +558,7 @@
     <string name="l10n_lab_book_screen_clear_719ea396">清空</string>
     <string name="l10n_lab_book_screen_delete_this_reading_b5c92bda">删除这条记录</string>
     <string name="l10n_lab_book_screen_import_readings_7ad0d28f">导入记录</string>
-    <string name="l10n_lab_book_screen_it_s_a_notebook_not_a_45835e98">这里只是您的私人记事本，而不是真正的医学实验室。NOOP 只是将您输入的数据进行时间对齐，并不进行医学测试与诊断。</string>
+    <string name="l10n_lab_book_screen_it_s_a_notebook_not_a_45835e98">它是一个笔记本，而非实验室。NOOP 只是把你录入的数字排列对齐，它不检测、不解读、也不评判它们。并非医疗建议。</string>
     <string name="l10n_lab_book_screen_keep_your_own_numbers_here_1ca6c8ed">在此记录您个人的各项医学数值</string>
     <string name="l10n_lab_book_screen_lab_book_f966c140">实验室</string>
     <string name="l10n_lab_book_screen_lab_book_is_a_private_notebook_d07380ca">实验室是一本私人记事本，非医疗服务。NOOP 会存储并对齐您输入的数值，帮您发现体征的潜在关联。</string>
@@ -571,7 +571,7 @@
     <string name="l10n_lab_book_screen_read_the_full_lab_book_note_3a250750">阅读完整的《实验室免责声明》</string>
     <string name="l10n_lab_book_screen_read_the_full_note_3fd0e4d1">阅读完整声明</string>
     <string name="l10n_lab_book_screen_reading_your_logbook_e31992b0">正在读取您的实验日志…</string>
-    <string name="l10n_lab_book_screen_these_are_your_own_numbers_shown_7667508d">这些都是您亲手录入的数值。NOOP 并不会判定哪个值属于“正常”或“异常”。</string>
+    <string name="l10n_lab_book_screen_these_are_your_own_numbers_shown_7667508d">这些是原样呈现给你的、你自己的数字。NOOP 不会判定任何数值是正常、偏高还是偏低。</string>
     <string name="l10n_lab_book_screen_type_in_a_blood_pressure_reading_c276d418">手动输入您上次体检的血压记录、或者胆固醇指标数值。</string>
     <string name="l10n_lab_book_screen_what_lab_book_is_and_isn_f28686df">实验室是什么（以及不是什么）</string>
     <string name="l10n_live_screen_manage_devices_e5c277ff">管理设备</string>
@@ -717,7 +717,7 @@
     <string name="l10n_scoring_guide_screen_how_your_scores_work_21a0e2be">评分是如何计算的</string>
     <string name="l10n_scoring_guide_screen_noop_gives_you_three_daily_scores_36244209">NOOP 每天会为您提供三个维度的评分 (充能、负荷与恢复)，每项满分为 100。</string>
     <string name="l10n_scoring_guide_screen_scorecardhighlight_4af6985c">评分卡高亮色</string>
-    <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">这些是基于公开科学研究、从消费级手环数据中推算出的独立评估值：并非绝对权威，仅供参考。</string>
+    <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">这些是来自消费级手环的独立近似值，基于开放科学构建，并非医疗建议，也不是 WHOOP 的官方评分。</string>
     <string name="l10n_scoring_guide_screen_vs_whoop_9a8126a7">对比 WHOOP</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">高级选项</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
@@ -806,7 +806,7 @@
     <string name="l10n_steps_calibration_screen_how_this_works_b895a8c3">工作原理</string>
     <string name="l10n_steps_calibration_screen_no_days_yet_where_both_noop_71d6005b">尚未收集到 NOOP 和手机同时记录步数的日期。一旦您的手机记录了...</string>
     <string name="l10n_steps_calibration_screen_no_motion_synced_yet_65106670">暂未同步到体动数据</string>
-    <string name="l10n_steps_calibration_screen_noop_estimates_your_steps_from_your_d569bc31">NOOP 会通过 WHOOP 的体动数据来预估您的步数，并参考手机的记步数据来进行校准计算。</string>
+    <string name="l10n_steps_calibration_screen_noop_estimates_your_steps_from_your_d569bc31">NOOP 会根据你 WHOOP 的运动来估算步数，并以你手机的步数进行校准。这是一个估算值，而非计步器，WHOOP 4.0 不传输步数。</string>
     <string name="l10n_steps_calibration_screen_not_calibrated_yet_30abe0d0">尚未完成校准</string>
     <string name="l10n_steps_calibration_screen_on_the_days_your_phone_also_2f65a14c">在手机也计步的日子里，NOOP 会学习体动数据应该如何映射到实际步数，从而越来越精准。</string>
     <string name="l10n_steps_calibration_screen_open_noop_near_your_strap_and_e08ddd6d">请在手环附近打开 NOOP 并等待数据同步完成 (如果是全量历史数据同步，可能会花点时间)。</string>
@@ -815,8 +815,8 @@
     <string name="l10n_steps_calibration_screen_shortday_row_day_estimated_row_estimated_f2d71597">%1$s: 预估 %2$s 步，手机记录 %3$s 步</string>
     <string name="l10n_steps_calibration_screen_steps_per_motion_unit_a2c2ac56">每单位体动对应步数</string>
     <string name="l10n_steps_calibration_screen_takes_effect_on_the_next_analytics_13205327">将在下一次数据分析（同步后）生效。</string>
-    <string name="l10n_steps_calibration_screen_these_are_the_days_where_your_ae5c9c2c">这些是手机同时记录了步数的日期，因此 NOOP 可以借此学习如何...</string>
-    <string name="l10n_steps_calibration_screen_these_days_are_excluded_from_the_6bedabbf">这些日期已被排除在预估模型之外（将直接显示您手机记录的实际步数）。</string>
+    <string name="l10n_steps_calibration_screen_these_are_the_days_where_your_ae5c9c2c">这些是你手机也统计了步数的日子，因此 NOOP 可以学习你的运动如何对应步数。或者在下方手动设置系数。</string>
+    <string name="l10n_steps_calibration_screen_these_days_are_excluded_from_the_6bedabbf">这些日子被排除在估算之外（改为显示你手机的真实计数）， 它们出现在这里只是为了让你判断估算的准确性。</string>
     <string name="l10n_steps_calibration_screen_we_re_not_seeing_any_motion_6ac8e092">我们暂未接收到手环的体动数据。步数是根据 WHOOP 传来的体动信号推算的。</string>
     <string name="l10n_steps_calibration_screen_whoop_4_0_motion_steps_a63239dc">WHOOP 4.0 · 体动 → 步数换算</string>
     <string name="l10n_strand_components_next_day_38f859dd">下一天</string>
@@ -1562,7 +1562,7 @@
     <string name="l10n_stress_screen_on_demand_today_s_r_r_17d716e1">按需测量 · 今日的 R-R 间期分析</string>
     <string name="l10n_stress_screen_on_the_0_3_autonomic_load_8a0d5107">在 0-3 自主神经负荷量表上</string>
     <string name="l10n_stress_screen_the_line_traces_your_autonomic_load_804f4028">折线追踪着您清醒状态下的自主神经负荷变化，按</string>
-    <string name="l10n_stress_screen_these_are_extra_on_demand_hrv_9303f1de">这是些通过今日捕获的心跳间期(R-R)按需计算的额外 HRV 分析视角。它们...</string>
+    <string name="l10n_stress_screen_these_are_extra_on_demand_hrv_9303f1de">这些是根据今天的 R-R 间期计算的额外、按需的 HRV 视角。它们仅供参考，不会改变上方的压力评分。</string>
     <string name="l10n_stress_screen_we_compare_today_s_resting_heart_a9cd0955">我们会将今天的静息心率和 HRV 与您过去 30 天的</string>
     <string name="l10n_test_centre_screen_bug_report_5a7ee5ac">Bug 报告</string>
     <string name="l10n_today_screen_arrange_cfdd099c">整理</string>
@@ -1588,7 +1588,7 @@
     <string name="l10n_today_screen_move_item_metric_title_down_890afe60">下移 %1$s</string>
     <string name="l10n_today_screen_move_item_metric_title_up_52d2104c">上移 %1$s</string>
     <string name="l10n_today_screen_new_data_added_e59345b4">有新数据写入</string>
-    <string name="l10n_today_screen_no_cardio_load_yet_effort_builds_e952006c">暂无心肺负荷。只有当您的心率攀升到</string>
+    <string name="l10n_today_screen_no_cardio_load_yet_effort_builds_e952006c">还没有心肺负荷。心率进入你的消耗区间（约储备心率的 50%）后，消耗才会累积。平静的一天读数接近零，这很正常。</string>
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">个人资料与设置</string>
     <string name="l10n_today_screen_recovery_ea924f72">恢复分数</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -317,7 +317,7 @@
     <string name="l10n_caffeine_log_had_it_8576ac66">Had it</string>
     <string name="l10n_caffeine_log_have_your_last_caffeine_by_about_16b09033">Have your last caffeine by about %1$s to clear most of it </string>
     <string name="l10n_caffeine_log_late_caffeine_nudge_6b2ff690">Late-caffeine nudge</string>
-    <string name="l10n_caffeine_log_log_a_coffee_tea_or_energy_982bde5b">Log a coffee, tea, or energy drink and NOOP shows a rough estimate of how much may </string>
+    <string name="l10n_caffeine_log_log_a_coffee_tea_or_energy_982bde5b">Log a coffee, tea, or energy drink and NOOP shows a rough estimate of how much may still be active. It\'s a guide based on a typical 5 to 6 hour half-life, not a measurement.</string>
     <string name="l10n_caffeine_log_logged_today_0071a46c">Logged today</string>
     <string name="l10n_caffeine_log_remove_e963907d">Remove</string>
     <string name="l10n_coach_screen_api_key_hidden_f3cde531">API key (hidden)</string>
@@ -365,7 +365,7 @@
     <string name="l10n_coupled_screen_no_sleep_tracked_last_night_cd0dd79e">No sleep tracked last night</string>
     <string name="l10n_coupled_screen_recovery_b668d988">RECOVERY</string>
     <string name="l10n_coupled_screen_sleep_performance_4611539f">SLEEP PERFORMANCE</string>
-    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">Acts as a standard Bluetooth heart-rate strap. Pair NOOP from your treadmill, </string>
+    <string name="l10n_data_sources_screen_acts_as_a_standard_bluetooth_heart_f8d13439">Acts as a standard Bluetooth heart-rate strap. Pair NOOP from your treadmill, bike or app to see your strap\'s heart rate there.</string>
     <string name="l10n_data_sources_screen_apple_health_b19b87da">Apple Health</string>
     <string name="l10n_data_sources_screen_auto_sync_health_connect_periodically_6f3f4d92">Auto-sync Health Connect periodically</string>
     <string name="l10n_data_sources_screen_auto_sync_periodically_5f3041e8">Auto-sync periodically</string>
@@ -396,7 +396,7 @@
     <string name="l10n_data_sources_screen_remove_imported_data_813e4695">Remove imported data</string>
     <string name="l10n_data_sources_screen_share_back_to_health_connect_1d578f4a">Share back to Health Connect</string>
     <string name="l10n_data_sources_screen_share_computed_metrics_back_to_health_c11f5d70">Share computed metrics back to Health Connect</string>
-    <string name="l10n_data_sources_screen_this_permanently_deletes_everything_imported_from_f42e760e">This permanently deletes everything imported from Apple Health: heart rate, HRV, </string>
+    <string name="l10n_data_sources_screen_this_permanently_deletes_everything_imported_from_f42e760e">This permanently deletes everything imported from Apple Health: heart rate, HRV, sleep, steps, workouts and more. Your live strap data is untouched. This can\'t be undone.</string>
     <string name="l10n_data_sources_screen_whoop_history_db101974">WHOOP History</string>
     <string name="l10n_data_sources_screen_whoop_strap_live_ble_217f7df6">WHOOP Strap (Live BLE)</string>
     <string name="l10n_data_sources_screen_workout_file_gpx_tcx_fit_5469c068">Workout file (GPX / TCX / FIT)</string>
@@ -427,7 +427,7 @@
     <string name="l10n_devices_screen_leave_none_active_b5c858cb">Leave none active</string>
     <string name="l10n_devices_screen_name_709a2322">Name</string>
     <string name="l10n_devices_screen_pack_voltage_9af3c3ff">%1$.2f V</string>
-    <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Paired locally. NOOP owns this ring while it holds the key. If you reset it again or set it </string>
+    <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Paired locally. NOOP owns this ring while it holds the key. If you reset it again or set it up in the Oura app, NOOP no longer owns it and you would re-add it to take it over.</string>
     <string name="l10n_devices_screen_pick_a_new_active_strap_edd73542">Pick a new active strap</string>
     <string name="l10n_devices_screen_rename_device_ee233604">Rename device</string>
     <string name="l10n_devices_screen_send_probe_read_only_36b318bc">Send probe (read-only)</string>
@@ -436,7 +436,7 @@
     <string name="l10n_devices_screen_waiting_for_the_straps_reply_5a06e7ac">Waiting for the strap\'s reply…</string>
     <string name="l10n_devices_screen_whoop_4_0_reboot_probe_b51fb50f">WHOOP 4.0 reboot probe</string>
     <string name="l10n_devices_screen_whoop_is_noop_s_primary_fully_1c9e67fd">WHOOP is NOOP\'s primary, fully-supported band. Other heart-rate straps are an early, </string>
-    <string name="l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48">You removed your active strap. Choose which paired band provides your live data, or </string>
+    <string name="l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48">You removed your active strap. Choose which paired band provides your live data, or leave none active and pair one later.</string>
     <string name="l10n_fused_record_screen_contrib_source_displayname_fusionformat_value_contrib_d182dd7f">%1$s, %2$s</string>
     <string name="l10n_fused_record_screen_done_e9b450d1">Done</string>
     <string name="l10n_fused_record_screen_fused_on_devicenoun_nothing_leaves_it_8a1e6a3d">Fused on %1$s. Nothing leaves it: no account, no cloud.</string>
@@ -481,11 +481,11 @@
     <string name="l10n_how_noop_works_screen_close_bbfa773e">Close</string>
     <string name="l10n_how_noop_works_screen_got_it_5b8027fa">Got it</string>
     <string name="l10n_how_noop_works_screen_how_noop_works_3396b27a">How NOOP works</string>
-    <string name="l10n_how_noop_works_screen_noop_never_makes_up_a_number_da29aca5">NOOP never makes up a number. When it can\'t compute one honestly it tells you </string>
+    <string name="l10n_how_noop_works_screen_noop_never_makes_up_a_number_da29aca5">NOOP never makes up a number. When it can\'t compute one honestly it tells you what\'s missing and what to do, rather than showing a fake value.</string>
     <string name="l10n_how_noop_works_screen_noop_never_shows_you_a_number_d1db9958">NOOP never shows you a number it had to make up. If a score isn\'t ready, </string>
     <string name="l10n_how_noop_works_screen_section_title_section_body_efb1a999">%1$s. %2$s</string>
     <string name="l10n_how_noop_works_screen_sleep_scores_recording_where_your_numbers_1b3e981f">Sleep · scores · recording · where your numbers come from</string>
-    <string name="l10n_hrv_snapshot_screen_an_hrv_reading_needs_the_live_11b70bff">An HRV reading needs the live R-R stream. Open the Live screen and connect your strap, </string>
+    <string name="l10n_hrv_snapshot_screen_an_hrv_reading_needs_the_live_11b70bff">An HRV reading needs the live R-R stream. Open the Live screen and connect your strap, then come back.</string>
     <string name="l10n_hrv_snapshot_screen_beats_12aafda0">Beats</string>
     <string name="l10n_hrv_snapshot_screen_hrvdial_4c244c45">hrvDial</string>
     <string name="l10n_hrv_snapshot_screen_mean_hr_6c9272dd">Mean HR</string>
@@ -538,7 +538,7 @@
     <string name="l10n_insights_screen_not_enough_overlap_between_your_journal_0ebdd7a2">Not enough overlap between your journal answers and </string>
     <string name="l10n_insights_screen_not_enough_overlapping_history_to_correlate_a552dbd4">Not enough overlapping history to correlate your metrics yet.</string>
     <string name="l10n_insights_screen_pick_one_behaviour_you_log_one_bd34090e">Pick one behaviour you log, one outcome, and a short window. NOOP </string>
-    <string name="l10n_insights_screen_ranked_lag_aware_which_of_your_e0e91b39">Ranked, lag-aware: which of your habits actually move your Charge, plus your </string>
+    <string name="l10n_insights_screen_ranked_lag_aware_which_of_your_e0e91b39">Ranked, lag-aware: which of your habits actually move your Charge, plus your personal alcohol/caffeine dose-response.</string>
     <string name="l10n_insights_screen_rest_baseline_b3ac52a5">Rest baseline</string>
     <string name="l10n_insights_screen_run_a_clean_personal_test_4da69781">Run a clean personal test</string>
     <string name="l10n_insights_screen_sessions_e11e37a9">Sessions</string>
@@ -589,7 +589,7 @@
     <string name="l10n_lab_book_screen_clear_719ea396">Clear</string>
     <string name="l10n_lab_book_screen_delete_this_reading_b5c92bda">Delete this reading</string>
     <string name="l10n_lab_book_screen_import_readings_7ad0d28f">Import readings</string>
-    <string name="l10n_lab_book_screen_it_s_a_notebook_not_a_45835e98">It\'s a notebook, not a lab. NOOP lines up the numbers you enter. It doesn\'t test, </string>
+    <string name="l10n_lab_book_screen_it_s_a_notebook_not_a_45835e98">It\'s a notebook, not a lab. NOOP lines up the numbers you enter. It doesn\'t test, read, or judge them. Not medical advice.</string>
     <string name="l10n_lab_book_screen_keep_your_own_numbers_here_1ca6c8ed">Keep your own numbers here</string>
     <string name="l10n_lab_book_screen_lab_book_f966c140">Lab Book</string>
     <string name="l10n_lab_book_screen_lab_book_is_a_private_notebook_d07380ca">Lab Book is a private notebook, not a medical service. NOOP stores and lines up the numbers </string>
@@ -602,7 +602,7 @@
     <string name="l10n_lab_book_screen_read_the_full_lab_book_note_3a250750">Read the full Lab Book note</string>
     <string name="l10n_lab_book_screen_read_the_full_note_3fd0e4d1">Read the full note</string>
     <string name="l10n_lab_book_screen_reading_your_logbook_e31992b0">Reading your logbook…</string>
-    <string name="l10n_lab_book_screen_these_are_your_own_numbers_shown_7667508d">These are your own numbers shown back to you. NOOP doesn\'t decide whether any value is </string>
+    <string name="l10n_lab_book_screen_these_are_your_own_numbers_shown_7667508d">These are your own numbers shown back to you. NOOP doesn\'t decide whether any value is normal, high or low.</string>
     <string name="l10n_lab_book_screen_type_in_a_blood_pressure_reading_c276d418">Type in a blood-pressure reading or a cholesterol value from your last appointment. </string>
     <string name="l10n_lab_book_screen_what_lab_book_is_and_isn_f28686df">What Lab Book is (and isn\'t)</string>
     <string name="l10n_live_screen_manage_devices_e5c277ff">Manage devices</string>
@@ -752,7 +752,7 @@
     <string name="l10n_scoring_guide_screen_how_your_scores_work_21a0e2be">How your scores work</string>
     <string name="l10n_scoring_guide_screen_noop_gives_you_three_daily_scores_36244209">NOOP gives you three daily scores (Charge, Effort and Rest), each on a 0-100 </string>
     <string name="l10n_scoring_guide_screen_scorecardhighlight_4af6985c">scoreCardHighlight</string>
-    <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">These are independent approximations from a consumer strap, built on open science: not </string>
+    <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">These are independent approximations from a consumer strap, built on open science: not medical advice, and not WHOOP\'s official scores.</string>
     <string name="l10n_scoring_guide_screen_vs_whoop_9a8126a7">VS WHOOP</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">advancedChevron</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
@@ -841,7 +841,7 @@
     <string name="l10n_steps_calibration_screen_how_this_works_b895a8c3">How this works</string>
     <string name="l10n_steps_calibration_screen_no_days_yet_where_both_noop_71d6005b">No days yet where both NOOP and your phone counted steps. Once your phone logs a </string>
     <string name="l10n_steps_calibration_screen_no_motion_synced_yet_65106670">No motion synced yet</string>
-    <string name="l10n_steps_calibration_screen_noop_estimates_your_steps_from_your_d569bc31">NOOP estimates your steps from your WHOOP\'s motion, calibrated to your phone\'s step </string>
+    <string name="l10n_steps_calibration_screen_noop_estimates_your_steps_from_your_d569bc31">NOOP estimates your steps from your WHOOP\'s motion, calibrated to your phone\'s step count. It\'s an estimate, not a step counter. A WHOOP 4.0 doesn\'t transmit steps.</string>
     <string name="l10n_steps_calibration_screen_not_calibrated_yet_30abe0d0">Not calibrated yet</string>
     <string name="l10n_steps_calibration_screen_on_the_days_your_phone_also_2f65a14c">On the days your phone also counted steps, NOOP learns how much your motion maps to </string>
     <string name="l10n_steps_calibration_screen_open_noop_near_your_strap_and_e08ddd6d">Open NOOP near your strap and let it catch up (a full history sync can take a while on </string>
@@ -850,8 +850,8 @@
     <string name="l10n_steps_calibration_screen_shortday_row_day_estimated_row_estimated_f2d71597">%1$s: estimated %2$s steps, phone %3$s </string>
     <string name="l10n_steps_calibration_screen_steps_per_motion_unit_a2c2ac56">steps per motion unit</string>
     <string name="l10n_steps_calibration_screen_takes_effect_on_the_next_analytics_13205327">Takes effect on the next analytics pass (after the next sync).</string>
-    <string name="l10n_steps_calibration_screen_these_are_the_days_where_your_ae5c9c2c">These are the days where your phone also counted steps, so NOOP can learn how your </string>
-    <string name="l10n_steps_calibration_screen_these_days_are_excluded_from_the_6bedabbf">These days are excluded from the estimate (your phone\'s real count is shown instead). </string>
+    <string name="l10n_steps_calibration_screen_these_are_the_days_where_your_ae5c9c2c">These are the days where your phone also counted steps, so NOOP can learn how your motion maps to steps. Or set the coefficient manually below.</string>
+    <string name="l10n_steps_calibration_screen_these_days_are_excluded_from_the_6bedabbf">These days are excluded from the estimate (your phone\'s real count is shown instead). They\'re here only so you can judge the estimate\'s accuracy.</string>
     <string name="l10n_steps_calibration_screen_we_re_not_seeing_any_motion_6ac8e092">We\'re not seeing any motion from your strap yet. Steps are estimated from your WHOOP\'s </string>
     <string name="l10n_steps_calibration_screen_whoop_4_0_motion_steps_a63239dc">WHOOP 4.0 · motion → steps</string>
     <string name="l10n_strand_components_next_day_38f859dd">Next day</string>
@@ -1609,7 +1609,7 @@
     <string name="l10n_stress_screen_on_demand_today_s_r_r_17d716e1">on demand · today\'s R-R</string>
     <string name="l10n_stress_screen_on_the_0_3_autonomic_load_8a0d5107">on the 0-3 autonomic-load scale</string>
     <string name="l10n_stress_screen_the_line_traces_your_autonomic_load_804f4028">The line traces your autonomic load across the waking day, scored </string>
-    <string name="l10n_stress_screen_these_are_extra_on_demand_hrv_9303f1de">These are extra, on-demand HRV lenses computed from today\'s R-R intervals. They </string>
+    <string name="l10n_stress_screen_these_are_extra_on_demand_hrv_9303f1de">These are extra, on-demand HRV lenses computed from today\'s R-R intervals. They are informational and do not change the stress score above.</string>
     <string name="l10n_stress_screen_we_compare_today_s_resting_heart_a9cd0955">We compare today\'s resting heart rate and HRV to your own 30-day </string>
     <string name="l10n_test_centre_screen_bug_report_5a7ee5ac">Bug report</string>
     <string name="l10n_today_screen_arrange_cfdd099c">Arrange</string>
@@ -1635,7 +1635,7 @@
     <string name="l10n_today_screen_move_item_metric_title_down_890afe60">Move %1$s down</string>
     <string name="l10n_today_screen_move_item_metric_title_up_52d2104c">Move %1$s up</string>
     <string name="l10n_today_screen_new_data_added_e59345b4">New data added</string>
-    <string name="l10n_today_screen_no_cardio_load_yet_effort_builds_e952006c">No cardio load yet. Effort builds once your heart rate climbs into your effort </string>
+    <string name="l10n_today_screen_no_cardio_load_yet_effort_builds_e952006c">No cardio load yet. Effort builds once your heart rate climbs into your effort zone (around 50% of your heart-rate reserve). A calm day honestly reads near zero.</string>
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">Profile and settings</string>
     <string name="l10n_today_screen_recovery_ea924f72">Recovery</string>


### PR DESCRIPTION
Partial fix for #557 / #922.

## The bug

Sixteen `values/strings.xml` entries end mid-sentence and are completed at the call site by a hardcoded English literal:

```kotlin
uiString(R.string.l10n_devices_screen_you_removed_your_active_strap_choose_2ac91d48) +
    "leave none active and pair one later.",
```

Every non-English locale therefore renders half the paragraph translated and half in English:

> Du hast deinen aktiven Riemen entfernt. Wählen Sie aus, welches gepaarte Band Ihre Live-Daten bereitstellt, oder **leave none active and pair one later.**

## Why these sixteen

Swift never had the split — its strings were always whole — so `Strand/Resources/Localizable.xcstrings` already carries the complete sentence, translated, in every locale Android ships (de, es, fr, pt-rPT, zh).

These sixteen are exactly the sites whose full English matches an xcstrings key verbatim **and** has a translation present in all five. Each merged value is copied from that catalogue, not retyped or machine-translated, so the tree gains no unreviewed copy and Android's rendering ends up identical to Swift's.

That is the split axis, rather than #922's suggested by-screen one: it isolates the subset carrying zero translation risk. The remaining 63 sites have copy that has drifted from Swift's wording, so they need real translation into five locales and stay for follow-ups.

Also drops the now-internal trailing space from each leading fragment (#922 step 3).

## One correction to #922

#922 says these literals "are part of the **229** it reports and sit in `Tools/i18n_audit_baseline.json`". They do not. `_extract_literals` skips any literal whose preceding token is `+`, deliberately, citing #557 — added 2026-07-18 in the #540/#558 commit, ten days before #922 was filed. Checked on this branch: **0 of the 62** prose tails appear in the baseline.

So the gate is blind twice over — the resource that exists *is* fully translated, and the scanner never looks at the tail — which is how 79 accumulated. It also means #922's step 4 ("remove those entries from the audit baseline") is a no-op, and no baseline update is needed here.

## Verification

- Every merged locale value round-trip parsed back out of the XML and compared byte-for-byte against its xcstrings source — 80/80 exact.
- `i18n_audit.py --ci` exits 0; all four focus locales OK, no new hardcoded literals.
- `Tools/test_i18n_audit.py` — 36 tests pass. (The test at line 63 pins the `+` exclusion, so the scanner is deliberately left alone.)
- `doc_comment_lint.py` exits 0.
- Concatenation sites: 79 on main → 63 here, exactly 16 removed, no dangling `+` continuations left behind.
- `TodayScreen`'s merged string contains a literal `50%`. Safe: `uiString` forwards to `localizedString`, which calls `getString(id)` with no varargs (`NoopApplication.kt:138`), so `String.format` never runs. `ANDROID_FORMAT_PATTERN` requires `%<n>$`, so the German "50 %" is not a format mismatch either.

## Note for review

Merging replaces the whole value, including the already-translated leading half, because a translated sentence cannot be split mechanically across languages. One visible effect: German picks up Swift's "Strap" where Android had "Riemen" — Android already uses Strap 60× vs Riemen 19×, so this moves toward the majority. It also fixes a register break in the Devices string, which mixed *du* and *Sie* in one sentence.

Android-only; no Swift or shared-package code is touched.