### PR TITLE
onboarding: fix LocalLifecycleOwner-not-present crash on Activity attach

### DIFF
--- a/android/app/src/main/java/com/noop/ui/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/OnboardingScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -73,7 +74,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.noop.ble.WhoopModel
 import com.noop.data.ImportSummary
 import com.noop.ingest.AppleHealthImporter
@@ -98,7 +98,7 @@ fun OnboardingScreen(viewModel: AppViewModel, onFinished: () -> Unit) {
     // multi-window) doesn't recreate the Activity and throw the user back to page 1.
     var pageIndex by rememberSaveable { mutableIntStateOf(0) }
     val page = pages[pageIndex]
-    val live by viewModel.live.collectAsStateWithLifecycle()
+    val live by viewModel.live.collectAsState()
 
     // The bonded celebration only makes sense once a strap is actually bonded. Auto-advance to it
     // the moment that happens on the Connect step (mirrors macOS's scan → celebration), and skip
@@ -483,8 +483,8 @@ private fun WearStep() {
 @Composable
 private fun ConnectStep(viewModel: AppViewModel) {
     val context = LocalContext.current
-    val live by viewModel.live.collectAsStateWithLifecycle()
-    val selectedModel by viewModel.selectedModel.collectAsStateWithLifecycle()
+    val live by viewModel.live.collectAsState()
+    val selectedModel by viewModel.selectedModel.collectAsState()
 
     val blePerms = remember { blePermissions() }
     // The Scan button goes through the same shared gate as Live/Settings (requests the permission
@@ -618,7 +618,7 @@ private fun ConnectStep(viewModel: AppViewModel) {
 // the nav skips it entirely when nothing is bonded (mirrors the macOS scan → bonded moment).
 @Composable
 private fun BondedStep(viewModel: AppViewModel) {
-    val live by viewModel.live.collectAsStateWithLifecycle()
+    val live by viewModel.live.collectAsState()
     StepShell {
         Column(
             modifier = Modifier


### PR DESCRIPTION
## The crash

From a strap-log \`Last crash\` section (WHOOP 4.0 device, 9.3.x):
\`\`\`
thread: main
java.lang.IllegalStateException: CompositionLocal LocalLifecycleOwner not present
    at com.noop.ui.OnboardingScreenKt.OnboardingScreen(SourceFile:86)
    at com.noop.ui.MainActivityKt.NoopRoot(SourceFile:280)
    ... via Choreographer.doFrame (a normal Compose frame on the main thread)
\`\`\`

## Root cause

\`collectAsStateWithLifecycle()\` defaults its \`lifecycleOwner\` to \`androidx.lifecycle.compose.LocalLifecycleOwner.current\`, which is a \`staticCompositionLocalOf { error("CompositionLocal LocalLifecycleOwner not present") }\` — **the crash text is that local's verbatim default error**, which pins the thrower to \`collectAsStateWithLifecycle\` (not the ActivityResult launchers — those would throw a different "No ActivityResultRegistryOwner" string).

Onboarding is hosted on the normal \`ComponentActivity\` \`setContent\` path (never a Dialog/Popup — checked git history), so the local is normally provided. But it's the one screen reading \`collectAsStateWithLifecycle\` at the **very top of the first-run composition**, before the app shell exists. On this dependency set (compose-bom 2024.06.00 → compose-ui 1.6.8, lifecycle-runtime-compose 2.8.2) a \`Choreographer.doFrame\` recomposition that runs during **Activity (re)creation** — a config change (rotation / dark-mode / font-scale / locale / multi-window, all of which onboarding is explicitly built to survive via \`rememberSaveable\`) or a process-death restore — can land before the lifecycle-owner provider is wired for the subtree and fall through to the \`error(...)\` default. That timing race is why it's rare and shows up as a single \`Last crash\` entry, not an every-launch failure.

## Fix

\`viewModel.live\` / \`viewModel.selectedModel\` are hot \`StateFlow\`s (always have \`.value\`), so swap the four \`collectAsStateWithLifecycle()\` reads (lines 101, 486, 487, 621) to \`collectAsState()\`, which collects inside a plain \`LaunchedEffect\` and **never reads \`LocalLifecycleOwner\`** — eliminating the crash regardless of attach timing. The only trade-off (it doesn't pause collection when STOPPED) is harmless for a foreground-only first-run flow reading a cheap in-memory flow.

## Scope / verification

- **UI-collection only** — no analytics/stored-data change, so no Swift twin (the parity contract is about byte-identity of analytics/data, not UI collection).
- \`compileFullDebugKotlin\` passes.

Not tackling the underlying compose-ui 1.6.x timing race app-wide (a compose-bom bump to 1.7+ would harden the local's provisioning) — that's a repo-wide dependency change, out of scope for this one crash.