### PR TITLE
Readiness RD2 window-fold + Kotlin twin (rebase of #469)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
@@ -213,12 +213,25 @@ public enum Baselines {
                                halfLifeB: 14.0, halfLifeS: 21.0),
         "strain": MetricCfg(minVal: 0.0, maxVal: 100.0, floorSpread: 5.0,
                             halfLifeB: 14.0, halfLifeS: 21.0),
+
+        // Readiness HRV baseline, folded in the LOG domain with hard-outlier rejection OFF (RD2 · the
+        // window-fold spine mode — see Baselines.update's `rejectHardOutliers`). ReadinessEngine
+        // z-scores lnRMSSD (RD1: HRV is right-skewed), so these bounds/floor are in LN(ms) units — NOT
+        // the raw-ms "hrv" config above (which the RecoveryScorer folds linearly, untouched).
+        // minVal/maxVal = ln(8)/ln(250), the plausible HRV band in ln. floorSpread 0.08 (ln) sits just
+        // below a real wearer's own ln-HRV night-to-night spread (~0.10, measured on real WHOOP nights),
+        // so personal spread drives the z while an ultra-stable baseline is floored against saturation.
+        "readiness_hrv_ln": MetricCfg(minVal: 2.079, maxVal: 5.521, floorSpread: 0.08,
+                                      halfLifeB: 14.0, halfLifeS: 21.0),
     ]
 
     /// Convenience accessors for the standard configs.
     public static var hrvCfg: MetricCfg { metricCfg["hrv"]! }
     public static var restingHRCfg: MetricCfg { metricCfg["resting_hr"]! }
     public static var respCfg: MetricCfg { metricCfg["resp"]! }
+    /// Readiness HRV baseline config — folded in the LOG domain (ln ms) with hard-outlier rejection
+    /// OFF. See the `readiness_hrv_ln` comment above; distinct from the raw-ms `hrvCfg`.
+    public static var readinessHRVLnCfg: MetricCfg { metricCfg["readiness_hrv_ln"]! }
     /// Baseline config for the RecoveryScorer Activity-Balance / previous-day-Effort term.
     public static var strainCfg: MetricCfg { metricCfg["strain"]! }
 
@@ -272,7 +285,8 @@ public enum Baselines {
     /// - `value == nil` or out-of-range: skip-and-hold (carry forward).
     /// - hard outlier (> HARD_OUTLIER_K × spread): seen but not folded.
     /// - otherwise: Winsorized EWMA center + EWMA-abs-dev spread update.
-    public static func update(_ state: BaselineState?, value: Double?, cfg: MetricCfg) -> BaselineState {
+    public static func update(_ state: BaselineState?, value: Double?, cfg: MetricCfg,
+                              rejectHardOutliers: Bool = true) -> BaselineState {
         let lb = lambda(halfLife: cfg.halfLifeB)
         let ls = lambda(halfLife: cfg.halfLifeS)
 
@@ -313,7 +327,17 @@ public enum Baselines {
         // Suspending this during early life is the core anti-anchoring fix — a high seed with a
         // floor-tight spread would otherwise reject the user's real, lower readings as "outliers"
         // (a true 54ms vs an anchored ~90ms baseline is >5× the floor spread).
-        if state.nValid >= minNightsSeed && !isYoung {
+        //
+        // `rejectHardOutliers` (default true) can turn this OFF for a TRAILING-WINDOW re-fold — where
+        // the same 30-night window is re-folded every call and a *recent sustained* shift lands at the
+        // window's end (past the young grace period), so rejection would discard a real new normal as a
+        // string of "outliers" (readiness's device-swap / supplement-onset failure mode). With it off,
+        // the Winsorization below STILL damps a single freak night (clamped to ±winsorK·spread rather
+        // than folded raw) — but a sustained shift is followed instead of rejected, because each night
+        // nudges the center and widens the spread until the new level is no longer an outlier. This is
+        // exactly the incremental-fold (reject on, RecoveryScorer) vs window-fold (reject off, Readiness)
+        // distinction; validated on real HRV history (see ReadinessEngine's RD2 note).
+        if rejectHardOutliers && state.nValid >= minNightsSeed && !isYoung {
             let dev = abs(value - state.baseline)
             if dev > hardOutlierK * state.spread {
                 return BaselineState(baseline: state.baseline, spread: state.spread,
@@ -351,9 +375,10 @@ public enum Baselines {
 
     /// Replay an ordered sequence of nightly values (oldest first) to build state.
     /// `nil` entries are treated as missing nights (skip-and-hold).
-    public static func foldHistory(_ values: [Double?], cfg: MetricCfg) -> BaselineState {
+    public static func foldHistory(_ values: [Double?], cfg: MetricCfg,
+                                   rejectHardOutliers: Bool = true) -> BaselineState {
         var state: BaselineState? = nil
-        for v in values { state = update(state, value: v, cfg: cfg) }
+        for v in values { state = update(state, value: v, cfg: cfg, rejectHardOutliers: rejectHardOutliers) }
         if let s = state { return s }
         let seed = (cfg.minVal + cfg.maxVal) / 2.0
         return BaselineState(baseline: seed, spread: cfg.floorSpread, nValid: 0,

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ReadinessEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ReadinessEngine.swift
@@ -145,6 +145,7 @@ public enum ReadinessEngine {
             decimals: 0,
             higherIsBetter: true,
             logDomain: true,   // RD1: lnRMSSD — HRV is right-skewed
+            cfg: Baselines.readinessHRVLnCfg,   // RD2: ln-space spine, reject off
             goodText: "above your baseline - well recovered",
             neutralText: "in your normal range",
             watchText: "a touch below baseline",
@@ -159,6 +160,7 @@ public enum ReadinessEngine {
             unit: "bpm",
             decimals: 0,
             higherIsBetter: false,
+            cfg: Baselines.restingHRCfg,   // RD2: raw-bpm spine, reject off
             goodText: "at or below baseline",
             neutralText: "in your normal range",
             watchText: "running a little high",
@@ -232,6 +234,7 @@ public enum ReadinessEngine {
     private static func zSignal(value: Double?, baseline: [Double],
                                 key: String, label: String, unit: String, decimals: Int,
                                 higherIsBetter: Bool, logDomain: Bool = false,
+                                cfg: MetricCfg,
                                 goodText: String, neutralText: String,
                                 watchText: String, badText: String) -> Signal? {
         guard let v = value, baseline.count >= minBaseline else { return nil }
@@ -243,9 +246,20 @@ public enum ReadinessEngine {
         // outlier-inflated arithmetic mean.
         let tv = logDomain ? log(max(v, 1.0)) : v
         let tb = logDomain ? baseline.map { log(max($0, 1.0)) } : baseline
-        guard let m = mean(tb), let sd = sampleSD(tb), sd > 0 else { return nil }
+        // RD2: fold the trailing baseline through the shared Winsorized-EWMA spine — recency-weighted,
+        // σ-floored (a tight baseline can't saturate the z), and Winsor-clamped so a single freak night
+        // is DAMPED not folded raw — instead of a flat mean + sample SD. Hard-outlier REJECTION is off
+        // (`rejectHardOutliers: false`): a re-folded trailing window must ADAPT to a recent sustained
+        // shift (fitness change / device swap) rather than reject the new normal as a run of outliers —
+        // the window-fold vs incremental-fold distinction, validated on real HRV history. `cfg` is in
+        // the SAME space as `tb` (ln for HRV, linear for RHR); center + spread come back σ-floored.
+        let state = Baselines.foldHistory(tb.map { Optional($0) }, cfg: cfg, rejectHardOutliers: false)
+        guard state.usable else { return nil }
+        let sigma = max(1.253 * state.spread, 1e-9)   // robust σ from the EWMA-abs-dev spread
+        guard sigma > 0 else { return nil }
+        let m = state.baseline
         // Orient z so positive always means "better".
-        let z = (higherIsBetter ? (tv - m) : (m - tv)) / sd
+        let z = (higherIsBetter ? (tv - m) : (m - tv)) / sigma
         let flag: Flag
         let text: String
         switch z {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RD1LogDomainTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RD1LogDomainTests.swift
@@ -23,8 +23,12 @@ final class RD1LogDomainTests: XCTestCase {
         days.append(d(29, hrv: 50, rhr: 52))   // today: a typical night
 
         let hrv = ReadinessEngine.evaluate(days: days).signals.first { $0.key == "hrv" }
-        // Log domain baselines against the geometric mean (51). Raw-ms z would report "50 vs 54 ms".
-        XCTAssertEqual(hrv?.evidence, "50 vs 51 ms")
+        // Log domain baselines against a GEOMETRIC center (49 ms), well below the arithmetic mean (54)
+        // a raw-ms z would report. Under RD2 the center is the recency-weighted, Winsor-clamped EWMA
+        // (Baselines spine, reject off): the 8 recent 85 ms nights nudge it up from the 42 ms cluster
+        // but Winsorization caps their pull, so it lands at 49 — still geometric, not the tail-inflated
+        // arithmetic 54.
+        XCTAssertEqual(hrv?.evidence, "50 vs 49 ms")
         // 50 sits at the typical night → neutral, read against a representative (not tail-inflated) baseline.
         XCTAssertEqual(hrv?.flag, .neutral)
     }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RD2SpineTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RD2SpineTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import StrandAnalytics
+import WhoopStore
+
+/// RD2 — the readiness HRV/RHR baselines are folded through the shared Winsorized-EWMA spine
+/// (`Baselines.foldHistory`) instead of a naive mean + sample SD, in the WINDOW-FOLD mode
+/// (`rejectHardOutliers: false`). Chosen over the full incremental spine after replaying real HRV
+/// history: hard-outlier rejection is right for RecoveryScorer's incremental nightly fold but WRONG
+/// for a re-folded trailing window, where a recent sustained shift lands past the young grace period
+/// and would be rejected as a run of "outliers". Winsorization (kept) still damps single freak nights.
+final class RD2SpineTests: XCTestCase {
+
+    // MARK: - The spine capability itself: reject on (incremental) vs off (window-fold)
+
+    func testWindowFoldAdaptsToSustainedShiftThatIncrementalRejects() {
+        // 20 settled nights at 140 ms, then 10 recent nights at 85 ms (a real sustained shift). The
+        // incremental fold (reject on) discards the recent block as >5σ outliers and stays anchored
+        // high; the window fold (reject off) follows the shift down. This is the exact readiness
+        // failure mode (device swap / supplement onset) the mode switch fixes.
+        let vals: [Double?] = Array(repeating: 140.0, count: 20) + Array(repeating: 85.0, count: 10)
+        let rejectOn = Baselines.foldHistory(vals, cfg: Baselines.hrvCfg, rejectHardOutliers: true)
+        let rejectOff = Baselines.foldHistory(vals, cfg: Baselines.hrvCfg, rejectHardOutliers: false)
+        XCTAssertGreaterThan(rejectOn.baseline, 130, "hard-reject keeps the stale high baseline")
+        XCTAssertLessThan(rejectOff.baseline, rejectOn.baseline - 10,
+                          "window-fold adapts meaningfully toward the recent sustained level")
+    }
+
+    func testSingleFreakNightIsDampedNotRejectedInWindowFold() {
+        // One freak sensor night in an otherwise stable baseline. With reject OFF the freak is not
+        // discarded — but Winsorization still CLAMPS it, so it barely moves the center. (Contrast the
+        // sustained block above, which the same mode follows: single spike damped, sustained shift
+        // adapted — the whole point of Winsor-without-reject.)
+        let stable: [Double?] = Array(repeating: 90.0, count: 29)
+        let withFreak: [Double?] = stable + [180.0]
+        let base0 = Baselines.foldHistory(stable, cfg: Baselines.hrvCfg, rejectHardOutliers: false)
+        let base1 = Baselines.foldHistory(withFreak, cfg: Baselines.hrvCfg, rejectHardOutliers: false)
+        XCTAssertLessThan(abs(base1.baseline - base0.baseline), 8,
+                          "a single 2× freak night must be Winsor-damped, not swing the baseline")
+    }
+
+    // MARK: - Readiness end-to-end (ln-space HRV, reject off)
+
+    private func d(_ i: Int, hrv: Double?, rhr: Int?) -> DailyMetric {
+        DailyMetric(day: String(format: "2024-03-%02d", i), totalSleepMin: nil, efficiency: nil,
+                    deepMin: nil, remMin: nil, lightMin: nil, disturbances: nil, restingHr: rhr,
+                    avgHrv: hrv, recovery: nil, strain: 10, exerciseCount: nil,
+                    spo2Pct: nil, skinTempDevC: nil, respRateBpm: nil)
+    }
+
+    func testReadinessAdaptsToRecentSustainedHRVShift() {
+        // 12 old nights at 130 ms, then 18 recent nights settled at 85 ms (a sustained shift), today at
+        // the new normal 85. It must NOT read BAD — the window fold adapts. Under the incremental
+        // (reject-on) mode this exact case reads BAD (the recent block is rejected, baseline stuck at
+        // 130), which is the readiness regression RD2 exists to prevent.
+        var days: [DailyMetric] = []
+        for i in 1...12 { days.append(d(i, hrv: 130, rhr: 52)) }
+        for i in 13...30 { days.append(d(i, hrv: 85, rhr: 52)) }
+        days.append(d(31, hrv: 85, rhr: 52))   // today: the new normal
+        let hrv = ReadinessEngine.evaluate(days: days).signals.first { $0.key == "hrv" }
+        XCTAssertNotNil(hrv)
+        XCTAssertNotEqual(hrv?.flag, .bad,
+                          "today at the recent sustained normal must not read BAD (the reject-mode failure)")
+    }
+
+    func testGenuineLowStillFlagsAfterSpineAdoption() {
+        // Regression: the spine must not blunt a real drop. Stable ~95 ms baseline, today a clear 68 ms.
+        var days: [DailyMetric] = []
+        for i in 1...30 { days.append(d(i, hrv: i % 2 == 0 ? 97 : 93, rhr: 52)) }
+        days.append(d(31, hrv: 68, rhr: 52))
+        let hrv = ReadinessEngine.evaluate(days: days).signals.first { $0.key == "hrv" }
+        XCTAssertEqual(hrv?.flag, .bad, "a genuine ~28% HRV drop must still read BAD")
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/Baselines.kt
+++ b/android/app/src/main/java/com/noop/analytics/Baselines.kt
@@ -162,6 +162,18 @@ object Baselines {
             minVal = 0.0, maxVal = 100.0, floorSpread = 5.0,
             halfLifeB = 14.0, halfLifeS = 21.0,
         ),
+        // Readiness HRV baseline, folded in the LOG domain (ln ms) with hard-outlier rejection OFF
+        // (RD2 · the window-fold spine mode — see update's `rejectHardOutliers`). ReadinessEngine
+        // z-scores lnRMSSD (RD1: HRV is right-skewed), so these bounds/floor are in LN(ms) units — NOT
+        // the raw-ms "hrv" config above (which the RecoveryScorer folds linearly, untouched).
+        // minVal/maxVal = ln(8)/ln(250), the plausible HRV band in ln. floorSpread 0.08 (ln) sits just
+        // below a real wearer's own ln-HRV night-to-night spread (~0.10), so personal spread drives the
+        // z while an ultra-stable baseline is floored against saturation. Byte-identical to the Swift
+        // `readiness_hrv_ln` config.
+        "readiness_hrv_ln" to MetricCfg(
+            minVal = 2.079, maxVal = 5.521, floorSpread = 0.08,
+            halfLifeB = 14.0, halfLifeS = 21.0,
+        ),
     )
 
     /** Convenience accessor for the standard HRV config. */
@@ -169,6 +181,10 @@ object Baselines {
 
     /** Convenience accessor for the standard resting-HR config. */
     val restingHRCfg: MetricCfg get() = metricCfg.getValue("resting_hr")
+
+    /** Readiness HRV baseline config — folded in the LOG domain (ln ms) with hard-outlier rejection
+     *  OFF. See the `readiness_hrv_ln` comment above; distinct from the raw-ms [hrvCfg]. */
+    val readinessHRVLnCfg: MetricCfg get() = metricCfg.getValue("readiness_hrv_ln")
 
     /** Convenience accessor for the standard respiration config. */
     val respCfg: MetricCfg get() = metricCfg.getValue("resp")
@@ -234,8 +250,17 @@ object Baselines {
      * - `value == null` or out-of-range: skip-and-hold (carry forward).
      * - hard outlier (> HARD_OUTLIER_K × spread): seen but not folded.
      * - otherwise: Winsorized EWMA center + EWMA-abs-dev spread update.
+     *
+     * `rejectHardOutliers` (default true) can turn the hard-outlier gate OFF for a TRAILING-WINDOW
+     * re-fold — where the same window is re-folded every call and a *recent sustained* shift lands at
+     * the window's end (past the young grace period), so rejection would discard a real new normal as a
+     * string of "outliers" (Readiness's device-swap / supplement-onset failure mode). With it off the
+     * Winsorization below STILL damps a single freak night (clamped, not folded raw) but a sustained
+     * shift is followed instead of rejected — the incremental-fold (reject on, RecoveryScorer) vs
+     * window-fold (reject off, Readiness) distinction. Byte-identical to the Swift `rejectHardOutliers`.
      */
-    fun update(state: BaselineState?, value: Double?, cfg: MetricCfg): BaselineState {
+    fun update(state: BaselineState?, value: Double?, cfg: MetricCfg,
+               rejectHardOutliers: Boolean = true): BaselineState {
         val lb = lambda(cfg.halfLifeB)
         val ls = lambda(cfg.halfLifeS)
 
@@ -284,7 +309,7 @@ object Baselines {
         // Suspending this during early life is the core anti-anchoring fix — a high seed with a
         // floor-tight spread would otherwise reject the user's real, lower readings as "outliers"
         // (a true 54ms vs an anchored ~90ms baseline is >5× the floor spread).
-        if (state.nValid >= minNightsSeed && !isYoung) {
+        if (rejectHardOutliers && state.nValid >= minNightsSeed && !isYoung) {
             val dev = abs(value - state.baseline)
             if (dev > hardOutlierK * state.spread) {
                 return BaselineState(
@@ -330,9 +355,10 @@ object Baselines {
      * Replay an ordered sequence of nightly values (oldest first) to build state.
      * `null` entries are treated as missing nights (skip-and-hold).
      */
-    fun foldHistory(values: List<Double?>, cfg: MetricCfg): BaselineState {
+    fun foldHistory(values: List<Double?>, cfg: MetricCfg,
+                    rejectHardOutliers: Boolean = true): BaselineState {
         var state: BaselineState? = null
-        for (v in values) state = update(state, v, cfg)
+        for (v in values) state = update(state, v, cfg, rejectHardOutliers)
         state?.let { return it }
         val seed = (cfg.minVal + cfg.maxVal) / 2.0
         return BaselineState(

--- a/android/app/src/main/java/com/noop/analytics/ReadinessEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/ReadinessEngine.kt
@@ -176,6 +176,7 @@ object ReadinessEngine {
             key = "hrv", label = "HRV",
             unit = "ms", decimals = 0,
             higherIsBetter = true,
+            cfg = Baselines.readinessHRVLnCfg,   // RD2: ln-space spine, reject off
             logDomain = true,   // RD1: lnRMSSD — HRV is right-skewed
             goodText = "above your baseline - well recovered",
             neutralText = "in your normal range",
@@ -191,6 +192,7 @@ object ReadinessEngine {
             key = "rhr", label = "Resting HR",
             unit = "bpm", decimals = 0,
             higherIsBetter = false,
+            cfg = Baselines.restingHRCfg,   // RD2: raw-bpm spine, reject off
             goodText = "at or below baseline",
             neutralText = "in your normal range",
             watchText = "running a little high",
@@ -289,6 +291,7 @@ object ReadinessEngine {
     private fun zSignal(
         value: Double?, baseline: List<Double>,
         key: String, label: String, unit: String, decimals: Int, higherIsBetter: Boolean,
+        cfg: MetricCfg,
         logDomain: Boolean = false,
         goodText: String, neutralText: String,
         watchText: String, badText: String,
@@ -302,11 +305,21 @@ object ReadinessEngine {
         // outlier-inflated arithmetic mean.
         val tv = if (logDomain) ln(maxOf(value, 1.0)) else value
         val tb = if (logDomain) baseline.map { ln(maxOf(it, 1.0)) } else baseline
-        val m = mean(tb) ?: return null
-        val sd = sampleSD(tb) ?: return null
-        if (sd <= 0) return null
+        // RD2: fold the trailing baseline through the shared Winsorized-EWMA spine — recency-weighted,
+        // σ-floored (a tight baseline can't saturate the z), and Winsor-clamped so a single freak night
+        // is DAMPED not folded raw — instead of a flat mean + sample SD. Hard-outlier REJECTION is off
+        // (`rejectHardOutliers = false`): a re-folded trailing window must ADAPT to a recent sustained
+        // shift (fitness change / device swap) rather than reject the new normal as a run of outliers —
+        // the window-fold vs incremental-fold distinction, validated on real HRV history. `cfg` is in
+        // the SAME space as `tb` (ln for HRV, linear for RHR); center + spread come back σ-floored.
+        // Mirrors Swift ReadinessEngine.zSignal.
+        val state = Baselines.foldHistory(tb, cfg, rejectHardOutliers = false)
+        if (!state.usable) return null
+        val sigma = maxOf(1.253 * state.spread, 1e-9)   // robust σ from the EWMA-abs-dev spread
+        if (sigma <= 0) return null
+        val m = state.baseline
         // Orient z so positive always means "better".
-        val z = (if (higherIsBetter) (tv - m) else (m - tv)) / sd
+        val z = (if (higherIsBetter) (tv - m) else (m - tv)) / sigma
         val flag: Flag
         val text: String
         when {

--- a/android/app/src/test/java/com/noop/analytics/RD1LogDomainTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RD1LogDomainTest.kt
@@ -34,8 +34,12 @@ class RD1LogDomainTest {
         days.add(d(29, hrv = 50.0, rhr = 52))   // today: a typical night
 
         val hrv = ReadinessEngine.evaluate(days).signals.first { it.key == "hrv" }
-        // Log domain baselines against the geometric mean (51). Raw-ms z would report "50 vs 54 ms".
-        assertEquals("50 vs 51 ms", hrv.evidence)
+        // Log domain baselines against a GEOMETRIC center (49 ms), well below the arithmetic mean (54)
+        // a raw-ms z would report. Under RD2 the center is the recency-weighted, Winsor-clamped EWMA
+        // (Baselines spine, reject off): the 8 recent 85 ms nights nudge it up from the 42 ms cluster
+        // but Winsorization caps their pull, so it lands at 49 — still geometric, not the tail-inflated
+        // arithmetic 54. Byte-identical to the Swift RD1LogDomainTests value.
+        assertEquals("50 vs 49 ms", hrv.evidence)
         // 50 sits at the typical night → neutral, read against a representative (not tail-inflated) baseline.
         assertEquals(ReadinessEngine.Flag.NEUTRAL, hrv.flag)
     }

--- a/android/app/src/test/java/com/noop/analytics/RD2SpineTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RD2SpineTest.kt
@@ -1,0 +1,95 @@
+package com.noop.analytics
+
+import com.noop.data.DailyMetric
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+
+/**
+ * Faithful Kotlin port of
+ * Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RD2SpineTests.swift (RD2, PR #469).
+ *
+ * The readiness HRV/RHR baselines are folded through the shared Winsorized-EWMA spine
+ * (Baselines.foldHistory) instead of a naive mean + sample SD, in the WINDOW-FOLD mode
+ * (rejectHardOutliers = false). Hard-outlier rejection is right for RecoveryScorer's incremental
+ * nightly fold but WRONG for a re-folded trailing window, where a recent sustained shift lands past
+ * the young grace period and would be rejected as a run of "outliers". Winsorization (kept) still
+ * damps single freak nights. Same fixtures and thresholds as the Swift test.
+ */
+class RD2SpineTest {
+
+    // The spine capability itself: reject on (incremental) vs off (window-fold) -------------------
+
+    @Test
+    fun windowFoldAdaptsToSustainedShiftThatIncrementalRejects() {
+        // 20 settled nights at 140 ms, then 10 recent nights at 85 ms (a real sustained shift). The
+        // incremental fold (reject on) discards the recent block as >5σ outliers and stays anchored
+        // high; the window fold (reject off) follows the shift down. This is the exact readiness
+        // failure mode (device swap / supplement onset) the mode switch fixes.
+        val vals: List<Double?> = List(20) { 140.0 } + List(10) { 85.0 }
+        val rejectOn = Baselines.foldHistory(vals, Baselines.hrvCfg, rejectHardOutliers = true)
+        val rejectOff = Baselines.foldHistory(vals, Baselines.hrvCfg, rejectHardOutliers = false)
+        assertTrue("hard-reject keeps the stale high baseline", rejectOn.baseline > 130)
+        assertTrue(
+            "window-fold adapts meaningfully toward the recent sustained level",
+            rejectOff.baseline < rejectOn.baseline - 10,
+        )
+    }
+
+    @Test
+    fun singleFreakNightIsDampedNotRejectedInWindowFold() {
+        // One freak sensor night in an otherwise stable baseline. With reject OFF the freak is not
+        // discarded — but Winsorization still CLAMPS it, so it barely moves the center. (Contrast the
+        // sustained block above, which the same mode follows: single spike damped, sustained shift
+        // adapted — the whole point of Winsor-without-reject.)
+        val stable: List<Double?> = List(29) { 90.0 }
+        val withFreak: List<Double?> = stable + listOf(180.0)
+        val base0 = Baselines.foldHistory(stable, Baselines.hrvCfg, rejectHardOutliers = false)
+        val base1 = Baselines.foldHistory(withFreak, Baselines.hrvCfg, rejectHardOutliers = false)
+        assertTrue(
+            "a single 2× freak night must be Winsor-damped, not swing the baseline",
+            abs(base1.baseline - base0.baseline) < 8,
+        )
+    }
+
+    // Readiness end-to-end (ln-space HRV, reject off) ---------------------------------------------
+
+    private fun d(i: Int, hrv: Double?, rhr: Int?): DailyMetric = DailyMetric(
+        deviceId = "test",
+        day = "2024-03-%02d".format(i),
+        restingHr = rhr,
+        avgHrv = hrv,
+        strain = 10.0,
+    )
+
+    @Test
+    fun readinessAdaptsToRecentSustainedHRVShift() {
+        // 12 old nights at 130 ms, then 18 recent nights settled at 85 ms (a sustained shift), today at
+        // the new normal 85. It must NOT read BAD — the window fold adapts. Under the incremental
+        // (reject-on) mode this exact case reads BAD (the recent block is rejected, baseline stuck at
+        // 130), which is the readiness regression RD2 exists to prevent.
+        val days = mutableListOf<DailyMetric>()
+        for (i in 1..12) days.add(d(i, hrv = 130.0, rhr = 52))
+        for (i in 13..30) days.add(d(i, hrv = 85.0, rhr = 52))
+        days.add(d(31, hrv = 85.0, rhr = 52))   // today: the new normal
+        val hrv = ReadinessEngine.evaluate(days).signals.firstOrNull { it.key == "hrv" }
+        assertNotNull(hrv)
+        assertNotEquals(
+            "today at the recent sustained normal must not read BAD (the reject-mode failure)",
+            ReadinessEngine.Flag.BAD, hrv!!.flag,
+        )
+    }
+
+    @Test
+    fun genuineLowStillFlagsAfterSpineAdoption() {
+        // Regression: the spine must not blunt a real drop. Stable ~95 ms baseline, today a clear 68 ms.
+        val days = mutableListOf<DailyMetric>()
+        for (i in 1..30) days.add(d(i, hrv = if (i % 2 == 0) 97.0 else 93.0, rhr = 52))
+        days.add(d(31, hrv = 68.0, rhr = 52))
+        val hrv = ReadinessEngine.evaluate(days).signals.firstOrNull { it.key == "hrv" }
+        assertEquals("a genuine ~28% HRV drop must still read BAD", ReadinessEngine.Flag.BAD, hrv?.flag)
+    }
+}


### PR DESCRIPTION
Rebase of #469 (@vishk23) down to just the RD2 readiness window-fold, **plus the Kotlin twin** that closes its parity gap. The fork branch could not be pushed to directly (maintainer-edit push 403), so this carries @vishk23's Swift commit unchanged in authorship and adds the Android twin on top.

Now that #456 (Wave 0) has landed, this drops #456's duplicated commits — the diff is just RD2.

### Swift (unchanged from #469, @vishk23)
`ReadinessEngine` z-scored HRV/RHR against a naive mean + sample SD; a single freak night inflates that SD (under-flags a real drop for weeks) and a tight baseline saturates the z. This folds the trailing baseline through the shared Winsorized-EWMA spine (`Baselines`) in a **window-fold mode**: `rejectHardOutliers` (default `true` → RecoveryScorer byte-identical) is turned **off** for readiness, so Winsorization still damps a single freak night but a *sustained* shift (device swap / fitness change) is followed instead of rejected. HRV folds in the log domain via the new `readiness_hrv_ln` config.

### Kotlin twin (new — @ryanbr, closes the parity gap)
The original #469 was Swift-only, so Android readiness couldn't adapt to a sustained shift the way iOS does — an analytics divergence. This ports it faithfully:
- `Baselines.kt`: `rejectHardOutliers` flag on `update()`/`foldHistory()` (default true, byte-identical), gating the hard-outlier block; `readiness_hrv_ln` config + `readinessHRVLnCfg` accessor.
- `ReadinessEngine.kt`: `zSignal` folds through the spine (reject off), `sigma = max(1.253 * spread, 1e-9)`, same z thresholds/evidence.
- `RD2SpineTest.kt`: transcribes the 4 Swift tests; `RD1LogDomainTest.kt` geometric center `51 → 49 ms` under the Winsor-EWMA fold — **byte-identical to the Swift value**.

### Validation
- **Android: 3831 tests, 0 failures** (full `testFullDebugUnitTest`) — the `rejectHardOutliers` default preserved every existing `Baselines`/`RecoveryScorer`/HRV-recalibration test.
- Swift RD2 tests run under swift-packages CI here. RD2 touches only `Packages/StrandAnalytics` (no app-target Swift), so no app-build gate is required.

Closes #469.
