### PR TITLE
Label skin temp: absolute °C vs Δ°C baseline deviation (#622) — supersedes #1221

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SkinTempDisplay.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SkinTempDisplay.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// How to present the bimodal `skinTempDevC` / `skin_temp` field (#622).
+///
+/// CSV / Health imports store **absolute** wrist °C (~30–35). The live BLE pipeline stores a
+/// **signed deviation** from the personal baseline (±°C, e.g. −0.1). Both land in the same column;
+/// `VitalBands.isAbsoluteSkinTemp` (v ≥ 20) tells them apart. Deep timeline charts raw absolute
+/// samples, so a Today/Health tile that only shows −0.1 without saying "vs baseline" looks broken.
+///
+/// Twin of `com.noop.analytics.SkinTempDisplay`. Pure — unit-tested. Localization of full titles
+/// stays in the app layer; this package only supplies kind, unit symbol, and number formatting.
+public enum SkinTempDisplay {
+
+    public enum Kind: String, Sendable, Equatable {
+        /// Absolute wrist temperature (°C scale, typically ~30–35 worn).
+        case absolute
+        /// Signed deviation from the personal nightly baseline (±°C).
+        case deviation
+    }
+
+    public static func kind(of value: Double) -> Kind {
+        VitalBands.isAbsoluteSkinTemp(value) ? .absolute : .deviation
+    }
+
+    /// Trailing unit chip: `"°C"` / `"°F"` for absolute, `"Δ°C"` / `"Δ°F"` for deviation.
+    public static func unitSymbol(kind: Kind, fahrenheit: Bool) -> String {
+        let base = fahrenheit ? "°F" : "°C"
+        return kind == .absolute ? base : "Δ\(base)"
+    }
+
+    /// Format the **number only** (no unit suffix). Deviations are always signed (`+0.1` / `-0.1`);
+    /// absolute readings are unsigned. Applies °F conversion when `fahrenheit` is true
+    /// (full C→F for absolute, ×9/5 only for deviation).
+    public static func numberString(
+        _ value: Double,
+        kind: Kind,
+        fahrenheit: Bool,
+        decimals: Int = 1
+    ) -> String {
+        let display: Double
+        if fahrenheit {
+            display = kind == .absolute
+                ? (value * 9.0 / 5.0 + 32.0)
+                : (value * 9.0 / 5.0)
+        } else {
+            display = value
+        }
+        if kind == .absolute {
+            return String(format: "%.\(decimals)f", display)
+        }
+        return String(format: "%+.\(decimals)f", display)
+    }
+
+    /// Full `"34.2 °C"` / `"+0.1 Δ°C"` string for one-shot call sites (Today cards, explorers).
+    public static func format(
+        _ value: Double,
+        fahrenheit: Bool,
+        decimals: Int = 1
+    ) -> String {
+        let k = kind(of: value)
+        let n = numberString(value, kind: k, fahrenheit: fahrenheit, decimals: decimals)
+        return "\(n) \(unitSymbol(kind: k, fahrenheit: fahrenheit))"
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SkinTempDisplayTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SkinTempDisplayTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import StrandAnalytics
+
+final class SkinTempDisplayTests: XCTestCase {
+
+    func testKindSplitsAbsoluteAndDeviation() {
+        XCTAssertEqual(SkinTempDisplay.kind(of: 34.2), .absolute)
+        XCTAssertEqual(SkinTempDisplay.kind(of: 20.0), .absolute)
+        XCTAssertEqual(SkinTempDisplay.kind(of: 0.1), .deviation)
+        XCTAssertEqual(SkinTempDisplay.kind(of: -0.1), .deviation)
+        XCTAssertEqual(SkinTempDisplay.kind(of: 19.9), .deviation)
+    }
+
+    func testUnitSymbolMarksDeviation() {
+        XCTAssertEqual(SkinTempDisplay.unitSymbol(kind: .absolute, fahrenheit: false), "°C")
+        XCTAssertEqual(SkinTempDisplay.unitSymbol(kind: .absolute, fahrenheit: true), "°F")
+        XCTAssertEqual(SkinTempDisplay.unitSymbol(kind: .deviation, fahrenheit: false), "Δ°C")
+        XCTAssertEqual(SkinTempDisplay.unitSymbol(kind: .deviation, fahrenheit: true), "Δ°F")
+    }
+
+    func testNumberStringAbsoluteUnsigned() {
+        XCTAssertEqual(
+            SkinTempDisplay.numberString(34.24, kind: .absolute, fahrenheit: false),
+            "34.2"
+        )
+    }
+
+    func testNumberStringDeviationAlwaysSigned() {
+        XCTAssertEqual(
+            SkinTempDisplay.numberString(-0.1, kind: .deviation, fahrenheit: false),
+            "-0.1"
+        )
+        XCTAssertEqual(
+            SkinTempDisplay.numberString(0.3, kind: .deviation, fahrenheit: false),
+            "+0.3"
+        )
+    }
+
+    func testFahrenheitConversionAbsoluteVsDelta() {
+        // 0 °C absolute → 32 °F
+        XCTAssertEqual(
+            SkinTempDisplay.numberString(0, kind: .absolute, fahrenheit: true, decimals: 0),
+            "32"
+        )
+        // 1 °C deviation → 1.8 Δ°F (no +32)
+        XCTAssertEqual(
+            SkinTempDisplay.numberString(1.0, kind: .deviation, fahrenheit: true),
+            "+1.8"
+        )
+    }
+
+    func testFormatCombinesNumberAndUnit() {
+        XCTAssertEqual(
+            SkinTempDisplay.format(-0.1, fahrenheit: false),
+            "-0.1 Δ°C"
+        )
+        XCTAssertEqual(
+            SkinTempDisplay.format(34.2, fahrenheit: false),
+            "34.2 °C"
+        )
+    }
+
+    func testParityWithIsAbsoluteSkinTemp() {
+        for v in [-2.0, -0.1, 0.0, 0.5, 19.9, 20.0, 30.6, 34.24] {
+            let abs = VitalBands.isAbsoluteSkinTemp(v)
+            XCTAssertEqual(SkinTempDisplay.kind(of: v) == .absolute, abs, "v=\(v)")
+        }
+    }
+}

--- a/Strand/Data/MetricCatalog.swift
+++ b/Strand/Data/MetricCatalog.swift
@@ -66,10 +66,10 @@ struct MetricDescriptor: Identifiable, Hashable {
         switch unit {
         case "kg":  return UnitFormatter.massFromKilograms(v, system: system)
         case "°C":
-            // #111: a skin-temp DEVIATION (v < 20 °C) scales without the +32 offset; an absolute reading
-            // (WHOOP export, v >= 20 °C) keeps the full C→F. Every other °C metric is absolute.
-            if isSkinTemp && !VitalBands.isAbsoluteSkinTemp(v) {
-                return UnitFormatter.temperatureDeltaFromCelsius(v, unit: temperature, decimals: decimals)
+            // #111 / #622: skin_temp is bimodal — absolute (import) vs ±deviation (live). Use
+            // SkinTempDisplay so deviation units read "Δ°C" / "Δ°F" and stay signed.
+            if isSkinTemp {
+                return SkinTempDisplay.format(v, fahrenheit: temperature == .fahrenheit, decimals: decimals)
             }
             return UnitFormatter.temperatureFromCelsius(v, unit: temperature, decimals: decimals)
         default:    return isEffort ? format(v, effortScale: effortScale) : format(v)

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -177290,6 +177290,122 @@
           }
         }
       }
+    },
+    "Skin Temp Δ": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skin Temp Δ"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hauttemperatur Δ"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temp. de piel Δ"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temp. cutanée Δ"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temp. pelle Δ"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temperatura da pele Δ"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Темп. кожи Δ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "皮肤温度 Δ"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "皮膚溫度 Δ"
+          }
+        }
+      }
+    },
+    "vs baseline": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vs baseline"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ggü. Basiswert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vs. referencia"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vs référence"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vs riferimento"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vs referência"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "относит. исходного"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "相对基线"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "相對基線"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Strand/Screens/VitalSignsSummary.swift
+++ b/Strand/Screens/VitalSignsSummary.swift
@@ -83,7 +83,8 @@ struct BodyVitalReading: Identifiable {
         case .whoopImport:
             return String(localized: "WHOOP import")
         case .noopComputed:
-            if key == "skin" { return String(localized: "Overnight computed") }
+            // Live pipeline stores ±°C vs personal baseline (#622) — not absolute wrist °C.
+            if key == "skin" { return String(localized: "vs baseline") }
             return String(localized: "NOOP computed")
         case .appleHealth:
             return String(localized: "Apple Health")
@@ -203,14 +204,16 @@ enum BodyVitalSigns {
             skinResult = VitalBands.Result(band: .noData, basis: .population, nights: 0)
         }
 
-        // Resolve the skin-temp label + converter once, honouring the °C/°F preference. An ABSOLUTE
-        // reading uses the full C→F formula (×9/5 + 32); a ±DEVIATION must omit the offset.
-        let skinUnitLabel = UnitFormatter.temperatureUnit(temperatureUnit)
+        // Resolve the skin-temp label + unit once (#622). Absolute → "Skin Temp" / "°C";
+        // deviation → "Skin Temp Δ" / "Δ°C" so −0.1 is never read as a broken thermometer.
+        let skinKind: SkinTempDisplay.Kind = skinIsAbsolute ? .absolute : .deviation
+        let fahrenheit = temperatureUnit == .fahrenheit
+        let skinUnitLabel = SkinTempDisplay.unitSymbol(kind: skinKind, fahrenheit: fahrenheit)
+        let skinTitle = skinIsAbsolute
+            ? String(localized: "Skin Temp")
+            : String(localized: "Skin Temp Δ")
         let skinFormat: (Double) -> String = { c in
-            let full = skinIsAbsolute
-                ? UnitFormatter.temperatureFromCelsius(c, unit: temperatureUnit, decimals: 1)
-                : UnitFormatter.temperatureDeltaFromCelsius(c, unit: temperatureUnit, decimals: 1)
-            return full.replacingOccurrences(of: " " + skinUnitLabel, with: "")
+            SkinTempDisplay.numberString(c, kind: skinKind, fahrenheit: fahrenheit, decimals: 1)
         }
 
         return [
@@ -330,7 +333,7 @@ enum BodyVitalSigns {
             ),
             BodyVitalReading(
                 key: "skin",
-                label: String(localized: "Skin Temp"),
+                label: skinTitle,
                 unit: skinUnitLabel,
                 value: skin,
                 format: skinFormat,
@@ -338,7 +341,7 @@ enum BodyVitalSigns {
                 metricColor: StrandPalette.metricAmber,
                 day: skinRow?.day,
                 source: skinRow?.source,
-                // #548: empty is often calibrating (needs ~4 nights for ±deviation) or import-less —
+                // #548/#622: empty is often calibrating (needs ~4 nights for ±deviation) or import-less —
                 // not a silent "broken sensor". Absolute °C still arrives via WHOOP CSV import.
                 missingCaption: String(localized: "No nightly skin-temp yet — needs ~4 worn nights (or import a WHOOP CSV)"),
                 // Keep the trail on the displayed value's kind — absolute °C and ±deviation must not

--- a/android/app/src/main/java/com/noop/analytics/SkinTempDisplay.kt
+++ b/android/app/src/main/java/com/noop/analytics/SkinTempDisplay.kt
@@ -1,0 +1,59 @@
+package com.noop.analytics
+
+/**
+ * How to present the bimodal `skinTempDevC` / `skin_temp` field (#622).
+ *
+ * CSV / Health imports store **absolute** wrist °C (~30–35). The live BLE pipeline stores a
+ * **signed deviation** from the personal baseline (±°C, e.g. −0.1). Both land in the same column;
+ * [VitalBands.isAbsoluteSkinTemp] (v ≥ 20) tells them apart. Deep timeline charts raw absolute
+ * samples, so a Today/Health tile that only shows −0.1 without saying "vs baseline" looks broken.
+ *
+ * Twin of Swift `SkinTempDisplay`. Pure — unit-tested.
+ */
+object SkinTempDisplay {
+
+    enum class Kind {
+        /** Absolute wrist temperature (°C scale, typically ~30–35 worn). */
+        ABSOLUTE,
+        /** Signed deviation from the personal nightly baseline (±°C). */
+        DEVIATION,
+    }
+
+    fun kind(value: Double): Kind =
+        if (VitalBands.isAbsoluteSkinTemp(value)) Kind.ABSOLUTE else Kind.DEVIATION
+
+    /** Trailing unit chip: `"°C"` / `"°F"` for absolute, `"Δ°C"` / `"Δ°F"` for deviation. */
+    fun unitSymbol(kind: Kind, fahrenheit: Boolean): String {
+        val base = if (fahrenheit) "°F" else "°C"
+        return if (kind == Kind.ABSOLUTE) base else "Δ$base"
+    }
+
+    /**
+     * Format the **number only** (no unit suffix). Deviations are always signed; absolute readings
+     * are unsigned. Applies °F conversion when [fahrenheit] is true.
+     */
+    fun numberString(
+        value: Double,
+        kind: Kind,
+        fahrenheit: Boolean,
+        decimals: Int = 1,
+    ): String {
+        val display = if (fahrenheit) {
+            if (kind == Kind.ABSOLUTE) value * 9.0 / 5.0 + 32.0 else value * 9.0 / 5.0
+        } else {
+            value
+        }
+        return if (kind == Kind.ABSOLUTE) {
+            String.format(java.util.Locale.US, "%.${decimals}f", display)
+        } else {
+            String.format(java.util.Locale.US, "%+.${decimals}f", display)
+        }
+    }
+
+    /** Full `"34.2 °C"` / `"+0.1 Δ°C"` string for one-shot call sites (Today cards, explorers). */
+    fun format(value: Double, fahrenheit: Boolean, decimals: Int = 1): String {
+        val k = kind(value)
+        val n = numberString(value, k, fahrenheit, decimals)
+        return "$n ${unitSymbol(k, fahrenheit)}"
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/CompareScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CompareScreen.kt
@@ -104,11 +104,20 @@ data class CompareMetric(
         return if (unit.isEmpty()) n else "$n $unit"
     }
 
-    /** Unit-aware format (D#103): weight/lean_mass (kg) and skin_temp (°C) convert + relabel via
-     *  [UnitFormatter]; everything else (%, bpm, ms, min, …) is unit-agnostic and falls through. */
+    /** Unit-aware format (D#103): weight/lean_mass (kg) and skin_temp (°C / Δ°C) convert + relabel via
+     *  [UnitFormatter] / [SkinTempDisplay]; everything else falls through. */
     fun format(v: Double, system: UnitSystem, temperature: TemperatureUnit): String = when (unit) {
         "kg" -> UnitFormatter.massFromKilograms(v, system)
-        "°C" -> UnitFormatter.temperatureFromCelsius(v, temperature, decimals)
+        "°C" -> if (key == "skin_temp") {
+            // #622: absolute vs baseline-deviation share the same key — label Δ°C when deviation.
+            com.noop.analytics.SkinTempDisplay.format(
+                v,
+                fahrenheit = temperature == TemperatureUnit.FAHRENHEIT,
+                decimals = decimals,
+            )
+        } else {
+            UnitFormatter.temperatureFromCelsius(v, temperature, decimals)
+        }
         else -> format(v)
     }
 

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -78,6 +78,7 @@ import com.noop.analytics.FitnessAgeReadiness
 import com.noop.analytics.FitnessReadinessItem
 import com.noop.analytics.FitnessReadinessRole
 import com.noop.analytics.FitnessReadinessStatus
+import com.noop.analytics.SkinTempDisplay
 import com.noop.analytics.VitalBands
 import com.noop.ble.LiveState
 import com.noop.data.DailyMetric
@@ -2029,27 +2030,25 @@ private fun buildVitalDetail(
     )
     "skin" -> {
         val latest = days.asReversed().asSequence().mapNotNull { it.skinTempDevC }.firstOrNull() ?: return null
-        val absolute = VitalBands.isAbsoluteSkinTemp(latest)
-        val unit = UnitFormatter.temperatureUnit(tempUnit)
-        val format: (Double) -> String = { c ->
-            val full = if (absolute) {
-                UnitFormatter.temperatureFromCelsius(c, tempUnit, decimals = 1)
-            } else {
-                UnitFormatter.temperatureDeltaFromCelsius(c, tempUnit, decimals = 1)
-            }
-            full.removeSuffix(" $unit")
+        val kind = SkinTempDisplay.kind(latest)
+        val fahrenheit = tempUnit == TemperatureUnit.FAHRENHEIT
+        val unit = SkinTempDisplay.unitSymbol(kind, fahrenheit)
+        val title = if (kind == SkinTempDisplay.Kind.ABSOLUTE) {
+            uiString(R.string.l10n_health_screen_skin_temperature_f59127f6)
+        } else {
+            uiString(R.string.skin_temp_delta_title)
         }
         VitalDetailModel(
             key = key,
-            title = uiString(R.string.l10n_health_screen_skin_temperature_f59127f6),
+            title = title,
             unit = unit,
             color = Palette.metricAmber,
             readings = days.mapNotNull { row ->
                 row.skinTempDevC
-                    ?.takeIf { VitalBands.isAbsoluteSkinTemp(it) == absolute }
+                    ?.takeIf { VitalBands.isAbsoluteSkinTemp(it) == (kind == SkinTempDisplay.Kind.ABSOLUTE) }
                     ?.let { value -> VitalReading(row.day, value, row.deviceId) }
             },
-            format = format,
+            format = { c -> SkinTempDisplay.numberString(c, kind, fahrenheit, decimals = 1) },
         )
     }
     else -> null

--- a/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
@@ -3,6 +3,7 @@ package com.noop.ui
 import androidx.compose.ui.graphics.Color
 import com.noop.R
 import com.noop.analytics.Baselines
+import com.noop.analytics.SkinTempDisplay
 import com.noop.analytics.VitalBands
 import com.noop.data.DailyMetric
 import java.time.LocalDate
@@ -160,16 +161,18 @@ internal fun vitalsFor(
             cfg = if (skinIsAbsolute) Baselines.metricCfg.getValue("skin_temp") else VitalBands.skinTempDeviationCfg,
         )
     }
-    // Resolve the skin-temp label + converter once, honouring the °C/°F preference. `Vital.formattedValue`
-    // appends `unit`, so strip the trailing " °C/°F" the formatter adds.
-    val skinUnitLabel = UnitFormatter.temperatureUnit(tempUnit)
+    // Resolve the skin-temp label + unit once (#622). Absolute → "Skin Temp" / "°C";
+    // deviation → "Skin Temp Δ" / "Δ°C" so −0.1 is never read as a broken thermometer.
+    val skinKind = if (skinIsAbsolute) SkinTempDisplay.Kind.ABSOLUTE else SkinTempDisplay.Kind.DEVIATION
+    val fahrenheit = tempUnit == TemperatureUnit.FAHRENHEIT
+    val skinUnitLabel = SkinTempDisplay.unitSymbol(skinKind, fahrenheit)
+    val skinTitle = if (skinIsAbsolute) {
+        uiString(R.string.l10n_health_screen_skin_temp_a4affc5a)
+    } else {
+        uiString(R.string.skin_temp_delta_title)
+    }
     val skinFormat: (Double) -> String = { c ->
-        val full = if (skinIsAbsolute) {
-            UnitFormatter.temperatureFromCelsius(c, tempUnit, decimals = 1)
-        } else {
-            UnitFormatter.temperatureDeltaFromCelsius(c, tempUnit, decimals = 1)
-        }
-        full.removeSuffix(" $skinUnitLabel")
+        SkinTempDisplay.numberString(c, skinKind, fahrenheit, decimals = 1)
     }
     val previousSkin = history.asReversed().asSequence()
         .mapNotNull { row -> row.skinTempDevC?.takeIf { VitalBands.isAbsoluteSkinTemp(it) == skinIsAbsolute } }
@@ -281,15 +284,20 @@ internal fun vitalsFor(
             sparkline = trail(d?.avgHrv) { it.avgHrv },
         ),
         Vital(
-            key = "skin", label = uiString(R.string.l10n_health_screen_skin_temp_a4affc5a), unit = skinUnitLabel,
-            // #548: empty is often calibrating (~4 nights for ±deviation) or import-less — not a silent
-            // "broken sensor". Absolute °C still arrives via WHOOP CSV / Health Connect import.
+            key = "skin", label = skinTitle, unit = skinUnitLabel,
+            // #548/#622: empty is often calibrating (~4 nights for ±deviation) or import-less — not a
+            // silent broken sensor. Absolute °C still arrives via WHOOP CSV / Health Connect import.
             missingCaption = uiString(R.string.skin_temp_missing_caption),
             value = skin, format = skinFormat,
             deltaText = deltaText(skin, previousSkin),
             readingDay = todayKey,
             asOfLabel = asOfLabel(todayKey),
-            rangeCaption = skinRangeCaption,
+            // Live deviation: name the scale so "−0.1 Δ°C" is not read as absolute wrist temp (#622).
+            rangeCaption = if (!skinIsAbsolute && skin != null) {
+                listOfNotNull(uiString(R.string.skin_temp_vs_baseline), skinRangeCaption).joinToString(" · ")
+            } else {
+                skinRangeCaption
+            },
             banding = skinResult, metricColor = Palette.metricAmber,
             // Keep the trail on the displayed value's kind — absolute °C and ±deviation must not mix.
             sparkline = trail(skin) { row ->

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3284,10 +3284,13 @@ private fun dashboardCardValue(
             (vd?.spo2Pct ?: spo2Day?.spo2Pct)?.let { String.format(Locale.US, "%.0f%%", it) }
                 ?: (vd?.day ?: day?.day)?.let { spo2CandidateByDay[it] }?.let { String.format(Locale.US, "%.0f%%", it) }
                 ?: NO_DATA
-        DashboardCard.SKIN_TEMP ->
-            // Stored as a deviation from baseline (°C); show it signed so +/- reads honestly.
-            // Same per-field carry as Blood Oxygen.
-            (vd?.skinTempDevC ?: skinTempDay?.skinTempDevC)?.let { String.format(Locale.US, "%+.1f°", it) } ?: NO_DATA
+        DashboardCard.SKIN_TEMP -> {
+            // #622: bimodal field — absolute °C (import) vs signed Δ°C vs baseline (live).
+            // Always label the scale; bare "−0.1°" next to a 34° deep-timeline chart looked broken.
+            val v = vd?.skinTempDevC ?: skinTempDay?.skinTempDevC
+            if (v == null) NO_DATA
+            else com.noop.analytics.SkinTempDisplay.format(v, fahrenheit = false)
+        }
         DashboardCard.SLEEP -> sleepValue(vd)
         DashboardCard.STEPS -> {
             val real = day?.steps?.let { intStringGrouped(it.toDouble()) }

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1979,4 +1979,6 @@
     <string name="cycle_day_single">· ~Tag %1$d</string>
     <string name="cycle_day_range">· ~Tag %1$d–%2$d</string>
     <string name="skin_temp_missing_caption">Noch keine nächtliche Hauttemperatur — benötigt ~4 getragene Nächte (oder importiere eine WHOOP-CSV)</string>
+    <string name="skin_temp_delta_title">Hauttemperatur Δ</string>
+    <string name="skin_temp_vs_baseline">ggü. Basiswert</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1964,4 +1964,6 @@
     <string name="cycle_day_single">· ~día %1$d</string>
     <string name="cycle_day_range">· ~día %1$d–%2$d</string>
     <string name="skin_temp_missing_caption">Aún no hay temperatura cutánea nocturna: necesita ~4 noches de uso (o importa un CSV de WHOOP)</string>
+    <string name="skin_temp_delta_title">Temp. de piel Δ</string>
+    <string name="skin_temp_vs_baseline">vs. referencia</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1964,4 +1964,6 @@
     <string name="cycle_day_single">· ~jour %1$d</string>
     <string name="cycle_day_range">· ~jour %1$d–%2$d</string>
     <string name="skin_temp_missing_caption">Pas encore de température cutanée nocturne — nécessite ~4 nuits portées (ou importez un CSV WHOOP)</string>
+    <string name="skin_temp_delta_title">Temp. cutanée Δ</string>
+    <string name="skin_temp_vs_baseline">vs référence</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1958,4 +1958,6 @@
     <string name="cycle_day_single">· ~dia %1$d</string>
     <string name="cycle_day_range">· ~dia %1$d–%2$d</string>
     <string name="skin_temp_missing_caption">Ainda sem temperatura da pele noturna — precisa de ~4 noites de utilização (ou importe um CSV da WHOOP)</string>
+    <string name="skin_temp_delta_title">Temperatura da pele Δ</string>
+    <string name="skin_temp_vs_baseline">vs referência</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1891,4 +1891,6 @@
     <string name="cycle_day_single">· 约第 %1$d 天</string>
     <string name="cycle_day_range">· 约第 %1$d–%2$d 天</string>
     <string name="skin_temp_missing_caption">暂无夜间皮肤温度 — 需要约 4 个佩戴夜晚（或导入 WHOOP CSV）</string>
+    <string name="skin_temp_delta_title">皮肤体温 Δ</string>
+    <string name="skin_temp_vs_baseline">相对基线</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1991,4 +1991,6 @@
     <string name="cycle_day_single">· ~day %1$d</string>
     <string name="cycle_day_range">· ~day %1$d–%2$d</string>
     <string name="skin_temp_missing_caption">No nightly skin-temp yet — needs ~4 worn nights (or import a WHOOP CSV)</string>
+    <string name="skin_temp_delta_title">Skin Temp Δ</string>
+    <string name="skin_temp_vs_baseline">vs baseline</string>
 </resources>

--- a/android/app/src/test/java/com/noop/analytics/SkinTempDisplayTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SkinTempDisplayTest.kt
@@ -1,0 +1,76 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Byte-parity twin of Swift `SkinTempDisplayTests` (#622). */
+class SkinTempDisplayTest {
+
+    @Test
+    fun kindSplitsAbsoluteAndDeviation() {
+        assertEquals(SkinTempDisplay.Kind.ABSOLUTE, SkinTempDisplay.kind(34.2))
+        assertEquals(SkinTempDisplay.Kind.ABSOLUTE, SkinTempDisplay.kind(20.0))
+        assertEquals(SkinTempDisplay.Kind.DEVIATION, SkinTempDisplay.kind(0.1))
+        assertEquals(SkinTempDisplay.Kind.DEVIATION, SkinTempDisplay.kind(-0.1))
+        assertEquals(SkinTempDisplay.Kind.DEVIATION, SkinTempDisplay.kind(19.9))
+    }
+
+    @Test
+    fun unitSymbolMarksDeviation() {
+        assertEquals("°C", SkinTempDisplay.unitSymbol(SkinTempDisplay.Kind.ABSOLUTE, fahrenheit = false))
+        assertEquals("°F", SkinTempDisplay.unitSymbol(SkinTempDisplay.Kind.ABSOLUTE, fahrenheit = true))
+        assertEquals("Δ°C", SkinTempDisplay.unitSymbol(SkinTempDisplay.Kind.DEVIATION, fahrenheit = false))
+        assertEquals("Δ°F", SkinTempDisplay.unitSymbol(SkinTempDisplay.Kind.DEVIATION, fahrenheit = true))
+    }
+
+    @Test
+    fun numberStringAbsoluteUnsigned() {
+        assertEquals(
+            "34.2",
+            SkinTempDisplay.numberString(34.24, SkinTempDisplay.Kind.ABSOLUTE, fahrenheit = false),
+        )
+    }
+
+    @Test
+    fun numberStringDeviationAlwaysSigned() {
+        assertEquals(
+            "-0.1",
+            SkinTempDisplay.numberString(-0.1, SkinTempDisplay.Kind.DEVIATION, fahrenheit = false),
+        )
+        assertEquals(
+            "+0.3",
+            SkinTempDisplay.numberString(0.3, SkinTempDisplay.Kind.DEVIATION, fahrenheit = false),
+        )
+    }
+
+    @Test
+    fun fahrenheitConversionAbsoluteVsDelta() {
+        assertEquals(
+            "32",
+            SkinTempDisplay.numberString(0.0, SkinTempDisplay.Kind.ABSOLUTE, fahrenheit = true, decimals = 0),
+        )
+        assertEquals(
+            "+1.8",
+            SkinTempDisplay.numberString(1.0, SkinTempDisplay.Kind.DEVIATION, fahrenheit = true),
+        )
+    }
+
+    @Test
+    fun formatCombinesNumberAndUnit() {
+        assertEquals("-0.1 Δ°C", SkinTempDisplay.format(-0.1, fahrenheit = false))
+        assertEquals("34.2 °C", SkinTempDisplay.format(34.2, fahrenheit = false))
+    }
+
+    @Test
+    fun parityWithIsAbsoluteSkinTemp() {
+        for (v in listOf(-2.0, -0.1, 0.0, 0.5, 19.9, 20.0, 30.6, 34.24)) {
+            val abs = VitalBands.isAbsoluteSkinTemp(v)
+            assertEquals(
+                "v=$v",
+                abs,
+                SkinTempDisplay.kind(v) == SkinTempDisplay.Kind.ABSOLUTE,
+            )
+        }
+    }
+}


### PR DESCRIPTION
Based on #1221 by **@dnesdan**, rebased onto current `main` + reconciled with the just-merged #1223 + localized. Supersedes #1221 (which went `CONFLICTING` after #1223 landed). Fixes #622.

## What (from #1221)
Live skin temp on Today/Health showed a bare `−0.1°` while the deep timeline showed `~34°C`, so users thought the homepage was broken. Both are correct (absolute wrist °C vs signed deviation from personal baseline, both stored in `skinTempDevC`); the bug was **presentation**. Adds a `SkinTempDisplay` helper (Swift + Kotlin twin) that labels the scale honestly:
- Kind: absolute (`v ≥ 20`, via the existing `VitalBands.isAbsoluteSkinTemp` contract) vs deviation.
- Unit: `°C`/`°F` vs **`Δ°C`/`Δ°F`**; numbers unsigned-absolute vs always-signed-deviation. (Correct °F handling: a *deviation* scales by 9/5 with **no +32 offset**.)
- UI: title `Skin Temp` vs `Skin Temp Δ`, `vs baseline` caption on live deviation, honest empty-state.
- No score/decode change; deep timeline (already absolute) untouched. Twin unit tests (7 vectors each).

## My reconcile + fix-up
- **Rebased onto `main` and reconciled with #1223** (both touched `VitalSignsSummary`/`HealthVitalsLogic` + the skin caption): kept #1223's **localized** `missingCaption` (`uiString(R.string.skin_temp_missing_caption)`), dropped #1221's hardcoded duplicate of the same text.
- **Localized the two new strings** — `#1221` introduced `"Skin Temp Δ"` and `"vs baseline"` as literals (iOS `String(localized:)` with no xcstrings; Android hardcoded). Added them to `Localizable.xcstrings` (9 locales) + `skin_temp_delta_title`/`skin_temp_vs_baseline` Android resources (all locales), and routed `HealthVitalsLogic` + `HealthScreen` through `uiString`.

## Verification
- Kotlin: `SkinTempDisplayTest` (7) + `SchemaOracleTest` (4, unaffected) green; `compileFullDebugKotlin` clean; `i18n_audit --ci` **exit 0**.
- Swift: `SkinTempDisplay` is in `StrandAnalytics` → validated by `swift-packages` CI (`test (StrandAnalytics)`). `VitalSignsSummary`/`MetricCatalog` are app-target — I'll run the compile gate (testing build) before merge.

Closes #622. Credit: @dnesdan.

Co-authored-by: dnesdan <dnesdan@users.noreply.github.com>
