### PR TITLE
Android trends: neutralize card surfaces (EXP-004 parity)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
@@ -238,7 +238,6 @@ fun TrendsScreen(vm: AppViewModel) {
                 headlineValue = recAvg,
                 color = Palette.chargeColor,
                 tipColor = Palette.chargeBright,
-                tint = Palette.chargeColor,
                 values = recovery.values,
                 dates = recovery.dates,
                 formatY = { "${it.roundToInt()}" },
@@ -257,8 +256,9 @@ fun TrendsScreen(vm: AppViewModel) {
             )
         }
 
-        // --- Small multiples , HRV / Resting HR / Effort. HRV/RHR are Charge sub-signals → the green
-        // card world (each line keeps its metric hue); Effort is the WHOOP blue strain world. ---
+        // --- Small multiples , HRV / Resting HR / Effort. HRV/RHR are Charge sub-signals; the card
+        // surface is neutral (EXP-004) and each line keeps its metric hue; Effort is the WHOOP blue
+        // strain world. ---
         // No trailing window label , the range bar's overline already states it.
         item {
             Column(
@@ -269,7 +269,6 @@ fun TrendsScreen(vm: AppViewModel) {
                 MetricTrendCard(
                     title = stringResource(R.string.trends_hrv_full), unit = "ms",
                     color = Palette.metricPurple,
-                    tint = Palette.chargeColor,
                     higherIsBetter = true,
                     resolved = hrv,
                     fmt = { "${it.roundToInt()}" },
@@ -277,7 +276,6 @@ fun TrendsScreen(vm: AppViewModel) {
                 MetricTrendCard(
                     title = stringResource(R.string.trends_resting_hr_full), unit = "bpm",
                     color = Palette.metricRose,
-                    tint = Palette.chargeColor,
                     higherIsBetter = false,
                     resolved = rhr,
                     fmt = { "${it.roundToInt()}" },
@@ -452,7 +450,7 @@ private fun WeekInReviewCard(
     val restAvg = rest.values.averageOrNull()
     if (chargeAvg == null && effortAvg == null && restAvg == null) return
 
-    NoopCard(modifier = modifier, tint = Palette.chargeColor) {
+    NoopCard(modifier = modifier) {
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             SectionHeader(stringResource(R.string.trends_week_in_review), overline = stringResource(R.string.trends_charge_effort_rest))
             if (chargeAvg != null) {
@@ -973,7 +971,7 @@ private fun RecoveryHistoryCard(days: List<DailyMetric>, range: TrendsRange) {
         "Charge , past year"
     }
 
-    NoopCard(tint = Palette.chargeColor) {
+    NoopCard {
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             SectionHeader(title, overline = stringResource(R.string.trends_calendar), trailing = "${recovery.size} days")
             if (recovery.size >= 2) {


### PR DESCRIPTION
## What this does

Neutralizes the Trends card surfaces to match the iOS cleanup (#1068's EXP-004): drops the green (`chargeColor`) surface glow from the **HRV** and **Resting-HR** small multiples, the **Week-in-Review** card, and the **Charge history** strip.

**Semantic colors stay inside the data graphics** (the key constraint): the HRV line stays purple, the RHR line stays rose, and the Week-in-Review Charge pip keeps its green fill. Card contents, order, chart data, and interactions are unchanged.

The Charge hero already renders neutral on Android — its liquid frosted-black wrapper ignores the `tint` under `liquidHero=true` — so it needed no visual change; its dead `tint` argument is removed for clarity.

Scoped from the #1068 parity gap analysis (the one clearly-worthwhile cosmetic item). Note: iOS's EXP-004 also removed a redundant "WEEK IN REVIEW" subtitle, but that's entangled with Android's deliberate pip-language weekly summary (EXP-009/012, which the gap analysis flagged as a regression to port) — so this PR is the tint neutralization only.

## Cross-platform
Android-only (iOS via #1068). No analytics, decoder, stored-data, or BLE change — pure surface-tint removal.

## Testing
- `:app:compileFullDebugKotlin` — BUILD SUCCESSFUL.
- `Tools/i18n_audit.py --ci` — exit 0 (no string changes).
- **Not device-verified** — Compose can't render on this Linux box, so the neutral-surface look needs an on-device glance.