### PR TITLE
Custom background: fix the empty gap under the Scaling control

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1457,7 +1457,12 @@ fun SettingsScreen(
                     checked = BackgroundImageStore.enabled,
                     onCheckedChange = { BackgroundImageStore.setEnabled(context, it) },
                 )
-                SettingsFormRow(label = "Scaling") {
+                // Scaling label ABOVE a full-width segmented control — NOT a SettingsFormRow. In a
+                // label|control row the adaptsToAvailableWidth pill fills the width and starves the label
+                // to ~0px, which wrapped "Scaling" one letter per line and blew the row up to a tall
+                // empty gap. A stacked label sidesteps that entirely.
+                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Text("Scaling", style = NoopType.footnote, color = Palette.textSecondary)
                     SegmentedPillControl(
                         items = BackgroundFillMode.entries,
                         selection = BackgroundImageStore.fillMode,


### PR DESCRIPTION
The Fill/Fit/Stretch/Tile control sat in a `SettingsFormRow` (label | control). With `adaptsToAvailableWidth` the pill fills the row width, so the weighted **"Scaling"** label was starved to ~0px — which wrapped the word *one letter per line*, inflating the row into a tall empty gap (and left the label invisible). Screenshot showed a big dead space between the pill and **Remove image**.

Fix: render **Scaling** as a stacked label *above* a full-width segmented control (not a `SettingsFormRow`). No squeeze, no gap, and the label is visible. Android-only (iOS uses a menu picker here, unaffected). No new strings.

Verified: `compileFullDebugKotlin` green.