### PR TITLE
Give the Oura central an iOS state-restoration identifier (#1213)

### DIFF
--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -90,6 +90,10 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     private static let writeChar = CBUUID(string: OuraGatt.writeCharacteristicUUID)
     private static let notifyChar = CBUUID(string: OuraGatt.notifyCharacteristicUUID)
 
+    /// iOS state-restoration identifier for the PERSISTENT Oura central (#1213). DISTINCT from the WHOOP
+    /// central's `BLEManager.restoreID` — each restoring `CBCentralManager` needs its own unique id.
+    private static let restoreID = "com.openwhoop.ble.oura"
+
     /// The `0x25` SetAuthKey-response outer opcode (`25 01 <status>`, status `0x00` = OK). Per
     /// OURA_PROTOCOL.md s3.2. This is the install-ack the adopt key-install awaits.
     private static let setAuthKeyRespOp: UInt8 = 0x25
@@ -785,7 +789,23 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         self.rawDump = feedsLive && !deviceId.isEmpty ? OuraRawDump(deviceId: deviceId, log: log) : nil
         super.init()
         // Dedicated queue-less central -> callbacks arrive on the main queue, matching @MainActor.
+        #if os(iOS)
+        // iOS state restoration (#1213): only the PERSISTENT live source (feedsLive, real deviceId) carries a
+        // restore identifier, so CoreBluetooth relaunches the app into the background and delivers
+        // willRestoreState after a suspend-then-jettison — without it an overnight Oura session dies with the
+        // process and nothing reconnects until the user re-opens the app. The discovery-only wizard scanner
+        // (feedsLive == false, deviceId "scan-preview") must NOT restore, and two centrals may never share one
+        // restore identifier, so it is deliberately excluded. Mirrors the WHOOP central in BLEManager.
+        if feedsLive && !deviceId.isEmpty {
+            self.central = CBCentralManager(delegate: self, queue: nil,
+                                            options: [CBCentralManagerOptionRestoreIdentifierKey: Self.restoreID])
+        } else {
+            self.central = CBCentralManager(delegate: self, queue: nil)
+        }
+        #else
+        // Strand (macOS desktop): no state-restoration identifier (iOS background feature).
         self.central = CBCentralManager(delegate: self, queue: nil)
+        #endif
     }
 
     // MARK: - Scanning
@@ -1570,6 +1590,37 @@ public final class OuraLiveSource: NSObject, ObservableObject {
 // MARK: - CBCentralManagerDelegate
 
 extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
+    /// iOS relaunched us into the background after a suspend-then-jettison and handed back the Oura central's
+    /// peripheral (#1213). Re-adopt it so an overnight session resumes without the user opening the app. Only
+    /// the persistent live source carries the restore identifier, so only it is ever restored here. Mirrors
+    /// `BLEManager.willRestoreState`; never called on macOS (no restore identifier is set there).
+    public func centralManager(_ central: CBCentralManager, willRestoreState dict: [String: Any]) {
+        guard let peripherals = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral],
+              let p = peripherals.first else {
+            log("Oura restore: no peripherals in restore state")
+            return
+        }
+        let id = p.identifier
+        seenPeripherals[id] = p
+        peripheral = p
+        p.delegate = self
+        reconnectID = id                 // an involuntary drop re-targets this ring (#912)
+        intentionalDisconnect = false
+        if p.state == .connected {
+            // The link survived; CoreBluetooth does NOT re-fire didConnect for an already-connected restored
+            // peripheral, so re-run the session bring-up (fresh driver + service discovery) directly.
+            log("Oura restore: peripheral \(id) still connected — resuming session")
+            centralManager(central, didConnect: p)
+        } else if central.state == .poweredOn {
+            log("Oura restore: peripheral \(id) disconnected — reconnecting")
+            central.connect(p, options: nil)
+        } else {
+            // Radio not ready yet; centralManagerDidUpdateState replays pendingConnectID on poweredOn.
+            pendingConnectID = id
+            log("Oura restore: peripheral \(id) disconnected, central not poweredOn — deferring to poweredOn")
+        }
+    }
+
     public func centralManagerDidUpdateState(_ central: CBCentralManager) {
         switch central.state {
         case .poweredOn:


### PR DESCRIPTION
Fixes #1213. Diagnosis and field evidence by @pipiche38 — confirmed against source.

## Problem
`OuraLiveSource` created its `CBCentralManager` with **no restore identifier** (`CBCentralManager(delegate: self, queue: nil)`) and implemented **no `willRestoreState`**. `UIBackgroundModes: bluetooth-central` keeps an *already-open* connection alive under suspension but does **not** relaunch the app after iOS terminates it — only a restore identifier + `willRestoreState` does. So the moment iOS jettisons the suspended app overnight, the Oura ring is dropped and nothing reconnects until the user opens the app by hand, losing every `0x80` IBI burst after the process dies. The WHOOP central (`BLEManager`) already has this; the Oura central didn't.

This is a **client-side confounder** for the open "ring goes BLE-silent overnight" hypothesis — until the restore path exists, every overnight-silence night is confounded.

## Fix (minimal, iOS-only, one file)
1. **Restore identifier** — pass `CBCentralManagerOptionRestoreIdentifierKey` (a distinct id, `com.openwhoop.ble.oura`), `#if os(iOS)`, **gated on `feedsLive && !deviceId.isEmpty`** so only the persistent `SourceCoordinator` live source restores. The discovery-only `AddDeviceWizard` scanner (`feedsLive == false`, `deviceId: "scan-preview"`) is excluded — two centrals may never share one restore identifier.
2. **`willRestoreState`** — re-adopt the restored peripheral: an already-connected link re-runs the `didConnect` bring-up (CoreBluetooth won't re-fire `didConnect` for it); a dropped one reconnects now, or defers to `poweredOn` via the existing `pendingConnectID` path. Mirrors `BLEManager.willRestoreState` and reuses `OuraLiveSource`'s existing connect machinery (`seenPeripherals`/`retrievePeripherals`).

Construction timing (the reporter's precondition) is already met for the common case: `SourceCoordinator.start()` subscribes to `registry.$activeDeviceId`, which emits immediately, so if the Oura ring is the active device the source (and its central) is rebuilt during launch — inside CoreBluetooth's restore window is what the strap test confirms.

## Parity
iOS-only mechanism — there is **no `CBCentralManager` state restoration on Android**, and none is needed: Android's overnight survival is the `WhoopConnectionService` **foreground service** keeping the process (and the `OuraLiveSource.kt` #912 auto-reconnect loop) alive, so it's never jettisoned-then-relaunched-on-a-BLE-event the way iOS is. Feature-level parity (BLE lifecycle), not the byte-identical analytics contract. *Separate, out-of-scope question worth its own look:* whether that foreground service actually holds the **Oura** GATT link overnight or only the WHOOP client.

## Verification / caveats
- **App-target Swift** (`Strand/BLE/`) — `app-build.yml` is disabled, so no default CI compiles this; I can't build it on Linux (no Xcode). Mirrors `BLEManager` line-for-line to minimize risk.
- **EXPERIMENTAL Oura**, and this **is** the connection path — **needs real-strap validation across ≥2 nights before it is believed**. Please **do not auto-merge on green**; it wants hardware sign-off (a held overnight connection + `willRestoreState` firing after a jettison).
