### PR TITLE
Heatmap: outline today's cell + slightly rounder boxes (closer to #222)

### DIFF
--- a/Strand/Screens/WorkoutsView.swift
+++ b/Strand/Screens/WorkoutsView.swift
@@ -845,7 +845,7 @@ struct WorkoutsView: View {
                                     .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
                             }
                         }
-                        Canvas { ctx, size in drawHeatmap(ctx, size: size, grid: grid) }
+                        Canvas { ctx, size in drawHeatmap(ctx, size: size, grid: grid, today: todayDayString()) }
                         .aspectRatio(13.0 / 7.6, contentMode: .fit)
                         .frame(maxWidth: .infinity)
                         .accessibilityLabel(Text("Active-calorie heatmap, last 13 weeks"))
@@ -867,7 +867,7 @@ struct WorkoutsView: View {
     /// Renders the heatmap into the Canvas: a left gutter of weekday labels (Mon/Wed/Fri/Sun) and a top
     /// row of month labels (drawn where the month changes), then the cells. Labels use the LOCALIZED
     /// calendar symbols so they translate for free and carry no hardcoded literals.
-    private func drawHeatmap(_ ctx: GraphicsContext, size: CGSize, grid: ActivityHeatmap.Grid) {
+    private func drawHeatmap(_ ctx: GraphicsContext, size: CGSize, grid: ActivityHeatmap.Grid, today: String) {
         let cols = grid.columns.count
         guard cols > 0 else { return }
         let gap: CGFloat = 3
@@ -909,15 +909,18 @@ struct WorkoutsView: View {
             }
         }
 
-        // Cells.
+        // Cells; today's cell gets an outline so "where am I" reads at a glance (mirrors #222).
         for c in 0..<cols {
             let col = grid.columns[c]
             for r in 0..<7 {
                 let rect = CGRect(x: leftInset + CGFloat(c) * (cell + gap),
                                   y: topInset + CGFloat(r) * (cell + gap),
                                   width: cell, height: cell)
-                ctx.fill(Path(roundedRect: rect, cornerRadius: cell * 0.22),
-                         with: .color(heatColor(col[r].level)))
+                let path = Path(roundedRect: rect, cornerRadius: cell * 0.24)
+                ctx.fill(path, with: .color(heatColor(col[r].level)))
+                if col[r].day == today {
+                    ctx.stroke(path, with: .color(StrandPalette.textPrimary), lineWidth: 1.5)
+                }
             }
         }
     }

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -831,7 +831,7 @@ private fun CalorieHeatmapSection(recentDays: List<com.noop.data.DailyMetric>) {
                     val cellPx = cell.toPx()
                     val leftPx = leftInset.toPx()
                     val topPx = topInset.toPx()
-                    val radius = CornerRadius(cellPx * 0.22f, cellPx * 0.22f)
+                    val radius = CornerRadius(cellPx * 0.24f, cellPx * 0.24f)
                     val labelPaint = android.graphics.Paint().apply {
                         isAntiAlias = true
                         color = labelArgb
@@ -858,15 +858,26 @@ private fun CalorieHeatmapSection(recentDays: List<com.noop.data.DailyMetric>) {
                             nc.drawText(sym, leftPx + c * (cellPx + gapPx), labelPaint.textSize, labelPaint)
                         }
                     }
+                    // Cells; today's cell gets an outline so "where am I" reads at a glance (mirrors #222).
                     for (c in 0 until cols) {
                         val column = grid.columns[c]
                         for (r in 0 until 7) {
+                            val tl = Offset(leftPx + c * (cellPx + gapPx), topPx + r * (cellPx + gapPx))
                             drawRoundRect(
                                 color = colorFor(column[r].level),
-                                topLeft = Offset(leftPx + c * (cellPx + gapPx), topPx + r * (cellPx + gapPx)),
+                                topLeft = tl,
                                 size = Size(cellPx, cellPx),
                                 cornerRadius = radius,
                             )
+                            if (column[r].day == today) {
+                                drawRoundRect(
+                                    color = Palette.textPrimary,
+                                    topLeft = tl,
+                                    size = Size(cellPx, cellPx),
+                                    cornerRadius = radius,
+                                    style = Stroke(width = 1.5.dp.toPx()),
+                                )
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Small visual pass to line the activity heatmap up with the OpenStrap #222 screenshots:

- **Today's cell is outlined** (stroke in `textPrimary`) so you can spot where the current day sits in the 13-week grid — the highlighted cell in the shots.
- **Cell corner radius 0.22 → 0.24** so the boxes read as the same rounded squares.
- **Palette unchanged** — NOOP's amber token, not OpenStrap's coral (design system is law).

Both platforms; matches by `cell.day == today`. Android `compileFullDebugKotlin` green; the Swift UI is app-target so it's validated by the on-demand app-build gate (dispatched on this branch).