### PR TITLE
fix(sleep): measure sleep debt against the engine's personalized need (#242)

### DIFF
--- a/Strand/Screens/SleepModel.swift
+++ b/Strand/Screens/SleepModel.swift
@@ -328,6 +328,21 @@ extension SleepModel {
         Swift.max(450, typicalTotalMin(days: days) ?? 450)   // 450 min = 7.5h
     }
 
+    /// The NORMATIVE per-user sleep need (minutes) the DEBT surfaces measure against — the
+    /// population-anchored, age-floored, upper-quartile `personalizedNeedHours`, the SAME estimator
+    /// Rest/Intelligence score against. Deliberately NOT the descriptive `sleepNeedMin` (mean total
+    /// sleep): the mean drifts DOWN toward a chronic under-sleeper's own deficit and quietly erases
+    /// their debt, whereas the upper-quartile floored at the ~8 h adult target only adjusts UP for
+    /// genuine long sleepers. Age isn't plumbed to this screen (age: nil → adult target); wiring it
+    /// would only raise it for under-18s. One need across every debt surface, agreeing with the engine.
+    /// (#242; need-unification from #464 by @vishk23. The descriptive `sleepNeedMin` still drives the
+    /// non-debt "hours vs needed" performance tile.)
+    static func debtNeedMin(days: [DailyMetric]) -> Double {
+        AnalyticsEngine.Rest.personalizedNeedHours(
+            nightlyHours: days.compactMap { $0.totalSleepMin.map { $0 / 60.0 } },
+            age: nil) * 60.0
+    }
+
     // MARK: Per-tile series (latest, typical mean, sparkline history)
 
     /// Build a metric from a per-day transform, keeping only finite values.
@@ -433,7 +448,7 @@ extension SleepModel {
     static func sleepDebtSeries(days: [DailyMetric], importedSleep: [String: ImportedSleepFigures],
                                 napSleepMinByDay: [String: Double]) -> Metric {
         let imported = importedSleep
-        let need = sleepNeedMin(days: days)
+        let need = debtNeedMin(days: days)   // #242: normative need, not the self-referential mean
         let series = days.compactMap { d -> Double? in
             if let debt = imported[d.day]?.debtMin { return debt }   // minutes, export-verbatim
             guard let asleep = SleepDebt.creditedSleepMin(
@@ -454,9 +469,10 @@ extension SleepModel {
 
     // MARK: Sleep-debt ledger
 
-    /// The rolling 14-night sleep-debt ledger from the cached daily metrics. Uses the SAME personal
-    /// sleep need the tiles use (`sleepNeedMin`), measured against each main night's `totalSleepMin`
-    /// plus actual asleep minutes from separately-recorded naps. (#242)
+    /// The rolling 14-night sleep-debt ledger from the cached daily metrics. Measures against the
+    /// normative `debtNeedMin` (the engine's `personalizedNeedHours`) — the SAME need the per-night
+    /// "Sleep Debt" tile uses, so the running-balance card and the tile agree — over each main night's
+    /// `totalSleepMin` plus actual asleep minutes from separately-recorded naps. (#242)
     static func debtLedger(days: [DailyMetric], napSleepMinByDay: [String: Double]) -> SleepDebtLedger {
         SleepDebt.ledger(
             series: days.map { day in
@@ -464,7 +480,7 @@ extension SleepModel {
                     mainSleepMin: day.totalSleepMin,
                     napSleepMin: napSleepMinByDay[day.day] ?? 0))
             },
-            needHours: sleepNeedMin(days: days) / 60.0)
+            needHours: debtNeedMin(days: days) / 60.0)
     }
 
     // MARK: - Build

--- a/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
@@ -2,6 +2,7 @@ package com.noop.ui
 
 import com.noop.analytics.AnalyticsEngine
 import com.noop.analytics.Baselines
+import com.noop.analytics.RestScorer
 import com.noop.analytics.SleepDebt
 import com.noop.analytics.SleepStageTotals
 import com.noop.data.DailyMetric
@@ -182,6 +183,14 @@ internal fun buildSleepModel(
 
     // Personal sleep need (minutes): mean asleep, floored at 7.5h (450 min).
     val needMin = max(450.0, typicalTotalMin ?: 450.0)
+    // #242: NORMATIVE need (min) the DEBT surfaces measure against — population-anchored, age-floored,
+    // upper-quartile personalizedNeedHours (the SAME estimator Rest/Intelligence score against), NOT the
+    // descriptive `needMin` mean which drifts toward a chronic under-sleeper's own deficit and quietly
+    // erases their debt. Age isn't plumbed here (null → adult target). One need across the debt tile +
+    // ledger + trend, agreeing with the engine. Need-unification from #464 by @vishk23; the descriptive
+    // `needMin` still drives the "hours vs needed" performance tile.
+    val debtNeedMin = RestScorer.personalizedNeedHours(
+        days.mapNotNull { it.totalSleepMin?.let { m -> m / 60.0 } }, null) * 60.0
 
     // Per-tile metrics — each a full pass over the FULL day history (asleep totals, no in-bed
     // substitution), latest = the most-recent day. Mirrors iOS SleepView, where every tile series
@@ -222,8 +231,8 @@ internal fun buildSleepModel(
         val series = days.mapNotNull { d ->
             imported.debtMin[d.day]   // minutes, export-verbatim
                 ?: SleepDebt.creditedSleepMin(d.totalSleepMin, napSleepMinByDay[d.day] ?: 0.0)
-                    ?.takeIf { needMin > 0.0 }
-                    ?.let { max(0.0, needMin - it) }   // APPROXIMATE fallback
+                    ?.takeIf { debtNeedMin > 0.0 }
+                    ?.let { max(0.0, debtNeedMin - it) }   // #242: normative need, not the self-referential mean
         }
         Metric(series.lastOrNull(), mean(series), series)
     }
@@ -232,10 +241,10 @@ internal fun buildSleepModel(
     // not the browsed night). Mirrors iOS's trailing trend over repo.days.
     val trendRows = days.filter { (it.totalSleepMin ?: 0.0) > 0.0 }.takeLast(14)
     val trendHours = trendRows.mapNotNull { it.totalSleepMin?.let { minutes -> minutes / 60.0 } }
-    val trendNeedHours = trendRows.map { row -> ((imported.needMin[row.day] ?: needMin) / 60.0) }
+    val trendNeedHours = trendRows.map { row -> ((imported.needMin[row.day] ?: debtNeedMin) / 60.0) }
     val trendDebtHours = trendRows.map { row ->
         val sleptMin = SleepDebt.creditedSleepMin(row.totalSleepMin, napSleepMinByDay[row.day] ?: 0.0) ?: 0.0
-        val neededMin = imported.needMin[row.day] ?: needMin
+        val neededMin = imported.needMin[row.day] ?: debtNeedMin   // #242: normative need, not the mean
         ((imported.debtMin[row.day] ?: max(0.0, neededMin - sleptMin)) / 60.0)
     }
     val trendDates = trendRows.map { it.day }
@@ -256,16 +265,16 @@ internal fun buildSleepModel(
     val realSegments = hypnogramSegments?.map { seg -> seg.stage to ((seg.end - seg.start) / 60f) }
 
     // Rolling 14-night sleep-debt ledger over the FULL day history (the analytics caps to the
-    // most-recent 14 counted nights and skips no-data nights), using the SAME personal need the
-    // tiles use (`needMin`, ≥ 7.5 h — the per-user override over the 8 h default). Full history,
-    // not the browsed-night window: the ledger is a "Last 14 nights" at-a-glance summary that
-    // matches the debt TILE (both read main-night totals plus separately decoded nap credit),
-    // and mirrors iOS's debtLedger over repo.days. (#242, #5)
+    // most-recent 14 counted nights and skips no-data nights), using the normative `debtNeedMin`
+    // (the engine's personalizedNeedHours) — the SAME need the debt TILE + trend use, so all debt
+    // surfaces agree. Full history, not the browsed-night window: the ledger is a "Last 14 nights"
+    // at-a-glance summary that matches the debt TILE (both read main-night totals plus separately
+    // decoded nap credit), and mirrors iOS's debtLedger over repo.days. (#242, #5)
     val sleepDebtLedger = SleepDebt.ledger(
         series = days.map { d ->
             d.day to SleepDebt.creditedSleepMin(d.totalSleepMin, napSleepMinByDay[d.day] ?: 0.0)
         },
-        needHours = needMin / 60.0,
+        needHours = debtNeedMin / 60.0,
     )
 
     return SleepModel(

--- a/android/app/src/test/java/com/noop/ui/SleepImportedFiguresTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepImportedFiguresTest.kt
@@ -134,10 +134,13 @@ class SleepImportedFiguresTest {
             deviceId = "my-whoop", startTs = 1780351200L, endTs = 1780387200L, efficiency = 90.0,
         )
         val m = buildSleepModel(days, session = session, todayKey = pinnedToday)!!
-        // need = max(450, mean asleep[420,410]=415) = 450. hours-vs-needed reads ASLEEP 410, not 600.
+        // hours-vs-needed (DESCRIPTIVE) still uses the mean need = max(450, mean[420,410]=415) = 450,
+        // and reads ASLEEP 410, not the 600-min in-bed window.
         assertEquals(410.0 / 450.0 * 100.0, m.hoursVsNeeded.latest!!, 1e-9)
-        // Debt tile reads ASLEEP too: max(0, 450 − 410) = 40, never max(0, 450 − 600) = 0.
-        assertEquals(40.0, m.sleepDebt.latest!!, 1e-9)
+        // Debt tile reads ASLEEP too, but against the NORMATIVE need now (#242): only 2 nights < the
+        // 7-night minimum, so personalizedNeedHours cold-starts to the 8 h population target = 480, and
+        // debt = max(0, 480 − 410) = 70, never max(0, 480 − 600) = 0.
+        assertEquals(70.0, m.sleepDebt.latest!!, 1e-9)
         // The debt TILE and the LEDGER agree (both asleep over the full history) — the #5 symptom.
         assertEquals(m.sleepDebt.latest, -m.sleepDebtLedger.nights.last().deltaMin, 1e-9)
     }


### PR DESCRIPTION
Makes the Sleep tab measure debt against the **same** sleep need the scoring engine uses. Extracted from @vishk23's **#464** (the need-unification half; the recency/cap/asymmetric ledger formula in #464 is left as a separate decision).

## The bug

Sleep need had **two definitions** on `main`:

- **Rest / Readiness scoring** → `AnalyticsEngine.Rest.personalizedNeedHours(nightlyHours:age:)` — population-anchored, age-floored, upper-quartile of nightly duration (#456, "your less-restricted nights").
- **The Sleep tab** (debt ledger + per-night debt tile + Android debt trend) → a separate `SleepModel.sleepNeedMin` / `SleepModelLogic.needMin` = `max(7.5h, mean-asleep)`.

So the app reported one "need" for scoring and a different one on the Sleep tab. Worse, the **mean-based** version drifts *down* toward a chronic under-sleeper's own deficit — quietly **erasing their debt** (a run of 6 h nights makes "need" ≈ 6 h, so debt ≈ 0). #456 (Wave 0) unified need *for scoring* but left the Sleep tab behind; this closes that follow-through gap.

## The change

Route every **debt** surface through the engine's `personalizedNeedHours` (via a `debtNeedMin` helper), both platforms:

- ledger card (`debtLedger` / `sleepDebtLedger`)
- per-night Sleep-Debt tile (`sleepDebtSeries` / `sleepDebt`)
- Android debt **trend** (`trendNeedHours` / `trendDebtHours`) — Android has this extra surface; Swift has no trend twin

The **descriptive "hours vs needed" performance tile deliberately stays on the mean** (it's a "vs your typical" read, not "vs target"). Imported per-day need/debt still win; only the *fallback* need changes. All debt surfaces now agree **with each other** and use the **same estimator** as the scoring engine.

> Precision note: the Sleep tab computes `personalizedNeedHours` over its own day history (`repo.days`), whereas the engine computes it over a trailing `maxDays` (~21-night) window. Same **estimator**, so the debt is now a defensible population-anchored/upper-quartile need instead of the self-referential mean — but it is not guaranteed to be the byte-identical value the engine computed for that run. Importing the engine's exact per-run need would be a larger change; this matches #464's `repo.days` approach and fixes the actual bug (the mean erasing debt).

Age isn't plumbed to the Sleep screen, so it floors at the adult target (`age: nil`) — matching #464; wiring profile age would only raise it for under-18s.

## Parity

`personalizedNeedHours` is already the byte-identical twin shared by the two engines (Swift `AnalyticsEngine.Rest` ↔ Kotlin `RestScorer`). Both platforms feed it the same series (`days.totalSleepMin/60`, dropping nil, `age: nil`), so **given the same `days`** the ledger balance + per-night debt are byte-identical across Swift/Kotlin — the same cross-platform contract the previous `sleepNeedMin`/`needMin` mean already relied on.

## Verification

- `compileFullDebugKotlin` + the sleep/debt suites green. `SleepImportedFiguresTest.sessionInBedWindowDoesNotSubstituteForAsleep` rebaselined: 2 nights < the 7-night minimum → `personalizedNeedHours` cold-starts to the 8 h population target (480), so the in-bed test's debt is `max(0, 480−410)=70` (was 40 under the mean). The test's other two assertions are unchanged — `hoursVsNeeded` still reads the mean (450), and the debt-tile == ledger agreement still holds — which validates the descriptive-vs-normative split.
- `SleepDebtTests` (pure ledger math) unaffected — those pass an explicit `needHours`; only the UI-layer need source changed.
- Swift `SleepModel` is app-target (no default CI) → validated via the on-demand **app-build gate** (Test Strand); there is no Swift `SleepModel` debt-value test to rebaseline.

## User-visible effect

Sleep-tab debt gets **more honest** — a chronic under-sleeper now sees real accumulated debt against the ~8 h target instead of ~0, and the Sleep tab stops disagreeing with Recovery/Readiness about how much sleep you need.

Refs #242. Extracts the need-unification from #464 (@vishk23).
