### PR TITLE
fix(ble): flip the charging pill on CHARGING_ON/OFF events, not just BATTERY_LEVEL

### DIFF
--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -211,6 +211,15 @@ public final class FrameRouter {
                 if ev.hasPrefix("BATTERY_LEVEL"), let mv = parsed.parsed["battery_mV"]?.intValue {
                     state.batteryMv = mv
                 }
+                // The strap raises CHARGING_ON(7)/CHARGING_OFF(8) the instant a pack goes on or comes off —
+                // flip the pill directly instead of waiting on the ~8-min BATTERY_LEVEL cadence above. Live-
+                // only like those blocks (backfill skips this router), so no replay guard is needed. Ported
+                // from tanarchytan/noop @72ac14d9. Twin of the Kotlin WhoopBleClient handler.
+                if ev.hasPrefix("CHARGING_ON") {
+                    state.charging = true
+                } else if ev.hasPrefix("CHARGING_OFF") {
+                    state.charging = false
+                }
                 // Physical inputs the strap exposes — live only (this path never sees historical
                 // replay, which goes through the Backfiller). Event strings are "NAME(rawValue)".
                 if ev.hasPrefix("DOUBLE_TAP") {

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5577,6 +5577,18 @@ class WhoopBleClient(
                                 _state.update { s -> s.copy(batteryMv = mv) }
                             }
                         }
+                        // The strap raises CHARGING_ON(7)/CHARGING_OFF(8) the instant a pack goes on or comes
+                        // off — so flip the charging pill directly instead of waiting on the ~8-min
+                        // BATTERY_LEVEL cadence, which was the only thing moving it before. Same historical-
+                        // replay exclusion as the battery event: a replayed offload event must not move the
+                        // LIVE pill. Ported from tanarchytan/noop @72ac14d9.
+                        if (shouldApplyChargingFromBatteryEvent(replayedOffload)) {
+                            if (ev.startsWith("CHARGING_ON")) {
+                                _state.update { s -> s.copy(charging = true) }
+                            } else if (ev.startsWith("CHARGING_OFF")) {
+                                _state.update { s -> s.copy(charging = false) }
+                            }
+                        }
                         // PR #577: the strap fired its firmware smart alarm (STRAP_DRIVEN_ALARM_EXECUTED,
                         // event 57) → re-arm the next day's instant (single absolute time, no recurrence).
                         // This is NOT a gesture, so it MUST dispatch from here — the gesture branch never


### PR DESCRIPTION
## What
The strap raises `CHARGING_ON(7)` / `CHARGING_OFF(8)` the instant a pack goes on or comes off, but the live `charging` flag only ever moved on the `BATTERY_LEVEL` event's **~8-min cadence** — so the charging pill lagged a plug/unplug by up to minutes even though the strap had already reported it. The events already reached the handler (they show up in **Last Event**) but never touched the flag.

## Fix — both platforms set `charging` directly on those events
- **Kotlin** (`WhoopBleClient`): gated on the same `shouldApplyChargingFromBatteryEvent(replayedOffload)` exclusion the `BATTERY_LEVEL` path uses, so a **historical** event replayed mid-backfill can't move the LIVE pill.
- **Swift** (`FrameRouter`): the live router already skips historical replay structurally (backfill doesn't call it), matching the `BATTERY_LEVEL` block right beside it — so no explicit guard needed.

`EventNumber.CHARGING_ON(7)`/`CHARGING_OFF(8)` already exist upstream; this only wires them to the flag.

## Provenance
Protocol fact ported from **tanarchytan/noop @72ac14d9** — reimplemented natively (their version routes through the fork's Rust layer; upstream doesn't). The *other* half of that fork commit — reading hardware revision `0x2A27` — is **already in upstream** (`readDisHardwareRevision` / `Whoop5Variant.from`), so only the charging-event half was portable.

## Verification
- `compileFullDebugKotlin` ✅; **app-build** running (`FrameRouter.swift` is app-target Swift, no default CI).
- ⚠️ **Live-BLE behaviour — not testable in CI or on Linux** (BLE safety contract). Compile-clean here; the pill turning over on plug/unplug needs confirming on a real strap. No writes to hardware; reads/observation only.