### PR TITLE
settings→more: relocate NOOP Limitations into the More tab / sidebar (all platforms)

### DIFF
--- a/Strand/App/RootView.swift
+++ b/Strand/App/RootView.swift
@@ -25,6 +25,7 @@ enum NavItem: String, CaseIterable, Identifiable, Hashable {
     case backupSync = "Backup & Sync"
     case fusedRecord = "Your Data, Fused"
     case devices = "Devices"
+    case noopLimitations = "NOOP Limitations"
     case notifications = "Notifications"
     case automation = "Automations"
     case smartAlarm = "Smart Alarm"
@@ -60,6 +61,7 @@ enum NavItem: String, CaseIterable, Identifiable, Hashable {
         case .backupSync: return "Backup & Sync"
         case .fusedRecord: return "Your Data, Fused"
         case .devices: return "Devices"
+        case .noopLimitations: return "NOOP Limitations"
         case .notifications: return "Notifications"
         case .automation: return "Automations"
         // "Alarms" is the ONE alarm surface (#766): the strap's silent wake-alarm (moved in from
@@ -102,6 +104,7 @@ enum NavItem: String, CaseIterable, Identifiable, Hashable {
         case .backupSync: return String(localized: "Backup & Sync")
         case .fusedRecord: return String(localized: "Your Data, Fused")
         case .devices: return String(localized: "Devices")
+        case .noopLimitations: return String(localized: "NOOP Limitations")
         case .notifications: return String(localized: "Notifications")
         case .automation: return String(localized: "Automations")
         // Mirrors the `titleKey` remap above (#766): the row reads "Alarms", not the raw "Smart Alarm".
@@ -136,6 +139,7 @@ enum NavItem: String, CaseIterable, Identifiable, Hashable {
         case .backupSync: return "externaldrive.fill.badge.icloud"
         case .fusedRecord: return "square.stack.3d.up.fill"
         case .devices: return "badge.plus.radiowaves.right"
+        case .noopLimitations: return "list.bullet.rectangle"
         case .notifications: return "bell.badge.fill"
         case .automation: return "wand.and.stars"
         case .smartAlarm: return "alarm.fill"
@@ -173,7 +177,7 @@ struct NavGroup: Identifiable {
             .labBook, .rhythm, .trends,
         ]),
         NavGroup(title: "Data & App", id: "data_app", items: [
-            .devices, .dataSources, .appleHealth, .xiaomi, .backupSync, .fusedRecord,
+            .devices, .noopLimitations, .dataSources, .appleHealth, .xiaomi, .backupSync, .fusedRecord,
             .notifications, .automation, .smartAlarm, .settings, .testCentre,
         ]),
     ]
@@ -434,6 +438,7 @@ struct RootView: View {
         case .backupSync: BackupSyncView()
         case .fusedRecord: FusedRecordHost()
         case .devices: DevicesView()
+        case .noopLimitations: NoopLimitationsView()
         case .notifications: NotificationSettingsView()
         case .automation: AutomationsView()
         case .smartAlarm: SmartAlarmView()

--- a/Strand/Screens/NoopLimitationsView.swift
+++ b/Strand/Screens/NoopLimitationsView.swift
@@ -3,15 +3,15 @@ import StrandDesign
 
 // MARK: - NoopLimitationsView — "what NOOP can (and can't) read off each strap"
 //
-// The iOS/macOS twin of Android's NoopLimitationsScreen: a plain tri-state capability grid reached from
-// Settings, note-free, listing every metric NOOP surfaces and whether it comes live off a WHOOP 4.0 vs a
-// 5.0/MG. Marks mirror the decoder/analytics truth (Interpreter / AnalyticsEngine / HistoricalStreams):
-// full = read live; partial = an on-device estimate or an experimental / firmware-gated read; none = not
-// off the strap (SpO₂ % is import-only on both; blood pressure has no path at all). A legend carries the
-// meaning in place of per-row prose. Presented as a sheet, mirroring HowNoopWorksView / ScoringGuideView.
+// The iOS/macOS twin of Android's NoopLimitationsScreen: a plain tri-state capability grid listing every
+// metric NOOP surfaces and whether it comes live off a WHOOP 4.0 vs a 5.0/MG. Marks mirror the
+// decoder/analytics truth (Interpreter / AnalyticsEngine / HistoricalStreams): full = read live; partial =
+// an on-device estimate or an experimental / firmware-gated read; none = not off the strap (SpO₂ % is
+// import-only on both; blood pressure has no path). A legend carries the meaning in place of per-row prose.
+// Rendered through the shared ScreenScaffold like every other destination — reached from the iOS More tab
+// (Data group) and the macOS sidebar (Data & App); navigation chrome (back / tab bar) handles dismissal.
 
 struct NoopLimitationsView: View {
-    let onClose: () -> Void
 
     /// Tri-state support for a metric on a given strap — honest, never overstated.
     private enum LimitState {
@@ -69,65 +69,10 @@ struct NoopLimitationsView: View {
     ]
 
     var body: some View {
-        VStack(spacing: 0) {
-            header
-            Divider().overlay(StrandPalette.hairline)
-            ScrollView {
-                VStack(alignment: .leading, spacing: NoopMetrics.sectionGap) {
-                    tableCard
-                    legendCard
-                }
-                .padding(20)
-            }
-            Divider().overlay(StrandPalette.hairline)
-            footerBar
+        ScreenScaffold(title: "NOOP Limitations", subtitle: "What each WHOOP can read") {
+            tableCard
+            legendCard
         }
-        #if os(macOS)
-        .frame(width: 560, height: 640)
-        #else
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .noopSheetPresentation(largeFirst: true)
-        #endif
-        .background(StrandPalette.surfaceBase)
-    }
-
-    // MARK: - Header / footer
-
-    private var header: some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("PER STRAP").font(StrandFont.overline)
-                    .tracking(StrandFont.overlineTracking)
-                    .foregroundStyle(StrandPalette.textTertiary)
-                Text("NOOP Limitations").font(StrandFont.rounded(26, weight: .bold))
-                    .foregroundStyle(StrandPalette.textPrimary)
-                Text("What each WHOOP can read")
-                    .font(StrandFont.caption)
-                    .foregroundStyle(StrandPalette.textSecondary)
-            }
-            Spacer()
-            Button(action: onClose) {
-                Image(systemName: "xmark.circle.fill")
-                    .font(.system(size: 22))
-                    .foregroundStyle(StrandPalette.textTertiary)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Close")
-        }
-        .padding(20)
-    }
-
-    private var footerBar: some View {
-        HStack {
-            Spacer()
-            Button(action: onClose) {
-                Text("Done").frame(minWidth: 120).padding(.vertical, 4)
-            }
-            .buttonStyle(.borderedProminent)
-            .tint(StrandPalette.accent)
-            .keyboardShortcut(.defaultAction)
-        }
-        .padding(16)
     }
 
     // MARK: - Cards
@@ -191,17 +136,17 @@ struct NoopLimitationsView: View {
         }
     }
 
-    /// VoiceOver line for one row, assembled at runtime from already-localized parts. A plain String (not a
-    /// LocalizedStringKey), so it carries no catalog key of its own.
-    private func a11yLabel(_ row: LimitRow) -> String {
-        "\(row.spokenFeature): WHOOP 4.0 \(row.whoop4.spoken), 5.0/MG \(row.whoop5.spoken)"
-    }
-
     private func supportCell(_ state: LimitState) -> some View {
         Image(systemName: state.glyph)
             .font(.system(size: 15, weight: .semibold))
             .foregroundStyle(state.tint)
             .frame(width: 52)
             .accessibilityHidden(true)
+    }
+
+    /// VoiceOver line for one row, assembled at runtime from already-localized parts. A plain String (not a
+    /// LocalizedStringKey), so it carries no catalog key of its own.
+    private func a11yLabel(_ row: LimitRow) -> String {
+        "\(row.spokenFeature): WHOOP 4.0 \(row.whoop4.spoken), 5.0/MG \(row.whoop5.spoken)"
     }
 }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -194,7 +194,6 @@ struct SettingsView: View {
     /// time from About — covers how sleep is sorted, how scores + calibration work, what
     /// recording means, and where the provenance badges come from.
     @State private var showHowNoopWorks = false
-    @State private var showLimitations = false
 
     /// "Set up Apple Watch" sheet: the honest watch onboarding flow (what it's great at, where
     /// it's lighter, then the Health permission request). Presented from the About page's primary
@@ -298,9 +297,6 @@ struct SettingsView: View {
         }
         .sheet(isPresented: $showHowNoopWorks) {
             HowNoopWorksView(onClose: { showHowNoopWorks = false })
-        }
-        .sheet(isPresented: $showLimitations) {
-            NoopLimitationsView(onClose: { showLimitations = false })
         }
         .sheet(isPresented: $showAppleWatchSetup) {
             AppleWatchSetupView(onClose: { showAppleWatchSetup = false })
@@ -2177,35 +2173,6 @@ struct SettingsView: View {
                 }
                 .buttonStyle(LiquidPressStyle())
                 .accessibilityLabel("How NOOP works")
-
-                // NOOP Limitations — the plain 4.0 vs 5.0/MG capability grid (what reads live off each
-                // strap vs import-only). Note-free sibling of the Android screen; honest tri-state + legend.
-                Button {
-                    showLimitations = true
-                } label: {
-                    HStack(spacing: 10) {
-                        Image(systemName: "list.bullet.rectangle")
-                            .foregroundStyle(StrandPalette.accent)
-                            .accessibilityHidden(true)
-                        VStack(alignment: .leading, spacing: 1) {
-                            Text("NOOP Limitations")
-                                .font(StrandFont.body)
-                                .foregroundStyle(StrandPalette.textPrimary)
-                            Text("What each strap can read live, and what needs an import.")
-                                .font(StrandFont.footnote)
-                                .foregroundStyle(StrandPalette.textTertiary)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-                        Spacer()
-                        Image(systemName: "chevron.right")
-                            .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(StrandPalette.textTertiary)
-                            .accessibilityHidden(true)
-                    }
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(LiquidPressStyle())
-                .accessibilityLabel("NOOP Limitations")
 
                 // How your scores work — the honest explainer for Charge / Effort / Rest and the
                 // confidence labels. Always reachable here, mirroring the "What's new" affordance.

--- a/StrandiOS/App/RootTabView.swift
+++ b/StrandiOS/App/RootTabView.swift
@@ -383,6 +383,8 @@ struct RootTabView: View {
                     // #155: HealthKit-free Apple Health path for sideloaded installs (Siri Shortcut
                     // reads the opt-in Documents/noop_sync.txt drop file).
                     MoreRow("Shortcuts Export", "square.and.arrow.up.fill", .shortcutsExport)
+                    // The plain 4.0 vs 5.0/MG capability grid — what NOOP reads live off each strap.
+                    MoreRow("NOOP Limitations", "list.bullet.rectangle", .noopLimitations)
                 }
                 moreSection("App") {
                     // #805/#811: the v7.3.1 #766 alarm consolidation moved Smart Alarm under a single
@@ -486,7 +488,7 @@ struct RootTabView: View {
 private enum MoreDestination: Hashable {
     case insightsHub, intelligence, coach, insights, explore, compare
     case live, workouts, health, labBook, stress, breathe, intervals, rhythm
-    case fusedRecord, appleHealth, miBand, dataSources, backupSync, shortcutsExport
+    case fusedRecord, appleHealth, miBand, dataSources, backupSync, shortcutsExport, noopLimitations
     case alarms, automations, testCentre, siriShortcuts, settings
 
     @ViewBuilder var destination: some View {
@@ -509,6 +511,7 @@ private enum MoreDestination: Hashable {
         case .appleHealth:     AppleHealthView()
         case .miBand:          XiaomiBandView()
         case .dataSources:     DataSourcesView()
+        case .noopLimitations: NoopLimitationsView()
         case .backupSync:      BackupSyncView()
         case .shortcutsExport: ShortcutExportSettingsView()
         case .alarms:          SmartAlarmView()

--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -482,23 +482,7 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt",
-      "Close"
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt",
-      "Done"
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt",
       "Feature"
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt",
-      "NOOP Limitations"
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt",
-      "What each WHOOP can read"
     ],
     [
       "android/app/src/main/java/com/noop/ui/NotificationsSettingsScreen.kt",
@@ -542,14 +526,6 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
-      "NOOP Limitations"
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
-      "NOOP Limitations — what each strap can read"
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Needs the full encrypted bond: close the official WHOOP app and pair the strap to NOOP first (a live-HR-only link can't carry the unlock)."
     ],
     [
@@ -575,10 +551,6 @@
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Wear the strap, tap once, then let it sync and share your strap log."
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
-      "What each strap can read live"
     ],
     [
       "android/app/src/main/java/com/noop/ui/SkinTempCardsScreen.kt",

--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -47,6 +47,7 @@ import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Psychology
+import androidx.compose.material.icons.filled.Rule
 import androidx.compose.material.icons.filled.Sensors
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Spa
@@ -161,6 +162,8 @@ private enum class Destination(
     // name fits. Route id stays "smart_alarm" (display string only).
     SmartAlarm("smart_alarm", R.string.nav_alarms, Icons.Filled.Alarm),
     Devices("devices", R.string.nav_devices, Icons.Filled.Sensors),
+    // The plain 4.0 vs 5.0/MG capability grid — what NOOP reads live off each strap vs import-only.
+    NoopLimitations("noop_limitations", R.string.nav_noop_limitations, Icons.Filled.Rule),
     DataSources("data_sources", R.string.nav_data_sources, Icons.Filled.Storage),
     BackupSync("backup_sync", R.string.nav_backup_sync, Icons.Filled.CloudSync),
     FusedRecord("fused_record", R.string.nav_fused_record, Icons.AutoMirrored.Filled.CompareArrows),
@@ -211,7 +214,7 @@ private val drawerGroups: List<DrawerGroup> = listOf(
     ), defaultExpanded = true),
     DrawerGroup("Data", R.string.more_group_data, listOf(
         Destination.FusedRecord, Destination.AppleHealth, Destination.DataSources,
-        Destination.BackupSync, Destination.Devices,
+        Destination.BackupSync, Destination.Devices, Destination.NoopLimitations,
     ), defaultExpanded = false),
     DrawerGroup("App", R.string.more_group_app, listOf(
         Destination.Automations, Destination.SmartAlarm, Destination.Notifications,
@@ -427,6 +430,7 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
                     )
                 }
                 composable(Destination.DataSources.route) { DataSourcesScreen(viewModel) }
+                composable(Destination.NoopLimitations.route) { NoopLimitationsScreen() }
                 composable(Destination.BackupSync.route) { BackupSyncScreen() }
                 composable(Destination.Notifications.route) { NotificationsSettingsScreen(viewModel) }
                 composable(Destination.Settings.route) {

--- a/android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt
@@ -1,33 +1,27 @@
 package com.noop.ui
 
+import com.noop.R
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Remove
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
@@ -35,11 +29,12 @@ import androidx.compose.ui.unit.dp
 
 // MARK: - NoopLimitationsScreen — "what NOOP can (and can't) read off each strap"
 //
-// A companion to WhoopModelComparisonScreen (#490), reached from Settings → Strap. Where that screen is
-// prose-with-notes reassuring a 4.0 owner, this is the plain capability grid: every metric NOOP surfaces,
-// and whether it comes live off a 4.0 vs a 5.0/MG — no per-row prose, just the honest tri-state and a
-// legend. Marks mirror the values traced from the decoders/analytics: partial = an on-device estimate or an
-// experimental/firmware-gated read; "not from strap" = only an import (WHOOP CSV / Health) can fill it.
+// A More-tab page (Data group): the plain tri-state capability grid of what NOOP reads live off a WHOOP
+// 4.0 vs a 5.0/MG, note-free, with a legend in place of per-row prose. Marks mirror the decoder/analytics
+// truth (Interpreter / AnalyticsEngine / HistoricalStreams): full = read live; partial = an on-device
+// estimate or an experimental / firmware-gated read; none = not off the strap (SpO₂ % is import-only on
+// both; blood pressure has no path). iOS twin: NoopLimitationsView. Rendered through the shared
+// ScreenScaffold like every other More destination — the bottom bar carries navigation (no close button).
 
 /** Tri-state support for a metric on a given strap — honest, never overstated. */
 private enum class LimitState { FULL, PARTIAL, NONE }
@@ -63,26 +58,13 @@ private val LIMIT_ROWS: List<LimitRow> = listOf(
 )
 
 @Composable
-fun NoopLimitationsScreen(onClose: () -> Unit) {
-    val scroll = rememberScrollState()
-    Surface(modifier = Modifier.fillMaxSize(), color = Palette.surfaceBase) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            Header(onClose)
-            Hairline()
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-                    .verticalScroll(scroll)
-                    .padding(20.dp),
-                verticalArrangement = Arrangement.spacedBy(Metrics.sectionGap),
-            ) {
-                LimitTableCard()
-                LegendCard()
-            }
-            Hairline()
-            Footer(onClose)
-        }
+fun NoopLimitationsScreen() {
+    ScreenScaffold(
+        title = stringResource(R.string.nav_noop_limitations),
+        subtitle = "What each strap can read",
+    ) {
+        LimitTableCard()
+        LegendCard()
     }
 }
 
@@ -148,38 +130,6 @@ private fun SupportCell(state: LimitState) {
 @Composable
 private fun SupportGlyph(icon: ImageVector, tint: Color, label: String) {
     Icon(icon, contentDescription = label, tint = tint, modifier = Modifier.size(18.dp))
-}
-
-// MARK: - Header / footer (matches WhoopModelComparisonScreen's idiom)
-
-@Composable
-private fun Header(onClose: () -> Unit) {
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(20.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            Overline("Per strap", color = Palette.textTertiary)
-            Text("NOOP Limitations", style = NoopType.display(26f), color = Palette.textPrimary)
-            Text("What each WHOOP can read", style = NoopType.caption, color = Palette.textSecondary)
-        }
-        IconButton(onClick = onClose, modifier = Modifier.size(36.dp)) {
-            Icon(Icons.Filled.Close, contentDescription = "Close", tint = Palette.textTertiary, modifier = Modifier.size(22.dp))
-        }
-    }
-}
-
-@Composable
-private fun Footer(onClose: () -> Unit) {
-    Row(modifier = Modifier.fillMaxWidth().padding(16.dp), horizontalArrangement = Arrangement.End) {
-        Button(
-            onClick = onClose,
-            colors = ButtonDefaults.buttonColors(containerColor = Palette.accent, contentColor = Palette.surfaceBase),
-        ) {
-            Text("Done", modifier = Modifier.padding(horizontal = 24.dp))
-        }
-    }
 }
 
 @Composable

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -451,9 +451,6 @@ fun SettingsScreen(
     // Strap section by BOTH model owners. Clears up which features each strap supports — e.g. why the
     // strap-firmware broadcast-out is 5/MG-only while NOOP's own re-broadcast works on any strap.
     var showModelComparison by remember { mutableStateOf(false) }
-    // "NOOP Limitations" — the plain capability grid (what each strap can read live). Sibling of the model
-    // comparison, opened from the same Strap section.
-    var showLimitations by remember { mutableStateOf(false) }
 
     // "Recalibrate Charge baseline" confirm dialog (Charge advanced). Writes now-seconds to BOTH the
     // noop.hrvBaselineEpoch and noop.recoveryBaselineEpoch prefs so foldHistory re-seeds every baseline
@@ -1726,46 +1723,6 @@ fun SettingsScreen(
                             Text(uiString(R.string.l10n_settings_screen_whoop_4_0_vs_5_0_2babb05a), style = NoopType.headline, color = Palette.textPrimary)
                             Text(
                                 uiString(R.string.l10n_settings_screen_what_each_strap_can_read_and_51e7d3fc),
-                                style = NoopType.footnote,
-                                color = Palette.textSecondary,
-                            )
-                        }
-                        Text("›", style = NoopType.title2, color = Palette.accent)
-                    }
-                }
-
-                // "NOOP Limitations" — the plain 4.0 vs 5.0/MG capability grid (no prose). Same tap-through
-                // idiom as the model-comparison row above; honest about what reads live vs import-only.
-                val limitationsInteraction = remember { MutableInteractionSource() }
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .liquidPress(limitationsInteraction)
-                        .clip(RoundedCornerShape(10.dp))
-                        .background(Palette.surfaceInset)
-                        .border(1.dp, Palette.hairline, RoundedCornerShape(10.dp))
-                        .clickable(
-                            interactionSource = limitationsInteraction,
-                            indication = null,
-                        ) { showLimitations = true }
-                        .padding(horizontal = 14.dp, vertical = 12.dp)
-                        .semantics { contentDescription = "NOOP Limitations — what each strap can read" },
-                ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    ) {
-                        Icon(
-                            Icons.Filled.Info,
-                            contentDescription = null,
-                            tint = Palette.accent,
-                            modifier = Modifier.size(18.dp),
-                        )
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text("NOOP Limitations", style = NoopType.headline, color = Palette.textPrimary)
-                            Text(
-                                "What each strap can read live",
                                 style = NoopType.footnote,
                                 color = Palette.textSecondary,
                             )
@@ -3089,16 +3046,6 @@ fun SettingsScreen(
             }
         }
 
-        if (showLimitations) {
-            Dialog(
-                onDismissRequest = { showLimitations = false },
-                properties = DialogProperties(usePlatformDefaultWidth = false),
-            ) {
-                Surface(modifier = Modifier.fillMaxSize(), color = Palette.surfaceBase) {
-                    NoopLimitationsScreen(onClose = { showLimitations = false })
-                }
-            }
-        }
 
         // Steps-estimate calibration, opened from the Profile card's "Steps estimate" row. Same
         // full-screen Dialog idiom; a manual-coefficient write bumps `rev` so the Profile summary

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -31,6 +31,7 @@
     <string name="nav_automations">Automationen</string>
     <string name="nav_alarms">Wecker</string>
     <string name="nav_devices">Geräte</string>
+    <string name="nav_noop_limitations">NOOP-Grenzen</string>
     <string name="nav_data_sources">Datenquellen</string>
     <string name="nav_backup_sync">Backup &amp; Sync</string>
     <string name="nav_fused_record">Deine Daten, vereint</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1543,6 +1543,7 @@
     <string name="nav_automations">Automatizaciones</string>
     <string name="nav_alarms">Alarmas</string>
     <string name="nav_devices">Dispositivos</string>
+    <string name="nav_noop_limitations">Limitaciones de NOOP</string>
     <string name="nav_data_sources">Fuentes de datos</string>
     <string name="nav_backup_sync">Copia y sincronización</string>
     <string name="nav_fused_record">Tus datos, fusionados</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1543,6 +1543,7 @@
     <string name="nav_automations">Automatisations</string>
     <string name="nav_alarms">Alarmes</string>
     <string name="nav_devices">Appareils</string>
+    <string name="nav_noop_limitations">Limites de NOOP</string>
     <string name="nav_data_sources">Sources de données</string>
     <string name="nav_backup_sync">Sauvegarde et synchronisation</string>
     <string name="nav_fused_record">Vos données, fusionnées</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -31,6 +31,7 @@
     <string name="nav_automations">Automatizações</string>
     <string name="nav_alarms">Alarmes</string>
     <string name="nav_devices">Dispositivos</string>
+    <string name="nav_noop_limitations">Limitações do NOOP</string>
     <string name="nav_data_sources">Fontes de dados</string>
     <string name="nav_backup_sync">Cópia de segurança e sincronização</string>
     <string name="nav_fused_record">Os teus dados, fundidos</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -29,6 +29,7 @@
     <string name="nav_automations">自动化</string>
     <string name="nav_alarms">智能闹钟</string>
     <string name="nav_devices">设备管理</string>
+    <string name="nav_noop_limitations">NOOP 限制</string>
     <string name="nav_data_sources">数据源</string>
     <string name="nav_backup_sync">备份与同步</string>
     <string name="nav_fused_record">融合数据</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="nav_automations">Automations</string>
     <string name="nav_alarms">Alarms</string>
     <string name="nav_devices">Devices</string>
+    <string name="nav_noop_limitations">NOOP Limitations</string>
     <string name="nav_data_sources">Data Sources</string>
     <string name="nav_backup_sync">Backup &amp; Sync</string>
     <string name="nav_fused_record">Your Data, Fused</string>


### PR DESCRIPTION
Moves the NOOP Limitations capability grid out of Settings and into the primary navigation on every platform, as requested.

## Placement
- **Android** — a first-class More-tab destination in the **Data** group (next to Devices). Was a Settings → Strap dialog.
- **iOS** — a `MoreDestination` in the More tab's **Data** section.
- **macOS** — a `NavItem` in the sidebar's **Data & App** group (wired through titleKey / localizedTitle / icon / detail switch + the routability group).

The screen is now a shared **`ScreenScaffold` page** (`NoopLimitationsScreen` / `NoopLimitationsView`) instead of a modal — navigation chrome (bottom bar / back / tab) handles dismissal, so the X/Done chrome is gone. The button, state, and dialog/sheet are removed from the shared `SettingsView` and the Android `SettingsScreen`.

## Verification
- Android `compileFullDebugKotlin` ✓; new `nav_noop_limitations` string in all 6 locales.
- iOS + macOS app targets compiled via `app-build.yml` (dispatched on this branch).
- i18n `--ci` ✓ — no new catalog strings (all reuse keys added with #1135); Android baseline reconciled (7 stale entries pruned).
- Design tokens only; render-only.

Content unchanged from #1135 (same 12-row 4.0-vs-5.0/MG tri-state table + legend).