### PR TITLE
Custom background: auto-enable on first pick

### DIFF
--- a/Strand/System/BackgroundImageStore.swift
+++ b/Strand/System/BackgroundImageStore.swift
@@ -73,6 +73,10 @@ final class BackgroundImageStore: ObservableObject {
         }
         d.set(true, forKey: BackgroundImagePrefs.presentKey)
         image = Image(platformImage: platform)
+        // Actively picking an image means the user wants to SEE it — turn the background on so it shows
+        // immediately, instead of silently storing a photo that stays hidden behind a separate toggle.
+        // They can still toggle it off afterwards (the image is kept) or Remove it entirely.
+        if !enabled { enabled = true }
     }
 
     /// Remove the photo: delete the file, clear the present flag, drop the cached ``image``.

--- a/android/app/src/main/java/com/noop/ui/BackgroundImage.kt
+++ b/android/app/src/main/java/com/noop/ui/BackgroundImage.kt
@@ -114,6 +114,10 @@ object BackgroundImageStore {
         }
         NoopPrefs.setBackgroundImagePresent(app, true)
         bitmap = scaled.asImageBitmap()
+        // Actively picking an image means the user wants to SEE it — turn the background on so it shows
+        // immediately, instead of silently storing a photo that stays hidden behind a separate toggle.
+        // They can still toggle it off afterwards (the image is kept) or Remove it entirely.
+        if (!enabled) setEnabled(app, true)
         return true
     }
 


### PR DESCRIPTION
## Re-review finding

Re-reviewing the merged custom-background PRs (#1235 Android, #1236 iOS/macOS) surfaced a real UX papercut: **picking an image set the file + `present` flag but never the `enabled` toggle**, so `isActive` stayed false and the photo was invisible until the user separately found and flipped **Show custom background**. First-run reads as "I picked a background and nothing happened."

## Fix

A successful pick now turns the background on, in the store (`BackgroundImageStore.setImageFromUri` / `setImage`) so it covers both the Photos and Files paths on both platforms. The image is still kept if the user toggles it off afterwards (toggle → sky, image preserved), and Remove clears it entirely. Byte-identical Swift ↔ Kotlin.

## Verification

- Android: `compileFullDebugKotlin` + full `testFullDebugUnitTest` green.
- iOS + macOS: app-build gate (Build Strand + Build NOOPiOS).