### PR TITLE
feat(stress): motion-gate the daytime timeline — mask exertion, don't score it as stress

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeStress.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeStress.swift
@@ -42,6 +42,33 @@ public enum DaytimeStress {
     public static let wakingStartHour: Int = 6
     public static let wakingEndHour: Int = 22
 
+    // MARK: - Motion gate
+    //
+    // Cardiac signals alone cannot separate psychological stress from EXERTION: a brisk walk and a
+    // tense meeting both raise HR and suppress HRV. Without a motion channel an ambulatory hour is
+    // scored as "stress". When the caller supplies the day's gravity (wrist accelerometer), an hour
+    // that was substantially ambulatory is MASKED (`level == nil`, `HourPoint.maskedForActivity ==
+    // true`) rather than scored, and it is excluded from the calm reference and the coverage totals.
+    // No gravity → no masking → byte-identical prior behaviour, so the gate only applies when motion
+    // is actually observable.
+
+    /// An hour whose gravity-derived activity is ambulatory for at least this fraction of its records
+    /// is EXERTION, not stress — masked, not scored. "Ambulatory" = a per-record activity intensity
+    /// above `WorkoutDetector.motionThreshold` (0.20 L2-g, the codebase's calibrated walk floor: desk
+    /// ≈ 0.05–0.10 g, walking ≈ 0.2–0.4 g). 0.30 means "at least 30 % of the hour was walking or
+    /// moving"; below it, a stray reach or one trip to the kitchen does not mask a desk hour. An
+    /// hourly grain is coarse — this is the gate that later allows finer epochs, at which point the
+    /// fraction can tighten. Range (0, 1].
+    public static let activityMaskFraction: Double = 0.30
+    /// Post-exercise shadow: HR stays elevated for a while AFTER exertion ends, so the single hour
+    /// that immediately FOLLOWS a directly-ambulatory hour is ALSO masked WHILE its mean HR is still
+    /// above the calm reference by this margin (bpm). A following hour whose HR has already returned
+    /// to the calm reference is scored normally, so the shadow self-limits to genuine cardiac
+    /// recovery. Deliberately ONE hour deep (keyed on the directly-active hour, not chained through
+    /// prior shadows) so a genuinely tense afternoon that happens to follow a workout is not masked
+    /// away. Range ≥ 0.
+    public static let postActivityShadowBPM: Double = 8.0
+
     // MARK: - Output
 
     /// One hour of the daytime timeline. `level` is the shared 0–3 stress proxy, or nil
@@ -57,16 +84,23 @@ public enum DaytimeStress {
         public let meanHR: Double?
         /// RMSSD over the hour's clean R-R (ms), or nil (too few clean beats).
         public let rmssd: Double?
+        /// True when this hour was left unscored because it was AMBULATORY (exertion), not because it
+        /// lacked HR — so `level == nil` here means "masked as activity", not "no data". Lets the UI
+        /// separate "you were moving" from "no reading" and keeps active hours out of the calm
+        /// reference and the coverage totals. See the motion-gate constants above.
+        public let maskedForActivity: Bool
 
         /// True when the hour was scored (had enough HR to place on the curve).
         public var hasData: Bool { level != nil }
 
-        public init(hour: Int, startTs: Int, level: Double?, meanHR: Double?, rmssd: Double?) {
+        public init(hour: Int, startTs: Int, level: Double?, meanHR: Double?, rmssd: Double?,
+                    maskedForActivity: Bool = false) {
             self.hour = hour
             self.startTs = startTs
             self.level = level
             self.meanHR = meanHR
             self.rmssd = rmssd
+            self.maskedForActivity = maskedForActivity
         }
     }
 
@@ -82,14 +116,20 @@ public enum DaytimeStress {
         public let dayMean: Double?
         /// Peak scored hour (highest `level`), or nil.
         public let peak: HourPoint?
+        /// Count of waking hours left unscored because they were AMBULATORY (the motion gate fired),
+        /// i.e. `hours.filter { $0.maskedForActivity }.count`. Lets a caller report honest coverage
+        /// ("N hours excluded — you were moving") instead of a silently short timeline. 0 when no
+        /// gravity was supplied or nothing was masked; 0 for `.empty`.
+        public let activityMaskedHours: Int
 
         public init(hours: [HourPoint], sustainedHigh: Bool, sustainedRun: Int,
-                    dayMean: Double?, peak: HourPoint?) {
+                    dayMean: Double?, peak: HourPoint?, activityMaskedHours: Int = 0) {
             self.hours = hours
             self.sustainedHigh = sustainedHigh
             self.sustainedRun = sustainedRun
             self.dayMean = dayMean
             self.peak = peak
+            self.activityMaskedHours = activityMaskedHours
         }
 
         /// The scored hours only (level non-nil), in time order.
@@ -97,7 +137,7 @@ public enum DaytimeStress {
 
         /// Empty read — used when the day had no usable intraday HR at all.
         public static let empty = Result(hours: [], sustainedHigh: false, sustainedRun: 0,
-                                         dayMean: nil, peak: nil)
+                                         dayMean: nil, peak: nil, activityMaskedHours: 0)
     }
 
     // MARK: - Shared stress math (identical formula to the daily StressModel)
@@ -142,11 +182,15 @@ public enum DaytimeStress {
     /// - Parameters:
     ///   - hr: the day's `[HRSample]` (any order; bucketed by ts here).
     ///   - rr: the day's `[RRInterval]`.
+    ///   - gravity: the day's `[GravitySample]` (wrist accelerometer), for the motion gate. Defaults
+    ///     empty: with no gravity NOTHING is masked and the read is byte-identical to before. When
+    ///     present, ambulatory hours are masked out of the score (see the motion-gate constants).
     ///   - tzOffsetSeconds: seconds east of UTC, for placing each bucket on the LOCAL
     ///     clock (so "waking hours" and the hour labels are local). Defaults to UTC.
     ///
     /// Returns `.empty` when there isn't a single hour with enough HR to score.
     public static func analyze(hr: [HRSample], rr: [RRInterval],
+                               gravity: [GravitySample] = [],
                                tzOffsetSeconds: Int = 0) -> Result {
         // v7.0.2 perf (#707): buckets the day's full HR + R-R streams into per-hour aggregates and runs an
         // RMSSD per hour — invoked from the Stress view, so a `body` re-evaluation re-buckets the whole day.
@@ -154,14 +198,25 @@ public enum DaytimeStress {
         let key = StressKey(
             hr: StreamFingerprint.of(hr, ts: { $0.ts }, quant: { Int($0.bpm) }),
             rr: StreamFingerprint.of(rr, ts: { $0.ts }, quant: { Int($0.rrMs) }),
+            // Fold all three axes into one quant so two different gravity streams cannot share a key
+            // (same hr/rr with different motion must NOT reuse a cached result).
+            gravity: StreamFingerprint.of(gravity, ts: { $0.ts }, quant: {
+                Int(($0.x * 128).rounded()) &+ Int(($0.y * 128).rounded()) &* 257
+                    &+ Int(($0.z * 128).rounded()) &* 66_049
+            }),
             tz: tzOffsetSeconds)
-        return analyzeCache.value(key) { analyzeUncached(hr: hr, rr: rr, tzOffsetSeconds: tzOffsetSeconds) }
+        return analyzeCache.value(key) {
+            analyzeUncached(hr: hr, rr: rr, gravity: gravity, tzOffsetSeconds: tzOffsetSeconds)
+        }
     }
 
-    private struct StressKey: Hashable { let hr: StreamFingerprint; let rr: StreamFingerprint; let tz: Int }
+    private struct StressKey: Hashable {
+        let hr: StreamFingerprint; let rr: StreamFingerprint; let gravity: StreamFingerprint; let tz: Int
+    }
     private static let analyzeCache = AnalyticsMemoCache<StressKey, Result>(capacity: 8)
 
     private static func analyzeUncached(hr: [HRSample], rr: [RRInterval],
+                                        gravity: [GravitySample],
                                         tzOffsetSeconds: Int) -> Result {
         guard !hr.isEmpty else { return .empty }
 
@@ -194,6 +249,30 @@ public enum DaytimeStress {
             aggs.append(HourAgg(bucket: b, meanHR: mHR, rmssd: rrRes.rmssd, nHR: hrs.count))
         }
 
+        // 2b) Motion gate: bucket the day's gravity-derived activity by the SAME local hour and mark
+        //     each hour AMBULATORY when at least `activityMaskFraction` of its records clear the
+        //     calibrated walk floor (`WorkoutDetector.motionThreshold`) — reusing the exact activity
+        //     series `SedentaryDetector` / `WorkoutDetector` already trust. Empty gravity → no active
+        //     buckets → nothing masked below (byte-identical to the pre-motion behaviour).
+        var activeFracByBucket: [Int: Double] = [:]
+        if !gravity.isEmpty {
+            var counts: [Int: (active: Int, total: Int)] = [:]
+            for p in WorkoutDetector.activitySeries(gravity) {
+                let local = p.ts + tzOffsetSeconds
+                let bucket = floorDiv(local, bucketSeconds) * bucketSeconds
+                var e = counts[bucket] ?? (0, 0)
+                e.total += 1
+                if p.intensity > WorkoutDetector.motionThreshold { e.active += 1 }
+                counts[bucket] = e
+            }
+            for (b, e) in counts where e.total > 0 {
+                activeFracByBucket[b] = Double(e.active) / Double(e.total)
+            }
+        }
+        func isAmbulatory(_ bucket: Int) -> Bool {
+            (activeFracByBucket[bucket] ?? 0) >= activityMaskFraction
+        }
+
         // 3) The day's OWN quiet reference: centre on the CALM end (the lower quartile of
         //    hourly mean HR, the upper quartile of hourly RMSSD), and spread from the
         //    across-hour SD. This makes a flat day read ~baseline and a spiky day surface
@@ -206,7 +285,10 @@ public enum DaytimeStress {
         //    hours of it. Letting those night hours into the reference drags the "calm" anchor
         //    far beneath every waking hour, inflating an ordinary calm day toward HIGH and
         //    falsely tripping the sustained-high Breathe nudge.
-        let referenceAggs = aggs.filter { isWakingHour($0.bucket) }
+        //    Ambulatory hours are excluded from the day's OWN calm reference too: an exertion hour's
+        //    elevated HR / suppressed HRV must not pull the calm anchor up or inflate the across-hour
+        //    spread the z-scores divide by.
+        let referenceAggs = aggs.filter { isWakingHour($0.bucket) && !isAmbulatory($0.bucket) }
         let hrMeans = referenceAggs.compactMap { $0.meanHR }
         let rmssdVals = referenceAggs.compactMap { $0.rmssd }
         let refHR = calmReference(hrMeans, calmIsLow: true)         // calm HR is LOW
@@ -222,15 +304,26 @@ public enum DaytimeStress {
             let hourOfDay = floorDiv(a.bucket, bucketSeconds) % 24
             // The wall-clock bucket start (undo the local shift applied above).
             let wallStart = a.bucket - tzOffsetSeconds
-            // Score only when at least one signal is present AND HR cleared the count gate
-            // (HR is the always-available anchor; RMSSD enriches it when beats allow).
-            let level: Double? = a.meanHR != nil
+            // Motion gate: an AMBULATORY hour — or the post-exercise shadow hour whose HR has not yet
+            // recovered to the calm reference — is EXERTION, so its elevated HR is masked out of the
+            // score instead of read as stress. The shadow is gated on `refHR` so it self-limits to
+            // genuine cardiac recovery (a following hour already back at baseline scores normally).
+            // Only meaningful when the hour actually HAD a reading to withhold — a no-HR hour is plain
+            // `.noData`, not "masked".
+            let shadow = isAmbulatory(a.bucket - bucketSeconds)
+                && a.meanHR != nil && refHR != nil && a.meanHR! > refHR! + postActivityShadowBPM
+            let masked = a.meanHR != nil && (isAmbulatory(a.bucket) || shadow)
+            // Score only when at least one signal is present AND HR cleared the count gate AND the
+            // hour was not motion-masked (HR is the always-available anchor; RMSSD enriches it).
+            let level: Double? = (a.meanHR != nil && !masked)
                 ? squash(rawScore(hr: a.meanHR, meanHR: refHR, sdHR: sdHR,
                                   rmssd: a.rmssd, meanRMSSD: refRMSSD, sdRMSSD: sdRMSSD))
                 : nil
             points.append(HourPoint(hour: hourOfDay, startTs: wallStart,
-                                    level: level, meanHR: a.meanHR, rmssd: a.rmssd))
+                                    level: level, meanHR: a.meanHR, rmssd: a.rmssd,
+                                    maskedForActivity: masked))
         }
+        let activityMaskedHours = points.reduce(0) { $0 + ($1.maskedForActivity ? 1 : 0) }
 
         let scored = points.compactMap { p -> (HourPoint, Double)? in p.level.map { (p, $0) } }
         guard !scored.isEmpty else {
@@ -238,7 +331,7 @@ public enum DaytimeStress {
             // show "not enough data" rather than nothing.
             return points.isEmpty ? .empty
                 : Result(hours: points, sustainedHigh: false, sustainedRun: 0,
-                         dayMean: nil, peak: nil)
+                         dayMean: nil, peak: nil, activityMaskedHours: activityMaskedHours)
         }
 
         // 5) Sustained-high flag: walk back from the latest SCORED hour while each is HIGH.
@@ -252,7 +345,7 @@ public enum DaytimeStress {
         let peak = scored.max { $0.1 < $1.1 }?.0
 
         return Result(hours: points, sustainedHigh: sustained, sustainedRun: run,
-                      dayMean: dayMean, peak: peak)
+                      dayMean: dayMean, peak: peak, activityMaskedHours: activityMaskedHours)
     }
 
     // MARK: - Helpers

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeStressTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeStressTests.swift
@@ -132,4 +132,155 @@ final class DaytimeStressTests: XCTestCase {
         let base = hour * 3_600
         return (0..<n).map { RRInterval(ts: base + $0 * 50, rrMs: rrMs + ($0 % 2 == 0 ? jitter : -jitter)) }
     }
+
+    // MARK: - Motion gate
+
+    /// Gravity for one local hour. `activeFraction` of the records step far enough between
+    /// consecutive samples to clear `WorkoutDetector.motionThreshold` (0.20 g L2); the rest hold
+    /// still. The alternating ±step keeps every active record above the floor rather than only the
+    /// first, so the produced active fraction matches `activeFraction` closely.
+    private func hourGravity(_ hour: Int, activeFraction: Double, n: Int = 120) -> [GravitySample] {
+        let base = hour * 3_600
+        let activeCount = Int((Double(n) * activeFraction).rounded())
+        return (0..<n).map { i in
+            // 0.5 g of step per axis-pair is comfortably above the 0.20 walk floor when it alternates.
+            let x = i < activeCount ? (i % 2 == 0 ? 0.5 : 0.0) : 0.0
+            return GravitySample(ts: base + i * 30, x: x, y: 0, z: 1)
+        }
+    }
+
+    func testEmptyGravityIsByteIdenticalToNoGravity() {
+        // The degradation contract: with no motion channel NOTHING is masked and the read is
+        // unchanged from the pre-gate behaviour.
+        var hr: [HRSample] = []
+        for h in [8, 9, 10, 11] { hr += hourHR(h, bpm: 60 + (h - 8) * 5) }
+        let withoutGravity = DaytimeStress.analyze(hr: hr, rr: [])
+        let withEmptyGravity = DaytimeStress.analyze(hr: hr, rr: [], gravity: [])
+        XCTAssertEqual(withoutGravity, withEmptyGravity)
+        XCTAssertEqual(withEmptyGravity.activityMaskedHours, 0)
+        XCTAssertFalse(withEmptyGravity.hours.contains { $0.maskedForActivity })
+    }
+
+    func testAmbulatoryHourIsMaskedNotScored() {
+        // Four hours; the 11:00 hour has an elevated HR AND is ambulatory. Without motion it scores
+        // as the day's most "stressed" hour — the exact false positive the gate exists to remove.
+        var hr: [HRSample] = []
+        for h in [8, 9, 10] { hr += hourHR(h, bpm: 60) }
+        hr += hourHR(11, bpm: 110)   // the walk
+
+        let unGated = DaytimeStress.analyze(hr: hr, rr: [])
+        XCTAssertNotNil(unGated.scored.first { $0.hour == 11 }?.level,
+            "precondition: without gravity the ambulatory hour is scored as stress")
+
+        var gravity: [GravitySample] = []
+        for h in [8, 9, 10] { gravity += hourGravity(h, activeFraction: 0.0) }
+        gravity += hourGravity(11, activeFraction: 1.0)
+
+        let gated = DaytimeStress.analyze(hr: hr, rr: [], gravity: gravity)
+        let masked = gated.hours.first { $0.hour == 11 }
+        XCTAssertNotNil(masked)
+        XCTAssertNil(masked?.level, "an ambulatory hour must not be scored")
+        XCTAssertTrue(masked?.maskedForActivity ?? false,
+            "the hour must report WHY it is unscored — masked, not noData")
+        XCTAssertEqual(masked?.meanHR, 110, "the reading itself is still reported, only the score is withheld")
+        XCTAssertEqual(gated.activityMaskedHours, 1)
+    }
+
+    func testStillHourIsStillScoredWhenGravityPresent() {
+        // The gate must not swallow a genuinely sedentary day just because gravity was supplied.
+        var hr: [HRSample] = []
+        var gravity: [GravitySample] = []
+        for h in [8, 9, 10, 11] {
+            hr += hourHR(h, bpm: h == 11 ? 85 : 60)
+            gravity += hourGravity(h, activeFraction: 0.0)
+        }
+        let r = DaytimeStress.analyze(hr: hr, rr: [], gravity: gravity)
+        XCTAssertEqual(r.activityMaskedHours, 0, "a still day must have nothing masked")
+        XCTAssertNotNil(r.scored.first { $0.hour == 11 }?.level,
+            "a stationary elevated-HR hour is exactly what the timeline SHOULD score")
+    }
+
+    func testLightMovementBelowFractionDoesNotMask() {
+        // A stray reach or one trip to the kitchen (under activityMaskFraction) is not exertion.
+        var hr: [HRSample] = []
+        var gravity: [GravitySample] = []
+        for h in [8, 9, 10, 11] {
+            hr += hourHR(h, bpm: 60)
+            gravity += hourGravity(h, activeFraction: h == 10 ? 0.10 : 0.0)
+        }
+        let r = DaytimeStress.analyze(hr: hr, rr: [], gravity: gravity)
+        XCTAssertEqual(r.activityMaskedHours, 0,
+            "10 % ambulatory is below activityMaskFraction (0.30) and must not mask the hour")
+    }
+
+    func testPostActivityShadowMasksOnlyWhileHRStaysElevated() {
+        // The hour AFTER exertion is masked while its HR is still above the calm reference by
+        // postActivityShadowBPM, and scored normally once it has recovered.
+        func day(followingBPM: Int) -> DaytimeStress.Result {
+            var hr: [HRSample] = []
+            var gravity: [GravitySample] = []
+            for h in [8, 9, 10, 13] {                       // still hours, set the ~60 bpm calm anchor
+                hr += hourHR(h, bpm: 60)
+                gravity += hourGravity(h, activeFraction: 0.0)
+            }
+            hr += hourHR(11, bpm: 120)                      // 11:00 — the workout hour
+            gravity += hourGravity(11, activeFraction: 1.0)
+            hr += hourHR(12, bpm: followingBPM)             // 12:00 — the shadow hour, now still
+            gravity += hourGravity(12, activeFraction: 0.0)
+            return DaytimeStress.analyze(hr: hr, rr: [], gravity: gravity)
+        }
+        // Still elevated well above the ~60 bpm calm reference → masked.
+        let hot = day(followingBPM: 100)
+        XCTAssertTrue(hot.hours.first { $0.hour == 12 }?.maskedForActivity ?? false,
+            "an unrecovered post-exercise hour must be masked, not read as stress")
+        // Back at the calm reference → the shadow self-limits and the hour is scored.
+        let recovered = day(followingBPM: 60)
+        XCTAssertFalse(recovered.hours.first { $0.hour == 12 }?.maskedForActivity ?? true,
+            "once HR is back at the calm reference the shadow must not keep masking")
+    }
+
+    func testMaskedHoursAreExcludedFromTheCalmReference() {
+        // An exertion hour must not drag the day's calm anchor upward, which would depress every
+        // other hour's score. Same still hours, with and without an added ambulatory hour.
+        var stillHR: [HRSample] = []
+        var stillGravity: [GravitySample] = []
+        for h in [8, 9, 10, 13] {
+            stillHR += hourHR(h, bpm: h == 13 ? 80 : 60)
+            stillGravity += hourGravity(h, activeFraction: 0.0)
+        }
+        let withoutWorkout = DaytimeStress.analyze(hr: stillHR, rr: [], gravity: stillGravity)
+
+        var withHR = stillHR, withGravity = stillGravity
+        withHR += hourHR(11, bpm: 130)
+        withGravity += hourGravity(11, activeFraction: 1.0)
+        let withWorkout = DaytimeStress.analyze(hr: withHR, rr: [], gravity: withGravity)
+
+        let before = withoutWorkout.scored.first { $0.hour == 13 }?.level
+        let after = withWorkout.scored.first { $0.hour == 13 }?.level
+        XCTAssertNotNil(before); XCTAssertNotNil(after)
+        XCTAssertEqual(before!, after!, accuracy: 1e-9,
+            "a masked exertion hour leaked into the calm reference and moved an unrelated hour's score")
+    }
+
+    func testDifferentGravityDoesNotReuseAMemoizedResult() {
+        // The analyze memo is keyed on the streams; two identical hr/rr days with DIFFERENT motion
+        // must not share a cached Result.
+        var hr: [HRSample] = []
+        for h in [8, 9, 10] { hr += hourHR(h, bpm: 60) }
+        hr += hourHR(11, bpm: 110)
+
+        var still: [GravitySample] = []
+        var moving: [GravitySample] = []
+        for h in [8, 9, 10] {
+            still += hourGravity(h, activeFraction: 0.0)
+            moving += hourGravity(h, activeFraction: 0.0)
+        }
+        still += hourGravity(11, activeFraction: 0.0)
+        moving += hourGravity(11, activeFraction: 1.0)
+
+        let a = DaytimeStress.analyze(hr: hr, rr: [], gravity: still)
+        let b = DaytimeStress.analyze(hr: hr, rr: [], gravity: moving)
+        XCTAssertEqual(a.activityMaskedHours, 0)
+        XCTAssertEqual(b.activityMaskedHours, 1, "the memo key ignored gravity and returned a stale Result")
+    }
 }

--- a/Strand/Screens/StressView.swift
+++ b/Strand/Screens/StressView.swift
@@ -111,8 +111,13 @@ struct StressView: View {
         }
         let rr = (try? await repo.storeHandle()?.rrIntervals(
             deviceId: repo.deviceId, from: from, to: to, limit: 200_000)) ?? []
+        // Wrist accelerometer for the motion gate: an ambulatory hour is EXERTION, not stress, so it
+        // is masked rather than scored (DaytimeStress). Same store read as R-R; empty on hardware or
+        // imports with no gravity, which is exactly the "no masking, prior behaviour" degradation.
+        let gravity = (try? await repo.storeHandle()?.gravitySamples(
+            deviceId: repo.deviceId, from: from, to: to, limit: 200_000)) ?? []
 
-        daytime = DaytimeStress.analyze(hr: hr, rr: rr, tzOffsetSeconds: tz)
+        daytime = DaytimeStress.analyze(hr: hr, rr: rr, gravity: gravity, tzOffsetSeconds: tz)
 
         // ADDITIVE advanced readouts, computed on-demand from the SAME `rr` (no extra fetch, no
         // DB / schema change, and no effect on the 0..3 score above). Each engine returns nil when

--- a/android/app/src/main/java/com/noop/analytics/DaytimeStress.kt
+++ b/android/app/src/main/java/com/noop/analytics/DaytimeStress.kt
@@ -1,5 +1,6 @@
 package com.noop.analytics
 
+import com.noop.data.GravitySample
 import com.noop.data.HrSample
 import com.noop.data.RrInterval
 import kotlin.math.exp
@@ -51,6 +52,38 @@ object DaytimeStress {
     const val wakingStartHour: Int = 6
     const val wakingEndHour: Int = 22
 
+    // MARK: - Motion gate
+    //
+    // Cardiac signals alone cannot separate psychological stress from EXERTION: a brisk walk and a
+    // tense meeting both raise HR and suppress HRV. Without a motion channel an ambulatory hour is
+    // scored as "stress". When the caller supplies the day's gravity (wrist accelerometer), an hour
+    // that was substantially ambulatory is MASKED (null level, [HourPoint.maskedForActivity] true)
+    // rather than scored, and it is excluded from the calm reference and the coverage totals. No
+    // gravity → no masking → byte-identical prior behaviour, so the gate only applies when motion is
+    // actually observable.
+
+    /**
+     * An hour whose gravity-derived activity is ambulatory for at least this fraction of its records
+     * is EXERTION, not stress — masked, not scored. "Ambulatory" = a per-record activity intensity
+     * above [WorkoutDetector.motionThreshold] (0.20 L2-g, the codebase's calibrated walk floor: desk
+     * ≈ 0.05–0.10 g, walking ≈ 0.2–0.4 g). 0.30 means "at least 30 % of the hour was walking or
+     * moving"; below it, a stray reach or one trip to the kitchen does not mask a desk hour. An
+     * hourly grain is coarse — this is the gate that later allows finer epochs, at which point the
+     * fraction can tighten. Range (0, 1].
+     */
+    const val activityMaskFraction: Double = 0.30
+
+    /**
+     * Post-exercise shadow: HR stays elevated for a while AFTER exertion ends, so the single hour
+     * that immediately FOLLOWS a directly-ambulatory hour is ALSO masked WHILE its mean HR is still
+     * above the calm reference by this margin (bpm). A following hour whose HR has already returned
+     * to the calm reference is scored normally, so the shadow self-limits to genuine cardiac
+     * recovery. Deliberately ONE hour deep (keyed on the directly-active hour, not chained through
+     * prior shadows) so a genuinely tense afternoon that happens to follow a workout is not masked
+     * away. Range >= 0.
+     */
+    const val postActivityShadowBpm: Double = 8.0
+
     // MARK: - Output
 
     /**
@@ -68,6 +101,13 @@ object DaytimeStress {
         val meanHr: Double?,
         /** RMSSD over the hour's clean R-R (ms), or null (too few clean beats). */
         val rmssd: Double?,
+        /**
+         * True when this hour was left unscored because it was AMBULATORY (exertion), not because it
+         * lacked HR — so a null [level] here means "masked as activity", not "no data". Lets the UI
+         * separate "you were moving" from "no reading" and keeps active hours out of the calm
+         * reference and the coverage totals. See the motion-gate constants above.
+         */
+        val maskedForActivity: Boolean = false,
     ) {
         /** True when the hour was scored (had enough HR to place on the curve). */
         val hasData: Boolean get() = level != null
@@ -85,6 +125,13 @@ object DaytimeStress {
         val dayMean: Double?,
         /** Peak scored hour (highest level), or null. */
         val peak: HourPoint?,
+        /**
+         * Count of waking hours left unscored because they were AMBULATORY (the motion gate fired),
+         * i.e. `hours.count { it.maskedForActivity }`. Lets a caller report honest coverage
+         * ("N hours excluded — you were moving") instead of a silently short timeline. 0 when no
+         * gravity was supplied or nothing was masked; 0 for [EMPTY].
+         */
+        val activityMaskedHours: Int = 0,
     ) {
         /** The scored hours only (level non-null), in time order. */
         val scored: List<HourPoint> get() = hours.filter { it.level != null }
@@ -92,7 +139,7 @@ object DaytimeStress {
         companion object {
             /** Empty read — used when the day had no usable intraday HR at all. */
             val EMPTY = Result(emptyList(), sustainedHigh = false, sustainedRun = 0,
-                dayMean = null, peak = null)
+                dayMean = null, peak = null, activityMaskedHours = 0)
         }
     }
 
@@ -140,12 +187,20 @@ object DaytimeStress {
      *
      * @param hr the day's HR samples (any order; bucketed by ts here).
      * @param rr the day's R-R intervals.
+     * @param gravity the day's gravity samples (wrist accelerometer), for the motion gate. Defaults
+     *   empty: with no gravity NOTHING is masked and the read is byte-identical to before. When
+     *   present, ambulatory hours are masked out of the score (see the motion-gate constants).
      * @param tzOffsetSeconds seconds east of UTC, for placing each bucket on the LOCAL clock
      *   (so "waking hours" and the hour labels are local). Defaults to UTC.
      *
      * Returns [Result.EMPTY] when there isn't a single hour with enough HR to score.
      */
-    fun analyze(hr: List<HrSample>, rr: List<RrInterval>, tzOffsetSeconds: Long = 0L): Result {
+    fun analyze(
+        hr: List<HrSample>,
+        rr: List<RrInterval>,
+        gravity: List<GravitySample> = emptyList(),
+        tzOffsetSeconds: Long = 0L,
+    ): Result {
         if (hr.isEmpty()) return Result.EMPTY
 
         // 1) Bucket HR + R-R into LOCAL hour-of-day buckets, keyed by the bucket start
@@ -176,6 +231,30 @@ object DaytimeStress {
             aggs.add(HourAgg(b, mHr, rrRes.rmssd))
         }
 
+        // 2b) Motion gate: bucket the day's gravity-derived activity by the SAME local hour and mark
+        //     each hour AMBULATORY when at least [activityMaskFraction] of its records clear the
+        //     calibrated walk floor ([WorkoutDetector.motionThreshold]) — reusing the exact activity
+        //     series SedentaryDetector / WorkoutDetector already trust. Empty gravity → no active
+        //     buckets → nothing masked below (byte-identical to the pre-motion behaviour).
+        val activeFracByBucket = HashMap<Long, Double>()
+        if (gravity.isNotEmpty()) {
+            val activeCounts = HashMap<Long, Int>()
+            val totalCounts = HashMap<Long, Int>()
+            for (p in WorkoutDetector.activitySeries(gravity)) {
+                val localTs = p.ts + tzOffsetSeconds
+                val bucket = floorDiv(localTs, bucketSeconds) * bucketSeconds
+                totalCounts[bucket] = (totalCounts[bucket] ?: 0) + 1
+                if (p.intensity > WorkoutDetector.motionThreshold) {
+                    activeCounts[bucket] = (activeCounts[bucket] ?: 0) + 1
+                }
+            }
+            for ((b, total) in totalCounts) {
+                if (total > 0) activeFracByBucket[b] = (activeCounts[b] ?: 0).toDouble() / total
+            }
+        }
+        fun isAmbulatory(bucket: Long): Boolean =
+            (activeFracByBucket[bucket] ?: 0.0) >= activityMaskFraction
+
         // 3) The day's OWN quiet reference: centre on the CALM end (the lower quartile of
         //    hourly mean HR, the upper quartile of hourly RMSSD), and spread from the
         //    across-hour SD. This makes a flat day read ~baseline and a spiky day surface its
@@ -188,7 +267,10 @@ object DaytimeStress {
         //    hours of it. Letting those night hours into the reference drags the "calm" anchor
         //    far beneath every waking hour, inflating an ordinary calm day toward HIGH and
         //    falsely tripping the sustained-high Breathe nudge.
-        val referenceAggs = aggs.filter { isWakingHour(it.bucket) }
+        //    Ambulatory hours are excluded from the day's OWN calm reference too: an exertion hour's
+        //    elevated HR / suppressed HRV must not pull the calm anchor up or inflate the across-hour
+        //    spread the z-scores divide by.
+        val referenceAggs = aggs.filter { isWakingHour(it.bucket) && !isAmbulatory(it.bucket) }
         val hrMeans = referenceAggs.mapNotNull { it.meanHr }
         val rmssdVals = referenceAggs.mapNotNull { it.rmssd }
         val refHr = calmReference(hrMeans, calmIsLow = true)         // calm HR is LOW
@@ -203,22 +285,33 @@ object DaytimeStress {
             val hourOfDay = (floorDiv(a.bucket, bucketSeconds) % 24).toInt()
             // The wall-clock bucket start (undo the local shift applied above).
             val wallStart = a.bucket - tzOffsetSeconds
-            // Score only when HR cleared the count gate (HR is the always-available anchor;
-            // RMSSD enriches it when beats allow).
-            val level: Double? = if (a.meanHr != null) {
+            // Motion gate: an AMBULATORY hour — or the post-exercise shadow hour whose HR has not
+            // yet recovered to the calm reference — is EXERTION, so its elevated HR is masked out of
+            // the score instead of read as stress. The shadow is gated on refHr so it self-limits to
+            // genuine cardiac recovery (a following hour already back at baseline scores normally).
+            // Only meaningful when the hour actually HAD a reading to withhold — a no-HR hour is
+            // plain no-data, not "masked".
+            val shadow = isAmbulatory(a.bucket - bucketSeconds) &&
+                a.meanHr != null && refHr != null && a.meanHr > refHr + postActivityShadowBpm
+            val masked = a.meanHr != null && (isAmbulatory(a.bucket) || shadow)
+            // Score only when HR cleared the count gate AND the hour was not motion-masked (HR is
+            // the always-available anchor; RMSSD enriches it when beats allow).
+            val level: Double? = if (a.meanHr != null && !masked) {
                 squash(rawScore(a.meanHr, refHr, sdHr, a.rmssd, refRmssd, sdRmssd))
             } else {
                 null
             }
-            points.add(HourPoint(hourOfDay, wallStart, level, a.meanHr, a.rmssd))
+            points.add(HourPoint(hourOfDay, wallStart, level, a.meanHr, a.rmssd, masked))
         }
+        val activityMaskedHours = points.count { it.maskedForActivity }
 
         val scored = points.mapNotNull { p -> p.level?.let { p to it } }
         if (scored.isEmpty()) {
             // No scorable waking hour — still return the (unscored) timeline so the UI can
             // show "not enough data" rather than nothing.
             return if (points.isEmpty()) Result.EMPTY
-            else Result(points, sustainedHigh = false, sustainedRun = 0, dayMean = null, peak = null)
+            else Result(points, sustainedHigh = false, sustainedRun = 0, dayMean = null, peak = null,
+                activityMaskedHours = activityMaskedHours)
         }
 
         // 5) Sustained-high flag: walk back from the latest SCORED hour while each is HIGH.
@@ -231,7 +324,7 @@ object DaytimeStress {
         val dayMean = mean(scored.map { it.second })
         val peak = scored.maxByOrNull { it.second }?.first
 
-        return Result(points, sustained, run, dayMean, peak)
+        return Result(points, sustained, run, dayMean, peak, activityMaskedHours)
     }
 
     // MARK: - Helpers

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -183,7 +183,11 @@ private suspend fun loadDaytimeStress(vm: AppViewModel): DaytimeReadout {
         return DaytimeReadout(DaytimeStress.Result.EMPTY, null, null)
     }
     val rr = vm.repo.rrIntervals("my-whoop", from, nowSeconds, limit = 200_000)
-    val daytime = DaytimeStress.analyze(hr, rr, tzOffsetSeconds)
+    // Wrist accelerometer for the motion gate: an ambulatory hour is EXERTION, not stress, so it is
+    // masked rather than scored (DaytimeStress). Same repo read as R-R; empty on hardware or imports
+    // with no gravity, which is exactly the "no masking, prior behaviour" degradation.
+    val gravity = vm.repo.gravitySamples("my-whoop", from, nowSeconds, limit = 200_000)
+    val daytime = DaytimeStress.analyze(hr, rr, gravity, tzOffsetSeconds)
     // ADDITIVE advanced readouts from the SAME `rr`. Each engine self-gates and returns null when
     // its requirement is not met, in which case its row is simply hidden in the UI.
     val si = StressIndex.components(rr)

--- a/android/app/src/test/java/com/noop/analytics/DaytimeStressTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DaytimeStressTest.kt
@@ -1,10 +1,13 @@
 package com.noop.analytics
 
+import com.noop.data.GravitySample
 import com.noop.data.HrSample
 import com.noop.data.RrInterval
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -55,6 +58,143 @@ class DaytimeStressTest {
         assertFalse(
             "a calm desk day must not read as sustained high stress",
             withSleep.sustainedHigh,
+        )
+    }
+
+    // MARK: - Motion gate (Kotlin twin of the Swift gate tests)
+
+    /**
+     * Gravity for one local hour. [activeFraction] of the records step far enough between
+     * consecutive samples to clear WorkoutDetector.motionThreshold (0.20 g L2); the rest hold still.
+     */
+    private fun hourGravity(hour: Int, activeFraction: Double, n: Int = 120): List<GravitySample> {
+        val base = hour.toLong() * 3_600L
+        val activeCount = Math.round(n * activeFraction).toInt()
+        return (0 until n).map { i ->
+            val x = if (i < activeCount && i % 2 == 0) 0.5 else 0.0
+            GravitySample(deviceId = "t", ts = base + i * 30L, x = x, y = 0.0, z = 1.0)
+        }
+    }
+
+    @Test
+    fun emptyGravityIsByteIdenticalToNoGravity() {
+        var hr = emptyList<HrSample>()
+        for (h in listOf(8, 9, 10, 11)) hr = hr + hourHr(h, 60 + (h - 8) * 5)
+        val withoutGravity = DaytimeStress.analyze(hr, emptyList())
+        val withEmptyGravity = DaytimeStress.analyze(hr, emptyList(), emptyList())
+        assertEquals(withoutGravity, withEmptyGravity)
+        assertEquals(0, withEmptyGravity.activityMaskedHours)
+        assertFalse(withEmptyGravity.hours.any { it.maskedForActivity })
+    }
+
+    @Test
+    fun ambulatoryHourIsMaskedNotScored() {
+        var hr = emptyList<HrSample>()
+        for (h in listOf(8, 9, 10)) hr = hr + hourHr(h, 60)
+        hr = hr + hourHr(11, 110)   // the walk
+
+        val unGated = DaytimeStress.analyze(hr, emptyList())
+        assertNotNull(
+            "precondition: without gravity the ambulatory hour is scored as stress",
+            unGated.scored.firstOrNull { it.hour == 11 }?.level,
+        )
+
+        var gravity = emptyList<GravitySample>()
+        for (h in listOf(8, 9, 10)) gravity = gravity + hourGravity(h, 0.0)
+        gravity = gravity + hourGravity(11, 1.0)
+
+        val gated = DaytimeStress.analyze(hr, emptyList(), gravity)
+        val masked = gated.hours.firstOrNull { it.hour == 11 }
+        assertNotNull(masked)
+        assertNull("an ambulatory hour must not be scored", masked!!.level)
+        assertTrue(
+            "the hour must report WHY it is unscored — masked, not no-data",
+            masked.maskedForActivity,
+        )
+        assertEquals(
+            "the reading itself is still reported, only the score is withheld",
+            110.0, masked.meanHr!!, 1e-9,
+        )
+        assertEquals(1, gated.activityMaskedHours)
+    }
+
+    @Test
+    fun stillHourIsStillScoredWhenGravityPresent() {
+        var hr = emptyList<HrSample>()
+        var gravity = emptyList<GravitySample>()
+        for (h in listOf(8, 9, 10, 11)) {
+            hr = hr + hourHr(h, if (h == 11) 85 else 60)
+            gravity = gravity + hourGravity(h, 0.0)
+        }
+        val r = DaytimeStress.analyze(hr, emptyList(), gravity)
+        assertEquals("a still day must have nothing masked", 0, r.activityMaskedHours)
+        assertNotNull(
+            "a stationary elevated-HR hour is exactly what the timeline SHOULD score",
+            r.scored.firstOrNull { it.hour == 11 }?.level,
+        )
+    }
+
+    @Test
+    fun lightMovementBelowFractionDoesNotMask() {
+        var hr = emptyList<HrSample>()
+        var gravity = emptyList<GravitySample>()
+        for (h in listOf(8, 9, 10, 11)) {
+            hr = hr + hourHr(h, 60)
+            gravity = gravity + hourGravity(h, if (h == 10) 0.10 else 0.0)
+        }
+        val r = DaytimeStress.analyze(hr, emptyList(), gravity)
+        assertEquals(
+            "10 % ambulatory is below activityMaskFraction (0.30) and must not mask the hour",
+            0, r.activityMaskedHours,
+        )
+    }
+
+    @Test
+    fun postActivityShadowMasksOnlyWhileHrStaysElevated() {
+        fun day(followingBpm: Int): DaytimeStress.Result {
+            var hr = emptyList<HrSample>()
+            var gravity = emptyList<GravitySample>()
+            for (h in listOf(8, 9, 10, 13)) {
+                hr = hr + hourHr(h, 60)
+                gravity = gravity + hourGravity(h, 0.0)
+            }
+            hr = hr + hourHr(11, 120)                 // the workout hour
+            gravity = gravity + hourGravity(11, 1.0)
+            hr = hr + hourHr(12, followingBpm)        // the shadow hour, now still
+            gravity = gravity + hourGravity(12, 0.0)
+            return DaytimeStress.analyze(hr, emptyList(), gravity)
+        }
+        assertTrue(
+            "an unrecovered post-exercise hour must be masked, not read as stress",
+            day(100).hours.firstOrNull { it.hour == 12 }?.maskedForActivity ?: false,
+        )
+        assertFalse(
+            "once HR is back at the calm reference the shadow must not keep masking",
+            day(60).hours.firstOrNull { it.hour == 12 }?.maskedForActivity ?: true,
+        )
+    }
+
+    @Test
+    fun maskedHoursAreExcludedFromTheCalmReference() {
+        var stillHr = emptyList<HrSample>()
+        var stillGravity = emptyList<GravitySample>()
+        for (h in listOf(8, 9, 10, 13)) {
+            stillHr = stillHr + hourHr(h, if (h == 13) 80 else 60)
+            stillGravity = stillGravity + hourGravity(h, 0.0)
+        }
+        val withoutWorkout = DaytimeStress.analyze(stillHr, emptyList(), stillGravity)
+
+        val withHr = stillHr + hourHr(11, 130)
+        val withGravity = stillGravity + hourGravity(11, 1.0)
+        val withWorkout = DaytimeStress.analyze(withHr, emptyList(), withGravity)
+
+        val before = withoutWorkout.scored.firstOrNull { it.hour == 13 }?.level
+        val after = withWorkout.scored.firstOrNull { it.hour == 13 }?.level
+        assertNotNull(before)
+        assertNotNull(after)
+        assertEquals(
+            "a masked exertion hour leaked into the calm reference and moved an unrelated hour's score",
+            before!!, after!!, 1e-9,
         )
     }
 }


### PR DESCRIPTION
## The problem

Cardiac signals alone cannot separate psychological stress from **exertion**: a brisk walk and a tense meeting both raise HR and suppress HRV. The daytime stress timeline has no motion channel today, so an ambulatory hour is scored as stress — on a real worn day a walk reads as the day's most "stressed" hour, and because the hour also joins the day's calm reference it drags the anchor upward and depresses every other hour's score.

## The change

`DaytimeStress.analyze` gains a `gravity: [GravitySample] = []` parameter.

- An hour whose gravity-derived activity clears the calibrated walk floor (`WorkoutDetector.motionThreshold`, 0.20 L2-g) for at least `activityMaskFraction` (**0.30**) of its records is **masked** rather than scored.
- Masked hours are excluded from the day's **calm reference**, so an exertion hour can no longer pull the anchor up or inflate the across-hour spread the z-scores divide by.
- **Post-exercise shadow:** the single hour that immediately follows an ambulatory hour is also masked *while* its mean HR is still `postActivityShadowBPM` (**8 bpm**) above the calm reference. It self-limits — an hour already back at baseline is scored normally — and is deliberately one hour deep, so a genuinely tense afternoon that happens to follow a workout is still scored.
- The masking is reported rather than hidden: `HourPoint.maskedForActivity` separates "you were moving" from "no reading", and `Result.activityMaskedHours` lets a caller state honest coverage instead of rendering a silently short timeline.

It reuses the exact activity series `SedentaryDetector` and `WorkoutDetector` already trust, so there is no second definition of "moving" in the tree.

## Degradation is byte-identical

`gravity` defaults to empty, and with no gravity **nothing is masked** — the read is byte-identical to the current behaviour. Hardware and imports with no gravity stream (WHOOP 4.0 sparse motion, CSV/Health imports) degrade to exactly what they do today. There is a test pinning this.

The `analyze` memo key now folds in the gravity stream, so two days with identical HR/R-R but different motion cannot share a cached `Result` (also covered by a test).

## Cross-platform parity

Per the parity contract, the Kotlin twin `android/…/analytics/DaytimeStress.kt` carries the same constants (`activityMaskFraction = 0.30`, `postActivityShadowBpm = 8.0`, the same `motionThreshold`) and the same masking logic, with the same 7 test cases ported. Both UI callers (`StressView`, `StressScreen`) now pass the gravity they already have repo access to, so the gate is live rather than dormant on both platforms.

## Verification

- **`swift test` (StrandAnalytics): 1255 tests, 0 failures.** 7 new cases: the empty-gravity byte-identical contract, an ambulatory hour masked instead of scored (with the pre-condition that it *is* scored without gravity), a still elevated-HR hour still scored, sub-threshold movement not masking, the shadow in both directions, calm-reference exclusion, and memo-key separation.
- **Android: `./gradlew testFullDebugUnitTest` — 3528 tests, 0 failures**, including the 7-case Kotlin twin. Run locally, since `android.yml` is disabled by default.
- **`StressView.swift` is app-target Swift that no default CI compiles**, so the macOS app was built locally: `xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS'` → **BUILD SUCCEEDED**.
- **No UI strings added**, so there is no i18n surface in this PR.
- Not a BLE change — no hardware behaviour is touched. The gravity read is an existing store query.

## Tuning honesty

`activityMaskFraction = 0.30` and `postActivityShadowBPM = 8.0` are first-cut values chosen against real worn days, not a validated fit. An hourly grain is coarse; this gate is the piece that later makes finer (5-minute) epochs meaningful, at which point the fraction can tighten. Both constants are named, documented, and in one place.

## Scope

Deliberately just the motion gate. The personal cross-day daytime baseline (`ScoringMode.baselineRelative`), the Oura-comparable `highStressMinutes` readout, and the redesigned daily stress engine are separate concerns and are not in this PR.