### PR TITLE
fix(android): reject manual workouts ending in the future

### DIFF
--- a/android/app/src/main/java/com/noop/ui/WorkoutEditing.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutEditing.kt
@@ -365,13 +365,19 @@ object WorkoutEditing {
         if (trimmed.isEmpty() || startSeconds > nowSeconds || startSeconds <= 0) return null
         if (avgHr != null && avgHr !in 25..250) return null
         if (energyKcal != null && (energyKcal < 0 || energyKcal > 20_000)) return null
+        val durationSeconds = durationMin.toLong() * 60L
+        // Keep both the addition and the future-end check overflow-safe. A valid start can be close to
+        // Long.MAX_VALUE in a boundary test even though production timestamps are much smaller.
+        if (durationSeconds > Long.MAX_VALUE - startSeconds) return null
+        val endSeconds = startSeconds + durationSeconds
+        if (endSeconds > nowSeconds) return null
         return WorkoutRow(
             deviceId = deviceId,
             startTs = startSeconds,
-            endTs = startSeconds + durationMin * 60L,
+            endTs = endSeconds,
             sport = trimmed,
             source = "manual",
-            durationS = durationMin * 60.0,
+            durationS = durationSeconds.toDouble(),
             energyKcal = energyKcal,
             avgHr = avgHr,
             maxHr = null,

--- a/android/app/src/test/java/com/noop/ui/WorkoutEditingTest.kt
+++ b/android/app/src/test/java/com/noop/ui/WorkoutEditingTest.kt
@@ -314,6 +314,34 @@ class WorkoutEditingTest {
         assertNull(WorkoutEditing.buildManualRow("my-whoop", start, 30, "Run", null, 99_999.0, now))
     }
 
+    @Test
+    fun buildManualRow_acceptsEndExactlyAtNow_rejectsOneSecondFuture() {
+        val now = 1_700_003_600L
+        val endingNow = WorkoutEditing.buildManualRow(
+            "my-whoop", startSeconds = now - 60, durationMin = 1, sport = "Run",
+            avgHr = null, energyKcal = null, nowSeconds = now,
+        )
+        requireNotNull(endingNow)
+        assertEquals(now, endingNow.endTs)
+
+        val endingOneSecondFuture = WorkoutEditing.buildManualRow(
+            "my-whoop", startSeconds = now - 59, durationMin = 1, sport = "Run",
+            avgHr = null, energyKcal = null, nowSeconds = now,
+        )
+        assertNull(endingOneSecondFuture)
+    }
+
+    @Test
+    fun buildManualRow_rejectsEndTimestampOverflow() {
+        val now = Long.MAX_VALUE
+        assertNull(
+            WorkoutEditing.buildManualRow(
+                "my-whoop", startSeconds = Long.MAX_VALUE - 30, durationMin = 1, sport = "Run",
+                avgHr = null, energyKcal = null, nowSeconds = now,
+            ),
+        )
+    }
+
     // MARK: - preservingCaptured
 
     @Test


### PR DESCRIPTION
## What this PR does

Reject manual workout rows whose computed end timestamp is later than the injected wall-clock `nowSeconds`. The check also guards the start-plus-duration addition against `Long` overflow. A workout ending exactly at `nowSeconds` remains valid.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- `android/gradlew.bat testFullDebugUnitTest --no-daemon --dependency-verification=off --console=plain` — 3,448 tests, 0 failures, 0 errors (5 pre-existing skips).
- `android/gradlew.bat testFullDebugUnitTest --tests com.noop.ui.WorkoutEditingTest --no-daemon --dependency-verification=off --console=plain` — 41 tests, 0 failures, 0 errors.
- `android/gradlew.bat assembleFullDebug --no-daemon --dependency-verification=off --console=plain` — passed.
- Focused cases cover end exactly at `nowSeconds`, one second beyond `nowSeconds`, and `Long.MAX_VALUE` addition overflow.
- No BLE or hardware behavior changed; real-hardware evidence is not applicable.

The local `--dependency-verification=off` flag only bypasses the existing unpinned Windows AAPT2 artifact in this checkout; no verification metadata was changed. Standard CI runs the commands without that local workaround.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Not applicable — this is a deterministic Android input-validation fix with focused regression coverage.