### PR TITLE
diag(sleep): log why a night with HR staged to no sleep (#1244)

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -217,6 +217,22 @@ final class IntelligenceEngine: ObservableObject {
             + "(floor = WHOOP-style lowest-sustained = NOOP RHR; mean = sleeping-HR-app number)"
     }
 
+    /// #1244: one line for a day that CLEARED the ≥200-HR gate yet detected NO in-bed session, so the
+    /// dashboard shows "HR tracked but no sleep". Today only the summary `sleep day=… totalSleepMin=nil`
+    /// rides the log — with no clue WHY, since every other night trace (`rhr`/`rrsample`/`hrv diag`) only
+    /// emits once a session exists. This names the raw inputs the stager was handed so the next capture
+    /// separates the causes: `grav=0` = no motion offloaded (the in-bed detector can't gate — the WHOOP
+    /// 4.0 sparse-motion path has no HR-only fallback); a large `hr` with a night still empty = coverage
+    /// gap or the sleep hours fell outside `window`; `provided=` = a persisted hypnogram was (not) available.
+    /// Counts + a window length only — same privacy class as the sibling `sleep day=` line, no PII. Pure so
+    /// it's unit-tested directly; byte-identical to the Android `sleepDetectNoNightLogLine`.
+    nonisolated static func sleepDetectNoNightLogLine(day: String, hrCount: Int, rrCount: Int,
+                                                      respCount: Int, gravCount: Int, stepCount: Int,
+                                                      providedCount: Int, windowHours: Int) -> String {
+        return "sleep-detect day=\(day) NO-NIGHT hr=\(hrCount) rr=\(rrCount) resp=\(respCount) "
+            + "grav=\(gravCount) steps=\(stepCount) provided=\(providedCount) window=\(windowHours)h"
+    }
+
     /// The Saturday on-or-before a "yyyy-MM-dd" local-day string , the weekly key Fitness Age writes to.
     static func saturdayKey(onOrBefore dayStr: String) -> String {
         var cal = Calendar(identifier: .gregorian); cal.timeZone = .current
@@ -786,7 +802,22 @@ final class IntelligenceEngine: ObservableObject {
                 let sleepRr = sleepRrRows.map { Double($0.rrMs) }
                 let hrvDiag: String?
                 if sleepRr.isEmpty {
-                    hrvDiag = nil
+                    // #1244: no in-sleep R-R means no HRV summary. If the whole night also detected NO
+                    // session (past the ≥200-HR gate → this is the "HR tracked, no sleep" case), carry a
+                    // counts-only reason line on the SAME loop-1 diagnostic channel (emitted in the
+                    // main-actor replay below) so the report says WHY the stager found nothing. `window` is
+                    // the read span in whole hours (30 h back → next local midnight, or +18 h for today).
+                    if res.cachedSleep.isEmpty {
+                        // from/to are Int unix seconds; the span is always a whole-hour multiple
+                        // (30 h + 24 h, or 30 h + 18 h), so integer division is exact. Matches Kotlin.
+                        let windowHours = (to - from) / 3_600
+                        hrvDiag = Self.sleepDetectNoNightLogLine(
+                            day: day, hrCount: hr.count, rrCount: rr.count, respCount: resp.count,
+                            gravCount: grav.count, stepCount: steps.count,
+                            providedCount: providedSleep.count, windowHours: windowHours)
+                    } else {
+                        hrvDiag = nil
+                    }
                 } else {
                     let h = HRVAnalyzer.analyze(rawRR: sleepRr)
                     func ms(_ v: Double?) -> String { v.map { String(format: "%.0f", $0) } ?? "nil" }

--- a/StrandTests/IntelligenceSleepDetectNoNightTests.swift
+++ b/StrandTests/IntelligenceSleepDetectNoNightTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import Strand
+
+/// Pins the "HR tracked but no sleep" diagnostic (#1244). When a day clears the >=200-HR gate yet the
+/// stager detects NO in-bed session, the summary line only says `totalSleepMin=nil` with no clue why —
+/// every other night trace (`rhr`/`rrsample`/`hrv diag`) emits only once a session exists. The engine now
+/// ships one counts-only reason line naming the raw inputs the stager was handed, so the next capture
+/// separates the causes (no motion vs coverage gap vs window). `sleepDetectNoNightLogLine` is the pure
+/// formatter the loop calls; tested directly (no store). Mirrors the Android `sleepDetectNoNightLogLine`
+/// so the two platforms log a byte-identical line.
+@MainActor
+final class IntelligenceSleepDetectNoNightTests: XCTestCase {
+
+    private typealias IE = IntelligenceEngine
+
+    func testNoMotionNight_theLeadingHypothesis() {
+        // The #1244 shape: plenty of HR, but grav=0 (no motion offloaded) so the in-bed detector can't
+        // gate the night → nothing stages. `window=54h` is the past-day span (30 h back → next midnight).
+        let line = IE.sleepDetectNoNightLogLine(
+            day: "2026-08-11", hrCount: 41230, rrCount: 0, respCount: 880,
+            gravCount: 0, stepCount: 12, providedCount: 0, windowHours: 54)
+        XCTAssertEqual(line,
+            "sleep-detect day=2026-08-11 NO-NIGHT hr=41230 rr=0 resp=880 "
+            + "grav=0 steps=12 provided=0 window=54h")
+    }
+
+    func testTodayWindowIs48h() {
+        // Today's read caps at dayStart+18h (vs a past day's next-midnight), so the whole span is 48 h.
+        let line = IE.sleepDetectNoNightLogLine(
+            day: "2026-08-12", hrCount: 5000, rrCount: 900, respCount: 300,
+            gravCount: 4, stepCount: 0, providedCount: 0, windowHours: 48)
+        XCTAssertTrue(line.contains("window=48h"), line)
+    }
+
+    func testLineCarriesNoEmDash() {
+        // House style: never an em-dash in shared text.
+        let line = IE.sleepDetectNoNightLogLine(
+            day: "2026-08-11", hrCount: 1, rrCount: 1, respCount: 1,
+            gravCount: 1, stepCount: 1, providedCount: 1, windowHours: 54)
+        XCTAssertFalse(line.contains("—"))
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -694,6 +694,19 @@ object IntelligenceEngine {
                     )
                     if (sample.isNotEmpty()) diag("hrv rrsample day=${res.daily.day} $sample")
                 }
+            } else if (res.sleepSessions.isEmpty()) {
+                // #1244: no in-sleep R-R AND no detected session (past the >=200-HR gate) = the "HR tracked,
+                // no sleep" case. Emit a counts-only reason line naming the inputs the stager had, so the
+                // report says WHY nothing staged. `window` is the read span in whole hours (30 h back → next
+                // local midnight, or +18 h for today). Byte-identical to the Swift line.
+                val windowHours = ((to - from) / 3_600L).toInt()
+                diag(
+                    sleepDetectNoNightLogLine(
+                        day = day, hrCount = hr.size, rrCount = rr.size, respCount = resp.size,
+                        gravCount = grav.size, stepCount = steps.size, providedCount = providedSleep.size,
+                        windowHours = windowHours,
+                    ),
+                )
             }
 
             // Steps test mode: emit the 5/MG raw-counter trace for this day (cumulative @57 series +
@@ -1960,5 +1973,24 @@ object IntelligenceEngine {
             else Math.round(inBedBpms.sum().toDouble() / inBedBpms.size).toString()
         return "rhr day=$day floor=$floor nightMean=$meanLog inBedSamples=${inBedBpms.size} " +
             "(floor = WHOOP-style lowest-sustained = NOOP RHR; mean = sleeping-HR-app number)"
+    }
+
+    /**
+     * #1244: one line for a day that CLEARED the >=200-HR gate yet detected NO in-bed session, so the
+     * dashboard shows "HR tracked but no sleep". Today only the summary `sleep day=... totalSleepMin=nil`
+     * rides the log — with no clue WHY, since every other night trace (`rhr`/`rrsample`/`hrv diag`) only
+     * emits once a session exists. This names the raw inputs the stager was handed so the next capture
+     * separates the causes: `grav=0` = no motion offloaded (the in-bed detector can't gate — the WHOOP
+     * 4.0 sparse-motion path has no HR-only fallback); a large `hr` with a night still empty = coverage
+     * gap or the sleep hours fell outside `window`; `provided=` = a persisted hypnogram was (not) available.
+     * Counts + a window length only — same privacy class as the sibling `sleep day=` line, no PII. Pure so
+     * it's unit-tested directly; byte-identical to the Swift `sleepDetectNoNightLogLine`.
+     */
+    internal fun sleepDetectNoNightLogLine(
+        day: String, hrCount: Int, rrCount: Int, respCount: Int, gravCount: Int,
+        stepCount: Int, providedCount: Int, windowHours: Int,
+    ): String {
+        return "sleep-detect day=$day NO-NIGHT hr=$hrCount rr=$rrCount resp=$respCount " +
+            "grav=$gravCount steps=$stepCount provided=$providedCount window=${windowHours}h"
     }
 }

--- a/android/app/src/test/java/com/noop/analytics/IntelligenceSleepDetectNoNightTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/IntelligenceSleepDetectNoNightTest.kt
@@ -1,0 +1,53 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the "HR tracked but no sleep" diagnostic (#1244). When a day clears the >=200-HR gate yet the
+ * stager detects NO in-bed session, the summary line only says `totalSleepMin=nil` with no clue why —
+ * every other night trace (`rhr`/`rrsample`/`hrv diag`) emits only once a session exists. The engine now
+ * ships one counts-only reason line naming the raw inputs the stager was handed, so the next capture
+ * separates the causes (no motion vs coverage gap vs window). `sleepDetectNoNightLogLine` is the pure
+ * formatter the loop calls; tested directly. Mirrors the Swift `IntelligenceSleepDetectNoNightTests`
+ * so the two platforms log a byte-identical line.
+ */
+class IntelligenceSleepDetectNoNightTest {
+
+    @Test
+    fun noMotionNight_theLeadingHypothesis() {
+        // The #1244 shape: plenty of HR, but grav=0 (no motion offloaded) so the in-bed detector can't
+        // gate the night → nothing stages. window=54h is the past-day span (30 h back → next midnight).
+        val line = IntelligenceEngine.sleepDetectNoNightLogLine(
+            day = "2026-08-11", hrCount = 41230, rrCount = 0, respCount = 880,
+            gravCount = 0, stepCount = 12, providedCount = 0, windowHours = 54,
+        )
+        assertEquals(
+            "sleep-detect day=2026-08-11 NO-NIGHT hr=41230 rr=0 resp=880 " +
+                "grav=0 steps=12 provided=0 window=54h",
+            line,
+        )
+    }
+
+    @Test
+    fun todayWindowIs48h() {
+        // Today's read caps at dayStart+18h (vs a past day's next-midnight), so the whole span is 48 h.
+        val line = IntelligenceEngine.sleepDetectNoNightLogLine(
+            day = "2026-08-12", hrCount = 5000, rrCount = 900, respCount = 300,
+            gravCount = 4, stepCount = 0, providedCount = 0, windowHours = 48,
+        )
+        assertTrue(line, line.contains("window=48h"))
+    }
+
+    @Test
+    fun lineCarriesNoEmDash() {
+        // House style: never an em-dash in shared text.
+        val line = IntelligenceEngine.sleepDetectNoNightLogLine(
+            day = "2026-08-11", hrCount = 1, rrCount = 1, respCount = 1,
+            gravCount = 1, stepCount = 1, providedCount = 1, windowHours = 54,
+        )
+        assertFalse(line.contains("—"))
+    }
+}


### PR DESCRIPTION
## What
When a day clears the `>=200`-HR gate but the stager detects **no in-bed session**, the strap log today shows only `sleep day=… totalSleepMin=nil source=computed` — with no clue *why*. Every other per-night trace (`rhr`/`hrv rrsample`/`hrv diag`) emits **only once a session exists**, so a "HR tracked but no sleep" report (#1244) is untriageable from the capture.

This adds one counts-only reason line for exactly that case:
```
sleep-detect day=2026-08-11 NO-NIGHT hr=41230 rr=0 resp=880 grav=0 steps=12 provided=0 window=54h
```
which separates the candidate causes the current log can't:
- **`grav=0`** → no motion offloaded, so the in-bed detector can't gate (the WHOOP-4.0 sparse-motion path has no HR-only fallback — the `providedSleep` reconstruction is non-WHOOP-only);
- large **`hr`** with the night still empty → coverage gap, or sleep hours fell outside **`window`**;
- **`provided=`** → whether a persisted hypnogram was available.

## Why it's safe
- **Log-only.** No analytics, stored value, migration, or behavior change.
- **Pure formatter** `sleepDetectNoNightLogLine`, **byte-identical Swift + Kotlin**, with a matched unit test each side (Android test run locally: green; Swift validated via the app-build gate).
- **PII-free** — counts + a window length, same privacy class as the sibling `sleep day=` line; rides the same always-on strap log.
- **No capture-completeness token** — the always-on `sleep day=` line already covers the day, and `sleep-detect ` neither prefixes nor contains `sleep day=`, so it isn't miscounted.

## Context
Triage of #1244 (WHOOP 4.0, last night `day=2026-08-11` staged nil despite HR present). The log pins the failing *stage* but not the *cause* — this is the instrument-first step (per CLAUDE.md) before any detector change. The recent `band sleep_state wake-veto` was ruled out (default-off; 4.0 has no band stream). If a real capture then shows `grav=0` on a 4.0, the follow-up is a targeted HR-only in-bed fallback.