### PR TITLE
fix(oura): #1339 follow-ups — contain the dup-gen diagnostic, and log what adjudicates

### DIFF
--- a/Strand/BLE/SourceCoordinator.swift
+++ b/Strand/BLE/SourceCoordinator.swift
@@ -330,6 +330,23 @@ final class SourceCoordinator: ObservableObject {
             onBattery: { [live] pct in live.setBattery(Double(pct)) })
     }
 
+    /// One duplicate-candidate's shape for the `dup-gen(#1284)` line: the window, its duration, and the two
+    /// measures that actually decide WHICH row is fuller — the stage-segment count and the decoded JSON
+    /// length. Duration cannot decide it on its own: the mode-1 re-anchor mints rows of IDENTICAL length at
+    /// two `0x49` onsets (measured 2026-08-14/15: three 390 min / 1333 B rows, and four 26 min / 266 B
+    /// fragments), so a duration-derived "code count" prints the same value for both members of the pair and
+    /// the corpus cannot adjudicate. Segments + JSON length are also the fields the issue's own analysis is
+    /// written in, so the log lines drop straight into it.
+    ///
+    /// Both terms are plain substring/length counts over the ASCII segments JSON — no parser, no locale, and
+    /// identical arithmetic in the Kotlin twin (`SourceCoordinator.dupGenShape`), so the two platforms' lines
+    /// compare directly.
+    private static func dupGenShape(_ s: CachedSleepSession) -> String {
+        let json = s.stagesJSON ?? ""
+        let segments = json.components(separatedBy: "\"stage\"").count - 1
+        return "[\(s.startTs) -> \(s.endTs)] min=\((s.endTs - s.startTs) / 60) segs=\(segments) json=\(json.utf8.count)"
+    }
+
     /// Build the EXPERIMENTAL Oura source (Oura Ring gen 3/4/5) for `id`, driven by the clean-room
     /// `OuraProtocol.OuraDriver`. Decoded raw signals (HR / IBI / HRV / SpO2 / temp / sleep-phase / battery)
     /// ride the SAME `LiveState` + persist channels as the other sources, so NOOP scores the Oura day with
@@ -367,18 +384,16 @@ final class SourceCoordinator: ObservableObject {
                     // blind to the common case: an overnight with link drops mints the duplicate across
                     // DIFFERENT connections. Read the day's stored sessions here instead (cross-connection,
                     // survives an app restart) and log — using the SAME `SleepSessionDedup.isDuplicate` rule
-                    // the heal uses — when this persist duplicates one. `startΔ` ≈ the 0x49 onset jitter
-                    // (a session's startTs IS its anchored onset); both code counts confirm the fuller row
-                    // is the one to keep. One compact line per duplicate, to survive the log head-clip. This
-                    // is the corpus the generation-side 0x49/sleep-day keying will be designed against.
+                    // the heal uses — when this persist duplicates one. `startDelta` ≈ the 0x49 onset jitter
+                    // (a session's startTs IS its anchored onset); the two shapes say WHICH row is fuller.
+                    // One compact line per duplicate, to survive the log head-clip. This is the corpus the
+                    // generation-side 0x49/sleep-day keying will be designed against.
                     let from = session.startTs - 16 * 3600 - 3600
                     let to = session.endTs + 3600
                     let stored = ((try? await store.sleepSessions(deviceId: id, from: from, to: to, limit: 64)) ?? [])
                         .filter { $0.startTs != session.startTs }
                     for e in stored where SleepSessionDedup.isDuplicate(session, e) {
-                        let newCodes = max(0, (session.endTs - session.startTs) / 30)
-                        let storedCodes = max(0, (e.endTs - e.startTs) / 30)
-                        straplog("Oura: dup-gen(#1284) persist [\(session.startTs) -> \(session.endTs)] codes=\(newCodes) duplicates stored [\(e.startTs) -> \(e.endTs)] codes=\(storedCodes) startDelta=\(session.startTs - e.startTs)s (~0x49 onset jitter) - cross-connection DB read")
+                        straplog("Oura: dup-gen(#1284) persist \(SourceCoordinator.dupGenShape(session)) duplicates stored \(SourceCoordinator.dupGenShape(e)) startDelta=\(session.startTs - e.startTs)s (~0x49 onset jitter) - cross-connection DB read")
                     }
                     _ = try? await store.upsertSleepSessions([session], deviceId: id)
                 }

--- a/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
+++ b/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
@@ -393,6 +393,25 @@ class SourceCoordinator(
     }
 
     /**
+     * One duplicate-candidate's shape for the `dup-gen(#1284)` line: the window, its duration, and the two
+     * measures that actually decide WHICH row is fuller — the stage-segment count and the decoded JSON
+     * length. Duration cannot decide it on its own: the mode-1 re-anchor mints rows of IDENTICAL length at
+     * two `0x49` onsets (measured 2026-08-14/15: three 390 min / 1333 B rows, and four 26 min / 266 B
+     * fragments), so a duration-derived "code count" prints the same value for both members of the pair and
+     * the corpus cannot adjudicate. Segments + JSON length are also the fields the issue's own analysis is
+     * written in, so the log lines drop straight into it.
+     *
+     * Both terms are plain substring/length counts over the ASCII segments JSON — no parser, no locale, and
+     * identical arithmetic in the Swift twin (`SourceCoordinator.dupGenShape`), so the two platforms' lines
+     * compare directly.
+     */
+    private fun dupGenShape(startTs: Long, endTs: Long, stagesJSON: String?): String {
+        val json = stagesJSON ?: ""
+        val segments = json.split("\"stage\"").size - 1
+        return "[$startTs -> $endTs] min=${(endTs - startTs) / 60} segs=$segments json=${json.length}"
+    }
+
+    /**
      * Build the EXPERIMENTAL Oura ring source (gen3 / gen4 / gen5) for [id]. Also wires the adopt-outcome
      * mirror ([ouraStateJob]) and consumes the one-shot adopt consent — side effects the coordinator owns,
      * so they live here rather than in the plain FTMS / Huami / Standard arms of [makeSource]. Mirrors the
@@ -432,8 +451,8 @@ class SourceCoordinator(
                         // connections. Read the day's stored sessions here (cross-connection, survives an app
                         // restart) and log — using the SAME SleepSessionDedup.isDuplicate rule the heal uses —
                         // when this persist duplicates one. startDelta ~ the 0x49 onset jitter (a session's
-                        // startTs IS its anchored onset); both code counts confirm the fuller row wins. One
-                        // compact line per duplicate, to survive the log head-clip. This is the corpus the
+                        // startTs IS its anchored onset); the two shapes say WHICH row is fuller. One compact
+                        // line per duplicate, to survive the log head-clip. This is the corpus the
                         // generation-side 0x49/sleep-day keying will be designed against.
                         //
                         // ISOLATED in its own runCatching: log-only means log-only. The read below is a DB
@@ -447,9 +466,7 @@ class SourceCoordinator(
                             repo.sleepSessions(deviceId, from, to, 64)
                                 .filter { it.startTs != s.startTs && com.noop.analytics.SleepSessionDedup.isDuplicate(session, it) }
                                 .forEach { e ->
-                                    val newCodes = maxOf(0L, (s.endTs - s.startTs) / 30)
-                                    val storedCodes = maxOf(0L, (e.endTs - e.startTs) / 30)
-                                    straplog("Oura: dup-gen(#1284) persist [${s.startTs} -> ${s.endTs}] codes=$newCodes duplicates stored [${e.startTs} -> ${e.endTs}] codes=$storedCodes startDelta=${s.startTs - e.startTs}s (~0x49 onset jitter) - cross-connection DB read")
+                                    straplog("Oura: dup-gen(#1284) persist ${dupGenShape(s.startTs, s.endTs, s.stagesJson)} duplicates stored ${dupGenShape(e.startTs, e.endTs, e.stagesJSON)} startDelta=${s.startTs - e.startTs}s (~0x49 onset jitter) - cross-connection DB read")
                                 }
                         }
                         repo.upsertSleepSessions(listOf(session))

--- a/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
+++ b/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
@@ -435,15 +435,23 @@ class SourceCoordinator(
                         // startTs IS its anchored onset); both code counts confirm the fuller row wins. One
                         // compact line per duplicate, to survive the log head-clip. This is the corpus the
                         // generation-side 0x49/sleep-day keying will be designed against.
-                        val from = s.startTs - 16 * 3600 - 3600
-                        val to = s.endTs + 3600
-                        repo.sleepSessions(deviceId, from, to, 64)
-                            .filter { it.startTs != s.startTs && com.noop.analytics.SleepSessionDedup.isDuplicate(session, it) }
-                            .forEach { e ->
-                                val newCodes = maxOf(0L, (s.endTs - s.startTs) / 30)
-                                val storedCodes = maxOf(0L, (e.endTs - e.startTs) / 30)
-                                straplog("Oura: dup-gen(#1284) persist [${s.startTs} -> ${s.endTs}] codes=$newCodes duplicates stored [${e.startTs} -> ${e.endTs}] codes=$storedCodes startDelta=${s.startTs - e.startTs}s (~0x49 onset jitter) - cross-connection DB read")
-                            }
+                        //
+                        // ISOLATED in its own runCatching: log-only means log-only. The read below is a DB
+                        // round-trip on the BLE persist path and CAN throw (locked DB, disk I/O, a store
+                        // closed under a background teardown); sharing the outer runCatching would let a
+                        // failed DIAGNOSTIC skip the upsert underneath it and silently lose the night. The
+                        // Swift twin contains its read the same way (`(try? ...) ?? []`).
+                        runCatching {
+                            val from = s.startTs - 16 * 3600 - 3600
+                            val to = s.endTs + 3600
+                            repo.sleepSessions(deviceId, from, to, 64)
+                                .filter { it.startTs != s.startTs && com.noop.analytics.SleepSessionDedup.isDuplicate(session, it) }
+                                .forEach { e ->
+                                    val newCodes = maxOf(0L, (s.endTs - s.startTs) / 30)
+                                    val storedCodes = maxOf(0L, (e.endTs - e.startTs) / 30)
+                                    straplog("Oura: dup-gen(#1284) persist [${s.startTs} -> ${s.endTs}] codes=$newCodes duplicates stored [${e.startTs} -> ${e.endTs}] codes=$storedCodes startDelta=${s.startTs - e.startTs}s (~0x49 onset jitter) - cross-connection DB read")
+                                }
+                        }
                         repo.upsertSleepSessions(listOf(session))
                     }
                 }


### PR DESCRIPTION
## Commit 1 — Android: the diagnostic can silently lose the night it is diagnosing

`SourceCoordinator.kt`'s `persistSleepSession` closure looks like this on `main` today:

```kotlin
runCatching {
    val session = SleepSession(...)
    // #1284 duplicate-generation diagnostic (LOG-ONLY)
    val from = s.startTs - 16 * 3600 - 3600
    val to = s.endTs + 3600
    repo.sleepSessions(deviceId, from, to, 64)        // <-- can throw
        .filter { ... }
        .forEach { e -> straplog("Oura: dup-gen(#1284) ...") }
    repo.upsertSleepSessions(listOf(session))         // <-- never reached if it does
}
```

The diagnostic's DB read shares the **outer** `runCatching` with the upsert, and runs **ahead** of it.
A throw from `repo.sleepSessions` — a locked DB, disk I/O, a store closed under a background teardown,
all reachable on the overnight BLE persist path — is swallowed, and `repo.upsertSleepSessions` never
runs. The ring's hypnogram night is lost silently, by a line whose only job was to describe it.

**A diagnostic that can cost the data it is diagnosing is not log-only.** The read now sits in its own
`runCatching`, so a failure there costs a log line and nothing else.

This also removes an asymmetry rather than adding one: the **Swift twin already contained its read**
(`(try? await store.sleepSessions(...)) ?? []`). Android was the odd side.

- Android-only; no Swift change is owed for this half.
- Happy-path behaviour identical.

## Commit 2 — both platforms: `codes=` restated the timestamps beside it

The line's `codes=` term was `(endTs - startTs) / 30` — the duration in half-minutes, **fully derived
from the two timestamps already printed on the same line**. It carries no completeness information,
yet the line exists precisely to show which of two duplicate rows is the fuller one.

The **2026-08-14/15 capture** makes the gap concrete. That night banked **13 sleep rows** for one night
on the ring id, and the mode-1 re-anchor set is **three rows of IDENTICAL 390 min / 25 segments /
1333 B** at three different `0x49` onsets, plus **four identical 26 min / 5 segment / 266 B** fragments.
A duration-derived count prints the same value for both members of every such pair, so the corpus this
diagnostic is being collected for cannot adjudicate any of them.

`dupGenShape` now prints:

```
[start -> end] min=<duration> segs=<stage segments> json=<bytes>
```

— the window, the duration, and the two measures that **do** adjudicate. Those are also the vocabulary
the #1284 analysis is already written in (segments / JSON bytes), so the log lines drop straight into
it.

Both terms are plain substring/length counts over the ASCII segments JSON — no parser, no locale — and
the Swift and Kotlin helpers do identical arithmetic, so the two platforms' lines compare directly. In
the 08-14/15 stored rows **chars == bytes for every `stagesJSON`**, which is the assumption both counts
rest on, checked rather than assumed.

Log-format only; no behaviour change on either platform.

## Verification

- `xcodebuild -scheme Strand -destination 'platform=macOS'` ✅ — app-target Swift, which **no default
  CI compiles** (`app-build.yml` is disabled).
- `./gradlew compileFullDebugKotlin` ✅.
- **No hardware run is owed to land this.** Commit 1 is a containment change with identical happy-path
  behaviour; commit 2's content is validated against the *stored rows* of the 08-14/15 capture, not
  against a live link.

Relates to #1284, follows #1339.