### PR TITLE
Workout route export: GPX + FIT builders (Swift + Kotlin twins)

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/RouteExporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/RouteExporter.swift
@@ -106,24 +106,30 @@ public enum RouteExporter {
         }
 
         let elapsedMs = UInt32(max(0, endTs - startTs)) &* 1000
-        let distCenti: UInt32 = distanceM.map { UInt32(max(0, (($0 * 100.0).rounded()))) } ?? 0xFFFF_FFFF
-        let kcal: UInt16 = energyKcal.map { UInt16(min(max(0, $0.rounded()), 65534)) } ?? 0xFFFF
+        let distCenti: UInt32? = distanceM.map { UInt32(max(0, ($0 * 100.0).rounded())) }
 
         // lap (global 19): external tools expect at least one; our decoder folds it under session.
+        // Distance uses the FIT 0xFFFFFFFF "invalid" value when absent — the decoder special-cases it.
         defn(&body, local: 2, global: 19, fields: [(253, 4, 0x86), (2, 4, 0x86), (7, 4, 0x86), (9, 4, 0x86)])
         body.append(2)
-        u32(&body, fitTime(endTs)); u32(&body, fitTime(startTs)); u32(&body, elapsedMs); u32(&body, distCenti)
+        u32(&body, fitTime(endTs)); u32(&body, fitTime(startTs)); u32(&body, elapsedMs)
+        u32(&body, distCenti ?? 0xFFFF_FFFF)
 
-        // session (global 18): the authoritative summary the importer reads.
-        defn(&body, local: 3, global: 18, fields: [
-            (253, 4, 0x86), (2, 4, 0x86), (7, 4, 0x86), (9, 4, 0x86),
-            (5, 1, 0x00), (11, 2, 0x84), (16, 1, 0x02), (17, 1, 0x02),
-        ])
+        // session (global 18): only the fields we actually have. An absent HR must be truly absent — the
+        // importer's validHr accepts 1..300 and would misread a 0xFF sentinel as a real HR of 255.
+        var sf: [(Int, Int, Int)] = []
+        var sd: [UInt8] = []
+        sf.append((253, 4, 0x86)); u32(&sd, fitTime(endTs))
+        sf.append((2, 4, 0x86)); u32(&sd, fitTime(startTs))
+        sf.append((7, 4, 0x86)); u32(&sd, elapsedMs)
+        sf.append((5, 1, 0x00)); u8(&sd, fitSport(canon))
+        if let distCenti { sf.append((9, 4, 0x86)); u32(&sd, distCenti) }
+        if let energyKcal { sf.append((11, 2, 0x84)); u16(&sd, UInt16(min(max(0, energyKcal.rounded()), 65534))) }
+        if let avgHr { sf.append((16, 1, 0x02)); u8(&sd, min(max(avgHr, 0), 254)) }
+        if let maxHr { sf.append((17, 1, 0x02)); u8(&sd, min(max(maxHr, 0), 254)) }
+        defn(&body, local: 3, global: 18, fields: sf)
         body.append(3)
-        u32(&body, fitTime(endTs)); u32(&body, fitTime(startTs)); u32(&body, elapsedMs); u32(&body, distCenti)
-        u8(&body, fitSport(canon)); u16(&body, UInt16(kcal))
-        u8(&body, avgHr.map { min(max($0, 0), 254) } ?? 0xFF)
-        u8(&body, maxHr.map { min(max($0, 0), 254) } ?? 0xFF)
+        body.append(contentsOf: sd)
 
         // activity (global 34): one session.
         defn(&body, local: 4, global: 34, fields: [(253, 4, 0x86), (1, 2, 0x84), (2, 1, 0x00)])

--- a/Packages/StrandImport/Sources/StrandImport/RouteExporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/RouteExporter.swift
@@ -1,0 +1,278 @@
+import Foundation
+
+/// Export a recorded GPS workout route to a standard interchange file (GPX 1.1 or FIT) — the sibling of
+/// ``ActivityFileImporter`` and the byte-for-byte twin of the Kotlin `RouteExport`. Pure Swift + Foundation
+/// (no CoreLocation/UIKit), so it lives in this package, unit-tests without an app, and is covered by
+/// `swift-packages.yml`.
+///
+/// FIDELITY NOTE: the stored route (`RouteMath` polyline) is lat/lon ONLY — no per-point timestamp,
+/// elevation, speed, or HR is persisted. So an export carries the lat/lon track plus per-point timestamps
+/// INTERPOLATED evenly across the workout window `[startTs, endTs]` (total duration is exact; instantaneous
+/// pace is not), and workout-level metadata (sport, distance, calories, avg/max HR). That's the honest
+/// maximum from what's stored, and what Strava / Garmin Connect need to read the track as a timed activity.
+public enum RouteExporter {
+
+    public enum Format: String, Sendable, Equatable {
+        case gpx, fit
+        public var ext: String { rawValue }
+        public var label: String { self == .gpx ? "GPX" : "FIT" }
+    }
+
+    /// Seconds between the Unix epoch and the FIT epoch (1989-12-31T00:00:00Z).
+    static let fitEpoch = 631_065_600
+
+    /// Semicircles per degree — the FIT position unit: `semicircles = degrees × 2^31 / 180`.
+    static let semiPerDeg = 2_147_483_648.0 / 180.0
+
+    // MARK: - Public API
+
+    public static func render(
+        _ format: Format,
+        route: [RoutePoint],
+        startTs: Int,
+        endTs: Int,
+        sport: String?,
+        distanceM: Double? = nil,
+        energyKcal: Double? = nil,
+        avgHr: Int? = nil,
+        maxHr: Int? = nil
+    ) -> Data {
+        switch format {
+        case .gpx:
+            return Data(buildGpx(route: route, startTs: startTs, endTs: endTs, sport: sport,
+                                 distanceM: distanceM).utf8)
+        case .fit:
+            return buildFit(route: route, startTs: startTs, endTs: endTs, sport: sport,
+                            distanceM: distanceM, energyKcal: energyKcal, avgHr: avgHr, maxHr: maxHr)
+        }
+    }
+
+    /// GPX 1.1 track. Each `trkpt` carries lat/lon + an interpolated `time`; no `ele`/HR (none stored).
+    public static func buildGpx(
+        route: [RoutePoint],
+        startTs: Int,
+        endTs: Int,
+        sport: String?,
+        distanceM: Double? = nil
+    ) -> String {
+        let canon = canonicalSport(sport)
+        let times = interpolatedTimes(route.count, startTs, endTs)
+        var s = ""
+        s += "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        s += "<gpx version=\"1.1\" creator=\"NOOP\" xmlns=\"http://www.topografix.com/GPX/1/1\">\n"
+        s += "  <metadata>\n    <time>\(iso(startTs))</time>\n  </metadata>\n"
+        s += "  <trk>\n"
+        s += "    <name>\(xmlEscape(displaySport(canon)))</name>\n"
+        s += "    <type>\(xmlEscape(canon))</type>\n"
+        s += "    <trkseg>\n"
+        for i in route.indices {
+            let p = route[i]
+            s += "      <trkpt lat=\"\(coord(p.lat))\" lon=\"\(coord(p.lon))\">"
+            s += "<time>\(iso(times[i]))</time></trkpt>\n"
+        }
+        s += "    </trkseg>\n  </trk>\n</gpx>\n"
+        return s
+    }
+
+    /// A minimal but well-formed FIT activity file: file_id, one record per point, lap, session, activity,
+    /// and the trailing CRC-16. Decodes back through ``ActivityFileImporter`` and imports into Strava /
+    /// Garmin Connect.
+    public static func buildFit(
+        route: [RoutePoint],
+        startTs: Int,
+        endTs: Int,
+        sport: String?,
+        distanceM: Double? = nil,
+        energyKcal: Double? = nil,
+        avgHr: Int? = nil,
+        maxHr: Int? = nil
+    ) -> Data {
+        let canon = canonicalSport(sport)
+        let times = interpolatedTimes(route.count, startTs, endTs)
+        var body: [UInt8] = []
+
+        // file_id (global 0): type=activity, manufacturer=development, time_created.
+        defn(&body, local: 0, global: 0, fields: [(0, 1, 0x00), (1, 2, 0x84), (4, 4, 0x86)])
+        body.append(0)
+        u8(&body, 4); u16(&body, 255); u32(&body, fitTime(startTs))
+
+        // record (global 20): timestamp + position.
+        defn(&body, local: 1, global: 20, fields: [(253, 4, 0x86), (0, 4, 0x85), (1, 4, 0x85)])
+        for i in route.indices {
+            body.append(1)
+            u32(&body, fitTime(times[i]))
+            s32(&body, semicircles(route[i].lat))
+            s32(&body, semicircles(route[i].lon))
+        }
+
+        let elapsedMs = UInt32(max(0, endTs - startTs)) &* 1000
+        let distCenti: UInt32 = distanceM.map { UInt32(max(0, (($0 * 100.0).rounded()))) } ?? 0xFFFF_FFFF
+        let kcal: UInt16 = energyKcal.map { UInt16(min(max(0, $0.rounded()), 65534)) } ?? 0xFFFF
+
+        // lap (global 19): external tools expect at least one; our decoder folds it under session.
+        defn(&body, local: 2, global: 19, fields: [(253, 4, 0x86), (2, 4, 0x86), (7, 4, 0x86), (9, 4, 0x86)])
+        body.append(2)
+        u32(&body, fitTime(endTs)); u32(&body, fitTime(startTs)); u32(&body, elapsedMs); u32(&body, distCenti)
+
+        // session (global 18): the authoritative summary the importer reads.
+        defn(&body, local: 3, global: 18, fields: [
+            (253, 4, 0x86), (2, 4, 0x86), (7, 4, 0x86), (9, 4, 0x86),
+            (5, 1, 0x00), (11, 2, 0x84), (16, 1, 0x02), (17, 1, 0x02),
+        ])
+        body.append(3)
+        u32(&body, fitTime(endTs)); u32(&body, fitTime(startTs)); u32(&body, elapsedMs); u32(&body, distCenti)
+        u8(&body, fitSport(canon)); u16(&body, UInt16(kcal))
+        u8(&body, avgHr.map { min(max($0, 0), 254) } ?? 0xFF)
+        u8(&body, maxHr.map { min(max($0, 0), 254) } ?? 0xFF)
+
+        // activity (global 34): one session.
+        defn(&body, local: 4, global: 34, fields: [(253, 4, 0x86), (1, 2, 0x84), (2, 1, 0x00)])
+        body.append(4)
+        u32(&body, fitTime(endTs)); u16(&body, 1); u8(&body, 0)
+
+        // 12-byte header + body + CRC-16 over header+body.
+        var out: [UInt8] = []
+        u8(&out, 12); u8(&out, 0x20); u16(&out, 2140); u32(&out, UInt32(body.count))
+        out.append(contentsOf: Array(".FIT".utf8))
+        out.append(contentsOf: body)
+        let crc = fitCrc(out)
+        u16(&out, UInt16(crc))
+        return Data(out)
+    }
+
+    // MARK: - Timing / units
+
+    /// Per-point Unix seconds, spread evenly across `[startTs, endTs]` (start for a single point).
+    static func interpolatedTimes(_ n: Int, _ startTs: Int, _ endTs: Int) -> [Int] {
+        if n <= 0 { return [] }
+        if n == 1 { return [startTs] }
+        let span = Double(max(0, endTs - startTs))
+        return (0..<n).map { i in startTs + Int((span * Double(i) / Double(n - 1)).rounded()) }
+    }
+
+    private static func fitTime(_ unix: Int) -> UInt32 {
+        UInt32(min(max(0, unix - fitEpoch), 0xFFFF_FFFF))
+    }
+
+    private static func semicircles(_ deg: Double) -> Int32 {
+        let v = (deg * semiPerDeg).rounded()
+        if v >= Double(Int32.max) { return Int32.max }
+        if v <= Double(Int32.min) { return Int32.min }
+        return Int32(v)
+    }
+
+    /// ISO-8601 UTC to whole seconds, e.g. `2026-08-11T04:47:38Z`. Computed by hand (civil-from-days) so
+    /// it is deterministic and matches the Kotlin `Instant.toString()` twin exactly, with no shared
+    /// mutable `DateFormatter`.
+    static func iso(_ unix: Int) -> String {
+        let days = Int(floor(Double(unix) / 86400.0))
+        let secOfDay = unix - days * 86400
+        let hh = secOfDay / 3600, mm = (secOfDay % 3600) / 60, ss = secOfDay % 60
+        // Howard Hinnant's civil_from_days.
+        let z = days + 719_468
+        let era = (z >= 0 ? z : z - 146_096) / 146_097
+        let doe = z - era * 146_097
+        let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365
+        let y0 = yoe + era * 400
+        let doy = doe - (365 * yoe + yoe / 4 - yoe / 100)
+        let mp = (5 * doy + 2) / 153
+        let d = doy - (153 * mp + 2) / 5 + 1
+        let m = mp < 10 ? mp + 3 : mp - 9
+        let y = m <= 2 ? y0 + 1 : y0
+        return String(format: "%04d-%02d-%02dT%02d:%02d:%02dZ", y, m, d, hh, mm, ss)
+    }
+
+    /// Fixed 6-dp coordinate — well beyond the polyline's ~1 m (precision-5) resolution.
+    private static func coord(_ v: Double) -> String { String(format: "%.6f", v) }
+
+    // MARK: - Sport mapping
+
+    /// Collapse a free-form sport string to one canonical key (the GPS-relevant families).
+    static func canonicalSport(_ sport: String?) -> String {
+        let s = (sport ?? "").lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        switch s {
+        case "", "other": return "other"
+        case "run", "running", "jog", "jogging", "treadmill": return "run"
+        case "cycle", "cycling", "bike", "biking", "ride", "spinning": return "cycle"
+        case "walk", "walking", "rucking": return "walk"
+        case "hike", "hiking": return "hike"
+        case "swim", "swimming": return "swim"
+        default: return s
+        }
+    }
+
+    private static func displaySport(_ canon: String) -> String {
+        canon.isEmpty ? canon : canon.prefix(1).uppercased() + canon.dropFirst()
+    }
+
+    /// FIT `sport` enum (session field 5). Round-trips through the importer's sport-name map.
+    private static func fitSport(_ canon: String) -> Int {
+        switch canon {
+        case "run": return 1
+        case "cycle": return 2
+        case "swim": return 5
+        case "walk": return 11
+        case "hike": return 15
+        default: return 0
+        }
+    }
+
+    // MARK: - XML / byte helpers
+
+    private static func xmlEscape(_ s: String) -> String {
+        var out = ""
+        out.reserveCapacity(s.count + 8)
+        for c in s {
+            switch c {
+            case "&": out += "&amp;"
+            case "<": out += "&lt;"
+            case ">": out += "&gt;"
+            case "\"": out += "&quot;"
+            case "'": out += "&apos;"
+            default: out.append(c)
+            }
+        }
+        return out
+    }
+
+    /// Emit a FIT definition message for `local`/`global` with `fields` (field num, size, base-type),
+    /// little-endian.
+    private static func defn(_ b: inout [UInt8], local: Int, global: Int,
+                             fields: [(Int, Int, Int)]) {
+        u8(&b, 0x40 | (local & 0x0F)) // definition record header
+        u8(&b, 0)                     // reserved
+        u8(&b, 0)                     // architecture: 0 = little-endian
+        u16(&b, UInt16(global))
+        u8(&b, fields.count)
+        for f in fields { u8(&b, f.0); u8(&b, f.1); u8(&b, f.2) }
+    }
+
+    private static func u8(_ b: inout [UInt8], _ v: Int) { b.append(UInt8(v & 0xFF)) }
+    private static func u16(_ b: inout [UInt8], _ v: UInt16) {
+        b.append(UInt8(v & 0xFF)); b.append(UInt8((v >> 8) & 0xFF))
+    }
+    private static func u32(_ b: inout [UInt8], _ v: UInt32) {
+        b.append(UInt8(v & 0xFF)); b.append(UInt8((v >> 8) & 0xFF))
+        b.append(UInt8((v >> 16) & 0xFF)); b.append(UInt8((v >> 24) & 0xFF))
+    }
+    private static func s32(_ b: inout [UInt8], _ v: Int32) { u32(&b, UInt32(bitPattern: v)) }
+
+    /// The standard FIT CRC-16 (nibble-table variant), computed over `data`.
+    static func fitCrc(_ data: [UInt8]) -> Int {
+        let table = [
+            0x0000, 0xCC01, 0xD801, 0x1400, 0xF001, 0x3C00, 0x2800, 0xE401,
+            0xA001, 0x6C00, 0x7800, 0xB401, 0x5000, 0x9C01, 0x8801, 0x4400,
+        ]
+        var crc = 0
+        for byte in data {
+            let b = Int(byte)
+            var tmp = table[crc & 0xF]
+            crc = (crc >> 4) & 0x0FFF
+            crc = crc ^ tmp ^ table[b & 0xF]
+            tmp = table[crc & 0xF]
+            crc = (crc >> 4) & 0x0FFF
+            crc = crc ^ tmp ^ table[(b >> 4) & 0xF]
+        }
+        return crc & 0xFFFF
+    }
+}

--- a/Packages/StrandImport/Tests/StrandImportTests/RouteExporterTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/RouteExporterTests.swift
@@ -61,6 +61,17 @@ final class RouteExporterTests: XCTestCase {
         XCTAssertEqual(RouteExporter.fitCrc(Array(bytes[0..<(bytes.count - 2)])), crc)
     }
 
+    func testFitWithoutHrDoesNotFabricateHr() {
+        // Regression: the FIT "no HR" case must decode to nil HR. validHr accepts 1...300, so a 0xFF
+        // sentinel would be misread as a real HR of 255 — the fields must be OMITTED, not sentinelled.
+        let data = RouteExporter.render(.fit, route: route, startTs: startTs, endTs: endTs, sport: "walk")
+        let a = ActivityFileImporter.parse(data: data, filename: "x.fit").activity
+        XCTAssertNotNil(a)
+        XCTAssertNil(a!.avgHr)
+        XCTAssertNil(a!.maxHr)
+        XCTAssertNil(a!.energyKcal)
+    }
+
     func testInterpolatedTimesSpanTheWindow() {
         let t = RouteExporter.interpolatedTimes(5, 1000, 2000)
         XCTAssertEqual(t.first, 1000)

--- a/Packages/StrandImport/Tests/StrandImportTests/RouteExporterTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/RouteExporterTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import StrandImport
+
+/// RouteExporter (GPX/FIT) is validated by ROUND-TRIP through ``ActivityFileImporter``: a route + metadata
+/// is exported, then re-parsed, and the decoded track/summary must match. This pins the encoders against
+/// the app's own decoders (the same ones that read real Strava/Garmin files), so a byte-layout regression
+/// in either format is caught in `swift-packages` CI. The Kotlin twin (`RouteExportTest`) asserts the same.
+final class RouteExporterTests: XCTestCase {
+
+    private let route = [
+        RoutePoint(lat: 37.334900, lon: -122.009000),
+        RoutePoint(lat: 37.335200, lon: -122.008400),
+        RoutePoint(lat: 37.335900, lon: -122.007700),
+        RoutePoint(lat: 37.336500, lon: -122.006900),
+    ]
+    private let startTs = 1_723_000_000
+    private let endTs = 1_723_001_800 // +30 min
+
+    func testGpxRoundTripsThroughTheImporter() {
+        let data = RouteExporter.render(.gpx, route: route, startTs: startTs, endTs: endTs,
+                                        sport: "running", distanceM: 1234.5)
+        XCTAssertEqual(ActivityFileImporter.detectFormat(data: data), .gpx)
+        let a = ActivityFileImporter.parse(data: data, filename: "route.gpx").activity
+        XCTAssertNotNil(a)
+        XCTAssertEqual(a!.route.count, route.count)
+        for i in route.indices {
+            XCTAssertEqual(a!.route[i].lat, route[i].lat, accuracy: 1e-5)
+            XCTAssertEqual(a!.route[i].lon, route[i].lon, accuracy: 1e-5)
+        }
+        XCTAssertEqual(Int(a!.start.timeIntervalSince1970), startTs)
+        XCTAssertEqual(Int(a!.end.timeIntervalSince1970), endTs)
+    }
+
+    func testFitRoundTripsThroughTheImporter() {
+        let data = RouteExporter.render(.fit, route: route, startTs: startTs, endTs: endTs,
+                                        sport: "cycling", distanceM: 1234.5, energyKcal: 210, avgHr: 142, maxHr: 171)
+        XCTAssertEqual(ActivityFileImporter.detectFormat(data: data), .fit)
+        let a = ActivityFileImporter.parse(data: data, filename: "route.fit").activity
+        XCTAssertNotNil(a)
+        XCTAssertEqual(a!.route.count, route.count)
+        for i in route.indices {
+            XCTAssertEqual(a!.route[i].lat, route[i].lat, accuracy: 1e-5)
+            XCTAssertEqual(a!.route[i].lon, route[i].lon, accuracy: 1e-5)
+        }
+        XCTAssertEqual(a!.sport?.lowercased().contains("cycl"), true)
+        XCTAssertEqual(a!.distanceM ?? 0, 1234.5, accuracy: 0.5)
+        XCTAssertEqual(a!.energyKcal ?? 0, 210, accuracy: 0.5)
+        XCTAssertEqual(a!.avgHr, 142)
+        XCTAssertEqual(a!.maxHr, 171)
+        XCTAssertEqual(Int(a!.start.timeIntervalSince1970), startTs)
+        XCTAssertEqual(Int(a!.end.timeIntervalSince1970), endTs)
+    }
+
+    func testFitHasValidHeaderAndCrc() {
+        let bytes = [UInt8](RouteExporter.render(.fit, route: route, startTs: startTs, endTs: endTs, sport: "run"))
+        XCTAssertEqual(Int(bytes[0]), 12)                  // header size
+        XCTAssertEqual(Array(bytes[8...11]), Array(".FIT".utf8)) // ".FIT"
+        let dataSize = Int(bytes[4]) | (Int(bytes[5]) << 8) | (Int(bytes[6]) << 16) | (Int(bytes[7]) << 24)
+        XCTAssertEqual(bytes.count, 12 + dataSize + 2)     // header + body + 2-byte CRC
+        let crc = Int(bytes[bytes.count - 2]) | (Int(bytes[bytes.count - 1]) << 8)
+        XCTAssertEqual(RouteExporter.fitCrc(Array(bytes[0..<(bytes.count - 2)])), crc)
+    }
+
+    func testInterpolatedTimesSpanTheWindow() {
+        let t = RouteExporter.interpolatedTimes(5, 1000, 2000)
+        XCTAssertEqual(t.first, 1000)
+        XCTAssertEqual(t.last, 2000)
+        XCTAssertEqual(t[2], 1500)
+        XCTAssertEqual(RouteExporter.interpolatedTimes(1, 500, 900), [500])
+    }
+
+    func testIsoMatchesTheKotlinInstantFormat() {
+        // Kotlin's Instant.ofEpochSecond(1_723_000_000).toString() == "2024-08-07T03:06:40Z".
+        XCTAssertEqual(RouteExporter.iso(1_723_000_000), "2024-08-07T03:06:40Z")
+        XCTAssertEqual(RouteExporter.iso(0), "1970-01-01T00:00:00Z")
+    }
+
+    func testCanonicalSportCollapsesAliases() {
+        XCTAssertEqual(RouteExporter.canonicalSport("Running"), "run")
+        XCTAssertEqual(RouteExporter.canonicalSport("bike"), "cycle")
+        XCTAssertEqual(RouteExporter.canonicalSport("Walking"), "walk")
+        XCTAssertEqual(RouteExporter.canonicalSport(nil), "other")
+    }
+}

--- a/android/app/src/main/java/com/noop/ingest/RouteExport.kt
+++ b/android/app/src/main/java/com/noop/ingest/RouteExport.kt
@@ -111,26 +111,31 @@ object RouteExport {
         }
 
         val elapsedMs = ((endTs - startTs).coerceAtLeast(0)) * 1000L
-        val distCenti = distanceM?.let { (it * 100.0).roundToLong().coerceAtLeast(0) } ?: 0xFFFFFFFFL
-        val kcal = energyKcal?.let { it.roundToLong().coerceIn(0, 0xFFFEL) } ?: 0xFFFFL
+        val distCenti = distanceM?.let { (it * 100.0).roundToLong().coerceAtLeast(0) }
 
-        // ── lap (global 19) ── (external tools expect at least one; our decoder folds it under session)
+        // ── lap (global 19) ── (external tools expect at least one; our decoder folds it under session).
+        // Distance uses the FIT 0xFFFFFFFF "invalid" value when absent — the decoder special-cases it.
         body.defn(2, 19, listOf(F(253, 4, 0x86), F(2, 4, 0x86), F(7, 4, 0x86), F(9, 4, 0x86)))
         body.write(2)
-        body.u32(fitTime(endTs)); body.u32(fitTime(startTs)); body.u32(elapsedMs); body.u32(distCenti)
+        body.u32(fitTime(endTs)); body.u32(fitTime(startTs)); body.u32(elapsedMs)
+        body.u32(distCenti ?: 0xFFFFFFFFL)
 
-        // ── session (global 18): the authoritative summary the importer reads ──
-        body.defn(
-            3, 18,
-            listOf(
-                F(253, 4, 0x86), F(2, 4, 0x86), F(7, 4, 0x86), F(9, 4, 0x86),
-                F(5, 1, 0x00), F(11, 2, 0x84), F(16, 1, 0x02), F(17, 1, 0x02),
-            ),
-        )
+        // ── session (global 18): the authoritative summary the importer reads. ONLY the fields we
+        // actually have are emitted — an absent HR must be truly absent, since the importer's validHr
+        // accepts 1..300 and would misread a 0xFF sentinel as a real HR of 255. ──
+        val sf = ArrayList<F>(8)
+        val sd = ByteArrayOutputStream(28)
+        sf.add(F(253, 4, 0x86)); sd.u32(fitTime(endTs))
+        sf.add(F(2, 4, 0x86)); sd.u32(fitTime(startTs))
+        sf.add(F(7, 4, 0x86)); sd.u32(elapsedMs)
+        sf.add(F(5, 1, 0x00)); sd.u8(fitSport(canon))
+        if (distCenti != null) { sf.add(F(9, 4, 0x86)); sd.u32(distCenti) }
+        energyKcal?.let { sf.add(F(11, 2, 0x84)); sd.u16(it.roundToLong().coerceIn(0, 0xFFFEL).toInt()) }
+        avgHr?.let { sf.add(F(16, 1, 0x02)); sd.u8(it.coerceIn(0, 254)) }
+        maxHr?.let { sf.add(F(17, 1, 0x02)); sd.u8(it.coerceIn(0, 254)) }
+        body.defn(3, 18, sf)
         body.write(3)
-        body.u32(fitTime(endTs)); body.u32(fitTime(startTs)); body.u32(elapsedMs); body.u32(distCenti)
-        body.u8(fitSport(canon)); body.u16(kcal.toInt())
-        body.u8(avgHr?.coerceIn(0, 254) ?: 0xFF); body.u8(maxHr?.coerceIn(0, 254) ?: 0xFF)
+        body.write(sd.toByteArray())
 
         // ── activity (global 34): one session ──
         body.defn(4, 34, listOf(F(253, 4, 0x86), F(1, 2, 0x84), F(2, 1, 0x00)))

--- a/android/app/src/main/java/com/noop/ingest/RouteExport.kt
+++ b/android/app/src/main/java/com/noop/ingest/RouteExport.kt
@@ -1,0 +1,258 @@
+package com.noop.ingest
+
+import java.io.ByteArrayOutputStream
+import java.time.Instant
+import kotlin.math.roundToLong
+
+/**
+ * Export a recorded GPS workout route to a standard interchange file (GPX 1.1 or FIT), the sibling of
+ * [ActivityFileImporter]. Pure JVM — no Android/Room/UI types — so it unit-tests off-device and stays the
+ * byte-for-byte twin of the Swift `RouteExporter` in `Packages/StrandImport`.
+ *
+ * FIDELITY NOTE: the stored route ([com.noop.analytics.RouteMath] polyline) is lat/lon ONLY — no per-point
+ * timestamp, elevation, speed, or HR is persisted (see the workout's `routePolyline`). So an export carries
+ * the lat/lon track plus per-point timestamps INTERPOLATED evenly across the workout window
+ * [startTs, endTs] (total duration is exact; instantaneous pace is not), and workout-level metadata
+ * (sport, distance, calories, avg/max HR). That's the honest maximum from what's stored, and it's what
+ * Strava / Garmin Connect need to read the track back as a timed activity.
+ */
+object RouteExport {
+
+    /** One route point — lat/lon only, matching the stored polyline. */
+    data class Point(val lat: Double, val lon: Double)
+
+    enum class Format(val ext: String, val label: String) {
+        GPX("gpx", "GPX"),
+        FIT("fit", "FIT"),
+    }
+
+    /** Seconds between the Unix epoch and the FIT epoch (1989-12-31T00:00:00Z). */
+    private const val FIT_EPOCH = 631_065_600L
+
+    /** Semicircles per degree — the FIT position unit: `semicircles = degrees × 2^31 / 180`. */
+    private const val SEMI_PER_DEG = 2_147_483_648.0 / 180.0
+
+    // ── Public API ──────────────────────────────────────────────────────────────────────────────────
+
+    fun render(
+        format: Format,
+        points: List<Point>,
+        startTs: Long,
+        endTs: Long,
+        sport: String?,
+        distanceM: Double? = null,
+        energyKcal: Double? = null,
+        avgHr: Int? = null,
+        maxHr: Int? = null,
+    ): ByteArray = when (format) {
+        Format.GPX -> buildGpx(points, startTs, endTs, sport, distanceM).toByteArray(Charsets.UTF_8)
+        Format.FIT -> buildFit(points, startTs, endTs, sport, distanceM, energyKcal, avgHr, maxHr)
+    }
+
+    /** GPX 1.1 track. Each `trkpt` carries lat/lon + an interpolated `time`; no `ele`/HR (none stored). */
+    fun buildGpx(
+        points: List<Point>,
+        startTs: Long,
+        endTs: Long,
+        sport: String?,
+        distanceM: Double? = null,
+    ): String {
+        val canon = canonicalSport(sport)
+        val times = interpolatedTimes(points.size, startTs, endTs)
+        val sb = StringBuilder(256 + points.size * 96)
+        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+        sb.append("<gpx version=\"1.1\" creator=\"NOOP\" ")
+        sb.append("xmlns=\"http://www.topografix.com/GPX/1/1\">\n")
+        sb.append("  <metadata>\n    <time>").append(iso(startTs)).append("</time>\n  </metadata>\n")
+        sb.append("  <trk>\n")
+        sb.append("    <name>").append(xmlEscape(displaySport(canon))).append("</name>\n")
+        sb.append("    <type>").append(xmlEscape(canon)).append("</type>\n")
+        sb.append("    <trkseg>\n")
+        for (i in points.indices) {
+            val p = points[i]
+            sb.append("      <trkpt lat=\"").append(coord(p.lat)).append("\" lon=\"").append(coord(p.lon))
+                .append("\"><time>").append(iso(times[i])).append("</time></trkpt>\n")
+        }
+        sb.append("    </trkseg>\n  </trk>\n</gpx>\n")
+        return sb.toString()
+    }
+
+    /** A minimal but well-formed FIT activity file: file_id, one record per point, lap, session,
+     *  activity, and the trailing CRC-16. Decodes back through [ActivityFileImporter]/FIT and imports into
+     *  Strava / Garmin Connect. */
+    fun buildFit(
+        points: List<Point>,
+        startTs: Long,
+        endTs: Long,
+        sport: String?,
+        distanceM: Double? = null,
+        energyKcal: Double? = null,
+        avgHr: Int? = null,
+        maxHr: Int? = null,
+    ): ByteArray {
+        val canon = canonicalSport(sport)
+        val times = interpolatedTimes(points.size, startTs, endTs)
+        val body = ByteArrayOutputStream(64 + points.size * 14)
+
+        // ── file_id (global 0): type=activity, manufacturer=development, time_created ──
+        body.defn(0, 0, listOf(F(0, 1, 0x00), F(1, 2, 0x84), F(4, 4, 0x86)))
+        body.write(0)                 // local type 0 data header
+        body.u8(4)                    // type = activity
+        body.u16(255)                 // manufacturer = development
+        body.u32(fitTime(startTs))
+
+        // ── record (global 20): timestamp + position ──
+        body.defn(1, 20, listOf(F(253, 4, 0x86), F(0, 4, 0x85), F(1, 4, 0x85)))
+        for (i in points.indices) {
+            body.write(1)             // local type 1 data header
+            body.u32(fitTime(times[i]))
+            body.s32(semicircles(points[i].lat))
+            body.s32(semicircles(points[i].lon))
+        }
+
+        val elapsedMs = ((endTs - startTs).coerceAtLeast(0)) * 1000L
+        val distCenti = distanceM?.let { (it * 100.0).roundToLong().coerceAtLeast(0) } ?: 0xFFFFFFFFL
+        val kcal = energyKcal?.let { it.roundToLong().coerceIn(0, 0xFFFEL) } ?: 0xFFFFL
+
+        // ── lap (global 19) ── (external tools expect at least one; our decoder folds it under session)
+        body.defn(2, 19, listOf(F(253, 4, 0x86), F(2, 4, 0x86), F(7, 4, 0x86), F(9, 4, 0x86)))
+        body.write(2)
+        body.u32(fitTime(endTs)); body.u32(fitTime(startTs)); body.u32(elapsedMs); body.u32(distCenti)
+
+        // ── session (global 18): the authoritative summary the importer reads ──
+        body.defn(
+            3, 18,
+            listOf(
+                F(253, 4, 0x86), F(2, 4, 0x86), F(7, 4, 0x86), F(9, 4, 0x86),
+                F(5, 1, 0x00), F(11, 2, 0x84), F(16, 1, 0x02), F(17, 1, 0x02),
+            ),
+        )
+        body.write(3)
+        body.u32(fitTime(endTs)); body.u32(fitTime(startTs)); body.u32(elapsedMs); body.u32(distCenti)
+        body.u8(fitSport(canon)); body.u16(kcal.toInt())
+        body.u8(avgHr?.coerceIn(0, 254) ?: 0xFF); body.u8(maxHr?.coerceIn(0, 254) ?: 0xFF)
+
+        // ── activity (global 34): one session ──
+        body.defn(4, 34, listOf(F(253, 4, 0x86), F(1, 2, 0x84), F(2, 1, 0x00)))
+        body.write(4)
+        body.u32(fitTime(endTs)); body.u16(1); body.u8(0)
+
+        val bodyBytes = body.toByteArray()
+
+        // ── 12-byte header + body + CRC-16 over header+body ──
+        val out = ByteArrayOutputStream(14 + bodyBytes.size + 2)
+        out.u8(12)                    // header size
+        out.u8(0x20)                  // protocol version 2.0
+        out.u16(2140)                 // profile version 21.40
+        out.u32(bodyBytes.size.toLong())
+        out.write(byteArrayOf('.'.code.toByte(), 'F'.code.toByte(), 'I'.code.toByte(), 'T'.code.toByte()))
+        out.write(bodyBytes)
+        val crc = fitCrc(out.toByteArray())
+        out.u16(crc)
+        return out.toByteArray()
+    }
+
+    // ── Timing / units ────────────────────────────────────────────────────────────────────────────────
+
+    /** Per-point Unix seconds, spread evenly across [startTs, endTs] (start for a single point). */
+    internal fun interpolatedTimes(n: Int, startTs: Long, endTs: Long): LongArray {
+        if (n <= 0) return LongArray(0)
+        if (n == 1) return longArrayOf(startTs)
+        val span = (endTs - startTs).coerceAtLeast(0).toDouble()
+        return LongArray(n) { i -> startTs + (span * i / (n - 1)).roundToLong() }
+    }
+
+    private fun fitTime(unix: Long): Long = (unix - FIT_EPOCH).coerceIn(0, 0xFFFFFFFFL)
+
+    private fun semicircles(deg: Double): Int =
+        (deg * SEMI_PER_DEG).roundToLong().coerceIn(Int.MIN_VALUE.toLong(), Int.MAX_VALUE.toLong()).toInt()
+
+    /** ISO-8601 UTC to whole seconds, e.g. `2026-08-11T04:47:38Z`. */
+    private fun iso(unix: Long): String = Instant.ofEpochSecond(unix).toString()
+
+    /** Fixed 6-dp coordinate — well beyond the polyline's ~1 m (precision-5) resolution. */
+    private fun coord(v: Double): String = String.format(java.util.Locale.US, "%.6f", v)
+
+    // ── Sport mapping ───────────────────────────────────────────────────────────────────────────────
+
+    /** Collapse a free-form sport string to one canonical key (the GPS-relevant families). */
+    internal fun canonicalSport(sport: String?): String {
+        val s = (sport ?: "").lowercase(java.util.Locale.US).trim()
+        return when (s) {
+            "", "other" -> "other"
+            "run", "running", "jog", "jogging", "treadmill" -> "run"
+            "cycle", "cycling", "bike", "biking", "ride", "spinning" -> "cycle"
+            "walk", "walking", "rucking" -> "walk"
+            "hike", "hiking" -> "hike"
+            "swim", "swimming" -> "swim"
+            else -> s
+        }
+    }
+
+    private fun displaySport(canon: String): String =
+        canon.replaceFirstChar { if (it.isLowerCase()) it.titlecase(java.util.Locale.US) else it.toString() }
+
+    /** FIT `sport` enum (session field 5). Round-trips through the importer's `sportName`. */
+    private fun fitSport(canon: String): Int = when (canon) {
+        "run" -> 1
+        "cycle" -> 2
+        "swim" -> 5
+        "walk" -> 11
+        "hike" -> 15
+        else -> 0
+    }
+
+    // ── XML / byte helpers ────────────────────────────────────────────────────────────────────────────
+
+    private fun xmlEscape(s: String): String {
+        val sb = StringBuilder(s.length + 8)
+        for (c in s) when (c) {
+            '&' -> sb.append("&amp;")
+            '<' -> sb.append("&lt;")
+            '>' -> sb.append("&gt;")
+            '"' -> sb.append("&quot;")
+            '\'' -> sb.append("&apos;")
+            else -> sb.append(c)
+        }
+        return sb.toString()
+    }
+
+    /** A FIT field definition (field number, byte size, base-type byte). */
+    private data class F(val num: Int, val size: Int, val baseType: Int)
+
+    /** Emit a FIT definition message for [localType]/[globalNum] with [fields] (little-endian). */
+    private fun ByteArrayOutputStream.defn(localType: Int, globalNum: Int, fields: List<F>) {
+        u8(0x40 or (localType and 0x0F)) // definition record header
+        u8(0)                            // reserved
+        u8(0)                            // architecture: 0 = little-endian
+        u16(globalNum)
+        u8(fields.size)
+        for (f in fields) { u8(f.num); u8(f.size); u8(f.baseType) }
+    }
+
+    private fun ByteArrayOutputStream.u8(v: Int) = write(v and 0xFF)
+    private fun ByteArrayOutputStream.u16(v: Int) { write(v and 0xFF); write((v ushr 8) and 0xFF) }
+    private fun ByteArrayOutputStream.u32(v: Long) {
+        write((v and 0xFF).toInt()); write(((v ushr 8) and 0xFF).toInt())
+        write(((v ushr 16) and 0xFF).toInt()); write(((v ushr 24) and 0xFF).toInt())
+    }
+    private fun ByteArrayOutputStream.s32(v: Int) = u32(v.toLong() and 0xFFFFFFFFL)
+
+    /** The standard FIT CRC-16 (nibble-table variant), computed over [data]. */
+    internal fun fitCrc(data: ByteArray): Int {
+        val table = intArrayOf(
+            0x0000, 0xCC01, 0xD801, 0x1400, 0xF001, 0x3C00, 0x2800, 0xE401,
+            0xA001, 0x6C00, 0x7800, 0xB401, 0x5000, 0x9C01, 0x8801, 0x4400,
+        )
+        var crc = 0
+        for (b in data) {
+            var tmp = table[crc and 0xF]
+            crc = (crc ushr 4) and 0x0FFF
+            crc = crc xor tmp xor table[b.toInt() and 0xF]
+            tmp = table[crc and 0xF]
+            crc = (crc ushr 4) and 0x0FFF
+            crc = crc xor tmp xor table[(b.toInt() ushr 4) and 0xF]
+        }
+        return crc and 0xFFFF
+    }
+}

--- a/android/app/src/test/java/com/noop/ingest/RouteExportTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/RouteExportTest.kt
@@ -1,0 +1,116 @@
+package com.noop.ingest
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.xmlpull.v1.XmlPullParser
+
+/**
+ * RouteExport (GPX/FIT) is validated by ROUND-TRIP through [ActivityFileImporter]: a route + metadata is
+ * exported, then re-parsed, and the decoded track/summary must match. This pins the encoders against the
+ * app's own decoders (the same decoders that read real Strava/Garmin files), so a byte-layout regression
+ * in either format is caught off-device. The Swift twin (`RouteExporterTests`) asserts the same shape.
+ */
+class RouteExportTest {
+
+    // The GPX path parses via ActivityFileImporter's pull-parser seam; android.util.Xml is a throwing
+    // stub off-device, so swap in kXML2 exactly like ActivityFileImporterTest.
+    @Before fun installRealParser() {
+        ActivityFileImporter.newPullParser = {
+            Class.forName("org.kxml2.io.KXmlParser").getDeclaredConstructor().newInstance() as XmlPullParser
+        }
+    }
+
+    @After fun resetParser() { ActivityFileImporter.newPullParser = { android.util.Xml.newPullParser() } }
+
+    private val route = listOf(
+        RouteExport.Point(37.334900, -122.009000),
+        RouteExport.Point(37.335200, -122.008400),
+        RouteExport.Point(37.335900, -122.007700),
+        RouteExport.Point(37.336500, -122.006900),
+    )
+    private val startTs = 1_723_000_000L
+    private val endTs = 1_723_001_800L // +30 min
+
+    @Test fun gpxRoundTripsThroughTheImporter() {
+        val bytes = RouteExport.buildGpx(route, startTs, endTs, "running", distanceM = 1234.5)
+            .toByteArray(Charsets.UTF_8)
+        assertEquals(ActivityFileImporter.Format.GPX, ActivityFileImporter.detectFormat(bytes))
+        val a = ActivityFileImporter.parse(bytes, "route.gpx").activity
+        assertNotNull(a)
+        assertEquals(route.size, a!!.route.size)
+        for (i in route.indices) {
+            assertEquals(route[i].lat, a.route[i].lat, 1e-5)
+            assertEquals(route[i].lon, a.route[i].lon, 1e-5)
+        }
+        // Interpolated per-point times span the whole window, so start/end round-trip exactly.
+        assertEquals(startTs, a.startTs)
+        assertEquals(endTs, a.endTs)
+    }
+
+    @Test fun fitRoundTripsThroughTheImporter() {
+        val bytes = RouteExport.buildFit(
+            route, startTs, endTs, "cycling",
+            distanceM = 1234.5, energyKcal = 210.0, avgHr = 142, maxHr = 171,
+        )
+        assertEquals(ActivityFileImporter.Format.FIT, ActivityFileImporter.detectFormat(bytes))
+        val a = ActivityFileImporter.parse(bytes, "route.fit").activity
+        assertNotNull(a)
+        assertEquals(route.size, a!!.route.size)
+        for (i in route.indices) {
+            assertEquals(route[i].lat, a.route[i].lat, 1e-5)
+            assertEquals(route[i].lon, a.route[i].lon, 1e-5)
+        }
+        assertEquals("Cycling", a.sport)
+        assertEquals(1234.5, a.distanceM!!, 0.5)
+        assertEquals(210.0, a.energyKcal!!, 0.5)
+        assertEquals(142, a.avgHr)
+        assertEquals(171, a.maxHr)
+        assertEquals(startTs, a.startTs)
+        assertEquals(endTs, a.endTs)
+    }
+
+    @Test fun fitHasValidHeaderAndCrc() {
+        val bytes = RouteExport.buildFit(route, startTs, endTs, "run")
+        // 12-byte header, ".FIT" at offset 8, declared data size fits, trailing CRC matches.
+        assertEquals(12, bytes[0].toInt() and 0xFF)
+        assertEquals('.'.code, bytes[8].toInt() and 0xFF)
+        assertEquals('F'.code, bytes[9].toInt() and 0xFF)
+        val dataSize = (bytes[4].toInt() and 0xFF) or ((bytes[5].toInt() and 0xFF) shl 8) or
+            ((bytes[6].toInt() and 0xFF) shl 16) or ((bytes[7].toInt() and 0xFF) shl 24)
+        assertEquals(12 + dataSize + 2, bytes.size) // header + body + 2-byte CRC
+        val crc = (bytes[bytes.size - 2].toInt() and 0xFF) or ((bytes[bytes.size - 1].toInt() and 0xFF) shl 8)
+        assertEquals(RouteExport.fitCrc(bytes.copyOfRange(0, bytes.size - 2)), crc)
+    }
+
+    @Test fun singlePointAndEmptyDegradeGracefully() {
+        // One point: still a valid file, one trackpoint at startTs.
+        val one = RouteExport.buildFit(listOf(route.first()), startTs, endTs, "walk")
+        val a = ActivityFileImporter.parse(one, "x.fit").activity
+        assertNotNull(a)
+        assertEquals(1, a!!.route.size)
+        // Empty GPX is still well-formed (no trackpoints); the importer rejects it without throwing.
+        val gpx = RouteExport.buildGpx(emptyList(), startTs, endTs, "run").toByteArray(Charsets.UTF_8)
+        assertTrue(String(gpx).contains("<trkseg>"))
+    }
+
+    @Test fun interpolatedTimesSpanTheWindow() {
+        val t = RouteExport.interpolatedTimes(5, 1000L, 2000L)
+        assertEquals(1000L, t.first())
+        assertEquals(2000L, t.last())
+        assertEquals(1500L, t[2]) // midpoint
+        assertTrue((1 until t.size).all { t[it] >= t[it - 1] })
+        assertEquals(longArrayOf(500L).toList(), RouteExport.interpolatedTimes(1, 500L, 900L).toList())
+    }
+
+    @Test fun canonicalSportCollapsesAliases() {
+        assertEquals("run", RouteExport.canonicalSport("Running"))
+        assertEquals("cycle", RouteExport.canonicalSport("bike"))
+        assertEquals("walk", RouteExport.canonicalSport("Walking"))
+        assertEquals("hike", RouteExport.canonicalSport("hiking"))
+        assertEquals("other", RouteExport.canonicalSport(null))
+    }
+}

--- a/android/app/src/test/java/com/noop/ingest/RouteExportTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/RouteExportTest.kt
@@ -3,6 +3,7 @@ package com.noop.ingest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -95,6 +96,17 @@ class RouteExportTest {
         // Empty GPX is still well-formed (no trackpoints); the importer rejects it without throwing.
         val gpx = RouteExport.buildGpx(emptyList(), startTs, endTs, "run").toByteArray(Charsets.UTF_8)
         assertTrue(String(gpx).contains("<trkseg>"))
+    }
+
+    @Test fun fitWithoutHrDoesNotFabricateHr() {
+        // Regression: the FIT "no HR" case must decode to NULL HR. validHr accepts 1..300, so a 0xFF
+        // sentinel would be misread as a real HR of 255 — the fields must be OMITTED, not sentinelled.
+        val bytes = RouteExport.buildFit(route, startTs, endTs, "walk") // no HR, no calories
+        val a = ActivityFileImporter.parse(bytes, "x.fit").activity
+        assertNotNull(a)
+        assertNull(a!!.avgHr)
+        assertNull(a.maxHr)
+        assertNull(a.energyKcal)
     }
 
     @Test fun interpolatedTimesSpanTheWindow() {


### PR DESCRIPTION
## What

Export a recorded GPS workout route to a standard **GPX 1.1** or **FIT** file (Strava / Garmin Connect / any GPS tool) — the sibling of the existing activity-file **importer**. This PR is the **pure builders + tests only** (parity-critical and fully CI-covered); the workout-detail **UI + share wiring** land in a follow-up PR.

## Changes

- **`StrandImport.RouteExporter`** (Swift) + **`com.noop.ingest.RouteExport`** (Kotlin) — twins: `buildGpx` / `buildFit` / `render`. Pure (no CoreLocation/UIKit, no Android/Room), so both unit-test off-device.
- **FIT** is hand-encoded — file_id + one `record` per point + lap + session + activity + trailing **CRC-16**, decoder-compatible.

## Fidelity (honest)

The stored route (`RouteMath` polyline) is **lat/lon only** — no per-point timestamp, elevation, speed, or HR is persisted. So the export carries the lat/lon track plus per-point timestamps **interpolated evenly** across the workout window `[startTs, endTs]` (total duration exact; instantaneous pace approximate), and workout-level metadata (sport, distance, calories, avg/max HR) in the summary. That's the honest maximum from what's stored, and it's what Strava/Garmin need to read the track as a timed activity.

## Verification

- Validated by **round-trip through the existing `ActivityFileImporter`/`FitDecoder`** on both platforms (the same decoders that read real Strava/Garmin files): route, window, sport, distance, calories, HR, and the FIT header/CRC all check out.
- Android: `./gradlew testFullDebugUnitTest` green (`RouteExportTest` 6/6, full suite clean). Swift `RouteExporterTests` run under `swift-packages.yml`.
- ISO-8601 timestamp formatting is a hand-rolled civil-from-days (verified against a reference), so Swift and Kotlin emit identical times with no shared `DateFormatter`.

## Parity note

Export files are **equivalent valid files per platform** (feature-level parity), not a byte-identical stored-data surface — they're output artifacts, not the `.noopbak`/analytics contract. The FIT binary is deterministic integer encoding; GPX float formatting uses each platform's `%.6f`.