### PR TITLE
Workouts: bump the Recent-sports cap 3 → 5

### DIFF
--- a/Strand/Data/RecentSportsPrefs.swift
+++ b/Strand/Data/RecentSportsPrefs.swift
@@ -19,8 +19,9 @@ enum RecentSportsPrefs {
     /// UserDefaults key. The Android twin persists the same "workout.recentSports" name.
     static let key = "workout.recentSports"
 
-    /// Most-recent-first cap — the issue asks for "2-3"; three keeps the section one glance tall.
-    static let maxCount = 3
+    /// Most-recent-first cap. Bumped 3 → 5 now the catalogue is large (~78 sports): a wider rotation
+    /// surfaces without scrolling, still short enough to stay above the full list. Twin of Android.
+    static let maxCount = 5
 
     /// Encode an ordered list of names into the stored comma-joined string.
     static func encode(_ names: [String]) -> String { names.joined(separator: ",") }

--- a/StrandTests/RecentSportsPrefsTests.swift
+++ b/StrandTests/RecentSportsPrefsTests.swift
@@ -11,7 +11,7 @@ final class RecentSportsPrefsTests: XCTestCase {
     func testKeyAndCapMatchAndroid() {
         // Both platforms persist "workout.recentSports", capped at three entries.
         XCTAssertEqual(RecentSportsPrefs.key, "workout.recentSports")
-        XCTAssertEqual(RecentSportsPrefs.maxCount, 3)
+        XCTAssertEqual(RecentSportsPrefs.maxCount, 5)
     }
 
     func testEncodeDecodeRoundTrips() {
@@ -37,9 +37,13 @@ final class RecentSportsPrefsTests: XCTestCase {
                        ["running", "Yoga", "Padel"])
     }
 
-    func testRecordingCapsAtThree() {
+    func testRecordingCapsAtFive() {
+        // A full list of 5, recording a 6th drops the oldest.
+        XCTAssertEqual(RecentSportsPrefs.recording("HIIT", into: ["Running", "Yoga", "Padel", "Boxing", "Tennis"]),
+                       ["HIIT", "Running", "Yoga", "Padel", "Boxing"])
+        // Under the cap, nothing is dropped.
         XCTAssertEqual(RecentSportsPrefs.recording("HIIT", into: ["Running", "Yoga", "Padel"]),
-                       ["HIIT", "Running", "Yoga"])
+                       ["HIIT", "Running", "Yoga", "Padel"])
     }
 
     func testRecordingIgnoresBlankAndCommaNames() {

--- a/android/app/src/main/java/com/noop/ui/RecentSportsPrefs.kt
+++ b/android/app/src/main/java/com/noop/ui/RecentSportsPrefs.kt
@@ -24,8 +24,9 @@ object RecentSportsPrefs {
     /** SharedPreferences key. The macOS/iOS twin persists the same "workout.recentSports" name. */
     const val KEY = "workout.recentSports"
 
-    /** Most-recent-first cap — the issue asks for "2-3"; three keeps the section one glance tall. */
-    const val MAX_COUNT = 3
+    /** Most-recent-first cap. Bumped 3 → 5 now the catalogue is large (~78 sports): a wider rotation
+     *  surfaces without scrolling, still short enough to stay above the full list. Twin of iOS. */
+    const val MAX_COUNT = 5
 
     /** Encode an ordered list of names into the stored comma-joined string. */
     fun encode(names: List<String>): String = names.joinToString(",")

--- a/android/app/src/test/java/com/noop/ui/RecentSportsPrefsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/RecentSportsPrefsTest.kt
@@ -18,7 +18,7 @@ class RecentSportsPrefsTest {
     fun keyAndCapMatchIos() {
         // Both platforms persist "workout.recentSports", capped at three entries.
         assertEquals("workout.recentSports", RecentSportsPrefs.KEY)
-        assertEquals(3, RecentSportsPrefs.MAX_COUNT)
+        assertEquals(5, RecentSportsPrefs.MAX_COUNT)
     }
 
     @Test
@@ -57,9 +57,15 @@ class RecentSportsPrefsTest {
     }
 
     @Test
-    fun recordingCapsAtThree() {
+    fun recordingCapsAtFive() {
+        // Full list of 5 → recording a 6th drops the oldest.
         assertEquals(
-            listOf("HIIT", "Running", "Yoga"),
+            listOf("HIIT", "Running", "Yoga", "Padel", "Boxing"),
+            RecentSportsPrefs.recording("HIIT", listOf("Running", "Yoga", "Padel", "Boxing", "Tennis")),
+        )
+        // Under the cap → nothing dropped.
+        assertEquals(
+            listOf("HIIT", "Running", "Yoga", "Padel"),
             RecentSportsPrefs.recording("HIIT", listOf("Running", "Yoga", "Padel")),
         )
     }


### PR DESCRIPTION
The picker's "Recent" section showed your last **3** sports. Now that the catalogue is ~78 sports, bump it to **5** so a wider rotation surfaces without scrolling the full list — still short enough to stay one section tall. Both platforms (`maxCount`/`MAX_COUNT`), recency-ordered as before (not frequency). Tests updated to pin the new cap. Android compiled + `RecentSportsPrefsTest` green; Swift via the app-build gate (`RecentSportsPrefsTests`).