### PR TITLE
feat(today): group the Customise 'Available' cards by origin (Sleep/Trends)

### DIFF
--- a/Strand/Screens/EditableLayoutList.swift
+++ b/Strand/Screens/EditableLayoutList.swift
@@ -19,6 +19,12 @@ where Item: Identifiable & Equatable, Options: View {
     /// last, so surfaces that need ≥1 item (Today sections, Key Metrics, Your Cards) can't be emptied. The
     /// hosted-cards page (#today-hosted-cards) is opt-in, so it passes `true` to allow un-hosting the last.
     var allowEmpty: Bool = false
+    /// Optional grouping key for the Hidden ("Available") list. When set (the hosted-cards page passes the
+    /// card's origin, e.g. "Sleep" / "Trends"), the Available items are split into one titled Section per
+    /// group so a user browses by origin instead of one flat list. nil (Today sections, Key Metrics, Your
+    /// Cards) keeps the single flat Available section. The Shown list stays flat — it is the user's own
+    /// cross-origin order.
+    var group: ((Item) -> String)? = nil
     @ViewBuilder let options: () -> Options
 
     var body: some View {
@@ -49,32 +55,47 @@ where Item: Identifiable & Equatable, Options: View {
                     .foregroundStyle(StrandPalette.textTertiary)
             }
 
-            Section {
-                if draft.hidden.isEmpty {
+            if draft.hidden.isEmpty {
+                Section {
                     Text("Nothing hidden")
                         .foregroundStyle(StrandPalette.textTertiary)
-                } else {
-                    ForEach(draft.hidden) { item in
-                        EditableLayoutRow(
-                            title: title(item),
-                            subtitle: subtitle(item),
-                            icon: icon(item),
-                            tint: tint(item),
-                            configurationLabel: configurationLabel(item),
-                            isVisible: false,
-                            canHide: true,
-                            onConfigure: { onConfigure(item) },
-                            onVisibilityChange: { show(item) }
-                        )
+                } header: {
+                    Text(hiddenTitle)
+                        .strandOverline()
+                } footer: {
+                    Text("Hidden items remain available here and can be restored at any time.")
+                        .font(StrandFont.footnote)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                }
+            } else if group != nil {
+                // Grouped Available list: one titled Section per origin (e.g. "Sleep", "Trends"), so the
+                // hidden cards read by category. The last group carries the shared restore-hint footer.
+                let groups = groupedHidden
+                ForEach(groups.indices, id: \.self) { i in
+                    Section {
+                        ForEach(groups[i].items) { item in hiddenRow(item) }
+                    } header: {
+                        Text(groups[i].name)
+                            .strandOverline()
+                    } footer: {
+                        if i == groups.count - 1 {
+                            Text("Hidden items remain available here and can be restored at any time.")
+                                .font(StrandFont.footnote)
+                                .foregroundStyle(StrandPalette.textTertiary)
+                        }
                     }
                 }
-            } header: {
-                Text(hiddenTitle)
-                    .strandOverline()
-            } footer: {
-                Text("Hidden items remain available here and can be restored at any time.")
-                    .font(StrandFont.footnote)
-                    .foregroundStyle(StrandPalette.textTertiary)
+            } else {
+                Section {
+                    ForEach(draft.hidden) { item in hiddenRow(item) }
+                } header: {
+                    Text(hiddenTitle)
+                        .strandOverline()
+                } footer: {
+                    Text("Hidden items remain available here and can be restored at any time.")
+                        .font(StrandFont.footnote)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                }
             }
 
             Section {
@@ -94,6 +115,36 @@ where Item: Identifiable & Equatable, Options: View {
         #if os(iOS)
         .environment(\.editMode, .constant(.active))
         #endif
+    }
+
+    /// One Available (hidden) row — the show affordance. Shared by the flat and grouped Available lists.
+    @ViewBuilder
+    private func hiddenRow(_ item: Item) -> some View {
+        EditableLayoutRow(
+            title: title(item),
+            subtitle: subtitle(item),
+            icon: icon(item),
+            tint: tint(item),
+            configurationLabel: configurationLabel(item),
+            isVisible: false,
+            canHide: true,
+            onConfigure: { onConfigure(item) },
+            onVisibilityChange: { show(item) }
+        )
+    }
+
+    /// The hidden items bucketed by `group`, groups in first-appearance order (which follows the draft's
+    /// canonical order). Only read when `group != nil`.
+    private var groupedHidden: [(name: String, items: [Item])] {
+        guard let group else { return [] }
+        var order: [String] = []
+        var buckets: [String: [Item]] = [:]
+        for item in draft.hidden {
+            let key = group(item)
+            if buckets[key] == nil { order.append(key) }
+            buckets[key, default: []].append(item)
+        }
+        return order.map { (name: $0, items: buckets[$0] ?? []) }
     }
 
     private func moveVisible(from offsets: IndexSet, to destination: Int) {

--- a/Strand/Screens/TodayCustomizationSheet.swift
+++ b/Strand/Screens/TodayCustomizationSheet.swift
@@ -396,7 +396,8 @@ private struct HostedCardsCustomizationPage: View {
             configurationLabel: { _ in nil },
             onConfigure: { _ in },
             onReset: onReset,
-            allowEmpty: true   // hosting is opt-in: the last card can be un-hosted (Shown may be empty)
+            allowEmpty: true,   // hosting is opt-in: the last card can be un-hosted (Shown may be empty)
+            group: { $0.origin }   // group the Available list by origin tab ("Sleep", "Trends")
         ) {
             EmptyView()
         }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3538,6 +3538,11 @@ internal fun <T> EditableVisibilityRows(
     // surfaces needing >=1 item can't be emptied. The hosted-cards editor (#today-hosted-cards) passes
     // true (opt-in: un-hosting the last card is valid).
     allowEmpty: Boolean = false,
+    // Optional grouping key for the Hidden ("Available") list. When set (the hosted-cards editor passes the
+    // card's origin, e.g. "Sleep" / "Trends"), the Available items render under one sub-header per group so
+    // a user browses by origin. null (Today sections, Key Metrics, Your Cards) keeps the flat list. The
+    // Shown list stays flat — it is the user's own cross-origin order. Twin of the Swift EditableLayoutList.
+    hiddenGroup: ((T) -> String)? = null,
 ) {
     val minShown = if (allowEmpty) 0 else 1
     Column(
@@ -3610,6 +3615,43 @@ internal fun <T> EditableVisibilityRows(
                 color = Palette.textTertiary,
                 modifier = Modifier.padding(vertical = Metrics.space12),
             )
+        } else if (hiddenGroup != null) {
+            // Grouped Available list: one sub-header per origin ("Sleep", "Trends"). Remove by identity
+            // (items are unique) so the move is index-free across the regrouped display.
+            val buckets = LinkedHashMap<String, MutableList<T>>()
+            hidden.forEach { item -> buckets.getOrPut(hiddenGroup(item)) { ArrayList() }.add(item) }
+            buckets.keys.toList().forEachIndexed { gi, groupName ->
+                Text(
+                    groupName,
+                    style = NoopType.overline,
+                    color = Palette.textTertiary,
+                    modifier = Modifier.padding(top = if (gi == 0) Metrics.space4 else Metrics.space12),
+                )
+                val itemsIn = buckets.getValue(groupName)
+                itemsIn.forEachIndexed { ii, item ->
+                    val title = itemTitle(item)
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = Metrics.space6),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(title, style = NoopType.body, color = Palette.textTertiary, modifier = Modifier.weight(1f))
+                        IconButton(
+                            onClick = { hidden.remove(item); shown.add(item) },
+                            modifier = Modifier.size(Metrics.iconButton),
+                        ) {
+                            Icon(
+                                Icons.Filled.Add,
+                                contentDescription = stringResource(R.string.today_customize_show, title),
+                                tint = Palette.accent,
+                                modifier = Modifier.size(Metrics.iconSmall),
+                            )
+                        }
+                    }
+                    if (ii < itemsIn.lastIndex) {
+                        HorizontalDivider(color = Palette.hairline, thickness = Metrics.divider)
+                    }
+                }
+            }
         } else {
             hidden.forEachIndexed { index, item ->
                 val title = itemTitle(item)
@@ -3746,6 +3788,7 @@ private fun HostedCardsEditorDialog(
                     hidden = hidden,
                     itemTitle = { it.title },
                     allowEmpty = true,   // hosting is opt-in: un-hosting the last card is valid
+                    hiddenGroup = { it.origin },   // group the Available list by origin tab ("Sleep", "Trends")
                 )
 
                 Row(verticalAlignment = Alignment.CenterVertically) {


### PR DESCRIPTION
## What
The Today **Customise → Added Cards** editor listed every available (not-yet-hosted) card in one flat list. This groups the **Available** list by origin, so the sleep-tab cards sit under a **"Sleep"** header (and Trends cards under "Trends" as they're wired), matching how each card is labelled today ("from Sleep").

## How
- The shared list gains an **optional** grouping key — Swift `EditableLayoutList.group`, Kotlin `EditableVisibilityRows.hiddenGroup` — **default off**, so "Your Cards", "Key Metrics" and Today sections stay flat and unchanged. Only the hosted-cards page passes `origin`.
- The **Shown** ("Added to Today") list stays flat — it's the user's own cross-origin order.
- Byte-identical Swift + Kotlin; **display-only**, no stored value or contract change.

## Notes
This is step 1 of making the remaining sleep cards hostable on Today — it sets up where those cards land in the editor. The card wiring (Stages, Night detail, Sleep-debt ledger, Stages vs typical) follows as separate PRs.

Validated: Android compiles locally; Swift app targets via the app-build gate.