### PR TITLE
fix(hrv): refuse SDNN when the R-R stream is banked, not only when it…

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -51,10 +51,13 @@ public enum HRVAnalyzer {
         public let rmssd: Double?
         /// SDNN (sample SD, ddof=1) in milliseconds, or nil when too few valid beats.
         ///
-        /// A caller holding the window's TIMESTAMPS should also refuse this value when
-        /// `beatSpreadIsTrustworthy(classifyCoverage(...))` is false: SDNN is a spread over every
-        /// interval, so an over-counted capture inflates it directly. `analyze` cannot do that itself —
-        /// it is given intervals, not times.
+        /// A caller holding the window's TIMESTAMPS should refuse this value when EITHER
+        /// `beatSpreadIsTrustworthy(classifyCoverage(...))` or
+        /// `beatValuesAreTrustworthy(beatAccurateFraction(...))` is false. SDNN is a spread over every
+        /// interval, so an over-counted capture inflates it directly — and so does a BANKED one, whose
+        /// stored intervals are a decomposition of a record period rather than beat-to-beat
+        /// measurements. The two faults are independent: a banked night can be perfectly covered.
+        /// `analyze` cannot check either itself — it is given intervals, not times.
         public let sdnn: Double?
         /// Mean NN interval (ms) over the cleaned beats, or nil.
         public let meanNN: Double?
@@ -401,6 +404,68 @@ public enum HRVAnalyzer {
         case .plausible, .underCovered, .unmeasurable:
             return true
         }
+    }
+
+    /// How closely a beat's own wall-clock gap matches its own R-R value: the fraction of consecutive
+    /// beats whose `ts` step is within `beatAccuracyToleranceS` of their interval. Pure. Byte-parity twin
+    /// of Kotlin `beatAccurateFraction`. Returns 1.0 for fewer than 2 beats — absence of evidence is not
+    /// evidence of banking, and the caller's own beat-count gates handle a series that short.
+    ///
+    /// A BEAT-ACCURATE stream steps one interval per beat, so the gap and the value agree and the
+    /// fraction is ~1.0 (WHOOP R-R, live spot readings, the synthetic fixtures). A BANKED stream stamps
+    /// a whole record of intervals on one coarse timestamp, so nearly every gap is 0 s against a ~1 s
+    /// value and the fraction collapses toward 0.
+    public static func beatAccurateFraction(tsSec: [Int], rrMs: [Double]) -> Double {
+        guard tsSec.count == rrMs.count, tsSec.count >= 2 else { return 1.0 }
+        var accurate = 0
+        for i in 1..<tsSec.count {
+            let gapS = Double(tsSec[i] - tsSec[i - 1])
+            if abs(gapS - rrMs[i] / 1000.0) <= beatAccuracyToleranceS { accurate += 1 }
+        }
+        return Double(accurate) / Double(tsSec.count - 1)
+    }
+
+    /// Tolerance (seconds) allowed between a beat's wall-clock gap and its own R-R value before the beat
+    /// is counted as not time-accurate. Whole-second `ts` against a sub-second interval means an honest
+    /// stream still rounds, so this is deliberately loose.
+    ///
+    /// Mirrors the constants the respiration gate uses for the SAME judgement (#882/#883). They are
+    /// duplicated rather than shared because that gate lives in `SleepStager` on a branch that is not
+    /// upstream; if it lands, the two should collapse onto this one definition — the boundary is worth
+    /// drawing once, in one place, for both.
+    public static let beatAccuracyToleranceS: Double = 0.5
+
+    /// Fraction of beats that must be time-accurate before BEAT-VALUE statistics are trusted.
+    ///
+    /// Not a tuned threshold: the two populations do not overlap anywhere near it. A beat-accurate
+    /// stream measures ~100%; every banked Oura overnight measured to date sits at **2.6-6.6%**
+    /// (five nights, 2026-07-29 → 08-06). Anything in the middle is a stream we have never seen and
+    /// should not be guessing about, which is what a mid-range boundary expresses.
+    public static let beatAccuracyMinFraction: Double = 0.5
+
+    /// Whether a window's BEAT-VALUE statistics — SDNN above all — can be trusted, given how
+    /// time-accurate its beats are. Pure. Byte-parity twin of Kotlin `beatValuesAreTrustworthy`.
+    ///
+    /// This is a SEPARATE failure from `beatSpreadIsTrustworthy`'s, and neither implies the other.
+    /// That one asks "is the same beat held twice?"; this one asks "is each stored interval a real
+    /// beat-to-beat measurement at all?" A banked stream can be perfectly covered — the 2026-08-06
+    /// Oura night measured coverage 1.03, verdict `plausible`, its records tiling the timeline at a
+    /// fill ratio of 0.990 — and still report **SDNN 174 ms** against a 40-100 ms physiological range,
+    /// because the ring decomposes each ~6.5 s record into 6 intervals whose SUM is right to ~1% (which
+    /// is why `meanNN` and resting HR stay correct and WHOOP-validated) while the individual values are
+    /// not beat-to-beat accurate. Measured on that night: within-5-minute SDNN of 123 ms after the
+    /// shipped Malik ectopic filter, against 30-80 ms physiological, with only 94 ms of the whole-night
+    /// figure attributable to genuine trend. Widening the ectopic window does not reach it (radius 2 →
+    /// 20 moves the within-window figure only 124 → 99 ms): each interval sits within 20% of its local
+    /// median, so no per-beat artifact rule can see the fault — it is in the decomposition, not in
+    /// outliers.
+    ///
+    /// Successive-difference statistics (RMSSD, pNN50) are deliberately NOT gated here, for the same
+    /// reason they are not gated by the coverage verdict: that is a question for a capture to answer.
+    public static func beatValuesAreTrustworthy(beatAccurateFraction: Double) -> Bool {
+        // Negated `<` so a NaN input lands on `true` — NaN means "not measured", and an unmeasured
+        // window must not be silently refused. Matches the NaN convention in `classifyCoverage`.
+        !(beatAccurateFraction < beatAccuracyMinFraction)
     }
 
     /// Tolerance BELOW 1.0 treated as "fits", the mirror of `coveragePlausibleCeiling`. Same allowance,

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RhythmScreener.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RhythmScreener.swift
@@ -257,6 +257,14 @@ public enum RhythmScreener {
             guard HRVAnalyzer.beatSpreadIsTrustworthy(verdict) else {
                 return .unreadable(nBeats: clean.count, confidence: confidence(for: clean.count))
             }
+            // Same gate, second fault: a BANKED stream stamps a whole record of intervals on one
+            // timestamp, so its stored values are a decomposition of a record period rather than
+            // beat-to-beat measurements. Coverage cannot see that — such a night can measure a
+            // textbook 1.03 — but every spread below is built from those values.
+            let accurate = HRVAnalyzer.beatAccurateFraction(tsSec: input.ts, rrMs: input.rrMs)
+            guard HRVAnalyzer.beatValuesAreTrustworthy(beatAccurateFraction: accurate) else {
+                return .unreadable(nBeats: clean.count, confidence: confidence(for: clean.count))
+            }
         }
 
         // Core descriptive statistics over the clean (range-filtered, ectopy-kept) series.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrCoverageVerdictTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrCoverageVerdictTests.swift
@@ -147,4 +147,75 @@ final class RrCoverageVerdictTests: XCTestCase {
             collapsed: HRVAnalyzer.collapsedCoverage(tsSec: bankedTs, rrMs: rr))
         XCTAssertFalse(HRVAnalyzer.beatSpreadIsTrustworthy(banked), "verdict was \(banked)")
     }
+
+    // MARK: - The second, independent fault: beat-VALUE accuracy (P7')
+
+    /// A beat-accurate stream steps one interval per beat, so each wall-clock gap equals its own R-R
+    /// value and the fraction is 1.0. This is what WHOOP R-R and the synthetic fixtures look like.
+    func testBeatAccurateStreamMeasuresFully() {
+        let rr = [Double](repeating: 1000.0, count: 60)     // 60 bpm, one beat per second
+        let ts = (0..<60).map { $0 }
+        XCTAssertEqual(HRVAnalyzer.beatAccurateFraction(tsSec: ts, rrMs: rr), 1.0, accuracy: 1e-9)
+        XCTAssertTrue(HRVAnalyzer.beatValuesAreTrustworthy(
+            beatAccurateFraction: HRVAnalyzer.beatAccurateFraction(tsSec: ts, rrMs: rr)))
+    }
+
+    /// A BANKED stream stamps a whole record of intervals on one timestamp, so nearly every gap is 0 s
+    /// against a ~1 s value. Six beats per record: five of every six gaps are 0, so the fraction lands
+    /// far below the boundary — the shape every measured Oura night has (2.6-6.6%).
+    func testBankedStreamIsNotBeatAccurateAndRefusesBeatValues() {
+        let rr = [Double](repeating: 1000.0, count: 60)
+        let ts = (0..<60).map { ($0 / 6) * 7 }              // 10 records of 6, 7 s apart
+        let frac = HRVAnalyzer.beatAccurateFraction(tsSec: ts, rrMs: rr)
+        XCTAssertLessThan(frac, HRVAnalyzer.beatAccuracyMinFraction)
+        XCTAssertFalse(HRVAnalyzer.beatValuesAreTrustworthy(beatAccurateFraction: frac))
+    }
+
+    /// **The case that motivated P7'.** The two faults are INDEPENDENT: this stream is perfectly
+    /// covered — one interval of beat-time per second of wall clock, so `classifyCoverage` says
+    /// `plausible` and the over-count gate passes it — yet the beats are banked six to a record, so
+    /// their individual values are a decomposition of a record period rather than beat-to-beat
+    /// measurements. The 2026-08-06 Oura night is exactly this shape (coverage 1.03, `plausible`,
+    /// SDNN 174 ms) and the over-count gate alone let it through.
+    func testAPerfectlyCoveredBankedNightStillRefusesBeatValues() {
+        // 10 records of 6 beats, records 7 s apart, so the span is 9 * 7 = 63 s. Sixty intervals of
+        // 1050 ms are exactly 63 s of beat-time: coverage lands on 1.0 while five of every six gaps
+        // are still 0 s. (Coverage is measured across the first-to-last STAMP, so the beat-time has to
+        // match that span, not the record count times the record period.)
+        let rr = [Double](repeating: 63_000.0 / 60.0, count: 60)
+        let ts = (0..<60).map { ($0 / 6) * 7 }
+        let verdict = HRVAnalyzer.classifyCoverage(
+            coverage: HRVAnalyzer.rrCoverage(tsSec: ts, rrMs: rr),
+            collapsed: HRVAnalyzer.collapsedCoverage(tsSec: ts, rrMs: rr))
+        XCTAssertTrue(HRVAnalyzer.beatSpreadIsTrustworthy(verdict),
+                      "the over-count gate must PASS this — that is the point (verdict \(verdict))")
+        let frac = HRVAnalyzer.beatAccurateFraction(tsSec: ts, rrMs: rr)
+        XCTAssertFalse(HRVAnalyzer.beatValuesAreTrustworthy(beatAccurateFraction: frac),
+                       "the beat-value gate must REFUSE it (fraction \(frac))")
+    }
+
+    /// A live spot reading carries no timestamps, so there is nothing to measure and nothing to refuse:
+    /// too-short input returns 1.0 and stays trusted. Suppressing honest live readings is the exact
+    /// failure this gate must not introduce.
+    func testTooShortOrMismatchedInputStaysTrusted() {
+        XCTAssertEqual(HRVAnalyzer.beatAccurateFraction(tsSec: [], rrMs: []), 1.0)
+        XCTAssertEqual(HRVAnalyzer.beatAccurateFraction(tsSec: [5], rrMs: [1000]), 1.0)
+        // Mismatched lengths cannot be paired up; refusing on that would be guessing.
+        XCTAssertEqual(HRVAnalyzer.beatAccurateFraction(tsSec: [0, 1, 2], rrMs: [1000]), 1.0)
+        XCTAssertTrue(HRVAnalyzer.beatValuesAreTrustworthy(beatAccurateFraction: 1.0))
+    }
+
+    /// NaN means "not measured", and an unmeasured window must not be silently refused — the same
+    /// negated-comparison convention `classifyCoverage` uses so both platforms fold NaN identically.
+    func testNaNAccuracyStaysTrusted() {
+        XCTAssertTrue(HRVAnalyzer.beatValuesAreTrustworthy(beatAccurateFraction: .nan))
+    }
+
+    /// The boundary itself: exactly at the minimum is trusted, just below is not.
+    func testBoundaryIsInclusive() {
+        XCTAssertTrue(HRVAnalyzer.beatValuesAreTrustworthy(
+            beatAccurateFraction: HRVAnalyzer.beatAccuracyMinFraction))
+        XCTAssertFalse(HRVAnalyzer.beatValuesAreTrustworthy(
+            beatAccurateFraction: HRVAnalyzer.beatAccuracyMinFraction - 0.01))
+    }
 }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -755,10 +755,21 @@ final class IntelligenceEngine: ObservableObject {
                     // `rrIntegrity=` field on the same line says why. RMSSD/meanNN are NOT withheld — mean
                     // rate survives an over-count, and RMSSD's dominant error was the emission order fixed
                     // at the write path (#1072).
+                    // P7' follow-up: the over-count verdict is necessary but NOT sufficient. The
+                    // 2026-08-06 Oura night measured coverage 1.03 / `plausible` — no duplication at
+                    // all, its records tiling the timeline at a fill ratio of 0.990 — and still printed
+                    // SDNN 174 ms. A BANKED stream stamps a whole record of intervals on one timestamp,
+                    // so its stored values are a decomposition of a record period, not beat-to-beat
+                    // measurements: the per-record SUM is right to ~1% (meanNN and RHR stay correct and
+                    // WHOOP-validated) while the individual intervals are not. Gate on that too.
+                    let accVal = HRVAnalyzer.beatAccurateFraction(tsSec: ts, rrMs: sleepRr)
+                    let acc = String(format: "%.2f", accVal)
                     let sdnnField = HRVAnalyzer.beatSpreadIsTrustworthy(verdict)
+                        && HRVAnalyzer.beatValuesAreTrustworthy(beatAccurateFraction: accVal)
                         ? "\(ms(h.sdnn))ms" : "withheld"
                     hrvDiag = "hrv diag day=\(res.daily.day) rmssd=\(ms(h.rmssd))ms sdnn=\(sdnnField) "
                         + "meanNN=\(ms(h.meanNN))ms rr=\(h.nInput)/\(h.nClean) rejected=\(rej)% coverage=\(cov) collapsedCov=\(colCov) dupBeats=\(dup) "
+                        + "beatAccurate=\(acc) "
                         + "rrIntegrity=\(verdict.rawValue)"
                 }
                 // ── Steps test mode: 5/MG raw-counter trace ──────────────────────────────────────────────

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -390,6 +390,71 @@ object HrvAnalyzer {
         RrCoverageVerdict.UNMEASURABLE -> true
     }
 
+    /**
+     * How closely a beat's own wall-clock gap matches its own R-R value: the fraction of consecutive
+     * beats whose `ts` step is within [BEAT_ACCURACY_TOLERANCE_S] of their interval. Pure. Byte-parity
+     * twin of Swift `beatAccurateFraction`. Returns 1.0 for fewer than 2 beats — absence of evidence is
+     * not evidence of banking, and the caller's own beat-count gates handle a series that short.
+     *
+     * A BEAT-ACCURATE stream steps one interval per beat, so the gap and the value agree and the
+     * fraction is ~1.0 (WHOOP R-R, live spot readings, the synthetic fixtures). A BANKED stream stamps
+     * a whole record of intervals on one coarse timestamp, so nearly every gap is 0 s against a ~1 s
+     * value and the fraction collapses toward 0.
+     */
+    fun beatAccurateFraction(tsSec: List<Long>, rrMs: List<Double>): Double {
+        if (tsSec.size != rrMs.size || tsSec.size < 2) return 1.0
+        var accurate = 0
+        for (i in 1 until tsSec.size) {
+            val gapS = (tsSec[i] - tsSec[i - 1]).toDouble()
+            if (kotlin.math.abs(gapS - rrMs[i] / 1000.0) <= BEAT_ACCURACY_TOLERANCE_S) accurate++
+        }
+        return accurate.toDouble() / (tsSec.size - 1).toDouble()
+    }
+
+    /**
+     * Tolerance (seconds) allowed between a beat's wall-clock gap and its own R-R value before the beat
+     * is counted as not time-accurate. Whole-second `ts` against a sub-second interval means an honest
+     * stream still rounds, so this is deliberately loose. Twin of Swift `beatAccuracyToleranceS`.
+     */
+    const val BEAT_ACCURACY_TOLERANCE_S: Double = 0.5
+
+    /**
+     * Fraction of beats that must be time-accurate before BEAT-VALUE statistics are trusted.
+     *
+     * Not a tuned threshold: the two populations do not overlap anywhere near it. A beat-accurate
+     * stream measures ~100%; every banked Oura overnight measured to date sits at **2.6-6.6%**
+     * (five nights, 2026-07-29 -> 08-06). Anything in the middle is a stream we have never seen and
+     * should not be guessing about, which is what a mid-range boundary expresses.
+     * Twin of Swift `beatAccuracyMinFraction`.
+     */
+    const val BEAT_ACCURACY_MIN_FRACTION: Double = 0.5
+
+    /**
+     * Whether a window's BEAT-VALUE statistics — SDNN above all — can be trusted, given how
+     * time-accurate its beats are. Pure. Byte-parity twin of Swift `beatValuesAreTrustworthy`.
+     *
+     * This is a SEPARATE failure from [beatSpreadIsTrustworthy]'s, and neither implies the other.
+     * That one asks "is the same beat held twice?"; this one asks "is each stored interval a real
+     * beat-to-beat measurement at all?" A banked stream can be perfectly covered — the 2026-08-06
+     * Oura night measured coverage 1.03, verdict PLAUSIBLE, its records tiling the timeline at a fill
+     * ratio of 0.990 — and still report **SDNN 174 ms** against a 40-100 ms physiological range,
+     * because the ring decomposes each ~6.5 s record into 6 intervals whose SUM is right to ~1% (which
+     * is why meanNN and resting HR stay correct and WHOOP-validated) while the individual values are
+     * not beat-to-beat accurate. Measured on that night: within-5-minute SDNN of 123 ms after the
+     * shipped Malik ectopic filter, against 30-80 ms physiological, with only 94 ms of the whole-night
+     * figure attributable to genuine trend. Widening the ectopic window does not reach it (radius 2 ->
+     * 20 moves the within-window figure only 124 -> 99 ms): each interval sits within 20% of its local
+     * median, so no per-beat artifact rule can see the fault — it is in the decomposition, not in
+     * outliers.
+     *
+     * Successive-difference statistics (RMSSD, pNN50) are deliberately NOT gated here, for the same
+     * reason they are not gated by the coverage verdict: that is a question for a capture to answer.
+     */
+    fun beatValuesAreTrustworthy(beatAccurateFraction: Double): Boolean =
+        // Negated `<` so a NaN input lands on `true` — NaN means "not measured", and an unmeasured
+        // window must not be silently refused. Matches the NaN convention in [classifyCoverage].
+        !(beatAccurateFraction < BEAT_ACCURACY_MIN_FRACTION)
+
     /** Classify a night from its coverage pair. Pure. Byte-parity twin of Swift `classifyCoverage`.
      *
      *  Both platforms use the NEGATED `>` form rather than `<=` so a non-finite input lands identically:

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -637,10 +637,21 @@ object IntelligenceEngine {
                 // `rrIntegrity=` field on the same line says why. RMSSD/meanNN are NOT withheld — mean rate
                 // survives an over-count, and RMSSD's dominant error was the emission order fixed at the
                 // write path (#1072). Twin of the Swift line.
+                // P7' follow-up: the over-count verdict is necessary but NOT sufficient. The 2026-08-06
+                // Oura night measured coverage 1.03 / PLAUSIBLE — no duplication at all, its records
+                // tiling the timeline at a fill ratio of 0.990 — and still printed SDNN 174 ms. A BANKED
+                // stream stamps a whole record of intervals on one timestamp, so its stored values are a
+                // decomposition of a record period, not beat-to-beat measurements: the per-record SUM is
+                // right to ~1% (meanNN and RHR stay correct and WHOOP-validated) while the individual
+                // intervals are not. Gate on that too. Twin of the Swift line.
+                val accVal = HrvAnalyzer.beatAccurateFraction(ts, sleepRr)
+                val acc = String.format(java.util.Locale.US, "%.2f", accVal)
                 val sdnnField =
-                    if (HrvAnalyzer.beatSpreadIsTrustworthy(verdict)) "${ms(h.sdnn)}ms" else "withheld"
+                    if (HrvAnalyzer.beatSpreadIsTrustworthy(verdict) &&
+                        HrvAnalyzer.beatValuesAreTrustworthy(accVal)) "${ms(h.sdnn)}ms" else "withheld"
                 diag("hrv diag day=${res.daily.day} rmssd=${ms(h.rmssd)}ms sdnn=$sdnnField meanNN=${ms(h.meanNN)}ms " +
                     "rr=${h.nInput}/${h.nClean} rejected=$rej% coverage=$cov collapsedCov=$colCov dupBeats=$dup " +
+                    "beatAccurate=$acc " +
                     "rrIntegrity=${verdict.raw}")
             }
 

--- a/android/app/src/main/java/com/noop/analytics/RhythmScreener.kt
+++ b/android/app/src/main/java/com/noop/analytics/RhythmScreener.kt
@@ -183,6 +183,14 @@ object RhythmScreener {
             if (!HrvAnalyzer.beatSpreadIsTrustworthy(verdict)) {
                 return WindowResult.unreadable(nBeats = clean.size, confidence = confidence(clean.size))
             }
+            // Same gate, second fault: a BANKED stream stamps a whole record of intervals on one
+            // timestamp, so its stored values are a decomposition of a record period rather than
+            // beat-to-beat measurements. Coverage cannot see that — such a night can measure a
+            // textbook 1.03 — but every spread below is built from those values. Twin of the Swift gate.
+            val accurate = HrvAnalyzer.beatAccurateFraction(tsLong, input.rrMs)
+            if (!HrvAnalyzer.beatValuesAreTrustworthy(accurate)) {
+                return WindowResult.unreadable(nBeats = clean.size, confidence = confidence(clean.size))
+            }
         }
 
         // Core descriptive statistics over the clean (range-filtered, ectopy-kept) series.

--- a/android/app/src/test/java/com/noop/analytics/HrvRrCoverageTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvRrCoverageTest.kt
@@ -119,4 +119,64 @@ class HrvRrCoverageTest {
             HrvAnalyzer.rrCoverage(bankedTs, rr), HrvAnalyzer.collapsedCoverage(bankedTs, rr))
         assertFalse("verdict was $banked", HrvAnalyzer.beatSpreadIsTrustworthy(banked))
     }
+
+    // --- The second, independent fault: beat-VALUE accuracy (P7'). Twin of the Swift tests. ---
+
+    /** A beat-accurate stream steps one interval per beat, so each wall-clock gap equals its own R-R
+     *  value and the fraction is 1.0. This is what WHOOP R-R and the synthetic fixtures look like. */
+    @Test fun beatAccurateFraction_isFullOnABeatAccurateStream() {
+        val rr = List(60) { 1000.0 }
+        val ts = (0 until 60).map { it.toLong() }
+        assertEquals(1.0, HrvAnalyzer.beatAccurateFraction(ts, rr), 1e-9)
+        assertTrue(HrvAnalyzer.beatValuesAreTrustworthy(HrvAnalyzer.beatAccurateFraction(ts, rr)))
+    }
+
+    /** A BANKED stream stamps a whole record of intervals on one timestamp, so nearly every gap is 0 s
+     *  against a ~1 s value. Six beats per record: five of every six gaps are 0, so the fraction lands
+     *  far below the boundary — the shape every measured Oura night has (2.6-6.6%). */
+    @Test fun beatAccurateFraction_collapsesOnABankedStream() {
+        val rr = List(60) { 1000.0 }
+        val ts = (0 until 60).map { ((it / 6) * 7).toLong() }
+        val frac = HrvAnalyzer.beatAccurateFraction(ts, rr)
+        assertTrue("fraction was $frac", frac < HrvAnalyzer.BEAT_ACCURACY_MIN_FRACTION)
+        assertFalse(HrvAnalyzer.beatValuesAreTrustworthy(frac))
+    }
+
+    /** **The case that motivated P7'.** The two faults are INDEPENDENT: this stream is perfectly
+     *  covered — 60 intervals of 1050 ms are exactly the 63 s first-to-last span, so classifyCoverage
+     *  says PLAUSIBLE and the over-count gate passes it — yet the beats are banked six to a record, so
+     *  their individual values are a decomposition of a record period, not beat-to-beat measurements.
+     *  The 2026-08-06 Oura night is exactly this shape (coverage 1.03, PLAUSIBLE, SDNN 174 ms). */
+    @Test fun aPerfectlyCoveredBankedNightStillRefusesBeatValues() {
+        val rr = List(60) { 63_000.0 / 60.0 }
+        val ts = (0 until 60).map { ((it / 6) * 7).toLong() }
+        val verdict = HrvAnalyzer.classifyCoverage(
+            HrvAnalyzer.rrCoverage(ts, rr), HrvAnalyzer.collapsedCoverage(ts, rr))
+        assertTrue("the over-count gate must PASS this — that is the point (verdict $verdict)",
+            HrvAnalyzer.beatSpreadIsTrustworthy(verdict))
+        val frac = HrvAnalyzer.beatAccurateFraction(ts, rr)
+        assertFalse("the beat-value gate must REFUSE it (fraction $frac)",
+            HrvAnalyzer.beatValuesAreTrustworthy(frac))
+    }
+
+    /** A live spot reading carries no timestamps, so there is nothing to measure and nothing to refuse:
+     *  too-short or mismatched input returns 1.0 and stays trusted. */
+    @Test fun beatAccurateFraction_tooShortOrMismatchedStaysTrusted() {
+        assertEquals(1.0, HrvAnalyzer.beatAccurateFraction(emptyList(), emptyList()), 1e-9)
+        assertEquals(1.0, HrvAnalyzer.beatAccurateFraction(listOf(5L), listOf(1000.0)), 1e-9)
+        assertEquals(1.0, HrvAnalyzer.beatAccurateFraction(listOf(0L, 1L, 2L), listOf(1000.0)), 1e-9)
+        assertTrue(HrvAnalyzer.beatValuesAreTrustworthy(1.0))
+    }
+
+    /** NaN means "not measured", and an unmeasured window must not be silently refused — the same
+     *  negated-comparison convention classifyCoverage uses so both platforms fold NaN identically. */
+    @Test fun beatValuesAreTrustworthy_nanStaysTrusted() {
+        assertTrue(HrvAnalyzer.beatValuesAreTrustworthy(Double.NaN))
+    }
+
+    /** The boundary itself: exactly at the minimum is trusted, just below is not. */
+    @Test fun beatValuesAreTrustworthy_boundaryIsInclusive() {
+        assertTrue(HrvAnalyzer.beatValuesAreTrustworthy(HrvAnalyzer.BEAT_ACCURACY_MIN_FRACTION))
+        assertFalse(HrvAnalyzer.beatValuesAreTrustworthy(HrvAnalyzer.BEAT_ACCURACY_MIN_FRACTION - 0.01))
+    }
 }


### PR DESCRIPTION
## What this fixes

#1085 taught the app to refuse SDNN on an over-counted capture. The drain the night after it merged
showed that gate is **necessary but not sufficient**: the 2026-08-06 Oura night measured
`coverage 1.03`, `rrIntegrity=plausible` — no duplication at all, its records tiling the timeline at
a fill ratio of 0.990 — and still printed **SDNN 174 ms** against a 40-100 ms physiological range.

Over-counting was never what made that number wrong.

A **banked** stream stamps a whole record of intervals on one coarse timestamp, so the stored values
are a *decomposition of a record period* rather than beat-to-beat measurements. The per-record SUM is
right to ~1% — which is why `meanNN` and resting HR stay correct and WHOOP-validated — while the
individual intervals are not. Coverage cannot see that fault by construction: it compares beat-time
against wall-clock, and a banked night can be textbook.

## Evidence

Measured on that night, **after** the shipped Malik ectopic filter:

| | measured | physiological |
|---|---|---|
| whole-night SDNN | 174 ms | 40-100 |
| within-5-minute SDNN (median, n=106) | **123 ms** | 30-80 |
| of which genuine trend (SD of 5-min medians) | 94 ms | — HR really moves 47-86 bpm |

And the fault is **not** reachable by artifact rejection — each interval sits within 20% of its own
local median, so no per-beat rule sees it:

| ectopic window radius | 2 (shipped) | 5 | 12 | 20 |
|---|---|---|---|---|
| within-5-min SDNN | 124 ms | 115 | 105 | 99 |
| beats kept | 91.0% | 90.8% | 89.9% | 89.3% |

## The change

* `beatAccurateFraction(tsSec:rrMs:)` — fraction of consecutive beats whose wall-clock gap matches
  their own R-R value. Beat-accurate streams step one interval per beat and measure ~1.0; a banked
  stream's gaps are 0 s against ~1 s values and it collapses toward 0.
* `beatValuesAreTrustworthy(beatAccurateFraction:)` — SDNN withheld below the boundary. Independent
  of `beatSpreadIsTrustworthy`: **neither implies the other**, and both now gate.
* `hrv diag` gains `beatAccurate=`, so the distribution can be gathered from traces that already
  exist — the same way `coverage=` was logged before anything acted on it.

**The boundary is not tuned.** The two populations do not overlap near it: a beat-accurate stream
measures ~100%, every banked Oura overnight measured to date sits at **2.6-6.6%** (five nights,
2026-07-29 → 08-06). A mid-range boundary is the honest expression of "anything in between is a
stream we have never seen".

## Scope held deliberately narrow

* **RMSSD / pNN50 stay ungated**, for the same reason they are ungated by the coverage verdict.
* **Live spot readings untouched** — too-short or mismatched input returns 1.0 and stays trusted, so
  an honest live capture is never suppressed. That is pinned by a test.
* The constants **duplicate** the ones the respiration gate uses for the same judgement (#882/#883)
  rather than sharing them, because that gate lives in `SleepStager` on a branch that is not
  upstream. If it lands, the two should collapse onto this definition — the boundary is worth drawing
  once, in one place, for both.

## Verification

* `swift test` StrandAnalytics **1,248** tests, incl. 6 new. The decisive one pins a **perfectly
  covered banked night** (coverage 1.0, verdict `plausible`) *passing* the over-count gate and being
  *refused* by the new one — the exact case that motivated this.
* Kotlin twins of each in `HrvRrCoverageTest`. `./gradlew testFullDebugUnitTest` **3,516** tests with
  the same **3 pre-existing locale failures as clean `main`** — verified by running those same tests
  on a clean `upstream/main` worktree, not assumed.
* `Strand` (macOS) built locally: `IntelligenceEngine.swift` is app-target Swift that no default CI
  job compiles.

## Not claimed

This does not make Oura SDNN correct — it makes the app stop reporting it. Recovering a real HRV
number from this ring needs the ring's own `0x5D` tag (P6d), which is separate work.