### PR TITLE
sleep: opt-in FILLED stepped hypnogram (Android), toggle back to classic

### DIFF
--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -481,34 +481,6 @@
       "Off"
     ],
     [
-      "android/app/src/main/java/com/noop/ui/OnboardingScreen.kt",
-      "Deep blue accent on a dark blue-grey canvas."
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/OnboardingScreen.kt",
-      "Deep blue accent on warm paper."
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/OnboardingScreen.kt",
-      "Following your phone's light/dark setting."
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/OnboardingScreen.kt",
-      "Re-scan"
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/OnboardingScreen.kt",
-      "Scan again"
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/OnboardingScreen.kt",
-      "Your strap is bonded and ready to stream."
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/OnboardingScreen.kt",
-      "Your strap is bonded · ${it.toInt()}% battery."
-    ],
-    [
       "android/app/src/main/java/com/noop/ui/PipBar.kt",
       "$label: $valueText"
     ],
@@ -538,14 +510,6 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
-      "Collapsed"
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
-      "Expanded"
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Manual override"
     ],
     [
@@ -570,15 +534,11 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
-      "Strap accepted ${live.r22FlagsAccepted}/15 R22 flags…"
+      "Sleep chart"
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Wear the strap, tap once, then let it sync and share your strap log."
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
-      "✓ Strap accepted all 15 R22 flags"
     ],
     [
       "android/app/src/main/java/com/noop/ui/SkinTempCardsScreen.kt",
@@ -655,6 +615,18 @@
     [
       "android/app/src/main/java/com/noop/ui/StressScreen.kt",
       "Today's value is your recorded daily stress score (0-3)."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TestCentreScreen.kt",
+      "Capturing… reproduce the issue, then share the log below."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TestCentreScreen.kt",
+      "Detailed capture to file"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TestCentreScreen.kt",
+      "Share captured log"
     ],
     [
       "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
@@ -895,10 +867,6 @@
       " \\(unit)"
     ],
     [
-      "Strand/Liquid/LiquidTodayView.swift",
-      "Arrange Today sections"
-    ],
-    [
       "Strand/Screens/AddDeviceWizard.swift",
       "The most common cause is the ring was not fully reset in the Oura app, or the Oura app is still running. Reset the ring again, force-quit Oura, then try once more. If it keeps failing, your ring may be a generation NOOP cannot adopt yet. The ring is not bricked: re-pair it in the Oura app to recover it. You can still use file import."
     ],
@@ -957,10 +925,6 @@
     [
       "Strand/Screens/JournalLogCard.swift",
       "Delete this custom item"
-    ],
-    [
-      "Strand/Screens/JournalLogCard.swift",
-      "Edit \\(item.display)"
     ],
     [
       "Strand/Screens/JournalLogCard.swift",

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -579,6 +579,7 @@ fun SettingsScreen(
     // Trend charts (Line / Bar) — flips the Trends tab between the gradient line and value-ramp bars.
     // Display-only; SharedPreferences isn't reactive, so mirror into local state and persist on select.
     var trendChartStyle by remember { mutableStateOf(UnitPrefs.trendChartStyle(context)) }
+    var sleepChartStyle by remember { mutableStateOf(UnitPrefs.sleepChartStyle(context)) }
     // HRV window (#141) — whole-night vs deep-sleep (WHOOP-style). NOT display-only: it changes the computed
     // avgHrv, so a switch clears the analyze watermark to force a re-score + re-baseline on the next pass.
     var hrvWindow by remember { mutableStateOf(UnitPrefs.hrvWindow(context)) }
@@ -1075,6 +1076,22 @@ fun SettingsScreen(
                     onSelect = { style ->
                         trendChartStyle = style
                         UnitPrefs.setTrendChartStyle(context, style)
+                    },
+                )
+            }
+            SettingsRowDivider()
+            // Sleep chart style (#sleep-chart-style). Display-only: "Classic" keeps the per-stage-rows
+            // timeline; "Filled" swaps the Sleep tab's stage chart for a single stepped hypnogram with the
+            // stages stacked by depth and each column filled to the baseline. Same data either way; this only
+            // changes the drawing, and it falls back to Classic on a night with no timestamped segments.
+            SettingsFormRow(label = "Sleep chart") {
+                SegmentedPillControl(
+                    items = listOf(SleepChartStyle.CLASSIC, SleepChartStyle.FILLED),
+                    selection = sleepChartStyle,
+                    label = { if (it == SleepChartStyle.FILLED) "Filled" else "Classic" },
+                    onSelect = { style ->
+                        sleepChartStyle = style
+                        UnitPrefs.setSleepChartStyle(context, style)
                     },
                 )
             }

--- a/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
@@ -16,12 +16,17 @@ import kotlin.math.roundToInt
  * segments exist); else null → the honest fallback. Never another night's data. (#160)
  */
 internal fun heroDisplay(model: SleepModel?, night: HeroNight?): HeroDisplay? {
-    if (model != null) return HeroDisplay(model.stages, model.realSegments, model.efficiencyText)
+    if (model != null) {
+        return HeroDisplay(model.stages, model.realSegments, model.hypnogramSegments, model.efficiencyText)
+    }
     val segments = night?.realSegments ?: return null
     val stages = stagesFromSegments(segments) ?: return null
     val eff = night.session.efficiency
         ?.let { e -> "${(if (e <= 1.0) e * 100.0 else e).roundToInt()}%" } ?: "—"
-    return HeroDisplay(stages, segments, eff)
+    // Timestamped segments for the FILLED chart on the fallback path too: the group's full-night segments
+    // when the night is fragmented, else this session's persisted array.
+    val tsSegments = night.groupSegments ?: parsePersistedSegments(night.session.stagesJSON)
+    return HeroDisplay(stages, segments, tsSegments, eff)
 }
 
 /** Sum (stage, minutes) weights into per-stage totals; null when nothing is > 0. */
@@ -219,13 +224,15 @@ internal fun buildSleepModel(
     // near-midnight-UTC wake only matches via the local key; selectNight attributes the
     // night the same way). A non-matching session degrades safely to synthesis, never to
     // a wrong night. (#160)
-    val realSegments = heroSegments?.map { seg -> seg.stage to ((seg.end - seg.start) / 60f) }
+    // Real timestamped segments (group when fragmented, else this session's) — kept whole for the FILLED
+    // hypnogram, and flattened to (stage, minutes) weights for the classic proportional/rows view.
+    val hypnogramSegments: List<PersistedSegment>? = heroSegments
         ?: session
             ?.takeIf {
                 AnalyticsEngine.dayString(it.endTs) == latest.day || localDayString(it.endTs) == latest.day
             }
             ?.let { parsePersistedSegments(it.stagesJSON) }
-            ?.map { seg -> seg.stage to ((seg.end - seg.start) / 60f) }
+    val realSegments = hypnogramSegments?.map { seg -> seg.stage to ((seg.end - seg.start) / 60f) }
 
     // Rolling 14-night sleep-debt ledger over the FULL day history (the analytics caps to the
     // most-recent 14 counted nights and skips no-data nights), using the SAME personal need the
@@ -260,6 +267,7 @@ internal fun buildSleepModel(
         trendDebtHours = trendDebtHours,
         trendDates = trendDates,
         realSegments = realSegments,
+        hypnogramSegments = hypnogramSegments,
         sleepDebtLedger = sleepDebtLedger,
     )
 }

--- a/android/app/src/main/java/com/noop/ui/SleepModels.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepModels.kt
@@ -55,6 +55,10 @@ internal data class SleepModel(
     /** Persisted per-epoch segments as ordered (stage, minutes) weights — the REAL
      *  hypnogram (on-device APPROXIMATE staging) — or null → synthesized fallback. */
     val realSegments: List<Pair<String, Float>>?,
+    /** The SAME real segments but with their wall-clock start/end kept, for the opt-in FILLED
+     *  stepped hypnogram (#sleep-chart-style) which plots stages at real times. Null when the night
+     *  has no timestamped segments (then FILLED falls back to the classic view). */
+    val hypnogramSegments: List<PersistedSegment>?,
     /** Rolling 14-night sleep-debt ledger: Σ(slept − personal need) across the recent
      *  fortnight, with the per-night deltas behind it. Computed once per data change. (#242) */
     val sleepDebtLedger: SleepDebtLedger,
@@ -103,6 +107,8 @@ internal data class HeroNight(
 internal data class HeroDisplay(
     val stages: Stages,
     val realSegments: List<Pair<String, Float>>?,
+    /** Timestamped segments for the opt-in FILLED hypnogram (#sleep-chart-style); null → classic fallback. */
+    val hypnogramSegments: List<PersistedSegment>?,
     val efficiencyText: String,
 )
 

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -1082,23 +1082,46 @@ private fun Hero(
             // else keeps the honest proportional strip + StageBreakdownRows footer.
             val real = display.realSegments?.takeIf { it.size >= 2 }
             if (real != null) {
-                ChartCard(
-                    title = uiString(R.string.l10n_sleep_screen_stage_breakdown_e9b714f9),
-                    subtitle = subtitle,
-                    trailing = durationText(s.asleep),
-                    tint = Palette.restColor,
-                    footer = {},
-                ) {
-                    StageTimeline(
-                        realSegments = real,
-                        s = s,
-                        // #345: the axis spans the WHOLE night. The group hypnogram (#364 seams) runs to
-                        // the group's last wake; labelling the axis off the session fragment's endTs cut
-                        // the clock labels short on a split night.
-                        onsetTs = windowOnsetTs ?: session?.effectiveStartTs,
-                        wakeTs = windowWakeTs ?: session?.endTs,
-                        motionEpochs = motionEpochs,
-                    )
+                // #sleep-chart-style: the opt-in FILLED stepped hypnogram when the user selected it AND the
+                // night has real timestamped segments; otherwise the classic per-stage-rows timeline (the
+                // default, unchanged for everyone who doesn't switch).
+                val chartStyle = UnitPrefs.sleepChartStyle(LocalContext.current)
+                val filledSegments = display.hypnogramSegments?.takeIf { it.size >= 2 }
+                if (chartStyle == SleepChartStyle.FILLED && filledSegments != null) {
+                    ChartCard(
+                        title = uiString(R.string.l10n_sleep_screen_stage_breakdown_e9b714f9),
+                        subtitle = subtitle,
+                        trailing = durationText(s.asleep),
+                        tint = Palette.restColor,
+                        // The stepped chart carries no built-in legend (the rows ARE the legend in the
+                        // classic view), so surface the per-stage breakdown below it, like the reference.
+                        footer = { StageBreakdownRows(s) },
+                    ) {
+                        FilledHypnogram(
+                            segments = filledSegments,
+                            onsetTs = windowOnsetTs ?: session?.effectiveStartTs,
+                            wakeTs = windowWakeTs ?: session?.endTs,
+                        )
+                    }
+                } else {
+                    ChartCard(
+                        title = uiString(R.string.l10n_sleep_screen_stage_breakdown_e9b714f9),
+                        subtitle = subtitle,
+                        trailing = durationText(s.asleep),
+                        tint = Palette.restColor,
+                        footer = {},
+                    ) {
+                        StageTimeline(
+                            realSegments = real,
+                            s = s,
+                            // #345: the axis spans the WHOLE night. The group hypnogram (#364 seams) runs to
+                            // the group's last wake; labelling the axis off the session fragment's endTs cut
+                            // the clock labels short on a split night.
+                            onsetTs = windowOnsetTs ?: session?.effectiveStartTs,
+                            wakeTs = windowWakeTs ?: session?.endTs,
+                            motionEpochs = motionEpochs,
+                        )
+                    }
                 }
             } else {
                 ChartCard(

--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -210,8 +210,13 @@ internal fun FilledHypnogram(
     val endSec = (wakeTs?.toDouble()) ?: segments.maxOf { it.end }.toDouble()
     val spanSec = (endSec - originSec).coerceAtLeast(1.0)
     val intervals = remember(segments, originSec, spanSec) {
+        // Sort by start BEFORE smoothing: displaySmoothed's coalesce assumes chronological order (it
+        // bridges seams via startSec − last.endSec), exactly like the Swift Hypnogram sorts before
+        // displaySmoothed. Group segments are normally already ordered, but a fragmented-night
+        // concatenation must not be trusted to be.
         displaySmoothed(
-            segments.map { StageInterval(it.stage, it.start - originSec, it.end - originSec) },
+            segments.sortedBy { it.start }
+                .map { StageInterval(it.stage, it.start - originSec, it.end - originSec) },
             FILLED_HYPNOGRAM_SMOOTH_SEC,
         )
     }

--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -186,6 +187,119 @@ internal fun HypnogramWithAxis(
         }
     }
 }
+
+/**
+ * #sleep-chart-style — the opt-in FILLED stepped hypnogram (the WHOOP-style single chart): stages stacked
+ * by depth (Awake top → REM → Light → Deep bottom), each stage's column FILLED from its level down to the
+ * baseline, with thin vertical risers tracing the transitions and an onset · midpoint · wake time axis.
+ *
+ * Unlike the classic proportional views this plots the night's REAL timestamps, so [segments] must be the
+ * timestamped `PersistedSegment` array (`SleepModel.hypnogramSegments`); the caller only routes here when
+ * the pref is FILLED and that array is present. Sub-90s fragments are display-smoothed (shared
+ * [displaySmoothed], render-only — totals/percentages are untouched) so the night reads as a clean
+ * staircase rather than a comb. One collapsed a11y node.
+ */
+@Composable
+internal fun FilledHypnogram(
+    segments: List<PersistedSegment>,
+    onsetTs: Long?,
+    wakeTs: Long?,
+) {
+    if (segments.isEmpty()) return
+    val originSec = (onsetTs?.toDouble()) ?: segments.minOf { it.start }.toDouble()
+    val endSec = (wakeTs?.toDouble()) ?: segments.maxOf { it.end }.toDouble()
+    val spanSec = (endSec - originSec).coerceAtLeast(1.0)
+    val intervals = remember(segments, originSec, spanSec) {
+        displaySmoothed(
+            segments.map { StageInterval(it.stage, it.start - originSec, it.end - originSec) },
+            FILLED_HYPNOGRAM_SMOOTH_SEC,
+        )
+    }
+    val showsAxis = onsetTs != null && wakeTs != null
+    val axSummary = hypnogramSummaryFor(intervals)
+    Column(verticalArrangement = Arrangement.spacedBy(Metrics.space6)) {
+        Canvas(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(Metrics.compactChartHeight)
+                .semantics { contentDescription = axSummary },
+        ) {
+            val w = size.width
+            val h = size.height
+            if (w <= 0f || h <= 0f || intervals.isEmpty()) return@Canvas
+            val rowStep = h / 4f
+            fun levelY(rank: Int): Float = rowStep * (rank + 0.5f)
+            fun rankOf(stage: String): Int = when (canonicalStage(stage)) {
+                "awake" -> 0
+                "rem" -> 1
+                "light" -> 2
+                "deep" -> 3
+                else -> 2
+            }
+            fun xOf(sec: Double): Float = (w * (sec / spanSec)).toFloat().coerceIn(0f, w)
+            val radius = CornerRadius(2.dp.toPx(), 2.dp.toPx())
+
+            // Faint per-stage lane guides so height → stage reads even across gaps (mirrors the iOS lanes).
+            for (rank in 0 until 4) {
+                val y = levelY(rank)
+                drawLine(
+                    color = Palette.hairline.copy(alpha = 0.25f),
+                    start = Offset(0f, y),
+                    end = Offset(w, y),
+                    strokeWidth = 1f,
+                )
+            }
+            // Filled columns: each stage from its level DOWN to the baseline.
+            intervals.forEach { iv ->
+                val x0 = xOf(iv.startSec)
+                val x1 = xOf(iv.endSec)
+                val top = levelY(rankOf(iv.stage))
+                drawRoundRect(
+                    color = stageColorFor(iv.stage),
+                    topLeft = Offset(x0, top),
+                    size = Size((x1 - x0).coerceAtLeast(1.5f).coerceAtMost(w - x0), (h - top).coerceAtLeast(0f)),
+                    cornerRadius = radius,
+                )
+            }
+            // Connecting risers tracing the staircase between consecutive column tops.
+            for (i in 0 until intervals.size - 1) {
+                val a = intervals[i]
+                val b = intervals[i + 1]
+                val x = xOf(b.startSec)
+                drawLine(
+                    color = Palette.textTertiary.copy(alpha = 0.5f),
+                    start = Offset(x, levelY(rankOf(a.stage))),
+                    end = Offset(x, levelY(rankOf(b.stage))),
+                    strokeWidth = 1.5f,
+                    cap = StrokeCap.Round,
+                )
+            }
+            // Time-axis vertical hairlines: onset · midpoint · wake.
+            if (showsAxis) {
+                listOf(0f, 0.5f, 1f).forEach { frac ->
+                    val hx = w * frac
+                    drawLine(
+                        color = Palette.hairline,
+                        start = Offset(hx, 0f),
+                        end = Offset(hx, h),
+                        strokeWidth = 1f,
+                    )
+                }
+            }
+        }
+        if (showsAxis && onsetTs != null && wakeTs != null) {
+            ClockLabelRow(onsetTs, wakeTs)
+        }
+    }
+}
+
+/** Display-smoothing floor for [FilledHypnogram] — matches the classic timeline's STAGE_ROW_SMOOTH_SEC so
+ *  both views absorb the same sub-minute flicker. */
+private const val FILLED_HYPNOGRAM_SMOOTH_SEC = 90.0
+
+/** One-line a11y summary of the smoothed hypnogram (stage count) — the collapsed node for [FilledHypnogram]. */
+private fun hypnogramSummaryFor(intervals: List<StageInterval>): String =
+    if (intervals.isEmpty()) "Sleep stages, no data" else "Sleep stage timeline, ${intervals.size} segments"
 
 /**
  * The onset · midpoint · wake clock-label row under a night timeline. Extracted from

--- a/android/app/src/main/java/com/noop/ui/Units.kt
+++ b/android/app/src/main/java/com/noop/ui/Units.kt
@@ -109,6 +109,24 @@ enum class HrvWindow(val raw: String) {
 }
 
 /**
+ * How the Sleep tab draws the night's stage timeline (#sleep-chart-style). Display-only — no metric or
+ * stored value changes; it only picks which chart renders. Default [CLASSIC] so nobody's view changes
+ * unless they opt in.
+ */
+enum class SleepChartStyle(val raw: String) {
+    /** The long-standing per-stage-rows timeline (Awake/Light/Deep/REM each on their own track). */
+    CLASSIC("classic"),
+
+    /** A single stepped hypnogram with the stages stacked by depth and each column FILLED to the
+     *  baseline, WHOOP-style — needs the night's real timestamped segments, else falls back to CLASSIC. */
+    FILLED("filled");
+
+    companion object {
+        fun fromRaw(raw: String?): SleepChartStyle = entries.firstOrNull { it.raw == raw } ?: CLASSIC
+    }
+}
+
+/**
  * Reads the two unit preferences from [NoopPrefs] and resolves the "match the system" default for
  * temperature. SharedPreferences isn't reactive, so Compose screens read these once into remembered
  * state (exactly like the other toggles) and re-read on a recomposition triggered by the Settings write.
@@ -164,6 +182,18 @@ object UnitPrefs {
     /** Persist the nightly-HRV window. Changing it re-scores + re-baselines (the value itself moves). */
     fun setHrvWindow(context: Context, window: HrvWindow) {
         NoopPrefs.of(context).edit().putString(KEY_HRV_WINDOW, window.raw).apply()
+    }
+
+    /** SharedPreferences key for the Sleep tab's stage-chart style (#sleep-chart-style). */
+    const val KEY_SLEEP_CHART_STYLE = "sleep.chart.style"
+
+    /** The Sleep stage-chart style (default CLASSIC per-stage rows). Display-only. */
+    fun sleepChartStyle(context: Context): SleepChartStyle =
+        SleepChartStyle.fromRaw(NoopPrefs.of(context).getString(KEY_SLEEP_CHART_STYLE, null))
+
+    /** Persist the Sleep stage-chart style. Display-only — no re-score. */
+    fun setSleepChartStyle(context: Context, style: SleepChartStyle) {
+        NoopPrefs.of(context).edit().putString(KEY_SLEEP_CHART_STYLE, style.raw).apply()
     }
 }
 


### PR DESCRIPTION
Adds an opt-in **FILLED stepped hypnogram** to the Sleep tab (the requested reference look) with a **toggle back to the classic view** — Android only for now.

## What
**Settings → "Sleep chart"** pill: **Classic** (default) / **Filled**.
- **Classic** — the current per-stage-rows timeline, unchanged for everyone.
- **Filled** — a single stepped hypnogram: stages stacked by depth (Awake top → REM → Light → Deep bottom), each stage's column **filled to the baseline**, thin vertical **risers** tracing transitions, onset·mid·wake **time axis**, and the per-stage breakdown as the legend below.

Default is **Classic**, so nobody's view changes unless they switch; flipping the pill back to Classic is the "old graph" toggle.

## How
The reference is a **real time-ordered** hypnogram, so it needs the night's timestamped segments. That data already existed (`HeroNight.groupSegments` / the session's `stagesJSON`) but was **flattened to `(stage, minutes)` weights** before reaching the card. This threads the timestamped `PersistedSegment` list through `SleepModel` + `HeroDisplay` (`hypnogramSegments`), and the new `FilledHypnogram` Canvas plots it. On a night with **no** timestamped segments it falls back to Classic automatically.

- `SleepChartStyle` pref (mirrors the existing `TrendChartStyle` pattern; `UnitPrefs.sleepChartStyle`, default `CLASSIC`).
- `FilledHypnogram` in `SleepStageBreakdownUi.kt` — filled columns + risers + axis, reusing the shared `displaySmoothed` (90 s) and `stageColorFor`.
- Stages card in `SleepScreen` branches on the pref (+ ≥2 timestamped segments).
- Settings pill in `SettingsScreen`.

## Scope / safety
- **Display-only** — no metric or stored-value change; the 90 s display-smoothing is render-only (totals/percentages untouched), same as the classic rows.
- **Android only** — the Swift `Hypnogram` (StrandDesign) already has the stepped shape and would take a small `filled` variant; that's a deliberate follow-up, not a parity gap in analytics/data.

## Verification
`compileFullDebugKotlin` + the `Sleep*` unit suites pass. Visual needs an on-device look (staging build) — hence opt-in.

Note: the Settings label/pill strings are hardcoded English for now (same as the adjacent `Bars`/`Line` trend-style pill); can be localized in a follow-up if promoted beyond testing.