### PR TITLE
fix(hrv): stop reporting SDNN for a capture already known to be over-counted

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -50,6 +50,11 @@ public enum HRVAnalyzer {
         /// RMSSD in milliseconds, or nil when too few valid beats.
         public let rmssd: Double?
         /// SDNN (sample SD, ddof=1) in milliseconds, or nil when too few valid beats.
+        ///
+        /// A caller holding the window's TIMESTAMPS should also refuse this value when
+        /// `beatSpreadIsTrustworthy(classifyCoverage(...))` is false: SDNN is a spread over every
+        /// interval, so an over-counted capture inflates it directly. `analyze` cannot do that itself —
+        /// it is given intervals, not times.
         public let sdnn: Double?
         /// Mean NN interval (ms) over the cleaned beats, or nil.
         public let meanNN: Double?
@@ -369,6 +374,33 @@ public enum HRVAnalyzer {
         /// evidence, NOT a clean night: reporting those as `plausible` would claim the capture was fine
         /// when nothing was measurable, which is the opposite of what this verdict exists to do.
         case unmeasurable
+    }
+
+    /// Whether a window's BEAT-SPREAD statistics — SDNN, and anything derived from it — can be trusted,
+    /// given that window's coverage verdict. Pure. Byte-parity twin of Kotlin `beatSpreadIsTrustworthy`.
+    ///
+    /// SDNN is the standard deviation of EVERY NN interval in the window, so a capture that holds some
+    /// beats twice reports a spread no heart produced. It is not a subtle bias: measured on a ring whose
+    /// banked R-R covers 1.25× the wall-clock it spans, a sleeping night reads **197 ms** against a
+    /// 40-100 ms physiological range, and the app had no way to refuse the number — `classifyCoverage`
+    /// already knew the capture was over-counted, but nothing acted on it.
+    ///
+    /// Only the two OVER-COUNT verdicts gate. `underCovered` and `unmeasurable` stay trusted: neither
+    /// duplicates a beat. `unmeasurable` in particular is what a LIVE spot reading looks like — beats
+    /// arriving in real time, carrying no timestamps to measure coverage with — and suppressing those
+    /// would refuse honest readings, the opposite of the point.
+    ///
+    /// Successive-difference statistics (RMSSD, pNN50) are deliberately NOT gated here. Their dominant
+    /// error on a banked stream was the lost within-second emission order (#823, root-caused in #1072),
+    /// which is fixed at the write path; whether they need a gate of their own is a question for a
+    /// post-fix capture to answer, not an assumption to bake in now.
+    public static func beatSpreadIsTrustworthy(_ verdict: RrCoverageVerdict) -> Bool {
+        switch verdict {
+        case .sameSecondOverCount, .crossSecondOverCount:
+            return false
+        case .plausible, .underCovered, .unmeasurable:
+            return true
+        }
     }
 
     /// Tolerance BELOW 1.0 treated as "fits", the mirror of `coveragePlausibleCeiling`. Same allowance,

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RhythmScreener.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RhythmScreener.swift
@@ -241,6 +241,24 @@ public enum RhythmScreener {
             return .unreadable(nBeats: clean.count, confidence: confidence(for: clean.count))
         }
 
+        // Gate 4: beat-time integrity. Every statistic below is a SPREAD over the interval cloud —
+        // SD2 is built from SDNN outright — so a window whose beats are partly held twice describes a
+        // rhythm the heart never had, and describes it as MORE varied than it was. That is the wrong
+        // direction to be wrong in for a label a person reads. `unreadable` is the honest answer: the
+        // capture cannot support the read, which is exactly what this state exists for.
+        //
+        // Timestamps are optional on `WindowInput`, and without them coverage is not measurable — the
+        // verdict is then `unmeasurable`, which stays readable (a live spot capture has no timestamps
+        // and is perfectly time-accurate). Only a MEASURED over-count gates.
+        if input.ts.count == input.rrMs.count, !input.ts.isEmpty {
+            let coverage = HRVAnalyzer.rrCoverage(tsSec: input.ts, rrMs: input.rrMs)
+            let collapsed = HRVAnalyzer.collapsedCoverage(tsSec: input.ts, rrMs: input.rrMs)
+            let verdict = HRVAnalyzer.classifyCoverage(coverage: coverage, collapsed: collapsed)
+            guard HRVAnalyzer.beatSpreadIsTrustworthy(verdict) else {
+                return .unreadable(nBeats: clean.count, confidence: confidence(for: clean.count))
+            }
+        }
+
         // Core descriptive statistics over the clean (range-filtered, ectopy-kept) series.
         let stats = computeStats(clean)
         let rrLabel = classify(stats)

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RhythmScreenerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RhythmScreenerTests.swift
@@ -263,4 +263,44 @@ final class RhythmScreenerTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - Beat-time integrity gate
+
+    /// A window whose beats are partly held twice describes a rhythm the heart never had — and describes
+    /// it as MORE varied, because every statistic here is a spread over the interval cloud. The honest
+    /// answer is `unreadable`. Same beats, same label inputs; only the timestamps differ.
+    func testBankedOverCountedWindowIsUnreadableRatherThanVaried() {
+        let rr = Self.regularSinus()
+        // Banked: 6 beats per record, records 5 s apart — beat-time exceeds the span it is stamped into.
+        let bankedTs = (0..<rr.count).map { ($0 / 6) * 5 }
+        let banked = RhythmScreener.screenWindow(
+            RhythmScreener.WindowInput(rrMs: rr, ts: bankedTs, motionStill: true, meanHR: 60))
+        XCTAssertEqual(banked.label, .unreadable,
+                       "an over-counted capture must not be described, in either direction")
+        XCTAssertNil(banked.sd2, "SD2 is built from SDNN — it must not survive the gate")
+    }
+
+    /// The same beats, honestly stamped, still read normally: the gate keys on MEASURED over-count, not
+    /// on the presence of timestamps.
+    func testHonestlyStampedWindowStillReads() {
+        let rr = Self.regularSinus()
+        let ts = (0..<rr.count).map { $0 }
+        let r = RhythmScreener.screenWindow(
+            RhythmScreener.WindowInput(rrMs: rr, ts: ts, motionStill: true, meanHR: 60))
+        XCTAssertEqual(r.label, .steady)
+        XCTAssertNotNil(r.sd2)
+    }
+
+    /// A LIVE spot capture carries no timestamps, so coverage is unmeasurable — and unmeasurable is not
+    /// over-counted. Those readings must keep working exactly as before.
+    func testWindowWithoutTimestampsIsUnaffected() {
+        let rr = Self.regularSinus()
+        let withTs = RhythmScreener.screenWindow(
+            RhythmScreener.WindowInput(rrMs: rr, ts: (0..<rr.count).map { $0 },
+                                       motionStill: true, meanHR: 60))
+        let withoutTs = RhythmScreener.screenWindow(
+            RhythmScreener.WindowInput(rrMs: rr, motionStill: true, meanHR: 60))
+        XCTAssertEqual(withoutTs.label, withTs.label)
+        XCTAssertEqual(withoutTs.sd2, withTs.sd2)
+    }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrCoverageVerdictTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrCoverageVerdictTests.swift
@@ -103,4 +103,48 @@ final class RrCoverageVerdictTests: XCTestCase {
     func testCollapsedAboveCoverageStillClassifiesOnCoverageFirst() {
         XCTAssertEqual(HRVAnalyzer.classifyCoverage(coverage: 0.5, collapsed: 9.9), .underCovered)
     }
+
+    // MARK: - Acting on the verdict: beat-spread statistics (SDNN)
+
+    /// The whole point of the gate: an over-counted capture inflates SDNN directly, because SDNN is a
+    /// spread over EVERY interval and some of those intervals are the same beat twice.
+    func testOverCountedWindowsRefuseBeatSpreadStatistics() {
+        XCTAssertFalse(HRVAnalyzer.beatSpreadIsTrustworthy(.sameSecondOverCount))
+        XCTAssertFalse(HRVAnalyzer.beatSpreadIsTrustworthy(.crossSecondOverCount))
+    }
+
+    /// Nothing else gates. `underCovered` is a capture with holes and `unmeasurable` is what a LIVE spot
+    /// reading looks like (real-time beats, no timestamps to measure coverage with) — neither duplicates
+    /// a beat, and refusing them would suppress honest readings, which is the opposite of the point.
+    func testGapsAndUnmeasurableWindowsStayTrusted() {
+        XCTAssertTrue(HRVAnalyzer.beatSpreadIsTrustworthy(.plausible))
+        XCTAssertTrue(HRVAnalyzer.beatSpreadIsTrustworthy(.underCovered))
+        XCTAssertTrue(HRVAnalyzer.beatSpreadIsTrustworthy(.unmeasurable))
+    }
+
+    /// End to end on the shape that motivated this: beats banked in bursts at their record's second
+    /// (an Oura night — 6 beats per record, records ~5 s apart) cover more beat-time than wall-clock and
+    /// therefore refuse SDNN, while the SAME beats stamped at the times they really occurred stay
+    /// trusted. The verdict is measured from the data, never assumed from the device.
+    func testBankedBeatsRefuseSpreadWhileTheSameBeatsHonestlySpacedDoNot() {
+        let beat = 1000.0                       // 60 bpm
+        let rr = [Double](repeating: beat, count: 60)
+
+        // Honest: one beat per second, so beat-time ~= wall-clock (the whole-second stamps cost the
+        // final interval, which is what the ceiling's rounding allowance exists for).
+        let honestTs = (0..<60).map { $0 }
+        let honest = HRVAnalyzer.classifyCoverage(
+            coverage: HRVAnalyzer.rrCoverage(tsSec: honestTs, rrMs: rr),
+            collapsed: HRVAnalyzer.collapsedCoverage(tsSec: honestTs, rrMs: rr))
+        XCTAssertEqual(honest, .plausible)
+        XCTAssertTrue(HRVAnalyzer.beatSpreadIsTrustworthy(honest))
+
+        // Banked: the same 60 beats delivered as 10 records of 6, each record stamping all six of its
+        // beats at its own second, records 5 s apart. 60 s of beat-time inside a 45 s span.
+        let bankedTs = (0..<60).map { ($0 / 6) * 5 }
+        let banked = HRVAnalyzer.classifyCoverage(
+            coverage: HRVAnalyzer.rrCoverage(tsSec: bankedTs, rrMs: rr),
+            collapsed: HRVAnalyzer.collapsedCoverage(tsSec: bankedTs, rrMs: rr))
+        XCTAssertFalse(HRVAnalyzer.beatSpreadIsTrustworthy(banked), "verdict was \(banked)")
+    }
 }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -747,7 +747,17 @@ final class IntelligenceEngine: ObservableObject {
                     // from a cross-second one (it would not) — a rule that lived only in the comment above,
                     // so triaging an "HRV reads ~2x high" report required knowing it. Now the line says which.
                     let verdict = HRVAnalyzer.classifyCoverage(coverage: covVal, collapsed: colCovVal)
-                    hrvDiag = "hrv diag day=\(res.daily.day) rmssd=\(ms(h.rmssd))ms sdnn=\(ms(h.sdnn))ms "
+                    // #550 follow-up: having stated the conclusion, ACT on it. SDNN is a spread over every
+                    // interval, so an over-counted night inflates it directly — a ring whose banked R-R
+                    // covers 1.25x its wall-clock reads ~197 ms across a sleeping night, against a 40-100 ms
+                    // physiological range. Printing that number beside the verdict that says it cannot be
+                    // trusted invites it to be read as a measurement, so it is withheld instead; the
+                    // `rrIntegrity=` field on the same line says why. RMSSD/meanNN are NOT withheld — mean
+                    // rate survives an over-count, and RMSSD's dominant error was the emission order fixed
+                    // at the write path (#1072).
+                    let sdnnField = HRVAnalyzer.beatSpreadIsTrustworthy(verdict)
+                        ? "\(ms(h.sdnn))ms" : "withheld"
+                    hrvDiag = "hrv diag day=\(res.daily.day) rmssd=\(ms(h.rmssd))ms sdnn=\(sdnnField) "
                         + "meanNN=\(ms(h.meanNN))ms rr=\(h.nInput)/\(h.nClean) rejected=\(rej)% coverage=\(cov) collapsedCov=\(colCov) dupBeats=\(dup) "
                         + "rrIntegrity=\(verdict.rawValue)"
                 }

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -364,6 +364,32 @@ object HrvAnalyzer {
      */
     const val COVERAGE_PLAUSIBLE_FLOOR: Double = 1.0 - (COVERAGE_PLAUSIBLE_CEILING - 1.0)
 
+    /**
+     * Whether a window's BEAT-SPREAD statistics — SDNN, and anything derived from it — can be trusted,
+     * given that window's coverage verdict. Pure. Byte-parity twin of Swift `beatSpreadIsTrustworthy`.
+     *
+     * SDNN is the standard deviation of EVERY NN interval in the window, so a capture that holds some
+     * beats twice reports a spread no heart produced. It is not a subtle bias: measured on a ring whose
+     * banked R-R covers 1.25x the wall-clock it spans, a sleeping night reads **197 ms** against a
+     * 40-100 ms physiological range, and the app had no way to refuse the number — [classifyCoverage]
+     * already knew the capture was over-counted, but nothing acted on it.
+     *
+     * Only the two OVER-COUNT verdicts gate. UNDER_COVERED and UNMEASURABLE stay trusted: neither
+     * duplicates a beat. UNMEASURABLE in particular is what a LIVE spot reading looks like — beats
+     * arriving in real time, carrying no timestamps to measure coverage with — and suppressing those
+     * would refuse honest readings, the opposite of the point.
+     *
+     * Successive-difference statistics (RMSSD, pNN50) are deliberately NOT gated here. Their dominant
+     * error on a banked stream was the lost within-second emission order (#823, root-caused in #1072),
+     * which is fixed at the write path; whether they need a gate of their own is a question for a
+     * post-fix capture to answer, not an assumption to bake in now.
+     */
+    fun beatSpreadIsTrustworthy(verdict: RrCoverageVerdict): Boolean = when (verdict) {
+        RrCoverageVerdict.SAME_SECOND_OVER_COUNT, RrCoverageVerdict.CROSS_SECOND_OVER_COUNT -> false
+        RrCoverageVerdict.PLAUSIBLE, RrCoverageVerdict.UNDER_COVERED,
+        RrCoverageVerdict.UNMEASURABLE -> true
+    }
+
     /** Classify a night from its coverage pair. Pure. Byte-parity twin of Swift `classifyCoverage`.
      *
      *  Both platforms use the NEGATED `>` form rather than `<=` so a non-finite input lands identically:

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -629,7 +629,17 @@ object IntelligenceEngine {
                 // one (it would not) — a rule that lived only in the comments above, so triaging an
                 // "HRV reads ~2x high" report required knowing it. Now the line says which.
                 val verdict = HrvAnalyzer.classifyCoverage(covVal, colCovVal)
-                diag("hrv diag day=${res.daily.day} rmssd=${ms(h.rmssd)}ms sdnn=${ms(h.sdnn)}ms meanNN=${ms(h.meanNN)}ms " +
+                // #550 follow-up: having stated the conclusion, ACT on it. SDNN is a spread over every
+                // interval, so an over-counted night inflates it directly — a ring whose banked R-R covers
+                // 1.25x its wall-clock reads ~197 ms across a sleeping night, against a 40-100 ms
+                // physiological range. Printing that number beside the verdict that says it cannot be
+                // trusted invites it to be read as a measurement, so it is withheld instead; the
+                // `rrIntegrity=` field on the same line says why. RMSSD/meanNN are NOT withheld — mean rate
+                // survives an over-count, and RMSSD's dominant error was the emission order fixed at the
+                // write path (#1072). Twin of the Swift line.
+                val sdnnField =
+                    if (HrvAnalyzer.beatSpreadIsTrustworthy(verdict)) "${ms(h.sdnn)}ms" else "withheld"
+                diag("hrv diag day=${res.daily.day} rmssd=${ms(h.rmssd)}ms sdnn=$sdnnField meanNN=${ms(h.meanNN)}ms " +
                     "rr=${h.nInput}/${h.nClean} rejected=$rej% coverage=$cov collapsedCov=$colCov dupBeats=$dup " +
                     "rrIntegrity=${verdict.raw}")
             }

--- a/android/app/src/main/java/com/noop/analytics/RhythmScreener.kt
+++ b/android/app/src/main/java/com/noop/analytics/RhythmScreener.kt
@@ -166,6 +166,25 @@ object RhythmScreener {
             return WindowResult.unreadable(nBeats = clean.size, confidence = confidence(clean.size))
         }
 
+        // Gate 4: beat-time integrity. Every statistic below is a SPREAD over the interval cloud — SD2
+        // is built from SDNN outright — so a window whose beats are partly held twice describes a rhythm
+        // the heart never had, and describes it as MORE varied than it was. That is the wrong direction
+        // to be wrong in for a label a person reads. `unreadable` is the honest answer: the capture
+        // cannot support the read, which is exactly what this state exists for.
+        //
+        // Timestamps are optional on [WindowInput], and without them coverage is not measurable — the
+        // verdict is then UNMEASURABLE, which stays readable (a live spot capture has no timestamps and
+        // is perfectly time-accurate). Only a MEASURED over-count gates. Twin of the Swift gate.
+        if (input.ts.size == input.rrMs.size && input.ts.isNotEmpty()) {
+            val tsLong = input.ts.map { it.toLong() }
+            val coverage = HrvAnalyzer.rrCoverage(tsLong, input.rrMs)
+            val collapsed = HrvAnalyzer.collapsedCoverage(tsLong, input.rrMs)
+            val verdict = HrvAnalyzer.classifyCoverage(coverage, collapsed)
+            if (!HrvAnalyzer.beatSpreadIsTrustworthy(verdict)) {
+                return WindowResult.unreadable(nBeats = clean.size, confidence = confidence(clean.size))
+            }
+        }
+
         // Core descriptive statistics over the clean (range-filtered, ectopy-kept) series.
         val stats = computeStats(clean)
         val rrLabel = classify(stats)

--- a/android/app/src/test/java/com/noop/analytics/HrvRrCoverageTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvRrCoverageTest.kt
@@ -1,6 +1,8 @@
 package com.noop.analytics
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -81,5 +83,40 @@ class HrvRrCoverageTest {
         val ts = listOf(100L, 100L, 101L)
         val rr = listOf(900.0, 1200.0, 1000.0)   // |1200-900| = 300 ms > 30 ms tol
         assertEquals(HrvAnalyzer.rrCoverage(ts, rr), HrvAnalyzer.collapsedCoverage(ts, rr), 1e-9)
+    }
+
+    // --- Acting on the verdict: beat-spread statistics (SDNN). Twin of Swift RrCoverageVerdictTests. ---
+
+    /** The whole point of the gate: an over-counted capture inflates SDNN directly, because SDNN is a
+     *  spread over EVERY interval and some of those intervals are the same beat twice. */
+    @Test fun beatSpreadIsTrustworthy_refusesOverCountedWindows() {
+        assertFalse(HrvAnalyzer.beatSpreadIsTrustworthy(HrvAnalyzer.RrCoverageVerdict.SAME_SECOND_OVER_COUNT))
+        assertFalse(HrvAnalyzer.beatSpreadIsTrustworthy(HrvAnalyzer.RrCoverageVerdict.CROSS_SECOND_OVER_COUNT))
+    }
+
+    /** Nothing else gates. UNDER_COVERED is a capture with holes and UNMEASURABLE is what a LIVE spot
+     *  reading looks like (real-time beats, no timestamps) — neither duplicates a beat, and refusing
+     *  them would suppress honest readings. */
+    @Test fun beatSpreadIsTrustworthy_keepsGapsAndUnmeasurable() {
+        assertTrue(HrvAnalyzer.beatSpreadIsTrustworthy(HrvAnalyzer.RrCoverageVerdict.PLAUSIBLE))
+        assertTrue(HrvAnalyzer.beatSpreadIsTrustworthy(HrvAnalyzer.RrCoverageVerdict.UNDER_COVERED))
+        assertTrue(HrvAnalyzer.beatSpreadIsTrustworthy(HrvAnalyzer.RrCoverageVerdict.UNMEASURABLE))
+    }
+
+    /** End to end on the shape that motivated this: 60 beats delivered as 10 records of 6, each record
+     *  stamping all six at its own second, records 5 s apart — 60 s of beat-time inside a 45 s span. The
+     *  same beats stamped one per second stay trusted. Verdict measured, never assumed from the device. */
+    @Test fun beatSpreadIsTrustworthy_bankedBurstsRefused_honestlySpacedKept() {
+        val rr = List(60) { 1000.0 }
+        val honestTs = (0 until 60).map { it.toLong() }
+        val honest = HrvAnalyzer.classifyCoverage(
+            HrvAnalyzer.rrCoverage(honestTs, rr), HrvAnalyzer.collapsedCoverage(honestTs, rr))
+        assertEquals(HrvAnalyzer.RrCoverageVerdict.PLAUSIBLE, honest)
+        assertTrue(HrvAnalyzer.beatSpreadIsTrustworthy(honest))
+
+        val bankedTs = (0 until 60).map { ((it / 6) * 5).toLong() }
+        val banked = HrvAnalyzer.classifyCoverage(
+            HrvAnalyzer.rrCoverage(bankedTs, rr), HrvAnalyzer.collapsedCoverage(bankedTs, rr))
+        assertFalse("verdict was $banked", HrvAnalyzer.beatSpreadIsTrustworthy(banked))
     }
 }

--- a/android/app/src/test/java/com/noop/analytics/RhythmScreenerTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RhythmScreenerTest.kt
@@ -258,4 +258,42 @@ class RhythmScreenerTest {
             }
         }
     }
+
+    // --- Beat-time integrity gate. Twin of the Swift RhythmScreenerTests gate tests. ---
+
+    /** A window whose beats are partly held twice describes a rhythm the heart never had — and describes
+     *  it as MORE varied, because every statistic here is a spread over the interval cloud. The honest
+     *  answer is unreadable. Same beats, same label inputs; only the timestamps differ. */
+    @Test fun bankedOverCountedWindow_isUnreadableRatherThanVaried() {
+        val rr = regularSinus()
+        val bankedTs = (rr.indices).map { (it / 6) * 5 }
+        val banked = RhythmScreener.screenWindow(
+            RhythmScreener.WindowInput(rrMs = rr, ts = bankedTs, motionStill = true, meanHR = 60.0))
+        assertEquals(RhythmRegularity.UNREADABLE, banked.label)
+        assertNull("SD2 is built from SDNN — it must not survive the gate", banked.sd2)
+    }
+
+    /** The same beats, honestly stamped, still read normally: the gate keys on MEASURED over-count, not
+     *  on the presence of timestamps. */
+    @Test fun honestlyStampedWindow_stillReads() {
+        val rr = regularSinus()
+        val r = RhythmScreener.screenWindow(
+            RhythmScreener.WindowInput(rrMs = rr, ts = rr.indices.toList(),
+                                       motionStill = true, meanHR = 60.0))
+        assertEquals(RhythmRegularity.STEADY, r.label)
+        assertNotNull(r.sd2)
+    }
+
+    /** A LIVE spot capture carries no timestamps, so coverage is unmeasurable — and unmeasurable is not
+     *  over-counted. Those readings must keep working exactly as before. */
+    @Test fun windowWithoutTimestamps_isUnaffected() {
+        val rr = regularSinus()
+        val withTs = RhythmScreener.screenWindow(
+            RhythmScreener.WindowInput(rrMs = rr, ts = rr.indices.toList(),
+                                       motionStill = true, meanHR = 60.0))
+        val withoutTs = RhythmScreener.screenWindow(
+            RhythmScreener.WindowInput(rrMs = rr, motionStill = true, meanHR = 60.0))
+        assertEquals(withTs.label, withoutTs.label)
+        assertEquals(withTs.sd2, withoutTs.sd2)
+    }
 }


### PR DESCRIPTION

**Branch:** `fix/gate-sdnn-on-overcounted-rr` (based on `main` @ `7c7b3f0c`, commit `a863170f`)
**Base:** `main`. No migration, no stored-value change, no new UI strings.
**Related:** follows #550 (which added the verdict) · #1072 / #1082 (the emission-order fix this
deliberately does *not* pre-empt) · #882/#883 drew the same boundary for respiration.

---

## The gap

`HRVAnalyzer.classifyCoverage` (#550) already decides whether a window's beat-time fits the wall clock
it spans, and the nightly `hrv diag` line has printed the answer ever since:

```
hrv diag day=2026-08-05 rmssd=85ms sdnn=197ms meanNN=1108ms rr=36225/31637 rejected=13%
         coverage=1.33 collapsedCov=0.87 dupBeats=0 rrIntegrity=sameSecondOverCount
```

Nothing acted on it. The app had diagnosed the capture as holding some beats twice **and printed an
SDNN anyway**, next to the field saying it could not be trusted.

SDNN is the standard deviation of *every* NN interval in the window, so duplicated beats inflate it
directly. On a ring whose banked R-R covers 1.25× the wall clock it spans, a sleeping night reads
**197 ms** against a 40–100 ms physiological range. That is not a small bias — it describes a heart
that does not exist.

## The change

One named boundary, `HRVAnalyzer.beatSpreadIsTrustworthy(_:)` (Kotlin twin
`HrvAnalyzer.beatSpreadIsTrustworthy`), and two places that act on it:

1. **The nightly `hrv diag` line** withholds the value — `sdnn=withheld` — rather than printing it.
   The `rrIntegrity=` field on the same line already says why, so the log stays self-diagnosing.
2. **`RhythmScreener.screenWindow`** returns `unreadable` for an over-counted window instead of
   describing it. Every statistic there is a spread over the interval cloud — SD2 is built from SDNN
   outright — so an over-count makes a rhythm read **more varied** than it was. That is the wrong
   direction to be wrong in for a label a person reads.

### What is *not* gated, and why

- **`underCovered` and `unmeasurable` stay trusted.** Neither duplicates a beat. `unmeasurable` is
  precisely what a **live spot reading** looks like: real-time beats carrying no timestamps to measure
  coverage with. Gating those would refuse honest readings, the opposite of the point — so the HRV
  snapshot screen is untouched on both platforms.
- **RMSSD and pNN50 are not gated.** Their dominant error on a banked stream was the lost
  within-second emission order (#823, root-caused and fixed in #1072 / #1082) — repaired at the write
  path, not here. Whether they need a gate of their own is a question for a post-fix capture to
  answer, not an assumption to bake in now.
- **Not device-specific.** A WHOOP night that ever measured an over-count is gated on the same
  evidence. No code here asks which strap produced the beats.

## Honest scope

The rhythm screener **is not wired to any UI yet** (its own header notes the screening verdict is
held behind a separate go/no-go). So today's only live effect is the diagnostic line. The screener
change is preventive: it makes it impossible for that engine to ship a wrong label later, at the cost
of four lines.

**Known gap, deliberately left:** `SleepStager` computes a per-epoch `sdnn` feature over 30 s windows
on both platforms. Gating that needs a *per-epoch* coverage measure, which is a different measurement
from the night-level one, and the stager is already unsettled (#930, #1008). Out of scope here rather
than done badly.

## Tests

Package-level on both platforms (`swift-packages.yml` / `./gradlew testFullDebugUnitTest`):

- the gate refuses both over-count verdicts and keeps the other three;
- end-to-end on the shape that motivated it — 60 beats delivered as 10 records of 6, each record
  stamping all six at its own second, records 5 s apart (60 s of beat-time in a 45 s span) — refuses,
  while the *same* beats stamped one per second classify `plausible` and stay readable;
- `RhythmScreener`: a banked window reads `unreadable` with `sd2 == nil`; the same beats honestly
  stamped still read `steady`; a window with **no** timestamps behaves exactly as before.

Every one has a Kotlin twin.

## Verification

- `swift test` StrandAnalytics: **1241 pass, 0 failures**.
- `./gradlew testFullDebugUnitTest`: 3,474 tests, the **same 3 pre-existing locale failures** as clean
  `main` (`AiCoachContextTest`, `StandardHrSensorFormatTest` ×2).
- App-target Swift is touched (`IntelligenceEngine.swift`) and no default CI builds it
  (`app-build.yml` is disabled): `xcodebuild` **Strand (macOS) and NOOPiOS both BUILD SUCCEEDED**.
- No hardware needed — this is pure analytics plus one log line. Nothing on the BLE path changed.