### PR TITLE
fix(sleep): credit naps toward sleep debt

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepDebt.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepDebt.swift
@@ -71,6 +71,19 @@ public enum SleepDebt {
     /// than as a debt/surplus, so a few stray minutes don't flip the headline.
     public static let onTargetBandMin: Double = 30.0
 
+    /// Sleep credited toward debt for one day. `mainSleepMin` remains the canonical
+    /// main-night total used by Rest and the sleep headline; separately-recorded naps
+    /// add repayment credit without changing that canonical figure. A day with no
+    /// usable main sleep stays missing, and a malformed negative nap total is ignored.
+    ///
+    /// This is deliberately arithmetic rather than a physiological model: callers
+    /// classify the day's main-night group and pass only asleep minutes from blocks
+    /// outside that group. Mirrored value-for-value in Kotlin `SleepDebt`.
+    public static func creditedSleepMin(mainSleepMin: Double?, napSleepMin: Double = 0) -> Double? {
+        guard let mainSleepMin, mainSleepMin > 0 else { return nil }
+        return mainSleepMin + max(napSleepMin, 0)
+    }
+
     /// Build the ledger from a chronological `[(day, totalSleepMin?)]` series.
     ///
     /// - Parameters:

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepDebtTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepDebtTests.swift
@@ -75,6 +75,21 @@ final class SleepDebtTests: XCTestCase {
         XCTAssertEqual(l.balanceMin, -60.0, accuracy: 1e-9)
     }
 
+    /// Main sleep remains the canonical nightly figure, while a separately-recorded nap
+    /// contributes its asleep minutes when the caller prepares the debt series.
+    func testNapMinutesAddDebtRepaymentCredit() throws {
+        let credited = try XCTUnwrap(SleepDebt.creditedSleepMin(mainSleepMin: 392, napSleepMin: 48))
+        XCTAssertEqual(credited, 440, accuracy: 1e-9)
+        let l = SleepDebt.ledger(series: [("2026-06-01", credited)], needHours: 8.0)
+        XCTAssertEqual(l.balanceMin, -40, accuracy: 1e-9)
+    }
+
+    func testNapCreditRequiresMainSleepAndIgnoresNegativeNapMinutes() {
+        XCTAssertNil(SleepDebt.creditedSleepMin(mainSleepMin: nil, napSleepMin: 48))
+        XCTAssertNil(SleepDebt.creditedSleepMin(mainSleepMin: 0, napSleepMin: 48))
+        XCTAssertEqual(SleepDebt.creditedSleepMin(mainSleepMin: 392, napSleepMin: -10), 392.0)
+    }
+
     /// A NEGATIVE EXACT half-tie balance rounds AWAY from zero (−0.05 → −0.1), the documented
     /// `round1` contract the Kotlin mirror must match (audit #6). needMin = 0.1, slept 0.05 →
     /// delta −0.05 exactly → balance −0.1. Kotlin's old `roundToInt()` (half toward +∞) gave

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -1830,6 +1830,7 @@ struct SleepView: View {
         } else {
             return nil
         }
+        let napSleepMinByDay = self.napSleepMinutesByDay
         return SleepModel(
             night: night,
             intervals: night.intervals,
@@ -1841,22 +1842,27 @@ struct SleepView: View {
             hoursVsNeeded: hoursVsNeededSeries,
             restorative: restorativeSeries,
             respiratory: respiratorySeries,
-            sleepDebt: sleepDebtSeries,
+            sleepDebt: sleepDebtSeries(napSleepMinByDay: napSleepMinByDay),
             typicalTotalMin: typicalTotalMin,
             typicalDeepMin: typicalStageMin(\.deepMin),
             typicalRemMin: typicalStageMin(\.remMin),
             typicalLightMin: typicalStageMin(\.lightMin),
             trendPoints: durationTrendPoints,
-            sleepDebtLedger: debtLedger)
+            sleepDebtLedger: debtLedger(napSleepMinByDay: napSleepMinByDay))
     }
 
     /// The rolling 14-night sleep-debt ledger from the cached daily metrics. Uses the
     /// SAME personal sleep need the tiles use (`sleepNeedMin`, ≥ 7.5 h, the per-user
-    /// override over the 8 h default), measured against each night's `totalSleepMin`.
+    /// override over the 8 h default), measured against each main night's `totalSleepMin`
+    /// plus actual asleep minutes from separately-recorded naps.
     /// Skips nights with no sleep (the analytics function does the skip). (#242)
-    private var debtLedger: SleepDebtLedger {
+    private func debtLedger(napSleepMinByDay: [String: Double]) -> SleepDebtLedger {
         SleepDebt.ledger(
-            series: repo.days.map { (day: $0.day, totalSleepMin: $0.totalSleepMin) },
+            series: repo.days.map { day in
+                (day: day.day, totalSleepMin: SleepDebt.creditedSleepMin(
+                    mainSleepMin: day.totalSleepMin,
+                    napSleepMin: napSleepMinByDay[day.day] ?? 0))
+            },
             needHours: sleepNeedMin / 60.0)
     }
 
@@ -1928,6 +1934,22 @@ struct SleepView: View {
             sessions.map { SleepStageTotals.NightBlock(start: $0.effectiveStartTs, end: $0.endTs) },
             offsetSec: tzOffsetSec, habitualMidsleepSec: habitualMidsleepSec) else { return [] }
         return idx.map { sessions[$0] }.sorted { $0.effectiveStartTs < $1.effectiveStartTs }
+    }
+
+    /// Actual asleep minutes in blocks outside a day's canonical main-night group. The Repository's
+    /// all-session union has already removed cross-namespace duplicates; this helper only applies the
+    /// same main-vs-nap classification the hero uses and decodes persisted stages. A stage-less nap
+    /// contributes nothing rather than substituting its in-bed window. Mirrors Android
+    /// `napSleepMinutesByDay`.
+    static func napSleepMinutes(_ sessions: [CachedSleepSession],
+                                habitualMidsleepSec: Int? = nil) -> Double {
+        let mainStarts = Set(mainNightGroup(sessions, habitualMidsleepSec: habitualMidsleepSec)
+            .map { $0.startTs })
+        return sessions
+            .filter { !mainStarts.contains($0.startTs) }
+            .reduce(0) { total, nap in
+                total + decodedAsleepMinutes(nap.stagesJSON, effectiveStartTs: nap.effectiveStartTs)
+            }
     }
 
     /// The day's main-night bridged SPAN (onset → wake), the same window `mainNightGroup` bridges into
@@ -2320,16 +2342,31 @@ struct SleepView: View {
     }
 
     /// Sleep debt (minutes): the imported sleep_debt_min when the export carried it; else
-    /// the APPROXIMATE per-night need − asleep, floored at 0 (no "credit").
-    private var sleepDebtSeries: Metric {
+    /// the APPROXIMATE per-night need − (main sleep + nap sleep), floored at 0.
+    private func sleepDebtSeries(napSleepMinByDay: [String: Double]) -> Metric {
         let imported = repo.importedSleep
         let need = sleepNeedMin
         let series = repo.days.compactMap { d -> Double? in
             if let debt = imported[d.day]?.debtMin { return debt }   // minutes, export-verbatim
-            guard let asleep = d.totalSleepMin, asleep > 0, need > 0 else { return nil }
+            guard let asleep = SleepDebt.creditedSleepMin(
+                mainSleepMin: d.totalSleepMin,
+                napSleepMin: napSleepMinByDay[d.day] ?? 0), need > 0 else { return nil }
             return Swift.max(0, need - asleep)   // APPROXIMATE fallback
         }
         return (series.last, mean(series), series)
+    }
+
+    /// Per-local-wake-day nap credit derived from the same un-deduplicated session list and
+    /// main-night selector the hero/naps card use. `DailyMetric.totalSleepMin` stays main-night-only;
+    /// this separate map is consumed only by the local debt tile and ledger.
+    private var napSleepMinutesByDay: [String: Double] {
+        var result: [String: Double] = [:]
+        for blocks in navDays {
+            guard let endTs = blocks.first?.endTs else { continue }
+            let day = Repository.localDayKey(Date(timeIntervalSince1970: TimeInterval(endTs)))
+            result[day] = Self.napSleepMinutes(blocks, habitualMidsleepSec: habitualMidsleepSec)
+        }
+        return result
     }
 
     /// The personal sleep need (minutes): mean asleep, but never below a 7.5h floor so

--- a/StrandTests/SleepNapDebtTests.swift
+++ b/StrandTests/SleepNapDebtTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+import WhoopStore
+@testable import Strand
+
+/// Nap debt-credit wiring: the Sleep tab must credit only actual asleep minutes from blocks outside
+/// the canonical main-night group. The scalar debt arithmetic is pinned in StrandAnalytics tests;
+/// these app-target tests pin the session classification/decoding seam. Android mirrors both cases.
+final class SleepNapDebtTests: XCTestCase {
+
+    private let midnight = 1_749_513_600
+
+    private func session(start: Int, durationMin: Int, stages: String) -> CachedSleepSession {
+        CachedSleepSession(startTs: start, endTs: start + durationMin * 60,
+                           efficiency: nil, restingHr: nil, avgHrv: nil, stagesJSON: stages)
+    }
+
+    func testAfternoonNapContributesItsAsleepMinutes() {
+        let nightStart = midnight - 60 * 60
+        let napStart = midnight + 14 * 60 * 60
+        let night = session(
+            start: nightStart, durationMin: 416,
+            stages: #"{"awake":24,"light":214,"deep":82,"rem":96}"#) // 392 asleep
+        let nap = session(
+            start: napStart, durationMin: 50,
+            stages: #"{"awake":2,"light":30,"deep":10,"rem":8}"#) // 48 asleep
+
+        XCTAssertEqual(SleepView.napSleepMinutes([night, nap]), 48, accuracy: 1e-9)
+    }
+
+    func testBridgedMainNightFragmentsAreNotDoubleCreditedAsNaps() {
+        let firstStart = midnight - 60 * 60                 // 23:00
+        let secondStart = midnight + 90 * 60                // 01:30, 30-minute gap
+        let napStart = midnight + 14 * 60 * 60
+        let first = session(
+            start: firstStart, durationMin: 120,
+            stages: #"{"awake":10,"light":70,"deep":25,"rem":15}"#)
+        let second = session(
+            start: secondStart, durationMin: 210,
+            stages: #"{"awake":15,"light":120,"deep":40,"rem":35}"#)
+        let nap = session(
+            start: napStart, durationMin: 50,
+            stages: #"{"awake":2,"light":30,"deep":10,"rem":8}"#)
+
+        XCTAssertEqual(SleepView.napSleepMinutes([first, second, nap]), 48, accuracy: 1e-9)
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -273,13 +273,14 @@ object AnalyticsEngine {
 
         // ── The day's MAIN night (#525) ───────────────────────────────────────
         // A day can hold an overnight AND a daytime nap (both end on `day`, so both are in `matched`).
-        // The sleep-DURATION figures (total sleep / stage minutes / efficiency / disturbances, hence the
-        // Rest composite, the debt ledger, and the dashboard card) describe the MAIN night — the SAME
-        // block the Sleep tab's hero shows (longest, preferring an overnight-anchored onset). They must
-        // NOT silently sum the nap in, or the "your night" number disagrees across screens (the #525
-        // report). Naps stay their OWN session rows in `sleepSessions`, where the Sleep tab lists and
-        // labels them separately. [SleepStageTotals.mainNightIndex] is the single shared selector so the
-        // analytics rollup and the Sleep tab resolve to the identical block.
+        // The canonical sleep-DURATION figures (total sleep / stage minutes / efficiency / disturbances,
+        // hence the Rest composite and dashboard card) describe the MAIN night — the SAME block the Sleep
+        // tab's hero shows (longest, preferring an overnight-anchored onset). They must NOT silently sum the
+        // nap in, or the "your night" number disagrees across screens (the #525 report). Naps stay their OWN
+        // session rows in `sleepSessions`, where the Sleep tab lists and labels them separately. The Sleep
+        // tab's debt calculation deliberately adds those rows' actual asleep minutes as repayment credit;
+        // it does not mutate this canonical main-night aggregate. [SleepStageTotals.mainNightIndex] is the
+        // single shared selector so the analytics rollup and Sleep tab classify the same blocks.
         // Pick by the LEARNED-TIMING score, threading the user's learned habitual midsleep so a
         // late/shift sleeper's real night out-scores a daytime nap (null = cold-start overnight band).
         // BIPHASIC GAP-BRIDGE (#561): a main sleep briefly interrupted by a short wake (a fragment the
@@ -289,8 +290,9 @@ object AnalyticsEngine {
         // fragments in the winning group. The AASM aggregate below then SUMS the group's stages — in-bed is
         // the SUM of each fragment's own in-bed span (the inter-fragment wake gap is NOT part of any fragment,
         // so it is excluded and we do NOT invent WASO for it). A day with no bridgeable gap collapses to the
-        // single block the bare [mainNightIndex] would pick. Intelligence / the Ledger / the Sleep tab all
-        // read this SAME group, so #525 does not regress. Mirrors Swift. (#525 / #561)
+        // single block the bare [mainNightIndex] would pick. Intelligence and the Sleep headline read this
+        // SAME group; the debt ledger starts with it and separately credits naps, so #525 does not regress.
+        // Mirrors Swift. (#525 / #561)
         val mainGroupIdx = SleepStageTotals.mainNightGroupIndices(
             matched.map { SleepStageTotals.NightBlock(it.start, it.end) },
             tzOffsetSeconds, habitualMidsleepSec,

--- a/android/app/src/main/java/com/noop/analytics/SleepDebt.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepDebt.kt
@@ -80,6 +80,21 @@ object SleepDebt {
     const val ON_TARGET_BAND_MIN: Double = 30.0
 
     /**
+     * Sleep credited toward debt for one day. [mainSleepMin] remains the canonical
+     * main-night total used by Rest and the sleep headline; separately-recorded naps
+     * add repayment credit without changing that canonical figure. A day with no
+     * usable main sleep stays missing, and a malformed negative nap total is ignored.
+     *
+     * This is deliberately arithmetic rather than a physiological model: callers
+     * classify the day's main-night group and pass only asleep minutes from blocks
+     * outside that group. Mirrors Swift `SleepDebt.creditedSleepMin` value-for-value.
+     */
+    fun creditedSleepMin(mainSleepMin: Double?, napSleepMin: Double = 0.0): Double? {
+        val main = mainSleepMin?.takeIf { it > 0.0 } ?: return null
+        return main + napSleepMin.coerceAtLeast(0.0)
+    }
+
+    /**
      * Build the ledger from a chronological `List<Pair<day, totalSleepMin?>>` series.
      *
      * @param series per-night `(day, totalSleepMin)` rows in CHRONOLOGICAL order

--- a/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
@@ -101,6 +101,9 @@ internal fun buildSleepModel(
     // single-block day → the session/DailyMetric path below is unchanged.
     heroStages: StageMins? = null,
     heroSegments: List<PersistedSegment>? = null,
+    // Actual asleep minutes from blocks outside each day's canonical main-night group. They repay
+    // debt without changing DailyMetric.totalSleepMin, which remains the Rest/headline main-night figure.
+    napSleepMinByDay: Map<String, Double> = emptyMap(),
 ): SleepModel? {
     val effectiveDay = selectedDay ?: days.lastOrNull()?.day ?: return null
     // The HERO night = the selected day's stage-bearing row. The TILE / debt / need / trend
@@ -192,7 +195,8 @@ internal fun buildSleepModel(
     val sleepDebt = run {
         val series = days.mapNotNull { d ->
             imported.debtMin[d.day]   // minutes, export-verbatim
-                ?: d.totalSleepMin?.takeIf { it > 0.0 && needMin > 0.0 }
+                ?: SleepDebt.creditedSleepMin(d.totalSleepMin, napSleepMinByDay[d.day] ?: 0.0)
+                    ?.takeIf { needMin > 0.0 }
                     ?.let { max(0.0, needMin - it) }   // APPROXIMATE fallback
         }
         Metric(series.lastOrNull(), mean(series), series)
@@ -204,7 +208,7 @@ internal fun buildSleepModel(
     val trendHours = trendRows.mapNotNull { it.totalSleepMin?.let { minutes -> minutes / 60.0 } }
     val trendNeedHours = trendRows.map { row -> ((imported.needMin[row.day] ?: needMin) / 60.0) }
     val trendDebtHours = trendRows.map { row ->
-        val sleptMin = row.totalSleepMin ?: 0.0
+        val sleptMin = SleepDebt.creditedSleepMin(row.totalSleepMin, napSleepMinByDay[row.day] ?: 0.0) ?: 0.0
         val neededMin = imported.needMin[row.day] ?: needMin
         ((imported.debtMin[row.day] ?: max(0.0, neededMin - sleptMin)) / 60.0)
     }
@@ -227,10 +231,12 @@ internal fun buildSleepModel(
     // most-recent 14 counted nights and skips no-data nights), using the SAME personal need the
     // tiles use (`needMin`, ≥ 7.5 h — the per-user override over the 8 h default). Full history,
     // not the browsed-night window: the ledger is a "Last 14 nights" at-a-glance summary that
-    // matches the debt TILE (both now read asleep totals over `days`), and mirrors iOS's
-    // debtLedger over repo.days. (#242, #5)
+    // matches the debt TILE (both read main-night totals plus separately decoded nap credit),
+    // and mirrors iOS's debtLedger over repo.days. (#242, #5)
     val sleepDebtLedger = SleepDebt.ledger(
-        series = days.map { it.day to it.totalSleepMin },
+        series = days.map { d ->
+            d.day to SleepDebt.creditedSleepMin(d.totalSleepMin, napSleepMinByDay[d.day] ?: 0.0)
+        },
         needHours = needMin / 60.0,
     )
 
@@ -269,11 +275,13 @@ internal fun buildSleepModel(
 internal fun fallbackSleepModel(
     days: List<DailyMetric>,
     imported: ImportedSleepSeries = ImportedSleepSeries(),
+    napSleepMinByDay: Map<String, Double> = emptyMap(),
 ): SleepModel? {
     val anchorDay = days.lastOrNull {
         (it.deepMin ?: 0.0) + (it.remMin ?: 0.0) + (it.lightMin ?: 0.0) > 0.0
     }?.day ?: return null
-    return buildSleepModel(days, null, imported, selectedDay = anchorDay)
+    return buildSleepModel(days, null, imported, selectedDay = anchorDay,
+        napSleepMinByDay = napSleepMinByDay)
 }
 
 /** Build a metric from a per-day transform, keeping only finite values. */

--- a/android/app/src/main/java/com/noop/ui/SleepNightSelection.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepNightSelection.kt
@@ -161,6 +161,24 @@ internal fun mainSleepGroup(blocks: List<SleepSession>, habitualMidsleepSec: Lon
 }
 
 /**
+ * Actual asleep minutes in blocks outside each day's canonical main-night group. The Sleep screen's
+ * session union has already removed cross-namespace duplicates; this helper only applies the same
+ * main-vs-nap classification the hero uses and decodes the persisted stage minutes. A stage-less nap
+ * contributes nothing rather than substituting its in-bed window. Mirrors `SleepView.napSleepMinutesByDay`.
+ */
+internal fun napSleepMinutesByDay(
+    sleeps: List<SleepSession>,
+    habitualMidsleepSec: Long? = null,
+): Map<String, Double> = sleeps
+    .groupBy { localDayString(it.endTs) }
+    .mapValues { (_, blocks) ->
+        val mainStarts = mainSleepGroup(blocks, habitualMidsleepSec).mapTo(hashSetOf()) { it.startTs }
+        blocks.asSequence()
+            .filter { it.startTs !in mainStarts }
+            .sumOf { decodedAsleepMinutes(it.stagesJSON, it.effectiveStartTs) }
+    }
+
+/**
  * The day's main-night bridged SPAN (onset -> wake), the same window [mainSleepGroup] bridges into one
  * continuous night. The ONE canonical bed/wake read every glance screen (Coupled, Today's HR band) should
  * show -- never a screen-local "freshest" or "longest single block" heuristic, which can silently disagree

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -358,6 +358,13 @@ fun SleepScreen(
             .map { (_, blocks) -> blocks.sortedBy { it.effectiveStartTs } }
     }
 
+    // Debt credit is the canonical main-night DailyMetric total PLUS actual asleep minutes from blocks
+    // outside that main-night group. Keep the nap sum separate: Rest, the hero and daily total deliberately
+    // remain main-night-only. Stage-less naps add no guessed in-bed time. Mirrors Swift SleepView. (#525)
+    val napSleepMinByDay = remember(sleeps, habitualMidsleep) {
+        napSleepMinutesByDay(sleeps, habitualMidsleep)
+    }
+
     // The navigated night, decoded once per (offset, data) change — chevron taps re-pick
     // instantly without re-parsing stagesJSON on every recomposition. The offset now indexes
     // DAYS (navDays), so a day with a detected night always resolves to that night. (#160, #59)
@@ -369,9 +376,10 @@ fun SleepScreen(
     // at-a-glance TILES, the debt ledger, the personal need and the trend stay full-history /
     // latest-anchored, matching iOS SleepView. `selectedDay` re-points only the hero. Model is null
     // when the selected day has no stage minutes. (#5)
-    val model = remember(days, night, imported) {
+    val model = remember(days, night, imported, napSleepMinByDay) {
         buildSleepModel(days, night?.session, imported, selectedDay = night?.dayKey,
-            heroStages = night?.groupStages, heroSegments = night?.groupSegments)
+            heroStages = night?.groupStages, heroSegments = night?.groupSegments,
+            napSleepMinByDay = napSleepMinByDay)
     }
     val display = remember(model, night) { heroDisplay(model, night) }
 
@@ -382,7 +390,9 @@ fun SleepScreen(
     // newest stage-bearing day instead of vanishing. The HERO stays on `model`/`display` (an
     // honest no-stage-data fallback for the bad day, edit pencil reachable). Null only when NO day
     // has stage data: the true first-run empty state.
-    val tilesModel = remember(model, days, imported) { model ?: fallbackSleepModel(days, imported) }
+    val tilesModel = remember(model, days, imported, napSleepMinByDay) {
+        model ?: fallbackSleepModel(days, imported, napSleepMinByDay)
+    }
 
     // Jump straight to a night by its (local) wake-day — the center date block opens a picker.
     // navDays is newest-day-first, so the day's index IS its offset (0 = last night). (#160, #59)

--- a/android/app/src/test/java/com/noop/analytics/SleepDebtTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepDebtTest.kt
@@ -2,6 +2,7 @@ package com.noop.analytics
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -74,6 +75,22 @@ class SleepDebtTest {
         val l = SleepDebt.ledger(listOf("2026-06-01" to 420.0))
         assertEquals(RestScorer.defaultSleepNeedHours * 60.0, l.needMin, 1e-9)
         assertEquals(-60.0, l.balanceMin, 1e-9)
+    }
+
+    /** Main sleep stays canonical; separately-recorded nap sleep adds debt repayment credit. */
+    @Test
+    fun napMinutes_addDebtRepaymentCredit() {
+        val credited = SleepDebt.creditedSleepMin(mainSleepMin = 392.0, napSleepMin = 48.0)
+        assertEquals(440.0, credited!!, 1e-9)
+        val l = SleepDebt.ledger(listOf("2026-06-01" to credited), needHours = 8.0)
+        assertEquals(-40.0, l.balanceMin, 1e-9)
+    }
+
+    @Test
+    fun napCredit_requiresMainSleepAndIgnoresNegativeNapMinutes() {
+        assertNull(SleepDebt.creditedSleepMin(mainSleepMin = null, napSleepMin = 48.0))
+        assertNull(SleepDebt.creditedSleepMin(mainSleepMin = 0.0, napSleepMin = 48.0))
+        assertEquals(392.0, SleepDebt.creditedSleepMin(mainSleepMin = 392.0, napSleepMin = -10.0)!!, 1e-9)
     }
 
     /**

--- a/android/app/src/test/java/com/noop/ui/SleepImportedFiguresTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepImportedFiguresTest.kt
@@ -7,6 +7,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneId
 
 /**
  * Pins the Sleep screen's prefer-imported logic: where the WHOOP export carried a figure
@@ -145,6 +147,60 @@ class SleepImportedFiguresTest {
         assertEquals(noSession.sleepDebt, withSession.sleepDebt)
         assertEquals(noSession.sleepDebtLedger, withSession.sleepDebtLedger)
         assertEquals(noSession.typicalTotalMin, withSession.typicalTotalMin)
+    }
+
+    /** A detected nap repays debt on every local fallback surface without changing the canonical
+     *  main-night total used by Hours vs Needed. Mirrors StrandTests/SleepNapDebtTests.swift. */
+    @Test
+    fun napSleepRepaysDebtWithoutChangingMainNightMetrics() {
+        val zone = ZoneId.systemDefault()
+        val nightStart = LocalDate.of(2026, 6, 2).atStartOfDay(zone).toEpochSecond()
+        val napStart = LocalDate.of(2026, 6, 2).atTime(14, 0).atZone(zone).toEpochSecond()
+        val night = SleepSession(
+            deviceId = "my-whoop", startTs = nightStart, endTs = nightStart + 416 * 60,
+            stagesJSON = """{"awake":24,"light":214,"deep":82,"rem":96}""", // 392 asleep
+        )
+        val nap = SleepSession(
+            deviceId = "my-whoop", startTs = napStart, endTs = napStart + 50 * 60,
+            stagesJSON = """{"awake":2,"light":30,"deep":10,"rem":8}""", // 48 asleep
+        )
+        val napCredit = napSleepMinutesByDay(listOf(night, nap))
+        assertEquals(48.0, napCredit["2026-06-02"]!!, 1e-9)
+
+        // Mean main-night sleep is exactly 480 min, so personal need is 480. The latest day is
+        // 392 main + 48 nap = 440 credited: 40 min debt rather than the old 88 min.
+        val m = buildSleepModel(
+            days = listOf(day("2026-06-01", 568.0), day("2026-06-02", 392.0)),
+            session = night,
+            napSleepMinByDay = napCredit,
+        )!!
+        assertEquals(40.0, m.sleepDebt.latest!!, 1e-9)
+        assertEquals(40.0 / 60.0, m.trendDebtHours.last(), 1e-9)
+        assertEquals(440.0, m.sleepDebtLedger.nights.last().sleptMin, 1e-9)
+        assertEquals(-40.0, m.sleepDebtLedger.nights.last().deltaMin, 1e-9)
+        assertEquals(392.0 / 480.0 * 100.0, m.hoursVsNeeded.latest!!, 1e-9)
+    }
+
+    @Test
+    fun bridgedMainNightFragmentsAreNotDoubleCreditedAsNaps() {
+        val zone = ZoneId.systemDefault()
+        val midnight = LocalDate.of(2026, 6, 2).atStartOfDay(zone).toEpochSecond()
+        val first = SleepSession(
+            deviceId = "my-whoop", startTs = midnight - 60 * 60, endTs = midnight + 60 * 60,
+            stagesJSON = """{"awake":10,"light":70,"deep":25,"rem":15}""",
+        )
+        val second = SleepSession(
+            deviceId = "my-whoop", startTs = midnight + 90 * 60, endTs = midnight + 300 * 60,
+            stagesJSON = """{"awake":15,"light":120,"deep":40,"rem":35}""",
+        )
+        val napStart = midnight + 14 * 60 * 60
+        val nap = SleepSession(
+            deviceId = "my-whoop", startTs = napStart, endTs = napStart + 50 * 60,
+            stagesJSON = """{"awake":2,"light":30,"deep":10,"rem":8}""",
+        )
+
+        val credit = napSleepMinutesByDay(listOf(first, second, nap))
+        assertEquals(48.0, credit["2026-06-02"]!!, 1e-9)
     }
 
     /** Browsing a PAST night (selectedDay = an earlier day) leaves the at-a-glance tiles and the


### PR DESCRIPTION
## What this PR does

Credits actual asleep minutes from separately-recorded naps toward NOOP's locally-computed sleep debt on Swift and Android, while preserving the deliberately main-night-only contract for `DailyMetric.totalSleepMin`, Rest, the dashboard, the Sleep hero, and Hours vs Needed.

The local debt calculation now receives:

```text
credited sleep = canonical main-night sleep + staged asleep minutes from naps
```

The session layer derives nap credit with the same main-night-group selector used by the Sleep hero. That keeps bridged fragments of an interrupted/biphasic night in the main group and credits only blocks outside it. A stage-less nap contributes zero rather than substituting its full in-bed window. Imported `sleep_debt_min` values continue to pass through verbatim.

The arithmetic is a small pure helper mirrored value-for-value in `SleepDebt.swift` and `SleepDebt.kt`; it does not attempt to reproduce a proprietary sleep model. WHOOP's public documentation describes naps as affecting Sleep Planner/Sleep Need and helping reduce acute sleep debt:

- https://www.whoop.com/us/en/thelocker/feature-update-whoop-app-sleep-planner/
- https://www.whoop.com/us/en/thelocker/what-is-sleep-debt-catch-up/

Example pinned on both platforms: 392 minutes main sleep + 48 minutes nap against a 480-minute need produces 40 minutes of debt, rather than 88 minutes, while the canonical main-night total remains 392 minutes.

No BLE, protocol, persistence schema, migration, UI layout, or generated-project changes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

No BLE path changes, so strap/hardware validation does not apply.

Added mirrored pure analytics tests:

- `SleepDebtTests.testNapMinutesAddDebtRepaymentCredit`
- `SleepDebtTest.napMinutes_addDebtRepaymentCredit`
- missing-main and negative-nap defensive cases on both platforms

Added mirrored app-layer regression coverage:

- Swift `SleepNapDebtTests`: afternoon nap credit and bridged-main-fragment exclusion
- Android `SleepImportedFiguresTest`: debt tile, debt trend, ledger, unchanged main-night Hours vs Needed, and bridged-main-fragment exclusion

Local source checks:

- `python3 Tools/doc_comment_lint.py` — pass
- `python3 Tools/i18n_audit.py --ci origin/main` — pass
- `git diff --check` — pass

The development environment is WSL without Swift/Xcode, Java, or an Android SDK. The PR is therefore opened as a draft so the repository's Android, Swift-package, macOS, and iOS GitHub workflows can compile and run the exact branch before it is marked ready.

## Checklist

- [ ] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`) — awaiting PR CI
- [ ] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`) — awaiting PR CI
- [ ] No new build warnings introduced — awaiting PR CI
- [x] UI changes use only `StrandDesign` tokens — no UI/layout changes
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders — no protocol changes
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Closes #1041
