### PR TITLE
fix(ble): let Broadcast-HR be turned OFF on 5/MG + make its log honest (#1061)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/DeviceConfigWriteGate.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/DeviceConfigWriteGate.swift
@@ -158,6 +158,15 @@ public enum DeviceConfigWriteGate {
         return String(decoding: name, as: UTF8.self)
     }
 
+    /// The single value byte a `SET_DEVICE_CONFIG_VALUE` payload carries immediately after the 32-byte
+    /// NUL-padded name field, or nil when the payload is too short to hold one. The gate only ever writes
+    /// single-character values ('0'/'1'), so this one byte is the whole value. Used to tell a turn-OFF
+    /// write from a turn-ON write in `admitsSend`.
+    public static func valueByte(inSendPayload payload: [UInt8]) -> UInt8? {
+        guard payload.count > 1 + nameFieldBytes, payload[0] == 0x01 else { return nil }
+        return payload[1 + nameFieldBytes]
+    }
+
     // MARK: - The allowlist predicate
 
     /// Whether a device-config KEY may be written, given the two opt-ins and the hardware attestation.
@@ -189,6 +198,13 @@ public enum DeviceConfigWriteGate {
                                   broadcastHrOptIn: Bool) -> Bool {
         guard opcode == setDeviceConfigValueCmd else { return false }
         guard let key = keyName(inSendPayload: payload) else { return false }
+        // #1061: turning the Broadcast-HR flag OFF is the safe UNDO and must NEVER be gated on the opt-in.
+        // The opt-in (`broadcastHrEnabled`) is bound straight to the Settings switch, so it is already false
+        // by the time the user disables — gating the OFF write on it made the toggle-off path DEAD (the
+        // disable was refused here, the strap stayed advertising, and the app could not clear it). Same
+        // lesson the #174 R22 disable clause records for SET_FF_VALUE. So admit the Broadcast-HR OFF write
+        // unconditionally; the ON write (and the ECG key, both directions) stay gated by `isWritableKey`.
+        if key == broadcastHrKey, valueByte(inSendPayload: payload) == disabledValue { return true }
         return isWritableKey(key, ecgGateOptIn: ecgGateOptIn, isMG: isMG, broadcastHrOptIn: broadcastHrOptIn)
     }
 

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DeviceConfigWriteGateTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DeviceConfigWriteGateTests.swift
@@ -72,6 +72,26 @@ final class DeviceConfigWriteGateTests: XCTestCase {
             opcode: 119, payload: p, ecgGateOptIn: true, isMG: false, broadcastHrOptIn: true))
     }
 
+    func testAdmitsBroadcastHrDisableWriteRegardlessOfOptIn() {
+        // #1061: turning the Broadcast-HR flag OFF is the safe UNDO and must NOT be gated on the opt-in —
+        // it is already false by the time the user disables, which made the toggle-off path dead (the
+        // disable refused here, strap left advertising). The OFF write must be admitted with NO opt-in.
+        let off = payload(key: DeviceConfigWriteGate.broadcastHrKey, value: DeviceConfigWriteGate.disabledValue)
+        XCTAssertTrue(DeviceConfigWriteGate.admitsSend(
+            opcode: 119, payload: off, ecgGateOptIn: false, isMG: false, broadcastHrOptIn: false))
+        XCTAssertTrue(DeviceConfigWriteGate.admitsSend(
+            opcode: 119, payload: off, ecgGateOptIn: false, isMG: false, broadcastHrOptIn: true))
+        // The ON write stays gated on the opt-in — the exemption is for OFF only.
+        let on = payload(key: DeviceConfigWriteGate.broadcastHrKey, value: DeviceConfigWriteGate.enabledValue)
+        XCTAssertFalse(DeviceConfigWriteGate.admitsSend(
+            opcode: 119, payload: on, ecgGateOptIn: false, isMG: false, broadcastHrOptIn: false))
+        // The OFF exemption is Broadcast-HR ONLY: the ECG key's OFF write is still gated on its own opt-in
+        // (a mandatory read-back gate, #891) — the exemption must not leak to it.
+        let ecgOff = payload(key: DeviceConfigWriteGate.ecgRawDataKey, value: DeviceConfigWriteGate.disabledValue)
+        XCTAssertFalse(DeviceConfigWriteGate.admitsSend(
+            opcode: 119, payload: ecgOff, ecgGateOptIn: false, isMG: true, broadcastHrOptIn: false))
+    }
+
     // MARK: - The allowlist: what it refuses
 
     func testRefusesEveryOtherEnumeratedKeyEvenWithBothOptInsOn() {

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2755,10 +2755,22 @@ public final class BLEManager: NSObject, ObservableObject {
         guard state.connected, state.bonded else {
             log("Broadcast HR: connect and bond a 5/MG strap first — ignored."); return
         }
-        let value: UInt8 = on ? 0x31 : 0x30   // ASCII '1' / '0'
-        send(.setDeviceConfig,
-             payload: [0x01] + Whoop5Config.deviceConfigBody(name: "whoop_live_hr_in_adv_ind_pkt", value: value),
-             writeType: .withResponse)
+        let payload = [0x01] + Whoop5Config.deviceConfigBody(name: DeviceConfigWriteGate.broadcastHrKey,
+                                                             value: DeviceConfigWriteGate.value(on: on))
+        // #1061: report the ACTUAL outcome, not a fire-and-forget "wrote". `send` SILENTLY drops a command
+        // the 5/MG send gate refuses, so the old unconditional "wrote" line lied when the write never went
+        // out — which is exactly what a reporter saw on the disable path. Consult the SAME gate the send
+        // path uses and log honestly. (With the gate's #1061 fix the OFF write is now admitted, so this
+        // branch normally reports a real write; the guard keeps the log truthful if a write is ever refused.)
+        guard DeviceConfigWriteGate.admitsSend(opcode: DeviceConfigWriteGate.setDeviceConfigValueCmd,
+                                               payload: payload,
+                                               ecgGateOptIn: PuffinExperiment.ecgRawDataEnabled,
+                                               isMG: isWhoop5MG,
+                                               broadcastHrOptIn: PuffinExperiment.broadcastHrEnabled) else {
+            log("Broadcast HR: write whoop_live_hr_in_adv_ind_pkt=\(on ? "1" : "0") REFUSED by the 5/MG send gate — strap unchanged.")
+            return
+        }
+        send(.setDeviceConfig, payload: payload, writeType: .withResponse)
         log("Broadcast HR: wrote whoop_live_hr_in_adv_ind_pkt=\(on ? "1" : "0")")
     }
 

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -6037,12 +6037,26 @@ class WhoopBleClient(
         if (!s.connected || !s.bonded) {
             log("Broadcast HR: connect and bond a 5/MG strap first — ignored."); return
         }
-        val value = if (on) 0x31 else 0x30   // ASCII '1' / '0'
-        send(
-            CommandNumber.SET_DEVICE_CONFIG,
-            byteArrayOf(0x01) + Whoop5Config.deviceConfigBody("whoop_live_hr_in_adv_ind_pkt", value),
-            withResponse = true,
-        )
+        val payload = byteArrayOf(0x01) +
+            Whoop5Config.deviceConfigBody(DeviceConfigWriteGate.BROADCAST_HR_KEY, DeviceConfigWriteGate.value(on))
+        // #1061: report the ACTUAL outcome, not a fire-and-forget "wrote". send() SILENTLY drops a command
+        // the 5/MG send gate refuses, so the old unconditional "wrote" line lied when the write never went
+        // out — exactly what a reporter saw on the disable path. Consult the SAME gate the send path uses and
+        // log honestly. (With the gate's #1061 fix the OFF write is now admitted, so this normally reports a
+        // real write; the guard keeps the log truthful if a write is ever refused.)
+        if (!DeviceConfigWriteGate.admitsSend(
+                opcode = CommandNumber.SET_DEVICE_CONFIG.rawValue,
+                payload = payload,
+                ecgGateOptIn = puffinExperiment.ecgRawData,
+                isMG = whoop5Variant().isMG,
+                broadcastHrOptIn = puffinExperiment.broadcastHr,
+            )
+        ) {
+            log("Broadcast HR: write whoop_live_hr_in_adv_ind_pkt=" + (if (on) "1" else "0") +
+                " REFUSED by the 5/MG send gate — strap unchanged.")
+            return
+        }
+        send(CommandNumber.SET_DEVICE_CONFIG, payload, withResponse = true)
         log("Broadcast HR: wrote whoop_live_hr_in_adv_ind_pkt=" + (if (on) "1" else "0"))
     }
 

--- a/android/app/src/main/java/com/noop/protocol/DeviceConfigWriteGate.kt
+++ b/android/app/src/main/java/com/noop/protocol/DeviceConfigWriteGate.kt
@@ -161,6 +161,16 @@ object DeviceConfigWriteGate {
         return name.toString()
     }
 
+    /** The single value byte a SET_DEVICE_CONFIG_VALUE payload carries immediately after the 32-byte
+     *  NUL-padded name field, or null when the payload is too short to hold one. The gate only ever writes
+     *  single-character values ('0'/'1'), so this one byte is the whole value. Used to tell a turn-OFF write
+     *  from a turn-ON write in [admitsSend]. Twin of Swift `DeviceConfigWriteGate.valueByte(inSendPayload:)`. */
+    fun valueByteInSendPayload(payload: ByteArray): Int? {
+        if (payload.size <= 1 + NAME_FIELD_BYTES) return null
+        if ((payload[0].toInt() and 0xFF) != 0x01) return null
+        return payload[1 + NAME_FIELD_BYTES].toInt() and 0xFF
+    }
+
     // The allowlist predicate -----------------------------------------------------------------------
 
     /**
@@ -198,6 +208,13 @@ object DeviceConfigWriteGate {
     ): Boolean {
         if (opcode != SET_DEVICE_CONFIG_VALUE_CMD) return false
         val key = keyNameInSendPayload(payload) ?: return false
+        // #1061: turning the Broadcast-HR flag OFF is the safe UNDO and must NEVER be gated on the opt-in.
+        // The opt-in is bound straight to the Settings switch, so it is already false by the time the user
+        // disables — gating the OFF write on it made the toggle-off path DEAD (the disable refused here, the
+        // strap left advertising, the app unable to clear it). Same lesson the #174 R22 disable clause
+        // records for SET_FF_VALUE. Admit the Broadcast-HR OFF write unconditionally; the ON write (and the
+        // ECG key, both directions) stay gated by [isWritableKey]. Byte-identical to the Swift twin.
+        if (key == BROADCAST_HR_KEY && valueByteInSendPayload(payload) == DISABLED_VALUE) return true
         return isWritableKey(key, ecgGateOptIn, isMG, broadcastHrOptIn)
     }
 

--- a/android/app/src/test/java/com/noop/protocol/DeviceConfigWriteGateTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/DeviceConfigWriteGateTest.kt
@@ -78,6 +78,22 @@ class DeviceConfigWriteGateTest {
         assertTrue(DeviceConfigWriteGate.admitsSend(119, p, ecgGateOptIn = true, isMG = false, broadcastHrOptIn = true))
     }
 
+    @Test
+    fun admitsBroadcastHrDisableWriteRegardlessOfOptIn() {
+        // #1061: turning the Broadcast-HR flag OFF is the safe UNDO and must NOT be gated on the opt-in — it
+        // is already false by the time the user disables, which made the toggle-off path dead (the disable
+        // refused here, strap left advertising). The OFF write must be admitted with NO opt-in.
+        val off = payload(DeviceConfigWriteGate.BROADCAST_HR_KEY, DeviceConfigWriteGate.DISABLED_VALUE)
+        assertTrue(DeviceConfigWriteGate.admitsSend(119, off, ecgGateOptIn = false, isMG = false, broadcastHrOptIn = false))
+        assertTrue(DeviceConfigWriteGate.admitsSend(119, off, ecgGateOptIn = false, isMG = false, broadcastHrOptIn = true))
+        // The ON write stays gated on the opt-in — the exemption is for OFF only.
+        val on = payload(DeviceConfigWriteGate.BROADCAST_HR_KEY, DeviceConfigWriteGate.ENABLED_VALUE)
+        assertFalse(DeviceConfigWriteGate.admitsSend(119, on, ecgGateOptIn = false, isMG = false, broadcastHrOptIn = false))
+        // The OFF exemption is Broadcast-HR ONLY: the ECG key's OFF write stays gated on its own opt-in (#891).
+        val ecgOff = payload(DeviceConfigWriteGate.ECG_RAW_DATA_KEY, DeviceConfigWriteGate.DISABLED_VALUE)
+        assertFalse(DeviceConfigWriteGate.admitsSend(119, ecgOff, ecgGateOptIn = false, isMG = true, broadcastHrOptIn = false))
+    }
+
     // The allowlist: what it refuses -----------------------------------------------------------------
 
     @Test


### PR DESCRIPTION
Fixes two bugs the #1061 report surfaced in the experimental "Broadcast strap HR" feature (#181) on WHOOP 5/MG. (The firmware question — does 50.36.2.0 actually advertise 0x180D — is separate and stays open; see below.)

### Bug 1 — you could turn Broadcast-HR ON but never OFF
The 5/MG send gate admitted the broadcast-HR `SET_DEVICE_CONFIG` write only while `broadcastHrEnabled` was true. But that opt-in is bound straight to the Settings switch, so it's **already false by the time the user disables** — the `=0` write was refused ("skipped — no WHOOP 5/MG framing"), the strap kept advertising, and the app couldn't clear it. This is the **exact dead-toggle-off the #174 deep-data clause already documents and fixes** for `SET_FF_VALUE`; #181 never got the same treatment.

**Fix:** `DeviceConfigWriteGate.admitsSend` now admits the Broadcast-HR **OFF** write unconditionally (turning a flag off is the safe undo); the **ON** write and the ECG key (both directions) stay gated. A new `valueByte` parser tells on from off. Scoped strictly to the broadcast key — the ECG gate's OFF write is *not* exempted (asserted by test).

### Bug 2 — the "wrote …" log lied when the send was dropped
`setBroadcastHr` logged `Broadcast HR: wrote …=N` unconditionally, but `send()` **silently drops** a command the gate refuses — so the reporter saw "wrote =0" for a write that never went out. **Fix:** `setBroadcastHr` consults the same gate and logs the real outcome (`wrote` vs `REFUSED by the send gate — strap unchanged`).

Together these caused the confusion: disable → write refused (bug 1) → log says "wrote =0" (bug 2) → user thinks it's off, but the strap is stuck on and can't be cleared from the app.

### The firmware question (still open)
On this reporter's MG at 50.36.2.0 the strap doesn't advertise 0x180D despite the write (it worked on other hardware — validated on a Garmin Edge 840). That's a firmware-behaviour question this PR doesn't touch. Next step is the reporter's own suggestion: **run the Test Centre device-config READ probe (GET_DEVICE_CONFIG_VALUE/121) against `whoop_live_hr_in_adv_ind_pkt`** to distinguish "written but fw doesn't advertise" from "write ignored".

### Verification
- **Pure gate** (`WhoopProtocol`, runs on Linux + CI): `swift build` + `swift test` ✓, new `testAdmitsBroadcastHrDisableWriteRegardlessOfOptIn`. Android: `compileFullDebugKotlin` + `DeviceConfigWriteGateTest` ✓ (twin test).
- **App-target log change** (`BLEManager` / `WhoopBleClient`): no default CI → validated via **app-build**. BLE send behaviour itself is confirmed only on a strap (the gate predicate is the unit-tested part).

Refs #1061, #181, #174 (the precedent), #103 (the read probe).
