### PR TITLE
WHOOP battery pack: decode GET_BATTERY_PACK_INFO (151), both platforms

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/BatteryPackInfo.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/BatteryPackInfo.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Decodes a `GET_BATTERY_PACK_INFO` (command 151) COMMAND_RESPONSE — the WHOOP 5.0/MG battery pack's
+/// charge, serial and Bluetooth address, read THROUGH the strap (a 4.0 has no pack command). noop already
+/// probes `GET_EXTENDED_BATTERY_INFO` (98), but the 5/MG reply to 98 is an undecoded stub; 151 is the
+/// command that actually carries the pack's fuel gauge.
+///
+/// The field offsets are re-derived (clean-room, project rule: real captures, never invented offsets) from
+/// two captured 5/MG frames — one strap with a pack attached, then physically removed — so this is an
+/// UNVALIDATED CANDIDATE pending broader hardware confirmation. Pure + deterministic, unit-tested against
+/// those frames without a strap; the Kotlin `BatteryPackInfo` is its byte-identical twin.
+public enum BatteryPackInfo {
+
+    public struct Info: Equatable, Sendable {
+        /// Whether a pack is attached. The command answers SUCCESS either way; a removed pack sends a
+        /// zeroed block with the present flag clear, which is the ONLY thing that tells the two apart — so
+        /// an absent reply must clear the card, never keep a stale charge.
+        public let present: Bool
+        /// State of charge (%), tenths precision, or nil when no pack is attached.
+        public let socPct: Double?
+        /// The pack's own serial (ASCII), or nil when absent.
+        public let serial: String?
+        /// The pack's Bluetooth address as lowercase hex — identity, not a reading. nil when absent.
+        public let btAddr: String?
+
+        public init(present: Bool, socPct: Double?, serial: String?, btAddr: String?) {
+            self.present = present; self.socPct = socPct; self.serial = serial; self.btAddr = btAddr
+        }
+    }
+
+    /// The response-command byte sits at `cmdOff` (10 on WHOOP 5/MG — the only family with a pack; a 4.0's
+    /// 6 is accepted only so a caller can pass it, though 4.0 never answers 151). Returns nil when the
+    /// frame is not a well-formed 151 SUCCESS response. The caller is expected to have CRC-gated the frame
+    /// (the framing layer already does), as the sibling probes assume.
+    public static func decode(frame: [UInt8], cmdOff: Int = 10) -> Info? {
+        // Layout relative to cmdOff, pinned to the captures: +0 resp-cmd (151), +2 result (1 = SUCCESS),
+        // +4 present flag, +5 BT address (6 bytes), +11 serial (16-byte ASCII, NUL-terminated),
+        // +27 SoC (u16 little-endian, tenths of a percent).
+        guard cmdOff >= 0, frame.count > cmdOff + 4 else { return nil }
+        guard Int(frame[cmdOff]) == 151, Int(frame[cmdOff + 2]) == 1 else { return nil }
+        let present = frame[cmdOff + 4] == 1
+        guard present else { return Info(present: false, socPct: nil, serial: nil, btAddr: nil) }
+
+        let btStart = cmdOff + 5
+        let serStart = cmdOff + 11
+        let socStart = cmdOff + 27
+        guard frame.count >= socStart + 2 else { return nil }
+
+        let btAddr = frame[btStart..<btStart + 6].map { String(format: "%02x", $0) }.joined()
+        let serBytes = Array(frame[serStart..<serStart + 16].prefix { $0 != 0 })
+        let serial = serBytes.isEmpty ? nil : String(bytes: serBytes, encoding: .ascii)
+        let raw = Int(frame[socStart]) | (Int(frame[socStart + 1]) << 8)
+        let socPct = Double(raw) / 10.0
+        return Info(present: true, socPct: socPct, serial: serial, btAddr: btAddr)
+    }
+}

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/BatteryPackInfoTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/BatteryPackInfoTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import WhoopProtocol
+
+/// GET_BATTERY_PACK_INFO (151) has two answers and the Devices card must behave oppositely on each: a
+/// reply naming a pack fills the row, a reply naming none must CLEAR it. Both frames below came off one
+/// WHOOP 5 strap — pack attached, then physically removed — so the decode is pinned to real bytes. The
+/// Kotlin `BatteryPackInfoTest` asserts the same values, keeping the two decoders byte-identical.
+final class BatteryPackInfoTests: XCTestCase {
+
+    private func bytes(_ s: String) -> [UInt8] {
+        stride(from: 0, to: s.count, by: 2).map { i in
+            let a = s.index(s.startIndex, offsetBy: i)
+            return UInt8(s[a...s.index(a, offsetBy: 1)], radix: 16)!
+        }
+    }
+
+    private let attachedHex =
+        "aa01280001002de1245c9704010101f7381d2e3161574242354150303132363339" +
+        "35000000e5020c01000000be577aee"
+    private let absentHex =
+        "aa01280001002de1240797040101000000000000000000000000000000000000" +
+        "000000000000000000000000cf8e5340"
+
+    func testAttachedPackNamesItsChargeAndSerial() {
+        let info = BatteryPackInfo.decode(frame: bytes(attachedHex))
+        XCTAssertNotNil(info)
+        XCTAssertEqual(info?.present, true)
+        XCTAssertEqual(info?.socPct ?? 0, 74.1, accuracy: 1e-9)
+        XCTAssertEqual(info?.serial, "WBB5AP0126395")
+        XCTAssertEqual(info?.btAddr, "f7381d2e3161")
+    }
+
+    func testRemovedPackReportsAbsenceNotAStaleReading() {
+        let info = BatteryPackInfo.decode(frame: bytes(absentHex))
+        XCTAssertEqual(info?.present, false)
+        XCTAssertNil(info?.socPct)
+        XCTAssertNil(info?.serial)
+        XCTAssertNil(info?.btAddr)
+    }
+
+    func testNonPackOrShortFrameIsNil() {
+        XCTAssertNil(BatteryPackInfo.decode(frame: bytes("aa0128000100"))) // too short
+        // A 151 response whose result byte is not SUCCESS decodes to nil.
+        var f = bytes(attachedHex); f[12] = 0 // result = FAILURE
+        XCTAssertNil(BatteryPackInfo.decode(frame: f))
+    }
+}

--- a/android/app/src/main/java/com/noop/protocol/BatteryPackInfo.kt
+++ b/android/app/src/main/java/com/noop/protocol/BatteryPackInfo.kt
@@ -1,0 +1,47 @@
+package com.noop.protocol
+
+/**
+ * Decodes a `GET_BATTERY_PACK_INFO` (command 151) COMMAND_RESPONSE — the WHOOP 5.0/MG battery pack's
+ * charge, serial and Bluetooth address, read THROUGH the strap (a 4.0 has no pack command). noop already
+ * probes `GET_EXTENDED_BATTERY_INFO` (98), but the 5/MG reply to 98 is an undecoded stub; 151 is the
+ * command that actually carries the pack's fuel gauge.
+ *
+ * Field offsets re-derived (clean-room; real captures, never invented offsets) from two captured 5/MG
+ * frames — pack attached, then physically removed — so this is an UNVALIDATED CANDIDATE pending broader
+ * hardware. Pure + deterministic; the Swift `BatteryPackInfo` (WhoopProtocol) is its byte-identical twin.
+ */
+object BatteryPackInfo {
+
+    /** [present] tells an attached pack from a removed one — the command answers SUCCESS either way, so a
+     *  removed pack's zeroed block is the only discriminator and MUST clear the card, never keep a stale
+     *  charge. [socPct] is tenths-precision %, null when absent; [serial]/[btAddr] null when absent. */
+    data class Info(
+        val present: Boolean,
+        val socPct: Double?,
+        val serial: String?,
+        val btAddr: String?,
+    )
+
+    /** Resp-cmd byte sits at [cmdOff] (10 on WHOOP 5/MG — the only family with a pack). Null when the
+     *  frame is not a well-formed 151 SUCCESS response; the caller CRC-gates the frame (framing layer does). */
+    fun decode(frame: ByteArray, cmdOff: Int = 10): Info? {
+        // Layout vs cmdOff, pinned to the captures: +0 resp-cmd (151), +2 result (1 = SUCCESS), +4 present
+        // flag, +5 BT address (6 bytes), +11 serial (16-byte ASCII, NUL-terminated), +27 SoC (u16 LE,
+        // tenths of a percent).
+        if (cmdOff < 0 || frame.size <= cmdOff + 4) return null
+        if ((frame[cmdOff].toInt() and 0xFF) != 151 || (frame[cmdOff + 2].toInt() and 0xFF) != 1) return null
+        val present = (frame[cmdOff + 4].toInt() and 0xFF) == 1
+        if (!present) return Info(false, null, null, null)
+
+        val btStart = cmdOff + 5
+        val serStart = cmdOff + 11
+        val socStart = cmdOff + 27
+        if (frame.size < socStart + 2) return null
+
+        val btAddr = (btStart until btStart + 6).joinToString("") { "%02x".format(frame[it].toInt() and 0xFF) }
+        val serBytes = (serStart until serStart + 16).map { frame[it] }.takeWhile { it.toInt() != 0 }
+        val serial = if (serBytes.isEmpty()) null else String(serBytes.toByteArray(), Charsets.US_ASCII)
+        val raw = (frame[socStart].toInt() and 0xFF) or ((frame[socStart + 1].toInt() and 0xFF) shl 8)
+        return Info(true, raw / 10.0, serial, btAddr)
+    }
+}

--- a/android/app/src/test/java/com/noop/protocol/BatteryPackInfoTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/BatteryPackInfoTest.kt
@@ -1,0 +1,46 @@
+package com.noop.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Twin of Swift BatteryPackInfoTests. GET_BATTERY_PACK_INFO (151) has two answers and the Devices card
+ * must behave oppositely on each: a reply naming a pack fills the row, a reply naming none must CLEAR it.
+ * Both frames came off one WHOOP 5 strap — pack attached, then physically removed — pinning the decode to
+ * real bytes, byte-identical to the Swift twin.
+ */
+class BatteryPackInfoTest {
+
+    private fun bytes(s: String): ByteArray =
+        ByteArray(s.length / 2) { ((s[it * 2].digitToInt(16) shl 4) or s[it * 2 + 1].digitToInt(16)).toByte() }
+
+    private val attachedHex =
+        "aa01280001002de1245c9704010101f7381d2e3161574242354150303132363339" +
+            "35000000e5020c01000000be577aee"
+    private val absentHex =
+        "aa01280001002de1240797040101000000000000000000000000000000000000" +
+            "000000000000000000000000cf8e5340"
+
+    @Test fun attachedPackNamesItsChargeAndSerial() {
+        val info = BatteryPackInfo.decode(bytes(attachedHex))!!
+        assertEquals(true, info.present)
+        assertEquals(74.1, info.socPct!!, 1e-9)
+        assertEquals("WBB5AP0126395", info.serial)
+        assertEquals("f7381d2e3161", info.btAddr)
+    }
+
+    @Test fun removedPackReportsAbsenceNotAStaleReading() {
+        val info = BatteryPackInfo.decode(bytes(absentHex))!!
+        assertEquals(false, info.present)
+        assertNull(info.socPct)
+        assertNull(info.serial)
+        assertNull(info.btAddr)
+    }
+
+    @Test fun nonPackOrShortFrameIsNull() {
+        assertNull(BatteryPackInfo.decode(bytes("aa0128000100")))
+        val f = bytes(attachedHex); f[12] = 0 // result != SUCCESS
+        assertNull(BatteryPackInfo.decode(f))
+    }
+}


### PR DESCRIPTION
Clean-room re-implementation of WHOOP battery-pack readout (idea seen in a fork; re-derived from facts, not code).

## What
A pure decoder for **command 151 (`GET_BATTERY_PACK_INFO`)** — the WHOOP **5.0/MG** battery pack's **charge %, serial, and BT address**, read through the strap. noop already probes `GET_EXTENDED_BATTERY_INFO` (98), but the 5/MG reply to 98 is an undecoded stub; **151 is the command that actually carries the pack's fuel gauge**.

## Clean-room + honest
Field offsets are **re-derived from two captured 5/MG frames** (pack attached, then physically removed) — never copied — so per the project rule this is an **UNVALIDATED CANDIDATE** pending broader hardware. The removed-pack frame pins the key subtlety: the command returns SUCCESS either way, so the **zeroed block is the only discriminator** — an absent reply must report absence, not keep a stale charge.

Layout (relative to the 5/MG resp-cmd byte @10): +2 result, +4 present-flag, +5 BT-addr(6), +11 serial(16, ASCII), +27 SoC(u16-LE ÷10).

## Where + tests
`BatteryPackInfo` in the pure **WhoopProtocol** package (Swift) + a **byte-identical `com.noop.protocol` Kotlin twin**. The two captured frames are the tests — decode `74.1%` / `WBB5AP0126395` on attach, clear on removal. **Validated locally on both** (Swift `swift test` on Linux; Kotlin JVM). No app-target, no BLE → covered by `swift-packages.yml` + Android `build-and-test`, no gate.

## Scope
This is the **decoder foundation only**. Wiring 151 into the strap's command poller (+ the `BATTERY_PACK_CONNECTED/REMOVED` events 21/22) and a Devices-card pack row are **follow-ups that need a real strap + pack to validate** (BLE can't be CI-tested).