### PR TITLE
fix(analytics): stop the post-offload re-score flickering daily history to empty (#1196)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/ScoreInputProvenanceStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/ScoreInputProvenanceStore.swift
@@ -27,6 +27,12 @@ extension WhoopStore {
         from: String,
         to: String
     ) async throws {
+        // #1196: an empty scoring pass must not destructively rewrite the window — with no daily rows to
+        // write, the provenance wide-delete below would blank the window's attribution while a degenerate
+        // pass (a transient read over an incomplete raw store during a reconnect/offload storm) produced
+        // nothing. A real pass always carries the days it scored, so this guard never fires in steady state.
+        // Twin of the Android WhoopDao.replaceComputedScoreWindow empty guard.
+        guard !dailyMetrics.isEmpty else { return }
         try syncWrite { db in
             _ = try Self.upsertDailyMetrics(dailyMetrics, deviceId: deviceId, in: db)
             _ = try Self.upsertMetricSeries(metricPoints, deviceId: deviceId, in: db)

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/ScoreInputProvenanceStoreTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/ScoreInputProvenanceStoreTests.swift
@@ -74,6 +74,32 @@ final class ScoreInputProvenanceStoreTests: XCTestCase {
         XCTAssertNil(strainSource)
     }
 
+    func testEmptyPassDoesNotWipeExistingWindow() async throws {
+        // #1196: a scoring pass that produced NO daily rows must not destructively rewrite the window.
+        // Before the guard, an empty pass still ran the provenance wide-delete and blanked the window's
+        // attribution; the guard makes an empty pass a no-op so recovery/strain/streak history survives a
+        // transient/degenerate empty pass (the "0 days / lost streak" flicker during an offload storm).
+        let store = try await WhoopStore.inMemory()
+        let day = "2026-07-24"
+        try await store.persistComputedScores(
+            dailyMetrics: [makeDaily(day: day, recovery: 71, strain: 42)],
+            metricPoints: [],
+            provenance: [.init(day: day, key: "recovery", sourceId: "polar-1")],
+            deviceId: "my-whoop-noop", from: day, to: day
+        )
+        // An EMPTY pass over the same window must leave the stored row + provenance untouched.
+        try await store.persistComputedScores(
+            dailyMetrics: [],
+            metricPoints: [],
+            provenance: [],
+            deviceId: "my-whoop-noop", from: day, to: day
+        )
+        let storedDaily = try await store.dailyMetrics(deviceId: "my-whoop-noop", from: day, to: day)
+        let source = try await store.scoreInputSource(deviceId: "my-whoop-noop", day: day, key: "recovery")
+        XCTAssertEqual(storedDaily.first?.recovery, 71)   // window not wiped
+        XCTAssertEqual(source, "polar-1")                 // provenance not wiped
+    }
+
     private func makeDaily(day: String, recovery: Double?, strain: Double?) -> DailyMetric {
         DailyMetric(
             day: day,

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -552,7 +552,11 @@ final class AppModel: ObservableObject {
         // analyzeRecent tick , otherwise a just-synced night's Charge / Effort / Rest can take up to
         // 15 minutes to appear on a strap-only (no-import) dashboard. analyzeRecent no-ops if a tick is
         // already running and refreshes the dashboard itself once the new scores persist. (PR #218)
-        await intelligence.analyzeRecent()
+        // #1196/#1146: `skipIfUnchanged` gates THIS post-offload pass on the HR fingerprint — an empty/
+        // duplicate offload (nothing new banked, common on a flapping link) skips the whole-window rescore
+        // instead of churning it, which was surfacing as a Trends/streak "0 days" flicker. Only this
+        // post-offload caller opts in; every other analyzeRecent path still forces unconditionally.
+        await intelligence.analyzeRecent(skipIfUnchanged: true)
         await refreshV5Signals()
         #if os(iOS)
         // #980: a strap backfill routinely completes while the app is BACKGROUNDED (it runs as a

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -360,7 +360,7 @@ final class IntelligenceEngine: ObservableObject {
     /// Compute on-device scores for each of the last `maxDays` that actually has raw HR data.
     /// Personal baselines (HRV / resting HR) are folded from the imported history, so even the first
     /// live night can be scored against your norm.
-    func analyzeRecent(maxDays: Int = 21, force: Bool = true) async {
+    func analyzeRecent(maxDays: Int = 21, force: Bool = true, skipIfUnchanged: Bool = false) async {
         // #899-A: a concurrent pass already holds the lock. A NON-forced idle tick is safe to drop (the
         // in-flight pass already covers the same window). But a FORCED call is a real update path (a
         // post-backfill rescore after a sync) , dropping it would leave a freshly-synced night unscored
@@ -386,6 +386,19 @@ final class IntelligenceEngine: ObservableObject {
             .map { "\($0.count):\($0.maxTs)" } ?? ""
         if !force, !wmKey.isEmpty,
            UserDefaults.standard.string(forKey: Self.analyzeWatermarkKey) == wmKey {
+            return
+        }
+        // #1196/#1146: a FORCED post-offload pass can opt into the same fingerprint gate. An empty/duplicate
+        // offload (fingerprint already == the watermark the last successful run advanced) has no new HR to
+        // score, so a re-score would reproduce IDENTICAL rows; skip the whole pass rather than churn the
+        // window. Over a flapping-link offload storm that churn made the reactive Trends/streak reads
+        // flicker between full and empty — a scare that looked like data loss (#1196). Scoped via
+        // `skipIfUnchanged` to the post-offload caller (refreshAfterCompletedBackfill) ONLY, so an
+        // import/edit/settings/recalibrate re-score — which changes scores WITHOUT changing the HR
+        // fingerprint — always runs. Twin of the Android WhoopBleClient post-offload `newData` gate.
+        if force, skipIfUnchanged, !wmKey.isEmpty,
+           UserDefaults.standard.string(forKey: Self.analyzeWatermarkKey) == wmKey {
+            diagnosticSink?("re-score: trigger=post-offload newData=no — skipped (nothing changed since last run)", nil)
             return
         }
         // Attribute a FORCED re-score. A completed offload / edit / recalibrate always re-scores
@@ -1346,10 +1359,18 @@ final class IntelligenceEngine: ObservableObject {
         // keys we just upserted, and delete each leftover day individually (from == to == key). This
         // removes #277's UTC/local duplicates WITHOUT the wide delete-then-reinsert dip. No-op in steady
         // state (the new keys cover the window), so it adds nothing once the migration has settled.
-        let freshKeys = Set(dailies.map { $0.day })
-        let existingWindow = (try? await store.dailyMetrics(deviceId: computedId, from: oldestDay, to: newestDay)) ?? []
-        for stale in existingWindow where !freshKeys.contains(stale.day) {
-            _ = try? await store.deleteDailyMetrics(deviceId: computedId, from: stale.day, to: stale.day)
+        // #1196: skip stale-eviction on an EMPTY pass so a transient/degenerate empty `dailies` (a read
+        // over a still-incomplete raw store during a reconnect/offload storm, or the active strap
+        // momentarily resolving to an empty id) never evicts the whole window. In steady state `dailies`
+        // covers the window, so eviction runs exactly as before; `persistComputedScores` is guarded the
+        // same way, so an empty pass leaves the persisted window untouched. Twin of the Android
+        // WhoopDao.replaceComputedScoreWindow empty guard.
+        if !dailies.isEmpty {
+            let freshKeys = Set(dailies.map { $0.day })
+            let existingWindow = (try? await store.dailyMetrics(deviceId: computedId, from: oldestDay, to: newestDay)) ?? []
+            for stale in existingWindow where !freshKeys.contains(stale.day) {
+                _ = try? await store.deleteDailyMetrics(deviceId: computedId, from: stale.day, to: stale.day)
+            }
         }
         // ── Fitness Age (Phase 2) , weekly, keyed to the week's Saturday ────────────────────────────
         // Roll the last 7 computed days into the Nes/HUNT inputs and upsert a weekly Fitness Age (+ an

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2156,10 +2156,19 @@ class WhoopBleClient(
                 // nothing changed since the last run — a re-score driven purely by the reconnect+offload, not
                 // by data. These lines quantify the background battery cost (#1005). Log-only; behaviour is
                 // unchanged (the pass still runs, matching Swift's force-re-score after a completed backfill).
+                // #1196/#1146: an empty/duplicate offload (newData=no) has no new HR to score — the
+                // fingerprint already equals the watermark the last successful run advanced, so a re-score
+                // would reproduce IDENTICAL rows. SKIP the whole-window pass rather than churn it; over a
+                // flapping-link offload storm (~186 passes in 7.5h were measured) that churn made the
+                // reactive Trends/streak Flows flicker between full and empty — a scare that looked like
+                // data loss (#1196). Scoped to THIS post-offload trigger only: import/edit/settings/
+                // recalibrate re-scores force regardless of the HR fingerprint and are untouched. Twin of
+                // the Swift `analyzeRecent(skipIfUnchanged:)` gate at the refreshAfterCompletedBackfill site.
+                val newData = analyzeFp != NoopPrefs.analyzeWatermark(context)
                 log("re-score: trigger=post-offload newData=" +
-                    if (analyzeFp != NoopPrefs.analyzeWatermark(context)) "yes"
-                    else "no (empty/duplicate offload — nothing changed since last run)")
-                runCatching {
+                    if (newData) "yes"
+                    else "no (empty/duplicate offload — nothing changed since last run) — skipping (#1146)")
+                if (newData) runCatching {
                     IntelligenceEngine.analyzeRecent(
                         repo = repository,
                         profile = profile,

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -229,9 +229,18 @@ interface WhoopDao : DeviceRegistryDao {
         metricPoints: List<MetricSeriesRow>,
         provenance: List<ScoreInputProvenanceRow>,
     ) {
+        // #1196: a scoring pass that produced NO computed daily rows must NOT wipe the persisted window.
+        // That happens transiently during a reconnect+offload storm (a pass runs over a still-incomplete
+        // raw store, or the active strap momentarily resolves to an empty id) — the old unconditional
+        // whole-window delete then blanked recovery/strain/streak history until the next pass repopulated
+        // it, and the reactive Trends/streak Flows surfaced that as a "0 days / lost streak" scare that
+        // looked like data loss. In steady state `dailyMetrics` covers the window, so this guard never
+        // fires and the write is byte-identical to before. (Twin of the Swift IntelligenceEngine
+        // empty-window guard; the post-offload trigger is additionally gated on newData — see #1146.)
+        if (dailyMetrics.isEmpty()) return
         deleteDailyMetricsInRange(deviceId, from, to)
         deleteScoreInputProvenanceInRange(deviceId, from, to)
-        if (dailyMetrics.isNotEmpty()) upsertDailyMetrics(dailyMetrics)
+        upsertDailyMetrics(dailyMetrics)
         if (metricPoints.isNotEmpty()) upsertMetricSeries(metricPoints)
         if (provenance.isNotEmpty()) upsertScoreInputProvenance(provenance)
     }


### PR DESCRIPTION
Fixes the #1196 "all my data is gone after the update" scare. **No data was ever lost** — the historical daily metrics are intact (the reporter's "Longest: 300 days" streak is preserved, and the app's own *"21 new days of history is ready in Trends"* notice is the re-score repopulating). It's a **transient visibility bug**.

### Root cause

After every completed offload the forced re-score (#836) runs a **whole-window** `dailyMetric` replace. On a WHOOP 5.0 offloading a ~22-day backlog over a **flapping link**, that trigger fires over and over (~186 whole-window passes in 7.5h were measured by #1192). A pass that scores *fewer* days than currently persisted — mid-offload over an incomplete raw store, or the active id momentarily resolving to an empty row — commits a **sparse window**, and the reactive Room `Flow` / Combine Trends+streak reads re-emit it → the **0↔21-day flicker** the reporter filmed. It self-heals once the backlog finishes.

### Fix (both platforms — parity)

**B — gate the post-offload trigger on `newData`.** An empty/duplicate offload (HR fingerprint already equals the watermark the last successful run advanced) has nothing new to score, so a re-score would reproduce identical rows. Skip the whole-window pass instead of churning it. **Scoped to the post-offload path only** — import / edit / settings / recalibrate re-scores still force unconditionally (they change scores without changing the HR fingerprint).
- Android: `WhoopBleClient` `newData` gate around the post-offload `analyzeRecent`.
- Swift: new `analyzeRecent(skipIfUnchanged:)`, passed `true` only from `AppModel.refreshAfterCompletedBackfill`.

**A — never let an *empty* pass destroy the window.** A pass that produced no daily rows is transient/degenerate and must not wipe history.
- Android: `WhoopDao.replaceComputedScoreWindow` returns early when `dailyMetrics` is empty.
- Swift: guards `persistComputedScores` (provenance wide-delete) **and** the `IntelligenceEngine` stale-eviction.

Both changes are **byte-identical** for every real (non-empty, changed-data) scoring pass — the guards only affect the degenerate empty/unchanged passes that caused the flicker, and they also cut the wasteful offload-storm re-scores (battery, #1005/#1146).

### Verification

- **Android** (built + tested locally): `compileFullDebugKotlin` ✓; `com.noop.data.*` + `com.noop.analytics.*` unit tests ✓.
- **Swift store** (macOS CI, `swift-packages.yml`): new `ScoreInputProvenanceStoreTests.testEmptyPassDoesNotWipeExistingWindow` asserts an empty pass leaves the stored daily row + provenance intact.
- **iOS/macOS app target** (`Strand/Data/IntelligenceEngine.swift`, `Strand/App/AppModel.swift`): no default CI — needs a macOS app compile before merge (I authored on Linux). Changes are a param + two guards + one call-site; happy to dispatch `app-build.yml` to confirm.
- BLE offload behavior itself is validated only on a real strap; this change is data-layer, not connection-path.

Fixes #1196. Related: #836 (forced post-offload re-score), #1146/#1005 (empty-offload storm), #1192 (the fingerprint attribution this reuses).
