### PR TITLE
fix(sleep): resolve edit/delete owner across every visible namespace

### DIFF
--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -165,6 +165,14 @@ final class Repository: ObservableObject {
         computedDeviceId == canonicalComputedId ? [computedDeviceId] : [computedDeviceId, canonicalComputedId]
     }
 
+    /// Every namespace that can own a sleep row the Sleep tab currently shows: computed sources first
+    /// (they keep precedence over imported), the active id ahead of the canonical one on each side.
+    /// `CachedSleepSession` deliberately carries no device id, so a write that starts from a merged
+    /// Sleep-tab row must resolve its owner against this same union the reads use — otherwise a
+    /// historical night sitting under the CANONICAL source (after a strap re-add) looks editable but its
+    /// save silently matches nothing.
+    private var sleepOwnerIds: [String] { computedReadIds + importedReadIds }
+
     /// True when the ACTIVE strap is an Oura ring, resolved from its registry id prefix against the canonical
     /// brand table (`DeviceBrandCatalog.idPrefix`) rather than an ad-hoc "oura" literal. The device registry
     /// mints every non-WHOOP id as "<idPrefix>-<uuid>", so the stored id's prefix IS its brand key. Read/UI
@@ -1221,16 +1229,15 @@ final class Repository: ObservableObject {
         let stagesJSON = await restageFromRaw(start: safeStartTs, end: safeEndTs)
             ?? SleepWindowReclip.reclip(stagesJSON: storedStagesJSON, sessionStart: detectedStartTs,
                                         oldEnd: oldEndTs, newStart: safeStartTs, newEnd: safeEndTs)
-        // Apply to the source that actually OWNS this block. Try the computed source first; only fall
-        // back to the imported source when no computed row matched , so we never edit a coincidental
-        // same-startTs row in the other namespace (which the old unconditional double-write could do).
-        let computedChanged = (try? await store.applySleepEdit(
-            deviceId: computedDeviceId, detectedStartTs: detectedStartTs,
-            newStartTs: safeStartTs, newEndTs: safeEndTs, stagesJSON: stagesJSON)) ?? 0
-        if computedChanged == 0 {
-            _ = try? await store.applySleepEdit(
-                deviceId: deviceId, detectedStartTs: detectedStartTs,
-                newStartTs: safeStartTs, newEndTs: safeEndTs, stagesJSON: stagesJSON)
+        // Apply to the source that actually OWNS this block, resolved against every namespace the Sleep
+        // tab can display (computed precedence preserved by ordering). Stop at the first source that
+        // matched, so a coincidental same-startTs row in another namespace never takes a second edit —
+        // and, unlike the old computed-then-active pair, a night under the canonical source is reached.
+        for ownerDeviceId in sleepOwnerIds {
+            let changed = (try? await store.applySleepEdit(
+                deviceId: ownerDeviceId, detectedStartTs: detectedStartTs,
+                newStartTs: safeStartTs, newEndTs: safeEndTs, stagesJSON: stagesJSON)) ?? 0
+            if changed > 0 { break }
         }
         await refresh()
     }
@@ -1269,11 +1276,12 @@ final class Repository: ObservableObject {
             dismissedSleepSpans = DismissedSleepSpans.adding(startTs: detectedStartTs, endTs: endTs,
                                                              to: dismissedSleepSpans)
         }
-        // Delete from the namespace that actually owns the row: computed first, imported as a fallback.
-        let computedDeleted = (try? await store.deleteSleepSession(
-            deviceId: computedDeviceId, startTs: detectedStartTs)) ?? 0
-        if computedDeleted == 0 {
-            _ = try? await store.deleteSleepSession(deviceId: deviceId, startTs: detectedStartTs)
+        // Delete from the same union of possible owners the Sleep tab reads from, first match wins —
+        // so a night under the canonical source (post strap re-add) is actually removed, not no-op'd.
+        for ownerDeviceId in sleepOwnerIds {
+            let deleted = (try? await store.deleteSleepSession(
+                deviceId: ownerDeviceId, startTs: detectedStartTs)) ?? 0
+            if deleted > 0 { break }
         }
         await refresh()
         return snapshot
@@ -1324,11 +1332,12 @@ final class Repository: ObservableObject {
             return SleepDeletionSnapshot(session: session, ownerDeviceId: owner, endTs: session.endTs,
                                          motion: motion ?? nil, sleepState: sleepState ?? nil)
         }
-        if let computed = await row(computedDeviceId) {
-            return await snapshot(computed, owner: computedDeviceId)
-        }
-        if let imported = await row(deviceId) {
-            return await snapshot(imported, owner: deviceId)
+        // Same owner union as the edit/delete paths, so the undo snapshot records the row's REAL owner
+        // (including the canonical source) instead of guessing computed-or-active.
+        for ownerDeviceId in sleepOwnerIds {
+            if let session = await row(ownerDeviceId) {
+                return await snapshot(session, owner: ownerDeviceId)
+            }
         }
         return nil
     }

--- a/StrandTests/ReadSpineActiveDeviceTests.swift
+++ b/StrandTests/ReadSpineActiveDeviceTests.swift
@@ -122,6 +122,35 @@ final class ReadSpineActiveDeviceTests: XCTestCase {
                         "the canonical computed history must NOT be orphaned by the re-add")
     }
 
+    /// A historical sleep can stay visible under the CANONICAL source after a strap re-add. The editor
+    /// hands `editSleepTimes` an id-free `CachedSleepSession`, so the write must resolve that canonical
+    /// owner (via `sleepOwnerIds`) instead of trying only the active strap's two namespaces and silently
+    /// no-op'ing — the "I corrected the night but it snapped back" report.
+    @MainActor
+    func testEditingCanonicalSleepAfterReAddPersistsTheVisibleNight() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: canonicalId, mac: nil, name: "WHOOP")
+        try await store.upsertDevice(id: newId, mac: nil, name: "WHOOP")
+        _ = try await store.upsertSleepSessions(
+            [CachedSleepSession(startTs: 1_000, endTs: 5_000, efficiency: 0.9,
+                                restingHr: 52, avgHrv: 60, stagesJSON: nil)],
+            deviceId: canonicalId)
+
+        // Seed under the canonical id, then re-add a strap so the ACTIVE id is a different namespace.
+        let repo = Repository(deviceId: canonicalId)
+        repo.setStoreForTesting(store)
+        _ = repo.adoptActiveDeviceId(newId)
+
+        await repo.editSleepTimes(detectedStartTs: 1_000, oldEndTs: 5_000,
+                                  storedStagesJSON: nil, newStartTs: 1_200, newEndTs: 4_800)
+
+        let rows = try await store.sleepSessions(deviceId: canonicalId, from: 0, to: 10_000, limit: 10)
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0].effectiveStartTs, 1_200, "the correction under the canonical source must persist")
+        XCTAssertEqual(rows[0].endTs, 4_800)
+        XCTAssertTrue(rows[0].userEdited)
+    }
+
     /// THE union-model regression (#814 follow-up): import history under the CANONICAL "my-whoop", THEN
     /// re-add a strap so the active id becomes "whoop-uuid" and write LIVE HR under it. Assert (i) the
     /// imported canonical days STILL surface in refresh(), (ii) the new live HR under the re-added id also


### PR DESCRIPTION
## Resolve sleep edit/delete owner across every visible namespace

Ported from a fix by **@DX23876** (their "NOOP AI" fork), reimplemented on current `main` with its regression test.

### The bug
`editSleepTimes` / `deleteSleepSession` start from a `CachedSleepSession`, which **deliberately carries no device id**, so the write must resolve which source owns the night. The old code tried the active strap's computed id, then its raw id — but after a **strap re-add**, a night can stay visible under the **canonical** source (`canonicalComputedId` / `canonicalDeviceId`), which neither of those matches. The edit then silently changed nothing (the correction "snapped back"); `deleteSleepSession` and the undo-snapshot resolver shared the blind spot.

This is the multi-device-identity family (#1193/#740) intersecting sleep edits.

### The fix
Resolve against `sleepOwnerIds = computedReadIds + importedReadIds` — the exact union the Sleep tab **reads** from — first match wins. Computed-over-imported precedence and the "never touch a coincidental same-`startTs` row in another namespace" guarantee are preserved by the ordering + early `break`; the canonical source is now reachable. Applied at all three sites (edit, delete, undo-snapshot resolver).

### Parity
**Swift-only.** Android's `SleepSession` carries its `deviceId`, so `updateSleepSessionTimes` / `deleteSleepSession` already write under the row's own owner — no two-try, no twin change needed.

### Verification
New `StrandTests` case `testEditingCanonicalSleepAfterReAddPersistsTheVisibleNight`: seed a night under the canonical id, re-add a strap (active id becomes a different namespace), edit → assert the correction persists. Fails on the old two-try, passes on the loop. The gate's "Test Strand" step runs it. App-target Swift → app-build gate.

### Not included
The fork's follow-up debt-recalc commit (`c9e20396`) **redesigns** upstream's #509 edited-sleep merge with heavy Swift↔Kotlin parity implications in a fragile area (#674/#1244) — evaluating that separately, not bundling it here.
