### PR TITLE
Match the Today sync chip height to the header controls (#1207 follow-up)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -2184,9 +2184,12 @@ private fun ChipCapsule(icon: ImageVector, text: String, tint: Color, desc: Stri
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
         modifier = Modifier
+            // Match the round header controls' height so the pill sits the same size in the cluster
+            // (#1207 follow-up); width stays content-driven. Content centres via the fixed height.
+            .height(HeaderClusterControl)
             .clip(RoundedCornerShape(50))
             .background(Palette.surfaceInset)
-            .padding(horizontal = 8.dp, vertical = 5.dp),
+            .padding(horizontal = 10.dp),
     ) {
         Icon(icon, contentDescription = desc, tint = tint, modifier = Modifier.size(14.dp))
         Text(text, style = NoopType.caption, color = tint)


### PR DESCRIPTION
Follow-up to #1207. After the round Today header controls went 34→36, the persistent **sync-status chip** ("↻ 0" / "✓ 5m") stayed content-sized (~26dp tall), so it read a touch small beside them. This gives the pill a fixed height of `HeaderClusterControl` (36dp) with centred content — width stays content-driven, so it's the same *height* as the round controls and sits level.

## Scope
**Android-only** — and this time it genuinely is: the iOS **liquid** Today header has **no persistent sync chip**. It shows a transient, centred "Syncing…" pull-to-refresh vessel (`LiquidRefreshIndicator`) only while a sync is running, not an always-on header pill. So there's no twin to bump. This is a pre-existing platform difference, not one introduced here.

## Verification
- `compileFullDebugKotlin` clean. Design-token only (reuses the `HeaderClusterControl` constant); no strings, no logic. Visual-only — worth a glance on device.