### PR TITLE
fix(stress): refuse a Stress Index reading from a mostly-rejected spot capture

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StressIndex.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StressIndex.swift
@@ -68,6 +68,9 @@ public enum StressIndex {
     public static func components(rawRR: [Double]) -> Components? {
         let clean = HRVAnalyzer.cleanRR(rawRR)
         guard clean.count >= minBeats else { return nil }
+        // #585 spot-honesty gate, matching HRVAnalyzer.analyze: a mostly-rejected capture (out-of-range or
+        // ectopic beats) is too noisy to label as stress. clean.count >= minBeats > 0 => rawRR non-empty.
+        guard 1.0 - Double(clean.count) / Double(rawRR.count) <= HRVAnalyzer.defaultSpotMaxRejectedFraction else { return nil }
 
         // Work in seconds (Baevsky's convention).
         let sec = clean.map { $0 / 1000.0 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StressIndexTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StressIndexTests.swift
@@ -55,4 +55,14 @@ final class StressIndexTests: XCTestCase {
         let rr = raw.enumerated().map { RRInterval(ts: 1000 + $0.offset, rrMs: Int($0.element)) }
         XCTAssertEqual(StressIndex.stressIndex(rr: rr)!, StressIndex.stressIndex(rawRR: raw)!, accuracy: 1e-9)
     }
+
+    func testMostlyRejectedSpotCaptureReturnsNil() {
+        // A varied 22-beat capture that alone yields a reading, padded with out-of-range (>2000 ms) beats
+        // so >35% are rejected — too noisy to label as stress (#585 spot-honesty gate).
+        let valid: [Double] = [700, 720, 740, 760, 780, 800, 820, 840, 860, 800, 800,
+                               800, 800, 820, 780, 800, 810, 790, 800, 800, 805, 795]
+        XCTAssertNotNil(StressIndex.components(rawRR: valid), "baseline: the valid beats alone yield a reading")
+        XCTAssertNil(StressIndex.components(rawRR: valid + Array(repeating: 2500, count: 14)), "39% rejected (14/36) is too noisy")
+        XCTAssertNotNil(StressIndex.components(rawRR: valid + Array(repeating: 2500, count: 7)), "24% rejected (7/29) still reads")
+    }
 }

--- a/android/app/src/main/java/com/noop/analytics/StressIndex.kt
+++ b/android/app/src/main/java/com/noop/analytics/StressIndex.kt
@@ -52,6 +52,9 @@ object StressIndex {
     fun componentsRaw(rawRR: List<Double>): Components? {
         val clean = HrvAnalyzer.cleanRR(rawRR)
         if (clean.size < MIN_BEATS) return null
+        // #585 spot-honesty gate, matching HrvAnalyzer.analyzeRaw: a mostly-rejected capture (out-of-range
+        // or ectopic beats) is too noisy to label as stress. clean.size >= MIN_BEATS > 0 => rawRR non-empty.
+        if (1.0 - clean.size.toDouble() / rawRR.size.toDouble() > HrvAnalyzer.DEFAULT_SPOT_MAX_REJECTED_FRACTION) return null
 
         val sec = clean.map { it / 1000.0 }
         val minV = sec.min()

--- a/android/app/src/test/java/com/noop/analytics/StressIndexTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StressIndexTest.kt
@@ -58,4 +58,15 @@ class StressIndexTest {
         val rr = raw.mapIndexed { i, v -> RrInterval(deviceId = "d", ts = 1000L + i, rrMs = v.toInt()) }
         assertEquals(StressIndex.stressIndexRaw(raw)!!, StressIndex.stressIndex(rr)!!, 1e-9)
     }
+
+    @Test
+    fun mostlyRejectedSpotCaptureReturnsNull() {
+        // A varied 22-beat capture that alone yields a reading, padded with out-of-range (>2000 ms) beats
+        // so >35% are rejected — too noisy to label as stress (#585 spot-honesty gate).
+        val valid = listOf(700.0, 720.0, 740.0, 760.0, 780.0, 800.0, 820.0, 840.0, 860.0, 800.0, 800.0,
+            800.0, 800.0, 820.0, 780.0, 800.0, 810.0, 790.0, 800.0, 800.0, 805.0, 795.0)
+        assertNotNull("baseline: the valid beats alone yield a reading", StressIndex.componentsRaw(valid))
+        assertNull("39% rejected (14/36) is too noisy", StressIndex.componentsRaw(valid + List(14) { 2500.0 }))
+        assertNotNull("24% rejected (7/29) still reads", StressIndex.componentsRaw(valid + List(7) { 2500.0 }))
+    }
 }


### PR DESCRIPTION
Minimal extraction from #331 — the one self-contained, parity-safe fix in that large personal-workspace PR.

## The gap
`StressIndex.components` / `componentsRaw` guarded only `MIN_BEATS` (≥20 clean beats), so a noisy spot capture with 20 surviving beats but *most* of the input rejected (out-of-range or ectopic) still produced a Stress Index. `HRVAnalyzer` already refuses that on its own path via the **#585 spot-honesty gate** (`defaultSpotMaxRejectedFraction = 0.35`) — StressIndex just didn't apply it, so the two disagreed on "too noisy to score."

## The fix
Apply the identical #585 gate to StressIndex: refuse when `1 − clean/nInput > 0.35`. Swift + Kotlin twins, byte-identical formulation; one test each (39% rejected → nil, 24% → still reads, baseline valid capture unaffected). Kotlin suite green locally; Swift via swift-packages.

**Scope:** deliberately just this. #331's other 249 files (Android-only features on an old base, personal dev tooling, handoff docs) are out of scope for upstream `main`.

Idea credit: @Newbbsss (#331).
