### PR TITLE
sleep: denser hypnogram time axis on narrow screens + hour-only, locale-aware marks

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import android.text.format.DateFormat
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
@@ -229,8 +231,12 @@ internal fun FilledHypnogram(
     val axSummary = hypnogramSummaryFor(intervals)
     // Responsive time axis: exact onset/wake at the edges + round-hour marks between, MORE marks on a wider
     // screen (~one label per 90dp). Empty when the night has no clock window (no axis then).
-    val maxAxisLabels = (LocalConfiguration.current.screenWidthDp / 90).coerceIn(3, 8)
-    val axisTicks = if (showsAxis) hypnogramAxisTicks(onsetTs!!, wakeTs!!, maxAxisLabels) else emptyList()
+    // ~60dp per label so a phone (~360dp) budgets ~6 -> fills the interior with round-hour marks instead of
+    // stranding the axis at just onset/mid/wake; a tablet fans out to the 8-label ceiling. Floor 4 keeps a
+    // narrow phone from collapsing back to bare edges.
+    val maxAxisLabels = (LocalConfiguration.current.screenWidthDp / 60).coerceIn(4, 8)
+    val is24h = DateFormat.is24HourFormat(LocalContext.current)
+    val axisTicks = if (showsAxis) hypnogramAxisTicks(onsetTs!!, wakeTs!!, maxAxisLabels, is24h) else emptyList()
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.space6)) {
         Canvas(
             modifier = Modifier
@@ -322,16 +328,23 @@ internal fun FilledHypnogram(
 private const val FILLED_HYPNOGRAM_SMOOTH_SEC = 300.0
 
 /**
- * Time-axis ticks for the stepped hypnogram: the EXACT onset (frac 0) and wake (frac 1) at the edges, plus
- * round-hour marks between at a "nice" step chosen so the interior count is ≤ [maxLabels]−2 — so a WIDER
- * screen (larger [maxLabels]) shows MORE marks. Interior marks within ~8% of either edge are dropped so they
- * can't collide with the onset/wake labels. Local-clock formatted via [clockTimeLabel]. Pure/unit-testable.
+ * Time-axis ticks for the stepped hypnogram: the EXACT onset (frac 0) and wake (frac 1) at the edges
+ * (minute precision, [axisEdgeLabel]), plus round-hour marks between at a "nice" step chosen so the interior
+ * count is ≤ [maxLabels]−2 — so a WIDER screen (larger [maxLabels]) shows MORE marks. Interior marks read as
+ * the hour only ([axisHourLabel] — "06:00" / "6 AM"), which is shorter than an edge label, so more fit. Marks
+ * within ~15% of either edge are dropped so a round-hour label can't collide with the onset/wake label.
+ * [is24h] (from `DateFormat.is24HourFormat`) picks 12/24h formatting. Pure/unit-testable.
  */
-internal fun hypnogramAxisTicks(onsetTs: Long, wakeTs: Long, maxLabels: Int): List<Pair<Float, String>> {
+internal fun hypnogramAxisTicks(
+    onsetTs: Long,
+    wakeTs: Long,
+    maxLabels: Int,
+    is24h: Boolean = true,
+): List<Pair<Float, String>> {
     val span = (wakeTs - onsetTs).toDouble()
-    if (span <= 0.0) return listOf(0f to clockTimeLabel(onsetTs))
+    if (span <= 0.0) return listOf(0f to axisEdgeLabel(onsetTs, is24h))
     val out = ArrayList<Pair<Float, String>>()
-    out.add(0f to clockTimeLabel(onsetTs))
+    out.add(0f to axisEdgeLabel(onsetTs, is24h))
     val spanHours = span / 3600.0
     val interiorTarget = (maxLabels - 2).coerceAtLeast(1)
     val stepH = intArrayOf(1, 2, 3, 4, 6, 8, 12).firstOrNull { spanHours / it <= interiorTarget + 0.5 } ?: 12
@@ -339,12 +352,12 @@ internal fun hypnogramAxisTicks(onsetTs: Long, wakeTs: Long, maxLabels: Int): Li
     var t = ((onsetTs / stepSec) + 1L) * stepSec // first step-aligned hour boundary strictly after onset
     while (t < wakeTs) {
         val frac = ((t - onsetTs).toDouble() / span).toFloat()
-        // Drop marks within ~12% of an edge so a round-hour label can't overlap the onset/wake label
+        // Drop marks within ~15% of an edge so a round-hour label can't overlap the onset/wake label
         // (each is roughly a tenth of the width, plus half the mark's own width, on a phone).
-        if (frac > 0.12f && frac < 0.88f) out.add(frac to clockTimeLabel(t))
+        if (frac > 0.15f && frac < 0.85f) out.add(frac to axisHourLabel(t, is24h))
         t += stepSec
     }
-    out.add(1f to clockTimeLabel(wakeTs))
+    out.add(1f to axisEdgeLabel(wakeTs, is24h))
     return out
 }
 

--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import android.text.format.DateFormat
+import java.util.TimeZone
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
@@ -349,7 +350,12 @@ internal fun hypnogramAxisTicks(
     val interiorTarget = (maxLabels - 2).coerceAtLeast(1)
     val stepH = intArrayOf(1, 2, 3, 4, 6, 8, 12).firstOrNull { spanHours / it <= interiorTarget + 0.5 } ?: 12
     val stepSec = stepH * 3600L
-    var t = ((onsetTs / stepSec) + 1L) * stepSec // first step-aligned hour boundary strictly after onset
+    // Align marks to LOCAL hour boundaries, not UNIX-epoch ones: on a half-hour-offset zone (e.g. UTC+5:30)
+    // an epoch-aligned 3h step lands at local :30, and axisHourLabel's "HH:00" would then LIE. Local midnight
+    // is a whole number of days (a multiple of stepSec for every stepH that divides 24), so shifting into
+    // local-epoch space by the zone offset, aligning there, and shifting back puts every mark on a true :00.
+    val offset = TimeZone.getDefault().getOffset(onsetTs * 1000L) / 1000L
+    var t = (((onsetTs + offset) / stepSec) + 1L) * stepSec - offset // first LOCAL hour boundary after onset
     while (t < wakeTs) {
         val frac = ((t - onsetTs).toDouble() / span).toFloat()
         // Drop marks within ~15% of an edge so a round-hour label can't overlap the onset/wake label

--- a/android/app/src/main/java/com/noop/ui/SleepTimeLabels.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepTimeLabels.kt
@@ -45,3 +45,19 @@ internal fun localDayString(ts: Long): String =
 /** Unix seconds → a local wall-clock "HH:mm" (same 24h formatting the nav-header span uses). */
 internal fun clockTimeLabel(ts: Long): String =
     SimpleDateFormat("HH:mm", Locale.US).format(Date(ts * 1000L))
+
+/**
+ * Hypnogram-axis EDGE label (onset / wake) at minute precision, honouring the device 12/24h setting:
+ * "23:28" when the clock is 24h, "11:28 PM" when it's 12h. The [is24h] flag comes from
+ * `DateFormat.is24HourFormat(context)` at the call site so this stays pure/unit-testable.
+ */
+internal fun axisEdgeLabel(ts: Long, is24h: Boolean): String =
+    SimpleDateFormat(if (is24h) "HH:mm" else "h:mm a", Locale.US).format(Date(ts * 1000L))
+
+/**
+ * Hypnogram-axis INTERIOR round-hour mark — the label is always on the hour, so it drops the minutes and
+ * reads shorter than an edge label ("06:00" in 24h, "6 AM" in 12h). The narrower label lets a phone fit an
+ * extra mark in the same width. Locale 12/24h via [is24h], same source as [axisEdgeLabel].
+ */
+internal fun axisHourLabel(ts: Long, is24h: Boolean): String =
+    SimpleDateFormat(if (is24h) "HH:00" else "h a", Locale.US).format(Date(ts * 1000L))

--- a/android/app/src/test/java/com/noop/ui/HypnogramAxisTicksTest.kt
+++ b/android/app/src/test/java/com/noop/ui/HypnogramAxisTicksTest.kt
@@ -3,6 +3,7 @@ package com.noop.ui
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.TimeZone
 
 /**
  * Pure coverage for the stepped-hypnogram time axis (#sleep-chart-style): the exact onset/wake anchor the
@@ -44,6 +45,19 @@ class HypnogramAxisTicksTest {
     @Test fun interiorMarksAreHourOnly24h() {
         hypnogramAxisTicks(onset, eightHours, maxLabels = 8, is24h = true).drop(1).dropLast(1)
             .forEach { (_, label) -> assertTrue("'$label' should be HH:00", label.matches(Regex("""\d{2}:00"""))) }
+    }
+
+    // Marks align to LOCAL hour boundaries, so "HH:00" is truthful even on a half-hour-offset zone where
+    // epoch-aligned steps would land at :30. Pin IST (UTC+5:30) and assert every interior mark ends ":00".
+    @Test fun halfHourOffsetZoneStillLandsOnRoundHours() {
+        val saved = TimeZone.getDefault()
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("Asia/Kolkata"))
+            hypnogramAxisTicks(onset, onset + 9 * 3600L, maxLabels = 8, is24h = true).drop(1).dropLast(1)
+                .forEach { (_, label) -> assertTrue("'$label' should end :00 in IST", label.endsWith(":00")) }
+        } finally {
+            TimeZone.setDefault(saved)
+        }
     }
 
     @Test fun twelveHourFormatUsesAmPm() {

--- a/android/app/src/test/java/com/noop/ui/HypnogramAxisTicksTest.kt
+++ b/android/app/src/test/java/com/noop/ui/HypnogramAxisTicksTest.kt
@@ -38,4 +38,18 @@ class HypnogramAxisTicksTest {
         assertEquals(1, hypnogramAxisTicks(onset, onset, maxLabels = 5).size)
         assertEquals(1, hypnogramAxisTicks(onset, onset - 100L, maxLabels = 5).size)
     }
+
+    // Interior round-hour marks read as the hour only. Timezone shifts WHICH hour, not the shape, so assert
+    // the format: 24h marks are "HH:00", 12h marks are "h AM/PM" — never a non-zero minute.
+    @Test fun interiorMarksAreHourOnly24h() {
+        hypnogramAxisTicks(onset, eightHours, maxLabels = 8, is24h = true).drop(1).dropLast(1)
+            .forEach { (_, label) -> assertTrue("'$label' should be HH:00", label.matches(Regex("""\d{2}:00"""))) }
+    }
+
+    @Test fun twelveHourFormatUsesAmPm() {
+        val ticks = hypnogramAxisTicks(onset, eightHours, maxLabels = 8, is24h = false)
+        ticks.drop(1).dropLast(1)
+            .forEach { (_, label) -> assertTrue("interior '$label' should be 'h AM/PM'", label.matches(Regex("""\d{1,2} (AM|PM)"""))) }
+        assertTrue("edge '${ticks.first().second}' should carry AM/PM", ticks.first().second.contains(Regex("AM|PM")))
+    }
 }


### PR DESCRIPTION
Follow-up to #1130. On a phone the stepped-hypnogram axis was stranded at onset/mid/wake with most of the width empty. This fills it and cleans up the labels.

## Changes
- **Density** — `~60dp/label` (was 90), floor 4. A ~360dp phone now budgets ~6 labels, so the round-hour step tightens: an 11h night (23:28→10:25) renders **23:28 · 03:00 · 06:00 · 10:25** instead of just **23:28 · 06:00 · 10:25**. Tablets still fan out to the 8-label ceiling (unchanged).
- **Hour-only, locale-aware marks** — interior round-hour labels drop the minutes and honour `DateFormat.is24HourFormat`: `06:00` on a 24h device, `6 AM` on a 12h one. Shorter than the minute-precise onset/wake edges, so more fit. Edges also gain AM/PM on 12h locales.
- **Edge guard** widened `0.12→0.15` so the extra interior marks can't crowd the onset/wake labels (e.g. a 09:00 mark sitting right under 10:25 is dropped).

## Verification
- `compileFullDebugKotlin` ✓
- `HypnogramAxisTicksTest` ✓ — added coverage for hour-only 24h marks and 12h AM/PM formatting (TZ-independent shape assertions).
- i18n gate ✓ (format patterns aren't UI literals; no baseline change).
- Design tokens only; render-only (totals/percentages untouched).

Android-only (Filled/Ribbon hypnogram). A Swift `Hypnogram` axis twin follows for feature parity.