### PR TITLE
Write manually added/edited workouts back to Health Connect (#1195)

### DIFF
--- a/android/app/src/main/java/com/noop/analytics/WorkoutSport.kt
+++ b/android/app/src/main/java/com/noop/analytics/WorkoutSport.kt
@@ -27,6 +27,12 @@ object WorkoutSport {
     /** The default when none is chosen ("Other"). */
     val default: Sport get() = all.first { it.name == "Other" }
 
+    /** The Health Connect exercise type for a stored sport NAME (free-text tolerant, case-insensitive),
+     *  falling back to [default]'s OTHER_WORKOUT when the name isn't a catalogue sport. Used by the
+     *  manual-workout HC writeback so a hand-entered workout maps to the same type the live path uses. */
+    fun exerciseTypeForName(name: String): Int =
+        (all.firstOrNull { it.name.equals(name.trim(), ignoreCase = true) } ?: default).exerciseType
+
     /** Sports where a step count is meaningful — feet on the ground — so the workout summary can show
      *  steps (#398). Deliberately narrow: outdoor + treadmill run/walk and hiking, NOT cycling/rowing/
      *  swimming (no footfalls) or gym/court sports (a step tally would be noise). Kept in lockstep with

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
@@ -340,4 +340,21 @@ object HealthConnectWriter {
         recordStatus(context, result)
         return result
     }
+
+    /** Remove a workout's session + distance records from Health Connect by client-record id (the same ids
+     *  [buildExerciseRecords] assigns: "noop-workout-$startTs" + "-dist"). Used when an edit MOVES the start
+     *  time so the old record doesn't orphan beside the new one — mirroring the iOS delete-before-write.
+     *  Best-effort; a missing record is a no-op. (#1195) */
+    suspend fun deleteExercise(context: Context, startTs: Long) {
+        if (HealthConnectClient.getSdkStatus(context) != HealthConnectClient.SDK_AVAILABLE) return
+        val client = HealthConnectClient.getOrCreate(context)
+        runCatching {
+            client.deleteRecords(ExerciseSessionRecord::class,
+                recordIdsList = emptyList(), clientRecordIdsList = listOf("noop-workout-$startTs"))
+        }
+        runCatching {
+            client.deleteRecords(DistanceRecord::class,
+                recordIdsList = emptyList(), clientRecordIdsList = listOf("noop-workout-dist-$startTs"))
+        }
+    }
 }

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1795,6 +1795,20 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
             // No-ops when there's no strap HR for the window; never overrides a value the user typed.
             rescoreAfterEdit()
             loadWorkouts()
+            // #1195 follow-up: a manually added/edited workout writes back to Health Connect too, mirroring
+            // the live endWorkout path (iOS already syncs manual workouts to HealthKit via its query-based
+            // export). Opt-in; writes the same session + distance the live path does, under the same
+            // "noop-workout-*" client id (so a re-import skips it, no double-count). On ANY edit, delete the
+            // OLD workout's records first, then write fresh — matching iOS's delete-before-write. Deleting
+            // only when the start MOVED would leave a stale distance record when a same-start edit clears or
+            // drops the distance (writeExercise upserts the session but writes no distance record to
+            // overwrite it), or a moved-start record orphaned.
+            if (_hcWriteback.value) {
+                runCatching {
+                    replacing?.let { HealthConnectWriter.deleteExercise(appContext, it.startTs) }
+                    HealthConnectWriter.writeExercise(appContext, row, WorkoutSport.exerciseTypeForName(row.sport))
+                }
+            }
         }
     }
 
@@ -1819,6 +1833,12 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         viewModelScope.launch {
             runCatching { repository.deleteWorkout(row) }
             loadWorkouts()
+            // #1195 follow-up: a workout removed in NOOP is removed from Health Connect too, so a session
+            // we wrote (manual or live) doesn't linger there after the user deletes it here. Opt-in, keyed
+            // on the same "noop-workout-*" client id; a no-op for a workout we never wrote.
+            if (_hcWriteback.value) {
+                runCatching { HealthConnectWriter.deleteExercise(appContext, row.startTs) }
+            }
         }
     }
 

--- a/android/app/src/test/java/com/noop/analytics/WorkoutSportTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/WorkoutSportTest.kt
@@ -34,6 +34,15 @@ class WorkoutSportTest {
         assertEquals("Other", WorkoutSport.default.name)
     }
 
+    /** #1195: the manual-workout HC writeback maps a stored sport NAME to its exercise type — case- and
+     *  whitespace-tolerant, OTHER_WORKOUT for a free-typed sport not in the catalogue. */
+    @Test fun exerciseTypeForName_mapsKnownAndFallsBackForFreeText() {
+        assertEquals(ExerciseSessionRecord.EXERCISE_TYPE_RUNNING, WorkoutSport.exerciseTypeForName("Running"))
+        assertEquals(ExerciseSessionRecord.EXERCISE_TYPE_RUNNING, WorkoutSport.exerciseTypeForName("  running "))
+        assertEquals(ExerciseSessionRecord.EXERCISE_TYPE_OTHER_WORKOUT, WorkoutSport.exerciseTypeForName("Quidditch"))
+        assertEquals(ExerciseSessionRecord.EXERCISE_TYPE_OTHER_WORKOUT, WorkoutSport.exerciseTypeForName(""))
+    }
+
     /** #768: the newly requested presets are present, spelled byte-for-byte the way iOS persists them. */
     @Test fun newPresets_arePresent() {
         val names = WorkoutSport.all.map { it.name }


### PR DESCRIPTION
Follow-up to #1203. When I added the manual **Distance** field, I found the write-back was asymmetric: Android's `HealthConnectWriter.writeExercise` is only called from the **live `endWorkout`** path, so a workout **added or edited in the manual dialog** (distance included) never reached Health Connect — even with writeback opted in. **iOS already syncs manual workouts** to HealthKit (its `writeWorkouts` export queries *all* non-Apple workouts, so manual ones are covered). This brings Android to parity.

## What changed
- **`AppViewModel.saveManualWorkout`** — when HC writeback is on, write the saved row's session + distance via `writeExercise`, mirroring `endWorkout`. Same `noop-workout-*` client id as the live path, so a later re-import **skips it** (no double-count). An edit that **moves the start time** deletes the stale record first (the id is keyed on `startTs`) — matching iOS's delete-before-write.
- **`AppViewModel.deleteWorkout`** — also remove the record from Health Connect, so a workout we wrote doesn't **linger** there after the user deletes it in NOOP. Covers live + manual; a no-op for a workout we never wrote. (This gap existed for live workouts too.)
- **`HealthConnectWriter.deleteExercise`** — delete a workout's session + distance by client id.
- **`WorkoutSport.exerciseTypeForName`** — map a stored sport *name* (free-text tolerant, case-insensitive → `OTHER_WORKOUT`) to its HC exercise type, so a hand-entered workout types the same as the live path. Unit-tested.

All gated on the existing `hcWriteback` opt-in.

## Parity note
**Android-only by design** — iOS already writes manual workouts to HealthKit via its query-based export (`HealthKitBridge.writeWorkouts` filters `source != apple`, which includes `manual`), so no Swift change is needed. This closes the behavioral gap, it doesn't create a new one.

## Verification
- `compileFullDebugKotlin` clean; `WorkoutSportTest` (new `exerciseTypeForName` cases) + HealthConnect/ManualWorkout suites green.
- No UI strings, no app-target Swift → no i18n/app-build impact (i18n `--ci` clean).
- The Health Connect round-trip (insert/delete/self-write-skip) needs a device with Health Connect to confirm on hardware.