### PR TITLE
docs(oura): document the confirmed macOS pairing limitation

### DIFF
--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -172,6 +172,29 @@ Before app-auth, the ring answers a small set unauthenticated: firmware (`0x08`)
 
 Treat this key like a password: it authenticates as the real Oura app against your account's ring. NOOP stores it locally the same way it stores its own provisioned key (Keychain on iOS / EncryptedSharedPreferences-Keystore on Android, §3.2) — nothing is transmitted anywhere. This recipe extracts a fact from **your own** device backup and a public schema doc; it does not touch, decompile, or redistribute any Oura app code.
 
+### 3.8 macOS pairing limitation (observed, 2026-07-29)
+
+Pairing an Oura ring that has never been Bluetooth-bonded to the Mac (i.e. any ring whose only prior
+bond is with the official Oura app on a phone) reproducibly fails on macOS. `CBCentralManager.connect()`
+is issued cleanly (scanning stopped first, `central.state == .poweredOn`, a valid, in-range peripheral -
+observed RSSI as good as -55), but **no CoreBluetooth delegate callback ever arrives** - not
+`didConnect`, not `didFailToConnect`. The ring never appears in System Settings ▸ Bluetooth either
+(no partial bond record is created). Ruled out: a second central holding the ring - the same failure
+reproduces with the paired phone's Bluetooth fully off. This matches CoreBluetooth's documented
+behavior that `connect()` has no built-in timeout (an unanswered connect just stays pending forever),
+so the practical symptom is a silent, permanent hang rather than an error.
+
+This is a different (and apparently more total) failure surface than the already-known WHOOP 5.0/MG
+macOS limitation (see `docs/WHOOP5_DEEP_DATA.md`, "iOS / Android only on real hardware") - WHOOP 5/MG
+at least connects and discovers services, failing only at an authenticated characteristic write
+(`CBATTError` "Encryption is insufficient"). Oura's connect doesn't get that far at all. The exact
+CoreBluetooth/bluetoothd mechanism isn't diagnosed further than this (would need a low-level HCI/SMP
+trace), but the practical conclusion is the same as WHOOP 5/MG's: **treat Oura ring pairing as
+iOS/Android-only** until proven otherwise on macOS. This applies to the §3.7 Advanced-key flow as
+much as to the §3.2 factory-reset one - the limitation is at connect time, before any key is used.
+Not yet tested: whether a genuinely never-bonded-anywhere (factory-reset) ring behaves differently
+from the already-Oura-app-owned case tested here.
+
 ---
 
 ## 4. Opcode Table


### PR DESCRIPTION
## Summary

Records a real-hardware finding that currently exists nowhere in the tree: **an Oura ring whose only
prior Bluetooth bond is with the official Oura app on a phone cannot be paired from macOS.**

`CBCentralManager.connect()` is issued cleanly — scanning stopped first, `central.state ==
.poweredOn`, a valid in-range peripheral (RSSI as good as −55) — and then **no CoreBluetooth delegate
callback ever arrives**: no `didConnect`, no `didFailToConnect`. The ring never appears in System
Settings ▸ Bluetooth either, so not even a partial bond record is created. Because `connect()` has no
built-in timeout, the practical symptom is a **silent, permanent hang** rather than an error — which
is exactly what makes it worth documenting.

**Ruled out:** a second central holding the ring. The same failure reproduces with the paired
iPhone's Bluetooth fully off.

## Why it goes next to §3.7

The limitation bites at connect time, *before* any key is used, so it applies to both pairing paths —
the §3.2 factory-reset flow and the §3.7 Advanced-key recipe. It lands as **§3.8**, immediately after
the Advanced-key section whose readers are most likely to hit it.

## Relation to the known WHOOP 5.0/MG macOS limitation

Same category, different surface — and Oura's is more total. WHOOP 5/MG at least connects and
discovers services, failing only at an authenticated characteristic write (`CBATTError` "Encryption
is insufficient"); Oura's connect never completes at all. The doc cross-references
`docs/WHOOP5_DEEP_DATA.md` and lands on the same practical conclusion: **treat Oura ring pairing as
iOS/Android-only** until proven otherwise on macOS.

## Scope

**Docs-only.** One file, +23/−0, no code, no strings, no behavior change — so no i18n gate and no app
build is implicated. `Tools/doc_comment_lint.py` passes (baseline unchanged at 25).

## What is deliberately NOT claimed

- The underlying CoreBluetooth/`bluetoothd` mechanism is **not** diagnosed — that would need a
  low-level HCI/SMP trace. The doc says so.
- **Not tested:** whether a genuinely never-bonded-anywhere (factory-reset) ring behaves differently
  from the already-Oura-app-owned ring tested here. Stated as an open question rather than papered
  over.

## Provenance

This is the documentation half of the earlier closed PR #947, which also carried connect-error
diagnostics and an in-app wizard warning. Those were dropped on purpose; only the confirmed finding
is re-landed here, cut fresh from current `main` so the diff is clean.