### PR TITLE
feat(android): strap-log durability across restart (parity, #1263 item 2)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -439,6 +439,23 @@ class WhoopBleClient(
         private const val LOG_BUFFER_MAX = 5000
 
         /**
+         * #1263: durable strap-log tail + generation ring (Android parity for iOS `LiveState`). The in-memory
+         * [logBuffer] dies with the process, so an export taken after a restart would begin at the restart and
+         * lose the lines that explain it. We mirror a durable tail to SharedPreferences every
+         * [LOG_TAIL_PERSIST_EVERY] lines and, at the first log line of each process (and at export time), roll
+         * the surviving tail into a bounded generation ring so an export STILL carries the previous session.
+         * Keys mirror the iOS UserDefaults keys; the tail is newline-joined, the generations a JSON array of
+         * newline-joined blocks. Pure ring math lives in [com.noop.ui.StrapLogGenerations].
+         */
+        private const val STRAP_LOG_TAIL_KEY = "strapLog.tail"
+        private const val STRAP_LOG_GENERATIONS_KEY = "strapLog.generations"
+        /** Persist the durable tail every N lines (batched, not per-line — mirrors iOS `persistEveryNLines`). */
+        private const val LOG_TAIL_PERSIST_EVERY = 32
+        /** How many recent lines the durable tail retains — a sensible day's worth, larger than a single
+         *  generation's cap so a session's whole tail is available to roll. Mirrors iOS `tailLimit`. */
+        private const val LOG_DURABLE_TAIL_LIMIT = 2_000
+
+        /**
          * Fallback device id when the registry has no active device yet (fresh install before the v8
          * migration seeds it, or an all-archived registry). Matches the Swift default and the legacy
          * hardcoded id, so behaviour is unchanged today — the registry resolves to exactly this string.
@@ -2035,6 +2052,86 @@ class WhoopBleClient(
     private val logTimeFmt = java.text.SimpleDateFormat("HH:mm:ss", java.util.Locale.US)
     // PII scrubbers for the shareable strap log (#445) live at file scope as [redactStrapLogPii]
     // so they're unit-testable without constructing this Android-only client (#421).
+
+    // ── #1263 Durable strap-log tail + generation ring (Android parity for iOS LiveState) ───────────
+    // The in-memory [logBuffer] dies with the process. To make an export taken AFTER a restart still carry
+    // the previous session's tail (issues #1259/#1264), we mirror a durable tail to SharedPreferences and,
+    // once per process, roll the surviving tail into a bounded generation ring. The ring MATH is the pure,
+    // JVM-tested [com.noop.ui.StrapLogGenerations]; this is the thin, untested SharedPreferences wrapper
+    // (the same split iOS has with UserDefaults). All of it runs inside log()'s no-throw guard, and the
+    // roll latch + persistence are serialised on [genLock] because log() is called from BOTH the GATT binder
+    // thread and the main looper — the roll must happen exactly once and must not race the tail mirror.
+    private val genLock = Any()
+    /** Once-per-process latch: the roll must run BEFORE this process's first durable-tail mirror overwrites
+     *  the surviving tail, and exactly once, or a second roll would push this process's own partial tail in
+     *  as a "previous" session. Guarded by [genLock]. */
+    private var didRollGenerations = false
+    /** Durable-tail mirror counter, mutated only under [logBuffer]'s monitor (like [logBuffer] itself). */
+    private var logsSincePersist = 0
+
+    private fun strapLogPrefs() = context.getSharedPreferences("noop_prefs", Context.MODE_PRIVATE)
+
+    /** The persisted durable tail, newest-last. Empty when nothing has been logged on this device. */
+    private fun persistedLogTail(): List<String> {
+        val s = strapLogPrefs().getString(STRAP_LOG_TAIL_KEY, null)
+        return if (s.isNullOrEmpty()) emptyList() else s.split('\n')
+    }
+
+    /** Mirror the most recent [LOG_DURABLE_TAIL_LIMIT] lines to SharedPreferences (newline-joined). */
+    private fun persistLogTail(lines: List<String>) {
+        val tail = if (lines.size > LOG_DURABLE_TAIL_LIMIT)
+            lines.subList(lines.size - LOG_DURABLE_TAIL_LIMIT, lines.size) else lines
+        strapLogPrefs().edit().putString(STRAP_LOG_TAIL_KEY, tail.joinToString("\n")).apply()
+    }
+
+    /** The stored generations, oldest-first — each a newline-joined block whose first line is its own header.
+     *  Persisted as a JSON array of strings; a corrupt/absent value reads as none. */
+    private fun persistedLogGenerations(): List<List<String>> {
+        val s = strapLogPrefs().getString(STRAP_LOG_GENERATIONS_KEY, null) ?: return emptyList()
+        return runCatching {
+            val arr = org.json.JSONArray(s)
+            (0 until arr.length()).map { i ->
+                val block = arr.getString(i)
+                if (block.isEmpty()) emptyList() else block.split('\n')
+            }
+        }.getOrDefault(emptyList())
+    }
+
+    private fun persistLogGenerations(gens: List<List<String>>) {
+        val arr = org.json.JSONArray()
+        for (g in gens) arr.put(g.joinToString("\n"))
+        strapLogPrefs().edit().putString(STRAP_LOG_GENERATIONS_KEY, arr.toString()).apply()
+    }
+
+    /**
+     * Roll the surviving durable tail into the generation ring. Idempotent per process (latched) and a NO-OP
+     * when the tail is empty — so a launch that logs nothing (or a run right after a roll) never pushes an
+     * empty generation and never evicts a real one. Runs on the FIRST log() append of the process AND in the
+     * export path, so an export taken before the first append isn't empty (iOS #1264). Serialised on [genLock].
+     */
+    private fun rollLogGenerationsIfNeeded() {
+        synchronized(genLock) {
+            if (didRollGenerations) return
+            didRollGenerations = true
+            val tail = persistedLogTail()
+            if (tail.isEmpty()) return
+            val gens = com.noop.ui.StrapLogGenerations.roll(tail, persistedLogGenerations(), System.currentTimeMillis())
+            persistLogGenerations(gens)
+            // Clear the live slot: this tail now belongs to a generation, and leaving it would duplicate it
+            // in every export until the next mirror overwrites it. Empty string reads back as no tail.
+            strapLogPrefs().edit().putString(STRAP_LOG_TAIL_KEY, "").apply()
+        }
+    }
+
+    /** Flush the current in-memory tail to the durable slot (mirroring is batched every N lines, so a
+     *  disconnect / shutdown flushes the last partial batch — the twin of iOS flushing in clearBiometrics).
+     *  No-throw; called off the per-line path. */
+    private fun flushDurableLogTail() {
+        runCatching {
+            val snapshot = synchronized(logBuffer) { logsSincePersist = 0; logBuffer.toList() }
+            if (snapshot.isNotEmpty()) persistLogTail(snapshot)
+        }
+    }
 
     /** Fired if a scan finds nothing in [SCAN_TIMEOUT_MS]; stops scanning and explains why. */
     private val scanTimeoutRunnable = Runnable {
@@ -7518,6 +7615,10 @@ class WhoopBleClient(
         // (not stranded), and the next connection starts a fresh window rather than spanning the gap. No-op
         // when capture is off. Do it BEFORE the connect-down line so the summary reads before the drop.
         flushFrameTimingSummary()
+        // #1263: flush the durable strap-log tail so a completed session's last partial batch survives to a
+        // later export even if the process is killed before the next 32-line mirror (twin of iOS's flush on
+        // disconnect). The connect-down line logged just below still mirrors again once it crosses a batch.
+        flushDurableLogTail()
         // Snapshot the hold time and clear it IMMEDIATELY: every drop log below reads the snapshot, and a
         // stale `linkUpSinceMs` surviving into the next drop would report a hold time for a link that never
         // reached STATE_CONNECTED — the diagnostic would then invent exactly the evidence it exists to find.
@@ -7874,6 +7975,7 @@ class WhoopBleClient(
      * (e.g. AppViewModel.onCleared) AFTER [disconnect]. Idempotent.
      */
     fun shutdown() {
+        flushDurableLogTail()   // #1263: persist the last partial tail batch before we go away
         ioScope.cancel()
     }
 
@@ -8085,6 +8187,10 @@ class WhoopBleClient(
         // in here may propagate. (The regex bug itself is also fixed; this guarantees the class can't
         // recur.)
         try {
+            // #1263: FIRST append of this process — rescue the previous process's durable tail into the
+            // generation ring BEFORE this process's own mirror overwrites it. Latched + a no-op on an empty
+            // tail, so this is one guarded check per line after the first.
+            rollLogGenerationsIfNeeded()
             // Scrub personal identifiers FIRST so a user can safely share the strap log (#445), THEN
             // apply the optional Test Centre domain tag in front of the already-safe line.
             val safe = taggedStrapLogLine(redactPii(s), domain)
@@ -8093,12 +8199,21 @@ class WhoopBleClient(
             if (debugLogcat) Log.d(TAG, safe)
             // Mirror into the in-app ring buffer (format under the lock — SimpleDateFormat isn't
             // thread-safe and log() is called from both the GATT binder thread and the main looper).
+            // #1263: while under the lock, snapshot the tail for the durable mirror every N lines (so the
+            // SharedPreferences write itself happens OUTSIDE the monitor, off the hot per-line path).
+            var tailToPersist: List<String>? = null
             val stamped = synchronized(logBuffer) {
                 val line = "${logTimeFmt.format(System.currentTimeMillis())}  $safe"
                 logBuffer.addLast(line)
                 while (logBuffer.size > LOG_BUFFER_MAX) logBuffer.removeFirst()
+                if (++logsSincePersist >= LOG_TAIL_PERSIST_EVERY) {
+                    logsSincePersist = 0
+                    tailToPersist = logBuffer.toList()
+                }
                 line
             }
+            // #1263: durable-tail mirror (batched), OUTSIDE the logBuffer monitor.
+            tailToPersist?.let { persistLogTail(it) }
             // #1121: when detailed capture is on, ALSO append the (already PII-scrubbed) line to the
             // rolling on-device file, so a long-running issue is captured for hours rather than only the
             // ~5000-line (~50 min) in-memory ring. No-op + near-zero cost when capture is off, and inside
@@ -8248,8 +8363,22 @@ class WhoopBleClient(
         log("bondState $detail", com.noop.testcentre.TestDomain.CONNECTION)
     }
 
-    /** Snapshot of the recent strap log, newest last, for the "Share strap log" diagnostics export. */
-    fun exportLogText(): String = synchronized(logBuffer) { logBuffer.joinToString("\n") }
+    /**
+     * Snapshot of the recent strap log, newest last, for the "Share strap log" diagnostics export.
+     *
+     * #1263: previous app sessions come FIRST (oldest-first, each with its own header, then a
+     * "===== current app session =====" marker), so `report.txt` stays chronological and the log-parsing
+     * tools read it unchanged — they just get the session a restart used to erase. We roll here too, not only
+     * in [log], because a user can open the app and export BEFORE this process logs its first line — at which
+     * point the surviving tail is still unrolled and [logBuffer] is empty. The roll is latched + a no-op on an
+     * empty tail, so it's harmless when [log] already ran.
+     */
+    fun exportLogText(): String {
+        rollLogGenerationsIfNeeded()
+        val previous = com.noop.ui.StrapLogGenerations.previousSessionsText(persistedLogGenerations())
+        val current = synchronized(logBuffer) { logBuffer.joinToString("\n") }
+        return previous + current
+    }
 }
 
 // PII scrubbers for the shareable strap log (#445). Kept at FILE scope (not inside WhoopBleClient) so

--- a/android/app/src/main/java/com/noop/ui/StrapLogGenerations.kt
+++ b/android/app/src/main/java/com/noop/ui/StrapLogGenerations.kt
@@ -1,0 +1,73 @@
+package com.noop.ui
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/**
+ * Pure, JVM-testable logic for the strap-log "generation ring" (#1263 item 2 — Android parity for the
+ * iOS `LiveState` generations in `Strand/BLE/LiveState.swift`, issues #1259 / #1264).
+ *
+ * WHY THIS EXISTS. Android's live strap log ([com.noop.ble.WhoopBleClient.logBuffer]) lives ONLY for the
+ * life of the process, and an export renders exactly that — so an export taken after the app process has
+ * restarted begins at the restart, and the lines that would explain the restart are gone. To fix that,
+ * [com.noop.ble.WhoopBleClient] now mirrors a DURABLE tail to SharedPreferences and, at the first log line
+ * of each process (and at export time), ROLLS the surviving tail into a small ring of previous generations.
+ * Exports render the generations oldest-first ahead of the current session, keeping `report.txt` in
+ * chronological order so the log-parsing tools read it unchanged — they just get the session a restart
+ * used to erase.
+ *
+ * This object is the PURE part: it operates only on `List<String>` / `List<List<String>>`, holds no
+ * Android types and does no I/O, so it unit-tests directly (like [StrapLogBuffer]). The SharedPreferences
+ * read/write is the thin, untested wrapper in [com.noop.ble.WhoopBleClient] — the same split iOS has
+ * between its pure ring logic and UserDefaults.
+ */
+object StrapLogGenerations {
+
+    /** How many previous processes to keep. Three covers the observed failure shape (a wake-time restart,
+     *  occasionally two) without turning a debug tail into a database. Mirrors iOS `maxLogGenerations`. */
+    const val MAX_GENERATIONS = 3
+
+    /** Per-generation line cap — smaller than the durable live tail because what explains a stop is the END
+     *  of the previous session. 3 × 1,000 short redacted lines ≈ 300 KB, bounded. Mirrors iOS
+     *  `generationTailLimit`. */
+    const val GENERATION_TAIL_LIMIT = 1_000
+
+    /**
+     * Roll the surviving durable [previousTail] into the generation ring: prepend a self-describing header,
+     * clip the tail to [GENERATION_TAIL_LIMIT] keeping the NEWEST lines (what explains a stop is the end of
+     * the previous session, not its start), append it to [existing], and drop the oldest beyond
+     * [MAX_GENERATIONS].
+     *
+     * A NO-OP (returns [existing] unchanged) when [previousTail] is empty, so a launch that logged nothing —
+     * or a roll that already ran this process — never pushes an empty generation and never evicts a real one.
+     *
+     * [nowMs] stamps the header as when the roll happened (i.e. THIS launch), NOT when those lines were
+     * written — the lines carry their own clock. Said plainly in the text so nobody reads it as the session's
+     * end. Pure: the caller owns reading [existing] and persisting the result.
+     */
+    fun roll(previousTail: List<String>, existing: List<List<String>>, nowMs: Long): List<List<String>> {
+        if (previousTail.isEmpty()) return existing
+        val iso = Instant.ofEpochMilli(nowMs).truncatedTo(ChronoUnit.SECONDS).toString()
+        val header = "===== previous app session, ${previousTail.size} line(s), rolled at $iso (this launch) ====="
+        val clipped = if (previousTail.size > GENERATION_TAIL_LIMIT) {
+            previousTail.subList(previousTail.size - GENERATION_TAIL_LIMIT, previousTail.size)
+        } else previousTail
+        val gens = existing.toMutableList()
+        gens.add(listOf(header) + clipped)
+        while (gens.size > MAX_GENERATIONS) gens.removeAt(0)
+        return gens
+    }
+
+    /**
+     * The previous processes' lines, oldest-first, ready to sit AHEAD of the current session in an export.
+     * Each generation is its own newline-joined block (its first line is its own separator header), and a
+     * "===== current app session =====" marker follows so the reader can see where the live tail begins.
+     * Empty string when there are no generations, so a caller can concatenate unconditionally. Mirrors iOS
+     * `previousSessionsText()`.
+     */
+    fun previousSessionsText(generations: List<List<String>>): String {
+        if (generations.isEmpty()) return ""
+        return generations.joinToString("\n") { it.joinToString("\n") } + "\n" +
+            "===== current app session =====\n"
+    }
+}

--- a/android/app/src/test/java/com/noop/ui/StrapLogGenerationsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/StrapLogGenerationsTest.kt
@@ -1,0 +1,109 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the pure strap-log "generation ring" logic (#1263 item 2 — Android parity for the iOS
+ * `LiveStateLogGenerationsTests`). The durable strap-log tail used to be lost entirely on process death:
+ * a fresh process began logging and its own mirror overwrote the previous session's tail before anyone
+ * could read it — so the lines that would explain an unexplained restart were destroyed BY the restart.
+ * These guard the ring that rescues the surviving tail into a bounded set of previous generations.
+ *
+ * Pure JVM (no Android, no SharedPreferences), so it runs directly in the unit-test JVM — the ring MATH
+ * lives in [StrapLogGenerations]; the persistence + once-per-process latch is the thin, untested
+ * SharedPreferences wrapper in `WhoopBleClient` (the same split iOS has with UserDefaults).
+ */
+class StrapLogGenerationsTest {
+
+    private val now = 1_700_000_000_000L
+
+    /** THE ONE THAT MATTERS: a surviving tail is moved into a generation, keeping its own header. */
+    @Test
+    fun rollMovesTheSurvivingTailIntoAGeneration() {
+        val gens = StrapLogGenerations.roll(
+            listOf("22:01 connected", "22:02 drain done"), emptyList(), now,
+        )
+        assertEquals(1, gens.size)
+        assertEquals(listOf("22:01 connected", "22:02 drain done"), gens[0].drop(1))
+        assertTrue("generation must carry its own header", gens[0][0].contains("previous app session"))
+        assertTrue("header must say it's this launch's roll", gens[0][0].contains("this launch"))
+    }
+
+    /**
+     * Once-per-process, expressed purely: after a roll the wrapper CLEARS the live slot, so the next roll
+     * sees an EMPTY tail and must push nothing — otherwise it would evict a real generation and mislabel
+     * this process's own lines as a "previous" session.
+     */
+    @Test
+    fun rollAfterClearedTailAddsNothing() {
+        val first = StrapLogGenerations.roll(listOf("old line"), emptyList(), now)
+        assertEquals(1, first.size)
+        // The client clears the tail after a successful roll; a second roll therefore gets an empty tail.
+        val second = StrapLogGenerations.roll(emptyList(), first, now)
+        assertEquals("a cleared/empty tail must not push a second generation", 1, second.size)
+        assertEquals(first, second)
+    }
+
+    /** A launch that logs nothing must not push an empty generation — that would evict a real one. */
+    @Test
+    fun emptyTailRollsNothing() {
+        val gens = StrapLogGenerations.roll(emptyList(), emptyList(), now)
+        assertEquals(0, gens.size)
+    }
+
+    /** The ring is bounded and drops the OLDEST, keeping the most recent restarts. */
+    @Test
+    fun ringKeepsTheMostRecentGenerations() {
+        var gens: List<List<String>> = emptyList()
+        for (i in 1..(StrapLogGenerations.MAX_GENERATIONS + 2)) {
+            gens = StrapLogGenerations.roll(listOf("session $i"), gens, now)
+        }
+        assertEquals(StrapLogGenerations.MAX_GENERATIONS, gens.size)
+        assertEquals("oldest generations are evicted first", "session 3", gens.first().drop(1).first())
+        assertEquals("session ${StrapLogGenerations.MAX_GENERATIONS + 2}", gens.last().drop(1).first())
+    }
+
+    /** Each generation is clipped to its own cap, keeping the TAIL — what explains a stop is the END of the
+     *  previous session, not its start — so the ring can't grow persistence without bound. */
+    @Test
+    fun generationIsClippedToItsTail() {
+        val many = (0 until (StrapLogGenerations.GENERATION_TAIL_LIMIT + 50)).map { "line $it" }
+        val gens = StrapLogGenerations.roll(many, emptyList(), now)
+        val body = gens[0].drop(1)
+        assertEquals(StrapLogGenerations.GENERATION_TAIL_LIMIT, body.size)
+        assertEquals(
+            "the newest line must survive",
+            "line ${StrapLogGenerations.GENERATION_TAIL_LIMIT + 49}", body.last(),
+        )
+    }
+
+    /** The export puts previous sessions AHEAD of the current-session marker, so `report.txt` stays
+     *  chronological and the log-parsing tools keep working on it unchanged. */
+    @Test
+    fun previousSessionsTextPrecedesTheCurrentMarker() {
+        val gens = StrapLogGenerations.roll(listOf("last night 03:00 disconnected"), emptyList(), now)
+        val text = StrapLogGenerations.previousSessionsText(gens)
+        val prevIdx = text.indexOf("last night 03:00 disconnected")
+        val curIdx = text.indexOf("current app session")
+        assertTrue(prevIdx >= 0)
+        assertTrue(curIdx >= 0)
+        assertTrue("previous session must precede the current marker", prevIdx < curIdx)
+    }
+
+    /** Oldest-first across multiple generations, each keeping its own header block. */
+    @Test
+    fun previousSessionsTextIsOldestFirst() {
+        var gens: List<List<String>> = emptyList()
+        gens = StrapLogGenerations.roll(listOf("older session line"), gens, now)
+        gens = StrapLogGenerations.roll(listOf("newer session line"), gens, now)
+        val text = StrapLogGenerations.previousSessionsText(gens)
+        assertTrue(text.indexOf("older session line") < text.indexOf("newer session line"))
+    }
+
+    @Test
+    fun noGenerationsRendersNothing() {
+        assertEquals("", StrapLogGenerations.previousSessionsText(emptyList()))
+    }
+}


### PR DESCRIPTION
Android parity for the iOS strap-log generation ring (#1259/#1264). Android's log was in-memory only, so an export after a process restart lost the previous session. Adds a SharedPreferences durable tail + a 3-generation ring (pure JVM-testable StrapLogGenerations + a thin WhoopBleClient wrapper), rolled once per process at the first log() and at export time, thread-safe under genLock (log() runs on the GATT + main threads). exportLogText() prepends previous sessions. 8 pure tests mirror the iOS ones; compile + tests + i18n green. Resolves #1263 (last item). Diagnostics infra — behavior parity, not byte-identical.