### PR TITLE
harden(backup): warn on stale auto-backup + verify the written .noopbak

### DIFF
--- a/Strand/Data/BackupSync.swift
+++ b/Strand/Data/BackupSync.swift
@@ -26,6 +26,20 @@ enum BackupSync {
 
     // MARK: - Pure helpers (unit-tested; mirror Android BackupSync)
 
+    /// Default staleness threshold (3 days). Auto-backup runs a DAILY on-launch catch-up, so a
+    /// *successful* backup older than this means the catch-up isn't landing — a stale/permission-lost
+    /// folder bookmark, or the app simply hasn't been launched in a while. Surfaced as a warning so a
+    /// silently-failing auto-backup is visible instead of only discovered when a restore is needed.
+    static let staleThresholdMs = 3 * 24 * 60 * 60 * 1000
+
+    /// True when auto-backup should be flagged STALE: the last SUCCESSFUL backup is older than
+    /// `thresholdMs`. `lastBackupMs == 0` (never backed up while auto is on) also counts as stale. Pure so
+    /// it's unit-tested with literal ms; the caller supplies `nowMs` and gates on `autoEnabled`/folder.
+    /// Twin of Android `BackupSync.isBackupStale`.
+    static func isBackupStale(lastBackupMs: Int, nowMs: Int, thresholdMs: Int = staleThresholdMs) -> Bool {
+        nowMs - lastBackupMs >= thresholdMs
+    }
+
     /// A fresh UTC second-resolution formatter. Created per call so the type stays trivially `Sendable`
     /// and there is no shared mutable `DateFormatter` to data-race; the cost is irrelevant at this rate.
     private static func stampFormatter() -> DateFormatter {

--- a/Strand/Data/DataBackup.swift
+++ b/Strand/Data/DataBackup.swift
@@ -127,6 +127,16 @@ enum DataBackup {
         }
     }
 
+    /// The freshly-written `.noopbak` failed a post-write structural check — its DB entry is missing or
+    /// truncated, i.e. a torn write from a full disk / dying filesystem / flaky cloud sync mid-write.
+    /// Thrown by `writeVerifiedBackupZip` so a bad backup fails at WRITE time, not silently — the old
+    /// behaviour let a truncated file sit as a "successful" snapshot and only surface at restore (#1014).
+    private struct BackupWriteIncomplete: LocalizedError {
+        var errorDescription: String? {
+            String(localized: "the backup file was written incompletely (its database entry is missing or truncated). Free up space or check the backup folder, then try again.")
+        }
+    }
+
     /// The production export path: verify, then archive. GRDB checkpoints the WAL first (the
     /// callers' `checkpoint()` guard), so at this point the single file IS the whole store — run a
     /// read-only `PRAGMA quick_check` over it BEFORE zipping (#1014). Archiving an already-corrupt
@@ -139,6 +149,19 @@ enum DataBackup {
             throw ExportIntegrityFailure(complaint: complaint)
         }
         try writeBackupZip(dbURL: dbURL, to: dest, settingsJSON: settingsJSON)
+        // #1014 (write-side): the SOURCE is verified above, but the PRODUCED file can still be torn by a
+        // full disk / dying filesystem / flaky cloud-sync mid-write, and such a truncated `.noopbak`
+        // otherwise "restores" into an empty store — caught only by the import-side quick_check much later.
+        // Re-open the file we just wrote (a cheap central-directory read, no extraction — and a torn file
+        // has no valid trailing central directory, so it won't even open) and confirm its DB entry is
+        // present and non-empty (a SQLite header alone is 100 bytes). Fail HERE if not, and don't leave a
+        // corrupt file behind masquerading as a good snapshot. Twin of the Android post-write check.
+        guard let written = try? Archive(url: dest, accessMode: .read),
+              let dbEntry = written.first(where: { $0.path == backupEntryName }),
+              dbEntry.uncompressedSize >= 100 else {
+            try? FileManager.default.removeItem(at: dest)
+            throw BackupWriteIncomplete()
+        }
     }
 
     /// Write the live SQLite at `dbURL` into a fresh deflate ZIP at `dest`: the DB under the canonical

--- a/Strand/Data/DataBackup.swift
+++ b/Strand/Data/DataBackup.swift
@@ -157,7 +157,7 @@ enum DataBackup {
         // present and non-empty (a SQLite header alone is 100 bytes). Fail HERE if not, and don't leave a
         // corrupt file behind masquerading as a good snapshot. Twin of the Android post-write check.
         guard let written = try? Archive(url: dest, accessMode: .read),
-              let dbEntry = written.first(where: { $0.path == backupEntryName }),
+              let dbEntry = written.first(where: { ($0.path as NSString).lastPathComponent == backupEntryName }),
               dbEntry.uncompressedSize >= 100 else {
             try? FileManager.default.removeItem(at: dest)
             throw BackupWriteIncomplete()

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -1,6 +1,110 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "Auto-backup hasn't run in a few days. Check the backup folder is still available — a moved or disconnected cloud folder stops backups silently.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das automatische Backup lief seit einigen Tagen nicht. Prüfe, ob der Backup-Ordner noch verfügbar ist – ein verschobener oder getrennter Cloud-Ordner stoppt Backups stillschweigend."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La copia de seguridad automática no se ha ejecutado en varios días. Comprueba que la carpeta de copias sigue disponible: una carpeta en la nube movida o desconectada detiene las copias sin avisar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La sauvegarde automatique n'a pas eu lieu depuis plusieurs jours. Vérifie que le dossier de sauvegarde est toujours disponible — un dossier cloud déplacé ou déconnecté interrompt les sauvegardes en silence."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il backup automatico non viene eseguito da alcuni giorni. Verifica che la cartella di backup sia ancora disponibile: una cartella cloud spostata o disconnessa interrompe i backup senza avvisare."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A cópia de segurança automática não é feita há alguns dias. Verifica se a pasta de backup ainda está disponível — uma pasta na nuvem movida ou desligada interrompe as cópias silenciosamente."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автоматическое резервное копирование не выполнялось несколько дней. Проверьте, доступна ли папка для резервных копий — перемещённая или отключённая облачная папка молча останавливает копирование."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动备份已有几天未运行。请检查备份文件夹是否仍然可用——被移动或断开连接的云文件夹会悄然停止备份。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動備份已有幾天未執行。請檢查備份資料夾是否仍然可用——被移動或中斷連線的雲端資料夾會悄悄停止備份。"
+          }
+        }
+      }
+    },
+    "the backup file was written incompletely (its database entry is missing or truncated). Free up space or check the backup folder, then try again.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Backup-Datei wurde unvollständig geschrieben (ihr Datenbankeintrag fehlt oder ist abgeschnitten). Gib Speicherplatz frei oder prüfe den Backup-Ordner und versuche es erneut."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El archivo de copia de seguridad se escribió de forma incompleta (falta su entrada de base de datos o está truncada). Libera espacio o comprueba la carpeta de copias e inténtalo de nuevo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le fichier de sauvegarde a été écrit de façon incomplète (son entrée de base de données est manquante ou tronquée). Libère de l'espace ou vérifie le dossier de sauvegarde, puis réessaie."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il file di backup è stato scritto in modo incompleto (la sua voce di database è mancante o troncata). Libera spazio o controlla la cartella di backup, poi riprova."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O ficheiro de cópia de segurança foi escrito de forma incompleta (falta a entrada da base de dados ou está truncada). Liberta espaço ou verifica a pasta de backup e tenta novamente."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Файл резервной копии записан не полностью (запись базы данных отсутствует или усечена). Освободите место или проверьте папку резервных копий и повторите попытку."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份文件写入不完整（其数据库条目缺失或被截断）。请释放空间或检查备份文件夹，然后重试。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "備份檔案寫入不完整（其資料庫項目遺失或被截斷）。請釋放空間或檢查備份資料夾，然後重試。"
+          }
+        }
+      }
+    },
     "Forget device": {
       "localizations": {
         "de": {

--- a/Strand/Screens/BackupSyncView.swift
+++ b/Strand/Screens/BackupSyncView.swift
@@ -139,6 +139,22 @@ struct BackupSyncView: View {
                 }
                 Text(lastMs > 0 ? "Last backup: \(relativeTime(lastMs))" : "No backup yet.")
                     .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
+                // Auto is ON but the last SUCCESSFUL backup is stale — the on-launch catch-up isn't landing
+                // (a moved/disconnected cloud folder stops backups silently, or NOOP hasn't been opened).
+                // Surface it so a silently-failing auto-backup is visible, not discovered only at restore.
+                if auto, folderLabel != nil,
+                   BackupSync.isBackupStale(lastBackupMs: lastMs,
+                                            nowMs: Int(Date().timeIntervalSince1970 * 1000.0)) {
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(StrandPalette.statusWarning)
+                            .font(.system(size: 12))
+                            .accessibilityHidden(true)
+                        Text("Auto-backup hasn't run in a few days. Check the backup folder is still available — a moved or disconnected cloud folder stops backups silently.")
+                            .font(StrandFont.caption).foregroundStyle(StrandPalette.statusWarning)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
                 NoopButton(busy ? "Working…" : "Back up now",
                            systemImage: "icloud.and.arrow.up", kind: .primary, fullWidth: true) { backupNow() }
                     .disabled(folderLabel == nil || busy)

--- a/Strand/Screens/BackupSyncView.swift
+++ b/Strand/Screens/BackupSyncView.swift
@@ -142,7 +142,9 @@ struct BackupSyncView: View {
                 // Auto is ON but the last SUCCESSFUL backup is stale — the on-launch catch-up isn't landing
                 // (a moved/disconnected cloud folder stops backups silently, or NOOP hasn't been opened).
                 // Surface it so a silently-failing auto-backup is visible, not discovered only at restore.
-                if auto, folderLabel != nil,
+                // `lastMs > 0` excludes the never-backed-up state (the "No backup yet." line above owns that,
+                // and it would otherwise false-fire the moment auto is switched on, before the first backup).
+                if auto, folderLabel != nil, lastMs > 0,
                    BackupSync.isBackupStale(lastBackupMs: lastMs,
                                             nowMs: Int(Date().timeIntervalSince1970 * 1000.0)) {
                     HStack(alignment: .top, spacing: 8) {

--- a/StrandTests/BackupSyncTests.swift
+++ b/StrandTests/BackupSyncTests.swift
@@ -37,6 +37,16 @@ final class BackupSyncTests: XCTestCase {
         XCTAssertEqual(sorted, [c, b, a])
     }
 
+    func testIsBackupStale() {
+        let last = 1_782_000_000_000
+        let day = 24 * 60 * 60 * 1000
+        XCTAssertFalse(BackupSync.isBackupStale(lastBackupMs: last, nowMs: last))            // same instant
+        XCTAssertFalse(BackupSync.isBackupStale(lastBackupMs: last, nowMs: last + 2 * day))  // 2 days: still fresh
+        XCTAssertTrue(BackupSync.isBackupStale(lastBackupMs: last, nowMs: last + 3 * day))   // 3 days: stale (threshold)
+        XCTAssertTrue(BackupSync.isBackupStale(lastBackupMs: last, nowMs: last + 10 * day))  // well past
+        XCTAssertTrue(BackupSync.isBackupStale(lastBackupMs: 0, nowMs: last))                // never backed up: stale
+    }
+
     func testPruneKeepsNewestN() {
         let names = (0..<5).map { BackupSync.snapshotName(1_782_000_000_000 + $0 * 60_000) }
         let pruned = BackupSync.snapshotsToPrune(names + ["keepme.txt"], keep: 2)

--- a/android/app/src/main/java/com/noop/data/DataBackup.kt
+++ b/android/app/src/main/java/com/noop/data/DataBackup.kt
@@ -57,6 +57,36 @@ object DataBackup {
             0x6F, 0x72, 0x6D, 0x61, 0x74, 0x20, 0x33, 0x00,
         )
 
+    /**
+     * #1014 (write-side): cheaply confirm a JUST-WRITTEN `.noopbak` at [uri] is structurally intact — its
+     * DB entry is present and begins with the SQLite magic header. A torn write (truncated ZIP / a
+     * half-flushed SAF document on a full disk or flaky provider) otherwise leaves a `.noopbak` that
+     * silently "restores" into an empty store, caught only by the import-side quick_check much later. Fail
+     * HERE at write time instead. Twin of the Apple post-write check in `writeVerifiedBackupZip`.
+     * Best-effort: any read/format error returns false (treated as not-intact).
+     */
+    fun isWrittenBackupIntact(context: Context, uri: Uri): Boolean = runCatching {
+        context.contentResolver.openInputStream(uri)?.use { stream ->
+            ZipInputStream(stream).use { zip ->
+                var entry = zip.nextEntry
+                while (entry != null) {
+                    if (!entry.isDirectory && entry.name.substringAfterLast('/') == ZIP_ENTRY_NAME) {
+                        val header = ByteArray(SQLITE_MAGIC.size)
+                        var got = 0
+                        while (got < header.size) {
+                            val r = zip.read(header, got, header.size - got)
+                            if (r < 0) break
+                            got += r
+                        }
+                        return@runCatching got == header.size && header.contentEquals(SQLITE_MAGIC)
+                    }
+                    entry = zip.nextEntry
+                }
+                false
+            }
+        } ?: false
+    }.getOrDefault(false)
+
     /** First 4 bytes of every ZIP file: "PK\x03\x04". */
     private val ZIP_MAGIC: ByteArray =
         byteArrayOf(0x50, 0x4B, 0x03, 0x04)

--- a/android/app/src/main/java/com/noop/ui/BackupSync.kt
+++ b/android/app/src/main/java/com/noop/ui/BackupSync.kt
@@ -164,6 +164,17 @@ object BackupSync {
     /** True when [nowMs] is at least a day past [lastBackupMs] (pure, so the catch-up gate is testable). */
     fun isCatchUpDue(lastBackupMs: Long, nowMs: Long): Boolean = nowMs - lastBackupMs >= DAY_MS
 
+    /** Staleness threshold (3 days). Auto-backup runs a DAILY catch-up, so a *successful* backup older than
+     *  this means the catch-up isn't landing — a lost folder grant, or the app hasn't been opened in a
+     *  while. Twin of Apple `BackupSync.staleThresholdMs`. */
+    const val STALE_MS = 3L * DAY_MS
+
+    /** True when auto-backup should be flagged STALE: the last SUCCESSFUL backup is older than [thresholdMs]
+     *  ([lastBackupMs] == 0, i.e. never backed up while auto is on, also counts). Pure so it's testable with
+     *  literal ms; the caller gates on auto being ON + a chosen folder. Twin of Apple `BackupSync.isBackupStale`. */
+    fun isBackupStale(lastBackupMs: Long, nowMs: Long, thresholdMs: Long = STALE_MS): Boolean =
+        nowMs - lastBackupMs >= thresholdMs
+
     // ── Folder destination I/O (SAF tree via DocumentsContract - no extra dep) ──
 
     /** Create + write one snapshot into the chosen [treeUri]; returns the new file Uri, or null on failure. */
@@ -180,6 +191,11 @@ object BackupSync {
         // never picks up a corrupt snapshot.
         return runCatching {
             DataBackup.exportTo(context, fileUri)
+            // #1014 (write-side): confirm the file we just wrote is structurally intact — a torn write (full
+            // disk / flaky SAF provider) otherwise leaves a truncated .noopbak that "restores" empty, caught
+            // only at import. Require the DB entry present + valid SQLite header, else treat as a failure and
+            // delete it below. Twin of the Apple post-write check in writeVerifiedBackupZip.
+            require(DataBackup.isWrittenBackupIntact(context, fileUri)) { "backup written incompletely" }
             fileUri
         }.getOrElse {
             runCatching { DocumentsContract.deleteDocument(resolver, fileUri) }

--- a/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
@@ -315,6 +315,9 @@ fun BackupSyncScreen() {
                             Text(
                                 uiString(R.string.l10n_backup_sync_screen_auto_backup_hasn_t_run_in_e3cd484e),
                                 style = NoopType.caption, color = Palette.statusWarning,
+                                // weight(1f) so the long warning wraps within the Row instead of overflowing
+                                // the card on a narrow screen (parity with the iOS row's fixedSize wrap).
+                                modifier = Modifier.weight(1f),
                             )
                         }
                     }

--- a/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
@@ -298,6 +298,26 @@ fun BackupSyncScreen() {
                         },
                         style = NoopType.caption, color = Palette.textTertiary,
                     )
+                    // Auto is ON but the last SUCCESSFUL backup is stale — the daily catch-up isn't landing
+                    // (a lost folder grant, or the app hasn't been opened in a while). backupNow only stamps
+                    // lastMs on success, so this surfaces a silently-failing auto-backup instead of it being
+                    // discovered only at restore.
+                    if (auto && treeUri != null &&
+                        BackupSync.isBackupStale(lastMs, System.currentTimeMillis())
+                    ) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Icon(
+                                Icons.Filled.Warning,
+                                contentDescription = null,
+                                tint = Palette.statusWarning,
+                                modifier = Modifier.size(16.dp),
+                            )
+                            Text(
+                                uiString(R.string.l10n_backup_sync_screen_auto_backup_hasn_t_run_in_e3cd484e),
+                                style = NoopType.caption, color = Palette.statusWarning,
+                            )
+                        }
+                    }
                     NoopButton(
                         text = if (busy) "Working…" else "Back up now",
                         leadingIcon = Icons.Filled.CloudUpload,

--- a/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
@@ -302,7 +302,7 @@ fun BackupSyncScreen() {
                     // (a lost folder grant, or the app hasn't been opened in a while). backupNow only stamps
                     // lastMs on success, so this surfaces a silently-failing auto-backup instead of it being
                     // discovered only at restore.
-                    if (auto && treeUri != null &&
+                    if (auto && treeUri != null && lastMs > 0L &&
                         BackupSync.isBackupStale(lastMs, System.currentTimeMillis())
                     ) {
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1934,4 +1934,5 @@
     <string name="l10n_devices_screen_forget_device_926e503d">Gerät vergessen</string>
     <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">Dieses Gerät vergessen?</string>
     <string name="l10n_devices_screen_noop_removes_this_device_503aff9e">NOOP entfernt dieses Gerät aus deiner Liste und löscht die hier aufgezeichneten Daten. Du kannst den Strap erneut koppeln, um den jüngsten Verlauf wieder abzurufen.</string>
+    <string name="l10n_backup_sync_screen_auto_backup_hasn_t_run_in_e3cd484e">Das automatische Backup lief seit einigen Tagen nicht. Prüfe, ob der Backup-Ordner noch verfügbar ist – ein verschobener oder getrennter Cloud-Ordner stoppt Backups stillschweigend.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1919,4 +1919,5 @@
     <string name="l10n_devices_screen_forget_device_926e503d">Olvidar dispositivo</string>
     <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">¿Olvidar este dispositivo?</string>
     <string name="l10n_devices_screen_noop_removes_this_device_503aff9e">NOOP quita este dispositivo de tu lista y elimina los datos registrados aquí. Puedes volver a emparejar la banda para recuperar su historial reciente.</string>
+    <string name="l10n_backup_sync_screen_auto_backup_hasn_t_run_in_e3cd484e">La copia de seguridad automática no se ha ejecutado en varios días. Comprueba que la carpeta de copias sigue disponible: una carpeta en la nube movida o desconectada detiene las copias sin avisar.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1919,4 +1919,5 @@
     <string name="l10n_devices_screen_forget_device_926e503d">Oublier l\'appareil</string>
     <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">Oublier cet appareil ?</string>
     <string name="l10n_devices_screen_noop_removes_this_device_503aff9e">NOOP retire cet appareil de votre liste et supprime les données enregistrées ici. Vous pouvez ré-appairer le bracelet pour récupérer son historique récent.</string>
+    <string name="l10n_backup_sync_screen_auto_backup_hasn_t_run_in_e3cd484e">La sauvegarde automatique n\'a pas eu lieu depuis plusieurs jours. Vérifie que le dossier de sauvegarde est toujours disponible — un dossier cloud déplacé ou déconnecté interrompt les sauvegardes en silence.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1913,4 +1913,5 @@
     <string name="l10n_devices_screen_forget_device_926e503d">Esquecer dispositivo</string>
     <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">Esquecer este dispositivo?</string>
     <string name="l10n_devices_screen_noop_removes_this_device_503aff9e">O NOOP remove este dispositivo da tua lista e elimina os dados registados aqui. Podes voltar a emparelhar a banda para obter novamente o histórico recente.</string>
+    <string name="l10n_backup_sync_screen_auto_backup_hasn_t_run_in_e3cd484e">A cópia de segurança automática não é feita há alguns dias. Verifica se a pasta de backup ainda está disponível — uma pasta na nuvem movida ou desligada interrompe as cópias silenciosamente.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1847,4 +1847,5 @@
     <string name="l10n_devices_screen_forget_device_926e503d">忘记设备</string>
     <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">忘记此设备？</string>
     <string name="l10n_devices_screen_noop_removes_this_device_503aff9e">NOOP 会从你的列表中移除此设备，并删除此处记录的数据。你可以重新配对设备，以再次获取其最近的历史记录。</string>
+    <string name="l10n_backup_sync_screen_auto_backup_hasn_t_run_in_e3cd484e">自动备份已有几天未运行。请检查备份文件夹是否仍然可用——被移动或断开连接的云文件夹会悄然停止备份。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1946,4 +1946,5 @@
     <string name="l10n_devices_screen_forget_device_926e503d">Forget device</string>
     <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">Forget this device?</string>
     <string name="l10n_devices_screen_noop_removes_this_device_503aff9e">NOOP removes this device from your list and deletes its recorded data here. You can re-pair the strap to pull its recent history back.</string>
+    <string name="l10n_backup_sync_screen_auto_backup_hasn_t_run_in_e3cd484e">Auto-backup hasn\'t run in a few days. Check the backup folder is still available — a moved or disconnected cloud folder stops backups silently.</string>
 </resources>

--- a/android/app/src/test/java/com/noop/ui/BackupSyncTest.kt
+++ b/android/app/src/test/java/com/noop/ui/BackupSyncTest.kt
@@ -87,6 +87,16 @@ class BackupSyncTest {
         assertTrue(BackupSync.isCatchUpDue(0L, last))                          // never-backed-up: due
     }
 
+    @Test fun isBackupStaleAfterThreshold() {
+        val last = 1_782_000_000_000L
+        val day = 24L * 3_600_000L
+        assertFalse(BackupSync.isBackupStale(last, last))            // same instant
+        assertFalse(BackupSync.isBackupStale(last, last + 2 * day))  // 2 days: still fresh
+        assertTrue(BackupSync.isBackupStale(last, last + 3 * day))   // 3 days: stale (threshold)
+        assertTrue(BackupSync.isBackupStale(last, last + 10 * day))  // well past
+        assertTrue(BackupSync.isBackupStale(0L, last))              // never backed up: stale
+    }
+
     // Restore listing accepts ANY .noopbak, including date-only manual names (#852).
 
     @Test fun isBackupFileAcceptsAnyNoopbakExtension() {


### PR DESCRIPTION
Two hardening items for the **Backup & Sync auto-backup** — the safety net that makes the new Forget-device hard-delete (#1194) recoverable. Both platforms, parity.

### 1. Stale-backup warning (the real gap)
`backupNow()` only stamps the last-backup timestamp on **success**, so a **silently-failing** auto-backup — a moved / permission-lost cloud folder, or simply not launching the app — left the timestamp stale with **no signal**. A user could believe they're covered when they aren't, and only find out at restore.
- New **pure** `isBackupStale(lastBackupMs, nowMs, threshold=3d)` (twin on both platforms; unit-tested with literal ms).
- A **warning row** on the Backup & Sync screen when auto is on + a folder is set + the last *successful* backup is > 3 days old. Matches the existing #644 warning-row style.

### 2. Post-write structural verify
`writeVerifiedBackupZip` already `quick_check`s the **source** DB before zipping. Now it also re-opens the **produced** `.noopbak` (a cheap central-directory read, no extraction) and requires the DB entry to be **present + begin with the SQLite magic header**. A torn write (full disk / flaky cloud / SAF provider) now **fails at write time** — and the corrupt file is deleted — instead of silently "restoring" into an empty store, caught only by the import-side `quick_check` much later (#1014). Android mirrors this via `DataBackup.isWrittenBackupIntact` (re-read the produced Uri → `ZipInputStream` → entry + `SQLITE_MAGIC`).

### Context
Investigated per the Forget-device follow-up: auto-backup is **opt-in and off by default**, on-launch daily, keeps ~7 snapshots — solid machinery (WAL checkpoint, DEFLATE ~5–10×, armored restore, safe prune, iCloud-placeholder handling) but with these two edges. This closes them.

### Verification
- **Android** (local): `compileFullDebugKotlin` ✓; `com.noop.ui.BackupSyncTest` (incl. new `isBackupStaleAfterThreshold`) + `com.noop.data.DataBackup*` ✓; `i18n_audit.py --platform android --ci` ✓.
- **iOS**: new `BackupSyncTests.testIsBackupStale` (pure). These + `BackupSyncView`/`DataBackup` are **app-target/StrandTests** (no default CI) → validated via **app-build** (macOS `StrandTests` + iOS compile). `i18n_audit.py --platform ios --ci` ✓ (2 new strings ×8 locales).
- Backup I/O itself (SAF / security-scoped folders, cloud sync) is inherently device-side; the pure logic + write/restore integrity are unit-covered.
