### PR TITLE
fix(android): hold-to-drag reorder for Sleep cards, matching Today (#sleep-layout)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -54,7 +55,9 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -286,6 +289,37 @@ fun SleepScreen(
     var sleepSectionOrder by remember { mutableStateOf(SleepLayoutPrefs.order(context)) }
     var hiddenSections by remember { mutableStateOf(SleepLayoutPrefs.hidden(context)) }
     var showSleepArrange by remember { mutableStateOf(false) }
+    // #sleep-layout (hold-to-drag): the hoisted list state (the drag math needs layoutInfo + scrollBy) and
+    // the live drag state, mirroring Today (TodayScreen.kt §today-layout). The frame loop runs ONLY while a
+    // card is lifted: each frame it retries the swap (so a card held still at a viewport edge keeps
+    // reordering as the list scrolls under it — onDrag alone only fires while the finger moves) and applies
+    // the edge auto-scroll velocity SleepReorderableSection's onDrag computed. Persistence is on drop
+    // (onDrop below), not here — this only updates the in-memory order live.
+    val sleepListState = rememberLazyListState()
+    val sleepSectionDrag = remember { SleepSectionDragState() }
+    val sleepDragActive = sleepSectionDrag.key != null
+    LaunchedEffect(sleepDragActive) {
+        // Auto-scroll is TIME-based (px/second × real frame delta), not per-frame, so it reads the same on
+        // 60/90/120 Hz. dt is clamped so a dropped/backgrounded frame can't produce one giant jump.
+        var lastFrameNanos = 0L
+        while (sleepSectionDrag.key != null) {
+            val frameNanos = withFrameNanos { it }
+            val dtSec = if (lastFrameNanos == 0L) 0f
+            else ((frameNanos - lastFrameNanos) / 1_000_000_000f).coerceAtMost(0.05f)
+            lastFrameNanos = frameNanos
+            swapTargetForDraggedSleepSection(sleepListState, sleepSectionDrag, sleepSectionOrder)?.let { (dragged, target) ->
+                // Freeze the scroll anchor across the reorder so a swap involving the first visible item
+                // can't leap the viewport by the two cards' height difference in a single frame.
+                val anchorIndex = sleepListState.firstVisibleItemIndex
+                val anchorOffset = sleepListState.firstVisibleItemScrollOffset
+                sleepSectionOrder = sleepSectionOrder.movedSleepSection(dragged, target)
+                sleepListState.scrollToItem(anchorIndex, anchorOffset)
+            }
+            if (sleepSectionDrag.autoScrollPxPerSecond != 0f && dtSec > 0f) {
+                sleepListState.scrollBy(sleepSectionDrag.autoScrollPxPerSecond * dtSec)
+            }
+        }
+    }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     LaunchedEffect(sleeps) {
         // #627: the journal-reminder toggle (default ON) gates this morning sheet too, so disabling the
@@ -437,6 +471,7 @@ fun SleepScreen(
     LazyScreenScaffold(
         title = uiString(R.string.l10n_sleep_screen_sleep_3cac34e6),
         subtitle = "Last night, read in two seconds.",
+        listState = sleepListState,   // #sleep-layout: the hold-to-drag frame loop drives this list state
         // LIQUID SKY BACKDROP (the pilot pattern — LiquidScreenSky.kt): the static time-of-day liquid sky
         // settles into the theme canvas behind the header + hero, bled full-width up behind the status bar
         // via the scaffold's topBackground plumbing. Gated on the day-cycle preference exactly like Today
@@ -562,15 +597,22 @@ fun SleepScreen(
                 }
             }
             // Analytical cards render in the user's saved order (SleepLayoutPrefs), minus the hidden set.
-            // Reordered via the Arrange sheet; each card's data guards (tilesModel/model) are preserved.
+            // Reordered via the Arrange sheet OR by long-press hold-to-drag on the card (#sleep-layout,
+            // mirrors Today); each card's data guards (tilesModel/model) are preserved. Each section is ONE
+            // keyed reorderable item so the whole card (incl. its top spacer) lifts and drops as a unit.
+            // #sleep-layout: persist the live hold-to-drag reorder when the gesture drops (the in-memory
+            // `sleepSectionOrder` already moved live in the frame loop; this writes it through).
+            val persistSleepOrder = { SleepLayoutPrefs.setOrder(context, sleepSectionOrder) }
             sleepSectionOrder.filterNot { it in hiddenSections }.forEach { section ->
+              val k = SLEEP_SECTION_KEY_PREFIX + section.raw
               when (section) {
-                SleepSection.SLEEP_MARKS -> {
-                    item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
+                SleepSection.SLEEP_MARKS -> item(key = k) {
                     // SLEEP MARKS — tap to log "going to sleep" / "I'm awake" (#461, Phase 1). LOGGING ONLY:
                     // a mark is persisted to the `sleep_mark` series + the shareable strap log; it never
                     // changes the detected sleep. Mirrors macOS SleepView.sleepMarkCard.
-                    item {
+                    SleepReorderableSection(k, sleepListState, sleepSectionDrag, persistSleepOrder) {
+                    Column {
+                    Spacer(Modifier.height(Metrics.selectorTopUp))
                     SleepMarkCard(
                 onMark = { type ->
                     val mark = SleepMark.now(type)
@@ -585,10 +627,12 @@ fun SleepScreen(
                 },
             )
                     }
+                    }
                 }
-                SleepSection.STAGES -> {
-                    item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
-                    item {
+                SleepSection.STAGES -> item(key = k) {
+                    SleepReorderableSection(k, sleepListState, sleepSectionDrag, persistSleepOrder) {
+                    Column {
+                    Spacer(Modifier.height(Metrics.selectorTopUp))
                     Hero(
                 display = display,
                 activeIsOura = activeIsOura,
@@ -680,30 +724,55 @@ fun SleepScreen(
                 windowWakeTs = night?.heroWakeTs,
             )
                     }
+                    }
                 }
                 // Tiles / ledger / trends read the FULL-history model (#940): they stay up when only the
                 // selected day's model failed to build, exactly as iOS keeps them while browsing. Each
                 // `tilesModel?.let { m -> ... }` binds a non-null local so the smart-cast carries across
                 // the item {} lambda boundary — same guard the old `if (tilesModel != null)` block used.
                 SleepSection.NIGHT_DETAIL -> tilesModel?.let { m ->
-                    item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
-                    item { MetricGrid(m, onMetricClick = { detailMetricKey = it }) }
+                    item(key = k) {
+                        SleepReorderableSection(k, sleepListState, sleepSectionDrag, persistSleepOrder) {
+                            Column {
+                                Spacer(Modifier.height(Metrics.selectorTopUp))
+                                MetricGrid(m, onMetricClick = { detailMetricKey = it })
+                            }
+                        }
+                    }
                 }
                 SleepSection.SLEEP_DEBT -> tilesModel?.let { m ->
-                    item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
-                    item { SleepDebtLedgerCard(m.sleepDebtLedger) }
+                    item(key = k) {
+                        SleepReorderableSection(k, sleepListState, sleepSectionDrag, persistSleepOrder) {
+                            Column {
+                                Spacer(Modifier.height(Metrics.selectorTopUp))
+                                SleepDebtLedgerCard(m.sleepDebtLedger)
+                            }
+                        }
+                    }
                 }
                 // StagesVsTypical reads the SELECTED day's model, never the full-history fallback: a
                 // phantom newest day with no stage model would otherwise label ANOTHER night's stages as
                 // this one (#940). Guarded on BOTH tilesModel and model, exactly as the pre-refactor
                 // nesting was (it lived inside the `if (tilesModel != null)` block).
                 SleepSection.STAGES_VS_TYPICAL -> if (tilesModel != null) model?.let { selectedModel ->
-                    item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
-                    item { StagesVsTypical(selectedModel) }
+                    item(key = k) {
+                        SleepReorderableSection(k, sleepListState, sleepSectionDrag, persistSleepOrder) {
+                            Column {
+                                Spacer(Modifier.height(Metrics.selectorTopUp))
+                                StagesVsTypical(selectedModel)
+                            }
+                        }
+                    }
                 }
                 SleepSection.ASLEEP_DURATION -> tilesModel?.let { m ->
-                    item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
-                    item { DurationTrend(m) }
+                    item(key = k) {
+                        SleepReorderableSection(k, sleepListState, sleepSectionDrag, persistSleepOrder) {
+                            Column {
+                                Spacer(Modifier.height(Metrics.selectorTopUp))
+                                DurationTrend(m)
+                            }
+                        }
+                    }
                 }
               }
             }

--- a/android/app/src/main/java/com/noop/ui/SleepSectionReorder.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepSectionReorder.kt
@@ -1,0 +1,207 @@
+package com.noop.ui
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyItemScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.zIndex
+import kotlinx.coroutines.launch
+
+/**
+ * #sleep-layout (hold-to-drag) — the Sleep tab's on-card long-press reorder. This is a DELIBERATE, verbatim
+ * mirror of the Today tab's #today-layout drag infrastructure (`TodaySectionDragState` /
+ * `swapTargetForDraggedSection` / `movedTodaySection` / `TodayReorderableSection` in TodayScreen.kt), kept
+ * as a separate SleepSection-typed copy so adding drag to Sleep can't destabilise the shipping Today
+ * reorder. The two are behaviourally identical; if you fix a drag bug in one, port it to the other. The
+ * screen-level frame loop (retry-swap + edge auto-scroll) lives in SleepScreen, exactly as Today's lives in
+ * TodayScreen — it reads the screen's own `sleepSectionOrder` state fresh each frame.
+ */
+
+/** LazyColumn key prefix for a reorderable Sleep section item, so the drag can tell a section from the
+ *  pinned rows around it. Twin of `TODAY_SECTION_KEY_PREFIX`. */
+const val SLEEP_SECTION_KEY_PREFIX = "sleepSection:"
+
+/**
+ * Live drag state for the Sleep hold-to-drag reorder. One instance per screen. `key`/`distance` are
+ * snapshot state (they drive the lifted card's translation each frame); the rest are plain fields written
+ * by the gesture and read on the same (main) thread. Twin of `TodaySectionDragState`.
+ */
+class SleepSectionDragState {
+    /** LazyColumn key of the section being dragged; null when idle. */
+    var key by mutableStateOf<String?>(null)
+
+    /** Accumulated finger travel since pickup (px). */
+    var distance by mutableFloatStateOf(0f)
+
+    /** The dragged item's viewport offset at pickup (px) — with [distance], the finger-anchored position. */
+    var pickedUpAt = 0f
+
+    /** Edge auto-scroll velocity (px/SECOND — the frame loop scales by real frame time, so the speed is
+     *  identical on 60/90/120 Hz displays), set by onDrag from edge proximity; 0 outside the edge zones. */
+    var autoScrollPxPerSecond = 0f
+}
+
+/** This order with [section] moved to [target]'s position (the classic list move). Twin of
+ *  `movedTodaySection`. */
+fun List<SleepSection>.movedSleepSection(section: SleepSection, target: SleepSection): List<SleepSection> {
+    val from = indexOf(section)
+    val to = indexOf(target)
+    if (from == -1 || to == -1 || from == to) return this
+    return toMutableList().apply { add(to, removeAt(from)) }
+}
+
+/**
+ * The (dragged, target) pair to swap right now, or null. The lifted card's finger-anchored middle
+ * (`pickedUpAt + distance + size/2`, viewport space) must sit over another section item AND have crossed
+ * that item's CENTRE in the direction of travel — the centre gate stops a tall card over a short one from
+ * ping-ponging. The direction is derived from [order] (the section list, the source of truth), NOT from
+ * layout offsets, so a stale post-swap frame can't re-derive and undo the move. Pure read; the caller
+ * applies the move. Twin of `swapTargetForDraggedSection`.
+ */
+fun swapTargetForDraggedSleepSection(
+    listState: LazyListState,
+    drag: SleepSectionDragState,
+    order: List<SleepSection>,
+): Pair<SleepSection, SleepSection>? {
+    val key = drag.key ?: return null
+    val info = listState.layoutInfo
+    val current = info.visibleItemsInfo.firstOrNull { it.key == key } ?: return null
+    val middle = drag.pickedUpAt + drag.distance + current.size / 2f
+    val target = info.visibleItemsInfo.firstOrNull { item ->
+        item.key != key && (item.key as? String)?.startsWith(SLEEP_SECTION_KEY_PREFIX) == true &&
+            middle >= item.offset && middle <= item.offset + item.size
+    } ?: return null
+    val dragged = SleepSection.fromRaw(key.removePrefix(SLEEP_SECTION_KEY_PREFIX)) ?: return null
+    val tgt = SleepSection.fromRaw((target.key as String).removePrefix(SLEEP_SECTION_KEY_PREFIX)) ?: return null
+    val targetCentre = target.offset + target.size / 2f
+    val movingDown = order.indexOf(tgt) > order.indexOf(dragged)
+    if (movingDown && middle < targetCentre) return null
+    if (!movingDown && middle > targetCentre) return null
+    return dragged to tgt
+}
+
+/**
+ * #sleep-layout (hold-to-drag): the per-section drag wrapper. LONG-PRESS anywhere on the section lifts it
+ * (haptic; the card raises + follows the finger via graphicsLayer, translation computed against the item's
+ * CURRENT layout offset so a mid-drag reorder or auto-scroll can't teleport it). onDrag only accumulates
+ * finger travel + the edge auto-scroll velocity — the screen-level frame loop owns the swap + scroll.
+ * Taps/scrolls pass through untouched (the detector waits for a long press). Twin of `TodayReorderableSection`.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun LazyItemScope.SleepReorderableSection(
+    itemKey: String,
+    listState: LazyListState,
+    drag: SleepSectionDragState,
+    onDrop: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val isDragging = drag.key == itemKey
+    val haptics = LocalHapticFeedback.current
+    // Drop SETTLE: on release the lifted card is usually mid-air between slots; the residual offset animates
+    // to 0 so the card glides into its slot. `settling` keeps the lifted chrome (zIndex) during the glide.
+    val settleScope = rememberCoroutineScope()
+    val settle = remember { Animatable(0f) }
+    var settling by remember { mutableStateOf(false) }
+    fun releaseWithSettle() {
+        val current = listState.layoutInfo.visibleItemsInfo.firstOrNull { it.key == itemKey }
+        val residual = if (current != null) drag.pickedUpAt + drag.distance - current.offset else 0f
+        onDrop()
+        drag.key = null
+        drag.distance = 0f
+        drag.autoScrollPxPerSecond = 0f
+        if (residual != 0f) {
+            settling = true
+            settleScope.launch {
+                settle.snapTo(residual)
+                settle.animateTo(0f, tween(durationMillis = 220, easing = FastOutSlowInEasing))
+                settling = false
+            }
+        }
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .zIndex(if (isDragging || settling) 1f else 0f)
+            .then(
+                if (isDragging || settling) {
+                    Modifier.graphicsLayer {
+                        translationY = if (isDragging) {
+                            // Finger-anchored viewport position minus wherever layout currently placed it.
+                            val current = listState.layoutInfo.visibleItemsInfo.firstOrNull { it.key == itemKey }
+                            if (current != null) drag.pickedUpAt + drag.distance - current.offset else 0f
+                        } else {
+                            settle.value
+                        }
+                        shadowElevation = if (isDragging) 12f else 6f
+                        scaleX = 1.01f
+                        scaleY = 1.01f
+                    }
+                } else {
+                    // Non-dragged sections animate to their new slot as the lifted card crosses them.
+                    Modifier.animateItemPlacement(tween(durationMillis = 260, easing = FastOutSlowInEasing))
+                },
+            )
+            .pointerInput(itemKey) {
+                detectDragGesturesAfterLongPress(
+                    onDragStart = {
+                        settling = false
+                        drag.key = itemKey
+                        drag.distance = 0f
+                        drag.pickedUpAt = listState.layoutInfo.visibleItemsInfo
+                            .firstOrNull { it.key == itemKey }?.offset?.toFloat() ?: 0f
+                        drag.autoScrollPxPerSecond = 0f
+                        haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                    },
+                    onDragEnd = { releaseWithSettle() },
+                    onDragCancel = {
+                        // The list already reordered live; persist what the user sees rather than
+                        // silently reverting on a system-cancelled gesture.
+                        releaseWithSettle()
+                    },
+                    onDrag = onDrag@{ change, amount ->
+                        change.consume()
+                        drag.distance += amount.y
+                        val info = listState.layoutInfo
+                        val current = info.visibleItemsInfo.firstOrNull { it.key == itemKey } ?: return@onDrag
+                        // Edge auto-scroll velocity (px/SECOND — the frame loop scales by real frame time)
+                        // from the lifted card's proximity to the viewport edges; ramps linearly across the
+                        // zone with an eased-in feel via the squared fraction.
+                        val zone = 112.dp.toPx()
+                        val maxV = 620.dp.toPx()
+                        val top = drag.pickedUpAt + drag.distance
+                        val bottom = top + current.size
+                        drag.autoScrollPxPerSecond = when {
+                            bottom > info.viewportEndOffset - zone -> {
+                                val f = ((bottom - (info.viewportEndOffset - zone)) / zone).coerceAtMost(1f)
+                                maxV * f * f
+                            }
+                            top < info.viewportStartOffset + zone -> {
+                                val f = (((info.viewportStartOffset + zone) - top) / zone).coerceAtMost(1f)
+                                -maxV * f * f
+                            }
+                            else -> 0f
+                        }
+                    },
+                )
+            },
+    ) { content() }
+}

--- a/android/app/src/test/java/com/noop/ui/PoseStillCoverageTest.kt
+++ b/android/app/src/test/java/com/noop/ui/PoseStillCoverageTest.kt
@@ -67,10 +67,14 @@ class PoseStillCoverageTest {
      * user's finger is down. Quieting it would not save idle power (there is no idle: the user is dragging);
      * it would break the interaction by stripping the auto-scroll out from under them.
      *
+     * `SleepScreen.kt` runs the byte-identical drag-reorder auto-scroll loop (#sleep-layout, the Sleep-tab
+     * twin of Today's), gated the same way on `while (sleepSectionDrag.key != null)` — the same direct-
+     * manipulation case, exempt for the same reason. Its only `withFrameNanos` IS that loop.
+     *
      * The distinction this file draws is idle-vs-driven, not animated-vs-still. Anything added here needs a
      * reason of that shape.
      */
-    private val directManipulation = setOf("TodayScreen.kt")
+    private val directManipulation = setOf("TodayScreen.kt", "SleepScreen.kt")
 
     private fun animatingFiles(): List<File> =
         uiDir().walkTopDown()

--- a/android/app/src/test/java/com/noop/ui/SleepSectionReorderTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepSectionReorderTest.kt
@@ -1,0 +1,47 @@
+package com.noop.ui
+
+import com.noop.ui.SleepSection.ASLEEP_DURATION
+import com.noop.ui.SleepSection.NIGHT_DETAIL
+import com.noop.ui.SleepSection.SLEEP_DEBT
+import com.noop.ui.SleepSection.SLEEP_MARKS
+import com.noop.ui.SleepSection.STAGES
+import com.noop.ui.SleepSection.STAGES_VS_TYPICAL
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins [movedSleepSection] (#sleep-layout hold-to-drag): the pure "move this card to the target's slot"
+ * step the drag frame loop applies on every swap. A bug here silently reorders the wrong card. This is the
+ * behavioural twin of Today's `movedTodaySection`; the gesture/auto-scroll code around it can only be
+ * validated on-device.
+ */
+class SleepSectionReorderTest {
+
+    // MARKS, STAGES, NIGHT_DETAIL, SLEEP_DEBT, STAGES_VS_TYPICAL, ASLEEP_DURATION
+    private val order = SleepSection.defaultOrder
+
+    @Test fun movingDownPlacesTheCardAtTheTargetsSlot() {
+        assertEquals(
+            listOf(STAGES, NIGHT_DETAIL, SLEEP_MARKS, SLEEP_DEBT, STAGES_VS_TYPICAL, ASLEEP_DURATION),
+            order.movedSleepSection(SLEEP_MARKS, NIGHT_DETAIL),
+        )
+    }
+
+    @Test fun movingUpPlacesTheCardAtTheTargetsSlot() {
+        assertEquals(
+            listOf(SLEEP_MARKS, ASLEEP_DURATION, STAGES, NIGHT_DETAIL, SLEEP_DEBT, STAGES_VS_TYPICAL),
+            order.movedSleepSection(ASLEEP_DURATION, STAGES),
+        )
+    }
+
+    @Test fun movingOntoItselfIsANoOp() {
+        assertEquals(order, order.movedSleepSection(STAGES, STAGES))
+    }
+
+    @Test fun aSectionNotInTheOrderLeavesItUnchanged() {
+        // A hidden/absent section can't be moved (indexOf == -1) — guards a phantom drag key from mangling
+        // the list.
+        val partial = listOf(SLEEP_MARKS, STAGES)
+        assertEquals(partial, partial.movedSleepSection(NIGHT_DETAIL, STAGES))
+    }
+}


### PR DESCRIPTION
## What

Reported on Android: **moving/customising the Sleep cards doesn't work like the Today tab** — long-press-dragging a Sleep card did nothing. Only the Arrange sheet's up/down buttons could reorder them.

Root cause: **Today wraps each card in an on-card hold-to-drag container; Sleep never got that.** The Sleep cards were plain, unkeyed `item {}`s with no drag gesture attached, so a user dragging one (muscle memory from Today) got nothing.

## Fix

Add the same hold-to-drag reorder Today ships:

- **`SleepSectionReorder.kt`** (new) — a deliberate, verbatim `SleepSection`-typed twin of Today's `#today-layout` drag infra (`TodaySectionDragState` / `swapTargetForDraggedSection` / `movedTodaySection` / `TodayReorderableSection`). Kept as a separate copy **so this can't destabilise the shipping Today reorder** the maintainer relies on; the two are behaviourally identical (comment in the file asks to keep them in sync).
- **`SleepScreen.kt`** — hoists a `LazyListState` + drag state, runs the same per-frame retry-swap + edge auto-scroll loop, passes the state into the scaffold's `LazyColumn`, and wraps each of the six analytical sections (top spacer + card) in **one keyed reorderable item** so the whole card lifts and drops as a unit. On drop it persists via `SleepLayoutPrefs.setOrder` (the same store the Arrange sheet writes); the live in-memory order already moved during the drag.

The Arrange sheet (arrow buttons) still works — this is additive, exactly like Today (hold-drag **or** Arrange).

## iOS / macOS parity

**Unchanged, and correct.** Apple already reorders Sleep via the customization sheet's native SwiftUI `.onMove` (same mechanism as its Today tab), and `SleepLayoutPrefs` is byte-identical across platforms — so the feature parity holds. On-tab drag (Android) vs sheet drag (Apple) is a legitimate per-platform UI difference that matches how **each platform's own Today tab already behaves**; it's not a data divergence (the #1 parity rule is about analytics/stored data, which is identical here).

## Verification

- `compileFullDebugKotlin --no-build-cache`: clean.
- `SleepSectionReorderTest` (new): pins the pure `movedSleepSection` move semantics (down / up / no-op / absent-section) — green.
- The drag gesture + edge auto-scroll itself is validated **on-device** (gesture code isn't unit-testable), same as Today's.