### PR TITLE
Personalized HR zones — Settings editor (recreates #531, 3c · final)

### DIFF
--- a/Strand/Data/Profile.swift
+++ b/Strand/Data/Profile.swift
@@ -209,6 +209,7 @@ final class ProfileStore: ObservableObject {
         var next = hrZoneThresholds
         let floor = index == 0 ? HRZones.customBPMRange.lowerBound : next[index - 1] + 1
         let ceiling = index == next.count - 1 ? HRZones.customBPMRange.upperBound : next[index + 1] - 1
+        guard floor <= ceiling else { return }   // no room between neighbours -> no-op (parity w/ Kotlin)
         next[index] = min(max(next[index] + (up ? 1 : -1), floor), ceiling)
         hrZoneThresholds = next
     }

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -199230,6 +199230,262 @@
           }
         }
       }
+    },
+    "Custom HR zones": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eigene HF-Zonen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom HR zones"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zonas de FC personalizadas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zones FC personnalisées"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zone FC personalizzate"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Własne strefy HR"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zonas de RH personalizadas"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Свои зоны пульса"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义心率区间"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自訂心率區間"
+          }
+        }
+      }
+    },
+    "Set the BPM where each zone begins. Turn off to restore the default percentage-of-max zones.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lege die Herzfrequenz fest, bei der jede Zone beginnt. Ausschalten, um die Standardzonen in Prozent der maximalen Herzfrequenz wiederherzustellen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set the BPM where each zone begins. Turn off to restore the default percentage-of-max zones."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Define las pulsaciones en las que empieza cada zona. Desactiva para restaurar las zonas predeterminadas por porcentaje de la frecuencia máxima."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définis la fréquence cardiaque à laquelle chaque zone commence. Désactive pour rétablir les zones par défaut en pourcentage de la fréquence maximale."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta la frequenza cardiaca a cui inizia ogni zona. Disattiva per ripristinare le zone predefinite in percentuale della frequenza massima."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ustaw tętno, przy którym zaczyna się każda strefa. Wyłącz, aby przywrócić domyślne strefy oparte na procencie tętna maksymalnego."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Define os batimentos em que cada zona começa. Desativa para repor as zonas predefinidas por percentagem da frequência máxima."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Задайте пульс, с которого начинается каждая зона. Выключите, чтобы вернуть стандартные зоны в процентах от максимального пульса."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置每个区间开始时的心率。关闭可恢复按最大心率百分比划分的默认区间。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定每個區間開始時的心率。關閉可恢復按最大心率百分比劃分的預設區間。"
+          }
+        }
+      }
+    },
+    "Zone %lld starts": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beginn Zone %lld"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zone %lld starts"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicio de la zona %lld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Début de la zone %lld"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inizio della zona %lld"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Początek strefy %lld"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Início da zona %lld"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Начало зоны %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "区间 %lld 起点"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "區間 %lld 起點"
+          }
+        }
+      }
+    },
+    "Zone %lld starts at %lld beats per minute": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zone %1$lld beginnt bei %2$lld Schlägen pro Minute"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zone %lld starts at %lld beats per minute"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La zona %1$lld empieza en %2$lld pulsaciones por minuto"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La zone %1$lld débute à %2$lld battements par minute"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La zona %1$lld inizia a %2$lld battiti al minuto"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Strefa %1$lld zaczyna się przy %2$lld uderzeniach na minutę"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A zona %1$lld começa aos %2$lld batimentos por minuto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зона %1$lld начинается при %2$lld ударах в минуту"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "区间 %1$lld 从每分钟 %2$lld 次开始"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "區間 %1$lld 從每分鐘 %2$lld 次開始"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -482,6 +482,29 @@ struct SettingsView: View {
                     }
                 }
                 rowDivider
+                // Custom HR zones (#531, @kavemang): replace the conventional %HRmax bands with five
+                // personalized inclusive BPM lower bounds. Off = the effective set stays conventional.
+                FormRow(label: "Custom HR zones") {
+                    Toggle("Custom HR zones", isOn: Binding(
+                        get: { profile.hasCustomHRZones },
+                        set: { profile.setCustomHRZonesEnabled($0) }
+                    ))
+                    .labelsHidden()
+                    .accessibilityLabel("Custom HR zones")
+                }
+                if profile.hasCustomHRZones {
+                    Text("Set the BPM where each zone begins. Turn off to restore the default percentage-of-max zones.")
+                        .font(StrandFont.footnote)
+                        .foregroundStyle(StrandPalette.textTertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    ForEach(profile.hrZoneThresholds.indices, id: \.self) { index in
+                        rowDivider
+                        FormRow(label: "Zone \(index + 1) starts") {
+                            hrZoneThresholdField(index: index)
+                        }
+                    }
+                }
+                rowDivider
                 // Step calibration (#139/#132): daily steps = @57 counter ticks ÷ this divisor.
                 // 1.0 = raw pass-through until the true 5/MG tick rate is known. The divisor goes
                 // up to 30 because a 5/MG motion counter can overcount by ~24×; the stepper uses a
@@ -875,6 +898,31 @@ struct SettingsView: View {
                     value: $profile.hrMaxOverride, in: 0...230, step: 1)
                 .labelsHidden()
                 .accessibilityLabel("Max heart rate override, \(profile.hrMaxOverride == 0 ? "automatic" : "\(profile.hrMaxOverride) bpm")")
+        }
+        .fixedSize()
+    }
+
+    /// One personalized zone lower bound (bpm), stepped neighbour-aware (see `Profile.stepHRZoneThreshold`)
+    /// so the five bounds stay strictly increasing. Mirrors `hrMaxField`'s compact value + stepper layout.
+    private func hrZoneThresholdField(index: Int) -> some View {
+        let value = profile.hrZoneThresholds.indices.contains(index) ? profile.hrZoneThresholds[index] : 0
+        return HStack(spacing: NoopMetrics.space2) {
+            HStack(alignment: .firstTextBaseline, spacing: NoopMetrics.space1) {
+                Text("\(value)")
+                    .font(StrandFont.bodyNumber)
+                    .foregroundStyle(StrandPalette.textPrimary)
+                    .frame(width: NoopMetrics.formValueColumnWidth, alignment: .center)
+                Text("bpm")
+                    .font(StrandFont.caption)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize()
+            }
+            .fixedSize()
+            Stepper("",
+                    onIncrement: { profile.stepHRZoneThreshold(at: index, up: true) },
+                    onDecrement: { profile.stepHRZoneThreshold(at: index, up: false) })
+                .labelsHidden()
+                .accessibilityLabel("Zone \(index + 1) starts at \(value) beats per minute")
         }
         .fixedSize()
     }

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1015,6 +1015,42 @@ fun SettingsScreen(
                     }
                 }
                 SettingsRowDivider()
+                // Custom HR zones (#531, @kavemang): five personalized inclusive BPM lower bounds that
+                // replace the conventional %HRmax bands. Off -> the effective set stays conventional.
+                SettingsFormRow(label = uiString(R.string.l10n_settings_screen_custom_hr_zones_84736ca5)) {
+                    Switch(
+                        checked = profile.hasCustomHrZones,
+                        onCheckedChange = { mutate { profile.setCustomHrZonesEnabled(it) } },
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = Palette.surfaceBase,
+                            checkedTrackColor = Palette.accent,
+                            uncheckedThumbColor = Palette.textSecondary,
+                            uncheckedTrackColor = Palette.surfaceInset,
+                            uncheckedBorderColor = Palette.hairline,
+                        ),
+                    )
+                }
+                if (profile.hasCustomHrZones) {
+                    Spacer(Modifier.height(6.dp))
+                    Text(
+                        text = uiString(R.string.l10n_settings_screen_custom_hr_zones_hint_f7fa3bae),
+                        style = NoopType.footnote,
+                        color = Palette.textTertiary,
+                    )
+                    profile.hrZoneThresholds?.forEachIndexed { index, value ->
+                        SettingsRowDivider()
+                        SettingsFormRow(label = uiString(R.string.l10n_settings_screen_zone_starts_a0a60d45, index + 1)) {
+                            StepperField(
+                                value = value.toString(),
+                                unit = "bpm",
+                                accessibility = "Zone ${index + 1} starts at $value bpm",
+                                onMinus = { mutate { profile.stepHrZoneThreshold(index, up = false) } },
+                                onPlus = { mutate { profile.stepHrZoneThreshold(index, up = true) } },
+                            )
+                        }
+                    }
+                }
+                SettingsRowDivider()
                 // Step calibration (#139/#132): daily steps = @57 counter ticks ÷ this divisor.
                 // 1.0 = raw pass-through until the true 5/MG tick rate is known. The divisor goes
                 // up to 30 because a 5/MG motion counter can overcount by ~24×; the stepper uses a

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -321,6 +321,7 @@ class ProfileStore(private val prefs: SharedPreferences) {
         if (index !in current.indices) return
         val floor = if (index == 0) HrZones.customBPMRange.first else current[index - 1] + 1
         val ceiling = if (index == current.lastIndex) HrZones.customBPMRange.last else current[index + 1] - 1
+        if (floor > ceiling) return   // no room between neighbours -> no-op (coerceIn throws on empty range)
         current[index] = (current[index] + if (up) 1 else -1).coerceIn(floor, ceiling)
         hrZoneThresholds = current
     }

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1991,4 +1991,7 @@
     <string name="skin_temp_delta_title">Hauttemperatur Δ</string>
     <string name="skin_temp_vs_baseline">ggü. Basiswert</string>
     <string name="l10n_app_changelog_make_noop_yours_theme_colours_and_6bdef2a7">Mach NOOP zu deinem — Akzentfarben und eigene Hintergründe, vierzig weitere Sportarten mit GPS-Strecken und eine Kalorien-Heatmap</string>
+    <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Eigene HF-Zonen</string>
+    <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Lege die Herzfrequenz fest, bei der jede Zone beginnt. Ausschalten, um die Standardzonen in Prozent der maximalen Herzfrequenz wiederherzustellen.</string>
+    <string name="l10n_settings_screen_zone_starts_a0a60d45">Beginn Zone %1$d</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1976,4 +1976,7 @@
     <string name="skin_temp_delta_title">Temp. de piel Δ</string>
     <string name="skin_temp_vs_baseline">vs. referencia</string>
     <string name="l10n_app_changelog_make_noop_yours_theme_colours_and_6bdef2a7">Haz NOOP tuyo: colores de acento y fondos personalizados, cuarenta deportes más con rutas GPS y un mapa de calor de calorías</string>
+    <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Zonas de FC personalizadas</string>
+    <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Define las pulsaciones en las que empieza cada zona. Desactiva para restaurar las zonas predeterminadas por porcentaje de la frecuencia máxima.</string>
+    <string name="l10n_settings_screen_zone_starts_a0a60d45">Inicio de la zona %1$d</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1976,4 +1976,7 @@
     <string name="skin_temp_delta_title">Temp. cutanée Δ</string>
     <string name="skin_temp_vs_baseline">vs référence</string>
     <string name="l10n_app_changelog_make_noop_yours_theme_colours_and_6bdef2a7">NOOP à votre image — couleurs d\'accent et fonds personnalisés, quarante sports de plus avec tracés GPS, et une carte de chaleur des calories</string>
+    <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Zones FC personnalisées</string>
+    <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Définis la fréquence cardiaque à laquelle chaque zone commence. Désactive pour rétablir les zones par défaut en pourcentage de la fréquence maximale.</string>
+    <string name="l10n_settings_screen_zone_starts_a0a60d45">Début de la zone %1$d</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -1970,4 +1970,7 @@
     <string name="l10n_sleep_screen_stages_c1d33ad5">Fazy</string>
     <string name="l10n_sleep_screen_stages_vs_typical_28463f24">Fazy na tle typowych wartości</string>
     <string name="l10n_app_changelog_make_noop_yours_theme_colours_and_6bdef2a7">Dostosuj NOOP do siebie — kolory motywu i własne tła, czterdzieści kolejnych dyscyplin z trasami GPS oraz mapa cieplna kalorii</string>
+    <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Własne strefy HR</string>
+    <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Ustaw tętno, przy którym zaczyna się każda strefa. Wyłącz, aby przywrócić domyślne strefy oparte na procencie tętna maksymalnego.</string>
+    <string name="l10n_settings_screen_zone_starts_a0a60d45">Początek strefy %1$d</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1970,4 +1970,7 @@
     <string name="skin_temp_delta_title">Temperatura da pele Δ</string>
     <string name="skin_temp_vs_baseline">vs referência</string>
     <string name="l10n_app_changelog_make_noop_yours_theme_colours_and_6bdef2a7">Torna o NOOP teu — cores de destaque e fundos personalizados, mais quarenta desportos com percursos GPS e um mapa de calor de calorias</string>
+    <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Zonas de RH personalizadas</string>
+    <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Define os batimentos em que cada zona começa. Desativa para repor as zonas predefinidas por percentagem da frequência máxima.</string>
+    <string name="l10n_settings_screen_zone_starts_a0a60d45">Início da zona %1$d</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1903,4 +1903,7 @@
     <string name="skin_temp_delta_title">皮肤体温 Δ</string>
     <string name="skin_temp_vs_baseline">相对基线</string>
     <string name="l10n_app_changelog_make_noop_yours_theme_colours_and_6bdef2a7">把 NOOP 变成你的——强调色与自定义背景、新增四十多项运动及 GPS 轨迹，还有卡路里热力图</string>
+    <string name="l10n_settings_screen_custom_hr_zones_84736ca5">自定义心率区间</string>
+    <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">设置每个区间开始时的心率。关闭可恢复按最大心率百分比划分的默认区间。</string>
+    <string name="l10n_settings_screen_zone_starts_a0a60d45">区间 %1$d 起点</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2003,4 +2003,7 @@
     <string name="skin_temp_delta_title">Skin Temp Δ</string>
     <string name="skin_temp_vs_baseline">vs baseline</string>
     <string name="l10n_app_changelog_make_noop_yours_theme_colours_and_6bdef2a7">Make NOOP yours — theme colours and custom backgrounds, forty more sports with GPS routes, and a calorie heatmap</string>
+    <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Custom HR zones</string>
+    <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Set the BPM where each zone begins. Turn off to restore the default percentage-of-max zones.</string>
+    <string name="l10n_settings_screen_zone_starts_a0a60d45">Zone %1$d starts</string>
 </resources>


### PR DESCRIPTION
## Personalized HR zones — Settings editor (recreates #531, stage 3c · final)

The user-facing piece that completes @kavemang's **#531**: an editor to actually **set** custom HR zones. The analytics core (#1318), `.noopbak` contract (#1320), model (#1321) and consumer routing (#1322) already carry personalized zones — until now nothing let a user enter them.

### The editor (both platforms, beside "Max heart rate")
- A **Custom HR zones** toggle. Turning it on seeds the five conventional %HRmax lower bounds (ceil'd to whole bpm) as an editable starting point; turning it off clears the stored thresholds and the effective set falls straight back to conventional %HRmax.
- When on, **five neighbour-aware bpm steppers** — one per zone. Each step is clamped to stay strictly between its neighbours (`Profile.stepHRZoneThreshold` / `ProfileStore.stepHrZoneThreshold`), so the five bounds can never cross or collide — the validity invariant the analytics core enforces is enforced at the UI too.

Everything the steppers write flows through the already-merged `hrZoneThresholds` → `hrZoneSet` path, so live HR, workout splits, and the haptic coach immediately reflect the personalized zones.

### i18n
Three new visible strings (toggle label, hint, `Zone N starts` — a positional integer format) plus one iOS accessibility string, translated across **every shipped locale** (iOS `de/es/fr/it/pl/pt-PT/ru/zh-Hans/zh-Hant`; Android `de/es/fr/pl/pt-rPT/zh`), reusing the catalog's established zone/HR terminology (`HF-Zonen`, `Zonas de FC`, `Zones FC`, `心率区间`, …).

### Verification
- Android `compileFullDebugKotlin` + `mergeFullDebugResources` clean (the `%1$d` format strings validate under aapt2).
- `Tools/i18n_audit.py --ci main` clean — focus locales complete, no new hardcoded literals, no new gaps in the ratcheting locales.
- Swift is app-target → app-build gate (both `Strand` macOS + `NOOPiOS` iOS).
- On-device QA (both platforms) still to do: toggle on/off, step each of the five bounds against its neighbours, confirm live HR / workout split / coach pick up the custom zones.

With this, #531 is fully recreated end-to-end. Recreates @kavemang's #531.
