### PR TITLE
capture: summarise frameTiming into one rolling line instead of per-transition

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2293,6 +2293,19 @@ class WhoopBleClient(
     // state, touched only inside the CONNECTION-domain gate.
     private val connFrameCounts = LinkedHashMap<String, Int>()
     private var connFrameWindowStartMs = 0L
+
+    /** Flush the accumulated frame-timing counts as ONE summary line and reset the window. No-op when
+     *  nothing has accumulated (capture off, or already flushed). Called on the 60s boundary AND on
+     *  disconnect — the latter so the frames RIGHT BEFORE a drop are recorded rather than stranded in an
+     *  un-flushed window, and so the next connection's window can't span the (possibly hours-long) quiet
+     *  gap and report a misleading windowSec. */
+    private fun flushFrameTimingSummary() {
+        if (connFrameCounts.isEmpty()) return
+        val elapsedSec = ((System.currentTimeMillis() - connFrameWindowStartMs).coerceAtLeast(0L)) / 1000L
+        log(formatFrameTimingSummary(connFrameCounts, elapsedSec), com.noop.testcentre.TestDomain.CONNECTION)
+        connFrameCounts.clear()
+        connFrameWindowStartMs = 0L
+    }
     /** #580: tracks CONSECUTIVE empty 5/MG offloads so a 5/MG whose firmware serves no history (but streams
      *  live HR fine) reads as "history sync experimental on 5.0" instead of a sync error, and the 120s
      *  bounce loop backs off while live HR is flowing. Reset on connect / a banking offload. Twin of macOS. */
@@ -5258,13 +5271,7 @@ class WhoopBleClient(
             val nowMs = System.currentTimeMillis()
             if (connFrameWindowStartMs == 0L) connFrameWindowStartMs = nowMs
             connFrameCounts[parsed.typeName] = (connFrameCounts[parsed.typeName] ?: 0) + 1
-            val elapsedMs = nowMs - connFrameWindowStartMs
-            if (elapsedMs >= FRAME_TIMING_SUMMARY_WINDOW_MS) {
-                log(formatFrameTimingSummary(connFrameCounts, elapsedMs / 1000L),
-                    com.noop.testcentre.TestDomain.CONNECTION)
-                connFrameCounts.clear()
-                connFrameWindowStartMs = nowMs
-            }
+            if (nowMs - connFrameWindowStartMs >= FRAME_TIMING_SUMMARY_WINDOW_MS) flushFrameTimingSummary()
         }
 
         when (parsed.typeName) {
@@ -7120,6 +7127,10 @@ class WhoopBleClient(
 
     @SuppressLint("MissingPermission")
     private fun handleDisconnect(status: Int) {
+        // #1151: flush any pending frame-timing window so the frames right before this drop are recorded
+        // (not stranded), and the next connection starts a fresh window rather than spanning the gap. No-op
+        // when capture is off. Do it BEFORE the connect-down line so the summary reads before the drop.
+        flushFrameTimingSummary()
         // Snapshot the hold time and clear it IMMEDIATELY: every drop log below reads the snapshot, and a
         // stale `linkUpSinceMs` surviving into the next drop would report a hold time for a link that never
         // reached STATE_CONNECTED — the diagnostic would then invent exactly the evidence it exists to find.

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1368,6 +1368,21 @@ class WhoopBleClient(
          *  BackfillContinuation.defaultBehindGapSeconds (and StuckStrapDetector's behindGapSeconds). */
         const val AUTO_CONTINUE_BEHIND_GAP_SECONDS = 300L
 
+        /** #1151: rolling window over which detailed-capture frame timing is summarised into one line. */
+        const val FRAME_TIMING_SUMMARY_WINDOW_MS = 60_000L
+
+        /** One detailed-capture line summarising [counts] (frame typeName → count) over [windowSec] seconds,
+         *  types listed most-frequent first: `frameTiming 60s: 84 frame(s) [EVENT×40, COMMAND_RESPONSE×30,
+         *  METADATA×14]`. Empty counts → a `0 frame(s) []` line (harmless; the caller only flushes after real
+         *  frames). Pure/deterministic (ties broken by type name) so it's unit-testable. */
+        fun formatFrameTimingSummary(counts: Map<String, Int>, windowSec: Long): String {
+            val total = counts.values.sum()
+            val types = counts.entries
+                .sortedWith(compareByDescending<Map.Entry<String, Int>> { it.value }.thenBy { it.key })
+                .joinToString(", ") { "${it.key}×${it.value}" }
+            return "frameTiming ${windowSec}s: $total frame(s) [$types]"
+        }
+
         /** #928: how far past the WALL CLOCK the strap-reported "newest" may sit before it is implausible.
          *  A strap clock set in the FUTURE makes [dataRangeNewestUnix] read ahead of every real frontier,
          *  so the "backlog remains" guard would report backlog forever and burn the whole auto-continue
@@ -2272,7 +2287,12 @@ class WhoopBleClient(
      *  read AND written exclusively inside the mode gate, so the live hot path is untouched when the mode is
      *  off. The Swift side instead reuses LiveState.lastFrameType (a production field the Live console readout
      *  maintains anyway); Android has no such field, so this mirrors the emit while staying zero-cost off. */
-    private var connLastFrameType: String? = null
+    // #1151 detailed-capture: frame timing is accumulated per-type over a rolling window and flushed as ONE
+    // summary line, instead of a line per frame-TYPE transition (which was ~a third of a real capture, so the
+    // noise crowded actionable offload/reconnect/re-score history out of the 8MB rolling buffer). Test-only
+    // state, touched only inside the CONNECTION-domain gate.
+    private val connFrameCounts = LinkedHashMap<String, Int>()
+    private var connFrameWindowStartMs = 0L
     /** #580: tracks CONSECUTIVE empty 5/MG offloads so a 5/MG whose firmware serves no history (but streams
      *  live HR fine) reads as "history sync experimental on 5.0" instead of a sync error, and the 120s
      *  bounce loop backs off while live HR is flowing. Reset on connect / a banking offload. Twin of macOS. */
@@ -5228,18 +5248,22 @@ class WhoopBleClient(
         // Reject frames that failed their checksum — never let bad bytes drive state.
         if (parsed.crcOk == false) return
 
-        // Connection test mode: one tagged line per genuine frame-TYPE transition (not per frame - the raw
-        // flood repeats one type, so the transition guard naturally throttles it). Gated FIRST so this is
-        // genuinely zero-work on the live hot path when the mode is off: the type compare AND the
-        // connLastFrameType write both happen only inside the gate, so a frame on the non-test path touches
-        // no extra state at all. (connLastFrameType is test-only here; the macOS FrameRouter instead reuses
-        // its EXISTING lastFrameType field, which the Live console readout maintains anyway, so on macOS the
-        // per-change write is not extra work. Android has no such production field, hence the gate.)
+        // Connection test mode: accumulate frames by type and flush ONE `frameTiming` SUMMARY line per
+        // rolling window (#1151), instead of a line per frame-TYPE transition — during offloads/command
+        // bursts the type flips constantly, so the old per-transition log was ~a third of a real capture and
+        // aged actionable history out of the 8MB rolling buffer. Gated FIRST so a frame on the non-test path
+        // touches no extra state at all. (Android-only diagnostic; macOS uses FrameRouter's own lastFrameType
+        // for the Live console — a different surface, untouched here.)
         if (testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)) {
-            if (parsed.typeName != connLastFrameType) {
-                log("frameTiming type=${parsed.typeName} t=${System.currentTimeMillis() / 1000L}s",
+            val nowMs = System.currentTimeMillis()
+            if (connFrameWindowStartMs == 0L) connFrameWindowStartMs = nowMs
+            connFrameCounts[parsed.typeName] = (connFrameCounts[parsed.typeName] ?: 0) + 1
+            val elapsedMs = nowMs - connFrameWindowStartMs
+            if (elapsedMs >= FRAME_TIMING_SUMMARY_WINDOW_MS) {
+                log(formatFrameTimingSummary(connFrameCounts, elapsedMs / 1000L),
                     com.noop.testcentre.TestDomain.CONNECTION)
-                connLastFrameType = parsed.typeName
+                connFrameCounts.clear()
+                connFrameWindowStartMs = nowMs
             }
         }
 

--- a/android/app/src/test/java/com/noop/ble/FrameTimingSummaryTest.kt
+++ b/android/app/src/test/java/com/noop/ble/FrameTimingSummaryTest.kt
@@ -1,0 +1,49 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [WhoopBleClient.formatFrameTimingSummary] (#1151): the detailed capture now flushes ONE rolling
+ * summary line for frame timing instead of a line per frame-TYPE transition (which was ~a third of a real
+ * capture). Pure formatter → unit-testable without a GATT stack.
+ */
+class FrameTimingSummaryTest {
+
+    @Test
+    fun summarisesTotalAndListsTypesMostFrequentFirst() {
+        val counts = linkedMapOf("METADATA" to 14, "EVENT" to 40, "COMMAND_RESPONSE" to 30)
+        assertEquals(
+            "frameTiming 60s: 84 frame(s) [EVENT×40, COMMAND_RESPONSE×30, METADATA×14]",
+            WhoopBleClient.formatFrameTimingSummary(counts, 60L),
+        )
+    }
+
+    /** Deterministic ordering: equal counts break ties by type name, so the line never flaps run-to-run. */
+    @Test
+    fun tiesAreBrokenByTypeNameSoTheLineIsStable() {
+        val counts = linkedMapOf("EVENT" to 5, "COMMAND_RESPONSE" to 5, "METADATA" to 5)
+        assertEquals(
+            "frameTiming 30s: 15 frame(s) [COMMAND_RESPONSE×5, EVENT×5, METADATA×5]",
+            WhoopBleClient.formatFrameTimingSummary(counts, 30L),
+        )
+    }
+
+    @Test
+    fun singleTypeAndWindowSecondsAreEchoed() {
+        assertEquals(
+            "frameTiming 75s: 3 frame(s) [EVENT×3]",
+            WhoopBleClient.formatFrameTimingSummary(linkedMapOf("EVENT" to 3), 75L),
+        )
+    }
+
+    /** The compression the change is FOR: N frame lines collapse to one, and the total is preserved. */
+    @Test
+    fun collapsesManyTransitionsIntoOneLineKeepingTheTotal() {
+        val counts = linkedMapOf("EVENT" to 500, "COMMAND_RESPONSE" to 300, "METADATA" to 200)
+        val line = WhoopBleClient.formatFrameTimingSummary(counts, 60L)
+        assertTrue("total must be the sum", line.contains("1000 frame(s)"))
+        assertEquals("one line, not 1000", 1, line.lines().size)
+    }
+}


### PR DESCRIPTION
Closes #1151. From the same WHOOP 4.0 capture that surfaced #1144.

## Why
`[connection] frameTiming` was **9,336 of ~29k lines (32%)** of a real detailed capture — one line per frame-TYPE transition, and during offloads/command bursts the type flips constantly (COMMAND_RESPONSE ↔ EVENT ↔ METADATA ↔ CONSOLE_LOGS). The capture is a fixed 8MB×2 rolling buffer, so that noise ages the *actionable* history (offload results, reconnects, re-scores, the `[phonebattery]` curve) out of the window faster.

## What
Accumulate frames by type over a 60s window and flush **one** summary line:
```
frameTiming 60s: 84 frame(s) [EVENT×40, COMMAND_RESPONSE×30, METADATA×14]
```
~1 line/min instead of ~8, while still showing frame activity by type. Types are listed most-frequent-first with ties broken by name, so the line is deterministic.

## No-regression
- Still gated FIRST on the CONNECTION test domain → **zero work when capture is off** (unchanged hot path).
- No BLE/analytics behaviour change — purely what's written to the diagnostic file.
- Android-only diagnostic tooling (#1121); macOS uses FrameRouter's own `lastFrameType` for the Live console — a different surface, untouched. No Swift twin.
- `connLastFrameType` fully removed (no dangling refs).
- Pure formatter unit-tested (`FrameTimingSummaryTest`); full `com.noop.ble.*` suite green locally; i18n `--ci` green (log strings aren't UI copy).