### PR TITLE
Sleep stages: label the night carousel by calendar nights, not recorded-night index (#1311)

### DIFF
--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -352,8 +352,26 @@ struct SleepView: View {
     /// ◀/▶-navigated night. Shared by the Rest hero overline and the hypnogram nav header so both
     /// name the SAME night the hero's score is now resolved for.
     private var nightRelativeLabel: LocalizedStringKey {
-        nightOffset == 0 ? "Last night"
-            : (nightOffset == 1 ? "1 night ago" : "\(nightOffset) nights ago")
+        let n = nightsAgo(nightOffset)
+        return n == 0 ? "Last night" : (n == 1 ? "1 night ago" : "\(n) nights ago")
+    }
+
+    /// #1311: how many CALENDAR nights back the carousel night at `offset` is from the newest recorded
+    /// night. The ◀/▶ carousel steps by RECORDED night (`navDays`, newest-first), so a night with no
+    /// data (strap off-body) is a gap the flat index can't see — labelling by index makes two nights
+    /// either side of a skipped night read as consecutive and desyncs the "N nights ago" labels (and the
+    /// Rest value they name). Uses the same local start-of-day `navDays` is grouped by; falls back to the
+    /// raw index if it can't resolve. 0 = last night. Mirrors Android SleepHeroLogic.calendarNightsAgo.
+    private func nightsAgo(_ offset: Int) -> Int {
+        let days = navDays
+        guard offset >= 0, offset < days.count,
+              let newestTs = days.first?.first?.endTs, let shownTs = days[offset].first?.endTs
+        else { return offset }
+        let cal = Calendar.current
+        let shown = cal.startOfDay(for: Date(timeIntervalSince1970: TimeInterval(shownTs)))
+        let newest = cal.startOfDay(for: Date(timeIntervalSince1970: TimeInterval(newestTs)))
+        let d = cal.dateComponents([.day], from: shown, to: newest).day ?? offset
+        return d >= 0 ? d : offset
     }
 
     /// The night the Rest hero reflects: the ◀/▶-navigated night while browsing (falling back to

--- a/android/app/src/main/java/com/noop/ui/SleepHeroLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepHeroLogic.kt
@@ -2,6 +2,7 @@ package com.noop.ui
 
 import com.noop.analytics.RestScorer
 import com.noop.data.DailyMetric
+import com.noop.data.SleepSession
 
 /** A short Rest state word for the hero gauge — same banding the synthesis hero uses. */
 internal fun sleepScoreWord(score: Double): String = when {
@@ -20,6 +21,28 @@ internal fun nightRelativeLabel(offset: Int): String = when (offset) {
     0 -> "Last night"
     1 -> "1 night ago"
     else -> "$offset nights ago"
+}
+
+/**
+ * How many CALENDAR nights back the carousel night at [offset] is from the newest recorded night.
+ * The ◀/▶ carousel steps by RECORDED night ([navDays], newest-first), so a night with no data (strap
+ * off-body) is a gap the flat index can't see — labelling by index makes two nights either side of a
+ * skipped night read as consecutive and desyncs the "N nights ago" labels (#1311). This restores the
+ * true calendar distance from each night's local wake-day (the same key navDays is grouped by), so the
+ * label — and the Rest value it names — line up with the night actually shown. Falls back to the raw
+ * index if a day can't be read. 0 = last night. Mirrors iOS SleepView.nightsAgo.
+ */
+internal fun calendarNightsAgo(
+    navDays: List<List<SleepSession>>, offset: Int, zone: java.util.TimeZone,
+): Int {
+    if (offset < 0 || offset >= navDays.size) return offset
+    val newestTs = navDays.firstOrNull()?.firstOrNull()?.endTs ?: return offset
+    val shownTs = navDays[offset].firstOrNull()?.endTs ?: return offset
+    val z = zone.toZoneId()
+    val shown = java.time.Instant.ofEpochSecond(shownTs).atZone(z).toLocalDate()
+    val newest = java.time.Instant.ofEpochSecond(newestTs).atZone(z).toLocalDate()
+    val d = java.time.temporal.ChronoUnit.DAYS.between(shown, newest).toInt()
+    return if (d >= 0) d else offset
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -439,6 +439,14 @@ fun SleepScreen(
         selectNight(navDays, days, nightOffset, habitualMidsleep, motionByStart)
     }
 
+    // #1311: label the carousel by CALENDAR nights, not the flat recorded-night index — a night with no
+    // data (strap off-body) is skipped by the carousel, so labelling by index makes two nights either
+    // side of it read as consecutive and desyncs the "N nights ago" labels. Shared by the Rest hero
+    // overline and the nav header so both name the SAME calendar night.
+    val nightLabel = nightRelativeLabel(
+        calendarNightsAgo(navDays, nightOffset, java.util.TimeZone.getDefault())
+    )
+
     // The HERO follows the selected night (its stage breakdown comes from that day's row); the
     // at-a-glance TILES, the debt ledger, the personal need and the trend stay full-history /
     // latest-anchored, matching iOS SleepView. `selectedDay` re-points only the hero. Model is null
@@ -577,7 +585,7 @@ fun SleepScreen(
                             else tilesModel?.performance?.latest,
                     asleepMin = model?.stages?.asleep,
                     source = restHeroSource(imported, night?.dayKey ?: days.lastOrNull()?.day, activeIsOura),
-                    overline = nightRelativeLabel(nightOffset),
+                    overline = nightLabel,
                 )
             }
             // #sleep-layout: a compact "Arrange" affordance (the same Tune entry Today uses) opens the
@@ -640,6 +648,7 @@ fun SleepScreen(
                 clock = night?.clockLabel ?: model?.clockLabel,
                 nightOffset = nightOffset,
                 lastIndex = max(navDays.lastIndex, 0),
+                nightLabel = nightLabel,
                 onNavigate = { nightOffset = it },
                 session = night?.session,
                 onUpdateTimes = { s, start, end ->
@@ -1102,6 +1111,9 @@ private fun Hero(
     clock: String?,
     nightOffset: Int,
     lastIndex: Int,
+    // #1311: the calendar-aware "N nights ago" label for the shown night, computed by the caller from
+    // navDays so a skipped no-data night doesn't desync the count. Used by the overline + nav header.
+    nightLabel: String,
     onNavigate: (Int) -> Unit,
     session: SleepSession? = null,
     onUpdateTimes: (SleepSession, Long, Long) -> Unit = { _, _, _ -> },
@@ -1133,7 +1145,7 @@ private fun Hero(
     windowWakeTs: Long? = null,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
-        NightNavHeader(nightOffset, lastIndex, clock, onNavigate, session, onUpdateTimes, onDeleteSession, onAddNap, onPickNightDate)
+        NightNavHeader(nightOffset, nightLabel, lastIndex, clock, onNavigate, session, onUpdateTimes, onDeleteSession, onAddNap, onPickNightDate)
         // The night's clock window — when you fell asleep and when you woke — as its own clearly
         // labelled row. These were only ever in the nav-header's trailing caption, which truncates
         // between the two chevrons on a phone, so in practice the two times people look for first
@@ -1953,6 +1965,9 @@ private fun SleepTime(icon: androidx.compose.ui.graphics.vector.ImageVector, lab
 @Composable
 private fun NightNavHeader(
     offset: Int,
+    // #1311: calendar-aware "N nights ago" label, computed by the caller from navDays so a skipped
+    // no-data night doesn't desync the count. Replaces the old offset-index labelling.
+    nightLabel: String,
     lastIndex: Int,
     clock: String?,
     onNavigate: (Int) -> Unit,
@@ -2280,7 +2295,7 @@ private fun NightNavHeader(
         )
     }
 
-    val nightLabel = nightRelativeLabel(offset)
+    // #1311: nightLabel is now the calendar-aware label passed in (was nightRelativeLabel(offset)).
     val blockShape = RoundedCornerShape(Metrics.cornerSm)
     val clockParts = clock?.split(" · ", limit = 2)
     val dateLabel = clockParts?.getOrNull(0)

--- a/android/app/src/test/java/com/noop/ui/SleepHeroLogicTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepHeroLogicTest.kt
@@ -1,0 +1,54 @@
+package com.noop.ui
+
+import com.noop.data.SleepSession
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.TimeZone
+
+/**
+ * #1311: the Sleep → Stages carousel steps by RECORDED night, so a night with no data (strap
+ * off-body) is skipped. Labelling by the flat carousel index then makes two nights either side of
+ * the gap read as consecutive and desyncs the "N nights ago" labels. `calendarNightsAgo` restores
+ * the true calendar distance from each night's local wake-day. Mirrors iOS SleepView.nightsAgo.
+ */
+class SleepHeroLogicTest {
+
+    private fun nightOn(date: LocalDate): List<SleepSession> {
+        val endTs = date.atStartOfDay(ZoneOffset.UTC).plusHours(7).toEpochSecond()  // 07:00 UTC wake
+        return listOf(SleepSession(deviceId = "d", startTs = endTs - 6 * 3600, endTs = endTs))
+    }
+
+    @Test
+    fun countsCalendarNights_notCarouselIndex_whenANightIsMissing() {
+        val utc = TimeZone.getTimeZone("UTC")
+        // Newest night 2026-08-13, then a night 3 calendar days earlier — the two nights between had no
+        // data, so they aren't in navDays. navDays is newest-first.
+        val navDays = nightOn(LocalDate.of(2026, 8, 13)) to nightOn(LocalDate.of(2026, 8, 10))
+        val nav = listOf(navDays.first, navDays.second)
+        assertEquals(0, calendarNightsAgo(nav, 0, utc))         // last night
+        assertEquals(3, calendarNightsAgo(nav, 1, utc))         // 3 calendar nights ago, NOT index 1
+        assertEquals("3 nights ago", nightRelativeLabel(calendarNightsAgo(nav, 1, utc)))
+    }
+
+    @Test
+    fun matchesIndex_whenNightsAreConsecutive() {
+        val utc = TimeZone.getTimeZone("UTC")
+        val nav = listOf(
+            nightOn(LocalDate.of(2026, 8, 13)),
+            nightOn(LocalDate.of(2026, 8, 12)),
+            nightOn(LocalDate.of(2026, 8, 11)),
+        )
+        assertEquals(0, calendarNightsAgo(nav, 0, utc))
+        assertEquals(1, calendarNightsAgo(nav, 1, utc))
+        assertEquals(2, calendarNightsAgo(nav, 2, utc))
+    }
+
+    @Test
+    fun fallsBackToIndex_whenOutOfRangeOrEmpty() {
+        val utc = TimeZone.getTimeZone("UTC")
+        assertEquals(5, calendarNightsAgo(emptyList(), 5, utc))
+        assertEquals(9, calendarNightsAgo(nightOn(LocalDate.of(2026, 8, 13)).let { listOf(it) }, 9, utc))
+    }
+}


### PR DESCRIPTION
## Sleep stages: label the night carousel by calendar nights, not recorded-night index

Fixes #1311 (reported by @h-nry).

### The bug
The Sleep → Stages carousel steps by **recorded** night — a night with no data (strap off-body) isn't a stop. But the "N nights ago" label was just the flat carousel index, so two nights either side of a missed night read as **consecutive**, the labels drifted out of sync, and the **Rest** stat looked like it was showing the missing night's value (it was the neighbouring recorded night's).

### The fix
Label by **calendar** nights: `calendarNightsAgo` (Kotlin) / `nightsAgo` (Swift) compute the true gap from each night's **local wake-day** — the same `startOfDay(endTs)` key `navDays` is grouped by — with a fallback to the raw index if a day can't be resolved. The carousel still steps by recorded night (that was deliberate in #57/#59, to stop the arrows getting stuck inside one night's naps); only the label changes, so it now names the calendar night actually shown, and Rest lines up with it.

### Parity
Both platforms, mirrored: Android threads one computed `nightLabel` string through `Hero` → `NightNavHeader` (used by the Rest overline + the nav header); iOS's `nightRelativeLabel` now derives from `nightsAgo`. Same local-start-of-day gap math on each.

### Deliberately out of scope
Rendering the empty nights as explicit "no data" stops (with Rest marked unavailable there) is the fuller version of the request, but it re-opens the #57/#59 UX tradeoff (long gaps → many empty stops) and is a bigger change — left as a possible follow-up. The label fix already resolves the desync and the Rest mislabel h-nry described.

### Verification
- **Android**: `compileFullDebugKotlin` clean; new unit test `SleepHeroLogicTest` (a night 3 calendar days back after a 2-night gap → "3 nights ago", not index-1; consecutive nights still match index; out-of-range falls back) — green.
- **iOS/macOS**: `SleepView.swift` is app-target (no default CI) → validated via the app-build gate.
- No new strings (same `LocalizedStringKey`s); `i18n_audit --ci` and `doc_comment_lint` clean.
