### PR TITLE
fix(chart): stop the pan hijacking a touch scrub on the Deep Timeline (#1342, Bug 1)

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/OverviewHRChart.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/OverviewHRChart.swift
@@ -484,6 +484,13 @@ public struct OverviewHRChart: View {
         // itself) never flips the hint/Reset row into its "Zoomed in" state.
         .modifier(ZoomPanModifier(
             isActive: zoomBounds != nil,
+            scrubActive: {
+                #if os(iOS)
+                scrubEngaged
+                #else
+                false
+                #endif
+            },
             isZoomed: { zoomDomain != nil },
             current: { xDomain },
             bounds: zoomClampBounds,
@@ -612,6 +619,9 @@ private struct ZoomPanModifier: ViewModifier {
     let reset: () -> Void
     let zoom: (ClosedRange<Date>, Double, Double, ClosedRange<Date>) -> ClosedRange<Date>
     let pan: (ClosedRange<Date>, CGFloat, CGFloat, ClosedRange<Date>) -> ClosedRange<Date>
+    /// #1342: true while a touch scrub is engaged, so the pan drag is masked off (`.subviews`) and can't
+    /// ALSO slide the window sideways out from under the crosshair. Always false on macOS (no touch scrub).
+    let scrubActive: () -> Bool
 
     @State private var plotWidth: CGFloat = 1
     // Reduce Motion: the reset snaps instantly when on, otherwise it eases out (the gesture frames
@@ -626,7 +636,9 @@ private struct ZoomPanModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         guard isActive else { return AnyView(content) }
-        let drag = DragGesture(minimumDistance: 6)
+        // #1342: 10 pt (not 6) so the pan can't start inside the scrub long-press's 8 pt hold window —
+        // the 6–8 pt overlap band is what let a held-then-dragged finger begin panning during a scrub.
+        let drag = DragGesture(minimumDistance: 10)
             .onChanged { value in
                 let base = anchor ?? current()
                 if anchor == nil { anchor = base }
@@ -661,8 +673,10 @@ private struct ZoomPanModifier: ViewModifier {
         // host's scroll modifier (it owns the NSEvent monitor); here we wire pan + the double-tap reset.
         return AnyView(measured.gesture(drag).simultaneousGesture(doubleTapReset))
         #else
+        // #1342: mask the pan off while a scrub is engaged so a horizontal scrub no longer ALSO slides
+        // the window (the pan is `.simultaneous`, so it otherwise co-recognises alongside the scrub).
         return AnyView(measured.gesture(magnify)
-            .simultaneousGesture(drag)
+            .simultaneousGesture(drag, including: scrubActive() ? .subviews : .all)
             .simultaneousGesture(doubleTapReset))
         #endif
     }

--- a/Packages/StrandDesign/Sources/StrandDesign/OverviewHRChart.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/OverviewHRChart.swift
@@ -608,6 +608,9 @@ private struct SleepBandLabel: View {
 
 private struct ZoomPanModifier: ViewModifier {
     let isActive: Bool
+    /// #1342: true while a touch scrub is engaged, so the pan drag is masked off (`.subviews`) and can't
+    /// ALSO slide the window sideways out from under the crosshair. Always false on macOS (no touch scrub).
+    let scrubActive: () -> Bool
     /// True while the window is zoomed in (a reset is meaningful). Read at double-tap time so a tap on the
     /// already-full-day chart does nothing rather than re-triggering a no-op animation.
     let isZoomed: () -> Bool
@@ -619,9 +622,6 @@ private struct ZoomPanModifier: ViewModifier {
     let reset: () -> Void
     let zoom: (ClosedRange<Date>, Double, Double, ClosedRange<Date>) -> ClosedRange<Date>
     let pan: (ClosedRange<Date>, CGFloat, CGFloat, ClosedRange<Date>) -> ClosedRange<Date>
-    /// #1342: true while a touch scrub is engaged, so the pan drag is masked off (`.subviews`) and can't
-    /// ALSO slide the window sideways out from under the crosshair. Always false on macOS (no touch scrub).
-    let scrubActive: () -> Bool
 
     @State private var plotWidth: CGFloat = 1
     // Reduce Motion: the reset snaps instantly when on, otherwise it eases out (the gesture frames


### PR DESCRIPTION
## Bug 1 — scrub hijacked by pan (fixed)
On the Deep Timeline, press-and-hold + horizontal drag slid the whole window instead of scrubbing the crosshair. `OverviewHRChart`'s scrub is a low-priority `.gesture` behind a 0.25 s long-press (8 pt hold), but `ZoomPanModifier`'s pan is a `.simultaneousGesture` `DragGesture(minimumDistance: 6)` — so it co-recognises with the scrub and starts sliding the window in the 6–8 pt overlap band.

**Fix (both in `OverviewHRChart.swift`):** mask the pan off while a scrub is engaged (`including: scrubActive() ? .subviews : .all`, the same `GestureMask` idiom `RootTabView` uses), and raise the pan `minimumDistance` 6 → 10 so it can't start inside the 8 pt hold window. macOS is unchanged (no touch scrub → `scrubActive` false).

**Validation:** compiles via swift-packages (StrandDesign). ⚠️ The gesture *behaviour* needs an **on-device pass** — confirm scrub, pan, pinch-zoom, and double-tap-reset all still work. SwiftUI gesture priority can't be verified without a device.

## Bug 2 — vertical scroll stutter (NOT fixed here, on purpose)
I traced this and am being straight: the tempting culprit (`LiquidTodayView` writing `pullY` every scroll frame) is a **red herring for scroll-down** — `pullY` is only consumed by the refresh indicator, and `max(0, negativeMinY) = 0` during downward scroll, so SwiftUI **dedupes** the equal `@State` write (no body rebuild). The real cost is **draw-time**: per-card `NoopPanelSurface` drop shadows rasterising as cards enter the viewport, plus the live `Canvas`/`TimelineView` views (sky/vessels/live-HR) redrawing on the main thread during scroll. Those are **visual/UX tradeoffs** and I can't rank them without on-device **Instruments** (Time Profiler + Animation Hitches). Shipping a blind "optimization" there would risk a visual regression or simply not move the needle — so I've deliberately left it for a profile rather than over-build.

## Also noted (not touched here)
Classic `TodayView` excludes chart-frame drags from its day-swipe (`#829`, `guard !hrChartFrame.contains(...)`); `LiquidTodayView.daySwipeGesture` lacks that carve-out. It's latent today (liquid cards use `TrendChart`, which has no touch scrub) — a small follow-up if that changes.

Relates to #1342. Reporter @ben3man (note: the form said macOS but it's clearly iOS).
