### PR TITLE
feat(android): opt-in wrist buzz for the phone's native timer/alarm (#1115)

### DIFF
--- a/android/app/src/main/java/com/noop/notif/NoopNotificationListener.kt
+++ b/android/app/src/main/java/com/noop/notif/NoopNotificationListener.kt
@@ -22,6 +22,11 @@ import com.noop.ui.NotifPrefs
  */
 class NoopNotificationListener : NotificationListenerService() {
 
+    // #1115: notification keys we've already buzzed for a native timer/alarm (CATEGORY_ALARM). onNotification-
+    // Posted fires on every post AND update, and a ringing alarm re-posts repeatedly — so buzz ONCE per key
+    // and forget it on removal, so a re-ring buzzes again but an updating notification can't storm the strap.
+    private val buzzedAlarmKeys = java.util.Collections.synchronizedSet(mutableSetOf<String>())
+
     override fun onNotificationPosted(sbn: StatusBarNotification) {
         val ctx = applicationContext
         val n = sbn.notification ?: return
@@ -49,9 +54,13 @@ class NoopNotificationListener : NotificationListenerService() {
             NotifPrefs.getBool(ctx, NotifPrefs.MASTER, false) &&
             NotifPrefs.getBool(ctx, NotifPrefs.ALARM_TIMER, false)) {
             val ble = (application as? NoopApplication)?.ble
+            // Buzz at most ONCE per notification key. `add()` is the LAST term, so a key is recorded only
+            // when we actually buzz (deliverable) — a re-posting/updating notification can't storm, and a
+            // genuine re-ring gets a fresh key (cleared in onNotificationRemoved) so it buzzes again.
             if (ble != null && !NotifPrefs.inQuietHours(ctx) &&
-                (!NotifPrefs.getBool(ctx, NotifPrefs.WORN, true) || ble.state.value.worn)) {
-                ble.buzz(3)   // a strong triple cue for a timer/alarm; send() no-ops if the strap isn't connected
+                (!NotifPrefs.getBool(ctx, NotifPrefs.WORN, true) || ble.state.value.worn) &&
+                buzzedAlarmKeys.add(sbn.key)) {
+                ble.buzz(3)   // a strong triple cue; send() no-ops if the strap isn't connected
             }
             return
         }
@@ -82,5 +91,8 @@ class NoopNotificationListener : NotificationListenerService() {
         if (VoipCallClassifier.isKnownVoipPackage(sbn.packageName)) {
             CallAlertController.stop(CallAlertSource.VOIP, sbn.key)
         }
+        // #1115: the alarm/timer is dismissed → forget its key so a genuinely new alarm with a re-used key
+        // (some clock apps reuse ids) buzzes again. Cheap no-op for any non-alarm key.
+        buzzedAlarmKeys.remove(sbn.key)
     }
 }

--- a/android/app/src/main/java/com/noop/notif/NoopNotificationListener.kt
+++ b/android/app/src/main/java/com/noop/notif/NoopNotificationListener.kt
@@ -39,6 +39,23 @@ class NoopNotificationListener : NotificationListenerService() {
             }
         }
 
+        // Native Clock timer/alarm → wrist buzz (#1115 follow-up, Android-only — iOS can't observe another
+        // app's notifications). Matched by CATEGORY_ALARM (any clock app, no package list) so it also
+        // catches a RINGING alarm, whose ONGOING notification the per-app path below deliberately skips.
+        // Own opt-in (default OFF), still under the notification master + quiet-hours + only-when-worn.
+        // Only INTERCEPTS when the toggle is on (then returns, so it can't also double-buzz via per-app);
+        // with the toggle off a Clock notification falls through to the per-app path unchanged.
+        if (n.category == Notification.CATEGORY_ALARM &&
+            NotifPrefs.getBool(ctx, NotifPrefs.MASTER, false) &&
+            NotifPrefs.getBool(ctx, NotifPrefs.ALARM_TIMER, false)) {
+            val ble = (application as? NoopApplication)?.ble
+            if (ble != null && !NotifPrefs.inQuietHours(ctx) &&
+                (!NotifPrefs.getBool(ctx, NotifPrefs.WORN, true) || ble.state.value.worn)) {
+                ble.buzz(3)   // a strong triple cue for a timer/alarm; send() no-ops if the strap isn't connected
+            }
+            return
+        }
+
         // Master gate + per-app opt-in (both default off — nothing buzzes until the user turns it on).
         // The "all other apps" catch-all (#168) lets anything outside the curated catalog through, since
         // Android package-visibility limits mean we can't list every installed app for per-app opt-in.

--- a/android/app/src/main/java/com/noop/notif/NoopNotificationListener.kt
+++ b/android/app/src/main/java/com/noop/notif/NoopNotificationListener.kt
@@ -50,7 +50,13 @@ class NoopNotificationListener : NotificationListenerService() {
         // Own opt-in (default OFF), still under the notification master + quiet-hours + only-when-worn.
         // Only INTERCEPTS when the toggle is on (then returns, so it can't also double-buzz via per-app);
         // with the toggle off a Clock notification falls through to the per-app path unchanged.
+        // EXCLUDE NOOP's OWN notifications: our SmartAlarmNotifier + SmartAlarmReceiver also set
+        // CATEGORY_ALARM, and this service receives its own app's posts — without this guard the toggle
+        // would buzz for NOOP's OWN smart alarm (a surprise for a "phone Clock" toggle, and a double-buzz
+        // with its firmware-alarm path). NOOP's alarm keeps its own settings; an app-buzz for it is a
+        // separate, deliberate feature, not this.
         if (n.category == Notification.CATEGORY_ALARM &&
+            sbn.packageName != ctx.packageName &&
             NotifPrefs.getBool(ctx, NotifPrefs.MASTER, false) &&
             NotifPrefs.getBool(ctx, NotifPrefs.ALARM_TIMER, false)) {
             val ble = (application as? NoopApplication)?.ble

--- a/android/app/src/main/java/com/noop/ui/NotificationsSettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/NotificationsSettingsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Alarm
 import androidx.compose.material.icons.filled.Call
 import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.filled.Email
@@ -160,6 +161,9 @@ internal object NotifPrefs {
     const val CALLS_PHONE = "notif.calls.phoneEnabled"
     const val CALLS_VOIP = "notif.calls.voipEnabled"
     const val CALLS_PATTERN = "notif.calls.pattern"
+    /** Buzz the strap when the phone's native Clock fires a timer/alarm (CATEGORY_ALARM). Android-only
+     *  (iOS can't observe another app's notifications). Default OFF. */
+    const val ALARM_TIMER = "notif.alarmTimer"
 
     private fun prefs(ctx: Context) =
         ctx.applicationContext.getSharedPreferences(FILE, Context.MODE_PRIVATE)
@@ -235,6 +239,7 @@ fun NotificationsSettingsScreen(vm: AppViewModel) {
     var callsEnabled by remember { mutableStateOf(NotifPrefs.getBool(context, NotifPrefs.CALLS_MASTER, false)) }
     var phoneCallsEnabled by remember { mutableStateOf(NotifPrefs.getBool(context, NotifPrefs.CALLS_PHONE, false)) }
     var voipCallsEnabled by remember { mutableStateOf(NotifPrefs.getBool(context, NotifPrefs.CALLS_VOIP, false)) }
+    var alarmTimerEnabled by remember { mutableStateOf(NotifPrefs.getBool(context, NotifPrefs.ALARM_TIMER, false)) }
     var callsPattern by remember { mutableStateOf(NotifPrefs.callPattern(context)) }
     // Scheduled report notifications (#517) — opt-in, default OFF. SharedPreferences isn't reactive, so
     // each Switch mirrors into local state and writes straight through to NoopPrefs.
@@ -354,6 +359,27 @@ fun NotificationsSettingsScreen(vm: AppViewModel) {
             },
             onTest = { vm.buzz(loops = callsPattern.loops) },
         )
+
+        // #1115 follow-up: buzz the strap when the phone's native Clock fires a timer or alarm
+        // (CATEGORY_ALARM, any clock app). Android-only — iOS can't observe another app's notifications.
+        AlertSection(
+            icon = Icons.Filled.Alarm,
+            title = uiString(R.string.notif_timer_alarm_title),
+            blurb = "Buzz your wrist when your phone's Clock app finishes a timer or rings an alarm.",
+        ) {
+            Column(modifier = Modifier.alphaIf(if (masterEnabled) 1f else Palette.disabledOpacity)) {
+                FormToggleRow(
+                    label = uiString(R.string.notif_timer_alarm_title),
+                    help = "Requires wrist alerts (above) to be on. Buzzes once when a timer/alarm notification fires.",
+                    checked = alarmTimerEnabled,
+                    enabled = masterEnabled,
+                    onChange = {
+                        alarmTimerEnabled = it
+                        NotifPrefs.setBool(context, NotifPrefs.ALARM_TIMER, it)
+                    },
+                )
+            }
+        }
 
         // #926: on a 5/MG the buzz payload is a hardcoded 12-byte literal and byte[11] (overallLoop) is
         // 0, so the caller's repeat count never reaches the wire — every BuzzPattern produces the same

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1905,4 +1905,5 @@
     <string name="l10n_app_changelog_widgets_stop_inventing_numbers_naps_count_4f7491bb">Widgets erfinden keine Zahlen mehr, Nickerchen zählen für die Schlafschuld, und die Android-Statusanzeigen sprechen deine Sprache</string>
     <string name="l10n_sleep_screen_may_be_incomplete_7230dc27">Möglicherweise unvollständig</string>
     <string name="l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4">Über Nacht wurde wenig Bewegung aufgezeichnet, daher wurde diese Nacht möglicherweise nicht vollständig erfasst und die Schlafdauer kann zu kurz erscheinen. Stelle sicher, dass das Band vollständig synchronisiert wurde.</string>
+    <string name="notif_timer_alarm_title">Timer &amp; Wecker</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1890,4 +1890,5 @@
     <string name="l10n_app_changelog_widgets_stop_inventing_numbers_naps_count_4f7491bb">Los widgets dejan de inventar números, las siestas cuentan para la deuda de sueño y los indicadores de Android hablan tu idioma</string>
     <string name="l10n_sleep_screen_may_be_incomplete_7230dc27">Puede estar incompleto</string>
     <string name="l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4">Se registró poco movimiento durante la noche, por lo que esta noche puede haberse detectado de forma incompleta y el total de sueño puede parecer corto. Asegúrate de que la correa se haya sincronizado por completo.</string>
+    <string name="notif_timer_alarm_title">Temporizador y alarma</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1890,4 +1890,5 @@
     <string name="l10n_app_changelog_widgets_stop_inventing_numbers_naps_count_4f7491bb">Les widgets n\'inventent plus de chiffres, les siestes comptent pour la dette de sommeil, et les indicateurs Android parlent votre langue</string>
     <string name="l10n_sleep_screen_may_be_incomplete_7230dc27">Peut être incomplet</string>
     <string name="l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4">Peu de mouvement a été enregistré cette nuit ; cette nuit peut donc être sous-détectée et le total de sommeil peut sembler court. Assurez-vous que le bracelet est entièrement synchronisé.</string>
+    <string name="notif_timer_alarm_title">Minuteur et alarme</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1884,4 +1884,5 @@
     <string name="l10n_app_changelog_widgets_stop_inventing_numbers_naps_count_4f7491bb">Os widgets deixam de inventar números, as sestas contam para a dívida de sono, e os indicadores Android falam a tua língua</string>
     <string name="l10n_sleep_screen_may_be_incomplete_7230dc27">Pode estar incompleto</string>
     <string name="l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4">Foi registado pouco movimento durante a noite, por isso esta noite pode ter sido subdetetada e o total de sono pode parecer curto. Certifique-se de que a pulseira sincronizou totalmente.</string>
+    <string name="notif_timer_alarm_title">Temporizador e alarme</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1818,4 +1818,5 @@
     <string name="l10n_app_changelog_widgets_stop_inventing_numbers_naps_count_4f7491bb">小组件不再编造数字、小睡计入睡眠债，Android 状态提示也终于会说你的语言</string>
     <string name="l10n_sleep_screen_may_be_incomplete_7230dc27">可能不完整</string>
     <string name="l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4">夜间记录到的动作很少，因此这一夜可能未被完整检测，睡眠总时长可能偏短。请确保表带已完全同步。</string>
+    <string name="notif_timer_alarm_title">计时器和闹钟</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1916,4 +1916,5 @@
     <string name="l10n_app_changelog_widgets_stop_inventing_numbers_naps_count_4f7491bb">Widgets stop inventing numbers, naps count toward sleep debt, and the Android status chips speak your language</string>
     <string name="l10n_sleep_screen_may_be_incomplete_7230dc27">May be incomplete</string>
     <string name="l10n_sleep_screen_little_motion_was_recorded_over_f061b7e4">Little motion was recorded overnight, so this night may be under-detected and the sleep total can read short. Make sure the strap fully synced.</string>
+    <string name="notif_timer_alarm_title">Timer &amp; alarm</string>
 </resources>


### PR DESCRIPTION
A follow-up to #1115: a dedicated **Android** toggle so NOOP buzzes your WHOOP strap when your **phone's own Clock app** fires a **timer or alarm** — the natively-set ones you already use.

## Why / how
The existing per-app notification buzz can already fire on a Clock notification *if* you enable that app in Notifications — but a **ringing alarm** posts an **ongoing** notification that the per-app path deliberately skips. So this catches it earlier by **`Notification.CATEGORY_ALARM`** (matches any clock app — no hardcoded package list):

- New `notif.alarmTimer` toggle, **default OFF**, under the existing **wrist-alerts master + quiet-hours + only-when-worn**.
- **Only intercepts when the toggle is on** (then returns, so it can't double-buzz via the per-app path). With it off, a Clock notification falls through to the per-app path unchanged — no regression.
- Buzz is the existing `RUN_HAPTICS_PATTERN` (works on 4.0; on 5/MG the haptic isn't honoured yet, #48).

## Android-only by nature
iOS/macOS **cannot** observe another app's notifications (no `NotificationListenerService`) — the same OS ceiling as calls and per-app buzzes — so there's **no Apple twin**. A **"Timer & alarm"** row is added to the Android Notifications screen (localized: `values` + de/es/fr/pt-PT/zh).

## Verification
- `compileFullDebugKotlin` ✓, `i18n_audit.py --ci main` ✓, `lintVitalFullRelease` (running).
- **Not hardware-tested** against a real Clock alarm yet — `CATEGORY_ALARM` is the standard for alarm notifications, but per-device timer categories should be confirmed on a strap.

Refs #1115.