### PR TITLE
Personalized HR zones — Profile model (recreates #531, 3a)

### DIFF
--- a/Strand/Data/Profile.swift
+++ b/Strand/Data/Profile.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Combine
 import SwiftUI
+import StrandAnalytics
 
 /// User profile (age/sex/body metrics/HR-max) persisted in UserDefaults.
 /// Powers HR zones, calories and recovery baselines.
@@ -26,6 +27,13 @@ final class ProfileStore: ObservableObject {
     @Published var waistCm: Double { didSet { d.set(waistCm, forKey: K.waist) } }
     /// 0 = auto-estimate from age.
     @Published var hrMaxOverride: Int { didSet { d.set(hrMaxOverride, forKey: K.hrMax) } }
+    /// Five personalized inclusive zone starts in BPM; empty = conventional %HRmax zones.
+    @Published var hrZoneThresholds: [Int] {
+        didSet {
+            if hrZoneThresholds.isEmpty { d.removeObject(forKey: K.hrZoneThresholds) }
+            else { d.set(hrZoneThresholds.map(String.init).joined(separator: ","), forKey: K.hrZoneThresholds) }
+        }
+    }
     /// Step-calibration divisor (#139/#132): counter ticks per real step for the @57 motion
     /// counter. 1.0 = raw pass-through (default — no behavior change). Clamped 0.5–30.0
     /// (WHOOP 5/MG motion-counter overcount can reach ~24×, so the ceiling has to be high).
@@ -69,6 +77,7 @@ final class ProfileStore: ObservableObject {
         static let legacyAge = "profile.age"
         static let sex = "profile.sex", weight = "profile.weightKg"
         static let height = "profile.heightCm", hrMax = "profile.hrMaxOverride"
+        static let hrZoneThresholds = "profile.hrZoneThresholds"
         static let stepScale = "profile.stepTicksPerStep"
         static let waist = "profile.waistCm"
         static let stepsCoeff = "profile.stepsCalibrationCoefficient"
@@ -106,6 +115,9 @@ final class ProfileStore: ObservableObject {
         heightCm = d.object(forKey: K.height) as? Double ?? 178
         waistCm = d.object(forKey: K.waist) as? Double ?? 0
         hrMaxOverride = d.object(forKey: K.hrMax) as? Int ?? 0
+        let storedThresholds = d.string(forKey: K.hrZoneThresholds)?
+            .split(separator: ",").compactMap { Int($0) } ?? []
+        hrZoneThresholds = Self.validZoneThresholds(storedThresholds) ? storedThresholds : []
         stepTicksPerStep = min(max(d.object(forKey: K.stepScale) as? Double ?? 1.0, 0.5), 30.0)
         stepsCalibrationCoefficient = d.object(forKey: K.stepsCoeff) as? Double ?? 0
         stepsCalibrationSampleDays = d.object(forKey: K.stepsSampleDays) as? Int ?? 0
@@ -170,6 +182,42 @@ final class ProfileStore: ObservableObject {
 
     /// Tanaka estimate unless overridden.
     var hrMax: Int { hrMaxOverride > 0 ? hrMaxOverride : Int((208 - 0.7 * Double(age)).rounded()) }
+
+    /// Personalized zone starts after enforcing the same five-value invariant as `HRZones`.
+    var customHRZoneLowerBounds: [Double]? {
+        guard Self.validZoneThresholds(hrZoneThresholds) else { return nil }
+        return hrZoneThresholds.map(Double.init)
+    }
+
+    /// The single display-zone model used by live HR, workout splits, and haptic coaching.
+    var hrZoneSet: HRZoneSet {
+        HRZones.zones(maxHR: Double(hrMax), customLowerBounds: customHRZoneLowerBounds)
+    }
+
+    var hasCustomHRZones: Bool { customHRZoneLowerBounds != nil }
+
+    /// Enable by seeding the editor with boundaries that classify integer BPM exactly like today's
+    /// conventional percentages; disabling removes the override and immediately restores defaults.
+    func setCustomHRZonesEnabled(_ enabled: Bool) {
+        hrZoneThresholds = enabled ? HRZones.defaultLowerBounds(maxHR: Double(hrMax)) : []
+    }
+
+    /// Move one boundary while preserving strict ordering. Neighbour-aware clamps make it impossible
+    /// for the stepper to create a gap, overlap, or invalid persisted state.
+    func stepHRZoneThreshold(at index: Int, up: Bool) {
+        guard hrZoneThresholds.indices.contains(index) else { return }
+        var next = hrZoneThresholds
+        let floor = index == 0 ? HRZones.customBPMRange.lowerBound : next[index - 1] + 1
+        let ceiling = index == next.count - 1 ? HRZones.customBPMRange.upperBound : next[index + 1] - 1
+        next[index] = min(max(next[index] + (up ? 1 : -1), floor), ceiling)
+        hrZoneThresholds = next
+    }
+
+    nonisolated static func validZoneThresholds(_ values: [Int]) -> Bool {
+        guard values.count == 5,
+              values.allSatisfy(HRZones.customBPMRange.contains) else { return false }
+        return zip(values, values.dropFirst()).allSatisfy(<)
+    }
 
     /// Whether the cycle-awareness opt-in applies to this profile (#801). Cycle phase is read from the
     /// MENSTRUAL skin-temperature shift, so the opt-in (the Health card + the Automations toggle) is only

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -119,6 +119,8 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.noop.BuildConfig
 import com.noop.analytics.Baselines
+import com.noop.analytics.HrZoneSet
+import com.noop.analytics.HrZones
 import com.noop.analytics.Zones
 import com.noop.R
 import com.noop.ble.PuffinExperiment
@@ -283,6 +285,46 @@ class ProfileStore(private val prefs: SharedPreferences) {
     /** Effective HR-max: the manual override if set, else the Tanaka estimate. */
     val hrMax: Int get() = if (hrMaxOverride > 0) hrMaxOverride else hrMaxAuto
 
+    /**
+     * Five personalized inclusive zone starts in BPM, or null for the conventional %HRmax zones.
+     * Persisted under [KEY_HR_ZONE_THRESHOLDS]; a stored value failing the shared invariant is treated
+     * as absent. Mirrors macOS `Profile.hrZoneThresholds`.
+     */
+    var hrZoneThresholds: List<Int>?
+        get() {
+            val values = prefs.getString(KEY_HR_ZONE_THRESHOLDS, null)
+                ?.split(",")?.mapNotNull(String::toIntOrNull) ?: return null
+            return values.takeIf { validZoneThresholds(it) }
+        }
+        set(values) {
+            if (values == null || !validZoneThresholds(values)) {
+                prefs.edit().remove(KEY_HR_ZONE_THRESHOLDS).apply()
+            } else {
+                prefs.edit().putString(KEY_HR_ZONE_THRESHOLDS, values.joinToString(",")).apply()
+            }
+        }
+
+    /** The single display-zone model used by live HR, workout splits, and haptic coaching. */
+    val hrZoneSet: HrZoneSet
+        get() = HrZones.zones(maxHR = hrMax.toDouble(), customLowerBounds = hrZoneThresholds?.map(Int::toDouble))
+
+    val hasCustomHrZones: Boolean get() = hrZoneThresholds != null
+
+    /** Enable by seeding the editor with conventional boundaries; disabling restores the defaults. */
+    fun setCustomHrZonesEnabled(enabled: Boolean) {
+        hrZoneThresholds = if (enabled) HrZones.defaultLowerBounds(hrMax.toDouble()) else null
+    }
+
+    /** Move one boundary while preserving strict ordering, with neighbour-aware clamps. */
+    fun stepHrZoneThreshold(index: Int, up: Boolean) {
+        val current = hrZoneThresholds?.toMutableList() ?: return
+        if (index !in current.indices) return
+        val floor = if (index == 0) HrZones.customBPMRange.first else current[index - 1] + 1
+        val ceiling = if (index == current.lastIndex) HrZones.customBPMRange.last else current[index + 1] - 1
+        current[index] = (current[index] + if (up) 1 else -1).coerceIn(floor, ceiling)
+        hrZoneThresholds = current
+    }
+
     // ── Backup settings snapshot/apply (#1000) ──────────────────────────────────────────────────
     // The profile half of a `.noopbak`'s `settings.json`. Canonical key strings mirror
     // `BackupSettingsCodec.WHITELIST` (and the Apple `BackupSettings.whitelist`) exactly — note
@@ -302,6 +344,9 @@ class ProfileStore(private val prefs: SharedPreferences) {
         if (prefs.contains(KEY_HEIGHT)) out["profile.heightCm"] = heightCm
         if (prefs.contains(KEY_WAIST)) out["profile.waistCm"] = waistCm
         if (prefs.contains(KEY_HRMAX)) out["profile.hrMax"] = hrMaxOverride
+        if (prefs.contains(KEY_HR_ZONE_THRESHOLDS)) {
+            hrZoneThresholds?.let { out["profile.hrZoneThresholds"] = it.joinToString(",") }
+        }
         return out
     }
 
@@ -320,6 +365,9 @@ class ProfileStore(private val prefs: SharedPreferences) {
         (values["profile.heightCm"] as? Number)?.let { heightCm = it.toDouble() }
         (values["profile.waistCm"] as? Number)?.let { waistCm = it.toDouble() }
         (values["profile.hrMax"] as? Number)?.let { hrMaxOverride = it.toInt() }
+        (values["profile.hrZoneThresholds"] as? String)?.let {
+            hrZoneThresholds = it.split(",").mapNotNull(String::toIntOrNull)
+        }
     }
 
     companion object {
@@ -334,6 +382,13 @@ class ProfileStore(private val prefs: SharedPreferences) {
         private const val KEY_HEIGHT = "height_cm"
         private const val KEY_WAIST = "waist_cm"
         private const val KEY_HRMAX = "hr_max_override"
+        private const val KEY_HR_ZONE_THRESHOLDS = "hr_zone_thresholds"
+
+        /** The shared five-boundary invariant (parity with `HRZones.validCustomLowerBounds`). */
+        fun validZoneThresholds(values: List<Int>): Boolean =
+            values.size == 5 &&
+                values.all { it in HrZones.customBPMRange } &&
+                values.zipWithNext().all { (a, b) -> a < b }
         private const val KEY_STEP_SCALE = "step_ticks_per_step"
         private const val KEY_STEPS_COEFF = "steps_calibration_coefficient"
         private const val KEY_STEPS_SAMPLE_DAYS = "steps_calibration_sample_days"


### PR DESCRIPTION
## Personalized HR zones — Profile model (recreates #531, stage 3a)

The storage model both platforms share for custom HR zones — **no UI yet**. Builds on the merged analytics core (#1318) and backup contract (#1320).

### What this adds
- **`hrZoneThresholds`** — five personalized inclusive BPM zone starts, persisted (Swift `Profile`, Android `ProfileStore`), null/empty = conventional %HRmax. A stored value failing the invariant is treated as absent.
- **`hrZoneSet`** — the single effective display-zone model (`HRZones.zones(maxHR:, customLowerBounds:)`) that live HR, workout splits, and haptic coaching will route through in stage 3b.
- **`setCustomHrZonesEnabled` / `stepHrZoneThreshold`** — enable (seeds conventional bounds) / neighbour-aware ordered stepping.
- **`.noopbak` snapshot/apply wiring** for `profile.hrZoneThresholds` (Android `ProfileStore.backupSnapshot`/`applyBackup`; Swift is whitelist-driven automatically), completing what #1320 whitelisted.

### Parity & safety
- `validZoneThresholds` mirrors `HRZones.validCustomLowerBounds` exactly (5 values in `30…250`, strictly increasing).
- No Effort/strain/scoring change, no migration; opt-in and inert until a caller reads `hrZoneSet`.
- Android `ProfileStore` lives inside `SettingsScreen.kt`, so the model methods are added there — **not** the editor composables.

### Scope: why the UI isn't here
The editor UI + routing is a **from-scratch re-implementation** onto the redesigned screens — #531's `SettingsView`/`LiveWorkoutView` diffs conflict with 891 / 312 lines of the `ui-experimental` redesign + recent merges, so they're unusable. That lands as **stage 3b** (SwiftUI/Compose editor + wiring live HR/workouts/haptics through `hrZoneSet` + `de/es/fr/pl`), where the `HrZoneSetCache` cache-awareness fix also lands.

### Verification
- Android `compileFullDebugKotlin` clean.
- Swift `Profile.swift` is app-target (no default CI) → app-build gate.

Recreates @kavemang's #531.
