### PR TITLE
Add leeway to Apple BLE maintenance timers

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -525,6 +525,10 @@ public final class BLEManager: NSObject, ObservableObject {
     // The timer fires this often, but BackfillPolicy.periodicFloorSeconds is the real floor (a recent
     // event-triggered sync defers the next periodic tick). 900s = 15 min, matching WHOOP.
     static let backfillIntervalSeconds = 900
+    /// Scheduling flexibility for the long-running periodic offload timer. The offload remains no
+    /// earlier than its battery-adaptive deadline; this only lets Darwin coalesce the wake with nearby
+    /// system work instead of waking the CPU at an unnecessarily exact instant.
+    static let backfillTimerLeewaySeconds = 60
     /// #477: stretched offload cadence while low on power (45 min). The strap banks to flash meanwhile,
     /// so this only delays sync (larger batches), never loses data. Mirrors Android
     /// `LOW_BATTERY_BACKFILL_INTERVAL_MS`.
@@ -548,6 +552,9 @@ public final class BLEManager: NSObject, ObservableObject {
     /// never silently dies. Started on bond, cancelled on disconnect.
     private var keepAliveTimer: DispatchSourceTimer?
     static let keepAliveIntervalSeconds = 30
+    /// Ten-percent tolerance for the maintenance tick. Liveness decisions still use wall-clock age, so
+    /// a slightly coalesced tick cannot hide a stalled link or accumulate timing drift.
+    static let keepAliveTimerLeewaySeconds = 3
     private var keepAliveTick = 0
     /// If a persisted/missing strap-family preference points at the wrong service, a service-filtered
     /// BLE scan can run forever even though the strap is nearby (the common "won't reconnect after an
@@ -3411,7 +3418,8 @@ public final class BLEManager: NSObject, ObservableObject {
         keepAliveTimer?.cancel()
         let s = BLEManager.keepAliveIntervalSeconds
         let t = DispatchSource.makeTimerSource(queue: .main)
-        t.schedule(deadline: .now() + .seconds(s), repeating: .seconds(s))
+        t.schedule(deadline: .now() + .seconds(s), repeating: .seconds(s),
+                   leeway: .seconds(BLEManager.keepAliveTimerLeewaySeconds))
         t.setEventHandler { [weak self] in self?.keepAliveFire() }
         t.resume()
         keepAliveTimer = t
@@ -3473,7 +3481,8 @@ public final class BLEManager: NSObject, ObservableObject {
         // each tick — so the cadence can stretch/relax as power state changes (was a fixed repeating timer).
         let interval = nextBackfillInterval()
         let t = DispatchSource.makeTimerSource(queue: .main)
-        t.schedule(deadline: .now() + .seconds(interval))
+        t.schedule(deadline: .now() + .seconds(interval),
+                   leeway: .seconds(BLEManager.backfillTimerLeewaySeconds))
         t.setEventHandler { [weak self] in self?.triggerPeriodicBackfill() }
         t.resume()
         backfillTimer = t


### PR DESCRIPTION
## Summary

- add 3 seconds of leeway to the 30-second BLE keep-alive timer
- add 60 seconds of leeway to the battery-adaptive 15/45-minute backfill timer
- preserve every existing deadline, interval, BLE command, and wall-clock liveness check

Apple recommends timer tolerance so the system can coalesce CPU wakeups and spend longer idle: https://developer.apple.com/library/archive/documentation/Performance/Conceptual/EnergyGuide-iOS/MinimizeTimerUse.html

The timers never fire before their existing deadline. The keep-alive remains repeating from its original schedule, while the one-shot backfill timer is re-armed exactly as before.

## Why

Both timers currently request exact wakeups while the app maintains a long-running Bluetooth connection. These maintenance operations do not need sub-second precision. A small leeway gives iOS/macOS room to batch the work with nearby system activity without changing the app's calculations or BLE protocol behavior.

## Verification

- [x] `git diff --check`
- [x] Swift parser check: `swiftc -frontend -parse Strand/BLE/BLEManager.swift`
- [ ] Full Xcode app build (Xcode is not installed in the isolated environment)
- [ ] Device/strap smoke test

Draft because the app-target build and device smoke test still need maintainer/CI verification.
