### PR TITLE
Compare tooltip i18n (#529 follow-up): baseline the no-value dash + localize the date

### DIFF
--- a/Strand/Screens/CompareView.swift
+++ b/Strand/Screens/CompareView.swift
@@ -1085,7 +1085,10 @@ private struct MultiTooltip: View {
     /// Shared formatter; was rebuilt from scratch on every hover frame.
     private static let dateLabelFormatter: DateFormatter = {
         let f = DateFormatter()
-        f.locale = Locale(identifier: "en_US_POSIX")
+        // Device locale (not en_US_POSIX) so the DISPLAYED weekday/month names translate — the crosshair
+        // parser above still uses en_US_POSIX for stable yyyy-MM-dd parsing. Same pattern + device locale
+        // as the Android twin so both localize consistently.
+        f.locale = Locale.autoupdatingCurrent
         f.dateFormat = "EEE d MMM yyyy"
         return f
     }()

--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -169,6 +169,10 @@
       "Max 4"
     ],
     [
+      "android/app/src/main/java/com/noop/ui/CompareScreen.kt",
+      "\\u2014"
+    ],
+    [
       "android/app/src/main/java/com/noop/ui/CoupledScreen.kt",
       "A classic one-glance read of NOOP's own scores. Same data, different lens."
     ],

--- a/android/app/src/main/java/com/noop/ui/CompareScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CompareScreen.kt
@@ -1167,8 +1167,10 @@ private fun CompareChartTooltip(
     }
 }
 
+// Device locale so the weekday/month names translate (a non-English user shouldn't see an English
+// tooltip date). Same pattern + device locale as the iOS twin, so both localize consistently.
 private val compareTooltipDateFormatter: DateTimeFormatter =
-    DateTimeFormatter.ofPattern("EEE d MMM yyyy", Locale.US)
+    DateTimeFormatter.ofPattern("EEE d MMM yyyy", Locale.getDefault())
 
 private fun prettyCompareDay(day: String): String =
     runCatching { LocalDate.parse(day).format(compareTooltipDateFormatter) }.getOrDefault(day)


### PR DESCRIPTION
Two i18n fixes for the Compare crosshair tooltip from #529:

1. **The audit was failing on main.** #529 added a hardcoded `\u2014` ("no value" em-dash) at `CompareScreen.kt:1160` that wasn't in the i18n baseline, so `i18n_audit --ci` went red. It's a non-translatable symbol (the iOS twin's is already tracked), so it's added to the baseline — a 1-entry change.
2. **Localized the tooltip date, both platforms.** It used a fixed English format (Android `Locale.US`, iOS `en_US_POSIX`), so non-English users saw an English date. Switched the DISPLAY formatter to the device locale on both (same `EEE d MMM yyyy` pattern → both localize consistently, parity preserved). The crosshair's `yyyy-MM-dd` PARSER stays `en_US_POSIX` (must be stable).

Android `compileFullDebugKotlin` + `i18n_audit --ci` green; the iOS side (`CompareView.swift`, app-target) is validated by the app-build gate, dispatched.