### PR TITLE
fix(ios): don't resubmit the scheduled-export BGTask once disabled

### DIFF
--- a/Strand/System/ScheduledDebugExport.swift
+++ b/Strand/System/ScheduledDebugExport.swift
@@ -135,6 +135,11 @@ enum ScheduledDebugExport {
 
     static var isEnabled: Bool { UserDefaults.standard.bool(forKey: K.enabled) }
 
+    /// A delivered BGAppRefresh request is single-shot and should schedule its successor only while the
+    /// user still has scheduled exports enabled. Kept outside the iOS-only `register` block so the
+    /// disable-versus-delivery race is testable on every platform.
+    static func backgroundTaskShouldResubmit(enabled: Bool) -> Bool { enabled }
+
     /// Time-of-day to export, minutes since local midnight. Clamped to a valid minute. Default 07:00.
     static var timeMinutes: Int {
         let v = UserDefaults.standard.object(forKey: K.time) as? Int ?? defaultTimeMinutes
@@ -306,8 +311,16 @@ enum ScheduledDebugExport {
             // report that honestly as a failure (so the run is retried) instead of leaving the task
             // marked incomplete, and instead of the old hardcoded `success: true`.
             task.expirationHandler = { completion.finish(success: false) }
-            // Write the drop, then immediately request the next one (BGAppRefresh is single-shot).
-            // `catchUpIfDue()` already no-ops (returning true) when the feature is off.
+            // BGAppRefresh is single-shot. `setEnabled(false)` cancels the pending request, but iOS can
+            // already be delivering one when it does — `cancel` loses that race. Gate the successor on a
+            // fresh enabled read so a stale delivery can't resurrect a daily background wake the user
+            // turned off. Disabled is a terminal no-op: nothing to export, nothing to resubmit.
+            guard backgroundTaskShouldResubmit(enabled: isEnabled) else {
+                completion.finish(success: true)
+                return
+            }
+            // Write the drop, then immediately request the next one.
+            // `catchUpIfDue()` already no-ops (returning true) when nothing is due.
             let succeeded = catchUpIfDue()
             submitBackgroundRequest()
             completion.finish(success: succeeded)

--- a/StrandTests/ScheduledDebugExportTests.swift
+++ b/StrandTests/ScheduledDebugExportTests.swift
@@ -55,4 +55,10 @@ final class ScheduledDebugExportTests: XCTestCase {
         // The default (14) must be one of the choices the picker actually offers.
         XCTAssertTrue(ScheduledDebugExport.keepOptions.contains(14))
     }
+
+    /// A stale BGTask delivery must not re-arm tomorrow's wake once the user has disabled the feature.
+    func testBackgroundTaskResubmitsOnlyWhileEnabled() {
+        XCTAssertTrue(ScheduledDebugExport.backgroundTaskShouldResubmit(enabled: true))
+        XCTAssertFalse(ScheduledDebugExport.backgroundTaskShouldResubmit(enabled: false))
+    }
 }


### PR DESCRIPTION
Carries forward **#1054 by @whisp0** — which was conflicting because it targeted the export handler *before* #955 (merged 2026-08-06) restructured it. The bug it fixes **survived #955** and is live on `main`. Re-applied onto the current `register()` (with #955's `TaskCompletionGuard` + `expirationHandler`), full credit to @whisp0.

Closes the same race as #1054.

## The bug (still present after #955)
`setEnabled(false)` cancels the pending `BGAppRefreshTaskRequest`, but iOS can already be **delivering** one when it does — `cancel` loses the race. The handler checks the preference before exporting, but `submitBackgroundRequest()` runs **unconditionally**, so a stale delivery re-arms tomorrow's wake — resurrecting the daily background export the user explicitly turned off.

## The fix (@whisp0's design)
Gate the successor (catch-up + resubmit) on a fresh `isEnabled` read; **disabled is a terminal no-op** that completes the task cleanly. Enabled behaviour is unchanged. The policy is extracted as `backgroundTaskShouldResubmit(enabled:)` so the disable-vs-delivery decision is testable off-device.

## Verification
- App targets (macOS Strand + iOS NOOPiOS) compiling via `app-build` (dispatched on this branch) — the original couldn't do a full build.
- iOS-only: it's a `BGAppRefresh` single-shot-resubmit race; Android's scheduled export uses WorkManager periodic work (cancelled on disable, doesn't self-resubmit), so no equivalent race and no twin.