### PR TITLE
feat(today): host the Stages-vs-typical sleep card

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -57,6 +57,11 @@ struct LiquidTodayView: View {
     @State private var importedActiveKcalDay: Double?  // #616: Apple Health active energy for the day (calorie fallback)
     @State private var hrValues: [Double] = []     // hrBuckets since midnight → 5-min means
     @State private var workouts: [WorkoutRow] = [] // newest-first
+    /// #today-hosted-cards: the shared SleepModel that backs every SleepModel-derived hosted sleep card
+    /// (Stages vs typical today; more to follow). Built ONCE in `load()` from the SAME inputs the Sleep tab
+    /// uses (`SleepModel.build`), and only when a sleep-origin card is actually hosted — so a Today with no
+    /// hosted sleep card pays none of the extra Repository work. nil until (and unless) it's built.
+    @State private var hostedSleepModel: SleepModel? = nil
 
     // sheets / expanders
     @State private var guideSection: ScoreSection?
@@ -662,6 +667,29 @@ struct LiquidTodayView: View {
         switch card {
         case .sleepMarks: SleepMarkCard()
         case .asleepDuration: AsleepDurationCard(data: AsleepDurationData.build(days: repo.days))
+        case .stagesVsTypical:
+            // Renders from the shared SleepModel built in load() (same inputs as the Sleep tab). Until that
+            // async build lands — or on a device with no usable latest night — show the graceful placeholder
+            // rather than a half-built card, mirroring how AsleepDuration degrades on no data.
+            if let m = hostedSleepModel {
+                StagesVsTypicalCard(model: m)
+            } else {
+                hostedSleepPlaceholder
+            }
+        }
+    }
+
+    /// Graceful empty state for a SleepModel-backed hosted card whose model hasn't built yet (first frame)
+    /// or is nil (no usable latest night). Keeps the hosted slot present + labelled so add/remove/reorder in
+    /// Customise still reads, without rendering a partial card. #today-hosted-cards.
+    private var hostedSleepPlaceholder: some View {
+        VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+            SectionHeader("Stages vs typical", overline: "Last night")
+            Text("Not enough nights yet.")
+                .font(StrandFont.subhead)
+                .foregroundStyle(StrandPalette.textTertiary)
+                .frame(maxWidth: .infinity, minHeight: 60, alignment: .center)
+                .background(NoopPanelSurface(tint: StrandPalette.restColor, cornerRadius: 12))
         }
     }
 
@@ -1309,6 +1337,27 @@ struct LiquidTodayView: View {
             }
         }
         heroProviderByMetric = providers
+
+        // #today-hosted-cards: build the shared SleepModel that backs the hosted sleep cards, but ONLY when
+        // at least one sleep-origin card is actually hosted — otherwise Today pays no extra Repository cost.
+        // The inputs (allSleepSessions / habitualMidsleepSec / sessionMotions) are loaded exactly as the
+        // Sleep tab loads them, then handed to the SAME pure `SleepModel.build`, so a hosted card renders
+        // numbers byte-identical to the Sleep tab. Reused by every SleepModel-backed hosted card (built once).
+        let sleepOrigin = String(localized: "Sleep")
+        if HostedCardPrefs.decodeEnabled(hostedCardsRaw).contains(where: { $0.origin == sleepOrigin }) {
+            let hostedSessions = await repo.allSleepSessions()
+            let hostedHabitual = await repo.habitualMidsleepSec()
+            let hostedMotion = await repo.sessionMotions(starts: hostedSessions.map { $0.startTs })
+            hostedSleepModel = SleepModel.build(SleepModelInputs(
+                days: repo.days,
+                sleeps: repo.sleeps,
+                allSessions: hostedSessions,
+                importedSleep: repo.importedSleep,
+                habitualMidsleepSec: hostedHabitual,
+                motionByStart: hostedMotion))
+        } else {
+            hostedSleepModel = nil
+        }
 
         // First load done — bring the hero gauges + sky to life now the launch churn has settled.
         if !dataLoaded { withAnimation(.easeIn(duration: 0.4)) { dataLoaded = true } }

--- a/Strand/Screens/HostedCards.swift
+++ b/Strand/Screens/HostedCards.swift
@@ -21,6 +21,9 @@ enum HostedCard: String, CaseIterable, Identifiable {
     case sleepMarks = "sleep.sleepMarks"
     /// Sleep tab · "Asleep duration" — trailing-30-night sleep-hours trend (#today-hosted-cards P1).
     case asleepDuration = "sleep.asleepDuration"
+    /// Sleep tab · "Stages vs typical" — last night's Deep/REM/Light vs the wearer's personal per-stage
+    /// means (#today-hosted-cards). First of the SleepModel-backed sleep cards hosted in Today.
+    case stagesVsTypical = "sleep.stagesVsTypical"
 
     var id: String { rawValue }
 
@@ -29,6 +32,7 @@ enum HostedCard: String, CaseIterable, Identifiable {
         switch self {
         case .sleepMarks: return String(localized: "Sleep marks")
         case .asleepDuration: return String(localized: "Asleep duration")
+        case .stagesVsTypical: return String(localized: "Stages vs typical")
         }
     }
 
@@ -36,7 +40,7 @@ enum HostedCard: String, CaseIterable, Identifiable {
     /// Trends". Matches the Android `HostedCard.origin`.
     var origin: String {
         switch self {
-        case .sleepMarks, .asleepDuration: return String(localized: "Sleep")
+        case .sleepMarks, .asleepDuration, .stagesVsTypical: return String(localized: "Sleep")
         }
     }
 
@@ -45,13 +49,14 @@ enum HostedCard: String, CaseIterable, Identifiable {
         switch self {
         case .sleepMarks: return "moon.zzz"
         case .asleepDuration: return "chart.bar.xaxis"
+        case .stagesVsTypical: return "chart.bar.doc.horizontal"
         }
     }
 
     /// Editor row tint.
     var customizationTint: Color {
         switch self {
-        case .sleepMarks, .asleepDuration: return StrandPalette.restColor
+        case .sleepMarks, .asleepDuration, .stagesVsTypical: return StrandPalette.restColor
         }
     }
 

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -385,7 +385,7 @@ struct SleepView: View {
         case .stages:          hero(model)
         case .nightDetail:     metricGrid(model)
         case .sleepDebt:       sleepDebtLedger(model)
-        case .stagesVsTypical: stagesVsTypical(model)
+        case .stagesVsTypical: StagesVsTypicalCard(model: model)
         case .asleepDuration:  durationTrend(model)
         }
     }
@@ -1738,107 +1738,6 @@ struct SleepView: View {
         .accessibilityLabel("Per-night sleep balance: \(ledger.nightCount) nights, net \(debtSigned(ledger.balanceMin))")
     }
 
-    // MARK: - 3. Stages vs typical
-
-    @ViewBuilder
-    private func stagesVsTypical(_ model: SleepModel) -> some View {
-        let s = model.night.stages
-        // Per-stage typical means are computed ONCE in the model build (each a full pass
-        // over repo.days) and read here.
-        VStack(alignment: .leading, spacing: NoopMetrics.gap) {
-            SectionHeader("Stages vs typical", overline: "Last night")
-            NoopCard(tint: StrandPalette.restColor) {
-                VStack(alignment: .leading, spacing: NoopMetrics.space4) {
-                    stageRow(stage: String(localized: "Deep"),  last: s.deep,  typical: model.typicalDeepMin,  nightTotal: s.total, color: StrandPalette.sleepDeep)
-                    Divider().overlay(StrandPalette.hairline)
-                    stageRow(stage: String(localized: "REM"),   last: s.rem,   typical: model.typicalRemMin,   nightTotal: s.total, color: StrandPalette.sleepREM)
-                    Divider().overlay(StrandPalette.hairline)
-                    stageRow(stage: String(localized: "Light"), last: s.light, typical: model.typicalLightMin, nightTotal: s.total, color: StrandPalette.sleepLight)
-                }
-            }
-        }
-    }
-
-    /// One stage row, WHOOP sleep-detail style: a colour swatch + UPPERCASE stage + the share-of-night %
-    /// (in the stage colour), then a bar that reads "solid = you, hatch = the context" — a diagonal-hatch
-    /// track spanning the TYPICAL (the personal mean for this stage) with the user's last-night value as a
-    /// solid coloured fill on top, plus a thin marker at the typical mean and the right-aligned duration.
-    /// Same data as before (`last` minutes, `typical` personal mean) — the hatch just renders the typical
-    /// context the prior vertical-only marker implied.
-    @ViewBuilder
-    private func stageRow(stage label: String, last: Double, typical: Double?, nightTotal: Double, color: Color) -> some View {
-        // Scale both values against a shared per-row max so the typical hatch + marker are meaningful.
-        let scaleMax = max(last, typical ?? 0) * 1.18
-        let max = scaleMax > 0 ? scaleMax : 1
-        // Share of the night this stage took (drives the WHOOP coloured %); over time-in-bed, matching the
-        // stage-breakdown rows above.
-        let sharePct = nightTotal > 0 ? Int((last / nightTotal * 100).rounded()) : 0
-        let deltaText: String = {
-            guard let typical, typical > 0 else { return "" }
-            let diff = last - typical
-            let sign = diff >= 0 ? "+" : "−"
-            return String(localized: "\(sign)\(durationText(abs(diff))) vs typ")
-        }()
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                RoundedRectangle(cornerRadius: 3, style: .continuous)
-                    .fill(color)
-                    .frame(width: 12, height: 12)
-                    .accessibilityHidden(true)
-                Text(label.uppercased())
-                    .font(StrandFont.overline)
-                    .tracking(StrandFont.overlineTracking)
-                    .foregroundStyle(StrandPalette.textPrimary)
-                Text("\(sharePct)%")
-                    .font(StrandFont.captionNumber)
-                    .foregroundStyle(color)
-                Spacer()
-                Text(durationText(last)).font(StrandFont.captionNumber).foregroundStyle(StrandPalette.textPrimary)
-                if !deltaText.isEmpty {
-                    Text(deltaText)
-                        .font(StrandFont.footnote)
-                        .foregroundStyle(last >= (typical ?? last) ? StrandPalette.statusPositive : StrandPalette.statusWarning)
-                }
-            }
-            GeometryReader { geo in
-                let w = geo.size.width
-                ZStack(alignment: .leading) {
-                    // Last-night value as the signature liquid tube — "solid = you", now a filling liquid
-                    // capsule tinted in the stage colour (static/posed, like Today's grid tubes). It renders
-                    // its own dark capsule track, so it replaces the flat solid fill + track. The fraction
-                    // is unchanged (last / shared per-row max).
-                    LiquidTube(frac: min(1, last / max), tint: color, height: 12, animated: false)
-                    // Typical-range CONTEXT overlaid on top: a diagonal-hatch track spanning the personal
-                    // mean for this stage. "Hatch = the context" — the liquid value sits under it.
-                    if let typical, typical > 0 {
-                        DiagonalHatch(spacing: 5, lineWidth: 1)
-                            .stroke(color.opacity(0.6), lineWidth: 1)
-                            .frame(width: w * CGFloat(min(1, typical / max)))
-                            .clipShape(Capsule(style: .continuous))
-                    }
-                    // Crisp typical-mean marker so the exact mean still reads at a glance.
-                    if let typical, typical > 0 {
-                        Rectangle()
-                            .fill(StrandPalette.textPrimary)
-                            .frame(width: 2, height: 18)
-                            .position(x: w * CGFloat(min(1, typical / max)), y: 6)
-                    }
-                }
-            }
-            .frame(height: 12)
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(stageRowAccessibilityLabel(label: label, last: last, sharePct: sharePct, typical: typical))
-        }
-    }
-
-    /// Whole-string VoiceOver label for a stage row: one key per variant, never a stitched tail fragment.
-    private func stageRowAccessibilityLabel(label: String, last: Double, sharePct: Int, typical: Double?) -> String {
-        if let typical, typical > 0 {
-            return String(localized: "\(label): \(durationText(last)) last night, \(sharePct) percent of the night, typical \(durationText(typical))")
-        }
-        return String(localized: "\(label): \(durationText(last)) last night, \(sharePct) percent of the night")
-    }
-
     // MARK: - 4. 30-day asleep-hours trend
 
     @ViewBuilder
@@ -2762,28 +2661,6 @@ private struct SleepSyncingNote: View {
     @EnvironmentObject private var live: LiveState
     var body: some View {
         if live.backfilling { SyncingHistoryNote(chunks: live.syncChunksThisSession) }
-    }
-}
-
-// MARK: - Diagonal-hatch track (WHOOP "typical range" context)
-
-/// A repeating set of 45° diagonal lines for the "typical range" context track behind a stage bar
-/// ("solid = you, hatch = the context"). Pure geometry — stroke it in the stage colour and clip it to a
-/// capsule. `spacing` is the gap between lines; the lines run further than the bounds so the clip edges
-/// stay clean. Presentation-only; no data of its own.
-private struct DiagonalHatch: Shape {
-    var spacing: CGFloat = 5
-    var lineWidth: CGFloat = 1
-    func path(in rect: CGRect) -> Path {
-        var p = Path()
-        // Start well before the left edge so the 45° lines fully cover the rect after the diagonal shear.
-        var x = -rect.height
-        while x < rect.width {
-            p.move(to: CGPoint(x: x, y: rect.height))
-            p.addLine(to: CGPoint(x: x + rect.height, y: 0))
-            x += spacing
-        }
-        return p
     }
 }
 

--- a/Strand/Screens/StagesVsTypicalCard.swift
+++ b/Strand/Screens/StagesVsTypicalCard.swift
@@ -1,0 +1,144 @@
+import SwiftUI
+import StrandDesign
+import WhoopStore
+
+// MARK: - Stages vs typical (#today-hosted-cards)
+//
+// The Sleep tab's "Stages vs typical" card, extracted into a standalone view so it can ALSO be hosted in
+// the Today tab. Both the Sleep tab and the Today host render THIS view from the SAME `SleepModel`, so the
+// per-stage last-night-vs-typical bars can never diverge between the two surfaces (the parity contract).
+// The card body + its `stageRow` / `stageRowAccessibilityLabel` helpers are a verbatim lift of the former
+// `SleepView.stagesVsTypical` (and its helpers); the per-stage typical means are computed once in
+// `SleepModel.build` and read here.
+
+/// The "Stages vs typical" card. Renders last night's Deep/REM/Light against the wearer's personal
+/// per-stage means from the shared [SleepModel].
+struct StagesVsTypicalCard: View {
+    let model: SleepModel
+
+    var body: some View {
+        let s = model.night.stages
+        // Per-stage typical means are computed ONCE in the model build (each a full pass
+        // over repo.days) and read here.
+        VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+            SectionHeader("Stages vs typical", overline: "Last night")
+            NoopCard(tint: StrandPalette.restColor) {
+                VStack(alignment: .leading, spacing: NoopMetrics.space4) {
+                    stageRow(stage: String(localized: "Deep"),  last: s.deep,  typical: model.typicalDeepMin,  nightTotal: s.total, color: StrandPalette.sleepDeep)
+                    Divider().overlay(StrandPalette.hairline)
+                    stageRow(stage: String(localized: "REM"),   last: s.rem,   typical: model.typicalRemMin,   nightTotal: s.total, color: StrandPalette.sleepREM)
+                    Divider().overlay(StrandPalette.hairline)
+                    stageRow(stage: String(localized: "Light"), last: s.light, typical: model.typicalLightMin, nightTotal: s.total, color: StrandPalette.sleepLight)
+                }
+            }
+        }
+    }
+
+    /// One stage row, WHOOP sleep-detail style: a colour swatch + UPPERCASE stage + the share-of-night %
+    /// (in the stage colour), then a bar that reads "solid = you, hatch = the context" — a diagonal-hatch
+    /// track spanning the TYPICAL (the personal mean for this stage) with the user's last-night value as a
+    /// solid coloured fill on top, plus a thin marker at the typical mean and the right-aligned duration.
+    /// Same data as before (`last` minutes, `typical` personal mean) — the hatch just renders the typical
+    /// context the prior vertical-only marker implied.
+    @ViewBuilder
+    private func stageRow(stage label: String, last: Double, typical: Double?, nightTotal: Double, color: Color) -> some View {
+        // Scale both values against a shared per-row max so the typical hatch + marker are meaningful.
+        let scaleMax = max(last, typical ?? 0) * 1.18
+        let max = scaleMax > 0 ? scaleMax : 1
+        // Share of the night this stage took (drives the WHOOP coloured %); over time-in-bed, matching the
+        // stage-breakdown rows above.
+        let sharePct = nightTotal > 0 ? Int((last / nightTotal * 100).rounded()) : 0
+        let deltaText: String = {
+            guard let typical, typical > 0 else { return "" }
+            let diff = last - typical
+            let sign = diff >= 0 ? "+" : "−"
+            return String(localized: "\(sign)\(durationText(abs(diff))) vs typ")
+        }()
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                RoundedRectangle(cornerRadius: 3, style: .continuous)
+                    .fill(color)
+                    .frame(width: 12, height: 12)
+                    .accessibilityHidden(true)
+                Text(label.uppercased())
+                    .font(StrandFont.overline)
+                    .tracking(StrandFont.overlineTracking)
+                    .foregroundStyle(StrandPalette.textPrimary)
+                Text("\(sharePct)%")
+                    .font(StrandFont.captionNumber)
+                    .foregroundStyle(color)
+                Spacer()
+                Text(durationText(last)).font(StrandFont.captionNumber).foregroundStyle(StrandPalette.textPrimary)
+                if !deltaText.isEmpty {
+                    Text(deltaText)
+                        .font(StrandFont.footnote)
+                        .foregroundStyle(last >= (typical ?? last) ? StrandPalette.statusPositive : StrandPalette.statusWarning)
+                }
+            }
+            GeometryReader { geo in
+                let w = geo.size.width
+                ZStack(alignment: .leading) {
+                    // Last-night value as the signature liquid tube — "solid = you", now a filling liquid
+                    // capsule tinted in the stage colour (static/posed, like Today's grid tubes). It renders
+                    // its own dark capsule track, so it replaces the flat solid fill + track. The fraction
+                    // is unchanged (last / shared per-row max).
+                    LiquidTube(frac: min(1, last / max), tint: color, height: 12, animated: false)
+                    // Typical-range CONTEXT overlaid on top: a diagonal-hatch track spanning the personal
+                    // mean for this stage. "Hatch = the context" — the liquid value sits under it.
+                    if let typical, typical > 0 {
+                        DiagonalHatch(spacing: 5, lineWidth: 1)
+                            .stroke(color.opacity(0.6), lineWidth: 1)
+                            .frame(width: w * CGFloat(min(1, typical / max)))
+                            .clipShape(Capsule(style: .continuous))
+                    }
+                    // Crisp typical-mean marker so the exact mean still reads at a glance.
+                    if let typical, typical > 0 {
+                        Rectangle()
+                            .fill(StrandPalette.textPrimary)
+                            .frame(width: 2, height: 18)
+                            .position(x: w * CGFloat(min(1, typical / max)), y: 6)
+                    }
+                }
+            }
+            .frame(height: 12)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(stageRowAccessibilityLabel(label: label, last: last, sharePct: sharePct, typical: typical))
+        }
+    }
+
+    /// Whole-string VoiceOver label for a stage row: one key per variant, never a stitched tail fragment.
+    private func stageRowAccessibilityLabel(label: String, last: Double, sharePct: Int, typical: Double?) -> String {
+        if let typical, typical > 0 {
+            return String(localized: "\(label): \(durationText(last)) last night, \(sharePct) percent of the night, typical \(durationText(typical))")
+        }
+        return String(localized: "\(label): \(durationText(last)) last night, \(sharePct) percent of the night")
+    }
+
+    /// Minutes → "Xm" / "Yh Zm" (verbatim of `SleepView.durationText`). Kept local to the card so it renders
+    /// identically whether hosted in Today or shown in the Sleep tab.
+    private func durationText(_ minutes: Double) -> String {
+        let m = Swift.max(0, Int(minutes.rounded()))
+        if m < 60 { return String(localized: "\(m)m") }
+        return String(localized: "\(m / 60)h \(m % 60)m")
+    }
+}
+
+/// 45° diagonal-hatch fill used by the stage rows' "typical" context track (verbatim of the former
+/// file-private `SleepView.DiagonalHatch` — moved here with its only caller). The public
+/// `StrandDesign.DiagonalHatch` has no `lineWidth`, so this local shape is kept to preserve byte-identical
+/// rendering.
+private struct DiagonalHatch: Shape {
+    var spacing: CGFloat = 5
+    var lineWidth: CGFloat = 1
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        // Start well before the left edge so the 45° lines fully cover the rect after the diagonal shear.
+        var x = -rect.height
+        while x < rect.width {
+            p.move(to: CGPoint(x: x, y: rect.height))
+            p.addLine(to: CGPoint(x: x + rect.height, y: 0))
+            x += spacing
+        }
+        return p
+    }
+}

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -306,6 +306,11 @@ struct TodayView: View {
     // used to anchor the recovery marker at wake time (WHOOP-style Overview HR annotations).
     @State private var sleepToday: CachedSleepSession?
 
+    // #today-hosted-cards: the shared SleepModel backing every SleepModel-derived hosted sleep card (Stages
+    // vs typical today; more to follow). Built in loadAll() from the SAME inputs the Sleep tab uses, and only
+    // when a sleep-origin card is hosted. Twin of the LiquidTodayView `hostedSleepModel`.
+    @State private var hostedSleepModel: SleepModel? = nil
+
     // TODAY's in-progress Effort (NOOP 0–100 axis), recomputed over the day's HR (local-midnight→now)
     // each load so the gauge tracks today as it accumulates rather than waiting on the heavy daily pass
     // to persist, which early in the day would otherwise surface yesterday's completed Effort or a stale
@@ -2199,6 +2204,22 @@ struct TodayView: View {
         switch card {
         case .sleepMarks: SleepMarkCard()
         case .asleepDuration: AsleepDurationCard(data: AsleepDurationData.build(days: repo.days))
+        case .stagesVsTypical:
+            // Renders from the shared SleepModel built in loadAll() (same inputs as the Sleep tab). Until the
+            // async build lands — or on a device with no usable latest night — show the graceful placeholder,
+            // mirroring how AsleepDuration degrades on no data.
+            if let m = hostedSleepModel {
+                StagesVsTypicalCard(model: m)
+            } else {
+                VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+                    SectionHeader("Stages vs typical", overline: "Last night")
+                    Text("Not enough nights yet.")
+                        .font(StrandFont.subhead)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                        .frame(maxWidth: .infinity, minHeight: 60, alignment: .center)
+                        .background(NoopPanelSurface(tint: StrandPalette.restColor, cornerRadius: 12))
+                }
+            }
         }
     }
 
@@ -3779,6 +3800,10 @@ struct TodayView: View {
         // #860 retired the launch auto-land, this pass no longer changes `selectedDayOffset`, so there's no
         // re-fire to bail for: the history-wide set + the new-day announce run straight through below.
         await loadDayScoped()
+        // #today-hosted-cards: refresh the shared SleepModel for the hosted sleep cards. Runs on EVERY load
+        // (before the cache-restore short-circuit below), so the card survives a tab-away/return; the gate
+        // inside makes it a no-op unless a sleep card is actually hosted.
+        await loadHostedSleepModel()
         // #849: a bare Today RE-MOUNT (tab-away + return, or an Apple-Health import that recreates the view)
         // re-fires this task with TodayView's `@State` reset, so the heavy history-wide pass re-ran in full
         // every time even when NOTHING in the data had changed: hundreds of redundant reads (incl. the
@@ -3817,6 +3842,29 @@ struct TodayView: View {
             repo.todayHistoryWideLoadedSeq = currentSeq
         }
         announceNewDaysIfNeeded()
+    }
+
+    /// #today-hosted-cards: build the shared SleepModel backing the hosted sleep cards, ONLY when a
+    /// sleep-origin card is actually hosted (else Today pays no extra cost). Loads the inputs the SAME way
+    /// SleepView does (`allSleepSessions` / `habitualMidsleepSec` / `sessionMotions`) and hands them to the
+    /// SAME pure `SleepModel.build`, so a hosted card's numbers match the Sleep tab. Twin of the
+    /// LiquidTodayView hostedSleepModel build.
+    private func loadHostedSleepModel() async {
+        let sleepOrigin = String(localized: "Sleep")
+        guard HostedCardPrefs.decodeEnabled(hostedCardsRaw).contains(where: { $0.origin == sleepOrigin }) else {
+            hostedSleepModel = nil
+            return
+        }
+        let hostedSessions = await repo.allSleepSessions()
+        let hostedHabitual = await repo.habitualMidsleepSec()
+        let hostedMotion = await repo.sessionMotions(starts: hostedSessions.map { $0.startTs })
+        hostedSleepModel = SleepModel.build(SleepModelInputs(
+            days: repo.days,
+            sleeps: repo.sleeps,
+            allSessions: hostedSessions,
+            importedSleep: repo.importedSleep,
+            habitualMidsleepSec: hostedHabitual,
+            motionByStart: hostedMotion))
     }
 
     /// True while the strap is mid history-offload, the SAME signal the "Syncing strap history…" note

--- a/android/app/src/main/java/com/noop/ui/HostedCards.kt
+++ b/android/app/src/main/java/com/noop/ui/HostedCards.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Bedtime
+import androidx.compose.material.icons.filled.StackedBarChart
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
@@ -37,7 +38,10 @@ enum class HostedCard(
      *  only, no model), the first card wired end-to-end. */
     SLEEP_MARKS("sleep.sleepMarks", "Sleep marks", "Sleep", Icons.Filled.Bedtime),
     /** Sleep tab · "Asleep duration" — trailing-14-night sleep-hours trend (#today-hosted-cards P1). */
-    ASLEEP_DURATION("sleep.asleepDuration", "Asleep duration", "Sleep", Icons.Filled.BarChart);
+    ASLEEP_DURATION("sleep.asleepDuration", "Asleep duration", "Sleep", Icons.Filled.BarChart),
+    /** Sleep tab · "Stages vs typical" — last night's Deep/REM/Light vs the wearer's personal per-stage
+     *  means (#today-hosted-cards). First of the SleepModel-backed sleep cards hosted in Today. */
+    STAGES_VS_TYPICAL("sleep.stagesVsTypical", "Stages vs typical", "Sleep", Icons.Filled.StackedBarChart);
 
     companion object {
         fun fromRaw(raw: String?): HostedCard? = entries.firstOrNull { it.raw == raw }
@@ -60,6 +64,7 @@ enum class HostedCard(
 fun HostedCard.localizedTitle(): String = when (this) {
     HostedCard.SLEEP_MARKS -> stringResource(R.string.l10n_sleep_screen_sleep_marks_8e9b86f0)
     HostedCard.ASLEEP_DURATION -> stringResource(R.string.l10n_sleep_screen_asleep_duration_3638413f)
+    HostedCard.STAGES_VS_TYPICAL -> stringResource(R.string.l10n_sleep_screen_stages_vs_typical_28463f24)
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
@@ -5,6 +5,7 @@ import com.noop.analytics.SleepDebt
 import com.noop.analytics.SleepStageTotals
 import com.noop.data.DailyMetric
 import com.noop.data.SleepSession
+import com.noop.data.WhoopRepository
 import java.util.Calendar
 import org.json.JSONArray
 import org.json.JSONObject
@@ -307,6 +308,55 @@ internal fun fallbackSleepModel(
     }?.day ?: return null
     return buildSleepModel(days, null, imported, selectedDay = anchorDay,
         napSleepMinByDay = napSleepMinByDay, sessions = sessions)
+}
+
+/**
+ * #today-hosted-cards: the ONE loader that builds the shared [SleepModel] backing every SleepModel-derived
+ * hosted sleep card in Today (Stages vs typical today; more to follow). It mirrors the Sleep tab's own
+ * inputs step-for-step — the active∪canonical session union with the #241 richness merge, the learned
+ * habitual midsleep, the imported metric series, and the nap-minutes-by-day map — then hands them to the
+ * SAME [fallbackSleepModel] the Sleep tab uses (SleepScreen.kt), so a hosted card renders numbers
+ * byte-identical to the Sleep tab. Returns null when no day has stage data (the first-run empty state).
+ * Suspends (a handful of repo reads); call it from a keyed LaunchedEffect and cache the result, and only
+ * when a SleepModel-backed card is actually hosted, so a Today with none pays no cost. Twin of the iOS
+ * `LiquidTodayView` hostedSleepModel build.
+ */
+internal suspend fun buildHostedSleepModel(
+    repo: WhoopRepository,
+    activeStrapId: String,
+    days: List<DailyMetric>,
+): SleepModel? {
+    val now = System.currentTimeMillis() / 1000L
+    // Active∪canonical union + #241 richness merge, keyed by LOCAL wake-day — the SAME merge SleepScreen
+    // does for its `sleeps` (imported-wins, stage-less imports yield to a computed day that has stages),
+    // ordered by effective onset.
+    val sleeps: List<SleepSession> = runCatching {
+        val imported = repo.sleepSessionsUnion(activeStrapId, 0L, now)
+        val computed = repo.computedSleepSessionsUnion(activeStrapId, 0L, now)
+        fun localEndDay(ts: Long): String {
+            val offsetSec = (java.util.TimeZone.getDefault().getOffset(ts * 1000) / 1000).toLong()
+            return AnalyticsEngine.dayString(ts, offsetSec)
+        }
+        WhoopRepository.mergeSleepRichness(imported, computed) { localEndDay(it.endTs) }
+            .sortedBy { it.effectiveStartTs }
+    }.getOrDefault(emptyList())
+
+    // Learned habitual midsleep (threads the active strap id, as SleepScreen does); null under threshold.
+    val habitualMidsleep = runCatching { repo.habitualMidsleepSec(activeStrapId) }.getOrNull()
+
+    // Imported headline series (the SAME ImportedSleepSeries the Sleep tab loads). metricSeries has no Flow.
+    suspend fun load(key: String) = runCatching {
+        repo.metricSeries("my-whoop", key, "0000-00-00", "9999-99-99")
+    }.getOrDefault(emptyList()).associate { it.day to it.value }
+    val imported = ImportedSleepSeries(
+        performance = load("sleep_performance"),
+        consistency = load("sleep_consistency"),
+        needMin = load("sleep_need_min"),
+        debtMin = load("sleep_debt_min"),
+    )
+
+    val napSleepMinByDay = napSleepMinutesByDay(sleeps, habitualMidsleep)
+    return fallbackSleepModel(days, imported, napSleepMinByDay, sessions = sleeps)
 }
 
 /** Build a metric from a per-day transform, keeping only finite values. */

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -759,7 +759,7 @@ fun SleepScreen(
                         SleepReorderableSection(k, sleepListState, sleepSectionDrag, persistSleepOrder) {
                             Column {
                                 Spacer(Modifier.height(Metrics.selectorTopUp))
-                                StagesVsTypical(selectedModel)
+                                StagesVsTypicalHostCard(selectedModel)
                             }
                         }
                     }
@@ -2571,8 +2571,14 @@ private fun DebtDeltaBars(ledger: SleepDebtLedger) {
 
 // MARK: - 3. Stages vs typical
 
+/**
+ * #today-hosted-cards: the "Stages vs typical" card — last night's Deep/REM/Light against the wearer's
+ * personal per-stage means from the shared [SleepModel]. `internal` so the Today host (TodayScreen) can
+ * render the SAME view the Sleep tab does (a mirror, not a copy); lives here so its StageRow/Hairline
+ * siblings are in-file. Twin of the iOS `StagesVsTypicalCard`.
+ */
 @Composable
-private fun StagesVsTypical(m: SleepModel) {
+internal fun StagesVsTypicalHostCard(m: SleepModel) {
     val s = m.stages
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
         SectionHeader("Stages vs typical", overline = "Selected night", trailing = "marker = your mean")

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3070,6 +3070,20 @@ private fun HostedCardsSection(cards: List<HostedCard>, days: List<DailyMetric>,
     if (cards.isEmpty()) return
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+    // #today-hosted-cards: the SleepModel-backed hosted sleep cards (Stages vs typical today; more to
+    // follow). Build the shared model ONCE, and only when at least one such card is actually hosted, so a
+    // Today hosting none pays no cost. Same inputs + builder as the Sleep tab (buildHostedSleepModel), so
+    // hosted numbers match the Sleep tab. Reused by every model-backed card. Twin of the iOS hostedSleepModel.
+    val modelBackedHosted = setOf(HostedCard.STAGES_VS_TYPICAL)
+    val needsSleepModel = cards.any { it in modelBackedHosted }
+    var hostedSleepModel by remember { mutableStateOf<SleepModel?>(null) }
+    LaunchedEffect(needsSleepModel, days, viewModel.activeStrapId) {
+        hostedSleepModel = if (needsSleepModel) {
+            buildHostedSleepModel(viewModel.repo, viewModel.activeStrapId, days)
+        } else {
+            null
+        }
+    }
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.sectionGap)) {
         cards.forEach { card ->
             when (card) {
@@ -3092,6 +3106,11 @@ private fun HostedCardsSection(cards: List<HostedCard>, days: List<DailyMetric>,
                     val (hours, dates) = sleepDurationTrend(days)
                     AsleepDurationHostCard(hours = hours, dates = dates)
                 }
+                // #today-hosted-cards: last night's stages vs the wearer's personal per-stage means, rendered
+                // from the SAME shared SleepModel the Sleep tab uses (mirror, not copy). Until the async build
+                // lands — or on a device with no stage data — the model is null and the slot renders nothing
+                // this frame, matching how the Sleep tab guards the section on a null model.
+                HostedCard.STAGES_VS_TYPICAL -> hostedSleepModel?.let { StagesVsTypicalHostCard(it) }
             }
         }
     }


### PR DESCRIPTION
First hosted sleep card on the shared `SleepModel` foundation (#1254). Lifts `SleepView.stagesVsTypical` into a standalone `StagesVsTypicalCard(model:)` rendered by BOTH the Sleep tab and the Today host from the same model (no divergence). Registers `HostedCard.stagesVsTypical` (byte-identical `sleep.stagesVsTypical`, localized title) and the reusable Today-host model plumbing (build once when a sleep card is hosted; both classic + Liquid Today). Android twin included. Android compile + i18n + HostedCardPrefsTest green; Swift via the app-build gate.