### PR TITLE
fix(ble): stop hardcoding device.name to "WHOOP 4.0" for every paired device

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1029,7 +1029,12 @@ public final class BLEManager: NSObject, ObservableObject {
            !activeId.isEmpty {
             self.deviceId = activeId
         }
-        try? await store.upsertDevice(id: deviceId, mac: nil, name: "WHOOP 4.0")
+        // Look up the active device's real brand/model instead of a hardcoded string — this predated
+        // multi-device support and mislabeled every non-"WHOOP 4.0" device (a WHOOP 5.0/MG strap, an Oura
+        // ring, …) with the same literal "WHOOP 4.0". `device.name` has no production reader today (only
+        // the `deviceRowForTest` helper), so this is dormant, but still wrong data on disk.
+        let registeredName = (try? registry.all())?.first(where: { $0.id == deviceId })?.displayName
+        try? await store.upsertDevice(id: deviceId, mac: nil, name: registeredName)
         // Research toggle — OFF by default. When disabled the app is decoded-only and never
         // persists raw frames. Flip "enableRawCapture" in UserDefaults to capture raw again.
         let enableRawCapture = UserDefaults.standard.bool(forKey: "enableRawCapture")


### PR DESCRIPTION
## The bug

`bootstrapStore()` (`Strand/BLE/BLEManager.swift:1032` on today's `main`) writes the literal string
`"WHOOP 4.0"` into the `device` table's `name` column **regardless of which device is actually
active** — a leftover from before multi-device support existed. A WHOOP 5.0/MG strap and an Oura ring
both get labelled `"WHOOP 4.0"`.

```swift
try? await store.upsertDevice(id: deviceId, mac: nil, name: "WHOOP 4.0")
```

Found by exporting a `.noopbak` and inspecting the raw `device` table directly — the real registry
(`pairedDevice`) was already correct, so this only shows up if you query the DB.

## The fix

Look up the active device's real brand/model from the registry. `PairedDevice` already has a
`displayName` computed property built for exactly this (nickname, else "Brand Model"):

```swift
let registeredName = (try? registry.all())?.first(where: { $0.id == deviceId })?.displayName
try? await store.upsertDevice(id: deviceId, mac: nil, name: registeredName)
```

The `registry` handle already exists two lines above — this reuses it, no new plumbing.

## Scope — deliberately small

`device.name` has **no production reader today** (only the `deviceRowForTest` test helper), so the bug
is **dormant**: visible by querying the DB, never in the shipped UI. It is still worth fixing rather
than leaving a wrong value in stored data that a future reader would inherit — which is the whole
point of fixing it *before* something reads it.

**On the `nil` case:** `upsertDevice` takes `name: String?` and its upsert does `name = excluded.name`,
so an unreadable/empty registry now writes NULL where the old code wrote a confident `"WHOOP 4.0"`. In
practice migration v15 seeds a `my-whoop` row, so the lookup resolves; and with no production reader,
NULL costs no display. A NULL that says "unknown" beats a literal that says the wrong model.

**No Android twin is owed.** There is no live-BLE `upsertDevice` call for the main device row in
`WhoopBleClient.kt` / `OuraLiveSource.kt` — the parity contract has nothing to mirror here.

## Not a duplicate of #1304 or #1193

Both are adjacent and neither covers this:

- **#1304** (multi-WHOOP `"my-whoop"` sweep) is the hardcoded device **id** on **read** paths — code
  assuming the strap is literally `"my-whoop"`, so a second strap's `whoop-<uuid>` is invisible to it.
  This is a hardcoded **display name** on a **write** path; `bootstrapStore` is not in that issue's
  at-risk list.
- **#1193** (duplicate device rows) is about **identity** — a WHOOP keyed on a transient CoreBluetooth
  UUID rather than its serial. It changes *which row exists*, not what goes in that row's `name` column.

Land both in full and an Oura ring is still written down as `"WHOOP 4.0"`.

## Verification

- **`Strand` macOS builds** after the rebase onto `46cf3e58` — **app-target Swift, which no default CI
  compiles** (`app-build.yml` is disabled), so this was built locally rather than trusted to a green tick.
- Original #966 run was **confirmed against a second `.noopbak`** pulled after installing the fix: the
  `device` row read `name="WHOOP"` instead of the hardcoded literal, matching what the registry actually
  held at that instant (`my-whoop` still carried the generic seeded model `"WHOOP"` — the #716 correction
  to `"WHOOP 4.0"` fires later, once the scan confirms the physical strap, and `displayName` collapses
  model == brand to just `"WHOOP"`). That is the fix behaving correctly: honest about what was known at
  that moment, where before it was confidently wrong.
- No UI behaviour change is observable, by the no-reader argument above; the change is to what is
  written into the `device` row.