### PR TITLE
fix(oura): decode unwritten 0xFF hypnogram pages as a gap, not awake (#1246)

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -476,6 +476,18 @@ public enum OuraDecoders {
         let b = rec.payload
         // body[0] is the header (spec offset 6); phase codes begin at body[1].
         guard b.count >= 2 else { return nil }
+        // #1246: a whole record of `0xFF` is an UNWRITTEN (erased-flash) hypnogram page, not sleep — the
+        // ring serves pages of it for a stretch it never classified (confirmed on-device: SpO2/R-R go dark
+        // in the SAME window). The 2-bit unpack would read each `0xFF` as `11 11 11 11` = four `awake`,
+        // manufacturing hours of fake wake (one night: 320 of 334 "awake" min were padding → 36 %
+        // efficiency). Detect it at the RECORD level (unambiguous; a byte-level filter would eat the four
+        // genuine `awake` epochs that also encode as `0xFF`) and flag the epochs `unwritten` so the
+        // assembler drops them as a GAP while they still hold their place in the time axis.
+        // Require ≥2 code bytes so a LONE 0xFF byte — four genuine `awake` epochs, which also encode as
+        // 0xFF (the reporter's explicit caution) — is never mistaken for an erased page. Observed erased
+        // pages are whole ~13-byte records; a single byte is real wake.
+        let codeBytes = b.dropFirst()
+        let unwritten = codeBytes.count >= 2 && codeBytes.allSatisfy { $0 == 0xFF }
         var out: [OuraSleepPhase] = []
         var index = 0
         for k in 1..<b.count {
@@ -484,7 +496,8 @@ public enum OuraDecoders {
             for shift in stride(from: 6, through: 0, by: -2) {
                 let code = Int((byte >> UInt8(shift)) & 0x03)
                 if let stage = OuraSleepStage(rawValue: code) {
-                    out.append(OuraSleepPhase(ringTimestamp: rec.ringTimestamp, index: index, stage: stage))
+                    out.append(OuraSleepPhase(ringTimestamp: rec.ringTimestamp, index: index,
+                                              stage: stage, unwritten: unwritten))
                     index += 1
                 }
             }

--- a/Packages/OuraProtocol/Sources/OuraProtocol/HypnogramAssembler.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/HypnogramAssembler.swift
@@ -66,9 +66,15 @@ public struct OuraHypnogramBurst: Equatable, Sendable {
                 j += 1
             }
         }
-        guard let start = sleepStartUnixSeconds else { return out }
-        let clipped = out.filter { $0.ts >= start }
-        return clipped.isEmpty ? out : clipped
+        // #1246: drop UNWRITTEN epochs (whole-record `0xFF` erased pages) from the reconstructed hypnogram
+        // — they are a GAP, not `awake`. Done AFTER the lay so `n`/`j` (and thus every WRITTEN code's ts)
+        // are computed over the full sequence: an unwritten run anywhere — head, middle, or tail — leaves
+        // the real codes around it correctly timed. An all-unwritten burst yields [] (an honest no-stage
+        // night), which the caller drops rather than persisting a blank session.
+        let written = out.filter { !$0.phase.unwritten }
+        guard let start = sleepStartUnixSeconds else { return written }
+        let clipped = written.filter { $0.ts >= start }
+        return clipped.isEmpty ? written : clipped
     }
 }
 

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
@@ -159,8 +159,15 @@ public struct OuraSleepPhase: Equatable, Sendable, Codable {
     public let ringTimestamp: UInt32
     public let index: Int          // position within the record's phase sequence
     public let stage: OuraSleepStage
-    public init(ringTimestamp: UInt32, index: Int, stage: OuraSleepStage) {
+    /// #1246: this epoch came from an UNWRITTEN hypnogram page (a whole record of the erased-flash value
+    /// `0xFF`, which the 2-bit decode would otherwise read as four `awake` codes). It keeps a placeholder
+    /// `stage` so it still OCCUPIES its 30 s slot in the burst's time axis (dropping it would mis-time the
+    /// real codes laid around it), but the assembler EXCLUDES it from the reconstructed hypnogram — a gap,
+    /// not `awake`. Defaults false so every real decoded/constructed phase is a written epoch.
+    public let unwritten: Bool
+    public init(ringTimestamp: UInt32, index: Int, stage: OuraSleepStage, unwritten: Bool = false) {
         self.ringTimestamp = ringTimestamp; self.index = index; self.stage = stage
+        self.unwritten = unwritten
     }
 }
 

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
@@ -216,6 +216,38 @@ final class DecoderGoldenTests: XCTestCase {
         ])
     }
 
+    func testSleepPhase0x4EWholeFFRecordIsUnwritten() {
+        // #1246: two code bytes of 0xFF (an erased/unwritten flash page). The 2-bit unpack still reads
+        // four awake each, but because the WHOLE record's code bytes are 0xFF the epochs are flagged
+        // `unwritten` — the assembler drops them as a GAP instead of manufacturing 8 awake epochs.
+        let rec = record("4e070200010000ffff")   // len 07 = rt(4) + payload(00 ff ff): header + two 0xFF bytes
+        let phases = OuraDecoders.decodeSleepPhase(rec)
+        XCTAssertEqual(phases?.count, 8)
+        XCTAssertEqual(phases?.allSatisfy { $0.unwritten && $0.stage == .awake }, true)
+    }
+
+    func testSleepPhase0x4ELoneFFByteIsGenuineAwake() {
+        // #1246 caution: a SINGLE 0xFF code byte is four genuine `awake` epochs, NOT an erased page — it
+        // must stay written (only a run of >=2 all-0xFF code bytes reads as unwritten).
+        let rec = record("4e060200010000ff")   // header + one 0xFF code byte
+        let phases = OuraDecoders.decodeSleepPhase(rec)
+        XCTAssertEqual(phases?.count, 4)
+        XCTAssertEqual(phases?.contains { $0.unwritten }, false)
+        XCTAssertEqual(phases?.allSatisfy { $0.stage == .awake }, true)
+    }
+
+    func testSleepPhase0x4EMixedFFIsWritten() {
+        // A record that is NOT entirely 0xFF (real codes 0x6C + one 0xFF byte) is genuine data — its 0xFF
+        // byte is four REAL awake epochs, so NONE of the record is flagged unwritten. Guards against a
+        // byte-level filter eating genuine wake.
+        let rec = record("4e0702000100006cff")
+        let phases = OuraDecoders.decodeSleepPhase(rec)
+        XCTAssertEqual(phases?.count, 8)
+        XCTAssertEqual(phases?.contains { $0.unwritten }, false)
+        // The trailing 0xFF byte still decodes to four awake epochs (real wake, kept).
+        XCTAssertEqual(phases?.suffix(4).allSatisfy { $0.stage == .awake }, true)
+    }
+
     // MARK: - 0x6B motion period (2-bit MOTION_STATE codes; 2 header bytes skipped)
 
     func testMotionPeriod0x6B() {

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/HypnogramAssemblerTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/HypnogramAssemblerTests.swift
@@ -23,6 +23,37 @@ final class HypnogramAssemblerTests: XCTestCase {
         XCTAssertEqual(laid.last!.ts + 30, 10_000)
     }
 
+    // MARK: - #1246 unwritten (0xFF) epochs excluded, real codes stay timed
+
+    func testUnwrittenEpochsDroppedButRealCodesKeepFullSequenceTimes_middleGap() {
+        // A burst with an UNWRITTEN run in the MIDDLE. codesWithTimes lays times over the FULL count (so
+        // the real codes keep their true positions), then drops the unwritten as a gap — it must NOT pull
+        // the pre-gap codes toward the post-gap ones (which a drop-before-lay would).
+        let real1 = phases([.deep, .light, .rem, .awake], rt: 1000)
+        let gap = (0..<4).map { OuraSleepPhase(ringTimestamp: 1001, index: $0, stage: .awake, unwritten: true) }
+        let real2 = phases([.light, .deep, .rem, .light], rt: 1002)
+        let burst = OuraHypnogramBurst(records: [
+            OuraHypnogramRecord(ringTimestamp: 1000, phases: real1),
+            OuraHypnogramRecord(ringTimestamp: 1001, phases: gap),
+            OuraHypnogramRecord(ringTimestamp: 1002, phases: real2),
+        ])
+        let laid = burst.codesWithTimes(endUnixSeconds: 10_000)   // n=12, 30 s/code
+        XCTAssertEqual(laid.count, 8)                              // 4 unwritten dropped
+        XCTAssertTrue(laid.allSatisfy { !$0.phase.unwritten })
+        // real1 keeps its EARLY slots (j 0..3 of 12); real2 keeps its LATE slots (j 8..11) — a 120 s gap
+        // sits where the unwritten run was, instead of real1 sliding later to meet real2.
+        XCTAssertEqual(laid.prefix(4).map { $0.ts }, [9_640, 9_670, 9_700, 9_730])
+        XCTAssertEqual(laid.suffix(4).map { $0.ts }, [9_880, 9_910, 9_940, 9_970])
+    }
+
+    func testAllUnwrittenBurstReconstructsEmpty() {
+        // Every page erased → no stageable sleep. Returns [] so the caller drops it (no blank/awake night).
+        let gap = (0..<4).map { OuraSleepPhase(ringTimestamp: 1000, index: $0, stage: .awake, unwritten: true) }
+        let burst = OuraHypnogramBurst(records: [OuraHypnogramRecord(ringTimestamp: 1000, phases: gap)])
+        XCTAssertTrue(burst.codesWithTimes(endUnixSeconds: 10_000).isEmpty)
+        XCTAssertTrue(burst.codesWithTimes(endUnixSeconds: 10_000, sleepStartUnixSeconds: 9_000).isEmpty)
+    }
+
     // MARK: - 0x49 onset start-clamp (clips leading pre-window codes)
 
     private func fourCodeBurst() -> OuraHypnogramBurst {

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -632,8 +632,16 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         // Reconstruct the time axis; `sleepStart` (the 0x49 onset, or nil) clips leading pre-window codes
         // in the PURE assembler (never emptying the night). Testable there; the app just logs the trim.
         let laid = burst.codesWithTimes(endUnixSeconds: end, sleepStartUnixSeconds: sleepStart)
+        // #1246: an all-unwritten burst (every hypnogram page erased) reconstructs to nothing. Note the
+        // resume cursor so the ring stops re-serving it, but persist no blank/awake session.
+        guard !laid.isEmpty else {
+            log("Oura: hypnogram burst entirely unwritten (0xFF) - \(burst.totalCodes) code(s), no stageable sleep; skipped")
+            noteStoredHistoryRingTime(burst.lastRingTimestamp)
+            return
+        }
         if laid.count < burst.totalCodes {
-            log("Oura: hypnogram start clamped to 0x49 onset - dropped \(burst.totalCodes - laid.count) pre-window code(s)")
+            // Fewer laid than decoded = unwritten (#1246, 0xFF pages) and/or pre-0x49-onset epochs trimmed.
+            log("Oura: hypnogram trimmed \(burst.totalCodes - laid.count) code(s) - unwritten (0xFF) and/or pre-onset")
         }
         for code in laid {
             enqueue([.sleepPhase(code.phase)], ts: code.ts)

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -706,8 +706,16 @@ class OuraLiveSource(
         // Reconstruct the time axis; `sleepStart` (the 0x49 onset, or null) clips leading pre-window codes
         // in the PURE assembler (never emptying the night). Testable there; the app just logs the trim.
         val laid = burst.codesWithTimes(endUnixSeconds = end, sleepStartUnixSeconds = sleepStart)
+        // #1246: an all-unwritten burst (every hypnogram page erased) reconstructs to nothing. Note the
+        // resume cursor so the ring stops re-serving it, but persist no blank/awake session.
+        if (laid.isEmpty()) {
+            log("Oura: hypnogram burst entirely unwritten (0xFF) - ${burst.totalCodes} code(s), no stageable sleep; skipped")
+            drain.noteStoredRingTime(burst.lastRingTimestamp, resumeCursorAtFetchStart)
+            return
+        }
         if (laid.size < burst.totalCodes) {
-            log("Oura: hypnogram start clamped to 0x49 onset - dropped ${burst.totalCodes - laid.size} pre-window code(s)")
+            // Fewer laid than decoded = unwritten (#1246, 0xFF pages) and/or pre-0x49-onset epochs trimmed.
+            log("Oura: hypnogram trimmed ${burst.totalCodes - laid.size} code(s) - unwritten (0xFF) and/or pre-onset")
         }
         for (code in laid) enqueue(listOf(OuraEvent.SleepPhaseEvent(code.phase)), code.ts.toInt())
         drain.noteStoredRingTime(burst.lastRingTimestamp, resumeCursorAtFetchStart)

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -543,6 +543,17 @@ object OuraDecoders {
         val b = rec.payload
         // body[0] is the header (spec offset 6); phase codes begin at body[1].
         if (b.size < 2) return null
+        // #1246: a whole record of 0xFF is an UNWRITTEN (erased-flash) hypnogram page, not sleep — the ring
+        // serves pages of it for a stretch it never classified (confirmed on-device: SpO2/R-R go dark in the
+        // SAME window). The 2-bit unpack would read each 0xFF as `11 11 11 11` = four AWAKE, manufacturing
+        // hours of fake wake (one night: 320 of 334 "awake" min were padding → 36 % efficiency). Detect it
+        // at the RECORD level (unambiguous; a byte-level filter would eat the four genuine AWAKE epochs that
+        // also encode as 0xFF) and flag the epochs unwritten so the assembler drops them as a GAP while they
+        // still hold their place in the time axis. Byte-parity twin of the Swift decodeSleepPhase.
+        // Require >=2 code bytes so a LONE 0xFF byte — four genuine AWAKE epochs, which also encode as 0xFF
+        // (the reporter's explicit caution) — is never mistaken for an erased page. Observed erased pages
+        // are whole ~13-byte records; a single byte is real wake.
+        val unwritten = (b.size - 1) >= 2 && (1 until b.size).all { (b[it].toInt() and 0xFF) == 0xFF }
         val out = ArrayList<OuraSleepPhase>()
         var index = 0
         for (k in 1 until b.size) {
@@ -553,7 +564,12 @@ object OuraDecoders {
                 val code = (byte shr shift) and 0x03
                 val stage = OuraSleepStage.fromRaw(code)
                 if (stage != null) {
-                    out.add(OuraSleepPhase(ringTimestamp = rec.ringTimestamp, index = index, stage = stage))
+                    out.add(
+                        OuraSleepPhase(
+                            ringTimestamp = rec.ringTimestamp, index = index,
+                            stage = stage, unwritten = unwritten,
+                        ),
+                    )
                     index += 1
                 }
                 shift -= 2

--- a/android/app/src/main/java/com/noop/oura/HypnogramAssembler.kt
+++ b/android/app/src/main/java/com/noop/oura/HypnogramAssembler.kt
@@ -73,9 +73,15 @@ data class OuraHypnogramBurst(val records: List<OuraHypnogramRecord>) {
                 j += 1
             }
         }
-        if (sleepStartUnixSeconds == null) return out
-        val clipped = out.filter { it.ts >= sleepStartUnixSeconds }
-        return if (clipped.isEmpty()) out else clipped
+        // #1246: drop UNWRITTEN epochs (whole-record 0xFF erased pages) from the reconstructed hypnogram —
+        // they are a GAP, not AWAKE. Done AFTER the lay so n/j (and thus every WRITTEN code's ts) are
+        // computed over the full sequence: an unwritten run anywhere — head, middle, or tail — leaves the
+        // real codes around it correctly timed. An all-unwritten burst yields [] (an honest no-stage night),
+        // which the caller drops rather than persisting a blank session. Byte-parity twin of Swift.
+        val written = out.filter { !it.phase.unwritten }
+        if (sleepStartUnixSeconds == null) return written
+        val clipped = written.filter { it.ts >= sleepStartUnixSeconds }
+        return if (clipped.isEmpty()) written else clipped
     }
 }
 

--- a/android/app/src/main/java/com/noop/oura/OuraEvents.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraEvents.kt
@@ -159,8 +159,21 @@ enum class OuraSleepStage(val raw: Int) {
     }
 }
 
-/** One decoded sleep-phase code in order within a 0x4E/0x5A record (OURA_PROTOCOL.md s6.12). */
-data class OuraSleepPhase(val ringTimestamp: Long, val index: Int, val stage: OuraSleepStage)
+/**
+ * One decoded sleep-phase code in order within a 0x4E/0x5A record (OURA_PROTOCOL.md s6.12). [unwritten]
+ * (#1246) marks an epoch from an UNWRITTEN hypnogram page (a whole record of the erased-flash value 0xFF,
+ * which the 2-bit decode would otherwise read as four AWAKE codes). It keeps a placeholder [stage] so it
+ * still OCCUPIES its 30 s
+ * slot in the burst time axis (dropping it would mis-time the real codes around it), but the assembler
+ * EXCLUDES it from the reconstructed hypnogram — a gap, not AWAKE. Defaults false = a written epoch.
+ * Byte-parity twin of the Swift OuraSleepPhase.
+ */
+data class OuraSleepPhase(
+    val ringTimestamp: Long,
+    val index: Int,
+    val stage: OuraSleepStage,
+    val unwritten: Boolean = false,
+)
 
 /** Motion state (OURA_PROTOCOL.md s6.13): 0 NO_MOTION, 1 RESTLESS, 2 TOSSING, 3 ACTIVE. */
 enum class OuraMotionState(val raw: Int) {

--- a/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
+++ b/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
@@ -253,6 +253,38 @@ class DecoderGoldenTest {
     }
 
     @Test
+    fun testSleepPhase0x4EWholeFFRecordIsUnwritten() {
+        // #1246: two 0xFF code bytes (an erased/unwritten flash page). Flagged unwritten so the assembler
+        // drops them as a GAP instead of 8 awake epochs. PARITY twin of the Swift test.
+        val rec = record("4e070200010000ffff")
+        val phases = OuraDecoders.decodeSleepPhase(rec)
+        assertEquals(8, phases?.size)
+        assertTrue(phases!!.all { it.unwritten && it.stage == OuraSleepStage.AWAKE })
+    }
+
+    @Test
+    fun testSleepPhase0x4ELoneFFByteIsGenuineAwake() {
+        // #1246 caution: a SINGLE 0xFF code byte is four genuine AWAKE epochs, NOT an erased page — it must
+        // stay written (only a run of >=2 all-0xFF code bytes reads as unwritten). PARITY twin of Swift.
+        val rec = record("4e060200010000ff")
+        val phases = OuraDecoders.decodeSleepPhase(rec)
+        assertEquals(4, phases?.size)
+        assertTrue(phases!!.none { it.unwritten })
+        assertTrue(phases.all { it.stage == OuraSleepStage.AWAKE })
+    }
+
+    @Test
+    fun testSleepPhase0x4EMixedFFIsWritten() {
+        // A record that is NOT entirely 0xFF is genuine data — its 0xFF byte is four REAL awake epochs, so
+        // none of the record is flagged unwritten. Guards against a byte-level filter eating genuine wake.
+        val rec = record("4e0702000100006cff")
+        val phases = OuraDecoders.decodeSleepPhase(rec)
+        assertEquals(8, phases?.size)
+        assertTrue(phases!!.none { it.unwritten })
+        assertTrue(phases.takeLast(4).all { it.stage == OuraSleepStage.AWAKE })
+    }
+
+    @Test
     fun testSleepStageRawValuesMatchOpenOura() {
         // Pin the validated open_oura order (0=deep, 1=light, 2=rem, 3=awake) so a regression to the
         // old unverified mapping (0=awake/2=deep/3=REM) breaks loudly. Twin of the Swift enum.

--- a/android/app/src/test/java/com/noop/oura/HypnogramAssemblerTest.kt
+++ b/android/app/src/test/java/com/noop/oura/HypnogramAssemblerTest.kt
@@ -33,6 +33,39 @@ class HypnogramAssemblerTest {
         assertEquals(10_000L, laid.last().ts + 30)
     }
 
+    // MARK: - #1246 unwritten (0xFF) epochs excluded, real codes stay timed. Twin of Swift.
+
+    @Test
+    fun unwrittenEpochsDroppedButRealCodesKeepFullSequenceTimes_middleGap() {
+        // A burst with an UNWRITTEN run in the MIDDLE. codesWithTimes lays times over the FULL count (so
+        // the real codes keep their true positions), then drops the unwritten as a gap — it must NOT pull
+        // the pre-gap codes toward the post-gap ones (which a drop-before-lay would).
+        val real1 = phases(listOf(OuraSleepStage.DEEP, OuraSleepStage.LIGHT, OuraSleepStage.REM, OuraSleepStage.AWAKE), rt = 1000)
+        val gap = (0 until 4).map { OuraSleepPhase(ringTimestamp = 1001, index = it, stage = OuraSleepStage.AWAKE, unwritten = true) }
+        val real2 = phases(listOf(OuraSleepStage.LIGHT, OuraSleepStage.DEEP, OuraSleepStage.REM, OuraSleepStage.LIGHT), rt = 1002)
+        val burst = OuraHypnogramBurst(
+            listOf(
+                OuraHypnogramRecord(1000, real1),
+                OuraHypnogramRecord(1001, gap),
+                OuraHypnogramRecord(1002, real2),
+            ),
+        )
+        val laid = burst.codesWithTimes(endUnixSeconds = 10_000)   // n=12, 30 s/code
+        assertEquals(8, laid.size)                                 // 4 unwritten dropped
+        assertTrue(laid.none { it.phase.unwritten })
+        assertEquals(listOf(9_640L, 9_670L, 9_700L, 9_730L), laid.take(4).map { it.ts })
+        assertEquals(listOf(9_880L, 9_910L, 9_940L, 9_970L), laid.takeLast(4).map { it.ts })
+    }
+
+    @Test
+    fun allUnwrittenBurstReconstructsEmpty() {
+        // Every page erased → no stageable sleep. Returns [] so the caller drops it (no blank/awake night).
+        val gap = (0 until 4).map { OuraSleepPhase(ringTimestamp = 1000, index = it, stage = OuraSleepStage.AWAKE, unwritten = true) }
+        val burst = OuraHypnogramBurst(listOf(OuraHypnogramRecord(1000, gap)))
+        assertTrue(burst.codesWithTimes(endUnixSeconds = 10_000).isEmpty())
+        assertTrue(burst.codesWithTimes(endUnixSeconds = 10_000, sleepStartUnixSeconds = 9_000).isEmpty())
+    }
+
     // MARK: - 0x49 onset start-clamp (clips leading pre-window codes). Twin of Swift's clamp tests.
 
     private fun fourCodeBurst(): OuraHypnogramBurst {


### PR DESCRIPTION
## The bug (#1246)
`decodeSleepPhase` unpacks four 2-bit codes from every hypnogram body byte with **no notion of an unwritten epoch**. `0xFF` — the canonical erased-flash value the ring serves for a stretch it never classified — is `11 11 11 11` = **four `awake` codes**. So whole erased pages decode as sleep-awake: on the reported night **320 of 334 "awake" minutes were padding**, rendering **36% efficiency** where the ring's own `0x49` sleep window (and WHOOP) agreed on ~9% wake. Confirmed on-device — SpO2/R-R go dark in the *same* window, so those pages really were never written.

## The fix
- **Detect at the record level** (`Decoders`): a whole record of **≥2 all-`0xFF`** code bytes is an unwritten page → flag its epochs `unwritten`. A **lone `0xFF` byte is four genuine `awake` epochs** and stays written (the reporter's explicit caution — no byte-level filtering).
- **Exclude after laying the time axis** (`HypnogramAssembler.codesWithTimes`): unwritten epochs keep a placeholder stage so they still hold their 30 s slot while `n`/`j` (and thus every real code's `ts`) are computed over the full sequence, then they're dropped. An unwritten run **anywhere — head, middle, or tail — leaves the real codes around it correctly timed**; a blackout reads as an honest **gap**, not fake wake.
- **All-unwritten burst → empty** → the live source drops it (no blank/awake session) but still advances the resume cursor so the ring stops re-serving it.

## Safety / contract
- `OuraSleepPhase.unwritten` is **transient** (decode → assemble → excluded); it is never persisted, so **no stored-contract change**.
- Byte-identical **Swift + Kotlin** across the pure `OuraProtocol` decode + assembler and both live sources.

## Tests
Decode + assembler tests each side, incl. the **middle-gap time-preservation** case (proves exclude-after-lay, not drop-before-lay) and the **lone-`0xFF`-byte guard**. Pure `OuraProtocol` (default CI); Swift package tests run locally green, Kotlin unit tests run locally green. App-target live-source guard validated via the app-build gate.

## Scope (honest)
Fixes **whole-record** erased pages — the dominant contributor. Deliberately deferred as the reporter's flagged design questions (they change more contract / need tuning):
- trimming `0xFF` **edge-runs within a mixed record** (needs the run-length `N`);
- a **night-level** ">X% unknown → prefer `0x49` totals / mark unstageable" policy;
- a **re-decode heal for already-banked nights** (`stage.rawValue` persists, so this repairs *new* offloads only).

**Independent of #1248** (the dedup-scope fix) per the reporter — the wake block is byte-identical across all stored copies, so decode and dedup don't interact. Oura is experimental-gated, but the defect lives in `main`'s shared decoder.
