### PR TITLE
Workout route export: Export-route UI + share (iOS/macOS + Android)

### DIFF
--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -178082,6 +178082,214 @@
           }
         }
       }
+    },
+    "Export route": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Route exportieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar ruta"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporter l'itinéraire"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esporta percorso"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar percurso"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Экспорт маршрута"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出路线"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匯出路線"
+          }
+        }
+      }
+    },
+    "GPX — Strava, Garmin, most apps": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GPX — Strava, Garmin, die meisten Apps"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GPX — Strava, Garmin, la mayoría de apps"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GPX — Strava, Garmin, la plupart des apps"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GPX — Strava, Garmin, la maggior parte delle app"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GPX — Strava, Garmin, a maioria das apps"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GPX — Strava, Garmin, большинство приложений"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GPX — Strava、Garmin 及大多数应用"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GPX — Strava、Garmin 及大多數應用程式"
+          }
+        }
+      }
+    },
+    "FIT — Garmin Connect": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FIT — Garmin Connect"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FIT — Garmin Connect"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FIT — Garmin Connect"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FIT — Garmin Connect"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FIT — Garmin Connect"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FIT — Garmin Connect"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FIT — Garmin Connect"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FIT — Garmin Connect"
+          }
+        }
+      }
+    },
+    "Save this route as a standard file you can import into Strava, Garmin Connect, and other apps.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichere diese Route als Standarddatei, die du in Strava, Garmin Connect und andere Apps importieren kannst."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guarda esta ruta como un archivo estándar que puedes importar en Strava, Garmin Connect y otras apps."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistre cet itinéraire dans un fichier standard que tu peux importer dans Strava, Garmin Connect et d'autres apps."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salva questo percorso come file standard da importare in Strava, Garmin Connect e altre app."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guarda este percurso como um ficheiro padrão que podes importar para o Strava, o Garmin Connect e outras apps."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохрани этот маршрут как стандартный файл, который можно импортировать в Strava, Garmin Connect и другие приложения."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将此路线保存为标准文件，可导入 Strava、Garmin Connect 及其他应用。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將此路線儲存為標準檔案，可匯入 Strava、Garmin Connect 及其他應用程式。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Strand/Screens/WorkoutDetailView.swift
+++ b/Strand/Screens/WorkoutDetailView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import StrandDesign
 import StrandAnalytics
+import StrandImport
 import WhoopStore
 import Foundation
 #if canImport(MapKit)
@@ -54,6 +55,9 @@ struct WorkoutDetailView: View {
     /// The GPS route captured for this session on-device (#524), if any. Decoded from `RouteStore` by the
     /// row's natural key. nil = no route was recorded (honest — the map only shows when points exist).
     @State private var route: [RouteMath.LatLng] = []
+
+    /// Drives the GPX/FIT export chooser for the recorded route.
+    @State private var showRouteExport = false
 
     /// Steps over the session window for an on-foot sport (#398): the count plus whether it came from the
     /// strap's own counter (MG/5.0) or the phone pedometer (fallback for WHOOP 4.0 / not-yet-synced / CSV
@@ -298,8 +302,37 @@ struct WorkoutDetailView: View {
                     .font(StrandFont.footnote)
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
+
+                Button {
+                    showRouteExport = true
+                } label: {
+                    Label("Export route", systemImage: "square.and.arrow.up")
+                }
+                .buttonStyle(NoopButtonStyle(.secondary, fullWidth: true))
+                .confirmationDialog("Export route", isPresented: $showRouteExport, titleVisibility: .visible) {
+                    Button("GPX — Strava, Garmin, most apps") { exportRoute(.gpx) }
+                    Button("FIT — Garmin Connect") { exportRoute(.fit) }
+                    Button("Cancel", role: .cancel) {}
+                } message: {
+                    Text("Save this route as a standard file you can import into Strava, Garmin Connect, and other apps.")
+                }
             }
         }
+    }
+
+    /// Write the route to a GPX/FIT file and hand it to the system share sheet (or a Save panel on macOS).
+    /// Points are decoded lat/lon only (the stored polyline), so the exporter interpolates per-point times
+    /// across the session window and carries the workout's summary (sport, distance, calories, HR).
+    @MainActor private func exportRoute(_ format: RouteExporter.Format) {
+        guard route.count >= 2 else { return }
+        let points = route.map { RoutePoint(lat: $0.lat, lon: $0.lon) }
+        let data = RouteExporter.render(
+            format, route: points, startTs: row.startTs, endTs: row.endTs, sport: row.sport,
+            distanceM: row.distanceM, energyKcal: row.energyKcal, avgHr: row.avgHr, maxHr: row.maxHr)
+        let name = FileExport.timestampedName("noop-route", ext: format.ext)
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(name)
+        do { try data.write(to: url) } catch { return }
+        FileExport.exportFile(at: url, suggestedName: name)
     }
 
     private func routeStat(_ title: String, _ value: String, tint: Color) -> some View {

--- a/Strand/Screens/WorkoutDetailView.swift
+++ b/Strand/Screens/WorkoutDetailView.swift
@@ -329,7 +329,8 @@ struct WorkoutDetailView: View {
     @MainActor private func exportRoute(_ format: RouteExporter.Format) {
         guard route.count >= 2 else { return }
         let points = route.map { RoutePoint(lat: $0.lat, lon: $0.lon) }
-        let name = FileExport.timestampedName("noop-route", ext: format.ext)
+        // Name the file by the workout's start (not export time) so it's stable + matches the Android twin.
+        let name = "noop-route-\(row.startTs).\(format.ext)"
         let startTs = row.startTs, endTs = row.endTs, sport = row.sport
         let distanceM = row.distanceM, energyKcal = row.energyKcal, avgHr = row.avgHr, maxHr = row.maxHr
         Task.detached(priority: .userInitiated) {

--- a/Strand/Screens/WorkoutDetailView.swift
+++ b/Strand/Screens/WorkoutDetailView.swift
@@ -323,16 +323,23 @@ struct WorkoutDetailView: View {
     /// Write the route to a GPX/FIT file and hand it to the system share sheet (or a Save panel on macOS).
     /// Points are decoded lat/lon only (the stored polyline), so the exporter interpolates per-point times
     /// across the session window and carries the workout's summary (sport, distance, calories, HR).
+    ///
+    /// The build + disk write run OFF the main actor (a long route is a non-trivial encode, and blocking
+    /// file IO must never stall the UI); only the share-sheet present hops back to the main actor.
     @MainActor private func exportRoute(_ format: RouteExporter.Format) {
         guard route.count >= 2 else { return }
         let points = route.map { RoutePoint(lat: $0.lat, lon: $0.lon) }
-        let data = RouteExporter.render(
-            format, route: points, startTs: row.startTs, endTs: row.endTs, sport: row.sport,
-            distanceM: row.distanceM, energyKcal: row.energyKcal, avgHr: row.avgHr, maxHr: row.maxHr)
         let name = FileExport.timestampedName("noop-route", ext: format.ext)
-        let url = FileManager.default.temporaryDirectory.appendingPathComponent(name)
-        do { try data.write(to: url) } catch { return }
-        FileExport.exportFile(at: url, suggestedName: name)
+        let startTs = row.startTs, endTs = row.endTs, sport = row.sport
+        let distanceM = row.distanceM, energyKcal = row.energyKcal, avgHr = row.avgHr, maxHr = row.maxHr
+        Task.detached(priority: .userInitiated) {
+            let data = RouteExporter.render(
+                format, route: points, startTs: startTs, endTs: endTs, sport: sport,
+                distanceM: distanceM, energyKcal: energyKcal, avgHr: avgHr, maxHr: maxHr)
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent(name)
+            do { try data.write(to: url) } catch { return }
+            await MainActor.run { FileExport.exportFile(at: url, suggestedName: name) }
+        }
     }
 
     private func routeStat(_ title: String, _ value: String, tint: Color) -> some View {

--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -810,11 +810,23 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Export route"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "FIT"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
       "Finish selecting"
     ],
     [
       "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
       "From strap HR"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "GPX"
     ],
     [
       "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
@@ -827,6 +839,10 @@
     [
       "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
       "Save"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Save this GPS route as a file to import into Strava, Garmin Connect, or another app. "
     ],
     [
       "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",

--- a/android/app/src/main/java/com/noop/ui/RouteExportShare.kt
+++ b/android/app/src/main/java/com/noop/ui/RouteExportShare.kt
@@ -1,0 +1,52 @@
+package com.noop.ui
+
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+import androidx.core.content.FileProvider
+import com.noop.analytics.RouteMath
+import com.noop.data.WorkoutRow
+import com.noop.ingest.RouteExport
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * Share a recorded workout route as a GPX/FIT file — the UI-layer wrapper around the pure
+ * [com.noop.ingest.RouteExport] builder (which stays Android-free/JVM-testable). Mirrors
+ * [LogExport.shareStrapLog]: write the bytes to a shared cache subdir, then hand a FileProvider URI to a
+ * chooser. The Swift twin is `WorkoutDetailView.exportRoute`.
+ */
+object RouteExportShare {
+
+    suspend fun share(
+        context: Context,
+        format: RouteExport.Format,
+        track: List<RouteMath.LatLng>,
+        row: WorkoutRow,
+    ) {
+        runCatching {
+            val points = track.map { RouteExport.Point(it.lat, it.lon) }
+            val bytes = RouteExport.render(
+                format, points, row.startTs, row.endTs, row.sport,
+                distanceM = row.distanceM, energyKcal = row.energyKcal, avgHr = row.avgHr, maxHr = row.maxHr,
+            )
+            val filename = "noop-route-${row.startTs}.${format.ext}"
+            val file = withContext(Dispatchers.IO) {
+                File(File(context.cacheDir, "exports").apply { mkdirs() }, filename)
+                    .apply { writeBytes(bytes) }
+            }
+            val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+            val mime = if (format == RouteExport.Format.GPX) "application/gpx+xml" else "application/octet-stream"
+            val send = Intent(Intent.ACTION_SEND).apply {
+                type = mime
+                putExtra(Intent.EXTRA_STREAM, uri)
+                putExtra(Intent.EXTRA_SUBJECT, "NOOP workout route")
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            context.startActivity(Intent.createChooser(send, "Share route"))
+        }.onFailure {
+            Toast.makeText(context, "Couldn't export the route: ${it.message}", Toast.LENGTH_LONG).show()
+        }
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/RouteExportShare.kt
+++ b/android/app/src/main/java/com/noop/ui/RouteExportShare.kt
@@ -26,13 +26,15 @@ object RouteExportShare {
         row: WorkoutRow,
     ) {
         runCatching {
-            val points = track.map { RouteExport.Point(it.lat, it.lon) }
-            val bytes = RouteExport.render(
-                format, points, row.startTs, row.endTs, row.sport,
-                distanceM = row.distanceM, energyKcal = row.energyKcal, avgHr = row.avgHr, maxHr = row.maxHr,
-            )
             val filename = "noop-route-${row.startTs}.${format.ext}"
+            // Build the file AND write it off the main thread — a long route (10k+ points) is a non-trivial
+            // string/byte build, and file IO must never block the UI. Only the chooser launch stays on Main.
             val file = withContext(Dispatchers.IO) {
+                val points = track.map { RouteExport.Point(it.lat, it.lon) }
+                val bytes = RouteExport.render(
+                    format, points, row.startTs, row.endTs, row.sport,
+                    distanceM = row.distanceM, energyKcal = row.energyKcal, avgHr = row.avgHr, maxHr = row.maxHr,
+                )
                 File(File(context.cacheDir, "exports").apply { mkdirs() }, filename)
                     .apply { writeBytes(bytes) }
             }

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -88,6 +88,10 @@ import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.runtime.rememberCoroutineScope
+import com.noop.analytics.RouteMath
+import com.noop.ingest.RouteExport
+import kotlinx.coroutines.launch
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -1352,6 +1356,46 @@ private fun WorkoutDetailSheet(vm: AppViewModel, row: WorkoutRow, onDismiss: () 
             }
             steps?.let { DetailRow("Steps", "${grouped(it.toDouble())} steps") }  // #398, on-foot sports
             if (!row.notes.isNullOrBlank()) DetailRow("Notes", row.notes)
+
+            // Export the recorded GPS route as a GPX/FIT file (Strava / Garmin Connect / any GPS app).
+            // Only when a route with a drawable path was recorded; the file is built on-device and shared.
+            row.routePolyline?.let { poly ->
+                val track = remember(poly) { RouteMath.decode(poly) }
+                if (track.size >= 2) {
+                    val exportCtx = LocalContext.current
+                    val exportScope = rememberCoroutineScope()
+                    CardDivider()
+                    Text("Export route", style = NoopType.subhead, color = Palette.textPrimary)
+                    Text(
+                        "Save this GPS route as a file to import into Strava, Garmin Connect, or another app. " +
+                            "Built on your phone — nothing is uploaded until you choose to share it.",
+                        style = NoopType.footnote,
+                        color = Palette.textTertiary,
+                    )
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        NoopButton(
+                            text = "GPX",
+                            kind = NoopButtonKind.Secondary,
+                            modifier = Modifier.weight(1f),
+                            onClick = {
+                                exportScope.launch {
+                                    RouteExportShare.share(exportCtx, RouteExport.Format.GPX, track, row)
+                                }
+                            },
+                        )
+                        NoopButton(
+                            text = "FIT",
+                            kind = NoopButtonKind.Secondary,
+                            modifier = Modifier.weight(1f),
+                            onClick = {
+                                exportScope.launch {
+                                    RouteExportShare.share(exportCtx, RouteExport.Format.FIT, track, row)
+                                }
+                            },
+                        )
+                    }
+                }
+            }
 
             // #796 - per-session Effort contribution. The session's captured strain re-homed from a plain
             // value row into a prominent Effort-amber card (the big count-up value + the "This session"

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- FileProvider paths for in-app exports. Only the app's own cache subdirs are shared:
      - logs/    : the strap-log export (LogExport) + 5/MG raw capture
-     - reports/ : the shareable offline trends report PDF (TrendsReport, #436) -->
+     - reports/ : the shareable offline trends report PDF (TrendsReport, #436)
+     - exports/ : GPX/FIT workout route export (RouteExportShare) -->
 <paths>
     <cache-path name="logs" path="logs/" />
     <cache-path name="reports" path="reports/" />
+    <cache-path name="exports" path="exports/" />
 </paths>


### PR DESCRIPTION
## What

Wires the GPX/FIT exporters (#1238) into the **workout detail screen** on both platforms — a recorded GPS route can now be exported as a standard file for **Strava / Garmin Connect / any GPS app**. This is the UI/share half; the pure builders landed in #1238.

## Changes

- **iOS/macOS** — `WorkoutDetailView`'s route card gains an **Export route** button → a `confirmationDialog` (GPX / FIT) → `RouteExporter.render` → `FileExport` (share sheet on iOS, Save panel on macOS). New copy localized across **all 8 xcstrings locales**.
- **Android** — `WorkoutDetailSheet` gains an **Export route** row (GPX / FIT buttons) when the workout row carries a `routePolyline`, shared via a new `RouteExportShare` (`FileProvider` + `ACTION_SEND`, mirroring `LogExport`). Adds an `exports/` FileProvider cache path.
- The pure builder stays in the package/ingest layer; the app layer only decodes the stored polyline and hands `(lat, lon)` pairs + the workout summary to the exporter.

## Verification

- Android: `compileFullDebugKotlin` + full `testFullDebugUnitTest` green; `i18n_audit.py --ci` green.
- iOS/macOS app-target Swift has no default CI → validated on the **app-build gate** (Build Strand + Build NOOPiOS).
- On-device pass (share from a real GPS workout, import the file into Strava/Garmin) still to run on a device — the builders are round-trip-tested against the app's own decoders in #1238.