### PR TITLE
Workouts: 13-week active-calorie heatmap (Swift + Kotlin)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ActivityHeatmap.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ActivityHeatmap.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// Build a GitHub-contribution-style heat grid from per-day values (e.g. daily active calories) — the
+/// pure, cross-platform core of the Workouts "last 13 weeks" heatmap. Columns are calendar weeks
+/// (Monday-first), rows are weekdays (0 = Mon … 6 = Sun); the LAST column is the current week and future
+/// days in it are empty. Byte-for-byte twin of the Kotlin `ActivityHeatmap` — the calendar arithmetic is
+/// pure integer `days_from_civil`/`civil_from_days` on the `"yyyy-MM-dd"` day keys the app stores, so the
+/// two platforms bucket identically.
+public enum ActivityHeatmap {
+
+    public static let defaultWeeks = 13
+
+    /// One grid cell. `day` = "yyyy-MM-dd" (nil for a future pad cell); `value` = the metric (nil = no
+    /// data that day); `level` = 0 for no-data, 1...4 for intensity buckets.
+    public struct Cell: Equatable, Sendable {
+        public let day: String?
+        public let value: Double?
+        public let level: Int
+        public init(day: String?, value: Double?, level: Int) {
+            self.day = day
+            self.value = value
+            self.level = level
+        }
+    }
+
+    /// `columns` is `weeks` arrays of 7 cells (row 0 = Monday). `maxValue` scales the intensity ramp.
+    public struct Grid: Equatable, Sendable {
+        public let weeks: Int
+        public let columns: [[Cell]]
+        public let maxValue: Double
+        public init(weeks: Int, columns: [[Cell]], maxValue: Double) {
+            self.weeks = weeks
+            self.columns = columns
+            self.maxValue = maxValue
+        }
+        public var isEmpty: Bool { columns.allSatisfy { col in col.allSatisfy { $0.value == nil } } }
+    }
+
+    /// - Parameters:
+    ///   - values: day ("yyyy-MM-dd") → metric value. Missing days render as no-data cells.
+    ///   - today: the "yyyy-MM-dd" anchoring the rightmost column.
+    ///   - weeks: number of week columns (default 13).
+    public static func build(values: [String: Double], today: String, weeks: Int = defaultWeeks) -> Grid {
+        guard let e = epochDay(today) else { return Grid(weeks: weeks, columns: [], maxValue: 0) }
+        let cols = max(weeks, 1)
+        let todayWeekday = mondayFirstWeekday(e)
+        let currentMonday = e - todayWeekday
+        let firstMonday = currentMonday - (cols - 1) * 7
+
+        var maxValue = 0.0
+        var raw: [[Cell]] = []
+        raw.reserveCapacity(cols)
+        for c in 0..<cols {
+            var col: [Cell] = []
+            col.reserveCapacity(7)
+            for r in 0..<7 {
+                let d = firstMonday + c * 7 + r
+                if d > e {
+                    col.append(Cell(day: nil, value: nil, level: 0)) // future day in the current week
+                } else {
+                    let ds = civilDay(d)
+                    let v = values[ds]
+                    if let v, v > maxValue { maxValue = v }
+                    col.append(Cell(day: ds, value: v, level: 0))
+                }
+            }
+            raw.append(col)
+        }
+        let leveled = raw.map { col in
+            col.map { Cell(day: $0.day, value: $0.value, level: levelFor($0.value, maxValue)) }
+        }
+        return Grid(weeks: cols, columns: leveled, maxValue: maxValue)
+    }
+
+    /// 0 = no data; otherwise 1...4 by fraction of `maxValue` (a present-but-zero day is still level 1).
+    static func levelFor(_ value: Double?, _ maxValue: Double) -> Int {
+        guard let value else { return 0 }
+        if maxValue <= 0 { return 1 }
+        return min(max(Int(ceil(value / maxValue * 4.0)), 1), 4)
+    }
+
+    /// Monday-first weekday (Mon = 0 … Sun = 6) of an epoch-day count. Epoch day 0 (1970-01-01) is a Thu.
+    static func mondayFirstWeekday(_ epochDay: Int) -> Int { ((epochDay + 3) % 7 + 7) % 7 }
+
+    /// Parse "yyyy-MM-dd" → days since 1970-01-01 (proleptic Gregorian), or nil if malformed.
+    static func epochDay(_ ymd: String) -> Int? {
+        let p = ymd.split(separator: "-", omittingEmptySubsequences: false)
+        guard p.count == 3, let y = Int(p[0]), let m = Int(p[1]), let d = Int(p[2]),
+              m >= 1, m <= 12, d >= 1, d <= 31 else { return nil }
+        return daysFromCivil(y, m, d)
+    }
+
+    /// days since 1970-01-01 → "yyyy-MM-dd". Inverse of `epochDay` (Howard Hinnant's civil_from_days).
+    static func civilDay(_ epochDay: Int) -> String {
+        let z = epochDay + 719_468
+        let era = (z >= 0 ? z : z - 146_096) / 146_097
+        let doe = z - era * 146_097
+        let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365
+        let y0 = yoe + era * 400
+        let doy = doe - (365 * yoe + yoe / 4 - yoe / 100)
+        let mp = (5 * doy + 2) / 153
+        let d = doy - (153 * mp + 2) / 5 + 1
+        let m = mp < 10 ? mp + 3 : mp - 9
+        let y = m <= 2 ? y0 + 1 : y0
+        return String(format: "%04d-%02d-%02d", y, m, d)
+    }
+
+    /// "yyyy-MM-dd" fields → days since 1970-01-01 (Howard Hinnant's days_from_civil).
+    private static func daysFromCivil(_ year: Int, _ month: Int, _ day: Int) -> Int {
+        let y = month <= 2 ? year - 1 : year
+        let era = (y >= 0 ? y : y - 399) / 400
+        let yoe = y - era * 400
+        let mp = month > 2 ? month - 3 : month + 9
+        let doy = (153 * mp + 2) / 5 + day - 1
+        let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy
+        return era * 146_097 + doe - 719_468
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ActivityHeatmapTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ActivityHeatmapTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// Pins the ActivityHeatmap grid builder + its calendar arithmetic. The Kotlin twin
+/// (`ActivityHeatmapTest`) asserts the same shape, so the two platforms bucket days into identical
+/// week-columns / weekday-rows / intensity levels.
+final class ActivityHeatmapTests: XCTestCase {
+
+    private let today = "2026-08-11" // a Tuesday (Monday-first weekday 1)
+
+    func testGridShapeAndTodayPlacement() {
+        let values = ["2026-08-11": 400.0, "2026-08-10": 100.0, "2026-08-09": 200.0]
+        let g = ActivityHeatmap.build(values: values, today: today, weeks: 13)
+        XCTAssertEqual(g.weeks, 13)
+        XCTAssertEqual(g.columns.count, 13)
+        XCTAssertTrue(g.columns.allSatisfy { $0.count == 7 })
+        XCTAssertEqual(g.maxValue, 400.0)
+
+        // The rightmost column is the current week; today sits at weekday row 1, Monday at row 0.
+        let last = g.columns[12]
+        XCTAssertEqual(last[1].day, "2026-08-11")
+        XCTAssertEqual(last[1].value, 400.0)
+        XCTAssertEqual(last[1].level, 4)          // max → level 4
+        XCTAssertEqual(last[0].day, "2026-08-10")
+        XCTAssertEqual(last[0].level, 1)          // 100/400 → level 1
+        // Future days in the current week are empty pad cells.
+        XCTAssertNil(last[2].day)
+        XCTAssertEqual(last[2].level, 0)
+
+        // The first column starts 13 weeks back on a Monday; no value → no-data cell.
+        XCTAssertEqual(g.columns[0][0].day, "2026-05-18")
+        XCTAssertEqual(g.columns[0][0].level, 0)
+    }
+
+    func testLevelBuckets() {
+        XCTAssertEqual(ActivityHeatmap.levelFor(nil, 400.0), 0)    // no data
+        XCTAssertEqual(ActivityHeatmap.levelFor(0.0, 400.0), 1)    // present but zero → 1
+        XCTAssertEqual(ActivityHeatmap.levelFor(100.0, 400.0), 1)  // 25%
+        XCTAssertEqual(ActivityHeatmap.levelFor(200.0, 400.0), 2)  // 50%
+        XCTAssertEqual(ActivityHeatmap.levelFor(300.0, 400.0), 3)  // 75%
+        XCTAssertEqual(ActivityHeatmap.levelFor(400.0, 400.0), 4)  // max
+        XCTAssertEqual(ActivityHeatmap.levelFor(50.0, 0.0), 1)     // no max → 1
+    }
+
+    func testCalendarArithmeticMatchesTheProlepticGregorian() {
+        XCTAssertEqual(ActivityHeatmap.epochDay("2026-08-11"), 20676)
+        XCTAssertEqual(ActivityHeatmap.epochDay("1970-01-01"), 0)
+        XCTAssertEqual(ActivityHeatmap.civilDay(20676), "2026-08-11")
+        XCTAssertEqual(ActivityHeatmap.civilDay(0), "1970-01-01")
+        XCTAssertEqual(ActivityHeatmap.mondayFirstWeekday(20676), 1) // Tue
+        XCTAssertEqual(ActivityHeatmap.mondayFirstWeekday(0), 3)     // 1970-01-01 = Thu
+        XCTAssertNil(ActivityHeatmap.epochDay("not-a-date"))
+        XCTAssertNil(ActivityHeatmap.epochDay("2026-13-40"))
+    }
+
+    func testEmptyValuesGivesAllNoData() {
+        let g = ActivityHeatmap.build(values: [:], today: today, weeks: 13)
+        XCTAssertTrue(g.isEmpty)
+        XCTAssertEqual(g.maxValue, 0.0)
+        XCTAssertTrue(g.columns.flatMap { $0 }.allSatisfy { $0.level == 0 })
+    }
+}

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -178290,6 +178290,162 @@
           }
         }
       }
+    },
+    "Active calories": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktive Kalorien"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calorías activas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calories actives"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calorie attive"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calorias ativas"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Активные калории"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "活动卡路里"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "活動卡路里"
+          }
+        }
+      }
+    },
+    "Active-calorie heatmap, last 13 weeks": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heatmap der aktiven Kalorien, letzte 13 Wochen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mapa de calor de calorías activas, últimas 13 semanas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carte thermique des calories actives, 13 dernières semaines"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mappa di calore delle calorie attive, ultime 13 settimane"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mapa de calor de calorias ativas, últimas 13 semanas"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тепловая карта активных калорий, последние 13 недель"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "活动卡路里热力图，最近 13 周"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "活動卡路里熱力圖，最近 13 週"
+          }
+        }
+      }
+    },
+    "Less": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weniger"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Moins"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meno"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Меньше"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更少"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更少"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Strand/Screens/WorkoutsView.swift
+++ b/Strand/Screens/WorkoutsView.swift
@@ -58,6 +58,21 @@ struct WorkoutsView: View {
     @State private var loadedWindowDays: Int?
     private let usesPreviewRows: Bool
 
+    /// Daily active-calorie totals (day "yyyy-MM-dd" → kcal) for the 13-week heatmap, loaded alongside the
+    /// rows. Empty until loaded / when there's no daily-calorie data (the heatmap then hides itself).
+    @State private var dailyKcal: [String: Double] = [:]
+
+    /// Local `yyyy-MM-dd` formatter for the heatmap's day keys + "today" anchor (matches the stored keys).
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.calendar = Calendar(identifier: .gregorian)
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = .current
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+    private func todayDayString() -> String { Self.dayFormatter.string(from: Date()) }
+
     /// #797: trailing-day window the FIRST workouts read is bounded to, so first paint never sorts a
     /// multi-thousand-workout history. Comfortably covers the default range (the tightest range with ≥2
     /// sessions, almost always ≤90 days); a wider pick pages the rest in via `expandWindow`. 400 days
@@ -171,6 +186,7 @@ struct WorkoutsView: View {
                 if let postLogNote { postLogBanner(postLogNote) }
                 effortHero(rows: windowRows, effectiveRange: resolved, groups: groups)
                 summarySection(rows: windowRows, effectiveRange: resolved, groups: groups)
+                heatmapSection()
                 breakdownSection(groups: groups, rows: windowRows)
                 if let z = zonesSummary {
                     zonesSection(z, totalSessions: windowRows.count)
@@ -184,6 +200,12 @@ struct WorkoutsView: View {
             // #797: read only the currently-loaded window (bounded on first paint), not the whole history.
             let r = await repo.workoutRows(days: loadedWindowDays ?? 4000)
             allRows = r
+            // 13-week active-calorie heatmap: pull ~100 days of daily metrics and map day → active kcal.
+            let toDay = todayDayString()
+            let fromDate = Calendar.current.date(byAdding: .day, value: -100, to: Date()) ?? Date()
+            let metrics = await repo.dailyMetrics(fromDay: Self.dayFormatter.string(from: fromDate), toDay: toDay)
+            dailyKcal = Dictionary(metrics.compactMap { m in m.activeKcalEst.map { (m.day, $0) } },
+                                   uniquingKeysWith: max)
             let wasLoaded = loaded
             loaded = true
             if !wasLoaded {
@@ -792,6 +814,66 @@ struct WorkoutsView: View {
     }
 
     // MARK: - Summary tiles (uniform 104pt StatTiles)
+
+    // MARK: - Active-calorie heatmap (last 13 weeks)
+    //
+    // A GitHub-contribution-style grid of daily active calories: columns = weeks (Monday-first), rows =
+    // weekdays, cell shade = that day's burn vs the window max. The bucketing is the pure cross-platform
+    // `ActivityHeatmap` (parity with the Kotlin twin); this is just the SwiftUI renderer. Hidden entirely
+    // when there's no daily-calorie data yet.
+    @ViewBuilder
+    private func heatmapSection() -> some View {
+        let grid = ActivityHeatmap.build(values: dailyKcal, today: todayDayString())
+        if !grid.isEmpty {
+            VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+                SectionHeader("Active calories", overline: "Last 13 weeks")
+                NoopCard(tint: StrandPalette.effortColor) {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Canvas { ctx, size in
+                            let cols = grid.columns.count
+                            guard cols > 0 else { return }
+                            let gap: CGFloat = 3
+                            let cell = min((size.width - gap * CGFloat(cols - 1)) / CGFloat(cols),
+                                           (size.height - gap * 6) / 7)
+                            guard cell > 0 else { return }
+                            for c in 0..<cols {
+                                let col = grid.columns[c]
+                                for r in 0..<7 {
+                                    let rect = CGRect(x: CGFloat(c) * (cell + gap), y: CGFloat(r) * (cell + gap),
+                                                      width: cell, height: cell)
+                                    ctx.fill(Path(roundedRect: rect, cornerRadius: cell * 0.22),
+                                             with: .color(heatColor(col[r].level)))
+                                }
+                            }
+                        }
+                        .aspectRatio(13.0 / 7.0, contentMode: .fit)
+                        .frame(maxWidth: .infinity)
+                        .accessibilityLabel(Text("Active-calorie heatmap, last 13 weeks"))
+                        HStack(spacing: 4) {
+                            Text("Less").font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
+                            ForEach(0..<5, id: \.self) { lvl in
+                                RoundedRectangle(cornerRadius: 2, style: .continuous)
+                                    .fill(heatColor(lvl))
+                                    .frame(width: 10, height: 10)
+                            }
+                            Text("More").font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Level (0 = no data, 1...4 by intensity) → the amber calorie ramp.
+    private func heatColor(_ level: Int) -> Color {
+        switch level {
+        case 0: return StrandPalette.surfaceInset
+        case 1: return StrandPalette.metricAmber.opacity(0.28)
+        case 2: return StrandPalette.metricAmber.opacity(0.52)
+        case 3: return StrandPalette.metricAmber.opacity(0.78)
+        default: return StrandPalette.metricAmber
+        }
+    }
 
     private func summarySection(rows: [WorkoutRow], effectiveRange: Range, groups: [SportGroup]) -> some View {
         let totalCount = rows.count

--- a/Strand/Screens/WorkoutsView.swift
+++ b/Strand/Screens/WorkoutsView.swift
@@ -200,18 +200,20 @@ struct WorkoutsView: View {
             // #797: read only the currently-loaded window (bounded on first paint), not the whole history.
             let r = await repo.workoutRows(days: loadedWindowDays ?? 4000)
             allRows = r
-            // 13-week active-calorie heatmap: pull ~100 days of daily metrics and map day → active kcal.
-            let toDay = todayDayString()
-            let fromDate = Calendar.current.date(byAdding: .day, value: -100, to: Date()) ?? Date()
-            let metrics = await repo.dailyMetrics(fromDay: Self.dayFormatter.string(from: fromDate), toDay: toDay)
-            dailyKcal = Dictionary(metrics.compactMap { m in m.activeKcalEst.map { (m.day, $0) } },
-                                   uniquingKeysWith: max)
             let wasLoaded = loaded
             loaded = true
             if !wasLoaded {
                 range = defaultRange(for: r)
                 seededInitialRange = true
             }
+            // 13-week active-calorie heatmap: pull ~100 days of daily metrics and map day → active kcal.
+            // Loaded AFTER `loaded`/range are set so the secondary heatmap never delays the list's first
+            // paint — the card is hidden until this populates, then appears in place.
+            let toDay = todayDayString()
+            let fromDate = Calendar.current.date(byAdding: .day, value: -100, to: Date()) ?? Date()
+            let metrics = await repo.dailyMetrics(fromDay: Self.dayFormatter.string(from: fromDate), toDay: toDay)
+            dailyKcal = Dictionary(metrics.compactMap { m in m.activeKcalEst.map { (m.day, $0) } },
+                                   uniquingKeysWith: max)
         }
         .onAppear {
             // Preview-seeded rows skip `.task`; still choose a range that has data.

--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -782,6 +782,10 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Active calories"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
       "Add"
     ],
     [
@@ -830,7 +834,19 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Last 13 weeks · daily burn"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Less"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
       "Logged sessions across ${effectiveRange.caption}."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "More"
     ],
     [
       "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",

--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -786,6 +786,10 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
+      "Active-calorie heatmap, last 13 weeks"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
       "Add"
     ],
     [

--- a/android/app/src/main/java/com/noop/analytics/ActivityHeatmap.kt
+++ b/android/app/src/main/java/com/noop/analytics/ActivityHeatmap.kt
@@ -1,0 +1,105 @@
+package com.noop.analytics
+
+import kotlin.math.ceil
+
+/**
+ * Build a GitHub-contribution-style heat grid from per-day values (e.g. daily active calories) — the pure,
+ * cross-platform core of the Workouts "last 13 weeks" heatmap. Columns are calendar weeks (Monday-first),
+ * rows are weekdays (0 = Mon … 6 = Sun); the LAST column is the current week and future days in it are
+ * empty. Byte-for-byte twin of the Swift `ActivityHeatmap` in StrandAnalytics — the calendar arithmetic is
+ * pure integer `days_from_civil`/`civil_from_days` on the `"yyyy-MM-dd"` day keys the app stores, so the
+ * two platforms bucket identically. JVM-pure (JUnit-testable off-device).
+ */
+object ActivityHeatmap {
+
+    const val DEFAULT_WEEKS = 13
+
+    /** One grid cell. [day] = "yyyy-MM-dd" (null for a future pad cell); [value] = the metric (null = no
+     *  data that day); [level] = 0 for no-data, 1..4 for intensity buckets. */
+    data class Cell(val day: String?, val value: Double?, val level: Int)
+
+    /** [columns] is [weeks] lists of 7 cells (row 0 = Monday). [maxValue] scales the intensity ramp. */
+    data class Grid(val weeks: Int, val columns: List<List<Cell>>, val maxValue: Double) {
+        val isEmpty: Boolean get() = columns.all { col -> col.all { it.value == null } }
+    }
+
+    /**
+     * @param values day ("yyyy-MM-dd") → metric value. Missing days render as no-data cells.
+     * @param today the "yyyy-MM-dd" anchoring the rightmost column.
+     * @param weeks number of week columns (default 13).
+     */
+    fun build(values: Map<String, Double>, today: String, weeks: Int = DEFAULT_WEEKS): Grid {
+        val e = epochDay(today) ?: return Grid(weeks, emptyList(), 0.0)
+        val cols = weeks.coerceAtLeast(1)
+        val todayWeekday = mondayFirstWeekday(e)
+        val currentMonday = e - todayWeekday
+        val firstMonday = currentMonday - (cols - 1).toLong() * 7L
+
+        var maxValue = 0.0
+        val raw = ArrayList<List<Cell>>(cols)
+        for (c in 0 until cols) {
+            val col = ArrayList<Cell>(7)
+            for (r in 0 until 7) {
+                val d = firstMonday + c.toLong() * 7L + r.toLong()
+                if (d > e) {
+                    col.add(Cell(null, null, 0)) // future day in the current week
+                } else {
+                    val ds = civilDay(d)
+                    val v = values[ds]
+                    if (v != null && v > maxValue) maxValue = v
+                    col.add(Cell(ds, v, 0))
+                }
+            }
+            raw.add(col)
+        }
+        val leveled = raw.map { col -> col.map { it.copy(level = levelFor(it.value, maxValue)) } }
+        return Grid(cols, leveled, maxValue)
+    }
+
+    /** 0 = no data; otherwise 1..4 by fraction of [maxValue] (a present-but-zero day is still level 1). */
+    internal fun levelFor(value: Double?, maxValue: Double): Int {
+        if (value == null) return 0
+        if (maxValue <= 0.0) return 1
+        return ceil(value / maxValue * 4.0).toInt().coerceIn(1, 4)
+    }
+
+    /** Monday-first weekday (Mon = 0 … Sun = 6) of an epoch-day count. Epoch day 0 (1970-01-01) is a Thu. */
+    internal fun mondayFirstWeekday(epochDay: Long): Int = (((epochDay + 3L) % 7L + 7L) % 7L).toInt()
+
+    /** Parse "yyyy-MM-dd" → days since 1970-01-01 (proleptic Gregorian), or null if malformed. */
+    internal fun epochDay(ymd: String): Long? {
+        val p = ymd.split('-')
+        if (p.size != 3) return null
+        val y = p[0].toIntOrNull() ?: return null
+        val m = p[1].toIntOrNull() ?: return null
+        val d = p[2].toIntOrNull() ?: return null
+        if (m < 1 || m > 12 || d < 1 || d > 31) return null
+        return daysFromCivil(y, m, d)
+    }
+
+    /** days since 1970-01-01 → "yyyy-MM-dd". Inverse of [epochDay] (Howard Hinnant's civil_from_days). */
+    internal fun civilDay(epochDay: Long): String {
+        val z = epochDay + 719468L
+        val era = (if (z >= 0) z else z - 146096L) / 146097L
+        val doe = z - era * 146097L
+        val yoe = (doe - doe / 1460L + doe / 36524L - doe / 146096L) / 365L
+        val y0 = yoe + era * 400L
+        val doy = doe - (365L * yoe + yoe / 4L - yoe / 100L)
+        val mp = (5L * doy + 2L) / 153L
+        val d = doy - (153L * mp + 2L) / 5L + 1L
+        val m = if (mp < 10L) mp + 3L else mp - 9L
+        val y = if (m <= 2L) y0 + 1L else y0
+        return "%04d-%02d-%02d".format(y, m, d)
+    }
+
+    /** "yyyy-MM-dd" fields → days since 1970-01-01 (Howard Hinnant's days_from_civil). */
+    private fun daysFromCivil(year: Int, month: Int, day: Int): Long {
+        val y = if (month <= 2) year - 1 else year
+        val era = (if (y >= 0) y else y - 399).toLong() / 400L
+        val yoe = y.toLong() - era * 400L
+        val mp = if (month > 2) month - 3 else month + 9
+        val doy = (153L * mp + 2L) / 5L + day - 1L
+        val doe = yoe * 365L + yoe / 4L - yoe / 100L + doy
+        return era * 146097L + doe - 719468L
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -799,7 +799,12 @@ private fun CalorieHeatmapSection(recentDays: List<com.noop.data.DailyMetric>) {
                 val gap = 3.dp
                 val cols = grid.weeks
                 val cell = ((maxWidth - gap * (cols - 1)) / cols).coerceAtLeast(2.dp)
-                Canvas(Modifier.fillMaxWidth().height(cell * 7 + gap * 6)) {
+                Canvas(
+                    Modifier
+                        .fillMaxWidth()
+                        .height(cell * 7 + gap * 6)
+                        .semantics { contentDescription = "Active-calorie heatmap, last 13 weeks" },
+                ) {
                     val gapPx = gap.toPx()
                     val cellPx = cell.toPx()
                     val radius = CornerRadius(cellPx * 0.22f, cellPx * 0.22f)

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -89,6 +89,11 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Size
+import com.noop.analytics.ActivityHeatmap
 import com.noop.analytics.RouteMath
 import com.noop.ingest.RouteExport
 import kotlinx.coroutines.launch
@@ -287,6 +292,7 @@ fun WorkoutsScreen(vm: AppViewModel) {
             postLogNote?.let { item { PostLogNoteBanner(it) } }
             item { EffortHero(rows = windowRows, effectiveRange = resolved, groups = groups) }
             item { SummarySection(rows = windowRows, effectiveRange = resolved, groups = groups) }
+            item { CalorieHeatmapSection(recentDays) }
             item { BreakdownSection(groups = groups, rows = windowRows) }
             item { ZonesSection(windowRows) }
             if (recoveryTrend.isNotEmpty()) {
@@ -755,6 +761,77 @@ private fun HeroStat(title: String, value: String, tint: Color, modifier: Modifi
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
         Overline(title)
         Text(value, style = NoopType.number(20f), color = tint, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    }
+}
+
+// MARK: - Active-calorie heatmap (last 13 weeks)
+//
+// A GitHub-contribution-style grid of daily active calories: columns = weeks (Monday-first), rows =
+// weekdays, cell shade = that day's burn vs the window max. The bucketing is the pure cross-platform
+// [ActivityHeatmap] (parity with the Swift twin); this composable is just the Compose renderer. Hidden
+// entirely when there's no daily-calorie data yet.
+@Composable
+private fun CalorieHeatmapSection(recentDays: List<com.noop.data.DailyMetric>) {
+    val values = remember(recentDays) {
+        recentDays.mapNotNull { d -> d.activeKcalEst?.let { d.day to it } }
+            .groupBy({ it.first }, { it.second })
+            .mapValues { (_, v) -> v.max() }
+    }
+    val today = remember { java.time.LocalDate.now().toString() }
+    val grid = remember(values, today) { ActivityHeatmap.build(values, today) }
+    if (grid.isEmpty) return
+
+    val amber = Palette.effortColor
+    val inset = Palette.surfaceInset
+    fun colorFor(level: Int): Color = when (level) {
+        0 -> inset
+        1 -> amber.copy(alpha = 0.28f)
+        2 -> amber.copy(alpha = 0.52f)
+        3 -> amber.copy(alpha = 0.78f)
+        else -> amber
+    }
+
+    NoopCard(tint = Palette.effortColor) {
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Text("Active calories", style = NoopType.title2, color = Palette.textPrimary)
+            Text("Last 13 weeks · daily burn", style = NoopType.footnote, color = Palette.textTertiary)
+            BoxWithConstraints(Modifier.fillMaxWidth()) {
+                val gap = 3.dp
+                val cols = grid.weeks
+                val cell = ((maxWidth - gap * (cols - 1)) / cols).coerceAtLeast(2.dp)
+                Canvas(Modifier.fillMaxWidth().height(cell * 7 + gap * 6)) {
+                    val gapPx = gap.toPx()
+                    val cellPx = cell.toPx()
+                    val radius = CornerRadius(cellPx * 0.22f, cellPx * 0.22f)
+                    for (c in 0 until cols) {
+                        val column = grid.columns[c]
+                        for (r in 0 until 7) {
+                            drawRoundRect(
+                                color = colorFor(column[r].level),
+                                topLeft = Offset(c * (cellPx + gapPx), r * (cellPx + gapPx)),
+                                size = Size(cellPx, cellPx),
+                                cornerRadius = radius,
+                            )
+                        }
+                    }
+                }
+            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text("Less", style = NoopType.caption, color = Palette.textTertiary)
+                for (lvl in 0..4) {
+                    Box(
+                        Modifier
+                            .size(10.dp)
+                            .clip(RoundedCornerShape(2.dp))
+                            .background(colorFor(lvl)),
+                    )
+                }
+                Text("More", style = NoopType.caption, color = Palette.textTertiary)
+            }
+        }
     }
 }
 

--- a/android/app/src/test/java/com/noop/analytics/ActivityHeatmapTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ActivityHeatmapTest.kt
@@ -1,0 +1,68 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the ActivityHeatmap grid builder + its calendar arithmetic. The Swift twin
+ * (`ActivityHeatmapTests`) asserts the same shape, so the two platforms bucket days into identical
+ * week-columns / weekday-rows / intensity levels.
+ */
+class ActivityHeatmapTest {
+
+    private val today = "2026-08-11" // a Tuesday (Monday-first weekday 1)
+
+    @Test fun gridShapeAndTodayPlacement() {
+        val values = mapOf("2026-08-11" to 400.0, "2026-08-10" to 100.0, "2026-08-09" to 200.0)
+        val g = ActivityHeatmap.build(values, today, weeks = 13)
+        assertEquals(13, g.weeks)
+        assertEquals(13, g.columns.size)
+        assertTrue(g.columns.all { it.size == 7 })
+        assertEquals(400.0, g.maxValue, 0.0)
+
+        // The rightmost column is the current week; today sits at weekday row 1, Monday at row 0.
+        val last = g.columns[12]
+        assertEquals("2026-08-11", last[1].day)
+        assertEquals(400.0, last[1].value)
+        assertEquals(4, last[1].level)          // max → level 4
+        assertEquals("2026-08-10", last[0].day)
+        assertEquals(1, last[0].level)          // 100/400 → level 1
+        // Future days in the current week are empty pad cells.
+        assertNull(last[2].day)
+        assertEquals(0, last[2].level)
+
+        // The first column starts 13 weeks back on a Monday; no value → no-data cell.
+        assertEquals("2026-05-18", g.columns[0][0].day)
+        assertEquals(0, g.columns[0][0].level)
+    }
+
+    @Test fun levelBuckets() {
+        assertEquals(0, ActivityHeatmap.levelFor(null, 400.0))   // no data
+        assertEquals(1, ActivityHeatmap.levelFor(0.0, 400.0))    // present but zero → 1
+        assertEquals(1, ActivityHeatmap.levelFor(100.0, 400.0))  // 25%
+        assertEquals(2, ActivityHeatmap.levelFor(200.0, 400.0))  // 50%
+        assertEquals(3, ActivityHeatmap.levelFor(300.0, 400.0))  // 75%
+        assertEquals(4, ActivityHeatmap.levelFor(400.0, 400.0))  // max
+        assertEquals(1, ActivityHeatmap.levelFor(50.0, 0.0))     // no max → 1
+    }
+
+    @Test fun calendarArithmeticMatchesTheProlepticGregorian() {
+        assertEquals(20676L, ActivityHeatmap.epochDay("2026-08-11"))
+        assertEquals(0L, ActivityHeatmap.epochDay("1970-01-01"))
+        assertEquals("2026-08-11", ActivityHeatmap.civilDay(20676L))
+        assertEquals("1970-01-01", ActivityHeatmap.civilDay(0L))
+        assertEquals(1, ActivityHeatmap.mondayFirstWeekday(20676L)) // Tue
+        assertEquals(3, ActivityHeatmap.mondayFirstWeekday(0L))     // 1970-01-01 = Thu
+        assertNull(ActivityHeatmap.epochDay("not-a-date"))
+        assertNull(ActivityHeatmap.epochDay("2026-13-40"))
+    }
+
+    @Test fun emptyValuesGivesAllNoData() {
+        val g = ActivityHeatmap.build(emptyMap(), today, weeks = 13)
+        assertTrue(g.isEmpty)
+        assertEquals(0.0, g.maxValue, 0.0)
+        assertTrue(g.columns.flatten().all { it.level == 0 })
+    }
+}


### PR DESCRIPTION
## What

A **GitHub-contribution-style heatmap** of daily active calories on the Workouts screen, on both platforms — surfaced while reviewing the sibling app OpenStrap/edge (which shipped one). Columns = weeks (Monday-first), rows = weekdays, cell shade = that day's burn vs the window max.

## Changes

- **Pure cross-platform grid builder** — `StrandAnalytics.ActivityHeatmap` + `com.noop.analytics.ActivityHeatmap` twins. Integer `days_from_civil`/`civil_from_days` over the `"yyyy-MM-dd"` day keys the app already stores, so both platforms bucket days into **identical** week-columns / weekday-rows / intensity levels. This is the parity-critical part and it's fully CI-covered.
- **iOS/macOS** — a `heatmapSection` card on `WorkoutsView` (SwiftUI `Canvas`, amber ramp), fed by ~100 days of `repo.dailyMetrics` (`activeKcalEst`). New copy in all 8 xcstrings locales.
- **Android** — a `CalorieHeatmapSection` on `WorkoutsScreen` (Compose `Canvas`) fed by `vm.recentDays`. Both platforms **hide the card** entirely when there's no daily-calorie data.

## Parity

Both platforms render the *same* pure grid. The calendar arithmetic is deterministic integer math (verified against the proleptic Gregorian calendar), pinned by twin tests (`ActivityHeatmapTest` / `ActivityHeatmapTests`) asserting identical shape, today-placement, level buckets, and epoch/civil round-trips. Cell colours are per-platform amber tokens (feature-level parity — the UI is an artifact, not stored data).

## Verification

- Kotlin `ActivityHeatmapTest` (4/4) + full `testFullDebugUnitTest` green; `compileFullDebugKotlin` green; `i18n_audit.py --ci` green.
- Swift `ActivityHeatmapTests` run under `swift-packages.yml`; the app-target `WorkoutsView` UI is validated on the app-build gate (no default CI).
- On-device pass (render the grid from real daily-calorie history) still to run on a device.