### PR TITLE
i18n(android): localize the sleep/customise card-catalog titles

### DIFF
--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -131295,6 +131295,64 @@
         }
       }
     },
+    "Stages": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phasen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fases"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stades"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fasi"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estágios"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стадии"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "阶段"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "階段"
+          }
+        }
+      }
+    },
     "Stages vs typical": {
       "localizations": {
         "de": {

--- a/android/app/src/main/java/com/noop/ui/HostedCards.kt
+++ b/android/app/src/main/java/com/noop/ui/HostedCards.kt
@@ -4,7 +4,10 @@ import android.content.Context
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Bedtime
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import com.noop.R
 import org.json.JSONArray
 
 // MARK: - Hosted cards (#today-hosted-cards)
@@ -45,6 +48,29 @@ enum class HostedCard(
         /** Canonical order used to list the not-yet-hosted remainder in the editor (matches iOS allCases). */
         val canonicalOrder: List<HostedCard> = entries.toList()
     }
+}
+
+/**
+ * The card's display title, localized. The enum's [title] field stays the English source-of-truth default
+ * (used for logging/comparisons); the UI reads this so the editor shows a translated title. Enum
+ * constructors can't call [stringResource], so resolution happens here at the render site. Mirrors iOS,
+ * where `HostedCard.title` is a `String(localized:)`.
+ */
+@Composable
+fun HostedCard.localizedTitle(): String = when (this) {
+    HostedCard.SLEEP_MARKS -> stringResource(R.string.l10n_sleep_screen_sleep_marks_8e9b86f0)
+    HostedCard.ASLEEP_DURATION -> stringResource(R.string.l10n_sleep_screen_asleep_duration_3638413f)
+}
+
+/**
+ * The origin (source tab) label, localized — the editor groups the Available list by this. Resolves off the
+ * English [origin] field so a future Trends-origin card localizes automatically; the raw [origin] stays the
+ * source of truth for non-UI uses. Reuses the nav tab names, which carry the same text in every locale.
+ */
+@Composable
+fun HostedCard.localizedOrigin(): String = when (origin) {
+    "Trends" -> stringResource(R.string.nav_trends)
+    else -> stringResource(R.string.nav_sleep)
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/SleepArrangeSheet.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepArrangeSheet.kt
@@ -61,10 +61,14 @@ fun SleepArrangeSheet(
                     )
                 }
 
+                // Resolve the localized title per section up front (the composable-only stringResource
+                // call can't run inside the plain itemTitle lambda). The enum's raw title stays the English
+                // source of truth; the sheet shows the translated text.
+                val titleFor = SleepSection.entries.associateWith { it.localizedTitle() }
                 EditableVisibilityRows(
                     shown = shown,
                     hidden = hidden,
-                    itemTitle = { it.title },
+                    itemTitle = { titleFor.getValue(it) },
                 )
 
                 Row(verticalAlignment = Alignment.CenterVertically) {

--- a/android/app/src/main/java/com/noop/ui/SleepLayoutPrefs.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepLayoutPrefs.kt
@@ -1,6 +1,9 @@
 package com.noop.ui
 
 import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.noop.R
 
 // MARK: - Reorderable Sleep sections (#sleep-layout)
 //
@@ -35,7 +38,7 @@ enum class SleepSection(val raw: String, val title: String) {
      *  so these two rawValues are Android-only — the macOS `SleepSection` stops at `asleepDuration`. Safe to
      *  diverge here: `sleep.sectionOrder` is not in the .noopbak whitelist, so a cross-OS restore never
      *  reads them. (Consistency's underlying score also differs across platforms — a separate parity item.) */
-    HOURS_VS_NEEDED("hoursVsNeeded", "Hours vs needed"),
+    HOURS_VS_NEEDED("hoursVsNeeded", "Hours vs Needed"),
     CONSISTENCY("consistency", "Consistency");
 
     companion object {
@@ -50,6 +53,24 @@ enum class SleepSection(val raw: String, val title: String) {
             HOURS_VS_NEEDED, CONSISTENCY,
         )
     }
+}
+
+/**
+ * The section's display title, localized. The enum's [title] field stays the English source-of-truth
+ * default (used for logging/comparisons); the UI reads this so the Sleep arrange sheet shows a translated
+ * title. Enum constructors can't call [stringResource], so resolution happens here at the render site.
+ * Mirrors the Apple platforms, where `SleepSection.title` is a `String(localized:)`.
+ */
+@Composable
+fun SleepSection.localizedTitle(): String = when (this) {
+    SleepSection.SLEEP_MARKS -> stringResource(R.string.l10n_sleep_screen_sleep_marks_8e9b86f0)
+    SleepSection.STAGES -> stringResource(R.string.l10n_sleep_screen_stages_c1d33ad5)
+    SleepSection.NIGHT_DETAIL -> stringResource(R.string.l10n_sleep_screen_night_detail_8f271bcf)
+    SleepSection.SLEEP_DEBT -> stringResource(R.string.l10n_sleep_screen_sleep_debt_ledger_8cc9a992)
+    SleepSection.STAGES_VS_TYPICAL -> stringResource(R.string.l10n_sleep_screen_stages_vs_typical_28463f24)
+    SleepSection.ASLEEP_DURATION -> stringResource(R.string.l10n_sleep_screen_asleep_duration_3638413f)
+    SleepSection.HOURS_VS_NEEDED -> stringResource(R.string.l10n_sleep_screen_hours_vs_needed_500a0aca)
+    SleepSection.CONSISTENCY -> stringResource(R.string.l10n_sleep_screen_consistency_0ea7b95e)
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3783,12 +3783,17 @@ private fun HostedCardsEditorDialog(
                     )
                 }
 
+                // Resolve the localized title/origin per card up front (composable-only calls can't run
+                // inside the plain itemTitle/hiddenGroup lambdas). The enum's raw title/origin stay the
+                // English source of truth; the UI shows the translated text.
+                val titleFor = HostedCard.entries.associateWith { it.localizedTitle() }
+                val originFor = HostedCard.entries.associateWith { it.localizedOrigin() }
                 EditableVisibilityRows(
                     shown = shown,
                     hidden = hidden,
-                    itemTitle = { it.title },
+                    itemTitle = { titleFor.getValue(it) },
                     allowEmpty = true,   // hosting is opt-in: un-hosting the last card is valid
-                    hiddenGroup = { it.origin },   // group the Available list by origin tab ("Sleep", "Trends")
+                    hiddenGroup = { originFor.getValue(it) },   // group the Available list by origin tab ("Sleep", "Trends")
                 )
 
                 Row(verticalAlignment = Alignment.CenterVertically) {

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -781,8 +781,10 @@
     <string name="l10n_sleep_screen_about_your_main_sleep_1da8a640">Über deinen Hauptschlaf</string>
     <string name="l10n_sleep_screen_as_of_latest_first_726f20bb">wie von %1$s</string>
     <string name="l10n_sleep_screen_asleep_b9692bbe">Schlafend</string>
+    <string name="l10n_sleep_screen_asleep_duration_3638413f">Schlafdauer</string>
     <string name="l10n_sleep_screen_asleep_last_night_b969b068">letzte Nacht geschlafen</string>
     <string name="l10n_sleep_screen_bedtime_wake_time_b2a22c32">Schlafenszeit und Wachzeit</string>
+    <string name="l10n_sleep_screen_consistency_0ea7b95e">Konsistenz</string>
     <string name="l10n_sleep_screen_consistencypct_roundtoint_b23a9d40">%1$s%%</string>
     <string name="l10n_sleep_screen_delete_this_nap_1adf0a3f">Löschen Sie dieses Nickerchen</string>
     <string name="l10n_sleep_screen_fell_asleep_at_asleep_woke_at_80465b2d">Schlafen bei %1$s, wachen bei %2$s</string>
@@ -797,6 +799,7 @@
     <string name="l10n_sleep_screen_log_waking_up_2f9c230e">Aufwachen erfassen</string>
     <string name="l10n_sleep_screen_logged_as_a_nap_wrong_tap_4285d23e">Als Nickerchen erfasst. Falsch? Tippe auf „Bearbeiten“, um Schlaf- und Aufwachzeiten anzupassen.</string>
     <string name="l10n_sleep_screen_nap_window_durationtext_durmin_bbc35167">Nap %1$s, %2$s</string>
+    <string name="l10n_sleep_screen_night_detail_8f271bcf">Nacht-Details</string>
     <string name="l10n_sleep_screen_no_movement_detail_for_this_night_a6f9736a">Kein Bewegungsdetail für diese Nacht.</string>
     <string name="l10n_sleep_screen_no_nights_here_yet_607248f5">Keine Nächte hier noch</string>
     <string name="l10n_sleep_screen_no_nights_with_sleep_data_yet_fa71b6b3">Noch keine Nächte mit Schlafdaten. Deine Bilanz füllt sich, wenn du den Strap im Bett trägst.</string>
@@ -807,6 +810,7 @@
     <string name="l10n_sleep_screen_score_roundtoint_a2d1cc99">%1$s%%</string>
     <string name="l10n_sleep_screen_sleep_consistency_nightly_bed_and_wake_14526f89">Schlafkonsistenz Nachtbett und Wake Chart</string>
     <string name="l10n_sleep_screen_sleep_debt_3aec7d9c">Schlafdefizit</string>
+    <string name="l10n_sleep_screen_sleep_debt_ledger_8cc9a992">Schlafdefizit-Bilanz</string>
     <string name="l10n_sleep_screen_sleep_debt_trend_chart_9e178776">Schlaf Schulden Trend Chart</string>
     <string name="l10n_sleep_screen_sleep_hours_trend_chart_a6fbc46d">Sleep Stunden Trend Chart</string>
     <string name="l10n_sleep_screen_sleep_marks_8e9b86f0">Schlafmarken</string>
@@ -818,6 +822,8 @@
     <string name="l10n_sleep_screen_spec_format_v_spec_unit_7a7f630c">%1$s %2$s</string>
     <string name="l10n_sleep_screen_spec_title_trend_chart_3085ac6e">%1$s Trenddiagramm</string>
     <string name="l10n_sleep_screen_stage_durationtext_minutes_percent_percent_of_477dbf14">%1$s: %2$s, %3$s Prozent der Nacht</string>
+    <string name="l10n_sleep_screen_stages_c1d33ad5">Phasen</string>
+    <string name="l10n_sleep_screen_stages_vs_typical_28463f24">Phasen vs. typisch</string>
     <string name="l10n_sleep_screen_tap_when_you_re_heading_to_1f401690">Tippe, wenn du ins Bett gehst oder aufwachst. Jeder Tipp wird mit der Zeit erfasst. Er ändert den heute Nacht erkannten Schlaf nicht.</string>
     <string name="l10n_sleep_screen_this_metric_needs_at_least_two_2de1d37a">Diese Metrik benötigt mindestens zwei Nächte Daten.</string>
     <string name="l10n_sleep_screen_undo_39fc7212">Undo</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -596,8 +596,10 @@
     <string name="l10n_sleep_screen_about_your_main_sleep_1da8a640">Acerca de tu sueño principal</string>
     <string name="l10n_sleep_screen_as_of_latest_first_726f20bb">de %1$s</string>
     <string name="l10n_sleep_screen_asleep_b9692bbe">Dormido</string>
+    <string name="l10n_sleep_screen_asleep_duration_3638413f">Duración del sueño</string>
     <string name="l10n_sleep_screen_asleep_last_night_b969b068">dormido anoche</string>
     <string name="l10n_sleep_screen_bedtime_wake_time_b2a22c32">Hora de dormir y hora de despertar</string>
+    <string name="l10n_sleep_screen_consistency_0ea7b95e">Consistencia</string>
     <string name="l10n_sleep_screen_consistencypct_roundtoint_b23a9d40">%1$s%%</string>
     <string name="l10n_sleep_screen_delete_this_nap_1adf0a3f">Eliminar esta siesta</string>
     <string name="l10n_sleep_screen_fell_asleep_at_asleep_woke_at_80465b2d">Duerme en %1$s, despertó en %2$s</string>
@@ -612,6 +614,7 @@
     <string name="l10n_sleep_screen_log_waking_up_2f9c230e">Registrar que te despiertas</string>
     <string name="l10n_sleep_screen_logged_as_a_nap_wrong_tap_4285d23e">Registrado como siesta. ¿No es correcto? Toca Editar para ajustar tus horas de sueño y despertar.</string>
     <string name="l10n_sleep_screen_nap_window_durationtext_durmin_bbc35167">Nap %1$s, %2$s</string>
+    <string name="l10n_sleep_screen_night_detail_8f271bcf">Detalle de la noche</string>
     <string name="l10n_sleep_screen_no_movement_detail_for_this_night_a6f9736a">No hay detalle de movimiento para esta noche.</string>
     <string name="l10n_sleep_screen_no_nights_here_yet_607248f5">Aún no hay noches aquí.</string>
     <string name="l10n_sleep_screen_no_nights_with_sleep_data_yet_fa71b6b3">Aún no hay noches con datos de sueño. Tu registro se irá llenando a medida que duermas con la pulsera puesta.</string>
@@ -622,6 +625,7 @@
     <string name="l10n_sleep_screen_score_roundtoint_a2d1cc99">%1$s%%</string>
     <string name="l10n_sleep_screen_sleep_consistency_nightly_bed_and_wake_14526f89">Plano de dormir con consistencia nocturna</string>
     <string name="l10n_sleep_screen_sleep_debt_3aec7d9c">Deuda de sueño</string>
+    <string name="l10n_sleep_screen_sleep_debt_ledger_8cc9a992">Registro de deuda de sueño</string>
     <string name="l10n_sleep_screen_sleep_debt_trend_chart_9e178776">Gráfico de la tendencia al sueño</string>
     <string name="l10n_sleep_screen_sleep_hours_trend_chart_a6fbc46d">Gráfico de tendencia de horas de sueño</string>
     <string name="l10n_sleep_screen_sleep_marks_8e9b86f0">Marcas de sueño</string>
@@ -633,6 +637,8 @@
     <string name="l10n_sleep_screen_spec_format_v_spec_unit_7a7f630c">%1$s %2$s</string>
     <string name="l10n_sleep_screen_spec_title_trend_chart_3085ac6e">Gráfico de tendencia %1$s</string>
     <string name="l10n_sleep_screen_stage_durationtext_minutes_percent_percent_of_477dbf14">%1$s: %2$s, %3$s por ciento de la noche</string>
+    <string name="l10n_sleep_screen_stages_c1d33ad5">Fases</string>
+    <string name="l10n_sleep_screen_stages_vs_typical_28463f24">Fases vs lo habitual</string>
     <string name="l10n_sleep_screen_tap_when_you_re_heading_to_1f401690">Toca cuando te vayas a la cama o cuando despiertes. Cada toque se registra con la hora. No cambia el sueño detectado esta noche.</string>
     <string name="l10n_sleep_screen_this_metric_needs_at_least_two_2de1d37a">Esta métrica necesita al menos dos noches de datos.</string>
     <string name="l10n_sleep_screen_undo_39fc7212">Undo</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -596,8 +596,10 @@
     <string name="l10n_sleep_screen_about_your_main_sleep_1da8a640">À propos de votre sommeil principal</string>
     <string name="l10n_sleep_screen_as_of_latest_first_726f20bb">à partir de %1$s</string>
     <string name="l10n_sleep_screen_asleep_b9692bbe">Endormi</string>
+    <string name="l10n_sleep_screen_asleep_duration_3638413f">Durée de sommeil</string>
     <string name="l10n_sleep_screen_asleep_last_night_b969b068">endormi la nuit dernière</string>
     <string name="l10n_sleep_screen_bedtime_wake_time_b2a22c32">Heure de coucher &amp; réveil</string>
+    <string name="l10n_sleep_screen_consistency_0ea7b95e">Régularité</string>
     <string name="l10n_sleep_screen_consistencypct_roundtoint_b23a9d40">%1$s%%</string>
     <string name="l10n_sleep_screen_delete_this_nap_1adf0a3f">Supprimer cette sieste</string>
     <string name="l10n_sleep_screen_fell_asleep_at_asleep_woke_at_80465b2d">Je me suis endormi à %1$s, réveillé à %2$s</string>
@@ -612,6 +614,7 @@
     <string name="l10n_sleep_screen_log_waking_up_2f9c230e">Enregistrer le réveil</string>
     <string name="l10n_sleep_screen_logged_as_a_nap_wrong_tap_4285d23e">Enregistré comme sieste. Ce n\'est pas correct ? Touchez Modifier pour ajuster vos heures de coucher et de réveil.</string>
     <string name="l10n_sleep_screen_nap_window_durationtext_durmin_bbc35167">Nap %1$s, %2$s</string>
+    <string name="l10n_sleep_screen_night_detail_8f271bcf">Détail de nuit</string>
     <string name="l10n_sleep_screen_no_movement_detail_for_this_night_a6f9736a">Pas de mouvement pour cette nuit.</string>
     <string name="l10n_sleep_screen_no_nights_here_yet_607248f5">Pas encore de nuit ici</string>
     <string name="l10n_sleep_screen_no_nights_with_sleep_data_yet_fa71b6b3">Aucune nuit avec des données de sommeil pour l\'instant. Votre registre se remplit à mesure que vous portez le bracelet pour dormir.</string>
@@ -622,6 +625,7 @@
     <string name="l10n_sleep_screen_score_roundtoint_a2d1cc99">%1$s%%</string>
     <string name="l10n_sleep_screen_sleep_consistency_nightly_bed_and_wake_14526f89">Cohérence du sommeil lit et sillage</string>
     <string name="l10n_sleep_screen_sleep_debt_3aec7d9c">Dette de sommeil</string>
+    <string name="l10n_sleep_screen_sleep_debt_ledger_8cc9a992">Registre de la dette de sommeil</string>
     <string name="l10n_sleep_screen_sleep_debt_trend_chart_9e178776">Graphique des tendances de la dette du sommeil</string>
     <string name="l10n_sleep_screen_sleep_hours_trend_chart_a6fbc46d">Tableau de tendance des heures de sommeil</string>
     <string name="l10n_sleep_screen_sleep_marks_8e9b86f0">Repères de sommeil</string>
@@ -633,6 +637,8 @@
     <string name="l10n_sleep_screen_spec_format_v_spec_unit_7a7f630c">%1$s %2$s</string>
     <string name="l10n_sleep_screen_spec_title_trend_chart_3085ac6e">Graphique de tendance %1$s</string>
     <string name="l10n_sleep_screen_stage_durationtext_minutes_percent_percent_of_477dbf14">%1$s: %2$s, %3$s pour cent de la nuit</string>
+    <string name="l10n_sleep_screen_stages_c1d33ad5">Stades</string>
+    <string name="l10n_sleep_screen_stages_vs_typical_28463f24">Stades vs typique</string>
     <string name="l10n_sleep_screen_tap_when_you_re_heading_to_1f401690">Touchez quand vous allez vous coucher ou quand vous vous réveillez. Chaque appui est enregistré avec l\'heure. Cela ne modifie pas le sommeil détecté cette nuit.</string>
     <string name="l10n_sleep_screen_this_metric_needs_at_least_two_2de1d37a">Cette mesure nécessite au moins deux nuits de données.</string>
     <string name="l10n_sleep_screen_undo_39fc7212">Annuler</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -764,8 +764,10 @@
     <string name="l10n_sleep_screen_about_your_main_sleep_1da8a640">Sobre o teu sono principal</string>
     <string name="l10n_sleep_screen_as_of_latest_first_726f20bb">a partir de %1$s</string>
     <string name="l10n_sleep_screen_asleep_b9692bbe">Adormecido</string>
+    <string name="l10n_sleep_screen_asleep_duration_3638413f">Duração do sono</string>
     <string name="l10n_sleep_screen_asleep_last_night_b969b068">dormi ontem à noite</string>
     <string name="l10n_sleep_screen_bedtime_wake_time_b2a22c32">Hora de dormir e acordar</string>
+    <string name="l10n_sleep_screen_consistency_0ea7b95e">Consistência</string>
     <string name="l10n_sleep_screen_consistencypct_roundtoint_b23a9d40">%1$s%%</string>
     <string name="l10n_sleep_screen_delete_this_nap_1adf0a3f">Exclua este cochilo</string>
     <string name="l10n_sleep_screen_fell_asleep_at_asleep_woke_at_80465b2d">Adormeci às %1$s, acordei às %2$s</string>
@@ -780,6 +782,7 @@
     <string name="l10n_sleep_screen_log_waking_up_2f9c230e">Registo acordando</string>
     <string name="l10n_sleep_screen_logged_as_a_nap_wrong_tap_4285d23e">Registado como um cochilo. Errado? Toque em Editar para ajustar os teus horários de deitar e acordar.</string>
     <string name="l10n_sleep_screen_nap_window_durationtext_durmin_bbc35167">Sesta %1$s, %2$s</string>
+    <string name="l10n_sleep_screen_night_detail_8f271bcf">Detalhe noturno</string>
     <string name="l10n_sleep_screen_no_movement_detail_for_this_night_a6f9736a">Sem detalhes de movimento para esta noite.</string>
     <string name="l10n_sleep_screen_no_nights_here_yet_607248f5">Nenhuma noite aqui ainda</string>
     <string name="l10n_sleep_screen_no_nights_with_sleep_data_yet_fa71b6b3">Ainda não há noites com dados de sono. O teu livro-razão é preenchido à medida que usa a pega para dormir.</string>
@@ -790,6 +793,7 @@
     <string name="l10n_sleep_screen_score_roundtoint_a2d1cc99">%1$s%%</string>
     <string name="l10n_sleep_screen_sleep_consistency_nightly_bed_and_wake_14526f89">Gráfico noturno da consistência do sono, cama e vigília</string>
     <string name="l10n_sleep_screen_sleep_debt_3aec7d9c">Dívida de sono</string>
+    <string name="l10n_sleep_screen_sleep_debt_ledger_8cc9a992">Livro-razão da dívida do sono</string>
     <string name="l10n_sleep_screen_sleep_debt_trend_chart_9e178776">Gráfico de tendências da dívida do sono</string>
     <string name="l10n_sleep_screen_sleep_hours_trend_chart_a6fbc46d">Gráfico de tendências das horas de sono</string>
     <string name="l10n_sleep_screen_sleep_marks_8e9b86f0">Marcas de sono</string>
@@ -801,6 +805,8 @@
     <string name="l10n_sleep_screen_spec_format_v_spec_unit_7a7f630c">%1$s %2$s</string>
     <string name="l10n_sleep_screen_spec_title_trend_chart_3085ac6e">%1$s gráfico de tendências</string>
     <string name="l10n_sleep_screen_stage_durationtext_minutes_percent_percent_of_477dbf14">%1$s: %2$s, %3$s por cento da noite</string>
+    <string name="l10n_sleep_screen_stages_c1d33ad5">Estágios</string>
+    <string name="l10n_sleep_screen_stages_vs_typical_28463f24">Estágios versus típico</string>
     <string name="l10n_sleep_screen_tap_when_you_re_heading_to_1f401690">Toque quando estiver a ir para a cama ou ao acordar. Cada toque é registado com a hora. Isto não altera o sono detetado desta noite.</string>
     <string name="l10n_sleep_screen_this_metric_needs_at_least_two_2de1d37a">Esta métrica necessita de pelo menos duas noites de dados.</string>
     <string name="l10n_sleep_screen_undo_39fc7212">Desfazer</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -746,8 +746,10 @@
     <string name="l10n_sleep_screen_about_your_main_sleep_1da8a640">关于您的主睡眠</string>
     <string name="l10n_sleep_screen_as_of_latest_first_726f20bb">数据截至 %1$s</string>
     <string name="l10n_sleep_screen_asleep_b9692bbe">入睡时间</string>
+    <string name="l10n_sleep_screen_asleep_duration_3638413f">睡眠时长</string>
     <string name="l10n_sleep_screen_asleep_last_night_b969b068">昨晚的睡眠情况</string>
     <string name="l10n_sleep_screen_bedtime_wake_time_b2a22c32">就寝与起床时间</string>
+    <string name="l10n_sleep_screen_consistency_0ea7b95e">规律性</string>
     <string name="l10n_sleep_screen_consistencypct_roundtoint_b23a9d40">%1$s%%</string>
     <string name="l10n_sleep_screen_delete_this_nap_1adf0a3f">删除这条小睡记录</string>
     <string name="l10n_sleep_screen_fell_asleep_at_asleep_woke_at_80465b2d">%1$s 入睡，%2$s 醒来</string>
@@ -762,6 +764,7 @@
     <string name="l10n_sleep_screen_log_waking_up_2f9c230e">打卡我已醒来</string>
     <string name="l10n_sleep_screen_logged_as_a_nap_wrong_tap_4285d23e">这段时间被记录为了小睡。系统误判了？请点击“编辑”调整您的真实入睡和醒来时间。</string>
     <string name="l10n_sleep_screen_nap_window_durationtext_durmin_bbc35167">小睡 %1$s, 持续 %2$s</string>
+    <string name="l10n_sleep_screen_night_detail_8f271bcf">夜间详情</string>
     <string name="l10n_sleep_screen_no_movement_detail_for_this_night_a6f9736a">缺少昨晚的详细体动数据。</string>
     <string name="l10n_sleep_screen_no_nights_here_yet_607248f5">暂无睡眠记录</string>
     <string name="l10n_sleep_screen_no_nights_with_sleep_data_yet_fa71b6b3">目前还没有睡眠数据。戴着手环入睡后，您的睡眠账本将在这里逐渐完善。</string>
@@ -772,6 +775,7 @@
     <string name="l10n_sleep_screen_score_roundtoint_a2d1cc99">%1$s%%</string>
     <string name="l10n_sleep_screen_sleep_consistency_nightly_bed_and_wake_14526f89">睡眠规律性（就寝与起床时间分布）</string>
     <string name="l10n_sleep_screen_sleep_debt_3aec7d9c">睡眠负债</string>
+    <string name="l10n_sleep_screen_sleep_debt_ledger_8cc9a992">睡眠负债账本</string>
     <string name="l10n_sleep_screen_sleep_debt_trend_chart_9e178776">睡眠负债趋势图</string>
     <string name="l10n_sleep_screen_sleep_hours_trend_chart_a6fbc46d">睡眠时长趋势图</string>
     <string name="l10n_sleep_screen_sleep_marks_8e9b86f0">睡眠标记打卡</string>
@@ -783,6 +787,8 @@
     <string name="l10n_sleep_screen_spec_format_v_spec_unit_7a7f630c">%1$s %2$s</string>
     <string name="l10n_sleep_screen_spec_title_trend_chart_3085ac6e">%1$s 趋势图</string>
     <string name="l10n_sleep_screen_stage_durationtext_minutes_percent_percent_of_477dbf14">%1$s：%2$s，占整晚的 %3$s%%</string>
+    <string name="l10n_sleep_screen_stages_c1d33ad5">阶段</string>
+    <string name="l10n_sleep_screen_stages_vs_typical_28463f24">各阶段 vs 常态</string>
     <string name="l10n_sleep_screen_tap_when_you_re_heading_to_1f401690">在您准备睡觉或刚醒来时点击这里。每次点击都会记录下当前时间。这不会干扰系统自动检测出的睡眠阶段。</string>
     <string name="l10n_sleep_screen_this_metric_needs_at_least_two_2de1d37a">该指标需要至少两晚的睡眠数据。</string>
     <string name="l10n_sleep_screen_undo_39fc7212">撤销</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -782,8 +782,10 @@
     <string name="l10n_sleep_screen_about_your_main_sleep_1da8a640">About your main sleep</string>
     <string name="l10n_sleep_screen_as_of_latest_first_726f20bb">as of %1$s</string>
     <string name="l10n_sleep_screen_asleep_b9692bbe">Asleep</string>
+    <string name="l10n_sleep_screen_asleep_duration_3638413f">Asleep duration</string>
     <string name="l10n_sleep_screen_asleep_last_night_b969b068">asleep last night</string>
     <string name="l10n_sleep_screen_bedtime_wake_time_b2a22c32">Bedtime &amp; wake time</string>
+    <string name="l10n_sleep_screen_consistency_0ea7b95e">Consistency</string>
     <string name="l10n_sleep_screen_consistencypct_roundtoint_b23a9d40">%1$s%%</string>
     <string name="l10n_sleep_screen_delete_this_nap_1adf0a3f">Delete this nap</string>
     <string name="l10n_sleep_screen_fell_asleep_at_asleep_woke_at_80465b2d">Fell asleep at %1$s, woke at %2$s</string>
@@ -798,6 +800,7 @@
     <string name="l10n_sleep_screen_log_waking_up_2f9c230e">Log waking up</string>
     <string name="l10n_sleep_screen_logged_as_a_nap_wrong_tap_4285d23e">Logged as a nap. Wrong? Tap Edit to adjust your sleep and wake times.</string>
     <string name="l10n_sleep_screen_nap_window_durationtext_durmin_bbc35167">Nap %1$s, %2$s</string>
+    <string name="l10n_sleep_screen_night_detail_8f271bcf">Night detail</string>
     <string name="l10n_sleep_screen_no_movement_detail_for_this_night_a6f9736a">No movement detail for this night.</string>
     <string name="l10n_sleep_screen_no_nights_here_yet_607248f5">No nights here yet</string>
     <string name="l10n_sleep_screen_no_nights_with_sleep_data_yet_fa71b6b3">No nights with sleep data yet. Your ledger fills in as you wear the strap to bed.</string>
@@ -808,6 +811,7 @@
     <string name="l10n_sleep_screen_score_roundtoint_a2d1cc99">%1$s%%</string>
     <string name="l10n_sleep_screen_sleep_consistency_nightly_bed_and_wake_14526f89">Sleep consistency nightly bed and wake chart</string>
     <string name="l10n_sleep_screen_sleep_debt_3aec7d9c">Sleep Debt</string>
+    <string name="l10n_sleep_screen_sleep_debt_ledger_8cc9a992">Sleep-debt ledger</string>
     <string name="l10n_sleep_screen_sleep_debt_trend_chart_9e178776">Sleep debt trend chart</string>
     <string name="l10n_sleep_screen_sleep_hours_trend_chart_a6fbc46d">Sleep hours trend chart</string>
     <string name="l10n_sleep_screen_sleep_marks_8e9b86f0">Sleep marks</string>
@@ -819,6 +823,8 @@
     <string name="l10n_sleep_screen_spec_format_v_spec_unit_7a7f630c">%1$s %2$s</string>
     <string name="l10n_sleep_screen_spec_title_trend_chart_3085ac6e">%1$s trend chart</string>
     <string name="l10n_sleep_screen_stage_durationtext_minutes_percent_percent_of_477dbf14">%1$s: %2$s, %3$s percent of the night</string>
+    <string name="l10n_sleep_screen_stages_c1d33ad5">Stages</string>
+    <string name="l10n_sleep_screen_stages_vs_typical_28463f24">Stages vs typical</string>
     <string name="l10n_sleep_screen_tap_when_you_re_heading_to_1f401690">Tap when you\'re heading to bed or when you wake. Each tap is logged with the time. It doesn\'t change tonight\'s detected sleep.</string>
     <string name="l10n_sleep_screen_this_metric_needs_at_least_two_2de1d37a">This metric needs at least two nights of data.</string>
     <string name="l10n_sleep_screen_undo_39fc7212">Undo</string>


### PR DESCRIPTION
## What
Android rendered `HostedCard` and `SleepSection` titles/origins from **hardcoded English enum literals**, so the Customise editors (and the new Available-list "Sleep"/"Trends" group headers from #1252) stayed English in every locale. iOS already localizes these via `String(localized:)`.

## How
- Resolve at the **render sites** via new `@Composable` extensions — `HostedCard.localizedTitle()`/`localizedOrigin()`, `SleepSection.localizedTitle()` — mapping each case to an `R.string`. Enum `String` fields stay as the English source-of-truth for non-UI uses; **persisted raw/id strings untouched**.
- The editors pre-resolve a `Map<Enum,String>` in composable scope and feed the plain `itemTitle`/`hiddenGroup` lambdas (which can't call `stringResource`).
- **6 new l10n keys** across **all** Android locales (values + de/es/fr/zh/**pt-rPT**), translations **pulled from the iOS String Catalog** so the platforms match exactly. Reused existing keys for *Sleep marks*, *Hours vs Needed*, and the nav *Sleep*/*Trends* origin labels.
- **iOS:** added the one missing catalog entry, *Stages* (it was absent, so iOS showed it untranslated too).

## Scope
`HostedCard` + `SleepSection` only — the sleep/customise surface. `DashboardCard`/`KeyMetric` share the pattern and are a separate follow-up.

## Verified
`compileFullDebugKotlin` + `Tools/i18n_audit.py --ci main` both green (run independently). iOS change is resource-only (String Catalog); the i18n-coverage check covers it.