### PR TITLE
sleep: add a RIBBON style for the stepped hypnogram

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1099,6 +1099,9 @@ fun SettingsScreen(
                         sleepChartStyle = style
                         UnitPrefs.setSleepChartStyle(context, style)
                     },
+                    // Three segments — share the row width equally so the labels can't widen the card past
+                    // the screen (the component's own guidance for longer option sets).
+                    adaptsToAvailableWidth = true,
                 )
             }
 

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1086,9 +1086,15 @@ fun SettingsScreen(
             // changes the drawing, and it falls back to Classic on a night with no timestamped segments.
             SettingsFormRow(label = "Sleep chart") {
                 SegmentedPillControl(
-                    items = listOf(SleepChartStyle.CLASSIC, SleepChartStyle.FILLED),
+                    items = listOf(SleepChartStyle.CLASSIC, SleepChartStyle.FILLED, SleepChartStyle.RIBBON),
                     selection = sleepChartStyle,
-                    label = { if (it == SleepChartStyle.FILLED) "Filled" else "Classic" },
+                    label = {
+                        when (it) {
+                            SleepChartStyle.FILLED -> "Filled"
+                            SleepChartStyle.RIBBON -> "Ribbon"
+                            else -> "Classic"
+                        }
+                    },
                     onSelect = { style ->
                         sleepChartStyle = style
                         UnitPrefs.setSleepChartStyle(context, style)

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -1087,7 +1087,8 @@ private fun Hero(
                 // default, unchanged for everyone who doesn't switch).
                 val chartStyle = UnitPrefs.sleepChartStyle(LocalContext.current)
                 val filledSegments = display.hypnogramSegments?.takeIf { it.size >= 2 }
-                if (chartStyle == SleepChartStyle.FILLED && filledSegments != null) {
+                if ((chartStyle == SleepChartStyle.FILLED || chartStyle == SleepChartStyle.RIBBON) &&
+                    filledSegments != null) {
                     ChartCard(
                         title = uiString(R.string.l10n_sleep_screen_stage_breakdown_e9b714f9),
                         subtitle = subtitle,
@@ -1101,6 +1102,7 @@ private fun Hero(
                             segments = filledSegments,
                             onsetTs = windowOnsetTs ?: session?.effectiveStartTs,
                             wakeTs = windowWakeTs ?: session?.endTs,
+                            filled = chartStyle == SleepChartStyle.FILLED,
                         )
                     }
                 } else {

--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -204,6 +204,9 @@ internal fun FilledHypnogram(
     segments: List<PersistedSegment>,
     onsetTs: Long?,
     wakeTs: Long?,
+    // true → each stage FILLS its column to the baseline (the stepped-area look). false → a slim uniform
+    // RIBBON at each stage level (the WHOOP-style stepped line), which reads cleaner on a fragmented night.
+    filled: Boolean = true,
 ) {
     if (segments.isEmpty()) return
     val originSec = (onsetTs?.toDouble()) ?: segments.minOf { it.start }.toDouble()
@@ -253,18 +256,28 @@ internal fun FilledHypnogram(
                     strokeWidth = 1f,
                 )
             }
-            // Filled columns: each stage from its level DOWN to the baseline. Sharp rects (not rounded) so
-            // adjacent columns TILE seamlessly into one continuous staircase — the 2dp rounding left dark
-            // notch-gaps between blocks that read as a comb on a fragmented night.
+            // FILLED: each stage from its level DOWN to the baseline (sharp rects tile seamlessly into one
+            // continuous staircase). RIBBON: a slim uniform band centred at the stage level — the WHOOP-style
+            // stepped line, lighter on a fragmented night where full columns amplify the noise.
+            val ribbonThickness = 10.dp.toPx()
             intervals.forEach { iv ->
                 val x0 = xOf(iv.startSec)
                 val x1 = xOf(iv.endSec)
-                val top = levelY(rankOf(iv.stage))
-                drawRect(
-                    color = stageColorFor(iv.stage),
-                    topLeft = Offset(x0, top),
-                    size = Size((x1 - x0).coerceAtLeast(1.5f).coerceAtMost(w - x0), (h - top).coerceAtLeast(0f)),
-                )
+                val y = levelY(rankOf(iv.stage))
+                val segW = (x1 - x0).coerceAtLeast(1.5f).coerceAtMost(w - x0)
+                if (filled) {
+                    drawRect(
+                        color = stageColorFor(iv.stage),
+                        topLeft = Offset(x0, y),
+                        size = Size(segW, (h - y).coerceAtLeast(0f)),
+                    )
+                } else {
+                    drawRect(
+                        color = stageColorFor(iv.stage),
+                        topLeft = Offset(x0, y - ribbonThickness / 2f),
+                        size = Size(segW, ribbonThickness),
+                    )
+                }
             }
             // Connecting risers tracing the staircase between consecutive column tops.
             for (i in 0 until intervals.size - 1) {

--- a/android/app/src/main/java/com/noop/ui/Units.kt
+++ b/android/app/src/main/java/com/noop/ui/Units.kt
@@ -119,7 +119,11 @@ enum class SleepChartStyle(val raw: String) {
 
     /** A single stepped hypnogram with the stages stacked by depth and each column FILLED to the
      *  baseline, WHOOP-style — needs the night's real timestamped segments, else falls back to CLASSIC. */
-    FILLED("filled");
+    FILLED("filled"),
+
+    /** The same single stepped chart but drawn as a slim RIBBON (a uniform band at each stage level, not
+     *  filled to the baseline) — the WHOOP-style stepped line, which reads cleaner on a fragmented night. */
+    RIBBON("ribbon");
 
     companion object {
         fun fromRaw(raw: String?): SleepChartStyle = entries.firstOrNull { it.raw == raw } ?: CLASSIC


### PR DESCRIPTION
Adds a third **Sleep chart** option: **Classic / Filled / Ribbon**.

**Ribbon** draws the same single stepped hypnogram — real timestamped segments, stages stacked by depth, risers, time axis — but as a **slim uniform band at each stage level** instead of filling each column to the baseline (the WHOOP-style stepped *line*).

## Why
On a fragmented / under-detected night the **Filled** columns amplify the noise — heavy blocks plus dark gaps at real data holes (as seen on-device). The thin **Ribbon** traces the same staircase far more cleanly, since it's just a line at each level rather than a solid area.

## How
- `FilledHypnogram` gains a `filled` flag: `true` = columns to baseline; `false` = a 10 dp band centred at the stage level.
- The stages card routes **FILLED → filled=true**, **RIBBON → filled=false** through the same component (same real-segment gate + fallback to Classic).
- Settings becomes a **3-way pill**.

## Scope
- **Display-only**; **Classic** stays the default, so nobody's view changes unless they pick a style.
- **Android only** (the single-chart hypnogram is Android). `compileFullDebugKotlin` + i18n pass.

Follow-up to #1122/#1126; still one shared component, so future polish (gradient, legend) applies to both filled and ribbon.