### PR TITLE
Localize the Android score-state note, and make its countdown a real plural (#612)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1241,6 +1241,12 @@ fun TodayScreen(
             // hero. So on Android it's dismissible-into-the-inbox (restorable) like the calibrating note: a
             // small × tucks it into Updates so it isn't a fixed fixture between the header and the hero.
             if (selectedDayOffset == 0 && scoreState is ScoreState.CarriedLastNight && !carriedSleepDismissed) {
+                // Resolved HERE, not in the onClick below: dismissTodayCard runs from a non-composable
+                // lambda, and what it stores is what the Updates inbox later shows. Passing the raw
+                // `scoreState.title`/`.detail` filed the dismissed card in English while the card itself
+                // rendered localized — the same strings reaching a second sink. (#612)
+                val carriedTitle = scoreStateTitle(scoreState)
+                val carriedDetail = scoreStateDetail(scoreState)
                 Box(modifier = Modifier.fillMaxWidth()) {
                     ScoreStateNote(scoreState)
                     if (updateStore != null) {
@@ -1249,8 +1255,8 @@ fun TodayScreen(
                             onClick = {
                                 dismissTodayCard(
                                     CARD_CARRIED_SLEEP,
-                                    scoreState.title,
-                                    scoreState.detail,
+                                    carriedTitle,
+                                    carriedDetail,
                                 )
                             },
                         )
@@ -4113,6 +4119,39 @@ private fun ContributorBar(label: String, readout: String, fraction: Double?, co
 
 // ── COMPONENT 2, explained score states ─────────────────────────────────────────────────────────────
 
+/** The score-state title, LOCALIZED — same split as [recordingTitle] and for the same reason:
+ *  [ScoreState.title] is the English parity contract asserted verbatim against Swift in
+ *  `TodayExplainabilityTest`, so the resource lookup lives here rather than in the pure mapper. */
+@Composable
+private fun scoreStateTitle(state: ScoreState): String = when (state) {
+    is ScoreState.Scored -> ""
+    is ScoreState.Calibrating -> uiString(R.string.score_state_title_calibrating)
+    is ScoreState.CarriedLastNight ->
+        if (state.stale) uiString(R.string.score_state_title_latest_sleep, state.dateLabel)
+        else uiString(R.string.score_state_title_last_night, state.dateLabel)
+    ScoreState.NeedsStrap -> uiString(R.string.score_state_title_needs_strap)
+}
+
+/** The score-state detail line, LOCALIZED.
+ *
+ *  The calibrating countdown becomes a real `<plurals>`. Kotlin picked the noun with
+ *  `if (nightsRemaining == 1) "night" else "nights"`, which bakes in English's TWO categories — the
+ *  exact hand-rolling [uiPlural]'s doc warns about. `getQuantityString` applies the LOCALE's own rules
+ *  instead. (Swift splits the same sentence into two catalogue keys, so it shares the assumption; both
+ *  values here come from those keys. The one-forms carry `%1$d` where the Swift copy spelled the number
+ *  out — pt-PT said "mais uma noite" — because `i18n_audit` requires every quantity form of a plural to
+ *  share its siblings' placeholders, the check that catches a `%1$d` dropped from just one form.) */
+@Composable
+private fun scoreStateDetail(state: ScoreState): String = when (state) {
+    is ScoreState.Scored -> ""
+    is ScoreState.Calibrating ->
+        uiPlural(R.plurals.score_state_detail_calibrating, state.nightsRemaining, state.nightsRemaining)
+    is ScoreState.CarriedLastNight ->
+        if (state.stale) uiString(R.string.score_state_detail_carried_stale)
+        else uiString(R.string.score_state_detail_carried_fresh)
+    ScoreState.NeedsStrap -> uiString(R.string.score_state_detail_needs_strap)
+}
+
 /** The honest score-state note shown in the Today flow when there is no own number to render, the
  *  state title + one what-to-do line, no fabricated value. [ScoreState.Scored] renders nothing (the
  *  tiles carry the real number). The whole card is the spec's "never a bare blank". Mirrors the iOS
@@ -4130,11 +4169,16 @@ private fun ScoreStateNote(state: ScoreState, restartCause: String? = null) {
         ScoreState.NeedsStrap -> Palette.statusWarning
         else -> Palette.textTertiary
     }
+    // Resolved before the Row: `semantics { }` is not a composable scope, so uiString/uiPlural cannot be
+    // called inside it, and reading them once keeps the card and its a11y label on one string.
+    val title = scoreStateTitle(state)
+    val detail = scoreStateDetail(state)
+    val noteA11y = uiString(R.string.l10n_today_screen_state_title_state_detail_f5380609, title, detail)
     NoopCard {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .semantics { contentDescription = uiString(R.string.l10n_today_screen_state_title_state_detail_f5380609, state.title, state.detail) },
+                .semantics { contentDescription = noteA11y },
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalAlignment = Alignment.Top,
         ) {
@@ -4147,8 +4191,8 @@ private fun ScoreStateNote(state: ScoreState, restartCause: String? = null) {
                     .size(Metrics.iconSmall),
             )
             Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                Text(state.title, style = NoopType.headline, color = Palette.textPrimary)
-                Text(state.detail, style = NoopType.subhead, color = Palette.textSecondary)
+                Text(title, style = NoopType.headline, color = Palette.textPrimary)
+                Text(detail, style = NoopType.subhead, color = Palette.textSecondary)
                 // #731: when the countdown restarted because the user tapped "Recalibrate
                 // baseline", say so - otherwise the natural response to a fresh countdown is to
                 // tap it again, resetting it once more. null (no line) if never recalibrated.

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1883,4 +1883,15 @@
     <string name="recording_chip_detail_not_recording">Strap nicht verbunden. Tippe zum Verbinden.</string>
     <string name="recording_chip_detail_history_experimental">Verlaufssynchronisierung ist auf 5.0 experimentell.</string>
     <string name="recording_chip_detail_connected_no_data">Noch keine Live-Herzfrequenz und kein synchronisierter Verlauf in dieser Sitzung.</string>
+    <string name="score_state_title_calibrating">Kalibrierung</string>
+    <string name="score_state_title_needs_strap">Strap erforderlich</string>
+    <string name="score_state_title_last_night">Letzte Nacht · %1$s</string>
+    <string name="score_state_title_latest_sleep">Letzter Schlaf · %1$s</string>
+    <string name="score_state_detail_needs_strap">Keine Daten für heute. War dein Strap über Nacht getragen und verbunden?</string>
+    <string name="score_state_detail_carried_fresh">Der Wert für heute Nacht kommt, nachdem du mit dem Strap geschlafen hast.</string>
+    <string name="score_state_detail_carried_stale">Das ist deine letzte bewertete Sitzung. Trage den Strap über Nacht für einen frischen Wert.</string>
+    <plurals name="score_state_detail_calibrating">
+        <item quantity="one">Deine Basislinie wird aufgebaut. Noch etwa %1$d Nacht, bis deine Werte persönlich sind.</item>
+        <item quantity="other">Deine Basislinie wird aufgebaut. Noch etwa %1$d Nächte, bis deine Werte persönlich sind.</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1868,4 +1868,15 @@
     <string name="recording_chip_detail_not_recording">Pulsera no conectada. Toca para conectar.</string>
     <string name="recording_chip_detail_history_experimental">La sincronización del historial es experimental en la 5.0.</string>
     <string name="recording_chip_detail_connected_no_data">Aún no hay frecuencia cardíaca en vivo ni historial sincronizado en esta sesión.</string>
+    <string name="score_state_title_calibrating">Calibrando</string>
+    <string name="score_state_title_needs_strap">Necesita la banda</string>
+    <string name="score_state_title_last_night">Anoche · %1$s</string>
+    <string name="score_state_title_latest_sleep">Último sueño · %1$s</string>
+    <string name="score_state_detail_needs_strap">No hay datos de hoy. ¿Llevaste puesta y conectada tu pulsera durante la noche?</string>
+    <string name="score_state_detail_carried_fresh">El de esta noche llega después de dormir con la pulsera puesta.</string>
+    <string name="score_state_detail_carried_stale">Esta es tu última sesión puntuada. Usa la pulsera durante la noche para una puntuación nueva.</string>
+    <plurals name="score_state_detail_calibrating">
+        <item quantity="one">Construyendo tu línea base. Falta más o menos %1$d noche para que tus puntuaciones sean personales.</item>
+        <item quantity="other">Construyendo tu línea base. Faltan unas %1$d noches para que tus puntuaciones sean personales.</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1868,4 +1868,15 @@
     <string name="recording_chip_detail_not_recording">Bracelet non connecté. Touchez pour vous connecter.</string>
     <string name="recording_chip_detail_history_experimental">La synchronisation de l\'historique est expérimentale sur 5.0.</string>
     <string name="recording_chip_detail_connected_no_data">Aucune fréquence cardiaque en direct ni historique synchronisé durant cette session.</string>
+    <string name="score_state_title_calibrating">Calibration en cours</string>
+    <string name="score_state_title_needs_strap">Nécessite le bracelet</string>
+    <string name="score_state_title_last_night">La nuit dernière · %1$s</string>
+    <string name="score_state_title_latest_sleep">Dernier sommeil · %1$s</string>
+    <string name="score_state_detail_needs_strap">Pas de données pour aujourd\'hui. Votre bracelet était-il porté et connecté pendant la nuit ?</string>
+    <string name="score_state_detail_carried_fresh">Celui de ce soir arrive après avoir dormi avec le bracelet.</string>
+    <string name="score_state_detail_carried_stale">Voici votre dernière séance notée. Portez le bracelet pendant la nuit pour obtenir un nouveau score.</string>
+    <plurals name="score_state_detail_calibrating">
+        <item quantity="one">Construction de votre référence. Encore environ %1$d nuit avant que vos scores soient personnels.</item>
+        <item quantity="other">Construction de votre référence. Encore environ %1$d nuits avant que vos scores soient personnels.</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1862,4 +1862,15 @@
     <string name="recording_chip_detail_not_recording">Correia não ligada. Toque para ligar.</string>
     <string name="recording_chip_detail_history_experimental">A sincronização do histórico é experimental na versão 5.0.</string>
     <string name="recording_chip_detail_connected_no_data">Ainda não há frequência cardíaca em direto nem histórico sincronizado nesta sessão.</string>
+    <string name="score_state_title_calibrating">A calibrar</string>
+    <string name="score_state_title_needs_strap">Precisa da pega</string>
+    <string name="score_state_title_last_night">Ontem à noite · %1$s</string>
+    <string name="score_state_title_latest_sleep">Último sono · %1$s</string>
+    <string name="score_state_detail_needs_strap">Não há dados para hoje. A tua bracelete foi usada e ligada durante a noite?</string>
+    <string name="score_state_detail_carried_fresh">A noite de hoje chega depois de ter dormido com a pega.</string>
+    <string name="score_state_detail_carried_stale">Esta é a tua última sessão pontuada. Usa a bracelete durante a noite para obteres uma nova pontuação.</string>
+    <plurals name="score_state_detail_calibrating">
+        <item quantity="one">A construir a tua linha de base. Cerca de mais %1$d noite até que a tua pontuação seja pessoal.</item>
+        <item quantity="other">A construir a tua linha de base. Cerca de %1$d mais noites até que a tua pontuação seja pessoal.</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1796,4 +1796,15 @@
     <string name="recording_chip_detail_not_recording">手环未连接。点击以连接。</string>
     <string name="recording_chip_detail_history_experimental">历史同步在 5.0 上属实验性。</string>
     <string name="recording_chip_detail_connected_no_data">本次连接尚无实时心率或已同步的历史记录。</string>
+    <string name="score_state_title_calibrating">校准中</string>
+    <string name="score_state_title_needs_strap">需要手环</string>
+    <string name="score_state_title_last_night">昨晚 · %1$s</string>
+    <string name="score_state_title_latest_sleep">最近睡眠 · %1$s</string>
+    <string name="score_state_detail_needs_strap">今天没有数据。你的手环整晚都佩戴并保持连接了吗？</string>
+    <string name="score_state_detail_carried_fresh">今晚的会在你佩戴手环入睡后出现。</string>
+    <string name="score_state_detail_carried_stale">这是你上一次已评分的会话。佩戴手环过夜以获得新的评分。</string>
+    <plurals name="score_state_detail_calibrating">
+        <item quantity="one">正在建立你的基线。大约还需 %1$d 晚，你的分数就会个性化。</item>
+        <item quantity="other">正在建立你的基线。大约还需 %1$d 晚，你的分数就会个性化。</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1894,4 +1894,15 @@
     <string name="recording_chip_detail_not_recording">Strap not connected. Tap to connect.</string>
     <string name="recording_chip_detail_history_experimental">History sync is experimental on 5.0.</string>
     <string name="recording_chip_detail_connected_no_data">No live heart rate or synced history yet this session.</string>
+    <string name="score_state_title_calibrating">Calibrating</string>
+    <string name="score_state_title_needs_strap">Needs the strap</string>
+    <string name="score_state_title_last_night">Last night · %1$s</string>
+    <string name="score_state_title_latest_sleep">Latest sleep · %1$s</string>
+    <string name="score_state_detail_needs_strap">No data for today. Was your strap worn and connected overnight?</string>
+    <string name="score_state_detail_carried_fresh">Tonight\'s lands after you sleep with the strap on.</string>
+    <string name="score_state_detail_carried_stale">This is your last scored session. Wear the strap overnight for a fresh score.</string>
+    <plurals name="score_state_detail_calibrating">
+        <item quantity="one">Building your baseline. About %1$d more night until your scores are personal.</item>
+        <item quantity="other">Building your baseline. About %1$d more nights until your scores are personal.</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
Second half of the blind spot #1047 exposed. The Today score-state card renders in English on Android whatever the phone's language.

## Same asymmetry, same invisibility

```swift
// Swift — literals are catalogue KEYS
var title: LocalizedStringKey?  { is Calibrating -> "Calibrating" }
```
```kotlin
// Kotlin — plain String, rendered straight into the card
is Calibrating -> "Calibrating"   →  Text(state.title)
```

`scan_android` inspects Compose call arguments, and these literals live in a sealed-class getter, so CI never saw them. A German user reads *"Needs the strap. No data for today. Was your strap worn and connected overnight?"* where the iPhone shows German.

## `TodayScoring.kt` is untouched

Its `title`/`detail` are the English parity contract, asserted verbatim against Swift in `TodayExplainabilityTest`:

```kotlin
assertEquals("Last night · 14 Jan", state.title)
assertEquals("Tonight's lands after you sleep with the strap on.", state.detail)
```

So the lookup lives at the render site — where Swift resolves its keys too. Same split as #1047.

## The countdown becomes a real plural

Kotlin chose the noun itself:

```kotlin
val nights = if (nightsRemaining == 1) "night" else "nights"
```

That bakes in English's two categories, which is precisely what `uiPlural`'s own doc warns against. It is now a `<plurals>`, so `getQuantityString` applies each locale's rules.

Swift splits the same sentence into two catalogue keys, so it shares the assumption — both `one`/`other` values are copied from those keys rather than invented.

**One deliberate wording change:** the one-forms carry `%1$d` where the Swift copy spelled the number out (pt-PT read "mais **uma** noite"). `i18n_audit` requires every quantity form of a plural to share its siblings' placeholders — the check that catches a `%1$d` dropped from just one form — and following that rule is better than routing around it. I hit the failure, read the rule, and adjusted rather than dropping the plural.

## No other new translation

All seven strings and both plural forms already existed in `Strand/Resources/Localizable.xcstrings`, fully translated in every locale Android ships (de/es/fr/pt-PT/zh). Copied 1:1; `%@` → `%1$s`, `%lld` → `%1$d`.

## Verification

- `i18n_audit.py --ci` exits 0 — all four focus locales OK, and the plural's format signature is now consistent within every language.
- `doc_comment_lint.py` exits 0.
- `TodayScoring.kt` unchanged, so the Swift-parity assertions are unaffected.
- Android-only.

## Still unfixed, same class

Each needs its own render-site pass, and none is a regression — all three shipped in 9.3.0:

- Breathe pace copy (`Pace`, rendered at `BreatheScreen.kt:316/386/442`)
- `DeviceType.title` in Add Device (plus a hardcoded `"Device"` fallback)
- `DoubleTapAction` picker labels in Settings

The durable fix is extending `scan_android` to enum/sealed-class members so the gate stops missing this shape entirely — worth its own issue, since it will surface a backlog needing baseline entries.