### PR TITLE
widget(ios): read the App Group once on the live fast path (follow-up to #1055)

### DIFF
--- a/StrandiOS/Widgets/WidgetPublish.swift
+++ b/StrandiOS/Widgets/WidgetPublish.swift
@@ -90,19 +90,25 @@ extension WidgetSnapshot {
             await publish(from: model)
             return
         }
+        // The loaded value IS the current on-disk state (this runs on the main actor, so nothing else
+        // rewrote it between here and the save); hand it to the dedup so the live path reads the App Group
+        // ONCE per tick instead of loading it again inside saveAndReloadIfChanged.
+        let previous = snap
         snap.bpm = model.bpm ?? model.live.heartRate
         snap.batteryPct = model.live.batteryPct.map { Int($0.rounded()) }
         snap.bonded = model.live.bonded
         snap.updated = now
-        saveAndReloadIfChanged(snap)
+        saveAndReloadIfChanged(snap, previous: previous)
     }
 
     /// Persist and ask WidgetKit for a new timeline only when a rendered field changed. The snapshot's
     /// timestamp is metadata only (no widget family displays it), so an otherwise-identical publish is a
     /// true no-op rather than an App-Group write plus an extension reload.
+    /// `previous` lets the live fast path pass the snapshot it already loaded (it runs on the main actor,
+    /// so that value is still current); the full publish path omits it and this loads once for the dedup.
     @MainActor
-    private static func saveAndReloadIfChanged(_ snap: WidgetSnapshot) {
-        let previous = load()
+    private static func saveAndReloadIfChanged(_ snap: WidgetSnapshot, previous: WidgetSnapshot? = nil) {
+        let previous = previous ?? load()
         if renderedContentChanged(from: previous, to: snap) {
             snap.save()
             WidgetCenter.shared.reloadAllTimelines()


### PR DESCRIPTION
Follow-up to **#1055** (@whisp0's live-only widget publish path). No behaviour change — a micro-opt in the spirit of that PR.

## The nit
#1055's live path reads the App Group **twice** per tick: `publishLive` calls `load()` to get the snapshot, then `saveAndReloadIfChanged` calls `load()` again to fetch the same value for the dedup compare. In a PR whose whole point is cutting redundant App-Group work on the per-minute HR hook, that extra read is worth removing.

## The fix
Thread the snapshot `publishLive` already loaded into `saveAndReloadIfChanged(_:previous:)`. It all runs on the main actor, so the loaded value is still the current on-disk state — the second read returned the identical snapshot anyway. The full `publish` path is unchanged (omits `previous`, loads its own for the dedup).

## Verification
- App targets (macOS Strand + iOS NOOPiOS) compiling via `app-build` (dispatched) — the original couldn't do a full build.
- Behaviour-identical: `previous` is the same value either path; no concurrency between the two former loads (both `@MainActor`).
- iOS-only (widgets); no macOS/Android surface.