### PR TITLE
analytics: primary-session mean resting-HR definition, pure + unwired (#1169)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/PrimarySessionRestingHR.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/PrimarySessionRestingHR.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// #1169: an alternative headline resting-HR definition — the arithmetic MEAN of valid HR samples in the
+/// LONGEST (primary) sleep session, rather than the lowest-per-session floor `AnalyticsEngine` ships today.
+///
+/// ## Why (issue #1169, artemc)
+/// The shipped daily RHR is `restingHRDaily = matched…restingHR.min()` (`AnalyticsEngine`) — a nightly HR
+/// FLOOR, and the `.min()` lets a short low-HR nap replace the main overnight session. A clean-room,
+/// single-participant 5-night experiment (official WHOOP RHR + a Polar H10 ECG mean as independent
+/// references, a pre-declared dev/holdout split, no fitted offset) found the primary-session sample mean
+/// tracked both references far better: rounded MAE vs the official target 6.0→2.0 (dev) / 7.5→0.8 (holdout).
+///
+/// ## Deliberately PURE and UNWIRED
+/// This computes the metric and is unit-tested, but **nothing consumes it yet**. The shipped headline AND the
+/// recovery / strain / workout-detection / energy inputs all read `restingHRDaily` (the floor) in
+/// `AnalyticsEngine`, so switching them is a re-baselining of core scores — which the issue itself says needs
+/// a larger multi-participant, pre-declared holdout first. That is out of scope here; this lands the
+/// transparent, testable definition so that validation and any later wiring have something concrete to use.
+///
+/// ## Definition (documented per the issue)
+/// - **Primary session**: the LONGEST session by duration; ties resolve to the FIRST (stable). A shorter nap
+///   never replaces the main night — this is the half the shipped `.min()` gets wrong.
+/// - **Valid sample**: bpm within `validBpm` (default 30…220, matching `AnalyticsEngine`'s worn-HR range).
+///   Anything outside the range — or a missing sample (simply absent from the array) — is excluded.
+/// - **Mean**: the arithmetic SAMPLE mean (unweighted). The experiment validated the sample mean; a
+///   time-weighted variant behaves differently under irregular cadence and must be evaluated separately.
+/// - **Coverage**: returns `nil` unless the primary session has at least `minValidSamples` valid samples.
+/// - The result is an APPROXIMATION, not a clinically validated measurement.
+///
+/// Twin of Kotlin `PrimarySessionRestingHR`. Keep byte-identical.
+public enum PrimarySessionRestingHR {
+
+    /// One sleep session for a wake day: its duration and its raw (possibly-invalid) HR samples in bpm.
+    /// Wake-day assignment and session building stay in the caller (`AnalyticsEngine`); this type is the
+    /// minimal input the pure metric needs, so it is testable with no engine, DB, or clock.
+    public struct Session: Sendable, Equatable {
+        public let durationSec: Double
+        public let bpm: [Int]
+        public init(durationSec: Double, bpm: [Int]) {
+            self.durationSec = durationSec
+            self.bpm = bpm
+        }
+    }
+
+    /// The worn-HR range `AnalyticsEngine` uses when deciding a sample is real; reused so validity is one rule.
+    public static let defaultValidBpm: ClosedRange<Int> = 30...220
+    /// Provisional minimum valid-sample coverage before a value is returned. A sample count is cadence-blind;
+    /// the exact rule is a tuning parameter for the multi-participant validation the issue calls for.
+    public static let defaultMinValidSamples = 30
+
+    /// Mean valid HR of the LONGEST session, or `nil` when no session clears `minValidSamples` valid samples.
+    public static func meanHR(sessions: [Session],
+                              validBpm: ClosedRange<Int> = defaultValidBpm,
+                              minValidSamples: Int = defaultMinValidSamples) -> Double? {
+        // Primary = longest by duration. `max(by:)` keeps the FIRST of equal-duration sessions (only a
+        // strictly-longer one replaces it); Kotlin `maxByOrNull` resolves ties the same way, so parity holds.
+        guard let primary = sessions.max(by: { $0.durationSec < $1.durationSec }) else { return nil }
+        let valid = primary.bpm.filter { validBpm.contains($0) }
+        guard valid.count >= minValidSamples else { return nil }
+        return Double(valid.reduce(0, +)) / Double(valid.count)
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/PrimarySessionRestingHRTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/PrimarySessionRestingHRTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// #1169 — the primary-session mean resting-HR definition. The oracle for the Android
+/// `PrimarySessionRestingHRTest`; keep the two in lockstep (same fixtures, same numbers).
+final class PrimarySessionRestingHRTests: XCTestCase {
+    private typealias P = PrimarySessionRestingHR
+    private typealias S = PrimarySessionRestingHR.Session
+
+    /// A shorter, lower-HR nap must NOT replace the longer main night — the half the shipped `.min()`
+    /// across sessions gets wrong. Longest session wins, order-independent.
+    func testNapDoesNotReplaceTheLongerMainNight() {
+        let mainNight = S(durationSec: 8 * 3600, bpm: Array(repeating: 64, count: 480))  // 8h @ 64
+        let nap = S(durationSec: 40 * 60, bpm: Array(repeating: 50, count: 40))           // 40m @ 50 (lower)
+        XCTAssertEqual(P.meanHR(sessions: [nap, mainNight]), 64.0)
+        XCTAssertEqual(P.meanHR(sessions: [mainNight, nap]), 64.0)
+    }
+
+    /// The SAMPLE mean is unweighted, so irregular cadence weights by COUNT, not wall-time. Asserted
+    /// explicitly so a future time-weighted variant is a deliberate, visible change (issue's caveat).
+    func testSampleMeanIsUnweightedByCadence() {
+        let bpm = Array(repeating: 60, count: 90) + Array(repeating: 40, count: 10)
+        // (90*60 + 10*40) / 100 = 58.0
+        XCTAssertEqual(P.meanHR(sessions: [S(durationSec: 8 * 3600, bpm: bpm)]), 58.0)
+    }
+
+    /// Spikes, dropouts and 0s outside 30…220 are excluded; the mean is over the valid samples only.
+    func testInvalidSamplesAreExcluded() {
+        let bpm = Array(repeating: 60, count: 40) + [0, 300, -5, 250]
+        XCTAssertEqual(P.meanHR(sessions: [S(durationSec: 8 * 3600, bpm: bpm)]), 60.0)
+    }
+
+    /// Below the coverage floor → nil rather than a noisy value; an all-invalid session is nil too.
+    func testInsufficientCoverageReturnsNil() {
+        XCTAssertNil(P.meanHR(sessions: [S(durationSec: 3600, bpm: Array(repeating: 60, count: 5))]))
+        XCTAssertNil(P.meanHR(sessions: [S(durationSec: 3600, bpm: Array(repeating: 0, count: 100))]))
+    }
+
+    /// A constant-HR session returns exactly that value.
+    func testConstantHRExact() {
+        XCTAssertEqual(P.meanHR(sessions: [S(durationSec: 3600, bpm: Array(repeating: 58, count: 100))]), 58.0)
+    }
+
+    /// No sessions → nil.
+    func testNoSessionsReturnsNil() {
+        XCTAssertNil(P.meanHR(sessions: []))
+    }
+
+    /// Equal-duration sessions resolve to the FIRST (the documented tie rule). Locked so the selection
+    /// can't silently diverge from the Kotlin twin under a tie — the two stdlibs must agree here.
+    func testEqualDurationTieSelectsFirst() {
+        let a = S(durationSec: 6 * 3600, bpm: Array(repeating: 60, count: 100))
+        let b = S(durationSec: 6 * 3600, bpm: Array(repeating: 50, count: 100))
+        XCTAssertEqual(P.meanHR(sessions: [a, b]), 60.0)  // first (a) wins the tie
+        XCTAssertEqual(P.meanHR(sessions: [b, a]), 50.0)  // order flips → first (b) wins
+    }
+
+    /// The coverage threshold is a parameter, so the validation phase can tune it.
+    func testCoverageThresholdIsParameterised() {
+        let bpm = Array(repeating: 62, count: 12)
+        XCTAssertNil(P.meanHR(sessions: [S(durationSec: 3600, bpm: bpm)], minValidSamples: 20))
+        XCTAssertEqual(P.meanHR(sessions: [S(durationSec: 3600, bpm: bpm)], minValidSamples: 10), 62.0)
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/PrimarySessionRestingHR.kt
+++ b/android/app/src/main/java/com/noop/analytics/PrimarySessionRestingHR.kt
@@ -1,0 +1,57 @@
+package com.noop.analytics
+
+/**
+ * #1169: an alternative headline resting-HR definition — the arithmetic MEAN of valid HR samples in the
+ * LONGEST (primary) sleep session, rather than the lowest-per-session floor `AnalyticsEngine` ships today.
+ *
+ * ## Why (issue #1169, artemc)
+ * The shipped daily RHR is `restingHRDaily = matched…restingHR.min()` — a nightly HR FLOOR, and the `.min()`
+ * lets a short low-HR nap replace the main overnight session. A clean-room, single-participant 5-night
+ * experiment (official WHOOP RHR + a Polar H10 ECG mean as independent references, a pre-declared dev/holdout
+ * split, no fitted offset) found the primary-session sample mean tracked both far better: rounded MAE vs the
+ * official target 6.0->2.0 (dev) / 7.5->0.8 (holdout).
+ *
+ * ## Deliberately PURE and UNWIRED
+ * This computes the metric and is unit-tested, but nothing consumes it yet. The shipped headline AND the
+ * recovery / strain / workout-detection / energy inputs all read the floor `restingHRDaily`, so switching
+ * them is a re-baselining of core scores that the issue itself says needs a larger multi-participant,
+ * pre-declared holdout first. Out of scope here; this lands the transparent, testable definition.
+ *
+ * ## Definition
+ * - **Primary session**: the LONGEST by duration; ties resolve to the FIRST. A nap never replaces the night.
+ * - **Valid sample**: bpm within [validBpm] (default 30..220, matching AnalyticsEngine's worn-HR range).
+ *   Out-of-range or missing samples are excluded.
+ * - **Mean**: arithmetic SAMPLE mean (unweighted). A time-weighted variant behaves differently under
+ *   irregular cadence and must be evaluated separately.
+ * - **Coverage**: returns null unless the primary session has at least [minValidSamples] valid samples.
+ * - An APPROXIMATION, not a clinically validated measurement.
+ *
+ * Twin of macOS `PrimarySessionRestingHR`. Keep byte-identical.
+ */
+object PrimarySessionRestingHR {
+
+    /** One sleep session for a wake day: its duration and raw (possibly-invalid) HR samples in bpm. Wake-day
+     *  assignment and session building stay in the caller; this is the minimal input the pure metric needs. */
+    data class Session(val durationSec: Double, val bpm: List<Int>)
+
+    /** The worn-HR range AnalyticsEngine uses when deciding a sample is real; reused so validity is one rule. */
+    val DEFAULT_VALID_BPM = 30..220
+
+    /** Provisional minimum valid-sample coverage before a value is returned. A sample count is cadence-blind;
+     *  the exact rule is a tuning parameter for the multi-participant validation the issue calls for. */
+    const val DEFAULT_MIN_VALID_SAMPLES = 30
+
+    /** Mean valid HR of the LONGEST session, or null when no session clears [minValidSamples] valid samples. */
+    fun meanHR(
+        sessions: List<Session>,
+        validBpm: IntRange = DEFAULT_VALID_BPM,
+        minValidSamples: Int = DEFAULT_MIN_VALID_SAMPLES,
+    ): Double? {
+        // Primary = longest by duration. `maxByOrNull` keeps the FIRST of equal-duration sessions (only a
+        // strictly-longer one replaces it); Swift `max(by:)` resolves ties the same way, so parity holds.
+        val primary = sessions.maxByOrNull { it.durationSec } ?: return null
+        val valid = primary.bpm.filter { it in validBpm }
+        if (valid.size < minValidSamples) return null
+        return valid.sum().toDouble() / valid.size
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/PrimarySessionRestingHRTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/PrimarySessionRestingHRTest.kt
@@ -1,0 +1,66 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #1169 — the primary-session mean resting-HR definition. The Android twin of the macOS
+ * `PrimarySessionRestingHRTests`; same fixtures, same numbers (cross-platform parity).
+ */
+class PrimarySessionRestingHRTest {
+    private fun s(durationSec: Double, bpm: List<Int>) = PrimarySessionRestingHR.Session(durationSec, bpm)
+
+    /** A shorter, lower-HR nap must NOT replace the longer main night (the half the shipped `.min()` gets
+     *  wrong). Longest session wins, order-independent. */
+    @Test fun napDoesNotReplaceTheLongerMainNight() {
+        val mainNight = s(8 * 3600.0, List(480) { 64 })
+        val nap = s(40 * 60.0, List(40) { 50 })
+        assertEquals(64.0, PrimarySessionRestingHR.meanHR(listOf(nap, mainNight))!!, 1e-9)
+        assertEquals(64.0, PrimarySessionRestingHR.meanHR(listOf(mainNight, nap))!!, 1e-9)
+    }
+
+    /** The SAMPLE mean is unweighted, so irregular cadence weights by COUNT, not wall-time. */
+    @Test fun sampleMeanIsUnweightedByCadence() {
+        val bpm = List(90) { 60 } + List(10) { 40 }
+        assertEquals(58.0, PrimarySessionRestingHR.meanHR(listOf(s(8 * 3600.0, bpm)))!!, 1e-9)
+    }
+
+    /** Spikes, dropouts and 0s outside 30..220 are excluded; the mean is over the valid samples only. */
+    @Test fun invalidSamplesAreExcluded() {
+        val bpm = List(40) { 60 } + listOf(0, 300, -5, 250)
+        assertEquals(60.0, PrimarySessionRestingHR.meanHR(listOf(s(8 * 3600.0, bpm)))!!, 1e-9)
+    }
+
+    /** Below the coverage floor -> null rather than a noisy value; an all-invalid session is null too. */
+    @Test fun insufficientCoverageReturnsNull() {
+        assertNull(PrimarySessionRestingHR.meanHR(listOf(s(3600.0, List(5) { 60 }))))
+        assertNull(PrimarySessionRestingHR.meanHR(listOf(s(3600.0, List(100) { 0 }))))
+    }
+
+    /** A constant-HR session returns exactly that value. */
+    @Test fun constantHRExact() {
+        assertEquals(58.0, PrimarySessionRestingHR.meanHR(listOf(s(3600.0, List(100) { 58 })))!!, 1e-9)
+    }
+
+    /** No sessions -> null. */
+    @Test fun noSessionsReturnsNull() {
+        assertNull(PrimarySessionRestingHR.meanHR(emptyList()))
+    }
+
+    /** Equal-duration sessions resolve to the FIRST (the documented tie rule). Locked so the selection
+     *  can't silently diverge from the macOS twin under a tie — the two stdlibs must agree here. */
+    @Test fun equalDurationTieSelectsFirst() {
+        val a = s(6 * 3600.0, List(100) { 60 })
+        val b = s(6 * 3600.0, List(100) { 50 })
+        assertEquals(60.0, PrimarySessionRestingHR.meanHR(listOf(a, b))!!, 1e-9)
+        assertEquals(50.0, PrimarySessionRestingHR.meanHR(listOf(b, a))!!, 1e-9)
+    }
+
+    /** The coverage threshold is a parameter, so the validation phase can tune it. */
+    @Test fun coverageThresholdIsParameterised() {
+        val bpm = List(12) { 62 }
+        assertNull(PrimarySessionRestingHR.meanHR(listOf(s(3600.0, bpm)), minValidSamples = 20))
+        assertEquals(62.0, PrimarySessionRestingHR.meanHR(listOf(s(3600.0, bpm)), minValidSamples = 10)!!, 1e-9)
+    }
+}


### PR DESCRIPTION
Implements the metric proposed in **#1169** (@artemc) — the arithmetic **mean HR of the primary (longest) sleep session** — as a pure, tested, cross-platform building block. **Deliberately minimal: it wires nothing.**

## Why unwired
The shipped daily RHR is a nightly HR **floor** — `restingHRDaily = matched…restingHR.min()` in `AnalyticsEngine` — which a low-HR nap can replace. The issue's clean-room 5-night experiment (official WHOOP RHR + Polar H10 ECG mean references, pre-declared dev/holdout, no fitted offset) shows the primary-session sample mean tracks both far better (MAE vs the official target **6.0→2.0** dev / **7.5→0.8** holdout).

But that one `restingHRDaily` value **also feeds recovery, strain, workout-detection, and energy** — so switching them is a re-baselining of core scores that would silently change everyone's recovery/strain. The issue itself says that needs a **larger multi-participant, pre-declared holdout first**. So this PR lands only the transparent, testable definition; **the shipped headline and every score are unchanged.** Wiring (display, then — much later, evidence-gated — scoring) is a follow-up.

## What it does
A pure `PrimarySessionRestingHR.meanHR(sessions:)` (Swift `StrandAnalytics` + Kotlin `com.noop.analytics`, byte-identical):
- **Primary session = the longest by duration** (ties → first) — a nap never replaces the main night (the half the shipped `.min()` gets wrong).
- **Valid sample = 30…220 bpm** (reusing `AnalyticsEngine`'s worn-HR range); out-of-range/missing excluded.
- **Arithmetic sample mean** (unweighted — the experiment validated the sample mean; a time-weighted variant is a separate future evaluation, and the tests make the weighting explicit).
- **Coverage-gated** (`nil` below a provisional min-valid-samples floor).
- Documented in-file as an **approximation**, and that wake-day assignment/session-building stay in the existing caller.

## Tests
7 deterministic cases per platform, **same fixtures + numbers** (the parity check): nap-not-replace, unweighted-cadence, invalid-excluded, coverage floor, constant-HR exact, empty, parameterised threshold. Swift runs in `swift-packages` CI; the Kotlin twin mirrors it (run via `testFullDebugUnitTest`).

Closes nothing — #1169 stays open for the wiring/validation phase. Credit: @artemc.