### PR TITLE
fix(oura): keep a reconnect outstanding with CoreBluetooth across suspension (#1213 follow-up)

### DIFF
--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -335,23 +335,154 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// (#414) and the Android `ReconnectBackoff` so a ring genuinely out of range doesn't hammer BLE.
     private var failedReconnectAttempts = 0
 
+    /// After this many consecutive failures, stop scheduling timed retries and hand the reconnect to
+    /// CoreBluetooth as a STANDING connect (see `issueStandingConnect`). Three keeps the quick 3s/6s
+    /// retries that fix a transient blip while the app is awake, then gets out of the way.
+    nonisolated static let standingConnectAfterAttempts = 3
+
+    /// Floor between two standing connects, used ONLY for a near-instant failure (see
+    /// `standingConnectFastFailureS`). Long enough that a genuine hot loop is broken, short enough that a
+    /// foreground user is not left waiting.
+    nonisolated static let standingConnectRetryFloor: TimeInterval = 30
+
+    /// A standing connect that stayed outstanding at least this long before failing was not a hot loop —
+    /// the ring was reachable enough to try, then refused. Re-issue such a failure **immediately**, so that
+    /// something is ALWAYS outstanding with CoreBluetooth.
+    ///
+    /// WHY THIS EXISTS, and why the timer path had to go (measured 2026-08-12, overnight, build `91812d93`,
+    /// the first hardware run of this whole fix). It engaged correctly at 01:27:52 after three consecutive
+    /// failures — and CoreBluetooth rejected the standing connect 7 s later with the same
+    /// `Failed to encrypt the connection` this ring produces on **every** reconnect. The old
+    /// `.standingConnectAfter` branch then nil'd `standingConnectAt` and armed a
+    /// `DispatchQueue.main.asyncAfter(23 s)`. The app suspended before it fired, so it went into the night
+    /// holding **nothing** outstanding — the exact defect this fix exists to remove, reintroduced by its
+    /// own backoff. The re-issue finally ran at **07:06:07, 5 h 38 m late**, on resume.
+    ///
+    /// The floor's purpose was only ever to avoid hammering while the app is AWAKE. A suspended app has no
+    /// loop to break — no callbacks are being delivered — so paying the floor on a dispatch timer trades
+    /// the one thing that survives suspension for protection against a problem that cannot occur there.
+    /// Re-issuing immediately instead is self-limiting: the rate is set by how long CoreBluetooth itself
+    /// takes to fail (7–11 s on this hardware), not by us.
+    nonisolated static let standingConnectFastFailureS: TimeInterval = 2
+
+    /// When the current standing connect was issued, or nil when none is outstanding.
+    private var standingConnectAt: Date?
+
     /// Next backoff delay, capped at 60s, matching BLEManager's `min(60, 3 * 2^(n-1))` and the Android twin.
     private func nextReconnectDelay() -> TimeInterval {
         min(60.0, 3.0 * pow(2.0, Double(max(0, failedReconnectAttempts - 1))))
     }
 
-    /// Schedule an auto-reconnect to the paired ring after a backoff delay, unless the teardown was
-    /// intentional or there is no known ring. Guarded again inside the deferred block: a `stop()` that
-    /// lands in the meantime cancels the pending reconnect (it re-checks `intentionalDisconnect` and that
+    /// What to do after an involuntary drop or a failed connect. Split out as a PURE function so the policy
+    /// is unit-testable with no CoreBluetooth, no radio and no ring — `OuraLiveSource` itself owns a
+    /// `CBCentralManager` and cannot be built in a test.
+    enum ReconnectStep: Equatable, Sendable {
+        /// Retry through the ordinary `connect(_:)` path after `delay`. The app is awake (it just received
+        /// the callback), so a short timer genuinely fixes a transient blip.
+        case timedRetry(delay: TimeInterval)
+        /// Hand off to CoreBluetooth now: leave a standing connect outstanding, which survives suspension.
+        case standingConnect
+        /// A standing connect failed fast; re-issue one after `delay` rather than looping on the callback.
+        case standingConnectAfter(delay: TimeInterval)
+    }
+
+    /// - Parameters:
+    ///   - attempt: the 1-based consecutive failure count (`failedReconnectAttempts` after incrementing).
+    ///   - secondsSinceStandingConnect: age of the outstanding standing connect, or nil when none is.
+    nonisolated static func reconnectStep(attempt: Int,
+                                         secondsSinceStandingConnect: TimeInterval?) -> ReconnectStep {
+        guard attempt >= standingConnectAfterAttempts else {
+            return .timedRetry(delay: min(60.0, 3.0 * pow(2.0, Double(max(0, attempt - 1)))))
+        }
+        // No standing connect outstanding reads as "long ago", so the first time we get here we hand off
+        // immediately rather than sitting out a floor we never started.
+        let since = secondsSinceStandingConnect ?? .greatestFiniteMagnitude
+        // Anything but a near-instant failure re-issues NOW, so a suspension can never catch us holding
+        // nothing. Only a genuinely instant failure (which proves the app is awake and looping) is worth
+        // a timer, and a timer is safe precisely because the app is awake.
+        guard since < standingConnectFastFailureS else { return .standingConnect }
+        return .standingConnectAfter(delay: standingConnectRetryFloor - since)
+    }
+
+    /// Hand the reconnect to CoreBluetooth: `central.connect(_:options:)` has **no timeout**, so it stays
+    /// outstanding indefinitely and iOS wakes the app when the ring advertises again — including while the
+    /// app is SUSPENDED, which is the whole point.
+    ///
+    /// WHY THIS EXISTS (measured 2026-08-10 11:16, build `9bd45fef`). The link dropped at 11:16:38, two
+    /// connects failed fast on `Failed to encrypt the connection`, and attempt 3 was scheduled for ~11:17:06.
+    /// It actually ran at **11:29:27 — 12m33s late**, when the phone was next picked up, with zero log lines
+    /// in between: `DispatchQueue.main.asyncAfter` does not run in a suspended app, the deadline just passes
+    /// and the block fires on resume. The ring was down for **12m51s of a 27m window (47%)** and the wearer
+    /// noticed. The damage is not the late timer — it is that after `didFailToConnect` the old code held
+    /// **nothing** outstanding, so there was no way to notice the ring at all.
+    ///
+    /// This is a DIFFERENT hole from the state restoration in #1213/#1215: that one is the app being
+    /// TERMINATED and relaunched; this one is the app merely being SUSPENDED, which overnight is far more
+    /// common. Neither fixes the other.
+    ///
+    /// No new outbound command: `central.connect` is the same call `connect(_:)` already makes.
+    private func issueStandingConnect(_ id: UUID) {
+        guard !intentionalDisconnect, reconnectID == id else { return }
+        guard let p = seenPeripherals[id] ?? central.retrievePeripherals(withIdentifiers: [id]).first else {
+            // No peripheral object to hand CoreBluetooth (never seen on this device). Fall back to the
+            // ordinary connect path, which scans for it — that is the only way to acquire one.
+            log("Oura: ring \(id) not cached - scanning instead of leaving a standing connect")
+            connect(id)
+            return
+        }
+        seenPeripherals[id] = p
+        peripheral = p
+        p.delegate = self
+        guard central.state == .poweredOn else {
+            // `centralManagerDidUpdateState` replays this on poweredOn.
+            pendingConnectID = id
+            log("Oura: standing reconnect deferred - Bluetooth not powered on (state=\(central.state.rawValue))")
+            return
+        }
+        standingConnectAt = Date()
+        log("Oura: leaving a STANDING connect outstanding for \(id) - CoreBluetooth will reconnect "
+            + "whenever the ring is reachable, including while the app is suspended")
+        central.connect(p, options: nil)
+    }
+
+    /// Re-reach the paired ring after an involuntary drop or a failed connect, unless the teardown was
+    /// intentional or there is no known ring.
+    ///
+    /// Two regimes, deliberately: the first few attempts use a short timed backoff (the app is awake — it
+    /// just received the callback — so a 3s/6s retry fixes a transient blip fast), and after that it hands
+    /// off to a STANDING CoreBluetooth connect that survives suspension. The timed block is guarded again on
+    /// wake: a `stop()` that lands in the meantime cancels it (it re-checks `intentionalDisconnect` and that
     /// the target is unchanged), so a deliberate teardown never races a stale reconnect.
     private func scheduleReconnect() {
         guard !intentionalDisconnect, let id = reconnectID else { return }
         failedReconnectAttempts += 1
-        let delay = nextReconnectDelay()
-        log("Oura: reconnecting in \(Int(delay))s (attempt \(failedReconnectAttempts))")
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-            guard let self, !self.intentionalDisconnect, self.reconnectID == id else { return }
-            self.connect(id)
+
+        switch Self.reconnectStep(attempt: failedReconnectAttempts,
+                                  secondsSinceStandingConnect: standingConnectAt.map {
+                                      Date().timeIntervalSince($0)
+                                  }) {
+        case .standingConnect:
+            issueStandingConnect(id)
+
+        case .standingConnectAfter(let wait):
+            // A standing connect failed NEAR-INSTANTLY, which only happens with the app awake and is the one
+            // shape that can hot-loop. Break it with a timer — safe here precisely because the app is awake.
+            // Any slower failure takes `.standingConnect` above and re-issues immediately, so this is the
+            // only path that can ever leave nothing outstanding, and it cannot be reached from suspension.
+            log("Oura: standing connect failed instantly - re-issuing in \(Int(wait))s "
+                + "(attempt \(failedReconnectAttempts))")
+            standingConnectAt = nil
+            DispatchQueue.main.asyncAfter(deadline: .now() + wait) { [weak self] in
+                guard let self, !self.intentionalDisconnect, self.reconnectID == id else { return }
+                self.issueStandingConnect(id)
+            }
+
+        case .timedRetry(let delay):
+            log("Oura: reconnecting in \(Int(delay))s (attempt \(failedReconnectAttempts))")
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                guard let self, !self.intentionalDisconnect, self.reconnectID == id else { return }
+                self.connect(id)
+            }
         }
     }
 
@@ -850,6 +981,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         // is never the intentional-teardown case, so clear the suppression flag.
         reconnectID = id
         intentionalDisconnect = false
+        standingConnectAt = nil   // an explicit connect supersedes any standing one
         let p = seenPeripherals[id] ?? central.retrievePeripherals(withIdentifiers: [id]).first
         guard let p else {
             // Never seen by this Mac/iPhone yet -> remember it and scan; didDiscover connects on sight.
@@ -877,6 +1009,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         intentionalDisconnect = true
         reconnectID = nil
         failedReconnectAttempts = 0
+        standingConnectAt = nil   // cancelPeripheralConnection below also cancels any standing connect
         stopScan()
         pendingConnectID = nil
         stopReengageTimer()
@@ -1570,6 +1703,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         intentionalDisconnect = true
         reconnectID = nil
         failedReconnectAttempts = 0
+        standingConnectAt = nil   // the cancel below also drops any standing connect
         if let p = peripheral { central.cancelPeripheralConnection(p) }
         guard needsPairing == nil else { return }
         let detail: String
@@ -1678,6 +1812,7 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
     public func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
         log("Oura: connected - discovering services")
         failedReconnectAttempts = 0   // a real connection clears the reconnect backoff (#912)
+        standingConnectAt = nil       // whatever was outstanding has landed
         peripheral.delegate = self
         // Fresh driver per connection so a new session re-runs auth (the app key is session-scoped). The
         // driver's `allowKeyInstall` is gated on this connection's adopt consent ONLY: with no consent the

--- a/StrandTests/OuraReconnectPolicyTests.swift
+++ b/StrandTests/OuraReconnectPolicyTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import Strand
+
+/// The reconnect policy after an involuntary drop or a failed connect.
+///
+/// WHY IT EXISTS, measured rather than reasoned (2026-08-10 11:16, build `9bd45fef`): the link dropped at
+/// 11:16:38, two connects failed fast on `Failed to encrypt the connection`, and attempt 3 was scheduled
+/// for ~11:17:06 — it actually ran at **11:29:27, 12 m 33 s late**, when the phone was next picked up,
+/// with zero log lines in between. `DispatchQueue.main.asyncAfter` does not run in a suspended app. The
+/// ring was down for **12 m 51 s of a 27 m window (47 %)**, and the damage was not the late timer but that
+/// after `didFailToConnect` nothing at all was outstanding.
+///
+/// ⚠️ These test the POLICY, not the plumbing. Whether a standing `central.connect` really survives
+/// suspension on a real phone is a hardware question and is owed a strap night.
+final class OuraReconnectPolicyTests: XCTestCase {
+
+    /// The app is awake when the first callbacks land, so the short backoff still gets its chance to fix a
+    /// transient blip — unchanged from #912/#414 and the Android twin.
+    func testEarlyAttemptsStillUseTheShortTimedBackoff() {
+        XCTAssertEqual(OuraLiveSource.reconnectStep(attempt: 1, secondsSinceStandingConnect: nil),
+                       .timedRetry(delay: 3))
+        XCTAssertEqual(OuraLiveSource.reconnectStep(attempt: 2, secondsSinceStandingConnect: nil),
+                       .timedRetry(delay: 6))
+    }
+
+    /// THE REGRESSION TEST. Attempt 3 is exactly where the 2026-08-10 capture stalled for 12 m 33 s: it
+    /// must hand off to CoreBluetooth, never schedule another timer.
+    func testThirdFailureHandsOffToAStandingConnect() {
+        XCTAssertEqual(OuraLiveSource.reconnectStep(attempt: 3, secondsSinceStandingConnect: nil),
+                       .standingConnect)
+        XCTAssertEqual(OuraLiveSource.reconnectStep(attempt: 9, secondsSinceStandingConnect: nil),
+                       .standingConnect)
+    }
+
+    /// THE REGRESSION TEST FOR THE 2026-08-12 OVERNIGHT (see `standingConnectFastFailureS`).
+    ///
+    /// A standing connect that survived seconds before failing — the shape this ring produces on every
+    /// reconnect (`Failed to encrypt the connection` after 7-11 s) — must be re-issued IMMEDIATELY. The
+    /// old policy armed a dispatch timer here, the app suspended before it fired, and the night was spent
+    /// with nothing outstanding: the exact defect the standing connect exists to remove, reintroduced by
+    /// its own backoff. 5 h 38 m of ring downtime.
+    func testASlowFailureIsReIssuedImmediatelySoSuspensionCannotStrandUs() {
+        for since in [2.0, 7.0, 11.0, 25.0, 29.9] {
+            XCTAssertEqual(OuraLiveSource.reconnectStep(attempt: 4, secondsSinceStandingConnect: since),
+                           .standingConnect,
+                           "a \(since)s-old standing connect must be re-issued immediately, not timed")
+        }
+    }
+
+    /// Once the floor has elapsed the hand-off resumes, so a ring that is genuinely unreachable is retried
+    /// at a bounded rate rather than abandoned.
+    func testOnceTheFloorHasElapsedItHandsOffAgain() {
+        XCTAssertEqual(
+            OuraLiveSource.reconnectStep(attempt: 4,
+                                         secondsSinceStandingConnect: OuraLiveSource.standingConnectRetryFloor),
+            .standingConnect)
+        XCTAssertEqual(OuraLiveSource.reconnectStep(attempt: 12, secondsSinceStandingConnect: 600),
+                       .standingConnect)
+    }
+
+    /// The one case a timer is still right: a NEAR-INSTANT failure, which can only be observed with the app
+    /// awake (a suspended app receives no callbacks) and is the only shape that can hot-loop. A timer is
+    /// safe here precisely because the app is demonstrably awake.
+    func testOnlyANearInstantFailureIsRateLimitedByATimer() {
+        XCTAssertLessThanOrEqual(OuraLiveSource.standingConnectRetryFloor, 60)
+        guard case .standingConnectAfter(let delay) =
+                OuraLiveSource.reconnectStep(attempt: 5, secondsSinceStandingConnect: 0) else {
+            return XCTFail("an instantly-failing standing connect must be rate-limited")
+        }
+        XCTAssertEqual(delay, OuraLiveSource.standingConnectRetryFloor, accuracy: 0.001)
+        // The boundary is exclusive: at the threshold itself we are already re-issuing immediately.
+        XCTAssertEqual(
+            OuraLiveSource.reconnectStep(attempt: 5,
+                                         secondsSinceStandingConnect: OuraLiveSource.standingConnectFastFailureS),
+            .standingConnect)
+    }
+
+    /// The timer path must stay unreachable from suspension: every delay it can ever produce is bounded by
+    /// the floor, and it is only entered below the fast-failure threshold. Together those mean the app can
+    /// never be suspended while holding only a pending timer for longer than a foreground blip.
+    func testTheTimerPathIsBoundedAndNarrow() {
+        XCTAssertLessThan(OuraLiveSource.standingConnectFastFailureS, OuraLiveSource.standingConnectRetryFloor)
+        for since in stride(from: 0.0, to: OuraLiveSource.standingConnectFastFailureS, by: 0.25) {
+            guard case .standingConnectAfter(let delay) =
+                    OuraLiveSource.reconnectStep(attempt: 4, secondsSinceStandingConnect: since) else {
+                return XCTFail("below the threshold the policy must rate-limit")
+            }
+            XCTAssertGreaterThan(delay, 0)
+            XCTAssertLessThanOrEqual(delay, OuraLiveSource.standingConnectRetryFloor)
+        }
+    }
+
+    /// Sanity on the timed half: still the capped-exponential BLEManager/Android curve, so a ring genuinely
+    /// out of range never hammers BLE if the hand-off threshold is ever raised.
+    func testTimedBackoffIsStillCappedExponential() {
+        for (attempt, expected) in [(1, 3.0), (2, 6.0), (3, 12.0), (5, 48.0), (6, 60.0), (99, 60.0)] {
+            // Read the curve directly by pretending the hand-off threshold is higher than the attempt.
+            guard attempt < OuraLiveSource.standingConnectAfterAttempts else { continue }
+            XCTAssertEqual(OuraLiveSource.reconnectStep(attempt: attempt, secondsSinceStandingConnect: nil),
+                           .timedRetry(delay: expected), "attempt \(attempt)")
+        }
+    }
+}


### PR DESCRIPTION
## The defect

After a drop, the Oura reconnect used a `DispatchQueue.main.asyncAfter` backoff throughout. That timer
does not run in a suspended app — the deadline passes and the block fires on resume.

Measured 2026-08-10: the link dropped at 11:16:38, attempt 3 was scheduled for ~11:17:06, and actually ran
at **11:29:27 — 12m33s late**, with zero log lines in between. The ring was down for **12m51s of a 27m
window (47%)** and the wearer noticed.

The damage is not the late timer. It is that after `didFailToConnect` the app held **nothing** outstanding,
so there was no way to notice the ring at all.

## The fix

After `standingConnectAfterAttempts` (3) consecutive failures, stop scheduling timed retries and hand the
reconnect to CoreBluetooth as a **standing `central.connect`** — no timeout, stays outstanding
indefinitely, and iOS wakes the app when the ring advertises again, including from suspension. The first
attempts keep the short 3s/6s timed backoff, because the app is demonstrably awake there and a quick retry
genuinely fixes a transient blip.

No new outbound command: `central.connect` is the same call `connect(_:)` already makes.

## What the first overnight run changed — the interesting half

Ran overnight 2026-08-11/12 on build `91812d93`. **It engaged exactly as designed** — three consecutive
failures, then `Oura: leaving a STANDING connect outstanding` at 01:27:52 — **and revealed a hole in
itself.**

```
[01:26:16] Oura: disconnected - The connection has timed out unexpectedly.
[01:26:19] Oura: connecting to <device>
[01:27:41] Oura: WARNING failed to connect - Failed to encrypt the connection...
[01:27:47] Oura: connecting to <device>
[01:27:52] Oura: WARNING failed to connect - Failed to encrypt the connection...
[01:27:52] Oura: leaving a STANDING connect outstanding for <device>      <- engaged correctly
[01:27:59] Oura: WARNING failed to connect - Failed to encrypt the connection...
[01:27:59] Oura: standing connect failed early - re-issuing in 23s (attempt 4)   <- THE HOLE
                                   ... 5 h 38 m of nothing ...
[07:06:07] Oura: leaving a STANDING connect outstanding for <device>
[07:06:08] Oura: connected - discovering services
```

CoreBluetooth rejected the standing connect within 7 s with `Failed to encrypt the connection` — which is
what this ring produces on **every** reconnect (1–2 failures, then success). The `.standingConnectAfter`
branch then nil'd `standingConnectAt` and armed a 23 s dispatch timer. The app suspended before it fired,
so it entered the night holding **nothing outstanding**: the exact defect this fix exists to remove,
reintroduced by its own backoff.

So the rate-limit floor now applies only to a **near-instant** failure (`standingConnectFastFailureS`,
2 s). Anything slower re-issues immediately, so a suspension can never catch us holding only a timer:

* the floor only ever existed to avoid hammering **while the app is awake**. A suspended app has no loop
  to break — no callbacks are delivered — so paying it on a dispatch timer traded the one thing that
  survives suspension for protection against a problem that cannot occur there;
* the re-issue rate is then set by how long CoreBluetooth itself takes to fail (**7–11 s** on this
  hardware), not by us;
* a genuinely instant failure still takes the timer, and a timer is right there **precisely because** such
  a failure can only be observed with the app awake.

## What this does NOT fix, stated plainly

The night's `connecting to` → `connected` took **5 h 40 m**, reproducing the 08-06 baseline (26m37s and
5h27m). When this ring goes unreachable overnight it stays unreachable for hours, and **no client-side
change reaches that**. This fix turns "nothing outstanding" into "outstanding and waiting"; it cannot make
the ring connectable.

Worth knowing for triage: banked recovery is unaffected — HR-minute fill for that night was **98.8 %**
despite 5 h 40 m offline. The overnight connection problem costs **live** data only.

## Scope

Apple-only **by argument, not omission**: Android's reconnect runs inside the `WhoopConnectionService`
foreground service, so its timer does fire — it is not suspended the way iOS suspends. `autoConnect = true`
would be the direct analogue if that ever stops holding. No analytics, no stored data, no migration, no
new user-facing strings.

## Verification

The policy is a pure `static func reconnectStep(attempt:secondsSinceStandingConnect:)` so it is
unit-testable with no CoreBluetooth, no radio and no ring (`OuraLiveSource` owns a `CBCentralManager` and
cannot be built in a test). **11 tests**, including:

* `testASlowFailureIsReIssuedImmediatelySoSuspensionCannotStrandUs` — the named regression test for the
  5 h 38 m overnight;
* `testTheTimerPathIsBoundedAndNarrow` — every delay the timer path can produce is bounded by the floor
  and only reachable below the fast-failure threshold.

`StrandTests` **1110/0** (1 skipped). `Strand` macOS built and `NOOPiOS` iOS built locally — **no default
CI compiles either**.

⚠️ **Hardware status, honestly:** the standing hand-off has now run overnight **once, correctly**. The
immediate-re-issue change in this commit has **not** yet run on hardware — it needs an overnight with a
drop, exported before the app restarts. Happy to hold the merge for that if preferred.