### PR TITLE
Store primary-session RHR coverage inputs beside the shadow mean (#1169)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -1065,6 +1065,21 @@ public enum AnalyticsEngine {
         }, validBpm: validBpm, minValidSamples: minValidSamples)
     }
 
+    /// #1169 coverage inputs for the shadow `rhr_primary_session` mean (valid-sample count + primary-session
+    /// duration). Builds the SAME per-session inputs as `primarySessionRestingHR` and delegates to
+    /// `PrimarySessionRestingHR.coverage`, so it is `nil` in lockstep with the mean. Byte-parity twin of the
+    /// Kotlin `primarySessionRestingHRCoverage`.
+    public static func primarySessionRestingHRCoverage(
+        sessions: [SleepSession], hr: [HRSample],
+        validBpm: ClosedRange<Int> = PrimarySessionRestingHR.defaultValidBpm,
+        minValidSamples: Int = PrimarySessionRestingHR.defaultMinValidSamples) -> PrimarySessionRestingHR.Coverage? {
+        PrimarySessionRestingHR.coverage(sessions: sessions.map { s in
+            PrimarySessionRestingHR.Session(
+                durationSec: Double(s.end - s.start),
+                bpm: hr.filter { $0.ts >= s.start && $0.ts < s.end }.map { $0.bpm })
+        }, validBpm: validBpm, minValidSamples: minValidSamples)
+    }
+
     // MARK: - Skin-temp funnel diagnostic (#752)
 
     // Skin temp coming out 0/absent on a WHOOP 4.0 (or any) night is opaque: the user can't tell whether

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/PrimarySessionRestingHR.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/PrimarySessionRestingHR.swift
@@ -59,4 +59,33 @@ public enum PrimarySessionRestingHR {
         guard valid.count >= minValidSamples else { return nil }
         return Double(valid.reduce(0, +)) / Double(valid.count)
     }
+
+    /// #1169 coverage INPUTS for the same primary session `meanHR` averages: its valid-sample count and its
+    /// duration. The fixed `minValidSamples` gate is cadence-blind, so the accruing shadow dataset needs to
+    /// weight/filter each night's mean by how well-covered it was — but this deliberately records the raw
+    /// inputs, NOT a derived coverage fraction, so the later multi-participant holdout can pick its own
+    /// coverage definition rather than inheriting one. Same longest-session selection + gate as `meanHR`
+    /// (returns `nil` in lockstep with it), so the mean and its coverage are always emitted together. Still
+    /// pure + unwired — shadow instrumentation only. Twin of Kotlin `PrimarySessionRestingHR.coverage`.
+    public struct Coverage: Sendable, Equatable {
+        /// Valid HR samples in the primary session (the count the `minValidSamples` gate saw).
+        public let validSamples: Int
+        /// The primary (longest) session's duration in seconds.
+        public let durationSec: Double
+        public init(validSamples: Int, durationSec: Double) {
+            self.validSamples = validSamples
+            self.durationSec = durationSec
+        }
+    }
+
+    /// The primary session's valid-sample count + duration, or `nil` in lockstep with `meanHR` (no session
+    /// clears `minValidSamples`). Selection + gate mirror `meanHR` exactly.
+    public static func coverage(sessions: [Session],
+                                validBpm: ClosedRange<Int> = defaultValidBpm,
+                                minValidSamples: Int = defaultMinValidSamples) -> Coverage? {
+        guard let primary = sessions.max(by: { $0.durationSec < $1.durationSec }) else { return nil }
+        let valid = primary.bpm.filter { validBpm.contains($0) }
+        guard valid.count >= minValidSamples else { return nil }
+        return Coverage(validSamples: valid.count, durationSec: primary.durationSec)
+    }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/PrimarySessionRestingHRTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/PrimarySessionRestingHRTests.swift
@@ -81,4 +81,36 @@ final class PrimarySessionRestingHRTests: XCTestCase {
         hr.append(HRSample(ts: 3000, bpm: 200))                          // exactly at end → excluded
         XCTAssertEqual(AnalyticsEngine.primarySessionRestingHR(sessions: [s], hr: hr), 58.0)
     }
+
+    // MARK: - #1169 coverage inputs (shadow metadata beside the mean)
+
+    /// Coverage reports the LONGEST session's VALID-sample count (invalids excluded) and its duration —
+    /// the raw inputs the later holdout weights by. Nap + out-of-range samples must not count.
+    func testCoverageReportsValidCountAndDurationOfLongestSession() {
+        let night = S(durationSec: 8 * 3600, bpm: Array(repeating: 64, count: 480) + [0, 300])
+        let nap = S(durationSec: 40 * 60, bpm: Array(repeating: 50, count: 40))
+        let cov = P.coverage(sessions: [nap, night])
+        XCTAssertEqual(cov?.validSamples, 480)
+        XCTAssertEqual(cov?.durationSec, 8 * 3600)
+    }
+
+    /// Coverage is nil in LOCKSTEP with `meanHR`: below the gate, both return nil (so the mean and its
+    /// coverage are always emitted together or not at all).
+    func testCoverageIsNilInLockstepWithMean() {
+        let thin = [S(durationSec: 3600, bpm: Array(repeating: 60, count: 5))]
+        XCTAssertNil(P.meanHR(sessions: thin))
+        XCTAssertNil(P.coverage(sessions: thin))
+        XCTAssertNil(P.coverage(sessions: []))
+    }
+
+    /// The AnalyticsEngine wrapper windows HR to the longest session, same as the mean wrapper.
+    func testPrimarySessionRestingHRCoverageWindowsToLongest() {
+        let night = SleepSession(start: 0, end: 30_000, efficiency: 0.9, stages: [], restingHR: nil, avgHRV: nil)
+        let nap = SleepSession(start: 40_000, end: 45_000, efficiency: 0.9, stages: [], restingHR: nil, avgHRV: nil)
+        var hr = (0..<100).map { HRSample(ts: $0 * 30, bpm: 60) }
+        hr += (0..<50).map { HRSample(ts: 40_000 + $0 * 30, bpm: 45) }
+        let cov = AnalyticsEngine.primarySessionRestingHRCoverage(sessions: [nap, night], hr: hr)
+        XCTAssertEqual(cov?.validSamples, 100)
+        XCTAssertEqual(cov?.durationSec, 30_000)
+    }
 }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -140,6 +140,10 @@ final class IntelligenceEngine: ObservableObject {
         /// no session clears the coverage gate. Written to metricSeries as "rhr_primary_session" in pass 2 —
         /// instrumentation only, never shown and never fed to any score.
         let primarySessionRHR: Double?
+        /// #1169 coverage inputs for the shadow mean above (valid-sample count + primary-session duration),
+        /// written as "rhr_primary_session_valid_samples" / "rhr_primary_session_duration_s" in pass 2. nil
+        /// in lockstep with `primarySessionRHR`.
+        let primarySessionRHRCoverage: PrimarySessionRestingHR.Coverage?
     }
 
     struct Computed: Identifiable {
@@ -885,11 +889,13 @@ final class IntelligenceEngine: ObservableObject {
                 // score; #1174's definition is unchanged — this only records its per-night output. The
                 // windowing + delegation lives in the byte-identical, tested `AnalyticsEngine`.
                 let primarySessionRHR = AnalyticsEngine.primarySessionRestingHR(sessions: res.sleepSessions, hr: hr)
+                let primarySessionRHRCoverage = AnalyticsEngine.primarySessionRestingHRCoverage(sessions: res.sleepSessions, hr: hr)
                 out.append(DayScan(result: res, rhrLine: rhrLine,
                                    readOwner: owner, hrRows: hr.count,
                                    sleepTrace: sleepTrace, stepsTrace: stepsTrace, hrvTrace: hrvTrace,
                                    hrvDiag: hrvDiag, spo2Candidate: spo2CandidateMean,
-                                   primarySessionRHR: primarySessionRHR))
+                                   primarySessionRHR: primarySessionRHR,
+                                   primarySessionRHRCoverage: primarySessionRHRCoverage))
             }
             return (out, skippedDayLines)
         }.value
@@ -909,6 +915,8 @@ final class IntelligenceEngine: ObservableObject {
         var spo2CandidateByDay: [String: Int] = [:]
         // #1169: primary-session mean RHR shadow metric per day, carried from pass 1 for metricSeries persistence.
         var primarySessionRHRByDay: [String: Double] = [:]
+        // #1169: its coverage inputs (valid-sample count + primary-session duration), same lifetime as the mean.
+        var primarySessionRHRCoverageByDay: [String: PrimarySessionRestingHR.Coverage] = [:]
 
         // Back on the main actor: fold the off-actor results into the pass-2 state in the SAME order the
         // loop produced them. Pure assignment / appends , no further store reads , so this is cheap and the
@@ -929,6 +937,9 @@ final class IntelligenceEngine: ObservableObject {
             // #1169: carry the primary-session mean RHR shadow metric into pass 2 for persistence.
             if let v = scan.primarySessionRHR {
                 primarySessionRHRByDay[res.daily.day] = v
+            }
+            if let cov = scan.primarySessionRHRCoverage {
+                primarySessionRHRCoverageByDay[res.daily.day] = cov
             }
             if let line = scan.rhrLine { diagnosticSink?(line, nil) }
             // Sleep & Rest test mode (E5): replay this day's gate-trace + Rest lines tagged `.sleep` so they
@@ -1171,6 +1182,12 @@ final class IntelligenceEngine: ObservableObject {
             // scored — so the mean-vs-floor comparison the issue needs can be evaluated from exports later.
             if let v = primarySessionRHRByDay[daily.day] {
                 restPoints.append(MetricPoint(day: daily.day, key: "rhr_primary_session", value: v))
+            }
+            // #1169: its coverage inputs beside the mean — valid-sample count + primary-session duration (s)
+            // — so a thin-coverage night can be down-weighted in the later holdout. Raw inputs, not a fraction.
+            if let cov = primarySessionRHRCoverageByDay[daily.day] {
+                restPoints.append(MetricPoint(day: daily.day, key: "rhr_primary_session_valid_samples", value: Double(cov.validSamples)))
+                restPoints.append(MetricPoint(day: daily.day, key: "rhr_primary_session_duration_s", value: cov.durationSec))
             }
             cachedSleep.append(contentsOf: night.cachedSleep)
             // Persist the detected workouts the pipeline already computes (previously discarded).

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -879,6 +879,26 @@ object AnalyticsEngine {
         minValidSamples,
     )
 
+    /** #1169 coverage inputs for the shadow `rhr_primary_session` mean (valid-sample count + primary-session
+     *  duration). Builds the SAME per-session inputs as [primarySessionRestingHR] and delegates to
+     *  [PrimarySessionRestingHR.coverage], so it is null in lockstep with the mean. Byte-parity twin of the
+     *  Swift `primarySessionRestingHRCoverage`. */
+    internal fun primarySessionRestingHRCoverage(
+        sessions: List<DetectedSleep>,
+        hr: List<HrSample>,
+        validBpm: IntRange = PrimarySessionRestingHR.DEFAULT_VALID_BPM,
+        minValidSamples: Int = PrimarySessionRestingHR.DEFAULT_MIN_VALID_SAMPLES,
+    ): PrimarySessionRestingHR.Coverage? = PrimarySessionRestingHR.coverage(
+        sessions.map { s ->
+            PrimarySessionRestingHR.Session(
+                durationSec = (s.end - s.start).toDouble(),
+                bpm = hr.filter { it.ts >= s.start && it.ts < s.end }.map { it.bpm },
+            )
+        },
+        validBpm,
+        minValidSamples,
+    )
+
     /** Plausible worn skin-temperature range (°C). Off-wrist/charging samples drift to ambient and are
      *  excluded; the strap's own decode gate is the looser 20–45. (PR #85) */
     private const val SKIN_TEMP_MIN_C: Double = 28.0

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -407,6 +407,8 @@ object IntelligenceEngine {
         val spo2CandidateByDay = LinkedHashMap<String, Int>()
         // #1169: primary-session mean RHR shadow metric per day, carried from pass 1 for persistence.
         val primarySessionRHRByDay = LinkedHashMap<String, Double>()
+        // #1169: its coverage inputs (valid-sample count + primary-session duration), same lifetime as the mean.
+        val primarySessionRHRCoverageByDay = LinkedHashMap<String, PrimarySessionRestingHR.Coverage>()
 
         // In-memory nightly values harvested in pass 1, used to seed the pass-2 baseline.
         // Keyed by day so the union with imported history de-dupes cleanly per UTC day.
@@ -757,6 +759,7 @@ object IntelligenceEngine {
             // #1174's definition is unchanged. The windowing + delegation lives in the byte-identical,
             // tested AnalyticsEngine.
             AnalyticsEngine.primarySessionRestingHR(res.sleepSessions, hr)?.let { primarySessionRHRByDay[res.daily.day] = it }
+            AnalyticsEngine.primarySessionRestingHRCoverage(res.sleepSessions, hr)?.let { primarySessionRHRCoverageByDay[res.daily.day] = it }
             scoredNights.add(res)
             resolvedScoreOwnerByDay[res.daily.day] = owner
         }
@@ -932,6 +935,12 @@ object IntelligenceEngine {
             // scored — for later mean-vs-floor evaluation from exports.
             primarySessionRHRByDay[daily.day]?.let { v ->
                 restRows.add(MetricSeriesRow(deviceId = computedId, day = daily.day, key = "rhr_primary_session", value = v))
+            }
+            // #1169: its coverage inputs beside the mean — valid-sample count + primary-session duration (s)
+            // — so a thin-coverage night can be down-weighted in the later holdout. Raw inputs, not a fraction.
+            primarySessionRHRCoverageByDay[daily.day]?.let { cov ->
+                restRows.add(MetricSeriesRow(deviceId = computedId, day = daily.day, key = "rhr_primary_session_valid_samples", value = cov.validSamples.toDouble()))
+                restRows.add(MetricSeriesRow(deviceId = computedId, day = daily.day, key = "rhr_primary_session_duration_s", value = cov.durationSec))
             }
 
             out.add(

--- a/android/app/src/main/java/com/noop/analytics/PrimarySessionRestingHR.kt
+++ b/android/app/src/main/java/com/noop/analytics/PrimarySessionRestingHR.kt
@@ -54,4 +54,23 @@ object PrimarySessionRestingHR {
         if (valid.size < minValidSamples) return null
         return valid.sum().toDouble() / valid.size
     }
+
+    /** #1169 coverage INPUTS for the same primary session [meanHR] averages: its valid-sample count and its
+     *  duration. The fixed [minValidSamples] gate is cadence-blind, so the accruing shadow dataset needs to
+     *  weight/filter each night by how well-covered it was — but this records the RAW inputs, not a derived
+     *  coverage fraction, so the later multi-participant holdout can pick its own coverage definition. Same
+     *  longest-session selection + gate as [meanHR] (null in lockstep with it). Pure + unwired. Twin of the
+     *  Swift `PrimarySessionRestingHR.Coverage` / `coverage`. */
+    data class Coverage(val validSamples: Int, val durationSec: Double)
+
+    fun coverage(
+        sessions: List<Session>,
+        validBpm: IntRange = DEFAULT_VALID_BPM,
+        minValidSamples: Int = DEFAULT_MIN_VALID_SAMPLES,
+    ): Coverage? {
+        val primary = sessions.maxByOrNull { it.durationSec } ?: return null
+        val valid = primary.bpm.filter { it in validBpm }
+        if (valid.size < minValidSamples) return null
+        return Coverage(validSamples = valid.size, durationSec = primary.durationSec)
+    }
 }

--- a/android/app/src/test/java/com/noop/analytics/PrimarySessionRestingHRTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/PrimarySessionRestingHRTest.kt
@@ -82,4 +82,36 @@ class PrimarySessionRestingHRTest {
         val hr = (0 until 40).map { HrSample("d", (it * 60).toLong(), 58) } + HrSample("d", 3000L, 200)
         assertEquals(58.0, AnalyticsEngine.primarySessionRestingHR(listOf(s), hr)!!, 1e-9)
     }
+
+    // --- #1169 coverage inputs (shadow metadata beside the mean) ---
+
+    /** Coverage reports the LONGEST session's VALID-sample count (invalids excluded) and its duration —
+     *  the raw inputs the later holdout weights by. Nap + out-of-range samples must not count. */
+    @Test fun coverageReportsValidCountAndDurationOfLongestSession() {
+        val night = s(8 * 3600.0, List(480) { 64 } + listOf(0, 300))   // 480 valid + 2 invalid
+        val nap = s(40 * 60.0, List(40) { 50 })
+        val cov = PrimarySessionRestingHR.coverage(listOf(nap, night))!!
+        assertEquals(480, cov.validSamples)
+        assertEquals(8 * 3600.0, cov.durationSec, 1e-9)
+    }
+
+    /** Coverage is null in LOCKSTEP with meanHR: below the gate, both return null (so the mean and its
+     *  coverage are always emitted together or not at all). */
+    @Test fun coverageIsNullInLockstepWithMean() {
+        val thin = listOf(s(3600.0, List(5) { 60 }))
+        assertNull(PrimarySessionRestingHR.meanHR(thin))
+        assertNull(PrimarySessionRestingHR.coverage(thin))
+        assertNull(PrimarySessionRestingHR.coverage(emptyList()))
+    }
+
+    /** The AnalyticsEngine wrapper windows HR to the longest session, same as the mean wrapper. */
+    @Test fun primarySessionRestingHRCoverageWindowsToLongest() {
+        val night = DetectedSleep(0L, 30_000L, 0.9, emptyList(), null, null)
+        val nap = DetectedSleep(40_000L, 45_000L, 0.9, emptyList(), null, null)
+        val hr = (0 until 100).map { HrSample("d", (it * 30).toLong(), 60) } +
+            (0 until 50).map { HrSample("d", (40_000 + it * 30).toLong(), 45) }
+        val cov = AnalyticsEngine.primarySessionRestingHRCoverage(listOf(nap, night), hr)!!
+        assertEquals(100, cov.validSamples)
+        assertEquals(30_000.0, cov.durationSec, 1e-9)
+    }
 }


### PR DESCRIPTION
Small, in-scope follow-up to #1188 (shadow-metric collection for #1169). That PR stores only the bare primary-session mean (`rhr_primary_session`). Its fixed 30-valid-sample gate is **cadence-blind** (artemc's point in the issue), so a night's mean can't be weighted or filtered by how well-covered it was when the later multi-participant holdout evaluates it. This records the raw **coverage inputs** beside the mean:

- `rhr_primary_session_valid_samples` — the valid HR samples the gate saw
- `rhr_primary_session_duration_s` — the primary (longest) session's duration

Deliberately the **raw inputs, not a derived coverage fraction** — so the holdout picks its own coverage definition rather than inheriting one (the issue explicitly cautions against baking in a fixed rule). Emitted in **lockstep** with the mean (same longest-session selection + same gate → both present or both absent), under the same `-noop` computed id.

## Stays in scope
- **Pure shadow instrumentation** — never shown, never scored.
- The **frozen #1174 mean definition is untouched**, and the shipped floor (`daily.restingHr`) remains the sole scoring input.
- No display wiring, no recovery/strain re-baselining — those stay gated on the multi-participant validation, per the issue and your #1188 comment.
- Adds it **now** so nights from here accrue the metadata, rather than a re-collection gap later.

## Implementation
- `PrimarySessionRestingHR.coverage(...)` (Swift + Kotlin) — returns the primary session's valid-sample count + duration, `nil` in lockstep with `meanHR`; mirrors its selection/gate exactly. `meanHR` (the frozen definition) is left byte-identical.
- `AnalyticsEngine.primarySessionRestingHRCoverage(...)` wrapper (both platforms), threaded through `IntelligenceEngine` beside the existing `rhr_primary_session` emission.
- Byte-parity twins with mirrored unit tests (count/duration, lockstep-nil, windowing).

## Verification
- Android `compileFullDebugKotlin` + `PrimarySessionRestingHRTest` (new coverage cases) green.
- `StrandAnalytics` (pure) covered by swift-packages CI; the app-target `IntelligenceEngine.swift` emit change validated via `app-build`.