### PR TITLE
Say what the Oura SpO2 unit tag actually means, and correct the mapping table (#1043)

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -224,6 +224,18 @@ public enum OuraDecoders {
     /// Decode the 0x6F spo2_event: byte6 bits [7:4]=SpO2 base/status field, [3:0]=status flag; then one
     /// uint8 SpO2 value per second from byte7 onward (optional 0xFF terminator). Per OURA_PROTOCOL.md
     /// s6.5. Returns nil on a short body.
+    ///
+    /// UNIT TAG: these samples carry the default `unit: "raw"`, which is a legacy CHANNEL label, not a
+    /// claim about the quantity — 0x6F is a firmware-computed PERCENTAGE (s6.5, corroborated by
+    /// open_oura), unlike 0x77 which really is a raw DC channel and tags itself `"dc_raw"`. The string
+    /// is deliberately left alone: it is a persisted column (`Database.swift` spo2 `unit`), no consumer
+    /// branches on it (only the CLI dump and one log line read it), and rewriting it would split stored
+    /// history across two spellings of the same channel for a cosmetic gain. Kotlin matches exactly.
+    ///
+    /// s6.5 also records an OPEN ISSUE: ~47% of decoded 0x6F samples exceed 100%, which no ground truth
+    /// yet explains, so no offset is applied here — a guessed calibration would be worse than the gap.
+    /// These land in the RAW channel (`SpO2Sample.red`), never in `spo2Pct`, so an impossible value is
+    /// not surfaced as a Blood Oxygen reading.
     public static func decodeSpO2PerSample(_ rec: OuraRecord) -> [OuraSpO2]? {
         let b = rec.payload
         guard b.count >= 2 else { return nil }

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -42,7 +42,10 @@ public enum OuraStreamMapping {
     ///   - `.hr`         (0x55 live-HR push)            → `hr:[HRSample]`
     ///   - `.ibi`        (0x44/0x60 IBI)                → `rr:[RRInterval]`
     ///   - `.hrv`        (0x5D HRV tag, raw int8 b1/b2)  → `events:[WhoopEvent(kind: OURA_HRV)]`
-    ///   - `.spo2`       (0x6F/0x70/0x77)              → `spo2:[SpO2Sample(raw_adc)]`
+    ///   - `.spo2`       (0x6F/0x70/0x77)              → `spo2:[SpO2Sample]`, carrying the decoder's own
+    ///     `unit` tag. NOT all one quantity: 0x6F/0x70 are firmware-computed PERCENTAGES (tagged `"raw"`,
+    ///     a legacy channel label — see `OuraDecoders.decodeSpO2PerSample`), while 0x77 is a genuine raw
+    ///     DC channel tagged `"dc_raw"`. Both land in `SpO2Sample.red`; neither is written to `spo2Pct`.
     ///   - `.temp`       (0x46/0x75)                    → `skinTemp:[SkinTempSample(raw_adc)]`
     ///   - `.sleepPhase` (0x4E/0x5A 2-bit codes)        → `events:[WhoopEvent(kind: OURA_SLEEP_PHASE)]`
     ///   - `.battery`                                   → `battery:[BatterySample]`

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -242,9 +242,21 @@ object OuraDecoders {
     // MARK: - SpO2 per-sample (0x6F; s6.5)
 
     /**
-     * Decode the 0x6F spo2_event: byte6 bits [7:4]=SpO2 base (<<7), [3:0]=status flag; then one
+     * Decode the 0x6F spo2_event: byte6 bits [7:4]=SpO2 base/status field, [3:0]=status flag; then one
      * uint8 SpO2 value per second from byte7 onward (optional 0xFF terminator). Per OURA_PROTOCOL.md
      * s6.5. Returns null on a short body.
+     *
+     * UNIT TAG: these samples carry the default `unit = "raw"`, which is a legacy CHANNEL label, not a
+     * claim about the quantity — 0x6F is a firmware-computed PERCENTAGE (s6.5, corroborated by
+     * open_oura), unlike 0x77 which really is a raw DC channel and tags itself `"dc_raw"`. The string is
+     * deliberately left alone: it is a persisted column, no consumer branches on it, and rewriting it
+     * would split stored history across two spellings of the same channel for a cosmetic gain. Swift
+     * `OuraDecoders.decodeSpO2PerSample` matches exactly.
+     *
+     * s6.5 also records an OPEN ISSUE: ~47% of decoded 0x6F samples exceed 100%, which no ground truth
+     * yet explains, so no offset is applied here — a guessed calibration would be worse than the gap.
+     * These land in the RAW channel (`Spo2Sample.red`), never in a percentage field, so an impossible
+     * value is not surfaced as a Blood Oxygen reading.
      */
     fun decodeSpO2PerSample(rec: OuraRecord): List<OuraSpO2>? {
         val b = rec.payload


### PR DESCRIPTION
Follow-up to #1043, which established that `0x6F`/`0x70` are firmware-computed **percentages**, not raw ADCs. Two places in the code still implied otherwise. Comments only — no behaviour, no stored data, no test changes.

## The unit tag says "raw" for a percentage

`decodeSpO2PerSample` constructs `OuraSpO2(ringTimestamp:value:)` with no `unit` argument, so it takes the default `"raw"` — directly above its own comment saying the samples are direct percentages. The `0x77` path passes `"dc_raw"` explicitly, so the field is meaningful and in use.

**Deliberately not changing the string.** I checked what that would cost:

- `unit` is a **persisted column** (`Database.swift:340`, `.notNull()`), so rewriting it changes stored data
- **no consumer branches on it** — the only readers are `oura-decode`'s dump line and one `OuraLiveSource` log
- Swift and Kotlin **already agree byte-for-byte** (`unit: String = "raw"` on both, `"dc_raw"` on both `0x77` paths), so there is no parity bug to fix
- `OuraStreamMappingTests` pins `["raw", "dc_raw"]`

Changing it would split stored history across two spellings of the same channel, for a label no code reads. Documenting it as a legacy channel label is the honest fix, so the next person doesn't read `"raw"` as a claim about the quantity — or "correct" it and silently fork the data.

## The mapping table was wrong

`OuraStreamMapping`'s section-4 table said:

```
- `.spo2` (0x6F/0x70/0x77) → `spo2:[SpO2Sample(raw_adc)]`
```

Wrong for two of the three tags, and it hid that `0x77` is a genuinely different quantity from the other two. Now names the per-tag units. Kotlin's `OuraStreamMapping` carries no equivalent table, so this one is Swift-only.

## Also

- Records why the open >100% finding is **not** a display bug: those samples land in the raw channel (`SpO2Sample.red`) and are never written to `spo2Pct`, so an impossible value cannot surface as a Blood Oxygen reading. Traced through the mapping and the Today/Health cards.
- Aligns the Kotlin decoder's byte6 description with Swift's. Kotlin still said `[7:4]=SpO2 base (<<7)` — the discredited offset reading that its own inline comment two lines below already corrects.

## Verification

- `doc_comment_lint.py` exits 0, no new detached comments.
- Every changed line is a comment, verified mechanically rather than by eye (filtering the diff to non-comment changes returns nothing).
- No test touched; the `["raw", "dc_raw"]` expectation stands unchanged, which is the point.