### PR TITLE
fix(diagnostics): keep the last 3 strap-log generations, so a restart…

### DIFF
--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -568,6 +568,10 @@ public final class LiveState: ObservableObject {
     private static let trimSlack = 256
 
     public func append(log line: String, domain: TestDomain? = nil) {
+        // FIRST append of this process: rescue the previous process's durable tail into the generation ring
+        // before this process's own `persistTail` overwrites it (see `rollLogGenerationsIfNeeded`). Latched,
+        // so this is one Bool test per line after the first.
+        Self.rollLogGenerationsIfNeeded()
         // Tag inert when nil (today's behaviour, byte-identical). When tagged, prefix a compact,
         // parseable marker the export filters on. Redaction is STILL the only scrub point
         // (redactPii below); tagging happens BEFORE redaction so the scrub covers the whole line.
@@ -628,6 +632,80 @@ public final class LiveState: ObservableObject {
         (UserDefaults.standard.array(forKey: tailKey) as? [String]) ?? []
     }
 
+    // MARK: - Previous-process log generations (the "why did the app stop" record)
+
+    /// WHY THIS EXISTS. The in-memory `log` lives for the life of the PROCESS, and `exportableLogText()`
+    /// renders exactly that — so an export taken after a restart begins at the restart and the lines that
+    /// would explain the restart are gone. Worse, the single durable slot did not survive either: a fresh
+    /// process starts logging and, 32 lines in, `persistTail` OVERWRITES `strapLog.tail` with the new
+    /// (short) array, destroying the previous session's tail before anyone can read it.
+    ///
+    /// That is not hypothetical — it has now cost THREE consecutive overnight Oura captures, each time the
+    /// same way: the app restarted after wake, and the whole night (connection drops, drain timings, the
+    /// `0x6A` lines) was gone by the time the bundle was exported. An unexplained restart is exactly when
+    /// the previous lines matter most.
+    ///
+    /// So: at the first append of each process, the surviving tail is ROLLED into a small ring of previous
+    /// generations (and the live slot cleared, so a generation is never double-counted). Exports render the
+    /// generations oldest-first ahead of the current process, which keeps `report.txt` in chronological
+    /// order — the log-parsing tools read it unchanged, they simply get more of the night.
+    private static let generationsKey = "strapLog.generations"
+    /// How many previous processes to keep. Three covers the observed failure shape (a wake-time restart,
+    /// occasionally two) without turning a debug tail into a database.
+    static let maxLogGenerations = 3
+    /// Per-generation line cap — smaller than the live `tailLimit` because what explains a stop is the END
+    /// of the previous session. 3 × 1,000 short redacted lines ≈ 300 KB of UserDefaults, bounded.
+    static let generationTailLimit = 1_000
+    /// Once-per-process latch: the roll must happen BEFORE the first `persistTail` of this process, and
+    /// exactly once, or a second roll would push this process's own partial tail in as a "previous" one.
+    nonisolated(unsafe) private static var didRollGenerations = false
+
+    /// Roll the surviving durable tail into the generation ring. Idempotent per process, and a NO-OP when
+    /// the tail is empty — so a launch that logs nothing (or a run right after a roll) never pushes an
+    /// empty generation and never evicts a real one.
+    nonisolated static func rollLogGenerationsIfNeeded(now: Date = Date()) {
+        if didRollGenerations { return }
+        didRollGenerations = true
+        let tail = persistedLogTail()
+        guard !tail.isEmpty else { return }
+        let iso = ISO8601DateFormatter()
+        iso.timeZone = TimeZone(identifier: "UTC")
+        // The stamp is when the roll happened (i.e. this launch), NOT when those lines were written — the
+        // lines carry their own clock. Said plainly in the text so nobody reads it as the session's end.
+        let header = "===== previous app session, \(tail.count) line(s), rolled at "
+            + iso.string(from: now) + " (this launch) ====="
+        let clipped = tail.count > generationTailLimit ? Array(tail.suffix(generationTailLimit)) : tail
+        var gens = persistedLogGenerations()
+        gens.append([header] + clipped)
+        if gens.count > maxLogGenerations { gens.removeFirst(gens.count - maxLogGenerations) }
+        UserDefaults.standard.set(gens, forKey: generationsKey)
+        // Clear the live slot: this tail now belongs to a generation, and leaving it would duplicate it in
+        // every export until 32 fresh lines happen to overwrite it.
+        UserDefaults.standard.set([String](), forKey: tailKey)
+    }
+
+    /// The stored generations, oldest-first. Each element's first line is its own separator header.
+    nonisolated static func persistedLogGenerations() -> [[String]] {
+        (UserDefaults.standard.array(forKey: generationsKey) as? [[String]]) ?? []
+    }
+
+    /// The previous processes' lines, oldest-first, ready to sit AHEAD of the current session in an export.
+    /// Empty string when there are none, so a caller can concatenate unconditionally.
+    nonisolated static func previousSessionsText() -> String {
+        let gens = persistedLogGenerations()
+        guard !gens.isEmpty else { return "" }
+        return gens.map { $0.joined(separator: "\n") }.joined(separator: "\n") + "\n"
+            + "===== current app session =====\n"
+    }
+
+    /// Drop every stored generation (Settings → the same place the log is cleared from).
+    nonisolated static func clearLogGenerations() {
+        UserDefaults.standard.removeObject(forKey: generationsKey)
+    }
+
+    /// Tests only: clear the once-per-process latch so a test can stand in for a fresh app launch.
+    nonisolated static func resetGenerationRollLatchForTesting() { didRollGenerations = false }
+
     /// A shareable strap-log body sourced from the DURABLE tail, for a background / scheduled export that
     /// runs with no live `LiveState` instance. Mirrors `exportableLogText()`'s header so a scheduled drop
     /// reads the same as a manual share; falls back to the live `log` is not available here by design
@@ -643,7 +721,9 @@ public final class LiveState: ObservableObject {
             + ProcessInfo.processInfo.operatingSystemVersionString + "\n"
         if !extraHeaderLines.isEmpty { header += extraHeaderLines.joined(separator: "\n") + "\n" }
         header += String(repeating: "-", count: 40) + "\n"
-        return header + persistedLogTail().joined(separator: "\n")
+        // Same generations-then-current shape as `exportableLogText()`: a scheduled drop that fires after a
+        // restart must not report only the (possibly empty) current tail.
+        return header + previousSessionsText() + persistedLogTail().joined(separator: "\n")
     }
 
     /// Scrub personal identifiers from a strap-log line so it's safe to share publicly (#445): BLE MAC
@@ -690,6 +770,8 @@ public final class LiveState: ObservableObject {
         #endif
         if !extraHeaderLines.isEmpty { header += extraHeaderLines.joined(separator: "\n") + "\n" }
         header += String(repeating: "-", count: 40) + "\n"
-        return header + log.joined(separator: "\n")
+        // Previous processes first, so the body stays in chronological order and the log-parsing tools read
+        // it unchanged — they just get the night that a wake-time restart used to erase.
+        return header + Self.previousSessionsText() + log.joined(separator: "\n")
     }
 }

--- a/StrandTests/LiveStateLogGenerationsTests.swift
+++ b/StrandTests/LiveStateLogGenerationsTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import Strand
+
+/// The durable strap-log tail used to be a SINGLE slot: a fresh process began logging and, 32 lines in,
+/// `persistTail` overwrote it — so the lines that would explain an unexplained restart were destroyed by
+/// the restart itself. Three consecutive overnight Oura captures were lost exactly that way. These pin the
+/// generation ring that rescues the tail at first append.
+@MainActor
+final class LiveStateLogGenerationsTests: XCTestCase {
+    private let tailKey = "strapLog.tail"
+    private let gensKey = "strapLog.generations"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: tailKey)
+        UserDefaults.standard.removeObject(forKey: gensKey)
+        LiveState.resetGenerationRollLatchForTesting()
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: tailKey)
+        UserDefaults.standard.removeObject(forKey: gensKey)
+        LiveState.resetGenerationRollLatchForTesting()
+        super.tearDown()
+    }
+
+    /// THE ONE THAT MATTERS: a surviving tail is moved into a generation, and the live slot is cleared so
+    /// the next `persistTail` cannot destroy it.
+    func testRollMovesTheSurvivingTailIntoAGeneration() {
+        UserDefaults.standard.set(["22:01 connected", "22:02 drain done"], forKey: tailKey)
+
+        LiveState.rollLogGenerationsIfNeeded()
+
+        let gens = LiveState.persistedLogGenerations()
+        XCTAssertEqual(gens.count, 1)
+        XCTAssertEqual(gens[0].dropFirst(), ["22:01 connected", "22:02 drain done"])
+        XCTAssertTrue(gens[0][0].contains("previous app session"), "generation must carry its own header")
+        XCTAssertEqual(LiveState.persistedLogTail(), [], "the live slot must be cleared, not left to duplicate")
+    }
+
+    /// Idempotent per process: a second call must NOT push this process's own partial tail in as a
+    /// "previous" session (which would evict a real one and mislabel the current lines).
+    func testRollIsOncePerProcess() {
+        UserDefaults.standard.set(["old line"], forKey: tailKey)
+        LiveState.rollLogGenerationsIfNeeded()
+        UserDefaults.standard.set(["a line this process just wrote"], forKey: tailKey)
+
+        LiveState.rollLogGenerationsIfNeeded()
+
+        XCTAssertEqual(LiveState.persistedLogGenerations().count, 1)
+        XCTAssertEqual(LiveState.persistedLogTail(), ["a line this process just wrote"])
+    }
+
+    /// A launch that logs nothing (or one right after a roll) must not push an empty generation — that
+    /// would evict a real one, which is the opposite of the point.
+    func testEmptyTailRollsNothing() {
+        LiveState.rollLogGenerationsIfNeeded()
+        XCTAssertEqual(LiveState.persistedLogGenerations().count, 0)
+    }
+
+    /// The ring is bounded and drops the OLDEST, keeping the most recent restarts.
+    func testRingKeepsTheMostRecentGenerations() {
+        for i in 1...(LiveState.maxLogGenerations + 2) {
+            UserDefaults.standard.set(["session \(i)"], forKey: tailKey)
+            LiveState.resetGenerationRollLatchForTesting()   // stands in for a fresh process
+            LiveState.rollLogGenerationsIfNeeded()
+        }
+        let gens = LiveState.persistedLogGenerations()
+        XCTAssertEqual(gens.count, LiveState.maxLogGenerations)
+        XCTAssertEqual(gens.first?.dropFirst().first, "session 3", "oldest generations are evicted first")
+        XCTAssertEqual(gens.last?.dropFirst().first, "session \(LiveState.maxLogGenerations + 2)")
+    }
+
+    /// Each generation is clipped to its own cap so the ring cannot grow UserDefaults without bound, and
+    /// the clip keeps the TAIL — what explains a stop is the end of the previous session, not its start.
+    func testGenerationIsClippedToItsTail() {
+        let many = (0..<(LiveState.generationTailLimit + 50)).map { "line \($0)" }
+        UserDefaults.standard.set(many, forKey: tailKey)
+
+        LiveState.rollLogGenerationsIfNeeded()
+
+        let body = Array(LiveState.persistedLogGenerations()[0].dropFirst())
+        XCTAssertEqual(body.count, LiveState.generationTailLimit)
+        XCTAssertEqual(body.last, "line \(LiveState.generationTailLimit + 49)", "the newest line must survive")
+    }
+
+    /// The export puts previous sessions AHEAD of the current one, so `report.txt` stays chronological and
+    /// the log-parsing tools keep working on it unchanged.
+    func testPreviousSessionsTextPrecedesTheCurrentMarker() {
+        UserDefaults.standard.set(["last night 03:00 disconnected"], forKey: tailKey)
+        LiveState.rollLogGenerationsIfNeeded()
+
+        let text = LiveState.previousSessionsText()
+        let prevIdx = try? XCTUnwrap(text.range(of: "last night 03:00 disconnected")?.lowerBound)
+        let curIdx = try? XCTUnwrap(text.range(of: "current app session")?.lowerBound)
+        XCTAssertNotNil(prevIdx)
+        XCTAssertNotNil(curIdx)
+        if let p = prevIdx, let c = curIdx { XCTAssertTrue(p < c) }
+    }
+
+    func testNoGenerationsRendersNothing() {
+        XCTAssertEqual(LiveState.previousSessionsText(), "")
+    }
+}


### PR DESCRIPTION
## The defect

Take a diagnostics export after the app has restarted and `report.txt` begins **at the restart**. The
lines that would explain the restart are gone — which is exactly when they are worth having.

Two independent causes, both on `main` (`644b5b04`):

1. **`exportableLogText()` renders the in-memory array** (`LiveState.swift:693`, `return header +
   log.joined(...)`). `log` lives for the life of the process, so a fresh process exports a fresh, nearly
   empty log.
2. **The durable tail is a single slot, and the new process destroys it.** `strapLog.tail`
   (`LiveState.swift:611`) is mirrored by `persistTail` every 32 lines — but nothing reloads it at launch,
   so ~32 lines into the new process it is **overwritten** with the new short array. The previous
   session's tail is destroyed by the restart itself, before anyone can read it.

The second one is the reason a workaround like "export sooner" does not help: by the time the user opens
the app and taps Report, the evidence has already been overwritten.

## Why it is worth fixing rather than living with

It is not theoretical. It has now cost **three consecutive overnight captures** in the same shape: iOS
relaunches the app after wake, and the whole night — connection drops, reconnect timings, drain
boundaries — is gone by the time the bundle is exported. An unexplained restart is precisely the case the
strap log exists for, and it is the one case the strap log could not survive.

Nothing here is Oura-specific: any user whose app restarts (a crash, an iOS jetsam kill, a relaunch for
BLE state restoration) loses the same evidence on the same path.

## The fix

At the **first append of each process**, the surviving durable tail is rolled into a small ring of
previous generations, and the live slot is cleared so a generation is never double-counted:

* **3 generations**, each clipped to its **last 1,000 lines** — what explains a stop is the END of the
  previous session. Bounded at roughly 300 KB of `UserDefaults`, against a live ring that was already
  storing 2,000 lines.
* **Latched per process** and a **no-op on an empty tail**, so a launch that logs nothing cannot push an
  empty generation or evict a real one.
* Both exports — manual (`exportableLogText`) and scheduled (`scheduledExportText`) — render generations
  **oldest-first, ahead of** the current session, each behind a
  `===== previous app session, N line(s), rolled at … =====` header, followed by
  `===== current app session =====`.

**`report.txt` therefore stays in chronological order**, which is deliberate: log-parsing tooling reads it
unchanged and simply gets more of the night, instead of needing to learn a second file.

## Verification

* **7 new tests** (`StrandTests/LiveStateLogGenerationsTests.swift`) pinning the failure shape rather than
  the happy path: the roll is once-per-process (a second call must not push this process's own partial
  tail in as a "previous" one), the ring evicts oldest-first, the clip keeps the **tail**, an empty tail
  rolls nothing, and previous sessions render before the current marker.
* `StrandTests` **1102 / 0** (1 skipped) on this branch.
* Built locally, since no default CI covers the app targets: **`Strand` macOS ✅** and **`NOOPiOS` iOS ✅**.
* No BLE behaviour is touched — this is the log sink and the export path only.

## Cross-platform

**Apple-only, and the reason is structural rather than a shortcut.** Android's `StrapLogBuffer`
(`android/…/ui/StrapLogBuffer.kt`) is an in-memory `object` with **no durable store at all**, so there is
nothing to roll — the twin would first have to add durability (SharedPreferences or a file), which is a
different change with its own design question. Android has the same *symptom* (a restart loses the
buffer); it needs its own PR, and I am happy to write it if you want it.

## One design question worth your opinion

Previous generations are inlined into `report.txt` to keep the body chronological. The alternative is a
separate `strap-log-previous.txt` bundle entry, which keeps `report.txt` byte-shaped exactly as today at
the cost of splitting a night across two files. I picked inline because the parsers stay happy and a
reader sees one timeline; say the word and I will move it.

📌 Minor knock-on: `report.txt` is non-trimmable in the bundle cap, so a full ring adds a few hundred KB
that is reserved before the trimmable sidecars get their share. Against the 20 MB cap that is ~1 %, but it
is a real interaction with the sidecar-starvation behaviour and I would rather name it than have it found.