### PR TITLE
feat(sleep): "sleep may be incomplete" caveat for sparse-motion nights (#345)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -737,7 +737,11 @@ public enum AnalyticsEngine {
                 efficiency: s.efficiency,
                 restingHr: s.restingHR,
                 avgHrv: s.avgHRV,
-                stagesJSON: encodeStages(s.stages))
+                stagesJSON: encodeStages(s.stages),
+                // #345 follow-up: stamp the DAY's motion-coverage verdict on every session so the Sleep
+                // tab can caption a sparse (likely under-detected) night. A NOOP-computed night is always
+                // true/false here; imported nights never reach this path and keep nil (unknown).
+                stagingSparse: gravitySparse)
         }
 
         // ── Per-session per-epoch motion (H8) ─────────────────────────────────

--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -762,6 +762,19 @@ extension WhoopStore {
                 t.add(column: "steps", .integer)
             }
         }
+        // #345 follow-up: per-session flag recording that a night was staged on SPARSE motion coverage
+        // (`SleepStager.isGravitySparse`), so the Sleep tab can honestly caption "sleep may be incomplete"
+        // when a sparse night likely under-detected (the "slept 8h, shows 1h" reports). Additive, nullable
+        // (existing rows / imported nights read null = unknown, never flagged); not part of the primary
+        // key. The v13 (`userEdited`) / v14 (`startTsAdjusted`) form. Byte-parity with Room MIGRATION_27_28.
+        migrator.registerMigration("v34-sleep-staging-sparse") { db in
+            // `.integer` (not `.boolean`) so the affinity is INTEGER on BOTH platforms — Room maps Kotlin
+            // Boolean? to INTEGER too — and this column carries no `grdb-boolean-affinity` divergence.
+            // The value is a 0/1 flag; GRDB binds/reads the Swift `Bool?` as 0/1 over an INTEGER column.
+            try db.alter(table: "sleepSession") { t in
+                t.add(column: "stagingSparse", .integer)
+            }
+        }
         return migrator
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
@@ -28,14 +28,22 @@ public struct CachedSleepSession: Equatable, Codable {
     public let startTsAdjusted: Int?
     /// The onset to display / stage from: the user's correction if present, else the detected `startTs`.
     public var effectiveStartTs: Int { startTsAdjusted ?? startTs }
+    /// True when this night's on-device staging ran on SPARSE motion coverage (`SleepStager.isGravitySparse`
+    /// — the same signal that downgrades Rest confidence, #345). A sparse night is unreliable and can
+    /// UNDER-detect: the gravity-only spine fragments and the sub-60-min pieces are dropped, so a real ~8h
+    /// night can collapse to ~1h. The UI reads this to caption "sleep may be incomplete" honestly instead
+    /// of presenting the short total as fact. nil for imported nights and pre-migration rows (unknown, not
+    /// flagged). Set per session to the DAY's value; only NOOP-computed nights populate it. Byte-parity twin.
+    public let stagingSparse: Bool?
     public init(startTs: Int, endTs: Int, efficiency: Double?, restingHr: Int?,
                 avgHrv: Double?, stagesJSON: String?, userEdited: Bool = false,
-                startTsAdjusted: Int? = nil) {
+                startTsAdjusted: Int? = nil, stagingSparse: Bool? = nil) {
         self.startTs = startTs; self.endTs = endTs
         self.efficiency = efficiency; self.restingHr = restingHr
         self.avgHrv = avgHrv; self.stagesJSON = stagesJSON
         self.userEdited = userEdited
         self.startTsAdjusted = startTsAdjusted
+        self.stagingSparse = stagingSparse
     }
 }
 
@@ -128,8 +136,8 @@ extension WhoopStore {
                 try db.execute(sql: """
                     INSERT INTO sleepSession
                         (deviceId, startTs, endTs, efficiency, restingHr, avgHrv, stagesJSON,
-                         userEdited, startTsAdjusted)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                         userEdited, startTsAdjusted, stagingSparse)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT(deviceId, startTs) DO UPDATE SET
                         -- A user-corrected night keeps its hand-set bed/wake times and stage breakdown;
                         -- a recompute/import refresh (this path) updates only the derived vitals. The
@@ -141,9 +149,12 @@ extension WhoopStore {
                         avgHrv = excluded.avgHrv,
                         stagesJSON = CASE WHEN sleepSession.userEdited THEN sleepSession.stagesJSON ELSE excluded.stagesJSON END,
                         startTsAdjusted = CASE WHEN sleepSession.userEdited THEN sleepSession.startTsAdjusted ELSE excluded.startTsAdjusted END,
-                        userEdited = sleepSession.userEdited
+                        userEdited = sleepSession.userEdited,
+                        -- Derived from the day's motion coverage, so a recompute always refreshes it.
+                        stagingSparse = excluded.stagingSparse
                     """, arguments: [deviceId, s.startTs, s.endTs, s.efficiency,
-                                     s.restingHr, s.avgHrv, s.stagesJSON, s.userEdited, s.startTsAdjusted])
+                                     s.restingHr, s.avgHrv, s.stagesJSON, s.userEdited, s.startTsAdjusted,
+                                     s.stagingSparse])
                 n += db.changesCount
             }
             return n
@@ -444,7 +455,7 @@ extension WhoopStore {
         try syncRead { db in
             try Row.fetchAll(db, sql: """
                 SELECT startTs, endTs, efficiency, restingHr, avgHrv, stagesJSON, userEdited,
-                       startTsAdjusted FROM sleepSession
+                       startTsAdjusted, stagingSparse FROM sleepSession
                 WHERE deviceId = ? AND startTs >= ? AND startTs <= ?
                 ORDER BY startTs ASC LIMIT ?
                 """, arguments: [deviceId, from, to, limit])
@@ -452,7 +463,8 @@ extension WhoopStore {
                     CachedSleepSession(startTs: $0["startTs"], endTs: $0["endTs"],
                                        efficiency: $0["efficiency"], restingHr: $0["restingHr"],
                                        avgHrv: $0["avgHrv"], stagesJSON: $0["stagesJSON"],
-                                       userEdited: $0["userEdited"], startTsAdjusted: $0["startTsAdjusted"])
+                                       userEdited: $0["userEdited"], startTsAdjusted: $0["startTsAdjusted"],
+                                       stagingSparse: $0["stagingSparse"])
                 }
         }
     }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/MetricsCacheTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/MetricsCacheTests.swift
@@ -43,6 +43,32 @@ final class MetricsCacheTests: XCTestCase {
         XCTAssertNil(rows[0].stagesJSON)
     }
 
+    /// #345: the persisted sparse-coverage flag survives write→read, REFRESHES on a recompute (excluded
+    /// wins on conflict, since it's derived from the day's motion), and stays nil for an unknown/imported
+    /// night. This is what lets the Sleep tab caption a possibly-under-detected night.
+    func testSleepSessionStagingSparseRoundTrips() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertSleepSessions([
+            CachedSleepSession(startTs: 2000, endTs: 6000, efficiency: 0.8, restingHr: 55, avgHrv: 60,
+                               stagesJSON: nil, stagingSparse: true)], deviceId: "devB")
+        var rows = try await store.sleepSessions(deviceId: "devB", from: 0, to: 100_000, limit: 100)
+        XCTAssertEqual(rows.first?.stagingSparse, true)
+
+        // A recompute refreshes it (not preserved like userEdited fields).
+        try await store.upsertSleepSessions([
+            CachedSleepSession(startTs: 2000, endTs: 6000, efficiency: 0.8, restingHr: 55, avgHrv: 60,
+                               stagesJSON: nil, stagingSparse: false)], deviceId: "devB")
+        rows = try await store.sleepSessions(deviceId: "devB", from: 0, to: 100_000, limit: 100)
+        XCTAssertEqual(rows.first?.stagingSparse, false, "recompute refreshes stagingSparse")
+
+        // An unknown/imported night (default nil) is never flagged.
+        try await store.upsertSleepSessions([
+            CachedSleepSession(startTs: 9000, endTs: 12_000, efficiency: nil, restingHr: nil,
+                               avgHrv: nil, stagesJSON: nil)], deviceId: "devB")
+        rows = try await store.sleepSessions(deviceId: "devB", from: 0, to: 100_000, limit: 100)
+        XCTAssertNil(rows.first { $0.startTs == 9000 }?.stagingSparse)
+    }
+
     func testSleepSessionRangeFilter() async throws {
         let store = try await WhoopStore.inMemory()
         try await store.upsertSleepSessions([

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
@@ -1,6 +1,6 @@
 {
   "_readme": "SHARED Room<->GRDB SCHEMA ORACLE (#775). Two byte-identical copies: Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json and android/app/src/test/resources/schema_oracle.json. SchemaOracleTests.swift compares GRDB's PRAGMA table_info/index_list against it; SchemaOracleTest.kt compares Room's exported schema JSON against it. `columns` is the iOS/GRDB shape in GRDB column order (macOS is the reference implementation); every way Android differs is spelled out in an `android` / `iosAbsent` / `androidColumnOrder` override naming a key in `divergenceReasons`. Adding a column, reordering one, or changing a type/nullability on one platform only fails both suites until it is either fixed or written down here.",
-  "roomVersion": 27,
+  "roomVersion": 28,
   "grdbMigrations": [
     "v1",
     "v2",
@@ -34,7 +34,8 @@
     "v30-rr-ord",
     "v31-deep-capture-channels",
     "v32-rr-src-channel",
-    "v33-workout-steps"
+    "v33-workout-steps",
+    "v34-sleep-staging-sparse"
   ],
   "divergenceReasons": {
     "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android \u2014 the per-row upload flag belongs to an upload path that does not exist there \u2014 so it is dead width, not divergent data. Removing it needs a Room table rebuild.",
@@ -1501,6 +1502,12 @@
         {
           "name": "sleepStateJSON",
           "affinity": "TEXT",
+          "notNull": false,
+          "default": null
+        },
+        {
+          "name": "stagingSparse",
+          "affinity": "INTEGER",
           "notNull": false,
           "default": null
         }

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -173360,6 +173360,58 @@
           }
         }
       }
+    },
+    "Your strap recorded little movement overnight (common on WHOOP 4.0), so this night may be under-detected and the sleep total can read short. Make sure the strap fully synced; the numbers are kept as-is.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dein Band hat über Nacht wenig Bewegung aufgezeichnet (häufig bei WHOOP 4.0), daher wurde diese Nacht möglicherweise nicht vollständig erfasst und die Schlafdauer kann zu kurz erscheinen. Stelle sicher, dass das Band vollständig synchronisiert wurde; die Werte bleiben unverändert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu correa registró poco movimiento durante la noche (habitual en WHOOP 4.0), por lo que esta noche puede haberse detectado de forma incompleta y el total de sueño puede parecer corto. Asegúrate de que la correa se haya sincronizado por completo; los valores se mantienen tal cual."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ton bracelet a enregistré peu de mouvement cette nuit (fréquent sur WHOOP 4.0), donc cette nuit peut être sous-détectée et le total de sommeil peut sembler court. Assure-toi que le bracelet est entièrement synchronisé ; les valeurs sont conservées telles quelles."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il tuo cinturino ha registrato pochi movimenti durante la notte (comune su WHOOP 4.0), quindi questa notte potrebbe essere rilevata in modo incompleto e il totale del sonno può sembrare breve. Assicurati che il cinturino sia completamente sincronizzato; i valori restano invariati."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A tua pulseira registou pouco movimento durante a noite (comum na WHOOP 4.0), por isso esta noite pode ter sido subdetetada e o total de sono pode parecer curto. Certifica-te de que a pulseira sincronizou totalmente; os valores são mantidos como estão."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ремешок зафиксировал мало движений за ночь (часто у WHOOP 4.0), поэтому эта ночь могла быть распознана не полностью, а общее время сна может выглядеть коротким. Убедись, что ремешок полностью синхронизировался; значения остаются без изменений."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表带在夜间记录到的动作很少（WHOOP 4.0 常见），因此这一夜可能未被完整检测，睡眠总时长可能偏短。请确保表带已完全同步；数值保持不变。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "錶帶在夜間記錄到的動作很少（WHOOP 4.0 常見），因此這一夜可能未被完整偵測，睡眠總時長可能偏短。請確保錶帶已完全同步；數值維持不變。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -853,8 +853,8 @@ struct SleepView: View {
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(.horizontal, 2)
+        // `.combine` builds the a11y label from the badge + body Text (no separate localized string).
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Sleep may be incomplete. Your strap recorded little movement overnight, so this night may be under-detected and the total can read short. Make sure the strap fully synced.")
     }
 
     /// Honest caveat for an Oura-provided night: the stage split shown here is the ring's RAW on-device

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -724,6 +724,13 @@ struct SleepView: View {
             if stageStagingIsLowConfidence(night) {
                 stageLowConfidenceNote
             }
+            // #345 follow-up: when a night was staged on SPARSE motion coverage it can UNDER-detect — the
+            // gravity-only spine fragments and the sub-60-min pieces are dropped, so a real ~8h night can
+            // collapse to a fraction ("slept 8h, app shows 1h"). Say so honestly so the short total isn't
+            // read as fact. Distinct from the H9 note above (a plausible-duration night with an off split).
+            if stageStagingIsSparse(night) {
+                stageIncompleteNote
+            }
             // For an Oura-provided night, say plainly that this split is the ring's RAW on-device
             // classification — so the larger Awake / smaller Deep+REM here isn't misread as the polished
             // numbers the Oura app shows for the same night (the app post-processes the same stream).
@@ -782,6 +789,15 @@ struct SleepView: View {
             asleepMin: s.asleep, deepMin: s.deep, remMin: s.rem, efficiency: effPct / 100.0)
     }
 
+    /// True when this night was staged on SPARSE motion coverage — the persisted `stagingSparse` flag the
+    /// engine sets from `SleepStager.isGravitySparse` (#345). Such a night can UNDER-detect: the gravity-only
+    /// spine fragments and sub-60-min pieces are dropped, so a real night collapses to a fraction. Reads the
+    /// day's REAL stored blocks (each carries the day's value), never the synthetic merged `session`; a nil
+    /// flag (imported / pre-migration night) is never flagged. Mirror in Kotlin.
+    private func stageStagingIsSparse(_ night: Night) -> Bool {
+        night.sourceBlocks.contains { $0.stagingSparse == true }
+    }
+
     /// Pure H9 gate (unit-testable without a live view) — true when a night's staging is low-confidence:
     /// a high-efficiency night whose deep+REM share is below the restorative floor. Built on the engine's
     /// own `ScoreConfidence.rest(...)` so the UI flag and the persisted Rest confidence agree. `asleepMin`,
@@ -823,6 +839,22 @@ struct SleepView: View {
         .padding(.horizontal, 2)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Low confidence staging. This night scored high efficiency but very little deep or REM, more likely an estimate miss than a real restorative shortfall.")
+    }
+
+    /// The sparse-coverage caveat: a night staged on thin motion data can under-detect and collapse a real
+    /// night to a fraction ("slept 8h, shows 1h"). Honest + actionable — tells the user to make sure the
+    /// strap fully synced. Distinct from the H9 note (an off deep/REM split, not a short total). (#345)
+    private var stageIncompleteNote: some View {
+        HStack(alignment: .top, spacing: 8) {
+            SourceBadge("May be incomplete", tint: StrandPalette.statusWarning)
+            Text("Your strap recorded little movement overnight (common on WHOOP 4.0), so this night may be under-detected and the sleep total can read short. Make sure the strap fully synced; the numbers are kept as-is.")
+                .font(StrandFont.footnote)
+                .foregroundStyle(StrandPalette.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, 2)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Sleep may be incomplete. Your strap recorded little movement overnight, so this night may be under-detected and the total can read short. Make sure the strap fully synced.")
     }
 
     /// Honest caveat for an Oura-provided night: the stage split shown here is the ring's RAW on-device

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -670,6 +670,7 @@ object AnalyticsEngine {
             restConfidence = restConfidence,
             sessionMotionByStart = sessionMotionByStart,
             sessionSleepStateByStart = sessionSleepStateByStart,
+            gravitySparse = gravitySparse,
         )
     }
 

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsModels.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsModels.kt
@@ -289,4 +289,12 @@ data class DayResult(
      * hypnogram. Empty on a WHOOP 4.0. Mirrors Swift `DayResult.sessionSleepStateByStart`. (#175)
      */
     val sessionSleepStateByStart: Map<Long, List<Int>> = emptyMap(),
+    /**
+     * Whether this day's on-device sleep staging ran on SPARSE motion coverage
+     * ([SleepStager.isGravitySparse], #345) — the same signal that downgrades Rest confidence. The caller
+     * stamps it onto each persisted `SleepSession.stagingSparse` so the Sleep tab can caption a possibly
+     * under-detected night ("slept 8h, shows 1h"). Transient (not persisted on DayResult itself). Mirrors
+     * the value Swift's `analyzeDay` writes directly onto its `CachedSleepSession.stagingSparse`.
+     */
+    val gravitySparse: Boolean = false,
 )

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -923,6 +923,9 @@ object IntelligenceEngine {
                         restingHr = s.restingHR,
                         avgHrv = s.avgHRV,
                         stagesJSON = AnalyticsEngine.encodeStages(s.stages),
+                        // #345 follow-up: stamp the day's motion-coverage verdict so the Sleep tab can
+                        // caption a sparse (likely under-detected) night. Twin of Swift analyzeDay.
+                        stagingSparse = res.gravitySparse,
                     ),
                 )
             }

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -357,6 +357,13 @@ data class SleepSession(
     // through the targeted DAO methods (not the @Upsert path, which never names them and so preserves them).
     val motionJSON: String? = null,
     val sleepStateJSON: String? = null,
+    // v34 (Swift WhoopStore v34-sleep-staging-sparse parity, MIGRATION_27_28). True when this night was
+    // staged on SPARSE motion coverage (SleepStager.isGravitySparse, #345) — a night that can UNDER-detect
+    // and read short ("slept 8h, shows 1h"), so the Sleep tab captions it honestly. Nullable INTEGER (Kotlin
+    // Boolean? -> INTEGER affinity, matching GRDB's `.integer` twin — no boolean-affinity divergence); old
+    // rows / imported nights read null = unknown. Declared LAST so the ALTER-appended column matches this
+    // fresh-schema order.
+    val stagingSparse: Boolean? = null,
 ) {
     /** The bed (onset) time to DISPLAY / sort / re-stage by: the user's hand-set onset when edited,
      *  else the immutable detected [startTs]. Mirrors Swift `CachedSleepSession.effectiveStartTs`. */

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -52,7 +52,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         RawImuSampleEntity::class,
         V18AuxSampleEntity::class,
     ],
-    version = 27,
+    version = 28,
     // #775: ON so Room's KSP processor writes the generated schema (every table's exact `CREATE TABLE`,
     // columns in declaration order with affinity/NOT NULL/default, PK and indices) as JSON. That export
     // is what lets a plain JVM test — no device, no Robolectric — read Android's REAL schema and compare
@@ -767,6 +767,24 @@ abstract class WhoopDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * v27 -> v28: ADDITIVE, adds `sleepSession.stagingSparse` (nullable INTEGER) so the Sleep tab can
+         * caption a night staged on SPARSE motion coverage as possibly incomplete (#345 — the "slept 8h,
+         * shows 1h" reports). Boolean? -> INTEGER affinity, matching Swift GRDB's `.integer` twin (no
+         * boolean-affinity divergence). Additive, nullable, not part of the PK; the MIGRATION_3_4 form. The
+         * ALTER appends the column LAST, matching the entity field order (declared after `sleepStateJSON`).
+         * Byte-parity with Swift WhoopStore `v34-sleep-staging-sparse`.
+         */
+        internal val SLEEP_STAGING_SPARSE_MIGRATION_SQL: List<String> = listOf(
+            "ALTER TABLE `sleepSession` ADD COLUMN `stagingSparse` INTEGER",
+        )
+
+        internal val MIGRATION_27_28 = object : Migration(27, 28) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                for (stmt in SLEEP_STAGING_SPARSE_MIGRATION_SQL) db.execSQL(stmt)
+            }
+        }
+
         private fun build(appContext: Context): WhoopDatabase =
             Room.databaseBuilder(appContext, WhoopDatabase::class.java, DB_NAME)
                 // #1014: replace ONLY the corruption handling of the default open-helper. The
@@ -784,7 +802,7 @@ abstract class WhoopDatabase : RoomDatabase() {
                     MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18,
                     MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
                     MIGRATION_22_23, MIGRATION_23_24, MIGRATION_24_25, MIGRATION_25_26,
-                    MIGRATION_26_27,
+                    MIGRATION_26_27, MIGRATION_27_28,
                 )
                 // #1037: a FRESH install builds the schema straight at the current version and runs NO
                 // migrations, so the MIGRATION_7_8 "my-whoop" registry seed never fires and the WHOOP,

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -1069,6 +1069,12 @@ private fun Hero(
             // so the larger Awake / smaller Deep+REM here isn't misread as the polished numbers the Oura app
             // shows for the same night (the app post-processes the same stream). Mirrors iOS ouraRawStagesNote.
             if (activeIsOura) OuraRawStagesNote()
+            // #345 follow-up: a night staged on SPARSE motion coverage can UNDER-detect and read short
+            // ("slept 8h, shows 1h"). Say so honestly, gated on the persisted stagingSparse flag (the day's
+            // SleepStager.isGravitySparse verdict). `session` is the REAL main block (selectNight's edit
+            // anchor), so it carries the flag; nil (imported / pre-migration) is never flagged. Mirrors iOS
+            // SleepView.stageIncompleteNote.
+            if (session?.stagingSparse == true) SleepIncompleteNote()
         }
         // Naps card (#508/#518): the day's blocks OTHER than the main night, each editable / deletable
         // with the SAME mechanism main sleep uses, plus a Main / Nap(s) / Total split so what drives the
@@ -1162,6 +1168,24 @@ private fun OuraRawStagesNote() {
             "This split is the ring's raw on-device classification read over Bluetooth, not the adjusted " +
                 "stages the Oura app shows. Expect more Awake and less Deep/REM here than in the Oura app " +
                 "for the same night.",
+            style = NoopType.caption,
+            color = Palette.textTertiary,
+        )
+    }
+}
+
+/** The sparse-coverage caveat (#345): a night staged on thin motion data can under-detect and read short
+ *  ("slept 8h, shows 1h"). Honest + actionable. Mirrors iOS SleepView.stageIncompleteNote. */
+@Composable
+private fun SleepIncompleteNote() {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.Top,
+        modifier = Modifier.padding(horizontal = 2.dp),
+    ) {
+        SourceBadge(text = uiString(R.string.l10n_sleep_screen_may_be_incomplete_7230dc27), tint = Palette.statusWarning)
+        Text(
+            uiString(R.string.l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4),
             style = NoopType.caption,
             color = Palette.textTertiary,
         )

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1896,4 +1896,6 @@
         <item quantity="other">Deine Basislinie wird aufgebaut. Noch etwa %1$d Nächte, bis deine Werte persönlich sind.</item>
     </plurals>
     <string name="l10n_app_changelog_widgets_stop_inventing_numbers_naps_count_4f7491bb">Widgets erfinden keine Zahlen mehr, Nickerchen zählen für die Schlafschuld, und die Android-Statusanzeigen sprechen deine Sprache</string>
+    <string name="l10n_sleep_screen_may_be_incomplete_7230dc27">Möglicherweise unvollständig</string>
+    <string name="l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4">Über Nacht wurde wenig Bewegung aufgezeichnet, daher wurde diese Nacht möglicherweise nicht vollständig erfasst und die Schlafdauer kann zu kurz erscheinen. Stelle sicher, dass das Band vollständig synchronisiert wurde.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1881,4 +1881,6 @@
         <item quantity="other">Construyendo tu línea base. Faltan unas %1$d noches para que tus puntuaciones sean personales.</item>
     </plurals>
     <string name="l10n_app_changelog_widgets_stop_inventing_numbers_naps_count_4f7491bb">Los widgets dejan de inventar números, las siestas cuentan para la deuda de sueño y los indicadores de Android hablan tu idioma</string>
+    <string name="l10n_sleep_screen_may_be_incomplete_7230dc27">Puede estar incompleto</string>
+    <string name="l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4">Se registró poco movimiento durante la noche, por lo que esta noche puede haberse detectado de forma incompleta y el total de sueño puede parecer corto. Asegúrate de que la correa se haya sincronizado por completo.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1881,4 +1881,6 @@
         <item quantity="other">Construction de votre référence. Encore environ %1$d nuits avant que vos scores soient personnels.</item>
     </plurals>
     <string name="l10n_app_changelog_widgets_stop_inventing_numbers_naps_count_4f7491bb">Les widgets n\'inventent plus de chiffres, les siestes comptent pour la dette de sommeil, et les indicateurs Android parlent votre langue</string>
+    <string name="l10n_sleep_screen_may_be_incomplete_7230dc27">Peut être incomplet</string>
+    <string name="l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4">Peu de mouvement a été enregistré cette nuit ; cette nuit peut donc être sous-détectée et le total de sommeil peut sembler court. Assurez-vous que le bracelet est entièrement synchronisé.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1875,4 +1875,6 @@
         <item quantity="other">A construir a tua linha de base. Cerca de %1$d mais noites até que a tua pontuação seja pessoal.</item>
     </plurals>
     <string name="l10n_app_changelog_widgets_stop_inventing_numbers_naps_count_4f7491bb">Os widgets deixam de inventar números, as sestas contam para a dívida de sono, e os indicadores Android falam a tua língua</string>
+    <string name="l10n_sleep_screen_may_be_incomplete_7230dc27">Pode estar incompleto</string>
+    <string name="l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4">Foi registado pouco movimento durante a noite, por isso esta noite pode ter sido subdetetada e o total de sono pode parecer curto. Certifique-se de que a pulseira sincronizou totalmente.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1809,4 +1809,6 @@
         <item quantity="other">正在建立你的基线。大约还需 %1$d 晚，你的分数就会个性化。</item>
     </plurals>
     <string name="l10n_app_changelog_widgets_stop_inventing_numbers_naps_count_4f7491bb">小组件不再编造数字、小睡计入睡眠债，Android 状态提示也终于会说你的语言</string>
+    <string name="l10n_sleep_screen_may_be_incomplete_7230dc27">可能不完整</string>
+    <string name="l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4">夜间记录到的动作很少，因此这一夜可能未被完整检测，睡眠总时长可能偏短。请确保表带已完全同步。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1907,4 +1907,6 @@
         <item quantity="other">Building your baseline. About %1$d more nights until your scores are personal.</item>
     </plurals>
     <string name="l10n_app_changelog_widgets_stop_inventing_numbers_naps_count_4f7491bb">Widgets stop inventing numbers, naps count toward sleep debt, and the Android status chips speak your language</string>
+    <string name="l10n_sleep_screen_may_be_incomplete_7230dc27">May be incomplete</string>
+    <string name="l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4">Little motion was recorded overnight, so this night may be under-detected and the sleep total can read short. Make sure the strap fully synced.</string>
 </resources>

--- a/android/app/src/test/resources/schema_oracle.json
+++ b/android/app/src/test/resources/schema_oracle.json
@@ -1,6 +1,6 @@
 {
   "_readme": "SHARED Room<->GRDB SCHEMA ORACLE (#775). Two byte-identical copies: Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json and android/app/src/test/resources/schema_oracle.json. SchemaOracleTests.swift compares GRDB's PRAGMA table_info/index_list against it; SchemaOracleTest.kt compares Room's exported schema JSON against it. `columns` is the iOS/GRDB shape in GRDB column order (macOS is the reference implementation); every way Android differs is spelled out in an `android` / `iosAbsent` / `androidColumnOrder` override naming a key in `divergenceReasons`. Adding a column, reordering one, or changing a type/nullability on one platform only fails both suites until it is either fixed or written down here.",
-  "roomVersion": 27,
+  "roomVersion": 28,
   "grdbMigrations": [
     "v1",
     "v2",
@@ -34,7 +34,8 @@
     "v30-rr-ord",
     "v31-deep-capture-channels",
     "v32-rr-src-channel",
-    "v33-workout-steps"
+    "v33-workout-steps",
+    "v34-sleep-staging-sparse"
   ],
   "divergenceReasons": {
     "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android \u2014 the per-row upload flag belongs to an upload path that does not exist there \u2014 so it is dead width, not divergent data. Removing it needs a Room table rebuild.",
@@ -1501,6 +1502,12 @@
         {
           "name": "sleepStateJSON",
           "affinity": "TEXT",
+          "notNull": false,
+          "default": null
+        },
+        {
+          "name": "stagingSparse",
+          "affinity": "INTEGER",
           "notNull": false,
           "default": null
         }


### PR DESCRIPTION
Follow-up to #1094. Prompted by field reports of "slept ~8h, app shows ~1h" sleep. On a night staged from SPARSE motion coverage (WHOOP 4.0, or an interrupted sync), the gravity-only spine fragments and the sub-60-min pieces are dropped, so a real night can collapse to a fraction — and today that short total is shown as fact. This surfaces it honestly.

## The change
- **Persist the verdict**: `sleepSession.stagingSparse` — the day's `SleepStager.isGravitySparse` result, stamped on every session by `analyzeDay`. New nullable column: GRDB **v34** / Room **v28** (INTEGER affinity both — `Bool?`/`Boolean?` — so no boolean-affinity divergence). Schema oracle updated (both copies, byte-identical). Additive, no detection/staging/total math change.
- **Surface it**: a "May be incomplete" caveat under the stage breakdown on **both** platforms (`SleepView.stageIncompleteNote` / `SleepScreen.SleepIncompleteNote`), gated on the flag, explaining the possible under-detection and telling the user to make sure the strap fully synced. `nil` (imported / pre-migration nights) is never flagged.

## Safety / parity
- No detection or totals change — a pure additive flag + a caption.
- **Byte-parity of the stored value**: Swift stamps `gravitySparse`; Android stamps `res.gravitySparse`; both are `isGravitySparse(gravity, hr)` for the day (existing twin).
- Predicate reads the **real** persisted block (iOS `sourceBlocks`; Android `session`, `selectNight`'s edit anchor), not a synthetic merge, so the flag is actually present.

## Tests / verification
- WhoopStore round-trip: `stagingSparse` survives write→read, refreshes on recompute, `nil` for imported.
- Android `compileFullDebugKotlin` + `SchemaOracleTest` (Room v28) + `SleepStager*` + `i18n_audit` — all green locally.
- Swift store/oracle/analytics via `swift-packages` CI; app-target (`SleepView`) via app-build (running).

## Notes
- i18n: Android strings translated across **de/es/fr/pt-PT/zh** (machine drafts — worth a native pass). iOS `Localizable.xcstrings` translation-seeding (`seed-string-catalog.py` on macOS) is a small follow-up; the i18n gate is green as-is.