### PR TITLE
ble: count empty-offload stalls toward the backfill backoff (battery)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2306,6 +2306,16 @@ class WhoopBleClient(
      *  `consecutiveAutoContinues`. */
     private var consecutiveAutoContinues = 0
 
+    /** #battery: consecutive offload sessions that handed over ZERO sensor rows — whether a clean
+     *  HISTORY_COMPLETE-empty OR an idle-timeout STALL (`result=stalled … rows=0`). Feeds BackfillPolicy's
+     *  exponential backoff so the 15-min periodic poll STOPS spinning the radio on a strap that keeps
+     *  returning nothing (a real battery drain: a capture showed ~6 empty stalls/hour at the 15-min floor
+     *  with no backoff, because only HISTORY_COMPLETE fed [emptySyncTracker]). SEPARATE from that tracker —
+     *  which stays console-only-specific for the clock-lost banner — so counting stalls here can never
+     *  falsely fire that banner. Any banked rows reset it; the productive auto-continue tail doesn't count.
+     *  Main-looper only. */
+    private var consecutiveEmptyOffloads = 0
+
     /** #364 spin-detector: the trim cursor as of the END of the PREVIOUS backfill session this
      *  connection. [exitBackfilling] compares Backfiller.lastAckedTrim against this to decide whether the
      *  just-ended session advanced the strap's trim (progress) or froze (stop re-kicking). null until the
@@ -6510,7 +6520,10 @@ class WhoopBleClient(
                 trigger = trigger,
                 nowSeconds = System.currentTimeMillis() / 1000.0,
                 lastBackfillAtSeconds = lastBackfillAtMs?.let { it / 1000.0 },
-                emptyStreak = emptySyncTracker.consecutiveEmptySyncs,
+                // #battery: back off on EITHER a console-only streak (clock-lost, [emptySyncTracker]) OR a
+                // plain empty-offload streak incl. idle-timeout stalls ([consecutiveEmptyOffloads]); the
+                // latter is what stops the 15-min radio poll spinning on a caught-up strap.
+                emptyStreak = maxOf(emptySyncTracker.consecutiveEmptySyncs, consecutiveEmptyOffloads),
                 clockUntrusted = clockUntrusted,
             )
         ) {
@@ -6732,6 +6745,16 @@ class WhoopBleClient(
                 "Backfill: completed but the strap banked no sensor history ($detail); " +
                     "consecutive empty syncs = ${emptySyncTracker.consecutiveEmptySyncs}.",
             )
+        }
+        // #battery: maintain the empty-offload backoff counter (see [consecutiveEmptyOffloads]). A 0-row
+        // session — clean HISTORY_COMPLETE-empty OR an idle-timeout STALL — means there was nothing new to
+        // fetch, so let BackfillPolicy stretch the next PERIODIC/STRAP poll instead of re-spinning the radio
+        // in 15 min. Any banked rows reset it; a productive auto-continue tail (an earlier session in the
+        // burst already banked) neither counts nor resets.
+        consecutiveEmptyOffloads = when {
+            backfiller.sessionRowsPersisted > 0 -> 0
+            productiveBurstTail -> consecutiveEmptyOffloads
+            else -> consecutiveEmptyOffloads + 1
         }
         // #324/#928: a strap whose newest banked record is dated in the FUTURE (RTC relatched ahead) is
         // future-dated regardless of HOW this offload ended — a deep future-dated backlog TIMES OUT as


### PR DESCRIPTION
## Symptom (from a real capture)
A phone-battery capture (WHOOP 4.0, **~5.4 %/hr background drain**, phone cooling so not screen) shows NOOP spinning up a historical offload every ~15 min that **stalls empty**, six times in an hour:
```
19:51  offload result=stalled (idle timeout, rows=0)
19:56  offload result=stalled (idle timeout, rows=0)
20:10  offload result=stalled (idle timeout, rows=0)
20:22  offload result=stalled (idle timeout, rows=0)
20:34  offload result=stalled (idle timeout, rows=0)
21:00  offload result=complete rows=19429      ← finally releases the backlog
```
Each stall holds the radio open for the **60 s idle timeout** before giving up — with **no backoff** — so the poll spins on a strap handing over nothing.

## Root cause
`BackfillPolicy` **already** has an exponential empty-streak backoff (PERIODIC/STRAP floors stretch past `EMPTY_BACKOFF_THRESHOLD`). But its input, `emptySyncTracker.consecutiveEmptySyncs`, is incremented **only on a `HISTORY_COMPLETE` that banked nothing** (line 6722). An idle-timeout **stall** (`reason="timeout", rows=0`) never fed it, so the backoff never engaged.

## Fix
A dedicated **`consecutiveEmptyOffloads`** counter: incremented whenever a session ends with **zero sensor rows** (clean HISTORY_COMPLETE-empty *or* a stall), reset on any banked rows, and not counting the productive auto-continue tail. Fed (max'd with the existing console-only streak) into `BackfillPolicy.shouldRun`, so after 3 empties the periodic offload stretches **15 → 30 → 60 min** (capped). Kept **separate** from `emptySyncTracker` so counting stalls can never falsely fire the clock-lost banner.

## Trade-off (bounded, lossless)
A strap that banks new data during a backed-off window syncs slightly later — but it banks to flash (**no data loss**), the STRAP-event trigger is floored only ~6 min, and CONNECT / FOREGROUND / manual are **never** floored, so the next app-open or reconnect fetches immediately.

## Scope / validation
- **BLE-path change** → needs a **real-strap re-capture** to confirm fewer empty stalls without hurting sync latency (per CLAUDE.md; the capture that found this is exactly the validation tool).
- **Android only.** The Swift `BackfillPolicy` twin should get the same `emptyStreak`-source fix for behavioral parity — follow-up (the pure policy is unchanged, only the Android client's input).
- `compileFullDebugKotlin` + `BackfillPolicy`/offload/empty unit suites pass.

Distinct from and complementary to the dormant #477 idle-throttle and the #364 auto-continue levers.