### PR TITLE
Correct the manual-workout HR read doc, and pin the case that distinguishes the rule (#836)

### DIFF
--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1734,23 +1734,35 @@ class WhoopRepository(private val dao: WhoopDao) {
         }
 
         /** A workout row is DETECTED when the engine scored it from a strap trace it recorded itself
-         *  (source "<id>-noop"). This is the strict subset of [isStrapNativeWorkout] that actually carries
-         *  its own recording strap id — a "manual" row does not (see [workoutHrDeviceIds]). */
+         *  (source "<id>-noop"). This is the strict subset of [isStrapNativeWorkout] whose stored deviceId is
+         *  RELIABLY the strap that recorded it. A "manual" row's is not: it holds whatever its creator passed
+         *  — the "my-whoop" placeholder from the Workouts screen, or the active strap id from the auto-workout
+         *  nudge — so manual rows read the union instead (see [workoutHrDeviceIds]). */
         fun isDetectedWorkout(source: String): Boolean = source.lowercase().endsWith("-noop")
 
         /** #510/#836: the device id(s) whose `hrSample` rows back a workout's Avg HR / calories / Effort
          *  recompute. A DETECTED row was charted from its OWN strap's trace, so read HR under that strap —
          *  strip the computed "-noop" suffix to reach the raw hrSample id (a detected row lives under
-         *  "<id>-noop", its HR under "<id>"). Everything else — a MANUAL row or an IMPORTED one — has no
-         *  strap trace of its own to point at: a manual row's stored deviceId is just "my-whoop", a
-         *  retroactive-add placeholder ([com.noop.ui.WorkoutEditing.buildManualRow]), not the strap that was
-         *  actually worn. So both read the #814 UNION via [importedSourceIdsFor] (active strap ∪ canonical
-         *  "my-whoop", active first) — the same window #77 fills IMPORTED rows from. Byte-identical to the
-         *  Swift twin (`Repository.workoutHrDeviceIds`), which has always kept only DETECTED on the single-id
-         *  path. Before this fix, a manual row read "my-whoop" verbatim, so a manual workout on a SECOND WHOOP
-         *  ("whoop-<mac>") or any re-added strap read an empty window — its Avg HR went un-reconciled and a
-         *  null Effort un-recomputed (#836). A single-WHOOP install still resolves to one id, so nothing
-         *  changes there. (This fill only sets avgHr/maxHr/strain; calories come from the detector.) */
+         *  "<id>-noop", its HR under "<id>"). Everything else — a MANUAL row or an IMPORTED one — reads the
+         *  #814 UNION via [importedSourceIdsFor] (active strap ∪ canonical "my-whoop", active first), the
+         *  same window #77 fills IMPORTED rows from. Byte-identical to the Swift twin
+         *  (`Repository.workoutHrDeviceIds`), which has always kept only DETECTED on the single-id path.
+         *
+         *  Why MANUAL cannot key on its own `rowDeviceId`: [com.noop.ui.WorkoutEditing.buildManualRow]
+         *  stores whatever `deviceId` its CALLER passes, and the two callers disagree — the Workouts screen
+         *  passes the canonical "my-whoop" placeholder, while [com.noop.ui.AutoWorkoutNudge] deliberately
+         *  passes the ACTIVE strap id (mirroring iOS `saveDetectedWorkout`). Both write source "manual", so
+         *  the source string cannot tell them apart. Keying on the stored id therefore served the nudge rows
+         *  and broke the placeholder ones: a manual workout on a SECOND WHOOP ("whoop-<mac>") or any re-added
+         *  strap read the empty "my-whoop" window, leaving Avg HR un-reconciled and a null Effort
+         *  un-recomputed (#836).
+         *
+         *  The union costs a nudge-created row its exact recording strap once the ACTIVE strap changes, which
+         *  is deliberate and degrades safely in both directions: an empty window returns the row untouched
+         *  (the `stats.n < minSamples` guard below), preserving whatever Avg HR was stored, and a non-empty
+         *  one is the same wearer over the same interval — a re-added strap re-banks that history under its
+         *  fresh id. A single-WHOOP install still resolves to one id, so nothing changes there.
+         *  (This fill only sets avgHr/maxHr/strain; calories come from the detector.) */
         fun workoutHrDeviceIds(source: String, rowDeviceId: String, activeStrapId: String): List<String> =
             if (isDetectedWorkout(source)) listOf(rowDeviceId.removeSuffix("-noop"))
             else importedSourceIdsFor(activeStrapId)

--- a/android/app/src/test/java/com/noop/data/WorkoutHrDeviceKeyTest.kt
+++ b/android/app/src/test/java/com/noop/data/WorkoutHrDeviceKeyTest.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 /**
  * #510: `fillWorkoutHrFromStrap` used to read every workout's HR window under a hardcoded "my-whoop",
  * so a workout recorded on a SECOND WHOOP (id "whoop-<mac>", its HR banked under that id) read an empty
- * window and lost its Avg HR / calories / Effort. [WhoopRepository.workoutHrDeviceId] now resolves the
+ * window and lost its Avg HR / calories / Effort. [WhoopRepository.workoutHrDeviceIds] now resolves the
  * correct read key per row; this pins that resolution and the strap-native classification it rides on.
  */
 class WorkoutHrDeviceKeyTest {
@@ -49,14 +49,41 @@ class WorkoutHrDeviceKeyTest {
     }
 
     @Test fun `manual row reads HR under the active union, not its stored placeholder id`() {
-        // #836: a manual row's stored deviceId is a retroactive-add placeholder ("my-whoop"), not the
-        // strap that was actually worn — so, like an imported row, it reads the #814 union (active
-        // strap first, canonical "my-whoop" second). Byte-parity with the Swift twin, which has always
-        // kept manual rows off the single-id path.
+        // #836: a manual row reads the #814 union (active strap first, canonical "my-whoop" second) rather
+        // than its own stored id, because that id is not reliably the recording strap. Byte-parity with the
+        // Swift twin, which has always kept manual rows off the single-id path.
         assertEquals(
             listOf("whoop-aabbcc", "my-whoop"),
             WhoopRepository.workoutHrDeviceIds("manual", "whoop-aabbcc", activeStrapId = "whoop-aabbcc"),
         )
+    }
+
+    @Test fun `manual row ignores its stored strap id when a DIFFERENT strap is active`() {
+        // The divergent case, pinned explicitly: before #1039 a manual row keyed on its stored deviceId, so
+        // this returned ["whoop-aabbcc"]. It now returns the active union instead, which is the deliberate
+        // trade — see workoutHrDeviceIds' doc. Asserting it here rather than at rowDeviceId == activeStrapId
+        // (where the old and new rules happen to agree) is the whole point: that is the only shape that can
+        // tell the two rules apart, so without it a regression to per-row keying passes the suite silently.
+        //
+        // It matters because both buildManualRow callers write source "manual" with DIFFERENT ids — the
+        // Workouts screen passes "my-whoop", AutoWorkoutNudge passes the active strap id — so a nudge-created
+        // row genuinely does carry a real recording strap that this rule declines to use.
+        assertEquals(
+            listOf("whoop-ddeeff", "my-whoop"),
+            WhoopRepository.workoutHrDeviceIds("manual", "whoop-aabbcc", activeStrapId = "whoop-ddeeff"),
+        )
+    }
+
+    @Test fun `the read key never exceeds the two ids hrWindowStats consumes`() {
+        // fillWorkoutHrFromStrap calls hrWindowStats(hrIds[0], hrIds.getOrElse(1) { hrIds[0] }, ...) — exactly
+        // two. A third id would be silently dropped, so any future widening of this key has to fail here
+        // first rather than lose a read at the call site.
+        for (source in listOf("manual", "apple-health", "activity-file", "whoop-aabbcc-noop", "my-whoop-noop")) {
+            for (active in listOf("my-whoop", "whoop-aabbcc")) {
+                val ids = WhoopRepository.workoutHrDeviceIds(source, "whoop-ddeeff", activeStrapId = active)
+                assertTrue("$source/$active produced ${ids.size} ids", ids.isNotEmpty() && ids.size <= 2)
+            }
+        }
     }
 
     @Test fun `imported row reads HR under the active strap (the worn strap), preserving the #77 fill`() {


### PR DESCRIPTION
Follow-up to #1039, which fixed the real #836 bug. Comment and test only; no behaviour change.

## The doc is inaccurate

#1039 explains the rule as "a manual row's stored deviceId is just `my-whoop`, a retroactive-add placeholder". That holds for one of the two callers.

`buildManualRow` takes `deviceId` as a parameter and stores it verbatim:

| caller | `deviceId` passed |
|---|---|
| `WorkoutsScreen.kt` — user "add manual workout" | `"my-whoop"` |
| `AutoWorkoutNudge.kt` — accepting a detected nudge | `viewModel.deviceId`, the **active strap id** (deliberate, mirroring iOS `saveDetectedWorkout`) |

Both write `source = "manual"`, so `workoutHrDeviceIds` cannot tell them apart by source. That — not the placeholder claim — is the actual reason manual rows can't key on their own id, and it's what the doc now says.

The `isDetectedWorkout` doc had the same problem ("a manual row does not carry its own recording strap id"); a nudge-created row does.

## What the union costs, now written down

A nudge-created row loses its exact recording strap once the active strap changes. That is deliberate and degrades safely in both directions, which is why #1039 is still the right call:

- **empty window** → the `stats.n < minSamples` guard returns the row untouched, so the stored Avg HR survives — it cannot overwrite a good value
- **non-empty window** → same wearer over the same interval; a re-added strap re-banks that history under its fresh id

Worth stating explicitly so the next person weighing #856's "detected reads only the strap that recorded it" against this can see the trade rather than rediscover it.

## Restored coverage

#1039 replaced

```kotlin
@Test fun `manual row reads HR under its own strap id`()   // rowDeviceId="whoop-aabbcc", active="my-whoop"
```

with a case where `rowDeviceId == activeStrapId` — the one shape where the old per-row rule and the new union rule return the same first id. The divergent shape is the only one that can tell them apart, so without it a regression to per-row keying passes the suite silently.

Adds back that shape with the **new** expectation (`["whoop-ddeeff", "my-whoop"]`), plus a guard on the two-id ceiling: `fillWorkoutHrFromStrap` calls `hrWindowStats(hrIds[0], hrIds.getOrElse(1) { hrIds[0] }, …)`, exactly two, so a third id would be dropped silently. Widening the key now fails in the test instead of at the call site.

Also fixes a stale KDoc link in the test class header — `WhoopRepository.workoutHrDeviceId` (singular) no longer exists.

## Verification

- Expected values checked against the shipped logic rather than assumed: `("manual", "whoop-aabbcc", active="whoop-ddeeff")` → `["whoop-ddeeff", "my-whoop"]`, and no source/active combination exceeds two ids.
- `doc_comment_lint.py` exits 0, no new detached comments.
- Android-only; no Swift or shared-package code touched.