### PR TITLE
Oura #1284: persisted-session log prints the stored (post-trim) window

### DIFF
--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -815,8 +815,14 @@ public final class OuraLiveSource: NSObject, ObservableObject {
             // #1284 residual 3: stamp the 0x49 anchor state on EVERY persist, so an unanchored early-drain row
             // (the prime suspect for the short nested duplicate) is self-evident even when it is the FIRST
             // persist, before the duplicate-gen line above can fire.
+            // #1284: log the SESSION's STORED window, not the pre-trim burst window. The #1293
+            // trailing-run trim shortens the persisted end, so `startStr`/`endStr` (from the burst) read
+            // ~tens of minutes wider than the row — every future capture then reads the wrong window out
+            // of the log. `session.startTs`/`.endTs` are exactly what `persistSleepSession` banks.
+            let persistedStart = fmt.string(from: Date(timeIntervalSince1970: TimeInterval(session.startTs)))
+            let persistedEnd = fmt.string(from: Date(timeIntervalSince1970: TimeInterval(session.endTs)))
             let anchorTag = sleepStart != nil ? "0x49-onset" : "no-0x49-onset"
-            log("Oura: sleep session persisted [\(startStr) → \(endStr)] eff=\(effStr) [\(anchorTag)] → \(deviceId) (ring-provided night; wins merge over computed)")
+            log("Oura: sleep session persisted [\(persistedStart) → \(persistedEnd)] eff=\(effStr) [\(anchorTag)] → \(deviceId) (ring-provided night; wins merge over computed)")
         }
     }
 

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -759,8 +759,12 @@ class OuraLiveSource(
             // #1284 residual 3: stamp the 0x49 anchor state on EVERY persist, so an unanchored early-drain row
             // (the prime suspect for the short nested duplicate) is self-evident even when it is the FIRST
             // persist, before the duplicate-gen line above can fire.
+            // #1284: log the SESSION's STORED window, not the pre-trim burst window. The #1293
+            // trailing-run trim shortens the persisted end, so [$start -> $end] (from the burst) reads
+            // ~tens of minutes wider than the row — every future capture then reads the wrong window out
+            // of the log. it.startTs/it.endTs are exactly what persistSleepSession banks.
             val anchorTag = if (sleepStart != null) "0x49-onset" else "no-0x49-onset"
-            log("Oura: sleep session persisted [$start -> $end] eff=$effStr [$anchorTag] -> $deviceId (ring-provided night; wins merge over computed)")
+            log("Oura: sleep session persisted [${it.startTs} -> ${it.endTs}] eff=$effStr [$anchorTag] -> $deviceId (ring-provided night; wins merge over computed)")
         }
     }
 


### PR DESCRIPTION
## Oura #1284: the persisted-session log line prints the STORED window

Small log-accuracy fix from pipiche38's #1284 residual review.

### The bug
`Oura: sleep session persisted [start → end]` logged the **pre-trim burst window**, but the DB row carries the **post-#1293-trim** window — so the two disagreed by the trimmed minutes (26 min measured on one night). Since overnight process logs are the primary evidence for these Oura investigations, every future capture read the wrong window out of the log.

### The fix
Log `session.startTs`/`session.endTs` (Swift) / `it.startTs`/`it.endTs` (Kotlin) — exactly what `persistSleepSession` banks — so the line always matches the row, wherever the trim happens.

Log-only: no behaviour, data, or schema change. Both platforms in parity.

### Scope note
This is only the minor log fix from #1284. The substantive items are tracked on the issue: residual 1's *leading* padding is held (a `0xFF` run is ambiguous with real `awake`, which encodes identically), residual 2 (one-shot banked heal) is a maintainer decision, and residual 3's real fix (`0x49`-window session keying + the cross-connection diagnostic upgrade) is hardware-gated on pipiche's ring.

### Verification
- Android `compileFullDebugKotlin` clean.
- Swift `OuraLiveSource` is app-target (no default CI) → app-build gate.
