### PR TITLE
fix(sleep): give the brand hypnogram ramps a light-mode variant (#1290 follow-up)

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Palette.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Palette.swift
@@ -379,15 +379,51 @@ public enum StrandPalette {
     // Brand sleep ramps for the two stepped-hypnogram styles, so the chart reads like the app it's modelled
     // on. Ribbon = Oura's ramp (cream awake + blues, sampled from the ring's app); Filled = Garmin's
     // (blue light/deep + magenta REM). Opt-in only (Sleep-tab stepped chart) — every other Hypnogram caller
-    // keeps `sleepStageColor`. Flat (theme-independent): both source apps are dark-tuned. (#sleep-chart-style)
-    static let oSleepAwake = Color(light: "#EAE3D3", dark: "#EAE3D3")
-    static let oSleepREM   = Color(light: "#90D0F0", dark: "#90D0F0")
-    static let oSleepLight = Color(light: "#40B0E0", dark: "#40B0E0")
-    static let oSleepDeep  = Color(light: "#206080", dark: "#206080")
-    static let gSleepAwake = Color(light: "#F26FE8", dark: "#F26FE8")
-    static let gSleepREM   = Color(light: "#E22DD0", dark: "#E22DD0")
-    static let gSleepLight = Color(light: "#4AA6F2", dark: "#4AA6F2")
-    static let gSleepDeep  = Color(light: "#2472D8", dark: "#2472D8")
+    // keeps `sleepStageColor`. (#sleep-chart-style)
+    //
+    // WHY THERE IS A LIGHT VARIANT. Both source apps are dark-tuned, so the ramps shipped flat — the same
+    // hex in both schemes. On the light card those bands are drawn on near-white (`NoopVisualStyle.surface`
+    // = #FFFFFF; a real Sleep-screen capture samples #FEFEFF), and measured there the Oura ramp collapses:
+    // three of its four bands fall under the 3:1 non-text minimum and `awake` #EAE3D3 sits at **1.28:1**,
+    // i.e. not drawn. That is not a rare band — on one real ring night awake was 64% of the chart.
+    //
+    // HOW THE LIGHT VALUES WERE DERIVED (not eyeballed, and not invented hues). Clamping each band on its
+    // own to 3:1 is the obvious fix and it BREAKS THE RAMP: Oura `rem` → #1E9EDD and `light` → #239FD5 land
+    // 1.00:1 apart, two adjacent stages the same colour. Instead ONE uniform HLS-lightness scale is applied
+    // per ramp, pinned so the ramp's lightest band reaches 3:1 on white — Oura ×0.575, Garmin ×0.912. Hue
+    // and saturation are untouched, so it is still recognisably the brand ramp; stage ORDERING survives;
+    // and the intra-ramp separation is no worse than the shipped dark ramp's (pinned in
+    // `BrandSleepRampTests`, twin `BrandSleepRampTest` on Android).
+    static let oSleepAwake = Color(light: BrandSleepRamp.ouraAwake.light, dark: BrandSleepRamp.ouraAwake.dark)
+    static let oSleepREM   = Color(light: BrandSleepRamp.ouraREM.light,   dark: BrandSleepRamp.ouraREM.dark)
+    static let oSleepLight = Color(light: BrandSleepRamp.ouraLight.light, dark: BrandSleepRamp.ouraLight.dark)
+    static let oSleepDeep  = Color(light: BrandSleepRamp.ouraDeep.light,  dark: BrandSleepRamp.ouraDeep.dark)
+    static let gSleepAwake = Color(light: BrandSleepRamp.garminAwake.light, dark: BrandSleepRamp.garminAwake.dark)
+    static let gSleepREM   = Color(light: BrandSleepRamp.garminREM.light,   dark: BrandSleepRamp.garminREM.dark)
+    static let gSleepLight = Color(light: BrandSleepRamp.garminLight.light, dark: BrandSleepRamp.garminLight.dark)
+    static let gSleepDeep  = Color(light: BrandSleepRamp.garminDeep.light,  dark: BrandSleepRamp.garminDeep.dark)
+
+    /// The brand ramps as hex PAIRS, so the properties above can be asserted in a test — a `SwiftUI.Color`
+    /// built from a dynamic provider cannot be read back, and these are also the values the Kotlin twin
+    /// must match byte for byte (`stageColorForBrand` in `SleepStageBreakdownUi.kt`). `.dark` is the
+    /// shipped ramp, unchanged.
+    enum BrandSleepRamp {
+        static let ouraAwake   = (light: "#AD9153", dark: "#EAE3D3")
+        static let ouraREM     = (light: "#1A8AC2", dark: "#90D0F0")
+        static let ouraLight   = (light: "#176B8E", dark: "#40B0E0")
+        static let ouraDeep    = (light: "#12374A", dark: "#206080")
+        static let garminAwake = (light: "#EF52E3", dark: "#F26FE8")
+        static let garminREM   = (light: "#D91EC7", dark: "#E22DD0")
+        static let garminLight = (light: "#3099F0", dark: "#4AA6F2")
+        static let garminDeep  = (light: "#2168C5", dark: "#2472D8")
+
+        /// Oura's ramp in STAGE order (awake → rem → light → deep), which is not the same as luminance
+        /// order — Garmin's `light` is lighter than its `rem`. What the light pass must preserve is each
+        /// ramp's OWN luminance order, whatever it is; that is what the tests assert.
+        static let oura   = [ouraAwake, ouraREM, ouraLight, ouraDeep]
+        /// Garmin's ramp in stage order.
+        static let garmin = [garminAwake, garminREM, garminLight, garminDeep]
+    }
 
     /// The brand sleep ramp for the stepped hypnogram: Garmin's for Filled, Oura's for Ribbon.
     public static func sleepStageColorBrand(_ stage: SleepStage, filled: Bool) -> Color {

--- a/Packages/StrandDesign/Tests/StrandDesignTests/BrandSleepRampTests.swift
+++ b/Packages/StrandDesign/Tests/StrandDesignTests/BrandSleepRampTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+import SwiftUI
+@testable import StrandDesign
+
+/// The brand sleep ramps (#1290) shipped FLAT — one hex for both schemes — because both source apps are
+/// dark-tuned. Measured against the card they are actually drawn on that is fine in dark and broken in
+/// light: the Oura `awake` cream sits at 1.28:1 on #FFFFFF, i.e. not drawn, and awake was 64% of one real
+/// ring night's chart. The light variants added here are DERIVED, and these tests pin the three properties
+/// that make the derivation defensible — because "it looks fine on my phone" is exactly how the flat ramp
+/// shipped in the first place.
+///
+/// The obvious alternative is clamping each band to 3:1 on its own, and it is a trap worth remembering:
+/// it drives Oura `rem` to #1E9EDD and `light` to #239FD5, **1.00:1 apart** — two adjacent stages rendered
+/// the same colour. A uniform per-ramp lightness scale is used instead. Twin: `BrandSleepRampTest` (Android).
+final class BrandSleepRampTests: XCTestCase {
+
+    /// `NoopVisualStyle.surface` — the card the stepped hypnogram is drawn on (ChartCard → NoopCard).
+    private let lightSurface = "#FFFFFF"
+    private let darkSurface  = "#2A2C34"
+
+    private typealias Ramp = [(light: String, dark: String)]
+    private var ramps: [(name: String, ramp: Ramp)] {
+        [("Oura/Ribbon", StrandPalette.BrandSleepRamp.oura),
+         ("Garmin/Filled", StrandPalette.BrandSleepRamp.garmin)]
+    }
+
+    // MARK: WCAG relative luminance / contrast, on the hex strings (a dynamic Color cannot be read back)
+
+    private func luminance(_ hex: String) -> Double {
+        let c = Color.sRGBComponents(hex: hex)
+        func lin(_ v: Double) -> Double { v <= 0.04045 ? v / 12.92 : pow((v + 0.055) / 1.055, 2.4) }
+        return 0.2126 * lin(c.r) + 0.7152 * lin(c.g) + 0.0722 * lin(c.b)
+    }
+
+    private func contrast(_ a: String, _ b: String) -> Double {
+        let (hi, lo) = { (x: Double, y: Double) in x > y ? (x, y) : (y, x) }(luminance(a), luminance(b))
+        return (hi + 0.05) / (lo + 0.05)
+    }
+
+    /// Sanity-check the metric itself before trusting the assertions built on it.
+    func testContrastMetricMatchesKnownValues() {
+        XCTAssertEqual(contrast("#FFFFFF", "#000000"), 21.0, accuracy: 0.01)
+        XCTAssertEqual(contrast("#FFFFFF", "#FFFFFF"), 1.0, accuracy: 0.001)
+        // The defect this whole change exists for, stated as a number.
+        XCTAssertEqual(contrast("#EAE3D3", "#FFFFFF"), 1.28, accuracy: 0.01)
+    }
+
+    // MARK: The three properties
+
+    /// THE ONE THAT MATTERS: every band is actually visible on the light card. 3:1 is the WCAG minimum for
+    /// non-text graphics, which is what a stage band is.
+    func testEveryLightBandClearsThreeToOneOnTheLightCard() {
+        for (name, ramp) in ramps {
+            for (i, pair) in ramp.enumerated() {
+                let c = contrast(pair.light, lightSurface)
+                XCTAssertGreaterThanOrEqual(
+                    c, 3.0,
+                    "\(name) band \(i) \(pair.light) is \(String(format: "%.2f", c)):1 on \(lightSurface) — under the 3:1 non-text minimum")
+            }
+        }
+    }
+
+    /// The dark ramp is @ryanbr's and is NOT changed here. Pinned so this file notices if a later light-mode
+    /// tweak reaches across and edits it. 2:1 rather than 3:1 because the shipped Oura `deep` is 2.02:1 on
+    /// the dark card — a real weak spot, but a pre-existing one and not this change's business.
+    func testDarkRampIsUnchangedAndStillClearsTwoToOneOnTheDarkCard() {
+        XCTAssertEqual(StrandPalette.BrandSleepRamp.ouraAwake.dark, "#EAE3D3")
+        XCTAssertEqual(StrandPalette.BrandSleepRamp.ouraDeep.dark, "#206080")
+        XCTAssertEqual(StrandPalette.BrandSleepRamp.garminAwake.dark, "#F26FE8")
+        XCTAssertEqual(StrandPalette.BrandSleepRamp.garminDeep.dark, "#2472D8")
+        for (name, ramp) in ramps {
+            for (i, pair) in ramp.enumerated() {
+                let c = contrast(pair.dark, darkSurface)
+                XCTAssertGreaterThanOrEqual(
+                    c, 2.0,
+                    "\(name) band \(i) \(pair.dark) is \(String(format: "%.2f", c)):1 on \(darkSurface)")
+            }
+        }
+    }
+
+    /// A ramp is an ORDERED scale — light-to-dark is what makes it read as one. A per-band clamp destroys
+    /// that (see the file header); a uniform lightness scale is monotone, so each ramp's own luminance order
+    /// must survive into the light variant.
+    func testLightVariantPreservesEachRampsOwnLuminanceOrder() {
+        for (name, ramp) in ramps {
+            let darkOrder  = ramp.indices.sorted { luminance(ramp[$0].dark)  > luminance(ramp[$1].dark) }
+            let lightOrder = ramp.indices.sorted { luminance(ramp[$0].light) > luminance(ramp[$1].light) }
+            XCTAssertEqual(lightOrder, darkOrder,
+                           "\(name): the light variant reorders the ramp (dark \(darkOrder) vs light \(lightOrder))")
+        }
+    }
+
+    /// ...and the stages must stay as separable from EACH OTHER as they already were. This is the property
+    /// the naive per-band clamp fails: it passes the 3:1 test above while collapsing two stages onto the
+    /// same colour.
+    ///
+    /// Two rules, because either alone has a hole. RELATIVE (no pair loses more than 30% of its separation)
+    /// catches a ramp squashed flat — worst observed under the uniform scale is 0.76 (Oura light vs deep),
+    /// against 0.42 for the naive clamp. ABSOLUTE (a pair that was distinguishable stays distinguishable)
+    /// catches a single pair collapsing while the rest of the ramp looks healthy, which is exactly the naive
+    /// clamp's Oura `rem` vs `light`: 1.47 → 1.00. The 1.20 floor is grandfathered against the SHIPPED dark
+    /// ramp, so pairs that are already luminance-close there (Garmin awake vs light, 1.02:1 — magenta vs
+    /// blue, separated by hue not lightness) are not held to a bar the original never met.
+    func testLightVariantDoesNotWorsenSeparationBetweenStages() {
+        let collapseFloor = 1.20
+        for (name, ramp) in ramps {
+            for i in ramp.indices {
+                for j in ramp.indices where j > i {
+                    let dark  = contrast(ramp[i].dark,  ramp[j].dark)
+                    let light = contrast(ramp[i].light, ramp[j].light)
+                    XCTAssertGreaterThanOrEqual(
+                        light / dark, 0.70,
+                        "\(name) \(i) vs \(j): separation drops \(String(format: "%.2f", dark)) → \(String(format: "%.2f", light))")
+                    if dark >= collapseFloor {
+                        XCTAssertGreaterThanOrEqual(
+                            light, collapseFloor,
+                            "\(name) \(i) vs \(j): a pair that was separable in dark (\(String(format: "%.2f", dark))) collapses in light (\(String(format: "%.2f", light)))")
+                    }
+                }
+            }
+        }
+    }
+
+    /// The trap, pinned as a value so it cannot be re-derived by accident: clamping each band to 3:1 on its
+    /// own gives Oura `rem` #1E9EDD and `light` #239FD5, which are the same colour to the eye. If a future
+    /// change adopts a per-band clamp, the test above fails — this one says why in one line.
+    func testNaivePerBandClampWouldCollapseTwoOuraStages() {
+        XCTAssertEqual(contrast("#1E9EDD", "#239FD5"), 1.00, accuracy: 0.02)
+        XCTAssertGreaterThan(contrast(StrandPalette.BrandSleepRamp.ouraREM.light,
+                                      StrandPalette.BrandSleepRamp.ouraLight.light), 1.20)
+    }
+
+    /// The eight light hexes, pinned literally. They are the byte-identical contract with the Kotlin twin,
+    /// and a silent edit on one platform is exactly the divergence the parity rule exists to stop.
+    func testLightHexesArePinnedForKotlinParity() {
+        XCTAssertEqual(StrandPalette.BrandSleepRamp.oura.map(\.light),
+                       ["#AD9153", "#1A8AC2", "#176B8E", "#12374A"])
+        XCTAssertEqual(StrandPalette.BrandSleepRamp.garmin.map(\.light),
+                       ["#EF52E3", "#D91EC7", "#3099F0", "#2168C5"])
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -451,16 +451,57 @@ private fun stageColorFor(name: String): Color = when (canonicalStage(name)) {
 
 // Brand sleep ramps for the stepped [FilledHypnogram]: Garmin's for Filled (blue light/deep + magenta REM),
 // Oura's for Ribbon (cream awake + blues, sampled from the ring's app), so the chart reads like the app it's
-// modelled on. Byte-identical hexes to the Swift `StrandPalette.sleepStageColorBrand`. The classic hero
-// strip ([HypnogramWithAxis]) keeps the NOOP tokens via [stageColorFor]. (#sleep-chart-style)
-private val ouraSleepAwake = Color(0xFFEAE3D3)
-private val ouraSleepREM = Color(0xFF90D0F0)
-private val ouraSleepLight = Color(0xFF40B0E0)
-private val ouraSleepDeep = Color(0xFF206080)
-private val garminSleepAwake = Color(0xFFF26FE8)
-private val garminSleepREM = Color(0xFFE22DD0)
-private val garminSleepLight = Color(0xFF4AA6F2)
-private val garminSleepDeep = Color(0xFF2472D8)
+// modelled on. Byte-identical hexes to the Swift `StrandPalette.BrandSleepRamp`. The classic hero strip
+// ([HypnogramWithAxis]) keeps the NOOP tokens via [stageColorFor]. (#sleep-chart-style)
+//
+// PER-SCHEME since the light-mode pass. The ramps shipped flat — one hex for both schemes — because both
+// source apps are dark-tuned; measured on the light card (near-white) the Oura ramp collapses, with `awake`
+// #EAE3D3 at 1.28:1, i.e. not drawn. The light values apply ONE uniform HLS-lightness scale per ramp
+// (Oura x0.575, Garmin x0.912), pinned so each ramp's lightest band reaches 3:1 on white: hue and
+// saturation untouched, ordering preserved, no stage pair collapsed. Clamping each band separately to 3:1
+// is the trap — it drives Oura `rem` and `light` to 1.00:1 apart. Properties pinned in [BrandSleepRampTest],
+// twin of the Swift `BrandSleepRampTests`.
+/**
+ * The eight brand hexes x two schemes, declared ONCE as ARGB longs — the [Color]s below and the ramp lists
+ * [BrandSleepRampTest] asserts on are both built from these, so there is no second copy to drift. Stage
+ * order is awake, rem, light, deep (which is NOT luminance order: Garmin's `light` is lighter than its
+ * `rem`; what the light pass preserves is each ramp's own order, whatever it is).
+ */
+internal object BrandSleepRamp {
+    const val OURA_AWAKE_DARK = 0xFFEAE3D3
+    const val OURA_REM_DARK = 0xFF90D0F0
+    const val OURA_LIGHT_DARK = 0xFF40B0E0
+    const val OURA_DEEP_DARK = 0xFF206080
+    const val GARMIN_AWAKE_DARK = 0xFFF26FE8
+    const val GARMIN_REM_DARK = 0xFFE22DD0
+    const val GARMIN_LIGHT_DARK = 0xFF4AA6F2
+    const val GARMIN_DEEP_DARK = 0xFF2472D8
+    const val OURA_AWAKE_LIGHT = 0xFFAD9153
+    const val OURA_REM_LIGHT = 0xFF1A8AC2
+    const val OURA_LIGHT_LIGHT = 0xFF176B8E
+    const val OURA_DEEP_LIGHT = 0xFF12374A
+    const val GARMIN_AWAKE_LIGHT = 0xFFEF52E3
+    const val GARMIN_REM_LIGHT = 0xFFD91EC7
+    const val GARMIN_LIGHT_LIGHT = 0xFF3099F0
+    const val GARMIN_DEEP_LIGHT = 0xFF2168C5
+
+    val ouraDark = listOf(OURA_AWAKE_DARK, OURA_REM_DARK, OURA_LIGHT_DARK, OURA_DEEP_DARK)
+    val ouraLight = listOf(OURA_AWAKE_LIGHT, OURA_REM_LIGHT, OURA_LIGHT_LIGHT, OURA_DEEP_LIGHT)
+    val garminDark = listOf(GARMIN_AWAKE_DARK, GARMIN_REM_DARK, GARMIN_LIGHT_DARK, GARMIN_DEEP_DARK)
+    val garminLight = listOf(GARMIN_AWAKE_LIGHT, GARMIN_REM_LIGHT, GARMIN_LIGHT_LIGHT, GARMIN_DEEP_LIGHT)
+}
+
+// The scheme-resolved ramp. `Palette.isLight` is snapshot state, so a theme flip re-resolves these inside a
+// Canvas DrawScope with no call-site change — the same per-scheme idiom the rest of the palette uses.
+private fun brand(light: Long, dark: Long) = Color(if (Palette.isLight) light else dark)
+private val ouraSleepAwake: Color get() = brand(BrandSleepRamp.OURA_AWAKE_LIGHT, BrandSleepRamp.OURA_AWAKE_DARK)
+private val ouraSleepREM: Color get() = brand(BrandSleepRamp.OURA_REM_LIGHT, BrandSleepRamp.OURA_REM_DARK)
+private val ouraSleepLight: Color get() = brand(BrandSleepRamp.OURA_LIGHT_LIGHT, BrandSleepRamp.OURA_LIGHT_DARK)
+private val ouraSleepDeep: Color get() = brand(BrandSleepRamp.OURA_DEEP_LIGHT, BrandSleepRamp.OURA_DEEP_DARK)
+private val garminSleepAwake: Color get() = brand(BrandSleepRamp.GARMIN_AWAKE_LIGHT, BrandSleepRamp.GARMIN_AWAKE_DARK)
+private val garminSleepREM: Color get() = brand(BrandSleepRamp.GARMIN_REM_LIGHT, BrandSleepRamp.GARMIN_REM_DARK)
+private val garminSleepLight: Color get() = brand(BrandSleepRamp.GARMIN_LIGHT_LIGHT, BrandSleepRamp.GARMIN_LIGHT_DARK)
+private val garminSleepDeep: Color get() = brand(BrandSleepRamp.GARMIN_DEEP_LIGHT, BrandSleepRamp.GARMIN_DEEP_DARK)
 
 private fun stageColorForBrand(name: String, filled: Boolean): Color = when (canonicalStage(name)) {
     "deep" -> if (filled) garminSleepDeep else ouraSleepDeep

--- a/android/app/src/test/java/com/noop/ui/BrandSleepRampTest.kt
+++ b/android/app/src/test/java/com/noop/ui/BrandSleepRampTest.kt
@@ -1,0 +1,132 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.pow
+
+/**
+ * Android twin of the Swift `BrandSleepRampTests`. The brand sleep ramps (#1290) shipped FLAT — one hex for
+ * both schemes — because both source apps are dark-tuned. Measured against the card they are drawn on that
+ * is fine in dark and broken in light: Oura `awake` cream is 1.28:1 on white, i.e. not drawn, and awake was
+ * 64% of one real ring night's chart. These pin the properties that make the derived light variants
+ * defensible, and the byte-identical hexes the parity rule requires.
+ *
+ * The trap worth remembering: clamping each band to 3:1 on its own drives Oura `rem` to #1E9EDD and `light`
+ * to #239FD5 — 1.00:1 apart, two adjacent stages the same colour. A uniform per-ramp lightness scale is
+ * used instead (Oura x0.575, Garmin x0.912).
+ */
+class BrandSleepRampTest {
+
+    // Palette.surfaceRaised — the card the stepped hypnogram is drawn on.
+    private val lightSurface = 0xFFFFFFFF
+    private val darkSurface = 0xFF2A2C34
+
+    private fun luminance(argb: Long): Double {
+        fun lin(v: Double) = if (v <= 0.04045) v / 12.92 else ((v + 0.055) / 1.055).pow(2.4)
+        val r = ((argb shr 16) and 0xFF) / 255.0
+        val g = ((argb shr 8) and 0xFF) / 255.0
+        val b = (argb and 0xFF) / 255.0
+        return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b)
+    }
+
+    private fun contrast(a: Long, b: Long): Double {
+        val la = luminance(a)
+        val lb = luminance(b)
+        return (maxOf(la, lb) + 0.05) / (minOf(la, lb) + 0.05)
+    }
+
+    private val ramps = listOf(
+        Triple("Oura/Ribbon", BrandSleepRamp.ouraLight, BrandSleepRamp.ouraDark),
+        Triple("Garmin/Filled", BrandSleepRamp.garminLight, BrandSleepRamp.garminDark),
+    )
+
+    /** Sanity-check the metric before trusting anything built on it. */
+    @Test
+    fun contrastMetricMatchesKnownValues() {
+        assertEquals(21.0, contrast(0xFFFFFFFF, 0xFF000000), 0.01)
+        assertEquals(1.0, contrast(0xFFFFFFFF, 0xFFFFFFFF), 0.001)
+        // The defect this change exists for, stated as a number.
+        assertEquals(1.28, contrast(0xFFEAE3D3, 0xFFFFFFFF), 0.01)
+    }
+
+    /** THE ONE THAT MATTERS: every band is visible on the light card (3:1 = the WCAG non-text minimum). */
+    @Test
+    fun everyLightBandClearsThreeToOneOnTheLightCard() {
+        for ((name, light, _) in ramps) {
+            light.forEachIndexed { i, argb ->
+                val c = contrast(argb, lightSurface)
+                assertTrue("$name band $i is %.2f:1 on white — under the 3:1 minimum".format(c), c >= 3.0)
+            }
+        }
+    }
+
+    /**
+     * The dark ramp is not changed here; pinned so a later light-mode tweak cannot quietly edit it. 2:1
+     * rather than 3:1 because the shipped Oura `deep` is 2.02:1 on the dark card — pre-existing, and not
+     * this change's business.
+     */
+    @Test
+    fun darkRampIsUnchangedAndStillClearsTwoToOneOnTheDarkCard() {
+        assertEquals(listOf(0xFFEAE3D3, 0xFF90D0F0, 0xFF40B0E0, 0xFF206080), BrandSleepRamp.ouraDark)
+        assertEquals(listOf(0xFFF26FE8, 0xFFE22DD0, 0xFF4AA6F2, 0xFF2472D8), BrandSleepRamp.garminDark)
+        for ((name, _, dark) in ramps) {
+            dark.forEachIndexed { i, argb ->
+                val c = contrast(argb, darkSurface)
+                assertTrue("$name band $i is %.2f:1 on the dark card".format(c), c >= 2.0)
+            }
+        }
+    }
+
+    /** A ramp is an ORDERED scale — a uniform lightness scale is monotone, so the order must survive. */
+    @Test
+    fun lightVariantPreservesEachRampsOwnLuminanceOrder() {
+        for ((name, light, dark) in ramps) {
+            val darkOrder = dark.indices.sortedByDescending { luminance(dark[it]) }
+            val lightOrder = light.indices.sortedByDescending { luminance(light[it]) }
+            assertEquals("$name: the light variant reorders the ramp", darkOrder, lightOrder)
+        }
+    }
+
+    /**
+     * ...and the stages stay as separable from EACH OTHER as they already were — the property the naive
+     * per-band clamp fails while still passing the 3:1 test. RELATIVE (no pair loses more than 30%) catches
+     * a ramp squashed flat; ABSOLUTE (a pair distinguishable in dark stays distinguishable) catches one pair
+     * collapsing while the rest looks healthy. The 1.20 floor is grandfathered against the SHIPPED dark
+     * ramp, so pairs already luminance-close there (Garmin awake vs light, 1.02:1 — separated by hue, not
+     * lightness) are not held to a bar the original never met.
+     */
+    @Test
+    fun lightVariantDoesNotWorsenSeparationBetweenStages() {
+        val collapseFloor = 1.20
+        for ((name, light, dark) in ramps) {
+            for (i in light.indices) {
+                for (j in i + 1 until light.size) {
+                    val d = contrast(dark[i], dark[j])
+                    val l = contrast(light[i], light[j])
+                    assertTrue("$name $i vs $j: separation drops %.2f -> %.2f".format(d, l), l / d >= 0.70)
+                    if (d >= collapseFloor) {
+                        assertTrue(
+                            "$name $i vs $j: separable in dark (%.2f) collapses in light (%.2f)".format(d, l),
+                            l >= collapseFloor,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /** The trap, pinned as a value so it cannot be re-derived by accident. */
+    @Test
+    fun naivePerBandClampWouldCollapseTwoOuraStages() {
+        assertEquals(1.00, contrast(0xFF1E9EDD, 0xFF239FD5), 0.02)
+        assertTrue(contrast(BrandSleepRamp.OURA_REM_LIGHT, BrandSleepRamp.OURA_LIGHT_LIGHT) > 1.20)
+    }
+
+    /** The byte-identical contract with `StrandPalette.BrandSleepRamp` (Swift). */
+    @Test
+    fun lightHexesArePinnedForSwiftParity() {
+        assertEquals(listOf(0xFFAD9153, 0xFF1A8AC2, 0xFF176B8E, 0xFF12374A), BrandSleepRamp.ouraLight)
+        assertEquals(listOf(0xFFEF52E3, 0xFFD91EC7, 0xFF3099F0, 0xFF2168C5), BrandSleepRamp.garminLight)
+    }
+}


### PR DESCRIPTION
Follow-up to #1290, taking up its own caveat:

> Flat (theme-independent) — both source apps are dark-tuned; a light-mode pass can follow if needed
> (the cream Awake is the one to watch on a light background).

It is the right one to watch. Measured against the card the stepped chart is drawn on (`ChartCard` →
`NoopCard`, i.e. `NoopVisualStyle.surface` = `#FFFFFF` light / `#2A2C34` dark; a real Sleep-screen
capture samples `#FEFEFF`):

| | light `#FFFFFF` | dark `#2A2C34` |
|---|---|---|
| Oura `awake` `#EAE3D3` | **1.28:1** | 10.89:1 |
| Oura `rem` `#90D0F0` | 1.68:1 | 8.27:1 |
| Oura `light` `#40B0E0` | 2.47:1 | 5.64:1 |
| Oura `deep` `#206080` | 6.89:1 | 2.02:1 |
| Garmin `awake` `#F26FE8` | 2.56:1 | 5.45:1 |
| Garmin `rem` `#E22DD0` | 3.80:1 | 3.66:1 |
| Garmin `light` `#4AA6F2` | 2.62:1 | 5.32:1 |
| Garmin `deep` `#2472D8` | 4.69:1 | 4.66:1 |

The dark-tuned claim holds — every band clears 2:1 there. In light mode three of the four Oura bands
fall under the 3:1 non-text minimum and `awake` at 1.28:1 is effectively not drawn. **Awake is not a
rare band:** on one real ring night here it was **64 %** of the charted night (5 h 34 m of 8 h 40 m),
so in light mode that ramp renders most of the chart as blank card.

### How the light values were derived

Not eyeballed, and no invented hues — but the obvious approach is a trap worth naming. **Clamping each
band to 3:1 on its own breaks the ramp:** Oura `rem` → `#1E9EDD` and `light` → `#239FD5` land **1.00:1
apart**, two adjacent stages rendered the same colour. It would pass a per-band contrast check and look
worse than the bug.

Instead **one uniform HLS-lightness scale per ramp**, pinned so that ramp's lightest band reaches 3:1 on
white — **Oura ×0.575, Garmin ×0.912**:

| | dark (shipped, unchanged) | light (new) | on white |
|---|---|---|---|
| Oura `awake` | `#EAE3D3` | `#AD9153` | 3.02:1 |
| Oura `rem` | `#90D0F0` | `#1A8AC2` | 3.85:1 |
| Oura `light` | `#40B0E0` | `#176B8E` | 5.95:1 |
| Oura `deep` | `#206080` | `#12374A` | 12.57:1 |
| Garmin `awake` | `#F26FE8` | `#EF52E3` | 3.01:1 |
| Garmin `rem` | `#E22DD0` | `#D91EC7` | 4.23:1 |
| Garmin `light` | `#4AA6F2` | `#3099F0` | 3.03:1 |
| Garmin `deep` | `#2472D8` | `#2168C5` | 5.45:1 |

Hue and saturation are untouched, so it still reads as the brand ramp; each ramp's own luminance order
survives (Garmin's `light` is lighter than its `rem`, and stays that way); and no stage pair collapses.
**The dark ramps are unchanged**, and pinned in the tests so a later tweak cannot quietly edit them.

### Verification

Seven tests each side, asserting properties rather than appearance: 3:1 on the light card, dark
unchanged and still ≥2:1, order preserved, no pair losing more than 30 % of its separation or dropping
below 1.20:1 when it was above it, the naive clamp's collapse pinned as a value, and the eight light
hexes pinned literally as the Swift↔Kotlin contract. The Swift half lives in `Packages/StrandDesign`,
so `swift-packages` CI covers it — the Android twin runs in `testFullDebugUnitTest`.

- StrandDesign `swift test` **55/0**; Android `--tests "com.noop.ui.BrandSleepRampTest"` **7/0**,
  `compileFullDebugKotlin` green.
- `Strand` (macOS) and `NOOPiOS` (iOS) both built locally — no default CI compiles either.
- **On-device colour check still owed, in both schemes.** Happy to run it on a night with ring-hypnogram
  ground truth if that is useful before merge.

### One thing deliberately not done

The Android hexes stay in `SleepStageBreakdownUi.kt` where #1290 put them, rather than moving to
`Palette`/`PaletteTokens` (which is where the design-system rule points, and where the Swift half already
lives). That is a structural change to your file and a separate concern from the light-mode fix — happy
to do it in a follow-up if you want it.