### PR TITLE
Break the BGTask completion-guard retain cycle (follow-up to #955)

### DIFF
--- a/Strand/System/ScheduledDebugExport.swift
+++ b/Strand/System/ScheduledDebugExport.swift
@@ -331,6 +331,11 @@ enum ScheduledDebugExport {
             guard !finished else { return }
             finished = true
             task.setTaskCompleted(success: success)
+            // Break the retain cycle set up in `register()` (task → expirationHandler closure → self →
+            // task). The handler is useless once the task is completed, so drop it here; without this the
+            // guard + task + closure leak until the system happens to release the task. Harmless to nil
+            // after completion.
+            task.expirationHandler = nil
         }
     }
 


### PR DESCRIPTION
Follow-up to #955.

## Problem

#955 added `TaskCompletionGuard` to stop the scheduled-export BGTask handler calling `setTaskCompleted` twice. The guard holds its `BGTask` strongly, and `register()` installs:

```swift
task.expirationHandler = { completion.finish(success: false) }
```

which captures the guard strongly. That's a retain cycle — **task → expirationHandler closure → guard → task** — so the guard + task + closure leak after each run until the system happens to release the task.

## Fix

Nil the `expirationHandler` inside `finish()` once `setTaskCompleted` has been called:

```swift
task.setTaskCompleted(success: success)
task.expirationHandler = nil   // release the closure → break the cycle
```

The handler is useless after completion, so dropping it releases the closure and breaks the cycle. It's:
- **idempotent** — `finish()` early-returns on a second call, so this runs exactly once;
- **race-safe** — done under the same `NSLock` as the completion flag, and nil-ing a closure that may be mid-execution on another queue is safe (the executing closure retains itself while running).

## Scope
- One concern. iOS-only (inside `#if os(iOS)`); no macOS build or behaviour change, no change to the export logic or the completion semantics #955 established.

## Verification
- **App-target iOS Swift** — no default CI job compiles it (`app-build.yml` is disabled). The change is a single settable-property assignment (`BGTask.expirationHandler` is `(() -> Void)?`); worth an `app-build.yml` (`NOOPiOS`) compile-check before merge, same as the parent PR.