### PR TITLE
WHOOP battery pack: clarify 4.0 `present` is not a pack-attached signal

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/BatteryPackInfo.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/BatteryPackInfo.swift
@@ -12,9 +12,11 @@ import Foundation
 public enum BatteryPackInfo {
 
     public struct Info: Equatable, Sendable {
-        /// Whether a pack is attached. The command answers SUCCESS either way; a removed pack sends a
-        /// zeroed block with the present flag clear, which is the ONLY thing that tells the two apart — so
-        /// an absent reply must clear the card, never keep a stale charge.
+        /// Whether a pack is attached. From `decode` (5/MG, cmd 151) this is a REAL flag: a removed pack
+        /// sends a zeroed block with the flag clear, which is the only thing that tells the two apart, so
+        /// an absent reply must clear the card. From `decodeExtended` (4.0, cmd 98) it only means "a
+        /// voltage decoded" — cmd 98 has no presence flag and its voltage may be the strap's, so it's ~always
+        /// true. Real 4.0 pack presence must come from the attach/detach events, NOT this field.
         public let present: Bool
         /// State of charge (%), tenths precision, or nil when no pack is attached.
         public let socPct: Double?
@@ -64,6 +66,10 @@ public enum BatteryPackInfo {
     /// WHOOP4 (#592: a 3970 mV capture); `cmdOff` is 6 on WHOOP4. This is the same offset noop's
     /// `ExtendedBatteryProbe` reads. Returns an Info carrying only `voltageMv`, or nil when the frame is
     /// not a 98 response with a voltage payload.
+    ///
+    /// NOTE on `present`: cmd 98 carries no present/absent flag (unlike 151), so `present` here just marks
+    /// "a voltage decoded" and is ~always true — it is NOT a reliable "pack attached" signal. A 4.0 UI must
+    /// take pack presence from the attach/detach events and use this only for the voltage reading.
     public static func decodeExtended(frame: [UInt8], cmdOff: Int = 6) -> Info? {
         // Need the voltage bytes to fall inside the payload (before the 4-byte CRC32 trailer): the payload
         // ends at frame.count - 4, so byte cmdOff+9 must be < that ⇒ frame.count >= cmdOff + 14.

--- a/android/app/src/main/java/com/noop/protocol/BatteryPackInfo.kt
+++ b/android/app/src/main/java/com/noop/protocol/BatteryPackInfo.kt
@@ -12,9 +12,11 @@ package com.noop.protocol
  */
 object BatteryPackInfo {
 
-    /** [present] tells an attached pack from a removed one — the command answers SUCCESS either way, so a
-     *  removed pack's zeroed block is the only discriminator and MUST clear the card, never keep a stale
-     *  charge. [socPct] is tenths-precision %, null when absent; [serial]/[btAddr] null when absent. */
+    /** [present]: from [decode] (5/MG, cmd 151) this is a REAL flag — a removed pack's zeroed block is the
+     *  only discriminator, so an absent reply MUST clear the card. From [decodeExtended] (4.0, cmd 98) it
+     *  only means "a voltage decoded" — cmd 98 has no presence flag and its voltage may be the strap's, so
+     *  it's ~always true; real 4.0 pack presence must come from the attach/detach events, NOT this field.
+     *  [socPct] is tenths-precision %, null when absent; [serial]/[btAddr] null when absent. */
     data class Info(
         val present: Boolean,
         val socPct: Double?,
@@ -57,6 +59,10 @@ object BatteryPackInfo {
      * payload bytes 7..8 (LE), i.e. `frame[cmdOff+8..cmdOff+9]`, confirmed on WHOOP4 (#592: a 3970 mV
      * capture); [cmdOff] is 6 on WHOOP4. Same offset noop's `ExtendedBatteryProbe` reads. Null when the
      * frame is not a 98 response with a voltage payload. Byte-identical twin of Swift `decodeExtended`.
+     *
+     * NOTE on `present`: cmd 98 has no present/absent flag (unlike 151), so `present` here only marks "a
+     * voltage decoded" and is ~always true — NOT a reliable "pack attached" signal. A 4.0 UI must take pack
+     * presence from the attach/detach events and use this only for the voltage reading.
      */
     fun decodeExtended(frame: ByteArray, cmdOff: Int = 6): Info? {
         // The voltage bytes must fall inside the payload (before the 4-byte CRC32 trailer) ⇒ len >= cmdOff+14.


### PR DESCRIPTION
Doc-only follow-up to the battery-pack decoder (#1277/#1278/#1279).

A re-review surfaced a semantic footgun: `BatteryPackInfo.present` means two different things across the two decoders, and the difference matters for the future Devices card.

- **5/MG (`decode`, cmd 151):** `present` is a **real flag** — a removed pack sends a zeroed block with the flag clear, so it cleanly distinguishes "pack at 74%" from "no pack".
- **4.0 (`decodeExtended`, cmd 98):** cmd 98 has **no** present/absent flag — it just returns a voltage. So `present` only means *"a voltage decoded"* and is effectively **always true**, and (per the inherited pack-vs-strap caveat) the voltage may even be the strap's own.

So a 4.0 UI must take pack presence from the attach/detach events, **not** from `decodeExtended(...).present` — which this documents on both the `present` field and `decodeExtended`, on the Swift package and its byte-identical Kotlin twin.

Comment-only; no behaviour change. `swift build` clean.