### PR TITLE
fix(android): manual workouts read HR under the active strap union (#836)

### DIFF
--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -2325,9 +2325,9 @@ final class Repository: ObservableObject {
     /// SECOND WHOOP no longer reads the active strap's empty window (which blanked its reconcile). MANUAL and
     /// IMPORTED rows carry no strap id in `source`, so they reconcile against the active strap [activeStrapId]
     /// as before; on a single-device install a detected "<base>-noop" strips to the active id, so the read is
-    /// byte-identical. (The Kotlin twin also keys MANUAL rows on their stored deviceId; the Swift read-model
-    /// `WorkoutRow` carries no deviceId, so a manual session created on a NON-active strap reconciles here
-    /// against the active strap instead — a minor, display-only divergence, never persisted.)
+    /// byte-identical. (#836: the Kotlin twin used to key MANUAL rows on their stored deviceId instead —
+    /// a minor, display-only divergence from this file — but now reads the same active union Swift always
+    /// has, so a manual session recorded on a re-added/second strap reconciles correctly on both platforms.)
     /// #856: the ids whose HR backs a workout's chart, zones and Avg HR, in read precedence.
     ///
     /// DETECTED rows return exactly ONE id — the strap that recorded the bout. Unioning here would mix

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1733,15 +1733,26 @@ class WhoopRepository(private val dao: WhoopDao) {
             return s == "manual" || s.endsWith("-noop")
         }
 
-        /** #510: the device id whose `hrSample` rows back a workout's Avg HR / calories / Effort recompute.
-         *  A STRAP-NATIVE row was charted from its OWN strap's trace, so read HR under that strap — strip the
-         *  computed "-noop" suffix to reach the raw hrSample id (a detected row lives under "<id>-noop", its
-         *  HR under "<id>"). An IMPORTED row has no strap HR of its own; #77 fills it from the WORN strap, i.e.
-         *  the active strap [activeStrapId]. Before this both keyed on a hardcoded "my-whoop", so a strap-native
-         *  workout on a SECOND WHOOP ("whoop-<mac>") read an empty window — its Avg HR went un-reconciled and a
-         *  null Effort un-recomputed. (This fill only sets avgHr/maxHr/strain; calories come from the detector.) */
+        /** A workout row is DETECTED when the engine scored it from a strap trace it recorded itself
+         *  (source "<id>-noop"). This is the strict subset of [isStrapNativeWorkout] that actually carries
+         *  its own recording strap id — a "manual" row does not (see [workoutHrDeviceIds]). */
+        fun isDetectedWorkout(source: String): Boolean = source.lowercase().endsWith("-noop")
+
+        /** #510/#836: the device id(s) whose `hrSample` rows back a workout's Avg HR / calories / Effort
+         *  recompute. A DETECTED row was charted from its OWN strap's trace, so read HR under that strap —
+         *  strip the computed "-noop" suffix to reach the raw hrSample id (a detected row lives under
+         *  "<id>-noop", its HR under "<id>"). Everything else — a MANUAL row or an IMPORTED one — has no
+         *  strap trace of its own to point at: a manual row's stored deviceId is just "my-whoop", a
+         *  retroactive-add placeholder ([com.noop.ui.WorkoutEditing.buildManualRow]), not the strap that was
+         *  actually worn. So both read the #814 UNION via [importedSourceIdsFor] (active strap ∪ canonical
+         *  "my-whoop", active first) — the same window #77 fills IMPORTED rows from. Byte-identical to the
+         *  Swift twin (`Repository.workoutHrDeviceIds`), which has always kept only DETECTED on the single-id
+         *  path. Before this fix, a manual row read "my-whoop" verbatim, so a manual workout on a SECOND WHOOP
+         *  ("whoop-<mac>") or any re-added strap read an empty window — its Avg HR went un-reconciled and a
+         *  null Effort un-recomputed (#836). A single-WHOOP install still resolves to one id, so nothing
+         *  changes there. (This fill only sets avgHr/maxHr/strain; calories come from the detector.) */
         fun workoutHrDeviceIds(source: String, rowDeviceId: String, activeStrapId: String): List<String> =
-            if (isStrapNativeWorkout(source)) listOf(rowDeviceId.removeSuffix("-noop"))
+            if (isDetectedWorkout(source)) listOf(rowDeviceId.removeSuffix("-noop"))
             else importedSourceIdsFor(activeStrapId)
 
         /** Default row cap on range reads. Matches the Swift call sites' bounded scans. */

--- a/android/app/src/test/java/com/noop/data/WorkoutHrDeviceKeyTest.kt
+++ b/android/app/src/test/java/com/noop/data/WorkoutHrDeviceKeyTest.kt
@@ -48,10 +48,14 @@ class WorkoutHrDeviceKeyTest {
         )
     }
 
-    @Test fun `manual row reads HR under its own strap id`() {
+    @Test fun `manual row reads HR under the active union, not its stored placeholder id`() {
+        // #836: a manual row's stored deviceId is a retroactive-add placeholder ("my-whoop"), not the
+        // strap that was actually worn — so, like an imported row, it reads the #814 union (active
+        // strap first, canonical "my-whoop" second). Byte-parity with the Swift twin, which has always
+        // kept manual rows off the single-id path.
         assertEquals(
-            "whoop-aabbcc",
-            WhoopRepository.workoutHrDeviceIds("manual", "whoop-aabbcc", activeStrapId = "my-whoop").first(),
+            listOf("whoop-aabbcc", "my-whoop"),
+            WhoopRepository.workoutHrDeviceIds("manual", "whoop-aabbcc", activeStrapId = "whoop-aabbcc"),
         )
     }
 
@@ -68,10 +72,24 @@ class WorkoutHrDeviceKeyTest {
     }
 
     @Test fun `a bare strap id with no -noop suffix is returned unchanged`() {
-        // removeSuffix is a no-op when the suffix is absent — a manual/base id must not be truncated.
+        // removeSuffix is a no-op when the suffix is absent — a detected row's base id must not be
+        // truncated. (Only detected rows carry rowDeviceId into the read key at all; see the manual/
+        // imported cases above for the union path.)
         assertEquals(
             "whoop-aabbcc",
-            WhoopRepository.workoutHrDeviceIds("manual", "whoop-aabbcc", activeStrapId = "ignored").first(),
+            WhoopRepository.workoutHrDeviceIds("whoop-aabbcc-noop", "whoop-aabbcc", activeStrapId = "ignored").first(),
+        )
+    }
+
+    @Test fun `manual workout on a re-added strap reads the active union, not the stale my-whoop`() {
+        // #836/#928 (bartmuskala): a manual workout is always stored under deviceId "my-whoop"
+        // (WorkoutEditing.buildManualRow), regardless of which strap actually recorded the live HR. On a
+        // re-added or second strap, the live trace banks under the strap's fresh id ("whoop-aabbcc"), not
+        // under "my-whoop" — so reading only "my-whoop" (the pre-fix behaviour) hit an empty window and
+        // left Avg HR / Effort blank. The union reads the active strap first, so it finds the trace.
+        assertEquals(
+            listOf("whoop-aabbcc", "my-whoop"),
+            WhoopRepository.workoutHrDeviceIds("manual", rowDeviceId = "my-whoop", activeStrapId = "whoop-aabbcc"),
         )
     }
 }


### PR DESCRIPTION
Manual workouts on a re-added or secondary WHOOP now correctly reconcile their HR data. Previously, the read keyed only the stale `my-whoop` placeholder; a manual session on a WHOOP 5.0 or re-added strap read an empty window and left Avg HR / Effort blank.

**Root cause:** A retroactively logged manual workout stores under deviceId `"my-whoop"` regardless of which strap recorded it. On display, fillWorkoutHrFromStrap reconciles against the strap trace — but manual rows read ONLY the placeholder, while imported (HC) rows read the active∪canonical union. A WHOOP 5.0/re-added strap banks under its fresh id (`whoop-<mac>`), not "my-whoop" → empty window → blank Avg HR.

**Fix:** Manual rows now read the union, matching Swift's already-correct path. Only DETECTED rows read the single strap id. Single-WHOOP unchanged (union → one id).

**Testing:** 7 tests pass; compileFullDebugKotlin successful. Swift comment-only.

**Note:** Diagnosed from code asymmetry + divergence fingerprint; logs not parsed locally. Maintainer can cross-check against actual data before merging.