### PR TITLE
iOS: avoid full widget rebuilds for live-only updates

### DIFF
--- a/StrandTests/WidgetSnapshotTests.swift
+++ b/StrandTests/WidgetSnapshotTests.swift
@@ -53,4 +53,59 @@ final class WidgetSnapshotTests: XCTestCase {
         XCTAssertNil(snapshot.batteryPct)
         XCTAssertFalse(snapshot.bonded)
     }
+
+    private func renderedSnapshot(updated: Date = Date(timeIntervalSince1970: 1_700_000_000)) -> WidgetSnapshot {
+        WidgetSnapshot(recovery: 72, bpm: 58, batteryPct: 84, bonded: true, updated: updated,
+                       effort: 38, rest: 81, hrv: 64, restingHr: 52,
+                       effortDisplay: "38", effortWhoop: false)
+    }
+
+    func testRenderedContentFirstPublishAlwaysChanges() {
+        XCTAssertTrue(WidgetSnapshot.renderedContentChanged(from: nil, to: renderedSnapshot()))
+    }
+
+    func testRenderedContentIgnoresTimestampOnlyChange() {
+        let previous = renderedSnapshot()
+        let next = renderedSnapshot(updated: previous.updated.addingTimeInterval(900))
+
+        XCTAssertFalse(WidgetSnapshot.renderedContentChanged(from: previous, to: next))
+    }
+
+    func testRenderedContentDetectsLiveFieldChange() {
+        let previous = renderedSnapshot()
+        var next = previous
+        next.bpm = 59
+
+        XCTAssertTrue(WidgetSnapshot.renderedContentChanged(from: previous, to: next))
+    }
+
+    func testRenderedContentDetectsScoreFieldChange() {
+        let previous = renderedSnapshot()
+        var next = previous
+        next.rest = 82
+
+        XCTAssertTrue(WidgetSnapshot.renderedContentChanged(from: previous, to: next))
+    }
+
+    func testLiveUpdateReusesSnapshotWithinSameLocalDay() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let previous = renderedSnapshot(updated: Date(timeIntervalSince1970: 1_700_000_000))
+        let oneHourLater = previous.updated.addingTimeInterval(3_600)
+
+        XCTAssertFalse(WidgetSnapshot.liveUpdateRequiresFullBuild(
+            previous: previous, now: oneHourLater, calendar: calendar))
+    }
+
+    func testLiveUpdateRequiresFullBuildAfterLocalDayRollover() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let previous = renderedSnapshot(updated: Date(timeIntervalSince1970: 1_700_000_000))
+        let nextDay = previous.updated.addingTimeInterval(86_400)
+
+        XCTAssertTrue(WidgetSnapshot.liveUpdateRequiresFullBuild(
+            previous: previous, now: nextDay, calendar: calendar))
+        XCTAssertTrue(WidgetSnapshot.liveUpdateRequiresFullBuild(
+            previous: nil, now: nextDay, calendar: calendar))
+    }
 }

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -28,6 +28,9 @@ struct StrandiOSApp: App {
     @AppStorage(AppearanceMode.storageKey) private var appearanceRaw = AppearanceMode.system.rawValue
     /// Chart data-colour style (Titanium / Classic throwback). Re-colours gauges + charts.
     @AppStorage(ChartStyle.storageKey) private var chartStyleRaw = ChartStyle.titanium.rawValue
+    /// Effort's display scale is also embedded in the shared widget snapshot. Observe it here so a
+    /// Settings change gets one accurate full rebuild instead of waiting for an unrelated repo refresh.
+    @AppStorage(UnitPrefs.effortScaleKey) private var effortScaleRaw = EffortScale.hundred.rawValue
 
     init() {
         // #1008: pin the pre-change Overnight-only default for existing installs before
@@ -144,11 +147,11 @@ struct StrandiOSApp: App {
                 // and foreground-initiated reloads are budget-exempt. dropFirst() skips the attach replay.
                 .onReceive(model.live.$batteryPct.dropFirst()) { _ in
                     guard scenePhase == .active else { return }
-                    Task { await WidgetSnapshot.publish(from: model) }
+                    Task { await WidgetSnapshot.publishLive(from: model) }
                 }
                 .onReceive(model.live.$connected.dropFirst()) { _ in
                     guard scenePhase == .active else { return }
-                    Task { await WidgetSnapshot.publish(from: model) }
+                    Task { await WidgetSnapshot.publishLive(from: model) }
                 }
                 // #114 (follow-up): `WidgetSnapshot.bpm` reads `model.bpm` (WidgetPublish.swift), the
                 // smoothed live HR — same LIVE-not-repo-cache category as battery/connected above, so it
@@ -156,11 +159,16 @@ struct StrandiOSApp: App {
                 // widget's HR froze at the last foreground snapshot for the rest of the session. UNLIKE
                 // battery/connection, HR is HIGH-frequency (the smoothed median moves every few seconds
                 // under activity), so — unlike the ungated hooks above — this one is throttled through
-                // `HRPublishThrottle` (60 s, mirroring Android's PushGate HR cadence) so it can't re-run
-                // publish's `exploreSeries` read + `reloadAllTimelines()` on every tick.
+                // `HRPublishThrottle` (60 s, mirroring Android's PushGate HR cadence). `publishLive` then
+                // updates the saved live fields without re-reading the full Rest series, while the throttle
+                // still bounds the App-Group writes + WidgetKit timeline reloads.
                 .onReceive(model.$bpm.dropFirst()) { _ in
                     guard scenePhase == .active else { return }
                     guard WidgetSnapshot.HRPublishThrottle.admit() else { return }
+                    Task { await WidgetSnapshot.publishLive(from: model) }
+                }
+                .onChange(of: effortScaleRaw) { _, _ in
+                    guard scenePhase == .active else { return }
                     Task { await WidgetSnapshot.publish(from: model) }
                 }
                 // #581: the `noop://import-health` deep link the iOS Shortcut opens after building the

--- a/StrandiOS/Widgets/WidgetPublish.swift
+++ b/StrandiOS/Widgets/WidgetPublish.swift
@@ -73,17 +73,53 @@ extension WidgetSnapshot {
             effortDisplay: effortDisplay,
             effortWhoop: effortScale == .whoop
         )
-        snap.save()
-        WidgetCenter.shared.reloadAllTimelines()
+        saveAndReloadIfChanged(snap)
+    }
+
+    /// Publish fields that come directly from the live BLE state without re-reading the Rest metric
+    /// series. HR is admitted once a minute and battery arrives about every eight minutes; routing those
+    /// hooks through the full `publish` path used to query up to 4,000 days of Rest history every time even
+    /// though none of the score fields could have changed. Reusing the last full snapshot keeps every score
+    /// byte-identical and changes only the three live fields. A cold start with no snapshot falls back to a
+    /// full build so this fast path can never publish an incomplete first glance. The first live update
+    /// after a local-day rollover also takes the full path so the score anchor advances with Today.
+    @MainActor
+    static func publishLive(from model: AppModel) async {
+        let now = Date()
+        guard var snap = load(), !liveUpdateRequiresFullBuild(previous: snap, now: now) else {
+            await publish(from: model)
+            return
+        }
+        snap.bpm = model.bpm ?? model.live.heartRate
+        snap.batteryPct = model.live.batteryPct.map { Int($0.rounded()) }
+        snap.bonded = model.live.bonded
+        snap.updated = now
+        saveAndReloadIfChanged(snap)
+    }
+
+    /// Persist and ask WidgetKit for a new timeline only when a rendered field changed. The snapshot's
+    /// timestamp is metadata only (no widget family displays it), so an otherwise-identical publish is a
+    /// true no-op rather than an App-Group write plus an extension reload.
+    @MainActor
+    private static func saveAndReloadIfChanged(_ snap: WidgetSnapshot) {
+        let previous = load()
+        if renderedContentChanged(from: previous, to: snap) {
+            snap.save()
+            WidgetCenter.shared.reloadAllTimelines()
+        } else if liveUpdateRequiresFullBuild(previous: previous, now: snap.updated) {
+            // The rollover's visible values can legitimately match yesterday's. Persist the fresh day
+            // stamp once without spending a redundant WidgetKit reload, so later live ticks stay fast.
+            snap.save()
+        }
     }
 
     /// #114/#169: HR is the ONE high-frequency widget-publish trigger — `model.bpm` moves every few
     /// seconds during activity, unlike battery (~8 min) or connection flips (rare). Left ungated, the
-    /// `model.$bpm` hook re-ran `publish`'s `exploreSeries` read + `reloadAllTimelines()` on every tick.
-    /// This caps HR-DRIVEN publishes to one per `interval`, mirroring Android's `PushGate` 60 s
-    /// `HR_REFRESH_MS` cadence. Only the bpm hook consults it; the low-frequency score/battery/connection/
-    /// scenePhase publish sites stay ungated, exactly as before. `@MainActor` (the hook already runs there),
-    /// so the shared timestamp needs no locking.
+    /// `model.$bpm` hook rewrote the shared snapshot + called `reloadAllTimelines()` on every tick (and,
+    /// before the live-only fast path, also re-read the full Rest series). This caps HR-DRIVEN publishes
+    /// to one per `interval`, mirroring Android's `PushGate` 60 s `HR_REFRESH_MS` cadence. Only the bpm
+    /// hook consults it; the low-frequency score/battery/connection/scenePhase publish sites stay ungated,
+    /// exactly as before. `@MainActor` (the hook already runs there), so the timestamp needs no locking.
     @MainActor
     enum HRPublishThrottle {
         static let interval: TimeInterval = 60

--- a/StrandiOSShared/WidgetSnapshot.swift
+++ b/StrandiOSShared/WidgetSnapshot.swift
@@ -119,4 +119,35 @@ public struct WidgetSnapshot: Codable, Equatable {
               let data = try? JSONEncoder().encode(self) else { return }
         defaults.set(data, forKey: WidgetSnapshot.storageKey)
     }
+
+    /// Whether publishing `next` would change anything the widget actually renders. `updated` is
+    /// deliberately excluded: no widget family displays it, and treating a fresh timestamp as content
+    /// would defeat deduplication because every otherwise-identical build creates a new date.
+    ///
+    /// Shared by the full score publish and the live-only fast path so a redundant foreground, repository,
+    /// battery, or connection signal does not rewrite App-Group defaults and ask WidgetKit to rebuild an
+    /// identical timeline. nil means the app has never published, so the first snapshot always writes.
+    static func renderedContentChanged(from previous: WidgetSnapshot?, to next: WidgetSnapshot) -> Bool {
+        guard let previous else { return true }
+        return previous.recovery != next.recovery
+            || previous.bpm != next.bpm
+            || previous.batteryPct != next.batteryPct
+            || previous.bonded != next.bonded
+            || previous.effort != next.effort
+            || previous.rest != next.rest
+            || previous.hrv != next.hrv
+            || previous.restingHr != next.restingHr
+            || previous.effortDisplay != next.effortDisplay
+            || previous.effortWhoop != next.effortWhoop
+    }
+
+    /// A live-only update may reuse score fields only within the same local calendar day. At rollover,
+    /// the full publisher must resolve `Repository.widgetAnchor` again so yesterday's Charge/Rest cannot
+    /// be carried forward indefinitely by a stream of HR updates. Calendar is injectable for deterministic
+    /// tests; production uses the user's current calendar and time zone.
+    static func liveUpdateRequiresFullBuild(previous: WidgetSnapshot?, now: Date,
+                                            calendar: Calendar = .current) -> Bool {
+        guard let previous else { return true }
+        return !calendar.isDate(previous.updated, inSameDayAs: now)
+    }
 }


### PR DESCRIPTION
## What changed

- add a live-only widget publish path for heart rate, battery, and connection updates
- reuse the last score snapshot instead of re-querying the computed Rest series for live-only changes
- skip App Group writes and WidgetKit reloads when no rendered value changed
- force a full rebuild on cold start, local-day rollover, repository refresh, and Effort-scale changes
- add unit coverage for rendered-content deduplication and rollover behavior

## Why

The foreground heart-rate hook is admitted once per minute, but each admitted update called the full publisher. That path asks `exploreSeries` for the Rest metric with the default 4,000-day window even though a live HR, battery, or connection change cannot alter any score field. It then rewrote the shared snapshot and requested a WidgetKit timeline reload even when the rendered values were identical.

This keeps the widget's displayed behavior intact while removing repeated database/computation work. During a live session it can avoid up to roughly 60 full Rest-series reads per hour, plus reads triggered by battery and connection events.

## Validation

- `git diff --check`
- Swift frontend parsing for every changed source and test file
- added XCTest coverage for first publish, timestamp-only deduplication, live/score changes, same-day reuse, and day rollover

A full iOS build/test run was not available because the local environment has Command Line Tools rather than full Xcode.
