### PR TITLE
oura(sleep): log the duplicate-session generation moment (#1284 residual 3)

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -503,8 +503,13 @@ public enum OuraDecoders {
         // real wake (the ring wrote it; a genuinely pre-onset run is dropped separately by the assembler's
         // onset clip), and a short trailing run is spared as possible real end-of-page wake. `minTrailing`
         // is the tunable safety margin between "padding" and "a long real wake block at a page boundary".
+        // The floor is clamped to >= 2: a LONE trailing 0xFF is four genuine awake epochs (the #1246 case),
+        // and the whole-record rule above only fires at codeCount >= 2 — the trailing rule must never undercut
+        // that even if `minTrailingUnwritten` is lowered by someone who hasn't read #1284. So the constant is
+        // freely tunable upward, but can never drop low enough to eat a single real-wake byte.
+        let effectiveFloor = max(2, Self.minTrailingUnwritten)
         let trailingFF = codeBytes.reversed().prefix { $0 == 0xFF }.count
-        let trailingStart = trailingFF >= Self.minTrailingUnwritten ? codeCount - trailingFF : codeCount
+        let trailingStart = trailingFF >= effectiveFloor ? codeCount - trailingFF : codeCount
         var out: [OuraSleepPhase] = []
         var index = 0
         for k in 1..<b.count {

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
@@ -272,6 +272,19 @@ final class DecoderGoldenTests: XCTestCase {
         XCTAssertEqual(OuraDecoders.decodeSleepPhase(belowFloor)?.contains { $0.unwritten }, false)
     }
 
+    func testSleepPhase0x4ETrailingSingleFFIsGenuineAwake() {
+        // #1284/#1246 boundary: a written record ending in a SINGLE trailing 0xFF is four genuine awake epochs,
+        // never pad. The trailing floor is clamped to >= 2, so this holds even if `minTrailingUnwritten` is
+        // lowered — a lone trailing byte can never be eaten (the case #1246 was careful to protect). Kotlin twin.
+        XCTAssertGreaterThanOrEqual(OuraDecoders.minTrailingUnwritten, 2,
+                                    "floor < 2 would eat a lone trailing 0xFF (#1246); the decode clamps to 2 as a backstop")
+        let rec = record("4e120200010000555555555555555555555555ff")   // 12 real codes + 1 trailing 0xFF
+        let phases = OuraDecoders.decodeSleepPhase(rec)
+        XCTAssertEqual(phases?.count, 52)
+        XCTAssertEqual(phases?.contains { $0.unwritten }, false)                    // nothing flagged unwritten
+        XCTAssertEqual(phases?.suffix(4).allSatisfy { $0.stage == .awake }, true)   // the lone 0xFF stays real wake
+    }
+
     func testSleepPhase0x4ELeadingFFRunIsRealWake() {
         // Trailing-only, by design: a LONG leading/interior 0xFF run (nine here) that does NOT reach the
         // record's end is left as genuine wake — the ring wrote it, and a pre-onset run is dropped by the

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -770,6 +770,16 @@ public enum SleepStager {
     /// bare "asleep".
     static let bandVetoRecoverStage: String = "light"
 
+    /// #1210: a TRACE-ONLY line reporting what the (dormant) band wake-veto WOULD recover on a banded night,
+    /// so a validator gathers the recovered-minutes distribution across real nights without any output change
+    /// (the persisted hypnogram stays the flag-gated, unchanged one). Namespaced `bandVeto(shadow):` and free
+    /// of a `day=` / `t=…s` token so `CaptureAccumulator` never counts it as a captured day. Mirrors Kotlin
+    /// `bandVetoShadowLine`. (band sleep_state veto)
+    static func bandVetoShadowLine(startTs: Int, recoveredMin: Double, rawEff: Double, shadowEff: Double) -> String {
+        "bandVeto(shadow): startTs=\(startTs) recoveredMin=\(Int(recoveredMin.rounded())) "
+            + "eff \(Int((rawEff * 100).rounded()))%->\(Int((shadowEff * 100).rounded()))%"
+    }
+
     /// Band sleep_state WAKE-veto. Given a staged hypnogram `stages` (StageSegments tiling `[start, end]`)
     /// and the strap's OWN per-timestamp band sleep_state, reclassify INTERIOR wake epochs the strap itself
     /// scored "asleep" (`bandStateAsleep`) to `bandVetoRecoverStage`. Conservative by construction:
@@ -1169,6 +1179,21 @@ public enum SleepStager {
             traceSink?(GateTrace.runLine(index: runIndex, startTs: p.start, endTs: p.end,
                 verdict: .kept, gate: "accepted",
                 detail: "spanMin=\(spanMin) eff=\(round2(eff)) restingHR=\(resting ?? -1) daytime=\(isDaytime)"))
+            // #1210 shadow: the band wake-veto is dormant (default-off), but its recovered-vs-reverse ratio
+            // can only come from banded nights. When a band stream is present, compute what the veto WOULD
+            // recover and trace it — OUTPUT-NEUTRAL: `stages`/`eff` persisted above are the flag-gated
+            // (unchanged) values and nothing reads `shadowStages`. Guarded on `traceSink`, so it fires ONLY
+            // while a diagnostic is collecting (zero production cost). Retire once the flip (#1210) lands.
+            if let traceSink, !bandStateWakeVetoEnabled, !bandSleepState.isEmpty {
+                let shadowStages = applyBandStateWakeVeto(rawStages, start: p.start, end: p.end,
+                                                          bandSleepState: bandSleepState, enabled: true)
+                let shadowEff = efficiency(start: p.start, end: p.end, stages: shadowStages)
+                let recoveredMin = (shadowEff - eff) * Double(p.end - p.start) / 60.0
+                if recoveredMin >= 1.0 {
+                    traceSink(bandVetoShadowLine(startTs: p.start, recoveredMin: recoveredMin,
+                                                 rawEff: eff, shadowEff: shadowEff))
+                }
+            }
             // A run that does NOT continue the chain re-anchors it on this run's onset.
             if !continuesChain { chainFromOvernight = isOvernightOnset(p.start, tzOffsetSeconds: tzOffsetSeconds) }
             chainPrevEnd = p.end

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -763,6 +763,14 @@ public enum SleepStager {
     /// explicitly). An absent band stream (WHOOP 4.0 / unbanded window) is a no-op regardless.
     public static let bandStateWakeVetoEnabled: Bool = false
 
+    /// #1210 item 2 (retroactive-rescore story): the new-nights-only cutoff. When the veto is flipped on
+    /// (`bandStateWakeVetoEnabled = true`), a NON-ZERO cutoff (a unix second) restricts the correction to
+    /// sessions whose `start >= cutoffTs` — nights already in history keep their raw efficiency, so flipping
+    /// the default cannot silently re-score months of banked nights upward. `0` (the default) applies the
+    /// veto to every banded night (the "just ship the one-time shift" path). Inert while the flag is off.
+    /// Set this to the flip date at the same time as the flag. Mirrors Kotlin `bandStateWakeVetoCutoffTs`.
+    public static let bandStateWakeVetoCutoffTs: Int = 0
+
     /// The sleep stage a band-vetoed false-wake epoch is reclassified to. `bandStateAsleep` (band sleep_state == 2) means
     /// only "asleep" — the band carries NO light/deep/REM resolution — so the veto maps it to the generic,
     /// most-common sleep stage rather than inventing deep/REM detail the strap never asserted (deep/REM
@@ -796,10 +804,14 @@ public enum SleepStager {
     /// (band sleep_state veto)
     static func applyBandStateWakeVeto(_ stages: [StageSegment], start: Int, end: Int,
                                        bandSleepState: [(ts: Int, state: Int)],
-                                       enabled: Bool = bandStateWakeVetoEnabled) -> [StageSegment] {
+                                       enabled: Bool = bandStateWakeVetoEnabled,
+                                       cutoffTs: Int = bandStateWakeVetoCutoffTs) -> [StageSegment] {
         guard enabled, !bandSleepState.isEmpty, !stages.isEmpty, end > start else {
             return stages
         }
+        // #1210 item 2: new-nights-only gate. A non-zero cutoff spares nights that started before it (history
+        // keeps its raw efficiency); `0` applies to every banded night. Inert while the flag is off.
+        if cutoffTs > 0, start < cutoffTs { return stages }
         // Per-epoch band on the 30 s stagesJSON grid — byte-identical to the persisted sleepStateJSON.
         let states = sessionEpochSleepState(start: start, end: end, sleepState: bandSleepState)
         if states.isEmpty { return stages }
@@ -1185,8 +1197,12 @@ public enum SleepStager {
             // (unchanged) values and nothing reads `shadowStages`. Guarded on `traceSink`, so it fires ONLY
             // while a diagnostic is collecting (zero production cost). Retire once the flip (#1210) lands.
             if let traceSink, !bandStateWakeVetoEnabled, !bandSleepState.isEmpty {
+                // `cutoffTs: 0` on purpose: the shadow measures the FULL veto potential across EVERY banded
+                // night (history included) to build the validation distribution, independent of whatever
+                // new-nights cutoff the eventual flip uses.
                 let shadowStages = applyBandStateWakeVeto(rawStages, start: p.start, end: p.end,
-                                                          bandSleepState: bandSleepState, enabled: true)
+                                                          bandSleepState: bandSleepState,
+                                                          enabled: true, cutoffTs: 0)
                 let shadowEff = efficiency(start: p.start, end: p.end, stages: shadowStages)
                 let recoveredMin = (shadowEff - eff) * Double(p.end - p.start) / 60.0
                 if recoveredMin >= 1.0 {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerTests.swift
@@ -1215,6 +1215,25 @@ final class SleepStagerTests: XCTestCase {
                       "a banded night with interior false-wake emits a shadow line")
     }
 
+    func testBandVetoCutoffSparesNightsBeforeCutoff() {
+        // #1210 item 2: with the veto ON, a non-zero cutoff spares a night that STARTED before it (history
+        // keeps its raw hypnogram) and applies to one starting at/after it. Boundary is inclusive. Kotlin twin.
+        let base = 1_000_000
+        let fixture = vetoHypnoFixture().map {
+            StageSegment(start: $0.start + base, end: $0.end + base, stage: $0.stage)
+        }
+        let band = bandAllAsleep(start: base, end: base + 960)
+        let recovered = SleepStager.applyBandStateWakeVeto(fixture, start: base, end: base + 960,
+                                                           bandSleepState: band, enabled: true, cutoffTs: 0)
+        XCTAssertNotEqual(recovered, fixture, "sanity: the veto does change this fixture")
+        XCTAssertEqual(SleepStager.applyBandStateWakeVeto(fixture, start: base, end: base + 960,
+                                                          bandSleepState: band, enabled: true, cutoffTs: base + 1),
+                       fixture, "a night starting before the cutoff keeps its raw hypnogram")
+        XCTAssertEqual(SleepStager.applyBandStateWakeVeto(fixture, start: base, end: base + 960,
+                                                          bandSleepState: band, enabled: true, cutoffTs: base),
+                       recovered, "a night starting at/after the cutoff (inclusive) gets the veto")
+    }
+
     // MARK: - REM-funnel diagnostic (#688)
 
     /// A still, REM-eligible epoch (still + cardiac-activated + irregular resp). The percentile

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerTests.swift
@@ -1181,6 +1181,40 @@ final class SleepStagerTests: XCTestCase {
                        "default-off: efficiency is untouched by the band stream")
     }
 
+    func testBandVetoShadowLineIsNamespacedAndUncounted() {
+        // #1210 shadow: the validation line formats the recovered delta and is NEVER miscounted as a captured
+        // sleep day (carries no `sleep day=` / `gate run=` / `day=` token). Byte-identical format to Kotlin.
+        let line = SleepStager.bandVetoShadowLine(startTs: 1_723_000_000, recoveredMin: 31.4,
+                                                  rawEff: 0.742, shadowEff: 0.808)
+        XCTAssertEqual(line, "bandVeto(shadow): startTs=1723000000 recoveredMin=31 eff 74%->81%")
+        XCTAssertEqual(CaptureAccumulator.capturedDays(domain: .sleep, reportText: line, tzOffsetSeconds: 0), 0,
+                       "shadow line must not be counted as a captured sleep day")
+    }
+
+    func testBandVetoShadowTraceReportsRecoveryOutputNeutral() {
+        // #1210 shadow: veto DORMANT (default-off) + a band present + a collecting traceSink -> a
+        // `bandVeto(shadow):` line quantifying what the veto WOULD recover, WITHOUT changing the persisted
+        // hypnogram (detectSleep's documented trace contract). Same burst fixture as the default-off wiring
+        // test. (The line reports MAGNITUDE only; whether the move is toward truth needs the PSG harness.)
+        let start = nightStart(2)
+        let dur = 6 * 3600
+        var grav = stillGravity(start: start, durationS: dur)
+        var hr = hrStream(start: start, durationS: dur, bpm: 50)
+        for i in (3 * 3600)..<(3 * 3600 + 5 * 60) {   // interior 5-min burst -> false wake
+            grav[i] = GravitySample(ts: start + i, x: Double(i % 2) * 0.5, y: 0, z: 1.0)
+            hr[i] = HRSample(ts: start + i, bpm: 95)
+        }
+        let band = bandAllAsleep(start: start, end: start + dur)
+        let untraced = SleepStager.detectSleep(hr: hr, gravity: grav, bandSleepState: band)
+        var lines: [String] = []
+        let traced = SleepStager.detectSleep(hr: hr, gravity: grav, bandSleepState: band,
+                                             traceSink: { lines.append($0) })
+        XCTAssertEqual(traced[0].stages, untraced[0].stages,
+                       "shadow trace must not change the persisted hypnogram")
+        XCTAssertTrue(lines.contains { $0.hasPrefix("bandVeto(shadow):") && $0.contains("recoveredMin=") },
+                      "a banded night with interior false-wake emits a shadow line")
+    }
+
     // MARK: - REM-funnel diagnostic (#688)
 
     /// A still, REM-eligible epoch (still + cardiac-activated + irregular resp). The percentile

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -250,6 +250,15 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     private var recentSleepWindows049: [(ringTimestamp: UInt32, startOffMin: Int, endOffMin: Int)] = []
     private static let recentSleepWindows049Cap = 16
 
+    /// #1284 residual 3 (duplicate-generation diagnostic): the [start, end] window of each sleep session
+    /// banked THIS connection. The session PK is (deviceId, startTs) and the burst end moves with the 0x49
+    /// drain, so an early partial drain can bank a short session that a later full burst then nests inside,
+    /// minting a second row that the #899 heal only cleans up afterward. Comparing each new persist against
+    /// this list surfaces the GENERATION in the strap log. Diagnostic only; nothing is skipped. Bounded;
+    /// reset per session with the 0x49 windows. Twin of Kotlin's recentPersistedSessionWindows.
+    private var recentPersistedSessionWindows: [(start: Int, end: Int)] = []
+    private static let recentPersistedSessionsCap = 16
+
     // MARK: - Activity (0x50 MET) estimate accumulation — INVESTIGATION ONLY
     // Aggregate the decoded 0x50 MET stream into an honest, clearly-labeled per-day estimate
     // (OuraActivityEstimator) logged at drain-end, for eyeballing against WHOOP active minutes / Apple
@@ -786,6 +795,21 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         // Reuses the anchored+0x49-refined `end` via `laid`, so the session end IS the true sleep end. The
         // confirmation line makes the persist self-evident in the strap log for on-device validation.
         if let session = OuraSleepSessionMapping.session(fromCodes: laid.map { (ts: $0.ts, stage: $0.phase.stage) }) {
+            let start = laid.first!.ts
+            // #1284 residual 3: log when this persist lands wholly inside — or overlapping — a session already
+            // banked this connection (the duplicate GENERATION an early partial drain creates, which the #899
+            // heal only cleans up afterward). `sleepStart != nil` = a 0x49 anchor was applied; a persist with
+            // NO anchor is the prime suspect for the short nested row. Diagnostic only — nothing is skipped
+            // here; the fix is 0x49-window session keying (hardware-gated). Twin of Kotlin's.
+            if let prior = recentPersistedSessionWindows.first(where: { start < $0.end && end > $0.start }) {
+                let nested = start >= prior.start && end <= prior.end
+                let anchor = sleepStart != nil ? "0x49 anchor applied (onset=\(sleepStart!))" : "NO 0x49 anchor (write-envelope end)"
+                log("Oura: duplicate-gen(#1284) new session [\(start) → \(end)] \(nested ? "NESTED IN" : "OVERLAPS") already-banked [\(prior.start) → \(prior.end)] this connection - \(anchor); PK=(deviceId,startTs) mints a 2nd row")
+            }
+            recentPersistedSessionWindows.append((start: start, end: end))
+            if recentPersistedSessionWindows.count > Self.recentPersistedSessionsCap {
+                recentPersistedSessionWindows.removeFirst(recentPersistedSessionWindows.count - Self.recentPersistedSessionsCap)
+            }
             persistSleepSession(session)
             let effStr = session.efficiency.map { String(format: "%.0f%%", $0 * 100) } ?? "n/a"
             log("Oura: sleep session persisted [\(startStr) → \(endStr)] eff=\(effStr) → \(deviceId) (ring-provided night; wins merge over computed)")
@@ -1035,6 +1059,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         greenIbiAmpCount = 0
         greenIbiAmpLengths.removeAll()
         recentSleepWindows049.removeAll()
+        recentPersistedSessionWindows.removeAll()
         activityMETByDay.removeAll()
         activityCadenceObs.removeAll()
         lastActivityUtc = nil
@@ -1834,6 +1859,7 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
         greenIbiAmpCount = 0
         greenIbiAmpLengths.removeAll()
         recentSleepWindows049.removeAll()
+        recentPersistedSessionWindows.removeAll()
         pendingAnchorEvents.removeAll()   // a fresh session must never replay a stale-anchor guess
         hypnogramAssembler.reset()        // ditto for a half-accumulated burst from a dead session
         pendingUnanchoredBursts.removeAll()
@@ -1918,6 +1944,7 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
         greenIbiAmpCount = 0
         greenIbiAmpLengths.removeAll()
         recentSleepWindows049.removeAll()
+        recentPersistedSessionWindows.removeAll()
         activityMETByDay.removeAll()
         activityCadenceObs.removeAll()
         lastActivityUtc = nil

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -812,7 +812,11 @@ public final class OuraLiveSource: NSObject, ObservableObject {
             }
             persistSleepSession(session)
             let effStr = session.efficiency.map { String(format: "%.0f%%", $0 * 100) } ?? "n/a"
-            log("Oura: sleep session persisted [\(startStr) → \(endStr)] eff=\(effStr) → \(deviceId) (ring-provided night; wins merge over computed)")
+            // #1284 residual 3: stamp the 0x49 anchor state on EVERY persist, so an unanchored early-drain row
+            // (the prime suspect for the short nested duplicate) is self-evident even when it is the FIRST
+            // persist, before the duplicate-gen line above can fire.
+            let anchorTag = sleepStart != nil ? "0x49-anchored" : "NO-0x49-anchor"
+            log("Oura: sleep session persisted [\(startStr) → \(endStr)] eff=\(effStr) [\(anchorTag)] → \(deviceId) (ring-provided night; wins merge over computed)")
         }
     }
 

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -803,7 +803,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
             // here; the fix is 0x49-window session keying (hardware-gated). Twin of Kotlin's.
             if let prior = recentPersistedSessionWindows.first(where: { start < $0.end && end > $0.start }) {
                 let nested = start >= prior.start && end <= prior.end
-                let anchor = sleepStart != nil ? "0x49 anchor applied (onset=\(sleepStart!))" : "NO 0x49 anchor (write-envelope end)"
+                let anchor = sleepStart != nil ? "0x49 onset=\(sleepStart!)" : "no 0x49 onset (start derived from burst end)"
                 log("Oura: duplicate-gen(#1284) new session [\(start) → \(end)] \(nested ? "NESTED IN" : "OVERLAPS") already-banked [\(prior.start) → \(prior.end)] this connection - \(anchor); PK=(deviceId,startTs) mints a 2nd row")
             }
             recentPersistedSessionWindows.append((start: start, end: end))
@@ -815,7 +815,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
             // #1284 residual 3: stamp the 0x49 anchor state on EVERY persist, so an unanchored early-drain row
             // (the prime suspect for the short nested duplicate) is self-evident even when it is the FIRST
             // persist, before the duplicate-gen line above can fire.
-            let anchorTag = sleepStart != nil ? "0x49-anchored" : "NO-0x49-anchor"
+            let anchorTag = sleepStart != nil ? "0x49-onset" : "no-0x49-onset"
             log("Oura: sleep session persisted [\(startStr) → \(endStr)] eff=\(effStr) [\(anchorTag)] → \(deviceId) (ring-provided night; wins merge over computed)")
         }
     }

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -164,6 +164,14 @@ object SleepStager {
      *  Mirrors Swift `bandStateWakeVetoEnabled`. (band sleep_state veto) */
     const val bandStateWakeVetoEnabled: Boolean = false
 
+    /** #1210 item 2 (retroactive-rescore story): the new-nights-only cutoff. When the veto is flipped on
+     *  ([bandStateWakeVetoEnabled] = true), a NON-ZERO cutoff (a unix second) restricts the correction to
+     *  sessions whose `start >= cutoffTs` — nights already in history keep their raw efficiency, so flipping
+     *  the default cannot silently re-score months of banked nights upward. `0` (the default) applies the veto
+     *  to every banded night (the "just ship the one-time shift" path). Inert while the flag is off. Set this
+     *  to the flip date at the same time as the flag. Byte-identical to Swift `bandStateWakeVetoCutoffTs`. */
+    const val bandStateWakeVetoCutoffTs: Long = 0L
+
     /** The sleep stage a band-vetoed false-wake epoch is reclassified to. [bandStateAsleep] (band sleep_state == 2) means
      *  only "asleep" — the band carries NO light/deep/REM resolution — so the veto maps it to the generic,
      *  most-common sleep stage rather than inventing deep/REM detail the strap never asserted (deep/REM
@@ -844,10 +852,14 @@ object SleepStager {
         stages: List<StageSegment>, start: Long, end: Long,
         bandSleepState: List<Pair<Long, Int>>,
         enabled: Boolean = bandStateWakeVetoEnabled,
+        cutoffTs: Long = bandStateWakeVetoCutoffTs,
     ): List<StageSegment> {
         if (!enabled || bandSleepState.isEmpty() || stages.isEmpty() || end <= start) {
             return stages
         }
+        // #1210 item 2: new-nights-only gate. A non-zero cutoff spares nights that started before it (history
+        // keeps its raw efficiency); `0` applies to every banded night. Inert while the flag is off.
+        if (cutoffTs > 0L && start < cutoffTs) return stages
         // Per-epoch band on the 30 s stagesJSON grid — byte-identical to the persisted sleepStateJSON.
         val states = sessionEpochSleepState(start, end, bandSleepState)
         if (states.isEmpty()) return stages
@@ -1268,8 +1280,11 @@ object SleepStager {
             // (unchanged) values and nothing reads `shadowStages`. Guarded on `traceSink`, so it fires ONLY
             // while a diagnostic is collecting (zero production cost). Retire once the flip (#1210) lands.
             if (traceSink != null && !bandStateWakeVetoEnabled && bandSleepState.isNotEmpty()) {
+                // cutoffTs = 0 on purpose: the shadow measures the FULL veto potential across EVERY banded
+                // night (history included) to build the validation distribution, independent of whatever
+                // new-nights cutoff the eventual flip uses.
                 val shadowStages = applyBandStateWakeVeto(rawStages, start = p.start, end = p.end,
-                    bandSleepState = bandSleepState, enabled = true)
+                    bandSleepState = bandSleepState, enabled = true, cutoffTs = 0L)
                 val shadowEff = efficiency(start = p.start, end = p.end, stages = shadowStages)
                 val recoveredMin = (shadowEff - eff) * (p.end - p.start).toDouble() / 60.0
                 if (recoveredMin >= 1.0) {

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -157,11 +157,14 @@ object SleepStager {
      *  this conservative. Mirrors Swift `morningReonsetBandAsleepFrac`. (H8 consume) */
     const val morningReonsetBandAsleepFrac: Double = 0.6
 
-    /** Default-ON gate for the band sleep_state WAKE-veto. Flip to false to fall back to the byte-identical
-     *  pre-veto hypnogram. [bandStateAsleep] is WHOOP's OWN banked verdict (not a signal we re-derive), which
-     *  is why vetoing false-wakes with it is well-founded; it stays a single flip-point + fully tested. An
-     *  absent band stream (WHOOP 4.0 / unbanded window) makes the veto a no-op regardless of this flag.
-     *  Mirrors Swift `bandStateWakeVetoEnabled`. (band sleep_state veto) */
+    /** Default-OFF gate for the band sleep_state WAKE-veto (the SHIPPED state; the pre-veto hypnogram is what
+     *  users see). [bandStateAsleep] is WHOOP's OWN banked verdict (not a signal we re-derive), so vetoing
+     *  false-wakes with it is well-founded on the n=12 that motivated it — but the PSG harness measures the
+     *  recipe UNDER-calling wake overall (bias -4.92 pp), so a veto that converts wake->light moves the
+     *  population result AWAY from truth. Flip to true only with PSG evidence in hand (see #1210), and set
+     *  [bandStateWakeVetoCutoffTs] alongside to spare history. It stays a single flip-point + fully tested
+     *  (tests pass `enabled = true` explicitly). An absent band stream (WHOOP 4.0 / unbanded window) makes the
+     *  veto a no-op regardless of this flag. Mirrors Swift `bandStateWakeVetoEnabled`. (band sleep_state veto) */
     const val bandStateWakeVetoEnabled: Boolean = false
 
     /** #1210 item 2 (retroactive-rescore story): the new-nights-only cutoff. When the veto is flipped on

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -171,6 +171,15 @@ object SleepStager {
      *  bare "asleep". Mirrors Swift `bandVetoRecoverStage`. (band sleep_state veto) */
     const val bandVetoRecoverStage: String = "light"
 
+    /** #1210: a TRACE-ONLY line reporting what the (dormant) band wake-veto WOULD recover on a banded night,
+     *  so a validator gathers the recovered-minutes distribution across real nights without any output change
+     *  (the persisted hypnogram stays the flag-gated, unchanged one). Namespaced `bandVeto(shadow):` and free
+     *  of a `day=` / `t=…s` token so `CaptureAccumulator` never counts it as a captured day. Byte-identical to
+     *  Swift `bandVetoShadowLine`. (band sleep_state veto) */
+    internal fun bandVetoShadowLine(startTs: Long, recoveredMin: Double, rawEff: Double, shadowEff: Double): String =
+        "bandVeto(shadow): startTs=$startTs recoveredMin=${Math.round(recoveredMin)} " +
+            "eff ${Math.round(rawEff * 100)}%->${Math.round(shadowEff * 100)}%"
+
     /** Seconds in a calendar day (for local-hour-of-day arithmetic). */
     const val secondsPerDay: Long = 86_400L
 
@@ -1253,6 +1262,21 @@ object SleepStager {
             traceSink?.invoke(SleepStagerTrace.runLine(runIndex, p.start, p.end,
                 SleepStagerTrace.Verdict.KEPT, "accepted",
                 "spanMin=$spanMin eff=${SleepStagerTrace.round2(eff)} restingHR=${resting ?: -1} daytime=$isDaytime"))
+            // #1210 shadow: the band wake-veto is dormant (default-off), but its recovered-vs-reverse ratio
+            // can only come from banded nights. When a band stream is present, compute what the veto WOULD
+            // recover and trace it — OUTPUT-NEUTRAL: `stages`/`eff` persisted above are the flag-gated
+            // (unchanged) values and nothing reads `shadowStages`. Guarded on `traceSink`, so it fires ONLY
+            // while a diagnostic is collecting (zero production cost). Retire once the flip (#1210) lands.
+            if (traceSink != null && !bandStateWakeVetoEnabled && bandSleepState.isNotEmpty()) {
+                val shadowStages = applyBandStateWakeVeto(rawStages, start = p.start, end = p.end,
+                    bandSleepState = bandSleepState, enabled = true)
+                val shadowEff = efficiency(start = p.start, end = p.end, stages = shadowStages)
+                val recoveredMin = (shadowEff - eff) * (p.end - p.start).toDouble() / 60.0
+                if (recoveredMin >= 1.0) {
+                    traceSink(bandVetoShadowLine(startTs = p.start, recoveredMin = recoveredMin,
+                        rawEff = eff, shadowEff = shadowEff))
+                }
+            }
             // A run that does NOT continue the chain re-anchors it on this run's onset.
             if (!continuesChain) chainFromOvernight = isOvernightOnset(p.start, tzOffsetSeconds)
             chainPrevEnd = p.end

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -507,6 +507,16 @@ class OuraLiveSource(
      */
     private val recentSleepWindows049 = ArrayList<Triple<Long, Int, Int>>()
 
+    /**
+     * #1284 residual 3 (duplicate-generation diagnostic): the [start, end] window of each sleep session
+     * banked THIS connection. The session PK is (deviceId, startTs) and the burst end moves with the 0x49
+     * drain, so an early partial drain can bank a short session that a later full burst then nests inside,
+     * minting a second row that the #899 heal only cleans up afterwards. Comparing each new persist against
+     * this list surfaces the GENERATION in the strap log (the heal side is #899's own line). Diagnostic only,
+     * nothing is skipped. Bounded; cleared on disconnect with the 0x49 windows. Twin of Swift's.
+     */
+    private val recentPersistedSessionWindows = ArrayList<Pair<Long, Long>>()
+
     /** 0x71 fixture capture (#287): per-session count + observed payload lengths; log cap vs flooding. */
     private var greenIbiAmpCount = 0
     private val greenIbiAmpLengths = sortedSetOf<Int>()
@@ -728,9 +738,25 @@ class OuraLiveSource(
         // over NOOP's computed night (#325 persist). Uses the anchored+0x49-refined `end` via `laid`. The
         // confirmation line makes the persist self-evident in the strap log for on-device validation.
         OuraSleepSessionMapping.session(laid.map { it.ts to it.phase.stage })?.let {
+            val start = laid.first().ts
+            // #1284 residual 3: log when this persist lands wholly inside — or overlapping — a session already
+            // banked this connection. That is the duplicate GENERATION (an early partial drain banked a short
+            // session; this fuller burst nests it), which the #899 heal only cleans up afterward. Include the
+            // 0x49 anchor state, since a persist with NO 0x49 anchor is the prime suspect for the short row.
+            // Diagnostic only — nothing is skipped here; the fix is 0x49-window session keying (hardware-gated).
+            recentPersistedSessionWindows.firstOrNull { (s, e) -> start < e && end > s }?.let { (s, e) ->
+                val nested = start >= s && end <= e
+                val anchor = if (w != null) "0x49 anchor=[onset-${w.second}..end-${w.third}]min" else "NO 0x49 anchor (write-envelope end)"
+                log("Oura: duplicate-gen(#1284) new session [$start -> $end] ${if (nested) "NESTED IN" else "OVERLAPS"} " +
+                    "already-banked [$s -> $e] this connection - $anchor; PK=(deviceId,startTs) mints a 2nd row")
+            }
+            recentPersistedSessionWindows.add(start to end)
+            if (recentPersistedSessionWindows.size > RECENT_PERSISTED_SESSIONS_CAP) {
+                recentPersistedSessionWindows.subList(0, recentPersistedSessionWindows.size - RECENT_PERSISTED_SESSIONS_CAP).clear()
+            }
             persistSleepSession(it, deviceId)
             val effStr = it.efficiency?.let { e -> "${(e * 100).toInt()}%" } ?: "n/a"
-            log("Oura: sleep session persisted [${laid.first().ts} -> $end] eff=$effStr -> $deviceId (ring-provided night; wins merge over computed)")
+            log("Oura: sleep session persisted [$start -> $end] eff=$effStr -> $deviceId (ring-provided night; wins merge over computed)")
         }
     }
 
@@ -890,6 +916,7 @@ class OuraLiveSource(
         hypnogramAssembler.reset()        // never replay a half-accumulated burst from a dead session
         pendingUnanchoredBursts.clear()
         recentSleepWindows049.clear()
+        recentPersistedSessionWindows.clear()
         greenIbiAmpCount = 0
         greenIbiAmpLengths.clear()
         // Resume the GetEvents cursor from where the LAST connection to this ring left off (s5.1/5.3), so a
@@ -1899,6 +1926,9 @@ class OuraLiveSource(
 
         /** Bound on stashed 0x49 windows (twin of Swift's recentSleepWindows049Cap). */
         private const val RECENT_SLEEP_WINDOWS_049_CAP = 16
+
+        /** Bound on the #1284 duplicate-generation window list (twin of Swift's). */
+        private const val RECENT_PERSISTED_SESSIONS_CAP = 16
 
         /**
          * The 0x49 window in [windows] whose envelope ring-time is nearest [rt] and within [tolerance]

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -756,7 +756,11 @@ class OuraLiveSource(
             }
             persistSleepSession(it, deviceId)
             val effStr = it.efficiency?.let { e -> "${(e * 100).toInt()}%" } ?: "n/a"
-            log("Oura: sleep session persisted [$start -> $end] eff=$effStr -> $deviceId (ring-provided night; wins merge over computed)")
+            // #1284 residual 3: stamp the 0x49 anchor state on EVERY persist, so an unanchored early-drain row
+            // (the prime suspect for the short nested duplicate) is self-evident even when it is the FIRST
+            // persist, before the duplicate-gen line above can fire.
+            val anchorTag = if (sleepStart != null) "0x49-anchored" else "NO-0x49-anchor"
+            log("Oura: sleep session persisted [$start -> $end] eff=$effStr [$anchorTag] -> $deviceId (ring-provided night; wins merge over computed)")
         }
     }
 

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -746,7 +746,7 @@ class OuraLiveSource(
             // Diagnostic only — nothing is skipped here; the fix is 0x49-window session keying (hardware-gated).
             recentPersistedSessionWindows.firstOrNull { (s, e) -> start < e && end > s }?.let { (s, e) ->
                 val nested = start >= s && end <= e
-                val anchor = if (sleepStart != null) "0x49 anchor applied (onset=$sleepStart)" else "NO 0x49 anchor (write-envelope end)"
+                val anchor = if (sleepStart != null) "0x49 onset=$sleepStart" else "no 0x49 onset (start derived from burst end)"
                 log("Oura: duplicate-gen(#1284) new session [$start -> $end] ${if (nested) "NESTED IN" else "OVERLAPS"} " +
                     "already-banked [$s -> $e] this connection - $anchor; PK=(deviceId,startTs) mints a 2nd row")
             }
@@ -759,7 +759,7 @@ class OuraLiveSource(
             // #1284 residual 3: stamp the 0x49 anchor state on EVERY persist, so an unanchored early-drain row
             // (the prime suspect for the short nested duplicate) is self-evident even when it is the FIRST
             // persist, before the duplicate-gen line above can fire.
-            val anchorTag = if (sleepStart != null) "0x49-anchored" else "NO-0x49-anchor"
+            val anchorTag = if (sleepStart != null) "0x49-onset" else "no-0x49-onset"
             log("Oura: sleep session persisted [$start -> $end] eff=$effStr [$anchorTag] -> $deviceId (ring-provided night; wins merge over computed)")
         }
     }

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -746,7 +746,7 @@ class OuraLiveSource(
             // Diagnostic only — nothing is skipped here; the fix is 0x49-window session keying (hardware-gated).
             recentPersistedSessionWindows.firstOrNull { (s, e) -> start < e && end > s }?.let { (s, e) ->
                 val nested = start >= s && end <= e
-                val anchor = if (w != null) "0x49 anchor=[onset-${w.second}..end-${w.third}]min" else "NO 0x49 anchor (write-envelope end)"
+                val anchor = if (sleepStart != null) "0x49 anchor applied (onset=$sleepStart)" else "NO 0x49 anchor (write-envelope end)"
                 log("Oura: duplicate-gen(#1284) new session [$start -> $end] ${if (nested) "NESTED IN" else "OVERLAPS"} " +
                     "already-banked [$s -> $e] this connection - $anchor; PK=(deviceId,startTs) mints a 2nd row")
             }

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -565,10 +565,14 @@ object OuraDecoders {
         // bytes (to the record's end) as unwritten too. Trailing-only + a run floor, on purpose: a
         // leading/interior 0xFF run stays real wake (a pre-onset run is dropped by the assembler's onset
         // clip), and a short trailing run is spared. Byte-parity twin of the Swift decodeSleepPhase.
+        // Floor clamped to >= 2 (see Swift): a LONE trailing 0xFF is four genuine awake epochs (the #1246
+        // case), and the whole-record rule only fires at codeCount >= 2 — the trailing rule must never undercut
+        // that even if MIN_TRAILING_UNWRITTEN is lowered by someone who hasn't read #1284.
+        val effectiveFloor = maxOf(2, MIN_TRAILING_UNWRITTEN)
         var trailingFF = 0
         var t = b.size - 1
         while (t >= 1 && (b[t].toInt() and 0xFF) == 0xFF) { trailingFF++; t-- }
-        val trailingStart = if (trailingFF >= MIN_TRAILING_UNWRITTEN) codeCount - trailingFF else codeCount
+        val trailingStart = if (trailingFF >= effectiveFloor) codeCount - trailingFF else codeCount
         val out = ArrayList<OuraSleepPhase>()
         var index = 0
         for (k in 1 until b.size) {

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerBandVetoTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerBandVetoTest.kt
@@ -6,6 +6,7 @@ import com.noop.testcentre.CaptureAccumulator
 import com.noop.testcentre.TestDomain
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import kotlin.math.ceil
@@ -189,6 +190,26 @@ class SleepStagerBandVetoTest {
             noBand[0].stages, withBand[0].stages)
         assertEquals("default-off: efficiency is untouched by the band stream",
             noBand[0].efficiency, withBand[0].efficiency, 1e-9)
+    }
+
+    @Test
+    fun cutoffSparesNightsBeforeCutoff() {
+        // #1210 item 2: with the veto ON, a non-zero cutoff spares a night that STARTED before it (history
+        // keeps its raw hypnogram) and applies to one starting at/after it. Boundary is inclusive. Swift twin.
+        val base = 1_000_000L
+        val fixture = vetoHypnoFixture().map {
+            StageSegment(start = it.start + base, end = it.end + base, stage = it.stage)
+        }
+        val band = bandAllAsleep(start = base, end = base + 960)
+        val recovered = SleepStager.applyBandStateWakeVeto(fixture, start = base, end = base + 960,
+            bandSleepState = band, enabled = true, cutoffTs = 0L)
+        assertNotEquals("sanity: the veto does change this fixture", recovered, fixture)
+        assertEquals("a night starting before the cutoff keeps its raw hypnogram",
+            fixture, SleepStager.applyBandStateWakeVeto(fixture, start = base, end = base + 960,
+                bandSleepState = band, enabled = true, cutoffTs = base + 1))
+        assertEquals("a night starting at/after the cutoff (inclusive) gets the veto",
+            recovered, SleepStager.applyBandStateWakeVeto(fixture, start = base, end = base + 960,
+                bandSleepState = band, enabled = true, cutoffTs = base))
     }
 
     @Test

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerBandVetoTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerBandVetoTest.kt
@@ -2,6 +2,8 @@ package com.noop.analytics
 
 import com.noop.data.GravitySample
 import com.noop.data.HrSample
+import com.noop.testcentre.CaptureAccumulator
+import com.noop.testcentre.TestDomain
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -187,5 +189,43 @@ class SleepStagerBandVetoTest {
             noBand[0].stages, withBand[0].stages)
         assertEquals("default-off: efficiency is untouched by the band stream",
             noBand[0].efficiency, withBand[0].efficiency, 1e-9)
+    }
+
+    @Test
+    fun shadowLineIsNamespacedAndUncountedByCaptureAccumulator() {
+        // #1210 shadow: the validation line formats the recovered delta and is NEVER miscounted as a captured
+        // sleep day (carries no `sleep day=` / `gate run=` / `day=` token). Byte-identical format to Swift.
+        val line = SleepStager.bandVetoShadowLine(
+            startTs = 1_723_000_000L, recoveredMin = 31.4, rawEff = 0.742, shadowEff = 0.808,
+        )
+        assertEquals("bandVeto(shadow): startTs=1723000000 recoveredMin=31 eff 74%->81%", line)
+        assertEquals("shadow line must not be counted as a captured sleep day",
+            0, CaptureAccumulator.capturedDays(TestDomain.SLEEP, line, 0L))
+    }
+
+    @Test
+    fun shadowTraceReportsRecoveryOutputNeutral() {
+        // #1210 shadow: veto DORMANT (default-off) + a band present + a collecting traceSink -> a
+        // `bandVeto(shadow):` line quantifying what the veto WOULD recover, WITHOUT changing the persisted
+        // hypnogram (detectSleep's documented trace contract). Same burst fixture as the default-off wiring
+        // test. (The line reports MAGNITUDE only; whether the move is toward truth needs the PSG harness.)
+        val start = startAtHour(2)
+        val dur = 6 * 3600
+        val grav = stillGravity(start, dur).toMutableList()
+        val hr = hrStream(start, dur, 50).toMutableList()
+        for (i in (3 * 3600) until (3 * 3600 + 5 * 60)) {  // interior 5-min burst -> false wake
+            grav[i] = GravitySample(deviceId = dev, ts = start + i, x = (i % 2) * 0.5, y = 0.0, z = 1.0)
+            hr[i] = HrSample(deviceId = dev, ts = start + i, bpm = 95)
+        }
+        val band = bandAllAsleep(start = start, end = start + dur)
+        val untraced = SleepStager.detectSleep(hr = hr, gravity = grav, bandSleepState = band)
+        val lines = mutableListOf<String>()
+        val traced = SleepStager.detectSleep(
+            hr = hr, gravity = grav, bandSleepState = band, traceSink = { lines.add(it) },
+        )
+        assertEquals("shadow trace must not change the persisted hypnogram",
+            untraced[0].stages, traced[0].stages)
+        assertTrue("a banded night with interior false-wake emits a shadow line",
+            lines.any { it.startsWith("bandVeto(shadow):") && it.contains("recoveredMin=") })
     }
 }

--- a/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
+++ b/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
@@ -305,6 +305,19 @@ class DecoderGoldenTest {
     }
 
     @Test
+    fun testSleepPhase0x4ETrailingSingleFFIsGenuineAwake() {
+        // #1284/#1246 boundary: a written record ending in a SINGLE trailing 0xFF is four genuine awake epochs,
+        // never pad. The trailing floor is clamped to >= 2, so this holds even if MIN_TRAILING_UNWRITTEN is
+        // lowered — a lone trailing byte can never be eaten (the case #1246 protects). PARITY twin of Swift.
+        assertTrue("floor < 2 would eat a lone trailing 0xFF (#1246); the decode clamps to 2 as a backstop",
+            OuraDecoders.MIN_TRAILING_UNWRITTEN >= 2)
+        val phases = OuraDecoders.decodeSleepPhase(record("4e120200010000555555555555555555555555ff"))
+        assertEquals(52, phases?.size)                                 // 13 code bytes * 4
+        assertTrue(phases!!.none { it.unwritten })                     // nothing flagged unwritten
+        assertTrue(phases.takeLast(4).all { it.stage == OuraSleepStage.AWAKE })   // the lone 0xFF stays real wake
+    }
+
+    @Test
     fun testSleepPhase0x4ELeadingFFRunIsRealWake() {
         // Trailing-only: a long leading 0xFF run that does NOT reach the record's end stays real wake.
         val phases = OuraDecoders.decodeSleepPhase(record("4e120200010000ffffffffffffffffff55555555"))


### PR DESCRIPTION
Instrument-first step on @pipiche38's #1284 **residual 3**. His second-night capture shows a night still mints a **second row** — a short session (`22:32:30 → 23:50:30`, eff 0.385) banked by an early partial drain, nested inside the real one (`22:26:14 → 07:06:14`) banked by the later full burst. #1249 fixed the #899 heal, not the cause, and from the strap log alone the *generation* is invisible.

### Why instrument, not fix
The cause is a **session-identity change** (PK is `(deviceId, startTs)`; the burst end moves with the 0x49 drain) in **hardware-gated BLE persist code** — pipiche's recommended fix (key the session on the stable 0x49 window) can't be validated without a strap reproducing the duplicate. So this ships the diagnostic first; the fix follows once the mechanism is pinned on-device.

### What it logs
When a persist lands wholly inside — or overlapping — a session already banked **this connection**, with the 0x49 anchor state:
```
Oura: duplicate-gen(#1284) new session [S → E] NESTED IN already-banked [s → e] this connection - NO 0x49 anchor (write-envelope end); PK=(deviceId,startTs) mints a 2nd row
```
A persist with **no 0x49 anchor** is the prime suspect for the short row, so the line names it — that's the signal pipiche's next capture needs.

### Safety + scope
- **Diagnostic only** — a bounded in-memory `[start,end]` list + log lines. **No BLE/connection/write-path change**, nothing is skipped, no stored value changes. Reset per connection with the 0x49 windows.
- Byte-parity **Swift** (`Strand/BLE`, app-target) + **Kotlin** (`com.noop.ble`). Android compiles locally; the Swift half is app-target Swift with no default CI → verified on the **app-build gate** (dispatching now). On-device confirmation that the line fires is pipiche's next capture (the point of the instrument).

Residual 1 is done + hardened (#1293/#1296); residual 2 (one-shot heal of banked nights) stays open as a stored-contract decision.