### PR TITLE
Heatmap: scale the activity ramp to the 90th-percentile day (floored), not the max

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ActivityHeatmap.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ActivityHeatmap.swift
@@ -23,31 +23,40 @@ public enum ActivityHeatmap {
         }
     }
 
-    /// `columns` is `weeks` arrays of 7 cells (row 0 = Monday). `maxValue` scales the intensity ramp.
+    /// `columns` is `weeks` arrays of 7 cells (row 0 = Monday). `scale` is the ramp denominator: the
+    /// wearer's 90th-percentile ACTIVE day, floored at `rampFloorKcal`. Scaling to the percentile (not
+    /// the raw max) stops one exceptional session flattening the whole grid to pale; the floor keeps a
+    /// beginner's low-calorie days appropriately cool instead of maxing them out.
     public struct Grid: Equatable, Sendable {
         public let weeks: Int
         public let columns: [[Cell]]
-        public let maxValue: Double
-        public init(weeks: Int, columns: [[Cell]], maxValue: Double) {
+        public let scale: Double
+        public init(weeks: Int, columns: [[Cell]], scale: Double) {
             self.weeks = weeks
             self.columns = columns
-            self.maxValue = maxValue
+            self.scale = scale
         }
         public var isEmpty: Bool { columns.allSatisfy { col in col.allSatisfy { $0.value == nil } } }
     }
+
+    /// The ramp denominator floor (kcal): days at/above this shade fullest, so a light week reads cool
+    /// rather than maxing a beginner's grid. Mirrors OpenStrap's 250 kcal floor.
+    public static let rampFloorKcal = 250.0
+    /// Percentile of the active days the ramp scales to (90th).
+    public static let rampPercentile = 90.0
 
     /// - Parameters:
     ///   - values: day ("yyyy-MM-dd") → metric value. Missing days render as no-data cells.
     ///   - today: the "yyyy-MM-dd" anchoring the rightmost column.
     ///   - weeks: number of week columns (default 13).
     public static func build(values: [String: Double], today: String, weeks: Int = defaultWeeks) -> Grid {
-        guard let e = epochDay(today) else { return Grid(weeks: weeks, columns: [], maxValue: 0) }
+        guard let e = epochDay(today) else { return Grid(weeks: weeks, columns: [], scale: 0) }
         let cols = max(weeks, 1)
         let todayWeekday = mondayFirstWeekday(e)
         let currentMonday = e - todayWeekday
         let firstMonday = currentMonday - (cols - 1) * 7
 
-        var maxValue = 0.0
+        var active: [Double] = []   // present days with a positive value → the ramp's percentile basis
         var raw: [[Cell]] = []
         raw.reserveCapacity(cols)
         for c in 0..<cols {
@@ -60,23 +69,35 @@ public enum ActivityHeatmap {
                 } else {
                     let ds = civilDay(d)
                     let v = values[ds]
-                    if let v, v > maxValue { maxValue = v }
+                    if let v, v > 0 { active.append(v) }
                     col.append(Cell(day: ds, value: v, level: 0))
                 }
             }
             raw.append(col)
         }
+        let scale = rampScale(active)
         let leveled = raw.map { col in
-            col.map { Cell(day: $0.day, value: $0.value, level: levelFor($0.value, maxValue)) }
+            col.map { Cell(day: $0.day, value: $0.value, level: levelFor($0.value, scale)) }
         }
-        return Grid(weeks: cols, columns: leveled, maxValue: maxValue)
+        return Grid(weeks: cols, columns: leveled, scale: scale)
     }
 
-    /// 0 = no data; otherwise 1...4 by fraction of `maxValue` (a present-but-zero day is still level 1).
-    static func levelFor(_ value: Double?, _ maxValue: Double) -> Int {
+    /// Ramp denominator: the 90th-percentile ACTIVE day (nearest-rank, mirroring `deriveRestingHR`),
+    /// floored at `rampFloorKcal`. No active days → the floor. Scaling to the percentile rather than the
+    /// max keeps one huge session from washing every other day out to level 1.
+    static func rampScale(_ active: [Double]) -> Double {
+        guard !active.isEmpty else { return rampFloorKcal }
+        let sorted = active.sorted()
+        let rank = max(1, Int(ceil(rampPercentile / 100.0 * Double(sorted.count))))
+        let p90 = sorted[min(rank, sorted.count) - 1]
+        return max(rampFloorKcal, p90)
+    }
+
+    /// 0 = no data; otherwise 1...4 by fraction of `scale` (a present-but-zero day is still level 1).
+    static func levelFor(_ value: Double?, _ scale: Double) -> Int {
         guard let value else { return 0 }
-        if maxValue <= 0 { return 1 }
-        return min(max(Int(ceil(value / maxValue * 4.0)), 1), 4)
+        if scale <= 0 { return 1 }
+        return min(max(Int(ceil(value / scale * 4.0)), 1), 4)
     }
 
     /// Monday-first weekday (Mon = 0 … Sun = 6) of an epoch-day count. Epoch day 0 (1970-01-01) is a Thu.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ActivityHeatmapTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ActivityHeatmapTests.swift
@@ -14,7 +14,7 @@ final class ActivityHeatmapTests: XCTestCase {
         XCTAssertEqual(g.weeks, 13)
         XCTAssertEqual(g.columns.count, 13)
         XCTAssertTrue(g.columns.allSatisfy { $0.count == 7 })
-        XCTAssertEqual(g.maxValue, 400.0)
+        XCTAssertEqual(g.scale, 400.0)   // p90 of [100,200,400] = 400 ≥ floor 250
 
         // The rightmost column is the current week; today sits at weekday row 1, Monday at row 0.
         let last = g.columns[12]
@@ -56,7 +56,30 @@ final class ActivityHeatmapTests: XCTestCase {
     func testEmptyValuesGivesAllNoData() {
         let g = ActivityHeatmap.build(values: [:], today: today, weeks: 13)
         XCTAssertTrue(g.isEmpty)
-        XCTAssertEqual(g.maxValue, 0.0)
+        XCTAssertEqual(g.scale, 250.0)   // no active days → the floor
         XCTAssertTrue(g.columns.flatMap { $0 }.allSatisfy { $0.level == 0 })
+    }
+
+    func testRampScaleIsPercentileFloored() {
+        XCTAssertEqual(ActivityHeatmap.rampScale([]), 250.0)                    // no active days → floor
+        XCTAssertEqual(ActivityHeatmap.rampScale(Array(repeating: 100.0, count: 10)), 250.0)  // p90 100 < floor
+        // 9×400 + one 8000 outlier: nearest-rank p90 (rank 9 of 10) = 400, NOT the 8000 → outlier excluded.
+        XCTAssertEqual(ActivityHeatmap.rampScale(Array(repeating: 400.0, count: 9) + [8000.0]), 400.0)
+    }
+
+    func testOneHugeSessionDoesNotFlattenTheGrid() {
+        // 10 recent days at 300 kcal + a single 9000 kcal monster. Under the old max-scaling the 300s
+        // would all wash out to level 1 (300/9000 → 1); with percentile scaling the ramp is ~300, so a
+        // 300 day shades near full and the monster just caps at 4.
+        var values: [String: Double] = ["2026-08-11": 9000.0]
+        for i in 1...10 { values[ActivityHeatmap.civilDay(20676 - i)] = 300.0 }
+        let g = ActivityHeatmap.build(values: values, today: today, weeks: 13)
+        XCTAssertLessThanOrEqual(g.scale, 300.0)   // percentile, not the 9000 max
+        let monster = g.columns[12][1]
+        XCTAssertEqual(monster.value, 9000.0)
+        XCTAssertEqual(monster.level, 4)
+        // A representative 300-day is well above the washed-out level 1 the max-scale produced.
+        let a300 = g.columns.flatMap { $0 }.first { $0.value == 300.0 }
+        XCTAssertGreaterThanOrEqual(a300?.level ?? 0, 3)
     }
 }

--- a/android/app/src/main/java/com/noop/analytics/ActivityHeatmap.kt
+++ b/android/app/src/main/java/com/noop/analytics/ActivityHeatmap.kt
@@ -18,10 +18,20 @@ object ActivityHeatmap {
      *  data that day); [level] = 0 for no-data, 1..4 for intensity buckets. */
     data class Cell(val day: String?, val value: Double?, val level: Int)
 
-    /** [columns] is [weeks] lists of 7 cells (row 0 = Monday). [maxValue] scales the intensity ramp. */
-    data class Grid(val weeks: Int, val columns: List<List<Cell>>, val maxValue: Double) {
+    /**
+     * [columns] is [weeks] lists of 7 cells (row 0 = Monday). [scale] is the ramp denominator: the
+     * wearer's 90th-percentile ACTIVE day, floored at [RAMP_FLOOR_KCAL]. Scaling to the percentile (not
+     * the raw max) stops one exceptional session flattening the whole grid to pale; the floor keeps a
+     * beginner's low-calorie days appropriately cool instead of maxing them out.
+     */
+    data class Grid(val weeks: Int, val columns: List<List<Cell>>, val scale: Double) {
         val isEmpty: Boolean get() = columns.all { col -> col.all { it.value == null } }
     }
+
+    /** The ramp denominator floor (kcal): days at/above this shade fullest. Mirrors OpenStrap's 250. */
+    const val RAMP_FLOOR_KCAL = 250.0
+    /** Percentile of the active days the ramp scales to (90th). */
+    const val RAMP_PERCENTILE = 90.0
 
     /**
      * @param values day ("yyyy-MM-dd") → metric value. Missing days render as no-data cells.
@@ -35,7 +45,7 @@ object ActivityHeatmap {
         val currentMonday = e - todayWeekday
         val firstMonday = currentMonday - (cols - 1).toLong() * 7L
 
-        var maxValue = 0.0
+        val active = ArrayList<Double>()   // present days with a positive value → the ramp's percentile basis
         val raw = ArrayList<List<Cell>>(cols)
         for (c in 0 until cols) {
             val col = ArrayList<Cell>(7)
@@ -46,21 +56,35 @@ object ActivityHeatmap {
                 } else {
                     val ds = civilDay(d)
                     val v = values[ds]
-                    if (v != null && v > maxValue) maxValue = v
+                    if (v != null && v > 0.0) active.add(v)
                     col.add(Cell(ds, v, 0))
                 }
             }
             raw.add(col)
         }
-        val leveled = raw.map { col -> col.map { it.copy(level = levelFor(it.value, maxValue)) } }
-        return Grid(cols, leveled, maxValue)
+        val scale = rampScale(active)
+        val leveled = raw.map { col -> col.map { it.copy(level = levelFor(it.value, scale)) } }
+        return Grid(cols, leveled, scale)
     }
 
-    /** 0 = no data; otherwise 1..4 by fraction of [maxValue] (a present-but-zero day is still level 1). */
-    internal fun levelFor(value: Double?, maxValue: Double): Int {
+    /**
+     * Ramp denominator: the 90th-percentile ACTIVE day (nearest-rank, mirroring `deriveRestingHR`),
+     * floored at [RAMP_FLOOR_KCAL]. No active days → the floor. Scaling to the percentile rather than
+     * the max keeps one huge session from washing every other day out to level 1.
+     */
+    internal fun rampScale(active: List<Double>): Double {
+        if (active.isEmpty()) return RAMP_FLOOR_KCAL
+        val sorted = active.sorted()
+        val rank = ceil(RAMP_PERCENTILE / 100.0 * sorted.size.toDouble()).toInt().coerceAtLeast(1)
+        val p90 = sorted[minOf(rank, sorted.size) - 1]
+        return maxOf(RAMP_FLOOR_KCAL, p90)
+    }
+
+    /** 0 = no data; otherwise 1..4 by fraction of [scale] (a present-but-zero day is still level 1). */
+    internal fun levelFor(value: Double?, scale: Double): Int {
         if (value == null) return 0
-        if (maxValue <= 0.0) return 1
-        return ceil(value / maxValue * 4.0).toInt().coerceIn(1, 4)
+        if (scale <= 0.0) return 1
+        return ceil(value / scale * 4.0).toInt().coerceIn(1, 4)
     }
 
     /** Monday-first weekday (Mon = 0 … Sun = 6) of an epoch-day count. Epoch day 0 (1970-01-01) is a Thu. */

--- a/android/app/src/test/java/com/noop/analytics/ActivityHeatmapTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ActivityHeatmapTest.kt
@@ -20,7 +20,7 @@ class ActivityHeatmapTest {
         assertEquals(13, g.weeks)
         assertEquals(13, g.columns.size)
         assertTrue(g.columns.all { it.size == 7 })
-        assertEquals(400.0, g.maxValue, 0.0)
+        assertEquals(400.0, g.scale, 0.0)   // p90 of [100,200,400] = 400 ≥ floor 250
 
         // The rightmost column is the current week; today sits at weekday row 1, Monday at row 0.
         val last = g.columns[12]
@@ -62,7 +62,29 @@ class ActivityHeatmapTest {
     @Test fun emptyValuesGivesAllNoData() {
         val g = ActivityHeatmap.build(emptyMap(), today, weeks = 13)
         assertTrue(g.isEmpty)
-        assertEquals(0.0, g.maxValue, 0.0)
+        assertEquals(250.0, g.scale, 0.0)   // no active days → the floor
         assertTrue(g.columns.flatten().all { it.level == 0 })
+    }
+
+    @Test fun rampScaleIsPercentileFloored() {
+        assertEquals(250.0, ActivityHeatmap.rampScale(emptyList()), 0.0)                 // no active days → floor
+        assertEquals(250.0, ActivityHeatmap.rampScale(List(10) { 100.0 }), 0.0)          // p90 100 < floor
+        // 9×400 + one 8000 outlier: nearest-rank p90 (rank 9 of 10) = 400, NOT the 8000 → outlier excluded.
+        assertEquals(400.0, ActivityHeatmap.rampScale(List(9) { 400.0 } + 8000.0), 0.0)
+    }
+
+    @Test fun oneHugeSessionDoesNotFlattenTheGrid() {
+        // 10 recent days at 300 kcal + a single 9000 kcal monster. Percentile scaling keeps the ramp ~300
+        // (not the 9000 max), so a 300 day shades near full and the monster just caps at 4.
+        val values = HashMap<String, Double>()
+        values["2026-08-11"] = 9000.0
+        for (i in 1..10) values[ActivityHeatmap.civilDay(20676L - i)] = 300.0
+        val g = ActivityHeatmap.build(values, today, weeks = 13)
+        assertTrue(g.scale <= 300.0)   // percentile, not the 9000 max
+        val monster = g.columns[12][1]
+        assertEquals(9000.0, monster.value)
+        assertEquals(4, monster.level)
+        val a300 = g.columns.flatten().first { it.value == 300.0 }
+        assertTrue(a300.level >= 3)
     }
 }


### PR DESCRIPTION
## What

The Workouts **activity heatmap** (#1240) scaled its intensity ramp to the **single biggest day** in the 13-week window. One exceptional session (a long ride, a race) then washed every other day out to the palest shade, so the grid stopped conveying the quarter's rhythm — the exact problem OpenStrap called out in their heatmap PR (#222).

## Fix

Scale the ramp to the wearer's **90th-percentile active day** (nearest-rank, mirroring `deriveRestingHR`), **floored at 250 kcal**:
- Percentile, not max → one monster session no longer flattens everything else.
- Floor → a genuinely light week reads cool instead of maxing out a beginner's low-calorie grid.

`Grid.maxValue` → **`scale`** (it's the ramp denominator now, not the max). Only the builder + tests read it — the SwiftUI/Compose renderers use `cell.level` — so there's **no UI change** and no app-build gate needed. Both platforms byte-identical (pure `ActivityHeatmap` builder).

## Tests

- `rampScale` pinned: empty → floor; all-low → floor; `9×400 + 8000` → **400** (the 8000 outlier excluded by the nearest-rank p90).
- `oneHugeSessionDoesNotFlattenTheGrid`: 10 days @300 + one 9000 → a 300-day now shades near full (level ≥3) where max-scaling made it level 1; the monster caps at 4.
- Existing shape/calendar/empty tests updated for the rename.

## Scope

Just the shading math. The other polish in OpenStrap #222 — inline **streak/total header**, **month/weekday axis labels**, tap-a-day readout — is deliberately left out (app-target UI, needs the app-build gate); happy to do it as a follow-up.

Validated by `swift-packages.yml` (StrandAnalytics) + Android `build-and-test`; Kotlin compiled + tested locally.