### PR TITLE
oura(sleep): trim trailing 0xFF pad in a partly-written page + log the #899 sweep (#1284)

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -15,6 +15,12 @@ import Foundation
 
 public enum OuraDecoders {
 
+    /// #1284: minimum length (in code bytes; 1 byte = 4 epochs = 16 min) of a TRAILING run of `0xFF` for
+    /// `decodeSleepPhase` to treat it as unwritten flash pad rather than continuous `awake`. Conservative
+    /// (a real end-of-page wake block shorter than this is left intact); tunable as hardware captures pin
+    /// the true padding lengths. 6 bytes = 24 min; the measured pads ran 9-10 bytes (36-40 min).
+    public static let minTrailingUnwritten = 6
+
     // MARK: - Little-endian helpers (body offset == spec offset - 6)
 
     @inline(__always) static func u16le(_ b: [UInt8], _ i: Int) -> Int {
@@ -487,17 +493,30 @@ public enum OuraDecoders {
         // 0xFF (the reporter's explicit caution) — is never mistaken for an erased page. Observed erased
         // pages are whole ~13-byte records; a single byte is real wake.
         let codeBytes = b.dropFirst()
-        let unwritten = codeBytes.count >= 2 && codeBytes.allSatisfy { $0 == 0xFF }
+        let codeCount = codeBytes.count
+        let allUnwritten = codeCount >= 2 && codeBytes.allSatisfy { $0 == 0xFF }
+        // #1284: a PARTLY-written page fills front-to-back and leaves the TAIL as 0xFF padding, which the
+        // whole-record rule above misses — so the trailing pad still unpacks as `run*4` epochs of fake
+        // `awake` (measured ~86-88 min/night on hardware, pushing efficiency far below WHOOP's). Flag a
+        // TRAILING run of >= `minTrailingUnwritten` consecutive 0xFF code bytes (to the record's end) as
+        // unwritten too. Trailing-only + a run floor, on purpose: a leading/interior 0xFF run is left as
+        // real wake (the ring wrote it; a genuinely pre-onset run is dropped separately by the assembler's
+        // onset clip), and a short trailing run is spared as possible real end-of-page wake. `minTrailing`
+        // is the tunable safety margin between "padding" and "a long real wake block at a page boundary".
+        let trailingFF = codeBytes.reversed().prefix { $0 == 0xFF }.count
+        let trailingStart = trailingFF >= Self.minTrailingUnwritten ? codeCount - trailingFF : codeCount
         var out: [OuraSleepPhase] = []
         var index = 0
         for k in 1..<b.count {
             let byte = b[k]
+            // Whole erased page (#1246), or this byte is inside the trailing 0xFF pad (#1284).
+            let byteUnwritten = allUnwritten || (k - 1) >= trailingStart
             // MSB-first within the byte: [7:6] is the first code.
             for shift in stride(from: 6, through: 0, by: -2) {
                 let code = Int((byte >> UInt8(shift)) & 0x03)
                 if let stage = OuraSleepStage(rawValue: code) {
                     out.append(OuraSleepPhase(ringTimestamp: rec.ringTimestamp, index: index,
-                                              stage: stage, unwritten: unwritten))
+                                              stage: stage, unwritten: byteUnwritten))
                     index += 1
                 }
             }

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
@@ -248,6 +248,40 @@ final class DecoderGoldenTests: XCTestCase {
         XCTAssertEqual(phases?.suffix(4).allSatisfy { $0.stage == .awake }, true)
     }
 
+    func testSleepPhase0x4ETrailingFFRunIsUnwritten() {
+        // #1284: a PARTLY-written page — real codes then a trailing 0xFF pad. The reporter's `hdr=01`
+        // record: `ff ff f3 c0` then nine straight 0xFF (13 code bytes). The whole-record rule missed it;
+        // the trailing-run rule flags the 9-byte tail (36 epochs) as unwritten while the leading `ff ff`
+        // stays real wake.
+        let rec = record("4e120200010000fffff3c0ffffffffffffffffff")
+        let phases = OuraDecoders.decodeSleepPhase(rec)
+        XCTAssertEqual(phases?.count, 52)                                  // 13 code bytes * 4
+        XCTAssertEqual(phases?.filter { $0.unwritten }.count, 36)          // trailing 9 bytes * 4
+        XCTAssertEqual(phases?.prefix(16).allSatisfy { !$0.unwritten }, true)   // leading ff ff f3 c0 kept
+        XCTAssertEqual(phases?.suffix(36).allSatisfy { $0.unwritten }, true)    // the pad, dropped as a gap
+    }
+
+    func testSleepPhase0x4ETrailingRunFloorIsExclusive() {
+        // Exactly `minTrailingUnwritten` trailing 0xFF flags; one fewer is spared as possible real wake.
+        // 7 real codes + 6 trailing 0xFF (== floor): the 6-byte tail is unwritten.
+        let atFloor = record("4e12020001000055555555555555ffffffffffff")
+        XCTAssertEqual(OuraDecoders.decodeSleepPhase(atFloor)?.filter { $0.unwritten }.count,
+                       OuraDecoders.minTrailingUnwritten * 4)
+        // 8 real codes + 5 trailing 0xFF (floor - 1): nothing flagged.
+        let belowFloor = record("4e1202000100005555555555555555ffffffffff")
+        XCTAssertEqual(OuraDecoders.decodeSleepPhase(belowFloor)?.contains { $0.unwritten }, false)
+    }
+
+    func testSleepPhase0x4ELeadingFFRunIsRealWake() {
+        // Trailing-only, by design: a LONG leading/interior 0xFF run (nine here) that does NOT reach the
+        // record's end is left as genuine wake — the ring wrote it, and a pre-onset run is dropped by the
+        // assembler's onset clip, not here. Guards against eating real wake at the start of a page.
+        let rec = record("4e120200010000ffffffffffffffffff55555555")
+        let phases = OuraDecoders.decodeSleepPhase(rec)
+        XCTAssertEqual(phases?.count, 52)
+        XCTAssertEqual(phases?.contains { $0.unwritten }, false)
+    }
+
     // MARK: - 0x6B motion period (2-bit MOTION_STATE codes; 2 header bytes skipped)
 
     func testMotionPeriod0x6B() {

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1698,6 +1698,11 @@ final class IntelligenceEngine: ObservableObject {
             }
             healDropped.append(contentsOf: dropped)
         }
+        // #1284: log the sweep ALWAYS, even at zero removals — a heal that collapsed rows was previously
+        // silent (the line below only fired on a non-empty drop), so from the strap log alone it was
+        // indistinguishable from never having run. Counts only, no PII.
+        diagnosticSink?("Dedup(#899): swept \(healDeviceIds.count) device id(s), removed "
+            + "\(healDropped.count) overlapping duplicate session(s).", nil)
         if !healDropped.isEmpty {
             diagnosticSink?("Dedup(#899): removed \(healDropped.count) overlapping duplicate sleep "
                 + "session(s) re-banked under a shifted strap timebase; re-scoring the affected days.", nil)

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1410,6 +1410,13 @@ object IntelligenceEngine {
             for (stale in dropped) repo.deleteSleepSessionRowOnly(stale)
             healDropped.addAll(dropped)
         }
+        // #1284: log the sweep ALWAYS, even at zero removals — a heal that collapsed rows was previously
+        // silent (the line below only fired on a non-empty drop), so from the strap log alone it was
+        // indistinguishable from never having run. Counts only, no PII. Twin of the Swift line.
+        diag(
+            "Dedup(#899): swept ${healDeviceIds.size} device id(s), removed " +
+                "${healDropped.size} overlapping duplicate session(s).",
+        )
         if (healDropped.isNotEmpty()) {
             diag(
                 "Dedup(#899): removed ${healDropped.size} overlapping duplicate sleep " +

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -19,6 +19,11 @@ package com.noop.oura
 
 object OuraDecoders {
 
+    /** #1284: minimum TRAILING run of 0xFF code bytes (1 byte = 4 epochs = 16 min) for [decodeSleepPhase]
+     *  to treat it as unwritten flash pad rather than continuous awake. Byte-identical to the Swift
+     *  `OuraDecoders.minTrailingUnwritten`. Conservative + tunable; measured pads ran 9-10 bytes. */
+    const val MIN_TRAILING_UNWRITTEN = 6
+
     /**
      * Decode a GetProductInfo reply body (serial page `18 03 08 00 10` or hardware page `18 03 18 00 10`,
      * both under outer op 0x19). On-device capture 2026-07-24 (Gen3): the body is `byte0 = 0x00 status, then
@@ -553,11 +558,22 @@ object OuraDecoders {
         // Require >=2 code bytes so a LONE 0xFF byte — four genuine AWAKE epochs, which also encode as 0xFF
         // (the reporter's explicit caution) — is never mistaken for an erased page. Observed erased pages
         // are whole ~13-byte records; a single byte is real wake.
-        val unwritten = (b.size - 1) >= 2 && (1 until b.size).all { (b[it].toInt() and 0xFF) == 0xFF }
+        val codeCount = b.size - 1
+        val allUnwritten = codeCount >= 2 && (1 until b.size).all { (b[it].toInt() and 0xFF) == 0xFF }
+        // #1284: a PARTLY-written page fills front-to-back and leaves the TAIL as 0xFF pad, which the
+        // whole-record rule misses. Flag a TRAILING run of >= MIN_TRAILING_UNWRITTEN consecutive 0xFF code
+        // bytes (to the record's end) as unwritten too. Trailing-only + a run floor, on purpose: a
+        // leading/interior 0xFF run stays real wake (a pre-onset run is dropped by the assembler's onset
+        // clip), and a short trailing run is spared. Byte-parity twin of the Swift decodeSleepPhase.
+        var trailingFF = 0
+        var t = b.size - 1
+        while (t >= 1 && (b[t].toInt() and 0xFF) == 0xFF) { trailingFF++; t-- }
+        val trailingStart = if (trailingFF >= MIN_TRAILING_UNWRITTEN) codeCount - trailingFF else codeCount
         val out = ArrayList<OuraSleepPhase>()
         var index = 0
         for (k in 1 until b.size) {
             val byte = b[k]
+            val byteUnwritten = allUnwritten || (k - 1) >= trailingStart
             // MSB-first within the byte: [7:6] is the first code.
             var shift = 6
             while (shift >= 0) {
@@ -567,7 +583,7 @@ object OuraDecoders {
                     out.add(
                         OuraSleepPhase(
                             ringTimestamp = rec.ringTimestamp, index = index,
-                            stage = stage, unwritten = unwritten,
+                            stage = stage, unwritten = byteUnwritten,
                         ),
                     )
                     index += 1

--- a/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
+++ b/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
@@ -285,6 +285,34 @@ class DecoderGoldenTest {
     }
 
     @Test
+    fun testSleepPhase0x4ETrailingFFRunIsUnwritten() {
+        // #1284: the reporter's `hdr=01` record — `ff ff f3 c0` then nine straight 0xFF (13 code bytes). The
+        // 9-byte trailing pad is flagged unwritten; the leading `ff ff` stays real wake. PARITY twin of Swift.
+        val phases = OuraDecoders.decodeSleepPhase(record("4e120200010000fffff3c0ffffffffffffffffff"))
+        assertEquals(52, phases?.size)
+        assertEquals(36, phases!!.count { it.unwritten })
+        assertTrue(phases.take(16).none { it.unwritten })
+        assertTrue(phases.takeLast(36).all { it.unwritten })
+    }
+
+    @Test
+    fun testSleepPhase0x4ETrailingRunFloorIsExclusive() {
+        // Exactly MIN_TRAILING_UNWRITTEN trailing 0xFF flags; one fewer is spared. PARITY twin of Swift.
+        val atFloor = OuraDecoders.decodeSleepPhase(record("4e12020001000055555555555555ffffffffffff"))
+        assertEquals(OuraDecoders.MIN_TRAILING_UNWRITTEN * 4, atFloor!!.count { it.unwritten })
+        val belowFloor = OuraDecoders.decodeSleepPhase(record("4e1202000100005555555555555555ffffffffff"))
+        assertTrue(belowFloor!!.none { it.unwritten })
+    }
+
+    @Test
+    fun testSleepPhase0x4ELeadingFFRunIsRealWake() {
+        // Trailing-only: a long leading 0xFF run that does NOT reach the record's end stays real wake.
+        val phases = OuraDecoders.decodeSleepPhase(record("4e120200010000ffffffffffffffffff55555555"))
+        assertEquals(52, phases?.size)
+        assertTrue(phases!!.none { it.unwritten })
+    }
+
+    @Test
     fun testSleepStageRawValuesMatchOpenOura() {
         // Pin the validated open_oura order (0=deep, 1=light, 2=rem, 3=awake) so a regression to the
         // old unverified mapping (0=awake/2=deep/3=REM) breaks loudly. Twin of the Swift enum.


### PR DESCRIPTION
Two residuals from @pipiche38's measured hardware report (#1284), both validated by offline replay against the raw captures.

### 1. Trailing 0xFF pad in a partly-written page
#1246/#1251 flag a hypnogram page unwritten only when **every** code byte is 0xFF. A **partly**-written page fills front-to-back and leaves the **tail** as 0xFF pad, which still unpacks as run×4 epochs of fake `awake` — measured **~86–88 min/night**, pushing efficiency far below WHOOP's. This flags a **trailing run of ≥ 6 code bytes** (24 min) of consecutive 0xFF as unwritten too.

**Trailing-only + a run floor, on purpose** (the ambiguity pipiche named — a 0xFF run can be real wake): a leading/interior 0xFF run stays real wake (the ring wrote it; a genuinely pre-onset run is dropped by the assembler's onset clip), and a short trailing run is spared as possible end-of-page wake. Byte-identical **Swift + Android** `OuraDecoders` (same 6-byte floor), with tests both sides (the reporter's `hdr=01` record → 36 unwritten / 16 kept, the floor boundary, and a leading-only guard). **All existing #1246 tests preserved** (the 1–2-byte cases stay below the floor).

⚠️ **The floor is a starting value, tunable.** The measured pads ran 9–10 bytes; @pipiche38 — could you validate 6 against the full capture (does it recover the 86–88 min without eating real wake)? Easy one-line change to  on both platforms.

### 2. Log the #899 dedup sweep always
The heal only logged on a non-empty drop, so a heal that collapsed rows was indistinguishable from never running. Now always logs `Dedup(#899): swept N id(s), removed M …`, both platforms.

### Verification
- `OuraProtocol` `swift test` green (the decode is package-level → `swift-packages` CI); Android `testFullDebugUnitTest` green.
- The heal-log touches app-target Swift (`IntelligenceEngine.swift`, no default CI) → app-build gate.

Not in this PR (residual #3, duplicate *generation* / 0x49 keying): a bigger session-identity change, tracked separately.