### PR TITLE
fix(ble): correct a WHOOP 5.0 mislabelled 4.0 from the strap's DIS attestation

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -3892,6 +3892,22 @@ public final class BLEManager: NSObject, ObservableObject {
         // Publish it so an MG-only capability can gate on attested hardware. Still diagnostic for every
         // existing consumer — nothing about framing or decode reads this.
         state.whoop5Variant = variant.label
+        reconcileModelFromAttestation(variant)
+    }
+
+    /// The strap's own DIS attestation is ground truth (a WHOOP 4.0 never attests a 5AM/5AG serial). When
+    /// it positively identifies a 5-generation strap but the active registry row still resolves to WHOOP
+    /// 4.0 — a wrong Add-Device pick, or a legacy "4.0" row — correct the model so the Devices display and
+    /// the `forRegistryModel`-driven skin-temp raw→°C scale (#938) stop treating a 5.0 as a 4.0. Extends the
+    /// #716 stamp (which only fixed the "WHOOP" placeholder). ONE-DIRECTIONAL: attestation can only upgrade
+    /// 4.0→5.0, never the reverse, and once corrected the guard below no longer matches, so it self-limits.
+    private func reconcileModelFromAttestation(_ variant: Whoop5Variant) {
+        guard variant != .unknown, let rs = registryStore,
+              let active = try? rs.all().first(where: { $0.status == .active }),
+              DeviceFamily.forRegistryDevice(model: active.model, brand: active.brand) == .whoop4
+        else { return }
+        try? rs.setModel(active.id, model: "WHOOP 5.0 / MG")
+        log("Corrected device model \"\(active.model ?? "nil")\" → \"WHOOP 5.0 / MG\" from DIS attestation (variant=\(variant.label))")
     }
 
     private func requestNotify(_ c: CBCharacteristic, on p: CBPeripheral, reason: String) {

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3844,6 +3844,25 @@ class WhoopBleClient(
         _whoop5Variant.value = variant   // #520/#891: publish so MG-only UI can gate on it
         val prefix = disSerial?.trim()?.uppercase()?.take(3) ?: "?"
         log("DIS: serialPrefix=$prefix hwRev=${disHwRev ?: "?"} -> variant=${variant.label}")
+        reconcileModelFromAttestation(variant)
+    }
+
+    /** The strap's own DIS attestation is ground truth (a WHOOP 4.0 never attests a 5AM/5AG serial). When
+     *  it positively identifies a 5-generation strap but the active registry row still resolves to WHOOP
+     *  4.0 — a wrong Add-Device pick, or a legacy "4.0" row — correct the model so the Devices display and
+     *  the forRegistryModel-driven skin-temp raw->°C scale (#938) stop treating a 5.0 as a 4.0. Extends the
+     *  #716 stamp (which only fixed the "WHOOP" placeholder). ONE-DIRECTIONAL: attestation can only upgrade
+     *  4.0->5.0, never the reverse, and once corrected the guard no longer matches, so it self-limits.
+     *  Twin of Swift `reconcileModelFromAttestation`. */
+    private fun reconcileModelFromAttestation(variant: Whoop5Variant) {
+        if (variant == Whoop5Variant.UNKNOWN) return
+        ioScope.launch {
+            val active = repository.pairedDevices().firstOrNull { it.status == "active" } ?: return@launch
+            if (DeviceFamily.forRegistryDevice(active.model, active.brand) == DeviceFamily.WHOOP4) {
+                repository.setDeviceModel(active.id, "WHOOP 5.0 / MG")
+                log("Corrected device model \"${active.model}\" -> \"WHOOP 5.0 / MG\" from DIS attestation (variant=${variant.label})")
+            }
+        }
     }
 
     fun refreshBattery() {


### PR DESCRIPTION
A user reported NOOP showing **"4.0" for a WHOOP 5.0**. Minimal, root-cause fix.

## Why it happened
The displayed generation is the registry `model` label via `DeviceFamily.forRegistryModel` (`"4.0"`/`"WHOOP 4.0"` → 4.0, else 5.0). That label is set **once** — from the Add-Device pick (which **defaults to `.whoop4`** when the type is ambiguous, `AddDeviceWizard:1057/1255`) or a legacy row — and **nothing reconciled it against the ground-truth signals NOOP already has**. The existing #716 stamp only corrected the `"WHOOP"` placeholder, not a wrong `"4.0"`.

## The fix
The strap's own **DIS serial / hardware-rev is authoritative** — a WHOOP 4.0 never attests a `5AM`/`5AG` (MG/5.0) serial. So in `noteWhoop5VariantFromDIS`, when the attestation positively identifies a 5-generation strap **but** the active registry row still resolves to `.whoop4`, stamp `"WHOOP 5.0 / MG"`.

- Fixes the **Devices display** *and* the `forRegistryModel`-driven **skin-temp raw→°C scale** (#938), which was scaling a 5.0 as a 4.0 (so it's not just cosmetic).
- **One-directional & self-limiting:** attestation can only upgrade 4.0→5.0 (there's no false-4.0 attestation), and once corrected the guard no longer matches.
- **Swift + Kotlin twins**, symmetric logic; reuses the already-tested `forRegistryDevice` resolver (RegistryModelFamilyTests) + the existing `setModel` path — so no new pure logic to test, just glue in the BLE layer.

## Scope
Minimal and in the right place. It does **not** touch the wizard default or the scan-service selection — those are separate (and a mis-selected 4.0 that blocks a 5.0 from connecting is a different, larger fix). This targets the reported case: a connected 5.0 whose stored label reads 4.0, self-healing on the next DIS read.

Validation: `compileFullDebugKotlin` clean; Swift via **app-build** (running). Behavioural confirmation ideally on a real 5.0 that currently shows 4.0.