### PR TITLE
fix(sleep): collapse a near-adjacent pre-onset fragment in the dedup heal (#1284)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/SleepSessionDedup.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/SleepSessionDedup.swift
@@ -25,19 +25,37 @@ public enum SleepSessionDedup {
     /// the absolute overlap is under the 30 min bar (e.g. a 40 min fragment 60% inside the night).
     public static let minOverlapFractionOfShorter = 0.5
 
+    /// Edge gap (seconds) at or below which two DISJOINT sessions are still one night (#1284 residual 3).
+    /// The Oura SleepNet burst runs a few epochs before the `0x49` onset, so its pre-onset piece can bank
+    /// as a short session ending seconds before the anchored night begins with NO overlap — the overlap
+    /// rule above misses it (measured 69 s on 08-10/11; the pre-onset run is ~7 min / 14 codes per
+    /// `OuraLiveSource`). A gap this small can only be one interrupted night, never two real sleeps: a
+    /// genuine nap is hours from the main sleep, so it never trips this. 15 min is ~2× the observed
+    /// pre-onset span, catching the fragment with margin while staying far below any real inter-sleep gap.
+    public static let nearAdjacentSeconds = 15 * 60
+
     /// Seconds of overlap between the two sessions' EFFECTIVE spans (edited onsets honoured,
     /// mirroring how display / day assignment place the block). 0 when disjoint.
     static func overlapSeconds(_ a: CachedSleepSession, _ b: CachedSleepSession) -> Int {
         max(0, min(a.endTs, b.endTs) - max(a.effectiveStartTs, b.effectiveStartTs))
     }
 
-    /// True when `a` and `b` are overlapping copies of the same night: overlap of at least
-    /// `minOverlapSeconds` absolute, OR at least `minOverlapFractionOfShorter` of the shorter
-    /// session's duration. Both terms use only (effectiveStartTs, endTs), the only time fields
-    /// the data model carries (there is no banked-at column to compare).
+    /// Edge gap (seconds) between two DISJOINT sessions (the later start minus the earlier end); 0 when
+    /// they touch or overlap. Only meaningful when `overlapSeconds == 0`.
+    static func edgeGapSeconds(_ a: CachedSleepSession, _ b: CachedSleepSession) -> Int {
+        max(0, max(a.effectiveStartTs, b.effectiveStartTs) - min(a.endTs, b.endTs))
+    }
+
+    /// True when `a` and `b` are copies of the same night: overlap of at least `minOverlapSeconds`
+    /// absolute, OR at least `minOverlapFractionOfShorter` of the shorter session's duration, OR (when
+    /// disjoint) an edge gap within `nearAdjacentSeconds` (#1284, the non-overlapping pre-onset fragment).
+    /// All terms use only (effectiveStartTs, endTs), the only time fields the data model carries.
     public static func isDuplicate(_ a: CachedSleepSession, _ b: CachedSleepSession) -> Bool {
         let overlap = overlapSeconds(a, b)
-        guard overlap > 0 else { return false }
+        if overlap <= 0 {
+            // Disjoint: a same-night fragment banked just before/after the anchored night (#1284).
+            return edgeGapSeconds(a, b) <= nearAdjacentSeconds
+        }
         if overlap >= minOverlapSeconds { return true }
         let shorter = min(max(a.endTs - a.effectiveStartTs, 0), max(b.endTs - b.effectiveStartTs, 0))
         return shorter > 0 && Double(overlap) >= minOverlapFractionOfShorter * Double(shorter)

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/SleepSessionDedupTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/SleepSessionDedupTests.swift
@@ -131,7 +131,6 @@ final class SleepSessionDedupTests: XCTestCase {
         let night = session(start: midnight - 2 * 3600, end: midnight + 6 * 3600)
         let fragEnd = (midnight - 2 * 3600) - 69
         let fragment = session(start: fragEnd - 40 * 60, end: fragEnd)
-        XCTAssertEqual(SleepSessionDedup.overlapSeconds(fragment, night), 0)   // disjoint
         XCTAssertTrue(SleepSessionDedup.isDuplicate(fragment, night), "a 69 s edge gap is one interrupted night")
         let result = SleepSessionDedup.dedupe([fragment, night], freshStarts: [night.startTs])
         XCTAssertEqual(result.kept.count, 1, "fragment + night collapse to one")
@@ -150,7 +149,6 @@ final class SleepSessionDedupTests: XCTestCase {
         // Two disjoint sessions 20 min apart (> the 15 min near-adjacent bar) are not merged.
         let a = session(start: midnight - 3 * 3600, end: midnight - 2 * 3600)
         let b = session(start: midnight - 2 * 3600 + 20 * 60, end: midnight + 4 * 3600)
-        XCTAssertEqual(SleepSessionDedup.overlapSeconds(a, b), 0)
         XCTAssertFalse(SleepSessionDedup.isDuplicate(a, b))
         XCTAssertEqual(SleepSessionDedup.dedupe([a, b]).kept.count, 2)
     }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/SleepSessionDedupTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/SleepSessionDedupTests.swift
@@ -122,4 +122,36 @@ final class SleepSessionDedupTests: XCTestCase {
         let one = session(start: midnight, end: midnight + 3600)
         XCTAssertEqual(SleepSessionDedup.dedupe([one]).kept.map(\.startTs), [one.startTs])
     }
+
+    // MARK: - #1284 residual 3: a non-overlapping pre-onset fragment collapses; a real nap does not
+
+    func testOura1284PreOnsetFragmentCollapsesDespiteNoOverlap() {
+        // The anchored night 22:00 → 06:00, and the Oura SleepNet pre-onset fragment ending 69 s before
+        // the night starts (measured on 08-10/11) — a 40 min piece with NO overlap with the night.
+        let night = session(start: midnight - 2 * 3600, end: midnight + 6 * 3600)
+        let fragEnd = (midnight - 2 * 3600) - 69
+        let fragment = session(start: fragEnd - 40 * 60, end: fragEnd)
+        XCTAssertEqual(SleepSessionDedup.overlapSeconds(fragment, night), 0)   // disjoint
+        XCTAssertTrue(SleepSessionDedup.isDuplicate(fragment, night), "a 69 s edge gap is one interrupted night")
+        let result = SleepSessionDedup.dedupe([fragment, night], freshStarts: [night.startTs])
+        XCTAssertEqual(result.kept.count, 1, "fragment + night collapse to one")
+        XCTAssertEqual(result.kept.first?.startTs, night.startTs, "the fuller anchored night survives")
+    }
+
+    func testOura1284RealNapStaysSeparate() {
+        // A genuine afternoon nap hours before the night is never near-adjacent.
+        let nap = session(start: midnight - 9 * 3600, end: midnight - 8 * 3600)
+        let night = session(start: midnight - 2 * 3600, end: midnight + 6 * 3600)
+        XCTAssertFalse(SleepSessionDedup.isDuplicate(nap, night))
+        XCTAssertEqual(SleepSessionDedup.dedupe([nap, night]).kept.count, 2)
+    }
+
+    func testOura1284GapBeyondNearAdjacentStaysSeparate() {
+        // Two disjoint sessions 20 min apart (> the 15 min near-adjacent bar) are not merged.
+        let a = session(start: midnight - 3 * 3600, end: midnight - 2 * 3600)
+        let b = session(start: midnight - 2 * 3600 + 20 * 60, end: midnight + 4 * 3600)
+        XCTAssertEqual(SleepSessionDedup.overlapSeconds(a, b), 0)
+        XCTAssertFalse(SleepSessionDedup.isDuplicate(a, b))
+        XCTAssertEqual(SleepSessionDedup.dedupe([a, b]).kept.count, 2)
+    }
 }

--- a/android/app/src/main/java/com/noop/analytics/SleepSessionDedup.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepSessionDedup.kt
@@ -33,6 +33,16 @@ object SleepSessionDedup {
      */
     const val MIN_OVERLAP_FRACTION_OF_SHORTER: Double = 0.5
 
+    /**
+     * Edge gap (seconds) at or below which two DISJOINT sessions are still one night (#1284 residual 3).
+     * The Oura SleepNet burst runs a few epochs before the `0x49` onset, so its pre-onset piece can bank
+     * as a short session ending seconds before the anchored night begins with NO overlap — the overlap
+     * rule misses it (measured 69 s on 08-10/11; the pre-onset run is ~7 min / 14 codes per OuraLiveSource).
+     * A gap this small can only be one interrupted night, never two real sleeps: a genuine nap is hours
+     * from the main sleep, so it never trips this. 15 min is ~2x the observed pre-onset span.
+     */
+    const val NEAR_ADJACENT_SECONDS: Long = 15L * 60L
+
     /** The collapse outcome: canonical survivors + the duplicates dropped, both sorted by startTs. */
     data class Result(val kept: List<SleepSession>, val dropped: List<SleepSession>)
 
@@ -41,15 +51,23 @@ object SleepSessionDedup {
     internal fun overlapSeconds(a: SleepSession, b: SleepSession): Long =
         maxOf(0L, minOf(a.endTs, b.endTs) - maxOf(a.effectiveStartTs, b.effectiveStartTs))
 
+    /** Edge gap (seconds) between two DISJOINT sessions (the later start minus the earlier end); 0 when
+     *  they touch or overlap. Only meaningful when [overlapSeconds] is 0. */
+    internal fun edgeGapSeconds(a: SleepSession, b: SleepSession): Long =
+        maxOf(0L, maxOf(a.effectiveStartTs, b.effectiveStartTs) - minOf(a.endTs, b.endTs))
+
     /**
-     * True when [a] and [b] are overlapping copies of the same night: overlap of at least
-     * [MIN_OVERLAP_SECONDS] absolute, OR at least [MIN_OVERLAP_FRACTION_OF_SHORTER] of the shorter
-     * session's duration. Both terms use only (effectiveStartTs, endTs), the only time fields the
-     * data model carries (there is no banked-at column to compare).
+     * True when [a] and [b] are copies of the same night: overlap of at least [MIN_OVERLAP_SECONDS]
+     * absolute, OR at least [MIN_OVERLAP_FRACTION_OF_SHORTER] of the shorter session's duration, OR (when
+     * disjoint) an edge gap within [NEAR_ADJACENT_SECONDS] (#1284, the non-overlapping pre-onset fragment).
+     * All terms use only (effectiveStartTs, endTs), the only time fields the data model carries.
      */
     fun isDuplicate(a: SleepSession, b: SleepSession): Boolean {
         val overlap = overlapSeconds(a, b)
-        if (overlap <= 0L) return false
+        if (overlap <= 0L) {
+            // Disjoint: a same-night fragment banked just before/after the anchored night (#1284).
+            return edgeGapSeconds(a, b) <= NEAR_ADJACENT_SECONDS
+        }
         if (overlap >= MIN_OVERLAP_SECONDS) return true
         val shorter = minOf(
             maxOf(a.endTs - a.effectiveStartTs, 0L),

--- a/android/app/src/test/java/com/noop/analytics/SleepSessionDedupTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepSessionDedupTest.kt
@@ -142,7 +142,6 @@ class SleepSessionDedupTest {
         val night = session(midnight - 2 * 3600L, midnight + 6 * 3600L)
         val fragEnd = (midnight - 2 * 3600L) - 69L
         val fragment = session(fragEnd - 40 * 60L, fragEnd)
-        assertEquals(0L, SleepSessionDedup.overlapSeconds(fragment, night)) // disjoint
         assertTrue("a 69 s edge gap is one interrupted night", SleepSessionDedup.isDuplicate(fragment, night))
         val result = SleepSessionDedup.dedupe(listOf(fragment, night), freshStarts = setOf(night.startTs))
         assertEquals("fragment + night collapse to one", 1, result.kept.size)
@@ -163,7 +162,6 @@ class SleepSessionDedupTest {
         // Two disjoint sessions 20 min apart (> the 15 min near-adjacent bar) are not merged.
         val a = session(midnight - 3 * 3600L, midnight - 2 * 3600L)
         val b = session(midnight - 2 * 3600L + 20 * 60L, midnight + 4 * 3600L)
-        assertEquals(0L, SleepSessionDedup.overlapSeconds(a, b))
         assertTrue(!SleepSessionDedup.isDuplicate(a, b))
         assertEquals(2, SleepSessionDedup.dedupe(listOf(a, b)).kept.size)
     }

--- a/android/app/src/test/java/com/noop/analytics/SleepSessionDedupTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepSessionDedupTest.kt
@@ -132,4 +132,39 @@ class SleepSessionDedupTest {
         val one = session(midnight, midnight + 3600L)
         assertEquals(listOf(one.startTs), SleepSessionDedup.dedupe(listOf(one)).kept.map { it.startTs })
     }
+
+    // ── #1284 residual 3: a non-overlapping pre-onset fragment collapses; a real nap does not ────────
+
+    @Test
+    fun oura1284_preOnsetFragment_collapsesDespiteNoOverlap() {
+        // The anchored night 22:00 -> 06:00, and the Oura SleepNet pre-onset fragment ending 69 s before
+        // the night starts (measured on 08-10/11) — a 40 min piece with NO overlap with the night.
+        val night = session(midnight - 2 * 3600L, midnight + 6 * 3600L)
+        val fragEnd = (midnight - 2 * 3600L) - 69L
+        val fragment = session(fragEnd - 40 * 60L, fragEnd)
+        assertEquals(0L, SleepSessionDedup.overlapSeconds(fragment, night)) // disjoint
+        assertTrue("a 69 s edge gap is one interrupted night", SleepSessionDedup.isDuplicate(fragment, night))
+        val result = SleepSessionDedup.dedupe(listOf(fragment, night), freshStarts = setOf(night.startTs))
+        assertEquals("fragment + night collapse to one", 1, result.kept.size)
+        assertEquals("the fuller anchored night survives", night.startTs, result.kept.first().startTs)
+    }
+
+    @Test
+    fun oura1284_realNap_staysSeparate() {
+        // A genuine afternoon nap hours before the night is never near-adjacent.
+        val nap = session(midnight - 9 * 3600L, midnight - 8 * 3600L)
+        val night = session(midnight - 2 * 3600L, midnight + 6 * 3600L)
+        assertTrue(!SleepSessionDedup.isDuplicate(nap, night))
+        assertEquals(2, SleepSessionDedup.dedupe(listOf(nap, night)).kept.size)
+    }
+
+    @Test
+    fun oura1284_gapBeyondNearAdjacent_staysSeparate() {
+        // Two disjoint sessions 20 min apart (> the 15 min near-adjacent bar) are not merged.
+        val a = session(midnight - 3 * 3600L, midnight - 2 * 3600L)
+        val b = session(midnight - 2 * 3600L + 20 * 60L, midnight + 4 * 3600L)
+        assertEquals(0L, SleepSessionDedup.overlapSeconds(a, b))
+        assertTrue(!SleepSessionDedup.isDuplicate(a, b))
+        assertEquals(2, SleepSessionDedup.dedupe(listOf(a, b)).kept.size)
+    }
 }


### PR DESCRIPTION
Extends the #899 `SleepSessionDedup` heal to close the one Oura duplicate mode it misses (#1284 residual 3).

## What
`SleepSessionDedup.isDuplicate` (Swift + Kotlin twin) required `overlap > 0`, so it missed the Oura SleepNet **pre-onset fragment**: a short session ending seconds *before* the `0x49`-anchored night starts, with **no overlap** (measured 69 s on 08-10/11; the pre-onset run is ~7 min / 14 codes per `OuraLiveSource`). Now two **disjoint** sessions within a **15-min edge gap** are also treated as one night. A gap that small can only be one interrupted night — a real nap is hours out (tested).

The overlap branch and the survivor sort (`userEdited > fresh > longest`) are unchanged, so the fuller/edited row still wins and WHOOP behaviour is untouched.

## Tests
Swift + Kotlin, 3 each: fragment-collapses-despite-no-overlap, real-nap-stays-separate, gap-beyond-15-min-stays-separate. **Full Android suite green (3834 tests, 0 failures)**; Swift via swift-packages.

## Scope — honest framing
This is **heal-side** (post-hoc): it completes the sweep so no duplicate *survives* to the next analyze pass. It does **not** stop duplicate **generation** or the transient phantom-nap window before the heal runs — @pipiche38 was clear that residual 3 needs the **generation side** (`0x49`/sleep-day keying), which is separate and hardware-gated. This ships as the heal-completeness half; the generation-side fix + the logging to design it are tracked on #1284.

Relates to #1284. Measurements: @pipiche38.
