### PR TITLE
Add "Forget device" hard-delete for archived rows (iOS + Android) — #1193 cleanup

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
@@ -48,6 +48,20 @@ public struct DeviceRegistryStore: Sendable {
         }
     }
 
+    /// Permanently remove a device's REGISTRY entry — both the `pairedDevice` row the Devices screen
+    /// lists and its `device` provenance row — so a duplicate/stale strap can be purged entirely
+    /// instead of lingering in the archived "Removed" list forever (issue #1193: today the only
+    /// removal is the soft `archive`, and `deleteAllData` empties recordings but leaves the row). The
+    /// device's recorded SAMPLES are NOT touched here — the caller wipes those first via
+    /// `deleteAllData(deviceId:)` (registry entry vs. recordings are separate ops, exactly as
+    /// `adoptSerialIdentity` treats them). Idempotent: removing an absent id is a no-op.
+    public func remove(_ id: String) throws {
+        try dbQueue.write { db in
+            try db.execute(sql: "DELETE FROM pairedDevice WHERE id = ?", arguments: [id])
+            try db.execute(sql: "DELETE FROM device WHERE id = ?", arguments: [id])
+        }
+    }
+
     public func rename(_ id: String, nickname: String?) throws {
         try dbQueue.write { db in
             try db.execute(sql: "UPDATE pairedDevice SET nickname = ? WHERE id = ?", arguments: [nickname, id])

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/DeviceRegistryStoreTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/DeviceRegistryStoreTests.swift
@@ -36,6 +36,23 @@ final class DeviceRegistryStoreTests: XCTestCase {
         XCTAssertNil(try store.activeDeviceId())
     }
 
+    // #1193: unlike `archive` (which keeps the row so it lingers in "Removed"), `remove` hard-deletes the
+    // registry entry so a duplicate/stale strap can be purged entirely — and touches only the given id.
+    func testRemoveDeletesOnlyTheGivenRegistryRow() throws {
+        let store = DeviceRegistryStore(dbQueue: try makeDB())
+        try store.add(PairedDevice(id: "whoop-DEAD", brand: "WHOOP", model: "4.0", sourceKind: .liveBLE,
+                                   capabilities: [.hr], status: .archived, addedAt: 2, lastSeenAt: 2))
+        XCTAssertEqual(Set(try store.all().map(\.id)), ["my-whoop", "whoop-DEAD"])
+        try store.remove("whoop-DEAD")
+        XCTAssertEqual(try store.all().map(\.id), ["my-whoop"])     // duplicate purged, seed untouched
+    }
+
+    func testRemoveIsANoOpForAnAbsentId() throws {
+        let store = DeviceRegistryStore(dbQueue: try makeDB())
+        try store.remove("whoop-never-existed")                    // must not throw
+        XCTAssertEqual(try store.all().map(\.id), ["my-whoop"])
+    }
+
     func testSeededWhoopHasNilPeripheralId() throws {
         // v16 applies cleanly: the seeded my-whoop row exists with peripheralId nil (it connects to
         // "any WHOOP" today; it adopts its peripheral id later).

--- a/Strand/Data/DeviceRegistry.swift
+++ b/Strand/Data/DeviceRegistry.swift
@@ -100,6 +100,23 @@ final class DeviceRegistry: ObservableObject {
         reload()
     }
 
+    /// Permanently FORGET a device: wipe all of its recorded data AND remove its registry entry, so a
+    /// duplicate/stale strap disappears from the Devices list entirely. Today an archived ("Removed")
+    /// row can only be re-activated or have its data wiped — never purged — so a duplicate strap lingers
+    /// forever (issue #1193). Routes the heavy multi-table sample wipe through the `WhoopStore` actor
+    /// (off-main, like `deleteDeviceData`), then removes the small `pairedDevice`/`device` registry rows
+    /// and refreshes the published list. Best-effort: if the data wipe fails the registry row is left in
+    /// place (we never leave orphaned recordings behind a removed row).
+    func forget(_ id: String, store: WhoopStore) async {
+        do {
+            try await store.deleteAllData(deviceId: id)
+        } catch {
+            return
+        }
+        try? self.store.remove(id)
+        reload()
+    }
+
     /// Adopt (or clear, when nil) the stable BLE identity for a device — the
     /// CBPeripheral.identifier.uuidString on iOS/Mac. Lets NOOP tell physical straps apart and map a
     /// connected peripheral back to its registry row. Refreshes the published list. Best-effort.

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -157,54 +157,54 @@
         }
       }
     },
-    "NOOP removes this device from your list and permanently deletes all of its recorded data. This can't be undone.": {
+    "NOOP removes this device from your list and deletes its recorded data here. You can re-pair the strap to pull its recent history back.": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "NOOP entfernt dieses Gerät aus deiner Liste und löscht dauerhaft alle aufgezeichneten Daten. Das kann nicht rückgängig gemacht werden."
+            "value": "NOOP entfernt dieses Gerät aus deiner Liste und löscht die hier aufgezeichneten Daten. Du kannst den Strap erneut koppeln, um den jüngsten Verlauf wieder abzurufen."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "NOOP quita este dispositivo de tu lista y elimina permanentemente todos sus datos registrados. No se puede deshacer."
+            "value": "NOOP quita este dispositivo de tu lista y elimina los datos registrados aquí. Puedes volver a emparejar la banda para recuperar su historial reciente."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "NOOP retire cet appareil de votre liste et supprime définitivement toutes ses données enregistrées. Cette action est irréversible."
+            "value": "NOOP retire cet appareil de votre liste et supprime les données enregistrées ici. Vous pouvez ré-appairer le bracelet pour récupérer son historique récent."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "NOOP rimuove questo dispositivo dal tuo elenco ed elimina definitivamente tutti i suoi dati registrati. L’operazione non può essere annullata."
+            "value": "NOOP rimuove questo dispositivo dal tuo elenco ed elimina i dati registrati qui. Puoi riassociare la fascia per recuperare la cronologia recente."
           }
         },
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "O NOOP remove este dispositivo da tua lista e elimina permanentemente todos os seus dados registados. Esta ação não pode ser anulada."
+            "value": "O NOOP remove este dispositivo da tua lista e elimina os dados registados aqui. Podes voltar a emparelhar a banda para obter novamente o histórico recente."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "NOOP удалит это устройство из вашего списка и безвозвратно удалит все записанные им данные. Это действие нельзя отменить."
+            "value": "NOOP удаляет это устройство из вашего списка и стирает записанные здесь данные. Вы можете заново подключить ремешок, чтобы снова загрузить его недавнюю историю."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "NOOP 会从你的列表中移除此设备，并永久删除其记录的所有数据。此操作无法撤销。"
+            "value": "NOOP 会从你的列表中移除此设备，并删除此处记录的数据。你可以重新配对设备，以再次获取其最近的历史记录。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "NOOP 會從你的清單中移除此裝置，並永久刪除其記錄的所有資料。此操作無法復原。"
+            "value": "NOOP 會從你的清單中移除此裝置，並刪除此處記錄的資料。你可以重新配對裝置，以再次取得其最近的歷史記錄。"
           }
         }
       }

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -1,6 +1,214 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "Forget device": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerät vergessen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olvidar dispositivo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oublier l'appareil"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dimentica dispositivo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esquecer dispositivo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Забыть устройство"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "忘记设备"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "忘記裝置"
+          }
+        }
+      }
+    },
+    "Forget device…": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerät vergessen…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olvidar dispositivo…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oublier l'appareil…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dimentica dispositivo…"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esquecer dispositivo…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Забыть устройство…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "忘记设备…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "忘記裝置…"
+          }
+        }
+      }
+    },
+    "Forget this device?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Gerät vergessen?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Olvidar este dispositivo?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oublier cet appareil ?"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dimenticare questo dispositivo?"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esquecer este dispositivo?"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Забыть это устройство?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "忘记此设备？"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "忘記此裝置？"
+          }
+        }
+      }
+    },
+    "NOOP removes this device from your list and permanently deletes all of its recorded data. This can't be undone.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP entfernt dieses Gerät aus deiner Liste und löscht dauerhaft alle aufgezeichneten Daten. Das kann nicht rückgängig gemacht werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP quita este dispositivo de tu lista y elimina permanentemente todos sus datos registrados. No se puede deshacer."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP retire cet appareil de votre liste et supprime définitivement toutes ses données enregistrées. Cette action est irréversible."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP rimuove questo dispositivo dal tuo elenco ed elimina definitivamente tutti i suoi dati registrati. L’operazione non può essere annullata."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O NOOP remove este dispositivo da tua lista e elimina permanentemente todos os seus dados registados. Esta ação não pode ser anulada."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP удалит это устройство из вашего списка и безвозвратно удалит все записанные им данные. Это действие нельзя отменить."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP 会从你的列表中移除此设备，并永久删除其记录的所有数据。此操作无法撤销。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOOP 會從你的清單中移除此裝置，並永久刪除其記錄的所有資料。此操作無法復原。"
+          }
+        }
+      }
+    },
     "": {
       "localizations": {
         "de": {

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -1165,9 +1165,6 @@ private struct ExtendedBatteryProbeResultView: View {
     }
 }
 
-/// #690: the body-location probe's confirm + result dialogs as one ViewModifier, so they're type-checked
-/// in isolation instead of extending the DevicesView `.confirmationDialog`/`.sheet` chain (which is already
-/// near the iOS Swift type-checker's budget). `model`/`live` auto-inject from the parent's environment.
 /// The hard-delete ("Forget device") confirm for an archived row (#1193). Isolated into its own
 /// ViewModifier — like the probe sheets below — so this extra dialog doesn't push the DevicesContent
 /// body over the iOS Swift type-checker budget. `registry` is threaded in (it's an `@ObservedObject`
@@ -1201,6 +1198,9 @@ private struct ForgetDeviceSheet: ViewModifier {
     }
 }
 
+/// #690: the body-location probe's confirm + result dialogs as one ViewModifier, so they're type-checked
+/// in isolation instead of extending the DevicesView `.confirmationDialog`/`.sheet` chain (which is already
+/// near the iOS Swift type-checker's budget). `model`/`live` auto-inject from the parent's environment.
 private struct BodyLocationProbeSheets: ViewModifier {
     @EnvironmentObject var model: AppModel
     @EnvironmentObject var live: LiveState

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -57,6 +57,7 @@ private struct DevicesContent: View {
     @State private var renameDraft = ""
     @State private var removeTarget: PairedDevice?
     @State private var deleteDataTarget: PairedDevice?
+    @State private var forgetTarget: PairedDevice?
     @State private var rebootTarget: PairedDevice?
     /// WHOOP 4.0 reboot probe (Test Centre → Connection, 4.0 only) — the device whose probe sheet is open.
     @State private var probeTarget: PairedDevice?
@@ -363,6 +364,11 @@ private struct DevicesContent: View {
         } message: { device in
             Text("This permanently deletes all data recorded from \(device.displayName). This can't be undone.")
         }
+        // Hard-delete confirm (reached from a REMOVED card's ⋮ menu): purge the registry entry itself,
+        // not just its data — the only way to get a duplicate/stale strap out of the list for good (#1193).
+        // Isolated into its own ViewModifier for the same iOS type-checker-budget reason as the probe
+        // sheets above (the dialog chain is already near the limit; a 6th/7th inline modifier tips it over).
+        .modifier(ForgetDeviceSheet(registry: registry, target: $forgetTarget))
         // After removing the active device, offer to pick a new active one (if any remain).
         .confirmationDialog("Pick a new active strap",
                             isPresented: $pickNewActive,
@@ -400,7 +406,8 @@ private struct DevicesContent: View {
                     onRename: { renameDraft = device.nickname ?? device.displayName; renameTarget = device },
                     onRemove: nil,
                     onReAdd: { registry.setActive(device.id) },
-                    onDeleteData: { deleteDataTarget = device })
+                    onDeleteData: { deleteDataTarget = device },
+                    onForget: { forgetTarget = device })
             }
         }
     }
@@ -606,9 +613,12 @@ private struct DeviceCard: View {
     /// #103 device-config READ probe (Test Centre → Connection, both WHOOP families). Read-only: it asks
     /// the strap for a config key's VALUE and writes none.
     var onDeviceConfigProbe: (() -> Void)? = nil
-    /// Removed-section affordances (re-add as active / delete its data).
+    /// Removed-section affordances (re-add as active / delete its data / forget it entirely).
     var onReAdd: (() -> Void)? = nil
     var onDeleteData: (() -> Void)? = nil
+    /// Hard-delete: purge the registry entry itself (and its data), so a duplicate/stale strap can be
+    /// removed from the list for good rather than lingering in "Removed" forever (#1193). Archived-only.
+    var onForget: (() -> Void)? = nil
 
     /// The card's visible content. The required `body` wraps this in the whole-card liquid press button +
     /// the ⋮ menu overlay.
@@ -832,6 +842,13 @@ private struct DeviceCard: View {
                     Divider()
                     Button(role: .destructive) { onDeleteData() } label: {
                         Label("Delete this device's data…", systemImage: "trash")
+                    }
+                }
+                // Purge the registry entry itself — the only way to get a duplicate/stale strap out of
+                // the "Removed" list for good (#1193). Below "Delete data" as the stronger, final action.
+                if let onForget {
+                    Button(role: .destructive) { onForget() } label: {
+                        Label("Forget device…", systemImage: "trash.slash")
                     }
                 }
             } else {
@@ -1151,6 +1168,39 @@ private struct ExtendedBatteryProbeResultView: View {
 /// #690: the body-location probe's confirm + result dialogs as one ViewModifier, so they're type-checked
 /// in isolation instead of extending the DevicesView `.confirmationDialog`/`.sheet` chain (which is already
 /// near the iOS Swift type-checker's budget). `model`/`live` auto-inject from the parent's environment.
+/// The hard-delete ("Forget device") confirm for an archived row (#1193). Isolated into its own
+/// ViewModifier — like the probe sheets below — so this extra dialog doesn't push the DevicesContent
+/// body over the iOS Swift type-checker budget. `registry` is threaded in (it's an `@ObservedObject`
+/// param on `DevicesContent`, not an environment object).
+private struct ForgetDeviceSheet: ViewModifier {
+    @EnvironmentObject var model: AppModel
+    @ObservedObject var registry: DeviceRegistry
+    @Binding var target: PairedDevice?
+
+    func body(content: Content) -> some View {
+        content
+            .alert("Forget this device?",
+                   isPresented: Binding(get: { target != nil },
+                                        set: { if !$0 { target = nil } }),
+                   presenting: target) { device in
+                Button("Cancel", role: .cancel) { target = nil }
+                Button("Forget device", role: .destructive) {
+                    // Same off-main routing as delete-data: the sample wipe runs on the WhoopStore actor,
+                    // then the registry row is removed and the list reloads. Resolve the store handle
+                    // inside the Task so the main thread never blocks on it.
+                    let deviceId = device.id
+                    Task {
+                        guard let store = await model.repo.storeHandle() else { return }
+                        await registry.forget(deviceId, store: store)
+                    }
+                    target = nil
+                }
+            } message: { _ in
+                Text("NOOP removes this device from your list and permanently deletes all of its recorded data. This can't be undone.")
+            }
+    }
+}
+
 private struct BodyLocationProbeSheets: ViewModifier {
     @EnvironmentObject var model: AppModel
     @EnvironmentObject var live: LiveState

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -1193,7 +1193,7 @@ private struct ForgetDeviceSheet: ViewModifier {
                     target = nil
                 }
             } message: { _ in
-                Text("NOOP removes this device from your list and permanently deletes all of its recorded data. This can't be undone.")
+                Text("NOOP removes this device from your list and deletes its recorded data here. You can re-pair the strap to pull its recent history back.")
             }
     }
 }

--- a/android/app/src/main/java/com/noop/data/DeviceRegistry.kt
+++ b/android/app/src/main/java/com/noop/data/DeviceRegistry.kt
@@ -108,6 +108,22 @@ class DeviceRegistry(
     /** Archive a device — keeps its row and samples (invariant I4). */
     suspend fun archive(id: String) = dao.archiveDevice(id)
 
+    /**
+     * Permanently FORGET a device: wipe all of its recorded data AND remove its registry entry (both the
+     * `pairedDevice` row the Devices screen lists and its `device` provenance row), so a duplicate/stale
+     * strap can be purged entirely instead of lingering in the archived "Removed" list forever (#1193).
+     * Twin of the Swift `DeviceRegistry.forget`. The data wipe runs first (its own transaction, via
+     * [deleteDeviceData]), then the small registry-row deletes — registry entry vs. recordings are separate
+     * ops, exactly as [adoptSerialIdentity] treats them.
+     */
+    suspend fun forget(id: String) {
+        deleteDeviceData(id)
+        transactor.run {
+            dao.deletePairedDeviceRow(id)
+            dao.deleteDeviceRow(id)
+        }
+    }
+
     /** Update the model label for a device. Mirrors the Swift store's `setModel`. */
     suspend fun setModel(id: String, model: String) = dao.setModel(id, model)
 

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -226,6 +226,11 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     /** Permanently delete all of a device's recorded data (its registry row is kept). */
     suspend fun deletePairedDeviceData(id: String) = noopApp.deviceRegistry.deleteDeviceData(id)
 
+    /** Permanently forget a device: wipe all its recorded data AND remove its registry entry, so a
+     *  duplicate/stale strap disappears from the list entirely (an archived row could otherwise only be
+     *  re-activated or data-wiped, never purged — #1193). Twin of Swift `DeviceRegistry.forget`. */
+    suspend fun forgetPairedDevice(id: String) = noopApp.deviceRegistry.forget(id)
+
     /**
      * A DISCOVERY-ONLY [StandardHrSource] for the Add-a-strap wizard. It runs its OWN scan and never
      * connects or persists here — the [SourceCoordinator] owns connection once a strap becomes active.

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -492,7 +492,7 @@ fun DevicesScreen(
     forgetTarget?.let { device ->
         ConfirmDialog(
             title = uiString(R.string.l10n_devices_screen_forget_this_device_8dbbc3f3),
-            message = uiString(R.string.l10n_devices_screen_noop_removes_this_device_a9cb6b5b),
+            message = uiString(R.string.l10n_devices_screen_noop_removes_this_device_503aff9e),
             confirmLabel = uiString(R.string.l10n_devices_screen_forget_device_926e503d),
             destructive = true,
             onConfirm = {

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Circle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.GraphicEq
@@ -139,6 +140,7 @@ fun DevicesScreen(
     var renameTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     var removeTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     var deleteDataTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
+    var forgetTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     var rebootTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     // WHOOP 4.0 reboot probe (Test Centre → Connection, 4.0 only) — the device whose probe sheet is open.
     var probeTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
@@ -319,6 +321,7 @@ fun DevicesScreen(
                     onRemove = null,
                     onReAdd = { switchTarget = device },
                     onDeleteData = { deleteDataTarget = device },
+                    onForget = { forgetTarget = device },
                 )
             }
         }
@@ -484,6 +487,22 @@ fun DevicesScreen(
         )
     }
 
+    // --- Hard-delete confirm (from a Removed card's ⋮ menu): purge the registry entry itself, not just
+    //     its data — the only way to get a duplicate/stale strap out of the list for good (#1193). ---
+    forgetTarget?.let { device ->
+        ConfirmDialog(
+            title = uiString(R.string.l10n_devices_screen_forget_this_device_8dbbc3f3),
+            message = uiString(R.string.l10n_devices_screen_noop_removes_this_device_a9cb6b5b),
+            confirmLabel = uiString(R.string.l10n_devices_screen_forget_device_926e503d),
+            destructive = true,
+            onConfirm = {
+                scope.launch { viewModel.forgetPairedDevice(device.id); reload() }
+                forgetTarget = null
+            },
+            onDismiss = { forgetTarget = null },
+        )
+    }
+
     // --- After removing the active device, offer to pick a new active one (if any remain) ---
     if (pickNewActive) {
         PickActiveDialog(
@@ -533,6 +552,9 @@ private fun DeviceCard(
     onRemove: (() -> Unit)?,
     onReAdd: (() -> Unit)? = null,
     onDeleteData: (() -> Unit)? = null,
+    /** Hard-delete: purge the registry entry itself (and its data), so a duplicate/stale strap can be
+     *  removed from the list for good rather than lingering in "Removed" forever (#1193). Archived-only. */
+    onForget: (() -> Unit)? = null,
     onConnect: (() -> Unit)? = null,
     onDisconnect: (() -> Unit)? = null,
     onReboot: (() -> Unit)? = null,
@@ -660,6 +682,7 @@ private fun DeviceCard(
                     onRemove = onRemove,
                     onReAdd = onReAdd,
                     onDeleteData = onDeleteData,
+                    onForget = onForget,
                     onConnect = onConnect,
                     onDisconnect = onDisconnect,
                     onReboot = onReboot,
@@ -783,6 +806,7 @@ private fun DeviceActionsMenu(
     onRemove: (() -> Unit)?,
     onReAdd: (() -> Unit)?,
     onDeleteData: (() -> Unit)?,
+    onForget: (() -> Unit)? = null,
     onConnect: (() -> Unit)? = null,
     onDisconnect: (() -> Unit)? = null,
     onReboot: (() -> Unit)? = null,
@@ -816,6 +840,13 @@ private fun DeviceActionsMenu(
                     HorizontalDivider(color = Palette.hairline)
                     MenuItem(uiString(R.string.l10n_devices_screen_delete_this_device_s_data_3cae7a2a), Icons.Filled.Delete, destructive = true) {
                         onOpenChange(false); onDeleteData()
+                    }
+                }
+                // Purge the registry entry itself — the only way to get a duplicate/stale strap out of the
+                // "Removed" list for good (#1193). Below "Delete data" as the stronger, final action.
+                if (onForget != null) {
+                    MenuItem(uiString(R.string.l10n_devices_screen_forget_device_d6eb6209), Icons.Filled.DeleteForever, destructive = true) {
+                        onOpenChange(false); onForget()
                     }
                 }
             } else {

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1930,4 +1930,8 @@
     <string name="settings_trend_bars">Balken</string>
     <string name="spo2_strap_estimate_caption">Armband-Schätzung (unbestätigt)</string>
     <string name="spo2_toggle_on_no_data">Schalter EIN · keine @82-Daten</string>
+    <string name="l10n_devices_screen_forget_device_d6eb6209">Gerät vergessen…</string>
+    <string name="l10n_devices_screen_forget_device_926e503d">Gerät vergessen</string>
+    <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">Dieses Gerät vergessen?</string>
+    <string name="l10n_devices_screen_noop_removes_this_device_a9cb6b5b">NOOP entfernt dieses Gerät aus deiner Liste und löscht dauerhaft alle aufgezeichneten Daten. Das kann nicht rückgängig gemacht werden.</string>
 </resources>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1933,5 +1933,5 @@
     <string name="l10n_devices_screen_forget_device_d6eb6209">Gerät vergessen…</string>
     <string name="l10n_devices_screen_forget_device_926e503d">Gerät vergessen</string>
     <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">Dieses Gerät vergessen?</string>
-    <string name="l10n_devices_screen_noop_removes_this_device_a9cb6b5b">NOOP entfernt dieses Gerät aus deiner Liste und löscht dauerhaft alle aufgezeichneten Daten. Das kann nicht rückgängig gemacht werden.</string>
+    <string name="l10n_devices_screen_noop_removes_this_device_503aff9e">NOOP entfernt dieses Gerät aus deiner Liste und löscht die hier aufgezeichneten Daten. Du kannst den Strap erneut koppeln, um den jüngsten Verlauf wieder abzurufen.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1918,5 +1918,5 @@
     <string name="l10n_devices_screen_forget_device_d6eb6209">Olvidar dispositivo…</string>
     <string name="l10n_devices_screen_forget_device_926e503d">Olvidar dispositivo</string>
     <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">¿Olvidar este dispositivo?</string>
-    <string name="l10n_devices_screen_noop_removes_this_device_a9cb6b5b">NOOP quita este dispositivo de tu lista y elimina permanentemente todos sus datos registrados. No se puede deshacer.</string>
+    <string name="l10n_devices_screen_noop_removes_this_device_503aff9e">NOOP quita este dispositivo de tu lista y elimina los datos registrados aquí. Puedes volver a emparejar la banda para recuperar su historial reciente.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1915,4 +1915,8 @@
     <string name="settings_trend_bars">Barras</string>
     <string name="spo2_strap_estimate_caption">estimación de la correa (sin verificar)</string>
     <string name="spo2_toggle_on_no_data">activado · sin datos de @82</string>
+    <string name="l10n_devices_screen_forget_device_d6eb6209">Olvidar dispositivo…</string>
+    <string name="l10n_devices_screen_forget_device_926e503d">Olvidar dispositivo</string>
+    <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">¿Olvidar este dispositivo?</string>
+    <string name="l10n_devices_screen_noop_removes_this_device_a9cb6b5b">NOOP quita este dispositivo de tu lista y elimina permanentemente todos sus datos registrados. No se puede deshacer.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1918,5 +1918,5 @@
     <string name="l10n_devices_screen_forget_device_d6eb6209">Oublier l\'appareil…</string>
     <string name="l10n_devices_screen_forget_device_926e503d">Oublier l\'appareil</string>
     <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">Oublier cet appareil ?</string>
-    <string name="l10n_devices_screen_noop_removes_this_device_a9cb6b5b">NOOP retire cet appareil de votre liste et supprime définitivement toutes ses données enregistrées. Cette action est irréversible.</string>
+    <string name="l10n_devices_screen_noop_removes_this_device_503aff9e">NOOP retire cet appareil de votre liste et supprime les données enregistrées ici. Vous pouvez ré-appairer le bracelet pour récupérer son historique récent.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1915,4 +1915,8 @@
     <string name="settings_trend_bars">Barres</string>
     <string name="spo2_strap_estimate_caption">estimation du bracelet (non vérifiée)</string>
     <string name="spo2_toggle_on_no_data">activé · aucune donnée @82</string>
+    <string name="l10n_devices_screen_forget_device_d6eb6209">Oublier l\'appareil…</string>
+    <string name="l10n_devices_screen_forget_device_926e503d">Oublier l\'appareil</string>
+    <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">Oublier cet appareil ?</string>
+    <string name="l10n_devices_screen_noop_removes_this_device_a9cb6b5b">NOOP retire cet appareil de votre liste et supprime définitivement toutes ses données enregistrées. Cette action est irréversible.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1909,4 +1909,8 @@
     <string name="settings_trend_bars">Barras</string>
     <string name="spo2_strap_estimate_caption">estimativa da pulseira (não verificada)</string>
     <string name="spo2_toggle_on_no_data">ativado · sem dados de @82</string>
+    <string name="l10n_devices_screen_forget_device_d6eb6209">Esquecer dispositivo…</string>
+    <string name="l10n_devices_screen_forget_device_926e503d">Esquecer dispositivo</string>
+    <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">Esquecer este dispositivo?</string>
+    <string name="l10n_devices_screen_noop_removes_this_device_a9cb6b5b">O NOOP remove este dispositivo da tua lista e elimina permanentemente todos os seus dados registados. Esta ação não pode ser anulada.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1912,5 +1912,5 @@
     <string name="l10n_devices_screen_forget_device_d6eb6209">Esquecer dispositivo…</string>
     <string name="l10n_devices_screen_forget_device_926e503d">Esquecer dispositivo</string>
     <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">Esquecer este dispositivo?</string>
-    <string name="l10n_devices_screen_noop_removes_this_device_a9cb6b5b">O NOOP remove este dispositivo da tua lista e elimina permanentemente todos os seus dados registados. Esta ação não pode ser anulada.</string>
+    <string name="l10n_devices_screen_noop_removes_this_device_503aff9e">O NOOP remove este dispositivo da tua lista e elimina os dados registados aqui. Podes voltar a emparelhar a banda para obter novamente o histórico recente.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1846,5 +1846,5 @@
     <string name="l10n_devices_screen_forget_device_d6eb6209">忘记设备…</string>
     <string name="l10n_devices_screen_forget_device_926e503d">忘记设备</string>
     <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">忘记此设备？</string>
-    <string name="l10n_devices_screen_noop_removes_this_device_a9cb6b5b">NOOP 会从你的列表中移除此设备，并永久删除其记录的所有数据。此操作无法撤销。</string>
+    <string name="l10n_devices_screen_noop_removes_this_device_503aff9e">NOOP 会从你的列表中移除此设备，并删除此处记录的数据。你可以重新配对设备，以再次获取其最近的历史记录。</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1843,4 +1843,8 @@
     <string name="settings_trend_bars">柱形</string>
     <string name="spo2_strap_estimate_caption">腕带估算（未验证）</string>
     <string name="spo2_toggle_on_no_data">已开启 · 无 @82 数据</string>
+    <string name="l10n_devices_screen_forget_device_d6eb6209">忘记设备…</string>
+    <string name="l10n_devices_screen_forget_device_926e503d">忘记设备</string>
+    <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">忘记此设备？</string>
+    <string name="l10n_devices_screen_noop_removes_this_device_a9cb6b5b">NOOP 会从你的列表中移除此设备，并永久删除其记录的所有数据。此操作无法撤销。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1945,5 +1945,5 @@
     <string name="l10n_devices_screen_forget_device_d6eb6209">Forget device…</string>
     <string name="l10n_devices_screen_forget_device_926e503d">Forget device</string>
     <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">Forget this device?</string>
-    <string name="l10n_devices_screen_noop_removes_this_device_a9cb6b5b">NOOP removes this device from your list and permanently deletes all of its recorded data. This can\'t be undone.</string>
+    <string name="l10n_devices_screen_noop_removes_this_device_503aff9e">NOOP removes this device from your list and deletes its recorded data here. You can re-pair the strap to pull its recent history back.</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1942,4 +1942,8 @@
     <!-- #103: Blood Oxygen tile captions for the experimental WHOOP 5/MG @82 strap estimate. -->
     <string name="spo2_strap_estimate_caption">strap estimate (unverified)</string>
     <string name="spo2_toggle_on_no_data">toggle ON · no @82 data</string>
+    <string name="l10n_devices_screen_forget_device_d6eb6209">Forget device…</string>
+    <string name="l10n_devices_screen_forget_device_926e503d">Forget device</string>
+    <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">Forget this device?</string>
+    <string name="l10n_devices_screen_noop_removes_this_device_a9cb6b5b">NOOP removes this device from your list and permanently deletes all of its recorded data. This can\'t be undone.</string>
 </resources>

--- a/android/app/src/test/java/com/noop/data/DeviceRegistryTest.kt
+++ b/android/app/src/test/java/com/noop/data/DeviceRegistryTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -210,6 +211,17 @@ class DeviceRegistryTest {
         assertEquals(1, reg.all().size)
         assertEquals(DeviceStatus.archived.name, reg.all().first().status)
         assertNull(reg.activeDeviceId())
+    }
+
+    @Test
+    fun forgetRemovesRegistryRowAndWipesData() = runBlocking {
+        // #1193: unlike archive (row kept, I4) and deleteDeviceData (row kept), forget PURGES the registry
+        // entry so a duplicate/stale strap disappears from the list entirely — after wiping its recordings.
+        val dao = seededDao()
+        val reg = registryWith(dao)
+        reg.forget("my-whoop")
+        assertTrue(reg.all().isEmpty())                               // registry row purged, not just archived
+        assertTrue(dao.deletedTables.any { it.second == "my-whoop" }) // its recorded data was wiped first
     }
 
     @Test


### PR DESCRIPTION
Draft — cleanup half of #1193. **iOS + Android.**

### What

Adds a **"Forget device"** hard-delete for archived rows on **both platforms**. Today a removed
("Removed · Data kept") device can only be **Made active** again or have its **data** wiped
(which leaves the registry row) — so a duplicate/stale strap lingers in the list forever with no
way to purge it. This adds the missing affordance: a **"Forget device…"** item in a removed card's
⋮ menu that deletes the registry entry itself (and its recorded data).

**iOS / macOS**
- `DeviceRegistryStore.remove(_:)` — hard-deletes the `pairedDevice` + `device` registry rows (the
  recorded samples are wiped separately, exactly as `adoptSerialIdentity` already treats the two).
  Idempotent; no-op on an absent id.
- `DeviceRegistry.forget(_:store:)` — wipes the device's data on the `WhoopStore` actor (off-main,
  like `deleteDeviceData`), then removes the registry row and reloads.
- `DevicesView` — "Forget device…" ⋮ item + confirm alert, isolated into its own `ViewModifier`
  (the DevicesContent dialog chain is already near the iOS Swift type-checker budget — same reason
  the probe sheets were extracted).
- `Localizable.xcstrings` — 4 new strings across all 8 locales.

**Android** (parity)
- `DeviceRegistry.forget(id)` — `deleteDeviceData` then delete the `pairedDevice` + `device` rows.
- `AppViewModel.forgetPairedDevice(id)`.
- `DevicesScreen` — "Forget device…" ⋮ item + confirm dialog, all copy via `uiString`.
- `strings.xml` — 4 new strings across all 5 locales (de/es/fr/pt-rPT/zh + base).

### Scope

This is the **cleanup half** of #1193 — it lets users get rid of a duplicate, but does **not** stop
the duplicate from being created. The root cause (WHOOP identity keyed on a transient CoreBluetooth
UUID / MAC instead of the strap serial; the existing `adoptSerialIdentity` serial-merge is wired
Oura-only) is tracked in #1193 and needs (a) a raw 4.0 `GET_HELLO_HARVARD` capture to decode the 4.0
serial and (b) on-strap validation.

### Verification

- **Android** (built + tested locally): `compileFullDebugKotlin` ✓, `DeviceRegistryTest` ✓ (incl.
  new `forgetRemovesRegistryRowAndWipesData`), `i18n_audit.py --platform android --ci` ✓.
- **iOS store**: `DeviceRegistryStoreTests` `remove()` purges only the target row / no-ops on an
  absent id — green on `swift-packages.yml` (macos-15). `i18n_audit.py --platform ios --ci` ✓.
- **iOS app target NOT compiled** — `Strand/` has no default CI and I authored it on Linux; the
  macOS/iOS app build + a real removed-device tap still need to be run before merge (why this stays
  a draft). No BLE/strap behavior is touched by this change.

Refs #1193.
