### PR TITLE
feat(oura): cross-connection duplicate-generation diagnostic (#1284, log-only)

### DIFF
--- a/Strand/BLE/SourceCoordinator.swift
+++ b/Strand/BLE/SourceCoordinator.swift
@@ -378,7 +378,7 @@ final class SourceCoordinator: ObservableObject {
                     for e in stored where SleepSessionDedup.isDuplicate(session, e) {
                         let newCodes = max(0, (session.endTs - session.startTs) / 30)
                         let storedCodes = max(0, (e.endTs - e.startTs) / 30)
-                        straplog("Oura: dup-gen(#1284) persist [\(session.startTs)→\(session.endTs)] codes=\(newCodes) duplicates stored [\(e.startTs)→\(e.endTs)] codes=\(storedCodes) startΔ=\(session.startTs - e.startTs)s (≈0x49 onset jitter) - cross-connection DB read")
+                        straplog("Oura: dup-gen(#1284) persist [\(session.startTs) -> \(session.endTs)] codes=\(newCodes) duplicates stored [\(e.startTs) -> \(e.endTs)] codes=\(storedCodes) startDelta=\(session.startTs - e.startTs)s (~0x49 onset jitter) - cross-connection DB read")
                     }
                     _ = try? await store.upsertSleepSessions([session], deviceId: id)
                 }

--- a/Strand/BLE/SourceCoordinator.swift
+++ b/Strand/BLE/SourceCoordinator.swift
@@ -356,11 +356,32 @@ final class SourceCoordinator: ObservableObject {
             persist: { [storeHandle] streams in
                 Task { if let store = await storeHandle() { _ = try? await store.insert(streams, deviceId: id) } }
             },
-            persistSleepSession: { [storeHandle] session in
+            persistSleepSession: { [storeHandle, straplog] session in
                 // The ring-PROVIDED hypnogram night, upserted under the ring's OWN id (the imported/measured
                 // side, NOT the "-noop" computed sibling) so SleepMerge's imported-over-computed rule makes
                 // Oura's SleepNet staging win over NOOP's sparse-motion computed night (#325).
-                Task { if let store = await storeHandle() { _ = try? await store.upsertSleepSessions([session], deviceId: id) } }
+                Task {
+                    guard let store = await storeHandle() else { return }
+                    // #1284 duplicate-generation diagnostic (LOG-ONLY, no behaviour change). The in-source
+                    // `duplicate-gen(#1284)` line compares against a PER-CONNECTION memory list, so it is
+                    // blind to the common case: an overnight with link drops mints the duplicate across
+                    // DIFFERENT connections. Read the day's stored sessions here instead (cross-connection,
+                    // survives an app restart) and log — using the SAME `SleepSessionDedup.isDuplicate` rule
+                    // the heal uses — when this persist duplicates one. `startΔ` ≈ the 0x49 onset jitter
+                    // (a session's startTs IS its anchored onset); both code counts confirm the fuller row
+                    // is the one to keep. One compact line per duplicate, to survive the log head-clip. This
+                    // is the corpus the generation-side 0x49/sleep-day keying will be designed against.
+                    let from = session.startTs - 16 * 3600 - 3600
+                    let to = session.endTs + 3600
+                    let stored = ((try? await store.sleepSessions(deviceId: id, from: from, to: to, limit: 64)) ?? [])
+                        .filter { $0.startTs != session.startTs }
+                    for e in stored where SleepSessionDedup.isDuplicate(session, e) {
+                        let newCodes = max(0, (session.endTs - session.startTs) / 30)
+                        let storedCodes = max(0, (e.endTs - e.startTs) / 30)
+                        straplog("Oura: dup-gen(#1284) persist [\(session.startTs)→\(session.endTs)] codes=\(newCodes) duplicates stored [\(e.startTs)→\(e.endTs)] codes=\(storedCodes) startΔ=\(session.startTs - e.startTs)s (≈0x49 onset jitter) - cross-connection DB read")
+                    }
+                    _ = try? await store.upsertSleepSessions([session], deviceId: id)
+                }
             },
             log: straplog,
             onBattery: { [live] pct in live.setBattery(Double(pct)) },

--- a/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
+++ b/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
@@ -423,9 +423,28 @@ class SourceCoordinator(
                 // staging over NOOP's sparse-motion computed night (#325).
                 scope.launch {
                     runCatching {
-                        repo.upsertSleepSessions(listOf(com.noop.data.SleepSession(
+                        val session = com.noop.data.SleepSession(
                             deviceId = deviceId, startTs = s.startTs, endTs = s.endTs,
-                            efficiency = s.efficiency, stagesJSON = s.stagesJson)))
+                            efficiency = s.efficiency, stagesJSON = s.stagesJson)
+                        // #1284 duplicate-generation diagnostic (LOG-ONLY). The in-source
+                        // duplicate-gen(#1284) line compares a PER-CONNECTION memory list, so it is blind to
+                        // the common case: an overnight with link drops mints the duplicate across DIFFERENT
+                        // connections. Read the day's stored sessions here (cross-connection, survives an app
+                        // restart) and log — using the SAME SleepSessionDedup.isDuplicate rule the heal uses —
+                        // when this persist duplicates one. startDelta ~ the 0x49 onset jitter (a session's
+                        // startTs IS its anchored onset); both code counts confirm the fuller row wins. One
+                        // compact line per duplicate, to survive the log head-clip. This is the corpus the
+                        // generation-side 0x49/sleep-day keying will be designed against.
+                        val from = s.startTs - 16 * 3600 - 3600
+                        val to = s.endTs + 3600
+                        repo.sleepSessions(deviceId, from, to, 64)
+                            .filter { it.startTs != s.startTs && com.noop.analytics.SleepSessionDedup.isDuplicate(session, it) }
+                            .forEach { e ->
+                                val newCodes = maxOf(0L, (s.endTs - s.startTs) / 30)
+                                val storedCodes = maxOf(0L, (e.endTs - e.startTs) / 30)
+                                straplog("Oura: dup-gen(#1284) persist [${s.startTs} -> ${s.endTs}] codes=$newCodes duplicates stored [${e.startTs} -> ${e.endTs}] codes=$storedCodes startDelta=${s.startTs - e.startTs}s (~0x49 onset jitter) - cross-connection DB read")
+                            }
+                        repo.upsertSleepSessions(listOf(session))
                     }
                 }
             },


### PR DESCRIPTION
Log-only cross-connection diagnostic to gather the corpus for the generation-side `0x49` keying (#1284 residual 3).

## Why
The in-source `duplicate-gen(#1284)` line compares against a **per-connection** in-memory list, so it's blind to the *common* case @pipiche38 measured: an overnight with link drops mints the duplicate across **different connections**. As shipped it "can only see the mode that doesn't happen."

## What
At persist, read the day's stored sessions (**cross-connection, survives an app restart**) and log — via the **same `SleepSessionDedup.isDuplicate` rule the heal uses** (#1338), so the diagnostic and the eventual fix agree by construction — when this persist duplicates one. One compact line:

```
Oura: dup-gen(#1284) persist [start→end] codes=N duplicates stored [start→end] codes=M startΔ=Ss (≈0x49 onset jitter) - cross-connection DB read
```

`startΔ` ≈ the `0x49` onset jitter (a session's `startTs` *is* its anchored onset); both code counts confirm the fuller row is the one to keep.

**Log-only** — behaviour is unchanged (still upserts); one line per duplicate, to survive the log head-clip far better than the multi-line burst trace. Swift + Kotlin twins.

## What it's for
The `startΔ` distribution + same/cross-connection split decides the generation-side keying grain (quantise onset vs noon-anchored sleep-day key) and validates the completeness guard — turning that fix from "designed on 2–4 nights" into "validated on a corpus."

Relates to #1284. Compile-validated via the app-build gate; runtime data comes from @pipiche38's captures.
