### PR TITLE
perf(ios): memoize the Live Activity widget-anchor across live-HR ticks

### DIFF
--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -419,6 +419,23 @@ final class Repository: ObservableObject {
         widgetAnchor(days: days, logicalKey: logicalDayKey(now), localKey: localDayKey(now))
     }
 
+    /// #1051-shaped memo for the anchor resolve on the high-frequency live surfaces. Not @Published — pure
+    /// bookkeeping, never drives the UI (like `todayHistoryWideLoadedSeq`).
+    private var widgetAnchorMemo = WidgetAnchorMemo()
+
+    /// Memoized `widgetAnchor(days: self.days)` for the Live Activity's ~1-3 Hz `onReceive` closures, which
+    /// otherwise re-derive the anchor (two `DateFormatter` formats + up to two full-history scans) on every
+    /// live-HR tick. Recomputes only when `days` changes (`refreshSeq`) or the day rolls — byte-identical to
+    /// the static overload. Call THIS from the per-tick live surfaces; tests use the pure 3-arg overload.
+    func cachedWidgetAnchor(now: Date = Date()) -> DailyMetric? {
+        widgetAnchorMemo.resolve(
+            days: days,
+            seq: refreshSeq,
+            logicalKey: Self.logicalDayKey(now),
+            localKey: Self.localDayKey(now)
+        ) { Repository.widgetAnchor(days: $0, logicalKey: $1, localKey: $2) }
+    }
+
     /// The recovery-INDEPENDENT overnight-vitals carry (the durable fix for the v8 Today rollover blank):
     /// the freshest strictly-prior day that recorded any of HRV / resting HR / respiratory, so the recovery
     /// VITALS keep reading through the post-04:00 window before tonight's sleep is scored, WITHOUT being

--- a/Strand/Data/WidgetAnchorMemo.swift
+++ b/Strand/Data/WidgetAnchorMemo.swift
@@ -1,0 +1,39 @@
+import Foundation
+import WhoopStore
+
+/// Memoizes `Repository.widgetAnchor` across the high-frequency live-HR path (#1051-shaped).
+///
+/// The Live Activity's `$heartRate` / `$connected` `onReceive` closures in `StrandiOSApp` resolve the
+/// widget anchor on EVERY live tick (~1-3 Hz). Each `widgetAnchor` call re-derives today's anchor row:
+/// two `DateFormatter` formats to build the day keys plus up to two full-history `days.last(where:)`
+/// scans that grow with years of stored rows — all on the MainActor, and BEFORE `LiveActivityController`'s
+/// own 2 s push throttle, so that throttle never saves it.
+///
+/// The anchor only changes when `days` changes (tracked by `Repository.refreshSeq`, bumped on every
+/// `days` assignment) or when the local/logical day rolls. Keying the memo on `(seq, logicalKey, localKey)`
+/// makes it exactly behavior-preserving: a streaming tick reuses the last row, and the anchor is recomputed
+/// precisely once per data refresh or day-roll. Same `refreshSeq`-keyed idiom as `todayHistoryWideLoadedSeq`.
+///
+/// Pure given the `compute` it is handed, so it is unit-tested without a live `Repository` — the twin of
+/// Android's `NotifyDayStateCache` (#1051). Held as a `Repository` stored property and only ever touched on
+/// the MainActor, so the plain `mutating` cache needs no locking.
+struct WidgetAnchorMemo {
+    private var cached: (seq: Int, logicalKey: String, localKey: String, row: DailyMetric?)?
+
+    /// Return the anchor for `(seq, logicalKey, localKey)`, recomputing via `compute` only when that key
+    /// differs from the last one. `compute` is the pure `Repository.widgetAnchor(days:logicalKey:localKey:)`.
+    mutating func resolve(
+        days: [DailyMetric],
+        seq: Int,
+        logicalKey: String,
+        localKey: String,
+        compute: ([DailyMetric], String, String) -> DailyMetric?
+    ) -> DailyMetric? {
+        if let cached, cached.seq == seq, cached.logicalKey == logicalKey, cached.localKey == localKey {
+            return cached.row
+        }
+        let row = compute(days, logicalKey, localKey)
+        cached = (seq, logicalKey, localKey, row)
+        return row
+    }
+}

--- a/StrandTests/WidgetAnchorMemoTests.swift
+++ b/StrandTests/WidgetAnchorMemoTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+import WhoopStore
+@testable import Strand
+
+/// Pins the #1051-shaped anchor memo: the Live Activity resolves the widget anchor on every ~1-3 Hz live-HR
+/// tick, so `WidgetAnchorMemo` must reuse the last row while its key is unchanged and recompute exactly when
+/// `days` changes (`refreshSeq`) or the day rolls. `compute` is injected here to count recomputes without a
+/// live `Repository` — the twin of Android's `NotifyDayStateCacheTest`.
+final class WidgetAnchorMemoTests: XCTestCase {
+
+    private func row(_ recovery: Double) -> DailyMetric {
+        DailyMetric(day: "2026-08-06", totalSleepMin: nil, efficiency: nil, deepMin: nil, remMin: nil,
+                    lightMin: nil, disturbances: nil, restingHr: nil, avgHrv: nil, recovery: recovery,
+                    strain: nil, exerciseCount: nil)
+    }
+
+    func testReusesAnchorWhileKeyUnchanged() {
+        var memo = WidgetAnchorMemo()
+        var computeCalls = 0
+        func resolve() -> DailyMetric? {
+            memo.resolve(days: [], seq: 5, logicalKey: "2026-08-06", localKey: "2026-08-06") { _, _, _ in
+                computeCalls += 1
+                return self.row(Double(computeCalls))
+            }
+        }
+        let first = resolve()
+        for _ in 0..<1_000 { XCTAssertEqual(resolve(), first) }
+        XCTAssertEqual(computeCalls, 1, "unchanged key must reuse the memoized anchor")
+        XCTAssertEqual(first?.recovery, 1.0)
+    }
+
+    func testRefreshSeqBumpRecomputes() {
+        var memo = WidgetAnchorMemo()
+        var computeCalls = 0
+        let compute: ([DailyMetric], String, String) -> DailyMetric? = { _, _, _ in
+            computeCalls += 1
+            return self.row(Double(computeCalls))
+        }
+        _ = memo.resolve(days: [], seq: 1, logicalKey: "d", localKey: "d", compute: compute)
+        // A new day-list instance bumps refreshSeq → the anchor may have moved, so recompute.
+        _ = memo.resolve(days: [], seq: 2, logicalKey: "d", localKey: "d", compute: compute)
+        XCTAssertEqual(computeCalls, 2, "a new refreshSeq (days changed) must recompute")
+    }
+
+    func testDayRolloverRecomputes() {
+        var memo = WidgetAnchorMemo()
+        var computeCalls = 0
+        let compute: ([DailyMetric], String, String) -> DailyMetric? = { _, _, _ in
+            computeCalls += 1
+            return self.row(Double(computeCalls))
+        }
+        _ = memo.resolve(days: [], seq: 1, logicalKey: "2026-08-06", localKey: "2026-08-06", compute: compute)
+        // Local midnight roll (localKey moves, logicalKey not yet).
+        _ = memo.resolve(days: [], seq: 1, logicalKey: "2026-08-06", localKey: "2026-08-07", compute: compute)
+        // Logical 04:00 roll (logicalKey moves too).
+        _ = memo.resolve(days: [], seq: 1, logicalKey: "2026-08-07", localKey: "2026-08-07", compute: compute)
+        XCTAssertEqual(computeCalls, 3, "each local/logical day-key change must recompute")
+    }
+}

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -96,7 +96,9 @@ struct StrandiOSApp: App {
                     // Home/Lock widget and the watch snapshot use, so this fourth surface can't drift to a
                     // different day at the rollover (it previously read `days.last(where: recovery != nil)`,
                     // which kept pointing at yesterday's scored row after Today had moved on).
-                    let day = Repository.widgetAnchor(days: model.repo.days)
+                    // Memoized: this closure fires on EVERY live-HR tick, so re-deriving the anchor here
+                    // scanned the whole history + hit the DateFormatter lock ~1-3x/sec (#1051-shaped).
+                    let day = model.repo.cachedWidgetAnchor()
                     liveActivity.update(
                         bpm: model.live.connected ? (model.bpm ?? model.live.heartRate) : nil,
                         recovery: day?.recovery.map { Int($0.rounded()) },
@@ -107,8 +109,9 @@ struct StrandiOSApp: App {
                 // End the Live Activity the moment the link drops, even if no further HR tick arrives.
                 .onReceive(model.live.$connected) { isConnected in
                     // #911: same shared anchor as the heartRate site above, so the Live Activity, the
-                    // widget, the watch and Today never disagree about which day they describe.
-                    let day = Repository.widgetAnchor(days: model.repo.days)
+                    // widget, the watch and Today never disagree about which day they describe. Memoized
+                    // (shares the heartRate site's cache; recomputes only on a data refresh or day-roll).
+                    let day = model.repo.cachedWidgetAnchor()
                     liveActivity.update(
                         bpm: isConnected ? (model.bpm ?? model.live.heartRate) : nil,
                         recovery: day?.recovery.map { Int($0.rounded()) },


### PR DESCRIPTION
Follows the #1051 pattern (Android FGS daily-projection memoization) — this is the iOS analogue on the Live Activity path, which was the missing half (the widget-snapshot republish is already throttled to 60 s; the Live Activity was not).

## The hot path
The Live Activity's `$heartRate` / `$connected` `onReceive` closures in `StrandiOSApp` resolved `Repository.widgetAnchor(days:)` on **every** live-HR emission (~1–3 Hz). Each call re-derives today's anchor: two `DateFormatter` formats to build the day keys + up to two full-history `days.last(where:)` scans that grow with years of stored rows — all on the MainActor, and **before** `LiveActivityController`'s own 2 s push throttle, so that throttle never saved it.

## The change
- `WidgetAnchorMemo` (Strand/Data) — the iOS twin of Android's `NotifyDayStateCache`. Memoizes the anchor on `(refreshSeq, logicalKey, localKey)`.
- `refreshSeq` already versions `repo.days` (bumped on every `days` assignment), and the day keys capture the local/logical roll — so a streaming tick reuses the last row and the anchor recomputes **exactly once** per data refresh or day-roll. Byte-identical to `widgetAnchor(days:)`; same `refreshSeq`-keyed idiom `TodayView` already uses (`todayHistoryWideLoadedSeq`).
- Both Live Activity call sites now use `repo.cachedWidgetAnchor()`. The already-throttled widget/watch snapshot paths are left untouched.

## Behavior
Pure over the cache key (the 3-arg `widgetAnchor`/`resolveToday` are `nonisolated` pure; only the wrapper's `now = Date()` is impure and folds into the key). No BLE, decoder, DB, or Live Activity cadence change — same anchor row, just not re-derived per tick.

## Tests / verification
- `WidgetAnchorMemoTests` (StrandTests): injected `compute` counts recomputes — 1,000 unchanged ticks reuse the row (1 compute), a `refreshSeq` bump recomputes, and each local/logical day-key change recomputes.
- App-target Swift (no default CI): **app-build green** — Strand (macOS) + NOOPiOS both BUILD SUCCEEDED.

Android-only equivalent for HR-zone coaching is in a separate PR.