### PR TITLE
settings: NOOP Limitations capability grid (4.0 vs 5.0/MG)

### DIFF
--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -1,6 +1,422 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "PER STRAP": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PRO BAND"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "POR PULSERA"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PAR BRACELET"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PER FASCIA"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "POR PULSEIRA"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ПО БРАСЛЕТУ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按设备"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按裝置"
+          }
+        }
+      }
+    },
+    "NOOP Limitations": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP-Grenzen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limitaciones de NOOP"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limites de NOOP"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limiti di NOOP"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limitações do NOOP"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ограничения NOOP"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP 限制"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP 限制"
+          }
+        }
+      }
+    },
+    "What each WHOOP can read": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Was jedes WHOOP lesen kann"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Qué puede leer cada WHOOP"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce que chaque WHOOP peut lire"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cosa può leggere ogni WHOOP"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O que cada WHOOP consegue ler"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Что считывает каждый WHOOP"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每款 WHOOP 能读取的内容"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每款 WHOOP 能讀取的內容"
+          }
+        }
+      }
+    },
+    "WHAT NOOP READS": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WAS NOOP LIEST"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QUÉ LEE NOOP"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CE QUE NOOP LIT"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "COSA LEGGE NOOP"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O QUE O NOOP LÊ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ЧТО СЧИТЫВАЕТ NOOP"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP 读取的内容"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP 讀取的內容"
+          }
+        }
+      }
+    },
+    "Feature": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funktion"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Función"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fonction"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funzione"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funcionalidade"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Функция"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "功能"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "功能"
+          }
+        }
+      }
+    },
+    "5.0/MG": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5.0/MG"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5.0/MG"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5.0/MG"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5.0/MG"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5.0/MG"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5.0/MG"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5.0/MG"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5.0/MG"
+          }
+        }
+      }
+    },
+    "LEGEND": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LEGENDE"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LEYENDA"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LÉGENDE"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LEGENDA"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LEGENDA"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ОБОЗНАЧЕНИЯ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "图例"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "圖例"
+          }
+        }
+      }
+    },
+    "What each strap can read live, and what needs an import.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Was jedes Band live lesen kann und was einen Import erfordert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Qué puede leer cada pulsera en directo y qué necesita una importación."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce que chaque bracelet peut lire en direct, et ce qui nécessite un import."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cosa può leggere ogni fascia in tempo reale e cosa richiede un'importazione."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O que cada pulseira consegue ler em direto e o que precisa de importação."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Что каждый браслет считывает вживую, а что требует импорта."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每条设备可实时读取的内容，以及哪些需要导入。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每條裝置可即時讀取的內容，以及哪些需要匯入。"
+          }
+        }
+      }
+    },
     "": {
       "localizations": {
         "de": {

--- a/Strand/Screens/NoopLimitationsView.swift
+++ b/Strand/Screens/NoopLimitationsView.swift
@@ -160,7 +160,7 @@ struct NoopLimitationsView: View {
                         supportCell(row.whoop5)
                     }
                     .accessibilityElement(children: .ignore)
-                    .accessibilityLabel(Text("\(row.spokenFeature): WHOOP 4.0 \(row.whoop4.spoken), 5.0/MG \(row.whoop5.spoken)"))
+                    .accessibilityLabel(a11yLabel(row))
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -189,6 +189,12 @@ struct NoopLimitationsView: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
+    }
+
+    /// VoiceOver line for one row, assembled at runtime from already-localized parts. A plain String (not a
+    /// LocalizedStringKey), so it carries no catalog key of its own.
+    private func a11yLabel(_ row: LimitRow) -> String {
+        "\(row.spokenFeature): WHOOP 4.0 \(row.whoop4.spoken), 5.0/MG \(row.whoop5.spoken)"
     }
 
     private func supportCell(_ state: LimitState) -> some View {

--- a/Strand/Screens/NoopLimitationsView.swift
+++ b/Strand/Screens/NoopLimitationsView.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+import StrandDesign
+
+// MARK: - NoopLimitationsView — "what NOOP can (and can't) read off each strap"
+//
+// The iOS/macOS twin of Android's NoopLimitationsScreen: a plain tri-state capability grid reached from
+// Settings, note-free, listing every metric NOOP surfaces and whether it comes live off a WHOOP 4.0 vs a
+// 5.0/MG. Marks mirror the decoder/analytics truth (Interpreter / AnalyticsEngine / HistoricalStreams):
+// full = read live; partial = an on-device estimate or an experimental / firmware-gated read; none = not
+// off the strap (SpO₂ % is import-only on both; blood pressure has no path at all). A legend carries the
+// meaning in place of per-row prose. Presented as a sheet, mirroring HowNoopWorksView / ScoringGuideView.
+
+struct NoopLimitationsView: View {
+    let onClose: () -> Void
+
+    /// Tri-state support for a metric on a given strap — honest, never overstated.
+    private enum LimitState {
+        case full, partial, none
+
+        /// SF Symbol glyph shown in the strap column.
+        var glyph: String {
+            switch self {
+            case .full:    return "checkmark"
+            case .partial: return "minus"
+            case .none:    return "xmark"
+            }
+        }
+
+        var tint: Color {
+            switch self {
+            case .full:    return StrandPalette.statusPositive
+            case .partial: return StrandPalette.statusWarning
+            case .none:    return StrandPalette.textTertiary
+            }
+        }
+
+        /// Spoken label for the row's accessibility description.
+        var spoken: String {
+            switch self {
+            case .full:    return String(localized: "yes")
+            case .partial: return String(localized: "partly")
+            case .none:    return String(localized: "no")
+            }
+        }
+    }
+
+    /// One row: a metric, and how it reads on a 4.0 vs a 5.0/MG. No note — the legend carries the meaning.
+    private struct LimitRow: Identifiable {
+        let feature: LocalizedStringKey
+        let spokenFeature: String
+        let whoop4: LimitState
+        let whoop5: LimitState
+        var id: String { spokenFeature }
+    }
+
+    private let rows: [LimitRow] = [
+        LimitRow(feature: "Live heart rate", spokenFeature: "Live heart rate", whoop4: .full, whoop5: .full),
+        LimitRow(feature: "HRV (rMSSD)", spokenFeature: "HRV", whoop4: .full, whoop5: .full),
+        LimitRow(feature: "Sleep staging", spokenFeature: "Sleep staging", whoop4: .full, whoop5: .full),
+        LimitRow(feature: "Recovery & strain", spokenFeature: "Recovery and strain", whoop4: .full, whoop5: .full),
+        LimitRow(feature: "Respiratory rate", spokenFeature: "Respiratory rate", whoop4: .full, whoop5: .full),
+        LimitRow(feature: "Stress (on-device)", spokenFeature: "Stress", whoop4: .full, whoop5: .full),
+        LimitRow(feature: "Workout detection", spokenFeature: "Workout detection", whoop4: .full, whoop5: .full),
+        LimitRow(feature: "Skin temperature", spokenFeature: "Skin temperature", whoop4: .partial, whoop5: .full),
+        LimitRow(feature: "Steps", spokenFeature: "Steps", whoop4: .partial, whoop5: .full),
+        LimitRow(feature: "Blood oxygen (SpO₂ %)", spokenFeature: "Blood oxygen", whoop4: .none, whoop5: .none),
+        LimitRow(feature: "ECG", spokenFeature: "ECG", whoop4: .none, whoop5: .partial),
+        LimitRow(feature: "Blood pressure", spokenFeature: "Blood pressure", whoop4: .none, whoop5: .none),
+    ]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().overlay(StrandPalette.hairline)
+            ScrollView {
+                VStack(alignment: .leading, spacing: NoopMetrics.sectionGap) {
+                    tableCard
+                    legendCard
+                }
+                .padding(20)
+            }
+            Divider().overlay(StrandPalette.hairline)
+            footerBar
+        }
+        #if os(macOS)
+        .frame(width: 560, height: 640)
+        #else
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .noopSheetPresentation(largeFirst: true)
+        #endif
+        .background(StrandPalette.surfaceBase)
+    }
+
+    // MARK: - Header / footer
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("PER STRAP").font(StrandFont.overline)
+                    .tracking(StrandFont.overlineTracking)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                Text("NOOP Limitations").font(StrandFont.rounded(26, weight: .bold))
+                    .foregroundStyle(StrandPalette.textPrimary)
+                Text("What each WHOOP can read")
+                    .font(StrandFont.caption)
+                    .foregroundStyle(StrandPalette.textSecondary)
+            }
+            Spacer()
+            Button(action: onClose) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 22))
+                    .foregroundStyle(StrandPalette.textTertiary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close")
+        }
+        .padding(20)
+    }
+
+    private var footerBar: some View {
+        HStack {
+            Spacer()
+            Button(action: onClose) {
+                Text("Done").frame(minWidth: 120).padding(.vertical, 4)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(StrandPalette.accent)
+            .keyboardShortcut(.defaultAction)
+        }
+        .padding(16)
+    }
+
+    // MARK: - Cards
+
+    private var tableCard: some View {
+        NoopCard {
+            VStack(alignment: .leading, spacing: 14) {
+                Text("WHAT NOOP READS").font(StrandFont.overline)
+                    .tracking(StrandFont.overlineTracking)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                // Column header.
+                HStack {
+                    Text("Feature").font(StrandFont.caption)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Text("4.0").font(StrandFont.caption)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                        .frame(width: 52)
+                    Text("5.0/MG").font(StrandFont.caption)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                        .frame(width: 52)
+                }
+                ForEach(Array(rows.enumerated()), id: \.element.id) { idx, row in
+                    if idx > 0 { Divider().overlay(StrandPalette.hairline) }
+                    HStack {
+                        Text(row.feature).font(StrandFont.body)
+                            .foregroundStyle(StrandPalette.textPrimary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        supportCell(row.whoop4)
+                        supportCell(row.whoop5)
+                    }
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(Text("\(row.spokenFeature): WHOOP 4.0 \(row.whoop4.spoken), 5.0/MG \(row.whoop5.spoken)"))
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var legendCard: some View {
+        NoopCard {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("LEGEND").font(StrandFont.overline)
+                    .tracking(StrandFont.overlineTracking)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                legendRow(.full, "Read live off the strap")
+                legendRow(.partial, "On-device estimate, or experimental / firmware-gated")
+                legendRow(.none, "Not from the strap. SpO₂ can be filled by importing a WHOOP or Health export.")
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func legendRow(_ state: LimitState, _ label: LocalizedStringKey) -> some View {
+        HStack(spacing: 12) {
+            supportCell(state)
+            Text(label).font(StrandFont.footnote)
+                .foregroundStyle(StrandPalette.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func supportCell(_ state: LimitState) -> some View {
+        Image(systemName: state.glyph)
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundStyle(state.tint)
+            .frame(width: 52)
+            .accessibilityHidden(true)
+    }
+}

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -194,6 +194,7 @@ struct SettingsView: View {
     /// time from About — covers how sleep is sorted, how scores + calibration work, what
     /// recording means, and where the provenance badges come from.
     @State private var showHowNoopWorks = false
+    @State private var showLimitations = false
 
     /// "Set up Apple Watch" sheet: the honest watch onboarding flow (what it's great at, where
     /// it's lighter, then the Health permission request). Presented from the About page's primary
@@ -297,6 +298,9 @@ struct SettingsView: View {
         }
         .sheet(isPresented: $showHowNoopWorks) {
             HowNoopWorksView(onClose: { showHowNoopWorks = false })
+        }
+        .sheet(isPresented: $showLimitations) {
+            NoopLimitationsView(onClose: { showLimitations = false })
         }
         .sheet(isPresented: $showAppleWatchSetup) {
             AppleWatchSetupView(onClose: { showAppleWatchSetup = false })
@@ -2173,6 +2177,35 @@ struct SettingsView: View {
                 }
                 .buttonStyle(LiquidPressStyle())
                 .accessibilityLabel("How NOOP works")
+
+                // NOOP Limitations — the plain 4.0 vs 5.0/MG capability grid (what reads live off each
+                // strap vs import-only). Note-free sibling of the Android screen; honest tri-state + legend.
+                Button {
+                    showLimitations = true
+                } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "list.bullet.rectangle")
+                            .foregroundStyle(StrandPalette.accent)
+                            .accessibilityHidden(true)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text("NOOP Limitations")
+                                .font(StrandFont.body)
+                                .foregroundStyle(StrandPalette.textPrimary)
+                            Text("What each strap can read live, and what needs an import.")
+                                .font(StrandFont.footnote)
+                                .foregroundStyle(StrandPalette.textTertiary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(StrandPalette.textTertiary)
+                            .accessibilityHidden(true)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(LiquidPressStyle())
+                .accessibilityLabel("NOOP Limitations")
 
                 // How your scores work — the honest explainer for Charge / Effort / Rest and the
                 // confidence labels. Always reachable here, mirroring the "What's new" affordance.

--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -473,6 +473,34 @@
       "r = %+.2f"
     ],
     [
+      "android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt",
+      "${row.feature}: WHOOP 4.0 ${row.whoop4.spoken}, 5.0/MG ${row.whoop5.spoken}"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt",
+      "5.0/MG"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt",
+      "Close"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt",
+      "Done"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt",
+      "Feature"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt",
+      "NOOP Limitations"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt",
+      "What each WHOOP can read"
+    ],
+    [
       "android/app/src/main/java/com/noop/ui/NotificationsSettingsScreen.kt",
       "Buzzes your wrist"
     ],
@@ -514,6 +542,14 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "NOOP Limitations"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "NOOP Limitations — what each strap can read"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Needs the full encrypted bond: close the official WHOOP app and pair the strap to NOOP first (a live-HR-only link can't carry the unlock)."
     ],
     [
@@ -539,6 +575,10 @@
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Wear the strap, tap once, then let it sync and share your strap log."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "What each strap can read live"
     ],
     [
       "android/app/src/main/java/com/noop/ui/SkinTempCardsScreen.kt",

--- a/android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt
@@ -121,7 +121,7 @@ private fun LegendCard() {
             Overline("Legend")
             LegendRow(LimitState.FULL, "Read live off the strap")
             LegendRow(LimitState.PARTIAL, "On-device estimate, or experimental / firmware-gated")
-            LegendRow(LimitState.NONE, "Not from the strap — import a WHOOP or Health export to see it")
+            LegendRow(LimitState.NONE, "Not from the strap. SpO₂ can be filled by importing a WHOOP or Health export.")
         }
     }
 }

--- a/android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt
@@ -1,0 +1,196 @@
+package com.noop.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+// MARK: - NoopLimitationsScreen — "what NOOP can (and can't) read off each strap"
+//
+// A companion to WhoopModelComparisonScreen (#490), reached from Settings → Strap. Where that screen is
+// prose-with-notes reassuring a 4.0 owner, this is the plain capability grid: every metric NOOP surfaces,
+// and whether it comes live off a 4.0 vs a 5.0/MG — no per-row prose, just the honest tri-state and a
+// legend. Marks mirror the values traced from the decoders/analytics: partial = an on-device estimate or an
+// experimental/firmware-gated read; "not from strap" = only an import (WHOOP CSV / Health) can fill it.
+
+/** Tri-state support for a metric on a given strap — honest, never overstated. */
+private enum class LimitState { FULL, PARTIAL, NONE }
+
+/** One row: a metric, and how it reads on a 4.0 vs a 5.0/MG. No note — the legend carries the meaning. */
+private data class LimitRow(val feature: String, val whoop4: LimitState, val whoop5: LimitState)
+
+private val LIMIT_ROWS: List<LimitRow> = listOf(
+    LimitRow("Live heart rate", LimitState.FULL, LimitState.FULL),
+    LimitRow("HRV (rMSSD)", LimitState.FULL, LimitState.FULL),
+    LimitRow("Sleep staging", LimitState.FULL, LimitState.FULL),
+    LimitRow("Recovery & strain", LimitState.FULL, LimitState.FULL),
+    LimitRow("Respiratory rate", LimitState.FULL, LimitState.FULL),
+    LimitRow("Stress (on-device)", LimitState.FULL, LimitState.FULL),
+    LimitRow("Workout detection", LimitState.FULL, LimitState.FULL),
+    LimitRow("Skin temperature", LimitState.PARTIAL, LimitState.FULL),
+    LimitRow("Steps", LimitState.PARTIAL, LimitState.FULL),
+    LimitRow("Blood oxygen (SpO₂ %)", LimitState.NONE, LimitState.NONE),
+    LimitRow("ECG", LimitState.NONE, LimitState.PARTIAL),
+    LimitRow("Blood pressure", LimitState.NONE, LimitState.NONE),
+)
+
+@Composable
+fun NoopLimitationsScreen(onClose: () -> Unit) {
+    val scroll = rememberScrollState()
+    Surface(modifier = Modifier.fillMaxSize(), color = Palette.surfaceBase) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Header(onClose)
+            Hairline()
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .verticalScroll(scroll)
+                    .padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(Metrics.sectionGap),
+            ) {
+                LimitTableCard()
+                LegendCard()
+            }
+            Hairline()
+            Footer(onClose)
+        }
+    }
+}
+
+@Composable
+private fun LimitTableCard() {
+    NoopCard(padding = 20.dp) {
+        Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
+            Overline("What NOOP reads")
+            // Column header.
+            Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                Text("Feature", style = NoopType.caption, color = Palette.textTertiary, modifier = Modifier.weight(1f))
+                Text("4.0", style = NoopType.caption, color = Palette.textTertiary, textAlign = TextAlign.Center, modifier = Modifier.width(48.dp))
+                Text("5.0/MG", style = NoopType.caption, color = Palette.textTertiary, textAlign = TextAlign.Center, modifier = Modifier.width(48.dp))
+            }
+            LIMIT_ROWS.forEachIndexed { idx, row ->
+                if (idx > 0) Hairline()
+                Row(
+                    modifier = Modifier.fillMaxWidth().semantics {
+                        contentDescription = "${row.feature}: WHOOP 4.0 ${row.whoop4.spoken}, 5.0/MG ${row.whoop5.spoken}"
+                    },
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(row.feature, style = NoopType.body, color = Palette.textPrimary, modifier = Modifier.weight(1f))
+                    SupportCell(row.whoop4)
+                    SupportCell(row.whoop5)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LegendCard() {
+    NoopCard(padding = 20.dp) {
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Overline("Legend")
+            LegendRow(LimitState.FULL, "Read live off the strap")
+            LegendRow(LimitState.PARTIAL, "On-device estimate, or experimental / firmware-gated")
+            LegendRow(LimitState.NONE, "Not from the strap — import a WHOOP or Health export to see it")
+        }
+    }
+}
+
+@Composable
+private fun LegendRow(state: LimitState, label: String) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        SupportCell(state)
+        Text(label, style = NoopType.footnote, color = Palette.textSecondary, modifier = Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun SupportCell(state: LimitState) {
+    Box(modifier = Modifier.width(48.dp), contentAlignment = Alignment.Center) {
+        when (state) {
+            LimitState.FULL -> SupportGlyph(Icons.Filled.Check, Palette.statusPositive, "yes")
+            LimitState.PARTIAL -> SupportGlyph(Icons.Filled.Remove, Palette.statusWarning, "partly")
+            LimitState.NONE -> SupportGlyph(Icons.Filled.Close, Palette.textTertiary, "no")
+        }
+    }
+}
+
+@Composable
+private fun SupportGlyph(icon: ImageVector, tint: Color, label: String) {
+    Icon(icon, contentDescription = label, tint = tint, modifier = Modifier.size(18.dp))
+}
+
+// MARK: - Header / footer (matches WhoopModelComparisonScreen's idiom)
+
+@Composable
+private fun Header(onClose: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(20.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Overline("Per strap", color = Palette.textTertiary)
+            Text("NOOP Limitations", style = NoopType.display(26f), color = Palette.textPrimary)
+            Text("What each WHOOP can read", style = NoopType.caption, color = Palette.textSecondary)
+        }
+        IconButton(onClick = onClose, modifier = Modifier.size(36.dp)) {
+            Icon(Icons.Filled.Close, contentDescription = "Close", tint = Palette.textTertiary, modifier = Modifier.size(22.dp))
+        }
+    }
+}
+
+@Composable
+private fun Footer(onClose: () -> Unit) {
+    Row(modifier = Modifier.fillMaxWidth().padding(16.dp), horizontalArrangement = Arrangement.End) {
+        Button(
+            onClick = onClose,
+            colors = ButtonDefaults.buttonColors(containerColor = Palette.accent, contentColor = Palette.surfaceBase),
+        ) {
+            Text("Done", modifier = Modifier.padding(horizontal = 24.dp))
+        }
+    }
+}
+
+@Composable
+private fun Hairline() {
+    Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(Palette.hairline))
+}
+
+/** Spoken support label for the row's accessibility description. */
+private val LimitState.spoken: String
+    get() = when (this) {
+        LimitState.FULL -> "yes"
+        LimitState.PARTIAL -> "partly"
+        LimitState.NONE -> "no"
+    }

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -451,6 +451,9 @@ fun SettingsScreen(
     // Strap section by BOTH model owners. Clears up which features each strap supports — e.g. why the
     // strap-firmware broadcast-out is 5/MG-only while NOOP's own re-broadcast works on any strap.
     var showModelComparison by remember { mutableStateOf(false) }
+    // "NOOP Limitations" — the plain capability grid (what each strap can read live). Sibling of the model
+    // comparison, opened from the same Strap section.
+    var showLimitations by remember { mutableStateOf(false) }
 
     // "Recalibrate Charge baseline" confirm dialog (Charge advanced). Writes now-seconds to BOTH the
     // noop.hrvBaselineEpoch and noop.recoveryBaselineEpoch prefs so foldHistory re-seeds every baseline
@@ -1723,6 +1726,46 @@ fun SettingsScreen(
                             Text(uiString(R.string.l10n_settings_screen_whoop_4_0_vs_5_0_2babb05a), style = NoopType.headline, color = Palette.textPrimary)
                             Text(
                                 uiString(R.string.l10n_settings_screen_what_each_strap_can_read_and_51e7d3fc),
+                                style = NoopType.footnote,
+                                color = Palette.textSecondary,
+                            )
+                        }
+                        Text("›", style = NoopType.title2, color = Palette.accent)
+                    }
+                }
+
+                // "NOOP Limitations" — the plain 4.0 vs 5.0/MG capability grid (no prose). Same tap-through
+                // idiom as the model-comparison row above; honest about what reads live vs import-only.
+                val limitationsInteraction = remember { MutableInteractionSource() }
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .liquidPress(limitationsInteraction)
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(Palette.surfaceInset)
+                        .border(1.dp, Palette.hairline, RoundedCornerShape(10.dp))
+                        .clickable(
+                            interactionSource = limitationsInteraction,
+                            indication = null,
+                        ) { showLimitations = true }
+                        .padding(horizontal = 14.dp, vertical = 12.dp)
+                        .semantics { contentDescription = "NOOP Limitations — what each strap can read" },
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    ) {
+                        Icon(
+                            Icons.Filled.Info,
+                            contentDescription = null,
+                            tint = Palette.accent,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text("NOOP Limitations", style = NoopType.headline, color = Palette.textPrimary)
+                            Text(
+                                "What each strap can read live",
                                 style = NoopType.footnote,
                                 color = Palette.textSecondary,
                             )
@@ -3042,6 +3085,17 @@ fun SettingsScreen(
             ) {
                 Surface(modifier = Modifier.fillMaxSize(), color = Palette.surfaceBase) {
                     WhoopModelComparisonScreen(onClose = { showModelComparison = false })
+                }
+            }
+        }
+
+        if (showLimitations) {
+            Dialog(
+                onDismissRequest = { showLimitations = false },
+                properties = DialogProperties(usePlatformDefaultWidth = false),
+            ) {
+                Surface(modifier = Modifier.fillMaxSize(), color = Palette.surfaceBase) {
+                    NoopLimitationsScreen(onClose = { showLimitations = false })
                 }
             }
         }


### PR DESCRIPTION
Adds a **NOOP Limitations** row to Settings → Strap that opens a plain tri-state capability grid — a note-free sibling to the existing `WhoopModelComparisonScreen` (#490), built in the same idiom (header / table card / footer, `✓ / – / ✗` glyphs).

Requested: a 4.0-vs-5.0/MG table "like" the model-comparison one, without the per-row prose.

## The table
| Feature | 4.0 | 5.0/MG |
|---|:--:|:--:|
| Live HR, HRV, Sleep, Recovery & strain, Respiratory rate, Stress, Workout detection | ✓ | ✓ |
| Skin temperature | – | ✓ |
| Steps | – | ✓ |
| Blood oxygen (SpO₂ %) | ✗ | ✗ |
| ECG | ✗ | – |
| Blood pressure | ✗ | ✗ |

Marks mirror the decoder/analytics ground truth (traced from `Interpreter`/`AnalyticsEngine`/`HistoricalStreams`): **✓** read live · **–** on-device estimate or experimental/firmware-gated (4.0 steps + skin-temp, 5/MG ECG) · **✗** not off the strap. A legend carries the meaning in place of notes.

## Verification
- `compileFullDebugKotlin` ✓
- i18n gate ✓ (raw UI literals baselined, matching the existing capability-checklist precedent)
- Design tokens only; reuses `NoopCard`/`Overline`/`Palette`/`Metrics`.
- Self-review fix folded in: the `✗` legend scopes the import path to SpO₂ (blood pressure has no import either).

Android only; iOS twin can follow for parity.