### PR TITLE
fix(spo2): localize the Android @82 estimate captions + align wording (#103 follow-up)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -137,6 +137,9 @@ fun HealthScreen(
     // Mirrors the shipped Today liveSnap fix. Appearance-preserving.
     val live by vm.live.collectAsStateWithLifecycle()
     val bpm by vm.bpm.collectAsStateWithLifecycle()
+    // #103: collect reactively (not .value) so the Latest-readings card recomposes on its own when the
+    // SpO₂ candidate map updates, matching VitalSignsScreen — not only incidentally via `days`.
+    val spo2CandidateByDay by vm.spo2CandidateByDay.collectAsStateWithLifecycle()
     val hasLiveHr by remember { derivedStateOf { displayHr(bpm, live) != null } }
 
     // LIQUID SKY BACKDROP (the pilot pattern — LiquidScreenSky.kt): the time-of-day liquid sky settles into
@@ -179,7 +182,7 @@ fun HealthScreen(
                     vitals = latestVitals(
                         days,
                         UnitPrefs.temperature(LocalContext.current),
-                        vm.spo2CandidateByDay.value,
+                        spo2CandidateByDay,
                         NoopPrefs.spo2CandidateDisplay(LocalContext.current),
                     ),
                     onVitalClick = onVitalClick,

--- a/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
@@ -218,9 +218,9 @@ internal fun vitalsFor(
             // Android per selected day, Apple `logicalDay ?? most recent` — so the ROW is not the
             // parity contract here; the relationship between the two tiles is.
             missingCaption = if (d?.spo2Pct == null && d?.day?.let { spo2CandidateByDay[it] } != null)
-                "Estimate (unverified)"
+                uiString(R.string.spo2_strap_estimate_caption)
             else if (d?.spo2Pct == null && spo2ToggleOn && spo2CandidateByDay.isEmpty())
-                "toggle ON · no @82 data"
+                uiString(R.string.spo2_toggle_on_no_data)
             else uiString(spo2MissingCaptionRes(d?.let(spo2RawMean) != null)),
             value = d?.spo2Pct ?: d?.day?.let { spo2CandidateByDay[it] },
             format = { String.format("%.0f", it) },

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1928,4 +1928,6 @@
     <string name="settings_chart_classic">Klassisch</string>
     <string name="settings_trend_line">Linie</string>
     <string name="settings_trend_bars">Balken</string>
+    <string name="spo2_strap_estimate_caption">Armband-Schätzung (unbestätigt)</string>
+    <string name="spo2_toggle_on_no_data">Schalter EIN · keine @82-Daten</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1913,4 +1913,6 @@
     <string name="settings_chart_classic">Clásico</string>
     <string name="settings_trend_line">Línea</string>
     <string name="settings_trend_bars">Barras</string>
+    <string name="spo2_strap_estimate_caption">estimación de la correa (sin verificar)</string>
+    <string name="spo2_toggle_on_no_data">activado · sin datos de @82</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1913,4 +1913,6 @@
     <string name="settings_chart_classic">Classique</string>
     <string name="settings_trend_line">Courbe</string>
     <string name="settings_trend_bars">Barres</string>
+    <string name="spo2_strap_estimate_caption">estimation du bracelet (non vérifiée)</string>
+    <string name="spo2_toggle_on_no_data">activé · aucune donnée @82</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1907,4 +1907,6 @@
     <string name="settings_chart_classic">Clássico</string>
     <string name="settings_trend_line">Linha</string>
     <string name="settings_trend_bars">Barras</string>
+    <string name="spo2_strap_estimate_caption">estimativa da pulseira (não verificada)</string>
+    <string name="spo2_toggle_on_no_data">ativado · sem dados de @82</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1841,4 +1841,6 @@
     <string name="settings_chart_classic">经典</string>
     <string name="settings_trend_line">折线</string>
     <string name="settings_trend_bars">柱形</string>
+    <string name="spo2_strap_estimate_caption">腕带估算（未验证）</string>
+    <string name="spo2_toggle_on_no_data">已开启 · 无 @82 数据</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1939,4 +1939,7 @@
     <string name="settings_chart_classic">Classic</string>
     <string name="settings_trend_line">Line</string>
     <string name="settings_trend_bars">Bars</string>
+    <!-- #103: Blood Oxygen tile captions for the experimental WHOOP 5/MG @82 strap estimate. -->
+    <string name="spo2_strap_estimate_caption">strap estimate (unverified)</string>
+    <string name="spo2_toggle_on_no_data">toggle ON · no @82 data</string>
 </resources>


### PR DESCRIPTION
Follow-up to #1185 (WHOOP 5.0 @82 SpO₂ candidate). Re-review surfaced two Android nits; this cleans them up.

## Fixes
1. **Raw-literal captions bypassing i18n.** The Blood Oxygen tile's candidate captions in `HealthVitalsLogic.kt` were hardcoded English literals (`"Estimate (unverified)"`, `"toggle ON · no @82 data"`). The i18n audit **didn't catch them** — it flags `Text("…")`/Settings literals but misses strings *returned from logic-file functions*, so they'd have stayed English forever without tripping the gate. Extracted both to `strings.xml` via `uiString` and translated across the shipped locales (de/es/fr/pt-PT/zh), matching iOS which already used `String(localized:)`.
2. **Wording parity.** Android read `"Estimate (unverified)"`; iOS reads `"strap estimate (unverified)"`. Aligned Android to iOS so the tile caption is identical on both platforms.
3. **Reactive read (nit).** `HealthScreen` read `vm.spo2CandidateByDay.value` (non-reactive) while the detail screen uses `collectAsStateWithLifecycle`. Made it reactive for consistency — the Latest-readings card now recomposes on its own when the candidate map updates, not only incidentally via `days`.

## Notes
- **Android-only, display-only** — no behavior, scoring, or stored-data change.
- iOS captions already use `String(localized:)` with the matching wording (functional English fallback); a future xcstrings pass can add their translations, consistent with how iOS translations are managed.
- The **audit blind spot** (logic-file return literals aren't scanned) is worth knowing about independently — it's why these slipped through #1185's gate despite it being green.

## Verification
- `./gradlew compileFullDebugKotlin` ✅
- `python3 Tools/i18n_audit.py --ci main` → exit 0 ✅
- No app-target Swift touched, so no app-build needed.