### PR TITLE
feat(today): host the Night-detail sleep card

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -676,6 +676,14 @@ struct LiquidTodayView: View {
             } else {
                 hostedSleepPlaceholder
             }
+        case .nightDetail:
+            // Renders from the same shared SleepModel built in load(). Until that async build lands — or on a
+            // device with no usable latest night — show the graceful placeholder, mirroring stagesVsTypical.
+            if let m = hostedSleepModel {
+                NightDetailCard(model: m)
+            } else {
+                hostedNightDetailPlaceholder
+            }
         }
     }
 
@@ -685,6 +693,20 @@ struct LiquidTodayView: View {
     private var hostedSleepPlaceholder: some View {
         VStack(alignment: .leading, spacing: NoopMetrics.gap) {
             SectionHeader("Stages vs typical", overline: "Last night")
+            Text("Not enough nights yet.")
+                .font(StrandFont.subhead)
+                .foregroundStyle(StrandPalette.textTertiary)
+                .frame(maxWidth: .infinity, minHeight: 60, alignment: .center)
+                .background(NoopPanelSurface(tint: StrandPalette.restColor, cornerRadius: 12))
+        }
+    }
+
+    /// Graceful empty state for the hosted "Night detail" grid before its shared SleepModel builds (first
+    /// frame) or when there is no usable latest night. Same treatment as `hostedSleepPlaceholder`, labelled
+    /// for this card so add/remove/reorder in Customise still reads. #today-hosted-cards.
+    private var hostedNightDetailPlaceholder: some View {
+        VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+            SectionHeader("Night detail", overline: "Metrics")
             Text("Not enough nights yet.")
                 .font(StrandFont.subhead)
                 .foregroundStyle(StrandPalette.textTertiary)

--- a/Strand/Screens/HostedCards.swift
+++ b/Strand/Screens/HostedCards.swift
@@ -24,6 +24,10 @@ enum HostedCard: String, CaseIterable, Identifiable {
     /// Sleep tab · "Stages vs typical" — last night's Deep/REM/Light vs the wearer's personal per-stage
     /// means (#today-hosted-cards). First of the SleepModel-backed sleep cards hosted in Today.
     case stagesVsTypical = "sleep.stagesVsTypical"
+    /// Sleep tab · "Night detail" — the metric grid (Rest/Efficiency/Consistency/Hours vs Needed/
+    /// Restorative/Respiratory/Sleep Debt) rendered from the wearer's `SleepModel` (#today-hosted-cards).
+    /// Second of the SleepModel-backed sleep cards hosted in Today.
+    case nightDetail = "sleep.nightDetail"
 
     var id: String { rawValue }
 
@@ -33,6 +37,7 @@ enum HostedCard: String, CaseIterable, Identifiable {
         case .sleepMarks: return String(localized: "Sleep marks")
         case .asleepDuration: return String(localized: "Asleep duration")
         case .stagesVsTypical: return String(localized: "Stages vs typical")
+        case .nightDetail: return String(localized: "Night detail")
         }
     }
 
@@ -40,7 +45,7 @@ enum HostedCard: String, CaseIterable, Identifiable {
     /// Trends". Matches the Android `HostedCard.origin`.
     var origin: String {
         switch self {
-        case .sleepMarks, .asleepDuration, .stagesVsTypical: return String(localized: "Sleep")
+        case .sleepMarks, .asleepDuration, .stagesVsTypical, .nightDetail: return String(localized: "Sleep")
         }
     }
 
@@ -50,13 +55,14 @@ enum HostedCard: String, CaseIterable, Identifiable {
         case .sleepMarks: return "moon.zzz"
         case .asleepDuration: return "chart.bar.xaxis"
         case .stagesVsTypical: return "chart.bar.doc.horizontal"
+        case .nightDetail: return "square.grid.2x2"
         }
     }
 
     /// Editor row tint.
     var customizationTint: Color {
         switch self {
-        case .sleepMarks, .asleepDuration, .stagesVsTypical: return StrandPalette.restColor
+        case .sleepMarks, .asleepDuration, .stagesVsTypical, .nightDetail: return StrandPalette.restColor
         }
     }
 

--- a/Strand/Screens/NightDetailCard.swift
+++ b/Strand/Screens/NightDetailCard.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+import StrandDesign
+import WhoopStore
+
+// MARK: - Night detail (#today-hosted-cards)
+//
+// The Sleep tab's "Night detail" metric grid, extracted into a standalone view so it can ALSO be hosted
+// in the Today tab. Both the Sleep tab and the Today host render THIS view from the SAME `SleepModel`, so
+// the per-metric latest value / sparkline / typical caption can never diverge between the two surfaces
+// (the parity contract). The card body + its `pctValue` / `rrValue` / `vsTypical` / `debtCaption` /
+// `debtColor` / `spark` helpers are a verbatim lift of the former `SleepView.metricGrid` (and the helpers
+// only it used); the seven series are computed once in `SleepModel.build` and read here.
+
+/// The "Night detail" card. A grid of UNIFORM fixed-height StatTiles (Rest, Efficiency, Consistency,
+/// Hours vs Needed, Restorative, Respiratory, Sleep Debt), each with its sparkline + typical caption,
+/// rendered from the shared [SleepModel].
+struct NightDetailCard: View {
+    let model: SleepModel
+
+    private let tileColumns = [GridItem(.adaptive(minimum: 168), spacing: NoopMetrics.gap)]
+
+    var body: some View {
+        // Per-tile latest value + history series (for the sparkline) + typical mean.
+        // All seven series are computed ONCE in the model build (each is a full pass over
+        // repo.days/repo.sleeps) — here we only read the memoized results.
+        let perf  = model.performance
+        let eff   = model.efficiency
+        let cons  = model.consistency
+        let need  = model.hoursVsNeeded
+        let rest  = model.restorative
+        let resp  = model.respiratory
+        let debt  = model.sleepDebt
+
+        VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+            SectionHeader("Night detail", overline: "Metrics")
+
+            #if os(iOS)
+            // On iOS, Sleep Debt is the actionable summary for the section, so it leads at the
+            // full two-column width. The remaining six peer metrics keep the established 2 × 3 grid.
+            StatTile(
+                label: "Sleep Debt",
+                value: debt.latest.map { durationText($0) } ?? "—",
+                caption: debtCaption(debt.latest),
+                accent: debtColor(debt.latest),
+                sparkline: spark(debt.series),
+                sparkColor: StrandPalette.metricRose)
+                .frame(maxWidth: .infinity)
+            #endif
+
+            LazyVGrid(columns: tileColumns, alignment: .leading, spacing: NoopMetrics.gap) {
+
+                StatTile(
+                    label: "Rest",
+                    value: pctValue(perf.latest),
+                    caption: vsTypical(perf.latest, perf.typical, suffix: "%"),
+                    accent: perf.latest.map { StrandPalette.recoveryColor($0) } ?? StrandPalette.textPrimary,
+                    sparkline: spark(perf.series),
+                    sparkColor: StrandPalette.restColor)
+
+                StatTile(
+                    label: "Efficiency",
+                    value: pctValue(eff.latest),
+                    caption: vsTypical(eff.latest, eff.typical, suffix: "%"),
+                    accent: StrandPalette.statusPositive,
+                    sparkline: spark(eff.series),
+                    sparkColor: StrandPalette.statusPositive)
+
+                StatTile(
+                    label: "Consistency",
+                    value: pctValue(cons.latest),
+                    caption: vsTypical(cons.latest, cons.typical, suffix: "%"),
+                    accent: cons.latest.map { StrandPalette.recoveryColor($0) } ?? StrandPalette.textPrimary,
+                    sparkline: spark(cons.series),
+                    sparkColor: StrandPalette.metricCyan)
+
+                StatTile(
+                    label: "Hours vs Needed",
+                    value: pctValue(need.latest),
+                    caption: vsTypical(need.latest, need.typical, suffix: "%"),
+                    accent: need.latest.map { StrandPalette.recoveryColor(min(100, $0)) } ?? StrandPalette.textPrimary,
+                    sparkline: spark(need.series),
+                    sparkColor: StrandPalette.restColor)
+
+                StatTile(
+                    label: "Restorative",
+                    value: pctValue(rest.latest),
+                    caption: vsTypical(rest.latest, rest.typical, suffix: "%"),
+                    accent: StrandPalette.sleepREM,
+                    sparkline: spark(rest.series),
+                    sparkColor: StrandPalette.sleepREM)
+
+                StatTile(
+                    label: "Respiratory",
+                    value: rrValue(resp.latest),
+                    caption: vsTypical(resp.latest, resp.typical, suffix: " rpm", decimals: 1),
+                    accent: StrandPalette.metricPurple,
+                    sparkline: spark(resp.series),
+                    sparkColor: StrandPalette.metricPurple)
+
+                #if !os(iOS)
+                // macOS keeps the original adaptive dashboard instead of stretching one
+                // phone-width summary tile across an unbounded desktop detail pane.
+                StatTile(
+                    label: "Sleep Debt",
+                    value: debt.latest.map { durationText($0) } ?? "—",
+                    caption: debtCaption(debt.latest),
+                    accent: debtColor(debt.latest),
+                    sparkline: spark(debt.series),
+                    sparkColor: StrandPalette.metricRose)
+                #endif
+            }
+        }
+    }
+
+    // MARK: - Tile formatting (verbatim lift of the metricGrid-only SleepView helpers)
+
+    private func pctValue(_ v: Double?) -> String {
+        v.map { "\(Int($0.rounded()))%" } ?? "—"
+    }
+
+    private func rrValue(_ v: Double?) -> String {
+        v.map { String(format: "%.1f", $0) } ?? "—"
+    }
+
+    /// "+12% vs typical" / "−0.4 rpm vs typical" — the latest-vs-mean caption every tile carries.
+    private func vsTypical(_ latest: Double?, _ typical: Double?, suffix: String, decimals: Int = 0) -> String {
+        guard let latest, let typical, typical != 0 else { return String(localized: "vs typical - ") }
+        let diff = latest - typical
+        let sign = diff >= 0 ? "+" : "−"
+        let mag = abs(diff)
+        let num = decimals == 0 ? "\(Int(mag.rounded()))" : String(format: "%.\(decimals)f", mag)
+        return String(localized: "\(sign)\(num)\(suffix) vs typical")
+    }
+
+    private func debtCaption(_ debt: Double?) -> String {
+        guard let debt else { return String(localized: "vs need") }
+        return debt < 15 ? String(localized: "On target") : String(localized: "Below need")
+    }
+
+    private func debtColor(_ debt: Double?) -> Color {
+        guard let debt else { return StrandPalette.textPrimary }
+        switch debt {
+        case ..<15:  return StrandPalette.statusPositive
+        case ..<60:  return StrandPalette.statusWarning
+        default:     return StrandPalette.statusCritical
+        }
+    }
+
+    /// A sparkline needs at least two points; otherwise return nil so the tile stays clean.
+    private func spark(_ series: [Double]) -> [Double]? {
+        let tail = Array(series.suffix(30))
+        return tail.count > 1 ? tail : nil
+    }
+
+    /// Minutes → "Xm" / "Yh Zm" (verbatim of `SleepView.durationText`). Kept local to the card so it
+    /// renders identically whether hosted in Today or shown in the Sleep tab.
+    private func durationText(_ minutes: Double) -> String {
+        let m = Swift.max(0, Int(minutes.rounded()))
+        if m < 60 { return String(localized: "\(m)m") }
+        return String(localized: "\(m / 60)h \(m % 60)m")
+    }
+}

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -35,9 +35,6 @@ struct SleepView: View {
     // leaf below (mirrors the Today leaf-scoping pattern), so a tick refreshes only that leaf.
     @EnvironmentObject var intelligence: IntelligenceEngine
 
-    // The standard tile grid: ONE adaptive column set, used for every tile group.
-    private let tileColumns = [GridItem(.adaptive(minimum: 168), spacing: NoopMetrics.gap)]
-
     /// Memoized snapshot of every expensive derivation (latest Night with its intervals
     /// resolved once, the seven metric series, the trend points, the typical means). Rebuilt
     /// only when the underlying repo data actually changes — NOT on hover/animation/1Hz HR
@@ -383,7 +380,7 @@ struct SleepView: View {
         switch section {
         case .sleepMarks:      SleepMarkCard()
         case .stages:          hero(model)
-        case .nightDetail:     metricGrid(model)
+        case .nightDetail:     NightDetailCard(model: model)
         case .sleepDebt:       sleepDebtLedger(model)
         case .stagesVsTypical: StagesVsTypicalCard(model: model)
         case .asleepDuration:  durationTrend(model)
@@ -1554,100 +1551,11 @@ struct SleepView: View {
     }
 
     // MARK: - 2. Metric grid (UNIFORM fixed-height StatTiles, each with sparkline)
-
-    @ViewBuilder
-    private func metricGrid(_ model: SleepModel) -> some View {
-        // Per-tile latest value + history series (for the sparkline) + typical mean.
-        // All seven series are computed ONCE in the model build (each is a full pass over
-        // repo.days/repo.sleeps) — here we only read the memoized results.
-        let perf  = model.performance
-        let eff   = model.efficiency
-        let cons  = model.consistency
-        let need  = model.hoursVsNeeded
-        let rest  = model.restorative
-        let resp  = model.respiratory
-        let debt  = model.sleepDebt
-
-        VStack(alignment: .leading, spacing: NoopMetrics.gap) {
-            SectionHeader("Night detail", overline: "Metrics")
-
-            #if os(iOS)
-            // On iOS, Sleep Debt is the actionable summary for the section, so it leads at the
-            // full two-column width. The remaining six peer metrics keep the established 2 × 3 grid.
-            StatTile(
-                label: "Sleep Debt",
-                value: debt.latest.map { durationText($0) } ?? "—",
-                caption: debtCaption(debt.latest),
-                accent: debtColor(debt.latest),
-                sparkline: spark(debt.series),
-                sparkColor: StrandPalette.metricRose)
-                .frame(maxWidth: .infinity)
-            #endif
-
-            LazyVGrid(columns: tileColumns, alignment: .leading, spacing: NoopMetrics.gap) {
-
-                StatTile(
-                    label: "Rest",
-                    value: pctValue(perf.latest),
-                    caption: vsTypical(perf.latest, perf.typical, suffix: "%"),
-                    accent: perf.latest.map { StrandPalette.recoveryColor($0) } ?? StrandPalette.textPrimary,
-                    sparkline: spark(perf.series),
-                    sparkColor: StrandPalette.restColor)
-
-                StatTile(
-                    label: "Efficiency",
-                    value: pctValue(eff.latest),
-                    caption: vsTypical(eff.latest, eff.typical, suffix: "%"),
-                    accent: StrandPalette.statusPositive,
-                    sparkline: spark(eff.series),
-                    sparkColor: StrandPalette.statusPositive)
-
-                StatTile(
-                    label: "Consistency",
-                    value: pctValue(cons.latest),
-                    caption: vsTypical(cons.latest, cons.typical, suffix: "%"),
-                    accent: cons.latest.map { StrandPalette.recoveryColor($0) } ?? StrandPalette.textPrimary,
-                    sparkline: spark(cons.series),
-                    sparkColor: StrandPalette.metricCyan)
-
-                StatTile(
-                    label: "Hours vs Needed",
-                    value: pctValue(need.latest),
-                    caption: vsTypical(need.latest, need.typical, suffix: "%"),
-                    accent: need.latest.map { StrandPalette.recoveryColor(min(100, $0)) } ?? StrandPalette.textPrimary,
-                    sparkline: spark(need.series),
-                    sparkColor: StrandPalette.restColor)
-
-                StatTile(
-                    label: "Restorative",
-                    value: pctValue(rest.latest),
-                    caption: vsTypical(rest.latest, rest.typical, suffix: "%"),
-                    accent: StrandPalette.sleepREM,
-                    sparkline: spark(rest.series),
-                    sparkColor: StrandPalette.sleepREM)
-
-                StatTile(
-                    label: "Respiratory",
-                    value: rrValue(resp.latest),
-                    caption: vsTypical(resp.latest, resp.typical, suffix: " rpm", decimals: 1),
-                    accent: StrandPalette.metricPurple,
-                    sparkline: spark(resp.series),
-                    sparkColor: StrandPalette.metricPurple)
-
-                #if !os(iOS)
-                // macOS keeps the original adaptive dashboard instead of stretching one
-                // phone-width summary tile across an unbounded desktop detail pane.
-                StatTile(
-                    label: "Sleep Debt",
-                    value: debt.latest.map { durationText($0) } ?? "—",
-                    caption: debtCaption(debt.latest),
-                    accent: debtColor(debt.latest),
-                    sparkline: spark(debt.series),
-                    sparkColor: StrandPalette.metricRose)
-                #endif
-            }
-        }
-    }
+    //
+    // The "Night detail" grid now lives in `NightDetailCard` (a standalone view) so it can ALSO be hosted
+    // in the Today tab from the SAME `SleepModel`. `sleepSectionView(.nightDetail)` renders `NightDetailCard`
+    // directly; the grid body and its tile-formatting helpers (`pctValue` / `rrValue` / `vsTypical` /
+    // `debtCaption` / `debtColor` / `spark` / `tileColumns`) moved there with it.
 
     // MARK: - 2b. Sleep-debt ledger (rolling 14-night running balance)
 
@@ -2100,37 +2008,8 @@ struct SleepView: View {
         total > 0 ? Int((minutes / total * 100).rounded()) : 0
     }
 
-    private func pctValue(_ v: Double?) -> String {
-        v.map { "\(Int($0.rounded()))%" } ?? "—"
-    }
-
-    private func rrValue(_ v: Double?) -> String {
-        v.map { String(format: "%.1f", $0) } ?? "—"
-    }
-
-    /// "+12% vs typical" / "−0.4 rpm vs typical" — the latest-vs-mean caption every tile carries.
-    private func vsTypical(_ latest: Double?, _ typical: Double?, suffix: String, decimals: Int = 0) -> String {
-        guard let latest, let typical, typical != 0 else { return String(localized: "vs typical - ") }
-        let diff = latest - typical
-        let sign = diff >= 0 ? "+" : "−"
-        let mag = abs(diff)
-        let num = decimals == 0 ? "\(Int(mag.rounded()))" : String(format: "%.\(decimals)f", mag)
-        return String(localized: "\(sign)\(num)\(suffix) vs typical")
-    }
-
-    private func debtCaption(_ debt: Double?) -> String {
-        guard let debt else { return String(localized: "vs need") }
-        return debt < 15 ? String(localized: "On target") : String(localized: "Below need")
-    }
-
-    private func debtColor(_ debt: Double?) -> Color {
-        guard let debt else { return StrandPalette.textPrimary }
-        switch debt {
-        case ..<15:  return StrandPalette.statusPositive
-        case ..<60:  return StrandPalette.statusWarning
-        default:     return StrandPalette.statusCritical
-        }
-    }
+    // The metric-grid tile formatters (`pctValue` / `rrValue` / `vsTypical` / `debtCaption` / `debtColor`)
+    // moved to `NightDetailCard` with the grid; they had no other caller in SleepView.
 
     // MARK: - Sleep-debt ledger formatting
 
@@ -2209,11 +2088,7 @@ struct SleepView: View {
         return String(localized: "\(m / 60)h \(m % 60)m")
     }
 
-    /// A sparkline needs at least two points; otherwise return nil so the tile stays clean.
-    private func spark(_ series: [Double]) -> [Double]? {
-        let tail = Array(series.suffix(30))
-        return tail.count > 1 ? tail : nil
-    }
+    // The metric-grid `spark(_:)` sparkline helper moved to `NightDetailCard` with the grid.
 
     // MARK: - Stage decoding
 

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -2220,6 +2220,21 @@ struct TodayView: View {
                         .background(NoopPanelSurface(tint: StrandPalette.restColor, cornerRadius: 12))
                 }
             }
+        case .nightDetail:
+            // Renders from the shared SleepModel built in loadAll() (same inputs as the Sleep tab). Until the
+            // async build lands — or with no usable latest night — show the graceful placeholder, as above.
+            if let m = hostedSleepModel {
+                NightDetailCard(model: m)
+            } else {
+                VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+                    SectionHeader("Night detail", overline: "Metrics")
+                    Text("Not enough nights yet.")
+                        .font(StrandFont.subhead)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                        .frame(maxWidth: .infinity, minHeight: 60, alignment: .center)
+                        .background(NoopPanelSurface(tint: StrandPalette.restColor, cornerRadius: 12))
+                }
+            }
         }
     }
 

--- a/android/app/src/main/java/com/noop/ui/HostedCards.kt
+++ b/android/app/src/main/java/com/noop/ui/HostedCards.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Bedtime
+import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.StackedBarChart
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -41,7 +42,11 @@ enum class HostedCard(
     ASLEEP_DURATION("sleep.asleepDuration", "Asleep duration", "Sleep", Icons.Filled.BarChart),
     /** Sleep tab · "Stages vs typical" — last night's Deep/REM/Light vs the wearer's personal per-stage
      *  means (#today-hosted-cards). First of the SleepModel-backed sleep cards hosted in Today. */
-    STAGES_VS_TYPICAL("sleep.stagesVsTypical", "Stages vs typical", "Sleep", Icons.Filled.StackedBarChart);
+    STAGES_VS_TYPICAL("sleep.stagesVsTypical", "Stages vs typical", "Sleep", Icons.Filled.StackedBarChart),
+    /** Sleep tab · "Night detail" — the metric grid (Rest/Efficiency/Consistency/Hours vs Needed/
+     *  Restorative/Respiratory/Sleep Debt) from the wearer's SleepModel (#today-hosted-cards). Second of
+     *  the SleepModel-backed sleep cards hosted in Today. */
+    NIGHT_DETAIL("sleep.nightDetail", "Night detail", "Sleep", Icons.Filled.GridView);
 
     companion object {
         fun fromRaw(raw: String?): HostedCard? = entries.firstOrNull { it.raw == raw }
@@ -65,6 +70,7 @@ fun HostedCard.localizedTitle(): String = when (this) {
     HostedCard.SLEEP_MARKS -> stringResource(R.string.l10n_sleep_screen_sleep_marks_8e9b86f0)
     HostedCard.ASLEEP_DURATION -> stringResource(R.string.l10n_sleep_screen_asleep_duration_3638413f)
     HostedCard.STAGES_VS_TYPICAL -> stringResource(R.string.l10n_sleep_screen_stages_vs_typical_28463f24)
+    HostedCard.NIGHT_DETAIL -> stringResource(R.string.l10n_sleep_screen_night_detail_8f271bcf)
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -735,7 +735,7 @@ fun SleepScreen(
                         SleepReorderableSection(k, sleepListState, sleepSectionDrag, persistSleepOrder) {
                             Column {
                                 Spacer(Modifier.height(Metrics.selectorTopUp))
-                                MetricGrid(m, onMetricClick = { detailMetricKey = it })
+                                NightDetailHostCard(m, onMetricClick = { detailMetricKey = it })
                             }
                         }
                     }
@@ -2368,6 +2368,18 @@ private fun NightNavHeader(
 }
 
 // MARK: - 2. Metric grid (row-equalized min-height tiles, each with a bottom sparkline)
+
+/**
+ * #today-hosted-cards: the "Night detail" metric grid rendered from the shared [SleepModel]. `internal` so
+ * the Today host (TodayScreen) can render the SAME grid the Sleep tab does (a mirror, not a copy); lives
+ * here so its [MetricGrid]/[SparkTile] siblings stay in-file. Twin of the iOS `NightDetailCard`. The Sleep
+ * tab passes an [onMetricClick] to open per-metric detail; the Today host omits it (no detail sheet there),
+ * so the tiles render read-only when hosted.
+ */
+@Composable
+internal fun NightDetailHostCard(m: SleepModel, onMetricClick: (String) -> Unit = {}) {
+    MetricGrid(m, onMetricClick = onMetricClick)
+}
 
 @Composable
 private fun MetricGrid(m: SleepModel, onMetricClick: (String) -> Unit = {}) {

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3074,7 +3074,7 @@ private fun HostedCardsSection(cards: List<HostedCard>, days: List<DailyMetric>,
     // follow). Build the shared model ONCE, and only when at least one such card is actually hosted, so a
     // Today hosting none pays no cost. Same inputs + builder as the Sleep tab (buildHostedSleepModel), so
     // hosted numbers match the Sleep tab. Reused by every model-backed card. Twin of the iOS hostedSleepModel.
-    val modelBackedHosted = setOf(HostedCard.STAGES_VS_TYPICAL)
+    val modelBackedHosted = setOf(HostedCard.STAGES_VS_TYPICAL, HostedCard.NIGHT_DETAIL)
     val needsSleepModel = cards.any { it in modelBackedHosted }
     var hostedSleepModel by remember { mutableStateOf<SleepModel?>(null) }
     LaunchedEffect(needsSleepModel, days, viewModel.activeStrapId) {
@@ -3111,6 +3111,10 @@ private fun HostedCardsSection(cards: List<HostedCard>, days: List<DailyMetric>,
                 // lands — or on a device with no stage data — the model is null and the slot renders nothing
                 // this frame, matching how the Sleep tab guards the section on a null model.
                 HostedCard.STAGES_VS_TYPICAL -> hostedSleepModel?.let { StagesVsTypicalHostCard(it) }
+                // #today-hosted-cards: the Night-detail metric grid, rendered from the SAME shared SleepModel
+                // the Sleep tab uses (mirror, not copy). Null until the async build lands / no stage data —
+                // the slot renders nothing this frame, matching the Sleep tab's null-model guard.
+                HostedCard.NIGHT_DETAIL -> hostedSleepModel?.let { NightDetailHostCard(it) }
             }
         }
     }


### PR DESCRIPTION
Card 2 of the hosted sleep cards. Standalone NightDetailCard(model:) (lift of SleepView.metricGrid) rendered by both Sleep tab + Today host from the same SleepModel. HostedCard.nightDetail (byte-identical sleep.nightDetail, existing localized title). Reuses card-1's Today-host plumbing. Android NightDetailHostCard preserves Sleep-tab metric-detail nav; Today is read-only. Android compile + i18n green; Swift via app-build gate.