### PR TITLE
Raw history archive: decide on the layout version, and stop empty records evicting real ones

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
@@ -65,10 +65,11 @@ public func isPlausibleHistoricalUnix(_ ts: Int, wallNow: Int,
     return ts >= oldest - SESSION_RANGE_MARGIN && ts <= newest + SESSION_RANGE_MARGIN
 }
 
-/// The HISTORICAL_DATA record frames in `rawFrames` that FAIL decode — a genuine CRC failure, or an
-/// unmapped firmware layout whose envelope parsed but yielded no usable biometrics. These are the
-/// records the strap is about to free once we ack the trim, so without an archive they are lost
-/// forever while the UI reports a clean sync (#77 / #91).
+/// The HISTORICAL_DATA record frames in `rawFrames` that NOOP cannot turn into rows — a genuine CRC
+/// failure, an unmapped firmware layout (5/MG: any `hist_version` outside
+/// `mappedWhoop5HistoricalVersions`), or a mapped layout whose envelope parsed but yielded no usable
+/// biometrics. These are the records the strap is about to free once we ack the trim, so without an
+/// archive they are lost forever while the UI reports a clean sync (#77 / #91).
 ///
 /// Console (type-50, `frame[typeIndex] == 0x32`) frames are strap-side debug-log text that decode to
 /// zero rows BY DESIGN and are never returned. 5/MG v26 (raw PPG block, hist_version 26) is also
@@ -91,6 +92,20 @@ public func rejectedHistoricalRecords(_ rawFrames: [[UInt8]], family: DeviceFami
         // different type byte, so they never pass this gate — they are excluded by construction.
         guard f.count > typeIndex, Int(f[typeIndex]) == 47 else { return false }
         if family == .whoop5, f.count > versionIndex, Int(f[versionIndex]) == 26 { return false }  // v26 PPG: has its own durable stream (ppgWaveform), not this reject archive
+        // UNMAPPED LAYOUT (5/MG) — archive UNCONDITIONALLY, whatever it decoded.
+        //
+        // The decode-outcome test below is the wrong question for a layout NOOP has no field map for.
+        // `decodeWhoop5Historical`'s unmapped branch reads no offsets, so anything that DOES appear in
+        // `parsed` for such a record came from the envelope, not from a mapped biometric — and a record
+        // that happened to yield a plausible `unix` plus a `gravity_x`/`heart_rate` used to pass the
+        // screen and be kept NOWHERE, its bytes freed by the very next trim ack. That is exactly the
+        // shape a novel record type (a new firmware's rollup, an on-demand capture) can take.
+        //
+        // This cannot flood the archive with records we already understand: v18/v20/v21/v26 are in
+        // `mappedWhoop5HistoricalVersions` and never reach here. Retention for the records that DO
+        // (`RawHistoryArchive.evictLines`) evicts entirely-zero-payload frames first, so a firmware that
+        // banks empty placeholder records at 1 Hz cannot push out the one informative frame either.
+        if family == .whoop5, isUnmappedWhoop5HistoricalRecord(f) { return true }
         let p = parseFrame(f, family: family)
         // Envelope/CRC reject: parse failed outright or the CRC32 trailer mismatched.
         if !p.ok || p.crcOK == false { return true }

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
@@ -331,6 +331,26 @@ private func parseFrameWhoop5(_ frame: [UInt8], collectFields: Bool) -> ParsedFr
                        fields: fb.fields, parsed: fb.parsed)
 }
 
+/// The WHOOP 5/MG type-47 `hist_version` values `decodeWhoop5Historical` has a REAL field map for.
+/// Every other version falls through to the "unmapped layout" branch, which decodes nothing and only
+/// describes the payload as an opaque region.
+///
+/// This is the single source of truth for "does NOOP understand this layout": the dispatch `switch` in
+/// `decodeWhoop5Historical` reads nothing else, and `rejectedHistoricalRecords` uses it to decide which
+/// records must be archived raw. Keeping one set means the two can never disagree — the failure mode
+/// this replaced was a record from an unmapped layout that happened to decode a plausible `unix` and
+/// `gravity_x`/`heart_rate` slipping past the archive filter, so its bytes were kept nowhere at all.
+/// `Whoop5HistoricalLayoutMapTests` pins the set against the decoder's actual behaviour.
+public let mappedWhoop5HistoricalVersions: Set<Int> = [18, 20, 21, 26]
+
+/// True when `frame` is a WHOOP 5/MG type-47 record whose layout version has NO field map — the
+/// records that reach the unmapped branch of `decodeWhoop5Historical` and are therefore never
+/// re-derivable from anything NOOP stores. Non-type-47 and too-short frames are false.
+public func isUnmappedWhoop5HistoricalRecord(_ frame: [UInt8]) -> Bool {
+    guard frame.count > 9, Int(frame[8]) == 47 else { return false }
+    return !mappedWhoop5HistoricalVersions.contains(Int(frame[9]))
+}
+
 /// Decode a WHOOP 5.0 HISTORICAL_DATA (type 47) DSP biometric record.
 ///
 /// The layout version is carried in the byte at frame[9] — the inner record's seq slot, which the
@@ -351,16 +371,21 @@ private func decodeWhoop5Historical(_ frame: [UInt8], fb: FieldBuilder, payloadE
     let version = frame.count > 9 ? Int(frame[9]) : -1
     fb.parsed["hist_version"] = .int(version)
     fb.add(9, 1, "hist_version", "meta", value: .int(version))
-    if version == 26 {
+    // One dispatch, one list: every `case` here must appear in `mappedWhoop5HistoricalVersions` and
+    // vice versa, because that set is what decides whether a record gets archived raw. A `switch`
+    // rather than the old if-chain so the mapped versions are readable in one place.
+    switch version {
+    case 26:
         decodeWhoop5HistoricalV26(frame, fb: fb)
         return
-    }
-    if version == 20 || version == 21 {
+    case 20, 21:
         decodeWhoop5HistoricalV2021(frame, fb: fb, version: version, payloadEnd: payloadEnd)
         return
-    }
-    guard version == 18 else {
-        // Unknown historical layout — describe it faithfully without inventing offsets.
+    case 18:
+        break   // falls through to the v18 field decode below
+    default:
+        // Unknown historical layout — describe it faithfully without inventing offsets. The bytes are
+        // NOT lost: `rejectedHistoricalRecords` archives every record that lands here (#77 / #91).
         if let payloadEnd = payloadEnd, 11 < payloadEnd, payloadEnd <= frame.count {
             fb.region(11, payloadEnd, "HISTORICAL_DATA v\(version) (unmapped layout)", "unknown")
         }

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/UnmappedHistoricalLayoutTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/UnmappedHistoricalLayoutTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import WhoopProtocol
+
+/// The archive decision for a WHOOP 5/MG type-47 record must be made on its LAYOUT VERSION, not on
+/// what the record happened to decode to.
+///
+/// `rejectedHistoricalRecords` used to ask only "did this decode to a `unix` plus a
+/// `heart_rate`/`gravity_x`?". That screen is the wrong question for a layout NOOP has no field map
+/// for: a record from an unmapped version that answered yes was kept NOWHERE — not as rows (nothing
+/// mapped it) and not as bytes (it passed the archive filter) — and the strap freed it on the very next
+/// trim ack. A record type NOOP has not mapped yet — banked to flash by a newer firmware and pulled
+/// back in a later offload — is exactly the shape that can look well-formed enough to pass.
+///
+/// The screen survived in practice only because of an accident: the unmapped branch of
+/// `decodeWhoop5Historical` reads no offsets, so today nothing but `hist_version` ever lands in
+/// `parsed` for such a record (`testUnmappedLayoutsDecodeNothingButTheVersionByte` pins that this is
+/// true right now). One added static schema field for type 47, or one partially-mapped new version,
+/// would silently reopen the hole. These tests pin the version-based decision instead, so the archive
+/// no longer depends on that accident holding.
+final class UnmappedHistoricalLayoutTests: XCTestCase {
+
+    private func bytes(_ s: String) -> [UInt8] {
+        var out = [UInt8](); out.reserveCapacity(s.count / 2); var i = s.startIndex
+        while i < s.endIndex { let j = s.index(i, offsetBy: 2)
+            out.append(UInt8(s[i..<j], radix: 16)!); i = j }
+        return out
+    }
+
+    // A real WHOOP 5/MG type-47 v18 record (from Whoop5HistoricalTests): decodes a real unix, a
+    // plausible heart rate and a ~1 g gravity vector — i.e. it PASSES the old decode-outcome screen.
+    private let whoop5V18Hex =
+        "aa01740001003fb12f1280733d8401b69f266a66460066025a0265020000000000007b0a8d656463ff0012163cf6a439bf2924fd3ed763fe3e3200aa000000000000000000f7000901f10b0007010c020c00000000000000000000000000000000000000000000000100656f1e1e0000009d61a7c00000003e862817"
+
+    /// Re-stamp the WHOOP 5 CRC32 trailer after mutating a payload byte, so the frame stays CRC-VALID.
+    /// Load-bearing for every test here: a CRC failure is archived on its own, which would make the
+    /// version-based path untestable.
+    private func whoop5FrameWithVersion(_ version: UInt8) -> [UInt8] {
+        var f = bytes(whoop5V18Hex)
+        f[9] = version
+        let payloadEnd = f.count - 4
+        let c = crc32(f, 8, payloadEnd)
+        f[payloadEnd] = UInt8(c & 0xFF)
+        f[payloadEnd + 1] = UInt8((c >> 8) & 0xFF)
+        f[payloadEnd + 2] = UInt8((c >> 16) & 0xFF)
+        f[payloadEnd + 3] = UInt8((c >> 24) & 0xFF)
+        return f
+    }
+
+    // MARK: - defect: an unmapped layout that decodes real biometrics must still be archived
+
+    /// The headline case. The frame's BYTES are a real v18 record — at the v18 offsets they carry a
+    /// valid unix, a plausible heart rate and a ~1 g gravity vector, the exact combination that made
+    /// the old screen say "decodable, nothing lost". Only the layout-version byte differs. Whatever
+    /// such a record decodes to, its bytes must reach the archive.
+    func testUnmappedLayoutIsArchivedEvenThoughItsBytesDecodeCleanlyAsV18() {
+        // Precondition: read as its true version, this record decodes everything the old screen wanted.
+        let asV18 = parseFrame(bytes(whoop5V18Hex), family: .whoop5)
+        XCTAssertEqual(asV18.crcOK, true)
+        XCTAssertNotNil(asV18.parsed["unix"], "precondition: these bytes DO decode a unix")
+        XCTAssertNotNil(asV18.parsed["heart_rate"], "precondition: these bytes DO decode a heart rate")
+        XCTAssertNotNil(asV18.parsed["gravity_x"], "precondition: these bytes DO decode a gravity vector")
+
+        let unmapped = whoop5FrameWithVersion(22)
+        XCTAssertEqual(parseFrame(unmapped, family: .whoop5).crcOK, true,
+                       "precondition: the record is CRC-VALID, so only the layout decision can archive it")
+        XCTAssertTrue(isUnmappedWhoop5HistoricalRecord(unmapped))
+        XCTAssertEqual(rejectedHistoricalRecords([unmapped], family: .whoop5), [unmapped],
+                       "a record from a layout NOOP cannot map must be archived whatever it decoded")
+    }
+
+    /// Every version outside `mappedWhoop5HistoricalVersions` is archived — no gaps, no lucky values.
+    func testEveryUnmappedVersionIsArchived() {
+        for v in 0...255 where !mappedWhoop5HistoricalVersions.contains(v) {
+            let f = whoop5FrameWithVersion(UInt8(v))
+            XCTAssertEqual(rejectedHistoricalRecords([f], family: .whoop5), [f],
+                           "hist_version \(v) has no field map, so its bytes must be archived")
+        }
+    }
+
+    // MARK: - lockstep: the version set and the decoder's dispatch cannot drift apart
+
+    /// `mappedWhoop5HistoricalVersions` is the single source of truth for the archive decision, so it
+    /// must not claim more (or fewer) versions than `decodeWhoop5Historical` actually maps. Proved from
+    /// the decoder's own behaviour: for EVERY version outside the set, the decode yields nothing but
+    /// `hist_version` — i.e. the dispatch `switch` has no case the set omits.
+    func testUnmappedLayoutsDecodeNothingButTheVersionByte() {
+        for v in 0...255 where !mappedWhoop5HistoricalVersions.contains(v) {
+            let p = parseFrame(whoop5FrameWithVersion(UInt8(v)), family: .whoop5)
+            XCTAssertEqual(p.parsed.keys.sorted(), ["hist_version"],
+                           "v\(v) is outside the mapped set but the decoder populated fields for it — "
+                               + "the set and the dispatch switch have drifted")
+        }
+    }
+
+    /// The four mapped versions ARE recognised as mapped (the other direction of the lockstep).
+    func testMappedVersionsAreNotTreatedAsUnmapped() {
+        XCTAssertEqual(mappedWhoop5HistoricalVersions, [18, 20, 21, 26])
+        for v in mappedWhoop5HistoricalVersions {
+            XCTAssertFalse(isUnmappedWhoop5HistoricalRecord(whoop5FrameWithVersion(UInt8(v))),
+                           "v\(v) has a field map and must not be archived on layout grounds")
+        }
+    }
+
+    /// A cleanly-decoding v18 record is still NOT archived — widening the screen must not start
+    /// archiving the layouts NOOP already understands wholesale.
+    func testMappedV18RecordStillNotArchived() {
+        XCTAssertTrue(rejectedHistoricalRecords([bytes(whoop5V18Hex)], family: .whoop5).isEmpty)
+    }
+
+    /// The layout rule is WHOOP 5-only: it keys off `frame[9]`, which on a WHOOP 4 frame is a payload
+    /// byte, not a version. WHOOP 4's unmapped versions go through the schema's validated v24 fallback
+    /// (`PostHooks`), which keeps a record only when it decodes to a ~1 g gravity vector and a plausible
+    /// HR and otherwise drops the biometrics — so those records reach the archive by the decode-outcome
+    /// route and must not be dragged in by this one.
+    func testWhoop4FramesAreUnaffectedByTheWhoop5LayoutRule() {
+        // A synthetic WHOOP 4 V24 type-47 record (HR=63) that decodes cleanly (from HistoricalV24Tests).
+        let v24Hex =
+            "aa5a008e2f18000000000000f153650000000000003f0152030000000000000000dc053075" +
+            "000000cdcc4c3dcdcccc3d5a657e3f00000040cdcc4c3dcdcccc3d5a657e3f504668428403" +
+            "200364006400b80bb80b000000000000c25c1a88"
+        XCTAssertTrue(rejectedHistoricalRecords([bytes(v24Hex)], family: .whoop4).isEmpty)
+        XCTAssertFalse(isUnmappedWhoop5HistoricalRecord(bytes(v24Hex)),
+                       "a WHOOP 4 frame has no type-47 byte at index 8 — the rule must not fire on it")
+    }
+}

--- a/Strand/Collect/RawHistoryArchive.swift
+++ b/Strand/Collect/RawHistoryArchive.swift
@@ -18,11 +18,16 @@ import WhoopProtocol
 struct RawHistoryArchive {
     /// File name under `<AppSupport>/com.noopapp.noop/`.
     static let fileName = "rejected_history.jsonl"
-    /// Soft cap (~5 MB). When appending would push the file past this, the archive EVICTS oldest
-    /// surplus lines to make room rather than refusing the write — but only down to a per-version
-    /// retention floor (see `perVersionFloor`), so a brand-new layout version is never binned merely
-    /// because common versions filled the file. Only when the incoming frames alone can't fit even an
-    /// empty archive does `archive` skip them (reported as unarchived). (#344)
+    /// Soft cap (~5 MB). When appending would push the file past this, the archive EVICTS surplus lines
+    /// to make room rather than refusing the write — weakest-value first, and never below a per-version
+    /// retention floor, so a brand-new layout version is never binned merely because common versions
+    /// filled the file (see `evictLines` for the full priority order). Only when the incoming frames
+    /// alone can't fit even an empty archive does `archive` skip them (reported as unarchived). (#344)
+    ///
+    /// Deliberately NOT raised to survive a placeholder flood. At ~3.2 KB per hex line a 1 Hz stream of
+    /// 1584-byte records fills any cap in hours, so a bigger number buys a linear factor of time and
+    /// costs every user disk — while `zeroPayloadFloor` removes the pressure outright by evicting the
+    /// informationless records first. Value, not volume, is what was missing.
     static let maxBytes = 5 * 1024 * 1024
 
     /// Per distinct layout VERSION, keep at least this many of the newest archived lines, immune to
@@ -31,6 +36,48 @@ struct RawHistoryArchive {
     /// samples survive while the most-populous versions shed their oldest surplus. Bounded: the floor
     /// can hold at most `floor × distinctVersions` lines, a tiny set. (#344)
     static let perVersionFloor = 64
+
+    /// Per-version retention floor for lines whose PAYLOAD REGION IS ENTIRELY ZERO — far smaller than
+    /// `perVersionFloor`, because such a record carries no information beyond "the strap banked a record
+    /// at time T".
+    ///
+    /// Measured motivation, from a WHOOP MG offload: 1,275 consecutive type-47 records of layout version
+    /// 16, 1584 bytes each, every byte from offset 21 to the 4-byte CRC32 trailer zero in EVERY one. The
+    /// records' own frame clock advanced by 1 s across 933 of the gaps and 0 s across the other 339 — a
+    /// contiguous 1 Hz producer, not a burst. At ~3.2 KB per hex JSONL line the 5 MB archive holds about
+    /// 1,500 of them, i.e. ~21 minutes of retention: under a purely age-ordered policy every
+    /// informative record older than that is gone, evicted by frames that carry nothing. Keeping a
+    /// handful still proves the artefact exists (and dates it); keeping thousands costs the evidence.
+    static let zeroPayloadFloor = 8
+
+    /// First byte of a record's PAYLOAD region — everything past the record header, ending at the 4-byte
+    /// CRC32 trailer. 21 on WHOOP 5/MG (magic @0, seq @11, unix ts @15–18, a constant @19–20), and 17 on
+    /// WHOOP 4: the same +4 that shifts the type byte 4→8 and the version byte 5→9, because the puffin
+    /// envelope is 4 bytes longer. Starting AFTER the header is load-bearing — a region that included the
+    /// non-zero seq/timestamp bytes would never test as all-zero and the rule below would never fire.
+    static func payloadStart(_ family: DeviceFamily) -> Int { family == .whoop5 ? 21 : 17 }
+
+    /// Bytes of the CRC32 trailer excluded from the payload region.
+    static let crcTrailerBytes = 4
+
+    /// A payload region shorter than this is not judged at all (`hasZeroPayload` returns false): a
+    /// truncated or tiny frame is not evidence of an empty record, and must not lose retention priority
+    /// on the strength of a few zero bytes.
+    static let minPayloadBytesToJudge = 32
+
+    /// True when EVERY byte of the frame's payload region is zero — an informationless record.
+    ///
+    /// Deliberately the strict test: a single non-zero byte anywhere in the region makes the frame
+    /// informative and gives it full retention priority. "Mostly zero" is NOT the test — a novel record
+    /// that carries one small populated block inside an otherwise-empty buffer is precisely the thing
+    /// this archive exists to catch.
+    static func hasZeroPayload(_ frame: [UInt8], family: DeviceFamily) -> Bool {
+        let start = payloadStart(family)
+        let end = frame.count - crcTrailerBytes
+        guard end - start >= minPayloadBytesToJudge else { return false }
+        for i in start..<end where frame[i] != 0 { return false }
+        return true
+    }
 
     /// Outcome of an archive attempt.
     enum Result {
@@ -49,11 +96,13 @@ struct RawHistoryArchive {
     /// eviction path with a small archive instead of generating 5 MB of frames. (#344)
     private let maxBytes: Int
     private let perVersionFloor: Int
+    private let zeroPayloadFloor: Int
 
     /// Default location: `<AppSupport>/com.noopapp.noop/`, created on demand. Overridable for tests.
     init(directory: URL? = nil,
          maxBytes: Int = RawHistoryArchive.maxBytes,
-         perVersionFloor: Int = RawHistoryArchive.perVersionFloor) {
+         perVersionFloor: Int = RawHistoryArchive.perVersionFloor,
+         zeroPayloadFloor: Int = RawHistoryArchive.zeroPayloadFloor) {
         if let directory {
             self.directory = directory
         } else {
@@ -65,6 +114,7 @@ struct RawHistoryArchive {
         }
         self.maxBytes = maxBytes
         self.perVersionFloor = perVersionFloor
+        self.zeroPayloadFloor = zeroPayloadFloor
     }
 
     /// The archive file URL (does not create anything).
@@ -131,11 +181,12 @@ struct RawHistoryArchive {
         }
 
         // Over cap: rewrite with floor-aware eviction. Read existing lines (oldest first), append the
-        // new lines (which sort newest), then drop oldest surplus until we fit — never dropping a line
-        // within the newest `perVersionFloor` of its version. `evictLines` is the pure, unit-tested core.
+        // new lines (which sort newest), then drop the weakest-value surplus until we fit — never a line
+        // inside a per-version floor. `evictLines` is the pure, unit-tested core and documents the bands.
         let existing = (try? String(contentsOf: url, encoding: .utf8))
             .map { $0.split(separator: "\n", omittingEmptySubsequences: true).map { String($0) + "\n" } } ?? []
-        let kept = RawHistoryArchive.evictLines(existing + newLines, maxBytes: maxBytes, floor: perVersionFloor)
+        let kept = RawHistoryArchive.evictLines(existing + newLines, maxBytes: maxBytes,
+                                               floor: perVersionFloor, zeroFloor: zeroPayloadFloor)
         let data = Data(kept.joined().utf8)
         do {
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -160,11 +211,27 @@ struct RawHistoryArchive {
         }
     }
 
-    /// The `VersionKey` of one archived JSONL line, re-derived from its stored frame + family; `nil`
-    /// for a malformed/unparseable line — those get NO retention floor (evict them first, never let
-    /// garbage occupy a floor slot a real rare version could use), and are always evictable before any
-    /// real, floor-protected line.
-    private static func lineVersionKey(_ line: String) -> VersionKey? {
+    /// How one archived line is classified for retention: which version bucket it belongs to, and
+    /// whether its payload region is entirely zero (informationless — see `hasZeroPayload`).
+    private struct LineClass { let key: VersionKey; let zeroPayload: Bool }
+
+    /// Classify one archived JSONL line from its stored frame + family; `nil` for a
+    /// malformed/unparseable line — those get NO retention floor (evict them first, never let garbage
+    /// occupy a floor slot a real rare version could use), and are always evictable before any real,
+    /// floor-protected line.
+    private static func lineClass(_ line: String) -> LineClass? {
+        guard let (bytes, family) = parseArchiveLine(line) else { return nil }
+        return LineClass(key: VersionKey(family: family.rawValue,
+                                         version: versionByte(bytes, family: family)),
+                         zeroPayload: hasZeroPayload(bytes, family: family))
+    }
+
+    /// The frame bytes + family of one archived JSONL line, or `nil` if the line is malformed.
+    /// Hand-parsed to match the hand-built writer: the only dynamic fields are `family` and the
+    /// [0-9a-f] `frameHex`. Shared by `readAll` and retention so both agree on exactly which lines are
+    /// readable — retention must never protect a line the read-back would then skip. Twin of the Android
+    /// `RawHistoryArchive.parseArchiveLine`.
+    static func parseArchiveLine<S: StringProtocol>(_ line: S) -> (frame: [UInt8], family: DeviceFamily)? {
         guard let fr = line.range(of: "\"family\":\""),
               let hr = line.range(of: "\"frameHex\":\"") else { return nil }
         let fam = String(line[fr.upperBound...].prefix { $0 != "\"" })
@@ -176,58 +243,83 @@ struct RawHistoryArchive {
             guard let b = UInt8(hex[i..<j], radix: 16) else { return nil }
             bytes.append(b); i = j
         }
-        return VersionKey(family: fam, version: RawHistoryArchive.versionByte(bytes, family: family))
+        return (bytes, family)
     }
 
+    /// Fraction of the cap freed once eviction has to run at all: the rewrite evicts down to
+    /// `maxBytes − maxBytes/lowWaterDivisor` rather than to exactly the cap.
+    ///
+    /// Without this, an archive sitting AT the cap does a full read-parse-rewrite of the whole file on
+    /// EVERY subsequent batch — and the batches that matter here arrive during an offload, on the main
+    /// actor, at up to one record per strap-second. Leaving an eighth of the cap free amortises that to
+    /// one rewrite per ~600 KB of new frames. The bytes given up are the ones eviction would have taken
+    /// next anyway, in the same priority order.
+    static let lowWaterDivisor = 8
+
     /// Floor-aware cap eviction (#344), PURE so it is unit-testable. `lines` is the full
-    /// newline-terminated JSONL set, oldest-first (existing + incoming). Drops oldest SURPLUS lines
-    /// until the UTF-8 byte total fits `maxBytes`, but NEVER a line within the newest `floor` lines of
-    /// its version — so a rare never-seen layout (WHOOP 4 v19, WHOOP 5 v20/v21) always survives even
-    /// when common versions fill the archive. Bounded: if everything left is floor-protected it stops
-    /// even if still over cap (the floor wins — `floor × distinctVersions` is tiny). Mirrors the Android
-    /// RawHistoryArchive.evictLines.
-    static func evictLines(_ lines: [String], maxBytes: Int, floor: Int) -> [String] {
-        // Mark the newest `floor` indices of each version as protected (scan newest→oldest). Malformed
-        // lines (nil key) are never protected — they are evicted before any real, floor-kept line.
-        let keys = lines.map { lineVersionKey($0) }
+    /// newline-terminated JSONL set, oldest-first (existing + incoming).
+    ///
+    /// Retention priority, weakest first — everything in a band is evicted before anything in the next:
+    ///  1. malformed lines (unparseable — no version, no floor);
+    ///  2. surplus lines whose payload region is ENTIRELY ZERO (`hasZeroPayload`), oldest first;
+    ///  3. surplus informative lines, oldest first;
+    ///  4. floor-protected lines, never evicted: the newest `zeroFloor` zero-payload lines of each
+    ///     version and the newest `floor` informative lines of each version.
+    ///
+    /// Band 2 is what keeps a rare informative record recoverable. A 5/MG has been measured banking one
+    /// all-zero 1584-byte record per second (see `zeroPayloadFloor`); age-ordered eviction alone flushes
+    /// the whole archive within ~21 minutes of that, and an all-zero payload carries nothing that would
+    /// be worth the trade. Band 4's split floor means a version whose records are ALL empty still keeps a
+    /// few dated samples of the artefact, while the full `floor` stays reserved for records that
+    /// actually contain something.
+    ///
+    /// Bounded: if everything left is floor-protected it stops even if still over cap (the floor wins —
+    /// `(floor + zeroFloor) × distinctVersions` is tiny). Mirrors the Android
+    /// `RawHistoryArchive.evictLines`.
+    static func evictLines(_ lines: [String], maxBytes: Int, floor: Int,
+                           zeroFloor: Int = RawHistoryArchive.zeroPayloadFloor) -> [String] {
+        // Mark the newest `floor` informative and newest `zeroFloor` zero-payload indices of each version
+        // as protected (scan newest→oldest). Malformed lines (nil class) are never protected — they are
+        // evicted before any real, floor-kept line.
+        let classes = lines.map { lineClass($0) }
         var protectedIdx = Set<Int>()
-        var seen: [VersionKey: Int] = [:]
+        var seenInformative: [VersionKey: Int] = [:]
+        var seenZero: [VersionKey: Int] = [:]
         for idx in lines.indices.reversed() {
-            guard let k = keys[idx] else { continue }
-            let c = (seen[k] ?? 0)
-            if c < floor { protectedIdx.insert(idx); seen[k] = c + 1 }
+            guard let c = classes[idx] else { continue }
+            if c.zeroPayload {
+                let n = (seenZero[c.key] ?? 0)
+                if n < zeroFloor { protectedIdx.insert(idx); seenZero[c.key] = n + 1 }
+            } else {
+                let n = (seenInformative[c.key] ?? 0)
+                if n < floor { protectedIdx.insert(idx); seenInformative[c.key] = n + 1 }
+            }
         }
         var total = lines.reduce(0) { $0 + $1.utf8.count }
         guard total > maxBytes else { return lines }
-        // Evict oldest unprotected lines first.
+        let target = maxBytes - maxBytes / lowWaterDivisor
+        // Evict in weakest-first bands; within a band, oldest first (ascending index).
         var dropped = Set<Int>()
-        for idx in lines.indices where total > maxBytes {   // ascending = oldest first
-            if protectedIdx.contains(idx) { continue }
-            dropped.insert(idx)
-            total -= lines[idx].utf8.count
+        func evict(_ admits: (Int) -> Bool) {
+            for idx in lines.indices where total > target {
+                if protectedIdx.contains(idx) || dropped.contains(idx) { continue }
+                guard admits(idx) else { continue }
+                dropped.insert(idx)
+                total -= lines[idx].utf8.count
+            }
         }
+        evict { classes[$0] == nil }                       // 1. malformed
+        evict { classes[$0]?.zeroPayload == true }         // 2. zero-payload surplus
+        evict { _ in true }                                // 3. informative surplus
         return lines.enumerated().filter { !dropped.contains($0.offset) }.map(\.element)
     }
 
     /// Every archived frame with its strap family, oldest first — the read-back of the JSONL that
-    /// `archive` writes. Malformed lines are skipped; an absent/empty file yields []. (Hand-parsed to
-    /// match the hand-built writer: the only dynamic fields are `family` and the [0-9a-f] `frameHex`.)
+    /// `archive` writes. Malformed lines are skipped; an absent/empty file yields []. Parsed through the
+    /// same `parseArchiveLine` retention uses, so the two can never disagree on what is readable.
     func readAll() -> [(frame: [UInt8], family: DeviceFamily)] {
         guard let text = try? String(contentsOf: fileURL, encoding: .utf8) else { return [] }
-        return text.split(separator: "\n").compactMap { line in
-            guard let fr = line.range(of: "\"family\":\""),
-                  let hr = line.range(of: "\"frameHex\":\"") else { return nil }
-            let fam = String(line[fr.upperBound...].prefix { $0 != "\"" })
-            let hex = line[hr.upperBound...].prefix { $0 != "\"" }
-            guard let family = DeviceFamily(rawValue: fam), hex.count % 2 == 0 else { return nil }
-            var bytes = [UInt8](); bytes.reserveCapacity(hex.count / 2); var i = hex.startIndex
-            while i < hex.endIndex {
-                let j = hex.index(i, offsetBy: 2)
-                guard let b = UInt8(hex[i..<j], radix: 16) else { return nil }
-                bytes.append(b); i = j
-            }
-            return (bytes, family)
-        }
+        return text.split(separator: "\n").compactMap { RawHistoryArchive.parseArchiveLine($0) }
     }
 
     /// Re-decode every archived frame through the CURRENT decoder and insert whatever now decodes.

--- a/StrandTests/RawHistoryArchiveEvictionTests.swift
+++ b/StrandTests/RawHistoryArchiveEvictionTests.swift
@@ -113,6 +113,130 @@ final class RawHistoryArchiveEvictionTests: XCTestCase {
         return "{\"capturedAtMs\":1,\"trim\":1,\"family\":\"\(family)\",\"frameHex\":\"\(hex)\"}\n"
     }
 
+    // MARK: - zero-payload frames lose retention priority
+
+    /// A synthetic WHOOP 5/MG type-47 record: a non-zero 21-byte header (type @8 = 47, hist_version @9),
+    /// then `payloadBytes` of payload, then a 4-byte CRC trailer.
+    ///
+    /// `payloadByte: 0` reproduces the measured empty record — a 5/MG banks one per second with every
+    /// byte from offset 21 to the CRC trailer zero. `marker` writes a single distinguishing byte into
+    /// the payload, which is also what makes a frame informative.
+    private func whoop5Frame(version: UInt8, payloadByte: UInt8,
+                             payloadBytes: Int = 64, marker: UInt8? = nil) -> [UInt8] {
+        var f = [UInt8](repeating: 0x11, count: 21)          // non-zero header (seq/ts/const bytes)
+        f[0] = 0xAA; f[8] = 47; f[9] = version
+        var payload = [UInt8](repeating: payloadByte, count: payloadBytes)
+        if let marker { payload[0] = marker }
+        f.append(contentsOf: payload)
+        f.append(contentsOf: [0xDE, 0xAD, 0xBE, 0xEF])       // CRC32 trailer (never part of the payload)
+        return f
+    }
+
+    /// The strict test: entirely-zero payload region → yes; ONE non-zero byte anywhere → no.
+    func testZeroPayloadDetectionIsStrictAndHeaderAware() {
+        let empty = whoop5Frame(version: 22, payloadByte: 0)
+        XCTAssertTrue(RawHistoryArchive.hasZeroPayload(empty, family: .whoop5),
+                      "the header and CRC bytes are non-zero but the PAYLOAD region is all zero")
+        // A single populated byte in an otherwise-empty buffer is exactly what this archive is for.
+        var oneByte = empty
+        oneByte[21 + 40] = 0x01
+        XCTAssertFalse(RawHistoryArchive.hasZeroPayload(oneByte, family: .whoop5),
+                       "'mostly zero' must NOT count as empty — one non-zero byte makes it informative")
+        // The last payload byte, immediately before the CRC trailer, is inside the region.
+        var lastByte = empty
+        lastByte[lastByte.count - 5] = 0x01
+        XCTAssertFalse(RawHistoryArchive.hasZeroPayload(lastByte, family: .whoop5))
+        // A payload region too short to judge is never called empty.
+        XCTAssertFalse(RawHistoryArchive.hasZeroPayload(whoop5Frame(version: 22, payloadByte: 0,
+                                                                    payloadBytes: 8), family: .whoop5))
+        XCTAssertFalse(RawHistoryArchive.hasZeroPayload([0xAA, 0x01], family: .whoop5))
+    }
+
+    /// The DEFECT: a 5/MG has been measured banking one all-zero record per second, so a purely
+    /// age-ordered archive evicts everything informative within ~21 minutes. An informative frame must
+    /// outrank an all-zero one of the SAME layout version, even when it is the oldest line in the file
+    /// and the empties are the newest.
+    func testZeroPayloadFramesAreEvictedBeforeInformativeOnes() {
+        let dir = tmpDir("zero"); defer { try? FileManager.default.removeItem(at: dir) }
+        let archive = RawHistoryArchive(directory: dir, maxBytes: 4_096,
+                                        perVersionFloor: 2, zeroPayloadFloor: 2)
+
+        // Three informative records land FIRST — the oldest lines in the archive. Two would survive on
+        // the per-version floor alone; the third can only survive if the empties are evicted before it.
+        let informative = (0..<3).map { whoop5Frame(version: 22, payloadByte: 0x00, marker: UInt8(0xE0 + $0)) }
+        for f in informative { _ = archive.archive([f], trim: 1, family: .whoop5) }
+        XCTAssertFalse(RawHistoryArchive.hasZeroPayload(informative[0], family: .whoop5),
+                       "precondition: a marker byte makes these frames informative")
+
+        // Then the placeholder flood: same layout version, all-zero payload, newest in the file.
+        for _ in 0..<200 { _ = archive.archive([whoop5Frame(version: 22, payloadByte: 0)],
+                                               trim: 2, family: .whoop5) }
+
+        let back = archive.readAll().map(\.frame)
+        let size = (try? FileManager.default.attributesOfItem(atPath: archive.fileURL.path))
+            .flatMap { $0[.size] as? Int } ?? 0
+        XCTAssertLessThanOrEqual(size, 4_096, "the archive must still respect its cap")
+        for (i, f) in informative.enumerated() {
+            XCTAssertTrue(back.contains(f), "informative frame #\(i) must outrank 200 empty records")
+        }
+        // …and the empties really were the thing evicted (a handful kept to date the artefact).
+        let zeros = back.filter { RawHistoryArchive.hasZeroPayload($0, family: .whoop5) }
+        XCTAssertLessThan(zeros.count, 200, "the placeholder flood must have been evicted, not the data")
+    }
+
+    /// Same ordering in the pure core, with the informative line the OLDEST of its version so no floor
+    /// can be what saves it.
+    func testEvictLinesEvictsZeroPayloadBeforeInformative() {
+        let informative = archiveLine(whoop5Frame(version: 22, payloadByte: 0, marker: 0xE7))
+        var lines = [informative]
+        for _ in 0..<200 { lines.append(archiveLine(whoop5Frame(version: 22, payloadByte: 0))) }
+        let kept = RawHistoryArchive.evictLines(lines, maxBytes: 4_096, floor: 2, zeroFloor: 2)
+        XCTAssertLessThanOrEqual(kept.reduce(0) { $0 + $1.utf8.count }, 4_096)
+        XCTAssertTrue(kept.contains(informative),
+                      "the one informative line must survive a flood of all-zero-payload lines")
+        XCTAssertLessThan(kept.count, 200, "the zero-payload surplus must actually have been evicted")
+    }
+
+    /// A version whose records are ALL empty still keeps `zeroFloor` dated samples — enough to prove the
+    /// artefact exists without letting it own the archive.
+    func testAllZeroVersionKeepsItsSmallFloor() {
+        var lines: [String] = []
+        for _ in 0..<200 { lines.append(archiveLine(whoop5Frame(version: 22, payloadByte: 0))) }
+        for i in 0..<200 { lines.append(archiveLine(whoop5Frame(version: 18, payloadByte: 0,
+                                                                marker: UInt8(i & 0xFF)))) }
+        let kept = RawHistoryArchive.evictLines(lines, maxBytes: 4_096, floor: 2, zeroFloor: 2)
+        let keptZeroVersion = kept.filter { $0.contains("2f16") }   // 0x2f = type 47, 0x16 = v22
+        XCTAssertGreaterThanOrEqual(keptZeroVersion.count, 2,
+                                    "an all-empty version must keep its small floor, not vanish")
+    }
+
+    /// The eviction target is a low-water mark BELOW the cap, not the cap itself. Without the headroom an
+    /// archive sitting at the cap read-parse-rewrites the whole file on every subsequent batch, and during
+    /// an offload those batches arrive at up to one record per strap-second on the main actor.
+    func testEvictionLeavesHeadroomSoAOneHzStreamDoesNotRewriteEveryRecord() {
+        let lines = (0..<400).map { jsonl(18, filler: String(format: "%02x", $0 & 0xFF)) }
+        let kept = RawHistoryArchive.evictLines(lines, maxBytes: 4_096, floor: 2)
+        let bytes = kept.reduce(0) { $0 + $1.utf8.count }
+        XCTAssertLessThanOrEqual(bytes, 4_096 - 4_096 / RawHistoryArchive.lowWaterDivisor,
+                                 "eviction must go PAST the cap to 7/8 of it, or every subsequent batch "
+                                     + "rewrites the whole file")
+    }
+
+    /// The shipped floors are the documented ones, and the zero floor is far smaller than the real one —
+    /// a few dated samples of an empty layout, not a share of the archive comparable to real records.
+    func testShippedFloors() {
+        XCTAssertEqual(RawHistoryArchive.perVersionFloor, 64)
+        XCTAssertEqual(RawHistoryArchive.zeroPayloadFloor, 8)
+        XCTAssertLessThan(RawHistoryArchive.zeroPayloadFloor, RawHistoryArchive.perVersionFloor)
+        XCTAssertEqual(RawHistoryArchive.maxBytes, 5 * 1024 * 1024, "the cap was deliberately not raised")
+    }
+
+    /// One archived JSONL line for `frame`, in the exact shape `archive` writes.
+    private func archiveLine(_ frame: [UInt8], family: DeviceFamily = .whoop5) -> String {
+        let hex = frame.map { String(format: "%02x", $0) }.joined()
+        return "{\"capturedAtMs\":1,\"trim\":1,\"family\":\"\(family.rawValue)\",\"frameHex\":\"\(hex)\"}\n"
+    }
+
     /// `evictLines` is the pure core: a flood of common-version lines plus two rare-version lines (the
     /// oldest), capped tight → the rare lines must survive and the result must fit the cap.
     func testEvictLinesKeepsRareVersionUnderCap() {

--- a/android/app/src/main/java/com/noop/ble/RawHistoryArchive.kt
+++ b/android/app/src/main/java/com/noop/ble/RawHistoryArchive.kt
@@ -21,12 +21,14 @@ import java.io.FileOutputStream
  *   {"capturedAtMs":<Long>,"trim":<Long>,"family":"whoop4"|"whoop5","frameHex":"<hex>"}
  * Each [append] flushes + fsyncs before returning, so a row is durable before the caller acks.
  *
- * Size cap ([maxBytes], ~5 MB): if appending would push the file past the cap, [append] EVICTS oldest
- * surplus lines to make room rather than refusing the write — but only down to a per-version retention
- * floor ([PER_VERSION_FLOOR]), so a brand-new layout version is never binned merely because common
- * versions filled the file. Only when the incoming frames alone can't fit even an empty archive does
- * [append] skip them ([AppendResult.written] = false); the caller records those as unarchived so the
- * sync status never falsely claims they were preserved. (#344)
+ * Size cap ([maxBytes], ~5 MB): if appending would push the file past the cap, [append] EVICTS surplus
+ * lines to make room rather than refusing the write — weakest-value first, and never below a per-version
+ * retention floor ([PER_VERSION_FLOOR] for informative lines, [ZERO_PAYLOAD_FLOOR] for lines whose
+ * payload region is entirely zero), so a brand-new layout version is never binned merely because common
+ * versions — or a 1 Hz flood of empty placeholder records — filled the file. See [evictLines] for the
+ * full priority order. Only when the incoming frames alone can't fit even an empty archive does [append]
+ * skip them ([AppendResult.written] = false); the caller records those as unarchived so the sync status
+ * never falsely claims they were preserved. (#344)
  *
  * A genuine WRITE FAILURE (I/O error) instead throws — the caller treats that as "do NOT ack", so the
  * strap keeps the records and re-sends them on the next offload. No data is lost either way.
@@ -36,6 +38,7 @@ class RawHistoryArchive(
     private val maxBytes: Long = REJECTED_ARCHIVE_MAX_BYTES,
     // Overridable so tests can drive eviction with a small archive instead of 5 MB of frames. (#344)
     private val perVersionFloor: Int = PER_VERSION_FLOOR,
+    private val zeroPayloadFloor: Int = ZERO_PAYLOAD_FLOOR,
 ) {
     /**
      * Outcome of an [append]. [ok] is true whenever the offload may proceed to ack; [written] is true
@@ -87,7 +90,7 @@ class RawHistoryArchive(
         // the newest [PER_VERSION_FLOOR] of its version. Atomic rewrite (temp file + rename) so the
         // archive is durable BEFORE the ack. [evictLines] is the pure, unit-tested core.
         val existing = if (f.exists()) f.readLines().filter { it.isNotEmpty() }.map { "$it\n" } else emptyList()
-        val kept = evictLines(existing + newLines, maxBytes, perVersionFloor)
+        val kept = evictLines(existing + newLines, maxBytes, perVersionFloor, zeroPayloadFloor)
         val tmp = File(context.filesDir, "$REJECTED_ARCHIVE_FILE.tmp")
         FileOutputStream(tmp).use { out ->
             out.write(kept.joinToString("").toByteArray(Charsets.UTF_8))
@@ -168,7 +171,15 @@ class RawHistoryArchive(
         /** Archive filename in the app-private filesDir. */
         const val REJECTED_ARCHIVE_FILE = "rejected_history.jsonl"
 
-        /** ~5 MB cap; above this [append] evicts oldest surplus (floor-aware) to make room (#344). */
+        /**
+         * ~5 MB cap; above this [append] evicts surplus (weakest-value first, floor-aware) to make room
+         * (#344). See [evictLines] for the full priority order.
+         *
+         * Deliberately NOT raised to survive a placeholder flood. At ~3.2 KB per hex line a 1 Hz stream of
+         * 1584-byte records fills any cap in hours, so a bigger number buys a linear factor of time and
+         * costs every user disk — while [ZERO_PAYLOAD_FLOOR] removes the pressure outright by evicting the
+         * informationless records first. Value, not volume, is what was missing.
+         */
         const val REJECTED_ARCHIVE_MAX_BYTES = 5L * 1024 * 1024
 
         /**
@@ -180,6 +191,70 @@ class RawHistoryArchive(
          * perVersionFloor. (#344)
          */
         const val PER_VERSION_FLOOR = 64
+
+        /**
+         * Per-version retention floor for lines whose PAYLOAD REGION IS ENTIRELY ZERO — far smaller than
+         * [PER_VERSION_FLOOR], because such a record carries no information beyond "the strap banked a
+         * record at time T".
+         *
+         * Measured motivation, from a WHOOP MG offload: 1,275 consecutive type-47 records of layout
+         * version 16, 1584 bytes each, every byte from offset 21 to the 4-byte CRC32 trailer zero in
+         * EVERY one. The records' own frame clock advanced by 1 s across 933 of the gaps and 0 s across
+         * the other 339 — a contiguous 1 Hz producer, not a burst. At ~3.2 KB per hex JSONL line the 5 MB
+         * archive holds about 1,500 of them, i.e. ~21 minutes of retention: under a purely age-ordered
+         * policy every informative record older than that is gone, evicted by frames that carry nothing.
+         * Keeping a handful still proves the artefact exists (and dates it); keeping thousands costs the
+         * evidence. Twin of the Swift `RawHistoryArchive.zeroPayloadFloor`.
+         */
+        const val ZERO_PAYLOAD_FLOOR = 8
+
+        /** Bytes of the CRC32 trailer excluded from the payload region. */
+        const val CRC_TRAILER_BYTES = 4
+
+        /**
+         * A payload region shorter than this is not judged at all ([hasZeroPayload] returns false): a
+         * truncated or tiny frame is not evidence of an empty record, and must not lose retention
+         * priority on the strength of a few zero bytes.
+         */
+        const val MIN_PAYLOAD_BYTES_TO_JUDGE = 32
+
+        /**
+         * First byte of a record's PAYLOAD region — everything past the record header, ending at the
+         * 4-byte CRC32 trailer. 21 on WHOOP 5/MG (magic @0, seq @11, unix ts @15-18, a constant @19-20)
+         * and 17 on WHOOP 4: the same +4 that shifts the type byte 4→8 and the version byte 5→9, because
+         * the puffin envelope is 4 bytes longer. Starting AFTER the header is load-bearing — a region
+         * that included the non-zero seq/timestamp bytes would never test as all-zero and
+         * [hasZeroPayload] would never fire. Twin of the Swift `RawHistoryArchive.payloadStart`.
+         */
+        fun payloadStart(family: DeviceFamily): Int = if (family == DeviceFamily.WHOOP5) 21 else 17
+
+        /**
+         * True when EVERY byte of [frame]'s payload region is zero — an informationless record.
+         *
+         * Deliberately the STRICT test: a single non-zero byte anywhere in the region makes the frame
+         * informative and gives it full retention priority. "Mostly zero" is NOT the test — a novel
+         * record that carries one small populated block inside an otherwise-empty buffer is precisely the
+         * thing this archive exists to catch. Twin of the Swift `RawHistoryArchive.hasZeroPayload`.
+         */
+        fun hasZeroPayload(frame: ByteArray, family: DeviceFamily): Boolean {
+            val start = payloadStart(family)
+            val end = frame.size - CRC_TRAILER_BYTES
+            if (end - start < MIN_PAYLOAD_BYTES_TO_JUDGE) return false
+            for (i in start until end) if (frame[i].toInt() != 0) return false
+            return true
+        }
+
+        /**
+         * Fraction of the cap freed once eviction has to run at all: the rewrite evicts down to
+         * `maxBytes - maxBytes/LOW_WATER_DIVISOR` rather than to exactly the cap.
+         *
+         * Without this, an archive sitting AT the cap does a full read-parse-rewrite of the whole file on
+         * EVERY subsequent batch — and the batches that matter here arrive during an offload at up to one
+         * record per strap-second. Leaving an eighth of the cap free amortises that to one rewrite per
+         * ~600 KB of new frames. The bytes given up are the ones eviction would have taken next anyway,
+         * in the same priority order. Twin of the Swift `RawHistoryArchive.lowWaterDivisor`.
+         */
+        const val LOW_WATER_DIVISOR = 8
 
         /**
          * The hist_version byte distinguishing one historical layout from another: `frame[5]` on WHOOP
@@ -198,46 +273,91 @@ class RawHistoryArchive(
         private data class VersionKey(val family: String, val version: Int)
 
         /**
-         * The [VersionKey] of one archived JSONL line, re-derived from its stored frame + family; null
-         * for a malformed line (which then gets NO retention floor — it is evicted before any real,
-         * floor-protected line, so garbage can never occupy a slot a real rare version could use).
+         * How one archived line is classified for retention: which version bucket it belongs to, and
+         * whether its payload region is entirely zero (informationless — see [hasZeroPayload]).
          */
-        private fun lineVersionKey(line: String): VersionKey? {
-            val parsed = parseArchiveLine(line) ?: return null
-            val tag = if (parsed.second == DeviceFamily.WHOOP5) "whoop5" else "whoop4"
-            return VersionKey(tag, versionByte(parsed.first, parsed.second))
+        private data class LineClass(val key: VersionKey, val zeroPayload: Boolean)
+
+        /**
+         * Classify one archived JSONL line from its stored frame + family; null for a
+         * malformed/unparseable line — those get NO retention floor (evict them first, never let garbage
+         * occupy a floor slot a real rare version could use), and are always evictable before any real,
+         * floor-protected line.
+         */
+        private fun lineClass(line: String): LineClass? {
+            val (frame, family) = parseArchiveLine(line) ?: return null
+            val tag = if (family == DeviceFamily.WHOOP5) "whoop5" else "whoop4"
+            return LineClass(VersionKey(tag, versionByte(frame, family)), hasZeroPayload(frame, family))
         }
 
         /**
          * Floor-aware cap eviction (#344), PURE so it is JVM-unit-testable without a Context. [lines] is
-         * the full newline-terminated JSONL set, oldest-first (existing ++ incoming). Drops oldest
-         * SURPLUS lines until the UTF-8 byte total fits [maxBytes], but NEVER a line within the newest
-         * [floor] lines of its version — so a rare never-seen layout (WHOOP 4 v19, WHOOP 5 v20/v21)
-         * always survives even when common versions fill the archive. Bounded: if everything left is
-         * floor-protected it stops even if still over cap (the floor wins — floor x distinctVersions is
-         * tiny). Mirrors the macOS RawHistoryArchive.evictLines.
+         * the full newline-terminated JSONL set, oldest-first (existing ++ incoming).
+         *
+         * Retention priority, weakest first — everything in a band is evicted before anything in the next:
+         *  1. malformed lines (unparseable — no version, no floor);
+         *  2. surplus lines whose payload region is ENTIRELY ZERO ([hasZeroPayload]), oldest first;
+         *  3. surplus informative lines, oldest first;
+         *  4. floor-protected lines, never evicted: the newest [zeroFloor] zero-payload lines of each
+         *     version and the newest [floor] informative lines of each version — so a rare never-seen
+         *     layout (WHOOP 4 v19, WHOOP 5 v20/v21) always survives even when common versions fill the
+         *     archive.
+         *
+         * Band 2 is what keeps a rare informative record recoverable. A 5/MG has been measured banking one
+         * all-zero 1584-byte record per second (see [ZERO_PAYLOAD_FLOOR]); age-ordered eviction alone
+         * flushes the whole archive within ~21 minutes of that, and an all-zero payload carries nothing
+         * that would be worth the trade. Band 4's split floor means a version whose records are ALL empty
+         * still keeps a few dated samples of the artefact, while the full [floor] stays reserved for
+         * records that actually contain something.
+         *
+         * Once eviction has to run at all it evicts to [LOW_WATER_DIVISOR] below the cap rather than to
+         * exactly the cap, so a 1 Hz stream no longer rewrites the whole file once per record.
+         *
+         * Bounded: if everything left is floor-protected it stops even if still over cap (the floor wins —
+         * `(floor + zeroFloor) x distinctVersions` is tiny). Mirrors the macOS
+         * `RawHistoryArchive.evictLines`; [zeroFloor] is defaulted for exactly the reason it is defaulted
+         * on the Swift side — so existing call sites do not have to churn.
          */
-        fun evictLines(lines: List<String>, maxBytes: Long, floor: Int): List<String> {
-            // Mark the newest [floor] indices of each version as protected (scan newest -> oldest).
-            // Malformed lines (null key) are never protected — evicted before any real, floor-kept line.
-            val keys = lines.map { lineVersionKey(it) }
+        fun evictLines(
+            lines: List<String>,
+            maxBytes: Long,
+            floor: Int,
+            zeroFloor: Int = ZERO_PAYLOAD_FLOOR,
+        ): List<String> {
+            // Mark the newest [floor] informative and newest [zeroFloor] zero-payload indices of each
+            // version as protected (scan newest -> oldest). Malformed lines (null class) are never
+            // protected — evicted before any real, floor-kept line.
+            val classes = lines.map { lineClass(it) }
             val protectedIdx = HashSet<Int>()
-            val seen = HashMap<VersionKey, Int>()
+            val seenInformative = HashMap<VersionKey, Int>()
+            val seenZero = HashMap<VersionKey, Int>()
             for (idx in lines.indices.reversed()) {
-                val k = keys[idx] ?: continue
-                val c = seen[k] ?: 0
-                if (c < floor) { protectedIdx.add(idx); seen[k] = c + 1 }
+                val c = classes[idx] ?: continue
+                if (c.zeroPayload) {
+                    val n = seenZero[c.key] ?: 0
+                    if (n < zeroFloor) { protectedIdx.add(idx); seenZero[c.key] = n + 1 }
+                } else {
+                    val n = seenInformative[c.key] ?: 0
+                    if (n < floor) { protectedIdx.add(idx); seenInformative[c.key] = n + 1 }
+                }
             }
             var total = lines.sumOf { it.toByteArray(Charsets.UTF_8).size.toLong() }
             if (total <= maxBytes) return lines
-            // Evict oldest unprotected lines first.
+            val target = maxBytes - maxBytes / LOW_WATER_DIVISOR
+            // Evict in weakest-first bands; within a band, oldest first (ascending index).
             val dropped = HashSet<Int>()
-            for (idx in lines.indices) {                       // ascending = oldest first
-                if (total <= maxBytes) break
-                if (idx in protectedIdx) continue
-                dropped.add(idx)
-                total -= lines[idx].toByteArray(Charsets.UTF_8).size.toLong()
+            fun evict(admits: (Int) -> Boolean) {
+                for (idx in lines.indices) {                   // ascending = oldest first
+                    if (total <= target) break
+                    if (idx in protectedIdx || idx in dropped) continue
+                    if (!admits(idx)) continue
+                    dropped.add(idx)
+                    total -= lines[idx].toByteArray(Charsets.UTF_8).size.toLong()
+                }
             }
+            evict { classes[it] == null }                      // 1. malformed
+            evict { classes[it]?.zeroPayload == true }         // 2. zero-payload surplus
+            evict { true }                                     // 3. informative surplus
             return lines.filterIndexed { idx, _ -> idx !in dropped }
         }
 

--- a/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
+++ b/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
@@ -294,6 +294,40 @@ fun decodeHistorical(frame: ByteArray, family: DeviceFamily = DeviceFamily.WHOOP
 }
 
 /**
+ * The WHOOP 5/MG type-47 `hist_version` values THIS platform has a real field map for. Every other
+ * version reaches no decoder at all: [decodeWhoop5Historical] returns null and nothing but the raw bytes
+ * of the record can preserve it.
+ *
+ * This is the single source of truth for "does NOOP-Android understand this layout": the version gates in
+ * [decodeWhoop5Historical] and the v26 branch of [extractHistoricalStreams] read nothing else, and
+ * [rejectedHistoricalRecords] uses it to decide which records must be archived raw. Keeping one set means
+ * the two can never disagree — the failure mode this replaced was a record from an unmapped layout that
+ * happened to decode a plausible `unix` and `gravity_x`/`heart_rate` slipping past the archive filter, so
+ * its bytes were kept nowhere at all and the strap freed them on the very next trim ack.
+ *
+ * ⚠️ DELIBERATELY NARROWER THAN THE SWIFT `mappedWhoop5HistoricalVersions`, which is `[18, 20, 21, 26]`.
+ * Swift's `decodeWhoop5Historical` dispatches v20 (raw optical block) and v21 (raw 6-axis IMU) through
+ * `decodeWhoop5HistoricalV2021`; the Kotlin historical path has no such branch — `Whoop5RawOptical` and
+ * `Whoop5RawImu` exist here but are wired to the LIVE deep-buffer route in `WhoopBleClient`, not to the
+ * type-47 historical dispatch. Claiming 20/21 here would assert a field map Android does not have, which
+ * is precisely the "it holds by accident" class of bug this constant was introduced to close. The archive
+ * OUTCOME is unchanged either way today: an unmapped 5/MG version already decodes to null on Android and
+ * so was already archived by the decode-outcome route. Add a version here only when a decoder for it
+ * lands on this side. Pinned by `UnmappedHistoricalLayoutTest`.
+ */
+val MAPPED_WHOOP5_HISTORICAL_VERSIONS: Set<Int> = setOf(18, 26)
+
+/**
+ * True when [frame] is a WHOOP 5/MG type-47 record whose layout version has NO field map on this
+ * platform — the records that are never re-derivable from anything NOOP stores. Non-type-47 and
+ * too-short frames are false. Twin of the Swift `isUnmappedWhoop5HistoricalRecord`.
+ */
+fun isUnmappedWhoop5HistoricalRecord(frame: ByteArray): Boolean {
+    if (frame.size <= 9 || (frame[8].toInt() and 0xFF) != PacketType.HISTORICAL_DATA.rawValue) return false
+    return (frame[9].toInt() and 0xFF) !in MAPPED_WHOOP5_HISTORICAL_VERSIONS
+}
+
+/**
  * WHOOP 5.0/MG type-47 "v18" historical decode. The puffin envelope is longer, so the record starts at
  * byte 8 (type@8, version@9) and fields sit at their WHOOP5-ABSOLUTE offsets — NOT the WHOOP4 V24 layout
  * shifted by +4 (that decodes to garbage on v18). Offsets verified against real worn/off-wrist frames
@@ -307,6 +341,11 @@ fun decodeHistorical(frame: ByteArray, family: DeviceFamily = DeviceFamily.WHOOP
 private fun decodeWhoop5Historical(frame: ByteArray): Map<String, Any?>? {
     if (frame.histU8(8) != PacketType.HISTORICAL_DATA.rawValue) return null
     val version = frame.histU8(9) ?: return null
+    // One gate, one list: 18 is the only version this function maps, and v26 (handled by
+    // [decodeWhoop5HistoricalV26] from [extractHistoricalStreams]) is the only other one this platform
+    // maps at all — so [MAPPED_WHOOP5_HISTORICAL_VERSIONS] must contain exactly {18, 26}. That set is
+    // what decides whether a record gets archived raw, so the two cannot be allowed to drift;
+    // `UnmappedHistoricalLayoutTest` pins the lockstep against the decoder's actual behaviour.
     if (version != 18) return null
 
     val out = LinkedHashMap<String, Any?>()
@@ -477,10 +516,12 @@ private fun decodeWhoop5HistoricalV26(frame: ByteArray): V26Record? {
 }
 
 /**
- * The HISTORICAL_DATA (type-47) record frames in [rawFrames] that genuinely FAIL to decode — a CRC
- * failure, or an unmapped firmware layout whose v24 plausibility gate (see [decodeHistorical]) also
- * rejects it. These are exactly the record frames [extractHistoricalStreams] silently drops: their
- * biometric payload would otherwise be lost forever once the strap trims the acked history.
+ * The HISTORICAL_DATA (type-47) record frames in [rawFrames] that NOOP cannot turn into rows — a CRC
+ * failure, an unmapped firmware layout (5/MG: any `hist_version` outside
+ * [MAPPED_WHOOP5_HISTORICAL_VERSIONS]), or a mapped layout whose envelope parsed but whose v24
+ * plausibility gate (see [decodeHistorical]) rejected it. These are the record frames
+ * [extractHistoricalStreams] silently drops: their biometric payload would otherwise be lost forever once
+ * the strap trims the acked history.
  *
  * EXCLUDED (decode to zero rows BY DESIGN, never "lost" data — must NOT be counted):
  *   - CONSOLE_LOGS (type-50) frames — the strap's own diagnostics text channel. On WHOOP 4.0 the
@@ -507,6 +548,24 @@ fun rejectedHistoricalRecords(
         if (t != PacketType.HISTORICAL_DATA.rawValue) return@filter false // type-50 console / metadata / etc.
         // WHOOP 5/MG v26 = raw PPG block, deliberately not stored — known-skipped, not lost data.
         if (family == DeviceFamily.WHOOP5 && frame.histU8(9) == 26) return@filter false
+        // UNMAPPED LAYOUT (5/MG) — archive UNCONDITIONALLY, whatever it decoded.
+        //
+        // The decode-outcome test below is the wrong QUESTION for a layout NOOP has no field map for.
+        // Today it happens to give the right ANSWER, because [decodeWhoop5Historical] returns null for
+        // every version outside [MAPPED_WHOOP5_HISTORICAL_VERSIONS] — but that is an accident of the
+        // decoder's current shape, not a property of the format. One static schema field for type 47, or
+        // one partially-mapped new version, and a record that yielded a plausible `unix` plus a
+        // `heart_rate`/`gravity_x` would pass the screen and be kept NOWHERE at all, its bytes freed by
+        // the very next trim ack. That is exactly the shape a novel record type (a new firmware's rollup,
+        // an on-demand capture) can take. Deciding on the VERSION makes it structural.
+        //
+        // This cannot flood the archive with records we already understand: the mapped versions never
+        // reach here. Retention for the records that DO ([RawHistoryArchive.evictLines]) evicts
+        // entirely-zero-payload frames first, so a firmware that banks empty placeholder records at 1 Hz
+        // cannot push out the one informative frame either. Twin of the Swift `rejectedHistoricalRecords`
+        // layout clause. WHOOP 4 is untouched: its unmapped versions go through the v24 fallback below,
+        // which keeps a record only when it validates physiologically.
+        if (family == DeviceFamily.WHOOP5 && isUnmappedWhoop5HistoricalRecord(frame)) return@filter true
         // A type-47 record that [decodeHistorical] cannot turn into usable biometrics — CRC failure or
         // an unmapped layout the v24-fallback plausibility gate rejected. This is precisely what
         // [extractHistoricalStreams] drops (`decodeHistorical(...) ?: continue`), so the rejected set

--- a/android/app/src/test/java/com/noop/ble/RawHistoryArchiveEvictionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/RawHistoryArchiveEvictionTest.kt
@@ -1,6 +1,7 @@
 package com.noop.ble
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -51,6 +52,119 @@ class RawHistoryArchiveEvictionTest {
     @Test fun noOpUnderCap() {
         val lines = (0 until 10).map { jsonl(18, filler = "%02x".format(it)) }
         assertEquals(lines, RawHistoryArchive.evictLines(lines, maxBytes = 1_000_000, floor = 2))
+    }
+
+    // MARK: - zero-payload frames lose retention priority
+
+    /**
+     * A synthetic WHOOP 5/MG type-47 record: a non-zero 21-byte header (type @8 = 47, hist_version @9),
+     * then [payloadBytes] of payload, then a 4-byte CRC trailer.
+     *
+     * [payloadByte] = 0 reproduces the measured empty record — a 5/MG banks one per second with every
+     * byte from offset 21 to the CRC trailer zero. [marker] writes a single distinguishing byte into the
+     * payload, which is also what makes a frame informative.
+     */
+    private fun whoop5Frame(
+        version: Int,
+        payloadByte: Int,
+        payloadBytes: Int = 64,
+        marker: Int? = null,
+    ): ByteArray {
+        val f = ByteArray(21) { 0x11 }                 // non-zero header (seq/ts/const bytes)
+        f[0] = 0xAA.toByte(); f[8] = 47; f[9] = version.toByte()
+        val payload = ByteArray(payloadBytes) { payloadByte.toByte() }
+        if (marker != null) payload[0] = marker.toByte()
+        return f + payload + byteArrayOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte())
+    }
+
+    /** One archived JSONL line for [frame], in the exact shape `append` writes. */
+    private fun archiveLine(frame: ByteArray, family: String = "whoop5"): String {
+        val hex = frame.joinToString("") { "%02x".format(it) }
+        return """{"capturedAtMs":1,"trim":1,"family":"$family","frameHex":"$hex"}""" + "\n"
+    }
+
+    /** The strict test: entirely-zero payload region -> yes; ONE non-zero byte anywhere -> no. */
+    @Test fun zeroPayloadDetectionIsStrictAndHeaderAware() {
+        val empty = whoop5Frame(22, payloadByte = 0)
+        assertTrue(
+            "the header and CRC bytes are non-zero but the PAYLOAD region is all zero",
+            RawHistoryArchive.hasZeroPayload(empty, com.noop.protocol.DeviceFamily.WHOOP5),
+        )
+        // A single populated byte in an otherwise-empty buffer is exactly what this archive is for.
+        val oneByte = empty.copyOf().also { it[21 + 40] = 1 }
+        assertFalse(
+            "'mostly zero' must NOT count as empty — one non-zero byte makes it informative",
+            RawHistoryArchive.hasZeroPayload(oneByte, com.noop.protocol.DeviceFamily.WHOOP5),
+        )
+        // The last payload byte, immediately before the CRC trailer, is inside the region.
+        val lastByte = empty.copyOf().also { it[it.size - 5] = 1 }
+        assertFalse(RawHistoryArchive.hasZeroPayload(lastByte, com.noop.protocol.DeviceFamily.WHOOP5))
+        // A payload region too short to judge is never called empty.
+        assertFalse(RawHistoryArchive.hasZeroPayload(
+            whoop5Frame(22, payloadByte = 0, payloadBytes = 8), com.noop.protocol.DeviceFamily.WHOOP5))
+        assertFalse(RawHistoryArchive.hasZeroPayload(
+            byteArrayOf(0xAA.toByte(), 1), com.noop.protocol.DeviceFamily.WHOOP5))
+        // The header length is family-aware: the puffin envelope is 4 bytes longer.
+        assertEquals(21, RawHistoryArchive.payloadStart(com.noop.protocol.DeviceFamily.WHOOP5))
+        assertEquals(17, RawHistoryArchive.payloadStart(com.noop.protocol.DeviceFamily.WHOOP4))
+    }
+
+    /**
+     * THE DEFECT. A 5/MG has been measured banking one all-zero record per second, so a purely
+     * age-ordered archive evicts everything informative within ~21 minutes. An informative frame must
+     * outrank an all-zero one of the SAME layout version, even when it is the OLDEST line in the file and
+     * the empties are the newest — so no floor can be what saves it.
+     */
+    @Test fun evictLinesEvictsZeroPayloadBeforeInformative() {
+        val informative = archiveLine(whoop5Frame(22, payloadByte = 0, marker = 0xE7))
+        val lines = ArrayList<String>()
+        lines.add(informative)
+        repeat(200) { lines.add(archiveLine(whoop5Frame(22, payloadByte = 0))) }
+
+        val kept = RawHistoryArchive.evictLines(lines, maxBytes = 4_096, floor = 2, zeroFloor = 2)
+        assertTrue(kept.sumOf { it.toByteArray(Charsets.UTF_8).size } <= 4_096)
+        assertTrue(
+            "the one informative line must survive a flood of all-zero-payload lines",
+            kept.contains(informative),
+        )
+        assertTrue("the zero-payload surplus must actually have been evicted", kept.size < 200)
+    }
+
+    /**
+     * A version whose records are ALL empty still keeps [zeroFloor] dated samples — enough to prove the
+     * artefact exists without letting it own the archive.
+     */
+    @Test fun allZeroVersionKeepsItsSmallFloor() {
+        val lines = ArrayList<String>()
+        repeat(200) { lines.add(archiveLine(whoop5Frame(22, payloadByte = 0))) }
+        repeat(200) { i -> lines.add(archiveLine(whoop5Frame(18, payloadByte = 0, marker = (i and 0xFF).coerceAtLeast(1)))) }
+
+        val kept = RawHistoryArchive.evictLines(lines, maxBytes = 4_096, floor = 2, zeroFloor = 2)
+        val keptZeroVersion = kept.count { it.contains("2f16") }   // 0x2f = type 47, 0x16 = v22
+        assertTrue(
+            "an all-empty version must keep its small floor, not vanish (kept $keptZeroVersion)",
+            keptZeroVersion >= 2,
+        )
+    }
+
+    /** The eviction target is a low-water mark below the cap, not the cap itself — see LOW_WATER_DIVISOR. */
+    @Test fun evictionLeavesHeadroomSoAOneHzStreamDoesNotRewriteEveryRecord() {
+        val lines = (0 until 400).map { jsonl(18, filler = "%02x".format(it and 0xFF)) }
+        val kept = RawHistoryArchive.evictLines(lines, maxBytes = 4_096, floor = 2)
+        val bytes = kept.sumOf { it.toByteArray(Charsets.UTF_8).size }
+        assertTrue("must fit the cap", bytes <= 4_096)
+        assertTrue(
+            "must evict PAST the cap to 7/8 of it, or every subsequent batch rewrites the whole file",
+            bytes <= 4_096 - 4_096 / RawHistoryArchive.LOW_WATER_DIVISOR,
+        )
+    }
+
+    /** The shipped floors are the documented ones, and the zero floor is far smaller than the real one. */
+    @Test fun shippedFloors() {
+        assertEquals(64, RawHistoryArchive.PER_VERSION_FLOOR)
+        assertEquals(8, RawHistoryArchive.ZERO_PAYLOAD_FLOOR)
+        assertTrue(RawHistoryArchive.ZERO_PAYLOAD_FLOOR < RawHistoryArchive.PER_VERSION_FLOOR)
+        assertEquals(5L * 1024 * 1024, RawHistoryArchive.REJECTED_ARCHIVE_MAX_BYTES)
     }
 
     @Test fun versionByteReadsTheRightIndexPerFamily() {

--- a/android/app/src/test/java/com/noop/protocol/UnmappedHistoricalLayoutTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/UnmappedHistoricalLayoutTest.kt
@@ -1,0 +1,154 @@
+package com.noop.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The archive decision for a WHOOP 5/MG type-47 record must be made on its LAYOUT VERSION, not on what
+ * the record happened to decode to. Twin of the Swift `UnmappedHistoricalLayoutTests`.
+ *
+ * [rejectedHistoricalRecords] used to ask only "did [decodeHistorical] produce a record?". That screen is
+ * the wrong QUESTION for a layout NOOP has no field map for: a record from an unmapped version that
+ * answered yes would be kept NOWHERE — not as rows (nothing mapped it) and not as bytes (it passed the
+ * archive filter) — and the strap frees it on the very next trim ack. A record type NOOP has not mapped
+ * yet — banked to flash by a newer firmware and pulled back in a later offload — is exactly the shape
+ * that can look well-formed enough to pass.
+ *
+ * The screen survives in practice only because of an accident: [decodeWhoop5Historical] returns null for
+ * every version but 18 (`unmappedLayoutsDecodeNothing` pins that this is true right now). One added
+ * static field for type 47, or one partially-mapped new version, would silently reopen the hole. These
+ * pin the version-based decision instead, so the archive no longer depends on that accident holding.
+ */
+class UnmappedHistoricalLayoutTest {
+
+    private fun bytes(s: String): ByteArray = s.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+
+    // A real WHOOP 5/MG type-47 v18 record (from Whoop5HistoricalDecodeTest): decodes a real unix, a
+    // plausible heart rate and a ~1 g gravity vector — i.e. it PASSES the old decode-outcome screen.
+    private val whoop5V18Hex =
+        "aa01740001003fb12f1280733d8401b69f266a66460066025a0265020000000000007b0a8d656463ff0012163cf6a439bf2924fd3ed763fe3e3200aa000000000000000000f7000901f10b0007010c020c00000000000000000000000000000000000000000000000100656f1e1e0000009d61a7c00000003e862817"
+
+    /**
+     * Re-stamp the WHOOP 5 CRC32 trailer after mutating the version byte, so the frame stays CRC-VALID.
+     * Load-bearing for every test here: a CRC failure is archived on its own, which would make the
+     * version-based path untestable.
+     */
+    private fun whoop5FrameWithVersion(version: Int): ByteArray {
+        val f = bytes(whoop5V18Hex)
+        f[9] = version.toByte()
+        val payloadEnd = f.size - 4
+        val c = Crc.crc32(f, 8, payloadEnd)
+        for (b in 0 until 4) f[payloadEnd + b] = ((c shr (8 * b)) and 0xFF).toByte()
+        return f
+    }
+
+    // MARK: - defect: an unmapped layout that decodes real biometrics must still be archived
+
+    /**
+     * The headline case. The frame's BYTES are a real v18 record — at the v18 offsets they carry a valid
+     * unix, a plausible heart rate and a ~1 g gravity vector, the exact combination that made the old
+     * screen say "decodable, nothing lost". Only the layout-version byte differs. Whatever such a record
+     * decodes to, its bytes must reach the archive.
+     */
+    @Test fun unmappedLayoutIsArchivedEvenThoughItsBytesDecodeCleanlyAsV18() {
+        // Precondition: read as its true version, this record decodes everything the old screen wanted.
+        val asV18 = decodeHistorical(bytes(whoop5V18Hex), DeviceFamily.WHOOP5)!!
+        assertEquals("precondition: these bytes DO decode a unix", 1780916150, asV18["unix"])
+        assertEquals("precondition: these bytes DO decode a heart rate", 102, asV18["heart_rate"])
+        assertTrue("precondition: these bytes DO decode a gravity vector", asV18["gravity_x"] is Double)
+
+        val unmapped = whoop5FrameWithVersion(22)
+        assertEquals(
+            "precondition: the record is CRC-VALID, so only the layout decision can archive it",
+            true, Framing.parseFrame(unmapped, DeviceFamily.WHOOP5).crcOk,
+        )
+        assertTrue(isUnmappedWhoop5HistoricalRecord(unmapped))
+        assertEquals(
+            "a record from a layout NOOP cannot map must be archived whatever it decoded",
+            listOf(unmapped.toList()),
+            rejectedHistoricalRecords(listOf(unmapped), DeviceFamily.WHOOP5).map { it.toList() },
+        )
+    }
+
+    /** Every version outside [MAPPED_WHOOP5_HISTORICAL_VERSIONS] is archived — no gaps, no lucky values. */
+    @Test fun everyUnmappedVersionIsArchived() {
+        for (v in 0..255) {
+            if (v in MAPPED_WHOOP5_HISTORICAL_VERSIONS) continue
+            val f = whoop5FrameWithVersion(v)
+            assertEquals(
+                "hist_version $v has no field map, so its bytes must be archived",
+                1, rejectedHistoricalRecords(listOf(f), DeviceFamily.WHOOP5).size,
+            )
+        }
+    }
+
+    // MARK: - lockstep: the version set and the decoder's dispatch cannot drift apart
+
+    /**
+     * [MAPPED_WHOOP5_HISTORICAL_VERSIONS] is the single source of truth for the archive decision, so it
+     * must not claim more (or fewer) versions than the decoder actually maps. Proved from the decoder's
+     * own behaviour: EVERY version outside the set decodes to nothing at all.
+     */
+    @Test fun unmappedLayoutsDecodeNothing() {
+        for (v in 0..255) {
+            if (v in MAPPED_WHOOP5_HISTORICAL_VERSIONS) continue
+            assertNull(
+                "v$v is outside the mapped set but the decoder produced a record for it — the set and " +
+                    "the version gate in decodeWhoop5Historical have drifted",
+                decodeHistorical(whoop5FrameWithVersion(v), DeviceFamily.WHOOP5),
+            )
+        }
+    }
+
+    /**
+     * The mapped versions ARE recognised as mapped (the other direction of the lockstep).
+     *
+     * ⚠️ This set is {18, 26}, NOT the Swift `[18, 20, 21, 26]`. Swift dispatches v20 (raw optical) and
+     * v21 (raw 6-axis IMU) through `decodeWhoop5HistoricalV2021`; the Kotlin historical path has no such
+     * branch — `Whoop5RawOptical`/`Whoop5RawImu` are wired to the LIVE deep-buffer route, not to the
+     * type-47 historical dispatch. Claiming 20/21 here would assert a field map Android does not have.
+     * Update BOTH this assertion and the constant when a v20/v21 historical decoder lands on this side.
+     */
+    @Test fun mappedVersionsAreNotTreatedAsUnmapped() {
+        assertEquals(setOf(18, 26), MAPPED_WHOOP5_HISTORICAL_VERSIONS)
+        for (v in MAPPED_WHOOP5_HISTORICAL_VERSIONS) {
+            assertFalse(
+                "v$v has a field map and must not be archived on layout grounds",
+                isUnmappedWhoop5HistoricalRecord(whoop5FrameWithVersion(v)),
+            )
+        }
+    }
+
+    /**
+     * A cleanly-decoding v18 record is still NOT archived — widening the screen must not start archiving
+     * the layouts NOOP already understands wholesale. v26 keeps its own exclusion (raw PPG has a durable
+     * `ppgWaveformSample` stream; it is known-skipped, not lost).
+     */
+    @Test fun mappedRecordsAreStillNotArchived() {
+        assertTrue(rejectedHistoricalRecords(listOf(bytes(whoop5V18Hex)), DeviceFamily.WHOOP5).isEmpty())
+        assertTrue(rejectedHistoricalRecords(listOf(whoop5FrameWithVersion(26)), DeviceFamily.WHOOP5).isEmpty())
+    }
+
+    /**
+     * The layout rule is WHOOP 5-only: it keys off `frame[9]`, which on a WHOOP 4 frame is a payload byte,
+     * not a version. WHOOP 4's unmapped versions go through the validated v24 fallback in
+     * [decodeHistorical], which keeps a record only when it decodes to a ~1 g gravity vector and a
+     * plausible HR and otherwise drops the biometrics — so those records reach the archive by the
+     * decode-outcome route and must not be dragged in by this one.
+     */
+    @Test fun whoop4FramesAreUnaffectedByTheWhoop5LayoutRule() {
+        // A synthetic WHOOP 4 V24 type-47 record (HR=63) that decodes cleanly.
+        val v24Hex =
+            "aa5a008e2f18000000000000f153650000000000003f0152030000000000000000dc053075" +
+                "000000cdcc4c3dcdcccc3d5a657e3f00000040cdcc4c3dcdcccc3d5a657e3f504668428403" +
+                "200364006400b80bb80b000000000000c25c1a88"
+        assertTrue(rejectedHistoricalRecords(listOf(bytes(v24Hex)), DeviceFamily.WHOOP4).isEmpty())
+        assertFalse(
+            "a WHOOP 4 frame has no type-47 byte at index 8 — the rule must not fire on it",
+            isUnmappedWhoop5HistoricalRecord(bytes(v24Hex)),
+        )
+    }
+}


### PR DESCRIPTION
The reject archive (#77 / #91) is the only surviving copy of a HISTORICAL_DATA record NOOP cannot
turn into rows — the strap frees its copy the instant we ack the trim. Two ways a record can still be
lost through it. Both are pre-existing; one is currently held shut by an accident, the other is
reproducible on a WHOOP 5/MG today.

This PR is protocol + storage only. No UI, no schema migration, no BLE command changes.

## 1. An unmapped layout is screened on the wrong question

`rejectedHistoricalRecords` archives a type-47 record only when the DECODE came up short — parse
failed, CRC mismatched, or the result had no `unix`, or neither `heart_rate` nor `gravity_x`. That is
the wrong question to ask about a layout NOOP has no field map for. A record whose `hist_version` is
unmapped but which happens to yield a plausible `unix` plus one of those fields passes the screen and
is then kept **nowhere at all** — not as rows (nothing mapped it) and not as bytes (it was not
archived) — and the very next trim ack frees it on the strap.

Today that cannot fire, but only by accident: the unmapped branch of `decodeWhoop5Historical` reads
no offsets, so nothing but `hist_version` ever reaches `parsed` for such a record. One added static
schema field for type 47, or one partially-mapped new version, silently reopens it.

The decision is now structural rather than incidental. `mappedWhoop5HistoricalVersions`
(`[18, 20, 21, 26]`) is the single source of truth behind both the decoder's dispatch and the archive
filter, and any 5/MG record outside it is archived whatever it decoded. The if-chain in
`decodeWhoop5Historical` became a `switch` so the mapped versions are readable in one place.

- v18/v20/v21/v26 are unaffected — nothing already understood starts being archived wholesale.
- WHOOP 4 is untouched. Its unmapped versions go through the schema's v24 fallback, which keeps a
  record only when it validates physiologically and otherwise drops the biometrics, so those records
  already reach the archive by the decode-outcome route. The new rule keys off `frame[9]`, which on a
  WHOOP 4 frame is a payload byte, not a version — a test pins that it never fires there.

`UnmappedHistoricalLayoutTests` pins both directions, including a lockstep check that for **every**
version outside the mapped set the decoder populates nothing but `hist_version` — so the constant and
the dispatch `switch` cannot drift apart without a test failing.

The headline test takes a real v18 record, changes only the version byte, re-stamps the CRC32 trailer
so the frame stays valid, and asserts it is archived. Read at the v18 offsets those same bytes decode
a valid `unix`, a plausible heart rate and a ~1 g gravity vector — i.e. exactly the record that used
to pass the screen and be kept nowhere.

## 2. Records with an all-zero payload evict the informative ones

The archive is a ~5 MB rolling JSONL and eviction was purely age-ordered (below a per-version floor,
#344). Measured on a WHOOP 5/MG offload:

- **1,275 consecutive** type-47 records, layout version **16**, **1584 bytes** each, with **every byte
  from offset 21 to the 4-byte CRC32 trailer zero in every one of them**.
- The records' own frame clock advanced by **1 s across 933** of the gaps and **0 s across the other
  339** — a contiguous 1 Hz producer, not a burst.
- At ~3.2 KB per hex JSONL line, the 5 MB archive holds about 1,500 of these, i.e. **~21 minutes** of
  retention. Under an age-ordered policy every informative record older than that is gone, evicted by
  frames that carry nothing.

Eviction is now weakest-value-first. Everything in a band goes before anything in the next:

1. malformed lines (unparseable — no version, no floor);
2. surplus lines whose payload region is **entirely** zero, oldest first;
3. surplus informative lines, oldest first;
4. floor-protected lines, never evicted: the newest 64 **informative** lines per layout version, plus
   the newest 8 **zero-payload** lines per layout version.

The split floor matters in both directions: a version whose records are only ever empty still keeps a
few dated samples, so the archive proves the artefact exists rather than erasing it, while the full
64 stays reserved for records that actually contain something.

The emptiness test is deliberately **strict** — one non-zero byte anywhere in the region makes the
frame informative. A novel record carrying one small populated block inside an otherwise-empty buffer
is precisely what this archive exists to catch, so "mostly zero" is not the test. The region starts
**after** the record header (offset 21 on 5/MG, 17 on WHOOP 4 — the same +4 that shifts the type byte
4→8 and the version byte 5→9) and ends before the CRC trailer; a region that included the non-zero
seq/timestamp bytes would never test as all-zero and the rule would never fire. A payload region
shorter than 32 bytes is not judged at all, so a truncated frame does not lose priority on the
strength of a few zero bytes.

Two smaller things came with it:

- **The 5 MB cap is deliberately NOT raised.** At ~3.2 KB a line, a 1 Hz stream fills any cap in
  hours; a bigger number buys a linear factor of time and costs every user disk. Value, not volume,
  was the missing thing.
- **Eviction now goes to 7/8 of the cap, not exactly the cap.** An archive sitting *at* the cap did a
  full read-parse-rewrite of the whole file on every subsequent batch — and during an offload those
  batches arrive on the main actor at up to one record per strap-second. The bytes given up are the
  ones eviction would have taken next anyway, in the same priority order.

`readAll` and retention now share one `parseArchiveLine`, so retention can never protect a line the
read-back would then skip.

## Cross-platform

Both halves have their Kotlin twins in the same PR, per the parity contract.

One deliberate divergence, documented at the declaration and asserted in the test:
`MAPPED_WHOOP5_HISTORICAL_VERSIONS` is `{18, 26}` on Android, not Swift's `{18, 20, 21, 26}`. Swift
dispatches v20 (raw optical) and v21 (raw IMU) through `decodeWhoop5HistoricalV2021`; the Kotlin
historical path has no such branch — `Whoop5RawOptical` / `Whoop5RawImu` exist there but are wired to
the live deep-buffer route, not to the type-47 historical dispatch. Claiming 20/21 on Android would
assert a field map that platform does not have, which is the exact class of bug this constant closes.
The archive OUTCOME is identical today either way: an unmapped 5/MG version already decodes to null on
Android and so already reached the archive by the decode-outcome route.

`evictLines` takes `zeroFloor` defaulted on both sides, so no existing call site churns.

## Verification

```
$ cd Packages/WhoopProtocol && swift test
Executed 537 tests, with 0 failures (0 unexpected) in 4.644 (5.056) seconds

$ xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand \
    -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test
Executed 1032 tests, with 1 test skipped and 0 failures (0 unexpected)
** TEST SUCCEEDED **

$ cd android && ./gradlew testFullDebugUnitTest
BUILD SUCCESSFUL in 15m 56s
3506 tests, 0 failures, 5 skipped
  RawHistoryArchiveEvictionTest    9 tests, 0 failures
  UnmappedHistoricalLayoutTest     6 tests, 0 failures

$ python3 Tools/doc_comment_lint.py
OK no NEW detached doc comments (1473 files, 25 baselined site(s) remaining)

$ python3 Tools/i18n_audit.py
exit 0 — no user-facing strings added, so no catalog changes
```

App-target Swift is touched (`Strand/Collect/RawHistoryArchive.swift`), which `swift-packages.yml`
does not cover, so the macOS app was built and its test target run locally as shown above.

**Not validated on a strap.** Nothing here touches the CoreBluetooth path, the offload sequence, or
any command sent to the device — the change is in what the phone decides to keep on disk after the
frames have already arrived. The 1,275-frame observation above comes from a real 5/MG offload; the
retention behaviour itself is pinned by unit tests on synthetic frames.
