### PR TITLE
Heatmap: kcal unit beside the quarter total

### DIFF
--- a/Strand/Screens/WorkoutsView.swift
+++ b/Strand/Screens/WorkoutsView.swift
@@ -833,10 +833,11 @@ struct WorkoutsView: View {
                     VStack(alignment: .leading, spacing: 12) {
                         // Quarter total + current streak. Both come from the pure builder; the streak
                         // reuses the same "day(s) in a row" copy as the Settings streak (no new string).
-                        HStack(alignment: .firstTextBaseline, spacing: 6) {
-                            // Quarter total (the "Active calories" title above supplies the kcal unit).
+                        HStack(alignment: .firstTextBaseline, spacing: 4) {
                             Text(grouped(grid.total))
                                 .font(StrandFont.number(24)).foregroundStyle(StrandPalette.textPrimary)
+                            Text(String(localized: "KCAL"))   // reuses the miniStat/colHeader unit label
+                                .font(StrandFont.caption).foregroundStyle(StrandPalette.textSecondary)
                             Spacer(minLength: 8)
                             if grid.streak > 0 {
                                 Text("\(grid.streak)").font(StrandFont.number(15))

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -804,8 +804,11 @@ private fun CalorieHeatmapSection(recentDays: List<com.noop.data.DailyMetric>) {
             Text("Last 13 weeks · daily burn", style = NoopType.footnote, color = Palette.textTertiary)
             // Quarter total + current streak (streak reuses the Settings streak plural — no new string;
             // the "Active calories" title above supplies the kcal unit for the big number).
-            Row(verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text(grouped(grid.total), style = NoopType.title1, color = Palette.textPrimary)
+            Row(verticalAlignment = Alignment.Bottom) {
+                Row(verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(3.dp)) {
+                    Text(grouped(grid.total), style = NoopType.title1, color = Palette.textPrimary)
+                    Text("kcal", style = NoopType.caption, color = Palette.textTertiary)  // unit, as elsewhere on this screen
+                }
                 Spacer(Modifier.weight(1f))
                 if (grid.streak > 0) {
                     Text(


### PR DESCRIPTION
Adds the **kcal unit** next to the heatmap's quarter total (small, beside the big number) to match the OpenStrap #222 header.

Reuses each platform's existing unit label — iOS `String(localized: "KCAL")` (as in miniStat/colHeader), Android the `"kcal"` literal the summary tiles already use — so **no new strings** (i18n audit clean). Both platforms.

Android `compileFullDebugKotlin` + `i18n_audit --ci` green; Swift UI validated by the app-build gate (dispatched).