### PR TITLE
perf(offload): skip the hex dump of all-zero rejected frames (#1007)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
@@ -118,6 +118,16 @@ public func rejectedHistoricalRecords(_ rawFrames: [[UInt8]], family: DeviceFami
     }
 }
 
+/// A rejected history frame whose entire record PAYLOAD is zero — a valid header + trailing CRC wrapping
+/// nothing. Such a frame carries no field layout to reverse-engineer, so the Backfiller skips its (large)
+/// hex dump (#1007: a strap emitting these produced ~4 MB of all-`00` in the strap log, ~8 dumps/chunk).
+/// Only the payload between the ~21-byte header and the 4-byte trailing CRC is examined; the size guard
+/// keeps a runt frame from ever reading as "empty". Mirrors the Android `isEmptyRecordFrame`.
+public func isEmptyRecordFrame(_ frame: [UInt8]) -> Bool {
+    guard frame.count > 25 else { return false }
+    return frame[21..<(frame.count - 4)].allSatisfy { $0 == 0 }
+}
+
 /// Turn historical (offload) parsed frames into datastore rows. Port of
 /// interpreter.extract_historical_streams.
 ///

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/RejectedHistoryTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/RejectedHistoryTests.swift
@@ -97,4 +97,17 @@ final class RejectedHistoryTests: XCTestCase {
         let rejected = rejectedHistoricalRecords([good, bad, console], family: .whoop4)
         XCTAssertEqual(rejected, [bad])
     }
+
+    func testIsEmptyRecordFrameFlagsAllZeroPayloadOnly() {
+        // A 104 B frame with header + CRC bytes set but the record payload (21..<count-4) all zero -> empty.
+        var empty = [UInt8](repeating: 0, count: 104)
+        empty[0] = 0xAA; empty[103] = 0x78
+        XCTAssertTrue(isEmptyRecordFrame(empty))
+        // One non-zero byte inside the payload -> not empty.
+        var nonEmpty = empty
+        nonEmpty[50] = 0x01
+        XCTAssertFalse(isEmptyRecordFrame(nonEmpty))
+        // A runt frame (no room for a payload past header+CRC) is never treated as empty.
+        XCTAssertFalse(isEmptyRecordFrame([UInt8](repeating: 0, count: 20)))
+    }
 }

--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -575,9 +575,17 @@ final class Backfiller {
                 // prefix — v25/v26 records run ~84 B and the truncated tail is exactly where the
                 // unmapped motion/HR fields sit), and sample a few more so one log carries enough
                 // records to triangulate offsets. These only ever fire for unmapped firmware.
-                for (i, f) in rejected.prefix(8).enumerated() {
+                let sample = Array(rejected.prefix(8))
+                var emptySkipped = 0
+                for (i, f) in sample.enumerated() {
+                    // #1007: an all-zero frame has no record layout to map, so its hex dump is pure log
+                    // bloat (a strap emitting these produced ~4 MB of all-00). Keep the WARNING count above.
+                    if isEmptyRecordFrame(f) { emptySkipped += 1; continue }
                     let hex = f.map { String(format: "%02x", $0) }.joined()
                     log?("Backfill: rejected frame[\(i)] \(f.count)B: \(hex)")
+                }
+                if emptySkipped > 0 {
+                    log?("Backfill: #1007 \(emptySkipped)/\(sample.count) sampled frame(s) all-zero (empty payload) - hex dump skipped")
                 }
             }
             // Commit the decoded rows FIRST (durable). Doing this before the reject archive means a

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -12,6 +12,7 @@ import com.noop.protocol.HistoricalMeta
 import com.noop.protocol.classifyHistoricalMeta
 import com.noop.protocol.decodeHistorical
 import com.noop.protocol.extractHistoricalStreams
+import com.noop.protocol.isEmptyRecordFrame
 import com.noop.protocol.rejectedHistoricalRecords
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -501,9 +502,17 @@ class Backfiller(
                 // records run ~84 B and the truncated tail is exactly where the unmapped motion/HR
                 // fields sit), and sample a few more so one log carries enough records to triangulate
                 // offsets. These only ever fire for unmapped firmware.
-                rejected.take(8).forEachIndexed { i, f ->
+                val sample = rejected.take(8)
+                var emptySkipped = 0
+                sample.forEachIndexed { i, f ->
+                    // #1007: an all-zero frame has no record layout to map, so its hex dump is pure log
+                    // bloat (a strap emitting these produced ~4 MB of all-00). Keep the WARNING count above.
+                    if (isEmptyRecordFrame(f)) { emptySkipped++; return@forEachIndexed }
                     val hex = f.joinToString("") { "%02x".format(it) }
                     log("Backfill: rejected frame[$i] ${f.size}B: $hex")
+                }
+                if (emptySkipped > 0) {
+                    log("Backfill: #1007 $emptySkipped/${sample.size} sampled frame(s) all-zero (empty payload) - hex dump skipped")
                 }
             }
             // Commit the decoded rows FIRST (durable) — BEFORE the reject archive (#1006, matching the

--- a/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
+++ b/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
@@ -574,6 +574,19 @@ fun rejectedHistoricalRecords(
     }
 }
 
+/**
+ * A rejected history frame whose entire record PAYLOAD is zero — a valid header + trailing CRC wrapping
+ * nothing. Such a frame carries no field layout to reverse-engineer, so the Backfiller skips its (large)
+ * hex dump (#1007: a strap emitting these produced ~4 MB of all-00 in the strap log, ~8 dumps/chunk).
+ * Only the payload between the ~21-byte header and the 4-byte trailing CRC is examined; the size guard
+ * keeps a runt frame from ever reading as "empty". Mirrors the Swift `isEmptyRecordFrame`.
+ */
+fun isEmptyRecordFrame(frame: ByteArray): Boolean {
+    if (frame.size <= 25) return false
+    for (i in 21 until frame.size - 4) if (frame[i].toInt() != 0) return false
+    return true
+}
+
 // MARK: - METADATA classification (port of HistoricalMeta.swift)
 
 /** Classification of a METADATA frame (type 49) for the historical-offload state machine. */

--- a/android/app/src/test/java/com/noop/protocol/RejectedHistoricalRecordsTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/RejectedHistoricalRecordsTest.kt
@@ -92,4 +92,15 @@ class RejectedHistoricalRecordsTest {
         assertEquals(1, rejected.size)
         assertTrue(rejected[0].contentEquals(bad))
     }
+
+    @Test
+    fun isEmptyRecordFrame_flagsAllZeroPayloadOnly() {
+        // A 104 B frame with header + CRC bytes set but the record payload (21..end-4) all zero -> empty.
+        val empty = ByteArray(104).also { it[0] = 0xAA.toByte(); it[103] = 0x78 }
+        assertTrue(isEmptyRecordFrame(empty))
+        // One non-zero byte inside the payload -> not empty.
+        assertTrue(!isEmptyRecordFrame(empty.copyOf().also { it[50] = 0x01 }))
+        // A runt frame (no room for a payload past header+CRC) is never treated as empty.
+        assertTrue(!isEmptyRecordFrame(ByteArray(20)))
+    }
 }


### PR DESCRIPTION
A small log-hygiene extraction from the #1007 thread.

## What
The Backfiller hex-dumps up to 8 full rejected frames per chunk so an unmapped firmware's record layout can be reverse-engineered from the strap log. A frame whose **entire payload is zero** (valid header + CRC wrapping nothing) has no layout to map, so its hex dump is pure bloat — @vishk23's byte census measured a strap emitting these producing **~4 MB of all-`00`** in the tail (1307 frames), each also running the PII regex over a ~3 KB string.

Adds a pure `isEmptyRecordFrame(frame)` to `WhoopProtocol` / `com.noop.protocol` (payload between the ~21 B header and 4 B CRC all zero, size-guarded) and skips such frames' hex dump in both Backfillers — keeping the WARNING count and logging a compact `N/M all-zero, hex skipped` line so the occurrence is still visible.

## Parity + tests
Swift + Kotlin twins, byte-identical (`21..<count−4` all zero, `>25` guard). One test each (all-zero → true, one non-zero payload byte → false, runt → false). **Swift passes via `swift test` locally** (WhoopProtocol is Linux-testable) and swift-packages; **Kotlin 6/6 green**; Backfiller.swift (app-target) via the app-build gate.

## Honest scope
Log-hygiene / CPU only — it does **not** reduce the offload **radio** airtime (the strap still sends the frames) and does **not** close #1007's protocol gap (that needs the un-RE'd bulk-transfer command + an HCI capture of the official app). The larger `persistTail` re-serialization the thread flagged is already fixed on `main` (batched `persistEveryNLines`); the trim-cursor fold needs a Room migration (separate). This is the one clean, small, general slice.

Idea + measurement: @vishk23 (#1007).
