### PR TITLE
feat(fitness): surface how to unlock VO₂max + tappable fixes

### DIFF
--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -199486,6 +199486,70 @@
           }
         }
       }
+    },
+    "Add your waist to unlock your VO₂max": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taille eintragen, um deine VO₂max freizuschalten"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add your waist to unlock your VO₂max"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Añade tu cintura para desbloquear tu VO₂máx"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajoute ton tour de taille pour débloquer ta VO₂max"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiungi il girovita per sbloccare la tua VO₂max"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podaj obwód talii, aby odblokować VO₂max"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adiciona a tua cintura para desbloquear a tua VO₂máx"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Укажите обхват талии, чтобы открыть VO₂max"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加腰围以解锁你的最大摄氧量"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增腰圍以解鎖你的最大攝氧量"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Strand/Screens/HealthView.swift
+++ b/Strand/Screens/HealthView.swift
@@ -725,6 +725,9 @@ private struct FitnessAgeSection: View {
     @ViewBuilder private var content: some View {
         if let age = fitnessAge {
             heroCard(age: age)
+            // Prompt on WAIST being unset (the sole gate), not on vo2max == nil — the latter can be
+            // transiently nil right after waist is set, before the recompute writes vo2max_est.
+            if profile.waistCm <= 0 { vo2maxUnlockPrompt }
             if showReadiness {
                 ReadinessChecklistCard(readiness: readiness,
                                        lead: nil,
@@ -777,6 +780,29 @@ private struct FitnessAgeSection: View {
     /// The shown-value hero: a scenic Charge-world backdrop, the big Fitness Age number, a
     /// younger/older-than-your-age subtitle, the optional VO₂max, the ±band disclaimer, and the two
     /// affordances (tap-through to the trend + the "How accurate is this?" disclosure).
+    /// Shown when the Fitness Age computes but VO₂max doesn't — the one missing input is a waist
+    /// measurement (the Nes waist-variant needs it). Tapping opens Settings so it's a one-step fix,
+    /// instead of the number silently never appearing (a common "where's my VO₂max?" question).
+    private var vo2maxUnlockPrompt: some View {
+        Button { fitnessSheet = .settings } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "lungs.fill")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(StrandPalette.metricCyan)
+                Text("Add your waist to unlock your VO₂max")
+                    .font(StrandFont.footnote)
+                    .foregroundStyle(StrandPalette.textSecondary)
+                Spacer(minLength: 0)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(StrandPalette.textTertiary)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint("Opens Settings to add your waist measurement")
+    }
+
     private func heroCard(age: Double) -> some View {
         let shown = Int(age.rounded())
         let delta = Double(profile.age) - age        // +ve = fitness age younger than chronological

--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -397,6 +397,7 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
                         onVitalClick = { nav.navigate("vital_detail/$it") },
                         onOpenLabBook = { nav.navigateTopLevel(Destination.LabBook.route) },
                         onOpenFusedRecord = { nav.navigateTopLevel(Destination.FusedRecord.route) },
+                        onOpenSettings = { nav.navigateTopLevel(Destination.Settings.route) },
                     )
                 }
                 composable(Destination.Hydration.route) { HydrationScreen(viewModel) }

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -109,6 +111,7 @@ fun HealthScreen(
     onVitalClick: (String) -> Unit = {},
     onOpenLabBook: () -> Unit = {},
     onOpenFusedRecord: () -> Unit = {},
+    onOpenSettings: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val profile = remember { ProfileStore.from(context.applicationContext) }
@@ -196,7 +199,7 @@ fun HealthScreen(
             // age), with an honest readiness checklist behind a tap. Authoritative value comes from the
             // metricSeries the IntelligenceEngine writes; readiness is derived from what this screen sees.
             item { Spacer(Modifier.height(Metrics.selectorTopUp)) }
-            item { FitnessAgeSection(vm = vm, days = days, profile = profile) }
+            item { FitnessAgeSection(vm = vm, days = days, profile = profile, onOpenSettings = onOpenSettings) }
             item { VitalitySection(vm = vm, days = days, profile = profile) }
             // SKIN TEMPERATURE (v5 pillar) — Cycle awareness (opt-in), Body clock + an illness heads-up,
             // each from a pure engine RESULT the ViewModel publishes. A section of Health, never its own
@@ -642,7 +645,7 @@ private fun rememberFitnessReadiness(days: List<DailyMetric>, profile: ProfileSt
 }
 
 @Composable
-private fun FitnessAgeSection(vm: AppViewModel, days: List<DailyMetric>, profile: ProfileStore) {
+private fun FitnessAgeSection(vm: AppViewModel, days: List<DailyMetric>, profile: ProfileStore, onOpenSettings: () -> Unit = {}) {
     val context = LocalContext.current
     // Latest weekly value + its optional VO₂max companion, read once (metricSeries has no Flow, so we
     // re-read whenever the merged history changes — a fresh sync/import is what moves these).
@@ -685,8 +688,32 @@ private fun FitnessAgeSection(vm: AppViewModel, days: List<DailyMetric>, profile
                 onHowAccurate = { showChecklist = !showChecklist },
                 checklistOpen = showChecklist,
             )
+            // #1: the weekly Fitness Age computed but VO₂max didn't — the one missing input is a waist
+            // measurement. Key on waist being unset (not vo2max == null, which is transiently null right
+            // after waist is set) — prompt for it (tap → Settings) instead of silently omitting the number.
+            if (profile.waistCm <= 0.0) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(12.dp))
+                        .clickable(onClick = onOpenSettings)
+                        .padding(vertical = Metrics.space8),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(Metrics.space8),
+                ) {
+                    Icon(Icons.Filled.MonitorHeart, contentDescription = null,
+                        tint = Palette.metricCyan, modifier = Modifier.size(16.dp))
+                    Text(
+                        uiString(R.string.l10n_health_screen_add_your_waist_to_unlock_your_vo_max_94c646cb),
+                        style = NoopType.footnote, color = Palette.textSecondary,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null,
+                        tint = Palette.textTertiary, modifier = Modifier.size(16.dp))
+                }
+            }
             if (showChecklist) {
-                FitnessReadinessCard(readiness = readiness, headed = false)
+                FitnessReadinessCard(readiness = readiness, headed = false, onOpenSettings = onOpenSettings)
             }
         } else {
             // No weekly value yet — lead with a concrete countdown, then the checklist. The refresh button
@@ -1002,6 +1029,7 @@ private fun FitnessReadinessCard(
     // immediate Fitness Age recompute; [refreshing] swaps it for a spinner while that runs.
     onRefresh: (() -> Unit)? = null,
     refreshing: Boolean = false,
+    onOpenSettings: (() -> Unit)? = null,
 ) {
     val drivesAge = readiness.items
         .filter { it.role == FitnessReadinessRole.DRIVES_AGE }
@@ -1050,8 +1078,8 @@ private fun FitnessReadinessCard(
                 }
             }
 
-            ReadinessGroup(title = uiString(R.string.l10n_health_screen_drives_your_fitness_age_9d0d1219), items = drivesAge)
-            ReadinessGroup(title = uiString(R.string.l10n_health_screen_unlocks_your_vo_max_b3c67dda), items = unlocksVo2)
+            ReadinessGroup(title = uiString(R.string.l10n_health_screen_drives_your_fitness_age_9d0d1219), items = drivesAge, onOpenSettings = onOpenSettings)
+            ReadinessGroup(title = uiString(R.string.l10n_health_screen_unlocks_your_vo_max_b3c67dda), items = unlocksVo2, onOpenSettings = onOpenSettings)
 
             Text(
                 uiString(R.string.l10n_health_screen_weight_height_and_waist_add_a_fd2699f5),
@@ -1071,16 +1099,20 @@ private fun readinessSortKey(item: FitnessReadinessItem): Int = when {
 }
 
 @Composable
-private fun ReadinessGroup(title: String, items: List<FitnessReadinessItem>) {
+private fun ReadinessGroup(title: String, items: List<FitnessReadinessItem>, onOpenSettings: (() -> Unit)? = null) {
     if (items.isEmpty()) return
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.space8)) {
         Overline(title)
-        items.forEach { ReadinessRow(it) }
+        items.forEach { ReadinessRow(it, onOpenSettings) }
     }
 }
 
 @Composable
-private fun ReadinessRow(item: FitnessReadinessItem) {
+private fun ReadinessRow(item: FitnessReadinessItem, onOpenSettings: (() -> Unit)? = null) {
+    // #2: a still-unsatisfied input that CAN be filled in Settings (age/sex/body metrics/waist) gets a
+    // "Fix in Settings" tap; strap-driven inputs (resting-HR/activity coverage) don't. Mirrors iOS.
+    val fixable = onOpenSettings != null && item.status != FitnessReadinessStatus.SATISFIED &&
+        item.key in setOf("age", "sex", "bodyMetrics", "waist")
     val glyph = when (item.status) {
         FitnessReadinessStatus.SATISFIED -> "✓"
         FitnessReadinessStatus.PARTIAL -> "⚠"
@@ -1110,13 +1142,22 @@ private fun ReadinessRow(item: FitnessReadinessItem) {
             color = Palette.textPrimary,
             modifier = Modifier.weight(1f),
         )
-        Text(
-            item.detail,
-            style = NoopType.footnote,
-            color = Palette.textTertiary,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
+        if (fixable) {
+            Text(
+                uiString(R.string.l10n_health_screen_fix_in_settings_d7472915),
+                style = NoopType.footnote,
+                color = Palette.accent,
+                modifier = Modifier.clickable { onOpenSettings?.invoke() },
+            )
+        } else {
+            Text(
+                item.detail,
+                style = NoopType.footnote,
+                color = Palette.textTertiary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
     }
 }
 

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1994,4 +1994,6 @@
     <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Eigene HF-Zonen</string>
     <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Lege die Herzfrequenz fest, bei der jede Zone beginnt. Ausschalten, um die Standardzonen in Prozent der maximalen Herzfrequenz wiederherzustellen.</string>
     <string name="l10n_settings_screen_zone_starts_a0a60d45">Beginn Zone %1$d</string>
+    <string name="l10n_health_screen_add_your_waist_to_unlock_your_vo_max_94c646cb">Taille eintragen, um deine VO₂max freizuschalten</string>
+    <string name="l10n_health_screen_fix_in_settings_d7472915">In Einstellungen beheben</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1979,4 +1979,6 @@
     <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Zonas de FC personalizadas</string>
     <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Define las pulsaciones en las que empieza cada zona. Desactiva para restaurar las zonas predeterminadas por porcentaje de la frecuencia máxima.</string>
     <string name="l10n_settings_screen_zone_starts_a0a60d45">Inicio de la zona %1$d</string>
+    <string name="l10n_health_screen_add_your_waist_to_unlock_your_vo_max_94c646cb">Añade tu cintura para desbloquear tu VO₂máx</string>
+    <string name="l10n_health_screen_fix_in_settings_d7472915">Corregir en Ajustes</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1979,4 +1979,6 @@
     <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Zones FC personnalisées</string>
     <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Définis la fréquence cardiaque à laquelle chaque zone commence. Désactive pour rétablir les zones par défaut en pourcentage de la fréquence maximale.</string>
     <string name="l10n_settings_screen_zone_starts_a0a60d45">Début de la zone %1$d</string>
+    <string name="l10n_health_screen_add_your_waist_to_unlock_your_vo_max_94c646cb">Ajoute ton tour de taille pour débloquer ta VO₂max</string>
+    <string name="l10n_health_screen_fix_in_settings_d7472915">Corriger dans les réglages</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -1973,4 +1973,6 @@
     <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Własne strefy HR</string>
     <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Ustaw tętno, przy którym zaczyna się każda strefa. Wyłącz, aby przywrócić domyślne strefy oparte na procencie tętna maksymalnego.</string>
     <string name="l10n_settings_screen_zone_starts_a0a60d45">Początek strefy %1$d</string>
+    <string name="l10n_health_screen_add_your_waist_to_unlock_your_vo_max_94c646cb">Podaj obwód talii, aby odblokować VO₂max</string>
+    <string name="l10n_health_screen_fix_in_settings_d7472915">Popraw w Ustawieniach</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1973,4 +1973,6 @@
     <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Zonas de RH personalizadas</string>
     <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Define os batimentos em que cada zona começa. Desativa para repor as zonas predefinidas por percentagem da frequência máxima.</string>
     <string name="l10n_settings_screen_zone_starts_a0a60d45">Início da zona %1$d</string>
+    <string name="l10n_health_screen_add_your_waist_to_unlock_your_vo_max_94c646cb">Adiciona a tua cintura para desbloquear a tua VO₂máx</string>
+    <string name="l10n_health_screen_fix_in_settings_d7472915">Corrigir nas Definições</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1906,4 +1906,6 @@
     <string name="l10n_settings_screen_custom_hr_zones_84736ca5">自定义心率区间</string>
     <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">设置每个区间开始时的心率。关闭可恢复按最大心率百分比划分的默认区间。</string>
     <string name="l10n_settings_screen_zone_starts_a0a60d45">区间 %1$d 起点</string>
+    <string name="l10n_health_screen_add_your_waist_to_unlock_your_vo_max_94c646cb">添加腰围以解锁你的最大摄氧量</string>
+    <string name="l10n_health_screen_fix_in_settings_d7472915">在设置中修复</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2006,4 +2006,6 @@
     <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Custom HR zones</string>
     <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Set the BPM where each zone begins. Turn off to restore the default percentage-of-max zones.</string>
     <string name="l10n_settings_screen_zone_starts_a0a60d45">Zone %1$d starts</string>
+    <string name="l10n_health_screen_add_your_waist_to_unlock_your_vo_max_94c646cb">Add your waist to unlock your VO₂max</string>
+    <string name="l10n_health_screen_fix_in_settings_d7472915">Fix in Settings</string>
 </resources>


### PR DESCRIPTION
## Surface how to unlock VO₂max + tappable fixes

From a "where's my VO₂max?" question: VO₂max is estimated once a **waist** measurement is set (`FitnessAgeEngine` fills it only `if waistCm > 0`), but when waist is missing the Fitness Age screen just **omitted the number silently** — no cue that a waist unlocks it.

### 1. Inline unlock prompt (both platforms)
When the weekly Fitness Age computes but VO₂max doesn't (the sole missing input is waist), show a tappable **"Add your waist to unlock your VO₂max"** on the Fitness Age card → opens Settings. Instead of the number never appearing with no explanation.

### 2. Tappable "Fix in Settings" on the readiness checklist
The fixable inputs (age / sex / body metrics / waist) now offer a **"Fix in Settings"** tap. **iOS already had this**; Android now matches — `onOpenSettings` threaded through `FitnessReadinessCard → ReadinessGroup → ReadinessRow`, with the same `key ∈ {age, sex, bodyMetrics, waist}` fixability rule.

### Scope / re-review notes
- Kept it to the two asks — no model changes (we do compute a waist-free Uth VO₂max for calories, but surfacing that is a separate call and out of scope).
- Re-review caught a **dead affordance**: a third `FitnessReadinessCard` (the metric-detail context) had no `onOpenSettings`, so its rows would show a non-working "Fix". Made `onOpenSettings` nullable through the chain and gated the Fix on a real handler — no dead button.

### Verification
Android `compileFullDebugKotlin` + `i18n_audit --ci main` + `doc_comment_lint` clean; Swift is app-target → app-build gate. New copy translated across all shipped locales (iOS 9, Android 6).
