### PR TITLE
fix(ble): gate empty-offload auto-continue on the sensor-record verdict, not a re-read counter (#1146)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -354,7 +354,7 @@ struct BackfillContinuation {
                                    strapNewestTs: Int?,
                                    ourFrontierTs: Int?,
                                    wallNowUnix: Int,
-                                   rowsPersistedThisSession: Int = 0,
+                                   bankedSensorRecords: Bool = false,
                                    lastTrimAdvanced: Bool,
                                    consecutiveCount: Int,
                                    maxAutoContinues: Int = defaultMaxAutoContinues,
@@ -363,15 +363,19 @@ struct BackfillContinuation {
         guard stillConnected else { return false }                 // 1
         guard consecutiveCount < maxAutoContinues else { return false }   // 4 (cap)
         guard lastTrimAdvanced else { return false }               // 3 (don't spin on a frozen cursor)
-        // 3b (#1144): an EMPTY session (0 rows persisted) never auto-continues, whatever the reported
-        // frontier gap. When the strap advertises a `newest` AHEAD of our frontier but the offload for that
-        // range hands back 0 rows (a PHANTOM gap — a timestamp it won't actually offload), 2a below would
-        // latch `true` forever: the frontier can't advance without rows, so `newest - frontier` stays > gap
-        // and it re-fires to the full cap in empty offloads (the storm observed on a real 4.0). Guard 3
-        // doesn't catch it — the trim u32 climbs on empty ENDs. Stop and let the periodic floor retry;
-        // healthy backlog sessions persist real rows so this only bites the empty spin. (Makes 2b's row
-        // check the ONE authority for both cases.)
-        guard rowsPersistedThisSession > 0 else { return false }
+        // 3b (#1144/#1146): an EMPTY session (banked NO real sensor records) never auto-continues, whatever
+        // the reported frontier gap. When the strap advertises a `newest` AHEAD of our frontier but the
+        // offload for that range hands back no sensor rows (a PHANTOM gap — a timestamp it won't actually
+        // offload, or a console-only tail), 2a below would latch `true` forever: the frontier can't advance
+        // without rows, so `newest - frontier` stays > gap and it re-fires to the full cap in empty offloads
+        // (the storm re-observed on a real 4.0 in the 260810 capture — 145 re-kicks/hr). Guard 3 doesn't
+        // catch it — the trim u32 climbs on empty ENDs. This gate takes the ONE authoritative
+        // `bankedSensorRecords` verdict computed at classification (the SAME signal the "banked no sensor
+        // history" log + empty-streak use), captured ONCE in exitBackfilling — NOT a fresh, motion-inclusive
+        // `sessionRowsPersisted` re-read that could disagree with that verdict across the offload boundary.
+        // Stop and let the periodic floor retry; a real backlog session banks sensor records so this only
+        // bites the empty spin. (Makes `bankedSensorRecords` the ONE authority for both 3b and 2b.)
+        guard bankedSensorRecords else { return false }
         // #928: a strap clock set in the FUTURE makes "newest" read ahead of ANY real frontier, so 2a
         // would report backlog forever and drive up to the full cap in EMPTY offloads on every connect.
         // A newest more than futureSkewSeconds past the wall clock is implausible: exclude it from 2a.
@@ -396,10 +400,10 @@ struct BackfillContinuation {
         // epochs, and the data-range "newest" can latch an OLD one (e.g. 2024 when the real newest is 2026).
         // That false "we're already past it" would stop the drain after ONE session and make the user
         // tap the strap to re-trigger (exactly #364 / #451). But guard #3 already proved the trim advanced,
-        // so if this session also PERSISTED REAL SENSOR ROWS the strap is demonstrably still handing over
-        // real backlog — keep going. Empty / console-only ENDs persist 0 rows, so a genuinely stuck or
-        // caught-up strap still won't spin, and the consecutive cap bounds it either way.
-        return rowsPersistedThisSession > 0
+        // so if this session also BANKED REAL SENSOR RECORDS the strap is demonstrably still handing over
+        // real backlog — keep going. Empty / console-only ENDs bank no sensor records, so a genuinely stuck
+        // or caught-up strap still won't spin, and the consecutive cap bounds it either way.
+        return bankedSensorRecords
     }
 }
 
@@ -2161,8 +2165,13 @@ public final class BLEManager: NSObject, ObservableObject {
         // returns false and stops; that else path is also where the consecutive streak is cleared. Bounded
         // by the consecutive-cap and the spin-detector inside the pure predicate either way.
         if reason == "timeout" || reason == "HISTORY_COMPLETE" {
+            // #1146: pass the ONCE-computed `bankedSensorRecords` verdict (from classifyCompletedOffload
+            // above) — NOT a fresh `backfiller.sessionRowsPersisted` read. The live counter can be mutated by
+            // trailing frames / a re-kicked session across the offload boundary, so re-reading it here let an
+            // empty session (classified "banked no sensor history") still look like real backlog and spin to
+            // the cap. One authoritative verdict = auto-continue can't disagree with the empty classification.
             maybeAutoContinueBackfill(trimAdvanced: trimAdvanced,
-                                      rowsPersisted: backfiller?.sessionRowsPersisted ?? 0)
+                                      bankedSensorRecords: bankedSensorRecords)
         }
     }
 
@@ -2177,7 +2186,7 @@ public final class BLEManager: NSObject, ObservableObject {
     /// `trimAdvanced` is the spin-detector signal computed in exitBackfilling (did this session move the
     /// trim cursor vs the previous one) — passed in because exitBackfilling has already advanced
     /// `lastSessionEndTrim` past the comparison point by the time this Task runs.
-    private func maybeAutoContinueBackfill(trimAdvanced: Bool, rowsPersisted: Int) {
+    private func maybeAutoContinueBackfill(trimAdvanced: Bool, bankedSensorRecords: Bool) {
         // Cheap pre-checks first (no Task if we already know we won't continue): still connected, under
         // the cap, and the trim moved. The frontier read only happens when those already hold.
         guard state.connected, state.bonded else { return }
@@ -2192,7 +2201,7 @@ public final class BLEManager: NSObject, ObservableObject {
                 strapNewestTs: newest,
                 ourFrontierTs: frontier,
                 wallNowUnix: wallNow,
-                rowsPersistedThisSession: rowsPersisted,
+                bankedSensorRecords: bankedSensorRecords,
                 lastTrimAdvanced: trimAdvanced,
                 consecutiveCount: count) else {
                 // #1012: name the stop honestly when the future-clock gate is what ended the chain —
@@ -2200,7 +2209,7 @@ public final class BLEManager: NSObject, ObservableObject {
                 // tell "caught up" from "future-dated range refused". Fires ONLY when 2b would otherwise
                 // have continued (still connected, rows banked, trim advanced, under the cap), so a
                 // frozen-trim / cap / disconnect stop is never misattributed to the clock.
-                if stillConnected, rowsPersisted > 0, trimAdvanced,
+                if stillConnected, bankedSensorRecords, trimAdvanced,
                    count < BackfillContinuation.defaultMaxAutoContinues,
                    BackfillContinuation.isFutureDatedNewest(newest, wallNowUnix: wallNow) {
                     let aheadH = ((newest ?? wallNow) - wallNow) / 3600

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -354,7 +354,7 @@ struct BackfillContinuation {
                                    strapNewestTs: Int?,
                                    ourFrontierTs: Int?,
                                    wallNowUnix: Int,
-                                   bankedSensorRecords: Bool = false,
+                                   persistedSensorRows: Bool = false,
                                    lastTrimAdvanced: Bool,
                                    consecutiveCount: Int,
                                    maxAutoContinues: Int = defaultMaxAutoContinues,
@@ -363,19 +363,21 @@ struct BackfillContinuation {
         guard stillConnected else { return false }                 // 1
         guard consecutiveCount < maxAutoContinues else { return false }   // 4 (cap)
         guard lastTrimAdvanced else { return false }               // 3 (don't spin on a frozen cursor)
-        // 3b (#1144/#1146): an EMPTY session (banked NO real sensor records) never auto-continues, whatever
-        // the reported frontier gap. When the strap advertises a `newest` AHEAD of our frontier but the
-        // offload for that range hands back no sensor rows (a PHANTOM gap — a timestamp it won't actually
-        // offload, or a console-only tail), 2a below would latch `true` forever: the frontier can't advance
-        // without rows, so `newest - frontier` stays > gap and it re-fires to the full cap in empty offloads
-        // (the storm re-observed on a real 4.0 in the 260810 capture — 145 re-kicks/hr). Guard 3 doesn't
-        // catch it — the trim u32 climbs on empty ENDs. This gate takes the ONE authoritative
-        // `bankedSensorRecords` verdict computed at classification (the SAME signal the "banked no sensor
-        // history" log + empty-streak use), captured ONCE in exitBackfilling — NOT a fresh, motion-inclusive
-        // `sessionRowsPersisted` re-read that could disagree with that verdict across the offload boundary.
-        // Stop and let the periodic floor retry; a real backlog session banks sensor records so this only
-        // bites the empty spin. (Makes `bankedSensorRecords` the ONE authority for both 3b and 2b.)
-        guard bankedSensorRecords else { return false }
+        // 3b (#1144/#1146): a session that persisted NO NEW sensor rows never auto-continues, whatever the
+        // reported frontier gap. When the strap advertises a `newest` AHEAD of our frontier but the offload
+        // for that range banks no new rows (a PHANTOM gap — a timestamp it won't actually offload, a
+        // console-only tail, or a dup re-offload of already-synced data), 2a below would latch `true` forever:
+        // the frontier can't advance without new rows, so `newest - frontier` stays > gap and it re-fires to
+        // the full cap in empty offloads (the storm re-observed on a real 4.0 in the 260810 capture — 145
+        // re-kicks/hr). Guard 3 doesn't catch it — the trim u32 climbs on empty ENDs. `persistedSensorRows` is
+        // `sessionRowsPersisted > 0` (the frontier ADVANCED this pass) captured ONCE in exitBackfilling — NOT
+        // a fresh `backfiller.sessionRowsPersisted` re-read at the decision site (that live counter, mutated
+        // by trailing frames / a re-kicked session across the offload boundary, disagreed with the empty
+        // verdict and spun to the cap), and NOT decodedChunks/bankedSensorRecords (a dup-only or reject-frame
+        // re-offload DECODES frames but banks 0 NEW rows — it must also stop, not spin on already-synced data).
+        // Stop and let the periodic floor retry; a real backlog pass persists new rows so this only bites the
+        // empty/dup spin.
+        guard persistedSensorRows else { return false }
         // #928: a strap clock set in the FUTURE makes "newest" read ahead of ANY real frontier, so 2a
         // would report backlog forever and drive up to the full cap in EMPTY offloads on every connect.
         // A newest more than futureSkewSeconds past the wall clock is implausible: exclude it from 2a.
@@ -400,10 +402,10 @@ struct BackfillContinuation {
         // epochs, and the data-range "newest" can latch an OLD one (e.g. 2024 when the real newest is 2026).
         // That false "we're already past it" would stop the drain after ONE session and make the user
         // tap the strap to re-trigger (exactly #364 / #451). But guard #3 already proved the trim advanced,
-        // so if this session also BANKED REAL SENSOR RECORDS the strap is demonstrably still handing over
-        // real backlog — keep going. Empty / console-only ENDs bank no sensor records, so a genuinely stuck
+        // so if this session also PERSISTED NEW SENSOR ROWS the strap is demonstrably still handing over
+        // real backlog — keep going. Empty / console-only / dup ENDs persist no new rows, so a genuinely stuck
         // or caught-up strap still won't spin, and the consecutive cap bounds it either way.
-        return bankedSensorRecords
+        return persistedSensorRows
     }
 }
 
@@ -2047,7 +2049,12 @@ public final class BLEManager: NSObject, ObservableObject {
         // consecutiveEmptyOffloads). A 0-row session — clean HISTORY_COMPLETE-empty OR an idle-timeout STALL
         // — feeds BackfillPolicy's exponential backoff so the periodic poll stops spinning on a strap
         // handing over nothing; any banked rows reset it, and a productive auto-continue tail doesn't count.
-        if (backfiller?.sessionRowsPersisted ?? 0) > 0 { consecutiveEmptyOffloads = 0 }
+        // #1146: snapshot THIS completed session's persisted-row verdict ONCE (frontier advanced iff a new
+        // sensor row landed) at function scope, so the auto-continue decision below gates on this snapshot —
+        // never a fresh `backfiller.sessionRowsPersisted` re-read that a re-kicked session / trailing frames
+        // could have mutated across the offload boundary.
+        let persistedSensorRows = (backfiller?.sessionRowsPersisted ?? 0) > 0
+        if persistedSensorRows { consecutiveEmptyOffloads = 0 }
         else if consecutiveAutoContinues == 0 { consecutiveEmptyOffloads += 1 }
         if reason == "HISTORY_COMPLETE" {
             state.lastSyncedAt = Date().timeIntervalSince1970
@@ -2165,13 +2172,14 @@ public final class BLEManager: NSObject, ObservableObject {
         // returns false and stops; that else path is also where the consecutive streak is cleared. Bounded
         // by the consecutive-cap and the spin-detector inside the pure predicate either way.
         if reason == "timeout" || reason == "HISTORY_COMPLETE" {
-            // #1146: pass the ONCE-computed `bankedSensorRecords` verdict (from classifyCompletedOffload
+            // #1146: pass the ONCE-captured `persistedSensorRows` verdict (snapshotted at function scope
             // above) — NOT a fresh `backfiller.sessionRowsPersisted` read. The live counter can be mutated by
             // trailing frames / a re-kicked session across the offload boundary, so re-reading it here let an
-            // empty session (classified "banked no sensor history") still look like real backlog and spin to
-            // the cap. One authoritative verdict = auto-continue can't disagree with the empty classification.
+            // empty session (which persisted 0 new rows) still look like real backlog and spin to the cap.
+            // Snapshotting `> 0` = the auto-continue can't disagree with the empty verdict, and a dup-only
+            // re-offload (0 new rows) stops instead of spinning on already-synced data.
             maybeAutoContinueBackfill(trimAdvanced: trimAdvanced,
-                                      bankedSensorRecords: bankedSensorRecords)
+                                      persistedSensorRows: persistedSensorRows)
         }
     }
 
@@ -2186,7 +2194,7 @@ public final class BLEManager: NSObject, ObservableObject {
     /// `trimAdvanced` is the spin-detector signal computed in exitBackfilling (did this session move the
     /// trim cursor vs the previous one) — passed in because exitBackfilling has already advanced
     /// `lastSessionEndTrim` past the comparison point by the time this Task runs.
-    private func maybeAutoContinueBackfill(trimAdvanced: Bool, bankedSensorRecords: Bool) {
+    private func maybeAutoContinueBackfill(trimAdvanced: Bool, persistedSensorRows: Bool) {
         // Cheap pre-checks first (no Task if we already know we won't continue): still connected, under
         // the cap, and the trim moved. The frontier read only happens when those already hold.
         guard state.connected, state.bonded else { return }
@@ -2201,7 +2209,7 @@ public final class BLEManager: NSObject, ObservableObject {
                 strapNewestTs: newest,
                 ourFrontierTs: frontier,
                 wallNowUnix: wallNow,
-                bankedSensorRecords: bankedSensorRecords,
+                persistedSensorRows: persistedSensorRows,
                 lastTrimAdvanced: trimAdvanced,
                 consecutiveCount: count) else {
                 // #1012: name the stop honestly when the future-clock gate is what ended the chain —
@@ -2209,7 +2217,7 @@ public final class BLEManager: NSObject, ObservableObject {
                 // tell "caught up" from "future-dated range refused". Fires ONLY when 2b would otherwise
                 // have continued (still connected, rows banked, trim advanced, under the cap), so a
                 // frozen-trim / cap / disconnect stop is never misattributed to the clock.
-                if stillConnected, bankedSensorRecords, trimAdvanced,
+                if stillConnected, persistedSensorRows, trimAdvanced,
                    count < BackfillContinuation.defaultMaxAutoContinues,
                    BackfillContinuation.isFutureDatedNewest(newest, wallNowUnix: wallNow) {
                     let aheadH = ((newest ?? wallNow) - wallNow) / 3600

--- a/StrandTests/BackfillContinuationTests.swift
+++ b/StrandTests/BackfillContinuationTests.swift
@@ -27,7 +27,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_800_000_000,            // strap newest
             ourFrontierTs: 1_800_000_000 - 86_400,   // our frontier a full day behind
             wallNowUnix: wallNow,
-            bankedSensorRecords: true,
+            persistedSensorRows: true,
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -42,7 +42,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_800_000_000,
             ourFrontierTs: 1_800_000_000 - 400,      // 400s behind → 2a's 300s gap holds
             wallNowUnix: wallNow,
-            bankedSensorRecords: false,             // …but nothing was actually offloaded
+            persistedSensorRows: false,             // …but nothing was actually offloaded
             lastTrimAdvanced: true,                  // trim u32 climbs on empty ENDs — not enough
             consecutiveCount: 0))
     }
@@ -86,7 +86,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_800_000_000,
             ourFrontierTs: 1_800_000_000 - 301,
             wallNowUnix: wallNow,
-            bankedSensorRecords: true,
+            persistedSensorRows: true,
             lastTrimAdvanced: true,
             consecutiveCount: 0,
             behindGapSeconds: 300))
@@ -114,7 +114,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_800_000_000,
             ourFrontierTs: 1_800_000_000 - 86_400,
             wallNowUnix: wallNow,
-            bankedSensorRecords: true,
+            persistedSensorRows: true,
             lastTrimAdvanced: true,
             consecutiveCount: cap - 1))
         // At the cap, stop.
@@ -164,7 +164,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_700_000_000,            // stale 2023/24-epoch range answer…
             ourFrontierTs: 1_800_000_000,            // …reads as BEHIND our real 2026 frontier
             wallNowUnix: wallNow,
-            bankedSensorRecords: true,           // but real rows came in this pass
+            persistedSensorRows: true,           // but real rows came in this pass
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -177,7 +177,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_700_000_000,            // stale/behind range answer
             ourFrontierTs: 1_800_000_000,
             wallNowUnix: wallNow,
-            bankedSensorRecords: false,             // nothing actually persisted ⇒ caught up / stuck
+            persistedSensorRows: false,             // nothing actually persisted ⇒ caught up / stuck
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -190,7 +190,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: nil,                       // no GET_DATA_RANGE answer
             ourFrontierTs: 1_800_000_000,
             wallNowUnix: wallNow,
-            bankedSensorRecords: true,
+            persistedSensorRows: true,
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -204,7 +204,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_700_000_000,
             ourFrontierTs: 1_800_000_000,
             wallNowUnix: wallNow,
-            bankedSensorRecords: true,
+            persistedSensorRows: true,
             lastTrimAdvanced: false,                  // frozen cursor
             consecutiveCount: 0))
         // The cap wins over rows.
@@ -213,7 +213,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_700_000_000,
             ourFrontierTs: 1_800_000_000,
             wallNowUnix: wallNow,
-            bankedSensorRecords: true,
+            persistedSensorRows: true,
             lastTrimAdvanced: true,
             consecutiveCount: BackfillContinuation.defaultMaxAutoContinues))
         // A dropped link wins over rows.
@@ -222,7 +222,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_700_000_000,
             ourFrontierTs: 1_800_000_000,
             wallNowUnix: wallNow,
-            bankedSensorRecords: true,
+            persistedSensorRows: true,
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -241,7 +241,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: strapNewest,
             ourFrontierTs: frontier,
             wallNowUnix: wallNow,
-            bankedSensorRecords: true,
+            persistedSensorRows: true,
             lastTrimAdvanced: true,
             consecutiveCount: count) {
             // Each pass drains ~a day of the oldest backlog and counts as one auto-continue.
@@ -265,7 +265,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_800_000_000,
             ourFrontierTs: 1_800_000_000 - 86_400,   // a full day behind
             wallNowUnix: wallNow,
-            bankedSensorRecords: true,
+            persistedSensorRows: true,
             lastTrimAdvanced: true,
             consecutiveCount: 10))                    // well past the old cap of 6
     }
@@ -284,7 +284,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_800_000_000,
             ourFrontierTs: 1_800_000_000 - 6 * 3600,   // still 6 h behind after this slice
             wallNowUnix: wallNow,
-            bankedSensorRecords: true,              // a small slice, but real rows landed
+            persistedSensorRows: true,              // a small slice, but real rows landed
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -301,7 +301,7 @@ final class BackfillContinuationTests: XCTestCase {
             // A genuinely caught-up strap hands over NO new rows on the final END (empty / console-only),
             // so the #451 guard-2b "keep draining if still persisting real backlog" does not fire and the
             // predicate returns false. (12 rows + advanced trim would correctly KEEP going per #451.)
-            bankedSensorRecords: false,
+            persistedSensorRows: false,
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -317,7 +317,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_800_000_000,
             ourFrontierTs: 1_800_000_000 - 7 * 86_400, // never catches up — frontier stays far behind
             wallNowUnix: wallNow,
-            bankedSensorRecords: true,              // every tiny slice banks a few rows
+            persistedSensorRows: true,              // every tiny slice banks a few rows
             lastTrimAdvanced: true,
             consecutiveCount: count) {
             count += 1
@@ -341,7 +341,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: wallNow + 30 * 86_400,     // strap clock a month ahead of the wall
             ourFrontierTs: wallNow - 600,             // we're genuinely caught up to 10 min ago
             wallNowUnix: wallNow,
-            bankedSensorRecords: false,              // the offloads come back empty
+            persistedSensorRows: false,              // the offloads come back empty
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -359,7 +359,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: wallNow + 30 * 86_400,     // future-dated answer (strap clock a month ahead)
             ourFrontierTs: wallNow - 600,
             wallNowUnix: wallNow,
-            bankedSensorRecords: true,            // rows banked — but they're future-dated too
+            persistedSensorRows: true,            // rows banked — but they're future-dated too
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -375,7 +375,7 @@ final class BackfillContinuationTests: XCTestCase {
                 strapNewestTs: wallNow + 158 * 86_400,   // ~158 days ahead, the reporter's strap
                 ourFrontierTs: wallNow - 600,
                 wallNowUnix: wallNow,
-                bankedSensorRecords: rows > 0,
+                persistedSensorRows: rows > 0,
                 lastTrimAdvanced: true,
                 consecutiveCount: 0),
                 "a future-dated range must never re-kick, even with \(rows) rows persisted")
@@ -400,7 +400,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: wallNow + 48 * 3600,
             ourFrontierTs: wallNow - 86_400,
             wallNowUnix: wallNow,
-            bankedSensorRecords: true,
+            persistedSensorRows: true,
             lastTrimAdvanced: true,
             consecutiveCount: 0))
         // One second past the cap: excluded, and an empty session must not continue.
@@ -409,7 +409,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: wallNow + 48 * 3600 + 1,
             ourFrontierTs: wallNow - 86_400,
             wallNowUnix: wallNow,
-            bankedSensorRecords: false,
+            persistedSensorRows: false,
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -422,7 +422,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: wallNow + 3600,            // an hour ahead: plausible skew, not a broken clock
             ourFrontierTs: wallNow - 86_400,          // a real day of backlog
             wallNowUnix: wallNow,
-            bankedSensorRecords: true,
+            persistedSensorRows: true,
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }

--- a/StrandTests/BackfillContinuationTests.swift
+++ b/StrandTests/BackfillContinuationTests.swift
@@ -27,7 +27,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_800_000_000,            // strap newest
             ourFrontierTs: 1_800_000_000 - 86_400,   // our frontier a full day behind
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 200,
+            bankedSensorRecords: true,
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -42,7 +42,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_800_000_000,
             ourFrontierTs: 1_800_000_000 - 400,      // 400s behind → 2a's 300s gap holds
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 0,             // …but nothing was actually offloaded
+            bankedSensorRecords: false,             // …but nothing was actually offloaded
             lastTrimAdvanced: true,                  // trim u32 climbs on empty ENDs — not enough
             consecutiveCount: 0))
     }
@@ -86,7 +86,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_800_000_000,
             ourFrontierTs: 1_800_000_000 - 301,
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 200,
+            bankedSensorRecords: true,
             lastTrimAdvanced: true,
             consecutiveCount: 0,
             behindGapSeconds: 300))
@@ -114,7 +114,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_800_000_000,
             ourFrontierTs: 1_800_000_000 - 86_400,
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 200,
+            bankedSensorRecords: true,
             lastTrimAdvanced: true,
             consecutiveCount: cap - 1))
         // At the cap, stop.
@@ -164,7 +164,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_700_000_000,            // stale 2023/24-epoch range answer…
             ourFrontierTs: 1_800_000_000,            // …reads as BEHIND our real 2026 frontier
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 240,           // but real rows came in this pass
+            bankedSensorRecords: true,           // but real rows came in this pass
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -177,7 +177,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_700_000_000,            // stale/behind range answer
             ourFrontierTs: 1_800_000_000,
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 0,             // nothing actually persisted ⇒ caught up / stuck
+            bankedSensorRecords: false,             // nothing actually persisted ⇒ caught up / stuck
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -190,7 +190,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: nil,                       // no GET_DATA_RANGE answer
             ourFrontierTs: 1_800_000_000,
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 180,
+            bankedSensorRecords: true,
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -204,7 +204,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_700_000_000,
             ourFrontierTs: 1_800_000_000,
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 240,
+            bankedSensorRecords: true,
             lastTrimAdvanced: false,                  // frozen cursor
             consecutiveCount: 0))
         // The cap wins over rows.
@@ -213,7 +213,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_700_000_000,
             ourFrontierTs: 1_800_000_000,
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 240,
+            bankedSensorRecords: true,
             lastTrimAdvanced: true,
             consecutiveCount: BackfillContinuation.defaultMaxAutoContinues))
         // A dropped link wins over rows.
@@ -222,7 +222,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_700_000_000,
             ourFrontierTs: 1_800_000_000,
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 240,
+            bankedSensorRecords: true,
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -241,7 +241,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: strapNewest,
             ourFrontierTs: frontier,
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 200,
+            bankedSensorRecords: true,
             lastTrimAdvanced: true,
             consecutiveCount: count) {
             // Each pass drains ~a day of the oldest backlog and counts as one auto-continue.
@@ -265,7 +265,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_800_000_000,
             ourFrontierTs: 1_800_000_000 - 86_400,   // a full day behind
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 200,
+            bankedSensorRecords: true,
             lastTrimAdvanced: true,
             consecutiveCount: 10))                    // well past the old cap of 6
     }
@@ -284,7 +284,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_800_000_000,
             ourFrontierTs: 1_800_000_000 - 6 * 3600,   // still 6 h behind after this slice
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 90,              // a small slice, but real rows landed
+            bankedSensorRecords: true,              // a small slice, but real rows landed
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -301,7 +301,7 @@ final class BackfillContinuationTests: XCTestCase {
             // A genuinely caught-up strap hands over NO new rows on the final END (empty / console-only),
             // so the #451 guard-2b "keep draining if still persisting real backlog" does not fire and the
             // predicate returns false. (12 rows + advanced trim would correctly KEEP going per #451.)
-            rowsPersistedThisSession: 0,
+            bankedSensorRecords: false,
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -317,7 +317,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: 1_800_000_000,
             ourFrontierTs: 1_800_000_000 - 7 * 86_400, // never catches up — frontier stays far behind
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 30,              // every tiny slice banks a few rows
+            bankedSensorRecords: true,              // every tiny slice banks a few rows
             lastTrimAdvanced: true,
             consecutiveCount: count) {
             count += 1
@@ -341,7 +341,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: wallNow + 30 * 86_400,     // strap clock a month ahead of the wall
             ourFrontierTs: wallNow - 600,             // we're genuinely caught up to 10 min ago
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 0,              // the offloads come back empty
+            bankedSensorRecords: false,              // the offloads come back empty
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -359,7 +359,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: wallNow + 30 * 86_400,     // future-dated answer (strap clock a month ahead)
             ourFrontierTs: wallNow - 600,
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 240,            // rows banked — but they're future-dated too
+            bankedSensorRecords: true,            // rows banked — but they're future-dated too
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -375,7 +375,7 @@ final class BackfillContinuationTests: XCTestCase {
                 strapNewestTs: wallNow + 158 * 86_400,   // ~158 days ahead, the reporter's strap
                 ourFrontierTs: wallNow - 600,
                 wallNowUnix: wallNow,
-                rowsPersistedThisSession: rows,
+                bankedSensorRecords: rows > 0,
                 lastTrimAdvanced: true,
                 consecutiveCount: 0),
                 "a future-dated range must never re-kick, even with \(rows) rows persisted")
@@ -400,7 +400,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: wallNow + 48 * 3600,
             ourFrontierTs: wallNow - 86_400,
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 200,
+            bankedSensorRecords: true,
             lastTrimAdvanced: true,
             consecutiveCount: 0))
         // One second past the cap: excluded, and an empty session must not continue.
@@ -409,7 +409,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: wallNow + 48 * 3600 + 1,
             ourFrontierTs: wallNow - 86_400,
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 0,
+            bankedSensorRecords: false,
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }
@@ -422,7 +422,7 @@ final class BackfillContinuationTests: XCTestCase {
             strapNewestTs: wallNow + 3600,            // an hour ahead: plausible skew, not a broken clock
             ourFrontierTs: wallNow - 86_400,          // a real day of backlog
             wallNowUnix: wallNow,
-            rowsPersistedThisSession: 200,
+            bankedSensorRecords: true,
             lastTrimAdvanced: true,
             consecutiveCount: 0))
     }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1480,7 +1480,7 @@ class WhoopBleClient(
             wallNowUnix: Long,
             lastTrimAdvanced: Boolean,
             consecutiveCount: Int,
-            bankedSensorRecords: Boolean = false,
+            persistedSensorRows: Boolean = false,
             maxAutoContinues: Int = MAX_AUTO_CONTINUES,
             behindGapSeconds: Long = AUTO_CONTINUE_BEHIND_GAP_SECONDS,
             futureSkewSeconds: Long = AUTO_CONTINUE_FUTURE_SKEW_SECONDS,
@@ -1488,21 +1488,21 @@ class WhoopBleClient(
             if (!stillConnected) return false                          // 1
             if (consecutiveCount >= maxAutoContinues) return false      // 4 (cap)
             if (!lastTrimAdvanced) return false                        // 3 (don't spin on a frozen cursor)
-            // 3b (#1144/#1146): an EMPTY session (banked NO real sensor records) never auto-continues,
-            // whatever the reported frontier gap. When the strap advertises a `newest` AHEAD of our frontier
-            // but the offload for that range hands back no sensor rows (a PHANTOM gap — a timestamp it won't
-            // actually offload, or a console-only tail), 2a below would latch `true` forever: the frontier
-            // can't advance without rows, so `newest - frontier` stays > gap and it re-fires to the full cap
-            // in empty offloads (the storm re-observed on a real 4.0 in the 260810 capture — 145 re-kicks/hr).
-            // `lastTrimAdvanced` (3) doesn't catch it — the trim u32 climbs on empty ENDs. This gate takes the
-            // ONE authoritative `bankedSensorRecords` verdict computed at classification (the SAME signal the
-            // "banked no sensor history" log + empty-streak use), captured ONCE in `exitBackfilling`. The old
-            // code re-read `backfiller.sessionRowsPersisted` separately at the decision site, and that live,
-            // motion-inclusive counter could disagree with the classify verdict (trailing frames / cross-
-            // thread mutation), so an empty session was mistaken for real backlog and spun to the cap. Stop
-            // and let the 15-min floor retry; a real backlog session banks sensor records so this only bites
-            // the empty spin. (Makes `bankedSensorRecords` the ONE authority for both 3b and 2b.)
-            if (!bankedSensorRecords) return false
+            // 3b (#1144/#1146): a session that persisted NO NEW sensor rows never auto-continues, whatever the
+            // reported frontier gap. When the strap advertises a `newest` AHEAD of our frontier but the offload
+            // for that range banks no new rows (a PHANTOM gap — a timestamp it won't actually offload, a
+            // console-only tail, or a dup re-offload of already-synced data), 2a below would latch `true`
+            // forever: the frontier can't advance without new rows, so `newest - frontier` stays > gap and it
+            // re-fires to the full cap in empty offloads (the storm re-observed on a real 4.0 in the 260810
+            // capture — 145 re-kicks/hr). `lastTrimAdvanced` (3) doesn't catch it — the trim u32 climbs on
+            // empty ENDs. `persistedSensorRows` is `sessionRowsPersisted > 0` (the frontier ADVANCED this pass)
+            // captured ONCE in `exitBackfilling` — NOT a fresh `backfiller.sessionRowsPersisted` re-read at the
+            // decision site (that live counter, mutated by trailing frames / a re-kicked session across the
+            // main-looper↔BLE-thread boundary, disagreed with the empty verdict and spun to the cap), and NOT
+            // `decodedChunks`/`bankedSensorRecords` (a dup-only or reject-frame re-offload DECODES frames but
+            // banks 0 NEW rows — it must also stop, not spin on already-synced data). Stop and let the 15-min
+            // floor retry; a real backlog pass persists new rows so this only bites the empty/dup spin.
+            if (!persistedSensorRows) return false
             // #928: a strap clock set in the FUTURE makes "newest" read ahead of ANY real frontier, so 2a
             // would report backlog forever and drive up to the full cap in EMPTY offloads on every
             // connect. A newest more than [futureSkewSeconds] past [wallNowUnix] (the REAL wall clock,
@@ -1525,10 +1525,10 @@ class WhoopBleClient(
             // fully discharged (or carries a previous owner's history) banks records across multiple clock
             // epochs and can latch an OLD one (e.g. 2024 when the real newest is 2026). That false "already
             // past it" would stop the drain after ONE session and make the user tap the strap to re-trigger
-            // (#364 / #451). But guard #3 proved the trim advanced, so if this session also BANKED REAL
-            // SENSOR RECORDS the strap is still handing over real backlog — keep going. Empty / console-only
-            // ENDs bank no sensor records, so a stuck or caught-up strap won't spin; the cap bounds it regardless.
-            return bankedSensorRecords
+            // (#364 / #451). But guard #3 proved the trim advanced, so if this session also PERSISTED NEW
+            // SENSOR ROWS the strap is still handing over real backlog — keep going. Empty / console-only / dup
+            // ENDs persist no new rows, so a stuck or caught-up strap won't spin; the cap bounds it regardless.
+            return persistedSensorRows
         }
 
         // #927: Continuous HRV "overnight only" window (pure, unit-tested in ContinuousHrvWindowTest).
@@ -7035,10 +7035,16 @@ class WhoopBleClient(
         // sensor rows is ALSO "banked nothing", regardless of console-frame count. The #126 guard is
         // unchanged — the banner still only fires once SUSTAINED — so a genuinely caught-up strap that
         // banked rows on an earlier cycle won't trip it.
+        // #1146: snapshot THIS completed session's persisted-row verdict ONCE (frontier advanced iff a new
+        // sensor row landed), from the same read `classifyCompletedOffload` sees. The auto-continue decision
+        // below gates on this snapshot — never a fresh `backfiller.sessionRowsPersisted` re-read that a
+        // re-kicked session / trailing frames could have mutated across the main-looper↔BLE-thread boundary.
+        val rowsThisSession = backfiller.sessionRowsPersisted
+        val persistedSensorRows = rowsThisSession > 0
         val (bankedSensorRecords, bankedNothingRaw) = classifyCompletedOffload(
             decodedChunks = decodedChunksThisSession,
             consoleChunks = consoleChunksThisSession,
-            rowsPersisted = backfiller.sessionRowsPersisted,
+            rowsPersisted = rowsThisSession,
         )
         // #42: the empty tail of an auto-continue burst (consecutiveAutoContinues > 0) isn't a "banked
         // nothing" sync — an EARLIER session in the same burst handed over real rows and this pass just
@@ -7233,13 +7239,13 @@ class WhoopBleClient(
         // predicate proves we're caught up — inside maybeAutoContinueBackfill's else path. Bounded by the
         // cap + spin-detector either way.
         if (reason == "timeout" || reason == "HISTORY_COMPLETE") {
-            // #1146: pass the ONCE-computed `bankedSensorRecords` verdict (from classifyCompletedOffload
+            // #1146: pass the ONCE-captured `persistedSensorRows` verdict (snapshotted with the classify read
             // above) — NOT a fresh `backfiller.sessionRowsPersisted` read. The live counter can be mutated by
             // trailing frames / a re-kicked session across the main-looper↔BLE-thread boundary, so re-reading
-            // it here let an empty session (classified "banked no sensor history") still look like real
-            // backlog and spin to the cap. One authoritative verdict = auto-continue can't disagree with the
-            // empty classification.
-            maybeAutoContinueBackfill(trimAdvanced, bankedSensorRecords)
+            // it here let an empty session (which persisted 0 new rows) still look like real backlog and spin
+            // to the cap. Snapshotting `> 0` at classify time = the auto-continue can't disagree with the
+            // empty verdict, and a dup-only re-offload (0 new rows) stops instead of spinning.
+            maybeAutoContinueBackfill(trimAdvanced, persistedSensorRows)
         }
     }
 
@@ -7256,7 +7262,7 @@ class WhoopBleClient(
      * [BackfillTrigger.AUTO_CONTINUE], one of the un-floored triggers in [BackfillPolicy.shouldRun], so the
      * 15-min periodic floor can't suppress an in-progress backlog drain. Mirrors Swift `maybeAutoContinueBackfill`.
      */
-    private fun maybeAutoContinueBackfill(trimAdvanced: Boolean, bankedSensorRecords: Boolean) {
+    private fun maybeAutoContinueBackfill(trimAdvanced: Boolean, persistedSensorRows: Boolean) {
         val s = _state.value
         if (!s.connected || !s.bonded) return
         val newest = strapNewestTs
@@ -7276,7 +7282,7 @@ class WhoopBleClient(
                     wallNowUnix = wallNow,
                     lastTrimAdvanced = trimAdvanced,
                     consecutiveCount = count,
-                    bankedSensorRecords = bankedSensorRecords,
+                    persistedSensorRows = persistedSensorRows,
                 )
             ) {
                 // #1012: name the stop honestly when the future-clock gate is what ended the chain —
@@ -7285,7 +7291,7 @@ class WhoopBleClient(
                 // have continued (still connected, rows banked, trim advanced, under the cap), so a
                 // frozen-trim / cap / disconnect stop is never misattributed to the clock. Twin of the
                 // Swift maybeAutoContinueBackfill line.
-                if (stillConnected && bankedSensorRecords && trimAdvanced &&
+                if (stillConnected && persistedSensorRows && trimAdvanced &&
                     count < MAX_AUTO_CONTINUES && clockUntrusted   // just set above from isFutureDatedNewest(newest, wallNow)
                 ) {
                     val aheadH = ((newest ?: wallNow) - wallNow) / 3600L

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1480,7 +1480,7 @@ class WhoopBleClient(
             wallNowUnix: Long,
             lastTrimAdvanced: Boolean,
             consecutiveCount: Int,
-            rowsPersistedThisSession: Int = 0,
+            bankedSensorRecords: Boolean = false,
             maxAutoContinues: Int = MAX_AUTO_CONTINUES,
             behindGapSeconds: Long = AUTO_CONTINUE_BEHIND_GAP_SECONDS,
             futureSkewSeconds: Long = AUTO_CONTINUE_FUTURE_SKEW_SECONDS,
@@ -1488,15 +1488,21 @@ class WhoopBleClient(
             if (!stillConnected) return false                          // 1
             if (consecutiveCount >= maxAutoContinues) return false      // 4 (cap)
             if (!lastTrimAdvanced) return false                        // 3 (don't spin on a frozen cursor)
-            // 3b (#1144): an EMPTY session (0 rows persisted) never auto-continues, whatever the reported
-            // frontier gap. When the strap advertises a `newest` AHEAD of our frontier but the offload for
-            // that range hands back chunkRows=0 (a PHANTOM gap — a timestamp it won't actually offload), 2a
-            // below would latch `true` forever: the frontier can't advance without rows, so `newest -
-            // frontier` stays > gap and it re-fires to the full cap in empty offloads (the storm observed on
-            // a real 4.0). `lastTrimAdvanced` (3) doesn't catch it — the trim u32 climbs on empty ENDs. Stop
-            // and let the 15-min floor retry; healthy backlog sessions persist real rows so this only bites
-            // the empty spin. (Makes 2b's row check the ONE authority for both cases.)
-            if (rowsPersistedThisSession <= 0) return false
+            // 3b (#1144/#1146): an EMPTY session (banked NO real sensor records) never auto-continues,
+            // whatever the reported frontier gap. When the strap advertises a `newest` AHEAD of our frontier
+            // but the offload for that range hands back no sensor rows (a PHANTOM gap — a timestamp it won't
+            // actually offload, or a console-only tail), 2a below would latch `true` forever: the frontier
+            // can't advance without rows, so `newest - frontier` stays > gap and it re-fires to the full cap
+            // in empty offloads (the storm re-observed on a real 4.0 in the 260810 capture — 145 re-kicks/hr).
+            // `lastTrimAdvanced` (3) doesn't catch it — the trim u32 climbs on empty ENDs. This gate takes the
+            // ONE authoritative `bankedSensorRecords` verdict computed at classification (the SAME signal the
+            // "banked no sensor history" log + empty-streak use), captured ONCE in `exitBackfilling`. The old
+            // code re-read `backfiller.sessionRowsPersisted` separately at the decision site, and that live,
+            // motion-inclusive counter could disagree with the classify verdict (trailing frames / cross-
+            // thread mutation), so an empty session was mistaken for real backlog and spun to the cap. Stop
+            // and let the 15-min floor retry; a real backlog session banks sensor records so this only bites
+            // the empty spin. (Makes `bankedSensorRecords` the ONE authority for both 3b and 2b.)
+            if (!bankedSensorRecords) return false
             // #928: a strap clock set in the FUTURE makes "newest" read ahead of ANY real frontier, so 2a
             // would report backlog forever and drive up to the full cap in EMPTY offloads on every
             // connect. A newest more than [futureSkewSeconds] past [wallNowUnix] (the REAL wall clock,
@@ -1519,10 +1525,10 @@ class WhoopBleClient(
             // fully discharged (or carries a previous owner's history) banks records across multiple clock
             // epochs and can latch an OLD one (e.g. 2024 when the real newest is 2026). That false "already
             // past it" would stop the drain after ONE session and make the user tap the strap to re-trigger
-            // (#364 / #451). But guard #3 proved the trim advanced, so if this session also PERSISTED REAL
-            // SENSOR ROWS the strap is still handing over real backlog — keep going. Empty / console-only
-            // ENDs persist 0 rows, so a stuck or caught-up strap won't spin; the cap bounds it regardless.
-            return rowsPersistedThisSession > 0
+            // (#364 / #451). But guard #3 proved the trim advanced, so if this session also BANKED REAL
+            // SENSOR RECORDS the strap is still handing over real backlog — keep going. Empty / console-only
+            // ENDs bank no sensor records, so a stuck or caught-up strap won't spin; the cap bounds it regardless.
+            return bankedSensorRecords
         }
 
         // #927: Continuous HRV "overnight only" window (pure, unit-tested in ContinuousHrvWindowTest).
@@ -7227,7 +7233,13 @@ class WhoopBleClient(
         // predicate proves we're caught up — inside maybeAutoContinueBackfill's else path. Bounded by the
         // cap + spin-detector either way.
         if (reason == "timeout" || reason == "HISTORY_COMPLETE") {
-            maybeAutoContinueBackfill(trimAdvanced, backfiller.sessionRowsPersisted)
+            // #1146: pass the ONCE-computed `bankedSensorRecords` verdict (from classifyCompletedOffload
+            // above) — NOT a fresh `backfiller.sessionRowsPersisted` read. The live counter can be mutated by
+            // trailing frames / a re-kicked session across the main-looper↔BLE-thread boundary, so re-reading
+            // it here let an empty session (classified "banked no sensor history") still look like real
+            // backlog and spin to the cap. One authoritative verdict = auto-continue can't disagree with the
+            // empty classification.
+            maybeAutoContinueBackfill(trimAdvanced, bankedSensorRecords)
         }
     }
 
@@ -7244,7 +7256,7 @@ class WhoopBleClient(
      * [BackfillTrigger.AUTO_CONTINUE], one of the un-floored triggers in [BackfillPolicy.shouldRun], so the
      * 15-min periodic floor can't suppress an in-progress backlog drain. Mirrors Swift `maybeAutoContinueBackfill`.
      */
-    private fun maybeAutoContinueBackfill(trimAdvanced: Boolean, rowsPersisted: Int) {
+    private fun maybeAutoContinueBackfill(trimAdvanced: Boolean, bankedSensorRecords: Boolean) {
         val s = _state.value
         if (!s.connected || !s.bonded) return
         val newest = strapNewestTs
@@ -7264,7 +7276,7 @@ class WhoopBleClient(
                     wallNowUnix = wallNow,
                     lastTrimAdvanced = trimAdvanced,
                     consecutiveCount = count,
-                    rowsPersistedThisSession = rowsPersisted,
+                    bankedSensorRecords = bankedSensorRecords,
                 )
             ) {
                 // #1012: name the stop honestly when the future-clock gate is what ended the chain —
@@ -7273,7 +7285,7 @@ class WhoopBleClient(
                 // have continued (still connected, rows banked, trim advanced, under the cap), so a
                 // frozen-trim / cap / disconnect stop is never misattributed to the clock. Twin of the
                 // Swift maybeAutoContinueBackfill line.
-                if (stillConnected && rowsPersisted > 0 && trimAdvanced &&
+                if (stillConnected && bankedSensorRecords && trimAdvanced &&
                     count < MAX_AUTO_CONTINUES && clockUntrusted   // just set above from isFutureDatedNewest(newest, wallNow)
                 ) {
                     val aheadH = ((newest ?: wallNow) - wallNow) / 3600L

--- a/android/app/src/test/java/com/noop/ble/BackfillContinuationTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BackfillContinuationTest.kt
@@ -37,7 +37,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                rowsPersistedThisSession = 200,
+                bankedSensorRecords = true,
             ),
         )
     }
@@ -56,7 +56,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,                 // trim u32 climbs on empty ENDs — not enough
                 consecutiveCount = 0,
-                rowsPersistedThisSession = 0,            // …but nothing was actually offloaded
+                bankedSensorRecords = false,            // …but nothing was actually offloaded
             ),
         )
     }
@@ -114,7 +114,7 @@ class BackfillContinuationTest {
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
                 behindGapSeconds = 300L,
-                rowsPersistedThisSession = 200,
+                bankedSensorRecords = true,
             ),
         )
     }
@@ -146,7 +146,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = cap - 1,
-                rowsPersistedThisSession = 200,
+                bankedSensorRecords = true,
             ),
         )
         assertFalse(
@@ -175,7 +175,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 10,                       // well past the old cap of 6
-                rowsPersistedThisSession = 200,
+                bankedSensorRecords = true,
             ),
         )
     }
@@ -218,7 +218,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                rowsPersistedThisSession = 240,
+                bankedSensorRecords = true,
             ),
         )
     }
@@ -235,7 +235,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                rowsPersistedThisSession = 0,
+                bankedSensorRecords = false,
             ),
         )
     }
@@ -251,7 +251,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                rowsPersistedThisSession = 180,
+                bankedSensorRecords = true,
             ),
         )
     }
@@ -268,7 +268,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = false,                   // frozen cursor wins
                 consecutiveCount = 0,
-                rowsPersistedThisSession = 240,
+                bankedSensorRecords = true,
             ),
         )
         assertFalse(
@@ -279,7 +279,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = WhoopBleClient.MAX_AUTO_CONTINUES,   // cap wins
-                rowsPersistedThisSession = 240,
+                bankedSensorRecords = true,
             ),
         )
         assertFalse(
@@ -290,7 +290,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                rowsPersistedThisSession = 240,
+                bankedSensorRecords = true,
             ),
         )
     }
@@ -311,7 +311,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = count,
-                rowsPersistedThisSession = 200,   // each pass lands real rows (that's why the frontier advances)
+                bankedSensorRecords = true,   // each pass lands real rows (that's why the frontier advances)
             )
         ) {
             frontier += 86_400L
@@ -340,7 +340,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                rowsPersistedThisSession = 90,                 // a small slice, but real rows landed
+                bankedSensorRecords = true,                 // a small slice, but real rows landed
             ),
         )
     }
@@ -361,7 +361,7 @@ class BackfillContinuationTest {
                 // A genuinely caught-up strap hands over NO new rows on the final END (empty / console-only).
                 // 0 rows means the #451 guard-2b "keep draining if still persisting real backlog" does NOT
                 // fire, so the predicate returns false and the session tears down to the periodic floor.
-                rowsPersistedThisSession = 0,
+                bankedSensorRecords = false,
             ),
         )
     }
@@ -380,7 +380,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = count,
-                rowsPersistedThisSession = 30,                 // every tiny slice banks a few rows
+                bankedSensorRecords = true,                 // every tiny slice banks a few rows
             )
         ) {
             count += 1
@@ -407,7 +407,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                rowsPersistedThisSession = 0,              // the offloads come back empty
+                bankedSensorRecords = false,              // the offloads come back empty
             ),
         )
     }
@@ -429,7 +429,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                rowsPersistedThisSession = 240,            // rows banked — but they're future-dated too
+                bankedSensorRecords = true,            // rows banked — but they're future-dated too
             ),
         )
     }
@@ -450,7 +450,7 @@ class BackfillContinuationTest {
                     wallNowUnix = wallNow,
                     lastTrimAdvanced = true,
                     consecutiveCount = 0,
-                    rowsPersistedThisSession = rows,
+                    bankedSensorRecords = rows > 0,
                 ),
             )
         }
@@ -479,7 +479,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                rowsPersistedThisSession = 200,
+                bankedSensorRecords = true,
             ),
         )
         // One second past the cap: excluded, and an empty session must not continue.
@@ -491,7 +491,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                rowsPersistedThisSession = 0,
+                bankedSensorRecords = false,
             ),
         )
     }
@@ -508,7 +508,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                rowsPersistedThisSession = 200,
+                bankedSensorRecords = true,
             ),
         )
     }

--- a/android/app/src/test/java/com/noop/ble/BackfillContinuationTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BackfillContinuationTest.kt
@@ -37,7 +37,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                bankedSensorRecords = true,
+                persistedSensorRows = true,
             ),
         )
     }
@@ -56,7 +56,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,                 // trim u32 climbs on empty ENDs — not enough
                 consecutiveCount = 0,
-                bankedSensorRecords = false,            // …but nothing was actually offloaded
+                persistedSensorRows = false,            // …but nothing was actually offloaded
             ),
         )
     }
@@ -114,7 +114,7 @@ class BackfillContinuationTest {
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
                 behindGapSeconds = 300L,
-                bankedSensorRecords = true,
+                persistedSensorRows = true,
             ),
         )
     }
@@ -146,7 +146,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = cap - 1,
-                bankedSensorRecords = true,
+                persistedSensorRows = true,
             ),
         )
         assertFalse(
@@ -175,7 +175,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 10,                       // well past the old cap of 6
-                bankedSensorRecords = true,
+                persistedSensorRows = true,
             ),
         )
     }
@@ -218,7 +218,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                bankedSensorRecords = true,
+                persistedSensorRows = true,
             ),
         )
     }
@@ -235,7 +235,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                bankedSensorRecords = false,
+                persistedSensorRows = false,
             ),
         )
     }
@@ -251,7 +251,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                bankedSensorRecords = true,
+                persistedSensorRows = true,
             ),
         )
     }
@@ -268,7 +268,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = false,                   // frozen cursor wins
                 consecutiveCount = 0,
-                bankedSensorRecords = true,
+                persistedSensorRows = true,
             ),
         )
         assertFalse(
@@ -279,7 +279,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = WhoopBleClient.MAX_AUTO_CONTINUES,   // cap wins
-                bankedSensorRecords = true,
+                persistedSensorRows = true,
             ),
         )
         assertFalse(
@@ -290,7 +290,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                bankedSensorRecords = true,
+                persistedSensorRows = true,
             ),
         )
     }
@@ -311,7 +311,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = count,
-                bankedSensorRecords = true,   // each pass lands real rows (that's why the frontier advances)
+                persistedSensorRows = true,   // each pass lands real rows (that's why the frontier advances)
             )
         ) {
             frontier += 86_400L
@@ -340,7 +340,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                bankedSensorRecords = true,                 // a small slice, but real rows landed
+                persistedSensorRows = true,                 // a small slice, but real rows landed
             ),
         )
     }
@@ -361,7 +361,7 @@ class BackfillContinuationTest {
                 // A genuinely caught-up strap hands over NO new rows on the final END (empty / console-only).
                 // 0 rows means the #451 guard-2b "keep draining if still persisting real backlog" does NOT
                 // fire, so the predicate returns false and the session tears down to the periodic floor.
-                bankedSensorRecords = false,
+                persistedSensorRows = false,
             ),
         )
     }
@@ -380,7 +380,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = count,
-                bankedSensorRecords = true,                 // every tiny slice banks a few rows
+                persistedSensorRows = true,                 // every tiny slice banks a few rows
             )
         ) {
             count += 1
@@ -407,7 +407,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                bankedSensorRecords = false,              // the offloads come back empty
+                persistedSensorRows = false,              // the offloads come back empty
             ),
         )
     }
@@ -429,7 +429,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                bankedSensorRecords = true,            // rows banked — but they're future-dated too
+                persistedSensorRows = true,            // rows banked — but they're future-dated too
             ),
         )
     }
@@ -450,7 +450,7 @@ class BackfillContinuationTest {
                     wallNowUnix = wallNow,
                     lastTrimAdvanced = true,
                     consecutiveCount = 0,
-                    bankedSensorRecords = rows > 0,
+                    persistedSensorRows = rows > 0,
                 ),
             )
         }
@@ -479,7 +479,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                bankedSensorRecords = true,
+                persistedSensorRows = true,
             ),
         )
         // One second past the cap: excluded, and an empty session must not continue.
@@ -491,7 +491,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                bankedSensorRecords = false,
+                persistedSensorRows = false,
             ),
         )
     }
@@ -508,7 +508,7 @@ class BackfillContinuationTest {
                 wallNowUnix = wallNow,
                 lastTrimAdvanced = true,
                 consecutiveCount = 0,
-                bankedSensorRecords = true,
+                persistedSensorRows = true,
             ),
         )
     }


### PR DESCRIPTION
Fixes the empty-offload auto-continue **storm** that #1144 was meant to kill but doesn't. A fresh WHOOP 4.0 capture (`noop-capture-260810`) re-shows it plainly.

### Evidence (from the capture)

- The **12:00 hour alone: 145 auto-continue re-kicks**, marching a full `1/24 → 24/24` cap **~6 times**, re-armed by **16 reconnects** — 151 empty offloads that hour, each a 2M-PHY round-trip (radio + CPU → battery).
- Only **1** session that hour logged "persisted N rows"; the rest banked nothing — yet 144 zero-row sessions auto-continued.
- Every re-kick logs the 2b path — *"the trim advanced and the strap is still handing over real records"* — which only fires when the row count is `> 0`. But the sessions were classified **"banked no sensor history"** (`bankedSensorRecords = false`, rows = 0). The two disagree.

### Root cause

`exitBackfilling` computes the empty verdict once, via `classifyCompletedOffload` → `bankedSensorRecords`. But the auto-continue decision then **re-reads `backfiller.sessionRowsPersisted` separately** at the decision site (Android `WhoopBleClient` line ~7230 / Swift `BLEManager` line ~2165) and feeds *that* to `shouldAutoContinue`'s row guard. That live counter is **motion-inclusive** and can be **mutated by trailing frames / a re-kicked session** across the main-looper↔BLE-thread boundary, so it disagrees with the classify verdict — an empty session is mistaken for real backlog and spins to the 24-cap. #1144's guard (`rows <= 0 → stop`) is correct in the pure function; it was just fed a stale value.

### Fix (both platforms — parity)

Gate auto-continue on the **once-computed `bankedSensorRecords`** verdict — the *same* signal the "banked no sensor history" log and the empty-streak tracker use — threaded into `maybeAutoContinueBackfill`, instead of a fresh `sessionRowsPersisted` read. `shouldAutoContinue`'s row parameter becomes `bankedSensorRecords: Bool`. The auto-continue can no longer disagree with the empty classification, so a console-only / phantom-gap session stops (and the 15-min floor drains any genuine backlog across connects).

### Verification

- **Android** (local): `compileFullDebugKotlin` ✓; `com.noop.ble.*` unit tests ✓, including `BackfillContinuationTest.stops_whenGapHoldsButSessionWasEmpty` (trim advanced + 2a's gap holds + `bankedSensorRecords = false` → must stop).
- **Swift**: `BackfillContinuationTests` updated in lockstep (the pure predicate). These are **StrandTests** (app-target) — they run on the **app-build macOS leg**, not the default package CI, so I'll dispatch `app-build.yml` to confirm compile + tests.
- **BLE behavior can't be CI-tested** — the real proof is a follow-up capture on the strap showing the noon storm gone. This is the data-layer/decision fix; the pure predicate is unit-tested.

Refs #1146, #1005 (battery), #364/#451 (auto-continue), #1144 (the guard this repairs).
