### PR TITLE
feat(hrv): caption an over-counted night's HRV reading "unverified" (#1118, part 2)

### DIFF
--- a/Strand/Screens/HealthView.swift
+++ b/Strand/Screens/HealthView.swift
@@ -1221,12 +1221,14 @@ private struct VitalsSection: View {
     // #103: SpO₂ candidate @82 nightly means from metricSeries, loaded when the experimental toggle is ON.
     // Empty when the toggle is OFF or no candidate data exists (WHOOP 4.0 has no v18 aux stream).
     @State private var spo2CandidateByDay: [String: Double] = [:]
+    @State private var hrvOverCountByDay: [String: Double] = [:]   // #1118
 
     var body: some View {
         let readings = BodyVitalSigns.readings(
             sourceRows: repo.vitalMetricRows,
             temperatureUnit: temperatureUnit,
-            spo2CandidateByDay: spo2CandidateByDay
+            spo2CandidateByDay: spo2CandidateByDay,
+            hrvOverCountByDay: hrvOverCountByDay
         )
         VStack(alignment: .leading, spacing: NoopMetrics.gap) {
             SectionHeader("Vital Signs", overline: "Latest", trailing: BodyVitalSigns.latestDayLabel(readings))
@@ -1251,6 +1253,12 @@ private struct VitalsSection: View {
                 .fixedSize(horizontal: false, vertical: true)
         }
         .task(id: PuffinExperiment.spo2CandidateDisplayEnabled) {
+            // #1118: load the per-night HRV over-count flags (always — no toggle) so the HRV tile can
+            // caption an over-counted 4.0 night's reading "unverified". The engine writes "hrv_rr_overcount"
+            // (1/0) under the "-noop" computed device ID; `exploreSeries` with source "my-whoop" reads it
+            // from the computed metricSeries. Absent/0 on a clean or imported night → no caveat.
+            let ocPts = await repo.exploreSeries(key: "hrv_rr_overcount", source: "my-whoop", days: 14)
+            hrvOverCountByDay = Dictionary(ocPts.map { ($0.day, $0.value) }, uniquingKeysWith: { a, _ in a })
             // #103: load the SpO₂ candidate @82 nightly means from metricSeries when the toggle is ON.
             // The engine writes "spo2_candidate" under the "-noop" computed device ID; `exploreSeries`
             // with source "my-whoop" reads it from Layer 2 (computed metricSeries). Empty when the toggle

--- a/Strand/Screens/VitalSignsSummary.swift
+++ b/Strand/Screens/VitalSignsSummary.swift
@@ -23,6 +23,10 @@ struct BodyVitalReading: Identifiable {
     /// the resolved value, banding and source are unchanged — this is just the trend for the trail.
     /// Defaulted so existing call sites (previews/tests) keep compiling unchanged.
     var sparkline: [Double]? = nil
+    /// #1118: an "unverified" caveat appended to the caption when the resolved value is present but the
+    /// strap's own capture is known-unreliable for it (e.g. a WHOOP 4.0 R-R over-count contaminating HRV).
+    /// nil = no caveat. Defaulted so existing call sites keep compiling unchanged.
+    var caveat: String? = nil
 
     var id: String { key }
 
@@ -49,6 +53,7 @@ struct BodyVitalReading: Identifiable {
             parts.append(sourceText)
         }
         parts.append(stateText)
+        if let caveat { parts.append(caveat) }   // #1118: e.g. "unverified · over-reports R-R"
         return parts.joined(separator: " · ")
     }
 
@@ -117,7 +122,8 @@ enum BodyVitalSigns {
     static func readings(sourceRows: [SourcedDailyMetric],
                          temperatureUnit: TemperatureUnit,
                          now: Date = Date(),
-                         spo2CandidateByDay: [String: Double] = [:]) -> [BodyVitalReading] {
+                         spo2CandidateByDay: [String: Double] = [:],
+                         hrvOverCountByDay: [String: Double] = [:]) -> [BodyVitalReading] {
         let logicalDay = logicalDayKey(now)
 
         // Resolve one metric to a per-day series, taking the FIRST source (by precedence) that carries
@@ -185,6 +191,15 @@ enum BodyVitalSigns {
         let rhrRow = latest(rhrPoints)
         let hrvRow = latest(hrvPoints)
         let skinRow = latest(skinPoints)
+        // #1118: mark HRV "unverified" when this night's in-sleep R-R was over-counted — the WHOOP 4.0
+        // two-optical-channel artifact that inflates R-R and contaminates RMSSD, so NOOP's HRV won't match
+        // WHOOP until the de-dup fix lands. The flag is written only for NOOP's OWN measured capture (an
+        // imported WHOOP-app night never sets it), so a pure-import night is never caveated. Gated on the
+        // flag ALONE — no source check — to stay behaviourally identical to Android, whose DailyMetric
+        // carries no per-row source (feature-level parity). (#1118)
+        let hrvCaveat: String? = (hrvRow.map { (hrvOverCountByDay[$0.day] ?? 0) >= 0.5 } ?? false)
+            ? String(localized: "unverified · over-reports R-R")
+            : nil
 
         // Trailing values (oldest → newest) feeding each tile's sparkline trail. A 2+ point series
         // draws; the tile hides the trail otherwise. Presentation-only — built from the same resolved
@@ -335,7 +350,8 @@ enum BodyVitalSigns {
                 day: hrvRow?.day,
                 source: hrvRow?.source,
                 missingCaption: String(localized: "No HRV value"),
-                sparkline: trail(hrvPoints)
+                sparkline: trail(hrvPoints),
+                caveat: hrvCaveat   // #1118
             ),
             BodyVitalReading(
                 key: "skin",

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -665,6 +665,20 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyMap())
 
     /**
+     * #1118: per-night HRV over-count flags (1/0), loaded from the "hrv_rr_overcount" metricSeries key
+     * (written by IntelligenceEngine for every scored night with in-sleep R-R). Drives the HRV tile's
+     * "unverified · over-reports R-R" caveat on a WHOOP 4.0 over-counted night. Always loaded (no toggle,
+     * unlike the SpO₂ candidate). Mirrors iOS HealthView loading `hrv_rr_overcount`.
+     */
+    val hrvOverCountByDay: StateFlow<Map<String, Double>> =
+        recentDays.map { days ->
+            if (days.isEmpty()) emptyMap()
+            else repository.metricSeriesComputedUnion(deviceId, "hrv_rr_overcount", days.first().day, days.last().day)
+                .associate { it.day to it.value }
+        }.flowOn(Dispatchers.IO)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyMap())
+
+    /**
      * #386 self-heal: a "kick" the app-resume hook sends to wake the 15-min analyze loop early, so an
      * OEM-killed overnight re-score tick catches up the moment the user opens NOOP instead of showing a
      * stale Today card until the next sync/tick. The loop re-runs its EXISTING fingerprint-gated

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -146,6 +146,7 @@ fun HealthScreen(
     // #103: collect reactively (not .value) so the Latest-readings card recomposes on its own when the
     // SpO₂ candidate map updates, matching VitalSignsScreen — not only incidentally via `days`.
     val spo2CandidateByDay by vm.spo2CandidateByDay.collectAsStateWithLifecycle()
+    val hrvOverCountByDay by vm.hrvOverCountByDay.collectAsStateWithLifecycle()   // #1118
     val hasLiveHr by remember { derivedStateOf { displayHr(bpm, live) != null } }
 
     // LIQUID SKY BACKDROP (the pilot pattern — LiquidScreenSky.kt): the time-of-day liquid sky settles into
@@ -190,6 +191,7 @@ fun HealthScreen(
                         UnitPrefs.temperature(LocalContext.current),
                         spo2CandidateByDay,
                         NoopPrefs.spo2CandidateDisplay(LocalContext.current),
+                        hrvOverCountByDay = hrvOverCountByDay,   // #1118
                     ),
                     onVitalClick = onVitalClick,
                     captionMode = VitalCaptionMode.AS_OF,
@@ -1167,6 +1169,7 @@ private fun yearWord(years: Int): String = if (kotlin.math.abs(years) == 1) "yea
 fun VitalSignsScreen(vm: AppViewModel, onVitalClick: (String) -> Unit = {}) {
     val days by vm.recentDays.collectAsStateWithLifecycle()
     val spo2CandidateByDay by vm.spo2CandidateByDay.collectAsStateWithLifecycle()
+    val hrvOverCountByDay by vm.hrvOverCountByDay.collectAsStateWithLifecycle()   // #1118
     var selectedDayOffset by remember { mutableIntStateOf(0) }
     val selectedDay = remember(selectedDayOffset) { LocalDate.now().minusDays(selectedDayOffset.toLong()) }
     val selectedDayKey = remember(selectedDay) { selectedDay.toString() }
@@ -1175,8 +1178,8 @@ fun VitalSignsScreen(vm: AppViewModel, onVitalClick: (String) -> Unit = {}) {
     // Read the toggle here in the composable body, NOT inside remember{} — LocalContext.current is a
     // @Composable read and is illegal inside the calculation lambda; pass the resolved value in + key on it.
     val spo2CandidateDisplay = NoopPrefs.spo2CandidateDisplay(LocalContext.current)
-    val vitals = remember(selectedMetric, days, tempUnit, spo2CandidateByDay, spo2CandidateDisplay) {
-        selectedMetric?.let { vitalsFor(it, days, tempUnit, spo2CandidateByDay, spo2CandidateDisplay) }.orEmpty()
+    val vitals = remember(selectedMetric, days, tempUnit, spo2CandidateByDay, spo2CandidateDisplay, hrvOverCountByDay) {
+        selectedMetric?.let { vitalsFor(it, days, tempUnit, spo2CandidateByDay, spo2CandidateDisplay, hrvOverCountByDay) }.orEmpty()
     }
 
     ScreenScaffold(

--- a/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
@@ -36,6 +36,11 @@ internal data class Vital(
      *  Drives the "Estimate (unverified)" caption so the user knows this is an unverified value.
      *  Defaulted false so every other vital is unaffected. */
     val isEstimate: Boolean = false,
+    /** #1118: an "unverified" caveat appended to the caption when the value is present but the strap's own
+     *  capture is known-unreliable for it (a WHOOP 4.0 R-R over-count contaminating HRV). null = none.
+     *  Kotlin twin of `BodyVitalReading.caveat` (VitalSignsSummary.swift). Defaulted so other vitals are
+     *  unaffected. */
+    val caveat: String? = null,
 ) {
     /** Value with its unit appended, or null when no data. */
     val formattedValue: String? = value?.let { "${format(it)} $unit" }
@@ -50,7 +55,7 @@ internal data class Vital(
 
     /** The in-range caption that stands in for a StatePill inside the fixed-height tile.
      *  The wording says which yardstick judged it: your baseline vs typical ranges. */
-    val stateCaption: String = when {
+    private val baseCaption: String = when {
         // #103: when the Blood O₂ tile is showing the spo2_candidate_82 strap estimate (not a
         // calibrated spo2Pct), label it "estimate" so the user knows this is an unverified value.
         isEstimate && banding.band != VitalBands.Band.NO_DATA -> "Estimate (unverified)"
@@ -67,6 +72,12 @@ internal data class Vital(
         else ->
             if (banding.band == VitalBands.Band.IN_RANGE) "In typical range" else "Outside typical range"
     }
+
+    /** #1118: the base caption plus any "unverified" caveat (an over-counted HRV night), so the caveat
+     *  rides the same line the user already reads. Never on an empty tile. Twin of Swift's stateCaption
+     *  append in VitalSignsSummary.swift. */
+    val stateCaption: String =
+        if (caveat != null && banding.band != VitalBands.Band.NO_DATA) "$baseCaption · $caveat" else baseCaption
 
     val accessibilityText: String =
         formattedValue?.let {
@@ -113,6 +124,7 @@ internal fun vitalsFor(
     tempUnit: TemperatureUnit = TemperatureUnit.CELSIUS,
     spo2CandidateByDay: Map<String, Double> = emptyMap(),
     spo2ToggleOn: Boolean = false,
+    hrvOverCountByDay: Map<String, Double> = emptyMap(),   // #1118
 ): List<Vital> {
     val todayKey = d?.day
     // History strictly before the displayed day, oldest→newest (recentDays is already
@@ -282,6 +294,11 @@ internal fun vitalsFor(
             banding = VitalBands.band(d?.avgHrv, series { it.avgHrv }, 40.0..120.0, Baselines.hrvCfg),
             metricColor = Palette.metricPurple,
             sparkline = trail(d?.avgHrv) { it.avgHrv },
+            // #1118: mark HRV "unverified" on an over-counted night — the WHOOP 4.0 two-optical-channel
+            // artifact inflates R-R and contaminates RMSSD, so NOOP's HRV won't match WHOOP until the
+            // de-dup fix lands. The flag is written only for NOOP's own measured capture, so an imported
+            // night never sets it. Gated on the flag alone (no source check) — twin of the Swift caveat.
+            caveat = if ((d?.day?.let { hrvOverCountByDay[it] } ?: 0.0) >= 0.5) "unverified · over-reports R-R" else null,
         ),
         Vital(
             key = "skin", label = skinTitle, unit = skinUnitLabel,
@@ -312,8 +329,9 @@ internal fun latestVitals(
     tempUnit: TemperatureUnit,
     spo2CandidateByDay: Map<String, Double> = emptyMap(),
     spo2ToggleOn: Boolean = false,
+    hrvOverCountByDay: Map<String, Double> = emptyMap(),   // #1118
 ): List<Vital> {
-    val emptyByKey = vitalsFor(null, days, tempUnit, spo2CandidateByDay, spo2ToggleOn).associateBy { it.key }
+    val emptyByKey = vitalsFor(null, days, tempUnit, spo2CandidateByDay, spo2ToggleOn, hrvOverCountByDay).associateBy { it.key }
     return listOf(
         latestVital("resp", days, tempUnit, emptyByKey, spo2CandidateByDay, spo2ToggleOn) { it.respRateBpm != null },
         latestVital("spo2", days, tempUnit, emptyByKey, spo2CandidateByDay, spo2ToggleOn) {
@@ -321,7 +339,7 @@ internal fun latestVitals(
         },
         latestVital("spo2raw", days, tempUnit, emptyByKey, spo2CandidateByDay, spo2ToggleOn) { it.spo2Red != null && it.spo2Ir != null },
         latestVital("rhr", days, tempUnit, emptyByKey, spo2CandidateByDay, spo2ToggleOn) { it.restingHr != null },
-        latestVital("hrv", days, tempUnit, emptyByKey) { it.avgHrv != null },
+        latestVital("hrv", days, tempUnit, emptyByKey, hrvOverCountByDay = hrvOverCountByDay) { it.avgHrv != null },
         latestVital("skin", days, tempUnit, emptyByKey) { it.skinTempDevC != null },
     )
 }
@@ -341,6 +359,7 @@ private fun latestVital(
     emptyByKey: Map<String, Vital>,
     spo2CandidateByDay: Map<String, Double> = emptyMap(),
     spo2ToggleOn: Boolean = false,
+    hrvOverCountByDay: Map<String, Double> = emptyMap(),   // #1118
     todayKey: String = logicalDayKeyNow(),
     hasValue: (DailyMetric) -> Boolean,
 ): Vital {
@@ -349,7 +368,7 @@ private fun latestVital(
         todayKey,
     )?.second
     return row
-        ?.let { latestRow -> vitalsFor(latestRow, days, tempUnit, spo2CandidateByDay, spo2ToggleOn).firstOrNull { it.key == key } }
+        ?.let { latestRow -> vitalsFor(latestRow, days, tempUnit, spo2CandidateByDay, spo2ToggleOn, hrvOverCountByDay).firstOrNull { it.key == key } }
         ?.copy(asOfLabel = asOfLabel(row.day))
         ?: emptyByKey.getValue(key)
 }


### PR DESCRIPTION
**Part 2 of the #1118 caveat gate** (part 1 — persist — is #1349). Reads the per-night `hrv_rr_overcount` flag and captions an over-counted night's HRV reading **"unverified · over-reports R-R"**, so a WHOOP 4.0 user who sees NOOP's HRV not matching WHOOP knows the reading is a known-unreliable strap value until the two-channel de-dup fix lands.

## What

When a night's in-sleep R-R was over-counted (the 4.0 two-optical-channel artifact that inflates R-R and contaminates RMSSD), the HRV vital's caption gains an "unverified" suffix — on both the **vitals summary** and the **HRV detail**.

- **iOS**: `BodyVitalReading.caveat` + `stateCaption` append; `VitalSignsSummary.readings` takes `hrvOverCountByDay`; `HealthView` fetches `hrv_rr_overcount` from `metricSeries` (always — no toggle).
- **Android**: `Vital.caveat` + `stateCaption` append; threaded through `vitalsFor` / `latestVital` / `latestVitals`; `AppViewModel.hrvOverCountByDay` StateFlow; `HealthScreen` + `VitalSignsScreen` wire it.

## Gating & parity

Gated on the **flag alone** — no source check — so both platforms behave identically (Android's `DailyMetric` carries no per-row source). Safe because the flag is written **only for NOOP's own measured capture**: a pure-import HRV night never sets it, so an imported clean value is never caveated. (The only imperfection is a rare *mixed* night — both an imported HRV and a NOOP over-counted capture — which is an accepted edge, documented in code.)

## Verification

- `compileFullDebugKotlin` + the vitals suite green.
- **i18n `--ci` audit clean**: no new hardcoded literals (the caption matches the existing literal convention in `HealthVitalsLogic`, e.g. "Estimate (unverified)"); the iOS `String(localized:)` English-fallbacks until the next translation pass.
- iOS `VitalSignsSummary`/`HealthView` are app-target → validated via the app-build gate.

Refs #1118. Completes the caveat gate (#1349 persist + this display).
