### PR TITLE
fix(oura): correct the 0x6B motion_period decode to match the documented layout

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -531,13 +531,17 @@ public enum OuraDecoders {
 
     // MARK: - Motion period, 2-bit MOTION_STATE codes (0x6B; s6.13)
 
-    /// Decode the 0x6B motion_period: a compact run of 2-bit MOTION_STATE codes. Layout is a byte-for-byte
-    /// port of the native `parse_api_motion_period` (clean-room fact citation; OURA_PROTOCOL.md s6.13),
-    /// the SAME shape as the validated `decodeSleepPhase` (one header byte, then 2-bit codes from byte 1):
+    /// Decode the 0x6B motion_period: a compact run of 2-bit MOTION_STATE codes. Layout cross-checked
+    /// against the native `parse_api_motion_period` (attribution, not a port — re-derived from a real
+    /// capture; OURA_PROTOCOL.md s6.13), the SAME shape as the validated `decodeSleepPhase` (one header
+    /// byte, then 2-bit codes from byte 1):
     ///   byte0 = header — bits[7:6] period_type; bits[5:4] = `count` of valid codes in the FINAL byte;
     ///           bits[3:0] = a rolling mod-16 sequence counter (record ordering / dedup, not a state).
     ///   byte1… = 2-bit codes, 4 per byte, MSB-first ([7:6][5:4][3:2][1:0]); every byte carries 4 codes
-    ///           EXCEPT the last, which carries only `count` (so a short "period" can hold a single code).
+    ///           EXCEPT the last, which carries `count` — where `count == 0` means 4 (a full final byte):
+    ///           the field is only 2 bits but the byte holds up to 4 codes, so 4 has to wrap to 0. In a real
+    ///           capture all 81 `count == 0` records have a NON-ZERO final byte (0xc0/0x80/0x40 — real
+    ///           codes), never 0x00, confirming 0 ⇒ 4 rather than 0 ⇒ empty.
     /// 0=NO_MOTION, 1=RESTLESS, 2=TOSSING, 3=ACTIVE. Returns nil on a body too short to hold the header
     /// plus one code byte (< 2), or when no codes result.
     ///
@@ -548,11 +552,12 @@ public enum OuraDecoders {
     public static func decodeMotionPeriod(_ rec: OuraRecord) -> [OuraMotion]? {
         let b = rec.payload
         guard b.count >= 2 else { return nil }
-        let count = Int((b[0] >> 4) & 0x03)   // valid codes in the FINAL byte (bits[5:4] of the header)
+        let countField = Int((b[0] >> 4) & 0x03)     // bits[5:4] of the header: codes in the FINAL byte
+        let lastCount = countField == 0 ? 4 : countField   // 0 encodes a full (4-code) final byte
         var out: [OuraMotion] = []
         var index = 0
         for k in 1..<b.count {
-            let n = (k == b.count - 1) ? count : 4   // last byte carries `count` codes; others carry 4
+            let n = (k == b.count - 1) ? lastCount : 4   // last byte carries `lastCount` codes; others 4
             let byte = b[k]
             for j in 0..<n {
                 let code = Int((byte >> UInt8(6 - 2 * j)) & 0x03)

--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -531,19 +531,31 @@ public enum OuraDecoders {
 
     // MARK: - Motion period, 2-bit MOTION_STATE codes (0x6B; s6.13)
 
-    /// Decode the 0x6B motion_period: 12-bit period header, byte6 bits[5:4]=leading-symbol count, then
-    /// 2-bit MOTION_STATE codes, 4 per byte (MSB-first). 0=NO_MOTION,1=RESTLESS,2=TOSSING,3=ACTIVE.
-    /// Per OURA_PROTOCOL.md s6.13. Returns nil on a short body. The first two bytes carry the period
-    /// header; codes follow from byte index 2.
+    /// Decode the 0x6B motion_period: a compact run of 2-bit MOTION_STATE codes. Layout is a byte-for-byte
+    /// port of the native `parse_api_motion_period` (clean-room fact citation; OURA_PROTOCOL.md s6.13),
+    /// the SAME shape as the validated `decodeSleepPhase` (one header byte, then 2-bit codes from byte 1):
+    ///   byte0 = header — bits[7:6] period_type; bits[5:4] = `count` of valid codes in the FINAL byte;
+    ///           bits[3:0] = a rolling mod-16 sequence counter (record ordering / dedup, not a state).
+    ///   byte1… = 2-bit codes, 4 per byte, MSB-first ([7:6][5:4][3:2][1:0]); every byte carries 4 codes
+    ///           EXCEPT the last, which carries only `count` (so a short "period" can hold a single code).
+    /// 0=NO_MOTION, 1=RESTLESS, 2=TOSSING, 3=ACTIVE. Returns nil on a body too short to hold the header
+    /// plus one code byte (< 2), or when no codes result.
+    ///
+    /// The header's low-nibble sequence counter is what pins this layout: in a real capture it increments
+    /// and wraps mod-16 across consecutive records (…c, d, e, f, 0, 1…), proving byte0 is a header and the
+    /// codes begin at byte1 — NOT the earlier reading (byte0/1 a 12-bit period, codes from byte2), which
+    /// dropped the first code byte and read phantom codes from the final byte's padding.
     public static func decodeMotionPeriod(_ rec: OuraRecord) -> [OuraMotion]? {
         let b = rec.payload
-        guard b.count >= 3 else { return nil }
+        guard b.count >= 2 else { return nil }
+        let count = Int((b[0] >> 4) & 0x03)   // valid codes in the FINAL byte (bits[5:4] of the header)
         var out: [OuraMotion] = []
         var index = 0
-        for k in 2..<b.count {
+        for k in 1..<b.count {
+            let n = (k == b.count - 1) ? count : 4   // last byte carries `count` codes; others carry 4
             let byte = b[k]
-            for shift in stride(from: 6, through: 0, by: -2) {
-                let code = Int((byte >> UInt8(shift)) & 0x03)
+            for j in 0..<n {
+                let code = Int((byte >> UInt8(6 - 2 * j)) & 0x03)
                 if let state = OuraMotionState(rawValue: code) {
                     out.append(OuraMotion(ringTimestamp: rec.ringTimestamp, index: index, state: state))
                     index += 1

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
@@ -322,6 +322,20 @@ final class DecoderGoldenTests: XCTestCase {
                        [OuraMotion(ringTimestamp: rt, index: 0, state: .tossing)])
     }
 
+    func testMotionPeriod0x6BCountZeroMeansFullFinalByte() {
+        // Real short capture `05c0`: header 0x05 -> count FIELD 0, which encodes a FULL final byte (4 codes),
+        // NOT 0 — the 2-bit field can't hold 4, so 4 wraps to 0 (all 81 count==0 records in the capture have
+        // a non-zero final byte, never 0x00). byte1 0xC0 = 11 00 00 00 -> active, noMotion, noMotion,
+        // noMotion. The `count==0 ? 0` reading returned NIL for this record; `count==0 ? 4` recovers 4 codes.
+        let rec = record("6b06020001000dc0")   // header 0x0D: count field 0 (0x0D>>4 & 3 == 0), seq 0xD
+        XCTAssertEqual(OuraDecoders.decodeMotionPeriod(rec), [
+            OuraMotion(ringTimestamp: rt, index: 0, state: .active),
+            OuraMotion(ringTimestamp: rt, index: 1, state: .noMotion),
+            OuraMotion(ringTimestamp: rt, index: 2, state: .noMotion),
+            OuraMotion(ringTimestamp: rt, index: 3, state: .noMotion),
+        ])
+    }
+
     // MARK: - 0x47 motion events (averaged accel vector)
 
     func testMotionEvents0x47() {

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
@@ -295,18 +295,31 @@ final class DecoderGoldenTests: XCTestCase {
         XCTAssertEqual(phases?.contains { $0.unwritten }, false)
     }
 
-    // MARK: - 0x6B motion period (2-bit MOTION_STATE codes; 2 header bytes skipped)
+    // MARK: - 0x6B motion period (2-bit MOTION_STATE codes; 1 header byte, codes from byte1)
 
     func testMotionPeriod0x6B() {
-        // 2 header bytes 0x00 0x00, code byte 0x1B = 00 01 10 11 -> noMotion, restless, tossing, active.
-        let rec = record("6b070200010000001b")
+        // header 0x13 = 0001_0011: period_type 0, count(bits[5:4]) = 1 code in the FINAL byte, seq 0x3.
+        // byte1 0x1B = 00 01 10 11 -> noMotion, restless, tossing, active (a full middle byte, 4 codes).
+        // byte2 0xC0 = 11 00 00 00 -> LAST byte, truncated to count=1 -> just active. The 0.. padding is
+        // NOT read (the earlier decoder would have emitted 3 phantom noMotion codes here).
+        let rec = record("6b0702000100131bc0")
         let m = OuraDecoders.decodeMotionPeriod(rec)
         XCTAssertEqual(m, [
             OuraMotion(ringTimestamp: rt, index: 0, state: .noMotion),
             OuraMotion(ringTimestamp: rt, index: 1, state: .restless),
             OuraMotion(ringTimestamp: rt, index: 2, state: .tossing),
             OuraMotion(ringTimestamp: rt, index: 3, state: .active),
+            OuraMotion(ringTimestamp: rt, index: 4, state: .active),
         ])
+    }
+
+    func testMotionPeriod0x6BShortSingleCodeRecord() {
+        // Real short capture `1ea0`: header 0x1E = 0001_1110 -> count = 1, seq 0xE; byte1 0xA0 = 10 00 00 00
+        // truncated to count=1 -> a single TOSSING code. The earlier decoder (codes from byte2) produced
+        // NOTHING for this 2-byte payload; the corrected one recovers the one real code.
+        let rec = record("6b06020001001ea0")
+        XCTAssertEqual(OuraDecoders.decodeMotionPeriod(rec),
+                       [OuraMotion(ringTimestamp: rt, index: 0, state: .tossing)])
     }
 
     // MARK: - 0x47 motion events (averaged accel vector)

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -601,27 +601,35 @@ object OuraDecoders {
     // MARK: - Motion period, 2-bit MOTION_STATE codes (0x6B; s6.13)
 
     /**
-     * Decode the 0x6B motion_period: 12-bit period header, byte6 bits[5:4]=leading-symbol count, then
-     * 2-bit MOTION_STATE codes, 4 per byte (MSB-first). 0=NO_MOTION,1=RESTLESS,2=TOSSING,3=ACTIVE.
-     * Per OURA_PROTOCOL.md s6.13. Returns null on a short body. The first two bytes carry the period
-     * header; codes follow from byte index 2.
+     * Decode the 0x6B motion_period: a compact run of 2-bit MOTION_STATE codes. Byte-for-byte port of
+     * the native parse_api_motion_period (clean-room fact citation; OURA_PROTOCOL.md s6.13), the SAME
+     * shape as the validated decodeSleepPhase (one header byte, then 2-bit codes from byte 1):
+     *   byte0 = header — bits[7:6] period_type; bits[5:4] = `count` of valid codes in the FINAL byte;
+     *           bits[3:0] = a rolling mod-16 sequence counter (record ordering / dedup, not a state).
+     *   byte1… = 2-bit codes, 4 per byte, MSB-first; every byte carries 4 codes EXCEPT the last, which
+     *           carries only `count` (so a short "period" can hold a single code).
+     * 0=NO_MOTION, 1=RESTLESS, 2=TOSSING, 3=ACTIVE. Returns null on a body too short to hold the header
+     * plus one code byte (< 2), or when no codes result. The header's low-nibble sequence counter is what
+     * pins this layout: in a real capture it increments and wraps mod-16 across consecutive records,
+     * proving byte0 is a header and codes begin at byte1 — NOT the earlier reading (byte0/1 a 12-bit
+     * period, codes from byte2). Byte-identical twin of Swift.
      */
     fun decodeMotionPeriod(rec: OuraRecord): List<OuraMotion>? {
         val b = rec.payload
-        if (b.size < 3) return null
+        if (b.size < 2) return null
+        val count = (b[0] shr 4) and 0x03   // valid codes in the FINAL byte (bits[5:4] of the header)
         val out = ArrayList<OuraMotion>()
         var index = 0
-        for (k in 2 until b.size) {
+        for (k in 1 until b.size) {
+            val n = if (k == b.size - 1) count else 4   // last byte carries `count` codes; others carry 4
             val byte = b[k]
-            var shift = 6
-            while (shift >= 0) {
-                val code = (byte shr shift) and 0x03
+            for (j in 0 until n) {
+                val code = (byte shr (6 - 2 * j)) and 0x03
                 val state = OuraMotionState.fromRaw(code)
                 if (state != null) {
                     out.add(OuraMotion(ringTimestamp = rec.ringTimestamp, index = index, state = state))
                     index += 1
                 }
-                shift -= 2
             }
         }
         return if (out.isEmpty()) null else out

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -601,13 +601,16 @@ object OuraDecoders {
     // MARK: - Motion period, 2-bit MOTION_STATE codes (0x6B; s6.13)
 
     /**
-     * Decode the 0x6B motion_period: a compact run of 2-bit MOTION_STATE codes. Byte-for-byte port of
-     * the native parse_api_motion_period (clean-room fact citation; OURA_PROTOCOL.md s6.13), the SAME
-     * shape as the validated decodeSleepPhase (one header byte, then 2-bit codes from byte 1):
+     * Decode the 0x6B motion_period: a compact run of 2-bit MOTION_STATE codes. Layout cross-checked
+     * against the native parse_api_motion_period (attribution, not a port — re-derived from a real capture;
+     * OURA_PROTOCOL.md s6.13), the SAME shape as the validated decodeSleepPhase (one header byte, then 2-bit
+     * codes from byte 1):
      *   byte0 = header — bits[7:6] period_type; bits[5:4] = `count` of valid codes in the FINAL byte;
      *           bits[3:0] = a rolling mod-16 sequence counter (record ordering / dedup, not a state).
      *   byte1… = 2-bit codes, 4 per byte, MSB-first; every byte carries 4 codes EXCEPT the last, which
-     *           carries only `count` (so a short "period" can hold a single code).
+     *           carries `count` — where `count == 0` means 4 (a full final byte): the field is 2 bits but the
+     *           byte holds up to 4 codes, so 4 wraps to 0. In a real capture all 81 `count == 0` records have
+     *           a NON-ZERO final byte (0xc0/0x80/0x40), never 0x00, confirming 0 ⇒ 4 not 0 ⇒ empty.
      * 0=NO_MOTION, 1=RESTLESS, 2=TOSSING, 3=ACTIVE. Returns null on a body too short to hold the header
      * plus one code byte (< 2), or when no codes result. The header's low-nibble sequence counter is what
      * pins this layout: in a real capture it increments and wraps mod-16 across consecutive records,
@@ -617,11 +620,12 @@ object OuraDecoders {
     fun decodeMotionPeriod(rec: OuraRecord): List<OuraMotion>? {
         val b = rec.payload
         if (b.size < 2) return null
-        val count = (b[0] shr 4) and 0x03   // valid codes in the FINAL byte (bits[5:4] of the header)
+        val countField = (b[0] shr 4) and 0x03      // bits[5:4] of the header: codes in the FINAL byte
+        val lastCount = if (countField == 0) 4 else countField   // 0 encodes a full (4-code) final byte
         val out = ArrayList<OuraMotion>()
         var index = 0
         for (k in 1 until b.size) {
-            val n = if (k == b.size - 1) count else 4   // last byte carries `count` codes; others carry 4
+            val n = if (k == b.size - 1) lastCount else 4   // last byte carries `lastCount` codes; others 4
             val byte = b[k]
             for (j in 0 until n) {
                 val code = (byte shr (6 - 2 * j)) and 0x03

--- a/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
+++ b/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
@@ -335,12 +335,14 @@ class DecoderGoldenTest {
         assertEquals(3, OuraSleepStage.AWAKE.raw)
     }
 
-    // MARK: - 0x6B motion period (2-bit MOTION_STATE codes; 2 header bytes skipped)
+    // MARK: - 0x6B motion period (2-bit MOTION_STATE codes; 1 header byte, codes from byte1)
 
     @Test
     fun testMotionPeriod0x6B() {
-        // 2 header bytes 0x00 0x00, code byte 0x1B = 00 01 10 11 -> noMotion, restless, tossing, active.
-        val rec = record("6b070200010000001b")
+        // header 0x13: period_type 0, count(bits[5:4]) = 1 code in the FINAL byte, seq 0x3.
+        // byte1 0x1B = 00 01 10 11 -> noMotion, restless, tossing, active (a full middle byte, 4 codes).
+        // byte2 0xC0 = 11 00 00 00 -> LAST byte, truncated to count=1 -> just active (padding not read).
+        val rec = record("6b0702000100131bc0")
         val m = OuraDecoders.decodeMotionPeriod(rec)
         assertEquals(
             listOf(
@@ -348,8 +350,20 @@ class DecoderGoldenTest {
                 OuraMotion(ringTimestamp = rt, index = 1, state = OuraMotionState.RESTLESS),
                 OuraMotion(ringTimestamp = rt, index = 2, state = OuraMotionState.TOSSING),
                 OuraMotion(ringTimestamp = rt, index = 3, state = OuraMotionState.ACTIVE),
+                OuraMotion(ringTimestamp = rt, index = 4, state = OuraMotionState.ACTIVE),
             ),
             m,
+        )
+    }
+
+    @Test
+    fun testMotionPeriod0x6BShortSingleCodeRecord() {
+        // Real short capture `1ea0`: header 0x1E -> count = 1; byte1 0xA0 = 10 00 00 00 truncated to
+        // count=1 -> a single TOSSING code. The earlier decoder (codes from byte2) produced NOTHING here.
+        val rec = record("6b06020001001ea0")
+        assertEquals(
+            listOf(OuraMotion(ringTimestamp = rt, index = 0, state = OuraMotionState.TOSSING)),
+            OuraDecoders.decodeMotionPeriod(rec),
         )
     }
 

--- a/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
+++ b/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
@@ -367,6 +367,23 @@ class DecoderGoldenTest {
         )
     }
 
+    @Test
+    fun testMotionPeriod0x6BCountZeroMeansFullFinalByte() {
+        // Header 0x0D: count FIELD 0 encodes a FULL final byte (4 codes), not 0 — the 2-bit field can't hold
+        // 4, so 4 wraps to 0 (all 81 count==0 records in the capture have a non-zero final byte). byte1 0xC0
+        // = 11 00 00 00 -> active, noMotion, noMotion, noMotion. `count==0 ? 0` returned null; `? 4` recovers.
+        val rec = record("6b06020001000dc0")
+        assertEquals(
+            listOf(
+                OuraMotion(ringTimestamp = rt, index = 0, state = OuraMotionState.ACTIVE),
+                OuraMotion(ringTimestamp = rt, index = 1, state = OuraMotionState.NO_MOTION),
+                OuraMotion(ringTimestamp = rt, index = 2, state = OuraMotionState.NO_MOTION),
+                OuraMotion(ringTimestamp = rt, index = 3, state = OuraMotionState.NO_MOTION),
+            ),
+            OuraDecoders.decodeMotionPeriod(rec),
+        )
+    }
+
     // MARK: - 0x47 motion events (averaged accel vector)
 
     @Test


### PR DESCRIPTION
## `main` already documents this layout — the code just doesn't implement it

This is a **doc/code contradiction on `main` today**, which is what makes it worth landing as-is.
`docs/OURA_PROTOCOL.md` §6.13 currently says:

> **`0x6B` `motion_period`**: byte6 = header — bits`[7:6]`=period_type, bits`[5:4]`=`count` of valid
> codes in the **FINAL** byte […]; byte7… = 2-bit MOTION_STATE codes, 4 per byte (MSB-first), the last
> byte carrying `count` codes where **`count == 0` means 4** […] correcting an earlier reading (byte6/7
> a 12-bit period, codes from byte8) that dropped the first code byte and read phantom codes from the
> final byte's padding.

`OuraDecoders.decodeMotionPeriod` still implements **the earlier reading the spec says is wrong** —
it skips two header bytes and reads all four codes from every byte:

```swift
guard b.count >= 3 else { return nil }
for k in 2..<b.count {                                  // codes from byte8 — drops the first code byte
    for shift in stride(from: 6, through: 0, by: -2) {  // always 4 codes — reads the final byte's padding
```

**This PR is the code half only.** The doc is untouched (`docs/` diff is empty) because the spec
already landed.

## What changes

```swift
let countField = Int((b[0] >> 4) & 0x03)         // bits[5:4]: codes in the FINAL byte
let lastCount  = countField == 0 ? 4 : countField // 0 encodes a full (4-code) final byte
for k in 1..<b.count {                            // 1-byte header — codes start at byte7
    let n = (k == b.count - 1) ? lastCount : 4
```

Two defects fixed:

1. **A dropped code byte.** The old decode skipped `payload[1]`, i.e. the first four MOTION_STATE codes
   of every record went missing.
2. **Phantom codes from padding.** The final byte was always unpacked as four codes, so the unused
   2-bit slots decoded as `noMotion` — manufactured stillness that the ring never reported.

The `count == 0 ⇒ 4` case is the subtle one and is evidenced: a 2-bit field cannot hold 4, so 4 wraps
to 0. All **81** `count == 0` records in a real capture have a **non-zero final byte, never `0x00`** —
if 0 meant "no codes", that byte would be padding and would read `0x00`.

## Blast radius: nothing is scored on it

`.motion` (0x6B) is deliberately **not folded into any durable stream** — verified in both
implementations, not just the doc comment:

- `OuraStreamMapping.swift:195` — `case .motion, .state, .timeSync, … : continue`
- `OuraStreamMapping.kt:210` — motion/state/time-sync/rtc/debug/TierB "never map onto a stream"

(Android's `MotionVectorEvent` — the `0x47` window — is a different event and is unaffected.) So this
corrects decoded output that today only reaches diagnostics; no stored value, score or migration moves.

## Cross-platform

Swift and Kotlin twins changed together, and the two implementations are line-for-line equivalent
(same guard, same `countField`/`lastCount`, same loop bounds). Golden fixtures added on both sides.

## Verification

- `swift test` (`OuraProtocol`) — **193 tests, 0 failures**.
- Android `testFullDebugUnitTest` — **3,855 tests, 0 failures** (5 skipped).
- Three new golden vectors on each platform, each pinning a distinct defect:
  - a `count=1` final byte asserts the 3 padding slots are **not** emitted (the old decode invented 3
    `noMotion`);
  - a real 2-byte payload (`1ea0`) that the old decode returned **nothing** for now recovers its one
    genuine `tossing` code;
  - a `count == 0` record asserts a **full 4-code** final byte (the `count==0 ⇒ 0` reading returned nil).