### PR TITLE
diag(sleep): one-line detection summary to make fragmentation legible

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -977,11 +977,23 @@ public enum SleepStager {
         // `traceSink?(...)` calls are the only addition and never alter `sessions`. `runIndex` counts
         // only sleep-stage runs so the trace numbers match the candidate ordinal.
         var runIndex = -1
+        // #737 follow-up: counters for the one-line detection summary emitted before `return` (below).
+        // Trace-only — never read back into `sessions`, so the untraced path stays byte-identical. They
+        // make the "slept 8h, app shows 1h" shape legible at a glance: a big detectedSpan with most runs
+        // dropped by the 60-min gate is the fragmentation signature.
+        var sleepRunsSeen = 0
+        var minSleepDrops = 0
+        var firstSleepStart = Int.max
+        var lastSleepEnd = 0
         for p in runs {
             if p.stage != "sleep" { continue }
             runIndex += 1
+            sleepRunsSeen += 1
+            firstSleepStart = min(firstSleepStart, p.start)
+            lastSleepEnd = max(lastSleepEnd, p.end)
             let spanMin = (p.end - p.start) / 60
             if (p.end - p.start) <= minSleepS {
+                minSleepDrops += 1
                 traceSink?(GateTrace.runLine(index: runIndex, startTs: p.start, endTs: p.end,
                     verdict: .dropped, gate: "minSleepMin",
                     detail: "spanMin=\(spanMin) minSleepMin=\(minSleepMin)"))
@@ -1065,6 +1077,17 @@ public enum SleepStager {
             chainPrevEnd = p.end
         }
         sessions.sort { $0.start < $1.start }
+        // #737 follow-up: one glanceable line summarising the whole detection pass. A large
+        // `detectedSpanMin` with most runs `droppedMinSleep` and a small `survivingSpanMin` is exactly
+        // the "slept ~8h, only ~1h confirmed" fragmentation the field reports describe — this makes it
+        // readable without hand-summing the per-run lines above. Trace-only.
+        if let traceSink {
+            let detectedSpanMin = lastSleepEnd > firstSleepStart ? (lastSleepEnd - firstSleepStart) / 60 : 0
+            let survivingSpanMin = sessions.reduce(0) { $0 + ($1.end - $1.start) } / 60
+            traceSink("sleep-detect summary: sleepRuns=\(sleepRunsSeen) droppedMinSleep=\(minSleepDrops) "
+                + "kept=\(sessions.count) detectedSpanMin=\(detectedSpanMin) survivingSpanMin=\(survivingSpanMin) "
+                + "sparse=\(sparse) grav=\(grav.count) hr=\(hrS.count)")
+        }
         return sessions
     }
 

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerTraceTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerTraceTests.swift
@@ -59,6 +59,28 @@ final class SleepStagerTraceTests: XCTestCase {
                       "expected a minSleepMin drop line, got: \(lines)")
     }
 
+    /// The one-line detection summary must be emitted and reflect the pass: a single 30-min run is seen
+    /// and dropped by minSleepMin, so `kept=0` and `droppedMinSleep=1`. This is the glanceable line that
+    /// makes the "slept 8h, app shows 1h" fragmentation readable in an export without hand-summing.
+    func testDetectionSummaryLineEmitted() {
+        let start = 1_749_513_600 + 2 * 3600
+        let dur = 30 * 60
+        var lines: [String] = []
+        let sessions = SleepStager.detectSleep(
+            hr: hr(start, dur, 50), gravity: still(start, dur),
+            traceSink: { lines.append($0) })
+        XCTAssertEqual(sessions.count, 0)
+        guard let summary = lines.first(where: { $0.hasPrefix("sleep-detect summary:") }) else {
+            return XCTFail("expected a sleep-detect summary line, got: \(lines)")
+        }
+        // Guaranteed-true facts (no exact span/count pins — those depend on run-boundary mechanics):
+        // nothing survived, so kept=0 and survivingSpanMin=0; a run WAS seen and dropped by minSleepMin.
+        XCTAssertTrue(summary.contains("kept=0"), summary)
+        XCTAssertTrue(summary.contains("survivingSpanMin=0"), summary)
+        XCTAssertFalse(summary.contains("droppedMinSleep=0"), "expected >=1 drop: \(summary)")
+        XCTAssertFalse(summary.contains("detectedSpanMin=0"), "expected a detected run: \(summary)")
+    }
+
     func testGateTraceKeepsRealNight() {
         // A 90-minute still low-HR overnight run clears every gate -> one KEPT line.
         let start = 1_749_513_600 + 2 * 3600

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -1059,11 +1059,23 @@ object SleepStager {
         // traceSink calls are the only addition and never alter `sessions`. `runIndex` counts only
         // sleep-stage runs so the trace numbers match the candidate ordinal.
         var runIndex = -1
+        // #737 follow-up: counters for the one-line detection summary emitted before `return` (below).
+        // Trace-only — never read back into `sessions`, so the untraced path stays byte-identical. They
+        // make the "slept 8h, app shows 1h" shape legible at a glance: a big detectedSpan with most runs
+        // dropped by the 60-min gate is the fragmentation signature. Mirrors Swift.
+        var sleepRunsSeen = 0
+        var minSleepDrops = 0
+        var firstSleepStart = Long.MAX_VALUE
+        var lastSleepEnd = 0L
         for (p in runs) {
             if (p.stage != "sleep") continue
             runIndex += 1
+            sleepRunsSeen += 1
+            firstSleepStart = minOf(firstSleepStart, p.start)
+            lastSleepEnd = maxOf(lastSleepEnd, p.end)
             val spanMin = ((p.end - p.start) / 60).toInt()
             if ((p.end - p.start) <= minSleepS) {
+                minSleepDrops += 1
                 traceSink?.invoke(SleepStagerTrace.runLine(runIndex, p.start, p.end,
                     SleepStagerTrace.Verdict.DROPPED, "minSleepMin", "spanMin=$spanMin minSleepMin=$minSleepMin"))
                 continue
@@ -1147,6 +1159,19 @@ object SleepStager {
             chainPrevEnd = p.end
         }
         sessions.sortBy { it.start }
+        // #737 follow-up: one glanceable line summarising the whole detection pass. A large
+        // detectedSpanMin with most runs droppedMinSleep and a small survivingSpanMin is exactly the
+        // "slept ~8h, only ~1h confirmed" fragmentation the field reports describe. Trace-only. Byte-
+        // identical string to Swift's summary line.
+        if (traceSink != null) {
+            val detectedSpanMin = if (lastSleepEnd > firstSleepStart) ((lastSleepEnd - firstSleepStart) / 60).toInt() else 0
+            val survivingSpanMin = (sessions.sumOf { it.end - it.start } / 60).toInt()
+            traceSink(
+                "sleep-detect summary: sleepRuns=$sleepRunsSeen droppedMinSleep=$minSleepDrops " +
+                    "kept=${sessions.size} detectedSpanMin=$detectedSpanMin survivingSpanMin=$survivingSpanMin " +
+                    "sparse=$sparse grav=${grav.size} hr=${hrS.size}"
+            )
+        }
         return sessions
     }
 

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerTraceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerTraceTest.kt
@@ -37,6 +37,25 @@ class SleepStagerTraceTest {
         assertTrue(lines.any { it.contains("DROPPED gate=minSleepMin") })
     }
 
+    /** The one-line detection summary must be emitted and reflect the pass: a single 30-min run is seen
+     *  and dropped by minSleepMin, so kept=0 and droppedMinSleep=1. Twin of Swift. */
+    @Test fun detectionSummaryLineEmitted() {
+        val start = refMidnight + 2 * 3600
+        val dur = 30 * 60
+        val lines = ArrayList<String>()
+        val sessions = SleepStager.detectSleep(
+            hr = hr(start, dur, 50), gravity = still(start, dur), traceSink = { lines.add(it) })
+        assertEquals(0, sessions.size)
+        val summary = lines.firstOrNull { it.startsWith("sleep-detect summary:") }.orEmpty()
+        assertTrue("expected a sleep-detect summary line, got: $lines", summary.startsWith("sleep-detect summary:"))
+        // Guaranteed-true facts (no exact span/count pins — those depend on run-boundary mechanics):
+        // nothing survived, so kept=0 and survivingSpanMin=0; a run WAS seen and dropped by minSleepMin.
+        assertTrue(summary, summary.contains("kept=0"))
+        assertTrue(summary, summary.contains("survivingSpanMin=0"))
+        assertFalse(summary, summary.contains("droppedMinSleep=0"))
+        assertFalse(summary, summary.contains("detectedSpanMin=0"))
+    }
+
     @Test fun realNightKept() {
         val start = refMidnight + 2 * 3600
         val dur = 90 * 60


### PR DESCRIPTION
Prompted by field reports of "slept ~8h, app shows ~1h" sleep. The #737/#319 diagnostics already log every run dropped by the 60-min gate and the sparse-bridge reasons, but reading them means hand-summing the per-run lines. This adds one glanceable summary at the end of the detection pass.

## Change
A `sleep-detect summary:` trace line (emitted only when a trace/export is requested), byte-identical on both platforms:

```
sleep-detect summary: sleepRuns=N droppedMinSleep=M kept=K detectedSpanMin=X survivingSpanMin=Y sparse=b grav=g hr=h
```

A large `detectedSpanMin` with most runs `droppedMinSleep` and a small `survivingSpanMin` is exactly the fragmentation signature behind the "8h → 1h" reports — now readable at a glance.

## Safety / parity
- **Trace-only**: the counters are never read back into `sessions`, so the untraced path is byte-identical — detection, staging, and totals are unchanged. No schema, no stored-value change, no BLE path.
- **Byte-parity**: the summary string and every value (`sleepRuns`/`droppedMinSleep`/`kept`/`detectedSpanMin`/`survivingSpanMin`/`sparse`/`grav`/`hr`) are computed identically in `SleepStager.swift` and `SleepStager.kt`; the counter placement mirrors exactly.
- Twin tests (`SleepStagerTraceTests` / `SleepStagerTraceTest`) assert the line + its guaranteed facts on both platforms.

## Verification
Android: `compileFullDebugKotlin` + `SleepStagerTraceTest` + the `SleepStager*` suite pass locally. Swift: covered by `swift-packages` CI (StrandAnalytics needs macOS/GRDB). No app-target Swift touched.

Follow-up (separate PR): surface this to users — a "sleep may be incomplete" caveat gated on a persisted sparse-coverage flag.