### PR TITLE
Today: host Trends/Sleep cards in Today — P0 (infra + Sleep marks)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/BackupSettings.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/BackupSettings.swift
@@ -39,7 +39,14 @@ public enum BackupSettings {
     /// display prefs that exist with identical semantics on both platforms. Deliberately EXCLUDED:
     /// step calibration (per-strap, not per-person), the avatar blob (bulky, and not "settings"),
     /// steps-engine fitted outputs (derived), and every noop.* toggle that is device- or
-    /// install-specific.
+    /// install-specific — INCLUDING the Today/Sleep section order, Key-Metrics and dashboard-card
+    /// selections, which stay per-install.
+    ///
+    /// The ONE layout pref that IS carried is `today.hostedCards` (#today-hosted-cards): the Trends/Sleep
+    /// cards the user chose to host in Today. Unlike section order, this is a deliberate composition the
+    /// user built and expects to keep across a restore; it is a JSON `[String]` (rides the String kind).
+    /// The hosted cards' POSITION (the `addedCards` section slot in `today.sectionOrder`) is not carried,
+    /// so on restore the set + internal order return but the section sits at its default position.
     public static let whitelist: [String: Kind] = [
         "profile.age": .int,
         "profile.sex": .string,
@@ -50,6 +57,7 @@ public enum BackupSettings {
         "units.system": .string,
         "units.temperature": .string,
         "effort.scale": .string,
+        "today.hostedCards": .string,
     ]
 
     /// Canonical JSON key → this platform's UserDefaults key. Identity everywhere except
@@ -65,6 +73,7 @@ public enum BackupSettings {
         "units.system": "units.system",
         "units.temperature": "units.temperature",
         "effort.scale": "effort.scale",
+        "today.hostedCards": "today.hostedCards",
     ]
 
     // MARK: - Snapshot / apply (UserDefaults boundary)

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/BackupSettingsTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/BackupSettingsTests.swift
@@ -20,6 +20,8 @@ final class BackupSettingsTests: XCTestCase {
             "units.system": "imperial",
             "units.temperature": "celsius",
             "effort.scale": "whoop",
+            // #today-hosted-cards: the one layout pref carried, a JSON [String] stored under the String kind.
+            "today.hostedCards": "[\"sleep.sleepMarks\"]",
         ]
         let data = try XCTUnwrap(BackupSettings.encode(values))
         let back = BackupSettings.decode(data)
@@ -33,6 +35,7 @@ final class BackupSettingsTests: XCTestCase {
         XCTAssertEqual(back["units.system"] as? String, "imperial")
         XCTAssertEqual(back["units.temperature"] as? String, "celsius")
         XCTAssertEqual(back["effort.scale"] as? String, "whoop")
+        XCTAssertEqual(back["today.hostedCards"] as? String, "[\"sleep.sleepMarks\"]")
         XCTAssertEqual(back.count, values.count, "Nothing extra should appear")
     }
 

--- a/Strand/Data/TodayLayoutPrefs.swift
+++ b/Strand/Data/TodayLayoutPrefs.swift
@@ -33,6 +33,10 @@ enum TodaySection: String, CaseIterable, Identifiable {
     case yourCards
     case menstrualCycle
     case journal
+    /// Cards hosted from the Trends / Sleep tabs (#today-hosted-cards). Renders the `HostedCardPrefs`
+    /// selection in order; empty (and effectively invisible) until the user adds a card in Customise.
+    /// Appended LAST so `decodeOrder`'s back-fill lands it predictably for existing saved orders.
+    case addedCards
 
     var id: String { rawValue }
 
@@ -49,6 +53,7 @@ enum TodaySection: String, CaseIterable, Identifiable {
         case .yourCards:      return String(localized: "Your Cards")
         case .menstrualCycle: return String(localized: "Menstrual Cycle")
         case .journal:        return String(localized: "Journal")
+        case .addedCards:     return String(localized: "Added Cards")
         }
     }
 
@@ -56,7 +61,7 @@ enum TodaySection: String, CaseIterable, Identifiable {
     /// widget (#656) is last by default, where it was first added, above the data-sources card.
     static let defaultOrder: [TodaySection] = [
         .hero, .liveSession, .synthesis, .keyMetrics, .workouts, .heartRate, .recoveryVitals, .yourCards,
-        .menstrualCycle, .journal,
+        .menstrualCycle, .journal, .addedCards,
     ]
 }
 

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -295,7 +295,8 @@ struct LiquidTodayView: View {
                         case .journal: if selectedDayOffset == 0 { JournalReminderCard() }
                         // #today-hosted-cards: cards the user pulled in from the Trends/Sleep tabs, in the
                         // order they arranged. Empty (renders nothing) until they add one in Customise.
-                        case .addedCards: hostedCardsSection
+                        // Today-only, matching Android's addedCards section gate + the classic TodayView.
+                        case .addedCards: if selectedDayOffset == 0 { hostedCardsSection }
                         }
                     }
                     // Opt-in "looks like a workout?" suggestion, dropped in the liquid Home rewrite. Its

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -34,6 +34,9 @@ struct LiquidTodayView: View {
 
     /// Shared with the real Today's card-customise editor so the two stay in sync.
     @AppStorage(DashboardCardPrefs.selectionKey) private var dashboardCardsRaw = ""
+    /// #today-hosted-cards: the ordered Trends/Sleep cards the user has hosted in Today. Empty by default
+    /// (opt-in); rendered by the `.addedCards` section. Shared @AppStorage key with Android.
+    @AppStorage(HostedCardPrefs.selectionKey) private var hostedCardsRaw = ""
     /// #989 parity with classic Today + Android: the hydration card is opt-in twice over — the feature
     /// toggle AND an explicit add in CUSTOMISE. Liquid filtered on neither, so a user who added the card
     /// and later switched the feature off kept a permanently-blank row.
@@ -290,6 +293,9 @@ struct LiquidTodayView: View {
                         // the card self-hides when the reminder toggle is off (an empty branch renders
                         // nothing yet keeps its slot). Twin of Android TodayScreen's JOURNAL arm.
                         case .journal: if selectedDayOffset == 0 { JournalReminderCard() }
+                        // #today-hosted-cards: cards the user pulled in from the Trends/Sleep tabs, in the
+                        // order they arranged. Empty (renders nothing) until they add one in Customise.
+                        case .addedCards: hostedCardsSection
                         }
                     }
                     // Opt-in "looks like a workout?" suggestion, dropped in the liquid Home rewrite. Its
@@ -362,7 +368,8 @@ struct LiquidTodayView: View {
                 keyMetricsRaw: $keyMetricsRaw,
                 keyMetricsDetailed: $keyMetricsDetailed,
                 keyMetricsWindowDays: $keyMetricsWindowDays,
-                dashboardCardsRaw: $dashboardCardsRaw
+                dashboardCardsRaw: $dashboardCardsRaw,
+                hostedCardsRaw: $hostedCardsRaw
             )
         }
         .sheet(isPresented: $showSettings) {
@@ -619,6 +626,33 @@ struct LiquidTodayView: View {
                         .filter { hydrationEnabled || $0 != .hydration }) { card in
                 liquidCard(for: card)
             }
+        }
+    }
+
+    // MARK: - Added cards (#today-hosted-cards)
+
+    /// The Trends/Sleep cards the user hosted in Today, in their arranged order. Data-driven off the SAME
+    /// @AppStorage the Customise editor writes, so add / remove / reorder reflects live. Each hosted card
+    /// is the SAME view its home tab renders (a mirror, not a copy) and carries its own header, so this
+    /// section adds no header of its own. Renders nothing until the user hosts a card.
+    @ViewBuilder
+    private var hostedCardsSection: some View {
+        let cards = HostedCardPrefs.decodeEnabled(hostedCardsRaw)
+        if !cards.isEmpty {
+            VStack(spacing: NoopMetrics.sectionGap) {
+                ForEach(cards) { card in
+                    hostedCard(for: card)
+                }
+            }
+        }
+    }
+
+    /// Dispatch a hosted card id to its native view. Each case renders the exact view the originating tab
+    /// uses, so the Today copy and the home-tab copy never diverge. P0 hosts only Sleep marks.
+    @ViewBuilder
+    private func hostedCard(for card: HostedCard) -> some View {
+        switch card {
+        case .sleepMarks: SleepMarkCard()
         }
     }
 

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -22768,6 +22768,58 @@
         }
       }
     },
+    "Added Cards": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinzugefügte Karten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tarjetas añadidas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cartes ajoutées"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schede aggiunte"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cartões adicionados"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавленные карточки"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已添加的卡片"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已新增的卡片"
+          }
+        }
+      }
+    },
     "Add workout": {
       "localizations": {
         "de": {

--- a/Strand/Screens/EditableLayoutList.swift
+++ b/Strand/Screens/EditableLayoutList.swift
@@ -15,6 +15,10 @@ where Item: Identifiable & Equatable, Options: View {
     let configurationLabel: (Item) -> String?
     let onConfigure: (Item) -> Void
     let onReset: () -> Void
+    /// Whether the Shown list may go EMPTY. Default false — every visible item can be hidden EXCEPT the
+    /// last, so surfaces that need ≥1 item (Today sections, Key Metrics, Your Cards) can't be emptied. The
+    /// hosted-cards page (#today-hosted-cards) is opt-in, so it passes `true` to allow un-hosting the last.
+    var allowEmpty: Bool = false
     @ViewBuilder let options: () -> Options
 
     var body: some View {
@@ -30,7 +34,7 @@ where Item: Identifiable & Equatable, Options: View {
                         tint: tint(item),
                         configurationLabel: configurationLabel(item),
                         isVisible: true,
-                        canHide: draft.visible.count > 1,
+                        canHide: draft.visible.count > (allowEmpty ? 0 : 1),
                         onConfigure: { onConfigure(item) },
                         onVisibilityChange: { hide(item) }
                     )

--- a/Strand/Screens/HostedCards.swift
+++ b/Strand/Screens/HostedCards.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+import StrandDesign
+
+// MARK: - Hosted cards (#today-hosted-cards)
+//
+// Cards that natively live in the Trends or Sleep tab, which the user can ALSO surface inside the Today
+// tab via the Customise sheet — added, removed and reordered like "Your cards", while still appearing in
+// their home tab (mirrored, not moved). The selection is display-only: nothing is computed or stored
+// differently, this just decides which foreign cards Today additionally renders and in what order.
+//
+// The rawValues are ORIGIN-NAMESPACED (`sleep.*` / `trends.*`) so a hosted id is self-describing on the
+// wire and routes to the right provider, and can never collide with a Today `DashboardCard` id. Keep them
+// byte-identical to the Android `HostedCard` enum so a backup/restore reads the same Today composition on
+// either OS — the selection rides `.noopbak` under the `today.hostedCards` key.
+
+/// One card that can be hosted in Today from another tab. The rawValue is the stable persisted identifier
+/// (origin-namespaced); keep it byte-identical to the Android `HostedCard`.
+enum HostedCard: String, CaseIterable, Identifiable {
+    /// Sleep tab · "Sleep marks" — the tap-to-log going-to-sleep / awake card. Self-contained (logging
+    /// only, no model), the first card wired end-to-end.
+    case sleepMarks = "sleep.sleepMarks"
+
+    var id: String { rawValue }
+
+    /// The card's display label in the Customise editor — matches the Android `HostedCard.title`.
+    var title: String {
+        switch self {
+        case .sleepMarks: return String(localized: "Sleep marks")
+        }
+    }
+
+    /// The originating tab, shown as the editor subtitle so a hosted card reads as "from Sleep" / "from
+    /// Trends". Matches the Android `HostedCard.origin`.
+    var origin: String {
+        switch self {
+        case .sleepMarks: return String(localized: "Sleep")
+        }
+    }
+
+    /// SF Symbol for the editor row (reuses the shared customization-icon treatment).
+    var customizationIcon: String {
+        switch self {
+        case .sleepMarks: return "moon.zzz"
+        }
+    }
+
+    /// Editor row tint.
+    var customizationTint: Color {
+        switch self {
+        case .sleepMarks: return StrandPalette.restColor
+        }
+    }
+}
+
+/// Display-only persistence for the Today-hosted card selection. Holds an ORDERED list of the enabled
+/// hosted cards as a JSON-encoded [String] of ids; a card not in the list is not hosted. Stored in
+/// @AppStorage("today.hostedCards") and whitelisted into `.noopbak`. Mirrors `DashboardCardPrefs`
+/// byte-for-byte EXCEPT the default is EMPTY — hosting is purely additive/opt-in, so a fresh install
+/// (and every existing user) hosts nothing until they add a card in Customise.
+enum HostedCardPrefs {
+    /// UserDefaults key — a JSON array of `HostedCard` ids in display order. In the `.noopbak` whitelist.
+    static let selectionKey = "today.hostedCards"
+
+    /// The default selection: EMPTY. Nothing is hosted until the user opts in.
+    static let defaultSelection: [HostedCard] = []
+
+    /// Canonical order used to list the not-yet-hosted remainder in the editor.
+    static let canonicalOrder: [HostedCard] = HostedCard.allCases
+
+    /// Encode an ordered list of hosted cards into the stored JSON string. Falls back to a comma-joined
+    /// string if JSON encoding ever fails (it won't for [String]), so the value is always decodable.
+    static func encode(_ cards: [HostedCard]) -> String {
+        let ids = cards.map(\.rawValue)
+        if let data = try? JSONEncoder().encode(ids), let json = String(data: data, encoding: .utf8) {
+            return json
+        }
+        return ids.joined(separator: ",")
+    }
+
+    /// Decode the stored string into an ordered list of hosted cards. An empty/unset string yields the
+    /// EMPTY default (nothing hosted). Accepts both the JSON-array form and a legacy comma-joined form.
+    /// Unknown ids are dropped; duplicates are de-duped; returns ONLY the hosted cards in their saved
+    /// order. Unlike `DashboardCardPrefs`, an all-unknown decode stays EMPTY (never back-fills a default),
+    /// because there is no sensible non-empty default for an opt-in surface.
+    static func decodeEnabled(_ raw: String) -> [HostedCard] {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return HostedCard.defaultSelection }
+
+        let ids: [String]
+        if let data = trimmed.data(using: .utf8), let decoded = try? JSONDecoder().decode([String].self, from: data) {
+            ids = decoded
+        } else {
+            ids = trimmed.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) }
+        }
+
+        var seen = Set<HostedCard>()
+        var result: [HostedCard] = []
+        for token in ids {
+            if let c = HostedCard(rawValue: token), seen.insert(c).inserted {
+                result.append(c)
+            }
+        }
+        return result
+    }
+}

--- a/Strand/Screens/HostedCards.swift
+++ b/Strand/Screens/HostedCards.swift
@@ -50,6 +50,13 @@ enum HostedCard: String, CaseIterable, Identifiable {
         case .sleepMarks: return StrandPalette.restColor
         }
     }
+
+    /// The default selection: EMPTY. Nothing is hosted until the user opts in. On the enum (not the prefs)
+    /// to mirror `DashboardCard.defaultSelection`; keep byte-identical to the Android companion default.
+    static let defaultSelection: [HostedCard] = []
+
+    /// Canonical order used to list the not-yet-hosted remainder in the editor (mirrors `allCases`).
+    static let canonicalOrder: [HostedCard] = allCases
 }
 
 /// Display-only persistence for the Today-hosted card selection. Holds an ORDERED list of the enabled
@@ -60,12 +67,6 @@ enum HostedCard: String, CaseIterable, Identifiable {
 enum HostedCardPrefs {
     /// UserDefaults key — a JSON array of `HostedCard` ids in display order. In the `.noopbak` whitelist.
     static let selectionKey = "today.hostedCards"
-
-    /// The default selection: EMPTY. Nothing is hosted until the user opts in.
-    static let defaultSelection: [HostedCard] = []
-
-    /// Canonical order used to list the not-yet-hosted remainder in the editor.
-    static let canonicalOrder: [HostedCard] = HostedCard.allCases
 
     /// Encode an ordered list of hosted cards into the stored JSON string. Falls back to a comma-joined
     /// string if JSON encoding ever fails (it won't for [String]), so the value is always decodable.

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -3090,7 +3090,10 @@ private struct SleepPerformanceNightScene: View {
 /// with a haptic and a transient line. LOGGING ONLY: a mark never touches the sleep detector or the
 /// night boundaries. Owns `live` (it appends to the strap log) + `repo` (the metric-series write) and
 /// the `lastMark` confirmation state, so its strap-log write keeps working without SleepView observing.
-private struct SleepMarkCard: View {
+/// The "Sleep marks" tap-to-log card. Lives in the Sleep tab but is also hostable in Today
+/// (#today-hosted-cards), so it is `internal` (not `private`) and self-contained — it reads only the
+/// shared `repo`/`live` environment objects, both present on Today too.
+struct SleepMarkCard: View {
     @EnvironmentObject private var repo: Repository
     @EnvironmentObject private var live: LiveState
 

--- a/Strand/Screens/TodayCustomizationMetadata.swift
+++ b/Strand/Screens/TodayCustomizationMetadata.swift
@@ -14,6 +14,7 @@ extension TodaySection {
         case .yourCards: return "rectangle.stack"
         case .menstrualCycle: return "drop.degreesign"
         case .journal: return "book.closed"
+        case .addedCards: return "rectangle.stack.badge.plus"
         }
     }
 
@@ -29,6 +30,7 @@ extension TodaySection {
         case .yourCards: return StrandPalette.accent
         case .menstrualCycle: return StrandPalette.restColor
         case .journal: return StrandPalette.metricAmber
+        case .addedCards: return StrandPalette.accent
         }
     }
 }

--- a/Strand/Screens/TodayCustomizationSheet.swift
+++ b/Strand/Screens/TodayCustomizationSheet.swift
@@ -395,7 +395,8 @@ private struct HostedCardsCustomizationPage: View {
             tint: \.customizationTint,
             configurationLabel: { _ in nil },
             onConfigure: { _ in },
-            onReset: onReset
+            onReset: onReset,
+            allowEmpty: true   // hosting is opt-in: the last card can be un-hosted (Shown may be empty)
         ) {
             EmptyView()
         }

--- a/Strand/Screens/TodayCustomizationSheet.swift
+++ b/Strand/Screens/TodayCustomizationSheet.swift
@@ -8,6 +8,7 @@ enum TodayCustomizationDestination: String, Identifiable, Hashable {
     case today
     case keyMetrics
     case yourCards
+    case addedCards
 
     var id: String { rawValue }
 }
@@ -18,11 +19,13 @@ struct TodayCustomizationSheet: View {
     private enum Route: Hashable {
         case keyMetrics
         case yourCards
+        case addedCards
     }
 
     private let initialSectionDraft: EditableLayoutDraft<TodaySection>
     private let initialKeyMetricDraft: EditableLayoutDraft<KeyMetric>
     private let initialDashboardDraft: EditableLayoutDraft<DashboardCard>
+    private let initialHostedDraft: EditableLayoutDraft<HostedCard>
     private let initialDetailed: Bool
     private let initialWindowDays: Int
 
@@ -32,11 +35,13 @@ struct TodayCustomizationSheet: View {
     @Binding private var keyMetricsDetailed: Bool
     @Binding private var keyMetricsWindowDays: Int
     @Binding private var dashboardCardsRaw: String
+    @Binding private var hostedCardsRaw: String
 
     @State private var path: [Route]
     @State private var sectionDraft: EditableLayoutDraft<TodaySection>
     @State private var keyMetricDraft: EditableLayoutDraft<KeyMetric>
     @State private var dashboardDraft: EditableLayoutDraft<DashboardCard>
+    @State private var hostedDraft: EditableLayoutDraft<HostedCard>
     @State private var detailed: Bool
     @State private var windowDays: Int
 
@@ -44,6 +49,7 @@ struct TodayCustomizationSheet: View {
         switch path.last {
         case .keyMetrics: return .keyMetrics
         case .yourCards: return .yourCards
+        case .addedCards: return .addedCards
         case nil: return .today
         }
     }
@@ -52,6 +58,7 @@ struct TodayCustomizationSheet: View {
         sectionDraft != initialSectionDraft
             || keyMetricDraft != initialKeyMetricDraft
             || dashboardDraft != initialDashboardDraft
+            || hostedDraft != initialHostedDraft
             || detailed != initialDetailed
             || windowDays != initialWindowDays
     }
@@ -63,7 +70,8 @@ struct TodayCustomizationSheet: View {
         keyMetricsRaw: Binding<String>,
         keyMetricsDetailed: Binding<Bool>,
         keyMetricsWindowDays: Binding<Int>,
-        dashboardCardsRaw: Binding<String>
+        dashboardCardsRaw: Binding<String>,
+        hostedCardsRaw: Binding<String>
     ) {
         _sectionOrderRaw = sectionOrderRaw
         _hiddenSectionsRaw = hiddenSectionsRaw
@@ -71,6 +79,7 @@ struct TodayCustomizationSheet: View {
         _keyMetricsDetailed = keyMetricsDetailed
         _keyMetricsWindowDays = keyMetricsWindowDays
         _dashboardCardsRaw = dashboardCardsRaw
+        _hostedCardsRaw = hostedCardsRaw
 
         let fullSectionOrder = TodayLayoutPrefs.decodeOrder(sectionOrderRaw.wrappedValue)
         let hiddenSectionSet = Set(TodayLayoutPrefs.decodeHidden(hiddenSectionsRaw.wrappedValue))
@@ -86,16 +95,22 @@ struct TodayCustomizationSheet: View {
             visible: DashboardCardPrefs.decodeEnabled(dashboardCardsRaw.wrappedValue),
             allItems: DashboardCard.canonicalOrder
         )
+        let hosted = EditableLayoutDraft(
+            visible: HostedCardPrefs.decodeEnabled(hostedCardsRaw.wrappedValue),
+            allItems: HostedCard.canonicalOrder
+        )
 
         initialSectionDraft = sections
         initialKeyMetricDraft = metrics
         initialDashboardDraft = cards
+        initialHostedDraft = hosted
         initialDetailed = keyMetricsDetailed.wrappedValue
         initialWindowDays = keyMetricsWindowDays.wrappedValue
 
         _sectionDraft = State(initialValue: sections)
         _keyMetricDraft = State(initialValue: metrics)
         _dashboardDraft = State(initialValue: cards)
+        _hostedDraft = State(initialValue: hosted)
         _detailed = State(initialValue: keyMetricsDetailed.wrappedValue)
         _windowDays = State(initialValue: keyMetricsWindowDays.wrappedValue)
 
@@ -106,6 +121,8 @@ struct TodayCustomizationSheet: View {
             _path = State(initialValue: [.keyMetrics])
         case .yourCards:
             _path = State(initialValue: [.yourCards])
+        case .addedCards:
+            _path = State(initialValue: [.addedCards])
         }
     }
 
@@ -115,6 +132,7 @@ struct TodayCustomizationSheet: View {
                 draft: $sectionDraft,
                 keyMetricCount: keyMetricDraft.visible.count,
                 dashboardCardCount: dashboardDraft.visible.count,
+                hostedCardCount: hostedDraft.visible.count,
                 onConfigure: openConfiguration,
                 onReset: resetCurrentLayout
             )
@@ -141,6 +159,14 @@ struct TodayCustomizationSheet: View {
                         .toolbar {
                             customizationToolbar(showCancel: false)
                         }
+                case .addedCards:
+                    HostedCardsCustomizationPage(
+                        draft: $hostedDraft,
+                        onReset: resetCurrentLayout
+                    )
+                        .toolbar {
+                            customizationToolbar(showCancel: false)
+                        }
                 }
             }
         }
@@ -160,6 +186,8 @@ struct TodayCustomizationSheet: View {
             path.append(.keyMetrics)
         case .yourCards:
             path.append(.yourCards)
+        case .addedCards:
+            path.append(.addedCards)
         default:
             break
         }
@@ -184,6 +212,11 @@ struct TodayCustomizationSheet: View {
                 visible: DashboardCard.defaultSelection,
                 allItems: DashboardCard.canonicalOrder
             )
+        case .addedCards:
+            hostedDraft = EditableLayoutDraft(
+                visible: HostedCard.defaultSelection,
+                allItems: HostedCard.canonicalOrder
+            )
         }
     }
 
@@ -198,6 +231,7 @@ struct TodayCustomizationSheet: View {
         keyMetricsDetailed = detailed
         keyMetricsWindowDays = windowDays
         dashboardCardsRaw = DashboardCardPrefs.encode(dashboardDraft.visible)
+        hostedCardsRaw = HostedCardPrefs.encode(hostedDraft.visible)
         dismiss()
     }
 
@@ -220,6 +254,7 @@ private struct TodaySectionsCustomizationPage: View {
     @Binding var draft: EditableLayoutDraft<TodaySection>
     let keyMetricCount: Int
     let dashboardCardCount: Int
+    let hostedCardCount: Int
     let onConfigure: (TodaySection) -> Void
     let onReset: () -> Void
 
@@ -250,6 +285,10 @@ private struct TodaySectionsCustomizationPage: View {
             return String(localized: "\(keyMetricCount) metrics shown")
         case .yourCards:
             return String(localized: "\(dashboardCardCount) cards shown")
+        case .addedCards:
+            return hostedCardCount == 0
+                ? String(localized: "None added yet")
+                : String(localized: "\(hostedCardCount) added")
         default:
             return nil
         }
@@ -257,7 +296,7 @@ private struct TodaySectionsCustomizationPage: View {
 
     private func configurationLabel(for section: TodaySection) -> String? {
         switch section {
-        case .keyMetrics, .yourCards:
+        case .keyMetrics, .yourCards, .addedCards:
             return String(localized: "Edit")
         default:
             return nil
@@ -338,6 +377,35 @@ private struct DashboardCardsCustomizationPage: View {
     }
 }
 
+/// The Customise page for the Trends/Sleep cards hosted in Today (#today-hosted-cards). Reuses the shared
+/// Shown/Hidden editor exactly like "Your cards"; the Shown list is the `HostedCardPrefs` selection in
+/// order, the Hidden list is every not-yet-hosted card. Subtitle names the originating tab.
+private struct HostedCardsCustomizationPage: View {
+    @Binding var draft: EditableLayoutDraft<HostedCard>
+    let onReset: () -> Void
+
+    var body: some View {
+        EditableLayoutList(
+            draft: $draft,
+            shownTitle: String(localized: "Added to Today"),
+            hiddenTitle: String(localized: "Available"),
+            title: \.title,
+            subtitle: { String(localized: "from \($0.origin)") },
+            icon: \.customizationIcon,
+            tint: \.customizationTint,
+            configurationLabel: { _ in nil },
+            onConfigure: { _ in },
+            onReset: onReset
+        ) {
+            EmptyView()
+        }
+        .navigationTitle(String(localized: "Added Cards"))
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+    }
+}
+
 #if DEBUG
 #Preview("Customize Today") {
     TodayCustomizationSheet(
@@ -346,7 +414,8 @@ private struct DashboardCardsCustomizationPage: View {
         keyMetricsRaw: .constant(""),
         keyMetricsDetailed: .constant(false),
         keyMetricsWindowDays: .constant(14),
-        dashboardCardsRaw: .constant("")
+        dashboardCardsRaw: .constant(""),
+        hostedCardsRaw: .constant("")
     )
     .preferredColorScheme(.dark)
 }

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -226,6 +226,9 @@ struct TodayView: View {
     // Resting HR). The "CUSTOMISE" link on the section header opens a local sheet (no new nav destination).
     // Persistence is display-only, these cards read the SAME values the rest of Today already loads.
     @AppStorage(DashboardCardPrefs.selectionKey) private var dashboardCardsRaw = ""
+    /// #today-hosted-cards: the ordered Trends/Sleep cards hosted in Today (empty/opt-in). Shared key
+    /// with Android; rendered by the `.addedCards` section.
+    @AppStorage(HostedCardPrefs.selectionKey) private var hostedCardsRaw = ""
     @AppStorage(TodayLayoutPrefs.orderKey) private var sectionOrderRaw = ""
     @AppStorage(TodayLayoutPrefs.hiddenKey) private var hiddenSectionsRaw = ""
     @AppStorage(LiveSessionPrefs.betaKey) private var liveSessionsBeta = true
@@ -1422,7 +1425,8 @@ struct TodayView: View {
                 keyMetricsRaw: $keyMetricsRaw,
                 keyMetricsDetailed: $keyMetricsDetailed,
                 keyMetricsWindowDays: $keyMetricsWindowDays,
-                dashboardCardsRaw: $dashboardCardsRaw
+                dashboardCardsRaw: $dashboardCardsRaw,
+                hostedCardsRaw: $hostedCardsRaw
             )
         }
         #if os(iOS)
@@ -1698,6 +1702,8 @@ struct TodayView: View {
             if selectedDayOffset == 0 { MenstrualCycleHomeCard() }
         case .journal:
             if selectedDayOffset == 0 { JournalReminderCard() }
+        case .addedCards:
+            hostedCardsSection
         }
     }
 
@@ -2169,6 +2175,29 @@ struct TodayView: View {
                     dashboardCardRow(card)
                 }
             }
+        }
+    }
+
+    /// #today-hosted-cards: the Trends/Sleep cards the user hosted in Today, in arranged order. Each is the
+    /// SAME view its home tab renders, carrying its own header, so this section adds none. Renders nothing
+    /// until the user hosts a card (opt-in). TODAY only. Twin of the LiquidTodayView `hostedCardsSection`.
+    @ViewBuilder
+    private var hostedCardsSection: some View {
+        let cards = HostedCardPrefs.decodeEnabled(hostedCardsRaw)
+        if selectedDayOffset == 0 && !cards.isEmpty {
+            VStack(alignment: .leading, spacing: NoopMetrics.sectionGap) {
+                ForEach(cards) { card in
+                    hostedCard(for: card)
+                }
+            }
+        }
+    }
+
+    /// Dispatch a hosted card id to its native view (mirror, not a copy). P0 hosts only Sleep marks.
+    @ViewBuilder
+    private func hostedCard(for card: HostedCard) -> some View {
+        switch card {
+        case .sleepMarks: SleepMarkCard()
         }
     }
 

--- a/StrandTests/HostedCardPrefsTests.swift
+++ b/StrandTests/HostedCardPrefsTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import Strand
+
+/// Pins the Today-hosted card selection (#today-hosted-cards): the origin-namespaced rawValues (a
+/// byte-identical cross-platform contract), the EMPTY opt-in default, and the encode/decode idiom (JSON
+/// array, unknown-id drop, de-dupe, order-preserving). Mirrors the Android `HostedCardPrefsTest`
+/// case-for-case; a drift on either side fails one of the twins.
+final class HostedCardPrefsTests: XCTestCase {
+
+    /// The rawValues are persisted + cross the .noopbak wire, so they are frozen. Origin-namespaced.
+    func testRawValuesAreTheFrozenNamespacedContract() {
+        XCTAssertEqual(HostedCard.sleepMarks.rawValue, "sleep.sleepMarks")
+        // Every id must be origin-namespaced so it routes to the right provider and can't collide with a
+        // Today DashboardCard id.
+        for card in HostedCard.allCases {
+            XCTAssertTrue(card.rawValue.contains("."), "hosted id must be namespaced: \(card.rawValue)")
+        }
+    }
+
+    /// Opt-in surface: nothing is hosted until the user adds a card.
+    func testDefaultIsEmpty() {
+        XCTAssertEqual(HostedCard.defaultSelection, [])
+        XCTAssertEqual(HostedCardPrefs.decodeEnabled(""), [])
+        XCTAssertEqual(HostedCardPrefs.decodeEnabled("   "), [])
+    }
+
+    func testEncodeDecodeRoundTripsInOrder() {
+        let selection: [HostedCard] = [.sleepMarks]
+        let encoded = HostedCardPrefs.encode(selection)
+        XCTAssertEqual(encoded, "[\"sleep.sleepMarks\"]")
+        XCTAssertEqual(HostedCardPrefs.decodeEnabled(encoded), selection)
+    }
+
+    /// Unknown ids are dropped, duplicates collapsed — and an all-unknown decode stays EMPTY (unlike the
+    /// dashboard, an opt-in surface has no sensible non-empty default to back-fill).
+    func testDecodeDropsUnknownAndDedupesNeverBackfills() {
+        XCTAssertEqual(
+            HostedCardPrefs.decodeEnabled("[\"sleep.sleepMarks\",\"trends.bogus\",\"sleep.sleepMarks\"]"),
+            [.sleepMarks]
+        )
+        XCTAssertEqual(HostedCardPrefs.decodeEnabled("[\"nope\",\"also.nope\"]"), [])
+    }
+
+    /// Accepts the legacy comma-joined form as well as the canonical JSON array.
+    func testDecodeAcceptsLegacyCommaForm() {
+        XCTAssertEqual(HostedCardPrefs.decodeEnabled("sleep.sleepMarks"), [.sleepMarks])
+    }
+}

--- a/StrandTests/TodayLayoutPrefsTests.swift
+++ b/StrandTests/TodayLayoutPrefsTests.swift
@@ -14,10 +14,10 @@ final class TodayLayoutPrefsTests: XCTestCase {
     func testEncodeDecodeRoundTripsAReorderedList() {
         let reordered: [TodaySection] = [
             .heartRate, .hero, .yourCards, .liveSession, .synthesis, .keyMetrics, .workouts, .recoveryVitals,
-            .journal, .menstrualCycle,
+            .journal, .menstrualCycle, .addedCards,
         ]
         let encoded = TodayLayoutPrefs.encode(reordered)
-        XCTAssertEqual(encoded, "heartRate,hero,yourCards,liveSession,synthesis,keyMetrics,workouts,recoveryVitals,journal,menstrualCycle")
+        XCTAssertEqual(encoded, "heartRate,hero,yourCards,liveSession,synthesis,keyMetrics,workouts,recoveryVitals,journal,menstrualCycle,addedCards")
         XCTAssertEqual(TodayLayoutPrefs.decodeOrder(encoded), reordered)
     }
 
@@ -28,8 +28,8 @@ final class TodayLayoutPrefsTests: XCTestCase {
         let firstCut = "synthesis,keyMetrics,workouts,heartRate,recoveryVitals,yourCards"
         XCTAssertEqual(
             TodayLayoutPrefs.decodeOrder(firstCut),
-            // journal(8) follows everything saved → appended.
-            [.hero, .liveSession, .synthesis, .keyMetrics, .workouts, .heartRate, .recoveryVitals, .yourCards, .menstrualCycle, .journal]
+            // journal(8) follows everything saved → appended; addedCards(10) is last, appended after it.
+            [.hero, .liveSession, .synthesis, .keyMetrics, .workouts, .heartRate, .recoveryVitals, .yourCards, .menstrualCycle, .journal, .addedCards]
         )
     }
 
@@ -37,7 +37,7 @@ final class TodayLayoutPrefsTests: XCTestCase {
         let partial = "heartRate,synthesis,keyMetrics,recoveryVitals"
         XCTAssertEqual(
             TodayLayoutPrefs.decodeOrder(partial),
-            [.hero, .liveSession, .workouts, .heartRate, .synthesis, .keyMetrics, .recoveryVitals, .yourCards, .menstrualCycle, .journal]
+            [.hero, .liveSession, .workouts, .heartRate, .synthesis, .keyMetrics, .recoveryVitals, .yourCards, .menstrualCycle, .journal, .addedCards]
         )
     }
 
@@ -45,7 +45,7 @@ final class TodayLayoutPrefsTests: XCTestCase {
         let messy = "yourCards,BOGUS,yourCards,heartRate, ,heartRate"
         XCTAssertEqual(
             TodayLayoutPrefs.decodeOrder(messy),
-            [.hero, .liveSession, .synthesis, .keyMetrics, .workouts, .recoveryVitals, .yourCards, .heartRate, .menstrualCycle, .journal]
+            [.hero, .liveSession, .synthesis, .keyMetrics, .workouts, .recoveryVitals, .yourCards, .heartRate, .menstrualCycle, .journal, .addedCards]
         )
     }
 
@@ -63,11 +63,11 @@ final class TodayLayoutPrefsTests: XCTestCase {
         let order = "heartRate,hero,yourCards,liveSession,synthesis,keyMetrics,workouts,recoveryVitals,journal"
         XCTAssertEqual(
             TodayLayoutPrefs.visibleOrder(orderRaw: order, hiddenRaw: "hero,workouts"),
-            [.heartRate, .yourCards, .liveSession, .synthesis, .keyMetrics, .recoveryVitals, .menstrualCycle, .journal]
+            [.heartRate, .yourCards, .liveSession, .synthesis, .keyMetrics, .recoveryVitals, .menstrualCycle, .journal, .addedCards]
         )
         XCTAssertEqual(TodayLayoutPrefs.decodeOrder(order), [
             .heartRate, .hero, .yourCards, .liveSession, .synthesis, .keyMetrics, .workouts,
-            .recoveryVitals, .menstrualCycle, .journal,
+            .recoveryVitals, .menstrualCycle, .journal, .addedCards,
         ])
     }
 
@@ -93,7 +93,7 @@ final class TodayLayoutPrefsTests: XCTestCase {
         // Pin the exact wire strings — they must match the Android TodaySection byte-for-byte.
         XCTAssertEqual(
             raws,
-            ["hero", "liveSession", "synthesis", "keyMetrics", "workouts", "heartRate", "recoveryVitals", "yourCards", "menstrualCycle", "journal"]
+            ["hero", "liveSession", "synthesis", "keyMetrics", "workouts", "heartRate", "recoveryVitals", "yourCards", "menstrualCycle", "journal", "addedCards"]
         )
     }
 

--- a/android/app/src/main/java/com/noop/data/BackupSettings.kt
+++ b/android/app/src/main/java/com/noop/data/BackupSettings.kt
@@ -1,6 +1,7 @@
 package com.noop.data
 
 import android.content.Context
+import com.noop.ui.HostedCardPrefs
 import com.noop.ui.NoopPrefs
 import com.noop.ui.ProfileStore
 import com.noop.ui.UnitPrefs
@@ -54,6 +55,11 @@ object BackupSettingsCodec {
         "units.system" to Kind.STRING,
         "units.temperature" to Kind.STRING,
         "effort.scale" to Kind.STRING,
+        // The ONE layout pref carried (#today-hosted-cards): the Trends/Sleep cards the user chose to host
+        // in Today, a JSON [String] of ids. Unlike section order, this is a deliberate composition the user
+        // built and expects across a restore. Its POSITION (the addedCards slot in today.sectionOrder) is
+        // not carried, so on restore the set + internal order return but the section sits at its default.
+        HostedCardPrefs.KEY_SELECTION to Kind.STRING,
     )
 
     /**
@@ -124,6 +130,9 @@ object BackupSettingsBridge {
         if (noop.contains(UnitPrefs.KEY_EFFORT_SCALE)) {
             noop.getString(UnitPrefs.KEY_EFFORT_SCALE, null)?.let { values["effort.scale"] = it }
         }
+        if (noop.contains(HostedCardPrefs.KEY_SELECTION)) {
+            noop.getString(HostedCardPrefs.KEY_SELECTION, null)?.let { values[HostedCardPrefs.KEY_SELECTION] = it }
+        }
         return BackupSettingsCodec.encode(values)
     }
 
@@ -147,6 +156,7 @@ object BackupSettingsBridge {
             else editor.putString(NoopPrefs.KEY_TEMPERATURE_UNIT, raw)
         }
         (values["effort.scale"] as? String)?.let { editor.putString(UnitPrefs.KEY_EFFORT_SCALE, it) }
+        (values[HostedCardPrefs.KEY_SELECTION] as? String)?.let { editor.putString(HostedCardPrefs.KEY_SELECTION, it) }
         editor.apply()
     }
 }

--- a/android/app/src/main/java/com/noop/ui/HostedCards.kt
+++ b/android/app/src/main/java/com/noop/ui/HostedCards.kt
@@ -1,0 +1,98 @@
+package com.noop.ui
+
+import android.content.Context
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bedtime
+import androidx.compose.ui.graphics.vector.ImageVector
+import org.json.JSONArray
+
+// MARK: - Hosted cards (#today-hosted-cards)
+//
+// Cards that natively live in the Trends or Sleep tab, which the user can ALSO surface inside the Today
+// tab via the Customise sheet — added, removed and reordered like "Your cards", while still appearing in
+// their home tab (mirrored, not moved). Display-only: nothing is computed or stored differently, this
+// just decides which foreign cards Today additionally renders and in what order.
+//
+// The [raw] ids are ORIGIN-NAMESPACED ("sleep.*" / "trends.*") so a hosted id is self-describing and
+// routes to the right provider, and can never collide with a Today DashboardCard id. Keep them
+// byte-identical to the iOS HostedCard enum so a backup/restore reads the same Today composition on
+// either OS — the selection rides .noopbak under the "today.hostedCards" key.
+
+/**
+ * One card that can be hosted in Today from another tab. The [raw] is the stable persisted identifier
+ * (origin-namespaced); keep it byte-identical to the iOS `HostedCard`. [origin] names the source tab,
+ * shown as the editor subtitle.
+ */
+enum class HostedCard(
+    val raw: String,
+    val title: String,
+    val origin: String,
+    val icon: ImageVector,
+) {
+    /** Sleep tab · "Sleep marks" — the tap-to-log going-to-sleep / awake card. Self-contained (logging
+     *  only, no model), the first card wired end-to-end. */
+    SLEEP_MARKS("sleep.sleepMarks", "Sleep marks", "Sleep", Icons.Filled.Bedtime);
+
+    companion object {
+        fun fromRaw(raw: String?): HostedCard? = entries.firstOrNull { it.raw == raw }
+
+        /** The default selection: EMPTY. Nothing is hosted until the user opts in. Mirrors iOS. */
+        val defaultSelection: List<HostedCard> = emptyList()
+
+        /** Canonical order used to list the not-yet-hosted remainder in the editor (matches iOS allCases). */
+        val canonicalOrder: List<HostedCard> = entries.toList()
+    }
+}
+
+/**
+ * Display-only persistence for the Today-hosted card selection. Holds an ORDERED list of the enabled
+ * hosted cards as a JSON-encoded array of ids; a card not in the list is not hosted. Stored in
+ * SharedPreferences under "today.hostedCards" and whitelisted into .noopbak. Mirrors [DashboardCardPrefs]
+ * byte-for-byte EXCEPT the default is EMPTY — hosting is purely additive/opt-in, so a fresh install (and
+ * every existing user) hosts nothing until they add a card in Customise. Mirrors iOS HostedCardPrefs.
+ */
+object HostedCardPrefs {
+    /** The SharedPreferences / canonical backup key. Public so the `.noopbak` bridge can reference it
+     *  instead of a magic string. Byte-identical to the iOS `HostedCardPrefs.selectionKey`. */
+    const val KEY_SELECTION = "today.hostedCards"
+
+    /** The hosted cards in display order. An empty/unset value yields the EMPTY default (nothing hosted). */
+    fun enabled(context: Context): List<HostedCard> =
+        decodeEnabled(NoopPrefs.of(context).getString(KEY_SELECTION, null))
+
+    /** Persist the hosted cards in order. Cards not hosted are simply omitted from the stored string. */
+    fun setEnabled(context: Context, cards: List<HostedCard>) {
+        NoopPrefs.of(context).edit().putString(KEY_SELECTION, encode(cards)).apply()
+    }
+
+    /** Encode an ordered list of hosted cards into the stored JSON-array string (matches the iOS form). */
+    fun encode(cards: List<HostedCard>): String {
+        val arr = JSONArray()
+        cards.forEach { arr.put(it.raw) }
+        return arr.toString()
+    }
+
+    /**
+     * Decode the stored string into an ordered list of hosted cards. An empty/unset string yields the
+     * EMPTY default (nothing hosted). Accepts both the JSON-array form (canonical) and a legacy
+     * comma-joined form. Unknown ids are dropped; duplicates de-duped; returns ONLY the hosted cards in
+     * their saved order. Unlike [DashboardCardPrefs], an all-unknown decode stays EMPTY (never back-fills
+     * a default), because there is no sensible non-empty default for an opt-in surface. Mirrors iOS.
+     */
+    fun decodeEnabled(raw: String?): List<HostedCard> {
+        val trimmed = raw?.trim().orEmpty()
+        if (trimmed.isEmpty()) return HostedCard.defaultSelection
+
+        val ids: List<String> = parseJsonArray(trimmed)
+            ?: trimmed.split(",").map { it.trim() }
+
+        val seen = LinkedHashSet<HostedCard>()
+        ids.forEach { token -> HostedCard.fromRaw(token)?.let { seen.add(it) } }
+        return seen.toList()
+    }
+
+    private fun parseJsonArray(s: String): List<String>? = runCatching {
+        val arr = JSONArray(s)
+        (0 until arr.length()).map { arr.getString(it) }
+    }.getOrNull()
+}

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -796,8 +796,10 @@ fun SleepScreen(
 // on this screen; it's a record for later tap-driven sleep bounds + calibration. Mirrors macOS
 // SleepView.sleepMarkCard.
 
+// Lives in the Sleep tab but also hostable in Today (#today-hosted-cards), so it is `internal` (not
+// private). Self-contained apart from the [onMark] persistence callback the host supplies.
 @Composable
-private fun SleepMarkCard(onMark: (SleepMarkType) -> Unit) {
+internal fun SleepMarkCard(onMark: (SleepMarkType) -> Unit) {
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
         SectionHeader(title = uiString(R.string.l10n_sleep_screen_sleep_marks_8e9b86f0), overline = "Tap to log", trailing = "Phase 1")
         NoopCard(tint = Palette.restColor) {

--- a/android/app/src/main/java/com/noop/ui/TodayLayoutPrefs.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayLayoutPrefs.kt
@@ -30,7 +30,12 @@ enum class TodaySection(val raw: String, val title: String) {
     RECOVERY_VITALS("recoveryVitals", "Recovery Vitals"),
     YOUR_CARDS("yourCards", "Your Cards"),
     MENSTRUAL_CYCLE("menstrualCycle", "Menstrual Cycle"),
-    JOURNAL("journal", "Journal");
+    JOURNAL("journal", "Journal"),
+
+    /** Cards hosted from the Trends / Sleep tabs (#today-hosted-cards). Renders the [HostedCardPrefs]
+     *  selection in order; empty (and effectively invisible) until the user adds a card in Customise.
+     *  Appended LAST so [decodeOrder]'s back-fill lands it predictably for existing saved orders. */
+    ADDED_CARDS("addedCards", "Added Cards");
 
     companion object {
         fun fromRaw(raw: String?): TodaySection? = entries.firstOrNull { it.raw == raw }
@@ -39,7 +44,7 @@ enum class TodaySection(val raw: String, val title: String) {
          *  journal widget (#656) is last by default, where it was first added, above the data-sources card. */
         val defaultOrder: List<TodaySection> = listOf(
             HERO, LIVE_SESSION, SYNTHESIS, KEY_METRICS, WORKOUTS, HEART_RATE, RECOVERY_VITALS, YOUR_CARDS,
-            MENSTRUAL_CYCLE, JOURNAL,
+            MENSTRUAL_CYCLE, JOURNAL, ADDED_CARDS,
         )
     }
 }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3526,7 +3526,12 @@ internal fun <T> EditableVisibilityRows(
     hidden: MutableList<T>,
     itemTitle: (T) -> String,
     modifier: Modifier = Modifier,
+    // Whether the Shown list may go EMPTY. Default false — the last shown item can't be hidden, so
+    // surfaces needing >=1 item can't be emptied. The hosted-cards editor (#today-hosted-cards) passes
+    // true (opt-in: un-hosting the last card is valid).
+    allowEmpty: Boolean = false,
 ) {
+    val minShown = if (allowEmpty) 0 else 1
     Column(
         modifier = modifier
             .heightIn(max = Metrics.editorListMaxHeight)
@@ -3570,15 +3575,15 @@ internal fun <T> EditableVisibilityRows(
                 }
                 IconButton(
                     onClick = {
-                        if (shown.size > 1) hidden.add(shown.removeAt(index))
+                        if (shown.size > minShown) hidden.add(shown.removeAt(index))
                     },
-                    enabled = shown.size > 1,
+                    enabled = shown.size > minShown,
                     modifier = Modifier.size(Metrics.iconButton),
                 ) {
                     Icon(
                         Icons.Filled.Close,
                         contentDescription = stringResource(R.string.today_customize_hide, title),
-                        tint = if (shown.size > 1) Palette.textSecondary else Palette.textTertiary,
+                        tint = if (shown.size > minShown) Palette.textSecondary else Palette.textTertiary,
                         modifier = Modifier.size(Metrics.iconSmall),
                     )
                 }
@@ -3732,6 +3737,7 @@ private fun HostedCardsEditorDialog(
                     shown = shown,
                     hidden = hidden,
                     itemTitle = { it.title },
+                    allowEmpty = true,   // hosting is opt-in: un-hosting the last card is valid
                 )
 
                 Row(verticalAlignment = Alignment.CenterVertically) {

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -139,6 +139,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import android.app.DatePickerDialog
 import android.view.HapticFeedbackConstants
+import android.widget.Toast
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.noop.R
 import com.noop.analytics.Baselines
@@ -148,6 +149,8 @@ import com.noop.analytics.HydrationGoal
 import com.noop.analytics.HydrationStore
 import com.noop.analytics.ReadinessEngine
 import com.noop.analytics.ScoreConfidence
+import com.noop.analytics.SleepMark
+import com.noop.analytics.SleepMarkType
 import com.noop.analytics.StepsEstimateEngine
 import com.noop.analytics.StrainScorer
 import com.noop.data.DailyMetric
@@ -447,6 +450,10 @@ fun TodayScreen(
     // SharedPreferences isn't reactive, so it's mirrored into local state and re-read when the editor saves.
     var showDashboardEditor by remember { mutableStateOf(false) }
     var enabledDashboardCards by remember { mutableStateOf(DashboardCardPrefs.enabled(context)) }
+    // #today-hosted-cards: the Trends/Sleep cards hosted in Today (empty/opt-in). Mirrored into local
+    // state like the dashboard selection and re-read when the hosted-cards editor saves.
+    var showHostedEditor by remember { mutableStateOf(false) }
+    var enabledHostedCards by remember { mutableStateOf(HostedCardPrefs.enabled(context)) }
 
     // The pinned "Your cards" values (Stress / Fitness age / Vitality), surfaced on Today so the buried
     // Explore features sit on the home screen (#582). The same merged resolvedSeries reads their detail
@@ -1361,6 +1368,8 @@ fun TodayScreen(
                         (cycleOptInApplies(profileStore.sex) || cycleEnabled || periodStarts.isNotEmpty())
                 TodaySection.JOURNAL ->
                     selectedDayOffset == 0 && journalReminderOn
+                TodaySection.ADDED_CARDS ->
+                    selectedDayOffset == 0 && enabledHostedCards.isNotEmpty()
                 else -> true
             }
             if (!sectionVisible) return@forEach
@@ -1579,6 +1588,12 @@ fun TodayScreen(
                             days = days,
                             onOpenJournal = onOpenJournal,
                         )
+                        // #today-hosted-cards: the Trends/Sleep cards the user pulled into Today, in
+                        // arranged order. Each is the SAME card its home tab renders (a mirror).
+                        TodaySection.ADDED_CARDS -> HostedCardsSection(
+                            cards = enabledHostedCards,
+                            viewModel = viewModel,
+                        )
                     }
                 }
             }
@@ -1716,13 +1731,32 @@ fun TodayScreen(
         )
     }
 
+    // #today-hosted-cards: the add/remove/reorder editor for the Trends/Sleep cards hosted in Today. Saves
+    // the selection and re-reads it into local state so the Added-cards section reflects it immediately.
+    if (showHostedEditor) {
+        HostedCardsEditorDialog(
+            initial = enabledHostedCards,
+            onDismiss = { showHostedEditor = false },
+            onSave = { cards ->
+                HostedCardPrefs.setEnabled(context, cards)
+                enabledHostedCards = cards
+                showHostedEditor = false
+            },
+        )
+    }
+
     // #today-layout: the section-order editor (reorder the below-hero sections). Saves the order and
-    // re-reads it into local state so Today re-lays-out immediately and survives relaunch.
+    // re-reads it into local state so Today re-lays-out immediately and survives relaunch. Its "Edit added
+    // cards" button hands off to the hosted-cards editor above (#today-hosted-cards).
     if (showLayoutEditor) {
         TodayLayoutEditorDialog(
             initialOrder = sectionOrder,
             initialHidden = hiddenSections,
             onDismiss = { showLayoutEditor = false },
+            onEditAdded = {
+                showLayoutEditor = false
+                showHostedEditor = true
+            },
             onSave = { order, hidden ->
                 TodayLayoutPrefs.setOrder(context, order)
                 TodayLayoutPrefs.setHidden(context, hidden)
@@ -3024,6 +3058,37 @@ private fun TodayEditAction(
     }
 }
 
+/**
+ * #today-hosted-cards render: the Trends/Sleep cards hosted in Today, in arranged order. Each case renders
+ * the SAME card its home tab uses (a mirror, not a copy) so the two never diverge. P0 hosts only Sleep
+ * marks; its logging callback mirrors the Sleep tab's exactly (external log + metric-series upsert +
+ * confirmation toast). Renders nothing when [cards] is empty. Twin of the iOS `hostedCardsSection`.
+ */
+@Composable
+private fun HostedCardsSection(cards: List<HostedCard>, viewModel: AppViewModel) {
+    if (cards.isEmpty()) return
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    Column(verticalArrangement = Arrangement.spacedBy(Metrics.sectionGap)) {
+        cards.forEach { card ->
+            when (card) {
+                HostedCard.SLEEP_MARKS -> SleepMarkCard(
+                    onMark = { type ->
+                        val mark = SleepMark.now(type)
+                        viewModel.ble.externalLog(mark.logLine())
+                        scope.launch {
+                            runCatching {
+                                viewModel.repo.upsertMetricSeries(listOf(mark.metricPoint("my-whoop")))
+                            }
+                        }
+                        Toast.makeText(context, mark.confirmation(), Toast.LENGTH_SHORT).show()
+                    }
+                )
+            }
+        }
+    }
+}
+
 @Composable
 private fun YourCardsSection(
     cards: List<DashboardCard>,
@@ -3629,6 +3694,70 @@ private fun DashboardCardsEditorDialog(
     }
 }
 
+/**
+ * #today-hosted-cards: the add/remove/reorder editor for the Trends/Sleep cards hosted in Today. Clone of
+ * [DashboardCardsEditorDialog] over [HostedCard], with ONE difference — Done is always enabled, because an
+ * EMPTY hosted set is valid (the feature is opt-in; hosting nothing simply hides the Added-cards section).
+ * Reuses the shared [EditableVisibilityRows]. Twin of the iOS `HostedCardsCustomizationPage`.
+ */
+@Composable
+private fun HostedCardsEditorDialog(
+    initial: List<HostedCard>,
+    onDismiss: () -> Unit,
+    onSave: (List<HostedCard>) -> Unit,
+) {
+    val shown = remember { mutableStateListOf<HostedCard>().apply { addAll(initial) } }
+    val hidden = remember {
+        mutableStateListOf<HostedCard>().apply {
+            addAll(HostedCard.canonicalOrder.filter { it !in initial })
+        }
+    }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(color = Palette.surfaceOverlay, shape = RoundedCornerShape(16.dp)) {
+            Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text(stringResource(R.string.today_hosted_editor_title), style = NoopType.title2, color = Palette.textPrimary)
+                    Text(
+                        stringResource(R.string.today_hosted_editor_desc),
+                        style = NoopType.subhead,
+                        color = Palette.textSecondary,
+                    )
+                }
+
+                EditableVisibilityRows(
+                    shown = shown,
+                    hidden = hidden,
+                    itemTitle = { it.title },
+                )
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    TextButton(
+                        onClick = {
+                            shown.clear()
+                            shown.addAll(HostedCard.defaultSelection)
+                            hidden.clear()
+                            hidden.addAll(HostedCard.canonicalOrder.filter { it !in shown })
+                        },
+                        colors = ButtonDefaults.textButtonColors(contentColor = Palette.textSecondary),
+                    ) { Text(uiString(R.string.l10n_today_screen_reset_44c57abd), style = NoopType.body) }
+                    Spacer(Modifier.weight(1f))
+                    Button(
+                        onClick = { onSave(shown.toList()) },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Palette.accent,
+                            contentColor = Palette.surfaceBase,
+                        ),
+                    ) { Text(uiString(R.string.l10n_today_screen_done_e9b450d1), style = NoopType.captionNumber) }
+                }
+            }
+        }
+    }
+}
+
 // #today-layout (hold-to-drag): LazyColumn key prefix for the reorderable section items, so the drag can
 // tell a section item from the pinned rows around it.
 private const val TODAY_SECTION_KEY_PREFIX = "todaySection:"
@@ -3820,6 +3949,7 @@ private fun TodayLayoutEditorDialog(
     initialOrder: List<TodaySection>,
     initialHidden: List<TodaySection>,
     onDismiss: () -> Unit,
+    onEditAdded: () -> Unit,
     onSave: (List<TodaySection>, List<TodaySection>) -> Unit,
 ) {
     val hiddenSet = remember(initialHidden) { initialHidden.toSet() }
@@ -3850,6 +3980,17 @@ private fun TodayLayoutEditorDialog(
                     hidden = hidden,
                     itemTitle = { it.title },
                 )
+
+                // #today-hosted-cards: hand-off to the editor that chooses WHICH Trends/Sleep cards the
+                // "Added Cards" section hosts (the section row above only reorders/hides the section).
+                TextButton(
+                    onClick = onEditAdded,
+                    colors = ButtonDefaults.textButtonColors(contentColor = Palette.accent),
+                ) {
+                    Icon(Icons.Filled.Add, contentDescription = null, modifier = Modifier.size(Metrics.iconSmall))
+                    Spacer(Modifier.width(Metrics.space6))
+                    Text(stringResource(R.string.today_customize_edit_added_cards), style = NoopType.body)
+                }
 
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     TextButton(

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -56,6 +56,9 @@
     <string name="today_customize_title">Heute anpassen</string>
     <string name="today_customize_action">Anpassen</string>
     <string name="today_customize_description">Ordne sichtbare Elemente neu an oder verschiebe einen Abschnitt nach „Ausgeblendet“, ohne ihn zu löschen.</string>
+    <string name="today_customize_edit_added_cards">Hinzugefügte Karten bearbeiten</string>
+    <string name="today_hosted_editor_title">Hinzugefügte Karten</string>
+    <string name="today_hosted_editor_desc">Wähle, welche Trends- und Schlaf-Karten auf „Heute“ erscheinen. Sie bleiben auch in ihren eigenen Tabs.</string>
     <string name="sleep_customize_title">Schlaf anpassen</string>
     <string name="sleep_customize_description">Ordne sichtbare Elemente neu an oder verschiebe einen Abschnitt nach „Ausgeblendet“, ohne ihn zu löschen.</string>
     <string name="today_customize_shown">ANGEZEIGT</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1566,6 +1566,9 @@
     <string name="today_customize_title">Personalizar Hoy</string>
     <string name="today_customize_action">Personalizar</string>
     <string name="today_customize_description">Reordena lo que se muestra o mueve una sección a Ocultos sin eliminarla.</string>
+    <string name="today_customize_edit_added_cards">Editar tarjetas añadidas</string>
+    <string name="today_hosted_editor_title">Tarjetas añadidas</string>
+    <string name="today_hosted_editor_desc">Elige qué tarjetas de Tendencias y Sueño se muestran en Hoy. También permanecen en sus propias pestañas.</string>
     <string name="sleep_customize_title">Personalizar Sueño</string>
     <string name="sleep_customize_description">Reordena lo que se muestra o mueve una sección a Ocultos sin eliminarla.</string>
     <string name="today_customize_shown">VISIBLES</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1566,6 +1566,9 @@
     <string name="today_customize_title">Personnaliser Aujourd’hui</string>
     <string name="today_customize_action">Personnaliser</string>
     <string name="today_customize_description">Réorganisez les éléments affichés ou déplacez une section dans Masqués sans la supprimer.</string>
+    <string name="today_customize_edit_added_cards">Modifier les cartes ajoutées</string>
+    <string name="today_hosted_editor_title">Cartes ajoutées</string>
+    <string name="today_hosted_editor_desc">Choisissez les cartes Tendances et Sommeil affichées dans Aujourd\'hui. Elles restent aussi dans leurs propres onglets.</string>
     <string name="sleep_customize_title">Personnaliser le sommeil</string>
     <string name="sleep_customize_description">Réorganisez les éléments affichés ou déplacez une section dans Masqués sans la supprimer.</string>
     <string name="today_customize_shown">AFFICHÉS</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -52,6 +52,9 @@
     <string name="today_customize_title">Personalizar Hoje</string>
     <string name="today_customize_action">Personalizar</string>
     <string name="today_customize_description">Reordena o que é mostrado ou move uma secção para Ocultos sem a apagar.</string>
+    <string name="today_customize_edit_added_cards">Editar cartões adicionados</string>
+    <string name="today_hosted_editor_title">Cartões adicionados</string>
+    <string name="today_hosted_editor_desc">Escolhe que cartões de Tendências e Sono aparecem em Hoje. Também permanecem nos seus próprios separadores.</string>
     <string name="sleep_customize_title">Personalizar Sono</string>
     <string name="sleep_customize_description">Reordena o que é mostrado ou move uma secção para Ocultos sem a apagar.</string>
     <string name="today_customize_shown">MOSTRADOS</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -50,6 +50,9 @@
     <string name="today_customize_title">自定义“今天”</string>
     <string name="today_customize_action">自定义</string>
     <string name="today_customize_description">重新排序已显示内容，或将某个部分移至“已隐藏”而不删除。</string>
+    <string name="today_customize_edit_added_cards">编辑已添加的卡片</string>
+    <string name="today_hosted_editor_title">已添加的卡片</string>
+    <string name="today_hosted_editor_desc">选择在“今天”中显示哪些趋势和睡眠卡片。它们也会保留在各自的标签页中。</string>
     <string name="sleep_customize_title">自定义睡眠</string>
     <string name="sleep_customize_description">重新排序已显示内容，或将某个部分移至“已隐藏”而不删除。</string>
     <string name="today_customize_shown">已显示</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -62,6 +62,9 @@
     <string name="today_customize_title">Customize Today</string>
     <string name="today_customize_action">Customize</string>
     <string name="today_customize_description">Reorder what is shown, or move a section to Hidden without deleting it.</string>
+    <string name="today_customize_edit_added_cards">Edit added cards</string>
+    <string name="today_hosted_editor_title">Added cards</string>
+    <string name="today_hosted_editor_desc">Choose which Trends and Sleep cards show on Today. They stay in their own tabs too.</string>
     <string name="sleep_customize_title">Customize Sleep</string>
     <string name="sleep_customize_description">Reorder what is shown, or move a section to Hidden without deleting it.</string>
     <string name="today_customize_shown">SHOWN</string>

--- a/android/app/src/test/java/com/noop/data/BackupSettingsCodecTest.kt
+++ b/android/app/src/test/java/com/noop/data/BackupSettingsCodecTest.kt
@@ -38,6 +38,8 @@ class BackupSettingsCodecTest {
             "units.system" to "imperial",
             "units.temperature" to "celsius",
             "effort.scale" to "whoop",
+            // #today-hosted-cards: the one layout pref carried, a JSON [String] stored under the String kind.
+            "today.hostedCards" to "[\"sleep.sleepMarks\"]",
         )
         val json = requireNotNull(BackupSettingsCodec.encode(values))
         val back = BackupSettingsCodec.decode(json)
@@ -51,6 +53,7 @@ class BackupSettingsCodecTest {
         assertEquals("imperial", back["units.system"])
         assertEquals("celsius", back["units.temperature"])
         assertEquals("whoop", back["effort.scale"])
+        assertEquals("[\"sleep.sleepMarks\"]", back["today.hostedCards"])
         assertEquals(values.size, back.size)
     }
 

--- a/android/app/src/test/java/com/noop/ui/HostedCardPrefsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/HostedCardPrefsTest.kt
@@ -1,0 +1,59 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-logic coverage for the Today-hosted card selection (#today-hosted-cards): the origin-namespaced
+ * rawValues (a byte-identical cross-platform contract), the EMPTY opt-in default, and the encode/decode
+ * idiom (JSON array, unknown-id drop, de-dupe, order-preserving). Mirrors the macOS HostedCardPrefs tests;
+ * a drift on either side fails one of the twins.
+ */
+class HostedCardPrefsTest {
+
+    /** The rawValues are persisted + cross the .noopbak wire, so they are frozen. Origin-namespaced. */
+    @Test
+    fun rawValues_areTheFrozenNamespacedContract() {
+        assertEquals("sleep.sleepMarks", HostedCard.SLEEP_MARKS.raw)
+        // Every id must be origin-namespaced so it routes to the right provider and can't collide with a
+        // Today DashboardCard id.
+        HostedCard.entries.forEach { card ->
+            assertTrue("hosted id must be namespaced: ${card.raw}", card.raw.contains('.'))
+        }
+    }
+
+    /** Opt-in surface: nothing is hosted until the user adds a card. */
+    @Test
+    fun default_isEmpty() {
+        assertEquals(emptyList<HostedCard>(), HostedCard.defaultSelection)
+        assertEquals(emptyList<HostedCard>(), HostedCardPrefs.decodeEnabled(null))
+        assertEquals(emptyList<HostedCard>(), HostedCardPrefs.decodeEnabled(""))
+        assertEquals(emptyList<HostedCard>(), HostedCardPrefs.decodeEnabled("   "))
+    }
+
+    @Test
+    fun encodeDecode_roundTripsInOrder() {
+        val selection = listOf(HostedCard.SLEEP_MARKS)
+        val encoded = HostedCardPrefs.encode(selection)
+        assertEquals("[\"sleep.sleepMarks\"]", encoded)
+        assertEquals(selection, HostedCardPrefs.decodeEnabled(encoded))
+    }
+
+    /** Unknown ids are dropped, duplicates collapsed — and an all-unknown decode stays EMPTY (unlike the
+     *  dashboard, an opt-in surface has no sensible non-empty default to back-fill). */
+    @Test
+    fun decode_dropsUnknownAndDedupes_neverBackfills() {
+        assertEquals(
+            listOf(HostedCard.SLEEP_MARKS),
+            HostedCardPrefs.decodeEnabled("[\"sleep.sleepMarks\",\"trends.bogus\",\"sleep.sleepMarks\"]"),
+        )
+        assertEquals(emptyList<HostedCard>(), HostedCardPrefs.decodeEnabled("[\"nope\",\"also.nope\"]"))
+    }
+
+    /** Accepts the legacy comma-joined form as well as the canonical JSON array. */
+    @Test
+    fun decode_acceptsLegacyCommaForm() {
+        assertEquals(listOf(HostedCard.SLEEP_MARKS), HostedCardPrefs.decodeEnabled("sleep.sleepMarks"))
+    }
+}

--- a/android/app/src/test/java/com/noop/ui/TodayLayoutPrefsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/TodayLayoutPrefsTest.kt
@@ -24,11 +24,11 @@ class TodayLayoutPrefsTest {
             TodaySection.HEART_RATE, TodaySection.HERO, TodaySection.YOUR_CARDS,
             TodaySection.LIVE_SESSION, TodaySection.SYNTHESIS, TodaySection.KEY_METRICS,
             TodaySection.WORKOUTS, TodaySection.RECOVERY_VITALS, TodaySection.JOURNAL,
-            TodaySection.MENSTRUAL_CYCLE,
+            TodaySection.MENSTRUAL_CYCLE, TodaySection.ADDED_CARDS,
         )
         val encoded = TodayLayoutPrefs.encode(reordered)
         assertEquals(
-            "heartRate,hero,yourCards,liveSession,synthesis,keyMetrics,workouts,recoveryVitals,journal,menstrualCycle",
+            "heartRate,hero,yourCards,liveSession,synthesis,keyMetrics,workouts,recoveryVitals,journal,menstrualCycle,addedCards",
             encoded,
         )
         assertEquals(reordered, TodayLayoutPrefs.decodeOrder(encoded))
@@ -45,7 +45,7 @@ class TodayLayoutPrefsTest {
                 TodaySection.HERO, TodaySection.LIVE_SESSION,
                 TodaySection.SYNTHESIS, TodaySection.KEY_METRICS, TodaySection.WORKOUTS,
                 TodaySection.HEART_RATE, TodaySection.RECOVERY_VITALS, TodaySection.YOUR_CARDS,
-                TodaySection.MENSTRUAL_CYCLE, TodaySection.JOURNAL,
+                TodaySection.MENSTRUAL_CYCLE, TodaySection.JOURNAL, TodaySection.ADDED_CARDS,
             ),
             TodayLayoutPrefs.decodeOrder(firstCut),
         )
@@ -66,6 +66,7 @@ class TodayLayoutPrefsTest {
                 TodaySection.HEART_RATE, TodaySection.SYNTHESIS, TodaySection.KEY_METRICS,
                 TodaySection.RECOVERY_VITALS,
                 TodaySection.YOUR_CARDS, TodaySection.MENSTRUAL_CYCLE, TodaySection.JOURNAL,
+                TodaySection.ADDED_CARDS,
             ),
             decoded,
         )
@@ -83,7 +84,7 @@ class TodayLayoutPrefsTest {
                 TodaySection.HERO, TodaySection.LIVE_SESSION, TodaySection.SYNTHESIS,
                 TodaySection.KEY_METRICS, TodaySection.WORKOUTS, TodaySection.RECOVERY_VITALS,
                 TodaySection.YOUR_CARDS, TodaySection.HEART_RATE,
-                TodaySection.MENSTRUAL_CYCLE, TodaySection.JOURNAL,
+                TodaySection.MENSTRUAL_CYCLE, TodaySection.JOURNAL, TodaySection.ADDED_CARDS,
             ),
             decoded,
         )
@@ -108,7 +109,7 @@ class TodayLayoutPrefsTest {
             listOf(
                 TodaySection.HEART_RATE, TodaySection.YOUR_CARDS, TodaySection.LIVE_SESSION,
                 TodaySection.SYNTHESIS, TodaySection.KEY_METRICS, TodaySection.RECOVERY_VITALS,
-                TodaySection.MENSTRUAL_CYCLE, TodaySection.JOURNAL,
+                TodaySection.MENSTRUAL_CYCLE, TodaySection.JOURNAL, TodaySection.ADDED_CARDS,
             ),
             TodayLayoutPrefs.visibleOrder(order, "hero,workouts"),
         )
@@ -141,6 +142,7 @@ class TodayLayoutPrefsTest {
             listOf(
                 "hero", "liveSession", "synthesis", "keyMetrics",
                 "workouts", "heartRate", "recoveryVitals", "yourCards", "menstrualCycle", "journal",
+                "addedCards",
             ),
             raws,
         )


### PR DESCRIPTION
First cut of **hosting Trends/Sleep cards in the Today tab** (#today-hosted-cards): add/remove them via Customise, reorder within Today, while they still appear in their home tabs. This P0 lands the **whole pipeline end-to-end** with one already-portable card (**Sleep marks**); the Sleep-detail and Trends cards that need model extraction follow in P1/P2 (see the plan).

### What P0 adds
- **`HostedCard` + `HostedCardPrefs`** — origin-namespaced ids (`sleep.sleepMarks`), JSON-array persistence under `today.hostedCards`, **empty opt-in default** (nothing hosted until the user adds one). Mirrors `DashboardCardPrefs` but default-empty.
- **`TodaySection.addedCards`** — a new reorderable Today section (appended to `defaultOrder`) that renders hosted cards in arranged order. Headerless: each hosted card is the **same view** its home tab renders (a mirror, no data divergence).
- **Customise** — iOS: an "Added Cards" page in the unified sheet. Android: a hosted-cards editor reached from the layout dialog. Reuses the shared editor (`EditableLayoutList` / `EditableVisibilityRows`); Done always enabled (empty is valid). `SleepMarkCard` made `internal` so Today can host it.
- **Backup** — `today.hostedCards` added to the `.noopbak` whitelist (String) on both platforms: the one layout pref carried, since it's a deliberate composition the user built. Its section *position* isn't carried (stays default on restore).

### Parity + verification
- Four new byte-identical Swift↔Kotlin surfaces (enum rawValues, `today.hostedCards`, `addedCards`, whitelist entry) — all pinned by tests.
- **Android**: `compileFullDebugKotlin` clean; `HostedCardPrefsTest` / `TodayLayoutPrefsTest` / `BackupSettingsCodecTest` pass; `i18n_audit.py --ci` green (new strings localized de/es/fr/pt-PT/zh + iOS xcstrings).
- **iOS app-target** (new section, sheet page, both Today views, `SleepMarkCard`): no default CI covers it — validating via the on-demand app-build gate (Build + Test Strand + iOS).
- **Backup codec** (`Packages/WhoopStore`): covered by default `swift-packages.yml`.

Default-off / additive: nothing changes for existing users until they host a card.