### PR TITLE
fix(android): close historical backfill drain handoff race

### DIFF
--- a/android/app/src/main/java/com/noop/ble/BackfillDrainGate.kt
+++ b/android/app/src/main/java/com/noop/ble/BackfillDrainGate.kt
@@ -1,0 +1,64 @@
+package com.noop.ble
+
+import java.util.ArrayDeque
+
+/**
+ * Serial ownership gate and queue for historical frames.
+ *
+ * Enqueueing and the empty-queue ownership handoff share one monitor. A producer therefore either
+ * leaves work for the current drain or receives a lease and starts the replacement drain; it can
+ * never enqueue into the gap between an empty poll and ownership release.
+ *
+ * [reset] advances the generation. A coroutine from the previous connection can then neither poll
+ * frames from the new connection nor release its owner, even if its `finally` block runs late.
+ */
+internal class BackfillDrainGate<T> {
+    internal data class Lease internal constructor(
+        internal val generation: Long,
+        internal val ownerId: Long,
+    )
+
+    private val lock = Any()
+    private val pending = ArrayDeque<T>()
+    private var generation = 0L
+    private var nextOwnerId = 0L
+    private var owner: Lease? = null
+
+    /** Enqueue [item], returning a lease only when the caller must start the serial drain. */
+    fun enqueue(item: T): Lease? = synchronized(lock) {
+        pending.addLast(item)
+        if (owner != null) return@synchronized null
+        Lease(generation, ++nextOwnerId).also { owner = it }
+    }
+
+    /**
+     * Return the next item for [lease]. An empty queue releases ownership atomically; a stale lease
+     * returns null without touching the current connection's owner or queue.
+     */
+    fun pollOrRelease(lease: Lease): T? = synchronized(lock) {
+        if (owner != lease) return@synchronized null
+        if (pending.isEmpty()) {
+            owner = null
+            null
+        } else {
+            pending.removeFirst()
+        }
+    }
+
+    /** Release [lease] after an exceptional drain exit. Stale releases are intentionally no-ops. */
+    fun release(lease: Lease) = synchronized(lock) {
+        if (owner == lease) owner = null
+    }
+
+    /** Drop queued frames without invalidating the current connection's drain owner. */
+    fun clear() = synchronized(lock) {
+        pending.clear()
+    }
+
+    /** Begin a new connection generation and invalidate every lease and frame from the old one. */
+    fun reset() = synchronized(lock) {
+        generation += 1
+        owner = null
+        pending.clear()
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2319,11 +2319,8 @@ class WhoopBleClient(
 
     // --- Offload frame drain (preserves START/data/END arrival order; port of routeBackfillFrame) ---
 
-    /** Ordered queue of offload frames awaiting the serial Backfiller drain. */
-    private val backfillFrameQueue = ConcurrentLinkedQueue<ByteArray>()
-
-    @Volatile
-    private var backfillDraining = false
+    /** Ordered queue + generation-safe owner for the serial Backfiller drain. */
+    private val backfillDrain = BackfillDrainGate<ByteArray>()
 
     /** Periodic re-offload + idle-watchdog tokens (handler-posted; cancelled on disconnect). */
     private val periodicBackfillRunnable = Runnable { triggerPeriodicBackfill() }
@@ -6515,16 +6512,19 @@ class WhoopBleClient(
      * END chunk assembly is never reordered. Port of `routeBackfillFrame` + the serial drain task.
      */
     private fun routeBackfillFrame(frame: ByteArray) {
-        backfillFrameQueue.add(frame)
-        if (backfillDraining) return
-        backfillDraining = true
+        val lease = backfillDrain.enqueue(frame) ?: return
         ioScope.launch {
-            // A throw from ingest() must NEVER leave backfillDraining stuck true (that would wedge the
+            var ownsDrain = true
+            // A throw from ingest() must NEVER leave the drain stuck owned (that would wedge the
             // offload — every later frame returns early and the queue never drains). finally guarantees
-            // the flag is cleared even if a chunk handler throws. (#77/#91 hardening.)
+            // the lease is released even if a chunk handler throws. (#77/#91 hardening.)
             try {
                 while (true) {
-                    val f = backfillFrameQueue.poll() ?: break
+                    val f = backfillDrain.pollOrRelease(lease)
+                    if (f == null) {
+                        ownsDrain = false
+                        break
+                    }
                     try {
                         backfiller.ingest(f)
                     } catch (t: Throwable) {
@@ -6536,7 +6536,7 @@ class WhoopBleClient(
                     }
                 }
             } finally {
-                backfillDraining = false
+                if (ownsDrain) backfillDrain.release(lease)
             }
         }
     }
@@ -6562,7 +6562,7 @@ class WhoopBleClient(
             backfilling = false
             _state.update { it.copy(backfilling = false, syncChunksThisSession = 0) }
             handler.removeCallbacks(backfillTimeoutRunnable)
-            backfillFrameQueue.clear()
+            backfillDrain.clear()
             log("Backfill: no history frames arrived — retrying request (attempt ${whoop5HistoryAttempts + 1})")
             // Bounded mid-attempt retry (whoop5HistoryAttempts < 2): AUTO_CONTINUE so the 90s event floor
             // can't suppress it — it's continuing THIS connect's offload, not a fresh periodic kick.
@@ -6758,7 +6758,7 @@ class WhoopBleClient(
             )
         } }
         handler.removeCallbacks(backfillTimeoutRunnable)
-        backfillFrameQueue.clear()
+        backfillDrain.clear()
         closeWhoop5BackfillCapture(flushSummary = true)
         log("Backfill: session ended — reason=$reason")
         // Inactivity reminder (#419): read-only hook on the natural offload completion (no cadence
@@ -7306,8 +7306,7 @@ class WhoopBleClient(
                 System.currentTimeMillis() - backfillStartedAtMs)} (interrupted)")
         }
         backfilling = false
-        backfillDraining = false
-        backfillFrameQueue.clear()
+        backfillDrain.reset()
         strapNewestTs = null
         offloadFramesThisSession = 0
         lastOffloadFrameAtMs = 0L   // #174: don't carry a stale cooldown reference into the next session

--- a/android/app/src/test/java/com/noop/ble/BackfillDrainGateTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BackfillDrainGateTest.kt
@@ -1,0 +1,66 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** Pure JVM coverage for the historical-frame drain ownership handoff. */
+class BackfillDrainGateTest {
+
+    @Test
+    fun producerBeforeEmptyHandoffLeavesWorkForCurrentOwner() {
+        val gate = BackfillDrainGate<Int>()
+        val lease = gate.enqueue(1)!!
+
+        assertEquals(1, gate.pollOrRelease(lease))
+        assertNull(gate.enqueue(2))
+        assertEquals(2, gate.pollOrRelease(lease))
+        assertNull(gate.pollOrRelease(lease))
+    }
+
+    @Test
+    fun producerAfterEmptyHandoffStartsReplacementDrain() {
+        val gate = BackfillDrainGate<Int>()
+        val firstLease = gate.enqueue(1)!!
+
+        assertEquals(1, gate.pollOrRelease(firstLease))
+        assertNull(gate.pollOrRelease(firstLease))
+
+        val replacementLease = gate.enqueue(2)
+        assertNotNull(replacementLease)
+        assertEquals(2, gate.pollOrRelease(replacementLease!!))
+        assertNull(gate.pollOrRelease(replacementLease))
+    }
+
+    @Test
+    fun resetMakesLateOldDrainHarmlessToNewConnection() {
+        val gate = BackfillDrainGate<Int>()
+        val oldLease = gate.enqueue(1)!!
+        assertNull(gate.enqueue(99))
+
+        gate.reset()
+        val newLease = gate.enqueue(2)!!
+
+        // Simulate the old coroutine resuming and then running its finally block after reconnect.
+        // It must neither see queued old-session frames nor release the new connection's owner.
+        assertNull(gate.pollOrRelease(oldLease))
+        gate.release(oldLease)
+
+        assertEquals(2, gate.pollOrRelease(newLease))
+        assertNull(gate.pollOrRelease(newLease))
+    }
+
+    @Test
+    fun exceptionalReleaseLetsNextProducerOwnDrain() {
+        val gate = BackfillDrainGate<Int>()
+        val failedLease = gate.enqueue(1)!!
+        assertEquals(1, gate.pollOrRelease(failedLease))
+
+        gate.release(failedLease)
+
+        val replacementLease = gate.enqueue(2)!!
+        assertEquals(2, gate.pollOrRelease(replacementLease))
+        assertNull(gate.pollOrRelease(replacementLease))
+    }
+}


### PR DESCRIPTION
## What this PR does

Fixes the Android historical-offload serial drain race.

`WhoopBleClient.routeBackfillFrame` previously used a volatile Boolean to claim drain ownership. A producer could enqueue after the consumer observed an empty queue but before the consumer cleared the flag; that producer saw the old drain as active and returned, leaving its frame stranded with no future wake-up. The old check/set also allowed more than one drain coroutine to start concurrently.

This PR adds `BackfillDrainGate`, which makes enqueueing and empty-queue ownership release one monitor-protected transition. A drain lease is unique and connection-generation aware, so a late coroutine from a disconnected session cannot consume new-session frames or release the new session's owner. Queue clearing for same-session timeout/completion is preserved; `reset()` is used at connection teardown.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- Targeted JVM race coverage: `:app:testFullDebugUnitTest --tests com.noop.ble.BackfillDrainGateTest` — 4 tests, 0 failures, 0 errors, 0 skipped.
- Full Android suite: `:app:testFullDebugUnitTest` under CI-like `JAVA_TOOL_OPTIONS=-Duser.country=US -Duser.language=en` — 3,450 tests, 0 failures, 0 errors, 5 skipped.
- Android packaging: `:app:assembleFullDebug` — BUILD SUCCESSFUL in 3m03s.
- Built APK: 28,407,460 bytes; SHA-256 `729563F98ED7BD0FC0DA10DBFBA92B1F81B6F326540497239DF5456424AC4921`.
- APK signature: `apksigner` v2 verified; debug certificate SHA-256 `4511d9037513f582e52a82ac03d8f928655d29e86a21245dce59a133a2fee3ab`.
- Room schema input: `:app:syncRoomSchemaSnapshot --rerun-tasks` passed before the test runs.

The workstation's default `pl_PL` locale makes three unrelated existing tests fail because they assert English decimal formatting or an English-only coach fixture (`AiCoachContextTest` and two `StandardHrSensorFormatTest` cases). The same unchanged baseline passes under the `en_US` JVM locale used above; no locale or analytics code is included here.

### Real hardware no-regression evidence

The same historical-drain handoff fix was exercised in the personal Android build on a Solana Saga (Android 14) with a WHOOP 5.0 `WG50_r52`, firmware `50.39.1.0`:

- encrypted bond and live HR remained active;
- one v18 offload delivered 474 frames in 2.3 seconds and persisted 583 rows, including 254 motion and 254 skin-temperature rows;
- a manual follow-up delivered 77 frames / 72 rows and then 11 frames / 15 rows;
- the final trim sentinel was `0xFFFFFFFF`, confirming the strap was caught up.

This is a no-regression offload check on real WHOOP 5 hardware. It is not a claim that the rare scheduling race was physically reproduced; deterministic JVM tests cover both handoff interleavings and the late-reset owner case.

## Checklist

- [ ] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [ ] No new build warnings introduced (Gradle emitted the pre-existing SDK XML v4 compatibility warning from the local toolchain)
- [ ] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

No existing issue appears to cover this Android queue handoff defect. It was found during real-device WHOOP 5 offload validation.