### PR TITLE
docs: drop dead noopapp Homebrew tap, point macOS users to Releases (#1069)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Pre-built apps you can run right now:
 
 | Platform | Build | Notes |
 |---|---|---|
-| **macOS** | `NOOP.app` (see [Releases](https://github.com/ryanbr/noop/releases)) or Homebrew: `brew tap noopapp/noop && brew trust noopapp/noop && brew install --cask noop` | Apple Silicon + Intel. Drag to Applications. Not notarized — see **First launch on macOS** below. The one-time `brew trust noopapp/noop` is needed on Homebrew 6.0+ (harmless on older versions) — see [Homebrew docs](docs/HOMEBREW.md). |
+| **macOS** | `NOOP.app` (see [Releases](https://github.com/ryanbr/noop/releases)) | Apple Silicon + Intel. Drag to Applications. Not notarized — see **First launch on macOS** below. _(A Homebrew cask isn't currently published for this fork — grab the `.app` from Releases.)_ |
 | **Android** | `NOOP-full.apk` (see [Releases](https://github.com/ryanbr/noop/releases)) | The full app. `minSdk 26` (Android 8+). Sideload — enable "install unknown apps". Blocked by Play Protect? See **Installing on Android** below. |
 | **iOS** | **AltStore / SideStore source** (recommended — one-tap install + auto-updates): add `https://raw.githubusercontent.com/ryanbr/noop/main/altstore-source.json` as a source. Or a **direct** [`NOOP-vX-ios.ipa`](https://github.com/ryanbr/noop/releases) download. | The `.ipa` is unsigned; **you** sign it on your iPhone with your own free Apple ID (no App Store, no developer account — NOOP stays anonymous). Re-signs every 7 days (AltStore/SideStore automates it). See [docs/IOS.md](docs/IOS.md). Or build from source in Xcode. |
 

--- a/docs/HOMEBREW.md
+++ b/docs/HOMEBREW.md
@@ -1,58 +1,68 @@
 # Homebrew Cask (macOS)
 
-macOS users install + auto-update NOOP with:
+> **Status: not currently available.** There is **no working Homebrew tap for this fork**. The original
+> `noopapp/noop` tap referenced by older releases is gone — the upstream `noopapp` GitHub org (and its
+> `homebrew-noop` repo) no longer exists (#1069), so `brew tap noopapp/noop` fails outright.
+>
+> **Install NOOP on macOS by downloading `NOOP.app` directly from
+> [Releases](https://github.com/ryanbr/noop/releases)** — Apple Silicon + Intel, drag to Applications.
+> See **First launch on macOS** in the [README](../README.md#download) for the one-time Gatekeeper step
+> (NOOP ships anonymously and isn't notarized, so macOS blocks it on first open until you clear the
+> download quarantine flag).
+
+The rest of this doc is a maintainer reference for **re-publishing** a tap under this fork, should that
+happen later. Until a tap exists and this notice is removed, ignore any `brew …` commands below.
+
+## Publishing a tap under this fork (maintainers)
+
+A Homebrew cask lets macOS users install + auto-update with:
 
 ```bash
-brew tap noopapp/noop
-brew trust noopapp/noop    # required since Homebrew 6.0.0 (see note below)
+brew tap <org>/noop
+brew trust <org>/noop      # required since Homebrew 6.0.0 (see note below)
 brew install --cask noop
 brew upgrade --cask noop   # later updates
 ```
 
-The cask lives in the **`NoopApp/homebrew-noop`** tap on GitHub and points at the macOS `.zip`
-attached to each release.
+To bring that back, a public `homebrew-noop` tap repo must be created under this fork's org (e.g.
+`ryanbr/homebrew-noop`), holding `Casks/noop.rb` pointing at the macOS `.zip` attached to each release.
+`Tools/update-homebrew-cask.sh` still automates the cask refresh, but it defaults to the dead `NoopApp`
+tap — point it at the new repo via the `FORGE_ORG` / `FORGE_REPO` environment variables:
+
+```bash
+FORGE_ORG=ryanbr Tools/update-homebrew-cask.sh <version>   # e.g. … 1.95
+```
+
+That script computes the release zip's SHA256, regenerates `Casks/noop.rb`, and pushes it to the tap.
+There is **no GitHub Actions workflow / repo secret** — releases are cut by hand, so the cask update
+rides along with them.
 
 > **Why `brew trust`?** Since **Homebrew 6.0.0** (June 2026), non-official taps must be explicitly
 > trusted before Homebrew will load their code — otherwise you'll see
-> `Error: Refusing to load cask noopapp/noop/noop from untrusted tap`. Trust is a one-time,
-> per-machine decision (publishers can't pre-trust their own tap — only Homebrew's official taps are
-> trusted by default). Trust the whole tap with `brew trust noopapp/noop`, or just our cask with
-> `brew trust --cask noopapp/noop/noop`. It's the Homebrew equivalent of the Gatekeeper
-> right-click-Open below: you're vouching for code you can read — the cask is one short file in the
-> public tap, and the app's full source is in this repo.
+> `Error: Refusing to load cask <org>/noop/noop from untrusted tap`. Trust is a one-time, per-machine
+> decision (publishers can't pre-trust their own tap — only Homebrew's official taps are trusted by
+> default). Trust the whole tap with `brew trust <org>/noop`, or just the cask with
+> `brew trust --cask <org>/noop/noop`. It's the Homebrew equivalent of the Gatekeeper right-click-Open:
+> you're vouching for code you can read — the cask is one short file in the public tap, and the app's
+> full source is in this repo.
 
 > **Unsigned-app note.** NOOP ships anonymously with no Apple Developer ID, so it isn't notarized.
 > Homebrew can't strip the quarantine flag for an un-notarized app, so on **first launch** Gatekeeper
 > blocks it. On **macOS 15 Sequoia and later**: try to open NOOP once, then **System Settings →
 > Privacy & Security**, scroll down, and click **"Open Anyway"** next to NOOP. (On macOS 14 and
-> earlier you can right-click NOOP in `/Applications` → **Open** → **Open**.) The cask's `caveats`
-> says this. Updates after that are just `brew upgrade`.
+> earlier you can right-click NOOP in `/Applications` → **Open** → **Open**.) Updates after that are
+> just `brew upgrade`.
 
-## How it stays current
+## Requirements (for a republished tap)
 
-The cask is refreshed **as part of cutting each macOS release** — the last step of the release process
-runs:
-
-```bash
-Tools/update-homebrew-cask.sh <version>     # e.g. Tools/update-homebrew-cask.sh 1.95
-```
-
-That script computes the release zip's SHA256, regenerates `Casks/noop.rb`, and pushes it to the tap.
-There is **no GitHub Actions workflow / repo secret** — releases are cut by hand, so the cask update
-rides along with them. Fewer secrets, nothing to fail, one less surface to keep anonymous.
-
-## Requirements
-
-- The tap repo **`NoopApp/homebrew-noop`** exists (public). ✅ done.
-- The NoopApp PAT at `~/.config/noop/gh_token` (the same one used to push releases) has
-  **Contents: Read and write** on `homebrew-noop`. The script reads the token from that file and
-  supplies it through a transient git credential helper, so **the token never appears on a command
-  line, in a remote URL, or in any output** (a clean remote URL is used for clone + push).
+- A public `homebrew-noop` tap repo exists under the fork's org.
+- A PAT with **Contents: Read and write** on that repo (the same one used to push releases), read from a
+  local file and supplied through a transient git credential helper, so **the token never appears on a
+  command line, in a remote URL, or in any output**.
 
 ## Anonymity checklist
 
-- Tap repo + commits under the anonymous **NoopApp** identity (the script commits as
-  `NoopApp <thenoopapp@gmail.com>`).
+- Tap repo + commits under an anonymous identity (the script commits with a configurable name/email).
 - Token read from the local file only; never echoed. Scope it to the repos it needs and no more.
 - The cask installs the **already-anonymized** release zip (scrubbed by `Tools/anonymize-macos-app.sh`
   at build time) — no new surface.


### PR DESCRIPTION
Fixes #1069 (reported by @rube-de).

## Problem
The README's macOS install instructions pointed at `brew tap noopapp/noop && brew trust noopapp/noop && brew install --cask noop`. The upstream `noopapp` GitHub org and its `homebrew-noop` tap **no longer exist** — both 404 — so `brew tap noopapp/noop` fails outright. No replacement tap is published under this fork yet, and the direct `NOOP.app` download from Releases works fine.

Verified: `orgs/noopapp` → 404, `noopapp/homebrew-noop` → 404, `ryanbr/homebrew-noop` → doesn't exist.

## Change (docs only)
- **README** macOS row → points solely at the direct [`NOOP.app`](https://github.com/ryanbr/noop/releases) download, with a one-line note that no Homebrew cask is currently published. Drops the dead `brew …` shorthand and the user-facing link to the Homebrew doc.
- **docs/HOMEBREW.md** → leads with a clear **"not currently available — install from Releases"** status banner, and reframes the rest as a maintainer reference for *re-publishing* a tap under this fork's org (using the existing `Tools/update-homebrew-cask.sh` + its `FORGE_ORG` override), instead of describing the dead `NoopApp` tap as live.

## Deliberately left alone
- Historical `CHANGELOG.md` / `docs/releases/v*.md` entries — a point-in-time record, not rewritten.
- The app bundle id `com.noopapp.noop` and the `thenoopapp@gmail.com` contact — unrelated to the tap.
- `Tools/update-homebrew-cask.sh` runtime behavior — it already supports the `FORGE_ORG`/`FORGE_REPO` override the doc now documents; publishing an actual `ryanbr/homebrew-noop` tap is a separate follow-up.

No code paths touched.