### PR TITLE
fix(oura): give the bare 0x44 IBI tag its own channel code, not 0x60's

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -80,7 +80,12 @@ public enum OuraDecoders {
     /// byte-scatter layout, cross-checked against the same capture, yields a coherent ~60 bpm train
     /// (10% jump rate) that tracks the night's sleep stages and its day/night dip. Validated against
     /// the `open_oura` decompiled `parse_api_ibi_and_amplitude_event`.
-    public static func decodeIBIAmplitude(_ rec: OuraRecord) -> [OuraIBI]? {
+    /// - Parameter channel: which tag's record this is. 0x60 and 0x44 share this layout byte for byte,
+    ///   so they share the decoder — but they are different tags on the wire, and the caller states
+    ///   which one it routed here so the beat carries its true origin (#1071 follow-up). Defaults to
+    ///   0x60's channel, which is what every existing call site means.
+    public static func decodeIBIAmplitude(_ rec: OuraRecord,
+                                          channel: OuraIBIChannel = .ibiAmplitude) -> [OuraIBI]? {
         let b = rec.payload
         guard b.count >= 14 else { return nil }   // fixed 14-byte packet (body bytes 6..19)
         let b12 = Int(b[12]), b13 = Int(b[13])
@@ -99,7 +104,7 @@ public enum OuraDecoders {
             guard ibi[k] > 0 else { continue }                 // drop a zero IBI, never invent one
             let amp = (Int(b[6 + k]) >> 1) << shift            // 7-bit mantissa << exponent
             out.append(OuraIBI(ringTimestamp: rec.ringTimestamp, ibiMs: ibi[k], amplitude: amp,
-                               channel: .ibiAmplitude))
+                               channel: channel))
         }
         return out.isEmpty ? nil : out
     }

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
@@ -304,8 +304,11 @@ public final class OuraDriver {
         case .spo2IbiAmplitude:
             return (OuraDecoders.decodeSpO2IBI(record) ?? []).map { OuraEvent.ibi($0) }
         case .ibi:
-            // The bare 0x44 IBI tag shares the bit-packed layout family; route through the same decoder.
-            return (OuraDecoders.decodeIBIAmplitude(record) ?? []).map { OuraEvent.ibi($0) }
+            // The bare 0x44 IBI tag shares the bit-packed layout family; route through the same decoder,
+            // but stamp its OWN channel — same layout is not the same tag, and a stored beat that cannot
+            // name which of the two produced it cannot answer whether they duplicate each other (#1071
+            // follow-up). Read identically to 0x60; this is a label, not a filter.
+            return (OuraDecoders.decodeIBIAmplitude(record, channel: .ibiBare) ?? []).map { OuraEvent.ibi($0) }
 
         // --- Tier A: HRV ---
         case .hrvRmssd:

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
@@ -28,8 +28,18 @@ public enum OuraIBIChannel: Int, Equatable, Sendable, Codable, CaseIterable {
     /// 0x6E `spo2_ibi_and_amplitude_event` (s6.3) — the SpO2 measurement's own beat train, quantised to
     /// an 8 ms grid with NO quality gate, and only present while an SpO2 measurement is running.
     case spo2Ibi = 2
-    /// 0x60 / 0x44 `ibi_and_amplitude_event` (s6.1) — the bit-packed IBI + amplitude family.
+    /// 0x60 `ibi_and_amplitude_event` (s6.1) — the bit-packed IBI + amplitude family.
     case ibiAmplitude = 3
+    /// 0x44 `ibi_event` (s6 / s0) — the SAME bit-packed layout as 0x60 and decoded by the same routine,
+    /// but a DIFFERENT tag on the wire, so it gets its own code.
+    ///
+    /// Both tags stamped `ibiAmplitude` until now, which made them indistinguishable once stored. That
+    /// hid the question the scoring-channel choice turns on: when that channel covers 1.25x the
+    /// wall-clock it spans, is ONE tag repeating beats across its records, or are TWO tags reporting the
+    /// same beats to each other? No stored night could answer it, because the label collapsed them.
+    /// Separating the codes costs nothing and makes the next capture decisive. Labelling only — both
+    /// tags decode and are read exactly as before.
+    case ibiBare = 4
 }
 
 /// One decoded inter-beat interval (and optional amplitude), in milliseconds.

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/IbiChannelTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/IbiChannelTests.swift
@@ -75,6 +75,38 @@ final class IbiChannelTests: XCTestCase {
         XCTAssertEqual(channels(green).count + channels(spo2).count, 11)
     }
 
+    /// 0x44 shares 0x60's layout byte for byte, so it shares the decoder — but it is a DIFFERENT tag,
+    /// and a stored beat has to be able to name which one produced it. The same bytes routed as each tag
+    /// must therefore yield the same intervals under different channels: identical values, distinct
+    /// labels. (Until this split both stamped `ibiAmplitude`, so a night in which that channel covered
+    /// 1.25x its own wall-clock could not say whether one tag repeats beats across records or two tags
+    /// report the same beats to each other — the question the scoring-channel choice turns on.)
+    func testBare0x44StampsItsOwnChannelWhileDecodingIdenticalValues() {
+        let asAmplitude = OuraDecoders.decodeIBIAmplitude(record(amp0x60))
+        let asBare = OuraDecoders.decodeIBIAmplitude(record(amp0x60), channel: .ibiBare)
+        XCTAssertEqual(asBare?.map(\.ibiMs), asAmplitude?.map(\.ibiMs), "same layout, same values")
+        XCTAssertEqual(asBare?.map(\.amplitude), asAmplitude?.map(\.amplitude))
+        XCTAssertEqual(asBare?.map(\.channel), Array(repeating: .ibiBare, count: 6))
+        XCTAssertNotEqual(asBare?.map(\.channel), asAmplitude?.map(\.channel))
+    }
+
+    /// And the driver is what routes them: a 0x44 record must reach the app labelled `ibiBare`, a 0x60
+    /// record `ibiAmplitude`, from the same decoder. Both are still emitted — this is a label, not a
+    /// filter, and nothing about which beats are read changes.
+    func testDriverLabels0x44AndVerifies0x60IsUnchanged() {
+        let driver = OuraDriver(ringGen: .gen3, authKey: nil)
+        // The 0x60 golden fixture re-tagged 0x44: identical body, different tag byte.
+        let bare0x44 = "441202000100807b77757a78e4ddccd4e8d79d33"
+        func channels(_ events: [OuraEvent]) -> [OuraIBIChannel?] {
+            events.compactMap { if case .ibi(let v) = $0 { return v.channel } else { return nil } }
+        }
+        let fromBare = driver.ingest(record: record(bare0x44))
+        let fromAmp = driver.ingest(record: record(amp0x60))
+        XCTAssertEqual(channels(fromBare).count, 6, "0x44 must still emit every beat")
+        XCTAssertEqual(Set(channels(fromBare).compactMap { $0 }), [.ibiBare])
+        XCTAssertEqual(Set(channels(fromAmp).compactMap { $0 }), [.ibiAmplitude])
+    }
+
     /// The raw values are a DURABLE storage format (`rrInterval.srcChannel`, and the `.noopbak` that
     /// carries it between platforms), so renumbering a case would silently relabel stored history.
     /// Pinned here rather than trusted to declaration order.
@@ -82,6 +114,7 @@ final class IbiChannelTests: XCTestCase {
         XCTAssertEqual(OuraIBIChannel.greenQuality.rawValue, 1)
         XCTAssertEqual(OuraIBIChannel.spo2Ibi.rawValue, 2)
         XCTAssertEqual(OuraIBIChannel.ibiAmplitude.rawValue, 3)
-        XCTAssertEqual(OuraIBIChannel.allCases.count, 3)
+        XCTAssertEqual(OuraIBIChannel.ibiBare.rawValue, 4)
+        XCTAssertEqual(OuraIBIChannel.allCases.count, 4)
     }
 }

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
@@ -28,8 +28,17 @@ public enum RRSourceChannel: Int, Equatable, Codable, Sendable, CaseIterable {
     /// Oura 0x6E `spo2_ibi_and_amplitude_event` — the SpO2/red-channel beat train, on an 8 ms
     /// quantisation grid with no quality gate, and present ONLY while SpO2 measurement is running.
     case spo2Ibi = 2
-    /// Oura 0x60 / 0x44 `ibi_and_amplitude_event` — the bit-packed IBI+amplitude family.
+    /// Oura 0x60 `ibi_and_amplitude_event` — the bit-packed IBI+amplitude family.
     case ibiAmplitude = 3
+    /// Oura 0x44 `ibi_event` — the SAME bit-packed layout family as 0x60, decoded by the same routine,
+    /// but a DIFFERENT tag on the wire.
+    ///
+    /// Split out (#1071 follow-up) because both tags used to stamp `ibiAmplitude`, which made them
+    /// indistinguishable once stored: a capture showing that channel over-covering its own wall-clock
+    /// could not say whether one tag repeats beats or two tags report the same beats to each other. That
+    /// is the question the channel choice for scoring rests on, and no stored night could answer it.
+    /// Labelling only — both are read exactly as before.
+    case ibiBare = 4
 }
 
 public struct RRInterval: Equatable, Codable {

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -213,6 +213,7 @@ public enum OuraStreamMapping {
         case .greenQuality:  return .greenQuality
         case .spo2Ibi:       return .spo2Ibi
         case .ibiAmplitude:  return .ibiAmplitude
+        case .ibiBare:       return .ibiBare
         case nil:            return nil
         }
     }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/RrSourceChannelTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/RrSourceChannelTests.swift
@@ -105,6 +105,39 @@ final class RrSourceChannelTests: XCTestCase {
         XCTAssertEqual(scored.map(\.rrMs), (0..<10).map { 800 + $0 })
     }
 
+    /// The 0x44 split (#1071 follow-up) is a LABEL, not a filter: 0x60 and 0x44 share a decoder and now
+    /// carry distinct codes, and BOTH are still read for scoring exactly as the merged label was. If this
+    /// ever starts failing, the split has quietly become a behaviour change — which it must not be, or
+    /// the capture it exists to make measurable would be measuring a different night.
+    func testBare0x44RowsAreLabelledSeparatelyAndStillScored() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: "ring", mac: nil, name: nil)
+        var rows: [RRInterval] = []
+        for i in 0..<6 {
+            rows.append(RRInterval(ts: ts + i, rrMs: 800 + i,
+                                   srcChannel: i % 2 == 0 ? .ibiAmplitude : .ibiBare))
+        }
+        _ = try await store.insert(Streams(rr: rows), deviceId: "ring")
+
+        let stored = try await store.rrRowsWithChannelForTest(deviceId: "ring")
+        XCTAssertEqual(stored.filter { $0.srcChannel == RRSourceChannel.ibiBare.rawValue }.count, 3)
+        XCTAssertEqual(stored.filter { $0.srcChannel == RRSourceChannel.ibiAmplitude.rawValue }.count, 3,
+                       "0x60 keeps its own code — the split must not relabel it")
+
+        let scored = try await store.rrIntervals(deviceId: "ring", from: 0, to: ts + 1_000, limit: 1_000)
+        XCTAssertEqual(scored.count, 6, "both tags are still scored; only the label changed")
+        XCTAssertEqual(Set(scored.compactMap(\.srcChannel)), [.ibiAmplitude, .ibiBare])
+    }
+
+    /// The mapping carries the new code end to end, and it is the durable storage value 4.
+    func testBare0x44MapsToItsOwnDurableStorageCode() {
+        let s = OuraStreamMapping.streams(from: [
+            .ibi(OuraIBI(ringTimestamp: 100, ibiMs: 820, amplitude: 42, channel: .ibiBare)),
+        ], at: ts)
+        XCTAssertEqual(s.rr.map(\.srcChannel), [.ibiBare])
+        XCTAssertEqual(RRSourceChannel.ibiBare.rawValue, 4)
+    }
+
     /// The regression the filter could most easily cause. A WHOOP strap has ONE beat source, so its
     /// rows carry no channel — a whitelist filter would have deleted every WHOOP night from scoring.
     func testWhoopRowsCarryNoChannelAndAreNeverFiltered() async throws {

--- a/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
+++ b/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
@@ -232,6 +232,7 @@ object OuraStreamMapping {
         OuraIbiChannel.GREEN_QUALITY -> RrSourceChannel.GREEN_QUALITY
         OuraIbiChannel.SPO2_IBI -> RrSourceChannel.SPO2_IBI
         OuraIbiChannel.IBI_AMPLITUDE -> RrSourceChannel.IBI_AMPLITUDE
+        OuraIbiChannel.IBI_BARE -> RrSourceChannel.IBI_BARE
         null -> null
     }
 }

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -87,8 +87,16 @@ object OuraDecoders {
      * decoded to an 82% beat-to-beat >200ms "jump" rate (not a heartbeat train). This byte-scatter
      * layout yields a coherent ~60 bpm train (10% jump rate). Validated against open_oura. Byte-identical
      * twin of Swift's decodeIBIAmplitude.
+     *
+     * @param channel which tag's record this is. 0x60 and 0x44 share this layout byte for byte, so they
+     *   share the decoder — but they are different tags on the wire, and the caller states which one it
+     *   routed here so the beat carries its true origin (#1071 follow-up). Defaults to 0x60's channel,
+     *   which is what every existing call site means.
      */
-    fun decodeIBIAmplitude(rec: OuraRecord): List<OuraIBI>? {
+    fun decodeIBIAmplitude(
+        rec: OuraRecord,
+        channel: OuraIbiChannel = OuraIbiChannel.IBI_AMPLITUDE,
+    ): List<OuraIBI>? {
         val b = rec.payload
         if (b.size < 14) return null   // fixed 14-byte packet (body bytes 6..19)
         val b12 = b[12] and 0xFF
@@ -110,7 +118,7 @@ object OuraDecoders {
             out.add(
                 OuraIBI(
                     ringTimestamp = rec.ringTimestamp, ibiMs = ibi[k], amplitude = amp,
-                    channel = OuraIbiChannel.IBI_AMPLITUDE,
+                    channel = channel,
                 ),
             )
         }

--- a/android/app/src/main/java/com/noop/oura/OuraDriver.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraDriver.kt
@@ -380,8 +380,12 @@ class OuraDriver(
             OuraEventTag.SPO2_IBI_AMPLITUDE ->
                 (OuraDecoders.decodeSpO2IBI(record) ?: emptyList()).map { OuraEvent.Ibi(it) }
             OuraEventTag.IBI ->
-                // The bare 0x44 IBI tag shares the bit-packed layout family; route through the same decoder.
-                (OuraDecoders.decodeIBIAmplitude(record) ?: emptyList()).map { OuraEvent.Ibi(it) }
+                // The bare 0x44 IBI tag shares the bit-packed layout family; route through the same
+                // decoder, but stamp its OWN channel — same layout is not the same tag, and a stored beat
+                // that cannot name which of the two produced it cannot answer whether they duplicate each
+                // other (#1071 follow-up). Read identically to 0x60; this is a label, not a filter.
+                (OuraDecoders.decodeIBIAmplitude(record, OuraIbiChannel.IBI_BARE) ?: emptyList())
+                    .map { OuraEvent.Ibi(it) }
 
             // --- Tier A: HRV ---
             OuraEventTag.HRV_RMSSD ->

--- a/android/app/src/main/java/com/noop/oura/OuraEvents.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraEvents.kt
@@ -41,8 +41,21 @@ enum class OuraIbiChannel(val code: Int) {
      */
     SPO2_IBI(2),
 
-    /** 0x60 / 0x44 `ibi_and_amplitude_event` (s6.1) — the bit-packed IBI + amplitude family. */
+    /** 0x60 `ibi_and_amplitude_event` (s6.1) — the bit-packed IBI + amplitude family. */
     IBI_AMPLITUDE(3),
+
+    /**
+     * 0x44 `ibi_event` (s6 / s0) — the SAME bit-packed layout as 0x60 and decoded by the same routine,
+     * but a DIFFERENT tag on the wire, so it gets its own code.
+     *
+     * Both tags stamped [IBI_AMPLITUDE] until now, which made them indistinguishable once stored. That
+     * hid the question the scoring-channel choice turns on: when that channel covers 1.25x the
+     * wall-clock it spans, is ONE tag repeating beats across its records, or are TWO tags reporting the
+     * same beats to each other? No stored night could answer it, because the label collapsed them.
+     * Separating the codes costs nothing and makes the next capture decisive. Labelling only — both
+     * tags decode and are read exactly as before.
+     */
+    IBI_BARE(4),
     ;
 
     companion object {

--- a/android/app/src/main/java/com/noop/protocol/Streams.kt
+++ b/android/app/src/main/java/com/noop/protocol/Streams.kt
@@ -37,8 +37,20 @@ enum class RrSourceChannel(val code: Int) {
      */
     SPO2_IBI(2),
 
-    /** Oura 0x60 / 0x44 `ibi_and_amplitude_event` — the bit-packed IBI+amplitude family. */
+    /** Oura 0x60 `ibi_and_amplitude_event` — the bit-packed IBI+amplitude family. */
     IBI_AMPLITUDE(3),
+
+    /**
+     * Oura 0x44 `ibi_event` — the SAME bit-packed layout family as 0x60, decoded by the same routine,
+     * but a DIFFERENT tag on the wire.
+     *
+     * Split out (#1071 follow-up) because both tags used to stamp [IBI_AMPLITUDE], which made them
+     * indistinguishable once stored: a capture showing that channel over-covering its own wall-clock
+     * could not say whether one tag repeats beats or two tags report the same beats to each other. That
+     * is the question the channel choice for scoring rests on, and no stored night could answer it.
+     * Labelling only — both are read exactly as before.
+     */
+    IBI_BARE(4),
     ;
 
     companion object {

--- a/android/app/src/test/java/com/noop/data/RrSourceChannelTest.kt
+++ b/android/app/src/test/java/com/noop/data/RrSourceChannelTest.kt
@@ -72,6 +72,40 @@ class RrSourceChannelTest {
     }
 
     /**
+     * 0x44 shares 0x60's layout byte for byte, so it shares the decoder — but it is a DIFFERENT tag, and
+     * a stored beat has to be able to name which one produced it. The same bytes routed as each tag must
+     * therefore yield the same intervals under different channels: identical values, distinct labels.
+     * (Until this split both stamped IBI_AMPLITUDE, so a night in which that channel covered 1.25x its
+     * own wall-clock could not say whether one tag repeats beats across records or two tags report the
+     * same beats to each other — the question the scoring-channel choice turns on.) Twin of Swift.
+     */
+    @Test
+    fun bare0x44StampsItsOwnChannelWhileDecodingIdenticalValues() {
+        val asAmplitude = OuraDecoders.decodeIBIAmplitude(record(amp0x60))
+        val asBare = OuraDecoders.decodeIBIAmplitude(record(amp0x60), OuraIbiChannel.IBI_BARE)
+        assertEquals(asAmplitude?.map { it.ibiMs }, asBare?.map { it.ibiMs })
+        assertEquals(asAmplitude?.map { it.amplitude }, asBare?.map { it.amplitude })
+        assertEquals(List(6) { OuraIbiChannel.IBI_BARE }, asBare?.map { it.channel })
+    }
+
+    /**
+     * And the driver is what routes them: a 0x44 record reaches the app labelled IBI_BARE, a 0x60 record
+     * IBI_AMPLITUDE, from the same decoder. Both still emit every beat — a label, not a filter.
+     */
+    @Test
+    fun driverLabels0x44AndLeaves0x60Unchanged() {
+        val driver = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = null)
+        val bare0x44 = "441202000100807b77757a78e4ddccd4e8d79d33"   // 0x60 golden body, 0x44 tag
+        fun channels(events: List<OuraEvent>) =
+            events.mapNotNull { (it as? OuraEvent.Ibi)?.value?.channel }
+        val fromBare = channels(driver.ingest(record(bare0x44)))
+        val fromAmp = channels(driver.ingest(record(amp0x60)))
+        assertEquals(6, fromBare.size)
+        assertEquals(setOf(OuraIbiChannel.IBI_BARE), fromBare.toSet())
+        assertEquals(setOf(OuraIbiChannel.IBI_AMPLITUDE), fromAmp.toSet())
+    }
+
+    /**
      * The end-to-end shape of the defect: two records covering the same wall-clock moment, one per
      * channel, both reaching the driver as `Ibi`. Before #1071 the resulting events were
      * indistinguishable; now the channel survives dispatch, which is what makes the two streams
@@ -151,9 +185,11 @@ class RrSourceChannelTest {
         assertEquals(1, RrSourceChannel.GREEN_QUALITY.code)
         assertEquals(2, RrSourceChannel.SPO2_IBI.code)
         assertEquals(3, RrSourceChannel.IBI_AMPLITUDE.code)
+        assertEquals(4, RrSourceChannel.IBI_BARE.code)
         assertEquals(1, OuraIbiChannel.GREEN_QUALITY.code)
         assertEquals(2, OuraIbiChannel.SPO2_IBI.code)
         assertEquals(3, OuraIbiChannel.IBI_AMPLITUDE.code)
+        assertEquals(4, OuraIbiChannel.IBI_BARE.code)
         assertEquals(RrSourceChannel.SPO2_IBI, RrSourceChannel.fromCode(2))
         assertNull("an unknown code is unknown, not a default", RrSourceChannel.fromCode(99))
         assertNull(RrSourceChannel.fromCode(null))


### PR DESCRIPTION
**Branch:** `fix/oura-label-0x44-ibi-channel` (based on `main` @ `7c7b3f0c`, commit `4d35fc32`)
**Base:** `main`. **No migration** — `srcChannel` is an existing nullable column (v32 / Room 26) and
this adds a new *value*, not a schema change.
**Follows:** #1071 (merged as #1076), whose channel labelling this completes.

---

## The gap

`0x44` `ibi_event` and `0x60` `ibi_and_amplitude_event` carry the same bit-packed layout byte for
byte, so `OuraDriver` routes both through `decodeIBIAmplitude`. Until now they also *shared a channel
code*, so once a beat was stored nothing could say which tag produced it.

That matters because it collapses the question the scoring-channel choice turns on. A post-#1076
validation night measured `srcChannel = ibiAmplitude` covering **1.25× the wall-clock it spans** —
over-counted from that channel alone, and the dominant source of the night's implausible ~197 ms
SDNN. But "that channel" is two tags, so the capture cannot distinguish:

- **one tag repeating beats** across consecutive records → the fix is a time-and-value de-dup; from
- **two tags reporting the same beats** to each other → the fix is a second channel exclusion.

Different fixes. No stored night can tell them apart, because the label merged them before the row
was written.

## The change

- `OuraIBIChannel.ibiBare` / `OuraIbiChannel.IBI_BARE` = **4**, with the storage twin
  `RRSourceChannel.ibiBare` / `RrSourceChannel.IBI_BARE` = **4**. Appended, never renumbered — the raw
  values are the durable cross-platform storage codes that reach `rrInterval.srcChannel` and cross the
  `.noopbak` boundary.
- `decodeIBIAmplitude` gains a `channel` parameter defaulting to `.ibiAmplitude`, so every existing
  call site means exactly what it meant before.
- The driver's `0x44` arm passes `.ibiBare`.

## This is a label, not a filter

Nothing about which beats are read changes. The scoring read (`Reads.rrIntervals`) still excludes only
0x6E, so both tags remain scored exactly as the merged label was — no night's coverage, HRV, resting
HR or scoring moves. There is a test pinning precisely that, because if it ever starts failing the
split has quietly become a behaviour change, and then the capture it exists to make measurable would
be measuring a different night.

Pre-split rows keep code 3 and stay honest: on those, 3 means "0x60 **or** 0x44, unknown which" —
which is the state this ends going forward. Nothing is backfilled; the tag was never recorded, so it
cannot be recovered.

## Tests

Package-level on both platforms (`swift-packages.yml` / `./gradlew testFullDebugUnitTest`):

- the same golden bytes routed as each tag decode to **identical intervals and amplitudes under
  distinct channels** — same layout, different origin;
- the driver labels a `0x44` record `ibiBare` and a `0x60` record `ibiAmplitude`, **both still emitting
  every beat**;
- a `0x44` row is stored with code 4 **and still returned by the scoring read**, while `0x60` keeps
  code 3;
- the durable-code pins extended to 4, and the existing cross-enum parity test (which compares
  `allCases` counts and every mapped raw value) now covers the new case automatically.

Kotlin twins of each.

## Verification

- `swift test`: OuraProtocol **168 pass**, WhoopStore **351 pass**, 0 failures.
- `./gradlew testFullDebugUnitTest`: 3,470 tests, the **same 3 pre-existing locale failures** as clean
  `main`.
- `xcodebuild` **Strand (macOS) and NOOPiOS both BUILD SUCCEEDED** — app targets have no default CI.
- **No hardware needed for correctness**, but the point of the change is the next capture: a drain from
  a build carrying this will show rows in `srcChannel` 3 and/or 4 and settle which of the two
  hypotheses above is true. Worth landing alongside #1082 so one night answers both questions.