### PR TITLE
perf(android): memoize the HR-zone set across live-HR ticks in coachZone

### DIFF
--- a/android/app/src/main/java/com/noop/analytics/HrZones.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrZones.kt
@@ -189,3 +189,22 @@ object HrZones {
         return maxOf(gaps[gaps.size / 2], 1.0)
     }
 }
+
+/**
+ * Single-entry memo for [HrZones.zones]. The zone set is a pure function of maxHR (the [HrZones.zoneEdges]
+ * are constant), and maxHR changes only when the user edits their profile — orders of magnitude less often
+ * than [com.noop.ui.AppViewModel.coachZone] runs, which is every ~1 Hz live-HR sample while zone coaching
+ * is active. Rebuilds the 5-zone set only when maxHR changes, so a streaming tick reuses it instead of
+ * allocating six objects a second. Not thread-safe by design: touched only from the single coachZone call
+ * on the live-state collector.
+ */
+internal class HrZoneSetCache {
+    private var maxHR = Double.NaN
+    private var set: HrZoneSet? = null
+
+    /** The `manual`-source zone set for [maxHR], rebuilt only when [maxHR] differs from the last call. */
+    fun zones(maxHR: Double): HrZoneSet {
+        set?.let { if (maxHR == this.maxHR) return it }
+        return HrZones.zones(maxHR = maxHR).also { this.maxHR = maxHR; set = it }
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -10,7 +10,6 @@ import com.noop.alarm.SmartAlarmStore
 import com.noop.alarm.WindDownScheduler
 import com.noop.alarm.WindDownStore
 import com.noop.analytics.Baselines
-import com.noop.analytics.HrZones
 import com.noop.analytics.IllnessSignalEngine
 import com.noop.analytics.IllnessWatch
 import com.noop.analytics.IntelligenceEngine
@@ -532,6 +531,8 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     val zoneCoachRecovery: StateFlow<Boolean> = _zoneCoachRecovery.asStateFlow()
     /** Last HR zone the coach saw (1..5, 0 = below Zone 1); -1 until the first sample. Mirrors macOS lastCoachZone. */
     private var lastZone = -1
+    /** Memoizes the HR-zone set so [coachZone] doesn't rebuild it on every live-HR sample (only on maxHR change). */
+    private val zoneSetCache = com.noop.analytics.HrZoneSetCache()
 
     // Double-tap action (parity since 4.2.8) — persisted in SharedPreferences (NoopPrefs). Default NONE,
     // manual-first. The Automations screen edits this; the live double-tap dispatch (init collector below)
@@ -2474,7 +2475,9 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         if (hr < 30) return
         val maxHR = profileStore.hrMax.toDouble()
         if (maxHR <= 0) return
-        val zone = HrZones.zones(maxHR = maxHR).zoneNumber(hr.toDouble())
+        // Memoized on maxHR: this runs every ~1 Hz live-HR sample while zone coaching is active, but the
+        // zone set only changes when the user edits their max HR — so don't rebuild it per tick.
+        val zone = zoneSetCache.zones(maxHR).zoneNumber(hr.toDouble())
         val previous = lastZone
         lastZone = zone
         val loops = zoneCoachBuzzLoops(previous, zone, _zoneCoachRecovery.value)

--- a/android/app/src/test/java/com/noop/analytics/HrZonesTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrZonesTest.kt
@@ -2,6 +2,8 @@ package com.noop.analytics
 
 import com.noop.data.HrSample
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -30,5 +32,28 @@ class HrZonesTest {
             tiz.total < 10.0,
         )
         assertEquals(tiz.total, tiz.secondsInZone(1), 1e-9) // all of it is zone 1
+    }
+
+    // --- HrZoneSetCache: coachZone runs ~1 Hz but the zone set only changes when maxHR does. ---
+
+    /** The same maxHR reuses the exact zone-set instance (identity, not just equality) across ticks. */
+    @Test fun hrZoneSetCache_reusesSetWhileMaxHrUnchanged() {
+        val cache = HrZoneSetCache()
+        val first = cache.zones(190.0)
+        repeat(1_000) { assertSame(first, cache.zones(190.0)) }
+        assertEquals(190.0, first.maxHR, 0.0)
+    }
+
+    /** A changed maxHR rebuilds. Single-entry by design (coachZone's maxHR is stable), so returning to a
+     *  previous value rebuilds again rather than restoring an older instance. */
+    @Test fun hrZoneSetCache_rebuildsWhenMaxHrChanges() {
+        val cache = HrZoneSetCache()
+        val a = cache.zones(190.0)
+        val b = cache.zones(180.0)
+        assertNotSame(a, b)
+        assertEquals(180.0, b.maxHR, 0.0)
+        val a2 = cache.zones(190.0)
+        assertNotSame(a, a2)               // single-entry: not restored, rebuilt
+        assertEquals(a, a2)                // but value-equal — same pure output for the same maxHR
     }
 }


### PR DESCRIPTION
Small companion to the iOS Live-Activity anchor memo (#1091); both follow the #1051 pattern of not recomputing a stable projection on the high-frequency live-HR path.

## The hot path
`AppViewModel.coachZone` runs on **every** ~1 Hz live-HR sample while zone coaching is active (bonded + worn + opt-in). It rebuilt the 5-zone `HrZoneSet` from scratch each time — ~6 object allocations/sec — even though the set is a pure function of `maxHR`, which only changes when the user edits their profile (orders of magnitude less often).

## The change
- `HrZoneSetCache` (in `HrZones.kt`) — a single-entry memo keyed on `maxHR`; rebuilds only when `maxHR` differs from the last call.
- `coachZone` uses it instead of `HrZones.zones(maxHR)` directly.

## Behavior
Behavior-preserving — same zone number for the same inputs (`ZoneCoachTest` unchanged). Zero cost when the opt-in feature is off (the existing `bonded/worn/_zoneCoaching` gate short-circuits first). Single-entry by design because `coachZone`'s `maxHR` is stable within a session.

## Tests / verification
- `HrZonesTest`: same `maxHR` reuses the exact instance (identity) across 1,000 calls; a changed `maxHR` rebuilds.
- Local: `compileFullDebugKotlin` + `HrZonesTest` + `ZoneCoachTest` pass (Android-only; `android.yml` disabled → compiled locally).