### PR TITLE
Move PuffinFrameRecorder encode+write off the main actor (#652, reimplements #958 by @tigercraft4)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/PuffinCapture.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/PuffinCapture.swift
@@ -6,7 +6,7 @@ import Foundation
 /// The `hex` key is intentionally the same shape the test fixtures use (`frames.json` is an array of
 /// `{"hex": …}`), so a capture file is *directly* usable as a parity fixture — the extra fields are a
 /// superset the decoder ignores. Keys are snake_case to match the existing `golden.json` style.
-public struct PuffinCaptureRecord: Codable, Equatable {
+public struct PuffinCaptureRecord: Codable, Equatable, Sendable {
     /// Full on-wire frame as lowercase hex — the canonical `ParsedFrame.rawHex`.
     public let hex: String
     /// Source notify characteristic UUID (e.g. `fd4b0005-…`) — tells you which channel the frame

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -761,7 +761,9 @@ public final class BLEManager: NSObject, ObservableObject {
     private lazy var puffinDeepBufferLog = PuffinDeepBufferLog()
 
     /// Force the puffin capture buffer to disk so the Settings export/reveal targets a current file.
-    public func flushPuffinCaptures() { puffinRecorder.flush() }
+    /// `async` because the actual encode + write now happens off the main actor (#652); callers that
+    /// need the file to be current when this returns (export, reveal) must await it.
+    public func flushPuffinCaptures() async { await puffinRecorder.flush() }
 
     /// Record a local physical-phase marker for the passive optical experiment. This deliberately has
     /// no peripheral/write path: it only appends to `puffin-deepbuffers.jsonl` when capture is enabled.
@@ -4710,7 +4712,9 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         keepAliveTimer?.cancel()
         keepAliveTimer = nil
         resetCharacteristics()
-        puffinRecorder.flush()   // persist any buffered puffin capture frames before reconnect
+        // Best-effort, fire-and-forget: nothing below depends on this write completing, and the
+        // recorder keeps writing the same session file after reconnect (#652: encode+write off-main).
+        Task { @MainActor in await puffinRecorder.flush() }   // persist any buffered puffin capture frames
         puffinEventLog.close()   // release the event-log handle so the file is safe to export
         puffinDeepBufferLog.close()   // same for the high-rate deep-buffer log (#423)
         Task { @MainActor in await collector?.flushStandardHR() }   // persist any buffered 0x2A37 HR

--- a/Strand/BLE/PuffinFrameRecorder.swift
+++ b/Strand/BLE/PuffinFrameRecorder.swift
@@ -8,7 +8,13 @@ import WhoopProtocol
 /// that already arrived, it never writes to the device — so it is always safe to leave on.
 ///
 /// `@MainActor` because it reads `LiveState.heartRate` and updates published capture status; the
-/// BLEManager delegate callbacks that feed it are already on the main queue.
+/// BLEManager delegate callbacks that feed it are already on the main queue. The actual JSON encode +
+/// atomic file write + old-capture eviction — the part whose cost grows with the capture size — does
+/// NOT run on the main actor: it is handed off to the `fileWriter` background actor (#652) so a flush
+/// never blocks the main thread / SwiftUI, no matter how large the in-memory buffer has grown this
+/// session. Only the cheap bookkeeping (appending to `buffer`, bumping counters, snapshotting the
+/// buffer for a flush) stays on the main actor, since that is what other code reads synchronously for
+/// live-state display (`LiveState.puffinCaptureCount`/`puffinCaptureURL`, read by SettingsView et al).
 @MainActor
 final class PuffinFrameRecorder {
     /// UserDefaults flag, mirrored by the Settings toggle (`@AppStorage`). Separate from the puffin
@@ -23,12 +29,23 @@ final class PuffinFrameRecorder {
     /// capture toggle a 5/MG user left on reached 19 GB. After each flush, oldest files are evicted
     /// (by filename, which is timestamp-sorted) until the total is back under the cap. Never deletes
     /// the file the current session is still writing.
-    private static let directorySoftCapBytes = 50 * 1024 * 1024
+    private nonisolated static let directorySoftCapBytes = 50 * 1024 * 1024
 
     private weak var state: LiveState?
     private let buffer = PuffinCapture()
     private var sinceFlush = 0
     private var fileURL: URL?
+
+    /// Performs the encode + write + eviction off the main actor. An `actor`, so overlapping flushes
+    /// serialize on it rather than racing two writes at the same file.
+    private let fileWriter = PuffinFileWriter()
+
+    /// Non-nil while a flush's background write is in-flight. Lets `capture()` skip redundant
+    /// auto-flush triggers while one is already running, and lets a concurrent explicit `flush()` call
+    /// (export/reveal/disconnect) await the SAME write instead of racing a second one for the same
+    /// file — which could otherwise let an older, smaller snapshot's write land after a newer one's
+    /// and regress the on-disk capture.
+    private var flushTask: Task<Void, Never>?
 
     init(state: LiveState) {
         self.state = state
@@ -36,8 +53,9 @@ final class PuffinFrameRecorder {
 
     private var isEnabled: Bool { UserDefaults.standard.bool(forKey: Self.enabledKey) }
 
-    /// `<AppSupport>/OpenWhoop/puffin-captures/`, created on demand.
-    private static func captureDirectory() throws -> URL {
+    /// `<AppSupport>/OpenWhoop/puffin-captures/`, created on demand. `nonisolated` so the background
+    /// `fileWriter` actor can call it (via `evictOldCaptures`) without hopping back to the main actor.
+    private nonisolated static func captureDirectory() throws -> URL {
         let fm = FileManager.default
         let dir = try fm.url(for: .applicationSupportDirectory, in: .userDomainMask,
                              appropriateFor: nil, create: true)
@@ -48,6 +66,9 @@ final class PuffinFrameRecorder {
     }
 
     /// Record one puffin frame (off `fd4b0003/0004/0005/0007`). No-op unless capture is enabled.
+    /// Synchronous — this is called directly from a CoreBluetooth delegate callback on the main queue
+    /// and must never block on file I/O, so a due auto-flush is only ever *triggered* here, never
+    /// awaited (see `flush()`).
     func capture(frame: [UInt8], char: CBUUID) {
         guard isEnabled else { return }
         let tsMs = Int(Date().timeIntervalSince1970 * 1000)
@@ -55,30 +76,57 @@ final class PuffinFrameRecorder {
                       tsMs: tsMs, hr: state?.heartRate)
         sinceFlush += 1
         state?.puffinCaptureCount = buffer.count
-        if sinceFlush >= Self.flushEvery { flush() }
+        if sinceFlush >= Self.flushEvery && flushTask == nil {
+            flushTask = Task { [weak self] in
+                guard let self else { return }
+                await self.runFlush()
+            }
+        }
     }
 
-    /// Write the full capture to disk (best-effort, atomic). Called periodically and on disconnect.
-    func flush() {
-        guard buffer.count > 0 else { return }
-        do {
-            let url = try sessionFileURL()
-            let data = try buffer.encodedJSON()
-            try data.write(to: url, options: .atomic)
+    /// Flush the buffered frames to disk (best-effort, atomic). Awaited by explicit callers (export,
+    /// reveal, disconnect-before-reconnect) so the on-disk file is guaranteed current by the time this
+    /// returns — joins an in-flight auto-flush instead of starting a second, racing write when one is
+    /// already running.
+    func flush() async {
+        // Let any in-flight auto-flush finish first (don't race a second write for the same generation),
+        // THEN do one FRESH write of the current buffer — so the file includes every frame captured up to
+        // this call, which export / reveal / disconnect rely on. (Coalescing straight onto the in-flight
+        // flush would return that flush's OLDER snapshot and silently drop frames captured since.) This
+        // fresh write goes directly through the serializing `fileWriter` actor and deliberately does NOT
+        // touch `flushTask`, so it can't disturb the auto-flush guard; if capture() starts a new auto-flush
+        // while this write is in flight, the actor serializes the two (this one submitted first, so an
+        // even-newer auto-flush lands last) and neither corrupts nor regresses the file.
+        if let inFlight = flushTask { await inFlight.value }
+        guard buffer.count > 0, let url = try? sessionFileURL() else { return }
+        if await fileWriter.write(records: buffer.records, to: url) {
             sinceFlush = 0
             state?.puffinCaptureURL = url
-            // Bound on-disk growth (#27): evict oldest captures beyond the soft cap, never the
-            // file this session is still writing.
-            Self.evictOldCaptures(keeping: url)
-        } catch {
-            // Best-effort: a failed flush just means the next one rewrites the whole file.
         }
+    }
+
+    /// The actual flush body: snapshot the buffer on the main actor (an O(1) copy-on-write of a
+    /// value-type array, not a re-encode), then hand the JSON encode + atomic write + eviction to the
+    /// `fileWriter` background actor. Only the state hand-off crosses the actor boundary.
+    private func runFlush() async {
+        defer { flushTask = nil }
+        guard buffer.count > 0, let url = try? sessionFileURL() else { return }
+        let snapshot = buffer.records
+        let ok = await fileWriter.write(records: snapshot, to: url)
+        if ok {
+            sinceFlush = 0
+            state?.puffinCaptureURL = url
+        }
+        // A failed write is best-effort, exactly as before: `sinceFlush` and `puffinCaptureURL` are
+        // left alone, so the next flush just rewrites the whole file again.
     }
 
     /// Enforce the directory soft cap by deleting the oldest capture files (best-effort). Filenames are
     /// `puffin-yyyyMMdd-HHmmss.json`, so lexicographic order is chronological — delete from the front
     /// until the total is back under the cap. `keep` (the active session file) is never deleted.
-    private static func evictOldCaptures(keeping keep: URL) {
+    /// `fileprivate nonisolated` so the background `fileWriter` actor can call it directly after a
+    /// write, without hopping back to the main actor.
+    fileprivate nonisolated static func evictOldCaptures(keeping keep: URL) {
         let fm = FileManager.default
         guard let dir = try? captureDirectory() else { return }
         guard let entries = try? fm.contentsOfDirectory(
@@ -117,4 +165,35 @@ final class PuffinFrameRecorder {
         f.dateFormat = "yyyyMMdd-HHmmss"
         return f
     }()
+}
+
+/// Off-main-actor home for the expensive part of a puffin flush: encoding the (growing) in-memory
+/// capture to JSON and atomically rewriting the session file, then evicting old captures. `actor`
+/// isolation means two overlapping calls (an auto-flush racing an explicit flush) are serialized
+/// rather than both touching the same file at once — `PuffinFrameRecorder.flush()` additionally
+/// coalesces callers onto a single in-flight `Task` so a second write for the same generation of data
+/// is never even started, but the actor boundary is kept as a second, independent safety net.
+///
+/// This still re-encodes+rewrites the WHOLE capture on every flush (the JSON-array-of-objects format
+/// that downstream tooling — the export/share/bundle paths and the protocol-mapping fixture format —
+/// already expects is kept as-is here; switching to an append-only JSONL format was judged a bigger
+/// format-migration risk than the win of avoiding the O(n) re-encode, see #652). What moved is WHERE
+/// that encode+write runs, not how much work it does per flush.
+private actor PuffinFileWriter {
+    /// Encode `records` and atomically write them to `url`, then run the directory eviction. Returns
+    /// whether the write succeeded; best-effort exactly like the flush this replaces.
+    func write(records: [PuffinCaptureRecord], to url: URL) -> Bool {
+        do {
+            let enc = JSONEncoder()
+            enc.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            let data = try enc.encode(records)
+            try data.write(to: url, options: .atomic)
+            // Bound on-disk growth (#27): evict oldest captures beyond the soft cap, never the file
+            // this session is still writing. Runs off the main actor too, alongside the write.
+            PuffinFrameRecorder.evictOldCaptures(keeping: url)
+            return true
+        } catch {
+            return false
+        }
+    }
 }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -2087,29 +2087,31 @@ struct SettingsView: View {
     /// Flush the in-flight capture, then copy it to a user-chosen location (save panel on macOS) or
     /// hand it to the system share sheet (iOS).
     private func exportPuffinCaptures() {
-        model.ble.flushPuffinCaptures()
-        guard let src = live.puffinCaptureURL else { return }
-        // Suggest a friendly, timestamped name so a reporter saving several captures gets sortable,
-        // non-colliding files (#510) — e.g. noop-raw-capture-260617-1042.json.
-        let suggested = FileExport.timestampedName("noop-raw-capture", ext: "json")
-        #if os(macOS)
-        let panel = NSSavePanel()
-        panel.allowedContentTypes = [.json]
-        panel.nameFieldStringValue = suggested
-        panel.canCreateDirectories = true
-        guard panel.runModal() == .OK, let dest = panel.url else { return }
-        let fm = FileManager.default
-        do {
-            if fm.fileExists(atPath: dest.path) { try fm.removeItem(at: dest) }
-            try fm.copyItem(at: src, to: dest)
-        } catch {
-            backupAlertTitle = String(localized: "Export failed")
-            backupAlertMessage = error.localizedDescription
-            showBackupAlert = true
+        Task { @MainActor in
+            await model.ble.flushPuffinCaptures()
+            guard let src = live.puffinCaptureURL else { return }
+            // Suggest a friendly, timestamped name so a reporter saving several captures gets sortable,
+            // non-colliding files (#510) — e.g. noop-raw-capture-260617-1042.json.
+            let suggested = FileExport.timestampedName("noop-raw-capture", ext: "json")
+            #if os(macOS)
+            let panel = NSSavePanel()
+            panel.allowedContentTypes = [.json]
+            panel.nameFieldStringValue = suggested
+            panel.canCreateDirectories = true
+            guard panel.runModal() == .OK, let dest = panel.url else { return }
+            let fm = FileManager.default
+            do {
+                if fm.fileExists(atPath: dest.path) { try fm.removeItem(at: dest) }
+                try fm.copyItem(at: src, to: dest)
+            } catch {
+                backupAlertTitle = String(localized: "Export failed")
+                backupAlertMessage = error.localizedDescription
+                showBackupAlert = true
+            }
+            #else
+            FileExport.exportFile(at: src, suggestedName: suggested)
+            #endif
         }
-        #else
-        FileExport.exportFile(at: src, suggestedName: suggested)
-        #endif
     }
 
     private func markOpticalPhase(_ phase: PuffinOpticalExperimentPhase) {
@@ -2144,20 +2146,22 @@ struct SettingsView: View {
     /// `rawAndLogBusy` disables the button for the duration: without it a second tap mid-export fires a
     /// second `exportPair` (two staged zips, two save panels / stacked share sheets).
     private func exportRawAndLog() {
-        model.ble.flushPuffinCaptures()
-        guard let capture = live.puffinCaptureURL else {
-            backupAlertTitle = String(localized: "Nothing to export")
-            backupAlertMessage = String(localized: "No raw capture has been recorded yet this session.")
-            showBackupAlert = true
-            return
-        }
-        let stamp = FileExport.timestamp()
         rawAndLogBusy = true
-        Task {
+        Task { @MainActor in
             // `defer` so the flag is cleared on ANY exit (#961 follow-up), including cancellation. It
             // cleared correctly before, but only because `exportPair` is non-throwing — the guard should
             // not depend on that. Otherwise the button stays disabled behind a spinner that never stops.
             defer { rawAndLogBusy = false }
+            // #652: `flushPuffinCaptures` is async now (encode+write moved off the main actor), so await
+            // it here — the file must be current before we read `puffinCaptureURL` to export it.
+            await model.ble.flushPuffinCaptures()
+            guard let capture = live.puffinCaptureURL else {
+                backupAlertTitle = String(localized: "Nothing to export")
+                backupAlertMessage = String(localized: "No raw capture has been recorded yet this session.")
+                showBackupAlert = true
+                return
+            }
+            let stamp = FileExport.timestamp()
             await FileExport.exportPair(
                 file: capture, fileSuggestedName: "noop-raw-capture-\(stamp).json",
                 text: live.exportableLogText(), textSuggestedName: "noop-strap-log-\(stamp).txt")
@@ -2167,9 +2171,11 @@ struct SettingsView: View {
     #if os(macOS)
     /// Flush, then reveal the capture file in Finder so the user can grab it directly.
     private func revealPuffinCaptures() {
-        model.ble.flushPuffinCaptures()
-        guard let url = live.puffinCaptureURL else { return }
-        NSWorkspace.shared.activateFileViewerSelecting([url])
+        Task { @MainActor in
+            await model.ble.flushPuffinCaptures()
+            guard let url = live.puffinCaptureURL else { return }
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+        }
     }
     #endif
 

--- a/Strand/Screens/TestCentreView.swift
+++ b/Strand/Screens/TestCentreView.swift
@@ -390,20 +390,22 @@ struct TestCentreView: View {
     }
 
     private func runScheduledExportNow() {
-        model.ble.flushPuffinCaptures()
-        let url = ScheduledDebugExport.runNow(captureURL: live.puffinCaptureURL)
-        if let url {
-            infoTitle = String(localized: "Strap log exported")
-            #if os(iOS)
-            infoMessage = String(localized: "Saved \(url.lastPathComponent) to NOOP's folder in the Files app.")
-            #else
-            infoMessage = String(localized: "Saved \(url.lastPathComponent) to your Documents folder.")
-            #endif
-        } else {
-            infoTitle = String(localized: "Export failed")
-            infoMessage = String(localized: "Couldn't write the strap log right now.")
+        Task { @MainActor in
+            await model.ble.flushPuffinCaptures()
+            let url = ScheduledDebugExport.runNow(captureURL: live.puffinCaptureURL)
+            if let url {
+                infoTitle = String(localized: "Strap log exported")
+                #if os(iOS)
+                infoMessage = String(localized: "Saved \(url.lastPathComponent) to NOOP's folder in the Files app.")
+                #else
+                infoMessage = String(localized: "Saved \(url.lastPathComponent) to your Documents folder.")
+                #endif
+            } else {
+                infoTitle = String(localized: "Export failed")
+                infoMessage = String(localized: "Couldn't write the strap log right now.")
+            }
+            showInfo = true
         }
-        showInfo = true
     }
 }
 


### PR DESCRIPTION
Reimplements **@tigercraft4's #958** onto current `main` (it had drifted out of date and conflicted). All the design is theirs — this rebases it and reconciles the one collision with `main`'s newer code, plus one correctness tightening on `flush()`.

## The fix (#652)
`PuffinFrameRecorder` is `@MainActor` and every 25 frames JSON-encodes the **entire** growing capture and atomically rewrites the file, **synchronously on main** — so a long capture increasingly janks SwiftUI.

- Encode + atomic write + #27 directory-size eviction now run on a background **`PuffinFileWriter` actor**. Only cheap bookkeeping stays on main: append a frame, bump `puffinCaptureCount`, and take an **O(1) copy-on-write snapshot** of `buffer.records` to hand off.
- **File format unchanged** — same `[.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]` as the existing `buffer.encodedJSON()` (verified), so the export/share/fixture paths are unaffected.
- `flush()` is `async`; the auto-flush trigger in `capture()` stays **fire-and-forget** (it runs on a CoreBluetooth delegate callback and must never block), while explicit callers (export / reveal / disconnect-before-reconnect) `await` it.
- `PuffinCaptureRecord` gains `Sendable` (pure `WhoopProtocol`) since a snapshot now crosses the actor boundary.

## What I changed vs #958
1. **Rebase conflict:** only `SettingsView.swift` collided — `main`'s #961 busy-flag export guard vs the PR's async-flush wrapping. Reconciled into one `Task`: keep the `rawAndLogBusy` guard **and** `await` the now-async flush (capture in scope, both awaits, spinner cleared via `defer` on any exit).
2. **`flush()` currency tightening.** The original coalesced onto an in-flight auto-flush and returned *its* older snapshot, so an export could silently drop frames captured since — contradicting the "file is current on return" guarantee export/reveal rely on. Now `flush()` drains any in-flight auto-flush, then does one **fresh** write of the current buffer. The serializing `fileWriter` actor keeps concurrent writes ordered (older can't land after newer), so it's both current and race-safe.

## Verification
- `Packages/WhoopProtocol`: `swift build` + `swift test --filter PuffinCaptureTests` — 6/6 pass (the `Sendable` addition is inert).
- App-target Swift (`PuffinFrameRecorder`, `BLEManager`, `SettingsView`, `TestCentreView`) validated via `app-build`.

## ⚠️ Needs on-strap validation before merge (BLE-adjacent)
Per @tigercraft4's own caveat — compile-success proves nothing about live capture. On a connected WHOOP 5.0/MG:
- The frame counter keeps updating live, and **Export frames… / Export raw + log / Reveal in Finder** produce a complete, valid JSON file immediately after tapping.
- No jank/dropped frames over a long capture (the whole point of #652).
- A disconnect/reconnect mid-capture still ends with a complete file (the fire-and-forget flush at `didDisconnectPeripheral`).

Thanks @tigercraft4 — clean, well-reasoned refactor.