### PR TITLE
Today: host the Asleep-duration Sleep card (P1 — first Sleep detail card)

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -654,6 +654,7 @@ struct LiquidTodayView: View {
     private func hostedCard(for card: HostedCard) -> some View {
         switch card {
         case .sleepMarks: SleepMarkCard()
+        case .asleepDuration: AsleepDurationCard(data: AsleepDurationData.build(days: repo.days))
         }
     }
 

--- a/Strand/Screens/AsleepDurationCard.swift
+++ b/Strand/Screens/AsleepDurationCard.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+import StrandDesign
+import WhoopStore
+
+// MARK: - Asleep duration trend (#today-hosted-cards)
+//
+// The Sleep tab's "Asleep duration" card, extracted into a standalone view so it can ALSO be hosted in
+// the Today tab. Both the Sleep tab and the Today host render THIS view from the SAME `AsleepDurationData`,
+// so the number can never diverge between the two surfaces (the parity contract). The card body is a
+// verbatim lift of the former `SleepView.durationTrend`; the data builder is a verbatim lift of
+// `SleepView.durationTrendPoints` + `typicalTotalMin`.
+
+/// Pure inputs for the asleep-duration card: trailing-30-night sleep hours + the typical mean minutes.
+/// Built identically by the Sleep tab and by a Today host so the two never diverge.
+struct AsleepDurationData {
+    let points: [TrendPoint]
+    let typicalTotalMin: Double?
+
+    /// yyyy-MM-dd → Date (en_US_POSIX, UTC) — matches `SleepView.dayParser`.
+    private static let dayParser: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+
+    /// Trailing 30 days of total sleep in HOURS, falling back to all nights with data when the trailing
+    /// window is too sparse (verbatim of `SleepView.durationTrendPoints`). `typicalTotalMin` is the mean
+    /// asleep minutes across nights with data (verbatim of `SleepView.typicalTotalMin`).
+    static func build(days: [DailyMetric]) -> AsleepDurationData {
+        func mk(_ slice: ArraySlice<DailyMetric>) -> [TrendPoint] {
+            slice.compactMap { d -> TrendPoint? in
+                guard let mins = d.totalSleepMin, mins > 0,
+                      let date = dayParser.date(from: d.day) else { return nil }
+                return TrendPoint(date: date, value: mins / 60.0)
+            }
+        }
+        let recent = mk(days.suffix(30))
+        let points = recent.count >= 2 ? recent : mk(days[...])
+        let totals = days.compactMap { $0.totalSleepMin }.filter { $0 > 0 }
+        let typical = totals.isEmpty ? nil : totals.reduce(0, +) / Double(totals.count)
+        return AsleepDurationData(points: points, typicalTotalMin: typical)
+    }
+}
+
+/// The "Asleep duration" trend card. Renders [AsleepDurationData] with the shared chart components.
+struct AsleepDurationCard: View {
+    let data: AsleepDurationData
+
+    var body: some View {
+        let pts = data.points
+        let avg = data.typicalTotalMin.map { $0 / 60.0 }
+        VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+            SectionHeader("Asleep duration", overline: "Trend")
+            ChartCard(
+                title: "Hours asleep",
+                subtitle: String(localized: "Per night, trailing 30 days"),
+                trailing: avg.map { String(localized: "\(String(format: "%.1f", $0)) h avg") },
+                height: NoopMetrics.chartHeight,
+                tint: StrandPalette.restColor,
+                chart: {
+                    if pts.count >= 2 {
+                        TrendChart(points: pts,
+                                   gradient: StrandPalette.restGradient,
+                                   valueRange: Self.trendRange(pts),
+                                   showsBars: true,
+                                   height: NoopMetrics.chartHeight,
+                                   valueFormat: { String(format: "%.1f h", $0) },
+                                   accessibilityLabel: String(localized: "Hours asleep trend"))
+                    } else {
+                        Self.sparsePlaceholder
+                    }
+                },
+                footer: {
+                    HStack {
+                        ChartFooter([
+                            ("Avg",    avg.map { String(format: "%.1f h", $0) } ?? "—"),
+                            ("Min",    pts.map(\.value).min().map { String(format: "%.1f h", $0) } ?? "—"),
+                            ("Max",    pts.map(\.value).max().map { String(format: "%.1f h", $0) } ?? "—"),
+                            ("Nights", "\(pts.count)"),
+                        ])
+                        durationTrendStat(pts)
+                    }
+                }
+            )
+        }
+    }
+
+    /// A padded value range so the line isn't flat against the axis (verbatim of `SleepView.trendRange`).
+    private static func trendRange(_ pts: [TrendPoint]) -> ClosedRange<Double> {
+        let vals = pts.map(\.value)
+        let lo = Swift.max(0, (vals.min() ?? 0) - 1)
+        let hi = (vals.max() ?? 9) + 1
+        return lo...Swift.max(hi, lo + 1)
+    }
+
+    private static var sparsePlaceholder: some View {
+        Text("Not enough nights yet.")
+            .font(StrandFont.subhead)
+            .foregroundStyle(StrandPalette.textTertiary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            .background(NoopPanelSurface(tint: StrandPalette.restColor, cornerRadius: 12))
+    }
+
+    /// Recent-half mean minus earlier-half mean (verbatim of `SleepView.durationTrendChange`). Direction
+    /// is neutral: more sleep isn't automatically better, so the chip conveys movement without a verdict.
+    private static func durationTrendChange(_ points: [TrendPoint]) -> Double? {
+        guard points.count >= 4 else { return nil }
+        let midpoint = points.count / 2
+        let earlier = points.prefix(midpoint).map(\.value)
+        let recent = points.suffix(points.count - midpoint).map(\.value)
+        guard !earlier.isEmpty, !recent.isEmpty else { return nil }
+        return recent.reduce(0, +) / Double(recent.count)
+            - earlier.reduce(0, +) / Double(earlier.count)
+    }
+
+    @ViewBuilder
+    private func durationTrendStat(_ points: [TrendPoint]) -> some View {
+        let delta = Self.durationTrendChange(points)
+        let deltaText = delta.map {
+            let sign = $0 >= 0 ? "+" : "−"
+            return "\(sign)\(String(format: "%.1f h", abs($0)))"
+        }
+        VStack(alignment: .leading, spacing: NoopMetrics.spaceHalf) {
+            Text("Trend")
+                .textCase(.uppercase)
+                .font(StrandFont.footnote)
+                .foregroundStyle(StrandPalette.textTertiary)
+            if let deltaText {
+                TrendChip(text: deltaText, color: StrandPalette.textTertiary)
+            } else {
+                Text("—")
+                    .font(StrandFont.captionNumber)
+                    .foregroundStyle(StrandPalette.textSecondary)
+            }
+        }
+        .fixedSize(horizontal: true, vertical: false)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(verbatim: "\(String(localized: "Trend")): \(deltaText ?? "—")"))
+    }
+}

--- a/Strand/Screens/HostedCards.swift
+++ b/Strand/Screens/HostedCards.swift
@@ -19,6 +19,8 @@ enum HostedCard: String, CaseIterable, Identifiable {
     /// Sleep tab · "Sleep marks" — the tap-to-log going-to-sleep / awake card. Self-contained (logging
     /// only, no model), the first card wired end-to-end.
     case sleepMarks = "sleep.sleepMarks"
+    /// Sleep tab · "Asleep duration" — trailing-30-night sleep-hours trend (#today-hosted-cards P1).
+    case asleepDuration = "sleep.asleepDuration"
 
     var id: String { rawValue }
 
@@ -26,6 +28,7 @@ enum HostedCard: String, CaseIterable, Identifiable {
     var title: String {
         switch self {
         case .sleepMarks: return String(localized: "Sleep marks")
+        case .asleepDuration: return String(localized: "Asleep duration")
         }
     }
 
@@ -33,7 +36,7 @@ enum HostedCard: String, CaseIterable, Identifiable {
     /// Trends". Matches the Android `HostedCard.origin`.
     var origin: String {
         switch self {
-        case .sleepMarks: return String(localized: "Sleep")
+        case .sleepMarks, .asleepDuration: return String(localized: "Sleep")
         }
     }
 
@@ -41,13 +44,14 @@ enum HostedCard: String, CaseIterable, Identifiable {
     var customizationIcon: String {
         switch self {
         case .sleepMarks: return "moon.zzz"
+        case .asleepDuration: return "chart.bar.xaxis"
         }
     }
 
     /// Editor row tint.
     var customizationTint: Color {
         switch self {
-        case .sleepMarks: return StrandPalette.restColor
+        case .sleepMarks, .asleepDuration: return StrandPalette.restColor
         }
     }
 

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -1843,82 +1843,11 @@ struct SleepView: View {
 
     @ViewBuilder
     private func durationTrend(_ model: SleepModel) -> some View {
-        // Trailing-30 trend points and the typical total are precomputed in the model build
-        // (full passes over repo.days) — read here, not recomputed per render.
-        let pts = model.trendPoints
-        let avg = model.typicalTotalMin.map { $0 / 60.0 }
-        VStack(alignment: .leading, spacing: NoopMetrics.gap) {
-            SectionHeader("Asleep duration", overline: "Trend")
-            ChartCard(
-                title: "Hours asleep",
-                subtitle: String(localized: "Per night, trailing 30 days"),
-                trailing: avg.map { String(localized: "\(String(format: "%.1f", $0)) h avg") },
-                height: NoopMetrics.chartHeight,
-                tint: StrandPalette.restColor,
-                chart: {
-                    if pts.count >= 2 {
-                        TrendChart(points: pts,
-                                   gradient: StrandPalette.restGradient,
-                                   valueRange: trendRange(pts),
-                                   showsBars: true,
-                                   height: NoopMetrics.chartHeight,
-                                   valueFormat: { String(format: "%.1f h", $0) },
-                                   accessibilityLabel: String(localized: "Hours asleep trend"))
-                    } else {
-                        sparsePlaceholder
-                    }
-                },
-                footer: {
-                    HStack {
-                        ChartFooter([
-                            ("Avg",    avg.map { String(format: "%.1f h", $0) } ?? "—"),
-                            ("Min",    pts.map(\.value).min().map { String(format: "%.1f h", $0) } ?? "—"),
-                            ("Max",    pts.map(\.value).max().map { String(format: "%.1f h", $0) } ?? "—"),
-                            ("Nights", "\(pts.count)"),
-                        ])
-                        durationTrendStat(pts)
-                    }
-                }
-            )
-        }
-    }
-
-    /// Recent-half mean minus earlier-half mean, matching the Trends screen's directional comparison.
-    /// Direction is neutral here: more sleep is not automatically better, so the chip conveys movement
-    /// without assigning a positive/warning colour.
-    private func durationTrendChange(_ points: [TrendPoint]) -> Double? {
-        guard points.count >= 4 else { return nil }
-        let midpoint = points.count / 2
-        let earlier = points.prefix(midpoint).map(\.value)
-        let recent = points.suffix(points.count - midpoint).map(\.value)
-        guard !earlier.isEmpty, !recent.isEmpty else { return nil }
-        return recent.reduce(0, +) / Double(recent.count)
-            - earlier.reduce(0, +) / Double(earlier.count)
-    }
-
-    @ViewBuilder
-    private func durationTrendStat(_ points: [TrendPoint]) -> some View {
-        let delta = durationTrendChange(points)
-        let deltaText = delta.map {
-            let sign = $0 >= 0 ? "+" : "−"
-            return "\(sign)\(String(format: "%.1f h", abs($0)))"
-        }
-        VStack(alignment: .leading, spacing: NoopMetrics.spaceHalf) {
-            Text("Trend")
-                .textCase(.uppercase)
-                .font(StrandFont.footnote)
-                .foregroundStyle(StrandPalette.textTertiary)
-            if let deltaText {
-                TrendChip(text: deltaText, color: StrandPalette.textTertiary)
-            } else {
-                Text("—")
-                    .font(StrandFont.captionNumber)
-                    .foregroundStyle(StrandPalette.textSecondary)
-            }
-        }
-        .fixedSize(horizontal: true, vertical: false)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(Text(verbatim: "\(String(localized: "Trend")): \(deltaText ?? "—")"))
+        // #today-hosted-cards: the card view was extracted to AsleepDurationCard so Today can host it.
+        // The memoized model values keep the Sleep-tab perf (no per-render recompute); the Today host
+        // builds AsleepDurationData itself from the same source, so the two render identical numbers.
+        AsleepDurationCard(data: AsleepDurationData(points: model.trendPoints,
+                                                    typicalTotalMin: model.typicalTotalMin))
     }
 
     // MARK: - Memoization plumbing
@@ -2536,17 +2465,9 @@ struct SleepView: View {
     /// Trailing 30 days of total sleep, plotted in HOURS. Falls back to all nights with
     /// data if the trailing window is too sparse.
     private var durationTrendPoints: [TrendPoint] {
-        let fmt = SleepView.dayParser
-        func build(_ slice: ArraySlice<DailyMetric>) -> [TrendPoint] {
-            slice.compactMap { d -> TrendPoint? in
-                guard let mins = d.totalSleepMin, mins > 0,
-                      let date = fmt.date(from: d.day) else { return nil }
-                return TrendPoint(date: date, value: mins / 60.0)
-            }
-        }
-        let recent = build(repo.days.suffix(30))
-        if recent.count >= 2 { return recent }
-        return build(repo.days[...])
+        // #today-hosted-cards: single source of truth shared with the Today host (AsleepDurationCard),
+        // so the Sleep-tab trend and the hosted copy are byte-identical.
+        AsleepDurationData.build(days: repo.days).points
     }
 
     private func trendRange(_ pts: [TrendPoint]) -> ClosedRange<Double> {

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -2470,12 +2470,6 @@ struct SleepView: View {
         AsleepDurationData.build(days: repo.days).points
     }
 
-    private func trendRange(_ pts: [TrendPoint]) -> ClosedRange<Double> {
-        let vals = pts.map(\.value)
-        let lo = Swift.max(0, (vals.min() ?? 0) - 1)
-        let hi = (vals.max() ?? 9) + 1
-        return lo...Swift.max(hi, lo + 1)
-    }
 
     // MARK: - Empty / sparse states
 
@@ -2492,13 +2486,6 @@ struct SleepView: View {
         }
     }
 
-    private var sparsePlaceholder: some View {
-        Text("Not enough nights yet.")
-            .font(StrandFont.subhead)
-            .foregroundStyle(StrandPalette.textTertiary)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-            .background(NoopPanelSurface(tint: StrandPalette.restColor, cornerRadius: 12))
-    }
 
     /// Hero chart slot for a NAVIGATED session with no decodable stages — honest about the
     /// gap instead of rendering the latest night under a navigated label. (#160)

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -2198,6 +2198,7 @@ struct TodayView: View {
     private func hostedCard(for card: HostedCard) -> some View {
         switch card {
         case .sleepMarks: SleepMarkCard()
+        case .asleepDuration: AsleepDurationCard(data: AsleepDurationData.build(days: repo.days))
         }
     }
 

--- a/StrandTests/HostedCardPrefsTests.swift
+++ b/StrandTests/HostedCardPrefsTests.swift
@@ -10,6 +10,7 @@ final class HostedCardPrefsTests: XCTestCase {
     /// The rawValues are persisted + cross the .noopbak wire, so they are frozen. Origin-namespaced.
     func testRawValuesAreTheFrozenNamespacedContract() {
         XCTAssertEqual(HostedCard.sleepMarks.rawValue, "sleep.sleepMarks")
+        XCTAssertEqual(HostedCard.asleepDuration.rawValue, "sleep.asleepDuration")
         // Every id must be origin-namespaced so it routes to the right provider and can't collide with a
         // Today DashboardCard id.
         for card in HostedCard.allCases {

--- a/android/app/src/main/java/com/noop/ui/HostedCards.kt
+++ b/android/app/src/main/java/com/noop/ui/HostedCards.kt
@@ -2,6 +2,7 @@ package com.noop.ui
 
 import android.content.Context
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.ui.graphics.vector.ImageVector
 import org.json.JSONArray
@@ -31,7 +32,9 @@ enum class HostedCard(
 ) {
     /** Sleep tab · "Sleep marks" — the tap-to-log going-to-sleep / awake card. Self-contained (logging
      *  only, no model), the first card wired end-to-end. */
-    SLEEP_MARKS("sleep.sleepMarks", "Sleep marks", "Sleep", Icons.Filled.Bedtime);
+    SLEEP_MARKS("sleep.sleepMarks", "Sleep marks", "Sleep", Icons.Filled.Bedtime),
+    /** Sleep tab · "Asleep duration" — trailing-14-night sleep-hours trend (#today-hosted-cards P1). */
+    ASLEEP_DURATION("sleep.asleepDuration", "Asleep duration", "Sleep", Icons.Filled.BarChart);
 
     companion object {
         fun fromRaw(raw: String?): HostedCard? = entries.firstOrNull { it.raw == raw }

--- a/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
@@ -96,6 +96,18 @@ internal fun parseSessionStages(stagesJSON: String?): StageMins? {
  * here, matching the macOS buildModel(). Internal so SleepImportedFiguresTest can pin the
  * prefer-imported logic (the recoveryCalibrationNights test pattern).
  */
+/**
+ * #today-hosted-cards: the pure trailing-14-night sleep-hours trend — hours + index-aligned day keys, the
+ * SAME rows [buildSleepModel] derives `trendHours`/`trendDates` from. Nap-free (no debt/session data), so a
+ * Today host can build it from `days` alone. Kept byte-identical to the inline logic in [buildSleepModel].
+ */
+internal fun sleepDurationTrend(days: List<DailyMetric>): Pair<List<Double>, List<String>> {
+    val trendRows = days.filter { (it.totalSleepMin ?: 0.0) > 0.0 }.takeLast(14)
+    val hours = trendRows.mapNotNull { it.totalSleepMin?.let { minutes -> minutes / 60.0 } }
+    val dates = trendRows.map { it.day }
+    return hours to dates
+}
+
 internal fun buildSleepModel(
     days: List<DailyMetric>,
     session: SleepSession?,

--- a/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
@@ -90,13 +90,6 @@ internal fun parseSessionStages(stagesJSON: String?): StageMins? {
 }
 
 /**
- * Build the whole model from the cached daily metrics + the latest sleep session + the
- * export-verbatim sleep figures. Returns null when there is no usable latest night (no
- * stage minutes), which renders the empty state. All series are computed in one pass-set
- * here, matching the macOS buildModel(). Internal so SleepImportedFiguresTest can pin the
- * prefer-imported logic (the recoveryCalibrationNights test pattern).
- */
-/**
  * #today-hosted-cards: the pure trailing-14-night sleep-hours trend — hours + index-aligned day keys, the
  * SAME rows [buildSleepModel] derives `trendHours`/`trendDates` from. Nap-free (no debt/session data), so a
  * Today host can build it from `days` alone. Kept byte-identical to the inline logic in [buildSleepModel].
@@ -108,6 +101,13 @@ internal fun sleepDurationTrend(days: List<DailyMetric>): Pair<List<Double>, Lis
     return hours to dates
 }
 
+/**
+ * Build the whole model from the cached daily metrics + the latest sleep session + the
+ * export-verbatim sleep figures. Returns null when there is no usable latest night (no
+ * stage minutes), which renders the empty state. All series are computed in one pass-set
+ * here, matching the macOS buildModel(). Internal so SleepImportedFiguresTest can pin the
+ * prefer-imported logic (the recoveryCalibrationNights test pattern).
+ */
 internal fun buildSleepModel(
     days: List<DailyMetric>,
     session: SleepSession?,

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -2649,6 +2649,52 @@ private fun DrawScope.drawRoundRectFill(color: Color, frac: Float) {
 
 // MARK: - 4. 14-day asleep-hours trend
 
+/**
+ * #today-hosted-cards P1: the hosted "Asleep duration" card — the hours-asleep BarChart from [DurationTrend],
+ * hours-only (no debt sub-chart, so no nap/session data needed), built from the pure [sleepDurationTrend].
+ * `internal` so the Today host (TodayScreen) can render it; lives here so its ChartCard/BarChart siblings
+ * are in-file. Twin of the iOS `AsleepDurationCard`.
+ */
+@Composable
+internal fun AsleepDurationHostCard(hours: List<Double>, dates: List<String>) {
+    val avg = hours.sleepAverageOrNull()
+    Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
+        SectionHeader("Asleep duration", overline = "Sleep", trailing = "Last 14 days")
+        ChartCard(
+            title = uiString(R.string.l10n_sleep_screen_hours_asleep_06f68993),
+            subtitle = "Per night, trailing 14 days",
+            trailing = avg?.let { String.format(Locale.US, "%.1f h avg", it) },
+            tint = Palette.restColor,
+            footer = {
+                ChartFooter(
+                    listOf(
+                        "Avg" to (avg?.let { String.format(Locale.US, "%.1f h", it) } ?: "—"),
+                        "Min" to (hours.minOrNull()?.let { String.format(Locale.US, "%.1f h", it) } ?: "—"),
+                        "Max" to (hours.maxOrNull()?.let { String.format(Locale.US, "%.1f h", it) } ?: "—"),
+                        "Nights" to "${hours.size}",
+                    ),
+                )
+            },
+        ) {
+            if (hours.size >= 2) {
+                Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    BarChart(
+                        values = hours,
+                        modifier = Modifier.fillMaxWidth().height(Metrics.compactChartHeight)
+                            .semantics { contentDescription = uiString(R.string.l10n_sleep_screen_sleep_hours_trend_chart_a6fbc46d) },
+                        color = Palette.restColor,
+                        selectionEnabled = true,
+                        selectionLabels = dates.map(::shortDayLabel),
+                    )
+                    DateAxisRow(dates)
+                }
+            } else {
+                TrendPlaceholder()
+            }
+        }
+    }
+}
+
 @Composable
 private fun DurationTrend(m: SleepModel) {
     val pts = m.trendHours
@@ -2730,7 +2776,8 @@ private fun DurationTrend(m: SleepModel) {
 }
 
 @Composable
-private fun TrendPlaceholder() {
+// internal (not private) so the Today hosted-cards duration card (#today-hosted-cards) can reuse it.
+internal fun TrendPlaceholder() {
     Box(
         modifier = Modifier.fillMaxWidth(),
         contentAlignment = Alignment.Center,
@@ -2760,8 +2807,9 @@ private fun TrendLegend(items: List<Pair<String, Color>>) {
     }
 }
 
+// internal (not private) so the Today hosted-cards duration card (#today-hosted-cards) can reuse it.
 @Composable
-private fun DateAxisRow(days: List<String>) {
+internal fun DateAxisRow(days: List<String>) {
     if (days.isEmpty()) return
     val labels = listOf(
         days.firstOrNull(),

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1592,6 +1592,7 @@ fun TodayScreen(
                         // arranged order. Each is the SAME card its home tab renders (a mirror).
                         TodaySection.ADDED_CARDS -> HostedCardsSection(
                             cards = enabledHostedCards,
+                            days = days,
                             viewModel = viewModel,
                         )
                     }
@@ -3065,7 +3066,7 @@ private fun TodayEditAction(
  * confirmation toast). Renders nothing when [cards] is empty. Twin of the iOS `hostedCardsSection`.
  */
 @Composable
-private fun HostedCardsSection(cards: List<HostedCard>, viewModel: AppViewModel) {
+private fun HostedCardsSection(cards: List<HostedCard>, days: List<DailyMetric>, viewModel: AppViewModel) {
     if (cards.isEmpty()) return
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -3084,6 +3085,13 @@ private fun HostedCardsSection(cards: List<HostedCard>, viewModel: AppViewModel)
                         Toast.makeText(context, mark.confirmation(), Toast.LENGTH_SHORT).show()
                     }
                 )
+                // #today-hosted-cards P1: the hours-asleep trend, built pure from `days` (no nap/debt) so
+                // it matches the Sleep tab's hours chart. The card composable lives in SleepScreen.kt
+                // (internal) where its ChartCard/BarChart siblings are in-file.
+                HostedCard.ASLEEP_DURATION -> {
+                    val (hours, dates) = sleepDurationTrend(days)
+                    AsleepDurationHostCard(hours = hours, dates = dates)
+                }
             }
         }
     }

--- a/android/app/src/test/java/com/noop/ui/HostedCardPrefsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/HostedCardPrefsTest.kt
@@ -16,6 +16,7 @@ class HostedCardPrefsTest {
     @Test
     fun rawValues_areTheFrozenNamespacedContract() {
         assertEquals("sleep.sleepMarks", HostedCard.SLEEP_MARKS.raw)
+        assertEquals("sleep.asleepDuration", HostedCard.ASLEEP_DURATION.raw)
         // Every id must be origin-namespaced so it routes to the right provider and can't collide with a
         // Today DashboardCard id.
         HostedCard.entries.forEach { card ->


### PR DESCRIPTION
**P1 of #today-hosted-cards** — the first Sleep *detail* card a user can add to Today via Customise: **Asleep duration** (the trailing sleep-hours trend). Builds on P0's infra (#1230).

### Why this card first
Of the Sleep detail cards, the hours trend is the **cleanest to host**: it's purely `repo.days`-derived (per-night `totalSleepMin`), with **no nap/session/debt async coupling** — unlike the Night-detail grid's Sleep-Debt tile, which needs the session/nap pipeline (a later P1 increment). So this proves the "extract a real analytics card into Today" pattern at low risk.

### What changed
- **iOS**: new `AsleepDurationCard` + `AsleepDurationData.build(days:)` — a verbatim lift of the former `SleepView.durationTrend` / `durationTrendPoints`. `SleepView` now renders the extracted card and delegates its trend points to the shared builder, so the **Sleep tab and the Today host render from one source** (never diverge).
- **Android**: new `AsleepDurationHostCard` (internal, beside its `ChartCard`/`BarChart` siblings) + pure `sleepDurationTrend(days)`; `DateAxisRow`/`TrendPlaceholder` made `internal` for reuse. Hours-only (no debt sub-chart → no nap data).
- **Parity**: `HostedCard.asleepDuration` / `ASLEEP_DURATION` — byte-identical id `sleep.asleepDuration`, pinned in both HostedCardPrefs tests. Dispatch added to both Today views + the Android section.

Platform-idiomatic per tab (iOS 30-day line, Android 14-day bars) — the **analytics are identical**; the display windows are pre-existing UI divergence (feature-level parity).

### Verification
- Android: `compileFullDebugKotlin` clean; `HostedCardPrefsTest` passes; `i18n_audit.py --ci` green.
- iOS app-target (new card, SleepView rewire, both Today dispatches): validated via the on-demand app-build gate.
- Additive / default-off — nothing changes until a user hosts the card.