### PR TITLE
fix(diagnostics): a clipped log generation must say it lost its head

### DIFF
--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -672,9 +672,17 @@ public final class LiveState: ObservableObject {
         iso.timeZone = TimeZone(identifier: "UTC")
         // The stamp is when the roll happened (i.e. this launch), NOT when those lines were written — the
         // lines carry their own clock. Said plainly in the text so nobody reads it as the session's end.
-        let header = "===== previous app session, \(tail.count) line(s), rolled at "
-            + iso.string(from: now) + " (this launch) ====="
         let clipped = tail.count > generationTailLimit ? Array(tail.suffix(generationTailLimit)) : tail
+        // Say the KEPT count, and say so when the head was dropped. The header used to report only
+        // `tail.count` (the pre-clip total), so a generation that had lost its first 1,000 lines still
+        // announced "2,000 line(s)" and read as a complete session — a reader (or a log tool) then
+        // measures the missing head as silence. Both numbers are printed: the pre-clip total is what
+        // tells anyone how much is gone.
+        let count = clipped.count == tail.count
+            ? "\(tail.count) line(s)"
+            : "\(clipped.count) of \(tail.count) line(s), head clipped"
+        let header = "===== previous app session, \(count), rolled at "
+            + iso.string(from: now) + " (this launch) ====="
         var gens = persistedLogGenerations()
         gens.append([header] + clipped)
         if gens.count > maxLogGenerations { gens.removeFirst(gens.count - maxLogGenerations) }

--- a/StrandTests/LiveStateLogGenerationsTests.swift
+++ b/StrandTests/LiveStateLogGenerationsTests.swift
@@ -84,6 +84,32 @@ final class LiveStateLogGenerationsTests: XCTestCase {
         XCTAssertEqual(body.last, "line \(LiveState.generationTailLimit + 49)", "the newest line must survive")
     }
 
+    /// A clipped generation must SAY it lost its head. The header reported the pre-clip total, so a
+    /// generation holding 1,000 of 2,000 lines announced "2000 line(s)" and read as a complete session —
+    /// and the dropped head then measures as silence in the log tools.
+    func testClippedGenerationHeaderSaysWhatWasKept() {
+        let many = (0..<(LiveState.generationTailLimit + 50)).map { "line \($0)" }
+        UserDefaults.standard.set(many, forKey: tailKey)
+
+        LiveState.rollLogGenerationsIfNeeded()
+
+        let header = LiveState.persistedLogGenerations()[0][0]
+        XCTAssertTrue(header.contains("\(LiveState.generationTailLimit) of \(many.count) line(s)"),
+                      "header must carry both the kept and the pre-clip count: \(header)")
+        XCTAssertTrue(header.contains("head clipped"), "a clipped generation must say so: \(header)")
+    }
+
+    /// ...and an UNCLIPPED one must not cry wolf: no "head clipped", just the count.
+    func testUnclippedGenerationHeaderClaimsNoLoss() {
+        UserDefaults.standard.set(["22:01 connected", "22:02 drain done"], forKey: tailKey)
+
+        LiveState.rollLogGenerationsIfNeeded()
+
+        let header = LiveState.persistedLogGenerations()[0][0]
+        XCTAssertTrue(header.contains("2 line(s)"), header)
+        XCTAssertFalse(header.contains("clipped"), header)
+    }
+
     /// The export puts previous sessions AHEAD of the current one, so `report.txt` stays chronological and
     /// the log-parsing tools keep working on it unchanged.
     func testPreviousSessionsTextPrecedesTheCurrentMarker() {

--- a/android/app/src/main/java/com/noop/ui/StrapLogGenerations.kt
+++ b/android/app/src/main/java/com/noop/ui/StrapLogGenerations.kt
@@ -48,10 +48,17 @@ object StrapLogGenerations {
     fun roll(previousTail: List<String>, existing: List<List<String>>, nowMs: Long): List<List<String>> {
         if (previousTail.isEmpty()) return existing
         val iso = Instant.ofEpochMilli(nowMs).truncatedTo(ChronoUnit.SECONDS).toString()
-        val header = "===== previous app session, ${previousTail.size} line(s), rolled at $iso (this launch) ====="
         val clipped = if (previousTail.size > GENERATION_TAIL_LIMIT) {
             previousTail.subList(previousTail.size - GENERATION_TAIL_LIMIT, previousTail.size)
         } else previousTail
+        // Say the KEPT count, and say so when the head was dropped — byte-identical wording to iOS,
+        // because the same log tools parse both platforms' report.txt. The header used to report only
+        // the pre-clip total, so a generation that had lost its first 1,000 lines still announced
+        // "2000 line(s)" and read as a complete session; the missing head then measures as silence.
+        val count = if (clipped.size == previousTail.size) {
+            "${previousTail.size} line(s)"
+        } else "${clipped.size} of ${previousTail.size} line(s), head clipped"
+        val header = "===== previous app session, $count, rolled at $iso (this launch) ====="
         val gens = existing.toMutableList()
         gens.add(listOf(header) + clipped)
         while (gens.size > MAX_GENERATIONS) gens.removeAt(0)

--- a/android/app/src/test/java/com/noop/ui/StrapLogGenerationsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/StrapLogGenerationsTest.kt
@@ -79,6 +79,28 @@ class StrapLogGenerationsTest {
         )
     }
 
+    /** A clipped generation must SAY it lost its head, in the same words iOS uses — the header reported the
+     *  pre-clip total, so a generation holding 1,000 of 2,000 lines announced "2000 line(s)" and read as a
+     *  complete session, and the dropped head then measures as silence in the log tools. */
+    @Test
+    fun clippedGenerationHeaderSaysWhatWasKept() {
+        val many = (0 until (StrapLogGenerations.GENERATION_TAIL_LIMIT + 50)).map { "line $it" }
+        val header = StrapLogGenerations.roll(many, emptyList(), now)[0][0]
+        assertTrue(
+            "header must carry both the kept and the pre-clip count: $header",
+            header.contains("${StrapLogGenerations.GENERATION_TAIL_LIMIT} of ${many.size} line(s)"),
+        )
+        assertTrue("a clipped generation must say so: $header", header.contains("head clipped"))
+    }
+
+    /** ...and an UNCLIPPED one must not cry wolf: no "clipped", just the count. */
+    @Test
+    fun unclippedGenerationHeaderClaimsNoLoss() {
+        val header = StrapLogGenerations.roll(listOf("22:01 connected", "22:02 drain done"), emptyList(), now)[0][0]
+        assertTrue(header, header.contains("2 line(s)"))
+        assertTrue(header, !header.contains("clipped"))
+    }
+
     /** The export puts previous sessions AHEAD of the current-session marker, so `report.txt` stays
      *  chronological and the log-parsing tools keep working on it unchanged. */
     @Test


### PR DESCRIPTION
## The bug

A rolled strap-log generation keeps only its **last 1,000 lines**, but the header printed
`tail.count` — the **pre-clip** total. So a generation holding 1,000 of 2,000 lines announced
`2000 line(s)` and read as a complete session.

That is the worst possible place to be silently lossy. The dropped head is then measured as **silence**
by the log tools — and silence-vs-activity is exactly the classification (app suspended vs running) the
whole overnight Oura investigation turns on. A 14-hour night has been read as 21 minutes this way.

## The fix

Print both numbers: `1000 of 2000 line(s), head clipped`. The loss is stated, and the pre-clip total
still says **how much** is gone, so an analysis can bound what it is missing rather than guessing.
Unclipped generations keep the old wording and do not cry wolf.

Both platforms, **byte-identical wording**, because the same log tools parse both platforms'
`report.txt`.

## Verification

- `xcodebuild … test -only-testing:StrandTests/LiveStateLogGenerationsTests` — 10 tests, 0 failures.
  Two tests pin the clipped header, two pin the unclipped one.
- `Strand` macOS builds locally — this is **app-target Swift**, so no default CI compiles it
  (`app-build.yml` is disabled).
- `./gradlew testFullDebugUnitTest --tests "com.noop.ui.StrapLogGenerationsTest"` passes.

Diagnostics only — no BLE path, no scoring path, no stored data.