### PR TITLE
feat: user-selectable chrome accent colour (Mint / WHOOP Blue / Custom)

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Appearance.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Appearance.swift
@@ -36,6 +36,84 @@ public extension View {
     }
 }
 
+/// The user's CHROME accent colour (buttons, links, focus rings, selected states). Only the chrome
+/// accent — never the recovery/strain/sleep DATA colour worlds (those follow `ChartStyle`). Read globally
+/// via `StrandPalette.accentChoice` (+ `StrandPalette.customAccentHex` for `.custom`), set from
+/// `@AppStorage(AccentColor.storageKey)` / `@AppStorage(AccentColor.customHexKey)` at the app root; the
+/// `accent`/`accentHover`/`accentMuted`/`focusRing` accessors in `StrandPalette` branch on it. Mirror in
+/// Kotlin via `Palette.accentChoice` + `NoopPrefs.accentColor`/`accentCustomHex`.
+public enum AccentColor: String, CaseIterable, Identifiable, Sendable {
+    case mint        // the brand default (#1068 NoopVisualStyle.mint world)
+    case whoopBlue   // the classic WHOOP link blue
+    case custom      // a user-picked colour (hex stored separately)
+
+    public var id: String { rawValue }
+    public static let storageKey = "accent.color"
+    /// The custom colour's hex, kept separate so switching away from `.custom` and back keeps the choice.
+    public static let customHexKey = "accent.customHex"
+    /// Seeds the custom picker (mint) so a fresh `.custom` selection is not black.
+    public static let defaultCustomHex = "#149A78"
+
+    public var label: String {
+        switch self {
+        case .mint:      return String(localized: "Mint", bundle: .module)
+        case .whoopBlue: return String(localized: "WHOOP Blue", bundle: .module)
+        case .custom:    return String(localized: "Custom", bundle: .module)
+        }
+    }
+
+    public static func resolve(_ raw: String) -> AccentColor { AccentColor(rawValue: raw) ?? .mint }
+
+    /// The chrome accent. `.custom` resolves the stored hex at read time.
+    public var accent: Color {
+        switch self {
+        case .mint:      return NoopVisualStyle.mint
+        case .whoopBlue: return Color(light: "#234F9E", dark: "#60A0E0")
+        case .custom:    return Color(hex: StrandPalette.customAccentHex)
+        }
+    }
+
+    /// The brighter hover/pressed accent. For `.custom` it is the chosen colour lightened toward white.
+    public var accentHover: Color {
+        switch self {
+        case .mint:      return NoopVisualStyle.mintGlow
+        case .whoopBlue: return Color(light: "#3A6FC0", dark: "#8FBEEC")
+        case .custom:    return AccentColor.lighten(StrandPalette.customAccentHex)
+        }
+    }
+
+    /// A low-opacity tint of the accent for muted fills (chips, selected rows). Translucent so it
+    /// composites over whatever surface is behind it — the same 0.18 the mint world uses.
+    public var accentMuted: Color {
+        switch self {
+        case .mint:      return NoopVisualStyle.mintDeep.opacity(0.18)
+        case .whoopBlue: return Color(light: "#234F9E", dark: "#60A0E0").opacity(0.18)
+        case .custom:    return Color(hex: StrandPalette.customAccentHex).opacity(0.18)
+        }
+    }
+
+    public var focusRing: Color { accent }
+
+    /// Blend an sRGB hex toward white by `amount` (0…1) — the deterministic "hover" derivation for a
+    /// custom accent, so a single picked colour still gets a sensible brighter pressed state.
+    static func lighten(_ hex: String, by amount: Double = 0.24) -> Color {
+        let c = Color.sRGBComponents(hex: hex)
+        func up(_ x: Double) -> Double { min(1, x + (1 - x) * amount) }
+        return Color(.sRGB, red: up(c.r), green: up(c.g), blue: up(c.b), opacity: 1)
+    }
+}
+
+/// Applies the chrome accent: sets `StrandPalette.accentChoice` + `customAccentHex` (read by the accent
+/// accessors) and keys the content so a change re-renders live. Apply at each app root:
+/// `.noopAccent(accentRaw, customHex: accentCustomHex)`.
+public extension View {
+    func noopAccent(_ raw: String, customHex: String) -> some View {
+        StrandPalette.accentChoice = AccentColor.resolve(raw)
+        StrandPalette.customAccentHex = customHex
+        return self.id("noop.accent.\(raw).\(customHex)")
+    }
+}
+
 /// The user's appearance preference for the whole app. Persisted via
 /// `@AppStorage(AppearanceMode.storageKey)`. `.system` follows the OS (the default);
 /// `.light` / `.dark` force a scheme regardless of the system setting.

--- a/Packages/StrandDesign/Sources/StrandDesign/Palette.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Palette.swift
@@ -103,14 +103,19 @@ public enum StrandPalette {
     // MARK: Glow — ambient bloom behind heroes / charts (additive on dark; faint warm on light)
     public static let glowAmbient    = NoopVisualStyle.mintGlow.opacity(0.28)
 
-    // MARK: Accent — chrome anchor (links, selection, focus, generic accent). On DARK this is the brand
-    // GOLD; on LIGHT it shifts to the deep brand BLUE so gold is reserved for the recovery/Charge world
-    // and the gold FAB — keeping the light theme from reading as wall-to-wall gold (the maintainer 2026-06-16).
-    public static let accent         = NoopVisualStyle.mint
-    public static let accentHover    = NoopVisualStyle.mintGlow
-    public static let accentMuted    = NoopVisualStyle.mintDeep.opacity(0.18)
-    /// Focus ring color (blue on both schemes — WHOOP has no gold).
-    public static let focusRing      = NoopVisualStyle.mint
+    // MARK: Accent — chrome anchor (links, selection, focus, generic accent). USER-SELECTABLE (mint /
+    // WHOOP blue / custom) via `accentChoice` below, default mint (#1068). Only the chrome accent is
+    // user-themed — the recovery/strain/sleep DATA worlds follow `chartStyle`, never this.
+    /// The user's chrome-accent choice. Set from `@AppStorage(AccentColor.storageKey)` at the app root
+    /// via `.noopAccent(...)`; the four accessors below branch on it. Default mint.
+    public static var accentChoice: AccentColor = .mint
+    /// The custom accent's hex, used only when `accentChoice == .custom`. Set alongside `accentChoice`.
+    public static var customAccentHex: String = AccentColor.defaultCustomHex
+    public static var accent: Color { accentChoice.accent }
+    public static var accentHover: Color { accentChoice.accentHover }
+    public static var accentMuted: Color { accentChoice.accentMuted }
+    /// Focus ring color — the same accent, on both schemes.
+    public static var focusRing: Color { accentChoice.focusRing }
     /// Opacity for dimmed/disabled sections (shared so screens don't invent their own value).
     public static let disabledOpacity: Double = 0.45
 

--- a/Strand/App/StrandApp.swift
+++ b/Strand/App/StrandApp.swift
@@ -31,6 +31,9 @@ struct StrandApp: App {
     @AppStorage(AppearanceMode.storageKey) private var appearanceRaw = AppearanceMode.system.rawValue
     /// Chart data-colour style (Titanium / Classic throwback). Re-colours gauges + charts.
     @AppStorage(ChartStyle.storageKey) private var chartStyleRaw = ChartStyle.titanium.rawValue
+    /// Chrome accent colour (mint / WHOOP blue / custom). Chrome only — never the data colour worlds.
+    @AppStorage(AccentColor.storageKey) private var accentRaw = AccentColor.mint.rawValue
+    @AppStorage(AccentColor.customHexKey) private var accentCustomHex = AccentColor.defaultCustomHex
 
     var body: some Scene {
         WindowGroup {
@@ -51,6 +54,7 @@ struct StrandApp: App {
                 .frame(minWidth: 1000, minHeight: 700)
                 .preferredColorScheme(AppearanceMode.resolve(appearanceRaw).colorScheme)
                 .chartStyle(chartStyleRaw)
+                .noopAccent(accentRaw, customHex: accentCustomHex)
                 // Dynamic Type now scales the prose/label roles (StrandFont). Cap the upper end so the
                 // fixed-geometry tiles/gauges stay legible at the largest accessibility sizes rather than
                 // clipping; the common Larger-Text range still scales fully.

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -174828,6 +174828,162 @@
           }
         }
       }
+    },
+    "Accent": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Akzent"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acento"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accent"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accento"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Destaque"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Акцент"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "强调色"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "強調色"
+          }
+        }
+      }
+    },
+    "Accent colour": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Akzentfarbe"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color de acento"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couleur d’accent"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Colore d’accento"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cor de destaque"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Цвет акцента"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "强调色"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "強調色"
+          }
+        }
+      }
+    },
+    "Custom accent colour": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eigene Akzentfarbe"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color de acento personalizado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couleur d’accent personnalisée"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Colore d’accento personalizzato"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cor de destaque personalizada"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Свой цвет акцента"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义强调色"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自訂強調色"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -166,6 +166,9 @@ struct SettingsView: View {
     @AppStorage(AppearanceMode.storageKey) private var appearanceRaw = AppearanceMode.system.rawValue
     // Chart colour style: Titanium (brand) or Classic (throwback red→green). Re-colours gauges + charts.
     @AppStorage(ChartStyle.storageKey) private var chartStyleRaw = ChartStyle.titanium.rawValue
+    // Chrome accent colour (mint / WHOOP blue / custom). Chrome only — never the data colour worlds.
+    @AppStorage(AccentColor.storageKey) private var accentRaw = AccentColor.mint.rawValue
+    @AppStorage(AccentColor.customHexKey) private var accentCustomHex = AccentColor.defaultCustomHex
     // Day-cycle scene backdrop behind Today (#698). Default ON. Off swaps the scene for a plain dark
     // canvas. TodayView reads the same key to gate its SceneScreenBackground.
     @AppStorage(SceneBackgroundPrefs.enabledKey) private var showDayCycleBackground = true
@@ -804,6 +807,14 @@ struct SettingsView: View {
         }
     }
 
+    /// Bridges the SwiftUI `ColorPicker` (a `Color`) to the persisted custom-accent hex string.
+    private var customAccentBinding: Binding<Color> {
+        Binding(
+            get: { Color(hex: accentCustomHex) },
+            set: { accentCustomHex = $0.noopAccentHex ?? AccentColor.defaultCustomHex }
+        )
+    }
+
     private var appearanceCard: some View {
         SettingsSection(
             icon: "circle.lefthalf.filled",
@@ -835,6 +846,28 @@ struct SettingsView: View {
                     .pickerStyle(.menu)
                     .tint(StrandPalette.accent)
                     .accessibilityLabel("Chart colours")
+                }
+                rowDivider
+                // Chrome accent colour — the links/buttons/selection tint only. The recovery/strain/sleep
+                // DATA colours follow "Chart colours" above, never this. Custom reveals a colour well.
+                FormRow(label: "Accent") {
+                    Picker("Accent", selection: $accentRaw) {
+                        ForEach(AccentColor.allCases) { c in
+                            Text(c.label).tag(c.rawValue)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .tint(StrandPalette.accent)
+                    .accessibilityLabel("Accent colour")
+                }
+                if AccentColor.resolve(accentRaw) == .custom {
+                    rowDivider
+                    FormRow(label: "Custom colour") {
+                        ColorPicker("Custom colour", selection: customAccentBinding, supportsOpacity: false)
+                            .labelsHidden()
+                            .accessibilityLabel("Custom accent colour")
+                    }
                 }
                 rowDivider
                 // Trend chart style (line vs bar). Display-only: flips the Trends tab's charts between the
@@ -3297,3 +3330,21 @@ private struct FormRow<Control: View>: View {
         .preferredColorScheme(.dark)
 }
 #endif
+
+// MARK: - Custom accent colour bridge
+
+private extension Color {
+    /// sRGB hex (`#RRGGBB`) for persisting a `ColorPicker` selection into `AccentColor.customHexKey`.
+    /// Falls back to nil if the colour can't resolve to sRGB (the caller then keeps the default).
+    var noopAccentHex: String? {
+        #if os(iOS)
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        guard UIColor(self).getRed(&r, green: &g, blue: &b, alpha: &a) else { return nil }
+        #elseif os(macOS)
+        guard let ns = NSColor(self).usingColorSpace(.sRGB) else { return nil }
+        let r = ns.redComponent, g = ns.greenComponent, b = ns.blueComponent
+        #endif
+        return String(format: "#%02X%02X%02X",
+                      Int((r * 255).rounded()), Int((g * 255).rounded()), Int((b * 255).rounded()))
+    }
+}

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -28,6 +28,9 @@ struct StrandiOSApp: App {
     @AppStorage(AppearanceMode.storageKey) private var appearanceRaw = AppearanceMode.system.rawValue
     /// Chart data-colour style (Titanium / Classic throwback). Re-colours gauges + charts.
     @AppStorage(ChartStyle.storageKey) private var chartStyleRaw = ChartStyle.titanium.rawValue
+    /// Chrome accent colour (mint / WHOOP blue / custom). Chrome only — never the data colour worlds.
+    @AppStorage(AccentColor.storageKey) private var accentRaw = AccentColor.mint.rawValue
+    @AppStorage(AccentColor.customHexKey) private var accentCustomHex = AccentColor.defaultCustomHex
     /// Effort's display scale is also embedded in the shared widget snapshot. Observe it here so a
     /// Settings change gets one accurate full rebuild instead of waiting for an unrelated repo refresh.
     @AppStorage(UnitPrefs.effortScaleKey) private var effortScaleRaw = EffortScale.hundred.rawValue
@@ -90,6 +93,7 @@ struct StrandiOSApp: App {
                 .environment(\.stressNudgeCenter, model.stressNudgeCenter)
                 .preferredColorScheme(AppearanceMode.resolve(appearanceRaw).colorScheme)
                 .chartStyle(chartStyleRaw)
+                .noopAccent(accentRaw, customHex: accentCustomHex)
                 // Dynamic Type now scales the prose/label roles (StrandFont). Cap the upper end so the
                 // fixed-geometry tiles/gauges stay legible at the largest accessibility sizes rather than
                 // clipping; the common Larger-Text range still scales fully.

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -91,6 +91,7 @@ class MainActivity : ComponentActivity() {
         // and chart ramps are correct from the very first frame (no flash).
         AppearancePrefs.load(this)
         ChartStylePrefs.load(this)
+        AccentPrefs.load(this)   // chrome accent colour (mint / WHOOP blue / custom), live snapshot state
         // Decode the optional on-device profile photo (if set) before first composition so the Today
         // header + Settings avatars show it from the first frame. No-op when no photo is set.
         ProfileAvatarStore.load(this)

--- a/android/app/src/main/java/com/noop/ui/PaletteTokens.kt
+++ b/android/app/src/main/java/com/noop/ui/PaletteTokens.kt
@@ -271,3 +271,67 @@ object AppearancePrefs {
         prefs(ctx).edit().putString(KEY, value.storageValue).apply()
     }
 }
+
+/** The user's CHROME accent colour (buttons/links/selection/focus). Chrome only — the recovery/strain/
+ *  sleep DATA colour worlds are never themed by this. Twin of macOS `AccentColor` (StrandDesign). */
+enum class AccentColor(val storageValue: String, val label: String) {
+    MINT("mint", "Mint"),
+    WHOOP_BLUE("whoopBlue", "WHOOP Blue"),
+    CUSTOM("custom", "Custom");
+
+    companion object {
+        /** Seeds the custom picker (mint) so a fresh Custom selection is not black. */
+        const val DEFAULT_CUSTOM_HEX = "#149A78"
+
+        fun fromStorage(raw: String?): AccentColor =
+            entries.firstOrNull { it.storageValue == raw } ?: MINT
+
+        /** Parse `#RRGGBB` to a Color, falling back to [fallback] on any malformed value. */
+        fun parseHex(hex: String, fallback: Color): Color = try {
+            Color(("FF" + hex.removePrefix("#").trim()).toLong(16))
+        } catch (e: Exception) {
+            fallback
+        }
+
+        /** Blend a hex toward white by [amount] (0..1) — the deterministic hover for a custom accent. */
+        fun lighten(hex: String, amount: Float = 0.24f): Color {
+            val c = parseHex(hex, Color(0xFF149A78))
+            fun up(x: Float) = (x + (1 - x) * amount).coerceIn(0f, 1f)
+            return Color(up(c.red), up(c.green), up(c.blue), 1f)
+        }
+    }
+}
+
+/** Chrome-accent preference, persisted in `noop_prefs` + snapshot state so the picker is live. [load] is
+ *  called once from MainActivity; [setColor]/[setCustomHex] write + flip. Twin of the macOS
+ *  `@AppStorage(AccentColor.storageKey/customHexKey)` app-root wiring. */
+object AccentPrefs {
+    private const val FILE = "noop_prefs"
+    private const val KEY_COLOR = "accent.color"
+    private const val KEY_CUSTOM = "accent.customHex"
+
+    private fun prefs(ctx: Context): SharedPreferences =
+        ctx.applicationContext.getSharedPreferences(FILE, Context.MODE_PRIVATE)
+
+    /** Live accent choice + custom hex read by the Palette accent getters; defaults until [load] runs. */
+    var color by mutableStateOf(AccentColor.MINT)
+        private set
+    var customHex by mutableStateOf(AccentColor.DEFAULT_CUSTOM_HEX)
+        private set
+
+    fun load(ctx: Context) {
+        color = AccentColor.fromStorage(prefs(ctx).getString(KEY_COLOR, AccentColor.MINT.storageValue))
+        customHex = prefs(ctx).getString(KEY_CUSTOM, AccentColor.DEFAULT_CUSTOM_HEX)
+            ?: AccentColor.DEFAULT_CUSTOM_HEX
+    }
+
+    fun setColor(ctx: Context, value: AccentColor) {
+        color = value
+        prefs(ctx).edit().putString(KEY_COLOR, value.storageValue).apply()
+    }
+
+    fun setCustomHex(ctx: Context, hex: String) {
+        customHex = hex
+        prefs(ctx).edit().putString(KEY_CUSTOM, hex).apply()
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.material.icons.Icons
@@ -84,6 +85,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -582,6 +584,9 @@ fun SettingsScreen(
     var themeMode by remember { mutableStateOf(AppearancePrefs.mode) }
     // Chart colours (Titanium / Classic) — re-colours gauges + charts; ChartStylePrefs mirrors it live.
     var chartStyle by remember { mutableStateOf(ChartStylePrefs.style) }
+    // Chrome accent (Mint / WHOOP Blue / Custom) — chrome only; AccentPrefs mirrors it in snapshot state.
+    var accentColor by remember { mutableStateOf(AccentPrefs.color) }
+    var accentCustomHex by remember { mutableStateOf(AccentPrefs.customHex) }
     // Trend charts (Line / Bar) — flips the Trends tab between the gradient line and value-ramp bars.
     // Display-only; SharedPreferences isn't reactive, so mirror into local state and persist on select.
     var trendChartStyle by remember { mutableStateOf(UnitPrefs.trendChartStyle(context)) }
@@ -1071,6 +1076,30 @@ fun SettingsScreen(
                     onSelect = { style ->
                         chartStyle = style
                         ChartStylePrefs.set(context, style)
+                    },
+                )
+            }
+            SettingsRowDivider()
+            // Chrome accent colour — links/buttons/selection tint only. The recovery/strain/sleep DATA
+            // colours follow "Chart colours", never this. Custom reveals RGB sliders.
+            SettingsFormRow(label = uiString(R.string.l10n_settings_screen_accent)) {
+                SegmentedPillControl(
+                    items = listOf(AccentColor.MINT, AccentColor.WHOOP_BLUE, AccentColor.CUSTOM),
+                    selection = accentColor,
+                    label = { it.label },
+                    onSelect = { c ->
+                        accentColor = c
+                        AccentPrefs.setColor(context, c)
+                    },
+                )
+            }
+            if (accentColor == AccentColor.CUSTOM) {
+                SettingsRowDivider()
+                AccentCustomPicker(
+                    hex = accentCustomHex,
+                    onHexChange = { hex ->
+                        accentCustomHex = hex
+                        AccentPrefs.setCustomHex(context, hex)
                     },
                 )
             }
@@ -3192,4 +3221,53 @@ private fun setAppIcon(context: Context, navy: Boolean) {
         else PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
         PackageManager.DONT_KILL_APP,
     )
+}
+
+/** #accent: a compact RGB picker for the CUSTOM chrome accent — a live preview swatch + three channel
+ *  sliders. Emits `#RRGGBB` on every change; the Palette accent updates live via [AccentPrefs]. Shown only
+ *  when the accent picker is set to Custom. */
+@Composable
+private fun AccentCustomPicker(hex: String, onHexChange: (String) -> Unit) {
+    val base = AccentColor.parseHex(hex, Color(0xFF149A78))
+    var r by remember { mutableStateOf(base.red) }
+    var g by remember { mutableStateOf(base.green) }
+    var b by remember { mutableStateOf(base.blue) }
+    fun emit() = onHexChange(
+        String.format("#%02X%02X%02X", (r * 255).roundToInt(), (g * 255).roundToInt(), (b * 255).roundToInt()),
+    )
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .height(26.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(Color(r, g, b, 1f)),
+        )
+        AccentChannelSlider("R", r) { r = it; emit() }
+        AccentChannelSlider("G", g) { g = it; emit() }
+        AccentChannelSlider("B", b) { b = it; emit() }
+    }
+}
+
+@Composable
+private fun AccentChannelSlider(label: String, value: Float, onChange: (Float) -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(label, style = NoopType.caption, color = Palette.textTertiary, modifier = Modifier.width(14.dp))
+        Slider(
+            value = value,
+            onValueChange = onChange,
+            colors = SliderDefaults.colors(
+                thumbColor = Palette.accent,
+                activeTrackColor = Palette.accent,
+                inactiveTrackColor = Palette.surfaceInset,
+            ),
+            modifier = Modifier.weight(1f),
+        )
+    }
 }

--- a/android/app/src/main/java/com/noop/ui/Theme.kt
+++ b/android/app/src/main/java/com/noop/ui/Theme.kt
@@ -79,11 +79,25 @@ object Palette {
     // Glow.
     val glowAmbient get() = active.glowAmbient
 
-    // Accent — GOLD brand anchor.
-    val accent get() = active.accent
-    val accentHover get() = active.accentHover
-    val accentMuted get() = active.accentMuted
-    val focusRing get() = active.focusRing
+    // Accent — user-selectable chrome anchor (mint default / WHOOP blue / custom). Chrome ONLY; the
+    // recovery/strain/sleep DATA worlds are never themed by this. Reads AccentPrefs snapshot state so a
+    // change is live. Twin of macOS StrandPalette.accent* branching on AccentColor.
+    val accent get() = when (AccentPrefs.color) {
+        AccentColor.MINT -> active.accent
+        AccentColor.WHOOP_BLUE -> if (isLight) Color(0xFF234F9E) else Color(0xFF60A0E0)
+        AccentColor.CUSTOM -> AccentColor.parseHex(AccentPrefs.customHex, active.accent)
+    }
+    val accentHover get() = when (AccentPrefs.color) {
+        AccentColor.MINT -> active.accentHover
+        AccentColor.WHOOP_BLUE -> if (isLight) Color(0xFF3A6FC0) else Color(0xFF8FBEEC)
+        AccentColor.CUSTOM -> AccentColor.lighten(AccentPrefs.customHex)
+    }
+    val accentMuted get() = when (AccentPrefs.color) {
+        AccentColor.MINT -> active.accentMuted
+        AccentColor.WHOOP_BLUE -> (if (isLight) Color(0xFF234F9E) else Color(0xFF60A0E0)).copy(alpha = 0.18f)
+        AccentColor.CUSTOM -> AccentColor.parseHex(AccentPrefs.customHex, active.accent).copy(alpha = 0.18f)
+    }
+    val focusRing get() = if (AccentPrefs.color == AccentColor.MINT) active.focusRing else accent
     const val disabledOpacity = 0.45f
 
     // Recovery / Charge gradient.

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1916,4 +1916,5 @@
     <string name="l10n_settings_screen_ecg_gate_persistent_warning">Dies schreibt eine Einstellung, die AUF DEINEM BAND BLEIBT, bis du sie zurücksetzt — es ist keine App-Einstellung, und das Schließen von NOOP macht sie nicht rückgängig. „Sperre ausschalten“ schreibt mit einem Tippen wieder \'0\'. Es wird ausschließlich dieser eine Schlüssel geschrieben; die anderen sechs, die dein Band aufgelistet hat, werden nie angefasst.</string>
     <string name="l10n_settings_screen_ecg_gate_turn_on">Sperre einschalten (\'1\' schreiben)</string>
     <string name="l10n_settings_screen_ecg_gate_turn_off">Sperre ausschalten (\'0\' schreiben)</string>
+    <string name="l10n_settings_screen_accent">Akzent</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1901,4 +1901,5 @@
     <string name="l10n_settings_screen_ecg_gate_persistent_warning">Esto escribe un ajuste que PERMANECE EN TU CORREA hasta que lo cambies de vuelta: no es una preferencia de la app y cerrar NOOP no lo deshace. «Desactivar bloqueo» vuelve a escribir \'0\' con un solo toque. Solo se escribe esta clave; las otras seis que enumeró tu correa nunca se tocan.</string>
     <string name="l10n_settings_screen_ecg_gate_turn_on">Activar bloqueo (escribir \'1\')</string>
     <string name="l10n_settings_screen_ecg_gate_turn_off">Desactivar bloqueo (escribir \'0\')</string>
+    <string name="l10n_settings_screen_accent">Acento</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1901,4 +1901,5 @@
     <string name="l10n_settings_screen_ecg_gate_persistent_warning">Ceci écrit un réglage qui RESTE SUR VOTRE BRACELET jusqu\'à ce que vous le remettiez — ce n\'est pas une préférence de l\'app, et fermer NOOP ne l\'annule pas. « Désactiver le verrou » réécrit « 0 » en une seule touche. Seule cette clé est écrite ; les six autres que votre bracelet a énumérées ne sont jamais touchées.</string>
     <string name="l10n_settings_screen_ecg_gate_turn_on">Activer le verrou (écrire « 1 »)</string>
     <string name="l10n_settings_screen_ecg_gate_turn_off">Désactiver le verrou (écrire « 0 »)</string>
+    <string name="l10n_settings_screen_accent">Accent</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1895,4 +1895,5 @@
     <string name="l10n_settings_screen_ecg_gate_persistent_warning">Isto escreve uma definição que FICA NA SUA PULSEIRA até a repor — não é uma preferência da aplicação e fechar o NOOP não a desfaz. «Desativar bloqueio» volta a escrever \'0\' com um só toque. Só esta chave é escrita; as outras seis que a sua pulseira listou nunca são tocadas.</string>
     <string name="l10n_settings_screen_ecg_gate_turn_on">Ativar bloqueio (escrever \'1\')</string>
     <string name="l10n_settings_screen_ecg_gate_turn_off">Desativar bloqueio (escrever \'0\')</string>
+    <string name="l10n_settings_screen_accent">Destaque</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1829,4 +1829,5 @@
     <string name="l10n_settings_screen_ecg_gate_persistent_warning">这会写入一项会一直留在你手环上的设置，直到你改回来——它不是应用内的偏好设置，关闭 NOOP 也不会撤销。「关闭开关」一键即可再写入 \'0\'。全程只写入这一个键；你手环列出的另外六个从不触碰。</string>
     <string name="l10n_settings_screen_ecg_gate_turn_on">打开开关（写入 \'1\'）</string>
     <string name="l10n_settings_screen_ecg_gate_turn_off">关闭开关（写入 \'0\'）</string>
+    <string name="l10n_settings_screen_accent">强调色</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1927,4 +1927,5 @@
     <string name="l10n_settings_screen_ecg_gate_persistent_warning">This writes a setting that STAYS ON YOUR STRAP until you change it back — it isn\'t an app preference, and closing NOOP won\'t undo it. \"Turn gate off\" writes \'0\' again, in one tap. Only this one key is ever written; the other six your strap listed are never touched.</string>
     <string name="l10n_settings_screen_ecg_gate_turn_on">Turn gate on (write \'1\')</string>
     <string name="l10n_settings_screen_ecg_gate_turn_off">Turn gate off (write \'0\')</string>
+    <string name="l10n_settings_screen_accent">Accent</string>
 </resources>


### PR DESCRIPTION
Adds an **Accent colour** setting so users can theme the chrome accent (buttons, links, selection, focus rings). Two presets — **Mint** (the #1068 brand default) and **WHOOP Blue** (the previous accent) — plus a **Custom** colour. Both platforms.

## Scope
**Chrome accent only.** The recovery / strain / sleep **data colour worlds** are never touched by this — those follow the existing *Chart colours* setting. Default stays Mint, so it's purely opt-in. No data, analytics, or layout changes.

## How it works (mirrors the existing `ChartStyle` mechanism)
- **iOS:** `AccentColor` enum in StrandDesign; `StrandPalette.accentChoice` + `customAccentHex` settable statics; `accent`/`accentHover`/`accentMuted`/`focusRing` become computed on them; a `.noopAccent(...)` app-root modifier fed from `@AppStorage`. Settings → Appearance gets an **Accent** picker + a native `ColorPicker` for Custom.
- **Android:** `AccentColor` + `AccentPrefs` (snapshot state, twin of `AppearancePrefs`); the `Palette` accent getters branch on it; loaded at startup. Settings gets a `SegmentedPillControl` + a compact **RGB slider** custom picker (Compose has no native colour picker).
- **Custom:** one picked colour → `accent`; `hover` derived by lightening toward white; `muted` = accent @ 18%; `focusRing` = accent. Same derivation both platforms.

## Validation
- iOS: **app-build green (iOS + macOS)**.
- Android: `compileFullDebugKotlin` clean.
- i18n audit clean (new *Accent* label localised in 6 Android locales; 3 iOS labels added to `Localizable.xcstrings`).
- On-device glance worth doing for the custom picker + Android's warm light theme.