### PR TITLE
feat(workouts): per-sport Android icons, parity with iOS

### DIFF
--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -27,6 +27,19 @@ import androidx.compose.material.icons.Icons
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import androidx.compose.material.icons.filled.Accessible
+import androidx.compose.material.icons.filled.Hiking
+import androidx.compose.material.icons.filled.IceSkating
+import androidx.compose.material.icons.filled.Kayaking
+import androidx.compose.material.icons.filled.Sailing
+import androidx.compose.material.icons.filled.ScubaDiving
+import androidx.compose.material.icons.filled.Skateboarding
+import androidx.compose.material.icons.filled.Snowshoeing
+import androidx.compose.material.icons.filled.SportsCricket
+import androidx.compose.material.icons.filled.SportsFootball
+import androidx.compose.material.icons.filled.SportsHandball
+import androidx.compose.material.icons.filled.SportsHockey
+import androidx.compose.material.icons.filled.SportsRugby
+import androidx.compose.material.icons.filled.Surfing
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.CheckCircle
@@ -2483,35 +2496,82 @@ private fun grouped(v: Double): String = String.format(Locale.US, "%,d", v.round
 // MARK: - Sport icons (Material equivalents of the SF Symbols used on macOS)
 
 // internal (not private): reused by the Today Overview-HR chart to glyph each workout at its HR peak.
-internal fun sportIcon(sport: String): ImageVector {
+internal fun sportIcon(sport: String): ImageVector = when (sport.lowercase().trim()) {
+    // Per-sport glyphs, parity with the iOS SportIcon catalogue. Exact catalogue names first (each gets
+    // its closest Material sports glyph); free-typed / auto-detected labels fall through to the fuzzy
+    // matcher below. Sports Material has no dedicated glyph for (Dancing, Frisbee, Archery, Fishing,
+    // Hunting, Curling, Horseback riding, Elliptical, ...) resolve to the generic FitnessCenter there.
+    "running", "treadmill run" -> Icons.AutoMirrored.Filled.DirectionsRun
+    "walking", "treadmill walk" -> Icons.AutoMirrored.Filled.DirectionsWalk
+    "hiking", "rucking" -> Icons.Filled.Hiking
+    "cycling", "indoor cycle", "spinning", "mountain biking" -> Icons.AutoMirrored.Filled.DirectionsBike
+    "open-water swim", "pool swim", "water polo" -> Icons.Filled.Pool
+    "rowing", "row machine" -> Icons.Filled.Rowing
+    "kayaking", "stand-up paddleboard" -> Icons.Filled.Kayaking
+    "surfing" -> Icons.Filled.Surfing
+    "sailing" -> Icons.Filled.Sailing
+    "scuba diving" -> Icons.Filled.ScubaDiving
+    "skiing" -> Icons.Filled.DownhillSkiing
+    "snowboarding" -> Icons.Filled.Snowboarding
+    "snowshoeing" -> Icons.Filled.Snowshoeing
+    "ice skating" -> Icons.Filled.IceSkating
+    "inline skating", "skateboarding" -> Icons.Filled.Skateboarding
+    "hiit", "gymnastics" -> Icons.Filled.SportsGymnastics
+    "yoga", "pilates", "stretching", "meditation" -> Icons.Filled.SelfImprovement
+    "boxing", "martial arts", "kickboxing", "fencing" -> Icons.Filled.SportsMartialArts
+    "basketball", "netball" -> Icons.Filled.SportsBasketball
+    "soccer", "gaelic football" -> Icons.Filled.SportsSoccer
+    "american football", "australian football" -> Icons.Filled.SportsFootball
+    "rugby" -> Icons.Filled.SportsRugby
+    "cricket" -> Icons.Filled.SportsCricket
+    "baseball", "softball", "bowling" -> Icons.Filled.SportsBaseball
+    "handball" -> Icons.Filled.SportsHandball
+    "ice hockey", "field hockey", "lacrosse" -> Icons.Filled.SportsHockey
+    "tennis", "badminton", "squash", "racquetball", "table tennis", "padel", "pickleball" ->
+        Icons.Filled.SportsTennis
+    "volleyball", "sand volleyball", "spikeball" -> Icons.Filled.SportsVolleyball
+    "golf" -> Icons.Filled.SportsGolf
+    "climbing" -> Icons.Filled.Terrain
+    "wheelchair" -> Icons.Filled.Accessible
+    "gaming" -> Icons.Filled.SportsEsports
+    "motor racing" -> Icons.Filled.SportsMotorsports
+    else -> sportIconFuzzy(sport)
+}
+
+/// Free-text / auto-detected label fallback (e.g. "Morning Run", "trail hike"): fuzzy substring match,
+/// then the generic dumbbell. Catalogue names are handled exactly by [sportIcon] before this runs.
+private fun sportIconFuzzy(sport: String): ImageVector {
     val s = sport.lowercase()
     return when {
         s.contains("run") -> Icons.AutoMirrored.Filled.DirectionsRun
         s.contains("walk") || s.contains("hike") -> Icons.AutoMirrored.Filled.DirectionsWalk
-        s.contains("cycl") || s.contains("bike") || s.contains("ride") -> Icons.AutoMirrored.Filled.DirectionsBike
-        s.contains("swim") -> Icons.Filled.Pool
-        s.contains("row") || s.contains("kayak") || s.contains("paddle") -> Icons.Filled.Rowing
-        s.contains("surf") || s.contains("sail") || s.contains("scuba") || s.contains("polo") -> Icons.Filled.Pool
-        s.contains("cricket") || s.contains("softball") || s.contains("baseball") -> Icons.Filled.SportsBaseball
-        s.contains("spin") -> Icons.AutoMirrored.Filled.DirectionsBike
-        s.contains("yoga") || s.contains("pilates") || s.contains("meditat") || s.contains("stretch") -> Icons.Filled.SelfImprovement
-        s.contains("strength") || s.contains("weight") || s.contains("lift") -> Icons.Filled.FitnessCenter
-        s.contains("box") || s.contains("martial") || s.contains("jiu") || s.contains("judo") || s.contains("karate") -> Icons.Filled.SportsMartialArts
-        s.contains("hiit") || s.contains("functional") || s.contains("gymnast") -> Icons.Filled.SportsGymnastics
+        s.contains("cycl") || s.contains("bike") || s.contains("ride") || s.contains("spin") -> Icons.AutoMirrored.Filled.DirectionsBike
+        s.contains("swim") || s.contains("polo") -> Icons.Filled.Pool
+        s.contains("row") -> Icons.Filled.Rowing
+        s.contains("kayak") || s.contains("paddle") -> Icons.Filled.Kayaking
+        s.contains("surf") -> Icons.Filled.Surfing
+        s.contains("sail") -> Icons.Filled.Sailing
+        s.contains("scuba") || s.contains("dive") -> Icons.Filled.ScubaDiving
         s.contains("snowboard") -> Icons.Filled.Snowboarding
         s.contains("ski") -> Icons.Filled.DownhillSkiing
-        // All racquet sports share the tennis glyph (no dedicated icon for padel/pickleball/squash etc.).
+        s.contains("skat") || s.contains("board") -> Icons.Filled.Skateboarding
+        s.contains("cricket") -> Icons.Filled.SportsCricket
+        s.contains("rugby") -> Icons.Filled.SportsRugby
+        s.contains("hockey") -> Icons.Filled.SportsHockey
+        s.contains("handball") -> Icons.Filled.SportsHandball
+        s.contains("softball") || s.contains("baseball") || s.contains("bowl") -> Icons.Filled.SportsBaseball
+        s.contains("yoga") || s.contains("pilates") || s.contains("meditat") || s.contains("stretch") -> Icons.Filled.SelfImprovement
+        s.contains("strength") || s.contains("weight") || s.contains("lift") -> Icons.Filled.FitnessCenter
+        s.contains("box") || s.contains("martial") || s.contains("jiu") || s.contains("judo") || s.contains("karate") || s.contains("wrestl") || s.contains("fenc") -> Icons.Filled.SportsMartialArts
+        s.contains("hiit") || s.contains("functional") || s.contains("gymnast") -> Icons.Filled.SportsGymnastics
         s.contains("tennis") || s.contains("padel") || s.contains("pickle") || s.contains("squash") || s.contains("racquet") || s.contains("badminton") -> Icons.Filled.SportsTennis
         s.contains("volleyball") -> Icons.Filled.SportsVolleyball
         s.contains("golf") -> Icons.Filled.SportsGolf
-        // No dedicated bowling icon in the Material set; the plain ball glyph is the closest match
-        // (iOS has figure.bowling). (D#850)
-        s.contains("bowl") -> Icons.Filled.SportsBaseball
         s.contains("climb") -> Icons.Filled.Terrain
         s.contains("soccer") || s.contains("football") -> Icons.Filled.SportsSoccer
-        s.contains("basketball") -> Icons.Filled.SportsBasketball
-        s.contains("gaming") -> Icons.Filled.SportsEsports
-        s.contains("motor") -> Icons.Filled.SportsMotorsports
+        s.contains("basketball") || s.contains("netball") -> Icons.Filled.SportsBasketball
+        s.contains("gaming") || s.contains("esport") -> Icons.Filled.SportsEsports
+        s.contains("motor") || s.contains("racing") -> Icons.Filled.SportsMotorsports
         s.contains("wheelchair") -> Icons.Filled.Accessible
         else -> Icons.Filled.FitnessCenter
     }

--- a/android/app/src/test/java/com/noop/ui/SportIconTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SportIconTest.kt
@@ -1,0 +1,37 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Pins the per-sport iconography (parity with the iOS SportIcon catalogue): sports that used to fall
+ *  back to the generic dumbbell now resolve to their own Material glyph, and free-typed / auto-detected
+ *  labels still resolve via the fuzzy matcher. Compares ImageVector.name (stable "Filled.X"). */
+class SportIconTest {
+
+    @Test fun formerlyGenericSports_nowHaveDistinctGlyphs() {
+        val cases = mapOf(
+            "Rugby" to "Filled.SportsRugby",
+            "Ice Hockey" to "Filled.SportsHockey",
+            "Field hockey" to "Filled.SportsHockey",
+            "Lacrosse" to "Filled.SportsHockey",
+            "Handball" to "Filled.SportsHandball",
+            "Cricket" to "Filled.SportsCricket",
+            "Surfing" to "Filled.Surfing",
+            "Kayaking" to "Filled.Kayaking",
+            "Sailing" to "Filled.Sailing",
+            "Scuba diving" to "Filled.ScubaDiving",
+            "Ice skating" to "Filled.IceSkating",
+            "Inline skating" to "Filled.Skateboarding",
+            "Snowshoeing" to "Filled.Snowshoeing",
+            "Hiking" to "Filled.Hiking",
+            "American football" to "Filled.SportsFootball",
+        )
+        cases.forEach { (sport, icon) -> assertEquals(sport, icon, sportIcon(sport).name) }
+    }
+
+    @Test fun freeTypedLabels_resolveViaFuzzy() {
+        assertEquals("Filled.SportsRugby", sportIcon("touch rugby").name)
+        assertEquals("Filled.SportsHockey", sportIcon("field hockey scrimmage").name)
+        assertEquals("Filled.Surfing", sportIcon("dawn surf session").name)
+    }
+}


### PR DESCRIPTION
## Per-sport Android icons — parity with iOS

Follow-up to #1327 (the 5 new sports, now merged).

### The gap
iOS gives **every** catalogue sport a unique icon (SportIcon's exhaustive-uniqueness contract). Android's `sportIcon` was a coarse fuzzy matcher, so **32 of 84 sports fell back to a generic dumbbell** — including sports that have a dedicated Material glyph *and* a distinct iOS icon: Rugby, Ice Hockey, Field hockey, Lacrosse, Handball, Cricket, Surfing, Kayaking, Sailing, Ice/Inline skating, Snowshoeing, Hiking, …

### The change
- Rewrote `sportIcon` to **match the exact catalogue name first**, mapping each sport to its closest Material sports glyph (13 new Material icons: `SportsRugby`, `SportsHockey`, `SportsCricket`, `SportsHandball`, `SportsFootball`, `Surfing`, `Kayaking`, `Sailing`, `ScubaDiving`, `IceSkating`, `Skateboarding`, `Snowshoeing`, `Hiking`).
- Kept the old fuzzy substring matcher as **`sportIconFuzzy`** for free-typed / auto-detected labels (`"Morning Run"`, `"touch rugby"`).

**Result: generic fallback 32 → 18**, with **33 distinct Material glyphs**. The remaining 18 are sports Material genuinely lacks a glyph for (Dancing, Frisbee, Archery, Fishing, Hunting, Curling, Horseback riding, Elliptical, Jump rope, Stair climber) or the strength cluster — where the dumbbell is the right icon anyway.

### Honest limits
Android can't reach *full* iOS parity: Material Icons is sparser than SF Symbols, so a handful stay generic and a few legitimately share a glyph where Material has no distinct one (e.g. all racquet sports → one tennis glyph — same as before). This closes the gap as far as the Material set allows.

### Verification
Android-only (iOS is the reference — no iOS change). `compileFullDebugKotlin` clean; new `SportIconTest` (formerly-generic sports → distinct glyphs + fuzzy free-text) green locally.
