### PR TITLE
docs(oura): recording is motion-gated, and 0x50 MET tracks a varying input

### DIFF
--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -621,7 +621,38 @@ period is ever wanted, the consistent path is NOOP's OWN sleep staging from the 
 edit of the ring's tag.
 
 ### 6.13 Motion / activity
+
+> **⚑ RECORDING IS MOTION-GATED — the ABSENCE of a record is itself the signal (NOOP, 2026-08-02,
+> ground-truth validated).** The ring does not log on a fixed wall-clock cadence. When the wearer stops
+> moving it stops emitting, and resumes the moment movement resumes. On a measured 86-min walk containing
+> a deliberate ~3-min standing stop (17:49:16–17:52:17 UTC, per-second cadence from a Suunto `.fit`), all
+> three streams went silent together across the stop, then returned to their normal 30 s cadence:
+>
+> | stream | normal cadence | gap across the stop |
+> |---|---|---|
+> | `0x7E`/`0x7F` real_steps | 30 s | **174 s** |
+> | `0x47` motion | 30 s | **150 s** |
+> | `0x50` activity/MET | 60 s | **240 s** |
+>
+> Three independent streams agreeing rules out a decode drop or a drain artifact. **Consequences for
+> anyone consuming these streams:** (a) a gap must be read as "no motion", NOT as missing data to be
+> interpolated over — interpolating manufactures activity that did not happen; (b) any "samples × cadence"
+> total silently undercounts elapsed time and must not be used as a wall-clock duration; (c) it partly
+> re-explains the "~6–19 min holes … ring's own logging cadence" noted for `0x50` below — quiet periods,
+> not dropped records. It also means a stationary period yields NO rows to correlate, which is what
+> defeats the step-decoder test in the ⛔ entry further down.
+
 - **`0x47` `motion_events`** (variable): byte6 bits`[7:5]`=field_a, `[4:0]`=field_b; bytes7–9 = three **int8 × 8** axis magnitudes; optional bytes10–11. [ringverse]
+  - **⛔ `low_intensity` / `motion_seconds` SATURATE — they are occupancy, not cadence (NOOP, 2026-08-02).**
+    Both fields cap at **29** within a 30 s record. Across 168 records of continuous 4.6 km·h⁻¹ walking,
+    65 % of `low_intensity` and 82 % of `motion_seconds` samples are pinned at ≥ 27, mean 26.4 / 27.0,
+    max 29 / 29. They count **seconds containing motion**, not an amount or a rate of motion. `high_intensity`
+    is near-dead for walking (mean 0.4, zero in 77 % of records) — it is a vigorous-movement flag.
+    **Structural consequence: a step count or a cadence cannot be recovered from `0x47`, at any scale
+    factor.** A signal that is pinned at its ceiling throughout the entire dynamic range of interest carries
+    no information about how fast the wearer is moving — only that they are. This is an independent second
+    reason (beside the ⛔ ground-truth test below) why steps are unreachable over BLE, and it applies to the
+    Tier-A stream NOOP already trusts, so it will not be fixed by a better decode.
 - **`0x6B` `motion_period`** (variable): byte6 = header — bits`[7:6]`=period_type, bits`[5:4]`=`count` of valid codes in the **FINAL** byte, bits`[3:0]`=a rolling mod-16 sequence counter (record ordering / dedup, not a state); byte7… = 2-bit MOTION_STATE codes, 4 per byte (MSB-first), the last byte carrying `count` codes where **`count == 0` means 4** (a full final byte — the 2-bit field can't hold 4, so 4 wraps to 0; all 81 `count == 0` records in a real capture have a non-zero final byte, never 0x00, confirming 0 ⇒ 4). MOTION_STATE enum: `0 NO_MOTION, 1 RESTLESS, 2 TOSSING, 3 ACTIVE`. Same shape as the `0x4E` sleep-phase layout (header byte, codes from byte7). The header's low-nibble sequence counter increments and wraps mod-16 across consecutive records in a real capture — pinning byte6 as a header and codes at byte7, correcting an earlier reading (byte6/7 a 12-bit period, codes from byte8) that dropped the first code byte and read phantom codes from the final byte's padding. Layout cross-checked against the native `parse_api_motion_period` (attribution, not a port — re-derived from the capture). [ringverse][open_ring]
 - **`0x50` activity_info / `0x51`,`0x52` activity_summary**: activity category + intensity (MET-class). Layout **(UNVERIFIED - partial)**; [ringverse] notes real_steps/activity_info have unresolved constants. Gate on fixtures. [ringverse]
   - **`0x50` decode formula (PR #960 investigation, live Gen 3, 2026-07-02) [oura-rs]:** byte0 = a `state` code (activity-category, meaning unconfirmed); every following byte = one MET sample, `met = byte × 0.1` for `byte < 0x80`, else `met = 12.8 + (byte − 128) × 0.2` (two-slope: 0.1-MET resolution to 12.7, 0.2 steps above). **Plausible against six real Gen 3 captures** across two sessions - a full day from steady resting (0.9–1.1 MET) through a vigorous-activity burst (7.4 MET), everything physiologically sane, nothing negative or absurd - but **NOT ground-truth-validated** against the Oura app's own MET/step numbers. Stays Tier B: NOOP decodes it (`OuraDecoders.decodeActivityInfo` → `OuraEvent.activityInfo`, both platforms) but gates it behind `allowTierB`, logs it for investigation only, and never folds it into `OuraStreamMapping`/scoring - and NEVER derives a step count from it. `0x51`/`0x52` activity_summary stay fully undecoded (raw Tier-B bytes only).
@@ -637,6 +668,37 @@ edit of the ring's tag.
     HR/strain data model, so `0x50` remains a diagnostic JSONL corpus (`oura-activity-<id>.jsonl`); the ring's
     path into NOOP activity is HR (live push + banked IBI, §6.4), never MET. open_oura consumes this same
     `0x50` `met` as one input to its activity classifier (`activity_model.rs`). [open_oura-act]
+  - **✅ `0x50` MET TRACKS A VARYING INPUT — the strongest validation to date (NOOP, 2026-08-02, live Gen 3).**
+    The 2026-07-15 entry above showed MET correlating with speed over one 13-min walk; that is a *level*
+    match and could not exclude a coincidental fit (§194). This test uses a **transition** the wearer
+    deliberately created: an 86-min flat 6.5 km walk at 4.6 km·h⁻¹ containing a ~3-min standing stop,
+    against per-second cadence from a Suunto `.fit`. MET falls to a resting floor exactly when the feet stop
+    and recovers when they restart:
+
+    | minute (UTC) | MET | true steps·min⁻¹ |
+    |---|---|---|
+    | 17:49 | 5.0 | 106 |
+    | 17:50 | 2.8 | 24 |
+    | 17:51 | **1.3** | **1.7** |
+    | 17:52 | **1.2** | **0.0** |
+    | 17:53 | 1.7 | 74 ← MET lags ~1 min on recovery |
+    | 17:54 | 4.8 | 113 |
+
+    Over the whole walk **r = 0.860** (n = 88 minutes) against true step rate, and — the part that matters —
+    it is **robust**: dropping the 3 lowest-activity samples leaves r = 0.777 (contrast the `0x7E` field
+    below, which collapses 0.912 → 0.256 under the same test). Mean 4.75 MET is physiologically correct for
+    4.6 km·h⁻¹. The record count **independently re-confirms the 60 s cadence**: 86 MET samples for an
+    86-minute walk, exactly 1·min⁻¹. Two caveats kept explicit: MET has a **~1 min recovery lag**, so it
+    smears activity boundaries; and this validates that MET *tracks intensity*, NOT that the absolute MET
+    scale is calibrated against Oura's own numbers — it stays Tier B and unscored.
+  - **Walking-equivalent step estimate, scored against two reference devices (NOOP, 2026-08-02).** For the
+    same walk, `activeMinutes × 100` (MET ≥ 3.0 → 82 active min) gives **8,200** against a measured
+    **8,834** (Suunto `.fit` `total_cycles × 2`) and **7,868** (WHOOP, same walk): −7 % and +4 %. The
+    estimate lands **between two commercial devices that disagree with each other by 11 %**, which is the
+    realistic accuracy bar for any step figure. This does NOT promote the estimate: a walking-dominated
+    window is the single regime a walking-equivalent model should do best in, and it does not overturn the
+    857-day picture (median ≈ 0, p90 +186 %) that gates it. It is recorded because it bounds the error on
+    the one regime where the estimate is meant to apply.
   - **Real Steps (feature `0x0B`) server gating [open_oura-feat]:** real_steps is behind the server flag `activity/real_steps` (default **false**; `FeatureDefinitions.ActivityRealSteps`, Gen 3+), the same server-flag-off pattern as SpO2 (§7.1). This explains `0x7E`/`0x7F` never once appearing across the PR #960 live sessions - the ring isn't sending them, it is not a NOOP decode gap. `0x50` itself is an always-on base stream (not feature-gated), matching it appearing in every session.
 - **`0x7E`/`0x7F` real_steps_features 1/2** (18 B each): bit-packed step features merged across the paired events. **(UNVERIFIED - partial)** [ringverse]
   - **Unpack formula ([oura-rs] - Th0rgal/open_oura `crates/oura-protocol/src/events.rs#L566`, clean-room
@@ -679,6 +741,23 @@ edit of the ring's tag.
       reimplementing Oura's step model over these features, unvalidatable without many ground-truth days
       across varied activity. This closes the "decode steps from real_steps" line of investigation; `0x50`
       MET (above) already provides an activity signal with a validated cadence.
+  - **⚠️ A SECOND ground-truth walk did NOT rehabilitate the fields — and shows how a fake r = 0.91 arises
+    (NOOP, 2026-08-02).** An 86-min walk with per-second Suunto cadence gave 165 in-session `0x7E` records.
+    Naively, `fields[0]` correlates with true steps at **r = 0.912** — which would look like a decisive
+    result and is exactly the trap §194 warns about. It is an artifact, for two compounding reasons:
+    - **The input barely varied.** A flat 6.5 km at constant 4.6 km·h⁻¹ produces true steps per 30 s window
+      of p05 = 51.1, median = 55.2, max = 58.1 — 98 % of samples are effectively identical. Almost all the
+      apparent correlation rests on the 3–4 transition samples at the stop. **Dropping the 3 lowest-step
+      samples collapses r from 0.912 to 0.256**; restricted to the walking regime alone r = 0.355. A signal
+      that only "works" via a handful of points has not been shown to track anything.
+    - **The stop produced no rows to correlate.** Because recording is motion-gated (⚑ note at the top of
+      §6.13), the ring emitted NOTHING for 174 s across the stationary period — the one interval with real
+      contrast is precisely the interval with no data. At the single surviving low-motion sample
+      `fields[0]` reads 177 vs 365 walking: it **halves, it does not go to zero**. A counter zeroes.
+    - **Net: consistent with the fields being model features, not counts.** This walk neither refutes nor
+      supports a decode — it simply cannot discriminate, and is recorded so the r = 0.91 is not
+      rediscovered later and mistaken for validation. **A useful test needs cadence VARIATION** (mixed
+      slow/fast walking, stairs, walk/jog intervals), not a longer metronomic walk.
   - **WHY there is no step count on the wire at all — the sensor side (NOOP, 2026-08-02).** Recorded so
     this is not re-investigated:
     - **The Gen 3 IMU is a Bosch Sensortec BMI160** (public teardowns: [TechInsights], [System Plus]). That
@@ -850,6 +929,14 @@ NOOP ships a **read-only** probe that asks the ring to report a feature's own st
 - Validate all Tier-B sleep/activity/step layouts against real captures before enabling in scoring.
 - Confirm live-HR `0x02` path on actual Gen-4/Gen-5 hardware (only Gen-3 is verified in the corpus).
 - `0x68` and `0x86` are NOT emitted in the NOOP capture (0 of ~131k records) — do not hunt for them; wear inference uses `0x45/0x53` + live-HR (§6.15) and the `0x86` aohr never appears (§6.15).
+- **A step-decoder test needs cadence VARIATION, not more walking.** Both ground-truth sessions so far
+  (2026-08-01 golf, 2026-08-02 flat walk) were near-constant-cadence, which cannot discriminate a candidate
+  step field from a generic movement feature — the 2026-08-02 walk produced a spurious r = 0.912 that
+  collapses to 0.256 under a 3-sample drop (§6.13). Any future attempt should capture mixed slow/fast
+  walking, stairs, or walk/jog intervals with a per-second reference, and must clear the robustness test
+  (r must survive dropping the extreme samples) before being reported as a result. Note this is a test of
+  the *features*, not a route to a count: §6.13 records two independent structural reasons a count is not
+  on the wire at all.
 
 ---
 


### PR DESCRIPTION
Documents three findings about the Oura Gen 3 wire streams from a ground-truth session on 2026-08-02, and records why an earlier-looking correlation on `0x7E` is an artifact rather than a result.

### What this adds

**Recording is motion-gated.** The ring does not log on a fixed wall-clock cadence — it stops emitting when the wearer stops moving. On an 86-min flat 6.5 km walk containing a deliberate ~3-min standing stop, `0x7E`/`0x7F` (174 s), `0x47` (150 s) and `0x50` (240 s) went silent together across the stop and resumed at their normal cadence. Three independent streams agreeing rules out a decode drop or a drain artifact.

The consequence matters to anything consuming these streams: a gap must be read as *"no motion"*, not as missing data to interpolate over, and a "samples × cadence" product is not a wall-clock duration. It also re-explains the `0x50` logging holes noted earlier in §6.13 as quiet periods rather than dropped records.

**`0x47` `low_intensity` / `motion_seconds` saturate.** Both cap at 29 within a 30 s record; across 168 records of continuous 4.6 km·h⁻¹ walking, 65 % and 82 % of samples sit at ≥ 27. They count *seconds containing motion*, not an amount or rate of motion — so a step count or cadence cannot be recovered from `0x47` at any scale factor. This is a structural reason independent of the ground-truth test already recorded, and it applies to a Tier-A stream, so a better decode will not fix it.

**`0x50` MET tracks a varying input.** Against the deliberate stop, MET falls to a resting floor when the feet stop and recovers when they restart: **r = 0.860** over 88 minutes, and — the part that matters — robust: dropping the 3 lowest-activity samples leaves **r = 0.777**, where the `0x7E` field collapses **0.912 → 0.256** under the same test.

This is the *transition* evidence `CLAUDE.md` asks for ("prove the method tracks a varying input"), as distinct from the earlier level match which could not exclude a coincidental fit. Two caveats are kept explicit in the text: MET lags ~1 min on recovery, and this validates that MET *tracks intensity*, **not** that its absolute scale is calibrated. It stays **Tier B and unscored**.

**Why the `0x7E` r = 0.912 is not a result.** Recorded so it is not rediscovered later and mistaken for validation: the input barely varied (98 % of samples effectively identical), and the one interval with real contrast produced no rows at all because recording is motion-gated. A useful step-decoder test needs cadence **variation** — mixed slow/fast walking, stairs, walk/jog intervals — not a longer metronomic walk.

### Verification

- **Documentation only.** No code, no stored data, no test changes — the diff is `docs/OURA_PROTOCOL.md`, **+87 / −0**.
- Branched directly off `main`, so it is purely additive and does not touch 73c1dd8d (#1045) or any other v9.3.1 work.
- Findings come from a live Gen 3 ring paired to NOOP, with per-second cadence ground truth from a Suunto `.fit` for the same walk; every figure quoted is from that session's decoded streams.
- No CI job covers `docs/`; `swift-packages` is unaffected as no package source changes.