### PR TITLE
Persist SDNN alongside RMSSD (5-min index); fix HealthKit SDNN export mislabel (rebase of #475)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -607,6 +607,18 @@ public enum AnalyticsEngine {
             return weight > 0 ? total / weight : nil
         }()
 
+        // Daily SDNN (ms) = the 5-min SDNN INDEX (Task Force) over the in-bed R-R across matched sessions —
+        // the mean of per-5-min-segment SDNN, the BROAD autonomic-variability metric (both branches) and the
+        // slow twin of the vagal RMSSD `avgHRVDaily` above. The index (not a single whole-night SD) is used
+        // deliberately: whole-night SD is dominated by the slow HR drift across sleep stages and reads 2-3×
+        // high, which would mislabel Apple Health (its SDNN samples are short-window) and make any cross-check
+        // against a watch meaningless. The 5-min index is window-comparable to those. nil when no segment has
+        // enough clean beats (HRVAnalyzer's own gate). Keeps the R-R timestamps (segmentation needs them).
+        let avgSDNNDaily: Double? = {
+            let inBed = rr.filter { r in matched.contains { r.ts >= $0.start && r.ts < $0.end } }
+            return inBed.isEmpty ? nil : HRVAnalyzer.sdnnIndex(inBed, segmentSec: 300)
+        }()
+
         // ── HRV & Autonomic nightly trace (#141) ──────────────────────────────
         // Per-5-min-window RMSSD tagged by the sleep stage at its center, then a night summary comparing
         // NOOP's whole-night mean (what it reports) against a deep-only mean and a WHOOP-style
@@ -796,7 +808,8 @@ public enum AnalyticsEngine {
             steps: stepsTotal,
             activeKcalEst: activeKcalEst,
             spo2Red: nightlySpo2Raw?.red,
-            spo2Ir: nightlySpo2Raw?.ir)
+            spo2Ir: nightlySpo2Raw?.ir,
+            avgSdnn: avgSDNNDaily)
         _ = sleepStart; _ = sleepEnd  // available for callers wiring sleep_start/end columns
 
         // ── Cache rows ────────────────────────────────────────────────────────

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -294,6 +294,29 @@ public enum HRVAnalyzer {
                          nInput: nInput, nClean: clean.count)
     }
 
+    /// SDNN index (Task Force 1996): the MEAN of SDNN computed over consecutive fixed-length segments
+    /// (default 5 min) of the R-R series, each segment cleaned with the SAME range + Malik ectopic
+    /// rejection the nightly path uses. Unlike whole-night SDNN — which is dominated by the slow HR drift
+    /// ACROSS sleep stages and can read 2-3× higher — the index reflects SHORT-TERM variability, so it is
+    /// window-comparable to a wearable's short SDNN reading (e.g. Apple Watch's ~1-min
+    /// `heartRateVariabilitySDNN` samples) and is the value that can be honestly cross-checked against one.
+    /// Segments with fewer than `minBeats` clean intervals are skipped; nil when no segment qualifies.
+    /// Pure, deterministic. Kotlin twin: `HrvAnalyzer.sdnnIndex`.
+    public static func sdnnIndex(_ rr: [RRInterval], segmentSec: Int = 300) -> Double? {
+        guard segmentSec > 0, let first = rr.map(\.ts).min(), let last = rr.map(\.ts).max(),
+              last >= first else { return nil }
+        var segStart = first
+        var segmentSDNNs: [Double] = []
+        while segStart <= last {
+            if let sd = analyze(rr, windowStart: segStart, windowEnd: segStart + segmentSec - 1).sdnn {
+                segmentSDNNs.append(sd)
+            }
+            segStart += segmentSec
+        }
+        guard !segmentSDNNs.isEmpty else { return nil }
+        return segmentSDNNs.reduce(0, +) / Double(segmentSDNNs.count)
+    }
+
     // MARK: - Rolling / windowed rMSSD timeline (#803)
 
     /// One windowed rMSSD point: the rMSSD (ms) over the trailing `windowSec` of R-R intervals ending at

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerTests.swift
@@ -214,6 +214,50 @@ final class HRVAnalyzerTests: XCTestCase {
         XCTAssertEqual(HRVAnalyzer.duplicateBeatCount(tsSec: [100, 100], rrMs: [1000, 1010]), 0)  // diff rr = distinct
     }
 
+    // MARK: - SDNN index (5-min segmented SDNN, the Apple-comparable window)
+
+    func testSdnnIndexExcludesInterSegmentDrift() {
+        // Three 100 s segments, each internally near-steady (±5 ms) but at very different levels
+        // (800 / 900 / 1000 ms). Whole-night SDNN sees the big 800→1000 drift and reads large; the SDNN
+        // index averages each segment's OWN (small) SDNN, so it stays small — the exact property that makes
+        // it comparable to a watch's short-window reading instead of the drift-inflated whole-night value.
+        var rr: [RRInterval] = []
+        for t in 0..<50   { rr.append(RRInterval(ts: 0   + t, rrMs: t.isMultiple(of: 2) ? 795 : 805)) }
+        for t in 0..<50   { rr.append(RRInterval(ts: 100 + t, rrMs: t.isMultiple(of: 2) ? 895 : 905)) }
+        for t in 0..<50   { rr.append(RRInterval(ts: 200 + t, rrMs: t.isMultiple(of: 2) ? 995 : 1005)) }
+
+        let index = HRVAnalyzer.sdnnIndex(rr, segmentSec: 100)
+        let wholeNight = HRVAnalyzer.analyze(rawRR: rr.map { Double($0.rrMs) }).sdnn
+        let idx = try! XCTUnwrap(index)
+        let whole = try! XCTUnwrap(wholeNight)
+        XCTAssertEqual(idx, 5.05, accuracy: 1.5, "each segment's own SDNN is ~5 ms")
+        XCTAssertGreaterThan(whole, 50, "whole-night SDNN is inflated by the 800→1000 drift")
+        XCTAssertLessThan(idx, whole / 5, "the index must strip out the inter-segment drift")
+    }
+
+    func testSdnnIndexSteadySeriesIsSmallPositive() {
+        // A single steady segment (±5 ms) → a small, sane, non-nil index.
+        let rr = (0..<60).map { RRInterval(ts: $0, rrMs: $0.isMultiple(of: 2) ? 795 : 805) }
+        let idx = try! XCTUnwrap(HRVAnalyzer.sdnnIndex(rr, segmentSec: 100))
+        XCTAssertEqual(idx, 5.05, accuracy: 1.5)
+    }
+
+    func testSdnnIndexSingleSegmentEqualsWholeSdnn() {
+        // When all beats fall in ONE segment, the index is just that segment's SDNN = the whole SDNN.
+        let rr = (0..<60).map { RRInterval(ts: $0, rrMs: [800, 820, 780, 810, 790][$0 % 5]) }
+        let index = try! XCTUnwrap(HRVAnalyzer.sdnnIndex(rr, segmentSec: 1000))
+        let whole = try! XCTUnwrap(HRVAnalyzer.analyze(rr, windowStart: 0, windowEnd: 999).sdnn)
+        XCTAssertEqual(index, whole, accuracy: 1e-9)
+    }
+
+    func testSdnnIndexSparseSeriesIsNil() {
+        // Fewer than minBeats in the only segment → no qualifying segment → nil (honest absence).
+        let rr = (0..<10).map { RRInterval(ts: $0, rrMs: 800) }
+        XCTAssertNil(HRVAnalyzer.sdnnIndex(rr, segmentSec: 100))
+        XCTAssertNil(HRVAnalyzer.sdnnIndex([], segmentSec: 100))
+        XCTAssertNil(HRVAnalyzer.sdnnIndex(rr, segmentSec: 0), "non-positive segment length is rejected")
+    }
+
     // #550 — collapsedCoverage: previews a SAME-SECOND R-R de-dup so the always-on diag reveals whether
     // the #257 over-count is same-second (collapsible) or cross-second (needs an ingest-path fix).
 

--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -822,6 +822,20 @@ extension WhoopStore {
                 }
             }
         }
+
+        // v37: persist nightly SDNN — the 5-min SDNN index (broad-variability twin of avgHrv=RMSSD),
+        // window-matched to a watch's short SDNN rather than the drift-inflated whole-night SD. Additive,
+        // nullable; computed by HRVAnalyzer.sdnnIndex during the nightly analysis.
+        //
+        // Numbered v37: upstream migrations advanced to v36 (`v36-whoop-caps-no-spo2`) while this branch
+        // was open, so this branch-local, never-shipped identifier is renumbered to the next free slot.
+        // Renumbering an unshipped identifier is free (GRDB tracks applied migrations by id, not number);
+        // renaming a SHIPPED one is not, so only this id moves.
+        migrator.registerMigration("v37-daily-avg-sdnn") { db in
+            try db.alter(table: "dailyMetric") { t in
+                t.add(column: "avgSdnn", .double)
+            }
+        }
         return migrator
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
@@ -76,19 +76,27 @@ public struct DailyMetric: Equatable, Codable {
     // call site is unaffected.
     public let spo2Red: Int?           // mean raw red PPG ADC during detected sleep
     public let spo2Ir: Int?            // mean raw IR PPG ADC during detected sleep
+    /// Nightly SDNN (ms — the Task Force 5-min SDNN INDEX: mean of per-5-min-segment SDNN, ddof=1). The
+    /// BROAD autonomic-variability twin of `avgHrv` (which is RMSSD for the strap: the fast, vagal,
+    /// "recovered today?" metric). The 5-min index — not a single whole-night SD — is stored deliberately:
+    /// whole-night SD is dominated by the slow HR drift across sleep stages (reads 2-3× high) and is not
+    /// comparable to a watch's short-window SDNN; the index is. v31 column, nullable: WHOOP/on-device nights
+    /// compute it from the night's R-R (`HRVAnalyzer.sdnnIndex`); Apple rows mirror their own SDNN reading;
+    /// Oura/other imports carry no SDNN so it stays nil.
+    public let avgSdnn: Double?
     public init(day: String, totalSleepMin: Double?, efficiency: Double?, deepMin: Double?,
                 remMin: Double?, lightMin: Double?, disturbances: Int?, restingHr: Int?,
                 avgHrv: Double?, recovery: Double?, strain: Double?, exerciseCount: Int?,
                 spo2Pct: Double? = nil, skinTempDevC: Double? = nil, respRateBpm: Double? = nil,
                 steps: Int? = nil, activeKcalEst: Double? = nil,
-                spo2Red: Int? = nil, spo2Ir: Int? = nil) {
+                spo2Red: Int? = nil, spo2Ir: Int? = nil, avgSdnn: Double? = nil) {
         self.day = day; self.totalSleepMin = totalSleepMin; self.efficiency = efficiency
         self.deepMin = deepMin; self.remMin = remMin; self.lightMin = lightMin
         self.disturbances = disturbances; self.restingHr = restingHr; self.avgHrv = avgHrv
         self.recovery = recovery; self.strain = strain; self.exerciseCount = exerciseCount
         self.spo2Pct = spo2Pct; self.skinTempDevC = skinTempDevC; self.respRateBpm = respRateBpm
         self.steps = steps; self.activeKcalEst = activeKcalEst
-        self.spo2Red = spo2Red; self.spo2Ir = spo2Ir
+        self.spo2Red = spo2Red; self.spo2Ir = spo2Ir; self.avgSdnn = avgSdnn
     }
 
     /// The freshest STRICTLY-PRIOR day that carries at least one overnight vital (HRV / resting HR /
@@ -399,8 +407,8 @@ extension WhoopStore {
                     (deviceId, day, totalSleepMin, efficiency, deepMin, remMin, lightMin,
                      disturbances, restingHr, avgHrv, recovery, strain, exerciseCount,
                      spo2Pct, skinTempDevC, respRateBpm, steps, activeKcalEst,
-                     spo2Red, spo2Ir)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     spo2Red, spo2Ir, avgSdnn)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(deviceId, day) DO UPDATE SET
                     totalSleepMin = excluded.totalSleepMin,
                     efficiency = excluded.efficiency,
@@ -419,13 +427,14 @@ extension WhoopStore {
                     steps = excluded.steps,
                     activeKcalEst = excluded.activeKcalEst,
                     spo2Red = excluded.spo2Red,
-                    spo2Ir = excluded.spo2Ir
+                    spo2Ir = excluded.spo2Ir,
+                    avgSdnn = excluded.avgSdnn
                 """, arguments: [deviceId, d.day, d.totalSleepMin, d.efficiency, d.deepMin,
                                  d.remMin, d.lightMin, d.disturbances, d.restingHr, d.avgHrv,
                                  d.recovery, d.strain, d.exerciseCount,
                                  d.spo2Pct, d.skinTempDevC, d.respRateBpm,
                                  d.steps, d.activeKcalEst,
-                                 d.spo2Red, d.spo2Ir])
+                                 d.spo2Red, d.spo2Ir, d.avgSdnn])
             n += db.changesCount
         }
         return n
@@ -476,7 +485,7 @@ extension WhoopStore {
                 SELECT day, totalSleepMin, efficiency, deepMin, remMin, lightMin, disturbances,
                        restingHr, avgHrv, recovery, strain, exerciseCount,
                        spo2Pct, skinTempDevC, respRateBpm, steps, activeKcalEst,
-                       spo2Red, spo2Ir FROM dailyMetric
+                       spo2Red, spo2Ir, avgSdnn FROM dailyMetric
                 WHERE deviceId = ? AND day >= ? AND day <= ?
                 ORDER BY day ASC
                 """, arguments: [deviceId, from, to])
@@ -490,7 +499,7 @@ extension WhoopStore {
                                 spo2Pct: $0["spo2Pct"], skinTempDevC: $0["skinTempDevC"],
                                 respRateBpm: $0["respRateBpm"],
                                 steps: $0["steps"], activeKcalEst: $0["activeKcalEst"],
-                                spo2Red: $0["spo2Red"], spo2Ir: $0["spo2Ir"])
+                                spo2Red: $0["spo2Red"], spo2Ir: $0["spo2Ir"], avgSdnn: $0["avgSdnn"])
                 }
         }
     }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/MetricsCacheTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/MetricsCacheTests.swift
@@ -511,6 +511,63 @@ final class MetricsCacheTests: XCTestCase {
         XCTAssertNil(bareRow.activeKcalEst)
     }
 
+    // MARK: - v31 nightly SDNN column (avgSdnn, alongside avgHrv=RMSSD)
+
+    func testV31AvgSdnnColumnPresent() async throws {
+        let store = try await WhoopStore.inMemory()
+        let cols = try await store.columnNamesForTest(table: "dailyMetric")
+        XCTAssertTrue(cols.contains("avgSdnn"), "dailyMetric missing v31 avgSdnn column")
+    }
+
+    func testV31AvgSdnnRoundTrip() async throws {
+        let store = try await WhoopStore.inMemory()
+        // avgHrv carries RMSSD; avgSdnn carries the whole-night SDNN — distinct values on the same row.
+        let d = DailyMetric(day: "2026-05-29", totalSleepMin: 415, efficiency: 0.9,
+                            deepMin: 88, remMin: 108, lightMin: 219, disturbances: 2,
+                            restingHr: 50, avgHrv: 62.0, recovery: 0.73, strain: 10.5,
+                            exerciseCount: 1, spo2Pct: 96.2, skinTempDevC: 0.0, respRateBpm: 14.7,
+                            steps: 7_900, activeKcalEst: 2_180.0, avgSdnn: 88.4)
+        try await store.upsertDailyMetrics([d], deviceId: "devA")
+
+        let rows = try await store.dailyMetrics(deviceId: "devA", from: "2026-05-01", to: "2026-05-31")
+        XCTAssertEqual(rows.count, 1)
+        let row = try XCTUnwrap(rows.first)
+        XCTAssertEqual(try XCTUnwrap(row.avgHrv), 62.0, accuracy: 0.001, "RMSSD must survive intact")
+        XCTAssertEqual(try XCTUnwrap(row.avgSdnn), 88.4, accuracy: 0.001, "SDNN must persist distinctly")
+
+        // Omitting avgSdnn keeps it nil (defaulted init — old call sites unchanged).
+        let bare = DailyMetric(day: "2026-05-30", totalSleepMin: nil, efficiency: nil,
+                               deepMin: nil, remMin: nil, lightMin: nil, disturbances: nil,
+                               restingHr: nil, avgHrv: 55.0, recovery: nil, strain: nil, exerciseCount: nil)
+        try await store.upsertDailyMetrics([bare], deviceId: "devA")
+        let bareRows = try await store.dailyMetrics(deviceId: "devA", from: "2026-05-30", to: "2026-05-30")
+        let bareRow = try XCTUnwrap(bareRows.first)
+        XCTAssertEqual(try XCTUnwrap(bareRow.avgHrv), 55.0, accuracy: 0.001)
+        XCTAssertNil(bareRow.avgSdnn, "avgSdnn defaults to nil when the source has no whole-night SDNN")
+    }
+
+    func testV31AvgSdnnUpsertUpdates() async throws {
+        let store = try await WhoopStore.inMemory()
+        // Insert with nil SDNN, then re-upsert the same day with SDNN populated (WHOOP backfill path).
+        let d1 = DailyMetric(day: "2026-05-31", totalSleepMin: 400, efficiency: 0.88,
+                             deepMin: 80, remMin: 100, lightMin: 220, disturbances: 3,
+                             restingHr: 54, avgHrv: 60.0, recovery: 0.65, strain: 13.0, exerciseCount: 0)
+        try await store.upsertDailyMetrics([d1], deviceId: "devA")
+        let preRows = try await store.dailyMetrics(deviceId: "devA", from: "2026-05-31", to: "2026-05-31")
+        var row = try XCTUnwrap(preRows.first)
+        XCTAssertNil(row.avgSdnn)
+
+        let d2 = DailyMetric(day: "2026-05-31", totalSleepMin: 400, efficiency: 0.88,
+                             deepMin: 80, remMin: 100, lightMin: 220, disturbances: 3,
+                             restingHr: 54, avgHrv: 60.0, recovery: 0.65, strain: 13.0, exerciseCount: 0,
+                             avgSdnn: 91.2)
+        try await store.upsertDailyMetrics([d2], deviceId: "devA")
+        let rows = try await store.dailyMetrics(deviceId: "devA", from: "2026-05-31", to: "2026-05-31")
+        XCTAssertEqual(rows.count, 1, "upsert must not duplicate")
+        row = try XCTUnwrap(rows.first)
+        XCTAssertEqual(try XCTUnwrap(row.avgSdnn), 91.2, accuracy: 0.001)
+    }
+
     // MARK: - read highwater cursor (distinct prefix from upload highwater)
 
     func testReadHighwaterRoundTripsUnderDistinctPrefix() async throws {

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
@@ -37,11 +37,13 @@
     "v33-workout-steps",
     "v34-sleep-staging-sparse",
     "v35-rr-future-quarantine",
-    "v36-whoop-caps-no-spo2"
+    "v36-whoop-caps-no-spo2",
+    "v37-daily-avg-sdnn"
   ],
   "divergenceReasons": {
     "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android \u2014 the per-row upload flag belongs to an upload path that does not exist there \u2014 so it is dead width, not divergent data. Removing it needs a Room table rebuild.",
     "battery-alter-append-order": "REAL COLUMN-ORDER DRIFT (CLAUDE.md: 'column order in a Room CREATE TABLE must match the entity field order'). GRDB appended `synced` (v5) then `charging` (v6) with ALTER TABLE, which can only append; the Room entity declares `charging` before `synced`. Same columns, same types, different positions \u2014 so any positional copy (INSERT INTO battery SELECT * FROM \u2026) swaps them. Fixing it means reordering the Room entity's fields, which changes Room's identity hash and therefore needs a version bump plus a no-op migration.",
+    "daily-avg-sdnn-ios-only": "REAL COLUMN DRIFT, deliberate and one-directional: `dailyMetric.avgSdnn` (the 5-min SDNN index) is written by the Swift nightly analysis and has no Room twin, because the Android analytics reimplementation computes RMSSD only — there is no Kotlin `sdnnIndex` to persist. Adding the Room column without the computation would store NULL on every Android row, which is a fabricated parity, not a real one; the honest shape is an absent column until the Kotlin twin exists. Consequence: a .noopbak exported from iOS carries a column Android's `dailyMetric` cannot receive, in the same direction as `workout.routePolyline` but reversed. Closing it means porting `HRVAnalyzer.sdnnIndex` to Kotlin plus a Room version bump.",
     "grdb-boolean-affinity": "GRDB's .boolean column type is declared BOOLEAN, which SQLite gives NUMERIC affinity; Room maps Kotlin Boolean to INTEGER. For the 0/1 values both sides write, NUMERIC and INTEGER affinity store bit-identical INTEGERs, so a .noopbak round-trips. Closing it means a GRDB table rebuild.",
     "paired-device-alter-append-order": "REAL COLUMN-ORDER DRIFT, same shape as battery. GRDB's v16-paired-device-peripheral appended `peripheralId` at the end; the Room entity declares it fifth, between `nickname` and `sourceKind`.",
     "ppg-hr-bpm-integer-on-android": "AFFINITY DRIFT, and NOT a data consequence: ppgHrSample.bpm is declared REAL on iOS and INTEGER on Android \u2014 but only the SQLITE COLUMN differs. The ROW type is `Int` on both sides: Swift's `PpgHrSample.bpm` is `Int`, carrying the comment 'the same Int domain as the measured HRSample.bpm and the Android PpgHr.Estimate.bpm, so the stored value and type match across platforms (#219)'. Both platforms also round to whole bpm before that \u2014 Swift `(fsD * 60 / refinedLag).rounded()` then `Int(est.bpm)`, Kotlin `Math.round(fsD * 60 / refinedLag).toInt()` \u2014 and the read path (`CAST(ROUND(p.bpm) AS INTEGER)`) rounds again, a no-op on a whole number. There is one writer and one construction site on each side. So REAL holds the same whole numbers INTEGER does and NO value differs. Recorded because the DECLARED affinity genuinely diverges, and a bpm that ever became fractional would then diverge silently; closing it means a GRDB table rebuild. Deliberately NOT the decoder-oracle (#869) class \u2014 that caught a real value divergence.",
@@ -327,6 +329,14 @@
           "affinity": "INTEGER",
           "notNull": false,
           "default": null
+        },
+        {
+          "name": "avgSdnn",
+          "affinity": "REAL",
+          "notNull": false,
+          "default": null,
+          "androidAbsent": true,
+          "divergence": "daily-avg-sdnn-ios-only"
         }
       ],
       "primaryKey": [

--- a/Strand/Data/AppleHealthImport.swift
+++ b/Strand/Data/AppleHealthImport.swift
@@ -48,7 +48,8 @@ enum AppleHealthImport {
                         // #89: Apple Health steps must land in DailyMetric.steps too — the sourced-daily
                         // arbitration resolves "steps" via metricValue(d) = d.steps, so leaving it nil (the
                         // pre-fix state) meant imported Apple steps never surfaced there.
-                        steps: d.steps.map { Int($0) })
+                        steps: d.steps.map { Int($0) },
+                        avgSdnn: d.hrvSDNN)   // Apple HRV is SDNN — mirror into the SDNN field
         }
         let dmWritten = try await store.upsertDailyMetrics(dm, deviceId: deviceId)
 

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -2167,7 +2167,7 @@ private extension DailyMetric {
                     avgHrv: avgHrv, recovery: r, strain: strain, exerciseCount: exerciseCount,
                     spo2Pct: spo2Pct, skinTempDevC: sd, respRateBpm: respRateBpm,
                     steps: steps, activeKcalEst: activeKcalEst,
-                    spo2Red: spo2Red, spo2Ir: spo2Ir)
+                    spo2Red: spo2Red, spo2Ir: spo2Ir, avgSdnn: avgSdnn)
     }
 
     /// Rebuild with substituted sleep-derived fields (a user-corrected wake window), leaving every
@@ -2178,7 +2178,7 @@ private extension DailyMetric {
                     disturbances: disturbances, restingHr: restingHr, avgHrv: avgHrv, recovery: recovery,
                     strain: strain, exerciseCount: exerciseCount, spo2Pct: spo2Pct,
                     skinTempDevC: skinTempDevC, respRateBpm: respRateBpm, steps: steps,
-                    activeKcalEst: activeKcalEst, spo2Red: spo2Red, spo2Ir: spo2Ir)
+                    activeKcalEst: activeKcalEst, spo2Red: spo2Red, spo2Ir: spo2Ir, avgSdnn: avgSdnn)
     }
 }
 

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -2892,7 +2892,8 @@ private extension DailyMetric {
             // Raw SpO2 is on-device only (imports never carry it), so the imported row's nil is
             // backfilled from the computed fallback — otherwise the nightly means would be lost. (#93)
             spo2Red: spo2Red ?? fallback.spo2Red,
-            spo2Ir: spo2Ir ?? fallback.spo2Ir
+            spo2Ir: spo2Ir ?? fallback.spo2Ir,
+            avgSdnn: avgSdnn ?? fallback.avgSdnn
         )
     }
 
@@ -2920,7 +2921,8 @@ private extension DailyMetric {
             steps: steps,
             activeKcalEst: activeKcalEst,
             spo2Red: spo2Red,   // non-sleep field: preserved as-is (#93)
-            spo2Ir: spo2Ir
+            spo2Ir: spo2Ir,
+            avgSdnn: avgSdnn    // non-sleep (HRV) field: preserved as-is
         )
     }
 }

--- a/StrandiOS/Health/HealthKitBridge.swift
+++ b/StrandiOS/Health/HealthKitBridge.swift
@@ -457,7 +457,8 @@ final class HealthKitBridge: ObservableObject {
                         deepMin: a.deepMin, remMin: a.remMin, lightMin: a.coreMin, disturbances: nil,
                         restingHr: a.restingHr.map { Int($0.rounded()) }, avgHrv: a.hrv,
                         recovery: nil, strain: nil, exerciseCount: nil,
-                        spo2Pct: a.spo2, skinTempDevC: nil, respRateBpm: a.respRate)
+                        spo2Pct: a.spo2, skinTempDevC: nil, respRateBpm: a.respRate,
+                        avgSdnn: a.hrv)   // Apple's HRV IS SDNN — mirror it into the SDNN field too
         }
         // Flatten to the generic metricSeries the shared Apple Health screen, the Today apple-health
         // sparklines, and the Metric Explorer read from — repo.series(key:source:"apple-health")
@@ -682,8 +683,16 @@ final class HealthKitBridge: ObservableObject {
             if let rhr = row.restingHr {
                 add(.restingHeartRate, HKUnit.count().unitDivided(by: .minute()), Double(rhr), row.day, at)
             }
-            if let hrv = row.avgHrv {
-                add(.heartRateVariabilitySDNN, .secondUnit(with: .milli), hrv, row.day, at)
+            // Export the GENUINE SDNN (v31) when present — the strap's `avgHrv` is RMSSD, which HealthKit
+            // has no field for, so writing it under `.heartRateVariabilitySDNN` mislabels it. `avgSdnn` is the
+            // 5-min SDNN index, deliberately window-matched to Apple's own short-window SDNN samples so the
+            // written values sit consistently in the user's Health SDNN history (a whole-night SD would land
+            // 2-3× high). WHOOP rows backfill `avgSdnn` from stored raw R-R on the next re-score; Apple rows'
+            // `avgHrv` already IS SDNN. The `avgHrv` fallback fires for those two before re-scoring, and
+            // permanently for summary-only sources (Oura) that give RMSSD with no raw R-R to derive SDNN from
+            // — HealthKit's single HRV type leaves no better label there.
+            if let sdnn = row.avgSdnn ?? row.avgHrv {
+                add(.heartRateVariabilitySDNN, .secondUnit(with: .milli), sdnn, row.day, at)
             }
             if let spo2 = row.spo2Pct {
                 add(.oxygenSaturation, .percent(), spo2 / 100, row.day, at)

--- a/android/app/src/test/resources/schema_oracle.json
+++ b/android/app/src/test/resources/schema_oracle.json
@@ -37,11 +37,13 @@
     "v33-workout-steps",
     "v34-sleep-staging-sparse",
     "v35-rr-future-quarantine",
-    "v36-whoop-caps-no-spo2"
+    "v36-whoop-caps-no-spo2",
+    "v37-daily-avg-sdnn"
   ],
   "divergenceReasons": {
     "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android \u2014 the per-row upload flag belongs to an upload path that does not exist there \u2014 so it is dead width, not divergent data. Removing it needs a Room table rebuild.",
     "battery-alter-append-order": "REAL COLUMN-ORDER DRIFT (CLAUDE.md: 'column order in a Room CREATE TABLE must match the entity field order'). GRDB appended `synced` (v5) then `charging` (v6) with ALTER TABLE, which can only append; the Room entity declares `charging` before `synced`. Same columns, same types, different positions \u2014 so any positional copy (INSERT INTO battery SELECT * FROM \u2026) swaps them. Fixing it means reordering the Room entity's fields, which changes Room's identity hash and therefore needs a version bump plus a no-op migration.",
+    "daily-avg-sdnn-ios-only": "REAL COLUMN DRIFT, deliberate and one-directional: `dailyMetric.avgSdnn` (the 5-min SDNN index) is written by the Swift nightly analysis and has no Room twin, because the Android analytics reimplementation computes RMSSD only — there is no Kotlin `sdnnIndex` to persist. Adding the Room column without the computation would store NULL on every Android row, which is a fabricated parity, not a real one; the honest shape is an absent column until the Kotlin twin exists. Consequence: a .noopbak exported from iOS carries a column Android's `dailyMetric` cannot receive, in the same direction as `workout.routePolyline` but reversed. Closing it means porting `HRVAnalyzer.sdnnIndex` to Kotlin plus a Room version bump.",
     "grdb-boolean-affinity": "GRDB's .boolean column type is declared BOOLEAN, which SQLite gives NUMERIC affinity; Room maps Kotlin Boolean to INTEGER. For the 0/1 values both sides write, NUMERIC and INTEGER affinity store bit-identical INTEGERs, so a .noopbak round-trips. Closing it means a GRDB table rebuild.",
     "paired-device-alter-append-order": "REAL COLUMN-ORDER DRIFT, same shape as battery. GRDB's v16-paired-device-peripheral appended `peripheralId` at the end; the Room entity declares it fifth, between `nickname` and `sourceKind`.",
     "ppg-hr-bpm-integer-on-android": "AFFINITY DRIFT, and NOT a data consequence: ppgHrSample.bpm is declared REAL on iOS and INTEGER on Android \u2014 but only the SQLITE COLUMN differs. The ROW type is `Int` on both sides: Swift's `PpgHrSample.bpm` is `Int`, carrying the comment 'the same Int domain as the measured HRSample.bpm and the Android PpgHr.Estimate.bpm, so the stored value and type match across platforms (#219)'. Both platforms also round to whole bpm before that \u2014 Swift `(fsD * 60 / refinedLag).rounded()` then `Int(est.bpm)`, Kotlin `Math.round(fsD * 60 / refinedLag).toInt()` \u2014 and the read path (`CAST(ROUND(p.bpm) AS INTEGER)`) rounds again, a no-op on a whole number. There is one writer and one construction site on each side. So REAL holds the same whole numbers INTEGER does and NO value differs. Recorded because the DECLARED affinity genuinely diverges, and a bpm that ever became fractional would then diverge silently; closing it means a GRDB table rebuild. Deliberately NOT the decoder-oracle (#869) class \u2014 that caught a real value divergence.",
@@ -327,6 +329,14 @@
           "affinity": "INTEGER",
           "notNull": false,
           "default": null
+        },
+        {
+          "name": "avgSdnn",
+          "affinity": "REAL",
+          "notNull": false,
+          "default": null,
+          "androidAbsent": true,
+          "divergence": "daily-avg-sdnn-ios-only"
         }
       ],
       "primaryKey": [


### PR DESCRIPTION
Maintainer rebase of #475 (@vishk23) onto current `main` — the fork branch could not be pushed to directly (maintainer-edit push returned 403), so the author's commit is carried here unchanged in authorship.

**Only change vs #475:** the migration is renumbered `v32-daily-avg-sdnn` → **`v37-daily-avg-sdnn`** (upstream advanced to `v36` while the branch was open), and the `grdbMigrations` list in both `schema_oracle.json` copies is updated to match (v37 at position 37, both files byte-identical). All logic — `HRVAnalyzer.sdnnIndex`, the `avgSdnn` column/upsert/read, the HealthKit export fix, and the documented `daily-avg-sdnn-ios-only` divergence — is unchanged from #475.

Closes #475.

---
Original #475 summary: `DailyMetric.avgHrv` holds RMSSD for strap rows but SDNN for Apple-Health rows, and the HealthKit write-back exported the strap's RMSSD under `.heartRateVariabilitySDNN`, mislabeling it in the user's permanent Apple Health record. This persists a real 5-min SDNN index (`avgSdnn`) and exports that instead, falling back to `avgHrv` only when SDNN is absent.
