### PR TITLE
docs(store): mark rawImuSample as intentionally-dormant capture (#978)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -571,6 +571,17 @@ extension WhoopStore {
         // #423: WHOOP 5/MG raw-IMU offload capture (100 Hz 6-axis). `samples` is a packed i16 LE BLOB of
         // the six wire columns (ax…az,gx…gz). Twin of the Android `rawImuSample` table (MIGRATION_20_21);
         // same column order + PK so a `.noopbak` round-trips byte-for-byte.
+        //
+        // CONSUMER STATUS — deliberately none on this platform, in the same shape as the `ppgWaveformSample`
+        // (v27) and `v18AuxSample` (v31) notes. The writer (`Collector.storeRawImu`) is instrument-first: it
+        // fires only with raw capture enabled AND a 5/MG deep-data unlock, and is bounded to
+        // `WhoopStore.rawImuRetentionRows` (3600 one-second buffers, a rolling window — not a corpus). No
+        // analytic, score, gate, UI or export reads a row: the only SQL is the retention DELETE (`StreamStore`)
+        // plus a COUNT in the storage-stats readout (`LocalAccessCore`); `ImuFeatureExtractor` takes the
+        // protocol struct, never this table, so it is not a consumer either. Swift has NO reader yet, on
+        // purpose — a reader lands WITH a validated consumer, not before ("artifact, not one match", CLAUDE.md).
+        // Android keeps a dormant `rawImuSamples` reader (zero callers) for the eventual cross-check; do NOT
+        // "clean up" either side as dead code — the retained rows are the deliverable. Audit: #978.
         migrator.registerMigration("v28-raw-imu") { db in
             try db.create(table: "rawImuSample") { t in
                 t.column("deviceId", .text).notNull()

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -619,6 +619,12 @@ data class PpgWaveformSampleEntity(
  * Instrument-first + bounded: written only when raw capture is enabled, and pruned to a rolling recent
  * window ([WhoopRepository.RAW_IMU_RETENTION_ROWS]). Twin of the GRDB `rawImuSample` table. Natural key
  * (deviceId, ts) = one row per strap-second.
+ *
+ * CONSUMER STATUS (#978): deliberately none yet — instrument-first, the same stance as `v18AuxSample`. The
+ * writer runs only with raw capture enabled + a 5/MG deep-data unlock; nothing scores, gates or shows a row.
+ * The [WhoopRepository.rawImuSamples] / [WhoopDao.rawImuSamples] reader is intentionally dormant (zero
+ * callers) — the eventual cross-check seam, NOT dead code, so do not delete it. The GRDB twin has no reader
+ * yet by the same rule: one lands WITH a validated consumer, not before.
  */
 @Entity(tableName = "rawImuSample", primaryKeys = ["deviceId", "ts"])
 data class RawImuSampleEntity(

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -117,7 +117,9 @@ interface WhoopDao : DeviceRegistryDao {
     )
     suspend fun pruneRawImu(deviceId: String, keep: Int)
 
-    /** RAW 5/MG IMU buffers in [from, to] (ascending), packed i16 BLOB. (#423) */
+    /** RAW 5/MG IMU buffers in [from, to] (ascending), packed i16 BLOB. (#423)
+     *  Intentionally dormant — zero callers, retained for the eventual cross-check (see [RawImuSampleEntity]
+     *  CONSUMER STATUS, #978). Not dead code; do not delete. */
     @Query(
         "SELECT * FROM rawImuSample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to " +
             "ORDER BY ts ASC LIMIT :limit"

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -922,7 +922,9 @@ class WhoopRepository(
         dao.pruneRawImu(deviceId, RAW_IMU_RETENTION_ROWS)
     }
 
-    /** #423: raw 5/MG IMU buffers in [from, to] as the decoded i16 columns [ax…az,gx…gz] (100/axis). */
+    /** #423: raw 5/MG IMU buffers in [from, to] as the decoded i16 columns [ax…az,gx…gz] (100/axis).
+     *  Intentionally dormant — zero callers, retained for the eventual cross-check (see [RawImuSampleEntity]
+     *  CONSUMER STATUS, #978). Not dead code; do not delete. */
     suspend fun rawImuSamples(deviceId: String, from: Long, to: Long, limit: Int = DEFAULT_LIMIT):
         List<Pair<Long, ShortArray>> =
         dao.rawImuSamples(deviceId, from, to, limit)


### PR DESCRIPTION
Documents `rawImuSample` as an intentionally-dormant capture table, resolving the "is this what you intended?" audit in #978 (@vishk23). **Comments only — no behaviour change.**

## The finding (verified against `main`)

`rawImuSample` (#423) has a live writer but **no consumer** on either platform:

- **Swift has no reader at all.** The only SQL touching the table is the retention `DELETE` (`StreamStore.swift`) and a `COUNT(*)` in the storage-stats readout (`LocalAccessCore.swift`). `ImuFeatureExtractor` takes the protocol struct, not the table.
- **Android has a `rawImuSamples` reader with zero callers** (`WhoopRepository`/`WhoopDao`) — one dormant reader vs Swift's none.
- The writer (`Collector.storeRawImu`) is quadruple-gated (raw-capture pref off by default → 1244 B/100+100 buffer shape → 5/MG R22 deep-data unlock → a one-shot manual button), so on a normal install it never fires.

This is **not a bug** — it's the same instrument-first stance already documented for `ppgWaveformSample` (v27) and `v18AuxSample` (v31): the strap frees deep history the moment an offload is acked, so *banking* the raw IMU beats *losing* it, and a validated consumer lands later. The audit itself credits those existing comments for stopping mistaken deletions.

## What this PR does

Documents the table in that same voice, and — following the `v18AuxSample` precedent that explicitly says *"do NOT clean up the reader as dead code"* — marks the dormant Android reader as **retained, not dead**, so it survives a future cleanup pass:

- `Database.swift` (`v28-raw-imu`): a CONSUMER STATUS note mirroring the v27/v31 notes — instrument-first, bounded to `rawImuRetentionRows`, no analytic/score/gate/UI/export reader; Swift has no reader *yet*, by the "artifact, not one match" rule (a reader lands **with** a validated consumer).
- `Entities.kt` (`RawImuSampleEntity`): the twin CONSUMER STATUS note.
- `WhoopDao.kt` / `WhoopRepository.kt` (`rawImuSamples`): a "dormant — zero callers, do not delete" marker pointing back to the entity note.

## What this PR deliberately does NOT do (the product calls in #978)

- **Not** re-applying R22 on connect to make capture reachable — that writes to the strap on every connect, which the BLE contract keeps a deliberate, gated one-shot.
- **Not** removing the table — that contradicts the bank-it precedent and would be a drop-table migration on harmless dormant data.
- **Not** adding a Swift reader — a reader with no consumer is dead code; the honest parity is documenting both sides as dormant, not adding a second unused reader.

## Verification

Comments only; no code paths change. Confirmed the diff adds only comment lines.

Raised by @vishk23 in #978.

Closes #978
