### PR TITLE
feat(today)+fix(sleep): align Consistency score + host the Consistency card

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -710,6 +710,15 @@ struct LiquidTodayView: View {
             } else {
                 hostedHoursVsNeededPlaceholder
             }
+        case .consistency:
+            // The single sleep-consistency % metric, rendered from the same shared SleepModel built in
+            // load(). Until that async build lands — or on a device with no usable latest night — show the
+            // graceful placeholder, mirroring stagesVsTypical.
+            if let m = hostedSleepModel {
+                ConsistencyCard(model: m)
+            } else {
+                hostedConsistencyPlaceholder
+            }
         }
     }
 
@@ -761,6 +770,20 @@ struct LiquidTodayView: View {
     private var hostedHoursVsNeededPlaceholder: some View {
         VStack(alignment: .leading, spacing: NoopMetrics.gap) {
             SectionHeader("Hours vs Needed", overline: "Sleep")
+            Text("Not enough nights yet.")
+                .font(StrandFont.subhead)
+                .foregroundStyle(StrandPalette.textTertiary)
+                .frame(maxWidth: .infinity, minHeight: 60, alignment: .center)
+                .background(NoopPanelSurface(tint: StrandPalette.restColor, cornerRadius: 12))
+        }
+    }
+
+    /// Graceful empty state for the hosted "Consistency" card before its shared SleepModel builds (first
+    /// frame) or when there is no usable latest night. Same treatment as `hostedSleepPlaceholder`, labelled
+    /// for this card so add/remove/reorder in Customise still reads. #today-hosted-cards.
+    private var hostedConsistencyPlaceholder: some View {
+        VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+            SectionHeader("Consistency", overline: "Sleep")
             Text("Not enough nights yet.")
                 .font(StrandFont.subhead)
                 .foregroundStyle(StrandPalette.textTertiary)

--- a/Strand/Screens/ConsistencyCard.swift
+++ b/Strand/Screens/ConsistencyCard.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+import StrandDesign
+import WhoopStore
+
+// MARK: - Consistency (#today-hosted-cards)
+//
+// The Sleep tab surfaces "Consistency" only as a StatTile inside the Night-detail metric grid — there is
+// no standalone renderer for it. This card gives that single metric its own hostable view so it can be
+// surfaced in the Today tab on its own. Both the Sleep tab tile and this hosted card read the SAME
+// `SleepModel.consistency` metric (latest / typical / series) — the bedtime-onset-spread score that also
+// honours the imported-consistency preference and is byte-identical to Android's `consistencySeries` — so
+// the number, the vs-typical caption and the sparkline can never diverge between the two surfaces (the
+// parity contract). The tile presentation (value / caption / accent / sparkline) is a verbatim lift of the
+// `NightDetailCard` "Consistency" tile, so the hosted card reads byte-identically to the Sleep-tab tile.
+
+/// The "Consistency" card. Renders the wearer's latest sleep-consistency percentage against their personal
+/// typical from the shared [SleepModel], as a single full-width StatTile with its sparkline and vs-typical
+/// caption — the same presentation the Night-detail grid uses for this metric.
+struct ConsistencyCard: View {
+    let model: SleepModel
+
+    var body: some View {
+        // The metric (latest %, typical mean, history series) is computed ONCE in the model build and
+        // read here — the same memoized result the Night-detail grid reads for its tile.
+        let cons = model.consistency
+
+        VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+            SectionHeader("Consistency", overline: "Sleep")
+            // Verbatim of the NightDetailCard "Consistency" tile so the hosted value matches the Sleep-tab
+            // tile exactly; stretched to the card's full width as a single-metric summary.
+            StatTile(
+                label: "Consistency",
+                value: pctValue(cons.latest),
+                caption: vsTypical(cons.latest, cons.typical, suffix: "%"),
+                accent: cons.latest.map { StrandPalette.recoveryColor($0) } ?? StrandPalette.textPrimary,
+                sparkline: spark(cons.series),
+                sparkColor: StrandPalette.metricCyan)
+                .frame(maxWidth: .infinity)
+        }
+    }
+
+    // MARK: - Tile formatting (verbatim lift of the NightDetailCard "Consistency" tile helpers)
+
+    private func pctValue(_ v: Double?) -> String {
+        v.map { "\(Int($0.rounded()))%" } ?? "—"
+    }
+
+    /// "+12% vs typical" — the latest-vs-mean caption the metric tile carries.
+    private func vsTypical(_ latest: Double?, _ typical: Double?, suffix: String, decimals: Int = 0) -> String {
+        guard let latest, let typical, typical != 0 else { return String(localized: "vs typical - ") }
+        let diff = latest - typical
+        let sign = diff >= 0 ? "+" : "−"
+        let mag = abs(diff)
+        let num = decimals == 0 ? "\(Int(mag.rounded()))" : String(format: "%.\(decimals)f", mag)
+        return String(localized: "\(sign)\(num)\(suffix) vs typical")
+    }
+
+    /// A sparkline needs at least two points; otherwise return nil so the tile stays clean.
+    private func spark(_ series: [Double]) -> [Double]? {
+        let tail = Array(series.suffix(30))
+        return tail.count > 1 ? tail : nil
+    }
+}

--- a/Strand/Screens/HostedCards.swift
+++ b/Strand/Screens/HostedCards.swift
@@ -42,6 +42,12 @@ enum HostedCard: String, CaseIterable, Identifiable {
     /// only as a StatTile in the Night-detail grid; the Today host gives it a standalone card
     /// (`HoursVsNeededCard`) reading the SAME `hoursVsNeeded` metric, so the value can't diverge.
     case hoursVsNeeded = "sleep.hoursVsNeeded"
+    /// Sleep tab · "Consistency" — the wearer's latest sleep-consistency percentage (bedtime-onset spread,
+    /// honouring the imported-consistency preference) rendered from the shared `SleepModel`
+    /// (#today-hosted-cards). The Sleep tab surfaces this metric only as a StatTile in the Night-detail
+    /// grid; the Today host gives it a standalone card (`ConsistencyCard`) reading the SAME `consistency`
+    /// metric, so the value can't diverge.
+    case consistency = "sleep.consistency"
 
     var id: String { rawValue }
 
@@ -55,6 +61,7 @@ enum HostedCard: String, CaseIterable, Identifiable {
         case .sleepDebt: return String(localized: "Sleep-debt ledger")
         case .stages: return String(localized: "Stages")
         case .hoursVsNeeded: return String(localized: "Hours vs Needed")
+        case .consistency: return String(localized: "Consistency")
         }
     }
 
@@ -62,7 +69,7 @@ enum HostedCard: String, CaseIterable, Identifiable {
     /// Trends". Matches the Android `HostedCard.origin`.
     var origin: String {
         switch self {
-        case .sleepMarks, .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt, .stages, .hoursVsNeeded: return String(localized: "Sleep")
+        case .sleepMarks, .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt, .stages, .hoursVsNeeded, .consistency: return String(localized: "Sleep")
         }
     }
 
@@ -76,13 +83,14 @@ enum HostedCard: String, CaseIterable, Identifiable {
         case .sleepDebt: return "scalemass"
         case .stages: return "chart.bar.fill"
         case .hoursVsNeeded: return "gauge.medium"
+        case .consistency: return "repeat"
         }
     }
 
     /// Editor row tint.
     var customizationTint: Color {
         switch self {
-        case .sleepMarks, .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt, .stages, .hoursVsNeeded: return StrandPalette.restColor
+        case .sleepMarks, .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt, .stages, .hoursVsNeeded, .consistency: return StrandPalette.restColor
         }
     }
 

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -2282,6 +2282,22 @@ struct TodayView: View {
                         .background(NoopPanelSurface(tint: StrandPalette.restColor, cornerRadius: 12))
                 }
             }
+        case .consistency:
+            // The single sleep-consistency % metric, rendered from the shared SleepModel built in loadAll().
+            // Until the async build lands — or with no usable latest night — show the graceful placeholder,
+            // as above.
+            if let m = hostedSleepModel {
+                ConsistencyCard(model: m)
+            } else {
+                VStack(alignment: .leading, spacing: NoopMetrics.gap) {
+                    SectionHeader("Consistency", overline: "Sleep")
+                    Text("Not enough nights yet.")
+                        .font(StrandFont.subhead)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                        .frame(maxWidth: .infinity, minHeight: 60, alignment: .center)
+                        .background(NoopPanelSurface(tint: StrandPalette.restColor, cornerRadius: 12))
+                }
+            }
         }
     }
 

--- a/android/app/src/main/java/com/noop/ui/HostedCards.kt
+++ b/android/app/src/main/java/com/noop/ui/HostedCards.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.filled.Balance
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.StackedBarChart
 import androidx.compose.material.icons.filled.Timeline
@@ -62,7 +63,12 @@ enum class HostedCard(
      *  wearer's SleepModel (#today-hosted-cards). The Sleep tab surfaces this metric only as a StatTile in
      *  the Night-detail grid; the Today host gives it a standalone card (HoursVsNeededCard) reading the SAME
      *  metric, so the value can't diverge. */
-    HOURS_VS_NEEDED("sleep.hoursVsNeeded", "Hours vs Needed", "Sleep", Icons.Filled.Speed);
+    HOURS_VS_NEEDED("sleep.hoursVsNeeded", "Hours vs Needed", "Sleep", Icons.Filled.Speed),
+    /** Sleep tab · "Consistency" — the wearer's latest sleep-consistency percentage (bedtime-onset spread,
+     *  honouring the imported-consistency preference) from the wearer's SleepModel (#today-hosted-cards). The
+     *  Sleep tab surfaces this metric only as a StatTile in the Night-detail grid; the Today host gives it a
+     *  standalone card (ConsistencyHostCard) reading the SAME metric, so the value can't diverge. */
+    CONSISTENCY("sleep.consistency", "Consistency", "Sleep", Icons.Filled.Repeat);
 
     companion object {
         fun fromRaw(raw: String?): HostedCard? = entries.firstOrNull { it.raw == raw }
@@ -90,6 +96,7 @@ fun HostedCard.localizedTitle(): String = when (this) {
     HostedCard.SLEEP_DEBT -> stringResource(R.string.l10n_sleep_screen_sleep_debt_ledger_8cc9a992)
     HostedCard.STAGES -> stringResource(R.string.l10n_sleep_screen_stages_c1d33ad5)
     HostedCard.HOURS_VS_NEEDED -> stringResource(R.string.l10n_sleep_screen_hours_vs_needed_500a0aca)
+    HostedCard.CONSISTENCY -> stringResource(R.string.l10n_sleep_screen_consistency_0ea7b95e)
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -792,7 +792,7 @@ fun SleepScreen(
                     SleepReorderableSection(k, sleepListState, sleepSectionDrag, persistSleepOrder) {
                         Column {
                             Spacer(Modifier.height(Metrics.selectorTopUp))
-                            SleepConsistencyCard(sleeps, habitualMidsleep)
+                            SleepConsistencyCard(sleeps, habitualMidsleep, tilesModel.consistency.latest)
                         }
                     }
                 }
@@ -3195,6 +3195,60 @@ private fun LegendDot(label: String, color: Color) {
     }
 }
 
+// MARK: - Consistency host card (#today-hosted-cards)
+
+/**
+ * A SIMPLE standalone "Consistency" score card for the Today host — mirrors the [HoursVsNeededCard]
+ * presentation (a NoopCard header with a trend arrow + big % + a sparkline), NOT the rich scatter
+ * [SleepConsistencyCard] (which needs raw sessions). Renders `m.consistency` (latest / typical / series) —
+ * the SAME shared SleepModel metric the Sleep tab's Night-detail tile reads (bedtime-onset spread, honouring
+ * the imported-consistency preference, byte-identical to iOS `SleepModel.consistency`), so the number and the
+ * sparkline can never diverge between the two surfaces.
+ */
+@Composable
+internal fun ConsistencyHostCard(m: SleepModel) {
+    val cons = m.consistency
+    // Uncapped % (consistency is already 0–100); "—" when there is no latest night yet.
+    val latest = cons.latest
+    // Trend arrow off the last two nights of the consistency series (same idiom as HoursVsNeededCard).
+    val trendArrow = if (cons.series.size >= 2) {
+        val delta = cons.series.last() - cons.series[cons.series.lastIndex - 1]
+        when {
+            delta > 0.5 -> "↑"
+            delta < -0.5 -> "↓"
+            else -> "→"
+        }
+    } else "→"
+    val arrowColor = when (trendArrow) {
+        "↑" -> Palette.statusPositive
+        "↓" -> Palette.statusCritical
+        else -> Palette.textTertiary
+    }
+    // The simple host card summarizes the trend via the arrow + sparkline rather than a "vs typical"
+    // caption (mirrors the Android HoursVsNeeded host presentation, which carries no caption literal).
+    NoopCard(padding = Metrics.cardPadding, tint = Palette.restColor) {
+        Column(verticalArrangement = Arrangement.spacedBy(Metrics.space14)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Overline("Sleep")
+                    Text(uiString(R.string.l10n_sleep_screen_consistency_0ea7b95e), style = NoopType.headline, color = Palette.textPrimary)
+                }
+                Text(trendArrow, style = NoopType.title2, color = arrowColor)
+                Spacer(Modifier.width(Metrics.space6))
+                Text(
+                    if (latest != null) uiString(R.string.l10n_sleep_screen_score_roundtoint_a2d1cc99, latest.roundToInt()) else "—",
+                    style = NoopType.chartValue,
+                    color = Palette.restColor,
+                )
+            }
+            // Sparkline of the consistency history, in metricCyan to match the Sleep-tab Night-detail tile.
+            if (cons.series.size > 1) {
+                Sparkline(values = cons.series.takeLast(30), color = Palette.metricCyan)
+            }
+        }
+    }
+}
+
 // MARK: - Sleep Consistency card
 
 /** One night's bed/wake fold for [SleepConsistencyCard], memoized off `sleeps` (#perf). */
@@ -3207,7 +3261,14 @@ private data class SleepNightTiming(val label: String, val bedHour: Float, val w
  * of the personal typical. (PR #260)
  */
 @Composable
-internal fun SleepConsistencyCard(sleeps: List<SleepSession>, habitualMidsleepSec: Long? = null) {
+internal fun SleepConsistencyCard(
+    sleeps: List<SleepSession>,
+    habitualMidsleepSec: Long? = null,
+    // #sleep-consistency-parity: the iOS-canonical onset-spread score (model.consistency, which also
+    // honours the imported-consistency preference). Passed in so the card headline matches iOS + the tile
+    // instead of the old local "share of nights within 45 min" count (a third, divergent value).
+    consistencyScore: Double? = null,
+) {
     // #perf: building the per-night fold allocates 2 Calendars + a SimpleDateFormat per session (~28
     // objects for 14 nights). It's a pure derivation of `sleeps` (no wall-clock input), so memoize it on
     // `sleeps` — scrolling the Sleep screen then reuses it instead of rebuilding it every recompose frame.
@@ -3235,12 +3296,10 @@ internal fun SleepConsistencyCard(sleeps: List<SleepSession>, habitualMidsleepSe
     val wakeSdH = sd(timings.map { it.wakeHour })
     val typicalBed = timings.map { it.bedHour }.average().toFloat()
     val typicalWake = timings.map { it.wakeHour }.average().toFloat()
-    // Count nights where bed AND wake are within 45 min of the typical.
-    val threshold = 0.75f
-    val consistentNights = timings.count { t ->
-        abs(t.bedHour - typicalBed) <= threshold && abs(t.wakeHour - typicalWake) <= threshold
-    }
-    val consistencyPct = (consistentNights.toFloat() / timings.size * 100f).coerceIn(0f, 100f)
+    // #sleep-consistency-parity: the headline is the shared onset-spread score (iOS-canonical), not the
+    // old "share of nights within 45 min of typical" count. The bed/wake scatter + SD labels below are
+    // unchanged (they visualise the same onsets). Falls back to 0 only when the score is unavailable.
+    val consistencyPct = consistencyScore?.toFloat()?.coerceIn(0f, 100f) ?: 0f
     val typicalBedLabel = run {
         val h = ((typicalBed + 24f) % 24f).toInt()
         String.format(Locale.US, "%02d:00", h)

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3074,7 +3074,7 @@ private fun HostedCardsSection(cards: List<HostedCard>, days: List<DailyMetric>,
     // follow). Build the shared model ONCE, and only when at least one such card is actually hosted, so a
     // Today hosting none pays no cost. Same inputs + builder as the Sleep tab (buildHostedSleepModel), so
     // hosted numbers match the Sleep tab. Reused by every model-backed card. Twin of the iOS hostedSleepModel.
-    val modelBackedHosted = setOf(HostedCard.STAGES_VS_TYPICAL, HostedCard.NIGHT_DETAIL, HostedCard.SLEEP_DEBT, HostedCard.STAGES, HostedCard.HOURS_VS_NEEDED)
+    val modelBackedHosted = setOf(HostedCard.STAGES_VS_TYPICAL, HostedCard.NIGHT_DETAIL, HostedCard.SLEEP_DEBT, HostedCard.STAGES, HostedCard.HOURS_VS_NEEDED, HostedCard.CONSISTENCY)
     val needsSleepModel = cards.any { it in modelBackedHosted }
     var hostedSleepModel by remember { mutableStateOf<SleepModel?>(null) }
     LaunchedEffect(needsSleepModel, days, viewModel.activeStrapId) {
@@ -3129,6 +3129,11 @@ private fun HostedCardsSection(cards: List<HostedCard>, days: List<DailyMetric>,
                 // HoursVsNeededCard. Null until the async build lands / no stage data — the slot renders
                 // nothing this frame, matching the Sleep tab's null-model guard.
                 HostedCard.HOURS_VS_NEEDED -> hostedSleepModel?.let { HoursVsNeededCard(it) }
+                // #today-hosted-cards: the single sleep-consistency % metric, rendered from the SAME shared
+                // SleepModel the Sleep tab uses (mirror, not copy) via the simple standalone
+                // ConsistencyHostCard. Null until the async build lands / no stage data — the slot renders
+                // nothing this frame, matching the Sleep tab's null-model guard.
+                HostedCard.CONSISTENCY -> hostedSleepModel?.let { ConsistencyHostCard(it) }
             }
         }
     }


### PR DESCRIPTION
**Fix:** the Android Sleep-tab Consistency card showed its own `consistencyPct` (% of nights within 45 min of typical) — a third value divergent from the iOS onset-spread score. Since `model.consistency` is already byte-identical across platforms, point the card's headline at `model.consistency.latest` (drops the local count; scatter + SD labels unchanged). **Feat:** host the Consistency card on Today (both platforms) — a simple score card off the aligned `model.consistency` (verbatim of the Night-detail Consistency tile, so hosted == Sleep-tab tile). `HostedCard.consistency` byte-identical id, enum order matched. The 6th and final hosted sleep card. Android compile + i18n green; Swift via app-build gate.