### PR TITLE
fix(diagnostics): analytics funnel finds computed-only sleep nights (#1150)

### DIFF
--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1062,6 +1062,19 @@ final class Repository: ObservableObject {
         return await unionSleepSessions(store: store, from: from, to: to, limit: limit)
     }
 
+    /// Computed ("-noop") sleep sessions for a ts range, oldest→newest by onset — the funnel/diagnostic
+    /// FALLBACK (#1150). A Bluetooth-only strap (no WHOOP/Apple-Health import) banks every night under the
+    /// COMPUTED source, so the imported-only `sleepSessions(from:to:)` returns nothing and the funnel
+    /// reported "no sleep session in the last 14 days to analyze" for a 4.0 user whose nights are all
+    /// computed. Sorted by start so `.last` is the newest, matching the imported path's ASC order. Callers
+    /// use this ONLY when the imported read is empty ⇒ a mixed/imported install's read is byte-unchanged.
+    /// Mirrors Android `WhoopRepository.computedSleepSessionsUnion`.
+    func computedSleepSessions(from: Int, to: Int, limit: Int = 100) async -> [CachedSleepSession] {
+        guard let store = await ensureStore() else { return [] }
+        return (await unionComputedSleepSessions(store: store, from: from, to: to, limit: limit))
+            .sorted { $0.startTs < $1.startTs }
+    }
+
     /// Every sleep BLOCK across BOTH sources, UN-deduplicated , so a split-sleep day (a nap
     /// + a main sleep, or any night recorded as multiple blocks) keeps ALL of its blocks.
     /// `sleeps` collapses each day to a single winner for the dashboard; this does not.

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -124,6 +124,11 @@ enum DebugDataDiagnostics {
             // imported read ⇒ a mixed/imported install's funnel is byte-unchanged. Mirrors Android funnelLines.
             recent = await repo.computedSleepSessions(from: nowSec - 14 * 86400, to: nowSec, limit: 200)
         }
+        // `.last`/`.reversed()` below assume ASC-by-onset order. The imported union concatenates per-id
+        // blocks and is NOT globally sorted for a multi-id (re-added strap + canonical) install, so sort
+        // here — else `.last` can pick a non-newest night, and the pick would diverge from Android, which
+        // sorts explicitly. A single-source read is already ASC, so this is a no-op there.
+        recent.sort { $0.startTs < $1.startTs }
         guard let newest = recent.last else {
             lines.append("(no sleep session in the last 14 days to analyze)")
             return lines

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -115,7 +115,15 @@ enum DebugDataDiagnostics {
         // Pick the MOST RECENT night that actually carries skin-temp — not the OLDEST in the window. The old
         // `sleepSessions(…, limit: 1).last` returned the oldest session (ASC order), so a fresh gap night read
         // "skin=0" and the funnel never saw a real night. Walk newest→oldest and stop at the first with skin.
-        let recent = await repo.sleepSessions(from: nowSec - 14 * 86400, to: nowSec, limit: 200)
+        var recent = await repo.sleepSessions(from: nowSec - 14 * 86400, to: nowSec, limit: 200)
+        if recent.isEmpty {
+            // #1150: a Bluetooth-only strap (no WHOOP/Apple import) banks every night under the COMPUTED
+            // "-noop" source, so the imported union above is empty and the funnel reported "no session in
+            // 14 days" for a 4.0 user whose nights are all computed — even though computed session rows
+            // exist. Fall back to the computed sessions so a real night is analysed. Only on an empty
+            // imported read ⇒ a mixed/imported install's funnel is byte-unchanged. Mirrors Android funnelLines.
+            recent = await repo.computedSleepSessions(from: nowSec - 14 * 86400, to: nowSec, limit: 200)
+        }
         guard let newest = recent.last else {
             lines.append("(no sleep session in the last 14 days to analyze)")
             return lines

--- a/StrandTests/FunnelComputedSleepFallbackTests.swift
+++ b/StrandTests/FunnelComputedSleepFallbackTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+import Foundation
+import WhoopStore
+@testable import Strand
+
+/// #1150: a Bluetooth-only strap (no WHOOP/Apple-Health import) banks every night under the COMPUTED
+/// ("-noop") source, so the imported-only session read the analytics funnel used returned nothing and the
+/// funnel reported "no sleep session in the last 14 days to analyze" even though computed session rows
+/// existed. `Repository.computedSleepSessions` is the fallback the funnel now consults when the imported
+/// read is empty (see `DebugDataDiagnostics.funnelLines` / Android `AndroidDiagnostics.funnelLines`). These
+/// pin: (i) the imported read is empty while computed rows exist, (ii) the fallback returns them
+/// oldest→newest so `.last` is the newest night, and (iii) a re-added strap's "<uuid>-noop" sessions are
+/// reachable once the active id is adopted (the engine writes computed under `<activeStrapId>-noop`).
+final class FunnelComputedSleepFallbackTests: XCTestCase {
+
+    private let canonicalId = "my-whoop"
+    private let newId = "whoop-ABC123"   // the id a re-added strap gets (AddDeviceWizard: "whoop-<uuid>")
+
+    private func session(startTs: Int, endTs: Int) -> CachedSleepSession {
+        CachedSleepSession(startTs: startTs, endTs: endTs, efficiency: 0.9, restingHr: 52,
+                           avgHrv: 70, stagesJSON: nil, stagingSparse: true)
+    }
+
+    /// The core regression: computed-only nights (all under "-noop") are invisible to the imported read, but
+    /// the computed fallback surfaces them, sorted so `.last` is the newest — what the funnel's newest-night
+    /// walk relies on.
+    @MainActor
+    func testComputedOnlyNightsSurfaceViaFallbackSorted() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: canonicalId, mac: nil, name: "WHOOP")
+
+        let now = Int(Date().timeIntervalSince1970)
+        let older = now - 3 * 86_400
+        let newer = now - 1 * 86_400
+        // Insert NEWEST-first so a naive read would mis-order; the fallback must sort ascending by onset.
+        _ = try await store.upsertSleepSessions([
+            session(startTs: newer, endTs: newer + 7 * 3_600),
+            session(startTs: older, endTs: older + 7 * 3_600),
+        ], deviceId: canonicalId + "-noop")
+
+        let repo = Repository(deviceId: canonicalId)
+        repo.setStoreForTesting(store)
+
+        let imported = await repo.sleepSessions(from: now - 14 * 86_400, to: now, limit: 200)
+        XCTAssertTrue(imported.isEmpty,
+                      "computed nights are NOT under the imported source — this is the false-negative condition")
+
+        let computed = await repo.computedSleepSessions(from: now - 14 * 86_400, to: now, limit: 200)
+        XCTAssertEqual(computed.count, 2, "both computed nights must surface via the fallback")
+        XCTAssertEqual(computed.map(\.startTs), [older, newer],
+                       "oldest→newest so `.last` is the newest night the funnel analyses")
+    }
+
+    /// The re-added-strap case (the Kotlin active-id parity concern, mirrored): the engine writes computed
+    /// sessions under "<activeStrapId>-noop", so a fallback pinned to the canonical sibling alone would miss
+    /// a re-added strap's nights. After the active id is adopted the computed union reaches the strap's sibling.
+    @MainActor
+    func testFallbackReachesReAddedStrapComputedSibling() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: canonicalId, mac: nil, name: "WHOOP")
+        try await store.upsertDevice(id: newId, mac: nil, name: "WHOOP")
+
+        let now = Int(Date().timeIntervalSince1970)
+        let night = now - 2 * 86_400
+        _ = try await store.upsertSleepSessions([session(startTs: night, endTs: night + 7 * 3_600)],
+                                                deviceId: newId + "-noop")
+
+        let repo = Repository(deviceId: canonicalId)
+        repo.setStoreForTesting(store)
+
+        // Before the re-add the computed union reads the canonical sibling only → the strap's night is unseen.
+        let before = await repo.computedSleepSessions(from: now - 14 * 86_400, to: now, limit: 200)
+        XCTAssertTrue(before.isEmpty,
+                      "with only the canonical id active, the re-added strap's computed night is not yet reachable")
+
+        repo.adoptActiveDeviceId(newId)
+        let after = await repo.computedSleepSessions(from: now - 14 * 86_400, to: now, limit: 200)
+        XCTAssertEqual(after.count, 1,
+                       "after adopting the active id the fallback reaches the strap's '<uuid>-noop' sibling")
+        XCTAssertEqual(after.first?.startTs, night)
+    }
+}

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -80,12 +80,27 @@ object AndroidDiagnostics {
         add("Analytics funnels (latest night, best-effort)")
         runCatching {
             val repo = com.noop.data.WhoopRepository.from(context)
-            val id = "my-whoop"
+            // #1150: resolve the ACTIVE strap id (mirrors Swift's `did = repo.deviceId`). A single-WHOOP
+            // install resolves to "my-whoop" ⇒ every read below collapses to the canonical id and is
+            // byte-identical to the old hardcoded path; a re-added strap reads its own "whoop-<uuid>" raws
+            // and "<uuid>-noop" computed sessions (the engine writes computed under `<importedDeviceId>-noop`
+            // and both analyzeRecent callers pass the active strap as importedDeviceId).
+            val id = runCatching {
+                (context.applicationContext as? com.noop.NoopApplication)?.deviceRegistry?.activeDeviceId()
+            }.getOrNull()?.takeIf { it.isNotBlank() } ?: "my-whoop"
             val nowSec = System.currentTimeMillis() / 1000L
             // Pick the MOST RECENT night that actually carries skin-temp — not the OLDEST. The old
             // `sleepSessions(…, 1).lastOrNull()` returned the oldest session in the window (ASC order), so a
             // fresh gap night read "skin=0" and the funnel never saw a real night. Walk newest→oldest.
-            val recent = repo.sleepSessions(id, nowSec - 14L * 86400L, nowSec, 200)
+            var recent = repo.sleepSessionsUnion(id, nowSec - 14L * 86400L, nowSec, 200)
+            if (recent.isEmpty()) {
+                // #1150: a Bluetooth-only strap banks every night under the COMPUTED "-noop" source, so the
+                // imported union above is empty and the funnel used to report "no session in 14 days" for a
+                // 4.0 user whose nights are all computed. Fall back to the computed union so a real night is
+                // analysed. Only on an empty imported read ⇒ an imported install's funnel is unchanged.
+                recent = repo.computedSleepSessionsUnion(id, nowSec - 14L * 86400L, nowSec, 200)
+            }
+            recent = recent.sortedBy { it.startTs }   // `.last()` must be the newest across both branches
             if (recent.isEmpty()) {
                 add("(no sleep session in the last 14 days to analyze)")
                 return@runCatching


### PR DESCRIPTION
## What

A **Bluetooth-only WHOOP 4.0** user (no WHOOP CSV / Apple-Health import) has every night **computed on-device** and persisted under the computed `"<activeStrapId>-noop"` source. The analytics-funnel diagnostic (Test Centre debug export) queried only the *imported* id namespace, so it reported:

> (no sleep session in the last 14 days to analyze)

…even though computed session rows exist — the REM/skin funnels never ran for a 4.0 night. Surfaced by a real 4.0 capture + strap log (`Analytics funnels … no sleep session in the last 14 days to analyze` while the capture computes sleep `source=computed`).

## Why it happens

Computed nights are **already persisted** as full session rows — just under the `-noop` device id (both `analyzeRecent` callers pass the active strap as `importedDeviceId`, and the engine writes computed under `<importedDeviceId>-noop`). Nothing was missing; the funnel's session lookup simply never read the computed source.

## Fix — read-side, no schema / no migration

When the imported session lookup returns **zero** sessions, fall back to the **computed union**. Only on an empty imported read, so a mixed/imported install's funnel output is byte-unchanged.

- **Swift** — new `Repository.computedSleepSessions(from:to:limit:)` (computed union, sorted oldest→newest so `.last` is the newest night); `DebugDataDiagnostics.funnelLines` falls back to it. Raw reads already used `did = repo.deviceId` (the active strap), so a computed night's live raws resolve.
- **Android** — `AndroidDiagnostics.funnelLines` now resolves the **active strap id** (mirroring Swift's `did = repo.deviceId`), unions the imported source (`sleepSessionsUnion`), then falls back to `computedSleepSessionsUnion`, sorted. This also closes a pre-existing Kotlin divergence: the funnel hardcoded `"my-whoop"` for both the lookup **and** the raw reads, so a re-added strap's `whoop-<uuid>` raws were unreachable. A single-WHOOP install resolves to `"my-whoop"` ⇒ every read collapses to the canonical id and is **byte-identical** to the old path.

## Parity

The bug and the fix are symmetric across platforms. The two funnels now read the same imported∪computed set and the same active-strap raws.

## Tests / verification

- `StrandTests/FunnelComputedSleepFallbackTests.swift` (new): computed-only nights are invisible to the imported read but surface via the fallback, sorted oldest→newest; and a re-added strap's `<uuid>-noop` sibling is reachable once the active id is adopted.
- Android `compileFullDebugKotlin --no-build-cache`: clean.
- The Context-bound funnel itself is validated **on-device** (the Android unit suite is Robolectric-free — the Context path is exercised centrally, matching the existing `AndroidDiagnosticsTest` note); the underlying union readers (`sleepSessionsUnion` / `computedSleepSessionsUnion`) already carry coverage.

Closes #1150.