### PR TITLE
fix(backup): stop a silently-declined picker from wedging the Backup screen

### DIFF
--- a/Strand/Screens/BackupSyncView.swift
+++ b/Strand/Screens/BackupSyncView.swift
@@ -194,8 +194,12 @@ struct BackupSyncView: View {
         // `busy` guards against a double-tap stacking a second picker presentation on top of the first.
         busy = true
         Task {
+            // Clear in a `defer` so it clears on ANY exit. It matters more here than elsewhere: every
+            // control on this screen is `.disabled(busy)`, so a pick that never returned wedged the whole
+            // screen — including the "Use NOOP's own folder" escape hatch. DocumentPicker now guarantees
+            // the continuation resumes, but the flag must not depend on that promise holding.
+            defer { busy = false }
             let picked = await FolderBackup.pickFolder()
-            busy = false
             if picked != nil {
                 folderLabel = FolderBackup.folderLabel()
             } else if !FolderBackup.useInternalFolder {
@@ -225,10 +229,10 @@ struct BackupSyncView: View {
     private func backupNow() {
         busy = true
         Task {
+            defer { busy = false }   // any exit, incl. cancellation — see chooseFolder
             let ok = await FolderBackup.backupNow(checkpoint: { await model.repo.checkpointForBackup() })
             await MainActor.run {
                 lastMs = FolderBackup.lastBackupMs
-                busy = false
                 alertTitle = ok ? String(localized: "Backed up") : String(localized: "Backup problem")
                 alertMessage = ok
                     ? String(localized: "Saved a backup to your folder.")
@@ -253,13 +257,13 @@ struct BackupSyncView: View {
         pendingRestore = nil
         busy = true
         Task {
+            defer { busy = false }   // any exit, incl. cancellation — see chooseFolder
             // The restore is synchronous file I/O; run it off the main actor so the UI stays responsive
             // for a large store, then report on the main actor.
             let result = await Task.detached(priority: .userInitiated) {
                 FolderBackup.restore(snapshotNamed: snap.name)
             }.value
             await MainActor.run {
-                busy = false
                 switch result {
                 case .imported:
                     alertTitle = String(localized: "Restored")

--- a/Strand/System/DocumentPicker.swift
+++ b/Strand/System/DocumentPicker.swift
@@ -70,7 +70,20 @@ enum DocumentPicker {
             let picker = make(coordinator)
             // Keep the coordinator alive for the lifetime of the picker.
             objc_setAssociatedObject(picker, &Coordinator.assocKey, coordinator, .OBJC_ASSOCIATION_RETAIN)
-            root.present(picker, animated: true)
+            // The continuation is resumed ONLY by a delegate callback. UIKit can decline a presentation
+            // SILENTLY — no throw, no delegate — when the target is already presenting or mid-transition
+            // (`topViewController`'s walk down the presentedViewController chain is momentarily inconsistent
+            // during an animation). The caller would then await a value that never arrives, hanging forever
+            // and leaving `BackupSyncView.busy` stuck true — every control there is `.disabled(busy)`, so a
+            // pick that never appeared wedged the entire screen with no message. In the presentation
+            // completion, detect a picker that never reached a window and resume with nil. `finish` is
+            // resume-once, so a picker that DID open cannot be double-resumed.
+            root.present(picker, animated: true) {
+                if picker.view.window == nil && picker.presentingViewController == nil {
+                    DocumentPicker.recordEvent("not-presented", url: nil)
+                    coordinator.finish(nil)
+                }
+            }
         }
     }
 
@@ -105,7 +118,9 @@ enum DocumentPicker {
             finish(nil)
         }
 
-        private func finish(_ url: URL?) {
+        /// Resume the awaiting caller exactly once. Not private: `present` calls it when UIKit declined
+        /// to show the picker at all — the one outcome no delegate callback covers.
+        func finish(_ url: URL?) {
             guard !resumed else { return }
             resumed = true
             continuation.resume(returning: url)


### PR DESCRIPTION
## Stop a silently-declined folder picker from wedging the Backup screen

Ported from a fix by **@DX23876** (their "NOOP AI" fork), reimplemented on current `main`.

### The bug
`DocumentPicker.present` resumes its `CheckedContinuation` **only** from a `UIDocumentPickerDelegate` callback. But UIKit can decline a presentation **silently** — no throw, no delegate — when the target is already presenting or mid-transition (the `topViewController` walk down `presentedViewController` is momentarily inconsistent during an animation). The caller then `await`s a value that never arrives.

`BackupSyncView` turns that hang into a **dead screen**: `busy` was cleared only *after* the await, and every control is `.disabled(busy)` — so a pick that never appeared wedged *Choose folder*, *Back up now*, *Restore*, **and** the "Use NOOP's own folder" fallback the failure alert points at, with no message. That's exactly the "I can't select a backup folder, nothing happens" report.

### The fix
- **`DocumentPicker`**: pass a presentation-completion; if the picker never reached a window (`view.window == nil && presentingViewController == nil`), resume with `nil`. `finish` is resume-once, so a picker that *did* open can't be double-resumed.
- **`BackupSyncView`**: clear `busy` in a `defer` across the three backup tasks, so the flag never depends on that promise holding.

Scope kept tight: I did **not** port the fork's unrelated strap-log-diagnostics change that rode in the same commit.

### Verification
iOS-only (`DocumentPicker` is `#if os(iOS)`; the macOS folder pick is synchronous). App-target Swift → app-build gate (both `Strand` macOS + `NOOPiOS` iOS). Behaviour is on the CoreBluetooth-free picker path; on-device confirmation of a real declined-presentation is the one thing CI can't cover.
