### PR TITLE
Localize the Android recording chip, which shipped English to every locale (#612)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -4162,12 +4162,50 @@ private fun ScoreStateNote(state: ScoreState, restartCause: String? = null) {
 
 // ── COMPONENT 3, recording status ───────────────────────────────────────────────────────────────────
 
+/** The chip's status word, LOCALIZED.
+ *
+ *  [RecordingState.title] stays the English parity contract — it is asserted verbatim against the Swift
+ *  twin in `TodayExplainabilityTest` and must not become resource-backed, which would drag a `Context`
+ *  into a pure mapper and break those tests. So the resource lookup lives HERE, at the render site,
+ *  exactly like the Swift side: `RecordingState.label` is a `LocalizedStringKey`, so its literals are
+ *  catalogue KEYS that SwiftUI resolves. Kotlin's are plain `String`, so rendering `state.title`
+ *  directly shipped English to every locale — the chip read "Not recording. Strap not connected."
+ *  on a German phone while the iPhone read "Strap nicht verbunden. Tippe zum Verbinden."
+ *
+ *  Invisible to `i18n_audit`: the literals sit in a sealed-class getter, not a Compose call argument,
+ *  so the scanner never saw them. Translations here are the Swift catalogue's own, copied 1:1.
+ */
+@Composable
+private fun recordingTitle(state: RecordingState): String = when (state) {
+    RecordingState.Recording -> uiString(R.string.recording_chip_title_recording)
+    is RecordingState.LastSynced -> uiString(R.string.recording_chip_title_last_synced, state.minutesAgo)
+    RecordingState.NotRecording -> uiString(R.string.recording_chip_title_not_recording)
+    // Both connected states share the same word, as they do on Swift.
+    RecordingState.HistoryExperimental, RecordingState.ConnectedNoData ->
+        uiString(R.string.recording_chip_title_connected)
+}
+
+/** The chip's one-line detail, LOCALIZED. Same split as [recordingTitle]. */
+@Composable
+private fun recordingDetail(state: RecordingState): String = when (state) {
+    RecordingState.Recording -> uiString(R.string.recording_chip_detail_recording)
+    is RecordingState.LastSynced -> uiString(R.string.recording_chip_detail_last_synced)
+    RecordingState.NotRecording -> uiString(R.string.recording_chip_detail_not_recording)
+    RecordingState.HistoryExperimental -> uiString(R.string.recording_chip_detail_history_experimental)
+    RecordingState.ConnectedNoData -> uiString(R.string.recording_chip_detail_connected_no_data)
+}
+
 /** The Today/Live recording chip: a tinted StatePill with the status word (a pulsing dot while live),
  *  plus the one-line what-it-means below. Honest, never claims "Recording" without a live stream.
  *  Tapping a not-recording chip routes to connect (Settings). Mirrors the iOS RecordingStatusChip. */
 @Composable
 private fun RecordingStatusChip(state: RecordingState, onConnect: () -> Unit) {
     val clickable = state is RecordingState.NotRecording || state is RecordingState.LastSynced
+    // Resolved BEFORE the Row: `semantics { }` is not a composable scope, so uiString cannot be called
+    // inside it. Reading them once also keeps the pill, the detail line and the a11y label on one string.
+    val title = recordingTitle(state)
+    val detail = recordingDetail(state)
+    val chipA11y = uiString(R.string.l10n_today_screen_state_title_state_detail_f5380609, title, detail)
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -4182,18 +4220,18 @@ private fun RecordingStatusChip(state: RecordingState, onConnect: () -> Unit) {
                     Modifier
                 },
             )
-            .semantics { contentDescription = uiString(R.string.l10n_today_screen_state_title_state_detail_f5380609, state.title, state.detail) },
+            .semantics { contentDescription = chipA11y },
         horizontalArrangement = Arrangement.spacedBy(10.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         StatePill(
-            title = state.title,
+            title = title,
             tone = state.tone,
             showsDot = true,
             pulsing = state is RecordingState.Recording,
         )
         Text(
-            state.detail,
+            detail,
             style = NoopType.footnote,
             color = Palette.textTertiary,
             modifier = Modifier.weight(1f),

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1874,4 +1874,13 @@
     <string name="onboarding_theme_follow_system">Die Hell-/Dunkel-Einstellung deines Smartphones wird übernommen.</string>
     <string name="onboarding_theme_light_description">Tiefblaue Akzente auf einem warmen, hellen Hintergrund.</string>
     <string name="onboarding_theme_dark_description">Tiefblaue Akzente auf einem dunklen, blaugrauen Hintergrund.</string>
+    <string name="recording_chip_title_recording">Aufnahme</string>
+    <string name="recording_chip_title_last_synced">Zuletzt vor %1$d Min. synchronisiert</string>
+    <string name="recording_chip_title_not_recording">Keine Aufzeichnung</string>
+    <string name="recording_chip_title_connected">Verbunden</string>
+    <string name="recording_chip_detail_recording">Dein Strap ist verbunden und speichert Daten.</string>
+    <string name="recording_chip_detail_last_synced">Verbinde neu, um das Neueste zu laden.</string>
+    <string name="recording_chip_detail_not_recording">Strap nicht verbunden. Tippe zum Verbinden.</string>
+    <string name="recording_chip_detail_history_experimental">Verlaufssynchronisierung ist auf 5.0 experimentell.</string>
+    <string name="recording_chip_detail_connected_no_data">Noch keine Live-Herzfrequenz und kein synchronisierter Verlauf in dieser Sitzung.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1859,4 +1859,13 @@
     <string name="onboarding_theme_follow_system">Se usa el ajuste claro u oscuro de tu teléfono.</string>
     <string name="onboarding_theme_light_description">Acentos azul oscuro sobre un fondo cálido y claro.</string>
     <string name="onboarding_theme_dark_description">Acentos azul oscuro sobre un fondo azul grisáceo oscuro.</string>
+    <string name="recording_chip_title_recording">Grabando</string>
+    <string name="recording_chip_title_last_synced">Sincronizado hace %1$dm</string>
+    <string name="recording_chip_title_not_recording">Sin grabar</string>
+    <string name="recording_chip_title_connected">Conectado</string>
+    <string name="recording_chip_detail_recording">Tu pulsera está conectada y guardando datos.</string>
+    <string name="recording_chip_detail_last_synced">Reconecta para extraer lo más reciente.</string>
+    <string name="recording_chip_detail_not_recording">Pulsera no conectada. Toca para conectar.</string>
+    <string name="recording_chip_detail_history_experimental">La sincronización del historial es experimental en la 5.0.</string>
+    <string name="recording_chip_detail_connected_no_data">Aún no hay frecuencia cardíaca en vivo ni historial sincronizado en esta sesión.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1859,4 +1859,13 @@
     <string name="onboarding_theme_follow_system">Le réglage clair ou sombre de votre téléphone est utilisé.</string>
     <string name="onboarding_theme_light_description">Des accents bleu profond sur un fond clair et chaleureux.</string>
     <string name="onboarding_theme_dark_description">Des accents bleu profond sur un fond bleu-gris sombre.</string>
+    <string name="recording_chip_title_recording">Enregistrement</string>
+    <string name="recording_chip_title_last_synced">Synchronisé il y a %1$d min</string>
+    <string name="recording_chip_title_not_recording">Pas d\'enregistrement</string>
+    <string name="recording_chip_title_connected">Connecté</string>
+    <string name="recording_chip_detail_recording">Votre bracelet est connecté et enregistre les données.</string>
+    <string name="recording_chip_detail_last_synced">Reconnectez-vous pour récupérer les dernières données.</string>
+    <string name="recording_chip_detail_not_recording">Bracelet non connecté. Touchez pour vous connecter.</string>
+    <string name="recording_chip_detail_history_experimental">La synchronisation de l\'historique est expérimentale sur 5.0.</string>
+    <string name="recording_chip_detail_connected_no_data">Aucune fréquence cardiaque en direct ni historique synchronisé durant cette session.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1853,4 +1853,13 @@
     <string name="onboarding_theme_follow_system">É utilizada a definição de tema claro ou escuro do teu telemóvel.</string>
     <string name="onboarding_theme_light_description">Destaques em azul-escuro sobre um fundo claro e acolhedor.</string>
     <string name="onboarding_theme_dark_description">Destaques em azul-escuro sobre um fundo azul-acinzentado escuro.</string>
+    <string name="recording_chip_title_recording">Gravação</string>
+    <string name="recording_chip_title_last_synced">Última sincronização há %1$dm</string>
+    <string name="recording_chip_title_not_recording">Não está a gravar</string>
+    <string name="recording_chip_title_connected">Ligado</string>
+    <string name="recording_chip_detail_recording">A tua bracelete está conectada e a guardar dados.</string>
+    <string name="recording_chip_detail_last_synced">Volte a ligar para obter o mais recente.</string>
+    <string name="recording_chip_detail_not_recording">Correia não ligada. Toque para ligar.</string>
+    <string name="recording_chip_detail_history_experimental">A sincronização do histórico é experimental na versão 5.0.</string>
+    <string name="recording_chip_detail_connected_no_data">Ainda não há frequência cardíaca em direto nem histórico sincronizado nesta sessão.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1787,4 +1787,13 @@
     <string name="onboarding_theme_follow_system">跟随手机的浅色或深色设置。</string>
     <string name="onboarding_theme_light_description">深蓝色点缀搭配温暖的浅色背景。</string>
     <string name="onboarding_theme_dark_description">深蓝色点缀搭配深色蓝灰背景。</string>
+    <string name="recording_chip_title_recording">录制中</string>
+    <string name="recording_chip_title_last_synced">上次同步于 %1$d 分钟前</string>
+    <string name="recording_chip_title_not_recording">未在录制</string>
+    <string name="recording_chip_title_connected">已连接</string>
+    <string name="recording_chip_detail_recording">你的手环已连接并正在保存数据。</string>
+    <string name="recording_chip_detail_last_synced">重新连接以拉取最新内容。</string>
+    <string name="recording_chip_detail_not_recording">手环未连接。点击以连接。</string>
+    <string name="recording_chip_detail_history_experimental">历史同步在 5.0 上属实验性。</string>
+    <string name="recording_chip_detail_connected_no_data">本次连接尚无实时心率或已同步的历史记录。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1885,4 +1885,13 @@
     <string name="onboarding_theme_follow_system">Following your phone\'s light/dark setting.</string>
     <string name="onboarding_theme_light_description">Deep blue accent on warm paper.</string>
     <string name="onboarding_theme_dark_description">Deep blue accent on a dark blue-grey canvas.</string>
+    <string name="recording_chip_title_recording">Recording</string>
+    <string name="recording_chip_title_last_synced">Last synced %1$dm ago</string>
+    <string name="recording_chip_title_not_recording">Not recording</string>
+    <string name="recording_chip_title_connected">Connected</string>
+    <string name="recording_chip_detail_recording">Your strap is connected and saving data.</string>
+    <string name="recording_chip_detail_last_synced">Reconnect to pull the latest.</string>
+    <string name="recording_chip_detail_not_recording">Strap not connected. Tap to connect.</string>
+    <string name="recording_chip_detail_history_experimental">History sync is experimental on 5.0.</string>
+    <string name="recording_chip_detail_connected_no_data">No live heart rate or synced history yet this session.</string>
 </resources>


### PR DESCRIPTION
Follow-up found while reviewing #826. The Today/Live recording chip renders in English on Android regardless of the phone's language.

## The bug

A German user reads the chip as:

> **Not recording.** Strap not connected. Tap to connect.

while the iPhone next to them reads:

> **Strap nicht verbunden.** Tippe zum Verbinden.

It is a platform asymmetry in the twin, and it affects **every** branch — not just the state #826 added:

```swift
// Swift — the literals are catalogue KEYS, resolved by SwiftUI
var label: LocalizedStringKey  { case .notRecording: return "Not recording" }
var detail: LocalizedStringKey { ... }
```
```kotlin
// Kotlin — plain String, rendered straight into the UI
NotRecording -> "Not recording"        →  StatePill(title = state.title)
                                          Text(state.detail)
```

## Why nothing caught it

`i18n_audit`'s `scan_android` looks at Compose call arguments. These literals live in a sealed-class getter, so it never looks at them. Probed directly:

```
MISSED  'Not recording'
MISSED  'Strap not connected. Tap to connect.'
MISSED  'No live heart rate or synced history yet this session.'
```

Different blind spot from the #557/#922 concatenation class, same outcome: green CI over untranslated user-facing copy.

## The fix, and what it deliberately does not touch

`TodayScoring.kt` is **unchanged**. Its `title`/`detail` are the English parity contract, asserted verbatim against the Swift twin in `TodayExplainabilityTest`:

```kotlin
assertEquals("Not recording", state.title)
assertEquals("Strap not connected. Tap to connect.", state.detail)
```

Making them resource-backed would drag a `Context` into a pure mapper and break those tests. So the resource lookup lives at the render site in `TodayScreen.kt` — which is exactly where Swift resolves its `LocalizedStringKey` too. The sealed class stays pure and testable; the UI stays localized.

The strings are resolved once at the top of `RecordingStatusChip` because `semantics { }` is not a composable scope, so `uiString` cannot be called inside it — and reading them once keeps the pill, the detail line and the accessibility label on one string.

## No new translation

All nine strings already exist in `Strand/Resources/Localizable.xcstrings`, fully translated in **every locale Android ships** (de/es/fr/pt-PT/zh). Values are copied 1:1, so nothing here is invented or machine-translated. `%lld` becomes `%1$d`, and the format signature is identical across all six files:

```
values         specs=['d']  Last synced %1$dm ago
values-de      specs=['d']  Zuletzt vor %1$d Min. synchronisiert
values-zh      specs=['d']  上次同步于 %1$d 分钟前
```

`minutesAgo` is a `Long`, which `%d` accepts.

## Not fixed here

`ScoreState` has the identical asymmetry — Swift `LocalizedStringKey?`, Kotlin raw `String`, rendered directly by `ScoreStateNote`. Its copy carries dates and night counts, so it needs plural and date handling this change does not, and it deserves its own pass rather than being bolted on here.

## Verification

- `i18n_audit.py --ci` exits 0; all four focus locales OK, no new hardcoded literals, and the `%1$d` signature is consistent across all six files (the audit's own `android_format_gaps` check covers this).
- `doc_comment_lint.py` exits 0.
- `TodayScoring.kt` untouched, so the Swift-parity assertions are unaffected.
- Android-only; no Swift changed.