### PR TITLE
Add tolerance to the Apple live-session timer

### DIFF
--- a/Strand/App/LiveSessionRunner.swift
+++ b/Strand/App/LiveSessionRunner.swift
@@ -37,6 +37,10 @@ final class LiveSessionRunner: ObservableObject {
     static let autoEndStaleSec = 600
     /// Where the guarded HR came from. v1 only coaches the strap's live feed (see `LiveSessionRow.hrSource`).
     static let hrSource = "whoop"
+    /// The UI/staleness tick does not need an exact wakeup. A ten-percent tolerance lets the system
+    /// coalesce it with nearby work; all elapsed-time math below still uses the wall clock, so it cannot
+    /// accumulate drift or change the session totals.
+    static let timerToleranceSec: TimeInterval = 0.1
 
     // MARK: Published state (the session screen reads ONLY these — it never observes LiveState)
 
@@ -117,9 +121,11 @@ final class LiveSessionRunner: ObservableObject {
         // Bank the in-progress row immediately (endTs nil) — a mid-session crash still leaves a record.
         persist(row(endTs: nil, band: band))
 
-        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+        let tickTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.tick() }
         }
+        tickTimer.tolerance = Self.timerToleranceSec
+        timer = tickTimer
 
         // Pocket-the-phone survival: a suspended app stops firing Timers, but CoreBluetooth keeps
         // delivering HR notifies in the background (the same path that feeds the Live Activity), and each


### PR DESCRIPTION
## Summary

- give the live-session runner's one-second `Timer` a 100 ms tolerance
- keep the existing one-second cadence and session lifecycle
- keep elapsed time, stale detection, and session totals based on wall-clock timestamps

Apple recommends setting tolerance on repeating timers so the system can combine wakeups and spend more time idle: https://developer.apple.com/documentation/foundation/timer/tolerance

## Why

An active live session keeps this timer running once per second for UI and stale-stream checks. Those checks do not require an exact sub-second deadline. A 10% tolerance gives iOS/macOS room to coalesce the wake with nearby work without changing the engine's inputs or accumulating drift.

The timer cannot fire before its scheduled date, and Foundation calculates later repeating fire dates from the original schedule. The runner also computes elapsed time from `Date`, rather than incrementing a counter on each timer callback.

## Verification

- [x] `git diff --check`
- [x] Swift parser check: `swiftc -frontend -parse Strand/App/LiveSessionRunner.swift`
- [ ] Full Xcode app build (Xcode is not installed in the isolated environment)
- [ ] Live-session device smoke test

Draft because the app-target build and device smoke test still need maintainer/CI verification.
