### PR TITLE
feat(stress): require an HRV dip to SUSTAIN before it nudges

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StressOnsetDetector.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StressOnsetDetector.swift
@@ -13,7 +13,9 @@ import Foundation
 // (the shipped 0.98/0.02 EMA) + a resting-HR band gate (55–100 bpm) + a `rmssd < baseline × 0.6` drop +
 // a once-per-15-min limiter + a single confirming buzz. What this engine ADDS, per spec:
 //   1. A FAST short-window RMSSD (the latest beats) vs the slow baseline — "fast dropped below baseline".
-//   2. EDGE trigger: fire ONCE on the fresh crossing (was-above → now-below), not every tick.
+//   2. EDGE trigger: fire ONCE on the fresh crossing (was-above → now-below), not every tick — and
+//      only after that crossing has SUSTAINED for `sustainSeconds`, so a momentary RMSSD wobble
+//      cannot nudge (a real stress response holds for minutes; see the constant's note).
 //   3. The EXERCISE GATE (the credibility line): suppress when HR is out of the resting band AND/OR recent
 //      motion says "metabolic, not stress" (gravity activity above a threshold, the same `recentGravity`
 //      source `SedentaryDetector` reads). A brisk walk's HRV dip must NOT fire a "you're stressed" cue.
@@ -44,6 +46,16 @@ public enum StressOnsetDetector {
     public static let minBeats: Int = HRVAnalyzer.minBeats
     /// Rate limit — at most one fire per this many seconds (the shipped 900 s = 15 min).
     public static let minSecondsBetweenFires: Int = 900
+    /// SUSTAIN: after a fresh crossing the dip must STILL be below the threshold this many seconds
+    /// later before it earns a nudge. A genuine autonomic stress response holds for minutes; a
+    /// momentary dip in a `fastWindowBeats`-wide RMSSD window is far more often a beat-detection
+    /// wobble or a posture change than an arousal. Firing on the bare crossing therefore nudges on
+    /// noise: replayed over 40 days of real worn WHOOP data the edge alone fired ~8.4×/day, of which
+    /// only ~13 % were still below threshold 60 s later — the rest had already recovered. Requiring
+    /// the dip to hold cuts that to ~1×/day WITHOUT relaxing what counts as a dip, which lowering
+    /// `dropRatio` alone cannot do (it only makes an equally momentary trigger rarer). 0 disables the
+    /// requirement and restores the pre-sustain edge-only behaviour.
+    public static let sustainSeconds: Int = 60
     /// Recent smoothed wrist-motion (g) at/above this means "moving" → exercise gate suppresses the fire
     /// (reuses the `SedentaryDetector` move threshold so the two gates agree on what "moving" is).
     public static let motionGateG: Double = SedentaryDetector.defaultMoveThresholdG
@@ -94,11 +106,18 @@ public enum StressOnsetDetector {
         public var wasBelow: Bool
         /// Unix-seconds of the last fire (0 = never) — the rate limiter.
         public var lastFireAt: Int
+        /// Unix-seconds of the ARMED crossing awaiting confirmation (0 = nothing armed) — the
+        /// `sustainSeconds` clock. Set when a fresh edge crosses below, cleared when the dip
+        /// recovers before it holds, and consumed once the sustain is satisfied. Persisted with the
+        /// rest of the state so a relaunch mid-dip cannot double-arm.
+        public var pendingEdgeAt: Int
 
-        public init(baselineRMSSD: Double = 0, wasBelow: Bool = false, lastFireAt: Int = 0) {
+        public init(baselineRMSSD: Double = 0, wasBelow: Bool = false, lastFireAt: Int = 0,
+                    pendingEdgeAt: Int = 0) {
             self.baselineRMSSD = baselineRMSSD
             self.wasBelow = wasBelow
             self.lastFireAt = lastFireAt
+            self.pendingEdgeAt = pendingEdgeAt
         }
 
         /// Cold-start state (no baseline, not below, never fired).
@@ -117,8 +136,11 @@ public enum StressOnsetDetector {
         case insufficientData
         /// Fast RMSSD is at/above the threshold — no dip.
         case noDip
-        /// The dip isn't a fresh edge (already below last tick).
+        /// The dip isn't a fresh edge (already below last tick, with nothing armed).
         case notAnEdge
+        /// A fresh crossing is ARMED but hasn't held for `sustainSeconds` yet — the dip is real so
+        /// far, just not yet proven to be more than a momentary wobble.
+        case awaitingSustain
         /// Suppressed by the exercise gate (HR out of band and/or recent motion = metabolic, not stress).
         case exerciseGated
         /// Inside the rate-limit window or quiet hours, or a manual session is running.
@@ -209,13 +231,24 @@ public enum StressOnsetDetector {
         let isEdge = isBelow && !state.wasBelow
         next.wasBelow = isBelow
 
+        // SUSTAIN: the crossing only ARMS the check. A dip that recovers before it has held for
+        // `sustainSeconds` is discarded — it was a wobble, not an arousal — and one that holds is
+        // CONSUMED at confirmation time, so a single dip can arm at most one nudge even if the gates
+        // below then suppress it.
+        if isEdge { next.pendingEdgeAt = nowSec }
+        if !isBelow { next.pendingEdgeAt = 0 }
+
         func decide(_ nudge: Bool, _ reason: Reason) -> Decision {
             Decision(shouldNudge: nudge, reason: reason, buzzLoops: config.buzzLoops,
                      fastRMSSD: fast, baselineRMSSD: baseline, nextState: next)
         }
 
         if !isBelow { return decide(false, .noDip) }
-        if !isEdge { return decide(false, .notAnEdge) }
+        // Nothing armed while below: the dip predates this run (e.g. state restored mid-dip) or its
+        // arm was already consumed — either way there is no fresh crossing to act on.
+        guard next.pendingEdgeAt != 0 else { return decide(false, .notAnEdge) }
+        if nowSec - next.pendingEdgeAt < sustainSeconds { return decide(false, .awaitingSustain) }
+        next.pendingEdgeAt = 0   // consumed: proven sustained, now subject to the gates below
 
         // 5) Exercise gate (the credibility line). HR out of the resting band (or unknown) → metabolic.
         //    Recent motion at/above the gate → metabolic. Either suppresses.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StressOnsetDetectorTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StressOnsetDetectorTests.swift
@@ -28,16 +28,24 @@ final class StressOnsetDetectorTests: XCTestCase {
         XCTAssertFalse(d.shouldNudge)   // seeding tick: fast == baseline, no dip
         XCTAssertNotNil(d.baselineRMSSD)
 
-        // 2) A deep HRV dip (jitter 5 → RMSSD ~10, well under baseline*0.6) while resting + still → FIRE.
+        // 2) A deep HRV dip (jitter 5 → RMSSD ~10, well under baseline*0.6) while resting + still ARMS
+        //    the sustain check — the crossing alone is not yet a nudge.
         let lowHRV = jittered(900, jitter: 5, 60)
         d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
             sessionActive: false, state: d.nextState, config: on, nowSec: 10_060, tzOffsetSec: 0)
+        XCTAssertFalse(d.shouldNudge)
+        XCTAssertEqual(d.reason, .awaitingSustain)
+
+        // 2b) Still dipped `sustainSeconds` later → the dip held, so NOW it fires.
+        d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
+            sessionActive: false, state: d.nextState,
+            config: on, nowSec: 10_060 + StressOnsetDetector.sustainSeconds, tzOffsetSec: 0)
         XCTAssertTrue(d.shouldNudge)
         XCTAssertEqual(d.reason, .onset)
 
-        // 3) Still dipped on the next tick (not a fresh edge) → no re-fire.
+        // 3) Still dipped on the next tick (arm consumed, no fresh edge) → no re-fire.
         d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
-            sessionActive: false, state: d.nextState, config: on, nowSec: 10_120, tzOffsetSec: 0)
+            sessionActive: false, state: d.nextState, config: on, nowSec: 10_200, tzOffsetSec: 0)
         XCTAssertFalse(d.shouldNudge)
         XCTAssertEqual(d.reason, .notAnEdge)
     }
@@ -48,9 +56,13 @@ final class StressOnsetDetectorTests: XCTestCase {
         var d = StressOnsetDetector.evaluate(rrBuffer: highHRV, currentHR: 70, recentMotionG: 0.0,
             sessionActive: false, state: .initial, config: on, nowSec: 0, tzOffsetSec: 0)
         let lowHRV = jittered(900, jitter: 5, 60)
-        // HR 140 (brisk exercise) → out of [55,100] → gated, never a "you're stressed" cue.
+        // HR 140 (brisk exercise) → out of [55,100] → gated, never a "you're stressed" cue. The dip
+        // must first ARM and hold, so the gate is checked on the confirming tick.
         d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 140, recentMotionG: 0.0,
             sessionActive: false, state: d.nextState, config: on, nowSec: 60, tzOffsetSec: 0)
+        d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 140, recentMotionG: 0.0,
+            sessionActive: false, state: d.nextState, config: on,
+            nowSec: 60 + StressOnsetDetector.sustainSeconds, tzOffsetSec: 0)
         XCTAssertFalse(d.shouldNudge)
         XCTAssertEqual(d.reason, .exerciseGated)
     }
@@ -64,6 +76,9 @@ final class StressOnsetDetectorTests: XCTestCase {
         // Resting HR but the wrist is moving (0.5 g » 0.15 gate) → metabolic dip → gated.
         d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.5,
             sessionActive: false, state: d.nextState, config: on, nowSec: 60, tzOffsetSec: 0)
+        d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.5,
+            sessionActive: false, state: d.nextState, config: on,
+            nowSec: 60 + StressOnsetDetector.sustainSeconds, tzOffsetSec: 0)
         XCTAssertFalse(d.shouldNudge)
         XCTAssertEqual(d.reason, .exerciseGated)
     }
@@ -76,11 +91,16 @@ final class StressOnsetDetectorTests: XCTestCase {
             sessionActive: false, state: .initial, config: on, nowSec: 0, tzOffsetSec: 0)
         d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
             sessionActive: false, state: d.nextState, config: on, nowSec: 60, tzOffsetSec: 0)
+        d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
+            sessionActive: false, state: d.nextState, config: on,
+            nowSec: 60 + StressOnsetDetector.sustainSeconds, tzOffsetSec: 0)
         XCTAssertTrue(d.shouldNudge)
         let firedState = d.nextState
-        // Replay the exact same low window + state → wasBelow is true, so no fresh edge → no fire.
+        // Replay the exact same low window + state → wasBelow is true and the arm was consumed, so
+        // there is no fresh edge → no fire.
         let replay = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
-            sessionActive: false, state: firedState, config: on, nowSec: 61, tzOffsetSec: 0)
+            sessionActive: false, state: firedState, config: on,
+            nowSec: 61 + StressOnsetDetector.sustainSeconds, tzOffsetSec: 0)
         XCTAssertFalse(replay.shouldNudge)
     }
 
@@ -93,12 +113,17 @@ final class StressOnsetDetectorTests: XCTestCase {
             sessionActive: false, state: .initial, config: on, nowSec: 0, tzOffsetSec: 0)
         d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
             sessionActive: false, state: d.nextState, config: on, nowSec: 60, tzOffsetSec: 0)
-        XCTAssertTrue(d.shouldNudge)
-        // Recover above (fresh edge reset), then dip AGAIN only 5 min after the fire → rate-limited.
-        d = StressOnsetDetector.evaluate(rrBuffer: highHRV, currentHR: 70, recentMotionG: 0.0,
-            sessionActive: false, state: d.nextState, config: on, nowSec: 120, tzOffsetSec: 0)
         d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
-            sessionActive: false, state: d.nextState, config: on, nowSec: 360, tzOffsetSec: 0)   // +5 min
+            sessionActive: false, state: d.nextState, config: on, nowSec: 120, tzOffsetSec: 0)
+        XCTAssertTrue(d.shouldNudge)
+        // Recover above (fresh edge reset), then dip AGAIN and hold, still only ~5 min after the
+        // fire → rate-limited.
+        d = StressOnsetDetector.evaluate(rrBuffer: highHRV, currentHR: 70, recentMotionG: 0.0,
+            sessionActive: false, state: d.nextState, config: on, nowSec: 180, tzOffsetSec: 0)
+        d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
+            sessionActive: false, state: d.nextState, config: on, nowSec: 300, tzOffsetSec: 0)
+        d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
+            sessionActive: false, state: d.nextState, config: on, nowSec: 420, tzOffsetSec: 0)   // +5 min
         XCTAssertFalse(d.shouldNudge)
         XCTAssertEqual(d.reason, .suppressed)
     }
@@ -122,6 +147,9 @@ final class StressOnsetDetectorTests: XCTestCase {
             sessionActive: false, state: .initial, config: on, nowSec: 0, tzOffsetSec: 0)
         d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
             sessionActive: true, state: d.nextState, config: on, nowSec: 60, tzOffsetSec: 0)
+        d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
+            sessionActive: true, state: d.nextState, config: on,
+            nowSec: 60 + StressOnsetDetector.sustainSeconds, tzOffsetSec: 0)
         XCTAssertFalse(d.shouldNudge)
         XCTAssertEqual(d.reason, .suppressed)
     }
@@ -132,5 +160,85 @@ final class StressOnsetDetectorTests: XCTestCase {
             sessionActive: false, state: .initial, config: on, nowSec: 0, tzOffsetSec: 0)
         XCTAssertFalse(d.shouldNudge)
         XCTAssertEqual(d.reason, .insufficientData)
+    }
+
+    // MARK: - Sustain
+
+    // The headline behaviour: a dip that RECOVERS before it has held for `sustainSeconds` never
+    // nudges. This is the momentary-wobble case that dominated the pre-sustain fire count.
+    func test_transient_dip_that_recovers_never_fires() {
+        let highHRV = jittered(900, jitter: 60, 60)
+        let lowHRV = jittered(900, jitter: 5, 60)
+        var d = StressOnsetDetector.evaluate(rrBuffer: highHRV, currentHR: 70, recentMotionG: 0.0,
+            sessionActive: false, state: .initial, config: on, nowSec: 0, tzOffsetSec: 0)
+        // Arm.
+        d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
+            sessionActive: false, state: d.nextState, config: on, nowSec: 60, tzOffsetSec: 0)
+        XCTAssertEqual(d.reason, .awaitingSustain)
+        XCTAssertEqual(d.nextState.pendingEdgeAt, 60)
+        // Recover well before the sustain elapses → the arm is discarded.
+        d = StressOnsetDetector.evaluate(rrBuffer: highHRV, currentHR: 70, recentMotionG: 0.0,
+            sessionActive: false, state: d.nextState, config: on, nowSec: 70, tzOffsetSec: 0)
+        XCTAssertEqual(d.reason, .noDip)
+        XCTAssertEqual(d.nextState.pendingEdgeAt, 0, "a recovered dip must not stay armed")
+        // Dipping again LATER than the original arm+sustain must not fire on the stale clock.
+        d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
+            sessionActive: false, state: d.nextState, config: on, nowSec: 200, tzOffsetSec: 0)
+        XCTAssertFalse(d.shouldNudge, "a fresh dip must serve its own sustain, not inherit a stale arm")
+        XCTAssertEqual(d.reason, .awaitingSustain)
+    }
+
+    // One sustained dip arms at most ONE nudge: the arm is consumed at confirmation even when a gate
+    // then suppresses the fire, so the dip cannot keep retrying every tick until a gate happens to open.
+    func test_arm_is_consumed_even_when_a_gate_suppresses() {
+        let highHRV = jittered(900, jitter: 60, 60)
+        let lowHRV = jittered(900, jitter: 5, 60)
+        var d = StressOnsetDetector.evaluate(rrBuffer: highHRV, currentHR: 70, recentMotionG: 0.0,
+            sessionActive: false, state: .initial, config: on, nowSec: 0, tzOffsetSec: 0)
+        d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 140, recentMotionG: 0.0,
+            sessionActive: false, state: d.nextState, config: on, nowSec: 60, tzOffsetSec: 0)
+        // Confirm while HR is out of band → gated, and the arm is spent.
+        d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 140, recentMotionG: 0.0,
+            sessionActive: false, state: d.nextState, config: on,
+            nowSec: 60 + StressOnsetDetector.sustainSeconds, tzOffsetSec: 0)
+        XCTAssertEqual(d.reason, .exerciseGated)
+        XCTAssertEqual(d.nextState.pendingEdgeAt, 0)
+        // The gate now opens, but the same unbroken dip must NOT fire — there is no fresh crossing.
+        d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
+            sessionActive: false, state: d.nextState, config: on,
+            nowSec: 300 + StressOnsetDetector.sustainSeconds, tzOffsetSec: 0)
+        XCTAssertFalse(d.shouldNudge)
+        XCTAssertEqual(d.reason, .notAnEdge)
+    }
+
+    // A dip exactly AT the sustain boundary fires (the comparison is >=, not >).
+    func test_sustain_boundary_is_inclusive() {
+        let highHRV = jittered(900, jitter: 60, 60)
+        let lowHRV = jittered(900, jitter: 5, 60)
+        var d = StressOnsetDetector.evaluate(rrBuffer: highHRV, currentHR: 70, recentMotionG: 0.0,
+            sessionActive: false, state: .initial, config: on, nowSec: 0, tzOffsetSec: 0)
+        d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
+            sessionActive: false, state: d.nextState, config: on, nowSec: 1_000, tzOffsetSec: 0)
+        // One second short → still awaiting.
+        d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
+            sessionActive: false, state: d.nextState, config: on,
+            nowSec: 1_000 + StressOnsetDetector.sustainSeconds - 1, tzOffsetSec: 0)
+        XCTAssertEqual(d.reason, .awaitingSustain)
+        // Exactly at the boundary → fires.
+        d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
+            sessionActive: false, state: d.nextState, config: on,
+            nowSec: 1_000 + StressOnsetDetector.sustainSeconds, tzOffsetSec: 0)
+        XCTAssertTrue(d.shouldNudge)
+    }
+
+    // A state restored mid-dip (wasBelow true, nothing armed) must not fire without a fresh crossing.
+    func test_state_restored_mid_dip_does_not_fire() {
+        let lowHRV = jittered(900, jitter: 5, 60)
+        let restored = StressOnsetDetector.State(baselineRMSSD: 120, wasBelow: true,
+                                                 lastFireAt: 0, pendingEdgeAt: 0)
+        let d = StressOnsetDetector.evaluate(rrBuffer: lowHRV, currentHR: 70, recentMotionG: 0.0,
+            sessionActive: false, state: restored, config: on, nowSec: 100_000, tzOffsetSec: 0)
+        XCTAssertFalse(d.shouldNudge)
+        XCTAssertEqual(d.reason, .notAnEdge)
     }
 }

--- a/Strand/Screens/BiofeedbackPrefs.swift
+++ b/Strand/Screens/BiofeedbackPrefs.swift
@@ -27,6 +27,7 @@ enum BiofeedbackPrefs {
         static let stBaseline   = "biofeedback.stOnsetBaseline"
         static let stWasBelow   = "biofeedback.stOnsetWasBelow"
         static let stLastFire   = "biofeedback.stOnsetLastFire"
+        static let stPendingEdge = "biofeedback.stOnsetPendingEdge"
     }
 
     // MARK: - L1 locked resonance pace
@@ -99,12 +100,14 @@ enum BiofeedbackPrefs {
         StressOnsetDetector.State(
             baselineRMSSD: d.double(forKey: K.stBaseline),
             wasBelow: d.bool(forKey: K.stWasBelow),
-            lastFireAt: d.integer(forKey: K.stLastFire))
+            lastFireAt: d.integer(forKey: K.stLastFire),
+            pendingEdgeAt: d.integer(forKey: K.stPendingEdge))
     }
 
     static func saveStressState(_ s: StressOnsetDetector.State) {
         d.set(s.baselineRMSSD, forKey: K.stBaseline)
         d.set(s.wasBelow, forKey: K.stWasBelow)
         d.set(s.lastFireAt, forKey: K.stLastFire)
+        d.set(s.pendingEdgeAt, forKey: K.stPendingEdge)
     }
 }

--- a/android/app/src/main/java/com/noop/analytics/StressOnsetDetector.kt
+++ b/android/app/src/main/java/com/noop/analytics/StressOnsetDetector.kt
@@ -50,6 +50,19 @@ object StressOnsetDetector {
     /** Rate limit — at most one fire per this many seconds (the shipped 900 s = 15 min). */
     const val MIN_SECONDS_BETWEEN_FIRES: Long = 900L
 
+    /**
+     * SUSTAIN: after a fresh crossing the dip must STILL be below the threshold this many seconds
+     * later before it earns a nudge. A genuine autonomic stress response holds for minutes; a
+     * momentary dip in a [FAST_WINDOW_BEATS]-wide RMSSD window is far more often a beat-detection
+     * wobble or a posture change than an arousal. Firing on the bare crossing therefore nudges on
+     * noise: replayed over 40 days of real worn WHOOP data the edge alone fired ~8.4x/day, of which
+     * only ~13 % were still below threshold 60 s later — the rest had already recovered. Requiring
+     * the dip to hold cuts that to ~1x/day WITHOUT relaxing what counts as a dip, which lowering
+     * [DROP_RATIO] alone cannot do (it only makes an equally momentary trigger rarer). 0 disables
+     * the requirement and restores the pre-sustain edge-only behaviour.
+     */
+    const val SUSTAIN_SECONDS: Long = 60L
+
     /** Recent smoothed wrist-motion (g) at/above this means "moving" → exercise gate suppresses the fire
      *  (reuses the [SedentaryDetector] move threshold so the two gates agree on what "moving" is). */
     val MOTION_GATE_G: Double = SedentaryDetector.DEFAULT_MOVE_THRESHOLD_G
@@ -90,6 +103,11 @@ object StressOnsetDetector {
         val wasBelow: Boolean = false,
         /** Unix-seconds of the last fire (0 = never) — the rate limiter. */
         val lastFireAt: Long = 0L,
+        /** Unix-seconds of the ARMED crossing awaiting confirmation (0 = nothing armed) — the
+         *  [SUSTAIN_SECONDS] clock. Set when a fresh edge crosses below, cleared when the dip
+         *  recovers before it holds, and consumed once the sustain is satisfied. Persisted with the
+         *  rest of the state so a relaunch mid-dip cannot double-arm. */
+        val pendingEdgeAt: Long = 0L,
     ) {
         companion object {
             /** Cold-start state (no baseline, not below, never fired). */
@@ -113,8 +131,14 @@ object StressOnsetDetector {
         /** Fast RMSSD is at/above the threshold — no dip. */
         NO_DIP,
 
-        /** The dip isn't a fresh edge (already below last tick). */
+        /** The dip isn't a fresh edge (already below last tick, with nothing armed). */
         NOT_AN_EDGE,
+
+        /**
+         * A fresh crossing is ARMED but hasn't held for [SUSTAIN_SECONDS] yet — the dip is real so
+         * far, just not yet proven to be more than a momentary wobble.
+         */
+        AWAITING_SUSTAIN,
 
         /** Suppressed by the exercise gate (HR out of band and/or recent motion = metabolic, not stress). */
         EXERCISE_GATED,
@@ -212,13 +236,24 @@ object StressOnsetDetector {
         val isEdge = isBelow && !state.wasBelow
         next = next.copy(wasBelow = isBelow)
 
+        // SUSTAIN: the crossing only ARMS the check. A dip that recovers before it has held for
+        // [SUSTAIN_SECONDS] is discarded — it was a wobble, not an arousal — and one that holds is
+        // CONSUMED at confirmation time, so a single dip can arm at most one nudge even if the gates
+        // below then suppress it.
+        if (isEdge) next = next.copy(pendingEdgeAt = nowSec)
+        if (!isBelow) next = next.copy(pendingEdgeAt = 0L)
+
         fun decide(nudge: Boolean, reason: Reason) = Decision(
             shouldNudge = nudge, reason = reason, buzzLoops = config.buzzLoops,
             fastRMSSD = fast, baselineRMSSD = baseline, nextState = next,
         )
 
         if (!isBelow) return decide(false, Reason.NO_DIP)
-        if (!isEdge) return decide(false, Reason.NOT_AN_EDGE)
+        // Nothing armed while below: the dip predates this run (e.g. state restored mid-dip) or its
+        // arm was already consumed — either way there is no fresh crossing to act on.
+        if (next.pendingEdgeAt == 0L) return decide(false, Reason.NOT_AN_EDGE)
+        if (nowSec - next.pendingEdgeAt < SUSTAIN_SECONDS) return decide(false, Reason.AWAITING_SUSTAIN)
+        next = next.copy(pendingEdgeAt = 0L)   // consumed: proven sustained, now subject to the gates
 
         // 5) Exercise gate (the credibility line). HR out of the resting band (or unknown) → metabolic.
         //    Recent motion at/above the gate → metabolic. Either suppresses.

--- a/android/app/src/main/java/com/noop/ui/BiofeedbackPrefs.kt
+++ b/android/app/src/main/java/com/noop/ui/BiofeedbackPrefs.kt
@@ -29,6 +29,7 @@ object BiofeedbackPrefs {
     private const val KEY_ST_BASELINE = "biofeedback.stOnsetBaseline"
     private const val KEY_ST_WAS_BELOW = "biofeedback.stOnsetWasBelow"
     private const val KEY_ST_LAST_FIRE = "biofeedback.stOnsetLastFire"
+    private const val KEY_ST_PENDING_EDGE = "biofeedback.stOnsetPendingEdge"
 
     // ── L1 locked resonance pace ──────────────────────────────────────────────
 
@@ -87,6 +88,7 @@ object BiofeedbackPrefs {
             baselineRMSSD = p.getFloat(KEY_ST_BASELINE, 0f).toDouble(),
             wasBelow = p.getBoolean(KEY_ST_WAS_BELOW, false),
             lastFireAt = p.getLong(KEY_ST_LAST_FIRE, 0L),
+            pendingEdgeAt = p.getLong(KEY_ST_PENDING_EDGE, 0L),
         )
     }
 
@@ -95,6 +97,7 @@ object BiofeedbackPrefs {
             .putFloat(KEY_ST_BASELINE, s.baselineRMSSD.toFloat())
             .putBoolean(KEY_ST_WAS_BELOW, s.wasBelow)
             .putLong(KEY_ST_LAST_FIRE, s.lastFireAt)
+            .putLong(KEY_ST_PENDING_EDGE, s.pendingEdgeAt)
             .apply()
     }
 

--- a/android/app/src/test/java/com/noop/analytics/StressOnsetDetectorTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StressOnsetDetectorTest.kt
@@ -32,16 +32,25 @@ class StressOnsetDetectorTest {
         assertNotNull(d.baselineRMSSD)
 
         val lowHrv = jittered(900, 5, 60)
+        // The crossing ARMS the sustain check; it is not yet a nudge.
         d = StressOnsetDetector.evaluate(
             rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
             state = d.nextState, config = on, nowSec = 10_060L, tzOffsetSec = 0L,
+        )
+        assertFalse(d.shouldNudge)
+        assertEquals(StressOnsetDetector.Reason.AWAITING_SUSTAIN, d.reason)
+
+        // Still dipped SUSTAIN_SECONDS later → the dip held, so NOW it fires.
+        d = StressOnsetDetector.evaluate(
+            rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
+            state = d.nextState, config = on, nowSec = 10_060L + StressOnsetDetector.SUSTAIN_SECONDS, tzOffsetSec = 0L,
         )
         assertTrue(d.shouldNudge)
         assertEquals(StressOnsetDetector.Reason.ONSET, d.reason)
 
         d = StressOnsetDetector.evaluate(
             rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
-            state = d.nextState, config = on, nowSec = 10_120L, tzOffsetSec = 0L,
+            state = d.nextState, config = on, nowSec = 10_200L, tzOffsetSec = 0L,
         )
         assertFalse(d.shouldNudge)
         assertEquals(StressOnsetDetector.Reason.NOT_AN_EDGE, d.reason)
@@ -58,6 +67,10 @@ class StressOnsetDetectorTest {
             rrBuffer = lowHrv, currentHR = 140.0, recentMotionG = 0.0, sessionActive = false,
             state = d.nextState, config = on, nowSec = 60L, tzOffsetSec = 0L,
         )
+        d = StressOnsetDetector.evaluate(
+            rrBuffer = lowHrv, currentHR = 140.0, recentMotionG = 0.0, sessionActive = false,
+            state = d.nextState, config = on, nowSec = 60L + StressOnsetDetector.SUSTAIN_SECONDS, tzOffsetSec = 0L,
+        )
         assertFalse(d.shouldNudge)
         assertEquals(StressOnsetDetector.Reason.EXERCISE_GATED, d.reason)
     }
@@ -72,6 +85,10 @@ class StressOnsetDetectorTest {
         d = StressOnsetDetector.evaluate(
             rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.5, sessionActive = false,
             state = d.nextState, config = on, nowSec = 60L, tzOffsetSec = 0L,
+        )
+        d = StressOnsetDetector.evaluate(
+            rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.5, sessionActive = false,
+            state = d.nextState, config = on, nowSec = 60L + StressOnsetDetector.SUSTAIN_SECONDS, tzOffsetSec = 0L,
         )
         assertFalse(d.shouldNudge)
         assertEquals(StressOnsetDetector.Reason.EXERCISE_GATED, d.reason)
@@ -88,11 +105,15 @@ class StressOnsetDetectorTest {
             rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
             state = d.nextState, config = on, nowSec = 60L, tzOffsetSec = 0L,
         )
+        d = StressOnsetDetector.evaluate(
+            rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
+            state = d.nextState, config = on, nowSec = 60L + StressOnsetDetector.SUSTAIN_SECONDS, tzOffsetSec = 0L,
+        )
         assertTrue(d.shouldNudge)
         val firedState = d.nextState
         val replay = StressOnsetDetector.evaluate(
             rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
-            state = firedState, config = on, nowSec = 61L, tzOffsetSec = 0L,
+            state = firedState, config = on, nowSec = 61L + StressOnsetDetector.SUSTAIN_SECONDS, tzOffsetSec = 0L,
         )
         assertFalse(replay.shouldNudge)
     }
@@ -108,15 +129,23 @@ class StressOnsetDetectorTest {
             rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
             state = d.nextState, config = on, nowSec = 60L, tzOffsetSec = 0L,
         )
+        d = StressOnsetDetector.evaluate(
+            rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
+            state = d.nextState, config = on, nowSec = 120L, tzOffsetSec = 0L,
+        )
         assertTrue(d.shouldNudge)
-        // recover (edge reset) then dip again 5 min after the fire → rate-limited.
+        // recover (edge reset) then dip again and hold, still ~5 min after the fire → rate-limited.
         d = StressOnsetDetector.evaluate(
             rrBuffer = highHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
-            state = d.nextState, config = on, nowSec = 120L, tzOffsetSec = 0L,
+            state = d.nextState, config = on, nowSec = 180L, tzOffsetSec = 0L,
         )
         d = StressOnsetDetector.evaluate(
             rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
-            state = d.nextState, config = on, nowSec = 360L, tzOffsetSec = 0L,
+            state = d.nextState, config = on, nowSec = 300L, tzOffsetSec = 0L,
+        )
+        d = StressOnsetDetector.evaluate(
+            rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
+            state = d.nextState, config = on, nowSec = 420L, tzOffsetSec = 0L,
         )
         assertFalse(d.shouldNudge)
         assertEquals(StressOnsetDetector.Reason.SUPPRESSED, d.reason)
@@ -144,6 +173,10 @@ class StressOnsetDetectorTest {
             rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = true,
             state = d.nextState, config = on, nowSec = 60L, tzOffsetSec = 0L,
         )
+        d = StressOnsetDetector.evaluate(
+            rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = true,
+            state = d.nextState, config = on, nowSec = 60L + StressOnsetDetector.SUSTAIN_SECONDS, tzOffsetSec = 0L,
+        )
         assertFalse(d.shouldNudge)
         assertEquals(StressOnsetDetector.Reason.SUPPRESSED, d.reason)
     }
@@ -155,5 +188,100 @@ class StressOnsetDetectorTest {
         )
         assertFalse(d.shouldNudge)
         assertEquals(StressOnsetDetector.Reason.INSUFFICIENT_DATA, d.reason)
+    }
+
+    // ── Sustain (twins of the Swift sustain cases) ────────────────────────────
+
+    @Test fun transient_dip_that_recovers_never_fires() {
+        val highHrv = jittered(900, 60, 60)
+        val lowHrv = jittered(900, 5, 60)
+        var d = StressOnsetDetector.evaluate(
+            rrBuffer = highHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
+            state = StressOnsetDetector.State.INITIAL, config = on, nowSec = 0L, tzOffsetSec = 0L,
+        )
+        d = StressOnsetDetector.evaluate(
+            rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
+            state = d.nextState, config = on, nowSec = 60L, tzOffsetSec = 0L,
+        )
+        assertEquals(StressOnsetDetector.Reason.AWAITING_SUSTAIN, d.reason)
+        assertEquals(60L, d.nextState.pendingEdgeAt)
+        // Recovers well before the sustain elapses → the arm is discarded.
+        d = StressOnsetDetector.evaluate(
+            rrBuffer = highHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
+            state = d.nextState, config = on, nowSec = 70L, tzOffsetSec = 0L,
+        )
+        assertEquals(StressOnsetDetector.Reason.NO_DIP, d.reason)
+        assertEquals("a recovered dip must not stay armed", 0L, d.nextState.pendingEdgeAt)
+        d = StressOnsetDetector.evaluate(
+            rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
+            state = d.nextState, config = on, nowSec = 200L, tzOffsetSec = 0L,
+        )
+        assertFalse("a fresh dip must serve its own sustain", d.shouldNudge)
+        assertEquals(StressOnsetDetector.Reason.AWAITING_SUSTAIN, d.reason)
+    }
+
+    @Test fun arm_is_consumed_even_when_a_gate_suppresses() {
+        val highHrv = jittered(900, 60, 60)
+        val lowHrv = jittered(900, 5, 60)
+        var d = StressOnsetDetector.evaluate(
+            rrBuffer = highHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
+            state = StressOnsetDetector.State.INITIAL, config = on, nowSec = 0L, tzOffsetSec = 0L,
+        )
+        d = StressOnsetDetector.evaluate(
+            rrBuffer = lowHrv, currentHR = 140.0, recentMotionG = 0.0, sessionActive = false,
+            state = d.nextState, config = on, nowSec = 60L, tzOffsetSec = 0L,
+        )
+        d = StressOnsetDetector.evaluate(
+            rrBuffer = lowHrv, currentHR = 140.0, recentMotionG = 0.0, sessionActive = false,
+            state = d.nextState, config = on, nowSec = 60L + StressOnsetDetector.SUSTAIN_SECONDS,
+            tzOffsetSec = 0L,
+        )
+        assertEquals(StressOnsetDetector.Reason.EXERCISE_GATED, d.reason)
+        assertEquals(0L, d.nextState.pendingEdgeAt)
+        d = StressOnsetDetector.evaluate(
+            rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
+            state = d.nextState, config = on, nowSec = 300L + StressOnsetDetector.SUSTAIN_SECONDS,
+            tzOffsetSec = 0L,
+        )
+        assertFalse(d.shouldNudge)
+        assertEquals(StressOnsetDetector.Reason.NOT_AN_EDGE, d.reason)
+    }
+
+    @Test fun sustain_boundary_is_inclusive() {
+        val highHrv = jittered(900, 60, 60)
+        val lowHrv = jittered(900, 5, 60)
+        var d = StressOnsetDetector.evaluate(
+            rrBuffer = highHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
+            state = StressOnsetDetector.State.INITIAL, config = on, nowSec = 0L, tzOffsetSec = 0L,
+        )
+        d = StressOnsetDetector.evaluate(
+            rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
+            state = d.nextState, config = on, nowSec = 1_000L, tzOffsetSec = 0L,
+        )
+        d = StressOnsetDetector.evaluate(
+            rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
+            state = d.nextState, config = on,
+            nowSec = 1_000L + StressOnsetDetector.SUSTAIN_SECONDS - 1L, tzOffsetSec = 0L,
+        )
+        assertEquals(StressOnsetDetector.Reason.AWAITING_SUSTAIN, d.reason)
+        d = StressOnsetDetector.evaluate(
+            rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
+            state = d.nextState, config = on,
+            nowSec = 1_000L + StressOnsetDetector.SUSTAIN_SECONDS, tzOffsetSec = 0L,
+        )
+        assertTrue(d.shouldNudge)
+    }
+
+    @Test fun state_restored_mid_dip_does_not_fire() {
+        val lowHrv = jittered(900, 5, 60)
+        val restored = StressOnsetDetector.State(
+            baselineRMSSD = 120.0, wasBelow = true, lastFireAt = 0L, pendingEdgeAt = 0L,
+        )
+        val d = StressOnsetDetector.evaluate(
+            rrBuffer = lowHrv, currentHR = 70.0, recentMotionG = 0.0, sessionActive = false,
+            state = restored, config = on, nowSec = 100_000L, tzOffsetSec = 0L,
+        )
+        assertFalse(d.shouldNudge)
+        assertEquals(StressOnsetDetector.Reason.NOT_AN_EDGE, d.reason)
     }
 }


### PR DESCRIPTION
## The problem

The L3 stress check-in fires on the **bare crossing**: the moment the fast RMSSD drops below `baseline * dropRatio`, it offers a breath. But a genuine autonomic stress response holds for minutes, while a momentary dip in a 60-beat RMSSD window is far more often a beat-detection wobble or a posture change. So the detector nudges on noise.

I replayed the shipped `StressOnsetDetector` — the real engine, called directly, not a model of it — over **40 days of continuously banked WHOOP R-R** (1.30M intervals, 3.04M HR samples) at the shipped constants:

- **312 fires — ~8.4×/day**, on *every* covered day, up to **20 in one day**.
- Of those 312 crossings, only **40 (~13%) were still below threshold 60 s later**. The rest had already recovered.

At ~8 nudges a day a user learns to ignore the feature, which is the one outcome a JITAI cannot survive.

## The change

A crossing now **arms** the check and must still be below the threshold `sustainSeconds` (**60 s**) later to earn a nudge.

- A dip that **recovers first is discarded** — it was a wobble, not an arousal.
- A dip that holds is **consumed at confirmation**, so one dip can arm at most one nudge even when a gate then suppresses it, rather than retrying every tick until some gate happens to open.
- `State.pendingEdgeAt` carries the arm clock and is **persisted with the rest of the state** (both platforms), so a relaunch mid-dip cannot double-arm.
- A new `.awaitingSustain` reason reports the armed-but-unproven tick rather than overloading `.notAnEdge`.

Re-replaying the **same 40 days** against the modified engine:

| | fires | per day | firing days | max/day |
|---|---|---|---|---|
| before | 312 | 8.43 | 37 of 37 | 20 |
| **after** | **40** | **1.08** | 20 of 37 | 4 |

**Nothing about what counts as a dip changed.** `dropRatio`, the resting-HR band, the exercise gate, the rate limit and quiet hours are all untouched. Lowering `dropRatio` instead would only make an equally momentary trigger rarer — it cannot tell a wobble from an arousal, which is the actual failure mode. For reference, the same replay put `dropRatio` 0.60→0.40 at 2.14/day and 0.35 at 1.57/day, but every one of those fires is still a bare crossing.

`sustainSeconds = 0` restores the previous edge-only behaviour exactly, so the change is one constant away from being reverted.

## Behaviour change — golden vectors updated

This changes when the detector fires, so the existing behaviour vectors are updated in lockstep on **both** platforms: each previously fired on the arming tick and now fires on the confirming one. That is the intended change, not test-fitting — the assertions still pin the same gates.

## Cross-platform parity

The Kotlin twin carries the same constant, the same arm/consume logic, the same new `AWAITING_SUSTAIN` reason, the same persisted `pendingEdgeAt`, and the same 12 test vectors.

## Verification

- **`swift test` (StrandAnalytics): 1252 tests, 0 failures.** 4 new cases: a transient dip that recovers never fires (and leaves no stale arm), the arm is consumed even when a gate suppresses, the sustain boundary is inclusive, and a state restored mid-dip does not fire without a fresh crossing.
- **Android: `./gradlew testFullDebugUnitTest` — 3526 tests, 0 failures**, including the 12-case Kotlin twin. Run locally, since `android.yml` is disabled by default.
- **Empirical numbers above come from replaying the real engine over real banked strap data**, not from a reimplementation. (A separate parameter sweep was validated by reproducing the engine's 312 exactly before being trusted for the `dropRatio` figures.)
- **`BiofeedbackPrefs.swift` is app-target Swift that no default CI compiles**, so the macOS app was built locally: `xcodebuild -scheme Strand -destination 'platform=macOS'` → **BUILD SUCCEEDED**.
- **No UI strings added**, so no i18n surface. Not a BLE change.

## Honest limits

The 60 s figure comes from one wearer's 40 days — enough to show the *shape* of the problem (an 87 % cut with no change to the dip definition), not enough to call 60 s optimal. It is a named, documented constant in one place. The replay also evaluates continuously, whereas the live detector only runs while the app is foregrounded with a live link, so real-world rates on both sides of this change are lower than the figures above; the *ratio* is what this PR rests on.

Related: #1114 motion-gates the daytime stress timeline (a different surface, independent of this).