### PR TITLE
feat(today): host the Sleep-debt-ledger sleep card

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -684,6 +684,14 @@ struct LiquidTodayView: View {
             } else {
                 hostedNightDetailPlaceholder
             }
+        case .sleepDebt:
+            // Renders from the same shared SleepModel built in load(). Until that async build lands — or on a
+            // device with no usable latest night — show the graceful placeholder, mirroring stagesVsTypical.
+            if let m = hostedSleepModel {
+                SleepDebtLedgerCard(model: m)
+            } else {
+                hostedSleepDebtPlaceholder
+            }
         }
     }
 
@@ -707,6 +715,20 @@ struct LiquidTodayView: View {
     private var hostedNightDetailPlaceholder: some View {
         VStack(alignment: .leading, spacing: NoopMetrics.gap) {
             SectionHeader("Night detail", overline: "Metrics")
+            Text("Not enough nights yet.")
+                .font(StrandFont.subhead)
+                .foregroundStyle(StrandPalette.textTertiary)
+                .frame(maxWidth: .infinity, minHeight: 60, alignment: .center)
+                .background(NoopPanelSurface(tint: StrandPalette.restColor, cornerRadius: 12))
+        }
+    }
+
+    /// Graceful empty state for the hosted "Sleep-debt ledger" before its shared SleepModel builds (first
+    /// frame) or when there is no usable latest night. Same treatment as `hostedSleepPlaceholder`, labelled
+    /// for this card so add/remove/reorder in Customise still reads. #today-hosted-cards.
+    private var hostedSleepDebtPlaceholder: some View {
+        VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+            SectionHeader("Sleep-debt ledger", overline: "Last 14 nights")
             Text("Not enough nights yet.")
                 .font(StrandFont.subhead)
                 .foregroundStyle(StrandPalette.textTertiary)

--- a/Strand/Screens/HostedCards.swift
+++ b/Strand/Screens/HostedCards.swift
@@ -28,6 +28,10 @@ enum HostedCard: String, CaseIterable, Identifiable {
     /// Restorative/Respiratory/Sleep Debt) rendered from the wearer's `SleepModel` (#today-hosted-cards).
     /// Second of the SleepModel-backed sleep cards hosted in Today.
     case nightDetail = "sleep.nightDetail"
+    /// Sleep tab · "Sleep-debt ledger" — the rolling 14-night running balance of (slept − personal
+    /// need) rendered from the wearer's `SleepModel` (#today-hosted-cards). Third of the SleepModel-backed
+    /// sleep cards hosted in Today.
+    case sleepDebt = "sleep.sleepDebt"
 
     var id: String { rawValue }
 
@@ -38,6 +42,7 @@ enum HostedCard: String, CaseIterable, Identifiable {
         case .asleepDuration: return String(localized: "Asleep duration")
         case .stagesVsTypical: return String(localized: "Stages vs typical")
         case .nightDetail: return String(localized: "Night detail")
+        case .sleepDebt: return String(localized: "Sleep-debt ledger")
         }
     }
 
@@ -45,7 +50,7 @@ enum HostedCard: String, CaseIterable, Identifiable {
     /// Trends". Matches the Android `HostedCard.origin`.
     var origin: String {
         switch self {
-        case .sleepMarks, .asleepDuration, .stagesVsTypical, .nightDetail: return String(localized: "Sleep")
+        case .sleepMarks, .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt: return String(localized: "Sleep")
         }
     }
 
@@ -56,13 +61,14 @@ enum HostedCard: String, CaseIterable, Identifiable {
         case .asleepDuration: return "chart.bar.xaxis"
         case .stagesVsTypical: return "chart.bar.doc.horizontal"
         case .nightDetail: return "square.grid.2x2"
+        case .sleepDebt: return "scalemass"
         }
     }
 
     /// Editor row tint.
     var customizationTint: Color {
         switch self {
-        case .sleepMarks, .asleepDuration, .stagesVsTypical, .nightDetail: return StrandPalette.restColor
+        case .sleepMarks, .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt: return StrandPalette.restColor
         }
     }
 

--- a/Strand/Screens/SleepDebtLedgerCard.swift
+++ b/Strand/Screens/SleepDebtLedgerCard.swift
@@ -1,0 +1,161 @@
+import SwiftUI
+import StrandDesign
+import StrandAnalytics
+import WhoopStore
+
+// MARK: - Sleep-debt ledger (#today-hosted-cards)
+//
+// The Sleep tab's "Sleep-debt ledger" card, extracted into a standalone view so it can ALSO be hosted in
+// the Today tab. Both the Sleep tab and the Today host render THIS view from the SAME `SleepModel`, so the
+// rolling 14-night running balance can never diverge between the two surfaces (the parity contract). The
+// card body + its `debtDeltaBars` strip and the debt-only formatting helpers (`debtHeadline` /
+// `debtTag` / `debtRead` / `debtBalanceColor` / `debtSigned`) are a verbatim lift of the former
+// `SleepView.sleepDebtLedger` (and the helpers only it used); the nap-credited ledger is computed once in
+// `SleepModel.build` (the shared builder) and read here — it is NOT recomputed.
+
+/// The "Sleep-debt ledger" card. A running balance of (slept − personal need) across the recent
+/// fortnight — the net debt/surplus headline, a plain-English read, and a diverging per-night delta bar —
+/// rendered from the shared [SleepModel]'s `sleepDebtLedger`. (#242)
+struct SleepDebtLedgerCard: View {
+    let model: SleepModel
+
+    var body: some View {
+        let ledger = model.sleepDebtLedger
+        VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+            SectionHeader("Sleep-debt ledger", overline: "Last 14 nights")
+            NoopCard(tint: StrandPalette.restColor) {
+                if ledger.nightCount == 0 {
+                    Text("No nights with sleep data yet. Your ledger fills in as you wear the strap to bed.")
+                        .font(StrandFont.subhead)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    VStack(alignment: .leading, spacing: NoopMetrics.space4) {
+                        // Headline: net balance (count-up on appear) + the short tag (DEBT / SURPLUS / ON
+                        // TARGET). The number ticks from the accumulated magnitude via the same formatter.
+                        HStack(alignment: .firstTextBaseline) {
+                            CountUpText(
+                                value: ledger.magnitudeMin,
+                                format: { debtHeadline(forMagnitudeMin: $0, ledger: ledger) },
+                                font: StrandFont.number(26),
+                                color: debtBalanceColor(ledger)
+                            )
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.6)
+                            Spacer(minLength: NoopMetrics.space2)
+                            Text(debtTag(ledger))
+                                .font(StrandFont.captionNumber)
+                                .foregroundStyle(debtBalanceColor(ledger))
+                        }
+                        // Plain-English read.
+                        Text(debtRead(ledger))
+                            .font(StrandFont.subhead)
+                            .foregroundStyle(StrandPalette.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                        // Per-night diverging delta bars (surplus up, deficit down).
+                        debtDeltaBars(ledger)
+                        Divider().overlay(StrandPalette.hairline)
+                        ChartFooter([
+                            ("Balance", debtSigned(ledger.balanceMin)),
+                            ("Per-night need", durationText(ledger.needMin)),
+                            ("Nights", "\(ledger.nightCount)"),
+                        ])
+                    }
+                }
+            }
+        }
+    }
+
+    /// The diverging per-night delta strip: each night a bar from the centre line — up
+    /// (accent) for a surplus, down (rose) for a deficit — scaled to the largest |delta|.
+    @ViewBuilder
+    private func debtDeltaBars(_ ledger: SleepDebtLedger) -> some View {
+        let deltas = ledger.nights.map { $0.deltaMin }
+        let scale = max(deltas.map { abs($0) }.max() ?? 1, 1)
+        GeometryReader { geo in
+            let n = max(deltas.count, 1)
+            let slot = geo.size.width / CGFloat(n)
+            let barW = max(2, slot * 0.6)
+            let midY = geo.size.height / 2
+            ZStack(alignment: .topLeading) {
+                // Centre (zero) line.
+                Rectangle()
+                    .fill(StrandPalette.hairline)
+                    .frame(height: 1)
+                    .position(x: geo.size.width / 2, y: midY)
+                ForEach(Array(deltas.enumerated()), id: \.offset) { i, d in
+                    let frac = CGFloat(abs(d) / scale)
+                    let h = max(2, frac * (midY - 2))
+                    let x = slot * CGFloat(i) + slot / 2
+                    RoundedRectangle(cornerRadius: 2, style: .continuous)
+                        .fill(d >= 0 ? StrandPalette.accent : StrandPalette.metricRose)
+                        .frame(width: barW, height: h)
+                        // Surplus grows upward from the centre, deficit downward.
+                        .position(x: x, y: d >= 0 ? midY - h / 2 : midY + h / 2)
+                }
+            }
+        }
+        .frame(height: 56)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Per-night sleep balance: \(ledger.nightCount) nights, net \(debtSigned(ledger.balanceMin))")
+    }
+
+    // MARK: - Sleep-debt ledger formatting (verbatim lift of the ledger-only SleepView helpers)
+
+
+    /// The same headline formatter, but for an arbitrary (interpolated) magnitude so `CountUpText` can
+    /// render a coherent string on every frame as the number ticks up. The on-target deadband check
+    /// uses the LIVE magnitude `m` so the headline crosses from "On target" to "≈…" mid-count exactly
+    /// once, matching the final reading. Final-value identical to `debtHeadline(_:)`.
+    private func debtHeadline(forMagnitudeMin m: Double, ledger: SleepDebtLedger) -> String {
+        if m < SleepDebt.onTargetBandMin { return String(localized: "On target") }
+        return "≈\(durationText(m))"
+    }
+
+    /// Short tag under/beside the headline: DEBT / SURPLUS / ON TARGET.
+    private func debtTag(_ ledger: SleepDebtLedger) -> String {
+        if ledger.magnitudeMin < SleepDebt.onTargetBandMin { return String(localized: "balanced") }
+        return ledger.isDebt ? String(localized: "sleep debt") : String(localized: "surplus")
+    }
+
+    /// Plain-English read of the running balance over the window.
+    private func debtRead(_ ledger: SleepDebtLedger) -> String {
+        let nights = ledger.nightCount
+        let span = nights == 1
+            ? String(localized: "the last night")
+            : String(localized: "the last \(nights) nights")
+        if ledger.magnitudeMin < SleepDebt.onTargetBandMin {
+            return String(localized: "You're roughly on top of your sleep across \(span). Slept minutes balance out against your need.")
+        }
+        let mag = durationText(ledger.magnitudeMin)
+        if ledger.isDebt {
+            return String(localized: "You've banked about \(mag) of sleep debt over \(span). Surplus nights count back against it. An earlier night or two would clear it.")
+        }
+        return String(localized: "You're carrying about \(mag) of surplus over \(span). You've slept past your need on balance. Nicely ahead.")
+    }
+
+    /// Color the balance by sign + size: surplus/within-band → positive green, modest
+    /// debt → warning, heavier debt → critical.
+    private func debtBalanceColor(_ ledger: SleepDebtLedger) -> Color {
+        if ledger.magnitudeMin < SleepDebt.onTargetBandMin || !ledger.isDebt {
+            return StrandPalette.statusPositive
+        }
+        // A debt: amber up to ~3 h accumulated, red beyond.
+        return ledger.magnitudeMin < 180 ? StrandPalette.statusWarning : StrandPalette.statusCritical
+    }
+
+    /// Signed "+1h 20m" / "−2h 10m" / "0m" balance string.
+    private func debtSigned(_ minutes: Double) -> String {
+        if abs(minutes) < 1 { return String(localized: "0m") }
+        let sign = minutes >= 0 ? "+" : "−"
+        return "\(sign)\(durationText(abs(minutes)))"
+    }
+
+    /// Minutes → "Xm" / "Yh Zm" (verbatim of `SleepView.durationText`). Kept local to the card so it
+    /// renders identically whether hosted in Today or shown in the Sleep tab.
+    private func durationText(_ minutes: Double) -> String {
+        let m = Swift.max(0, Int(minutes.rounded()))
+        if m < 60 { return String(localized: "\(m)m") }
+        return String(localized: "\(m / 60)h \(m % 60)m")
+    }
+}

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -381,7 +381,7 @@ struct SleepView: View {
         case .sleepMarks:      SleepMarkCard()
         case .stages:          hero(model)
         case .nightDetail:     NightDetailCard(model: model)
-        case .sleepDebt:       sleepDebtLedger(model)
+        case .sleepDebt:       SleepDebtLedgerCard(model: model)
         case .stagesVsTypical: StagesVsTypicalCard(model: model)
         case .asleepDuration:  durationTrend(model)
         }
@@ -1557,94 +1557,11 @@ struct SleepView: View {
     // directly; the grid body and its tile-formatting helpers (`pctValue` / `rrValue` / `vsTypical` /
     // `debtCaption` / `debtColor` / `spark` / `tileColumns`) moved there with it.
 
-    // MARK: - 2b. Sleep-debt ledger (rolling 14-night running balance)
-
-    /// A running balance of (slept − personal need) across the recent fortnight, surfaced
-    /// as one card: the net debt/surplus headline, a plain-English read, and a diverging
-    /// bar of each night's delta (surplus above the line, deficit below). Honest: a simple
-    /// accumulator — a surplus night offsets a deficit one — capped at 14 nights, no-data
-    /// nights skipped. (#242)
-    @ViewBuilder
-    private func sleepDebtLedger(_ model: SleepModel) -> some View {
-        let ledger = model.sleepDebtLedger
-        VStack(alignment: .leading, spacing: NoopMetrics.gap) {
-            SectionHeader("Sleep-debt ledger", overline: "Last 14 nights")
-            NoopCard(tint: StrandPalette.restColor) {
-                if ledger.nightCount == 0 {
-                    Text("No nights with sleep data yet. Your ledger fills in as you wear the strap to bed.")
-                        .font(StrandFont.subhead)
-                        .foregroundStyle(StrandPalette.textTertiary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                } else {
-                    VStack(alignment: .leading, spacing: NoopMetrics.space4) {
-                        // Headline: net balance (count-up on appear) + the short tag (DEBT / SURPLUS / ON
-                        // TARGET). The number ticks from the accumulated magnitude via the same formatter.
-                        HStack(alignment: .firstTextBaseline) {
-                            CountUpText(
-                                value: ledger.magnitudeMin,
-                                format: { debtHeadline(forMagnitudeMin: $0, ledger: ledger) },
-                                font: StrandFont.number(26),
-                                color: debtBalanceColor(ledger)
-                            )
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.6)
-                            Spacer(minLength: NoopMetrics.space2)
-                            Text(debtTag(ledger))
-                                .font(StrandFont.captionNumber)
-                                .foregroundStyle(debtBalanceColor(ledger))
-                        }
-                        // Plain-English read.
-                        Text(debtRead(ledger))
-                            .font(StrandFont.subhead)
-                            .foregroundStyle(StrandPalette.textSecondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                        // Per-night diverging delta bars (surplus up, deficit down).
-                        debtDeltaBars(ledger)
-                        Divider().overlay(StrandPalette.hairline)
-                        ChartFooter([
-                            ("Balance", debtSigned(ledger.balanceMin)),
-                            ("Per-night need", durationText(ledger.needMin)),
-                            ("Nights", "\(ledger.nightCount)"),
-                        ])
-                    }
-                }
-            }
-        }
-    }
-
-    /// The diverging per-night delta strip: each night a bar from the centre line — up
-    /// (accent) for a surplus, down (rose) for a deficit — scaled to the largest |delta|.
-    @ViewBuilder
-    private func debtDeltaBars(_ ledger: SleepDebtLedger) -> some View {
-        let deltas = ledger.nights.map { $0.deltaMin }
-        let scale = max(deltas.map { abs($0) }.max() ?? 1, 1)
-        GeometryReader { geo in
-            let n = max(deltas.count, 1)
-            let slot = geo.size.width / CGFloat(n)
-            let barW = max(2, slot * 0.6)
-            let midY = geo.size.height / 2
-            ZStack(alignment: .topLeading) {
-                // Centre (zero) line.
-                Rectangle()
-                    .fill(StrandPalette.hairline)
-                    .frame(height: 1)
-                    .position(x: geo.size.width / 2, y: midY)
-                ForEach(Array(deltas.enumerated()), id: \.offset) { i, d in
-                    let frac = CGFloat(abs(d) / scale)
-                    let h = max(2, frac * (midY - 2))
-                    let x = slot * CGFloat(i) + slot / 2
-                    RoundedRectangle(cornerRadius: 2, style: .continuous)
-                        .fill(d >= 0 ? StrandPalette.accent : StrandPalette.metricRose)
-                        .frame(width: barW, height: h)
-                        // Surplus grows upward from the centre, deficit downward.
-                        .position(x: x, y: d >= 0 ? midY - h / 2 : midY + h / 2)
-                }
-            }
-        }
-        .frame(height: 56)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Per-night sleep balance: \(ledger.nightCount) nights, net \(debtSigned(ledger.balanceMin))")
-    }
+    // The "Sleep-debt ledger" card now lives in `SleepDebtLedgerCard` (a standalone view) so it can ALSO
+    // be hosted in the Today tab from the SAME `SleepModel`. `sleepSectionView(.sleepDebt)` renders
+    // `SleepDebtLedgerCard` directly; the card body, its `debtDeltaBars` strip and the debt-only
+    // formatters (`debtHeadline` / `debtTag` / `debtRead` / `debtBalanceColor` / `debtSigned`) moved there
+    // with it — they had no other caller in SleepView.
 
     // MARK: - 4. 30-day asleep-hours trend
 
@@ -2011,61 +1928,8 @@ struct SleepView: View {
     // The metric-grid tile formatters (`pctValue` / `rrValue` / `vsTypical` / `debtCaption` / `debtColor`)
     // moved to `NightDetailCard` with the grid; they had no other caller in SleepView.
 
-    // MARK: - Sleep-debt ledger formatting
-
-    /// "≈2h 10m" magnitude headline — leading "≈" because it's an accumulated estimate.
-    /// Reads "On target" inside the deadband so a few stray minutes don't show as debt.
-    private func debtHeadline(_ ledger: SleepDebtLedger) -> String {
-        debtHeadline(forMagnitudeMin: ledger.magnitudeMin, ledger: ledger)
-    }
-
-    /// The same headline formatter, but for an arbitrary (interpolated) magnitude so `CountUpText` can
-    /// render a coherent string on every frame as the number ticks up. The on-target deadband check
-    /// uses the LIVE magnitude `m` so the headline crosses from "On target" to "≈…" mid-count exactly
-    /// once, matching the final reading. Final-value identical to `debtHeadline(_:)`.
-    private func debtHeadline(forMagnitudeMin m: Double, ledger: SleepDebtLedger) -> String {
-        if m < SleepDebt.onTargetBandMin { return String(localized: "On target") }
-        return "≈\(durationText(m))"
-    }
-
-    /// Short tag under/beside the headline: DEBT / SURPLUS / ON TARGET.
-    private func debtTag(_ ledger: SleepDebtLedger) -> String {
-        if ledger.magnitudeMin < SleepDebt.onTargetBandMin { return String(localized: "balanced") }
-        return ledger.isDebt ? String(localized: "sleep debt") : String(localized: "surplus")
-    }
-
-    /// Plain-English read of the running balance over the window.
-    private func debtRead(_ ledger: SleepDebtLedger) -> String {
-        let nights = ledger.nightCount
-        let span = nights == 1
-            ? String(localized: "the last night")
-            : String(localized: "the last \(nights) nights")
-        if ledger.magnitudeMin < SleepDebt.onTargetBandMin {
-            return String(localized: "You're roughly on top of your sleep across \(span). Slept minutes balance out against your need.")
-        }
-        let mag = durationText(ledger.magnitudeMin)
-        if ledger.isDebt {
-            return String(localized: "You've banked about \(mag) of sleep debt over \(span). Surplus nights count back against it. An earlier night or two would clear it.")
-        }
-        return String(localized: "You're carrying about \(mag) of surplus over \(span). You've slept past your need on balance. Nicely ahead.")
-    }
-
-    /// Color the balance by sign + size: surplus/within-band → positive green, modest
-    /// debt → warning, heavier debt → critical.
-    private func debtBalanceColor(_ ledger: SleepDebtLedger) -> Color {
-        if ledger.magnitudeMin < SleepDebt.onTargetBandMin || !ledger.isDebt {
-            return StrandPalette.statusPositive
-        }
-        // A debt: amber up to ~3 h accumulated, red beyond.
-        return ledger.magnitudeMin < 180 ? StrandPalette.statusWarning : StrandPalette.statusCritical
-    }
-
-    /// Signed "+1h 20m" / "−2h 10m" / "0m" balance string.
-    private func debtSigned(_ minutes: Double) -> String {
-        if abs(minutes) < 1 { return String(localized: "0m") }
-        let sign = minutes >= 0 ? "+" : "−"
-        return "\(sign)\(durationText(abs(minutes)))"
-    }
+    // The Sleep-debt ledger formatters (`debtHeadline` / `debtTag` / `debtRead` / `debtBalanceColor` /
+    // `debtSigned`) moved to `SleepDebtLedgerCard` with the card; they had no other caller in SleepView.
 
     private func efficiencyText(_ night: Night) -> String {
         let e = efficiencyPct(night)

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -2235,6 +2235,21 @@ struct TodayView: View {
                         .background(NoopPanelSurface(tint: StrandPalette.restColor, cornerRadius: 12))
                 }
             }
+        case .sleepDebt:
+            // Renders from the shared SleepModel built in loadAll() (same inputs as the Sleep tab). Until the
+            // async build lands — or with no usable latest night — show the graceful placeholder, as above.
+            if let m = hostedSleepModel {
+                SleepDebtLedgerCard(model: m)
+            } else {
+                VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+                    SectionHeader("Sleep-debt ledger", overline: "Last 14 nights")
+                    Text("Not enough nights yet.")
+                        .font(StrandFont.subhead)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                        .frame(maxWidth: .infinity, minHeight: 60, alignment: .center)
+                        .background(NoopPanelSurface(tint: StrandPalette.restColor, cornerRadius: 12))
+                }
+            }
         }
     }
 

--- a/android/app/src/main/java/com/noop/ui/HostedCards.kt
+++ b/android/app/src/main/java/com/noop/ui/HostedCards.kt
@@ -2,6 +2,7 @@ package com.noop.ui
 
 import android.content.Context
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Balance
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.material.icons.filled.GridView
@@ -46,7 +47,11 @@ enum class HostedCard(
     /** Sleep tab · "Night detail" — the metric grid (Rest/Efficiency/Consistency/Hours vs Needed/
      *  Restorative/Respiratory/Sleep Debt) from the wearer's SleepModel (#today-hosted-cards). Second of
      *  the SleepModel-backed sleep cards hosted in Today. */
-    NIGHT_DETAIL("sleep.nightDetail", "Night detail", "Sleep", Icons.Filled.GridView);
+    NIGHT_DETAIL("sleep.nightDetail", "Night detail", "Sleep", Icons.Filled.GridView),
+    /** Sleep tab · "Sleep-debt ledger" — the rolling 14-night running balance of (slept − personal need)
+     *  from the wearer's SleepModel (#today-hosted-cards). Third of the SleepModel-backed sleep cards
+     *  hosted in Today. */
+    SLEEP_DEBT("sleep.sleepDebt", "Sleep-debt ledger", "Sleep", Icons.Filled.Balance);
 
     companion object {
         fun fromRaw(raw: String?): HostedCard? = entries.firstOrNull { it.raw == raw }
@@ -71,6 +76,7 @@ fun HostedCard.localizedTitle(): String = when (this) {
     HostedCard.ASLEEP_DURATION -> stringResource(R.string.l10n_sleep_screen_asleep_duration_3638413f)
     HostedCard.STAGES_VS_TYPICAL -> stringResource(R.string.l10n_sleep_screen_stages_vs_typical_28463f24)
     HostedCard.NIGHT_DETAIL -> stringResource(R.string.l10n_sleep_screen_night_detail_8f271bcf)
+    HostedCard.SLEEP_DEBT -> stringResource(R.string.l10n_sleep_screen_sleep_debt_ledger_8cc9a992)
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -745,7 +745,7 @@ fun SleepScreen(
                         SleepReorderableSection(k, sleepListState, sleepSectionDrag, persistSleepOrder) {
                             Column {
                                 Spacer(Modifier.height(Metrics.selectorTopUp))
-                                SleepDebtLedgerCard(m.sleepDebtLedger)
+                                SleepDebtLedgerHostCard(m)
                             }
                         }
                     }
@@ -2480,10 +2480,14 @@ private fun MetricGrid(m: SleepModel, onMetricClick: (String) -> Unit = {}) {
  * card: the net debt/surplus headline, a plain-English read, and a diverging bar of each
  * night's delta (surplus above the centre line, deficit below). Honest: a simple accumulator
  * — a surplus night offsets a deficit one — capped at 14 nights, no-data nights skipped.
- * Mirrors the macOS SleepView sleepDebtLedger card section-for-section. (#242)
+ * Mirrors the macOS SleepDebtLedgerCard section-for-section. `internal` and keyed on the shared
+ * [SleepModel] so the Today host (TodayScreen) can render the SAME view the Sleep tab does (a mirror,
+ * not a copy); the nap-credited ledger is read from `m.sleepDebtLedger`, never recomputed here. Twin of
+ * the iOS `SleepDebtLedgerCard`. (#242) (#today-hosted-cards)
  */
 @Composable
-internal fun SleepDebtLedgerCard(ledger: SleepDebtLedger) {
+internal fun SleepDebtLedgerHostCard(m: SleepModel) {
+    val ledger = m.sleepDebtLedger
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
         SectionHeader("Sleep-debt ledger", overline = "Last 14 nights", trailing = "running balance")
         NoopCard(padding = Metrics.cardPadding, tint = Palette.restColor) {

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3074,7 +3074,7 @@ private fun HostedCardsSection(cards: List<HostedCard>, days: List<DailyMetric>,
     // follow). Build the shared model ONCE, and only when at least one such card is actually hosted, so a
     // Today hosting none pays no cost. Same inputs + builder as the Sleep tab (buildHostedSleepModel), so
     // hosted numbers match the Sleep tab. Reused by every model-backed card. Twin of the iOS hostedSleepModel.
-    val modelBackedHosted = setOf(HostedCard.STAGES_VS_TYPICAL, HostedCard.NIGHT_DETAIL)
+    val modelBackedHosted = setOf(HostedCard.STAGES_VS_TYPICAL, HostedCard.NIGHT_DETAIL, HostedCard.SLEEP_DEBT)
     val needsSleepModel = cards.any { it in modelBackedHosted }
     var hostedSleepModel by remember { mutableStateOf<SleepModel?>(null) }
     LaunchedEffect(needsSleepModel, days, viewModel.activeStrapId) {
@@ -3115,6 +3115,10 @@ private fun HostedCardsSection(cards: List<HostedCard>, days: List<DailyMetric>,
                 // the Sleep tab uses (mirror, not copy). Null until the async build lands / no stage data —
                 // the slot renders nothing this frame, matching the Sleep tab's null-model guard.
                 HostedCard.NIGHT_DETAIL -> hostedSleepModel?.let { NightDetailHostCard(it) }
+                // #today-hosted-cards: the Sleep-debt ledger, rendered from the SAME shared SleepModel the
+                // Sleep tab uses (mirror, not copy). Null until the async build lands / no stage data — the
+                // slot renders nothing this frame, matching the Sleep tab's null-model guard.
+                HostedCard.SLEEP_DEBT -> hostedSleepModel?.let { SleepDebtLedgerHostCard(it) }
             }
         }
     }


### PR DESCRIPTION
Card 3 of the hosted sleep cards. SleepDebtLedgerCard(model:) (lift of SleepView.sleepDebtLedger + debtDeltaBars) rendered by both Sleep tab + Today host from model.sleepDebtLedger (the shared nap-credited ledger). HostedCard.sleepDebt (byte-identical sleep.sleepDebt, existing localized title). Android twin. Android compile + i18n green; Swift via app-build gate.