### PR TITLE
fix(theme): make the Liquid hero card theme-aware in light mode (#1160, #1161)

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Palette.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Palette.swift
@@ -82,13 +82,23 @@ public enum StrandPalette {
 
     // MARK: Text ON a permanently-dark surface (scheme-invariant)
     // Use these — NOT textPrimary/Secondary/Tertiary — for labels/pills drawn over a fill that is pinned
-    // dark in BOTH themes (e.g. the Liquid Today hero score card + session-start row, whose `heroFill` is
-    // a fixed near-black). The regular text tokens FLIP to dark ink in Light mode, so on a fixed-dark card
-    // they render dark-on-near-black and vanish (#1013). These hold the light-on-dark values in BOTH
-    // schemes, so a label always reads on the card. (Same hex as the *.dark side of the text tokens.)
+    // dark in BOTH themes (e.g. the over-sky ScreenScaffold title, on the time-of-day sky backdrop). The
+    // regular text tokens FLIP to dark ink in Light mode, so on a fixed-dark surface they render
+    // dark-on-near-black and vanish (#1013). These hold the light-on-dark values in BOTH schemes, so a
+    // label always reads. (The Liquid hero card USED to need these, but its `heroFill` is theme-aware as of
+    // #1160, so the hero now uses the normal text* tokens.)
     public static let onDarkPrimary   = Color(hex: "#F4F6F8")
     public static let onDarkSecondary = Color(hex: "#C8CFD8")
     public static let onDarkTertiary  = Color(hex: "#8A94A4")
+
+    // MARK: Liquid hero card surface (#1160/#1161)
+    // Was pinned near-black in BOTH themes, which read as a broken dark block in Light mode (#1160) and
+    // never honoured card transparency (#1161). Now THEME-AWARE: near-black in Dark, frosted white in
+    // Light, so the hero fits in with the other cards. Its own text uses the regular text*/tint tokens
+    // (which flip) — NOT onDark*, which stays fixed for the genuinely-always-dark SKY backdrop
+    // (ScreenScaffold's over-sky title). 8-digit hex = RRGGBBAA (alpha last).
+    public static let heroFill   = Color(light: "FFFFFFD9", dark: "0D0E14CC")
+    public static let heroBorder = Color(light: "0000001A", dark: "FFFFFF1C")
 
     // MARK: Glow — ambient bloom behind heroes / charts (additive on dark; faint warm on light)
     public static let glowAmbient    = Color(light: "#F0E4C0", dark: "#3A2D0A")

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -112,7 +112,7 @@ struct LiquidTodayView: View {
     /// The liquid heart pink (matches LiquidThread's default + the mockup #ff6b81).
     private let liquidHeart = Color(.sRGB, red: 1, green: 107 / 255, blue: 129 / 255, opacity: 1)
     /// Hero card fill: a translucent near-black so it floats over the sky (mock rgba(13,14,20,.78)).
-    private let heroFill = Color(.sRGB, red: 13 / 255, green: 14 / 255, blue: 20 / 255, opacity: 0.80)
+    private var heroFill: Color { StrandPalette.heroFill }
     /// "Card transparency" (0–100, default 100): fades every liquid card surface here — the hero, the
     /// session-start row, the metric tiles and the `card` helper — in lockstep with the frosted cards.
     /// Content sits above the surface so it stays readable. Mirrors Kotlin `NoopPrefs.cardOpacityPercent`.
@@ -476,21 +476,21 @@ struct LiquidTodayView: View {
                 Image(systemName: "shield.lefthalf.filled")
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundStyle(StrandPalette.metricCyan)
-                // The session-start row shares the hero card's pinned-dark `heroFill`, so its text/chevron
-                // use the on-dark tokens — textPrimary/Secondary/Tertiary flip to dark ink in Light mode and
-                // went dark-on-near-black here too (#1013).
+                // The session-start row shares the hero card's THEME-AWARE `heroFill` (#1160), so its text
+                // uses the normal text tokens — light ink on the Dark hero, dark ink on the Light frosted-
+                // white hero. (Was pinned-dark + on-dark tokens before #1160.)
                 Text("Start session")
                     .font(StrandFont.subhead)
-                    .foregroundStyle(StrandPalette.onDarkPrimary)
+                    .foregroundStyle(StrandPalette.textPrimary)
                 Text("BETA")
                     .font(StrandFont.overlineScaled(8.5)).tracking(1.2)
-                    .foregroundStyle(StrandPalette.onDarkSecondary)
+                    .foregroundStyle(StrandPalette.textSecondary)
                     .padding(.horizontal, 8).padding(.vertical, 2.5)
                     .background(Capsule().fill(.white.opacity(0.05))
                         .overlay(Capsule().strokeBorder(.white.opacity(0.18), lineWidth: 1)))
                 Spacer(minLength: 8)
                 Image(systemName: "chevron.right").font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(StrandPalette.onDarkTertiary)
+                    .foregroundStyle(StrandPalette.textTertiary)
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 11)
@@ -498,7 +498,7 @@ struct LiquidTodayView: View {
                 RoundedRectangle(cornerRadius: 18, style: .continuous)
                     .fill(heroFill)
                     .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous)
-                        .strokeBorder(.white.opacity(0.11), lineWidth: 1))
+                        .strokeBorder(StrandPalette.heroBorder, lineWidth: 1))
                     .opacity(cardOpacity)
             )
         }
@@ -528,7 +528,7 @@ struct LiquidTodayView: View {
                           animated: dataLoaded, onGuide: { guideSection = .rest })
                 .overlay(alignment: .top) {
                     if let sourceLabel = heroSourceLabel {
-                        SourceBadge("\(sourceLabel)", tint: StrandPalette.onDarkSecondary)
+                        SourceBadge("\(sourceLabel)", tint: StrandPalette.textSecondary)
                             // Match the badge's trailing edge to the Rest vessel and centre it on the card border.
                             .fixedSize()
                             .frame(width: HeroScoreCell.vesselDiameter, alignment: .trailing)
@@ -544,7 +544,7 @@ struct LiquidTodayView: View {
             RoundedRectangle(cornerRadius: 26, style: .continuous)
                 .fill(heroFill)
                 .overlay(RoundedRectangle(cornerRadius: 26, style: .continuous)
-                    .strokeBorder(.white.opacity(0.11), lineWidth: 1))
+                    .strokeBorder(StrandPalette.heroBorder, lineWidth: 1))
                 .shadow(color: .black.opacity(0.6), radius: 30, y: 16)
                 .opacity(cardOpacity)
         )
@@ -1500,7 +1500,7 @@ private struct HeroScoreCell: View {
                         Text("–").font(StrandFont.rounded(26))
                     }
                 }
-                .foregroundStyle(.white)
+                .foregroundStyle(StrandPalette.textPrimary)
                 .shadow(color: .black.opacity(0.5), radius: 6, y: 1)
                 .lineLimit(1)
                 .minimumScaleFactor(0.6)
@@ -1514,10 +1514,9 @@ private struct HeroScoreCell: View {
                         .lineLimit(1).minimumScaleFactor(0.7)
                     Image(systemName: "chevron.right").font(.system(size: 9, weight: .semibold)).opacity(0.6)
                 }
-                // The hero card fill is pinned dark in BOTH themes, so the CHARGE/EFFORT/REST label must use
-                // the scheme-invariant on-dark token — textSecondary flips to dark ink in Light mode and
-                // went dark-on-near-black here (#1013).
-                .foregroundStyle(StrandPalette.onDarkSecondary)
+                // The hero card fill is THEME-AWARE now (#1160), so the CHARGE/EFFORT/REST label uses the
+                // normal text token — readable on the Dark hero and the Light frosted-white hero alike.
+                .foregroundStyle(StrandPalette.textSecondary)
             }
             .buttonStyle(.plain)
             .accessibilityLabel(Text("\(label), \(score.map { decimals > 0 ? String(format: "%.\(decimals)f", $0) : String(Int($0.rounded())) } ?? String(localized: "no data yet")). See how it is scored."))

--- a/android/app/src/main/java/com/noop/ui/BreatheScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BreatheScreen.kt
@@ -128,7 +128,6 @@ private enum class Phase { Inhale, Exhale }
 // translucent near-black (mock rgba(13,14,20,.80)) so it floats over the day-of-sky and the vessel + white
 // count-up read crisp on it; radius 26 + a white@0.11 hairline give the frosted-glass edge. Declared here
 // (not shared from Today) because the Today copies are file-private — same values, kept in lockstep.
-private val LIQUID_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
 private val LIQUID_HERO_RADIUS = 26.dp
 
 /** The three biofeedback layers as a mode switch (mirrors BreathingView.Mode). */
@@ -374,8 +373,8 @@ fun BreatheScreen(viewModel: AppViewModel) {
             modifier = Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(LIQUID_HERO_RADIUS))
-                .background(LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity))
-                .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
+                .background(Palette.heroFill.copy(alpha = Palette.heroFill.alpha * CardAppearance.opacity))
+                .border(1.dp, Palette.heroBorder.copy(alpha = Palette.heroBorder.alpha * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
                 .padding(24.dp),
         ) {
             Column(

--- a/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
@@ -80,7 +80,6 @@ private const val COUPLED_NO_DATA = "No Data"
 // a translucent near-black that floats over the day-of-sky so the vessel + white count-up numbers stay
 // crisp — the card does the contrast work, not a muted sky. heroFill = rgba(13,14,20,.80), stroke
 // white@0.11, radius 26. Mirrors the iOS LiquidTodayView heroCard.
-private val LIQUID_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
 private val LIQUID_HERO_RADIUS: Dp = 26.dp
 
 @Composable
@@ -310,8 +309,8 @@ private fun HeroCard(
             .fillMaxWidth()
             .liquidPress(interaction)
             .clip(RoundedCornerShape(LIQUID_HERO_RADIUS))
-            .background(LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity))
-            .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
+            .background(Palette.heroFill.copy(alpha = Palette.heroFill.alpha * CardAppearance.opacity))
+            .border(1.dp, Palette.heroBorder.copy(alpha = Palette.heroBorder.alpha * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
             .clickable(
                 interactionSource = interaction,
                 indication = null,

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -99,7 +99,6 @@ import kotlinx.coroutines.launch
 // frosted card so the strap name + the live battery tube stay crisp on it. Same tokens as the liquid Today
 // hero (heroFill = rgba(13,14,20,.80), radius 26, white@0.11 hairline). Those Today constants are private to
 // TodayScreen, so the identical values are declared here. Mirrors the iOS liquid heroCard.
-private val LIQUID_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
 private val LIQUID_HERO_RADIUS: Dp = 26.dp
 
 @Composable
@@ -680,8 +679,8 @@ private fun DeviceCard(
             modifier = cardModifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(LIQUID_HERO_RADIUS))
-                .background(LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity))
-                .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
+                .background(Palette.heroFill.copy(alpha = Palette.heroFill.alpha * CardAppearance.opacity))
+                .border(1.dp, Palette.heroBorder.copy(alpha = Palette.heroBorder.alpha * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
                 .padding(18.dp),
         ) {
             body()

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -786,8 +786,6 @@ private fun VitalityHero(
 // The frosted translucent-black hero-card wrapper (mock rgba(13,14,20,.80), radius 26, white@0.11
 // hairline) that floats the hero over the day-of-sky so the vessel + white count-up stay crisp — the
 // card does the contrast work, not a muted sky. Byte-matched to the Today pilot's LIQUID_HERO_* values.
-private val HEALTH_HERO_FILL: Color =
-    Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
 private val HEALTH_HERO_RADIUS: Dp = 26.dp
 
 /** Wrap a hero's content in the frosted liquid glass surface so it floats over the sky backdrop. Applied
@@ -799,8 +797,8 @@ private fun LiquidHeroCard(content: @Composable () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(HEALTH_HERO_RADIUS))
-            .background(HEALTH_HERO_FILL)
-            .border(1.dp, Color.White.copy(alpha = 0.11f), RoundedCornerShape(HEALTH_HERO_RADIUS))
+            .background(Palette.heroFill.copy(alpha = Palette.heroFill.alpha * CardAppearance.opacity))
+            .border(1.dp, Palette.heroBorder.copy(alpha = Palette.heroBorder.alpha * CardAppearance.opacity), RoundedCornerShape(HEALTH_HERO_RADIUS))
             .padding(Metrics.cardPadding),
     ) {
         content()

--- a/android/app/src/main/java/com/noop/ui/HydrationScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HydrationScreen.kt
@@ -82,7 +82,6 @@ private val hydrationAccent: Color
 // The frosted translucent near-black the hydration vessel floats on (mock rgba(13,14,20,.80)), so the vessel
 // + the white count-up litre figure read crisp over the day-of-sky. Radius 26 + a white@0.11 hairline give
 // the frosted-glass edge. Same numbers as the liquid Today heroCard (TodayScreen.kt LIQUID_HERO_*).
-private val LIQUID_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
 private val LIQUID_HERO_RADIUS = 26.dp
 
 /** Upper bound (ml) for a single custom hydration log (#798) - a sane cap so a stray digit can't bank an
@@ -199,8 +198,8 @@ fun HydrationScreen(viewModel: AppViewModel) {
                 modifier = Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(LIQUID_HERO_RADIUS))
-                    .background(LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity))
-                    .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
+                    .background(Palette.heroFill.copy(alpha = Palette.heroFill.alpha * CardAppearance.opacity))
+                    .border(1.dp, Palette.heroBorder.copy(alpha = Palette.heroBorder.alpha * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
                     .padding(20.dp),
             ) {
                 Column(

--- a/android/app/src/main/java/com/noop/ui/LiveScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/LiveScreen.kt
@@ -90,7 +90,6 @@ import com.noop.ble.WhoopModel
 // (mock rgba(13,14,20,.80)) so it floats over the day-of-sky; the vessel + the white count-up number read
 // crisp on it. Radius 26 + a white@0.11 hairline give the frosted-glass edge. (Twins of the liquid Today
 // LIQUID_HERO_FILL / LIQUID_HERO_RADIUS, redeclared here since those are file-private to TodayScreen.)
-private val LIVE_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
 private val LIVE_HERO_RADIUS: Dp = 26.dp
 
 @Composable
@@ -936,8 +935,8 @@ private fun BodyConsole(live: LiveState, bpm: Int?, activeConnection: Boolean, z
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(LIVE_HERO_RADIUS))
-            .background(LIVE_HERO_FILL.copy(alpha = LIVE_HERO_FILL.alpha * CardAppearance.opacity))
-            .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIVE_HERO_RADIUS))
+            .background(Palette.heroFill.copy(alpha = Palette.heroFill.alpha * CardAppearance.opacity))
+            .border(1.dp, Palette.heroBorder.copy(alpha = Palette.heroBorder.alpha * CardAppearance.opacity), RoundedCornerShape(LIVE_HERO_RADIUS))
             .padding(20.dp),
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(18.dp)) {

--- a/android/app/src/main/java/com/noop/ui/PaletteTokens.kt
+++ b/android/app/src/main/java/com/noop/ui/PaletteTokens.kt
@@ -90,6 +90,12 @@ data class PaletteTokens(
     // The bright gauge-tip / sparkline-head core: white reads as a highlight on dark; on light it
     // would vanish into the white card, so it flips to a deep ink (crisp centre on the coloured bead).
     val tipCore: Color,
+    // #1160/#1161: the Liquid hero card surface (Today's Charge/Effort/Rest vessel + every screen's hero).
+    // Pinned near-black in DARK; in LIGHT it flips to a frosted white so the hero fits in with the other
+    // cards instead of reading as a broken dark block (was a raw literal inlined in 11 screens). heroBorder
+    // + heroLabel flip with it so the edge stays subtle and the source-badge text stays readable in both.
+    val heroFill: Color,
+    val heroBorder: Color,
 )
 
 // WHOOP-reset dark palette (gold killed 2026-06-22). Values match StrandPalette.swift's DARK
@@ -118,6 +124,7 @@ val DarkTokens = PaletteTokens(
     goldDeepText = Color(0xFFFFFFFF), signalYellow = Color(0xFFFFD63D),
     titaniumTop = Color(0xFFF1F3F5), titaniumMid = Color(0xFFC9CFD4), titaniumLow = Color(0xFF969DA4), titaniumDeep = Color(0xFF6B737B),
     tipCore = Color(0xFFFFFFFF),
+    heroFill = Color(0xCC0D0E14), heroBorder = Color(0x1CFFFFFF),
 )
 
 val LightTokens = PaletteTokens(
@@ -144,6 +151,9 @@ val LightTokens = PaletteTokens(
     goldDeepText = Color(0xFF3A2708), signalYellow = Color(0xFFE8A800),
     titaniumTop = Color(0xFFDDE1E6), titaniumMid = Color(0xFFBBC2C9), titaniumLow = Color(0xFF98A0A8), titaniumDeep = Color(0xFF6B737B),
     tipCore = Color(0xFF241B06),
+    // Frosted WHITE hero in light mode (#1160), subtle dark edge. (Hero text uses the flip-able text*
+    // tokens now, so no separate label token is needed.)
+    heroFill = Color(0xD9FFFFFF), heroBorder = Color(0x1A000000),
 )
 
 // MARK: - Chart style (data-viz colour mode) + the Classic throwback ramps

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -974,7 +974,6 @@ private fun DeletedSleepWindowsCard(
 // fill is a translucent near-black (mock rgba(13,14,20,.80)) so the card floats OVER the day-of-sky and the
 // vessel + white count-up number stay crisp — the CARD does the contrast work, not a muted sky. Radius 26 +
 // a white@0.11 hairline give the frosted-glass edge. Same constants as the liquid Today heroCard.
-private val LIQUID_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
 private val LIQUID_HERO_RADIUS: Dp = 26.dp
 
 // MARK: - 0. REST HERO — liquid sky + sleep-performance vessel (liquid restyle)
@@ -998,8 +997,8 @@ private fun RestHero(score: Double?, asleepMin: Double?, source: String, overlin
                 // the frosted-glass edge of the liquid Today heroCard (fill rgba(13,14,20,.80), stroke
                 // white@0.11). Replaces the per-hero night atmosphere (the sky now lives at screen level).
                 .clip(RoundedCornerShape(LIQUID_HERO_RADIUS))
-                .background(LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity))
-                .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS)),
+                .background(Palette.heroFill.copy(alpha = Palette.heroFill.alpha * CardAppearance.opacity))
+                .border(1.dp, Palette.heroBorder.copy(alpha = Palette.heroBorder.alpha * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS)),
         ) {
             Column(
                 modifier = Modifier.fillMaxWidth().padding(Metrics.space24),

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -251,7 +251,6 @@ private fun androidx.compose.foundation.lazy.LazyListScope.StressContent(
 // translucent near-black (mock rgba(13,14,20,.80)) so it floats over the day-of-sky; the vessel + white
 // count-up number read crisp on it. Radius 26 + a white@0.11 hairline give the frosted-glass edge. Same
 // numbers as the Today pilot's hero card.
-private val LIQUID_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
 private val LIQUID_HERO_RADIUS = 26.dp
 
 // MARK: - 1 · Hero — the liquid stress VESSEL (the flat PipBar is gone)
@@ -272,8 +271,8 @@ private fun StressHeroCard(model: StressModel, modifier: Modifier = Modifier) {
         modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(LIQUID_HERO_RADIUS))
-            .background(LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity))
-            .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
+            .background(Palette.heroFill.copy(alpha = Palette.heroFill.alpha * CardAppearance.opacity))
+            .border(1.dp, Palette.heroBorder.copy(alpha = Palette.heroBorder.alpha * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
             .padding(Metrics.cardPadding),
     ) {
         Column(

--- a/android/app/src/main/java/com/noop/ui/Theme.kt
+++ b/android/app/src/main/java/com/noop/ui/Theme.kt
@@ -67,8 +67,13 @@ object Palette {
     val textSecondary get() = active.textSecondary
     val textTertiary get() = active.textTertiary
 
-    // Text that always sits on a pinned-dark surface, independent of the app's active light/dark scheme.
-    // Mirrors StrandPalette.onDarkSecondary for the liquid hero's source badge.
+    // #1160/#1161: the Liquid hero card surface, now theme-aware — near-black in dark, frosted white in
+    // light so the hero fits in with the other cards; the border flips with it. The hero's own text uses
+    // the flip-able text* tokens now (readable on either fill).
+    val heroFill get() = active.heroFill
+    val heroBorder get() = active.heroBorder
+    // Light-on-dark text for a GENUINELY-always-dark surface (twin of StrandPalette.onDarkSecondary). The
+    // theme-aware hero no longer uses this; kept for any always-dark chrome.
     val onDarkSecondary = Color(0xFFC8CFD8)
 
     // Glow.

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -203,7 +203,6 @@ private var todayDidSnapToTodayThisLaunch = false
 // The hero card the score vessels float on, ported from the iOS LiquidTodayView. `heroFill` is a
 // translucent near-black (mock rgba(13,14,20,.80)) so it floats over the day-of-sky; the vessels + white
 // count-up numbers read crisp on it. Radius 26 + a white@0.11 hairline give the frosted-glass edge.
-private val LIQUID_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
 private val LIQUID_HERO_RADIUS: Dp = 26.dp
 
 // The Vitality vessel purple (#9b7bff) — no exact Palette token in this theme, so a fixed brand literal
@@ -1377,10 +1376,10 @@ fun TodayScreen(
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .background(
-                                        LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity),
+                                        Palette.heroFill.copy(alpha = Palette.heroFill.alpha * CardAppearance.opacity),
                                         RoundedCornerShape(LIQUID_HERO_RADIUS),
                                     )
-                                    .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
+                                    .border(1.dp, Palette.heroBorder.copy(alpha = Palette.heroBorder.alpha * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
                                     .staggeredAppear(stagger),
                             ) {
                                 ScoreHeroRow(
@@ -2471,7 +2470,8 @@ private fun ScoreHeroRow(
                     if (heroSourceLabel != null) {
                         SourceBadge(
                             text = heroSourceLabel,
-                            tint = Palette.onDarkSecondary,
+                            // #1160: the hero is theme-aware now, so its badge uses the flip-able text token.
+                            tint = Palette.textSecondary,
                             modifier = Modifier
                                 .align(Alignment.TopEnd)
                                 // Measure the full label even when it is wider than the Rest vessel, then

--- a/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
@@ -78,7 +78,6 @@ import kotlin.math.roundToInt
 // (rgba(13,14,20,.80)) rather than the classic frosted surface — the card does the contrast work so the
 // crisp line chart + the count-up vessel accent read clean over the sky. Radius 26 + a white@0.11 hairline
 // give it the frosted-glass edge. Mirrors the liquid Today heroCard (LiquidTodayView / TodayScreen).
-private val LIQUID_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
 private val LIQUID_HERO_RADIUS: Dp = 26.dp
 
 @Composable
@@ -700,8 +699,8 @@ private fun ChartCard(
             modifier = modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(LIQUID_HERO_RADIUS))
-                .background(LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity))
-                .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
+                .background(Palette.heroFill.copy(alpha = Palette.heroFill.alpha * CardAppearance.opacity))
+                .border(1.dp, Palette.heroBorder.copy(alpha = Palette.heroBorder.alpha * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
                 .padding(Metrics.cardPadding),
         ) {
             body()

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -651,7 +651,6 @@ private fun sessionSelectionKey(row: WorkoutRow): String = "${row.startTs}|${row
 // is a translucent near-black (mock rgba(13,14,20,.80)) so it floats over the day-of-sky; the vessel + the
 // white count-up read crisp on it. Radius 26 + a white@0.11 hairline give the frosted-glass edge. (These
 // are file-scoped to Workouts — the Today equivalents are private to that file.)
-private val LIQUID_HERO_FILL: Color = Color(red = 13f / 255f, green = 14f / 255f, blue = 20f / 255f, alpha = 0.80f)
 private val LIQUID_HERO_RADIUS: Dp = 26.dp
 
 // MARK: - Effort hero (typical-effort liquid vessel over the day-of-sky)
@@ -688,8 +687,8 @@ private fun EffortHero(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(LIQUID_HERO_RADIUS))
-            .background(LIQUID_HERO_FILL.copy(alpha = LIQUID_HERO_FILL.alpha * CardAppearance.opacity))
-            .border(1.dp, Color.White.copy(alpha = 0.11f * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
+            .background(Palette.heroFill.copy(alpha = Palette.heroFill.alpha * CardAppearance.opacity))
+            .border(1.dp, Palette.heroBorder.copy(alpha = Palette.heroBorder.alpha * CardAppearance.opacity), RoundedCornerShape(LIQUID_HERO_RADIUS))
             .padding(20.dp),
     ) {
         Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {


### PR DESCRIPTION
Fixes two bugs reported by @flexagoon (Android, WHOOP 5.0) that turned out to be **one root cause**.

## Root cause
The Liquid **hero card** (Today's Charge/Effort/Rest vessel + every screen's hero) painted a **hardcoded near-black fill** — `rgba(13,14,20,0.80)` — inlined as a private literal in **11 screens**, pinned dark and never consulting the theme tokens (unlike every normal card → `Palette.surfaceRaised`, white in light mode).

- **#1160 "Dark cards in light mode"** — the pinned near-black hero reads as a broken dark block among the white cards.
- **#1161 "Card transparency leaves ugly borders"** — the fill's `0.80` base alpha barely fades under the transparency slider while the `0.11` border vanishes ("transparent border, solid card"); **HealthScreen's hero ignored the slider entirely**.

## Fix
- New **theme-aware `heroFill` + `heroBorder`** tokens (Android `Palette` / Apple `StrandPalette`): near-black in **Dark** (unchanged), **frosted white in Light** so the hero fits in.
- Route every hero's fill + border through them, scaled by the card-opacity `op` **consistently** (Health included → fixes #1161 there).
- Switch the hero's **text** from the pinned `onDark*` tokens to the normal flip-able `text*` tokens. Those are **byte-identical to `onDark*` on the dark side**, so **Dark mode is unchanged**, and they render readable dark ink on the light hero. `onDark*` stays fixed for the genuinely-always-dark **sky backdrop** (`ScreenScaffold`).
- Removed the 11 dead inlined literals; updated the now-stale "pinned dark" comments.

## Parity + safety
- Both platforms aligned: **hero → `text*`, `onDark*` → fixed (sky)**. Same feature, same tokens.
- **Dark mode is byte-identical** (`onDark* == text*.dark`; fill/border dark values unchanged) — no regression for dark-mode users.

## Verification
- `compileFullDebugKotlin` ✓; Apple compile validated via **app-build** (running).
- **Light-mode look on a real device is the remaining check** — the fix is a pure token swap, but the exact frosted-white shade is worth a glance on-device.

Closes #1160. Closes #1161.