### PR TITLE
Fix skin-temp app-target tests after the #1224 Δ / vs-baseline relabel

### DIFF
--- a/Strand/Screens/VitalSignsSummary.swift
+++ b/Strand/Screens/VitalSignsSummary.swift
@@ -76,7 +76,7 @@ struct BodyVitalReading: Identifiable {
     }
 
     /// Short provenance word for the caption. The local-cache fallback stays unnamed (previews/tests),
-    /// and computed skin temp reads "Overnight computed" since that figure is a nightly derivation.
+    /// and computed skin temp reads "vs baseline" (#622) since that figure is a ±°C nightly deviation.
     private static func sourceLabel(_ source: DailyMetricSource?, key: String) -> String? {
         guard let source else { return nil }
         switch source {

--- a/StrandTests/UnitFormatterTests.swift
+++ b/StrandTests/UnitFormatterTests.swift
@@ -118,20 +118,22 @@ final class UnitFormatterTests: XCTestCase {
         XCTAssertEqual(UnitFormatter.temperatureDeltaFromCelsius(0.6, unit: .celsius), "0.6 °C")
     }
 
-    // #111: skin_temp holds EITHER a signed deviation (v < 20 °C) or an absolute reading (v >= 20 °C).
-    // A DEVIATION must convert ×9/5 with NO +32 — the absolute formula turned a −4.2 °C deviation into the
-    // reported nonsense "24.4 °F". An ABSOLUTE reading must still get the full C→F. Pin both branches.
+    // #111/#622: skin_temp holds EITHER a signed deviation (v < 20 °C) or an absolute reading (v >= 20 °C).
+    // A DEVIATION converts ×9/5 with NO +32 (the absolute formula turned a −4.2 °C deviation into the
+    // nonsense "24.4 °F") and is labelled as a signed baseline delta — "Δ°C" / "Δ°F", sign always shown —
+    // so −0.1 never reads as a broken thermometer (#622/#1224). An ABSOLUTE reading gets the full C→F and
+    // a plain unit. Pin both branches.
     func testSkinTempMetricPicksDeltaVsAbsoluteByValue() {
         guard let skin = MetricCatalog.all.first(where: { $0.key == "skin_temp" }) else {
             return XCTFail("skin_temp descriptor missing")
         }
-        // DEVIATION (< 20 °C): ×9/5, no +32 — NOT the bogus absolute 24.4 °F.
-        XCTAssertEqual(skin.format(-4.2, system: .imperial, temperature: .fahrenheit), "-7.6 °F")
-        XCTAssertEqual(skin.format(0.6, system: .imperial, temperature: .fahrenheit), "1.1 °F")
-        // ABSOLUTE (>= 20 °C, e.g. an imported WHOOP export reading): full C→F with +32 — 34 °C = 93.2 °F.
+        // DEVIATION (< 20 °C): ×9/5, no +32, signed Δ unit — NOT the bogus absolute 24.4 °F.
+        XCTAssertEqual(skin.format(-4.2, system: .imperial, temperature: .fahrenheit), "-7.6 Δ°F")
+        XCTAssertEqual(skin.format(0.6, system: .imperial, temperature: .fahrenheit), "+1.1 Δ°F")
+        // ABSOLUTE (>= 20 °C, e.g. an imported WHOOP export reading): full C→F with +32, plain unit — 34 °C = 93.2 °F.
         XCTAssertEqual(skin.format(34.0, system: .imperial, temperature: .fahrenheit), "93.2 °F")
-        // Celsius is unchanged for both — this always looked right; only °F was broken.
-        XCTAssertEqual(skin.format(0.6, system: .metric, temperature: .celsius), "0.6 °C")
+        // Celsius takes the same split: a deviation stays signed "Δ°C", an absolute reading a plain "°C".
+        XCTAssertEqual(skin.format(0.6, system: .metric, temperature: .celsius), "+0.6 Δ°C")
         XCTAssertEqual(skin.format(34.0, system: .metric, temperature: .celsius), "34.0 °C")
     }
 

--- a/StrandTests/VitalSourceResolutionTests.swift
+++ b/StrandTests/VitalSourceResolutionTests.swift
@@ -109,7 +109,9 @@ final class VitalSourceResolutionTests: XCTestCase {
         let skin = readings.first { $0.key == "skin" }
         XCTAssertEqual(skin?.value, 0.2)
         XCTAssertEqual(skin?.source, .noopComputed)
-        XCTAssertTrue(skin?.stateCaption.contains("Overnight computed") == true)
+        // #622/#1224: computed skin temp is a ±°C deviation from the personal baseline, so its caption
+        // reads "vs baseline" rather than the generic "NOOP computed" other computed vitals get.
+        XCTAssertTrue(skin?.stateCaption.contains("vs baseline") == true)
     }
 
     func testVitalsFallBackToLatestHistoricalDayWhenTodayHasNoValue() {


### PR DESCRIPTION
#1224 (#622) intentionally changed how computed skin temp presents:
- a **deviation** now renders as a signed baseline delta — `+1.1 Δ°F` / `-7.6 Δ°F` / `+0.6 Δ°C` (absolute readings stay plain, e.g. `93.2 °F`);
- its provenance caption reads **`vs baseline`** instead of the generic `NOOP computed`.

Two app-target tests pin the old strings and were never updated. Since `app-build.yml` is disabled, **no default CI runs `StrandTests`**, so `main` has been red at that merge without anyone seeing it (the failure only shows up when the on-demand app-build gate runs — which is how I caught it).

### Fix (test/comment-only — matches behavior already shipped on main)
- `UnitFormatterTests.testSkinTempMetricPicksDeltaVsAbsoluteByValue`: expect the signed `Δ` deviation strings; absolute readings still format plain.
- `VitalSourceResolutionTests.testComputedSkinTemperatureShowsComputedCaption`: expect the `vs baseline` caption.
- `VitalSignsSummary`: refresh the stale doc comment (`Overnight computed` → `vs baseline`).

Expected strings taken directly from the failing gate's actual output and `VitalSignsSummary.sourceLabel`. Validated by the app-build gate on the follow-on branch.