### PR TITLE
Sleep: nap-card "Main sleep" total = whole bridged night (Android parity with iOS)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -1251,8 +1251,17 @@ private fun Hero(
         // with the SAME mechanism main sleep uses, plus a Main / Nap(s) / Total split so what drives the
         // day's Rest total is explainable. Mirrors iOS SleepView.napSection.
         if (session != null) {
+            // Main = the WHOLE bridged main-night group's summed stage minutes (`display.stages.total`,
+            // the shared SleepModel's group total), NOT the winning fragment's window — a biphasic/
+            // bridged night has sibling fragments that are part of the main sleep, not naps. Mirrors iOS
+            // SleepView.napSection (`night.stages.total`); the old single-block window undercounted the
+            // Main / Total split on a fragmented night and disagreed with the hero above it. Window
+            // fallback only for a stage-less stub day (display == null), byte-identical to before there.
+            val mainMin = display?.stages?.total
+                ?: (session.endTs - session.effectiveStartTs) / 60.0
             NapsCard(
                 main = session,
+                mainMin = mainMin,
                 naps = napBlocks,
                 onEditNapTimes = onUpdateTimes,
                 onDeleteNap = onDeleteSession,
@@ -1274,6 +1283,10 @@ private fun Hero(
 @Composable
 private fun NapsCard(
     main: SleepSession,
+    // The day's MAIN-sleep minutes = the whole bridged main-night group's summed stage minutes
+    // (iOS `night.stages.total`), passed in from the hero's already-resolved `display.stages.total`
+    // so the split matches the hero. NOT `main`'s own window — that undercounts a bridged night.
+    mainMin: Double,
     naps: List<SleepSession>,
     onEditNapTimes: (SleepSession, Long, Long) -> Unit,
     onDeleteNap: (SleepSession) -> Unit,
@@ -1283,7 +1296,6 @@ private fun NapsCard(
     // Active strap is an Oura ring → a computed night's provenance reads "Oura" not "On-device" (C4).
     activeIsOura: Boolean = false,
 ) {
-    val mainMin = (main.endTs - main.effectiveStartTs) / 60.0
     val napMin = naps.sumOf { (it.endTs - it.effectiveStartTs) / 60.0 }
     NoopCard(padding = Metrics.space14, tint = Palette.restColor) {
         Column(verticalArrangement = Arrangement.spacedBy(Metrics.space12)) {


### PR DESCRIPTION
## What

On Android's Sleep tab, the **Naps** card's Main / Nap(s) / Total split computed **"Main sleep"** from a *single* fragment's window — `(main.endTs − main.effectiveStartTs)`. On a **bridged / biphasic** night (a brief mid-night wake splits the night into stored fragments < `GAP_BRIDGE_MAX_MIN`), that names only the winning fragment and **silently drops the night's siblings**, so both "Main sleep" and "Total" undercounted — and disagreed with the hero directly above the card.

iOS has always used the whole bridged main-night group's **summed stage minutes** (`night.stages.total`); Android was the outlier.

## Fix

Route the card's Main to the hero's already-resolved **`display.stages.total`** — the shared `SleepModel`'s group stage total (`sumGroupStages`, inter-fragment gaps excluded), which is the byte-for-byte twin of iOS `night.stages.total`. This is the same number the hero shows, so the split now agrees with it.

- Also corrects the **single-block** case, which previously used the raw window instead of stage minutes.
- A **stage-less stub day** (`display == null`) keeps the window fallback — byte-identical to prior behaviour there.
- **iOS was already correct** → Android-only parity fix (no Swift change; noted per the parity contract).

## Provenance

Surfaced while reviewing OpenStrap's recent sleep/nap commits for anything portable — this is a pre-existing **noop** cross-platform divergence found in the process, not a port. The OpenStrap fixes themselves didn't apply (noop is structurally immune to their nap bugs).

## Verification

- `./gradlew compileFullDebugKotlin` — clean.
- Sleep/nap unit suites green (`MainSleepSpanTest`, `ManualNapTest`, `MainNightConsistencyTest`, `SleepDebtTest`, `com.noop.ui.*Sleep*`).
- `Tools/i18n_audit.py --ci main` — no new literals (reuses existing labels).
- The Main value flows through `sumGroupStages` / the shared `SleepModel`, already covered by the group-total parity tests.