### PR TITLE
Fix sleep edits not preserving the wake calendar date

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepEditGuard.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepEditGuard.swift
@@ -57,15 +57,20 @@ public enum SleepEditGuard {
         newEnd <= coverageStart || newStart >= coverageEnd
     }
 
+    /// The maximum duration of an edited sleep window. The wake date is explicit for #970, but
+    /// allowing an unbounded date change can re-bucket stages and totals onto unrelated days (#406).
+    /// One day preserves legitimate long sleep/nap corrections while rejecting multi-day windows.
+    public static let maxEditWindowSec: Int = 24 * 3600
+
     /// Rule 3: the persistence belt-and-braces. Caps the corrected wake at `now + slackSec` (a sleep
     /// cannot END in the future; the slack absorbs clock skew) and refuses (nil) any window that is
-    /// inverted or entirely in the future once capped. The editor's own guards should make this
-    /// unreachable; it exists so NO client code path can write a phantom night the display merge
-    /// cannot render.
+    /// inverted, spans more than one day, or is entirely in the future once capped. The editor's own
+    /// guards should make this unreachable; it exists so NO client code path can write a phantom night
+    /// the display merge cannot render.
     public static func clampedEditWindow(start: Int, end: Int, now: Int,
                                          slackSec: Int = 300) -> (start: Int, end: Int)? {
         let cappedEnd = min(end, now + slackSec)
-        guard cappedEnd > start else { return nil }
+        guard cappedEnd > start, cappedEnd - start <= maxEditWindowSec else { return nil }
         return (start, cappedEnd)
     }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepEditGuardTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepEditGuardTests.swift
@@ -165,4 +165,19 @@ final class SleepEditGuardTests: XCTestCase {
         XCTAssertNil(SleepEditGuard.clampedEditWindow(start: 5_000, end: 4_000, now: 10_000))
         XCTAssertNil(SleepEditGuard.clampedEditWindow(start: 5_000, end: 5_000, now: 10_000))
     }
+
+    func testOneDayWindowIsAllowedButMultiDayWindowIsRefused() {
+        let now = date(2026, 7, 17, 8, 0)
+        let bed = date(2026, 7, 16, 8, 0)
+        let oneDay = SleepEditGuard.clampedEditWindow(
+            start: Int(bed.timeIntervalSince1970), end: Int(now.timeIntervalSince1970),
+            now: Int(now.timeIntervalSince1970))
+        XCTAssertEqual(oneDay?.start, Int(bed.timeIntervalSince1970))
+        XCTAssertEqual(oneDay?.end, Int(now.timeIntervalSince1970))
+
+        XCTAssertNil(SleepEditGuard.clampedEditWindow(
+            start: Int(date(2026, 7, 16, 23, 0).timeIntervalSince1970),
+            end: Int(date(2026, 7, 18, 7, 0).timeIntervalSince1970),
+            now: Int(date(2026, 7, 18, 8, 0).timeIntervalSince1970)))
+    }
 }

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -2969,9 +2969,9 @@ private struct AddNapSeed: Identifiable {
     }
 }
 
-/// A small sheet to hand-correct a night's bed (onset) and wake (end) times. Seeds both pickers with the
-/// current values; the wake picker is bounded to after the chosen bedtime. Hands the chosen unix-second
-/// (bed, wake) back via `onSave`. Pure presentation + a single async save — persistence lives in the repo.
+/// A small sheet to hand-correct a night's bed (onset) and wake (end) instants. Seeds both pickers with
+/// the current values, including each calendar date. Hands the chosen unix-second (bed, wake) back via
+/// `onSave`. Pure presentation + a single async save — persistence lives in the repo.
 private struct SleepTimeEditor: View {
     let onSave: (Int, Int) async -> Void
     /// Optional destructive delete (#68). Non-nil for an existing main-sleep / nap edit (the editor then
@@ -3006,9 +3006,9 @@ private struct SleepTimeEditor: View {
     @State private var confirmingDisjoint = false
 
     /// `title`/`blurb`/`bedLabel`/`wakeLabel` default to the edit-an-existing-night wording; the
-    /// "Add a nap" caller (#508) overrides them. The save logic + day-derived wake are identical either
-    /// way — adding a nap is just an edit whose "existing" window is a seed. `onDelete` (#68) is the
-    /// optional destructive action; `deleteLabel` lets the nap editor say "Delete this nap".
+    /// "Add a nap" caller (#508) overrides them. The save logic is identical either way — adding a nap
+    /// is just an edit whose "existing" window is a seed. `onDelete` (#68) is the optional destructive
+    /// action; `deleteLabel` lets the nap editor say "Delete this nap".
     init(bedTs: Int, wakeTs: Int,
          title: LocalizedStringKey = "Edit sleep times",
          blurb: LocalizedStringKey = "Correct when you went to bed and woke. Stages are re-derived from your data; the edit is kept through the next strap sync.",
@@ -3032,21 +3032,6 @@ private struct SleepTimeEditor: View {
         _bed = State(initialValue: Date(timeIntervalSince1970: TimeInterval(seedBed)))
         _previousBed = State(initialValue: Date(timeIntervalSince1970: TimeInterval(seedBed)))
         _wake = State(initialValue: Date(timeIntervalSince1970: TimeInterval(wakeTs)))
-    }
-
-    /// The wake instant to save: the picked wake TIME-OF-DAY landed on the FIRST occurrence strictly after
-    /// bedtime (within 24h). The Woke picker is time-only — its calendar day is always DERIVED from bed
-    /// here — so a wake can never be dragged onto an unrelated day. That independent wake-date drag was
-    /// what silently re-bucketed a night onto the wrong day and split its stages/totals across two days
-    /// (the edit-scramble half of #406). For a normal 23:00→07:00 night this resolves 07:00 to the next
-    /// morning; for a short evening nap it resolves to the same evening.
-    private func resolvedWake() -> Date {
-        let cal = Calendar.current
-        let hm = cal.dateComponents([.hour, .minute], from: wake)
-        // `nextDate(after:matching:)` returns the first instant with that hour:minute within 24h after the
-        // anchor, so starting one minute past bed keeps wake strictly after bedtime and inside (bed, bed+24h].
-        return cal.nextDate(after: bed.addingTimeInterval(60), matching: hm, matchingPolicy: .nextTime)
-            ?? bed.addingTimeInterval(8 * 3600)
     }
 
     /// The single save funnel: both the direct Save and the #940 disjoint confirm land here.
@@ -3076,10 +3061,10 @@ private struct SleepTimeEditor: View {
                         .font(StrandFont.body)
                         .tint(StrandPalette.restColor)
                     Divider().overlay(StrandPalette.hairline)
-                    // Time-only on purpose — the wake's calendar day is derived from bed (see resolvedWake),
-                    // so an edit can't move the night to a different day and scramble its stages/totals (#406).
+                    // The wake date and time are both editable so corrections preserve the exact
+                    // endpoint selected by the user (#970).
                     DatePicker(wakeLabel, selection: $wake,
-                               displayedComponents: [.hourAndMinute])
+                               displayedComponents: [.date, .hourAndMinute])
                         .datePickerStyle(.compact)
                         .font(StrandFont.body)
                         .tint(StrandPalette.restColor)
@@ -3110,13 +3095,15 @@ private struct SleepTimeEditor: View {
                     // coverage has no data to stage from. Silently accepting it fabricated an
                     // all-awake phantom night; ask first.
                     let start = Int(bed.timeIntervalSince1970)
-                    let end = Int(resolvedWake().timeIntervalSince1970)
+                    let end = Int(wake.timeIntervalSince1970)
+                    guard let window = SleepEditGuard.clampedEditWindow(
+                        start: start, end: end, now: Int(Date().timeIntervalSince1970)) else { return }
                     if let coverage, SleepEditGuard.isDisjoint(
-                        newStart: start, newEnd: end,
+                        newStart: window.start, newEnd: window.end,
                         coverageStart: coverage.lowerBound, coverageEnd: coverage.upperBound) {
                         confirmingDisjoint = true
                     } else {
-                        commit(start: start, end: end)
+                        commit(start: window.start, end: window.end)
                     }
                 }
                 .buttonStyle(.noopPrimary)
@@ -3142,8 +3129,11 @@ private struct SleepTimeEditor: View {
         .alert("Move this sleep?", isPresented: $confirmingDisjoint) {
             Button("Cancel", role: .cancel) { }
             Button("Move anyway") {
-                commit(start: Int(bed.timeIntervalSince1970),
-                       end: Int(resolvedWake().timeIntervalSince1970))
+                guard let window = SleepEditGuard.clampedEditWindow(
+                    start: Int(bed.timeIntervalSince1970),
+                    end: Int(wake.timeIntervalSince1970),
+                    now: Int(Date().timeIntervalSince1970)) else { return }
+                commit(start: window.start, end: window.end)
             }
         } message: {
             Text("This moves the night to a time with no recorded data. Stages can't be derived there, so it may show as empty until data covers it.")

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -3034,6 +3034,14 @@ private struct SleepTimeEditor: View {
         _wake = State(initialValue: Date(timeIntervalSince1970: TimeInterval(wakeTs)))
     }
 
+    /// The current edit window after the same future/inverted/duration guards used by persistence.
+    private var validatedWindow: (start: Int, end: Int)? {
+        SleepEditGuard.clampedEditWindow(
+            start: Int(bed.timeIntervalSince1970),
+            end: Int(wake.timeIntervalSince1970),
+            now: Int(Date().timeIntervalSince1970))
+    }
+
     /// The single save funnel: both the direct Save and the #940 disjoint confirm land here.
     private func commit(start: Int, end: Int) {
         saving = true
@@ -3044,6 +3052,8 @@ private struct SleepTimeEditor: View {
     }
 
     var body: some View {
+        let canSave = validatedWindow != nil
+
         VStack(alignment: .leading, spacing: NoopMetrics.gap) {
             Text(title).font(StrandFont.title2).foregroundStyle(StrandPalette.textPrimary)
             Text(blurb)
@@ -3063,7 +3073,7 @@ private struct SleepTimeEditor: View {
                     Divider().overlay(StrandPalette.hairline)
                     // The wake date and time are both editable so corrections preserve the exact
                     // endpoint selected by the user (#970).
-                    DatePicker(wakeLabel, selection: $wake,
+                    DatePicker(wakeLabel, selection: $wake, in: ...Date(),
                                displayedComponents: [.date, .hourAndMinute])
                         .datePickerStyle(.compact)
                         .font(StrandFont.body)
@@ -3094,10 +3104,7 @@ private struct SleepTimeEditor: View {
                     // #940 guard 2: a corrected window that no longer touches the night's recorded
                     // coverage has no data to stage from. Silently accepting it fabricated an
                     // all-awake phantom night; ask first.
-                    let start = Int(bed.timeIntervalSince1970)
-                    let end = Int(wake.timeIntervalSince1970)
-                    guard let window = SleepEditGuard.clampedEditWindow(
-                        start: start, end: end, now: Int(Date().timeIntervalSince1970)) else { return }
+                    guard let window = validatedWindow else { return }
                     if let coverage, SleepEditGuard.isDisjoint(
                         newStart: window.start, newEnd: window.end,
                         coverageStart: coverage.lowerBound, coverageEnd: coverage.upperBound) {
@@ -3107,7 +3114,8 @@ private struct SleepTimeEditor: View {
                     }
                 }
                 .buttonStyle(.noopPrimary)
-                .disabled(saving)
+                .disabled(saving || !canSave)
+                .opacity(canSave ? 1 : 0.55)
             }
         }
         .padding(NoopMetrics.screenPadding)

--- a/android/app/src/main/java/com/noop/analytics/SleepEditGuard.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepEditGuard.kt
@@ -74,15 +74,22 @@ object SleepEditGuard {
         newEnd <= coverageStart || newStart >= coverageEnd
 
     /**
+     * The maximum duration of an edited sleep window. The wake date is explicit for #970, but
+     * allowing an unbounded date change can re-bucket stages and totals onto unrelated days (#406).
+     * One day preserves legitimate long sleep/nap corrections while rejecting multi-day windows.
+     */
+    const val MAX_EDIT_WINDOW_SEC: Long = 24L * 3600L
+
+    /**
      * Rule 3: the persistence belt-and-braces. Caps the corrected wake at `nowTs + slackSec` (a
      * sleep cannot END in the future; the slack absorbs clock skew) and refuses (null) any window
-     * that is inverted or entirely in the future once capped. The editor's own guards should make
-     * this unreachable; it exists so NO client code path can write a phantom night the display
-     * merge cannot render.
+     * that is inverted, spans more than one day, or is entirely in the future once capped. The
+     * editor's own guards should make this unreachable; it exists so NO client code path can write
+     * a phantom night the display merge cannot render.
      */
     fun clampedEditWindow(start: Long, end: Long, nowTs: Long, slackSec: Long = 300L): Pair<Long, Long>? {
         val cappedEnd = minOf(end, nowTs + slackSec)
-        if (cappedEnd <= start) return null
+        if (cappedEnd <= start || cappedEnd - start > MAX_EDIT_WINDOW_SEC) return null
         return start to cappedEnd
     }
 }

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -1887,7 +1887,7 @@ private fun NightNavHeader(
             val dateDialog = DatePickerDialog(
                 context,
                 { _, year, month, day ->
-                    dateChosen = true,
+                    dateChosen = true
                     val selectedDate = Calendar.getInstance().apply {
                         timeInMillis = draftForWake.endTs * 1000L
                         set(Calendar.YEAR, year); set(Calendar.MONTH, month); set(Calendar.DAY_OF_MONTH, day)

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -1877,27 +1877,49 @@ private fun NightNavHeader(
         }
     }
 
-    // Wake-up picker also mutates only the draft. Its calendar day is derived from the DRAFT bedtime,
-    // so editing bedtime first and wake second produces one coherent cross-midnight window (#515/#406).
+    // Wake-up editing mutates only the draft. Date and time are selected explicitly so a correction can
+    // preserve the exact endpoint date instead of deriving it from bedtime (#970).
     val draftForWake = sleepEditDraft
     if (editingWake && session != null && draftForWake != null) {
         val endCal = Calendar.getInstance().apply { timeInMillis = draftForWake.endTs * 1000L }
         DisposableEffect(Unit) {
-            val dialog = TimePickerDialog(
+            var dateChosen = false
+            val dateDialog = DatePickerDialog(
                 context,
-                { _, h, m ->
-                    sleepEditDraft = draftForWake.withWakeTime(hour = h, minute = m)
+                { _, year, month, day ->
+                    dateChosen = true,
+                    val selectedDate = Calendar.getInstance().apply {
+                        timeInMillis = draftForWake.endTs * 1000L
+                        set(Calendar.YEAR, year); set(Calendar.MONTH, month); set(Calendar.DAY_OF_MONTH, day)
+                    }
+                    val timeDialog = TimePickerDialog(
+                        context,
+                        { _, h, m ->
+                            selectedDate.set(Calendar.HOUR_OF_DAY, h); selectedDate.set(Calendar.MINUTE, m)
+                            selectedDate.set(Calendar.SECOND, 0); selectedDate.set(Calendar.MILLISECOND, 0)
+                            sleepEditDraft = draftForWake.withWakeCandidate(selectedDate.timeInMillis / 1000L)
+                        },
+                        endCal.get(Calendar.HOUR_OF_DAY), endCal.get(Calendar.MINUTE), true,
+                    ).apply { setTitle("Wake-up time") }
+                    timeDialog.setOnDismissListener {
+                        editingWake = false
+                        if (sleepEditDraft != null) showTimeChoice = true
+                    }
+                    timeDialog.show()
                 },
-                endCal.get(Calendar.HOUR_OF_DAY),
-                endCal.get(Calendar.MINUTE),
-                true,
-            ).apply { setTitle("Wake-up time") }
-            dialog.setOnDismissListener {
-                editingWake = false
-                if (sleepEditDraft != null) showTimeChoice = true
+                endCal.get(Calendar.YEAR), endCal.get(Calendar.MONTH), endCal.get(Calendar.DAY_OF_MONTH),
+            ).apply {
+                datePicker.maxDate = System.currentTimeMillis()
+                setTitle("Wake-up date")
+                setOnDismissListener {
+                    if (editingWake && !dateChosen) {
+                        editingWake = false
+                        if (sleepEditDraft != null) showTimeChoice = true
+                    }
+                }
             }
-            dialog.show()
-            onDispose { runCatching { dialog.dismiss() } }
+            dateDialog.show()
+            onDispose { runCatching { dateDialog.dismiss() } }
         }
     }
 

--- a/android/app/src/main/java/com/noop/ui/SleepTimeEditDraft.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepTimeEditDraft.kt
@@ -1,7 +1,6 @@
 package com.noop.ui
 
 import com.noop.analytics.SleepEditGuard
-import java.time.Instant
 import java.time.ZoneId
 
 /**
@@ -28,17 +27,10 @@ internal data class SleepTimeEditDraft(
         ),
     )
 
-    /** Resolve a picked wake time to the first occurrence strictly after the drafted bedtime. */
-    fun withWakeTime(
-        hour: Int,
-        minute: Int,
-        zone: ZoneId = ZoneId.systemDefault(),
-    ): SleepTimeEditDraft {
-        val bed = Instant.ofEpochSecond(startTs).atZone(zone)
-        var wake = bed.withHour(hour).withMinute(minute).withSecond(0).withNano(0)
-        if (!wake.isAfter(bed)) wake = wake.plusDays(1)
-        return copy(endTs = wake.toEpochSecond())
-    }
+    /** Store a complete user-selected wake instant without deriving or shifting its calendar date. */
+    fun withWakeCandidate(candidateWakeTs: Long): SleepTimeEditDraft =
+        copy(endTs = candidateWakeTs)
+
 
     fun validatedWindow(
         nowTs: Long,

--- a/android/app/src/test/java/com/noop/analytics/SleepEditGuardTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepEditGuardTest.kt
@@ -180,4 +180,16 @@ class SleepEditGuardTest {
         assertNull(SleepEditGuard.clampedEditWindow(5_000, 4_000, nowTs = 10_000))
         assertNull(SleepEditGuard.clampedEditWindow(5_000, 5_000, nowTs = 10_000))
     }
+
+    @Test
+    fun oneDayWindowIsAllowedButMultiDayWindowIsRefused() {
+        val now = ts(2026, 7, 17, 8, 0)
+        val bed = ts(2026, 7, 16, 8, 0)
+        assertEquals(bed to now, SleepEditGuard.clampedEditWindow(bed, now, nowTs = now))
+        assertNull(SleepEditGuard.clampedEditWindow(
+            ts(2026, 7, 16, 23, 0),
+            ts(2026, 7, 18, 7, 0),
+            nowTs = ts(2026, 7, 18, 8, 0),
+        ))
+    }
 }

--- a/android/app/src/test/java/com/noop/ui/SleepTimeEditDraftTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepTimeEditDraftTest.kt
@@ -25,7 +25,7 @@ class SleepTimeEditDraftTest {
                 nowTs = ts(2026, 7, 16, 8, 0),
                 zone = zone,
             )
-            .withWakeTime(hour = 7, minute = 0, zone = zone)
+            .withWakeCandidate(ts(2026, 7, 16, 7, 0))
 
         assertEquals(
             ts(2026, 7, 16, 0, 0) to ts(2026, 7, 16, 7, 0),
@@ -34,7 +34,7 @@ class SleepTimeEditDraftTest {
     }
 
     @Test
-    fun crossMidnightBedAndWakeResolveAsOneNight() {
+    fun explicitWakeDateIsPreservedAfterBedCorrection() {
         val original = SleepTimeEditDraft(
             startTs = ts(2026, 7, 16, 1, 6),
             endTs = ts(2026, 7, 16, 5, 0),
@@ -46,22 +46,21 @@ class SleepTimeEditDraftTest {
                 nowTs = ts(2026, 7, 16, 8, 0),
                 zone = zone,
             )
-            .withWakeTime(hour = 7, minute = 0, zone = zone)
+            .withWakeCandidate(ts(2026, 7, 18, 7, 0))
 
-        assertEquals(
-            ts(2026, 7, 15, 23, 0) to ts(2026, 7, 16, 7, 0),
-            finalDraft.validatedWindow(nowTs = ts(2026, 7, 16, 8, 0)),
-        )
+        assertEquals(ts(2026, 7, 15, 23, 0), finalDraft.startTs)
+        assertEquals(ts(2026, 7, 18, 7, 0), finalDraft.endTs)
     }
 
     @Test
-    fun wakeAtOrBeforeBedRollsToFollowingDay() {
+    fun explicitWakeBeforeBedRemainsInvalid() {
         val draft = SleepTimeEditDraft(
-            startTs = ts(2026, 7, 15, 23, 0),
-            endTs = ts(2026, 7, 16, 5, 0),
-        ).withWakeTime(hour = 22, minute = 30, zone = zone)
+            startTs = ts(2026, 7, 16, 23, 0),
+            endTs = ts(2026, 7, 17, 5, 0),
+        ).withWakeCandidate(ts(2026, 7, 16, 22, 30))
 
         assertEquals(ts(2026, 7, 16, 22, 30), draft.endTs)
+        assertNull(draft.validatedWindow(nowTs = ts(2026, 7, 17, 8, 0)))
     }
 
     @Test

--- a/android/app/src/test/java/com/noop/ui/SleepTimeEditDraftTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepTimeEditDraftTest.kt
@@ -50,6 +50,7 @@ class SleepTimeEditDraftTest {
 
         assertEquals(ts(2026, 7, 15, 23, 0), finalDraft.startTs)
         assertEquals(ts(2026, 7, 18, 7, 0), finalDraft.endTs)
+        assertNull(finalDraft.validatedWindow(nowTs = ts(2026, 7, 18, 8, 0)))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Fix the Android compilation blocker caused by the trailing comma after `dateChosen = true`.
- Keep explicit wake-date selection for #970 on both platforms.
- Reject inverted, future-ending, and multi-day edited windows at the shared persistence guard.
- Preserve legitimate same-night corrections, including the reported 5-hour endpoint correction.
- Add Android and Swift parity coverage for the 24-hour boundary and the 32-hour #406 regression shape.

## Design decision

The wake date is user-selectable to fix #970, but a date change must not silently create an unbounded multi-day sleep. A maximum 24-hour edit window preserves normal long sleep/nap corrections while preventing stages and totals from being re-bucketed across unrelated days, addressing the design conflict raised in review for #406.

## Validation

- `git diff --check` passes.
- Focused diff is based directly on upstream `main` and contains only the eight sleep editor/guard/test files.
- Android full debug unit tests were attempted, but this Windows environment has no Android SDK configured.
- Swift package tests were attempted, but Swift tooling is not installed on this Windows environment.
- Static parity review confirms Android and Swift guards and tests use the same 24-hour rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)