### PR TITLE
feat(android): recolor chrome accent to brand mint (parity with iOS #1068)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/PaletteTokens.kt
+++ b/android/app/src/main/java/com/noop/ui/PaletteTokens.kt
@@ -106,7 +106,9 @@ val DarkTokens = PaletteTokens(
     surfaceInset = Color(0xFF1F2229), hairline = Color(0xFF21304A), hairlineStrong = Color(0xFF2E3C57),
     textPrimary = Color(0xFFF4F6F8), textSecondary = Color(0xFFC8CFD8), textTertiary = Color(0xFF8A94A4),
     glowAmbient = Color(0xFF3A2D0A),
-    accent = Color(0xFF60A0E0), accentHover = Color(0xFF8FBEEC), accentMuted = Color(0xFF16233A), focusRing = Color(0xFF60A0E0),
+    // Brand accent → mint, parity with iOS #1068 (NoopVisualStyle.mint/mintGlow). accentMuted is a dark
+    // teal muted surface (green-shifted analog of the old navy 0xFF16233A). Gold stays in the recovery world.
+    accent = Color(0xFF69DDB8), accentHover = Color(0xFF54E6BD), accentMuted = Color(0xFF163329), focusRing = Color(0xFF69DDB8),
     recovery000 = Color(0xFFE0463C), recovery030 = Color(0xFFE8743C), recovery055 = Color(0xFFF9DF4A),
     recovery078 = Color(0xFF8FD86A), recovery100 = Color(0xFF03E095),
     strain000 = Color(0xFF9C5A14), strain033 = Color(0xFFC2762A), strain066 = Color(0xFFD98A3D), strain100 = Color(0xFFF0A85A),
@@ -132,8 +134,10 @@ val LightTokens = PaletteTokens(
     surfaceInset = Color(0xFFDFD8C8), hairline = Color(0xFFD8D0BD), hairlineStrong = Color(0xFFC7BCA4),
     textPrimary = Color(0xFF1A2230), textSecondary = Color(0xFF4C5564), textTertiary = Color(0xFF7C8696),
     glowAmbient = Color(0xFFF0E4C0),
-    // Light chrome accent shifts to the deep brand blue (gold reserved for the recovery world + FAB).
-    accent = Color(0xFF234F9E), accentHover = Color(0xFF1C3F80), accentMuted = Color(0xFFE4ECF6), focusRing = Color(0xFF2F6FCB),
+    // Light chrome accent → brand mint, parity with iOS #1068 (NoopVisualStyle.mint/mintGlow, light side).
+    // accentMuted is a pale mint tint (green-shifted analog of the old pale blue 0xFFE4ECF6); note Android's
+    // light theme is a WARM paper theme, so this shade may want an on-device tweak. Gold stays in recovery.
+    accent = Color(0xFF149A78), accentHover = Color(0xFF38C99E), accentMuted = Color(0xFFDCEDE6), focusRing = Color(0xFF149A78),
     recovery000 = Color(0xFF8F6212), recovery030 = Color(0xFFA87718), recovery055 = Color(0xFFC28E26),
     recovery078 = Color(0xFFD2A23A), recovery100 = Color(0xFFE0B44C),
     strain000 = Color(0xFF7E460E), strain033 = Color(0xFFA4621B), strain066 = Color(0xFFC2792E), strain100 = Color(0xFFD89240),


### PR DESCRIPTION
Android twin of the accent recolor in **#1068** (iOS visual refresh), so the two apps share the brand accent instead of diverging.

Maps the chrome accent tokens from iOS's `NoopVisualStyle` mint world:

| token | old (blue) → new (mint), dark / light |
|---|---|
| `accent` | `60A0E0`/`234F9E` → `69DDB8`/`149A78` (`mint`) |
| `accentHover` | `8FBEEC`/`1C3F80` → `54E6BD`/`38C99E` (`mintGlow`) |
| `focusRing` | `60A0E0`/`2F6FCB` → `69DDB8`/`149A78` (`mint`) |
| `accentMuted` | `16233A`/`E4ECF6` → `163329`/`DCEDE6` (green-shifted analog) |

**Scope:** chrome accent only — no data, strings, or layout. The recovery/strain/sleep colour worlds are untouched (gold stays in recovery, as on iOS).

**Caveat:** `accentMuted` light is the one hand-picked value — Android's light theme is a warm/beige paper theme (iOS is cool white), so a literal `mintDeep@18%` composite would muddy. Worth an on-device light-mode glance.

**Sequencing:** ideally lands alongside/after #1068 so both platforms flip together. `compileFullDebugKotlin` clean.