### PR TITLE
Calories: use the Keytel fitness-adjusted (VO2max) model when a resting HR is known

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
@@ -398,21 +398,38 @@ public enum Calories {
         let restingWeight: Double
         let restingHeight: Double  // applied to height in METRES
         let restingAge: Double
+        // Keytel 2005 base (fitness-blind) active model: EE(kJ/min) = alpha + hr·HR + wt·W + age·A.
         let workoutHR: Double
         let workoutWeight: Double
         let workoutAge: Double
         let workoutAlpha: Double
+        // Keytel 2005 fitness-ADJUSTED active model, which reads VO2max and is the more accurate
+        // form the authors published: EE(kJ/min) = fitAlpha + fitHR·HR + fitVO2·VO2max + fitWeight·W
+        // + fitAge·A. Used only when a resting HR is known (so a Uth VO2max can be derived); otherwise
+        // the base workout* model above is used, unchanged. (Keytel et al. 2005, J. Sports Sci. 23(3).)
+        let fitHR: Double
+        let fitVO2: Double
+        let fitWeight: Double
+        let fitAge: Double
+        let fitAlpha: Double
     }
 
     static let male = Coeffs(restingAlpha: 88.362, restingWeight: 13.397, restingHeight: 479.9,
                              restingAge: 5.677, workoutHR: 0.6309, workoutWeight: 0.1988,
-                             workoutAge: 0.2017, workoutAlpha: -55.0969)
+                             workoutAge: 0.2017, workoutAlpha: -55.0969,
+                             fitHR: 0.634, fitVO2: 0.404, fitWeight: 0.394, fitAge: 0.271,
+                             fitAlpha: -95.7735)
     static let female = Coeffs(restingAlpha: 447.593, restingWeight: 9.247, restingHeight: 309.8,
                                restingAge: 4.33, workoutHR: 0.4472, workoutWeight: -0.1263,
-                               workoutAge: 0.0740, workoutAlpha: -20.4022)
+                               workoutAge: 0.0740, workoutAlpha: -20.4022,
+                               fitHR: 0.450, fitVO2: 0.380, fitWeight: 0.103, fitAge: 0.274,
+                               fitAlpha: -59.3954)
+    // Nonbinary = the male/female midpoint, the same convention the base workout* coeffs use.
     static let nonbinary = Coeffs(restingAlpha: 267.9775, restingWeight: 11.322, restingHeight: 394.85,
                                   restingAge: 5.0035, workoutHR: 0.53905, workoutWeight: 0.03625,
-                                  workoutAge: 0.13785, workoutAlpha: -37.74955)
+                                  workoutAge: 0.13785, workoutAlpha: -37.74955,
+                                  fitHR: 0.542, fitVO2: 0.392, fitWeight: 0.2485, fitAge: 0.2725,
+                                  fitAlpha: -77.58445)
 
     static let activeHRRFraction = 0.30
     /// Whole-day active gate (`estimateDayCalories` only). The Keytel 2005 equation is
@@ -440,9 +457,29 @@ public enum Calories {
         return max(0.0, bmr) / 86_400.0
     }
 
-    static func activeKcalPerS(_ c: Coeffs, hr: Double, hrmax: Double, weightKg: Double, age: Double) -> Double {
-        let eeKjMin = c.workoutHR * min(hr, hrmax) + c.workoutWeight * weightKg
-            + c.workoutAge * age + c.workoutAlpha
+    /// Uth–Sørensen VO2max estimate (ml·kg⁻¹·min⁻¹) ≈ 15.3 · HRmax / HRrest. Returns nil when no
+    /// usable resting HR — the caller then keeps the base (fitness-blind) Keytel model, so a strap
+    /// with no resting baseline is scored exactly as before. A function of HRmax + resting HR ONLY,
+    /// so every call site resolves it locally and day derivation stays deterministic (no cross-day
+    /// dependency). (Uth et al. 2004, Eur. J. Appl. Physiol. 91.)
+    static func vo2maxFor(hrmax: Double, restingHR: Double?) -> Double? {
+        guard let rhr = restingHR, rhr > 0, hrmax > 0 else { return nil }
+        return 15.3 * hrmax / rhr
+    }
+
+    /// Active energy rate (kcal/s). With `vo2max` present, uses the Keytel 2005 fitness-ADJUSTED
+    /// equation (personalizes beyond age/weight/sex); with nil, the base fitness-blind Keytel model,
+    /// byte-identical to before. HR is capped at HRmax in both, as the base model always did.
+    static func activeKcalPerS(_ c: Coeffs, hr: Double, hrmax: Double, weightKg: Double, age: Double,
+                               vo2max: Double? = nil) -> Double {
+        let eeKjMin: Double
+        if let vo2 = vo2max {
+            eeKjMin = c.fitHR * min(hr, hrmax) + c.fitVO2 * vo2 + c.fitWeight * weightKg
+                + c.fitAge * age + c.fitAlpha
+        } else {
+            eeKjMin = c.workoutHR * min(hr, hrmax) + c.workoutWeight * weightKg
+                + c.workoutAge * age + c.workoutAlpha
+        }
         return max(0.0, eeKjMin) / workoutDivisor
     }
 
@@ -469,6 +506,9 @@ public enum Calories {
         let activeThreshold = effResting + activeHRRFraction * (effHRmax - effResting)
 
         let restingRate = restingKcalPerS(coeffs, weightKg: weightKg, heightCm: heightCm, age: age)
+        // Fitness anchor (Uth VO2max) when a resting HR is known → the Keytel fitness-adjusted rate;
+        // nil restingHR → base model, unchanged. Computed once (constant across the bout).
+        let vo2max = vo2maxFor(hrmax: effHRmax, restingHR: restingHR)
 
         // Weight each sample by the ACTUAL elapsed time to the next sample, not a flat 1 s.
         // restingRate / activeKcalPerS are per-SECOND rates, so summing one per sample only
@@ -492,7 +532,7 @@ public enum Calories {
             if bpm < activeThreshold {
                 totalKcal += restingRate * dur
             } else {
-                totalKcal += activeKcalPerS(coeffs, hr: bpm, hrmax: effHRmax, weightKg: weightKg, age: age) * dur
+                totalKcal += activeKcalPerS(coeffs, hr: bpm, hrmax: effHRmax, weightKg: weightKg, age: age, vo2max: vo2max) * dur
             }
         }
         return (totalKcal, totalKcal * 4.184)
@@ -537,6 +577,9 @@ public enum Calories {
         let activeThreshold = effResting + dayActiveHRRFraction * (effHRmax - effResting)
 
         let restingRate = restingKcalPerS(coeffs, weightKg: weightKg, heightCm: heightCm, age: age)
+        // Fitness anchor (Uth VO2max) when a resting HR is known → Keytel fitness-adjusted rate; nil
+        // restingHR → base model, unchanged. Constant across the day.
+        let vo2max = vo2maxFor(hrmax: effHRmax, restingHR: restingHR)
 
         var totalKcal = 0.0
         for s in hrSamples {
@@ -547,7 +590,7 @@ public enum Calories {
                 // Floor the active rate at the resting BMR rate: a worn day-second never burns
                 // LESS than resting metabolism, even where the Keytel value dips low for some
                 // profiles just above the gate.
-                let active = activeKcalPerS(coeffs, hr: bpm, hrmax: effHRmax, weightKg: weightKg, age: age)
+                let active = activeKcalPerS(coeffs, hr: bpm, hrmax: effHRmax, weightKg: weightKg, age: age, vo2max: vo2max)
                 totalKcal += max(restingRate, active)
             }
         }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Vo2maxCaloriesTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Vo2maxCaloriesTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import StrandAnalytics
+import WhoopProtocol
+
+/// The Keytel 2005 FITNESS-ADJUSTED calorie path: when a resting HR is known, a Uth VO2max
+/// (15.3·HRmax/HRrest) is threaded into the more accurate Keytel equation that reads fitness; with
+/// no resting HR the estimator falls back to the base (fitness-blind) model, byte-identical to
+/// before. Expected values hand-computed from the published coefficients — the Kotlin twin
+/// `Vo2maxCaloriesTest` asserts the SAME literals, which is the cross-platform parity contract.
+final class Vo2maxCaloriesTests: XCTestCase {
+
+    func testVo2maxForIsUthAndNilWithoutRestingHR() {
+        XCTAssertEqual(Calories.vo2maxFor(hrmax: 190.0, restingHR: 50.0)!, 58.14, accuracy: 1e-9)
+        XCTAssertNil(Calories.vo2maxFor(hrmax: 190.0, restingHR: nil))
+        XCTAssertNil(Calories.vo2maxFor(hrmax: 190.0, restingHR: 0.0))
+        XCTAssertNil(Calories.vo2maxFor(hrmax: 0.0, restingHR: 50.0))
+    }
+
+    func testActiveRateUsesFitnessModelWhenVo2maxKnown() {
+        let r = Calories.activeKcalPerS(Calories.male, hr: 150.0, hrmax: 190.0, weightKg: 80.0, age: 30.0, vo2max: 58.14)
+        XCTAssertEqual(r, 0.248825127469726, accuracy: 1e-12)
+    }
+
+    func testActiveRateFallsBackToBaseWhenNoVo2max() {
+        let base = Calories.activeKcalPerS(Calories.male, hr: 150.0, hrmax: 190.0, weightKg: 80.0, age: 30.0, vo2max: nil)
+        XCTAssertEqual(base, 0.24495339388145318, accuracy: 1e-12)
+        // The whole point: the fitness anchor MOVES the number (here it is higher).
+        let fit = Calories.activeKcalPerS(Calories.male, hr: 150.0, hrmax: 190.0, weightKg: 80.0, age: 30.0, vo2max: 58.14)
+        XCTAssertNotEqual(fit, base)
+    }
+
+    func testFemaleAndNonbinaryFitnessCoeffs() {
+        XCTAssertEqual(
+            Calories.activeKcalPerS(Calories.female, hr: 150.0, hrmax: 190.0, weightKg: 80.0, age: 30.0, vo2max: 58.14),
+            0.18585803059273417, accuracy: 1e-12)
+        XCTAssertEqual(
+            Calories.activeKcalPerS(Calories.nonbinary, hr: 150.0, hrmax: 190.0, weightKg: 80.0, age: 30.0, vo2max: 58.14),
+            0.2173415790312301, accuracy: 1e-12)
+    }
+
+    func testBoutThreadsVo2maxWhenRestingHRKnown() {
+        // Dense 1 Hz bout, 60 s all at HR 150 (well above the 92 bpm active gate for RHR 50 / HRmax 190),
+        // male 80 kg / age 30. Every second is billed the fitness active rate → total = 60 × that rate.
+        let profile = UserProfile(weightKg: 80, heightCm: 180, age: 30, sex: "male")
+        let hr = (0..<60).map { HRSample(ts: $0, bpm: 150) }
+        let kcal = Calories.estimateBoutCalories(hr, profile: profile, hrmax: 190.0, restingHR: 50.0).0
+        XCTAssertEqual(kcal, 0.248825127469726 * 60, accuracy: 1e-9)
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/WorkoutDetectorTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/WorkoutDetectorTests.swift
@@ -26,11 +26,14 @@ final class WorkoutDetectorTests: XCTestCase {
     // MARK: - Calories
 
     func testCaloriesActiveAndRestingMale() {
-        // 600 active samples at 150 bpm, male 80 kg 30 y, hrmax 190 → matches Python golden.
+        // 600 active samples at 150 bpm, male 80 kg 30 y, hrmax 190, RHR 60. With a resting HR known,
+        // the Keytel FITNESS-adjusted model runs (Uth VO2max = 15.3·190/60 = 48.45): 58.5503 kJ/min ×
+        // 600 s / 251.04 = 139.9386 kcal. (The base fitness-blind model gave 146.972.) MUST match the
+        // Kotlin twin Vo2maxCaloriesTest.caloriesActiveAndRestingMale_matchesSwiftGolden.
         let hr = (0..<600).map { HRSample(ts: $0, bpm: 150) }
         let profile = UserProfile(weightKg: 80, heightCm: 180, age: 30, sex: "male")
         let (kcal, kj) = Calories.estimateBoutCalories(hr, profile: profile, hrmax: 190, restingHR: 60)
-        XCTAssertEqual(kcal, 146.972, accuracy: 0.1)
+        XCTAssertEqual(kcal, 139.9386, accuracy: 0.1)
         XCTAssertEqual(kj, kcal * 4.184, accuracy: 1e-6)
     }
 

--- a/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
+++ b/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
@@ -414,26 +414,40 @@ object Calories {
         /** Applied to height in METRES. */
         val restingHeight: Double,
         val restingAge: Double,
+        // Keytel 2005 base (fitness-blind) active model: EE(kJ/min) = alpha + hr·HR + wt·W + age·A.
         val workoutHR: Double,
         val workoutWeight: Double,
         val workoutAge: Double,
         val workoutAlpha: Double,
+        // Keytel 2005 fitness-ADJUSTED active model, which reads VO2max and is the more accurate form
+        // the authors published: EE(kJ/min) = fitAlpha + fitHR·HR + fitVO2·VO2max + fitWeight·W + fitAge·A.
+        // Used only when a resting HR is known (so a Uth VO2max can be derived); otherwise the base
+        // workout* model above, unchanged. (Keytel et al. 2005, J. Sports Sci. 23(3).)
+        val fitHR: Double,
+        val fitVO2: Double,
+        val fitWeight: Double,
+        val fitAge: Double,
+        val fitAlpha: Double,
     )
 
     val male = Coeffs(
         restingAlpha = 88.362, restingWeight = 13.397, restingHeight = 479.9,
         restingAge = 5.677, workoutHR = 0.6309, workoutWeight = 0.1988,
         workoutAge = 0.2017, workoutAlpha = -55.0969,
+        fitHR = 0.634, fitVO2 = 0.404, fitWeight = 0.394, fitAge = 0.271, fitAlpha = -95.7735,
     )
     val female = Coeffs(
         restingAlpha = 447.593, restingWeight = 9.247, restingHeight = 309.8,
         restingAge = 4.33, workoutHR = 0.4472, workoutWeight = -0.1263,
         workoutAge = 0.0740, workoutAlpha = -20.4022,
+        fitHR = 0.450, fitVO2 = 0.380, fitWeight = 0.103, fitAge = 0.274, fitAlpha = -59.3954,
     )
+    // Nonbinary = the male/female midpoint, the same convention the base workout* coeffs use.
     val nonbinary = Coeffs(
         restingAlpha = 267.9775, restingWeight = 11.322, restingHeight = 394.85,
         restingAge = 5.0035, workoutHR = 0.53905, workoutWeight = 0.03625,
         workoutAge = 0.13785, workoutAlpha = -37.74955,
+        fitHR = 0.542, fitVO2 = 0.392, fitWeight = 0.2485, fitAge = 0.2725, fitAlpha = -77.58445,
     )
 
     const val activeHRRFraction: Double = 0.30
@@ -463,9 +477,31 @@ object Calories {
         return maxOf(0.0, bmr) / 86_400.0
     }
 
-    fun activeKcalPerS(c: Coeffs, hr: Double, hrmax: Double, weightKg: Double, age: Double): Double {
-        val eeKjMin = c.workoutHR * minOf(hr, hrmax) + c.workoutWeight * weightKg +
-            c.workoutAge * age + c.workoutAlpha
+    /**
+     * Uth–Sørensen VO2max estimate (ml·kg⁻¹·min⁻¹) ≈ 15.3 · HRmax / HRrest. Returns null when no
+     * usable resting HR — the caller then keeps the base (fitness-blind) Keytel model, so a strap with
+     * no resting baseline is scored exactly as before. A function of HRmax + resting HR ONLY, so every
+     * call site resolves it locally and day derivation stays deterministic (no cross-day dependency).
+     * (Uth et al. 2004, Eur. J. Appl. Physiol. 91.)
+     */
+    fun vo2maxFor(hrmax: Double, restingHR: Double?): Double? {
+        if (restingHR == null || restingHR <= 0.0 || hrmax <= 0.0) return null
+        return 15.3 * hrmax / restingHR
+    }
+
+    /**
+     * Active energy rate (kcal/s). With [vo2max] present, uses the Keytel 2005 fitness-ADJUSTED
+     * equation (personalizes beyond age/weight/sex); with null, the base fitness-blind Keytel model,
+     * byte-identical to before. HR is capped at HRmax in both, as the base model always did.
+     */
+    fun activeKcalPerS(c: Coeffs, hr: Double, hrmax: Double, weightKg: Double, age: Double, vo2max: Double? = null): Double {
+        val eeKjMin = if (vo2max != null) {
+            c.fitHR * minOf(hr, hrmax) + c.fitVO2 * vo2max + c.fitWeight * weightKg +
+                c.fitAge * age + c.fitAlpha
+        } else {
+            c.workoutHR * minOf(hr, hrmax) + c.workoutWeight * weightKg +
+                c.workoutAge * age + c.workoutAlpha
+        }
         return maxOf(0.0, eeKjMin) / workoutDivisor
     }
 
@@ -501,6 +537,9 @@ object Calories {
         val activeThreshold = effResting + activeHRRFraction * (effHRmax - effResting)
 
         val restingRate = restingKcalPerS(coeffs, weightKg, heightCm, age)
+        // Fitness anchor (Uth VO2max) when a resting HR is known → the Keytel fitness-adjusted rate;
+        // null restingHR → base model, unchanged. Computed once (constant across the bout).
+        val vo2max = vo2maxFor(effHRmax, restingHR)
 
         // Weight each sample by the ACTUAL elapsed time to the next sample, not a flat 1 s.
         // restingRate / activeKcalPerS are per-SECOND rates, so summing one per sample only
@@ -523,7 +562,7 @@ object Calories {
             totalKcal += if (bpm < activeThreshold) {
                 restingRate * dur
             } else {
-                activeKcalPerS(coeffs, bpm, effHRmax, weightKg, age) * dur
+                activeKcalPerS(coeffs, bpm, effHRmax, weightKg, age, vo2max) * dur
             }
         }
         return totalKcal to (totalKcal * 4.184)
@@ -580,6 +619,9 @@ object Calories {
         val activeThreshold = effResting + dayActiveHRRFraction * (effHRmax - effResting)
 
         val restingRate = restingKcalPerS(coeffs, weightKg, heightCm, age)
+        // Fitness anchor (Uth VO2max) when a resting HR is known → Keytel fitness-adjusted rate; null
+        // restingHR → base model, unchanged. Constant across the day.
+        val vo2max = vo2maxFor(effHRmax, restingHR)
 
         var totalKcal = 0.0
         for (s in hrSamples) {
@@ -590,7 +632,7 @@ object Calories {
                 // Floor the active rate at the resting BMR rate: a worn day-second never
                 // burns LESS than resting metabolism, even where the Keytel value dips low
                 // for some profiles just above the gate.
-                maxOf(restingRate, activeKcalPerS(coeffs, bpm, effHRmax, weightKg, age))
+                maxOf(restingRate, activeKcalPerS(coeffs, bpm, effHRmax, weightKg, age, vo2max))
             }
         }
         return totalKcal

--- a/android/app/src/test/java/com/noop/analytics/Vo2maxCaloriesTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/Vo2maxCaloriesTest.kt
@@ -1,0 +1,57 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The Keytel 2005 FITNESS-ADJUSTED calorie path: when a resting HR is known, a Uth VO2max
+ * (15.3·HRmax/HRrest) is threaded into the more accurate Keytel equation that reads fitness;
+ * with no resting HR the estimator falls back to the base (fitness-blind) model, byte-identical
+ * to before. Expected values hand-computed from the published coefficients (see the Swift twin
+ * Vo2maxCaloriesTests — the two MUST agree, that is the cross-platform contract).
+ */
+class Vo2maxCaloriesTest {
+
+    @Test
+    fun vo2maxForIsUthAndNullWithoutRestingHr() {
+        assertEquals(58.14, Calories.vo2maxFor(hrmax = 190.0, restingHR = 50.0)!!, 1e-9)
+        assertNull(Calories.vo2maxFor(hrmax = 190.0, restingHR = null))
+        assertNull(Calories.vo2maxFor(hrmax = 190.0, restingHR = 0.0))
+        assertNull(Calories.vo2maxFor(hrmax = 0.0, restingHR = 50.0))
+    }
+
+    @Test
+    fun activeRateUsesFitnessModelWhenVo2maxKnown() {
+        val r = Calories.activeKcalPerS(Calories.male, hr = 150.0, hrmax = 190.0, weightKg = 80.0, age = 30.0, vo2max = 58.14)
+        assertEquals(0.248825127469726, r, 1e-12)
+    }
+
+    @Test
+    fun activeRateFallsBackToBaseWhenNoVo2max() {
+        val base = Calories.activeKcalPerS(Calories.male, hr = 150.0, hrmax = 190.0, weightKg = 80.0, age = 30.0, vo2max = null)
+        assertEquals(0.24495339388145318, base, 1e-12)
+        // The whole point: the fitness anchor MOVES the number (here it is higher).
+        val fit = Calories.activeKcalPerS(Calories.male, hr = 150.0, hrmax = 190.0, weightKg = 80.0, age = 30.0, vo2max = 58.14)
+        assertTrue(fit != base)
+    }
+
+    @Test
+    fun femaleAndNonbinaryFitnessCoeffs() {
+        assertEquals(0.18585803059273417,
+            Calories.activeKcalPerS(Calories.female, hr = 150.0, hrmax = 190.0, weightKg = 80.0, age = 30.0, vo2max = 58.14), 1e-12)
+        assertEquals(0.2173415790312301,
+            Calories.activeKcalPerS(Calories.nonbinary, hr = 150.0, hrmax = 190.0, weightKg = 80.0, age = 30.0, vo2max = 58.14), 1e-12)
+    }
+
+    @Test
+    fun boutThreadsVo2maxWhenRestingHrKnown() {
+        // Dense 1 Hz bout, 60 s all at HR 150 (well above the 92 bpm active gate for RHR 50 / HRmax 190),
+        // male 80 kg / age 30. Every second is billed the fitness active rate → total = 60 × that rate.
+        val profile = UserProfile(weightKg = 80.0, heightCm = 180.0, age = 30.0, sex = "male")
+        val hr = (0 until 60).map { com.noop.data.HrSample(deviceId = "test", ts = it.toLong(), bpm = 150) }
+        val kcal = Calories.estimateBoutCalories(hr, profile, hrmax = 190.0, restingHR = 50.0).first
+        assertEquals(0.248825127469726 * 60, kcal, 1e-9)
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/Vo2maxCaloriesTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/Vo2maxCaloriesTest.kt
@@ -46,6 +46,17 @@ class Vo2maxCaloriesTest {
     }
 
     @Test
+    fun caloriesActiveAndRestingMale_matchesSwiftGolden() {
+        // Twin of Swift WorkoutDetectorTests.testCaloriesActiveAndRestingMale (which had NO Kotlin
+        // equivalent — this closes that gap). 600 s @150 bpm, male 80 kg / 30 y, hrmax 190, RHR 60 →
+        // Uth VO2max 48.45 → fitness model 58.5503 kJ/min × 600 / 251.04 = 139.9386 kcal.
+        val hr = (0 until 600).map { com.noop.data.HrSample(deviceId = "test", ts = it.toLong(), bpm = 150) }
+        val profile = UserProfile(weightKg = 80.0, heightCm = 180.0, age = 30.0, sex = "male")
+        val kcal = Calories.estimateBoutCalories(hr, profile, hrmax = 190.0, restingHR = 60.0).first
+        assertEquals(139.9386, kcal, 0.1)
+    }
+
+    @Test
     fun boutThreadsVo2maxWhenRestingHrKnown() {
         // Dense 1 Hz bout, 60 s all at HR 150 (well above the 92 bpm active gate for RHR 50 / HRmax 190),
         // male 80 kg / age 30. Every second is billed the fitness active rate → total = 60 × that rate.


### PR DESCRIPTION
## What

NOOP's HR-only calorie estimate uses the **base, fitness-blind** Keytel 2005 equation. Keytel published a **second, more accurate** equation that reads **VO₂max** — and it was going unused, so everyone was effectively scored against an average fitness level. This threads the fitness anchor in.

When a **resting HR is known**, derive a **Uth VO₂max** (`15.3·HRmax/HRrest`) and use the fitness-adjusted Keytel equation. With **no resting HR**, fall back to the base model — **byte-identical to before**.

## How

- `Coeffs` gains the fitness-model coefficients. `vo2maxFor(hrmax, restingHR)` returns `nil` without a usable resting HR (a function of HRmax + resting HR **only** → resolved locally at each call site, so day derivation stays deterministic — no cross-day dependency). `activeKcalPerS` gains an optional `vo2max`; `estimateBoutCalories` / `estimateDayCalories` compute it once and pass it.
- **Call-site signatures unchanged** — `AppModel` / `ManualWorkoutRescore` / `AnalyticsEngine` untouched. HR is still capped at HRmax; the day path still floors the active rate at the resting BMR rate.

## Sources (published — clean-room, facts not code)

- Base + fitness EE equations: **Keytel et al. 2005**, *J. Sports Sci.* 23(3):289–297. Fitness-adjusted coefficients (kJ/min): male `−95.7735 + 0.634·HR + 0.404·VO₂max + 0.394·W + 0.271·A`; female `−59.3954 + 0.450·HR + 0.380·VO₂max + 0.103·W + 0.274·A`; nonbinary = male/female midpoint (the existing convention). Cross-checked across two independent applied sources.
- VO₂max estimate: **Uth et al. 2004**, *Eur. J. Appl. Physiol.* 91 — `VO₂max ≈ 15.3·HRmax/HRrest`.

## Scope / honesty

- **This moves persisted kcal** for any workout/day that has a resting HR (the common case). Days with no resting HR are unchanged.
- NOOP re-derives recent days via `analyzeRecent`, so they pick up the new rate on the next pass; **history beyond that window keeps its stored values** — NOOP has no full-recompute/algo-version mechanism, so older days stay on the prior number. Flagging for awareness; not introducing one here (out of scope, one concern per PR).
- Not a novel raw-sensor derivation — it's a published, validated refinement of the **already-shipped** Keytel HR-calorie model, and it feeds no health gate (recovery/illness), only the calorie readout.

## Verification

- **Parity contract:** both platforms byte-identical (same coefficients, same math).
- Pure-function parity tests (`Vo2maxCaloriesTests` / `Vo2maxCaloriesTest`) hand-compute the fitness rate (`0.2488251…`), the base fallback (`0.2449534…`), female/nonbinary sets, and the Uth estimate from the published numbers, and assert the bout estimator threads the anchor when a resting HR is present.
- Full Android `testFullDebugUnitTest` green (no existing calorie assertion shifted). Swift side validated by `swift-packages.yml` (StrandAnalytics tests) — the Linux sqlite wall blocks local Swift compile.