### PR TITLE
analytics: two-strap comparison engine (#1300 tier 2 — correlate, not combine)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StrapComparison.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StrapComparison.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+// StrapComparison.swift — #1300 tier 2: a READ-ONLY, non-diagnostic comparison of the SAME metric from
+// two straps (e.g. a WHOOP 4.0 and a 5/MG) for one user. It reuses the existing per-metric tolerances
+// (`MetricArbitrationPolicy.tolerance`) to say whether the two straps AGREE, differ a little, or conflict —
+// for a "compare my straps" card in the Devices window. It NEVER mixes the two into one score (scores stay
+// single-owner-per-day, invariant I2); it only describes how they line up, with both values kept visible.
+// Pure + deterministic, no clock, no I/O. Value-for-value Kotlin twin (`StrapComparison.kt`).
+public enum StrapComparison {
+
+    /// One metric's two-strap comparison. `a`/`b` are the two straps' values for that metric (nil = that
+    /// strap has no value); `agreement` is `.single` when only one strap reported it.
+    public struct Row: Equatable, Sendable {
+        public let metric: MetricArbitrationPolicy.MetricKind
+        public let a: Double?
+        public let b: Double?
+        public let agreement: AgreementState
+        public init(metric: MetricArbitrationPolicy.MetricKind, a: Double?, b: Double?, agreement: AgreementState) {
+            self.metric = metric
+            self.a = a
+            self.b = b
+            self.agreement = agreement
+        }
+    }
+
+    /// Compare two straps' per-metric values (each strap's stored daily mapped to MetricKind->value at the
+    /// call site). Emits a row per metric EITHER strap reported, in `MetricKind` declaration order; `.other`
+    /// is skipped (it's the non-comparable passthrough family). Read-only, non-diagnostic.
+    public static func compare(_ a: [MetricArbitrationPolicy.MetricKind: Double],
+                               _ b: [MetricArbitrationPolicy.MetricKind: Double]) -> [Row] {
+        MetricArbitrationPolicy.MetricKind.allCases.compactMap { metric in
+            guard metric != .other else { return nil }
+            let va = a[metric], vb = b[metric]
+            guard va != nil || vb != nil else { return nil }
+            return Row(metric: metric, a: va, b: vb, agreement: agreement(metric: metric, a: va, b: vb))
+        }
+    }
+
+    /// The agreement between two strap values for one metric, using that metric's published tolerance.
+    /// `.single` when only one strap has it. SYMMETRIC: a percentage tolerance is taken against the LARGER
+    /// magnitude, so neither strap is privileged as a "winner" (unlike the resolver, which has one).
+    public static func agreement(metric: MetricArbitrationPolicy.MetricKind,
+                                 a: Double?, b: Double?) -> AgreementState {
+        guard let a, let b else { return .single }
+        let tol = MetricArbitrationPolicy.tolerance(metric: metric)
+        let delta = abs(a - b)
+        let base = max(abs(a), abs(b))
+        let agreeEdge = tol.isPercent ? tol.agree * base : tol.agree
+        let minorEdge = tol.isPercent ? tol.minorDelta * base : tol.minorDelta
+        if delta <= agreeEdge { return .agree }
+        if delta <= minorEdge { return .minorDelta }
+        return .conflict
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrapComparisonTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrapComparisonTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// Pins the #1300 two-strap comparison (reuses the existing per-metric tolerances). Kotlin twin:
+/// `StrapComparisonTest`.
+final class StrapComparisonTests: XCTestCase {
+
+    private let rhr = MetricArbitrationPolicy.MetricKind.restingHR
+    private let hrv = MetricArbitrationPolicy.MetricKind.hrv
+    private let steps = MetricArbitrationPolicy.MetricKind.steps
+    private let spo2 = MetricArbitrationPolicy.MetricKind.spo2
+
+    func testClassifiesAgreeMinorConflictSingle() {
+        // RHR is an absolute tolerance (±3 agree / ±8 minor bpm).
+        XCTAssertEqual(StrapComparison.agreement(metric: rhr, a: 55, b: 57), .agree)       // delta 2
+        XCTAssertEqual(StrapComparison.agreement(metric: rhr, a: 55, b: 60), .minorDelta)  // delta 5
+        XCTAssertEqual(StrapComparison.agreement(metric: rhr, a: 55, b: 70), .conflict)    // delta 15
+        XCTAssertEqual(StrapComparison.agreement(metric: rhr, a: 55, b: nil), .single)     // one strap
+        XCTAssertEqual(StrapComparison.agreement(metric: rhr, a: nil, b: nil), .single)
+    }
+
+    func testPercentToleranceUsesLargerMagnitude() {
+        // Steps is a percentage tolerance; an 800-step gap on ~10.8k is within the agree band.
+        XCTAssertEqual(StrapComparison.agreement(metric: steps, a: 10000, b: 10800), .agree)
+    }
+
+    func testCompareRowPerMetricEitherReportedSkipsOther() {
+        let a: [MetricArbitrationPolicy.MetricKind: Double] = [rhr: 55, hrv: 60]
+        let b: [MetricArbitrationPolicy.MetricKind: Double] = [rhr: 56, spo2: 97]
+        let rows = StrapComparison.compare(a, b)
+        XCTAssertEqual(rows.count, 3) // RHR (both) + HRV (a only) + SpO2 (b only); .other never
+        XCTAssertEqual(rows.first { $0.metric == rhr }?.agreement, .agree)
+        XCTAssertEqual(rows.first { $0.metric == hrv }?.agreement, .single)
+        XCTAssertEqual(rows.first { $0.metric == rhr }?.b, 56)
+        XCTAssertEqual(rows.first { $0.metric == spo2 }?.a, nil)
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/StrapComparison.kt
+++ b/android/app/src/main/java/com/noop/analytics/StrapComparison.kt
@@ -1,0 +1,56 @@
+package com.noop.analytics
+
+import kotlin.math.abs
+import kotlin.math.max
+
+/**
+ * #1300 tier 2: a READ-ONLY, non-diagnostic comparison of the SAME metric from two straps (e.g. a WHOOP
+ * 4.0 and a 5/MG) for one user. Reuses the existing per-metric tolerances ([MetricArbitrationPolicy.tolerance])
+ * to say whether the two straps AGREE, differ a little, or conflict — for a "compare my straps" card in the
+ * Devices window. NEVER mixes the two into one score (scores stay single-owner-per-day, invariant I2); it
+ * only describes how they line up, both values kept visible. Pure + deterministic. Twin of Swift
+ * `StrapComparison`.
+ */
+object StrapComparison {
+
+    /** One metric's two-strap comparison. [a]/[b] are the two straps' values (null = no value); [agreement]
+     *  is [AgreementState.SINGLE] when only one strap reported it. */
+    data class Row(
+        val metric: MetricArbitrationPolicy.MetricKind,
+        val a: Double?,
+        val b: Double?,
+        val agreement: AgreementState,
+    )
+
+    /** Compare two straps' per-metric values (each strap's stored daily mapped to MetricKind->value at the
+     *  call site). One row per metric EITHER strap reported, in enum declaration order; OTHER is skipped
+     *  (the non-comparable passthrough family). Read-only, non-diagnostic. */
+    fun compare(
+        a: Map<MetricArbitrationPolicy.MetricKind, Double>,
+        b: Map<MetricArbitrationPolicy.MetricKind, Double>,
+    ): List<Row> =
+        MetricArbitrationPolicy.MetricKind.entries.mapNotNull { metric ->
+            if (metric == MetricArbitrationPolicy.MetricKind.OTHER) return@mapNotNull null
+            val va = a[metric]
+            val vb = b[metric]
+            if (va == null && vb == null) return@mapNotNull null
+            Row(metric, va, vb, agreement(metric, va, vb))
+        }
+
+    /** Agreement between two strap values for one metric, using that metric's published tolerance. SINGLE
+     *  when only one strap has it. SYMMETRIC: a percentage tolerance is taken against the LARGER magnitude,
+     *  so neither strap is privileged as a "winner". */
+    fun agreement(metric: MetricArbitrationPolicy.MetricKind, a: Double?, b: Double?): AgreementState {
+        if (a == null || b == null) return AgreementState.SINGLE
+        val tol = MetricArbitrationPolicy.tolerance(metric)
+        val delta = abs(a - b)
+        val base = max(abs(a), abs(b))
+        val agreeEdge = if (tol.isPercent) tol.agree * base else tol.agree
+        val minorEdge = if (tol.isPercent) tol.minorDelta * base else tol.minorDelta
+        return when {
+            delta <= agreeEdge -> AgreementState.AGREE
+            delta <= minorEdge -> AgreementState.MINOR_DELTA
+            else -> AgreementState.CONFLICT
+        }
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/StrapComparisonTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StrapComparisonTest.kt
@@ -1,0 +1,42 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Pins the #1300 two-strap comparison (reuses the existing per-metric tolerances). Swift twin:
+ *  `StrapComparisonTests`. */
+class StrapComparisonTest {
+
+    private val RHR = MetricArbitrationPolicy.MetricKind.RESTING_HR
+    private val HRV = MetricArbitrationPolicy.MetricKind.HRV
+    private val STEPS = MetricArbitrationPolicy.MetricKind.STEPS
+    private val SPO2 = MetricArbitrationPolicy.MetricKind.SPO2
+
+    @Test
+    fun classifiesAgreeMinorConflictSingle() {
+        // RHR is an absolute tolerance (±3 agree / ±8 minor bpm).
+        assertEquals(AgreementState.AGREE, StrapComparison.agreement(RHR, 55.0, 57.0))       // delta 2
+        assertEquals(AgreementState.MINOR_DELTA, StrapComparison.agreement(RHR, 55.0, 60.0)) // delta 5
+        assertEquals(AgreementState.CONFLICT, StrapComparison.agreement(RHR, 55.0, 70.0))    // delta 15
+        assertEquals(AgreementState.SINGLE, StrapComparison.agreement(RHR, 55.0, null))      // one strap
+        assertEquals(AgreementState.SINGLE, StrapComparison.agreement(RHR, null, null))
+    }
+
+    @Test
+    fun percentToleranceUsesLargerMagnitude() {
+        // Steps is a percentage tolerance; an 800-step gap on ~10.8k is within the agree band.
+        assertEquals(AgreementState.AGREE, StrapComparison.agreement(STEPS, 10000.0, 10800.0))
+    }
+
+    @Test
+    fun compareRowPerMetricEitherReportedSkipsOther() {
+        val a = mapOf(RHR to 55.0, HRV to 60.0)
+        val b = mapOf(RHR to 56.0, SPO2 to 97.0)
+        val rows = StrapComparison.compare(a, b)
+        assertEquals(3, rows.size) // RHR (both) + HRV (a only) + SpO2 (b only); OTHER never
+        assertEquals(AgreementState.AGREE, rows.first { it.metric == RHR }.agreement)
+        assertEquals(AgreementState.SINGLE, rows.first { it.metric == HRV }.agreement)
+        assertEquals(56.0, rows.first { it.metric == RHR }.b)
+        assertEquals(null, rows.first { it.metric == SPO2 }.a)
+    }
+}


### PR DESCRIPTION
Tier 2 of #1300 — the read-only foundation for a **"compare my straps"** card (a user with a WHOOP 4.0 + a 5/MG). This is the **correlate**, not combine, path.

## What it does
`StrapComparison` takes each strap's per-metric values and, using the **existing per-metric tolerances** (`MetricArbitrationPolicy.tolerance`), classifies each metric as **agree / minor-delta / conflict** (or **single** when only one strap has it) — the same semantics as the fusion resolver, but **symmetric**: a percentage band is taken against the larger magnitude, so neither strap is privileged as a "winner."

## Deliberately correlate, not combine
- **Does not touch `FusionSource` or the scores path.** Scores stay single-owner-per-day (invariant I2). This only *describes* how two straps line up — both values kept visible, no condition names, no averaging.
- **Sidesteps the `FusionSource`-per-`deviceId` refactor** I flagged in #1300: a *compare* card doesn't need it (only the fused *record* would). This keeps the change small and safe.

## Verification
- Pure + deterministic, byte-parity Swift (`StrandAnalytics`) + Kotlin (`com.noop.analytics`).
- Tested both sides — **Kotlin 3/3 local**; Swift `StrapComparisonTests` via `swift-packages`. **No app-target Swift** → `swift-packages` + android CI fully cover it, no gate.

## Next slice
The Devices **"compare straps" card** — read both straps' dailies (map to `MetricKind`→value) and render these rows with the agreement chips. That part is app-target UI (both platforms). Tier 1 (the strap switcher) is #1301.
