### PR TITLE
sleep: smooth + seamless the filled hypnogram to match the reference

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -242,7 +242,6 @@ internal fun FilledHypnogram(
                 else -> 2
             }
             fun xOf(sec: Double): Float = (w * (sec / spanSec)).toFloat().coerceIn(0f, w)
-            val radius = CornerRadius(2.dp.toPx(), 2.dp.toPx())
 
             // Faint per-stage lane guides so height → stage reads even across gaps (mirrors the iOS lanes).
             for (rank in 0 until 4) {
@@ -254,16 +253,17 @@ internal fun FilledHypnogram(
                     strokeWidth = 1f,
                 )
             }
-            // Filled columns: each stage from its level DOWN to the baseline.
+            // Filled columns: each stage from its level DOWN to the baseline. Sharp rects (not rounded) so
+            // adjacent columns TILE seamlessly into one continuous staircase — the 2dp rounding left dark
+            // notch-gaps between blocks that read as a comb on a fragmented night.
             intervals.forEach { iv ->
                 val x0 = xOf(iv.startSec)
                 val x1 = xOf(iv.endSec)
                 val top = levelY(rankOf(iv.stage))
-                drawRoundRect(
+                drawRect(
                     color = stageColorFor(iv.stage),
                     topLeft = Offset(x0, top),
                     size = Size((x1 - x0).coerceAtLeast(1.5f).coerceAtMost(w - x0), (h - top).coerceAtLeast(0f)),
-                    cornerRadius = radius,
                 )
             }
             // Connecting risers tracing the staircase between consecutive column tops.
@@ -298,9 +298,11 @@ internal fun FilledHypnogram(
     }
 }
 
-/** Display-smoothing floor for [FilledHypnogram] — matches the classic timeline's STAGE_ROW_SMOOTH_SEC so
- *  both views absorb the same sub-minute flicker. */
-private const val FILLED_HYPNOGRAM_SMOOTH_SEC = 90.0
+/** Display-smoothing floor for [FilledHypnogram] — 5 min, matching the WHOOP-style Swift `Hypnogram`
+ *  default (not the classic rows' 90s). The stepped single-chart view reads as a comb of thin spikes on a
+ *  fragmented / under-detected night unless brief fragments coalesce into legible blocks; render-only, so
+ *  totals/percentages are untouched. */
+private const val FILLED_HYPNOGRAM_SMOOTH_SEC = 300.0
 
 /** One-line a11y summary of the smoothed hypnogram (stage count) — the collapsed node for [FilledHypnogram]. */
 private fun hypnogramSummaryFor(intervals: List<StageInterval>): String =


### PR DESCRIPTION
First on-device look at the FILLED sleep chart (#1122) vs the reference: mine came out as a **comb of thin spikes with dark gaps** where the reference is a **clean continuous staircase**. Two render causes:

1. **Under-smoothed** — it used **90 s** (the classic rows' floor). The stepped single-chart view needs the WHOOP-style **5-min** coalescing (the Swift `Hypnogram` default), or a fragmented / under-detected night (like the test night: *"little motion, under-detected"*) renders every sub-minute flicker as a thin spike. → `FILLED_HYPNOGRAM_SMOOTH_SEC` **90 → 300**.
2. **Notch-gaps** — the 2 dp rounded corners on every column left dark gaps between abutting blocks (a comb on a fragmented night). → draw **sharp rects** so adjacent columns tile into one continuous fill.

Both are render-only — totals/percentages untouched.

Android-only (the filled chart is Android). `compileFullDebugKotlin` passes; the visual wants an on-device re-check on the next staging build.

Follow-up to #1122; the toggle-back-to-classic is unchanged.