### PR TITLE
fix(diagnostics): read Last sleep/recov from the merged spine, not the import spine

### DIFF
--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -64,8 +64,13 @@ object AndroidDiagnostics {
             val repo = com.noop.data.WhoopRepository.from(context)
             val days = repo.days("my-whoop")
             add("History:     ${days.size} day rows (my-whoop spine)")
-            add("Last sleep:  ${days.lastOrNull { (it.totalSleepMin ?: 0.0) > 0.0 }?.let { "${it.day} · ${it.totalSleepMin?.toInt()} min" } ?: "none"}")
-            add("Last recov.: ${days.lastOrNull { it.recovery != null }?.let { "${it.day} · ${it.recovery?.toInt()}%" } ?: "none"}")
+            // Last sleep/recov read the MERGED view (imported ∪ computed), not the import spine alone: a
+            // strap-only user's freshest scored day lives under the "-noop" computed sibling, so reading the
+            // spine showed a stale value (could be a month old) while the app displayed today's. Twin of
+            // Swift DebugDataDiagnostics, which already reads the merged `repo.days`.
+            val merged = repo.daysMerged("my-whoop")
+            add("Last sleep:  ${merged.lastOrNull { (it.totalSleepMin ?: 0.0) > 0.0 }?.let { "${it.day} · ${it.totalSleepMin?.toInt()} min" } ?: "none"}")
+            add("Last recov.: ${merged.lastOrNull { it.recovery != null }?.let { "${it.day} · ${it.recovery?.toInt()}%" } ?: "none"}")
         }.onFailure { add("(strap/data state unavailable: ${it.message})") }
     }
 


### PR DESCRIPTION
Found in a real testing-build capture (`9.3.2-staging`, WHOOP 4.0): the strap-log header read **"Last sleep: 2026-07-07"** while the app was displaying — and actively scoring — **2026-08-09** (data landing every few minutes).

## Cause — a Kotlin-only divergence
`AndroidDiagnostics` built "Last sleep" / "Last recov." from `repo.days("my-whoop")` — the **imported spine only**. A strap-only user's freshest scored day lives under the **`-noop` computed sibling**, so the import spine can trail the real latest by weeks. Swift's `DebugDataDiagnostics` already reads the **merged** view (`repo.days` = `merged.days`), so only Android was wrong.

## Fix
Read the merged view (`daysMerged`, imported ∪ computed) for those two lines — what the app itself shows. The `History: N day rows (my-whoop spine)` count deliberately stays the import-spine diagnostic.

## Verification
- `compileFullDebugKotlin` ✅. Android-only, diagnostics/export copy only — no analytics/stored-data change, no app-target Swift.