### PR TITLE
Android: label the Trends change indicator "Trend" (parity with #967)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
@@ -767,11 +767,28 @@ private fun HeadlineVessel(value: Double, tint: Color) {
 private fun ChangeChip(change: Double?, higherIsBetter: Boolean?, fmt: (Double) -> String) {
     if (change == null || kotlin.math.abs(change) <= 0.0001) return
     val sign = if (change >= 0) "+" else "−"
+    val deltaText = uiString(R.string.l10n_trends_screen_sign_fmt_kotlin_math_abs_change_9ad2f71e, sign, fmt(kotlin.math.abs(change)))
     val color = when (higherIsBetter) {
         null -> Palette.textTertiary
         else -> if ((change > 0) == higherIsBetter) Palette.statusPositive else Palette.metricRose
     }
-    TrendChip(text = uiString(R.string.l10n_trends_screen_sign_fmt_kotlin_math_abs_change_9ad2f71e, sign, fmt(kotlin.math.abs(change))), color = color)
+    // Parity with iOS #967 (fix(trends): label change indicators): a "Trend" overline above the delta chip
+    // so it reads as a labeled statistic beside the ChartFooter columns instead of an unlabeled pill at the
+    // card edge. Mirrors the sibling TrendsRangeCaption's leading-aligned Overline stack + merged a11y
+    // announcement ("Trend: +5") so TalkBack reads it as one statistic, not two.
+    val trendLabel = stringResource(R.string.trends_trend)
+    // A11y announces the label + delta as ONE statistic ("Trend: +5"), in natural case (not the visible
+    // all-caps, which readers may spell out). Routed through a format resource so the label + locale-correct
+    // separator (e.g. French thin space, Chinese full-width colon) are localized — a bare "$label: $delta"
+    // template is both un-localizable and flagged by the i18n regression gate.
+    val trendA11y = stringResource(R.string.trends_trend_a11y, deltaText)
+    Column(
+        modifier = Modifier.clearAndSetSemantics { contentDescription = trendA11y },
+        horizontalAlignment = Alignment.Start,
+    ) {
+        Overline(trendLabel, color = Palette.textTertiary)
+        TrendChip(text = deltaText, color = color)
+    }
 }
 
 /**

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -96,6 +96,8 @@
     <string name="trends_trailing">Letzte</string>
     <string name="trends_trailing_days">Letzte %1$d Tage</string>
     <string name="trends_all_history">Gesamter Verlauf</string>
+    <string name="trends_trend">Trend</string>
+    <string name="trends_trend_a11y">Trend: %1$s</string>
     <plurals name="trends_n_days">
         <item quantity="one">%1$d Tag</item>
         <item quantity="other">%1$d Tage</item>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1599,6 +1599,8 @@
     <string name="trends_trailing">Últimos</string>
     <string name="trends_trailing_days">Últimos %1$d días</string>
     <string name="trends_all_history">Todo el historial</string>
+    <string name="trends_trend">Tendencia</string>
+    <string name="trends_trend_a11y">Tendencia: %1$s</string>
     <plurals name="trends_n_days">
         <item quantity="one">%1$d día</item>
         <item quantity="other">%1$d días</item>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1599,6 +1599,8 @@
     <string name="trends_trailing">Derniers</string>
     <string name="trends_trailing_days">%1$d derniers jours</string>
     <string name="trends_all_history">Tout l’historique</string>
+    <string name="trends_trend">Tendance</string>
+    <string name="trends_trend_a11y">Tendance : %1$s</string>
     <plurals name="trends_n_days">
         <item quantity="one">%1$d jour</item>
         <item quantity="other">%1$d jours</item>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -85,6 +85,8 @@
     <string name="trends_trailing">Últimos</string>
     <string name="trends_trailing_days">Últimos %1$d dias</string>
     <string name="trends_all_history">Todo o histórico</string>
+    <string name="trends_trend">Tendência</string>
+    <string name="trends_trend_a11y">Tendência: %1$s</string>
     <plurals name="trends_n_days">
         <item quantity="one">%1$d dia</item>
         <item quantity="other">%1$d dias</item>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -83,6 +83,8 @@
     <string name="trends_trailing">近</string>
     <string name="trends_trailing_days">近 %1$d 天</string>
     <string name="trends_all_history">全部历史</string>
+    <string name="trends_trend">趋势</string>
+    <string name="trends_trend_a11y">趋势：%1$s</string>
     <plurals name="trends_n_days">
         <item quantity="other">%1$d 天</item>
     </plurals>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -105,6 +105,8 @@
     <string name="trends_trailing">Trailing</string>
     <string name="trends_trailing_days">Trailing %1$d days</string>
     <string name="trends_all_history">All history</string>
+    <string name="trends_trend">Trend</string>
+    <string name="trends_trend_a11y">Trend: %1$s</string>
     <plurals name="trends_n_days">
         <item quantity="one">%1$d day</item>
         <item quantity="other">%1$d days</item>


### PR DESCRIPTION
Android parity follow-up to #967 (merged). iOS #967's `fix(trends): label change indicators` added a **"Trend"** overline above the Trends per-metric directional change chip, so it reads as a labeled statistic beside the `ChartFooter` columns instead of an unlabeled pill at the card edge. Android's `ChangeChip` still rendered the bare `TrendChip` — this closes the gap.

## Change
- `TrendsScreen.ChangeChip` now stacks an `Overline("Trend")` label above the `TrendChip`, leading-aligned, with a merged `contentDescription` (`"Trend: +5"`) so TalkBack announces one statistic, not two. Mirrors the sibling `TrendsRangeCaption` idiom Quaii introduced in the same file (same `Column` + `clearAndSetSemantics` + `Overline` pattern).
- New `trends_trend` string localized across **all** Android locales (de/es/fr/pt-rPT/zh + default), values matched to the existing iOS `"Trend"` translations for cross-platform consistency.

## Parity notes
- The underlying delta (`periodChange` = recent-half mean − earlier-half mean, `<4`-point gate) and the green/rose valence logic were **already byte-identical** to iOS — only the label was missing. No algorithm/data/behavior change; presentation-only.
- The remaining #967 items are iOS-only spacing/layout polish (Settings/Sleep/Today), which feature-level parity permits to differ, plus the Sleep duration footer stat where Android already has a `DurationTrend` chart. This PR covers the one genuine content gap.

## Verification
- `./gradlew compileFullDebugKotlin` — clean.
- `./gradlew testFullDebugUnitTest --tests com.noop.ui.TrendsAxisLabelsTest` — pass.
- `python3 Tools/i18n_audit.py --ci main` — pass (no new un-extracted literals; `trends_trend` complete across focus locales).
