### PR TITLE
Read back the Broadcast-HR flag write and report what the strap stores (#1061)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/DeviceConfigWriteGate.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/DeviceConfigWriteGate.swift
@@ -369,3 +369,123 @@ public struct EcgRawDataGateReport: Equatable, Sendable {
         return sb
     }
 }
+
+// MARK: - Broadcast-HR read-back report (#1061)
+
+/// The result of one Broadcast-HR (#181) write + mandatory read-back, as a copyable report.
+///
+/// #1061: the strap-flag write (`whoop_live_hr_in_adv_ind_pkt`) was fire-and-forget — NOOP never read it
+/// back, so a reporter on FW 50.36.2.0 could not tell whether the firmware ACCEPTED the flag (and simply
+/// doesn't advertise 0x180D) or IGNORED the write. That is inconsistent with this file's own rule — "read-
+/// back is the proof, not the ack" — which the ECG gate on the SAME opcode already follows. So the write
+/// now reads itself back with `GET_DEVICE_CONFIG_VALUE(121)` and reports the value the strap actually stores.
+///
+/// Same order-dependent, pure verdict machinery as `EcgRawDataGateReport` (`noteWriteAck` → `noteReadBack`/
+/// `noteReadBackTimeout` → `render`), so `swift test` covers the whole table without a strap. Kotlin twin:
+/// `BroadcastHrGateReport`; the rendered text is byte-identical across platforms.
+public struct BroadcastHrGateReport: Equatable, Sendable {
+
+    /// What the run established — identical semantics to `EcgRawDataGateReport.Verdict`: a write whose ack
+    /// said SUCCESS but whose read-back did not move is `.unchanged`, not success.
+    public enum Verdict: String, Equatable, Sendable {
+        case confirmed, unchanged, notClaimed, refused, silent, undecodable, pending
+    }
+
+    /// The value that was requested, as the strap stores it ("1" = advertise on / "0" = off).
+    public let requested: String
+    public private(set) var writeResultCode: Int?
+    public private(set) var storedValue: String?
+    public private(set) var readBackResultCode: Int?
+    public private(set) var readBackRecordHex: String?
+    public private(set) var trace: [String] = []
+    public private(set) var verdict: Verdict = .pending
+
+    public init(on: Bool) {
+        self.requested = DeviceConfigWriteGate.valueString(on: on)
+        trace.append("SET_DEVICE_CONFIG_VALUE(119) key=\"\(DeviceConfigWriteGate.broadcastHrKey)\" value='\(requested)' sent")
+    }
+
+    /// Record the write's own ack. Logged and NOT used to decide anything — a SUCCESS result code does not
+    /// prove state changed (the #891 lesson applies to every device-config write).
+    public mutating func noteWriteAck(resultCode: Int?) {
+        writeResultCode = resultCode
+        let label = resultCode.map { "\(FeatureFlagProbe.resultLabel($0))(\($0))" } ?? "(unlabelled)"
+        trace.append("write ack → result=\(label) — recorded, not treated as proof; the read-back below is the proof")
+    }
+
+    /// Record the decoded read-back and reach a verdict.
+    public mutating func noteReadBack(_ r: DeviceConfigReadProbe.ValueResponse) {
+        readBackResultCode = r.resultCode
+        readBackRecordHex = r.recordHex
+        let stored = r.value(for: DeviceConfigWriteGate.broadcastHrKey)
+            .flatMap { (0x20...0x7E).contains($0) ? String(UnicodeScalar($0)) : nil }
+        storedValue = stored
+        var line = "GET_DEVICE_CONFIG_VALUE(121) key=\"\(DeviceConfigWriteGate.broadcastHrKey)\""
+        if let c = r.resultCode { line += " → result=\(FeatureFlagProbe.resultLabel(c))(\(c))" } else { line += " →" }
+        if let stored { line += " value='\(stored)'" }
+        line += " record=[\(r.recordHex)]"
+        trace.append(line)
+
+        if r.isUnsupported || r.isFailure {
+            verdict = .refused
+        } else if let stored {
+            verdict = stored == requested ? .confirmed : .unchanged
+        } else {
+            verdict = .notClaimed
+        }
+    }
+
+    /// Record a read-back reply that could not be decoded.
+    public mutating func noteReadBackFailure(_ f: DeviceConfigReadProbe.ParseFailure) {
+        let why: String
+        switch f {
+        case .crc:          why = "CRC failed — frame rejected (never decoded)"
+        case .envelope:     why = "not a COMMAND_RESPONSE envelope"
+        case .wrongCommand: why = "COMMAND_RESPONSE for a different command"
+        case .truncated:    why = "record too short to hold a response"
+        }
+        trace.append("read-back reply not decoded: \(why)")
+        verdict = .undecodable
+    }
+
+    /// Record the strap answering nothing at all to the read-back.
+    public mutating func noteReadBackTimeout(seconds: Int) {
+        trace.append("GET_DEVICE_CONFIG_VALUE(121) → no COMMAND_RESPONSE within \(seconds)s")
+        verdict = .silent
+    }
+
+    /// One-line summary, suitable for a strap-log line.
+    public var summary: String {
+        switch verdict {
+        case .confirmed:
+            return "Strap now reports \(DeviceConfigWriteGate.broadcastHrKey)='\(requested)' (read back, not just acked)."
+        case .unchanged:
+            return "Write did NOT take: asked for '\(requested)', strap still reports '\(storedValue ?? "?")'."
+        case .notClaimed:
+            return "Strap answered the read-back but did not echo the key, so no value is claimed."
+        case .refused:
+            return "Strap refused the read-back for this key — the stored value is unknown."
+        case .silent:
+            return "No reply to the read-back — the stored value is unknown."
+        case .undecodable:
+            return "The read-back reply did not decode — the stored value is unknown."
+        case .pending:
+            return "Waiting for the read-back…"
+        }
+    }
+
+    /// The full copyable report.
+    public func render() -> String {
+        var sb = "#1061 BROADCAST-HR FLAG — WHOOP 5/MG\n"
+        sb += "Key: \(DeviceConfigWriteGate.broadcastHrKey) (makes the strap advertise its HR as a standard 0x180D sensor)\n"
+        sb += "Wrote '\(requested)' via SET_DEVICE_CONFIG_VALUE(119), then read it back with "
+        sb += "GET_DEVICE_CONFIG_VALUE(121). The write ack is never trusted; only the read-back decides.\n"
+        sb += "\nVerdict: \(verdict.rawValue) — \(summary)\n"
+        sb += "\nExchange:\n"
+        for line in trace { sb += "  " + line + "\n" }
+        sb += "\nNOTE: a CONFIRMED read-back means the FLAG is stored, NOT that the strap advertises 0x180D — "
+        sb += "some firmware (e.g. 50.36.x) stores it but doesn't advertise. If it reads '1' here yet no "
+        sb += "watch/nRF-Connect scan shows 0x180D while disconnected, that is a firmware result for #1061.\n"
+        return sb
+    }
+}

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DeviceConfigWriteGateTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DeviceConfigWriteGateTests.swift
@@ -292,6 +292,44 @@ final class DeviceConfigWriteGateTests: XCTestCase {
         XCTAssertEqual(report.verdict, .confirmed)
     }
 
+    func testBroadcastHrReadBackVerdictTable() {
+        // #1061: the broadcast-HR write now reads itself back, same discipline as the ECG gate. Confirmed
+        // only when the strap stores what was asked; a SUCCESS ack with an unmoved value is `.unchanged`.
+        func parsed(_ value: String) -> DeviceConfigReadProbe.ValueResponse {
+            let frame = readBackFrame(record: echoRecord(key: DeviceConfigWriteGate.broadcastHrKey, value: value))
+            guard case .success(let r) = DeviceConfigReadProbe.parse(frame: frame, family: .whoop5, expecting: 121)
+            else { fatalError("read-back frame should parse") }
+            return r
+        }
+        var confirmed = BroadcastHrGateReport(on: true)
+        confirmed.noteWriteAck(resultCode: 1)
+        confirmed.noteReadBack(parsed("1"))
+        XCTAssertEqual(confirmed.verdict, .confirmed)
+        XCTAssertEqual(confirmed.storedValue, "1")
+        XCTAssertTrue(confirmed.render().contains("whoop_live_hr_in_adv_ind_pkt"))
+        // A CONFIRMED read-back must still warn that a stored flag ≠ actually advertising 0x180D (#1061).
+        XCTAssertTrue(confirmed.render().contains("0x180D"))
+
+        var unchanged = BroadcastHrGateReport(on: true)
+        unchanged.noteWriteAck(resultCode: 1)          // strap acked SUCCESS…
+        unchanged.noteReadBack(parsed("0"))            // …but the value did not move
+        XCTAssertEqual(unchanged.verdict, .unchanged)
+        XCTAssertTrue(unchanged.summary.contains("did NOT take"))
+
+        var off = BroadcastHrGateReport(on: false)     // disable confirms on '0'
+        XCTAssertEqual(off.requested, "0")
+        off.noteReadBack(parsed("0"))
+        XCTAssertEqual(off.verdict, .confirmed)
+
+        var silent = BroadcastHrGateReport(on: true)
+        silent.noteReadBackTimeout(seconds: 8)
+        XCTAssertEqual(silent.verdict, .silent)
+
+        var refused = BroadcastHrGateReport(on: true)
+        refused.noteReadBack(DeviceConfigReadProbe.ValueResponse(resultCode: 0, record: []))
+        XCTAssertEqual(refused.verdict, .refused)
+    }
+
     func testRefusedSilentNotClaimedAndUndecodableAreNeverSuccess() {
         // FAILURE for the key.
         var refused = EcgRawDataGateReport(on: true)

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1664,9 +1664,11 @@ public final class BLEManager: NSObject, ObservableObject {
                                                     ecgGateOptIn: PuffinExperiment.ecgRawDataEnabled,
                                                     isMG: isWhoop5MG,
                                                     broadcastHrOptIn: PuffinExperiment.broadcastHrEnabled)
-                // GET_DEVICE_CONFIG_VALUE(121) as the ECG gate's mandatory READ-BACK — gated on a write
-                // being verified, exactly like the R22 read-back above. The write ack is never the proof.
-                || (DeviceConfigWriteGate.isReadBackOpcode(command.rawValue) && ecgGateReport != nil)
+                // GET_DEVICE_CONFIG_VALUE(121) as a gate's mandatory READ-BACK — gated on a write being
+                // verified, exactly like the R22 read-back above. The write ack is never the proof. Both the
+                // ECG gate (#891) and the Broadcast-HR gate (#1061) read themselves back over this opcode.
+                || (DeviceConfigWriteGate.isReadBackOpcode(command.rawValue)
+                    && (ecgGateReport != nil || broadcastHrGateReport != nil))
                 // The WHOOP MG ECG ("Labrador") family — allowed ONLY when BOTH gates hold: the
                 // Experimental opt-in is on AND the strap has POSITIVELY attested itself an MG over the
                 // Device Information Service. A plain 5.0 has no electrodes and an unidentified strap
@@ -2755,13 +2757,17 @@ public final class BLEManager: NSObject, ObservableObject {
         guard state.connected, state.bonded else {
             log("Broadcast HR: connect and bond a 5/MG strap first — ignored."); return
         }
+        // Mutually exclusive with the ECG gate: both verify over the SAME 121 read-back opcode, so if both
+        // were in flight one strap reply would be consumed by both handlers and cross-contaminate the other's
+        // verdict (its key isn't echoed → a spurious notClaimed). Only one device-config write verifies at once.
+        guard broadcastHrGateReport == nil, ecgGateReport == nil else {
+            log("Broadcast HR: a device-config write is already being verified — ignored."); return
+        }
         let payload = [0x01] + Whoop5Config.deviceConfigBody(name: DeviceConfigWriteGate.broadcastHrKey,
                                                              value: DeviceConfigWriteGate.value(on: on))
-        // #1061: report the ACTUAL outcome, not a fire-and-forget "wrote". `send` SILENTLY drops a command
-        // the 5/MG send gate refuses, so the old unconditional "wrote" line lied when the write never went
-        // out — which is exactly what a reporter saw on the disable path. Consult the SAME gate the send
-        // path uses and log honestly. (With the gate's #1061 fix the OFF write is now admitted, so this
-        // branch normally reports a real write; the guard keeps the log truthful if a write is ever refused.)
+        // #1061: `send` SILENTLY drops a command the 5/MG gate refuses, so consult the SAME gate and log
+        // honestly instead of a fire-and-forget "wrote". (The gate's OFF-write fix means the disable is now
+        // admitted; this keeps the log truthful if a write is ever refused.)
         guard DeviceConfigWriteGate.admitsSend(opcode: DeviceConfigWriteGate.setDeviceConfigValueCmd,
                                                payload: payload,
                                                ecgGateOptIn: PuffinExperiment.ecgRawDataEnabled,
@@ -2770,8 +2776,58 @@ public final class BLEManager: NSObject, ObservableObject {
             log("Broadcast HR: write whoop_live_hr_in_adv_ind_pkt=\(on ? "1" : "0") REFUSED by the 5/MG send gate — strap unchanged.")
             return
         }
+        // #1061: write, then READ IT BACK — the ack is not the proof. A reporter on FW 50.36.2.0 saw the
+        // flag written yet the strap never advertised 0x180D, with no way to tell "accepted but not
+        // advertised" from "write ignored". The 121 read-back settles that, same discipline as the ECG gate.
+        broadcastHrGateReport = BroadcastHrGateReport(on: on)
+        log("Broadcast HR: writing \(DeviceConfigWriteGate.broadcastHrKey)='\(DeviceConfigWriteGate.valueString(on: on))' via SET_DEVICE_CONFIG_VALUE(119); the ack is NOT the result — a GET_DEVICE_CONFIG_VALUE(121) read-back follows.")
         send(.setDeviceConfig, payload: payload, writeType: .withResponse)
-        log("Broadcast HR: wrote whoop_live_hr_in_adv_ind_pkt=\(on ? "1" : "0")")
+
+        broadcastHrGateStep &+= 1
+        let armed = broadcastHrGateStep
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) { [weak self] in
+            guard let self, self.broadcastHrGateReport != nil, self.broadcastHrGateStep == armed else { return }
+            self.send(.getDeviceConfigValue,
+                      payload: DeviceConfigReadProbe.requestBody(key: DeviceConfigWriteGate.broadcastHrKey))
+            DispatchQueue.main.asyncAfter(deadline: .now() + BLEManager.ecgGateReadBackTimeout) { [weak self] in
+                guard let self, self.broadcastHrGateReport != nil, self.broadcastHrGateStep == armed else { return }
+                self.broadcastHrGateReport?.noteReadBackTimeout(seconds: Int(BLEManager.ecgGateReadBackTimeout))
+                self.finishBroadcastHrWrite()
+            }
+        }
+    }
+
+    /// Non-nil only while a Broadcast-HR write is being verified (#1061) — same single-flight discipline as
+    /// the ECG gate. The send allowlist consults it so the 121 read-back can go out; the frame router routes
+    /// the ack + read-back replies here.
+    private var broadcastHrGateReport: BroadcastHrGateReport?
+    private var broadcastHrGateStep = 0
+
+    private func finishBroadcastHrWrite() {
+        guard let report = broadcastHrGateReport else { return }
+        broadcastHrGateReport = nil
+        log("Broadcast HR (#1061):\n\(report.render())")
+    }
+
+    /// The write's own COMMAND_RESPONSE — recorded, never treated as proof. Routed here when a 119 reply
+    /// lands while a Broadcast-HR write is being verified.
+    private func handleBroadcastHrGateWriteAck(_ frame: [UInt8], cmdOff: Int) {
+        guard broadcastHrGateReport != nil else { return }
+        let resultIndex = cmdOff + 2
+        let code: Int? = frame.count > resultIndex ? Int(frame[resultIndex]) : nil
+        broadcastHrGateReport?.noteWriteAck(resultCode: code)
+    }
+
+    /// The 121 read-back — the ONLY thing that decides the verdict. Routed here from the frame router.
+    private func handleBroadcastHrGateReadBack(_ frame: [UInt8], isWhoop5: Bool) {
+        guard broadcastHrGateReport != nil else { return }
+        let family: DeviceFamily = isWhoop5 ? .whoop5 : .whoop4
+        switch DeviceConfigReadProbe.parse(frame: frame, family: family,
+                                           expecting: DeviceConfigWriteGate.getDeviceConfigValueCmd) {
+        case .success(let r): broadcastHrGateReport?.noteReadBack(r)
+        case .failure(let f): broadcastHrGateReport?.noteReadBackFailure(f)
+        }
+        finishBroadcastHrWrite()
     }
 
     // MARK: - ECG raw-data gate (#891) — an opt-in write with a MANDATORY read-back
@@ -2803,8 +2859,9 @@ public final class BLEManager: NSObject, ObservableObject {
         guard state.connected, state.encryptedBond else {
             log("ECG gate (#891): needs the full encrypted bond, not the live-HR-only link — close the official WHOOP app and pair the strap to NOOP first. Ignored."); return
         }
-        guard ecgGateReport == nil else {
-            log("ECG gate (#891): a write is already being verified — ignored."); return
+        // Mutually exclusive with the Broadcast-HR gate (#1061): both verify over the same 121 read-back.
+        guard ecgGateReport == nil, broadcastHrGateReport == nil else {
+            log("ECG gate (#891): a device-config write is already being verified — ignored."); return
         }
 
         ecgGateReport = EcgRawDataGateReport(on: on)
@@ -4590,6 +4647,12 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
             ecgGateReport?.noteReadBackTimeout(seconds: Int(BLEManager.ecgGateReadBackTimeout))
             finishEcgGateWrite()
         }
+        // #1061: a Broadcast-HR write interrupted mid-verification is likewise RENDERED, not dropped —
+        // it has already written, so the user is told the read-back never landed (verdict silent).
+        if broadcastHrGateReport != nil {
+            broadcastHrGateReport?.noteReadBackTimeout(seconds: Int(BLEManager.ecgGateReadBackTimeout))
+            finishBroadcastHrWrite()
+        }
         state.clearBiometrics()       // and a stale HR / R-R must not outlive the link either
         state.liveFeedActive = false  // a drop while Live is open must not leave a stale "Stop live feed"
         didBond = false
@@ -5524,11 +5587,15 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                     // write ack (recorded, never the proof) or the GET_DEVICE_CONFIG_VALUE(121) read-back that
                     // decides the verdict. Both handlers guard on ecgGateReport being live, so they no-op
                     // outside a verification (and the 121 read-probe clause above no-ops too, its run not live).
+                    // #1061 shares the SAME opcodes for its Broadcast-HR write read-back; only one gate is ever
+                    // in flight (both are single-flight), and each handler no-ops unless its own report is live.
                     if frame.count > 10, frame[8] == 0x24 {
                         if frame[10] == WhoopCommand.setDeviceConfig.rawValue {
                             handleEcgGateWriteAck(frame, cmdOff: 10)
+                            handleBroadcastHrGateWriteAck(frame, cmdOff: 10)
                         } else if frame[10] == WhoopCommand.getDeviceConfigValue.rawValue {
                             handleEcgGateReadBack(frame, isWhoop5: true)
+                            handleBroadcastHrGateReadBack(frame, isWhoop5: true)
                         }
                     }
                     // #695: a 5/MG GET_DATA_RANGE COMMAND_RESPONSE (puffin envelope: type @8, cmd @10). Feeds

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -43,6 +43,7 @@ import com.noop.protocol.DeviceFamily
 import com.noop.protocol.DeviceConfigReadProbe
 import com.noop.protocol.DeviceConfigReadProbeReport
 import com.noop.protocol.DeviceConfigWriteGate
+import com.noop.protocol.BroadcastHrGateReport
 import com.noop.protocol.EcgRawDataGateReport
 import com.noop.protocol.FeatureFlagProbe
 import com.noop.protocol.FeatureFlagProbeReport
@@ -3107,9 +3108,11 @@ class WhoopBleClient(
                     isMG = whoop5Variant().isMG,
                     broadcastHrOptIn = puffinExperiment.broadcastHr,
                 ) &&
-                // GET_DEVICE_CONFIG_VALUE(121) as the ECG gate's mandatory READ-BACK, gated on a write being
+                // GET_DEVICE_CONFIG_VALUE(121) as a gate's mandatory READ-BACK, gated on a write being
                 // verified — same discipline as the R22 read-back above. The write ack is never the proof.
-                !(DeviceConfigWriteGate.isReadBackOpcode(cmd.rawValue) && ecgGateReport != null)) {
+                // Both the ECG gate (#891) and the Broadcast-HR gate (#1061) read themselves back over this.
+                !(DeviceConfigWriteGate.isReadBackOpcode(cmd.rawValue) &&
+                    (ecgGateReport != null || broadcastHrGateReport != null))) {
                 log("send(${cmd.name}) skipped — no WHOOP 5/MG framing for this command yet")
                 return
             }
@@ -5211,12 +5214,16 @@ class WhoopBleClient(
                     // verdict. Both handlers guard on ecgGateReport being live, so these are byte compares on
                     // every other frame; 121 is also matched by the read-probe clause above, but the two
                     // paths guard on DIFFERENT in-flight sentinels, so exactly one acts.
+                    // #1061 shares the SAME opcodes for its Broadcast-HR write read-back; only one gate is
+                    // ever in flight (both single-flight), and each handler no-ops unless its report is live.
                     if (frame.size > cmdOff && (frame[cmdOff - 2].toInt() and 0xFF) == 0x24) {
                         val op = frame[cmdOff].toInt() and 0xFF
                         if (op == CommandNumber.SET_DEVICE_CONFIG.rawValue) {
                             handleEcgGateWriteAck(frame, cmdOff)
+                            handleBroadcastHrGateWriteAck(frame, cmdOff)
                         } else if (op == CommandNumber.GET_DEVICE_CONFIG_VALUE.rawValue) {
                             handleEcgGateReadBack(frame, connectedFamily == DeviceFamily.WHOOP5)
+                            handleBroadcastHrGateReadBack(frame, connectedFamily == DeviceFamily.WHOOP5)
                         }
                     }
                     if (frame.size > cmdOff && (frame[cmdOff].toInt() and 0xFF) == CommandNumber.GET_DATA_RANGE.rawValue) {
@@ -6037,13 +6044,17 @@ class WhoopBleClient(
         if (!s.connected || !s.bonded) {
             log("Broadcast HR: connect and bond a 5/MG strap first — ignored."); return
         }
+        // Mutually exclusive with the ECG gate: both verify over the SAME 121 read-back opcode, so if both
+        // were in flight one strap reply would be consumed by both handlers and cross-contaminate the other's
+        // verdict (its key isn't echoed → a spurious notClaimed). Only one device-config write verifies at once.
+        if (broadcastHrGateReport != null || ecgGateReport != null) {
+            log("Broadcast HR: a device-config write is already being verified — ignored."); return
+        }
         val payload = byteArrayOf(0x01) +
             Whoop5Config.deviceConfigBody(DeviceConfigWriteGate.BROADCAST_HR_KEY, DeviceConfigWriteGate.value(on))
-        // #1061: report the ACTUAL outcome, not a fire-and-forget "wrote". send() SILENTLY drops a command
-        // the 5/MG send gate refuses, so the old unconditional "wrote" line lied when the write never went
-        // out — exactly what a reporter saw on the disable path. Consult the SAME gate the send path uses and
-        // log honestly. (With the gate's #1061 fix the OFF write is now admitted, so this normally reports a
-        // real write; the guard keeps the log truthful if a write is ever refused.)
+        // #1061: send() SILENTLY drops a command the 5/MG gate refuses, so consult the SAME gate and log
+        // honestly instead of a fire-and-forget "wrote". (The gate's OFF-write fix means the disable is now
+        // admitted; this keeps the log truthful if a write is ever refused.)
         if (!DeviceConfigWriteGate.admitsSend(
                 opcode = CommandNumber.SET_DEVICE_CONFIG.rawValue,
                 payload = payload,
@@ -6056,8 +6067,61 @@ class WhoopBleClient(
                 " REFUSED by the 5/MG send gate — strap unchanged.")
             return
         }
+        // #1061: write, then READ IT BACK — the ack is not the proof. A reporter on FW 50.36.2.0 saw the
+        // flag written yet the strap never advertised 0x180D, with no way to tell "accepted but not
+        // advertised" from "write ignored". The 121 read-back settles that, same discipline as the ECG gate.
+        val report = BroadcastHrGateReport(on)
+        broadcastHrGateReport = report
+        log(
+            "Broadcast HR: writing ${DeviceConfigWriteGate.BROADCAST_HR_KEY}=" +
+                "'${DeviceConfigWriteGate.valueString(on)}' via SET_DEVICE_CONFIG_VALUE(119); the ack is NOT " +
+                "the result — a GET_DEVICE_CONFIG_VALUE(121) read-back follows.",
+        )
         send(CommandNumber.SET_DEVICE_CONFIG, payload, withResponse = true)
-        log("Broadcast HR: wrote whoop_live_hr_in_adv_ind_pkt=" + (if (on) "1" else "0"))
+
+        broadcastHrGateStep += 1
+        val armed = broadcastHrGateStep
+        handler.postDelayed({
+            if (broadcastHrGateReport == null || broadcastHrGateStep != armed) return@postDelayed
+            send(CommandNumber.GET_DEVICE_CONFIG_VALUE, DeviceConfigReadProbe.requestBody(DeviceConfigWriteGate.BROADCAST_HR_KEY))
+            handler.postDelayed(readBack@{
+                if (broadcastHrGateReport == null || broadcastHrGateStep != armed) return@readBack
+                broadcastHrGateReport?.noteReadBackTimeout((ecgGateReadBackTimeoutMs / 1000).toInt())
+                finishBroadcastHrWrite()
+            }, ecgGateReadBackTimeoutMs)
+        }, ecgGateSettleMs)
+    }
+
+    /** Non-null only while a Broadcast-HR write is being verified (#1061) — same single-flight discipline
+     *  as the ECG gate. The send allowlist consults it so the 121 read-back can go out; the frame router
+     *  routes the ack + read-back replies here. Log-surfaced only (no LiveState). */
+    private var broadcastHrGateReport: BroadcastHrGateReport? = null
+    private var broadcastHrGateStep = 0
+
+    private fun finishBroadcastHrWrite() {
+        val report = broadcastHrGateReport ?: return
+        broadcastHrGateReport = null
+        log("Broadcast HR (#1061):\n${report.render()}")
+    }
+
+    /** The write's own COMMAND_RESPONSE — recorded, never the proof. Routed here when a 119 reply lands
+     *  while a Broadcast-HR write is being verified. */
+    private fun handleBroadcastHrGateWriteAck(frame: ByteArray, cmdOff: Int) {
+        if (broadcastHrGateReport == null) return
+        val resultIndex = cmdOff + 2
+        val code = if (frame.size > resultIndex) frame[resultIndex].toInt() and 0xFF else null
+        broadcastHrGateReport?.noteWriteAck(code)
+    }
+
+    /** The 121 read-back — the ONLY thing that decides the verdict. */
+    private fun handleBroadcastHrGateReadBack(frame: ByteArray, isWhoop5: Boolean) {
+        if (broadcastHrGateReport == null) return
+        val family = if (isWhoop5) DeviceFamily.WHOOP5 else DeviceFamily.WHOOP4
+        val parsed = DeviceConfigReadProbe.parse(frame, family, CommandNumber.GET_DEVICE_CONFIG_VALUE.rawValue)
+        val value = parsed.value
+        if (value != null) broadcastHrGateReport?.noteReadBack(value)
+        else broadcastHrGateReport?.noteReadBackFailure(parsed.failure!!)
+        finishBroadcastHrWrite()
     }
 
     // ---- ECG raw-data gate (#891) — an opt-in write with a MANDATORY read-back ----
@@ -6112,8 +6176,9 @@ class WhoopBleClient(
         if (!s.connected || !s.bonded) {
             log("ECG gate (#891): connect and bond a 5/MG strap first — ignored."); return
         }
-        if (ecgGateReport != null) {
-            log("ECG gate (#891): a write is already being verified — ignored."); return
+        // Mutually exclusive with the Broadcast-HR gate (#1061): both verify over the same 121 read-back.
+        if (ecgGateReport != null || broadcastHrGateReport != null) {
+            log("ECG gate (#891): a device-config write is already being verified — ignored."); return
         }
 
         val report = EcgRawDataGateReport(on)
@@ -7582,6 +7647,12 @@ class WhoopBleClient(
         if (ecgGateReport != null) {
             ecgGateReport?.noteReadBackTimeout((ecgGateReadBackTimeoutMs / 1000).toInt())
             finishEcgGateWrite()
+        }
+        // #1061: a Broadcast-HR write interrupted mid-verification is likewise RENDERED, not dropped — it
+        // has already written, so the user is told the read-back never landed (verdict silent).
+        if (broadcastHrGateReport != null) {
+            broadcastHrGateReport?.noteReadBackTimeout((ecgGateReadBackTimeoutMs / 1000).toInt())
+            finishBroadcastHrWrite()
         }
         // #520/#891: the DIS strings belong to the link that just dropped; a stale variant must not keep an
         // MG-only capability unlocked for whatever connects next.

--- a/android/app/src/main/java/com/noop/protocol/DeviceConfigWriteGate.kt
+++ b/android/app/src/main/java/com/noop/protocol/DeviceConfigWriteGate.kt
@@ -398,3 +398,146 @@ class EcgRawDataGateReport(on: Boolean) {
         return sb.toString()
     }
 }
+
+/**
+ * The result of one Broadcast-HR (#181) write + mandatory read-back, as a copyable report.
+ *
+ * #1061: the strap-flag write (`whoop_live_hr_in_adv_ind_pkt`) was fire-and-forget — NOOP never read it
+ * back, so a reporter on FW 50.36.2.0 could not tell whether the firmware ACCEPTED the flag (and simply
+ * doesn't advertise 0x180D) or IGNORED the write. That contradicts this file's own rule — read-back is the
+ * proof, not the ack — which the ECG gate on the SAME opcode already follows. So the write now reads itself
+ * back with GET_DEVICE_CONFIG_VALUE(121) and reports the value the strap actually stores.
+ *
+ * Same order-dependent, pure verdict machinery as [EcgRawDataGateReport]. Twin of the Swift
+ * `BroadcastHrGateReport`; [render] is byte-identical across platforms.
+ */
+class BroadcastHrGateReport(on: Boolean) {
+
+    /** Identical semantics to [EcgRawDataGateReport.Verdict]. */
+    enum class Verdict(val label: String) {
+        CONFIRMED("confirmed"),
+        UNCHANGED("unchanged"),
+        NOT_CLAIMED("notClaimed"),
+        REFUSED("refused"),
+        SILENT("silent"),
+        UNDECODABLE("undecodable"),
+        PENDING("pending"),
+    }
+
+    /** The value that was requested, as the strap stores it ("1" = advertise on / "0" = off). */
+    val requested: String = DeviceConfigWriteGate.valueString(on)
+
+    var writeResultCode: Int? = null
+        private set
+
+    var storedValue: String? = null
+        private set
+
+    var readBackResultCode: Int? = null
+        private set
+
+    var readBackRecordHex: String? = null
+        private set
+
+    private val _trace = mutableListOf<String>()
+
+    val trace: List<String> get() = _trace
+
+    var verdict: Verdict = Verdict.PENDING
+        private set
+
+    init {
+        _trace.add(
+            "SET_DEVICE_CONFIG_VALUE(119) key=\"${DeviceConfigWriteGate.BROADCAST_HR_KEY}\" " +
+                "value='$requested' sent",
+        )
+    }
+
+    /** Record the write's own ack. Logged and NOT used to decide anything (the #891 lesson applies to
+     *  every device-config write). */
+    fun noteWriteAck(resultCode: Int?) {
+        writeResultCode = resultCode
+        val label = resultCode?.let { "${FeatureFlagProbe.resultLabel(it)}($it)" } ?: "(unlabelled)"
+        _trace.add(
+            "write ack → result=$label — recorded, not treated as proof; the read-back below is the proof",
+        )
+    }
+
+    /** Record the decoded read-back and reach a verdict. */
+    fun noteReadBack(r: DeviceConfigReadProbe.ValueResponse) {
+        readBackResultCode = r.resultCode
+        readBackRecordHex = r.recordHex
+        val stored = r.valueFor(DeviceConfigWriteGate.BROADCAST_HR_KEY)
+            ?.takeIf { it in 0x20..0x7E }?.toChar()?.toString()
+        storedValue = stored
+        val sb = StringBuilder(
+            "GET_DEVICE_CONFIG_VALUE(121) key=\"${DeviceConfigWriteGate.BROADCAST_HR_KEY}\"",
+        )
+        val c = r.resultCode
+        if (c != null) sb.append(" → result=${FeatureFlagProbe.resultLabel(c)}($c)") else sb.append(" →")
+        if (stored != null) sb.append(" value='$stored'")
+        sb.append(" record=[${r.recordHex}]")
+        _trace.add(sb.toString())
+
+        verdict = when {
+            r.isUnsupported || r.isFailure -> Verdict.REFUSED
+            stored == null -> Verdict.NOT_CLAIMED
+            stored == requested -> Verdict.CONFIRMED
+            else -> Verdict.UNCHANGED
+        }
+    }
+
+    /** Record a read-back reply that could not be decoded. */
+    fun noteReadBackFailure(f: DeviceConfigReadProbe.ParseFailure) {
+        val why = when (f) {
+            DeviceConfigReadProbe.ParseFailure.CRC -> "CRC failed — frame rejected (never decoded)"
+            DeviceConfigReadProbe.ParseFailure.ENVELOPE -> "not a COMMAND_RESPONSE envelope"
+            DeviceConfigReadProbe.ParseFailure.WRONG_COMMAND -> "COMMAND_RESPONSE for a different command"
+            DeviceConfigReadProbe.ParseFailure.TRUNCATED -> "record too short to hold a response"
+        }
+        _trace.add("read-back reply not decoded: $why")
+        verdict = Verdict.UNDECODABLE
+    }
+
+    /** Record the strap answering nothing at all to the read-back. */
+    fun noteReadBackTimeout(seconds: Int) {
+        _trace.add("GET_DEVICE_CONFIG_VALUE(121) → no COMMAND_RESPONSE within ${seconds}s")
+        verdict = Verdict.SILENT
+    }
+
+    /** One-line summary, suitable for a strap-log line. */
+    val summary: String
+        get() = when (verdict) {
+            Verdict.CONFIRMED ->
+                "Strap now reports ${DeviceConfigWriteGate.BROADCAST_HR_KEY}='$requested' " +
+                    "(read back, not just acked)."
+            Verdict.UNCHANGED ->
+                "Write did NOT take: asked for '$requested', strap still reports '${storedValue ?: "?"}'."
+            Verdict.NOT_CLAIMED ->
+                "Strap answered the read-back but did not echo the key, so no value is claimed."
+            Verdict.REFUSED ->
+                "Strap refused the read-back for this key — the stored value is unknown."
+            Verdict.SILENT -> "No reply to the read-back — the stored value is unknown."
+            Verdict.UNDECODABLE ->
+                "The read-back reply did not decode — the stored value is unknown."
+            Verdict.PENDING -> "Waiting for the read-back…"
+        }
+
+    /** The full copyable report. */
+    fun render(): String {
+        val sb = StringBuilder()
+        sb.append("#1061 BROADCAST-HR FLAG — WHOOP 5/MG\n")
+        sb.append("Key: ${DeviceConfigWriteGate.BROADCAST_HR_KEY} ")
+        sb.append("(makes the strap advertise its HR as a standard 0x180D sensor)\n")
+        sb.append("Wrote '$requested' via SET_DEVICE_CONFIG_VALUE(119), then read it back with ")
+        sb.append("GET_DEVICE_CONFIG_VALUE(121). The write ack is never trusted; only the read-back decides.\n")
+        sb.append("\nVerdict: ${verdict.label} — $summary\n")
+        sb.append("\nExchange:\n")
+        for (line in _trace) sb.append("  ").append(line).append("\n")
+        sb.append("\nNOTE: a CONFIRMED read-back means the FLAG is stored, NOT that the strap advertises ")
+        sb.append("0x180D — some firmware (e.g. 50.36.x) stores it but doesn't advertise. If it reads '1' ")
+        sb.append("here yet no watch/nRF-Connect scan shows 0x180D while disconnected, that is a firmware ")
+        sb.append("result for #1061.\n")
+        return sb.toString()
+    }
+}

--- a/android/app/src/test/java/com/noop/protocol/DeviceConfigWriteGateTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/DeviceConfigWriteGateTest.kt
@@ -313,6 +313,43 @@ class DeviceConfigWriteGateTest {
     }
 
     @Test
+    fun broadcastHrReadBackVerdictTable() {
+        // #1061: the broadcast-HR write now reads itself back, same discipline as the ECG gate. Confirmed
+        // only when the strap stores what was asked; a SUCCESS ack with an unmoved value is UNCHANGED.
+        val key = DeviceConfigWriteGate.BROADCAST_HR_KEY
+
+        val confirmed = BroadcastHrGateReport(true)
+        confirmed.noteWriteAck(1)
+        assertEquals(BroadcastHrGateReport.Verdict.PENDING, confirmed.verdict)   // ack alone decides nothing
+        confirmed.noteReadBack(parseReadBack(readBackFrame(echoRecord(key, "1"))))
+        assertEquals(BroadcastHrGateReport.Verdict.CONFIRMED, confirmed.verdict)
+        assertEquals("1", confirmed.storedValue)
+        assertTrue(confirmed.render().contains(key))
+        // A CONFIRMED read-back must still warn that a stored flag ≠ actually advertising 0x180D (#1061).
+        assertTrue(confirmed.render().contains("0x180D"))
+        assertTrue(confirmed.render().contains("#1061"))
+
+        val unchanged = BroadcastHrGateReport(true)
+        unchanged.noteWriteAck(1)                                               // acked SUCCESS…
+        unchanged.noteReadBack(parseReadBack(readBackFrame(echoRecord(key, "0"))))  // …but value unmoved
+        assertEquals(BroadcastHrGateReport.Verdict.UNCHANGED, unchanged.verdict)
+        assertTrue(unchanged.summary.contains("did NOT take"))
+
+        val off = BroadcastHrGateReport(false)
+        assertEquals("0", off.requested)
+        off.noteReadBack(parseReadBack(readBackFrame(echoRecord(key, "0"))))
+        assertEquals(BroadcastHrGateReport.Verdict.CONFIRMED, off.verdict)
+
+        val silent = BroadcastHrGateReport(true)
+        silent.noteReadBackTimeout(8)
+        assertEquals(BroadcastHrGateReport.Verdict.SILENT, silent.verdict)
+
+        val refused = BroadcastHrGateReport(true)
+        refused.noteReadBack(DeviceConfigReadProbe.ValueResponse(0, ByteArray(0)))
+        assertEquals(BroadcastHrGateReport.Verdict.REFUSED, refused.verdict)
+    }
+
+    @Test
     fun readBackIsCrcGatedLikeEveryOtherDecode() {
         val frame = readBackFrame(echoRecord("enable_raw_data_w_ecg", "1"))
         frame[frame.size - 1] = (frame[frame.size - 1].toInt() xor 0xFF).toByte()


### PR DESCRIPTION
Follow-up to #1200. That PR fixed the two app-side bugs (the disable path was dead behind the write gate; the log claimed "wrote" even when the send gate dropped the command). It did **not** answer the firmware half of #1061 — on FW `50.36.2.0` the flag is written but the strap never advertises the standard `0x180D` HR service — because NOOP still wrote `whoop_live_hr_in_adv_ind_pkt` **fire-and-forget** and trusted the write ack. A reporter could not tell "firmware accepted the flag but doesn't advertise it" from "the write was ignored".

This gives the Broadcast-HR write the same read-back discipline the ECG gate (#891) already applies on the **same** opcode: the ack is recorded but never trusted — only the `GET_DEVICE_CONFIG_VALUE(121)` read-back decides.

## What changed
- **`BroadcastHrGateReport`** (`WhoopProtocol` + `com.noop.protocol`) — pure, order-dependent verdict machine cloned from `EcgRawDataGateReport`, keyed on the broadcast-HR key. Verdicts: `confirmed` / `unchanged` (acked SUCCESS but value didn't move) / `refused` / `silent` / `notClaimed` / `undecodable`. `render()`/`summary` are byte-identical Swift↔Kotlin. A **CONFIRMED** verdict explicitly warns that a *stored* flag is **not** proof the strap advertises `0x180D` — the open firmware question here.
- **`setBroadcastHr`** (`BLEManager` + `WhoopBleClient`) — after the honest send-gate check: arm the report, write, settle 200 ms, read back, bound with the ECG gate's 8 s window. Single-flight; frame router routes `119`/`121` to the broadcast handlers only while a write is in flight (one gate is ever live); the send gate admits the `121` read-back; a mid-verification disconnect **renders** a `silent` report rather than dropping it. **Strap-log only** — no LiveState/Settings/i18n surface.
- Verdict-table unit tests on both platforms.

## Does this close #1061?
Not on its own — it makes the firmware question **answerable**. With this, a reporter on the affected firmware enables Broadcast HR, reconnects, and the strap log carries a copyable verdict: if it reads `confirmed` (flag stored) yet no nRF-Connect/watch scan shows `0x180D` while disconnected, that pins the cause to firmware, not the app.

## Verification
- `swift build && swift test` (WhoopProtocol, Linux) — `testBroadcastHrReadBackVerdictTable` green.
- `./gradlew testFullDebugUnitTest --tests com.noop.protocol.DeviceConfigWriteGateTest` — green; full `compileFullDebugKotlin` clean.
- App-target `BLEManager` compile-only has no default CI → validated via `app-build.yml` on demand.
- The BLE round-trip itself needs a WHOOP 5/MG strap on the affected firmware to confirm on hardware.