### PR TITLE
iOS/macOS: port the Sleep chart style setting (Classic / Filled / Ribbon)

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Appearance.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Appearance.swift
@@ -25,6 +25,32 @@ public enum ChartStyle: String, CaseIterable, Identifiable, Sendable {
     public static func resolve(_ raw: String) -> ChartStyle { ChartStyle(rawValue: raw) ?? .titanium }
 }
 
+/// The Sleep tab's stage-CHART shape (distinct from `ChartStyle`, which is colours): the long-standing
+/// per-stage-rows timeline, or the WHOOP-style single stepped hypnogram drawn either FILLED to the
+/// baseline or as a slim RIBBON. Display-only — the underlying stages/totals are identical; this only
+/// changes the drawing, and Filled/Ribbon fall back to Classic on a night with no timestamped segments.
+/// The byte-identical twin is Android `SleepChartStyle` (Units.kt): same `classic`/`filled`/`ribbon`
+/// rawValues and the same `sleep.chart.style` key, so a device reads its own choice consistently.
+/// Device-local (NOT in the `.noopbak` whitelist), like the Android pref.
+public enum SleepChartStyle: String, CaseIterable, Identifiable, Sendable {
+    case classic   // per-stage-rows timeline (the default, unchanged)
+    case filled    // single stepped hypnogram, each stage filled from its lane to the baseline
+    case ribbon    // the same stepped chart drawn as a slim band at each stage level
+
+    public var id: String { rawValue }
+    public static let storageKey = "sleep.chart.style"
+
+    public var label: String {
+        switch self {
+        case .classic: return String(localized: "Classic", bundle: .module)
+        case .filled:  return String(localized: "Filled", bundle: .module)
+        case .ribbon:  return String(localized: "Ribbon", bundle: .module)
+        }
+    }
+
+    public static func resolve(_ raw: String) -> SleepChartStyle { SleepChartStyle(rawValue: raw) ?? .classic }
+}
+
 /// Applies the chart style: sets the global `StrandPalette.chartStyle` (read by the data-ramp
 /// accessors) AND keys the content on the raw value so a flip re-renders the visible charts. The
 /// global is set during body evaluation, before the keyed content renders, so the new ramps are live

--- a/Packages/StrandDesign/Sources/StrandDesign/Hypnogram.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Hypnogram.swift
@@ -56,6 +56,10 @@ public struct Hypnogram: View {
     /// WHOOP's tap-a-stage interaction: when set, this stage's segments (and its lane)
     /// render at full strength while every other stage recedes. Nil = everything full.
     public var highlightedStage: SleepStage?
+    /// When true, each stage band extends from its lane DOWN to the baseline (the FILLED stepped-area
+    /// look) instead of the slim ribbon band. The stage → lane mapping, risers and axis are identical;
+    /// only the band height changes. Mirrors the Android `FilledHypnogram(filled:)`.
+    public var filled: Bool
 
     public init(
         intervals: [SleepInterval],
@@ -65,7 +69,8 @@ public struct Hypnogram: View {
         nightStart: Date? = nil,
         showsTimeAxis: Bool = false,
         smoothingSeconds: TimeInterval = 300,
-        highlightedStage: SleepStage? = nil
+        highlightedStage: SleepStage? = nil,
+        filled: Bool = false
     ) {
         let sorted = intervals.sorted { $0.start < $1.start }
         self.intervals = smoothingSeconds > 0
@@ -77,6 +82,7 @@ public struct Hypnogram: View {
         self.nightStart = nightStart
         self.showsTimeAxis = showsTimeAxis
         self.highlightedStage = highlightedStage
+        self.filled = filled
     }
 
     // MARK: Display smoothing (WHOOP-style)
@@ -242,15 +248,21 @@ public struct Hypnogram: View {
 
                             // stage bands (visual only — a11y is the single collapsed plot summary below)
                             ForEach(Array(intervals.enumerated()), id: \.element.id) { idx, interval in
-                                let rect = bandRect(for: interval, in: geo.size)
+                                let band = bandRect(for: interval, in: geo.size)
+                                // FILLED: extend the band from its lane centre down to the baseline so the
+                                // night reads as a continuous stepped-area staircase. RIBBON: the slim band.
+                                let rect = filled
+                                    ? CGRect(x: band.minX, y: band.midY, width: band.width,
+                                             height: max(0, geo.size.height - band.midY))
+                                    : band
                                 let color = StrandPalette.sleepStageColor(interval.stage)
                                 let hoverDimmed = hoverIndex != nil && hoverIndex != idx
                                 let stageDimmed = highlightedStage != nil && interval.stage != highlightedStage
-                                // WHOOP hypnogram: squared, uniform ribbon segments — the night reads as
-                                // one continuous square-wave step line. No pill caps: a brief stage draws
+                                // WHOOP hypnogram: squared segments — the night reads as one continuous
+                                // step line (ribbon) or filled staircase. No pill caps: a brief stage draws
                                 // at its true duration as a thin tick, never inflated into a dot. When a
                                 // stage is highlighted (tap its legend row), everything else recedes.
-                                RoundedRectangle(cornerRadius: 2.5, style: .continuous)
+                                RoundedRectangle(cornerRadius: filled ? 0 : 2.5, style: .continuous)
                                     .fill(color)
                                     .frame(width: rect.width, height: rect.height)
                                     .opacity(stageDimmed ? 0.22 : (hoverDimmed ? 0.45 : 1.0))

--- a/Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings
+++ b/Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings
@@ -3660,6 +3660,122 @@
           }
         }
       }
+    },
+    "Filled": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filled"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gefüllt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relleno"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rempli"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preenchido"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "С заливкой"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pieno"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "填充"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "填滿"
+          }
+        }
+      }
+    },
+    "Ribbon": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ribbon"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Band"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cinta"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruban"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fita"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Лента"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nastro"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "色带"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "色帶"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Packages/StrandDesign/Tests/StrandDesignTests/SleepChartStyleTests.swift
+++ b/Packages/StrandDesign/Tests/StrandDesignTests/SleepChartStyleTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import StrandDesign
+
+/// Pins the Sleep-chart-style contract (#sleep-chart-style): the three rawValues and the storage key must
+/// stay byte-identical to the Android `SleepChartStyle` / `UnitPrefs.KEY_SLEEP_CHART_STYLE` twins, so a
+/// device reads its own choice consistently and the default resolves the same on either platform.
+final class SleepChartStyleTests: XCTestCase {
+
+    func testRawValuesMatchTheKotlinContract() {
+        XCTAssertEqual(SleepChartStyle.classic.rawValue, "classic")
+        XCTAssertEqual(SleepChartStyle.filled.rawValue, "filled")
+        XCTAssertEqual(SleepChartStyle.ribbon.rawValue, "ribbon")
+        // Exactly these three, in this order (parity with the Kotlin enum entries).
+        XCTAssertEqual(SleepChartStyle.allCases.map(\.rawValue), ["classic", "filled", "ribbon"])
+    }
+
+    func testStorageKeyMatchesTheAndroidPrefKey() {
+        XCTAssertEqual(SleepChartStyle.storageKey, "sleep.chart.style")
+    }
+
+    func testResolveIsTolerantAndDefaultsToClassic() {
+        XCTAssertEqual(SleepChartStyle.resolve("filled"), .filled)
+        XCTAssertEqual(SleepChartStyle.resolve("ribbon"), .ribbon)
+        XCTAssertEqual(SleepChartStyle.resolve("nonsense"), .classic)
+        XCTAssertEqual(SleepChartStyle.resolve(""), .classic)
+    }
+}

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -178556,6 +178556,58 @@
           }
         }
       }
+    },
+    "Sleep chart": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schlafdiagramm"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gráfico de sueño"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphique du sommeil"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grafico del sonno"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gráfico do sono"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "График сна"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "睡眠图表"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "睡眠圖表"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -180,6 +180,8 @@ struct SettingsView: View {
     @AppStorage(AppLanguage.storageKey) private var appLanguageRaw = AppLanguage.system.rawValue
     // Chart colour style: Titanium (brand) or Classic (throwback red→green). Re-colours gauges + charts.
     @AppStorage(ChartStyle.storageKey) private var chartStyleRaw = ChartStyle.titanium.rawValue
+    // Sleep tab stage-CHART shape: Classic per-stage rows, or the WHOOP-style stepped hypnogram Filled/Ribbon.
+    @AppStorage(SleepChartStyle.storageKey) private var sleepChartStyleRaw = SleepChartStyle.classic.rawValue
     // Chrome accent colour (mint / WHOOP blue / custom). Chrome only — never the data colour worlds.
     @AppStorage(AccentColor.storageKey) private var accentRaw = AccentColor.mint.rawValue
     @AppStorage(AccentColor.customHexKey) private var accentCustomHex = AccentColor.defaultCustomHex
@@ -1058,6 +1060,21 @@ struct SettingsView: View {
                     .pickerStyle(.menu)
                     .tint(StrandPalette.accent)
                     .accessibilityLabel("Chart colours")
+                }
+                rowDivider
+                FormRow(label: "Sleep chart") {
+                    // Classic = the per-stage timeline rows (default). Filled/Ribbon = the WHOOP-style
+                    // single stepped hypnogram, filled to the baseline or as a slim band. Display-only —
+                    // same stages either way; falls back to Classic on a night with no timestamped segments.
+                    Picker("Sleep chart", selection: $sleepChartStyleRaw) {
+                        ForEach(SleepChartStyle.allCases) { style in
+                            Text(style.label).tag(style.rawValue)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .tint(StrandPalette.accent)
+                    .accessibilityLabel("Sleep chart")
                 }
                 rowDivider
                 // Chrome accent colour — the links/buttons/selection tint only. The recovery/strain/sleep

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -40,6 +40,9 @@ struct SleepView: View {
     /// only when the underlying repo data actually changes — NOT on hover/animation/1Hz HR
     /// ticks that merely re-evaluate `body`. `nil` until first build or when there's no night.
     @State private var model: SleepModel?
+    /// The Sleep tab's stage-chart shape (Settings → Appearance → Sleep chart). Display-only; Filled/Ribbon
+    /// draw the WHOOP-style stepped hypnogram, Classic keeps the per-stage rows. Mirrors Android. (#sleep-chart-style)
+    @AppStorage(SleepChartStyle.storageKey) private var sleepChartStyleRaw = SleepChartStyle.classic.rawValue
     /// The repo signature the cached `model` was built from. Cheap to compute every render;
     /// when it differs from the current inputs we rebuild the model.
     @State private var modelKey: SleepInputKey?
@@ -726,13 +729,17 @@ struct SleepView: View {
             : String(localized: "\(durationText(night.timeInBed)) in bed · \(efficiencyText(night)) efficiency")
         VStack(alignment: .leading, spacing: NoopMetrics.space2) {
             if intervals.count >= 2 {
-                // WHOOP sleep-details layout (ryanAtriumAi #988): one full-width timeline ROW per
-                // stage — hatched track = the whole night, solid segments = when that stage occurred,
-                // header carries the stage %, duration right-aligned. Tap a row to highlight that
-                // stage; the others grey out. Replaces the 4-level hypnogram, whose staircase turned
-                // fragmented on-device staging into an unreadable comb. No separate footer — the
-                // rows ARE the legend.
-                stageTimelineCard(s, subtitle: subtitle, intervals: intervals, night: night)
+                // #sleep-chart-style (Settings → Appearance): Classic keeps the per-stage timeline ROWS
+                // (ryanAtriumAi #988) — hatched track = the whole night, solid segments = when that stage
+                // occurred, tap a row to highlight it. Filled/Ribbon draw the WHOOP-style single stepped
+                // hypnogram (filled to the baseline, or a slim band) with the breakdown rows as the legend.
+                switch SleepChartStyle.resolve(sleepChartStyleRaw) {
+                case .classic:
+                    stageTimelineCard(s, subtitle: subtitle, intervals: intervals, night: night)
+                case .filled, .ribbon:
+                    steppedHypnogramCard(s, subtitle: subtitle, intervals: intervals, night: night,
+                                         filled: SleepChartStyle.resolve(sleepChartStyleRaw) == .filled)
+                }
             } else {
                 ChartCard(
                     title: "Stage breakdown",
@@ -799,6 +806,36 @@ struct SleepView: View {
                 stageTimeline(stages, intervals: intervals, night: night)
             }
         }
+    }
+
+    /// #sleep-chart-style — the WHOOP-style single stepped hypnogram (Filled = each stage banded down to
+    /// the baseline, Ribbon = a slim band at each stage level), with the per-stage breakdown rows below as
+    /// the legend. Mirrors the Android FilledHypnogram card; only routed here when the night has ≥2 real
+    /// segments (the shared `intervals`). The stages/totals are identical to Classic — this only redraws.
+    @ViewBuilder
+    private func steppedHypnogramCard(_ s: Stages, subtitle: String, intervals: [SleepInterval],
+                                      night: Night, filled: Bool) -> some View {
+        ChartCard(
+            title: "Stage breakdown",
+            subtitle: subtitle,
+            trailing: durationText(s.asleep),
+            height: NoopMetrics.chartHeight,
+            tint: StrandPalette.restColor,
+            chart: {
+                Hypnogram(
+                    intervals: intervals,
+                    height: NoopMetrics.chartHeight,
+                    showsStageAxis: false,
+                    showsHover: true,
+                    nightStart: night.onsetDate,
+                    showsTimeAxis: true,
+                    filled: filled
+                )
+            },
+            // The stepped chart carries no built-in legend (the rows ARE the legend in Classic), so surface
+            // the per-stage breakdown below it — the same apportioned rows the Classic view uses.
+            footer: { stageBreakdownRows(s) }
+        )
     }
 
     /// #407 — the per-epoch movement/restlessness strip drawn UNDER the hypnogram, on the SAME timeline.

--- a/Strand/Screens/StagesCard.swift
+++ b/Strand/Screens/StagesCard.swift
@@ -53,6 +53,9 @@ struct StageDetailView: View {
     @State private var selectedStage: SleepStage? = nil
     /// Per-night sleeping-HR buckets, loaded by `stageCard`'s `.task(id:)` below.
     @State private var nightHR: [HRBucket] = []
+    /// The Sleep-chart shape (Settings → Appearance → Sleep chart), so the Today host card switches with
+    /// the Sleep tab and Android's `StagesHostCard`. Display-only. (#sleep-chart-style)
+    @AppStorage(SleepChartStyle.storageKey) private var sleepChartStyleRaw = SleepChartStyle.classic.rawValue
 
     var body: some View {
         // `stageCard` carries its own `.task(id: night.session.startTs)` HR load; clearing the
@@ -76,13 +79,16 @@ struct StageDetailView: View {
             : String(localized: "\(durationText(night.timeInBed)) in bed · \(efficiencyText(night)) efficiency")
         VStack(alignment: .leading, spacing: NoopMetrics.space2) {
             if intervals.count >= 2 {
-                // WHOOP sleep-details layout (ryanAtriumAi #988): one full-width timeline ROW per
-                // stage — hatched track = the whole night, solid segments = when that stage occurred,
-                // header carries the stage %, duration right-aligned. Tap a row to highlight that
-                // stage; the others grey out. Replaces the 4-level hypnogram, whose staircase turned
-                // fragmented on-device staging into an unreadable comb. No separate footer — the
-                // rows ARE the legend.
-                stageTimelineCard(s, subtitle: subtitle, intervals: intervals, night: night)
+                // #sleep-chart-style: Classic keeps the per-stage timeline ROWS (ryanAtriumAi #988);
+                // Filled/Ribbon draw the WHOOP-style stepped hypnogram with the breakdown rows as the
+                // legend — switching with the Sleep tab and Android's StagesHostCard.
+                switch SleepChartStyle.resolve(sleepChartStyleRaw) {
+                case .classic:
+                    stageTimelineCard(s, subtitle: subtitle, intervals: intervals, night: night)
+                case .filled, .ribbon:
+                    steppedHypnogramCard(s, subtitle: subtitle, intervals: intervals,
+                                         filled: SleepChartStyle.resolve(sleepChartStyleRaw) == .filled)
+                }
             } else {
                 ChartCard(
                     title: "Stage breakdown",
@@ -149,6 +155,34 @@ struct StageDetailView: View {
                 stageTimeline(stages, intervals: intervals, night: night)
             }
         }
+    }
+
+    /// #sleep-chart-style — the WHOOP-style stepped hypnogram (Filled = each stage banded to the baseline,
+    /// Ribbon = a slim band) for the read-only Today host card, with the per-stage breakdown as the legend.
+    /// Matches Android `StagesHostCard`: no clock axis (this card carries no session window). Only routed
+    /// here when the night has ≥2 real segments; the stages/totals are identical to Classic.
+    @ViewBuilder
+    private func steppedHypnogramCard(_ s: Stages, subtitle: String, intervals: [SleepInterval],
+                                      filled: Bool) -> some View {
+        ChartCard(
+            title: "Stage breakdown",
+            subtitle: subtitle,
+            trailing: durationText(s.asleep),
+            height: NoopMetrics.chartHeight,
+            tint: StrandPalette.restColor,
+            chart: {
+                Hypnogram(
+                    intervals: intervals,
+                    height: NoopMetrics.chartHeight,
+                    showsStageAxis: false,
+                    showsHover: true,
+                    nightStart: nil,
+                    showsTimeAxis: false,
+                    filled: filled
+                )
+            },
+            footer: { stageBreakdownRows(s) }
+        )
     }
 
     /// #407 — the per-epoch movement/restlessness strip drawn UNDER the hypnogram, on the SAME timeline.


### PR DESCRIPTION
Ports Android's **Settings → Appearance → "Sleep chart"** control to iOS and macOS.

Android lets you swap the Sleep tab's stage chart between the per-stage-rows timeline (**Classic**) and the WHOOP-style single stepped hypnogram — drawn **Filled** (each stage banded down to the baseline) or as a slim **Ribbon**. iOS/macOS already had the Classic rows *and* the `Hypnogram` (which is exactly the Ribbon look), but no way to choose between them and no Filled variant. This wires up the choice.

### What's added
- **StrandDesign** — `SleepChartStyle` enum (`classic`/`filled`/`ribbon` rawValues + the **same `sleep.chart.style` key** as Android's `UnitPrefs`, so a device reads its own choice consistently). Device-local, **not** in the `.noopbak` whitelist (like the Android pref). Plus a `filled` mode on the shared `Hypnogram` that extends each band from its lane to the baseline (mirrors Android `FilledHypnogram(filled:)`).
- **SettingsView** — a "Sleep chart" menu `Picker` beside "Chart colours".
- **SleepView** — switches the stage chart on the pref when the night has ≥2 real segments: Classic keeps the timeline rows; Filled/Ribbon draw the stepped `Hypnogram` with the (apportioned, post-#1282) breakdown rows as the legend. Falls back to Classic otherwise. Shared file, so **macOS gets it too**.

### Notes
- **Display-only** — stages/totals are identical to Classic; this only changes the drawing.
- Scope matches Android: the switch applies to the **Sleep tab** chart, not the Today `StagesCard`.
- Localized: `Filled`/`Ribbon` in the package catalog (all shipped locales), `Sleep chart` in the app catalog (8 locales). Local `i18n_audit --ci` is clean.

### Verification
- `StrandDesignTests.SleepChartStyleTests` pins the rawValues + storage key to the Android twin (runs under `swift-packages`).
- App-target Swift (SleepView/SettingsView) has no default CI — validating via the on-demand **app-build gate** (both Strand macOS + NOOPiOS iOS). On-device visual check of Filled/Ribbon still pending.