### PR TITLE
iOS: Home Screen quick actions

### DIFF
--- a/StrandiOS/App/RootTabView.swift
+++ b/StrandiOS/App/RootTabView.swift
@@ -149,17 +149,17 @@ struct RootTabView: View {
         // Quick-action sheet presents with the calm easing (~0.42s) per the README sheet spec —
         // the easing is applied where `quickAction` is set (see `presentQuickAction`), keeping the
         // animation scoped to the sheet rather than the whole shell.
-        .sheet(item: $quickAction, onDismiss: presentPendingHomeScreenQuickActionIfPossible) { action in
+        .sheet(item: $quickAction) { action in
             quickActionDestination(action)
         }
         // Live's "Manage devices" affordance (and any future cross-screen link to Devices) routes here:
         // present the Devices manager in its own nav stack, the same way the quick-action screens do.
-        .sheet(isPresented: $showDevices, onDismiss: presentPendingHomeScreenQuickActionIfPossible) {
+        .sheet(isPresented: $showDevices) {
             devicesScreen
         }
         // v5 pillar deep-links (Insights hub / Lab Book / fused record / Rhythm) present as a sheet in
         // their own nav stack — the same idiom the quick-action + Devices screens use on iPhone.
-        .sheet(item: $routedPillar, onDismiss: presentPendingHomeScreenQuickActionIfPossible) { dest in
+        .sheet(item: $routedPillar) { dest in
             pillarScreen(dest)
         }
         // Honour a router request: Devices keeps its dedicated sheet; the v5 pillars route through the
@@ -216,13 +216,11 @@ struct RootTabView: View {
         }
     }
 
-    /// Presents only when the mandatory gates and any current shell modal are out of the way. Until then,
-    /// the scene delegate retains the action; each sheet's onDismiss and the readiness change retry it.
+    /// Mandatory launch gates defer an external action. Once the shell is available, an explicit Home
+    /// Screen choice supersedes any ordinary shell sheet; choosing the already-open destination simply
+    /// consumes the request and leaves that screen in place.
     private func presentPendingHomeScreenQuickActionIfPossible() {
         guard homeScreenQuickActionsEnabled,
-              quickAction == nil,
-              !showDevices,
-              routedPillar == nil,
               let action = homeScreenQuickActions.pendingAction else { return }
 
         let destination: QuickAction = switch action {
@@ -232,7 +230,11 @@ struct RootTabView: View {
         case .breathe: .breathe
         }
         homeScreenQuickActions.consume(action)
-        withAnimation(Self.sheetEase) { quickAction = destination }
+        withAnimation(Self.sheetEase) {
+            showDevices = false
+            routedPillar = nil
+            quickAction = destination
+        }
     }
 
     /// A routed v5 pillar screen wrapped in its own nav stack + Done button (mirrors `quickScreen`).

--- a/StrandiOS/App/RootTabView.swift
+++ b/StrandiOS/App/RootTabView.swift
@@ -10,6 +10,8 @@ struct RootTabView: View {
     /// Cross-screen navigation requests (e.g. Live → "Manage devices"). Devices isn't a tab — it lives
     /// behind the More list — so a request presents it as a sheet, matching the quick-action screens.
     @EnvironmentObject private var router: NavRouter
+    /// The scene-local receiver for actions chosen from NOOP's Home Screen icon menu.
+    @EnvironmentObject private var homeScreenQuickActions: HomeScreenQuickActionSceneDelegate
 
     /// Which quick-action screen the centre FAB is presenting (nil = sheet closed).
     @State private var quickAction: QuickAction?
@@ -197,6 +199,28 @@ struct RootTabView: View {
                 router.quickActionsRequested = false
             }
         }
+        // A cold-launch selection is already pending when this shell appears; a warm selection arrives
+        // through the change callback. Both route through the same screens as the centre FAB.
+        .onAppear {
+            if let action = homeScreenQuickActions.pendingAction {
+                presentHomeScreenQuickAction(action)
+            }
+        }
+        .onChange(of: homeScreenQuickActions.pendingAction) { _, action in
+            guard let action else { return }
+            presentHomeScreenQuickAction(action)
+        }
+    }
+
+    private func presentHomeScreenQuickAction(_ action: HomeScreenQuickAction) {
+        homeScreenQuickActions.consume(action)
+        let destination: QuickAction = switch action {
+        case .liveHeartRate: .live
+        case .startWorkout: .workout
+        case .logJournal: .journal
+        case .breathe: .breathe
+        }
+        withAnimation(Self.sheetEase) { quickAction = destination }
     }
 
     /// A routed v5 pillar screen wrapped in its own nav stack + Done button (mirrors `quickScreen`).

--- a/StrandiOS/App/RootTabView.swift
+++ b/StrandiOS/App/RootTabView.swift
@@ -6,6 +6,10 @@ import StrandDesign
 /// natural analogue is a `TabView` with the most-used screens as tabs and everything else under a
 /// "More" list. Every screen is the same `StrandDesign`-built view the macOS app uses.
 struct RootTabView: View {
+    /// External entry points must wait until the mandatory first-run gates have completed. The root owns
+    /// that state; keeping it explicit here prevents this shell's window-level sheet from covering a gate.
+    let homeScreenQuickActionsEnabled: Bool
+
     @EnvironmentObject private var repo: Repository
     /// Cross-screen navigation requests (e.g. Live → "Manage devices"). Devices isn't a tab — it lives
     /// behind the More list — so a request presents it as a sheet, matching the quick-action screens.
@@ -145,17 +149,17 @@ struct RootTabView: View {
         // Quick-action sheet presents with the calm easing (~0.42s) per the README sheet spec —
         // the easing is applied where `quickAction` is set (see `presentQuickAction`), keeping the
         // animation scoped to the sheet rather than the whole shell.
-        .sheet(item: $quickAction) { action in
+        .sheet(item: $quickAction, onDismiss: presentPendingHomeScreenQuickActionIfPossible) { action in
             quickActionDestination(action)
         }
         // Live's "Manage devices" affordance (and any future cross-screen link to Devices) routes here:
         // present the Devices manager in its own nav stack, the same way the quick-action screens do.
-        .sheet(isPresented: $showDevices) {
+        .sheet(isPresented: $showDevices, onDismiss: presentPendingHomeScreenQuickActionIfPossible) {
             devicesScreen
         }
         // v5 pillar deep-links (Insights hub / Lab Book / fused record / Rhythm) present as a sheet in
         // their own nav stack — the same idiom the quick-action + Devices screens use on iPhone.
-        .sheet(item: $routedPillar) { dest in
+        .sheet(item: $routedPillar, onDismiss: presentPendingHomeScreenQuickActionIfPossible) { dest in
             pillarScreen(dest)
         }
         // Honour a router request: Devices keeps its dedicated sheet; the v5 pillars route through the
@@ -202,24 +206,32 @@ struct RootTabView: View {
         // A cold-launch selection is already pending when this shell appears; a warm selection arrives
         // through the change callback. Both route through the same screens as the centre FAB.
         .onAppear {
-            if let action = homeScreenQuickActions.pendingAction {
-                presentHomeScreenQuickAction(action)
-            }
+            presentPendingHomeScreenQuickActionIfPossible()
         }
-        .onChange(of: homeScreenQuickActions.pendingAction) { _, action in
-            guard let action else { return }
-            presentHomeScreenQuickAction(action)
+        .onChange(of: homeScreenQuickActions.pendingAction) { _, _ in
+            presentPendingHomeScreenQuickActionIfPossible()
+        }
+        .onChange(of: homeScreenQuickActionsEnabled) { _, _ in
+            presentPendingHomeScreenQuickActionIfPossible()
         }
     }
 
-    private func presentHomeScreenQuickAction(_ action: HomeScreenQuickAction) {
-        homeScreenQuickActions.consume(action)
+    /// Presents only when the mandatory gates and any current shell modal are out of the way. Until then,
+    /// the scene delegate retains the action; each sheet's onDismiss and the readiness change retry it.
+    private func presentPendingHomeScreenQuickActionIfPossible() {
+        guard homeScreenQuickActionsEnabled,
+              quickAction == nil,
+              !showDevices,
+              routedPillar == nil,
+              let action = homeScreenQuickActions.pendingAction else { return }
+
         let destination: QuickAction = switch action {
         case .liveHeartRate: .live
         case .startWorkout: .workout
         case .logJournal: .journal
         case .breathe: .breathe
         }
+        homeScreenQuickActions.consume(action)
         withAnimation(Self.sheetEase) { quickAction = destination }
     }
 

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -14,6 +14,8 @@ import UserNotifications
 /// `RootTabView` so the iOS app keeps the same gating without depending on the macOS-only shell.
 @main
 struct StrandiOSApp: App {
+    /// UIKit bridge for Home Screen quick actions. SwiftUI keeps ownership of the scene and window.
+    @UIApplicationDelegateAdaptor(HomeScreenQuickActionAppDelegate.self) private var appDelegate
     @StateObject private var model: AppModel
     @StateObject private var health: HealthKitBridge
     /// The phone→watch link. Built + activated here so the watch app actually receives snapshots on a

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -274,6 +274,9 @@ private struct iOSRootView: View {
     @AppStorage("noop.lastSeenChangelogVersion") private var lastSeenChangelog = ""
     @AppStorage("noop.acceptedTermsVersion") private var acceptedTerms = ""
     @State private var showWhatsNew = false
+    /// Starts false so a cold-launch external action can't race this view's onAppear decision about the
+    /// automatic What's New sheet. It becomes true only when no sheet is due or its dismissal completes.
+    @State private var automaticLaunchSheetResolved = false
 
     var body: some View {
         #if DEBUG
@@ -297,7 +300,9 @@ private struct iOSRootView: View {
 
     private var shell: some View {
         ZStack {
-            RootTabView()
+            RootTabView(homeScreenQuickActionsEnabled:
+                demoBypass || (onboarded && acceptedTerms == Terms.currentVersion
+                    && automaticLaunchSheetResolved))
             if !onboarded && !demoBypass {
                 OnboardingWizard(onFinished: {
                     onboarded = true
@@ -318,7 +323,7 @@ private struct iOSRootView: View {
         }
         .animation(.easeInOut(duration: 0.35), value: onboarded)
         .animation(.easeInOut(duration: 0.35), value: acceptedTerms)
-        .sheet(isPresented: $showWhatsNew) {
+        .sheet(isPresented: $showWhatsNew, onDismiss: { automaticLaunchSheetResolved = true }) {
             WhatsNewView(onClose: {
                 lastSeenChangelog = AppChangelog.currentVersion
                 showWhatsNew = false
@@ -347,11 +352,17 @@ private struct iOSRootView: View {
     }
 
     private func showWhatsNewIfDue() {
-        if demoBypass { return }
+        if demoBypass {
+            automaticLaunchSheetResolved = true
+            return
+        }
         // Existing users who updated: their last-seen version is behind the current one.
         if onboarded && acceptedTerms == Terms.currentVersion
             && lastSeenChangelog != AppChangelog.currentVersion {
+            automaticLaunchSheetResolved = false
             showWhatsNew = true
+        } else {
+            automaticLaunchSheetResolved = true
         }
     }
 }

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -316,7 +316,12 @@ private struct iOSRootView: View {
             // Terms acknowledgment gate — over EVERYTHING (before onboarding/pairing/Bluetooth) until
             // the current terms version is accepted; re-appears if the terms materially change.
             if acceptedTerms != Terms.currentVersion && !demoBypass {
-                TermsGateView(onAccept: { acceptedTerms = Terms.currentVersion })
+                TermsGateView(onAccept: {
+                    // Keep any external action behind the gate while the accepted-terms change decides
+                    // whether What's New must present next. This write must precede acceptedTerms.
+                    automaticLaunchSheetResolved = false
+                    acceptedTerms = Terms.currentVersion
+                })
                     .transition(.opacity)
                     .zIndex(2)
             }

--- a/StrandiOS/System/HomeScreenQuickActions.swift
+++ b/StrandiOS/System/HomeScreenQuickActions.swift
@@ -5,8 +5,8 @@ import UIKit
 /// The app-specific actions shown when someone touches and holds NOOP's Home Screen icon.
 ///
 /// These are dynamic rather than Info.plist actions so their titles come from NOOP's existing
-/// localization catalog and follow the language selected in the app. The menu is installed at launch
-/// and refreshed as the app leaves the foreground.
+/// localization catalog and follow the language selected in the app. The menu is installed at launch;
+/// changing the app language requires the same process restart that updates every other localized bundle.
 enum HomeScreenQuickAction: String, CaseIterable {
     case liveHeartRate = "com.noop.quick-action.live-heart-rate"
     case startWorkout = "com.noop.quick-action.start-workout"
@@ -97,11 +97,6 @@ final class HomeScreenQuickActionSceneDelegate: NSObject, UIWindowSceneDelegate,
         if let shortcutItem = connectionOptions.shortcutItem {
             pendingAction = HomeScreenQuickAction(shortcutItem: shortcutItem)
         }
-    }
-
-    func sceneWillResignActive(_ scene: UIScene) {
-        // Refresh the titles after an in-app language change before the Home Screen menu can appear.
-        HomeScreenQuickAction.install()
     }
 
     func windowScene(

--- a/StrandiOS/System/HomeScreenQuickActions.swift
+++ b/StrandiOS/System/HomeScreenQuickActions.swift
@@ -1,0 +1,123 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+/// The app-specific actions shown when someone touches and holds NOOP's Home Screen icon.
+///
+/// These are dynamic rather than Info.plist actions so their titles come from NOOP's existing
+/// localization catalog and follow the language selected in the app. The menu is installed at launch
+/// and refreshed as the app leaves the foreground.
+enum HomeScreenQuickAction: String, CaseIterable {
+    case liveHeartRate = "com.noop.quick-action.live-heart-rate"
+    case startWorkout = "com.noop.quick-action.start-workout"
+    case logJournal = "com.noop.quick-action.log-journal"
+    case breathe = "com.noop.quick-action.breathe"
+
+    init?(shortcutItem: UIApplicationShortcutItem) {
+        self.init(rawValue: shortcutItem.type)
+    }
+
+    private var localizedTitle: String {
+        switch self {
+        case .liveHeartRate: String(localized: "Live HR")
+        case .startWorkout: String(localized: "Start workout")
+        case .logJournal: String(localized: "Log journal")
+        case .breathe: String(localized: "Breathe")
+        }
+    }
+
+    private var symbolName: String {
+        switch self {
+        case .liveHeartRate: "waveform.path.ecg"
+        case .startWorkout: "figure.run"
+        case .logJournal: "square.and.pencil"
+        case .breathe: "wind"
+        }
+    }
+
+    private var shortcutItem: UIApplicationShortcutItem {
+        UIApplicationShortcutItem(
+            type: rawValue,
+            localizedTitle: localizedTitle,
+            localizedSubtitle: nil,
+            icon: UIApplicationShortcutIcon(systemImageName: symbolName),
+            userInfo: nil
+        )
+    }
+
+    @MainActor
+    static func install(in application: UIApplication) {
+        application.shortcutItems = allCases.map(\.shortcutItem)
+    }
+
+    @MainActor
+    static func install() {
+        install(in: UIApplication.shared)
+    }
+}
+
+/// Adds UIKit's scene callback to the SwiftUI app lifecycle. SwiftUI continues to create and own the
+/// window; this delegate only names the scene delegate that receives Home Screen quick actions.
+final class HomeScreenQuickActionAppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        HomeScreenQuickAction.install(in: application)
+        return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        let configuration = UISceneConfiguration(
+            name: nil,
+            sessionRole: connectingSceneSession.role
+        )
+        if connectingSceneSession.role == .windowApplication {
+            configuration.delegateClass = HomeScreenQuickActionSceneDelegate.self
+        }
+        return configuration
+    }
+}
+
+/// Receives a selected icon action whether it created a new scene or resumed an existing one. SwiftUI
+/// automatically places an observable scene delegate in the environment for the scene it manages.
+@MainActor
+final class HomeScreenQuickActionSceneDelegate: NSObject, UIWindowSceneDelegate, ObservableObject {
+    @Published private(set) var pendingAction: HomeScreenQuickAction?
+
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        if let shortcutItem = connectionOptions.shortcutItem {
+            pendingAction = HomeScreenQuickAction(shortcutItem: shortcutItem)
+        }
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Refresh the titles after an in-app language change before the Home Screen menu can appear.
+        HomeScreenQuickAction.install()
+    }
+
+    func windowScene(
+        _ windowScene: UIWindowScene,
+        performActionFor shortcutItem: UIApplicationShortcutItem
+    ) async -> Bool {
+        guard let action = HomeScreenQuickAction(shortcutItem: shortcutItem) else { return false }
+        pendingAction = action
+        return true
+    }
+
+    /// Clears only the action the shell is about to present, protecting a newer selection from an old
+    /// subscriber callback if two lifecycle events arrive close together.
+    func consume(_ action: HomeScreenQuickAction) {
+        guard pendingAction == action else { return }
+        pendingAction = nil
+    }
+}
+#endif

--- a/StrandiOS/System/HomeScreenQuickActions.swift
+++ b/StrandiOS/System/HomeScreenQuickActions.swift
@@ -49,7 +49,6 @@ enum HomeScreenQuickAction: String, CaseIterable {
     static func install(in application: UIApplication) {
         application.shortcutItems = allCases.map(\.shortcutItem)
     }
-
 }
 
 /// Adds UIKit's scene callback to the SwiftUI app lifecycle. SwiftUI continues to create and own the

--- a/StrandiOS/System/HomeScreenQuickActions.swift
+++ b/StrandiOS/System/HomeScreenQuickActions.swift
@@ -50,10 +50,6 @@ enum HomeScreenQuickAction: String, CaseIterable {
         application.shortcutItems = allCases.map(\.shortcutItem)
     }
 
-    @MainActor
-    static func install() {
-        install(in: UIApplication.shared)
-    }
 }
 
 /// Adds UIKit's scene callback to the SwiftUI app lifecycle. SwiftUI continues to create and own the


### PR DESCRIPTION
Adds Home Screen quick actions to the iOS app: touch and hold NOOP's icon for Live HR, Start workout, Log journal, and Breathe. Each opens the same screen the centre FAB already routes to.

## What's here

- `StrandiOS/System/HomeScreenQuickActions.swift` — the four actions, a `UIApplicationDelegate` that installs them at launch, and a `UIWindowSceneDelegate` that receives the selection on both cold launch (`scene(_:willConnectTo:)`) and warm resume (`windowScene(_:performActionFor:)`). SwiftUI keeps ownership of the scene and window; the delegate only publishes the pending action.
- The items are dynamic rather than Info.plist entries so their titles come from the existing string catalog (all four strings already exist — they're the FAB's labels). Changing the app language takes effect on the next launch, the same restart every other localized string needs.
- `RootTabView` presents the pending action through the existing quick-action sheet.

## Behaviour worth reviewing

- **Mandatory launch gates win.** Onboarding, the Terms gate, and the automatic What's New sheet are layered over `RootTabView` in a ZStack, but a sheet presents at window level and would cover them. `homeScreenQuickActionsEnabled` holds the action in the scene delegate until those are resolved, then presents it. The Terms `onAccept` clears the resolved flag before writing `acceptedTerms` so the two state changes can't race in the same update.
- **An ordinary shell sheet loses.** A Home Screen choice is explicit, so it supersedes an open Devices or pillar sheet, clearing that state as it presents (leaving it set would re-present the old sheet on dismiss). Choosing the destination that's already open just consumes the request.

## Verification

`app-build.yml` is disabled, so the iOS target was compiled locally rather than by CI: `xcodebuild -scheme NOOPiOS -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build` succeeds on this branch, rebased on current main.

Exercised on the iPhone 17 Pro simulator:
- all four items appear in the icon menu with the right titles and symbols;
- warm selection opens the correct screen; selecting a different action while a quick-action sheet is open swaps it;
- with the Devices sheet open, selecting Breathe replaces it, and one tap on Done returns to Live with no stale sheet reappearing.

No BLE or analytics paths are touched.

## Not included

No Android counterpart yet — Android app shortcuts are the direct analogue and would be a separate change.
