### PR TITLE
fix(whoop): drop calibrated SpO2 from live WHOOP capabilities (#548)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -798,6 +798,30 @@ extension WhoopStore {
             // otherwise lean on SQLite's affinity coercion rather than being explicit.
             try db.execute(sql: "UPDATE rrInterval SET tsSuspect = 1 WHERE ts > CAST(strftime('%s','now') AS INTEGER)")
         }
+        // v36 (#548): drop calibrated SpO₂ from WHOOP registry capabilities. Live NOOP never fills
+        // spo2Pct from the strap (import-only / experimental @82 candidate); advertising `spo2` made
+        // an empty Blood Oxygen tile look broken. Data-only UPDATE — no schema change. Twin of Room
+        // MIGRATION_29_30. Decode-time strip in DeviceRegistryStore is the belt; this is the suspenders.
+        migrator.registerMigration("v36-whoop-caps-no-spo2") { db in
+            let rows = try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT id, capabilities FROM pairedDevice
+                    WHERE brand = 'WHOOP' OR id = 'my-whoop' OR id LIKE 'whoop-%'
+                    """
+            )
+            for row in rows {
+                let id: String = row["id"]
+                let encoded: String = row["capabilities"]
+                let stripped = WhoopLiveCapabilities.stripSpo2Token(fromEncoded: encoded)
+                if stripped != encoded && !stripped.isEmpty {
+                    try db.execute(
+                        sql: "UPDATE pairedDevice SET capabilities = ? WHERE id = ?",
+                        arguments: [stripped, id]
+                    )
+                }
+            }
+        }
         return migrator
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
@@ -226,11 +226,20 @@ public struct DeviceRegistryStore: Sendable {
     }
 
     private static func decode(_ row: Row) -> PairedDevice {
-        let caps = (row["capabilities"] as String).split(separator: ",").compactMap { Metric(rawValue: String($0)) }
-        return PairedDevice(id: row["id"], brand: row["brand"], model: row["model"], nickname: row["nickname"],
+        var caps = Set((row["capabilities"] as String).split(separator: ",").compactMap { Metric(rawValue: String($0)) })
+        // #548: calibrated SpO₂ % is never produced from a live WHOOP path — drop a stale registry bit
+        // so Devices / day-owner UI never advertise a capability AnalyticsEngine will not fill.
+        let brand = row["brand"] as String
+        let id = row["id"] as String
+        if brand.caseInsensitiveCompare("WHOOP") == .orderedSame
+            || id == "my-whoop"
+            || id.hasPrefix("whoop-") {
+            caps = WhoopLiveCapabilities.withoutCalibratedSpo2(caps)
+        }
+        return PairedDevice(id: id, brand: brand, model: row["model"], nickname: row["nickname"],
                             peripheralId: row["peripheralId"],
                             sourceKind: SourceKind(rawValue: row["sourceKind"]) ?? .liveBLE,
-                            capabilities: Set(caps), status: DeviceStatus(rawValue: row["status"]) ?? .paired,
+                            capabilities: caps, status: DeviceStatus(rawValue: row["status"]) ?? .paired,
                             addedAt: row["addedAt"], lastSeenAt: row["lastSeenAt"])
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/WhoopLiveCapabilities.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/WhoopLiveCapabilities.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Honest live-BLE capability set for a WHOOP strap that NOOP can actually drive **without** a CSV /
+/// Health import.
+///
+/// Calibrated SpO₂ **%** is deliberately **excluded**: AnalyticsEngine nulls `spo2Pct` for every WHOOP
+/// live path (see `Spo2ReTrace` — fabricating a % from raw ADC needs WHOOP's proprietary curve). The
+/// registry used to advertise `spo2` on every paired WHOOP, which made an empty Blood Oxygen tile look
+/// like a bug rather than import-only design (#548).
+///
+/// Steps are 5.0 / MG only over BLE (4.0 has no on-device step counter NOOP can read). Skin temp /
+/// sleep / strain remain listed because NOOP does decode and score them on-device (skin temp as a
+/// nightly ±°C deviation after baseline calibration; firmware layout dependent).
+///
+/// Twin of `com.noop.data.WhoopLiveCapabilities`. Pure — covered by `swift test`.
+public enum WhoopLiveCapabilities {
+
+    /// Core metrics every WHOOP generation can feed in NOOP over BLE (no calibrated SpO₂ %).
+    public static let base: Set<Metric> = [.hr, .hrv, .skinTemp, .sleep, .strainLoad]
+
+    /// True when the model label names a 5.0 or MG (wizard labels: "4.0", "5.0 MG", "WHOOP 5.0", …).
+    public static func isFiveOrMG(model: String) -> Bool {
+        let m = model.lowercased()
+        return m.contains("5") || m.contains("mg")
+    }
+
+    /// Capability set for a freshly paired WHOOP with the given model label.
+    public static func metrics(forModel model: String) -> Set<Metric> {
+        var caps = base
+        if isFiveOrMG(model: model) { caps.insert(.steps) }
+        return caps
+    }
+
+    /// Comma-joined, sorted encoding used in `pairedDevice.capabilities` (matches DeviceRegistryStore).
+    public static func encoded(forModel model: String) -> String {
+        metrics(forModel: model).map(\.rawValue).sorted().joined(separator: ",")
+    }
+
+    /// Drop calibrated SpO₂ from a stored set — used when reading old registry rows that still list it.
+    public static func withoutCalibratedSpo2(_ caps: Set<Metric>) -> Set<Metric> {
+        caps.subtracting([.spo2])
+    }
+
+    /// SQL-safe rewrite of a comma-joined capabilities string: remove bare `spo2` tokens only.
+    /// Does not touch other metrics. Empty result is preserved as empty (caller should not write that).
+    public static func stripSpo2Token(fromEncoded encoded: String) -> String {
+        encoded
+            .split(separator: ",", omittingEmptySubsequences: true)
+            .map(String.init)
+            .filter { $0 != Metric.spo2.rawValue }
+            .joined(separator: ",")
+    }
+}

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/WhoopLiveCapabilitiesTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/WhoopLiveCapabilitiesTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import WhoopStore
+
+final class WhoopLiveCapabilitiesTests: XCTestCase {
+
+    func testBaseExcludesCalibratedSpo2() {
+        XCTAssertFalse(WhoopLiveCapabilities.base.contains(.spo2))
+        XCTAssertEqual(
+            WhoopLiveCapabilities.base,
+            [.hr, .hrv, .skinTemp, .sleep, .strainLoad]
+        )
+    }
+
+    func testFourPointOhHasNoSteps() {
+        let caps = WhoopLiveCapabilities.metrics(forModel: "4.0")
+        XCTAssertFalse(caps.contains(.steps))
+        XCTAssertFalse(caps.contains(.spo2))
+        XCTAssertTrue(caps.contains(.hr))
+    }
+
+    func testFiveAndMGIncludeSteps() {
+        for model in ["5.0 MG", "WHOOP 5.0", "MG", "whoop5"] {
+            let caps = WhoopLiveCapabilities.metrics(forModel: model)
+            XCTAssertTrue(caps.contains(.steps), model)
+            XCTAssertFalse(caps.contains(.spo2), model)
+        }
+    }
+
+    func testEncodedIsSortedAndStable() {
+        XCTAssertEqual(
+            WhoopLiveCapabilities.encoded(forModel: "4.0"),
+            "hr,hrv,skinTemp,sleep,strainLoad"
+        )
+        XCTAssertEqual(
+            WhoopLiveCapabilities.encoded(forModel: "5.0 MG"),
+            "hr,hrv,skinTemp,sleep,steps,strainLoad"
+        )
+    }
+
+    func testStripSpo2TokenHandlesPositions() {
+        XCTAssertEqual(
+            WhoopLiveCapabilities.stripSpo2Token(fromEncoded: "hr,hrv,spo2,skinTemp,sleep,strainLoad"),
+            "hr,hrv,skinTemp,sleep,strainLoad"
+        )
+        XCTAssertEqual(
+            WhoopLiveCapabilities.stripSpo2Token(fromEncoded: "spo2,hr"),
+            "hr"
+        )
+        XCTAssertEqual(
+            WhoopLiveCapabilities.stripSpo2Token(fromEncoded: "hr,spo2"),
+            "hr"
+        )
+        XCTAssertEqual(
+            WhoopLiveCapabilities.stripSpo2Token(fromEncoded: "hr,hrv,skinTemp"),
+            "hr,hrv,skinTemp"
+        )
+    }
+
+    func testWithoutCalibratedSpo2() {
+        let raw: Set<Metric> = [.hr, .hrv, .spo2, .skinTemp]
+        XCTAssertEqual(
+            WhoopLiveCapabilities.withoutCalibratedSpo2(raw),
+            [.hr, .hrv, .skinTemp]
+        )
+    }
+}

--- a/Strand/Screens/AddDeviceWizard.swift
+++ b/Strand/Screens/AddDeviceWizard.swift
@@ -1251,7 +1251,8 @@ struct AddDeviceWizard: View {
         let device: PairedDevice
 
         if let pickedWhoop, let type, let wm = type.whoopModel {
-            // WHOOP: full capability set; id namespaced by uuid; model "4.0" / "5.0 MG".
+            // WHOOP: honest live capability set (no calibrated SpO₂ % — import-only; #548);
+            // id namespaced by uuid; model "4.0" / "5.0 MG". Steps only on 5.0/MG.
             let modelLabel = (wm == .whoop4) ? "4.0" : "5.0 MG"
             device = PairedDevice(
                 id: "whoop-\(pickedWhoop.uuid)",
@@ -1260,7 +1261,7 @@ struct AddDeviceWizard: View {
                 nickname: name,
                 peripheralId: pickedWhoop.uuid,
                 sourceKind: .liveBLE,
-                capabilities: [.hr, .hrv, .spo2, .skinTemp, .sleep, .strainLoad],
+                capabilities: WhoopLiveCapabilities.metrics(forModel: modelLabel),
                 status: .paired,
                 addedAt: now, lastSeenAt: now)
         } else if let pickedStrap {

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -1562,7 +1562,7 @@ struct DeviceCardCatalog: View {
     static func oura(_ model: String, status: DeviceStatus = .paired) -> PairedDevice {
         PairedDevice(id: "oura-demo-\(model)", brand: "Oura", model: model, nickname: nil,
                      peripheralId: "00000000-0000-0000-0000-0000000000aa", sourceKind: .oura,
-                     capabilities: [.hr, .hrv, .spo2, .skinTemp, .sleep],
+                     capabilities: WhoopLiveCapabilities.metrics(forModel: "4.0"),
                      status: status, addedAt: 0, lastSeenAt: 0)
     }
 
@@ -1638,7 +1638,7 @@ struct BondRefusedDemoScreen: View {
                        topBackground: liquidScaffoldSky()) {
             DeviceCard(device: PairedDevice(id: "whoop-5-refused-solo", brand: "WHOOP", model: "5.0 MG",
                                             nickname: nil, peripheralId: nil, sourceKind: .liveBLE,
-                                            capabilities: [.hr, .hrv, .spo2, .skinTemp, .sleep, .strainLoad, .steps],
+                                            capabilities: WhoopLiveCapabilities.metrics(forModel: "5.0 MG"),
                                             status: .active, addedAt: 0, lastSeenAt: 0),
                        isActive: true, isLiveConnected: true, bondRefused: true,
                        pairingHint: "NOOP can see your strap but it's refusing to pair - it's likely still bonded to the official WHOOP app, or your phone is holding an old pairing. To fix it: (1) fully close the WHOOP app, (2) on a 5.0/MG, tap the band repeatedly until the LEDs flash blue (pairing mode), (3) if your strap is listed under iPhone Settings → Bluetooth, tap it and choose Forget This Device, then reconnect in NOOP.",

--- a/Strand/Screens/VitalSignsSummary.swift
+++ b/Strand/Screens/VitalSignsSummary.swift
@@ -338,7 +338,9 @@ enum BodyVitalSigns {
                 metricColor: StrandPalette.metricAmber,
                 day: skinRow?.day,
                 source: skinRow?.source,
-                missingCaption: String(localized: "No nightly skin-temp value"),
+                // #548: empty is often calibrating (needs ~4 nights for ±deviation) or import-less —
+                // not a silent "broken sensor". Absolute °C still arrives via WHOOP CSV import.
+                missingCaption: String(localized: "No nightly skin-temp yet — needs ~4 worn nights (or import a WHOOP CSV)"),
                 // Keep the trail on the displayed value's kind — absolute °C and ±deviation must not
                 // mix on one sparkline (matches the banding partition above).
                 sparkline: trail(skinPoints.filter { VitalBands.isAbsoluteSkinTemp($0.value) == skinIsAbsolute })

--- a/android/app/src/main/java/com/noop/data/DeviceRegistry.kt
+++ b/android/app/src/main/java/com/noop/data/DeviceRegistry.kt
@@ -33,7 +33,22 @@ class DeviceRegistry(
     )
 
     /** All paired devices, oldest first. */
-    suspend fun all(): List<PairedDeviceRow> = dao.pairedDevices()
+    suspend fun all(): List<PairedDeviceRow> =
+        dao.pairedDevices().map { honestWhoopCapabilities(it) }
+
+    /**
+     * #548: calibrated SpO₂ % is never produced from a live WHOOP path — drop a stale registry bit so
+     * Devices / day-owner UI never advertise a capability AnalyticsEngine will not fill. Twin of the
+     * Swift `DeviceRegistryStore.decode` strip.
+     */
+    private fun honestWhoopCapabilities(row: PairedDeviceRow): PairedDeviceRow {
+        val isWhoop = row.brand.equals("WHOOP", ignoreCase = true)
+            || row.id == "my-whoop"
+            || row.id.startsWith("whoop-")
+        if (!isWhoop) return row
+        val stripped = WhoopLiveCapabilities.stripSpo2Token(row.capabilities)
+        return if (stripped == row.capabilities) row else row.copy(capabilities = stripped)
+    }
 
     /** The single active device id, or null if none. */
     suspend fun activeDeviceId(): String? = dao.activeDeviceId()

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -52,7 +52,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         RawImuSampleEntity::class,
         V18AuxSampleEntity::class,
     ],
-    version = 29,
+    version = 30,
     // #775: ON so Room's KSP processor writes the generated schema (every table's exact `CREATE TABLE`,
     // columns in declaration order with affinity/NOT NULL/default, PK and indices) as JSON. That export
     // is what lets a plain JVM test — no device, no Robolectric — read Android's REAL schema and compare
@@ -813,6 +813,35 @@ abstract class WhoopDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * #548: drop calibrated SpO₂ from WHOOP registry capabilities (import-only metric).
+         * Data-only UPDATE — no schema change. Twin of Swift WhoopStore `v36-whoop-caps-no-spo2`.
+         * Token strip matches [WhoopLiveCapabilities.stripSpo2Token].
+         */
+        internal val MIGRATION_29_30 = object : Migration(29, 30) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                val cursor = db.query(
+                    "SELECT `id`, `capabilities` FROM `pairedDevice` " +
+                        "WHERE `brand` = 'WHOOP' OR `id` = 'my-whoop' OR `id` LIKE 'whoop-%'",
+                )
+                cursor.use { c ->
+                    val idIdx = c.getColumnIndex("id")
+                    val capsIdx = c.getColumnIndex("capabilities")
+                    while (c.moveToNext()) {
+                        val id = c.getString(idIdx)
+                        val encoded = c.getString(capsIdx) ?: continue
+                        val stripped = WhoopLiveCapabilities.stripSpo2Token(encoded)
+                        if (stripped != encoded && stripped.isNotEmpty()) {
+                            db.execSQL(
+                                "UPDATE `pairedDevice` SET `capabilities` = ? WHERE `id` = ?",
+                                arrayOf(stripped, id),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
         private fun build(appContext: Context): WhoopDatabase =
             Room.databaseBuilder(appContext, WhoopDatabase::class.java, DB_NAME)
                 // #1014: replace ONLY the corruption handling of the default open-helper. The
@@ -830,13 +859,14 @@ abstract class WhoopDatabase : RoomDatabase() {
                     MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18,
                     MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
                     MIGRATION_22_23, MIGRATION_23_24, MIGRATION_24_25, MIGRATION_25_26,
-                    MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29,
+                    MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30,
                 )
                 // #1037: a FRESH install builds the schema straight at the current version and runs NO
                 // migrations, so the MIGRATION_7_8 "my-whoop" registry seed never fires and the WHOOP,
                 // though paired and streaming fine, never appears in the Devices list. Seed the canonical
                 // row on create too (same idempotent INSERT OR IGNORE as the migration) so a first-ever
                 // install still lists its WHOOP. iOS/GRDB re-runs migrations on a fresh DB, so it never hit this.
+                // #548: no calibrated SpO₂ in the seed (import-only).
                 .addCallback(object : RoomDatabase.Callback() {
                     override fun onCreate(db: SupportSQLiteDatabase) {
                         val now = System.currentTimeMillis() / 1000
@@ -845,7 +875,7 @@ abstract class WhoopDatabase : RoomDatabase() {
                                 "(`id`, `brand`, `model`, `nickname`, `sourceKind`, `capabilities`, " +
                                 "`status`, `addedAt`, `lastSeenAt`) VALUES " +
                                 "('my-whoop', 'WHOOP', 'WHOOP', NULL, 'liveBLE', " +
-                                "'hr,hrv,spo2,skinTemp,sleep,strainLoad', 'active', $now, $now)",
+                                "'${WhoopLiveCapabilities.encoded("WHOOP")}', 'active', $now, $now)",
                         )
                     }
                 })

--- a/android/app/src/main/java/com/noop/data/WhoopLiveCapabilities.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopLiveCapabilities.kt
@@ -1,0 +1,47 @@
+package com.noop.data
+
+/**
+ * Honest live-BLE capability set for a WHOOP strap that NOOP can actually drive **without** a CSV /
+ * Health Connect import.
+ *
+ * Calibrated SpO₂ **%** is deliberately **excluded**: AnalyticsEngine nulls `spo2Pct` for every WHOOP
+ * live path (see [com.noop.analytics.Spo2ReTrace] — fabricating a % from raw ADC needs WHOOP's
+ * proprietary curve). The registry used to advertise `spo2` on every paired WHOOP, which made an empty
+ * Blood Oxygen tile look like a bug rather than import-only design (#548).
+ *
+ * Steps are 5.0 / MG only over BLE. Twin of Swift `WhoopLiveCapabilities`. Pure — unit-tested.
+ */
+object WhoopLiveCapabilities {
+
+    /** Core metrics every WHOOP generation can feed in NOOP over BLE (no calibrated SpO₂ %). */
+    val base: Set<Metric> = setOf(
+        Metric.hr, Metric.hrv, Metric.skinTemp, Metric.sleep, Metric.strainLoad,
+    )
+
+    /** True when the model label names a 5.0 or MG (wizard labels: "4.0", "5.0 MG", …). */
+    fun isFiveOrMG(model: String): Boolean {
+        val m = model.lowercase()
+        return m.contains("5") || m.contains("mg")
+    }
+
+    /** Capability set for a freshly paired WHOOP with the given model label. */
+    fun metrics(forModel: String): Set<Metric> {
+        val caps = base.toMutableSet()
+        if (isFiveOrMG(forModel)) caps.add(Metric.steps)
+        return caps
+    }
+
+    /** Comma-joined, sorted encoding used in `pairedDevice.capabilities`. */
+    fun encoded(forModel: String): String =
+        metrics(forModel).map { it.name }.sorted().joinToString(",")
+
+    /** Drop calibrated SpO₂ from a stored set — when reading old registry rows that still list it. */
+    fun withoutCalibratedSpo2(caps: Set<Metric>): Set<Metric> = caps - Metric.spo2
+
+    /** Remove bare `spo2` tokens from a comma-joined capabilities string. */
+    fun stripSpo2Token(fromEncoded: String): String =
+        fromEncoded.split(',')
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && it != Metric.spo2.name }
+            .joinToString(",")
+}

--- a/android/app/src/main/java/com/noop/ui/AddDeviceWizard.kt
+++ b/android/app/src/main/java/com/noop/ui/AddDeviceWizard.kt
@@ -65,6 +65,7 @@ import com.noop.ble.WhoopModel
 import com.noop.data.DeviceStatus
 import com.noop.data.PairedDeviceRow
 import com.noop.data.SourceKind
+import com.noop.data.WhoopLiveCapabilities
 import com.noop.oura.OuraRingGen
 import kotlinx.coroutines.launch
 
@@ -279,7 +280,8 @@ fun AddDeviceWizard(
         val isGarmin = type == DeviceType.Garmin
         val device: PairedDeviceRow? = when {
             pw != null && type?.whoopModel != null -> {
-                // WHOOP: full capability set; id namespaced by address; model "4.0" / "5.0 MG".
+                // WHOOP: honest live capability set (no calibrated SpO₂ % — import-only; #548);
+                // id namespaced by address; model "4.0" / "5.0 MG". Steps only on 5.0/MG.
                 val wm = type!!.whoopModel!!
                 val modelLabel = if (wm == WhoopModel.WHOOP4) "4.0" else "5.0 MG"
                 PairedDeviceRow(
@@ -289,7 +291,7 @@ fun AddDeviceWizard(
                     nickname = confirmName,
                     peripheralId = pw.address,
                     sourceKind = SourceKind.liveBLE.name,
-                    capabilities = "hr,hrv,spo2,skinTemp,sleep,strainLoad",
+                    capabilities = WhoopLiveCapabilities.encoded(modelLabel),
                     status = DeviceStatus.paired.name,
                     addedAt = now,
                     lastSeenAt = now,

--- a/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
@@ -282,7 +282,9 @@ internal fun vitalsFor(
         ),
         Vital(
             key = "skin", label = uiString(R.string.l10n_health_screen_skin_temp_a4affc5a), unit = skinUnitLabel,
-            missingCaption = "No nightly skin-temp value",
+            // #548: empty is often calibrating (~4 nights for ±deviation) or import-less — not a silent
+            // "broken sensor". Absolute °C still arrives via WHOOP CSV / Health Connect import.
+            missingCaption = "No nightly skin-temp yet — needs ~4 worn nights (or import a WHOOP CSV)",
             value = skin, format = skinFormat,
             deltaText = deltaText(skin, previousSkin),
             readingDay = todayKey,

--- a/android/app/src/test/java/com/noop/data/DeviceRegistryTest.kt
+++ b/android/app/src/test/java/com/noop/data/DeviceRegistryTest.kt
@@ -2,6 +2,7 @@ package com.noop.data
 
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -178,6 +179,16 @@ class DeviceRegistryTest {
         assertEquals(1, all.size)
         assertEquals("my-whoop", all.first().id)
         assertEquals("my-whoop", reg.activeDeviceId())
+    }
+
+    /** #548: stale registry bits listing calibrated SpO₂ must not surface for a live WHOOP. */
+    @Test
+    fun allStripsSpo2FromWhoopCapabilities() = runBlocking {
+        val reg = registryWith(seededDao())
+        val caps = reg.all().first().capabilities
+        assertFalse(caps.split(',').contains("spo2"))
+        assertTrue(caps.contains("hr"))
+        assertTrue(caps.contains("skinTemp"))
     }
 
     @Test

--- a/android/app/src/test/java/com/noop/data/WhoopLiveCapabilitiesTest.kt
+++ b/android/app/src/test/java/com/noop/data/WhoopLiveCapabilitiesTest.kt
@@ -1,0 +1,71 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Byte-parity twin of Swift `WhoopLiveCapabilitiesTests` (#548). */
+class WhoopLiveCapabilitiesTest {
+
+    @Test
+    fun baseExcludesCalibratedSpo2() {
+        assertFalse(WhoopLiveCapabilities.base.contains(Metric.spo2))
+        assertEquals(
+            setOf(Metric.hr, Metric.hrv, Metric.skinTemp, Metric.sleep, Metric.strainLoad),
+            WhoopLiveCapabilities.base,
+        )
+    }
+
+    @Test
+    fun fourPointOhHasNoSteps() {
+        val caps = WhoopLiveCapabilities.metrics("4.0")
+        assertFalse(caps.contains(Metric.steps))
+        assertFalse(caps.contains(Metric.spo2))
+        assertTrue(caps.contains(Metric.hr))
+    }
+
+    @Test
+    fun fiveAndMGIncludeSteps() {
+        for (model in listOf("5.0 MG", "WHOOP 5.0", "MG", "whoop5")) {
+            val caps = WhoopLiveCapabilities.metrics(model)
+            assertTrue(model, caps.contains(Metric.steps))
+            assertFalse(model, caps.contains(Metric.spo2))
+        }
+    }
+
+    @Test
+    fun encodedIsSortedAndStable() {
+        assertEquals(
+            "hr,hrv,skinTemp,sleep,strainLoad",
+            WhoopLiveCapabilities.encoded("4.0"),
+        )
+        assertEquals(
+            "hr,hrv,skinTemp,sleep,steps,strainLoad",
+            WhoopLiveCapabilities.encoded("5.0 MG"),
+        )
+    }
+
+    @Test
+    fun stripSpo2TokenHandlesPositions() {
+        assertEquals(
+            "hr,hrv,skinTemp,sleep,strainLoad",
+            WhoopLiveCapabilities.stripSpo2Token("hr,hrv,spo2,skinTemp,sleep,strainLoad"),
+        )
+        assertEquals("hr", WhoopLiveCapabilities.stripSpo2Token("spo2,hr"))
+        assertEquals("hr", WhoopLiveCapabilities.stripSpo2Token("hr,spo2"))
+        assertEquals(
+            "hr,hrv,skinTemp",
+            WhoopLiveCapabilities.stripSpo2Token("hr,hrv,skinTemp"),
+        )
+    }
+
+    @Test
+    fun withoutCalibratedSpo2() {
+        val raw = setOf(Metric.hr, Metric.hrv, Metric.spo2, Metric.skinTemp)
+        assertEquals(
+            setOf(Metric.hr, Metric.hrv, Metric.skinTemp),
+            WhoopLiveCapabilities.withoutCalibratedSpo2(raw),
+        )
+    }
+}


### PR DESCRIPTION
## What this PR does

Fixes the core of [#548](https://github.com/ryanbr/noop/issues/548) / [#761](https://github.com/ryanbr/noop/issues/761): **stop advertising calibrated SpO₂ as a live WHOOP capability**.

NOOP never fills `spo2Pct` from a bonded strap (`AnalyticsEngine` nulls it; see `Spo2ReTrace` — fabricating a % needs WHOOP's proprietary curve). The registry still listed `spo2` for every paired WHOOP (`hr,hrv,spo2,skinTemp,…`), so an empty Blood Oxygen tile looked like a bug rather than import-only design.

### Changes

**`WhoopLiveCapabilities` (Swift + Kotlin twin)**  
- Base live set: `hr, hrv, skinTemp, sleep, strainLoad` — **no `spo2`**
- Steps only for 5.0 / MG model labels
- `stripSpo2Token` / `withoutCalibratedSpo2` helpers
- Unit tests on both platforms

**Write paths**  
- Add-a-device wizard uses the honest set (Swift + Android)
- Devices DEBUG previews updated

**Existing installs**  
- GRDB `v36-whoop-caps-no-spo2` + Room `MIGRATION_29_30` strip `spo2` from WHOOP rows
- Decode-time strip on registry read (belt-and-suspenders)

**Empty captions**  
- Skin temp: explains ~4-night calibration / CSV import (Health on both platforms)
- SpO₂ already had import-vs-raw captions; this PR fixes the **capability advertisement** half of #548

**No** SpO₂ fabrication, **no** BLE writes, **no** promote of `spo2_candidate_82`.

## Type of change

- [x] Bug fix
- [x] Documentation (captions)

## How it was tested

```bash
cd Packages/WhoopStore && swift test --filter WhoopLiveCapabilitiesTests
# 6 tests, all pass
```

Android unit tests for `WhoopLiveCapabilitiesTest` / `DeviceRegistryTest` were added; local Gradle on this machine failed before compile (environment / SDK `26.0.1` noise, not these tests). CI should run `testFullDebugUnitTest`.

## Checklist

- [x] Swift package tests pass for WhoopStore filter
- [x] Android twin + unit tests added
- [x] No new BLE commands
- [x] No fabricated SpO₂ / biosignal
- [x] Migrations data-only (no schema drop)
- [x] Clean-room — no decompiled WHOOP sources

## Related issues

- Closes / helps #548
- Helps #761 (capability honesty roadmap)
- Related #112 (blood oxygen not native)

## Provenance

Clean-room against NOOP's own decoder contracts and `Spo2ReTrace` documentation. No decompiled WHOOP app/firmware code or proprietary material.
