### PR TITLE
fix(oura): hand the store a record's beats at once so beat order stops being 0

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -175,6 +175,33 @@ public enum OuraStreamMapping {
         return out
     }
 
+    /// Group already-stamped events into ONE batch per timestamp, keeping the order they arrived in
+    /// (and the first-appearance order of the timestamps themselves). Pure → unit-testable.
+    ///
+    /// This exists because `StreamStore.insert`'s `seq` / `ord` counters are **batch-local by design**:
+    /// `ord` is a beat's position among the beats that share its second *within one insert*, which is
+    /// the only place emission order is still known (v30, #823). A transport that hands the store one
+    /// event per insert therefore restarts the counter on every beat and writes `ord = 0` on every row
+    /// — measured on a real database as 575,630 of 575,630 rows (#1072). With `ord` tied, the read falls
+    /// through to `(rrMs, seq)`, i.e. a second's beats come back sorted by VALUE, and RMSSD — built
+    /// entirely from successive differences — is biased down by construction.
+    ///
+    /// One record's beats all carry that record's own ring time, so grouping by the resolved timestamp
+    /// is what hands the store a record's beats together. Order is the only property callers may rely
+    /// on: events keep their relative order inside a batch, so `ord` counts in emission order.
+    public static func batched(_ stamped: [(event: OuraEvent, ts: Int)]) -> [(ts: Int, events: [OuraEvent])] {
+        var order: [Int] = []
+        var byTs: [Int: [OuraEvent]] = [:]
+        for s in stamped {
+            if byTs[s.ts] == nil {
+                order.append(s.ts)
+                byTs[s.ts] = []
+            }
+            byTs[s.ts]?.append(s.event)
+        }
+        return order.map { (ts: $0, events: byTs[$0] ?? []) }
+    }
+
     /// Translate the protocol layer's `OuraIBIChannel` to the store's `RRSourceChannel` (#1071).
     ///
     /// Two enums rather than one because `OuraProtocol` deliberately does not depend on `WhoopProtocol`

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/MigrationTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/MigrationTests.swift
@@ -106,6 +106,54 @@ final class MigrationTests: XCTestCase {
                              "sorted order should be the badly-biased one this fix avoids")
     }
 
+    /// `ord` is BATCH-LOCAL — a beat's position among the beats sharing its second *in this insert* —
+    /// which is what let #1072 happen: a transport that inserts one beat at a time restarts the counter
+    /// on every row, so every beat is written `ord = 0` and the v30 fix silently does nothing. With
+    /// `ord` tied the read falls back to `(rrMs, seq)`, i.e. magnitude order, which is exactly the #823
+    /// symptom. This pins both shapes side by side so the store-side contract the Oura call sites now
+    /// satisfy (one record's beats = one insert) cannot regress unnoticed.
+    func testV30OrdIsBatchLocalSoOneInsertPerBeatRecordsNoOrder() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: "dev1", mac: nil, name: nil)
+        let emission = [812, 795, 840, 801, 833]
+        for v in emission {   // the pre-#1072 Oura shape: one insert per beat
+            _ = try await store.insert(Streams(rr: [RRInterval(ts: 400, rrMs: v)]), deviceId: "dev1")
+        }
+        let ords = try await store.rrOrdValuesForTest(deviceId: "dev1", ts: 400)
+        XCTAssertEqual(ords, [0, 0, 0, 0, 0], "a one-beat insert can only ever compute ord 0")
+        let read = try await store.rrIntervals(deviceId: "dev1", from: 0, to: 1_000, limit: 100)
+        XCTAssertEqual(read.map(\.rrMs), emission.sorted(),
+                       "tied ord falls through to (rrMs, seq) — the magnitude order #823 reports")
+
+        // The same beats delivered as ONE insert keep their emission order, `ord` counting 0,1,2,…
+        _ = try await store.insert(
+            Streams(rr: emission.map { RRInterval(ts: 500, rrMs: $0) }), deviceId: "dev1")
+        let batchedOrds = try await store.rrOrdValuesForTest(deviceId: "dev1", ts: 500)
+        XCTAssertEqual(batchedOrds, [0, 1, 2, 3, 4])
+    }
+
+    /// The second consequence of insert-per-beat, and the reason a post-fix night holds slightly MORE
+    /// rows than a pre-fix one: `seq` (v24) exists so two beats with the same interval in the same
+    /// second survive as distinct rows, and it is batch-local for the same reason `ord` is. One insert
+    /// per beat recomputed `seq = 0` for the second beat, so it collided on the primary key and was
+    /// silently dropped by `ON CONFLICT DO NOTHING`. Batched, both are stored — real beats recovered,
+    /// not duplicates invented.
+    func testEqualIntervalsInOneRecordSurviveOnlyWhenTheRecordIsOneInsert() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: "dev1", mac: nil, name: nil)
+        for _ in 0..<2 {   // the pre-#1072 shape
+            _ = try await store.insert(Streams(rr: [RRInterval(ts: 600, rrMs: 812)]), deviceId: "dev1")
+        }
+        let dropped = try await store.rrIntervals(deviceId: "dev1", from: 590, to: 610, limit: 100)
+        XCTAssertEqual(dropped.count, 1, "insert-per-beat silently loses the second identical beat")
+
+        _ = try await store.insert(
+            Streams(rr: [RRInterval(ts: 700, rrMs: 812), RRInterval(ts: 700, rrMs: 812)]),
+            deviceId: "dev1")
+        let kept = try await store.rrIntervals(deviceId: "dev1", from: 690, to: 710, limit: 100)
+        XCTAssertEqual(kept.count, 2, "batched, seq 0/1 keeps both beats")
+    }
+
     /// Rows written before v30 have `ord` NULL — the order was never recorded, so it cannot be
     /// backfilled. SQLite sorts NULL first in ASC, so an all-legacy second ties on `ord` and falls
     /// through to the old (rrMs, seq) order: existing data reads back exactly as it did before.

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
@@ -225,6 +225,53 @@ final class OuraStreamMappingTests: XCTestCase {
         XCTAssertTrue(s.steps.isEmpty, "activity/MET must never fabricate a steps row")
     }
 
+    // MARK: - Batching a record's events into one insert (#1072, root cause for #823)
+
+    /// The defect's shape: the store's `ord` counter is batch-local, so a record's beats only get a
+    /// real emission order if they reach the store TOGETHER. Grouping is by the resolved second.
+    func testBatchedGroupsOneRecordsBeatsIntoASingleBatch() {
+        let beats = [812, 795, 840, 801, 833]
+        let batches = OuraStreamMapping.batched(beats.map {
+            (event: OuraEvent.ibi(OuraIBI(ringTimestamp: 100, ibiMs: $0)), ts: ts)
+        })
+        XCTAssertEqual(batches.count, 1, "one record's beats must be ONE batch, not five")
+        XCTAssertEqual(batches[0].ts, ts)
+        XCTAssertEqual(batches[0].events.count, beats.count)
+        // Emission order inside the batch is the whole point — it is what `ord` will record.
+        let rr = OuraStreamMapping.streams(from: batches[0].events, at: batches[0].ts).rr
+        XCTAssertEqual(rr.map { $0.rrMs }, beats)
+    }
+
+    /// Two records anchored to different seconds stay separate batches, in the order they arrived —
+    /// `ord` numbers beats within a second, so merging distinct seconds would mean nothing.
+    func testBatchedKeepsDistinctTimestampsSeparateAndInArrivalOrder() {
+        let batches = OuraStreamMapping.batched([
+            (event: .ibi(OuraIBI(ringTimestamp: 100, ibiMs: 800)), ts: ts + 3),
+            (event: .ibi(OuraIBI(ringTimestamp: 100, ibiMs: 810)), ts: ts + 3),
+            (event: .ibi(OuraIBI(ringTimestamp: 200, ibiMs: 900)), ts: ts),
+        ])
+        XCTAssertEqual(batches.map { $0.ts }, [ts + 3, ts],
+                       "timestamps keep first-appearance order, they are not re-sorted")
+        XCTAssertEqual(batches.map { $0.events.count }, [2, 1])
+    }
+
+    /// Same-second events that arrive interleaved with other seconds still land in one batch, and
+    /// their relative order is preserved — the store may never see a second's beats twice.
+    func testBatchedFoldsInterleavedSameSecondEventsIntoOneBatch() {
+        let batches = OuraStreamMapping.batched([
+            (event: .ibi(OuraIBI(ringTimestamp: 100, ibiMs: 800)), ts: ts),
+            (event: .ibi(OuraIBI(ringTimestamp: 200, ibiMs: 900)), ts: ts + 1),
+            (event: .ibi(OuraIBI(ringTimestamp: 100, ibiMs: 810)), ts: ts),
+        ])
+        XCTAssertEqual(batches.count, 2)
+        XCTAssertEqual(OuraStreamMapping.streams(from: batches[0].events, at: ts).rr.map { $0.rrMs },
+                       [800, 810])
+    }
+
+    func testBatchedOnEmptyInputYieldsNoBatches() {
+        XCTAssertTrue(OuraStreamMapping.batched([]).isEmpty)
+    }
+
     // MARK: - Empty batch + multi-signal batch
 
     func testEmptyBatchYieldsEmptyStreams() {

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -1064,9 +1064,10 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     private func drainPendingAnchorEvents() {
         guard !pendingAnchorEvents.isEmpty, let driver else { return }
         let now = Int(Date().timeIntervalSince1970)
+        var stamped: [(event: OuraEvent, ts: Int)] = []
         for pending in pendingAnchorEvents {
             if let ts = driver.unixSeconds(forRingTimestamp: pending.ringTimestamp) {
-                enqueue([pending.event], ts: ts)
+                stamped.append((event: pending.event, ts: ts))
                 // A parked IBI can be a LIVE beat that arrived before the anchor (see .ibi in ingest());
                 // it must never advance the resume cursor either, or a live push could skip un-drained
                 // backlog on a force-stopped drain. Only the history-only siblings drive the cursor.
@@ -1074,8 +1075,13 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                     noteStoredHistoryRingTime(pending.ringTimestamp)   // parked history sample placed → advance resume cursor
                 }
             } else {
-                enqueue([pending.event], ts: now)   // honest wall-clock fallback; NEVER advances the cursor
+                stamped.append((event: pending.event, ts: now))   // honest wall-clock fallback; NEVER advances the cursor
             }
+        }
+        // Batched by resolved second, exactly like the live path (#1072): a record's parked beats are
+        // released as ONE insert so `ord` records their emission order instead of restarting at 0 per beat.
+        for batch in OuraStreamMapping.batched(stamped) {
+            enqueue(batch.events, ts: batch.ts)
         }
         pendingAnchorEvents.removeAll()
     }
@@ -1155,6 +1161,24 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 }
             }
         }
+        // #1072 (root cause for #823): a RECORD's beats must reach the store as ONE batch. `StreamStore`'s
+        // `ord` counter is batch-local — a beat's position among the beats sharing its second WITHIN one
+        // insert is the only place emission order still exists — so enqueuing one beat at a time (what the
+        // `.ibi` arm below used to do) restarted the counter on every beat and wrote `ord = 0` on every
+        // row: 575,630 of 575,630 rows in a real database. With `ord` tied the read falls through to
+        // `(rrMs, seq)`, i.e. a second's beats come back sorted by VALUE, which minimises successive
+        // differences by construction and biases RMSSD down (#823). All of one record's beats carry that
+        // record's ring time, so grouping the anchored ones by their resolved `ts` hands the store a
+        // record at a time and `ord` becomes their real emission order. Unanchored beats still park below
+        // and are batched the same way when the 0x42 lands (`drainPendingAnchorEvents`).
+        let anchoredBeats: [(event: OuraEvent, ts: Int)] = events.compactMap { e in
+            guard case .ibi(let ibi) = e,
+                  let ts = driver.unixSeconds(forRingTimestamp: ibi.ringTimestamp) else { return nil }
+            return (event: e, ts: ts)
+        }
+        for batch in OuraStreamMapping.batched(anchoredBeats) {
+            enqueue(batch.events, ts: batch.ts)
+        }
         for e in events {
             switch e {
             case .hr(let hr):
@@ -1187,17 +1211,18 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 // A banked IBI is history data: anchor it to its REAL ring-time, exactly like the sibling
                 // banked streams (.hrv/.temp/.spo2/.sleepPhase) below — never the drain-arrival `now`.
                 // Stamping it at `now` (52b6e88d) misfiled every overnight beat to the daytime sync moment,
-                // so the sleep window ended up with zero R-R -> no restingHr/avgHrv for the night.
-                if let ts = driver.unixSeconds(forRingTimestamp: ibi.ringTimestamp) {
-                    enqueue([e], ts: ts)
-                    // NOTE: unlike the history-only siblings, do NOT noteStoredHistoryRingTime here — IBI is
-                    // the one stream that arrives both LIVE (ring-time ~now) and banked, indistinguishable
-                    // at this call site except by ring-time. Letting a live beat advance the resume cursor
-                    // could leap `maxStoredRingTime` to ~now during a force-stopped drain (300s/stall guard,
-                    // bytes_left > 0) and permanently skip the un-drained backlog. The resume cursor is still
-                    // driven correctly by the history-only siblings (hrv/temp/spo2/sleepPhase) that share the
-                    // same night window; this also matches Kotlin, which notes no stream's ring-time.
-                } else {
+                // so the sleep window ended up with zero R-R -> no restingHr/avgHrv for the night. The
+                // anchored beats were ALREADY enqueued above, as one batch per record (#1072); all this arm
+                // still owns is the live readout and parking the ones no anchor can place yet.
+                //
+                // NOTE: unlike the history-only siblings, an IBI never calls noteStoredHistoryRingTime — it
+                // is the one stream that arrives both LIVE (ring-time ~now) and banked, indistinguishable
+                // at this call site except by ring-time. Letting a live beat advance the resume cursor
+                // could leap `maxStoredRingTime` to ~now during a force-stopped drain (300s/stall guard,
+                // bytes_left > 0) and permanently skip the un-drained backlog. The resume cursor is still
+                // driven correctly by the history-only siblings (hrv/temp/spo2/sleepPhase) that share the
+                // same night window; this also matches Kotlin, which notes no stream's ring-time.
+                if driver.unixSeconds(forRingTimestamp: ibi.ringTimestamp) == nil {
                     pendingAnchorEvents.append((e, ibi.ringTimestamp))
                 }
 

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -1009,10 +1009,12 @@ class OuraLiveSource(
         if (pendingAnchorEvents.isEmpty()) return@guardedCallback
         val d = driver ?: return@guardedCallback
         val now = (System.currentTimeMillis() / 1000L).toInt()
-        for ((event, ringTimestamp) in pendingAnchorEvents) {
-            val ts = d.unixSeconds(forRingTimestamp = ringTimestamp)?.toInt() ?: now
-            enqueue(listOf(event), ts)
+        // Batched by resolved second, exactly like the live path (#1072): a record's parked beats are
+        // released as ONE persist so `ord` records their emission order instead of restarting at 0 per beat.
+        val stamped = pendingAnchorEvents.map { (event, ringTimestamp) ->
+            event to (d.unixSeconds(forRingTimestamp = ringTimestamp)?.toInt() ?: now)
         }
+        for ((ts, batch) in OuraStreamMapping.batched(stamped)) enqueue(batch, ts)
         pendingAnchorEvents.clear()
     }
 
@@ -1554,6 +1556,21 @@ class OuraLiveSource(
                 if (ts != null) enqueue(listOf(OuraEvent.Hr(hr)), ts.toInt())
             }
         }
+        // #1072 (root cause for #823): a RECORD's beats must reach the store as ONE batch. [assignRrSeq]'s
+        // `ord` counter is batch-local — a beat's position among the beats sharing its second WITHIN one
+        // persist is the only place emission order still exists — so enqueuing one beat at a time (what the
+        // Ibi arm below used to do) restarted the counter on every beat and wrote `ord = 0` on every row:
+        // 575,630 of 575,630 rows in a real database. With `ord` tied the read falls through to
+        // `(rrMs, seq)`, i.e. a second's beats come back sorted by VALUE, which minimises successive
+        // differences by construction and biases RMSSD down (#823). All of one record's beats carry that
+        // record's ring time, so grouping the anchored ones by their resolved ts hands the store a record
+        // at a time. Unanchored beats still park below and are batched the same way when the 0x42 lands
+        // (drainPendingAnchorEvents). Twin of the Swift ingest() batching.
+        val anchoredBeats = events.mapNotNull { e ->
+            if (e !is OuraEvent.Ibi) null
+            else d.unixSeconds(forRingTimestamp = e.value.ringTimestamp)?.let { ts -> e as OuraEvent to ts.toInt() }
+        }
+        for ((ts, batch) in OuraStreamMapping.batched(anchoredBeats)) enqueue(batch, ts)
         for (e in events) when (e) {
             is OuraEvent.Hr -> {
                 val bpm = e.value.bpm
@@ -1592,11 +1609,15 @@ class OuraLiveSource(
             is OuraEvent.Ibi -> {
                 val rr = e.value.ibiMs
                 if (rr in 250..3000) handler.post { guardedCallback("live-sink") { liveSink(0, listOf(rr)) } }
-                // A banked IBI is history data: anchor it to its REAL ring-time (via [enqueueAnchoredOrPark]),
-                // exactly like the sibling banked streams (.Hrv/.Temp/.Spo2/.SleepPhaseEvent) - never the
-                // drain-arrival `now`. Stamping at `now` misfiled every overnight beat to the daytime sync
-                // moment, so the sleep window ended up with zero R-R -> no restingHr/avgHrv for the night.
-                enqueueAnchoredOrPark(e, e.value.ringTimestamp, d)
+                // A banked IBI is history data: anchor it to its REAL ring-time, exactly like the sibling
+                // banked streams (.Hrv/.Temp/.Spo2/.SleepPhaseEvent) - never the drain-arrival `now`.
+                // Stamping at `now` misfiled every overnight beat to the daytime sync moment, so the sleep
+                // window ended up with zero R-R -> no restingHr/avgHrv for the night. The anchored beats
+                // were ALREADY enqueued above, as one batch per record (#1072); all this arm still owns is
+                // the live readout and parking the ones no anchor can place yet.
+                if (d.unixSeconds(forRingTimestamp = e.value.ringTimestamp) == null) {
+                    pendingAnchorEvents.add(e to e.value.ringTimestamp)
+                }
             }
             is OuraEvent.Battery -> {
                 handleBattery(e.value.percent)

--- a/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
+++ b/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
@@ -198,6 +198,28 @@ object OuraStreamMapping {
     }
 
     /**
+     * Group already-stamped events into ONE batch per timestamp, keeping the order they arrived in (and
+     * the first-appearance order of the timestamps themselves). Pure → JVM-unit-testable. Swift twin:
+     * `OuraStreamMapping.batched(_:)`.
+     *
+     * This exists because [com.noop.data.assignRrSeq]'s `seq` / `ord` counters are **batch-local by
+     * design**: `ord` is a beat's position among the beats that share its second *within one persist*,
+     * which is the only place emission order is still known (v30, #823). A transport that hands the
+     * store one event per persist therefore restarts the counter on every beat and writes `ord = 0` on
+     * every row — measured on a real database as 575,630 of 575,630 rows (#1072). With `ord` tied the
+     * read falls through to `(rrMs, seq)`, i.e. a second's beats come back sorted by VALUE, and RMSSD —
+     * built entirely from successive differences — is biased down by construction.
+     *
+     * One record's beats all carry that record's own ring time, so grouping by the resolved timestamp is
+     * what hands the store a record's beats together. Order is the only property callers may rely on.
+     */
+    fun batched(stamped: List<Pair<OuraEvent, Int>>): List<Pair<Int, List<OuraEvent>>> {
+        val byTs = LinkedHashMap<Int, MutableList<OuraEvent>>()
+        for ((event, ts) in stamped) byTs.getOrPut(ts) { mutableListOf() }.add(event)
+        return byTs.map { (ts, events) -> ts to events.toList() }
+    }
+
+    /**
      * Translate the protocol layer's [OuraIbiChannel] to the store's [RrSourceChannel] (#1071).
      *
      * Two enums rather than one because `com.noop.oura` is the pure ring decoder and does not depend on

--- a/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
+++ b/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
@@ -235,6 +235,77 @@ class OuraStreamMappingTest {
         assertTrue(s.hr.isEmpty())
     }
 
+    // --- Batching a record's events into one persist (#1072, root cause for #823) ---
+
+    /**
+     * The defect's shape: [assignRrSeq]'s `ord` counter is batch-local, so a record's beats only get a
+     * real emission order if they reach the store TOGETHER. Grouping is by the resolved second, and the
+     * `ord` values it produces are asserted end-to-end here. Twin of the Swift
+     * `testBatchedGroupsOneRecordsBeatsIntoASingleBatch`.
+     */
+    @Test
+    fun batchedGroupsOneRecordsBeatsIntoASinglePersist() {
+        val beats = listOf(812, 795, 840, 801, 833)
+        val stamped = beats.map { ms ->
+            OuraEvent.Ibi(OuraIBI(ringTimestamp = 10, ibiMs = ms)) as OuraEvent to base + 10
+        }
+        val batches = OuraStreamMapping.batched(stamped)
+        assertEquals("one record's beats must be ONE batch, not five", 1, batches.size)
+        assertEquals(base + 10, batches[0].first)
+
+        // Through the production widening (StreamPersistence.toBatch) so the ord assertion is on the
+        // rows the DAO actually inserts.
+        val rr = StreamPersistence.toBatch(OuraStreamMapping.streams(batches[0].second) { base + 10 }).rr
+        assertEquals(beats, rr.map { it.rrMs })
+        // ord is what the whole change exists for: emission order, not 0 on every row.
+        assertEquals(listOf(0, 1, 2, 3, 4), assignRrSeq("ring", rr).map { it.ord })
+    }
+
+    /** The pre-fix shape, pinned so it cannot come back: one beat per persist can only ever write 0. */
+    @Test
+    fun onePersistPerBeatRecordsNoOrder() {
+        val ords = listOf(812, 795, 840).map { ms ->
+            assignRrSeq("ring", listOf(RrRow(base.toLong(), ms))).single().ord
+        }
+        assertEquals(listOf(0, 0, 0), ords)
+    }
+
+    /** Distinct seconds stay distinct batches, in arrival order — `ord` numbers within a second. */
+    @Test
+    fun batchedKeepsDistinctTimestampsSeparateAndInArrivalOrder() {
+        val batches = OuraStreamMapping.batched(
+            listOf(
+                OuraEvent.Ibi(OuraIBI(ringTimestamp = 13, ibiMs = 800)) as OuraEvent to base + 13,
+                OuraEvent.Ibi(OuraIBI(ringTimestamp = 13, ibiMs = 810)) as OuraEvent to base + 13,
+                OuraEvent.Ibi(OuraIBI(ringTimestamp = 10, ibiMs = 900)) as OuraEvent to base + 10,
+            ),
+        )
+        assertEquals(listOf(base + 13, base + 10), batches.map { it.first })
+        assertEquals(listOf(2, 1), batches.map { it.second.size })
+    }
+
+    /** Interleaved same-second events fold into one batch, relative order preserved. */
+    @Test
+    fun batchedFoldsInterleavedSameSecondEventsIntoOneBatch() {
+        val batches = OuraStreamMapping.batched(
+            listOf(
+                OuraEvent.Ibi(OuraIBI(ringTimestamp = 10, ibiMs = 800)) as OuraEvent to base + 10,
+                OuraEvent.Ibi(OuraIBI(ringTimestamp = 11, ibiMs = 900)) as OuraEvent to base + 11,
+                OuraEvent.Ibi(OuraIBI(ringTimestamp = 10, ibiMs = 810)) as OuraEvent to base + 10,
+            ),
+        )
+        assertEquals(2, batches.size)
+        assertEquals(
+            listOf(800, 810),
+            OuraStreamMapping.streams(batches[0].second) { base + 10 }.rr.map { it.rrMs },
+        )
+    }
+
+    @Test
+    fun batchedOnEmptyInputYieldsNoBatches() {
+        assertTrue(OuraStreamMapping.batched(emptyList()).isEmpty())
+    }
+
     @Test
     fun tierBAndActivityInfoNeverMapToAStream() {
         // HONEST-DATA INVARIANT (PR #960): Tier-B raw summaries AND the decoded-but-unvalidated 0x50


### PR DESCRIPTION
Fixes #1072. Root cause for #823 — that issue's symptom is still live on `main` today.

**Branch:** `fix/oura-rr-ord-batching-1072` (based on `main` @ `7c7b3f0c`, commit `ee79530e`)
**Base:** `main` — the defect is byte-identical on `main`, not an integration-branch regression.
**Depends on:** #1071 (merged as #1076, `fddf9038`). Required: while two optical channels were
interleaved in one stream, `ord` would have numbered an interleaving of two sensors measuring the
same beats, which is not an emission order.

**No migration.** No schema change, no stored-value redefinition — this is a call-site fix. The
column and its counter have been correct since v30.

---

## The bug

`v30-rr-ord` added `rrInterval.ord` so a second's beats could be read in **emission** order rather
than magnitude order. The store-side machinery is right. On the Oura path `ord` is written **0 on
every row**: measured in a real database, **575,630 / 575,630** rows — the value 0, not NULL (NULL
would mean "pre-v30, never recorded"; 0 means the write path ran and computed 0 every time).

The counter is **batch-local by design** — one insert is the only place the order still exists — and
the v30 comment says so:

> *"Same batch-local caveat as seq: a second split across two live flushes restarts ord at 0 …"*

`Strand/BLE/OuraLiveSource.swift` enqueued **one event per batch**:

```swift
case .ibi(let ibi):
    …
    if let ts = driver.unixSeconds(forRingTimestamp: ibi.ringTimestamp) {
        enqueue([e], ts: ts)          // ← single-element array
    }
```

Every batch therefore held exactly one R-R row, `ordByTs` was always fresh, and every beat got
`ord = 0`. `android/…/ble/OuraLiveSource.kt` had the identical shape (`enqueue(listOf(event), ts)`).

### Why it matters

Five to six beats share each timestamp (records arrive ~2.8 s apart). With `ord` tied, reads fall
through to the `(rrMs, seq)` ordering in the primary key — **sorted by value**. RMSSD is built
entirely from successive differences, and sorting a sequence minimises those differences by
construction. That is precisely the bias #823 describes; on that issue's own example, magnitude
order reads 12.72 ms against 34.85 ms in emission order.

## The fix

All of one record's beats carry that record's ring time, so grouping the anchored `.ibi` events of
one ingest by their **resolved second** and enqueuing each group once hands the store a record at a
time — and `ord` becomes their real emission order.

- Grouping is a pure `OuraStreamMapping.batched` (Swift `Packages/WhoopStore`, Kotlin
  `com.noop.data`), so the ordering logic sits where package CI covers it instead of only in
  app-target code that no default CI builds.
- Applied on the live path (`ingest` / `emit`) and where parked beats are released after the 0x42
  anchor lands (`drainPendingAnchorEvents`), which is where a drain's first beats go.
- The `.ibi` arm now owns only the live readout and parking; it no longer enqueues.

Deliberately unchanged:

- an IBI still **never** advances the resume cursor (`noteStoredHistoryRingTime`) — a live beat could
  otherwise leap `maxStoredRingTime` to ~now during a force-stopped drain and permanently skip
  un-drained backlog;
- unanchored beats still **park** rather than being stamped with a guess;
- `.sleepPhase` stays outside the batch — it is assembled at record level by the hypnogram assembler.

### One behaviour does change, and it is a recovery

`seq` (v24) is batch-local for the same reason `ord` is, and it exists precisely so two beats sharing
an interval value in one second survive as distinct rows. Insert-per-beat recomputed `seq = 0` for
the second beat, so it collided on `(deviceId, ts, rrMs, seq)` and was **silently dropped** by
`ON CONFLICT DO NOTHING`. Batched, both are stored.

So a post-fix night holds **slightly more** R-R rows than a pre-fix one — real beats that were being
lost, not duplicates invented. Worth knowing when reading coverage numbers against the pre-fix
baseline in #1071's validation: a small rise there is expected and is not a regression. Pinned by
`testEqualIntervalsInOneRecordSurviveOnlyWhenTheRecordIsOneInsert`.

## Tests

Package-level (runs in `swift-packages.yml` / `./gradlew testFullDebugUnitTest`, no strap, no app):

- `OuraStreamMappingTests` / `OuraStreamMappingTest` — a record's beats become **one** batch;
  distinct seconds stay separate and in arrival order; interleaved same-second events fold into one
  batch with relative order preserved; empty input yields no batches. The Kotlin twin asserts the
  resulting `ord` end-to-end through `StreamPersistence.toBatch` + `assignRrSeq`: `0,1,2,3,4`.
- `MigrationTests.testV30OrdIsBatchLocalSoOneInsertPerBeatRecordsNoOrder` — pins **both** shapes side
  by side: one insert per beat can only ever write `ord = 0` and reads back in magnitude order; the
  same beats in one insert keep emission order. Kotlin twin: `onePersistPerBeatRecordsNoOrder`.
- `MigrationTests.testEqualIntervalsInOneRecordSurviveOnlyWhenTheRecordIsOneInsert` — the `seq`
  recovery above.

## Verification

- `swift test` in `Packages/WhoopStore`: **354 pass, 0 failures**.
- `./gradlew compileFullDebugKotlin` clean; `./gradlew testFullDebugUnitTest`: 3,473 tests, the
  **same 3 pre-existing locale failures** as clean `main` (`AiCoachContextTest`,
  `StandardHrSensorFormatTest` ×2) — verified by re-running them on a stashed tree.
- ⚠️ **App-target Swift, which no default CI builds** (`app-build.yml` is disabled). Built locally:
  `xcodebuild` `Strand` (macOS) and `NOOPiOS` (iOS Simulator) — both **BUILD SUCCEEDED**.
  `StrandTests` shows the same **73 pre-existing locale failures** as clean `main` (1010 tests), none
  new.
- ⚠️ **NOT yet validated on hardware.** This is on the BLE/offload path, so compile success proves
  nothing. A post-fix drain still has to show: `ord` running `0,1,2,…` within a second in
  `rrInterval`, and the resume cursor still reaching `bytes_left 0` across a full offload.

## What this does not fix

It does not by itself make Oura SDNN physiological. The validation night for #1071 showed a third
duplicated channel (0x60/0x44) dominating the scoring read, and beats banked in bursts rather than at
their true times. `ord` is the prerequisite for deciding channel selection on beat-accurate data
rather than on burst counts — it is not the decision.