### PR TITLE
Fix empty macOS "Choose a backup" restore sheet (#1093)

### DIFF
--- a/Strand/Screens/BackupSyncView.swift
+++ b/Strand/Screens/BackupSyncView.swift
@@ -308,6 +308,16 @@ private struct RestorePickerSheet: View {
                 }
             }
         }
+        // A macOS `.sheet` sizes to its content's ideal height, and a `List` inside a `NavigationStack`
+        // reports a near-zero intrinsic height there — so without an explicit frame the sheet collapses
+        // to just the title + Cancel and clips every row, leaving the user an empty "Choose a backup"
+        // with backups that ARE in the folder (the caller only opens this sheet when the list is
+        // non-empty). Give it a real size, the same way `AddDeviceWizard`/`HealthView` frame their macOS
+        // sheets with a fixed size. iOS/iPadOS sheets already take a sensible height, so the frame is
+        // macOS-only. A longer backup list scrolls within the List; a short one leaves trailing space. (#1093)
+        #if os(macOS)
+        .frame(width: 460, height: 420)
+        #endif
     }
 
     /// The row's headline: a friendly date when we resolved one, else the filename (never the epoch date).


### PR DESCRIPTION
## What

Fixes #1093 — on macOS, **Backup & Sync → Restore from a backup…** opens an empty "Choose a backup" sheet (just a Cancel button), even when the folder contains backups.

## Root cause

`RestorePickerSheet` is a `NavigationStack { List(snapshots) }` presented as a `.sheet` with **no explicit frame** (`Strand/Screens/BackupSyncView.swift`). On macOS a `.sheet` sizes to its content's ideal height, and a `List` inside a `NavigationStack` reports a near-zero intrinsic height there — so the sheet collapses to just the title + Cancel toolbar and clips every row.

This is **not** an empty-data case: `openRestorePicker()` only presents the sheet when `listSnapshots()` is non-empty (an empty folder shows a "No backups found" alert instead). So a user with real backups in the folder gets a blank sheet and a dead end — exactly the report.

macOS-specific: iOS/iPadOS sheets take a sensible height on their own, which is why there's no iOS report.

## Fix

Give the sheet content a fixed size on macOS, the same way `AddDeviceWizard` (`.frame(width: 480, height: 760)`) and `HealthView` (`.frame(width: 900, height: 820)`) frame their macOS sheets:

```swift
#if os(macOS)
.frame(width: 460, height: 420)
#endif
```

`BackupSyncView` is shared with iOS, so the frame is `#if os(macOS)`-guarded to leave iOS untouched. A longer backup list scrolls within the `List`; a short one leaves trailing space.

## Scope / parity

- macOS UI rendering only — no analytics, no stored data, no migration, no BLE, no new strings. Nothing to mirror on Android (the bug is a SwiftUI-on-macOS sheet-sizing behavior).
- One concern. (The related discoverability gap — the folder-restore only reads the *configured* Backup & Sync folder, while **Settings → Import** browses to any `.noopbak` — is left as-is; that's the reporter's immediate workaround.)

## Verification

Change is app-target Swift (`Strand/Screens/`), so the default `swift-packages` CI does **not** compile it. Fix is by inspection + matches the codebase's existing macOS-sheet framing convention (fixed `width`/`height`); the collapse itself is a well-known SwiftUI-on-macOS `List`-in-sheet behavior. Needs a **macOS build** (local or on-demand `app-build.yml`) to confirm the compile, and a real macOS render to confirm the rows now show.