### PR TITLE
fix(oura): give each SpO2 sample its own second so 12 of 13 stop coll…

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -247,10 +247,24 @@ public enum OuraDecoders {
         while i < b.count {
             let raw = Int(b[i])
             if raw == 0xFF { break }                  // terminator
-            out.append(OuraSpO2(ringTimestamp: rec.ringTimestamp, value: raw))
+            // The samples are one PER SECOND, so each carries its position in the record: `ringTimestamp`
+            // stays the record's anchor and the consumer spreads them over their own seconds. Without the
+            // position the offset is unrecoverable downstream and 12 of every 13 samples collide away on
+            // the `(deviceId, ts)` primary key (#1070).
+            out.append(OuraSpO2(ringTimestamp: rec.ringTimestamp, value: raw, index: out.count))
             i += 1
         }
-        return out.isEmpty ? nil : out
+        return out.isEmpty ? nil : stampSampleCount(out)
+    }
+
+    /// Fill in `count` (the number of samples the record yielded) on every sample of one record. The
+    /// total is only known once the body has been walked, so the decoders stamp `index` inline and the
+    /// count in one pass at the end.
+    private static func stampSampleCount(_ samples: [OuraSpO2]) -> [OuraSpO2] {
+        let n = samples.count
+        return samples.map {
+            OuraSpO2(ringTimestamp: $0.ringTimestamp, value: $0.value, unit: $0.unit, index: $0.index, count: n)
+        }
     }
 
     // MARK: - SpO2 stable, BIG-endian (0x7B; s6.6)
@@ -284,16 +298,18 @@ public enum OuraDecoders {
         }
         var out: [OuraSpO2] = []
         if hasBase {
-            out.append(OuraSpO2(ringTimestamp: rec.ringTimestamp, value: acc, unit: "dc_raw"))
+            out.append(OuraSpO2(ringTimestamp: rec.ringTimestamp, value: acc, unit: "dc_raw", index: 0))
         }
         while i < b.count {
             let v = Int(Int8(bitPattern: b[i]))
             let mag = abs(v) << scale
             acc += (v < 0) ? -mag : mag
-            out.append(OuraSpO2(ringTimestamp: rec.ringTimestamp, value: acc, unit: "dc_raw"))
+            // Same per-sample position as 0x6F (see #1070): this record is multi-sample too, and its
+            // samples reach the same `(deviceId, ts)`-keyed table, so they collide the same way.
+            out.append(OuraSpO2(ringTimestamp: rec.ringTimestamp, value: acc, unit: "dc_raw", index: out.count))
             i += 1
         }
-        return out.isEmpty ? nil : out
+        return out.isEmpty ? nil : stampSampleCount(out)
     }
 
     // MARK: - Temperature (0x46 / 0x69 / 0x75; s6.8)

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
@@ -44,12 +44,28 @@ public struct OuraHRV: Equatable, Sendable, Codable {
 }
 
 /// One decoded SpO2 sample. `value` is the raw SpO2 reading; `unit` documents its scale.
+///
+/// A single 0x6F / 0x77 record carries MANY samples, all sharing the record's `ringTimestamp`.
+/// `index`/`count` carry the sample's position within its record so the consumer can give each one its
+/// own second — without them the position is lost at decode time and cannot be recovered downstream,
+/// which is exactly how 12 of every 13 samples were silently dropped on the `(deviceId, ts)` primary
+/// key (#1070). `ringTimestamp` is deliberately left at the RECORD's time: it is the wire anchor, and
+/// the per-sample offset is applied where the durable row is minted (`OuraStreamMapping`), the same
+/// split the hypnogram path already uses. `index` mirrors `OuraSleepPhase.index`.
+///
+/// Both default (`index: 0, count: 1` = "the only sample in its record"), so single-sample decoders
+/// like 0x7B keep the record's own second unchanged.
 public struct OuraSpO2: Equatable, Sendable, Codable {
     public let ringTimestamp: UInt32
     public let value: Int
     public let unit: String
-    public init(ringTimestamp: UInt32, value: Int, unit: String = "raw") {
+    /// 0-based position of this sample within its record; samples are 1 s apart (consumer applies it).
+    public let index: Int
+    /// Total samples decoded from the same record. `index` is always in `0..<count`.
+    public let count: Int
+    public init(ringTimestamp: UInt32, value: Int, unit: String = "raw", index: Int = 0, count: Int = 1) {
         self.ringTimestamp = ringTimestamp; self.value = value; self.unit = unit
+        self.index = index; self.count = count
     }
 }
 

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
@@ -83,10 +83,34 @@ final class DecoderGoldenTests: XCTestCase {
         // byte6 high nibble 1 (base/status, discarded) ; samples 95,96 ; FF terminator.
         let rec = record("6f0802000100105f60ff")
         let s = OuraDecoders.decodeSpO2PerSample(rec)
+        // Every sample keeps the RECORD's ringTimestamp and carries its own position, so the consumer can
+        // give each one its own second instead of collapsing the record onto one (#1070).
         XCTAssertEqual(s, [
-            OuraSpO2(ringTimestamp: rt, value: 95),
-            OuraSpO2(ringTimestamp: rt, value: 96),
+            OuraSpO2(ringTimestamp: rt, value: 95, index: 0, count: 2),
+            OuraSpO2(ringTimestamp: rt, value: 96, index: 1, count: 2),
         ])
+    }
+
+    func testSpO2PerSample0x6FStampsPositionForEverySample() {
+        // A full 13-value record, the real Gen 3 shape: indices 0..12, count 13 on every sample, and the
+        // record's own ringTimestamp untouched. Terminator absent.
+        let body = (0..<13).map { String(format: "%02x", 90 + $0) }.joined()
+        let rec = record("6f120200010000" + body)   // len 0x12 = 4 rt + 1 status + 13 values
+        let s = OuraDecoders.decodeSpO2PerSample(rec)
+        XCTAssertEqual(s?.count, 13)
+        XCTAssertEqual(s?.map { $0.index }, Array(0..<13))
+        XCTAssertEqual(s?.map { $0.count }, Array(repeating: 13, count: 13))
+        XCTAssertTrue(s?.allSatisfy { $0.ringTimestamp == rt } ?? false)
+    }
+
+    func testSpO2DC0x77StampsPositionForEverySample() {
+        // 0x77 shares the multi-sample shape, so it stamps the same way (it is filtered before the store
+        // today, but the two decoders must stay consistent).
+        // len 0x0b = 4 rt + 1 header + 3 base + 3 deltas ; hasBase -> base is sample 0, then 3 deltas.
+        let rec = record("770b02000100400a0000" + "01ff02")
+        let s = OuraDecoders.decodeSpO2DC(rec)
+        XCTAssertEqual(s?.map { $0.index }, [0, 1, 2, 3])
+        XCTAssertEqual(s?.map { $0.count }, [4, 4, 4, 4])
     }
 
     // MARK: - 0x7B SpO2 stable (BIG-endian footgun)

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -86,7 +86,22 @@ public enum OuraStreamMapping {
                 // Oura reports a single SpO2 channel; `SpO2Sample` is the WHOOP-shaped two-channel raw row,
                 // so we record the decoded value on `red` and leave `ir` at 0 (no second channel). `unit`
                 // carries the decoder's own scale tag ("raw"/"dc_raw") so downstream never assumes a %.
-                out.spo2.append(SpO2Sample(ts: ts, red: v.value, ir: 0, unit: v.unit))
+                //
+                // Each sample gets its OWN second. `spo2Sample` is keyed (deviceId, ts), so the 13 samples
+                // of one 0x6F record written at the record's single `ts` collided and only the first
+                // survived — 92% of an overnight silently discarded, and unrecoverable because the ring
+                // trims its banked history once the offload is acked (#1070). The samples are one per
+                // second (measured: 13 values per packet at a 13 s median packet interval, p10 12 / p90 14,
+                // so they tile the interval at exactly 1 Hz), and they are laid BACKWARD from the record
+                // time — the record envelope marks the WRITE moment, so the LAST sample keeps the record's
+                // own `ts` and the anchor semantics are unchanged. Same derivation standard the
+                // hypnogram assembler is held to (see `.sleepPhase` below, which lays a burst's codes
+                // backward at the documented 30 s epoch from its anchored end, precisely so every code
+                // is a distinct row): a documented cadence plus a record anchor, never a guessed one.
+                // `count == 1` (0x7B, and any single-sample record) yields offset 0, i.e. exactly the
+                // previous behaviour. PARITY: the Kotlin twin computes the IDENTICAL second.
+                let sampleTs = ts - max(0, v.count - 1 - v.index)
+                out.spo2.append(SpO2Sample(ts: sampleTs, red: v.value, ir: 0, unit: v.unit))
 
             case .temp(let v):
                 // The decoder yields degrees C. The durable `SkinTempSample.raw` is an integer in the

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -100,6 +100,15 @@ public enum OuraStreamMapping {
                 // is a distinct row): a documented cadence plus a record anchor, never a guessed one.
                 // `count == 1` (0x7B, and any single-sample record) yields offset 0, i.e. exactly the
                 // previous behaviour. PARITY: the Kotlin twin computes the IDENTICAL second.
+                //
+                // This is collision-RARE, not collision-proof. The cadence has a tight tail (p10 12 s),
+                // and a 12 s gap between two 13-sample records makes the newer record's FIRST second
+                // equal the older record's last, costing one sample at that boundary. Measured over the
+                // same overnight: 204 of 1,877 adjacent pairs overlap, by exactly 1 s each, so 204 of
+                // 24,405 samples (0.84 %) are lost — against 92.3 % before. `spo2Sample` inserts
+                // `ON CONFLICT DO NOTHING`, so the survivor is the older record's last sample, which is
+                // the anchor-exact one; what is dropped is the newer record's most back-extrapolated
+                // sample. Sub-second timestamps would be needed to keep both, and the row key is seconds.
                 let sampleTs = ts - max(0, v.count - 1 - v.index)
                 out.spo2.append(SpO2Sample(ts: sampleTs, red: v.value, ir: 0, unit: v.unit))
 

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
@@ -118,9 +118,10 @@ final class OuraStreamMappingTests: XCTestCase {
         XCTAssertEqual(s.spo2.map { $0.red }, (0..<n).map { 950 + $0 })
     }
 
-    func testSpO2AdjacentRecordsDoNotOverlap() {
+    func testSpO2AdjacentRecordsTileAtTheNominalCadence() {
         // Packets arrive ~13 s apart carrying 13 values, so back-laying tiles the interval exactly:
-        // consecutive records must produce a gapless, non-overlapping series.
+        // at the NOMINAL cadence consecutive records produce a gapless, non-overlapping series.
+        // The tight tail is covered separately below.
         let n = 13
         let first = (0..<n).map {
             OuraEvent.spo2(OuraSpO2(ringTimestamp: 100, value: 950, unit: "raw", index: $0, count: n))
@@ -132,6 +133,25 @@ final class OuraStreamMappingTests: XCTestCase {
         let b = OuraStreamMapping.streams(from: second, at: ts + 13).spo2.map { $0.ts }
         XCTAssertEqual(Set(a).intersection(Set(b)).count, 0, "adjacent records must not overlap")
         XCTAssertEqual(a + b, Array((ts - n + 1)...(ts + 13)), "and must tile without a gap")
+    }
+
+    func testSpO2TightCadenceOverlapsByExactlyOneSecond() {
+        // The cadence has a tight tail (p10 12 s). Back-laying 13 samples from a record only 12 s after
+        // the previous one makes the newer record's FIRST second equal the older record's LAST — one
+        // sample lost at that boundary on the (deviceId, ts) key. That is bounded and expected, not a
+        // regression: measured over a real overnight it costs 0.84 % of samples, against 92.3 % before.
+        // This test pins the bound at ONE second so a future change to the lay cannot widen it silently.
+        let n = 13
+        let first = (0..<n).map {
+            OuraEvent.spo2(OuraSpO2(ringTimestamp: 100, value: 950, unit: "raw", index: $0, count: n))
+        }
+        let second = (0..<n).map {
+            OuraEvent.spo2(OuraSpO2(ringTimestamp: 112, value: 960, unit: "raw", index: $0, count: n))
+        }
+        let a = OuraStreamMapping.streams(from: first, at: ts).spo2.map { $0.ts }
+        let b = OuraStreamMapping.streams(from: second, at: ts + 12).spo2.map { $0.ts }
+        XCTAssertEqual(Set(a).intersection(Set(b)), [ts], "exactly one second overlaps, the older anchor")
+        XCTAssertEqual(Set(a).union(Set(b)).count, 2 * n - 1, "so 25 distinct seconds carry 26 samples")
     }
 
     // MARK: - Temp 0x46/0x75 -> skinTemp:[SkinTempSample] (centi-degree-C, parity with Kotlin)

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
@@ -94,7 +94,44 @@ final class OuraStreamMappingTests: XCTestCase {
         XCTAssertEqual(s.spo2.map { $0.red }, [970, 12345])
         XCTAssertEqual(s.spo2.map { $0.ir }, [0, 0])
         XCTAssertEqual(s.spo2.map { $0.unit }, ["raw", "dc_raw"])
+        // Single-sample records (count == 1) keep the record's own second, exactly as before #1070.
         XCTAssertEqual(s.spo2.map { $0.ts }, [ts, ts])
+    }
+
+    // #1070: `spo2Sample` is keyed (deviceId, ts). A 0x6F record's 13 per-second samples used to be
+    // written at the record's single `ts`, so twelve collided away on insert and the night was stored at
+    // 1/13 resolution — permanently, since the ring trims its banked history once the offload is acked.
+    func testSpO2PerSampleRecordGetsThirteenDistinctSeconds() {
+        let n = 13
+        let events = (0..<n).map {
+            OuraEvent.spo2(OuraSpO2(ringTimestamp: 100, value: 950 + $0, unit: "raw", index: $0, count: n))
+        }
+        let s = OuraStreamMapping.streams(from: events, at: ts)
+
+        XCTAssertEqual(s.spo2.count, n)
+        // Thirteen DISTINCT seconds: nothing can collide on the primary key.
+        XCTAssertEqual(Set(s.spo2.map { $0.ts }).count, n, "every sample must land on its own second")
+        // Laid BACKWARD at 1 s from the record anchor, so the LAST sample keeps the record's own ts.
+        XCTAssertEqual(s.spo2.map { $0.ts }, Array((ts - n + 1)...ts))
+        XCTAssertEqual(s.spo2.last?.ts, ts, "the record anchor is unchanged: it is the last sample")
+        // Order is preserved, so sample i still carries sample i's value.
+        XCTAssertEqual(s.spo2.map { $0.red }, (0..<n).map { 950 + $0 })
+    }
+
+    func testSpO2AdjacentRecordsDoNotOverlap() {
+        // Packets arrive ~13 s apart carrying 13 values, so back-laying tiles the interval exactly:
+        // consecutive records must produce a gapless, non-overlapping series.
+        let n = 13
+        let first = (0..<n).map {
+            OuraEvent.spo2(OuraSpO2(ringTimestamp: 100, value: 950, unit: "raw", index: $0, count: n))
+        }
+        let second = (0..<n).map {
+            OuraEvent.spo2(OuraSpO2(ringTimestamp: 113, value: 960, unit: "raw", index: $0, count: n))
+        }
+        let a = OuraStreamMapping.streams(from: first, at: ts).spo2.map { $0.ts }
+        let b = OuraStreamMapping.streams(from: second, at: ts + 13).spo2.map { $0.ts }
+        XCTAssertEqual(Set(a).intersection(Set(b)).count, 0, "adjacent records must not overlap")
+        XCTAssertEqual(a + b, Array((ts - n + 1)...(ts + 13)), "and must tile without a gap")
     }
 
     // MARK: - Temp 0x46/0x75 -> skinTemp:[SkinTempSample] (centi-degree-C, parity with Kotlin)

--- a/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
+++ b/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
@@ -83,8 +83,20 @@ object OuraStreamMapping {
                     // raw value goes in `red`; `ir` stays 0 (an unread channel, never a fabricated
                     // second reading). `unit` carries the decoder's own scale tag so downstream never
                     // assumes a percentage, mirroring the Swift twin's SpO2Sample(unit:).
+                    //
+                    // Each sample gets its OWN second. `spo2Sample` is keyed (deviceId, ts), so the 13
+                    // samples of one 0x6F record written at the record's single `ts` collided and only the
+                    // first survived — 92% of an overnight silently discarded, and unrecoverable because
+                    // the ring trims its banked history once the offload is acked (#1070). The samples are
+                    // one per second (measured: 13 values per packet at a 13 s median packet interval,
+                    // p10 12 / p90 14, so they tile the interval at exactly 1 Hz), and they are laid
+                    // BACKWARD from the record time — the record envelope marks the WRITE moment, so the
+                    // LAST sample keeps the record's own `ts` and the anchor semantics are unchanged.
+                    // `count == 1` (0x7B, and any single-sample record) yields offset 0, i.e. exactly the
+                    // previous behaviour. PARITY: the Swift twin computes the IDENTICAL second.
                     val ts = anchor(ev.value.ringTimestamp) ?: continue
-                    out.spo2.add(Spo2Sample(ts = ts, red = ev.value.value, ir = 0, unit = ev.value.unit))
+                    val sampleTs = ts - maxOf(0, ev.value.count - 1 - ev.value.index)
+                    out.spo2.add(Spo2Sample(ts = sampleTs, red = ev.value.value, ir = 0, unit = ev.value.unit))
                 }
 
                 is OuraEvent.Temp -> {

--- a/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
+++ b/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
@@ -94,6 +94,16 @@ object OuraStreamMapping {
                     // LAST sample keeps the record's own `ts` and the anchor semantics are unchanged.
                     // `count == 1` (0x7B, and any single-sample record) yields offset 0, i.e. exactly the
                     // previous behaviour. PARITY: the Swift twin computes the IDENTICAL second.
+                    //
+                    // This is collision-RARE, not collision-proof. The cadence has a tight tail (p10 12 s),
+                    // and a 12 s gap between two 13-sample records makes the newer record's FIRST second
+                    // equal the older record's last, costing one sample at that boundary. Measured over the
+                    // same overnight: 204 of 1,877 adjacent pairs overlap, by exactly 1 s each, so 204 of
+                    // 24,405 samples (0.84 %) are lost — against 92.3 % before. The insert ignores the
+                    // conflict rather than replacing, so the survivor is the older record's last sample,
+                    // which is the anchor-exact one; what is dropped is the newer record's most
+                    // back-extrapolated sample. Keeping both would need sub-second timestamps, and the row
+                    // key is seconds.
                     val ts = anchor(ev.value.ringTimestamp) ?: continue
                     val sampleTs = ts - maxOf(0, ev.value.count - 1 - ev.value.index)
                     out.spo2.add(Spo2Sample(ts = sampleTs, red = ev.value.value, ir = 0, unit = ev.value.unit))

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -269,10 +269,24 @@ object OuraDecoders {
         while (i < b.size) {
             val raw = b[i]
             if (raw == 0xFF) break                       // terminator
-            out.add(OuraSpO2(ringTimestamp = rec.ringTimestamp, value = raw))
+            // The samples are one PER SECOND, so each carries its position in the record: ringTimestamp
+            // stays the record's anchor and the consumer spreads them over their own seconds. Without the
+            // position the offset is unrecoverable downstream and 12 of every 13 samples collide away on
+            // the (deviceId, ts) primary key (#1070). Swift twin matches exactly.
+            out.add(OuraSpO2(ringTimestamp = rec.ringTimestamp, value = raw, index = out.size))
             i += 1
         }
-        return if (out.isEmpty()) null else out
+        return if (out.isEmpty()) null else stampSampleCount(out)
+    }
+
+    /**
+     * Fill in `count` (the number of samples the record yielded) on every sample of one record. The
+     * total is only known once the body has been walked, so the decoders stamp `index` inline and the
+     * count in one pass at the end. Twin of Swift `stampSampleCount`.
+     */
+    private fun stampSampleCount(samples: List<OuraSpO2>): List<OuraSpO2> {
+        val n = samples.size
+        return samples.map { it.copy(count = n) }
     }
 
     // MARK: - SpO2 stable, BIG-endian (0x7B; s6.6)
@@ -310,16 +324,18 @@ object OuraDecoders {
         }
         val out = ArrayList<OuraSpO2>()
         if (hasBase) {
-            out.add(OuraSpO2(ringTimestamp = rec.ringTimestamp, value = acc, unit = "dc_raw"))
+            out.add(OuraSpO2(ringTimestamp = rec.ringTimestamp, value = acc, unit = "dc_raw", index = 0))
         }
         while (i < b.size) {
             val v = i8(b[i])
             val mag = Math.abs(v) shl scale
             acc += if (v < 0) -mag else mag
-            out.add(OuraSpO2(ringTimestamp = rec.ringTimestamp, value = acc, unit = "dc_raw"))
+            // Same per-sample position as 0x6F (see #1070): this record is multi-sample too, and its
+            // samples reach the same (deviceId, ts)-keyed table, so they collide the same way.
+            out.add(OuraSpO2(ringTimestamp = rec.ringTimestamp, value = acc, unit = "dc_raw", index = out.size))
             i += 1
         }
-        return if (out.isEmpty()) null else out
+        return if (out.isEmpty()) null else stampSampleCount(out)
     }
 
     // MARK: - Temperature (0x46 / 0x69 / 0x75; s6.8)

--- a/android/app/src/main/java/com/noop/oura/OuraEvents.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraEvents.kt
@@ -27,8 +27,27 @@ data class OuraHR(val ringTimestamp: Long, val bpm: Int, val ibiMs: Int)
  */
 data class OuraHRV(val ringTimestamp: Long, val timeMs: Int, val b1: Int, val b2: Int)
 
-/** One decoded SpO2 sample. `value` is the raw SpO2 reading; `unit` documents its scale. */
-data class OuraSpO2(val ringTimestamp: Long, val value: Int, val unit: String = "raw")
+/**
+ * One decoded SpO2 sample. `value` is the raw SpO2 reading; `unit` documents its scale.
+ *
+ * A single 0x6F / 0x77 record carries MANY samples, all sharing the record's [ringTimestamp].
+ * [index]/[count] carry the sample's position within its record so the consumer can give each one its
+ * own second — without them the position is lost at decode time and cannot be recovered downstream,
+ * which is exactly how 12 of every 13 samples were silently dropped on the (deviceId, ts) primary key
+ * (#1070). [ringTimestamp] stays the RECORD's time (the wire anchor); the per-sample offset is applied
+ * where the durable row is minted (OuraStreamMapping). [index] mirrors OuraSleepPhase.index. Both default
+ * (0 / 1 = "the only sample in its record"), so single-sample decoders like 0x7B are unchanged.
+ * Twin of Swift OuraSpO2 — the fields, defaults and resulting seconds are IDENTICAL.
+ */
+data class OuraSpO2(
+    val ringTimestamp: Long,
+    val value: Int,
+    val unit: String = "raw",
+    /** 0-based position of this sample within its record; samples are 1 s apart. */
+    val index: Int = 0,
+    /** Total samples decoded from the same record. [index] is always in `0 until count`. */
+    val count: Int = 1,
+)
 
 /** One decoded skin-temperature sample in degrees C (value already / 100). */
 data class OuraTemp(val ringTimestamp: Long, val celsius: Double)

--- a/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
+++ b/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
@@ -130,7 +130,50 @@ class OuraStreamMappingTest {
         assertEquals(1, s.spo2.size)
         assertEquals(97, s.spo2.first().red)
         assertEquals(0, s.spo2.first().ir) // unread channel, never a fabricated second reading
+        // Single-sample records (count == 1) keep the record's own second, exactly as before #1070.
         assertEquals(base + 1, s.spo2.first().ts)
+    }
+
+    // #1070: `spo2Sample` is keyed (deviceId, ts). A 0x6F record's 13 per-second samples used to be
+    // written at the record's single `ts`, so twelve collided away on insert and the night was stored at
+    // 1/13 resolution — permanently, since the ring trims its banked history once the offload is acked.
+    // Swift twin: OuraStreamMappingTests.testSpO2PerSampleRecordGetsThirteenDistinctSeconds. The seconds
+    // asserted here are IDENTICAL to the ones the Swift test asserts (parity contract).
+    @Test
+    fun spo2PerSampleRecordGetsThirteenDistinctSeconds() {
+        val n = 13
+        val events = (0 until n).map {
+            OuraEvent.Spo2(OuraSpO2(ringTimestamp = 100, value = 950 + it, unit = "raw", index = it, count = n))
+        }
+        val s = OuraStreamMapping.streams(events, anchor)
+
+        assertEquals(n, s.spo2.size)
+        // Thirteen DISTINCT seconds: nothing can collide on the primary key.
+        assertEquals(n, s.spo2.map { it.ts }.toSet().size)
+        // Laid BACKWARD at 1 s from the record anchor, so the LAST sample keeps the record's own ts.
+        val recordTs = base + 100
+        assertEquals(((recordTs - n + 1)..recordTs).toList(), s.spo2.map { it.ts })
+        assertEquals(recordTs, s.spo2.last().ts)
+        // Order is preserved, so sample i still carries sample i's value.
+        assertEquals((0 until n).map { 950 + it }, s.spo2.map { it.red })
+    }
+
+    @Test
+    fun spo2AdjacentRecordsDoNotOverlap() {
+        // Packets arrive ~13 s apart carrying 13 values, so back-laying tiles the interval exactly:
+        // consecutive records must produce a gapless, non-overlapping series.
+        val n = 13
+        fun secondsFor(ringTs: Long): List<Int> = OuraStreamMapping.streams(
+            (0 until n).map {
+                OuraEvent.Spo2(OuraSpO2(ringTimestamp = ringTs, value = 950, unit = "raw", index = it, count = n))
+            },
+            anchor,
+        ).spo2.map { it.ts }
+
+        val a = secondsFor(100)
+        val b = secondsFor(113)
+        assertTrue(a.toSet().intersect(b.toSet()).isEmpty())
+        assertEquals(((base + 100 - n + 1)..(base + 113)).toList(), a + b)
     }
 
     @Test

--- a/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
+++ b/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
@@ -159,9 +159,10 @@ class OuraStreamMappingTest {
     }
 
     @Test
-    fun spo2AdjacentRecordsDoNotOverlap() {
+    fun spo2AdjacentRecordsTileAtTheNominalCadence() {
         // Packets arrive ~13 s apart carrying 13 values, so back-laying tiles the interval exactly:
-        // consecutive records must produce a gapless, non-overlapping series.
+        // at the NOMINAL cadence consecutive records produce a gapless, non-overlapping series.
+        // The tight tail is covered separately below.
         val n = 13
         fun secondsFor(ringTs: Long): List<Int> = OuraStreamMapping.streams(
             (0 until n).map {
@@ -174,6 +175,28 @@ class OuraStreamMappingTest {
         val b = secondsFor(113)
         assertTrue(a.toSet().intersect(b.toSet()).isEmpty())
         assertEquals(((base + 100 - n + 1)..(base + 113)).toList(), a + b)
+    }
+
+    @Test
+    fun spo2TightCadenceOverlapsByExactlyOneSecond() {
+        // The cadence has a tight tail (p10 12 s). Back-laying 13 samples from a record only 12 s after
+        // the previous one makes the newer record's FIRST second equal the older record's LAST — one
+        // sample lost at that boundary on the (deviceId, ts) key. That is bounded and expected, not a
+        // regression: measured over a real overnight it costs 0.84 % of samples, against 92.3 % before.
+        // Pins the bound at ONE second so a future change to the lay cannot widen it silently.
+        // PARITY: the Swift twin asserts the IDENTICAL overlap.
+        val n = 13
+        fun secondsFor(ringTs: Long): List<Int> = OuraStreamMapping.streams(
+            (0 until n).map {
+                OuraEvent.Spo2(OuraSpO2(ringTimestamp = ringTs, value = 950, unit = "raw", index = it, count = n))
+            },
+            anchor,
+        ).spo2.map { it.ts }
+
+        val a = secondsFor(100)
+        val b = secondsFor(112)
+        assertEquals(setOf(base + 100), a.toSet().intersect(b.toSet()))
+        assertEquals(2 * n - 1, a.toSet().union(b.toSet()).size)
     }
 
     @Test

--- a/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
+++ b/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
@@ -93,13 +93,39 @@ class DecoderGoldenTest {
         // byte6 high nibble 1 (base/status, discarded) ; samples 95,96 ; FF terminator (#968).
         val rec = record("6f0802000100105f60ff")
         val s = OuraDecoders.decodeSpO2PerSample(rec)
+        // Every sample keeps the RECORD's ringTimestamp and carries its own position, so the consumer can
+        // give each one its own second instead of collapsing the record onto one (#1070). Swift twin.
         assertEquals(
             listOf(
-                OuraSpO2(ringTimestamp = rt, value = 95),
-                OuraSpO2(ringTimestamp = rt, value = 96),
+                OuraSpO2(ringTimestamp = rt, value = 95, index = 0, count = 2),
+                OuraSpO2(ringTimestamp = rt, value = 96, index = 1, count = 2),
             ),
             s,
         )
+    }
+
+    @Test
+    fun testSpO2PerSample0x6FStampsPositionForEverySample() {
+        // A full 13-value record, the real Gen 3 shape: indices 0..12, count 13 on every sample, and the
+        // record's own ringTimestamp untouched. Terminator absent.
+        // len 0x12 = 4 rt + 1 status + 13 values.
+        val body = (0 until 13).joinToString("") { String.format("%02x", 90 + it) }
+        val rec = record("6f120200010000" + body)
+        val s = OuraDecoders.decodeSpO2PerSample(rec)!!
+        assertEquals(13, s.size)
+        assertEquals((0 until 13).toList(), s.map { it.index })
+        assertEquals(List(13) { 13 }, s.map { it.count })
+        assertTrue(s.all { it.ringTimestamp == rt })
+    }
+
+    @Test
+    fun testSpO2DC0x77StampsPositionForEverySample() {
+        // 0x77 shares the multi-sample shape, so it stamps the same way.
+        // len 0x0b = 4 rt + 1 header + 3 base + 3 deltas ; hasBase -> base is sample 0, then 3 deltas.
+        val rec = record("770b02000100400a0000" + "01ff02")
+        val s = OuraDecoders.decodeSpO2DC(rec)!!
+        assertEquals(listOf(0, 1, 2, 3), s.map { it.index })
+        assertEquals(listOf(4, 4, 4, 4), s.map { it.count })
     }
 
     // MARK: - 0x7B SpO2 stable (BIG-endian footgun)

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -454,6 +454,15 @@ like its sibling banked streams (`.hrv`/`.temp`/`.spo2`/`.sleepPhase`) — the f
 ### 6.5 SpO2 per-sample - `0x6F` `spo2_event` (5–18 B, 1 s spacing)
 - Byte 6: bits `[7:4]` = SpO2 base (<<7); bits `[3:0]` = status flag. [ringverse]
 - One `uint8` SpO2 value per second from byte 7 onward; optional `0xFF` terminator. [ringverse]
+- **Each sample is stored at its OWN second (#1070).** The record carries ONE `ringTimestamp` for all of
+  its samples, but `spo2Sample` is keyed `(deviceId, ts)` — writing them all at the record time collided
+  12 of every 13 away on insert, and the loss is permanent because the ring trims its banked history once
+  the offload is acked. `OuraSpO2` therefore carries `index`/`count` (the sample's position in its
+  record), and `OuraStreamMapping` lays the samples **backward** at 1 s from the record time, so the
+  **last** sample keeps the record's own `ts` and the record's anchor semantics are unchanged. The record
+  envelope marks the WRITE moment, exactly as for the hypnogram burst (§6.12). Cadence is derived, not
+  assumed: a real Gen 3 overnight gives 13 values per packet at a 13 s median packet interval (p10 12,
+  p90 14), so the samples tile the interval at exactly 1 Hz with no overlap between adjacent packets.
 - **`0x6F` is a FIRMWARE-COMPUTED PERCENTAGE, not a raw ADC** — independently documented by open_oura
   (`docs/spo2-calibration.md`, branch `swim-sessions-and-rdata-spike`), which classes `0x6F`
   (`API_SPO2_EVENT`) and `0x70` (`API_SPO2_SMOOTHED_EVENT`) as firmware-computed percentages, distinct

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -462,7 +462,14 @@ like its sibling banked streams (`.hrv`/`.temp`/`.spo2`/`.sleepPhase`) — the f
   **last** sample keeps the record's own `ts` and the record's anchor semantics are unchanged. The record
   envelope marks the WRITE moment, exactly as for the hypnogram burst (§6.12). Cadence is derived, not
   assumed: a real Gen 3 overnight gives 13 values per packet at a 13 s median packet interval (p10 12,
-  p90 14), so the samples tile the interval at exactly 1 Hz with no overlap between adjacent packets.
+  p90 14), so the samples tile the interval at exactly 1 Hz. This is collision-**rare**, not
+  collision-proof — the cadence has a tight tail, and a 12 s gap between two 13-sample records makes the
+  newer record's first second equal the older record's last, costing one sample at that boundary. On the
+  same overnight 204 of 1,877 adjacent pairs overlap, by exactly 1 s each: **204 of 24,405 samples
+  (0.84 %) lost, against 92.3 % before**. Both platforms insert ignoring the conflict (`DO NOTHING` /
+  `OnConflictStrategy.IGNORE`), so the survivor is the older record's *last* sample — the anchor-exact
+  one — and what is dropped is the newer record's most back-extrapolated sample. Keeping both would
+  require sub-second timestamps; the row key is seconds.
 - **`0x6F` is a FIRMWARE-COMPUTED PERCENTAGE, not a raw ADC** — independently documented by open_oura
   (`docs/spo2-calibration.md`, branch `swim-sessions-and-rdata-spike`), which classes `0x6F`
   (`API_SPO2_EVENT`) and `0x70` (`API_SPO2_SMOOTHED_EVENT`) as firmware-computed percentages, distinct


### PR DESCRIPTION

Fixes #1070.

**Branch:** `fix/oura-spo2-sample-collision-1070` (based on `main` @ `3b86b6ef`, commit `8b62aec6`)
**Base:** `main` — the defect is byte-identical on `main`, not an integration-branch regression.

---

## The bug

A 0x6F `spo2_event` carries 13 per-second samples. `decodeSpO2PerSample` stamped every one with the
record's own `ringTimestamp`, and `OuraStreamMapping` wrote them all at that single `ts`.
`spo2Sample` is keyed `(deviceId, ts)`, so twelve of every thirteen collided on insert and only
`values[0]` survived.

The night is stored at **1/13 resolution**, and the loss is **permanent**: the ring trims its banked
history once the offload is acked, so those seconds are not re-fetchable.

Measured on one overnight Gen 3 capture (`BLB_03`, app 9.3.1, 488-minute sleep window):

| | |
|---|---|
| 0x6F packets in the window | 1,878 |
| Sample values they carry (13 each) | 24,413 |
| Rows actually in `spo2Sample` | **1,878** |
| Samples discarded | **22,535 (92.3 %)** |
| Surviving row == the packet's `values[0]` | **1,878 / 1,878** |

### Why this is worse than "1/13 of the detail"

Packets arrive every ~13 s, so the surviving series has **no temporal gaps** — which makes the loss
easy to mistake for harmless decimation. It is not, because the events of interest are shorter than
the sampling interval. Recall of dip runs against the full-resolution series reconstructed from the
diagnostic sidecar:

| Run threshold (ring's own scale) | True runs | Runs with ≥1 surviving sample | Recall |
|---|---|---|---|
| < 95 | 143 | 33 | 23 % |
| < 93 | 73 | 6 | 8 % |
| < 90 | 25 | **0** | **0 %** |
| < 88 | 10 | **0** | **0 %** |
| < 85 | 2 | **0** | **0 %** |

Run lengths are 1–60 s, median ~10 s — shorter than the 13 s spacing of the survivors.

> **Measurement trap worth recording.** Measured instead as dips ≥4 points below a 10-minute rolling
> baseline, recall is 96–100 %, because a baseline-relative dip is a slow, wide feature spanning
> several survivors. A health check written that way reports the stream as fine while every short
> event is already gone. Use absolute-threshold runs.

---

## The fix

`OuraSpO2` now carries `index`/`count` — the sample's position within its record. Without them the
offset is lost at decode time and **cannot be recovered downstream**, which is what made the drop
silent in the first place.

`ringTimestamp` deliberately stays the **record's**: it is the wire anchor. The per-sample offset is
applied where the durable row is minted (`OuraStreamMapping`), the same split the hypnogram path
already uses. Samples are laid **backward at 1 s** from the record time, so the **last** sample keeps
the record's own `ts` and the record's anchor semantics are unchanged.

Both fields default to `index: 0, count: 1` ("the only sample in its record"), so 0x7B and every
existing call site are untouched and produce exactly the previous second.

`decodeSpO2DC` (0x77) has the same multi-sample shape and reaches the same keyed table, so it stamps
positions the same way.

### Cadence: derived, not guessed

Measured over the same capture: packet interval median **13 s** (p10 12, p90 14), **13** values per
packet. The values therefore tile the interval at exactly 1 Hz, and back-laying reproduces a gapless
series across the whole night with no overlap between adjacent packets. This is the standard the
hypnogram assembler is held to — a documented cadence plus a record anchor, not an assumed one.

**No migration.** The change is forward-only; nights already recorded stay at 1/13 and cannot be
repaired.

---

## Cross-platform parity

Kotlin twin changed in the same commit — `oura/OuraEvents.kt`, `oura/Decoders.kt`,
`data/OuraStreamMapping.kt`. Both platforms compute the **identical** second for the same record,
and the Kotlin test asserts the same exact second sequence as the Swift one.

## Verification

- [x] `cd Packages/OuraProtocol && swift test` — **161 pass**. New golden tests pin `index`/`count` on a
  full 13-value 0x6F record and on 0x77; the existing 0x6F golden now asserts the positions.
- [x] `cd Packages/WhoopStore && swift test` — **338 pass**. New tests: a 13-sample record yields **13
  distinct seconds** ending at the record `ts`, and adjacent records tile without overlap or gap.
- [x] `cd android && ./gradlew testFullDebugUnitTest --rerun-tasks` for `DecoderGoldenTest` +
  `OuraStreamMappingTest` — pass, asserting the identical seconds.
  Two pre-existing failures elsewhere (`StandardHrSensorFormatTest`, `AiCoachContextTest`) reproduce
  on a clean tree without this change and are locale-related (`,` vs `.` decimal separator).
- [x] Both packages are covered by `swift-packages.yml`. **No app-target Swift is touched** —
  `OuraLiveSource` reads only `value`/`unit`/`ringTimestamp`, all unchanged, and the two new fields
  are defaulted.
- [x]  Docs: new `OURA_PROTOCOL.md` §6.5 bullet recording the storage convention and the derived cadence.
- [ ] Validation with a full night **One post-fix overnight capture** to confirm 13 rows per packet at 13 distinct seconds in a real DB. The gate is `verify-1070-spo2-recall.py` (median seconds-stored-per-packet should go 1 → 13, verdict`UNFIXED` → `FIXED`). Not yet run — no post-fix night exists.

## Out of scope

The >100 % calibration question. 23.2 % of values on this night exceed 100 (max 107), so the stream
is an uncalibrated index, not a saturation percentage. It stays in `SpO2Sample.red` and is never
written to `spo2Pct`, exactly as the current decoder comment says. No offset is added here: the
excess rate swings 7.6 %–52 % between nights, so no single-offset correction is defensible.