### PR TITLE
fix(oura): heal banked-sleep duplicates across every device, not just computedId (#1248)

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -233,6 +233,16 @@ final class IntelligenceEngine: ObservableObject {
             + "grav=\(gravCount) steps=\(stepCount) provided=\(providedCount) window=\(windowHours)h"
     }
 
+    /// #1248: the device ids the banked-sleep heal (#899) must sweep — the computed-scores id AND every
+    /// registered device id. A live source (an Oura ring) banks its OWN hypnogram under its OWN device id,
+    /// so a computedId-only heal never sees (or collapses) those rows, and they are re-read as
+    /// `providedSleep` and re-detected every pass — one night ballooned to 14 stored rows / 9 phantom
+    /// "naps". The de-duplicated union, sorted for a deterministic sweep order. Pure so it's unit-tested
+    /// directly; byte-identical to the Android `healDeviceIds`.
+    nonisolated static func healDeviceIds(computedId: String, registeredIds: [String]) -> [String] {
+        Set([computedId] + registeredIds).sorted()
+    }
+
     /// The Saturday on-or-before a "yyyy-MM-dd" local-day string , the weekly key Fitness Age writes to.
     static func saturdayKey(onOrBefore dayStr: String) -> String {
         var cal = Calendar(identifier: .gregorian); cal.timeZone = .current
@@ -1645,14 +1655,27 @@ final class IntelligenceEngine: ObservableObject {
         // stale copies. Scoped to sessions whose wake day lies inside the [oldestDay, newestDay] daily
         // reconcile window: exactly the days this pass re-scored/evicted, so a session row is never
         // deleted out from under a daily row the pass did not refresh. Edited rows are never dropped.
-        let storedSessions = (try? await store.sleepSessions(deviceId: computedId, from: windowStart,
-                                                             to: now, limit: 4000)) ?? []
-        let healable = storedSessions.filter {
-            (oldestDay...newestDay).contains(AnalyticsEngine.dayString($0.endTs, offsetSec: tzOffset))
-        }
-        let healDropped = SleepSessionDedup.dedupe(healable, freshStarts: keptStarts).dropped
-        for stale in healDropped {
-            _ = try? await store.deleteSleepSession(deviceId: computedId, startTs: stale.startTs)
+        // #1248: heal EVERY device that banks sleep in this window, not just `computedId`. A live source
+        // (an Oura ring) banks its OWN hypnogram under its device id; a night re-banked there accumulates
+        // overlapping copies the computedId-only heal never saw — and, worse, those un-healed ring rows are
+        // re-read as `providedSleep` and re-detected every pass, so one night ballooned to 14 rows / 9
+        // "naps". Dedup each device's rows AMONG THEMSELVES and delete stale copies under that SAME id
+        // (never across ids, so a survivor is never orphaned under an id the day-owner read skips).
+        // `freshStarts` (this pass's computed bank witness) only matches the computedId rows; the others
+        // fall back to longest-wins, the read-side dedup's own default. Sorted for a deterministic order.
+        let healDeviceIds = Self.healDeviceIds(computedId: computedId, registeredIds: regDevices.map { $0.id })
+        var healDropped: [CachedSleepSession] = []
+        for healId in healDeviceIds {
+            let storedSessions = (try? await store.sleepSessions(deviceId: healId, from: windowStart,
+                                                                 to: now, limit: 4000)) ?? []
+            let healable = storedSessions.filter {
+                (oldestDay...newestDay).contains(AnalyticsEngine.dayString($0.endTs, offsetSec: tzOffset))
+            }
+            let dropped = SleepSessionDedup.dedupe(healable, freshStarts: keptStarts).dropped
+            for stale in dropped {
+                _ = try? await store.deleteSleepSession(deviceId: healId, startTs: stale.startTs)
+            }
+            healDropped.append(contentsOf: dropped)
         }
         if !healDropped.isEmpty {
             diagnosticSink?("Dedup(#899): removed \(healDropped.count) overlapping duplicate sleep "

--- a/StrandTests/IntelligenceHealDeviceScopeTests.swift
+++ b/StrandTests/IntelligenceHealDeviceScopeTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import Strand
+
+/// Pins the banked-sleep heal's device SCOPE (#1248). The `#899` overlap heal used to read/dedupe/delete
+/// only under `computedId`, so a live source that banks its OWN hypnogram under its OWN device id (an Oura
+/// ring) was never healed — and those un-collapsed rows were re-read as `providedSleep` and re-detected
+/// every pass, ballooning one night to 14 stored rows / 9 phantom "naps". `healDeviceIds` is the pure set
+/// of ids the heal now sweeps; tested directly. Mirrors the Android `healDeviceIds` so the two platforms
+/// heal the same device ids.
+@MainActor
+final class IntelligenceHealDeviceScopeTests: XCTestCase {
+
+    private typealias IE = IntelligenceEngine
+
+    func testRingIdIsInScope_theBug() {
+        // The exact #1248 shape: a WHOOP is primary (computed under "my-whoop-noop") and an Oura ring
+        // banks its own hypnogram under "oura-2H3B". The ring id MUST be swept, or its drift-duped
+        // hypnograms survive forever.
+        let ids = IE.healDeviceIds(computedId: "my-whoop-noop", registeredIds: ["my-whoop", "oura-2H3B"])
+        XCTAssertEqual(ids, ["my-whoop", "my-whoop-noop", "oura-2H3B"])
+        XCTAssertTrue(ids.contains("oura-2H3B"), "the ring id the computedId-only heal missed")
+    }
+
+    func testComputedIdAlwaysPresent_evenWithNoRegisteredDevices() {
+        // A BLE-only install with an empty registry still heals its computed rows (the prior behaviour).
+        XCTAssertEqual(IE.healDeviceIds(computedId: "my-whoop-noop", registeredIds: []), ["my-whoop-noop"])
+    }
+
+    func testDeDuplicatesAndSortsDeterministically() {
+        // computedId can also appear in the registry list; the union de-dups and sorts so the sweep order
+        // is stable across runs and matches Kotlin's toSortedSet().
+        let ids = IE.healDeviceIds(computedId: "b-noop", registeredIds: ["oura-1", "b-noop", "a-whoop"])
+        XCTAssertEqual(ids, ["a-whoop", "b-noop", "oura-1"])
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1380,14 +1380,28 @@ object IntelligenceEngine {
         // reconcile window: exactly the days this pass re-scored/evicted, so a session row is never
         // deleted out from under a daily row the pass did not refresh. Edited rows are never dropped.
         // Mirrors the Swift analyzeRecent heal.
-        val storedSessions = repo.sleepSessions(computedId, windowStart, nowSeconds, 4000)
-        val healable = storedSessions.filter {
-            AnalyticsEngine.dayString(it.endTs, tzOffsetSeconds) in oldestDay..newestDay
+        // #1248: heal EVERY device that banks sleep in this window, not just `computedId`. A live source
+        // (an Oura ring) banks its OWN hypnogram under its device id; a night re-banked there accumulates
+        // overlapping copies the computedId-only heal never saw — and, worse, those un-healed ring rows are
+        // re-read as `providedSleep` and re-detected every pass, so one night ballooned to 14 rows / 9
+        // "naps". Dedup each device's rows AMONG THEMSELVES and delete stale copies under that SAME id
+        // (deleteSleepSessionRowOnly deletes under the row's own deviceId), never across ids, so a survivor
+        // is never orphaned under an id the day-owner read skips. `freshStarts` (this pass's computed bank
+        // witness) only matches the computedId rows; the others fall back to longest-wins, the read-side
+        // dedup's own default. Sorted for a deterministic order. Mirrors the Swift analyzeRecent heal.
+        val healDeviceIds = healDeviceIds(computedId, candidatePriorities.map { it.first })
+        val healDropped = ArrayList<SleepSession>()
+        for (healId in healDeviceIds) {
+            val storedSessions = repo.sleepSessions(healId, windowStart, nowSeconds, 4000)
+            val healable = storedSessions.filter {
+                AnalyticsEngine.dayString(it.endTs, tzOffsetSeconds) in oldestDay..newestDay
+            }
+            val dropped = SleepSessionDedup.dedupe(healable, freshStarts = keptStarts).dropped
+            // Row-only delete: the user-facing deleteSleepSession writes a #33 dismissal tombstone, which
+            // would overlap the SURVIVING night's window and permanently suppress its re-detection.
+            for (stale in dropped) repo.deleteSleepSessionRowOnly(stale)
+            healDropped.addAll(dropped)
         }
-        val healDropped = SleepSessionDedup.dedupe(healable, freshStarts = keptStarts).dropped
-        // Row-only delete: the user-facing deleteSleepSession writes a #33 dismissal tombstone, which
-        // would overlap the SURVIVING night's window and permanently suppress its re-detection.
-        for (stale in healDropped) repo.deleteSleepSessionRowOnly(stale)
         if (healDropped.isNotEmpty()) {
             diag(
                 "Dedup(#899): removed ${healDropped.size} overlapping duplicate sleep " +
@@ -1993,4 +2007,15 @@ object IntelligenceEngine {
         return "sleep-detect day=$day NO-NIGHT hr=$hrCount rr=$rrCount resp=$respCount " +
             "grav=$gravCount steps=$stepCount provided=$providedCount window=${windowHours}h"
     }
+
+    /**
+     * #1248: the device ids the banked-sleep heal (#899) must sweep — the computed-scores id AND every
+     * registered device id. A live source (an Oura ring) banks its OWN hypnogram under its OWN device id,
+     * so a computedId-only heal never sees (or collapses) those rows, and they are re-read as
+     * `providedSleep` and re-detected every pass — one night ballooned to 14 stored rows / 9 phantom
+     * "naps". The de-duplicated union, sorted for a deterministic sweep order. Pure so it's unit-tested
+     * directly; byte-identical to the Swift `healDeviceIds`.
+     */
+    internal fun healDeviceIds(computedId: String, registeredIds: List<String>): List<String> =
+        (listOf(computedId) + registeredIds).toSortedSet().toList()
 }

--- a/android/app/src/test/java/com/noop/analytics/IntelligenceHealDeviceScopeTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/IntelligenceHealDeviceScopeTest.kt
@@ -1,0 +1,39 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the banked-sleep heal's device SCOPE (#1248). The `#899` overlap heal used to read/dedupe/delete
+ * only under `computedId`, so a live source that banks its OWN hypnogram under its OWN device id (an Oura
+ * ring) was never healed — and those un-collapsed rows were re-read as `providedSleep` and re-detected
+ * every pass, ballooning one night to 14 stored rows / 9 phantom "naps". `healDeviceIds` is the pure set
+ * of ids the heal now sweeps; tested directly. Mirrors the Swift `IntelligenceHealDeviceScopeTests` so the
+ * two platforms heal the same device ids.
+ */
+class IntelligenceHealDeviceScopeTest {
+
+    @Test
+    fun ringIdIsInScope_theBug() {
+        // The exact #1248 shape: a WHOOP is primary (computed under "my-whoop-noop") and an Oura ring
+        // banks its own hypnogram under "oura-2H3B". The ring id MUST be swept.
+        val ids = IntelligenceEngine.healDeviceIds("my-whoop-noop", listOf("my-whoop", "oura-2H3B"))
+        assertEquals(listOf("my-whoop", "my-whoop-noop", "oura-2H3B"), ids)
+        assertTrue("the ring id the computedId-only heal missed", ids.contains("oura-2H3B"))
+    }
+
+    @Test
+    fun computedIdAlwaysPresent_evenWithNoRegisteredDevices() {
+        // A BLE-only install with an empty registry still heals its computed rows (the prior behaviour).
+        assertEquals(listOf("my-whoop-noop"), IntelligenceEngine.healDeviceIds("my-whoop-noop", emptyList()))
+    }
+
+    @Test
+    fun deDuplicatesAndSortsDeterministically() {
+        // computedId can also appear in the registry list; the union de-dups and sorts so the sweep order
+        // is stable across runs and matches Swift's Set(...).sorted().
+        val ids = IntelligenceEngine.healDeviceIds("b-noop", listOf("oura-1", "b-noop", "a-whoop"))
+        assertEquals(listOf("a-whoop", "b-noop", "oura-1"), ids)
+    }
+}


### PR DESCRIPTION
## The bug (#1248)
The `#899` overlap heal in `analyzeRecent` reads/dedupes/deletes banked sleep sessions **only under `computedId`** (`IntelligenceEngine.swift` / `.kt`). But a live source — an Oura ring — banks its **own** hypnogram under its **own** device id. So those rows were never collapsed, and because the ring's hypnogram is re-read as `providedSleep` and re-detected on every pass, one night ballooned to **14 stored rows / 5 distinct hypnograms**, rendering **9 overlapping "naps"** (`NAP(S) 43h52m`, `matched=9`). Verified against `main`.

## The fix
Sweep the heal over the de-duplicated union of `computedId` **+ every registered device id**, deduping each device's rows **among themselves** and deleting stale copies under **that same id**:
- **never cross-device** — a survivor is never orphaned under an id the day-owner read skips (Kotlin deletes under the row's own `deviceId`, Swift under the explicit heal id);
- reuses the existing, already-tested `SleepSessionDedup` collapse rule verbatim;
- healing the ring id breaks the re-detect loop (next pass reads one `providedSleep`, detects one), and the existing `#899-A` re-arm reconciles in one forced re-pass.

## Safety
- **No data-loss:** the dedup keeps ≥1 survivor per overlap cluster, `userEdited` rows are exempt, and it's window-bounded to the days this pass rescored. Safe by the dedup's own documented invariant — *two real sleeps never overlap*.
- **Blast radius (called out):** the heal now also collapses overlapping duplicates under **raw/import** device ids (previously only computed). That's an improvement under the same overlap rule, not a new risk.
- **Perf:** N small `sleepSession` reads instead of one (N = device count, typically 1–3).

## Tests
Pure `healDeviceIds` scope formatter, **byte-identical Swift + Kotlin**, with a matched test each side pinning that the **ring id is now in scope** (the exact regression) + dedup/sort determinism. Android test run locally: green; Swift validated via the app-build gate. The collapse itself is already covered by `SleepSessionDedupTest`. (Full `analyzeRecent` can't be constructed in a unit context on either platform — the existing heal tests model the logic — so the scope helper is the testable crux.)

## Scope
**Independent of #1246** (the `0xFF`-padding decode) per the reporter — the wake block is byte-identical across all copies, so decode and dedup don't interact. Oura is experimental-gated, but the defect lives in `main`'s shared engine.