### PR TITLE
Today: replace the 2-day Key Metrics trend window with 1 month

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -981,7 +981,7 @@ struct LiquidTodayView: View {
             LiquidTube(frac: frac ?? 0, tint: tint, height: 9, animated: false,
                        showsHighlight: false, usesCleanFill: true)
             // #430 parity: DETAILED tiles grow the trend graph under the bar, tinted to the metric and
-            // windowed to the editor's 2-day / 1-week / 2-week choice (the Android twin). A metric with no
+            // windowed to the editor's 1-week / 2-week / 1-month choice (the Android twin). A metric with no
             // windowed series keeps a clear placeholder of the same height so every tile in a detailed row
             // stays equal-height with its bars aligned.
             if keyMetricsDetailed {
@@ -1188,8 +1188,8 @@ struct LiquidTodayView: View {
 
         // #430 parity: the day-keyed series the DETAILED Key-Metrics tiles graph — a trailing CALENDAR
         // window ending on the selected day (not the last-N stored rows, which on an old import showed
-        // months-old data as a fresh trend, issue #23). The loader banks the 14-day SUPERSET; the chosen
-        // 2-day/1-week/2-week window filters at render (windowedSpark), so a picker change applies without
+        // months-old data as a fresh trend, issue #23). The loader banks the 30-day SUPERSET; the chosen
+        // 1-week/2-week/1-month window filters at render (windowedSpark), so a picker change applies without
         // a reload. Keys mirror the metric catalog so a tile's graph, its tap-through detail and Android's
         // Window all read the same signal. Rest reuses the already-loaded sleep_performance series.
         let sparkCutoff = Repository.localDayKey(cal.date(byAdding: .day, value: -29, to: dayStart) ?? dayStart)

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -74,12 +74,12 @@ struct LiquidTodayView: View {
         TodayLayoutPrefs.visibleOrder(orderRaw: sectionOrderRaw, hiddenRaw: hiddenSectionsRaw)
     }
     // #430 parity: the Key-Metrics grid honours the SAME editor selection/order + Detailed-tiles switch as
-    // Android (byte-identical @AppStorage keys). `kSparks` holds the trailing-14-day series the detailed
+    // Android (byte-identical @AppStorage keys). `kSparks` holds the trailing-30-day series the detailed
     // tiles graph (keyed by metric-catalog key), filled by the loader alongside everything else.
     @AppStorage(KeyMetricPrefs.layoutKey) private var keyMetricsRaw = ""
     @AppStorage("today.keyMetricsDetailed") private var keyMetricsDetailed = false
-    /// The detailed graphs' trailing window — 2 days / 1 week / 2 weeks (shared key with Android). The
-    /// loader banks a day-keyed 14-day superset; render filters down, so a window change applies instantly.
+    /// The detailed graphs' trailing window — 1 week / 2 weeks / 1 month (shared key with Android). The
+    /// loader banks a day-keyed 30-day superset; render filters down, so a window change applies instantly.
     @AppStorage("today.keyMetricsWindowDays") private var keyMetricsWindowDays = 14
     @State private var kSparks: [String: [(String, Double)]] = [:]
     private var enabledKeyMetrics: [KeyMetric] { KeyMetricPrefs.decodeEnabled(keyMetricsRaw) }
@@ -837,11 +837,11 @@ struct LiquidTodayView: View {
 
     // MARK: - Key metrics grid
 
-    /// The chosen detailed-graph window's oldest day key (2 days / 1 week / 2 weeks ending on the
-    /// selected day). The loader banks a 14-day superset; render filters down so a window change in the
+    /// The chosen detailed-graph window's oldest day key (1 week / 2 weeks / 1 month ending on the
+    /// selected day). The loader banks a 30-day superset; render filters down so a window change in the
     /// editor applies instantly, no reload.
     private var sparkWindowCutoffKey: String {
-        let days = (keyMetricsWindowDays == 2 || keyMetricsWindowDays == 7) ? keyMetricsWindowDays : 14
+        let days = (keyMetricsWindowDays == 7 || keyMetricsWindowDays == 30) ? keyMetricsWindowDays : 14
         let cal = Calendar.current
         let anchor = cal.startOfDay(for: selectedLogicalDay)
         return Repository.localDayKey(cal.date(byAdding: .day, value: -(days - 1), to: anchor) ?? anchor)
@@ -856,8 +856,8 @@ struct LiquidTodayView: View {
     /// The Key-Metrics header's trailing label for the chosen detailed-graph window (Android twin).
     private var trendWindowLabel: String {
         switch keyMetricsWindowDays {
-        case 2: return String(localized: "2-day trend")
         case 7: return String(localized: "7-day trend")
+        case 30: return String(localized: "30-day trend")
         default: return String(localized: "14-day trend")
         }
     }
@@ -1192,7 +1192,7 @@ struct LiquidTodayView: View {
         // 2-day/1-week/2-week window filters at render (windowedSpark), so a picker change applies without
         // a reload. Keys mirror the metric catalog so a tile's graph, its tap-through detail and Android's
         // Window all read the same signal. Rest reuses the already-loaded sleep_performance series.
-        let sparkCutoff = Repository.localDayKey(cal.date(byAdding: .day, value: -13, to: dayStart) ?? dayStart)
+        let sparkCutoff = Repository.localDayKey(cal.date(byAdding: .day, value: -29, to: dayStart) ?? dayStart)
         let sparkRows = daysSnapshot.filter { $0.day >= sparkCutoff && $0.day <= selectedDayKey }
         // #616: imported-first calorie spark (the day's imported Apple active energy ?: NOOP's on-device
         // estimate) over the window, so a Health-Connect / Apple-only calorie user gets a trend too —

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -14800,6 +14800,58 @@
         }
       }
     },
+    "1 month": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Monat"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 mes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 mois"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 mese"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 mês"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 месяц"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 个月"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 個月"
+          }
+        }
+      }
+    },
     "1 week": {
       "localizations": {
         "de": {
@@ -15456,6 +15508,58 @@
           "stringUnit": {
             "state": "translated",
             "value": "2 semanas"
+          }
+        }
+      }
+    },
+    "30-day trend": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30-Tage-Trend"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tendencia de 30 días"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tendance sur 30 jours"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tendenza a 30 giorni"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tendência de 30 dias"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тренд за 30 дней"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 天趋势"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 天趨勢"
           }
         }
       }

--- a/Strand/Screens/TodayCustomizationSheet.swift
+++ b/Strand/Screens/TodayCustomizationSheet.swift
@@ -297,9 +297,9 @@ private struct KeyMetricsCustomizationPage: View {
 
                 if detailed {
                     Picker("Trend window", selection: $windowDays) {
-                        Text("2 days").tag(2)
                         Text("1 week").tag(7)
                         Text("2 weeks").tag(14)
+                        Text("1 month").tag(30)
                     }
                     .pickerStyle(.segmented)
                 }

--- a/android/app/src/main/java/com/noop/ui/KeyMetricPrefs.kt
+++ b/android/app/src/main/java/com/noop/ui/KeyMetricPrefs.kt
@@ -63,10 +63,11 @@ object KeyMetricPrefs {
 
     private const val KEY_WINDOW = "today.keyMetricsWindowDays"
 
-    /** Trailing trend window (calendar days) the DETAILED tiles graph: 2, 7 or 14 (default). Shared key
-     *  with the iOS twin; an unknown stored value coerces to 14 so a bad pref can't skew the window math. */
+    /** Trailing trend window (calendar days) the DETAILED tiles graph: 7, 14 (default) or 30. Shared key
+     *  with the iOS twin; an unknown stored value coerces to 14 so a bad pref can't skew the window math
+     *  (this also migrates users off the retired 2-day option). */
     fun detailWindowDays(context: Context): Int =
-        NoopPrefs.of(context).getInt(KEY_WINDOW, 14).let { if (it == 2 || it == 7 || it == 14) it else 14 }
+        NoopPrefs.of(context).getInt(KEY_WINDOW, 14).let { if (it == 7 || it == 14 || it == 30) it else 14 }
 
     fun setDetailWindowDays(context: Context, value: Int) {
         NoopPrefs.of(context).edit().putInt(KEY_WINDOW, value).apply()

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1503,6 +1503,7 @@ fun TodayScreen(
                                     metricsExpanded = metricsExpanded,
                                     onToggleMetrics = { metricsExpanded = !metricsExpanded },
                                     detailed = keyMetricsDetailed,
+                                    windowDays = keyMetricsWindowDays,
                                     onOpenMetric = onOpenMetric,
                                 )
                             }
@@ -4415,8 +4416,12 @@ private fun MetricGrid(
     // grid fully expanded for any caller that doesn't opt into the cap.
     metricsExpanded: Boolean = true,
     onToggleMetrics: () -> Unit = {},
-    // Detailed tiles (the #251 editor's switch): squarer tiles with a 14-day trend graph under the bar.
+    // Detailed tiles (the #251 editor's switch): squarer tiles with a trend graph under the bar, drawn
+    // over the editor's chosen window (7 / 14 / 30 days).
     detailed: Boolean = false,
+    // The editor's trailing-window choice (7 / 14 / 30). Caps each tile's sparkline to that many trailing
+    // points so "1 month" draws its full span instead of a fixed 14 (matches the iOS windowedSpark cutoff).
+    windowDays: Int = 14,
     // Tile drill-ins: every tile opens its focused trend timeline (vital_detail/<key>, the Sleep
     // night-detail pattern) via [onOpenMetric].
     onOpenMetric: (String) -> Unit = {},
@@ -4583,6 +4588,7 @@ private fun MetricGrid(
                     LiquidKeyTile(
                         tile,
                         detailed = detailed,
+                        windowDays = windowDays,
                         onClick = tapFor(metric),
                         modifier = Modifier.weight(1f).then(if (detailed) Modifier.fillMaxHeight() else Modifier),
                     )
@@ -4615,8 +4621,9 @@ private fun MetricGrid(
 }
 
 /** One compact Key-Metrics tile's data: iOS `ktile`(label, value, unit, tint, frac). [spark] is the
- *  14-day trend series (oldest→newest) the DETAILED tile style graphs; empty hides the graph (a metric
- *  with no windowed series — Steps/Weight/Calories — stays tube-only even in detailed mode). */
+ *  trailing trend series (oldest→newest) the DETAILED tile style graphs, capped at render to the editor's
+ *  chosen window; empty hides the graph (a metric with no windowed series — Steps/Weight/Calories —
+ *  stays tube-only even in detailed mode). */
 private data class KeyTileData(
     val label: String,
     val value: String,
@@ -4632,14 +4639,16 @@ private data class KeyTileData(
  * Flat surfaceRaised fill + a 16dp-corner hairline (iOS ktile background), padding 12h / 11v. Replaces the
  * old tall 2-column SparkStatTile. A No-Data value dims and the tube reads empty.
  *
- * [detailed] (the #251 editor's "Detailed tiles" switch): the tile grows a 14-day trend [Sparkline] in the
- * metric's tint under the fill bar — taller/squarer, per the tester mock. A metric with no windowed series
- * (Steps/Weight/Calories) or fewer than two points stays tube-only, so no tile ever draws a fake flat line.
+ * [detailed] (the #251 editor's "Detailed tiles" switch): the tile grows a trend [Sparkline] in the
+ * metric's tint under the fill bar — taller/squarer, per the tester mock — over the editor's [windowDays]
+ * window (7 / 14 / 30). A metric with no windowed series (Steps/Weight/Calories) or fewer than two points
+ * stays tube-only, so no tile ever draws a fake flat line.
  */
 @Composable
 private fun LiquidKeyTile(
     data: KeyTileData,
     detailed: Boolean = false,
+    windowDays: Int = 14,
     onClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
@@ -4696,10 +4705,12 @@ private fun LiquidKeyTile(
             animated = false,
             modifier = Modifier.fillMaxWidth(),
         )
-        // Detailed tiles: the 14-day trend graph under the bar (same Sparkline leaf the Sleep tiles use,
+        // Detailed tiles: the windowed trend graph under the bar (same Sparkline leaf the Sleep tiles use,
         // at the shared tile spark height), tinted to the metric so the graph reads as the same signal.
+        // Cap to the editor's chosen window (7 / 14 / 30) so "1 month" draws its full span; the w-based
+        // series is already windowed, but calories/rest sparks run longer, so this trims them to match.
         if (detailed) {
-            val tail = data.spark.takeLast(14)
+            val tail = data.spark.takeLast(windowDays)
             if (tail.size >= 2) {
                 Sparkline(
                     values = tail,

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -391,7 +391,7 @@ fun TodayScreen(
     var showMetricsEditor by remember { mutableStateOf(false) }
     var enabledKeyMetrics by remember { mutableStateOf(KeyMetricPrefs.enabled(context)) }
     // Detailed Key-Metrics tiles (squarer + trend graph), set from the same editor, plus the chosen
-    // trend window (2 days / 1 week / 2 weeks) the detailed graphs cover.
+    // trend window (1 week / 2 weeks / 1 month) the detailed graphs cover.
     var keyMetricsDetailed by remember { mutableStateOf(KeyMetricPrefs.detailed(context)) }
     var keyMetricsWindowDays by remember { mutableStateOf(KeyMetricPrefs.detailWindowDays(context)) }
     // #today-layout: the user-ordered below-hero section list + its editor dialog flag. Read once (prefs
@@ -5981,7 +5981,7 @@ private data class Window(
 )
 
 /**
- * Build the trailing trend windows from `recentDays` over the chosen span (2 / 7 / 14 calendar days —
+ * Build the trailing trend windows from `recentDays` over the chosen span (7 / 14 / 30 calendar days —
  * the editor's detailed-graph window). Each series drops null days from the trailing calendar window
  * only, so stale imports do not draw a current-day trend.
  */
@@ -6127,8 +6127,8 @@ private fun grouped(value: Int): String =
 
 /** The Key-Metrics header's trailing label for the chosen detailed-graph window. */
 private fun trendWindowLabel(days: Int): String = when (days) {
-    2 -> "2-day trend"
     7 -> "7-day trend"
+    30 -> "30-day trend"
     else -> "14-day trend"
 }
 
@@ -6141,7 +6141,7 @@ private fun KeyMetricsEditorDialog(
     onSave: (List<KeyMetric>, Boolean, Int) -> Unit,
 ) {
     // Detailed tiles: taller/squarer with a trend graph under the fill bar (display-only), over the
-    // chosen trailing window (2 days / 1 week / 2 weeks).
+    // chosen trailing window (1 week / 2 weeks / 1 month).
     var detailed by remember { mutableStateOf(initialDetailed) }
     var windowDays by remember { mutableStateOf(initialWindowDays) }
     val shown = remember { mutableStateListOf<KeyMetric>().apply { addAll(initial) } }
@@ -6195,13 +6195,13 @@ private fun KeyMetricsEditorDialog(
                         modifier = Modifier.semantics { contentDescription = uiString(R.string.l10n_today_screen_detailed_tiles_0801721b) },
                     )
                 }
-                // The detailed graphs' trailing window — 2 days / 1 week / 2 weeks (the NOOP signature
+                // The detailed graphs' trailing window — 1 week / 2 weeks / 1 month (the NOOP signature
                 // segmented pill, same control the trend screens use). Only shown while Detailed is on.
                 if (detailed) {
                     SegmentedPillControl(
-                        items = listOf(2, 7, 14),
+                        items = listOf(7, 14, 30),
                         selection = windowDays,
-                        label = { when (it) { 2 -> "2 days"; 7 -> "1 week"; else -> "2 weeks" } },
+                        label = { when (it) { 7 -> "1 week"; 14 -> "2 weeks"; else -> "1 month" } },
                         onSelect = { windowDays = it },
                         modifier = Modifier.fillMaxWidth(),
                     )


### PR DESCRIPTION
The detailed Key-Metrics tiles let you pick the trailing trend window under the fill bar. The shortest option was **2 days** — too little data to read a trend from. This swaps it for a **1 month (30-day)** window, so the selector is now **1 week / 2 weeks / 1 month** on both platforms.

### What changed
- **Picker options** — drop the `2`/2-day option, add a `30`/1-month one (iOS `Picker` in `TodayCustomizationSheet`, Android `SegmentedPillControl` in `TodayScreen`). Same shared `today.keyMetricsWindowDays` @AppStorage/prefs key.
- **Data window** — the sparkline loader banked a **14-day** superset; extended to **30** so the month window actually has data (iOS `sparkCutoff` `-13`→`-29`). All feeding series already reach that far: iOS `repo.days` / `exploreSeries` / `appleDailyRows`, and Android `recentDays` (capped at 800).
- **Migration** — the window clamp (iOS) and `detailWindowDays` reader (Android) now accept `{7,14,30}` and coerce anything else — including a stored `2` from before this change — to the 14-day default, so existing 2-day users land on a sensible window with no dead state.
- **Label** — `trendWindowLabel` drops the *2-day trend* case and adds *30-day trend*.
- **i18n** — `1 month` and `30-day trend` added to the iOS string catalog (all 8 locales); `i18n_audit.py --ci` is green.

### Parity / verification
- Byte-identical selector + stored key across Swift and Kotlin; no analytics/stored-data change.
- Android: `compileFullDebugKotlin` clean.
- iOS app-target Swift is edit-only (literal/tag/case swaps + one Int constant, no new symbols); validating via the on-demand app-build compile gate.