### PR TITLE
Batch Android stream writes in one Room transaction

### DIFF
--- a/android/app/src/main/java/com/noop/NoopApplication.kt
+++ b/android/app/src/main/java/com/noop/NoopApplication.kt
@@ -50,7 +50,7 @@ class NoopApplication : Application() {
 
     /** Process-wide Room-backed store. One instance shared by the UI and the background service. */
     val repository: WhoopRepository by lazy {
-        WhoopRepository(WhoopDatabase.get(this).whoopDao())
+        WhoopRepository(WhoopDatabase.get(this))
     }
 
     /** Process-wide device registry over the same Room DB — the single source of the active device id. */

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1,6 +1,7 @@
 package com.noop.data
 
 import android.content.Context
+import androidx.room.withTransaction
 import com.noop.protocol.DroppedRtcEvent
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -351,14 +352,29 @@ object HistoryHeal {
  * Reads.swift, MetricsCache.swift) , the phone does NO metric computation here; daily/sleep
  * rows are an offline cache of server-computed values.
  */
-class WhoopRepository(private val dao: WhoopDao) {
+class WhoopRepository(
+    private val dao: WhoopDao,
+    private val transactor: Transactor = object : Transactor {
+        override suspend fun <R> run(block: suspend () -> R): R = block()
+    },
+) {
+
+    /** Transaction boundary injected so repository writes remain testable without a Room runtime. */
+    interface Transactor {
+        suspend fun <R> run(block: suspend () -> R): R
+    }
 
     /** v18 aux rows banked since the retention sweep last ran, PER DEVICE — the sweep is per device too,
      *  so a shared counter would let one strap spend another's budget. Only the single-threaded offload
      *  path banks v18 rows, so a plain map is enough. Swift twin: `WhoopStore.v18AuxRowsSincePrune`. */
     private val v18AuxRowsSincePrune = mutableMapOf<String, Int>()
 
-    constructor(db: WhoopDatabase) : this(db.whoopDao())
+    constructor(db: WhoopDatabase) : this(
+        dao = db.whoopDao(),
+        transactor = object : Transactor {
+            override suspend fun <R> run(block: suspend () -> R): R = db.withTransaction { block() }
+        },
+    )
 
     // MARK: - Device
 
@@ -403,6 +419,23 @@ class WhoopRepository(private val dao: WhoopDao) {
     ): InsertCounts {
         if (streams.isEmpty) return InsertCounts()
 
+        return transactor.run {
+            insertWithinTransaction(
+                streams = streams,
+                deviceId = deviceId,
+                v18AuxRetentionRows = v18AuxRetentionRows,
+                v18AuxPruneEveryRows = v18AuxPruneEveryRows,
+            )
+        }
+    }
+
+    /** All DAO writes for one decoded chunk share the Room transaction opened by [insert]. */
+    private suspend fun insertWithinTransaction(
+        streams: StreamBatch,
+        deviceId: String,
+        v18AuxRetentionRows: Int,
+        v18AuxPruneEveryRows: Int,
+    ): InsertCounts {
         val hrIds = if (streams.hr.isEmpty()) emptyList() else
             dao.insertHr(streams.hr.map { HrSample(deviceId, it.ts, it.bpm) })
         val rrIds = if (streams.rr.isEmpty()) emptyList() else
@@ -477,9 +510,8 @@ class WhoopRepository(private val dao: WhoopDao) {
                 // delete is. Swift twin: `WhoopStore.v18AuxRowsSincePrune`.
                 val banked = (v18AuxRowsSincePrune[deviceId] ?: 0) + rows.size
                 v18AuxRowsSincePrune[deviceId] = banked
-                // Best-effort: the rows above are already committed, so a sweep failure must not surface
-                // as an insert failure and make Backfiller re-send a chunk it has already banked. Leaving
-                // the budget unspent means the next batch retries the sweep.
+                // Best-effort: a retention-sweep failure must not roll back the decoded rows and make
+                // Backfiller re-send the chunk. Leaving the budget unspent means the next batch retries.
                 if (banked >= v18AuxPruneEveryRows) {
                     runCatching { dao.pruneV18Aux(deviceId, v18AuxRetentionRows) }
                         .onSuccess { v18AuxRowsSincePrune[deviceId] = 0 }

--- a/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
@@ -33,7 +33,7 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
     // The networked coach, over the local store. No key is held here; the engine reads it from
     // the encrypted store at call time.
     private val aiCoach = AiCoach(
-        WhoopRepository(WhoopDatabase.get(app.applicationContext).whoopDao())
+        WhoopRepository(WhoopDatabase.get(app.applicationContext))
     )
 
     // MARK: - Transcript

--- a/android/app/src/test/java/com/noop/data/WhoopRepositoryTransactionTest.kt
+++ b/android/app/src/test/java/com/noop/data/WhoopRepositoryTransactionTest.kt
@@ -1,0 +1,74 @@
+package com.noop.data
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.reflect.Proxy
+
+class WhoopRepositoryTransactionTest {
+
+    @Test
+    fun mixedStreamBatchUsesOneTransactionForEveryDaoWrite() = runBlocking {
+        var transactionCalls = 0
+        var inTransaction = false
+        val daoCalls = mutableListOf<String>()
+        val dao = Proxy.newProxyInstance(
+            WhoopDao::class.java.classLoader,
+            arrayOf(WhoopDao::class.java),
+        ) { _, method, _ ->
+            assertTrue("${method.name} must run inside the batch transaction", inTransaction)
+            daoCalls += method.name
+            listOf(1L)
+        } as WhoopDao
+        val transactor = object : WhoopRepository.Transactor {
+            override suspend fun <R> run(block: suspend () -> R): R {
+                transactionCalls += 1
+                assertFalse("transactions must not nest", inTransaction)
+                inTransaction = true
+                return try {
+                    block()
+                } finally {
+                    inTransaction = false
+                }
+            }
+        }
+
+        val counts = WhoopRepository(dao, transactor).insert(
+            streams = StreamBatch(
+                hr = listOf(HrRow(ts = 100L, bpm = 60)),
+                rr = listOf(RrRow(ts = 100L, rrMs = 1_000)),
+                events = listOf(EventEntry(ts = 100L, kind = "test", payloadJSON = "{}")),
+            ),
+            deviceId = "my-whoop",
+        )
+
+        assertEquals(1, transactionCalls)
+        assertEquals(listOf("insertHr", "insertRr", "insertEvents"), daoCalls)
+        assertEquals(1, counts.hr)
+        assertEquals(1, counts.rr)
+        assertEquals(1, counts.events)
+        assertFalse(inTransaction)
+    }
+
+    @Test
+    fun emptyBatchSkipsTransactionAndDao() = runBlocking {
+        var transactionCalls = 0
+        val dao = Proxy.newProxyInstance(
+            WhoopDao::class.java.classLoader,
+            arrayOf(WhoopDao::class.java),
+        ) { _, method, _ ->
+            throw AssertionError("empty batch must not call ${method.name}")
+        } as WhoopDao
+        val transactor = object : WhoopRepository.Transactor {
+            override suspend fun <R> run(block: suspend () -> R): R {
+                transactionCalls += 1
+                return block()
+            }
+        }
+
+        assertEquals(InsertCounts(), WhoopRepository(dao, transactor).insert(StreamBatch(), "my-whoop"))
+        assertEquals(0, transactionCalls)
+    }
+}


### PR DESCRIPTION
## What this PR does

Wraps every DAO write for one decoded Android stream batch in a single Room transaction.

`WhoopRepository.insert` can write HR, RR, events, battery, SpO2, temperature, steps, sleep state, respiration, gravity, PPG, and v18 auxiliary rows for one history chunk. Previously each DAO call supplied its own transaction boundary. Production repository construction now retains the `WhoopDatabase` so the complete batch can use `withTransaction`; DAO-only construction remains available for plain-JVM proxy tests.

This preserves the rows, insert counts, conflict behavior, cursor handling, and ACK ordering. It reduces database transaction overhead in the history-offload path discussed in #1007 and makes a mixed batch atomic.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- Added `WhoopRepositoryTransactionTest`, which verifies that all DAO writes for a mixed stream batch run within one transaction and that an empty batch opens no transaction.
- Ran `./gradlew testFullDebugUnitTest`.
- Ran `./gradlew assembleFullDebug`.
- No real strap test was performed. This PR does not change BLE commands, chunk decoding, cursor persistence, or ACK ordering; it changes only the Room transaction boundary around the existing DAO calls.

## Checklist

- [x] Swift package tests are not applicable; no Swift package was touched
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no UI was changed
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Addresses one local-persistence cost identified in #1007.
