### PR TITLE
Add a Distance field to the manual add/edit workout sheet (#1195)

### DIFF
--- a/Strand/Data/WorkoutSource.swift
+++ b/Strand/Data/WorkoutSource.swift
@@ -320,16 +320,18 @@ enum WorkoutSource: Equatable {
 
     // MARK: - Building / preserving rows
 
-    /// Carry the captured fields the add/edit sheet does NOT expose (maxHr, strain, distanceM,
-    /// zonesJSON, notes) over from the row being edited. A v1.67 live-tracked session has real
-    /// captured strain/maxHr; rebuilding the row from the sheet's inputs alone would silently wipe
-    /// them on an edit. No-op for a fresh add (`old == nil`).
+    /// Carry the captured fields the add/edit sheet does NOT expose (maxHr, strain, zonesJSON, notes)
+    /// over from the row being edited. A v1.67 live-tracked session has real captured strain/maxHr;
+    /// rebuilding the row from the sheet's inputs alone would silently wipe them on an edit. No-op for a
+    /// fresh add (`old == nil`). `distanceM` is NOW a sheet field (#1195), so it comes from the freshly
+    /// built `row` (the sheet pre-fills it from the edited row, so an untouched field preserves the
+    /// captured GPS distance and a cleared one clears it) rather than being force-carried from `old`.
     static func preservingCaptured(_ row: WorkoutRow, from old: WorkoutRow?) -> WorkoutRow {
         guard let old else { return row }
         return WorkoutRow(startTs: row.startTs, endTs: row.endTs, sport: row.sport,
                           source: row.source, durationS: row.durationS,
                           energyKcal: row.energyKcal, avgHr: row.avgHr,
-                          maxHr: old.maxHr, strain: old.strain, distanceM: old.distanceM,
+                          maxHr: old.maxHr, strain: old.strain, distanceM: row.distanceM,
                           zonesJSON: old.zonesJSON, notes: old.notes)
     }
 
@@ -337,12 +339,16 @@ enum WorkoutSource: Equatable {
     /// caller — where v1.67's live sessions live). Returns nil when the input can't make an honest row.
     /// strain/zones stay nil: with no captured HR window an APPROXIMATE strain is never fabricated.
     static func buildManualRow(start: Date, durationMin: Int, sport: String,
-                               avgHr: Int?, energyKcal: Double?, now: Date = Date()) -> WorkoutRow? {
+                               avgHr: Int?, energyKcal: Double?, distanceM: Double? = nil,
+                               now: Date = Date()) -> WorkoutRow? {
         guard durationMin > 0, durationMin <= 24 * 60 else { return nil }
         let trimmed = sport.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty, start <= now else { return nil }
         if let hr = avgHr, !(25...250).contains(hr) { return nil }
         if let k = energyKcal, k < 0 || k > 20_000 { return nil }
+        // Distance 0–1000 km (#1195): rejects a negative or absurd manual entry. 1000 km comfortably
+        // covers any single session (an Ironman bike is 180 km, an ultra 160 km).
+        if let d = distanceM, d < 0 || d > 1_000_000 { return nil }
         let s = Int(start.timeIntervalSince1970)
         guard s > 0 else { return nil }
         // Reject a row whose END lands in the future: `start <= now` alone still lets `start + duration`
@@ -354,7 +360,7 @@ enum WorkoutSource: Equatable {
         guard end <= Int(now.timeIntervalSince1970) else { return nil }
         return WorkoutRow(startTs: s, endTs: end, sport: trimmed, source: "manual",
                           durationS: Double(durationSeconds), energyKcal: energyKcal,
-                          avgHr: avgHr, maxHr: nil, strain: nil, distanceM: nil,
+                          avgHr: avgHr, maxHr: nil, strain: nil, distanceM: distanceM,
                           zonesJSON: nil, notes: nil)
     }
 }

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -52063,6 +52063,110 @@
         }
       }
     },
+    "Distance must be 0–1,000 km.":     {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Distanz muss 0–1.000 km sein."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La distancia debe estar entre 0 y 1000 km."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La distance doit être comprise entre 0 et 1 000 km."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La distanza deve essere tra 0 e 1.000 km."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A distância deve ser de 0 a 1.000 km."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Расстояние должно быть в диапазоне 0–1 000 km."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "距离须在 0–1,000 km 之间。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "距離必須介於 0–1,000 km。"
+          }
+        }
+      }
+    },
+    "Distance, optional":     {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Distanz, optional"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Distancia, opcional"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Distance, facultatif"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Distanza, opzionale"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Distância, opcional"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Расстояние, необязательно"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "距离，可选"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "距離，可選"
+          }
+        }
+      }
+    },
     "Don't ask about donations again": {
       "localizations": {
         "de": {

--- a/Strand/Screens/ManualWorkoutSheet.swift
+++ b/Strand/Screens/ManualWorkoutSheet.swift
@@ -11,8 +11,8 @@ private struct SuggestionsHeightKey: PreferenceKey {
 
 // MARK: - Manual workout sheet
 //
-// Add a workout you tracked elsewhere, or edit one you already logged. Five inputs — sport,
-// start, duration, average HR, calories — validated by WorkoutSource.buildManualRow (the same
+// Add a workout you tracked elsewhere, or edit one you already logged. Six inputs — sport,
+// start, duration, distance, average HR, calories — validated by WorkoutSource.buildManualRow (the same
 // honest-row rules the engine uses). On save the caller persists it under the strap source via
 // Repository.saveManualWorkout. Captured-but-unexposed fields (maxHr / strain / zones) on an edited
 // row are carried over by WorkoutSource.preservingCaptured so editing a live-tracked session's
@@ -34,10 +34,19 @@ struct ManualWorkoutSheet: View {
     @State private var durationMin: Int
     @State private var avgHrText: String
     @State private var kcalText: String
+    /// Distance as ENTERED, in the user's unit (km or mi) — converted to stored metres on save (#1195).
+    @State private var distanceText: String
 
-    /// Focus for the numeric (Avg HR / Calories) fields so the keyboard Done button can resign them —
-    /// the decimal pad has no return key. iOS-only effect; the enum keeps both platforms compiling.
-    private enum NumberField: Hashable { case avgHr, calories }
+    /// The length unit system, so the Distance field reads/writes in the user's unit. Read live for the
+    /// field label + parse; the init pre-fill reads the same key straight from UserDefaults (@AppStorage
+    /// isn't available before `self` is formed).
+    @AppStorage(UnitPrefs.systemKey) private var unitSystemRaw = UnitSystem.metric.rawValue
+    private var unitSystem: UnitSystem { UnitSystem(rawValue: unitSystemRaw) ?? .metric }
+    private var distanceUnit: String { unitSystem == .imperial ? "mi" : "km" }
+
+    /// Focus for the numeric (Avg HR / Calories / Distance) fields so the keyboard Done button can resign
+    /// them — the decimal pad has no return key. iOS-only effect; the enum keeps both platforms compiling.
+    private enum NumberField: Hashable { case avgHr, calories, distance }
     @FocusState private var focusedField: NumberField?
 
     /// Whether the Sport text field is being edited — drives whether the catalogue suggestions show
@@ -62,6 +71,23 @@ struct ManualWorkoutSheet: View {
         _durationMin = State(initialValue: e.map { max(1, Int((($0.durationS ?? Double($0.endTs - $0.startTs)) / 60).rounded())) } ?? 45)
         _avgHrText = State(initialValue: e?.avgHr.map(String.init) ?? "")
         _kcalText = State(initialValue: e?.energyKcal.map { String(Int($0.rounded())) } ?? "")
+        // Pre-fill the distance in the user's unit so an untouched edit round-trips the stored metres
+        // (buildManualRow then re-stores exactly what's shown). @AppStorage isn't usable pre-init, so read
+        // the same key directly.
+        let sys = UnitSystem(rawValue: UserDefaults.standard.string(forKey: UnitPrefs.systemKey) ?? "") ?? .metric
+        _distanceText = State(initialValue: e?.distanceM.map { Self.distanceEntryString($0, system: sys) } ?? "")
+    }
+
+    /// The stored metres shown as a clean editable number in `system`'s unit (km/mi) — trailing zeros and a
+    /// dangling decimal trimmed so the field reads "5.2", not "5.20". Two decimals (~10 m) is plenty for a
+    /// hand-entered distance; the field's purpose is manual entry, not preserving GPS's metre precision.
+    private static func distanceEntryString(_ meters: Double, system: UnitSystem) -> String {
+        let km = meters / 1000.0
+        let value = system == .imperial ? km * UnitFormatter.milesPerKilometer : km
+        var s = String(format: "%.2f", value)
+        while s.hasSuffix("0") { s.removeLast() }
+        if s.hasSuffix(".") { s.removeLast() }
+        return s
     }
 
     var body: some View {
@@ -89,6 +115,10 @@ struct ManualWorkoutSheet: View {
                         }
                         .accessibilityLabel("Duration in minutes")
                     }
+                }
+                field(String(localized: "Distance")) {
+                    numberInput(String(localized: "optional"), text: $distanceText, unit: distanceUnit, field: .distance)
+                        .accessibilityLabel("Distance, optional")
                 }
                 HStack(spacing: 14) {
                     field(String(localized: "Avg HR")) {
@@ -322,14 +352,25 @@ struct ManualWorkoutSheet: View {
     private var avgHr: Int? { Int(avgHrText.trimmingCharacters(in: .whitespaces)) }
     private var kcal: Double? { Double(kcalText.trimmingCharacters(in: .whitespaces)) }
 
+    /// Parsed distance in stored METRES — nil for blank (no distance), or when the typed value can't be a
+    /// non-negative number. The user enters km/mi; convert to metres for the row. (#1195)
+    private var distanceMeters: Double? {
+        let t = distanceText.trimmingCharacters(in: .whitespaces)
+        guard !t.isEmpty, let v = Double(t), v >= 0 else { return nil }
+        let km = unitSystem == .imperial ? v / UnitFormatter.milesPerKilometer : v
+        return km * 1000.0
+    }
+
     /// The validated row, or nil when the inputs can't make an honest one (drives the disabled Save +
     /// the inline note). Built through the same WorkoutSource.buildManualRow the engine trusts.
     private var builtRow: WorkoutRow? {
         // A typed-but-unparseable number is invalid (e.g. "abc" in Avg HR) — guard before building.
         if !avgHrText.trimmingCharacters(in: .whitespaces).isEmpty && avgHr == nil { return nil }
         if !kcalText.trimmingCharacters(in: .whitespaces).isEmpty && kcal == nil { return nil }
+        if !distanceText.trimmingCharacters(in: .whitespaces).isEmpty && distanceMeters == nil { return nil }
         guard let base = WorkoutSource.buildManualRow(start: start, durationMin: durationMin,
-                                                      sport: sport, avgHr: avgHr, energyKcal: kcal)
+                                                      sport: sport, avgHr: avgHr, energyKcal: kcal,
+                                                      distanceM: distanceMeters)
         else { return nil }
         // Carry over captured-but-unexposed fields when editing an existing strap session.
         return WorkoutSource.preservingCaptured(base, from: editing)
@@ -355,6 +396,10 @@ struct ManualWorkoutSheet: View {
         }
         if !kcalText.trimmingCharacters(in: .whitespaces).isEmpty, kcal == nil || (kcal ?? -1) < 0 || (kcal ?? 0) > 20_000 {
             return String(localized: "Calories must be 0-20,000.")
+        }
+        if !distanceText.trimmingCharacters(in: .whitespaces).isEmpty,
+           distanceMeters == nil || (distanceMeters ?? -1) < 0 || (distanceMeters ?? 0) > 1_000_000 {
+            return String(localized: "Distance must be 0–1,000 km.")
         }
         return String(localized: "Check the values and try again.")
     }

--- a/StrandTests/WorkoutSourceTests.swift
+++ b/StrandTests/WorkoutSourceTests.swift
@@ -291,7 +291,37 @@ final class WorkoutSourceTests: XCTestCase {
                                                   now: start.addingTimeInterval(2699)))
     }
 
+    func testBuildManualRowAcceptsAndBoundsDistance() {
+        // #1195: distance is now a manual field. A valid entry is stored verbatim (metres); 0 and the
+        // 1,000 km ceiling are allowed; negative and beyond are rejected; nil means "no distance".
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        let now = start.addingTimeInterval(3600)
+        func build(_ d: Double?) -> WorkoutRow? {
+            WorkoutSource.buildManualRow(start: start, durationMin: 30, sport: "Run",
+                                         avgHr: nil, energyKcal: nil, distanceM: d, now: now)
+        }
+        XCTAssertEqual(build(5_234)?.distanceM, 5_234)
+        XCTAssertNil(build(nil)?.distanceM)
+        XCTAssertNotNil(build(0))
+        XCTAssertNotNil(build(1_000_000))     // exactly 1,000 km
+        XCTAssertNil(build(-1))
+        XCTAssertNil(build(1_000_001))
+    }
+
     // MARK: - preservingCaptured
+
+    func testPreservingCapturedTakesDistanceFromTheRebuiltRowNotOld() {
+        // #1195: distance is a sheet field now, so an edit's value wins over the old row's captured
+        // distance (the sheet pre-fills from old, so an untouched field still round-trips it), while
+        // maxHr/strain stay carried. A cleared field clears, not resurrects.
+        let old = fullRow(start: 100, end: 3700, sport: "Running", source: "manual", dist: 10_000, maxHr: 175)
+        let edited = fullRow(start: 100, end: 3700, sport: "Running", source: "manual", dist: 12_500)
+        let merged = WorkoutSource.preservingCaptured(edited, from: old)
+        XCTAssertEqual(merged.distanceM, 12_500)   // edited distance wins
+        XCTAssertEqual(merged.maxHr, 175)          // maxHr still carried from old
+        let cleared = fullRow(start: 100, end: 3700, sport: "Running", source: "manual", dist: nil)
+        XCTAssertNil(WorkoutSource.preservingCaptured(cleared, from: old).distanceM)
+    }
 
     func testPreservingCapturedCarriesUnexposedFieldsOnEdit() {
         // The sheet rebuilds a row from its 5 inputs; an edit must keep the original's captured

--- a/android/app/src/main/java/com/noop/ui/WorkoutEditing.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutEditing.kt
@@ -311,17 +311,19 @@ object WorkoutEditing {
     // MARK: - Building / preserving rows
 
     /**
-     * Carry the captured fields the add/edit sheet does NOT expose (maxHr, strain, distanceM,
-     * zonesJSON, notes, routePolyline) over from the row being edited. A live-tracked session has real
-     * captured strain/maxHr/route; rebuilding from the sheet's inputs alone would wipe them on an edit.
-     * No-op for a fresh add (old == null).
+     * Carry the captured fields the add/edit sheet does NOT expose (maxHr, strain, zonesJSON, notes,
+     * routePolyline) over from the row being edited. A live-tracked session has real captured
+     * strain/maxHr/route; rebuilding from the sheet's inputs alone would wipe them on an edit. No-op for a
+     * fresh add (old == null). distanceM is NOW a sheet field (#1195), so it comes from the freshly built
+     * row (the sheet pre-fills it from the edited row, so an untouched field preserves the captured GPS
+     * distance and a cleared one clears it); routePolyline still carries the captured map verbatim.
      */
     fun preservingCaptured(row: WorkoutRow, old: WorkoutRow?): WorkoutRow {
         if (old == null) return row
         return row.copy(
             maxHr = old.maxHr,
             strain = old.strain,
-            distanceM = old.distanceM,
+            distanceM = row.distanceM,
             zonesJSON = old.zonesJSON,
             notes = old.notes,
             routePolyline = old.routePolyline,
@@ -358,13 +360,19 @@ object WorkoutEditing {
         sport: String,
         avgHr: Int?,
         energyKcal: Double?,
+        // Trailing so the existing positional callers (which pass `nowSeconds` last) are unaffected; the
+        // one caller that sets a distance (the manual sheet) passes it by name. (#1195)
         nowSeconds: Long = System.currentTimeMillis() / 1000L,
+        distanceM: Double? = null,
     ): WorkoutRow? {
         if (durationMin <= 0 || durationMin > 24 * 60) return null
         val trimmed = sport.trim()
         if (trimmed.isEmpty() || startSeconds > nowSeconds || startSeconds <= 0) return null
         if (avgHr != null && avgHr !in 25..250) return null
         if (energyKcal != null && (energyKcal < 0 || energyKcal > 20_000)) return null
+        // Distance 0–1000 km (#1195): rejects a negative or absurd manual entry. 1000 km comfortably
+        // covers any single session (an Ironman bike is 180 km, an ultra 160 km).
+        if (distanceM != null && (distanceM < 0 || distanceM > 1_000_000)) return null
         val durationSeconds = durationMin.toLong() * 60L
         // Keep both the addition and the future-end check overflow-safe. A valid start can be close to
         // Long.MAX_VALUE in a boundary test even though production timestamps are much smaller.
@@ -382,7 +390,7 @@ object WorkoutEditing {
             avgHr = avgHr,
             maxHr = null,
             strain = null,
-            distanceM = null,
+            distanceM = distanceM,
             zonesJSON = null,
             notes = null,
             routePolyline = null,

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -1768,7 +1768,7 @@ private fun Cell(text: String, modifier: Modifier, color: Color? = null) {
 // MARK: - Manual workout add / edit dialog
 //
 // Five inputs — sport, start (date-time, here entered as minutes-ago for simplicity on phone),
-// duration, average HR, calories — validated by WorkoutEditing.buildManualRow (the same honest-row
+// duration, distance, average HR, calories — validated by WorkoutEditing.buildManualRow (the same honest-row
 // rules the engine uses). Editing carries the original's captured maxHr/strain/route over via
 // preservingCaptured so changing sport/duration never wipes them. Android mirror of macOS
 // ManualWorkoutSheet (the macOS sheet uses a DatePicker; on phone we take "minutes ago" to keep the
@@ -1796,6 +1796,19 @@ private fun ManualWorkoutDialog(
     }
     var avgHr by remember { mutableStateOf(editing?.avgHr?.toString() ?: "") }
     var kcal by remember { mutableStateOf(editing?.energyKcal?.let { it.roundToInt().toString() } ?: "") }
+    // #1195: distance as ENTERED, in the user's unit (km/mi), converted to stored metres on save. Pre-fill
+    // in that unit so an untouched edit round-trips the stored value. Period decimal (Locale.US) to match
+    // toDoubleOrNull parsing, exactly as the macOS ManualWorkoutSheet does.
+    val unitSystem = UnitPrefs.system(LocalContext.current)
+    val distUnit = if (unitSystem == UnitSystem.IMPERIAL) "mi" else "km"
+    var distance by remember {
+        mutableStateOf(
+            editing?.distanceM?.let { m ->
+                val v = (m / 1000.0).let { if (unitSystem == UnitSystem.IMPERIAL) it * UnitFormatter.MILES_PER_KILOMETER else it }
+                java.util.Locale.US.let { String.format(it, "%.2f", v) }.trimEnd('0').trimEnd('.')
+            } ?: "",
+        )
+    }
 
     // Build the validated row (null disables Save). Start = the chosen date+time. Captured fields preserved.
     val built: WorkoutRow? = run {
@@ -1805,9 +1818,15 @@ private fun ManualWorkoutDialog(
         // A typed-but-unparseable number is invalid (e.g. "abc" in Avg HR) — reject before building.
         val hr: Int? = if (hrText.isEmpty()) null else hrText.toIntOrNull()
         val k: Double? = if (kText.isEmpty()) null else kText.toDoubleOrNull()
+        val dText = distance.trim()
+        // Distance entered in the user's unit → stored metres. null for blank (no distance). (#1195)
+        val distM: Double? = if (dText.isEmpty()) null else dText.toDoubleOrNull()?.let { v ->
+            (if (unitSystem == UnitSystem.IMPERIAL) v / UnitFormatter.MILES_PER_KILOMETER else v) * 1000.0
+        }
         if (dur == null) return@run null
         if (hrText.isNotEmpty() && hr == null) return@run null
         if (kText.isNotEmpty() && k == null) return@run null
+        if (dText.isNotEmpty() && distM == null) return@run null
         // A manual workout ALWAYS lives under the strap source (where live-tracked sessions land), so
         // a "duplicate as manual" of an imported apple-health/whoop row never writes back to it.
         val base = WorkoutEditing.buildManualRow(
@@ -1817,6 +1836,7 @@ private fun ManualWorkoutDialog(
             sport = sport,
             avgHr = hr,
             energyKcal = k,
+            distanceM = distM,
             nowSeconds = nowSec,
         ) ?: return@run null
         WorkoutEditing.preservingCaptured(base, editing)
@@ -1852,6 +1872,7 @@ private fun ManualWorkoutDialog(
                 SportPickerField(sport, onChange = { sport = it })
                 StartTimeField(startMillis, onPick = { startMillis = it })
                 DialogField("Duration (minutes)", durationMin, onChange = { durationMin = it }, numeric = true)
+                DialogField("Distance ($distUnit, optional)", distance, onChange = { distance = it }, numeric = true)
                 DialogField("Avg HR (bpm, optional)", avgHr, onChange = { avgHr = it }, numeric = true)
                 DialogField("Calories (kcal, optional)", kcal, onChange = { kcal = it }, numeric = true)
                 if (built == null) {

--- a/android/app/src/test/java/com/noop/ui/WorkoutEditingTest.kt
+++ b/android/app/src/test/java/com/noop/ui/WorkoutEditingTest.kt
@@ -5,6 +5,7 @@ import com.noop.data.WorkoutRow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -342,7 +343,40 @@ class WorkoutEditingTest {
         )
     }
 
+    @Test
+    fun buildManualRow_acceptsAndBoundsDistance() {
+        // #1195: distance is now a manual field. A valid entry is stored verbatim (metres); 0 and the
+        // 1,000 km ceiling are allowed; negative and beyond are rejected; null means "no distance".
+        val now = 1_700_003_600L
+        fun build(d: Double?) = WorkoutEditing.buildManualRow(
+            "my-whoop", startSeconds = now - 1800, durationMin = 30, sport = "Run",
+            avgHr = null, energyKcal = null, nowSeconds = now, distanceM = d,
+        )
+        assertEquals(5_234.0, build(5_234.0)?.distanceM)
+        assertNull(build(null)?.distanceM)
+        assertNotNull(build(0.0))
+        assertNotNull(build(1_000_000.0))   // exactly 1,000 km
+        assertNull(build(-1.0))
+        assertNull(build(1_000_001.0))
+    }
+
     // MARK: - preservingCaptured
+
+    @Test
+    fun preservingCaptured_takesDistanceFromRebuiltNotOld() {
+        // #1195: distance is a sheet field now, so an edit's value wins over the old row's captured
+        // distance (the sheet pre-fills from old, so an untouched field still round-trips it), while
+        // maxHr/route stay carried. A cleared field clears, not resurrects.
+        val old = row("my-whoop", 100, 3700, "Running", "manual", maxHr = 175)
+            .copy(distanceM = 10_000.0, routePolyline = "abc")
+        val edited = row("my-whoop", 100, 3700, "Running", "manual").copy(distanceM = 12_500.0)
+        val merged = WorkoutEditing.preservingCaptured(edited, old)
+        assertEquals(12_500.0, merged.distanceM)   // edited distance wins
+        assertEquals(175, merged.maxHr)            // maxHr still carried
+        assertEquals("abc", merged.routePolyline)  // route still carried
+        val cleared = row("my-whoop", 100, 3700, "Running", "manual").copy(distanceM = null)
+        assertNull(WorkoutEditing.preservingCaptured(cleared, old).distanceM)
+    }
 
     @Test
     fun preservingCaptured_carriesUnexposedFieldsOnEdit() {


### PR DESCRIPTION
Second follow-up from #1195 (after #1202 added live distance/pace). The issue asks for **manual distance editing** — "manually add or edit the total distance after a workout is completed." The manual add/edit sheet already edits sport / start / duration / avg HR / calories, and the workout row already stores `distanceM` and shows it in the detail view — it just wasn't editable. This adds the field.

## What changed
- **`buildManualRow` (both platforms)** — accepts an optional `distanceM` (default nil), validated **0–1,000 km** (covers any single session; an Ironman bike is 180 km). `preservingCaptured` now takes `distanceM` from the freshly-built row instead of force-carrying the old value: the sheet pre-fills the field from the edited row, so an **untouched** edit round-trips the stored distance, a **changed** value overrides, and a **cleared** field clears. The captured **route polyline is still preserved**.
- **iOS `ManualWorkoutSheet`** — a Distance field beside Duration; entered in the user's unit (km/mi), stored as metres. New strings localized in **all 8** catalog locales.
- **Android `ManualWorkoutDialog`** — the same field, matching the dialog's existing plain-field style.
- **Unit tests both platforms** — distance bounds + the `preservingCaptured` override/clear behavior.

No migration (the `distanceM` column already exists). The Kotlin `distanceM` param is trailing so existing positional callers are untouched; the one caller that sets it passes it by name.

## Verification
- Android: `compileFullDebugKotlin` clean; `WorkoutEditingTest` (new distance cases) + `UnitFormatterTest` green.
- i18n: `Tools/i18n_audit.py --ci` clean (new iOS strings added to the catalog; the Android dialog matches its siblings' baselined plain-field pattern).
- iOS app-target (`WorkoutSource`, `ManualWorkoutSheet`, `Units`) compiled via `app-build.yml`. `StrandTests` has no CI, so the Swift test mirrors the passing Kotlin one verbatim.

## Scope vs #1195
Live distance/pace shipped in #1202; HC distance import shipped in #215. Remaining after this: **route import** (HC `ExerciseRoute` / Apple Health), and **splits** (needs per-point timestamps, which the stored track lacks) — both better as their own issues.