### PR TITLE
Workouts: add 9 long-tail sports (Rucking, Archery, Fishing, Hunting, Curling, Netball, Gaelic football, Spikeball, Sand volleyball)

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/SportIcon.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/SportIcon.swift
@@ -83,6 +83,16 @@ public enum KnownWorkoutType: String, CaseIterable, Sendable {
     case spinning = "Spinning"
     case jumpRope = "Jump rope"
     case powerlifting = "Powerlifting"
+    // Long-tail batch. Raw values byte-identical to WorkoutCatalog / Android.
+    case rucking = "Rucking"
+    case sandVolleyball = "Sand volleyball"
+    case archery = "Archery"
+    case fishing = "Fishing"
+    case hunting = "Hunting"
+    case curling = "Curling"
+    case netball = "Netball"
+    case gaelicFootball = "Gaelic football"
+    case spikeball = "Spikeball"
     case other = "Other"
 
     /// Case-insensitive exact match against a stored/free-typed sport label.
@@ -294,6 +304,15 @@ public enum WorkoutTypeIconography {
         case .spinning:             return .system("bicycle.circle")
         case .jumpRope:             return .system("figure.jumprope")
         case .powerlifting:         return .system("dumbbell")
+        case .rucking:              return .system("backpack")
+        case .sandVolleyball:       return .system("beach.umbrella")
+        case .archery:              return .system("figure.archery")
+        case .fishing:              return .system("figure.fishing")
+        case .hunting:              return .system("figure.hunting")
+        case .curling:              return .system("figure.curling")
+        case .netball:              return .system("basketball")
+        case .gaelicFootball:       return .system("soccerball")
+        case .spikeball:            return .system("volleyball")
         case .other:
             return .system("figure.mixed.cardio")
         }
@@ -371,6 +390,15 @@ public enum WorkoutTypeIconography {
         case .spinning:             return "system:bicycle.circle"
         case .jumpRope:             return "system:figure.jumprope"
         case .powerlifting:         return "system:dumbbell"
+        case .rucking:              return "system:backpack"
+        case .sandVolleyball:       return "system:beach.umbrella"
+        case .archery:              return "system:figure.archery"
+        case .fishing:              return "system:figure.fishing"
+        case .hunting:              return "system:figure.hunting"
+        case .curling:              return "system:figure.curling"
+        case .netball:              return "system:basketball"
+        case .gaelicFootball:       return "system:soccerball"
+        case .spikeball:            return "system:volleyball"
         case .other:            return "system:figure.mixed.cardio"
         }
     }

--- a/Strand/Data/WorkoutCatalog.swift
+++ b/Strand/Data/WorkoutCatalog.swift
@@ -104,6 +104,16 @@ enum WorkoutCatalog {
         Sport(name: "Spinning", isDistanceSport: false),
         Sport(name: "Jump rope", isDistanceSport: false),
         Sport(name: "Powerlifting", isDistanceSport: false),
+        // Long-tail batch (names byte-identical to Android EXTRA). All map to a fallback HC type, GPS off.
+        Sport(name: "Rucking", isDistanceSport: false),
+        Sport(name: "Sand volleyball", isDistanceSport: false),
+        Sport(name: "Archery", isDistanceSport: false),
+        Sport(name: "Fishing", isDistanceSport: false),
+        Sport(name: "Hunting", isDistanceSport: false),
+        Sport(name: "Curling", isDistanceSport: false),
+        Sport(name: "Netball", isDistanceSport: false),
+        Sport(name: "Gaelic football", isDistanceSport: false),
+        Sport(name: "Spikeball", isDistanceSport: false),
         Sport(name: "Other", isDistanceSport: false),
     ]
 

--- a/android/app/src/main/java/com/noop/ingest/ExerciseTypes.kt
+++ b/android/app/src/main/java/com/noop/ingest/ExerciseTypes.kt
@@ -105,6 +105,16 @@ object ExerciseTypes {
         "Spinning" to EX.EXERCISE_TYPE_BIKING_STATIONARY,
         "Jump rope" to EX.EXERCISE_TYPE_OTHER_WORKOUT,
         "Powerlifting" to EX.EXERCISE_TYPE_WEIGHTLIFTING,
+        // Long-tail batch: HC has no type → ride a nearby one for writeback, keep the label.
+        "Rucking" to EX.EXERCISE_TYPE_WALKING,
+        "Sand volleyball" to EX.EXERCISE_TYPE_VOLLEYBALL,
+        "Archery" to EX.EXERCISE_TYPE_OTHER_WORKOUT,
+        "Fishing" to EX.EXERCISE_TYPE_OTHER_WORKOUT,
+        "Hunting" to EX.EXERCISE_TYPE_OTHER_WORKOUT,
+        "Curling" to EX.EXERCISE_TYPE_OTHER_WORKOUT,
+        "Netball" to EX.EXERCISE_TYPE_OTHER_WORKOUT,
+        "Gaelic football" to EX.EXERCISE_TYPE_OTHER_WORKOUT,
+        "Spikeball" to EX.EXERCISE_TYPE_OTHER_WORKOUT,
     )
 
     /** Types where a route makes sense -> GPS defaults on. */


### PR DESCRIPTION
Adds the long-tail sports, same treatment as #1273. None have a native Health Connect type, so all ride a nearby type for writeback (Rucking→walking, Sand volleyball→volleyball, rest→other) and keep their own label like Padel. Both platforms; names + distance flags byte-identical; each Swift sport gets a distinct icon/identity (uniqueness tests); no i18n (stored English identifiers). Picker → ~78 sports.

Android compiled + `WorkoutSportTest` green; Swift validated by `swift-packages.yml` (icon uniqueness) + the app-build gate (catalogue lockstep), dispatched.