### PR TITLE
Custom background: live feature on Android (renderer, backdrop, Settings)

### DIFF
--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -514,7 +514,15 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Background image"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Blood Oxygen: strap estimate"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Browse files"
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
@@ -522,7 +530,15 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Choose from Photos"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Choose photo"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Let the background show through every card. Tune how much just below."
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
@@ -546,7 +562,23 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Remove image"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Replace from Photos"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Scaling"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Searching…"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Show custom background"
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
@@ -555,6 +587,10 @@
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Surfaces the WHOOP 5/MG strap's nightly SpO₂ estimate (spo2_candidate_82) in the "
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Transparent cards"
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",

--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -612,9 +612,9 @@ private fun MoreScreen(onNavigate: (String) -> Unit) {
     ScreenScaffold(
         title = uiString(R.string.l10n_app_root_more_4bab2d8f),
         subtitle = "Everything else, one tap away",
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        topBackground = screenBackdropSlot(showDayCycleBackground, skyBehindCards),
         // Sky-behind-cards fills the viewport so the transparent cards reveal the sky the whole way down.
-        fullBleedBackground = showDayCycleBackground && skyBehindCards,
+        fullBleedBackground = screenBackdropFullBleed(showDayCycleBackground, skyBehindCards),
     ) {
         // Mirror the iOS More page: each group is a tappable UPPERCASE overline header (with a disclosure
         // chevron) over a single grouped white NoopCard whose rows are tight (accent icon + title +

--- a/android/app/src/main/java/com/noop/ui/BackgroundImage.kt
+++ b/android/app/src/main/java/com/noop/ui/BackgroundImage.kt
@@ -1,0 +1,202 @@
+package com.noop.ui
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import android.media.ExifInterface
+import android.net.Uri
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.ImageShader
+import androidx.compose.ui.graphics.ShaderBrush
+import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import java.io.File
+
+// MARK: - Custom background image (#custom-background)
+//
+// A user-picked photo drawn full-bleed behind EVERY screen, REPLACING the day-cycle sky when enabled
+// (precedence: image > sky > flat canvas). Cloned from ProfileAvatarStore (ProfileAvatar.kt): the picked
+// image is downscaled + re-encoded to a single app-private JPEG, and the decoded [ImageBitmap] is held in
+// SNAPSHOT state so toggling/replacing it re-renders the backdrop live. Larger than the avatar (this fills
+// the whole screen), so MAX_DIMEN is the screen scale, not 256.
+//
+// The three prefs (enabled / fillMode / present) live in NoopPrefs (byte-identical keys to the iOS
+// BackgroundImagePrefs). The image file itself is device-local, like the avatar — deliberately NOT in the
+// .noopbak whitelist. The iOS twin is Strand/System/BackgroundImageStore.swift.
+
+/**
+ * The on-device custom background image. Snapshot-backed ([bitmap]/[enabled]/[fillMode]) so every
+ * screen's backdrop updates live when the photo, the enable toggle, or the fill mode changes in Settings.
+ * The bytes persist to `filesDir/background.jpg`; the toggles persist via [NoopPrefs]. [load] runs once
+ * from MainActivity before first composition.
+ */
+object BackgroundImageStore {
+    private const val FILE_NAME = "background.jpg"
+
+    /** Longest edge (px) the stored image is downscaled to. Big enough to cover a large tablet/foldable
+     *  screen crisply, capped so a 100MP pick can never fully decode into memory (it sub-samples first). */
+    private const val MAX_DIMEN = 2560
+
+    /** JPEG quality for the re-encoded background — a touch higher than the avatar since it fills the
+     *  whole screen behind (semi-transparent) cards, still modest on disk. */
+    private const val JPEG_QUALITY = 90
+
+    private fun backgroundFile(ctx: Context): File =
+        File(ctx.applicationContext.filesDir, FILE_NAME)
+
+    /** The decoded background for composition; null = none stored. */
+    var bitmap by mutableStateOf<ImageBitmap?>(null)
+        private set
+
+    /** Master enable toggle (mirrors NoopPrefs.backgroundImageEnabled), snapshot-backed for live redraw. */
+    var enabled by mutableStateOf(false)
+        private set
+
+    /** How the image is scaled (mirrors NoopPrefs.backgroundFillMode), snapshot-backed for live redraw. */
+    var fillMode by mutableStateOf(BackgroundFillMode.FILL)
+        private set
+
+    /** True when a photo is stored — drives the Remove affordance in Settings. */
+    val hasImage: Boolean get() = bitmap != null
+
+    /** The custom image is the ACTIVE backdrop (top of the precedence: enabled AND actually decoded). */
+    val isActive: Boolean get() = enabled && bitmap != null
+
+    /** Load the persisted toggles + image (if any). Safe to call before first composition. */
+    fun load(ctx: Context) {
+        val app = ctx.applicationContext
+        enabled = NoopPrefs.backgroundImageEnabled(app)
+        fillMode = NoopPrefs.backgroundFillMode(app)
+        val file = backgroundFile(app)
+        bitmap = if (NoopPrefs.backgroundImagePresent(app) && file.exists()) {
+            runCatching { BitmapFactory.decodeFile(file.absolutePath)?.asImageBitmap() }.getOrNull()
+        } else {
+            null
+        }
+    }
+
+    fun setEnabled(ctx: Context, on: Boolean) {
+        enabled = on
+        NoopPrefs.setBackgroundImageEnabled(ctx.applicationContext, on)
+    }
+
+    fun setFillMode(ctx: Context, mode: BackgroundFillMode) {
+        fillMode = mode
+        NoopPrefs.setBackgroundFillMode(ctx.applicationContext, mode)
+    }
+
+    /**
+     * Read the picked image, downscale to [MAX_DIMEN] on the longest edge, re-encode as a JPEG into
+     * `filesDir/background.jpg`, flip the present flag, and update the live [bitmap]. Returns true on
+     * success. Call off the main thread for a large source (bitmap decode + file IO).
+     */
+    fun setImageFromUri(ctx: Context, uri: Uri): Boolean {
+        val app = ctx.applicationContext
+        val scaled = runCatching { decodeDownscaled(app, uri) }.getOrNull() ?: return false
+        val file = backgroundFile(app)
+        val wrote = runCatching {
+            file.outputStream().use { out -> scaled.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, out) }
+        }.isSuccess
+        if (!wrote) {
+            scaled.recycle()
+            return false
+        }
+        NoopPrefs.setBackgroundImagePresent(app, true)
+        bitmap = scaled.asImageBitmap()
+        return true
+    }
+
+    /** Remove the photo: delete the file, clear the present flag, drop the live [bitmap] to null. */
+    fun clearImage(ctx: Context) {
+        val app = ctx.applicationContext
+        runCatching { backgroundFile(app).delete() }
+        NoopPrefs.setBackgroundImagePresent(app, false)
+        bitmap = null
+    }
+
+    /**
+     * Decode [uri] into a Bitmap whose longest edge is at most [MAX_DIMEN]: a bounds-only pass to pick an
+     * `inSampleSize`, then the real sub-sampled decode, an exact down-fit, and an EXIF-orientation
+     * correction so a sideways photo lands upright. Mirrors ProfileAvatarStore.decodeDownscaled.
+     */
+    private fun decodeDownscaled(ctx: Context, uri: Uri): Bitmap? {
+        val resolver = ctx.contentResolver
+
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) }
+        val srcW = bounds.outWidth
+        val srcH = bounds.outHeight
+        if (srcW <= 0 || srcH <= 0) return null
+
+        val orientation = runCatching {
+            resolver.openInputStream(uri)?.use {
+                ExifInterface(it).getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+            }
+        }.getOrNull() ?: ExifInterface.ORIENTATION_NORMAL
+
+        var sample = 1
+        while (srcW / (sample * 2) >= MAX_DIMEN && srcH / (sample * 2) >= MAX_DIMEN) {
+            sample *= 2
+        }
+        val decodeOpts = BitmapFactory.Options().apply { inSampleSize = sample }
+        val decoded = resolver.openInputStream(uri)?.use {
+            BitmapFactory.decodeStream(it, null, decodeOpts)
+        } ?: return null
+
+        val longest = maxOf(decoded.width, decoded.height)
+        val factor = if (longest > MAX_DIMEN) MAX_DIMEN.toFloat() / longest.toFloat() else 1f
+        val matrix = Matrix().apply {
+            if (factor != 1f) postScale(factor, factor)
+            for (op in ProfileAvatarStore.exifOps(orientation)) when (op) {
+                is ProfileAvatarStore.ExifOp.Rotate -> postRotate(op.degrees)
+                is ProfileAvatarStore.ExifOp.Scale -> postScale(op.sx, op.sy)
+            }
+        }
+        if (matrix.isIdentity) return decoded
+        val out = Bitmap.createBitmap(decoded, 0, 0, decoded.width, decoded.height, matrix, true)
+        if (out !== decoded) decoded.recycle()
+        return out
+    }
+}
+
+/**
+ * The custom-background backdrop: draws [BackgroundImageStore.bitmap] full-bleed under the whole screen,
+ * scaled per [BackgroundImageStore.fillMode]. Drop it into a scaffold's `topBackground` slot with
+ * `fullBleedBackground = true`. Non-interactive + accessibility-hidden (pure decoration). Tile mode is a
+ * single GPU-tiled shader draw — never N image views. Mirrors the iOS BackgroundImageBackdrop.
+ */
+@Composable
+fun BackgroundImageBackdrop(modifier: Modifier = Modifier) {
+    val bmp = BackgroundImageStore.bitmap ?: return
+    val base = modifier
+        .fillMaxSize()
+        .clearAndSetSemantics {} // decorative — invisible to TalkBack
+    when (BackgroundImageStore.fillMode) {
+        BackgroundFillMode.TILE -> {
+            // One tiled shader fill: the source bitmap repeats across the viewport in a single GPU draw.
+            val brush = ShaderBrush(ImageShader(bmp, TileMode.Repeated, TileMode.Repeated))
+            Canvas(modifier = base) { drawRect(brush = brush) }
+        }
+        else -> Image(
+            bitmap = bmp,
+            contentDescription = null,
+            modifier = base,
+            contentScale = when (BackgroundImageStore.fillMode) {
+                BackgroundFillMode.FIT -> ContentScale.Fit
+                BackgroundFillMode.STRETCH -> ContentScale.FillBounds
+                else -> ContentScale.Crop // FILL (and, defensively, TILE — handled above)
+            },
+        )
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/BreatheScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BreatheScreen.kt
@@ -303,10 +303,10 @@ fun BreatheScreen(viewModel: AppViewModel) {
         // into the theme canvas behind the header + top card and bleeds full-width up behind the status bar
         // via the scaffold's topBackground plumbing. The Android equivalent of the iOS
         // `ScreenScaffold(topBackground: liquidScaffoldSky())`; the cards float OVER it on the flat canvas.
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        topBackground = screenBackdropSlot(showDayCycleBackground, skyBehindCards),
         // Sky-behind-cards fills the viewport so the transparent cards reveal the sky the whole way
         // down (Today / Trends / Sleep / metric-detail parity - same two prefs, same two behaviours).
-        fullBleedBackground = showDayCycleBackground && skyBehindCards,
+        fullBleedBackground = screenBackdropFullBleed(showDayCycleBackground, skyBehindCards),
     ) {
         // Mode switch — Breathe / Resonance / Calm me.
         SegmentedPillControl(

--- a/android/app/src/main/java/com/noop/ui/CoachScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachScreen.kt
@@ -87,10 +87,10 @@ fun CoachScreen(vm: CoachViewModel = viewModel()) {
         // LIQUID SKY BACKDROP (the pilot pattern — LiquidScreenSky.kt): the liquid sky sits behind the
         // header and the cards float over the flat canvas below. Reuses the shared LiquidScreenSky() slot
         // verbatim; when the day-cycle background is off, the scaffold paints the plain surface instead.
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        topBackground = screenBackdropSlot(showDayCycleBackground, skyBehindCards),
         // Sky-behind-cards fills the viewport so the transparent cards reveal the sky the whole way
         // down (Today / Trends / Sleep / metric-detail parity - same two prefs, same two behaviours).
-        fullBleedBackground = showDayCycleBackground && skyBehindCards,
+        fullBleedBackground = screenBackdropFullBleed(showDayCycleBackground, skyBehindCards),
     ) {
         if (!configured) {
             CoachSetup(vm = vm)

--- a/android/app/src/main/java/com/noop/ui/CompareScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CompareScreen.kt
@@ -473,10 +473,10 @@ fun CompareScreen(vm: AppViewModel) {
         subtitle = "Overlay signals, draw conclusions.",
         // Liquid sky backdrop (LiquidScreenSky.kt) in the scaffold's topBackground slot, gated on the
         // day-cycle preference — the same pilot plumbing the liquid Today uses.
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        topBackground = screenBackdropSlot(showDayCycleBackground, skyBehindCards),
         // Sky-behind-cards fills the viewport so the transparent cards reveal the sky the whole way
         // down (Today / Trends / Sleep / metric-detail parity - same two prefs, same two behaviours).
-        fullBleedBackground = showDayCycleBackground && skyBehindCards,
+        fullBleedBackground = screenBackdropFullBleed(showDayCycleBackground, skyBehindCards),
     ) {
 
         // ── Metric picker section (chips + range control)

--- a/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
@@ -200,10 +200,10 @@ fun CoupledScreen(
         // The Android equivalent of the iOS `ScreenScaffold(topBackground: liquidScaffoldSky())`; it replaces
         // the classic flat-canvas backdrop with the liquid day-of-sky (LiquidSkyStatic — no per-frame cost on
         // this scrolling column). The other liquid screens drop in the SAME LiquidScreenSky() slot verbatim.
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        topBackground = screenBackdropSlot(showDayCycleBackground, skyBehindCards),
         // Sky-behind-cards fills the viewport so the transparent cards reveal the sky the whole way
         // down (Today / Trends / Sleep / metric-detail parity - same two prefs, same two behaviours).
-        fullBleedBackground = showDayCycleBackground && skyBehindCards,
+        fullBleedBackground = screenBackdropFullBleed(showDayCycleBackground, skyBehindCards),
     ) {
         HeroCard(
             recovery = recovery,

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -169,10 +169,10 @@ fun DevicesScreen(
         // into the flat canvas behind the top of the screen so the frosted device cards float over it. The
         // static sky (LiquidSkyStatic inside the helper) carries no per-frame cost on this scrolling list.
         // Gated on the same "Day-cycle background" setting as Today; off passes null for the plain canvas.
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        topBackground = screenBackdropSlot(showDayCycleBackground, skyBehindCards),
         // Sky-behind-cards fills the viewport so the transparent cards reveal the sky the whole way
         // down (Today / Trends / Sleep / metric-detail parity - same two prefs, same two behaviours).
-        fullBleedBackground = showDayCycleBackground && skyBehindCards,
+        fullBleedBackground = screenBackdropFullBleed(showDayCycleBackground, skyBehindCards),
     ) {
         // #802: the re-pair guide belongs HERE too, not only on Live. A strap that connects but never
         // finishes bonding leaves the user on this screen — it is where you go to fix a device — while the

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -157,10 +157,10 @@ fun HealthScreen(
     LazyScreenScaffold(
         title = uiString(R.string.l10n_health_screen_health_monitor_c4abc3fc),
         subtitle = "Live vitals, streamed from the strap.",
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        topBackground = screenBackdropSlot(showDayCycleBackground, skyBehindCards),
         // Sky-behind-cards fills the viewport so the transparent cards reveal the sky the whole way
         // down (Today / Trends / Sleep / metric-detail parity - same two prefs, same two behaviours).
-        fullBleedBackground = showDayCycleBackground && skyBehindCards,
+        fullBleedBackground = screenBackdropFullBleed(showDayCycleBackground, skyBehindCards),
     ) {
         if (today == null && !hasLiveHr) {
             // Even with no history yet, a freshly-connected strap can be told to sync now (#364) — the
@@ -1716,10 +1716,10 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
             loadedPoints == 1 -> "Your latest reading — trend to follow."
             else -> "Historical trend from cached daily metrics."
         },
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        topBackground = screenBackdropSlot(showDayCycleBackground, skyBehindCards),
         // Sky-behind-cards needs the full-viewport container too — the band container's status-bar
         // offset left the lower cards on plain canvas (tester report).
-        fullBleedBackground = showDayCycleBackground && skyBehindCards,
+        fullBleedBackground = screenBackdropFullBleed(showDayCycleBackground, skyBehindCards),
     ) {
         if (isSeriesBacked && !seriesLoaded) {
             DataPendingNote(

--- a/android/app/src/main/java/com/noop/ui/HydrationScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HydrationScreen.kt
@@ -184,10 +184,10 @@ fun HydrationScreen(viewModel: AppViewModel) {
     LazyScreenScaffold(
         title = uiString(R.string.l10n_hydration_screen_hydration_bdfb040f),
         subtitle = "Your fluid intake today, on this phone only.",
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        topBackground = screenBackdropSlot(showDayCycleBackground, skyBehindCards),
         // Sky-behind-cards fills the viewport so the transparent cards reveal the sky the whole way
         // down (Today / Trends / Sleep / metric-detail parity - same two prefs, same two behaviours).
-        fullBleedBackground = showDayCycleBackground && skyBehindCards,
+        fullBleedBackground = screenBackdropFullBleed(showDayCycleBackground, skyBehindCards),
     ) {
         // HERO — the day's intake as a LiquidVessel (water in a vessel: the literal fit), with the litre
         // figure counting up over it, floating on the frosted translucent-black liquid hero card so it reads

--- a/android/app/src/main/java/com/noop/ui/InsightsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/InsightsScreen.kt
@@ -328,10 +328,10 @@ fun InsightsScreen(vm: AppViewModel, onOpenInsightsHub: () -> Unit = {}) {
     LazyScreenScaffold(
         title = uiString(R.string.l10n_insights_screen_insights_b4510362),
         subtitle = "Interrogate what affects what.",
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        topBackground = screenBackdropSlot(showDayCycleBackground, skyBehindCards),
         // Sky-behind-cards fills the viewport so the transparent cards reveal the sky the whole way
         // down (Today / Trends / Sleep / metric-detail parity - same two prefs, same two behaviours).
-        fullBleedBackground = showDayCycleBackground && skyBehindCards,
+        fullBleedBackground = screenBackdropFullBleed(showDayCycleBackground, skyBehindCards),
     ) {
 
         // --- "What moves you" deep-link into the v5 Insights Hub (ranked, lag-aware ranked-effect feed +

--- a/android/app/src/main/java/com/noop/ui/LiquidScreenSky.kt
+++ b/android/app/src/main/java/com/noop/ui/LiquidScreenSky.kt
@@ -43,6 +43,33 @@ import androidx.compose.ui.unit.dp
 //
 // Non-interactive + accessibility-hidden — it is pure decoration (the scaffold slot never receives taps).
 
+// MARK: - Screen backdrop precedence (#custom-background)
+//
+// The ONE decision every liquid screen shares: which backdrop goes in the scaffold's `topBackground` slot.
+// Precedence is custom image > day-cycle sky > flat canvas. A custom background image (BackgroundImage.kt)
+// OVERRIDES the sky and always bleeds full-screen, so it reads identically behind every tab (the same
+// decode-once cached bitmap on each) — seamless at the tab crossfade. When no image is active this is
+// exactly the previous `showDayCycleBackground ? sky : null` behavior. Routing every screen through these
+// two helpers is what keeps the image seamless across tabs including More.
+
+/** The scaffold `topBackground` slot honouring the image > sky > canvas precedence. `isActive` is
+ *  snapshot-backed, so toggling/removing the image in Settings re-picks the backdrop live. */
+fun screenBackdropSlot(
+    showDayCycleBackground: Boolean,
+    skyBehindCards: Boolean,
+): (@Composable () -> Unit)? = when {
+    BackgroundImageStore.isActive -> { { BackgroundImageBackdrop() } }
+    showDayCycleBackground -> { { LiquidScreenSky(fillHeight = skyBehindCards) } }
+    else -> null
+}
+
+/** `fullBleedBackground` for the same precedence: a custom image always bleeds behind the whole scroll;
+ *  the sky only when "Sky behind cards" is on. */
+fun screenBackdropFullBleed(
+    showDayCycleBackground: Boolean,
+    skyBehindCards: Boolean,
+): Boolean = BackgroundImageStore.isActive || (showDayCycleBackground && skyBehindCards)
+
 /** The reusable liquid sky backdrop for a liquid screen's top region. Drop it into a scaffold's
  *  `topBackground` slot. [height] is the sky band; the sky fades into the theme canvas within it, so the
  *  cards below sit on the flat surface. Mirrors the iOS `liquidScaffoldSky`. */

--- a/android/app/src/main/java/com/noop/ui/LiveScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/LiveScreen.kt
@@ -212,10 +212,10 @@ fun LiveScreen(viewModel: AppViewModel, onManageDevices: () -> Unit = {}) {
         // behind the header + hero and the cards float over the flat canvas below. Reuses the shared
         // LiquidScreenSky() slot verbatim; when the day-cycle background is off, the scaffold paints the
         // plain surface instead (matching the liquid Today's showDayCycleBackground gate).
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        topBackground = screenBackdropSlot(showDayCycleBackground, skyBehindCards),
         // Sky-behind-cards fills the viewport so the transparent cards reveal the sky the whole way
         // down (Today / Trends / Sleep / metric-detail parity - same two prefs, same two behaviours).
-        fullBleedBackground = showDayCycleBackground && skyBehindCards,
+        fullBleedBackground = screenBackdropFullBleed(showDayCycleBackground, skyBehindCards),
     ) {
 
         // Active band row (MW-6) — names the band the console is reading, with a "Manage devices"

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -100,6 +100,10 @@ class MainActivity : ComponentActivity() {
         // header + Settings avatars show it from the first frame. No-op when no photo is set.
         ProfileAvatarStore.load(this)
 
+        // Decode the optional custom background image (if set) + its toggles before first composition so
+        // the backdrop is right from the first frame on every tab. No-op when no image is set.
+        BackgroundImageStore.load(this)
+
         setContent {
             NoopTheme {
                 NoopRoot()

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.material.icons.filled.Upload
 import androidx.compose.material.icons.filled.Vibration
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.outlined.AccountCircle
+import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
@@ -715,6 +716,25 @@ fun SettingsScreen(
         }
     }
 
+    // Custom background image (#custom-background) — two sources per the design: the modern Photo Picker
+    // (no storage permission) and the system file browser ("Browse"). Both read the bytes ONCE, downscale
+    // + persist a private JPEG off the main thread via BackgroundImageStore, which flips the live backdrop
+    // on every tab. We copy immediately, so no persistable-Uri grant is needed for the file source.
+    val setBackgroundFromUri: (Uri) -> Unit = { uri ->
+        scope.launch {
+            val ok = withContext(Dispatchers.IO) { BackgroundImageStore.setImageFromUri(context, uri) }
+            if (!ok) {
+                Toast.makeText(context, "Couldn't use that image. Try another.", Toast.LENGTH_LONG).show()
+            }
+        }
+    }
+    val backgroundPhotoLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickVisualMedia(),
+    ) { uri -> if (uri != null) setBackgroundFromUri(uri) }
+    val backgroundFileLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument(),
+    ) { uri -> if (uri != null) setBackgroundFromUri(uri) }
+
     ScreenScaffold(
         title = uiString(R.string.l10n_settings_screen_settings_c7f73bb5),
         subtitle = "Your numbers, your strap, and how NOOP works. All on this phone.",
@@ -723,10 +743,10 @@ fun SettingsScreen(
         // scroll-heavy list with NO hero gauge, so the liquid finish here is just the sky + liquidPress on
         // the tappable rows. Gated on the same day-cycle background pref Today reads, so turning that off
         // returns Settings to the plain dark canvas too.
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        topBackground = screenBackdropSlot(showDayCycleBackground, skyBehindCards),
         // Sky-behind-cards fills the viewport so the transparent cards reveal the sky the whole way
         // down (Today / Trends / Sleep / metric-detail parity - same two prefs, same two behaviours).
-        fullBleedBackground = showDayCycleBackground && skyBehindCards,
+        fullBleedBackground = screenBackdropFullBleed(showDayCycleBackground, skyBehindCards),
     ) {
         // Read the revision counter so every profile write recomposes this subtree
         // (SharedPreferences is not observable; `mutate` bumps `rev` after each write).
@@ -1315,6 +1335,41 @@ fun SettingsScreen(
                 )
             }
 
+            // Transparent cards (#custom-background): a quick on/off over the SAME cardOpacityPercent —
+            // no separate pref, so it stays in lock-step with the slider below. Off = solid (100%); on =
+            // a sensible see-through default the slider then fine-tunes. Lets the custom background (or the
+            // sky) show through the cards. `checked` is derived from the opacity, so dragging the slider
+            // to solid flips this off automatically.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Transparent cards", style = NoopType.subhead, color = Palette.textPrimary)
+                    Text(
+                        "Let the background show through every card. Tune how much just below.",
+                        style = NoopType.footnote,
+                        color = Palette.textTertiary,
+                    )
+                }
+                Switch(
+                    checked = cardOpacity < 1f,
+                    onCheckedChange = { on ->
+                        cardOpacity = if (on) { if (cardOpacity >= 1f) 0.7f else cardOpacity } else 1f
+                        CardAppearance.opacity = cardOpacity
+                        NoopPrefs.setCardOpacityPercent(context, (cardOpacity * 100).toInt())
+                    },
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = Palette.surfaceBase,
+                        checkedTrackColor = Palette.accent,
+                        uncheckedThumbColor = Palette.textSecondary,
+                        uncheckedTrackColor = Palette.surfaceInset,
+                        uncheckedBorderColor = Palette.hairline,
+                    ),
+                )
+            }
+
             // Card transparency: scale every frosted card's glass toward the background. Live-preview (the
             // cards on THIS screen update as you drag) via CardAppearance; saved on release. Default solid.
             Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
@@ -1356,6 +1411,74 @@ fun SettingsScreen(
                         activeTrackColor = Palette.accent,
                         inactiveTrackColor = Palette.surfaceInset,
                     ),
+                )
+            }
+        }
+
+        // --- Background image (#custom-background) ---
+        // An optional custom photo drawn full-bleed behind EVERY tab (including More), in place of the
+        // day-cycle sky (precedence: image > sky > flat canvas). Pick from Photos or Browse the files; the
+        // image is downscaled + kept on this phone only (NOOP is offline, so it's never uploaded), and left
+        // out of the .noopbak backup like the avatar. Reads BackgroundImageStore snapshot state, so the
+        // controls + the live backdrop update the instant an image is set, removed, or re-scaled.
+        SettingsCard(
+            icon = Icons.Outlined.Image,
+            title = "Background image",
+            blurb = "Optional. Use your own photo behind every tab, in place of the day-cycle sky. " +
+                "Stored only on this phone. Pair it with Transparent cards above to let it show through.",
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                NoopButton(
+                    text = if (BackgroundImageStore.hasImage) "Replace from Photos" else "Choose from Photos",
+                    kind = NoopButtonKind.Secondary,
+                    modifier = Modifier.weight(1f),
+                    onClick = {
+                        backgroundPhotoLauncher.launch(
+                            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+                        )
+                    },
+                )
+                NoopButton(
+                    text = "Browse files",
+                    kind = NoopButtonKind.Secondary,
+                    modifier = Modifier.weight(1f),
+                    onClick = { backgroundFileLauncher.launch(arrayOf("image/*")) },
+                )
+            }
+
+            if (BackgroundImageStore.hasImage) {
+                // Master gate + scaling only make sense once an image exists.
+                SettingsToggleRow(
+                    title = "Show custom background",
+                    detail = "Draw your photo behind every tab, replacing the day-cycle sky.",
+                    checked = BackgroundImageStore.enabled,
+                    onCheckedChange = { BackgroundImageStore.setEnabled(context, it) },
+                )
+                SettingsFormRow(label = "Scaling") {
+                    SegmentedPillControl(
+                        items = BackgroundFillMode.entries,
+                        selection = BackgroundImageStore.fillMode,
+                        label = { mode ->
+                            when (mode) {
+                                BackgroundFillMode.FILL -> "Fill"
+                                BackgroundFillMode.FIT -> "Fit"
+                                BackgroundFillMode.STRETCH -> "Stretch"
+                                BackgroundFillMode.TILE -> "Tile"
+                            }
+                        },
+                        onSelect = { BackgroundImageStore.setFillMode(context, it) },
+                        // Four segments share the row width equally so the labels can't widen the card.
+                        adaptsToAvailableWidth = true,
+                    )
+                }
+                NoopButton(
+                    text = "Remove image",
+                    kind = NoopButtonKind.Tertiary,
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = { BackgroundImageStore.clearImage(context) },
                 )
             }
         }

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -476,10 +476,10 @@ fun SleepScreen(
         // settles into the theme canvas behind the header + hero, bled full-width up behind the status bar
         // via the scaffold's topBackground plumbing. Gated on the day-cycle preference exactly like Today
         // (showDayCycleBackground ? sky : plain canvas). Replaces the classic per-hero scene backdrop.
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        topBackground = screenBackdropSlot(showDayCycleBackground, skyBehindCards),
         // Sky-behind-cards fills the viewport so the transparent cards reveal the sky the whole way down
         // (Today / metric-detail parity — the same two prefs drive the same two behaviours everywhere).
-        fullBleedBackground = showDayCycleBackground && skyBehindCards,
+        fullBleedBackground = screenBackdropFullBleed(showDayCycleBackground, skyBehindCards),
     ) {
         // #65: the transient UNDO banner after a suppressing delete. Restores the deleted row into its
         // ORIGINAL namespace + lifts the tombstone. Mirrors the macOS SleepView sleepUndoBanner.

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -140,10 +140,10 @@ fun StressScreen(vm: AppViewModel, onBreathe: () -> Unit = {}) {
         // status bar via the scaffold's topBackground plumbing), and the cards float OVER it on the flat
         // surface below. The Android equivalent of the iOS `ScreenScaffold(topBackground: liquidScaffoldSky())`.
         // Gated on the "Day-cycle background" setting like Today; off passes null (the flat-canvas path).
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        topBackground = screenBackdropSlot(showDayCycleBackground, skyBehindCards),
         // Sky-behind-cards fills the viewport so the transparent cards reveal the sky the whole way
         // down (Today / Trends / Sleep / metric-detail parity - same two prefs, same two behaviours).
-        fullBleedBackground = showDayCycleBackground && skyBehindCards,
+        fullBleedBackground = screenBackdropFullBleed(showDayCycleBackground, skyBehindCards),
     ) {
         when {
             model != null -> StressContent(model, daytime, stressIndex, freqHrv, onBreathe)

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1145,9 +1145,9 @@ fun TodayScreen(
         // LiquidScreenSky() slot verbatim.
         // #698, gated on the "Day-cycle background" setting (default ON). Off passes null, so the scaffold
         // paints the plain dark surface canvas instead, mirroring iOS's `showDayCycleBackground ? ... : nil`.
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        topBackground = screenBackdropSlot(showDayCycleBackground, skyBehindCards),
         // Sky-behind-cards fills the viewport so the transparent cards reveal the sky the whole way down.
-        fullBleedBackground = showDayCycleBackground && skyBehindCards,
+        fullBleedBackground = screenBackdropFullBleed(showDayCycleBackground, skyBehindCards),
     ) {
         item {
         // LIQUID Today header (iOS LiquidTodayView.scene parity), a full structural rebuild to mirror the

--- a/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
@@ -158,10 +158,10 @@ fun TrendsScreen(vm: AppViewModel) {
         // into the theme canvas behind the header + top rows, full-bleed via the scaffold's topBackground
         // plumbing. Static (LiquidSkyStatic, inside the helper) — never an animated sky behind a scrolling
         // list. Gated on the same day-cycle pref as Today; when off, the scaffold paints the flat canvas.
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        topBackground = screenBackdropSlot(showDayCycleBackground, skyBehindCards),
         // Sky-behind-cards fills the viewport so the transparent cards reveal the sky the whole way down
         // (Today / metric-detail parity — the same two prefs drive the same two behaviours everywhere).
-        fullBleedBackground = showDayCycleBackground && skyBehindCards,
+        fullBleedBackground = screenBackdropFullBleed(showDayCycleBackground, skyBehindCards),
     ) {
         if (days.isEmpty()) {
             item { EmptyTrends() }

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -237,10 +237,10 @@ fun WorkoutsScreen(vm: AppViewModel) {
         // into the theme canvas behind the header + top rows (bled full-width up behind the status bar via
         // the scaffold's topBackground plumbing), and the cards float OVER it on the flat surface below. The
         // Android equivalent of the iOS `ScreenScaffold(topBackground: liquidScaffoldSky())`.
-        topBackground = if (showDayCycleBackground) { { LiquidScreenSky(fillHeight = skyBehindCards) } } else null,
+        topBackground = screenBackdropSlot(showDayCycleBackground, skyBehindCards),
         // Sky-behind-cards fills the viewport so the transparent cards reveal the sky the whole way
         // down (Today / Trends / Sleep / metric-detail parity - same two prefs, same two behaviours).
-        fullBleedBackground = showDayCycleBackground && skyBehindCards,
+        fullBleedBackground = screenBackdropFullBleed(showDayCycleBackground, skyBehindCards),
     ) {
         // Start (or stop) a workout right here, not only on Live — mirrors the Live control (#115).
         // Start + Add sit side-by-side as an action row when a strap is bonded (EXP-018 parity).


### PR DESCRIPTION
## What

Wires the **custom background image** feature end-to-end on **Android**. A user-picked photo is drawn full-bleed behind **every tab (including More)**, replacing the day-cycle sky; cards can be made transparent so it shows through. The cross-platform pref + `BackgroundFillMode` foundation landed in #1234; **iOS + macOS parity follows in a separate PR** (app-target Swift has no default CI — it's validated on the on-demand app-build gate, so I'm keeping it out of this fully-CI-green Android PR).

## Changes

- **`BackgroundImageStore` (`BackgroundImage.kt`)** — cloned from `ProfileAvatarStore`: two-pass `inSampleSize` + EXIF downscale to a device-local `filesDir/background.jpg`, decoded once into snapshot state. `enabled`/`fillMode`/`present` mirror `NoopPrefs`. `MAX_DIMEN` 2560 so a huge pick sub-samples rather than fully decoding into memory.
- **`BackgroundImageBackdrop`** — full-bleed, per fill mode (`ContentScale.Crop`/`Fit`/`FillBounds`); **Tile is a single GPU-tiled `ImageShader` draw**, never N views. Non-interactive + accessibility-hidden.
- **One seam for precedence** — `screenBackdropSlot` / `screenBackdropFullBleed` (`LiquidScreenSky.kt`) return **image > sky > flat canvas**. All **17** scaffold sites route through it, so the same cached bitmap draws identically on every tab — seamless at the crossfade, zero per-tab re-decode. (`AppRoot`'s More scaffold is one of the 17, so More is covered.)
- **Settings "Background image" card** — Choose from Photos (`PickVisualMedia`) or Browse files (`OpenDocument`), a Fill/Fit/Stretch/Tile picker, enable + Remove. Plus a **"Transparent cards" toggle** over the existing `cardOpacityPercent` (one source of truth, no new pref). Decode/IO off the main thread.
- **Device-local, like the avatar** — the file + its toggles are **not** in the `.noopbak` whitelist.

## Scope call (honest)

A few non-frosted surfaces (content-level `surfaceBase` fills, materials, the liquid hero) stay opaque over the image — only `NoopCard`/frosted surfaces go translucent. v1 accepts this; translucent-ifying the hero/materials is a follow-up. Not attempting all ~160 fills.

## Verification

- `./gradlew compileFullDebugKotlin` + full `./gradlew testFullDebugUnitTest` — green.
- `Tools/i18n_audit.py --ci main` — passes (new Settings copy baselined, additive-only).
- On-device backdrop pass (photos + files, each fill mode, every tab incl. More, transparency legibility, Remove restores sky) still to run on a device.
