### PR TITLE
analyze: halve the idle backstop re-score cadence to 30 min (#836 battery, both platforms)

### DIFF
--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -443,7 +443,13 @@ final class AppModel: ObservableObject {
                 // v5: recompute the skin-temp suite snapshots (cycle phase + body clock) from the
                 // freshly-scored history so the Health hub cards read a ready result.
                 await self.refreshV5Signals()
-                try? await Task.sleep(nanoseconds: 900_000_000_000)  // 15 min, matches the offload cadence
+                // #836 battery: 30-min BACKSTOP cadence (twin of Android ANALYZE_INTERVAL_MS). The
+                // `force: false` gate above can't skip while the strap streams live HR — the fingerprint
+                // advances every second — so this re-scored the whole 21-day window every 15 min even though
+                // only today's daytime HR changed. It's a pure backstop (every real update rescores via its
+                // own forced call above), so halving the cadence only delays the idle refresh of today's
+                // live Effort/steps; recovery/sleep are night-computed and unaffected.
+                try? await Task.sleep(nanoseconds: 1_800_000_000_000)  // 30 min backstop (#836 battery)
             }
         }
     }

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -2517,8 +2517,19 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     private companion object {
         /** Grace before the first scoring pass, letting the first BLE offload land. */
         const val FIRST_OFFLOAD_GRACE_MS = 6_000L
-        /** On-device scoring cadence — 15 min, matching the strap offload cadence. */
-        const val ANALYZE_INTERVAL_MS = 15 * 60 * 1_000L
+        /**
+         * On-device BACKSTOP scoring cadence — 30 min (#836 battery). This loop's watermark gate can't
+         * skip while the strap is connected and streaming live HR, because the HR fingerprint
+         * (count:maxTs) advances every second — so it re-ran a full 21-day analyzeRecent every 15 min over
+         * a large DB even though only TODAY's daytime HR changed (a real-capture CPU drain: ~6-7 full
+         * passes/hour). It is purely a BACKSTOP — every real update (sync-with-rows, import, edit,
+         * recalibrate, the #547 heal) rescores via its OWN forced path, and an app-resume kick (#386,
+         * [analyzeKick]) still wakes it EARLY the moment the user opens NOOP — so halving its cadence only
+         * delays the idle refresh of Today's live Effort/steps (recovery/sleep are night-computed and
+         * unaffected), never a real data update. Android-only tuning; the Swift AppModel loop is a parity
+         * follow-up.
+         */
+        const val ANALYZE_INTERVAL_MS = 30 * 60 * 1_000L
         /** Daily re-arm cadence for the single-instant strap firmware alarm (secondary buzz cue). */
         const val STRAP_ALARM_REARM_INTERVAL_MS = 24 * 60 * 60 * 1_000L
         /** SharedPreferences key for the persisted double-tap action (stored as the enum NAME). */


### PR DESCRIPTION
## Symptom (from the same capture)
Alongside the empty-offload radio waste (#1123), the capture shows **~6–7 full 21-day `analyzeRecent` passes in one hour** — `142 hrv diag` + `142 rhr` + `126 dayOwner` lines — each reading ~21×54 h of HR and running `analyzeDay` + the sleep stager over a **16.6 M-row DB**. That's the #836 CPU cost, and it's a real chunk of the ~5.4 %/hr drain.

## Root cause
The 15-min backstop loop (`AppViewModel`) gates the re-score on the HR-fingerprint watermark (#1120). But while the strap is **connected and streaming live HR**, that fingerprint (`count : maxTs`) **advances every second**, so the gate never skips — it re-scores the **whole 21-day window every 15 min**, even though only **today's daytime HR** changed. The other 20 days and the night-computed baseline aren't affected by daytime HR, so 20/21 of that work is redundant.

## Fix
Bump `ANALYZE_INTERVAL_MS` **15 → 30 min**. This loop is a pure **backstop**:
- every real update (**sync-with-rows, import, sleep/workout edit, recalibrate, the #547 heal**) rescores via its **own forced path** — unchanged, still immediate;
- the **#386 app-resume kick** still wakes it **early** the moment the user opens NOOP (so a killed overnight night catches up on open).

So halving the cadence only delays the *idle* refresh of Today's live Effort/steps by up to 15 min while connected. Recovery/sleep are night-computed and untouched.

## Why this is the low-risk option
Pure **time throttle**, one constant, all-or-nothing (never a partial pass) — so it can't hit the **#899 window-wide-dedup / baseline-fold data-loss trap** that day-scoping would. Roughly **halves the re-score CPU** for a UX-only cost.

## Scope
- **Android-only** tuning; the Swift `AppModel` analyze loop is a parity follow-up.
- `compileFullDebugKotlin` passes; no test pins the constant.
- Confirm via a **re-capture**: fewer `hrv diag` clusters per hour.

Battery backlog now: **#477 idle throttle** (radio, biggest, dormant) · **#1123** empty-offload backoff (radio, merged) · **this** (CPU).