### PR TITLE
fix(ios): AI Coach robustness parity with Android (#1074)

### DIFF
--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -115,6 +115,7 @@ enum AICoachError: LocalizedError {
     case server(Int, String)
     case network(String)
     case decode
+    case emptyReply(String)   // #1074: verbatim provider-error / empty-reply text (byte-parity with Android emptyReplyMessage)
     case keySaveFailed
     case badCustomURL(String)
 
@@ -139,6 +140,8 @@ enum AICoachError: LocalizedError {
             return "Network problem: \(detail). The coach is the only feature that needs the internet."
         case .decode:
             return "Couldn't read the provider's reply. Try again."
+        case .emptyReply(let message):
+            return message
         }
     }
 }

--- a/Strand/AI/AIProvider.swift
+++ b/Strand/AI/AIProvider.swift
@@ -92,10 +92,27 @@ enum AIProvider: String, CaseIterable, Identifiable {
     static let customBaseURLKey = "ai.customBaseURL"
     static let customAuthHeaderKey = "ai.customAuthHeader"
 
-    /// The user-set Custom base URL, trimmed.
+    /// The user-set Custom base URL, normalised. Byte-parity with Android `AiCoach.normalizeCustomBaseUrl`.
     static var customBaseURL: String {
-        (UserDefaults.standard.string(forKey: customBaseURLKey) ?? "")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        normalizeCustomBaseURL(UserDefaults.standard.string(forKey: customBaseURLKey) ?? "")
+    }
+
+    /// #1074: normalise the Custom base URL so the derived `/chat/completions` and `/models` endpoints
+    /// are always well-formed. The user may paste the base (`http://…:11434/v1`) OR the whole chat URL
+    /// (`…/v1/chat/completions`) — the latter otherwise made the model scan hit `…/chat/completions/models`
+    /// and silently return nothing. Trim, drop trailing slashes, strip one trailing OpenAI-style chat
+    /// path, drop trailing slashes again. Pure — unit-tested. Byte-identical to Android normalizeCustomBaseUrl.
+    static func normalizeCustomBaseURL(_ url: String) -> String {
+        var base = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        while base.hasSuffix("/") { base.removeLast() }
+        for suffix in ["/chat/completions", "/completions"] {
+            if base.lowercased().hasSuffix(suffix) {
+                base.removeLast(suffix.count)
+                while base.hasSuffix("/") { base.removeLast() }
+                break
+            }
+        }
+        return base
     }
 
     static var customAuthHeader: CustomAIAuthHeader {
@@ -253,4 +270,16 @@ func providerErrorMessage(from data: Data) -> String {
     if let msg = obj["message"] as? String { return msg }
 
     return ""
+}
+
+/// #1074: the error to throw when a 200 response has no assistant content. Some OpenAI-compatible
+/// servers (e.g. a hand-set model they don't offer) return the real error INSIDE the 200 body rather
+/// than a 4xx; surface it instead of a blank decode error, so the cause is visible. Byte-parity with
+/// Android `AiCoach.emptyReplyMessage`.
+func emptyReplyError(_ json: [String: Any]) -> AICoachError {
+    if let err = json["error"] as? [String: Any], let msg = err["message"] as? String, !msg.isEmpty {
+        return .emptyReply("The provider returned an error: \(msg)")
+    }
+    return .emptyReply("The provider returned an empty reply. If you set a custom model by hand, check "
+        + "that the model name is one the provider actually offers.")
 }

--- a/Strand/AI/Providers/Anthropic.swift
+++ b/Strand/AI/Providers/Anthropic.swift
@@ -15,7 +15,9 @@ struct AnthropicClient: AIProviderClient {
         // Anthropic: system prompt is a top-level field, not a message role.
         let body: [String: Any] = [
             "model": model,
-            "max_tokens": 900,
+            // #1074: 900 truncated detailed coaching replies mid-sentence; 4096 lets a full multi-section
+            // reply complete (a cap, not a target — the system prompt keeps it short). Matches the others.
+            "max_tokens": 4096,
             "system": systemPrompt,
             "messages": wire
         ]
@@ -30,8 +32,9 @@ struct AnthropicClient: AIProviderClient {
         let json = try await performRequest(req, session: session)
         guard let content = json["content"] as? [[String: Any]],
               let first = content.first,
-              let text = first["text"] as? String else {
-            throw AICoachError.decode
+              let text = (first["text"] as? String)?
+                  .trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty else {
+            throw emptyReplyError(json)   // #1074: surface the provider's real error if the 200 body has one
         }
         return text
     }

--- a/Strand/AI/Providers/Custom.swift
+++ b/Strand/AI/Providers/Custom.swift
@@ -36,10 +36,11 @@ struct CustomClient: AIProviderClient {
     /// IGNORES `num_ctx` on the `/v1` endpoint) truncate silently — no error, the text just stops
     /// mid-sentence. We can't raise the window over the OpenAI wire format, so we make the cutoff
     /// visible and tell the user exactly how to fix it.
-    static let truncationNote = "\n\n---\n*Reply cut off: the model hit its context-window limit. "
-        + "On a local server like Ollama (default 2048 tokens), raise it - create a Modelfile with "
-        + "`PARAMETER num_ctx 8192` and select that model, or set `OLLAMA_CONTEXT_LENGTH=8192` and "
-        + "relaunch Ollama - then ask again.*"
+    // #1074: kept provider-agnostic. The old note gave Ollama-specific `num_ctx` instructions that were
+    // wrong for cloud providers (a DeepSeek user just hit the response-length cap, not a local window).
+    static let truncationNote = "\n\n---\n*Reply cut off at the response-length limit. Ask a more "
+        + "specific question for a shorter, complete answer — or, on a local server (e.g. Ollama), "
+        + "raise its context window.*"
 
     /// Pure: unwrap an OpenAI-compatible chat-completions body into the assistant text. Appends
     /// `truncationNote` when the server stopped early (`finish_reason == "length"`) so a context-
@@ -48,8 +49,9 @@ struct CustomClient: AIProviderClient {
         guard let choices = json["choices"] as? [[String: Any]],
               let first = choices.first,
               let message = first["message"] as? [String: Any],
-              let content = message["content"] as? String else {
-            throw AICoachError.decode
+              let content = (message["content"] as? String)?
+                  .trimmingCharacters(in: .whitespacesAndNewlines), !content.isEmpty else {
+            throw emptyReplyError(json)   // #1074: surface the provider's real error if the 200 body has one
         }
         if (first["finish_reason"] as? String)?.lowercased() == "length" {
             return content + Self.truncationNote
@@ -100,11 +102,13 @@ struct CustomClient: AIProviderClient {
         session: URLSession
     ) async throws -> String {
         var body: [String: Any] = ["model": model, "messages": wire]
+        // #1074: 900 truncated detailed coaching replies mid-sentence on cloud providers; 4096 lets a
+        // full multi-section reply complete (a cap, not a target). Matches the Gemini leg + Android.
         if modernParams {
-            body["max_completion_tokens"] = 900
+            body["max_completion_tokens"] = 4096
         } else {
             body["temperature"] = 0.6
-            body["max_tokens"] = 900
+            body["max_tokens"] = 4096
         }
 
         var req = URLRequest(url: AIProvider.custom.endpoint)

--- a/Strand/AI/Providers/Gemini.swift
+++ b/Strand/AI/Providers/Gemini.swift
@@ -44,10 +44,11 @@ struct GeminiClient: AIProviderClient {
               let first = candidates.first,
               let content = first["content"] as? [String: Any],
               let parts = content["parts"] as? [[String: Any]] else {
-            throw AICoachError.decode
+            throw emptyReplyError(json)   // #1074: surface the provider's real error if the 200 body has one
         }
         let text = parts.compactMap { $0["text"] as? String }.joined()
-        guard !text.isEmpty else { throw AICoachError.decode }
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { throw emptyReplyError(json) }   // #1074: friendlier empty-reply hint
         return text
     }
 

--- a/Strand/AI/Providers/OpenAI.swift
+++ b/Strand/AI/Providers/OpenAI.swift
@@ -54,11 +54,13 @@ struct OpenAIClient: AIProviderClient {
         session: URLSession
     ) async throws -> String {
         var body: [String: Any] = ["model": model, "messages": wire]
+        // #1074: 900 truncated detailed coaching replies mid-sentence; 4096 lets a full multi-section
+        // reply complete (a cap, not a target — the system prompt keeps it short). Matches Gemini + Android.
         if modernParams {
-            body["max_completion_tokens"] = 900
+            body["max_completion_tokens"] = 4096
         } else {
             body["temperature"] = 0.6
-            body["max_tokens"] = 900
+            body["max_tokens"] = 4096
         }
 
         var req = URLRequest(url: AIProvider.openAI.endpoint)
@@ -71,8 +73,9 @@ struct OpenAIClient: AIProviderClient {
         guard let choices = json["choices"] as? [[String: Any]],
               let first = choices.first,
               let message = first["message"] as? [String: Any],
-              let content = message["content"] as? String else {
-            throw AICoachError.decode
+              let content = (message["content"] as? String)?
+                  .trimmingCharacters(in: .whitespacesAndNewlines), !content.isEmpty else {
+            throw emptyReplyError(json)   // #1074: surface the provider's real error if the 200 body has one
         }
         return content
     }

--- a/StrandTests/AICoachEmptyReplyAndUrlTests.swift
+++ b/StrandTests/AICoachEmptyReplyAndUrlTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import Strand
+
+/// #1074: pins the two pure Custom-provider helpers that mirror Android `AiCoach.normalizeCustomBaseUrl`
+/// and `AiCoach.emptyReplyMessage`. The user-facing strings and the URL normalisation must stay
+/// byte-identical across platforms (the cross-platform parity contract). Pure logic — no network.
+final class AICoachEmptyReplyAndUrlTests: XCTestCase {
+
+    // MARK: - normalizeCustomBaseURL (parity with Android AiCoachCustomUrlTest)
+
+    func testNormalizeLeavesBareBaseUntouched() {
+        XCTAssertEqual(AIProvider.normalizeCustomBaseURL("https://api.deepseek.com"),
+                       "https://api.deepseek.com")
+        XCTAssertEqual(AIProvider.normalizeCustomBaseURL("https://api.deepseek.com/v1"),
+                       "https://api.deepseek.com/v1")
+    }
+
+    func testNormalizeTrimsTrailingSlash() {
+        XCTAssertEqual(AIProvider.normalizeCustomBaseURL("https://api.deepseek.com/v1/"),
+                       "https://api.deepseek.com/v1")
+    }
+
+    func testNormalizeStripsChatCompletionsSuffix() {
+        // A user who pastes the whole chat URL: the /models scan otherwise hit
+        // .../chat/completions/models and silently returned nothing (#1074).
+        XCTAssertEqual(AIProvider.normalizeCustomBaseURL("https://api.deepseek.com/v1/chat/completions"),
+                       "https://api.deepseek.com/v1")
+        XCTAssertEqual(AIProvider.normalizeCustomBaseURL("https://api.deepseek.com/chat/completions"),
+                       "https://api.deepseek.com")
+        XCTAssertEqual(AIProvider.normalizeCustomBaseURL("https://api.deepseek.com/v1/chat/completions/"),
+                       "https://api.deepseek.com/v1")
+    }
+
+    func testNormalizeStripsBareCompletionsSuffix() {
+        XCTAssertEqual(AIProvider.normalizeCustomBaseURL("http://192.168.1.10:11434/v1/completions"),
+                       "http://192.168.1.10:11434/v1")
+    }
+
+    func testNormalizeLeavesLocalBaseUntouched() {
+        XCTAssertEqual(AIProvider.normalizeCustomBaseURL("http://192.168.1.10:11434/v1"),
+                       "http://192.168.1.10:11434/v1")
+    }
+
+    func testNormalizeTrimsWhitespace() {
+        XCTAssertEqual(AIProvider.normalizeCustomBaseURL("  https://api.deepseek.com/v1  "),
+                       "https://api.deepseek.com/v1")
+    }
+
+    // MARK: - emptyReplyError (parity with Android AiCoachEmptyReplyTest)
+
+    func testEmptyReplySurfacesProviderErrorMessage() {
+        // Some OpenAI-compatible servers return the real error INSIDE a 200 body.
+        let json: [String: Any] = ["error": ["message": "Model does not exist"]]
+        XCTAssertEqual(emptyReplyError(json).errorDescription,
+                       "The provider returned an error: Model does not exist")
+    }
+
+    func testEmptyReplyFallsBackToModelHintWhenNoError() {
+        let json: [String: Any] = ["choices": []]
+        XCTAssertEqual(emptyReplyError(json).errorDescription,
+                       "The provider returned an empty reply. If you set a custom model by hand, check "
+                       + "that the model name is one the provider actually offers.")
+    }
+
+    func testEmptyReplyIgnoresBlankProviderMessage() {
+        let json: [String: Any] = ["error": ["message": ""]]
+        XCTAssertEqual(emptyReplyError(json).errorDescription,
+                       "The provider returned an empty reply. If you set a custom model by hand, check "
+                       + "that the model name is one the provider actually offers.")
+    }
+
+    // MARK: - parseChatContent wiring (Custom provider)
+
+    func testCustomParseThrowsEmptyReplyErrorOnErrorBody() {
+        let json: [String: Any] = ["error": ["message": "Insufficient balance"]]
+        XCTAssertThrowsError(try CustomClient().parseChatContent(json)) { error in
+            XCTAssertEqual((error as? AICoachError)?.errorDescription,
+                           "The provider returned an error: Insufficient balance")
+        }
+    }
+
+    func testCustomParseTreatsBlankContentAsEmptyReply() {
+        // A present-but-empty content string is a truncated/empty reply, not a valid answer.
+        let json: [String: Any] = [
+            "choices": [["message": ["content": ""]]]
+        ]
+        XCTAssertThrowsError(try CustomClient().parseChatContent(json))
+    }
+
+    func testCustomParseTreatsWhitespaceOnlyContentAsEmptyReply() {
+        // Content is trimmed before the empty-check (parity with Android's ?.trim()): a whitespace-only
+        // reply is empty, not a valid answer.
+        let json: [String: Any] = [
+            "choices": [["message": ["content": "   \n  "]]]
+        ]
+        XCTAssertThrowsError(try CustomClient().parseChatContent(json))
+    }
+
+    func testCustomParseTrimsSurroundingWhitespace() {
+        let json: [String: Any] = [
+            "choices": [["message": ["content": "  Get more sleep.  \n"]]]
+        ]
+        XCTAssertEqual(try CustomClient().parseChatContent(json), "Get more sleep.")
+    }
+}


### PR DESCRIPTION
iOS/macOS parity for the Android AI Coach fixes in #1083, all tracking #1074. App-target Swift only — no analytics, decoders, or stored data touched.

## Changes
- **Reply-cap truncation** — raise the cap 900 → 4096 on OpenAI, Anthropic and the Custom (OpenAI-compatible) provider, on **both** the standard (`max_tokens`) and modern/reasoning (`max_completion_tokens`) legs. Gemini was already 4096. It's a cap, not a target — the system prompt keeps normal replies short. Reasoning models count hidden thinking tokens against the budget, so 900 truncated detailed coaching replies mid-sentence (the reporter hit it on a DeepSeek model).
- **Provider-agnostic truncation note** — the old note gave Ollama-specific `num_ctx` advice that's wrong for a cloud provider hitting the response-length cap. Reworded, byte-identical to Android's `TRUNCATION_NOTE`.
- **Real provider errors on a 200** — some OpenAI-compatible servers return the error *inside* a 200 body rather than a 4xx. New `emptyReplyError()` + `AICoachError.emptyReply` case surface it (else a "check the model name" hint), rendering the **same user-facing text as Android `emptyReplyMessage`, byte-for-byte**. Wired into the Custom / OpenAI / Anthropic / Gemini parses.
- **Trim before the empty-check** — matches Android's `?.trim()`, so a whitespace-only 200 reply is treated as empty (empty-reply message fires) instead of returned as blank text.
- **Custom base-URL normalisation** — `normalizeCustomBaseURL` strips a trailing `/chat/completions` or `/completions`, so a pasted full chat URL no longer makes the model scan hit `.../chat/completions/models` and silently return nothing. Byte-identical to Android `normalizeCustomBaseUrl`.

## Tests
Adds `AICoachEmptyReplyAndUrlTests` mirroring the Android parity tests (URL normalisation, provider-error surfacing, empty/whitespace-reply handling, trimming).

## Verification
App-target Swift has no default CI (`app-build.yml` is disabled). Compiled via an on-demand `app-build` run (`Strand` macOS + `NOOPiOS` iOS). BLE/hardware paths untouched.