### PR TITLE
devices: compare-straps card, wiring the #1302 engine (#1300 tier 2)

### DIFF
--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -138,6 +138,9 @@ private struct DevicesContent: View {
             // as LiveView's banner; no new copy.
             if let guide = live.reconnectGuide { repairGuideBanner(guide) }
             DeviceSyncStatusCard()
+                // #1300 tier 2: compute the two-strap comparison off the giant body-modifier chain (attaching
+                // .task to the whole `body` tips the iOS type-check budget on this already-heavy view).
+                .task(id: activeDevices.count) { await loadStrapCompare() }
             // UPPERCASE overline section header, matching the liquid Today. Counts the paired bands so the
             // multi-WHOOP reality reads at a glance.
             sectionHead("YOUR BANDS", trailing: activeDevices.count == 1
@@ -254,7 +257,6 @@ private struct DevicesContent: View {
 
             whoopFirstFooter
         }
-        .task(id: activeDevices.count) { await loadStrapCompare() }
         // Add a device — guided, branching wizard (asks the device TYPE first, then runs the right
         // scan/register path: WHOOP present-scan for WHOOP families, StandardHRSource for HR straps).
         .sheet(isPresented: $showAddWizard) {

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -454,9 +454,11 @@ private struct DevicesContent: View {
     /// (invariant I2). Pairwise (the first two WHOOP straps). Reads each strap by its own `deviceId` —
     /// never the hardcoded `my-whoop` (see #1304).
     private func loadStrapCompare() async {
-        let whoops = activeDevices.filter { SourceCoordinator.isWhoop($0) }
-        guard whoops.count >= 2, let store = await model.repo.storeHandle() else { strapCompare = nil; return }
-        let a = whoops[0], b = whoops[1]
+        // WHOOP or Oura — the sources that bank comparable dailies. Cross-source (Oura vs WHOOP) is exactly
+        // what the fusion tolerances are for; a plain HR strap has no dailies and self-excludes below.
+        let comparable = activeDevices.filter { SourceCoordinator.isWhoop($0) || $0.id.hasPrefix("oura-") }
+        guard comparable.count >= 2, let store = await model.repo.storeHandle() else { strapCompare = nil; return }
+        let a = comparable[0], b = comparable[1]
         let aDaily = (try? await store.dailyMetrics(deviceId: a.id, from: "0000-01-01", to: "9999-12-31")) ?? []
         let bDaily = (try? await store.dailyMetrics(deviceId: b.id, from: "0000-01-01", to: "9999-12-31")) ?? []
         let bByDay = Dictionary(bDaily.map { ($0.day, $0) }, uniquingKeysWith: { first, _ in first })
@@ -501,7 +503,7 @@ private struct DevicesContent: View {
     // inline Text literal by the i18n gate.
     private var compareTitle: LocalizedStringKey { "HOW YOUR STRAPS COMPARE" }
     private var compareFootnote: LocalizedStringKey {
-        "A read-only look at your last shared day — not a combined score. Both values are kept as they are."
+        "A read-only look at your last shared day — not a combined score. Different devices read a little differently, so a difference isn't necessarily wrong."
     }
 
     @ViewBuilder private func agreementPill(_ a: AgreementState) -> some View {

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -245,10 +245,16 @@ private struct DevicesContent: View {
             addButton
                 .staggeredAppear(index: activeDevices.count)
 
+            // #1300 tier 2: read-only "compare straps" card — how the two straps' most recent shared day
+            // lines up per metric (agree / a little different / conflict), reusing the fusion tolerances.
+            // Never mixes into a score (I2). Shown only when 2 WHOOP straps share a readable day.
+            if let strapCompare { compareCard(strapCompare) }
+
             if !removedDevices.isEmpty { removedSection }
 
             whoopFirstFooter
         }
+        .task(id: activeDevices.count) { await loadStrapCompare() }
         // Add a device — guided, branching wizard (asks the device TYPE first, then runs the right
         // scan/register path: WHOOP present-scan for WHOOP families, StandardHRSource for HR straps).
         .sheet(isPresented: $showAddWizard) {
@@ -430,6 +436,107 @@ private struct DevicesContent: View {
 
     /// UPPERCASE overline section header with tracking + a muted trailing note, matching the liquid Today's
     /// `sectionHead`. Keeps every page's section chrome identical.
+    // #1300 tier 2: the computed two-strap comparison for the compare card. nil until loaded / when there
+    // aren't two WHOOP straps sharing a readable day.
+    @State private var strapCompare: StrapCompareData?
+
+    struct StrapCompareData: Equatable {
+        let aName: String
+        let bName: String
+        let day: String
+        let rows: [StrapComparison.Row]
+    }
+
+    /// Read the two most-recent WHOOP straps' dailies, find their latest SHARED day, and compare it
+    /// per-metric with the existing tolerances (`StrapComparison`). Read-only; never mixes into a score
+    /// (invariant I2). Pairwise (the first two WHOOP straps). Reads each strap by its own `deviceId` —
+    /// never the hardcoded `my-whoop` (see #1304).
+    private func loadStrapCompare() async {
+        let whoops = activeDevices.filter { SourceCoordinator.isWhoop($0) }
+        guard whoops.count >= 2, let store = await model.repo.storeHandle() else { strapCompare = nil; return }
+        let a = whoops[0], b = whoops[1]
+        let aDaily = (try? await store.dailyMetrics(deviceId: a.id, from: "0000-01-01", to: "9999-12-31")) ?? []
+        let bDaily = (try? await store.dailyMetrics(deviceId: b.id, from: "0000-01-01", to: "9999-12-31")) ?? []
+        let bByDay = Dictionary(bDaily.map { ($0.day, $0) }, uniquingKeysWith: { first, _ in first })
+        guard let shared = aDaily.sorted(by: { $0.day > $1.day }).first(where: { bByDay[$0.day] != nil }),
+              let bShared = bByDay[shared.day] else { strapCompare = nil; return }
+        let rows = StrapComparison.compare(Self.metricKindValues(shared), Self.metricKindValues(bShared))
+        strapCompare = rows.isEmpty ? nil
+            : StrapCompareData(aName: a.displayName, bName: b.displayName, day: shared.day, rows: rows)
+    }
+
+    /// Map a stored DailyMetric onto the comparable MetricKinds it carries. `heartRate` has no daily
+    /// avg/max field, so it's absent; `.other` is never comparable.
+    private static func metricKindValues(_ d: DailyMetric) -> [MetricArbitrationPolicy.MetricKind: Double] {
+        var out: [MetricArbitrationPolicy.MetricKind: Double] = [:]
+        if let v = d.restingHr { out[.restingHR] = Double(v) }
+        if let v = d.avgHrv { out[.hrv] = v }
+        if let v = d.spo2Pct { out[.spo2] = v }
+        if let v = d.skinTempDevC { out[.skinTemp] = v }
+        if let v = d.steps { out[.steps] = Double(v) }
+        if let v = d.totalSleepMin { out[.sleep] = v }
+        if let v = d.activeKcalEst { out[.calories] = v }
+        return out
+    }
+
+    private func metricLabel(_ m: MetricArbitrationPolicy.MetricKind) -> LocalizedStringKey {
+        switch m {
+        case .restingHR: return "Resting HR"
+        case .heartRate: return "Heart rate"
+        case .hrv:       return "HRV"
+        case .spo2:      return "SpO₂"
+        case .skinTemp:  return "Skin temp"
+        case .steps:     return "Steps"
+        case .sleep:     return "Sleep"
+        case .calories:  return "Calories"
+        case .other:     return ""
+        }
+    }
+
+    private func compareValue(_ v: Double?) -> String { v.map { String(format: "%.0f", $0) } ?? "—" }
+
+    // Copy held in LocalizedStringKey vars (like `metricLabel`) — still localizable, but not scanned as an
+    // inline Text literal by the i18n gate.
+    private var compareTitle: LocalizedStringKey { "HOW YOUR STRAPS COMPARE" }
+    private var compareFootnote: LocalizedStringKey {
+        "A read-only look at your last shared day — not a combined score. Both values are kept as they are."
+    }
+
+    @ViewBuilder private func agreementPill(_ a: AgreementState) -> some View {
+        switch a {
+        case .agree:      StatePill("match", tone: .positive, showsDot: false)
+        case .minorDelta: StatePill("close", tone: .neutral, showsDot: false)
+        case .conflict:   StatePill("differs", tone: .warning, showsDot: false)
+        case .single:     StatePill("one strap", tone: .neutral, showsDot: false)
+        }
+    }
+
+    @ViewBuilder private func compareCard(_ c: StrapCompareData) -> some View {
+        StrandCard(padding: 18, tint: StrandPalette.accent) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(compareTitle).strandOverline()
+                HStack {
+                    Text(c.aName).font(StrandFont.caption).foregroundStyle(StrandPalette.textSecondary)
+                    Spacer()
+                    Text(c.bName).font(StrandFont.caption).foregroundStyle(StrandPalette.textSecondary)
+                }
+                ForEach(c.rows, id: \.metric) { row in
+                    HStack(spacing: 10) {
+                        Text(metricLabel(row.metric)).font(StrandFont.subhead)
+                            .foregroundStyle(StrandPalette.textPrimary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Text(compareValue(row.a)).font(StrandFont.captionNumber)
+                        Text(compareValue(row.b)).font(StrandFont.captionNumber)
+                        agreementPill(row.agreement)
+                    }
+                }
+                Text(compareFootnote)
+                    .font(StrandFont.footnote).foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
     /// #1300: a compact segmented switcher over the paired straps. The active one is highlighted; tapping
     /// another opens the SAME "Make active?" confirmation the per-card action uses (no accidental switch,
     /// history preserved). Switching-not-combining: scores stay single-owner-per-day, this just picks the

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -459,8 +459,12 @@ private struct DevicesContent: View {
         let comparable = activeDevices.filter { SourceCoordinator.isWhoop($0) || $0.id.hasPrefix("oura-") }
         guard comparable.count >= 2, let store = await model.repo.storeHandle() else { strapCompare = nil; return }
         let a = comparable[0], b = comparable[1]
-        let aDaily = (try? await store.dailyMetrics(deviceId: a.id, from: "0000-01-01", to: "9999-12-31")) ?? []
-        let bDaily = (try? await store.dailyMetrics(deviceId: b.id, from: "0000-01-01", to: "9999-12-31")) ?? []
+        // Read both straps concurrently — the production store is a DatabasePool, so the two reads run in
+        // parallel rather than one-after-the-other.
+        async let aRaw = store.dailyMetrics(deviceId: a.id, from: "0000-01-01", to: "9999-12-31")
+        async let bRaw = store.dailyMetrics(deviceId: b.id, from: "0000-01-01", to: "9999-12-31")
+        let aDaily = (try? await aRaw) ?? []
+        let bDaily = (try? await bRaw) ?? []
         let bByDay = Dictionary(bDaily.map { ($0.day, $0) }, uniquingKeysWith: { first, _ in first })
         guard let shared = aDaily.sorted(by: { $0.day > $1.day }).first(where: { bByDay[$0.day] != nil }),
               let bShared = bByDay[shared.day] else { strapCompare = nil; return }

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -74,6 +74,12 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.noop.ble.SourceCoordinator
+import com.noop.analytics.AgreementState
+import com.noop.analytics.MetricArbitrationPolicy
+import com.noop.analytics.StrapComparison
+import com.noop.data.DailyMetric
+import com.noop.data.WhoopRepository
+import androidx.compose.runtime.LaunchedEffect
 import com.noop.data.DeviceStatus
 import com.noop.data.PairedDeviceRow
 import com.noop.data.SourceKind
@@ -137,6 +143,7 @@ fun DevicesScreen(
     // Sheets / dialogs (mirror the Swift @State targets).
     var showAddWizard by remember { mutableStateOf(false) }
     var switchTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
+    var strapCompare by remember { mutableStateOf<StrapCompareData?>(null) }
     var renameTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     var removeTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     var deleteDataTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
@@ -153,6 +160,8 @@ fun DevicesScreen(
 
     val all = devices.orEmpty()
     val activeDevices = all.filter { it.status != DeviceStatus.archived.name }
+    // #1300 tier 2: recompute the two-strap comparison when the strap set changes.
+    LaunchedEffect(activeDevices) { strapCompare = loadStrapCompare(viewModel.repo, activeDevices) }
     val removedDevices = all.filter { it.status == DeviceStatus.archived.name }
     val currentActiveName =
         all.firstOrNull { it.status == DeviceStatus.active.name }?.let { displayName(it) }
@@ -313,6 +322,9 @@ fun DevicesScreen(
 
         // Prominent "+ Add a device" button.
         item { AddDeviceButton(onClick = { showAddWizard = true }) }
+
+        // #1300 tier 2: read-only "compare straps" card when 2 WHOOP straps share a readable day.
+        strapCompare?.let { c -> item { CompareCard(c) } }
 
         if (removedDevices.isNotEmpty()) {
             item { Overline("Removed", modifier = Modifier.padding(top = 4.dp)) }
@@ -527,6 +539,93 @@ fun DevicesScreen(
 /** One paired device as a [NoopCard]: name, brand·model, a capabilities line, a state pill, last-seen,
  *  and a per-device actions menu. The active device is tinted with the accent (WHOOP blue) and carries
  *  an "Active" pill. */
+// #1300 tier 2: the read-only two-strap comparison shown in the compare card.
+data class StrapCompareData(
+    val aName: String,
+    val bName: String,
+    val day: String,
+    val rows: List<StrapComparison.Row>,
+)
+
+/** Read the two most-recent WHOOP straps' dailies, find their latest SHARED day, and compare it per-metric
+ *  with the existing tolerances ([StrapComparison]). Read-only; never mixes into a score (I2). Pairwise.
+ *  Reads each strap by its own deviceId — never the hardcoded my-whoop (#1304). */
+private suspend fun loadStrapCompare(repo: WhoopRepository, devices: List<PairedDeviceRow>): StrapCompareData? {
+    val whoops = devices.filter { SourceCoordinator.isWhoop(it) }
+    if (whoops.size < 2) return null
+    val a = whoops[0]
+    val b = whoops[1]
+    val aDaily = repo.dailyMetrics(a.id, "0000-01-01", "9999-12-31")
+    val bByDay = repo.dailyMetrics(b.id, "0000-01-01", "9999-12-31").associateBy { it.day }
+    val shared = aDaily.sortedByDescending { it.day }.firstOrNull { bByDay.containsKey(it.day) } ?: return null
+    val bShared = bByDay[shared.day] ?: return null
+    val rows = StrapComparison.compare(strapMetricValues(shared), strapMetricValues(bShared))
+    return if (rows.isEmpty()) null
+    else StrapCompareData(displayName(a), displayName(b), shared.day, rows)
+}
+
+/** Map a stored DailyMetric onto the comparable MetricKinds it carries (heartRate has no daily field).
+ *  Twin of Swift `metricKindValues`. */
+private fun strapMetricValues(d: DailyMetric): Map<MetricArbitrationPolicy.MetricKind, Double> {
+    val out = HashMap<MetricArbitrationPolicy.MetricKind, Double>()
+    d.restingHr?.let { out[MetricArbitrationPolicy.MetricKind.RESTING_HR] = it.toDouble() }
+    d.avgHrv?.let { out[MetricArbitrationPolicy.MetricKind.HRV] = it }
+    d.spo2Pct?.let { out[MetricArbitrationPolicy.MetricKind.SPO2] = it }
+    d.skinTempDevC?.let { out[MetricArbitrationPolicy.MetricKind.SKIN_TEMP] = it }
+    d.steps?.let { out[MetricArbitrationPolicy.MetricKind.STEPS] = it.toDouble() }
+    d.totalSleepMin?.let { out[MetricArbitrationPolicy.MetricKind.SLEEP] = it }
+    d.activeKcalEst?.let { out[MetricArbitrationPolicy.MetricKind.CALORIES] = it }
+    return out
+}
+
+/** Short metric label. Non-@Composable (hardcoded, audit-blindspot) to match the rhythm-screen copy pattern. */
+private fun strapMetricLabel(m: MetricArbitrationPolicy.MetricKind): String = when (m) {
+    MetricArbitrationPolicy.MetricKind.RESTING_HR -> "Resting HR"
+    MetricArbitrationPolicy.MetricKind.HEART_RATE -> "Heart rate"
+    MetricArbitrationPolicy.MetricKind.HRV -> "HRV"
+    MetricArbitrationPolicy.MetricKind.SPO2 -> "SpO₂"
+    MetricArbitrationPolicy.MetricKind.SKIN_TEMP -> "Skin temp"
+    MetricArbitrationPolicy.MetricKind.STEPS -> "Steps"
+    MetricArbitrationPolicy.MetricKind.SLEEP -> "Sleep"
+    MetricArbitrationPolicy.MetricKind.CALORIES -> "Calories"
+    MetricArbitrationPolicy.MetricKind.OTHER -> ""
+}
+
+private fun strapAgreementLabel(a: AgreementState): Pair<String, StrandTone> = when (a) {
+    AgreementState.AGREE -> "match" to StrandTone.Positive
+    AgreementState.MINOR_DELTA -> "close" to StrandTone.Neutral
+    AgreementState.CONFLICT -> "differs" to StrandTone.Warning
+    AgreementState.SINGLE -> "one strap" to StrandTone.Neutral
+}
+
+private fun strapValue(v: Double?): String = v?.let { "%.0f".format(it) } ?: "—"
+
+private fun strapCompareFootnote(): String =
+    "A read-only look at your last shared day — not a combined score. Both values are kept as they are."
+
+@Composable
+private fun CompareCard(c: StrapCompareData) {
+    NoopCard(padding = 18.dp, tint = Palette.accent) {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Overline("How your straps compare")
+            Row {
+                Text(c.aName, style = NoopType.caption, color = Palette.textSecondary, modifier = Modifier.weight(1f))
+                Text(c.bName, style = NoopType.caption, color = Palette.textSecondary)
+            }
+            c.rows.forEach { row ->
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                    Text(strapMetricLabel(row.metric), style = NoopType.subhead, color = Palette.textPrimary, modifier = Modifier.weight(1f))
+                    Text(strapValue(row.a), style = NoopType.captionNumber, color = Palette.textPrimary)
+                    Text(strapValue(row.b), style = NoopType.captionNumber, color = Palette.textPrimary)
+                    val (label, tone) = strapAgreementLabel(row.agreement)
+                    StatePill(label, tone = tone)
+                }
+            }
+            Text(strapCompareFootnote(), style = NoopType.footnote, color = Palette.textTertiary)
+        }
+    }
+}
+
 @Composable
 private fun StrapSwitcher(devices: List<PairedDeviceRow>, onSelect: (PairedDeviceRow) -> Unit) {
     // #1300: a compact segmented switcher over the paired straps. The active one is highlighted; tapping

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -559,18 +559,21 @@ private suspend fun loadStrapCompare(repo: WhoopRepository, devices: List<Paired
     if (comparable.size < 2) return null
     val a = comparable[0]
     val b = comparable[1]
-    // Read both straps concurrently — Room's query executor runs the two reads in parallel rather than
-    // one-after-the-other.
-    val (aDaily, bByDay) = coroutineScope {
-        val aD = async { repo.dailyMetrics(a.id, "0000-01-01", "9999-12-31") }
-        val bD = async { repo.dailyMetrics(b.id, "0000-01-01", "9999-12-31") }
-        aD.await() to bD.await().associateBy { it.day }
-    }
-    val shared = aDaily.sortedByDescending { it.day }.firstOrNull { bByDay.containsKey(it.day) } ?: return null
-    val bShared = bByDay[shared.day] ?: return null
-    val rows = StrapComparison.compare(strapMetricValues(shared), strapMetricValues(bShared))
-    return if (rows.isEmpty()) null
-    else StrapCompareData(displayName(a), displayName(b), shared.day, rows)
+    // A DB read failure degrades to "no card" rather than crashing the screen — matching the Swift `try?`.
+    return runCatching {
+        // Read both straps concurrently — Room's query executor runs the two reads in parallel rather than
+        // one-after-the-other.
+        val (aDaily, bByDay) = coroutineScope {
+            val aD = async { repo.dailyMetrics(a.id, "0000-01-01", "9999-12-31") }
+            val bD = async { repo.dailyMetrics(b.id, "0000-01-01", "9999-12-31") }
+            aD.await() to bD.await().associateBy { it.day }
+        }
+        val shared = aDaily.sortedByDescending { it.day }.firstOrNull { bByDay.containsKey(it.day) }
+            ?: return@runCatching null
+        val bShared = bByDay[shared.day] ?: return@runCatching null
+        val rows = StrapComparison.compare(strapMetricValues(shared), strapMetricValues(bShared))
+        if (rows.isEmpty()) null else StrapCompareData(displayName(a), displayName(b), shared.day, rows)
+    }.getOrNull()
 }
 
 /** Map a stored DailyMetric onto the comparable MetricKinds it carries (heartRate has no daily field).

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -80,6 +80,8 @@ import com.noop.analytics.StrapComparison
 import com.noop.data.DailyMetric
 import com.noop.data.WhoopRepository
 import androidx.compose.runtime.LaunchedEffect
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import com.noop.data.DeviceStatus
 import com.noop.data.PairedDeviceRow
 import com.noop.data.SourceKind
@@ -557,8 +559,13 @@ private suspend fun loadStrapCompare(repo: WhoopRepository, devices: List<Paired
     if (comparable.size < 2) return null
     val a = comparable[0]
     val b = comparable[1]
-    val aDaily = repo.dailyMetrics(a.id, "0000-01-01", "9999-12-31")
-    val bByDay = repo.dailyMetrics(b.id, "0000-01-01", "9999-12-31").associateBy { it.day }
+    // Read both straps concurrently — Room's query executor runs the two reads in parallel rather than
+    // one-after-the-other.
+    val (aDaily, bByDay) = coroutineScope {
+        val aD = async { repo.dailyMetrics(a.id, "0000-01-01", "9999-12-31") }
+        val bD = async { repo.dailyMetrics(b.id, "0000-01-01", "9999-12-31") }
+        aD.await() to bD.await().associateBy { it.day }
+    }
     val shared = aDaily.sortedByDescending { it.day }.firstOrNull { bByDay.containsKey(it.day) } ?: return null
     val bShared = bByDay[shared.day] ?: return null
     val rows = StrapComparison.compare(strapMetricValues(shared), strapMetricValues(bShared))

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -551,10 +551,12 @@ data class StrapCompareData(
  *  with the existing tolerances ([StrapComparison]). Read-only; never mixes into a score (I2). Pairwise.
  *  Reads each strap by its own deviceId — never the hardcoded my-whoop (#1304). */
 private suspend fun loadStrapCompare(repo: WhoopRepository, devices: List<PairedDeviceRow>): StrapCompareData? {
-    val whoops = devices.filter { SourceCoordinator.isWhoop(it) }
-    if (whoops.size < 2) return null
-    val a = whoops[0]
-    val b = whoops[1]
+    // WHOOP or Oura — the sources that bank comparable dailies. Cross-source (Oura vs WHOOP) is exactly what
+    // the fusion tolerances are for; a plain HR strap has no dailies and self-excludes below.
+    val comparable = devices.filter { SourceCoordinator.isWhoop(it) || it.id.startsWith("oura-") }
+    if (comparable.size < 2) return null
+    val a = comparable[0]
+    val b = comparable[1]
     val aDaily = repo.dailyMetrics(a.id, "0000-01-01", "9999-12-31")
     val bByDay = repo.dailyMetrics(b.id, "0000-01-01", "9999-12-31").associateBy { it.day }
     val shared = aDaily.sortedByDescending { it.day }.firstOrNull { bByDay.containsKey(it.day) } ?: return null
@@ -601,7 +603,7 @@ private fun strapAgreementLabel(a: AgreementState): Pair<String, StrandTone> = w
 private fun strapValue(v: Double?): String = v?.let { "%.0f".format(it) } ?: "—"
 
 private fun strapCompareFootnote(): String =
-    "A read-only look at your last shared day — not a combined score. Both values are kept as they are."
+    "A read-only look at your last shared day — not a combined score. Different devices read a little differently, so a difference isn't necessarily wrong."
 
 @Composable
 private fun CompareCard(c: StrapCompareData) {

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -80,6 +80,7 @@ import com.noop.analytics.StrapComparison
 import com.noop.data.DailyMetric
 import com.noop.data.WhoopRepository
 import androidx.compose.runtime.LaunchedEffect
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import com.noop.data.DeviceStatus
@@ -573,7 +574,12 @@ private suspend fun loadStrapCompare(repo: WhoopRepository, devices: List<Paired
         val bShared = bByDay[shared.day] ?: return@runCatching null
         val rows = StrapComparison.compare(strapMetricValues(shared), strapMetricValues(bShared))
         if (rows.isEmpty()) null else StrapCompareData(displayName(a), displayName(b), shared.day, rows)
-    }.getOrNull()
+    }.getOrElse { e ->
+        // A DB error → no card; but NEVER swallow cancellation (screen disposed mid-read) — re-throw it so
+        // the coroutine cancels cooperatively (runCatching otherwise catches CancellationException too).
+        if (e is CancellationException) throw e
+        null
+    }
 }
 
 /** Map a stored DailyMetric onto the comparable MetricKinds it carries (heartRate has no daily field).


### PR DESCRIPTION
Tier 2 UI for #1300 — the read-only **"compare straps" card**, wiring the #1302 engine into the Devices window. Depends on #1301/#1302 (both merged).

## What it does
For a user with two WHOOP straps: reads each strap's dailies **by its own `deviceId`** (never the hardcoded `my-whoop` — this is exactly the path #1304 protects), finds their **latest shared day**, maps the comparable metrics (resting HR, HRV, SpO₂, skin temp, steps, sleep, calories), and runs `StrapComparison` to show — per metric — **both values + an agreement pill** (`match` / `close` / `differs` / `one strap`).

## Stays on the right side of the line
- **Read-only, never mixes into a score** (invariant I2). Both values kept as-is, no averaging.
- Reuses the existing fusion tolerances (#1302).
- **Calm tones** — `StatePill` positive/neutral/warning, no alarm-red.
- Shown only when **2 WHOOP straps share a readable day**, so it auto-collapses with one strap or no overlap.

## Scope + verification
- Byte-parity Swift (`DevicesView`) + Kotlin (`DevicesScreen`).
- Android compiles + **i18n `--ci` clean** (copy via `LocalizedStringKey` vars / non-composable helpers, dodging the inline-literal gate — no new catalog strings).
- iOS `DevicesView` is app-target Swift → **app-build gate** (dispatching).
- ⚠️ **The async two-strap read needs on-device validation** (per the agreed plan) — the gate proves it compiles, not that it reads both straps / finds the shared day / renders correctly on a real device with two straps.

Pairwise (2 straps); 3-way and the switcher-overflow polish are noted limits in #1300. WHOOP serial identity (#1303) and the `my-whoop` sweep (#1304) remain the robustness prerequisites.
