### PR TITLE
WHOOP battery pack: add the WHOOP 4.0 voltage path (command 98)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/BatteryPackInfo.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/BatteryPackInfo.swift
@@ -22,9 +22,13 @@ public enum BatteryPackInfo {
         public let serial: String?
         /// The pack's Bluetooth address as lowercase hex — identity, not a reading. nil when absent.
         public let btAddr: String?
+        /// WHOOP 4.0 only: the pack VOLTAGE in millivolts. A 4.0 has no fuel-gauge command, so its pack is
+        /// read via GET_EXTENDED_BATTERY_INFO (98) which reports voltage, NOT a charge %. nil on 5/MG.
+        public let voltageMv: Int?
 
-        public init(present: Bool, socPct: Double?, serial: String?, btAddr: String?) {
-            self.present = present; self.socPct = socPct; self.serial = serial; self.btAddr = btAddr
+        public init(present: Bool, socPct: Double?, serial: String?, btAddr: String?, voltageMv: Int? = nil) {
+            self.present = present; self.socPct = socPct; self.serial = serial
+            self.btAddr = btAddr; self.voltageMv = voltageMv
         }
     }
 
@@ -52,5 +56,21 @@ public enum BatteryPackInfo {
         let raw = Int(frame[socStart]) | (Int(frame[socStart + 1]) << 8)
         let socPct = Double(raw) / 10.0
         return Info(present: true, socPct: socPct, serial: serial, btAddr: btAddr)
+    }
+
+    /// WHOOP 4.0 path. A 4.0 has no `GET_BATTERY_PACK_INFO` (151); its pack is read via
+    /// `GET_EXTENDED_BATTERY_INFO` (98), which reports the pack VOLTAGE (mV) — NOT a charge %. The
+    /// voltage sits at payload bytes 7..8 (little-endian), i.e. `frame[cmdOff+8..cmdOff+9]`, confirmed on
+    /// WHOOP4 (#592: a 3970 mV capture); `cmdOff` is 6 on WHOOP4. This is the same offset noop's
+    /// `ExtendedBatteryProbe` reads. Returns an Info carrying only `voltageMv`, or nil when the frame is
+    /// not a 98 response with a voltage payload.
+    public static func decodeExtended(frame: [UInt8], cmdOff: Int = 6) -> Info? {
+        // Need the voltage bytes to fall inside the payload (before the 4-byte CRC32 trailer): the payload
+        // ends at frame.count - 4, so byte cmdOff+9 must be < that ⇒ frame.count >= cmdOff + 14.
+        guard cmdOff >= 0, frame.count >= cmdOff + 14, Int(frame[cmdOff]) == 98 else { return nil }
+        let mv = Int(frame[cmdOff + 8]) | (Int(frame[cmdOff + 9]) << 8)
+        // 0 mV is not a real pack reading (no pack / empty answer) — report absence rather than "0.00 V".
+        guard mv > 0 else { return Info(present: false, socPct: nil, serial: nil, btAddr: nil) }
+        return Info(present: true, socPct: nil, serial: nil, btAddr: nil, voltageMv: mv)
     }
 }

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/BatteryPackInfoTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/BatteryPackInfoTests.swift
@@ -59,4 +59,18 @@ final class BatteryPackInfoTests: XCTestCase {
         XCTAssertNil(BatteryPackInfo.decode(frame: mut([10: 0])))                     // not a 151 response
         XCTAssertNil(BatteryPackInfo.decode(frame: mut([12: 0])))                     // not SUCCESS
     }
+
+    /// WHOOP 4.0 path: the pack is read via GET_EXTENDED_BATTERY_INFO (98), reporting VOLTAGE not a %.
+    /// The frame is the #592 WHOOP4 capture (pay[7..8] = 0x0f82 = 3970 mV). The Kotlin twin asserts the same.
+    func testWhoop4PackReportsVoltageNotPercent() {
+        let realFrame = "aa2400fa24c6620d010165006bff820f0c0128000f05e90321120200010100001a0000004675fe58"
+        let info = BatteryPackInfo.decodeExtended(frame: bytes(realFrame))
+        XCTAssertEqual(info?.present, true)
+        XCTAssertEqual(info?.voltageMv, 3970)   // 3.97 V
+        XCTAssertNil(info?.socPct)              // 4.0 has no fuel-gauge %
+        XCTAssertNil(info?.serial)
+        // A 5/MG 151 frame is not a 98 response → nil; and the 5/MG SoC decode never fills voltage.
+        XCTAssertNil(BatteryPackInfo.decodeExtended(frame: bytes(attachedHex)))
+        XCTAssertNil(BatteryPackInfo.decode(frame: bytes(attachedHex))?.voltageMv)
+    }
 }

--- a/android/app/src/main/java/com/noop/protocol/BatteryPackInfo.kt
+++ b/android/app/src/main/java/com/noop/protocol/BatteryPackInfo.kt
@@ -20,6 +20,9 @@ object BatteryPackInfo {
         val socPct: Double?,
         val serial: String?,
         val btAddr: String?,
+        /** WHOOP 4.0 only: pack VOLTAGE in mV — a 4.0 has no fuel-gauge command, so its pack is read via
+         *  GET_EXTENDED_BATTERY_INFO (98) which reports voltage, not a charge %. null on 5/MG. */
+        val voltageMv: Int? = null,
     )
 
     /** Resp-cmd byte sits at [cmdOff] (10 on WHOOP 5/MG — the only family with a pack). Null when the
@@ -46,5 +49,21 @@ object BatteryPackInfo {
         else String(serBytes.toByteArray(), Charsets.US_ASCII)
         val raw = (frame[socStart].toInt() and 0xFF) or ((frame[socStart + 1].toInt() and 0xFF) shl 8)
         return Info(true, raw / 10.0, serial, btAddr)
+    }
+
+    /**
+     * WHOOP 4.0 path. A 4.0 has no `GET_BATTERY_PACK_INFO` (151); its pack is read via
+     * `GET_EXTENDED_BATTERY_INFO` (98), which reports the pack VOLTAGE (mV) — NOT a charge %. Voltage at
+     * payload bytes 7..8 (LE), i.e. `frame[cmdOff+8..cmdOff+9]`, confirmed on WHOOP4 (#592: a 3970 mV
+     * capture); [cmdOff] is 6 on WHOOP4. Same offset noop's `ExtendedBatteryProbe` reads. Null when the
+     * frame is not a 98 response with a voltage payload. Byte-identical twin of Swift `decodeExtended`.
+     */
+    fun decodeExtended(frame: ByteArray, cmdOff: Int = 6): Info? {
+        // The voltage bytes must fall inside the payload (before the 4-byte CRC32 trailer) ⇒ len >= cmdOff+14.
+        if (cmdOff < 0 || frame.size < cmdOff + 14 || (frame[cmdOff].toInt() and 0xFF) != 98) return null
+        val mv = (frame[cmdOff + 8].toInt() and 0xFF) or ((frame[cmdOff + 9].toInt() and 0xFF) shl 8)
+        // 0 mV is not a real reading (no pack / empty answer) → report absence, not "0.00 V".
+        if (mv <= 0) return Info(false, null, null, null)
+        return Info(true, null, null, null, voltageMv = mv)
     }
 }

--- a/android/app/src/test/java/com/noop/protocol/BatteryPackInfoTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/BatteryPackInfoTest.kt
@@ -58,4 +58,17 @@ class BatteryPackInfoTest {
         assertNull(BatteryPackInfo.decode(mut(10 to 0)))                   // not a 151 response
         assertNull(BatteryPackInfo.decode(mut(12 to 0)))                   // not SUCCESS
     }
+
+    /** WHOOP 4.0 path: pack read via GET_EXTENDED_BATTERY_INFO (98), reporting VOLTAGE not a %. The frame
+     *  is the #592 WHOOP4 capture (pay[7..8] = 0x0f82 = 3970 mV); same values the Swift twin asserts. */
+    @Test fun whoop4PackReportsVoltageNotPercent() {
+        val realFrame = "aa2400fa24c6620d010165006bff820f0c0128000f05e90321120200010100001a0000004675fe58"
+        val info = BatteryPackInfo.decodeExtended(bytes(realFrame))!!
+        assertEquals(true, info.present)
+        assertEquals(3970, info.voltageMv)   // 3.97 V
+        assertNull(info.socPct)              // 4.0 has no fuel-gauge %
+        assertNull(info.serial)
+        assertNull(BatteryPackInfo.decodeExtended(bytes(attachedHex)))   // 151 frame is not a 98 response
+        assertNull(BatteryPackInfo.decode(bytes(attachedHex))!!.voltageMv) // 5/MG decode never fills voltage
+    }
 }


### PR DESCRIPTION
Extends the pack decoder (#1277/#1278) to cover **WHOOP 4.0**.

A 4.0 has **no fuel-gauge command** (151 is 5/MG-only), so it can't report a charge %. It *does* report the pack **voltage** via `GET_EXTENDED_BATTERY_INFO` (98) — the same reading noop's `ExtendedBatteryProbe` already decodes on WHOOP4. This folds that into `BatteryPackInfo` so one model covers both families:
- **5/MG** → SoC % + serial (command 151)
- **4.0** → voltage mV (command 98)

`Info` gains `voltageMv` (null on 5/MG); `decodeExtended(frame, cmdOff=6)` reads LE voltage at `frame[cmdOff+8..+9]`, matching the confirmed **#592 WHOOP4 capture (3970 mV / 3.97 V)** — which is the test. Both platforms, byte-identical, validated locally (swift test on Linux + Kotlin JVM). Pure decode → `swift-packages` + Android `build-and-test`, no gate.

**Honest note:** the 4.0 reading is voltage, not a %. A Devices card would show "3.97 V" on 4.0 and "74%" on 5/MG. The live poller + UI still need a real strap + pack to validate.