### PR TITLE
diag(battery): log each analyzeRecent run's night count + duration (#1005)

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -461,6 +461,9 @@ final class IntelligenceEngine: ObservableObject {
             diagnosticSink?("re-score: trigger=forced newData=\(hadNew ? "yes" : "no (nothing changed since last run)")", nil)
         }
 
+        // #1005: time the whole pass — the trigger line above records WHY; this records how many nights
+        // and how long (the CPU cost per run), so a re-score STORM is visible in the strap log.
+        let reScoreStart = Date()
         computing = true
         // #899-A re-arm: clear the lock, then if a forced rescore was dropped while this pass held it,
         // run it ONCE. The flag is cleared BEFORE the re-invoke (a single re-arm), so a forced call landing
@@ -1784,6 +1787,7 @@ final class IntelligenceEngine: ObservableObject {
         // short-circuit while it's unchanged. Written ONLY here at the end of a completed run (never on an
         // early guard-return), so an interrupted/failed run can't advance the watermark past unscored data.
         if !wmKey.isEmpty { UserDefaults.standard.set(wmKey, forKey: Self.analyzeWatermarkKey) }
+        diagnosticSink?("re-score: done — scored \(scoredNights.count) night(s) in \(Int(Date().timeIntervalSince(reScoreStart) * 1000)) ms (#1005)", nil)
     }
 
     /// UserDefaults key for the #836 idle-tick gate: the `(count:maxTs)` HR fingerprint the last completed

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -231,10 +231,13 @@ object IntelligenceEngine {
         // The Context-aware caller reads NoopPrefs.spo2CandidateDisplay(context) and passes it down.
         spo2CandidateDisplay: Boolean = false,
     ): List<Computed> = withContext(Dispatchers.Default) {
+        // #1005: time the whole pass so a re-score STORM is visible in the strap log (the trigger lines
+        // record WHY each pass runs; this records how many nights and how long — the CPU cost per run).
+        val reScoreStart = System.nanoTime()
         // Serialise the whole pass so overlapping callers never run two rescores in parallel (see
         // [analyzeGate]). The heavy scoring already ran off the caller's thread via withContext above; the
         // lock is held only for this engine's own passes, never across an unrelated suspension.
-        analyzeGate.withLock {
+        val scored = analyzeGate.withLock {
             val (out, healed) = analyzeRecentOnCpu(repo, profile, maxDays, importedDeviceId, maxHROverride,
                 nowSeconds, ownerSource, manualStepCoefficient, persistStepsCalibration, baselineEpoch,
                 recoveryEpoch, diag, useExperimentalSleepV2, useMotionAwareWake, sleepTraceSink, recoveryTraceSink,
@@ -250,6 +253,8 @@ object IntelligenceEngine {
                 recoveryEpoch, diag, useExperimentalSleepV2, useMotionAwareWake, sleepTraceSink, recoveryTraceSink,
                 stepsTraceSink, universalSink, workoutsTraceSink, hrvTraceSink, deepHrvWindow, spo2CandidateDisplay).first
         }
+        diag("re-score: done — scored ${scored.size} night(s) in ${(System.nanoTime() - reScoreStart) / 1_000_000} ms (#1005)")
+        scored
     }
 
     /** History span for the one-shot Effort rescore , large enough to cover any real wear history,


### PR DESCRIPTION
Log-only instrumentation so #1005's *background battery* drain can actually be diagnosed from an export.

## Why
The reporter's A/B confirmed the HRV stream isn't the bulk, and the drain is **worsening day over day** — which points at an accumulating cost (a re-score storm, a reconnect loop, or growing offload). Two of those are already visible in the strap log (reconnect/backoff via `WhoopBleClient`, offload cadence via `Backfiller`), and the re-score **trigger** is already attributed (`re-score: trigger=forced/post-offload newData=…`). But the **CPU cost of each pass was a blind spot**: nothing recorded how many nights `analyzeRecent` scored or how long it took — so a re-score storm (`~21×54h` re-scored too often) couldn't be seen.

## What
One completion line per pass, both platforms, via the existing diagnostic sink:
```
re-score: done — scored N night(s) in X ms (#1005)
```
Combined with the existing trigger lines, the log now gives **frequency** (line timestamps) × **cost** (ms) × **magnitude** (nights) — enough to distinguish a re-score storm from steady offload or a reconnect loop.

## Safety
**Log-only, no behaviour change.** The Kotlin edit just captures the same pass result to log it (Android `IntelligenceEngine`/`AnalyticsEngine` tests green); Swift adds a start-time + one line at the completed-run watermark write. Swift is app-target → validated by the app-build gate.

Instrument-first for #1005, mirroring how #1339 instrumented #1284 before attempting the fix. Relates to #1005 / #1007.
