### PR TITLE
Heatmap: quarter total + streak header and month/weekday axis labels

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ActivityHeatmap.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ActivityHeatmap.swift
@@ -31,10 +31,17 @@ public enum ActivityHeatmap {
         public let weeks: Int
         public let columns: [[Cell]]
         public let scale: Double
-        public init(weeks: Int, columns: [[Cell]], scale: Double) {
+        /// Total of the window's active days (kcal) — the header's big number.
+        public let total: Double
+        /// Current consecutive-day activity streak, ending today or (if nothing is logged yet today)
+        /// yesterday. 0 when neither today nor yesterday has activity.
+        public let streak: Int
+        public init(weeks: Int, columns: [[Cell]], scale: Double, total: Double = 0, streak: Int = 0) {
             self.weeks = weeks
             self.columns = columns
             self.scale = scale
+            self.total = total
+            self.streak = streak
         }
         public var isEmpty: Bool { columns.allSatisfy { col in col.allSatisfy { $0.value == nil } } }
     }
@@ -76,10 +83,16 @@ public enum ActivityHeatmap {
             raw.append(col)
         }
         let scale = rampScale(active)
+        // Streak = consecutive days with a positive value, via the shared StreakCalculator (same
+        // today-not-yet-scored grace the Settings streak uses) so the two never disagree in logic.
+        let keys = Array(values.keys)
+        let streak = StreakCalculator.streaks(dayKeys: keys,
+                                              qualified: keys.map { (values[$0] ?? 0) > 0 },
+                                              today: today).current
         let leveled = raw.map { col in
             col.map { Cell(day: $0.day, value: $0.value, level: levelFor($0.value, scale)) }
         }
-        return Grid(weeks: cols, columns: leveled, scale: scale)
+        return Grid(weeks: cols, columns: leveled, scale: scale, total: active.reduce(0, +), streak: streak)
     }
 
     /// Ramp denominator: the 90th-percentile ACTIVE day (nearest-rank, mirroring `deriveRestingHR`),

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ActivityHeatmapTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ActivityHeatmapTests.swift
@@ -57,7 +57,29 @@ final class ActivityHeatmapTests: XCTestCase {
         let g = ActivityHeatmap.build(values: [:], today: today, weeks: 13)
         XCTAssertTrue(g.isEmpty)
         XCTAssertEqual(g.scale, 250.0)   // no active days → the floor
+        XCTAssertEqual(g.total, 0.0)
+        XCTAssertEqual(g.streak, 0)
         XCTAssertTrue(g.columns.flatMap { $0 }.allSatisfy { $0.level == 0 })
+    }
+
+    func testStreakAndTotal() {
+        // Three consecutive days ending today (2026-08-09/10/11).
+        let g = ActivityHeatmap.build(values: ["2026-08-11": 400, "2026-08-10": 100, "2026-08-09": 200], today: today)
+        XCTAssertEqual(g.streak, 3)
+        XCTAssertEqual(g.total, 700.0)
+    }
+
+    func testStreakEndsYesterdayWhenTodayEmpty() {
+        // Nothing logged today yet, but yesterday + the day before → the streak still counts, from yesterday.
+        let g = ActivityHeatmap.build(values: ["2026-08-10": 100, "2026-08-09": 200], today: today)
+        XCTAssertEqual(g.streak, 2)
+    }
+
+    func testStreakZeroAndGapBreaks() {
+        // Neither today nor yesterday active → 0.
+        XCTAssertEqual(ActivityHeatmap.build(values: ["2026-08-08": 300], today: today).streak, 0)
+        // Today active but yesterday empty → a gap breaks it, streak of 1.
+        XCTAssertEqual(ActivityHeatmap.build(values: ["2026-08-11": 300, "2026-08-09": 300], today: today).streak, 1)
     }
 
     func testRampScaleIsPercentileFloored() {

--- a/Strand/Screens/WorkoutsView.swift
+++ b/Strand/Screens/WorkoutsView.swift
@@ -831,24 +831,22 @@ struct WorkoutsView: View {
                 SectionHeader("Active calories", overline: "Last 13 weeks")
                 NoopCard(tint: StrandPalette.effortColor) {
                     VStack(alignment: .leading, spacing: 12) {
-                        Canvas { ctx, size in
-                            let cols = grid.columns.count
-                            guard cols > 0 else { return }
-                            let gap: CGFloat = 3
-                            let cell = min((size.width - gap * CGFloat(cols - 1)) / CGFloat(cols),
-                                           (size.height - gap * 6) / 7)
-                            guard cell > 0 else { return }
-                            for c in 0..<cols {
-                                let col = grid.columns[c]
-                                for r in 0..<7 {
-                                    let rect = CGRect(x: CGFloat(c) * (cell + gap), y: CGFloat(r) * (cell + gap),
-                                                      width: cell, height: cell)
-                                    ctx.fill(Path(roundedRect: rect, cornerRadius: cell * 0.22),
-                                             with: .color(heatColor(col[r].level)))
-                                }
+                        // Quarter total + current streak. Both come from the pure builder; the streak
+                        // reuses the same "day(s) in a row" copy as the Settings streak (no new string).
+                        HStack(alignment: .firstTextBaseline, spacing: 6) {
+                            // Quarter total (the "Active calories" title above supplies the kcal unit).
+                            Text(grouped(grid.total))
+                                .font(StrandFont.number(24)).foregroundStyle(StrandPalette.textPrimary)
+                            Spacer(minLength: 8)
+                            if grid.streak > 0 {
+                                Text("\(grid.streak)").font(StrandFont.number(15))
+                                    .foregroundStyle(StrandPalette.effortColor)
+                                Text(grid.streak == 1 ? "day in a row" : "days in a row")
+                                    .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
                             }
                         }
-                        .aspectRatio(13.0 / 7.0, contentMode: .fit)
+                        Canvas { ctx, size in drawHeatmap(ctx, size: size, grid: grid) }
+                        .aspectRatio(13.0 / 7.6, contentMode: .fit)
                         .frame(maxWidth: .infinity)
                         .accessibilityLabel(Text("Active-calorie heatmap, last 13 weeks"))
                         HStack(spacing: 4) {
@@ -862,6 +860,59 @@ struct WorkoutsView: View {
                         }
                     }
                 }
+            }
+        }
+    }
+
+    /// Renders the heatmap into the Canvas: a left gutter of weekday labels (Mon/Wed/Fri/Sun) and a top
+    /// row of month labels (drawn where the month changes), then the cells. Labels use the LOCALIZED
+    /// calendar symbols so they translate for free and carry no hardcoded literals.
+    private func drawHeatmap(_ ctx: GraphicsContext, size: CGSize, grid: ActivityHeatmap.Grid) {
+        let cols = grid.columns.count
+        guard cols > 0 else { return }
+        let gap: CGFloat = 3
+        let leftInset: CGFloat = 20   // weekday gutter
+        let topInset: CGFloat = 14    // month row
+        let cell = min((size.width - leftInset - gap * CGFloat(cols - 1)) / CGFloat(cols),
+                       (size.height - topInset - gap * 6) / 7)
+        guard cell > 0 else { return }
+        let labelFont = StrandFont.caption
+        let labelColor = StrandPalette.textTertiary
+
+        // Weekday gutter: Mon/Wed/Fri/Sun. `veryShortWeekdaySymbols` is Sunday-first, so row r (Mon-first)
+        // maps to symbol (r + 1) % 7.
+        let wd = Calendar.current.veryShortWeekdaySymbols
+        if wd.count == 7 {
+            for r in stride(from: 0, to: 7, by: 2) {
+                let y = topInset + CGFloat(r) * (cell + gap) + cell / 2
+                ctx.draw(Text(wd[(r + 1) % 7]).font(labelFont).foregroundStyle(labelColor),
+                         at: CGPoint(x: 0, y: y), anchor: .leading)
+            }
+        }
+
+        // Month row: label a column when its month differs from the previous one.
+        let months = Calendar.current.shortMonthSymbols
+        var lastMonth = -1
+        for c in 0..<cols {
+            guard let day = grid.columns[c].first(where: { $0.day != nil })?.day,
+                  let m = Int(day.dropFirst(5).prefix(2)), m >= 1, m <= 12 else { continue }
+            if m != lastMonth {
+                lastMonth = m
+                let x = leftInset + CGFloat(c) * (cell + gap)
+                ctx.draw(Text(months[m - 1]).font(labelFont).foregroundStyle(labelColor),
+                         at: CGPoint(x: x, y: 0), anchor: .topLeading)
+            }
+        }
+
+        // Cells.
+        for c in 0..<cols {
+            let col = grid.columns[c]
+            for r in 0..<7 {
+                let rect = CGRect(x: leftInset + CGFloat(c) * (cell + gap),
+                                  y: topInset + CGFloat(r) * (cell + gap),
+                                  width: cell, height: cell)
+                ctx.fill(Path(roundedRect: rect, cornerRadius: cell * 0.22),
+                         with: .color(heatColor(col[r].level)))
             }
         }
     }

--- a/Strand/Screens/WorkoutsView.swift
+++ b/Strand/Screens/WorkoutsView.swift
@@ -881,12 +881,18 @@ struct WorkoutsView: View {
 
         // Weekday gutter: Mon/Wed/Fri/Sun. `veryShortWeekdaySymbols` is Sunday-first, so row r (Mon-first)
         // maps to symbol (r + 1) % 7.
+        // Resolve + colour via the Canvas shading (macOS 13 compatible — `Text.foregroundStyle`
+        // returning Text is macOS 14+, but a resolved text's `shading` is available here).
+        func label(_ s: String) -> GraphicsContext.ResolvedText {
+            var t = ctx.resolve(Text(s).font(labelFont))
+            t.shading = .color(labelColor)
+            return t
+        }
         let wd = Calendar.current.veryShortWeekdaySymbols
         if wd.count == 7 {
             for r in stride(from: 0, to: 7, by: 2) {
                 let y = topInset + CGFloat(r) * (cell + gap) + cell / 2
-                ctx.draw(Text(wd[(r + 1) % 7]).font(labelFont).foregroundStyle(labelColor),
-                         at: CGPoint(x: 0, y: y), anchor: .leading)
+                ctx.draw(label(wd[(r + 1) % 7]), at: CGPoint(x: 0, y: y), anchor: .leading)
             }
         }
 
@@ -899,8 +905,7 @@ struct WorkoutsView: View {
             if m != lastMonth {
                 lastMonth = m
                 let x = leftInset + CGFloat(c) * (cell + gap)
-                ctx.draw(Text(months[m - 1]).font(labelFont).foregroundStyle(labelColor),
-                         at: CGPoint(x: x, y: 0), anchor: .topLeading)
+                ctx.draw(label(months[m - 1]), at: CGPoint(x: x, y: 0), anchor: .topLeading)
             }
         }
 

--- a/android/app/src/main/java/com/noop/analytics/ActivityHeatmap.kt
+++ b/android/app/src/main/java/com/noop/analytics/ActivityHeatmap.kt
@@ -24,7 +24,16 @@ object ActivityHeatmap {
      * the raw max) stops one exceptional session flattening the whole grid to pale; the floor keeps a
      * beginner's low-calorie days appropriately cool instead of maxing them out.
      */
-    data class Grid(val weeks: Int, val columns: List<List<Cell>>, val scale: Double) {
+    data class Grid(
+        val weeks: Int,
+        val columns: List<List<Cell>>,
+        val scale: Double,
+        /** Total of the window's active days (kcal) — the header's big number. */
+        val total: Double = 0.0,
+        /** Current consecutive-day activity streak, ending today or (if nothing logged yet today)
+         *  yesterday. 0 when neither today nor yesterday has activity. */
+        val streak: Int = 0,
+    ) {
         val isEmpty: Boolean get() = columns.all { col -> col.all { it.value == null } }
     }
 
@@ -63,8 +72,12 @@ object ActivityHeatmap {
             raw.add(col)
         }
         val scale = rampScale(active)
+        // Streak = consecutive days with a positive value, via the shared StreakCalculator (same
+        // today-not-yet-scored grace the Settings streak uses) so the two never disagree in logic.
+        val keys = values.keys.toList()
+        val streak = StreakCalculator.streaks(keys, keys.map { (values[it] ?: 0.0) > 0.0 }, today).current
         val leveled = raw.map { col -> col.map { it.copy(level = levelFor(it.value, scale)) } }
-        return Grid(cols, leveled, scale)
+        return Grid(cols, leveled, scale, total = active.sum(), streak = streak)
     }
 
     /**

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -1,7 +1,11 @@
 package com.noop.ui
 
 import com.noop.R
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.Canvas
@@ -791,29 +795,75 @@ private fun CalorieHeatmapSection(recentDays: List<com.noop.data.DailyMetric>) {
         else -> amber
     }
 
+    val months = remember { java.text.DateFormatSymbols().shortMonths }        // localized, index 0 = Jan
+    val weekdays = remember { java.text.DateFormatSymbols().shortWeekdays }     // localized, index 1 = Sun
+    val labelArgb = Palette.textTertiary.toArgb()
     NoopCard(tint = Palette.effortColor) {
         Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
             Text("Active calories", style = NoopType.title2, color = Palette.textPrimary)
             Text("Last 13 weeks · daily burn", style = NoopType.footnote, color = Palette.textTertiary)
+            // Quarter total + current streak (streak reuses the Settings streak plural — no new string;
+            // the "Active calories" title above supplies the kcal unit for the big number).
+            Row(verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(grouped(grid.total), style = NoopType.title1, color = Palette.textPrimary)
+                Spacer(Modifier.weight(1f))
+                if (grid.streak > 0) {
+                    Text(
+                        pluralStringResource(R.plurals.settings_streak_run, grid.streak, grid.streak),
+                        style = NoopType.caption,
+                        color = Palette.textTertiary,
+                    )
+                }
+            }
             BoxWithConstraints(Modifier.fillMaxWidth()) {
                 val gap = 3.dp
+                val leftInset = 20.dp   // weekday gutter
+                val topInset = 14.dp    // month row
                 val cols = grid.weeks
-                val cell = ((maxWidth - gap * (cols - 1)) / cols).coerceAtLeast(2.dp)
+                val cell = ((maxWidth - leftInset - gap * (cols - 1)) / cols).coerceAtLeast(2.dp)
                 Canvas(
                     Modifier
                         .fillMaxWidth()
-                        .height(cell * 7 + gap * 6)
+                        .height(cell * 7 + gap * 6 + topInset)
                         .semantics { contentDescription = "Active-calorie heatmap, last 13 weeks" },
                 ) {
                     val gapPx = gap.toPx()
                     val cellPx = cell.toPx()
+                    val leftPx = leftInset.toPx()
+                    val topPx = topInset.toPx()
                     val radius = CornerRadius(cellPx * 0.22f, cellPx * 0.22f)
+                    val labelPaint = android.graphics.Paint().apply {
+                        isAntiAlias = true
+                        color = labelArgb
+                        textSize = 10.sp.toPx()
+                    }
+                    val nc = drawContext.canvas.nativeCanvas
+                    // Weekday gutter (Mon/Wed/Fri/Sun). shortWeekdays index 1 = Sun … 7 = Sat; row r is
+                    // Monday-first, so row r → weekday ((1 + r) % 7) + 1. Baseline ≈ row centre.
+                    for (r in 0 until 7 step 2) {
+                        val sym = weekdays.getOrNull(((1 + r) % 7) + 1).orEmpty()
+                        if (sym.isEmpty()) continue
+                        val y = topPx + r * (cellPx + gapPx) + cellPx / 2f + labelPaint.textSize / 3f
+                        nc.drawText(sym, 0f, y, labelPaint)
+                    }
+                    // Month row: label a column when its month changes.
+                    var lastMonth = -1
+                    for (c in 0 until cols) {
+                        val day = grid.columns[c].firstOrNull { it.day != null }?.day ?: continue
+                        val m = day.substring(5, 7).toIntOrNull() ?: continue
+                        if (m != lastMonth) {
+                            lastMonth = m
+                            val sym = months.getOrNull(m - 1).orEmpty()
+                            if (sym.isEmpty()) continue
+                            nc.drawText(sym, leftPx + c * (cellPx + gapPx), labelPaint.textSize, labelPaint)
+                        }
+                    }
                     for (c in 0 until cols) {
                         val column = grid.columns[c]
                         for (r in 0 until 7) {
                             drawRoundRect(
                                 color = colorFor(column[r].level),
-                                topLeft = Offset(c * (cellPx + gapPx), r * (cellPx + gapPx)),
+                                topLeft = Offset(leftPx + c * (cellPx + gapPx), topPx + r * (cellPx + gapPx)),
                                 size = Size(cellPx, cellPx),
                                 cornerRadius = radius,
                             )

--- a/android/app/src/test/java/com/noop/analytics/ActivityHeatmapTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ActivityHeatmapTest.kt
@@ -63,7 +63,25 @@ class ActivityHeatmapTest {
         val g = ActivityHeatmap.build(emptyMap(), today, weeks = 13)
         assertTrue(g.isEmpty)
         assertEquals(250.0, g.scale, 0.0)   // no active days → the floor
+        assertEquals(0.0, g.total, 0.0)
+        assertEquals(0, g.streak)
         assertTrue(g.columns.flatten().all { it.level == 0 })
+    }
+
+    @Test fun streakAndTotal() {
+        val g = ActivityHeatmap.build(mapOf("2026-08-11" to 400.0, "2026-08-10" to 100.0, "2026-08-09" to 200.0), today)
+        assertEquals(3, g.streak)
+        assertEquals(700.0, g.total, 0.0)
+    }
+
+    @Test fun streakEndsYesterdayWhenTodayEmpty() {
+        val g = ActivityHeatmap.build(mapOf("2026-08-10" to 100.0, "2026-08-09" to 200.0), today)
+        assertEquals(2, g.streak)
+    }
+
+    @Test fun streakZeroAndGapBreaks() {
+        assertEquals(0, ActivityHeatmap.build(mapOf("2026-08-08" to 300.0), today).streak)
+        assertEquals(1, ActivityHeatmap.build(mapOf("2026-08-11" to 300.0, "2026-08-09" to 300.0), today).streak)
     }
 
     @Test fun rampScaleIsPercentileFloored() {


### PR DESCRIPTION
## What

Rounds the Workouts activity heatmap (#1240, #1269) out toward the OpenStrap #222 layout the screenshots showed:

- **Header line** above the grid — the 13-week active-calorie **total** and the current activity **streak**.
- **Month labels** along the top + a **Mon/Wed/Fri/Sun weekday gutter** on the left.

## How

- `total` and `streak` are computed in the pure `ActivityHeatmap` builder (Grid gains both, defaulted so existing callers/tests are untouched). `total` = sum of the window's active days; **`streak` reuses the shared `StreakCalculator`** — the same today-not-yet-scored grace the Settings streak uses — so the two never disagree on streak logic (no reinvented streak math).
- Axis labels are drawn from the **localized** calendar symbols (`Calendar.shortMonthSymbols`/`veryShortWeekdaySymbols` on iOS, `DateFormatSymbols` on Android), so they translate automatically and carry no hardcoded literals.

## No new strings

The streak reuses the existing `settings_streak_run` plural / `"day(s) in a row"` copy; the "Active calories" card title supplies the unit for the total number. `i18n_audit --ci` passes with no new gaps.

## Scope note

Not porting OpenStrap's tap-a-day readout or the `(i)` percentile disclosure — those are lower-value and can follow if wanted.

## Verification

- Builder `total`/`streak` **parity-tested** both platforms (`ActivityHeatmap{Tests,Test}`): 3-day run, ends-yesterday grace, zero, gap-breaks.
- Android `compileFullDebugKotlin` + heatmap/streak tests green; `i18n_audit --ci` clean.
- Builder + tests validated by `swift-packages.yml`; **the app-target Swift UI (`WorkoutsView.swift`) is validated by the on-demand app-build gate** (dispatched on this branch), since no default CI compiles it.