### PR TITLE
devices: strap switcher to flip the active strap (#1300 — switch, don't combine)

### DIFF
--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -143,6 +143,10 @@ private struct DevicesContent: View {
             sectionHead("YOUR BANDS", trailing: activeDevices.count == 1
                         ? String(localized: "1 paired")
                         : String(localized: "\(activeDevices.count) paired"))
+            // #1300: a prominent switcher to flip which strap is active — the "switch, don't combine"
+            // option for a user with two straps (e.g. a 4.0 + a 5/MG). Shown only with 2+ straps, so it
+            // auto-collapses when one is forgotten. Reuses the existing active-strap confirmation.
+            if activeDevices.count > 1 { strapSwitcher }
             ForEach(Array(activeDevices.enumerated()), id: \.element.id) { idx, device in
                 // Shared read-only probe gate (Test Centre → Connection + a live WHOOP), hoisted so the two
                 // probe closures below don't each re-inline a 4-term && chain — which tips the iOS Swift
@@ -426,6 +430,33 @@ private struct DevicesContent: View {
 
     /// UPPERCASE overline section header with tracking + a muted trailing note, matching the liquid Today's
     /// `sectionHead`. Keeps every page's section chrome identical.
+    /// #1300: a compact segmented switcher over the paired straps. The active one is highlighted; tapping
+    /// another opens the SAME "Make active?" confirmation the per-card action uses (no accidental switch,
+    /// history preserved). Switching-not-combining: scores stay single-owner-per-day, this just picks the
+    /// owner. Collapses automatically when only one strap remains (the caller gates on count > 1).
+    private var strapSwitcher: some View {
+        HStack(spacing: 6) {
+            ForEach(activeDevices, id: \.id) { device in
+                let isActive = device.status == .active
+                Button { if !isActive { switchTarget = device } } label: {
+                    Text(device.displayName)
+                        .font(StrandFont.caption)
+                        .lineLimit(1)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 7)
+                        .background(isActive ? StrandPalette.accent.opacity(0.18) : Color.clear,
+                                    in: Capsule(style: .continuous))
+                        .overlay(Capsule(style: .continuous).strokeBorder(
+                            isActive ? StrandPalette.accent.opacity(0.45) : StrandPalette.hairline, lineWidth: 1))
+                        .foregroundStyle(isActive ? StrandPalette.accent : StrandPalette.textSecondary)
+                }
+                .buttonStyle(.plain)
+                .disabled(isActive)
+            }
+        }
+        .padding(.horizontal, 2)
+    }
+
     private func sectionHead(_ title: LocalizedStringKey, trailing: String) -> some View {
         HStack(alignment: .firstTextBaseline) {
             Text(title).font(StrandFont.overline).tracking(1.6).foregroundStyle(StrandPalette.textTertiary)

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -210,6 +210,12 @@ fun DevicesScreen(
             return@LazyScreenScaffold
         }
 
+        // #1300: a prominent switcher to flip which strap is active — the "switch, don't combine" option
+        // for a user with two straps (e.g. a 4.0 + a 5/MG). Shown only with 2+ straps, so it collapses
+        // when one is forgotten. Reuses the existing active-strap confirmation (switchTarget).
+        if (activeDevices.size > 1) {
+            item { StrapSwitcher(devices = activeDevices, onSelect = { switchTarget = it }) }
+        }
         items(activeDevices) { device ->
             DeviceCard(
                 device = device,
@@ -521,6 +527,36 @@ fun DevicesScreen(
 /** One paired device as a [NoopCard]: name, brand·model, a capabilities line, a state pill, last-seen,
  *  and a per-device actions menu. The active device is tinted with the accent (WHOOP blue) and carries
  *  an "Active" pill. */
+@Composable
+private fun StrapSwitcher(devices: List<PairedDeviceRow>, onSelect: (PairedDeviceRow) -> Unit) {
+    // #1300: a compact segmented switcher over the paired straps. The active one is highlighted; tapping
+    // another opens the SAME "Make active?" confirmation the per-card action uses (via switchTarget) — no
+    // accidental switch, history preserved. Switching-not-combining: scores stay single-owner-per-day.
+    val shape = RoundedCornerShape(50)
+    Row(horizontalArrangement = Arrangement.spacedBy(6.dp), modifier = Modifier.fillMaxWidth()) {
+        devices.forEach { device ->
+            val isActive = device.status == DeviceStatus.active.name
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(shape)
+                    .background(if (isActive) Palette.accent.copy(alpha = 0.18f) else Color.Transparent)
+                    .border(1.dp, if (isActive) Palette.accent.copy(alpha = 0.45f) else Palette.hairline, shape)
+                    .then(if (isActive) Modifier else Modifier.clickable { onSelect(device) })
+                    .padding(vertical = 7.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    displayName(device),
+                    style = NoopType.caption,
+                    color = if (isActive) Palette.accent else Palette.textSecondary,
+                    maxLines = 1,
+                )
+            }
+        }
+    }
+}
+
 @Composable
 private fun DeviceCard(
     device: PairedDeviceRow,


### PR DESCRIPTION
First slice of #1300 — the **"switch, don't combine"** option for a user with two straps (e.g. a WHOOP 4.0 + a 5/MG).

## What it does
A prominent segmented **switcher** in the Devices window ("YOUR BANDS"): the active strap is highlighted; tapping another opens the **same "Make active?" confirmation** the per-card action already uses (via `switchTarget`), so there's no accidental switch and history is preserved.

## Deliberately switching, not combining
Scores stay **single-owner-per-day** (`DayOwnerResolver`, invariant I2 — scores never mixed across sources). This just picks the owner *faster* than a card's actions menu; it reuses the existing `setActive` mechanism, so **no identity or fusion work**.

## De-registration handled for free
Shown only with **2+ straps** (`activeDevices.count > 1`), so it **auto-collapses** when one is forgotten — no orphaned group state.

## Scope
- Byte-parity Swift (`strapSwitcher`) + Kotlin (`StrapSwitcher`); reuses `displayName` + design tokens, **no new strings** (i18n audit exit 0).
- Android compiles; iOS app-target → **app-build gate**.
- The compare/correlate card + fused scores (#1300 non-goals) are not in this PR.
