### PR TITLE
Resolve a non-WHOOP device's family from its brand, not a fall-through (#1086)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/DeviceFamily.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/DeviceFamily.swift
@@ -154,6 +154,24 @@ public extension DeviceFamily {
         }
     }
 
+    /// Brand-aware family resolution (#1086). Returns `nil` for a positively non-WHOOP brand (e.g.
+    /// "Oura", "Apple") — `DeviceFamily` has only `.whoop4`/`.whoop5`, so it cannot represent "not a
+    /// WHOOP", and letting such a device fall through to `.whoop5` is exactly the #171 mistake (a family
+    /// question answered by a fall-through rather than by evidence). The row already carries the answer:
+    /// `PairedDevice.brand` is set from `DeviceBrandCatalog`.
+    ///
+    /// A nil/empty brand or the legacy "WHOOP" label (written identically for 4.0 and 5/MG) carries no
+    /// non-WHOOP signal, so it defers to `forRegistryModel`. Callers that need a concrete family for a
+    /// non-WHOOP device (e.g. the skin-temp raw→°C scale, where a non-WHOOP reading shares the non-4.0
+    /// branch) coalesce the nil to `.whoop5`, matching the prior behaviour exactly. Mirrors the Kotlin
+    /// `DeviceFamily.forRegistryDevice`.
+    static func forRegistryDevice(model: String?, brand: String?) -> DeviceFamily? {
+        if let brand, !brand.isEmpty, brand.caseInsensitiveCompare("WHOOP") != .orderedSame {
+            return nil
+        }
+        return forRegistryModel(model)
+    }
+
     /// The header-CRC algorithm this family uses. This is the single switch that the family-aware
     /// `verifyFrame`/`parseFrame` overloads branch on; the payload CRC32 is identical for both.
     var headerCRCKind: HeaderCRCKind {

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/RegistryModelFamilyTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/RegistryModelFamilyTests.swift
@@ -39,10 +39,54 @@ final class RegistryModelFamilyTests: XCTestCase {
         XCTAssertEqual(DeviceFamily.forRegistryModel("WHOOP"), .whoop5)
     }
 
+    /// Model-ONLY resolution is brand-blind: an Oura/Garmin model string has no WHOOP spelling, so it
+    /// lands on the `.whoop5` default. This is why a non-WHOOP device needs `forRegistryDevice` (#1086) —
+    /// the brand is the evidence the model string lacks.
     func testNilEmptyAndGarbageFallBackToWhoop5() {
         XCTAssertEqual(DeviceFamily.forRegistryModel(nil), .whoop5)
         XCTAssertEqual(DeviceFamily.forRegistryModel(""), .whoop5)
         XCTAssertEqual(DeviceFamily.forRegistryModel("Oura Ring Gen3"), .whoop5)
         XCTAssertEqual(DeviceFamily.forRegistryModel("garmin-hrm"), .whoop5)
+    }
+
+    // MARK: - Brand-aware resolution (#1086) — a non-WHOOP brand must NOT resolve to a WHOOP family
+
+    /// The core of #1086: an Oura ring carries `brand == "Oura"`, so it resolves to `nil` (not a WHOOP)
+    /// instead of silently falling through to `.whoop5`, whatever its model string. Because the brand is
+    /// tested BEFORE the model switch, every generation resolves to `nil` — no model-string enumeration
+    /// to keep in sync with new rings (Oura Ring 3/4/5 and the cloud fallback are all one code path).
+    func testNonWhoopBrandResolvesToNil() {
+        for model in ["Oura Ring 3", "Oura Ring 4", "Oura Ring 5", "Oura (cloud)"] {
+            XCTAssertNil(DeviceFamily.forRegistryDevice(model: model, brand: "Oura"),
+                         "Oura model \(model) must not resolve to a WHOOP family")
+        }
+        XCTAssertNil(DeviceFamily.forRegistryDevice(model: nil, brand: "Garmin"))
+        XCTAssertNil(DeviceFamily.forRegistryDevice(model: "Watch", brand: "Apple"))
+    }
+
+    /// A WHOOP brand still resolves by model spelling, exactly as `forRegistryModel` does.
+    func testWhoopBrandResolvesByModel() {
+        XCTAssertEqual(DeviceFamily.forRegistryDevice(model: "4.0", brand: "WHOOP"), .whoop4)
+        XCTAssertEqual(DeviceFamily.forRegistryDevice(model: "WHOOP 4.0", brand: "WHOOP"), .whoop4)
+        XCTAssertEqual(DeviceFamily.forRegistryDevice(model: "5.0 MG", brand: "WHOOP"), .whoop5)
+        XCTAssertEqual(DeviceFamily.forRegistryDevice(model: "WHOOP 5.0 / MG", brand: "WHOOP"), .whoop5)
+    }
+
+    /// A nil/empty brand carries no non-WHOOP signal (legacy rows, WHOOP straps), so it defers to the
+    /// model mapping — never `nil`.
+    func testMissingBrandDefersToModel() {
+        XCTAssertEqual(DeviceFamily.forRegistryDevice(model: "4.0", brand: nil), .whoop4)
+        XCTAssertEqual(DeviceFamily.forRegistryDevice(model: "5.0 MG", brand: ""), .whoop5)
+        XCTAssertEqual(DeviceFamily.forRegistryDevice(model: nil, brand: nil), .whoop5)
+    }
+
+    /// "No scoring change" half of #1086: every consumer coalesces a non-WHOOP `nil` to `.whoop5` (the
+    /// non-4.0 skin-temp scale), so the family a non-WHOOP row is *treated as* is identical to before the
+    /// brand-aware resolver existed. Guards the skin-temp/day-owner call sites against a scale regression.
+    func testNonWhoopCoalescesToPriorLabel() {
+        for model in ["Oura Ring 3", "Oura Ring 4", "Oura Ring 5"] {
+            XCTAssertEqual(DeviceFamily.forRegistryDevice(model: model, brand: "Oura") ?? .whoop5,
+                           DeviceFamily.forRegistryModel(model), "\(model) treated-as family must be unchanged")
+        }
     }
 }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1605,9 +1605,12 @@ final class IntelligenceEngine: ObservableObject {
 
     /// The strap family that wrote `owner`'s skin-temp rows (#938), so the nightly funnel converts the raw
     /// register on the right scale. The model-label → family mapping (and the `.whoop5` fallback for
-    /// unknowns) lives in `DeviceFamily.forRegistryModel` (#171).
+    /// unknowns) lives in `DeviceFamily.forRegistryDevice` (#171, #1086).
     nonisolated static func skinTempFamily(forOwner owner: String, devices: [PairedDevice]) -> DeviceFamily {
-        DeviceFamily.forRegistryModel(devices.first(where: { $0.id == owner })?.model)
+        let d = devices.first(where: { $0.id == owner })
+        // Non-WHOOP owner (nil) shares the non-4.0 temp scale, so coalesce to `.whoop5` — same conversion
+        // as before; the brand-aware resolver just no longer mislabels the owner as a WHOOP (#1086).
+        return DeviceFamily.forRegistryDevice(model: d?.model, brand: d?.brand) ?? .whoop5
     }
 
     /// #137: re-score under-sampled manual workouts. A `manual` workout is scored from the live HR

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1601,24 +1601,28 @@ final class Repository: ObservableObject {
 
     /// Map each device id to the strap family that wrote its rows (#938), for the family-aware skin-temp
     /// raw→°C conversion. Reads the registry ONCE; the model-label → family mapping (and the `.whoop5`
-    /// fallback for unknowns) lives in `DeviceFamily.forRegistryModel` (#171). Best-effort: an unreadable
+    /// fallback for unknowns) lives in `DeviceFamily.forRegistryDevice` (#171, #1086). Best-effort: an unreadable
     /// registry yields an empty map, so every caller falls back to `.whoop5`.
     private static func skinTempFamilies(store: WhoopStore, ids: [String]) -> [String: DeviceFamily] {
         let devices = (try? DeviceRegistryStore(dbQueue: store.registryWriter).all()) ?? []
         var out: [String: DeviceFamily] = [:]
         for id in ids {
-            out[id] = DeviceFamily.forRegistryModel(devices.first(where: { $0.id == id })?.model)
+            let d = devices.first(where: { $0.id == id })
+            // A non-WHOOP device (nil) shares the non-4.0 raw→°C branch, so it coalesces to `.whoop5` —
+            // the exact scale it got before; brand-awareness just stops it *claiming* to be a WHOOP (#1086).
+            out[id] = DeviceFamily.forRegistryDevice(model: d?.model, brand: d?.brand) ?? .whoop5
         }
         return out
     }
 
     /// Family of the ACTIVE strap (#623), for the deep timeline's family-specific empty-state copy. Reuses
-    /// the canonical `DeviceFamily.forRegistryModel` (#171) with its `.whoop5` fallback for nil/unknown/
+    /// the canonical `DeviceFamily.forRegistryDevice` (#171, #1086) with its `.whoop5` fallback for nil/unknown/
     /// ambiguous, matching Android's `FullDayChartScreen`. Best-effort: no store / unreadable registry → `.whoop5`.
     func activeStrapFamily() -> DeviceFamily {
         guard let store else { return .whoop5 }
         let devices = (try? DeviceRegistryStore(dbQueue: store.registryWriter).all()) ?? []
-        return DeviceFamily.forRegistryModel(devices.first(where: { $0.id == deviceId })?.model)
+        let d = devices.first(where: { $0.id == deviceId })
+        return DeviceFamily.forRegistryDevice(model: d?.model, brand: d?.brand) ?? .whoop5
     }
 
     /// Whether the active strap has EVER banked a sample of `metric` (#623) — distinguishes a strap that

--- a/android/app/src/main/java/com/noop/analytics/RegistryDayOwnerSource.kt
+++ b/android/app/src/main/java/com/noop/analytics/RegistryDayOwnerSource.kt
@@ -50,10 +50,12 @@ class RegistryDayOwnerSource(private val registry: DeviceRegistry) : Intelligenc
     override suspend fun activeWriteId(): String? = registry.activeDeviceId()
 
     // #938: resolve the strap family that wrote [deviceId]'s rows from its registry model. The model-label
-    // → family mapping (and the WHOOP5 fallback for unknowns) lives in DeviceFamily.forRegistryModel (#171).
+    // → family mapping (and the WHOOP5 fallback for unknowns) lives in DeviceFamily.forRegistryDevice (#171, #1086).
     // Mirrors the Swift IntelligenceEngine.skinTempFamily(forOwner:devices:).
     override suspend fun skinTempFamily(deviceId: String): DeviceFamily {
-        val model = registry.all().firstOrNull { it.id == deviceId }?.model
-        return DeviceFamily.forRegistryModel(model)
+        val d = registry.all().firstOrNull { it.id == deviceId }
+        // Non-WHOOP device (null) shares the non-4.0 temp scale, so coalesce to WHOOP5 — same conversion
+        // as before; brand-awareness just stops it claiming to be a WHOOP (#1086).
+        return DeviceFamily.forRegistryDevice(d?.model, d?.brand) ?: DeviceFamily.WHOOP5
     }
 }

--- a/android/app/src/main/java/com/noop/protocol/DeviceFamily.kt
+++ b/android/app/src/main/java/com/noop/protocol/DeviceFamily.kt
@@ -100,6 +100,24 @@ enum class DeviceFamily {
             else -> WHOOP5
         }
 
+        /**
+         * Brand-aware family resolution (#1086). Returns `null` for a positively non-WHOOP brand
+         * (e.g. "Oura", "Apple") — [DeviceFamily] has only [WHOOP4]/[WHOOP5], so it cannot represent
+         * "not a WHOOP", and letting such a device fall through to [WHOOP5] is exactly the #171
+         * mistake (a family question answered by a fall-through rather than by evidence). The row
+         * already carries the answer: `PairedDevice.brand` is set from `DeviceBrandCatalog`.
+         *
+         * A null/empty brand or the legacy "WHOOP" label (written identically for 4.0 and 5/MG)
+         * carries no non-WHOOP signal, so it defers to [forRegistryModel]. Callers that need a
+         * concrete family for a non-WHOOP device (e.g. the skin-temp raw→°C scale, where a non-WHOOP
+         * reading shares the non-4.0 branch) coalesce the null to [WHOOP5], matching the prior
+         * behaviour exactly. Mirrors the Swift `DeviceFamily.forRegistryDevice`.
+         */
+        fun forRegistryDevice(model: String?, brand: String?): DeviceFamily? {
+            if (!brand.isNullOrEmpty() && !brand.equals("WHOOP", ignoreCase = true)) return null
+            return forRegistryModel(model)
+        }
+
         /** Whoop 5.0 CLIENT_HELLO bytes (16 bytes). Exposed as a named constant for test/debug use. */
         val WHOOP5_CLIENT_HELLO: ByteArray = byteArrayOf(
             0xAA.toByte(), 0x01, 0x08, 0x00, 0x00, 0x01, 0xE6.toByte(), 0x71,

--- a/android/app/src/main/java/com/noop/ui/FullDayChartScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/FullDayChartScreen.kt
@@ -107,9 +107,11 @@ fun FullDayChartScreen(vm: AppViewModel, onBack: () -> Unit) {
     var everSpo2 by remember { mutableStateOf(true) }
     var everResp by remember { mutableStateOf(true) }
     LaunchedEffect(deviceId) {
-        val model = runCatching { vm.pairedDevices() }.getOrDefault(emptyList())
-            .firstOrNull { it.id == deviceId }?.model
-        val whoop5 = DeviceFamily.forRegistryModel(model) == DeviceFamily.WHOOP5
+        val d = runCatching { vm.pairedDevices() }.getOrDefault(emptyList())
+            .firstOrNull { it.id == deviceId }
+        // Non-WHOOP device (null) coalesces to WHOOP5 so this gate is unchanged from before; the
+        // brand-aware resolver just no longer claims a non-WHOOP device is a WHOOP (#1086).
+        val whoop5 = (DeviceFamily.forRegistryDevice(d?.model, d?.brand) ?: DeviceFamily.WHOOP5) == DeviceFamily.WHOOP5
         isWhoop5 = whoop5
         val now = System.currentTimeMillis() / 1000
         everSpo2 = !whoop5 || runCatching { vm.repo.spo2Samples(deviceId, 0, now, 1) }.getOrDefault(emptyList()).isNotEmpty()
@@ -397,11 +399,13 @@ private suspend fun readTimeline(
                 .mapNotNull { if (it.ir > 0) TimelinePoint(it.ts, it.red.toDouble() / it.ir) else null }
         TimelineMetric.SkinTemp -> {
             // #938: family-aware raw→°C — 5/MG centidegrees (raw/100, #156), a WHOOP 4.0 v24 raw ADC map.
-            // The registry-model-label → family mapping lives in DeviceFamily.forRegistryModel (#171).
+            // The registry-model-label → family mapping lives in DeviceFamily.forRegistryDevice (#171).
+            // A non-WHOOP device (null) shares the non-4.0 scale, so coalesce to WHOOP5 — same conversion
+            // as before; brand-awareness just stops it claiming to be a WHOOP (#1086).
             // Mirrors Swift Repository.timelineRawMetric.
-            val model = runCatching { vm.pairedDevices() }.getOrDefault(emptyList())
-                .firstOrNull { it.id == deviceId }?.model
-            val family = DeviceFamily.forRegistryModel(model)
+            val d = runCatching { vm.pairedDevices() }.getOrDefault(emptyList())
+                .firstOrNull { it.id == deviceId }
+            val family = DeviceFamily.forRegistryDevice(d?.model, d?.brand) ?: DeviceFamily.WHOOP5
             runCatching { repo.skinTempSamples(deviceId, from, to, 200_000) }.getOrDefault(emptyList())
                 .map { TimelinePoint(it.ts, skinTempCelsius(it.raw, family)) }
         }

--- a/android/app/src/test/java/com/noop/protocol/RegistryModelFamilyTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/RegistryModelFamilyTest.kt
@@ -49,9 +49,62 @@ class RegistryModelFamilyTest {
 
     @Test
     fun nullEmptyAndGarbageFallBackToWhoop5() {
+        // Model-ONLY resolution is brand-blind: an Oura/Garmin model string has no WHOOP spelling, so it
+        // lands on the WHOOP5 default. This is why a non-WHOOP device needs forRegistryDevice (#1086) —
+        // the brand is the evidence the model string lacks.
         assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel(null))
         assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel(""))
         assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel("Oura Ring Gen3"))
         assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel("garmin-hrm"))
+    }
+
+    // ── Brand-aware resolution (#1086) — a non-WHOOP brand must NOT resolve to a WHOOP family ──
+
+    /**
+     * The core of #1086: an Oura ring carries brand "Oura", so it resolves to null (not a WHOOP). The
+     * brand is tested BEFORE the model switch, so every generation resolves to null — no model-string
+     * enumeration to keep in sync with new rings (Oura Ring 3/4/5 and the cloud fallback are one path).
+     */
+    @Test
+    fun nonWhoopBrandResolvesToNull() {
+        for (model in listOf("Oura Ring 3", "Oura Ring 4", "Oura Ring 5", "Oura (cloud)")) {
+            assertEquals("Oura model $model must not resolve to a WHOOP family",
+                null, DeviceFamily.forRegistryDevice(model, "Oura"))
+        }
+        assertEquals(null, DeviceFamily.forRegistryDevice(null, "Garmin"))
+        assertEquals(null, DeviceFamily.forRegistryDevice("Watch", "Apple"))
+    }
+
+    /** A WHOOP brand still resolves by model spelling, exactly as forRegistryModel does. */
+    @Test
+    fun whoopBrandResolvesByModel() {
+        assertEquals(DeviceFamily.WHOOP4, DeviceFamily.forRegistryDevice("4.0", "WHOOP"))
+        assertEquals(DeviceFamily.WHOOP4, DeviceFamily.forRegistryDevice("WHOOP 4.0", "WHOOP"))
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryDevice("5.0 MG", "WHOOP"))
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryDevice("WHOOP 5.0 / MG", "WHOOP"))
+    }
+
+    /** A null/empty brand carries no non-WHOOP signal (legacy rows, WHOOP straps), so it defers to model. */
+    @Test
+    fun missingBrandDefersToModel() {
+        assertEquals(DeviceFamily.WHOOP4, DeviceFamily.forRegistryDevice("4.0", null))
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryDevice("5.0 MG", ""))
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryDevice(null, null))
+    }
+
+    /**
+     * "No scoring change" half of #1086: every consumer coalesces a non-WHOOP null to WHOOP5 (the
+     * non-4.0 skin-temp scale), so the family a non-WHOOP row is *treated as* is identical to before the
+     * brand-aware resolver existed. Guards the skin-temp/day-owner call sites against a scale regression.
+     */
+    @Test
+    fun nonWhoopCoalescesToPriorLabel() {
+        for (model in listOf("Oura Ring 3", "Oura Ring 4", "Oura Ring 5")) {
+            assertEquals(
+                "$model treated-as family must be unchanged",
+                DeviceFamily.forRegistryModel(model),
+                DeviceFamily.forRegistryDevice(model, "Oura") ?: DeviceFamily.WHOOP5,
+            )
+        }
     }
 }


### PR DESCRIPTION
Fixes #1086.

## Problem

`DeviceFamily.forRegistryModel` is the one canonical registry-model → family resolver (#171), but `DeviceFamily` has only `.whoop4`/`.whoop5` — so **every Oura ring (and any non-WHOOP device) resolves to `.whoop5` by construction**, the type having no way to express "not a WHOOP".

Latent today — the consumers (skin-temp raw→°C scale, day-owner, chart empty-state) all treat `.whoop5` as the harmless default — but it's exactly the #171-class trap: any *future* branch on `DeviceFamily` silently receives "this is a WHOOP 5", and it already makes an Oura strap log lie (`family=whoop5`).

## Fix

Add a brand-aware `forRegistryDevice(model:brand:) -> DeviceFamily?` that returns `nil` for a positively non-WHOOP brand. The row already carries `brand` from `DeviceBrandCatalog`; the resolver just consults it.

```swift
static func forRegistryDevice(model: String?, brand: String?) -> DeviceFamily? {
    if let brand, !brand.isEmpty, brand.caseInsensitiveCompare("WHOOP") != .orderedSame { return nil }
    return forRegistryModel(model)
}
```

**Why not a third `DeviceFamily` case** (the report's Option 2): `DeviceFamily` is a two-case *protocol* type — it drives `headerCRCKind` / `serviceUUIDString` / `characteristicUUIDStrings` / `commandCharacteristicUUIDString` / `clientHello` (Swift) and the same `when`s on Android, none of which a non-WHOOP device has. A `.other` case would force six protocol switches to invent meaningless answers. Keeping the type WHOOP-only and expressing "not a WHOOP" as `nil` is the smaller, honest change.

**Brand-first ordering handles every Oura generation.** Oura rings get model `"Oura Ring 3"` / `"Oura Ring 4"` / `"Oura Ring 5"` (+ `"Oura (cloud)"`), all with `brand: "Oura"`. Because the brand is tested *before* the model switch, all of them — and any future Gen 6 — resolve to `nil` with **no model-string list to maintain** (a model-matching fix would have to enumerate each generation and could silently miss one).

## No scoring change (asserted)

Every registry consumer coalesces the `nil` back to `.whoop5` — the non-4.0 skin-temp scale a non-WHOOP reading already shared — so the family each device is *treated as* is byte-identical to before. The win is purely that the canonical resolver now answers by evidence and future branches get an honest `nil`. Routed sites: `Repository.skinTempFamilies` + `activeStrapFamily`, `IntelligenceEngine.skinTempFamily`, Android `RegistryDayOwnerSource.skinTempFamily` + `FullDayChartScreen` (×2).

**Deliberately not touched**, per the report: the separate Oura sleep-staging bias (the `grav=0` issue) and the stager `family=` log line.

## Parity

`forRegistryDevice` is byte-identical in Swift (`WhoopProtocol`) and Kotlin (`com.noop.protocol`). Both test twins updated in lockstep.

## Verification

- `WhoopProtocol` resolver + tests — `swift test` **9/9** and `./gradlew testFullDebugUnitTest --tests "*RegistryModelFamilyTest"` **9/9** (both cover Oura Ring 3/4/5, WHOOP brand, missing/empty brand, and the no-scoring-change coalesce).
- Android consumers — `compileFullDebugKotlin` clean.
- Swift consumers (`Repository`, `IntelligenceEngine`) are **app-target Swift** — no default CI compiles them; needs a local `Strand`/`NOOPiOS` build (the change is a signature swap + `?? .whoop5`, no behavior change).