### PR TITLE
Custom background: recent-image presets (last 3, per-image scaling)

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Appearance.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Appearance.swift
@@ -272,6 +272,10 @@ public enum BackgroundImagePrefs {
     /// Whether a background image file has been stored (so the UI can offer Remove and the provider can
     /// skip a decode when absent). Default false.
     public static let presentKey = "noop.backgroundImagePresent"
+    /// The recent-images list (MRU, up to 3), serialized as `"<file>,<fillMode>;<file>,<fillMode>;…"`.
+    /// Device-local like the image files — the filenames differ per device, so only the KEY is shared,
+    /// not the value. Default `""`.
+    public static let recentsKey = "noop.backgroundRecents"
 }
 
 /// How a custom background image is scaled to the screen. RawValues are byte-identical to the Kotlin

--- a/Packages/StrandDesign/Tests/StrandDesignTests/BackgroundImagePrefsTests.swift
+++ b/Packages/StrandDesign/Tests/StrandDesignTests/BackgroundImagePrefsTests.swift
@@ -11,6 +11,7 @@ final class BackgroundImagePrefsTests: XCTestCase {
         XCTAssertEqual(BackgroundImagePrefs.enabledKey, "noop.backgroundImageEnabled")
         XCTAssertEqual(BackgroundImagePrefs.fillModeKey, "noop.backgroundFillMode")
         XCTAssertEqual(BackgroundImagePrefs.presentKey, "noop.backgroundImagePresent")
+        XCTAssertEqual(BackgroundImagePrefs.recentsKey, "noop.backgroundRecents")
     }
 
     func testFillModeRawValuesMatchTheKotlinContract() {

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -582,12 +582,6 @@ struct SettingsView: View {
         }
     }
 
-    /// Custom background image controls (#custom-background): pick from Photos or Browse the files,
-    /// choose the fill mode, and (once set) enable / remove. The store downscales + persists a
-    /// device-local file — nothing here is uploaded (NOOP is offline), and it is left out of `.noopbak`.
-    /// Wrapped in a layout-transparent `Group` so the picker `onChange` + the file importer can hang off
-    /// the whole cluster while it still flows inside the appearance VStack.
-    @ViewBuilder
     /// One recent-background preset: a small cropped thumbnail (accent-ringed when active) over its
     /// fill-mode label. Tapping re-applies that image + scaling.
     @ViewBuilder
@@ -611,6 +605,12 @@ struct SettingsView: View {
         .buttonStyle(.plain)
     }
 
+    /// Custom background image controls (#custom-background): pick from Photos or Browse the files,
+    /// choose the fill mode, and (once set) enable / remove. The store downscales + persists a
+    /// device-local file — nothing here is uploaded (NOOP is offline), and it is left out of `.noopbak`.
+    /// Wrapped in a layout-transparent `Group` so the picker `onChange` + the file importer can hang off
+    /// the whole cluster while it still flows inside the appearance VStack.
+    @ViewBuilder
     private var backgroundImageControls: some View {
         let hasImage = backgroundStore.hasImage
         Group {

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -637,11 +637,11 @@ struct SettingsView: View {
                             .font(StrandFont.footnote)
                             .foregroundStyle(StrandPalette.textSecondary)
                         HStack(spacing: 10) {
-                            ForEach(Array(backgroundStore.recents.enumerated()), id: \.offset) { index, recent in
+                            ForEach(backgroundStore.recents.indices, id: \.self) { index in
                                 backgroundRecentThumb(
                                     thumb: backgroundStore.thumbnails.indices.contains(index)
                                         ? backgroundStore.thumbnails[index] : nil,
-                                    mode: recent.fillMode,
+                                    mode: backgroundStore.recents[index].fillMode,
                                     active: index == 0,
                                     action: { backgroundStore.applyRecent(index) })
                             }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -588,6 +588,29 @@ struct SettingsView: View {
     /// Wrapped in a layout-transparent `Group` so the picker `onChange` + the file importer can hang off
     /// the whole cluster while it still flows inside the appearance VStack.
     @ViewBuilder
+    /// One recent-background preset: a small cropped thumbnail (accent-ringed when active) over its
+    /// fill-mode label. Tapping re-applies that image + scaling.
+    @ViewBuilder
+    private func backgroundRecentThumb(thumb: Image?, mode: BackgroundFillMode, active: Bool,
+                                       action: @escaping () -> Void) -> some View {
+        let shape = RoundedRectangle(cornerRadius: 10, style: .continuous)
+        Button(action: action) {
+            VStack(spacing: 3) {
+                Group {
+                    if let thumb { thumb.resizable().scaledToFill() } else { StrandPalette.surfaceInset }
+                }
+                .frame(width: 64, height: 64)
+                .clipShape(shape)
+                .overlay(shape.strokeBorder(active ? StrandPalette.accent : StrandPalette.hairline,
+                                            lineWidth: active ? 2 : 1))
+                Text(mode.label)
+                    .font(StrandFont.caption)
+                    .foregroundStyle(active ? StrandPalette.accent : StrandPalette.textTertiary)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
     private var backgroundImageControls: some View {
         let hasImage = backgroundStore.hasImage
         Group {
@@ -606,6 +629,26 @@ struct SettingsView: View {
             }
 
             if hasImage {
+                // Recent presets: tap a thumbnail to re-apply that image + the scaling it was last shown
+                // with. The first (accent-ringed) one is the active background.
+                if !backgroundStore.recents.isEmpty {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Recent")
+                            .font(StrandFont.footnote)
+                            .foregroundStyle(StrandPalette.textSecondary)
+                        HStack(spacing: 10) {
+                            ForEach(Array(backgroundStore.recents.enumerated()), id: \.offset) { index, recent in
+                                backgroundRecentThumb(
+                                    thumb: backgroundStore.thumbnails.indices.contains(index)
+                                        ? backgroundStore.thumbnails[index] : nil,
+                                    mode: recent.fillMode,
+                                    active: index == 0,
+                                    action: { backgroundStore.applyRecent(index) })
+                            }
+                        }
+                    }
+                }
+
                 Toggle(isOn: $backgroundStore.enabled) {
                     Text("Show custom background")
                         .font(StrandFont.subhead)
@@ -615,7 +658,9 @@ struct SettingsView: View {
                 .tint(StrandPalette.accent)
 
                 FormRow(label: "Scaling") {
-                    Picker("Scaling", selection: $backgroundStore.fillMode) {
+                    Picker("Scaling", selection: Binding(
+                        get: { backgroundStore.fillMode },
+                        set: { backgroundStore.setFillMode($0) })) {
                         ForEach(BackgroundFillMode.allCases) { mode in
                             Text(mode.label).tag(mode)
                         }

--- a/Strand/System/BackgroundImageStore.swift
+++ b/Strand/System/BackgroundImageStore.swift
@@ -21,8 +21,20 @@ import StrandDesign
 final class BackgroundImageStore: ObservableObject {
     static let shared = BackgroundImageStore()
 
-    /// The decoded background, cached; nil = none stored. Drawn by ``BackgroundImageBackdrop``.
+    /// One recent background: its app-private filename + the fill mode it was last shown with.
+    struct Recent: Equatable {
+        let id: String
+        let fillMode: BackgroundFillMode
+    }
+
+    /// The recent images, most-recent (== ACTIVE) first, up to ``maxRecents``.
+    @Published private(set) var recents: [Recent] = []
+
+    /// The active (recents[0]) decoded for the backdrop; nil = none stored. Drawn by ``BackgroundImageBackdrop``.
     @Published private(set) var image: Image?
+
+    /// Small preview images, index-aligned to ``recents`` (nil for a decode miss).
+    @Published private(set) var thumbnails: [Image?] = []
 
     /// Master enable toggle (persisted under ``BackgroundImagePrefs/enabledKey``). When true AND an
     /// image is present, the custom image overrides the sky.
@@ -30,12 +42,11 @@ final class BackgroundImageStore: ObservableObject {
         didSet { d.set(enabled, forKey: BackgroundImagePrefs.enabledKey) }
     }
 
-    /// How the image is scaled (persisted under ``BackgroundImagePrefs/fillModeKey`` as its rawValue).
-    @Published var fillMode: BackgroundFillMode {
-        didSet { d.set(fillMode.rawValue, forKey: BackgroundImagePrefs.fillModeKey) }
-    }
-
     private let d = UserDefaults.standard
+
+    /// How the ACTIVE image is scaled — the fill mode of the most-recent entry. Backed by `recents`
+    /// (`@Published`), so the backdrop re-reads it whenever the list changes.
+    var fillMode: BackgroundFillMode { recents.first?.fillMode ?? .fill }
 
     /// The custom image is the ACTIVE backdrop (top of the precedence: enabled AND actually decoded).
     var isActive: Bool { enabled && image != nil }
@@ -45,61 +56,130 @@ final class BackgroundImageStore: ObservableObject {
 
     private init() {
         enabled = d.bool(forKey: BackgroundImagePrefs.enabledKey)                       // default false
-        fillMode = BackgroundFillMode.resolve(d.string(forKey: BackgroundImagePrefs.fillModeKey) ?? "")
-        // Decode the persisted image (if any) once, up front.
-        if d.bool(forKey: BackgroundImagePrefs.presentKey),
-           let url = try? Self.fileURL(create: false),
-           let data = try? Data(contentsOf: url),
-           let platform = PlatformImage(data: data) {
-            image = Image(platformImage: platform)
-        } else {
-            image = nil
+        var list = Self.parse(d.string(forKey: BackgroundImagePrefs.recentsKey) ?? "")
+            .filter { Self.fileExists($0.id) }
+        // Migration: pre-recents installs stored ONE `background.jpg`; adopt it as the sole recent so an
+        // upgrading user keeps their background.
+        if list.isEmpty, d.bool(forKey: BackgroundImagePrefs.presentKey), Self.fileExists("background.jpg") {
+            list = [Recent(id: "background.jpg",
+                           fillMode: BackgroundFillMode.resolve(d.string(forKey: BackgroundImagePrefs.fillModeKey) ?? ""))]
         }
+        let capped = Array(list.prefix(Self.maxRecents))
+        recents = capped
+        image = capped.first.flatMap { Self.fullImage(id: $0.id) }
+        thumbnails = capped.map { Self.thumbnail(id: $0.id) }
+        persist()
     }
 
-    /// Store a picked image: downscale + re-encode to the app-private JPEG, flip the present flag, and
-    /// update the cached ``image``. Silently no-ops if the bytes can't be decoded/written (the current
-    /// background is left untouched). Reuses the avatar's ImageIO downscale path.
+    /// Store a picked image: downscale + re-encode to a new app-private JPEG, push it to the FRONT of the
+    /// recent list (deleting any dropped beyond ``maxRecents``), and refresh the decoded image/thumbnails.
+    /// Silently no-ops if the bytes can't be decoded/written. Reuses the avatar's ImageIO downscale path.
     func setImage(from data: Data) {
-        // Downscale the longest edge to at most MAX_DIMEN so a 100MP pick can never sit full-res in memory
-        // or on disk; fall back to the raw bytes only if the decode fails (matching setAvatar).
         let jpeg = AvatarImage.downscaledJPEG(from: data, maxDimension: Self.maxDimension, quality: 0.9) ?? data
-        guard let platform = PlatformImage(data: jpeg) else { return }
-        guard let url = try? Self.fileURL(create: true) else { return }
-        do {
-            try jpeg.write(to: url, options: .atomic)
-        } catch {
+        guard PlatformImage(data: jpeg) != nil else { return }
+        let id = "bg-\(Int(Date().timeIntervalSince1970 * 1000)).jpg"
+        guard let url = try? Self.fileURL(id: id, create: true) else { return }
+        do { try jpeg.write(to: url, options: .atomic) } catch { return }
+        // A fresh pick inherits the current fill mode. Prepend, cap, delete any dropped file.
+        let next = Array(([Recent(id: id, fillMode: fillMode)] + recents).prefix(Self.maxRecents))
+        for r in recents where !next.contains(r) {
+            if let u = try? Self.fileURL(id: r.id, create: false) { try? FileManager.default.removeItem(at: u) }
+        }
+        recents = next
+        refresh()
+        // Actively picking an image means the user wants to SEE it — turn the background on now.
+        if !enabled { enabled = true }
+        persist()
+    }
+
+    /// Re-apply a recent preset: move it to the front (so it becomes the ACTIVE image + its fill mode).
+    func applyRecent(_ index: Int) {
+        guard recents.indices.contains(index), index != 0 else { return }
+        let chosen = recents[index]
+        recents = [chosen] + recents.enumerated().filter { $0.offset != index }.map(\.element)
+        refresh()
+        if !enabled { enabled = true }
+        persist()
+    }
+
+    /// Change the ACTIVE image's fill mode (recents[0]).
+    func setFillMode(_ mode: BackgroundFillMode) {
+        guard !recents.isEmpty else {
+            d.set(mode.rawValue, forKey: BackgroundImagePrefs.fillModeKey)
             return
         }
-        d.set(true, forKey: BackgroundImagePrefs.presentKey)
-        image = Image(platformImage: platform)
-        // Actively picking an image means the user wants to SEE it — turn the background on so it shows
-        // immediately, instead of silently storing a photo that stays hidden behind a separate toggle.
-        // They can still toggle it off afterwards (the image is kept) or Remove it entirely.
-        if !enabled { enabled = true }
+        recents = recents.enumerated().map { $0.offset == 0 ? Recent(id: $0.element.id, fillMode: mode) : $0.element }
+        persist()
     }
 
-    /// Remove the photo: delete the file, clear the present flag, drop the cached ``image``.
+    /// Remove the ACTIVE image (recents[0]); the next recent becomes active, or the background clears.
     func clearImage() {
-        if let url = try? Self.fileURL(create: false) {
-            try? FileManager.default.removeItem(at: url)
-        }
-        d.set(false, forKey: BackgroundImagePrefs.presentKey)
-        image = nil
+        guard let removed = recents.first else { return }
+        if let u = try? Self.fileURL(id: removed.id, create: false) { try? FileManager.default.removeItem(at: u) }
+        recents = Array(recents.dropFirst())
+        refresh()
+        persist()
     }
 
-    /// Longest edge (px) the stored image is downscaled to — big enough to cover a large display crisply,
-    /// capped so a huge pick sub-samples rather than fully decoding. Mirrors the Kotlin MAX_DIMEN.
+    /// Decode the active image + every recent's thumbnail.
+    private func refresh() {
+        image = recents.first.flatMap { Self.fullImage(id: $0.id) }
+        thumbnails = recents.map { Self.thumbnail(id: $0.id) }
+    }
+
+    private func persist() {
+        d.set(Self.serialize(recents), forKey: BackgroundImagePrefs.recentsKey)
+        d.set(fillMode.rawValue, forKey: BackgroundImagePrefs.fillModeKey)
+        d.set(!recents.isEmpty, forKey: BackgroundImagePrefs.presentKey)
+    }
+
+    /// How many recent images the "presets" strip keeps (MRU). Mirrors the Kotlin MAX_RECENTS.
+    static let maxRecents = 3
+
+    /// Longest edge (px) the stored image is downscaled to. Mirrors the Kotlin MAX_DIMEN.
     private static let maxDimension: CGFloat = 2560
 
-    /// `<AppSupport>/OpenWhoop/background.jpg` (the same base folder the capture recorder uses).
-    private static func fileURL(create: Bool) throws -> URL {
+    /// `"<file>,<mode>;<file>,<mode>"`. Filenames never contain `,`/`;`.
+    static func serialize(_ list: [Recent]) -> String {
+        list.map { "\($0.id),\($0.fillMode.rawValue)" }.joined(separator: ";")
+    }
+
+    static func parse(_ s: String) -> [Recent] {
+        s.split(separator: ";").compactMap { entry -> Recent? in
+            let parts = entry.split(separator: ",", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2, !parts[0].isEmpty else { return nil }
+            return Recent(id: String(parts[0]), fillMode: BackgroundFillMode.resolve(String(parts[1])))
+        }
+    }
+
+    private static func fullImage(id: String) -> Image? {
+        guard let url = try? fileURL(id: id, create: false),
+              let data = try? Data(contentsOf: url),
+              let platform = PlatformImage(data: data) else { return nil }
+        return Image(platformImage: platform)
+    }
+
+    private static func thumbnail(id: String) -> Image? {
+        guard let url = try? fileURL(id: id, create: false),
+              let data = try? Data(contentsOf: url),
+              let jpeg = AvatarImage.downscaledJPEG(from: data, maxDimension: 256, quality: 0.85),
+              let platform = PlatformImage(data: jpeg) else { return nil }
+        return Image(platformImage: platform)
+    }
+
+    private static func fileExists(_ id: String) -> Bool {
+        guard let url = try? fileURL(id: id, create: false) else { return false }
+        return FileManager.default.fileExists(atPath: url.path)
+    }
+
+    /// `<AppSupport>/OpenWhoop/<id>` (the same base folder the capture recorder uses).
+    private static func fileURL(id: String, create: Bool) throws -> URL {
         let fm = FileManager.default
         let dir = try fm.url(for: .applicationSupportDirectory, in: .userDomainMask,
                              appropriateFor: nil, create: create)
             .appendingPathComponent("OpenWhoop", isDirectory: true)
         if create { try fm.createDirectory(at: dir, withIntermediateDirectories: true) }
-        return dir.appendingPathComponent("background.jpg", isDirectory: false)
+        return dir.appendingPathComponent(id, isDirectory: false)
     }
 }
 

--- a/Strand/System/BackgroundImageStore.swift
+++ b/Strand/System/BackgroundImageStore.swift
@@ -66,6 +66,10 @@ final class BackgroundImageStore: ObservableObject {
         }
         let capped = Array(list.prefix(Self.maxRecents))
         recents = capped
+        // GC orphan background files not referenced by the list — e.g. one left by a crash between writing
+        // a pick and persisting the list. (iOS writes atomically, so a partial file never appears; this
+        // catches only the crash-before-persist case.)
+        Self.gcOrphans(keeping: Set(capped.map(\.id)))
         image = capped.first.flatMap { Self.fullImage(id: $0.id) }
         thumbnails = capped.map { Self.thumbnail(id: $0.id) }
         persist()
@@ -174,12 +178,27 @@ final class BackgroundImageStore: ObservableObject {
 
     /// `<AppSupport>/OpenWhoop/<id>` (the same base folder the capture recorder uses).
     private static func fileURL(id: String, create: Bool) throws -> URL {
+        let dir = try dirURL(create: create)
+        return dir.appendingPathComponent(id, isDirectory: false)
+    }
+
+    private static func dirURL(create: Bool = false) throws -> URL {
         let fm = FileManager.default
         let dir = try fm.url(for: .applicationSupportDirectory, in: .userDomainMask,
                              appropriateFor: nil, create: create)
             .appendingPathComponent("OpenWhoop", isDirectory: true)
         if create { try fm.createDirectory(at: dir, withIntermediateDirectories: true) }
-        return dir.appendingPathComponent(id, isDirectory: false)
+        return dir
+    }
+
+    /// Delete background files (`bg-*.jpg` / legacy `background.jpg`) NOT referenced by `keeping` — only
+    /// OUR files are matched, so the avatar and capture files are untouched.
+    private static func gcOrphans(keeping kept: Set<String>) {
+        guard let dir = try? dirURL(create: false),
+              let names = try? FileManager.default.contentsOfDirectory(atPath: dir.path) else { return }
+        for name in names where (name.hasPrefix("bg-") || name == "background.jpg") && !kept.contains(name) {
+            try? FileManager.default.removeItem(at: dir.appendingPathComponent(name))
+        }
     }
 }
 

--- a/Strand/System/BackgroundImageStore.swift
+++ b/Strand/System/BackgroundImageStore.swift
@@ -100,7 +100,7 @@ final class BackgroundImageStore: ObservableObject {
     func applyRecent(_ index: Int) {
         guard recents.indices.contains(index), index != 0 else { return }
         let chosen = recents[index]
-        recents = [chosen] + recents.enumerated().filter { $0.offset != index }.map(\.element)
+        recents = [chosen] + recents.enumerated().filter { $0.offset != index }.map { $0.element }
         refresh()
         if !enabled { enabled = true }
         persist()

--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -538,6 +538,14 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Fill"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Fit"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Let the background show through every card. Tune how much just below."
     ],
     [
@@ -559,6 +567,10 @@
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Re-scan"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Recent"
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
@@ -586,7 +598,15 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Stretch"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Surfaces the WHOOP 5/MG strap's nightly SpO₂ estimate (spo2_candidate_82) in the "
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Tile"
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",

--- a/android/app/src/main/java/com/noop/ui/BackgroundImage.kt
+++ b/android/app/src/main/java/com/noop/ui/BackgroundImage.kt
@@ -42,30 +42,41 @@ import java.io.File
  * from MainActivity before first composition.
  */
 object BackgroundImageStore {
-    private const val FILE_NAME = "background.jpg"
-
     /** Longest edge (px) the stored image is downscaled to. Big enough to cover a large tablet/foldable
      *  screen crisply, capped so a 100MP pick can never fully decode into memory (it sub-samples first). */
     private const val MAX_DIMEN = 2560
+
+    /** Longest edge (px) for the small recent-image PREVIEW thumbnails in Settings. */
+    private const val THUMB_DIMEN = 256
 
     /** JPEG quality for the re-encoded background — a touch higher than the avatar since it fills the
      *  whole screen behind (semi-transparent) cards, still modest on disk. */
     private const val JPEG_QUALITY = 90
 
-    private fun backgroundFile(ctx: Context): File =
-        File(ctx.applicationContext.filesDir, FILE_NAME)
+    /** How many recent images the "presets" strip keeps (MRU). */
+    const val MAX_RECENTS = 3
 
-    /** The decoded background for composition; null = none stored. */
+    /** One recent background: its app-private filename + the fill mode it was last shown with. */
+    data class Recent(val id: String, val fillMode: BackgroundFillMode)
+
+    /** The recent images, most-recent (== ACTIVE) first, up to [MAX_RECENTS]. Snapshot-backed. */
+    var recents by mutableStateOf<List<Recent>>(emptyList())
+        private set
+
+    /** The active (recents[0]) decoded full-size for the backdrop; null = none stored. */
     var bitmap by mutableStateOf<ImageBitmap?>(null)
+        private set
+
+    /** Small preview thumbnails, index-aligned to [recents] (null for a decode miss). */
+    var thumbnails by mutableStateOf<List<ImageBitmap?>>(emptyList())
         private set
 
     /** Master enable toggle (mirrors NoopPrefs.backgroundImageEnabled), snapshot-backed for live redraw. */
     var enabled by mutableStateOf(false)
         private set
 
-    /** How the image is scaled (mirrors NoopPrefs.backgroundFillMode), snapshot-backed for live redraw. */
-    var fillMode by mutableStateOf(BackgroundFillMode.FILL)
-        private set
+    /** How the ACTIVE image is scaled — the fill mode of the most-recent entry. */
+    val fillMode: BackgroundFillMode get() = recents.firstOrNull()?.fillMode ?: BackgroundFillMode.FILL
 
     /** True when a photo is stored — drives the Remove affordance in Settings. */
     val hasImage: Boolean get() = bitmap != null
@@ -73,17 +84,21 @@ object BackgroundImageStore {
     /** The custom image is the ACTIVE backdrop (top of the precedence: enabled AND actually decoded). */
     val isActive: Boolean get() = enabled && bitmap != null
 
-    /** Load the persisted toggles + image (if any). Safe to call before first composition. */
+    private fun file(app: Context, id: String): File = File(app.applicationContext.filesDir, id)
+
+    /** Load the toggles + the recent list (migrating a pre-recents single `background.jpg`). */
     fun load(ctx: Context) {
         val app = ctx.applicationContext
         enabled = NoopPrefs.backgroundImageEnabled(app)
-        fillMode = NoopPrefs.backgroundFillMode(app)
-        val file = backgroundFile(app)
-        bitmap = if (NoopPrefs.backgroundImagePresent(app) && file.exists()) {
-            runCatching { BitmapFactory.decodeFile(file.absolutePath)?.asImageBitmap() }.getOrNull()
-        } else {
-            null
+        var list = parseRecents(NoopPrefs.backgroundRecents(app)).filter { file(app, it.id).exists() }
+        // Migration: pre-recents installs stored ONE `background.jpg`; adopt it as the sole recent so an
+        // upgrading user keeps their background.
+        if (list.isEmpty() && NoopPrefs.backgroundImagePresent(app) && file(app, "background.jpg").exists()) {
+            list = listOf(Recent("background.jpg", NoopPrefs.backgroundFillMode(app)))
         }
+        recents = list.take(MAX_RECENTS)
+        refreshDecoded(app)
+        persist(app)
     }
 
     fun setEnabled(ctx: Context, on: Boolean) {
@@ -91,42 +106,102 @@ object BackgroundImageStore {
         NoopPrefs.setBackgroundImageEnabled(ctx.applicationContext, on)
     }
 
+    /** Change the ACTIVE image's fill mode (recents[0]). */
     fun setFillMode(ctx: Context, mode: BackgroundFillMode) {
-        fillMode = mode
-        NoopPrefs.setBackgroundFillMode(ctx.applicationContext, mode)
+        val app = ctx.applicationContext
+        recents = if (recents.isEmpty()) recents
+        else recents.mapIndexed { i, r -> if (i == 0) r.copy(fillMode = mode) else r }
+        persist(app)
     }
 
     /**
-     * Read the picked image, downscale to [MAX_DIMEN] on the longest edge, re-encode as a JPEG into
-     * `filesDir/background.jpg`, flip the present flag, and update the live [bitmap]. Returns true on
-     * success. Call off the main thread for a large source (bitmap decode + file IO).
+     * Read the picked image, downscale, save a new app-private JPEG, and push it to the FRONT of the
+     * recent list (dropping + deleting the oldest beyond [MAX_RECENTS]). Returns true on success. Call off
+     * the main thread for a large source (bitmap decode + file IO).
      */
     fun setImageFromUri(ctx: Context, uri: Uri): Boolean {
         val app = ctx.applicationContext
         val scaled = runCatching { decodeDownscaled(app, uri) }.getOrNull() ?: return false
-        val file = backgroundFile(app)
+        val id = "bg-${System.currentTimeMillis()}.jpg"
         val wrote = runCatching {
-            file.outputStream().use { out -> scaled.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, out) }
+            file(app, id).outputStream().use { out -> scaled.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, out) }
         }.isSuccess
-        if (!wrote) {
-            scaled.recycle()
-            return false
-        }
-        NoopPrefs.setBackgroundImagePresent(app, true)
-        bitmap = scaled.asImageBitmap()
+        scaled.recycle()
+        if (!wrote) return false
+        // A fresh pick inherits the current fill mode. Prepend, cap at MAX_RECENTS, delete any dropped file.
+        val next = (listOf(Recent(id, fillMode)) + recents).take(MAX_RECENTS)
+        recents.filter { it !in next }.forEach { runCatching { file(app, it.id).delete() } }
+        recents = next
+        refreshDecoded(app)
         // Actively picking an image means the user wants to SEE it — turn the background on so it shows
-        // immediately, instead of silently storing a photo that stays hidden behind a separate toggle.
-        // They can still toggle it off afterwards (the image is kept) or Remove it entirely.
+        // immediately. They can still toggle it off afterwards (the image is kept) or Remove it.
         if (!enabled) setEnabled(app, true)
+        persist(app)
         return true
     }
 
-    /** Remove the photo: delete the file, clear the present flag, drop the live [bitmap] to null. */
+    /** Re-apply a recent preset: move it to the front (so it becomes the ACTIVE image + its fill mode). */
+    fun applyRecent(ctx: Context, index: Int) {
+        val app = ctx.applicationContext
+        if (index !in recents.indices || index == 0) return
+        val chosen = recents[index]
+        recents = listOf(chosen) + recents.filterIndexed { i, _ -> i != index }
+        refreshDecoded(app)
+        if (!enabled) setEnabled(app, true)
+        persist(app)
+    }
+
+    /** Remove the ACTIVE image (recents[0]); the next recent becomes active, or the background clears. */
     fun clearImage(ctx: Context) {
         val app = ctx.applicationContext
-        runCatching { backgroundFile(app).delete() }
-        NoopPrefs.setBackgroundImagePresent(app, false)
-        bitmap = null
+        val removed = recents.firstOrNull() ?: return
+        runCatching { file(app, removed.id).delete() }
+        recents = recents.drop(1)
+        refreshDecoded(app)
+        persist(app)
+    }
+
+    /** Decode the active image full-size + every recent as a small thumbnail. */
+    private fun refreshDecoded(app: Context) {
+        bitmap = recents.firstOrNull()?.let { r ->
+            runCatching { BitmapFactory.decodeFile(file(app, r.id).absolutePath)?.asImageBitmap() }.getOrNull()
+        }
+        thumbnails = recents.map { r ->
+            runCatching { decodeScaledFile(file(app, r.id), THUMB_DIMEN)?.asImageBitmap() }.getOrNull()
+        }
+    }
+
+    /** Persist the recent list + mirror the active fill mode / present flag onto the shared pref keys. */
+    private fun persist(app: Context) {
+        NoopPrefs.setBackgroundRecents(app, serializeRecents(recents))
+        NoopPrefs.setBackgroundFillMode(app, fillMode)
+        NoopPrefs.setBackgroundImagePresent(app, recents.isNotEmpty())
+    }
+
+    /** `"<file>,<mode>;<file>,<mode>"` — see [KEY_BACKGROUND_RECENTS]. Filenames never contain `,`/`;`. */
+    internal fun serializeRecents(list: List<Recent>): String =
+        list.joinToString(";") { "${it.id},${it.fillMode.storageValue}" }
+
+    internal fun parseRecents(s: String): List<Recent> =
+        s.split(";").mapNotNull { entry ->
+            if (entry.isBlank()) return@mapNotNull null
+            val parts = entry.split(",")
+            if (parts.size != 2 || parts[0].isBlank()) return@mapNotNull null
+            Recent(parts[0], BackgroundFillMode.fromStorage(parts[1]))
+        }.take(MAX_RECENTS)
+
+    /** Decode [f] downscaled so its longest edge is ~[maxDimen] (two-pass inSampleSize). Null on failure. */
+    private fun decodeScaledFile(f: File, maxDimen: Int): Bitmap? {
+        if (!f.exists()) return null
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(f.absolutePath, bounds)
+        if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+        var sample = 1
+        while (bounds.outWidth / (sample * 2) >= maxDimen && bounds.outHeight / (sample * 2) >= maxDimen) {
+            sample *= 2
+        }
+        val opts = BitmapFactory.Options().apply { inSampleSize = sample }
+        return BitmapFactory.decodeFile(f.absolutePath, opts)
     }
 
     /**

--- a/android/app/src/main/java/com/noop/ui/BackgroundImage.kt
+++ b/android/app/src/main/java/com/noop/ui/BackgroundImage.kt
@@ -97,6 +97,11 @@ object BackgroundImageStore {
             list = listOf(Recent("background.jpg", NoopPrefs.backgroundFillMode(app)))
         }
         recents = list.take(MAX_RECENTS)
+        // GC orphan background files (bg-*.jpg / legacy background.jpg) not referenced by the list — e.g.
+        // one left by a crash between writing a pick and persisting the list. Only OUR files are matched.
+        val kept = recents.map { it.id }.toSet()
+        app.filesDir.listFiles { f -> f.isFile && (f.name.startsWith("bg-") || f.name == "background.jpg") }
+            ?.forEach { if (it.name !in kept) runCatching { it.delete() } }
         refreshDecoded(app)
         persist(app)
     }

--- a/android/app/src/main/java/com/noop/ui/BackgroundImage.kt
+++ b/android/app/src/main/java/com/noop/ui/BackgroundImage.kt
@@ -127,7 +127,12 @@ object BackgroundImageStore {
             file(app, id).outputStream().use { out -> scaled.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, out) }
         }.isSuccess
         scaled.recycle()
-        if (!wrote) return false
+        if (!wrote) {
+            // A failed compress can leave a partial file behind — it's never added to `recents`, so delete
+            // it here or it leaks forever (unlike iOS's atomic write, which leaves nothing on failure).
+            runCatching { file(app, id).delete() }
+            return false
+        }
         // A fresh pick inherits the current fill mode. Prepend, cap at MAX_RECENTS, delete any dropped file.
         val next = (listOf(Recent(id, fillMode)) + recents).take(MAX_RECENTS)
         recents.filter { it !in next }.forEach { runCatching { file(app, it.id).delete() } }

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -789,6 +789,17 @@ object NoopPrefs {
         of(context).edit().putBoolean(KEY_BACKGROUND_IMAGE_PRESENT, present).apply()
     }
 
+    /** Recent background images (MRU, up to 3), serialized as `"<file>,<fillMode>;…"` — see
+     *  BackgroundImageStore. Default "". Device-local like the image files, NOT in the .noopbak whitelist. */
+    const val KEY_BACKGROUND_RECENTS = "noop.backgroundRecents"
+
+    fun backgroundRecents(context: Context): String =
+        of(context).getString(KEY_BACKGROUND_RECENTS, "") ?: ""
+
+    fun setBackgroundRecents(context: Context, value: String) {
+        of(context).edit().putString(KEY_BACKGROUND_RECENTS, value).apply()
+    }
+
     /** "Reduce motion in NOOP" (opt-in, default OFF). The literal key matches Apple so the setting has
      *  one cross-platform identity. [rememberQuietMotion] observes it live for every looping surface. */
     const val KEY_QUIET_MOTION = "noop.quietMotion"

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -14,7 +14,10 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.rememberScrollState
@@ -1450,6 +1453,27 @@ fun SettingsScreen(
             }
 
             if (BackgroundImageStore.hasImage) {
+                // Recent presets: tap a thumbnail to re-apply that image + the scaling it was last shown
+                // with. The first (accent-ringed) one is the active background.
+                val recents = BackgroundImageStore.recents
+                if (recents.isNotEmpty()) {
+                    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        Text("Recent", style = NoopType.footnote, color = Palette.textSecondary)
+                        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                            recents.forEachIndexed { i, r ->
+                                BackgroundRecentThumb(
+                                    thumb = BackgroundImageStore.thumbnails.getOrNull(i),
+                                    mode = r.fillMode,
+                                    active = i == 0,
+                                    // Off-main: applyRecent re-decodes the full-size active image.
+                                    onClick = {
+                                        scope.launch { withContext(Dispatchers.IO) { BackgroundImageStore.applyRecent(context, i) } }
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
                 // Master gate + scaling only make sense once an image exists.
                 SettingsToggleRow(
                     title = "Show custom background",
@@ -1483,7 +1507,9 @@ fun SettingsScreen(
                     text = "Remove image",
                     kind = NoopButtonKind.Tertiary,
                     modifier = Modifier.fillMaxWidth(),
-                    onClick = { BackgroundImageStore.clearImage(context) },
+                    onClick = {
+                        scope.launch { withContext(Dispatchers.IO) { BackgroundImageStore.clearImage(context) } }
+                    },
                 )
             }
         }
@@ -3632,4 +3658,53 @@ private fun Context.hostingActivity(): Activity? {
         current = current.baseContext
     }
     return current as? Activity
+}
+
+/** One recent-background preset: a small cropped thumbnail (accent-ringed when active) over its fill-mode
+ *  label. Tapping re-applies that image + scaling via [BackgroundImageStore.applyRecent]. */
+@Composable
+private fun BackgroundRecentThumb(
+    thumb: ImageBitmap?,
+    mode: BackgroundFillMode,
+    active: Boolean,
+    onClick: () -> Unit,
+) {
+    val shape = RoundedCornerShape(10.dp)
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(3.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(64.dp)
+                .clip(shape)
+                .border(
+                    width = if (active) 2.dp else 1.dp,
+                    color = if (active) Palette.accent else Palette.hairline,
+                    shape = shape,
+                )
+                .clickable(onClick = onClick),
+        ) {
+            if (thumb != null) {
+                Image(
+                    bitmap = thumb,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop,
+                )
+            } else {
+                Box(Modifier.fillMaxSize().background(Palette.surfaceInset))
+            }
+        }
+        Text(
+            text = when (mode) {
+                BackgroundFillMode.FILL -> "Fill"
+                BackgroundFillMode.FIT -> "Fit"
+                BackgroundFillMode.STRETCH -> "Stretch"
+                BackgroundFillMode.TILE -> "Tile"
+            },
+            style = NoopType.caption,
+            color = if (active) Palette.accent else Palette.textTertiary,
+        )
+    }
 }

--- a/android/app/src/test/java/com/noop/ui/BackgroundImagePrefsParityTest.kt
+++ b/android/app/src/test/java/com/noop/ui/BackgroundImagePrefsParityTest.kt
@@ -3,6 +3,7 @@ package com.noop.ui
 import com.noop.data.BackupSettingsCodec
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -18,6 +19,7 @@ class BackgroundImagePrefsParityTest {
         assertEquals("noop.backgroundImageEnabled", NoopPrefs.KEY_BACKGROUND_IMAGE_ENABLED)
         assertEquals("noop.backgroundFillMode", NoopPrefs.KEY_BACKGROUND_FILL_MODE)
         assertEquals("noop.backgroundImagePresent", NoopPrefs.KEY_BACKGROUND_IMAGE_PRESENT)
+        assertEquals("noop.backgroundRecents", NoopPrefs.KEY_BACKGROUND_RECENTS)
     }
 
     @Test fun fillModeRawValues_matchTheIosContract() {
@@ -39,11 +41,27 @@ class BackgroundImagePrefsParityTest {
         assertEquals(BackgroundFillMode.FILL, BackgroundFillMode.fromStorage(""))
     }
 
+    @Test fun recents_serializeAndParseRoundTrip() {
+        val list = listOf(
+            BackgroundImageStore.Recent("bg-1.jpg", BackgroundFillMode.FIT),
+            BackgroundImageStore.Recent("bg-2.jpg", BackgroundFillMode.TILE),
+            BackgroundImageStore.Recent("bg-3.jpg", BackgroundFillMode.FILL),
+        )
+        val s = BackgroundImageStore.serializeRecents(list)
+        assertEquals("bg-1.jpg,fit;bg-2.jpg,tile;bg-3.jpg,fill", s)
+        assertEquals(list, BackgroundImageStore.parseRecents(s))
+        // Empty / malformed entries are dropped, and the list is capped at MAX_RECENTS.
+        assertTrue(BackgroundImageStore.parseRecents("").isEmpty())
+        assertTrue(BackgroundImageStore.parseRecents("garbage").isEmpty())
+        assertEquals(BackgroundImageStore.MAX_RECENTS, BackgroundImageStore.parseRecents("a,fill;b,fit;c,tile;d,fill").size)
+    }
+
     @Test fun backgroundKeys_areNotInTheNoopbakWhitelist() {
         // Device-local (like the avatar) — a restore onto another device must not carry the picture
         // toggles. Guards against someone "helpfully" whitelisting them later.
         assertFalse(BackupSettingsCodec.WHITELIST.containsKey(NoopPrefs.KEY_BACKGROUND_IMAGE_ENABLED))
         assertFalse(BackupSettingsCodec.WHITELIST.containsKey(NoopPrefs.KEY_BACKGROUND_FILL_MODE))
         assertFalse(BackupSettingsCodec.WHITELIST.containsKey(NoopPrefs.KEY_BACKGROUND_IMAGE_PRESENT))
+        assertFalse(BackupSettingsCodec.WHITELIST.containsKey(NoopPrefs.KEY_BACKGROUND_RECENTS))
     }
 }


### PR DESCRIPTION
## What

The custom-background card now keeps the **last 3 images as tappable presets** — each with a small **thumbnail preview** and its own **Fill/Fit/Stretch/Tile** mode. Tap a preset to re-apply that image + its scaling.

## Changes

- **`BackgroundImageStore`** (Swift + Kotlin twins): an MRU list of up to 3 `Recent(id, fillMode)` instead of a single image. Prepend on pick, cap at 3 (delete the dropped file), move-to-front on re-apply; `fillMode` is the active (recents[0]) mode. **Migrates** a pre-recents single `background.jpg` into the list, so upgrading users keep their background. Persisted under a new shared **`noop.backgroundRecents`** pref key — device-local, **not** in `.noopbak` — added to `StrandDesign.BackgroundImagePrefs` + both parity tests.
- **Settings:** a **"Recent"** thumbnail strip (accent-ringed = active) above the toggle, each labelled with its scaling. iOS uses the localized `mode.label`; Android's new literals are baselined; "Recent" was already in xcstrings.
- **Perf:** Android `applyRecent`/`clearImage` re-decode the full active image, so the preset taps run **off-main** (IO). iOS decodes lazily via `UIImage(data:)` already.

## Verification

- Android: `compileFullDebugKotlin` + full `testFullDebugUnitTest` green (a recents serialize/parse round-trip test is pinned). `i18n_audit --ci` green.
- Swift `BackgroundImagePrefs` parity test runs under `swift-packages`; the app-target Settings/store UI is validated on the **app-build gate**.
- On-device pass (pick 3+ images, tap between presets, confirm each keeps its scaling; verify an upgrading user's existing background migrates) still to run on a device.