### PR TITLE
fix(ios): refresh Today after Apple Health sync

### DIFF
--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -961,6 +961,49 @@ final class AppModel: ObservableObject {
         }
     }
 
+    #if os(iOS)
+    /// Materializa Apple Health como dispositivo y actualiza la fuente que alimenta «Hoy».
+    /// Solo sustituye la fila WHOOP de arranque cuando sigue siendo un marcador sin pulsera ni datos;
+    /// una fuente física o elegida por el usuario conserva siempre la prioridad.
+    func refreshAfterAppleHealthSync(authorized: Bool, now: Date = Date()) async {
+        await wireSourceCoordinator()
+        guard let registry = deviceRegistry, let store = await repo.storeHandle() else {
+            await repo.refresh()
+            return
+        }
+
+        let current = registry.devices.first(where: { $0.id == registry.activeDeviceId })
+        var currentHasRecentData = false
+        if let current {
+            let range = AppleWatchDevice.recentDayRange(now: now)
+            let cutoff = Int(now.timeIntervalSince1970) - AppleWatchDevice.recentWindowDays * 86_400
+            let latestHR = (try? await store.latestHRSampleTs(deviceId: current.id)) ?? nil
+            let recentDaily = (try? await store.dailyMetrics(
+                deviceId: current.id, from: range.from, to: range.to)) ?? []
+            currentHasRecentData = (latestHR ?? 0) >= cutoff || !recentDaily.isEmpty
+        }
+
+        await AppleWatchDevice.registerIfAuthorized(
+            registry: registry, store: store, authorized: authorized, now: now)
+        guard registry.devices.contains(where: { $0.id == AppleWatchDevice.deviceId }) else {
+            await repo.refresh()
+            return
+        }
+
+        if AppleWatchDevice.shouldAutoActivate(
+            current: current, currentHasRecentData: currentHasRecentData) {
+            registry.setActive(AppleWatchDevice.deviceId)
+            await adoptActiveDevice(AppleWatchDevice.deviceId)
+        } else if registry.activeDeviceId == AppleWatchDevice.deviceId {
+            // Cubre relanzamientos: la fila ya era activa, pero el read spine puede estar inicializándose.
+            await adoptActiveDevice(AppleWatchDevice.deviceId)
+            await repo.refresh()
+        } else {
+            await repo.refresh()
+        }
+    }
+    #endif
+
     // MARK: - Oura adopt (factory-reset-and-adopt)
 
     /// The live adopt outcome of the active Oura ring, mirrored off the coordinator's live `OuraLiveSource`

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -962,9 +962,9 @@ final class AppModel: ObservableObject {
     }
 
     #if os(iOS)
-    /// Materializa Apple Health como dispositivo y actualiza la fuente que alimenta «Hoy».
-    /// Solo sustituye la fila WHOOP de arranque cuando sigue siendo un marcador sin pulsera ni datos;
-    /// una fuente física o elegida por el usuario conserva siempre la prioridad.
+    /// Materialize Apple Health as a device and update the source that feeds Today.
+    /// Only replaces the seeded WHOOP row while it is still a placeholder with no strap and no data;
+    /// a physical or user-selected source always keeps priority.
     func refreshAfterAppleHealthSync(authorized: Bool, now: Date = Date()) async {
         await wireSourceCoordinator()
         guard let registry = deviceRegistry, let store = await repo.storeHandle() else {
@@ -995,7 +995,7 @@ final class AppModel: ObservableObject {
             registry.setActive(AppleWatchDevice.deviceId)
             await adoptActiveDevice(AppleWatchDevice.deviceId)
         } else if registry.activeDeviceId == AppleWatchDevice.deviceId {
-            // Cubre relanzamientos: la fila ya era activa, pero el read spine puede estar inicializándose.
+            // Covers relaunches: the row was already active, but the read spine may still be initializing.
             await adoptActiveDevice(AppleWatchDevice.deviceId)
             await repo.refresh()
         } else {

--- a/Strand/Data/AppleWatchDevice.swift
+++ b/Strand/Data/AppleWatchDevice.swift
@@ -80,16 +80,16 @@ enum AppleWatchDevice {
             peripheralId: nil,                 // HealthKit source, not a BLE peripheral
             sourceKind: .liveAppleWatch,
             capabilities: caps,
-            // Refrescar capacidades no debe desactivar una fuente que el usuario ya tenía activa.
+            // Refreshing capabilities must not deactivate a source the user already had active.
             status: existing?.status ?? .paired,
             addedAt: existing?.addedAt ?? ts,
             lastSeenAt: ts)
     }
 
-    /// Apple Health pasa a alimentar «Hoy» únicamente cuando el activo es la fila WHOOP sembrada
-    /// por la migración y esa fila no representa una pulsera ni conserva datos recientes. Así una
-    /// autorización explícita de Salud arregla una instalación sin WHOOP, pero nunca desplaza una
-    /// pulsera real, un Oura u otra fuente que el usuario haya elegido.
+    /// Apple Health starts feeding Today only when the active source is the seeded WHOOP row
+    /// from the migration and that row represents no strap and holds no recent data. So an
+    /// explicit Health authorization fixes a strap-less install, but never displaces a
+    /// real strap, an Oura, or any other source the user has chosen.
     static func shouldAutoActivate(current: PairedDevice?, currentHasRecentData: Bool) -> Bool {
         guard let current else { return true }
         return current.id == Repository.whoopSource
@@ -101,7 +101,7 @@ enum AppleWatchDevice {
             && !currentHasRecentData
     }
 
-    /// Ventana civil compartida por el registro y la comprobación de datos del activo.
+    /// Shared calendar window used by the registry and the active-source recency check.
     static func recentDayRange(now: Date = Date()) -> (from: String, to: String) {
         let fromDate = Calendar.current.date(byAdding: .day, value: -recentWindowDays, to: now) ?? now
         return (dayString(fromDate), dayString(now))

--- a/Strand/Data/AppleWatchDevice.swift
+++ b/Strand/Data/AppleWatchDevice.swift
@@ -80,9 +80,31 @@ enum AppleWatchDevice {
             peripheralId: nil,                 // HealthKit source, not a BLE peripheral
             sourceKind: .liveAppleWatch,
             capabilities: caps,
-            status: .paired,
+            // Refrescar capacidades no debe desactivar una fuente que el usuario ya tenía activa.
+            status: existing?.status ?? .paired,
             addedAt: existing?.addedAt ?? ts,
             lastSeenAt: ts)
+    }
+
+    /// Apple Health pasa a alimentar «Hoy» únicamente cuando el activo es la fila WHOOP sembrada
+    /// por la migración y esa fila no representa una pulsera ni conserva datos recientes. Así una
+    /// autorización explícita de Salud arregla una instalación sin WHOOP, pero nunca desplaza una
+    /// pulsera real, un Oura u otra fuente que el usuario haya elegido.
+    static func shouldAutoActivate(current: PairedDevice?, currentHasRecentData: Bool) -> Bool {
+        guard let current else { return true }
+        return current.id == Repository.whoopSource
+            && current.status == .active
+            && current.sourceKind == .liveBLE
+            && current.brand.caseInsensitiveCompare("WHOOP") == .orderedSame
+            && current.model.caseInsensitiveCompare("WHOOP") == .orderedSame
+            && current.peripheralId == nil
+            && !currentHasRecentData
+    }
+
+    /// Ventana civil compartida por el registro y la comprobación de datos del activo.
+    static func recentDayRange(now: Date = Date()) -> (from: String, to: String) {
+        let fromDate = Calendar.current.date(byAdding: .day, value: -recentWindowDays, to: now) ?? now
+        return (dayString(fromDate), dayString(now))
     }
 
     // MARK: - Registration (live; iOS supplies `authorized` from HealthKitBridge)
@@ -98,12 +120,10 @@ enum AppleWatchDevice {
     static func registerIfAuthorized(registry: DeviceRegistry, store: WhoopStore,
                                      authorized: Bool, now: Date = Date()) async {
         guard authorized else { return }
-        let to = dayString(now)
-        let fromDate = Calendar.current.date(byAdding: .day, value: -recentWindowDays, to: now) ?? now
-        let from = dayString(fromDate)
+        let range = recentDayRange(now: now)
 
-        let daily = (try? await store.dailyMetrics(deviceId: deviceId, from: from, to: to)) ?? []
-        let apple = (try? await store.appleDaily(deviceId: deviceId, from: from, to: to)) ?? []
+        let daily = (try? await store.dailyMetrics(deviceId: deviceId, from: range.from, to: range.to)) ?? []
+        let apple = (try? await store.appleDaily(deviceId: deviceId, from: range.from, to: range.to)) ?? []
 
         let existing = registry.devices.first(where: { $0.id == deviceId })
         guard let device = device(daily: daily, apple: apple, authorized: authorized,

--- a/Strand/Data/HealthSyncRefreshCoordinator.swift
+++ b/Strand/Data/HealthSyncRefreshCoordinator.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// Mantiene el orden necesario entre la importación de Salud y la caché que alimenta «Hoy».
-/// HealthKit escribe primero en el almacén local; solo después se refresca el repositorio visible.
+/// Keeps the ordering between the Health import and the cache that feeds Today.
+/// HealthKit writes to the local store first; only then is the visible repository refreshed.
 @MainActor
 enum HealthSyncRefreshCoordinator {
     static func run(sync: () async -> Void, refresh: () async -> Void) async {

--- a/Strand/Data/HealthSyncRefreshCoordinator.swift
+++ b/Strand/Data/HealthSyncRefreshCoordinator.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Mantiene el orden necesario entre la importación de Salud y la caché que alimenta «Hoy».
+/// HealthKit escribe primero en el almacén local; solo después se refresca el repositorio visible.
+@MainActor
+enum HealthSyncRefreshCoordinator {
+    static func run(sync: () async -> Void, refresh: () async -> Void) async {
+        await sync()
+        await refresh()
+    }
+}

--- a/Strand/Screens/AppleHealthView.swift
+++ b/Strand/Screens/AppleHealthView.swift
@@ -46,6 +46,7 @@ struct AppleHealthView: View {
     // property and every `health.*` use below MUST stay inside `#if os(iOS)`.
     #if os(iOS)
     @EnvironmentObject private var health: HealthKitBridge
+    @EnvironmentObject private var model: AppModel
     #endif
 
     // Imperial/Metric display preference (D#103). Weight and lean mass (stored kg) re-label to lb here;
@@ -418,7 +419,13 @@ struct AppleHealthView: View {
                     Button {
                         Task {
                             await health.requestAuthorization()
-                            await health.sync()
+                            await HealthSyncRefreshCoordinator.run(
+                                sync: { await health.sync() },
+                                refresh: {
+                                    await model.refreshAfterAppleHealthSync(
+                                        authorized: health.auth == .authorized)
+                                }
+                            )
                             await load()
                         }
                     } label: {
@@ -445,7 +452,13 @@ struct AppleHealthView: View {
                     }
                     Button {
                         Task {
-                            await health.sync()
+                            await HealthSyncRefreshCoordinator.run(
+                                sync: { await health.sync() },
+                                refresh: {
+                                    await model.refreshAfterAppleHealthSync(
+                                        authorized: health.auth == .authorized)
+                                }
+                            )
                             await load()
                         }
                     } label: {

--- a/StrandTests/AppleWatchDeviceTests.swift
+++ b/StrandTests/AppleWatchDeviceTests.swift
@@ -93,13 +93,54 @@ final class AppleWatchDeviceTests: XCTestCase {
         let existing = PairedDevice(id: "apple-health", brand: "Apple", model: "Apple Watch",
                                     nickname: "My Watch", peripheralId: nil,
                                     sourceKind: .liveAppleWatch, capabilities: [.hr],
-                                    status: .paired, addedAt: 1000, lastSeenAt: 1000)
+                                    status: .active, addedAt: 1000, lastSeenAt: 1000)
         let d = [daily("2026-06-20", restingHr: 52, avgHrv: 45, totalSleepMin: 420, steps: 8000)]
         let dev = AppleWatchDevice.device(daily: d, apple: [], authorized: true,
                                           existing: existing, now: Date(timeIntervalSince1970: 2000))
         XCTAssertEqual(dev?.nickname, "My Watch")
         XCTAssertEqual(dev?.addedAt, 1000)             // pairing date preserved
         XCTAssertEqual(dev?.lastSeenAt, 2000)          // last-seen advances
+        XCTAssertEqual(dev?.status, .active)           // un refresh no desactiva la fuente visible
         XCTAssertEqual(dev?.capabilities, [.hr, .hrv, .sleep, .steps])
+    }
+
+    // MARK: - Activación automática segura
+
+    func testActivaAppleCuandoSoloQuedaElWhoopSemillaSinDatos() {
+        let placeholder = PairedDevice(
+            id: "my-whoop", brand: "WHOOP", model: "WHOOP", peripheralId: nil,
+            sourceKind: .liveBLE, capabilities: [.hr], status: .active,
+            addedAt: 1000, lastSeenAt: 1000)
+
+        XCTAssertTrue(AppleWatchDevice.shouldAutoActivate(
+            current: placeholder, currentHasRecentData: false))
+    }
+
+    func testNoSustituyeUnWhoopRealNiUnaFuenteElegida() {
+        let pairedWhoop = PairedDevice(
+            id: "my-whoop", brand: "WHOOP", model: "WHOOP 4.0", peripheralId: "BLE-123",
+            sourceKind: .liveBLE, capabilities: [.hr], status: .active,
+            addedAt: 1000, lastSeenAt: 2000)
+        let oura = PairedDevice(
+            id: "oura-123", brand: "Oura", model: "Ring 4", peripheralId: "BLE-456",
+            sourceKind: .oura, capabilities: [.hr, .hrv], status: .active,
+            addedAt: 1000, lastSeenAt: 2000)
+
+        XCTAssertFalse(AppleWatchDevice.shouldAutoActivate(
+            current: pairedWhoop, currentHasRecentData: false))
+        XCTAssertFalse(AppleWatchDevice.shouldAutoActivate(
+            current: pairedWhoop, currentHasRecentData: true))
+        XCTAssertFalse(AppleWatchDevice.shouldAutoActivate(
+            current: oura, currentHasRecentData: false))
+    }
+
+    func testNoSustituyeElWhoopSemillaSiTieneDatosRecientes() {
+        let placeholder = PairedDevice(
+            id: "my-whoop", brand: "WHOOP", model: "WHOOP", peripheralId: nil,
+            sourceKind: .liveBLE, capabilities: [.hr], status: .active,
+            addedAt: 1000, lastSeenAt: 1000)
+
+        XCTAssertFalse(AppleWatchDevice.shouldAutoActivate(
+            current: placeholder, currentHasRecentData: true))
     }
 }

--- a/StrandTests/AppleWatchDeviceTests.swift
+++ b/StrandTests/AppleWatchDeviceTests.swift
@@ -100,11 +100,11 @@ final class AppleWatchDeviceTests: XCTestCase {
         XCTAssertEqual(dev?.nickname, "My Watch")
         XCTAssertEqual(dev?.addedAt, 1000)             // pairing date preserved
         XCTAssertEqual(dev?.lastSeenAt, 2000)          // last-seen advances
-        XCTAssertEqual(dev?.status, .active)           // un refresh no desactiva la fuente visible
+        XCTAssertEqual(dev?.status, .active)           // a refresh doesn't deactivate the visible source
         XCTAssertEqual(dev?.capabilities, [.hr, .hrv, .sleep, .steps])
     }
 
-    // MARK: - Activación automática segura
+    // MARK: - Safe auto-activation
 
     func testActivaAppleCuandoSoloQuedaElWhoopSemillaSinDatos() {
         let placeholder = PairedDevice(

--- a/StrandTests/HealthSyncRefreshCoordinatorTests.swift
+++ b/StrandTests/HealthSyncRefreshCoordinatorTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import Strand
+
+@MainActor
+final class HealthSyncRefreshCoordinatorTests: XCTestCase {
+    func testRefrescaElRepositorioDespuesDeSincronizarHealthKit() async {
+        var eventos: [String] = []
+
+        await HealthSyncRefreshCoordinator.run(
+            sync: { eventos.append("sync") },
+            refresh: { eventos.append("refresh") }
+        )
+
+        XCTAssertEqual(eventos, ["sync", "refresh"])
+    }
+}

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -233,7 +233,13 @@ struct StrandiOSApp: App {
                 model.ble.requestSync(.foreground)
                 Task {
                     health.refreshAuthIfPreviouslyGranted()
-                    await health.sync()
+                    await HealthSyncRefreshCoordinator.run(
+                        sync: { await health.sync() },
+                        refresh: {
+                            await model.refreshAfterAppleHealthSync(
+                                authorized: health.auth == .authorized)
+                        }
+                    )
                     await WidgetSnapshot.publish(from: model)
                     // Push the wrist on the SAME refresh as the Home-screen widget so the watch, the
                     // widget and Today never disagree about which day they describe. Without this the


### PR DESCRIPTION
## Summary

- Refresh the active-device read spine after an Apple Health sync.
- Register Apple Health as a local source and activate it only when the seeded WHOOP placeholder has no recent data.
- Preserve a user-selected real WHOOP, Oura, or other active source.
- Keep foreground and manual sync behavior consistent through a shared coordinator.

## User-visible result

Apple Health data that is already visible in the Health screen now also populates Today in a strap-less setup, without overriding a real wearable selected by the user.

## Verification

- 79 focused and regression tests passed.
- Unsigned generic iOS build succeeded.
- `git diff --check` passed.

## Safety

The automatic source switch is intentionally narrow: it applies only to the seeded `my-whoop` placeholder when it has no recent data.