### PR TITLE
Show live distance & pace on the active workout screen (#1195)

### DIFF
--- a/Strand/Data/Units.swift
+++ b/Strand/Data/Units.swift
@@ -168,6 +168,19 @@ enum UnitFormatter {
         }
     }
 
+    /// Average pace for display: "m:ss /km" (metric) or "m:ss /mi" (imperial). "—" when pace is undefined
+    /// (nil or ≤ 0, i.e. no distance yet). `secPerKm` is the seconds-per-kilometre the GPS recorder
+    /// publishes. Byte-identical to the Kotlin `UnitFormatter.paceFromSecPerKm`, and to the post-workout
+    /// pace shown in the workout detail view. (#1195)
+    static func paceFromSecPerKm(_ secPerKm: Double?, system: UnitSystem) -> String {
+        guard let secPerKm, secPerKm > 0 else { return "—" }
+        let (secs, label): (Double, String) = system == .imperial
+            ? (secPerKm / milesPerKilometer, "/mi")
+            : (secPerKm, "/km")
+        let s = Int(secs.rounded())
+        return "\(s / 60):\(String(format: "%02d", s % 60)) \(label)"
+    }
+
     /// Format a distance given in KILOMETRES (e.g. the Workouts "Total Distance" sum), with one decimal
     /// and a unit label. Metric: "12.4 km". Imperial: "7.7 mi".
     static func distanceFromKilometers(_ km: Double, system: UnitSystem) -> String {

--- a/Strand/Screens/LiveWorkoutView.swift
+++ b/Strand/Screens/LiveWorkoutView.swift
@@ -51,6 +51,10 @@ struct LiveWorkoutView: View {
                     AnyView(effortGauge),
                     AnyView(zoneSection),
                     AnyView(statsGrid),
+                    // Live GPS distance + pace (#1195) — a self-gating leaf owning its own recorder
+                    // observation, so a GPS fix re-renders only this card. Renders nothing until the first
+                    // accepted fix, so non-GPS / denied sessions leave the stack unchanged.
+                    AnyView(DistancePaceRowIfPresent(recorder: model.gpsRecorder)),
                 ]
                 ForEach(Array(cards.enumerated()), id: \.offset) { index, card in
                     card.staggeredAppear(index: index)
@@ -422,8 +426,9 @@ private extension View {
 /// This is a standalone leaf that owns its OWN `@EnvironmentObject live` (the parent `LiveWorkoutView`
 /// no longer observes `LiveState`), so an incoming sensor / R-R packet re-renders only this row, not the
 /// HR hero / effort gauge / zone rail above. The gate, layout and `staggeredAppear(index: 5)` are
-/// preserved verbatim (index bumped to 6 after the glanceable layout split TIME / HR / Effort / zone
-/// into separate stagger slots), so the rendered output matches the previous inline code.
+/// preserved verbatim (index bumped to 7 — 6 after the glanceable layout split TIME / HR / Effort / zone
+/// into separate stagger slots, then 7 after the live distance/pace card #1195 took the slot before it),
+/// so the rendered output matches the previous inline code.
 private struct SensorRowIfPresent: View {
     @EnvironmentObject private var live: LiveState
 
@@ -444,7 +449,7 @@ private struct SensorRowIfPresent: View {
                     }
                 }
             }
-            .staggeredAppear(index: 6)
+            .staggeredAppear(index: 7)
         }
     }
 
@@ -461,5 +466,58 @@ private struct SensorRowIfPresent: View {
                 .lineLimit(1).minimumScaleFactor(0.6)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+/// Live GPS distance + average pace on the active-workout screen, for distance sports (#1195). The main
+/// gap this closes: the recorder already computes and publishes `distanceM` / `paceSecPerKm` on every
+/// accepted fix, but they were only ever shown in the post-workout detail view — never live.
+///
+/// A standalone leaf that owns its OWN `@ObservedObject` on the recorder (the parent `LiveWorkoutView`
+/// does not observe it), so a GPS fix re-renders only this card — not the HR hero / effort gauge above,
+/// the same scroll-stutter isolation as `SensorRowIfPresent`. Self-gates to nothing until the first
+/// accepted fix, so a denied-permission or GPS-less (Mac) session shows no empty card. Mirrors Android's
+/// gated distance/pace row in `LiveWorkoutScreen`.
+private struct DistancePaceRowIfPresent: View {
+    @ObservedObject var recorder: GpsWorkoutRecorder
+    @AppStorage(UnitPrefs.systemKey) private var unitSystemRaw = UnitSystem.metric.rawValue
+    private var unitSystem: UnitSystem { UnitSystem(rawValue: unitSystemRaw) ?? .metric }
+
+    var body: some View {
+        // `isRecording` is essential, not just `pointCount > 0`: the recorder is a single long-lived
+        // object and `stop()` leaves `pointCount`/`distanceM` intact (only `start()` resets them, and it
+        // runs solely for distance sports). Without the `isRecording` guard a non-GPS workout started
+        // after a GPS one would show the previous session's stale distance. Together they mean "a GPS
+        // recording is live AND has at least one accepted fix" — the Android `gpsEnabled && track` twin.
+        if recorder.isRecording, recorder.pointCount > 0 {
+            NoopCard(padding: NoopMetrics.cardInnerPadding, tint: StrandPalette.effortColor) {
+                HStack(spacing: 0) {
+                    // "Distance"/"Pace" are already localized (reused from the detail view); uppercased for
+                    // the caps stat grid, exactly as the detail route stats do.
+                    stat(String(localized: "Distance").uppercased(),
+                         UnitFormatter.distanceFromMeters(recorder.distanceM, system: unitSystem))
+                    statDivider
+                    stat(String(localized: "Pace").uppercased(),
+                         UnitFormatter.paceFromSecPerKm(recorder.paceSecPerKm, system: unitSystem))
+                }
+            }
+        }
+    }
+
+    private func stat(_ title: String, _ value: String) -> some View {
+        VStack(spacing: NoopMetrics.space1) {
+            Text(title)
+                .font(StrandFont.overline).tracking(StrandFont.overlineTracking)
+                .foregroundStyle(StrandPalette.textSecondary)
+            Text(value)
+                .font(StrandFont.number(28))
+                .foregroundStyle(StrandPalette.effortColor)
+                .lineLimit(1).minimumScaleFactor(0.5)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var statDivider: some View {
+        Rectangle().fill(StrandPalette.hairline).frame(width: 1, height: 48)
     }
 }

--- a/StrandTests/UnitFormatterTests.swift
+++ b/StrandTests/UnitFormatterTests.swift
@@ -53,6 +53,23 @@ final class UnitFormatterTests: XCTestCase {
         XCTAssertEqual(UnitFormatter.distanceFromMeters(100, system: .imperial), "109 yd")
     }
 
+    func testPaceFormatsAndConvertsPerUnit() {
+        // #1195: the live-workout distance/pace surface. Must byte-match the Kotlin formatter.
+        // 5:00 /km (300 s/km) stays 5:00 /km in metric.
+        XCTAssertEqual(UnitFormatter.paceFromSecPerKm(300, system: .metric), "5:00 /km")
+        // Same pace per MILE: 300 / 0.621371 = 482.8 s ≈ 8:03 /mi.
+        XCTAssertEqual(UnitFormatter.paceFromSecPerKm(300, system: .imperial), "8:03 /mi")
+        // Seconds pad to two digits.
+        XCTAssertEqual(UnitFormatter.paceFromSecPerKm(245, system: .metric), "4:05 /km")
+    }
+
+    func testPaceIsDashWhenUndefined() {
+        // nil (no distance yet) and non-positive are both "—" — never "0:00", which reads as instant.
+        XCTAssertEqual(UnitFormatter.paceFromSecPerKm(nil, system: .metric), "—")
+        XCTAssertEqual(UnitFormatter.paceFromSecPerKm(0, system: .imperial), "—")
+        XCTAssertEqual(UnitFormatter.paceFromSecPerKm(-1, system: .metric), "—")
+    }
+
     func testDistanceFromKilometers() {
         XCTAssertEqual(UnitFormatter.distanceFromKilometers(12.4, system: .metric), "12.4 km")
         // 12.4 km * 0.621371 = 7.704... → "7.7 mi"

--- a/android/app/src/main/java/com/noop/ui/LiveWorkoutScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/LiveWorkoutScreen.kt
@@ -63,6 +63,7 @@ fun LiveWorkoutScreen(vm: AppViewModel, onClose: () -> Unit) {
     val profile = remember { ProfileStore.from(context.applicationContext) }
     // Effort display scale (#268) — routes the live Effort read-out so it matches every other surface.
     val effortScale = UnitPrefs.effortScale(context)
+    val unitSystem = UnitPrefs.system(context)
     val bpm by vm.bpm.collectAsStateWithLifecycle()
     val activeWorkout by vm.activeWorkout.collectAsStateWithLifecycle()
     // Additive: instantaneous speed/cadence/power from a connected standard fitness sensor (RSC/CSC/CPS),
@@ -179,6 +180,20 @@ fun LiveWorkoutScreen(vm: AppViewModel, onClose: () -> Unit) {
                     accent = if (w.peakHr > 0) Palette.metricRose else Palette.textPrimary)
                 StatTile(modifier = Modifier.weight(1f), label = uiString(R.string.l10n_live_workout_screen_effort_8c974bc6), value = UnitFormatter.effortDisplay(w.liveStrain, effortScale),
                     accent = Palette.strainColor(w.liveStrain))
+            }
+
+            // Live GPS distance + average pace for distance sports (#1195). The values are already computed
+            // and published on every accepted fix (mirrored from GpsSession into ActiveWorkout) — this only
+            // surfaces them live, where before they appeared solely in the post-workout detail. Hidden until
+            // the first accepted fix, so a denied-permission session shows no empty tiles. Reuses the already
+            // localized "Distance"/"Pace" labels. Mirrors the iOS DistancePaceRowIfPresent leaf.
+            if (w.gpsEnabled && w.track.isNotEmpty()) {
+                Row(horizontalArrangement = Arrangement.spacedBy(Metrics.gap), modifier = Modifier.fillMaxWidth()) {
+                    StatTile(modifier = Modifier.weight(1f), label = uiString(R.string.l10n_live_screen_distance_42320809),
+                        value = UnitFormatter.distanceFromMeters(w.distanceM, unitSystem), accent = Palette.effortColor)
+                    StatTile(modifier = Modifier.weight(1f), label = uiString(R.string.l10n_live_screen_pace_7a9a6226),
+                        value = UnitFormatter.paceFromSecPerKm(w.paceSecPerKm, unitSystem), accent = Palette.effortColor)
+                }
             }
 
             // Additive sensor readout — only renders when a connected standard fitness sensor is feeding.

--- a/android/app/src/main/java/com/noop/ui/Units.kt
+++ b/android/app/src/main/java/com/noop/ui/Units.kt
@@ -246,6 +246,21 @@ object UnitFormatter {
     }
 
     /**
+     * Average pace for display: "m:ss /km" (metric) or "m:ss /mi" (imperial). "—" when pace is undefined
+     * (null or ≤ 0, i.e. no distance yet). [secPerKm] is the seconds-per-kilometre the GPS session
+     * publishes. Byte-identical to the Swift `UnitFormatter.paceFromSecPerKm`. (#1195)
+     */
+    fun paceFromSecPerKm(secPerKm: Double?, system: UnitSystem): String {
+        if (secPerKm == null || secPerKm <= 0) return "—"
+        val (secs, label) = when (system) {
+            UnitSystem.IMPERIAL -> (secPerKm / MILES_PER_KILOMETER) to "/mi"
+            UnitSystem.METRIC -> secPerKm to "/km"
+        }
+        val s = secs.roundToInt()
+        return "${s / 60}:${(s % 60).toString().padStart(2, '0')} $label"
+    }
+
+    /**
      * Format a distance given in KILOMETRES (e.g. the Workouts "Total Distance" sum), with one decimal
      * and a unit label. Metric: "12.4 km". Imperial: "7.7 mi".
      */

--- a/android/app/src/test/java/com/noop/ui/UnitFormatterTest.kt
+++ b/android/app/src/test/java/com/noop/ui/UnitFormatterTest.kt
@@ -154,4 +154,24 @@ class UnitFormatterTest {
         assertEquals(TemperatureUnit.FAHRENHEIT, TemperatureUnit.fromRaw("fahrenheit"))
         assertEquals(null, TemperatureUnit.fromRaw(""))
     }
+
+    // --- Pace (#1195): the live-workout distance/pace surface. Must byte-match the Swift formatter. ---
+
+    @Test
+    fun paceFormatsAndConvertsPerUnit() {
+        // 5:00 /km (300 s/km) stays 5:00 /km in metric.
+        assertEquals("5:00 /km", UnitFormatter.paceFromSecPerKm(300.0, UnitSystem.METRIC))
+        // Same pace in imperial is per MILE: 300 / 0.621371 = 482.8 s ≈ 8:03 /mi.
+        assertEquals("8:03 /mi", UnitFormatter.paceFromSecPerKm(300.0, UnitSystem.IMPERIAL))
+        // Seconds pad to two digits.
+        assertEquals("4:05 /km", UnitFormatter.paceFromSecPerKm(245.0, UnitSystem.METRIC))
+    }
+
+    @Test
+    fun paceIsDashWhenUndefined() {
+        // Null (no distance yet) and non-positive are both "—" — never "0:00", which would read as instant.
+        assertEquals("—", UnitFormatter.paceFromSecPerKm(null, UnitSystem.METRIC))
+        assertEquals("—", UnitFormatter.paceFromSecPerKm(0.0, UnitSystem.IMPERIAL))
+        assertEquals("—", UnitFormatter.paceFromSecPerKm(-1.0, UnitSystem.METRIC))
+    }
 }


### PR DESCRIPTION
Closes the headline ask in #1195. NOOP already does real GPS workout tracking — a live `CLLocationManager`/`LocationManager` stream, filtered, with Haversine distance + pace math — and already **stores** distance and **shows** distance + avg pace in the *post-workout detail* view. The gap the issue reports is that the **active** in-exercise screen shows time / HR / effort / zones but **not** the distance or pace, even though the recorder computes and publishes both on every accepted fix. This surfaces them live.

## What changed
- **`UnitFormatter.paceFromSecPerKm`** (Swift + Kotlin, byte-identical) — formats the recorder's seconds-per-km as `m:ss /km` / `m:ss /mi`, `—` until pace is defined. Unit-tested on both platforms.
- **iOS** — `DistancePaceRowIfPresent`, a leaf owning its OWN `@ObservedObject` on `GpsWorkoutRecorder`, so a GPS fix re-renders only that card and not the HR hero / effort gauge above (the same scroll-stutter isolation `SensorRowIfPresent` uses). Self-gates until the first accepted fix → a denied-permission or GPS-less (Mac) session shows no empty card.
- **Android** — a gated distance/pace `Row` in `LiveWorkoutScreen` (`ActiveWorkout` already carries `distanceM`/`paceSecPerKm`, mirrored from `GpsSession` each fix), hidden until the first fix. Mirrors iOS.
- Reuses the already-localized **"Distance"/"Pace"** labels — no new i18n.

No capture / storage / migration / import changes — pure surfacing of values already flowing, gated to distance sports (run/ride/walk/hike), design tokens only.

## Scope vs the rest of #1195
- **Health Connect distance import** (another ask) — **already shipped** in #215 (`HealthConnectImporter` sums `DistanceRecord` per session).
- **Manual distance editing** and **per-km/mile splits** — not included; better as separate follow-ups.

## Verification
- Kotlin: `compileFullDebugKotlin` clean; `UnitFormatterTest` (incl. new pace cases) green.
- i18n: `Tools/i18n_audit.py` and `--ci` both clean (no new literals).
- iOS app-target (`LiveWorkoutView`, `Units.swift`, `StrandTests`) has no default CI → compiled via `app-build.yml` on demand.
- The live GPS values on-screen need a device on an actual route to confirm on hardware.