### PR TITLE
i18n: extract 3 StrandDesign a11y labels via existing translations (#920)

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/DayNavBar.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/DayNavBar.swift
@@ -55,7 +55,7 @@ public struct DayNavBar: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Previous day")
+            .accessibilityLabel(Text("Previous day", bundle: .module))
 
             // Centre accent block — the selected day's label + full date, tappable to jump.
             Button { showingPicker = true } label: {
@@ -97,7 +97,7 @@ public struct DayNavBar: View {
             }
             .buttonStyle(.plain)
             .disabled(!canGoNewer)
-            .accessibilityLabel("Next day")
+            .accessibilityLabel(Text("Next day", bundle: .module))
             Spacer(minLength: 0)
         }
     }

--- a/Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings
+++ b/Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings
@@ -3498,6 +3498,168 @@
           }
         }
       }
+    },
+    "Next day": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nächster Tag"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Día siguiente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jour suivant"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giorno successivo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dia seguinte"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Следующий день"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次日"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次日"
+          }
+        }
+      }
+    },
+    "Previous day": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorheriger Tag"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Día anterior"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jour précédent"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giorno precedente"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dia anterior"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Предыдущий день"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前一天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前一天"
+          }
+        }
+      }
+    },
+    "Trend": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trend"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trend"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tendencia"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tendance"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Andamento"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tendência"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тренд"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "趋势"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "趨勢"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Packages/StrandDesign/Sources/StrandDesign/TrendChart.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/TrendChart.swift
@@ -338,7 +338,7 @@ public struct TrendChart: View {
         // stacked under-glow copy (showsHover:false, no label) is hidden so the same series isn't
         // double-announced; the crisp interactive copy passes showsHover:true (default) and speaks.
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(Text(accessibilityLabel ?? "Trend"))
+        .accessibilityLabel(accessibilityLabel.map(Text.init) ?? Text("Trend", bundle: .module))
         .accessibilityValue(Text(a11ySummary))
         .accessibilityHidden(!showsHover && accessibilityLabel == nil)
     }

--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -852,19 +852,7 @@
     ],
     [
       "Packages/StrandDesign/Sources/StrandDesign/DayNavBar.swift",
-      "Next day"
-    ],
-    [
-      "Packages/StrandDesign/Sources/StrandDesign/DayNavBar.swift",
       "Pick a date"
-    ],
-    [
-      "Packages/StrandDesign/Sources/StrandDesign/DayNavBar.swift",
-      "Previous day"
-    ],
-    [
-      "Packages/StrandDesign/Sources/StrandDesign/TrendChart.swift",
-      "Trend"
     ],
     [
       "Packages/StrandDesign/Sources/StrandDesign/YearHeatStrip.swift",


### PR DESCRIPTION
Rebase of #1038 by @digitalerdude onto current `main` — the original conflicted on the StrandDesign `Localizable.xcstrings` + `i18n_audit_baseline.json` after the intervening theming/accent merges. Content is unchanged; I reconstructed the two JSON edits programmatically to guarantee a minimal, valid diff (162/0 on the catalog, 0/12 on the baseline — identical to the original).

## What
Extracts 3 accessibility-label literals in StrandDesign whose exact English key already has full, reviewed translations elsewhere in the repo — **zero new translation work**:
- `Next day` / `Previous day` (`DayNavBar`) and `Trend` (`TrendChart`) become `Text(…, bundle: .module)` so they resolve from StrandDesign's own catalog.
- Their `localizations` blocks are copied **1:1** from `Strand/Resources/Localizable.xcstrings` (de/es/fr/pt-PT + it/ru/zh-Hans/zh-Hant) — verified byte-identical to the macOS catalog, no invented/machine values.
- Drops the 3 now-extracted entries from `Tools/i18n_audit_baseline.json`.

## Verification
- `python3 Tools/i18n_audit.py --ci HEAD` → exit 0, all focus locales OK
- `python3 Tools/test_i18n_audit.py` → 36 tests OK
- Both JSON files valid; catalog diff is a pure 3-key append (no reorder churn)
- `swift-packages.yml` compiles StrandDesign — the real gate for this change

StrandDesign-only accessibility catalog change — no analytics/schema/stored value, so the byte-parity contract doesn't apply. Credit to @digitalerdude (#1038, #920).

Closes #1038.