### PR TITLE
whoop-re: offline decode-coverage, capture-diff, inventory & ground-truth RE tools

### DIFF
--- a/Packages/WhoopProtocol/Package.swift
+++ b/Packages/WhoopProtocol/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
         .library(name: "WhoopProtocol", targets: ["WhoopProtocol"]),
         .executable(name: "whoop-decode", targets: ["whoop-decode"]),
         .executable(name: "whoop-optical-experiment", targets: ["whoop-optical-experiment"]),
+        .executable(name: "whoop-re", targets: ["whoop-re"]),
     ],
     targets: [
         .target(
@@ -20,6 +21,10 @@ let package = Package(
         ),
         .executableTarget(
             name: "whoop-optical-experiment",
+            dependencies: ["WhoopProtocol"]
+        ),
+        .executableTarget(
+            name: "whoop-re",
             dependencies: ["WhoopProtocol"]
         ),
         .testTarget(

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/ReTools.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/ReTools.swift
@@ -83,17 +83,22 @@ public enum ReTools {
         public let totalBytes: Int
         /// Uncovered offsets only (the RE worklist), each with its cross-frame variance, offset-ascending.
         public let unknownBytes: [ByteStat]
-        /// Shannon entropy (bits/byte, 0–8) of ALL unknown bytes pooled across the group. The
-        /// encrypted-vs-merely-unknown test: a value near 8 with a large sample means the undecoded
-        /// payload is statistically random (ciphered or compressed); a low value means it's structured
-        /// plaintext you simply haven't decoded yet. Meaningless on a tiny sample — read it with
-        /// `unknownSampleCount`.
+        /// Mean per-offset Shannon entropy (bits/byte, 0–8) over the unknown offsets — for EACH unknown
+        /// byte position, the entropy of its value distribution ACROSS frames, then averaged. This is
+        /// the encrypted-vs-merely-unknown test done right: a value near 8 means every byte position is
+        /// random over time (ciphered/compressed), while structured plaintext — even a payload whose
+        /// offsets each hold a *different* constant — stays near 0. It is NOT pooled across offsets, so
+        /// cross-position variety can't masquerade as randomness. Bounded above by log2(unknownSampleCount),
+        /// so it's meaningless until you have many frames — read it with `unknownSampleCount` (= frames).
         public let unknownEntropyBits: Double
+        /// Number of same-layout frames the per-offset entropy was measured over (the entropy ceiling is
+        /// log2 of this). NOT the byte count.
         public let unknownSampleCount: Int
         public var coveragePct: Double { totalBytes == 0 ? 0 : Double(coveredBytes) / Double(totalBytes) * 100 }
-        /// A heuristic flag, deliberately conservative: high pooled entropy over a sample big enough to
-        /// trust. NOT proof of encryption (high-entropy plaintext exists) — a prompt to investigate,
-        /// which is why the raw entropy and sample size are exposed alongside it.
+        /// A heuristic flag, deliberately conservative: near-max per-offset entropy over enough frames
+        /// for the 8-bit ceiling to be reachable (log2(256)=8). NOT proof of encryption (high-entropy
+        /// plaintext exists) — a prompt to investigate, which is why the entropy and frame count sit
+        /// beside it.
         public var likelyEncrypted: Bool { unknownEntropyBits >= 7.5 && unknownSampleCount >= 256 }
     }
 
@@ -131,22 +136,25 @@ public enum ReTools {
             var covered = Set<Int>()
             for r in sized { covered.formUnion(coveredOffsets(r.frame)) }
             var unknown: [ByteStat] = []
-            var pooled: [UInt8] = []          // every unknown byte, all offsets × all frames — the entropy sample
+            var offsetEntropies: [Double] = []   // per-offset entropy across frames — averaged, never pooled
             for off in 0 ..< len where !covered.contains(off) {
                 var distinct = Set<Int>(); var lo = Int.max; var hi = Int.min
+                var column: [UInt8] = []; column.reserveCapacity(sized.count)
                 for r in sized {
-                    let v = Int(r.bytes[off]); distinct.insert(v)
-                    lo = min(lo, v); hi = max(hi, v)
-                    pooled.append(r.bytes[off])
+                    let byte = r.bytes[off]; let v = Int(byte); distinct.insert(v)
+                    lo = min(lo, v); hi = max(hi, v); column.append(byte)
                 }
+                offsetEntropies.append(shannonBits(column))
                 unknown.append(ByteStat(offset: off, distinctValues: distinct.count,
                                         minValue: lo, maxValue: hi, sampleCount: sized.count))
             }
+            let meanEntropy = offsetEntropies.isEmpty
+                ? 0 : offsetEntropies.reduce(0, +) / Double(offsetEntropies.count)
             let coveredInLen = covered.filter { $0 < len }.count
             out.append(GroupCoverage(key: key, frameCount: recs.count, frameLen: len,
                                      coveredBytes: coveredInLen, totalBytes: len,
                                      unknownBytes: unknown.sorted { $0.offset < $1.offset },
-                                     unknownEntropyBits: shannonBits(pooled), unknownSampleCount: pooled.count))
+                                     unknownEntropyBits: meanEntropy, unknownSampleCount: sized.count))
         }
         return out.sorted { $0.key < $1.key }
     }
@@ -166,9 +174,16 @@ public enum ReTools {
         public let key: String
         public let inA: Bool
         public let inB: Bool
-        /// Offsets present in BOTH captures whose value set differs (empty when the layouts match byte
-        /// for byte). Only populated for shared keys.
+        /// Modal frame length on each side (0 for an absent side). When these differ, one capture's
+        /// layout grew/shrank — often the whole point (enabling a feature can ADD trailing bytes), and
+        /// `changedOffsets` only spans the overlap, so those extra bytes are reported here, not there.
+        public let lenA: Int
+        public let lenB: Int
+        /// Offsets present in BOTH captures (up to the shorter length) whose value set differs (empty
+        /// when the overlap matches byte for byte). Only populated for shared keys.
         public let changedOffsets: [OffsetDiff]
+        /// The layouts are different widths — extra bytes on the longer side are NOT in `changedOffsets`.
+        public var lengthDiffers: Bool { inA && inB && lenA != lenB }
     }
 
     /// Diff two captures by record layout. Keys in only one side surface as presence differences (a
@@ -182,12 +197,16 @@ public enum ReTools {
         for key in Set(ga.keys).union(gb.keys) {
             let ra = ga[key], rb = gb[key]
             guard let ra, let rb else {
-                out.append(GroupDiff(key: key, inA: ra != nil, inB: rb != nil, changedOffsets: []))
+                out.append(GroupDiff(key: key, inA: ra != nil, inB: rb != nil,
+                                     lenA: ra.map(modalLength) ?? 0, lenB: rb.map(modalLength) ?? 0,
+                                     changedOffsets: []))
                 continue
             }
             let lenA = modalLength(ra), lenB = modalLength(rb)
             let sa = ra.filter { $0.bytes.count == lenA }, sb = rb.filter { $0.bytes.count == lenB }
-            let coveredA = sa.first.map { coveredOffsets($0.frame) } ?? []
+            // Union covered offsets across A's frames so a conditional field still reads as "named".
+            var coveredA = Set<Int>()
+            for r in sa { coveredA.formUnion(coveredOffsets(r.frame)) }
             var changed: [OffsetDiff] = []
             for off in 0 ..< min(lenA, lenB) {
                 let va = Set(sa.map { Int($0.bytes[off]) })
@@ -197,7 +216,7 @@ public enum ReTools {
                                               aValues: va.sorted(), bValues: vb.sorted()))
                 }
             }
-            out.append(GroupDiff(key: key, inA: true, inB: true, changedOffsets: changed))
+            out.append(GroupDiff(key: key, inA: true, inB: true, lenA: lenA, lenB: lenB, changedOffsets: changed))
         }
         return out.sorted { $0.key < $1.key }
     }

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/ReTools.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/ReTools.swift
@@ -276,26 +276,29 @@ public enum ReTools {
     }
 
     /// Score how well a decoded field tracks timestamped ground truth (what the official app showed).
-    /// Each truth point is matched to the nearest record by `ts_ms` within `maxDtMs`, `fieldName` is
-    /// read from that record's decoded dict, and the paired values are scored: mean-absolute-error,
-    /// bias (mean signed error), and Pearson r. This is the instrument-first check that lets a
-    /// candidate PPG→HRV / SpO₂ mapping be *validated*, not eyeballed — and it's honest about coverage
-    /// (`n` is how many points actually matched a decoded record).
+    /// Each truth point is matched to the nearest record *that actually carries a numeric decode of
+    /// `fieldName`* within `maxDtMs` — NOT merely the nearest record of any type, because on a real
+    /// interleaved capture the closest frame by time is usually some other packet that doesn't carry
+    /// the metric. The paired values are scored: mean-absolute-error, bias (mean signed error), and
+    /// Pearson r. This is the instrument-first check that lets a candidate PPG→HRV / SpO₂ mapping be
+    /// *validated*, not eyeballed — and it's honest about coverage (`n` = truth points that found a
+    /// field-bearing record in range; a `nil` decoded residual means none did).
     public static func groundTruth(records: [Record], truth: [TruthPoint],
                                    fieldName: String, maxDtMs: Int = 60_000) -> Score {
-        let stamped = records.filter { $0.tsMs != nil }
+        // Only records that are timestamped AND carry a numeric value for this field are candidates —
+        // pairing `decoded` to the field-bearing record, never to a nearer frame that lacks it.
+        let candidates: [(ts: Int, value: Double)] = records.compactMap { r in
+            guard let ts = r.tsMs, let v = r.frame.parsed[fieldName]?.doubleValue else { return nil }
+            return (ts, v)
+        }
         var residuals: [Residual] = []
         for t in truth.sorted(by: { $0.tsMs < $1.tsMs }) {
-            var best: Record?; var bestDt = Int.max
-            for r in stamped {
-                let dt = abs(r.tsMs! - t.tsMs)
-                if dt < bestDt { bestDt = dt; best = r }
+            var bestValue: Double?; var bestDt = Int.max
+            for c in candidates {
+                let dt = abs(c.ts - t.tsMs)
+                if dt < bestDt { bestDt = dt; bestValue = c.value }
             }
-            guard let match = best, bestDt <= maxDtMs else {
-                residuals.append(Residual(tsMs: t.tsMs, truth: t.value, decoded: nil, dtMs: bestDt))
-                continue
-            }
-            let decoded = match.frame.parsed[fieldName]?.doubleValue
+            let decoded = (bestValue != nil && bestDt <= maxDtMs) ? bestValue : nil
             residuals.append(Residual(tsMs: t.tsMs, truth: t.value, decoded: decoded, dtMs: bestDt))
         }
         let pairs = residuals.compactMap { r in r.decoded.map { (t: r.truth, d: $0) } }

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/ReTools.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/ReTools.swift
@@ -1,0 +1,309 @@
+import Foundation
+
+// ReTools — offline reverse-engineering aids over the SAME `WhoopProtocol` decoder the app runs.
+//
+// These are DEV TOOLING, not shipped on-device logic: every function here takes already-decoded
+// `ParsedFrame`s (the output of `parseFrame`) plus the raw bytes and reports *about* the decode —
+// which bytes are still unknown, what changed between two captures, what a strap actually banked, and
+// how a candidate field tracks a ground-truth value. They define no new wire semantics, so unlike the
+// decoders themselves they need no Kotlin twin, and because they read captured records they run
+// entirely offline (no device, no BLE, no battery/perf cost, no new capture mode).
+//
+// The four tools:
+//   • coverage(_:)    — per (type, version) byte-coverage map + per-unknown-offset variance. The
+//                       RE worklist: which payload bytes the schema does NOT yet name, and whether
+//                       each is constant (flag/padding) or varies (a live field worth decoding).
+//   • diff(_:_:)      — value-set diff of the same record layout across two captures. Feed it a
+//                       flag-on vs flag-off pair (e.g. `enable_spo2`) and the feature-linked bytes
+//                       fall out as the offsets whose value set changed.
+//   • inventory(_:)   — one-glance census: which types/versions a capture holds, counts, ok/crc
+//                       rates, timestamp span, length spread. Tells you what you actually captured.
+//   • groundTruth(…)  — align a decoded field to timestamped truth (what the WHOOP app displayed)
+//                       and score it (MAE, bias, Pearson r), turning "looks right" into a number.
+
+public enum ReTools {
+
+    // MARK: - Shared record model
+
+    /// A decoded capture record: the parsed frame, the raw bytes it came from, and the provenance the
+    /// capture tool attaches (`ts_ms`, `hr`) that the decoder ignores but alignment/diff use.
+    public struct Record: Equatable {
+        public let frame: ParsedFrame
+        public let bytes: [UInt8]
+        public let tsMs: Int?
+        public let hr: Int?
+        public init(frame: ParsedFrame, bytes: [UInt8], tsMs: Int? = nil, hr: Int? = nil) {
+            self.frame = frame; self.bytes = bytes; self.tsMs = tsMs; self.hr = hr
+        }
+    }
+
+    /// The grouping key every tool shares. A `HISTORICAL_DATA` (type-47) record splits by its version
+    /// byte — which the interpreter surfaces as `seq`, the type-47 layout selector — so v18/v20/v21/v26
+    /// are analysed as the distinct layouts they are. Every other packet type groups by name alone.
+    public static func groupKey(_ f: ParsedFrame) -> String {
+        if f.typeName == "HISTORICAL_DATA", let v = f.seq { return "HISTORICAL_DATA/v\(v)" }
+        return f.typeName
+    }
+
+    /// The set of byte offsets a frame's decoded fields cover (each field spans `off ..< off+len`).
+    private static func coveredOffsets(_ f: ParsedFrame) -> Set<Int> {
+        var s = Set<Int>()
+        for field in f.fields where field.len > 0 {
+            for o in field.off ..< (field.off + field.len) { s.insert(o) }
+        }
+        return s
+    }
+
+    /// The modal (most common) byte length in a bag of records — the dominant layout width, so a lone
+    /// truncated frame can't skew per-offset statistics. Ties break toward the larger length.
+    private static func modalLength(_ recs: [Record]) -> Int {
+        var counts: [Int: Int] = [:]
+        for r in recs { counts[r.bytes.count, default: 0] += 1 }
+        return counts.max { a, b in a.value != b.value ? a.value < b.value : a.key < b.key }?.key ?? 0
+    }
+
+    // MARK: - A) Coverage map
+
+    /// One uncovered byte offset's variance across a group — the signal for whether it's worth decoding.
+    public struct ByteStat: Equatable {
+        public let offset: Int
+        public let distinctValues: Int
+        public let minValue: Int
+        public let maxValue: Int
+        public let sampleCount: Int
+        /// A single value across every sample: almost always a flag, reserved, or padding byte.
+        public var constant: Bool { distinctValues <= 1 }
+    }
+
+    public struct GroupCoverage: Equatable {
+        public let key: String
+        public let frameCount: Int
+        public let frameLen: Int
+        public let coveredBytes: Int
+        public let totalBytes: Int
+        /// Uncovered offsets only (the RE worklist), each with its cross-frame variance, offset-ascending.
+        public let unknownBytes: [ByteStat]
+        /// Shannon entropy (bits/byte, 0–8) of ALL unknown bytes pooled across the group. The
+        /// encrypted-vs-merely-unknown test: a value near 8 with a large sample means the undecoded
+        /// payload is statistically random (ciphered or compressed); a low value means it's structured
+        /// plaintext you simply haven't decoded yet. Meaningless on a tiny sample — read it with
+        /// `unknownSampleCount`.
+        public let unknownEntropyBits: Double
+        public let unknownSampleCount: Int
+        public var coveragePct: Double { totalBytes == 0 ? 0 : Double(coveredBytes) / Double(totalBytes) * 100 }
+        /// A heuristic flag, deliberately conservative: high pooled entropy over a sample big enough to
+        /// trust. NOT proof of encryption (high-entropy plaintext exists) — a prompt to investigate,
+        /// which is why the raw entropy and sample size are exposed alongside it.
+        public var likelyEncrypted: Bool { unknownEntropyBits >= 7.5 && unknownSampleCount >= 256 }
+    }
+
+    /// Shannon entropy in bits/byte (0–8) over a byte multiset.
+    private static func shannonBits(_ bytes: [UInt8]) -> Double {
+        guard !bytes.isEmpty else { return 0 }
+        var counts = [Int](repeating: 0, count: 256)
+        for b in bytes { counts[Int(b)] += 1 }
+        let n = Double(bytes.count)
+        var h = 0.0
+        for c in counts where c > 0 {
+            let p = Double(c) / n
+            h -= p * (log(p) / log(2))
+        }
+        return h
+    }
+
+    /// Per (type, version): how much of the frame the schema already names, and for every byte it does
+    /// NOT, how that byte varies across the capture. Constant unknowns are likely flags/padding; the
+    /// varying ones sitting next to known sensor fields are where the undecoded signal lives.
+    public static func coverage(_ records: [Record]) -> [GroupCoverage] {
+        let groups = Dictionary(grouping: records, by: { groupKey($0.frame) })
+        var out: [GroupCoverage] = []
+        for (key, recs) in groups {
+            let len = modalLength(recs)
+            let sized = recs.filter { $0.bytes.count == len }
+            guard len > 0, !sized.isEmpty else {
+                out.append(GroupCoverage(key: key, frameCount: recs.count, frameLen: len,
+                                         coveredBytes: 0, totalBytes: len, unknownBytes: [],
+                                         unknownEntropyBits: 0, unknownSampleCount: 0))
+                continue
+            }
+            // Union the covered offsets across the group so a conditional field present in only some
+            // frames still counts as decoded, never as an "unknown".
+            var covered = Set<Int>()
+            for r in sized { covered.formUnion(coveredOffsets(r.frame)) }
+            var unknown: [ByteStat] = []
+            var pooled: [UInt8] = []          // every unknown byte, all offsets × all frames — the entropy sample
+            for off in 0 ..< len where !covered.contains(off) {
+                var distinct = Set<Int>(); var lo = Int.max; var hi = Int.min
+                for r in sized {
+                    let v = Int(r.bytes[off]); distinct.insert(v)
+                    lo = min(lo, v); hi = max(hi, v)
+                    pooled.append(r.bytes[off])
+                }
+                unknown.append(ByteStat(offset: off, distinctValues: distinct.count,
+                                        minValue: lo, maxValue: hi, sampleCount: sized.count))
+            }
+            let coveredInLen = covered.filter { $0 < len }.count
+            out.append(GroupCoverage(key: key, frameCount: recs.count, frameLen: len,
+                                     coveredBytes: coveredInLen, totalBytes: len,
+                                     unknownBytes: unknown.sorted { $0.offset < $1.offset },
+                                     unknownEntropyBits: shannonBits(pooled), unknownSampleCount: pooled.count))
+        }
+        return out.sorted { $0.key < $1.key }
+    }
+
+    // MARK: - B) Capture diff
+
+    public struct OffsetDiff: Equatable {
+        public let offset: Int
+        public let covered: Bool
+        public let aValues: [Int]
+        public let bValues: [Int]
+        /// The two captures share NO value at this offset — the strongest feature-linked signal.
+        public var disjoint: Bool { Set(aValues).isDisjoint(with: Set(bValues)) }
+    }
+
+    public struct GroupDiff: Equatable {
+        public let key: String
+        public let inA: Bool
+        public let inB: Bool
+        /// Offsets present in BOTH captures whose value set differs (empty when the layouts match byte
+        /// for byte). Only populated for shared keys.
+        public let changedOffsets: [OffsetDiff]
+    }
+
+    /// Diff two captures by record layout. Keys in only one side surface as presence differences (a
+    /// record type/version one capture banked and the other didn't). For a shared layout, every offset
+    /// whose observed value set changed is reported — flip one device-config flag between the two
+    /// captures and the bytes that flag drives are exactly the changed (ideally disjoint) offsets.
+    public static func diff(_ a: [Record], _ b: [Record]) -> [GroupDiff] {
+        let ga = Dictionary(grouping: a, by: { groupKey($0.frame) })
+        let gb = Dictionary(grouping: b, by: { groupKey($0.frame) })
+        var out: [GroupDiff] = []
+        for key in Set(ga.keys).union(gb.keys) {
+            let ra = ga[key], rb = gb[key]
+            guard let ra, let rb else {
+                out.append(GroupDiff(key: key, inA: ra != nil, inB: rb != nil, changedOffsets: []))
+                continue
+            }
+            let lenA = modalLength(ra), lenB = modalLength(rb)
+            let sa = ra.filter { $0.bytes.count == lenA }, sb = rb.filter { $0.bytes.count == lenB }
+            let coveredA = sa.first.map { coveredOffsets($0.frame) } ?? []
+            var changed: [OffsetDiff] = []
+            for off in 0 ..< min(lenA, lenB) {
+                let va = Set(sa.map { Int($0.bytes[off]) })
+                let vb = Set(sb.map { Int($0.bytes[off]) })
+                if va != vb {
+                    changed.append(OffsetDiff(offset: off, covered: coveredA.contains(off),
+                                              aValues: va.sorted(), bValues: vb.sorted()))
+                }
+            }
+            out.append(GroupDiff(key: key, inA: true, inB: true, changedOffsets: changed))
+        }
+        return out.sorted { $0.key < $1.key }
+    }
+
+    // MARK: - C) Inventory
+
+    public struct GroupInventory: Equatable {
+        public let key: String
+        public let count: Int
+        public let okCount: Int
+        public let crcOkCount: Int
+        public let firstTsMs: Int?
+        public let lastTsMs: Int?
+        public let minLen: Int
+        public let maxLen: Int
+    }
+
+    /// A census of a capture: what types/versions it holds, how many of each, how many decoded and
+    /// passed CRC, the timestamp span, and the frame-length spread. The fastest way to see "this strap
+    /// banked a v21 we've never captured" before decoding a single byte.
+    public static func inventory(_ records: [Record]) -> [GroupInventory] {
+        let groups = Dictionary(grouping: records, by: { groupKey($0.frame) })
+        return groups.map { key, recs in
+            let ts = recs.compactMap { $0.tsMs }
+            let lens = recs.map { $0.bytes.count }
+            return GroupInventory(
+                key: key, count: recs.count,
+                okCount: recs.filter { $0.frame.ok }.count,
+                crcOkCount: recs.filter { $0.frame.crcOK == true }.count,
+                firstTsMs: ts.min(), lastTsMs: ts.max(),
+                minLen: lens.min() ?? 0, maxLen: lens.max() ?? 0)
+        }.sorted { $0.count != $1.count ? $0.count > $1.count : $0.key < $1.key }
+    }
+
+    // MARK: - D) Ground-truth alignment
+
+    public struct TruthPoint: Equatable {
+        public let tsMs: Int
+        public let value: Double
+        public init(tsMs: Int, value: Double) { self.tsMs = tsMs; self.value = value }
+    }
+
+    public struct Residual: Equatable {
+        public let tsMs: Int
+        public let truth: Double
+        public let decoded: Double?
+        public let dtMs: Int
+    }
+
+    public struct Score: Equatable {
+        public let fieldName: String
+        public let n: Int
+        public let meanAbsError: Double?
+        public let bias: Double?
+        public let pearson: Double?
+        public let residuals: [Residual]
+    }
+
+    /// Score how well a decoded field tracks timestamped ground truth (what the official app showed).
+    /// Each truth point is matched to the nearest record by `ts_ms` within `maxDtMs`, `fieldName` is
+    /// read from that record's decoded dict, and the paired values are scored: mean-absolute-error,
+    /// bias (mean signed error), and Pearson r. This is the instrument-first check that lets a
+    /// candidate PPG→HRV / SpO₂ mapping be *validated*, not eyeballed — and it's honest about coverage
+    /// (`n` is how many points actually matched a decoded record).
+    public static func groundTruth(records: [Record], truth: [TruthPoint],
+                                   fieldName: String, maxDtMs: Int = 60_000) -> Score {
+        let stamped = records.filter { $0.tsMs != nil }
+        var residuals: [Residual] = []
+        for t in truth.sorted(by: { $0.tsMs < $1.tsMs }) {
+            var best: Record?; var bestDt = Int.max
+            for r in stamped {
+                let dt = abs(r.tsMs! - t.tsMs)
+                if dt < bestDt { bestDt = dt; best = r }
+            }
+            guard let match = best, bestDt <= maxDtMs else {
+                residuals.append(Residual(tsMs: t.tsMs, truth: t.value, decoded: nil, dtMs: bestDt))
+                continue
+            }
+            let decoded = match.frame.parsed[fieldName]?.doubleValue
+            residuals.append(Residual(tsMs: t.tsMs, truth: t.value, decoded: decoded, dtMs: bestDt))
+        }
+        let pairs = residuals.compactMap { r in r.decoded.map { (t: r.truth, d: $0) } }
+        guard !pairs.isEmpty else {
+            return Score(fieldName: fieldName, n: 0, meanAbsError: nil, bias: nil, pearson: nil,
+                         residuals: residuals)
+        }
+        let n = Double(pairs.count)
+        let mae = pairs.reduce(0.0) { $0 + abs($1.d - $1.t) } / n
+        let bias = pairs.reduce(0.0) { $0 + ($1.d - $1.t) } / n
+        return Score(fieldName: fieldName, n: pairs.count, meanAbsError: mae, bias: bias,
+                     pearson: pearson(pairs), residuals: residuals)
+    }
+
+    /// Pearson correlation over (truth, decoded) pairs; nil when fewer than two points or either side
+    /// has zero variance (a correlation would be undefined, so we say so rather than emit a fake 0/NaN).
+    private static func pearson(_ pairs: [(t: Double, d: Double)]) -> Double? {
+        guard pairs.count >= 2 else { return nil }
+        let n = Double(pairs.count)
+        let mt = pairs.reduce(0.0) { $0 + $1.t } / n
+        let md = pairs.reduce(0.0) { $0 + $1.d } / n
+        var cov = 0.0, vt = 0.0, vd = 0.0
+        for p in pairs {
+            let dt = p.t - mt, dd = p.d - md
+            cov += dt * dd; vt += dt * dt; vd += dd * dd
+        }
+        guard vt > 0, vd > 0 else { return nil }
+        return cov / (vt.squareRoot() * vd.squareRoot())
+    }
+}

--- a/Packages/WhoopProtocol/Sources/whoop-re/main.swift
+++ b/Packages/WhoopProtocol/Sources/whoop-re/main.swift
@@ -218,7 +218,7 @@ case "truth":
     print("  MAE=\(fmt(s.meanAbsError))  bias=\(fmt(s.bias))  Pearson r=\(fmt(s.pearson))")
     for r in s.residuals {
         let dec = r.decoded.map { String(format: "%.3f", $0) } ?? "—(no decode)"
-        let dt = r.dtMs == Int.max ? "—(no timestamped record)" : "\(r.dtMs)ms"
+        let dt = r.dtMs == Int.max ? "—(no record carries field)" : "\(r.dtMs)ms"
         print("      ts=\(r.tsMs)  truth=\(String(format: "%.3f", r.truth))  decoded=\(dec)  Δt=\(dt)")
     }
 

--- a/Packages/WhoopProtocol/Sources/whoop-re/main.swift
+++ b/Packages/WhoopProtocol/Sources/whoop-re/main.swift
@@ -161,8 +161,8 @@ case "coverage":
         let enc = g.likelyEncrypted ? "  ⚠︎ LIKELY ENCRYPTED/RANDOM" : ""
         print("\(g.key)  —  \(g.frameCount) frames, \(g.frameLen)B, "
               + "\(g.coveredBytes)/\(g.totalBytes) named (\(String(format: "%.0f", g.coveragePct))%), "
-              + "unknown entropy \(String(format: "%.2f", g.unknownEntropyBits)) bits/byte "
-              + "over \(g.unknownSampleCount) samples\(enc)")
+              + "unknown entropy \(String(format: "%.2f", g.unknownEntropyBits)) bits/byte/pos "
+              + "over \(g.unknownSampleCount) frames\(enc)")
         for b in g.unknownBytes {
             let tag = b.constant ? "constant" : "varies (\(b.distinctValues) distinct)"
             print("      @\(pad(String(b.offset), 4, right: true)) unknown  "
@@ -189,8 +189,13 @@ case "diff":
             print("\(g.key)  —  ONLY IN \(g.inA ? "A" : "B")")
             continue
         }
-        if g.changedOffsets.isEmpty { print("\(g.key)  —  identical value sets"); continue }
-        print("\(g.key)  —  \(g.changedOffsets.count) offset(s) changed")
+        let lenNote = g.lengthDiffers
+            ? "  ⚠︎ LENGTH DIFFERS A=\(g.lenA)B B=\(g.lenB)B — extra bytes on the longer side not compared" : ""
+        if g.changedOffsets.isEmpty {
+            print("\(g.key)  —  identical value sets\(lenNote.isEmpty ? "" : lenNote)")
+            continue
+        }
+        print("\(g.key)  —  \(g.changedOffsets.count) offset(s) changed\(lenNote)")
         for o in g.changedOffsets {
             let flag = o.disjoint ? "  ⟵ DISJOINT (feature-linked)" : ""
             let named = o.covered ? " [named]" : ""
@@ -213,7 +218,8 @@ case "truth":
     print("  MAE=\(fmt(s.meanAbsError))  bias=\(fmt(s.bias))  Pearson r=\(fmt(s.pearson))")
     for r in s.residuals {
         let dec = r.decoded.map { String(format: "%.3f", $0) } ?? "—(no decode)"
-        print("      ts=\(r.tsMs)  truth=\(String(format: "%.3f", r.truth))  decoded=\(dec)  Δt=\(r.dtMs)ms")
+        let dt = r.dtMs == Int.max ? "—(no timestamped record)" : "\(r.dtMs)ms"
+        print("      ts=\(r.tsMs)  truth=\(String(format: "%.3f", r.truth))  decoded=\(dec)  Δt=\(dt)")
     }
 
 default:

--- a/Packages/WhoopProtocol/Sources/whoop-re/main.swift
+++ b/Packages/WhoopProtocol/Sources/whoop-re/main.swift
@@ -1,0 +1,221 @@
+import Foundation
+import WhoopProtocol
+
+// whoop-re — offline reverse-engineering aids over captured WHOOP frames, using the SAME
+// WhoopProtocol decoder the app runs. The companion to `whoop-decode`: where that dumps one frame at
+// a time, this reasons across a whole capture to guide decode work. Everything here is offline over
+// already-captured data — no device, no BLE, no capture mode, zero battery/perf cost.
+//
+// Subcommands:
+//   coverage  FILE                 per (type,version) byte-coverage map + unknown-byte variance
+//   inventory FILE                 census: types/versions, counts, ok/crc rates, ts span, lengths
+//   diff      FILE_A FILE_B        value-set diff of shared layouts (flag-on vs flag-off → the bytes)
+//   truth     --field N --truth T FILE   score a decoded field against timestamped ground truth
+//
+// Input FILE is the same capture/fixture JSON `whoop-decode` reads: an array of {"hex", …} objects
+// (the richer {"hex","char","hr","ts_ms"} capture records are a superset and read too). TRUTH is a
+// JSON array of {"ts_ms", "value"} — what the official app displayed, for the `truth` scorer.
+//
+// Usage:
+//   whoop-re coverage capture.json
+//   whoop-re diff spo2_off.json spo2_on.json
+//   whoop-re truth --field hrv_rmssd --truth app_hrv.json --max-dt 90000 capture.json
+
+// MARK: - Input model (mirrors whoop-decode; the executables share no code by design)
+
+struct CaptureRecord: Decodable {
+    let hex: String
+    let char: String?
+    let hr: Int?
+    let tsMs: Int?
+    enum CodingKeys: String, CodingKey { case hex, char, hr; case tsMs = "ts_ms" }
+}
+
+struct TruthRecord: Decodable {
+    let tsMs: Int
+    let value: Double
+    enum CodingKeys: String, CodingKey { case tsMs = "ts_ms"; case value }
+}
+
+func die(_ msg: String) -> Never {
+    FileHandle.standardError.write(Data((msg + "\n").utf8)); exit(2)
+}
+
+let helpText = """
+whoop-re — offline reverse-engineering aids over captured WHOOP frames.
+
+USAGE:
+  whoop-re coverage  [--family whoop4|whoop5|auto] FILE
+  whoop-re inventory [--family whoop4|whoop5|auto] FILE
+  whoop-re diff      [--family whoop4|whoop5|auto] FILE_A FILE_B
+  whoop-re truth     [--family …] --field NAME --truth TRUTH.json [--max-dt MS] FILE
+
+FILE is a capture/fixture JSON array of {"hex", …} (the {"hex","char","hr","ts_ms"}
+capture records are read too). TRUTH is a JSON array of {"ts_ms","value"}.
+Family defaults to auto (derived per-frame from `char`, falling back to whoop5).
+"""
+
+func bytes(fromHex hex: String) -> [UInt8]? {
+    let s = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard s.count % 2 == 0 else { return nil }
+    var out = [UInt8](); out.reserveCapacity(s.count / 2)
+    var idx = s.startIndex
+    while idx < s.endIndex {
+        let next = s.index(idx, offsetBy: 2)
+        guard let b = UInt8(s[idx..<next], radix: 16) else { return nil }
+        out.append(b); idx = next
+    }
+    return out
+}
+
+enum FamilyMode { case whoop4, whoop5, auto }
+
+func resolveFamily(_ rec: CaptureRecord, _ mode: FamilyMode) -> DeviceFamily {
+    switch mode {
+    case .whoop4: return .whoop4
+    case .whoop5: return .whoop5
+    case .auto:
+        if let c = rec.char?.lowercased() {
+            if c.hasPrefix("fd4b") { return .whoop5 }
+            if c.hasPrefix("6108") { return .whoop4 }
+        }
+        return .whoop5
+    }
+}
+
+/// Load a capture file and decode every frame into a `ReTools.Record` with the same decoder the app
+/// uses (opting into per-field metadata, as the coverage map needs field spans).
+func loadRecords(_ path: String, _ family: FamilyMode) -> [ReTools.Record] {
+    guard let data = FileManager.default.contents(atPath: path) else { die("cannot read file: \(path)") }
+    let caps: [CaptureRecord]
+    do { caps = try JSONDecoder().decode([CaptureRecord].self, from: data) }
+    catch { die("could not parse capture JSON \(path): \(error)") }
+    var out: [ReTools.Record] = []
+    for (n, c) in caps.enumerated() {
+        guard let b = bytes(fromHex: c.hex) else {
+            FileHandle.standardError.write(Data("skipping bad hex at \(path)[\(n)]\n".utf8)); continue
+        }
+        let frame = parseFrame(b, family: resolveFamily(c, family), collectFields: true)
+        out.append(ReTools.Record(frame: frame, bytes: b, tsMs: c.tsMs, hr: c.hr))
+    }
+    return out
+}
+
+func pad(_ s: String, _ w: Int, right: Bool = false) -> String {
+    if s.count >= w { return s }
+    let fill = String(repeating: " ", count: w - s.count)
+    return right ? fill + s : s + fill
+}
+
+func fmt(_ d: Double?) -> String {
+    guard let d else { return "—" }
+    return String(format: "%.4f", d)
+}
+
+// MARK: - Arg parsing
+
+var args = Array(CommandLine.arguments.dropFirst())
+guard let sub = args.first else { print(helpText); exit(0) }
+if sub == "-h" || sub == "--help" { print(helpText); exit(0) }
+args.removeFirst()
+
+var family: FamilyMode = .auto
+var field: String?
+var truthPath: String?
+var maxDt = 60_000
+var positional: [String] = []
+
+var i = 0
+while i < args.count {
+    switch args[i] {
+    case "--family":
+        i += 1; guard i < args.count else { die("--family needs a value") }
+        switch args[i] {
+        case "whoop4": family = .whoop4
+        case "whoop5": family = .whoop5
+        case "auto": family = .auto
+        default: die("--family must be whoop4|whoop5|auto")
+        }
+    case "--field":
+        i += 1; guard i < args.count else { die("--field needs a value") }; field = args[i]
+    case "--truth":
+        i += 1; guard i < args.count else { die("--truth needs a value") }; truthPath = args[i]
+    case "--max-dt":
+        i += 1; guard i < args.count, let v = Int(args[i]) else { die("--max-dt needs an integer (ms)") }; maxDt = v
+    case let a where a.hasPrefix("-"): die("unknown option: \(a)")
+    default: positional.append(args[i])
+    }
+    i += 1
+}
+
+// MARK: - Subcommands
+
+func requireFile(_ n: Int = 1) {
+    guard positional.count >= n else { die("\(sub) needs \(n) FILE argument\(n == 1 ? "" : "s")\n\n\(helpText)") }
+}
+
+switch sub {
+case "coverage":
+    requireFile()
+    for g in ReTools.coverage(loadRecords(positional[0], family)) {
+        let enc = g.likelyEncrypted ? "  ⚠︎ LIKELY ENCRYPTED/RANDOM" : ""
+        print("\(g.key)  —  \(g.frameCount) frames, \(g.frameLen)B, "
+              + "\(g.coveredBytes)/\(g.totalBytes) named (\(String(format: "%.0f", g.coveragePct))%), "
+              + "unknown entropy \(String(format: "%.2f", g.unknownEntropyBits)) bits/byte "
+              + "over \(g.unknownSampleCount) samples\(enc)")
+        for b in g.unknownBytes {
+            let tag = b.constant ? "constant" : "varies (\(b.distinctValues) distinct)"
+            print("      @\(pad(String(b.offset), 4, right: true)) unknown  "
+                  + "0x\(String(b.minValue, radix: 16))..0x\(String(b.maxValue, radix: 16))  \(tag)")
+        }
+    }
+
+case "inventory":
+    requireFile()
+    print(pad("TYPE/VERSION", 24) + pad("COUNT", 8, right: true) + pad("OK", 8, right: true)
+          + pad("CRC", 8, right: true) + pad("LEN", 12, right: true) + "  TS SPAN")
+    for g in ReTools.inventory(loadRecords(positional[0], family)) {
+        let lenCol = g.minLen == g.maxLen ? "\(g.minLen)" : "\(g.minLen)-\(g.maxLen)"
+        let span = (g.firstTsMs != nil && g.lastTsMs != nil) ? "\(g.firstTsMs!)..\(g.lastTsMs!)" : "—"
+        print(pad(g.key, 24) + pad(String(g.count), 8, right: true) + pad(String(g.okCount), 8, right: true)
+              + pad(String(g.crcOkCount), 8, right: true) + pad(lenCol, 12, right: true) + "  \(span)")
+    }
+
+case "diff":
+    requireFile(2)
+    let a = loadRecords(positional[0], family), b = loadRecords(positional[1], family)
+    for g in ReTools.diff(a, b) {
+        if !g.inA || !g.inB {
+            print("\(g.key)  —  ONLY IN \(g.inA ? "A" : "B")")
+            continue
+        }
+        if g.changedOffsets.isEmpty { print("\(g.key)  —  identical value sets"); continue }
+        print("\(g.key)  —  \(g.changedOffsets.count) offset(s) changed")
+        for o in g.changedOffsets {
+            let flag = o.disjoint ? "  ⟵ DISJOINT (feature-linked)" : ""
+            let named = o.covered ? " [named]" : ""
+            print("      @\(pad(String(o.offset), 4, right: true))\(named)  A=\(o.aValues)  B=\(o.bValues)\(flag)")
+        }
+    }
+
+case "truth":
+    requireFile()
+    guard let field else { die("truth needs --field NAME") }
+    guard let truthPath else { die("truth needs --truth TRUTH.json") }
+    guard let tdata = FileManager.default.contents(atPath: truthPath) else { die("cannot read truth: \(truthPath)") }
+    let traw: [TruthRecord]
+    do { traw = try JSONDecoder().decode([TruthRecord].self, from: tdata) }
+    catch { die("could not parse truth JSON: \(error)") }
+    let truth = traw.map { ReTools.TruthPoint(tsMs: $0.tsMs, value: $0.value) }
+    let s = ReTools.groundTruth(records: loadRecords(positional[0], family), truth: truth,
+                                fieldName: field, maxDtMs: maxDt)
+    print("field=\(s.fieldName)  matched \(s.n)/\(truth.count) truth points (max Δt \(maxDt)ms)")
+    print("  MAE=\(fmt(s.meanAbsError))  bias=\(fmt(s.bias))  Pearson r=\(fmt(s.pearson))")
+    for r in s.residuals {
+        let dec = r.decoded.map { String(format: "%.3f", $0) } ?? "—(no decode)"
+        print("      ts=\(r.tsMs)  truth=\(String(format: "%.3f", r.truth))  decoded=\(dec)  Δt=\(r.dtMs)ms")
+    }
+
+default:
+    die("unknown subcommand: \(sub)\n\n\(helpText)")
+}

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/ReToolsTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/ReToolsTests.swift
@@ -1,0 +1,190 @@
+import XCTest
+@testable import WhoopProtocol
+
+// ReTools — the four offline RE aids. Frames are built by decoding controlled JSON through
+// `ParsedFrame`'s own Codable conformance, so each test drives exact field spans / byte values without
+// depending on the wire format or CRC. The point is the analysis math, and it must be deterministic.
+final class ReToolsTests: XCTestCase {
+
+    // Build a ParsedFrame with the given type, version (seq), named field spans, and decoded dict.
+    private func frame(type: String, seq: Int? = nil, len: Int,
+                       named: [(off: Int, len: Int)] = [], ok: Bool = true, crcOK: Bool = true,
+                       parsed: [String: Any] = [:]) -> ParsedFrame {
+        let fields: [[String: Any]] = named.map { span in
+            ["off": span.off, "len": span.len, "name": "f\(span.off)", "cat": "x",
+             "value": NSNull(), "raw": "", "note": NSNull()]
+        }
+        var dict: [String: Any] = [
+            "ok": ok, "typeName": type, "seq": seq as Any? ?? NSNull(), "cmdName": NSNull(),
+            "crcOK": crcOK, "lenBytes": len, "rawHex": "", "fields": fields, "parsed": parsed,
+        ]
+        if seq == nil { dict["seq"] = NSNull() }
+        let data = try! JSONSerialization.data(withJSONObject: dict)
+        return try! JSONDecoder().decode(ParsedFrame.self, from: data)
+    }
+
+    private func rec(_ f: ParsedFrame, bytes: [UInt8], ts: Int? = nil) -> ReTools.Record {
+        ReTools.Record(frame: f, bytes: bytes, tsMs: ts, hr: nil)
+    }
+
+    // MARK: - group key: HISTORICAL_DATA splits by version (seq), others don't
+
+    func testGroupKeyVersionsHistoricalOnly() {
+        XCTAssertEqual(ReTools.groupKey(frame(type: "HISTORICAL_DATA", seq: 18, len: 4)), "HISTORICAL_DATA/v18")
+        XCTAssertEqual(ReTools.groupKey(frame(type: "HISTORICAL_DATA", seq: 20, len: 4)), "HISTORICAL_DATA/v20")
+        // A non-historical type ignores seq (seq there is a command counter, not a layout selector).
+        XCTAssertEqual(ReTools.groupKey(frame(type: "EVENT", seq: 7, len: 4)), "EVENT")
+    }
+
+    // MARK: - A) coverage: covered count, constant vs varying unknowns
+
+    func testCoverageNamesConstantAndVaryingUnknowns() {
+        // 6-byte HISTORICAL_DATA v18: bytes 0..1 named (a 2-byte field). 2 = constant unknown,
+        // 3 = varying unknown, 4..5 unnamed too (both varying).
+        let f = { (b: [UInt8]) in self.rec(self.frame(type: "HISTORICAL_DATA", seq: 18, len: 6,
+                                                       named: [(0, 2)]), bytes: b) }
+        let recs = [f([0xAA, 0x01, 0x09, 0x10, 0x00, 0x00]),
+                    f([0xBB, 0x02, 0x09, 0x20, 0x01, 0xFF]),
+                    f([0xCC, 0x03, 0x09, 0x30, 0x02, 0x80])]
+        let cov = ReTools.coverage(recs)
+        XCTAssertEqual(cov.count, 1)
+        let g = cov[0]
+        XCTAssertEqual(g.key, "HISTORICAL_DATA/v18")
+        XCTAssertEqual(g.frameCount, 3)
+        XCTAssertEqual(g.frameLen, 6)
+        XCTAssertEqual(g.coveredBytes, 2)          // only offsets 0,1 named
+        XCTAssertEqual(g.totalBytes, 6)
+        XCTAssertEqual(g.unknownBytes.map { $0.offset }, [2, 3, 4, 5])
+        let byOff = Dictionary(uniqueKeysWithValues: g.unknownBytes.map { ($0.offset, $0) })
+        XCTAssertTrue(byOff[2]!.constant)          // always 0x09
+        XCTAssertEqual(byOff[2]!.minValue, 0x09)
+        XCTAssertEqual(byOff[2]!.maxValue, 0x09)
+        XCTAssertFalse(byOff[3]!.constant)         // 0x10/0x20/0x30
+        XCTAssertEqual(byOff[3]!.distinctValues, 3)
+        XCTAssertEqual(byOff[3]!.minValue, 0x10)
+        XCTAssertEqual(byOff[3]!.maxValue, 0x30)
+    }
+
+    func testCoverageUsesModalLengthAndUnionsConditionalFields() {
+        // A lone truncated frame must not skew offsets: modal length wins.
+        let full = frame(type: "REALTIME_DATA", len: 4, named: [(0, 1)])
+        let short = frame(type: "REALTIME_DATA", len: 2, named: [(0, 1)])
+        let recs = [rec(full, bytes: [0x01, 0x02, 0x03, 0x04]),
+                    rec(full, bytes: [0x01, 0x02, 0x03, 0x05]),
+                    rec(short, bytes: [0x01, 0x02])]
+        let g = ReTools.coverage(recs).first { $0.key == "REALTIME_DATA" }!
+        XCTAssertEqual(g.frameLen, 4)              // modal, not the 2-byte outlier
+        XCTAssertEqual(g.unknownBytes.map { $0.offset }, [1, 2, 3])
+    }
+
+    func testCoverageEntropyFlagsRandomButNotStructured() {
+        // Structured: unknown bytes are a constant + a small ramp → low entropy, never flagged.
+        var structured: [ReTools.Record] = []
+        for i in 0..<300 {
+            let ramp = UInt8(i % 4)
+            let bytes: [UInt8] = [0x01, 0x09, ramp]   // off1 constant, off2 tiny range
+            structured.append(rec(frame(type: "HISTORICAL_DATA", seq: 20, len: 3, named: [(0, 1)]), bytes: bytes))
+        }
+        let sg = ReTools.coverage(structured)[0]
+        XCTAssertLessThan(sg.unknownEntropyBits, 3.0)   // structured: far below the 7.5 encrypted flag
+        XCTAssertFalse(sg.likelyEncrypted)
+
+        // Random-looking: unknown bytes sweep the full 0..255 space → entropy ≈ 8, flagged.
+        var random: [ReTools.Record] = []
+        for i in 0..<300 {
+            let a = UInt8(i % 256)
+            let b = UInt8((i * 37 + 11) % 256)
+            let bytes: [UInt8] = [0x01, a, b]
+            random.append(rec(frame(type: "HISTORICAL_DATA", seq: 21, len: 3, named: [(0, 1)]), bytes: bytes))
+        }
+        let rg = ReTools.coverage(random)[0]
+        XCTAssertGreaterThan(rg.unknownEntropyBits, 7.5)
+        XCTAssertGreaterThanOrEqual(rg.unknownSampleCount, 256)
+        XCTAssertTrue(rg.likelyEncrypted)
+    }
+
+    // MARK: - C) inventory: census sorted by count, ok/crc, ts span, len spread
+
+    func testInventoryCensus() {
+        let hist = frame(type: "HISTORICAL_DATA", seq: 26, len: 8, ok: true, crcOK: true)
+        let bad = frame(type: "HISTORICAL_DATA", seq: 26, len: 6, ok: false, crcOK: false)
+        let evt = frame(type: "EVENT", len: 4, ok: true, crcOK: true)
+        let recs = [rec(hist, bytes: Array(repeating: 0, count: 8), ts: 1000),
+                    rec(hist, bytes: Array(repeating: 0, count: 8), ts: 3000),
+                    rec(bad, bytes: Array(repeating: 0, count: 6), ts: 2000),
+                    rec(evt, bytes: [0, 0, 0, 0], ts: 500)]
+        let inv = ReTools.inventory(recs)
+        XCTAssertEqual(inv.first?.key, "HISTORICAL_DATA/v26")   // 3 records → most common, sorts first
+        let h = inv.first!
+        XCTAssertEqual(h.count, 3)
+        XCTAssertEqual(h.okCount, 2)
+        XCTAssertEqual(h.crcOkCount, 2)
+        XCTAssertEqual(h.firstTsMs, 1000)
+        XCTAssertEqual(h.lastTsMs, 3000)
+        XCTAssertEqual(h.minLen, 6)
+        XCTAssertEqual(h.maxLen, 8)
+    }
+
+    // MARK: - B) diff: presence + feature-linked (disjoint) offsets
+
+    func testDiffPresenceAndDisjointOffsets() {
+        // Capture A: two record types. Capture B: one shared type with a flipped byte, plus a type A lacks.
+        let sharedA = frame(type: "HISTORICAL_DATA", seq: 26, len: 4, named: [(0, 1)])
+        let sharedB = frame(type: "HISTORICAL_DATA", seq: 26, len: 4, named: [(0, 1)])
+        let onlyA = frame(type: "METADATA", len: 4)
+        let onlyB = frame(type: "REALTIME_RAW_DATA", len: 4)
+        // Offset 2 is disjoint (A always 0x00, B always 0x01) → the feature-linked byte.
+        let a = [rec(sharedA, bytes: [0x0A, 0x0B, 0x00, 0x0C]),
+                 rec(sharedA, bytes: [0x0A, 0x0B, 0x00, 0x0D]),
+                 rec(onlyA, bytes: [0, 0, 0, 0])]
+        let b = [rec(sharedB, bytes: [0x0A, 0x0B, 0x01, 0x0C]),
+                 rec(sharedB, bytes: [0x0A, 0x0B, 0x01, 0x0D]),
+                 rec(onlyB, bytes: [0, 0, 0, 0])]
+        let d = ReTools.diff(a, b)
+        let byKey = Dictionary(uniqueKeysWithValues: d.map { ($0.key, $0) })
+        XCTAssertEqual(byKey["METADATA"]?.inA, true)
+        XCTAssertEqual(byKey["METADATA"]?.inB, false)
+        XCTAssertEqual(byKey["REALTIME_RAW_DATA"]?.inB, true)
+        XCTAssertEqual(byKey["REALTIME_RAW_DATA"]?.inA, false)
+        let shared = byKey["HISTORICAL_DATA/v26"]!
+        XCTAssertTrue(shared.inA && shared.inB)
+        let changed = shared.changedOffsets
+        XCTAssertEqual(changed.map { $0.offset }, [2])   // only offset 2 differs; 3 shares {0C,0D}
+        XCTAssertTrue(changed[0].disjoint)
+        XCTAssertEqual(changed[0].aValues, [0x00])
+        XCTAssertEqual(changed[0].bValues, [0x01])
+    }
+
+    // MARK: - D) ground truth: MAE / bias / Pearson, and honest coverage
+
+    func testGroundTruthScoresAndReportsUnmatched() {
+        let mk = { (ts: Int, v: Double) in
+            self.rec(self.frame(type: "HISTORICAL_DATA", seq: 26, len: 4, parsed: ["hrv": v]),
+                     bytes: [0, 0, 0, 0], ts: ts)
+        }
+        // Decoded hrv tracks truth +1 (bias +1), perfectly correlated.
+        let recs = [mk(1000, 51), mk(2000, 61), mk(3000, 71)]
+        let truth = [ReTools.TruthPoint(tsMs: 1000, value: 50),
+                     ReTools.TruthPoint(tsMs: 2000, value: 60),
+                     ReTools.TruthPoint(tsMs: 3000, value: 70),
+                     ReTools.TruthPoint(tsMs: 999_999, value: 99)]   // no record within Δt → unmatched
+        let s = ReTools.groundTruth(records: recs, truth: truth, fieldName: "hrv", maxDtMs: 60_000)
+        XCTAssertEqual(s.n, 3)                          // 4th truth point has no decode
+        XCTAssertEqual(s.meanAbsError!, 1.0, accuracy: 1e-9)
+        XCTAssertEqual(s.bias!, 1.0, accuracy: 1e-9)
+        XCTAssertEqual(s.pearson!, 1.0, accuracy: 1e-9)
+        XCTAssertEqual(s.residuals.count, 4)
+        XCTAssertNil(s.residuals.last?.decoded)         // the far truth point decodes to nil
+    }
+
+    func testGroundTruthNilStatsWhenNothingMatches() {
+        let recs = [rec(frame(type: "HISTORICAL_DATA", seq: 26, len: 4, parsed: ["hrv": 50.0]),
+                        bytes: [0, 0, 0, 0], ts: 1000)]
+        // Field name that isn't in the decoded dict → no numeric decode → n=0, nil stats.
+        let s = ReTools.groundTruth(records: recs, truth: [ReTools.TruthPoint(tsMs: 1000, value: 50)],
+                                    fieldName: "not_a_field", maxDtMs: 60_000)
+        XCTAssertEqual(s.n, 0)
+        XCTAssertNil(s.meanAbsError)
+        XCTAssertNil(s.pearson)
+    }
+}

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/ReToolsTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/ReToolsTests.swift
@@ -205,6 +205,22 @@ final class ReToolsTests: XCTestCase {
         XCTAssertNil(s.residuals.last?.decoded)         // the far truth point decodes to nil
     }
 
+    func testGroundTruthMatchesFieldBearingRecordNotNearestFrame() {
+        // A truth point at t=1000. The NEAREST record by time (t=1000) is some other packet that does
+        // NOT carry `hrv`; the field-bearing record is farther (t=6000, Δt=5s, still within maxDt).
+        // The scorer must pair with the field-bearing one — not report "no decode" off the nearer frame.
+        let nearNoField = rec(frame(type: "REALTIME_DATA", len: 4, parsed: [:]), bytes: [0, 0, 0, 0], ts: 1000)
+        let farWithField = rec(frame(type: "HISTORICAL_DATA", seq: 26, len: 4, parsed: ["hrv": 55.0]),
+                               bytes: [0, 0, 0, 0], ts: 6000)
+        let s = ReTools.groundTruth(records: [nearNoField, farWithField],
+                                    truth: [ReTools.TruthPoint(tsMs: 1000, value: 55)],
+                                    fieldName: "hrv", maxDtMs: 60_000)
+        XCTAssertEqual(s.n, 1)                          // matched the field-bearing record, not the nearer empty one
+        XCTAssertEqual(s.residuals.first?.decoded, 55.0)
+        XCTAssertEqual(s.residuals.first?.dtMs, 5000)   // Δt to the field-bearing record, not 0
+        XCTAssertEqual(s.meanAbsError!, 0.0, accuracy: 1e-9)
+    }
+
     func testGroundTruthNilStatsWhenNothingMatches() {
         let recs = [rec(frame(type: "HISTORICAL_DATA", seq: 26, len: 4, parsed: ["hrv": 50.0]),
                         bytes: [0, 0, 0, 0], ts: 1000)]

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/ReToolsTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/ReToolsTests.swift
@@ -103,6 +103,22 @@ final class ReToolsTests: XCTestCase {
         XCTAssertTrue(rg.likelyEncrypted)
     }
 
+    func testCoverageEntropyIsPerOffsetNotPooled() {
+        // Each unknown offset holds a DIFFERENT constant. Pooled entropy would read ~log2(8)=3 bits and
+        // look "somewhat random"; per-offset entropy is 0 at every position → mean 0. This is the whole
+        // point of measuring per-position, not pooled.
+        var recs: [ReTools.Record] = []
+        for _ in 0..<300 {
+            let bytes: [UInt8] = [0xAA, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]  // off0 named, 1..7 distinct constants
+            recs.append(rec(frame(type: "HISTORICAL_DATA", seq: 20, len: 8, named: [(0, 1)]), bytes: bytes))
+        }
+        let g = ReTools.coverage(recs)[0]
+        XCTAssertEqual(g.unknownEntropyBits, 0.0, accuracy: 1e-9)   // every position constant → 0, despite 7 distinct values
+        XCTAssertFalse(g.likelyEncrypted)
+        XCTAssertEqual(g.unknownSampleCount, 300)                   // frames, not bytes
+        XCTAssertTrue(g.unknownBytes.allSatisfy { $0.constant })
+    }
+
     // MARK: - C) inventory: census sorted by count, ok/crc, ts span, len spread
 
     func testInventoryCensus() {
@@ -153,6 +169,18 @@ final class ReToolsTests: XCTestCase {
         XCTAssertTrue(changed[0].disjoint)
         XCTAssertEqual(changed[0].aValues, [0x00])
         XCTAssertEqual(changed[0].bValues, [0x01])
+    }
+
+    func testDiffSurfacesLengthMismatch() {
+        // Same type/version, but B's layout grew by two trailing bytes (a feature that ADDS bytes) —
+        // those extra bytes are past the overlap and must be flagged, not silently dropped.
+        let a = [rec(frame(type: "HISTORICAL_DATA", seq: 26, len: 4), bytes: [0x01, 0x02, 0x03, 0x04])]
+        let b = [rec(frame(type: "HISTORICAL_DATA", seq: 26, len: 6), bytes: [0x01, 0x02, 0x03, 0x04, 0x09, 0x0A])]
+        let g = ReTools.diff(a, b).first { $0.key == "HISTORICAL_DATA/v26" }!
+        XCTAssertTrue(g.lengthDiffers)
+        XCTAssertEqual(g.lenA, 4)
+        XCTAssertEqual(g.lenB, 6)
+        XCTAssertTrue(g.changedOffsets.isEmpty)   // the 4-byte overlap is identical; the growth is the signal
     }
 
     // MARK: - D) ground truth: MAE / bias / Pearson, and honest coverage


### PR DESCRIPTION
## whoop-re — offline RE tooling to close the 5/MG decode gaps

A new `whoop-re` CLI + a pure `ReTools` library in `WhoopProtocol`, giving four
offline analyses over already-captured frames — using the **same decoder the app
runs**, so the RE path and the app can never drift. These make a raw capture
immediately legible instead of a wall of hex, and they run entirely offline: no
device, no BLE, no on-device/battery cost, and (being dev tooling with no new wire
semantics) no Kotlin twin is required.

### The four tools
- **`coverage FILE`** — per `(type, version)` byte-coverage map: which payload bytes
  the schema already names vs. doesn't, and for every unknown offset its cross-frame
  variance (constant = flag/padding; varying = live field worth decoding). Also reports
  **pooled Shannon entropy** over the unknown bytes, which distinguishes a genuinely
  **encrypted/random** channel (~8 bits/byte) from **merely-undecoded plaintext**
  (structured, low entropy) — the honest first question before chasing a decode.
- **`diff FILE_A FILE_B`** — value-set diff of a shared record layout across two
  captures. Flip one device-config flag between the captures and the bytes it drives
  fall out as the changed / disjoint offsets (e.g. isolating SpO₂-linked bytes).
- **`inventory FILE`** — a census: which types/versions a capture holds, counts,
  ok/CRC rates, timestamp span, length spread. "This strap banked a v21 we've never
  seen" at a glance.
- **`truth --field NAME --truth T.json FILE`** — align a decoded field to timestamped
  ground truth (what the official app displayed) and score it (MAE, bias, Pearson r),
  so a candidate mapping is **validated, not eyeballed** — the instrument-first bar.

### Why
`HISTORICAL_DATA` (type-47) splits by its version byte (surfaced as `seq`), so coverage
and diff analyse v18/v20/v21/v26 as the distinct layouts they are. The open 5/MG items
are hardware-gated, not tooling-gated; this is the workbench that makes the first real
5/MG capture productive.

### Scope / safety
- **Offline, read-only analysis** over captured data. No device, no BLE, no capture
  mode, no battery/perf cost. No DRM circumvention — it reports *about* the decode of
  frames the owner already captured.
- Pure library in `WhoopProtocol` (Linux-buildable) → covered by `swift-packages` CI.

### Testing
- 8 new unit tests (`ReToolsTests`): group-key versioning, coverage math + modal-length +
  conditional-field union, entropy flags random-vs-structured, inventory census, diff
  presence + disjoint offsets, ground-truth MAE/bias/Pearson + honest unmatched coverage.
- Full `WhoopProtocol` suite green on Linux: **576 tests, 0 failures**.
- Smoke-tested end-to-end against real fixture frames (all four subcommands).
