### PR TITLE
feat(diagnostics): attribute forced re-scores as newData yes/no (battery)

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -388,6 +388,16 @@ final class IntelligenceEngine: ObservableObject {
            UserDefaults.standard.string(forKey: Self.analyzeWatermarkKey) == wmKey {
             return
         }
+        // Attribute a FORCED re-score. A completed offload / edit / recalibrate always re-scores
+        // (force: true) past the gate above, so an empty/duplicate offload — nothing changed since the last
+        // run — still pays for a full maxDays pass over the whole raw store (#1146). `newData=no` means the
+        // fingerprint already equals the watermark the last run advanced: a re-score driven by the trigger,
+        // not by data (#1005 background battery). Diagnostic only; the pass still runs. Twin of the Android
+        // WhoopBleClient post-offload attribution.
+        if force {
+            let hadNew = wmKey.isEmpty || UserDefaults.standard.string(forKey: Self.analyzeWatermarkKey) != wmKey
+            diagnosticSink?("re-score: trigger=forced newData=\(hadNew ? "yes" : "no (nothing changed since last run)")", nil)
+        }
 
         computing = true
         // #899-A re-arm: clear the lock, then if a forced rescore was dropped while this pass held it,

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2149,6 +2149,16 @@ class WhoopBleClient(
                 // this brings Android into lockstep. Captured before the run, written only on success, so an
                 // interrupted/failed pass can never advance the watermark past unscored data.
                 val analyzeFp = repository.hrFingerprint()
+                // Attribute this forced post-offload re-score. A completed offload ALWAYS re-scores (#836),
+                // so an EMPTY/duplicate offload (rows=0, common on a flapping link) still pays for a full
+                // ~18-day pass over the whole raw store (#1146). Compare the pre-run HR fingerprint
+                // (rowCount:maxTs) to the watermark the last successful run advanced: `newData=no` means
+                // nothing changed since the last run — a re-score driven purely by the reconnect+offload, not
+                // by data. These lines quantify the background battery cost (#1005). Log-only; behaviour is
+                // unchanged (the pass still runs, matching Swift's force-re-score after a completed backfill).
+                log("re-score: trigger=post-offload newData=" +
+                    if (analyzeFp != NoopPrefs.analyzeWatermark(context)) "yes"
+                    else "no (empty/duplicate offload — nothing changed since last run)")
                 runCatching {
                     IntelligenceEngine.analyzeRecent(
                         repo = repository,


### PR DESCRIPTION
## Why
A testing-build capture (WHOOP 4.0, flapping link) showed **~186 full 18-day `analyzeRecent` sweeps in 7.5 hours** — but the strap log never said *why* each ran or whether new data drove it, so the empty-offload re-score waste behind **#1005** / **#1146** couldn't be quantified.

## What it measures
The post-offload pass re-scores with **`force: true` on both platforms** (Swift's `analyzeRecent(force: Bool = true)` default; Android's #836 forced pass), so a completed but **empty/duplicate offload (`rows=0`, common on a flapping link) still folds the whole raw store for zero new data**. This adds one line at that forced re-score:
```
re-score: trigger=post-offload newData=no (empty/duplicate offload — nothing changed since last run)
```
`newData=no` compares the pre-run HR fingerprint (`rowCount:maxTs`) to the watermark the last successful run advanced. Those lines *are* the wasted re-scores — turning "186 sweeps" into a measured count of how many folded 18M rows for nothing.

- **Android**: at the `WhoopBleClient` post-offload trigger (vs `NoopPrefs.analyzeWatermark`).
- **Swift**: inside `analyzeRecent`, gated on `force`, using the fingerprint it already computes (:385).

## Scope
**Log-only, no behaviour change** — the pass still runs. I deliberately did **not** touch the re-score/reconnect logic (the analyzeRecent skip is a known data-loss trap); this measures first, per the instrument-first pattern (#1117, #688). The **reconnect backoff-reset** half is already legible in the existing `attempt N, held Xs` line **by design** (see the `linkUpSinceMs` comment — "a run of drops that all say `attempt 1` with a short `held` is that bug, with no instrumentation needed"), so no new logging there.

## Verification
- `compileFullDebugKotlin` ✅; **app-build** running (`IntelligenceEngine.swift` is app-target). Diagnostic sink line only — no analytics/stored-data change.