### PR TITLE
fix(sleep): honour the Day-cycle background toggle on the iOS Sleep tab (#1319)

### DIFF
--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -2148,7 +2148,18 @@ private struct SleepPerformanceNightScene: View {
         .init(x: 0.70, y: 0.31, size: 0.6, opacity: 0.18)
     ]
 
+    /// #1319: honour the Settings "Day-cycle background" toggle on the Sleep tab too. The bundled
+    /// moonlit-lake scene used to draw unconditionally here, so an iOS user who turned the toggle off
+    /// still saw it on Sleep — while Home/Today (and the Android Sleep screen) already went plain.
+    @AppStorage(SceneBackgroundPrefs.enabledKey) private var showDayCycleBackground = true
+
     var body: some View {
+        if showDayCycleBackground { nightScene } else { StrandPalette.surfaceBase }
+    }
+
+    /// The bundled night scene (moonlit lake + procedural fallback). Shown only when the day-cycle
+    /// background is enabled; off swaps it for the plain surfaceBase canvas, parity with Home/Today.
+    private var nightScene: some View {
         GeometryReader { geo in
             let w = geo.size.width
             let h = geo.size.height


### PR DESCRIPTION
## Honour the Day-cycle background toggle on the iOS Sleep tab

Fixes #1319.

### The report
A user asked how to remove the background on the Sleep tab. It turned out **not** to be the optional custom-photo feature — it's NOOP's own **bundled** night scene (`SleepPerformanceNightScene` / the moonlit-lake `SleepNightHero` asset), and on iOS it drew **unconditionally**.

### The gap
Settings → Appearance → **"Day-cycle background"** (default ON) turns these bundled scenes off. Home, Today and Trends all honour it, and the **Android** Sleep screen already gates its backdrop on it (`showDayCycleBackground ? sky : plain canvas`). But the **iOS** `SleepView` referenced the flag **zero** times — so turning the toggle off cleared every tab *except* Sleep, leaving iOS users no way to remove it.

### The fix
Gate `SleepPerformanceNightScene` on `SceneBackgroundPrefs.enabledKey`, exactly like the other iOS tabs: when the toggle is off, the scene is replaced by the plain `StrandPalette.surfaceBase` canvas. `@AppStorage` makes it reactive, so toggling in Settings updates the Sleep tab live.

iOS-only — Android already reads `showDayCycleBackground` here.

### Verification
App-target Swift → app-build gate (`Strand` macOS + `NOOPiOS` iOS). Behaviour: with "Day-cycle background" ON the Sleep tab is unchanged; OFF it now goes plain like the rest of the app.
