### PR TITLE
iOS: do not reschedule disabled debug exports

### DIFF
--- a/Strand/System/ScheduledDebugExport.swift
+++ b/Strand/System/ScheduledDebugExport.swift
@@ -135,6 +135,11 @@ enum ScheduledDebugExport {
 
     static var isEnabled: Bool { UserDefaults.standard.bool(forKey: K.enabled) }
 
+    /// A delivered BGAppRefresh request is single-shot and should schedule its successor only while the
+    /// user still has scheduled exports enabled. Keeping this policy outside the iOS-only block makes the
+    /// disable-versus-delivery race testable on every platform.
+    static func backgroundTaskShouldResubmit(enabled: Bool) -> Bool { enabled }
+
     /// Time-of-day to export, minutes since local midnight. Clamped to a valid minute. Default 07:00.
     static var timeMinutes: Int {
         let v = UserDefaults.standard.object(forKey: K.time) as? Int ?? defaultTimeMinutes
@@ -294,9 +299,14 @@ enum ScheduledDebugExport {
     /// uncalled: `submitBackgroundRequest()` fails gracefully and the macOS path + "Run now" still work.
     static func register() {
         BGTaskScheduler.shared.register(forTaskWithIdentifier: bgTaskIdentifier, using: nil) { task in
-            // Write the drop, then immediately request the next one (BGAppRefresh is single-shot).
-            if isEnabled { catchUpIfDue() }
-            submitBackgroundRequest()
+            // BGAppRefresh is single-shot. A request can already be delivering when Settings disables
+            // the feature, after `cancel` has lost the race. Do not let that stale delivery resurrect a
+            // daily background wake the user explicitly turned off.
+            let enabled = isEnabled
+            if backgroundTaskShouldResubmit(enabled: enabled) {
+                catchUpIfDue()
+                submitBackgroundRequest()
+            }
             task.setTaskCompleted(success: true)
         }
     }

--- a/StrandTests/ScheduledDebugExportTests.swift
+++ b/StrandTests/ScheduledDebugExportTests.swift
@@ -55,4 +55,9 @@ final class ScheduledDebugExportTests: XCTestCase {
         // The default (14) must be one of the choices the picker actually offers.
         XCTAssertTrue(ScheduledDebugExport.keepOptions.contains(14))
     }
+
+    func testBackgroundTaskResubmitsOnlyWhileEnabled() {
+        XCTAssertTrue(ScheduledDebugExport.backgroundTaskShouldResubmit(enabled: true))
+        XCTAssertFalse(ScheduledDebugExport.backgroundTaskShouldResubmit(enabled: false))
+    }
 }


### PR DESCRIPTION
## What changed

- gate the scheduled-export BGTask's successor request on the current enabled state
- skip both catch-up and resubmission when a stale task is delivered after the feature was disabled
- add a platform-independent policy test for enabled and disabled states

## Root cause

`setEnabled(false)` cancels the pending `BGAppRefreshTaskRequest`, but cancellation can race with a request that iOS has already begun delivering. The handler checked the preference before exporting, then unconditionally submitted tomorrow's request. A stale delivery could therefore resurrect the daily background wake after the user explicitly switched the feature off.

This change makes the delivered task a terminal no-op while disabled. Behavior while scheduled exports are enabled is unchanged.

## Existing work

#955 improves result reporting and expiration handling in the same BGTask handler. This draft isolates the separate enable-state race that remains in that PR; maintainers may prefer to fold this small guard into #955 or merge it afterward.

## Validation

- `git diff --check`
- Swift frontend parsing for the changed source and test files
- added XCTest coverage for the resubmission policy

A full iOS build/test run was not available because the local environment has Command Line Tools rather than full Xcode.
