### PR TITLE
Sleep: align Android Consistency analytic to iOS (bedtime-onset spread)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
@@ -5,6 +5,7 @@ import com.noop.analytics.SleepDebt
 import com.noop.analytics.SleepStageTotals
 import com.noop.data.DailyMetric
 import com.noop.data.SleepSession
+import java.util.Calendar
 import org.json.JSONArray
 import org.json.JSONObject
 import kotlin.math.max
@@ -121,6 +122,9 @@ internal fun buildSleepModel(
     // Actual asleep minutes from blocks outside each day's canonical main-night group. They repay
     // debt without changing DailyMetric.totalSleepMin, which remains the Rest/headline main-night figure.
     napSleepMinByDay: Map<String, Double> = emptyMap(),
+    // #sleep-consistency-parity: the full session list (onset times), used by the consistency FALLBACK
+    // (bedtime-onset spread). Defaults empty for callers/tests that only exercise the imported path.
+    sessions: List<SleepSession> = emptyList(),
 ): SleepModel? {
     val effectiveDay = selectedDay ?: days.lastOrNull()?.day ?: return null
     // The HERO night = the selected day's stage-bearing row. The TILE / debt / need / trend
@@ -197,7 +201,7 @@ internal fun buildSleepModel(
             val series = days.mapNotNull { imported.consistency[it.day] }
             Metric(series.lastOrNull(), mean(series), series)
         } else {
-            consistencySeries(days)
+            consistencySeries(sessions)
         }
     }
     val hoursVsNeeded = metric(days) { d ->
@@ -296,12 +300,13 @@ internal fun fallbackSleepModel(
     days: List<DailyMetric>,
     imported: ImportedSleepSeries = ImportedSleepSeries(),
     napSleepMinByDay: Map<String, Double> = emptyMap(),
+    sessions: List<SleepSession> = emptyList(),
 ): SleepModel? {
     val anchorDay = days.lastOrNull {
         (it.deepMin ?: 0.0) + (it.remMin ?: 0.0) + (it.lightMin ?: 0.0) > 0.0
     }?.day ?: return null
     return buildSleepModel(days, null, imported, selectedDay = anchorDay,
-        napSleepMinByDay = napSleepMinByDay)
+        napSleepMinByDay = napSleepMinByDay, sessions = sessions)
 }
 
 /** Build a metric from a per-day transform, keeping only finite values. */
@@ -311,15 +316,25 @@ private fun metric(days: List<DailyMetric>, transform: (DailyMetric) -> Double?)
 }
 
 /**
- * Consistency per day from the rolling bedtime spread — but Android's daily metrics carry
- * no per-night onset timestamp, so a bedtime-variance score isn't reconstructable from the
- * cached `days` alone. We approximate the same intent (steadier nights → higher score) from
- * the trailing-14 spread of total-sleep duration: low duration variability ≈ a consistent
- * routine. Each day's score uses the window ending at that day, matching the macOS rolling
- * shape. Honest note: this is a duration-based proxy, not the onset-spread score.
+ * Consistency per night from the rolling BEDTIME-ONSET spread — the real "sleep consistency" (steadier
+ * bed times → higher score), now reconstructed from the session onset timestamps (`sessions`) rather than
+ * the old duration proxy that read only `days`. Byte-identical to iOS `SleepView.consistencySeries` so the
+ * tile shows the SAME number on both platforms (#sleep-consistency-parity). The imported `sleep_consistency`
+ * series still wins when present; this is the strap-only fallback.
  */
-private fun consistencySeries(days: List<DailyMetric>): Metric {
-    val mins = days.mapNotNull { it.totalSleepMin?.takeIf { m -> m > 0.0 } }
+internal fun consistencySeries(sessions: List<SleepSession>): Metric {
+    // Byte-identical to iOS SleepView.consistencySeries (#sleep-consistency-parity): BEDTIME-ONSET
+    // regularity, not the old duration proxy. Each session's local bed-minute (hour*60+min, evening
+    // onsets wrapped +24h) over a trailing-14 SD → 100*(1 - sd/120). Sessions are ordered by startTs to
+    // match iOS's repo.sleeps ordering (the onset VALUE uses effectiveStartTs = startTsAdjusted ?: startTs).
+    val cal = Calendar.getInstance()
+    fun bedMinutes(effectiveStartTs: Long): Double {
+        cal.timeInMillis = effectiveStartTs * 1000L
+        var m = (cal.get(Calendar.HOUR_OF_DAY) * 60 + cal.get(Calendar.MINUTE)).toDouble()
+        if (m < 12 * 60) m += 24 * 60   // wrap evening onsets into one continuous scale
+        return m
+    }
+    val mins = sessions.sortedBy { it.startTs }.map { bedMinutes(it.effectiveStartTs) }
     if (mins.size < 3) return Metric(null, null, emptyList())
     val scores = ArrayList<Double>()
     for (i in mins.indices) {
@@ -329,8 +344,8 @@ private fun consistencySeries(days: List<DailyMetric>): Metric {
         val m = window.average()
         val variance = window.sumOf { (it - m) * (it - m) } / window.size
         val sd = Math.sqrt(variance)
-        // 90 min of duration SD maps to a 0 score; tighter routines climb to 100.
-        scores.add((100.0 * (1.0 - sd / 90.0)).coerceIn(0.0, 100.0))
+        // 120 min of onset SD maps to a 0 score; tighter routines climb to 100.
+        scores.add((100.0 * (1.0 - sd / 120.0)).coerceIn(0.0, 100.0))
     }
     return Metric(scores.lastOrNull(), mean(scores), scores)
 }

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -442,10 +442,10 @@ fun SleepScreen(
     // at-a-glance TILES, the debt ledger, the personal need and the trend stay full-history /
     // latest-anchored, matching iOS SleepView. `selectedDay` re-points only the hero. Model is null
     // when the selected day has no stage minutes. (#5)
-    val model = remember(days, night, imported, napSleepMinByDay) {
+    val model = remember(days, night, imported, napSleepMinByDay, sleeps) {
         buildSleepModel(days, night?.session, imported, selectedDay = night?.dayKey,
             heroStages = night?.groupStages, heroSegments = night?.groupSegments,
-            napSleepMinByDay = napSleepMinByDay)
+            napSleepMinByDay = napSleepMinByDay, sessions = sleeps)
     }
     val display = remember(model, night) { heroDisplay(model, night) }
 
@@ -456,8 +456,8 @@ fun SleepScreen(
     // newest stage-bearing day instead of vanishing. The HERO stays on `model`/`display` (an
     // honest no-stage-data fallback for the bad day, edit pencil reachable). Null only when NO day
     // has stage data: the true first-run empty state.
-    val tilesModel = remember(model, days, imported, napSleepMinByDay) {
-        model ?: fallbackSleepModel(days, imported, napSleepMinByDay)
+    val tilesModel = remember(model, days, imported, napSleepMinByDay, sleeps) {
+        model ?: fallbackSleepModel(days, imported, napSleepMinByDay, sessions = sleeps)
     }
 
     // Jump straight to a night by its (local) wake-day — the center date block opens a picker.

--- a/android/app/src/test/java/com/noop/ui/SleepConsistencyParityTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepConsistencyParityTest.kt
@@ -1,0 +1,79 @@
+package com.noop.ui
+
+import com.noop.data.SleepSession
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import java.util.Calendar
+import java.util.TimeZone
+
+/**
+ * Pins the BEDTIME-ONSET consistency fallback (#sleep-consistency-parity) — the score must be
+ * byte-identical to iOS `SleepView.consistencySeries` (bedtime-minute rolling-14 SD → 100·(1−sd/120)),
+ * NOT the old duration proxy. Runs under a fixed UTC default timezone so the local-time bed-minute is
+ * deterministic (both platforms use the device tz; the algorithm — not the tz — is what parity pins).
+ */
+class SleepConsistencyParityTest {
+
+    private var savedTz: TimeZone? = null
+
+    @Before fun forceUtc() {
+        savedTz = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+    }
+
+    @After fun restoreTz() { savedTz?.let { TimeZone.setDefault(it) } }
+
+    /** Unix seconds for a given UTC wall-clock (matches the tz the production Calendar reads under). */
+    private fun ts(year: Int, month0: Int, day: Int, hour: Int, minute: Int): Long {
+        val c = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+        c.clear()
+        c.set(year, month0, day, hour, minute, 0)
+        return c.timeInMillis / 1000L
+    }
+
+    private fun session(startTs: Long) =
+        SleepSession(deviceId = "my-whoop", startTs = startTs, endTs = startTs + 8 * 3600)
+
+    @Test fun onsetSpreadScore_matchesTheHandComputedIosValue() {
+        // Bedtimes 23:00 / 23:30 / 22:30 → bed-minutes 1380 / 1410 / 1350 (all >= 12h, no wrap).
+        // window mean 1380, population variance (0 + 900 + 900)/3 = 600, sd = √600 = 24.49490,
+        // score = 100·(1 − 24.49490/120) = 79.58758…  (only the 3rd night has a >=3 window).
+        val sessions = listOf(
+            session(ts(2026, 5, 1, 23, 0)),
+            session(ts(2026, 5, 2, 23, 30)),
+            session(ts(2026, 5, 3, 22, 30)),
+        )
+        val m = consistencySeries(sessions)
+        assertEquals(1, m.series.size)
+        assertEquals(79.58758, m.latest!!, 1e-4)
+        assertEquals(79.58758, m.typical!!, 1e-4)
+    }
+
+    @Test fun fewerThanThreeNights_yieldsEmpty() {
+        val m = consistencySeries(listOf(session(ts(2026, 5, 1, 23, 0)), session(ts(2026, 5, 2, 23, 0))))
+        assertNull(m.latest)
+        assertEquals(0, m.series.size)
+    }
+
+    /** Order is by startTs (matching iOS repo.sleeps), and the ONSET value uses effectiveStartTs
+     *  (startTsAdjusted when a bedtime was hand-edited). */
+    @Test fun sortsByStartTs_andReadsEffectiveOnset() {
+        val edited = SleepSession(
+            deviceId = "my-whoop",
+            startTs = ts(2026, 5, 2, 21, 0),               // raw onset 21:00…
+            endTs = ts(2026, 5, 3, 5, 0),
+            startTsAdjusted = ts(2026, 5, 2, 23, 0),       // …hand-set to 23:00 → this is what counts
+        )
+        val sessions = listOf(
+            session(ts(2026, 5, 1, 23, 0)),
+            edited,
+            session(ts(2026, 5, 3, 23, 0)),
+        )
+        // All three effective onsets are 23:00 → zero spread → score 100.
+        val m = consistencySeries(sessions)
+        assertEquals(100.0, m.latest!!, 1e-9)
+    }
+}


### PR DESCRIPTION
Fixes the parity divergence surfaced during the #1232 re-review: the Sleep **Consistency** tile showed a genuinely different number on each OS.

Both platforms prefer imported `sleep_consistency` (identical). Only the **strap-only fallback** diverged:
- **iOS** = bedtime-**onset** spread, `100·(1 − sd/120)`
- **Android** = **duration** spread, `100·(1 − sd/90)` — its own comment called it *"a proxy, not the onset-spread score"*

### Fix (Android → iOS; iOS is canonical, untouched)
- Rewrite Android `consistencySeries` to the **onset-spread**, byte-identical to `SleepView.consistencySeries`: per session (ordered by `startTs`, matching iOS `repo.sleeps`) the local bed-minute from `effectiveStartTs` (`hour·60+min`, evening onsets wrapped `+24h`), trailing-14 **population** SD, `100·(1 − sd/120)`, clamped 0–100.
- Thread the session list into `buildSleepModel` + `fallbackSleepModel` (default `emptyList()`, so imported-path callers/tests are unaffected); pass `sleeps` from the Sleep screen.
- **Sort by `startTs` *locally* inside the function** rather than changing Android's global session order — so the hero night-picker etc. are untouched (the risk I flagged when scoping this).
- **No iOS app-target change** → no app-build gate needed.

### Verification
- Android `compileFullDebugKotlin` + **full** `testFullDebugUnitTest` pass.
- New `SleepConsistencyParityTest` pins the onset-spread math: hand-computed **79.588** for a 23:00/23:30/22:30 window, the <3-night empty case, and the `effectiveStartTs`/`startTs`-sort behaviour.

Moves the shipped Consistency number **only** for strap-only users (those without an imported WHOOP consistency series).
