### PR TITLE
fix(oura): gate banked samples at "now", quarantine future-stamped R-R beats (#1073)

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
@@ -83,12 +83,19 @@ public final class OuraDriver {
     /// injected one (so re-auth after a key install uses the new key). Per OURA_PROTOCOL.md s3.2.
     private var effectiveKey: [UInt8]? { installedKey ?? authKey }
 
+    /// Wall-clock "now" in unix ms, used ONLY to reject a banked sample that converts to the future
+    /// (#1073). Injectable so the gate is testable without touching the system clock; defaults to the
+    /// real clock, so no ingest call site has to thread it.
+    private let nowMsProvider: () -> Int64
+
     public init(ringGen: OuraRingGen, authKey: [UInt8]?, allowTierB: Bool = false,
-                allowKeyInstall: Bool = false) {
+                allowKeyInstall: Bool = false,
+                nowMsProvider: @escaping () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1000) }) {
         self.ringGen = ringGen
         self.authKey = authKey
         self.allowTierB = allowTierB
         self.allowKeyInstall = allowKeyInstall
+        self.nowMsProvider = nowMsProvider
     }
 
     // MARK: - Command flow
@@ -223,11 +230,19 @@ public final class OuraDriver {
         let deltaTicks = Int64(rt) - Int64(anchorRingTime)
         let ms = anchorUtcMs + deltaTicks * 100   // default 100 ms/tick (s5.5); bounded input, no overflow
         // #968: a corrupt/misaligned ring timestamp (seen on a full cursor=0 history dump) can convert to
-        // an implausible epoch. Gate the RESULT to the same 2020-2035 plausible window used for anchoring
-        // (was a weak `ms > 0`), so the caller honestly falls back to arrival time instead of banking a
-        // 1970 or far-future sample.
+        // an implausible epoch; return nil so the caller falls back to arrival time instead of banking it.
+        //
+        // #1073: a banked SAMPLE is always in the past, so its upper bound is "now", NOT the 2020-2035
+        // anchor window. That window is the right screen for ADOPTING a clock anchor and far too generous
+        // for a sample — a corrupt ring timestamp that converts years ahead (measured on a live ring:
+        // ~1,600 R-R beats stamped 2026→2034, and still accruing) passed it cleanly and got filed into a
+        // future day, invisible to the night it belongs to. Gate a sample at `now + skew tolerance`
+        // (minutes, absorbing ring-clock skew + anchor rounding) and keep the 2020 lower bound (the #968
+        // 1970 guard). The 2020-2035 window stays in `plausibleAnchorMs`, for anchor adoption only.
         let seconds = ms / 1000
-        guard seconds >= Self.minPlausibleEpochSeconds, seconds <= Self.maxPlausibleEpochSeconds else { return nil }
+        let nowSeconds = nowMsProvider() / 1000
+        guard seconds >= Self.minPlausibleEpochSeconds,
+              seconds <= nowSeconds + Self.sampleFutureToleranceSeconds else { return nil }
         return Int(seconds)
     }
 
@@ -267,6 +282,12 @@ public final class OuraDriver {
     /// Int64 (a naive multiply on a near-Int64.max raw value traps).
     private static let minPlausibleEpochSeconds: Int64 = 1_577_836_800
     private static let maxPlausibleEpochSeconds: Int64 = 2_051_222_400
+
+    /// Skew allowance on the sample-side "must not be in the future" gate (#1073): a sample converting up
+    /// to this many seconds past `now` is still accepted, absorbing ring-clock skew and the anchor's own
+    /// rounding. Minutes, not the anchor window's years — a sample banked further ahead than this is
+    /// corrupt by construction. Applies ONLY to `unixSeconds(forRingTimestamp:)`, never anchor adoption.
+    private static let sampleFutureToleranceSeconds: Int64 = 300
 
     private static func plausibleAnchorMs(fromEpochSeconds seconds: Int64) -> Int64? {
         guard seconds >= minPlausibleEpochSeconds, seconds <= maxPlausibleEpochSeconds else { return nil }

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraDriverTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraDriverTests.swift
@@ -209,6 +209,47 @@ final class OuraDriverTests: XCTestCase {
         XCTAssertEqual(d.unixSeconds(forRingTimestamp: anchorRt + 100), Int(anchorEpochSeconds) + 10)
     }
 
+    /// #1073: a banked sample that converts to the future is rejected (the caller falls back to arrival
+    /// time), while a historical sample still converts. "now" is injected so the test does not depend on
+    /// the wall clock. The anchor is set to `now`, so a ring time far enough after it converts past now.
+    func testSampleConvertingToFutureIsRejected() {
+        let anchorEpochSeconds: Int64 = 1_700_000_000     // 2023-11-14, mid anchor window
+        let anchorRt: UInt32 = 1_000_000
+        // Freeze "now" AT the anchor instant, so any sample after the anchor is "in the future".
+        let d = OuraDriver(ringGen: .gen3, authKey: key,
+                           nowMsProvider: { anchorEpochSeconds * 1000 })
+        let payload = le8(anchorEpochSeconds) + [0x00]
+        _ = d.ingest(record: OuraRecord(type: OuraEventTag.timeSync.rawValue, ringTimestamp: anchorRt, payload: payload))
+
+        // Historical (10s before now) and exactly-now still convert.
+        XCTAssertEqual(d.unixSeconds(forRingTimestamp: anchorRt - 100), Int(anchorEpochSeconds) - 10)
+        XCTAssertEqual(d.unixSeconds(forRingTimestamp: anchorRt), Int(anchorEpochSeconds))
+        // Inside the 300s skew tolerance (+200s) still converts.
+        XCTAssertEqual(d.unixSeconds(forRingTimestamp: anchorRt + 2_000), Int(anchorEpochSeconds) + 200)
+        // Just past the tolerance (+301s) is rejected as future/corrupt.
+        XCTAssertNil(d.unixSeconds(forRingTimestamp: anchorRt + 3_010))
+        // The regression that #1073 is about: a sample ~1 year ahead (still inside the OLD 2020-2035
+        // anchor window, so the old gate banked it) is now rejected because it is after `now`.
+        XCTAssertNil(d.unixSeconds(forRingTimestamp: anchorRt + 315_360_000),
+                     "a sample a year in the future passed the old 2035 gate; the now-gate must reject it")
+    }
+
+    /// The two gates are decoupled (#1073): anchor ADOPTION still uses the full 2020-2035 window even when
+    /// "now" is frozen years earlier — only the per-sample conversion is bounded by now. A 2034 anchor is
+    /// adopted (event emitted), yet converting its own ring time returns nil because 2034 is after now.
+    func testAnchorAdoptionStillUsesFullWindowIndependentOfNow() {
+        let futureAnchorSeconds: Int64 = 2_020_000_000    // 2034, inside the 2020-2035 anchor window
+        let anchorRt: UInt32 = 500
+        let d = OuraDriver(ringGen: .gen3, authKey: key,
+                           nowMsProvider: { 1_700_000_000 * 1000 })   // now frozen at 2023
+        let payload = le8(futureAnchorSeconds) + [0x00]
+        let events = d.ingest(record: OuraRecord(type: OuraEventTag.timeSync.rawValue, ringTimestamp: anchorRt, payload: payload))
+        XCTAssertEqual(events, [.timeSync(OuraTimeSync(ringTimestamp: anchorRt, epochMs: futureAnchorSeconds, tzOffsetSeconds: 0))],
+                       "a 2034 anchor is still adopted — adoption uses the 2020-2035 window, not now")
+        XCTAssertNil(d.unixSeconds(forRingTimestamp: anchorRt),
+                     "but converting a sample stamped in 2034 is rejected because it is after now (2023)")
+    }
+
     func testRtcBeaconOnlyAnchorsWhenNoTimeSyncSeenYet() {
         let d = OuraDriver(ringGen: .gen3, authKey: key)
         let beaconRt: UInt32 = 5_000

--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -775,6 +775,29 @@ extension WhoopStore {
                 t.add(column: "stagingSparse", .integer)
             }
         }
+        // v35 (#1073): quarantine R-R beats whose timestamp is in the FUTURE. An Oura ring's history
+        // timestamp is occasionally corrupt/misaligned and, before the OuraDriver gate was tightened to
+        // "now", converted to a date years ahead (measured on a live ring: ~1,600 beats stamped 2026→2034)
+        // and was banked — removed from the night it was measured in and queued to poison whichever future
+        // day it lands on. The ingest gate now rejects such samples, but rows already stored have to be
+        // taken out of scoring.
+        //
+        // NOT a delete: these are real heartbeats with a wrong timestamp, so — like the v32 srcChannel
+        // form — the column MARKS them and `Reads.rrIntervals` filters at READ, keeping them inspectable
+        // and recoverable if the ring-time offset is ever characterised (the migration rule warns against
+        // window-wide deletes). `strftime('%s','now')` runs once, at migration time; new rows are gated at
+        // ingest so never land future, and stay NULL. Additive nullable INTEGER, the v32 form: no table
+        // rebuild, no existing key touched, NOT in the primary key.
+        //
+        // Twin of Room MIGRATION_28_29.
+        migrator.registerMigration("v35-rr-future-quarantine") { db in
+            try db.alter(table: "rrInterval") { t in
+                t.add(column: "tsSuspect", .integer)
+            }
+            // CAST so the compare is numeric: `strftime` returns TEXT, and `ts` (INTEGER) > TEXT would
+            // otherwise lean on SQLite's affinity coercion rather than being explicit.
+            try db.execute(sql: "UPDATE rrInterval SET tsSuspect = 1 WHERE ts > CAST(strftime('%s','now') AS INTEGER)")
+        }
         return migrator
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -200,6 +200,7 @@ extension WhoopStore {
                 SELECT ts, rrMs, srcChannel FROM rrInterval
                 WHERE deviceId = ? AND ts >= ? AND ts <= ?
                 AND (srcChannel IS NULL OR srcChannel <> ?)
+                AND (tsSuspect IS NULL OR tsSuspect <> 1)   -- #1073: exclude future-stamped beats
                 ORDER BY ts ASC, ord ASC, rrMs ASC, seq ASC LIMIT ?
                 """, arguments: [deviceId, from, to, RRSourceChannel.spo2Ibi.rawValue, limit])
                 .map { row in

--- a/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
@@ -689,4 +689,23 @@ extension WhoopStore {
                 """, arguments: [deviceId]).map { (rrMs: $0["rrMs"], srcChannel: $0["srcChannel"]) }
         }
     }
+
+    /// Run the `v35-rr-future-quarantine` backfill predicate with an EXPLICIT `now` (the migration itself
+    /// uses `strftime('%s','now')`; a test needs a fixed instant). Marks every stored R-R beat whose ts is
+    /// after `nowSeconds`. Test-only (#1073).
+    public func markFutureRrSuspectForTest(nowSeconds: Int) async throws {
+        try syncWrite { db in
+            try db.execute(sql: "UPDATE rrInterval SET tsSuspect = 1 WHERE ts > ?", arguments: [nowSeconds])
+        }
+    }
+
+    /// Every STORED R-R row for a device as `(ts, tsSuspect)`, bypassing the scoring read's filter — so a
+    /// test can assert which rows were quarantined AND that none were deleted. Test-only (#1073).
+    public func rrSuspectRowsForTest(deviceId: String) async throws -> [(ts: Int, tsSuspect: Int?)] {
+        try syncRead { db in
+            try Row.fetchAll(db, sql: """
+                SELECT ts, tsSuspect FROM rrInterval WHERE deviceId = ? ORDER BY ts ASC
+                """, arguments: [deviceId]).map { (ts: $0["ts"], tsSuspect: $0["tsSuspect"]) }
+        }
+    }
 }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
@@ -1,6 +1,6 @@
 {
   "_readme": "SHARED Room<->GRDB SCHEMA ORACLE (#775). Two byte-identical copies: Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json and android/app/src/test/resources/schema_oracle.json. SchemaOracleTests.swift compares GRDB's PRAGMA table_info/index_list against it; SchemaOracleTest.kt compares Room's exported schema JSON against it. `columns` is the iOS/GRDB shape in GRDB column order (macOS is the reference implementation); every way Android differs is spelled out in an `android` / `iosAbsent` / `androidColumnOrder` override naming a key in `divergenceReasons`. Adding a column, reordering one, or changing a type/nullability on one platform only fails both suites until it is either fixed or written down here.",
-  "roomVersion": 28,
+  "roomVersion": 29,
   "grdbMigrations": [
     "v1",
     "v2",
@@ -35,7 +35,8 @@
     "v31-deep-capture-channels",
     "v32-rr-src-channel",
     "v33-workout-steps",
-    "v34-sleep-staging-sparse"
+    "v34-sleep-staging-sparse",
+    "v35-rr-future-quarantine"
   ],
   "divergenceReasons": {
     "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android \u2014 the per-row upload flag belongs to an upload path that does not exist there \u2014 so it is dead width, not divergent data. Removing it needs a Room table rebuild.",
@@ -1322,6 +1323,12 @@
         },
         {
           "name": "srcChannel",
+          "affinity": "INTEGER",
+          "notNull": false,
+          "default": null
+        },
+        {
+          "name": "tsSuspect",
           "affinity": "INTEGER",
           "notNull": false,
           "default": null

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/RrFutureQuarantineTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/RrFutureQuarantineTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+import WhoopProtocol
+@testable import WhoopStore
+
+/// #1073: R-R beats stamped in the FUTURE (a corrupt/misaligned Oura ring timestamp) are quarantined by
+/// `v35-rr-future-quarantine` — MARKED, never deleted, so they stay inspectable and recoverable — and
+/// excluded from the scoring read. The ingest-side gate (`OuraDriver.unixSeconds`) stops new ones; this
+/// covers the stored-row half. Mirrors the Android `RrFutureQuarantineMigrationTest`.
+final class RrFutureQuarantineTests: XCTestCase {
+
+    /// v35 adds the nullable `tsSuspect` column without touching the primary key (the v32 srcChannel form).
+    func testV35AddsTsSuspectAndKeepsThePrimaryKey() async throws {
+        let store = try await WhoopStore.inMemory()
+        let cols = try await store.columnNamesForTest(table: "rrInterval")
+        XCTAssertTrue(cols.contains("tsSuspect"), "rrInterval missing v35 tsSuspect column")
+        let pk = try await store.primaryKeyColumns("rrInterval")
+        XCTAssertEqual(pk, ["deviceId", "ts", "rrMs", "seq"], "tsSuspect must not enter the primary key")
+    }
+
+    /// The whole shape of the fix in one test: future-stamped beats are MARKED (not deleted), remain on
+    /// disk, and drop out of the scoring read; historical beats are untouched and still scored.
+    func testFutureBeatsAreQuarantinedAndExcludedFromScoringButKept() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: "ring", mac: nil, name: nil)
+        let now = 1_700_000_000
+        let rows = [
+            RRInterval(ts: now - 20, rrMs: 800),                 // historical
+            RRInterval(ts: now - 10, rrMs: 810),                 // historical
+            RRInterval(ts: now + 86_400, rrMs: 820),             // a day ahead (corrupt)
+            RRInterval(ts: now + 315_360_000, rrMs: 830),        // a year ahead (corrupt)
+        ]
+        _ = try await store.insert(Streams(rr: rows), deviceId: "ring")
+
+        // What v35 does, with a fixed `now` so the test does not depend on the wall clock.
+        try await store.markFutureRrSuspectForTest(nowSeconds: now)
+
+        // Nothing deleted — all four beats remain on disk; exactly the future ones are marked.
+        let onDisk = try await store.rrSuspectRowsForTest(deviceId: "ring")
+        XCTAssertEqual(onDisk.count, 4, "quarantine MARKS, never deletes (count preserved)")
+        XCTAssertEqual(onDisk.filter { $0.tsSuspect == 1 }.map(\.ts), [now + 86_400, now + 315_360_000],
+                       "exactly the future-stamped beats are marked suspect")
+        XCTAssertNil(onDisk.first(where: { $0.ts == now - 20 })?.tsSuspect, "historical beats stay unmarked")
+
+        // Scoring reads exclude the quarantined beats.
+        let scored = try await store.rrIntervals(deviceId: "ring", from: 0, to: now + 400_000_000, limit: 1_000)
+        XCTAssertEqual(scored.map(\.rrMs), [800, 810], "only the two historical beats reach scoring")
+    }
+}

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -148,6 +148,9 @@ data class RrInterval(
     val synced: Int = 0,
     val ord: Int? = null,
     val srcChannel: Int? = null,
+    /** #1073 (Room v29): 1 when this beat's ts is in the FUTURE (corrupt ring time); NULL otherwise.
+     *  Marked, never deleted; `WhoopDao.rrIntervals` filters it at READ. Twin of GRDB `tsSuspect`. */
+    val tsSuspect: Int? = null,
 )
 
 /**

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -389,6 +389,7 @@ interface WhoopDao : DeviceRegistryDao {
         // pins the two together.
         "SELECT * FROM rrInterval WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to " +
             "AND (srcChannel IS NULL OR srcChannel <> 2) " +
+            "AND (tsSuspect IS NULL OR tsSuspect <> 1) " +   // #1073: exclude future-stamped beats
             "ORDER BY ts ASC, ord ASC, rrMs ASC, seq ASC LIMIT :limit"
     )
     suspend fun rrIntervals(deviceId: String, from: Long, to: Long, limit: Int): List<RrInterval>

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -52,7 +52,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         RawImuSampleEntity::class,
         V18AuxSampleEntity::class,
     ],
-    version = 28,
+    version = 29,
     // #775: ON so Room's KSP processor writes the generated schema (every table's exact `CREATE TABLE`,
     // columns in declaration order with affinity/NOT NULL/default, PK and indices) as JSON. That export
     // is what lets a plain JVM test — no device, no Robolectric — read Android's REAL schema and compare
@@ -785,6 +785,34 @@ abstract class WhoopDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * v28 -> v29: ADDITIVE, adds `rrInterval.tsSuspect` (nullable INTEGER) and MARKS every stored beat
+         * whose ts is in the FUTURE (#1073). An Oura ring's history timestamp is occasionally corrupt and,
+         * before the OuraDriver gate was tightened to "now", converted to a date years ahead (measured on a
+         * live ring: ~1,600 beats stamped 2026→2034) and was banked — lost to the night it was measured in
+         * and queued to poison a future day. The ingest gate now rejects such samples; rows already stored
+         * are marked here and `WhoopDao.rrIntervals` filters them at READ.
+         *
+         * NOT a delete: real beats with a wrong timestamp, kept inspectable/recoverable (the migration rule
+         * warns against window-wide deletes). Additive nullable, the srcChannel (`MIGRATION_25_26`) form:
+         * no table rebuild, no row/key touched, ALTER appends the column LAST to match the entity field
+         * order. `strftime('%s','now')` runs once, at migration time; CAST so `ts` (INTEGER) > it is a
+         * numeric compare. New rows are gated at ingest so never land future, staying NULL. Byte-parity
+         * with Swift WhoopStore `v35-rr-future-quarantine`.
+         *
+         * Exposed as [RR_FUTURE_QUARANTINE_MIGRATION_SQL] so a plain-JVM unit test can assert its shape.
+         */
+        internal val RR_FUTURE_QUARANTINE_MIGRATION_SQL: List<String> = listOf(
+            "ALTER TABLE `rrInterval` ADD COLUMN `tsSuspect` INTEGER",
+            "UPDATE `rrInterval` SET `tsSuspect` = 1 WHERE `ts` > CAST(strftime('%s','now') AS INTEGER)",
+        )
+
+        internal val MIGRATION_28_29 = object : Migration(28, 29) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                for (stmt in RR_FUTURE_QUARANTINE_MIGRATION_SQL) db.execSQL(stmt)
+            }
+        }
+
         private fun build(appContext: Context): WhoopDatabase =
             Room.databaseBuilder(appContext, WhoopDatabase::class.java, DB_NAME)
                 // #1014: replace ONLY the corruption handling of the default open-helper. The
@@ -802,7 +830,7 @@ abstract class WhoopDatabase : RoomDatabase() {
                     MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18,
                     MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
                     MIGRATION_22_23, MIGRATION_23_24, MIGRATION_24_25, MIGRATION_25_26,
-                    MIGRATION_26_27, MIGRATION_27_28,
+                    MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29,
                 )
                 // #1037: a FRESH install builds the schema straight at the current version and runs NO
                 // migrations, so the MIGRATION_7_8 "my-whoop" registry seed never fires and the WHOOP,

--- a/android/app/src/main/java/com/noop/oura/OuraDriver.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraDriver.kt
@@ -86,6 +86,12 @@ class OuraDriver(
      * Per OURA_PROTOCOL.md s3.2 (the 0x24 SetAuthKey is a DANGEROUS, one-time provisioning write).
      */
     val allowKeyInstall: Boolean = false,
+    /**
+     * Wall-clock "now" in unix ms, used ONLY to reject a banked sample that converts to the future
+     * (#1073). Injectable so the gate is testable without touching the system clock; defaults to the
+     * real clock, so no ingest call site has to thread it. Twin of Swift's `nowMsProvider`.
+     */
+    private val nowMsProvider: () -> Long = { System.currentTimeMillis() },
 ) {
     var phase: OuraDriverPhase = OuraDriverPhase.Idle
         private set
@@ -300,11 +306,19 @@ class OuraDriver(
         val deltaTicks = forRingTimestamp - anchorRt
         val ms = anchorMs + deltaTicks * 100   // default 100 ms/tick (s5.5); bounded input, no overflow
         // #968: a corrupt/misaligned ring timestamp (seen on a full cursor=0 history dump) can convert to
-        // an implausible epoch. Gate the RESULT to the same 2020-2035 plausible window used for anchoring
-        // (was a weak `ms <= 0`), so the caller honestly falls back to arrival time instead of banking a
-        // 1970 or far-future sample. Byte-identical to the Swift twin.
+        // an implausible epoch; return null so the caller falls back to arrival time instead of banking it.
+        //
+        // #1073: a banked SAMPLE is always in the past, so its upper bound is "now", NOT the 2020-2035
+        // anchor window. That window is the right screen for ADOPTING a clock anchor and far too generous
+        // for a sample — a corrupt ring timestamp that converts years ahead (measured on a live ring:
+        // ~1,600 R-R beats stamped 2026→2034, and still accruing) passed it cleanly and got filed into a
+        // future day, invisible to the night it belongs to. Gate a sample at `now + skew tolerance`
+        // (minutes, absorbing ring-clock skew + anchor rounding) and keep the 2020 lower bound (the #968
+        // 1970 guard). The 2020-2035 window stays in `plausibleAnchorMs`, for anchor adoption only.
+        // Byte-identical to the Swift twin.
         val seconds = ms / 1000
-        if (seconds < MIN_PLAUSIBLE_EPOCH_SECONDS || seconds > MAX_PLAUSIBLE_EPOCH_SECONDS) return null
+        val nowSeconds = nowMsProvider() / 1000
+        if (seconds < MIN_PLAUSIBLE_EPOCH_SECONDS || seconds > nowSeconds + SAMPLE_FUTURE_TOLERANCE_SECONDS) return null
         return seconds
     }
 
@@ -609,6 +623,14 @@ class OuraDriver(
          */
         private const val MIN_PLAUSIBLE_EPOCH_SECONDS = 1_577_836_800L
         private const val MAX_PLAUSIBLE_EPOCH_SECONDS = 2_051_222_400L
+
+        /**
+         * Skew allowance on the sample-side "must not be in the future" gate (#1073): a sample converting
+         * up to this many seconds past `now` is still accepted, absorbing ring-clock skew and the anchor's
+         * own rounding. Minutes, not the anchor window's years. Applies ONLY to [unixSeconds], never anchor
+         * adoption. Byte-identical to the Swift `sampleFutureToleranceSeconds`.
+         */
+        private const val SAMPLE_FUTURE_TOLERANCE_SECONDS = 300L
 
         /**
          * Resolve the 0x13 SyncTime-response device timestamp into ring TICKS, or null when no

--- a/android/app/src/test/java/com/noop/data/RrFutureQuarantineMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/RrFutureQuarantineMigrationTest.kt
@@ -1,0 +1,42 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the v28 -> v29 Room migration (#1073): adds `rrInterval.tsSuspect` and one-time MARKS every
+ * stored R-R beat whose ts is in the future (a corrupt Oura ring timestamp), so scoring stops reading
+ * them while they stay on disk. This environment has no Robolectric/Room-testing, so the migration SQL is
+ * exposed as [WhoopDatabase.RR_FUTURE_QUARANTINE_MIGRATION_SQL] and pinned here. Twin of the Swift
+ * WhoopStore `RrFutureQuarantineTests`.
+ */
+class RrFutureQuarantineMigrationTest {
+
+    @Test
+    fun migration_addsNullableColumnThenMarksFutureRowsNonDestructively() {
+        val sql = WhoopDatabase.RR_FUTURE_QUARANTINE_MIGRATION_SQL
+        assertEquals("one ADD COLUMN + one backfill UPDATE", 2, sql.size)
+
+        // 1. additive nullable column, exactly like srcChannel/ord (no NOT NULL, no DEFAULT).
+        assertEquals("ALTER TABLE `rrInterval` ADD COLUMN `tsSuspect` INTEGER", sql[0])
+        val alter = sql[0].uppercase()
+        assertFalse("column stays nullable: ${sql[0]}", alter.contains("NOT NULL"))
+        assertFalse("column has no DEFAULT: ${sql[0]}", alter.contains("DEFAULT"))
+
+        // 2. the backfill only MARKS future rows — never deletes, drops, or rewrites other data.
+        val update = sql[1].uppercase()
+        assertTrue("marks suspect rows: ${sql[1]}", update.startsWith("UPDATE") && update.contains("SET `TSSUSPECT` = 1"))
+        assertTrue("only rows whose ts is in the future: ${sql[1]}", update.contains("WHERE `TS` >"))
+        for (banned in listOf("DELETE", "DROP", "CREATE", "INSERT")) {
+            assertFalse("quarantine must not '$banned' (real beats, kept inspectable): ${sql[1]}", update.contains(banned))
+        }
+    }
+
+    @Test
+    fun migration_versionPair_is28to29() {
+        assertEquals(28, WhoopDatabase.MIGRATION_28_29.startVersion)
+        assertEquals(29, WhoopDatabase.MIGRATION_28_29.endVersion)
+    }
+}

--- a/android/app/src/test/java/com/noop/oura/OuraDriverTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraDriverTest.kt
@@ -659,4 +659,45 @@ class OuraDriverTest {
         assertTrue(OuraCommands.getBattery().bytes[0] != 0x0E)
         assertTrue(OuraCommands.getBattery().bytes[0] != 0x1A)
     }
+
+    /**
+     * #1073: a banked sample that converts to the future is rejected (the caller falls back to arrival
+     * time), while a historical sample still converts. "now" is injected so the test does not touch the
+     * wall clock. Byte-parity with Swift `testSampleConvertingToFutureIsRejected`.
+     */
+    @Test
+    fun sampleConvertingToFutureIsRejected() {
+        val anchorSeconds = 1_700_000_000L               // 2023-11-14, mid anchor window
+        val anchorRt = 1_000_000L
+        // Freeze "now" AT the anchor instant, so any sample after the anchor is "in the future".
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key, nowMsProvider = { anchorSeconds * 1000 })
+        assertTrue(d.adoptSyncTimeAnchor(ringTimestamp = anchorRt, unixSeconds = anchorSeconds))
+
+        // Historical (10s before now) and exactly-now still convert.
+        assertEquals(anchorSeconds - 10, d.unixSeconds(forRingTimestamp = anchorRt - 100))
+        assertEquals(anchorSeconds, d.unixSeconds(forRingTimestamp = anchorRt))
+        // Inside the 300s skew tolerance (+200s) still converts.
+        assertEquals(anchorSeconds + 200, d.unixSeconds(forRingTimestamp = anchorRt + 2_000))
+        // Just past the tolerance (+301s) is rejected as future/corrupt.
+        assertNull(d.unixSeconds(forRingTimestamp = anchorRt + 3_010))
+        // The regression #1073 is about: a sample ~1 year ahead (inside the OLD 2020-2035 window, so the
+        // old gate banked it) is now rejected because it is after `now`.
+        assertNull(d.unixSeconds(forRingTimestamp = anchorRt + 315_360_000))
+    }
+
+    /**
+     * The two gates are decoupled (#1073): anchor ADOPTION still uses the full 2020-2035 window even when
+     * "now" is frozen years earlier — only per-sample conversion is bounded by now. Byte-parity with Swift
+     * `testAnchorAdoptionStillUsesFullWindowIndependentOfNow`.
+     */
+    @Test
+    fun anchorAdoptionStillUsesFullWindowIndependentOfNow() {
+        val futureAnchorSeconds = 2_020_000_000L         // 2034, inside the 2020-2035 anchor window
+        val anchorRt = 500L
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key, nowMsProvider = { 1_700_000_000L * 1000 })
+        assertTrue("a 2034 anchor is still adopted — adoption uses the window, not now",
+            d.adoptSyncTimeAnchor(ringTimestamp = anchorRt, unixSeconds = futureAnchorSeconds))
+        assertNull("but converting a 2034 sample is rejected because it is after now (2023)",
+            d.unixSeconds(forRingTimestamp = anchorRt))
+    }
 }

--- a/android/app/src/test/resources/schema_oracle.json
+++ b/android/app/src/test/resources/schema_oracle.json
@@ -1,6 +1,6 @@
 {
   "_readme": "SHARED Room<->GRDB SCHEMA ORACLE (#775). Two byte-identical copies: Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json and android/app/src/test/resources/schema_oracle.json. SchemaOracleTests.swift compares GRDB's PRAGMA table_info/index_list against it; SchemaOracleTest.kt compares Room's exported schema JSON against it. `columns` is the iOS/GRDB shape in GRDB column order (macOS is the reference implementation); every way Android differs is spelled out in an `android` / `iosAbsent` / `androidColumnOrder` override naming a key in `divergenceReasons`. Adding a column, reordering one, or changing a type/nullability on one platform only fails both suites until it is either fixed or written down here.",
-  "roomVersion": 28,
+  "roomVersion": 29,
   "grdbMigrations": [
     "v1",
     "v2",
@@ -35,7 +35,8 @@
     "v31-deep-capture-channels",
     "v32-rr-src-channel",
     "v33-workout-steps",
-    "v34-sleep-staging-sparse"
+    "v34-sleep-staging-sparse",
+    "v35-rr-future-quarantine"
   ],
   "divergenceReasons": {
     "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android \u2014 the per-row upload flag belongs to an upload path that does not exist there \u2014 so it is dead width, not divergent data. Removing it needs a Room table rebuild.",
@@ -1322,6 +1323,12 @@
         },
         {
           "name": "srcChannel",
+          "affinity": "INTEGER",
+          "notNull": false,
+          "default": null
+        },
+        {
+          "name": "tsSuspect",
           "affinity": "INTEGER",
           "notNull": false,
           "default": null


### PR DESCRIPTION
Fixes #1073.

## Problem

`OuraDriver.unixSeconds(forRingTimestamp:)` validated a converted **sample** time against the **anchor** plausibility window (2020-01-01 … 2035-01-01). That's the right screen for *adopting a clock anchor* and the wrong one for *a banked sample* — a sample from the ring's history is always in the past, so anything after "now" is corrupt by definition. A misaligned ring timestamp that converted years ahead passed the 2035 gate and got banked, removed from the night it was measured in and queued to poison a future day. Measured on a live Gen 3: **~1,600 `rrInterval` rows stamped 2026→2034, and growing**.

## Fix — two parts

### Part 1 — stop the accrual (`OuraProtocol`, both platforms)
- **Decouple the gates.** A *sample* must fall in `[2020-01-01, now + skewTolerance]` (tolerance **300 s**, absorbing ring-clock skew + anchor rounding); `nil` past that, so the caller keeps its honest fall-back to arrival time. The 2020–2035 window stays in `plausibleAnchorMs`, for **anchor adoption only** — the two tests stop sharing a bound.
- **`now` is an injected provider** (default wall clock), so the gate is testable and **no ingest call site changes** — the fix stays inside the CI-covered package.

### Part 2 — quarantine the rows already stored (GRDB **v35** / Room **MIGRATION_28_29**)
- Additive nullable **`rrInterval.tsSuspect`**, the v32 `srcChannel` form: the migration **marks** every row with `ts > now` (**never deletes** — real beats with a wrong timestamp, kept inspectable and recoverable if the ring-time offset is ever characterised), and `Reads.rrIntervals` / `WhoopDao.rrIntervals` **filter it at read**. Not in the primary key.
- `CAST(strftime('%s','now') AS INTEGER)` so `ts` (INTEGER) `>` it is a numeric compare.
- Both `schema_oracle.json` copies updated; `roomVersion` → 29.

> The reporter's suggested "v32" slot was already taken (v32 `srcChannel`, v33 `workout-steps`, v34 `sleep-staging-sparse`), so this lands at **v35 / Room 29**.

## What this does and doesn't fix
- **Stops the accrual** — a rejected sample banks at *arrival time* (`now`), not 2034, so the future-row count stops growing. Since `now` is normally outside a sleep window, these rare (singly-interleaved) corrupt beats don't reach nightly HRV.
- **Stops future-day poisoning** — existing future rows are quarantined out of scoring.
- **Does not recover** a corrupt beat to the night it was measured in — the timestamp is corrupt, so its true time is unknowable. Those beats are singly-interleaved among thousands of good ones per night, so the loss to that night's HRV is negligible; the quarantine keeps them inspectable for a future recovery pass if the ring-time offset is ever characterised.

## Deliberately NOT touched (per the report)
The separate Oura sleep-staging bias (the `grav=0` issue) and the stager `family=` log line — different defects.

## Parity
`unixSeconds` gate + the migration/read-filter are byte-identical Swift↔Kotlin; test twins added on both sides. The caller-side fallback (`OuraLiveSource` parks a still-unresolvable beat and stamps it `now`) is also a twin on both platforms.

## Verification
- `OuraProtocol` — `swift test` **41/41** (incl. future-sample rejection, the 1-year-ahead regression the old gate banked, and gate/anchor decoupling).
- Android — `OuraDriverTest` **38/0**, `RrFutureQuarantineMigrationTest` **2/0**, `SchemaOracleTest` **4/0** (Room's generated v29 schema with `tsSuspect` matches both oracle copies), `compileFullDebugKotlin` clean.
- `WhoopStore` `RrFutureQuarantineTests` (marks future rows, keeps them on disk, excludes from scoring, count preserved) is macOS-only → runs on `swift-packages.yml`.
- No app-target Swift touched.

**On a real database** — note this is a *mark-in-place* quarantine (the rows keep their future `ts`, they're flagged, not re-stamped or deleted), so the raw `SELECT COUNT(*) FROM rrInterval WHERE ts > strftime('%s','now')` will **not** drop to 0. The correct post-fix invariants are:
- that count **stops growing** across drains (the ingest gate adds no new future rows), and
- `SELECT COUNT(*) FROM rrInterval WHERE ts > strftime('%s','now') AND tsSuspect IS NULL` **== 0** (every future row is flagged).