### PR TITLE
Personalized HR zones — analytics core (recreates #531, 1/3)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRZones.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRZones.swift
@@ -41,13 +41,14 @@ public struct HRZone: Equatable, Sendable {
     }
 }
 
-/// Five HR zones derived from a max HR, plus the max HR itself and its source.
+/// Five HR zones derived from a max HR or personalized BPM boundaries, plus the max HR itself and
+/// its source.
 public struct HRZoneSet: Equatable, Sendable {
     /// The five zones, z1...z5, in ascending order.
     public let zones: [HRZone]
     /// Max HR (bpm) the zones were built from.
     public let maxHR: Double
-    /// "tanaka" (age formula) or "manual" (caller override).
+    /// "tanaka" (age formula), "manual" (caller override), or "custom" (personalized boundaries).
     public let source: String
 
     public init(zones: [HRZone], maxHR: Double, source: String) {
@@ -97,6 +98,10 @@ public enum HRZones {
     /// %HRmax band edges for zones 1...5: [0.50, 0.60, 0.70, 0.80, 0.90, 1.00].
     public static let zoneEdges: [Double] = [0.50, 0.60, 0.70, 0.80, 0.90, 1.00]
 
+    /// Sensible editable BPM range for personalized zone starts. The analytics API accepts any
+    /// positive finite values; the app UIs use this range to keep steppers practical.
+    public static let customBPMRange: ClosedRange<Int> = 30...250
+
     /// Tanaka (2001) age-predicted max HR: 208 − 0.7 × age (gender-independent).
     public static func tanakaMaxHR(age: Double) -> Double {
         208.0 - 0.7 * age
@@ -107,7 +112,9 @@ public enum HRZones {
     /// - Parameters:
     ///   - age: age in years (used only when `maxHROverride` is nil).
     ///   - maxHROverride: explicit HRmax (bpm); when provided, `source == "manual"`.
-    public static func zones(age: Double, maxHROverride: Double? = nil) -> HRZoneSet {
+    public static func zones(age: Double,
+                             maxHROverride: Double? = nil,
+                             customLowerBounds: [Double]? = nil) -> HRZoneSet {
         let maxHR: Double
         let source: String
         if let override = maxHROverride {
@@ -117,24 +124,48 @@ public enum HRZones {
             maxHR = tanakaMaxHR(age: age)
             source = "tanaka"
         }
-        return zones(maxHR: maxHR, source: source)
+        return zones(maxHR: maxHR, source: source, customLowerBounds: customLowerBounds)
     }
 
-    /// Build the 5-zone set directly from a known max HR.
-    public static func zones(maxHR: Double, source: String = "manual") -> HRZoneSet {
+    /// Build the 5-zone set directly from a known max HR, optionally replacing the conventional
+    /// percentage edges with five personalized inclusive lower bounds in BPM. Invalid custom input
+    /// falls back to the conventional model, so malformed restored preferences can never create gaps.
+    public static func zones(maxHR: Double,
+                             source: String = "manual",
+                             customLowerBounds: [Double]? = nil) -> HRZoneSet {
+        let custom = customLowerBounds.flatMap(validCustomLowerBounds)
         var built: [HRZone] = []
         for i in 0..<5 {
-            let loPct = zoneEdges[i]
-            let hiPct = zoneEdges[i + 1]
+            let lower = custom?[i] ?? zoneEdges[i] * maxHR
+            let upper = custom.map { i < 4 ? $0[i + 1] : max(maxHR, $0[i]) }
+                ?? zoneEdges[i + 1] * maxHR
+            let loPct = maxHR > 0 ? lower / maxHR : 0
+            let hiPct = maxHR > 0 ? upper / maxHR : 0
             built.append(HRZone(
                 number: i + 1,
-                lower: loPct * maxHR,
-                upper: hiPct * maxHR,
+                lower: lower,
+                upper: upper,
                 lowerPct: loPct,
                 upperPct: hiPct
             ))
         }
-        return HRZoneSet(zones: built, maxHR: maxHR, source: source)
+        return HRZoneSet(zones: built, maxHR: maxHR, source: custom == nil ? source : "custom")
+    }
+
+    /// The conventional five inclusive lower bounds, rounded up to whole BPM for an editor. Rounding
+    /// up preserves the existing integer-sample classification (e.g. a 93.5 edge starts at 94 bpm).
+    public static func defaultLowerBounds(maxHR: Double) -> [Int] {
+        Array(zoneEdges.prefix(5)).map { Int(ceil($0 * maxHR)) }
+    }
+
+    /// Return a valid five-boundary custom model, or nil unless values are positive, finite, and
+    /// strictly increasing. Kept public so persistence layers can reject hand-edited backup values
+    /// using the exact same invariant as the analytics engine.
+    public static func validCustomLowerBounds(_ values: [Double]) -> [Double]? {
+        guard values.count == 5,
+              values.allSatisfy({ $0.isFinite && $0 > 0 }) else { return nil }
+        for i in 1..<values.count where values[i] <= values[i - 1] { return nil }
+        return values
     }
 
     /// Compute time-in-zone (seconds) from a time-ordered HR stream.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRZonesTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRZonesTests.swift
@@ -47,6 +47,28 @@ final class HRZonesTests: XCTestCase {
         XCTAssertEqual(zs.zoneNumber(forBPM: 250), 5)   // above max still z5
     }
 
+    func testCustomBPMBoundariesReplacePercentageEdges() {
+        let zs = HRZones.zones(maxHR: 200, customLowerBounds: [95, 118, 142, 168, 184])
+        XCTAssertEqual(zs.source, "custom")
+        XCTAssertEqual(zs.zones.map(\.lower), [95, 118, 142, 168, 184])
+        XCTAssertEqual(zs.zoneNumber(forBPM: 117), 1)
+        XCTAssertEqual(zs.zoneNumber(forBPM: 118), 2)
+        XCTAssertEqual(zs.zoneNumber(forBPM: 167), 3)
+        XCTAssertEqual(zs.zoneNumber(forBPM: 168), 4)
+        XCTAssertEqual(zs.zoneNumber(forBPM: 184), 5)
+        XCTAssertEqual(zs.zoneNumber(forBPM: 230), 5)
+    }
+
+    func testInvalidCustomBoundariesFallBackToDefaults() {
+        let zs = HRZones.zones(maxHR: 200, customLowerBounds: [100, 120, 120, 160, 180])
+        XCTAssertEqual(zs.source, "manual")
+        XCTAssertEqual(zs.zones.map(\.lower), [100, 120, 140, 160, 180])
+    }
+
+    func testDefaultEditorBoundsPreserveIntegerClassification() {
+        XCTAssertEqual(HRZones.defaultLowerBounds(maxHR: 187), [94, 113, 131, 150, 169])
+    }
+
     func testTimeInZoneAccountsForAllTime() {
         let zs = HRZones.zones(maxHR: 200)  // edges 100/120/140/160/180/200
         // 1 Hz samples: 3 in z1 (110), 2 in z3 (150), 1 below (90).

--- a/android/app/src/main/java/com/noop/analytics/HrZones.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrZones.kt
@@ -48,7 +48,7 @@ data class HrZoneSet(
     val zones: List<HrZone>,
     /** Max HR (bpm) the zones were built from. */
     val maxHR: Double,
-    /** "tanaka" (age formula) or "manual" (caller override). */
+    /** "tanaka" (age formula), "manual" (caller override), or "custom" (personalized boundaries). */
     val source: String,
 ) {
     /** Return the zone number (1..5) for a bpm value, or 0 when below Zone 1. */
@@ -90,6 +90,12 @@ object HrZones {
     /** %HRmax band edges for zones 1..5: [0.50, 0.60, 0.70, 0.80, 0.90, 1.00]. */
     val zoneEdges: List<Double> = listOf(0.50, 0.60, 0.70, 0.80, 0.90, 1.00)
 
+    /**
+     * Sensible editable BPM range for personalized zone starts. The analytics API accepts any
+     * positive finite values; the app UIs use this range to keep steppers practical.
+     */
+    val customBPMRange: IntRange = 30..250
+
     /** Tanaka (2001) age-predicted max HR: 208 − 0.7 × age (gender-independent). */
     fun tanakaMaxHR(age: Double): Double = 208.0 - 0.7 * age
 
@@ -99,7 +105,7 @@ object HrZones {
      * @param age age in years (used only when [maxHROverride] is null).
      * @param maxHROverride explicit HRmax (bpm); when provided, `source == "manual"`.
      */
-    fun zones(age: Double, maxHROverride: Double? = null): HrZoneSet {
+    fun zones(age: Double, maxHROverride: Double? = null, customLowerBounds: List<Double>? = null): HrZoneSet {
         val maxHR: Double
         val source: String
         if (maxHROverride != null) {
@@ -109,26 +115,50 @@ object HrZones {
             maxHR = tanakaMaxHR(age)
             source = "tanaka"
         }
-        return zones(maxHR, source)
+        return zones(maxHR, source, customLowerBounds)
     }
 
-    /** Build the 5-zone set directly from a known max HR. */
-    fun zones(maxHR: Double, source: String = "manual"): HrZoneSet {
+    /**
+     * Build the 5-zone set directly from a known max HR, optionally replacing the conventional
+     * percentage edges with five personalized inclusive lower bounds in BPM. Invalid custom input
+     * falls back to the conventional model, so malformed restored preferences can never create gaps.
+     */
+    fun zones(maxHR: Double, source: String = "manual", customLowerBounds: List<Double>? = null): HrZoneSet {
+        val custom = customLowerBounds?.let(::validCustomLowerBounds)
         val built = ArrayList<HrZone>(5)
         for (i in 0 until 5) {
-            val loPct = zoneEdges[i]
-            val hiPct = zoneEdges[i + 1]
+            val lower = custom?.get(i) ?: (zoneEdges[i] * maxHR)
+            val upper = custom?.let { if (i < 4) it[i + 1] else maxOf(maxHR, it[i]) } ?: (zoneEdges[i + 1] * maxHR)
+            val loPct = if (maxHR > 0) lower / maxHR else 0.0
+            val hiPct = if (maxHR > 0) upper / maxHR else 0.0
             built.add(
                 HrZone(
                     number = i + 1,
-                    lower = loPct * maxHR,
-                    upper = hiPct * maxHR,
+                    lower = lower,
+                    upper = upper,
                     lowerPct = loPct,
                     upperPct = hiPct,
                 )
             )
         }
-        return HrZoneSet(zones = built, maxHR = maxHR, source = source)
+        return HrZoneSet(zones = built, maxHR = maxHR, source = if (custom == null) source else "custom")
+    }
+
+    /**
+     * The conventional five inclusive lower bounds, rounded up to whole BPM for an editor. Rounding
+     * up preserves the existing integer-sample classification (e.g. a 93.5 edge starts at 94 bpm).
+     */
+    fun defaultLowerBounds(maxHR: Double): List<Int> = zoneEdges.take(5).map { kotlin.math.ceil(it * maxHR).toInt() }
+
+    /**
+     * Return a valid five-boundary custom model, or null unless values are positive, finite, and
+     * strictly increasing. Kept public so persistence layers can reject hand-edited backup values
+     * using the exact same invariant as the analytics engine.
+     */
+    fun validCustomLowerBounds(values: List<Double>): List<Double>? {
+        if (values.size != 5 || !values.all { it.isFinite() && it > 0 }) return null
+        for (i in 1 until values.size) if (values[i] <= values[i - 1]) return null
+        return values
     }
 
     /**

--- a/android/app/src/test/java/com/noop/analytics/HrZonesTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrZonesTest.kt
@@ -56,4 +56,34 @@ class HrZonesTest {
         assertNotSame(a, a2)               // single-entry: not restored, rebuilt
         assertEquals(a, a2)                // but value-equal — same pure output for the same maxHR
     }
+
+    @Test
+    fun customBpmBoundariesReplacePercentageEdges() {
+        val zs = HrZones.zones(
+            maxHR = 200.0,
+            customLowerBounds = listOf(95.0, 118.0, 142.0, 168.0, 184.0),
+        )
+        assertEquals("custom", zs.source)
+        assertEquals(listOf(95.0, 118.0, 142.0, 168.0, 184.0), zs.zones.map { it.lower })
+        assertEquals(1, zs.zoneNumber(117.0))
+        assertEquals(2, zs.zoneNumber(118.0))
+        assertEquals(4, zs.zoneNumber(168.0))
+        assertEquals(5, zs.zoneNumber(184.0))
+        assertEquals(5, zs.zoneNumber(230.0))
+    }
+
+    @Test
+    fun invalidCustomBoundariesFallBackToDefaults() {
+        val zs = HrZones.zones(
+            maxHR = 200.0,
+            customLowerBounds = listOf(100.0, 120.0, 120.0, 160.0, 180.0),
+        )
+        assertEquals("manual", zs.source)
+        assertEquals(listOf(100.0, 120.0, 140.0, 160.0, 180.0), zs.zones.map { it.lower })
+    }
+
+    @Test
+    fun defaultEditorBoundsPreserveIntegerClassification() {
+        assertEquals(listOf(94, 113, 131, 150, 169), HrZones.defaultLowerBounds(187.0))
+    }
 }


### PR DESCRIPTION
## Personalized HR zones — analytics core (recreates #531, stage 1/3)

Recreates the analytics foundation of @kavemang's custom-HR-zones feature (#531, closes toward #138) onto current `main`. The original PR is **417 commits behind** and conflicts across 24 of 27 files, so it can't be rebased — this re-applies the work in reviewable stages, crediting @kavemang.

### What this adds
Extends the existing `HRZones` / `HrZones` model with a third `source`, **`"custom"`**: five personalized inclusive **BPM** lower bounds replace the conventional %HRmax edges when supplied and valid.

- `zones(…)` gains `customLowerBounds`; **`validCustomLowerBounds`** enforces one shared invariant (5 finite, positive, strictly-increasing) and **falls back to the conventional model on bad input**, so a malformed restored preference can never create zone gaps.
- `defaultLowerBounds` rounds up to whole BPM to preserve the existing integer-sample classification.
- **No Effort/strain/scoring change, no stored-workout change, no migration.** Opt-in and inert until a caller passes custom bounds.

### Parity & safety
- Byte-parity Swift↔Kotlin (same logic, constants `30…250`, `"custom"` source string).
- Kotlin's `HrZoneSetCache` (a main-only maxHR memo for the 1 Hz coach path) is preserved untouched.
- 3 parity tests each side: custom replaces edges, invalid→fallback, default bounds preserve integer classification.

### Verification
- Android `HrZonesTest` green locally (`testFullDebugUnitTest`).
- Swift `HRZonesTests` via `swift-packages` CI (StrandAnalytics is macOS-only).

### Scope / what follows
This is intentionally the analytics core only — the public API is added and tested but not yet consumed. Next:
- **Stage 2** — profile keys + `.noopbak` whitelist (byte-identical, backup round-trip tests).
- **Stage 3** — Settings editor (neighbour-aware ordered boundaries) + routing live HR / workouts / haptics through the effective set, with `de/es/fr/pl`, via the app-build gate.

**Nit carried to stage 3:** `HrZoneSetCache` keys on `maxHR` only, so it can't serve custom zones as-is — the routing that consumes it will need cache-awareness (or bypass) when a custom set is active.
