### PR TITLE
fix(ble): throttle 5/MG battery poll + stretch empty-history backfill

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -557,11 +557,41 @@ public final class BLEManager: NSObject, ObservableObject {
             ? max(baseSeconds, lowSeconds) : baseSeconds
     }
 
+    /// #battery: pure 5/MG battery-read throttle decision, unit-testable without a CoreBluetooth seam.
+    /// Returns true when no prior read exists (the first read of a connection, or post-disconnect re-seed)
+    /// OR when at least `whoop5BatteryReadMinIntervalSeconds` has elapsed since the last read. Stops the
+    /// 30 s keep-alive tick from re-reading 0x2A19 every cycle. Twin of the Android `keepAliveTick % 2 == 0`
+    /// ~60 s cadence (WhoopBleClient keepAliveFire).
+    static func shouldPollWhoop5Battery(lastReadAt: Date?, now: Date = Date()) -> Bool {
+        guard let last = lastReadAt else { return true }
+        return now.timeIntervalSince(last) >= whoop5BatteryReadMinIntervalSeconds
+    }
+
+    /// #battery: pure periodic-offload interval for a 5/MG whose history is known-empty, unit-testable
+    /// without a CoreBluetooth seam. Stretches to the low-battery floor (45 min) regardless of battery %,
+    /// because an experimental-history 5/MG banks nothing per pass. Stacks with the BackfillPolicy
+    /// empty-backoff (which engages one cycle later, at 3 empties). Twin of Android `nextBackfillDelayMs`'s
+    /// `whoop5EmptyOffload.historyEmpty` branch.
+    static func whoop5EmptyHistoryBackfillInterval(baseSeconds: Int, lowSeconds: Int,
+                                                   historyEmpty: Bool) -> Int {
+        historyEmpty ? max(baseSeconds, lowSeconds) : baseSeconds
+    }
+
     /// Keep-alive: re-arm realtime, poll battery, and bounce a stalled link so streaming
     /// never silently dies. Started on bond, cancelled on disconnect.
     private var keepAliveTimer: DispatchSourceTimer?
     static let keepAliveIntervalSeconds = 30
     private var keepAliveTick = 0
+    /// #battery: minimum gap between 5/MG 0x2A19 battery reads. `enableLiveNotifications` fires from the
+    /// 30 s keep-alive tick AND once each from the CLIENT_HELLO-ack / post-bond callers, so without a
+    /// throttle a 5/MG was READ every ~30 s — 2 880 GATT reads/day, 2× the Android twin's ~60 s cadence
+    /// (WhoopBleClient keepAliveFire polls 5/MG battery on `keepAliveTick % 2 == 0`) and 20× finer than
+    /// the BatteryEstimator's own 600 s same-% throttle can consume. The post-bond / CLIENT_HELLO-ack
+    /// reads still fire promptly (the first read of a connection has `lastBatteryReadAt == nil`); only
+    /// the repeating keep-alive ticks are spaced to this floor. Reset to nil on disconnect so the next
+    /// connect reads immediately. Parity fix — Android was already at ~60 s, this brings iOS to match.
+    static let whoop5BatteryReadMinIntervalSeconds: TimeInterval = 60
+    private var lastBatteryReadAt: Date?
     /// If a persisted/missing strap-family preference points at the wrong service, a service-filtered
     /// BLE scan can run forever even though the strap is nearby (the common "won't reconnect after an
     /// update" report). Rotate between WHOOP families after a short miss and persist whichever family
@@ -2355,7 +2385,22 @@ public final class BLEManager: NSObject, ObservableObject {
 
     /// The next periodic-offload interval — normally `backfillIntervalSeconds`, stretched when low on
     /// power (#477). Reads the battery snapshot only when the lever is armed (threshold > 0).
+    /// #battery: a 5/MG whose history offload is known-empty (`whoop5EmptyOffload.historyEmpty`, crossed
+    /// after 2 consecutive empty offloads) is stretched to the low-battery cadence (45 min) regardless of
+    /// battery % — history sync is experimental on 5.0 and such a strap banks nothing per pass, so a 15-min
+    /// periodic kick just holds the link ~60 s for zero data. The BackfillPolicy empty-backoff also
+    /// stretches (after 3 empties, doubling to a 1-hr cap), but this engages one cycle earlier (the
+    /// tracker's quietThreshold is 2) and at a fixed 45-min floor that stacks with it. Twin of Android
+    /// `nextBackfillDelayMs`. Resets with `whoop5EmptyOffload` on disconnect (a fresh connect re-probes).
     private func nextBackfillInterval() -> Int {
+        // #battery: known-empty-history 5/MG → stretch to the 45-min floor before any battery lever.
+        if selectedModel.deviceFamily == .whoop5 {
+            let stretched = BLEManager.whoop5EmptyHistoryBackfillInterval(
+                baseSeconds: BLEManager.backfillIntervalSeconds,
+                lowSeconds: BLEManager.lowBatteryBackfillIntervalSeconds,
+                historyEmpty: whoop5EmptyOffload.historyEmpty)
+            if stretched != BLEManager.backfillIntervalSeconds { return stretched }
+        }
         guard lowBatteryOffloadPct > 0 else { return BLEManager.backfillIntervalSeconds }
         let (pct, charging) = batteryPctAndCharging()
         return BLEManager.offloadInterval(
@@ -3707,15 +3752,19 @@ public final class BLEManager: NSObject, ObservableObject {
         // before the link is encrypted) and is never retried, so `batteryPct` stays nil from connect — and
         // the 5/MG sends NO unsolicited battery notification (so the notify subscription above never fills
         // it on its own). Re-issue the read here: every caller is post-bond (CLIENT_HELLO-ack, post-bond,
-        // keep-alive), so the link is encrypted and the read succeeds; the keep-alive caller also RE-polls
-        // it (~every 30 s) so the reading stays current as the strap drains and BatteryEstimator gets its
-        // discharge samples on any screen. This is the iOS parity for Android's post-handshake read +
-        // ~60 s keep-alive poll (WhoopBleClient BATTERY_ON_CONNECT_DELAY_MS / refreshBattery). 4.0 is
-        // EXCLUDED — its 0x2A19 is a stub constant 100 (real value = GET_BATTERY_LEVEL; re-reading the stub
-        // would revert the true reading, #77). The 600 s same-% throttle in LiveState guards the estimator.
+        // keep-alive), so the link is encrypted and the read succeeds. #battery: THROTTLED to
+        // `whoop5BatteryReadMinIntervalSeconds` (~60 s) so the 30 s keep-alive tick no longer re-reads it
+        // every cycle — matching the Android twin's `keepAliveTick % 2 == 0` ~60 s cadence and the
+        // BatteryEstimator's 600 s same-% throttle (a 30 s poll was 20× finer than the estimator uses).
+        // The first read of a connection (`lastBatteryReadAt == nil`, reset on disconnect) always fires,
+        // so the post-bond / CLIENT_HELLO-ack callers still seed the reading promptly. 4.0 is EXCLUDED —
+        // its 0x2A19 is a stub constant 100 (real value = GET_BATTERY_LEVEL; re-reading the stub would
+        // revert the true reading, #77). The 600 s same-% throttle in LiveState guards the estimator.
         if let b = batteryCharacteristic, b.properties.contains(.read),
-           selectedModel.deviceFamily != .whoop4 {
+           selectedModel.deviceFamily != .whoop4,
+           BLEManager.shouldPollWhoop5Battery(lastReadAt: lastBatteryReadAt) {
             p.readValue(for: b)
+            lastBatteryReadAt = Date()
         }
         // #520 DIS identity read — same post-bond reasoning as the #490 battery read above: on a 5/MG the
         // link must be encrypted first. Gated to 5/MG (a 4.0 issues NO new reads, exactly like the battery
@@ -4435,6 +4484,7 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         // re-derives it. (The honest flag is per-link, like the syncing pill / reject counters above.)
         whoop5EmptyOffload.reset()
         state.historySyncExperimental = false
+        lastBatteryReadAt = nil   // #battery: next connect's first enableLiveNotifications re-seeds the 5/MG battery reading
         // #612: the display flag only, not the underlying emptySyncTracker streak (that counter
         // deliberately survives a reconnect — unchanged, existing behaviour). A fresh link re-derives
         // this from its own next HISTORY_COMPLETE.

--- a/StrandTests/Whoop5BatteryBackfillThrottleTests.swift
+++ b/StrandTests/Whoop5BatteryBackfillThrottleTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import Strand
+
+/// #battery: pins the two 5/MG battery-drain fixes.
+///
+/// 1. `shouldPollWhoop5Battery` — the 5/MG 0x2A19 battery read was issued every ~30 s by the keep-alive
+///    tick (2 880 GATT reads/day, 2× the Android twin's ~60 s cadence and 20× finer than the
+///    BatteryEstimator's 600 s same-% throttle). This throttle spaces it to ~60 s while still reading
+///    promptly on the first call of a connection (post-bond / CLIENT_HELLO-ack) and after a disconnect
+///    re-seed.
+///
+/// 2. `whoop5EmptyHistoryBackfillInterval` — a 5/MG whose history offload is known-empty (experimental on
+///    5.0) is stretched to the 45-min low-battery floor regardless of battery %, so the 15-min periodic
+///    kick stops holding the link ~60 s for zero data. Engages after the tracker's 2-empty threshold
+///    (one cycle earlier than the BackfillPolicy 3-empty backoff) and stacks with it.
+///
+/// Pure static logic → no CoreBluetooth seam. Twin of Android `nextBackfillDelayMs`'s
+/// `whoop5EmptyOffload.historyEmpty` branch.
+final class Whoop5BatteryBackfillThrottleTests: XCTestCase {
+
+    // MARK: - 5/MG battery-read throttle
+
+    // No prior read → always poll (the first read of a connection, post-bond / CLIENT_HELLO-ack, or after
+    // a disconnect re-seed). This is what makes the prompt connect-time reads still fire.
+    func testFirstReadAlwaysPolls() {
+        XCTAssertTrue(BLEManager.shouldPollWhoop5Battery(lastReadAt: nil))
+    }
+
+    // Under the 60 s floor → blocked. The 30 s keep-alive tick no longer re-reads every cycle.
+    func testUnderFloorBlocked() {
+        let now = Date()
+        let last = now.addingTimeInterval(-29)
+        XCTAssertFalse(BLEManager.shouldPollWhoop5Battery(lastReadAt: last, now: now))
+    }
+
+    // At exactly the floor → polls (>= is the boundary).
+    func testAtFloorPolls() {
+        let now = Date()
+        let last = now.addingTimeInterval(-BLEManager.whoop5BatteryReadMinIntervalSeconds)
+        XCTAssertTrue(BLEManager.shouldPollWhoop5Battery(lastReadAt: last, now: now))
+    }
+
+    // Past the floor → polls.
+    func testPastFloorPolls() {
+        let now = Date()
+        let last = now.addingTimeInterval(-BLEManager.whoop5BatteryReadMinIntervalSeconds - 1)
+        XCTAssertTrue(BLEManager.shouldPollWhoop5Battery(lastReadAt: last, now: now))
+    }
+
+    // The floor matches the Android twin's ~60 s cadence (keepAliveTick % 2 == 0 on a 30 s timer).
+    func testFloorMatchesAndroidCadence() {
+        XCTAssertEqual(BLEManager.whoop5BatteryReadMinIntervalSeconds, 60)
+        XCTAssertEqual(BLEManager.keepAliveIntervalSeconds, 30)
+    }
+
+    // MARK: - empty-history 5/MG backfill stretch
+
+    // History NOT known-empty → unchanged (the normal 15-min cadence; the lever only acts on a sustained
+    // empty streak, never on a healthy or unknown strap).
+    func testNonEmptyReturnsBase() {
+        XCTAssertEqual(
+            BLEManager.whoop5EmptyHistoryBackfillInterval(
+                baseSeconds: BLEManager.backfillIntervalSeconds,
+                lowSeconds: BLEManager.lowBatteryBackfillIntervalSeconds,
+                historyEmpty: false),
+            BLEManager.backfillIntervalSeconds)
+    }
+
+    // History known-empty → stretched to the 45-min low-battery floor.
+    func testEmptyStretchesToLowFloor() {
+        XCTAssertEqual(
+            BLEManager.whoop5EmptyHistoryBackfillInterval(
+                baseSeconds: BLEManager.backfillIntervalSeconds,
+                lowSeconds: BLEManager.lowBatteryBackfillIntervalSeconds,
+                historyEmpty: true),
+            BLEManager.lowBatteryBackfillIntervalSeconds)
+    }
+
+    // The stretch is the same value the low-battery lever uses (parity with #477).
+    func testStretchMatchesLowBatteryFloor() {
+        XCTAssertEqual(BLEManager.backfillIntervalSeconds, 900)       // 15 min
+        XCTAssertEqual(BLEManager.lowBatteryBackfillIntervalSeconds, 2700) // 45 min
+    }
+
+    // Defensive: a misconfigured low floor below the base never SHORTENS the cadence (max, not min).
+    func testNeverShortensBelowBase() {
+        XCTAssertEqual(
+            BLEManager.whoop5EmptyHistoryBackfillInterval(baseSeconds: 900, lowSeconds: 300, historyEmpty: true),
+            900)
+    }
+}

--- a/StrandTests/Whoop5BatteryBackfillThrottleTests.swift
+++ b/StrandTests/Whoop5BatteryBackfillThrottleTests.swift
@@ -16,6 +16,9 @@ import XCTest
 ///
 /// Pure static logic → no CoreBluetooth seam. Twin of Android `nextBackfillDelayMs`'s
 /// `whoop5EmptyOffload.historyEmpty` branch.
+// BLEManager is @MainActor, so its static helpers are main-actor-isolated; the test methods must run on
+// the main actor to call them (matches BackfillerSessionTallyTests etc.). Class-level @MainActor covers all.
+@MainActor
 final class Whoop5BatteryBackfillThrottleTests: XCTestCase {
 
     // MARK: - 5/MG battery-read throttle

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -639,6 +639,13 @@ class WhoopBleClient(
             thresholdPct: Int,
         ): Long = if (idleThrottleActive(batteryPct, charging, thresholdPct)) maxOf(baseMs, lowBatteryMs) else baseMs
 
+        /** #battery: pure periodic-offload interval for a 5/MG whose history is known-empty, unit-testable
+         *  without a BLE stack. Stretches to the low-battery floor (45 min) regardless of battery %, because
+         *  an experimental-history 5/MG banks nothing per pass. Stacks with the BackfillPolicy empty-backoff
+         *  (which engages one cycle later, at 3 empties). Twin of iOS `BLEManager.whoop5EmptyHistoryBackfillInterval`. */
+        fun whoop5EmptyHistoryBackfillIntervalMs(baseMs: Long, lowBatteryMs: Long, historyEmpty: Boolean): Long =
+            if (historyEmpty) maxOf(baseMs, lowBatteryMs) else baseMs
+
         /** Pure keep/teardown decision for [prepareForPresentScan] (#74), unit-testable without a BLE
          *  stack (the [scanModeForReconnectAttempts] idiom). Keep the live link ONLY when one exists AND
          *  the wizard is scanning the SAME model; Android [WhoopModel] has exactly two members (one per
@@ -1858,8 +1865,24 @@ class WhoopBleClient(
     }
 
     /** The delay before the next periodic offload — normally [BACKFILL_INTERVAL_MS], stretched when low on
-     *  battery (#477). Reads the battery snapshot at re-arm time. */
+     *  battery (#477). Reads the battery snapshot at re-arm time.
+     *  #battery: a 5/MG whose history offload is known-empty ([whoop5EmptyOffload.historyEmpty], crossed
+     *  after 2 consecutive empty offloads) is stretched to [LOW_BATTERY_BACKFILL_INTERVAL_MS] (45 min)
+     *  regardless of battery % — history sync is experimental on 5.0 and such a strap banks nothing per
+     *  pass, so a 15-min periodic kick just holds the link ~60 s for zero data. The BackfillPolicy
+     *  empty-backoff also stretches (after 3 empties), but this engages one cycle earlier (tracker
+     *  quietThreshold = 2) at a fixed 45-min floor that stacks with it. Twin of iOS
+     *  `BLEManager.nextBackfillInterval`. Resets with [whoop5EmptyOffload] on disconnect. */
     private fun nextBackfillDelayMs(): Long {
+        // #battery: known-empty-history 5/MG → stretch to the 45-min floor before any battery lever.
+        if (connectedFamily == DeviceFamily.WHOOP5) {
+            val stretched = whoop5EmptyHistoryBackfillIntervalMs(
+                baseMs = BACKFILL_INTERVAL_MS,
+                lowBatteryMs = LOW_BATTERY_BACKFILL_INTERVAL_MS,
+                historyEmpty = whoop5EmptyOffload.historyEmpty,
+            )
+            if (stretched != BACKFILL_INTERVAL_MS) return stretched
+        }
         if (lowBatteryOffloadPct <= 0) return BACKFILL_INTERVAL_MS   // dormant: no battery read, unchanged cadence
         val (batteryPct, charging) = batteryPctAndCharging()
         return offloadIntervalMsFor(

--- a/android/app/src/test/java/com/noop/ble/ConnectionPriorityTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ConnectionPriorityTest.kt
@@ -148,4 +148,20 @@ class ConnectionPriorityTest {
         // threshold 0 → normal cadence always
         assertEquals(base, WhoopBleClient.offloadIntervalMsFor(base, low, batteryPct = 3, charging = false, thresholdPct = 0))
     }
+
+    // #battery: a 5/MG whose history offload is known-empty (experimental on 5.0) stretches to the 45-min
+    // floor regardless of battery % — it banks nothing per pass, so a 15-min kick just holds the link ~60 s
+    // for zero data. Twin of iOS BLEManager.whoop5EmptyHistoryBackfillInterval.
+    @Test fun whoop5EmptyHistoryStretchesToLowFloor() {
+        assertEquals(low, WhoopBleClient.whoop5EmptyHistoryBackfillIntervalMs(base, low, historyEmpty = true))
+    }
+
+    @Test fun whoop5NonEmptyStaysAtBase() {
+        assertEquals(base, WhoopBleClient.whoop5EmptyHistoryBackfillIntervalMs(base, low, historyEmpty = false))
+    }
+
+    // Defensive: a misconfigured low floor below the base never SHORTENS the cadence (max, not min).
+    @Test fun whoop5EmptyHistoryNeverShortensBelowBase() {
+        assertEquals(base, WhoopBleClient.whoop5EmptyHistoryBackfillIntervalMs(base, lowBatteryMs = 300_000L, historyEmpty = true))
+    }
 }


### PR DESCRIPTION
## Summary

Two cross-platform parity fixes for WHOOP 5.0/MG battery drain — a 5/MG draining at the 4.0 rate (~4.5 days vs the rated 12 days, a ~2.5× over-drain).

### Fix 1: iOS 5/MG battery read throttle (30s → 60s)

`enableLiveNotifications` fires from the 30s keep-alive tick AND once each from the CLIENT_HELLO-ack / post-bond callers, so without a throttle a 5/MG was **READ every ~30s — 2,880 GATT reads/day**, 2× the Android twin's ~60s cadence (`keepAliveTick % 2 == 0`) and 20× finer than the BatteryEstimator's own 600s same-% throttle can consume.

Added `shouldPollWhoop5Battery` + `whoop5BatteryReadMinIntervalSeconds` (60s) + `lastBatteryReadAt` state. The first read of a connection (`lastBatteryReadAt == nil`, reset on disconnect) always fires, so the post-bond / CLIENT_HELLO-ack callers still seed the reading promptly. Android was already at ~60s — this brings iOS to match.

### Fix 2: Empty-history 5/MG backfill stretch (both platforms)

A 5/MG whose history offload is known-empty (`whoop5EmptyOffload.historyEmpty`, crossed after 2 consecutive empty offloads) is stretched to the 45-min low-battery floor regardless of battery % — history sync is experimental on 5.0 and such a strap banks nothing per pass, so a 15-min periodic kick just holds the link ~60s for zero data. The BackfillPolicy empty-backoff also stretches (after 3 empties), but this engages one cycle earlier (tracker `quietThreshold = 2`) at a fixed 45-min floor that stacks with it.

Added `whoop5EmptyHistoryBackfillInterval` (Swift) + `whoop5EmptyHistoryBackfillIntervalMs` (Android) pure helpers.

### Safety

- Both fixes are **pure-logic additions that gate existing behavior** — the non-empty-history and non-5.0 paths are byte-for-byte unchanged.
- **No mock or test data reaches users** — all readings come from the real strap over BLE. The throttle only changes *when* the 0x2A19 read fires, not what data it returns.
- WHOOP 4.0 is explicitly excluded from the battery-read throttle (its 0x2A19 is a stub constant 100; real value comes from `GET_BATTERY_LEVEL`).

#### Test plan

- [x] Android JVM unit tests: 3 new cases in `ConnectionPriorityTest` (14/14 pass), full suite 3,568/3,568 pass, 0 failures
- [ ] iOS `StrandTests`: 8 new cases in `Whoop5BatteryBackfillThrottleTests` — **SCAFFOLDED** (no Xcode on dev machine; requires `xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=iOS' build test` on macOS)
- [ ] BLE behavior on a real 5.0/MG strap — compile-success proves nothing about connection behavior; validate on hardware

Generated with [Devin](https://devin.ai)
