### PR TITLE
fix(oura): gate RSA respiration to no-data when the R-R stream is banked

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -429,10 +429,10 @@ public enum HRVAnalyzer {
     /// is counted as not time-accurate. Whole-second `ts` against a sub-second interval means an honest
     /// stream still rounds, so this is deliberately loose.
     ///
-    /// Mirrors the constants the respiration gate uses for the SAME judgement (#882/#883). They are
-    /// duplicated rather than shared because that gate lives in `SleepStager` on a branch that is not
-    /// upstream; if it lands, the two should collapse onto this one definition — the boundary is worth
-    /// drawing once, in one place, for both.
+    /// Shared with the RSA respiration gate (#882/#883), which asks the SAME question of the same stream
+    /// and calls `beatAccurateFraction` / `beatValuesAreTrustworthy` directly rather than keeping its own
+    /// copy. One boundary, drawn once, in one place, for both — which is what makes a threshold change
+    /// here move respiration and SDNN together instead of letting them drift apart.
     public static let beatAccuracyToleranceS: Double = 0.5
 
     /// Fraction of beats that must be time-accurate before BEAT-VALUE statistics are trusted.

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -1560,6 +1560,43 @@ public enum SleepStager {
         let inBedRows = rr.filter { $0.ts >= start && $0.ts <= end }
             .sortedByTsStable()
             .filter { Double($0.rrMs) >= HRVAnalyzer.rrMinMs && Double($0.rrMs) <= HRVAnalyzer.rrMaxMs }
+
+        // Beat-accuracy gate (#882/#883): RSA needs per-beat-accurate TIMING - each row's wall-clock gap
+        // must be ≈ its own R-R value. A BANKED stream (an Oura overnight IBI stamps a whole record of
+        // intervals on one coarse ring-time) fails this, and the estimate it produces is not physiology;
+        // return NaN instead. Beat-accurate callers (WHOOP R-R, the synthetic RSA fixtures) measure ~100%
+        // and pass unchanged. Needs a few beats to judge; below that the count gate below handles it.
+        //
+        // Shares HRVAnalyzer's ONE definition of the judgement (#1108) rather than keeping a second copy:
+        // "is each stored interval a real beat-to-beat measurement?" is the same question SDNN asks, and
+        // one boundary deserves one set of constants. `rangeFilter` has already run, so an out-of-range
+        // R-R cannot fail the accuracy test spuriously.
+        //
+        // WHAT THIS ACTUALLY CATCHES, measured (2026-08-07, two Oura nights, 31,460 and 30,754 in-bed
+        // beats, fraction 0.0246 / 0.0235): NOT a corrupted time AXIS - the ring's records tile the night,
+        // sum(R-R) over wall span is 1.030 / 1.008, so beat-time reconstructs the night to 1-3%. What is
+        // unusable is the interval VALUES: the ring decomposes each ~6.6 s record into ~6 intervals whose
+        // SUM is right to ~1% while the individual values are not beat-to-beat measurements (the same
+        // decomposition documented on `HRVAnalyzer.beatValuesAreTrustworthy`). RSA reads the beat-to-beat
+        // variation, so it has nothing to read, and the peak-picker returns its own floor: on both nights
+        // the ungated estimate is 13.33 bpm, and SHUFFLING or REVERSING the night's R-R values returns the
+        // SAME 13.3333 to four decimals. It is a plausible-looking number carrying zero information -
+        // squarely inside `respPlausibleRangeBpm`, so the range clamp below never sees it. That is why the
+        // gate is on BANKED-ness rather than on the output value.
+        //
+        // DISTINCT FROM #977's splice skip below, and BOTH are needed - they catch opposite banking
+        // GEOMETRIES. #977 catches banking that TILES time (the real ring: a ~7 s record boundary against a
+        // ~1.1 s interval reads as a splice, and on those two nights it independently discards 113/113 and
+        // 114/114 windows). This catches banking that COMPRESSES time - `testRespRateFromRRBatchedTimestamps`
+        // stamps 6 beats per single second, so no gap ever exceeds `rsaGapToleranceS` and the splice skip
+        // never fires. Neither subsumes the other; a firmware that changes its record period moves a stream
+        // from one geometry to the other without warning.
+        if inBedRows.count >= 30 {
+            let fraction = HRVAnalyzer.beatAccurateFraction(tsSec: inBedRows.map { $0.ts },
+                                                            rrMs: inBedRows.map { Double($0.rrMs) })
+            if !HRVAnalyzer.beatValuesAreTrustworthy(beatAccurateFraction: fraction) { return nan }
+        }
+
         let filtered = inBedRows.map { Double($0.rrMs) }
         if filtered.count < 30 { return nan }  // need enough beats for any RSA estimate
 

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RespRateRsaTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RespRateRsaTests.swift
@@ -57,6 +57,142 @@ final class RespRateRsaTests: XCTestCase {
         XCTAssertLessThan(est, 16.0, "resp estimate must not be doubled toward ~22 (#958)")
     }
 
+    /// A banked/batched R-R stream whose timestamps are NOT beat-accurate (an Oura overnight IBI stamps
+    /// many beats at one coarse ring-time) must return NaN — RSA is a frequency-domain method and cannot
+    /// recover breathing from a corrupted time axis, so the honest answer is no-data, not a wrong ~8 bpm.
+    /// Same R-R VALUES as the recovering test, only the TIMESTAMPS are batched.
+    func testRespRateFromRRBatchedTimestampsIsNaN() {
+        let breathHz = 0.25
+        let baseRrMs = 1000.0, ampMs = 40.0
+        let start = 1_700_000_000
+        var rows: [RRInterval] = []
+        var tSec = 0.0
+        var beat = 0
+        while tSec < 600.0 {
+            let rrMs = baseRrMs + ampMs * sin(2.0 * Double.pi * breathHz * tSec)
+            tSec += rrMs / 1000.0
+            // Batched stamp: 6 beats share one coarse second, then jump — like a banked-IBI record.
+            // The wall-clock gap (mostly 0) no longer matches the ~1 s R-R value.
+            rows.append(RRInterval(ts: start + (beat / 6), rrMs: Int(rrMs)))
+            beat += 1
+        }
+        let est = SleepStager.respRateFromRR(rows, start: start, end: start + 600)
+        XCTAssertTrue(est.isNaN, "batched (non-beat-accurate) timestamps must gate to NaN, got \(est)")
+    }
+
+    /// The gate is on BANKED-ness, not on the output value — because the value a banked stream produces
+    /// is PLAUSIBLE. Measured on two real Oura nights (2026-08-07): ungated, both return 13.33 bpm, which
+    /// sits squarely inside `respPlausibleRangeBpm`, so the range clamp is no protection at all. This
+    /// reproduces that regime synthetically: banked timestamps over R-R values carrying NO breathing
+    /// modulation at all still yield a finite, physiological-looking rate once the gate is bypassed.
+    ///
+    /// Guards against "just widen the plausible band" or "just check the number looks sane" as an
+    /// alternative to the gate: neither can see this failure.
+    func testBankedStreamWithoutBreathingStillLooksPlausibleUngated() {
+        // Flat R-R + small pseudo-random jitter: zero RSA content by construction.
+        let start = 1_700_000_000
+        var rows: [RRInterval] = []
+        var seed = UInt64(12345)
+        var beat = 0
+        var tSec = 0.0
+        while tSec < 900.0 {
+            seed = seed &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+            let jitter = Double(Int(truncatingIfNeeded: seed >> 33) % 120)
+            let rrMs = 1000.0 + jitter
+            tSec += rrMs / 1000.0
+            // Banked exactly as the ring does: ~6 beats share one record timestamp.
+            rows.append(RRInterval(ts: start + (beat / 6) * 6, rrMs: Int(rrMs)))
+            beat += 1
+        }
+        let fraction = HRVAnalyzer.beatAccurateFraction(tsSec: rows.map { $0.ts },
+                                                       rrMs: rows.map { Double($0.rrMs) })
+        XCTAssertFalse(HRVAnalyzer.beatValuesAreTrustworthy(beatAccurateFraction: fraction),
+                       "fixture must be banked; measured fraction \(fraction)")
+        // The shipped path refuses it — which is the whole point.
+        XCTAssertTrue(SleepStager.respRateFromRR(rows, start: start, end: start + 900).isNaN)
+    }
+
+    /// The gate and #977's splice skip catch OPPOSITE banking geometries, so neither subsumes the other.
+    /// This pins the half that only the gate can catch: banking that COMPRESSES time (6 beats stamped
+    /// inside one second) never produces a wall-clock gap above `rsaGapToleranceS`, so no window ever
+    /// looks spliced. On the real ring the geometry is the other one — records TILE time, every record
+    /// boundary reads as a splice — which is why both protections are kept.
+    func testCompressedBankingProducesNoSplicesSoOnlyTheGateCatchesIt() {
+        let breathHz = 0.25, baseRrMs = 1000.0, ampMs = 40.0
+        let start = 1_700_000_000
+        var rows: [RRInterval] = []
+        var tSec = 0.0, beat = 0
+        while tSec < 600.0 {
+            let rrMs = baseRrMs + ampMs * sin(2.0 * Double.pi * breathHz * tSec)
+            tSec += rrMs / 1000.0
+            rows.append(RRInterval(ts: start + (beat / 6), rrMs: Int(rrMs)))
+            beat += 1
+        }
+        // No consecutive pair exceeds the splice tolerance: the wall clock never outruns the beats here,
+        // it LAGS them. So #977's mechanism is blind to this stream and the gate is the only defence.
+        var maxOverrun = 0.0
+        for i in 1..<rows.count {
+            let gapS: Double = Double(rows[i].ts - rows[i - 1].ts)
+            let rrS: Double = Double(rows[i].rrMs) / 1000.0
+            maxOverrun = max(maxOverrun, gapS - rrS)
+        }
+        XCTAssertLessThan(maxOverrun, SleepStager.rsaGapToleranceS,
+                          "compressed banking must not register as a splice, else this proves nothing")
+        XCTAssertTrue(SleepStager.respRateFromRR(rows, start: start, end: start + 600).isNaN)
+    }
+
+    /// KNOWN LIMITATION, pinned deliberately so the next person does not walk into it.
+    ///
+    /// The gate detects BANKING by its symptom — coarse, repeated timestamps. That symptom is a
+    /// TRANSPORT artifact and is trivially repairable: give each beat in a record `recordTs + cumsum` of
+    /// that record's own intervals and the stream looks beat-accurate again. Measured on the two real
+    /// Oura nights (2026-08-07), re-timing moves `beatAccurateFraction` 0.0246 / 0.0235 -> 0.875 / 0.863,
+    /// so it sails through this gate AND through #977's splice skip — and the estimate it then yields is
+    /// still 13.3333 bpm, still unchanged when the R-R values are shuffled. Re-timing repairs the axis;
+    /// it does not repair the VALUES, which is where the fault actually is.
+    ///
+    /// So: a well-intentioned decoder change that distributes beat timestamps within a record would
+    /// silently switch respiration back on for a stream that carries no breathing information. If that
+    /// change is ever made, this gate must move with it — onto provenance (was this stream banked?)
+    /// rather than onto timestamp shape. This test fails the day someone re-times, which is the point.
+    func testRetimingABankedStreamDefeatsTheGate_knownLimitation() {
+        let start = 1_700_000_000
+        var banked: [RRInterval] = []
+        var seed = UInt64(999)
+        var beat = 0
+        while beat < 600 {
+            seed = seed &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+            let rrMs = 1000 + Int(truncatingIfNeeded: seed >> 33) % 120
+            banked.append(RRInterval(ts: start + (beat / 6) * 6, rrMs: rrMs))
+            beat += 1
+        }
+        let bankedFraction = HRVAnalyzer.beatAccurateFraction(tsSec: banked.map { $0.ts },
+                                                             rrMs: banked.map { Double($0.rrMs) })
+        XCTAssertFalse(HRVAnalyzer.beatValuesAreTrustworthy(beatAccurateFraction: bankedFraction),
+                       "as stored, the banked stream must be refused")
+
+        // Re-time: each record's beats laid out from the record's own timestamp by cumulative sum.
+        var retimed: [RRInterval] = []
+        var i = 0
+        while i < banked.count {
+            let recordTs = banked[i].ts
+            var offset = 0.0
+            var j = i
+            while j < banked.count && banked[j].ts == recordTs {
+                retimed.append(RRInterval(ts: recordTs + Int(offset.rounded()), rrMs: banked[j].rrMs))
+                offset += Double(banked[j].rrMs) / 1000.0
+                j += 1
+            }
+            i = j
+        }
+        let retimedFraction = HRVAnalyzer.beatAccurateFraction(tsSec: retimed.map { $0.ts },
+                                                              rrMs: retimed.map { Double($0.rrMs) })
+        XCTAssertTrue(HRVAnalyzer.beatValuesAreTrustworthy(beatAccurateFraction: retimedFraction),
+                      "re-timing is expected to DEFEAT this gate (measured 0.875/0.863 on real nights); "
+                      + "got \(retimedFraction). If this now fails, the decoder changed and the gate "
+                      + "must be re-based on provenance, not on timestamp shape.")
+    }
+
     func testRespRateFromRRTooFewBeatsIsNaN() {
         let start = 1_700_000_000
         let rows = [

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -415,6 +415,11 @@ object HrvAnalyzer {
      * Tolerance (seconds) allowed between a beat's wall-clock gap and its own R-R value before the beat
      * is counted as not time-accurate. Whole-second `ts` against a sub-second interval means an honest
      * stream still rounds, so this is deliberately loose. Twin of Swift `beatAccuracyToleranceS`.
+     *
+     * Shared with the RSA respiration gate (#882/#883), which asks the SAME question of the same stream
+     * and calls [beatAccurateFraction] / [beatValuesAreTrustworthy] directly rather than keeping its own
+     * copy. One boundary, drawn once, in one place, for both — which is what makes a threshold change
+     * here move respiration and SDNN together instead of letting them drift apart.
      */
     const val BEAT_ACCURACY_TOLERANCE_S: Double = 0.5
 

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -1604,7 +1604,7 @@ object SleepStager {
      * enough that only an unambiguous dropout trips it, and deliberately not tuned to a corpus.
      * Byte-parity twin of Swift `rsaGapToleranceS`.
      */
-    private const val rsaGapToleranceS: Double = 3.0
+    internal const val rsaGapToleranceS: Double = 3.0
 
     /** Physiologic breath-interval band (seconds): 0.1–0.4 Hz = 6–24 breaths/min. */
     private const val rsaMinBreathIntervalS: Double = 2.5  // 24 bpm
@@ -1664,6 +1664,43 @@ object SleepStager {
             .sortedBy { it.ts }
             .filter { it.rrMs.toDouble() >= HrvAnalyzer.RR_MIN_MS && it.rrMs.toDouble() <= HrvAnalyzer.RR_MAX_MS }
             .toList()
+
+        // Beat-accuracy gate (#882/#883): RSA needs per-beat-accurate TIMING - each row's wall-clock gap
+        // must be ≈ its own R-R value. A BANKED stream (an Oura overnight IBI stamps a whole record of
+        // intervals on one coarse ring-time) fails this, and the estimate it produces is not physiology;
+        // return NaN instead. Beat-accurate callers (WHOOP R-R, the synthetic RSA fixtures) measure ~100%
+        // and pass unchanged. Needs a few beats to judge; below that the count gate below handles it.
+        //
+        // Shares HrvAnalyzer's ONE definition of the judgement (#1108) rather than keeping a second copy:
+        // "is each stored interval a real beat-to-beat measurement?" is the same question SDNN asks, and
+        // one boundary deserves one set of constants. The range filter has already run, so an out-of-range
+        // R-R cannot fail the accuracy test spuriously.
+        //
+        // WHAT THIS ACTUALLY CATCHES, measured (2026-08-07, two Oura nights, 31,460 and 30,754 in-bed
+        // beats, fraction 0.0246 / 0.0235): NOT a corrupted time AXIS - the ring's records tile the night,
+        // sum(R-R) over wall span is 1.030 / 1.008, so beat-time reconstructs the night to 1-3%. What is
+        // unusable is the interval VALUES: the ring decomposes each ~6.6 s record into ~6 intervals whose
+        // SUM is right to ~1% while the individual values are not beat-to-beat measurements (the same
+        // decomposition documented on HrvAnalyzer.beatValuesAreTrustworthy). RSA reads the beat-to-beat
+        // variation, so it has nothing to read, and the peak-picker returns its own floor: on both nights
+        // the ungated estimate is 13.33 bpm, and SHUFFLING or REVERSING the night's R-R values returns the
+        // SAME 13.3333 to four decimals. It is a plausible-looking number carrying zero information -
+        // squarely inside respPlausibleRangeBpm, so the range clamp below never sees it. That is why the
+        // gate is on BANKED-ness rather than on the output value.
+        //
+        // DISTINCT FROM #977's splice skip below, and BOTH are needed - they catch opposite banking
+        // GEOMETRIES. #977 catches banking that TILES time (the real ring: a ~7 s record boundary against a
+        // ~1.1 s interval reads as a splice, and on those two nights it independently discards 113/113 and
+        // 114/114 windows). This catches banking that COMPRESSES time - respRateFromRR_batchedTimestampsIsNaN
+        // stamps 6 beats per single second, so no gap ever exceeds rsaGapToleranceS and the splice skip
+        // never fires. Neither subsumes the other; a firmware that changes its record period moves a stream
+        // from one geometry to the other without warning. Byte-identical twin of the Swift gate.
+        if (inBedRows.size >= 30) {
+            val fraction = HrvAnalyzer.beatAccurateFraction(
+                inBedRows.map { it.ts }, inBedRows.map { it.rrMs.toDouble() })
+            if (!HrvAnalyzer.beatValuesAreTrustworthy(fraction)) return nan
+        }
+
         val filtered = inBedRows.map { it.rrMs.toDouble() }
         if (filtered.size < 30) return nan // need enough beats for any RSA estimate
 

--- a/android/app/src/test/java/com/noop/analytics/RespRateRsaTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RespRateRsaTest.kt
@@ -72,6 +72,140 @@ class RespRateRsaTest {
     }
 
     @Test
+    fun respRateFromRR_batchedTimestampsIsNaN() {
+        // A banked/batched R-R stream whose timestamps are NOT beat-accurate (an Oura overnight IBI stamps
+        // many beats at one coarse ring-time) must return NaN — RSA cannot recover breathing from a
+        // corrupted time axis. Same R-R VALUES as the recovering test, only the TIMESTAMPS are batched.
+        val breathHz = 0.25
+        val baseRrMs = 1000.0
+        val ampMs = 40.0
+        val start = 1_700_000_000L
+        val rows = ArrayList<RrInterval>()
+        var tSec = 0.0
+        var beat = 0
+        while (tSec < 600.0) {
+            val rrMs = baseRrMs + ampMs * Math.sin(2.0 * Math.PI * breathHz * tSec)
+            tSec += rrMs / 1000.0
+            // Batched stamp: 6 beats share one coarse second, then jump — like a banked-IBI record.
+            rows.add(RrInterval(deviceId = "test", ts = start + (beat / 6).toLong(), rrMs = rrMs.toInt()))
+            beat++
+        }
+        val est = SleepStager.respRateFromRR(rows, start, start + 600)
+        assertTrue("batched (non-beat-accurate) timestamps must gate to NaN, got $est", est.isNaN())
+    }
+
+    @Test
+    fun respRateFromRR_bankedStreamWithoutBreathingStillLooksPlausibleUngated() {
+        // The gate is on BANKED-ness, not on the output value — because the value a banked stream
+        // produces is PLAUSIBLE. Measured on two real Oura nights (2026-08-07): ungated, both return
+        // 13.33 bpm, squarely inside respPlausibleRangeBpm, so the range clamp is no protection at all.
+        // Here: banked timestamps over R-R values with NO breathing modulation by construction.
+        // Guards against "just widen the plausible band" as an alternative to the gate.
+        val start = 1_700_000_000L
+        val rows = ArrayList<RrInterval>()
+        var seed = 12345L
+        var beat = 0
+        var tSec = 0.0
+        while (tSec < 900.0) {
+            seed = seed * 6_364_136_223_846_793_005L + 1_442_695_040_888_963_407L
+            val jitter = ((seed ushr 33) % 120L).toDouble()
+            val rrMs = 1000.0 + jitter
+            tSec += rrMs / 1000.0
+            // Banked exactly as the ring does: ~6 beats share one record timestamp.
+            rows.add(RrInterval(deviceId = "test", ts = start + (beat / 6) * 6L, rrMs = rrMs.toInt()))
+            beat++
+        }
+        val fraction = HrvAnalyzer.beatAccurateFraction(rows.map { it.ts }, rows.map { it.rrMs.toDouble() })
+        assertTrue("fixture must be banked; measured fraction $fraction",
+            !HrvAnalyzer.beatValuesAreTrustworthy(fraction))
+        assertTrue(SleepStager.respRateFromRR(rows, start, start + 900).isNaN())
+    }
+
+    @Test
+    fun respRateFromRR_compressedBankingProducesNoSplicesSoOnlyTheGateCatchesIt() {
+        // The gate and #977's splice skip catch OPPOSITE banking geometries, so neither subsumes the
+        // other. This pins the half only the gate can catch: banking that COMPRESSES time (6 beats in one
+        // second) never produces a wall-clock gap above rsaGapToleranceS, so no window looks spliced. On
+        // the real ring the geometry is the other one — records TILE time and every boundary reads as a
+        // splice — which is why both protections are kept.
+        val breathHz = 0.25
+        val baseRrMs = 1000.0
+        val ampMs = 40.0
+        val start = 1_700_000_000L
+        val rows = ArrayList<RrInterval>()
+        var tSec = 0.0
+        var beat = 0
+        while (tSec < 600.0) {
+            val rrMs = baseRrMs + ampMs * Math.sin(2.0 * Math.PI * breathHz * tSec)
+            tSec += rrMs / 1000.0
+            rows.add(RrInterval(deviceId = "test", ts = start + (beat / 6).toLong(), rrMs = rrMs.toInt()))
+            beat++
+        }
+        var maxOverrun = 0.0
+        for (i in 1 until rows.size) {
+            val gapS = (rows[i].ts - rows[i - 1].ts).toDouble()
+            maxOverrun = kotlin.math.max(maxOverrun, gapS - rows[i].rrMs.toDouble() / 1000.0)
+        }
+        assertTrue("compressed banking must not register as a splice, else this proves nothing",
+            maxOverrun < SleepStager.rsaGapToleranceS)
+        assertTrue(SleepStager.respRateFromRR(rows, start, start + 600).isNaN())
+    }
+
+    @Test
+    fun respRateFromRR_retimingABankedStreamDefeatsTheGate_knownLimitation() {
+        // KNOWN LIMITATION, pinned deliberately so the next person does not walk into it.
+        //
+        // The gate detects BANKING by its symptom — coarse, repeated timestamps. That symptom is a
+        // TRANSPORT artifact and is trivially repairable: give each beat in a record recordTs + cumsum of
+        // that record's own intervals and the stream looks beat-accurate again. Measured on two real Oura
+        // nights (2026-08-07), re-timing moves beatAccurateFraction 0.0246 / 0.0235 -> 0.875 / 0.863, so it
+        // sails through this gate AND #977's splice skip — and the estimate is still 13.3333 bpm, still
+        // unchanged when the R-R values are shuffled. Re-timing repairs the axis, not the VALUES.
+        //
+        // A well-intentioned decoder change that distributes beat timestamps within a record would
+        // silently switch respiration back on for a stream carrying no breathing information. If that
+        // change is made, this gate must move onto provenance (was this stream banked?) rather than onto
+        // timestamp shape. This test fails the day someone re-times, which is the point.
+        val start = 1_700_000_000L
+        val banked = ArrayList<RrInterval>()
+        var seed = 999L
+        var beat = 0
+        while (beat < 600) {
+            seed = seed * 6_364_136_223_846_793_005L + 1_442_695_040_888_963_407L
+            val rrMs = 1000 + ((seed ushr 33) % 120L).toInt()
+            banked.add(RrInterval(deviceId = "test", ts = start + (beat / 6) * 6L, rrMs = rrMs))
+            beat++
+        }
+        val bankedFraction = HrvAnalyzer.beatAccurateFraction(
+            banked.map { it.ts }, banked.map { it.rrMs.toDouble() })
+        assertTrue("as stored, the banked stream must be refused",
+            !HrvAnalyzer.beatValuesAreTrustworthy(bankedFraction))
+
+        // Re-time: each record's beats laid out from the record's own timestamp by cumulative sum.
+        val retimed = ArrayList<RrInterval>()
+        var i = 0
+        while (i < banked.size) {
+            val recordTs = banked[i].ts
+            var offset = 0.0
+            var j = i
+            while (j < banked.size && banked[j].ts == recordTs) {
+                retimed.add(RrInterval(deviceId = "test",
+                    ts = recordTs + Math.round(offset), rrMs = banked[j].rrMs))
+                offset += banked[j].rrMs.toDouble() / 1000.0
+                j++
+            }
+            i = j
+        }
+        val retimedFraction = HrvAnalyzer.beatAccurateFraction(
+            retimed.map { it.ts }, retimed.map { it.rrMs.toDouble() })
+        assertTrue(
+            "re-timing is expected to DEFEAT this gate (measured 0.875/0.863 on real nights); got " +
+                "$retimedFraction. If this now fails, the decoder changed and the gate must be re-based " +
+                "on provenance, not on timestamp shape.",
+            HrvAnalyzer.beatValuesAreTrustworthy(retimedFraction))
+    }
+
+    @Test
     fun respRateFromRR_tooFewBeatsIsNaN() {
         val start = 1_700_000_000L
         val rows = listOf(


### PR DESCRIPTION

Re-land of #883, which was closed in the 2026-07-31 batch rather than on merit. Reworked onto
`HRVAnalyzer.beatAccurateFraction` (#1108 landed the canonical definition after #883 was written), and
re-validated on two fresh nights — which corrected the original writeup in three places.

## The problem

An Oura night reports a respiratory rate that looks entirely normal, while a WHOOP strap worn on the
same nights measures ~16.4. Respiration is derived by RSA from the R-R stream, and the ring's banked
overnight IBI cannot support RSA: it stores R-R **values** against coarse per-record timestamps, so the
beat-to-beat variation RSA reads is not in the data.

## The fix

`respRateFromRR` (both platforms) refuses a stream that is not beat-accurate, calling
`HRVAnalyzer.beatAccurateFraction` / `beatValuesAreTrustworthy` instead of carrying a second copy of the
same judgement and its two constants. That is the collapse #1108's body promised — one boundary, one
definition, so a threshold change moves respiration and SDNN together instead of letting them drift.
WHOOP R-R and the synthetic RSA fixtures measure ~100% and pass unchanged.

## Measured, 2026-08-07, two real nights

31,460 and 30,754 in-bed beats, through the **real** `SleepStager.respRateFromRR` (temporary probe
against `Packages/StrandAnalytics`), plus a port validated against it — both synthetic fixtures
reproduce (15.0000 / 10.9091) and both nights reproduce NaN — used to switch the gate off, since the
Swift constants are `static let`.

| | Night 1 (08-05→08-06) | Night 2 (08-06→08-07) |
|---|---|---|
| `beatAccurateFraction` | **0.0246** | **0.0235** |
| shipped path | **NaN** | **NaN** |
| gate OFF, splice-skip ON | NaN | NaN |
| both disabled | **13.33 bpm** | **13.33 bpm** |

### Three corrections to the original #883 writeup — all of which strengthen it

**1. The number is 13.33, not "~7–10".** It sits inside `respPlausibleRangeBpm` (8–25) *and* inside the
real adult sleeping range, so the range clamp is no protection whatsoever. Only **1 of 113** and **0 of
114** windows fall below 10 bpm. This also answers @vishk23's reading in
[#883 (comment)](https://github.com/ryanbr/noop/pull/883#issuecomment-5100465954) — the exposed band is
not 8–10 with the sub-8 part already clamped; it is dead centre. Everything else in that comment holds,
and the consequence chain it traced (Charge inflation via the lower-is-better recovery term →
contaminated `"resp"` baseline → second-order illness FP, no same-night false positive) is the right
one. It is just worse than it looked: a fabricated 13.3 is indistinguishable by eye from a real reading.

**2. The estimate carries zero information.** Shuffling or reversing the night's R-R values returns the
same **13.3333** to four decimals, on both nights. The tachogram's breath band is a flat 1/f shelf with
no peak (neighbouring bins at 0.86–0.96 of the maximum); 13.33 is the peak-picker's own floor on the
4 Hz grid, given its 2.5 s minimum distance. That is the #194 bar failed outright — hence a gate on
**banked-ness**, not on whether the output looks sane.

**3. The mechanism in the old comment was wrong.** The time *axis* is not corrupted: sum(R-R) over wall
span is **1.030 / 1.008**, so beat-time reconstructs the night to 1–3%. What is unusable is the interval
**values** — the ~6.6 s record decomposed into ~6 intervals whose sum is right to ~1% while the
individuals are not beat-to-beat measurements, the same decomposition already documented on
`beatValuesAreTrustworthy`. Proof: the batched fixture, run ungated, returns the *correct* 15.0, because
cumsum recovers relative beat timing. Banked timestamps alone do not break RSA.

## Why both this and #977's splice skip are kept

They catch **opposite banking geometries**, and neither subsumes the other — now pinned by a test:

- **#977 catches banking that TILES time** — the real ring. A ~7 s record boundary against a ~1.1 s
  interval reads as a splice; on these two nights it independently discards **113/113** and **114/114**
  windows. (So on this firmware the gate is the second lock. See the sequencing note below.)
- **This catches banking that COMPRESSES time** — the batched fixture stamps 6 beats per single second,
  so no gap ever exceeds `rsaGapToleranceS` and #977 is blind to it.

A firmware that changes its record period moves a stream from one geometry to the other without warning.

## Known limitation, pinned deliberately

The gate detects banking by its **symptom** — coarse, repeated timestamps — and that symptom is a
transport artifact that is trivially repairable. Re-timing each record's beats by cumsum from the
record's own timestamp moves the fraction **0.0246 / 0.0235 → 0.875 / 0.863**, defeating *both* this gate
and #977 — while the estimate stays 13.3333 and stays unchanged under shuffling. A well-meant decoder
change that distributes beat timestamps within a record would silently switch respiration back on for a
stream carrying no breathing information.

`testRetimingABankedStreamDefeatsTheGate_knownLimitation` fails the day that happens, and says what to
do: re-base the gate on **provenance** (was this stream banked?) rather than on timestamp shape.

## Sequencing vs #877

#877 is what first routes a ring night into the estimator (`detectSleep` currently bails on a
gravity-less owner, so `matched` is empty and `respRateBpm` comes out nil). Landing this first covers
that path on day one — worth doing, and free.

Honest caveat on the urgency: on **this** firmware the exposure window is empty. #977's splice skip
already returns NaN on both nights, so merging #877 first would still yield nil. The ordering is
belt-and-braces, not a live bug — but the geometry argument above is exactly why I would not rely on
that staying true.

## Verification

- Swift `StrandAnalytics` **1270 / 0** (`RespRateRsaTests` 7/7, 3 new).
- Android `compileFullDebugKotlin` clean; `testFullDebugUnitTest` **3554 tests / 3 failed** — all 3
  (`AiCoachContextTest`, 2× `StandardHrSensorFormatTest` locale) reproduce on clean `upstream/main`,
  pre-existing.
- Both platforms carry the same gate, the same constants (now via one shared definition), and the same
  four fixtures.
- Analytics-only; no BLE path touched, so no hardware behaviour changes.

## Still untested

Neither capture contains a beat-accurate R-R stream (`rrInterval` is 100% Oura; the WHOOP rows are
import-only with no R-R), so the gate's **false-positive** direction — refusing a stream it should
accept — is still covered only by the synthetic fixtures. A WHOOP night streamed rather than imported
would close that.