### PR TITLE
feat(oura): session-identity reconciler for #1284 residual 3 (pure core, draft)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/OuraSessionReconciler.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraSessionReconciler.swift
@@ -86,6 +86,12 @@ public enum OuraSessionReconciler {
     ///   (ties break toward `new`, so the re-anchor mode collapses to the latest/refined onset).
     /// - otherwise a stored same-session is fuller ⇒ `.skip` `new`.
     /// - no same-session ⇒ `.insert` (a distinct session — e.g. a nap hours away).
+    ///
+    /// Known limitation (not seen in the corpus, requires an implausible shape): a `new` that reaches
+    /// within `mergeGapS` of TWO mutually-distinct stored sessions AND is fuller than both would
+    /// `.replace` them both — merging a nap and a night. That needs a single session spanning the
+    /// nap→night gap and longer than the night, which Oura hypnograms don't produce; if a hardware
+    /// capture ever shows it, gate `.replace` on the matched set being mutually same-session too.
     public static func reconcile(new: SessionWindow,
                                  existing: [SessionWindow],
                                  mergeGapS: Int = defaultMergeGapSeconds) -> Decision {

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraSessionReconciler.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraSessionReconciler.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// Pure session-identity reconciler for the Oura live hypnogram path (#1284 residual 3).
+///
+/// THE PROBLEM. `OuraLiveSource.persistHypnogramBurst` sets a session's `startTs` from the matched
+/// `0x49` sleep-summary onset and banks under `PK = (deviceId, startTs)`. The ring serves more than
+/// one decode of the same night — measured by @pipiche38 over four nights — in two distinct modes:
+///
+///   • **Re-anchor** (08-12/13): the *same* hypnogram laid backwards from two different `0x49` onsets,
+///     boundary-for-boundary identical, offset by a fixed lag (554 s on that night). Two onsets ⇒ two
+///     `startTs` ⇒ two rows.
+///   • **Partial drain** (08-13/14): a genuinely shorter, divergent decode from an earlier partial
+///     burst, with its OWN `0x49` anchor (494 min/89 seg vs 234 min/35 seg, diverging at segment 5).
+///
+/// `PK=(deviceId,startTs)` mints a second row in both modes; the #899 heal only cleans up afterward.
+///
+/// THE FIX (validated against @pipiche38's corpus — option (2) collapses 4/4 nights, the 30-min grid
+/// only 1/4). Group a ring's sessions by the **noon-anchored sleep-day** (`date(startTs_local + 12h)`),
+/// then within a day treat two sessions as the SAME session when they overlap or sit within
+/// `mergeGapS` (≈60 min) of each other — and keep the FULLER one (the completeness guard, which is what
+/// actually adjudicates the partial-drain mode; the fuller row is the WHOOP-matching one on every night
+/// in the corpus). Sessions further apart than `mergeGapS` on the same sleep-day are DISTINCT (a genuine
+/// afternoon nap is hours from that night's sleep) and each keeps its own row.
+///
+/// Why noon-anchor and not plain wake-day: on 08-10/11 the 40-min fragment `22:09:40 → 22:49:40` ENDS
+/// before midnight, so its wake-day (Aug 10) differs from the night it belongs to (Aug 11); the noon
+/// anchor maps both fragment and full night to the same sleep-day. Why not a grid: two starts 6¼ min
+/// apart (08-11/12, 22:26 vs 22:32) straddle a 30-min boundary and fail to collapse, and a grid spends
+/// every night's bedtime precision — the precision that let 08-13/14's window be checked against WHOOP
+/// to −10 s/+50 s. Proximity needs no estimate of the jitter it corrects (242 s healthy … 2469 s worst).
+///
+/// This type is PURE (no store, no BLE, no CoreBluetooth) so the decision is unit-testable headlessly on
+/// both platforms against the measured nights. The caller (`OuraLiveSource`) supplies the day's already
+/// persisted sessions (read from the DB at persist time — the same read that lets the check see
+/// cross-connection duplicates, which a per-connection in-memory list cannot) and acts on the decision.
+/// Byte-identical twin: Kotlin `OuraSessionReconciler`.
+public enum OuraSessionReconciler {
+
+    /// A persisted (or about-to-persist) Oura sleep session, reduced to the fields the reconciler needs.
+    /// `codeCount` is the number of laid 30-s stage epochs — the completeness signal (more codes = a
+    /// fuller drain of the same night). Ties break toward the NEW session (see `reconcile`).
+    public struct SessionWindow: Equatable, Sendable {
+        public let startTs: Int
+        public let endTs: Int
+        public let codeCount: Int
+        public init(startTs: Int, endTs: Int, codeCount: Int) {
+            self.startTs = startTs
+            self.endTs = endTs
+            self.codeCount = codeCount
+        }
+    }
+
+    /// What the caller should do with the new session relative to the day's existing rows.
+    public enum Decision: Equatable, Sendable {
+        /// No existing session is the same as the new one — persist it as a fresh row.
+        case insert
+        /// An existing same-session row is at least as complete — drop the new one, keep what's stored.
+        case skip
+        /// The new session is the fullest decode of a same-session it collides with — persist it and
+        /// delete the superseded rows at these `startTs` keys (the earlier/shorter duplicates).
+        case replace(supersededStartTs: [Int])
+    }
+
+    /// Default same-session proximity: sessions within this many seconds (or overlapping) are the same
+    /// night's sleep; further apart on the same sleep-day is a distinct session (nap). 60 min clears the
+    /// widest measured duplicate gap (2469 s) with margin and is far below any real nap-to-sleep gap.
+    public static let defaultMergeGapSeconds = 3600
+
+    /// The noon-anchored sleep-day integer (days since the Unix epoch) a session belongs to:
+    /// `date(startTs_local + 12h)`. Sessions sharing this value are candidates to be the same night;
+    /// it is the grouping key the caller uses to read "this night's" existing rows. `tzOffsetSeconds`
+    /// is the wearer's UTC offset at the session (e.g. +7200 for CEST) — the day boundary is LOCAL noon,
+    /// so a UTC-only bucket would rebucket evening sleep across the date line.
+    public static func noonAnchoredSleepDay(startTs: Int, tzOffsetSeconds: Int) -> Int {
+        // floorDiv so pre-1970 / negative-offset instants still floor toward the earlier day.
+        let local = startTs + tzOffsetSeconds + 12 * 3600
+        return floorDiv(local, 86_400)
+    }
+
+    /// Decide how to persist `new` given the ring's already-stored sessions FOR THE SAME NOON-ANCHORED
+    /// SLEEP-DAY (`existing`). The caller must pass only same-sleep-day rows (it read them by
+    /// `noonAnchoredSleepDay`); this function does the proximity + completeness adjudication.
+    ///
+    /// - overlap OR gap < `mergeGapS` ⇒ same session as `new`.
+    /// - `new` at least as complete (`codeCount >=`) as every same-session it hits ⇒ `.replace` them
+    ///   (ties break toward `new`, so the re-anchor mode collapses to the latest/refined onset).
+    /// - otherwise a stored same-session is fuller ⇒ `.skip` `new`.
+    /// - no same-session ⇒ `.insert` (a distinct session — e.g. a nap hours away).
+    public static func reconcile(new: SessionWindow,
+                                 existing: [SessionWindow],
+                                 mergeGapS: Int = defaultMergeGapSeconds) -> Decision {
+        let sameSession = existing.filter { isSameSession(new, $0, mergeGapS: mergeGapS) }
+        guard !sameSession.isEmpty else { return .insert }
+        let fullestStored = sameSession.map(\.codeCount).max() ?? 0
+        if new.codeCount >= fullestStored {
+            return .replace(supersededStartTs: sameSession.map(\.startTs))
+        }
+        return .skip
+    }
+
+    /// Two windows are the same session when they overlap, or the nearest edge gap between them is under
+    /// `mergeGapS`. Symmetric; either ordering of the pair gives the same answer.
+    static func isSameSession(_ a: SessionWindow, _ b: SessionWindow, mergeGapS: Int) -> Bool {
+        if a.startTs < b.endTs && b.startTs < a.endTs { return true }   // overlap
+        let gap = a.startTs >= b.endTs ? a.startTs - b.endTs : b.startTs - a.endTs
+        return gap < mergeGapS
+    }
+
+    /// Floor division toward negative infinity (Swift `/` truncates toward zero), so the sleep-day is
+    /// correct for negative operands. Matches Kotlin `Math.floorDiv`.
+    static func floorDiv(_ a: Int, _ b: Int) -> Int {
+        let q = a / b
+        return (a % b != 0 && (a < 0) != (b < 0)) ? q - 1 : q
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraSessionReconciler.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraSessionReconciler.swift
@@ -104,6 +104,16 @@ public enum OuraSessionReconciler {
         return .skip
     }
 
+    /// The `[from, to]` startTs range the caller should read candidate sessions over, given the new
+    /// session's bounds. A hypnogram night is at most ~16 h and a same-session sits within `mergeGapS`,
+    /// so a stored session starting earlier than `from` or after `to` cannot be proximate to `new` —
+    /// `reconcile` would filter it out anyway. Read is proximity-scoped (a superset of the noon-anchored
+    /// sleep-day, and timezone-independent, so a mid-night travel offset change can't split the read).
+    public static func candidateReadWindow(newStartTs: Int, newEndTs: Int,
+                                           mergeGapS: Int = defaultMergeGapSeconds) -> (from: Int, to: Int) {
+        (from: newStartTs - 16 * 3600 - mergeGapS, to: newEndTs + mergeGapS)
+    }
+
     /// Two windows are the same session when they overlap, or the nearest edge gap between them is under
     /// `mergeGapS`. Symmetric; either ordering of the pair gives the same answer.
     static func isSameSession(_ a: SessionWindow, _ b: SessionWindow, mergeGapS: Int) -> Bool {

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraSessionReconcilerTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraSessionReconcilerTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import WhoopStore
+
+/// #1284 residual 3 — the reconciler on @pipiche38's four measured nights. Byte-identical twin of the
+/// Kotlin `OuraSessionReconcilerTest`. Every fixture reproduces the STRUCTURE she measured (overlap /
+/// gap / completeness ordering / noon-vs-midnight day), not exact wall-clock, so the assertions are the
+/// design claims: option (2) collapses all four nights to one row, the nap stays separate.
+final class OuraSessionReconcilerTests: XCTestCase {
+
+    private let tz = 7200 // CEST, the corpus timezone (Europe/Paris, summer)
+    // A UTC instant that is a LOCAL midnight (utc + tz is a multiple of 86400), so localTs() reads cleanly.
+    private var localMidnightUtc: Int { 86_400 * 20_670 - tz }
+
+    /// Unix seconds for a local wall-clock time on day `d` (days after the reference local midnight).
+    private func localTs(_ d: Int, _ h: Int, _ m: Int, _ s: Int) -> Int {
+        localMidnightUtc + d * 86_400 + h * 3600 + m * 60 + s
+    }
+
+    /// codeCount ~ 30-s epochs, the completeness signal (a fuller drain of the same night has more).
+    private func win(_ start: Int, _ end: Int) -> OuraSessionReconciler.SessionWindow {
+        .init(startTs: start, endTs: end, codeCount: (end - start) / 30)
+    }
+
+    /// Replay a persist ORDER through the reconciler against the growing DB; return the final rows.
+    private func simulate(_ order: [OuraSessionReconciler.SessionWindow]) -> [OuraSessionReconciler.SessionWindow] {
+        var db: [OuraSessionReconciler.SessionWindow] = []
+        for s in order {
+            switch OuraSessionReconciler.reconcile(new: s, existing: db) {
+            case .insert: db.append(s)
+            case .skip: break
+            case .replace(let superseded):
+                db.removeAll { superseded.contains($0.startTs) }
+                db.append(s)
+            }
+        }
+        return db
+    }
+
+    private func day(_ ts: Int) -> Int { OuraSessionReconciler.noonAnchoredSleepDay(startTs: ts, tzOffsetSeconds: tz) }
+    private func midnightDay(_ ts: Int) -> Int { OuraSessionReconciler.floorDiv(ts + tz, 86_400) }
+
+    // Night 08-12/13 — mode 1 (re-anchor): same hypnogram at 3 onsets, all overlapping.
+    func testMode1ReAnchorCollapsesToOneRow() {
+        let row1 = win(localTs(0, 4, 40, 55), localTs(0, 6, 50, 55)) // 130 min, fullest
+        let row2 = win(localTs(0, 4, 50, 9), localTs(0, 6, 48, 9))   // 118 min
+        let row3 = win(localTs(0, 6, 34, 9), localTs(0, 6, 48, 9))   // 14 min
+        XCTAssertEqual(day(row1.startTs), day(row2.startTs))
+        XCTAssertEqual(day(row1.startTs), day(row3.startTs))
+        let db = simulate([row3, row2, row1]) // arrive shortest-first, worst case
+        XCTAssertEqual(db.count, 1, "mode-1 must collapse to one row")
+        XCTAssertEqual(db.first?.startTs, row1.startTs, "the fullest decode survives")
+    }
+
+    // Night 08-13/14 — mode 2 (partial drain): B nested in A, A genuinely fuller.
+    func testMode2PartialDrainCompletenessGuardKeepsFuller() {
+        let rowA = win(1786657310, 1786657310 + 494 * 60) // 494 min / 988 codes
+        let rowB = win(1786657552, 1786657552 + 234 * 60) // 234 min / 468 codes, inside A
+        XCTAssertTrue(rowB.startTs >= rowA.startTs - 3600 && rowB.endTs <= rowA.endTs, "B is inside A")
+        XCTAssertEqual(simulate([rowB, rowA]).first?.startTs, rowA.startTs)
+        XCTAssertEqual(simulate([rowA, rowB]).first?.startTs, rowA.startTs)
+        XCTAssertEqual(OuraSessionReconciler.reconcile(new: rowB, existing: [rowA]), .skip)
+        XCTAssertEqual(OuraSessionReconciler.reconcile(new: rowA, existing: [rowB]), .replace(supersededStartTs: [rowB.startTs]))
+    }
+
+    // Night 08-11/12 — the case against a 30-min grid (starts 6¼ min apart straddle 22:30).
+    func testGridStraddleStillCollapsesUnderProximity() {
+        let real = win(localTs(0, 22, 26, 14), localTs(1, 7, 6, 14))    // the real session, fuller
+        let nested = win(localTs(0, 22, 32, 30), localTs(0, 23, 50, 30)) // 78 min, nested
+        XCTAssertTrue((1...3600).contains(nested.startTs - real.startTs))
+        XCTAssertEqual(simulate([nested, real]).count, 1)
+    }
+
+    // Night 08-10/11 — fragment ENDS before midnight: noon-anchor groups it, wake-day would not.
+    func testFragmentEndingBeforeMidnightSharesNoonSleepDayNotWakeDay() {
+        let fragment = win(localTs(0, 22, 9, 40), localTs(0, 22, 49, 40)) // ends 22:49, before midnight
+        let main = win(localTs(0, 22, 50, 49), localTs(1, 7, 30, 49))
+        XCTAssertEqual(day(fragment.startTs), day(main.startTs))
+        // The WAKE-day (the day each session ENDS) differs — the wake-day bug the noon anchor fixes.
+        XCTAssertNotEqual(midnightDay(fragment.endTs), midnightDay(main.endTs))
+        XCTAssertEqual(simulate([fragment, main]).count, 1)
+        XCTAssertEqual(simulate([fragment, main]).first?.startTs, main.startTs)
+    }
+
+    // Night 08-09 — a real afternoon nap shares the sleep-day with the night but must stay separate.
+    func testNapSharesSleepDayButStaysDistinct() {
+        let nap = win(localTs(0, 14, 24, 4), localTs(0, 14, 46, 4))     // 22 min afternoon nap
+        let night = win(localTs(0, 22, 23, 7), localTs(1, 6, 30, 0))
+        XCTAssertEqual(day(nap.startTs), day(night.startTs), "nap and night share the noon-anchored sleep-day")
+        XCTAssertEqual(simulate([nap, night]).count, 2)
+        XCTAssertEqual(OuraSessionReconciler.reconcile(new: night, existing: [nap]), .insert)
+    }
+
+    func testSameConnectionRepeatOfIdenticalWindowIsIdempotent() {
+        let s = win(localTs(0, 23, 0, 0), localTs(1, 7, 0, 0))
+        XCTAssertEqual(simulate([s, s, s]).count, 1, "re-persisting the exact same window keeps one row")
+    }
+}

--- a/Strand/BLE/SourceCoordinator.swift
+++ b/Strand/BLE/SourceCoordinator.swift
@@ -356,11 +356,40 @@ final class SourceCoordinator: ObservableObject {
             persist: { [storeHandle] streams in
                 Task { if let store = await storeHandle() { _ = try? await store.insert(streams, deviceId: id) } }
             },
-            persistSleepSession: { [storeHandle] session in
+            persistSleepSession: { [storeHandle, straplog] session in
                 // The ring-PROVIDED hypnogram night, upserted under the ring's OWN id (the imported/measured
                 // side, NOT the "-noop" computed sibling) so SleepMerge's imported-over-computed rule makes
                 // Oura's SleepNet staging win over NOOP's sparse-motion computed night (#325).
-                Task { if let store = await storeHandle() { _ = try? await store.upsertSleepSessions([session], deviceId: id) } }
+                //
+                // #1284 residual 3: the ring serves >1 decode of one night (re-anchor / partial-drain), and
+                // PK=(deviceId,startTs) mints a row per 0x49 onset. Before banking, read the day's already
+                // stored sessions (the read that ALSO sees cross-connection duplicates a per-connection
+                // in-memory list can't, closing the #1297 blind spot) and let the pure reconciler decide:
+                // insert a distinct session, skip when a fuller same-night row is already stored, or replace
+                // the earlier/shorter duplicates with this fuller one. Validated on @pipiche38's four nights.
+                Task {
+                    guard let store = await storeHandle() else { return }
+                    let newWindow = OuraSessionReconciler.SessionWindow(
+                        startTs: session.startTs, endTs: session.endTs,
+                        codeCount: max(0, (session.endTs - session.startTs) / 30))
+                    let range = OuraSessionReconciler.candidateReadWindow(newStartTs: session.startTs, newEndTs: session.endTs)
+                    // Exclude a row at this exact startTs: a true re-persist is handled idempotently by the
+                    // upsert below, never a delete+insert (which would churn / drop userEdited).
+                    let candidates = ((try? await store.sleepSessions(deviceId: id, from: range.from, to: range.to, limit: 64)) ?? [])
+                        .filter { $0.startTs != session.startTs }
+                        .map { OuraSessionReconciler.SessionWindow(startTs: $0.startTs, endTs: $0.endTs,
+                                                                   codeCount: max(0, ($0.endTs - $0.startTs) / 30)) }
+                    switch OuraSessionReconciler.reconcile(new: newWindow, existing: candidates) {
+                    case .skip:
+                        straplog("Oura: reconcile(#1284) skip [\(session.startTs) → \(session.endTs)] - a fuller same-night session is already stored")
+                    case .insert:
+                        _ = try? await store.upsertSleepSessions([session], deviceId: id)
+                    case .replace(let superseded):
+                        for s in superseded { _ = try? await store.deleteSleepSession(deviceId: id, startTs: s) }
+                        _ = try? await store.upsertSleepSessions([session], deviceId: id)
+                        straplog("Oura: reconcile(#1284) replaced \(superseded.count) earlier duplicate row(s) with fuller [\(session.startTs) → \(session.endTs)]")
+                    }
+                }
             },
             log: straplog,
             onBattery: { [live] pct in live.setBattery(Double(pct)) },

--- a/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
+++ b/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
@@ -421,11 +421,45 @@ class SourceCoordinator(
                 // The ring-PROVIDED hypnogram night, upserted under the ring's OWN id (imported/measured
                 // side, NOT the "-noop" computed sibling) so mergeSleepRichness surfaces Oura's SleepNet
                 // staging over NOOP's sparse-motion computed night (#325).
+                //
+                // #1284 residual 3: the ring serves >1 decode of one night (re-anchor / partial-drain), and
+                // PK=(deviceId,startTs) mints a row per 0x49 onset. Before banking, read the day's already
+                // stored sessions (the read that ALSO sees cross-connection duplicates a per-connection
+                // in-memory list can't, closing the #1297 blind spot) and let the pure reconciler decide:
+                // insert a distinct session, skip when a fuller same-night row is already stored, or replace
+                // the earlier/shorter duplicates with this fuller one. Validated on @pipiche38's four nights.
                 scope.launch {
                     runCatching {
-                        repo.upsertSleepSessions(listOf(com.noop.data.SleepSession(
+                        val session = com.noop.data.SleepSession(
                             deviceId = deviceId, startTs = s.startTs, endTs = s.endTs,
-                            efficiency = s.efficiency, stagesJSON = s.stagesJson)))
+                            efficiency = s.efficiency, stagesJSON = s.stagesJson)
+                        val newWindow = com.noop.oura.OuraSessionReconciler.SessionWindow(
+                            startTs = s.startTs, endTs = s.endTs,
+                            codeCount = maxOf(0L, (s.endTs - s.startTs) / 30).toInt())
+                        val range = com.noop.oura.OuraSessionReconciler.candidateReadWindow(s.startTs, s.endTs)
+                        // Exclude a row at this exact startTs: a true re-persist is handled idempotently by the
+                        // upsert below, never a delete+insert (which would churn / drop userEdited).
+                        val candidates = repo.sleepSessions(deviceId, range.first, range.second, 64)
+                            .filter { it.startTs != s.startTs }
+                        val windows = candidates.map {
+                            com.noop.oura.OuraSessionReconciler.SessionWindow(
+                                startTs = it.startTs, endTs = it.endTs,
+                                codeCount = maxOf(0L, (it.endTs - it.startTs) / 30).toInt())
+                        }
+                        when (val d = com.noop.oura.OuraSessionReconciler.reconcile(newWindow, windows)) {
+                            is com.noop.oura.OuraSessionReconciler.Decision.Skip ->
+                                straplog("Oura: reconcile(#1284) skip [${s.startTs} -> ${s.endTs}] - a fuller same-night session is already stored")
+                            is com.noop.oura.OuraSessionReconciler.Decision.Insert ->
+                                repo.upsertSleepSessions(listOf(session))
+                            is com.noop.oura.OuraSessionReconciler.Decision.Replace -> {
+                                // Tombstone-free row delete (same as the #899 heal): removing a duplicate
+                                // whose canonical copy stays must NOT suppress the surviving night's re-detection.
+                                candidates.filter { it.startTs in d.supersededStartTs }
+                                    .forEach { repo.deleteSleepSessionRowOnly(it) }
+                                repo.upsertSleepSessions(listOf(session))
+                                straplog("Oura: reconcile(#1284) replaced ${d.supersededStartTs.size} earlier duplicate row(s) with fuller [${s.startTs} -> ${s.endTs}]")
+                            }
+                        }
                     }
                 }
             },

--- a/android/app/src/main/java/com/noop/oura/OuraSessionReconciler.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraSessionReconciler.kt
@@ -68,7 +68,13 @@ object OuraSessionReconciler {
      *  SLEEP-DAY ([existing]). The caller must pass only same-sleep-day rows; this does the proximity +
      *  completeness adjudication. Overlap OR gap < [mergeGapS] => same session; [new] at least as complete
      *  (`codeCount >=`) as every same-session it hits => Replace them (ties break toward [new]); else a
-     *  stored same-session is fuller => Skip; no same-session => Insert. */
+     *  stored same-session is fuller => Skip; no same-session => Insert.
+     *
+     *  Known limitation (not in the corpus, needs an implausible shape): a [new] that reaches within
+     *  [mergeGapS] of TWO mutually-distinct stored sessions AND is fuller than both would Replace them
+     *  both — merging a nap and a night. That needs one session spanning the nap->night gap and longer
+     *  than the night, which Oura hypnograms don't produce; if hardware ever shows it, gate Replace on
+     *  the matched set being mutually same-session too. */
     fun reconcile(
         new: SessionWindow,
         existing: List<SessionWindow>,

--- a/android/app/src/main/java/com/noop/oura/OuraSessionReconciler.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraSessionReconciler.kt
@@ -1,0 +1,94 @@
+package com.noop.oura
+
+/**
+ * Pure session-identity reconciler for the Oura live hypnogram path (#1284 residual 3).
+ *
+ * THE PROBLEM. `OuraLiveSource.persistHypnogramBurst` sets a session's `startTs` from the matched
+ * `0x49` sleep-summary onset and banks under `PK = (deviceId, startTs)`. The ring serves more than one
+ * decode of the same night — measured by @pipiche38 over four nights — in two distinct modes:
+ *
+ *   - Re-anchor (08-12/13): the same hypnogram laid backwards from two different `0x49` onsets,
+ *     boundary-for-boundary identical, offset by a fixed lag (554 s). Two onsets -> two startTs -> two rows.
+ *   - Partial drain (08-13/14): a genuinely shorter, divergent decode from an earlier partial burst,
+ *     with its OWN `0x49` anchor (494 min/89 seg vs 234 min/35 seg, diverging at segment 5).
+ *
+ * `PK=(deviceId,startTs)` mints a second row in both modes; the #899 heal only cleans up afterward.
+ *
+ * THE FIX (validated against the corpus — option (2) collapses 4/4 nights, the 30-min grid only 1/4).
+ * Group a ring's sessions by the noon-anchored sleep-day (`date(startTs_local + 12h)`), then within a
+ * day treat two sessions as the SAME session when they overlap or sit within `mergeGapS` (~60 min), and
+ * keep the FULLER one (the completeness guard, which adjudicates the partial-drain mode — the fuller row
+ * is the WHOOP-matching one on every measured night). Sessions further apart than `mergeGapS` on the
+ * same sleep-day are DISTINCT (an afternoon nap is hours from that night's sleep) and each keeps its row.
+ *
+ * Noon-anchor, not plain wake-day: on 08-10/11 the 40-min fragment 22:09:40 -> 22:49:40 ENDS before
+ * midnight, so its wake-day (Aug 10) differs from the night it belongs to (Aug 11); the noon anchor maps
+ * both to the same sleep-day. Not a grid: two starts 6.25 min apart straddle a 30-min boundary and fail
+ * to collapse, and a grid spends the bedtime precision that let 08-13/14 be checked against WHOOP to
+ * -10 s/+50 s. Proximity needs no estimate of the jitter it corrects (242 s healthy .. 2469 s worst).
+ *
+ * PURE (no store, no BLE) so the decision is unit-testable headlessly. The caller (`OuraLiveSource`)
+ * supplies the day's already-persisted sessions (read from the DB at persist time — the read that lets
+ * the check see cross-connection duplicates a per-connection list cannot) and acts on the decision.
+ * Byte-identical twin: Swift `OuraSessionReconciler`.
+ */
+object OuraSessionReconciler {
+
+    /** A persisted (or about-to-persist) Oura sleep session, reduced to the fields the reconciler needs.
+     *  `codeCount` is the number of laid 30-s stage epochs — the completeness signal. Ties break toward
+     *  the NEW session (see [reconcile]). */
+    data class SessionWindow(val startTs: Int, val endTs: Int, val codeCount: Int)
+
+    /** What the caller should do with the new session relative to the day's existing rows. */
+    sealed class Decision {
+        /** No existing session is the same as the new one — persist it as a fresh row. */
+        object Insert : Decision()
+        /** An existing same-session row is at least as complete — drop the new one, keep what's stored. */
+        object Skip : Decision()
+        /** The new session is the fullest decode of a same-session it collides with — persist it and
+         *  delete the superseded rows at these `startTs` keys (the earlier/shorter duplicates). */
+        data class Replace(val supersededStartTs: List<Int>) : Decision()
+    }
+
+    /** Default same-session proximity: within this many seconds (or overlapping) is the same night's
+     *  sleep; further apart on the same sleep-day is a distinct session (nap). 60 min clears the widest
+     *  measured duplicate gap (2469 s) with margin and is far below any real nap-to-sleep gap. */
+    const val defaultMergeGapSeconds = 3600
+
+    /** The noon-anchored sleep-day integer (days since the Unix epoch) a session belongs to:
+     *  `date(startTs_local + 12h)`. Sessions sharing this value are candidates to be the same night; it
+     *  is the grouping key the caller uses to read "this night's" existing rows. `tzOffsetSeconds` is the
+     *  wearer's UTC offset at the session — the day boundary is LOCAL noon. */
+    fun noonAnchoredSleepDay(startTs: Int, tzOffsetSeconds: Int): Int {
+        val local = startTs + tzOffsetSeconds + 12 * 3600
+        return Math.floorDiv(local, 86_400)
+    }
+
+    /** Decide how to persist [new] given the ring's already-stored sessions FOR THE SAME NOON-ANCHORED
+     *  SLEEP-DAY ([existing]). The caller must pass only same-sleep-day rows; this does the proximity +
+     *  completeness adjudication. Overlap OR gap < [mergeGapS] => same session; [new] at least as complete
+     *  (`codeCount >=`) as every same-session it hits => Replace them (ties break toward [new]); else a
+     *  stored same-session is fuller => Skip; no same-session => Insert. */
+    fun reconcile(
+        new: SessionWindow,
+        existing: List<SessionWindow>,
+        mergeGapS: Int = defaultMergeGapSeconds,
+    ): Decision {
+        val sameSession = existing.filter { isSameSession(new, it, mergeGapS) }
+        if (sameSession.isEmpty()) return Decision.Insert
+        val fullestStored = sameSession.maxOf { it.codeCount }
+        return if (new.codeCount >= fullestStored) {
+            Decision.Replace(sameSession.map { it.startTs })
+        } else {
+            Decision.Skip
+        }
+    }
+
+    /** Two windows are the same session when they overlap, or the nearest edge gap is under [mergeGapS].
+     *  Symmetric. */
+    internal fun isSameSession(a: SessionWindow, b: SessionWindow, mergeGapS: Int): Boolean {
+        if (a.startTs < b.endTs && b.startTs < a.endTs) return true // overlap
+        val gap = if (a.startTs >= b.endTs) a.startTs - b.endTs else b.startTs - a.endTs
+        return gap < mergeGapS
+    }
+}

--- a/android/app/src/main/java/com/noop/oura/OuraSessionReconciler.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraSessionReconciler.kt
@@ -37,7 +37,7 @@ object OuraSessionReconciler {
     /** A persisted (or about-to-persist) Oura sleep session, reduced to the fields the reconciler needs.
      *  `codeCount` is the number of laid 30-s stage epochs — the completeness signal. Ties break toward
      *  the NEW session (see [reconcile]). */
-    data class SessionWindow(val startTs: Int, val endTs: Int, val codeCount: Int)
+    data class SessionWindow(val startTs: Long, val endTs: Long, val codeCount: Int)
 
     /** What the caller should do with the new session relative to the day's existing rows. */
     sealed class Decision {
@@ -47,7 +47,7 @@ object OuraSessionReconciler {
         object Skip : Decision()
         /** The new session is the fullest decode of a same-session it collides with — persist it and
          *  delete the superseded rows at these `startTs` keys (the earlier/shorter duplicates). */
-        data class Replace(val supersededStartTs: List<Int>) : Decision()
+        data class Replace(val supersededStartTs: List<Long>) : Decision()
     }
 
     /** Default same-session proximity: within this many seconds (or overlapping) is the same night's
@@ -59,9 +59,9 @@ object OuraSessionReconciler {
      *  `date(startTs_local + 12h)`. Sessions sharing this value are candidates to be the same night; it
      *  is the grouping key the caller uses to read "this night's" existing rows. `tzOffsetSeconds` is the
      *  wearer's UTC offset at the session — the day boundary is LOCAL noon. */
-    fun noonAnchoredSleepDay(startTs: Int, tzOffsetSeconds: Int): Int {
+    fun noonAnchoredSleepDay(startTs: Long, tzOffsetSeconds: Int): Long {
         val local = startTs + tzOffsetSeconds + 12 * 3600
-        return Math.floorDiv(local, 86_400)
+        return Math.floorDiv(local, 86_400L)
     }
 
     /** Decide how to persist [new] given the ring's already-stored sessions FOR THE SAME NOON-ANCHORED
@@ -90,11 +90,18 @@ object OuraSessionReconciler {
         }
     }
 
+    /** The `[from, to]` startTs range the caller should read candidate sessions over, given the new
+     *  session's bounds. A hypnogram night is at most ~16 h and a same-session sits within [mergeGapS],
+     *  so a stored session outside this range cannot be proximate to `new`. Proximity-scoped (a superset
+     *  of the noon-anchored sleep-day, timezone-independent). */
+    fun candidateReadWindow(newStartTs: Long, newEndTs: Long, mergeGapS: Int = defaultMergeGapSeconds): Pair<Long, Long> =
+        Pair(newStartTs - 16 * 3600 - mergeGapS, newEndTs + mergeGapS)
+
     /** Two windows are the same session when they overlap, or the nearest edge gap is under [mergeGapS].
      *  Symmetric. */
     internal fun isSameSession(a: SessionWindow, b: SessionWindow, mergeGapS: Int): Boolean {
         if (a.startTs < b.endTs && b.startTs < a.endTs) return true // overlap
         val gap = if (a.startTs >= b.endTs) a.startTs - b.endTs else b.startTs - a.endTs
-        return gap < mergeGapS
+        return gap < mergeGapS.toLong()
     }
 }

--- a/android/app/src/test/java/com/noop/oura/OuraSessionReconcilerTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraSessionReconcilerTest.kt
@@ -1,0 +1,119 @@
+package com.noop.oura
+
+import com.noop.oura.OuraSessionReconciler.Decision
+import com.noop.oura.OuraSessionReconciler.SessionWindow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1284 residual 3 — the reconciler on @pipiche38's four measured nights. Byte-identical twin of the
+ * Swift `OuraSessionReconcilerTests`. Every fixture reproduces the STRUCTURE she measured (overlap /
+ * gap / completeness ordering / noon-vs-midnight day), not exact wall-clock, so the assertions are the
+ * design claims: option (2) collapses all four nights to one row, the nap stays separate.
+ */
+class OuraSessionReconcilerTest {
+
+    private val tz = 7200 // CEST, the corpus timezone (Europe/Paris, summer)
+    // A UTC instant that is a LOCAL midnight (utc + tz is a multiple of 86400), so localTs() reads cleanly.
+    private val localMidnightUtc = 86_400 * 20_670 - tz
+
+    /** Unix seconds for a local wall-clock time on day `d` (days after the reference local midnight). */
+    private fun localTs(d: Int, h: Int, m: Int, s: Int): Int =
+        localMidnightUtc + d * 86_400 + h * 3600 + m * 60 + s
+
+    /** codeCount ~ 30-s epochs, the completeness signal (a fuller drain of the same night has more). */
+    private fun win(start: Int, end: Int): SessionWindow =
+        SessionWindow(startTs = start, endTs = end, codeCount = (end - start) / 30)
+
+    /** Replay a persist ORDER through the reconciler against the growing DB; return the final rows. */
+    private fun simulate(order: List<SessionWindow>): List<SessionWindow> {
+        val db = mutableListOf<SessionWindow>()
+        for (s in order) {
+            when (val d = OuraSessionReconciler.reconcile(s, db.toList())) {
+                is Decision.Insert -> db.add(s)
+                is Decision.Skip -> {}
+                is Decision.Replace -> {
+                    db.removeAll { it.startTs in d.supersededStartTs }
+                    db.add(s)
+                }
+            }
+        }
+        return db
+    }
+
+    // ── Night 08-12/13 — mode 1 (re-anchor): same hypnogram at 3 onsets, all overlapping ──────────────
+    @Test
+    fun mode1_reAnchor_collapsesToOneRow() {
+        val row1 = win(localTs(0, 4, 40, 55), localTs(0, 6, 50, 55)) // 130 min, fullest
+        val row2 = win(localTs(0, 4, 50, 9), localTs(0, 6, 48, 9))  // 118 min
+        val row3 = win(localTs(0, 6, 34, 9), localTs(0, 6, 48, 9))  // 14 min
+        // All three overlap and share the noon-anchored sleep-day.
+        assertEquals(day(row1.startTs), day(row2.startTs))
+        assertEquals(day(row1.startTs), day(row3.startTs))
+        val db = simulate(listOf(row3, row2, row1)) // arrive shortest-first, worst case
+        assertEquals("mode-1 must collapse to one row", 1, db.size)
+        assertEquals("the fullest decode survives", row1.startTs, db[0].startTs)
+    }
+
+    // ── Night 08-13/14 — mode 2 (partial drain): B nested in A, A genuinely fuller ────────────────────
+    @Test
+    fun mode2_partialDrain_completenessGuardKeepsFuller() {
+        val rowA = win(1786657310, 1786657310 + 494 * 60) // 494 min / 988 codes
+        val rowB = win(1786657552, 1786657552 + 234 * 60) // 234 min / 468 codes, inside A
+        assertTrue("B is inside A", rowB.startTs >= rowA.startTs - 3600 && rowB.endTs <= rowA.endTs)
+        // Fuller-arrives-second and shorter-arrives-second both leave A standing.
+        assertEquals(rowA.startTs, simulate(listOf(rowB, rowA)).single().startTs)
+        assertEquals(rowA.startTs, simulate(listOf(rowA, rowB)).single().startTs)
+        // Direct: the guard skips the shorter and replaces for the fuller.
+        assertEquals(Decision.Skip, OuraSessionReconciler.reconcile(rowB, listOf(rowA)))
+        assertEquals(Decision.Replace(listOf(rowB.startTs)), OuraSessionReconciler.reconcile(rowA, listOf(rowB)))
+    }
+
+    // ── Night 08-11/12 — the case against a 30-min grid (starts 6¼ min apart straddle 22:30) ─────────
+    @Test
+    fun gridStraddle_stillCollapsesUnderProximity() {
+        val real = win(localTs(0, 22, 26, 14), localTs(1, 7, 6, 14))   // the real session, fuller
+        val nested = win(localTs(0, 22, 32, 30), localTs(0, 23, 50, 30)) // 78 min, nested
+        // 376 s apart — a 30-min grid puts 22:26→22:00 and 22:32→22:30 in different buckets (would NOT
+        // collapse); proximity does.
+        assertTrue(nested.startTs - real.startTs in 1..3600)
+        assertEquals(1, simulate(listOf(nested, real)).size)
+    }
+
+    // ── Night 08-10/11 — fragment ENDS before midnight: noon-anchor groups it, wake-day would not ────
+    @Test
+    fun fragmentEndingBeforeMidnight_sharesNoonSleepDayNotWakeDay() {
+        val fragment = win(localTs(0, 22, 9, 40), localTs(0, 22, 49, 40)) // ends 22:49, before midnight
+        val main = win(localTs(0, 22, 50, 49), localTs(1, 7, 30, 49))
+        // Noon-anchored sleep-day is equal…
+        assertEquals(day(fragment.startTs), day(main.startTs))
+        // …but the WAKE-day (the day each session ENDS) differs: the fragment ends before midnight
+        // (Aug 10), the main night ends next morning (Aug 11) — the wake-day bug the noon anchor fixes.
+        assertNotEquals(midnightDay(fragment.endTs), midnightDay(main.endTs))
+        // 69 s apart → proximity collapses to the fuller main session.
+        assertEquals(1, simulate(listOf(fragment, main)).size)
+        assertEquals(main.startTs, simulate(listOf(fragment, main)).single().startTs)
+    }
+
+    // ── Night 08-09 — a real afternoon nap shares the sleep-day with the night but must stay separate ─
+    @Test
+    fun nap_sharesSleepDay_butStaysDistinct() {
+        val nap = win(localTs(0, 14, 24, 4), localTs(0, 14, 46, 4))    // 22 min afternoon nap
+        val night = win(localTs(0, 22, 23, 7), localTs(1, 6, 30, 0))
+        assertEquals("nap and night share the noon-anchored sleep-day", day(nap.startTs), day(night.startTs))
+        // ~7.5 h apart → NOT the same session → both persist.
+        assertEquals(2, simulate(listOf(nap, night)).size)
+        assertEquals(Decision.Insert, OuraSessionReconciler.reconcile(night, listOf(nap)))
+    }
+
+    @Test
+    fun sameConnectionRepeatOfIdenticalWindowIsIdempotent() {
+        val s = win(localTs(0, 23, 0, 0), localTs(1, 7, 0, 0))
+        assertEquals("re-persisting the exact same window keeps one row", 1, simulate(listOf(s, s, s)).size)
+    }
+
+    private fun day(ts: Int) = OuraSessionReconciler.noonAnchoredSleepDay(ts, tz)
+    private fun midnightDay(ts: Int) = Math.floorDiv(ts + tz, 86_400)
+}

--- a/android/app/src/test/java/com/noop/oura/OuraSessionReconcilerTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraSessionReconcilerTest.kt
@@ -17,15 +17,15 @@ class OuraSessionReconcilerTest {
 
     private val tz = 7200 // CEST, the corpus timezone (Europe/Paris, summer)
     // A UTC instant that is a LOCAL midnight (utc + tz is a multiple of 86400), so localTs() reads cleanly.
-    private val localMidnightUtc = 86_400 * 20_670 - tz
+    private val localMidnightUtc = 86_400L * 20_670 - tz
 
     /** Unix seconds for a local wall-clock time on day `d` (days after the reference local midnight). */
-    private fun localTs(d: Int, h: Int, m: Int, s: Int): Int =
-        localMidnightUtc + d * 86_400 + h * 3600 + m * 60 + s
+    private fun localTs(d: Int, h: Int, m: Int, s: Int): Long =
+        localMidnightUtc + d * 86_400L + h * 3600 + m * 60 + s
 
     /** codeCount ~ 30-s epochs, the completeness signal (a fuller drain of the same night has more). */
-    private fun win(start: Int, end: Int): SessionWindow =
-        SessionWindow(startTs = start, endTs = end, codeCount = (end - start) / 30)
+    private fun win(start: Long, end: Long): SessionWindow =
+        SessionWindow(startTs = start, endTs = end, codeCount = ((end - start) / 30).toInt())
 
     /** Replay a persist ORDER through the reconciler against the growing DB; return the final rows. */
     private fun simulate(order: List<SessionWindow>): List<SessionWindow> {
@@ -49,7 +49,6 @@ class OuraSessionReconcilerTest {
         val row1 = win(localTs(0, 4, 40, 55), localTs(0, 6, 50, 55)) // 130 min, fullest
         val row2 = win(localTs(0, 4, 50, 9), localTs(0, 6, 48, 9))  // 118 min
         val row3 = win(localTs(0, 6, 34, 9), localTs(0, 6, 48, 9))  // 14 min
-        // All three overlap and share the noon-anchored sleep-day.
         assertEquals(day(row1.startTs), day(row2.startTs))
         assertEquals(day(row1.startTs), day(row3.startTs))
         val db = simulate(listOf(row3, row2, row1)) // arrive shortest-first, worst case
@@ -60,13 +59,11 @@ class OuraSessionReconcilerTest {
     // ── Night 08-13/14 — mode 2 (partial drain): B nested in A, A genuinely fuller ────────────────────
     @Test
     fun mode2_partialDrain_completenessGuardKeepsFuller() {
-        val rowA = win(1786657310, 1786657310 + 494 * 60) // 494 min / 988 codes
-        val rowB = win(1786657552, 1786657552 + 234 * 60) // 234 min / 468 codes, inside A
+        val rowA = win(1786657310L, 1786657310L + 494 * 60) // 494 min / 988 codes
+        val rowB = win(1786657552L, 1786657552L + 234 * 60) // 234 min / 468 codes, inside A
         assertTrue("B is inside A", rowB.startTs >= rowA.startTs - 3600 && rowB.endTs <= rowA.endTs)
-        // Fuller-arrives-second and shorter-arrives-second both leave A standing.
         assertEquals(rowA.startTs, simulate(listOf(rowB, rowA)).single().startTs)
         assertEquals(rowA.startTs, simulate(listOf(rowA, rowB)).single().startTs)
-        // Direct: the guard skips the shorter and replaces for the fuller.
         assertEquals(Decision.Skip, OuraSessionReconciler.reconcile(rowB, listOf(rowA)))
         assertEquals(Decision.Replace(listOf(rowB.startTs)), OuraSessionReconciler.reconcile(rowA, listOf(rowB)))
     }
@@ -76,9 +73,7 @@ class OuraSessionReconcilerTest {
     fun gridStraddle_stillCollapsesUnderProximity() {
         val real = win(localTs(0, 22, 26, 14), localTs(1, 7, 6, 14))   // the real session, fuller
         val nested = win(localTs(0, 22, 32, 30), localTs(0, 23, 50, 30)) // 78 min, nested
-        // 376 s apart — a 30-min grid puts 22:26→22:00 and 22:32→22:30 in different buckets (would NOT
-        // collapse); proximity does.
-        assertTrue(nested.startTs - real.startTs in 1..3600)
+        assertTrue(nested.startTs - real.startTs in 1L..3600L)
         assertEquals(1, simulate(listOf(nested, real)).size)
     }
 
@@ -87,12 +82,10 @@ class OuraSessionReconcilerTest {
     fun fragmentEndingBeforeMidnight_sharesNoonSleepDayNotWakeDay() {
         val fragment = win(localTs(0, 22, 9, 40), localTs(0, 22, 49, 40)) // ends 22:49, before midnight
         val main = win(localTs(0, 22, 50, 49), localTs(1, 7, 30, 49))
-        // Noon-anchored sleep-day is equal…
         assertEquals(day(fragment.startTs), day(main.startTs))
-        // …but the WAKE-day (the day each session ENDS) differs: the fragment ends before midnight
-        // (Aug 10), the main night ends next morning (Aug 11) — the wake-day bug the noon anchor fixes.
+        // The WAKE-day (the day each session ENDS) differs: the fragment ends before midnight (Aug 10),
+        // the main night ends next morning (Aug 11) — the wake-day bug the noon anchor fixes.
         assertNotEquals(midnightDay(fragment.endTs), midnightDay(main.endTs))
-        // 69 s apart → proximity collapses to the fuller main session.
         assertEquals(1, simulate(listOf(fragment, main)).size)
         assertEquals(main.startTs, simulate(listOf(fragment, main)).single().startTs)
     }
@@ -103,7 +96,6 @@ class OuraSessionReconcilerTest {
         val nap = win(localTs(0, 14, 24, 4), localTs(0, 14, 46, 4))    // 22 min afternoon nap
         val night = win(localTs(0, 22, 23, 7), localTs(1, 6, 30, 0))
         assertEquals("nap and night share the noon-anchored sleep-day", day(nap.startTs), day(night.startTs))
-        // ~7.5 h apart → NOT the same session → both persist.
         assertEquals(2, simulate(listOf(nap, night)).size)
         assertEquals(Decision.Insert, OuraSessionReconciler.reconcile(night, listOf(nap)))
     }
@@ -114,6 +106,6 @@ class OuraSessionReconcilerTest {
         assertEquals("re-persisting the exact same window keeps one row", 1, simulate(listOf(s, s, s)).size)
     }
 
-    private fun day(ts: Int) = OuraSessionReconciler.noonAnchoredSleepDay(ts, tz)
-    private fun midnightDay(ts: Int) = Math.floorDiv(ts + tz, 86_400)
+    private fun day(ts: Long) = OuraSessionReconciler.noonAnchoredSleepDay(ts, tz)
+    private fun midnightDay(ts: Long) = Math.floorDiv(ts + tz, 86_400L)
 }


### PR DESCRIPTION
Draft — the **pure, testable core** of #1284 residual 3 (duplicate *generation*), landing the design @pipiche38's four-night corpus selected. Wiring into the live path is the hardware-gated follow-up (below), matching this issue's draft → hardware-run cadence.

## What this is
`OuraSessionReconciler` (Swift `WhoopStore` + byte-identical Kotlin `com.noop.oura` twin) — pure, no store/BLE:
- `noonAnchoredSleepDay(startTs, tz)` — groups a ring's sessions by `date(startTs_local + 12h)`.
- `reconcile(new, existing)` — within a sleep-day, overlap-or-gap<60min ⇒ same session; keep the **fuller** decode (the completeness guard). Returns `insert` / `skip` / `replace(supersededStartTs)`.

## Why this design (from the corpus, not a guess)
- **Option (2) collapses 4/4 nights; the 30-min grid only 1/4.** The grid fails on 08-11/12 (starts 6¼ min apart straddle 22:30) and spends the bedtime precision that let 08-13/14 be checked against WHOOP to −10 s/+50 s.
- **Noon-anchor, not wake-day** — on 08-10/11 the 40-min fragment ends before midnight, so its wake-day (Aug 10) differs from the night's (Aug 11); the noon anchor maps both together. The test asserts exactly this (and that wake-day would *not*).
- **Two duplicate modes, both handled** — re-anchor (same hypnogram, two onsets) and partial-drain (shorter divergent decode). The completeness guard adjudicates the partial-drain case; the fuller row is the WHOOP-matching one on every measured night.
- **Nap safety** — 08-09's real 22-min afternoon nap shares the sleep-day with that night's sleep, but the ~7½ h gap keeps it a distinct row.

## Validation
- **Kotlin: 6/6 green locally** (`OuraSessionReconcilerTest`) — every fixture is one of @pipiche38's nights.
- **Swift** runs under swift-packages (`WhoopStoreTests`, macos-15). Pure package code — no app-target Swift, so no app-build gate needed.
- One test caught a real bug in my own test premise while writing it (wake-day is the *end* day, not start), which is now asserted correctly — the design itself held.

## Follow-up (needs @pipiche38's ring — Q3)
Wire the reconciler into `OuraLiveSource.persistHypnogramBurst`: at persist time read the day's already-stored sessions (`noonAnchoredSleepDay` window) and `insert`/`skip`/`replace` on the decision. That read is the same one that lets the cross-connection check see duplicates a per-connection in-memory list can't — so it also closes the #1297 diagnostic blind spot. It's the write-only-source read dependency we discussed; it can't be unit-tested (BLE + store) and needs a hardware run confirming **one row across two connections at the correct window**.

Relates to #1284. Design + measurements: @pipiche38 (thank you).
