### PR TITLE
fix(android): center + shrink the Rest ring's calibrating subtext (#1168)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -2788,13 +2788,19 @@ private fun RingEmptyOverlay(
     diameter: Dp,
 ) {
     if (calibratingNights != null) {
+        // AutoSizeValue shrink-to-fit + the centring Column, same as RingNeedsTrackedNight (#1168): a longer
+        // localized "N of M nights" would otherwise fill the narrow ring and left-align/clip like the Rest tile.
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(uiString(R.string.l10n_today_screen_calibrating_37c2c9bd), style = NoopType.headline, color = Palette.textTertiary, maxLines = 1)
-            Text(
+            AutoSizeValue(
+                uiString(R.string.l10n_today_screen_calibrating_37c2c9bd),
+                style = NoopType.headline,
+                color = Palette.textTertiary,
+                minScale = 0.7f,
+            )
+            AutoSizeValue(
                 uiString(R.string.l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c, calibratingNights, Baselines.minNightsSeed),
                 style = NoopType.footnote,
                 color = Palette.textSecondary,
-                maxLines = 1,
             )
         }
     } else {
@@ -2812,13 +2818,21 @@ private fun RingNoData() {
  *  instead of a bare "No Data", without fabricating a number. Mirrors iOS restRing's needs-a-night branch. */
 @Composable
 private fun RingNeedsTrackedNight() {
+    // AutoSizeValue (not plain Text): the subtext "needs a tracked night" is wider than the narrow ring,
+    // so a maxLines=1 Text filled the width and left-aligned + clipped the tail (#1168). Shrink-to-fit and
+    // let the centering Column place the content-sized line — the Android mirror of iOS ringNeedsTrackedNight's
+    // .minimumScaleFactor + centred VStack.
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(uiString(R.string.l10n_today_screen_calibrating_37c2c9bd), style = NoopType.headline, color = Palette.textTertiary, maxLines = 1)
-        Text(
+        AutoSizeValue(
+            uiString(R.string.l10n_today_screen_calibrating_37c2c9bd),
+            style = NoopType.headline,
+            color = Palette.textTertiary,
+            minScale = 0.7f,
+        )
+        AutoSizeValue(
             uiString(R.string.l10n_today_screen_needs_a_tracked_night_ccfd532a),
             style = NoopType.footnote,
             color = Palette.textSecondary,
-            maxLines = 1,
         )
     }
 }


### PR DESCRIPTION
Reported by @bartmuskala (#1168): on Android, the Today hero's **Rest** vessel showed its "needs a tracked night" subtext **left-aligned and clipped** ("night" cut off), where it should be centered under "Calibrating".

## Cause
`RingNeedsTrackedNight` rendered the subtext as a plain `Text(maxLines = 1)` with **no `textAlign`**. The string is wider than the narrow ring, so Compose filled the width and fell back to `Start` alignment — left-aligned + clipped. The centering `Column` couldn't help because the text box was as wide as the ring.

## Fix
Both the Rest overlay and the sibling charge-ring calibrating overlay now use the existing **`AutoSizeValue`** (Components.kt) instead of a plain `Text`. It shrinks the line to fit (0.7× headline / 0.6× subtext floor), keeps one line, and being content-sized is centered by the `CenterHorizontally` Column.

## Parity
This is an **Android-only** gap: iOS's `ringNeedsTrackedNight` (TodayView.swift) already does the equivalent — `.lineLimit(1).minimumScaleFactor(0.6)` inside a centering `VStack`. `AutoSizeValue` is the codebase's Android mirror of `minimumScaleFactor` (already used on the ring for #332), so the two platforms now match. Also hardened the sibling "N of M nights" overlay against the same clip in longer locales (e.g. German).

## Verification
- `./gradlew compileFullDebugKotlin` ✅
- UI-only, Android-only — **no new strings** (reuses existing resources, so no i18n gate), no analytics/stored-data change, iOS untouched.

Fixes #1168.