### PR TITLE
fix(data): coalesce a duplicate day per column so two straps don't lose a row

### DIFF
--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -264,12 +264,48 @@ final class Repository: ObservableObject {
     /// single returned row per day feeds the existing imported-vs-computed `mergeDaily` unchanged.
     private func unionDailyMetrics(store: WhoopStore, from: String, to: String) async -> [DailyMetric] {
         var byDay: [String: DailyMetric] = [:]
-        for id in importedReadIds {   // active strap FIRST → it claims each day, canonical only fills gaps
-            for m in (try? await store.dailyMetrics(deviceId: id, from: from, to: to)) ?? [] where byDay[m.day] == nil {
-                byDay[m.day] = m
+        for id in importedReadIds {   // active strap FIRST → it claims each column, canonical fills its gaps
+            for m in (try? await store.dailyMetrics(deviceId: id, from: from, to: to)) ?? [] {
+                byDay[m.day] = byDay[m.day].map { Self.coalesceDay($0, m) } ?? m
             }
         }
         return byDay.values.sorted { $0.day < $1.day }
+    }
+
+    /// One day held by two source ids in the SAME bucket, folded into `winner`'s row: `winner` keeps every
+    /// column it carries (NON-nil — a measured zero is a reading) and `filler` supplies only the ones it
+    /// left nil. Whole-row first-wins let a hollow row (steps and nothing else) discard a complete one, and
+    /// nothing downstream healed it — `mergeDaily` only bridges imported/computed/phone, never two straps.
+    /// Columns that only mean something together move as a GROUP, whole and from one row, so a sleep total
+    /// never sits beside another strap's stage minutes: the sleep block, and the raw red/IR PPG pair.
+    /// Across-bucket precedence (`mergeDaily`) is untouched. Ported from tanarchytan/noop @de370b85, reduced
+    /// to the columns this DailyMetric carries. Byte-identical twin of Kotlin WhoopRepository.coalesceDay.
+    nonisolated static func coalesceDay(_ winner: DailyMetric, _ filler: DailyMetric) -> DailyMetric {
+        let sleepFromFiller = winner.totalSleepMin == nil && winner.efficiency == nil &&
+            winner.deepMin == nil && winner.remMin == nil && winner.lightMin == nil &&
+            winner.disturbances == nil
+        let rawSpo2FromFiller = winner.spo2Red == nil && winner.spo2Ir == nil
+        return DailyMetric(
+            day: winner.day,
+            totalSleepMin: sleepFromFiller ? filler.totalSleepMin : winner.totalSleepMin,
+            efficiency: sleepFromFiller ? filler.efficiency : winner.efficiency,
+            deepMin: sleepFromFiller ? filler.deepMin : winner.deepMin,
+            remMin: sleepFromFiller ? filler.remMin : winner.remMin,
+            lightMin: sleepFromFiller ? filler.lightMin : winner.lightMin,
+            disturbances: sleepFromFiller ? filler.disturbances : winner.disturbances,
+            restingHr: winner.restingHr ?? filler.restingHr,
+            avgHrv: winner.avgHrv ?? filler.avgHrv,
+            recovery: winner.recovery ?? filler.recovery,
+            strain: winner.strain ?? filler.strain,
+            exerciseCount: winner.exerciseCount ?? filler.exerciseCount,
+            spo2Pct: winner.spo2Pct ?? filler.spo2Pct,
+            skinTempDevC: winner.skinTempDevC ?? filler.skinTempDevC,
+            respRateBpm: winner.respRateBpm ?? filler.respRateBpm,
+            steps: winner.steps ?? filler.steps,
+            activeKcalEst: winner.activeKcalEst ?? filler.activeKcalEst,
+            spo2Red: rawSpo2FromFiller ? filler.spo2Red : winner.spo2Red,
+            spo2Ir: rawSpo2FromFiller ? filler.spo2Ir : winner.spo2Ir
+        )
     }
 
     /// metricSeries points across the imported union for a key + day range, DEDUPED per day with the active
@@ -296,8 +332,8 @@ final class Repository: ObservableObject {
     private func unionComputedDailyMetrics(store: WhoopStore, from: String, to: String) async -> [DailyMetric] {
         var byDay: [String: DailyMetric] = [:]
         for id in computedReadIds {
-            for m in (try? await store.dailyMetrics(deviceId: id, from: from, to: to)) ?? [] where byDay[m.day] == nil {
-                byDay[m.day] = m
+            for m in (try? await store.dailyMetrics(deviceId: id, from: from, to: to)) ?? [] {
+                byDay[m.day] = byDay[m.day].map { Self.coalesceDay($0, m) } ?? m
             }
         }
         return byDay.values.sorted { $0.day < $1.day }

--- a/StrandTests/ReadSpineUnionTests.swift
+++ b/StrandTests/ReadSpineUnionTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+import WhoopStore
+@testable import Strand
+
+/// #-: the per-column duplicate-day coalesce (`Repository.coalesceDay`). Byte-identical twin of the Android
+/// `ReadSpineUnionTest` cases (same fixtures, same numbers). A day two source ids in the SAME bucket both
+/// cover is folded per column — the winner keeps every column it carries and the filler supplies only the
+/// nils — with the sleep block and the raw red/IR pair moving as whole groups. Ported from
+/// tanarchytan/noop @de370b85.
+final class ReadSpineUnionTests: XCTestCase {
+
+    /// Swift `DailyMetric` carries no `deviceId` (external to the row); the value columns are the parity
+    /// contract, so the fixtures set only those.
+    private func dm(_ day: String,
+                    totalSleepMin: Double? = nil, efficiency: Double? = nil, deepMin: Double? = nil,
+                    remMin: Double? = nil, lightMin: Double? = nil, disturbances: Int? = nil,
+                    restingHr: Int? = nil, avgHrv: Double? = nil, recovery: Double? = nil,
+                    strain: Double? = nil, exerciseCount: Int? = nil, steps: Int? = nil) -> DailyMetric {
+        DailyMetric(day: day, totalSleepMin: totalSleepMin, efficiency: efficiency, deepMin: deepMin,
+                    remMin: remMin, lightMin: lightMin, disturbances: disturbances, restingHr: restingHr,
+                    avgHrv: avgHrv, recovery: recovery, strain: strain, exerciseCount: exerciseCount,
+                    steps: steps)
+    }
+
+    /// A hollow winner (steps and nothing else) keeps every column the other strap's fully-scored row
+    /// carries, instead of the old whole-row first-wins that discarded it.
+    func testAHollowWinningRowKeepsTheOtherStrapsColumns() {
+        let day = "2026-07-29"
+        let active = dm(day, steps: 10_775)
+        let other = dm(day, totalSleepMin: 435, efficiency: 91, deepMin: 96, remMin: 110, lightMin: 229,
+                       restingHr: 64, avgHrv: 37.06, recovery: 93.2, strain: 8.4)
+        let merged = Repository.coalesceDay(active, other)
+        XCTAssertEqual(merged.steps, 10_775)          // the winner's own reading survives
+        XCTAssertEqual(merged.totalSleepMin, 435)
+        XCTAssertEqual(merged.deepMin, 96)
+        XCTAssertEqual(merged.recovery, 93.2)
+        XCTAssertEqual(merged.restingHr, 64)
+        XCTAssertEqual(merged.avgHrv ?? 0, 37.06, accuracy: 1e-9)
+        XCTAssertEqual(merged.strain, 8.4)
+    }
+
+    /// A measured zero is a READING, not an absence — a 0 steps / 0 strain / 0 HRV winner is kept.
+    func testAMeasuredZeroIsAValueNotAnAbsence() {
+        let day = "2026-07-29"
+        let active = dm(day, avgHrv: 0, strain: 0, steps: 0)
+        let other = dm(day, avgHrv: 42, strain: 14.7, steps: 9_120)
+        let merged = Repository.coalesceDay(active, other)
+        XCTAssertEqual(merged.steps, 0)
+        XCTAssertEqual(merged.strain, 0)
+        XCTAssertEqual(merged.avgHrv, 0)
+    }
+
+    /// The sleep block moves as a GROUP: a winner carrying a sleep total keeps its OWN (nil) stages rather
+    /// than borrowing the other strap's — a total never sits beside foreign stages.
+    func testASleepBlockIsNeverAssembledFromTwoStraps() {
+        let day = "2026-07-29"
+        let active = dm(day, totalSleepMin: 402)
+        let other = dm(day, totalSleepMin: 435, deepMin: 96, remMin: 110, lightMin: 229)
+        let merged = Repository.coalesceDay(active, other)
+        XCTAssertEqual(merged.totalSleepMin, 402)     // the winner's total stands
+        XCTAssertNil(merged.deepMin)                  // stages must not be borrowed
+        XCTAssertNil(merged.remMin)
+        XCTAssertNil(merged.lightMin)
+    }
+}

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -2119,9 +2119,57 @@ class WhoopRepository(
         internal fun unionByDay(lists: List<List<DailyMetric>>): List<DailyMetric> {
             if (lists.size == 1) return lists[0]
             val byDay = LinkedHashMap<String, DailyMetric>()
-            // First list wins: only fill a day a later (lower-precedence) list covers and an earlier one didn't.
-            for (list in lists) for (d in list) byDay.putIfAbsent(d.day, d)
+            // A day two ids in this bucket both cover is coalesced per COLUMN ([coalesceDay]), not taken
+            // whole: the earlier (active) list keeps every column it carries and later lists fill only what
+            // it left null. Whole-row first-wins let a hollow row (steps and nothing else) discard a
+            // complete one, and nothing downstream healed it — [mergeDaily] only bridges imported/computed/
+            // phone, never two straps. Ported from tanarchytan/noop @de370b85.
+            for (list in lists) for (d in list) {
+                val held = byDay[d.day]
+                byDay[d.day] = if (held == null) d else coalesceDay(held, d)
+            }
             return byDay.values.toList()
+        }
+
+        /**
+         * One day held by two source ids in the SAME bucket, folded into [winner]'s row: [winner] keeps
+         * every column it carries and [filler] supplies only the ones it left null. "Carries" is NON-NULL,
+         * so a measured zero (no steps, no strain) is a value and is never overwritten.
+         *
+         * Columns that only mean something together are taken as a GROUP, whole and from one row, so a
+         * sleep total never sits beside another strap's stage minutes: the sleep block, and the raw red/IR
+         * PPG pair. A group moves only when [winner] is null across the WHOLE group. [winner]'s deviceId +
+         * day stay, so the folded row keeps the identity the union already gave it. Across-bucket precedence
+         * ([mergeDaily]) is untouched. Ported from tanarchytan/noop @de370b85, reduced to the columns this
+         * DailyMetric carries (upstream has no sleep-need / recovery-index / HR-zone / skin-abs columns).
+         * Byte-identical twin of Swift Repository.coalesceDay.
+         */
+        internal fun coalesceDay(winner: DailyMetric, filler: DailyMetric): DailyMetric {
+            val sleepFromFiller = winner.totalSleepMin == null && winner.efficiency == null &&
+                winner.deepMin == null && winner.remMin == null && winner.lightMin == null &&
+                winner.disturbances == null
+            val rawSpo2FromFiller = winner.spo2Red == null && winner.spo2Ir == null
+            return winner.copy(
+                totalSleepMin = if (sleepFromFiller) filler.totalSleepMin else winner.totalSleepMin,
+                efficiency = if (sleepFromFiller) filler.efficiency else winner.efficiency,
+                deepMin = if (sleepFromFiller) filler.deepMin else winner.deepMin,
+                remMin = if (sleepFromFiller) filler.remMin else winner.remMin,
+                lightMin = if (sleepFromFiller) filler.lightMin else winner.lightMin,
+                disturbances = if (sleepFromFiller) filler.disturbances else winner.disturbances,
+                spo2Red = if (rawSpo2FromFiller) filler.spo2Red else winner.spo2Red,
+                spo2Ir = if (rawSpo2FromFiller) filler.spo2Ir else winner.spo2Ir,
+                // Independent columns: each stands alone, so a plain per-column fill is safe.
+                restingHr = winner.restingHr ?: filler.restingHr,
+                avgHrv = winner.avgHrv ?: filler.avgHrv,
+                recovery = winner.recovery ?: filler.recovery,
+                strain = winner.strain ?: filler.strain,
+                exerciseCount = winner.exerciseCount ?: filler.exerciseCount,
+                spo2Pct = winner.spo2Pct ?: filler.spo2Pct,
+                skinTempDevC = winner.skinTempDevC ?: filler.skinTempDevC,
+                respRateBpm = winner.respRateBpm ?: filler.respRateBpm,
+                steps = winner.steps ?: filler.steps,
+                activeKcalEst = winner.activeKcalEst ?: filler.activeKcalEst,
+            )
         }
 
         /**

--- a/android/app/src/test/java/com/noop/data/ReadSpineUnionTest.kt
+++ b/android/app/src/test/java/com/noop/data/ReadSpineUnionTest.kt
@@ -1,6 +1,7 @@
 package com.noop.data
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -95,5 +96,58 @@ class ReadSpineUnionTest {
         val union = WhoopRepository.unionByDay(listOf(active, canonicalOnly))
         // mergeDaily re-sorts oldest-first downstream; here assert the day SET is the union.
         assertTrue(union.map { it.day }.toSet() == setOf("2026-06-09", "2026-06-13"))
+    }
+
+    /** #-: a day two straps in the bucket both cover is coalesced per COLUMN, not taken whole — a hollow
+     *  winner (steps and nothing else) keeps every column the other strap's fully-scored row carries,
+     *  instead of the old whole-row first-wins that discarded it. Ported from tanarchytan/noop @de370b85. */
+    @Test
+    fun aHollowWinningRowKeepsTheOtherStrapsColumns() {
+        val day = "2026-07-29"
+        val active = DailyMetric(deviceId = "$reAdded-noop", day = day, steps = 10_775)
+        val other = DailyMetric(
+            deviceId = "$canonical-noop", day = day,
+            totalSleepMin = 435.0, efficiency = 91.0, deepMin = 96.0, remMin = 110.0, lightMin = 229.0,
+            recovery = 93.2, restingHr = 64, avgHrv = 37.06, strain = 8.4,
+        )
+        val merged = WhoopRepository.unionByDay(listOf(listOf(active), listOf(other))).single()
+        assertEquals("the winner's identity is kept", "$reAdded-noop", merged.deviceId)
+        assertEquals("the winner's own steps survive", 10_775, merged.steps)
+        assertEquals(435.0, merged.totalSleepMin)
+        assertEquals(96.0, merged.deepMin)
+        assertEquals(93.2, merged.recovery)
+        assertEquals(64, merged.restingHr)
+        assertEquals(37.06, merged.avgHrv)
+        assertEquals(8.4, merged.strain)
+    }
+
+    /** A measured zero is a READING, not an absence: a hollow-looking 0 steps / 0 strain / 0 HRV on the
+     *  winner is kept ("carries" is non-null), never overwritten by the other strap's value. */
+    @Test
+    fun aMeasuredZeroIsAValueNotAnAbsence() {
+        val day = "2026-07-29"
+        val active = DailyMetric(deviceId = reAdded, day = day, steps = 0, strain = 0.0, avgHrv = 0.0)
+        val other = DailyMetric(deviceId = canonical, day = day, steps = 9_120, strain = 14.7, avgHrv = 42.0)
+        val merged = WhoopRepository.unionByDay(listOf(listOf(active), listOf(other))).single()
+        assertEquals("zero steps is a reading", 0, merged.steps)
+        assertEquals("zero strain is a reading", 0.0, merged.strain)
+        assertEquals("zero HRV is a reading", 0.0, merged.avgHrv)
+    }
+
+    /** The sleep block moves as a GROUP from one row: a winner that carries a sleep total keeps its OWN
+     *  (null) stages rather than borrowing the other strap's — a total never sits beside foreign stages. */
+    @Test
+    fun aSleepBlockIsNeverAssembledFromTwoStraps() {
+        val day = "2026-07-29"
+        val active = DailyMetric(deviceId = reAdded, day = day, totalSleepMin = 402.0)
+        val other = DailyMetric(
+            deviceId = canonical, day = day,
+            totalSleepMin = 435.0, deepMin = 96.0, remMin = 110.0, lightMin = 229.0,
+        )
+        val merged = WhoopRepository.unionByDay(listOf(listOf(active), listOf(other))).single()
+        assertEquals("the winner's total stands", 402.0, merged.totalSleepMin)
+        assertNull("stages must not be borrowed from the other strap", merged.deepMin)
+        assertNull(merged.remMin)
+        assertNull(merged.lightMin)
     }
 }


### PR DESCRIPTION
## The bug
`unionByDay` folded a day that two source ids in the **same bucket** both cover with **whole-row first-wins**, so the row from whichever strap is marked active discarded the other one entirely. The tiebreak is read-scope order — a *setting*, not a data-quality signal — and nothing downstream healed it: `mergeDaily`'s per-field coalesce bridges imported/computed/phone *across* buckets, never two straps *within* one.

On a real store, a day whose active row carried **steps and nothing else** rendered with no sleep, no recovery, no resting HR and no HRV — while a fully-scored row for that day sat right beside it.

## The fix — coalesce per column
The earlier (active) row keeps every column it **carries** (non-null, so a *measured zero* is a reading, never overwritten), and later rows fill only what it left null. Columns that only mean something **together move as a group** from one row — the **sleep block**, and the **raw red/IR PPG pair** — so a total never sits beside another strap's stages. Across-bucket precedence (`mergeDaily`) is untouched.

## Both platforms, byte-identical
- **Kotlin**: `WhoopRepository.unionByDay` → `coalesceDay` (covers both the imported and computed unions it feeds).
- **Swift**: `Repository.coalesceDay`, applied in **both** `unionDailyMetrics` and `unionComputedDailyMetrics`.
- Tests on both (`ReadSpineUnionTest` / new `ReadSpineUnionTests`) pin hollow-winner-keeps-columns, measured-zero-is-a-reading, and sleep-block-not-assembled-from-two-straps — identical fixtures/numbers.

## Provenance
Ported from **tanarchytan/noop @de370b85**, reimplemented natively and **reduced to the columns this `DailyMetric` carries** (upstream has no sleep-need / recovery-index / HR-zone / skin-abs columns the fork's schema added).

## Verification
- Android `testFullDebugUnitTest --tests ReadSpineUnionTest` ✅ locally.
- **app-build** running (`Repository.swift` is app-target Swift; the new `StrandTests` case runs in its Test-Strand step).
- Stored-data merge logic — the byte-identical contract applies and is now test-locked on both sides.