### PR TITLE
fix(today): carry last-known respiratory + diagnostic logging (#1331)

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -107,6 +107,8 @@ final class IntelligenceEngine: ObservableObject {
     private struct DayScan {
         let result: AnalyticsEngine.DayResult
         let rhrLine: String?
+        /// #1331 respiratory diagnostic line (see `respRateLogLine`); replayed with `rhrLine`.
+        let respLine: String?
         /// CAPTURE-B (#814/#799): the resolved READ owner id this day was scored from, and how many HR rows
         /// that owner returned for the night window, carried out of the off-actor loop so the main-actor
         /// fold can emit the universal `dayOwner …` self-diagnostic line (it needs the registry active id +
@@ -210,6 +212,12 @@ final class IntelligenceEngine: ObservableObject {
     /// SAME span the floor came from, so the two numbers are directly comparable). Empty in-bed → nightMean
     /// is "nil". Counts/bpm only , no timestamps or PII. Pure so it's unit-tested directly and is the SAME
     /// line `analyzeRecent` ships. Byte-identical to the Android `rhrFloorMeanLogLine`.
+    /// #1331 diagnostic line: the night's computed respiratory rate (breaths/min) or "nil". Format kept
+    /// simple so it stays byte-identical to the Android `respRateLogLine`.
+    nonisolated static func respRateLogLine(day: String, respRateBpm: Double?) -> String {
+        "resp day=\(day) rpm=\(respRateBpm.map { String(format: "%.1f", $0) } ?? "nil")"
+    }
+
     nonisolated static func rhrFloorMeanLogLine(day: String, floor: Int, inBedBpms: [Int]) -> String {
         let meanLog: String = inBedBpms.isEmpty ? "nil"
             : String(Int((Double(inBedBpms.reduce(0, +)) / Double(inBedBpms.count)).rounded()))
@@ -932,6 +940,9 @@ final class IntelligenceEngine: ObservableObject {
                     }.map { $0.bpm }
                     rhrLine = Self.rhrFloorMeanLogLine(day: res.daily.day, floor: floor, inBedBpms: inBedBpms)
                 }
+                // #1331 respiratory diagnostic — a run of nil nights localises when it stopped. Same
+                // pure-compute-here / replay-on-main-actor path as rhrLine.
+                let respLine: String? = Self.respRateLogLine(day: res.daily.day, respRateBpm: res.daily.respRateBpm)
                 // #103: SpO₂ candidate @82 nightly mean. Only computed when the display toggle is ON.
                 // Reads the V18AuxSample stream for this night's owner and averages the in-band (70–100)
                 // @82 readings that fall inside a detected sleep session. nil on a WHOOP 4.0 (no v18 aux
@@ -955,7 +966,7 @@ final class IntelligenceEngine: ObservableObject {
                 // windowing + delegation lives in the byte-identical, tested `AnalyticsEngine`.
                 let (primarySessionRHR, primarySessionRHRCoverage) =
                     AnalyticsEngine.primarySessionRestingHRWithCoverage(sessions: res.sleepSessions, hr: hr)
-                out.append(DayScan(result: res, rhrLine: rhrLine,
+                out.append(DayScan(result: res, rhrLine: rhrLine, respLine: respLine,
                                    readOwner: owner, hrRows: hr.count,
                                    sleepTrace: sleepTrace, stepsTrace: stepsTrace, hrvTrace: hrvTrace,
                                    hrvDiag: hrvDiag, spo2Candidate: spo2CandidateMean,
@@ -1007,6 +1018,7 @@ final class IntelligenceEngine: ObservableObject {
                 primarySessionRHRCoverageByDay[res.daily.day] = cov
             }
             if let line = scan.rhrLine { diagnosticSink?(line, nil) }
+            if let line = scan.respLine { diagnosticSink?(line, nil) }
             // Sleep & Rest test mode (E5): replay this day's gate-trace + Rest lines tagged `.sleep` so they
             // land under the profile tag in the export. Empty unless the mode is active.
             for line in scan.sleepTrace { diagnosticSink?(line, .sleep) }

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -521,6 +521,15 @@ final class Repository: ObservableObject {
     nonisolated static func lastSkinTempDay(days: [DailyMetric], todayKey: String) -> DailyMetric? {
         DailyMetric.lastSkinTempDay(days: days, todayKey: todayKey)
     }
+
+    /// PER-FIELD respiratory carry — twin of `lastSpo2Day`, but STALENESS-BOUNDED to `Baselines.vitalCarryDays`.
+    /// SpO₂/skin-temp are sparse/imported so last-known-of-any-age is expected; respiratory is nightly, so a
+    /// weeks-old value shown as the current number is the "Respiratory 15.6 a fortnight later" bug that
+    /// `vitalCarryDays` exists to prevent. Byte-twin of the Android `lastRespRow` (#1331).
+    nonisolated static func lastRespDay(days: [DailyMetric], todayKey: String) -> DailyMetric? {
+        guard let newest = days.last(where: { $0.respRateBpm != nil && $0.day < todayKey }) else { return nil }
+        return newest.day >= Baselines.cutoffKey(todayKey: todayKey) ? newest : nil
+    }
     /// The trailing 7 CALENDAR days ending today (for the week strip), oldest→newest , not the last 7
     /// stored rows, which on a stale import were old data. ISO yyyy-MM-dd compares chronologically.
     var week: [DailyMetric] {

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -820,10 +820,9 @@ struct LiquidTodayView: View {
                      value: unitText(displayDay?.restingHr.map(Double.init), card.unit),
                      tint: StrandPalette.metricRose, frac: fracOver(displayDay?.restingHr.map(Double.init), 100))
         case .respiratory:
-            let resp = displayDay?.respRateBpm ?? vitalsDay?.respRateBpm ?? respDay?.respRateBpm
             cardLink(.metric("resp_rate"), title: card.title, sub: card.subtitle,
-                     value: unitText(resp, card.unit, decimals: 1),
-                     tint: StrandPalette.accent, frac: fracOver(resp, 24))
+                     value: unitText(displayDay?.respRateBpm, card.unit, decimals: 1),
+                     tint: StrandPalette.accent, frac: fracOver(displayDay?.respRateBpm, 24))
         case .steps:
             // Route by the EXACT (key, source) the tile chose to display — measured my-whoop, imported
             // apple-health, or the my-whoop estimate — NOT by bare key (bare "steps" resolves to

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -106,6 +106,7 @@ struct LiquidTodayView: View {
     /// today's row has no vitals yet, so these fall back to the last night that recorded them. Never
     /// resolved in body — body rescans repo.days ~23× per pass, and this cache keeps that read O(1).
     @State private var cachedVitalsDay: DailyMetric?
+    @State private var cachedRespDay: DailyMetric?
     /// The Charge hero's resolved state (#543 carry + the honest label), resolved ONCE in load() alongside
     /// the other caches. It composes `TodayView.lastScoredRecoveryDay`, which is O(days) — exactly the scan
     /// this cache exists to keep out of body. Never resolved in body.
@@ -163,6 +164,9 @@ struct LiquidTodayView: View {
     /// The prior-day vitals carry (see `cachedVitalsDay`), read O(1) from the cache. Non-nil only at
     /// offset 0 (today); a navigated past day carries nothing (its own row is the whole story).
     private var vitalsDay: DailyMetric? { cachedVitalsDay }
+    /// The prior-day RESPIRATORY carry (#1331): staleness-bounded, so a recent missed night reads the last
+    /// real value while a weeks-old one honestly shows "No Data". Non-nil only at offset 0.
+    private var respDay: DailyMetric? { cachedRespDay }
     /// The Charge hero's resolved state (see `cachedChargeDisplay`), read O(1) from the cache.
     private var chargeDisplay: ChargeDisplay { cachedChargeDisplay }
 
@@ -816,9 +820,10 @@ struct LiquidTodayView: View {
                      value: unitText(displayDay?.restingHr.map(Double.init), card.unit),
                      tint: StrandPalette.metricRose, frac: fracOver(displayDay?.restingHr.map(Double.init), 100))
         case .respiratory:
+            let resp = displayDay?.respRateBpm ?? vitalsDay?.respRateBpm ?? respDay?.respRateBpm
             cardLink(.metric("resp_rate"), title: card.title, sub: card.subtitle,
-                     value: unitText(displayDay?.respRateBpm, card.unit, decimals: 1),
-                     tint: StrandPalette.accent, frac: fracOver(displayDay?.respRateBpm, 24))
+                     value: unitText(resp, card.unit, decimals: 1),
+                     tint: StrandPalette.accent, frac: fracOver(resp, 24))
         case .steps:
             // Route by the EXACT (key, source) the tile chose to display — measured my-whoop, imported
             // apple-health, or the my-whoop estimate — NOT by bare key (bare "steps" resolves to
@@ -1097,7 +1102,7 @@ struct LiquidTodayView: View {
             let spo2 = displayDay?.spo2Pct ?? vitalsDay?.spo2Pct
             ktile(String(localized: "Blood Oxygen"), icon: keyMetricIcon(metric), intText(spo2), "%", StrandPalette.metricCyan, fracOver(spo2, 100), key: "spo2")
         case .respiratory:
-            let resp = displayDay?.respRateBpm ?? vitalsDay?.respRateBpm
+            let resp = displayDay?.respRateBpm ?? vitalsDay?.respRateBpm ?? respDay?.respRateBpm
             ktile(String(localized: "Respiratory"), icon: keyMetricIcon(metric), resp.map { String(format: "%.1f", $0) } ?? "—", "rpm", StrandPalette.accent, fracOver(resp, 24), key: "resp_rate")
         case .steps:
             ktile(String(localized: "Steps"), icon: keyMetricIcon(metric), stepsText, "", StrandPalette.chargeColor,
@@ -1290,6 +1295,7 @@ struct LiquidTodayView: View {
         // echo today's still-forming row; only on today (a past day's own row is the whole story).
         let tkey = cachedDisplayDay?.day ?? selectedDayKey
         cachedVitalsDay = (selectedDayOffset == 0) ? Repository.lastVitalsDay(days: repo.days, todayKey: tkey) : nil
+        cachedRespDay = (selectedDayOffset == 0) ? Repository.lastRespDay(days: repo.days, todayKey: tkey) : nil
         // Charge carry (#543) + the honest label, resolved here for the same reason as the two above: the
         // selector below scans repo.days. Calibration nights come from the SAME `RecoveryScorer` helper the
         // classic Today reads, so the two screens agree on when a wearer is genuinely mid-calibration

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1991,6 +1991,11 @@ object IntelligenceEngine {
             "hrRows=$hrRows provenance=$provenance"
     }
 
+    /** #1331 diagnostic line: the night's computed respiratory rate (breaths/min) or "nil". Format kept
+     *  simple so the planned Swift twin (iOS #1331 follow-up) can match it byte-for-byte. */
+    internal fun respRateLogLine(day: String, respRateBpm: Double?): String =
+        "resp day=$day rpm=${respRateBpm?.let { String.format(Locale.US, "%.1f", it) } ?: "nil"}"
+
     /**
      * The per-day RHR floor-vs-mean diagnostic line (#691). NOOP's [floor] is the WHOOP-style resting
      * HR , the lowest SUSTAINED 5-min in-bed level (SleepStager picks the min 5-min rolling-mean HR per
@@ -2002,11 +2007,6 @@ object IntelligenceEngine {
      * is "nil". Counts/bpm only , no timestamps or PII. Pure so it's unit-tested directly and is the SAME
      * line analyzeRecent ships. Byte-identical to the Swift `rhrFloorMeanLogLine`.
      */
-    /** #1331 diagnostic line: the night's computed respiratory rate (breaths/min) or "nil". Format kept
-     *  simple so the planned Swift twin (iOS #1331 follow-up) can match it byte-for-byte. */
-    internal fun respRateLogLine(day: String, respRateBpm: Double?): String =
-        "resp day=$day rpm=${respRateBpm?.let { String.format(Locale.US, "%.1f", it) } ?: "nil"}"
-
     internal fun rhrFloorMeanLogLine(day: String, floor: Int, inBedBpms: List<Int>): String {
         val meanLog = if (inBedBpms.isEmpty()) "nil"
             else Math.round(inBedBpms.sum().toDouble() / inBedBpms.size).toString()

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1,5 +1,6 @@
 package com.noop.analytics
 
+import java.util.Locale
 import com.noop.data.DailyMetric
 import com.noop.data.MetricSeriesRow
 import com.noop.data.ScoreInputProvenanceRow
@@ -735,6 +736,10 @@ object IntelligenceEngine {
             nightlyRhrByDay[day] = res.daily.restingHr?.toDouble()
             nightlySkinByDay[day] = res.nightlySkinTempC
             nightlyRespByDay[day] = res.daily.respRateBpm
+            // #1331 respiratory diagnostic: log each night's breaths/min (or "nil") so a "respiratory not
+            // showing" report is explainable from the strap log — a run of nil nights localises when it
+            // stopped. Logging only; no scoring change. The Swift diag twin lands with the iOS carry (#1331 follow-up).
+            diag(respRateLogLine(day, res.daily.respRateBpm))
             // ── RHR floor-vs-mean diagnostic (#691) ────────────────────────────────────────────────
             // Make the recurring "NOOP's resting HR reads LOWER than my sleeping-HR app" reports
             // explainable from the strap log instead of a guess. The two numbers measure different
@@ -1997,6 +2002,11 @@ object IntelligenceEngine {
      * is "nil". Counts/bpm only , no timestamps or PII. Pure so it's unit-tested directly and is the SAME
      * line analyzeRecent ships. Byte-identical to the Swift `rhrFloorMeanLogLine`.
      */
+    /** #1331 diagnostic line: the night's computed respiratory rate (breaths/min) or "nil". Format kept
+     *  simple so the planned Swift twin (iOS #1331 follow-up) can match it byte-for-byte. */
+    internal fun respRateLogLine(day: String, respRateBpm: Double?): String =
+        "resp day=$day rpm=${respRateBpm?.let { String.format(Locale.US, "%.1f", it) } ?: "nil"}"
+
     internal fun rhrFloorMeanLogLine(day: String, floor: Int, inBedBpms: List<Int>): String {
         val meanLog = if (inBedBpms.isEmpty()) "nil"
             else Math.round(inBedBpms.sum().toDouble() / inBedBpms.size).toString()

--- a/android/app/src/main/java/com/noop/ui/LogicalDay.kt
+++ b/android/app/src/main/java/com/noop/ui/LogicalDay.kt
@@ -1,5 +1,6 @@
 package com.noop.ui
 
+import com.noop.analytics.Baselines
 import com.noop.data.DailyMetric
 import java.time.LocalDate
 import java.time.LocalTime
@@ -119,6 +120,20 @@ internal fun lastSpo2Row(days: List<DailyMetric>, todayKey: String): DailyMetric
 /** PER-FIELD twin of [lastVitalsRow] for skin temperature deviation. See [lastSpo2Row]. */
 internal fun lastSkinTempRow(days: List<DailyMetric>, todayKey: String): DailyMetric? =
     days.lastOrNull { it.skinTempDevC != null && it.day < todayKey }
+
+/** PER-FIELD twin of [lastVitalsRow] for respiratory rate. [lastVitalsRow]'s predicate is satisfied by a
+ *  row that has HRV/resting-HR but a null respRateBpm — respiratory needs a longer clean sleep R-R segment
+ *  than HRV, so a night can carry HRV yet no breaths/min, leaving the Respiratory card "No Data" while an
+ *  older row holds a real reading. Resolving it per field keeps the card honest. See [lastSpo2Row]. */
+internal fun lastRespRow(days: List<DailyMetric>, todayKey: String): DailyMetric? {
+    // STALENESS-BOUNDED, unlike lastSpo2Row/lastSkinTempRow. SpO₂/skin-temp are sparse/imported, so
+    // last-known-of-any-age is the expected reading. Respiratory is NIGHTLY, so a weeks-old value shown as
+    // the current card number is the "Respiratory 15.6 a fortnight later, no date beside it" bug
+    // Baselines.vitalCarryDays exists to prevent (see freshestCarried). Carry only within that window;
+    // past it the card honestly shows "No Data" (respiratory has genuinely stopped, not just hiccuped).
+    val newest = days.lastOrNull { it.respRateBpm != null && it.day < todayKey } ?: return null
+    return if (newest.day >= Baselines.cutoffKey(todayKey)) newest else null
+}
 
 /** 04:00 local — the hour the logical day rolls. Between midnight and this hour, Today stays put. */
 internal const val LOGICAL_DAY_ROLLOVER_HOUR: Int = 4

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -978,6 +978,11 @@ fun TodayScreen(
     val lastSkinTempDay: DailyMetric? = remember(days, carryOverTodayKey, selectedDayOffset, displayMetric) {
         if (selectedDayOffset == 0) lastSkinTempRow(days, maxOf(displayMetric?.day ?: "", carryOverTodayKey)) else null
     }
+    // PER-FIELD respiratory carry (#1331): the freshest strictly-prior row that actually HAS a breaths/min,
+    // since lastVitalsDay can land on a night with HRV/RHR but no respiratory. Twin of lastSpo2Day.
+    val lastRespDay: DailyMetric? = remember(days, carryOverTodayKey, selectedDayOffset, displayMetric) {
+        if (selectedDayOffset == 0) lastRespRow(days, maxOf(displayMetric?.day ?: "", carryOverTodayKey)) else null
+    }
     // Carry-over Charge for TODAY, the prior scored row's recovery + its "Last night · <date>" caption.
     // Derived from lastScoredRecoveryDay so Charge and every other recovery tile carry the SAME prior day.
     val lastScoredCharge: LastCharge? = remember(lastScoredRecoveryDay) {
@@ -1498,6 +1503,7 @@ fun TodayScreen(
                                     lastScoredCharge = lastScoredCharge,
                                     carriedDay = lastScoredRecoveryDay,
                                     spo2CarryDay = lastSpo2Day,
+                                    respCarryDay = lastRespDay,
                                     unitSystem = unitSystem,
                                     effortScale = effortScale,
                                     effortForDay = effortForDay,   // #1001: same figure as the hero ring
@@ -1552,6 +1558,7 @@ fun TodayScreen(
                             vitalsDay = lastVitalsDay,
                             spo2Day = lastSpo2Day,
                             skinTempDay = lastSkinTempDay,
+                            respDay = lastRespDay,
                             stress = stressToday,
                             fitnessAge = fitnessAgeToday,
                             vitality = vitalityToday,
@@ -3147,6 +3154,7 @@ private fun YourCardsSection(
     vitalsDay: DailyMetric?,
     spo2Day: DailyMetric?,
     skinTempDay: DailyMetric?,
+    respDay: DailyMetric?,
     stress: Double?,
     fitnessAge: Double?,
     vitality: Double?,
@@ -3183,6 +3191,7 @@ private fun YourCardsSection(
                         vitalsDay = vitalsDay,
                         spo2Day = spo2Day,
                         skinTempDay = skinTempDay,
+                        respDay = respDay,
                         stress = stress,
                         fitnessAge = fitnessAge,
                         vitality = vitality,
@@ -3199,6 +3208,7 @@ private fun YourCardsSection(
                         day = day,
                         carriedDay = carriedDay,
                         vitalsDay = vitalsDay,
+                        respDay = respDay,
                         stress = stress,
                         fitnessAge = fitnessAge,
                         vitality = vitality,
@@ -3326,6 +3336,7 @@ private fun dashboardCardFraction(
     day: DailyMetric?,
     carriedDay: DailyMetric?,
     vitalsDay: DailyMetric?,
+    respDay: DailyMetric?,
     stress: Double?,
     fitnessAge: Double?,
     vitality: Double?,
@@ -3340,7 +3351,7 @@ private fun dashboardCardFraction(
         DashboardCard.VITALITY -> over(vitality, 100.0)
         DashboardCard.HRV -> over(day?.avgHrv ?: vitalsDay?.avgHrv, 120.0)
         DashboardCard.RESTING_HR -> over((day?.restingHr ?: vitalsDay?.restingHr)?.toDouble(), 100.0)
-        DashboardCard.RESPIRATORY -> over(day?.respRateBpm ?: vitalsDay?.respRateBpm, 24.0)
+        DashboardCard.RESPIRATORY -> over(day?.respRateBpm ?: vitalsDay?.respRateBpm ?: respDay?.respRateBpm, 24.0)
         DashboardCard.STEPS -> {
             val steps = (day?.steps ?: importedStepsForDay ?: estimatedStepsForDay)?.toDouble()
             over(steps, 10000.0)
@@ -3373,6 +3384,7 @@ private fun dashboardCardValue(
     vitalsDay: DailyMetric?,
     spo2Day: DailyMetric?,
     skinTempDay: DailyMetric?,
+    respDay: DailyMetric?,
     stress: Double?,
     fitnessAge: Double?,
     vitality: Double?,
@@ -3395,7 +3407,7 @@ private fun dashboardCardValue(
         DashboardCard.RESTING_HR ->
             withUnit((day?.restingHr ?: vitalsDay?.restingHr)?.toString() ?: NO_DATA)
         DashboardCard.RESPIRATORY ->
-            withUnit((day?.respRateBpm ?: vitalsDay?.respRateBpm)?.let { String.format(Locale.US, "%.1f", it) } ?: NO_DATA)
+            withUnit((day?.respRateBpm ?: vitalsDay?.respRateBpm ?: respDay?.respRateBpm)?.let { String.format(Locale.US, "%.1f", it) } ?: NO_DATA)
         DashboardCard.BLOOD_OXYGEN ->
             // PER-FIELD carry: the whole-row carries (vd) land on rows whose spo2Pct is null (the engine
             // writes spo2Pct = null on computed rows), so fall through to the last row that HAS one.
@@ -4629,6 +4641,9 @@ private fun MetricGrid(
     // spo2Pct is null (computed rows never carry one), so the Blood Oxygen tile falls through to the
     // last row that actually has a reading. Mirrors iOS TodayView.lastSpo2Day (carriedVital's per-field fallback).
     spo2CarryDay: DailyMetric? = null,
+    // PER-FIELD respiratory carry (#1331): same reason as spo2CarryDay — respiratory needs a longer
+    // clean sleep R-R segment than HRV, so carriedDay can land on a night with HRV but no breaths/min.
+    respCarryDay: DailyMetric? = null,
     unitSystem: UnitSystem = UnitSystem.METRIC,
     effortScale: EffortScale = EffortScale.HUNDRED,
     // #1001: the day's resolved Effort (live-preferring for today, floored at the stored row). Threaded
@@ -4750,7 +4765,7 @@ private fun MetricGrid(
             )
         },
         KeyMetric.RESPIRATORY to run {
-            val v = d?.respRateBpm ?: carriedDay?.respRateBpm
+            val v = d?.respRateBpm ?: carriedDay?.respRateBpm ?: respCarryDay?.respRateBpm
             KeyTileData(
                 label = uiString(R.string.l10n_today_screen_respiratory_1cd8c175),
                 value = v?.let { String.format(Locale.US, "%.1f", it) } ?: NO_DATA,

--- a/android/app/src/test/java/com/noop/ui/TodayMetricTilesTest.kt
+++ b/android/app/src/test/java/com/noop/ui/TodayMetricTilesTest.kt
@@ -480,7 +480,9 @@ class TodayMetricTilesTest {
         hrv: Double? = null,
         spo2: Double? = null,
         skinTemp: Double? = null,
-    ) = DailyMetric(deviceId = "my-whoop", day = day, avgHrv = hrv, spo2Pct = spo2, skinTempDevC = skinTemp)
+        resp: Double? = null,
+    ) = DailyMetric(deviceId = "my-whoop", day = day, avgHrv = hrv, spo2Pct = spo2, skinTempDevC = skinTemp,
+                    respRateBpm = resp)
 
     @Test
     fun lastSpo2Row_skipsANewerVitalsRowWithNullSpo2_documentsTheWholeRowBug() {
@@ -495,6 +497,34 @@ class TodayMetricTilesTest {
         val spo2 = lastSpo2Row(days, todayKey = "2026-06-19")
         assertEquals("2026-06-17", spo2?.day)
         assertEquals(96.0, spo2?.spo2Pct)
+    }
+
+    @Test
+    fun lastRespRow_carriesARECENTReading_whenTheNewestVitalsNightLacksResp() {
+        // #1331: respiratory needs a longer clean sleep R-R segment than HRV, so last night can carry HRV
+        // but no breaths/min. lastVitalsRow picks last night (right for HRV); respiratory resolves per-field
+        // to the last night that HAD a reading — but only within the vitalCarryDays window.
+        val days = listOf(
+            fieldDay("2026-08-11", resp = 20.0),                 // 3 days back: within the 7-day carry window
+            fieldDay("2026-08-13", hrv = 65.0, resp = null),     // last night: HRV yes, respiratory null
+        )
+        assertEquals("2026-08-13", lastVitalsRow(days, todayKey = "2026-08-14")?.day)
+        val resp = lastRespRow(days, todayKey = "2026-08-14")
+        assertEquals("2026-08-11", resp?.day)
+        assertEquals(20.0, resp?.respRateBpm)
+    }
+
+    @Test
+    fun lastRespRow_returnsNull_whenTheLastReadingIsStale_soNoStaleNumberIsShownAsCurrent() {
+        // The reported #1331 case: respiratory last computed weeks ago (here 23 days). A nightly vital that
+        // old must NOT be carried as the current card value — a silent stale number reads as a live
+        // measurement (the "Respiratory 15.6 a fortnight later" bug). Beyond vitalCarryDays => "No Data".
+        val days = listOf(
+            fieldDay("2026-07-22", resp = 20.0),                 // 23 days back — beyond the 7-day window
+            fieldDay("2026-08-13", hrv = 65.0, resp = null),     // recent HRV-only night
+        )
+        assertEquals("2026-08-13", lastVitalsRow(days, todayKey = "2026-08-14")?.day)
+        assertNull(lastRespRow(days, todayKey = "2026-08-14"))
     }
 
     @Test


### PR DESCRIPTION
## Carry RECENT respiratory on the Today cards + diagnostic logging (#1331)

Reported (Android): **Respiratory** card shows **"No Data"** while the detail screen has history (latest 20.0 rpm, ~3 weeks back).

### 1. Per-field carry — staleness-bounded
Respiratory resolves as `day ?: vitalsDay` / `day ?: carriedDay`, which land on the freshest night with HRV/RHR. Respiratory needs a longer clean sleep R-R segment than HRV, so a recent night can carry HRV yet no breaths/min → the card reads "No Data" though a recent night had one. SpO₂/skin-temp already solved this with per-field carries; respiratory now gets `lastRespRow`/`lastRespDay`, threaded through **both** card systems (the "Your cards" dashboard *and* the "Key metrics" `MetricGrid` — whose Blood-Oxygen tile already used `spo2CarryDay`; respiratory now has the `respCarryDay` twin).

**Crucially, unlike `lastSpo2Row`/`lastSkinTempRow` it is bounded to `Baselines.vitalCarryDays` (7 days).** SpO₂/skin-temp are sparse/imported, so last-known-of-any-age is the expected reading. Respiratory is **nightly** — a weeks-old value shown as the current number is the *"Respiratory 15.6 a fortnight later, no date beside it"* bug `vitalCarryDays` exists to prevent. So:

> **The reported case (last reading 3 weeks old) correctly still shows "No Data".** The carry only fills a *recent* missed night (last night failed but a night within 7 days had it).

### 2. Diagnostic logging — what actually serves the report
`respRateBpm` is computed from sleep R-R via RSA and returns nil when the R-R is too sparse or fails the beat-accuracy gate. A new per-night `diag` line — `resp day=<day> rpm=<value|nil>` — routes into the strap-log export, so a "respiratory not showing" report is explainable: a run of nil nights localises *when* it stopped, and pairing it with the existing sleep/RHR diag shows *why*. Logging only; no scoring change.

### Honest scope
- This **does not** change the reporter's screenshot (their value is correctly stale → "No Data"); the **diagnostic** is what helps root-cause their case. The carry helps future users with a *recent* gap.
- **Now cross-platform.** iOS mirrors it: `Repository.lastRespDay` (bounded), `LiquidTodayView`'s respiratory dashboard + key-metric tiles carry it, and the `respRateLogLine` diag twin replays beside `rhrLine`. The hero recovery-vitals card is *not* carried (matches Android — a one-night snapshot). The classic `TodayView` tile keeps its existing unbounded sparkline-tail fallback (a separate mechanism, out of scope).

### Verification
`compileFullDebugKotlin` clean; `TodayMetricTilesTest` green — new `lastRespRow_carriesARECENTReading…` (within 7 days → carries) and `lastRespRow_returnsNull_whenTheLastReadingIsStale…` (23 days → "No Data") cases.
