### PR TITLE
Lab Book: read WHOOP's own biomarker CSV export directly (#1220)

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/LabMarkerCsvImport.swift
+++ b/Packages/StrandImport/Sources/StrandImport/LabMarkerCsvImport.swift
@@ -41,15 +41,20 @@ public struct LabMarkerCsvRow: Sendable, Equatable {
     public var unit: String
     /// True when the marker name didn't match the catalog and imported as a custom marker.
     public var isCustomMarker: Bool
+    /// Optional free-text note carried VERBATIM from the source (e.g. a vendor's own status
+    /// column, source-attributed). nil for the generic (date,marker,value,unit) importer, which
+    /// never annotates. Maps to `LabMarker.note`.
+    public var note: String?
 
     public init(markerKey: String, category: LabMarkerCategory, day: String,
-                value: Double, unit: String, isCustomMarker: Bool) {
+                value: Double, unit: String, isCustomMarker: Bool, note: String? = nil) {
         self.markerKey = markerKey
         self.category = category
         self.day = day
         self.value = value
         self.unit = unit
         self.isCustomMarker = isCustomMarker
+        self.note = note
     }
 }
 
@@ -71,9 +76,14 @@ public struct LabMarkerCsvResult: Sendable, Equatable {
     public var truncated: Bool
     /// True when the file was rejected outright for exceeding the byte cap.
     public var fileTooLarge: Bool
+    /// Rows a vendor export marked as NOT MEASURED (e.g. WHOOP's "--" / "No Data Available").
+    /// Counted SEPARATELY from `skippedRows` so a clean import of a normal export doesn't look
+    /// broken. Always 0 for the generic importer.
+    public var notMeasured: Int
 
     public init(rows: [LabMarkerCsvRow], skippedRows: Int, customMarkerKeys: [String],
-                earliestDay: String?, latestDay: String?, truncated: Bool, fileTooLarge: Bool) {
+                earliestDay: String?, latestDay: String?, truncated: Bool, fileTooLarge: Bool,
+                notMeasured: Int = 0) {
         self.rows = rows
         self.skippedRows = skippedRows
         self.customMarkerKeys = customMarkerKeys
@@ -81,6 +91,7 @@ public struct LabMarkerCsvResult: Sendable, Equatable {
         self.latestDay = latestDay
         self.truncated = truncated
         self.fileTooLarge = fileTooLarge
+        self.notMeasured = notMeasured
     }
 
     /// Number of readings imported.
@@ -376,8 +387,9 @@ public enum LabMarkerCsvImport {
     }
 
     /// Parse one bare numeric token with the comma rules — the token must be exactly
-    /// a number, nothing more.
-    private static func numberToken(_ t: String) -> Double? {
+    /// a number, nothing more. `internal` so the WHOOP biomarker parser can split a packed
+    /// "value unit" cell with the same grammar.
+    static func numberToken(_ t: String) -> Double? {
         if let d = finiteDouble(t) { return d }
         // One decimal comma ("5,2" / "12,345" is ambiguous: 3 digits after a single
         // comma reads as a thousands group, anything else as a decimal comma).
@@ -460,7 +472,8 @@ public enum LabMarkerCsvImport {
 
     /// "yyyy-MM-dd" when the components form a real calendar date, else nil.
     /// Pure math (leap-aware), no Foundation calendar — byte-identical to the Kotlin twin.
-    private static func validDay(year: Int, month: Int, day: Int) -> String? {
+    /// `internal` so the WHOOP biomarker parser can build a date from an M/D/YY (2-digit-year) cell.
+    static func validDay(year: Int, month: Int, day: Int) -> String? {
         guard (1...12).contains(month), day >= 1, day <= daysInMonth(year, month) else { return nil }
         return String(format: "%04d-%02d-%02d", year, month, day)
     }

--- a/Packages/StrandImport/Sources/StrandImport/WhoopBiomarkerExportParser.swift
+++ b/Packages/StrandImport/Sources/StrandImport/WhoopBiomarkerExportParser.swift
@@ -1,0 +1,196 @@
+import Foundation
+
+// MARK: - WHOOP biomarker CSV export parser (source "whoop-biomarkers")
+//
+// WhoopBiomarkerExportParser.swift — Kotlin twin of
+// android/app/src/main/java/com/noop/ingest/WhoopBiomarkerExportParser.kt. Keep the two
+// byte-identical.
+//
+// WHOOP's own biomarker export ("Biomarker Name","Value","Status","Recorded On Date") matches
+// none of the generic `LabMarkerCsvImport` column aliases cleanly and differs in four further
+// ways, so importing your own WHOOP labs otherwise means rewriting the file by hand (issue #1220).
+// This is a VENDOR-GATED parser (like the Fitbit/Garmin/Oura export parsers): its looser rules —
+// a US M/D/YY date, a unit packed inside the value cell — only ever run for a file that carries
+// the WHOOP signature, so the generic path's "never guess" discipline is untouched.
+//
+// It reuses `LabMarkerCsvImport`'s tested core (marker→key resolution, the number grammar, the
+// calendar-date validator) and produces the SAME `LabMarkerCsvResult` the generic importer does,
+// so the store/app path is unchanged. Five deltas, all WHOOP-only:
+//   1. Header aliases: "Biomarker Name" → marker, "Recorded On Date" → date.
+//   2. Split a packed "value unit" cell ("70 cells/uL" → 70 + "cells/uL"), unit stored verbatim.
+//   3. Accept a US M/D/YY (2-digit-year) date — contained to this vendor, never the generic path.
+//   4. Tolerate thousands separators (already handled by the shared number grammar).
+//   5. "--" / "No Data Available" rows are NOT MEASURED, counted separately, not "skipped".
+//
+// NON-CLINICAL: WHOOP's own "Status" column (Optimal / Sufficient / Out of Range) is carried
+// VERBATIM into `LabMarkerCsvRow.note` with a "WHOOP:" prefix — the user's own provider's word,
+// source-attributed, never NOOP asserting anything. Units are stored verbatim, never converted.
+//
+// Pure and deterministic — no DB, no I/O.
+
+public enum WhoopBiomarkerExportParser {
+
+    /// Provenance/source id stored on every imported reading. Distinct from the generic "lab-csv".
+    public static let sourceId = "whoop-biomarkers"
+
+    /// WHOOP export header keys (post-`HeaderNorm.normalize`; the foreign-alias map is wearable-only,
+    /// so these biomarker headers pass through unaliased on both platforms).
+    private static let nameCol = "biomarker_name"
+    private static let valueCol = "value"
+    private static let statusCol = "status"
+    private static let dateCol = "recorded_on_date"
+
+    /// True when `table` is a WHOOP biomarker export (its four-column signature). Only then do the
+    /// vendor-specific rules below apply; any other file falls to the generic `LabMarkerCsvImport`.
+    static func matches(_ table: CSVTable) -> Bool {
+        let h = Set(table.normalizedHeaders)
+        return h.contains(nameCol) && h.contains(valueCol) && h.contains(statusCol) && h.contains(dateCol)
+    }
+
+    public static func matches(text: String) -> Bool { matches(CSVTable(text: text)) }
+
+    /// Signature check on raw bytes, using the SAME decode as `parse(data:)` (BOM-tolerant, latin-1
+    /// fallback) so detection and parsing never disagree on an odd encoding. The app layer, which
+    /// can't see the internal `CSVTable`, routes on this before calling `parse(data:)`.
+    public static func matches(data: Data) -> Bool {
+        data.count <= LabMarkerCsvImport.maxBytes && matches(CSVTable(data: data))
+    }
+
+    /// Parse raw CSV bytes. Files over the shared byte cap are rejected outright.
+    public static func parse(data: Data) -> LabMarkerCsvResult {
+        guard data.count <= LabMarkerCsvImport.maxBytes else {
+            return LabMarkerCsvResult(rows: [], skippedRows: 0, customMarkerKeys: [],
+                                      earliestDay: nil, latestDay: nil, truncated: false,
+                                      fileTooLarge: true, notMeasured: 0)
+        }
+        return parseTable(CSVTable(data: data), maxRows: LabMarkerCsvImport.maxRows)
+    }
+
+    /// Parse CSV text.
+    public static func parse(text: String) -> LabMarkerCsvResult {
+        parseTable(CSVTable(text: text), maxRows: LabMarkerCsvImport.maxRows)
+    }
+
+    // MARK: - Core (row cap injectable for tests)
+
+    static func parseTable(_ table: CSVTable, maxRows: Int) -> LabMarkerCsvResult {
+        var byCell: [String: LabMarkerCsvRow] = [:]   // (markerKey \u{1} day) → last row wins
+        var skipped = 0
+        var notMeasured = 0
+        var truncated = false
+        var customKeys: Set<String> = []
+
+        func store(_ row: LabMarkerCsvRow) {
+            byCell[row.markerKey + "\u{1}" + row.day] = row
+        }
+
+        for (index, row) in table.rows.enumerated() {
+            if index >= maxRows {
+                skipped += table.rows.count - maxRows
+                truncated = true
+                break
+            }
+            let rawValue = row.cell(valueCol) ?? ""
+            let rawDate = row.cell(dateCol) ?? ""
+            let rawName = row.cell(nameCol)
+            let rawStatus = row.cell(statusCol)
+
+            // WHOOP marks an unmeasured marker with "--" (value AND date) or "No Data Available" (status).
+            // That is legitimately absent, not malformed — count it apart so a clean export doesn't report
+            // dozens of "skipped" rows and look broken.
+            if isNoData(rawValue) || isNoData(rawDate) { notMeasured += 1; continue }
+
+            guard let rawName else { skipped += 1; continue }
+            guard let day = whoopDay(rawDate) else { skipped += 1; continue }
+            guard let split = splitValueUnit(rawValue) else { skipped += 1; continue }
+            let (value, packedUnit) = split
+
+            // Reuse the generic marker→key resolution. A bp-combined sentinel (key == nil) has no single
+            // marker to land on in a one-value-per-row export, so skip it (WHOOP does not emit paired BP here).
+            let resolved = LabMarkerCsvImport.resolveMarker(rawName)
+            guard let key = resolved.key else { skipped += 1; continue }
+
+            let category: LabMarkerCategory
+            let unit: String
+            if let def = MarkerCatalog.definition(for: key) {
+                category = def.category
+                unit = packedUnit.isEmpty ? def.canonicalUnit : packedUnit
+            } else {
+                category = .other
+                unit = packedUnit
+                customKeys.insert(key)
+            }
+
+            let note: String? = {
+                guard let s = rawStatus?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !s.isEmpty, !isNoData(s) else { return nil }
+                return "WHOOP: " + s
+            }()
+            store(LabMarkerCsvRow(markerKey: key, category: category, day: day, value: value,
+                                  unit: unit, isCustomMarker: MarkerCatalog.definition(for: key) == nil,
+                                  note: note))
+        }
+
+        let rows = byCell.values.sorted {
+            $0.day == $1.day ? $0.markerKey < $1.markerKey : $0.day < $1.day
+        }
+        let days = rows.map(\.day)
+        return LabMarkerCsvResult(rows: rows, skippedRows: skipped, customMarkerKeys: customKeys.sorted(),
+                                  earliestDay: days.min(), latestDay: days.max(),
+                                  truncated: truncated, fileTooLarge: false, notMeasured: notMeasured)
+    }
+
+    // MARK: - WHOOP-specific cell handling
+
+    /// WHOOP's not-measured sentinels: a literal "--" or "No Data Available" (any case/spacing).
+    /// Matched via `LabMarkerCsvImport.matchNorm` so "no data available" folds regardless of casing.
+    static func isNoData(_ s: String) -> Bool {
+        let t = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        if t == "--" { return true }
+        return LabMarkerCsvImport.matchNorm(t) == "no_data_available"
+    }
+
+    /// Split a packed WHOOP value cell into (number, verbatim unit): "70 cells/uL" → 70 + "cells/uL",
+    /// "3,490 cells/uL" → 3490 + "cells/uL", "33 U/L" → 33 + "U/L", a bare "70" → 70 + "". nil when the
+    /// leading token is not a number (skip-and-count). Reuses the shared number grammar for the value.
+    static func splitValueUnit(_ raw: String) -> (Double, String)? {
+        let t = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !t.isEmpty else { return nil }
+        if let d = LabMarkerCsvImport.numberToken(t) { return (d, "") }   // whole cell is a number, no unit
+        let scalars = Array(t)
+        var i = 0
+        while i < scalars.count, "0123456789+-.,".contains(scalars[i]) { i += 1 }
+        guard i > 0, i < scalars.count, scalars[i] == " " else { return nil }
+        guard let value = LabMarkerCsvImport.numberToken(String(scalars[0..<i])) else { return nil }
+        let unit = String(scalars[(i + 1)...]).trimmingCharacters(in: .whitespaces)
+        return (value, unit)
+    }
+
+    /// Canonicalise a WHOOP date to "yyyy-MM-dd". WHOOP writes a US month-first date, usually with a
+    /// 2-digit year ("7/2/26" → 2026-07-02). ISO and 4-digit-year forms delegate to the shared
+    /// `LabMarkerCsvImport.canonicalDay`; the 2-digit-year form is handled here (vendor-gated, so the
+    /// generic path never guesses a 2-digit US year). Month-first is KNOWN for WHOOP, so an invalid
+    /// month (a value the generic ambiguity-resolver would swap) is simply rejected.
+    static func whoopDay(_ raw: String) -> String? {
+        let t = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let iso = LabMarkerCsvImport.canonicalDay(t) { return iso }
+        guard let m = firstMatch(t, pattern: "^([0-9]{1,2})[./-]([0-9]{1,2})[./-]([0-9]{2})(?![0-9])")
+        else { return nil }
+        let year = 2000 + m[2]
+        return LabMarkerCsvImport.validDay(year: year, month: m[0], day: m[1])
+    }
+
+    /// First regex match's integer capture groups, or nil (a local copy of the generic importer's
+    /// private helper — the two are trivially identical).
+    private static func firstMatch(_ s: String, pattern: String) -> [Int]? {
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: s, range: NSRange(s.startIndex..., in: s))
+        else { return nil }
+        var out: [Int] = []
+        for i in 1..<match.numberOfRanges {
+            guard let r = Range(match.range(at: i), in: s), let v = Int(s[r]) else { return nil }
+            out.append(v)
+        }
+        return out
+    }
+}

--- a/Packages/StrandImport/Tests/StrandImportTests/WhoopBiomarkerExportParserTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/WhoopBiomarkerExportParserTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import StrandImport
+
+/// Tests for the WHOOP biomarker export parser (#1220). Synthetic fixture with the same
+/// structural quirks as a real export (quoted names with commas, packed value+unit, thousands
+/// separators, "--"/"No Data Available" rows, US M/D/YY dates). Mirrors the Android
+/// `WhoopBiomarkerExportParserTest` fixture-for-fixture so the twins stay byte-identical.
+final class WhoopBiomarkerExportParserTests: XCTestCase {
+
+    // A synthetic export (values invented) mirroring the real header + row shapes from the issue.
+    private let fixture = """
+    "Biomarker Name",Value,Status,"Recorded On Date"
+    "1,5-Anhydroglucitol (1,5-AG)",--,"No Data Available",--
+    Ferritin,"1,050 ng/mL",Optimal,7/2/26
+    "Vitamin D","72 nmol/L",Sufficient,7/2/26
+    LDL,"3.1 mmol/L","Out of Range",1/23/26
+    Basophils,"70 cells/uL",Optimal,1/23/26
+    """
+
+    // MARK: - Detection
+
+    func testMatchesOnlyTheWhoopSignature() {
+        XCTAssertTrue(WhoopBiomarkerExportParser.matches(text: fixture))
+        // The generic (date,marker,value,unit) shape must NOT route to the vendor parser.
+        XCTAssertFalse(WhoopBiomarkerExportParser.matches(text: "date,marker,value,unit\n2026-05-01,ldl,3.1,mmol/L"))
+        // A near-miss missing the Status column is not a WHOOP export.
+        XCTAssertFalse(WhoopBiomarkerExportParser.matches(text: "\"Biomarker Name\",Value,\"Recorded On Date\"\nFerritin,80,7/2/26"))
+    }
+
+    // MARK: - Happy path
+
+    func testParsesReadingsCountsNotMeasuredSeparately() {
+        let result = WhoopBiomarkerExportParser.parse(text: fixture)
+        XCTAssertEqual(result.importedReadings, 4)   // ferritin, vitamin_d, ldl, basophils
+        XCTAssertEqual(result.notMeasured, 1)        // the "--" / "No Data Available" anhydroglucitol row
+        XCTAssertEqual(result.skippedRows, 0)        // nothing malformed
+        XCTAssertEqual(result.distinctMarkers, 4)
+        XCTAssertEqual(result.earliestDay, "2026-01-23")
+        XCTAssertEqual(result.latestDay, "2026-07-02")
+        XCTAssertFalse(result.truncated)
+        XCTAssertFalse(result.fileTooLarge)
+        XCTAssertEqual(result.customMarkerKeys, ["custom_basophils"])
+    }
+
+    func testKeepsPackedUnitAndThousandsSeparator() {
+        let rows = WhoopBiomarkerExportParser.parse(text: fixture).rows
+        let ferritin = rows.first { $0.markerKey == "ferritin" }!
+        XCTAssertEqual(ferritin.value, 1050.0)          // "1,050" thousands separator stripped
+        XCTAssertEqual(ferritin.unit, "ng/mL")          // unit split out of the packed cell, verbatim
+        XCTAssertEqual(ferritin.category, .bloodPanel)
+        XCTAssertFalse(ferritin.isCustomMarker)
+        XCTAssertEqual(ferritin.day, "2026-07-02")      // US M/D/YY (2-digit year) → ISO
+    }
+
+    func testCarriesStatusVerbatimIntoNoteAttributed() {
+        let rows = WhoopBiomarkerExportParser.parse(text: fixture).rows
+        XCTAssertEqual(rows.first { $0.markerKey == "ferritin" }?.note, "WHOOP: Optimal")
+        XCTAssertEqual(rows.first { $0.markerKey == "vitamin_d" }?.note, "WHOOP: Sufficient")
+        // A verdict is carried verbatim + attributed — NOOP never asserts it itself.
+        XCTAssertEqual(rows.first { $0.markerKey == "ldl" }?.note, "WHOOP: Out of Range")
+    }
+
+    func testUnknownMarkerBecomesCustomWithItsUnit() {
+        let baso = WhoopBiomarkerExportParser.parse(text: fixture).rows.first { $0.markerKey == "custom_basophils" }!
+        XCTAssertTrue(baso.isCustomMarker)
+        XCTAssertEqual(baso.category, .other)
+        XCTAssertEqual(baso.value, 70.0)
+        XCTAssertEqual(baso.unit, "cells/uL")
+        XCTAssertEqual(baso.note, "WHOOP: Optimal")
+    }
+
+    // MARK: - Cell-level rules
+
+    func testIsNoDataMatchesBothSentinels() {
+        XCTAssertTrue(WhoopBiomarkerExportParser.isNoData("--"))
+        XCTAssertTrue(WhoopBiomarkerExportParser.isNoData("No Data Available"))
+        XCTAssertTrue(WhoopBiomarkerExportParser.isNoData("  no data available  "))
+        XCTAssertFalse(WhoopBiomarkerExportParser.isNoData("Optimal"))
+        XCTAssertFalse(WhoopBiomarkerExportParser.isNoData("70 cells/uL"))
+    }
+
+    func testSplitValueUnitHandlesPackedAndBare() {
+        func eq(_ a: (Double, String)?, _ v: Double, _ u: String, _ line: UInt = #line) {
+            XCTAssertEqual(a?.0, v, line: line)
+            XCTAssertEqual(a?.1, u, line: line)
+        }
+        eq(WhoopBiomarkerExportParser.splitValueUnit("70 cells/uL"), 70.0, "cells/uL")
+        eq(WhoopBiomarkerExportParser.splitValueUnit("3,490 cells/uL"), 3490.0, "cells/uL")
+        eq(WhoopBiomarkerExportParser.splitValueUnit("33 U/L"), 33.0, "U/L")
+        eq(WhoopBiomarkerExportParser.splitValueUnit("70"), 70.0, "")
+        XCTAssertNil(WhoopBiomarkerExportParser.splitValueUnit("--"))
+        XCTAssertNil(WhoopBiomarkerExportParser.splitValueUnit("negative"))
+    }
+
+    func testWhoopDayAcceptsTwoDigitUsDates() {
+        XCTAssertEqual(WhoopBiomarkerExportParser.whoopDay("7/2/26"), "2026-07-02")
+        XCTAssertEqual(WhoopBiomarkerExportParser.whoopDay("1/23/26"), "2026-01-23")
+        XCTAssertEqual(WhoopBiomarkerExportParser.whoopDay("12/31/26"), "2026-12-31")
+        XCTAssertEqual(WhoopBiomarkerExportParser.whoopDay("2026-06-15"), "2026-06-15")  // ISO still ok
+        XCTAssertNil(WhoopBiomarkerExportParser.whoopDay("13/2/26"))   // month 13 is not a valid US date
+        XCTAssertNil(WhoopBiomarkerExportParser.whoopDay("--"))
+    }
+}

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -10365,6 +10365,58 @@
         }
       }
     },
+    "%lld not measured": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld nicht gemessen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld sin medir"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld non mesurés"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld non misurati"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld não medidos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld не измерено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 项未测量"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 項未測量"
+          }
+        }
+      }
+    },
     "%lld rows skipped": {
       "localizations": {
         "de": {
@@ -14328,6 +14380,58 @@
           "stringUnit": {
             "state": "translated",
             "value": "1 筆讀數 · 你自己的記錄"
+          }
+        }
+      }
+    },
+    "1 not measured": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 nicht gemessen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 sin medir"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 non mesuré"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 non misurato"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 não medido"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 не измерено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 项未测量"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 項未測量"
           }
         }
       }

--- a/Strand/Screens/LabBookView.swift
+++ b/Strand/Screens/LabBookView.swift
@@ -230,7 +230,13 @@ struct LabBookView: View {
             defer { if scoped { url.stopAccessingSecurityScopedResource() } }
             do {
                 let data = try Data(contentsOf: url)
-                let result = LabMarkerCsvImport.parse(data: data)
+                // A WHOOP biomarker export (its own header signature) routes to the vendor parser —
+                // packed units, US 2-digit dates, a Status column carried into note; any other file
+                // takes the generic (date,marker,value,unit) path.
+                let isWhoop = WhoopBiomarkerExportParser.matches(data: data)
+                let result = isWhoop ? WhoopBiomarkerExportParser.parse(data: data)
+                                     : LabMarkerCsvImport.parse(data: data)
+                let sourceId = isWhoop ? WhoopBiomarkerExportParser.sourceId : LabMarkerCsvImport.sourceId
                 guard !result.fileTooLarge else {
                     csvSummary = String(localized: "That file is too large for a markers CSV import.")
                     csvFailed = true
@@ -265,8 +271,8 @@ struct LabBookView: View {
                         value: r.value,
                         valueText: nil,
                         unit: r.unit,
-                        source: LabMarkerCsvImport.sourceId,
-                        note: nil,
+                        source: sourceId,
+                        note: r.note,
                         referenceText: nil
                     )
                 }
@@ -280,6 +286,13 @@ struct LabBookView: View {
                     msg += " · " + (result.skippedRows == 1
                                     ? String(localized: "1 row skipped")
                                     : String(localized: "\(result.skippedRows) rows skipped"))
+                }
+                // A vendor export's not-measured markers ("--" / "No Data Available") are absent by
+                // design, not malformed — reported apart so a clean import doesn't look broken.
+                if result.notMeasured > 0 {
+                    msg += " · " + (result.notMeasured == 1
+                                    ? String(localized: "1 not measured")
+                                    : String(localized: "\(result.notMeasured) not measured"))
                 }
                 csvSummary = msg
                 csvFailed = false

--- a/android/app/src/main/java/com/noop/ingest/LabMarkerCsvImport.kt
+++ b/android/app/src/main/java/com/noop/ingest/LabMarkerCsvImport.kt
@@ -62,6 +62,10 @@ object LabMarkerCsvImport {
          *  column for a known marker; empty for a unit-less custom marker. */
         val unit: String,
         val isCustomMarker: Boolean,
+        /** Optional free-text note carried VERBATIM from the source (e.g. a vendor's own
+         *  status column, source-attributed). null for the generic (date,marker,value,unit)
+         *  importer, which never annotates. Maps to LabMarker.note. */
+        val note: String? = null,
     )
 
     /** Result of parsing a markers CSV. Mirrors the Swift LabMarkerCsvResult. */
@@ -78,6 +82,10 @@ object LabMarkerCsvImport {
         val truncated: Boolean,
         /** True when the file was rejected outright for exceeding the byte cap. */
         val fileTooLarge: Boolean,
+        /** Rows a vendor export marked as NOT MEASURED (e.g. WHOOP's "--" / "No Data
+         *  Available"). Counted SEPARATELY from [skippedRows] so a clean import of a normal
+         *  export doesn't look broken. Always 0 for the generic importer. */
+        val notMeasured: Int = 0,
     ) {
         val importedReadings: Int get() = rows.size
         val distinctMarkers: Int get() = rows.map { it.markerKey }.toHashSet().size
@@ -104,7 +112,27 @@ object LabMarkerCsvImport {
             return ImportSummary.failure(SOURCE_LABEL, "Could not read CSV: ${e.message ?: "unknown error"}")
         }
 
-        val result = parse(bytes)
+        // Route a WHOOP biomarker export to its vendor parser (packed units, US 2-digit dates, a Status
+        // column carried into note); any other file takes the generic (date,marker,value,unit) path.
+        // Detection is on the header signature, so a normal markers CSV is never treated as a WHOOP export.
+        val result: LabMarkerCsvResult
+        val sourceId: String
+        if (bytes.size > MAX_BYTES) {
+            result = LabMarkerCsvResult(
+                rows = emptyList(), skippedRows = 0, customMarkerKeys = emptyList(),
+                earliestDay = null, latestDay = null, truncated = false, fileTooLarge = true,
+            )
+            sourceId = SOURCE_ID
+        } else {
+            val table = CsvTable.fromData(bytes)
+            if (WhoopBiomarkerExportParser.matches(table)) {
+                result = WhoopBiomarkerExportParser.parse(table, MAX_ROWS)
+                sourceId = WhoopBiomarkerExportParser.SOURCE_ID
+            } else {
+                result = parse(table, MAX_ROWS)
+                sourceId = SOURCE_ID
+            }
+        }
         if (result.fileTooLarge) {
             return ImportSummary.failure(SOURCE_LABEL, "That file is too large for a markers CSV import.")
         }
@@ -127,8 +155,8 @@ object LabMarkerCsvImport {
                 value = r.value,
                 valueText = null,
                 unit = r.unit,
-                source = SOURCE_ID,
-                note = null,
+                source = sourceId,
+                note = r.note,
                 referenceText = null,
             )
         }
@@ -154,6 +182,11 @@ object LabMarkerCsvImport {
                     append(" ${result.skippedRows} row")
                     if (result.skippedRows != 1) append("s")
                     append(" skipped.")
+                }
+                // A vendor export's not-measured markers ("--" / "No Data Available") are absent by
+                // design, not malformed — report them apart so a clean import doesn't look broken.
+                if (result.notMeasured > 0) {
+                    append(" ${result.notMeasured} not measured.")
                 }
             },
         )
@@ -459,8 +492,9 @@ object LabMarkerCsvImport {
         return if (d.isFinite()) d else null
     }
 
-    /** One bare numeric token with the comma rules — must be exactly a number. */
-    private fun numberToken(t: String): Double? {
+    /** One bare numeric token with the comma rules — must be exactly a number.
+     *  `internal` so the WHOOP biomarker parser can split a packed "value unit" cell. */
+    internal fun numberToken(t: String): Double? {
         finiteDouble(t)?.let { return it }
         // One decimal comma ("5,2"; but 3 digits after a single comma reads as a
         // thousands group, anything else as a decimal comma).
@@ -531,8 +565,9 @@ object LabMarkerCsvImport {
     }
 
     /** "yyyy-MM-dd" when the components form a real calendar date, else null.
-     *  Pure math (leap-aware) — byte-identical to the Swift twin. */
-    private fun validDay(year: Int, month: Int, day: Int): String? {
+     *  Pure math (leap-aware) — byte-identical to the Swift twin. `internal` so the WHOOP
+     *  biomarker parser can build a date from an M/D/YY (2-digit-year) cell. */
+    internal fun validDay(year: Int, month: Int, day: Int): String? {
         if (month !in 1..12 || day < 1 || day > daysInMonth(year, month)) return null
         return "%04d-%02d-%02d".format(Locale.US, year, month, day)
     }

--- a/android/app/src/main/java/com/noop/ingest/WhoopBiomarkerExportParser.kt
+++ b/android/app/src/main/java/com/noop/ingest/WhoopBiomarkerExportParser.kt
@@ -1,0 +1,185 @@
+package com.noop.ingest
+
+import com.noop.analytics.LabMarkerCategory
+import com.noop.analytics.MarkerCatalog
+import com.noop.ingest.LabMarkerCsvImport.LabMarkerCsvResult
+import com.noop.ingest.LabMarkerCsvImport.LabMarkerCsvRow
+
+/**
+ * WHOOP biomarker CSV export parser (source "whoop-biomarkers") — Kotlin twin of
+ * Packages/StrandImport/Sources/StrandImport/WhoopBiomarkerExportParser.swift. Keep the two
+ * byte-identical.
+ *
+ * WHOOP's own biomarker export ("Biomarker Name","Value","Status","Recorded On Date") matches
+ * none of the generic [LabMarkerCsvImport] column aliases cleanly and differs in four further
+ * ways, so importing your own WHOOP labs otherwise means rewriting the file by hand (issue #1220).
+ * This is a VENDOR-GATED parser (like the Fitbit/Garmin/Oura export parsers): its looser rules —
+ * a US M/D/YY date, a unit packed inside the value cell — only ever run for a file that carries
+ * the WHOOP signature, so the generic path's "never guess" discipline is untouched.
+ *
+ * It reuses [LabMarkerCsvImport]'s tested core (marker→key resolution, the number grammar, the
+ * calendar-date validator) and produces the SAME [LabMarkerCsvResult] the generic importer does,
+ * so the store/app path is unchanged. Five deltas, all WHOOP-only:
+ *   1. Header aliases: "Biomarker Name" → marker, "Recorded On Date" → date.
+ *   2. Split a packed "value unit" cell ("70 cells/uL" → 70 + "cells/uL"), unit stored verbatim.
+ *   3. Accept a US M/D/YY (2-digit-year) date — contained to this vendor, never the generic path.
+ *   4. Tolerate thousands separators (already handled by the shared number grammar).
+ *   5. "--" / "No Data Available" rows are NOT MEASURED, counted separately, not "skipped".
+ *
+ * NON-CLINICAL: WHOOP's own "Status" column (Optimal / Sufficient / Out of Range) is carried
+ * VERBATIM into [LabMarkerCsvRow.note] with a "WHOOP:" prefix — the user's own provider's word,
+ * source-attributed, never NOOP asserting anything. Units are stored verbatim, never converted.
+ *
+ * Pure parsing (JVM unit-testable, WhoopBiomarkerExportParserTest).
+ */
+object WhoopBiomarkerExportParser {
+
+    /** Provenance/source id stored on every imported reading. Distinct from the generic "lab-csv". */
+    const val SOURCE_ID = "whoop-biomarkers"
+
+    /** WHOOP export header keys (post-[HeaderNorm.normalize]; the foreign-alias map is wearable-only,
+     *  so these biomarker headers pass through unaliased on both platforms). */
+    private const val NAME_COL = "biomarker_name"
+    private const val VALUE_COL = "value"
+    private const val STATUS_COL = "status"
+    private const val DATE_COL = "recorded_on_date"
+
+    /** True when [table] is a WHOOP biomarker export (its four-column signature). Only then do the
+     *  vendor-specific rules below apply; any other file falls to the generic [LabMarkerCsvImport]. */
+    internal fun matches(table: CsvTable): Boolean {
+        val h = table.normalizedHeaders.toHashSet()
+        return NAME_COL in h && VALUE_COL in h && STATUS_COL in h && DATE_COL in h
+    }
+
+    fun matches(text: String): Boolean = matches(CsvTable.fromText(text))
+
+    /** Parse raw CSV bytes. Files over the shared byte cap are rejected outright. */
+    fun parse(data: ByteArray): LabMarkerCsvResult {
+        if (data.size > LabMarkerCsvImport.MAX_BYTES) {
+            return LabMarkerCsvResult(
+                rows = emptyList(), skippedRows = 0, customMarkerKeys = emptyList(),
+                earliestDay = null, latestDay = null, truncated = false, fileTooLarge = true,
+                notMeasured = 0,
+            )
+        }
+        return parse(CsvTable.fromData(data), LabMarkerCsvImport.MAX_ROWS)
+    }
+
+    /** Parse CSV text. */
+    fun parse(text: String): LabMarkerCsvResult = parse(CsvTable.fromText(text), LabMarkerCsvImport.MAX_ROWS)
+
+    /** Core parse; the row cap is injectable for tests. Mirrors the Swift parseTable. */
+    internal fun parse(table: CsvTable, maxRows: Int): LabMarkerCsvResult {
+        val byCell = LinkedHashMap<String, LabMarkerCsvRow>()   // (markerKey  day) → last row wins
+        var skipped = 0
+        var notMeasured = 0
+        var truncated = false
+        val customKeys = sortedSetOf<String>()
+
+        fun store(row: LabMarkerCsvRow) {
+            byCell[row.markerKey + "\u0001" + row.day] = row
+        }
+
+        for ((index, row) in table.rows.withIndex()) {
+            if (index >= maxRows) {
+                skipped += table.rows.size - maxRows
+                truncated = true
+                break
+            }
+            val rawValue = row.cell(VALUE_COL) ?: ""
+            val rawDate = row.cell(DATE_COL) ?: ""
+            val rawName = row.cell(NAME_COL)
+            val rawStatus = row.cell(STATUS_COL)
+
+            // WHOOP marks an unmeasured marker with "--" (value AND date) or "No Data Available" (status).
+            // That is legitimately absent, not malformed — count it apart so a clean export doesn't report
+            // dozens of "skipped" rows and look broken.
+            if (isNoData(rawValue) || isNoData(rawDate)) { notMeasured += 1; continue }
+
+            if (rawName == null) { skipped += 1; continue }
+            val day = whoopDay(rawDate)
+            if (day == null) { skipped += 1; continue }
+            val split = splitValueUnit(rawValue)
+            if (split == null) { skipped += 1; continue }
+            val (value, packedUnit) = split
+
+            // Reuse the generic marker→key resolution. A bp-combined sentinel (key == null) has no single
+            // marker to land on in a one-value-per-row export, so skip it (WHOOP does not emit paired BP here).
+            val resolved = LabMarkerCsvImport.resolveMarker(rawName)
+            val key = resolved.key
+            if (key == null) { skipped += 1; continue }
+
+            val def = MarkerCatalog.definition(key)
+            val category: LabMarkerCategory
+            val unit: String
+            if (def != null) {
+                category = def.category
+                unit = if (packedUnit.isNotEmpty()) packedUnit else def.canonicalUnit
+            } else {
+                category = LabMarkerCategory.OTHER
+                unit = packedUnit
+                customKeys.add(key)
+            }
+
+            val note = rawStatus?.trim()
+                ?.takeIf { it.isNotEmpty() && !isNoData(it) }
+                ?.let { "WHOOP: $it" }
+            store(LabMarkerCsvRow(key, category, day, value, unit, isCustomMarker = def == null, note = note))
+        }
+
+        val rows = byCell.values.sortedWith(compareBy({ it.day }, { it.markerKey }))
+        val days = rows.map { it.day }
+        return LabMarkerCsvResult(
+            rows = rows,
+            skippedRows = skipped,
+            customMarkerKeys = customKeys.toList(),
+            earliestDay = days.minOrNull(),
+            latestDay = days.maxOrNull(),
+            truncated = truncated,
+            fileTooLarge = false,
+            notMeasured = notMeasured,
+        )
+    }
+
+    // MARK: - WHOOP-specific cell handling
+
+    /** WHOOP's not-measured sentinels: a literal "--" or "No Data Available" (any case/spacing).
+     *  Matched via [LabMarkerCsvImport.matchNorm] so "no data available" folds regardless of casing. */
+    internal fun isNoData(s: String): Boolean {
+        val t = s.trim()
+        if (t == "--") return true
+        return LabMarkerCsvImport.matchNorm(t) == "no_data_available"
+    }
+
+    /** Split a packed WHOOP value cell into (number, verbatim unit): "70 cells/uL" → 70 + "cells/uL",
+     *  "3,490 cells/uL" → 3490 + "cells/uL", "33 U/L" → 33 + "U/L", a bare "70" → 70 + "". null when the
+     *  leading token is not a number (skip-and-count). Reuses the shared number grammar for the value. */
+    internal fun splitValueUnit(raw: String): Pair<Double, String>? {
+        val t = raw.trim()
+        if (t.isEmpty()) return null
+        LabMarkerCsvImport.numberToken(t)?.let { return it to "" }   // whole cell is a number, no unit
+        var i = 0
+        while (i < t.length && t[i] in "0123456789+-.,") i += 1
+        if (i == 0 || i >= t.length || t[i] != ' ') return null
+        val value = LabMarkerCsvImport.numberToken(t.substring(0, i)) ?: return null
+        val unit = t.substring(i + 1).trim()
+        return value to unit
+    }
+
+    /** Canonicalise a WHOOP date to "yyyy-MM-dd". WHOOP writes a US month-first date, usually with a
+     *  2-digit year ("7/2/26" → 2026-07-02). ISO and 4-digit-year forms delegate to the shared
+     *  [LabMarkerCsvImport.canonicalDay]; the 2-digit-year form is handled here (vendor-gated, so the
+     *  generic path never guesses a 2-digit US year). Month-first is KNOWN for WHOOP, so an invalid
+     *  month (a value the generic ambiguity-resolver would swap) is simply rejected. */
+    internal fun whoopDay(raw: String): String? {
+        val t = raw.trim()
+        LabMarkerCsvImport.canonicalDay(t)?.let { return it }
+        val m = MDY2.find(t) ?: return null
+        val month = m.groupValues[1].toInt()
+        val day = m.groupValues[2].toInt()
+        val year = 2000 + m.groupValues[3].toInt()
+        return LabMarkerCsvImport.validDay(year, month, day)
+    }
+
+    private val MDY2 = Regex("""^(\d{1,2})[./-](\d{1,2})[./-](\d{2})(?!\d)""")
+}

--- a/android/app/src/test/java/com/noop/ingest/WhoopBiomarkerExportParserTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/WhoopBiomarkerExportParserTest.kt
@@ -1,0 +1,107 @@
+package com.noop.ingest
+
+import com.noop.analytics.LabMarkerCategory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * JVM tests for the WHOOP biomarker export parser (#1220). Synthetic fixture with the same
+ * structural quirks as a real export (quoted names with commas, packed value+unit, thousands
+ * separators, "--"/"No Data Available" rows, US M/D/YY dates). Mirrors the Swift
+ * WhoopBiomarkerExportParserTests fixture-for-fixture so the twins stay byte-identical.
+ */
+class WhoopBiomarkerExportParserTest {
+
+    // A synthetic export (values invented) mirroring the real header + row shapes from the issue.
+    private val fixture = """
+        "Biomarker Name",Value,Status,"Recorded On Date"
+        "1,5-Anhydroglucitol (1,5-AG)",--,"No Data Available",--
+        Ferritin,"1,050 ng/mL",Optimal,7/2/26
+        "Vitamin D","72 nmol/L",Sufficient,7/2/26
+        LDL,"3.1 mmol/L","Out of Range",1/23/26
+        Basophils,"70 cells/uL",Optimal,1/23/26
+    """.trimIndent()
+
+    // MARK: - Detection
+
+    @Test fun matchesOnlyTheWhoopSignature() {
+        assertTrue(WhoopBiomarkerExportParser.matches(fixture))
+        // The generic (date,marker,value,unit) shape must NOT route to the vendor parser.
+        assertFalse(WhoopBiomarkerExportParser.matches("date,marker,value,unit\n2026-05-01,ldl,3.1,mmol/L"))
+        // A near-miss missing the Status column is not a WHOOP export.
+        assertFalse(WhoopBiomarkerExportParser.matches("\"Biomarker Name\",Value,\"Recorded On Date\"\nFerritin,80,7/2/26"))
+    }
+
+    // MARK: - Happy path
+
+    @Test fun parsesReadingsCountsNotMeasuredSeparately() {
+        val result = WhoopBiomarkerExportParser.parse(fixture)
+        assertEquals(4, result.importedReadings)   // ferritin, vitamin_d, ldl, basophils
+        assertEquals(1, result.notMeasured)         // the "--" / "No Data Available" anhydroglucitol row
+        assertEquals(0, result.skippedRows)         // nothing malformed
+        assertEquals(4, result.distinctMarkers)
+        assertEquals("2026-01-23", result.earliestDay)
+        assertEquals("2026-07-02", result.latestDay)
+        assertFalse(result.truncated)
+        assertFalse(result.fileTooLarge)
+        assertEquals(listOf("custom_basophils"), result.customMarkerKeys)
+    }
+
+    @Test fun keepsPackedUnitAndThousandsSeparator() {
+        val rows = WhoopBiomarkerExportParser.parse(fixture).rows
+        val ferritin = rows.first { it.markerKey == "ferritin" }
+        assertEquals(1050.0, ferritin.value, 1e-9)       // "1,050" thousands separator stripped
+        assertEquals("ng/mL", ferritin.unit)             // unit split out of the packed cell, verbatim
+        assertEquals(LabMarkerCategory.BLOOD_PANEL, ferritin.category)
+        assertFalse(ferritin.isCustomMarker)
+        assertEquals("2026-07-02", ferritin.day)         // US M/D/YY (2-digit year) → ISO
+    }
+
+    @Test fun carriesStatusVerbatimIntoNoteAttributed() {
+        val rows = WhoopBiomarkerExportParser.parse(fixture).rows
+        assertEquals("WHOOP: Optimal", rows.first { it.markerKey == "ferritin" }.note)
+        assertEquals("WHOOP: Sufficient", rows.first { it.markerKey == "vitamin_d" }.note)
+        // A verdict is carried verbatim + attributed — NOOP never asserts it itself.
+        assertEquals("WHOOP: Out of Range", rows.first { it.markerKey == "ldl" }.note)
+    }
+
+    @Test fun unknownMarkerBecomesCustomWithItsUnit() {
+        val baso = WhoopBiomarkerExportParser.parse(fixture).rows.first { it.markerKey == "custom_basophils" }
+        assertTrue(baso.isCustomMarker)
+        assertEquals(LabMarkerCategory.OTHER, baso.category)
+        assertEquals(70.0, baso.value, 1e-9)
+        assertEquals("cells/uL", baso.unit)
+        assertEquals("WHOOP: Optimal", baso.note)
+    }
+
+    // MARK: - Cell-level rules
+
+    @Test fun isNoDataMatchesBothSentinels() {
+        assertTrue(WhoopBiomarkerExportParser.isNoData("--"))
+        assertTrue(WhoopBiomarkerExportParser.isNoData("No Data Available"))
+        assertTrue(WhoopBiomarkerExportParser.isNoData("  no data available  "))
+        assertFalse(WhoopBiomarkerExportParser.isNoData("Optimal"))
+        assertFalse(WhoopBiomarkerExportParser.isNoData("70 cells/uL"))
+    }
+
+    @Test fun splitValueUnitHandlesPackedAndBare() {
+        assertEquals(70.0 to "cells/uL", WhoopBiomarkerExportParser.splitValueUnit("70 cells/uL"))
+        assertEquals(3490.0 to "cells/uL", WhoopBiomarkerExportParser.splitValueUnit("3,490 cells/uL"))
+        assertEquals(33.0 to "U/L", WhoopBiomarkerExportParser.splitValueUnit("33 U/L"))
+        assertEquals(70.0 to "", WhoopBiomarkerExportParser.splitValueUnit("70"))
+        assertNull(WhoopBiomarkerExportParser.splitValueUnit("--"))
+        assertNull(WhoopBiomarkerExportParser.splitValueUnit("negative"))
+    }
+
+    @Test fun whoopDayAcceptsTwoDigitUsDates() {
+        assertEquals("2026-07-02", WhoopBiomarkerExportParser.whoopDay("7/2/26"))
+        assertEquals("2026-01-23", WhoopBiomarkerExportParser.whoopDay("1/23/26"))
+        assertEquals("2026-12-31", WhoopBiomarkerExportParser.whoopDay("12/31/26"))
+        assertEquals("2026-06-15", WhoopBiomarkerExportParser.whoopDay("2026-06-15"))  // ISO still ok
+        assertNull(WhoopBiomarkerExportParser.whoopDay("13/2/26"))   // month 13 is not a valid US date
+        assertNull(WhoopBiomarkerExportParser.whoopDay("--"))
+    }
+}


### PR DESCRIPTION
Implements #1220 (reported + designed by @lukasito25). Reads WHOOP's own biomarker CSV export directly, so importing your own WHOOP labs no longer means rewriting the file by hand.

## What
A vendor-gated `WhoopBiomarkerExportParser` on both platforms, beside the existing Fitbit/Garmin/Oura export parsers. It reuses `LabMarkerCsvImport`'s tested core (marker→key resolution, number grammar, calendar validator) and emits the same `LabMarkerCsvResult`, so the store/app path is unchanged. Five WHOOP-only deltas, all contained to a file carrying the WHOOP header signature:

1. **Header aliases** — `Biomarker Name` → marker, `Recorded On Date` → date.
2. **Split a packed `value unit` cell** — `"70 cells/uL"` → `70` + `cells/uL`, unit verbatim. (The generic importer parsed the number but dropped the packed unit.)
3. **US `M/D/YY` 2-digit-year dates** — vendor-gated; the generic path still requires an unambiguous 4-digit year, so nothing is guessed globally.
4. **Thousands separators** — already handled by the shared number grammar.
5. **`--` / `No Data Available` = not measured** — counted **apart** from `skipped`, so a clean import of a normal export (e.g. 51 data rows, 75 unmeasured) doesn't report 75 "skipped" and look broken.

Detection routes in the import handler on each platform; a normal markers CSV never takes the WHOOP path.

## The Status column, and #1217
WHOOP's `Status` (`Optimal` / `Sufficient` / `Out of Range`) is carried **verbatim** into `LabMarker.note` as **`WHOOP: <status>`** — the user's own provider's word, source-attributed. This stays inside the Lab Book's non-clinical framing (spec §"Non-clinical / legal framing"): NOOP never decides a value is normal/high/low and never ships a range; it just doesn't discard the user's own data. It's put in `note` (not `referenceText`, which is a *range* field) precisely so a bare verdict never renders as NOOP's own.

This **supersedes #1217** (bundle cited ranges + a four-state classifier), which would have had NOOP itself assert normality — the reporter agreed. Recommend closing #1217 in favour of this.

## Verification
- **Kotlin (byte-identical twin, locally testable):** new `WhoopBiomarkerExportParserTest` (8) green; full `com.noop.ingest` suite **22 classes / 217 tests, 0 failures** (generic importer not regressed); `compileFullDebugKotlin` clean.
- **Swift:** the parser lives in `StrandImport` → validated by `swift-packages` CI (it can't build on Linux: GRDB/sqlite3.h). `WhoopBiomarkerExportParserTests` mirrors the Kotlin fixture-for-fixture.
- **i18n:** new iOS toast strings (`1 not measured` / `%lld not measured`) localized across all 8 locales; `i18n_audit.py --ci main` green (exit 0).
- Fixture is **synthetic** (invented values, real structural quirks) — nothing real in the repo, as @lukasito25 offered.

## Caveat before merge
`Strand/Screens/LabBookView.swift` is **app-target Swift** — `app-build.yml` is disabled, so no default CI compiles it and I can't build it on Linux. The parser change (`StrandImport`) *is* CI-covered; the LabBookView wiring is a small, mechanical routing change. I'd run the app compile gate (testing build) before merge to be sure.
