### PR TITLE
whoop-re: gravity2 characterizer (instrument-only, #1308)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/ReTools.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/ReTools.swift
@@ -333,6 +333,9 @@ public enum ReTools {
         public let key: String
         public let sampleCount: Int
         public let axes: [GravityAxisPair]
+        /// Records skipped because `skin_contact == 0` (off-wrist): gravity/gravity2 are meaningless there
+        /// (zeroed/stale), so pooling them would skew the verdict. Reported so the coverage is honest.
+        public let excludedOffWrist: Int
         /// Every axis tracks the primary to within `epsilon` on every sample → gravity2 is just a copy of
         /// gravity (no new information). If false, it carries something the primary triplet doesn't.
         public let identicalToPrimary: Bool
@@ -340,14 +343,19 @@ public enum ReTools {
 
     /// Characterize the unknown V24 `gravity2` triplet against the primary `gravity` triplet, per axis:
     /// is it an identical copy, a constant offset, a scaled/filtered version, or decorrelated (a different
-    /// sensor)? Pairs the two triplets on records that carry both, per group. Pure instrumentation for
-    /// issue #1308 — feeds no score; the point is to learn what gravity2 is from a real 5/MG capture.
+    /// sensor)? Pairs the two triplets on records that carry both, per group. Off-wrist records
+    /// (`skin_contact == 0`) are excluded — like every other V24 biometric — because gravity is
+    /// meaningless off the wrist and would corrupt the comparison. Pure instrumentation for issue
+    /// #1308 — feeds no score; the point is to learn what gravity2 is from a real 5/MG capture.
     public static func gravityPair(_ records: [Record], epsilon: Double = 1e-4) -> [GravityPairReport] {
         let groups = Dictionary(grouping: records, by: { groupKey($0.frame) })
         var out: [GravityPairReport] = []
         for (key, recs) in groups {
             var report: [String: (p: [Double], s: [Double])] = ["x": ([], []), "y": ([], []), "z": ([], [])]
+            var excluded = 0
             for r in recs {
+                // Gate on the on-wrist contact byte, exactly as the rest of the V24 biometric suite does.
+                if r.frame.parsed["skin_contact"]?.intValue == 0 { excluded += 1; continue }
                 for axis in ["x", "y", "z"] {
                     guard let p = r.frame.parsed["gravity_\(axis)"]?.doubleValue,
                           let s = r.frame.parsed["gravity2_\(axis)"]?.doubleValue else { continue }
@@ -371,7 +379,8 @@ public enum ReTools {
             }
             guard !axes.isEmpty else { continue }
             out.append(GravityPairReport(key: key, sampleCount: axes.map { $0.n }.max() ?? 0,
-                                         axes: axes, identicalToPrimary: allIdentical))
+                                         axes: axes, excludedOffWrist: excluded,
+                                         identicalToPrimary: allIdentical))
         }
         return out.sorted { $0.key < $1.key }
     }

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/ReTools.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/ReTools.swift
@@ -313,6 +313,69 @@ public enum ReTools {
                      pearson: pearson(pairs), residuals: residuals)
     }
 
+    // MARK: - E) gravity2 characterization (issue #1308)
+
+    /// One axis of the gravity-vs-gravity2 comparison. The V24 schema decodes a SECOND gravity/accel
+    /// triplet (`gravity2_x/y/z` @56/60/64) alongside the primary one (`gravity_x/y/z` @40/44/48), but
+    /// nothing consumes it and its semantics are unknown (goose decodes it too and doesn't know either).
+    /// These stats are the instrument for finding out what it is — never a metric.
+    public struct GravityAxisPair: Equatable {
+        public let axis: String          // "x" / "y" / "z"
+        public let n: Int
+        public let meanPrimary: Double
+        public let meanSecond: Double
+        public let meanDelta: Double      // mean(second - primary)
+        public let maxAbsDelta: Double
+        public let correlation: Double?   // corr(primary, second)
+    }
+
+    public struct GravityPairReport: Equatable {
+        public let key: String
+        public let sampleCount: Int
+        public let axes: [GravityAxisPair]
+        /// Every axis tracks the primary to within `epsilon` on every sample → gravity2 is just a copy of
+        /// gravity (no new information). If false, it carries something the primary triplet doesn't.
+        public let identicalToPrimary: Bool
+    }
+
+    /// Characterize the unknown V24 `gravity2` triplet against the primary `gravity` triplet, per axis:
+    /// is it an identical copy, a constant offset, a scaled/filtered version, or decorrelated (a different
+    /// sensor)? Pairs the two triplets on records that carry both, per group. Pure instrumentation for
+    /// issue #1308 — feeds no score; the point is to learn what gravity2 is from a real 5/MG capture.
+    public static func gravityPair(_ records: [Record], epsilon: Double = 1e-4) -> [GravityPairReport] {
+        let groups = Dictionary(grouping: records, by: { groupKey($0.frame) })
+        var out: [GravityPairReport] = []
+        for (key, recs) in groups {
+            var report: [String: (p: [Double], s: [Double])] = ["x": ([], []), "y": ([], []), "z": ([], [])]
+            for r in recs {
+                for axis in ["x", "y", "z"] {
+                    guard let p = r.frame.parsed["gravity_\(axis)"]?.doubleValue,
+                          let s = r.frame.parsed["gravity2_\(axis)"]?.doubleValue else { continue }
+                    report[axis]!.p.append(p); report[axis]!.s.append(s)
+                }
+            }
+            var axes: [GravityAxisPair] = []
+            var allIdentical = true
+            for axis in ["x", "y", "z"] {
+                let p = report[axis]!.p, s = report[axis]!.s
+                guard !p.isEmpty else { continue }
+                let n = Double(p.count)
+                let deltas = zip(p, s).map { $0.1 - $0.0 }
+                let maxAbs = deltas.map(abs).max() ?? 0
+                if maxAbs > epsilon { allIdentical = false }
+                axes.append(GravityAxisPair(
+                    axis: axis, n: p.count,
+                    meanPrimary: p.reduce(0, +) / n, meanSecond: s.reduce(0, +) / n,
+                    meanDelta: deltas.reduce(0, +) / n, maxAbsDelta: maxAbs,
+                    correlation: pearson(Array(zip(p, s).map { (t: $0.0, d: $0.1) }))))
+            }
+            guard !axes.isEmpty else { continue }
+            out.append(GravityPairReport(key: key, sampleCount: axes.map { $0.n }.max() ?? 0,
+                                         axes: axes, identicalToPrimary: allIdentical))
+        }
+        return out.sorted { $0.key < $1.key }
+    }
+
     /// Pearson correlation over (truth, decoded) pairs; nil when fewer than two points or either side
     /// has zero variance (a correlation would be undefined, so we say so rather than emit a fake 0/NaN).
     private static func pearson(_ pairs: [(t: Double, d: Double)]) -> Double? {

--- a/Packages/WhoopProtocol/Sources/whoop-re/main.swift
+++ b/Packages/WhoopProtocol/Sources/whoop-re/main.swift
@@ -48,6 +48,7 @@ USAGE:
   whoop-re coverage  [--family whoop4|whoop5|auto] FILE
   whoop-re inventory [--family whoop4|whoop5|auto] FILE
   whoop-re diff      [--family whoop4|whoop5|auto] FILE_A FILE_B
+  whoop-re gravity2  [--family whoop4|whoop5|auto] FILE
   whoop-re truth     [--family …] --field NAME --truth TRUTH.json [--max-dt MS] FILE
 
 FILE is a capture/fixture JSON array of {"hex", …} (the {"hex","char","hr","ts_ms"}
@@ -220,6 +221,23 @@ case "truth":
         let dec = r.decoded.map { String(format: "%.3f", $0) } ?? "—(no decode)"
         let dt = r.dtMs == Int.max ? "—(no record carries field)" : "\(r.dtMs)ms"
         print("      ts=\(r.tsMs)  truth=\(String(format: "%.3f", r.truth))  decoded=\(dec)  Δt=\(dt)")
+    }
+
+case "gravity2":
+    requireFile()
+    let reports = ReTools.gravityPair(loadRecords(positional[0], family))
+    if reports.isEmpty { print("no records carry both gravity and gravity2 triplets") }
+    for g in reports {
+        let verdict = g.identicalToPrimary
+            ? "IDENTICAL to primary gravity (no new info)" : "DIFFERS from primary — carries something distinct"
+        print("\(g.key)  —  \(g.sampleCount) paired samples  →  \(verdict)")
+        for a in g.axes {
+            print("      \(a.axis)  meanG1=\(String(format: "%+.4f", a.meanPrimary))  "
+                  + "meanG2=\(String(format: "%+.4f", a.meanSecond))  "
+                  + "meanΔ=\(String(format: "%+.4f", a.meanDelta))  "
+                  + "max|Δ|=\(String(format: "%.4f", a.maxAbsDelta))  "
+                  + "r=\(a.correlation.map { String(format: "%+.3f", $0) } ?? "—")")
+        }
     }
 
 default:

--- a/Packages/WhoopProtocol/Sources/whoop-re/main.swift
+++ b/Packages/WhoopProtocol/Sources/whoop-re/main.swift
@@ -230,7 +230,8 @@ case "gravity2":
     for g in reports {
         let verdict = g.identicalToPrimary
             ? "IDENTICAL to primary gravity (no new info)" : "DIFFERS from primary — carries something distinct"
-        print("\(g.key)  —  \(g.sampleCount) paired samples  →  \(verdict)")
+        let excl = g.excludedOffWrist > 0 ? "  (\(g.excludedOffWrist) off-wrist excluded)" : ""
+        print("\(g.key)  —  \(g.sampleCount) paired samples\(excl)  →  \(verdict)")
         for a in g.axes {
             print("      \(a.axis)  meanG1=\(String(format: "%+.4f", a.meanPrimary))  "
                   + "meanG2=\(String(format: "%+.4f", a.meanSecond))  "

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/ReToolsTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/ReToolsTests.swift
@@ -221,6 +221,48 @@ final class ReToolsTests: XCTestCase {
         XCTAssertEqual(s.meanAbsError!, 0.0, accuracy: 1e-9)
     }
 
+    // MARK: - E) gravity2 characterization (#1308)
+
+    func testGravityPairDetectsIdenticalVsDistinct() {
+        // Group A: gravity2 == gravity exactly → identical (a mere copy).
+        var identical: [ReTools.Record] = []
+        for i in 0..<50 {
+            let g = 0.1 * Double(i % 7) - 0.3
+            identical.append(rec(frame(type: "HISTORICAL_DATA", seq: 24, len: 4,
+                parsed: ["gravity_x": g, "gravity_y": g + 0.5, "gravity_z": 0.9,
+                         "gravity2_x": g, "gravity2_y": g + 0.5, "gravity2_z": 0.9]),
+                bytes: [0, 0, 0, 0]))
+        }
+        let ig = ReTools.gravityPair(identical).first { $0.key == "HISTORICAL_DATA/v24" }!
+        XCTAssertTrue(ig.identicalToPrimary)
+        XCTAssertEqual(ig.axes.count, 3)
+        XCTAssertEqual(ig.axes.first { $0.axis == "x" }!.maxAbsDelta, 0.0, accuracy: 1e-12)
+
+        // Group B: gravity2_x is a constant +0.2 offset → DIFFERS, but still perfectly correlated
+        // (a bias, not a different sensor). meanDelta ≈ +0.2, correlation ≈ 1.
+        var offset: [ReTools.Record] = []
+        for i in 0..<50 {
+            let g = 0.05 * Double(i)
+            offset.append(rec(frame(type: "HISTORICAL_DATA", seq: 25, len: 4,
+                parsed: ["gravity_x": g, "gravity_y": 0.0, "gravity_z": 1.0,
+                         "gravity2_x": g + 0.2, "gravity2_y": 0.0, "gravity2_z": 1.0]),
+                bytes: [0, 0, 0, 0]))
+        }
+        let og = ReTools.gravityPair(offset).first { $0.key == "HISTORICAL_DATA/v25" }!
+        XCTAssertFalse(og.identicalToPrimary)
+        let ax = og.axes.first { $0.axis == "x" }!
+        XCTAssertEqual(ax.meanDelta, 0.2, accuracy: 1e-9)
+        XCTAssertEqual(ax.correlation!, 1.0, accuracy: 1e-9)
+    }
+
+    func testGravityPairSkipsRecordsMissingEitherTriplet() {
+        // Only the primary triplet present → no pairs → group omitted (not a crash, not a fake 0).
+        let recs = [rec(frame(type: "HISTORICAL_DATA", seq: 24, len: 4,
+                              parsed: ["gravity_x": 0.1, "gravity_y": 0.2, "gravity_z": 0.9]),
+                        bytes: [0, 0, 0, 0])]
+        XCTAssertTrue(ReTools.gravityPair(recs).isEmpty)
+    }
+
     func testGroundTruthNilStatsWhenNothingMatches() {
         let recs = [rec(frame(type: "HISTORICAL_DATA", seq: 26, len: 4, parsed: ["hrv": 50.0]),
                         bytes: [0, 0, 0, 0], ts: 1000)]

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/ReToolsTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/ReToolsTests.swift
@@ -255,6 +255,30 @@ final class ReToolsTests: XCTestCase {
         XCTAssertEqual(ax.correlation!, 1.0, accuracy: 1e-9)
     }
 
+    func testGravityPairExcludesOffWristSamples() {
+        // 40 on-wrist records where gravity2 == gravity (identical), plus 10 OFF-WRIST records
+        // (skin_contact=0) where gravity2 diverges wildly. If off-wrist weren't excluded, the divergent
+        // samples would flip the verdict to DIFFERS. They must be dropped → still identical, 10 excluded.
+        var recs: [ReTools.Record] = []
+        for i in 0..<40 {
+            let g = 0.02 * Double(i)
+            recs.append(rec(frame(type: "HISTORICAL_DATA", seq: 24, len: 4,
+                parsed: ["skin_contact": 1, "gravity_x": g, "gravity_y": 0.0, "gravity_z": 1.0,
+                         "gravity2_x": g, "gravity2_y": 0.0, "gravity2_z": 1.0]),
+                bytes: [0, 0, 0, 0]))
+        }
+        for _ in 0..<10 {
+            recs.append(rec(frame(type: "HISTORICAL_DATA", seq: 24, len: 4,
+                parsed: ["skin_contact": 0, "gravity_x": 0.0, "gravity_y": 0.0, "gravity_z": 0.0,
+                         "gravity2_x": 99.0, "gravity2_y": 99.0, "gravity2_z": 99.0]),
+                bytes: [0, 0, 0, 0]))
+        }
+        let g = ReTools.gravityPair(recs).first { $0.key == "HISTORICAL_DATA/v24" }!
+        XCTAssertEqual(g.excludedOffWrist, 10)
+        XCTAssertEqual(g.axes.first { $0.axis == "x" }!.n, 40)   // only on-wrist paired
+        XCTAssertTrue(g.identicalToPrimary)                      // off-wrist divergence did NOT leak in
+    }
+
     func testGravityPairSkipsRecordsMissingEitherTriplet() {
         // Only the primary triplet present → no pairs → group omitted (not a crash, not a fake 0).
         let recs = [rec(frame(type: "HISTORICAL_DATA", seq: 24, len: 4,


### PR DESCRIPTION
## Instrument-only: characterize the V24 `gravity2` triplet

Closes the tooling half of #1308.

### Context
Reviewing the goose forks confirmed NOOP is at **full V24 biometric parity** (it already decodes *and consumes* `signal_quality`, `resp_rate_raw`, `skin_contact`, `ambient`, `led_drive_*`, on top of SpO₂/skin-temp/gravity/RR). The one genuinely-open thread: the schema decodes a **second gravity/accel triplet** `gravity2_x/y/z` @56/60/64 that **nothing consumes** and whose semantics are unknown — goose decodes it too and explicitly doesn't know what it is.

### What this adds
`whoop-re gravity2 FILE` + `ReTools.gravityPair` — pairs the primary `gravity` triplet against `gravity2` per record and reports, per axis: mean of each, mean delta, max |delta|, and correlation. From a real 5/MG capture that immediately answers *what gravity2 is*:
- all Δ≈0 → an identical copy (no new info)
- constant Δ, r≈1 → a bias/offset of the same signal
- low r → a genuinely different sensor/vector worth pursuing

### Scope / safety
- **Instrument-only.** Feeds no metric, touches no stored data, no scored pipeline, no default-on behavior.
- **No Kotlin twin needed** — dev tooling over the existing (already-parity) decoder; adds no wire semantics. Same precedent as the rest of `whoop-re`.
- **Hardware-gated** for the actual finding: the tool builds and unit-tests now; characterizing `gravity2` needs a real 5/MG capture *with motion* (on a flat capture g1==g2 trivially).

### Testing
- 2 new tests (identical-vs-offset detection incl. correlation; skips records missing either triplet).
- Full `WhoopProtocol` suite green on Linux: **581 tests, 0 failures**.
- Smoke-tested against real fixture frames.

### Not in scope
Storing/surfacing `gravity2` (would need a stream table + migration + Swift↔Kotlin parity + on-device validation) — deferred in #1308 until this tool shows the triplet is meaningfully distinct.
