### PR TITLE
diag(hrv): shadow-log a deduped R-R stream to validate the over-count fix (#1331/#1008/#1118)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -561,6 +561,37 @@ public enum HRVAnalyzer {
     /// deliberately same-second-ONLY: R-R ts are stored at second resolution, and at rest genuine
     /// consecutive beats are ~1 s apart, so collapsing ACROSS a second would drop real beats. Deterministic
     /// (ts, rr, index) ordering. Byte-parity twin of Kotlin `HrvAnalyzer.collapsedCoverage`.
+    /// #1008/#1118/#1331 SHADOW de-dup: collapse the WHOOP 4.0 R-R over-count. A same-second beat whose
+    /// value is within `rrTolMs` of one already kept in that second (the exact duplicates AND the
+    /// two-optical-channel ~34 ms pairs — hence a wider default tol than `collapsedCoverage`'s 30 ms) is
+    /// dropped, keeping one representative. Returns the deduped `(tsSec, rrMs)` in ts-ASC order.
+    ///
+    /// INSTRUMENTATION ONLY — the shipped HRV/resp path is unchanged; the always-on `hrv diag` line logs
+    /// RMSSD / coverage / beat-accuracy of BOTH the raw and the deduped stream so the de-dup can be
+    /// validated against WHOOP's own numbers and @artemc's Polar H10 (#1118) BEFORE it ever becomes the
+    /// read path (the "validate against the artifact, not one match" rule). Pure. Mirrors Kotlin
+    /// `HrvAnalyzer.collapseOverCount`.
+    public static func collapseOverCount(tsSec: [Int], rrMs: [Double], rrTolMs: Double = 40)
+        -> (tsSec: [Int], rrMs: [Double]) {
+        let n = min(tsSec.count, rrMs.count)
+        guard n >= 2 else { return (tsSec, rrMs) }
+        let order = (0..<n).sorted { a, b in (tsSec[a], rrMs[a], a) < (tsSec[b], rrMs[b], b) }
+        var keptTs: [Int] = []
+        var keptRr: [Double] = []
+        for idx in order {
+            let t = tsSec[idx]
+            let r = rrMs[idx]
+            var dup = false
+            var j = keptTs.count - 1
+            while j >= 0 && keptTs[j] == t {      // only beats already kept in the SAME second
+                if abs(keptRr[j] - r) <= rrTolMs { dup = true; break }
+                j -= 1
+            }
+            if !dup { keptTs.append(t); keptRr.append(r) }
+        }
+        return (keptTs, keptRr)
+    }
+
     public static func collapsedCoverage(tsSec: [Int], rrMs: [Double], rrTolMs: Double = 30) -> Double {
         let n = min(tsSec.count, rrMs.count)
         guard n >= 2 else { return 0 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HrvCollapseOverCountTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HrvCollapseOverCountTests.swift
@@ -35,6 +35,18 @@ final class HrvCollapseOverCountTests: XCTestCase {
                        "deduped coverage collapses toward 1.0")
     }
 
+    func testCollapseOverCountExactDupOnlyKeepsTheChannelTwin() {
+        // rrTolMs 0 collapses ONLY exact same-second duplicates (safe floor — no real-beat loss). The
+        // ~34 ms channel twin survives, so 180 (=60x[beat + exact-dup + twin]) → 120 (=60x[beat + twin])
+        // and coverage stays ~2x. This is the reference line the shadow logs beside the ~40 ms one.
+        let (ts, rr) = overCounted()
+        let ex = HRVAnalyzer.collapseOverCount(tsSec: ts, rrMs: rr, rrTolMs: 0)
+        XCTAssertEqual(ex.rrMs.count, 120, "exact-dup removed, channel twin kept")
+        XCTAssertEqual(ex.tsSec.count, 120)
+        XCTAssertGreaterThan(HRVAnalyzer.rrCoverage(tsSec: ex.tsSec, rrMs: ex.rrMs), 1.8,
+                             "exact-dup coverage stays ~2x (twins remain)")
+    }
+
     func testCollapseOverCountLeavesACleanStreamUntouched() {
         // A beat-accurate stream (one beat per second, no same-second duplicates) passes through as-is.
         let ts = Array(0..<60)

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HrvCollapseOverCountTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HrvCollapseOverCountTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// #1008/#1118/#1331: `HRVAnalyzer.collapseOverCount` — the SHADOW de-dup of the WHOOP 4.0 R-R over-count.
+/// Pins that a synthetic over-count (each real beat emitted three times — an exact duplicate plus a
+/// two-optical-channel twin ~34 ms off, the #1008 signature) collapses back to ~one beat per real
+/// interval, so coverage drops from ~3x toward ~1.0 and the stream becomes beat-accurate again (which is
+/// what would let it pass #1127's RSA gate — the #1331 fix). Mirrors the Android HrvCollapseOverCountTest.
+final class HrvCollapseOverCountTests: XCTestCase {
+
+    /// 60 real beats, one per second at 1000 ms, each emitted 3x in its second: exact dup + a ~34 ms twin.
+    private func overCounted() -> (tsSec: [Int], rrMs: [Double]) {
+        var ts: [Int] = []
+        var rr: [Double] = []
+        for s in 0..<60 {
+            let base = 1000.0
+            ts.append(s); rr.append(base)             // channel A: the beat
+            ts.append(s); rr.append(base)             // exact duplicate
+            ts.append(s); rr.append(base + 34.0)      // channel B: same beat, ~34 ms off, same second
+        }
+        return (ts, rr)
+    }
+
+    func testCollapseOverCountRecoversOneBeatPerInterval() {
+        let (ts, rr) = overCounted()
+        XCTAssertEqual(rr.count, 180, "fixture is 3x over-counted")
+        let rawCov = HRVAnalyzer.rrCoverage(tsSec: ts, rrMs: rr)
+        XCTAssertGreaterThan(rawCov, 2.5, "raw over-counted coverage should be ~3x, was \(rawCov)")
+
+        let dd = HRVAnalyzer.collapseOverCount(tsSec: ts, rrMs: rr)
+        // Exact dup + the 34 ms twin (< 40 ms tol) both collapse → one beat per second.
+        XCTAssertEqual(dd.rrMs.count, 60, "deduped to one beat per real interval")
+        XCTAssertEqual(dd.tsSec.count, 60, "ts and rr stay in lockstep")
+        XCTAssertEqual(HRVAnalyzer.rrCoverage(tsSec: dd.tsSec, rrMs: dd.rrMs), 1.0, accuracy: 0.1,
+                       "deduped coverage collapses toward 1.0")
+    }
+
+    func testCollapseOverCountLeavesACleanStreamUntouched() {
+        // A beat-accurate stream (one beat per second, no same-second duplicates) passes through as-is.
+        let ts = Array(0..<60)
+        let rr = [Double](repeating: 1000.0, count: 60)
+        let dd = HRVAnalyzer.collapseOverCount(tsSec: ts, rrMs: rr)
+        XCTAssertEqual(dd.rrMs.count, 60)
+        XCTAssertEqual(dd.tsSec, ts)
+    }
+}

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -925,6 +925,19 @@ final class IntelligenceEngine: ObservableObject {
                         let sample = HRVAnalyzer.densestSecondWindowSample(
                             tsSec: ts, rrMs: sleepRr, srcCodes: sleepRrRows.map { $0.srcChannel?.rawValue })
                         if !sample.isEmpty { diagLine += "\nhrv rrsample day=\(res.daily.day) \(sample)" }
+                        // #1331/#1008/#1118 SHADOW: log the DEDUPED stream's HRV + coverage + beat-accuracy
+                        // beside the raw (above), so the candidate two-channel de-dup can be validated
+                        // against WHOOP's own numbers and @artemc's Polar H10 BEFORE it becomes the read
+                        // path. Instrumentation only — the shipped HRV/resp is unchanged. If de-dup works:
+                        // coverage→~1.0, beatAccurate high (would pass #1127's RSA gate → resp returns, the
+                        // #1331 fix), and rmssd/sdnn become physiological + should match WHOOP. Kotlin twin.
+                        let dd = HRVAnalyzer.collapseOverCount(tsSec: ts, rrMs: sleepRr)
+                        let hDd = HRVAnalyzer.analyze(rawRR: dd.rrMs)
+                        let covDd = HRVAnalyzer.rrCoverage(tsSec: dd.tsSec, rrMs: dd.rrMs)
+                        let accDd = HRVAnalyzer.beatAccurateFraction(tsSec: dd.tsSec, rrMs: dd.rrMs)
+                        diagLine += "\nhrv dedup day=\(res.daily.day) n=\(dd.rrMs.count)/\(sleepRr.count) "
+                            + "rmssd=\(ms(hDd.rmssd))ms sdnn=\(ms(hDd.sdnn))ms meanNN=\(ms(hDd.meanNN))ms "
+                            + "coverage=\(String(format: "%.2f", covDd)) beatAccurate=\(String(format: "%.2f", accDd))"
                     }
                     hrvDiag = diagLine
                     // #1118: flag this night's HRV as over-counted (same verdict the diag logs) so the

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -931,13 +931,21 @@ final class IntelligenceEngine: ObservableObject {
                         // path. Instrumentation only — the shipped HRV/resp is unchanged. If de-dup works:
                         // coverage→~1.0, beatAccurate high (would pass #1127's RSA gate → resp returns, the
                         // #1331 fix), and rmssd/sdnn become physiological + should match WHOOP. Kotlin twin.
+                        // Two candidates so validation isn't confounded: EXACT-dup collapse (rrTolMs 0 —
+                        // same ts AND same value, provably no real-beat loss) is the safe floor; the ~40 ms
+                        // same-second collapse is the aggressive UPPER BOUND (it also catches the two-channel
+                        // twins but can over-merge two real neighbours whose values sit within 40 ms). The
+                        // real de-dup lives between them; the log shows both so we can see where.
+                        let ex = HRVAnalyzer.collapseOverCount(tsSec: ts, rrMs: sleepRr, rrTolMs: 0)
                         let dd = HRVAnalyzer.collapseOverCount(tsSec: ts, rrMs: sleepRr)
                         let hDd = HRVAnalyzer.analyze(rawRR: dd.rrMs)
+                        let covEx = HRVAnalyzer.rrCoverage(tsSec: ex.tsSec, rrMs: ex.rrMs)
                         let covDd = HRVAnalyzer.rrCoverage(tsSec: dd.tsSec, rrMs: dd.rrMs)
                         let accDd = HRVAnalyzer.beatAccurateFraction(tsSec: dd.tsSec, rrMs: dd.rrMs)
-                        diagLine += "\nhrv dedup day=\(res.daily.day) n=\(dd.rrMs.count)/\(sleepRr.count) "
-                            + "rmssd=\(ms(hDd.rmssd))ms sdnn=\(ms(hDd.sdnn))ms meanNN=\(ms(hDd.meanNN))ms "
-                            + "coverage=\(String(format: "%.2f", covDd)) beatAccurate=\(String(format: "%.2f", accDd))"
+                        diagLine += "\nhrv dedup day=\(res.daily.day) exactN=\(ex.rrMs.count)/\(sleepRr.count) "
+                            + "covExact=\(String(format: "%.2f", covEx)) | ch40N=\(dd.rrMs.count) "
+                            + "cov40=\(String(format: "%.2f", covDd)) beatAcc40=\(String(format: "%.2f", accDd)) "
+                            + "rmssd40=\(ms(hDd.rmssd))ms sdnn40=\(ms(hDd.sdnn))ms meanNN40=\(ms(hDd.meanNN))ms"
                     }
                     hrvDiag = diagLine
                     // #1118: flag this night's HRV as over-counted (same verdict the diag logs) so the

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -510,6 +510,35 @@ object HrvAnalyzer {
      *  deliberately same-second-ONLY: R-R ts are stored at second resolution, and at rest genuine
      *  consecutive beats are ~1 s apart, so collapsing ACROSS a second would drop real beats. Deterministic
      *  (ts, rr, index) ordering. Byte-parity twin of Swift `HRVAnalyzer.collapsedCoverage`. */
+    /**
+     * #1008/#1118/#1331 SHADOW de-dup: collapse the WHOOP 4.0 R-R over-count. A same-second beat whose
+     * value is within [rrTolMs] of one already kept that second (exact duplicates AND the two-optical-
+     * channel ~34 ms pairs — hence a wider default tol than [collapsedCoverage]'s 30 ms) is dropped,
+     * keeping one representative. Returns the deduped (tsSec, rrMs) in ts-ASC order. INSTRUMENTATION ONLY:
+     * the shipped HRV/resp path is unchanged; the always-on `hrv diag` logs BOTH raw and deduped so the
+     * de-dup can be validated vs WHOOP + @artemc's Polar (#1118) before it becomes the read path. Pure.
+     * Mirrors Swift `HRVAnalyzer.collapseOverCount`.
+     */
+    fun collapseOverCount(tsSec: List<Long>, rrMs: List<Double>, rrTolMs: Double = 40.0): Pair<List<Long>, List<Double>> {
+        val n = minOf(tsSec.size, rrMs.size)
+        if (n < 2) return Pair(tsSec, rrMs)
+        val order = (0 until n).sortedWith(compareBy({ tsSec[it] }, { rrMs[it] }, { it }))
+        val keptTs = ArrayList<Long>(n)
+        val keptRr = ArrayList<Double>(n)
+        for (idx in order) {
+            val t = tsSec[idx]
+            val r = rrMs[idx]
+            var dup = false
+            var j = keptTs.size - 1
+            while (j >= 0 && keptTs[j] == t) {      // only beats already kept in the SAME second
+                if (abs(keptRr[j] - r) <= rrTolMs) { dup = true; break }
+                j--
+            }
+            if (!dup) { keptTs.add(t); keptRr.add(r) }
+        }
+        return Pair(keptTs, keptRr)
+    }
+
     fun collapsedCoverage(tsSec: List<Long>, rrMs: List<Double>, rrTolMs: Double = 30.0): Double {
         val n = minOf(tsSec.size, rrMs.size)
         if (n < 2) return 0.0

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -500,16 +500,6 @@ object HrvAnalyzer {
         return dups
     }
 
-    /** #550: coverage AFTER collapsing SAME-SECOND near-duplicate beats (equal ts AND |Δrr| ≤ [rrTolMs])
-     *  to a single representative — a PREVIEW of what an R-R de-duplication fix would achieve, for the
-     *  always-on #257 diag ONLY. It does NOT feed the shipped nightly HRV. On clean data (no same-second
-     *  duplicates) it equals [rrCoverage]; when a live+historical merge double-stamps the same beat WITHIN
-     *  one second, it falls toward ~1. If it stays well above 1, the duplication is CROSS-second (the two
-     *  copies land in adjacent seconds), which a same-second collapse cannot catch — telling us the real
-     *  fix must reconcile the two ingest paths rather than dedup within a second. The collapse is
-     *  deliberately same-second-ONLY: R-R ts are stored at second resolution, and at rest genuine
-     *  consecutive beats are ~1 s apart, so collapsing ACROSS a second would drop real beats. Deterministic
-     *  (ts, rr, index) ordering. Byte-parity twin of Swift `HRVAnalyzer.collapsedCoverage`. */
     /**
      * #1008/#1118/#1331 SHADOW de-dup: collapse the WHOOP 4.0 R-R over-count. A same-second beat whose
      * value is within [rrTolMs] of one already kept that second (exact duplicates AND the two-optical-
@@ -539,6 +529,16 @@ object HrvAnalyzer {
         return Pair(keptTs, keptRr)
     }
 
+    /** #550: coverage AFTER collapsing SAME-SECOND near-duplicate beats (equal ts AND |Δrr| ≤ [rrTolMs])
+     *  to a single representative — a PREVIEW of what an R-R de-duplication fix would achieve, for the
+     *  always-on #257 diag ONLY. It does NOT feed the shipped nightly HRV. On clean data (no same-second
+     *  duplicates) it equals [rrCoverage]; when a live+historical merge double-stamps the same beat WITHIN
+     *  one second, it falls toward ~1. If it stays well above 1, the duplication is CROSS-second (the two
+     *  copies land in adjacent seconds), which a same-second collapse cannot catch — telling us the real
+     *  fix must reconcile the two ingest paths rather than dedup within a second. The collapse is
+     *  deliberately same-second-ONLY: R-R ts are stored at second resolution, and at rest genuine
+     *  consecutive beats are ~1 s apart, so collapsing ACROSS a second would drop real beats. Deterministic
+     *  (ts, rr, index) ordering. Byte-parity twin of Swift `HRVAnalyzer.collapsedCoverage`. */
     fun collapsedCoverage(tsSec: List<Long>, rrMs: List<Double>, rrTolMs: Double = 30.0): Double {
         val n = minOf(tsSec.size, rrMs.size)
         if (n < 2) return 0.0

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -730,6 +730,19 @@ object IntelligenceEngine {
                         ts, sleepRr, sleepRrRows.map { it.srcChannel },
                     )
                     if (sample.isNotEmpty()) diag("hrv rrsample day=${res.daily.day} $sample")
+                    // #1331/#1008/#1118 SHADOW: log the DEDUPED stream's HRV + coverage + beat-accuracy
+                    // beside the raw so the candidate de-dup can be validated vs WHOOP + @artemc's Polar
+                    // before it becomes the read path. Instrumentation only — shipped HRV/resp unchanged.
+                    // If de-dup works: coverage→~1.0, beatAccurate high (would pass #1127's RSA gate →
+                    // resp returns = the #1331 fix), rmssd/sdnn physiological. Twin of the Swift line.
+                    val dd = HrvAnalyzer.collapseOverCount(ts, sleepRr)
+                    val hDd = HrvAnalyzer.analyzeRaw(dd.second)
+                    val covDd = HrvAnalyzer.rrCoverage(dd.first, dd.second)
+                    val accDd = HrvAnalyzer.beatAccurateFraction(dd.first, dd.second)
+                    diag("hrv dedup day=${res.daily.day} n=${dd.second.size}/${sleepRr.size} " +
+                        "rmssd=${ms(hDd.rmssd)}ms sdnn=${ms(hDd.sdnn)}ms meanNN=${ms(hDd.meanNN)}ms " +
+                        "coverage=${String.format(java.util.Locale.US, "%.2f", covDd)} " +
+                        "beatAccurate=${String.format(java.util.Locale.US, "%.2f", accDd)}")
                 }
             } else if (res.sleepSessions.isEmpty()) {
                 // #1244: no in-sleep R-R AND no detected session (past the >=200-HR gate) = the "HR tracked,

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -735,14 +735,21 @@ object IntelligenceEngine {
                     // before it becomes the read path. Instrumentation only — shipped HRV/resp unchanged.
                     // If de-dup works: coverage→~1.0, beatAccurate high (would pass #1127's RSA gate →
                     // resp returns = the #1331 fix), rmssd/sdnn physiological. Twin of the Swift line.
+                    // Two candidates so validation isn't confounded: EXACT-dup collapse (rrTolMs 0 — same
+                    // ts AND value, no real-beat loss) is the safe floor; the ~40 ms collapse is the
+                    // aggressive UPPER BOUND (catches the two-channel twins but can over-merge two real
+                    // neighbours within 40 ms). Log both so we can see where the real de-dup sits. Twin.
+                    val ex = HrvAnalyzer.collapseOverCount(ts, sleepRr, 0.0)
                     val dd = HrvAnalyzer.collapseOverCount(ts, sleepRr)
                     val hDd = HrvAnalyzer.analyzeRaw(dd.second)
+                    val covEx = HrvAnalyzer.rrCoverage(ex.first, ex.second)
                     val covDd = HrvAnalyzer.rrCoverage(dd.first, dd.second)
                     val accDd = HrvAnalyzer.beatAccurateFraction(dd.first, dd.second)
-                    diag("hrv dedup day=${res.daily.day} n=${dd.second.size}/${sleepRr.size} " +
-                        "rmssd=${ms(hDd.rmssd)}ms sdnn=${ms(hDd.sdnn)}ms meanNN=${ms(hDd.meanNN)}ms " +
-                        "coverage=${String.format(java.util.Locale.US, "%.2f", covDd)} " +
-                        "beatAccurate=${String.format(java.util.Locale.US, "%.2f", accDd)}")
+                    diag("hrv dedup day=${res.daily.day} exactN=${ex.second.size}/${sleepRr.size} " +
+                        "covExact=${String.format(java.util.Locale.US, "%.2f", covEx)} | ch40N=${dd.second.size} " +
+                        "cov40=${String.format(java.util.Locale.US, "%.2f", covDd)} " +
+                        "beatAcc40=${String.format(java.util.Locale.US, "%.2f", accDd)} " +
+                        "rmssd40=${ms(hDd.rmssd)}ms sdnn40=${ms(hDd.sdnn)}ms meanNN40=${ms(hDd.meanNN)}ms")
                 }
             } else if (res.sleepSessions.isEmpty()) {
                 // #1244: no in-sleep R-R AND no detected session (past the >=200-HR gate) = the "HR tracked,

--- a/android/app/src/test/java/com/noop/analytics/HrvCollapseOverCountTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvCollapseOverCountTest.kt
@@ -1,0 +1,56 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1008/#1118/#1331: HrvAnalyzer.collapseOverCount — the SHADOW de-dup of the WHOOP 4.0 R-R over-count.
+ * Pins that a synthetic over-count (each real beat emitted three times — an exact duplicate plus a
+ * two-optical-channel twin ~34 ms off, the #1008 signature) collapses back to ~one beat per real
+ * interval, so coverage drops from ~3x toward ~1.0 and the stream becomes beat-accurate again (which is
+ * what would let it pass #1127's RSA gate — the #1331 fix). Mirrors the macOS HrvCollapseOverCountTests.
+ */
+class HrvCollapseOverCountTest {
+
+    /** 60 real beats, one per second at 1000 ms, each emitted 3x in its second: exact dup + a ~34 ms twin. */
+    private fun overCounted(): Pair<List<Long>, List<Double>> {
+        val ts = ArrayList<Long>()
+        val rr = ArrayList<Double>()
+        for (s in 0 until 60) {
+            val base = 1000.0
+            // channel A (green): the beat + an exact duplicate of it
+            ts.add(s.toLong()); rr.add(base)
+            ts.add(s.toLong()); rr.add(base)
+            // channel B (spo2): the SAME beat reported ~34 ms different, same second
+            ts.add(s.toLong()); rr.add(base + 34.0)
+        }
+        return Pair(ts, rr)
+    }
+
+    @Test
+    fun collapseOverCount_recoversOneBeatPerInterval() {
+        val (ts, rr) = overCounted()
+        assertEquals("fixture is 3x over-counted", 180, rr.size)
+        // Raw coverage ~3x (180 beats * ~1000 ms / 59 s span).
+        val rawCov = HrvAnalyzer.rrCoverage(ts, rr)
+        assertTrue("raw over-counted coverage should be ~3x, was $rawCov", rawCov > 2.5)
+
+        val (ddTs, ddRr) = HrvAnalyzer.collapseOverCount(ts, rr)
+        // Exact dup + the 34 ms twin (< 40 ms tol) both collapse → one beat per second.
+        assertEquals("deduped to one beat per real interval", 60, ddRr.size)
+        assertEquals("ts and rr stay in lockstep", 60, ddTs.size)
+        val ddCov = HrvAnalyzer.rrCoverage(ddTs, ddRr)
+        assertEquals("deduped coverage collapses toward 1.0", 1.0, ddCov, 0.1)
+    }
+
+    @Test
+    fun collapseOverCount_leavesACleanStreamUntouched() {
+        // A beat-accurate stream (one beat per second, no same-second duplicates) must pass through as-is.
+        val ts = (0 until 60).map { it.toLong() }
+        val rr = (0 until 60).map { 1000.0 }
+        val (ddTs, ddRr) = HrvAnalyzer.collapseOverCount(ts, rr)
+        assertEquals(60, ddRr.size)
+        assertEquals(ts, ddTs)
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/HrvCollapseOverCountTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvCollapseOverCountTest.kt
@@ -45,6 +45,18 @@ class HrvCollapseOverCountTest {
     }
 
     @Test
+    fun collapseOverCount_exactDupOnlyKeepsTheChannelTwin() {
+        // rrTolMs=0 collapses ONLY exact same-second duplicates (the safe floor — no real-beat loss). The
+        // ~34 ms channel twin survives, so 180 (=60x[beat + exact-dup + twin]) → 120 (=60x[beat + twin])
+        // and coverage stays ~2x, not 1.0. This is the reference line the shadow logs beside the ~40 ms one.
+        val (ts, rr) = overCounted()
+        val (exTs, exRr) = HrvAnalyzer.collapseOverCount(ts, rr, 0.0)
+        assertEquals("exact-dup removed, channel twin kept", 120, exRr.size)
+        assertEquals(120, exTs.size)
+        assertTrue("exact-dup coverage stays ~2x (twins remain)", HrvAnalyzer.rrCoverage(exTs, exRr) > 1.8)
+    }
+
+    @Test
     fun collapseOverCount_leavesACleanStreamUntouched() {
         // A beat-accurate stream (one beat per second, no same-second duplicates) must pass through as-is.
         val ts = (0 until 60).map { it.toLong() }


### PR DESCRIPTION
**Stage 1 of the WHOOP 4.0 over-count fix — instrumentation only, no behaviour change.** Shadow-logs a candidate de-dup so it can be validated against ground truth before it ever becomes the read path.

## Why

The WHOOP 4.0 R-R over-count (#1008 — each beat emitted 2–3×: an exact duplicate plus a two-optical-channel twin ~34 ms off) is behind **three** symptoms: HRV ≠ WHOOP (#1008), the HRV "unverified" caveat (#1118), and — via #1127's RSA beat-accuracy gate — the **respiratory blank on 4.0 since V10 (#1331)**. The real fix is a de-dup, but it changes a physiological signal (HRV + respiration), so per the "validate against the artifact, not one match" rule it can't be shipped on a guess.

## What (this PR)

- **`HRVAnalyzer.collapseOverCount` / `HrvAnalyzer.collapseOverCount`** — a pure, byte-identical de-dup: a same-second beat within ~40 ms of one already kept (the exact dups + the ~34 ms channel twins) is dropped, keeping one representative. Returns the deduped `(tsSec, rrMs)`.
- On an **over-count night only**, the always-on `hrv diag` appends a `hrv dedup …` line with the **deduped** stream's `rmssd / sdnn / meanNN / coverage / beatAccurate`, beside the raw values already logged. **The shipped HRV/resp path is unchanged** — this only logs a candidate.

## What it buys us

A strap log now shows, per 4.0 over-count night, whether de-dup:
- drives **coverage → ~1.0** and **beatAccurate high** — i.e. it would pass #1127's RSA gate, so **respiratory rate returns (the #1331 fix)**;
- brings **rmssd/sdnn** toward physiological and matching WHOOP.

That's the exact data to validate against **WHOOP's own numbers** and **@artemc's Polar H10 dataset** (#1118) — across his over-count *and* clean nights — before **Stage 2** flips the read path to the deduped stream (which closes #1008 + #1118 + #1331 together).

## Verification
- New `HrvCollapseOverCount{Test,Tests}` (both platforms): a synthetic 3× over-count collapses 180→60 beats, coverage ~3× → ~1.0, and a clean stream passes through untouched. Kotlin green locally.
- `StrandAnalytics` via `swift-packages`; the `IntelligenceEngine` shadow line is app-target → app-build gate.

Refs #1331, #1008, #1118, #1127. Instrumentation-first, mirroring #1117/#1332/#1344.
