### PR TITLE
fix(diagnostics): roll log generations on manual export too (#1263)

### DIFF
--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -756,6 +756,12 @@ public final class LiveState: ObservableObject {
     /// session log. Shared so BOTH the Live screen's log card AND a macOS Settings shortcut (#507 — a 4.0
     /// owner couldn't find the log on Mac) build the SAME text. Call on the main thread (button taps).
     func exportableLogText(extraHeaderLines: [String] = []) -> String {
+        // #1263: roll here too, not only in `append`. A restart's export is the whole point of the
+        // generation ring, and a user can open the app and tap Report BEFORE this process logs its first
+        // line — at which point the previous session is still in `tailKey` (unrolled) and the in-memory
+        // `log` is empty, so `previousSessionsText()` below would miss it. The roll is latched + a no-op on
+        // an empty tail, so this is harmless when `append` already ran.
+        Self.rollLogGenerationsIfNeeded()
         let v = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
         #if os(iOS)
         let osName = "iOS"

--- a/StrandTests/LiveStateLogGenerationsTests.swift
+++ b/StrandTests/LiveStateLogGenerationsTests.swift
@@ -101,4 +101,17 @@ final class LiveStateLogGenerationsTests: XCTestCase {
     func testNoGenerationsRendersNothing() {
         XCTAssertEqual(LiveState.previousSessionsText(), "")
     }
+
+    /// #1263: a manual export taken BEFORE this process's first append must still carry the previous
+    /// session. `exportableLogText()` rolls the surviving tail itself (not only `append`), so an
+    /// instant post-restart Report is not empty — the exact case the generation ring exists for.
+    func testExportBeforeFirstAppendStillCarriesThePreviousSession() {
+        UserDefaults.standard.set(["last night 03:14 reconnect storm", "03:15 gave up"], forKey: tailKey)
+        // Fresh process: setUp reset the roll latch and the in-memory `log` is empty (no append yet).
+        let text = LiveState().exportableLogText()
+        XCTAssertTrue(text.contains("last night 03:14 reconnect storm"),
+                      "export before the first append must roll + include the previous session")
+        XCTAssertTrue(text.contains("previous app session"), "the previous session keeps its header")
+        XCTAssertEqual(LiveState.persistedLogTail(), [], "the roll clears the live slot")
+    }
 }


### PR DESCRIPTION
Minimal fix for #1263 item 3 (the correctness gap from the #1259 re-review). The generation ring rolled the surviving tail only in `append()`; a Report tapped after a restart but before this process's first log line rendered an empty previous session. `exportableLogText()` now rolls too (latched + no-op on empty tail, so harmless once append ran). Test pins a pre-append export carries the previous session. Other two #1263 items (clearLogGenerations wiring, Android parity) left as follow-ups. Swift via app-build gate.