### PR TITLE
Sleep: apportion stage %s so the four shares sum to exactly 100

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StagePercentages.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StagePercentages.swift
@@ -1,0 +1,41 @@
+/// Largest-remainder ("Hamilton") apportionment of parts into whole percentages.
+///
+/// Rounding each part's share of the whole on its own — `round(part / total * 100)` — does NOT preserve
+/// the sum: four stages of one night land on 99 or 101 as often as 100, and two views that each round
+/// independently can disagree on the same part. This apportions ONCE: floor every share, then hand the
+/// leftover whole-percent units to the parts with the largest fractional remainders, so the results sum
+/// to exactly 100. Every call site reads the one result, so they agree with each other and add up.
+///
+/// Kotlin twin: `com.noop.analytics.StagePercentages.wholePercentages` — byte-identical, including the
+/// leftover tie-break (larger remainder first, then lower index), so both platforms return the same ints.
+public enum StagePercentages {
+
+    /// `parts` are raw non-negative magnitudes (e.g. stage minutes) in a FIXED order; the returned whole
+    /// percentages line up with them and sum to exactly 100. Returns nil when the total is <= 0 — there is
+    /// nothing to apportion, and the caller should show no share rather than a `0%` it never measured.
+    public static func wholePercentages(_ parts: [Double]) -> [Int]? {
+        let clamped = parts.map { Swift.max(0, $0) }
+        let total = clamped.reduce(0, +)
+        guard total > 0 else { return nil }
+
+        let raw = clamped.map { $0 / total * 100 }
+        var whole = raw.map { Int($0.rounded(.down)) }
+        var remaining = 100 - whole.reduce(0, +)   // the fractional units the floors dropped; in 0..<count
+        guard remaining > 0 else { return whole }
+
+        // Largest fractional remainder first; ties broken by lower index so the twin can match exactly.
+        let order = raw.indices.sorted { i, j in
+            let fi = raw[i] - Double(whole[i])
+            let fj = raw[j] - Double(whole[j])
+            if fi != fj { return fi > fj }
+            return i < j
+        }
+        var k = 0
+        while remaining > 0 && k < order.count {
+            whole[order[k]] += 1
+            remaining -= 1
+            k += 1
+        }
+        return whole
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StagePercentagesTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StagePercentagesTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// The Kotlin `StagePercentagesTest` asserts the SAME vectors → the two apportionments stay byte-identical.
+final class StagePercentagesTests: XCTestCase {
+
+    func testWorkedExampleSumsTo100() {
+        // 25 / 210 / 78 / 107 of a 420-minute night: independent rounding gives 6+50+19+25 on some nights
+        // and 99/101 on others. Apportioned once, it is always 100.
+        XCTAssertEqual(StagePercentages.wholePercentages([25, 210, 78, 107]), [6, 50, 19, 25])
+    }
+
+    func testEqualPartsSplitEvenly() {
+        XCTAssertEqual(StagePercentages.wholePercentages([1, 1, 1, 1]), [25, 25, 25, 25])
+    }
+
+    func testLeftoverGoesToLargestRemainderThenLowestIndex() {
+        // Three-way tie for one leftover unit → the lowest index takes it.
+        XCTAssertEqual(StagePercentages.wholePercentages([10, 10, 10, 0]), [34, 33, 33, 0])
+        // Two leftover units: the largest remainder first, then the lowest-index of the tied rest.
+        XCTAssertEqual(StagePercentages.wholePercentages([5, 5, 5, 2]), [30, 29, 29, 12])
+    }
+
+    func testWholeNightInOneStage() {
+        XCTAssertEqual(StagePercentages.wholePercentages([420, 0, 0, 0]), [100, 0, 0, 0])
+    }
+
+    func testNoMinutesIsNil() {
+        XCTAssertNil(StagePercentages.wholePercentages([0, 0, 0, 0]))
+        XCTAssertNil(StagePercentages.wholePercentages([]))
+    }
+
+    func testAlwaysSumsToExactly100() {
+        let nights: [[Double]] = [
+            [1, 2, 3, 4], [33, 33, 33, 1], [419, 1, 0, 0], [90, 240, 60, 30],
+            [7, 7, 7, 7], [100, 33, 33, 34], [1, 0, 0, 0], [12.5, 12.5, 12.5, 12.5],
+        ]
+        for n in nights {
+            let p = StagePercentages.wholePercentages(n)!
+            XCTAssertEqual(p.reduce(0, +), 100, "\(n) apportioned to \(p)")
+            XCTAssertTrue(p.allSatisfy { $0 >= 0 })
+        }
+    }
+}

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -1086,7 +1086,7 @@ struct SleepView: View {
             .frame(height: 34)
             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
             .accessibilityElement(children: .ignore)
-            .accessibilityLabel("Sleep stage breakdown: deep \(pct(s.deep, s.total)) percent, light \(pct(s.light, s.total)) percent, REM \(pct(s.rem, s.total)) percent, awake \(pct(s.awake, s.total)) percent")
+            .accessibilityLabel("Sleep stage breakdown: deep \(stageSharePercent(.deep, s)) percent, light \(stageSharePercent(.light, s)) percent, REM \(stageSharePercent(.rem, s)) percent, awake \(stageSharePercent(.awake, s)) percent")
             HStack(spacing: 16) {
                 legend(.deep, String(localized: "Deep"))
                 legend(.light, String(localized: "Light"))
@@ -1124,21 +1124,34 @@ struct SleepView: View {
     @ViewBuilder
     private func stageBreakdownRows(_ s: Stages) -> some View {
         VStack(alignment: .leading, spacing: NoopMetrics.cardInnerSpacing) {
-            stageBreakdownRow(.rem,   minutes: s.rem,   total: s.total)
-            stageBreakdownRow(.deep,  minutes: s.deep,  total: s.total)
-            stageBreakdownRow(.light, minutes: s.light, total: s.total)
-            stageBreakdownRow(.awake, minutes: s.awake, total: s.total)
+            stageBreakdownRow(.rem,   minutes: s.rem,   total: s.total, percent: stageSharePercent(.rem, s))
+            stageBreakdownRow(.deep,  minutes: s.deep,  total: s.total, percent: stageSharePercent(.deep, s))
+            stageBreakdownRow(.light, minutes: s.light, total: s.total, percent: stageSharePercent(.light, s))
+            stageBreakdownRow(.awake, minutes: s.awake, total: s.total, percent: stageSharePercent(.awake, s))
         }
     }
 
-    /// One WHOOP-style stage row. `fraction = minutes / total` sets both the % and the bar fill.
-    /// Tappable (WHOOP, ryanAtriumAi #988): selecting a row highlights that stage and recedes the
-    /// rest; tapping the selected row again clears the highlight.
+    /// The night's four stages as whole percentages that sum to exactly 100 (largest-remainder), so the
+    /// breakdown rows, the timeline rows and the stage-bar read-out all print ONE apportionment: they agree
+    /// with each other and add up. The bar fills still track the raw `minutes / total` fraction. Falls back
+    /// to 0 for a night with no minutes. Twin of Android `stageSharePercent`. (tanarchytan)
+    private func stageSharePercent(_ stage: SleepStage, _ s: Stages) -> Int {
+        guard let p = StagePercentages.wholePercentages([s.awake, s.light, s.deep, s.rem]) else { return 0 }
+        switch stage {
+        case .awake: return p[0]
+        case .light: return p[1]
+        case .deep:  return p[2]
+        case .rem:   return p[3]
+        }
+    }
+
+    /// One WHOOP-style stage row. `fraction = minutes / total` sets the bar fill; `percent` is the night's
+    /// apportioned share (so the four rows sum to 100). Tappable (WHOOP, ryanAtriumAi #988): selecting a
+    /// row highlights that stage and recedes the rest; tapping the selected row again clears the highlight.
     @ViewBuilder
-    private func stageBreakdownRow(_ stage: SleepStage, minutes: Double, total: Double) -> some View {
+    private func stageBreakdownRow(_ stage: SleepStage, minutes: Double, total: Double, percent: Int) -> some View {
         let color = StrandPalette.sleepStageColor(stage)
         let fraction = total > 0 ? min(1, max(0, minutes / total)) : 0
-        let percent = Int((fraction * 100).rounded())
         let isSelected = selectedStage == stage
         let othersSelected = selectedStage != nil && !isSelected
         HStack(spacing: 10) {
@@ -1210,10 +1223,10 @@ struct SleepView: View {
                 .frame(height: 124)
                 .padding(.horizontal, 10)
                 .padding(.bottom, 2)
-            stageTimelineRow(.awake, minutes: s.awake, total: s.total, intervals: smoothed, origin: origin, span: span)
-            stageTimelineRow(.light, minutes: s.light, total: s.total, intervals: smoothed, origin: origin, span: span)
-            stageTimelineRow(.deep,  minutes: s.deep,  total: s.total, intervals: smoothed, origin: origin, span: span)
-            stageTimelineRow(.rem,   minutes: s.rem,   total: s.total, intervals: smoothed, origin: origin, span: span)
+            stageTimelineRow(.awake, minutes: s.awake, percent: stageSharePercent(.awake, s), intervals: smoothed, origin: origin, span: span)
+            stageTimelineRow(.light, minutes: s.light, percent: stageSharePercent(.light, s), intervals: smoothed, origin: origin, span: span)
+            stageTimelineRow(.deep,  minutes: s.deep,  percent: stageSharePercent(.deep, s), intervals: smoothed, origin: origin, span: span)
+            stageTimelineRow(.rem,   minutes: s.rem,   percent: stageSharePercent(.rem, s), intervals: smoothed, origin: origin, span: span)
             // onset · midpoint · wake clock labels, aligned with the rows' inner strips.
             HStack {
                 Text(Self.stageAxisFormatter.string(from: night.onsetDate))
@@ -1357,12 +1370,11 @@ struct SleepView: View {
     /// night-long track with solid segments where the stage occurred. Tap toggles the highlight:
     /// the selected row keeps its colour + gains a border while every other row's segments grey out.
     @ViewBuilder
-    private func stageTimelineRow(_ stage: SleepStage, minutes: Double, total: Double,
+    private func stageTimelineRow(_ stage: SleepStage, minutes: Double, percent: Int,
                                   intervals: [SleepInterval], origin: TimeInterval, span: TimeInterval) -> some View {
         let color = StrandPalette.sleepStageColor(stage)
         let isSelected = selectedStage == stage
         let dimmed = selectedStage != nil && !isSelected
-        let percent = total > 0 ? Int((minutes / total * 100).rounded()) : 0
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 8) {
                 Text(stage.label.uppercased())
@@ -1920,10 +1932,6 @@ struct SleepView: View {
     }
 
     // MARK: - Formatting helpers
-
-    private func pct(_ minutes: Double, _ total: Double) -> Int {
-        total > 0 ? Int((minutes / total * 100).rounded()) : 0
-    }
 
     // The metric-grid tile formatters (`pctValue` / `rrValue` / `vsTypical` / `debtCaption` / `debtColor`)
     // moved to `NightDetailCard` with the grid; they had no other caller in SleepView.

--- a/Strand/Screens/StagesCard.swift
+++ b/Strand/Screens/StagesCard.swift
@@ -268,7 +268,7 @@ struct StageDetailView: View {
             .frame(height: 34)
             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
             .accessibilityElement(children: .ignore)
-            .accessibilityLabel("Sleep stage breakdown: deep \(pct(s.deep, s.total)) percent, light \(pct(s.light, s.total)) percent, REM \(pct(s.rem, s.total)) percent, awake \(pct(s.awake, s.total)) percent")
+            .accessibilityLabel("Sleep stage breakdown: deep \(stageSharePercent(.deep, s)) percent, light \(stageSharePercent(.light, s)) percent, REM \(stageSharePercent(.rem, s)) percent, awake \(stageSharePercent(.awake, s)) percent")
             HStack(spacing: 16) {
                 legend(.deep, String(localized: "Deep"))
                 legend(.light, String(localized: "Light"))
@@ -304,21 +304,34 @@ struct StageDetailView: View {
     @ViewBuilder
     private func stageBreakdownRows(_ s: Stages) -> some View {
         VStack(alignment: .leading, spacing: NoopMetrics.cardInnerSpacing) {
-            stageBreakdownRow(.rem,   minutes: s.rem,   total: s.total)
-            stageBreakdownRow(.deep,  minutes: s.deep,  total: s.total)
-            stageBreakdownRow(.light, minutes: s.light, total: s.total)
-            stageBreakdownRow(.awake, minutes: s.awake, total: s.total)
+            stageBreakdownRow(.rem,   minutes: s.rem,   total: s.total, percent: stageSharePercent(.rem, s))
+            stageBreakdownRow(.deep,  minutes: s.deep,  total: s.total, percent: stageSharePercent(.deep, s))
+            stageBreakdownRow(.light, minutes: s.light, total: s.total, percent: stageSharePercent(.light, s))
+            stageBreakdownRow(.awake, minutes: s.awake, total: s.total, percent: stageSharePercent(.awake, s))
         }
     }
 
-    /// One WHOOP-style stage row. `fraction = minutes / total` sets both the % and the bar fill.
-    /// Tappable (WHOOP, ryanAtriumAi #988): selecting a row highlights that stage and recedes the
-    /// rest; tapping the selected row again clears the highlight.
+    /// The night's four stages as whole percentages that sum to exactly 100 (largest-remainder), so this
+    /// card's breakdown rows, timeline rows and stage-bar read-out print ONE apportionment — and it matches
+    /// the SleepView detail for the same night. Bar fills still track the raw `minutes / total` fraction.
+    /// Falls back to 0 for a night with no minutes. Same helper as SleepView.stageSharePercent. (tanarchytan)
+    private func stageSharePercent(_ stage: SleepStage, _ s: Stages) -> Int {
+        guard let p = StagePercentages.wholePercentages([s.awake, s.light, s.deep, s.rem]) else { return 0 }
+        switch stage {
+        case .awake: return p[0]
+        case .light: return p[1]
+        case .deep:  return p[2]
+        case .rem:   return p[3]
+        }
+    }
+
+    /// One WHOOP-style stage row. `fraction = minutes / total` sets the bar fill; `percent` is the night's
+    /// apportioned share (so the four rows sum to 100). Tappable (WHOOP, ryanAtriumAi #988): selecting a
+    /// row highlights that stage and recedes the rest; tapping the selected row again clears the highlight.
     @ViewBuilder
-    private func stageBreakdownRow(_ stage: SleepStage, minutes: Double, total: Double) -> some View {
+    private func stageBreakdownRow(_ stage: SleepStage, minutes: Double, total: Double, percent: Int) -> some View {
         let color = StrandPalette.sleepStageColor(stage)
         let fraction = total > 0 ? min(1, max(0, minutes / total)) : 0
-        let percent = Int((fraction * 100).rounded())
         let isSelected = selectedStage == stage
         let othersSelected = selectedStage != nil && !isSelected
         HStack(spacing: 10) {
@@ -388,10 +401,10 @@ struct StageDetailView: View {
                 .frame(height: 124)
                 .padding(.horizontal, 10)
                 .padding(.bottom, 2)
-            stageTimelineRow(.awake, minutes: s.awake, total: s.total, intervals: smoothed, origin: origin, span: span)
-            stageTimelineRow(.light, minutes: s.light, total: s.total, intervals: smoothed, origin: origin, span: span)
-            stageTimelineRow(.deep,  minutes: s.deep,  total: s.total, intervals: smoothed, origin: origin, span: span)
-            stageTimelineRow(.rem,   minutes: s.rem,   total: s.total, intervals: smoothed, origin: origin, span: span)
+            stageTimelineRow(.awake, minutes: s.awake, percent: stageSharePercent(.awake, s), intervals: smoothed, origin: origin, span: span)
+            stageTimelineRow(.light, minutes: s.light, percent: stageSharePercent(.light, s), intervals: smoothed, origin: origin, span: span)
+            stageTimelineRow(.deep,  minutes: s.deep,  percent: stageSharePercent(.deep, s), intervals: smoothed, origin: origin, span: span)
+            stageTimelineRow(.rem,   minutes: s.rem,   percent: stageSharePercent(.rem, s), intervals: smoothed, origin: origin, span: span)
             // onset · midpoint · wake clock labels, aligned with the rows' inner strips.
             HStack {
                 Text(Self.stageAxisFormatter.string(from: night.onsetDate))
@@ -535,12 +548,11 @@ struct StageDetailView: View {
     /// night-long track with solid segments where the stage occurred. Tap toggles the highlight:
     /// the selected row keeps its colour + gains a border while every other row's segments grey out.
     @ViewBuilder
-    private func stageTimelineRow(_ stage: SleepStage, minutes: Double, total: Double,
+    private func stageTimelineRow(_ stage: SleepStage, minutes: Double, percent: Int,
                                   intervals: [SleepInterval], origin: TimeInterval, span: TimeInterval) -> some View {
         let color = StrandPalette.sleepStageColor(stage)
         let isSelected = selectedStage == stage
         let dimmed = selectedStage != nil && !isSelected
-        let percent = total > 0 ? Int((minutes / total * 100).rounded()) : 0
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 8) {
                 Text(stage.label.uppercased())
@@ -726,10 +738,6 @@ struct StageDetailView: View {
                 }
             }
         }
-    }
-
-    private func pct(_ minutes: Double, _ total: Double) -> Int {
-        total > 0 ? Int((minutes / total * 100).rounded()) : 0
     }
 
     private func efficiencyText(_ night: Night) -> String {

--- a/android/app/src/main/java/com/noop/analytics/StagePercentages.kt
+++ b/android/app/src/main/java/com/noop/analytics/StagePercentages.kt
@@ -1,0 +1,46 @@
+package com.noop.analytics
+
+import kotlin.math.floor
+
+/**
+ * Largest-remainder ("Hamilton") apportionment of parts into whole percentages.
+ *
+ * Rounding each part's share of the whole on its own — `round(part / total * 100)` — does NOT preserve
+ * the sum: four stages of one night land on 99 or 101 as often as 100, and two views that each round
+ * independently can disagree on the same part. This apportions ONCE: floor every share, then hand the
+ * leftover whole-percent units to the parts with the largest fractional remainders, so the results sum
+ * to exactly 100. Every call site reads the one result, so they agree with each other and add up.
+ *
+ * Swift twin: `StrandAnalytics.StagePercentages.wholePercentages` — byte-identical, including the
+ * leftover tie-break (larger remainder first, then lower index), so both platforms return the same ints.
+ */
+object StagePercentages {
+
+    /**
+     * [parts] are raw non-negative magnitudes (e.g. stage minutes) in a FIXED order; the returned whole
+     * percentages line up with them and sum to exactly 100. Returns null when the total is <= 0 — there is
+     * nothing to apportion, and the caller should show no share rather than a `0%` it never measured.
+     */
+    fun wholePercentages(parts: List<Double>): List<Int>? {
+        val clamped = parts.map { maxOf(0.0, it) }
+        val total = clamped.sum()
+        if (total <= 0.0) return null
+
+        val raw = clamped.map { it / total * 100.0 }
+        val whole = raw.map { floor(it).toInt() }.toIntArray()
+        var remaining = 100 - whole.sum()   // the fractional units the floors dropped; in 0..<count
+        if (remaining <= 0) return whole.toList()
+
+        // Largest fractional remainder first; ties broken by lower index so the twin can match exactly.
+        val order = raw.indices.sortedWith(
+            compareByDescending<Int> { raw[it] - whole[it] }.thenBy { it },
+        )
+        var k = 0
+        while (remaining > 0 && k < order.size) {
+            whole[order[k]]++
+            remaining--
+            k++
+        }
+        return whole.toList()
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/Charts.kt
+++ b/android/app/src/main/java/com/noop/ui/Charts.kt
@@ -1,5 +1,6 @@
 package com.noop.ui
 
+import com.noop.analytics.StagePercentages
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -85,12 +86,14 @@ private fun hypnogramSummary(stages: List<Pair<String, Float>>): String {
         }
         byStage[key] = (byStage[key] ?: 0f) + v
     }
-    val parts = order.mapNotNull { key ->
+    // One apportionment (largest-remainder) over the four stages so the read-out shares sum to 100 rather
+    // than 99/101 — same helper the visible breakdown rows use; absent stages get 0 and are skipped below.
+    val shares = StagePercentages.wholePercentages(order.map { (byStage[it] ?: 0f).toDouble() })
+    val parts = order.mapIndexedNotNull { i, key ->
         val v = byStage[key] ?: 0f
-        if (v <= 0f) null else {
-            val pct = (v / total * 100f).roundToInt()
+        if (v <= 0f || shares == null) null else {
             val label = if (key == "rem") "REM" else key.replaceFirstChar { it.uppercase() }
-            "$pct percent $label"
+            "${shares[i]} percent $label"
         }
     }
     return if (parts.isEmpty()) "Sleep stages, no data" else "Sleep stages, " + parts.joinToString(", ")

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -96,6 +96,7 @@ import com.noop.analytics.AnalyticsEngine
 import com.noop.analytics.SleepDebtLedger
 import com.noop.analytics.SleepEditGuard
 import com.noop.analytics.SleepStageTotals
+import com.noop.analytics.StagePercentages
 import com.noop.data.DismissedSleep
 import com.noop.data.SleepSession
 import com.noop.data.WhoopRepository
@@ -1656,7 +1657,7 @@ private fun StageTimeline(
             StageTimelineRow(
                 label = label,
                 minutes = minutes,
-                total = s.total,
+                percent = stageSharePercent(label, s),
                 color = color,
                 spans = stageRowSpans(intervals, label, spanSec),
                 selected = selectedStage == label,
@@ -1688,14 +1689,13 @@ private fun StageTimeline(
 private fun StageTimelineRow(
     label: String,
     minutes: Double,
-    total: Double,
+    percent: Int,
     color: Color,
     spans: List<Pair<Float, Float>>,
     selected: Boolean,
     dimmed: Boolean,
     onTap: () -> Unit,
 ) {
-    val percent = if (total > 0.0) (minutes / total * 100.0).roundToInt() else 0
     val segColor = if (dimmed) Palette.textTertiary.copy(alpha = 0.55f) else color
     val pctColor = if (dimmed) Palette.textTertiary else color
     val shape = RoundedCornerShape(Metrics.stageRowCorner)
@@ -1788,10 +1788,10 @@ private fun StageRowTrack(spans: List<Pair<Float, Float>>, color: Color) {
 @Composable
 private fun StageInsight(selectedStage: String?, s: Stages) {
     val text = when (selectedStage) {
-        "Awake" -> stageInsightLine("Awake", s.awake, s.total)
-        "Light" -> stageInsightLine("Light", s.light, s.total)
-        "Deep" -> stageInsightLine("Deep", s.deep, s.total)
-        "REM" -> stageInsightLine("REM", s.rem, s.total)
+        "Awake" -> stageInsightLine("Awake", s.awake, stageSharePercent("Awake", s))
+        "Light" -> stageInsightLine("Light", s.light, stageSharePercent("Light", s))
+        "Deep" -> stageInsightLine("Deep", s.deep, stageSharePercent("Deep", s))
+        "REM" -> stageInsightLine("REM", s.rem, stageSharePercent("REM", s))
         else -> "Tap a stage to highlight it across the night."
     }
     Box(
@@ -1802,9 +1802,25 @@ private fun StageInsight(selectedStage: String?, s: Stages) {
     }
 }
 
-private fun stageInsightLine(label: String, minutes: Double, total: Double): String {
-    val percent = if (total > 0.0) (minutes / total * 100.0).roundToInt() else 0
-    return "$label tonight: ${durationText(minutes)} — $percent% of the night."
+private fun stageInsightLine(label: String, minutes: Double, percent: Int): String =
+    "$label tonight: ${durationText(minutes)} — $percent% of the night."
+
+/**
+ * The night's four stages as whole percentages that sum to exactly 100 (largest-remainder), keyed by
+ * label — so the breakdown rows, the timeline rows and the insight line all read ONE apportionment: they
+ * agree with each other and add up, instead of four independent roundings landing on 99/101. The bar
+ * fills still track the raw minutes/total fraction. 0 for a night with no minutes. Twin of the Swift
+ * SleepView.stageSharePercent. (tanarchytan)
+ */
+internal fun stageSharePercent(label: String, s: Stages): Int {
+    val p = StagePercentages.wholePercentages(listOf(s.awake, s.light, s.deep, s.rem)) ?: return 0
+    return when (label) {
+        "Awake" -> p[0]
+        "Light" -> p[1]
+        "Deep" -> p[2]
+        "REM" -> p[3]
+        else -> 0
+    }
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -46,21 +46,20 @@ import kotlin.math.roundToInt
 @Composable
 internal fun StageBreakdownRows(s: Stages) {
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.space12)) {
-        StageBreakdownRow("REM", s.rem, s.total, Palette.sleepREM)
-        StageBreakdownRow("Deep", s.deep, s.total, Palette.sleepDeep)
-        StageBreakdownRow("Light", s.light, s.total, Palette.sleepLight)
-        StageBreakdownRow("Awake", s.awake, s.total, Palette.sleepAwake)
+        StageBreakdownRow("REM", s.rem, s.total, Palette.sleepREM, stageSharePercent("REM", s))
+        StageBreakdownRow("Deep", s.deep, s.total, Palette.sleepDeep, stageSharePercent("Deep", s))
+        StageBreakdownRow("Light", s.light, s.total, Palette.sleepLight, stageSharePercent("Light", s))
+        StageBreakdownRow("Awake", s.awake, s.total, Palette.sleepAwake, stageSharePercent("Awake", s))
     }
 }
 
 /**
- * One WHOOP-style stage row. `fraction = minutes / total` sets both the % and the PipBar fill, so the
- * coloured percent and the segmented bar always agree. Mirrors the macOS SleepView.stageBreakdownRow.
+ * One WHOOP-style stage row. `fraction = minutes / total` sets the PipBar fill; `percent` is the night's
+ * apportioned share (so the four rows sum to 100). Mirrors the macOS SleepView.stageBreakdownRow.
  */
 @Composable
-private fun StageBreakdownRow(stage: String, minutes: Double, total: Double, color: Color) {
+private fun StageBreakdownRow(stage: String, minutes: Double, total: Double, color: Color, percent: Int) {
     val fraction = if (total > 0.0) (minutes / total).coerceIn(0.0, 1.0) else 0.0
-    val percent = (fraction * 100.0).roundToInt()
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(Metrics.space10),

--- a/android/app/src/test/java/com/noop/analytics/StagePercentagesTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StagePercentagesTest.kt
@@ -1,0 +1,47 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** Twin of Swift StagePercentagesTests — the SAME vectors, so the two apportionments stay byte-identical. */
+class StagePercentagesTest {
+
+    @Test fun workedExampleSumsTo100() {
+        // 25 / 210 / 78 / 107 of a 420-minute night — always 100, never 99/101.
+        assertEquals(listOf(6, 50, 19, 25), StagePercentages.wholePercentages(listOf(25.0, 210.0, 78.0, 107.0)))
+    }
+
+    @Test fun equalPartsSplitEvenly() {
+        assertEquals(listOf(25, 25, 25, 25), StagePercentages.wholePercentages(listOf(1.0, 1.0, 1.0, 1.0)))
+    }
+
+    @Test fun leftoverGoesToLargestRemainderThenLowestIndex() {
+        // Three-way tie for one leftover unit → the lowest index takes it.
+        assertEquals(listOf(34, 33, 33, 0), StagePercentages.wholePercentages(listOf(10.0, 10.0, 10.0, 0.0)))
+        // Two leftover units: the largest remainder first, then the lowest-index of the tied rest.
+        assertEquals(listOf(30, 29, 29, 12), StagePercentages.wholePercentages(listOf(5.0, 5.0, 5.0, 2.0)))
+    }
+
+    @Test fun wholeNightInOneStage() {
+        assertEquals(listOf(100, 0, 0, 0), StagePercentages.wholePercentages(listOf(420.0, 0.0, 0.0, 0.0)))
+    }
+
+    @Test fun noMinutesIsNull() {
+        assertNull(StagePercentages.wholePercentages(listOf(0.0, 0.0, 0.0, 0.0)))
+        assertNull(StagePercentages.wholePercentages(emptyList()))
+    }
+
+    @Test fun alwaysSumsToExactly100() {
+        val nights = listOf(
+            listOf(1.0, 2.0, 3.0, 4.0), listOf(33.0, 33.0, 33.0, 1.0), listOf(419.0, 1.0, 0.0, 0.0),
+            listOf(90.0, 240.0, 60.0, 30.0), listOf(7.0, 7.0, 7.0, 7.0), listOf(100.0, 33.0, 33.0, 34.0),
+            listOf(1.0, 0.0, 0.0, 0.0), listOf(12.5, 12.5, 12.5, 12.5),
+        )
+        for (n in nights) {
+            val p = StagePercentages.wholePercentages(n)!!
+            assertEquals("$n apportioned to $p", 100, p.sum())
+            assert(p.all { it >= 0 })
+        }
+    }
+}


### PR DESCRIPTION
The stage breakdown rounded each stage's share of the night **independently**, at three sites per platform — the breakdown rows, the timeline rows, and (on Android) the stage-bar read-out / tap-insight line. Four independent roundings of one night sum to **99 or 101** as often as 100, and two sites could print **different** percentages for the same stage.

### Fix
A pure largest-remainder ("Hamilton") apportionment — `StagePercentages.wholePercentages`, in Swift `StrandAnalytics` and its byte-identical Kotlin `com.noop.analytics` twin — is computed **once per night**; every site reads that one result, so the four shares agree with each other and add up to exactly 100. The segmented bar fills still track the raw `minutes/total` fraction (unchanged). A night with no minutes apportions to nothing, so callers fall back to 0 rather than printing a share the night never measured.

- **iOS/macOS** (`SleepView.swift`): `stageBreakdownRow`, `stageTimelineRow`, and the stage-bar accessibility read-out now thread one apportioned `percent`.
- **Android** (`SleepScreen.kt`, `SleepStageBreakdownUi.kt`): the same three sites (`StageBreakdownRow`, `StageTimelineRow`, `stageInsightLine`).

### Notes
- Purely a **display** change — the underlying minutes and every analytic are untouched; only the rounded integers shown to the user change.
- One deliberate consequence: the label integer is now the apportioned value, so it can differ from the bar's exact `minutes/total` width by <1% — invisible, but worth stating since the two were previously locked to the same fraction.
- **Idea from tanarchytan's fork** — this is a clean-room reimplementation in noop's own Swift+Kotlin (their version delegates to a Rust core, which noop doesn't take).

### Tests
Parity tests on both platforms (`StagePercentagesTests` / `StagePercentagesTest`) assert the same vectors, the tie-break order, and the sum-to-100 property. Kotlin `testFullDebugUnitTest` + `compileFullDebugKotlin` green locally; Swift logic verified in isolation (the package's `swift test` runs under `swift-packages` CI). App-target Swift validated via the on-demand app-build gate.