### PR TITLE
Sleep: split Fill/Garmin Fill styles + colour-coded legend

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Appearance.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Appearance.swift
@@ -33,23 +33,42 @@ public enum ChartStyle: String, CaseIterable, Identifiable, Sendable {
 /// rawValues and the same `sleep.chart.style` key, so a device reads its own choice consistently.
 /// Device-local (NOT in the `.noopbak` whitelist), like the Android pref.
 public enum SleepChartStyle: String, CaseIterable, Identifiable, Sendable {
-    case classic   // per-stage-rows timeline (the default, unchanged)
-    case filled    // single stepped hypnogram, each stage filled from its lane to the baseline
-    case ribbon    // the same stepped chart drawn as a slim band at each stage level
+    case classic       // per-stage-rows timeline (the default, unchanged)
+    case filled        // stepped hypnogram filled to the baseline, NOOP sleep colours
+    case garminFilled  // the same filled chart in Garmin's blue/magenta ramp
+    case ribbon        // slim band at each stage level, Oura's cream/blue ramp
 
     public var id: String { rawValue }
     public static let storageKey = "sleep.chart.style"
 
     public var label: String {
         switch self {
-        case .classic: return String(localized: "Classic", bundle: .module)
-        case .filled:  return String(localized: "Filled", bundle: .module)
-        case .ribbon:  return String(localized: "Ribbon", bundle: .module)
+        case .classic:      return String(localized: "Classic", bundle: .module)
+        case .filled:       return String(localized: "Fill", bundle: .module)
+        case .garminFilled: return String(localized: "Garmin Fill", bundle: .module)
+        case .ribbon:       return String(localized: "Ribbon", bundle: .module)
+        }
+    }
+
+    /// Whether the stepped chart fills each stage to the baseline (Fill / Garmin Fill) or draws a slim
+    /// ribbon band (Ribbon). Classic doesn't use the stepped chart.
+    public var isFilled: Bool { self == .filled || self == .garminFilled }
+
+    /// The stage-colour ramp this style draws with.
+    public var stagePalette: SleepStagePalette {
+        switch self {
+        case .classic, .filled: return .noop
+        case .garminFilled:     return .garmin
+        case .ribbon:           return .oura
         }
     }
 
     public static func resolve(_ raw: String) -> SleepChartStyle { SleepChartStyle(rawValue: raw) ?? .classic }
 }
+
+/// Which stage-colour ramp a sleep chart draws with: NOOP's own tokens, Oura's ramp (Ribbon), or Garmin's
+/// (Garmin Fill). Twin of the Kotlin `SleepStagePalette`.
+public enum SleepStagePalette: String, Sendable { case noop, oura, garmin }
 
 /// Applies the chart style: sets the global `StrandPalette.chartStyle` (read by the data-ramp
 /// accessors) AND keys the content on the raw value so a flip re-renders the visible charts. The

--- a/Packages/StrandDesign/Sources/StrandDesign/Hypnogram.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Hypnogram.swift
@@ -60,10 +60,9 @@ public struct Hypnogram: View {
     /// look) instead of the slim ribbon band. The stage → lane mapping, risers and axis are identical;
     /// only the band height changes. Mirrors the Android `FilledHypnogram(filled:)`.
     public var filled: Bool
-    /// When true, the stage bands use the BRAND ramp for the stepped chart (Garmin's for Filled, Oura's
-    /// for Ribbon) instead of the NOOP sleep tokens — so the Sleep-tab stepped chart reads like the app it's
-    /// modelled on. Off for every other caller (e.g. the Xiaomi decode view), which keeps `sleepStageColor`.
-    public var brandPalette: Bool
+    /// The stage-colour ramp: NOOP tokens (default, and every non-sleep caller), Oura's (Ribbon), or
+    /// Garmin's (Garmin Fill). Only the Sleep-tab stepped chart passes a non-default ramp.
+    public var stagePalette: SleepStagePalette
 
     public init(
         intervals: [SleepInterval],
@@ -75,7 +74,7 @@ public struct Hypnogram: View {
         smoothingSeconds: TimeInterval = 300,
         highlightedStage: SleepStage? = nil,
         filled: Bool = false,
-        brandPalette: Bool = false
+        stagePalette: SleepStagePalette = .noop
     ) {
         let sorted = intervals.sorted { $0.start < $1.start }
         self.intervals = smoothingSeconds > 0
@@ -88,7 +87,7 @@ public struct Hypnogram: View {
         self.showsTimeAxis = showsTimeAxis
         self.highlightedStage = highlightedStage
         self.filled = filled
-        self.brandPalette = brandPalette
+        self.stagePalette = stagePalette
     }
 
     // MARK: Display smoothing (WHOOP-style)
@@ -211,8 +210,7 @@ public struct Hypnogram: View {
     /// The band/lane colour for a stage: the brand ramp (Garmin filled / Oura ribbon) when opted in, else
     /// the NOOP sleep tokens.
     private func stageColor(_ stage: SleepStage) -> Color {
-        brandPalette ? StrandPalette.sleepStageColorBrand(stage, filled: filled)
-                     : StrandPalette.sleepStageColor(stage)
+        StrandPalette.sleepStageColor(stage, palette: stagePalette)
     }
 
     public var body: some View {
@@ -420,6 +418,35 @@ public struct Hypnogram: View {
         }
         .stroke(StrandPalette.textTertiary.opacity(highlightedStage == nil ? 0.35 : 0.15),
                 style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round))
+    }
+}
+
+/// A compact colour-coded key for a stepped hypnogram: one dot + label per stage in the chart's ramp, so a
+/// reader can decode the bands — which is what makes the Garmin ramp's two pinks (Awake vs REM) legible.
+/// (#sleep-chart-style)
+public struct SleepStageLegend: View {
+    public var palette: SleepStagePalette
+    public init(palette: SleepStagePalette) { self.palette = palette }
+
+    // Awake · REM · Light · Deep — the order Oura/Garmin list them.
+    private let order: [SleepStage] = [.awake, .rem, .light, .deep]
+
+    public var body: some View {
+        HStack(spacing: 14) {
+            ForEach(order, id: \.rawValue) { stage in
+                HStack(spacing: 5) {
+                    Circle()
+                        .fill(StrandPalette.sleepStageColor(stage, palette: palette))
+                        .frame(width: 8, height: 8)
+                    Text(stage.label)
+                        .font(StrandFont.caption)
+                        .foregroundStyle(StrandPalette.textSecondary)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        // Decorative colour key — the breakdown rows below carry the same stages for VoiceOver.
+        .accessibilityHidden(true)
     }
 }
 

--- a/Packages/StrandDesign/Sources/StrandDesign/Palette.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Palette.swift
@@ -425,17 +425,24 @@ public enum StrandPalette {
         static let garmin = [garminAwake, garminREM, garminLight, garminDeep]
     }
 
-    /// The brand sleep ramp for the stepped hypnogram: Garmin's for Filled, Oura's for Ribbon.
-    public static func sleepStageColorBrand(_ stage: SleepStage, filled: Bool) -> Color {
-        switch (filled, stage) {
-        case (true, .awake): return gSleepAwake
-        case (true, .light): return gSleepLight
-        case (true, .deep):  return gSleepDeep
-        case (true, .rem):   return gSleepREM
-        case (false, .awake): return oSleepAwake
-        case (false, .light): return oSleepLight
-        case (false, .deep):  return oSleepDeep
-        case (false, .rem):   return oSleepREM
+    /// A sleep-stage colour in a chosen ramp: NOOP's own tokens, Oura's (Ribbon), or Garmin's (Garmin Fill).
+    public static func sleepStageColor(_ stage: SleepStage, palette: SleepStagePalette) -> Color {
+        switch palette {
+        case .noop: return sleepStageColor(stage)
+        case .oura:
+            switch stage {
+            case .awake: return oSleepAwake
+            case .light: return oSleepLight
+            case .deep:  return oSleepDeep
+            case .rem:   return oSleepREM
+            }
+        case .garmin:
+            switch stage {
+            case .awake: return gSleepAwake
+            case .light: return gSleepLight
+            case .deep:  return gSleepDeep
+            case .rem:   return gSleepREM
+            }
         }
     }
 

--- a/Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings
+++ b/Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings
@@ -3776,6 +3776,122 @@
           }
         }
       }
+    },
+    "Fill": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fill"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gefüllt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relleno"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rempli"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pieno"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preenchido"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заливка"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "填充"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "填滿"
+          }
+        }
+      }
+    },
+    "Garmin Fill": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Garmin Fill"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Garmin-Füllung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relleno Garmin"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remplissage Garmin"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riempimento Garmin"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preenchimento Garmin"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заливка Garmin"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Garmin 填充"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Garmin 填滿"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Packages/StrandDesign/Tests/StrandDesignTests/SleepChartStyleTests.swift
+++ b/Packages/StrandDesign/Tests/StrandDesignTests/SleepChartStyleTests.swift
@@ -11,7 +11,14 @@ final class SleepChartStyleTests: XCTestCase {
         XCTAssertEqual(SleepChartStyle.filled.rawValue, "filled")
         XCTAssertEqual(SleepChartStyle.ribbon.rawValue, "ribbon")
         // Exactly these three, in this order (parity with the Kotlin enum entries).
-        XCTAssertEqual(SleepChartStyle.allCases.map(\.rawValue), ["classic", "filled", "ribbon"])
+        XCTAssertEqual(SleepChartStyle.garminFilled.rawValue, "garminFilled")
+        XCTAssertEqual(SleepChartStyle.allCases.map(\.rawValue), ["classic", "filled", "garminFilled", "ribbon"])
+        // Style → ramp mapping: Fill/Classic keep NOOP, Garmin Fill → Garmin, Ribbon → Oura.
+        XCTAssertEqual(SleepChartStyle.filled.stagePalette, .noop)
+        XCTAssertEqual(SleepChartStyle.garminFilled.stagePalette, .garmin)
+        XCTAssertEqual(SleepChartStyle.ribbon.stagePalette, .oura)
+        XCTAssertTrue(SleepChartStyle.filled.isFilled && SleepChartStyle.garminFilled.isFilled)
+        XCTAssertFalse(SleepChartStyle.ribbon.isFilled || SleepChartStyle.classic.isFilled)
     }
 
     func testStorageKeyMatchesTheAndroidPrefKey() {

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -733,12 +733,13 @@ struct SleepView: View {
                 // (ryanAtriumAi #988) — hatched track = the whole night, solid segments = when that stage
                 // occurred, tap a row to highlight it. Filled/Ribbon draw the WHOOP-style single stepped
                 // hypnogram (filled to the baseline, or a slim band) with the breakdown rows as the legend.
-                switch SleepChartStyle.resolve(sleepChartStyleRaw) {
+                let chartStyle = SleepChartStyle.resolve(sleepChartStyleRaw)
+                switch chartStyle {
                 case .classic:
                     stageTimelineCard(s, subtitle: subtitle, intervals: intervals, night: night)
-                case .filled, .ribbon:
+                case .filled, .garminFilled, .ribbon:
                     steppedHypnogramCard(s, subtitle: subtitle, intervals: intervals, night: night,
-                                         filled: SleepChartStyle.resolve(sleepChartStyleRaw) == .filled)
+                                         style: chartStyle)
                 }
             } else {
                 ChartCard(
@@ -814,7 +815,7 @@ struct SleepView: View {
     /// segments (the shared `intervals`). The stages/totals are identical to Classic — this only redraws.
     @ViewBuilder
     private func steppedHypnogramCard(_ s: Stages, subtitle: String, intervals: [SleepInterval],
-                                      night: Night, filled: Bool) -> some View {
+                                      night: Night, style: SleepChartStyle) -> some View {
         ChartCard(
             title: "Stage breakdown",
             subtitle: subtitle,
@@ -829,13 +830,18 @@ struct SleepView: View {
                     showsHover: true,
                     nightStart: night.onsetDate,
                     showsTimeAxis: true,
-                    filled: filled,
-                    brandPalette: true   // Filled → Garmin ramp, Ribbon → Oura ramp
+                    filled: style.isFilled,
+                    stagePalette: style.stagePalette
                 )
             },
-            // The stepped chart carries no built-in legend (the rows ARE the legend in Classic), so surface
-            // the per-stage breakdown below it — the same apportioned rows the Classic view uses.
-            footer: { stageBreakdownRows(s) }
+            // A colour-coded key in the chart's ramp so the bands are decodable (esp. the Garmin ramp's two
+            // pinks), then the per-stage breakdown rows below.
+            footer: {
+                VStack(alignment: .leading, spacing: NoopMetrics.space2) {
+                    SleepStageLegend(palette: style.stagePalette)
+                    stageBreakdownRows(s)
+                }
+            }
         )
     }
 

--- a/Strand/Screens/StagesCard.swift
+++ b/Strand/Screens/StagesCard.swift
@@ -82,12 +82,12 @@ struct StageDetailView: View {
                 // #sleep-chart-style: Classic keeps the per-stage timeline ROWS (ryanAtriumAi #988);
                 // Filled/Ribbon draw the WHOOP-style stepped hypnogram with the breakdown rows as the
                 // legend — switching with the Sleep tab and Android's StagesHostCard.
-                switch SleepChartStyle.resolve(sleepChartStyleRaw) {
+                let chartStyle = SleepChartStyle.resolve(sleepChartStyleRaw)
+                switch chartStyle {
                 case .classic:
                     stageTimelineCard(s, subtitle: subtitle, intervals: intervals, night: night)
-                case .filled, .ribbon:
-                    steppedHypnogramCard(s, subtitle: subtitle, intervals: intervals,
-                                         filled: SleepChartStyle.resolve(sleepChartStyleRaw) == .filled)
+                case .filled, .garminFilled, .ribbon:
+                    steppedHypnogramCard(s, subtitle: subtitle, intervals: intervals, style: chartStyle)
                 }
             } else {
                 ChartCard(
@@ -163,7 +163,7 @@ struct StageDetailView: View {
     /// here when the night has ≥2 real segments; the stages/totals are identical to Classic.
     @ViewBuilder
     private func steppedHypnogramCard(_ s: Stages, subtitle: String, intervals: [SleepInterval],
-                                      filled: Bool) -> some View {
+                                      style: SleepChartStyle) -> some View {
         ChartCard(
             title: "Stage breakdown",
             subtitle: subtitle,
@@ -178,11 +178,16 @@ struct StageDetailView: View {
                     showsHover: true,
                     nightStart: nil,
                     showsTimeAxis: false,
-                    filled: filled,
-                    brandPalette: true   // Filled → Garmin ramp, Ribbon → Oura ramp
+                    filled: style.isFilled,
+                    stagePalette: style.stagePalette
                 )
             },
-            footer: { stageBreakdownRows(s) }
+            footer: {
+                VStack(alignment: .leading, spacing: NoopMetrics.space2) {
+                    SleepStageLegend(palette: style.stagePalette)
+                    stageBreakdownRows(s)
+                }
+            }
         )
     }
 

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1239,7 +1239,9 @@ fun SettingsScreen(
                     label = {
                         when (it) {
                             SleepChartStyle.FILLED -> "Fill"
-                            SleepChartStyle.GARMIN_FILLED -> "Garmin Fill"
+                            // "Garmin" not "Garmin Fill": four equal-width segments ellipsis-truncate a long
+                            // label on a normal-width phone (iOS keeps "Garmin Fill" — it's a menu, not a pill).
+                            SleepChartStyle.GARMIN_FILLED -> "Garmin"
                             SleepChartStyle.RIBBON -> "Ribbon"
                             else -> "Classic"
                         }

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1233,11 +1233,13 @@ fun SettingsScreen(
             ) {
                 Text("Sleep chart", style = NoopType.body, color = Palette.textPrimary)
                 SegmentedPillControl(
-                    items = listOf(SleepChartStyle.CLASSIC, SleepChartStyle.FILLED, SleepChartStyle.RIBBON),
+                    items = listOf(SleepChartStyle.CLASSIC, SleepChartStyle.FILLED,
+                                   SleepChartStyle.GARMIN_FILLED, SleepChartStyle.RIBBON),
                     selection = sleepChartStyle,
                     label = {
                         when (it) {
-                            SleepChartStyle.FILLED -> "Filled"
+                            SleepChartStyle.FILLED -> "Fill"
+                            SleepChartStyle.GARMIN_FILLED -> "Garmin Fill"
                             SleepChartStyle.RIBBON -> "Ribbon"
                             else -> "Classic"
                         }

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -1178,22 +1178,27 @@ private fun Hero(
                 // default, unchanged for everyone who doesn't switch).
                 val chartStyle = UnitPrefs.sleepChartStyle(LocalContext.current)
                 val filledSegments = display.hypnogramSegments?.takeIf { it.size >= 2 }
-                if ((chartStyle == SleepChartStyle.FILLED || chartStyle == SleepChartStyle.RIBBON) &&
-                    filledSegments != null) {
+                if (chartStyle != SleepChartStyle.CLASSIC && filledSegments != null) {
                     ChartCard(
                         title = uiString(R.string.l10n_sleep_screen_stage_breakdown_e9b714f9),
                         subtitle = subtitle,
                         trailing = durationText(s.asleep),
                         tint = Palette.restColor,
-                        // The stepped chart carries no built-in legend (the rows ARE the legend in the
-                        // classic view), so surface the per-stage breakdown below it, like the reference.
-                        footer = { StageBreakdownRows(s) },
+                        // A colour-coded key in the chart's ramp so the bands are decodable (esp. the Garmin
+                        // ramp's two pinks), then the per-stage breakdown rows below.
+                        footer = {
+                            Column(verticalArrangement = Arrangement.spacedBy(Metrics.space6)) {
+                                SleepStageLegend(chartStyle.stagePalette)
+                                StageBreakdownRows(s)
+                            }
+                        },
                     ) {
                         FilledHypnogram(
                             segments = filledSegments,
                             onsetTs = windowOnsetTs ?: session?.effectiveStartTs,
                             wakeTs = windowWakeTs ?: session?.endTs,
-                            filled = chartStyle == SleepChartStyle.FILLED,
+                            filled = chartStyle.isFilled,
+                            palette = chartStyle.stagePalette,
                         )
                     }
                 } else {
@@ -2653,20 +2658,25 @@ internal fun StagesHostCard(m: SleepModel) {
         if (real != null) {
             val chartStyle = UnitPrefs.sleepChartStyle(LocalContext.current)
             val filledSegments = m.hypnogramSegments?.takeIf { it.size >= 2 }
-            if ((chartStyle == SleepChartStyle.FILLED || chartStyle == SleepChartStyle.RIBBON) &&
-                filledSegments != null) {
+            if (chartStyle != SleepChartStyle.CLASSIC && filledSegments != null) {
                 ChartCard(
                     title = uiString(R.string.l10n_sleep_screen_stage_breakdown_e9b714f9),
                     subtitle = subtitle,
                     trailing = durationText(s.asleep),
                     tint = Palette.restColor,
-                    footer = { StageBreakdownRows(s) },
+                    footer = {
+                        Column(verticalArrangement = Arrangement.spacedBy(Metrics.space6)) {
+                            SleepStageLegend(chartStyle.stagePalette)
+                            StageBreakdownRows(s)
+                        }
+                    },
                 ) {
                     FilledHypnogram(
                         segments = filledSegments,
                         onsetTs = null,
                         wakeTs = null,
-                        filled = chartStyle == SleepChartStyle.FILLED,
+                        filled = chartStyle.isFilled,
+                        palette = chartStyle.stagePalette,
                     )
                 }
             } else {

--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -2,6 +2,7 @@ package com.noop.ui
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -211,6 +212,8 @@ internal fun FilledHypnogram(
     // true → each stage FILLS its column to the baseline (the stepped-area look). false → a slim uniform
     // RIBBON at each stage level (the WHOOP-style stepped line), which reads cleaner on a fragmented night.
     filled: Boolean = true,
+    // The stage-colour ramp: NOOP tokens (Fill), Garmin's (Garmin Fill), or Oura's (Ribbon).
+    palette: SleepStagePalette = SleepStagePalette.NOOP,
 ) {
     if (segments.isEmpty()) return
     val originSec = (onsetTs?.toDouble()) ?: segments.minOf { it.start }.toDouble()
@@ -279,13 +282,13 @@ internal fun FilledHypnogram(
                 val segW = (x1 - x0).coerceAtLeast(1.5f).coerceAtMost(w - x0)
                 if (filled) {
                     drawRect(
-                        color = stageColorForBrand(iv.stage, filled),
+                        color = stageColorForRamp(iv.stage, palette),
                         topLeft = Offset(x0, y),
                         size = Size(segW, (h - y).coerceAtLeast(0f)),
                     )
                 } else {
                     drawRect(
-                        color = stageColorForBrand(iv.stage, filled),
+                        color = stageColorForRamp(iv.stage, palette),
                         topLeft = Offset(x0, y - ribbonThickness / 2f),
                         size = Size(segW, ribbonThickness),
                     )
@@ -317,6 +320,27 @@ internal fun FilledHypnogram(
         }
         if (axisTicks.isNotEmpty()) {
             HypnogramTimeAxis(axisTicks)
+        }
+    }
+}
+
+/** A compact colour-coded key for the stepped hypnogram: one dot + label per stage in the chart's ramp, so
+ *  the bands are decodable (esp. the Garmin ramp's two pinks, Awake vs REM). Twin of Swift SleepStageLegend. */
+@Composable
+internal fun SleepStageLegend(palette: SleepStagePalette) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        for (label in listOf("Awake", "REM", "Light", "Deep")) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(5.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(modifier = Modifier.size(8.dp).clip(CircleShape).background(stageColorForRamp(label, palette)))
+                Text(label, style = NoopType.caption, color = Palette.textSecondary, maxLines = 1)
+            }
         }
     }
 }
@@ -503,10 +527,14 @@ private val garminSleepREM: Color get() = brand(BrandSleepRamp.GARMIN_REM_LIGHT,
 private val garminSleepLight: Color get() = brand(BrandSleepRamp.GARMIN_LIGHT_LIGHT, BrandSleepRamp.GARMIN_LIGHT_DARK)
 private val garminSleepDeep: Color get() = brand(BrandSleepRamp.GARMIN_DEEP_LIGHT, BrandSleepRamp.GARMIN_DEEP_DARK)
 
-private fun stageColorForBrand(name: String, filled: Boolean): Color = when (canonicalStage(name)) {
-    "deep" -> if (filled) garminSleepDeep else ouraSleepDeep
-    "rem" -> if (filled) garminSleepREM else ouraSleepREM
-    "light" -> if (filled) garminSleepLight else ouraSleepLight
-    "awake" -> if (filled) garminSleepAwake else ouraSleepAwake
-    else -> if (filled) garminSleepLight else ouraSleepLight
+private fun stageColorForRamp(name: String, palette: SleepStagePalette): Color = when (palette) {
+    SleepStagePalette.NOOP -> stageColorFor(name)
+    SleepStagePalette.OURA -> when (canonicalStage(name)) {
+        "deep" -> ouraSleepDeep; "rem" -> ouraSleepREM; "light" -> ouraSleepLight
+        "awake" -> ouraSleepAwake; else -> ouraSleepLight
+    }
+    SleepStagePalette.GARMIN -> when (canonicalStage(name)) {
+        "deep" -> garminSleepDeep; "rem" -> garminSleepREM; "light" -> garminSleepLight
+        "awake" -> garminSleepAwake; else -> garminSleepLight
+    }
 }

--- a/android/app/src/main/java/com/noop/ui/Units.kt
+++ b/android/app/src/main/java/com/noop/ui/Units.kt
@@ -117,18 +117,35 @@ enum class SleepChartStyle(val raw: String) {
     /** The long-standing per-stage-rows timeline (Awake/Light/Deep/REM each on their own track). */
     CLASSIC("classic"),
 
-    /** A single stepped hypnogram with the stages stacked by depth and each column FILLED to the
-     *  baseline, WHOOP-style — needs the night's real timestamped segments, else falls back to CLASSIC. */
+    /** A single stepped hypnogram FILLED to the baseline, in NOOP's sleep colours. Needs the night's real
+     *  timestamped segments, else falls back to CLASSIC. */
     FILLED("filled"),
 
-    /** The same single stepped chart but drawn as a slim RIBBON (a uniform band at each stage level, not
-     *  filled to the baseline) — the WHOOP-style stepped line, which reads cleaner on a fragmented night. */
+    /** The same filled chart drawn in Garmin's blue/magenta ramp. */
+    GARMIN_FILLED("garminFilled"),
+
+    /** The stepped chart drawn as a slim RIBBON (a uniform band at each stage level, not filled to the
+     *  baseline), in Oura's cream/blue ramp. */
     RIBBON("ribbon");
+
+    /** Whether the stepped chart fills to the baseline (Fill / Garmin Fill) or draws a slim ribbon. */
+    val isFilled: Boolean get() = this == FILLED || this == GARMIN_FILLED
+
+    /** The stage-colour ramp this style draws with. */
+    val stagePalette: SleepStagePalette
+        get() = when (this) {
+            CLASSIC, FILLED -> SleepStagePalette.NOOP
+            GARMIN_FILLED -> SleepStagePalette.GARMIN
+            RIBBON -> SleepStagePalette.OURA
+        }
 
     companion object {
         fun fromRaw(raw: String?): SleepChartStyle = entries.firstOrNull { it.raw == raw } ?: CLASSIC
     }
 }
+
+/** Which stage-colour ramp a sleep chart draws with. Twin of the Swift `SleepStagePalette`. */
+enum class SleepStagePalette { NOOP, OURA, GARMIN }
 
 /**
  * Reads the two unit preferences from [NoopPrefs] and resolves the "match the system" default for


### PR DESCRIPTION
Follow-up to the brand ramps (#1290), per feedback that Garmin's two pinks (Awake vs REM) were undecodable.

### 1. Four styles instead of three
The Sleep-chart picker is now **Classic · Fill · Garmin Fill · Ribbon**:
- **Fill** — filled stepped hypnogram in NOOP's own colours
- **Garmin Fill** — same shape in Garmin's blue/magenta ramp
- **Ribbon** — slim bands in Oura's ramp (unchanged)

So the palette is keyed on the **style**, not the `filled` flag — I reworked #1290's `filled`-keyed brand pick into an explicit **`SleepStagePalette`** (`noop`/`oura`/`garmin`) threaded through `Hypnogram` / `FilledHypnogram`. New enum case `garminFilled` (rawValue byte-identical both platforms), `isFilled`/`stagePalette` helpers, parity test extended.

### 2. Colour-coded legend
A compact key (dot + label per stage, **in the chart's ramp**) under the stepped chart — , like the Oura/Garmin apps — so the bands are decodable. This is what gives the Garmin pinks meaning (which pink is REM vs Awake).

### Notes
- **Display-only.** Same stages/totals.
- The **breakdown-row footer keeps NOOP colours** for now (it's the data table below the key, not the key itself) — recolouring it to the ramp is an easy follow-up if the mix reads oddly on-device.
- The two-pink Garmin ramp is **kept** (you chose legend over recolour); the estimated Garmin hexes still want an on-device tune.
- i18n clean (`Fill`/`Garmin Fill` localised in the package catalog; legend is a11y-hidden as decorative).

### Verification
Android `compileFullDebugKotlin` + i18n audit green locally; `StrandDesignTests` pins the 4 rawValues + style→ramp mapping (`swift-packages`). App-target Swift via the on-demand app-build gate. **On-device colour/legend check still owed.**