### PR TITLE
Drive live strap battery % from the pushed BATTERY_LEVEL event (WHOOP 4.0 blanks to "—")

### DIFF
--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -211,6 +211,15 @@ public final class FrameRouter {
                 if ev.hasPrefix("BATTERY_LEVEL"), let mv = parsed.parsed["battery_mV"]?.intValue {
                     state.batteryMv = mv
                 }
+                // The same pushed BATTERY_LEVEL event also carries the real SoC% (soc@17/10, what history
+                // already banks) — drive the LIVE battery % from it too, not only from the polled
+                // GET_BATTERY_LEVEL command-response. Otherwise a stalled/late poll (or a fresh LiveState
+                // after relaunch) blanks the % to "—" while charging — read from THIS same event — keeps
+                // updating (the WHOOP 4.0 report). Live-only path (backfill skips this router), so no replay
+                // guard is needed; the family-specific #77 concern was the 0x2A19 stub, a different source.
+                if ev.hasPrefix("BATTERY_LEVEL"), let pct = parsed.parsed["battery_pct"]?.doubleValue {
+                    state.setBattery(pct)
+                }
                 // The strap raises CHARGING_ON(7)/CHARGING_OFF(8) the instant a pack goes on or comes off —
                 // flip the pill directly instead of waiting on the ~8-min BATTERY_LEVEL cadence above. Live-
                 // only like those blocks (backfill skips this router), so no replay guard is needed. Ported

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5618,6 +5618,12 @@ class WhoopBleClient(
                             (parsed.parsed["battery_mV"] as? Int)?.let { mv ->
                                 _state.update { s -> s.copy(batteryMv = mv) }
                             }
+                            // The same pushed BATTERY_LEVEL event also carries the real SoC% (soc@17/10, what
+                            // history already banks) — drive the LIVE battery % from it too, not only from the
+                            // polled GET_BATTERY_LEVEL command-response. Otherwise a stalled/late poll (or fresh
+                            // state after relaunch) blanks the % while charging — read from THIS same event —
+                            // keeps updating (the WHOOP 4.0 report). Same live-only guard as charging above.
+                            doubleValue(parsed.parsed["battery_pct"])?.let { pct -> setBattery(pct) }
                         }
                         // The strap raises CHARGING_ON(7)/CHARGING_OFF(8) the instant a pack goes on or comes
                         // off — so flip the charging pill directly instead of waiting on the ~8-min


### PR DESCRIPTION
Fixes a WHOOP **4.0** report (via Reddit): the strap battery on Today blanks to **"—"** while the charging bolt keeps working.

## Root cause
The two signals had different sources, and only one is unsolicited:

| Signal | Source | When it updates |
|---|---|---|
| **Battery %** | polled `GET_BATTERY_LEVEL` **command-response** (`FrameRouter:88`) | only when the keep-alive sends it (~60 s) *and* the strap answers |
| **Charging** | **pushed** `BATTERY_LEVEL` event (~8 min) + `CHARGING_ON/OFF` (`FrameRouter:206–221`) | strap emits unsolicited |

So whenever the polled response doesn't repopulate `batteryPct` — a stalled/late keep-alive poll, a dropped response, or a fresh `LiveState` after relaunch — the % blanks while charging (from the pushed event) keeps updating. Exactly the symptom.

## Fix
The same pushed `BATTERY_LEVEL` event NOOP already receives (and reads for charging + mV) **also carries the real SoC** — `battery_pct = soc@17/10`, range-gated `raw<=1100` in the parser (`PostHooks.swift:129` / `HistoricalStreams.kt:1023`), the exact value history banks. Read it live too:
- `FrameRouter.swift` (macOS/iOS) + `WhoopBleClient.kt` (Android) — one `battery_pct → setBattery` per platform, in the existing `BATTERY_LEVEL` branch.

Now the live % updates from the pushed event like charging does, so it no longer depends solely on the polled command and stops blanking while connected.

## Why it's safe
- **Live-only:** Swift's `FrameRouter` never sees replayed offload frames (backfill skips it — same assumption the adjacent charging read already relies on); the Kotlin twin gates on the same `shouldApplyChargingFromBatteryEvent(replayedOffload)` guard charging uses. A historical BATTERY_LEVEL replay can't move the live %.
- **Real value, validated:** the event's SoC is `u16/10` (same scale as the command-response) and the parser already range-gates it (`raw<=1100`).
- **The `#77` caveat doesn't apply** — that was the `0x2A19` characteristic **stub** (constant 100 on 4.0), a different source. This event's SoC is real for both families.

## Verification
- Android `compileFullDebugKotlin` clean. The parse (`battery_pct` from `BATTERY_LEVEL`) is already covered by `WhoopProtocol`/history tests.
- **BLE behavior can't be CI-tested (CLAUDE.md).** Needs on-strap validation: a WHOOP 4.0 whose battery had blanked should refill the % within ~8 min **without** a reconnect. Swift `FrameRouter` is app-target (no default CI) — I'll run the compile gate before merge.

Optional follow-up (not in this PR): also re-request `GET_BATTERY_LEVEL` on the reconnect/settle path so a fresh connect reads immediately instead of waiting for the next event.
