### PR TITLE
BatteryPackInfo: byte-exact serial parity + shared edge-vector tests (#1277 follow-up)

### DIFF
--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/BatteryPackInfoTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/BatteryPackInfoTests.swift
@@ -44,4 +44,19 @@ final class BatteryPackInfoTests: XCTestCase {
         var f = bytes(attachedHex); f[12] = 0 // result = FAILURE
         XCTAssertNil(BatteryPackInfo.decode(frame: f))
     }
+
+    /// Edge vectors mutated off the attached golden. The Kotlin twin asserts the SAME results, byte for
+    /// byte — including the non-ASCII-serial case, where both must return a nil serial (not a garbage one).
+    func testEdgeVectorsDecodeIdenticallyToKotlin() {
+        let base = bytes(attachedHex)
+        func mut(_ kv: [Int: UInt8]) -> [UInt8] { var f = base; for (i, v) in kv { f[i] = v }; return f }
+        XCTAssertEqual(BatteryPackInfo.decode(frame: mut([37: 0, 38: 0]))?.socPct ?? -1, 0.0, accuracy: 1e-9)
+        XCTAssertEqual(BatteryPackInfo.decode(frame: mut([37: 0xe8, 38: 0x03]))?.socPct ?? -1, 100.0, accuracy: 1e-9)
+        XCTAssertNil(BatteryPackInfo.decode(frame: mut([21: 0]))?.serial)            // empty serial → nil
+        let hb = BatteryPackInfo.decode(frame: mut([21: 0x80]))                       // non-ASCII byte
+        XCTAssertEqual(hb?.present, true)
+        XCTAssertNil(hb?.serial)                                                      // undecodable → nil
+        XCTAssertNil(BatteryPackInfo.decode(frame: mut([10: 0])))                     // not a 151 response
+        XCTAssertNil(BatteryPackInfo.decode(frame: mut([12: 0])))                     // not SUCCESS
+    }
 }

--- a/android/app/src/main/java/com/noop/protocol/BatteryPackInfo.kt
+++ b/android/app/src/main/java/com/noop/protocol/BatteryPackInfo.kt
@@ -40,7 +40,10 @@ object BatteryPackInfo {
 
         val btAddr = (btStart until btStart + 6).joinToString("") { "%02x".format(frame[it].toInt() and 0xFF) }
         val serBytes = (serStart until serStart + 16).map { frame[it] }.takeWhile { it.toInt() != 0 }
-        val serial = if (serBytes.isEmpty()) null else String(serBytes.toByteArray(), Charsets.US_ASCII)
+        // Null on empty OR any non-ASCII byte, matching the Swift twin's `String(bytes:encoding:.ascii)`
+        // (which returns nil for any byte > 127) — keeps the two byte-identical on a malformed serial.
+        val serial = if (serBytes.isEmpty() || serBytes.any { (it.toInt() and 0xFF) >= 0x80 }) null
+        else String(serBytes.toByteArray(), Charsets.US_ASCII)
         val raw = (frame[socStart].toInt() and 0xFF) or ((frame[socStart + 1].toInt() and 0xFF) shl 8)
         return Info(true, raw / 10.0, serial, btAddr)
     }

--- a/android/app/src/test/java/com/noop/protocol/BatteryPackInfoTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/BatteryPackInfoTest.kt
@@ -43,4 +43,19 @@ class BatteryPackInfoTest {
         val f = bytes(attachedHex); f[12] = 0 // result != SUCCESS
         assertNull(BatteryPackInfo.decode(f))
     }
+
+    /** Edge vectors mutated off the attached golden — the SAME results the Swift twin asserts, byte for
+     *  byte, including the non-ASCII-serial case where both must return a null serial (not a garbage one). */
+    @Test fun edgeVectorsDecodeIdenticallyToSwift() {
+        val base = bytes(attachedHex)
+        fun mut(vararg kv: Pair<Int, Int>) = base.copyOf().also { for ((i, v) in kv) it[i] = v.toByte() }
+        assertEquals(0.0, BatteryPackInfo.decode(mut(37 to 0, 38 to 0))!!.socPct!!, 1e-9)
+        assertEquals(100.0, BatteryPackInfo.decode(mut(37 to 0xe8, 38 to 0x03))!!.socPct!!, 1e-9)
+        assertNull(BatteryPackInfo.decode(mut(21 to 0))!!.serial)          // empty serial → null
+        val hb = BatteryPackInfo.decode(mut(21 to 0x80))!!                  // non-ASCII byte
+        assertEquals(true, hb.present)
+        assertNull(hb.serial)                                              // undecodable → null
+        assertNull(BatteryPackInfo.decode(mut(10 to 0)))                   // not a 151 response
+        assertNull(BatteryPackInfo.decode(mut(12 to 0)))                   // not SUCCESS
+    }
 }


### PR DESCRIPTION
Follow-up to #1277 to make the pack decoder **byte-identical across platforms on every input**, not just the reachable ones.

A cross-platform run over edge vectors showed Swift and Kotlin agree on all reachable inputs (attach, absent, SoC 0/100%, empty serial, short/wrong-cmd/non-success). The **only** divergence was unreachable: a **non-ASCII byte in the serial** — Swift's `.ascii` returns nil (>127 rejected), Kotlin's `US_ASCII` substituted a replacement char. Real WHOOP serials are ASCII, so it can't occur, but this makes Kotlin **reject non-ASCII → null** to match Swift exactly.

Pinned with **shared edge-vector tests** on both sides (same vectors mutated off the attached golden, asserting identical results incl. non-ASCII serial → null). Validated locally: `swift test` (Linux) + Kotlin JVM. Pure protocol package + com.noop.protocol → `swift-packages.yml` + Android `build-and-test`, no gate.