### PR TITLE
fix(ui): stop a non-WHOOP device inheriting WHOOP-5 empty-state copy (#623/#1086)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/DeviceFamily.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/DeviceFamily.swift
@@ -172,6 +172,24 @@ public extension DeviceFamily {
         return forRegistryModel(model)
     }
 
+    /// Is this registry row positively a 5.0/MG-family WHOOP? For callers asking a YES/NO *identity*
+    /// question rather than needing a concrete family to compute with.
+    ///
+    /// The distinction matters because the two kinds of caller must treat `forRegistryDevice`'s `nil`
+    /// oppositely, and only one of them may coalesce it:
+    ///
+    ///   - **Needs a concrete family** (the skin-temp raw→°C scale): a non-WHOOP reading genuinely shares
+    ///     the non-4.0 branch, so `?? .whoop5` picks the right arithmetic and preserves prior behaviour.
+    ///   - **Asks "is it a 5/MG?"** (this): `?? .whoop5` answers **yes** for an Oura ring, which is the
+    ///     #171 fall-through mistake wearing #1086's clothes — the brand said "not a WHOOP" and the
+    ///     coalesce threw that evidence away.
+    ///
+    /// Exists so the second kind cannot be written as `forRegistryDevice(…) ?? .whoop5 == .whoop5`, which
+    /// reads plausible and is wrong. Mirrors the Kotlin `DeviceFamily.isWhoop5Registry`.
+    static func isWhoop5Registry(model: String?, brand: String?) -> Bool {
+        forRegistryDevice(model: model, brand: brand) == .whoop5
+    }
+
     /// The header-CRC algorithm this family uses. This is the single switch that the family-aware
     /// `verifyFrame`/`parseFrame` overloads branch on; the payload CRC32 is identical for both.
     var headerCRCKind: HeaderCRCKind {

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/RegistryModelFamilyTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/RegistryModelFamilyTests.swift
@@ -80,13 +80,52 @@ final class RegistryModelFamilyTests: XCTestCase {
         XCTAssertEqual(DeviceFamily.forRegistryDevice(model: nil, brand: nil), .whoop5)
     }
 
-    /// "No scoring change" half of #1086: every consumer coalesces a non-WHOOP `nil` to `.whoop5` (the
-    /// non-4.0 skin-temp scale), so the family a non-WHOOP row is *treated as* is identical to before the
-    /// brand-aware resolver existed. Guards the skin-temp/day-owner call sites against a scale regression.
+    /// "No scoring change" half of #1086: the consumers that need a CONCRETE family coalesce a non-WHOOP
+    /// `nil` to `.whoop5` (the non-4.0 skin-temp scale), so the family a non-WHOOP row is *treated as* is
+    /// identical to before the brand-aware resolver existed. Guards the skin-temp/day-owner call sites
+    /// against a scale regression.
+    ///
+    /// ⚠️ Deliberately scoped to those callers. It once said "every consumer", which was true when written
+    /// and became wrong: an identity question ("is it a 5/MG?") must NOT coalesce — see
+    /// `isWhoop5Registry` and the tests below.
     func testNonWhoopCoalescesToPriorLabel() {
         for model in ["Oura Ring 3", "Oura Ring 4", "Oura Ring 5"] {
             XCTAssertEqual(DeviceFamily.forRegistryDevice(model: model, brand: "Oura") ?? .whoop5,
                            DeviceFamily.forRegistryModel(model), "\(model) treated-as family must be unchanged")
         }
+    }
+
+    // MARK: - isWhoop5Registry — the identity question, which must never coalesce
+
+    /// The defect this helper exists to prevent: a non-WHOOP brand must answer NO, whatever its model
+    /// string — including the ones `forRegistryModel` maps to `.whoop5` by fall-through. Written against
+    /// the real registry row of an Oura Gen3 (`brand "Oura"`, `model "Oura Ring 3"`), which under the old
+    /// `forRegistryDevice(…) ?? .whoop5 == .whoop5` shape answered YES and inherited WHOOP-5 empty-state
+    /// copy pointing at an R-R/RSA estimate the ring's banked stream can never produce.
+    func testIsWhoop5RegistryIsFalseForNonWhoopBrands() {
+        for model in ["Oura Ring 3", "Oura Ring 4", "Oura Ring 5", "Oura (cloud)", nil] {
+            XCTAssertFalse(DeviceFamily.isWhoop5Registry(model: model, brand: "Oura"),
+                           "Oura model \(model ?? "nil") must not be treated as a WHOOP 5")
+        }
+        XCTAssertFalse(DeviceFamily.isWhoop5Registry(model: "Watch", brand: "Apple"))
+        XCTAssertFalse(DeviceFamily.isWhoop5Registry(model: nil, brand: "Garmin"))
+    }
+
+    /// A real WHOOP 5/MG still answers YES, so #623's empty-state copy is unchanged for the straps it was
+    /// written for — the whole point of fixing this narrowly.
+    func testIsWhoop5RegistryIsTrueForWhoop5() {
+        XCTAssertTrue(DeviceFamily.isWhoop5Registry(model: "5.0 MG", brand: "WHOOP"))
+        XCTAssertTrue(DeviceFamily.isWhoop5Registry(model: "WHOOP 5.0 / MG", brand: "WHOOP"))
+        // Legacy rows: no brand recorded, so the model mapping decides — including the bare-"WHOOP"
+        // fall-through that #171 documents as 5.0-family.
+        XCTAssertTrue(DeviceFamily.isWhoop5Registry(model: "WHOOP", brand: nil))
+        XCTAssertTrue(DeviceFamily.isWhoop5Registry(model: nil, brand: ""))
+    }
+
+    /// A WHOOP 4.0 answers NO — it is not the 5/MG family — which is what keeps a 4.0-v24 that banks SpO2
+    /// on the generic empty copy rather than "unsupported on this strap".
+    func testIsWhoop5RegistryIsFalseForWhoop4() {
+        XCTAssertFalse(DeviceFamily.isWhoop5Registry(model: "4.0", brand: "WHOOP"))
+        XCTAssertFalse(DeviceFamily.isWhoop5Registry(model: "WHOOP 4.0", brand: nil))
     }
 }

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1671,14 +1671,20 @@ final class Repository: ObservableObject {
         return out
     }
 
-    /// Family of the ACTIVE strap (#623), for the deep timeline's family-specific empty-state copy. Reuses
-    /// the canonical `DeviceFamily.forRegistryDevice` (#171, #1086) with its `.whoop5` fallback for nil/unknown/
-    /// ambiguous, matching Android's `FullDayChartScreen`. Best-effort: no store / unreadable registry → `.whoop5`.
-    func activeStrapFamily() -> DeviceFamily {
-        guard let store else { return .whoop5 }
+    /// Is the ACTIVE strap a 5.0/MG-family WHOOP (#623)? Gates the deep timeline's family-specific
+    /// empty-state copy.
+    ///
+    /// Asks the canonical `DeviceFamily.isWhoop5Registry` (#171, #1086) rather than resolving a family and
+    /// comparing, because the old shape — `forRegistryDevice(…) ?? .whoop5` — answered **yes** for a
+    /// positively non-WHOOP brand and handed an Oura ring WHOOP-5 copy that told it to look for an
+    /// estimate the ring cannot produce. Best-effort: no store / unreadable registry → `false`, i.e. the
+    /// generic empty copy, which is the safe direction (`strapHasEverProduced` already returns `true`
+    /// without a store, so this changes no behaviour for a WHOOP). Twin of Android's `FullDayChartScreen`.
+    func activeStrapIsWhoop5() -> Bool {
+        guard let store else { return false }
         let devices = (try? DeviceRegistryStore(dbQueue: store.registryWriter).all()) ?? []
         let d = devices.first(where: { $0.id == deviceId })
-        return DeviceFamily.forRegistryDevice(model: d?.model, brand: d?.brand) ?? .whoop5
+        return DeviceFamily.isWhoop5Registry(model: d?.model, brand: d?.brand)
     }
 
     /// Whether the active strap has EVER banked a sample of `metric` (#623) — distinguishes a strap that

--- a/Strand/Screens/FullDayChartView.swift
+++ b/Strand/Screens/FullDayChartView.swift
@@ -98,8 +98,12 @@ struct FullDayChartView: View {
     /// #623: a SpO2/respiration track is "unsupported on this strap" only when it's a 5.0-family strap that
     /// has never produced the metric — not merely an empty window (a 4.0-v24 banks SpO2, and the legacy
     /// bare-"WHOOP" model resolves to the 5.0 family). Re-resolves when the metric changes.
+    ///
+    /// The family test must be a positive "is it a 5/MG" (#1086), never a coalesced one: the respiration
+    /// copy tells the reader their estimate is on the Health screen, which is true for a WHOOP 5 (the R-R
+    /// RSA estimate runs) and false for a non-WHOOP device whose banked stream that estimate refuses.
     private func resolveMetricUnsupported() async {
-        guard repo.activeStrapFamily() == .whoop5, metric == .spo2 || metric == .respiration else {
+        guard repo.activeStrapIsWhoop5(), metric == .spo2 || metric == .respiration else {
             metricUnsupported = false
             return
         }

--- a/android/app/src/main/java/com/noop/protocol/DeviceFamily.kt
+++ b/android/app/src/main/java/com/noop/protocol/DeviceFamily.kt
@@ -118,6 +118,27 @@ enum class DeviceFamily {
             return forRegistryModel(model)
         }
 
+        /**
+         * Is this registry row positively a 5.0/MG-family WHOOP? For callers asking a YES/NO
+         * *identity* question rather than needing a concrete family to compute with.
+         *
+         * The distinction matters because the two kinds of caller must treat [forRegistryDevice]'s
+         * `null` oppositely, and only one of them may coalesce it:
+         *
+         *  - **Needs a concrete family** (the skin-temp raw→°C scale): a non-WHOOP reading genuinely
+         *    shares the non-4.0 branch, so `?: WHOOP5` picks the right arithmetic and preserves the
+         *    prior behaviour.
+         *  - **Asks "is it a 5/MG?"** (this): `?: WHOOP5` answers **yes** for an Oura ring, which is
+         *    the #171 fall-through mistake wearing #1086's clothes — the brand said "not a WHOOP"
+         *    and the coalesce threw that evidence away.
+         *
+         * Exists so the second kind cannot be written as
+         * `(forRegistryDevice(…) ?: WHOOP5) == WHOOP5`, which reads plausible and is wrong.
+         * Mirrors the Swift `DeviceFamily.isWhoop5Registry`.
+         */
+        fun isWhoop5Registry(model: String?, brand: String?): Boolean =
+            forRegistryDevice(model, brand) == WHOOP5
+
         /** Whoop 5.0 CLIENT_HELLO bytes (16 bytes). Exposed as a named constant for test/debug use. */
         val WHOOP5_CLIENT_HELLO: ByteArray = byteArrayOf(
             0xAA.toByte(), 0x01, 0x08, 0x00, 0x00, 0x01, 0xE6.toByte(), 0x71,

--- a/android/app/src/main/java/com/noop/ui/FullDayChartScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/FullDayChartScreen.kt
@@ -109,9 +109,10 @@ fun FullDayChartScreen(vm: AppViewModel, onBack: () -> Unit) {
     LaunchedEffect(deviceId) {
         val d = runCatching { vm.pairedDevices() }.getOrDefault(emptyList())
             .firstOrNull { it.id == deviceId }
-        // Non-WHOOP device (null) coalesces to WHOOP5 so this gate is unchanged from before; the
-        // brand-aware resolver just no longer claims a non-WHOOP device is a WHOOP (#1086).
-        val whoop5 = (DeviceFamily.forRegistryDevice(d?.model, d?.brand) ?: DeviceFamily.WHOOP5) == DeviceFamily.WHOOP5
+        // A positive "is it a 5/MG", never a coalesced one (#1086): the respiration copy tells the reader
+        // their estimate is on the Health screen, which is true for a WHOOP 5 (the R-R RSA estimate runs)
+        // and false for a non-WHOOP device whose banked stream that estimate refuses.
+        val whoop5 = DeviceFamily.isWhoop5Registry(d?.model, d?.brand)
         isWhoop5 = whoop5
         val now = System.currentTimeMillis() / 1000
         everSpo2 = !whoop5 || runCatching { vm.repo.spo2Samples(deviceId, 0, now, 1) }.getOrDefault(emptyList()).isNotEmpty()

--- a/android/app/src/test/java/com/noop/protocol/RegistryModelFamilyTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/RegistryModelFamilyTest.kt
@@ -1,6 +1,8 @@
 package com.noop.protocol
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -93,9 +95,14 @@ class RegistryModelFamilyTest {
     }
 
     /**
-     * "No scoring change" half of #1086: every consumer coalesces a non-WHOOP null to WHOOP5 (the
-     * non-4.0 skin-temp scale), so the family a non-WHOOP row is *treated as* is identical to before the
-     * brand-aware resolver existed. Guards the skin-temp/day-owner call sites against a scale regression.
+     * "No scoring change" half of #1086: the consumers that need a CONCRETE family coalesce a non-WHOOP
+     * null to WHOOP5 (the non-4.0 skin-temp scale), so the family a non-WHOOP row is *treated as* is
+     * identical to before the brand-aware resolver existed. Guards the skin-temp/day-owner call sites
+     * against a scale regression.
+     *
+     * Deliberately scoped to those callers. It once said "every consumer", which was true when written
+     * and became wrong: an identity question ("is it a 5/MG?") must NOT coalesce — see [isWhoop5Registry]
+     * and the tests below.
      */
     @Test
     fun nonWhoopCoalescesToPriorLabel() {
@@ -106,5 +113,50 @@ class RegistryModelFamilyTest {
                 DeviceFamily.forRegistryDevice(model, "Oura") ?: DeviceFamily.WHOOP5,
             )
         }
+    }
+
+    // ---- isWhoop5Registry — the identity question, which must never coalesce ----
+
+    /**
+     * The defect this helper exists to prevent: a non-WHOOP brand must answer NO, whatever its model
+     * string — including the ones [DeviceFamily.forRegistryModel] maps to WHOOP5 by fall-through.
+     * Written against the real registry row of an Oura Gen3 (brand "Oura", model "Oura Ring 3"), which
+     * under the old `(forRegistryDevice(…) ?: WHOOP5) == WHOOP5` shape answered YES and inherited
+     * WHOOP-5 empty-state copy pointing at an R-R/RSA estimate the ring's banked stream cannot produce.
+     */
+    @Test
+    fun isWhoop5RegistryIsFalseForNonWhoopBrands() {
+        for (model in listOf("Oura Ring 3", "Oura Ring 4", "Oura Ring 5", "Oura (cloud)", null)) {
+            assertFalse(
+                "Oura model $model must not be treated as a WHOOP 5",
+                DeviceFamily.isWhoop5Registry(model, "Oura"),
+            )
+        }
+        assertFalse(DeviceFamily.isWhoop5Registry("Watch", "Apple"))
+        assertFalse(DeviceFamily.isWhoop5Registry(null, "Garmin"))
+    }
+
+    /**
+     * A real WHOOP 5/MG still answers YES, so #623's empty-state copy is unchanged for the straps it was
+     * written for — the whole point of fixing this narrowly.
+     */
+    @Test
+    fun isWhoop5RegistryIsTrueForWhoop5() {
+        assertTrue(DeviceFamily.isWhoop5Registry("5.0 MG", "WHOOP"))
+        assertTrue(DeviceFamily.isWhoop5Registry("WHOOP 5.0 / MG", "WHOOP"))
+        // Legacy rows: no brand recorded, so the model mapping decides — including the bare-"WHOOP"
+        // fall-through that #171 documents as 5.0-family.
+        assertTrue(DeviceFamily.isWhoop5Registry("WHOOP", null))
+        assertTrue(DeviceFamily.isWhoop5Registry(null, ""))
+    }
+
+    /**
+     * A WHOOP 4.0 answers NO — it is not the 5/MG family — which is what keeps a 4.0-v24 that banks SpO2
+     * on the generic empty copy rather than "unsupported on this strap".
+     */
+    @Test
+    fun isWhoop5RegistryIsFalseForWhoop4() {
+        assertFalse(DeviceFamily.isWhoop5Registry("4.0", "WHOOP"))
+        assertFalse(DeviceFamily.isWhoop5Registry("WHOOP 4.0", null))
     }
 }


### PR DESCRIPTION
## The bug

#1086 made registry family resolution brand-aware: `DeviceFamily.forRegistryDevice` returns `nil` for a
positively non-WHOOP brand, precisely so such a device cannot claim to be a WHOOP. Its own test says so —
`testNonWhoopBrandResolvesToNil`: *"an Oura ring … resolves to `nil` (not a WHOOP) instead of silently
falling through to `.whoop5`"*.

#623's deep-timeline empty-state gate then coalesced that `nil` straight back:

```swift
// Repository.swift
return DeviceFamily.forRegistryDevice(model: d?.model, brand: d?.brand) ?? .whoop5
```
```kotlin
// FullDayChartScreen.kt
val whoop5 = (DeviceFamily.forRegistryDevice(d?.model, d?.brand) ?: DeviceFamily.WHOOP5) == DeviceFamily.WHOOP5
```

So the answer to *"is this a 5/MG?"* is **yes** for an Oura ring — the #171 fall-through mistake wearing
#1086's clothes. The brand said "not a WHOOP" and the coalesce threw that evidence away.

## What the user sees

Respiration, on a ring-only install:

1. `activeStrapFamily() == .whoop5` is true → the #623 guard passes instead of short-circuiting.
2. `strapHasEverProduced(.respiration)` reads `respSample`, which is empty for a ring (the `0x6A`
   `breathsPerMin` candidate is deliberately dropped at ingest as unverified Tier-B) → `metricUnsupported = true`.
3. The chart shows the WHOOP-5 copy: **"This strap sends no raw respiration stream. Your estimated
   respiratory rate appears on the Health screen."**
4. On the Health screen, the Resp Rate tile reads **"No respiratory-rate value"** — because
   `SleepStager.respRateFromRR` refuses the ring's banked R-R via the beat-accuracy gate (#882/#883/#1108;
   measured beat-accurate fraction 0.0246 / 0.0235).

That sentence is **true for a WHOOP 5**, where the R-R/RSA estimate does run, and **false for a ring**.
The user is walked from one empty tile to another with no explanation.

Verified against a real install: registry row `brand = "Oura"`, `model = "Oura Ring 3"`; `respSample`
0 rows; `dailyMetric.respRateBpm` NULL on every day.

## The fix

Adds `DeviceFamily.isWhoop5Registry(model:brand:)` (+ Kotlin twin) and uses it at the gate on both
platforms. The helper exists so the identity question **cannot** be written as
`forRegistryDevice(…) ?? .whoop5 == .whoop5`, which reads plausible and is wrong; its doc comment states
which callers may coalesce and which may not:

* **needs a concrete family** (the skin-temp raw→°C scale) — a non-WHOOP reading genuinely shares the
  non-4.0 branch, so `?? .whoop5` picks the right arithmetic. **Deliberately left alone**, on both
  platforms; the existing comments there already say why.
* **asks "is it a 5/MG?"** — must not coalesce. That is this gate.

A non-WHOOP device now falls to the existing generic empty copy. **No new strings**, so no locale work.

## Deliberately not in this PR

Honest ring-specific copy (something like *"this ring banks a respiration candidate NOOP does not yet
trust enough to show"*) would be better than the generic line, but it costs 4 locales × 2 platforms and
is a product/wording call rather than a correctness one. Happy to add it here if preferred.

## Verification

* `WhoopProtocol` **568/0**; `RegistryModelFamilyTests` 9 → **12** — new tests pin that a non-WHOOP brand
  answers NO whatever its model, a real 5/MG still answers YES (including legacy bare-"WHOOP" and
  empty-brand rows), and a 4.0 answers NO.
* Android twin `RegistryModelFamilyTest` **12/0** — same count, mirrored cases.
* One existing test's doc claimed *"every consumer coalesces a non-WHOOP nil to WHOOP5"*. That was true
  when written and this change falsifies it, so it is now scoped to the concrete-family callers, on both
  platforms, with a note saying why.
* `StrandTests` **1103/0** (1 skipped). `Strand` macOS built, `NOOPiOS` iOS built — **no default CI
  compiles either**.
* Android `compileFullDebugKotlin` clean; full suite **3749 tests / 3 failed** — the same 3 pre-existing
  (`AiCoachContextTest`, 2× `StandardHrSensorFormatTest` locale); `git diff --name-only upstream/main..HEAD`
  touches neither file.
* `python3 Tools/i18n_audit.py --ci upstream/main` clean.

**Behaviour for WHOOP straps is unchanged** — that is the point of fixing it this narrowly, and the tests
pin it.