### PR TITLE
feature-flag probe: log raw frame on a SEND_NEXT decode failure too (follow-up to #917)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -3334,7 +3334,9 @@ public final class BLEManager: NSObject, ObservableObject {
                 finishFeatureFlagProbe()
             }
         case .failure(let f):
-            featureFlagReport?.noteFailure(f, command: Int(awaiting))
+            // Log the whole frame on a 118 decode failure too — the START (117) arm above already does,
+            // and a reply that failed to decode is the only evidence of what the strap put on the wire.
+            featureFlagReport?.noteFailure(f, command: Int(awaiting), frame: frame)
             finishFeatureFlagProbe()
         }
     }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3857,7 +3857,9 @@ class WhoopBleClient(
         val parsed = FeatureFlagProbe.parseNext(frame, connectedFamily)
         val next = parsed.value
         if (next == null) {
-            featureFlagReport?.noteFailure(parsed.failure!!, awaiting)
+            // Log the whole frame on a 118 decode failure too — the START (117) arm above already does,
+            // and a reply that failed to decode is the only evidence of what the strap put on the wire.
+            featureFlagReport?.noteFailure(parsed.failure!!, awaiting, frame)
             finishFeatureFlagProbe()
             return
         }


### PR DESCRIPTION
## Follow-up to #917: log the raw frame on a SEND_NEXT decode failure too

A small diagnostic-completeness fix surfaced while reviewing #917.

### The gap
#917 added raw-frame logging on decode failures (its §4: *"a reply that fails to decode logs the whole frame"*), but only wired it into the **117 START** arm. The **118 SEND_NEXT** decode-failure arm still called `noteFailure` without the frame:

- `BLEManager.swift` — START `:3324` passed `frame:`, NEXT `:3337` did not.
- `WhoopBleClient.kt` — START `:3852` passed `frame`, NEXT `:3860` did not.

So a 118 reply that failed to decode logged no raw bytes — exactly the case #917 was trying to make legible, and (as its own §4 notes) findings have had to be re-run because only parsed output was kept.

### The fix
Pass the in-scope `frame` on both platforms. `noteFailure(…, frame:)` already exists and is unit-tested in the pure `WhoopProtocol`/`FeatureFlagProbe` package, so this is **app-code wiring only** — no probe-logic change, no package test change, no golden change, and byte-for-byte parity is preserved (identical one-line change on both sides).

### Deliberately not included
The other review nit (the `countFinding` MISMATCH line using de-duplicated `keys.count`) is left as-is: a firmware serving duplicate key names is itself an anomaly, so flagging a mismatch there is arguably correct, and changing the reconciliation semantics for a never-observed case isn't worth the golden churn. One concern per PR.

### Verification
- **Android**: `compileFullDebugKotlin --no-build-cache` — clean.
- **Swift**: `BLEManager.swift` is app-target (no default CI, doesn't build on Linux) → validated via the on-demand app-build gate. The change adds a labeled `frame:` argument to a call whose sibling arm 13 lines up already passes the same in-scope `frame`, so it's a guaranteed compile; the gate confirms it.
- No `swift-packages` impact (the pure package is untouched).
