### PR TITLE
Sleep tab: customise & reorder cards (like Today)

### DIFF
--- a/Strand/Data/SleepLayoutPrefs.swift
+++ b/Strand/Data/SleepLayoutPrefs.swift
@@ -1,0 +1,131 @@
+import Foundation
+import SwiftUI
+
+// MARK: - Reorderable Sleep sections (#sleep-layout)
+//
+// The Sleep tab's analytical cards — Sleep marks, the Stages hypnogram, Naps, Night detail, the Sleep-debt
+// ledger, Stages-vs-typical, and the Asleep-duration trend — render in one fixed order below the pinned
+// Sleep-performance hero + date navigator. This lets the user REORDER or HIDE those cards, mirroring the
+// Today tab's Arrange sheet (see `TodayLayoutPrefs`), with the default being the original order so nothing
+// changes for anyone who never customises Sleep. Display-only — no metric is computed or stored
+// differently; this only decides which already-built cards render and in what sequence.
+//
+// Stored as a single comma-joined string of section keys in @AppStorage("sleep.sectionOrder"), the same
+// mechanism `TodayLayoutPrefs`/`KeyMetricPrefs` use. The Android side mirrors this byte-identically in
+// SleepLayoutPrefs.kt (SharedPreferences "sleep.sectionOrder"). Every known section stays in the ORDER
+// registry: unknown tokens are dropped, and any known section missing from the saved order is INSERTED at
+// its default-order position relative to the saved sections — so a card added in a later version surfaces
+// where users expect it rather than teleporting to the bottom of an existing saved order.
+//
+// User visibility is stored separately in "sleep.hiddenSections". Keeping order and visibility separate is
+// intentional: hiding is reversible, a hidden card keeps its stable identity, and a card introduced by a
+// future version defaults to visible because it is absent from the explicit hidden set.
+//
+// The Sleep-performance hero and the date navigator are NOT reorderable — they are the fixed frame of the
+// tab, exactly as the Today hero is pinned above its arrangeable sections.
+
+/// One reorderable Sleep card. The rawValue is the stable persisted identifier — keep it byte-identical to
+/// the Android `SleepSection` enum so a backup/restore reads the same layout on either OS.
+enum SleepSection: String, CaseIterable, Identifiable {
+    case sleepMarks
+    case stages
+    case naps
+    case nightDetail
+    case sleepDebt
+    case stagesVsTypical
+    case asleepDuration
+
+    var id: String { rawValue }
+
+    /// The card's display label in the Arrange sheet — matches the Android `SleepSection.title`.
+    var title: String {
+        switch self {
+        case .sleepMarks:      return String(localized: "Sleep marks")
+        case .stages:          return String(localized: "Stages")
+        case .naps:            return String(localized: "Naps")
+        case .nightDetail:     return String(localized: "Night detail")
+        case .sleepDebt:       return String(localized: "Sleep-debt ledger")
+        case .stagesVsTypical: return String(localized: "Stages vs typical")
+        case .asleepDuration:  return String(localized: "Asleep duration")
+        }
+    }
+
+    /// The original, hard-coded card order — the default when the layout isn't customised. Matches the
+    /// pre-customisation render order in `SleepView` (Naps sits directly under Stages, where it was drawn
+    /// inside the stages hero before it became independently arrangeable).
+    static let defaultOrder: [SleepSection] = [
+        .sleepMarks, .stages, .naps, .nightDetail, .sleepDebt, .stagesVsTypical, .asleepDuration,
+    ]
+}
+
+/// Display-only persistence for the Sleep card order and visibility. The order registry always contains
+/// every known card; `hiddenKey` stores the explicit reversible hidden set. Mirrors Android byte-for-byte,
+/// and is a direct twin of `TodayLayoutPrefs` with a `sleep.` key namespace.
+enum SleepLayoutPrefs {
+    /// UserDefaults key — a comma-joined list of `SleepSection` rawValues in display order.
+    static let orderKey = "sleep.sectionOrder"
+    /// UserDefaults key — a comma-joined list of explicitly hidden `SleepSection` rawValues.
+    static let hiddenKey = "sleep.hiddenSections"
+
+    /// Encode an ordered card list into the stored comma-joined string.
+    static func encode(_ sections: [SleepSection]) -> String {
+        sections.map(\.rawValue).joined(separator: ",")
+    }
+
+    /// Encode the explicit hidden set in stable list order. The editor passes its Hidden-card order;
+    /// rendering treats the decoded value as a set.
+    static func encodeHidden(_ sections: [SleepSection]) -> String {
+        sections.map(\.rawValue).joined(separator: ",")
+    }
+
+    /// Decode the stored string into the FULL ordered card list. An empty/unset string yields the default
+    /// order. Unknown tokens are ignored, duplicates collapsed, and any known card missing from the saved
+    /// order is INSERTED at its default-order position relative to the saved cards (before the first saved
+    /// card that follows it in the default order; appended when none does) — so every card always renders,
+    /// and one added in a later app version surfaces where users expect it instead of teleporting to the
+    /// bottom of an existing saved order. Twin of the Kotlin `decodeOrder`.
+    static func decodeOrder(_ raw: String) -> [SleepSection] {
+        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return SleepSection.defaultOrder }
+        var saved: [SleepSection] = []
+        for token in trimmed.split(separator: ",") {
+            if let s = SleepSection(rawValue: token.trimmingCharacters(in: .whitespaces)), !saved.contains(s) {
+                saved.append(s)
+            }
+        }
+        guard !saved.isEmpty else { return SleepSection.defaultOrder }
+        // Iterate allCases (not defaultOrder) so a future case accidentally left out of defaultOrder can
+        // never be silently hidden; a card without a default index sorts after everything. defaultOrder
+        // covering allCases is pinned by SleepLayoutPrefsTests on both platforms.
+        func defIdx(_ s: SleepSection) -> Int {
+            SleepSection.defaultOrder.firstIndex(of: s) ?? SleepSection.defaultOrder.count
+        }
+        for missing in SleepSection.allCases where !saved.contains(missing) {
+            let insertAt = saved.firstIndex { defIdx($0) > defIdx(missing) }
+            if let insertAt { saved.insert(missing, at: insertAt) } else { saved.append(missing) }
+        }
+        return saved
+    }
+
+    /// Decode explicitly hidden cards. Empty/unset means nothing is hidden. Unknown tokens are ignored and
+    /// duplicates collapsed; unlike `decodeOrder`, missing cases are NOT inserted because absence here means
+    /// visible (including a card introduced by a future app version).
+    static func decodeHidden(_ raw: String) -> [SleepSection] {
+        var seen = Set<SleepSection>()
+        var hidden: [SleepSection] = []
+        for token in raw.split(separator: ",") {
+            if let section = SleepSection(rawValue: token.trimmingCharacters(in: .whitespaces)),
+               seen.insert(section).inserted {
+                hidden.append(section)
+            }
+        }
+        return hidden
+    }
+
+    /// The cards Sleep should render, preserving the full saved order while filtering only the user's
+    /// explicit hidden set. At least one visible card is enforced by the editor, not the decoder.
+    static func visibleOrder(orderRaw: String, hiddenRaw: String) -> [SleepSection] {
+        let hidden = Set(decodeHidden(hiddenRaw))
+        return decodeOrder(orderRaw).filter { !hidden.contains($0) }
+    }
+}

--- a/Strand/Data/SleepLayoutPrefs.swift
+++ b/Strand/Data/SleepLayoutPrefs.swift
@@ -29,7 +29,6 @@ import SwiftUI
 enum SleepSection: String, CaseIterable, Identifiable {
     case sleepMarks
     case stages
-    case naps
     case nightDetail
     case sleepDebt
     case stagesVsTypical
@@ -42,7 +41,6 @@ enum SleepSection: String, CaseIterable, Identifiable {
         switch self {
         case .sleepMarks:      return String(localized: "Sleep marks")
         case .stages:          return String(localized: "Stages")
-        case .naps:            return String(localized: "Naps")
         case .nightDetail:     return String(localized: "Night detail")
         case .sleepDebt:       return String(localized: "Sleep-debt ledger")
         case .stagesVsTypical: return String(localized: "Stages vs typical")
@@ -51,10 +49,11 @@ enum SleepSection: String, CaseIterable, Identifiable {
     }
 
     /// The original, hard-coded card order — the default when the layout isn't customised. Matches the
-    /// pre-customisation render order in `SleepView` (Naps sits directly under Stages, where it was drawn
-    /// inside the stages hero before it became independently arrangeable).
+    /// pre-customisation render order in `SleepView` below the pinned Sleep-performance hero. (Naps rides
+    /// with Stages for now — it's drawn inside the stages hero; making it an independently arrangeable
+    /// card is a follow-up that requires hoisting the hero's edit/delete callbacks.)
     static let defaultOrder: [SleepSection] = [
-        .sleepMarks, .stages, .naps, .nightDetail, .sleepDebt, .stagesVsTypical, .asleepDuration,
+        .sleepMarks, .stages, .nightDetail, .sleepDebt, .stagesVsTypical, .asleepDuration,
     ]
 }
 

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -173464,6 +173464,162 @@
           }
         }
       }
+    },
+    "Customize": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anpassen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalizar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personnaliser"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalizza"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalizar"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настроить"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自訂"
+          }
+        }
+      }
+    },
+    "Customize Sleep": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schlaf anpassen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalizar Sueño"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personnaliser le sommeil"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalizza Sonno"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalizar Sono"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настроить сон"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义睡眠"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自訂睡眠"
+          }
+        }
+      }
+    },
+    "Shown": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Angezeigt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Affiché"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrato"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrado"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показано"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已显示"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已顯示"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Strand/Screens/SleepCustomizationSheet.swift
+++ b/Strand/Screens/SleepCustomizationSheet.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+import StrandDesign
+
+// MARK: - Sleep card customization (#sleep-layout)
+
+/// The Sleep tab's "Arrange" sheet — reorder / show-hide the analytical cards. A single-page twin of
+/// `TodayCustomizationSheet` (Sleep has no nested editors), driven by the SAME generic `EditableLayoutList`
+/// so the reorder/hide UX is byte-for-byte Today's. Persists via `SleepLayoutPrefs`; the render side
+/// (`SleepView`) reads the same `@AppStorage` keys and re-lays-out on save.
+struct SleepCustomizationSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    private let initialDraft: EditableLayoutDraft<SleepSection>
+
+    @Binding private var sectionOrderRaw: String
+    @Binding private var hiddenSectionsRaw: String
+
+    @State private var draft: EditableLayoutDraft<SleepSection>
+
+    private var isDirty: Bool { draft != initialDraft }
+
+    init(sectionOrderRaw: Binding<String>, hiddenSectionsRaw: Binding<String>) {
+        _sectionOrderRaw = sectionOrderRaw
+        _hiddenSectionsRaw = hiddenSectionsRaw
+
+        let fullOrder = SleepLayoutPrefs.decodeOrder(sectionOrderRaw.wrappedValue)
+        let hiddenSet = Set(SleepLayoutPrefs.decodeHidden(hiddenSectionsRaw.wrappedValue))
+        let d = EditableLayoutDraft(
+            visible: fullOrder.filter { !hiddenSet.contains($0) },
+            hidden: fullOrder.filter { hiddenSet.contains($0) }
+        )
+        initialDraft = d
+        _draft = State(initialValue: d)
+    }
+
+    var body: some View {
+        NavigationStack {
+            EditableLayoutList(
+                draft: $draft,
+                shownTitle: String(localized: "Shown"),
+                hiddenTitle: String(localized: "Hidden"),
+                title: \.title,
+                subtitle: { _ in nil },
+                icon: \.customizationIcon,
+                tint: \.customizationTint,
+                configurationLabel: { _ in nil },
+                onConfigure: { _ in },
+                onReset: {
+                    draft = EditableLayoutDraft(
+                        visible: SleepSection.defaultOrder,
+                        allItems: SleepSection.defaultOrder
+                    )
+                }
+            ) {
+                EmptyView()
+            }
+            .navigationTitle("Customize Sleep")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                }
+            }
+        }
+        .interactiveDismissDisabled(isDirty)
+        .tint(StrandPalette.accent)
+        #if os(macOS)
+        .frame(
+            minWidth: NoopMetrics.editorSheetMinWidth,
+            minHeight: NoopMetrics.editorSheetMinHeight
+        )
+        #endif
+    }
+
+    private func save() {
+        // Store the FULL order (shown ++ hidden, so a hidden card keeps a stable slot) + the hidden set,
+        // matching SleepLayoutPrefs and the Android SleepArrangeSheet.
+        sectionOrderRaw = SleepLayoutPrefs.encode(draft.visible + draft.hidden)
+        hiddenSectionsRaw = SleepLayoutPrefs.encodeHidden(draft.hidden)
+        dismiss()
+    }
+}
+
+// MARK: - Per-card Arrange-sheet metadata (icon + tint), mirroring TodaySection's
+
+extension SleepSection {
+    /// SF Symbol shown beside the card's name in the Arrange sheet.
+    var customizationIcon: String {
+        switch self {
+        case .sleepMarks:      return "bed.double"
+        case .stages:          return "chart.bar.xaxis"
+        case .nightDetail:     return "square.grid.2x2"
+        case .sleepDebt:       return "arrow.down.right.circle"
+        case .stagesVsTypical: return "chart.bar"
+        case .asleepDuration:  return "clock"
+        }
+    }
+
+    /// Tint for the card's Arrange-sheet icon. Sleep cards live in the Rest world, so they lean on the
+    /// rest palette with the accent for the log/marks entry.
+    var customizationTint: Color {
+        switch self {
+        case .sleepMarks:      return StrandPalette.accent
+        case .stages:          return StrandPalette.restColor
+        case .nightDetail:     return StrandPalette.restBright
+        case .sleepDebt:       return StrandPalette.effortColor
+        case .stagesVsTypical: return StrandPalette.restColor
+        case .asleepDuration:  return StrandPalette.restBright
+        }
+    }
+}

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -113,6 +113,17 @@ struct SleepView: View {
     /// the user hits Undo, so a stale timer can't clear a fresh banner.
     @State private var sleepUndoTask: Task<Void, Never>?
 
+    // #sleep-layout: the arrangeable analytical-card order + explicit hidden set, byte-identical to the
+    // Android SleepLayoutPrefs keys. Reordered via the Arrange sheet; display-only, no metric changes.
+    @AppStorage(SleepLayoutPrefs.orderKey) private var sleepSectionOrderRaw = ""
+    @AppStorage(SleepLayoutPrefs.hiddenKey) private var sleepHiddenSectionsRaw = ""
+    @State private var showSleepCustomize = false
+
+    /// The analytical cards to render, in saved order minus the hidden set.
+    private var sleepVisibleSections: [SleepSection] {
+        SleepLayoutPrefs.visibleOrder(orderRaw: sleepSectionOrderRaw, hiddenRaw: sleepHiddenSectionsRaw)
+    }
+
     var body: some View {
         // Resolve the memoized model for THIS render. `dataKey` is O(1)-ish (counts + last-row
         // identity), so comparing it every render is cheap. When it matches the cached key we
@@ -136,12 +147,12 @@ struct SleepView: View {
                     VStack(alignment: .leading, spacing: NoopMetrics.sectionSpacing) {
                         if let sleepUndo { sleepUndoBanner(sleepUndo) }
                         restHero(resolved).staggeredAppear(index: 0)
-                        SleepMarkCard().staggeredAppear(index: 1)
-                        hero(resolved).staggeredAppear(index: 2)
-                        metricGrid(resolved).staggeredAppear(index: 3)
-                        sleepDebtLedger(resolved).staggeredAppear(index: 4)
-                        stagesVsTypical(resolved).staggeredAppear(index: 5)
-                        durationTrend(resolved).staggeredAppear(index: 6)
+                        sleepArrangeAffordance.staggeredAppear(index: 1)
+                        // #sleep-layout: the analytical cards render in the user's saved order minus the
+                        // hidden set, below the pinned Rest hero. Reordered via the Arrange sheet.
+                        ForEach(Array(sleepVisibleSections.enumerated()), id: \.element) { idx, section in
+                            sleepSectionView(section, resolved).staggeredAppear(index: idx + 2)
+                        }
                     }
                 } else {
                     emptyState
@@ -233,6 +244,12 @@ struct SleepView: View {
             // Manually add a missed nap (#508): same picker, but the chosen window is staged from raw and
             // stored as its OWN separate session — never folded into main sleep (which would mislabel the
             // awake daytime gap as light sleep).
+            .sheet(isPresented: $showSleepCustomize) {
+                SleepCustomizationSheet(
+                    sectionOrderRaw: $sleepSectionOrderRaw,
+                    hiddenSectionsRaw: $sleepHiddenSectionsRaw
+                )
+            }
             .sheet(item: $addNap) { seed in
                 SleepTimeEditor(bedTs: seed.bedTs, wakeTs: seed.wakeTs,
                                 title: "Add a nap",
@@ -373,6 +390,36 @@ struct SleepView: View {
     /// — the score is `performanceScore(for:)` on the ◀/▶-navigated `heroNight`, so the hero tracks the
     /// same night the hypnogram shows (was pinned to `performance.latest` = last night regardless).
     @ViewBuilder
+    /// Dispatch a reorderable Sleep section to its card. Naps rides with `.stages` (drawn inside the stages
+    /// hero); the Rest hero is pinned outside this list. Mirrors the Android SleepScreen `when(section)`.
+    @ViewBuilder
+    private func sleepSectionView(_ section: SleepSection, _ model: SleepModel) -> some View {
+        switch section {
+        case .sleepMarks:      SleepMarkCard()
+        case .stages:          hero(model)
+        case .nightDetail:     metricGrid(model)
+        case .sleepDebt:       sleepDebtLedger(model)
+        case .stagesVsTypical: stagesVsTypical(model)
+        case .asleepDuration:  durationTrend(model)
+        }
+    }
+
+    /// The compact "Customize" affordance above the arrangeable cards — opens the Arrange sheet. Mirrors
+    /// the Today tab's arrange entry and the Android Sleep affordance.
+    private var sleepArrangeAffordance: some View {
+        HStack(spacing: 0) {
+            Spacer()
+            Button {
+                showSleepCustomize = true
+            } label: {
+                Label("Customize", systemImage: "slider.horizontal.3")
+                    .font(StrandFont.footnote)
+                    .foregroundStyle(StrandPalette.textTertiary)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
     private func restHero(_ model: SleepModel) -> some View {
         let night = heroNight(model)
         let score = performanceScore(for: night)

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -382,14 +382,6 @@ struct SleepView: View {
         return min(max(p / 100.0, 0), 1)
     }
 
-    /// The Rest world's opening: a scenic indigo backdrop with — when the night carries a 0–100
-    /// sleep-performance score — the canonical liquid `LiquidVessel` in the Rest tint with the score
-    /// counting up over it (the SAME hero language Today's score cells and the Trends headline use);
-    /// otherwise a big SF-Rounded hours-slept headline over the same backdrop. A `SourceBadge` states
-    /// whether the score is WHOOP's own imported figure or NOOP's on-device estimate. Presentation-only
-    /// — the score is `performanceScore(for:)` on the ◀/▶-navigated `heroNight`, so the hero tracks the
-    /// same night the hypnogram shows (was pinned to `performance.latest` = last night regardless).
-    @ViewBuilder
     /// Dispatch a reorderable Sleep section to its card. Naps rides with `.stages` (drawn inside the stages
     /// hero); the Rest hero is pinned outside this list. Mirrors the Android SleepScreen `when(section)`.
     @ViewBuilder
@@ -420,6 +412,14 @@ struct SleepView: View {
         }
     }
 
+    /// The Rest world's opening: a scenic indigo backdrop with — when the night carries a 0–100
+    /// sleep-performance score — the canonical liquid `LiquidVessel` in the Rest tint with the score
+    /// counting up over it (the SAME hero language Today's score cells and the Trends headline use);
+    /// otherwise a big SF-Rounded hours-slept headline over the same backdrop. A `SourceBadge` states
+    /// whether the score is WHOOP's own imported figure or NOOP's on-device estimate. Presentation-only
+    /// — the score is `performanceScore(for:)` on the ◀/▶-navigated `heroNight`, so the hero tracks the
+    /// same night the hypnogram shows (was pinned to `performance.latest` = last night regardless).
+    @ViewBuilder
     private func restHero(_ model: SleepModel) -> some View {
         let night = heroNight(model)
         let score = performanceScore(for: night)

--- a/StrandTests/SleepLayoutPrefsTests.swift
+++ b/StrandTests/SleepLayoutPrefsTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import Strand
+
+/// Pure-logic coverage for the Sleep card-order persistence (#sleep-layout): default order, encode/decode
+/// round-trip, reorder, and the never-hide "insert missing card at its default position" invariant. These
+/// are the pure functions the Arrange editor + Sleep render rely on. Mirrors the Android
+/// `SleepLayoutPrefsTest` and the sibling `TodayLayoutPrefsTests`.
+final class SleepLayoutPrefsTests: XCTestCase {
+
+    func testEmptyOrUnsetYieldsDefaultOrder() {
+        XCTAssertEqual(SleepLayoutPrefs.decodeOrder(""), SleepSection.defaultOrder)
+        XCTAssertEqual(SleepLayoutPrefs.decodeOrder("   "), SleepSection.defaultOrder)
+    }
+
+    func testEncodeDecodeRoundTripsAReorderedList() {
+        let reordered: [SleepSection] = [
+            .nightDetail, .sleepMarks, .asleepDuration, .stages, .naps, .sleepDebt, .stagesVsTypical,
+        ]
+        let encoded = SleepLayoutPrefs.encode(reordered)
+        XCTAssertEqual(encoded, "nightDetail,sleepMarks,asleepDuration,stages,naps,sleepDebt,stagesVsTypical")
+        XCTAssertEqual(SleepLayoutPrefs.decodeOrder(encoded), reordered)
+    }
+
+    /// A saved order that explicitly ends on `sleepMarks` and leads with `asleepDuration` must keep those
+    /// two placements while every card missing from the save inserts at its default position (all before
+    /// asleepDuration, since each has a lower default index).
+    func testDecodeInsertsMissingCardsAtDefaultPositionNeverHides() {
+        let decoded = SleepLayoutPrefs.decodeOrder("asleepDuration,sleepMarks")
+        XCTAssertEqual(decoded.count, SleepSection.allCases.count)
+        XCTAssertEqual(decoded, [
+            .stages, .naps, .nightDetail, .sleepDebt, .stagesVsTypical, .asleepDuration, .sleepMarks,
+        ])
+    }
+
+    func testDecodeDropsUnknownTokensAndCollapsesDuplicates() {
+        let decoded = SleepLayoutPrefs.decodeOrder("nightDetail,BOGUS,nightDetail,naps, ,naps")
+        XCTAssertEqual(decoded.count, SleepSection.allCases.count)
+        XCTAssertEqual(decoded, [
+            .sleepMarks, .stages, .nightDetail, .naps, .sleepDebt, .stagesVsTypical, .asleepDuration,
+        ])
+    }
+
+    func testAllJunkYieldsDefaultOrder() {
+        XCTAssertEqual(SleepLayoutPrefs.decodeOrder("nope,,zzz"), SleepSection.defaultOrder)
+    }
+
+    func testHiddenSectionsAreExplicitReversibleAndDeduplicated() {
+        let hidden = SleepLayoutPrefs.decodeHidden("naps,BOGUS,naps,sleepDebt")
+        XCTAssertEqual(hidden, [.naps, .sleepDebt])
+        XCTAssertEqual(SleepLayoutPrefs.encodeHidden(hidden), "naps,sleepDebt")
+    }
+
+    func testVisibleOrderFiltersHiddenWithoutChangingSavedOrder() {
+        let order = "nightDetail,sleepMarks,asleepDuration,stages,naps,sleepDebt,stagesVsTypical"
+        XCTAssertEqual(
+            SleepLayoutPrefs.visibleOrder(orderRaw: order, hiddenRaw: "asleepDuration,naps"),
+            [.nightDetail, .sleepMarks, .stages, .sleepDebt, .stagesVsTypical]
+        )
+        XCTAssertEqual(SleepLayoutPrefs.decodeOrder(order).count, SleepSection.allCases.count)
+    }
+
+    func testNewOrPreviouslyMissingCardsDefaultToVisible() {
+        let visible = SleepLayoutPrefs.visibleOrder(orderRaw: "stages,nightDetail,sleepDebt", hiddenRaw: "nightDetail")
+        XCTAssertTrue(visible.contains(.naps))
+        XCTAssertTrue(visible.contains(.sleepMarks))
+    }
+
+    /// defaultOrder must cover EVERY case: the never-hide merge sorts by default index, so a case missing
+    /// from the default order could otherwise be dropped or mis-sorted. Twin of the Kotlin test.
+    func testDefaultOrderCoversEveryCase() {
+        XCTAssertEqual(Set(SleepSection.defaultOrder), Set(SleepSection.allCases))
+        XCTAssertEqual(SleepSection.defaultOrder.count, SleepSection.allCases.count)
+    }
+
+    func testSectionRawKeysAreStableAndUnique() {
+        let raws = SleepSection.allCases.map(\.rawValue)
+        XCTAssertEqual(raws.count, Set(raws).count)
+        // Pin the exact wire strings — they cross the .noopbak boundary and must match Android byte-for-byte.
+        XCTAssertEqual(raws, [
+            "sleepMarks", "stages", "naps", "nightDetail", "sleepDebt", "stagesVsTypical", "asleepDuration",
+        ])
+    }
+}

--- a/StrandTests/SleepLayoutPrefsTests.swift
+++ b/StrandTests/SleepLayoutPrefsTests.swift
@@ -14,30 +14,32 @@ final class SleepLayoutPrefsTests: XCTestCase {
 
     func testEncodeDecodeRoundTripsAReorderedList() {
         let reordered: [SleepSection] = [
-            .nightDetail, .sleepMarks, .asleepDuration, .stages, .naps, .sleepDebt, .stagesVsTypical,
+            .nightDetail, .sleepMarks, .asleepDuration, .stages, .sleepDebt, .stagesVsTypical,
         ]
         let encoded = SleepLayoutPrefs.encode(reordered)
-        XCTAssertEqual(encoded, "nightDetail,sleepMarks,asleepDuration,stages,naps,sleepDebt,stagesVsTypical")
+        XCTAssertEqual(encoded, "nightDetail,sleepMarks,asleepDuration,stages,sleepDebt,stagesVsTypical")
         XCTAssertEqual(SleepLayoutPrefs.decodeOrder(encoded), reordered)
     }
 
-    /// A saved order that explicitly ends on `sleepMarks` and leads with `asleepDuration` must keep those
-    /// two placements while every card missing from the save inserts at its default position (all before
-    /// asleepDuration, since each has a lower default index).
+    /// A saved order that leads with `asleepDuration` and ends on `sleepMarks` keeps those two placements
+    /// while every card missing from the save inserts at its default position (all before asleepDuration,
+    /// since each has a lower default index).
     func testDecodeInsertsMissingCardsAtDefaultPositionNeverHides() {
         let decoded = SleepLayoutPrefs.decodeOrder("asleepDuration,sleepMarks")
         XCTAssertEqual(decoded.count, SleepSection.allCases.count)
         XCTAssertEqual(decoded, [
-            .stages, .naps, .nightDetail, .sleepDebt, .stagesVsTypical, .asleepDuration, .sleepMarks,
+            .stages, .nightDetail, .sleepDebt, .stagesVsTypical, .asleepDuration, .sleepMarks,
         ])
     }
 
-    func testDecodeDropsUnknownTokensAndCollapsesDuplicates() {
-        let decoded = SleepLayoutPrefs.decodeOrder("nightDetail,BOGUS,nightDetail,naps, ,naps")
-        XCTAssertEqual(decoded.count, SleepSection.allCases.count)
-        XCTAssertEqual(decoded, [
-            .sleepMarks, .stages, .nightDetail, .naps, .sleepDebt, .stagesVsTypical, .asleepDuration,
-        ])
+    /// Whatever the input, every card always renders — unknown tokens dropped, duplicates collapsed, and
+    /// no card is ever hidden by a partial/messy save.
+    func testDecodeAlwaysReturnsEveryCard() {
+        for input in ["nightDetail,BOGUS,nightDetail, ,stages", "sleepDebt", "zzz,stages,,stages"] {
+            let decoded = SleepLayoutPrefs.decodeOrder(input)
+            XCTAssertEqual(Set(decoded), Set(SleepSection.allCases))
+            XCTAssertEqual(decoded.count, SleepSection.allCases.count)
+        }
     }
 
     func testAllJunkYieldsDefaultOrder() {
@@ -45,24 +47,24 @@ final class SleepLayoutPrefsTests: XCTestCase {
     }
 
     func testHiddenSectionsAreExplicitReversibleAndDeduplicated() {
-        let hidden = SleepLayoutPrefs.decodeHidden("naps,BOGUS,naps,sleepDebt")
-        XCTAssertEqual(hidden, [.naps, .sleepDebt])
-        XCTAssertEqual(SleepLayoutPrefs.encodeHidden(hidden), "naps,sleepDebt")
+        let hidden = SleepLayoutPrefs.decodeHidden("stages,BOGUS,stages,sleepDebt")
+        XCTAssertEqual(hidden, [.stages, .sleepDebt])
+        XCTAssertEqual(SleepLayoutPrefs.encodeHidden(hidden), "stages,sleepDebt")
     }
 
     func testVisibleOrderFiltersHiddenWithoutChangingSavedOrder() {
-        let order = "nightDetail,sleepMarks,asleepDuration,stages,naps,sleepDebt,stagesVsTypical"
+        let order = "nightDetail,sleepMarks,asleepDuration,stages,sleepDebt,stagesVsTypical"
         XCTAssertEqual(
-            SleepLayoutPrefs.visibleOrder(orderRaw: order, hiddenRaw: "asleepDuration,naps"),
-            [.nightDetail, .sleepMarks, .stages, .sleepDebt, .stagesVsTypical]
+            SleepLayoutPrefs.visibleOrder(orderRaw: order, hiddenRaw: "asleepDuration,sleepDebt"),
+            [.nightDetail, .sleepMarks, .stages, .stagesVsTypical]
         )
         XCTAssertEqual(SleepLayoutPrefs.decodeOrder(order).count, SleepSection.allCases.count)
     }
 
     func testNewOrPreviouslyMissingCardsDefaultToVisible() {
-        let visible = SleepLayoutPrefs.visibleOrder(orderRaw: "stages,nightDetail,sleepDebt", hiddenRaw: "nightDetail")
-        XCTAssertTrue(visible.contains(.naps))
+        let visible = SleepLayoutPrefs.visibleOrder(orderRaw: "stages,nightDetail", hiddenRaw: "nightDetail")
         XCTAssertTrue(visible.contains(.sleepMarks))
+        XCTAssertTrue(visible.contains(.asleepDuration))
     }
 
     /// defaultOrder must cover EVERY case: the never-hide merge sorts by default index, so a case missing
@@ -77,7 +79,7 @@ final class SleepLayoutPrefsTests: XCTestCase {
         XCTAssertEqual(raws.count, Set(raws).count)
         // Pin the exact wire strings — they cross the .noopbak boundary and must match Android byte-for-byte.
         XCTAssertEqual(raws, [
-            "sleepMarks", "stages", "naps", "nightDetail", "sleepDebt", "stagesVsTypical", "asleepDuration",
+            "sleepMarks", "stages", "nightDetail", "sleepDebt", "stagesVsTypical", "asleepDuration",
         ])
     }
 }

--- a/android/app/src/main/java/com/noop/ui/SleepArrangeSheet.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepArrangeSheet.kt
@@ -1,0 +1,92 @@
+package com.noop.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.noop.R
+
+/**
+ * "Arrange sleep cards" dialog (#sleep-layout) — reorder / show-hide the Sleep tab's analytical cards.
+ * A direct twin of the Today customize dialog: it reuses the SAME generic [EditableVisibilityRows] editor
+ * (drag to reorder in the shown list, tap to move a card between shown/hidden), then persists via
+ * [SleepLayoutPrefs]. Nothing Sleep-specific but the section type + the persistence namespace, so the
+ * reorder UX is byte-for-byte the one Today already ships.
+ *
+ * `onSave` receives the FULL order (shown ++ hidden, so a hidden card keeps its stable slot for when it's
+ * re-shown) and the hidden set separately, matching `SleepLayoutPrefs.setOrder`/`setHidden`.
+ */
+@Composable
+fun SleepArrangeSheet(
+    initialOrder: List<SleepSection>,
+    initialHidden: List<SleepSection>,
+    onDismiss: () -> Unit,
+    onSave: (order: List<SleepSection>, hidden: List<SleepSection>) -> Unit,
+) {
+    val hiddenSet = remember(initialHidden) { initialHidden.toSet() }
+    val shown = remember {
+        mutableStateListOf<SleepSection>().apply { addAll(initialOrder.filterNot { it in hiddenSet }) }
+    }
+    val hidden = remember {
+        mutableStateListOf<SleepSection>().apply { addAll(initialOrder.filter { it in hiddenSet }) }
+    }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(color = Palette.surfaceOverlay, shape = RoundedCornerShape(16.dp)) {
+            Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text(stringResource(R.string.sleep_customize_title), style = NoopType.title2, color = Palette.textPrimary)
+                    Text(
+                        stringResource(R.string.sleep_customize_description),
+                        style = NoopType.subhead,
+                        color = Palette.textSecondary,
+                    )
+                }
+
+                EditableVisibilityRows(
+                    shown = shown,
+                    hidden = hidden,
+                    itemTitle = { it.title },
+                )
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    TextButton(
+                        onClick = {
+                            shown.clear()
+                            shown.addAll(SleepSection.defaultOrder)
+                            hidden.clear()
+                        },
+                        colors = ButtonDefaults.textButtonColors(contentColor = Palette.textSecondary),
+                    ) { Text(uiString(R.string.l10n_today_screen_reset_44c57abd), style = NoopType.body) }
+                    Spacer(Modifier.weight(1f))
+                    Button(
+                        onClick = { onSave(shown.toList() + hidden.toList(), hidden.toList()) },
+                        enabled = shown.isNotEmpty(),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Palette.accent,
+                            contentColor = Palette.surfaceBase,
+                        ),
+                    ) { Text(uiString(R.string.l10n_today_screen_done_e9b450d1), style = NoopType.captionNumber) }
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/SleepLayoutPrefs.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepLayoutPrefs.kt
@@ -24,7 +24,6 @@ import android.content.Context
 enum class SleepSection(val raw: String, val title: String) {
     SLEEP_MARKS("sleepMarks", "Sleep marks"),
     STAGES("stages", "Stages"),
-    NAPS("naps", "Naps"),
     NIGHT_DETAIL("nightDetail", "Night detail"),
     SLEEP_DEBT("sleepDebt", "Sleep-debt ledger"),
     STAGES_VS_TYPICAL("stagesVsTypical", "Stages vs typical"),
@@ -34,10 +33,11 @@ enum class SleepSection(val raw: String, val title: String) {
         fun fromRaw(raw: String?): SleepSection? = entries.firstOrNull { it.raw == raw }
 
         /** The original, hard-coded card order — the default when the layout isn't customised. Matches the
-         *  pre-customisation render order in SleepScreen (Naps sits directly under Stages, where it was
-         *  drawn inside the stages hero before it became independently arrangeable). */
+         *  pre-customisation render order in SleepScreen below the pinned Sleep-performance hero. (Naps
+         *  rides with Stages for now — drawn inside the stages hero; making it an independently arrangeable
+         *  card is a follow-up that requires hoisting the hero's edit/delete callbacks.) */
         val defaultOrder: List<SleepSection> = listOf(
-            SLEEP_MARKS, STAGES, NAPS, NIGHT_DETAIL, SLEEP_DEBT, STAGES_VS_TYPICAL, ASLEEP_DURATION,
+            SLEEP_MARKS, STAGES, NIGHT_DETAIL, SLEEP_DEBT, STAGES_VS_TYPICAL, ASLEEP_DURATION,
         )
     }
 }

--- a/android/app/src/main/java/com/noop/ui/SleepLayoutPrefs.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepLayoutPrefs.kt
@@ -1,0 +1,122 @@
+package com.noop.ui
+
+import android.content.Context
+
+// MARK: - Reorderable Sleep sections (#sleep-layout)
+//
+// The Sleep tab's analytical cards — Sleep marks, the Stages hypnogram, Naps, Night detail, the Sleep-debt
+// ledger, Stages-vs-typical, and the Asleep-duration trend — render in one fixed order below the pinned
+// Sleep-performance hero + date navigator. This lets the user REORDER or HIDE those cards, mirroring the
+// Today tab's Arrange sheet (see TodayLayoutPrefs), with the default being the original order so nothing
+// changes for anyone who never customizes Sleep. Display-only — no metric is computed or stored
+// differently; this only decides which already-built cards render and in what sequence.
+//
+// Stored as a single comma-joined string of section keys in SharedPreferences ("sleep.sectionOrder"), the
+// same mechanism TodayLayoutPrefs/KeyMetricPrefs use. Mirrors the macOS SleepLayoutPrefs.swift +
+// @AppStorage("sleep.sectionOrder"). Every known section stays in the order registry: unknown tokens are
+// dropped, and missing known sections are inserted at their default positions. Explicit reversible
+// visibility lives separately in "sleep.hiddenSections", byte-identical to the Apple-platform key.
+
+/**
+ * One reorderable Sleep card. The [raw] is the stable persisted identifier — keep it byte-identical to the
+ * macOS `SleepSection` enum so a backup/restore reads the same layout on either OS.
+ */
+enum class SleepSection(val raw: String, val title: String) {
+    SLEEP_MARKS("sleepMarks", "Sleep marks"),
+    STAGES("stages", "Stages"),
+    NAPS("naps", "Naps"),
+    NIGHT_DETAIL("nightDetail", "Night detail"),
+    SLEEP_DEBT("sleepDebt", "Sleep-debt ledger"),
+    STAGES_VS_TYPICAL("stagesVsTypical", "Stages vs typical"),
+    ASLEEP_DURATION("asleepDuration", "Asleep duration");
+
+    companion object {
+        fun fromRaw(raw: String?): SleepSection? = entries.firstOrNull { it.raw == raw }
+
+        /** The original, hard-coded card order — the default when the layout isn't customised. Matches the
+         *  pre-customisation render order in SleepScreen (Naps sits directly under Stages, where it was
+         *  drawn inside the stages hero before it became independently arrangeable). */
+        val defaultOrder: List<SleepSection> = listOf(
+            SLEEP_MARKS, STAGES, NAPS, NIGHT_DETAIL, SLEEP_DEBT, STAGES_VS_TYPICAL, ASLEEP_DURATION,
+        )
+    }
+}
+
+/**
+ * Display-only persistence for the Sleep card order and explicit hidden set. Every known card remains in
+ * the order registry, while visibility is stored separately so hiding stays reversible. SharedPreferences
+ * isn't reactive, so Sleep reads this into remembered state and refreshes it after save. Mirrors the
+ * Apple-platform SleepLayoutPrefs, a direct twin of TodayLayoutPrefs with a `sleep.` key namespace.
+ */
+object SleepLayoutPrefs {
+    private const val KEY_ORDER = "sleep.sectionOrder"
+    private const val KEY_HIDDEN = "sleep.hiddenSections"
+
+    /** Every known card in display order (saved order first, then any newly-added card at its default position). */
+    fun order(context: Context): List<SleepSection> =
+        decodeOrder(NoopPrefs.of(context).getString(KEY_ORDER, null))
+
+    /** Persist the card order. */
+    fun setOrder(context: Context, sections: List<SleepSection>) {
+        NoopPrefs.of(context).edit().putString(KEY_ORDER, encode(sections)).apply()
+    }
+
+    /** The explicitly hidden cards in their editor order. Empty/unset means every card is visible. */
+    fun hidden(context: Context): List<SleepSection> =
+        decodeHidden(NoopPrefs.of(context).getString(KEY_HIDDEN, null))
+
+    /** Persist the explicit reversible hidden list. */
+    fun setHidden(context: Context, sections: List<SleepSection>) {
+        NoopPrefs.of(context).edit().putString(KEY_HIDDEN, encodeHidden(sections)).apply()
+    }
+
+    /** Encode an ordered list of cards into the stored comma-joined string. */
+    fun encode(sections: List<SleepSection>): String = sections.joinToString(",") { it.raw }
+
+    fun encodeHidden(sections: List<SleepSection>): String = sections.joinToString(",") { it.raw }
+
+    /**
+     * Decode the stored string into the FULL ordered card list. An empty/unset string yields the default
+     * order. Unknown tokens are ignored, duplicates collapsed, and any known card missing from the saved
+     * order is INSERTED at its default-order position relative to the saved cards (before the first saved
+     * card that follows it in the default order; appended when none does) — so every card always renders,
+     * and one added in a later app version surfaces where users expect it instead of teleporting to the
+     * bottom of an existing saved order.
+     */
+    fun decodeOrder(raw: String?): List<SleepSection> {
+        val trimmed = raw?.trim().orEmpty()
+        if (trimmed.isEmpty()) return SleepSection.defaultOrder
+        val saved = ArrayList<SleepSection>()
+        trimmed.split(",").forEach { token ->
+            SleepSection.fromRaw(token.trim())?.let { if (it !in saved) saved.add(it) }
+        }
+        if (saved.isEmpty()) return SleepSection.defaultOrder
+        // Iterate entries (not defaultOrder) so a future enum case accidentally left out of defaultOrder
+        // can never be silently hidden; a card without a default index sorts after everything. Twin of the
+        // Swift decodeOrder's degraded path; defaultOrder covering every entry is pinned by the tests.
+        fun defIdx(s: SleepSection): Int =
+            SleepSection.defaultOrder.indexOf(s).let { if (it == -1) SleepSection.defaultOrder.size else it }
+        for (missing in SleepSection.entries) {
+            if (missing in saved) continue
+            val insertAt = saved.indexOfFirst { defIdx(it) > defIdx(missing) }
+            if (insertAt == -1) saved.add(missing) else saved.add(insertAt, missing)
+        }
+        return saved
+    }
+
+    /**
+     * Decode only explicitly hidden cards. Unknown tokens are ignored and duplicates collapsed. Missing
+     * entries stay visible, so a card added by a future release automatically surfaces.
+     */
+    fun decodeHidden(raw: String?): List<SleepSection> {
+        val hidden = LinkedHashSet<SleepSection>()
+        raw?.split(",")?.forEach { token -> SleepSection.fromRaw(token.trim())?.let(hidden::add) }
+        return hidden.toList()
+    }
+
+    /** The full saved order filtered by the explicit hidden set. */
+    fun visibleOrder(orderRaw: String?, hiddenRaw: String?): List<SleepSection> {
+        val hidden = decodeHidden(hiddenRaw).toSet()
+        return decodeOrder(orderRaw).filterNot { it in hidden }
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -693,8 +693,9 @@ fun SleepScreen(
                 }
                 // StagesVsTypical reads the SELECTED day's model, never the full-history fallback: a
                 // phantom newest day with no stage model would otherwise label ANOTHER night's stages as
-                // this one (#940). Hidden in that state, exactly as before.
-                SleepSection.STAGES_VS_TYPICAL -> model?.let { selectedModel ->
+                // this one (#940). Guarded on BOTH tilesModel and model, exactly as the pre-refactor
+                // nesting was (it lived inside the `if (tilesModel != null)` block).
+                SleepSection.STAGES_VS_TYPICAL -> if (tilesModel != null) model?.let { selectedModel ->
                     item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
                     item { StagesVsTypical(selectedModel) }
                 }

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -16,6 +16,13 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.ui.res.stringResource
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -272,6 +279,13 @@ fun SleepScreen(
     // 12 hours, invite the user to log how they felt. The shown-day is persisted so the sheet never
     // re-pops on a recomposition or a same-day re-open. (PR #260)
     var showJournalPrompt by remember { mutableStateOf(false) }
+
+    // #sleep-layout: the arrangeable analytical-card order + explicit hidden set (SleepLayoutPrefs).
+    // SharedPreferences isn't reactive, so hold it in state and refresh after the Arrange sheet saves.
+    // Mirrors TodayScreen's section-order state.
+    var sleepSectionOrder by remember { mutableStateOf(SleepLayoutPrefs.order(context)) }
+    var hiddenSections by remember { mutableStateOf(SleepLayoutPrefs.hidden(context)) }
+    var showSleepArrange by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     LaunchedEffect(sleeps) {
         // #627: the journal-reminder toggle (default ON) gates this morning sheet too, so disabling the
@@ -330,6 +344,24 @@ fun SleepScreen(
                 }
             }
         }
+    }
+
+    // #sleep-layout: the Arrange sheet — reorder / show-hide the analytical cards, persisted via
+    // SleepLayoutPrefs. Reuses Today's generic EditableVisibilityRows editor. Refresh the in-memory
+    // order/hidden state on save so the cards re-lay-out immediately (SharedPreferences isn't reactive).
+    if (showSleepArrange) {
+        SleepArrangeSheet(
+            initialOrder = sleepSectionOrder,
+            initialHidden = hiddenSections,
+            onDismiss = { showSleepArrange = false },
+            onSave = { order, hidden ->
+                SleepLayoutPrefs.setOrder(context, order)
+                SleepLayoutPrefs.setHidden(context, hidden)
+                sleepSectionOrder = order
+                hiddenSections = hidden
+                showSleepArrange = false
+            },
+        )
     }
 
     // Tapping a metric tile opens a full-history detail sheet for that one metric. (PR #260)
@@ -512,12 +544,32 @@ fun SleepScreen(
                     overline = nightRelativeLabel(nightOffset),
                 )
             }
-            item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
-            // SLEEP MARKS — tap to log "going to sleep" / "I'm awake" (#461, Phase 1). LOGGING ONLY:
-            // a mark is persisted to the `sleep_mark` series + the shareable strap log; it never
-            // changes the detected sleep. Mirrors macOS SleepView.sleepMarkCard.
+            // #sleep-layout: a compact "Arrange" affordance (the same Tune entry Today uses) opens the
+            // reorder / show-hide sheet. Pinned just above the arrangeable cards.
             item {
-            SleepMarkCard(
+                Row(Modifier.fillMaxWidth().padding(top = Metrics.selectorTopUp)) {
+                    Spacer(Modifier.weight(1f))
+                    TextButton(
+                        onClick = { showSleepArrange = true },
+                        colors = ButtonDefaults.textButtonColors(contentColor = Palette.textTertiary),
+                    ) {
+                        Icon(Icons.Filled.Tune, contentDescription = stringResource(R.string.sleep_customize_title), modifier = Modifier.size(Metrics.iconSmall))
+                        Spacer(Modifier.width(Metrics.space4))
+                        Text(stringResource(R.string.sleep_customize_title), style = NoopType.footnote)
+                    }
+                }
+            }
+            // Analytical cards render in the user's saved order (SleepLayoutPrefs), minus the hidden set.
+            // Reordered via the Arrange sheet; each card's data guards (tilesModel/model) are preserved.
+            sleepSectionOrder.filterNot { it in hiddenSections }.forEach { section ->
+              when (section) {
+                SleepSection.SLEEP_MARKS -> {
+                    item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
+                    // SLEEP MARKS — tap to log "going to sleep" / "I'm awake" (#461, Phase 1). LOGGING ONLY:
+                    // a mark is persisted to the `sleep_mark` series + the shareable strap log; it never
+                    // changes the detected sleep. Mirrors macOS SleepView.sleepMarkCard.
+                    item {
+                    SleepMarkCard(
                 onMark = { type ->
                     val mark = SleepMark.now(type)
                     // The shareable strap log is the human-readable surface in a debug export.
@@ -530,10 +582,12 @@ fun SleepScreen(
                     Toast.makeText(context, mark.confirmation(), Toast.LENGTH_SHORT).show()
                 },
             )
-            }
-            item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
-            item {
-            Hero(
+                    }
+                }
+                SleepSection.STAGES -> {
+                    item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
+                    item {
+                    Hero(
                 display = display,
                 activeIsOura = activeIsOura,
                 clock = night?.clockLabel ?: model?.clockLabel,
@@ -623,31 +677,36 @@ fun SleepScreen(
                 windowOnsetTs = night?.heroOnsetTs,
                 windowWakeTs = night?.heroWakeTs,
             )
-            }
-            // Tiles / ledger / trends read the FULL-history model (#940): they stay up when only the
-            // selected day's model failed to build, exactly as iOS keeps them while browsing.
-            if (tilesModel != null) {
-                // Bind a non-null local so the smart-cast carries cleanly into each item {} lambda
-                // (a nullable val doesn't smart-cast across a lambda boundary). Same model, same order.
-                val m = tilesModel
-                item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
-                item { MetricGrid(m, onMetricClick = { detailMetricKey = it }) }
-                item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
-                item { SleepDebtLedgerCard(m.sleepDebtLedger) }
-                // StagesVsTypical describes ONE specific night's deep/REM/light minutes under the
-                // "Selected night" header, so it must read the SELECTED day's model, never the
-                // full-history fallback: when the selected day has no stage model (the phantom newest
-                // day), showing tilesModel here would label ANOTHER day's stages as this night (#940).
-                // Hide the card in that state (iOS shows the stub's honest zeros); MetricGrid/ledger/
-                // trends above/below stay on the full-history tilesModel exactly as before.
-                if (model != null) {
-                    // Bind a non-null local so the smart-cast carries into the item {} lambda.
-                    val selectedModel = model
+                    }
+                }
+                // Tiles / ledger / trends read the FULL-history model (#940): they stay up when only the
+                // selected day's model failed to build, exactly as iOS keeps them while browsing. Each
+                // `tilesModel?.let { m -> ... }` binds a non-null local so the smart-cast carries across
+                // the item {} lambda boundary — same guard the old `if (tilesModel != null)` block used.
+                SleepSection.NIGHT_DETAIL -> tilesModel?.let { m ->
+                    item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
+                    item { MetricGrid(m, onMetricClick = { detailMetricKey = it }) }
+                }
+                SleepSection.SLEEP_DEBT -> tilesModel?.let { m ->
+                    item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
+                    item { SleepDebtLedgerCard(m.sleepDebtLedger) }
+                }
+                // StagesVsTypical reads the SELECTED day's model, never the full-history fallback: a
+                // phantom newest day with no stage model would otherwise label ANOTHER night's stages as
+                // this one (#940). Hidden in that state, exactly as before.
+                SleepSection.STAGES_VS_TYPICAL -> model?.let { selectedModel ->
                     item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
                     item { StagesVsTypical(selectedModel) }
                 }
-                item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
-                item { DurationTrend(m) }
+                SleepSection.ASLEEP_DURATION -> tilesModel?.let { m ->
+                    item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
+                    item { DurationTrend(m) }
+                }
+              }
+            }
+            // Android-only detail cards, pinned below the arrangeable region (iOS folds these into Night
+            // detail; making them arrangeable too is a #sleep-layout follow-up).
+            tilesModel?.let { m ->
                 item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
                 item { HoursVsNeededCard(m) }
                 item { Spacer(Modifier.height(Metrics.selectorTopUp)) }

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -555,7 +555,9 @@ fun SleepScreen(
                     ) {
                         Icon(Icons.Filled.Tune, contentDescription = stringResource(R.string.sleep_customize_title), modifier = Modifier.size(Metrics.iconSmall))
                         Spacer(Modifier.width(Metrics.space4))
-                        Text(stringResource(R.string.sleep_customize_title), style = NoopType.footnote)
+                        // Concise verb on the affordance (the full "Customize Sleep" title is the icon's a11y
+                        // label + the sheet header); reuses Today's generic "Customize" action string.
+                        Text(stringResource(R.string.today_customize_action), style = NoopType.footnote)
                     }
                 }
             }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3382,7 +3382,7 @@ private fun intStringGrouped(v: Double): String {
  * the same ordering behavior in every editor. SnapshotStateList callers recompose on these mutations.
  */
 @Composable
-private fun <T> EditableVisibilityRows(
+internal fun <T> EditableVisibilityRows(
     shown: MutableList<T>,
     hidden: MutableList<T>,
     itemTitle: (T) -> String,

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -55,6 +55,8 @@
     <string name="today_customize_title">Heute anpassen</string>
     <string name="today_customize_action">Anpassen</string>
     <string name="today_customize_description">Ordne sichtbare Elemente neu an oder verschiebe einen Abschnitt nach „Ausgeblendet“, ohne ihn zu löschen.</string>
+    <string name="sleep_customize_title">Schlaf anpassen</string>
+    <string name="sleep_customize_description">Ordne sichtbare Elemente neu an oder verschiebe einen Abschnitt nach „Ausgeblendet“, ohne ihn zu löschen.</string>
     <string name="today_customize_shown">ANGEZEIGT</string>
     <string name="today_customize_hidden">AUSGEBLENDET</string>
     <string name="today_customize_nothing_hidden">Nichts ausgeblendet</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1563,6 +1563,8 @@
     <string name="today_customize_title">Personalizar Hoy</string>
     <string name="today_customize_action">Personalizar</string>
     <string name="today_customize_description">Reordena lo que se muestra o mueve una sección a Ocultos sin eliminarla.</string>
+    <string name="sleep_customize_title">Personalizar Sueño</string>
+    <string name="sleep_customize_description">Reordena lo que se muestra o mueve una sección a Ocultos sin eliminarla.</string>
     <string name="today_customize_shown">VISIBLES</string>
     <string name="today_customize_hidden">OCULTOS</string>
     <string name="today_customize_nothing_hidden">No hay nada oculto</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1563,6 +1563,8 @@
     <string name="today_customize_title">Personnaliser Aujourd’hui</string>
     <string name="today_customize_action">Personnaliser</string>
     <string name="today_customize_description">Réorganisez les éléments affichés ou déplacez une section dans Masqués sans la supprimer.</string>
+    <string name="sleep_customize_title">Personnaliser le sommeil</string>
+    <string name="sleep_customize_description">Réorganisez les éléments affichés ou déplacez une section dans Masqués sans la supprimer.</string>
     <string name="today_customize_shown">AFFICHÉS</string>
     <string name="today_customize_hidden">MASQUÉS</string>
     <string name="today_customize_nothing_hidden">Aucun élément masqué</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -51,6 +51,8 @@
     <string name="today_customize_title">Personalizar Hoje</string>
     <string name="today_customize_action">Personalizar</string>
     <string name="today_customize_description">Reordena o que é mostrado ou move uma secção para Ocultos sem a apagar.</string>
+    <string name="sleep_customize_title">Personalizar Sono</string>
+    <string name="sleep_customize_description">Reordena o que é mostrado ou move uma secção para Ocultos sem a apagar.</string>
     <string name="today_customize_shown">MOSTRADOS</string>
     <string name="today_customize_hidden">OCULTOS</string>
     <string name="today_customize_nothing_hidden">Nada oculto</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -49,6 +49,8 @@
     <string name="today_customize_title">自定义“今天”</string>
     <string name="today_customize_action">自定义</string>
     <string name="today_customize_description">重新排序已显示内容，或将某个部分移至“已隐藏”而不删除。</string>
+    <string name="sleep_customize_title">自定义睡眠</string>
+    <string name="sleep_customize_description">重新排序已显示内容，或将某个部分移至“已隐藏”而不删除。</string>
     <string name="today_customize_shown">已显示</string>
     <string name="today_customize_hidden">已隐藏</string>
     <string name="today_customize_nothing_hidden">没有隐藏项目</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -61,6 +61,8 @@
     <string name="today_customize_title">Customize Today</string>
     <string name="today_customize_action">Customize</string>
     <string name="today_customize_description">Reorder what is shown, or move a section to Hidden without deleting it.</string>
+    <string name="sleep_customize_title">Customize Sleep</string>
+    <string name="sleep_customize_description">Reorder what is shown, or move a section to Hidden without deleting it.</string>
     <string name="today_customize_shown">SHOWN</string>
     <string name="today_customize_hidden">HIDDEN</string>
     <string name="today_customize_nothing_hidden">Nothing hidden</string>

--- a/android/app/src/test/java/com/noop/ui/SleepLayoutPrefsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepLayoutPrefsTest.kt
@@ -1,0 +1,125 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-logic coverage for the Sleep card-order persistence (#sleep-layout): default order, encode/decode
+ * round-trip, reorder, and the never-hide "insert missing card at its default position" invariant. No
+ * Android context — these are the pure functions the Arrange editor + Sleep render rely on. Mirrors the
+ * macOS SleepLayoutPrefs tests and the sibling TodayLayoutPrefs tests.
+ */
+class SleepLayoutPrefsTest {
+
+    @Test
+    fun emptyOrUnset_yieldsDefaultOrder() {
+        assertEquals(SleepSection.defaultOrder, SleepLayoutPrefs.decodeOrder(null))
+        assertEquals(SleepSection.defaultOrder, SleepLayoutPrefs.decodeOrder(""))
+        assertEquals(SleepSection.defaultOrder, SleepLayoutPrefs.decodeOrder("   "))
+    }
+
+    @Test
+    fun encodeDecode_roundTripsAReorderedList() {
+        val reordered = listOf(
+            SleepSection.NIGHT_DETAIL, SleepSection.SLEEP_MARKS, SleepSection.ASLEEP_DURATION,
+            SleepSection.STAGES, SleepSection.NAPS, SleepSection.SLEEP_DEBT,
+            SleepSection.STAGES_VS_TYPICAL,
+        )
+        val encoded = SleepLayoutPrefs.encode(reordered)
+        assertEquals(
+            "nightDetail,sleepMarks,asleepDuration,stages,naps,sleepDebt,stagesVsTypical",
+            encoded,
+        )
+        assertEquals(reordered, SleepLayoutPrefs.decodeOrder(encoded))
+    }
+
+    /** A saved order that explicitly ends on `sleepMarks` and leads with `asleepDuration` must keep those
+     *  two placements while every card missing from the save inserts at its default position (all before
+     *  asleepDuration, since each has a lower default index). */
+    @Test
+    fun decode_insertsMissingCardsAtDefaultPositionRelativeToSaved_neverHides() {
+        val partial = "asleepDuration,sleepMarks"
+        val decoded = SleepLayoutPrefs.decodeOrder(partial)
+        assertEquals(SleepSection.entries.size, decoded.size)
+        assertEquals(
+            listOf(
+                SleepSection.STAGES, SleepSection.NAPS, SleepSection.NIGHT_DETAIL,
+                SleepSection.SLEEP_DEBT, SleepSection.STAGES_VS_TYPICAL,
+                SleepSection.ASLEEP_DURATION, SleepSection.SLEEP_MARKS,
+            ),
+            decoded,
+        )
+    }
+
+    @Test
+    fun decode_dropsUnknownTokensAndCollapsesDuplicates() {
+        val messy = "nightDetail,BOGUS,nightDetail,naps, ,naps"
+        val decoded = SleepLayoutPrefs.decodeOrder(messy)
+        assertEquals(SleepSection.entries.size, decoded.size)
+        assertEquals(
+            listOf(
+                // sleepMarks(0), stages(1) precede nightDetail(3) → insert before it in default order;
+                // the saved nightDetail→naps order is preserved; sleepDebt(4)/stagesVsTypical(5)/
+                // asleepDuration(6) all follow naps(2) but nightDetail(3) precedes them, so they append.
+                SleepSection.SLEEP_MARKS, SleepSection.STAGES, SleepSection.NIGHT_DETAIL,
+                SleepSection.NAPS, SleepSection.SLEEP_DEBT, SleepSection.STAGES_VS_TYPICAL,
+                SleepSection.ASLEEP_DURATION,
+            ),
+            decoded,
+        )
+    }
+
+    @Test
+    fun allJunk_yieldsDefaultOrder() {
+        assertEquals(SleepSection.defaultOrder, SleepLayoutPrefs.decodeOrder("nope,,zzz"))
+    }
+
+    @Test
+    fun hiddenSections_areExplicitReversibleAndDeduplicated() {
+        val hidden = SleepLayoutPrefs.decodeHidden("naps,BOGUS,naps,sleepDebt")
+        assertEquals(listOf(SleepSection.NAPS, SleepSection.SLEEP_DEBT), hidden)
+        assertEquals("naps,sleepDebt", SleepLayoutPrefs.encodeHidden(hidden))
+    }
+
+    @Test
+    fun visibleOrder_filtersHiddenWithoutChangingSavedOrder() {
+        val order = "nightDetail,sleepMarks,asleepDuration,stages,naps,sleepDebt,stagesVsTypical"
+        assertEquals(
+            listOf(
+                SleepSection.NIGHT_DETAIL, SleepSection.SLEEP_MARKS, SleepSection.STAGES,
+                SleepSection.SLEEP_DEBT, SleepSection.STAGES_VS_TYPICAL,
+            ),
+            SleepLayoutPrefs.visibleOrder(order, "asleepDuration,naps"),
+        )
+        assertEquals(SleepSection.entries.size, SleepLayoutPrefs.decodeOrder(order).size)
+    }
+
+    @Test
+    fun newOrPreviouslyMissingCards_defaultToVisible() {
+        val visible = SleepLayoutPrefs.visibleOrder("stages,nightDetail,sleepDebt", "nightDetail")
+        assertEquals(true, SleepSection.NAPS in visible)
+        assertEquals(true, SleepSection.SLEEP_MARKS in visible)
+    }
+
+    /** defaultOrder must cover EVERY entry: the never-hide merge sorts by default index, so an entry
+     *  missing from the default order could otherwise be dropped or mis-sorted. Twin of the Swift test. */
+    @Test
+    fun defaultOrderCoversEveryEntry() {
+        assertEquals(SleepSection.entries.toSet(), SleepSection.defaultOrder.toSet())
+        assertEquals(SleepSection.entries.size, SleepSection.defaultOrder.size)
+    }
+
+    @Test
+    fun sectionRawKeysAreStableAndUnique() {
+        val raws = SleepSection.entries.map { it.raw }
+        assertEquals("raw keys must be unique (they're the persisted identity)", raws.size, raws.toSet().size)
+        // Pin the exact wire strings — they cross the .noopbak boundary and must match macOS byte-for-byte.
+        assertEquals(
+            listOf(
+                "sleepMarks", "stages", "naps", "nightDetail",
+                "sleepDebt", "stagesVsTypical", "asleepDuration",
+            ),
+            raws,
+        )
+    }
+}

--- a/android/app/src/test/java/com/noop/ui/SleepLayoutPrefsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepLayoutPrefsTest.kt
@@ -1,6 +1,7 @@
 package com.noop.ui
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -22,51 +23,38 @@ class SleepLayoutPrefsTest {
     fun encodeDecode_roundTripsAReorderedList() {
         val reordered = listOf(
             SleepSection.NIGHT_DETAIL, SleepSection.SLEEP_MARKS, SleepSection.ASLEEP_DURATION,
-            SleepSection.STAGES, SleepSection.NAPS, SleepSection.SLEEP_DEBT,
-            SleepSection.STAGES_VS_TYPICAL,
+            SleepSection.STAGES, SleepSection.SLEEP_DEBT, SleepSection.STAGES_VS_TYPICAL,
         )
         val encoded = SleepLayoutPrefs.encode(reordered)
-        assertEquals(
-            "nightDetail,sleepMarks,asleepDuration,stages,naps,sleepDebt,stagesVsTypical",
-            encoded,
-        )
+        assertEquals("nightDetail,sleepMarks,asleepDuration,stages,sleepDebt,stagesVsTypical", encoded)
         assertEquals(reordered, SleepLayoutPrefs.decodeOrder(encoded))
     }
 
-    /** A saved order that explicitly ends on `sleepMarks` and leads with `asleepDuration` must keep those
-     *  two placements while every card missing from the save inserts at its default position (all before
-     *  asleepDuration, since each has a lower default index). */
+    /** A saved order that leads with `asleepDuration` and ends on `sleepMarks` keeps those two placements
+     *  while every card missing from the save inserts at its default position (all before asleepDuration,
+     *  since each has a lower default index). */
     @Test
     fun decode_insertsMissingCardsAtDefaultPositionRelativeToSaved_neverHides() {
-        val partial = "asleepDuration,sleepMarks"
-        val decoded = SleepLayoutPrefs.decodeOrder(partial)
+        val decoded = SleepLayoutPrefs.decodeOrder("asleepDuration,sleepMarks")
         assertEquals(SleepSection.entries.size, decoded.size)
         assertEquals(
             listOf(
-                SleepSection.STAGES, SleepSection.NAPS, SleepSection.NIGHT_DETAIL,
-                SleepSection.SLEEP_DEBT, SleepSection.STAGES_VS_TYPICAL,
-                SleepSection.ASLEEP_DURATION, SleepSection.SLEEP_MARKS,
+                SleepSection.STAGES, SleepSection.NIGHT_DETAIL, SleepSection.SLEEP_DEBT,
+                SleepSection.STAGES_VS_TYPICAL, SleepSection.ASLEEP_DURATION, SleepSection.SLEEP_MARKS,
             ),
             decoded,
         )
     }
 
+    /** Whatever the input, every card always renders — unknown tokens dropped, duplicates collapsed, and
+     *  no card is ever hidden by a partial/messy save. */
     @Test
-    fun decode_dropsUnknownTokensAndCollapsesDuplicates() {
-        val messy = "nightDetail,BOGUS,nightDetail,naps, ,naps"
-        val decoded = SleepLayoutPrefs.decodeOrder(messy)
-        assertEquals(SleepSection.entries.size, decoded.size)
-        assertEquals(
-            listOf(
-                // sleepMarks(0), stages(1) precede nightDetail(3) → insert before it in default order;
-                // the saved nightDetail→naps order is preserved; sleepDebt(4)/stagesVsTypical(5)/
-                // asleepDuration(6) all follow naps(2) but nightDetail(3) precedes them, so they append.
-                SleepSection.SLEEP_MARKS, SleepSection.STAGES, SleepSection.NIGHT_DETAIL,
-                SleepSection.NAPS, SleepSection.SLEEP_DEBT, SleepSection.STAGES_VS_TYPICAL,
-                SleepSection.ASLEEP_DURATION,
-            ),
-            decoded,
-        )
+    fun decode_alwaysReturnsEveryCard() {
+        for (input in listOf("nightDetail,BOGUS,nightDetail, ,stages", "sleepDebt", "zzz,stages,,stages")) {
+            val decoded = SleepLayoutPrefs.decodeOrder(input)
+            assertEquals(SleepSection.entries.toSet(), decoded.toSet())
+            assertEquals(SleepSection.entries.size, decoded.size)
+        }
     }
 
     @Test
@@ -76,29 +64,29 @@ class SleepLayoutPrefsTest {
 
     @Test
     fun hiddenSections_areExplicitReversibleAndDeduplicated() {
-        val hidden = SleepLayoutPrefs.decodeHidden("naps,BOGUS,naps,sleepDebt")
-        assertEquals(listOf(SleepSection.NAPS, SleepSection.SLEEP_DEBT), hidden)
-        assertEquals("naps,sleepDebt", SleepLayoutPrefs.encodeHidden(hidden))
+        val hidden = SleepLayoutPrefs.decodeHidden("stages,BOGUS,stages,sleepDebt")
+        assertEquals(listOf(SleepSection.STAGES, SleepSection.SLEEP_DEBT), hidden)
+        assertEquals("stages,sleepDebt", SleepLayoutPrefs.encodeHidden(hidden))
     }
 
     @Test
     fun visibleOrder_filtersHiddenWithoutChangingSavedOrder() {
-        val order = "nightDetail,sleepMarks,asleepDuration,stages,naps,sleepDebt,stagesVsTypical"
+        val order = "nightDetail,sleepMarks,asleepDuration,stages,sleepDebt,stagesVsTypical"
         assertEquals(
             listOf(
                 SleepSection.NIGHT_DETAIL, SleepSection.SLEEP_MARKS, SleepSection.STAGES,
-                SleepSection.SLEEP_DEBT, SleepSection.STAGES_VS_TYPICAL,
+                SleepSection.STAGES_VS_TYPICAL,
             ),
-            SleepLayoutPrefs.visibleOrder(order, "asleepDuration,naps"),
+            SleepLayoutPrefs.visibleOrder(order, "asleepDuration,sleepDebt"),
         )
         assertEquals(SleepSection.entries.size, SleepLayoutPrefs.decodeOrder(order).size)
     }
 
     @Test
     fun newOrPreviouslyMissingCards_defaultToVisible() {
-        val visible = SleepLayoutPrefs.visibleOrder("stages,nightDetail,sleepDebt", "nightDetail")
-        assertEquals(true, SleepSection.NAPS in visible)
-        assertEquals(true, SleepSection.SLEEP_MARKS in visible)
+        val visible = SleepLayoutPrefs.visibleOrder("stages,nightDetail", "nightDetail")
+        assertTrue(SleepSection.SLEEP_MARKS in visible)
+        assertTrue(SleepSection.ASLEEP_DURATION in visible)
     }
 
     /** defaultOrder must cover EVERY entry: the never-hide merge sorts by default index, so an entry
@@ -115,10 +103,7 @@ class SleepLayoutPrefsTest {
         assertEquals("raw keys must be unique (they're the persisted identity)", raws.size, raws.toSet().size)
         // Pin the exact wire strings — they cross the .noopbak boundary and must match macOS byte-for-byte.
         assertEquals(
-            listOf(
-                "sleepMarks", "stages", "naps", "nightDetail",
-                "sleepDebt", "stagesVsTypical", "asleepDuration",
-            ),
+            listOf("sleepMarks", "stages", "nightDetail", "sleepDebt", "stagesVsTypical", "asleepDuration"),
             raws,
         )
     }


### PR DESCRIPTION
Adds "arrange your cards" to the Sleep tab, mirroring the Today tab — reorder + show/hide the analytical cards. **Complete on both platforms; all checks green.**

## What works
The Sleep tab's **6 analytical cards** — Sleep marks, Stages, Night detail, Sleep-debt ledger, Stages-vs-typical, Asleep-duration — render in the user's **saved order** with hidden cards filtered out, below the pinned Rest hero. A **"Customize" affordance** opens a sheet to reorder + show/hide + reset. iOS + macOS + Android.

## Design
- **Byte-parity foundation** — `SleepSection` enum (stable wire keys) + `SleepLayoutPrefs` (order + hidden, same missing-card-insertion / reversible-hidden logic as `TodayLayoutPrefs`), Swift + Kotlin. Display-only prefs (`sleep.sectionOrder` / `sleep.hiddenSections`); no metric/stored-value changes, not in the `.noopbak` whitelist (same as Today's).
- **Reuses Today's editors, not copies** — Android widens the already-generic `EditableVisibilityRows<T>` to `internal`; iOS reuses the already-generic `EditableLayoutList<Item>`. `SleepArrangeSheet` / `SleepCustomizationSheet` are thin twins of the Today customize sheets. Zero `TodayScreen`/`TodayView` behaviour change.

## Parity
- **Data contract byte-identical** — same keys, same wire order, same decode/visibleOrder logic (Kotlin `SleepLayoutPrefsTest` 10/10; Swift twin identical).
- **Same movable set + per-card mapping** on both; Naps rides with Stages (nested in the stages hero) on both.
- UX is feature-level parity (Compose dialog vs SwiftUI sheet — the expected framework difference).

## Deliberate scope (follow-ups noted)
- **6 movable cards, not 7** — independent Naps needs hoisting the shared stages hero's edit/delete callbacks; deferred.
- **Sheet-based arrange, not in-place drag** — generalising Today's in-place `SectionDragState` for both tabs is the planned "refactor after".
- Android's **Hours-vs-needed + Consistency** cards stay pinned below (on iOS they're folded inside Night detail — a pre-existing cross-platform divergence; neither platform makes them movable).

## Verification
- **Android**: `build-and-test` green (compiles + `SleepLayoutPrefsTest` 10/10).
- **iOS/macOS**: `build (Strand, macOS)` + `build (NOOPiOS, iOS)` green via `app-build.yml` (SleepView is shared — builds on both).
- **i18n `check`** green (3 new iOS strings across 8 locales + Android across 6; the Swift/Android section titles keep the same enum-title asymmetry as Today).
- `doc-comments` green.