### PR TITLE
feat(hrv): persist a per-night R-R over-count flag for the HRV caveat (#1118)

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -137,6 +137,12 @@ final class IntelligenceEngine: ObservableObject {
         /// the night has no in-band @82 readings, or the owner is a WHOOP 4.0 (no v18 aux stream).
         /// Written to metricSeries as "spo2_candidate" under the "-noop" device ID in pass 2.
         let spo2Candidate: Int?
+        /// #1118: whether this night's in-sleep R-R is OVER-COUNTED (`crossSecondOverCount` /
+        /// `sameSecondOverCount`) — the WHOOP-4.0 two-optical-channel artifact that inflates R-R and
+        /// contaminates the displayed HRV. nil when the night has no in-sleep R-R (no HRV to caveat).
+        /// Persisted to metricSeries as "hrv_rr_overcount" (1/0) in pass 2 so the HRV card can flag the
+        /// reading "unverified" until the de-dup fix lands. Same verdict the always-on `hrv diag` logs.
+        let hrvOverCounted: Bool?
         /// #1169 SHADOW METRIC: the primary-session MEAN resting HR (PrimarySessionRestingHR, #1174) for this
         /// day, computed off the main actor beside the shipped nightly HR FLOOR (`daily.restingHr`). nil when
         /// no session clears the coverage gate. Written to metricSeries as "rhr_primary_session" in pass 2 —
@@ -845,7 +851,9 @@ final class IntelligenceEngine: ObservableObject {
                 let sleepRrRows = rr.filter { r in res.cachedSleep.contains { r.ts >= $0.startTs && r.ts < $0.endTs } }
                 let sleepRr = sleepRrRows.map { Double($0.rrMs) }
                 let hrvDiag: String?
+                let hrvOverCounted: Bool?   // #1118: nil = no in-sleep R-R (no HRV to caveat)
                 if sleepRr.isEmpty {
+                    hrvOverCounted = nil
                     // #1244: no in-sleep R-R means no HRV summary. If the whole night also detected NO
                     // session (past the ≥200-HR gate → this is the "HR tracked, no sleep" case), carry a
                     // counts-only reason line on the SAME loop-1 diagnostic channel (emitted in the
@@ -919,6 +927,9 @@ final class IntelligenceEngine: ObservableObject {
                         if !sample.isEmpty { diagLine += "\nhrv rrsample day=\(res.daily.day) \(sample)" }
                     }
                     hrvDiag = diagLine
+                    // #1118: flag this night's HRV as over-counted (same verdict the diag logs) so the
+                    // HRV card can mark the reading unverified until the two-channel de-dup lands.
+                    hrvOverCounted = (verdict == .crossSecondOverCount || verdict == .sameSecondOverCount)
                 }
                 // ── Steps test mode: 5/MG raw-counter trace ──────────────────────────────────────────────
                 // Only built when the Steps mode is on (the gate was read once before the loop). Recomputes
@@ -985,6 +996,7 @@ final class IntelligenceEngine: ObservableObject {
                                    readOwner: owner, hrRows: hr.count,
                                    sleepTrace: sleepTrace, stepsTrace: stepsTrace, hrvTrace: hrvTrace,
                                    hrvDiag: hrvDiag, spo2Candidate: spo2CandidateMean,
+                                   hrvOverCounted: hrvOverCounted,
                                    primarySessionRHR: primarySessionRHR,
                                    primarySessionRHRCoverage: primarySessionRHRCoverage))
             }
@@ -1004,6 +1016,9 @@ final class IntelligenceEngine: ObservableObject {
         var resolvedScoreOwnerByDay: [String: String] = [:]
         // #103: SpO₂ candidate @82 nightly mean per day, carried from pass 1 for metricSeries persistence.
         var spo2CandidateByDay: [String: Int] = [:]
+        // #1118: per-day HRV over-count flag, carried from pass 1 for metricSeries persistence. nil (absent)
+        // for a night with no in-sleep R-R; otherwise true/false, so a re-score always overwrites the row.
+        var hrvOverCountByDay: [String: Bool] = [:]
         // #1169: primary-session mean RHR shadow metric per day, carried from pass 1 for metricSeries persistence.
         var primarySessionRHRByDay: [String: Double] = [:]
         // #1169: its coverage inputs (valid-sample count + primary-session duration), same lifetime as the mean.
@@ -1024,6 +1039,10 @@ final class IntelligenceEngine: ObservableObject {
             // nil when the toggle is OFF or the night had no in-band @82 readings.
             if let cand = scan.spo2Candidate {
                 spo2CandidateByDay[res.daily.day] = cand
+            }
+            // #1118: carry the HRV over-count flag into pass 2 for metricSeries persistence.
+            if let oc = scan.hrvOverCounted {
+                hrvOverCountByDay[res.daily.day] = oc
             }
             // #1169: carry the primary-session mean RHR shadow metric into pass 2 for persistence.
             if let v = scan.primarySessionRHR {
@@ -1278,6 +1297,12 @@ final class IntelligenceEngine: ObservableObject {
             // split cross-device evidence and stays behind the experimental display toggle.
             if let cand = spo2CandidateByDay[daily.day] {
                 restPoints.append(MetricPoint(day: daily.day, key: "spo2_candidate", value: Double(cand)))
+            }
+            // #1118: persist the HRV over-count flag (1/0) so the HRV card can mark an over-counted 4.0
+            // night's reading "unverified" until the two-channel de-dup lands. 0 written on a clean night
+            // (not just absent) so a night that flips clean on re-score clears its prior flag.
+            if let oc = hrvOverCountByDay[daily.day] {
+                restPoints.append(MetricPoint(day: daily.day, key: "hrv_rr_overcount", value: oc ? 1.0 : 0.0))
             }
             // #1169 shadow metric: the primary-session mean RHR, stored beside the shipped floor
             // (daily.restingHr) under the "-noop" computed ID. Instrumentation only — never shown, never

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -411,6 +411,9 @@ object IntelligenceEngine {
         val scoredNights = ArrayList<DayResult>()
         // #103: SpO₂ candidate @82 nightly mean per day, carried from pass 1 for metricSeries persistence.
         val spo2CandidateByDay = LinkedHashMap<String, Int>()
+        // #1118: per-day HRV over-count flag, carried for metricSeries persistence. Absent for a night with
+        // no in-sleep R-R (no HRV to caveat); otherwise true/false, so a re-score always overwrites the row.
+        val hrvOverCountByDay = LinkedHashMap<String, Boolean>()
         // #1169: primary-session mean RHR shadow metric per day, carried from pass 1 for persistence.
         val primarySessionRHRByDay = LinkedHashMap<String, Double>()
         // #1169: its coverage inputs (valid-sample count + primary-session duration), same lifetime as the mean.
@@ -716,6 +719,11 @@ object IntelligenceEngine {
                 // #1008: on an OVER-COUNT night only, dump a raw-row sample around the densest second so the
                 // over-count's MECHANISM is readable from the always-on log (near-equal copies vs distinct
                 // trains vs a tagged channel) — clean nights stay quiet. srcChannel rides from the read model.
+                // #1118: flag this night's HRV as over-counted (same verdict the diag logs) so the HRV
+                // card can mark the reading unverified until the two-channel de-dup lands.
+                hrvOverCountByDay[res.daily.day] =
+                    (verdict == HrvAnalyzer.RrCoverageVerdict.CROSS_SECOND_OVER_COUNT ||
+                        verdict == HrvAnalyzer.RrCoverageVerdict.SAME_SECOND_OVER_COUNT)
                 if (verdict == HrvAnalyzer.RrCoverageVerdict.CROSS_SECOND_OVER_COUNT ||
                     verdict == HrvAnalyzer.RrCoverageVerdict.SAME_SECOND_OVER_COUNT) {
                     val sample = HrvAnalyzer.densestSecondWindowSample(
@@ -976,6 +984,12 @@ object IntelligenceEngine {
             // is ON. Written under the "-noop" computed device ID, never to `spo2Pct`.
             spo2CandidateByDay[daily.day]?.let { cand ->
                 restRows.add(MetricSeriesRow(deviceId = computedId, day = daily.day, key = "spo2_candidate", value = cand.toDouble()))
+            }
+            // #1118: persist the HRV over-count flag (1/0) so the HRV card can mark an over-counted 4.0
+            // night's reading "unverified" until the two-channel de-dup lands. 0 written on a clean night
+            // (not just absent) so a night that flips clean on re-score clears its prior flag.
+            hrvOverCountByDay[daily.day]?.let { oc ->
+                restRows.add(MetricSeriesRow(deviceId = computedId, day = daily.day, key = "hrv_rr_overcount", value = if (oc) 1.0 else 0.0))
             }
             // #1169 shadow metric: the primary-session mean RHR, stored beside the shipped floor
             // (daily.restingHr) under the "-noop" computed ID. Instrumentation only — never shown, never


### PR DESCRIPTION
Foundation for the #1118 HRV caveat: **persist** the per-night R-R over-count verdict so the HRV card can flag an unreliable reading. **No behaviour change to any score** — a new metricSeries key only.

## Why

WHOOP 4.0's two-optical-channel over-count (every beat reported twice ~30–35 ms apart) inflates R-R and contaminates the displayed deep-window HRV — the root cause of #1008 ("NOOP HRV ≠ WHOOP"). The over-count verdict is *already computed every pass* (the always-on `hrv diag` line) but **only logged**, so the HRV card can't see it to caveat the number.

## What

Each night whose in-sleep R-R is `crossSecondOverCount` / `sameSecondOverCount` writes **`hrv_rr_overcount = 1`** (else `0`) to the generic `metricSeries` under the `-noop` computed id — **no migration**, mirroring the `spo2_candidate` pattern:
- a night with no in-sleep R-R writes nothing (nil → no caveat possible);
- a clean re-score writes `0` so a night that flips clean clears its prior flag.

Byte-identical on both platforms: same verdict (`RrCoverageVerdict` cross/same-second), same key, same `1/0` encoding, same "absent when no R-R" semantics.

## Scope (deliberate split)

**Data foundation only.** The HRV-card **"unverified — over-reports R-R"** caption that *reads* this flag is the **immediate follow-up PR** (a `caveat` field on the vitals reading + a `readings()` param + the viewmodel load, both platforms). Splitting keeps this one concern — persist — clean, and the app-target UI change separate.

## Verification

- The verdict classification is already covered by `RrCoverageVerdictTests` / `HrvRrCoverageTest` on both platforms; this PR only maps that verdict → a boolean → a metricSeries row (the tested `spo2_candidate` write path).
- `compileFullDebugKotlin` green. Swift `IntelligenceEngine` is app-target → validated via the app-build gate.

Refs #1118.
