### PR TITLE
Reduce analytics + live-HR hot-path churn (no behavior change)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -1058,11 +1058,8 @@ public enum AnalyticsEngine {
         sessions: [SleepSession], hr: [HRSample],
         validBpm: ClosedRange<Int> = PrimarySessionRestingHR.defaultValidBpm,
         minValidSamples: Int = PrimarySessionRestingHR.defaultMinValidSamples) -> Double? {
-        PrimarySessionRestingHR.meanHR(sessions: sessions.map { s in
-            PrimarySessionRestingHR.Session(
-                durationSec: Double(s.end - s.start),
-                bpm: hr.filter { $0.ts >= s.start && $0.ts < s.end }.map { $0.bpm })
-        }, validBpm: validBpm, minValidSamples: minValidSamples)
+        PrimarySessionRestingHR.meanHR(sessions: primarySessions(sessions: sessions, hr: hr),
+                                       validBpm: validBpm, minValidSamples: minValidSamples)
     }
 
     /// #1169 coverage inputs for the shadow `rhr_primary_session` mean (valid-sample count + primary-session
@@ -1073,11 +1070,33 @@ public enum AnalyticsEngine {
         sessions: [SleepSession], hr: [HRSample],
         validBpm: ClosedRange<Int> = PrimarySessionRestingHR.defaultValidBpm,
         minValidSamples: Int = PrimarySessionRestingHR.defaultMinValidSamples) -> PrimarySessionRestingHR.Coverage? {
-        PrimarySessionRestingHR.coverage(sessions: sessions.map { s in
+        PrimarySessionRestingHR.coverage(sessions: primarySessions(sessions: sessions, hr: hr),
+                                         validBpm: validBpm, minValidSamples: minValidSamples)
+    }
+
+    /// Window `hr` to each session's `[start, end)` once — the shared input BOTH the #1169 mean and its coverage
+    /// average over. Extracted so a caller that needs both windows the samples a SINGLE time (this is O(sessions
+    /// × hr); doing it once per metric is pure duplicate work). Twin of the Kotlin `primarySessions`.
+    private static func primarySessions(sessions: [SleepSession], hr: [HRSample]) -> [PrimarySessionRestingHR.Session] {
+        sessions.map { s in
             PrimarySessionRestingHR.Session(
                 durationSec: Double(s.end - s.start),
                 bpm: hr.filter { $0.ts >= s.start && $0.ts < s.end }.map { $0.bpm })
-        }, validBpm: validBpm, minValidSamples: minValidSamples)
+        }
+    }
+
+    /// The #1169 mean AND its coverage from ONE windowing of `hr` (both read the same longest primary session).
+    /// Byte-identical to calling `primarySessionRestingHR` + `primarySessionRestingHRCoverage` separately, but
+    /// windows the per-session samples once instead of twice — the only caller (IntelligenceEngine) needs both.
+    /// Twin of the Kotlin `primarySessionRestingHRWithCoverage`.
+    public static func primarySessionRestingHRWithCoverage(
+        sessions: [SleepSession], hr: [HRSample],
+        validBpm: ClosedRange<Int> = PrimarySessionRestingHR.defaultValidBpm,
+        minValidSamples: Int = PrimarySessionRestingHR.defaultMinValidSamples)
+        -> (mean: Double?, coverage: PrimarySessionRestingHR.Coverage?) {
+        let built = primarySessions(sessions: sessions, hr: hr)
+        return (PrimarySessionRestingHR.meanHR(sessions: built, validBpm: validBpm, minValidSamples: minValidSamples),
+                PrimarySessionRestingHR.coverage(sessions: built, validBpm: validBpm, minValidSamples: minValidSamples))
     }
 
     // MARK: - Skin-temp funnel diagnostic (#752)

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/PrimarySessionRestingHRTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/PrimarySessionRestingHRTests.swift
@@ -113,4 +113,19 @@ final class PrimarySessionRestingHRTests: XCTestCase {
         XCTAssertEqual(cov?.validSamples, 100)
         XCTAssertEqual(cov?.durationSec, 30_000)
     }
+
+    /// The combined wrapper windows the HR ONCE but must return byte-identical (mean, coverage) to calling the
+    /// two separate wrappers — the only caller (IntelligenceEngine) needs both, so this locks the dedup.
+    func testWithCoverageMatchesSeparateCalls() {
+        let night = SleepSession(start: 0, end: 30_000, efficiency: 0.9, stages: [], restingHR: nil, avgHRV: nil)
+        let nap = SleepSession(start: 40_000, end: 45_000, efficiency: 0.9, stages: [], restingHR: nil, avgHRV: nil)
+        var hr = (0..<100).map { HRSample(ts: $0 * 30, bpm: 60) }
+        hr += (0..<50).map { HRSample(ts: 40_000 + $0 * 30, bpm: 45) }
+        let sessions = [nap, night]
+        let combined = AnalyticsEngine.primarySessionRestingHRWithCoverage(sessions: sessions, hr: hr)
+        XCTAssertEqual(combined.mean, AnalyticsEngine.primarySessionRestingHR(sessions: sessions, hr: hr))
+        let sep = AnalyticsEngine.primarySessionRestingHRCoverage(sessions: sessions, hr: hr)
+        XCTAssertEqual(combined.coverage?.validSamples, sep?.validSamples)
+        XCTAssertEqual(combined.coverage?.durationSec, sep?.durationSec)
+    }
 }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -901,8 +901,8 @@ final class IntelligenceEngine: ObservableObject {
                 // comparison the issue asks for accrues on real devices. NEVER shown and NEVER fed to any
                 // score; #1174's definition is unchanged — this only records its per-night output. The
                 // windowing + delegation lives in the byte-identical, tested `AnalyticsEngine`.
-                let primarySessionRHR = AnalyticsEngine.primarySessionRestingHR(sessions: res.sleepSessions, hr: hr)
-                let primarySessionRHRCoverage = AnalyticsEngine.primarySessionRestingHRCoverage(sessions: res.sleepSessions, hr: hr)
+                let (primarySessionRHR, primarySessionRHRCoverage) =
+                    AnalyticsEngine.primarySessionRestingHRWithCoverage(sessions: res.sleepSessions, hr: hr)
                 out.append(DayScan(result: res, rhrLine: rhrLine,
                                    readOwner: owner, hrRows: hr.count,
                                    sleepTrace: sleepTrace, stepsTrace: stepsTrace, hrvTrace: hrvTrace,

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -15,6 +15,7 @@ import com.noop.protocol.Whoop4SkinTemp
 import com.noop.protocol.skinTempCelsius
 import org.json.JSONObject
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import kotlin.math.max
@@ -95,6 +96,18 @@ object AnalyticsEngine {
      * pure-function callers/tests on UTC are unchanged.
      */
     fun dayString(ts: Long, offsetSec: Long): String = dayString(ts + offsetSec)
+
+    /**
+     * UTC-midnight epoch seconds of an ISO [day] key (yyyy-MM-dd). [isoDay] is a FIXED-UTC formatter, so
+     * `dayString(ts, offsetSec) == day` ⇔ `(ts + offsetSec) ∈ [dayStartUtcSeconds(day), +86400)` — an integer
+     * range check that replaces the per-sample DateFormatter the full-day stream filters in [analyzeDay] used
+     * to run (~170k formatter invocations per scored day, ×maxDays, every pass; #996). A malformed [day] falls
+     * back to 0 — an empty 1970 window no real sample matches — rather than throwing, so a single bad key can
+     * never take down a whole scoring pass. Byte-identical twin of the Swift `AnalyticsEngine.dayStartUtcSeconds`
+     * (locked cross-platform by AnalyticsEngineDayBoundsTest / AnalyticsEngineDayBoundsTests).
+     */
+    fun dayStartUtcSeconds(day: String): Long =
+        runCatching { LocalDate.parse(day).atStartOfDay(ZoneOffset.UTC).toEpochSecond() }.getOrDefault(0L)
 
     /**
      * JSON-encode stage segments to the verbatim array shape the sleepSession cache
@@ -309,6 +322,16 @@ object AnalyticsEngine {
         deepHrvWindow: Boolean = false,
     ): DayResult {
 
+        // Precompute the day's UTC bounds ONCE (#996). isoDay is a FIXED-UTC formatter, so
+        // `dayString(ts, tzOffsetSeconds) == day` is exactly membership in [dayStartUtc, +86400). That turns
+        // the day-bucketing filters below — otherwise a per-sample DateFormatter over the full-day
+        // dayHr/daySteps streams (~86k 1 Hz samples each) once per analyzeDay, ×maxDays every pass — into an
+        // integer range check. Byte-identical to the formatter compare (locked by AnalyticsEngineDayBoundsTest,
+        // incl. fractional offsets), matching the Swift twin.
+        val dayStartUtc = dayStartUtcSeconds(day)
+        val dayEndUtc = dayStartUtc + 86_400
+        fun tsInDay(ts: Long): Boolean = (ts + tzOffsetSeconds) >= dayStartUtc && (ts + tzOffsetSeconds) < dayEndUtc
+
         // ── Sleep detection + staging ─────────────────────────────────────────
         val detectedSessions = SleepStager.detectSleep(
             hr = hr, rr = rr, resp = resp, gravity = gravity, tzOffsetSeconds = tzOffsetSeconds,
@@ -349,7 +372,7 @@ object AnalyticsEngine {
         }
         // Sessions attributed to `day` = those whose end falls on `day` (LOCAL day, #277). `day` is
         // the caller's local-day key; attribute by the same offset so the bucket and the key agree.
-        val matched = allSessions.filter { dayString(it.end, tzOffsetSeconds) == day }
+        val matched = allSessions.filter { tsInDay(it.end) }
 
         // ── The day's MAIN night (#525) ───────────────────────────────────────
         // A day can hold an overnight AND a daytime nap (both end on `day`, so both are in `matched`).
@@ -634,7 +657,7 @@ object AnalyticsEngine {
             // day's read window may include adjacent-day samples, so filter to the LOCAL-day key first
             // (#277); the wrap-aware tick math itself lives in the shared StepsCounter kernel so the daily
             // and per-workout (#398) totals can never disagree.
-            val inDay = (daySteps ?: steps).filter { dayString(it.ts, tzOffsetSeconds) == day }
+            val inDay = (daySteps ?: steps).filter { tsInDay(it.ts) }
             val ticks = StepsCounter.stepsInWindow(inDay) ?: return@run null
             // @57 counts motion ticks, not validated steps — the 5/MG counter overcounts. Divide
             // by the user-calibrated ticks-per-step (default 1.0 = raw pass-through; floor 0.5 so
@@ -656,7 +679,7 @@ object AnalyticsEngine {
         // (dayString(ts, tzOffset)) so it agrees with the bucket (#277). Fall back to the
         // night-window hr for pure-function callers that don't supply dayHr. Strain keeps the full
         // window (bounded log).
-        val dayHrFiltered = (dayHr ?: hr).filter { dayString(it.ts, tzOffsetSeconds) == day }
+        val dayHrFiltered = (dayHr ?: hr).filter { tsInDay(it.ts) }
         val activeKcalEst: Double? = if (dayHrFiltered.isEmpty()) {
             null
         } else {
@@ -868,16 +891,7 @@ object AnalyticsEngine {
         hr: List<HrSample>,
         validBpm: IntRange = PrimarySessionRestingHR.DEFAULT_VALID_BPM,
         minValidSamples: Int = PrimarySessionRestingHR.DEFAULT_MIN_VALID_SAMPLES,
-    ): Double? = PrimarySessionRestingHR.meanHR(
-        sessions.map { s ->
-            PrimarySessionRestingHR.Session(
-                durationSec = (s.end - s.start).toDouble(),
-                bpm = hr.filter { it.ts >= s.start && it.ts < s.end }.map { it.bpm },
-            )
-        },
-        validBpm,
-        minValidSamples,
-    )
+    ): Double? = PrimarySessionRestingHR.meanHR(primarySessions(sessions, hr), validBpm, minValidSamples)
 
     /** #1169 coverage inputs for the shadow `rhr_primary_session` mean (valid-sample count + primary-session
      *  duration). Builds the SAME per-session inputs as [primarySessionRestingHR] and delegates to
@@ -888,16 +902,36 @@ object AnalyticsEngine {
         hr: List<HrSample>,
         validBpm: IntRange = PrimarySessionRestingHR.DEFAULT_VALID_BPM,
         minValidSamples: Int = PrimarySessionRestingHR.DEFAULT_MIN_VALID_SAMPLES,
-    ): PrimarySessionRestingHR.Coverage? = PrimarySessionRestingHR.coverage(
-        sessions.map { s ->
-            PrimarySessionRestingHR.Session(
-                durationSec = (s.end - s.start).toDouble(),
-                bpm = hr.filter { it.ts >= s.start && it.ts < s.end }.map { it.bpm },
-            )
-        },
-        validBpm,
-        minValidSamples,
-    )
+    ): PrimarySessionRestingHR.Coverage? =
+        PrimarySessionRestingHR.coverage(primarySessions(sessions, hr), validBpm, minValidSamples)
+
+    /** Window [hr] to each session's `[start, end)` once — the shared input BOTH the #1169 mean and its coverage
+     *  average over. Extracted so a caller that needs both windows the samples a SINGLE time (this is O(sessions
+     *  × hr); doing it once per metric is pure duplicate work). Twin of the Swift `primarySessions`. */
+    private fun primarySessions(
+        sessions: List<DetectedSleep>,
+        hr: List<HrSample>,
+    ): List<PrimarySessionRestingHR.Session> = sessions.map { s ->
+        PrimarySessionRestingHR.Session(
+            durationSec = (s.end - s.start).toDouble(),
+            bpm = hr.filter { it.ts >= s.start && it.ts < s.end }.map { it.bpm },
+        )
+    }
+
+    /** The #1169 mean AND its coverage from ONE windowing of [hr] (both read the same longest primary session).
+     *  Byte-identical to calling [primarySessionRestingHR] + [primarySessionRestingHRCoverage] separately, but
+     *  windows the per-session samples once instead of twice — the only caller (IntelligenceEngine) needs both.
+     *  Twin of the Swift `primarySessionRestingHRWithCoverage`. */
+    internal fun primarySessionRestingHRWithCoverage(
+        sessions: List<DetectedSleep>,
+        hr: List<HrSample>,
+        validBpm: IntRange = PrimarySessionRestingHR.DEFAULT_VALID_BPM,
+        minValidSamples: Int = PrimarySessionRestingHR.DEFAULT_MIN_VALID_SAMPLES,
+    ): Pair<Double?, PrimarySessionRestingHR.Coverage?> {
+        val built = primarySessions(sessions, hr)
+        return PrimarySessionRestingHR.meanHR(built, validBpm, minValidSamples) to
+            PrimarySessionRestingHR.coverage(built, validBpm, minValidSamples)
+    }
 
     /** Plausible worn skin-temperature range (°C). Off-wrist/charging samples drift to ambient and are
      *  excluded; the strap's own decode gate is the looser 20–45. (PR #85) */

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -758,8 +758,9 @@ object IntelligenceEngine {
             // comparison the issue asks for accrues on real devices. NEVER shown and NEVER fed to any score;
             // #1174's definition is unchanged. The windowing + delegation lives in the byte-identical,
             // tested AnalyticsEngine.
-            AnalyticsEngine.primarySessionRestingHR(res.sleepSessions, hr)?.let { primarySessionRHRByDay[res.daily.day] = it }
-            AnalyticsEngine.primarySessionRestingHRCoverage(res.sleepSessions, hr)?.let { primarySessionRHRCoverageByDay[res.daily.day] = it }
+            val (primaryRhr, primaryRhrCoverage) = AnalyticsEngine.primarySessionRestingHRWithCoverage(res.sleepSessions, hr)
+            primaryRhr?.let { primarySessionRHRByDay[res.daily.day] = it }
+            primaryRhrCoverage?.let { primarySessionRHRCoverageByDay[res.daily.day] = it }
             scoredNights.add(res)
             resolvedScoreOwnerByDay[res.daily.day] = owner
         }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1699,7 +1699,14 @@ class WhoopBleClient(
             // paused, so it never sets the flag for a WHOOP. `bonded` stays false (no encrypted bond), so
             // the buzz/alarm/HRV feature gates keep keying off the WHOOP bond. Twin of iOS OuraLiveSource
             // → LiveState.streamingLiveHR (PR #56).
-            _state.update { it.copy(heartRate = hr, connected = true, streamingLiveHR = true) }
+            // Skip the per-frame it.copy() once HR is steady AND both flags are already set — StateFlow drops
+            // the equal state anyway, so this only avoids the throwaway LiveState allocation. The guard still
+            // fires whenever ANY of the three isn't at its target, so the connected/streamingLiveHR
+            // transitions are never missed (matches the WHOOP live-HR paths).
+            val s = _state.value
+            if (s.heartRate != hr || !s.connected || !s.streamingLiveHR) {
+                _state.update { it.copy(heartRate = hr, connected = true, streamingLiveHR = true) }
+            }
         }
     }
 

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5435,7 +5435,10 @@ class WhoopBleClient(
             "REALTIME_DATA" -> {
                 // Reject 0 / out-of-range spikes; only accept physiologically plausible HR.
                 (parsed.parsed["heart_rate"] as? Int)?.let { hr ->
-                    if (hr in 30..220) _state.update { it.copy(heartRate = hr) }
+                    // Only republish when the value actually changed: a same-HR frame's it.copy() allocates a
+                    // whole throwaway LiveState that StateFlow drops as equal anyway — pure GC churn at ~1 Hz,
+                    // every frame. Matches the Swift FrameRouter guard (`state.heartRate != hr`).
+                    if (hr in 30..220 && _state.value.heartRate != hr) _state.update { it.copy(heartRate = hr) }
                 }
                 // The realtime stream usually reports rr_count=0; only update R-R when this frame
                 // actually carries intervals, so we don't wipe R-R sourced from the 0x2A37 profile.
@@ -5715,7 +5718,10 @@ class WhoopBleClient(
         if (rr.isNotEmpty()) _state.update { it.withRRIntervals(rr) }
         // HR: accept only physiologically plausible values; reject 0/garbage (off-wrist).
         if (hr in 30..220) {
-            _state.update { it.copy(heartRate = hr) }
+            // Skip the redundant it.copy() when HR is unchanged — StateFlow drops an equal state anyway, so
+            // this only avoids the per-frame throwaway LiveState allocation (matches FrameRouter). The bonded
+            // transition below stays UNCONDITIONAL: it must still fire once even while HR sits steady.
+            if (_state.value.heartRate != hr) _state.update { it.copy(heartRate = hr) }
             // EXPERIMENTAL WHOOP 5.0/MG: there is no confirmed-write bond for a 5/MG strap, so once
             // live HR actually streams over the standard profile we treat the link as established —
             // otherwise the UI sits on "Connecting…" forever even though data is flowing (issue #8).

--- a/android/app/src/test/java/com/noop/analytics/AnalyticsEngineDayBoundsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/AnalyticsEngineDayBoundsTest.kt
@@ -1,0 +1,129 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import com.noop.data.StepSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Locks the analyzeDay hot-path optimization (#996): the integer UTC-bounds membership check that replaced
+ * the per-sample `dayString(ts, offsetSec) == day` DateFormatter must be BYTE-IDENTICAL to it. If the two
+ * ever diverge, samples get attributed to the wrong calendar day (wrong step / calorie / Effort totals), so
+ * this sweeps timestamps densely across BOTH midnight edges at a range of fixed offsets — including the
+ * FRACTIONAL ones (+5:30 Kolkata, +5:45 Kathmandu, −9:30 Marquesas, −3:30 Newfoundland) — and asserts the two
+ * agree at every point. The macOS twin is `AnalyticsEngineDayBoundsTests` (same anchor, same prime step, same
+ * offsets) so the cross-platform golden vectors stay in lockstep.
+ */
+class AnalyticsEngineDayBoundsTest {
+
+    // --- Membership equivalence sweep -----------------------------------------
+
+    @Test fun integerBoundsMatchDayStringAcrossMidnightAndOffsets() {
+        val anchor = 1_700_000_000L  // 2023-11-14T22:13:20Z
+        val offsets = listOf(
+            0L,
+            -4 * 3600L, 5 * 3600L, 13 * 3600L, -12 * 3600L, 14 * 3600L,
+            5 * 3600L + 1800L,      // +5:30 Kolkata
+            5 * 3600L + 2700L,      // +5:45 Kathmandu
+            -(9 * 3600L + 1800L),   // −9:30 Marquesas
+            -(3 * 3600L + 1800L),   // −3:30 Newfoundland
+        )
+        for (off in offsets) {
+            val day = AnalyticsEngine.dayString(anchor, off)
+            val start = AnalyticsEngine.dayStartUtcSeconds(day)
+            // ±28 h around the anchor at a prime step, so both midnight edges of `day` are crossed densely
+            // and never in phase with the day grid.
+            var ts = anchor - 100_800L
+            while (ts < anchor + 100_800L) {
+                val viaFormatter = AnalyticsEngine.dayString(ts, off) == day
+                val viaBounds = (ts + off) >= start && (ts + off) < start + 86_400L
+                assertEquals("ts=$ts off=$off", viaFormatter, viaBounds)
+                ts += 97L
+            }
+        }
+    }
+
+    @Test fun exactMidnightEdgesAtFractionalOffset() {
+        // The two boundary seconds are where an off-by-one would hide: the local-midnight second is IN the
+        // day, the next local-midnight second is OUT. +5:30 so a whole-hour bug can't pass by luck.
+        val off = 5 * 3600L + 1800L
+        val day = "2021-06-15"
+        val start = AnalyticsEngine.dayStartUtcSeconds(day)   // 2021-06-15T00:00:00Z = 1623715200
+        assertEquals(1_623_715_200L, start)
+        val localMidnightUtcTs = start - off                  // wall-clock 00:00 +05:30 as a UTC instant
+        val probes = listOf(
+            localMidnightUtcTs to true,            // first second of the local day
+            localMidnightUtcTs - 1 to false,       // last second of the day before
+            localMidnightUtcTs + 86_399 to true,   // last second of the local day
+            localMidnightUtcTs + 86_400 to false,  // first second of the next
+        )
+        for ((probe, expected) in probes) {
+            assertEquals("probe=$probe", expected, AnalyticsEngine.dayString(probe, off) == day)
+            assertEquals("probe=$probe", expected, (probe + off) >= start && (probe + off) < start + 86_400L)
+        }
+    }
+
+    // --- dayStartUtcSeconds ----------------------------------------------------
+
+    @Test fun dayStartUtcSecondsIsUtcMidnight() {
+        assertEquals(0L, AnalyticsEngine.dayStartUtcSeconds("1970-01-01"))
+        // 1_700_000_000 is 2023-11-14T22:13:20Z, so that day's UTC midnight is 80_000 s earlier.
+        assertEquals(1_699_920_000L, AnalyticsEngine.dayStartUtcSeconds("2023-11-14"))
+        assertEquals(1_623_715_200L, AnalyticsEngine.dayStartUtcSeconds("2021-06-15"))
+    }
+
+    @Test fun dayStartUtcSecondsRoundTripsThroughDayString() {
+        for (day in listOf("1970-01-01", "2021-06-15", "2023-11-14", "2024-02-29", "2026-12-31")) {
+            assertEquals(day, AnalyticsEngine.dayString(AnalyticsEngine.dayStartUtcSeconds(day)))
+        }
+    }
+
+    @Test fun malformedDayFallsBackToEmptyEpochWindowNotATrap() {
+        // Nil-tolerant failure mode (#996 review): a malformed `day` degrades to 0 — an empty 1970 window no
+        // real sample matches — on BOTH platforms, never a crash. Unreachable in practice (`day` always comes
+        // from dayString), locked so the parity can't silently drift.
+        assertEquals(0L, AnalyticsEngine.dayStartUtcSeconds("not-a-day"))
+        assertEquals(0L, AnalyticsEngine.dayStartUtcSeconds(""))
+    }
+
+    // --- Byte-identity pin: same inputs → same DailyMetric numbers -------------
+
+    /** The optimization's whole contract: analyzeDay over FULL streams (which the tsInDay bounds check must
+     *  trim to the day) produces the IDENTICAL DailyMetric as analyzeDay over streams PRE-trimmed with the old
+     *  formatter compare. Runs at a fractional offset with spill samples planted on both sides of the local
+     *  day, so any membership divergence changes the step/kcal/Effort numbers and fails equals. */
+    @Test fun analyzeDayByteIdenticalToFormatterPrefilteredStreams() {
+        for (off in listOf(5 * 3600L + 1800L, -(9 * 3600L + 1800L))) {   // +5:30 and −9:30
+            val day = "2021-06-15"
+            val localMid = AnalyticsEngine.dayStartUtcSeconds(day) - off
+            // Full calendar-day HR every 10 s with ±2 h spill into the neighbour days; varying bpm so a
+            // wrongly-included/excluded sample shifts the calorie/Effort sums, not just the count.
+            val dayHr = (localMid - 7_200 until localMid + 86_400 + 7_200 step 10).map { ts ->
+                HrSample(deviceId = "t", ts = ts, bpm = (60 + (ts / 10) % 40).toInt())
+            }
+            // Cumulative @57 counter every minute (+7/min) with the same spill; the spill deltas must be
+            // excluded from the day total by BOTH filters identically.
+            var counter = 100
+            val daySteps = (localMid - 7_200 until localMid + 86_400 + 7_200 step 60).map { ts ->
+                counter += 7
+                StepSample(deviceId = "t", ts = ts, counter = counter and 0xFFFF)
+            }
+            val profile = UserProfile(weightKg = 75.0, heightCm = 178.0, age = 30.0, sex = "male")
+
+            val full = AnalyticsEngine.analyzeDay(day = day, dayHr = dayHr, daySteps = daySteps,
+                                                  profile = profile, tzOffsetSeconds = off)
+            // The OLD path, byte for byte: pre-trim each stream with the formatter compare.
+            val preHr = dayHr.filter { AnalyticsEngine.dayString(it.ts, off) == day }
+            val preSteps = daySteps.filter { AnalyticsEngine.dayString(it.ts, off) == day }
+            assertTrue("fixture must actually spill outside the day", preHr.size < dayHr.size)
+            val pre = AnalyticsEngine.analyzeDay(day = day, dayHr = preHr, daySteps = preSteps,
+                                                 profile = profile, tzOffsetSeconds = off)
+
+            assertEquals("off=$off", pre.daily, full.daily)
+            assertNotNull(full.daily.steps)          // the pin is vacuous if the day computed nothing
+            assertNotNull(full.daily.activeKcalEst)
+        }
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/PrimarySessionRestingHRTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/PrimarySessionRestingHRTest.kt
@@ -114,4 +114,19 @@ class PrimarySessionRestingHRTest {
         assertEquals(100, cov.validSamples)
         assertEquals(30_000.0, cov.durationSec, 1e-9)
     }
+
+    /** The combined wrapper windows the HR ONCE but must return byte-identical (mean, coverage) to calling the
+     *  two separate wrappers — the only caller (IntelligenceEngine) needs both, so this locks the dedup. */
+    @Test fun withCoverageMatchesSeparateCalls() {
+        val night = DetectedSleep(0L, 30_000L, 0.9, emptyList(), null, null)
+        val nap = DetectedSleep(40_000L, 45_000L, 0.9, emptyList(), null, null)
+        val hr = (0 until 100).map { HrSample("d", (it * 30).toLong(), 60) } +
+            (0 until 50).map { HrSample("d", (40_000 + it * 30).toLong(), 45) }
+        val sessions = listOf(nap, night)
+        val (mean, cov) = AnalyticsEngine.primarySessionRestingHRWithCoverage(sessions, hr)
+        assertEquals(AnalyticsEngine.primarySessionRestingHR(sessions, hr)!!, mean!!, 1e-9)
+        val sep = AnalyticsEngine.primarySessionRestingHRCoverage(sessions, hr)!!
+        assertEquals(sep.validSamples, cov!!.validSamples)
+        assertEquals(sep.durationSec, cov.durationSec, 1e-9)
+    }
 }


### PR DESCRIPTION
Three allocation/CPU micro-optimizations, each replicating a pattern already shipped elsewhere in the same codebase, each behavior-preserving and covered by a byte-identical Swift↔Kotlin parity test. No protocol, schema, or UI change.

### 1. Android live-HR — guard the per-frame `LiveState` copy (memory)
`LiveState` is a `data class`, so `MutableStateFlow` de-dupes an equal value; but the live-HR ingest paths rewrote a full `LiveState` via `it.copy(heartRate = …)` on **every** frame (~1 Hz) regardless, allocating a throwaway object `StateFlow` then drops. Added a change-guard on **all three** per-frame `LiveState.heartRate` write sites — **observably identical** (the equal copy wouldn't have emitted), matching the existing Swift `FrameRouter` guard:
- `WhoopBleClient` REALTIME_DATA path and standard-0x2A37 path (`_state.value.heartRate != hr`; the 5/MG bonded transition stays unconditional);
- `publishExternalLiveHr` — the Oura/FTMS/generic-HR source seam (#56) — guarded on heartRate + both flags (`connected`/`streamingLiveHR`) so those transitions still fire.

### 2. Kotlin `analyzeDay` day-bucketing — mirror the Swift #996 integer-bounds check (CPU)
The Kotlin day filters decided sample membership with a **per-sample `dayString(ts, offset) == day` `DateFormatter`** — ~170k formatter invocations per scored day, ×maxDays, every pass, over the full-day HR/steps streams. Swift already precomputes the day's UTC bounds once and does an integer compare (`dayStartUtcSeconds` + `tsInDay`); that #996 optimization was **never ported to Kotlin** (the Swift source even documented a Kotlin mirror that didn't exist). This adds the Kotlin `dayStartUtcSeconds` + `tsInDay` and swaps the three filters.

New `AnalyticsEngineDayBoundsTest` is the Kotlin twin of the existing `AnalyticsEngineDayBoundsTests` (which already named it): sweeps both midnight edges at whole-hour **and** fractional offsets (+5:30/+5:45/−9:30/−3:30), pins `dayStartUtcSeconds`, and asserts `analyzeDay` over full streams is **byte-for-byte identical** to `analyzeDay` over formatter-prefiltered streams.

### 3. #1169 shadow metric — window the sessions once (CPU, both platforms)
`primarySessionRestingHR` and `primarySessionRestingHRCoverage` each independently rebuilt the same `O(sessions × hr)` per-session windowed sample list. Added a shared `primarySessions()` builder and a combined `primarySessionRestingHRWithCoverage()`; the only caller (`IntelligenceEngine`) now windows **once** instead of twice. Byte-identical to the two separate calls, locked by a new parity test on both platforms. (Tidies duplication introduced in #1211.)

## Verification
- **Kotlin:** module compiles; ran the **entire `com.noop.analytics` suite — 144 classes / 1319 tests, 0 failures** (every engine downstream of `analyzeDay`), plus the new `AnalyticsEngineDayBoundsTest` and the #1169 combined-parity test.
- **Swift:** analytics twin validated by `swift-packages.yml` (GRDB/CSQLite blocks a local Linux build of `StrandAnalytics`). `Strand/Data/IntelligenceEngine.swift` is app-target Swift (no default CI) — a mechanical tuple destructure of the new function.
- **BLE:** all three live-HR guards are allocation-only and `StateFlow`-equivalent (`LiveState` has value `equals`, no counter/timestamp field); no on-strap behavior change.

Parity contract: analytics numbers stay byte-identical across Swift and Kotlin (all three are pure refactors of the membership predicate / windowing, not the formulas).
