### PR TITLE
diag(sleep): flag a computed day with a sleep total but no matched session (#674/#1244)

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -233,6 +233,17 @@ final class IntelligenceEngine: ObservableObject {
             + "grav=\(gravCount) steps=\(stepCount) provided=\(providedCount) window=\(windowHours)h"
     }
 
+    /// #674/#1244: the "sleep total with no matched session" divergence line. A COMPUTED day whose fresh
+    /// scoring pass matched ZERO detected sleep sessions yet still carries a non-nil totalSleepMin — the
+    /// value comes from a folded edited/hand-logged block (sleepEditedDaily) on a day the detector staged
+    /// nothing (often a day absorbed into a neighbour's coupled window, so it never got its own pass). That
+    /// total leaks to Today/Coupled while the Sleep tab (session-backed) shows nothing. `editFold` = how
+    /// many edited/manual rows folded a total onto this session-less day, so the next capture proves whether
+    /// it's an orphaned edit. Counts only, no PII. Pure; byte-identical to the Kotlin `sleepDivergenceLogLine`.
+    nonisolated static func sleepDivergenceLogLine(day: String, totalSleepMin: Int, editFold: Int) -> String {
+        return "sleep divergence day=\(day) totalSleepMin=\(totalSleepMin) matched=0 editFold=\(editFold)"
+    }
+
     /// #1248: the device ids the banked-sleep heal (#899) must sweep — the computed-scores id AND every
     /// registered device id. A live source (an Oura ring) banks its OWN hypnogram under its OWN device id,
     /// so a computedId-only heal never sees (or collapses) those rows, and they are re-read as
@@ -1186,6 +1197,16 @@ final class IntelligenceEngine: ObservableObject {
                             + "stages=\(Self.sleepStagesLogToken(deep: daily.deepMin, rem: daily.remMin, light: daily.lightMin)) "
                             + "eff=\(effLog) "
                             + "matched=\(night.cachedSleep.count) source=\(source.logToken)", nil)
+            // #674/#1244: flag a COMPUTED day carrying a sleep total with NO matched session — the folded
+            // edited/hand-logged block on a day the detector staged nothing (see sleepDivergenceLogLine).
+            // Scoped to computed days: an imported-total-only day legitimately has a total without our
+            // sessions, so it is NOT a divergence.
+            let dayImported = importedWhoopDays.contains(daily.day) || appleHealthDays.contains(daily.day)
+            if !dayImported, let tsm = daily.totalSleepMin, night.cachedSleep.isEmpty {
+                diagnosticSink?(Self.sleepDivergenceLogLine(day: daily.day,
+                                                            totalSleepMin: Int(tsm.rounded()),
+                                                            editFold: dayEditedRows.count), nil)
+            }
             // #195: one always-on line per scored night with the computed HRV value + the window it used,
             // so an "HRV reads high / deep-sleep window not changing" report is self-diagnosing straight
             // from the strap log — the whole-night vs deep-sleep value, and `avgHrv=nil window=deep` when a

--- a/StrandTests/IntelligenceSleepDivergenceTests.swift
+++ b/StrandTests/IntelligenceSleepDivergenceTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import Strand
+
+/// Pins the #674/#1244 divergence diagnostic. A COMPUTED day can carry a sleep total with zero matched
+/// sessions — an edited/hand-logged block folded onto a day the detector staged nothing (often a day
+/// absorbed into a neighbour's coupled window, so it never got its own pass). That total leaks to
+/// Today/Coupled while the Sleep tab (session-backed) shows nothing. The line names the fold (`editFold=`)
+/// so the next capture proves whether it's an orphaned edit. Pure formatter the loop calls; tested directly
+/// (no store). Mirrors the Android `sleepDivergenceLogLine` so the two platforms log a byte-identical line.
+@MainActor
+final class IntelligenceSleepDivergenceTests: XCTestCase {
+
+    private typealias IE = IntelligenceEngine
+
+    func testDivergenceNamesTheEditFold() {
+        // The #1244 shape: 558 min on the rollup, no matched session, folded from one edited row.
+        let line = IE.sleepDivergenceLogLine(day: "2026-08-11", totalSleepMin: 558, editFold: 1)
+        XCTAssertEqual(line, "sleep divergence day=2026-08-11 totalSleepMin=558 matched=0 editFold=1")
+    }
+
+    func testDivergenceWithNoEditIsAZeroFold() {
+        let line = IE.sleepDivergenceLogLine(day: "2026-08-07", totalSleepMin: 0, editFold: 0)
+        XCTAssertEqual(line, "sleep divergence day=2026-08-07 totalSleepMin=0 matched=0 editFold=0")
+    }
+
+    func testLineCarriesNoEmDash() {
+        let line = IE.sleepDivergenceLogLine(day: "2026-08-11", totalSleepMin: 1, editFold: 0)
+        XCTAssertFalse(line.contains("—"))
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -988,6 +988,14 @@ object IntelligenceEngine {
                     "matched=${res.sleepSessions.size} " +
                     "source=${daySourceToken(daily.day, importedWhoopDays, appleHealthDays)}",
             )
+            // #674/#1244: flag a COMPUTED day carrying a sleep total with NO matched session — the folded
+            // edited/hand-logged block on a day the detector staged nothing (see sleepDivergenceLogLine).
+            // Scoped to computed days: an imported-total-only day legitimately has a total without our
+            // sessions, so it is NOT a divergence.
+            val imported = daily.day in importedWhoopDays || daily.day in appleHealthDays
+            if (!imported && daily.totalSleepMin != null && res.sleepSessions.isEmpty()) {
+                diag(sleepDivergenceLogLine(daily.day, Math.round(daily.totalSleepMin).toInt(), dayEditedRows.size))
+            }
             // #195: one always-on line per scored night with the computed HRV value + the window it used,
             // so an "HRV reads high / deep-sleep window not changing" report is self-diagnosing straight
             // from the strap log — the whole-night vs deep-sleep value, and `avgHrv=nil window=deep` when a
@@ -2007,6 +2015,18 @@ object IntelligenceEngine {
         return "sleep-detect day=$day NO-NIGHT hr=$hrCount rr=$rrCount resp=$respCount " +
             "grav=$gravCount steps=$stepCount provided=$providedCount window=${windowHours}h"
     }
+
+    /**
+     * #674/#1244: the "sleep total with no matched session" divergence line. A COMPUTED day whose fresh
+     * scoring pass matched ZERO detected sleep sessions yet still carries a non-null totalSleepMin — the
+     * value comes from a folded edited/hand-logged block (sleepEditedDaily) on a day the detector staged
+     * nothing (often a day absorbed into a neighbour's coupled window, so it never got its own pass). That
+     * total leaks to Today/Coupled while the Sleep tab (session-backed) shows nothing. [editFold] = how
+     * many edited/manual rows folded a total onto this session-less day, so the next capture proves whether
+     * it's an orphaned edit. Counts only, no PII. Pure; byte-identical to the Swift `sleepDivergenceLogLine`.
+     */
+    internal fun sleepDivergenceLogLine(day: String, totalSleepMin: Int, editFold: Int): String =
+        "sleep divergence day=$day totalSleepMin=$totalSleepMin matched=0 editFold=$editFold"
 
     /**
      * #1248: the device ids the banked-sleep heal (#899) must sweep — the computed-scores id AND every

--- a/android/app/src/test/java/com/noop/analytics/IntelligenceSleepDivergenceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/IntelligenceSleepDivergenceTest.kt
@@ -1,0 +1,35 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Pins the #674/#1244 divergence diagnostic. A COMPUTED day can carry a sleep total with zero matched
+ * sessions — an edited/hand-logged block folded onto a day the detector staged nothing (often a day
+ * absorbed into a neighbour's coupled window, so it never got its own pass). That total leaks to
+ * Today/Coupled while the Sleep tab (session-backed) shows nothing. The line names the fold (`editFold=`)
+ * so the next capture proves whether it's an orphaned edit. Pure formatter the loop calls; tested directly,
+ * byte-identical to the Swift `IntelligenceSleepDivergenceTests`.
+ */
+class IntelligenceSleepDivergenceTest {
+
+    @Test
+    fun divergenceNamesTheEditFold() {
+        // The #1244 shape: 558 min on the rollup, no matched session, folded from one edited row.
+        val line = IntelligenceEngine.sleepDivergenceLogLine(day = "2026-08-11", totalSleepMin = 558, editFold = 1)
+        assertEquals("sleep divergence day=2026-08-11 totalSleepMin=558 matched=0 editFold=1", line)
+    }
+
+    @Test
+    fun divergenceWithNoEditIsAZeroFold() {
+        val line = IntelligenceEngine.sleepDivergenceLogLine(day = "2026-08-07", totalSleepMin = 0, editFold = 0)
+        assertEquals("sleep divergence day=2026-08-07 totalSleepMin=0 matched=0 editFold=0", line)
+    }
+
+    @Test
+    fun divergenceCarriesNoEmDash() {
+        val line = IntelligenceEngine.sleepDivergenceLogLine(day = "2026-08-11", totalSleepMin = 1, editFold = 0)
+        assertFalse(line.contains("—"))
+    }
+}


### PR DESCRIPTION
Instrument-first, log-only. Advances **#1244** (WHOOP 4.0 "no sleep last night") and the **#674** divergence, from the reporter's export.

### What the export showed
The 08-11 night **stages fine** — `sleep day=2026-08-11 totalSleepMin=558 stages=85+76+398 eff=0.96` — but `matched=0`. Decisively, 08-11 has **no `sleep-motion` line** and the maintainer's **`NO-NIGHT` diag never fired**, so the day **got no scoring pass of its own** — it was absorbed into a neighbour's 48–54 h coupled window. `AnalyticsEngine` correctly nils `totalSleepMin` when no sessions match, so the 558 is a **folded edited/hand-logged block** (`sleepEditedDaily`) on a session-less day. That total leaks to Today/Coupled while the Sleep tab (session-backed) shows nothing — the #674 symptom.

### This PR
Adds one counts-only line when a **computed** day carries a total with no matched session:

```
sleep divergence day=2026-08-11 totalSleepMin=558 matched=0 editFold=1
```

- **Scoped to computed days** — an imported-total-only day legitimately has a total without our sessions, so it's excluded (not a divergence).
- `editFold` = how many edited/manual rows folded a total onto the session-less day, so the next capture proves whether it's an **orphaned edit** vs a genuine hand-log — the missing bit needed to pick the real fix (coupled-window bucketing vs edit cleanup).

### Not in scope (deliberately)
The **fix** (coupled-window/day-bucketing + the `whoop4↔whoop5` family flip from #1193's late-model timing) needs a real 4.0 to validate and the reporter's session rows — this diagnostic is the safe step that makes the next export self-explaining. I dropped a family-resolve line I'd prototyped: the flip is already visible via the existing `dayOwner readId` + `sleep-motion family` lines, and mirroring it into Swift's deferred-diagnostic per-day loop risked an actor-isolation break for zero new signal.

### Verification
- Pure formatter `sleepDivergenceLogLine`, **byte-identical Swift+Kotlin**, unit-tested each side (`IntelligenceSleepDivergenceTest(s)`).
- Kotlin: `testFullDebugUnitTest` + `compileFullDebugKotlin` green locally.
- App-target Swift (`Strand/Data/IntelligenceEngine.swift` + the StrandTests case) has no default CI — validating via the on-demand **app-build gate** (Test Strand runs the case).