### PR TITLE
Custom background: pref + fill-mode foundation (parity-pinned)

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Appearance.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Appearance.swift
@@ -258,6 +258,44 @@ public enum SkyBehindCardsPrefs {
     public static let enabledKey = "noop.skyBehindCards"
 }
 
+/// Custom background image (#custom-background): a user-picked photo drawn full-bleed behind every screen,
+/// REPLACING the day-cycle sky when enabled (precedence: image > sky > plain canvas). The image itself is
+/// a device-local file (Application Support on Apple, `filesDir` on Android) — like the avatar it is
+/// deliberately kept OUT of the `.noopbak` whitelist. Read in the scaffold sky provider + Today's inline
+/// sky. Mirror in Kotlin via `NoopPrefs.backgroundImageEnabled` / `.backgroundFillMode` /
+/// `.backgroundImagePresent` — the three key strings are byte-identical across platforms.
+public enum BackgroundImagePrefs {
+    /// Master gate — when true AND an image is present, the custom image overrides the sky. Default false.
+    public static let enabledKey = "noop.backgroundImageEnabled"
+    /// The `BackgroundFillMode` rawValue. Default `"fill"`.
+    public static let fillModeKey = "noop.backgroundFillMode"
+    /// Whether a background image file has been stored (so the UI can offer Remove and the provider can
+    /// skip a decode when absent). Default false.
+    public static let presentKey = "noop.backgroundImagePresent"
+}
+
+/// How a custom background image is scaled to the screen. RawValues are byte-identical to the Kotlin
+/// `BackgroundFillMode` twin so a backup/restore (if ever whitelisted) would read the same, and the two
+/// platforms map them onto the same intent: fill → aspect-fill/crop, fit → aspect-fit, stretch →
+/// no-aspect fill, tile → repeat.
+public enum BackgroundFillMode: String, CaseIterable, Identifiable, Sendable {
+    case fill, fit, stretch, tile
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .fill:    return String(localized: "Fill", bundle: .module)
+        case .fit:     return String(localized: "Fit", bundle: .module)
+        case .stretch: return String(localized: "Stretch", bundle: .module)
+        case .tile:    return String(localized: "Tile", bundle: .module)
+        }
+    }
+
+    /// Tolerant parse — an unknown/legacy rawValue falls back to `.fill` (the default).
+    public static func resolve(_ raw: String) -> BackgroundFillMode { BackgroundFillMode(rawValue: raw) ?? .fill }
+}
+
 // MARK: - Light-idiom helpers
 
 /// An additive glow (ring blooms, sparkline heads, hero halos) only reads on a DARK canvas —

--- a/Packages/StrandDesign/Tests/StrandDesignTests/BackgroundImagePrefsTests.swift
+++ b/Packages/StrandDesign/Tests/StrandDesignTests/BackgroundImagePrefsTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import StrandDesign
+
+/// Pins the custom-background pref contract (#custom-background): the three pref-key strings and the
+/// four `BackgroundFillMode` rawValues must stay byte-identical to the Kotlin `NoopPrefs` /
+/// `BackgroundFillMode` twins (`BackgroundImagePrefsParityTest`) — a drift on either platform would
+/// read a different value out of the same UserDefaults/SharedPreferences key.
+final class BackgroundImagePrefsTests: XCTestCase {
+
+    func testKeyLiteralsMatchTheKotlinContract() {
+        XCTAssertEqual(BackgroundImagePrefs.enabledKey, "noop.backgroundImageEnabled")
+        XCTAssertEqual(BackgroundImagePrefs.fillModeKey, "noop.backgroundFillMode")
+        XCTAssertEqual(BackgroundImagePrefs.presentKey, "noop.backgroundImagePresent")
+    }
+
+    func testFillModeRawValuesMatchTheKotlinContract() {
+        XCTAssertEqual(BackgroundFillMode.fill.rawValue, "fill")
+        XCTAssertEqual(BackgroundFillMode.fit.rawValue, "fit")
+        XCTAssertEqual(BackgroundFillMode.stretch.rawValue, "stretch")
+        XCTAssertEqual(BackgroundFillMode.tile.rawValue, "tile")
+        // Exactly these four, in this order (parity with the Kotlin enum entries).
+        XCTAssertEqual(BackgroundFillMode.allCases.map(\.rawValue), ["fill", "fit", "stretch", "tile"])
+    }
+
+    func testResolveIsTolerantAndDefaultsToFill() {
+        XCTAssertEqual(BackgroundFillMode.resolve("tile"), .tile)
+        XCTAssertEqual(BackgroundFillMode.resolve("nonsense"), .fill)
+        XCTAssertEqual(BackgroundFillMode.resolve(""), .fill)
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -750,6 +750,41 @@ object NoopPrefs {
         of(context).edit().putBoolean(KEY_SKY_BEHIND_CARDS, enabled).apply()
     }
 
+    /** Custom background image (#custom-background): a user-picked photo drawn full-bleed behind every
+     *  screen, REPLACING the day-cycle sky when enabled (precedence: image > sky > flat canvas). The
+     *  image itself is a device-local file (see [BackgroundImageStore]) — like the avatar it is
+     *  deliberately kept OUT of the .noopbak whitelist. The three key strings are byte-identical to the
+     *  iOS BackgroundImagePrefs. */
+    const val KEY_BACKGROUND_IMAGE_ENABLED = "noop.backgroundImageEnabled"
+
+    fun backgroundImageEnabled(context: Context): Boolean =
+        of(context).getBoolean(KEY_BACKGROUND_IMAGE_ENABLED, false)
+
+    fun setBackgroundImageEnabled(context: Context, enabled: Boolean) {
+        of(context).edit().putBoolean(KEY_BACKGROUND_IMAGE_ENABLED, enabled).apply()
+    }
+
+    /** The [BackgroundFillMode] rawValue (default "fill"). */
+    const val KEY_BACKGROUND_FILL_MODE = "noop.backgroundFillMode"
+
+    fun backgroundFillMode(context: Context): BackgroundFillMode =
+        BackgroundFillMode.fromStorage(of(context).getString(KEY_BACKGROUND_FILL_MODE, null))
+
+    fun setBackgroundFillMode(context: Context, mode: BackgroundFillMode) {
+        of(context).edit().putString(KEY_BACKGROUND_FILL_MODE, mode.storageValue).apply()
+    }
+
+    /** Whether a background image file has been stored (so the UI can offer Remove and the backdrop can
+     *  skip a decode when absent). Default false. */
+    const val KEY_BACKGROUND_IMAGE_PRESENT = "noop.backgroundImagePresent"
+
+    fun backgroundImagePresent(context: Context): Boolean =
+        of(context).getBoolean(KEY_BACKGROUND_IMAGE_PRESENT, false)
+
+    fun setBackgroundImagePresent(context: Context, present: Boolean) {
+        of(context).edit().putBoolean(KEY_BACKGROUND_IMAGE_PRESENT, present).apply()
+    }
+
     /** "Reduce motion in NOOP" (opt-in, default OFF). The literal key matches Apple so the setting has
      *  one cross-platform identity. [rememberQuietMotion] observes it live for every looping surface. */
     const val KEY_QUIET_MOTION = "noop.quietMotion"

--- a/android/app/src/main/java/com/noop/ui/PaletteTokens.kt
+++ b/android/app/src/main/java/com/noop/ui/PaletteTokens.kt
@@ -171,6 +171,23 @@ enum class ChartStyle(val storageValue: String, val label: String) {
     }
 }
 
+/** How a custom background image is scaled to the screen (#custom-background). [storageValue] is
+ *  byte-identical to the iOS `BackgroundFillMode` rawValue so the pref reads the same on both
+ *  platforms: fill → aspect-crop, fit → aspect-fit, stretch → no-aspect fill, tile → repeat. Labels
+ *  are localized at the Settings call site (not in the enum), so no hardcoded UI literal lives here. */
+enum class BackgroundFillMode(val storageValue: String) {
+    FILL("fill"),
+    FIT("fit"),
+    STRETCH("stretch"),
+    TILE("tile");
+
+    companion object {
+        /** Tolerant parse — an unknown/legacy rawValue falls back to [FILL] (the default). */
+        fun fromStorage(raw: String?): BackgroundFillMode =
+            entries.firstOrNull { it.storageValue == raw } ?: FILL
+    }
+}
+
 /** Chart-colour preference, persisted in `noop_prefs` and mirrored in snapshot state so a flip
  *  re-colours every gauge/chart live (the Palette ramp accessors read [ChartStylePrefs.style]). */
 object ChartStylePrefs {

--- a/android/app/src/test/java/com/noop/ui/BackgroundImagePrefsParityTest.kt
+++ b/android/app/src/test/java/com/noop/ui/BackgroundImagePrefsParityTest.kt
@@ -1,0 +1,49 @@
+package com.noop.ui
+
+import com.noop.data.BackupSettingsCodec
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Pins the custom-background pref contract (#custom-background) so the three pref-key strings and the
+ * four [BackgroundFillMode] rawValues stay byte-identical to the iOS `BackgroundImagePrefs` /
+ * `BackgroundFillMode` twins — a drift on either platform would read a different value from the same
+ * SharedPreferences/UserDefaults. Also asserts the keys are deliberately NOT in the `.noopbak`
+ * whitelist (the image + its toggles are device-local, like the avatar).
+ */
+class BackgroundImagePrefsParityTest {
+
+    @Test fun keyLiterals_matchTheIosContract() {
+        assertEquals("noop.backgroundImageEnabled", NoopPrefs.KEY_BACKGROUND_IMAGE_ENABLED)
+        assertEquals("noop.backgroundFillMode", NoopPrefs.KEY_BACKGROUND_FILL_MODE)
+        assertEquals("noop.backgroundImagePresent", NoopPrefs.KEY_BACKGROUND_IMAGE_PRESENT)
+    }
+
+    @Test fun fillModeRawValues_matchTheIosContract() {
+        assertEquals("fill", BackgroundFillMode.FILL.storageValue)
+        assertEquals("fit", BackgroundFillMode.FIT.storageValue)
+        assertEquals("stretch", BackgroundFillMode.STRETCH.storageValue)
+        assertEquals("tile", BackgroundFillMode.TILE.storageValue)
+        // Exactly these four, in this order (parity with the Swift CaseIterable order).
+        assertEquals(
+            listOf("fill", "fit", "stretch", "tile"),
+            BackgroundFillMode.entries.map { it.storageValue },
+        )
+    }
+
+    @Test fun fromStorage_isTolerantAndDefaultsToFill() {
+        assertEquals(BackgroundFillMode.TILE, BackgroundFillMode.fromStorage("tile"))
+        assertEquals(BackgroundFillMode.FILL, BackgroundFillMode.fromStorage(null))
+        assertEquals(BackgroundFillMode.FILL, BackgroundFillMode.fromStorage("nonsense"))
+        assertEquals(BackgroundFillMode.FILL, BackgroundFillMode.fromStorage(""))
+    }
+
+    @Test fun backgroundKeys_areNotInTheNoopbakWhitelist() {
+        // Device-local (like the avatar) — a restore onto another device must not carry the picture
+        // toggles. Guards against someone "helpfully" whitelisting them later.
+        assertFalse(BackupSettingsCodec.WHITELIST.containsKey(NoopPrefs.KEY_BACKGROUND_IMAGE_ENABLED))
+        assertFalse(BackupSettingsCodec.WHITELIST.containsKey(NoopPrefs.KEY_BACKGROUND_FILL_MODE))
+        assertFalse(BackupSettingsCodec.WHITELIST.containsKey(NoopPrefs.KEY_BACKGROUND_IMAGE_PRESENT))
+    }
+}


### PR DESCRIPTION
## What

Foundation slice of a **custom background image** feature (browse a photo, Fill/Fit/Stretch/Tile scaling, transparent cards, seamless behind every tab). This PR is intentionally the smallest correct slice: the **cross-platform pref contract + scale enum only**, no UI wiring — so it lands fully covered by default CI ahead of the app-target renderer/Settings work.

## Changes

- **StrandDesign `Appearance.swift`** — `BackgroundImagePrefs` (three keys) + `BackgroundFillMode` (`fill`/`fit`/`stretch`/`tile`) with a tolerant `resolve(_:)`, mirroring the existing `SceneBackgroundPrefs` / `ChartStyle` idioms.
- **Android** — `NoopPrefs` key constants + typed getter/setters, and a Kotlin `BackgroundFillMode` twin whose `storageValue` is byte-identical to the Swift `rawValue`.

## Contract

- Keys (identical both platforms): `noop.backgroundImageEnabled` (Bool, default false), `noop.backgroundFillMode` (String, default `"fill"`), `noop.backgroundImagePresent` (Bool, default false).
- `BackgroundFillMode` rawValues, lowercase, identical: `fill`, `fit`, `stretch`, `tile`.
- **Device-local, like the avatar** — deliberately kept OUT of the `.noopbak` whitelist. The image file itself will be a device-local file, not a settings value.

## Verification

- Swift `StrandDesignTests.BackgroundImagePrefsTests` — asserts the three key literals + four rawValues + `resolve()` tolerance (runs under `swift-packages.yml`).
- Kotlin `BackgroundImagePrefsParityTest` — same assertions **plus** that the three keys are absent from `BackupSettingsCodec.WHITELIST`. Ran locally: `./gradlew compileFullDebugKotlin` + full `testFullDebugUnitTest` green.

## Scope

No behavior change yet — nothing reads these prefs. The renderer (decode-once cached backdrop), the mode-aware sky providers, the Settings "Background" card (Browse from photos + files, fill-mode picker, transparent-cards toggle), and the More-tab coverage land in the follow-up PR.
