### PR TITLE
fix(oura): label the R-R optical channel so scoring stops reading every beat twice

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -98,7 +98,8 @@ public enum OuraDecoders {
         for k in 0..<6 {
             guard ibi[k] > 0 else { continue }                 // drop a zero IBI, never invent one
             let amp = (Int(b[6 + k]) >> 1) << shift            // 7-bit mantissa << exponent
-            out.append(OuraIBI(ringTimestamp: rec.ringTimestamp, ibiMs: ibi[k], amplitude: amp))
+            out.append(OuraIBI(ringTimestamp: rec.ringTimestamp, ibiMs: ibi[k], amplitude: amp,
+                               channel: .ibiAmplitude))
         }
         return out.isEmpty ? nil : out
     }
@@ -165,7 +166,8 @@ public enum OuraDecoders {
             let ibi = (Int(b[i + 1]) & 0x07) | (Int(b[i]) << 3)   // high byte first
             let quality = (Int(b[i + 1]) >> 3) & 0x03
             if quality == 1 && ibi >= 300 && ibi <= 2000 {
-                out.append(OuraIBI(ringTimestamp: rec.ringTimestamp, ibiMs: ibi))
+                out.append(OuraIBI(ringTimestamp: rec.ringTimestamp, ibiMs: ibi,
+                                   channel: .greenQuality))
             }
             i += 2
             sampleCount += 1
@@ -192,7 +194,7 @@ public enum OuraDecoders {
         while idx >= 1 {
             let ibi = Int(b[idx]) * 8                  // 8-bit count x8 -> ms
             if ibi > 0 {
-                out.append(OuraIBI(ringTimestamp: rec.ringTimestamp, ibiMs: ibi))
+                out.append(OuraIBI(ringTimestamp: rec.ringTimestamp, ibiMs: ibi, channel: .spo2Ibi))
             }
             idx -= 1
         }

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
@@ -10,13 +10,40 @@ import Foundation
 // (OuraStreamMapping) apply the anchor. Honest-data invariant: a short/malformed record decodes to
 // nil upstream, so these structs only ever hold real decoded values.
 
+/// WHICH optical channel decoded an `OuraIBI` (#1071).
+///
+/// The ring reports the SAME heartbeats on more than one tag. They are not different beats and not
+/// duplicate records — they are independent measurements of one beat train, so a consumer that folds
+/// them together holds two copies of every night and every variability statistic built on successive
+/// differences (RMSSD, SDNN) breaks. The tag is the only thing that separates them at ingest; after the
+/// fact the two are only separable by the accident that their quantisation grids differ.
+///
+/// The raw values are the DURABLE cross-platform storage codes (they reach `rrInterval.srcChannel` via
+/// `WhoopProtocol.RRSourceChannel`, which pins the same numbers, and the Kotlin twin `OuraIbiChannel`).
+/// Never renumber a case; only append.
+public enum OuraIBIChannel: Int, Equatable, Sendable, Codable, CaseIterable {
+    /// 0x80 `green_ibi_quality_event` (s6.4) — green LED, gated on the ring's own `quality == 1` flag
+    /// and a 300-2000 ms physiological window, and it runs for the WHOLE wear period.
+    case greenQuality = 1
+    /// 0x6E `spo2_ibi_and_amplitude_event` (s6.3) — the SpO2 measurement's own beat train, quantised to
+    /// an 8 ms grid with NO quality gate, and only present while an SpO2 measurement is running.
+    case spo2Ibi = 2
+    /// 0x60 / 0x44 `ibi_and_amplitude_event` (s6.1) — the bit-packed IBI + amplitude family.
+    case ibiAmplitude = 3
+}
+
 /// One decoded inter-beat interval (and optional amplitude), in milliseconds.
 public struct OuraIBI: Equatable, Sendable, Codable {
     public let ringTimestamp: UInt32
     public let ibiMs: Int
     public let amplitude: Int?
-    public init(ringTimestamp: UInt32, ibiMs: Int, amplitude: Int? = nil) {
+    /// Which optical channel measured this beat (#1071). Every decoder stamps its own; nil only for a
+    /// value built by something that is not one of them.
+    public let channel: OuraIBIChannel?
+    public init(ringTimestamp: UInt32, ibiMs: Int, amplitude: Int? = nil,
+                channel: OuraIBIChannel? = nil) {
         self.ringTimestamp = ringTimestamp; self.ibiMs = ibiMs; self.amplitude = amplitude
+        self.channel = channel
     }
 }
 

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
@@ -59,11 +59,11 @@ final class DecoderGoldenTests: XCTestCase {
         let rec = record("6e0a02000100000a141e2832")
         let ibis = OuraDecoders.decodeSpO2IBI(rec)
         XCTAssertEqual(ibis, [
-            OuraIBI(ringTimestamp: rt, ibiMs: 400),
-            OuraIBI(ringTimestamp: rt, ibiMs: 320),
-            OuraIBI(ringTimestamp: rt, ibiMs: 240),
-            OuraIBI(ringTimestamp: rt, ibiMs: 160),
-            OuraIBI(ringTimestamp: rt, ibiMs: 80),
+            OuraIBI(ringTimestamp: rt, ibiMs: 400, channel: .spo2Ibi),
+            OuraIBI(ringTimestamp: rt, ibiMs: 320, channel: .spo2Ibi),
+            OuraIBI(ringTimestamp: rt, ibiMs: 240, channel: .spo2Ibi),
+            OuraIBI(ringTimestamp: rt, ibiMs: 160, channel: .spo2Ibi),
+            OuraIBI(ringTimestamp: rt, ibiMs: 80, channel: .spo2Ibi),
         ])
     }
 

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/IbiChannelTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/IbiChannelTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import OuraProtocol
+
+/// #1071: every decoded R-R must say WHICH optical channel measured it.
+///
+/// The ring reports the SAME heartbeats on more than one tag — 0x80 green-quality for the whole wear
+/// period, 0x6E only while an SpO2 measurement is running — and all of them decoded to `OuraEvent.ibi`
+/// with nothing to tell them apart, so the store held roughly two complete copies of every night. The
+/// tag is the ONLY thing that separates them at ingest: once the rows are written, the two are
+/// distinguishable only by the accident that their quantisation grids differ. These tests pin the label
+/// at its source, which is where it has to be right.
+final class IbiChannelTests: XCTestCase {
+    private let rt: UInt32 = 0x0001_0002   // 65538, as in DecoderGoldenTests
+
+    private func bytes(_ s: String) -> [UInt8] {
+        var out = [UInt8](); out.reserveCapacity(s.count / 2)
+        var i = s.startIndex
+        while i < s.endIndex {
+            let j = s.index(i, offsetBy: 2)
+            out.append(UInt8(s[i..<j], radix: 16)!)
+            i = j
+        }
+        return out
+    }
+
+    private func record(_ hex: String) -> OuraRecord {
+        guard let rec = OuraFraming.parseRecord(bytes(hex)) else {
+            XCTFail("record failed to parse: \(hex)"); return OuraRecord(type: 0, ringTimestamp: 0, payload: [])
+        }
+        return rec
+    }
+
+    // The three real/golden fixtures already pinned by DecoderGoldenTests, reused so the channel is
+    // asserted on exactly the bytes whose VALUES are pinned elsewhere.
+    private let green0x80 = "801202000100698c660e652a6a09670f6d2b693e"   // real capture, 6 good beats
+    private let spo20x6E  = "6e0a02000100000a141e2832"                   // synthetic, 5 beats
+    private let amp0x60   = "601202000100807b77757a78e4ddccd4e8d79d33"   // real capture, 6 beats
+
+    func testGreenQualityDecoderStampsGreenChannel() {
+        let ibis = OuraDecoders.decodeGreenIBIQuality(record(green0x80))
+        XCTAssertEqual(ibis?.count, 6)
+        XCTAssertEqual(ibis?.map(\.channel), Array(repeating: .greenQuality, count: 6))
+    }
+
+    func testSpO2DecoderStampsSpO2Channel() {
+        let ibis = OuraDecoders.decodeSpO2IBI(record(spo20x6E))
+        XCTAssertEqual(ibis?.count, 5)
+        XCTAssertEqual(ibis?.map(\.channel), Array(repeating: .spo2Ibi, count: 5))
+    }
+
+    func testIbiAmplitudeDecoderStampsAmplitudeChannel() {
+        let ibis = OuraDecoders.decodeIBIAmplitude(record(amp0x60))
+        XCTAssertEqual(ibis?.count, 6)
+        XCTAssertEqual(ibis?.map(\.channel), Array(repeating: .ibiAmplitude, count: 6))
+    }
+
+    /// The end-to-end shape of the defect: two records covering the SAME wall-clock moment, one per
+    /// channel, both reaching the driver as `.ibi`. Before #1071 the resulting events were
+    /// indistinguishable; now the channel survives the driver's dispatch, which is what makes the two
+    /// streams separable downstream instead of silently summed.
+    func testDriverPreservesTheChannelSoTwoTagsAreDistinguishable() {
+        let driver = OuraDriver(ringGen: .gen3, authKey: nil)
+        let green = driver.ingest(record: record(green0x80))
+        let spo2 = driver.ingest(record: record(spo20x6E))
+
+        func channels(_ events: [OuraEvent]) -> [OuraIBIChannel?] {
+            events.compactMap { if case .ibi(let v) = $0 { return v.channel } else { return nil } }
+        }
+        XCTAssertFalse(green.isEmpty)
+        XCTAssertFalse(spo2.isEmpty)
+        XCTAssertEqual(Set(channels(green).compactMap { $0 }), [.greenQuality])
+        XCTAssertEqual(Set(channels(spo2).compactMap { $0 }), [.spo2Ibi])
+        // Both are still emitted: neither channel is dropped at decode. The 0x6E stream is a real second
+        // measurement and stays available as the cross-check on green (#1071 "do not delete the rows").
+        XCTAssertEqual(channels(green).count + channels(spo2).count, 11)
+    }
+
+    /// The raw values are a DURABLE storage format (`rrInterval.srcChannel`, and the `.noopbak` that
+    /// carries it between platforms), so renumbering a case would silently relabel stored history.
+    /// Pinned here rather than trusted to declaration order.
+    func testChannelRawValuesAreTheDurableStorageCodes() {
+        XCTAssertEqual(OuraIBIChannel.greenQuality.rawValue, 1)
+        XCTAssertEqual(OuraIBIChannel.spo2Ibi.rawValue, 2)
+        XCTAssertEqual(OuraIBIChannel.ibiAmplitude.rawValue, 3)
+        XCTAssertEqual(OuraIBIChannel.allCases.count, 3)
+    }
+}

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
@@ -10,10 +10,37 @@ public struct HRSample: Equatable, Codable {
     public init(ts: Int, bpm: Int) { self.ts = ts; self.bpm = bpm }
 }
 
+/// WHICH sensor channel produced an R-R interval (#1071).
+///
+/// A WHOOP strap has ONE beat source, so its rows carry no channel (nil) and nothing here changes for
+/// them. An Oura ring has more than one: the green-quality tag (0x80) and the SpO2 tag (0x6E) both
+/// decode to R-R and both were stored, so the table held roughly TWO complete copies of every night —
+/// not duplicate rows to de-duplicate, but the SAME heartbeats measured twice. Labelling the channel is
+/// what lets scoring read one copy while both stay on disk as each other's cross-check.
+///
+/// The raw values are the DURABLE, cross-platform storage codes for `rrInterval.srcChannel` and must
+/// stay in lockstep with Kotlin `RrSourceChannel` — they are written to SQLite and cross the `.noopbak`
+/// boundary, so they are a wire format, not an implementation detail. Never renumber a case; only append.
+public enum RRSourceChannel: Int, Equatable, Codable, Sendable, CaseIterable {
+    /// Oura 0x80 `green_ibi_quality_event` — the green-LED beat train, gated on the ring's own
+    /// `quality == 1` flag and a 300-2000 ms physiological window, running the whole night.
+    case greenQuality = 1
+    /// Oura 0x6E `spo2_ibi_and_amplitude_event` — the SpO2/red-channel beat train, on an 8 ms
+    /// quantisation grid with no quality gate, and present ONLY while SpO2 measurement is running.
+    case spo2Ibi = 2
+    /// Oura 0x60 / 0x44 `ibi_and_amplitude_event` — the bit-packed IBI+amplitude family.
+    case ibiAmplitude = 3
+}
+
 public struct RRInterval: Equatable, Codable {
     public let ts: Int          // wall-clock unix seconds
     public let rrMs: Int
-    public init(ts: Int, rrMs: Int) { self.ts = ts; self.rrMs = rrMs }
+    /// The sensor channel this beat came from, or nil when the source does not distinguish one (every
+    /// WHOOP row, and every row written before the column existed). See `RRSourceChannel`.
+    public let srcChannel: RRSourceChannel?
+    public init(ts: Int, rrMs: Int, srcChannel: RRSourceChannel? = nil) {
+        self.ts = ts; self.rrMs = rrMs; self.srcChannel = srcChannel
+    }
 }
 
 public extension Array where Element == RRInterval {

--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -710,6 +710,48 @@ extension WhoopStore {
                 t.primaryKey(["deviceId", "ts"])
             }
         }
+
+        // v32 (#1071): record WHICH sensor channel produced each R-R beat.
+        //
+        // An Oura ring reports the SAME heartbeats on more than one tag, and every one of them decoded to
+        // `OuraEvent.ibi` and landed here untagged. Measured over one 488-min sleep window: 61,524 beats
+        // stored where the measured HR curve allows 29,800 (2.06x), and sum(rrMs)/wall-clock = 2.17x. The
+        // two are separable after the fact only by the accident that their quantisation grids differ
+        // (0x6E is `byte * 8`, always a multiple of 8; 0x80 is an 11-bit value on the 1 ms grid), and the
+        // 8 ms stream is ABSENT until SpO2 measurement starts and then tracks its duty cycle exactly —
+        // which is what proves these are two channels rather than accumulated re-syncs.
+        //
+        // The damage is to the VARIABILITY statistics, not the level: a duplicated beat train leaves
+        // meanNN (and so resting HR) correct while RMSSD/SDNN are built entirely from successive
+        // differences and collapse. The app's own `hrv diag` line has been reporting it as
+        // `coverage=2.21 rrIntegrity=crossSecondOverCount` with a non-physiological ~200 ms nocturnal SDNN.
+        //
+        // NOT a de-duplication: both rows are real measurements of the same beat by different optics, and
+        // the second channel is the obvious future cross-check on the first. So nothing is deleted and
+        // nothing is rewritten — the column labels the source and `Reads.rrIntervals` filters at READ.
+        //
+        // Additive nullable column, the v30-rr-ord form: no table rebuild, no existing row touched, and
+        // deliberately NOT in the primary key, which stays (deviceId, ts, rrMs, seq) from v24. Putting it
+        // in the key would make the SAME beat insertable twice under two labels, the data-loss/duplication
+        // regression the v24 note warns about from the other direction.
+        //
+        // Pre-v32 rows stay NULL and are still READ (a WHOOP row is legitimately NULL forever — one beat
+        // source, no channel to name — so a filter that dropped NULL would silently delete every WHOOP
+        // night from scoring). Historical Oura rows therefore keep their old inflated coverage; they were
+        // never labelled, and a backfill would be a guess. For the record, since this is how the defect
+        // was diagnosed: in an existing DB the two channels remain separable by `rrMs % 8`, an 0x6E row
+        // always being a multiple of 8 and an 0x80 row landing there only 1 time in 8 by chance.
+        //
+        // Values are `RRSourceChannel.rawValue` (1 green / 2 spo2 / 3 ibiAmplitude), a DURABLE wire format
+        // shared with Kotlin `RrSourceChannel`. INTEGER rather than a text label because `rrInterval` is
+        // the highest-volume table in the schema (~60k rows a night) and this column rides every one.
+        //
+        // Twin of Room MIGRATION_25_26.
+        migrator.registerMigration("v32-rr-src-channel") { db in
+            try db.alter(table: "rrInterval") { t in
+                t.add(column: "srcChannel", .integer)
+            }
+        }
         return migrator
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -65,7 +65,14 @@ public enum OuraStreamMapping {
                 out.hr.append(HRSample(ts: ts, bpm: v.bpm))
 
             case .ibi(let v):
-                out.rr.append(RRInterval(ts: ts, rrMs: v.ibiMs))
+                // Carry the decoder's OWN channel tag onto the durable row (#1071). The ring reports the
+                // same heartbeats on more than one tag — 0x80 green-quality all night, 0x6E only while an
+                // SpO2 measurement runs — and both decode to `.ibi`, so an untagged store held roughly TWO
+                // complete copies of every night (measured 2.06x beats and 2.17x sum(rrMs)/wall-clock over
+                // one 488-min window). Both rows are real measurements, so neither is dropped here; the
+                // scoring READ (`Reads.rrIntervals`) picks one channel and the other stays on disk as its
+                // cross-check. Nil stays nil — a channel is never guessed.
+                out.rr.append(RRInterval(ts: ts, rrMs: v.ibiMs, srcChannel: rrChannel(v.channel)))
 
             case .hrv(let v):
                 // The ring's own 0x5D tag, carried RAW for diagnostics/parity. The two int8 fields
@@ -142,5 +149,20 @@ public enum OuraStreamMapping {
             }
         }
         return out
+    }
+
+    /// Translate the protocol layer's `OuraIBIChannel` to the store's `RRSourceChannel` (#1071).
+    ///
+    /// Two enums rather than one because `OuraProtocol` deliberately does not depend on `WhoopProtocol`
+    /// (it is the pure, Linux-buildable ring decoder). They pin the SAME raw values, and the mapping is
+    /// written out case by case rather than as `RRSourceChannel(rawValue:)` so that adding a case on one
+    /// side without the other is a COMPILE error instead of a silent nil. Exposed for the parity test.
+    public static func rrChannel(_ c: OuraIBIChannel?) -> RRSourceChannel? {
+        switch c {
+        case .greenQuality:  return .greenQuality
+        case .spo2Ibi:       return .spo2Ibi
+        case .ibiAmplitude:  return .ibiAmplitude
+        case nil:            return nil
+        }
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -172,14 +172,40 @@ extension WhoopStore {
     /// RMSSD — all successive differences — downward. Pre-v30 rows have `ord` NULL and SQLite sorts NULL
     /// first in ASC, so an all-NULL second ties and falls through to the old (rrMs, seq) order unchanged.
     /// Byte-parity twin of Kotlin `WhoopDao.rrIntervals`; both are SQLite, so NULL ordering matches.
+    ///
+    /// ONE optical channel (#1071). An Oura ring measures the same heartbeats on more than one tag, and
+    /// every one of them is stored, so an unfiltered read returned roughly TWO complete copies of a night
+    /// — 2.06x the beats the measured HR curve allows. That leaves `meanNN` (and resting HR) correct and
+    /// destroys every statistic built on successive differences: RMSSD and a ~200 ms nocturnal SDNN where
+    /// a healthy adult asleep is 40-100 ms.
+    ///
+    /// The predicate EXCLUDES the one channel proven redundant (`spo2Ibi`, 0x6E) rather than whitelisting
+    /// the one preferred (`greenQuality`, 0x80), which matters for what it does NOT drop:
+    ///   - NULL is kept. Every WHOOP row is NULL by construction (one beat source), as is every row
+    ///     written before v32. A whitelist would delete every WHOOP night from scoring.
+    ///   - `ibiAmplitude` (0x60/0x44) is kept. It does not fire on the Gen-3 hardware this was measured
+    ///     on, so there is no evidence it duplicates green — and dropping a ring's ONLY beat source on an
+    ///     untested assumption is the more expensive mistake. If a capture ever shows 0x60 and 0x80 firing
+    ///     together, that is a second exclusion here, decided on that evidence.
+    /// 0x6E is the one excluded because it is the demonstrated duplicate AND the worse measurement of the
+    /// two: it is quantised to an 8 ms grid, applies no quality gate, and runs only while an SpO2
+    /// measurement is on — so scoring off it would make HRV coverage a function of the SpO2 duty cycle.
+    ///
+    /// Rows are FILTERED, never deleted: the 0x6E stream stays on disk as the cross-check on green.
+    /// Every R-R consumer reads through this one function, so the `hrv diag` trace moves with the scores
+    /// rather than reporting a coverage nobody can reproduce.
     public func rrIntervals(deviceId: String, from: Int, to: Int, limit: Int) async throws -> [RRInterval] {
         try syncRead { db in
             try Row.fetchAll(db, sql: """
-                SELECT ts, rrMs FROM rrInterval
+                SELECT ts, rrMs, srcChannel FROM rrInterval
                 WHERE deviceId = ? AND ts >= ? AND ts <= ?
+                AND (srcChannel IS NULL OR srcChannel <> ?)
                 ORDER BY ts ASC, ord ASC, rrMs ASC, seq ASC LIMIT ?
-                """, arguments: [deviceId, from, to, limit])
-                .map { RRInterval(ts: $0["ts"], rrMs: $0["rrMs"]) }
+                """, arguments: [deviceId, from, to, RRSourceChannel.spo2Ibi.rawValue, limit])
+                .map { row in
+                    RRInterval(ts: row["ts"], rrMs: row["rrMs"],
+                               srcChannel: (row["srcChannel"] as Int?).flatMap(RRSourceChannel.init(rawValue:)))
+                }
         }
     }
 

--- a/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
@@ -170,7 +170,8 @@ extension WhoopStore {
             }
             if !streams.rr.isEmpty {
                 let stmt = try db.cachedStatement(sql: """
-                    INSERT INTO rrInterval (deviceId, ts, rrMs, seq, ord) VALUES (?, ?, ?, ?, ?)
+                    INSERT INTO rrInterval (deviceId, ts, rrMs, seq, ord, srcChannel)
+                    VALUES (?, ?, ?, ?, ?, ?)
                     ON CONFLICT(deviceId, ts, rrMs, seq) DO NOTHING
                     """)
                 // v24 (#163): number EQUAL (ts, rrMs) beats 0, 1, … within this batch so both survive;
@@ -185,6 +186,15 @@ extension WhoopStore {
                 // batch-local caveat as seq: a second split across two live flushes restarts ord at 0 and
                 // DO NOTHING keeps the first row. The historical path delivers a second atomically.
                 // Twin of Kotlin assignRrSeq.
+                //
+                // v32 (#1071): `srcChannel` is the sensor channel that measured the beat, carried from the
+                // decoder that produced it. NULL for every WHOOP row (one beat source — there is no channel
+                // to name, and that is honest rather than a placeholder) and for any source that does not
+                // report one. Like `ord` it is OUTSIDE the key: two channels measuring the same beat can
+                // yield the same (ts, rrMs), and keying on the label would store both — which is precisely
+                // the double-count this fixes. `DO NOTHING` therefore keeps whichever arrived first and the
+                // second channel's copy of THAT exact beat is dropped at insert; the read filter is what
+                // separates the streams in general.
                 var seqByTsRr: [Int: [Int: Int]] = [:]
                 var ordByTs: [Int: Int] = [:]
                 for r in streams.rr {
@@ -192,7 +202,8 @@ extension WhoopStore {
                     seqByTsRr[r.ts, default: [:]][r.rrMs] = seq + 1
                     let ord = ordByTs[r.ts] ?? 0
                     ordByTs[r.ts] = ord + 1
-                    try stmt.execute(arguments: [deviceId, r.ts, r.rrMs, seq, ord])
+                    try stmt.execute(arguments: [deviceId, r.ts, r.rrMs, seq, ord,
+                                                 r.srcChannel?.rawValue])
                     rr += db.changesCount
                 }
             }
@@ -404,6 +415,12 @@ extension WhoopStore {
             // rr: stream=rr → rr_ms (col 4). Same-second beats need the #823 tiebreak here too, and
             // more so: bare "ORDER BY ts" left their order UNDEFINED, so a raw export could differ
             // between runs over identical data. Emission order first, then the pre-v30 fallback.
+            //
+            // DELIBERATELY UNFILTERED by `srcChannel`, unlike the scoring read (#1071). This is the raw
+            // dump: both optical channels are real measurements, and the whole point of keeping the
+            // second one is that it can be inspected against the first. A raw export that silently hid
+            // half the stored rows would make the duplication that motivated v32 un-diagnosable from an
+            // export — which is exactly how it WAS diagnosed.
             for r in try Row.fetchAll(db, sql:
                 "SELECT ts, rrMs FROM rrInterval WHERE deviceId = ? AND ts >= ? " +
                 "ORDER BY ts, ord, rrMs, seq",
@@ -658,6 +675,18 @@ extension WhoopStore {
                 SELECT ord FROM rrInterval WHERE deviceId = ? AND ts = ?
                 ORDER BY ts ASC, ord ASC, rrMs ASC, seq ASC
                 """, arguments: [deviceId, ts]).map { $0["ord"] }
+        }
+    }
+
+    /// Every STORED R-R row for a device as `(rrMs, srcChannel)`, bypassing the scoring read's channel
+    /// filter. Test-only (#1071): the fix is "filter at read, keep both channels on disk", and the only
+    /// way to assert the second half is to look at the table itself rather than through `rrIntervals`.
+    public func rrRowsWithChannelForTest(deviceId: String) async throws -> [(rrMs: Int, srcChannel: Int?)] {
+        try syncRead { db in
+            try Row.fetchAll(db, sql: """
+                SELECT rrMs, srcChannel FROM rrInterval WHERE deviceId = ?
+                ORDER BY ts ASC, ord ASC, rrMs ASC, seq ASC
+                """, arguments: [deviceId]).map { (rrMs: $0["rrMs"], srcChannel: $0["srcChannel"]) }
         }
     }
 }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
@@ -1,6 +1,6 @@
 {
   "_readme": "SHARED Room<->GRDB SCHEMA ORACLE (#775). Two byte-identical copies: Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json and android/app/src/test/resources/schema_oracle.json. SchemaOracleTests.swift compares GRDB's PRAGMA table_info/index_list against it; SchemaOracleTest.kt compares Room's exported schema JSON against it. `columns` is the iOS/GRDB shape in GRDB column order (macOS is the reference implementation); every way Android differs is spelled out in an `android` / `iosAbsent` / `androidColumnOrder` override naming a key in `divergenceReasons`. Adding a column, reordering one, or changing a type/nullability on one platform only fails both suites until it is either fixed or written down here.",
-  "roomVersion": 25,
+  "roomVersion": 26,
   "grdbMigrations": [
     "v1",
     "v2",
@@ -32,7 +32,8 @@
     "v28-raw-imu",
     "v29-score-input-provenance",
     "v30-rr-ord",
-    "v31-deep-capture-channels"
+    "v31-deep-capture-channels",
+    "v32-rr-src-channel"
   ],
   "divergenceReasons": {
     "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android \u2014 the per-row upload flag belongs to an upload path that does not exist there \u2014 so it is dead width, not divergent data. Removing it needs a Room table rebuild.",
@@ -1313,6 +1314,12 @@
         },
         {
           "name": "ord",
+          "affinity": "INTEGER",
+          "notNull": false,
+          "default": null
+        },
+        {
+          "name": "srcChannel",
           "affinity": "INTEGER",
           "notNull": false,
           "default": null

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/RrSourceChannelTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/RrSourceChannelTests.swift
@@ -1,0 +1,182 @@
+import XCTest
+import WhoopProtocol
+import OuraProtocol
+@testable import WhoopStore
+
+/// #1071 — `rrInterval` mixed two optical channels, so every Oura beat was stored twice.
+///
+/// The ring measures the SAME heartbeats on more than one tag (0x80 green all night, 0x6E only while
+/// SpO2 is running) and both decoded to `OuraEvent.ibi`, so the table held roughly two complete copies
+/// of a night: 2.06x the beats the measured HR curve allows over one 488-min window. That leaves the
+/// MEAN correct (resting HR was never wrong) and destroys everything built on successive differences —
+/// a ~200 ms nocturnal SDNN where a healthy adult asleep is 40-100 ms.
+///
+/// The fix is deliberately NOT a de-duplication: both rows are real measurements, so the channel is
+/// LABELLED at decode, both rows are STORED, and the scoring read takes one. These tests pin all three
+/// halves of that sentence, plus the two things a channel filter can most easily break — a WHOOP row
+/// (NULL forever, one beat source) and a pre-v32 row (NULL, never labelled).
+final class RrSourceChannelTests: XCTestCase {
+    private let ts = 1_750_000_000
+
+    // MARK: - The label survives the mapping
+
+    /// A 0x6E record and a 0x80 record covering the same interval must produce rows with DISTINCT
+    /// `srcChannel` values — the requirement that makes everything downstream possible.
+    func testTwoChannelsOverTheSameIntervalMapToDistinctSrcChannels() {
+        let s = OuraStreamMapping.streams(from: [
+            .ibi(OuraIBI(ringTimestamp: 100, ibiMs: 848, channel: .greenQuality)),
+            .ibi(OuraIBI(ringTimestamp: 100, ibiMs: 848, channel: .spo2Ibi)),
+        ], at: ts)
+        XCTAssertEqual(s.rr.map(\.srcChannel), [.greenQuality, .spo2Ibi])
+        // Same beat, same second, same value — nothing but the channel tells them apart.
+        XCTAssertEqual(s.rr.map(\.rrMs), [848, 848])
+        XCTAssertEqual(s.rr.map(\.ts), [ts, ts])
+    }
+
+    func testMappingCarriesEachDecodersOwnChannel() {
+        let s = OuraStreamMapping.streams(from: [
+            .ibi(OuraIBI(ringTimestamp: 100, ibiMs: 820, amplitude: 42, channel: .ibiAmplitude)),
+            .ibi(OuraIBI(ringTimestamp: 101, ibiMs: 815, channel: .greenQuality)),
+            .ibi(OuraIBI(ringTimestamp: 102, ibiMs: 808, channel: .spo2Ibi)),
+        ], at: ts)
+        XCTAssertEqual(s.rr.map(\.srcChannel), [.ibiAmplitude, .greenQuality, .spo2Ibi])
+    }
+
+    /// A channel is never invented. An `OuraIBI` from a source that does not report one stays nil all
+    /// the way to the row, where it reads as an unlabelled beat rather than a guessed channel.
+    func testAnUnlabelledIbiStaysNilRatherThanBeingGuessed() {
+        let s = OuraStreamMapping.streams(from: [
+            .ibi(OuraIBI(ringTimestamp: 100, ibiMs: 820)),
+        ], at: ts)
+        XCTAssertEqual(s.rr.map(\.srcChannel), [nil])
+    }
+
+    /// The two enums are pinned to the same raw values on purpose: they are one durable storage code
+    /// split across two packages only because `OuraProtocol` does not depend on `WhoopProtocol`.
+    func testTheTwoChannelEnumsAgreeCaseForCaseAndCodeForCode() {
+        XCTAssertEqual(OuraIBIChannel.allCases.count, RRSourceChannel.allCases.count)
+        for c in OuraIBIChannel.allCases {
+            let mapped = OuraStreamMapping.rrChannel(c)
+            XCTAssertEqual(mapped?.rawValue, c.rawValue,
+                           "\(c) must map to the SAME durable storage code on both sides")
+        }
+        XCTAssertNil(OuraStreamMapping.rrChannel(nil))
+    }
+
+    // MARK: - The migration
+
+    func testV32AddsSrcChannelAndKeepsItOutOfThePrimaryKey() async throws {
+        let store = try await WhoopStore.inMemory()
+        let cols = try await store.columnNamesForTest(table: "rrInterval")
+        XCTAssertTrue(cols.contains("srcChannel"), "rrInterval missing v32 srcChannel column")
+        let pk = try await store.primaryKeyColumns("rrInterval")
+        XCTAssertEqual(pk, ["deviceId", "ts", "rrMs", "seq"],
+                       "srcChannel must not enter the key — keying on the label would store the SAME " +
+                       "beat twice under two labels, which is the double-count this fixes")
+    }
+
+    // MARK: - Store, then filter at read
+
+    /// The whole shape of the fix in one test: both channels are WRITTEN, and only one is READ.
+    func testBothChannelsAreStoredButOnlyOneIsScored() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: "ring", mac: nil, name: nil)
+
+        // One night's worth in miniature: green runs throughout, 0x6E only over the middle stretch —
+        // the SpO2 duty cycle that makes the whole-night inflation ratio vary from 1.09x to 4.11x.
+        var rows: [RRInterval] = []
+        for i in 0..<10 {
+            rows.append(RRInterval(ts: ts + i, rrMs: 800 + i, srcChannel: .greenQuality))
+            if (3...6).contains(i) {
+                rows.append(RRInterval(ts: ts + i, rrMs: 900 + i, srcChannel: .spo2Ibi))
+            }
+        }
+        let n = try await store.insert(Streams(rr: rows), deviceId: "ring")
+        XCTAssertEqual(n.rr, 14, "every measurement is stored; nothing is de-duplicated at insert")
+
+        let stored = try await store.rrRowsWithChannelForTest(deviceId: "ring")
+        XCTAssertEqual(stored.count, 14)
+        XCTAssertEqual(stored.filter { $0.srcChannel == RRSourceChannel.spo2Ibi.rawValue }.count, 4,
+                       "the 0x6E rows must SURVIVE — they are the cross-check on green, not garbage")
+
+        let scored = try await store.rrIntervals(deviceId: "ring", from: 0, to: ts + 1_000, limit: 1_000)
+        XCTAssertEqual(scored.count, 10, "scoring reads ONE channel: the 4 SpO2 beats are filtered out")
+        XCTAssertEqual(Set(scored.compactMap(\.srcChannel)), [.greenQuality])
+        XCTAssertEqual(scored.map(\.rrMs), (0..<10).map { 800 + $0 })
+    }
+
+    /// The regression the filter could most easily cause. A WHOOP strap has ONE beat source, so its
+    /// rows carry no channel — a whitelist filter would have deleted every WHOOP night from scoring.
+    func testWhoopRowsCarryNoChannelAndAreNeverFiltered() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: "strap", mac: nil, name: nil)
+        let beats = [812, 795, 840, 801, 833]
+        _ = try await store.insert(
+            Streams(rr: beats.map { RRInterval(ts: ts, rrMs: $0) }), deviceId: "strap")
+
+        let stored = try await store.rrRowsWithChannelForTest(deviceId: "strap")
+        XCTAssertEqual(stored.map(\.srcChannel), Array(repeating: nil, count: 5),
+                       "NULL is the honest value for a single-source strap, not a placeholder")
+        let read = try await store.rrIntervals(deviceId: "strap", from: 0, to: ts + 10, limit: 100)
+        XCTAssertEqual(read.map(\.rrMs), beats, "emission order (#823) is unchanged by the filter")
+        XCTAssertEqual(read.map(\.srcChannel), Array(repeating: nil, count: 5))
+    }
+
+    /// Rows written before v32 are NULL and still read. They were never labelled, so their old inflated
+    /// coverage stands — a backfill would be a guess, and dropping them would delete real history.
+    func testPreV32RowsAreUnlabelledAndStillRead() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: "ring", mac: nil, name: nil)
+        for v in [812, 795, 840] {
+            try await store.insertLegacyRrWithoutOrdForTest(deviceId: "ring", ts: ts, rrMs: v)
+        }
+        let read = try await store.rrIntervals(deviceId: "ring", from: 0, to: ts + 10, limit: 100)
+        XCTAssertEqual(read.map(\.rrMs), [795, 812, 840],
+                       "pre-v32 rows keep the pre-v30 (rrMs, seq) fallback order, unchanged")
+        XCTAssertEqual(read.map(\.srcChannel), [nil, nil, nil])
+    }
+
+    /// `ibiAmplitude` (0x60/0x44) is deliberately NOT excluded: it does not fire on the hardware where
+    /// the duplication was measured, and on a ring where it is the only beat source, excluding it would
+    /// leave nothing to score. The filter drops the one channel proven redundant, not every non-green.
+    func testTheAmplitudeChannelIsKeptBecauseItMayBeARingsOnlyBeatSource() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: "ring", mac: nil, name: nil)
+        _ = try await store.insert(Streams(rr: [
+            RRInterval(ts: ts, rrMs: 1028, srcChannel: .ibiAmplitude),
+            RRInterval(ts: ts + 1, rrMs: 987, srcChannel: .ibiAmplitude),
+        ]), deviceId: "ring")
+
+        let read = try await store.rrIntervals(deviceId: "ring", from: 0, to: ts + 10, limit: 100)
+        XCTAssertEqual(read.map(\.rrMs), [1028, 987])
+        XCTAssertEqual(read.map(\.srcChannel), [.ibiAmplitude, .ibiAmplitude])
+    }
+
+    /// The measurable claim behind the issue: an unfiltered night reads ~2x the beats the HR curve
+    /// allows, and the filtered read is back on ~1x. This is the `coverage 2.21 -> ~1.0` regression
+    /// check in miniature, on data whose true beat count is known by construction.
+    func testFilteredReadRestoresOneBeatPerHeartbeat() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: "ring", mac: nil, name: nil)
+
+        let trueBeats = 600                              // 10 minutes at 1 Hz
+        var rows: [RRInterval] = []
+        for i in 0..<trueBeats {
+            // The SAME beat seen twice: green on the 1 ms grid, 0x6E rounded onto its 8 ms grid.
+            let rr = 1000 + (i % 7) * 3
+            rows.append(RRInterval(ts: ts + i, rrMs: rr, srcChannel: .greenQuality))
+            rows.append(RRInterval(ts: ts + i, rrMs: (rr / 8) * 8, srcChannel: .spo2Ibi))
+        }
+        _ = try await store.insert(Streams(rr: rows), deviceId: "ring")
+
+        let allStored = try await store.rrRowsWithChannelForTest(deviceId: "ring")
+        let scored = try await store.rrIntervals(deviceId: "ring", from: 0, to: ts + 10_000, limit: 10_000)
+
+        // Stored: ~2 rows per heartbeat (a shade under, where the 8 ms round lands on the green value
+        // and the two collide on the (ts, rrMs, seq) key — exactly the 1-in-8 chance the issue notes).
+        XCTAssertGreaterThan(Double(allStored.count) / Double(trueBeats), 1.8)
+        // Read: exactly one.
+        XCTAssertEqual(scored.count, trueBeats)
+        XCTAssertEqual(Set(scored.compactMap(\.srcChannel)), [.greenQuality])
+    }
+}

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -114,9 +114,30 @@ data class HrWindowStats(
  * NULL first in ASC, so a pre-v24 second (all NULL) ties on `ord` and falls through to the old
  * `rrMs, seq` order exactly. Not backfillable: the order was never recorded.
  *
- * PARITY: the Swift `rrInterval` key was widened to match in WhoopStore `v24-rr-seq`, and `ord` lands
- * there as `v30-rr-ord`. (An earlier revision of this note said the Swift widening was still pending;
- * it had already shipped.)
+ * `srcChannel` (Room v26, #1071) is WHICH sensor channel measured the beat, as [RrSourceChannel.code].
+ * An Oura ring reports the SAME heartbeats on more than one tag — 0x80 green-quality for the whole wear
+ * period, 0x6E only while an SpO2 measurement runs — and every one of them decoded to an R-R row, so an
+ * untagged table held roughly TWO complete copies of every night (2.06x the beats the measured HR curve
+ * allows over one 488-min window). That leaves the MEAN correct — resting HR was never wrong — and
+ * destroys everything built on successive differences: RMSSD, and a ~200 ms nocturnal SDNN where a
+ * healthy adult asleep is 40-100 ms.
+ *
+ * NOT a de-duplication: both rows are real measurements of one beat by different optics, and the second
+ * channel is the obvious cross-check on the first. So nothing is deleted — the column labels the source
+ * and `WhoopDao.rrIntervals` filters at READ. Also NOT in the key, for the same reason `ord` is not:
+ * keying on the label would make the SAME beat insertable twice under two labels, which is the
+ * double-count being fixed.
+ *
+ * NULL means "no channel to name": every WHOOP row forever (one beat source), every row written before
+ * v26, and any source that does not report one. Pre-v26 rows are still READ — a filter that dropped NULL
+ * would delete every WHOOP night from scoring — so historical Oura rows keep their old inflated
+ * coverage. Not backfillable: the channel was never recorded. (For the record, since it is how this was
+ * diagnosed: in an existing DB the two remain separable by `rrMs % 8`, an 0x6E row always being a
+ * multiple of 8 and an 0x80 row landing there only 1 time in 8 by chance.)
+ *
+ * PARITY: the Swift `rrInterval` key was widened to match in WhoopStore `v24-rr-seq`, `ord` lands there
+ * as `v30-rr-ord`, and `srcChannel` as `v32-rr-src-channel`. (An earlier revision of this note said the
+ * Swift widening was still pending; it had already shipped.)
  */
 @Entity(tableName = "rrInterval", primaryKeys = ["deviceId", "ts", "rrMs", "seq"])
 data class RrInterval(
@@ -126,6 +147,7 @@ data class RrInterval(
     val seq: Int = 0,
     val synced: Int = 0,
     val ord: Int? = null,
+    val srcChannel: Int? = null,
 )
 
 /**

--- a/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
+++ b/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
@@ -1,6 +1,8 @@
 package com.noop.data
 
 import com.noop.oura.OuraEvent
+import com.noop.oura.OuraIbiChannel
+import com.noop.protocol.RrSourceChannel
 import com.noop.protocol.SkinTempSample
 import com.noop.protocol.Spo2Sample
 import com.noop.protocol.Streams
@@ -58,7 +60,17 @@ object OuraStreamMapping {
 
                 is OuraEvent.Ibi -> {
                     val ts = anchor(ev.value.ringTimestamp) ?: continue
-                    out.rr.add(com.noop.protocol.RrInterval(ts, ev.value.ibiMs))
+                    // Carry the decoder's OWN channel tag onto the durable row (#1071). The ring reports
+                    // the same heartbeats on more than one tag — 0x80 green-quality all night, 0x6E only
+                    // while an SpO2 measurement runs — and both decode to Ibi, so an untagged store held
+                    // roughly TWO complete copies of every night (measured 2.06x beats and 2.17x
+                    // sum(rrMs)/wall-clock over one 488-min window). Both rows are real measurements, so
+                    // neither is dropped here; the scoring READ (WhoopDao.rrIntervals) picks one channel
+                    // and the other stays on disk as its cross-check. Null stays null — never a guess.
+                    // Mirrors the Swift OuraStreamMapping twin.
+                    out.rr.add(
+                        com.noop.protocol.RrInterval(ts, ev.value.ibiMs, rrChannel(ev.value.channel)),
+                    )
                 }
 
                 is OuraEvent.Hrv -> {
@@ -161,5 +173,21 @@ object OuraStreamMapping {
             }
         }
         return out
+    }
+
+    /**
+     * Translate the protocol layer's [OuraIbiChannel] to the store's [RrSourceChannel] (#1071).
+     *
+     * Two enums rather than one because `com.noop.oura` is the pure ring decoder and does not depend on
+     * the storage carriers — the same split the Swift twin has between `OuraProtocol` and
+     * `WhoopProtocol`. They pin the SAME [OuraIbiChannel.code] / [RrSourceChannel.code] values, and the
+     * mapping is written out case by case rather than as `fromCode(c.code)` so that adding a case on one
+     * side without the other is a COMPILE error instead of a silent null. Internal for the parity test.
+     */
+    internal fun rrChannel(c: OuraIbiChannel?): RrSourceChannel? = when (c) {
+        OuraIbiChannel.GREEN_QUALITY -> RrSourceChannel.GREEN_QUALITY
+        OuraIbiChannel.SPO2_IBI -> RrSourceChannel.SPO2_IBI
+        OuraIbiChannel.IBI_AMPLITUDE -> RrSourceChannel.IBI_AMPLITUDE
+        null -> null
     }
 }

--- a/android/app/src/main/java/com/noop/data/StreamPersistence.kt
+++ b/android/app/src/main/java/com/noop/data/StreamPersistence.kt
@@ -22,7 +22,10 @@ object StreamPersistence {
     /** Convert a decoded protocol [Streams] batch into the Room [StreamBatch] insert shape. */
     fun toBatch(streams: Streams): StreamBatch = StreamBatch(
         hr = streams.hr.map { HrRow(it.ts.toLong(), it.bpm) },
-        rr = streams.rr.map { RrRow(it.ts.toLong(), it.rrMs) },
+        // `srcChannel` (#1071) rides through unchanged: which optical channel measured the beat is
+        // decided by the decoder and must survive to the row, or the two Oura channels become
+        // indistinguishable and every night is stored twice over.
+        rr = streams.rr.map { RrRow(it.ts.toLong(), it.rrMs, it.srcChannel) },
         events = streams.events.map { EventEntry(it.ts.toLong(), it.kind, encodePayload(it.payload)) },
         battery = streams.battery.map { BatteryRow(it.ts.toLong(), it.soc, it.mv, it.charging) },
         // The WHOOP REALTIME_DATA stream carries no SpO2/skinTemp (those are type-47-only and arrive

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -363,7 +363,32 @@ interface WhoopDao : DeviceRegistryDao {
         // Byte-parity twin of Swift Reads.swift rrIntervals; both are SQLite, so NULL ordering matches.
         // Note this no longer matches the PK index (ts, rrMs, seq), so SQLite sorts; see the PR for why
         // that is acceptable at this query's size rather than adding a covering index.
+        //
+        // #1071: ONE optical channel. An Oura ring measures the same heartbeats on more than one tag and
+        // all of them are stored, so an unfiltered read returned roughly TWO complete copies of a night —
+        // 2.06x the beats the measured HR curve allows. That leaves meanNN (and resting HR) correct and
+        // destroys every statistic built on successive differences: RMSSD, and a ~200 ms nocturnal SDNN
+        // where a healthy adult asleep is 40-100 ms.
+        //
+        // The predicate EXCLUDES the one channel proven redundant (SPO2_IBI, 0x6E) rather than
+        // whitelisting the one preferred (GREEN_QUALITY, 0x80), which matters for what it does NOT drop:
+        //   - NULL is kept. Every WHOOP row is NULL by construction (one beat source), as is every row
+        //     written before v26. A whitelist would delete every WHOOP night from scoring.
+        //   - IBI_AMPLITUDE (0x60/0x44) is kept. It does not fire on the Gen-3 hardware this was measured
+        //     on, so there is no evidence it duplicates green — and dropping a ring's ONLY beat source on
+        //     an untested assumption is the more expensive mistake. If a capture ever shows 0x60 and 0x80
+        //     firing together, that is a second exclusion here, decided on that evidence.
+        // 0x6E is the one excluded because it is the demonstrated duplicate AND the worse measurement of
+        // the two: quantised to an 8 ms grid, no quality gate, and running only while an SpO2 measurement
+        // is on — so scoring off it would make HRV coverage a function of the SpO2 duty cycle.
+        //
+        // Rows are FILTERED, never deleted: the 0x6E stream stays on disk as the cross-check on green.
+        // Every R-R consumer reads through this one query, so the `hrv diag` trace moves with the scores
+        // rather than reporting a coverage nobody can reproduce. The literal 2 is RrSourceChannel.SPO2_IBI
+        // .code — a Room @Query is a compile-time constant string and cannot reference it; RrChannelTest
+        // pins the two together.
         "SELECT * FROM rrInterval WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to " +
+            "AND (srcChannel IS NULL OR srcChannel <> 2) " +
             "ORDER BY ts ASC, ord ASC, rrMs ASC, seq ASC LIMIT :limit"
     )
     suspend fun rrIntervals(deviceId: String, from: Long, to: Long, limit: Int): List<RrInterval>

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -52,7 +52,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         RawImuSampleEntity::class,
         V18AuxSampleEntity::class,
     ],
-    version = 25,
+    version = 26,
     // #775: ON so Room's KSP processor writes the generated schema (every table's exact `CREATE TABLE`,
     // columns in declaration order with affinity/NOT NULL/default, PK and indices) as JSON. That export
     // is what lets a plain JVM test — no device, no Robolectric — read Android's REAL schema and compare
@@ -691,6 +691,57 @@ abstract class WhoopDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * #1071: record WHICH sensor channel produced each R-R beat. Twin of the Swift GRDB migration
+         * `v32-rr-src-channel`.
+         *
+         * An Oura ring reports the SAME heartbeats on more than one tag, and every one of them decoded to
+         * an R-R row and landed here untagged. Measured over one 488-min sleep window: 61,524 beats stored
+         * where the measured HR curve allows 29,800 (2.06x), and sum(rrMs)/wall-clock = 2.17x. The two are
+         * separable after the fact only by the accident that their quantisation grids differ (0x6E is
+         * `byte * 8`, always a multiple of 8; 0x80 is an 11-bit value on the 1 ms grid), and the 8 ms
+         * stream is ABSENT until SpO2 measurement starts and then tracks its duty cycle exactly — which is
+         * what proves these are two channels rather than accumulated re-syncs.
+         *
+         * The damage is to the VARIABILITY statistics, not the level: a duplicated beat train leaves
+         * meanNN (and so resting HR) correct while RMSSD/SDNN are built entirely from successive
+         * differences and collapse. The app's own `hrv diag` line has been reporting it as
+         * `coverage=2.21 rrIntegrity=crossSecondOverCount` with a non-physiological ~200 ms nocturnal SDNN.
+         *
+         * NOT a de-duplication: both rows are real measurements of the same beat by different optics, and
+         * the second channel is the obvious future cross-check on the first. So nothing is deleted and
+         * nothing is rewritten — the column labels the source and [WhoopDao.rrIntervals] filters at READ.
+         *
+         * Additive and nullable, the MIGRATION_3_4 / MIGRATION_23_24 form: no table rebuild, no row
+         * touched, and NOT part of the primary key, which stays (deviceId, ts, rrMs, seq). Putting it in
+         * the key would make the SAME beat insertable twice under two labels — the double-count being
+         * fixed, arrived at from the other direction.
+         *
+         * Existing rows stay NULL and are still READ (a WHOOP row is legitimately NULL forever — one beat
+         * source, no channel to name), so historical Oura rows keep their old inflated coverage. Not
+         * backfillable: the channel was never recorded.
+         *
+         * Values are [com.noop.protocol.RrSourceChannel.code] (1 green / 2 spo2 / 3 ibiAmplitude), a
+         * DURABLE wire format shared with Swift `RRSourceChannel`. INTEGER rather than a text label
+         * because `rrInterval` is the highest-volume table in the schema (~60k rows a night) and this
+         * column rides every one.
+         *
+         * ALTER TABLE appends the column LAST, matching the entity field order (declared after `ord`), so
+         * a migrated schema and a freshly-created one agree.
+         *
+         * Exposed as [RR_SRC_CHANNEL_MIGRATION_SQL] so a plain-JVM unit test can assert its shape without
+         * an emulator, like the migrations above.
+         */
+        internal val RR_SRC_CHANNEL_MIGRATION_SQL: List<String> = listOf(
+            "ALTER TABLE `rrInterval` ADD COLUMN `srcChannel` INTEGER",
+        )
+
+        internal val MIGRATION_25_26 = object : Migration(25, 26) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                for (stmt in RR_SRC_CHANNEL_MIGRATION_SQL) db.execSQL(stmt)
+            }
+        }
+
         private fun build(appContext: Context): WhoopDatabase =
             Room.databaseBuilder(appContext, WhoopDatabase::class.java, DB_NAME)
                 // #1014: replace ONLY the corruption handling of the default open-helper. The
@@ -707,7 +758,7 @@ abstract class WhoopDatabase : RoomDatabase() {
                     MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
                     MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18,
                     MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
-                    MIGRATION_22_23, MIGRATION_23_24, MIGRATION_24_25,
+                    MIGRATION_22_23, MIGRATION_23_24, MIGRATION_24_25, MIGRATION_25_26,
                 )
                 // #1037: a FRESH install builds the schema straight at the current version and runs NO
                 // migrations, so the MIGRATION_7_8 "my-whoop" registry seed never fires and the WHOOP,

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -2,6 +2,7 @@ package com.noop.data
 
 import android.content.Context
 import com.noop.protocol.DroppedRtcEvent
+import com.noop.protocol.RrSourceChannel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlin.math.roundToInt
@@ -189,7 +190,12 @@ data class DynAccelDiag(
 
 // Device-agnostic decoded rows (deviceId attached when inserted). Mirror Streams.swift shapes.
 data class HrRow(val ts: Long, val bpm: Int)
-data class RrRow(val ts: Long, val rrMs: Int)
+
+/**
+ * One decoded R-R beat awaiting insert. [srcChannel] is the sensor channel that measured it (#1071),
+ * null for a source that does not distinguish one (every WHOOP row). Swift `RRInterval`.
+ */
+data class RrRow(val ts: Long, val rrMs: Int, val srcChannel: RrSourceChannel? = null)
 
 /**
  * Attach a tiebreaker `seq` to each R-R interval before insert (Room v18). Multiple beats share one
@@ -213,6 +219,12 @@ data class RrRow(val ts: Long, val rrMs: Int)
  * RMSSD down. Same batch-local caveat as `seq`: a second split across two live flushes restarts `ord` at 0,
  * and ON CONFLICT DO NOTHING keeps whichever row landed first. The historical path delivers a second
  * atomically, so the authoritative copy is correctly ordered.
+ *
+ * And carries `srcChannel` (Room v26, #1071): the sensor channel that measured the beat, as reported by
+ * the decoder that produced it. NULL for every WHOOP row (one beat source — there is no channel to name,
+ * and that is honest rather than a placeholder). Like `ord` it is OUTSIDE the key: two channels measuring
+ * the same beat can yield the same (ts, rrMs), and keying on the label would store both — which is
+ * precisely the double-count this fixes. Twin of the Swift StreamStore insert.
  */
 internal fun assignRrSeq(deviceId: String, rows: List<RrRow>): List<RrInterval> {
     val seqByBeat = HashMap<Pair<Long, Int>, Int>()
@@ -223,7 +235,10 @@ internal fun assignRrSeq(deviceId: String, rows: List<RrRow>): List<RrInterval> 
         seqByBeat[key] = s + 1
         val o = ordByTs.getOrDefault(row.ts, 0)
         ordByTs[row.ts] = o + 1
-        RrInterval(deviceId = deviceId, ts = row.ts, rrMs = row.rrMs, seq = s, ord = o)
+        RrInterval(
+            deviceId = deviceId, ts = row.ts, rrMs = row.rrMs, seq = s, ord = o,
+            srcChannel = row.srcChannel?.code,
+        )
     }
 }
 

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -107,7 +107,12 @@ object OuraDecoders {
         for (k in 0 until 6) {
             if (ibi[k] <= 0) continue                      // drop a zero IBI, never invent one
             val amp = ((b[6 + k] and 0xFF) shr 1) shl shift   // 7-bit mantissa << exponent
-            out.add(OuraIBI(ringTimestamp = rec.ringTimestamp, ibiMs = ibi[k], amplitude = amp))
+            out.add(
+                OuraIBI(
+                    ringTimestamp = rec.ringTimestamp, ibiMs = ibi[k], amplitude = amp,
+                    channel = OuraIbiChannel.IBI_AMPLITUDE,
+                ),
+            )
         }
         return if (out.isEmpty()) null else out
     }
@@ -181,7 +186,12 @@ object OuraDecoders {
             val ibi = (b[i + 1] and 0x07) or ((b[i] and 0xFF) shl 3)   // high byte first
             val quality = (b[i + 1] shr 3) and 0x03
             if (quality == 1 && ibi in 300..2000) {
-                out.add(OuraIBI(ringTimestamp = rec.ringTimestamp, ibiMs = ibi))
+                out.add(
+                    OuraIBI(
+                        ringTimestamp = rec.ringTimestamp, ibiMs = ibi,
+                        channel = OuraIbiChannel.GREEN_QUALITY,
+                    ),
+                )
             }
             i += 2
             sampleCount += 1
@@ -210,7 +220,12 @@ object OuraDecoders {
         while (idx >= 1) {
             val ibi = b[idx] * 8                          // 8-bit count x8 -> ms
             if (ibi > 0) {
-                out.add(OuraIBI(ringTimestamp = rec.ringTimestamp, ibiMs = ibi))
+                out.add(
+                    OuraIBI(
+                        ringTimestamp = rec.ringTimestamp, ibiMs = ibi,
+                        channel = OuraIbiChannel.SPO2_IBI,
+                    ),
+                )
             }
             idx -= 1
         }

--- a/android/app/src/main/java/com/noop/oura/OuraEvents.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraEvents.kt
@@ -14,8 +14,55 @@ package com.noop.oura
 // apply the anchor. Honest-data invariant: a short/malformed record decodes to null upstream, so
 // these structs only ever hold real decoded values.
 
-/** One decoded inter-beat interval (and optional amplitude), in milliseconds. */
-data class OuraIBI(val ringTimestamp: Long, val ibiMs: Int, val amplitude: Int? = null)
+/**
+ * WHICH optical channel decoded an [OuraIBI] (#1071).
+ *
+ * The ring reports the SAME heartbeats on more than one tag. They are not different beats and not
+ * duplicate records — they are independent measurements of one beat train, so a consumer that folds
+ * them together holds two copies of every night and every variability statistic built on successive
+ * differences (RMSSD, SDNN) breaks. The tag is the only thing that separates them at ingest; after the
+ * fact the two are only separable by the accident that their quantisation grids differ.
+ *
+ * [code] is the DURABLE cross-platform storage value (it reaches `rrInterval.srcChannel`), pinned to
+ * Swift `OuraIBIChannel` / `RRSourceChannel`. Never renumber a case; only append.
+ *
+ * Byte-identical twin of Swift's `OuraIBIChannel`.
+ */
+enum class OuraIbiChannel(val code: Int) {
+    /**
+     * 0x80 `green_ibi_quality_event` (s6.4) — green LED, gated on the ring's own `quality == 1` flag
+     * and a 300-2000 ms physiological window, and it runs for the WHOLE wear period.
+     */
+    GREEN_QUALITY(1),
+
+    /**
+     * 0x6E `spo2_ibi_and_amplitude_event` (s6.3) — the SpO2 measurement's own beat train, quantised to
+     * an 8 ms grid with NO quality gate, and only present while an SpO2 measurement is running.
+     */
+    SPO2_IBI(2),
+
+    /** 0x60 / 0x44 `ibi_and_amplitude_event` (s6.1) — the bit-packed IBI + amplitude family. */
+    IBI_AMPLITUDE(3),
+    ;
+
+    companion object {
+        /** The channel with this durable storage [code], or null for an unknown/absent one. */
+        fun fromCode(code: Int?): OuraIbiChannel? = entries.firstOrNull { it.code == code }
+    }
+}
+
+/**
+ * One decoded inter-beat interval (and optional amplitude), in milliseconds.
+ *
+ * [channel] is which optical channel measured the beat (#1071). Every decoder stamps its own; null
+ * only for a value built by something that is not one of them — never a guess.
+ */
+data class OuraIBI(
+    val ringTimestamp: Long,
+    val ibiMs: Int,
+    val amplitude: Int? = null,
+    val channel: OuraIbiChannel? = null,
+)
 
 /** One decoded heart-rate value in BPM (derived from a live-HR push IBI, OURA_PROTOCOL.md s5.6). */
 data class OuraHR(val ringTimestamp: Long, val bpm: Int, val ibiMs: Int)

--- a/android/app/src/main/java/com/noop/protocol/Streams.kt
+++ b/android/app/src/main/java/com/noop/protocol/Streams.kt
@@ -11,8 +11,50 @@ package com.noop.protocol
 /** A heart-rate sample at wall-clock unix seconds [ts]. */
 data class HrSample(val ts: Int, val bpm: Int)
 
-/** A single beat-to-beat R-R interval (ms) at wall-clock unix seconds [ts]. */
-data class RrInterval(val ts: Int, val rrMs: Int)
+/**
+ * WHICH sensor channel produced an R-R interval (#1071).
+ *
+ * A WHOOP strap has ONE beat source, so its rows carry no channel (null) and nothing here changes for
+ * them. An Oura ring has more than one: the green-quality tag (0x80) and the SpO2 tag (0x6E) both
+ * decode to R-R and both were stored, so the table held roughly TWO complete copies of every night —
+ * not duplicate rows to de-duplicate, but the SAME heartbeats measured twice. Labelling the channel is
+ * what lets scoring read one copy while both stay on disk as each other's cross-check.
+ *
+ * [code] is the DURABLE, cross-platform storage value for `rrInterval.srcChannel` and must stay in
+ * lockstep with Swift `RRSourceChannel` — it is written to SQLite and crosses the `.noopbak` boundary,
+ * so it is a wire format, not an implementation detail. Never renumber a case; only append.
+ */
+enum class RrSourceChannel(val code: Int) {
+    /**
+     * Oura 0x80 `green_ibi_quality_event` — the green-LED beat train, gated on the ring's own
+     * `quality == 1` flag and a 300-2000 ms physiological window, running the whole night.
+     */
+    GREEN_QUALITY(1),
+
+    /**
+     * Oura 0x6E `spo2_ibi_and_amplitude_event` — the SpO2/red-channel beat train, on an 8 ms
+     * quantisation grid with no quality gate, and present ONLY while SpO2 measurement is running.
+     */
+    SPO2_IBI(2),
+
+    /** Oura 0x60 / 0x44 `ibi_and_amplitude_event` — the bit-packed IBI+amplitude family. */
+    IBI_AMPLITUDE(3),
+    ;
+
+    companion object {
+        /** The channel with this durable storage [code], or null for an unknown/absent one. */
+        fun fromCode(code: Int?): RrSourceChannel? = entries.firstOrNull { it.code == code }
+    }
+}
+
+/**
+ * A single beat-to-beat R-R interval (ms) at wall-clock unix seconds [ts].
+ *
+ * [srcChannel] is the sensor channel that measured this beat, or null when the source does not
+ * distinguish one (every WHOOP row, and every row written before the column existed). See
+ * [RrSourceChannel].
+ */
+data class RrInterval(val ts: Int, val rrMs: Int, val srcChannel: RrSourceChannel? = null)
 
 /**
  * A raw-ADC SpO2 sample at wall-clock unix seconds [ts]. Mirrors the Room `Spo2Sample` (red/ir)

--- a/android/app/src/test/java/com/noop/data/RrSourceChannelTest.kt
+++ b/android/app/src/test/java/com/noop/data/RrSourceChannelTest.kt
@@ -1,0 +1,259 @@
+package com.noop.data
+
+import com.noop.oura.OuraDecoders
+import com.noop.oura.OuraDriver
+import com.noop.oura.OuraEvent
+import com.noop.oura.OuraFraming
+import com.noop.oura.OuraIBI
+import com.noop.oura.OuraIbiChannel
+import com.noop.oura.OuraRecord
+import com.noop.oura.OuraRingGen
+import com.noop.oura.OuraTestHex
+import com.noop.protocol.RrSourceChannel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * #1071 — `rrInterval` mixed two optical channels, so every Oura beat was stored twice.
+ *
+ * The ring measures the SAME heartbeats on more than one tag (0x80 green all night, 0x6E only while an
+ * SpO2 measurement runs) and both decoded to an R-R row, so the table held roughly two complete copies
+ * of a night: 2.06x the beats the measured HR curve allows over one 488-min window. That leaves the
+ * MEAN correct — resting HR was never wrong — and destroys everything built on successive differences:
+ * RMSSD, and a ~200 ms nocturnal SDNN where a healthy adult asleep is 40-100 ms.
+ *
+ * The fix is deliberately NOT a de-duplication: both rows are real measurements, so the channel is
+ * LABELLED at decode, both rows are STORED, and the scoring read takes one. This is the Kotlin half of
+ * the parity contract — the Swift twin is `RrSourceChannelTests` in WhoopStoreTests, which also
+ * exercises the read end-to-end against a real SQLite. There is no SQLite driver on this unit-test
+ * classpath (see [DeepCaptureMigrationTest]), so the read filter is guarded here by auditing the DAO
+ * query text, the way [HrFrontierQueryShapeTest] does.
+ */
+class RrSourceChannelTest {
+
+    // The same golden fixtures the Swift DecoderGoldenTests pin the VALUES of, so the channel is
+    // asserted on exactly those bytes. rt = 0x00010002 throughout.
+    private val green0x80 = "801202000100698c660e652a6a09670f6d2b693e"   // real capture, 6 good beats
+    private val spo20x6E = "6e0a02000100000a141e2832"                    // synthetic, 5 beats
+    private val amp0x60 = "601202000100807b77757a78e4ddccd4e8d79d33"     // real capture, 6 beats
+
+    private fun record(hex: String): OuraRecord {
+        val rec = OuraFraming.parseRecord(OuraTestHex.bytes(hex))
+        assertNotNull("record failed to parse: $hex", rec)
+        return rec!!
+    }
+
+    // MARK: - The decoders stamp their own channel
+
+    @Test
+    fun greenQualityDecoderStampsGreenChannel() {
+        val ibis = OuraDecoders.decodeGreenIBIQuality(record(green0x80))
+        assertEquals(6, ibis?.size)
+        assertEquals(List(6) { OuraIbiChannel.GREEN_QUALITY }, ibis?.map { it.channel })
+    }
+
+    @Test
+    fun spo2DecoderStampsSpO2Channel() {
+        val ibis = OuraDecoders.decodeSpO2IBI(record(spo20x6E))
+        assertEquals(5, ibis?.size)
+        assertEquals(List(5) { OuraIbiChannel.SPO2_IBI }, ibis?.map { it.channel })
+    }
+
+    @Test
+    fun ibiAmplitudeDecoderStampsAmplitudeChannel() {
+        val ibis = OuraDecoders.decodeIBIAmplitude(record(amp0x60))
+        assertEquals(6, ibis?.size)
+        assertEquals(List(6) { OuraIbiChannel.IBI_AMPLITUDE }, ibis?.map { it.channel })
+    }
+
+    /**
+     * The end-to-end shape of the defect: two records covering the same wall-clock moment, one per
+     * channel, both reaching the driver as `Ibi`. Before #1071 the resulting events were
+     * indistinguishable; now the channel survives dispatch, which is what makes the two streams
+     * separable downstream instead of silently summed. Neither is dropped at decode.
+     */
+    @Test
+    fun driverPreservesTheChannelSoTwoTagsAreDistinguishable() {
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = null)
+        fun channels(events: List<OuraEvent>) =
+            events.filterIsInstance<OuraEvent.Ibi>().map { it.value.channel }
+
+        val green = channels(d.ingest(record(green0x80)))
+        val spo2 = channels(d.ingest(record(spo20x6E)))
+        assertEquals(setOf(OuraIbiChannel.GREEN_QUALITY), green.toSet())
+        assertEquals(setOf(OuraIbiChannel.SPO2_IBI), spo2.toSet())
+        assertEquals("both channels still reach the store", 11, green.size + spo2.size)
+    }
+
+    // MARK: - The label survives the mapping
+
+    /**
+     * A 0x6E record and a 0x80 record covering the same interval must produce rows with DISTINCT
+     * `srcChannel` values — the requirement that makes everything downstream possible.
+     */
+    @Test
+    fun twoChannelsOverTheSameIntervalMapToDistinctSrcChannels() {
+        val ts = 1_750_000_000
+        val s = OuraStreamMapping.streams(
+            listOf(
+                OuraEvent.Ibi(OuraIBI(100L, 848, channel = OuraIbiChannel.GREEN_QUALITY)),
+                OuraEvent.Ibi(OuraIBI(100L, 848, channel = OuraIbiChannel.SPO2_IBI)),
+            ),
+        ) { ts }
+        assertEquals(
+            listOf(RrSourceChannel.GREEN_QUALITY, RrSourceChannel.SPO2_IBI),
+            s.rr.map { it.srcChannel },
+        )
+        // Same beat, same second, same value — nothing but the channel tells them apart.
+        assertEquals(listOf(848, 848), s.rr.map { it.rrMs })
+        assertEquals(listOf(ts, ts), s.rr.map { it.ts })
+    }
+
+    /**
+     * A channel is never invented. An IBI from a source that does not report one stays null all the way
+     * to the row, where it reads as an unlabelled beat rather than a guessed channel.
+     */
+    @Test
+    fun anUnlabelledIbiStaysNullRatherThanBeingGuessed() {
+        val s = OuraStreamMapping.streams(listOf(OuraEvent.Ibi(OuraIBI(100L, 820)))) { 1_750_000_000 }
+        assertEquals(listOf<RrSourceChannel?>(null), s.rr.map { it.srcChannel })
+    }
+
+    /**
+     * The two enums are pinned to the same codes on purpose: one durable storage value split across two
+     * packages only because the pure ring decoder does not depend on the storage carriers.
+     */
+    @Test
+    fun theTwoChannelEnumsAgreeCaseForCaseAndCodeForCode() {
+        assertEquals(OuraIbiChannel.entries.size, RrSourceChannel.entries.size)
+        for (c in OuraIbiChannel.entries) {
+            assertEquals(
+                "$c must map to the SAME durable storage code on both sides",
+                c.code,
+                OuraStreamMapping.rrChannel(c)?.code,
+            )
+        }
+        assertNull(OuraStreamMapping.rrChannel(null))
+    }
+
+    /**
+     * The raw codes are a DURABLE storage format (`rrInterval.srcChannel`, and the `.noopbak` that
+     * carries it between platforms), so renumbering a case would silently relabel stored history.
+     * Pinned here rather than trusted to declaration order. Twin of the Swift assertion.
+     */
+    @Test
+    fun channelCodesAreTheDurableStorageValues() {
+        assertEquals(1, RrSourceChannel.GREEN_QUALITY.code)
+        assertEquals(2, RrSourceChannel.SPO2_IBI.code)
+        assertEquals(3, RrSourceChannel.IBI_AMPLITUDE.code)
+        assertEquals(1, OuraIbiChannel.GREEN_QUALITY.code)
+        assertEquals(2, OuraIbiChannel.SPO2_IBI.code)
+        assertEquals(3, OuraIbiChannel.IBI_AMPLITUDE.code)
+        assertEquals(RrSourceChannel.SPO2_IBI, RrSourceChannel.fromCode(2))
+        assertNull("an unknown code is unknown, not a default", RrSourceChannel.fromCode(99))
+        assertNull(RrSourceChannel.fromCode(null))
+    }
+
+    // MARK: - The insert path
+
+    @Test
+    fun assignRrSeqCarriesTheChannelOntoTheRowWithoutTouchingTheKey() {
+        val ts = 1_780_916_150L
+        val out = assignRrSeq(
+            "ring",
+            listOf(
+                RrRow(ts, 848, RrSourceChannel.GREEN_QUALITY),
+                RrRow(ts, 848, RrSourceChannel.SPO2_IBI),
+                RrRow(ts, 856, null),
+            ),
+        )
+        assertEquals(listOf(1, 2, null), out.map { it.srcChannel })
+        // seq/ord are unaffected: the two equal beats still get distinct seq (so both are storable),
+        // and all three keep their emission order.
+        assertEquals(listOf(0, 1, 0), out.map { it.seq })
+        assertEquals(listOf(0, 1, 2), out.map { it.ord })
+    }
+
+    @Test
+    fun entityDefaultsSrcChannelToNull_soWhoopAndLegacyRowsStayHonest() {
+        // A WHOOP strap has ONE beat source: there is no channel to name, and NULL says exactly that
+        // rather than asserting a channel nobody measured.
+        assertNull(RrInterval(deviceId = "d", ts = 1L, rrMs = 800).srcChannel)
+        assertNull(RrRow(1L, 800).srcChannel)
+    }
+
+    // MARK: - The migration
+
+    @Test
+    fun migrationIsAdditiveNullableAndNotAKeyChange() {
+        val sql = WhoopDatabase.RR_SRC_CHANNEL_MIGRATION_SQL
+        assertEquals(1, sql.size)
+        assertEquals("ALTER TABLE `rrInterval` ADD COLUMN `srcChannel` INTEGER", sql[0])
+        val upper = sql[0].uppercase()
+        assertTrue(upper.startsWith("ALTER TABLE"))
+        assertTrue("must be additive", upper.contains("ADD COLUMN"))
+        assertFalse("srcChannel must be nullable", upper.contains("NOT NULL"))
+        assertFalse("no default — absent means no channel to name", upper.contains("DEFAULT"))
+        for (banned in listOf("DROP ", "DELETE ", "UPDATE ", "INSERT ", "PRIMARY KEY")) {
+            assertFalse("migration must not contain $banned", upper.contains(banned))
+        }
+        assertEquals(25, WhoopDatabase.MIGRATION_25_26.startVersion)
+        assertEquals(26, WhoopDatabase.MIGRATION_25_26.endVersion)
+    }
+
+    // MARK: - The read filter
+
+    /**
+     * The read is the half that actually fixes the numbers, and it is SQL — so it is audited as source.
+     * The behavioural end of it is the Swift twin, which CI runs against a real SQLite.
+     */
+    @Test
+    fun rrIntervalsReadsOneChannelAndKeepsNullRows() {
+        val q = rrIntervalsQuery().replace(Regex("\\s+"), " ")
+
+        assertTrue(
+            "the scoring read must exclude the SpO2 channel: $q",
+            q.contains("srcChannel <> ${RrSourceChannel.SPO2_IBI.code}"),
+        )
+        // NULL must survive the filter. `srcChannel <> 2` alone is NULL (not true) for a NULL row, so
+        // SQLite would drop every WHOOP night and every pre-v26 row — the one way this predicate can
+        // quietly delete real data.
+        assertTrue(
+            "NULL rows (WHOOP, pre-v26) must be kept explicitly: $q",
+            q.contains("srcChannel IS NULL OR"),
+        )
+        // The amplitude channel is deliberately NOT excluded: on a ring where 0x60 is the only beat
+        // source, excluding it would leave nothing to score.
+        assertFalse(
+            "only the demonstrated duplicate is excluded: $q",
+            q.contains("srcChannel <> ${RrSourceChannel.IBI_AMPLITUDE.code}"),
+        )
+        // #823's emission order still leads the sort — the filter must not have displaced it.
+        assertTrue("emission order must still lead: $q", q.contains("ORDER BY ts ASC, ord ASC"))
+    }
+
+    /** The `@Query` body attached to `rrIntervals`, string fragments joined, comments excluded. */
+    private fun rrIntervalsQuery(): String {
+        val userDir = File(System.getProperty("user.dir") ?: ".")
+        val rel = "src/main/java/com/noop/data/WhoopDao.kt"
+        val found = listOf(File(userDir, rel), File(userDir, "app/$rel"), File(userDir, "android/app/$rel"))
+            .firstOrNull { it.isFile }
+        assertNotNull(
+            "WhoopDao.kt not found from user.dir=$userDir — this guard cannot run, and a skip here " +
+                "reads as a pass. Add this host's working dir to the list rather than letting it slide.",
+            found,
+        )
+        val src = found!!.readText()
+        val decl = src.indexOf("suspend fun rrIntervals(")
+        assertTrue("rrIntervals not found — was it renamed?", decl > 0)
+        val annotationStart = src.lastIndexOf("@Query(", decl)
+        assertTrue("no @Query above rrIntervals", annotationStart > 0)
+        val block = src.substring(annotationStart, decl)
+        return Regex("\"([^\"]*)\"").findAll(block).joinToString("") { it.groupValues[1] }
+    }
+}

--- a/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
+++ b/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
@@ -66,11 +66,11 @@ class DecoderGoldenTest {
         val ibis = OuraDecoders.decodeSpO2IBI(rec)
         assertEquals(
             listOf(
-                OuraIBI(ringTimestamp = rt, ibiMs = 400),
-                OuraIBI(ringTimestamp = rt, ibiMs = 320),
-                OuraIBI(ringTimestamp = rt, ibiMs = 240),
-                OuraIBI(ringTimestamp = rt, ibiMs = 160),
-                OuraIBI(ringTimestamp = rt, ibiMs = 80),
+                OuraIBI(ringTimestamp = rt, ibiMs = 400, channel = OuraIbiChannel.SPO2_IBI),
+                OuraIBI(ringTimestamp = rt, ibiMs = 320, channel = OuraIbiChannel.SPO2_IBI),
+                OuraIBI(ringTimestamp = rt, ibiMs = 240, channel = OuraIbiChannel.SPO2_IBI),
+                OuraIBI(ringTimestamp = rt, ibiMs = 160, channel = OuraIbiChannel.SPO2_IBI),
+                OuraIBI(ringTimestamp = rt, ibiMs = 80, channel = OuraIbiChannel.SPO2_IBI),
             ),
             ibis,
         )

--- a/android/app/src/test/resources/schema_oracle.json
+++ b/android/app/src/test/resources/schema_oracle.json
@@ -1,6 +1,6 @@
 {
   "_readme": "SHARED Room<->GRDB SCHEMA ORACLE (#775). Two byte-identical copies: Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json and android/app/src/test/resources/schema_oracle.json. SchemaOracleTests.swift compares GRDB's PRAGMA table_info/index_list against it; SchemaOracleTest.kt compares Room's exported schema JSON against it. `columns` is the iOS/GRDB shape in GRDB column order (macOS is the reference implementation); every way Android differs is spelled out in an `android` / `iosAbsent` / `androidColumnOrder` override naming a key in `divergenceReasons`. Adding a column, reordering one, or changing a type/nullability on one platform only fails both suites until it is either fixed or written down here.",
-  "roomVersion": 25,
+  "roomVersion": 26,
   "grdbMigrations": [
     "v1",
     "v2",
@@ -32,7 +32,8 @@
     "v28-raw-imu",
     "v29-score-input-provenance",
     "v30-rr-ord",
-    "v31-deep-capture-channels"
+    "v31-deep-capture-channels",
+    "v32-rr-src-channel"
   ],
   "divergenceReasons": {
     "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android \u2014 the per-row upload flag belongs to an upload path that does not exist there \u2014 so it is dead width, not divergent data. Removing it needs a Room table rebuild.",
@@ -1313,6 +1314,12 @@
         },
         {
           "name": "ord",
+          "affinity": "INTEGER",
+          "notNull": false,
+          "default": null
+        },
+        {
+          "name": "srcChannel",
           "affinity": "INTEGER",
           "notNull": false,
           "default": null


### PR DESCRIPTION
Fixes #1071.

**Branch:** `fix/oura-rr-two-optical-channels-1071` (based on `main` @ `3b86b6ef`, commit `f5c23628`)
**Base:** `main` — the defect is byte-identical on `main`.
**Related:** #823 (beat order within a second) and #1072 (its root cause) are unblocked by this —
`ord` is meaningless while two channels are interleaved in one stream.

---

## The bug

Two Oura tags decode to R-R intervals and both were mapped to `OuraEvent.ibi`, so both landed in
`rrInterval` with nothing to tell them apart:

- **0x80** `green_ibi_quality_event` — green LED, an 11-bit value on the **1 ms grid**, gated on the
  ring's own `quality == 1` flag and a 300-2000 ms physiological window. Runs the **whole night**.
- **0x6E** `spo2_ibi_and_amplitude_event` — `byte * 8`, so always on the **8 ms grid**. No quality
  gate. Present **only while an SpO2 measurement is running**.

They are not different beats. They are the same heartbeats measured by two optical channels, so the
store held roughly **two complete copies of every night**.

Measured over one 488-minute sleep window (Gen 3, app 9.3.1):

| | |
|---|---|
| Beats stored in `rrInterval` | 61,524 |
| Beats the measured HR curve allows | 29,800 |
| Ratio | **2.06×** |
| `sum(rrMs) / wall-clock` | **2.17×** |

### Why this is the channels and not sync accumulation

The 8 ms-grid stream is **absent** until SpO2 measurement starts, then tracks it exactly. First SpO2
sample of this night: **00:02**.

| window | 8 ms beats | 1 ms beats | 8 ms share | `spo2Sample` rows |
|---|---|---|---|---|
| 23:14–23:44 | 315 | 1890 | **14 %** — the 12.5 % chance rate, i.e. no real 0x6E | **0** |
| 23:44–00:14 | 1165 | 1431 | 45 % | 52 |
| 01:14–01:44 | 2768 | 1702 | 62 % | 138 |
| 03:44–04:14 | 2744 | 1377 | 67 % | 138 |
| 06:44–07:14 | 2543 | 1313 | 66 % | 138 |

On a night where SpO2 barely ran the 8 ms share is 30 % and the whole-night ratio is only **1.09×**.
Across one week the ratio spans **1.09× – 4.11×** — that spread is the SpO2 duty cycle, not sync
history.

### What it breaks, and what it does not

A mean is insensitive to duplication, so `meanNN` (1041 ms = 57.6 bpm, matching `hrSample`) and
resting HR were **never wrong**. It is the variability statistics — built entirely from successive
differences — that collapse. The app's own always-on diagnostic has been reporting this for a while:

```
hrv diag day=… rmssd=68ms sdnn=201ms meanNN=1041ms rr=60052/53117
               coverage=2.21 collapsedCov=1.29 rrIntegrity=crossSecondOverCount
```

A nocturnal SDNN of ~200 ms is not physiological (healthy adult sleep: 40–100 ms).

Both tags are **Tier A**, so neither is behind `allowTierB` — this is reachable in a default build.

---

## The fix

**Not a de-duplication.** Both rows are real measurements of the same beat by different optics, and
the second channel is the obvious future cross-check on the first. So nothing is deleted and nothing
is rewritten:

1. **Label at decode.** Each decoder stamps its own channel — `OuraIBIChannel` (Swift) /
   `OuraIbiChannel` (Kotlin), codes `1` green / `2` spo2 / `3` ibiAmplitude. A channel is never
   guessed: a value from a source that does not report one stays nil.
2. **Carry it to the row.** `RRInterval.srcChannel` / `RrSourceChannel`, persisted as
   `rrInterval.srcChannel` by GRDB **`v32-rr-src-channel`** and Room **`MIGRATION_25_26`** (Room
   version 25 → 26). Additive, nullable, no table rebuild, no existing row touched, and deliberately
   **out of the primary key** — keying on the label would make the same beat insertable twice under
   two labels, which is the double-count being fixed, arrived at from the other direction.
3. **Score off one channel** — the read filters, the table keeps both.

### Why the filter excludes 0x6E rather than whitelisting green

The issue recommends green as the source of truth, and that is what the filter produces. It is
written as an **exclusion** because of what a whitelist would also drop:

- **NULL must survive.** Every WHOOP row is NULL by construction — one beat source, no channel to
  name — as is every row written before v32. A green-only whitelist would delete every WHOOP night
  from scoring.
- **`ibiAmplitude` (0x60/0x44) is kept.** It does not fire on the Gen-3 hardware this was measured
  on, so there is no evidence it duplicates green, and dropping a ring's *only* beat source on an
  untested assumption is the more expensive mistake. If a capture ever shows 0x60 and 0x80 firing
  together, that is a second exclusion, decided on that evidence.

0x6E is the one excluded because it is both the demonstrated duplicate *and* the worse measurement:
8 ms quantisation, no quality gate, and running only while SpO2 is on — so scoring off it would make
HRV coverage a function of the SpO2 duty cycle.

Every R-R consumer already reads through the single `rrIntervals` function on each platform
(`AnalyticsEngine`'s RMSSD/RHR paths and the `hrv diag` trace included), so they all move together
and the trace stays reproducible.

**The raw CSV export is deliberately left unfiltered.** It is the raw dump: both channels are real,
and an export that silently hid half the stored rows would make this defect un-diagnosable from an
export — which is exactly how it was diagnosed.

### Existing data

Pre-migration rows stay NULL and are still read. The channel was never recorded, so historical Oura
nights keep their old inflated coverage rather than a backfilled guess. Noted in the migration
comment for the record: in an existing DB the two remain separable by `rrMs % 8`, an 0x6E row always
being a multiple of 8 and an 0x80 row landing there only 1 time in 8 by chance.

`INTEGER` rather than a text label because `rrInterval` is the highest-volume table in the schema
(~60k rows a night) and this column rides every one.

---

## Cross-platform

Kotlin twin in the same commit, and the shared Room↔GRDB **`schema_oracle.json`** is updated on both
sides (Room version 26, GRDB migration list, and the new `rrInterval.srcChannel` column) — so the
existing drift guard covers this migration on both platforms.

The channel enum is deliberately two enums per platform (`OuraProtocol` does not depend on
`WhoopProtocol`; `com.noop.oura` does not depend on the storage carriers). They pin the same codes,
and the translation is written case by case rather than via `fromCode(...)` so that adding a case on
one side without the other is a **compile error**, not a silent nil. A test asserts they agree
case-for-case and code-for-code on both platforms.

---

## Tests

New — Swift `IbiChannelTests` (OuraProtocol), `RrSourceChannelTests` (WhoopStore), Kotlin
`RrSourceChannelTest`:

- each decoder stamps its own channel, on the same golden fixtures whose *values* are already pinned;
- the driver preserves it, so a 0x6E record and a 0x80 record covering the same interval yield rows
  with distinct `srcChannel` — and **both** still reach the store;
- an unlabelled IBI stays nil rather than being guessed;
- the two channel enums agree case-for-case and code-for-code, and the raw codes are pinned as a
  durable storage format on both platforms;
- migration adds the column, keeps it out of the primary key, and is additive/nullable/no-default;
- both channels are stored and only one is read — the 0x6E rows are asserted still present in the
  table via a test-only unfiltered read;
- WHOOP rows carry no channel and are never filtered, and #823 emission order is unchanged;
- pre-v32 NULL rows are still read, in the pre-v30 fallback order;
- `ibiAmplitude` is not excluded;
- the coverage claim itself: 600 known beats written twice read back as exactly 600.

The Kotlin half guards the read filter by auditing the DAO query text (no SQLite driver on that
unit-test classpath, the same constraint `DeepCaptureMigrationTest` / `HrFrontierQueryShapeTest` work
under); the behavioural end-to-end read is the Swift twin, which CI runs against a real SQLite.

---

## Verification

```
Packages/WhoopProtocol    swift test  531 tests, 0 failures
Packages/OuraProtocol     swift test  164 tests, 0 failures
Packages/WhoopStore       swift test  346 tests, 0 failures
Packages/StrandAnalytics  swift test 1234 tests, 0 failures
Packages/StrandImport     swift test  217 tests, 0 failures (1 skipped)
android  ./gradlew testFullDebugUnitTest --rerun-tasks
         3458 tests, 3 failed — all three are pre-existing on main
         (StandardHrSensorFormatTest ×2 locale, AiCoachContextTest), verified
         by running them on a clean main checkout
```

No app-target Swift is changed, but the package change reaches both app targets, so both were built
locally (CI builds neither by default):

```
xcodebuild -scheme Strand   -destination 'platform=macOS'      → BUILD SUCCEEDED
xcodebuild -scheme NOOPiOS  -destination 'generic/platform=iOS' → BUILD SUCCEEDED
```

Covered by `swift-packages.yml`.

### hardware validation

- [ ] This needs one post-fix overnight capture. The regression check, from
the issue:

- `coverage` in `hrv diag`: **2.21× → ~1.0**
- `SDNN`: **201 ms → 40–100 ms**
- `rrIntegrity`: `crossSecondOverCount` → `plausible`
- `meanNN` / resting HR: **unchanged** (they were never wrong)

If coverage does not move, the channel filter is not actually being read.

---

## Migration numbering

This takes GRDB **`v32`** and Room **26**. #1073 also wants a migration and must therefore use
**`v33` / Room 27**.