### PR TITLE
fix(ios): protect reject-history archive for locked background sync

### DIFF
--- a/Strand/Collect/RawHistoryArchive.swift
+++ b/Strand/Collect/RawHistoryArchive.swift
@@ -115,6 +115,11 @@ struct RawHistoryArchive {
         self.maxBytes = maxBytes
         self.perVersionFloor = perVersionFloor
         self.zeroPayloadFloor = zeroPayloadFloor
+        #if os(iOS)
+        // Migrate an archive created by an older build while launch is normally foreground/unlocked.
+        // The write path repeats this before every append so a first background write is covered too.
+        try? prepareStorageForBackgroundAccess()
+        #endif
     }
 
     /// The archive file URL (does not create anything).
@@ -147,6 +152,14 @@ struct RawHistoryArchive {
     func archive(_ frames: [[UInt8]], trim: UInt32, family: DeviceFamily) -> Result {
         guard !frames.isEmpty else { return .written(count: 0) }
         let url = fileURL
+        // Ensure the directory exists AND (on iOS) carries after-first-unlock protection before the reads
+        // below, so a locked background wake can read the existing archive and rewrite it rather than
+        // failing the mandatory pre-ack write. Directory creation is the only hard failure here.
+        do {
+            try prepareStorageForBackgroundAccess()
+        } catch {
+            return .failed
+        }
         let capturedAtMs = Date().timeIntervalSince1970 * 1000
         // Build the new JSONL lines (each newline-terminated). The version that drives floor-aware
         // retention (#344) is re-derived per line from the stored frame inside `evictLines`.
@@ -189,8 +202,8 @@ struct RawHistoryArchive {
                                                floor: perVersionFloor, zeroFloor: zeroPayloadFloor)
         let data = Data(kept.joined().utf8)
         do {
-            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
             try data.write(to: url, options: .atomic)   // atomic rewrite; durable before the ack
+            applyBackgroundProtectionToArchive()        // atomic replace makes a new inode — re-protect it
             return .written(count: frames.count)
         } catch {
             return .failed
@@ -199,7 +212,7 @@ struct RawHistoryArchive {
 
     /// Append `data` to `url`, fsyncing before returning so it is durable BEFORE the trim ack.
     private func appendDurably(_ data: Data, to url: URL) throws {
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try prepareStorageForBackgroundAccess()
         if FileManager.default.fileExists(atPath: url.path) {
             let handle = try FileHandle(forWritingTo: url)
             defer { try? handle.close() }
@@ -208,7 +221,39 @@ struct RawHistoryArchive {
             try handle.synchronize()   // durable BEFORE the ack — the point of the archive
         } else {
             try data.write(to: url, options: .atomic)
+            applyBackgroundProtectionToArchive()   // new file — set its protection (existing files keep theirs)
         }
+    }
+
+    /// Make the reject archive readable after the first unlock, matching the primary SQLite store's policy
+    /// in `StorePaths`. Background BLE can be woken while the phone is locked; the iOS default (complete)
+    /// protection would otherwise make this mandatory pre-ack write fail and force the strap to resend the
+    /// same history chunk. Applied to the directory (future files inherit it) and any archive left by an
+    /// older build. Non-iOS platforms only need the directory created — protection classes don't apply.
+    private func prepareStorageForBackgroundAccess() throws {
+        let fm = FileManager.default
+        try fm.createDirectory(at: directory, withIntermediateDirectories: true)
+        #if os(iOS)
+        let protection: [FileAttributeKey: Any] = [
+            .protectionKey: FileProtectionType.completeUntilFirstUserAuthentication,
+        ]
+        try? fm.setAttributes(protection, ofItemAtPath: directory.path)
+        if fm.fileExists(atPath: fileURL.path) {
+            try? fm.setAttributes(protection, ofItemAtPath: fileURL.path)
+        }
+        #endif
+    }
+
+    /// Atomic replacement creates a NEW inode, so re-apply the file protection after every fresh write
+    /// rather than relying on directory inheritance alone. Best-effort — the directory policy is the
+    /// durable guarantee; this closes the window on the specific file.
+    private func applyBackgroundProtectionToArchive() {
+        #if os(iOS)
+        try? FileManager.default.setAttributes(
+            [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+            ofItemAtPath: fileURL.path
+        )
+        #endif
     }
 
     /// How one archived line is classified for retention: which version bucket it belongs to, and

--- a/StrandTests/RawHistoryArchiveReplayTests.swift
+++ b/StrandTests/RawHistoryArchiveReplayTests.swift
@@ -98,4 +98,34 @@ final class RawHistoryArchiveReplayTests: XCTestCase {
             // expected — bootstrapStore's catch leaves the gate un-advanced.
         }
     }
+
+    #if os(iOS)
+    /// #649: locked/background BLE must be able to write rejects before acknowledging the strap trim, so the
+    /// archive directory + file carry after-first-unlock protection (matching the primary SQLite store),
+    /// not iOS's default complete protection which would fail a locked write.
+    ///
+    /// The iOS Simulator does not enforce data protection and may not report `.protectionKey` at all; when
+    /// it doesn't, the write-succeeded check above is all we can assert here, so skip rather than fail on a
+    /// platform that can't answer. On a real device (or a sim that does report it) the attribute is checked.
+    func testArchiveAndDirectoryUseBackgroundReadableProtection() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("noop-protection-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let archive = RawHistoryArchive(directory: dir)
+        let frame: [UInt8] = [0xAA, 0x01, 0x00, 0x00, 47, 25, 0x01]
+        guard case .written(count: 1) = archive.archive([frame], trim: 1, family: .whoop4) else {
+            return XCTFail("archive write should succeed")
+        }
+
+        let fm = FileManager.default
+        let expected = FileProtectionType.completeUntilFirstUserAuthentication
+        let directoryProtection = try fm.attributesOfItem(atPath: dir.path)[.protectionKey] as? FileProtectionType
+        let fileProtection = try fm.attributesOfItem(atPath: archive.fileURL.path)[.protectionKey] as? FileProtectionType
+        try XCTSkipIf(directoryProtection == nil && fileProtection == nil,
+                      "Data protection attributes are not reported on this platform (iOS Simulator).")
+        XCTAssertEqual(directoryProtection, expected)
+        XCTAssertEqual(fileProtection, expected)
+    }
+    #endif
 }


### PR DESCRIPTION
Carries forward **#1057 by @whisp0** — which had no maintainer response and had gone stale (conflicting) against `main`. Re-applied cleanly onto the current `RawHistoryArchive` (which since gained `zeroPayloadFloor`), with the regression test hardened for the iOS Simulator.

Closes #649. Credit for the fix is @whisp0's; this is a rebase + review-nits pass so it can land.

## The bug
`RawHistoryArchive` writes to its own App Support directory and inherited iOS's **default (complete)** file protection — unlike the primary SQLite store, which uses `completeUntilFirstUserAuthentication` precisely so background Bluetooth work can write while the phone is **locked**. An archive write must finish before NOOP acks the strap's history trim; a locked-wake write would fail, hold the ack, and make the strap **resend the same chunk**.

## The fix (@whisp0's design, unchanged in substance)
Apply after-first-unlock protection to the archive **directory** (new files inherit it) and **file**: migrate on `init` (foreground/unlocked), re-prepare before every write, and re-apply to the file after each atomic (new-inode) rewrite. macOS and other platforms only create the directory — protection classes don't apply.

## Nits addressed vs #1057
- **Rebased** onto current `main` (the removed `createDirectory` sites had shifted; `zeroPayloadFloor` is preserved).
- **Test made Simulator-safe:** the iOS Simulator doesn't enforce data protection and may not report `.protectionKey`, which would false-fail the original assertion. Now `XCTSkipIf` when the attribute is absent, still asserting it on a real device.

## Verification
- App targets (macOS Strand + iOS NOOPiOS) compiling via `app-build` (dispatched on this branch) — the original PR couldn't do a full build (Command Line Tools only).
- iOS-only change (file protection); no Android twin needed — Android file access isn't gated this way.