### PR TITLE
chore(android): clear all Kotlin compiler warnings (tests + main)

### DIFF
--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -190,6 +190,7 @@ object AnalyticsEngine {
      * @param maxHROverride explicit HRmax (bpm) to use for strain/zones; null →
      *   Tanaka from profile.age.
      */
+    @Suppress("UNUSED_PARAMETER") // sleepNeedNights kept for signature stability (unused in the current body)
     fun analyzeDay(
         day: String,
         hr: List<HrSample> = emptyList(),
@@ -1144,6 +1145,7 @@ object RestScorer {
         return "sleep-onset onsetTs=$onsetTs hrAtOnset=$hrAtOnsetBpm baselineHr=$baselineHrBpm hrRatio=$r2"
     }
 
+    @Suppress("UNUSED_PARAMETER") // inBedSeconds mirrors the Swift subScoreLine signature (parity)
     fun subScoreLine(
         tstSeconds: Double, inBedSeconds: Double, efficiency: Double, restorativeSeconds: Double,
         needHours: Double, consistency: Double?, deepSeconds: Double?,

--- a/android/app/src/main/java/com/noop/analytics/Baselines.kt
+++ b/android/app/src/main/java/com/noop/analytics/Baselines.kt
@@ -160,7 +160,7 @@ object Baselines {
         for (i in 0 until minOf(dayKeys.size, nightlyHrv.size)) {
             if (nightlyHrv[i] == null) continue
             val k = dayKeys[i]
-            if (newest == null || k > newest!!) newest = k
+            if (newest == null || k > newest) newest = k
         }
         val n = newest ?: return null
         val a = isoEpochDay(n) ?: return null

--- a/android/app/src/main/java/com/noop/analytics/DayOwnerResolver.kt
+++ b/android/app/src/main/java/com/noop/analytics/DayOwnerResolver.kt
@@ -13,6 +13,7 @@ object DayOwnerResolver {
 
     /** The owning deviceId, or null if no candidate has data for the day. A non-null [lockedOwner]
      *  (an explicit dayOwnership decision) always wins, regardless of priority or data. */
+    @Suppress("UNUSED_PARAMETER") // `day` mirrors the Swift DayOwnerResolver.resolve signature (parity)
     fun resolve(day: String, lockedOwner: String?, candidates: List<Candidate>): String? =
         if (lockedOwner != null) lockedOwner
         else candidates.filter { it.hasData }.minByOrNull { it.priority }?.deviceId

--- a/android/app/src/main/java/com/noop/analytics/GuidedCaptureProgress.kt
+++ b/android/app/src/main/java/com/noop/analytics/GuidedCaptureProgress.kt
@@ -9,6 +9,7 @@ sealed class GuidedCaptureProgress {
     object Complete : GuidedCaptureProgress()
 
     companion object {
+        @Suppress("UNUSED_PARAMETER") // nightsElapsed mirrors the Swift GuidedCaptureProgress.evaluate signature (parity)
         fun evaluate(target: Int, nightsWithData: Int, nightsElapsed: Int): GuidedCaptureProgress =
             if (nightsWithData >= target) Complete else Capturing(nightsWithData, target)
 

--- a/android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStagerV2.kt
@@ -126,6 +126,7 @@ object SleepStagerV2 {
     }
 
     /** The pure recipe, exactly as before — extracted so [stageSession] can memoize it. */
+    @Suppress("UNUSED_PARAMETER") // `resp` keeps this a drop-in for SleepStager.stageSession(…resp:) (parity)
     private fun stageSessionUncached(
         start: Long, end: Long, grav: List<GravitySample>,
         hr: List<HrSample>, rr: List<RrInterval>, resp: List<RespSample>,

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2124,6 +2124,7 @@ class WhoopBleClient(
      * UI's 15-min analysis tick (which also doesn't run at all with the app UI closed and only the
      * foreground service alive). Mirrors the AppViewModel loop's profile + writeback behaviour. (#78 fork)
      */
+    @Suppress("UNUSED_PARAMETER")
     private fun onBackfillChunkCommitted(batch: StreamBatch) {
         decodedChunksThisSession += 1   // invoked once per non-empty decoded chunk (#77 family tally)
         if (!analyzeAfterBackfillScheduled.compareAndSet(false, true)) return
@@ -6082,8 +6083,8 @@ class WhoopBleClient(
         handler.postDelayed({
             if (ecgGateReport == null || ecgGateStep != armed) return@postDelayed
             send(CommandNumber.GET_DEVICE_CONFIG_VALUE, DeviceConfigWriteGate.readBackPayload())
-            handler.postDelayed({
-                if (ecgGateReport == null || ecgGateStep != armed) return@postDelayed
+            handler.postDelayed(readBack@{
+                if (ecgGateReport == null || ecgGateStep != armed) return@readBack
                 ecgGateReport?.noteReadBackTimeout((ecgGateReadBackTimeoutMs / 1000).toInt())
                 finishEcgGateWrite()
             }, ecgGateReadBackTimeoutMs)
@@ -6457,6 +6458,7 @@ class WhoopBleClient(
      * mirroring how the Swift code writes the bond frame inline in didDiscoverCharacteristicsFor.
      */
     @SuppressLint("MissingPermission")
+    @Suppress("UNUSED_PARAMETER") // `g` kept for signature symmetry with the other write* frame helpers
     private fun writeBondFrame(g: BluetoothGatt, ch: BluetoothGattCharacteristic) {
         val ops = gattOps ?: return
         val s = seq.incrementAndGet() and 0xFF
@@ -6484,6 +6486,7 @@ class WhoopBleClient(
      * notify subscriptions). Unverified on real MG hardware.
      */
     @SuppressLint("MissingPermission")
+    @Suppress("UNUSED_PARAMETER") // `g` kept for signature symmetry with the other write* frame helpers
     private fun writeClientHello(g: BluetoothGatt, ch: BluetoothGattCharacteristic) {
         val hello = DeviceFamily.WHOOP5.clientHello ?: return
         val ops = gattOps ?: return

--- a/android/app/src/main/java/com/noop/data/DataBackup.kt
+++ b/android/app/src/main/java/com/noop/data/DataBackup.kt
@@ -170,7 +170,7 @@ object DataBackup {
         val tempSettings = File(appContext.cacheDir, "import-settings.json")
         tempSettings.delete()
         try {
-            when (val staged = stageBackupSqlite(resolver.openInputStream(uri), header, tempSqlite, tempSettings)) {
+            when (stageBackupSqlite(resolver.openInputStream(uri), header, tempSqlite, tempSettings)) {
                 StageResult.OK -> Unit
                 StageResult.CANNOT_OPEN -> return ImportResult.Failed("Could not open the chosen file.")
                 StageResult.NO_DB_IN_ZIP -> {

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -232,7 +232,7 @@ object HealthConnectImporter {
         // Whether the water read actually COMPLETED. Distinct from "found nothing": the write below
         // replaces the stored figure, so a swallowed read error must not be mistaken for an authoritative
         // zero and wipe 30 days of imported water.
-        var hydrationReadOk = false
+        var hydrationReadOk: Boolean
 
         val workouts = ArrayList<WorkoutRow>()
         // #1002: each workout's day key, computed at READ time while the record's own zone offset is

--- a/android/app/src/main/java/com/noop/ingest/WearableExportImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/WearableExportImporter.kt
@@ -849,6 +849,7 @@ object WearableExportImporter {
     }
 
     /** True if the file is a wellness JSON/CSV we care about (filters out a brand's non-wellness bulk). */
+    @Suppress("UNUSED_PARAMETER") // `data` kept to match the sibling is*File(name, data) probes
     internal fun isWellnessFile(name: String, data: ByteArray): Boolean {
         if (name.endsWith(".csv")) {
             // Includes Oura's generically-named daily-summary CSV (#857) so it reaches the parser.

--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -47,7 +47,7 @@ import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Psychology
-import androidx.compose.material.icons.filled.Rule
+import androidx.compose.material.icons.automirrored.filled.Rule
 import androidx.compose.material.icons.filled.Sensors
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Spa
@@ -163,7 +163,7 @@ private enum class Destination(
     SmartAlarm("smart_alarm", R.string.nav_alarms, Icons.Filled.Alarm),
     Devices("devices", R.string.nav_devices, Icons.Filled.Sensors),
     // The plain 4.0 vs 5.0/MG capability grid — what NOOP reads live off each strap vs import-only.
-    NoopLimitations("noop_limitations", R.string.nav_noop_limitations, Icons.Filled.Rule),
+    NoopLimitations("noop_limitations", R.string.nav_noop_limitations, Icons.AutoMirrored.Filled.Rule),
     DataSources("data_sources", R.string.nav_data_sources, Icons.Filled.Storage),
     BackupSync("backup_sync", R.string.nav_backup_sync, Icons.Filled.CloudSync),
     FusedRecord("fused_record", R.string.nav_fused_record, Icons.AutoMirrored.Filled.CompareArrows),

--- a/android/app/src/main/java/com/noop/ui/CoachMarkdown.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachMarkdown.kt
@@ -114,6 +114,7 @@ private fun BulletItem(marker: String, content: AnnotatedString, color: Color) {
  * Inline Markdown → [AnnotatedString]: **bold**, *italic* / _italic_, `code`. A single left-to-right
  * scan; an unterminated marker is emitted as literal text (so stray `*` never eats the rest of a line).
  */
+@Suppress("UNUSED_PARAMETER") // `color` kept for call-site clarity + API symmetry with the block parser
 fun parseInline(s: String, color: Color): AnnotatedString = buildAnnotatedString {
     var i = 0
     val n = s.length

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -481,6 +481,7 @@ private fun DiagnosticToolsCard(vm: AppViewModel) {
 }
 
 @Composable
+@Suppress("UNUSED_PARAMETER")
 private fun ExportCard(vm: AppViewModel, onReport: () -> Unit) {
     val context = LocalContext.current
     val settings = remember { DebugExportSettings.from(context) }

--- a/android/app/src/main/java/com/noop/ui/TimeOfDayBackground.kt
+++ b/android/app/src/main/java/com/noop/ui/TimeOfDayBackground.kt
@@ -233,6 +233,7 @@ private fun DrawScope.drawDawn(w: Float, h: Float, isLight: Boolean) {
 }
 
 // MARK: Day — cleanest of the four: a barely-there cool top-light only.
+@Suppress("UNUSED_PARAMETER") // `w` kept for signature symmetry with drawNight(w, h, isLight)
 private fun DrawScope.drawDay(w: Float, h: Float, isLight: Boolean) {
     drawRect(
         brush = Brush.verticalGradient(

--- a/android/app/src/main/java/com/noop/ui/TodayDayNav.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayDayNav.kt
@@ -21,6 +21,7 @@ import kotlin.math.abs
  * but on a fresh launch they intentionally have NO effect - the old "land on the most recent data day"
  * behaviour (#605/#739) is retired. Mirror EXACTLY in Swift.
  */
+@Suppress("UNUSED_PARAMETER")
 internal fun launchDayOffset(
     isFreshLaunch: Boolean,
     savedOffset: Int,

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -237,6 +237,7 @@ private data class TodayLiveSnapshot(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+@Suppress("UNUSED_PARAMETER")
 fun TodayScreen(
     viewModel: AppViewModel,
     onQuickActions: () -> Unit = {},
@@ -633,7 +634,6 @@ fun TodayScreen(
     // collapsed and are NOT persisted, so the home screen reopens compact. Mirrors iOS.
     var metricsExpanded by remember { mutableStateOf(false) }
     var sourcesExpanded by remember { mutableStateOf(false) }
-    var scoringCardSeen by remember { mutableStateOf(ScoringGuidePrefs.cardSeen(context)) }
 
     // Per-card "dismissed into the inbox" flags for the two Today info-cards. A small × on each card
     // sets these (and posts a `.dismissedCard` update); "Restore to Today" in the inbox flips them back
@@ -2785,6 +2785,7 @@ private fun ReadinessHeroPill(word: String, level: ReadinessEngine.Level, onTap:
  *  and drawn as a dimmed FILLED ring in the carried branch (matching iOS chargeRing), so this overlay only
  *  covers the calibrating and no-data cases. Mirrors iOS TodayView.ringEmptyOverlay. */
 @Composable
+@Suppress("UNUSED_PARAMETER")
 private fun RingEmptyOverlay(
     calibratingNights: Int?,
     diameter: Dp,
@@ -2852,6 +2853,7 @@ private fun RingNeedsTrackedNight() {
  *  card to the Key-Metrics tiles, which already read per-field. Each row still falls through to "No Data"
  *  for a vital neither today nor the carry supplies. */
 @Composable
+@Suppress("UNUSED_PARAMETER")
 private fun HeroMetricRows(day: DailyMetric?, carriedDay: DailyMetric? = null, vitalsDay: DailyMetric? = null) {
     // Per-field, today-first: today's own value wins; the vitals carry only fills a field today lacks.
     val hrv = day?.avgHrv ?: vitalsDay?.avgHrv
@@ -4323,6 +4325,7 @@ private fun RecordingStatusChip(state: RecordingState, onConnect: () -> Unit) {
  * grid tiles perfectly with no empty cells.
  */
 @Composable
+@Suppress("UNUSED_PARAMETER")
 private fun MetricGrid(
     d: DailyMetric?,
     w: Window,

--- a/android/app/src/test/java/com/noop/analytics/StepsEstimateEngineTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StepsEstimateEngineTest.kt
@@ -152,7 +152,7 @@ class StepsEstimateEngineTest {
             coefficient = 12.34, sampleDays = 6, confidence = 0.2,
         )
         assertEquals(StepsEstimateEngine.ConfidenceTier.LOW, status.confidenceTier)
-        assertEquals(12.34, status.coefficientOrNull!!, 1e-9)
+        assertEquals(12.34, status.coefficientOrNull, 1e-9)
         assertEquals("k=12.3 from 6 days, low confidence", status.detail)
         val one = StepsEstimateEngine.CalibrationStatus.Calibrated(
             coefficient = 5.0, sampleDays = 1, confidence = 0.8,
@@ -164,7 +164,7 @@ class StepsEstimateEngineTest {
     @Test fun statusDetailManualAndNeedsMoreDays() {
         val manual = StepsEstimateEngine.CalibrationStatus.Manual(coefficient = 9.5, sampleDays = 0)
         assertEquals(StepsEstimateEngine.ConfidenceTier.HIGH, manual.confidenceTier)
-        assertEquals(9.5, manual.coefficientOrNull!!, 1e-9)
+        assertEquals(9.5, manual.coefficientOrNull, 1e-9)
         assertEquals("manual k=9.5", manual.detail)
         val needs = StepsEstimateEngine.CalibrationStatus.NeedsMoreDays(have = 1, need = 3)
         assertEquals(StepsEstimateEngine.ConfidenceTier.LOW, needs.confidenceTier)

--- a/android/app/src/test/java/com/noop/analytics/VitalBandsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/VitalBandsTest.kt
@@ -73,7 +73,7 @@ class VitalBandsTest {
     @Test
     fun nullNights_doNotCountTowardTrust() {
         // 13 valid nights then 10 trailing skips → only 13 valid → provisional, still population.
-        val hist: List<Double?> = (1..13).map { 35.0 as Double? } + List(10) { null }
+        val hist: List<Double?> = (1..13).map { 35.0 } + List(10) { null }
         val r = VitalBands.band(35.0, hist, hrvPop, hrvCfg)
         assertEquals(VitalBands.Basis.POPULATION, r.basis)
     }
@@ -81,7 +81,7 @@ class VitalBandsTest {
     @Test
     fun staleBaseline_fallsBackToPopulation() {
         // 20 valid nights then 20 missing (> staleDays = 14): status STALE → population.
-        val hist: List<Double?> = List(20) { 35.0 as Double? } + List(20) { null }
+        val hist: List<Double?> = List(20) { 35.0 } + List(20) { null }
         val r = VitalBands.band(35.0, hist, hrvPop, hrvCfg)
         assertEquals(VitalBands.Basis.POPULATION, r.basis)
     }

--- a/android/app/src/test/java/com/noop/data/SchemaOracleTest.kt
+++ b/android/app/src/test/java/com/noop/data/SchemaOracleTest.kt
@@ -268,7 +268,7 @@ class SchemaOracleTest {
             .use { it.readBytes() }
 
         // Gradle runs unit tests with the module dir (android/app) or repo root as user.dir; try both.
-        val userDir = File(System.getProperty("user.dir"))
+        val userDir = File(System.getProperty("user.dir") ?: ".")
         val swiftFile = listOf(
             File(userDir, "Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json"),
             File(userDir, "../../Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json"),

--- a/android/app/src/test/java/com/noop/protocol/CommandCatalogueTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/CommandCatalogueTest.kt
@@ -39,7 +39,7 @@ class CommandCatalogueTest {
     @Test
     fun everyCommandInTheSharedSchemaIsNamedOnAndroid() {
         val rel = "Packages/WhoopProtocol/Sources/WhoopProtocol/Resources/whoop_protocol.json"
-        val userDir = File(System.getProperty("user.dir"))
+        val userDir = File(System.getProperty("user.dir") ?: ".")
         val schemaFile = listOf(File(userDir, rel), File(userDir, "../../$rel")).firstOrNull { it.exists() }
         org.junit.Assume.assumeTrue(
             "shared schema not found from user.dir=$userDir — skipping the catalogue lockstep check",

--- a/android/app/src/test/java/com/noop/protocol/DecoderOracleTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/DecoderOracleTest.kt
@@ -104,7 +104,7 @@ class DecoderOracleTest {
             .use { it.readBytes() }
 
         // Gradle runs unit tests with the module dir (android/app) or repo root as user.dir; try both.
-        val userDir = java.io.File(System.getProperty("user.dir"))
+        val userDir = java.io.File(System.getProperty("user.dir") ?: ".")
         val candidates = listOf(
             java.io.File(userDir, "Packages/WhoopProtocol/Tests/WhoopProtocolTests/Resources/decoder_oracle.json"),
             java.io.File(userDir, "../../Packages/WhoopProtocol/Tests/WhoopProtocolTests/Resources/decoder_oracle.json"),

--- a/android/app/src/test/java/com/noop/protocol/EventCatalogueTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/EventCatalogueTest.kt
@@ -36,7 +36,7 @@ class EventCatalogueTest {
     @Test
     fun everyEventInTheSharedSchemaIsNamedOnAndroid() {
         val rel = "Packages/WhoopProtocol/Sources/WhoopProtocol/Resources/whoop_protocol.json"
-        val userDir = File(System.getProperty("user.dir"))
+        val userDir = File(System.getProperty("user.dir") ?: ".")
         val schemaFile = listOf(File(userDir, rel), File(userDir, "../../$rel")).firstOrNull { it.exists() }
         org.junit.Assume.assumeTrue(
             "shared schema not found from user.dir=$userDir — skipping the catalogue lockstep check",

--- a/android/app/src/test/java/com/noop/ui/GermanLocalizationTest.kt
+++ b/android/app/src/test/java/com/noop/ui/GermanLocalizationTest.kt
@@ -27,7 +27,7 @@ import java.io.File
 class GermanLocalizationTest {
 
     private fun resFile(rel: String): File? {
-        val userDir = File(System.getProperty("user.dir"))
+        val userDir = File(System.getProperty("user.dir") ?: ".")
         // Gradle runs unit tests with the module dir (android/app) or the repo root as user.dir.
         return listOf(
             File(userDir, "src/main/res/$rel"),

--- a/android/app/src/test/java/com/noop/ui/SleepImportedFiguresTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepImportedFiguresTest.kt
@@ -59,7 +59,7 @@ class SleepImportedFiguresTest {
         val m = buildSleepModel(days, session = null, imported = imported)!!
         assertEquals(RestScorer.restFromDaily(days[1])!!, m.performance.latest!!, 1e-9)
         // …and it is NOT the retired asleep/need approximation.
-        assertNotEquals(410.0 / 450.0 * 100.0, m.performance.latest!!, 1e-6)
+        assertNotEquals(410.0 / 450.0 * 100.0, m.performance.latest, 1e-6)
         // …and the imported day still carries the verbatim figure inside the series.
         assertEquals(85.0, m.performance.series.first(), 1e-9)
     }
@@ -84,7 +84,7 @@ class SleepImportedFiguresTest {
         val composite = RestScorer.restFromDaily(night)!!
         assertEquals(composite, m.performance.latest!!, 1e-9)
         assertTrue("composite should be below the 100% proxy ceiling", composite < 100.0)
-        assertNotEquals(100.0, m.performance.latest!!, 1e-6)
+        assertNotEquals(100.0, m.performance.latest, 1e-6)
     }
 
     @Test
@@ -129,7 +129,7 @@ class SleepImportedFiguresTest {
         // Debt tile reads ASLEEP too: max(0, 450 − 410) = 40, never max(0, 450 − 600) = 0.
         assertEquals(40.0, m.sleepDebt.latest!!, 1e-9)
         // The debt TILE and the LEDGER agree (both asleep over the full history) — the #5 symptom.
-        assertEquals(m.sleepDebt.latest!!, -m.sleepDebtLedger.nights.last().deltaMin, 1e-9)
+        assertEquals(m.sleepDebt.latest, -m.sleepDebtLedger.nights.last().deltaMin, 1e-9)
     }
 
     /** A passed session must give the SAME tiles/ledger as no session — there is no display-time

--- a/android/app/src/test/java/com/noop/ui/SleepOnsetStubTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepOnsetStubTest.kt
@@ -127,7 +127,7 @@ class SleepOnsetStubTest {
         assertTrue("hero segments must start at real sleep (>= fragment A), not the pre-onset stub",
             firstSeg.start >= aStart)
         // Both real fragments contribute (biphasic night preserved): more than fragment B alone.
-        assertTrue("biphasic night must keep both real fragments", hero.groupSegments!!.size >= 4)
+        assertTrue("biphasic night must keep both real fragments", hero.groupSegments.size >= 4)
         // The stub is not a nap — it stays inside the main-night group.
         assertTrue(hero.napBlocks.none { it.startTs == stubStart })
         // #345: the hero's clock WINDOW spans the whole night — displayed bedtime (fragment A's onset,


### PR DESCRIPTION
Compiling the Android module emitted ~40 Kotlin warnings (test + main sources). This brings the count to **0**, split between real fixes and documented suppressions. Android-only, **no behaviour change**.

## Real fixes
**Tests** — unnecessary `!!` on non-null receivers (only the flagged sites; the genuinely-nullable `.latest!!` calls are left intact), redundant `as Double?` casts, and null-safe `System.getProperty("user.dir") ?: "."` in the resource-oracle tests.

**Main** —
- `Baselines`: drop `!!` on a smart-cast-non-null value.
- `DataBackup`: drop the unused `val staged =` `when` binding.
- `HealthConnectImporter`: drop the redundant `= false` initializer (definitely assigned before read).
- `WhoopBleClient`: label the nested read-back `postDelayed` lambda to remove the duplicate-label ambiguity.
- `TodayScreen`: remove never-read `scoringCardSeen` state.
- `AppRoot`: `Icons.Filled.Rule` → `Icons.AutoMirrored.Filled.Rule` (deprecation).

## Suppressions (intentional params, not removed)
The unused-parameter warnings are on params that are **intentional**, so they get `@Suppress("UNUSED_PARAMETER")` with a rationale comment rather than removal:
- **Swift-signature parity mirrors** — `analyzeDay`/`subScoreLine`, `DayOwnerResolver.resolve`, `GuidedCaptureProgress.evaluate`, `SleepStagerV2.stageSessionUncached` (its `resp` keeps it a drop-in for `SleepStager.stageSession(…resp:)`). Removing these would diverge from the Swift twins.
- **Stable composable/BLE API surface** — `TodayScreen`/`MetricGrid`/`HeroMetricRows`/`RingEmptyOverlay`, `TodayDayNav`, `TestCentreScreen`, `TimeOfDayBackground.drawDay`, `WhoopBleClient` write helpers, `WearableExportImporter.isWellnessFile`, `CoachMarkdown.parseInline`. Removing would churn many call sites for no functional gain.

## Verification
- `./gradlew compileFullDebugUnitTestKotlin --rerun-tasks` → **0 warnings**, BUILD SUCCESSFUL.
- No app-target Swift, no strings, no analytics/stored-data change.