### PR TITLE
feat(workouts): add 5 WHOOP-catalogue sports NOOP was missing

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/SportIcon.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/SportIcon.swift
@@ -93,6 +93,13 @@ public enum KnownWorkoutType: String, CaseIterable, Sendable {
     case netball = "Netball"
     case gaelicFootball = "Gaelic football"
     case spikeball = "Spikeball"
+    // WHOOP-parity batch: activities in WHOOP's catalogue NOOP lacked (raw values byte-identical to
+    // WorkoutCatalog / Android WorkoutSport). Icons are distinct SF Symbols available on iOS 17 / macOS 13.
+    case meditation = "Meditation"
+    case horsebackRiding = "Horseback riding"
+    case wheelchair = "Wheelchair"
+    case gaming = "Gaming"
+    case motorRacing = "Motor racing"
     case other = "Other"
 
     /// Case-insensitive exact match against a stored/free-typed sport label.
@@ -313,6 +320,11 @@ public enum WorkoutTypeIconography {
         case .netball:              return .system("basketball")
         case .gaelicFootball:       return .system("soccerball")
         case .spikeball:            return .system("volleyball")
+        case .meditation:           return .system("figure.mind.and.body")
+        case .horsebackRiding:      return .system("figure.equestrian.sports")
+        case .wheelchair:           return .system("figure.roll")
+        case .gaming:               return .system("gamecontroller.fill")
+        case .motorRacing:          return .system("steeringwheel")
         case .other:
             return .system("figure.mixed.cardio")
         }
@@ -399,6 +411,11 @@ public enum WorkoutTypeIconography {
         case .netball:              return "system:basketball"
         case .gaelicFootball:       return "system:soccerball"
         case .spikeball:            return "system:volleyball"
+        case .meditation:           return "system:figure.mind.and.body"
+        case .horsebackRiding:      return "system:figure.equestrian.sports"
+        case .wheelchair:           return "system:figure.roll"
+        case .gaming:               return "system:gamecontroller.fill"
+        case .motorRacing:          return "system:steeringwheel"
         case .other:            return "system:figure.mixed.cardio"
         }
     }

--- a/Strand/Data/WorkoutCatalog.swift
+++ b/Strand/Data/WorkoutCatalog.swift
@@ -114,6 +114,13 @@ enum WorkoutCatalog {
         Sport(name: "Netball", isDistanceSport: false),
         Sport(name: "Gaelic football", isDistanceSport: false),
         Sport(name: "Spikeball", isDistanceSport: false),
+        // WHOOP-parity batch: activities in WHOOP's catalogue NOOP lacked. All ride EXTRA on Android
+        // (no dedicated HC type) so GPS defaults off, like every other extra. Ordered to match.
+        Sport(name: "Meditation", isDistanceSport: false),
+        Sport(name: "Horseback riding", isDistanceSport: false),
+        Sport(name: "Wheelchair", isDistanceSport: false),
+        Sport(name: "Gaming", isDistanceSport: false),
+        Sport(name: "Motor racing", isDistanceSport: false),
         Sport(name: "Other", isDistanceSport: false),
     ]
 

--- a/android/app/src/main/java/com/noop/ingest/ExerciseTypes.kt
+++ b/android/app/src/main/java/com/noop/ingest/ExerciseTypes.kt
@@ -115,6 +115,13 @@ object ExerciseTypes {
         "Netball" to EX.EXERCISE_TYPE_OTHER_WORKOUT,
         "Gaelic football" to EX.EXERCISE_TYPE_OTHER_WORKOUT,
         "Spikeball" to EX.EXERCISE_TYPE_OTHER_WORKOUT,
+        // WHOOP-parity batch: activities in WHOOP's catalogue NOOP lacked. HC has no dedicated type, so
+        // they ride a nearby one for writeback and keep their own label. GPS off (EXTRA convention).
+        "Meditation" to EX.EXERCISE_TYPE_OTHER_WORKOUT,
+        "Horseback riding" to EX.EXERCISE_TYPE_OTHER_WORKOUT,
+        "Wheelchair" to EX.EXERCISE_TYPE_OTHER_WORKOUT,
+        "Gaming" to EX.EXERCISE_TYPE_OTHER_WORKOUT,
+        "Motor racing" to EX.EXERCISE_TYPE_OTHER_WORKOUT,
     )
 
     /** Types where a route makes sense -> GPS defaults on. */

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
+import androidx.compose.material.icons.filled.Accessible
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.CheckCircle
@@ -35,6 +36,8 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.automirrored.filled.MergeType
 import androidx.compose.material.icons.filled.RadioButtonUnchecked
+import androidx.compose.material.icons.filled.SportsEsports
+import androidx.compose.material.icons.filled.SportsMotorsports
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.automirrored.filled.DirectionsBike
 import androidx.compose.material.icons.automirrored.filled.DirectionsRun
@@ -2507,6 +2510,9 @@ internal fun sportIcon(sport: String): ImageVector {
         s.contains("climb") -> Icons.Filled.Terrain
         s.contains("soccer") || s.contains("football") -> Icons.Filled.SportsSoccer
         s.contains("basketball") -> Icons.Filled.SportsBasketball
+        s.contains("gaming") -> Icons.Filled.SportsEsports
+        s.contains("motor") -> Icons.Filled.SportsMotorsports
+        s.contains("wheelchair") -> Icons.Filled.Accessible
         else -> Icons.Filled.FitnessCenter
     }
 }


### PR DESCRIPTION
## Add 5 WHOOP-catalogue sports NOOP was missing

Diffing NOOP's suggestion catalogue against WHOOP's own sport list (their API `Sports` map) surfaced activities WHOOP users log that NOOP had no preset for. This adds the batch that has a **distinct, real SF Symbol on both deployment targets** (iOS 17 / macOS 13):

**Meditation · Horseback riding · Wheelchair · Gaming · Motor racing**

### Wired end-to-end (both platforms)
- **Apple:** `WorkoutCatalog` entry + `KnownWorkoutType` case + a **unique glyph** in `SportIcon` (its exhaustive-uniqueness contract, enforced by `WorkoutTypeIconTests`) — `figure.mind.and.body`, `figure.equestrian.sports`, `figure.roll`, `gamecontroller.fill`, `steeringwheel`.
- **Android:** `ExerciseTypes.EXTRA` + `sportIcon` (`SportsEsports`, `SportsMotorsports`, `Accessible`; Meditation already maps to `SelfImprovement`).

Names are persisted **data** and byte-identical across platforms (they round-trip through CSV / Apple-Health export), so both catalogues list them in the same order, just before the generic **Other**.

### Behaviour
Health Connect has no dedicated type for these, so on Android they ride a nearby type for the writeback and keep their own label — **GPS off**, exactly like every existing EXTRA (Padel, Pickleball, …). Import mapping benefits too: a WHOOP export naming e.g. "Meditation" now maps to the preset instead of "Other".

### Held for a follow-up
WHOOP sports whose icons need **SF Symbols 5** (would blank on macOS 13) or a hand-drawn custom glyph: Triathlon/Duathlon, Cross-country skiing, Wrestling, Jiu-jitsu, Barre, Assault bike, Obstacle Course Racing, Track & field, Parkour, Paddle tennis. The **unique-icon contract**, not the catalogue, is the gating cost there — worth doing but as a dedicated icon PR.

### Verification
Android `compileFullDebugKotlin` + `WorkoutSportTest` green. Apple: `StrandDesign` icon-uniqueness tests run in swift-packages CI; app-target `WorkoutCatalogTests` on the app-build gate (both legs).
