### PR TITLE
Sleep: brand-matched colour ramps for the stepped hypnogram styles

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Hypnogram.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Hypnogram.swift
@@ -60,6 +60,10 @@ public struct Hypnogram: View {
     /// look) instead of the slim ribbon band. The stage → lane mapping, risers and axis are identical;
     /// only the band height changes. Mirrors the Android `FilledHypnogram(filled:)`.
     public var filled: Bool
+    /// When true, the stage bands use the BRAND ramp for the stepped chart (Garmin's for Filled, Oura's
+    /// for Ribbon) instead of the NOOP sleep tokens — so the Sleep-tab stepped chart reads like the app it's
+    /// modelled on. Off for every other caller (e.g. the Xiaomi decode view), which keeps `sleepStageColor`.
+    public var brandPalette: Bool
 
     public init(
         intervals: [SleepInterval],
@@ -70,7 +74,8 @@ public struct Hypnogram: View {
         showsTimeAxis: Bool = false,
         smoothingSeconds: TimeInterval = 300,
         highlightedStage: SleepStage? = nil,
-        filled: Bool = false
+        filled: Bool = false,
+        brandPalette: Bool = false
     ) {
         let sorted = intervals.sorted { $0.start < $1.start }
         self.intervals = smoothingSeconds > 0
@@ -83,6 +88,7 @@ public struct Hypnogram: View {
         self.showsTimeAxis = showsTimeAxis
         self.highlightedStage = highlightedStage
         self.filled = filled
+        self.brandPalette = brandPalette
     }
 
     // MARK: Display smoothing (WHOOP-style)
@@ -202,6 +208,13 @@ public struct Hypnogram: View {
     // 4 stage rows; awake = rank 0 (top), deep = rank 3 (bottom).
     private let rowCount = 4
 
+    /// The band/lane colour for a stage: the brand ramp (Garmin filled / Oura ribbon) when opted in, else
+    /// the NOOP sleep tokens.
+    private func stageColor(_ stage: SleepStage) -> Color {
+        brandPalette ? StrandPalette.sleepStageColorBrand(stage, filled: filled)
+                     : StrandPalette.sleepStageColor(stage)
+    }
+
     public var body: some View {
         HStack(alignment: .top, spacing: 12) {
             if showsStageAxis { axis }
@@ -226,7 +239,7 @@ public struct Hypnogram: View {
                                 // The highlighted stage's lane brightens (WHOOP's selected-stage wash).
                                 let lane = highlightedStage == stage ? 0.16 : 0.07
                                 RoundedRectangle(cornerRadius: 7, style: .continuous)
-                                    .fill(StrandPalette.sleepStageColor(stage).opacity(lane))
+                                    .fill(stageColor(stage).opacity(lane))
                                     .frame(width: geo.size.width, height: rowStep * 0.74)
                                     .position(x: geo.size.width / 2, y: rowY(rank, in: geo.size.height))
                             }
@@ -255,7 +268,7 @@ public struct Hypnogram: View {
                                     ? CGRect(x: band.minX, y: band.midY, width: band.width,
                                              height: max(0, geo.size.height - band.midY))
                                     : band
-                                let color = StrandPalette.sleepStageColor(interval.stage)
+                                let color = stageColor(interval.stage)
                                 let hoverDimmed = hoverIndex != nil && hoverIndex != idx
                                 let stageDimmed = highlightedStage != nil && interval.stage != highlightedStage
                                 // WHOOP hypnogram: squared segments — the night reads as one continuous
@@ -278,7 +291,7 @@ public struct Hypnogram: View {
                         if showsHover, let idx = hoverIndex, idx < intervals.count {
                             let interval = intervals[idx]
                             let rect = bandRect(for: interval, in: geo.size)
-                            let color = StrandPalette.sleepStageColor(interval.stage)
+                            let color = stageColor(interval.stage)
                             // vertical crosshair across the full height at band centre
                             CrosshairRule(x: rect.midX, height: geo.size.height)
                             // ring around the hovered band

--- a/Packages/StrandDesign/Sources/StrandDesign/Palette.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Palette.swift
@@ -376,6 +376,33 @@ public enum StrandPalette {
         }
     }
 
+    // Brand sleep ramps for the two stepped-hypnogram styles, so the chart reads like the app it's modelled
+    // on. Ribbon = Oura's ramp (cream awake + blues, sampled from the ring's app); Filled = Garmin's
+    // (blue light/deep + magenta REM). Opt-in only (Sleep-tab stepped chart) — every other Hypnogram caller
+    // keeps `sleepStageColor`. Flat (theme-independent): both source apps are dark-tuned. (#sleep-chart-style)
+    static let oSleepAwake = Color(light: "#EAE3D3", dark: "#EAE3D3")
+    static let oSleepREM   = Color(light: "#90D0F0", dark: "#90D0F0")
+    static let oSleepLight = Color(light: "#40B0E0", dark: "#40B0E0")
+    static let oSleepDeep  = Color(light: "#206080", dark: "#206080")
+    static let gSleepAwake = Color(light: "#F26FE8", dark: "#F26FE8")
+    static let gSleepREM   = Color(light: "#E22DD0", dark: "#E22DD0")
+    static let gSleepLight = Color(light: "#4AA6F2", dark: "#4AA6F2")
+    static let gSleepDeep  = Color(light: "#2472D8", dark: "#2472D8")
+
+    /// The brand sleep ramp for the stepped hypnogram: Garmin's for Filled, Oura's for Ribbon.
+    public static func sleepStageColorBrand(_ stage: SleepStage, filled: Bool) -> Color {
+        switch (filled, stage) {
+        case (true, .awake): return gSleepAwake
+        case (true, .light): return gSleepLight
+        case (true, .deep):  return gSleepDeep
+        case (true, .rem):   return gSleepREM
+        case (false, .awake): return oSleepAwake
+        case (false, .light): return oSleepLight
+        case (false, .deep):  return oSleepDeep
+        case (false, .rem):   return oSleepREM
+        }
+    }
+
     // MARK: - Linear gradient stop interpolation
 
     /// Interpolate a set of gradient stops at a normalized position 0...1.

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -829,7 +829,8 @@ struct SleepView: View {
                     showsHover: true,
                     nightStart: night.onsetDate,
                     showsTimeAxis: true,
-                    filled: filled
+                    filled: filled,
+                    brandPalette: true   // Filled → Garmin ramp, Ribbon → Oura ramp
                 )
             },
             // The stepped chart carries no built-in legend (the rows ARE the legend in Classic), so surface

--- a/Strand/Screens/StagesCard.swift
+++ b/Strand/Screens/StagesCard.swift
@@ -178,7 +178,8 @@ struct StageDetailView: View {
                     showsHover: true,
                     nightStart: nil,
                     showsTimeAxis: false,
-                    filled: filled
+                    filled: filled,
+                    brandPalette: true   // Filled → Garmin ramp, Ribbon → Oura ramp
                 )
             },
             footer: { stageBreakdownRows(s) }

--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -279,13 +279,13 @@ internal fun FilledHypnogram(
                 val segW = (x1 - x0).coerceAtLeast(1.5f).coerceAtMost(w - x0)
                 if (filled) {
                     drawRect(
-                        color = stageColorFor(iv.stage),
+                        color = stageColorForBrand(iv.stage, filled),
                         topLeft = Offset(x0, y),
                         size = Size(segW, (h - y).coerceAtLeast(0f)),
                     )
                 } else {
                     drawRect(
-                        color = stageColorFor(iv.stage),
+                        color = stageColorForBrand(iv.stage, filled),
                         topLeft = Offset(x0, y - ribbonThickness / 2f),
                         size = Size(segW, ribbonThickness),
                     )
@@ -447,4 +447,25 @@ private fun stageColorFor(name: String): Color = when (canonicalStage(name)) {
     "light" -> Palette.sleepLight
     "awake" -> Palette.sleepAwake
     else -> Palette.sleepLight
+}
+
+// Brand sleep ramps for the stepped [FilledHypnogram]: Garmin's for Filled (blue light/deep + magenta REM),
+// Oura's for Ribbon (cream awake + blues, sampled from the ring's app), so the chart reads like the app it's
+// modelled on. Byte-identical hexes to the Swift `StrandPalette.sleepStageColorBrand`. The classic hero
+// strip ([HypnogramWithAxis]) keeps the NOOP tokens via [stageColorFor]. (#sleep-chart-style)
+private val ouraSleepAwake = Color(0xFFEAE3D3)
+private val ouraSleepREM = Color(0xFF90D0F0)
+private val ouraSleepLight = Color(0xFF40B0E0)
+private val ouraSleepDeep = Color(0xFF206080)
+private val garminSleepAwake = Color(0xFFF26FE8)
+private val garminSleepREM = Color(0xFFE22DD0)
+private val garminSleepLight = Color(0xFF4AA6F2)
+private val garminSleepDeep = Color(0xFF2472D8)
+
+private fun stageColorForBrand(name: String, filled: Boolean): Color = when (canonicalStage(name)) {
+    "deep" -> if (filled) garminSleepDeep else ouraSleepDeep
+    "rem" -> if (filled) garminSleepREM else ouraSleepREM
+    "light" -> if (filled) garminSleepLight else ouraSleepLight
+    "awake" -> if (filled) garminSleepAwake else ouraSleepAwake
+    else -> if (filled) garminSleepLight else ouraSleepLight
 }


### PR DESCRIPTION
The **Ribbon** and **Filled** sleep-chart styles used NOOP's periwinkle/orchid sleep tokens, so they looked nothing like the apps they echo. This gives each stepped style its own signature ramp so the chart reads native:

| Style | Ramp | Awake | REM | Light | Deep |
|---|---|---|---|---|---|
| **Ribbon** | Oura (sampled) | `#EAE3D3` | `#90D0F0` | `#40B0E0` | `#206080` |
| **Filled** | Garmin (estimated) | `#F26FE8` | `#E22DD0` | `#4AA6F2` | `#2472D8` |

- **Oura hexes are sampled** from the ring's own sleep chart (accurate). **Garmin hexes are estimated** from a screenshot I couldn't sample to disk — easy to tune once eyeballed on-device.
- Keyed on the existing `filled` flag, **gated behind an opt-in** (`brandPalette` on the shared `Hypnogram`; a dedicated `stageColorForBrand` on Android) so **only** the Sleep-tab stepped chart changes — the **classic timeline rows**, the **breakdown-row legend**, and the **Xiaomi decode view** all keep the NOOP tokens.
- Flat (theme-independent) — both source apps are dark-tuned; a light-mode pass can follow if needed (the cream Awake is the one to watch on a light background).
- Colour hexes **byte-identical Swift+Kotlin**. Display-only, no data change.

### Verification
- Android `compileFullDebugKotlin` green locally.
- iOS: `Palette`/`Hypnogram` are package layer (`swift-packages`); `SleepView`/`StagesCard` are app-target (no default CI) — validating via the on-demand app-build gate. **On-device colour check still owed** (esp. the estimated Garmin ramp).