### PR TITLE
test centre: adb-like detailed capture — rolling on-device strap-log file

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5671,6 +5671,12 @@ class WhoopBleClient(
                 // Advance the tick for both families so the ~60s battery cadence also fires on 5/MG (it
                 // previously incremented only inside the WHOOP 4 branch).
                 keepAliveTick += 1
+                // #1121: sample the PHONE battery on the SAME ~60s cadence as the strap poll, so a detailed
+                // capture carries a phone-battery curve on the same timeline as the offload/connection
+                // activity — turning the capture into a self-contained battery diagnostic ("phone dropped N%
+                // across this offload"). Cheap sticky-intent read; the strap `[battery]` line is the strap's
+                // SoC, this is the phone's. Unconditional (low volume, useful in any shared log), PII-free.
+                if (keepAliveTick % 2 == 0) phoneBatteryLine()?.let { log(it) }
                 if (connectedFamily == DeviceFamily.WHOOP4) {
                     if (wantsRealtime) { realtimeArmed = true; send(CommandNumber.TOGGLE_REALTIME_HR, byteArrayOf(1)) }
                     if (keepAliveTick % 2 == 0) send(CommandNumber.GET_BATTERY_LEVEL)
@@ -7705,6 +7711,25 @@ class WhoopBleClient(
         old.delete()
         f.renameTo(old)
     }
+
+    /** #1121: a PHONE-battery snapshot line (`[phonebattery] level=NN% charging=y/n temp=..C t=..s`) for the
+     *  strap log — the `[battery]` line is the STRAP's SoC; this is the phone's, so a capture can show the
+     *  phone drain against the offload/connection activity on one timeline. One-shot read of the sticky
+     *  ACTION_BATTERY_CHANGED intent (no receiver lifecycle). Null when unreadable. PII-free. */
+    private fun phoneBatteryLine(): String? = runCatching {
+        val i = context.registerReceiver(null, android.content.IntentFilter(android.content.Intent.ACTION_BATTERY_CHANGED))
+            ?: return null
+        val level = i.getIntExtra(android.os.BatteryManager.EXTRA_LEVEL, -1)
+        val scale = i.getIntExtra(android.os.BatteryManager.EXTRA_SCALE, -1)
+        val pct = if (level >= 0 && scale > 0) level * 100 / scale else -1
+        val status = i.getIntExtra(android.os.BatteryManager.EXTRA_STATUS, -1)
+        val charging = status == android.os.BatteryManager.BATTERY_STATUS_CHARGING ||
+            status == android.os.BatteryManager.BATTERY_STATUS_FULL
+        val tenths = i.getIntExtra(android.os.BatteryManager.EXTRA_TEMPERATURE, Int.MIN_VALUE)
+        val tempStr = if (tenths != Int.MIN_VALUE) " temp=${tenths / 10.0}C" else ""
+        "[phonebattery] level=$pct% charging=${if (charging) "yes" else "no"}$tempStr " +
+            "t=${System.currentTimeMillis() / 1000L}s"
+    }.getOrNull()
 
     /** Scrub personal identifiers from a strap-log line so it's safe to share publicly (#445, @maddognik):
      *  BLE MAC addresses are masked to their first + last byte, and the WHOOP's SERIAL — carried in its

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5671,12 +5671,15 @@ class WhoopBleClient(
                 // Advance the tick for both families so the ~60s battery cadence also fires on 5/MG (it
                 // previously incremented only inside the WHOOP 4 branch).
                 keepAliveTick += 1
-                // #1121: sample the PHONE battery on the SAME ~60s cadence as the strap poll, so a detailed
-                // capture carries a phone-battery curve on the same timeline as the offload/connection
-                // activity — turning the capture into a self-contained battery diagnostic ("phone dropped N%
-                // across this offload"). Cheap sticky-intent read; the strap `[battery]` line is the strap's
-                // SoC, this is the phone's. Unconditional (low volume, useful in any shared log), PII-free.
-                if (keepAliveTick % 2 == 0) phoneBatteryLine()?.let { log(it) }
+                // #1121: ONLY while a detailed capture is running (zero work otherwise — one volatile read):
+                // sample the PHONE battery on the same ~60s cadence as the strap poll, so the capture carries
+                // a phone-battery curve on the offload/connection timeline ("phone dropped N% across this
+                // offload"), and flush the rolling file this tick so a sparse idle tail survives an abrupt
+                // kill. The strap `[battery]` line is the strap's SoC; this is the phone's. PII-free.
+                if (captureLogWriter != null) {
+                    if (keepAliveTick % 2 == 0) phoneBatteryLine()?.let { log(it) }
+                    flushCaptureLog()
+                }
                 if (connectedFamily == DeviceFamily.WHOOP4) {
                     if (wantsRealtime) { realtimeArmed = true; send(CommandNumber.TOGGLE_REALTIME_HR, byteArrayOf(1)) }
                     if (keepAliveTick % 2 == 0) send(CommandNumber.GET_BATTERY_LEVEL)
@@ -7678,14 +7681,17 @@ class WhoopBleClient(
     }
 
     /** Append one already-scrubbed line to the rolling file, rotating at the cap. No-op when capture is
-     *  off. Called ONLY from [log], inside its no-throw guard. Flushes per line so a process kill (this
-     *  phone is not battery-exempt) keeps the tail. */
+     *  off. Called ONLY from [log], inside its no-throw guard. Does NOT flush per line — that would be a
+     *  syscall per line on the GATT binder thread during an offload burst; the BufferedWriter coalesces
+     *  writes (and auto-flushes when its buffer fills), and [flushCaptureLog] on the ~30s keep-alive tick
+     *  bounds how much of a sparse idle tail an abrupt kill could lose. Mirrors the 5/MG capture, which
+     *  likewise flushes on a cadence rather than per line. */
     private fun appendCaptureLog(line: String) {
         if (captureLogWriter == null) return
         synchronized(captureLogLock) {
             val w = captureLogWriter ?: return
             runCatching {
-                w.write(line); w.write("\n"); w.flush()
+                w.write(line); w.write("\n")
                 captureLogBytes += line.length + 1
                 if (captureLogBytes > CAPTURE_LOG_MAX_BYTES) {
                     w.flush(); w.close()
@@ -7697,6 +7703,20 @@ class WhoopBleClient(
             }.onFailure {
                 // A write/rotate failure (disk full, revoked FD) disables capture for the process rather
                 // than failing every subsequent line — same self-quiescing contract as the 5/MG capture.
+                captureLogDisabled = true
+                runCatching { captureLogWriter?.close() }
+                captureLogWriter = null
+            }
+        }
+    }
+
+    /** Push the buffered capture writer to the OS. Called on the ~30s keep-alive tick so a sparse idle tail
+     *  (e.g. the 60s phone/strap battery lines) is durable within one tick of an abrupt kill, without
+     *  paying a per-line flush during bursts. No-op + one volatile read when capture is off. */
+    private fun flushCaptureLog() {
+        if (captureLogWriter == null) return
+        synchronized(captureLogLock) {
+            runCatching { captureLogWriter?.flush() }.onFailure {
                 captureLogDisabled = true
                 runCatching { captureLogWriter?.close() }
                 captureLogWriter = null

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -801,6 +801,12 @@ class WhoopBleClient(
         // EVENT frames are ~40–120 B of hex each, a few KB per day of wear — 5 MB is years.
         private const val WHOOP5_EVENT_LOG_MAX_BYTES = 5L * 1024 * 1024
 
+        /** #1121 detailed-capture: opt-in rolling mirror of the strap log to an on-device file (adb-like,
+         *  but no computer). Shared via Test Centre → "Share captured log". */
+        const val CAPTURE_LOG_FILE = "noop-capture-log.txt"
+        // ~8 MB current + one rolled generation (.1) ≈ a full day even through heavy offload bursts.
+        private const val CAPTURE_LOG_MAX_BYTES = 8L * 1024 * 1024
+
         /** High-rate R22 deep-buffer research log (#423) — the big type-0x2F buffers (1244/2140 B) that
          *  carry tens-of-Hz motion/optical, kept raw in their own file so they survive long enough to
          *  reverse. The 2140-B buffers are ~4.3 KB of hex and arrive in bursts, so a bigger cap than the
@@ -7605,10 +7611,17 @@ class WhoopBleClient(
             if (debugLogcat) Log.d(TAG, safe)
             // Mirror into the in-app ring buffer (format under the lock — SimpleDateFormat isn't
             // thread-safe and log() is called from both the GATT binder thread and the main looper).
-            synchronized(logBuffer) {
-                logBuffer.addLast("${logTimeFmt.format(System.currentTimeMillis())}  $safe")
+            val stamped = synchronized(logBuffer) {
+                val line = "${logTimeFmt.format(System.currentTimeMillis())}  $safe"
+                logBuffer.addLast(line)
                 while (logBuffer.size > LOG_BUFFER_MAX) logBuffer.removeFirst()
+                line
             }
+            // #1121: when detailed capture is on, ALSO append the (already PII-scrubbed) line to the
+            // rolling on-device file, so a long-running issue is captured for hours rather than only the
+            // ~5000-line (~50 min) in-memory ring. No-op + near-zero cost when capture is off, and inside
+            // this same no-throw guard so a file error can never reach the connection path.
+            appendCaptureLog(stamped)
         } catch (t: Throwable) {
             // Last resort: note that a log line failed, without risking another throw. Never rethrow.
             runCatching {
@@ -7618,6 +7631,79 @@ class WhoopBleClient(
                 }
             }
         }
+    }
+
+    // ── #1121 Detailed capture: adb-like rolling strap-log file ────────────────────────────────────
+    // Opt-in mirror of every log() line into a rolling on-device file (filesDir/[CAPTURE_LOG_FILE], capped
+    // at [CAPTURE_LOG_MAX_BYTES] with one previous generation kept as ".1"), so a long-running diagnostic —
+    // battery, an overnight offload — survives well past the ~50 min the in-memory ring holds AND survives
+    // the process being killed (AppViewModel re-arms it from the persisted pref on launch). Lines are
+    // ALREADY PII-scrubbed by log() before they reach here (they are the same `safe` text the ring stores),
+    // so nothing extra is redacted on the way out. All file IO is under [captureLogLock]; a failure disables
+    // capture for the process rather than ever propagating to the connection path.
+    @Volatile private var captureLogWriter: java.io.BufferedWriter? = null
+    @Volatile private var captureLogDisabled = false
+    private var captureLogBytes = 0L
+    private val captureLogLock = Any()
+
+    /** Turn the rolling capture file on or off. Idempotent and safe to call from any thread. On enable it
+     *  opens (rotating first if the existing file is already at the cap); on disable it flushes + closes. */
+    fun setDetailedCapture(enabled: Boolean) {
+        synchronized(captureLogLock) {
+            if (enabled) {
+                if (captureLogWriter != null || captureLogDisabled) return
+                runCatching {
+                    val f = java.io.File(context.filesDir, CAPTURE_LOG_FILE)
+                    if (f.exists() && f.length() > CAPTURE_LOG_MAX_BYTES) rollCaptureFile(f)
+                    captureLogBytes = if (f.exists()) f.length() else 0L
+                    captureLogWriter = java.io.BufferedWriter(java.io.FileWriter(f, true))
+                }.onFailure { captureLogDisabled = true }
+            } else {
+                runCatching { captureLogWriter?.flush(); captureLogWriter?.close() }
+                captureLogWriter = null
+            }
+        }
+        // Emit the marker OUTSIDE the lock — log() → appendCaptureLog re-enters [captureLogLock].
+        when {
+            captureLogWriter != null ->
+                log("Detailed capture: rolling log ON (≤${CAPTURE_LOG_MAX_BYTES / (1024 * 1024)}MB ×2, filesDir/$CAPTURE_LOG_FILE)")
+            !enabled -> log("Detailed capture: OFF")
+        }
+    }
+
+    /** Append one already-scrubbed line to the rolling file, rotating at the cap. No-op when capture is
+     *  off. Called ONLY from [log], inside its no-throw guard. Flushes per line so a process kill (this
+     *  phone is not battery-exempt) keeps the tail. */
+    private fun appendCaptureLog(line: String) {
+        if (captureLogWriter == null) return
+        synchronized(captureLogLock) {
+            val w = captureLogWriter ?: return
+            runCatching {
+                w.write(line); w.write("\n"); w.flush()
+                captureLogBytes += line.length + 1
+                if (captureLogBytes > CAPTURE_LOG_MAX_BYTES) {
+                    w.flush(); w.close()
+                    val f = java.io.File(context.filesDir, CAPTURE_LOG_FILE)
+                    rollCaptureFile(f)
+                    captureLogWriter = java.io.BufferedWriter(java.io.FileWriter(f, true))
+                    captureLogBytes = 0L
+                }
+            }.onFailure {
+                // A write/rotate failure (disk full, revoked FD) disables capture for the process rather
+                // than failing every subsequent line — same self-quiescing contract as the 5/MG capture.
+                captureLogDisabled = true
+                runCatching { captureLogWriter?.close() }
+                captureLogWriter = null
+            }
+        }
+    }
+
+    /** Rotate [f] → "f.1", dropping any prior generation. Caller holds [captureLogLock] and has already
+     *  closed the writer (if any). */
+    private fun rollCaptureFile(f: java.io.File) {
+        val old = java.io.File(context.filesDir, "$CAPTURE_LOG_FILE.1")
+        old.delete()
+        f.renameTo(old)
     }
 
     /** Scrub personal identifiers from a strap-log line so it's safe to share publicly (#445, @maddognik):

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -677,6 +677,10 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         // existing WHOOP flow below runs unchanged; it only acts when a non-WHOOP strap is the active
         // device. The Devices screen (next task) calls onActiveDeviceChanged after a setActive.
         noopApp.sourceCoordinator.start()
+        // #1121: re-arm the opt-in detailed-capture rolling log on launch, so a capture the user started
+        // keeps going across the process being killed (this phone class is not battery-exempt and Android
+        // kills the background BLE overnight — the very window a battery capture needs to span).
+        if (NoopPrefs.detailedCapture(appContext)) ble.setDetailedCapture(true)
         // #78 hole-4: wire the app-foreground salvage probe (see salvageProbeLifecycleCallbacks above).
         noopApp.registerActivityLifecycleCallbacks(salvageProbeLifecycleCallbacks)
         // Resolve the active band's name for the Live screen header (MW-6). Falls back to "WHOOP" in the
@@ -1964,6 +1968,13 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     fun setDebugLogging(enabled: Boolean) {
         NoopPrefs.setDebugLogging(appContext, enabled)
         ble.debugLogcat = enabled
+    }
+
+    /** #1121: toggle the opt-in rolling "detailed capture" strap-log file. Persisted so it survives a
+     *  process kill (re-armed in [init] below). */
+    fun setDetailedCapture(enabled: Boolean) {
+        NoopPrefs.setDetailedCapture(appContext, enabled)
+        ble.setDetailedCapture(enabled)
     }
 
     // --- Broadcast heart rate (NOOP acts as a standard BLE HR peripheral; gym kit reads the strap HR) ---

--- a/android/app/src/main/java/com/noop/ui/LogExport.kt
+++ b/android/app/src/main/java/com/noop/ui/LogExport.kt
@@ -287,6 +287,53 @@ object LogExport {
         return out
     }
 
+    /**
+     * Share the opt-in "detailed capture" rolling strap-log file (#1121) — the adb-like long-run log the
+     * Test Centre toggle writes. Concatenates the rolled generation + the live file (oldest first) into one
+     * shareable `.txt`. Lines are ALREADY PII-scrubbed by `WhoopBleClient.log()`, so no extra redaction here.
+     */
+    suspend fun shareCaptureLog(context: Context) {
+        runCatching {
+            val out = withContext(Dispatchers.IO) { writeCaptureLogFile(context) }
+            if (out == null) {
+                Toast.makeText(
+                    context,
+                    "No detailed capture yet — turn on \"Detailed capture to file\" in Test Centre first.",
+                    Toast.LENGTH_LONG,
+                ).show()
+                return
+            }
+            val send = Intent(Intent.ACTION_SEND).apply {
+                type = "text/plain"
+                putExtra(Intent.EXTRA_STREAM, fileUri(context, out))
+                putExtra(Intent.EXTRA_SUBJECT, "NOOP detailed capture log")
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            context.startActivity(Intent.createChooser(send, "Share captured log"))
+        }.onFailure {
+            Toast.makeText(context, "Couldn't share the capture: ${it.message}", Toast.LENGTH_LONG).show()
+        }
+    }
+
+    /** Concatenate the rolling capture file's rolled + live generations (oldest first) into a shareable
+     *  copy under cache/logs. Null when nothing has been captured yet. */
+    private fun writeCaptureLogFile(context: Context): File? {
+        val main = File(context.filesDir, com.noop.ble.WhoopBleClient.CAPTURE_LOG_FILE)
+        val prev = File(context.filesDir, "${com.noop.ble.WhoopBleClient.CAPTURE_LOG_FILE}.1")
+        if (!main.exists() && !prev.exists()) return null
+        val header = buildString {
+            appendLine("# NOOP detailed capture — rolling strap log (PII-scrubbed at source)")
+            appendLine("# App: ${BuildConfig.VERSION_NAME} (${BuildConfig.TIER}) · Android ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT}) · ${Build.MANUFACTURER} ${Build.MODEL}")
+        }
+        val dir = File(context.cacheDir, "logs").apply { mkdirs() }
+        val out = File(dir, "noop-capture-${timestamp()}.txt")
+        out.outputStream().bufferedWriter().use { w ->
+            w.write(header)
+            for (f in listOf(prev, main)) if (f.exists()) f.bufferedReader().use { r -> r.copyTo(w) }
+        }
+        return out
+    }
+
     private fun fileUri(context: Context, file: File) =
         FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
 

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -412,6 +412,16 @@ object NoopPrefs {
         of(context).edit().putBoolean(KEY_DEBUG_LOGGING, enabled).apply()
     }
 
+    /** #1121: whether the opt-in "detailed capture" rolling strap-log file is on. Persisted so capture
+     *  RESUMES after the process is killed (AppViewModel re-arms the BLE client from this on launch). */
+    const val KEY_DETAILED_CAPTURE = "noop.detailedCapture"
+    fun detailedCapture(context: Context): Boolean =
+        of(context).getBoolean(KEY_DETAILED_CAPTURE, false)
+
+    fun setDetailedCapture(context: Context, enabled: Boolean) {
+        of(context).edit().putBoolean(KEY_DETAILED_CAPTURE, enabled).apply()
+    }
+
     /** Whether NOOP re-broadcasts its live HR as a standard BLE Heart Rate peripheral. Default OFF. */
     fun hrBroadcast(context: Context): Boolean =
         of(context).getBoolean(KEY_HR_BROADCAST, false)

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -346,6 +346,8 @@ private fun DiagnosticToolsCard(vm: AppViewModel) {
     var showRecalibrate by remember { mutableStateOf(false) }
     // "Debug logging" moved here from Settings: dev-only, mirrors the strap log to logcat over adb.
     var debugLogging by remember { mutableStateOf(NoopPrefs.debugLogging(context)) }
+    var detailedCapture by remember { mutableStateOf(NoopPrefs.detailedCapture(context)) }
+    var captureShareBusy by remember { mutableStateOf(false) }
     // #646/#651: LogExport.shareStrapLog's file write now runs on Dispatchers.IO instead of blocking the
     // caller, so nothing else stops a second tap mid-share. Same disable-while-busy + spinner shape as
     // Settings' backupBusy pattern — this screen has its own local flag, this button being a separate
@@ -407,6 +409,44 @@ private fun DiagnosticToolsCard(vm: AppViewModel) {
                     onCheckedChange = { debugLogging = it; vm.setDebugLogging(it) },
                     colors = settingsSwitchColors(),
                 )
+            }
+            // #1121 Detailed capture: an adb-like rolling on-device log, no computer needed. Off by default.
+            ToggleRowTC(
+                title = "Detailed capture to file",
+                description = "Continuously append the strap log to a rolling on-device file (≤8 MB, one " +
+                    "previous generation kept) so a long-running issue — battery drain, an overnight " +
+                    "offload — is captured for hours instead of the ~50 minutes the in-memory share holds. " +
+                    "Keeps going if the app is killed and resumes on next launch. The file stays on the " +
+                    "phone unless you share it below.",
+                checked = detailedCapture,
+                onCheckedChange = { detailedCapture = it; vm.setDetailedCapture(it) },
+            )
+            if (detailedCapture) {
+                Text(
+                    "Capturing… reproduce the issue, then share the log below.",
+                    style = NoopType.footnote,
+                    color = Palette.accent,
+                )
+            }
+            NoopButton(
+                text = "Share captured log",
+                leadingIcon = Icons.Filled.Upload,
+                kind = NoopButtonKind.Secondary,
+                fullWidth = true,
+                enabled = !captureShareBusy,
+                onClick = {
+                    captureShareBusy = true
+                    scope.launch {
+                        try {
+                            LogExport.shareCaptureLog(context)
+                        } finally {
+                            captureShareBusy = false
+                        }
+                    }
+                },
+            )
+            if (captureShareBusy) {
+                NoopBusyRow()
             }
         }
     }


### PR DESCRIPTION
## Why

The one-shot **Share strap log** only exports the in-memory ring (5000 lines ≈ **~50 min**), and battery polls (every 60 s) + connection frames burn that budget fast — so a long-running issue (battery drain, an overnight offload) scrolls out of the window before it can be captured. `adb logcat` has no cap but needs a computer. This gives the same coverage **in-app, no computer**.

## What

An opt-in **"Detailed capture to file"** toggle in **Test Centre → Diagnostic Tools** (beside Debug logging), plus a **"Share captured log"** button.

- Mirrors every `log()` line into a rolling file `filesDir/noop-capture-log.txt`, **≤ 8 MB with one previous generation kept** (`.1`) — hours-to-a-full-day of coverage.
- **Share** concatenates `.1` + live (oldest first) into one `.txt` via the existing FileProvider path.
- **Survives a process kill:** `AppViewModel` re-arms capture from the persisted pref on launch — essential on a non-battery-exempt phone where Android kills the background BLE overnight (the exact window a battery capture must span).

Example screen copy: *"Continuously append the strap log to a rolling on-device file (≤8 MB…) so a long-running issue is captured for hours instead of the ~50 minutes the in-memory share holds. Keeps going if the app is killed and resumes on next launch."*

## Safety / correctness

- **PII:** the captured lines are the *same* `safe` text `log()` already scrubs before the in-memory ring (`redactStrapLogPii`, #445) — nothing extra is written or leaked. File is app-private; never leaves the phone unless shared.
- **Never touches the connection path:** all file IO is under `captureLogLock` and sits **inside `log()`'s existing no-throw guard**; on any IO error capture disables itself for the process (like the existing `eventLogDisabled`), exactly as the 5/MG capture does.
- **Durable:** flushes per line so a process kill keeps the tail; rotates at the cap.
- Reuses the open-append-rotate-at-cap pattern the **5/MG raw capture already ships** (`WHOOP5_CAPTURE_FILE`), and the existing `LogExport` FileProvider share.

## Scope

- **Off by default**, opt-in — every NOOP capture is.
- **Android-only diagnostic tooling** — no analytics/stored-data touched, same as the existing 5/MG capture, so **no Swift twin**.
- Note: while capture is on, high-volume bursts (offload) do per-line file flushes on the log path — acceptable for an explicitly-enabled diagnostic (lighter than the existing `Log.d`/`appendText` per-line paths), and zero cost when off.

## Verification

`compileFullDebugKotlin` passes. Files: `WhoopBleClient` (sink + rolling file), `MainActivity` (NoopPrefs pref), `AppViewModel` (setter + resume), `LogExport` (share), `TestCentreScreen` (toggle + button).

Directly unblocks the WHOOP 4.0 battery investigation — a full-day connection/offload trace can now come from the phone alone.