### PR TITLE
fix(devices): keep strap firmware on the card via a last-known fallback

### DIFF
--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -175,9 +175,15 @@ private struct DevicesContent: View {
                     // generic strap, or an FTMS machine all funnel into live.batteryPct). nil otherwise.
                     liveBatteryPct: (device.status == .active && live.connected) ? live.batteryPct.map { Int($0.rounded()) } : nil,
                     liveBatteryMv: (device.status == .active && live.connected) ? live.batteryMv : nil,
-                    // Firmware version belongs to the active + connected strap only; nil otherwise (and
-                    // for a non-WHOOP source that never reports one).
-                    liveFirmware: (device.status == .active && live.connected) ? live.strapFirmware : nil,
+                    // Firmware version for the ACTIVE strap. It's a STABLE property (NOOP can't change a
+                    // strap's firmware), so prefer the live handshake value but fall back to the last-known
+                    // persisted firmware (written on connect in FrameRouter) when the live value is momentarily
+                    // nil — mid-handshake, or a connection that hasn't re-read GET_HELLO/REPORT_VERSION_INFO
+                    // yet this session. Without this the "· FW x" blanks out while actively connected. Single
+                    // last-connected-strap key, so a not-yet-connected active strap can briefly show the other
+                    // strap's build on a multi-WHOOP install until it connects and republishes. Twin of Android.
+                    liveFirmware: device.status == .active
+                        ? (live.strapFirmware ?? UserDefaults.standard.string(forKey: "noop.lastFirmware")) : nil,
                     // Historical record layout (v24/v25 on WHOOP 4.0) observed from this connection's
                     // backfill. Distinct from the strap firmware build shown as FW.
                     liveHistoryLayout: (device.status == .active && live.connected) ? live.strapRange?.firmwareLayout : nil,

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -179,11 +179,15 @@ private struct DevicesContent: View {
                     // strap's firmware), so prefer the live handshake value but fall back to the last-known
                     // persisted firmware (written on connect in FrameRouter) when the live value is momentarily
                     // nil — mid-handshake, or a connection that hasn't re-read GET_HELLO/REPORT_VERSION_INFO
-                    // yet this session. Without this the "· FW x" blanks out while actively connected. Single
-                    // last-connected-strap key, so a not-yet-connected active strap can briefly show the other
-                    // strap's build on a multi-WHOOP install until it connects and republishes. Twin of Android.
+                    // yet this session. Without this the "· FW x" blanks out while actively connected. The
+                    // persisted fallback is WHOOP-only: "noop.lastFirmware" is written solely from a WHOOP
+                    // handshake, so a non-WHOOP active device (Oura) must NOT inherit it. Single last-connected-
+                    // strap key, so a not-yet-connected active strap can briefly show the other strap's build on
+                    // a multi-WHOOP install until it republishes. Twin of Android.
                     liveFirmware: device.status == .active
-                        ? (live.strapFirmware ?? UserDefaults.standard.string(forKey: "noop.lastFirmware")) : nil,
+                        ? (live.strapFirmware
+                            ?? (SourceCoordinator.isWhoop(device) ? UserDefaults.standard.string(forKey: "noop.lastFirmware") : nil))
+                        : nil,
                     // Historical record layout (v24/v25 on WHOOP 4.0) observed from this connection's
                     // backfill. Distinct from the strap firmware build shown as FW.
                     liveHistoryLayout: (device.status == .active && live.connected) ? live.strapRange?.firmwareLayout : nil,

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -235,11 +235,14 @@ fun DevicesScreen(
                 // firmware), so prefer the live handshake value but fall back to the last-known persisted
                 // firmware (NoopPrefs, written on connect) when the live value is momentarily null — mid-
                 // handshake, or a connection that hasn't re-read REPORT_VERSION_INFO yet this session. Without
-                // this the "· FW x" blanks out while actively connected + syncing. Persisted value is a single
-                // last-connected-strap key, so on a multi-WHOOP install a not-yet-connected active strap can
-                // briefly show the other strap's build until it connects and republishes.
+                // this the "· FW x" blanks out while actively connected + syncing. The persisted fallback is
+                // WHOOP-only: `noop.lastFirmware` is written solely from a WHOOP handshake, so a non-WHOOP
+                // active device (Oura/FTMS) must NOT inherit it. Single-key, so on a multi-WHOOP install a
+                // not-yet-connected active strap can briefly show the other strap's build until it republishes.
                 liveFirmware = if (device.status == DeviceStatus.active.name)
-                    (live.strapFirmware ?: NoopPrefs.lastFirmware(context)) else null,
+                    (live.strapFirmware
+                        ?: if (device.brand.equals("WHOOP", ignoreCase = true)) NoopPrefs.lastFirmware(context) else null)
+                    else null,
                 // Historical record layout from the current backfill, distinct from strap firmware.
                 liveHistoryLayout = if (device.status == DeviceStatus.active.name && live.connected)
                     live.historyLayoutVersion else null,

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -231,9 +231,15 @@ fun DevicesScreen(
                     live.batteryPct?.let { Math.round(it).toInt() } else null,
                 liveBatteryMv = if (device.status == DeviceStatus.active.name && live.connected)
                     live.batteryMv else null,
-                // Firmware version from the connect handshake: only for the active, connected strap.
-                liveFirmware = if (device.status == DeviceStatus.active.name && live.connected)
-                    live.strapFirmware else null,
+                // Firmware version for the ACTIVE strap. It's a STABLE property (NOOP can't change a strap's
+                // firmware), so prefer the live handshake value but fall back to the last-known persisted
+                // firmware (NoopPrefs, written on connect) when the live value is momentarily null — mid-
+                // handshake, or a connection that hasn't re-read REPORT_VERSION_INFO yet this session. Without
+                // this the "· FW x" blanks out while actively connected + syncing. Persisted value is a single
+                // last-connected-strap key, so on a multi-WHOOP install a not-yet-connected active strap can
+                // briefly show the other strap's build until it connects and republishes.
+                liveFirmware = if (device.status == DeviceStatus.active.name)
+                    (live.strapFirmware ?: NoopPrefs.lastFirmware(context)) else null,
                 // Historical record layout from the current backfill, distinct from strap firmware.
                 liveHistoryLayout = if (device.status == DeviceStatus.active.name && live.connected)
                     live.historyLayoutVersion else null,


### PR DESCRIPTION
## What

Reported: the Devices card's **`· FW <version>` goes missing while the strap is actively connected + syncing**.

Two independent investigations confirmed the firmware **send → decode → display path is intact and unchanged** by any recent commit (including the `#1066` MTU/handshake work — it didn't touch this path). The reconnect path also re-runs the handshake (`connectHandshakeDone` is reset on disconnect at `WhoopBleClient.kt:7442`), so it's not a reconnect-skip either.

The actual fragility: the card showed **only the current connection's live handshake value** (`live.strapFirmware`), which is `null` whenever `REPORT_VERSION_INFO`/`GET_HELLO` hasn't (re-)landed this session (mid-handshake, or a connection that hasn't re-read it yet). Firmware is cleared on every disconnect, so any gap blanks the `· FW` suffix — even while connected.

## Fix

Firmware is a **stable strap property** (NOOP can't change it) and is **already persisted on connect** (`NoopPrefs.setLastFirmware` / iOS `FrameRouter` → `noop.lastFirmware`) — but only used for the debug export, never on the card. Prefer the live value, **fall back to the last-known persisted firmware** for the active device:

```
liveFirmware = if (active) (live.strapFirmware ?: lastKnownFirmware) else null
```

So the build stays visible through a live-null instead of blinking out.

## Parity

Both platforms had the **identical** live-only gate and the **same** `noop.lastFirmware` persistence — fixed symmetrically:
- Android `DevicesScreen.kt`
- iOS/macOS `DevicesView.swift`

Caveat noted in-code: the persisted key is a single last-connected-strap value, so on a multi-WHOOP install a not-yet-connected active strap can briefly show the *other* strap's build until it connects and republishes. (Firmware is display-only; no analytics/stored-data contract is affected.)

## Verification

- `compileFullDebugKotlin --no-build-cache`: clean.
- iOS/macOS app-target compile validated via **app-build** (no default CI covers `Strand/Screens`).
- On-device confirmation of the persistent `· FW` will come with the next staging build.