### PR TITLE
workouts(apple): reject a manual row whose end lands in the future (parity with #1067)

### DIFF
--- a/Strand/Data/WorkoutSource.swift
+++ b/Strand/Data/WorkoutSource.swift
@@ -345,8 +345,15 @@ enum WorkoutSource: Equatable {
         if let k = energyKcal, k < 0 || k > 20_000 { return nil }
         let s = Int(start.timeIntervalSince1970)
         guard s > 0 else { return nil }
-        return WorkoutRow(startTs: s, endTs: s + durationMin * 60, sport: trimmed, source: "manual",
-                          durationS: Double(durationMin) * 60, energyKcal: energyKcal,
+        // Reject a row whose END lands in the future: `start <= now` alone still lets `start + duration`
+        // overshoot (a start 10 min ago + a 45 min duration ends 35 min ahead). Overflow-safe, and a row
+        // ending exactly at `now` stays valid. Twin of Android `WorkoutEditing` (#1067).
+        let durationSeconds = durationMin * 60
+        guard durationSeconds <= Int.max - s else { return nil }
+        let end = s + durationSeconds
+        guard end <= Int(now.timeIntervalSince1970) else { return nil }
+        return WorkoutRow(startTs: s, endTs: end, sport: trimmed, source: "manual",
+                          durationS: Double(durationSeconds), energyKcal: energyKcal,
                           avgHr: avgHr, maxHr: nil, strain: nil, distanceM: nil,
                           zonesJSON: nil, notes: nil)
     }

--- a/StrandTests/WorkoutSourceTests.swift
+++ b/StrandTests/WorkoutSourceTests.swift
@@ -277,6 +277,20 @@ final class WorkoutSourceTests: XCTestCase {
         XCTAssertNil(WorkoutSource.buildManualRow(start: start, durationMin: 30, sport: "Run", avgHr: nil, energyKcal: 99_999, now: now))
     }
 
+    /// #1067 twin: a start at/before `now` still lets `start + duration` overshoot into the future. End
+    /// exactly at `now` is valid; one second beyond is rejected.
+    func testBuildManualRowRejectsAFutureEndButAllowsEndExactlyAtNow() {
+        let start = Date(timeIntervalSince1970: 1_700_000_000)   // 45 min = 2700 s
+        // End exactly at now → valid.
+        XCTAssertNotNil(WorkoutSource.buildManualRow(start: start, durationMin: 45, sport: "Run",
+                                                     avgHr: nil, energyKcal: nil,
+                                                     now: start.addingTimeInterval(2700)))
+        // start ≤ now, but start + duration overshoots now by one second → rejected.
+        XCTAssertNil(WorkoutSource.buildManualRow(start: start, durationMin: 45, sport: "Run",
+                                                  avgHr: nil, energyKcal: nil,
+                                                  now: start.addingTimeInterval(2699)))
+    }
+
     // MARK: - preservingCaptured
 
     func testPreservingCapturedCarriesUnexposedFieldsOnEdit() {


### PR DESCRIPTION
Follow-up to **#1067** (@TAKEOFF69), which fixed this on Android. The Swift twin `WorkoutSource.buildManualRow` had the **same gap**: it guarded `start <= now` but computed `endTs = start + durationMin * 60` with no end-in-future check — so a start 10 min ago + a 45 min duration was accepted with an end 35 min in the future.

## Fix
Add the overflow-safe future-end guard, mirroring the Kotlin logic:
- compute `durationSeconds`, guard `durationSeconds <= Int.max - s` (overflow-safe), then `guard end <= now`.
- a row ending **exactly at now** stays valid; one second beyond is rejected.

Keeps manual-workout validation byte-parity across platforms.

## Verification
- App targets (macOS Strand + iOS NOOPiOS) compiling via `app-build` (dispatched on this branch).
- Added `testBuildManualRowRejectsAFutureEndButAllowsEndExactlyAtNow` (exact-now valid, one-second-over rejected). The existing `testBuildManualRowHappyPath` (end 2700 s ≤ now 3600 s) still passes under the guard.
- Apple-only: this is the twin of the merged Android fix; the Android side already landed in #1067.