### PR TITLE
fix(workouts): show "–" not "0.0 km" when no workout has distance

### DIFF
--- a/Strand/Screens/WorkoutsView.swift
+++ b/Strand/Screens/WorkoutsView.swift
@@ -941,7 +941,12 @@ struct WorkoutsView: View {
         let totalCount = rows.count
         let totalTimeH = rows.compactMap(\.durationS).reduce(0, +) / 3600.0
         let totalKcal = rows.compactMap(\.energyKcal).reduce(0, +)
-        let totalKmRaw = rows.compactMap(\.distanceM).reduce(0, +) / 1000.0
+        // Only POSITIVE distances count as "has distance" (a strap-detected sport with no GPS/manual
+        // distance is nil, and an explicit 0 is not a real distance) — matches `distanceLabel`'s `m > 0`
+        // guard on the per-workout rows. When nothing in the window has distance, the tile shows "–"
+        // instead of a misleading "0.0 km covered" (#reddit: rugby read as data loss).
+        let distancesM = rows.compactMap(\.distanceM).filter { $0 > 0 }
+        let totalKmRaw = distancesM.reduce(0, +) / 1000.0
         let modal = modalSport(from: groups)
 
         return LazyVGrid(columns: tileColumns, alignment: .leading, spacing: NoopMetrics.gap) {
@@ -958,7 +963,7 @@ struct WorkoutsView: View {
                      caption: "kcal",
                      accent: StrandPalette.metricAmber)
             StatTile(label: "Total Distance",
-                     value: UnitFormatter.distanceFromKilometers(totalKmRaw, system: unitSystem),
+                     value: distancesM.isEmpty ? "–" : UnitFormatter.distanceFromKilometers(totalKmRaw, system: unitSystem),
                      caption: String(localized: "covered"),
                      accent: StrandPalette.metricCyan)
             StatTile(label: "Most Active",

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -918,7 +918,11 @@ private fun SummarySection(
     val totalCount = rows.size
     val totalTimeH = rows.mapNotNull { it.durationS }.sum() / 3600.0
     val totalKcal = rows.mapNotNull { it.energyKcal }.sum()
-    val totalKm = rows.mapNotNull { it.distanceM }.sum() / 1000.0
+    // Only POSITIVE distances count as "has distance" (a strap-detected sport with no GPS/manual
+    // distance is null; an explicit 0 is not a real distance) — matches the per-row distance label. When
+    // nothing in the window has distance, the tile shows "–" instead of a misleading "0.0 km covered".
+    val distancesM = rows.mapNotNull { it.distanceM }.filter { it > 0.0 }
+    val totalKm = distancesM.sum() / 1000.0
     val modal = groups.firstOrNull()
 
     val tiles = listOf<@Composable (Modifier) -> Unit>(
@@ -953,7 +957,7 @@ private fun SummarySection(
             StatTile(
                 modifier = m,
                 label = uiString(R.string.l10n_workouts_screen_total_distance_e8260e11),
-                value = UnitFormatter.distanceFromKilometers(totalKm, unitSystem),
+                value = if (distancesM.isEmpty()) "–" else UnitFormatter.distanceFromKilometers(totalKm, unitSystem),
                 caption = "covered",
                 accent = Palette.metricCyan,
             )


### PR DESCRIPTION
## Total Distance tile: show "–", not a fabricated "0.0 km", when nothing has distance

### The problem (a real user report)
A new user logged a **rugby** match and saw **"TOTAL DISTANCE — 0.0 km covered"**, and reasonably read it as broken/lost data (and worried it had corrupted strain etc.).

It hadn't. WHOOP straps have **no GPS**, so a strap-detected sport has no distance unless the workout was recorded **live in NOOP** (phone GPS, #1202), **entered manually** (#1195/#1203), or **imported**. Distance also never feeds strain/effort/calories — those are HR-based — so those figures were correct.

### The bug
The Sport-summary Total Distance tile summed `compactMap(\.distanceM)` (Swift) / `mapNotNull { it.distanceM }` (Android). A window whose workouts all lack a distance drops every nil, sums to `0`, and renders **"0.0 km covered"** — a fabricated zero that looks like data loss.

Meanwhile the per-workout **rows already do the right thing**: `distanceLabel` returns **`–`** for a nil/zero distance. The tile and the rows disagreed.

### The fix
Filter to **positive** distances (matching the rows' `> 0` guard, and treating an explicit `0` as "no distance"), and show **`–`** when none exist:

```swift
let distancesM = rows.compactMap(\.distanceM).filter { $0 > 0 }
// value: distancesM.isEmpty ? "–" : UnitFormatter.distanceFromKilometers(…)
```
```kotlin
val distancesM = rows.mapNotNull { it.distanceM }.filter { it > 0.0 }
// value: if (distancesM.isEmpty()) "–" else UnitFormatter.distanceFromKilometers(…)
```

When there *is* distance data the tile is unchanged (the dropped nils/zeros never contributed to the sum anyway). `–` is the app's existing no-data glyph on both platforms.

### Scope & verification
Display-only — no stored or analytics change; distance still doesn't touch strain/effort/calories. Both platforms for parity. Android `compileFullDebugKotlin` clean; `i18n_audit --ci main` clean (no new strings — `–` is a universal glyph); Swift is app-target → app-build gate.
