### PR TITLE
i18n(sleep): localize the iOS "May be incomplete" badge

### DIFF
--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -173412,6 +173412,58 @@
           }
         }
       }
+    },
+    "May be incomplete": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Möglicherweise unvollständig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puede estar incompleto"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Peut être incomplet"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Potrebbe essere incompleto"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pode estar incompleto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Возможно, неполно"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可能不完整"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可能不完整"
+          }
+        }
+      }
     }
   },
   "version": "1.0"


### PR DESCRIPTION
Small follow-up to #1096. The Sleep-tab sparse-coverage caveat **badge** ("May be incomplete") rendered in English on non-English iOS locales, while the Android badge was translated — a parity gap.

`SourceBadge.init` takes a `LocalizedStringKey`, so the badge string was already localizable and just lacked a catalog entry. This adds `"May be incomplete"` to `Localizable.xcstrings` with **de/es/fr/it/pt-PT/ru/zh-Hans/zh-Hant**.

Data-only (no Swift change, no compile risk). i18n audit passes locally. Translations are machine drafts — native review tracked in #1097.