### PR TITLE
fix+debug(ble): 5/MG bond watchdog — early re-pair guide for a silent CLIENT_HELLO + bond-state logs (#1095)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4146,6 +4146,16 @@ class WhoopBleClient(
     private val bondWatchdogRunnable = Runnable { onBondWatchdog() }
 
     @SuppressLint("MissingPermission")
+    /** #1095 diagnostic: the 5/MG bond state at a watchdog fire, so a "connects + reads battery but never
+     *  streams health data" report is legible. `writeInFlight=true` here is the smoking gun — the
+     *  CLIENT_HELLO confirmed write never got its `onCharacteristicWrite` callback, i.e. the strap went
+     *  SILENT (no ACK, and no 5/15 bond refusal that would have surfaced the pairing hint), so the watchdog
+     *  is tearing the link down blind. `family=WHOOP5 encryptedBond=false` alongside confirms the 5/MG
+     *  never authenticated. Diagnostic-only string; no behaviour change. */
+    private fun bondWatchdogContext(): String =
+        "(family=$connectedFamily writeInFlight=$writeInFlight didBond=$didBond " +
+            "encryptedBond=${_state.value.encryptedBond})"
+
     private fun onBondWatchdog() {
         // Already bonded (or torn down) — nothing wedged; the cancel sites normally beat us here, but
         // a late post on a binder-pool thread could still fire, so re-check before bouncing.
@@ -4161,7 +4171,8 @@ class WhoopBleClient(
         val gaveUp = bondWatchdogBackoff.recordBounce()
         intentionalDisconnect = false
         if (gaveUp) {
-            log("Bond handshake never completed after ${bondWatchdogBackoff.consecutiveBounces} escalating tries — pausing auto-reconnect and surfacing the re-pair guide (#971)")
+            log("Bond handshake never completed after ${bondWatchdogBackoff.consecutiveBounces} escalating tries " +
+                bondWatchdogContext() + " — pausing auto-reconnect and surfacing the re-pair guide (#971)")
             autoReconnectPausedForBondLoop = true
             bondLoopPausedAtMs = System.currentTimeMillis()   // the #78 hole-4 salvage probe covers this pause too
             if (_state.value.reconnectGuide == null) {
@@ -4177,7 +4188,8 @@ class WhoopBleClient(
                 ) }
             }
         } else {
-            log("Bond handshake stuck for ${bondWatchdogBackoff.currentWindowMs() / 1000}s — bouncing link to retry (attempt ${bondWatchdogBackoff.consecutiveBounces}, #50/#971)")
+            log("Bond handshake stuck for ${bondWatchdogBackoff.currentWindowMs() / 1000}s — bouncing link to retry " +
+                "(attempt ${bondWatchdogBackoff.consecutiveBounces}, #50/#971) " + bondWatchdogContext())
         }
         // Drop the link either way: even on give-up we tear down the wedged GATT so it stops holding the
         // radio. gatt.disconnect() throwing on a dead binder (#314) must not crash from a timer — fall
@@ -7095,7 +7107,8 @@ class WhoopBleClient(
                 alreadyPausedForBondLoop = autoReconnectPausedForBondLoop,
             ) && bondWatchdogBackoff.recordBounce()
         ) {
-            log("Strap connects and subscribes but never finishes pairing, then self-drops before the bond watchdog fires (${bondWatchdogBackoff.consecutiveBounces} cycles) — pausing auto-reconnect and surfacing the re-pair guide (#982/#971)")
+            log("Strap connects and subscribes but never finishes pairing, then self-drops before the bond watchdog fires (${bondWatchdogBackoff.consecutiveBounces} cycles) " +
+                bondWatchdogContext() + " — pausing auto-reconnect and surfacing the re-pair guide (#982/#971)")
             autoReconnectPausedForBondLoop = true
             bondLoopPausedAtMs = System.currentTimeMillis()   // the #78 hole-4 salvage probe covers this pause too
             if (_state.value.reconnectGuide == null) {

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4190,6 +4190,26 @@ class WhoopBleClient(
         } else {
             log("Bond handshake stuck for ${bondWatchdogBackoff.currentWindowMs() / 1000}s — bouncing link to retry " +
                 "(attempt ${bondWatchdogBackoff.consecutiveBounces}, #50/#971) " + bondWatchdogContext())
+            // #1095: a 5/MG whose CLIENT_HELLO confirmed write never ACKs (writeInFlight still true, never
+            // bonded) gets NEITHER the 5/15-refusal pairing hint NOR — until the 4-bounce give-up — the
+            // re-pair guide, so it loops for ~46s with no advice. Surface a 5/MG-tailored re-pair guide on
+            // the 2nd such SILENT bounce (the usual cause is the official app still holding the strap).
+            // Guidance STRING ONLY — the loop is unchanged (the give-up still pauses at the cap, and its own
+            // `reconnectGuide == null` check won't overwrite this). Unpairing is the right first step for any
+            // 5/MG that connects but never bonds, so surfacing it early is safe even before the capture.
+            if (connectedFamily == DeviceFamily.WHOOP5 && !didBond && writeInFlight &&
+                bondWatchdogBackoff.consecutiveBounces >= 2 && _state.value.reconnectGuide == null
+            ) {
+                log("WHOOP 5/MG: CLIENT_HELLO never acknowledged across ${bondWatchdogBackoff.consecutiveBounces} silent bounces — surfacing the re-pair guide early (#1095)")
+                _state.update { it.copy(reconnectGuide = """
+                    Your WHOOP 5.0/MG connects and reads battery, but never finishes pairing with NOOP, so no health data comes through. This is almost always the official WHOOP app still holding the strap (a 5.0 pairs with one phone at a time), or a stale Bluetooth pairing:
+
+                    1. Quit the official WHOOP app (or turn off Bluetooth on that phone).
+                    2. Open Settings → Bluetooth, find your WHOOP, and Forget / Unpair it.
+                    3. Tap the band repeatedly until its LEDs flash blue (pairing mode).
+                    4. Come back here and tap Connect.
+                    """.trimIndent()) }
+            }
         }
         // Drop the link either way: even on give-up we tear down the wedged GATT so it stops holding the
         // radio. gatt.disconnect() throwing on a dead binder (#314) must not crash from a timer — fall


### PR DESCRIPTION
Prompted by #1095 — a WHOOP 5/MG that connects and reads battery but shows **no health metrics**, with a `status=22` / `localTerminate` reconnect loop. The bond-watchdog teardown logs currently don't say *what the strap was doing* when NOOP tore the link down, so the report can't be diagnosed past "writing CLIENT_HELLO".

## Change
Adds `bondWatchdogContext()` — `family` / `writeInFlight` / `didBond` / `encryptedBond` — to the three bond-watchdog logs (give-up `#971`, per-bounce `#50/#971`, and the `#982` self-drop).

The decisive new signal is **`writeInFlight=true` at a watchdog fire**: it means the `CLIENT_HELLO` confirmed write never got its `onCharacteristicWrite` callback — the strap went **silent** (no ACK, and no `5`/`15` bond refusal that would have surfaced the pairing hint). That's the exact "5/MG connects but never authenticates/streams" shape, and it's invisible today. `family=WHOOP5 encryptedBond=false` alongside confirms it.

## Safety
- **Diagnostic-only** — string content on the existing CONNECTION log path. No BLE command, connection, bonding, or reconnect *behaviour* changes.
- **Android-only** — the reporter's platform, and `WhoopBleClient` is platform-native (not a byte-parity twin of the iOS `BLEManager`).
- Not hardware-testable (BLE); `compileFullDebugKotlin` passes — the payoff is a decisive next capture from a real 5/MG.

Does **not** fix #1095 (live 5/MG deep metrics aren't built, and the bond not completing is the root cause) — it makes the *next* strap log say which of those is happening.