### PR TITLE
feat(theme): named theme presets (Mint / Ocean / Classic / Midnight / Frosted)

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Appearance.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Appearance.swift
@@ -114,6 +114,72 @@ public extension View {
     }
 }
 
+/// A named THEME preset — a one-tap bundle that coordinates the accent, the chart colour world, the
+/// day-cycle backdrop, and the card opacity. Purely an orchestration over settings that already exist:
+/// selecting a preset writes those four prefs, and the granular controls stay available underneath. There
+/// is NO stored "current theme" — it's DERIVED from the live prefs via [matching], so tweaking any one
+/// control simply resolves to `.custom`. Theme MODE (System/Light/Dark) is independent and never bundled.
+/// Twin of Kotlin `ThemePreset`.
+public enum ThemePreset: String, CaseIterable, Identifiable, Sendable {
+    case mint       // brand default: mint accent, Titanium charts, backdrop on, solid cards
+    case ocean      // WHOOP-blue accent, Titanium charts, backdrop on, solid
+    case classic    // WHOOP-blue accent, Classic throwback charts, backdrop on, solid
+    case midnight   // mint accent, Titanium charts, backdrop OFF (plain canvas), solid
+    case frosted    // mint accent, Titanium charts, backdrop on, translucent cards
+    case custom     // sentinel: the live combination matches no preset
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .mint:     return String(localized: "Mint", bundle: .module)
+        case .ocean:    return String(localized: "Ocean", bundle: .module)
+        case .classic:  return String(localized: "Classic", bundle: .module)
+        case .midnight: return String(localized: "Midnight", bundle: .module)
+        case .frosted:  return String(localized: "Frosted", bundle: .module)
+        case .custom:   return String(localized: "Custom", bundle: .module)
+        }
+    }
+
+    /// The four coordinated values a preset writes (nil for `.custom`, which sets nothing). Named `Recipe`
+    /// rather than `Bundle` deliberately — `Bundle` would shadow `Foundation.Bundle`, used just above in
+    /// `String(localized:bundle:)`.
+    public struct Recipe: Sendable {
+        public let accent: AccentColor
+        public let chart: ChartStyle
+        public let backdrop: Bool
+        public let cardOpacity: Int
+    }
+
+    public var recipe: Recipe? {
+        switch self {
+        case .mint:     return Recipe(accent: .mint,      chart: .titanium, backdrop: true,  cardOpacity: 100)
+        case .ocean:    return Recipe(accent: .whoopBlue, chart: .titanium, backdrop: true,  cardOpacity: 100)
+        case .classic:  return Recipe(accent: .whoopBlue, chart: .classic,  backdrop: true,  cardOpacity: 100)
+        case .midnight: return Recipe(accent: .mint,      chart: .titanium, backdrop: false, cardOpacity: 100)
+        case .frosted:  return Recipe(accent: .mint,      chart: .titanium, backdrop: true,  cardOpacity: 85)
+        case .custom:   return nil
+        }
+    }
+
+    /// The presets a user can pick (everything except the derived `.custom` sentinel).
+    public static var selectable: [ThemePreset] { allCases.filter { $0 != .custom } }
+
+    public static func resolve(_ raw: String) -> ThemePreset { ThemePreset(rawValue: raw) ?? .mint }
+
+    /// Which preset the live prefs correspond to, or `.custom` when none match.
+    public static func matching(accent: AccentColor, chart: ChartStyle,
+                                backdrop: Bool, cardOpacity: Int) -> ThemePreset {
+        for p in selectable {
+            if let r = p.recipe, r.accent == accent, r.chart == chart,
+               r.backdrop == backdrop, r.cardOpacity == cardOpacity {
+                return p
+            }
+        }
+        return .custom
+    }
+}
+
 /// The user's appearance preference for the whole app. Persisted via
 /// `@AppStorage(AppearanceMode.storageKey)`. `.system` follows the OS (the default);
 /// `.light` / `.dark` force a scheme regardless of the system setting.

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -174984,6 +174984,110 @@
           }
         }
       }
+    },
+    "Preset": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorlage"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preajuste"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Préréglage"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preset"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predefinição"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пресет"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "预设"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預設"
+          }
+        }
+      }
+    },
+    "Theme preset": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Themenvorlage"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preajuste de tema"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Préréglage de thème"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preset del tema"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predefinição de tema"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пресет темы"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主题预设"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主題預設"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -815,6 +815,27 @@ struct SettingsView: View {
         )
     }
 
+    /// The Theme PRESET is derived from the four coordinated prefs (no stored value): reads which preset
+    /// the live combination matches (or `.custom`), and on pick writes accent + chart + backdrop + opacity.
+    private var themePresetBinding: Binding<ThemePreset> {
+        Binding(
+            get: {
+                ThemePreset.matching(
+                    accent: AccentColor.resolve(accentRaw),
+                    chart: ChartStyle.resolve(chartStyleRaw),
+                    backdrop: showDayCycleBackground,
+                    cardOpacity: cardOpacityPercent)
+            },
+            set: { preset in
+                guard let r = preset.recipe else { return }   // .custom → no-op
+                accentRaw = r.accent.rawValue
+                chartStyleRaw = r.chart.rawValue
+                showDayCycleBackground = r.backdrop
+                cardOpacityPercent = r.cardOpacity
+            }
+        )
+    }
+
     private var appearanceCard: some View {
         SettingsSection(
             icon: "circle.lefthalf.filled",
@@ -822,6 +843,20 @@ struct SettingsView: View {
             blurb: "Choose Light, Dark, or follow your system. Dark is the signature near-black; Light keeps the same clean look on a bright canvas."
         ) {
             VStack(spacing: 0) {
+                // Theme presets — one-tap bundles coordinating accent + chart world + backdrop + card
+                // opacity. Derived (no stored value): tweaking any control below flips this to Custom.
+                FormRow(label: "Preset") {
+                    Picker("Preset", selection: themePresetBinding) {
+                        ForEach(ThemePreset.allCases) { p in
+                            Text(p.label).tag(p)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .tint(StrandPalette.accent)
+                    .accessibilityLabel("Theme preset")
+                }
+                rowDivider
                 FormRow(label: "Theme") {
                     Picker("Theme", selection: $appearanceRaw) {
                         ForEach(AppearanceMode.allCases) { mode in

--- a/android/app/src/main/java/com/noop/ui/PaletteTokens.kt
+++ b/android/app/src/main/java/com/noop/ui/PaletteTokens.kt
@@ -335,3 +335,34 @@ object AccentPrefs {
         prefs(ctx).edit().putString(KEY_CUSTOM, hex).apply()
     }
 }
+
+/** A named THEME preset — a one-tap bundle coordinating accent + chart world + backdrop + card opacity.
+ *  Pure orchestration over prefs that already exist; DERIVED (no stored value) via [matching], so tweaking
+ *  any granular control resolves to [CUSTOM]. Theme MODE (light/dark) is independent. Twin of macOS
+ *  `ThemePreset`. */
+enum class ThemePreset(
+    val storageValue: String,
+    val label: String,
+    val accent: AccentColor?,   // null for CUSTOM
+    val chart: ChartStyle?,
+    val backdrop: Boolean,
+    val cardOpacity: Int,       // percent, 100 = solid
+) {
+    MINT("mint", "Mint", AccentColor.MINT, ChartStyle.TITANIUM, true, 100),
+    OCEAN("ocean", "Ocean", AccentColor.WHOOP_BLUE, ChartStyle.TITANIUM, true, 100),
+    CLASSIC("classic", "Classic", AccentColor.WHOOP_BLUE, ChartStyle.CLASSIC, true, 100),
+    MIDNIGHT("midnight", "Midnight", AccentColor.MINT, ChartStyle.TITANIUM, false, 100),
+    FROSTED("frosted", "Frosted", AccentColor.MINT, ChartStyle.TITANIUM, true, 85),
+    CUSTOM("custom", "Custom", null, null, true, 100);
+
+    companion object {
+        /** The presets a user can pick (everything but the derived CUSTOM sentinel). */
+        val selectable: List<ThemePreset> get() = entries.filter { it != CUSTOM }
+
+        /** Which preset the live prefs correspond to, or CUSTOM when none match. */
+        fun matching(accent: AccentColor, chart: ChartStyle, backdrop: Boolean, cardOpacity: Int): ThemePreset =
+            selectable.firstOrNull {
+                it.accent == accent && it.chart == chart && it.backdrop == backdrop && it.cardOpacity == cardOpacity
+            } ?: CUSTOM
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -68,6 +68,9 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Slider
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
@@ -1053,6 +1056,30 @@ fun SettingsScreen(
             title = uiString(R.string.l10n_settings_screen_appearance_41def7a0),
             blurb = "Choose Light, Dark, or follow your system. Dark is the signature near-black; Light keeps the same clean look on a bright canvas.",
         ) {
+            // Theme presets — one-tap bundles coordinating accent + chart world + backdrop + card opacity.
+            // Derived (no stored value): tweaking any control below flips this to Custom.
+            SettingsFormRow(label = uiString(R.string.l10n_settings_screen_preset)) {
+                ThemePresetDropdown(
+                    current = ThemePreset.matching(
+                        accentColor, chartStyle, showDayCycleBackground, (cardOpacity * 100).roundToInt(),
+                    ),
+                    onSelect = { p ->
+                        val accent = p.accent
+                        val chart = p.chart
+                        if (accent != null && chart != null) {
+                            accentColor = accent
+                            chartStyle = chart
+                            showDayCycleBackground = p.backdrop
+                            cardOpacity = p.cardOpacity / 100f
+                            AccentPrefs.setColor(context, accent)
+                            ChartStylePrefs.set(context, chart)
+                            NoopPrefs.setShowDayCycleBackground(context, p.backdrop)
+                            NoopPrefs.setCardOpacityPercent(context, p.cardOpacity)
+                        }
+                    },
+                )
+            }
+            SettingsRowDivider()
             SettingsFormRow(label = uiString(R.string.l10n_settings_screen_theme_a797e309)) {
                 SegmentedPillControl(
                     items = listOf(AppearanceMode.SYSTEM, AppearanceMode.LIGHT, AppearanceMode.DARK),
@@ -3269,5 +3296,38 @@ private fun AccentChannelSlider(label: String, value: Float, onChange: (Float) -
             ),
             modifier = Modifier.weight(1f),
         )
+    }
+}
+
+/** #theme: the theme-PRESET picker — a pill showing the current (derived) preset, opening a menu of the
+ *  selectable presets. Picking one writes accent + chart world + backdrop + card opacity at once; the
+ *  granular controls below stay available and flip this back to Custom when tweaked. */
+@Composable
+private fun ThemePresetDropdown(current: ThemePreset, onSelect: (ThemePreset) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(999.dp))
+                .clickable { expanded = true }
+                .background(Palette.surfaceInset)
+                .padding(horizontal = 14.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(current.label, style = NoopType.subhead, color = Palette.textPrimary)
+            Icon(Icons.Filled.ArrowDropDown, contentDescription = null, tint = Palette.textSecondary)
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            ThemePreset.selectable.forEach { p ->
+                DropdownMenuItem(
+                    text = { Text(p.label, color = Palette.textPrimary) },
+                    onClick = {
+                        expanded = false
+                        onSelect(p)
+                    },
+                )
+            }
+        }
     }
 }

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1917,4 +1917,5 @@
     <string name="l10n_settings_screen_ecg_gate_turn_on">Sperre einschalten (\'1\' schreiben)</string>
     <string name="l10n_settings_screen_ecg_gate_turn_off">Sperre ausschalten (\'0\' schreiben)</string>
     <string name="l10n_settings_screen_accent">Akzent</string>
+    <string name="l10n_settings_screen_preset">Vorlage</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1902,4 +1902,5 @@
     <string name="l10n_settings_screen_ecg_gate_turn_on">Activar bloqueo (escribir \'1\')</string>
     <string name="l10n_settings_screen_ecg_gate_turn_off">Desactivar bloqueo (escribir \'0\')</string>
     <string name="l10n_settings_screen_accent">Acento</string>
+    <string name="l10n_settings_screen_preset">Preajuste</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1902,4 +1902,5 @@
     <string name="l10n_settings_screen_ecg_gate_turn_on">Activer le verrou (écrire « 1 »)</string>
     <string name="l10n_settings_screen_ecg_gate_turn_off">Désactiver le verrou (écrire « 0 »)</string>
     <string name="l10n_settings_screen_accent">Accent</string>
+    <string name="l10n_settings_screen_preset">Préréglage</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1896,4 +1896,5 @@
     <string name="l10n_settings_screen_ecg_gate_turn_on">Ativar bloqueio (escrever \'1\')</string>
     <string name="l10n_settings_screen_ecg_gate_turn_off">Desativar bloqueio (escrever \'0\')</string>
     <string name="l10n_settings_screen_accent">Destaque</string>
+    <string name="l10n_settings_screen_preset">Predefinição</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1830,4 +1830,5 @@
     <string name="l10n_settings_screen_ecg_gate_turn_on">打开开关（写入 \'1\'）</string>
     <string name="l10n_settings_screen_ecg_gate_turn_off">关闭开关（写入 \'0\'）</string>
     <string name="l10n_settings_screen_accent">强调色</string>
+    <string name="l10n_settings_screen_preset">预设</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1928,4 +1928,5 @@
     <string name="l10n_settings_screen_ecg_gate_turn_on">Turn gate on (write \'1\')</string>
     <string name="l10n_settings_screen_ecg_gate_turn_off">Turn gate off (write \'0\')</string>
     <string name="l10n_settings_screen_accent">Accent</string>
+    <string name="l10n_settings_screen_preset">Preset</string>
 </resources>


### PR DESCRIPTION
Adds a **Theme** preset picker at the top of Settings → Appearance — a one-tap way to set a coordinated look, layered on top of the granular controls (which stay available).

## Presets
| Theme | Accent | Chart world | Backdrop | Cards |
|---|---|---|---|---|
| **Mint** (default) | Mint | Titanium | On | Solid |
| **Ocean** | WHOOP Blue | Titanium | On | Solid |
| **Classic** | WHOOP Blue | Classic | On | Solid |
| **Midnight** | Mint | Titanium | Off | Solid |
| **Frosted** | Mint | Titanium | On | ~85% |

## Design
- **Pure orchestration** — a preset just writes four prefs that already exist (accent colour, chart colour world, day-cycle backdrop, card opacity). No new rendering.
- **Derived, not stored** — the picker shows which preset the live combination matches via `ThemePreset.matching(...)`, or **Custom** the moment any granular control is tweaked. Presets are starting points, never a lock.
- **Theme mode (System/Light/Dark) stays independent** — a preset never forces a scheme.
- Twin `ThemePreset` enums (StrandDesign / PaletteTokens) with `matching()` + `selectable`; iOS menu `Picker`, Android `DropdownMenu`.

## Validation
- Android `compileFullDebugKotlin` clean; i18n audit clean.
- iOS via **app-build** (running).

Builds on #1171 (the accent setting this coordinates).