### PR TITLE
Custom background: iOS + macOS parity (store, backdrop, Settings)

### DIFF
--- a/Strand/Liquid/LiquidSky.swift
+++ b/Strand/Liquid/LiquidSky.swift
@@ -174,9 +174,15 @@ struct LiquidScaffoldSky: View {
     var height: CGFloat = 240
     @AppStorage(SceneBackgroundPrefs.enabledKey) private var showDayCycleBackground = true
     @AppStorage(SkyBehindCardsPrefs.enabledKey) private var skyBehindCards = true
+    // The custom-background store (#custom-background). A custom image OVERRIDES the sky and always fills
+    // the viewport, so every scaffold that passes `liquidScaffoldSky()` reads the SAME cached image and
+    // draws it identically — seamless across tabs including More.
+    @ObservedObject private var backgroundStore = BackgroundImageStore.shared
 
     var body: some View {
-        if showDayCycleBackground {
+        if backgroundStore.isActive {
+            BackgroundImageBackdrop()
+        } else if showDayCycleBackground {
             LiquidSkyStatic(hour: nil, settleStrength: skyBehindCards ? 0.78 : 1)
                 .frame(maxWidth: .infinity, maxHeight: skyBehindCards ? .infinity : nil)
                 .frame(height: skyBehindCards ? nil : height, alignment: .top)

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -137,6 +137,8 @@ struct LiquidTodayView: View {
     /// dark canvas — parity with Android and the classic TodayView, which already honour this pref. Mirrors
     /// Kotlin `NoopPrefs.showDayCycleBackground`.
     @AppStorage(SceneBackgroundPrefs.enabledKey) private var showDayCycleBackground = true
+    /// Custom background image (#custom-background): when active it overrides the sky in the backdrop below.
+    @ObservedObject private var backgroundStore = BackgroundImageStore.shared
 
     // MARK: - Day navigation (ported from classic Today: swipe + calendar, day-keyed reads)
 
@@ -328,9 +330,14 @@ struct LiquidTodayView: View {
         .background(alignment: .top) {
             ZStack(alignment: .top) {
                 StrandPalette.surfaceBase
-                // Day-cycle scene (#698): the sky only paints when the toggle is ON; off = the plain
-                // surfaceBase canvas above (parity with Android + the classic TodayView).
-                if showDayCycleBackground {
+                // Custom background image (#custom-background): a picked photo OVERRIDES the sky, filling
+                // the whole backdrop (same cached image as every other tab, so it's seamless).
+                if backgroundStore.isActive {
+                    BackgroundImageBackdrop()
+                }
+                // Day-cycle scene (#698): the sky only paints when the toggle is ON AND no custom image is
+                // active; off = the plain surfaceBase canvas above (parity with Android + classic TodayView).
+                else if showDayCycleBackground {
                     // Reduce-motion (and low-power) users get the same sky posed still — no twinkle/breath.
                     // Also static until the first data load settles, so launch isn't fighting a live sky too.
                     // "Sky behind cards" (opt-in): fill the whole backdrop with a softer settle so the sky

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -177562,6 +177562,526 @@
           }
         }
       }
+    },
+    "Replace from Photos": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aus Fotos ersetzen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reemplazar desde Fotos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remplacer depuis Photos"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sostituisci da Foto"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Substituir a partir de Fotos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заменить из Фото"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从照片替换"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從照片替換"
+          }
+        }
+      }
+    },
+    "Choose from Photos": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aus Fotos auswählen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elegir desde Fotos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisir depuis Photos"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scegli da Foto"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolher a partir de Fotos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбрать из Фото"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从照片选取"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從照片選取"
+          }
+        }
+      }
+    },
+    "Browse files": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateien durchsuchen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Explorar archivos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parcourir les fichiers"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sfoglia file"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Procurar ficheiros"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обзор файлов"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浏览文件"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "瀏覽檔案"
+          }
+        }
+      }
+    },
+    "Show custom background": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eigenen Hintergrund anzeigen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar fondo personalizado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher l'arrière-plan personnalisé"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra sfondo personalizzato"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar fundo personalizado"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показывать свой фон"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示自定义背景"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示自訂背景"
+          }
+        }
+      }
+    },
+    "Scaling": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skalierung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escala"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à l'échelle"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ridimensionamento"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escala"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Масштабирование"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缩放"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "縮放"
+          }
+        }
+      }
+    },
+    "Background scaling": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hintergrundskalierung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escala del fondo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à l'échelle de l'arrière-plan"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ridimensionamento dello sfondo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escala do fundo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Масштабирование фона"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "背景缩放"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "背景縮放"
+          }
+        }
+      }
+    },
+    "Remove image": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bild entfernen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar imagen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer l'image"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovi immagine"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover imagem"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить изображение"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除图片"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除圖片"
+          }
+        }
+      }
+    },
+    "Optional. Use your own photo behind every tab, in place of the day-cycle sky. It stays on %@ and is never uploaded. Pair it with Transparent cards above to let it show through.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optional. Verwende dein eigenes Foto hinter jedem Tab anstelle des Tageszeit-Himmels. Es bleibt auf %@ und wird nie hochgeladen. Kombiniere es mit „Transparente Karten“ oben, damit es durchscheint."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcional. Usa tu propia foto detrás de cada pestaña, en lugar del cielo del ciclo diario. Se queda en %@ y nunca se sube. Combínala con «Tarjetas transparentes» de arriba para que se vea a través de ellas."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Facultatif. Utilise ta propre photo derrière chaque onglet, à la place du ciel du cycle du jour. Elle reste sur %@ et n'est jamais mise en ligne. Associe-la aux « Cartes transparentes » ci-dessus pour la laisser transparaître."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Facoltativo. Usa una tua foto dietro ogni schermata, al posto del cielo del ciclo giornaliero. Resta su %@ e non viene mai caricata. Abbinala a «Schede trasparenti» qui sopra per lasciarla trasparire."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcional. Usa a tua própria foto por trás de cada separador, em vez do céu do ciclo do dia. Permanece em %@ e nunca é enviada. Combina-a com «Cartões transparentes» acima para a deixar transparecer."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Необязательно. Используйте своё фото за каждой вкладкой вместо неба по циклу дня. Оно остаётся на %@ и никогда не выгружается. Сочетайте его с «Прозрачными карточками» выше, чтобы оно просвечивало."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可选。用你自己的照片作为每个标签页的背景，替代随时间变化的天空。它只保存在 %@ 上，绝不会上传。搭配上方的“透明卡片”即可让它透出来。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可選。用你自己的相片作為每個標籤頁的背景，取代隨時間變化的天空。它只保存在 %@ 上，絕不會上傳。搭配上方的「透明卡片」即可讓它透出來。"
+          }
+        }
+      }
+    },
+    "Transparent cards": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transparente Karten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tarjetas transparentes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cartes transparentes"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schede trasparenti"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cartões transparentes"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Прозрачные карточки"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "透明卡片"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "透明卡片"
+          }
+        }
+      }
+    },
+    "Let the background show through every card. Tune how much just below.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lass den Hintergrund durch jede Karte durchscheinen. Wie stark, stellst du direkt darunter ein."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deja que el fondo se transparente a través de cada tarjeta. Ajusta cuánto justo debajo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laisse l'arrière-plan transparaître à travers chaque carte. Règle l'intensité juste en dessous."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lascia trasparire lo sfondo attraverso ogni scheda. Regola quanto proprio qui sotto."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deixa o fundo transparecer através de cada cartão. Ajusta o quanto mesmo abaixo."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Позвольте фону просвечивать сквозь каждую карточку. Настройте степень чуть ниже."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "让背景透过每张卡片显现。可在下方调整透出程度。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "讓背景透過每張卡片顯現。可在下方調整透出程度。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -471,6 +471,8 @@ struct MetricDetailView: View {
     /// extends the sky to the full viewport (softer settle) so the transparent cards reveal it throughout.
     @AppStorage(SceneBackgroundPrefs.enabledKey) private var showDayCycleBackground = true
     @AppStorage(SkyBehindCardsPrefs.enabledKey) private var skyBehindCards = true
+    /// Custom background image (#custom-background): when active it overrides the sky in the backdrop.
+    @ObservedObject private var backgroundStore = BackgroundImageStore.shared
     // Profile basics for the Fitness Age not-ready countdown (age/sex gate its readiness lead). Injected
     // app-wide at the root; previews supply their own. Only read on the fitness_age empty-state path.
     @EnvironmentObject var profile: ProfileStore
@@ -698,7 +700,10 @@ struct MetricDetailView: View {
         .background(alignment: .top) {
             ZStack(alignment: .top) {
                 StrandPalette.surfaceBase
-                if showDayCycleBackground {
+                // Custom background image (#custom-background) OVERRIDES the sky, full-bleed.
+                if backgroundStore.isActive {
+                    BackgroundImageBackdrop()
+                } else if showDayCycleBackground {
                     LiquidSkyStatic(hour: nil, settleStrength: skyBehindCards ? 0.78 : 1)
                         .frame(maxWidth: .infinity)
                         .frame(height: skyBehindCards ? nil : 240, alignment: .top)

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -24,6 +24,12 @@ struct SettingsView: View {
     /// Profile-photo picker selection (PhotosUI). Cleared back to nil once the bytes are loaded.
     @State private var avatarPickerItem: PhotosPickerItem?
 
+    /// Custom background image (#custom-background). The store owns the decoded image + toggles; the
+    /// picker selection + the file-importer flag are local UI state.
+    @ObservedObject private var backgroundStore = BackgroundImageStore.shared
+    @State private var backgroundPickerItem: PhotosPickerItem?
+    @State private var showBackgroundFileImporter = false
+
     /// Backup & restore UI state.
     @State private var backupBusy = false
     @State private var backupAlertTitle = ""
@@ -576,6 +582,87 @@ struct SettingsView: View {
         }
     }
 
+    /// Custom background image controls (#custom-background): pick from Photos or Browse the files,
+    /// choose the fill mode, and (once set) enable / remove. The store downscales + persists a
+    /// device-local file — nothing here is uploaded (NOOP is offline), and it is left out of `.noopbak`.
+    /// Wrapped in a layout-transparent `Group` so the picker `onChange` + the file importer can hang off
+    /// the whole cluster while it still flows inside the appearance VStack.
+    @ViewBuilder
+    private var backgroundImageControls: some View {
+        let hasImage = backgroundStore.hasImage
+        Group {
+            HStack(spacing: NoopMetrics.space2) {
+                PhotosPicker(selection: $backgroundPickerItem, matching: .images) {
+                    Text(hasImage ? "Replace from Photos" : "Choose from Photos")
+                }
+                .buttonStyle(NoopButtonStyle(.secondary, fullWidth: true))
+
+                Button {
+                    showBackgroundFileImporter = true
+                } label: {
+                    Text("Browse files")
+                }
+                .buttonStyle(NoopButtonStyle(.secondary, fullWidth: true))
+            }
+
+            if hasImage {
+                Toggle(isOn: $backgroundStore.enabled) {
+                    Text("Show custom background")
+                        .font(StrandFont.subhead)
+                        .foregroundStyle(StrandPalette.textPrimary)
+                }
+                .toggleStyle(.switch)
+                .tint(StrandPalette.accent)
+
+                FormRow(label: "Scaling") {
+                    Picker("Scaling", selection: $backgroundStore.fillMode) {
+                        ForEach(BackgroundFillMode.allCases) { mode in
+                            Text(mode.label).tag(mode)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .tint(StrandPalette.accent)
+                    .accessibilityLabel("Background scaling")
+                }
+
+                Button {
+                    backgroundStore.clearImage()
+                } label: {
+                    Text("Remove image")
+                }
+                .buttonStyle(NoopButtonStyle(.tertiary))
+                .accessibilityHint("Removes the custom background and restores the day-cycle sky")
+            }
+
+            Text("Optional. Use your own photo behind every tab, in place of the day-cycle sky. It stays on \(Platform.deviceNounPhrase) and is never uploaded. Pair it with Transparent cards above to let it show through.")
+                .font(StrandFont.caption)
+                .foregroundStyle(StrandPalette.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        // Load the picked photo's bytes, hand them to the store (which downscales + persists), then clear
+        // the selection so the same photo can be re-picked. Mirrors the avatar row.
+        .onChange(of: backgroundPickerItem) { newItem in
+            guard let newItem else { return }
+            Task {
+                let data = try? await newItem.loadTransferable(type: Data.self)
+                await MainActor.run {
+                    if let data { backgroundStore.setImage(from: data) }
+                    backgroundPickerItem = nil
+                }
+            }
+        }
+        // "Browse files" — the system file browser. The picked URL is security-scoped (outside the
+        // sandbox), so bracket the one-time read; we copy the bytes into our own file immediately.
+        .fileImporter(isPresented: $showBackgroundFileImporter, allowedContentTypes: [.image]) { result in
+            guard case .success(let url) = result else { return }
+            let didAccess = url.startAccessingSecurityScopedResource()
+            defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+            if let data = try? Data(contentsOf: url) { backgroundStore.setImage(from: data) }
+        }
+    }
+
     /// One-line state for the "Steps estimate" tap-through row: manual, the auto-fit confidence, or a
     /// not-yet-calibrated prompt — so the row reflects the current calibration without opening the sheet.
     private var stepsCalibrationSummary: String {
@@ -1029,6 +1116,26 @@ struct SettingsView: View {
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
+                // MARK: Transparent cards — a quick on/off over the SAME cardOpacityPercent (no separate
+                // pref), so it stays in lock-step with the slider below. Off = solid (100%); on = a sensible
+                // see-through default the slider then fine-tunes. Lets the custom background (or the sky)
+                // show through the cards. `isOn` is derived from the opacity, so dragging to solid flips off.
+                Toggle(isOn: Binding(
+                    get: { cardOpacityPercent < 100 },
+                    set: { on in cardOpacityPercent = on ? (cardOpacityPercent >= 100 ? 70 : cardOpacityPercent) : 100 }
+                )) {
+                    Text("Transparent cards")
+                        .font(StrandFont.subhead)
+                        .foregroundStyle(StrandPalette.textPrimary)
+                }
+                .toggleStyle(.switch)
+                .tint(StrandPalette.accent)
+                Text("Let the background show through every card. Tune how much just below.")
+                    .font(StrandFont.caption)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
                 // MARK: Card transparency — fade every frosted card's glass toward the background. Reactive
                 // @AppStorage, so all cards (incl. the ones on this screen) update live as you drag. The
                 // slider shows TRANSPARENCY (0 = solid, 100 = clear); we store the OPACITY percent.
@@ -1054,6 +1161,9 @@ struct SettingsView: View {
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
+
+                rowDivider
+                backgroundImageControls
             }
         }
     }

--- a/Strand/System/BackgroundImageStore.swift
+++ b/Strand/System/BackgroundImageStore.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Combine
+import SwiftUI
+import StrandDesign
+
+// MARK: - Custom background image (#custom-background)
+//
+// A user-picked photo drawn full-bleed behind EVERY screen, REPLACING the day-cycle sky when enabled
+// (precedence: image > sky > flat canvas). The Kotlin twin is BackgroundImageStore.kt; the pref KEYS +
+// the BackgroundFillMode rawValues are byte-identical (both read StrandDesign's BackgroundImagePrefs /
+// BackgroundFillMode). Cloned from the avatar pipeline (ProfileAvatarView.AvatarImage.downscaledJPEG),
+// but the bytes live in a FILE under Application Support rather than a UserDefaults blob — a full-screen
+// photo is far larger than a 256px avatar. Like the avatar, the file + its toggles are device-local and
+// deliberately NOT in the `.noopbak` whitelist.
+//
+// A single shared, @MainActor ObservableObject: the decoded `Image` is cached once and every scaffold's
+// backdrop (LiquidScaffoldSky) + Today's inline sky observe THE SAME instance, so the identical picture
+// is drawn on every tab (seamless at the crossfade) with zero per-tab re-decode.
+
+@MainActor
+final class BackgroundImageStore: ObservableObject {
+    static let shared = BackgroundImageStore()
+
+    /// The decoded background, cached; nil = none stored. Drawn by ``BackgroundImageBackdrop``.
+    @Published private(set) var image: Image?
+
+    /// Master enable toggle (persisted under ``BackgroundImagePrefs/enabledKey``). When true AND an
+    /// image is present, the custom image overrides the sky.
+    @Published var enabled: Bool {
+        didSet { d.set(enabled, forKey: BackgroundImagePrefs.enabledKey) }
+    }
+
+    /// How the image is scaled (persisted under ``BackgroundImagePrefs/fillModeKey`` as its rawValue).
+    @Published var fillMode: BackgroundFillMode {
+        didSet { d.set(fillMode.rawValue, forKey: BackgroundImagePrefs.fillModeKey) }
+    }
+
+    private let d = UserDefaults.standard
+
+    /// The custom image is the ACTIVE backdrop (top of the precedence: enabled AND actually decoded).
+    var isActive: Bool { enabled && image != nil }
+
+    /// Whether a photo is stored — drives the Remove affordance in Settings.
+    var hasImage: Bool { image != nil }
+
+    private init() {
+        enabled = d.bool(forKey: BackgroundImagePrefs.enabledKey)                       // default false
+        fillMode = BackgroundFillMode.resolve(d.string(forKey: BackgroundImagePrefs.fillModeKey) ?? "")
+        // Decode the persisted image (if any) once, up front.
+        if d.bool(forKey: BackgroundImagePrefs.presentKey),
+           let url = try? Self.fileURL(create: false),
+           let data = try? Data(contentsOf: url),
+           let platform = PlatformImage(data: data) {
+            image = Image(platformImage: platform)
+        } else {
+            image = nil
+        }
+    }
+
+    /// Store a picked image: downscale + re-encode to the app-private JPEG, flip the present flag, and
+    /// update the cached ``image``. Silently no-ops if the bytes can't be decoded/written (the current
+    /// background is left untouched). Reuses the avatar's ImageIO downscale path.
+    func setImage(from data: Data) {
+        // Downscale the longest edge to at most MAX_DIMEN so a 100MP pick can never sit full-res in memory
+        // or on disk; fall back to the raw bytes only if the decode fails (matching setAvatar).
+        let jpeg = AvatarImage.downscaledJPEG(from: data, maxDimension: Self.maxDimension, quality: 0.9) ?? data
+        guard let platform = PlatformImage(data: jpeg) else { return }
+        guard let url = try? Self.fileURL(create: true) else { return }
+        do {
+            try jpeg.write(to: url, options: .atomic)
+        } catch {
+            return
+        }
+        d.set(true, forKey: BackgroundImagePrefs.presentKey)
+        image = Image(platformImage: platform)
+    }
+
+    /// Remove the photo: delete the file, clear the present flag, drop the cached ``image``.
+    func clearImage() {
+        if let url = try? Self.fileURL(create: false) {
+            try? FileManager.default.removeItem(at: url)
+        }
+        d.set(false, forKey: BackgroundImagePrefs.presentKey)
+        image = nil
+    }
+
+    /// Longest edge (px) the stored image is downscaled to — big enough to cover a large display crisply,
+    /// capped so a huge pick sub-samples rather than fully decoding. Mirrors the Kotlin MAX_DIMEN.
+    private static let maxDimension: CGFloat = 2560
+
+    /// `<AppSupport>/OpenWhoop/background.jpg` (the same base folder the capture recorder uses).
+    private static func fileURL(create: Bool) throws -> URL {
+        let fm = FileManager.default
+        let dir = try fm.url(for: .applicationSupportDirectory, in: .userDomainMask,
+                             appropriateFor: nil, create: create)
+            .appendingPathComponent("OpenWhoop", isDirectory: true)
+        if create { try fm.createDirectory(at: dir, withIntermediateDirectories: true) }
+        return dir.appendingPathComponent("background.jpg", isDirectory: false)
+    }
+}
+
+// MARK: - BackgroundImageBackdrop
+//
+// Draws the cached custom image full-bleed under the whole screen, scaled per the store's fill mode. Drop
+// it into a scaffold's `topBackground` slot (or a Today/MetricExplorer inline `.background` ZStack) above
+// `surfaceBase`. Non-interactive + accessibility-hidden (pure decoration). Mirrors the Compose twin.
+
+struct BackgroundImageBackdrop: View {
+    @ObservedObject private var store = BackgroundImageStore.shared
+
+    var body: some View {
+        if let image = store.image {
+            scaled(image)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .clipped()
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+        }
+    }
+
+    @ViewBuilder
+    private func scaled(_ image: Image) -> some View {
+        switch store.fillMode {
+        case .fill:
+            image.resizable().scaledToFill()
+        case .fit:
+            // Aspect-fit letterboxes onto the surfaceBase canvas beneath (the scaffold ZStack draws it).
+            image.resizable().scaledToFit()
+        case .stretch:
+            // No aspect ratio — the image stretches to exactly fill the frame.
+            image.resizable()
+        case .tile:
+            // One GPU-tiled draw: the source repeats across the viewport.
+            image.resizable(resizingMode: .tile)
+        }
+    }
+}


### PR DESCRIPTION
## What

**iOS + macOS parity** for the custom background image feature — the Swift twin of #1235 (Android). Completes the three-platform rollout begun in #1234 (shared prefs + `BackgroundFillMode`). A user-picked photo is drawn full-bleed behind every scaffold (including More) in place of the day-cycle sky; cards can be made transparent so it shows through.

## Changes

- **`Strand/System/BackgroundImageStore.swift`** — `@MainActor ObservableObject` singleton (same shape as `CaffeineLogStore.shared`). Reuses the avatar's `AvatarImage.downscaledJPEG` (ImageIO, EXIF-correct), but persists a **device-local JPEG under Application Support** rather than a UserDefaults blob (a full-screen photo is far bigger than a 256px avatar). One cached decoded `Image`; `enabled`/`fillMode` persist to the shared `BackgroundImagePrefs` keys.
- **`BackgroundImageBackdrop`** — full-bleed, per fill mode: `scaledToFill` / `scaledToFit` / `resizable()` / `resizable(resizingMode: .tile)`. Non-interactive + accessibility-hidden.
- **One seam:** `LiquidScaffoldSky` is now image-aware (**image > sky > flat canvas**), so all ~25 `liquidScaffoldSky()` call sites — every macOS detail screen + the iOS tabs incl. More — pick it up for free. The two inline sky sites (`LiquidTodayView`, `MetricExplorerView`) get the same precedence check, so every surface draws the same cached image seamlessly.
- **Settings** — a "Background image" block: **Choose from Photos** (`PhotosPicker`) / **Browse files** (`.fileImporter`, security-scoped read), a Fill/Fit/Stretch/Tile `Picker`, enable + Remove, plus a **Transparent cards** toggle over the existing `cardOpacityPercent` (one source of truth, no new pref).
- **Localization** — the 10 new Settings strings added to `Localizable.xcstrings` across all 8 locales (de/es/fr/it/pt-PT/ru/zh-Hans/zh-Hant). `Tools/i18n_audit.py --ci` passes.
- **Device-local, like the avatar** — the file + toggles are **not** in the `.noopbak` whitelist.

## Parity

Byte-identical to Android: same `BackgroundImagePrefs` keys + `BackgroundFillMode` rawValues (from StrandDesign, parity-tested in #1234); same precedence, same fill-mode semantics, same "transparent cards over the opacity pref" model.

## Scope call

Same as #1235: only frosted `StrandCard`/`NoopCard` surfaces go translucent over the image; content-level `surfaceBase` fills / materials / the liquid hero stay opaque. v1 accepts this.

## Verification

- App-target Swift has **no default CI** (`app-build.yml` is disabled). Validated on the **on-demand app-build gate**: **Build Strand** (macOS) + **Build NOOPiOS** (iOS) both green on this branch.
- `Tools/i18n_audit.py --ci main` — green (new xcstrings entries, focus locales complete).
- On-device backdrop pass (photos + files, each fill mode, every tab incl. More, transparency legibility, Remove restores the sky) still to run on device.
