### PR TITLE
Release notes for v9.3.1

### DIFF
--- a/docs/releases/v9.3.1.md
+++ b/docs/releases/v9.3.1.md
@@ -1,0 +1,111 @@
+---
+whatsnew:
+  title: "Widgets stop inventing numbers, naps count toward sleep debt, and the Android status chips speak your language"
+  date: "August 2026"
+  items:
+    - "**iPhone widgets showed made-up numbers (#887).** A Home Screen widget that could not read your data fell back to the gallery sample — 72% Charge, 58 bpm, 84% battery — for everyone. It now shows dashes when there is nothing to show, and sample values appear only in the widget gallery."
+    - "**Naps count toward sleep debt (#1041).** A separately-recorded nap now repays debt with its actual asleep minutes. Your debt figure will drop on days you napped, including days already in your history. Rest and the sleep headline still describe the main night only."
+    - "**Manual workouts on a second or re-added strap get their Avg HR back (#836).** A workout logged by hand read its heart rate from a placeholder id, so on a WHOOP 5.0 or a re-paired strap it found an empty window and left Avg HR and Effort blank."
+    - "**A connected strap no longer says it is disconnected (#612).** When the link is up but nothing is arriving, the chip said \"Not recording. Strap not connected\", which was simply false. It now says \"Connected\" and explains what is missing — and on Android that chip, and the score-state card beside it, are finally translated instead of always English."
+    - "**Effort agrees with itself on Today (#1001).** The hero ring knew about the morning's climb while the Key Metrics tile and the chart badge still read the overnight row, so the same day showed 2.3 in one place and 0.5 in two others."
+  title_locales:
+    de: "Widgets erfinden keine Zahlen mehr, Nickerchen zählen für die Schlafschuld, und die Android-Statusanzeigen sprechen deine Sprache"
+    es: "Los widgets dejan de inventar números, las siestas cuentan para la deuda de sueño y los indicadores de Android hablan tu idioma"
+    fr: "Les widgets n'inventent plus de chiffres, les siestes comptent pour la dette de sommeil, et les indicateurs Android parlent votre langue"
+    pt-PT: "Os widgets deixam de inventar números, as sestas contam para a dívida de sono, e os indicadores Android falam a tua língua"
+    zh: "小组件不再编造数字、小睡计入睡眠债，Android 状态提示也终于会说你的语言"
+---
+# NOOP v9.3.1
+
+A release about not saying things that aren't true. An iPhone widget that couldn't reach your data
+showed a plausible-looking 72% Charge to everyone; a connected strap with nothing arriving told you it
+wasn't connected; and on Android two status cards on Today were English no matter what language the
+phone was set to. Alongside those, naps now repay sleep debt, and a hand-logged workout on a second
+strap gets its heart rate back. Everything still runs on your own device, offline, with no account.
+
+## Scores that change
+
+Read this before wondering why a number moved. Four changes alter values you have already seen.
+
+- **Sleep debt falls on days you napped (#1041).** The local debt calculation now credits the actual
+  asleep minutes from separately-recorded naps, so a 48-minute nap against an 8-hour need turns 88
+  minutes of debt into 40. This applies to your history, not just to new days. A nap with no stage
+  data contributes nothing rather than guessing from its in-bed window, and an imported `sleep_debt`
+  value from a WHOOP export still passes through untouched. Rest, the Sleep hero and "Hours vs Needed"
+  deliberately continue to describe the main night alone, so those figures do not move.
+- **Effort read-outs rise to meet the ring (#1001).** Effort was resolved separately in three places
+  and only the hero ring saw the in-progress recompute; the Key Metrics tile and the heart-rate chart's
+  edge badge read the stored daily row, which is rewritten only when the heavy daily pass runs. All
+  three now resolve through one figure, so the tile and badge will read higher on a day whose morning
+  had a real heart-rate climb. Nothing moves down: a live under-read can never pull a read-out below
+  what the day already earned.
+- **Respiratory rate goes blank on nights with dropped beats (#977).** The respiratory path rebuilt
+  beat times by summing intervals, which cannot represent a stretch where no beats arrived — a 30–45
+  second dropout was stitched shut, and the discontinuity read as a breath. Windows containing such a
+  gap now return no value instead of a wrong one, so some nights will show fewer respiratory readings
+  than before. That is the honest answer, not a regression.
+- **Some nights stop reporting a clean HRV capture (#977).** The coverage classifier had a ceiling and
+  no floor, so every coverage from near-zero to 1.10 came back "plausible" — a night missing 14% of its
+  beat-time reported that its beat-time fit the wall clock. Under-coverage is now named for what it is.
+  The floor is derived from the ceiling's own rounding allowance rather than fitted to any night.
+
+## Fixed
+
+- **iPhone Home Screen widgets showed sample data as if it were yours (#887).** Both real timeline
+  paths fell back to the gallery placeholder when the shared snapshot could not be read, so every user
+  saw the same 72% Charge, 58 bpm and 84% battery. Real timelines now show missing values honestly and
+  the sample only appears in the gallery preview. Sideloaded builds also keep the App Group capability
+  through re-signing, which is why the widget could not reach your data in the first place.
+- **Manual workouts on a second or re-added strap had no Avg HR (#836).** A hand-logged workout read
+  its heart-rate window under the canonical placeholder id only, so a strap banking under its own fresh
+  id returned an empty window and left Avg HR un-reconciled and Effort un-recomputed.
+- **A connected strap could report "Strap not connected" (#612).** The recording chip only checked the
+  connection in its "Recording" branch, so a genuinely connected strap that had never synced — a fresh
+  pairing, or one whose recent offloads were all empty — fell through to the disconnected wording.
+- **Apple Health received nothing until you opened the app (#1021).** Metrics computed from a finished
+  history offload are now written when the offload lands, rather than waiting for the next foreground
+  entry.
+- **Health Connect records were day-keyed with the phone's current zone (#1002).** Each record is now
+  keyed by the offset it was actually recorded in, so travel no longer shifts imported data onto the
+  wrong day.
+
+## Added
+
+- **WHOOP MG electrocardiogram packets are decoded (#896).** The "Labrador" packet family is now
+  parsed, with a hand-run turn-on probe that ships default OFF. This is decoding work, not a feature:
+  no ECG reading is presented, and the three disclaimers around it are deliberately English-only.
+- **Custom AI gateways can send the key as `x-api-key` (#765).** The Coach's Custom provider assumed
+  `Authorization: Bearer`. The header is now selectable, Bearer stays the default, and Android also
+  falls back to `max_completion_tokens` for gateways that reject `max_tokens`.
+- **The iPhone widget shows Charge, Effort and Rest as score rings (#1022).**
+- **Low Power Mode now stops everything decorative (#909).** Animated surfaces are posed still and the
+  tilt sensor is released rather than left running.
+
+## Translation
+
+- **16 Android paragraphs were half-English (#557).** A resource string ended mid-sentence and the rest
+  of the paragraph was a hardcoded English literal, so a translated sentence finished in English. The
+  16 whose full text already existed in the Apple catalogue are repaired; 63 sites remain.
+- **The Android recording chip and score-state card are now translated (#612).** Both rendered English
+  in every locale because their text lived in a Kotlin `when` branch that the translation audit does not
+  scan. The calibrating countdown is also a real plural now rather than English's singular/plural rule
+  applied to every language.
+- **German onboarding, and the Spanish and Portuguese battery alerts, read consistently (#1029, #867).**
+
+## Under the hood
+
+Connection traces now name which of our own code paths dropped a link rather than reporting five
+different causes as one (#1020), and say what each offload burst actually achieved (#1007). Quick
+export staging and zipping moved off the main thread (#646). Importers share one capped stream reader
+(#1017), secure preferences open once per process instead of per operation (#1016), and Health Connect
+imports range-scan the calorie lists instead of walking them per workout (#1012). V1 sleep staging now
+represents an unmeasured respiration explicitly instead of asserting that breathing was regular — with
+no change to any label (#847).
+
+## Thanks
+
+Thanks to @7ygjtyfwdf-beep, @akeschmidi, @bartmuskala, @ben-tsk, @digitalerdude, @pipiche38, @Quaii,
+@SpurgtBror, @tanarchytan, @tigercraft4 and @vishk23 — for the widget fix, the nap sleep-debt credit,
+the manual-workout heart-rate fix, the connected-no-data chip, the score rings, the German onboarding
+pass, the custom AI gateway support, the export threading work, the MG ECG decoding, the Oura protocol
+findings, and the reports behind the rest.


### PR DESCRIPTION
Notes for the release, covering the **41 commits since v9.3.0**. Docs-only — `fork-release.yml` reads `docs/releases/v9.3.1.md` and generates the in-app What's New from its front-matter, so this has to land before the release is dispatched.

## What it leads on

Three of this cycle's fixes have the same shape — the app was saying something untrue:

- an iPhone Home Screen widget that couldn't reach your data showed the gallery sample (72% Charge, 58 bpm, 84% battery) on a **real** timeline (#887)
- a genuinely connected strap reported "Not recording. Strap not connected." (#612)
- two Android Today cards rendered English in every locale (#612)

## "Scores that change"

Four retroactive shifts, named rather than left to be discovered:

| change | direction |
|---|---|
| naps repay sleep debt, across existing history (#1041) | debt falls |
| Effort tile + chart badge rise to agree with the hero ring (#1001) | rises; nothing moves down |
| respiratory rate blank on nights with dropped beats (#977) | readings removed |
| under-covered nights stop reporting a clean HRV capture (#977) | verdict corrected |

Two of those take numbers away. That is deliberate — they were wrong before, and the honest answer is no number.

## Verification

- Front-matter parses: title, date, 5 items, `title_locales` for de/es/fr/pt-PT/zh.
- Ran `Tools/appchangelog-gen.py` against it as a dry run: it inserts the v9.3.1 entry into `AppChangelog.swift` and `AppChangelog.kt` and adds the localized title to all six `strings.xml` files. With those generated, `i18n_audit.py --ci` and `doc_comment_lint.py` both exit 0 — so the release commit will not land a red main.
- Those generated files are **reverted and not included here**; `fork-release.yml` regenerates and commits them itself during the bump.
- Contributor credits taken from `Tools/release-contributors.sh v9.3.0`, by handle per #736.