### PR TITLE
sleep: responsive round-hour time axis for the stepped hypnogram

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
@@ -225,6 +227,13 @@ internal fun FilledHypnogram(
     }
     val showsAxis = onsetTs != null && wakeTs != null
     val axSummary = hypnogramSummaryFor(intervals)
+    // Responsive time axis: exact onset/wake at the edges + round-hour marks between, MORE marks on a wider
+    // screen (~one label per 90dp). Empty when the night has no clock window (no axis then).
+    val axisTicks = if (showsAxis) {
+        hypnogramAxisTicks(onsetTs!!, wakeTs!!, maxLabels = (LocalConfiguration.current.screenWidthDp / 90).coerceIn(3, 8))
+    } else {
+        emptyList()
+    }
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.space6)) {
         Canvas(
             modifier = Modifier
@@ -292,21 +301,19 @@ internal fun FilledHypnogram(
                     cap = StrokeCap.Round,
                 )
             }
-            // Time-axis vertical hairlines: onset · midpoint · wake.
-            if (showsAxis) {
-                listOf(0f, 0.5f, 1f).forEach { frac ->
-                    val hx = w * frac
-                    drawLine(
-                        color = Palette.hairline,
-                        start = Offset(hx, 0f),
-                        end = Offset(hx, h),
-                        strokeWidth = 1f,
-                    )
-                }
+            // Time-axis vertical hairlines at each label tick (onset · round hours · wake).
+            axisTicks.forEach { (frac, _) ->
+                val hx = w * frac
+                drawLine(
+                    color = Palette.hairline,
+                    start = Offset(hx, 0f),
+                    end = Offset(hx, h),
+                    strokeWidth = 1f,
+                )
             }
         }
-        if (showsAxis && onsetTs != null && wakeTs != null) {
-            ClockLabelRow(onsetTs, wakeTs)
+        if (axisTicks.isNotEmpty()) {
+            HypnogramTimeAxis(axisTicks)
         }
     }
 }
@@ -316,6 +323,60 @@ internal fun FilledHypnogram(
  *  fragmented / under-detected night unless brief fragments coalesce into legible blocks; render-only, so
  *  totals/percentages are untouched. */
 private const val FILLED_HYPNOGRAM_SMOOTH_SEC = 300.0
+
+/**
+ * Time-axis ticks for the stepped hypnogram: the EXACT onset (frac 0) and wake (frac 1) at the edges, plus
+ * round-hour marks between at a "nice" step chosen so the interior count is ≤ [maxLabels]−2 — so a WIDER
+ * screen (larger [maxLabels]) shows MORE marks. Interior marks within ~8% of either edge are dropped so they
+ * can't collide with the onset/wake labels. Local-clock formatted via [clockTimeLabel]. Pure/unit-testable.
+ */
+internal fun hypnogramAxisTicks(onsetTs: Long, wakeTs: Long, maxLabels: Int): List<Pair<Float, String>> {
+    val span = (wakeTs - onsetTs).toDouble()
+    if (span <= 0.0) return listOf(0f to clockTimeLabel(onsetTs))
+    val out = ArrayList<Pair<Float, String>>()
+    out.add(0f to clockTimeLabel(onsetTs))
+    val spanHours = span / 3600.0
+    val interiorTarget = (maxLabels - 2).coerceAtLeast(1)
+    val stepH = intArrayOf(1, 2, 3, 4, 6, 8, 12).firstOrNull { spanHours / it <= interiorTarget + 0.5 } ?: 12
+    val stepSec = stepH * 3600L
+    var t = ((onsetTs / stepSec) + 1L) * stepSec // first step-aligned hour boundary strictly after onset
+    while (t < wakeTs) {
+        val frac = ((t - onsetTs).toDouble() / span).toFloat()
+        if (frac > 0.08f && frac < 0.92f) out.add(frac to clockTimeLabel(t))
+        t += stepSec
+    }
+    out.add(1f to clockTimeLabel(wakeTs))
+    return out
+}
+
+/**
+ * Places [ticks] (fraction 0..1 → label) along a full-width row, each label CENTRED on its fraction and
+ * clamped so the edge labels stay on-screen. A [Layout] (not a weighted Row) so round-hour marks sit at
+ * their true time position rather than evenly spaced — the labels line up with the axis hairlines drawn at
+ * the same fractions in the chart above.
+ */
+@Composable
+private fun HypnogramTimeAxis(ticks: List<Pair<Float, String>>) {
+    Layout(
+        modifier = Modifier.fillMaxWidth(),
+        content = {
+            ticks.forEach { (_, label) ->
+                Text(label, style = NoopType.footnote, color = Palette.textTertiary, maxLines = 1)
+            }
+        },
+    ) { measurables, constraints ->
+        val placeables = measurables.map { it.measure(constraints.copy(minWidth = 0)) }
+        val wpx = constraints.maxWidth
+        val hpx = placeables.maxOfOrNull { it.height } ?: 0
+        layout(wpx, hpx) {
+            placeables.forEachIndexed { i, p ->
+                val centerX = ticks[i].first * wpx
+                val x = (centerX - p.width / 2f).roundToInt().coerceIn(0, (wpx - p.width).coerceAtLeast(0))
+                p.place(x, 0)
+            }
+        }
+    }
+}
 
 /** One-line a11y summary of the smoothed hypnogram (stage count) — the collapsed node for [FilledHypnogram]. */
 private fun hypnogramSummaryFor(intervals: List<StageInterval>): String =

--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -229,11 +229,8 @@ internal fun FilledHypnogram(
     val axSummary = hypnogramSummaryFor(intervals)
     // Responsive time axis: exact onset/wake at the edges + round-hour marks between, MORE marks on a wider
     // screen (~one label per 90dp). Empty when the night has no clock window (no axis then).
-    val axisTicks = if (showsAxis) {
-        hypnogramAxisTicks(onsetTs!!, wakeTs!!, maxLabels = (LocalConfiguration.current.screenWidthDp / 90).coerceIn(3, 8))
-    } else {
-        emptyList()
-    }
+    val maxAxisLabels = (LocalConfiguration.current.screenWidthDp / 90).coerceIn(3, 8)
+    val axisTicks = if (showsAxis) hypnogramAxisTicks(onsetTs!!, wakeTs!!, maxAxisLabels) else emptyList()
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.space6)) {
         Canvas(
             modifier = Modifier
@@ -342,7 +339,9 @@ internal fun hypnogramAxisTicks(onsetTs: Long, wakeTs: Long, maxLabels: Int): Li
     var t = ((onsetTs / stepSec) + 1L) * stepSec // first step-aligned hour boundary strictly after onset
     while (t < wakeTs) {
         val frac = ((t - onsetTs).toDouble() / span).toFloat()
-        if (frac > 0.08f && frac < 0.92f) out.add(frac to clockTimeLabel(t))
+        // Drop marks within ~12% of an edge so a round-hour label can't overlap the onset/wake label
+        // (each is roughly a tenth of the width, plus half the mark's own width, on a phone).
+        if (frac > 0.12f && frac < 0.88f) out.add(frac to clockTimeLabel(t))
         t += stepSec
     }
     out.add(1f to clockTimeLabel(wakeTs))

--- a/android/app/src/test/java/com/noop/ui/HypnogramAxisTicksTest.kt
+++ b/android/app/src/test/java/com/noop/ui/HypnogramAxisTicksTest.kt
@@ -1,0 +1,41 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure coverage for the stepped-hypnogram time axis (#sleep-chart-style): the exact onset/wake anchor the
+ * edges, round-hour marks fill the middle, and a WIDER screen (larger maxLabels) yields MORE marks. Labels
+ * depend on the JVM default timezone; these assert the fraction structure, which does not.
+ */
+class HypnogramAxisTicksTest {
+
+    private val onset = 1_786_000_000L
+    private val eightHours = onset + 8 * 3600L
+
+    @Test fun edgesAreExactOnsetAndWake() {
+        val ticks = hypnogramAxisTicks(onset, eightHours, maxLabels = 5)
+        assertEquals(0f, ticks.first().first, 1e-4f)
+        assertEquals(1f, ticks.last().first, 1e-4f)
+        assertTrue("expected at least one interior mark", ticks.size >= 3)
+    }
+
+    @Test fun interiorMarksAreStrictlyBetweenTheEdges() {
+        hypnogramAxisTicks(onset, eightHours, maxLabels = 6).drop(1).dropLast(1).forEach { (frac, _) ->
+            assertTrue("interior frac $frac must be inside (0,1)", frac > 0f && frac < 1f)
+        }
+    }
+
+    @Test fun widerScreenGivesAtLeastAsManyMarks() {
+        val narrow = hypnogramAxisTicks(onset, eightHours, maxLabels = 3)
+        val wide = hypnogramAxisTicks(onset, eightHours, maxLabels = 8)
+        assertTrue("wide=${wide.size} should be >= narrow=${narrow.size}", wide.size >= narrow.size)
+        assertTrue("a wide axis over an 8h night should have >3 marks", wide.size > 3)
+    }
+
+    @Test fun zeroOrNegativeSpanYieldsASingleTick() {
+        assertEquals(1, hypnogramAxisTicks(onset, onset, maxLabels = 5).size)
+        assertEquals(1, hypnogramAxisTicks(onset, onset - 100L, maxLabels = 5).size)
+    }
+}


### PR DESCRIPTION
Follow-up to the Filled/Ribbon sleep chart — the axis was fixed at three labels (onset · midpoint · wake). This makes it the reference's richer axis:

- **Exact onset/wake** anchor the edges, **round-hour marks** fill the middle (`23:28 · 02:00 · 04:00 · 06:00 · 08:00 · 10:25`).
- **Responsive to screen width** — ~one label per 90 dp, so a Fold/tablet shows more marks, a phone fewer (as requested).

## How
- `hypnogramAxisTicks` (pure, unit-tested): picks a nice hour step (1/2/3/4/6/8/12) so the interior count fits `maxLabels`; drops marks within ~8 % of an edge so they can't collide with onset/wake; anchors the exact edges.
- `HypnogramTimeAxis`: a `Layout` (not a weighted row) that centres each label on its **true time fraction**, clamped to stay on-screen — so labels line up with the axis hairlines drawn at the same fractions above.
- Applies to **both Filled and Ribbon** (shared component); **Classic**'s proportional strip is unchanged.

## Scope
Android only; display-only. `compileFullDebugKotlin` + `HypnogramAxisTicksTest` (edges exact, interior strictly-between, wider→more marks, zero-span→single tick) pass.