### PR TITLE
vitals: bound the carry so a stale value stops reading as today's measurement

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
@@ -100,6 +100,53 @@ public enum Baselines {
     public static let minNightsTrust: Int = 14
     /// Missing-night count after which a baseline is marked stale.
     public static let staleDays: Int = 14
+    /// How many days a nightly VITAL may be carried forward and still be presented as the "latest"
+    /// reading. A carry exists so one missed night doesn't blank a tile — not so a months-old value
+    /// reads as tonight's measurement. Past this age the tile must show "—": a silent stale number is
+    /// worse than no number, because the reader takes it for a current measurement (which is exactly
+    /// what a 14-day-old imported respiratory rate did, surfacing as "Respiratory 15.6" on the Sleep
+    /// tab's Night detail with no date beside it). A week comfortably covers a missed night or a
+    /// weekend off-strap while staying decisively short of `staleDays`, past which the personal
+    /// baseline that judges the value is itself stale. Byte-twin of the Android `vitalCarryDays`.
+    public static let vitalCarryDays: Int = 7
+
+    /// The freshest `(day, value)` pair that is still fresh enough to present as "latest", or nil when
+    /// the newest one is older than `vitalCarryDays` relative to `todayKey`. Both keys are `yyyy-MM-dd`,
+    /// which compares chronologically as a string, so no calendar math (or time zone) is involved —
+    /// `points` need only be sorted oldest→newest. Shared by every "latest vital" resolver so the Sleep
+    /// tab's Night detail, the Health tab's Vital Signs and the Android twin cannot disagree about when
+    /// a carried value has gone stale.
+    public static func freshestCarried<T>(_ points: [(day: String, value: T)],
+                                          todayKey: String,
+                                          carryDays: Int = vitalCarryDays) -> (day: String, value: T)? {
+        guard let newest = points.last else { return nil }
+        return newest.day >= cutoffKey(todayKey: todayKey, carryDays: carryDays) ? newest : nil
+    }
+
+    /// The oldest `yyyy-MM-dd` a carried vital may bear: `todayKey − carryDays` days. The parse, the
+    /// calendar and the format all pin UTC, so the arithmetic is pure key math and never shifts a day
+    /// under a local time zone or a DST edge. An unparseable key yields `todayKey`, which admits only
+    /// today — fail closed, never carry.
+    public static func cutoffKey(todayKey: String, carryDays: Int = vitalCarryDays) -> String {
+        guard let today = dayKeyFormatter.date(from: todayKey),
+              let cutoff = utcCalendar.date(byAdding: .day, value: -carryDays, to: today)
+        else { return todayKey }
+        return dayKeyFormatter.string(from: cutoff)
+    }
+
+    private static let utcCalendar: Calendar = {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(identifier: "UTC")!
+        return c
+    }()
+
+    private static let dayKeyFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
 
     // MARK: - Early-life anti-anchoring (Reddit HRV report)
     //

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/VitalCarryStalenessTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/VitalCarryStalenessTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// The staleness bound on a carried vital. A carry exists so a missed night doesn't blank a tile — not
+/// so a months-old value keeps reading as tonight's measurement. The regression these pin: NOOP showed
+/// "Respiratory 15.6" every day for a fortnight, which was the last value of a WHOOP CSV import that
+/// ended 2026-07-30, carried forward unbounded by two separate "latest vital" resolvers.
+final class VitalCarryStalenessTests: XCTestCase {
+
+    // MARK: cutoffKey
+
+    func testCutoffKeyIsTodayMinusCarryDays() {
+        XCTAssertEqual(Baselines.cutoffKey(todayKey: "2026-08-13", carryDays: 7), "2026-08-06")
+        XCTAssertEqual(Baselines.cutoffKey(todayKey: "2026-08-13", carryDays: 0), "2026-08-13")
+    }
+
+    func testCutoffKeyCrossesMonthAndYearBoundaries() {
+        XCTAssertEqual(Baselines.cutoffKey(todayKey: "2026-03-03", carryDays: 7), "2026-02-24")
+        XCTAssertEqual(Baselines.cutoffKey(todayKey: "2026-01-03", carryDays: 7), "2025-12-27")
+    }
+
+    /// Leap day is a real calendar step, not a 365-day assumption.
+    func testCutoffKeyHandlesLeapYear() {
+        XCTAssertEqual(Baselines.cutoffKey(todayKey: "2028-03-05", carryDays: 7), "2028-02-27")
+    }
+
+    /// Fail CLOSED: an unparseable key admits only today rather than opening the carry wide.
+    func testCutoffKeyFailsClosedOnGarbage() {
+        XCTAssertEqual(Baselines.cutoffKey(todayKey: "not-a-day", carryDays: 7), "not-a-day")
+    }
+
+    // MARK: freshestCarried
+
+    func testCarriesAValueInsideTheWindow() {
+        let points = [(day: "2026-08-01", value: 16.0), (day: "2026-08-10", value: 15.6)]
+        let got = Baselines.freshestCarried(points, todayKey: "2026-08-13", carryDays: 7)
+        XCTAssertEqual(got?.value, 15.6)
+        XCTAssertEqual(got?.day, "2026-08-10")
+    }
+
+    /// THE REPORTED BUG: the import's last day is 2026-07-30 and "today" is 2026-08-13 — 14 days.
+    /// It must not be presented as the latest reading.
+    func testDropsTheFourteenDayOldImportThatShowed156() {
+        let points = [(day: "2026-07-28", value: 16.0),
+                      (day: "2026-07-29", value: 16.2),
+                      (day: "2026-07-30", value: 15.6)]
+        XCTAssertNil(Baselines.freshestCarried(points, todayKey: "2026-08-13", carryDays: 7))
+    }
+
+    /// The window is inclusive at its edge and exclusive one day past it.
+    func testWindowEdgeIsInclusive() {
+        let atEdge = [(day: "2026-08-06", value: 15.6)]
+        XCTAssertEqual(Baselines.freshestCarried(atEdge, todayKey: "2026-08-13", carryDays: 7)?.value, 15.6)
+
+        let oneDayPast = [(day: "2026-08-05", value: 15.6)]
+        XCTAssertNil(Baselines.freshestCarried(oneDayPast, todayKey: "2026-08-13", carryDays: 7))
+    }
+
+    /// Only the NEWEST point is judged: an old value is not rescued by a fresh one, and a fresh value
+    /// is not blocked by old ones sitting behind it in the series.
+    func testJudgesOnlyTheNewestPoint() {
+        let points = [(day: "2026-07-30", value: 15.6), (day: "2026-08-12", value: 14.1)]
+        XCTAssertEqual(Baselines.freshestCarried(points, todayKey: "2026-08-13", carryDays: 7)?.value, 14.1)
+    }
+
+    func testTodaysOwnValueAlwaysCarries() {
+        let points = [(day: "2026-08-13", value: 14.1)]
+        XCTAssertEqual(Baselines.freshestCarried(points, todayKey: "2026-08-13", carryDays: 7)?.value, 14.1)
+    }
+
+    func testEmptySeriesCarriesNothing() {
+        XCTAssertNil(Baselines.freshestCarried([(day: String, value: Double)](),
+                                               todayKey: "2026-08-13", carryDays: 7))
+    }
+
+    /// A future-dated row (a bad-clock strap) is newer than the cutoff, so it still resolves — the
+    /// future-clock guard is the caller's `$0.day < todayKey` bound, not this one. Pinned so the
+    /// division of responsibility is explicit rather than accidental.
+    func testFutureDatedRowIsNotFilteredHere() {
+        let points = [(day: "2026-09-01", value: 14.1)]
+        XCTAssertEqual(Baselines.freshestCarried(points, todayKey: "2026-08-13", carryDays: 7)?.value, 14.1)
+    }
+
+    // MARK: the constant itself
+
+    /// The bound must stay well inside `staleDays` — past that the personal baseline judging the value
+    /// is itself stale, so presenting the value as "latest" is doubly wrong.
+    func testCarryWindowIsShorterThanBaselineStaleness() {
+        XCTAssertLessThan(Baselines.vitalCarryDays, Baselines.staleDays)
+        XCTAssertEqual(Baselines.vitalCarryDays, 7)
+    }
+}

--- a/Strand/Screens/SleepModel.swift
+++ b/Strand/Screens/SleepModel.swift
@@ -331,9 +331,26 @@ extension SleepModel {
     // MARK: Per-tile series (latest, typical mean, sparkline history)
 
     /// Build a metric from a per-day transform, keeping only finite values.
-    static func metric(days: [DailyMetric], _ transform: (DailyMetric) -> Double?) -> Metric {
-        let series = days.compactMap(transform).filter { $0.isFinite }
-        return (series.last, mean(series), series)
+    ///
+    /// `latest` is STALENESS-BOUNDED (`Baselines.vitalCarryDays`): it is the newest value only while
+    /// that value's own day is recent enough to still be presented as this night's reading, and nil
+    /// otherwise. Without the bound `series.last` reached back arbitrarily far — a respiratory rate
+    /// last written by a WHOOP CSV import on 30 Jul kept rendering as "Respiratory 15.6" in the Night
+    /// detail card two weeks later, with no date anywhere beside it, and was read (by the project's own
+    /// investigation) as a current measurement. `typical` and `series` are deliberately UNBOUNDED: they
+    /// are explicitly historical — the trend line and the "vs typical" mean are supposed to span the
+    /// whole history, and it is only the headline number that claims to be current.
+    static func metric(days: [DailyMetric], now: Date = Date(),
+                       _ transform: (DailyMetric) -> Double?) -> Metric {
+        let points = days.compactMap { d -> (day: String, value: Double)? in
+            guard let v = transform(d), v.isFinite else { return nil }
+            return (d.day, v)
+        }
+        let series = points.map(\.value)
+        // `BodyVitalSigns.logicalDayKey` rather than `Repository.logicalDayKey`: same 04:00 boundary,
+        // but self-contained, so this stays pure and independent of the @MainActor Repository.
+        let fresh = Baselines.freshestCarried(points, todayKey: BodyVitalSigns.logicalDayKey(now))
+        return (fresh?.value, mean(series), series)
     }
 
     /// Sleep performance %: the imported WHOOP figure when the export carried one for that day;

--- a/Strand/Screens/VitalSignsSummary.swift
+++ b/Strand/Screens/VitalSignsSummary.swift
@@ -135,9 +135,15 @@ enum BodyVitalSigns {
         }
 
         // Prefer the logical day's value; otherwise the most recent day that has one — so a vital still
-        // shows after a day with no wear instead of blanking to "—".
+        // shows after a day with no wear instead of blanking to "—". That carry is STALENESS-BOUNDED
+        // (`Baselines.vitalCarryDays`): it exists to survive a missed night, not to keep a months-old
+        // reading under a section headed "Latest". Unbounded, `pts.last` reached back arbitrarily far —
+        // a WHOOP CSV import that ended 30 Jul kept this tile reading "15.6 rpm" a fortnight later. The
+        // "· 30 Jul ·" in `stateCaption` was not enough: the eye takes the headline number for today's.
         func latest(_ pts: [VitalPoint]) -> VitalPoint? {
-            pts.last(where: { $0.day == logicalDay }) ?? pts.last
+            if let today = pts.last(where: { $0.day == logicalDay }) { return today }
+            return Baselines.freshestCarried(pts.map { (day: $0.day, value: $0) },
+                                             todayKey: logicalDay)?.value
         }
 
         func history(before day: String?, _ pts: [VitalPoint]) -> [Double?] {

--- a/StrandTests/SleepModelStaleCarryTests.swift
+++ b/StrandTests/SleepModelStaleCarryTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+import WhoopStore
+@testable import Strand
+
+/// The Night detail tiles must not present a stale value as this night's reading.
+///
+/// The regression, reported 2026-08-13: the Sleep tab's Respiratory tile read "15.6" every day for a
+/// fortnight — the last value of a WHOOP CSV import that ended 2026-07-30 — because the tile's `latest`
+/// was `series.last` with no age bound. This card is the worst place for it: unlike the Health tab's
+/// Vital Signs tile it shows NO date beside the number, and it sits under a header that names the night.
+/// Android mirrors these cases in `SleepTileCarryStalenessTest`.
+final class SleepModelStaleCarryTests: XCTestCase {
+
+    private func day(_ d: String, resp: Double? = nil) -> DailyMetric {
+        DailyMetric(day: d, totalSleepMin: 420, efficiency: 90,
+                    deepMin: 80, remMin: 90, lightMin: 200, disturbances: nil,
+                    restingHr: nil, avgHrv: nil, recovery: nil, strain: nil,
+                    exerciseCount: nil, spo2Pct: nil, skinTempDevC: nil, respRateBpm: resp)
+    }
+
+    private func noon(_ d: String) -> Date {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd HH:mm"
+        f.timeZone = .current
+        return f.date(from: "\(d) 12:00")!
+    }
+
+    /// The reported case: last respiratory value 2026-07-30, viewed on 2026-08-13.
+    func testStaleRespiratoryRateDoesNotReachTheTile() {
+        var days = [day("2026-07-29", resp: 16.2), day("2026-07-30", resp: 15.6)]
+        days += (1...13).map { day(String(format: "2026-08-%02d", $0)) }   // live nights, no resp value
+
+        let resp = SleepModel.metric(days: days, now: noon("2026-08-13")) { $0.respRateBpm }
+        XCTAssertNil(resp.latest)
+        // The trend line is HISTORICAL and survives — only the headline claims to be current.
+        XCTAssertEqual(resp.series.count, 2)
+        XCTAssertEqual(resp.typical ?? 0, 15.9, accuracy: 1e-9)
+    }
+
+    /// Sleep-derived siblings are unaffected: they carry a fresh value every night.
+    func testFreshSiblingMetricsAreUntouched() {
+        var days = [day("2026-07-30", resp: 15.6)]
+        days += (1...13).map { day(String(format: "2026-08-%02d", $0)) }
+
+        let eff = SleepModel.metric(days: days, now: noon("2026-08-13")) { $0.efficiency }
+        XCTAssertEqual(eff.latest ?? 0, 90, accuracy: 1e-9)
+    }
+
+    /// The carry still does its job: one missed night must not blank a tile.
+    func testRecentValueStillCarries() {
+        let days = [day("2026-08-11", resp: 14.1), day("2026-08-12")]
+        let resp = SleepModel.metric(days: days, now: noon("2026-08-13")) { $0.respRateBpm }
+        XCTAssertEqual(resp.latest ?? 0, 14.1, accuracy: 1e-9)
+    }
+}

--- a/StrandTests/VitalSourceResolutionTests.swift
+++ b/StrandTests/VitalSourceResolutionTests.swift
@@ -62,7 +62,13 @@ final class VitalSourceResolutionTests: XCTestCase {
             sourceRows: [
                 SourcedDailyMetric(metric: daily(day: "2026-06-12", spo2Pct: 98), source: .appleHealth)
             ],
-            temperatureUnit: .celsius
+            temperatureUnit: .celsius,
+            // Pin the clock: these fixtures are dated 2026-06-12, and the carry is staleness-bounded
+            // (`Baselines.vitalCarryDays`). Left to default to the real `Date()`, they only passed
+            // because the carry used to be unbounded — the very defect under test elsewhere. They are
+            // about SOURCE PRECEDENCE, so the day must sit inside the window for the resolution to be
+            // what is being asserted.
+            now: localNoon(day: "2026-06-13")
         )
 
         let spo2 = readings.first { $0.key == "spo2" }
@@ -77,7 +83,13 @@ final class VitalSourceResolutionTests: XCTestCase {
                 SourcedDailyMetric(metric: daily(day: "2026-06-12", spo2Pct: 96), source: .whoopImport),
                 SourcedDailyMetric(metric: daily(day: "2026-06-12", spo2Pct: 99), source: .appleHealth)
             ],
-            temperatureUnit: .celsius
+            temperatureUnit: .celsius,
+            // Pin the clock: these fixtures are dated 2026-06-12, and the carry is staleness-bounded
+            // (`Baselines.vitalCarryDays`). Left to default to the real `Date()`, they only passed
+            // because the carry used to be unbounded — the very defect under test elsewhere. They are
+            // about SOURCE PRECEDENCE, so the day must sit inside the window for the resolution to be
+            // what is being asserted.
+            now: localNoon(day: "2026-06-13")
         )
 
         let spo2 = readings.first { $0.key == "spo2" }
@@ -90,7 +102,13 @@ final class VitalSourceResolutionTests: XCTestCase {
             sourceRows: [
                 SourcedDailyMetric(metric: daily(day: "2026-06-12", skinTempDevC: 34.2), source: .appleHealth)
             ],
-            temperatureUnit: .celsius
+            temperatureUnit: .celsius,
+            // Pin the clock: these fixtures are dated 2026-06-12, and the carry is staleness-bounded
+            // (`Baselines.vitalCarryDays`). Left to default to the real `Date()`, they only passed
+            // because the carry used to be unbounded — the very defect under test elsewhere. They are
+            // about SOURCE PRECEDENCE, so the day must sit inside the window for the resolution to be
+            // what is being asserted.
+            now: localNoon(day: "2026-06-13")
         )
 
         let skin = readings.first { $0.key == "skin" }
@@ -103,7 +121,13 @@ final class VitalSourceResolutionTests: XCTestCase {
             sourceRows: [
                 SourcedDailyMetric(metric: daily(day: "2026-06-12", skinTempDevC: 0.2), source: .noopComputed)
             ],
-            temperatureUnit: .celsius
+            temperatureUnit: .celsius,
+            // Pin the clock: these fixtures are dated 2026-06-12, and the carry is staleness-bounded
+            // (`Baselines.vitalCarryDays`). Left to default to the real `Date()`, they only passed
+            // because the carry used to be unbounded — the very defect under test elsewhere. They are
+            // about SOURCE PRECEDENCE, so the day must sit inside the window for the resolution to be
+            // what is being asserted.
+            now: localNoon(day: "2026-06-13")
         )
 
         let skin = readings.first { $0.key == "skin" }
@@ -192,6 +216,48 @@ final class VitalSourceResolutionTests: XCTestCase {
         XCTAssertEqual(spo2?.source, .whoopImport)
         // The calibrated caption, NOT the "strap estimate" one.
         XCTAssertFalse(spo2?.missingCaption.contains("strap estimate") == true)
+    }
+
+    // MARK: - Carry staleness
+
+    /// THE REPORTED REGRESSION, end to end through the real resolver. A WHOOP CSV import ending
+    /// 2026-07-30 kept the Health tab's Resp Rate tile reading "15.6 rpm" on 2026-08-13 — 14 days on,
+    /// under a section headed "Latest", while the live device wrote no respiratory rate at all. The
+    /// tile must fall to its honest empty state instead of presenting a fortnight-old import as a
+    /// current measurement.
+    func testStaleImportedRespiratoryRateNoLongerCarries() {
+        let readings = BodyVitalSigns.readings(
+            sourceRows: [
+                SourcedDailyMetric(metric: daily(day: "2026-07-28", respRateBpm: 16.0), source: .whoopImport),
+                SourcedDailyMetric(metric: daily(day: "2026-07-29", respRateBpm: 16.2), source: .whoopImport),
+                SourcedDailyMetric(metric: daily(day: "2026-07-30", respRateBpm: 15.6), source: .whoopImport)
+            ],
+            temperatureUnit: .celsius,
+            now: localNoon(day: "2026-08-13")
+        )
+
+        let resp = readings.first { $0.key == "resp" }
+        XCTAssertNil(resp?.value)
+        XCTAssertNil(resp?.day)
+        XCTAssertNil(resp?.source)
+        XCTAssertEqual(resp?.banding.band, .noData)
+        // The trail is HISTORICAL and deliberately survives — only the headline claims to be current.
+        XCTAssertEqual(resp?.sparkline?.count, 3)
+    }
+
+    /// The carry still does its job: one missed night must not blank a tile.
+    func testRecentRespiratoryRateStillCarries() {
+        let readings = BodyVitalSigns.readings(
+            sourceRows: [
+                SourcedDailyMetric(metric: daily(day: "2026-08-12", respRateBpm: 14.1), source: .noopComputed)
+            ],
+            temperatureUnit: .celsius,
+            now: localNoon(day: "2026-08-13")
+        )
+
+        let resp = readings.first { $0.key == "resp" }
+        XCTAssertEqual(resp?.value, 14.1)
+        XCTAssertEqual(resp?.day, "2026-08-12")
     }
 
     // MARK: - Fixtures

--- a/android/app/src/main/java/com/noop/analytics/Baselines.kt
+++ b/android/app/src/main/java/com/noop/analytics/Baselines.kt
@@ -52,6 +52,43 @@ object Baselines {
     /** Missing-night count after which a baseline is marked stale. */
     const val staleDays: Int = 14
 
+    /**
+     * How many days a nightly VITAL may be carried forward and still be presented as the "latest"
+     * reading. A carry exists so one missed night doesn't blank a tile — not so a months-old value
+     * reads as tonight's measurement. Past this age the tile must show "—": a silent stale number is
+     * worse than no number, because the reader takes it for a current measurement (which is exactly
+     * what a 14-day-old imported respiratory rate did, surfacing as "Respiratory 15.6" on the Sleep
+     * tab's Night detail with no date beside it). A week comfortably covers a missed night or a
+     * weekend off-strap while staying decisively short of [staleDays], past which the personal
+     * baseline that judges the value is itself stale. Byte-twin of the Swift `vitalCarryDays`.
+     */
+    const val vitalCarryDays: Int = 7
+
+    /**
+     * The freshest `(day, value)` pair still fresh enough to present as "latest", or null when the
+     * newest one is older than [carryDays] relative to [todayKey]. Both keys are `yyyy-MM-dd`, which
+     * compares chronologically as a string, so no calendar math (or time zone) is involved — [points]
+     * need only be sorted oldest→newest. Byte-twin of the Swift `freshestCarried`.
+     */
+    fun <T> freshestCarried(
+        points: List<Pair<String, T>>,
+        todayKey: String,
+        carryDays: Int = vitalCarryDays,
+    ): Pair<String, T>? {
+        val newest = points.lastOrNull() ?: return null
+        return if (newest.first >= cutoffKey(todayKey, carryDays)) newest else null
+    }
+
+    /**
+     * The oldest `yyyy-MM-dd` a carried vital may bear: [todayKey] − [carryDays] days. An unparseable
+     * key yields [todayKey], which admits only today — fail closed, never carry. Byte-twin of the
+     * Swift `cutoffKey`.
+     */
+    fun cutoffKey(todayKey: String, carryDays: Int = vitalCarryDays): String =
+        runCatching {
+            java.time.LocalDate.parse(todayKey).minusDays(carryDays.toLong()).toString()
+        }.getOrDefault(todayKey)
+
     // ─────────────────────────────────────────────────────────────────────────
     // Early-life anti-anchoring (Reddit HRV report) — mirrors Baselines.swift
     // ─────────────────────────────────────────────────────────────────────────

--- a/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
@@ -326,6 +326,14 @@ internal fun latestVitals(
     )
 }
 
+/**
+ * The newest row carrying this vital, STALENESS-BOUNDED by [Baselines.vitalCarryDays]: the carry
+ * exists so a missed night doesn't blank a tile, not so a months-old reading sits under a section
+ * headed "Latest". Unbounded, this reached back arbitrarily far — a WHOOP CSV import that ended
+ * 30 Jul kept the Resp Rate tile reading "15.6 rpm" a fortnight later. The `asOfLabel` ("as of
+ * 30 Jul") was not enough on its own: the eye takes the headline number for today's. Byte-twin of
+ * the Swift `BodyVitalSigns.latest`.
+ */
 private fun latestVital(
     key: String,
     days: List<DailyMetric>,
@@ -333,9 +341,13 @@ private fun latestVital(
     emptyByKey: Map<String, Vital>,
     spo2CandidateByDay: Map<String, Double> = emptyMap(),
     spo2ToggleOn: Boolean = false,
+    todayKey: String = logicalDayKeyNow(),
     hasValue: (DailyMetric) -> Boolean,
 ): Vital {
-    val row = days.asReversed().firstOrNull(hasValue)
+    val row = Baselines.freshestCarried(
+        days.filter(hasValue).map { it.day to it },
+        todayKey,
+    )?.second
     return row
         ?.let { latestRow -> vitalsFor(latestRow, days, tempUnit, spo2CandidateByDay, spo2ToggleOn).firstOrNull { it.key == key } }
         ?.copy(asOfLabel = asOfLabel(row.day))

--- a/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
@@ -1,6 +1,7 @@
 package com.noop.ui
 
 import com.noop.analytics.AnalyticsEngine
+import com.noop.analytics.Baselines
 import com.noop.analytics.SleepDebt
 import com.noop.analytics.SleepStageTotals
 import com.noop.data.DailyMetric
@@ -126,6 +127,9 @@ internal fun buildSleepModel(
     // #sleep-consistency-parity: the full session list (onset times), used by the consistency FALLBACK
     // (bedtime-onset spread). Defaults empty for callers/tests that only exercise the imported path.
     sessions: List<SleepSession> = emptyList(),
+    // Today's logical-day key, the anchor for each tile's staleness bound (see [metric]). Injectable so
+    // tests can pin the clock instead of depending on the day they happen to run.
+    todayKey: String = logicalDayKeyNow(),
 ): SleepModel? {
     val effectiveDay = selectedDay ?: days.lastOrNull()?.day ?: return null
     // The HERO night = the selected day's stage-bearing row. The TILE / debt / need / trend
@@ -183,7 +187,7 @@ internal fun buildSleepModel(
     // substitution), latest = the most-recent day. Mirrors iOS SleepView, where every tile series
     // is `metric { … }` over repo.days. Where the WHOOP export carried the figure verbatim
     // (metricSeries), it wins per day; the on-device recomputation fills the rest.
-    val performance = metric(days) { d ->
+    val performance = metric(days, todayKey) { d ->
         imported.performance[d.day]                       // WHOOP's own 0–100 figure wins per day
             // else the REAL Rest composite (RestScorer.restFromDaily) — the SAME single source of
             // truth the Today Rest score, the metric-detail overlay (below) and iOS SleepView
@@ -191,7 +195,7 @@ internal fun buildSleepModel(
             // live 5.0 nights at 100% here while every other surface showed the ~85% composite (#298).
             ?: com.noop.analytics.RestScorer.restFromDaily(d)
     }
-    val efficiency = metric(days) { d ->
+    val efficiency = metric(days, todayKey) { d ->
         d.efficiency?.let { if (it <= 1.0) it * 100.0 else it }
     }
     val consistency = run {
@@ -205,15 +209,15 @@ internal fun buildSleepModel(
             consistencySeries(sessions)
         }
     }
-    val hoursVsNeeded = metric(days) { d ->
+    val hoursVsNeeded = metric(days, todayKey) { d ->
         val need = imported.needMin[d.day] ?: needMin   // imported need wins per day
         d.totalSleepMin?.takeIf { it > 0.0 && need > 0.0 }?.let { it / need * 100.0 }
     }
-    val restorative = metric(days) { d ->
+    val restorative = metric(days, todayKey) { d ->
         val dp = d.deepMin; val rm = d.remMin; val sl = d.totalSleepMin
         if (dp != null && rm != null && sl != null && sl > 0.0) (dp + rm) / sl * 100.0 else null
     }
-    val respiratory = metric(days) { it.respRateBpm }
+    val respiratory = metric(days, todayKey) { it.respRateBpm }
     val sleepDebt = run {
         val series = days.mapNotNull { d ->
             imported.debtMin[d.day]   // minutes, export-verbatim
@@ -302,12 +306,13 @@ internal fun fallbackSleepModel(
     imported: ImportedSleepSeries = ImportedSleepSeries(),
     napSleepMinByDay: Map<String, Double> = emptyMap(),
     sessions: List<SleepSession> = emptyList(),
+    todayKey: String = logicalDayKeyNow(),
 ): SleepModel? {
     val anchorDay = days.lastOrNull {
         (it.deepMin ?: 0.0) + (it.remMin ?: 0.0) + (it.lightMin ?: 0.0) > 0.0
     }?.day ?: return null
     return buildSleepModel(days, null, imported, selectedDay = anchorDay,
-        napSleepMinByDay = napSleepMinByDay, sessions = sessions)
+        napSleepMinByDay = napSleepMinByDay, sessions = sessions, todayKey = todayKey)
 }
 
 /**
@@ -359,10 +364,27 @@ internal suspend fun buildHostedSleepModel(
     return fallbackSleepModel(days, imported, napSleepMinByDay, sessions = sleeps)
 }
 
-/** Build a metric from a per-day transform, keeping only finite values. */
-private fun metric(days: List<DailyMetric>, transform: (DailyMetric) -> Double?): Metric {
-    val series = days.mapNotNull(transform).filter { it.isFinite() }
-    return Metric(series.lastOrNull(), mean(series), series)
+/**
+ * Build a metric from a per-day transform, keeping only finite values.
+ *
+ * `latest` is STALENESS-BOUNDED ([Baselines.vitalCarryDays]): it is the newest value only while that
+ * value's own day is recent enough to still be presented as this night's reading, and null otherwise.
+ * Unbounded, `series.lastOrNull()` reached back arbitrarily far — a respiratory rate last written by a
+ * WHOOP CSV import on 30 Jul kept rendering as "Respiratory 15.6" in the Night detail card a fortnight
+ * later, with no date anywhere beside it. `typical` and `series` stay UNBOUNDED on purpose: they are
+ * explicitly historical (the trend line and the "vs typical" mean span the whole history); only the
+ * headline number claims to be current. Byte-twin of the Swift `SleepModel.metric`.
+ */
+private fun metric(
+    days: List<DailyMetric>,
+    todayKey: String = logicalDayKeyNow(),
+    transform: (DailyMetric) -> Double?,
+): Metric {
+    val points = days.mapNotNull { d ->
+        transform(d)?.takeIf { it.isFinite() }?.let { d.day to it }
+    }
+    val series = points.map { it.second }
+    return Metric(Baselines.freshestCarried(points, todayKey)?.second, mean(series), series)
 }
 
 /**

--- a/android/app/src/test/java/com/noop/analytics/VitalCarryStalenessTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/VitalCarryStalenessTest.kt
@@ -1,0 +1,129 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Kotlin twin of `VitalCarryStalenessTests.swift` — the two must agree case for case, since the
+ * staleness bound decides what number a tile shows and the platforms may not disagree about that.
+ *
+ * The regression: NOOP showed "Respiratory 15.6" every day for a fortnight, which was the last value
+ * of a WHOOP CSV import that ended 2026-07-30, carried forward unbounded by two "latest vital"
+ * resolvers.
+ */
+class VitalCarryStalenessTest {
+
+    // ── cutoffKey ────────────────────────────────────────────────────────────
+
+    @Test
+    fun cutoffKeyIsTodayMinusCarryDays() {
+        assertEquals("2026-08-06", Baselines.cutoffKey("2026-08-13", 7))
+        assertEquals("2026-08-13", Baselines.cutoffKey("2026-08-13", 0))
+    }
+
+    @Test
+    fun cutoffKeyCrossesMonthAndYearBoundaries() {
+        assertEquals("2026-02-24", Baselines.cutoffKey("2026-03-03", 7))
+        assertEquals("2025-12-27", Baselines.cutoffKey("2026-01-03", 7))
+    }
+
+    /** Leap day is a real calendar step, not a 365-day assumption. */
+    @Test
+    fun cutoffKeyHandlesLeapYear() {
+        assertEquals("2028-02-27", Baselines.cutoffKey("2028-03-05", 7))
+    }
+
+    /** Fail CLOSED: an unparseable key admits only today rather than opening the carry wide. */
+    @Test
+    fun cutoffKeyFailsClosedOnGarbage() {
+        assertEquals("not-a-day", Baselines.cutoffKey("not-a-day", 7))
+    }
+
+    // ── freshestCarried ──────────────────────────────────────────────────────
+
+    @Test
+    fun carriesAValueInsideTheWindow() {
+        val points = listOf("2026-08-01" to 16.0, "2026-08-10" to 15.6)
+        val got = Baselines.freshestCarried(points, "2026-08-13", 7)
+        assertEquals(15.6, got?.second!!, 1e-9)
+        assertEquals("2026-08-10", got.first)
+    }
+
+    /**
+     * THE REPORTED BUG: the import's last day is 2026-07-30 and "today" is 2026-08-13 — 14 days.
+     * It must not be presented as the latest reading.
+     */
+    @Test
+    fun dropsTheFourteenDayOldImportThatShowed156() {
+        val points = listOf(
+            "2026-07-28" to 16.0,
+            "2026-07-29" to 16.2,
+            "2026-07-30" to 15.6,
+        )
+        assertNull(Baselines.freshestCarried(points, "2026-08-13", 7))
+    }
+
+    /** The window is inclusive at its edge and exclusive one day past it. */
+    @Test
+    fun windowEdgeIsInclusive() {
+        assertEquals(
+            15.6,
+            Baselines.freshestCarried(listOf("2026-08-06" to 15.6), "2026-08-13", 7)?.second!!,
+            1e-9,
+        )
+        assertNull(Baselines.freshestCarried(listOf("2026-08-05" to 15.6), "2026-08-13", 7))
+    }
+
+    /**
+     * Only the NEWEST point is judged: an old value is not rescued by a fresh one, and a fresh value
+     * is not blocked by old ones sitting behind it in the series.
+     */
+    @Test
+    fun judgesOnlyTheNewestPoint() {
+        val points = listOf("2026-07-30" to 15.6, "2026-08-12" to 14.1)
+        assertEquals(14.1, Baselines.freshestCarried(points, "2026-08-13", 7)?.second!!, 1e-9)
+    }
+
+    @Test
+    fun todaysOwnValueAlwaysCarries() {
+        assertEquals(
+            14.1,
+            Baselines.freshestCarried(listOf("2026-08-13" to 14.1), "2026-08-13", 7)?.second!!,
+            1e-9,
+        )
+    }
+
+    @Test
+    fun emptySeriesCarriesNothing() {
+        assertNull(Baselines.freshestCarried(emptyList<Pair<String, Double>>(), "2026-08-13", 7))
+    }
+
+    /**
+     * A future-dated row (a bad-clock strap) is newer than the cutoff, so it still resolves — the
+     * future-clock guard is the caller's `day < todayKey` bound, not this one. Pinned so the division
+     * of responsibility is explicit rather than accidental.
+     */
+    @Test
+    fun futureDatedRowIsNotFilteredHere() {
+        assertEquals(
+            14.1,
+            Baselines.freshestCarried(listOf("2026-09-01" to 14.1), "2026-08-13", 7)?.second!!,
+            1e-9,
+        )
+    }
+
+    // ── the constant itself ──────────────────────────────────────────────────
+
+    /**
+     * The bound must stay well inside [Baselines.staleDays] — past that the personal baseline judging
+     * the value is itself stale, so presenting the value as "latest" is doubly wrong. The literal 7
+     * pins the cross-platform contract: this number must equal the Swift `vitalCarryDays`.
+     */
+    @Test
+    fun carryWindowIsShorterThanBaselineStaleness() {
+        assertTrue(Baselines.vitalCarryDays < Baselines.staleDays)
+        assertEquals(7, Baselines.vitalCarryDays)
+    }
+}

--- a/android/app/src/test/java/com/noop/ui/SleepImportedFiguresTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepImportedFiguresTest.kt
@@ -19,6 +19,14 @@ import java.time.ZoneId
  */
 class SleepImportedFiguresTest {
 
+    /**
+     * The pinned "today" for every build below. These fixtures are dated 2026-06-01/02 and the tile
+     * `latest` is staleness-bounded ([Baselines.vitalCarryDays]), so the clock has to be pinned beside
+     * them — left to the real date they only passed while the carry was unbounded, which is the very
+     * defect `VitalCarryStalenessTest` pins. This file is about PREFER-IMPORTED, not staleness.
+     */
+    private val pinnedToday = "2026-06-03"
+
     private fun day(d: String, asleep: Double?) = DailyMetric(
         deviceId = "my-whoop", day = d, totalSleepMin = asleep,
         deepMin = 80.0, remMin = 90.0, lightMin = 200.0, efficiency = 90.0,
@@ -28,7 +36,7 @@ class SleepImportedFiguresTest {
     fun importedPerformanceWinsPerDay() {
         val days = listOf(day("2026-06-01", 420.0), day("2026-06-02", 410.0))
         val imported = ImportedSleepSeries(performance = mapOf("2026-06-02" to 85.0))
-        val m = buildSleepModel(days, session = null, imported = imported)!!
+        val m = buildSleepModel(days, session = null, imported = imported, todayKey = pinnedToday)!!
         assertEquals(85.0, m.performance.latest!!, 1e-9)
     }
 
@@ -36,7 +44,7 @@ class SleepImportedFiguresTest {
     fun importedDebtPassesThroughInMinutes() {
         val days = listOf(day("2026-06-01", 420.0), day("2026-06-02", 410.0))
         val imported = ImportedSleepSeries(debtMin = mapOf("2026-06-02" to 60.0))
-        val m = buildSleepModel(days, session = null, imported = imported)!!
+        val m = buildSleepModel(days, session = null, imported = imported, todayKey = pinnedToday)!!
         assertEquals(60.0, m.sleepDebt.latest!!, 1e-9)
     }
 
@@ -44,7 +52,7 @@ class SleepImportedFiguresTest {
     fun hoursVsNeededUsesImportedNeedPerDay() {
         val days = listOf(day("2026-06-01", 400.0))
         val imported = ImportedSleepSeries(needMin = mapOf("2026-06-01" to 480.0))
-        val m = buildSleepModel(days, session = null, imported = imported)!!
+        val m = buildSleepModel(days, session = null, imported = imported, todayKey = pinnedToday)!!
         assertEquals(400.0 / 480.0 * 100.0, m.hoursVsNeeded.latest!!, 1e-9)
     }
 
@@ -56,7 +64,7 @@ class SleepImportedFiguresTest {
         // that ceilinged live 5.0 nights at ~100% while every other surface showed ~85% (#298).
         val days = listOf(day("2026-06-01", 420.0), day("2026-06-02", 410.0))
         val imported = ImportedSleepSeries(performance = mapOf("2026-06-01" to 85.0))
-        val m = buildSleepModel(days, session = null, imported = imported)!!
+        val m = buildSleepModel(days, session = null, imported = imported, todayKey = pinnedToday)!!
         assertEquals(RestScorer.restFromDaily(days[1])!!, m.performance.latest!!, 1e-9)
         // …and it is NOT the retired asleep/need approximation.
         assertNotEquals(410.0 / 450.0 * 100.0, m.performance.latest, 1e-6)
@@ -80,7 +88,7 @@ class SleepImportedFiguresTest {
                 deepMin = 70.0, remMin = 80.0, lightMin = 270.0, efficiency = 0.85),
             night,
         )
-        val m = buildSleepModel(days, session = null)!!
+        val m = buildSleepModel(days, session = null, todayKey = pinnedToday)!!
         val composite = RestScorer.restFromDaily(night)!!
         assertEquals(composite, m.performance.latest!!, 1e-9)
         assertTrue("composite should be below the 100% proxy ceiling", composite < 100.0)
@@ -92,20 +100,22 @@ class SleepImportedFiguresTest {
         val days = listOf(day("2026-06-01", 420.0), day("2026-06-02", 410.0))
         // Covers the latest night → verbatim series wins.
         val covered = buildSleepModel(days, null,
-            ImportedSleepSeries(consistency = mapOf("2026-06-01" to 70.0, "2026-06-02" to 74.0)))!!
+            ImportedSleepSeries(consistency = mapOf("2026-06-01" to 70.0, "2026-06-02" to 74.0)),
+            todayKey = pinnedToday)!!
         assertEquals(74.0, covered.consistency.latest!!, 1e-9)
         // Ends before the latest night → the APPROXIMATE duration-spread proxy, never a
         // months-old import-era value presented as "latest".
         val stale = buildSleepModel(days, null,
-            ImportedSleepSeries(consistency = mapOf("2026-06-01" to 70.0)))!!
+            ImportedSleepSeries(consistency = mapOf("2026-06-01" to 70.0)),
+            todayKey = pinnedToday)!!
         assertNotEquals(70.0, stale.consistency.latest)
     }
 
     @Test
     fun emptyImportedReproducesTheApproximateBaseline() {
         val days = listOf(day("2026-06-01", 420.0), day("2026-06-02", 410.0))
-        val a = buildSleepModel(days, session = null)!!
-        val b = buildSleepModel(days, session = null, imported = ImportedSleepSeries())!!
+        val a = buildSleepModel(days, session = null, todayKey = pinnedToday)!!
+        val b = buildSleepModel(days, session = null, imported = ImportedSleepSeries(), todayKey = pinnedToday)!!
         assertEquals(a, b)
     }
 
@@ -123,7 +133,7 @@ class SleepImportedFiguresTest {
         val session = SleepSession(
             deviceId = "my-whoop", startTs = 1780351200L, endTs = 1780387200L, efficiency = 90.0,
         )
-        val m = buildSleepModel(days, session = session)!!
+        val m = buildSleepModel(days, session = session, todayKey = pinnedToday)!!
         // need = max(450, mean asleep[420,410]=415) = 450. hours-vs-needed reads ASLEEP 410, not 600.
         assertEquals(410.0 / 450.0 * 100.0, m.hoursVsNeeded.latest!!, 1e-9)
         // Debt tile reads ASLEEP too: max(0, 450 − 410) = 40, never max(0, 450 − 600) = 0.
@@ -140,8 +150,8 @@ class SleepImportedFiguresTest {
         val session = SleepSession(
             deviceId = "my-whoop", startTs = 1780351200L, endTs = 1780387200L, efficiency = 90.0,
         )
-        val withSession = buildSleepModel(days, session = session)!!
-        val noSession = buildSleepModel(days, session = null)!!
+        val withSession = buildSleepModel(days, session = session, todayKey = pinnedToday)!!
+        val noSession = buildSleepModel(days, session = null, todayKey = pinnedToday)!!
         assertEquals(noSession.performance, withSession.performance)
         assertEquals(noSession.hoursVsNeeded, withSession.hoursVsNeeded)
         assertEquals(noSession.sleepDebt, withSession.sleepDebt)
@@ -173,6 +183,7 @@ class SleepImportedFiguresTest {
             days = listOf(day("2026-06-01", 568.0), day("2026-06-02", 392.0)),
             session = night,
             napSleepMinByDay = napCredit,
+            todayKey = pinnedToday,
         )!!
         assertEquals(40.0, m.sleepDebt.latest!!, 1e-9)
         assertEquals(40.0 / 60.0, m.trendDebtHours.last(), 1e-9)
@@ -209,8 +220,8 @@ class SleepImportedFiguresTest {
     @Test
     fun browsingAPastNightKeepsTilesLatestAnchored() {
         val days = listOf(day("2026-06-01", 420.0), day("2026-06-02", 410.0), day("2026-06-03", 400.0))
-        val latestView = buildSleepModel(days, session = null)!!                       // newest night
-        val browsedView = buildSleepModel(days, session = null, selectedDay = "2026-06-01")!!
+        val latestView = buildSleepModel(days, session = null, todayKey = pinnedToday)!!                       // newest night
+        val browsedView = buildSleepModel(days, session = null, selectedDay = "2026-06-01", todayKey = pinnedToday)!!
         // Tiles, need, typical and the ledger are identical regardless of which night is browsed.
         assertEquals(latestView.performance, browsedView.performance)
         assertEquals(latestView.sleepDebt, browsedView.sleepDebt)

--- a/android/app/src/test/java/com/noop/ui/SleepTileCarryStalenessTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepTileCarryStalenessTest.kt
@@ -1,0 +1,49 @@
+package com.noop.ui
+
+import com.noop.data.DailyMetric
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The Night detail tiles must not present a stale value as this night's reading.
+ *
+ * The regression, reported 2026-08-13: the Sleep tab's Respiratory tile read "15.6" every day for a
+ * fortnight — the last value of a WHOOP CSV import that ended 2026-07-30 — because the tile's `latest`
+ * was `series.lastOrNull()` with no age bound, and this card shows no date beside the number at all.
+ * Twin of the Swift `SleepModelStaleCarryTests`.
+ */
+class SleepTileCarryStalenessTest {
+
+    private fun day(d: String, resp: Double? = null) = DailyMetric(
+        deviceId = "my-whoop", day = d, totalSleepMin = 420.0,
+        deepMin = 80.0, remMin = 90.0, lightMin = 200.0, efficiency = 90.0,
+        respRateBpm = resp,
+    )
+
+    /** The reported case: last respiratory value 2026-07-30, viewed on 2026-08-13. */
+    @Test
+    fun staleRespiratoryRateDoesNotReachTheTile() {
+        val days = listOf(
+            day("2026-07-29", resp = 16.2),
+            day("2026-07-30", resp = 15.6),
+        ) + (1..13).map { day("2026-08-%02d".format(it)) }   // live nights, no respiratory value
+
+        val m = buildSleepModel(days, session = null, todayKey = "2026-08-13")!!
+        assertNull(m.respiratory.latest)
+        // The trend line is HISTORICAL and survives — only the headline claims to be current.
+        assertEquals(2, m.respiratory.series.size)
+        // Sleep-derived siblings are unaffected: they have fresh values every night.
+        assertNotNull(m.efficiency.latest)
+        assertNotNull(m.restorative.latest)
+    }
+
+    /** The carry still does its job: a value inside the window is a legitimate "latest". */
+    @Test
+    fun recentRespiratoryRateStillReachesTheTile() {
+        val days = listOf(day("2026-08-11", resp = 14.1), day("2026-08-12"))
+        val m = buildSleepModel(days, session = null, todayKey = "2026-08-13")!!
+        assertEquals(14.1, m.respiratory.latest!!, 1e-9)
+    }
+}


### PR DESCRIPTION
## The bug

NOOP showed a respiratory rate of **15.6 every day**. It is the last value of a WHOOP CSV import that
ended **2026-07-30**, still on screen a fortnight later: `dailyMetric.respRateBpm` is NULL on every day
since, and the live device has never written one at all.

Two separate "latest vital" resolvers carried it forward with **no age bound**:

| screen | resolver | rendered |
|---|---|---|
| **Sleep → Night detail → RESPIRATORY** | `SleepModel.metric` — `series.last`, day keys discarded | **15.6**, "−0.7 rpm vs typical", **no date anywhere** |
| **Health → Vital Signs → RESP RATE** | `BodyVitalSigns.latest` — `pts.last` | **15.6 rpm**, "30 Jul · WHOOP import" |

The Sleep tile is the worse of the two: no date beside the number, under a header that names the night.

**A silent stale number is worse than no number**, because the reader takes it for a current
measurement. That is not hypothetical — this project read its own screen as WHOOP ground truth and
opened a `0x6A` respiration ledger with it, pairing a July WHOOP import against an August Oura night.
That result was retracted.

## The fix

One shared, staleness-bounded resolver, **byte-twinned across Swift and Kotlin**:

```
Baselines.vitalCarryDays = 7
Baselines.freshestCarried(points, todayKey:)   // newest point, or nil if older than the window
```

applied in `SleepModel.metric` / `BodyVitalSigns.latest` and the Android twins `metric()` /
`latestVital()`.

**Why 7 days.** A carry exists so one missed night doesn't blank a tile — not so a months-old value
reads as tonight's measurement. Seven days covers a missed night or a weekend off-strap, and stays
decisively inside `Baselines.staleDays` (14), past which the personal baseline that *judges* the value
is itself declared stale and banding already falls back to the population range. Presenting a value as
"latest" after the baseline that grades it has aged out is doubly wrong.

**`typical` and the sparkline series stay UNBOUNDED on purpose.** They are explicitly historical — the
trend line and the "vs typical" mean are meant to span the whole history. Only the headline number
claims to be current, so only the headline number is bounded.

Same bug class as **#23** (*"anchored to the most-recent point, which on a stale import pinned the
window to months-old data shown as a current trend"*), one field over. The code already knew this
hazard; `trailingWindow` exists because of it.

**No new user-facing strings**, so no i18n work: the tiles fall back to captions they already carry
("No respiratory-rate value", "vs typical").

## Verification

**Real data, both screens, before and after.** Loaded `noop-backup-20260813-053620.noopbak` onto the
macOS bench and looked.

| tile | before | after |
|---|---|---|
| Sleep → Night detail → Respiratory | **15.6** | `—` |
| Health → Vital Signs → Resp Rate | **15.6 rpm** · 30 Jul | `—` · "No respiratory-rate value" |
| Health → Vital Signs → Blood O₂ | 98 % · 30 Jul | `—` (same 30 Jul import) |
| Health → Vital Signs → HRV | 103 ms · Today | **unchanged** |
| Health → Vital Signs → Skin Temp Δ | +0.4 · 12 Aug | **unchanged** |
| Sleep → Rest / Efficiency / Restorative | 23 % / 46 % / 16 % | **unchanged** |
| Today (all paths) | `—` | `—` |

Every sparkline trail survives. The carry still does its job — only values past the window are refused.

**Tests.** `1339` StrandAnalytics + `1118` StrandTests + `3822` Android unit tests, **0 failures**, run
on this branch's `main` base (not only on the branch it was developed against).

New tests pin the exact reported case (30 Jul value viewed on 13 Aug) on **both** platforms, plus the
window edges (inclusive at `−7`, exclusive at `−8`), month / year / leap-year boundaries, fail-closed
parsing of a malformed day key, and that only the *newest* point is judged. The Kotlin suite asserts the
literal `7`, so changing the constant on one platform and not the other fails loudly.

**App-target Swift is touched**, which no default CI job covers (`app-build.yml` is disabled), so the
macOS app was compiled and its test target run locally.

## Two suites were fixture time-bombs

`VitalSourceResolutionTests` (Swift) and `SleepImportedFiguresTest` (Kotlin) used **absolute fixture
dates** with `now` **defaulting to the real clock**. They passed only *because* the carry was unbounded
— the very defect under fix. Both now pin their clock, which is what they meant to test all along.

Worth a look if any other suite does the same.

## Deliberately left unbounded

No observed symptom, and a separate concern — flagging rather than widening this PR:

- `MetricsCache.lastVitalsDay` and `TodayView.lastScoredRecoveryDay` (both unbounded, but Today
  resolved to `—` on this data anyway)
- `SleepModel.consistencySeries` / `sleepDebtSeries` — bespoke builders, not day-keyed through the
  shared helper
- The two Today sparkline windows still **disagree**: 14 d (`TodayView`) vs 30 d (`LiquidTodayView`)

## Reviewer note

The one judgment call is the **7-day window**. It is a single constant, twinned in both languages. Its
visible consequence: for an **import-only user** (no live strap), the Vital Signs tiles now blank a week
after their last import rather than showing month-old numbers under a header reading "Latest". That is
the intended behaviour, but it is a real UX change and the number is easy to move if 3 or 14 reads
better.