### PR TITLE
feat(analytics): record primary-session mean RHR as a shadow metric (#1169)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -1048,6 +1048,23 @@ public enum AnalyticsEngine {
         return (mean: sum / kept, samples: kept)
     }
 
+    /// #1169 SHADOW METRIC: the primary-session MEAN resting HR — window each detected sleep session's HR
+    /// samples to `[start, end)` and delegate to the #1174-defined `PrimarySessionRestingHR.meanHR` (that
+    /// definition is UNCHANGED). `IntelligenceEngine` stores the result beside the shipped nightly HR FLOOR
+    /// (`daily.restingHr`) as "rhr_primary_session" — instrumentation only, never shown, never scored — so
+    /// the mean-vs-floor comparison #1169 asks for can be evaluated from exports without a headline switch.
+    /// Byte-parity twin of the Kotlin `primarySessionRestingHR`.
+    public static func primarySessionRestingHR(
+        sessions: [SleepSession], hr: [HRSample],
+        validBpm: ClosedRange<Int> = PrimarySessionRestingHR.defaultValidBpm,
+        minValidSamples: Int = PrimarySessionRestingHR.defaultMinValidSamples) -> Double? {
+        PrimarySessionRestingHR.meanHR(sessions: sessions.map { s in
+            PrimarySessionRestingHR.Session(
+                durationSec: Double(s.end - s.start),
+                bpm: hr.filter { $0.ts >= s.start && $0.ts < s.end }.map { $0.bpm })
+        }, validBpm: validBpm, minValidSamples: minValidSamples)
+    }
+
     // MARK: - Skin-temp funnel diagnostic (#752)
 
     // Skin temp coming out 0/absent on a WHOOP 4.0 (or any) night is opaque: the user can't tell whether

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/PrimarySessionRestingHRTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/PrimarySessionRestingHRTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import StrandAnalytics
+import WhoopProtocol
 
 /// #1169 — the primary-session mean resting-HR definition. The oracle for the Android
 /// `PrimarySessionRestingHRTest`; keep the two in lockstep (same fixtures, same numbers).
@@ -60,5 +61,24 @@ final class PrimarySessionRestingHRTests: XCTestCase {
         let bpm = Array(repeating: 62, count: 12)
         XCTAssertNil(P.meanHR(sessions: [S(durationSec: 3600, bpm: bpm)], minValidSamples: 20))
         XCTAssertEqual(P.meanHR(sessions: [S(durationSec: 3600, bpm: bpm)], minValidSamples: 10), 62.0)
+    }
+
+    /// #1169 instrumentation: `AnalyticsEngine.primarySessionRestingHR` windows HR to each session and
+    /// selects the LONGEST — a nap and out-of-window samples must not pollute the primary-night mean.
+    func testPrimarySessionRestingHRWindowsAndSelectsLongest() {
+        let night = SleepSession(start: 0, end: 30_000, efficiency: 0.9, stages: [], restingHR: nil, avgHRV: nil)
+        let nap = SleepSession(start: 40_000, end: 45_000, efficiency: 0.9, stages: [], restingHR: nil, avgHRV: nil)
+        var hr = (0..<100).map { HRSample(ts: $0 * 30, bpm: 60) }        // inside the night
+        hr += (0..<50).map { HRSample(ts: 40_000 + $0 * 30, bpm: 45) }   // inside the nap
+        hr += (0..<50).map { HRSample(ts: 31_000 + $0 * 10, bpm: 100) }  // between the two — excluded
+        XCTAssertEqual(AnalyticsEngine.primarySessionRestingHR(sessions: [nap, night], hr: hr), 60.0)
+    }
+
+    /// Half-open `[start, end)`: a sample exactly at `end` is excluded (kept identical to the Kotlin twin).
+    func testPrimarySessionRestingHRExcludesEndBoundarySample() {
+        let s = SleepSession(start: 0, end: 3000, efficiency: 0.9, stages: [], restingHR: nil, avgHRV: nil)
+        var hr = (0..<40).map { HRSample(ts: $0 * 60, bpm: 58) }         // 0…2340, inside
+        hr.append(HRSample(ts: 3000, bpm: 200))                          // exactly at end → excluded
+        XCTAssertEqual(AnalyticsEngine.primarySessionRestingHR(sessions: [s], hr: hr), 58.0)
     }
 }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -135,6 +135,11 @@ final class IntelligenceEngine: ObservableObject {
         /// the night has no in-band @82 readings, or the owner is a WHOOP 4.0 (no v18 aux stream).
         /// Written to metricSeries as "spo2_candidate" under the "-noop" device ID in pass 2.
         let spo2Candidate: Int?
+        /// #1169 SHADOW METRIC: the primary-session MEAN resting HR (PrimarySessionRestingHR, #1174) for this
+        /// day, computed off the main actor beside the shipped nightly HR FLOOR (`daily.restingHr`). nil when
+        /// no session clears the coverage gate. Written to metricSeries as "rhr_primary_session" in pass 2 —
+        /// instrumentation only, never shown and never fed to any score.
+        let primarySessionRHR: Double?
     }
 
     struct Computed: Identifiable {
@@ -864,10 +869,17 @@ final class IntelligenceEngine: ObservableObject {
                         }
                     }
                 }
+                // #1169 SHADOW METRIC (instrumentation only): the primary-session MEAN resting HR, recorded
+                // beside the shipped nightly HR FLOOR (daily.restingHr = min per session) so the mean-vs-floor
+                // comparison the issue asks for accrues on real devices. NEVER shown and NEVER fed to any
+                // score; #1174's definition is unchanged — this only records its per-night output. The
+                // windowing + delegation lives in the byte-identical, tested `AnalyticsEngine`.
+                let primarySessionRHR = AnalyticsEngine.primarySessionRestingHR(sessions: res.sleepSessions, hr: hr)
                 out.append(DayScan(result: res, rhrLine: rhrLine,
                                    readOwner: owner, hrRows: hr.count,
                                    sleepTrace: sleepTrace, stepsTrace: stepsTrace, hrvTrace: hrvTrace,
-                                   hrvDiag: hrvDiag, spo2Candidate: spo2CandidateMean))
+                                   hrvDiag: hrvDiag, spo2Candidate: spo2CandidateMean,
+                                   primarySessionRHR: primarySessionRHR))
             }
             return (out, skippedDayLines)
         }.value
@@ -885,6 +897,8 @@ final class IntelligenceEngine: ObservableObject {
         var resolvedScoreOwnerByDay: [String: String] = [:]
         // #103: SpO₂ candidate @82 nightly mean per day, carried from pass 1 for metricSeries persistence.
         var spo2CandidateByDay: [String: Int] = [:]
+        // #1169: primary-session mean RHR shadow metric per day, carried from pass 1 for metricSeries persistence.
+        var primarySessionRHRByDay: [String: Double] = [:]
 
         // Back on the main actor: fold the off-actor results into the pass-2 state in the SAME order the
         // loop produced them. Pure assignment / appends , no further store reads , so this is cheap and the
@@ -901,6 +915,10 @@ final class IntelligenceEngine: ObservableObject {
             // nil when the toggle is OFF or the night had no in-band @82 readings.
             if let cand = scan.spo2Candidate {
                 spo2CandidateByDay[res.daily.day] = cand
+            }
+            // #1169: carry the primary-session mean RHR shadow metric into pass 2 for persistence.
+            if let v = scan.primarySessionRHR {
+                primarySessionRHRByDay[res.daily.day] = v
             }
             if let line = scan.rhrLine { diagnosticSink?(line, nil) }
             // Sleep & Rest test mode (E5): replay this day's gate-trace + Rest lines tagged `.sleep` so they
@@ -1137,6 +1155,12 @@ final class IntelligenceEngine: ObservableObject {
             // split cross-device evidence and stays behind the experimental display toggle.
             if let cand = spo2CandidateByDay[daily.day] {
                 restPoints.append(MetricPoint(day: daily.day, key: "spo2_candidate", value: Double(cand)))
+            }
+            // #1169 shadow metric: the primary-session mean RHR, stored beside the shipped floor
+            // (daily.restingHr) under the "-noop" computed ID. Instrumentation only — never shown, never
+            // scored — so the mean-vs-floor comparison the issue needs can be evaluated from exports later.
+            if let v = primarySessionRHRByDay[daily.day] {
+                restPoints.append(MetricPoint(day: daily.day, key: "rhr_primary_session", value: v))
             }
             cachedSleep.append(contentsOf: night.cachedSleep)
             // Persist the detected workouts the pipeline already computes (previously discarded).

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -855,6 +855,30 @@ object AnalyticsEngine {
         return Pair((sum / kept).toInt(), kept)
     }
 
+    /**
+     * #1169 SHADOW METRIC: the primary-session MEAN resting HR — window each detected sleep session's HR
+     * samples to `[start, end)` and delegate to the #1174-defined [PrimarySessionRestingHR.meanHR] (that
+     * definition is UNCHANGED). IntelligenceEngine stores the result beside the shipped nightly HR FLOOR
+     * (`daily.restingHr`) as "rhr_primary_session" — instrumentation only, never shown, never scored — so
+     * the mean-vs-floor comparison #1169 asks for can be evaluated from exports without a headline switch.
+     * Byte-parity twin of the Swift `primarySessionRestingHR`.
+     */
+    internal fun primarySessionRestingHR(
+        sessions: List<DetectedSleep>,
+        hr: List<HrSample>,
+        validBpm: IntRange = PrimarySessionRestingHR.DEFAULT_VALID_BPM,
+        minValidSamples: Int = PrimarySessionRestingHR.DEFAULT_MIN_VALID_SAMPLES,
+    ): Double? = PrimarySessionRestingHR.meanHR(
+        sessions.map { s ->
+            PrimarySessionRestingHR.Session(
+                durationSec = (s.end - s.start).toDouble(),
+                bpm = hr.filter { it.ts >= s.start && it.ts < s.end }.map { it.bpm },
+            )
+        },
+        validBpm,
+        minValidSamples,
+    )
+
     /** Plausible worn skin-temperature range (°C). Off-wrist/charging samples drift to ambient and are
      *  excluded; the strap's own decode gate is the looser 20–45. (PR #85) */
     private const val SKIN_TEMP_MIN_C: Double = 28.0

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -405,6 +405,8 @@ object IntelligenceEngine {
         val scoredNights = ArrayList<DayResult>()
         // #103: SpO₂ candidate @82 nightly mean per day, carried from pass 1 for metricSeries persistence.
         val spo2CandidateByDay = LinkedHashMap<String, Int>()
+        // #1169: primary-session mean RHR shadow metric per day, carried from pass 1 for persistence.
+        val primarySessionRHRByDay = LinkedHashMap<String, Double>()
 
         // In-memory nightly values harvested in pass 1, used to seed the pass-2 baseline.
         // Keyed by day so the union with imported history de-dupes cleanly per UTC day.
@@ -749,6 +751,12 @@ object IntelligenceEngine {
                     }
                 }
             }
+            // #1169 SHADOW METRIC (instrumentation only): the primary-session MEAN resting HR, recorded
+            // beside the shipped nightly HR FLOOR (daily.restingHr = min per session) so the mean-vs-floor
+            // comparison the issue asks for accrues on real devices. NEVER shown and NEVER fed to any score;
+            // #1174's definition is unchanged. The windowing + delegation lives in the byte-identical,
+            // tested AnalyticsEngine.
+            AnalyticsEngine.primarySessionRestingHR(res.sleepSessions, hr)?.let { primarySessionRHRByDay[res.daily.day] = it }
             scoredNights.add(res)
             resolvedScoreOwnerByDay[res.daily.day] = owner
         }
@@ -918,6 +926,12 @@ object IntelligenceEngine {
             // is ON. Written under the "-noop" computed device ID, never to `spo2Pct`.
             spo2CandidateByDay[daily.day]?.let { cand ->
                 restRows.add(MetricSeriesRow(deviceId = computedId, day = daily.day, key = "spo2_candidate", value = cand.toDouble()))
+            }
+            // #1169 shadow metric: the primary-session mean RHR, stored beside the shipped floor
+            // (daily.restingHr) under the "-noop" computed ID. Instrumentation only — never shown, never
+            // scored — for later mean-vs-floor evaluation from exports.
+            primarySessionRHRByDay[daily.day]?.let { v ->
+                restRows.add(MetricSeriesRow(deviceId = computedId, day = daily.day, key = "rhr_primary_session", value = v))
             }
 
             out.add(

--- a/android/app/src/test/java/com/noop/analytics/PrimarySessionRestingHRTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/PrimarySessionRestingHRTest.kt
@@ -1,5 +1,6 @@
 package com.noop.analytics
 
+import com.noop.data.HrSample
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -62,5 +63,23 @@ class PrimarySessionRestingHRTest {
         val bpm = List(12) { 62 }
         assertNull(PrimarySessionRestingHR.meanHR(listOf(s(3600.0, bpm)), minValidSamples = 20))
         assertEquals(62.0, PrimarySessionRestingHR.meanHR(listOf(s(3600.0, bpm)), minValidSamples = 10)!!, 1e-9)
+    }
+
+    /** #1169 instrumentation: AnalyticsEngine.primarySessionRestingHR windows HR to each session and
+     *  selects the LONGEST — a nap and out-of-window samples must not pollute the primary-night mean. */
+    @Test fun primarySessionRestingHRWindowsAndSelectsLongest() {
+        val night = DetectedSleep(0L, 30_000L, 0.9, emptyList(), null, null)
+        val nap = DetectedSleep(40_000L, 45_000L, 0.9, emptyList(), null, null)
+        val hr = (0 until 100).map { HrSample("d", (it * 30).toLong(), 60) } +
+            (0 until 50).map { HrSample("d", (40_000 + it * 30).toLong(), 45) } +
+            (0 until 50).map { HrSample("d", (31_000 + it * 10).toLong(), 100) }
+        assertEquals(60.0, AnalyticsEngine.primarySessionRestingHR(listOf(nap, night), hr)!!, 1e-9)
+    }
+
+    /** Half-open [start, end): a sample exactly at `end` is excluded (identical to the macOS twin). */
+    @Test fun primarySessionRestingHRExcludesEndBoundarySample() {
+        val s = DetectedSleep(0L, 3000L, 0.9, emptyList(), null, null)
+        val hr = (0 until 40).map { HrSample("d", (it * 60).toLong(), 58) } + HrSample("d", 3000L, 200)
+        assertEquals(58.0, AnalyticsEngine.primarySessionRestingHR(listOf(s), hr)!!, 1e-9)
     }
 }


### PR DESCRIPTION
#1174 landed the pure `PrimarySessionRestingHR` definition but left it computed **nowhere** — so the mean-vs-floor comparison #1169 asks for can't accrue on real devices (chicken-and-egg). This records it silently beside the shipped floor.

## Scope — exactly what @artemc asked for
Their two comments on #1169 (2026-08-09) are explicit: the new prospective, out-of-sample night (NOOP mean 61.309 ≈ OpenStrap 61.306 ≈ Polar H10 61.405 ≈ official 60, vs the floor's 56) supports collection, but *"keep the implementation from #1174 unchanged while collecting them … before considering display wiring or any recovery/strain re-baselining."* So this is **shadow-metric collection only** — no display, no scoring, #1174 untouched.

## Change
- **`AnalyticsEngine.primarySessionRestingHR(sessions, hr)`** (both platforms, byte-identical): windows each detected sleep session's HR to `[start, end)` and delegates to the **unchanged** `PrimarySessionRestingHR.meanHR` (#1174). It lives in the `swift-packages`-tested `AnalyticsEngine` (not the un-CI'd `IntelligenceEngine`), mirroring #1180's `nightlySpo2CandidateMean` — so the parity-critical windowing is **tested**, not inlined. New tests on both platforms cover the windowing, longest-session selection, and the half-open end boundary (same fixtures/numbers: 60.0, 58.0).
- **`IntelligenceEngine`** (both platforms): compute it per scored day and persist to `metricSeries` as **`rhr_primary_session`** under the `-noop` computed id, right beside the `spo2_candidate` write.

## Guarantees
- **Instrumentation only** — never shown, never fed to recovery/strain/workout/energy.
- The shipped floor (`daily.restingHr`) is **untouched** and remains the sole headline + scoring input.
- Byte-identical Swift↔Kotlin (windowing + the tested `meanHR`); `rhr_primary_session` is a new additive `metricSeries` key, no migration.

## Verification
- Android: `testFullDebugUnitTest --tests PrimarySessionRestingHRTest` ✅ (new windowing tests pass; `compileFullDebugKotlin` clean).
- Swift: `swift-packages` covers `AnalyticsEngine.primarySessionRestingHR` + the new `PrimarySessionRestingHRTests` cases.
- **app-build** running — `IntelligenceEngine.swift` is app-target (no default CI).

Refs #1169. Keeps the issue open as the tracking anchor for the future multi-participant validation.