### PR TITLE
hrv: sample the densest second on an over-count night (#1008)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -560,6 +560,81 @@ public enum HRVAnalyzer {
         return rrCoverage(tsSec: keptTs, rrMs: keptRr)
     }
 
+    /// #1008: a compact, deterministic RAW-ROW sample of the beats around the DENSEST second, for the
+    /// always-on `hrv diag` log — emitted ONLY on an over-count night, so the mechanism of a `coverage>1`
+    /// verdict can be READ off the log instead of guessed at. The coverage stats above say THAT a night is
+    /// over-counted and whether the extra beats straddle second boundaries; they cannot say WHY. This shows
+    /// the individual rows so the shape is visible:
+    ///
+    ///   - near-equal `rrMs` values sharing / adjacent-in a second (e.g. `[1200,1199]`) ⇒ the SAME beat
+    ///     stored twice (a de-dup / channel-tag fix recovers RMSSD),
+    ///   - a full interval beside a partial one (e.g. `[1200,600]`) ⇒ two DISTINCT interval trains (a
+    ///     genuine second stream, or real dense capture — not a duplicate),
+    ///   - a `@N` suffix ⇒ a non-null `srcChannel`; `src=none` confirms the beats are untagged (the #1071
+    ///     Oura channel machinery does NOT apply, so a WHOOP over-count is a different mechanism).
+    ///
+    /// Deliberately statistics-FREE: at second-resolution `ts`, a genuine consecutive beat and a duplicate
+    /// both look like "a near-equal beat ~1 s away", so any derived de-dup *number* is unreliable here (the
+    /// #550 trap). Raw rows carry no such inference. Pure; integer-only formatting so the twin Kotlin
+    /// `HrvAnalyzer.densestSecondWindowSample` is byte-identical. Returns "" for < 2 beats.
+    ///
+    /// - Parameters:
+    ///   - tsSec: per-beat timestamps (unix seconds).
+    ///   - rrMs: per-beat interval (ms, rounded for display).
+    ///   - srcCodes: per-beat `srcChannel` code or nil, index-aligned with the other two.
+    ///   - halfWindowSec: seconds of context to show either side of the densest second.
+    ///   - maxRowsPerSecond: cap on beats listed per second (a runaway second is truncated with `+K`).
+    public static func densestSecondWindowSample(
+        tsSec: [Int],
+        rrMs: [Double],
+        srcCodes: [Int?],
+        halfWindowSec: Int = 3,
+        maxRowsPerSecond: Int = 24
+    ) -> String {
+        let n = min(tsSec.count, rrMs.count)
+        guard n >= 2 else { return "" }
+        // Per-second beat counts; the densest second (ties → earliest) anchors the window.
+        var perSec: [Int: Int] = [:]
+        for i in 0..<n { perSec[tsSec[i], default: 0] += 1 }
+        let occ = perSec.count
+        var maxInSec = 0
+        var t0 = tsSec[0]
+        // Deterministic argmax: highest count, earliest ts on a tie.
+        for t in perSec.keys.sorted() where perSec[t]! > maxInSec { maxInSec = perSec[t]!; t0 = t }
+        let beatsPerSec = occ > 0 ? Double(n) / Double(occ) : 0
+        // src=none unless any beat in the whole stream carries a channel code; list the distinct codes.
+        var codes = Set<Int>()
+        for i in 0..<n where i < srcCodes.count { if let c = srcCodes[i] { codes.insert(c) } }
+        let srcField = codes.isEmpty ? "none" : codes.sorted().map { String($0) }.joined(separator: "/")
+
+        var out = ""
+        // Two-decimal beats/sec without locale: scale-and-truncate on integers so the twin can't drift.
+        let bpsX100 = Int(beatsPerSec * 100.0 + 0.5)
+        out += "beatsPerSec=\(bpsX100 / 100)."
+        let frac = bpsX100 % 100
+        if frac < 10 { out += "0" }
+        out += "\(frac)"
+        out += " maxInSec=\(maxInSec) occSec=\(occ) totBeats=\(n) src=\(srcField) | t0=\(t0)"
+        for offset in -halfWindowSec...halfWindowSec {
+            let t = t0 + offset
+            // Beats in this second, sorted by rrMs then original index — deterministic.
+            let rows = (0..<n).filter { tsSec[$0] == t }
+                .sorted { a, b in (rrMs[a], a) < (rrMs[b], b) }
+            if rows.isEmpty { continue }
+            out += " " + (offset > 0 ? "+" : "") + "\(offset)s["
+            let shown = min(rows.count, maxRowsPerSecond)
+            for k in 0..<shown {
+                if k > 0 { out += "," }
+                let idx = rows[k]
+                out += "\(Int(rrMs[idx] + 0.5))"
+                if idx < srcCodes.count, let c = srcCodes[idx] { out += "@\(c)" }
+            }
+            if rows.count > shown { out += ",+\(rows.count - shown)" }
+            out += "]"
+        }
+        return out
+    }
+
     // MARK: - Helpers
 
     /// Median of a non-empty array. (Caller guarantees non-empty.)

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerTests.swift
@@ -247,4 +247,49 @@ final class HRVAnalyzerTests: XCTestCase {
         XCTAssertEqual(HRVAnalyzer.collapsedCoverage(tsSec: ts, rrMs: rr),
                        HRVAnalyzer.rrCoverage(tsSec: ts, rrMs: rr), accuracy: 1e-9)
     }
+
+    // #1008 — densestSecondWindowSample: the raw-row sample that makes an over-count's MECHANISM readable
+    // from the always-on log. Exact-string assertions pin byte-parity with the Kotlin twin.
+
+    /// Near-equal copies clustered in one second (the "same beat stored twice" shape): the sample shows
+    /// `[1199,1200,1201]` — values a de-dup would collapse. This is the signature of a duplication bug.
+    func testDensestSampleShowsNearEqualCopies() {
+        let ts = [100, 100, 100, 101, 102]
+        let rr: [Double] = [1200, 1199, 1201, 1200, 1198]
+        let src: [Int?] = [nil, nil, nil, nil, nil]
+        XCTAssertEqual(
+            HRVAnalyzer.densestSecondWindowSample(tsSec: ts, rrMs: rr, srcCodes: src),
+            "beatsPerSec=1.67 maxInSec=3 occSec=3 totBeats=5 src=none | "
+                + "t0=100 0s[1199,1200,1201] +1s[1200] +2s[1198]")
+    }
+
+    /// Distinct interval trains (a full ~1200 ms beat beside a ~600 ms one, every second): the sample shows
+    /// `[600,1200]` — NOT copies of one beat, so a genuine second stream, not a de-dupable duplicate. The
+    /// two shapes are what the maintainer needs to tell apart to pick the fix.
+    func testDensestSampleShowsDistinctTrains() {
+        let ts = [100, 100, 101, 101, 102, 102]
+        let rr: [Double] = [1200, 600, 1200, 600, 1200, 600]
+        let src: [Int?] = [nil, nil, nil, nil, nil, nil]
+        XCTAssertEqual(
+            HRVAnalyzer.densestSecondWindowSample(tsSec: ts, rrMs: rr, srcCodes: src),
+            "beatsPerSec=2.00 maxInSec=2 occSec=3 totBeats=6 src=none | "
+                + "t0=100 0s[600,1200] +1s[600,1200] +2s[600,1200]")
+    }
+
+    /// A non-null srcChannel is surfaced as `@code`, and `src=` lists the distinct codes — so a tagged (Oura
+    /// #1071) stream is obvious, and `src=none` on a WHOOP night confirms that machinery does NOT apply.
+    func testDensestSampleSurfacesSrcChannelTags() {
+        let ts = [100, 100]
+        let rr: [Double] = [1000, 1000]
+        let src: [Int?] = [1, 2]
+        XCTAssertEqual(
+            HRVAnalyzer.densestSecondWindowSample(tsSec: ts, rrMs: rr, srcCodes: src),
+            "beatsPerSec=2.00 maxInSec=2 occSec=1 totBeats=2 src=1/2 | t0=100 0s[1000@1,1000@2]")
+    }
+
+    /// Nothing to sample (< 2 beats) → empty string, so the engine emits no `hrv rrsample` line.
+    func testDensestSampleEmptyForTooFewBeats() {
+        XCTAssertEqual(HRVAnalyzer.densestSecondWindowSample(tsSec: [], rrMs: [], srcCodes: []), "")
+        XCTAssertEqual(HRVAnalyzer.densestSecondWindowSample(tsSec: [100], rrMs: [1000], srcCodes: [nil]), "")
+    }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerTests.swift
@@ -292,4 +292,40 @@ final class HRVAnalyzerTests: XCTestCase {
         XCTAssertEqual(HRVAnalyzer.densestSecondWindowSample(tsSec: [], rrMs: [], srcCodes: []), "")
         XCTAssertEqual(HRVAnalyzer.densestSecondWindowSample(tsSec: [100], rrMs: [1000], srcCodes: [nil]), "")
     }
+
+    // Parity edge cases — the SAME literal strings are asserted in the Kotlin twin, so ties, truncation,
+    // short srcCodes, and half-value rounding are pinned byte-for-byte across platforms.
+
+    /// Densest-second TIE (100 & 101 both hold 2) resolves to the EARLIEST ts; equal rrMs order by index.
+    func testDensestSampleTieResolvesToEarliestSecond() {
+        XCTAssertEqual(
+            HRVAnalyzer.densestSecondWindowSample(
+                tsSec: [100, 100, 101, 101, 102], rrMs: [1000, 1000, 1000, 1000, 999],
+                srcCodes: [nil, nil, nil, nil, nil]),
+            "beatsPerSec=1.67 maxInSec=2 occSec=3 totBeats=5 src=none | t0=100 0s[1000,1000] +1s[1000,1000] +2s[999]")
+    }
+
+    /// A runaway second is truncated to maxRowsPerSecond with a `+K` remainder marker.
+    func testDensestSampleTruncatesRunawaySecond() {
+        XCTAssertEqual(
+            HRVAnalyzer.densestSecondWindowSample(
+                tsSec: [50, 50, 50, 50, 50, 51], rrMs: [700, 710, 720, 730, 740, 1000],
+                srcCodes: [nil, nil, nil, nil, nil, nil], maxRowsPerSecond: 3),
+            "beatsPerSec=3.00 maxInSec=5 occSec=2 totBeats=6 src=none | t0=50 0s[700,710,720,+2] +1s[1000]")
+    }
+
+    /// srcCodes SHORTER than the beat list is index-guarded (no crash), and only the tagged beat shows `@`.
+    func testDensestSampleShortSrcCodesAreIndexGuarded() {
+        XCTAssertEqual(
+            HRVAnalyzer.densestSecondWindowSample(tsSec: [10, 10, 11], rrMs: [1000, 1000, 1000], srcCodes: [3]),
+            "beatsPerSec=1.50 maxInSec=2 occSec=2 totBeats=3 src=3 | t0=10 0s[1000@3,1000] +1s[1000]")
+    }
+
+    /// beatsPerSec at an exact half (3 beats / 2 seconds = 1.50) folds identically on both platforms.
+    func testDensestSampleHalfValueBeatsPerSecRounding() {
+        XCTAssertEqual(
+            HRVAnalyzer.densestSecondWindowSample(tsSec: [200, 200, 201], rrMs: [900, 900, 900],
+                srcCodes: [nil, nil, nil]),
+            "beatsPerSec=1.50 maxInSec=2 occSec=2 totBeats=3 src=none | t0=200 0s[900,900] +1s[900]")
+    }
 }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -767,10 +767,20 @@ final class IntelligenceEngine: ObservableObject {
                     let sdnnField = HRVAnalyzer.beatSpreadIsTrustworthy(verdict)
                         && HRVAnalyzer.beatValuesAreTrustworthy(beatAccurateFraction: accVal)
                         ? "\(ms(h.sdnn))ms" : "withheld"
-                    hrvDiag = "hrv diag day=\(res.daily.day) rmssd=\(ms(h.rmssd))ms sdnn=\(sdnnField) "
+                    var diagLine = "hrv diag day=\(res.daily.day) rmssd=\(ms(h.rmssd))ms sdnn=\(sdnnField) "
                         + "meanNN=\(ms(h.meanNN))ms rr=\(h.nInput)/\(h.nClean) rejected=\(rej)% coverage=\(cov) collapsedCov=\(colCov) dupBeats=\(dup) "
                         + "beatAccurate=\(acc) "
                         + "rrIntegrity=\(verdict.rawValue)"
+                    // #1008: on an OVER-COUNT night only, append a raw-row sample around the densest second
+                    // (carried as a second \n-joined line, split back apart at the emit site) so the
+                    // over-count's MECHANISM is readable from the always-on log — clean nights stay quiet.
+                    // srcChannel rides from the read model. Byte-identical to the Kotlin `hrv rrsample` line.
+                    if verdict == .crossSecondOverCount || verdict == .sameSecondOverCount {
+                        let sample = HRVAnalyzer.densestSecondWindowSample(
+                            tsSec: ts, rrMs: sleepRr, srcCodes: sleepRrRows.map { $0.srcChannel?.rawValue })
+                        if !sample.isEmpty { diagLine += "\nhrv rrsample day=\(res.daily.day) \(sample)" }
+                    }
+                    hrvDiag = diagLine
                 }
                 // ── Steps test mode: 5/MG raw-counter trace ──────────────────────────────────────────────
                 // Only built when the Steps mode is on (the gate was read once before the loop). Recomputes
@@ -1037,7 +1047,13 @@ final class IntelligenceEngine: ObservableObject {
             let hrvLog = daily.avgHrv.map { String(format: "%.1f", $0) } ?? "nil"
             diagnosticSink?("hrv day=\(daily.day) window=\(deepHrvWindow ? "deep" : "whole") avgHrv=\(hrvLog)", nil)
             // #195: the whole-night HRV cleaning summary built in loop 1 (rmssd vs sdnn / cleaning counts).
-            if let hrvDiagLine = night.hrvDiag { diagnosticSink?(hrvDiagLine, nil) }
+            // #1008: on an over-count night this carries a second `hrv rrsample …` line, \n-joined at the
+            // build site; split it back into one diagnosticSink call per line so each is its own log line.
+            if let hrvDiagLine = night.hrvDiag {
+                for line in hrvDiagLine.split(separator: "\n", omittingEmptySubsequences: true) {
+                    diagnosticSink?(String(line), nil)
+                }
+            }
             // ── CAPTURE-B: universal dayOwner self-diagnostic (#814/#799) ────────────────────────────────
             // ONE line per scored day, tagged `.universal` so it rides EVERY Test Centre export regardless
             // of which mode is on. It pins down the read/write split #814 is about: `readId` is the owner

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -525,6 +525,85 @@ object HrvAnalyzer {
         return rrCoverage(keptTs, keptRr)
     }
 
+    /**
+     * #1008: a compact, deterministic RAW-ROW sample of the beats around the DENSEST second, for the
+     * always-on `hrv diag` log — emitted ONLY on an over-count night, so the mechanism of a `coverage>1`
+     * verdict can be READ off the log instead of guessed at. The coverage stats above say THAT a night is
+     * over-counted and whether the extra beats straddle second boundaries; they cannot say WHY. This shows
+     * the individual rows so the shape is visible:
+     *
+     *   - near-equal `rrMs` values sharing / adjacent-in a second (e.g. `[1200,1199]`) ⇒ the SAME beat
+     *     stored twice (a de-dup / channel-tag fix recovers RMSSD),
+     *   - a full interval beside a partial one (e.g. `[1200,600]`) ⇒ two DISTINCT interval trains (a
+     *     genuine second stream, or real dense capture — not a duplicate),
+     *   - a `@N` suffix ⇒ a non-null `srcChannel`; `src=none` confirms the beats are untagged (the #1071
+     *     Oura channel machinery does NOT apply, so a WHOOP over-count is a different mechanism).
+     *
+     * Deliberately statistics-FREE: at second-resolution `ts`, a genuine consecutive beat and a duplicate
+     * both look like "a near-equal beat ~1 s away", so any derived de-dup *number* is unreliable here (the
+     * #550 trap). Raw rows carry no such inference. Pure; integer-only formatting so the twin Swift
+     * `HRVAnalyzer.densestSecondWindowSample` is byte-identical. Returns "" for < 2 beats.
+     *
+     * @param tsSec per-beat timestamps (unix seconds); @param rrMs per-beat interval (ms, rounded for
+     *   display); @param srcCodes per-beat `srcChannel` code or null, index-aligned with the other two.
+     * @param halfWindowSec seconds of context to show either side of the densest second.
+     * @param maxRowsPerSecond cap on beats listed per second (a runaway second is truncated with `+K`).
+     */
+    fun densestSecondWindowSample(
+        tsSec: List<Long>,
+        rrMs: List<Double>,
+        srcCodes: List<Int?>,
+        halfWindowSec: Int = 3,
+        maxRowsPerSecond: Int = 24,
+    ): String {
+        val n = minOf(tsSec.size, rrMs.size)
+        if (n < 2) return ""
+        // Per-second beat counts; the densest second (ties → earliest) anchors the window.
+        val perSec = HashMap<Long, Int>()
+        for (i in 0 until n) perSec[tsSec[i]] = (perSec[tsSec[i]] ?: 0) + 1
+        val occ = perSec.size
+        var maxInSec = 0
+        var t0 = tsSec[0]
+        // Deterministic argmax: highest count, earliest ts on a tie.
+        for ((t, c) in perSec.toSortedMap()) if (c > maxInSec) { maxInSec = c; t0 = t }
+        val beatsPerSec = if (occ > 0) n.toDouble() / occ.toDouble() else 0.0
+        // src=none unless any beat in the whole stream carries a channel code; list the distinct codes.
+        val codes = sortedSetOf<Int>()
+        for (i in 0 until n) srcCodes.getOrNull(i)?.let { codes.add(it) }
+        val srcField = if (codes.isEmpty()) "none" else codes.joinToString("/")
+
+        val sb = StringBuilder()
+        // Two-decimal beats/sec without locale: scale-and-truncate on integers so the twin can't drift.
+        val bpsX100 = (beatsPerSec * 100.0 + 0.5).toLong()
+        sb.append("beatsPerSec=").append(bpsX100 / 100).append('.')
+        val frac = bpsX100 % 100
+        if (frac < 10) sb.append('0')
+        sb.append(frac)
+        sb.append(" maxInSec=").append(maxInSec)
+            .append(" occSec=").append(occ)
+            .append(" totBeats=").append(n)
+            .append(" src=").append(srcField)
+            .append(" | t0=").append(t0)
+        for (offset in -halfWindowSec..halfWindowSec) {
+            val t = t0 + offset
+            // Beats in this second, sorted by rrMs then original index — deterministic.
+            val rows = (0 until n).filter { tsSec[it] == t }
+                .sortedWith(compareBy({ rrMs[it] }, { it }))
+            if (rows.isEmpty()) continue
+            sb.append(' ').append(if (offset > 0) "+" else "").append(offset).append("s[")
+            val shown = minOf(rows.size, maxRowsPerSecond)
+            for (k in 0 until shown) {
+                if (k > 0) sb.append(',')
+                val idx = rows[k]
+                sb.append((rrMs[idx] + 0.5).toLong())
+                srcCodes.getOrNull(idx)?.let { sb.append('@').append(it) }
+            }
+            if (rows.size > shown) sb.append(",+").append(rows.size - shown)
+            sb.append(']')
+        }
+        return sb.toString()
+    }
+
     // ── Rolling / windowed rMSSD (#803) ──────────────────────────────────────
     //
     // The Deep Timeline's "HRV" trace used to plot RAW RR-interval values (ms) and label them "HRV",

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -653,6 +653,16 @@ object IntelligenceEngine {
                     "rr=${h.nInput}/${h.nClean} rejected=$rej% coverage=$cov collapsedCov=$colCov dupBeats=$dup " +
                     "beatAccurate=$acc " +
                     "rrIntegrity=${verdict.raw}")
+                // #1008: on an OVER-COUNT night only, dump a raw-row sample around the densest second so the
+                // over-count's MECHANISM is readable from the always-on log (near-equal copies vs distinct
+                // trains vs a tagged channel) — clean nights stay quiet. srcChannel rides from the read model.
+                if (verdict == HrvAnalyzer.RrCoverageVerdict.CROSS_SECOND_OVER_COUNT ||
+                    verdict == HrvAnalyzer.RrCoverageVerdict.SAME_SECOND_OVER_COUNT) {
+                    val sample = HrvAnalyzer.densestSecondWindowSample(
+                        ts, sleepRr, sleepRrRows.map { it.srcChannel },
+                    )
+                    if (sample.isNotEmpty()) diag("hrv rrsample day=${res.daily.day} $sample")
+                }
             }
 
             // Steps test mode: emit the 5/MG raw-counter trace for this day (cumulative @57 series +

--- a/android/app/src/test/java/com/noop/analytics/HrvRrCoverageTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvRrCoverageTest.kt
@@ -179,4 +179,53 @@ class HrvRrCoverageTest {
         assertTrue(HrvAnalyzer.beatValuesAreTrustworthy(HrvAnalyzer.BEAT_ACCURACY_MIN_FRACTION))
         assertFalse(HrvAnalyzer.beatValuesAreTrustworthy(HrvAnalyzer.BEAT_ACCURACY_MIN_FRACTION - 0.01))
     }
+
+    // #1008 — densestSecondWindowSample: the raw-row sample that makes an over-count's MECHANISM readable
+    // from the always-on log. Exact-string assertions pin byte-parity with the Swift twin. ---
+
+    /** Near-equal copies clustered in one second (the "same beat stored twice" shape): the sample shows
+     *  `[1199,1200,1201]` — values a de-dup would collapse. This is the signature of a duplication bug. */
+    @Test fun densestSample_showsNearEqualCopies() {
+        val ts = listOf(100L, 100L, 100L, 101L, 102L)
+        val rr = listOf(1200.0, 1199.0, 1201.0, 1200.0, 1198.0)
+        val src = listOf<Int?>(null, null, null, null, null)
+        assertEquals(
+            "beatsPerSec=1.67 maxInSec=3 occSec=3 totBeats=5 src=none | " +
+                "t0=100 0s[1199,1200,1201] +1s[1200] +2s[1198]",
+            HrvAnalyzer.densestSecondWindowSample(ts, rr, src),
+        )
+    }
+
+    /** Distinct interval trains (a full ~1200 ms beat beside a ~600 ms one, every second): the sample
+     *  shows `[600,1200]` — NOT copies of one beat, so this is a genuine second stream, not a de-dupable
+     *  duplicate. The two shapes are what the maintainer needs to tell apart to pick the fix. */
+    @Test fun densestSample_showsDistinctTrains() {
+        val ts = listOf(100L, 100L, 101L, 101L, 102L, 102L)
+        val rr = listOf(1200.0, 600.0, 1200.0, 600.0, 1200.0, 600.0)
+        val src = listOf<Int?>(null, null, null, null, null, null)
+        assertEquals(
+            "beatsPerSec=2.00 maxInSec=2 occSec=3 totBeats=6 src=none | " +
+                "t0=100 0s[600,1200] +1s[600,1200] +2s[600,1200]",
+            HrvAnalyzer.densestSecondWindowSample(ts, rr, src),
+        )
+    }
+
+    /** A non-null srcChannel is surfaced as `@code`, and the `src=` field lists the distinct codes — so a
+     *  tagged (Oura #1071) stream is obvious, and `src=none` on a WHOOP night confirms that machinery
+     *  does NOT apply and the over-count has a different origin. */
+    @Test fun densestSample_surfacesSrcChannelTags() {
+        val ts = listOf(100L, 100L)
+        val rr = listOf(1000.0, 1000.0)
+        val src = listOf<Int?>(1, 2)
+        assertEquals(
+            "beatsPerSec=2.00 maxInSec=2 occSec=1 totBeats=2 src=1/2 | t0=100 0s[1000@1,1000@2]",
+            HrvAnalyzer.densestSecondWindowSample(ts, rr, src),
+        )
+    }
+
+    /** Nothing to sample (< 2 beats) → empty string, so the engine emits no `hrv rrsample` line. */
+    @Test fun densestSample_emptyForTooFewBeats() {
+        assertEquals("", HrvAnalyzer.densestSecondWindowSample(emptyList(), emptyList(), emptyList()))
+        assertEquals("", HrvAnalyzer.densestSecondWindowSample(listOf(100L), listOf(1000.0), listOf<Int?>(null)))
+    }
 }

--- a/android/app/src/test/java/com/noop/analytics/HrvRrCoverageTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvRrCoverageTest.kt
@@ -228,4 +228,53 @@ class HrvRrCoverageTest {
         assertEquals("", HrvAnalyzer.densestSecondWindowSample(emptyList(), emptyList(), emptyList()))
         assertEquals("", HrvAnalyzer.densestSecondWindowSample(listOf(100L), listOf(1000.0), listOf<Int?>(null)))
     }
+
+    // Parity edge cases — the SAME literal strings are asserted in the Swift twin (produced by an
+    // independent Swift run), so ties, truncation, short srcCodes, and half-value rounding are pinned
+    // byte-for-byte across platforms, not just the three headline shapes above.
+
+    /** Densest-second TIE (100 & 101 both hold 2) resolves to the EARLIEST ts; equal rrMs order by index. */
+    @Test fun densestSample_tieResolvesToEarliestSecond() {
+        assertEquals(
+            "beatsPerSec=1.67 maxInSec=2 occSec=3 totBeats=5 src=none | t0=100 0s[1000,1000] +1s[1000,1000] +2s[999]",
+            HrvAnalyzer.densestSecondWindowSample(
+                listOf(100L, 100L, 101L, 101L, 102L),
+                listOf(1000.0, 1000.0, 1000.0, 1000.0, 999.0),
+                listOf<Int?>(null, null, null, null, null),
+            ),
+        )
+    }
+
+    /** A runaway second is truncated to maxRowsPerSecond with a `+K` remainder marker. */
+    @Test fun densestSample_truncatesRunawaySecond() {
+        assertEquals(
+            "beatsPerSec=3.00 maxInSec=5 occSec=2 totBeats=6 src=none | t0=50 0s[700,710,720,+2] +1s[1000]",
+            HrvAnalyzer.densestSecondWindowSample(
+                listOf(50L, 50L, 50L, 50L, 50L, 51L),
+                listOf(700.0, 710.0, 720.0, 730.0, 740.0, 1000.0),
+                listOf<Int?>(null, null, null, null, null, null),
+                maxRowsPerSecond = 3,
+            ),
+        )
+    }
+
+    /** srcCodes SHORTER than the beat list is index-guarded (no crash), and only the tagged beat shows `@`. */
+    @Test fun densestSample_shortSrcCodesAreIndexGuarded() {
+        assertEquals(
+            "beatsPerSec=1.50 maxInSec=2 occSec=2 totBeats=3 src=3 | t0=10 0s[1000@3,1000] +1s[1000]",
+            HrvAnalyzer.densestSecondWindowSample(
+                listOf(10L, 10L, 11L), listOf(1000.0, 1000.0, 1000.0), listOf<Int?>(3),
+            ),
+        )
+    }
+
+    /** beatsPerSec at an exact half (3 beats / 2 seconds = 1.50) folds identically on both platforms. */
+    @Test fun densestSample_halfValueBeatsPerSecRounding() {
+        assertEquals(
+            "beatsPerSec=1.50 maxInSec=2 occSec=2 totBeats=3 src=none | t0=200 0s[900,900] +1s[900]",
+            HrvAnalyzer.densestSecondWindowSample(
+                listOf(200L, 200L, 201L), listOf(900.0, 900.0, 900.0), listOf<Int?>(null, null, null),
+            ),
+        )
+    }
 }


### PR DESCRIPTION
## What

Instrumentation for the R-R over-count surfaced by #1008. The always-on `hrv diag` line already reports THAT a night is over-counted (`coverage>1`) and whether the excess beats are same- or cross-second, but not WHY. The #1008 strap log shows a WHOOP 4.0 on 9.3.1 whose **`measured` (live-captured) nights still read `coverage=2.1-2.4` / `crossSecondOverCount`** — and the #1071 `srcChannel` filter is Oura-only, so those untagged WHOOP beats pass straight through. The mechanism is unknown.

Add `densestSecondWindowSample` — a pure, integer-formatted twin on both platforms that dumps the raw R-R rows around the densest second, **emitted only on an over-count verdict** (clean nights stay quiet). The row *shape* is the diagnosis:

- near-equal values in/adjacent a second (`[1200,1199]`) → the **same beat stored twice** (de-dupable / channel-taggable),
- a full interval beside a partial one (`[1200,600]`) → **two distinct interval trains** (a genuine second stream, not a duplicate),
- a `@N` suffix → a non-null `srcChannel`; `src=none` confirms the beats are untagged, so the Oura #1071 path does not apply and a WHOOP over-count is a different mechanism.

Example line:
```
hrv rrsample day=2026-08-03 beatsPerSec=1.94 maxInSec=3 occSec=1420 totBeats=2760 src=none | t0=45123 -1s[1200] 0s[1199,1200,601] +1s[1198]
```

## Why statistics-free

At second-resolution `ts`, a genuine consecutive beat and a duplicate both look like "a near-equal beat ~1 s away", so any *derived* de-dup number would be unreliable — the #550 trap. Raw rows carry no such inference; the reader sees the actual duplication and picks the fix (seq/write-path de-dup vs channel tag vs "it's real dense capture").

## Scope

- **Instrumentation only.** No shipped value changes — same guard as the existing #195/#257/#550 diag fields; `avgHrv`, RMSSD, SDNN, gates all untouched.
- Byte-parity: `HrvAnalyzer.densestSecondWindowSample` (Kotlin) and `HRVAnalyzer.densestSecondWindowSample` (Swift) use integer-only formatting; **exact-string tests on both platforms** assert identical output.

## Verification

- Android: `testFullDebugUnitTest --tests HrvRrCoverageTest` passes (4 new tests) + module compiles.
- Swift pure fn: type-checked in isolation and confirmed to emit byte-identical strings to the Kotlin twin; `HRVAnalyzerTests` cover it (runs in `swift-packages.yml`).
- App-target wiring (`Strand/Data/IntelligenceEngine.swift`) is compile-validated via `app-build.yml` (CI does not compile app targets by default).

Groundwork for #1008: a fresh strap log on this build makes the WHOOP 4.0 over-count's mechanism readable, which decides the actual fix (write-path de-dup vs channel tag vs RMSSD gate).