### PR TITLE
feat(today): host the Hours-vs-Needed sleep card

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -701,6 +701,15 @@ struct LiquidTodayView: View {
             } else {
                 hostedSleepPlaceholder
             }
+        case .hoursVsNeeded:
+            // The single hours-vs-need % metric, rendered from the same shared SleepModel built in load().
+            // Until that async build lands — or on a device with no usable latest night — show the graceful
+            // placeholder, mirroring stagesVsTypical.
+            if let m = hostedSleepModel {
+                HoursVsNeededCard(model: m)
+            } else {
+                hostedHoursVsNeededPlaceholder
+            }
         }
     }
 
@@ -738,6 +747,20 @@ struct LiquidTodayView: View {
     private var hostedSleepDebtPlaceholder: some View {
         VStack(alignment: .leading, spacing: NoopMetrics.gap) {
             SectionHeader("Sleep-debt ledger", overline: "Last 14 nights")
+            Text("Not enough nights yet.")
+                .font(StrandFont.subhead)
+                .foregroundStyle(StrandPalette.textTertiary)
+                .frame(maxWidth: .infinity, minHeight: 60, alignment: .center)
+                .background(NoopPanelSurface(tint: StrandPalette.restColor, cornerRadius: 12))
+        }
+    }
+
+    /// Graceful empty state for the hosted "Hours vs Needed" card before its shared SleepModel builds (first
+    /// frame) or when there is no usable latest night. Same treatment as `hostedSleepPlaceholder`, labelled
+    /// for this card so add/remove/reorder in Customise still reads. #today-hosted-cards.
+    private var hostedHoursVsNeededPlaceholder: some View {
+        VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+            SectionHeader("Hours vs Needed", overline: "Sleep")
             Text("Not enough nights yet.")
                 .font(StrandFont.subhead)
                 .foregroundStyle(StrandPalette.textTertiary)

--- a/Strand/Screens/HostedCards.swift
+++ b/Strand/Screens/HostedCards.swift
@@ -37,6 +37,11 @@ enum HostedCard: String, CaseIterable, Identifiable {
     /// tab hero, the Today host carries NO night navigation, NO wake-edit and NO nap add/edit/delete —
     /// the interaction stays on the Sleep tab; only the display is mirrored (`StagesCard`).
     case stages = "sleep.stages"
+    /// Sleep tab · "Hours vs Needed" — the wearer's latest hours-slept-vs-personal-need percentage
+    /// rendered from the shared `SleepModel` (#today-hosted-cards). The Sleep tab surfaces this metric
+    /// only as a StatTile in the Night-detail grid; the Today host gives it a standalone card
+    /// (`HoursVsNeededCard`) reading the SAME `hoursVsNeeded` metric, so the value can't diverge.
+    case hoursVsNeeded = "sleep.hoursVsNeeded"
 
     var id: String { rawValue }
 
@@ -49,6 +54,7 @@ enum HostedCard: String, CaseIterable, Identifiable {
         case .nightDetail: return String(localized: "Night detail")
         case .sleepDebt: return String(localized: "Sleep-debt ledger")
         case .stages: return String(localized: "Stages")
+        case .hoursVsNeeded: return String(localized: "Hours vs Needed")
         }
     }
 
@@ -56,7 +62,7 @@ enum HostedCard: String, CaseIterable, Identifiable {
     /// Trends". Matches the Android `HostedCard.origin`.
     var origin: String {
         switch self {
-        case .sleepMarks, .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt, .stages: return String(localized: "Sleep")
+        case .sleepMarks, .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt, .stages, .hoursVsNeeded: return String(localized: "Sleep")
         }
     }
 
@@ -69,13 +75,14 @@ enum HostedCard: String, CaseIterable, Identifiable {
         case .nightDetail: return "square.grid.2x2"
         case .sleepDebt: return "scalemass"
         case .stages: return "chart.bar.fill"
+        case .hoursVsNeeded: return "gauge.medium"
         }
     }
 
     /// Editor row tint.
     var customizationTint: Color {
         switch self {
-        case .sleepMarks, .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt, .stages: return StrandPalette.restColor
+        case .sleepMarks, .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt, .stages, .hoursVsNeeded: return StrandPalette.restColor
         }
     }
 

--- a/Strand/Screens/HoursVsNeededCard.swift
+++ b/Strand/Screens/HoursVsNeededCard.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+import StrandDesign
+import WhoopStore
+
+// MARK: - Hours vs Needed (#today-hosted-cards)
+//
+// The Sleep tab surfaces "Hours vs Needed" only as a StatTile inside the Night-detail metric grid — there
+// is no standalone renderer for it. This card gives that single metric its own hostable view so it can be
+// surfaced in the Today tab on its own. Both the Sleep tab tile and this hosted card read the SAME
+// `SleepModel.hoursVsNeeded` metric (latest / typical / series), so the number, the vs-typical caption and
+// the sparkline can never diverge between the two surfaces (the parity contract). The tile presentation
+// (value / caption / accent / sparkline) is a verbatim lift of the `NightDetailCard` "Hours vs Needed"
+// tile, so the hosted card reads byte-identically to the Sleep-tab tile.
+
+/// The "Hours vs Needed" card. Renders the wearer's latest hours-vs-needed percentage against their
+/// personal typical from the shared [SleepModel], as a single full-width StatTile with its sparkline and
+/// vs-typical caption — the same presentation the Night-detail grid uses for this metric.
+struct HoursVsNeededCard: View {
+    let model: SleepModel
+
+    var body: some View {
+        // The metric (latest %, typical mean, history series) is computed ONCE in the model build and
+        // read here — the same memoized result the Night-detail grid reads for its tile.
+        let need = model.hoursVsNeeded
+
+        VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+            SectionHeader("Hours vs Needed", overline: "Sleep")
+            // Verbatim of the NightDetailCard "Hours vs Needed" tile so the hosted value matches the
+            // Sleep-tab tile exactly; stretched to the card's full width as a single-metric summary.
+            StatTile(
+                label: "Hours vs Needed",
+                value: pctValue(need.latest),
+                caption: vsTypical(need.latest, need.typical, suffix: "%"),
+                accent: need.latest.map { StrandPalette.recoveryColor(min(100, $0)) } ?? StrandPalette.textPrimary,
+                sparkline: spark(need.series),
+                sparkColor: StrandPalette.restColor)
+                .frame(maxWidth: .infinity)
+        }
+    }
+
+    // MARK: - Tile formatting (verbatim lift of the NightDetailCard "Hours vs Needed" tile helpers)
+
+    private func pctValue(_ v: Double?) -> String {
+        v.map { "\(Int($0.rounded()))%" } ?? "—"
+    }
+
+    /// "+12% vs typical" — the latest-vs-mean caption the metric tile carries.
+    private func vsTypical(_ latest: Double?, _ typical: Double?, suffix: String, decimals: Int = 0) -> String {
+        guard let latest, let typical, typical != 0 else { return String(localized: "vs typical - ") }
+        let diff = latest - typical
+        let sign = diff >= 0 ? "+" : "−"
+        let mag = abs(diff)
+        let num = decimals == 0 ? "\(Int(mag.rounded()))" : String(format: "%.\(decimals)f", mag)
+        return String(localized: "\(sign)\(num)\(suffix) vs typical")
+    }
+
+    /// A sparkline needs at least two points; otherwise return nil so the tile stays clean.
+    private func spark(_ series: [Double]) -> [Double]? {
+        let tail = Array(series.suffix(30))
+        return tail.count > 1 ? tail : nil
+    }
+}

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -2266,6 +2266,22 @@ struct TodayView: View {
                         .background(NoopPanelSurface(tint: StrandPalette.restColor, cornerRadius: 12))
                 }
             }
+        case .hoursVsNeeded:
+            // The single hours-vs-need % metric, rendered from the shared SleepModel built in loadAll().
+            // Until the async build lands — or with no usable latest night — show the graceful placeholder,
+            // as above.
+            if let m = hostedSleepModel {
+                HoursVsNeededCard(model: m)
+            } else {
+                VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+                    SectionHeader("Hours vs Needed", overline: "Sleep")
+                    Text("Not enough nights yet.")
+                        .font(StrandFont.subhead)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                        .frame(maxWidth: .infinity, minHeight: 60, alignment: .center)
+                        .background(NoopPanelSurface(tint: StrandPalette.restColor, cornerRadius: 12))
+                }
+            }
         }
     }
 

--- a/android/app/src/main/java/com/noop/ui/HostedCards.kt
+++ b/android/app/src/main/java/com/noop/ui/HostedCards.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.filled.Balance
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.StackedBarChart
 import androidx.compose.material.icons.filled.Timeline
 import androidx.compose.runtime.Composable
@@ -56,7 +57,12 @@ enum class HostedCard(
     /** Sleep tab · "Stages" — a READ-ONLY latest-night stage chart + breakdown from the wearer's
      *  SleepModel (#today-hosted-cards). Unlike the interactive Sleep tab hero (night nav, wake edit, nap
      *  add/edit/delete), the Today host mirrors ONLY the display. Fourth of the SleepModel-backed cards. */
-    STAGES("sleep.stages", "Stages", "Sleep", Icons.Filled.Timeline);
+    STAGES("sleep.stages", "Stages", "Sleep", Icons.Filled.Timeline),
+    /** Sleep tab · "Hours vs Needed" — the wearer's latest hours-slept-vs-personal-need percentage from the
+     *  wearer's SleepModel (#today-hosted-cards). The Sleep tab surfaces this metric only as a StatTile in
+     *  the Night-detail grid; the Today host gives it a standalone card (HoursVsNeededCard) reading the SAME
+     *  metric, so the value can't diverge. */
+    HOURS_VS_NEEDED("sleep.hoursVsNeeded", "Hours vs Needed", "Sleep", Icons.Filled.Speed);
 
     companion object {
         fun fromRaw(raw: String?): HostedCard? = entries.firstOrNull { it.raw == raw }
@@ -83,6 +89,7 @@ fun HostedCard.localizedTitle(): String = when (this) {
     HostedCard.NIGHT_DETAIL -> stringResource(R.string.l10n_sleep_screen_night_detail_8f271bcf)
     HostedCard.SLEEP_DEBT -> stringResource(R.string.l10n_sleep_screen_sleep_debt_ledger_8cc9a992)
     HostedCard.STAGES -> stringResource(R.string.l10n_sleep_screen_stages_c1d33ad5)
+    HostedCard.HOURS_VS_NEEDED -> stringResource(R.string.l10n_sleep_screen_hours_vs_needed_500a0aca)
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3074,7 +3074,7 @@ private fun HostedCardsSection(cards: List<HostedCard>, days: List<DailyMetric>,
     // follow). Build the shared model ONCE, and only when at least one such card is actually hosted, so a
     // Today hosting none pays no cost. Same inputs + builder as the Sleep tab (buildHostedSleepModel), so
     // hosted numbers match the Sleep tab. Reused by every model-backed card. Twin of the iOS hostedSleepModel.
-    val modelBackedHosted = setOf(HostedCard.STAGES_VS_TYPICAL, HostedCard.NIGHT_DETAIL, HostedCard.SLEEP_DEBT, HostedCard.STAGES)
+    val modelBackedHosted = setOf(HostedCard.STAGES_VS_TYPICAL, HostedCard.NIGHT_DETAIL, HostedCard.SLEEP_DEBT, HostedCard.STAGES, HostedCard.HOURS_VS_NEEDED)
     val needsSleepModel = cards.any { it in modelBackedHosted }
     var hostedSleepModel by remember { mutableStateOf<SleepModel?>(null) }
     LaunchedEffect(needsSleepModel, days, viewModel.activeStrapId) {
@@ -3124,6 +3124,11 @@ private fun HostedCardsSection(cards: List<HostedCard>, days: List<DailyMetric>,
                 // nap interaction. Null until the async build lands / no stage data — the slot renders nothing
                 // this frame, matching the Sleep tab's null-model guard.
                 HostedCard.STAGES -> hostedSleepModel?.let { StagesHostCard(it) }
+                // #today-hosted-cards: the single hours-vs-need % metric, rendered from the SAME shared
+                // SleepModel the Sleep tab uses (mirror, not copy) via the existing standalone
+                // HoursVsNeededCard. Null until the async build lands / no stage data — the slot renders
+                // nothing this frame, matching the Sleep tab's null-model guard.
+                HostedCard.HOURS_VS_NEEDED -> hostedSleepModel?.let { HoursVsNeededCard(it) }
             }
         }
     }


### PR DESCRIPTION
Fifth hosted sleep card. Android reuses its HoursVsNeededCard(m); iOS gets a small StatTile-based card (verbatim of the Night-detail 'Hours vs Needed' tile) off the shared model.hoursVsNeeded, so the value is byte-identical to the Sleep tab. HostedCard.hoursVsNeeded (byte-identical id, existing localized title, enum order matched → canonicalOrder/.noopbak identical). Parity on the value; layout may differ per platform. Android compile + i18n green; Swift via app-build gate.