### PR TITLE
android: advance the #836 watermark after the post-backfill re-score

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2071,6 +2071,16 @@ class WhoopBleClient(
                     sex = profileStore.sex,
                     stepTicksPerStep = profileStore.stepTicksPerStep,
                 )
+                // #836: the post-backfill pass is a real update path, so it ALWAYS re-scores (mirroring the
+                // Swift `analyzeRecent(force: true)` call `refreshAfterCompletedBackfill` makes) — but it must
+                // ADVANCE the shared HR-fingerprint watermark on success, which it previously did NOT. That
+                // watermark logic lived only in AppViewModel's 15-min loop, so after this pass the very next
+                // idle tick saw `fp != watermark` and re-ran the IDENTICAL maxDays×~54h re-score — the
+                // double-charge that made every reconnect pay for the multi-day pass twice. Swift already
+                // advances the watermark at the end of EVERY successful analyzeRecent (IntelligenceEngine.swift);
+                // this brings Android into lockstep. Captured before the run, written only on success, so an
+                // interrupted/failed pass can never advance the watermark past unscored data.
+                val analyzeFp = repository.hrFingerprint()
                 runCatching {
                     IntelligenceEngine.analyzeRecent(
                         repo = repository,
@@ -2143,6 +2153,8 @@ class WhoopBleClient(
                             else null,
                     )
                 }.onSuccess {
+                    // Advance the shared watermark so the next 15-min tick sees no change and skips (#836).
+                    NoopPrefs.setAnalyzeWatermark(context, analyzeFp)
                     log("Backfill: post-sync scoring pass done")
                     // #277 diagnostic: surface the day-key the dashboard treats as "today" against the
                     // newest banked row, so a UTC-bucket vs local-day split (rows persist but Today


### PR DESCRIPTION
## Symptom

On a phone that is **not** battery-optimization-exempt, Android kills NOOP's background BLE, so on the next foreground/reconnect the strap hands over a large banked backlog. A WHOOP 4.0 strap log (last sync ~10h prior) shows the reconnect doing a ~25k-row offload and then a **multi-day re-score** — `hrv diag`/`rhr` lines marching back through ~10 days, ~70s of solid CPU over a 16.6M-row DB. And it runs **twice** per reconnect.

## Root cause

`onBackfillChunkCommitted` (`WhoopBleClient.kt:2060`) fires after each committed backfill chunk → `IntelligenceEngine.analyzeRecent(maxDays = 21)`, a ~54h × up-to-21-day re-score. That pass is a legitimate update path and should run — **but it never advanced the #836 HR-fingerprint watermark.** On Android the watermark gate (PR #841) lives *only* in `AppViewModel`'s 15-min loop (`AppViewModel.kt:907/1011`); the post-backfill caller bypasses it and never writes it. So right after the post-backfill pass, the **next 15-min idle tick sees `fp != watermark` and re-runs the identical multi-day re-score** — the double-charge. A sliced offload can multiply it.

## Fix

Capture `repository.hrFingerprint()` before the post-backfill pass and, on success, `NoopPrefs.setAnalyzeWatermark(context, fp)`. The next idle tick then sees no change and skips. Captured-before / written-only-on-success mirrors the UI loop, so an interrupted/failed pass can never advance the watermark past unscored data.

The pass itself still **always runs** (a real sync should re-score) and the window/`maxDays` is unchanged — **no per-day skip and no scope shrink**, because the window is scored as a unit (baselines folded across all days; #899 does window-wide sleep-dedup deletes), which makes partial scoping a data-loss trap. Scores stay byte-identical; only the redundant second pass is removed.

## Parity — no Swift change needed

This is exactly what Swift **already** does:
- `IntelligenceEngine.swift` sets the watermark at the end of **every** successful `analyzeRecent` (`:1549`), forced or not.
- `refreshAfterCompletedBackfill` calls `analyzeRecent()` (`force: true`) — always runs **and** advances the watermark — so the Swift 15-min `analyzeRecent(force: false)` tick already skips.

Android's watermark-advance was simply missing from the post-backfill path. This brings Android into lockstep with the shipped Swift behavior — no Swift twin required.

## Verification

- `compileFullDebugKotlin` passes.
- Behavioral change is a scoring-*trigger* gate (no analytics value changes); mirrors the already-shipped Swift force+watermark semantics. The `finally` at `:2172` still resets the debounce flag, so the early path can't strand it.

Battery context: #1007 (offload radio), #1005; this addresses the CPU half (the reconnect re-score) by killing its redundant second run.