### PR TITLE
fix: sum activity-file steps across a day instead of overwriting (#1058)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -752,6 +752,16 @@ extension WhoopStore {
                 t.add(column: "srcChannel", .integer)
             }
         }
+        // #1058: per-session step count on a workout. Activity-file imports previously stored steps only
+        // as a whole-day DailyMetric row keyed on (deviceId, day), so a SECOND file for the same day
+        // overwrote the first's steps instead of adding. With steps on the session, the day total is
+        // recomputed as SUM over that day's sessions — additive across files, idempotent on re-import.
+        // Nullable; only foot-sport activity-file sessions populate it (a strap never writes it).
+        migrator.registerMigration("v33-workout-steps") { db in
+            try db.alter(table: "workout") { t in
+                t.add(column: "steps", .integer)
+            }
+        }
         return migrator
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/JournalWorkoutAppleCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/JournalWorkoutAppleCache.swift
@@ -40,13 +40,14 @@ public struct WorkoutRow: Equatable, Codable {
     public let distanceM: Double?
     public let zonesJSON: String?
     public let notes: String?
+    public let steps: Int?               // #1058: per-session steps (activity-file foot sports); nil otherwise
     public init(startTs: Int, endTs: Int, sport: String, source: String, durationS: Double?,
                 energyKcal: Double?, avgHr: Int?, maxHr: Int?, strain: Double?, distanceM: Double?,
-                zonesJSON: String?, notes: String?) {
+                zonesJSON: String?, notes: String?, steps: Int? = nil) {
         self.startTs = startTs; self.endTs = endTs; self.sport = sport; self.source = source
         self.durationS = durationS; self.energyKcal = energyKcal; self.avgHr = avgHr
         self.maxHr = maxHr; self.strain = strain; self.distanceM = distanceM
-        self.zonesJSON = zonesJSON; self.notes = notes
+        self.zonesJSON = zonesJSON; self.notes = notes; self.steps = steps
     }
 }
 
@@ -146,8 +147,8 @@ extension WhoopStore {
                 try db.execute(sql: """
                     INSERT INTO workout
                         (deviceId, startTs, endTs, sport, source, durationS, energyKcal,
-                         avgHr, maxHr, strain, distanceM, zonesJSON, notes)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                         avgHr, maxHr, strain, distanceM, zonesJSON, notes, steps)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT(deviceId, startTs, sport) DO UPDATE SET
                         endTs = excluded.endTs,
                         source = excluded.source,
@@ -158,10 +159,11 @@ extension WhoopStore {
                         strain = excluded.strain,
                         distanceM = excluded.distanceM,
                         zonesJSON = excluded.zonesJSON,
-                        notes = excluded.notes
+                        notes = excluded.notes,
+                        steps = excluded.steps
                     """, arguments: [deviceId, r.startTs, r.endTs, r.sport, r.source, r.durationS,
                                      r.energyKcal, r.avgHr, r.maxHr, r.strain, r.distanceM,
-                                     r.zonesJSON, r.notes])
+                                     r.zonesJSON, r.notes, r.steps])
                 n += db.changesCount
             }
             return n
@@ -235,7 +237,7 @@ extension WhoopStore {
         try syncRead { db in
             try Row.fetchAll(db, sql: """
                 SELECT startTs, endTs, sport, source, durationS, energyKcal, avgHr, maxHr,
-                       strain, distanceM, zonesJSON, notes FROM workout
+                       strain, distanceM, zonesJSON, notes, steps FROM workout
                 WHERE deviceId = ? AND startTs >= ? AND startTs <= ?
                 ORDER BY startTs ASC LIMIT ?
                 """, arguments: [deviceId, from, to, limit])
@@ -244,8 +246,21 @@ extension WhoopStore {
                                source: $0["source"], durationS: $0["durationS"],
                                energyKcal: $0["energyKcal"], avgHr: $0["avgHr"], maxHr: $0["maxHr"],
                                strain: $0["strain"], distanceM: $0["distanceM"],
-                               zonesJSON: $0["zonesJSON"], notes: $0["notes"])
+                               zonesJSON: $0["zonesJSON"], notes: $0["notes"], steps: $0["steps"])
                 }
+        }
+    }
+
+    /// #1058: sum per-session `steps` over one source's workouts whose startTs is in [from, to). Used to
+    /// recompute an activity-file day's step total from ALL its sessions, so a second file on the same day
+    /// adds rather than clobbers — and re-importing a file is idempotent (its row's steps are replaced,
+    /// not re-added, by `upsertWorkouts`). Returns 0 when no session in the range carried steps.
+    public func sumWorkoutSteps(deviceId: String, from: Int, to: Int) async throws -> Int {
+        try syncRead { db in
+            try Int.fetchOne(db, sql: """
+                SELECT COALESCE(SUM(steps), 0) FROM workout
+                WHERE deviceId = ? AND steps IS NOT NULL AND startTs >= ? AND startTs < ?
+                """, arguments: [deviceId, from, to]) ?? 0
         }
     }
 

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/JournalWorkoutAppleCacheTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/JournalWorkoutAppleCacheTests.swift
@@ -203,6 +203,71 @@ final class JournalWorkoutAppleCacheTests: XCTestCase {
         XCTAssertEqual(rows.count, 2, "same startTs but different sport are distinct rows")
     }
 
+    // MARK: - #1058 per-session steps: a second activity file for a day ADDS, and re-import is idempotent
+
+    func testWorkoutStepsRoundTrip() async throws {
+        let store = try await WhoopStore.inMemory()
+        let w = WorkoutRow(startTs: 1_000, endTs: 4_600, sport: "run", source: "activity-file",
+                           durationS: nil, energyKcal: nil, avgHr: nil, maxHr: nil, strain: nil,
+                           distanceM: nil, zonesJSON: nil, notes: nil, steps: 3_000)
+        try await store.upsertWorkouts([w], deviceId: "activity-file")
+        let rows = try await store.workouts(deviceId: "activity-file", from: 0, to: 100_000, limit: 100)
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0].steps, 3_000)
+    }
+
+    func testSumWorkoutStepsAddsAcrossSameDaySessionsAndIsIdempotent() async throws {
+        // The #1058 repro: two walks on one day. Before the fix, the second file's whole-day upsert
+        // clobbered the first's step count; now each session carries its steps and the day total is
+        // their SUM — and re-importing a file leaves that total unchanged.
+        let store = try await WhoopStore.inMemory()
+        let morning = WorkoutRow(startTs: 10_000, endTs: 12_000, sport: "walk", source: "activity-file",
+                                 durationS: nil, energyKcal: nil, avgHr: nil, maxHr: nil, strain: nil,
+                                 distanceM: nil, zonesJSON: nil, notes: nil, steps: 3_000)
+        let evening = WorkoutRow(startTs: 60_000, endTs: 63_000, sport: "walk", source: "activity-file",
+                                 durationS: nil, energyKcal: nil, avgHr: nil, maxHr: nil, strain: nil,
+                                 distanceM: nil, zonesJSON: nil, notes: nil, steps: 8_834)
+
+        try await store.upsertWorkouts([morning], deviceId: "activity-file")
+        var total = try await store.sumWorkoutSteps(deviceId: "activity-file", from: 0, to: 86_400)
+        XCTAssertEqual(total, 3_000, "one walk = its own steps")
+
+        try await store.upsertWorkouts([evening], deviceId: "activity-file")
+        total = try await store.sumWorkoutSteps(deviceId: "activity-file", from: 0, to: 86_400)
+        XCTAssertEqual(total, 11_834, "second same-day walk ADDS, not overwrites")
+
+        // Re-import the morning file (same startTs+sport) → its row is replaced, not duplicated.
+        try await store.upsertWorkouts([morning], deviceId: "activity-file")
+        total = try await store.sumWorkoutSteps(deviceId: "activity-file", from: 0, to: 86_400)
+        XCTAssertEqual(total, 11_834, "re-importing a file must not double-count")
+    }
+
+    func testSumWorkoutStepsIgnoresSteplessSessionsAndOtherDaysAndSources() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertWorkouts([
+            // a cycling session that day — no steps, must not affect the total or crash the SUM
+            WorkoutRow(startTs: 20_000, endTs: 22_000, sport: "cycle", source: "activity-file",
+                       durationS: nil, energyKcal: nil, avgHr: nil, maxHr: nil, strain: nil,
+                       distanceM: nil, zonesJSON: nil, notes: nil, steps: nil),
+            WorkoutRow(startTs: 30_000, endTs: 32_000, sport: "walk", source: "activity-file",
+                       durationS: nil, energyKcal: nil, avgHr: nil, maxHr: nil, strain: nil,
+                       distanceM: nil, zonesJSON: nil, notes: nil, steps: 5_000),
+            // next day — outside the range
+            WorkoutRow(startTs: 90_000, endTs: 92_000, sport: "walk", source: "activity-file",
+                       durationS: nil, energyKcal: nil, avgHr: nil, maxHr: nil, strain: nil,
+                       distanceM: nil, zonesJSON: nil, notes: nil, steps: 9_999),
+        ], deviceId: "activity-file")
+        // a different source with steps that day — must not bleed into the activity-file total
+        try await store.upsertWorkouts([
+            WorkoutRow(startTs: 40_000, endTs: 42_000, sport: "walk", source: "apple",
+                       durationS: nil, energyKcal: nil, avgHr: nil, maxHr: nil, strain: nil,
+                       distanceM: nil, zonesJSON: nil, notes: nil, steps: 7_777),
+        ], deviceId: "apple-health")
+
+        let total = try await store.sumWorkoutSteps(deviceId: "activity-file", from: 0, to: 86_400)
+        XCTAssertEqual(total, 5_000, "only same-source, same-day, step-bearing sessions count")
+    }
+
     func testWorkoutNullableMetricsRoundTripAsNil() async throws {
         let store = try await WhoopStore.inMemory()
         let w = WorkoutRow(startTs: 50, endTs: 60, sport: "yoga", source: "apple",

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
@@ -1,6 +1,6 @@
 {
   "_readme": "SHARED Room<->GRDB SCHEMA ORACLE (#775). Two byte-identical copies: Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json and android/app/src/test/resources/schema_oracle.json. SchemaOracleTests.swift compares GRDB's PRAGMA table_info/index_list against it; SchemaOracleTest.kt compares Room's exported schema JSON against it. `columns` is the iOS/GRDB shape in GRDB column order (macOS is the reference implementation); every way Android differs is spelled out in an `android` / `iosAbsent` / `androidColumnOrder` override naming a key in `divergenceReasons`. Adding a column, reordering one, or changing a type/nullability on one platform only fails both suites until it is either fixed or written down here.",
-  "roomVersion": 26,
+  "roomVersion": 27,
   "grdbMigrations": [
     "v1",
     "v2",
@@ -33,7 +33,8 @@
     "v29-score-input-provenance",
     "v30-rr-ord",
     "v31-deep-capture-channels",
-    "v32-rr-src-channel"
+    "v32-rr-src-channel",
+    "v33-workout-steps"
   ],
   "divergenceReasons": {
     "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android \u2014 the per-row upload flag belongs to an upload path that does not exist there \u2014 so it is dead width, not divergent data. Removing it needs a Room table rebuild.",
@@ -1746,6 +1747,12 @@
           "default": null,
           "iosAbsent": true,
           "divergence": "workout-route-polyline-android-only"
+        },
+        {
+          "name": "steps",
+          "affinity": "INTEGER",
+          "notNull": false,
+          "default": null
         }
       ],
       "primaryKey": [

--- a/Strand/Screens/DataSourcesView.swift
+++ b/Strand/Screens/DataSourcesView.swift
@@ -561,7 +561,8 @@ struct DataSourcesView: View {
                     strain: nil,                         // never a fabricated cardiovascular strain
                     distanceM: activity.distanceM,
                     zonesJSON: nil,
-                    notes: activity.importNote()
+                    notes: activity.importNote(),
+                    steps: activity.steps                 // #1058: per-session steps, summed into the day below
                 )
                 try await store.upsertWorkouts([row], deviceId: ActivityFileImporter.sourceId)
 
@@ -573,24 +574,38 @@ struct DataSourcesView: View {
                     let hr = activity.hrSamples.map { HRSample(ts: $0.ts, bpm: $0.bpm) }
                     _ = try? await store.insert(Streams(hr: hr), deviceId: ActivityFileImporter.sourceId)
                 }
-                if let steps = activity.steps, steps > 0 {
-                    let day = Repository.localDayKey(activity.start)
-                    let metric = DailyMetric(
-                        day: day,
-                        totalSleepMin: nil,
-                        efficiency: nil,
-                        deepMin: nil,
-                        remMin: nil,
-                        lightMin: nil,
-                        disturbances: nil,
-                        restingHr: nil,
-                        avgHrv: nil,
-                        recovery: nil,
-                        strain: nil,
-                        exerciseCount: nil,
-                        steps: steps
-                    )
-                    try? await store.upsertDailyMetrics([metric], deviceId: ActivityFileImporter.sourceId)
+                // #1058: recompute the day's activity-file step total as the SUM over ALL that day's
+                // sessions (now that each carries its own steps), so a second file for the same day ADDS
+                // to the first instead of clobbering it. Idempotent on re-import: the file's workout row
+                // (keyed on startTs+sport) is replaced, not duplicated, so the re-summed total is unchanged.
+                // Only recompute when THIS file contributed steps (a foot sport); a cycling import leaves
+                // the day's step total untouched.
+                if (activity.steps ?? 0) > 0 {
+                    let dayStart = Calendar.current.startOfDay(for: activity.start)
+                    let dayEnd = Calendar.current.date(byAdding: .day, value: 1, to: dayStart)
+                        ?? dayStart.addingTimeInterval(86_400)
+                    let daySteps = (try? await store.sumWorkoutSteps(
+                        deviceId: ActivityFileImporter.sourceId,
+                        from: Int(dayStart.timeIntervalSince1970),
+                        to: Int(dayEnd.timeIntervalSince1970))) ?? 0
+                    if daySteps > 0 {
+                        let metric = DailyMetric(
+                            day: Repository.localDayKey(activity.start),
+                            totalSleepMin: nil,
+                            efficiency: nil,
+                            deepMin: nil,
+                            remMin: nil,
+                            lightMin: nil,
+                            disturbances: nil,
+                            restingHr: nil,
+                            avgHrv: nil,
+                            recovery: nil,
+                            strain: nil,
+                            exerciseCount: nil,
+                            steps: daySteps
+                        )
+                        try? await store.upsertDailyMetrics([metric], deviceId: ActivityFileImporter.sourceId)
+                    }
                 }
 
                 // #137 (B1): register `activity-file` as an `.activityFile` device so the per-day owner

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -504,6 +504,10 @@ data class WorkoutRow(
     val zonesJSON: String? = null,
     val notes: String? = null,
     val routePolyline: String? = null, // Encoded GPS route (RouteMath polyline); null = no GPS.
+    // #1058: per-session step count (activity-file foot sports; null otherwise). The day's step total is
+    // recomputed as SUM over that day's sessions, so a second file for a day adds instead of clobbering.
+    // Declared LAST so the v27 ALTER-appended column matches this fresh-schema order. Swift `WorkoutRow.steps`.
+    val steps: Int? = null,
 )
 
 /**

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -742,6 +742,19 @@ interface WhoopDao : DeviceRegistryDao {
     suspend fun workoutsCount(deviceId: String, from: Long, to: Long): Int
 
     /**
+     * #1058: sum per-session `steps` over one source's workouts whose startTs is in [from, to). Used to
+     * recompute an activity-file day's step total from ALL its sessions, so a second file on the same day
+     * ADDS rather than clobbers — and re-importing a file is idempotent (its row's steps are replaced, not
+     * re-added, by [upsertWorkouts]). Returns 0 when no session in the range carried steps. Byte-parity
+     * with Swift WhoopStore `sumWorkoutSteps`.
+     */
+    @Query(
+        "SELECT COALESCE(SUM(steps), 0) FROM workout " +
+            "WHERE deviceId = :deviceId AND steps IS NOT NULL AND startTs >= :from AND startTs < :to"
+    )
+    suspend fun sumWorkoutSteps(deviceId: String, from: Long, to: Long): Int
+
+    /**
      * Apple-Health daily aggregates for days in [from, to] (lexicographic compare), oldest first.
      * Port of JournalWorkoutAppleCache.swift appleDaily(deviceId:from:to:).
      */

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -52,7 +52,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         RawImuSampleEntity::class,
         V18AuxSampleEntity::class,
     ],
-    version = 26,
+    version = 27,
     // #775: ON so Room's KSP processor writes the generated schema (every table's exact `CREATE TABLE`,
     // columns in declaration order with affinity/NOT NULL/default, PK and indices) as JSON. That export
     // is what lets a plain JVM test — no device, no Robolectric — read Android's REAL schema and compare
@@ -742,6 +742,31 @@ abstract class WhoopDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * v26 -> v27: ADDITIVE, adds `workout.steps` (nullable INTEGER) so an imported activity file can
+         * carry its OWN step count (#1058). Before this, activity-file steps were stored only as a
+         * whole-day `dailyMetric.steps` row keyed on (deviceId, day), so a SECOND file for the same day
+         * overwrote the first's steps instead of adding. With steps on the session, the day total is
+         * recomputed as SUM over that day's sessions — additive across files, idempotent on re-import.
+         *
+         * Additive and nullable, the MIGRATION_3_4 (`workout.routePolyline`) form: no table rebuild, no row
+         * touched, not part of the primary key. ALTER TABLE appends the column LAST, matching the entity
+         * field order (declared after `routePolyline`), so a migrated schema and a freshly-created one
+         * agree. Byte-parity with Swift WhoopStore `v33-workout-steps`.
+         *
+         * Exposed as [WORKOUT_STEPS_MIGRATION_SQL] so a plain-JVM unit test can assert its shape without an
+         * emulator, like the migrations above.
+         */
+        internal val WORKOUT_STEPS_MIGRATION_SQL: List<String> = listOf(
+            "ALTER TABLE `workout` ADD COLUMN `steps` INTEGER",
+        )
+
+        internal val MIGRATION_26_27 = object : Migration(26, 27) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                for (stmt in WORKOUT_STEPS_MIGRATION_SQL) db.execSQL(stmt)
+            }
+        }
+
         private fun build(appContext: Context): WhoopDatabase =
             Room.databaseBuilder(appContext, WhoopDatabase::class.java, DB_NAME)
                 // #1014: replace ONLY the corruption handling of the default open-helper. The
@@ -759,6 +784,7 @@ abstract class WhoopDatabase : RoomDatabase() {
                     MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18,
                     MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
                     MIGRATION_22_23, MIGRATION_23_24, MIGRATION_24_25, MIGRATION_25_26,
+                    MIGRATION_26_27,
                 )
                 // #1037: a FRESH install builds the schema straight at the current version and runs NO
                 // migrations, so the MIGRATION_7_8 "my-whoop" registry seed never fires and the WHOOP,

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1266,6 +1266,10 @@ class WhoopRepository(private val dao: WhoopDao) {
     suspend fun workoutsCount(deviceId: String, from: Long, to: Long): Int =
         dao.workoutsCount(deviceId, from, to)
 
+    /** #1058: SUM of per-session `steps` over one source's workouts with startTs in [from, to). */
+    suspend fun sumWorkoutSteps(deviceId: String, from: Long, to: Long): Int =
+        dao.sumWorkoutSteps(deviceId, from, to)
+
     /** Journal entries for the inclusive day range [from, to] (YYYY-MM-DD), oldest first. */
     suspend fun journal(deviceId: String, from: String, to: String): List<JournalEntry> =
         dao.journal(deviceId, from, to)

--- a/android/app/src/main/java/com/noop/ingest/ActivityFileImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/ActivityFileImporter.kt
@@ -212,6 +212,7 @@ object ActivityFileImporter {
             notes = activity.importNote(),
             routePolyline = activity.route.takeIf { it.size >= 2 }
                 ?.let { RouteMath.encode(it.map { p -> RouteMath.LatLng(p.lat, p.lon) }) },
+            steps = activity.steps,                         // #1058: per-session steps, summed into the day below
         )
 
         repo.upsertDevice(deviceId, name = "Workout files")
@@ -225,14 +226,28 @@ object ActivityFileImporter {
         if (activity.hrSamples.isNotEmpty()) {
             repo.insertHr(activity.hrSamples.map { HrSample(deviceId = deviceId, ts = it.ts, bpm = it.bpm) })
         }
+        // #1058: recompute the day's activity-file step total as the SUM over ALL that day's sessions
+        // (each now carries its own steps), so a second file for the same day ADDS to the first instead
+        // of clobbering it. Idempotent on re-import: the file's workout row (keyed on startTs+sport) is
+        // replaced, not duplicated, so the re-summed total is unchanged. Only recompute when THIS file
+        // contributed steps (a foot sport); a cycling import leaves the day's step total untouched.
+        var dayStepsWritten = false
         if (activity.steps != null && activity.steps > 0) {
-            repo.upsertDailyMetrics(
-                listOf(DailyMetric(deviceId = deviceId, day = localDayString(activity.startTs), steps = activity.steps)),
-            )
+            val zone = java.time.ZoneId.systemDefault()
+            val localDate = Instant.ofEpochSecond(activity.startTs).atZone(zone).toLocalDate()
+            val dayStart = localDate.atStartOfDay(zone).toEpochSecond()
+            val dayEnd = localDate.plusDays(1).atStartOfDay(zone).toEpochSecond()
+            val daySteps = repo.sumWorkoutSteps(deviceId, dayStart, dayEnd)
+            if (daySteps > 0) {
+                repo.upsertDailyMetrics(
+                    listOf(DailyMetric(deviceId = deviceId, day = localDayString(activity.startTs), steps = daySteps)),
+                )
+                dayStepsWritten = true
+            }
         }
 
         val counts = linkedMapOf("workouts" to 1)
-        if (activity.steps != null && activity.steps > 0) counts["dailyMetric"] = 1
+        if (dayStepsWritten) counts["dailyMetric"] = 1
         return ImportSummary(
             source = SOURCE_LABEL,
             counts = counts,

--- a/android/app/src/test/resources/schema_oracle.json
+++ b/android/app/src/test/resources/schema_oracle.json
@@ -1,6 +1,6 @@
 {
   "_readme": "SHARED Room<->GRDB SCHEMA ORACLE (#775). Two byte-identical copies: Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json and android/app/src/test/resources/schema_oracle.json. SchemaOracleTests.swift compares GRDB's PRAGMA table_info/index_list against it; SchemaOracleTest.kt compares Room's exported schema JSON against it. `columns` is the iOS/GRDB shape in GRDB column order (macOS is the reference implementation); every way Android differs is spelled out in an `android` / `iosAbsent` / `androidColumnOrder` override naming a key in `divergenceReasons`. Adding a column, reordering one, or changing a type/nullability on one platform only fails both suites until it is either fixed or written down here.",
-  "roomVersion": 26,
+  "roomVersion": 27,
   "grdbMigrations": [
     "v1",
     "v2",
@@ -33,7 +33,8 @@
     "v29-score-input-provenance",
     "v30-rr-ord",
     "v31-deep-capture-channels",
-    "v32-rr-src-channel"
+    "v32-rr-src-channel",
+    "v33-workout-steps"
   ],
   "divergenceReasons": {
     "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android \u2014 the per-row upload flag belongs to an upload path that does not exist there \u2014 so it is dead width, not divergent data. Removing it needs a Room table rebuild.",
@@ -1746,6 +1747,12 @@
           "default": null,
           "iosAbsent": true,
           "divergence": "workout-route-polyline-android-only"
+        },
+        {
+          "name": "steps",
+          "affinity": "INTEGER",
+          "notNull": false,
+          "default": null
         }
       ],
       "primaryKey": [


### PR DESCRIPTION
Fixes #1058 (reported by @pipiche38).

## The bug
Importing an activity file (`.fit`/`.gpx`/`.tcx`) stored its step count as a **whole-day** `dailyMetric` row keyed on `(deviceId, day)`, and the upsert overwrote unconditionally — so a **second** file for the same day replaced the first's steps rather than adding. Two walks on one day reported only the second walk's steps (silent data loss). Present on **both** platforms (`DataSourcesView.swift` and `ActivityFileImporter.kt`).

## Why the schema change
Per-session steps weren't recoverable after import — `workout` had no steps column and the raw activity is discarded — so "recompute the day from its sessions" had no source data. The idempotent fix is to attribute steps to the session:

- **`steps` column on `workout`** — GRDB `v33-workout-steps` + Room `MIGRATION_26_27` (version 26 → 27). Additive, nullable, declared **last** so the ALTER-appended column matches the fresh schema (the schema-oracle contract).
- **Store per-session steps** at import.
- **Day total = `SUM(steps)`** over that day's `activity-file` sessions. A second file **adds**; re-importing a file is **idempotent** because `upsertWorkouts` replaces the file's own row (keyed on `startTs+sport`), so the re-summed total is unchanged. (A plain additive `steps += excluded.steps` would double-count a re-import — deliberately avoided.)

Not `AppleHealthAggregator`'s `max()` (#589): that dedups the *same* steps double-reported by iPhone+Watch; activity files are *distinct sessions*, so this is a **sum**.

## Cross-platform / parity
Both platforms fixed. Both `schema_oracle.json` copies updated identically (`roomVersion` 27, `+v33-workout-steps`, `+workout.steps`), keeping the Room↔GRDB drift guard honest.

## Tests
- `JournalWorkoutAppleCacheTests` (WhoopStore, real SQLite): two same-day files → **11,834** (3,000 + 8,834), and re-importing one file leaves it **unchanged**; plus stepless/other-day/other-source exclusion. This is the exact pair the issue asked for.
- `SchemaOracleTest` (both platforms) guards the new column + version.

## Verification
Android: `compileFullDebugKotlin` + `SchemaOracleTest` + data/ingest unit tests pass locally (KSP regen to v27). App-target Swift (`DataSourcesView`) compiled via app-build; WhoopStore package tests run in `swift-packages` CI.