### PR TITLE
Android live workout: glanceable vertical-stack parity

### DIFF
--- a/android/app/src/main/java/com/noop/ui/LiveWorkoutScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/LiveWorkoutScreen.kt
@@ -38,7 +38,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.noop.analytics.HrZones
@@ -126,26 +127,48 @@ fun LiveWorkoutScreen(vm: AppViewModel, onClose: () -> Unit) {
                 .padding(28.dp),
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
-            // Header — sport + elapsed clock.
+            // Header — sport name on the left, a recording-status capsule on the right (glanceable
+            // hierarchy parity with the iOS live-workout redesign; the elapsed clock moved to its own
+            // centered TIME hero below).
             Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                    Overline("Recording workout", color = Palette.effortColor)
-                    Text(w.sport.name, style = NoopType.title1, color = Palette.textPrimary)
+                Text(
+                    w.sport.name, style = NoopType.title1, color = Palette.textPrimary,
+                    maxLines = 1, overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    modifier = Modifier
+                        .background(Palette.metricRose.copy(alpha = 0.12f), RoundedCornerShape(50))
+                        .padding(horizontal = 10.dp, vertical = 5.dp),
+                ) {
+                    Box(Modifier.size(7.dp).clip(CircleShape).background(Palette.metricRose))
+                    Overline("Recording workout", color = Palette.metricRose)
                 }
+            }
+
+            // Centered TIME hero — the elapsed clock, promoted out of the header into the glanceable stack.
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                Overline("Time", color = Palette.textSecondary)
                 Text(
                     String.format("%d:%02d", elapsedS / 60, elapsedS % 60),
-                    style = NoopType.number(34f), color = Palette.textPrimary,
+                    style = NoopType.number(56f), color = Palette.textPrimary,
                 )
             }
 
-            // The hero — big live HR, tinted to the current zone.
+            // Centered live-HR hero — tinted to the current zone; the zone label sits on the zone rail below.
             HeroHeartRate(bpm = bpm, zone = zone)
 
-            // The accumulating Effort on the shared layered StrainGauge — liveStrain is on NOOP's 0–100
-            // Effort axis, mapped to the gauge's 0–21 span (mirrors the Today effort hero). Display-only.
+            // The accumulating Effort — same liveStrain source and 0–21 / 0–100 scale, rendered as a centered
+            // free metric to sit alongside TIME and HEART RATE. Keeps the "of N" scale the iOS redesign dropped.
             EffortGauge(liveStrain = w.liveStrain, effortScale = effortScale)
 
-            // Zone rail — five segments, the active one lit.
+            // Zone section — the zone label capsule on the header row, the five-segment rail, and the band.
             ZoneRail(zone = zone, zoneSet = zoneSet)
 
             // Live stats grid — avg / peak / effort, from the captured window.
@@ -248,21 +271,32 @@ private fun SensorRow(sensor: StandardHrSource.SensorMetrics) {
 
 @Composable
 private fun EffortGauge(liveStrain: Double, effortScale: EffortScale) {
-    NoopCard(padding = 18.dp, tint = Palette.effortColor) {
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
-            Overline("Effort building", color = Palette.effortColor)
-            StrainGauge(
-                strain = UnitFormatter.effortValue(liveStrain, effortScale),
-                outOf = if (effortScale == EffortScale.WHOOP) 21.0 else 100.0,
-                valueText = UnitFormatter.effortDisplay(liveStrain, effortScale),
-                diameter = 150.dp,
-                lineWidth = 14.dp,
-            )
-        }
+    val outOf = if (effortScale == EffortScale.WHOOP) 21.0 else 100.0
+    val value = UnitFormatter.effortValue(liveStrain, effortScale)
+    // A centered free metric to sit alongside TIME and HEART RATE (glanceable parity with the iOS
+    // live-workout redesign). The value counts up; the scale denominator stays visible below — a bare
+    // number on the WHOOP 0–21 scale is ambiguous without "of 21", so unlike the iOS change we keep it.
+    // mergeDescendants: read "Effort building, <value>, of N" as one TalkBack utterance (the CountUpText
+    // otherwise reads on its own), matching the iOS effort VoiceOver label without new strings.
+    Column(
+        modifier = Modifier.fillMaxWidth().semantics(mergeDescendants = true) {},
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Overline("Effort building", color = Palette.effortColor)
+        CountUpText(
+            value = value,
+            format = { v ->
+                if (effortScale == EffortScale.WHOOP) String.format(java.util.Locale.US, "%.1f", v)
+                else v.toInt().toString()
+            },
+            style = NoopType.number(56f),
+            color = Palette.textPrimary,
+        )
+        Text(
+            uiString(R.string.l10n_live_workout_screen_of_c5e92da0, outOf.toInt()),
+            style = NoopType.captionNumber, color = Palette.textSecondary,
+        )
     }
 }
 
@@ -273,38 +307,36 @@ private fun HeroHeartRate(bpm: Int?, zone: Int) {
         zone >= 1 -> Palette.hrZoneColor(zone)
         else -> Palette.effortColor
     }
-    NoopCard(padding = 24.dp, tint = Palette.effortColor) {
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(6.dp),
-        ) {
-            Overline("Heart rate")
-            Box(contentAlignment = Alignment.Center) {
-                // Soft zone-tinted halo behind the numeral — the Bevel glow.
-                Box(
-                    modifier = Modifier
-                        .size(132.dp)
-                        .clip(CircleShape)
-                        .background(tint.copy(alpha = if (bpm == null) 0f else 0.14f)),
-                )
-                Text(bpm?.toString() ?: "—", style = NoopType.number(80f), color = tint)
-            }
-            Text("bpm", style = NoopType.subhead, color = Palette.textSecondary)
-            Text(
-                if (zone >= 1) "Zone $zone · ${zoneName(zone)}" else "Below Zone 1",
-                style = NoopType.captionNumber,
-                color = tint,
-                textAlign = TextAlign.Center,
-            )
-        }
+    // Centered free metric — no card chrome, matching the TIME and EFFORT heroes. The zone label moved
+    // to the zone-rail header row below, so the heart rate reads as one clean value.
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Overline("Heart rate", color = Palette.textSecondary)
+        Text(bpm?.toString() ?: "—", style = NoopType.number(72f), color = tint)
+        Text("bpm", style = NoopType.subhead, color = Palette.textSecondary)
     }
 }
 
 @Composable
 private fun ZoneRail(zone: Int, zoneSet: com.noop.analytics.HrZoneSet) {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        Overline("HR zone")
+        // Header row: the section label with the current-zone capsule on the right (moved off the HR hero).
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+            Overline("HR zone")
+            Spacer(Modifier.weight(1f))
+            val capsuleTint = if (zone >= 1) Palette.hrZoneColor(zone) else Palette.effortColor
+            Text(
+                if (zone >= 1) "Zone $zone · ${zoneName(zone)}" else "Below Zone 1",
+                style = NoopType.captionNumber,
+                color = capsuleTint,
+                modifier = Modifier
+                    .background(capsuleTint.copy(alpha = 0.12f), RoundedCornerShape(50))
+                    .padding(horizontal = 10.dp, vertical = 4.dp),
+            )
+        }
         Row(horizontalArrangement = Arrangement.spacedBy(6.dp), modifier = Modifier.fillMaxWidth()) {
             (1..5).forEach { z ->
                 val active = z == zone

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -633,6 +633,7 @@
     <string name="l10n_live_workout_screen_cadence_68af11f0">Trittfrequenz</string>
     <string name="l10n_live_workout_screen_cancel_77dfd213">Abbrechen</string>
     <string name="l10n_live_workout_screen_effort_8c974bc6">Anstrengung</string>
+    <string name="l10n_live_workout_screen_of_c5e92da0">von %1$d</string>
     <string name="l10n_live_workout_screen_end_this_workout_4869c76a">Workout beenden?</string>
     <string name="l10n_live_workout_screen_end_workout_3e8d6238">Workout beenden</string>
     <string name="l10n_live_workout_screen_peak_c83dbbd3">Spitze</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -463,6 +463,7 @@
     <string name="l10n_live_workout_screen_cadence_68af11f0">Cadence</string>
     <string name="l10n_live_workout_screen_cancel_77dfd213">Cancelar</string>
     <string name="l10n_live_workout_screen_effort_8c974bc6">Esfuerzo</string>
+    <string name="l10n_live_workout_screen_of_c5e92da0">de %1$d</string>
     <string name="l10n_live_workout_screen_end_this_workout_4869c76a">¿Finalizar entrenamiento?</string>
     <string name="l10n_live_workout_screen_end_workout_3e8d6238">Finalizar entrenamiento</string>
     <string name="l10n_live_workout_screen_peak_c83dbbd3">Pico</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -463,6 +463,7 @@
     <string name="l10n_live_workout_screen_cadence_68af11f0">Cadence</string>
     <string name="l10n_live_workout_screen_cancel_77dfd213">Annuler</string>
     <string name="l10n_live_workout_screen_effort_8c974bc6">Effort</string>
+    <string name="l10n_live_workout_screen_of_c5e92da0">sur %1$d</string>
     <string name="l10n_live_workout_screen_end_this_workout_4869c76a">Terminer l\'entraînement ?</string>
     <string name="l10n_live_workout_screen_end_workout_3e8d6238">Terminer l\'entraînement</string>
     <string name="l10n_live_workout_screen_peak_c83dbbd3">Pic</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -616,6 +616,7 @@
     <string name="l10n_live_workout_screen_cadence_68af11f0">Cadência</string>
     <string name="l10n_live_workout_screen_cancel_77dfd213">Cancelar</string>
     <string name="l10n_live_workout_screen_effort_8c974bc6">Esforço</string>
+    <string name="l10n_live_workout_screen_of_c5e92da0">de %1$d</string>
     <string name="l10n_live_workout_screen_end_this_workout_4869c76a">Terminar este treino?</string>
     <string name="l10n_live_workout_screen_end_workout_3e8d6238">Terminar treino</string>
     <string name="l10n_live_workout_screen_peak_c83dbbd3">Pico</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -602,6 +602,7 @@
     <string name="l10n_live_workout_screen_avg_cdc93143">平均</string>
     <string name="l10n_live_workout_screen_cadence_68af11f0">步频/踏频</string>
     <string name="l10n_live_workout_screen_effort_8c974bc6">负荷</string>
+    <string name="l10n_live_workout_screen_of_c5e92da0">共 %1$d</string>
     <string name="l10n_live_workout_screen_end_workout_3e8d6238">结束运动</string>
     <string name="l10n_live_workout_screen_peak_c83dbbd3">峰值</string>
     <string name="l10n_live_workout_screen_power_7548ab52">功率</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -634,6 +634,7 @@
     <string name="l10n_live_workout_screen_cadence_68af11f0">Cadence</string>
     <string name="l10n_live_workout_screen_cancel_77dfd213">Cancel</string>
     <string name="l10n_live_workout_screen_effort_8c974bc6">Effort</string>
+    <string name="l10n_live_workout_screen_of_c5e92da0">of %1$d</string>
     <string name="l10n_live_workout_screen_end_this_workout_4869c76a">End this workout?</string>
     <string name="l10n_live_workout_screen_end_workout_3e8d6238">End workout</string>
     <string name="l10n_live_workout_screen_peak_c83dbbd3">Peak</string>


### PR DESCRIPTION
## What this does

Restructures the Android in-exercise **live workout** screen to the glanceable hierarchy from the iOS redesign (#1068's `LiveWorkoutView`): a sport-name header with a **recording-status capsule**, then centered **TIME / HEART RATE / EFFORT** heroes, and the **HR-zone label as a capsule** on the zone-rail header row.

Scoped from the #1068 parity gap analysis — the live-workout screen was the one place Android's UI had genuinely fallen behind iOS. Feature-level parity per the CLAUDE.md contract, not a pixel port.

### Kept, unlike the iOS change
Effort keeps its **"of 21" / "of 100"** scale caption (localized de/es/fr/pt-PT/zh). Android already showed this; a bare number on the WHOOP 0–21 scale is ambiguous without it, so — unlike the iOS PR, which dropped the scale for a state word — we keep it.

### Deliberately not matched
iOS's latest effort block renders a strain **state word** (LIGHT/MODERATE/…) that Android has no byte-parity twin for; adding one is a separate change (new function + its own localized strings), so this keeps the numeric value + scale instead.

## Cross-platform
Android-only by design (iOS already has this via #1068). No analytics, decoder, stored-data, or BLE change — same `liveStrain` / bpm / zone sources and `effortValue`/`effortScale` mapping. The #845 scroll fix, `navigationBarsPadding`, sensor readout, and End-confirm are all preserved.

## Testing
- `:app:compileFullDebugKotlin` — BUILD SUCCESSFUL.
- `Tools/i18n_audit.py --ci` — exit 0 (one new `of %1$d` string, added to all focus locales + zh).
- **Not device-verified** — Compose can't render on this Linux box, so the visual layout needs an on-device glance before merge.