### PR TITLE
fix(android): close the Appearance gap above the Sleep-chart control (#1129)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1149,7 +1149,15 @@ fun SettingsScreen(
             // timeline; "Filled" swaps the Sleep tab's stage chart for a single stepped hypnogram with the
             // stages stacked by depth and each column filled to the baseline. Same data either way; this only
             // changes the drawing, and it falls back to Classic on a night with no timestamped segments.
-            SettingsFormRow(label = "Sleep chart") {
+            // A full-width (adaptsToAvailableWidth) control can't share a SettingsFormRow's single line with
+            // a beside-label: it fills the width and starves the weighted label to a tall wrapped sliver,
+            // ballooning the row (the #1129 gap). Stack it — label on its own line, equal-width segments
+            // below — which is how a full-width segmented control is meant to be laid out.
+            Column(
+                modifier = Modifier.fillMaxWidth().heightIn(min = 44.dp).padding(vertical = 4.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Text("Sleep chart", style = NoopType.body, color = Palette.textPrimary)
                 SegmentedPillControl(
                     items = listOf(SleepChartStyle.CLASSIC, SleepChartStyle.FILLED, SleepChartStyle.RIBBON),
                     selection = sleepChartStyle,
@@ -1164,7 +1172,7 @@ fun SettingsScreen(
                         sleepChartStyle = style
                         UnitPrefs.setSleepChartStyle(context, style)
                     },
-                    // Three segments — share the row width equally so the labels can't widen the card past
+                    // Three segments share the row width equally so the labels can't widen the card past
                     // the screen (the component's own guidance for longer option sets).
                     adaptsToAvailableWidth = true,
                 )


### PR DESCRIPTION
A user reported a **large empty gap** in Settings → Appearance (screenshot: the space between *Trend charts* and the label-less *Classic / Filled / Ribbon* control).

## Cause (pre-existing, #1129)
The Sleep-chart row puts a **full-width** `SegmentedPillControl` (`adaptsToAvailableWidth = true` → `.fillMaxWidth()`, `Components.kt:616`) inside `SettingsFormRow`'s single-line **label + control** Row. In a Compose Row, the `fillMaxWidth()` control takes the whole width, starving the `weight(1f)` label to ~0 — so "Sleep chart" wraps one character per line into a tall sliver and balloons the row height, leaving the segments floating in the middle with the label invisible. It's been there since #1129 (the RIBBON style added `adaptsToAvailableWidth`).

## Fix
Stack a full-width control's **label above it** (a `Column`) instead of beside it — exactly how `HealthScreen` already lays out its `adaptsToAvailableWidth` control. Keeps the equal-width segments and the large-text horizontal-scroll behaviour.

## Scope
- **Android-only** — iOS's Appearance rows are compact `.menu` Pickers, so there's no weight-starvation there.
- `compileFullDebugKotlin` clean; i18n unchanged ("Sleep chart" was already a baseline literal).
- **On-device glance worth doing** to confirm the spacing reads right (no CI can verify layout).

Surfaced while reviewing the theming screen; not caused by the recent accent/theme-preset work.