### PR TITLE
feat(oura): decode 0x7E/0x7F real_steps_features as Tier-B instrumentation

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -611,4 +611,72 @@ public enum OuraDecoders {
         }
         return OuraActivityInfo(ringTimestamp: rec.ringTimestamp, state: Int(state), met: met)
     }
+
+    // MARK: - Real steps features (0x7E/0x7F; s6.13) - Tier B, third-party formula
+
+    /// The byte offset at which a real_steps record's packed field block starts, per tag.
+    ///
+    /// `0x7E` starts at byte 0. **`0x7F` starts at byte 2** - its block is shifted by two bytes, so
+    /// applying `0x7E`'s layout to it (what this decoder did until 2026-08-01) mis-assembles every
+    /// field. Established from a real 5,122-record capture:
+    /// - Aligning `0x7F`'s per-byte statistics onto `0x7E`'s scores a **+2** shift at total error 19.0
+    ///   vs 58.6 for the next-best offset (a 3x separation); at +2 the per-byte mean, standard
+    ///   deviation AND MSB-set rate all match.
+    /// - The carry-bit test is decisive: fields 0/8 take their 9th bit from a neighbouring byte's MSB,
+    ///   which for a real carry bit sits near 50% set. `0x7E` reads 49.7%/49.0%; `0x7F` at the OLD
+    ///   (unshifted) offsets read 41.6%/**17.5%** - byte 11 at 17.5% is plainly a data byte, not a
+    ///   carry bit - and at +2 reads 51.6%/45.3%.
+    /// - Behaviourally, `0x7F`'s field 0 decoded to an INVERTED movement signal (Cohen's d = -1.72
+    ///   against a sleep-vs-activity contrast, i.e. higher at rest); at +2 it reads +2.36, matching
+    ///   `0x7E`'s own +2.35, and paired-window agreement goes r = -0.557 -> **+0.790**.
+    ///
+    /// See OURA_PROTOCOL.md s6.13. NOOP's own finding - not in the [oura-rs] source, which applies one
+    /// layout to both tags.
+    static func realStepsFieldOffset(forTag tag: UInt8) -> Int {
+        tag == OuraEventTag.realSteps2.rawValue ? 2 : 0
+    }
+
+    /// Decode a `0x7E`/`0x7F` real_steps_features record's bit-packed field block.
+    /// Formula ([oura-rs] - Th0rgal/open_oura `crates/oura-protocol/src/events.rs`, clean-room fact
+    /// citation, no code copied): fields 0 and 8 are 9-bit values built as `byte*2 + carry_bit`, where
+    /// the carry bit is the MSB of a neighboring byte (block byte 3's MSB for field 0, block byte 11's
+    /// MSB for field 8) - the same byte then also supplies field 3 / field 11 from its own low 7 bits.
+    /// Fields 1, 2, 9, 10 are a bare `byte<<1` (no carry completion). Fields 4-7 and 12-13 are plain
+    /// bytes. Returns nil unless the body is exactly 14 bytes (the source's own length gate).
+    ///
+    /// TAG-DEPENDENT OFFSET (NOOP, 2026-08-01): the block starts at byte 0 for `0x7E` but at **byte 2**
+    /// for `0x7F` - see `realStepsFieldOffset(forTag:)` for the evidence. Consequences for `0x7F`:
+    /// - It yields **12 fields, not 14**: fields 12/13 would need block bytes 12/13 = record bytes
+    ///   14/15, which do not exist in a 14-byte body. They are OMITTED rather than zero-filled - a
+    ///   fabricated zero would be indistinguishable from a real one (honest-data invariant).
+    /// - CONFIDENCE TIERS on the 12 it does yield, from the same capture: **fields 0-7 are validated**
+    ///   (mean and standard deviation match `0x7E`'s to ~1%, and the sleep-vs-activity effect size
+    ///   matches within 0.13 on two independent contrasts); **field 8 is likely right** (effect +2.82 vs
+    ///   `0x7E`'s +2.33, r = +0.854, but its mean is offset); **fields 9-11 remain uncertain** (they
+    ///   improve but do not converge, consistent with the block being truncated by the record boundary).
+    ///   All 12 are emitted because the only consumer is the Tier-B research sidecar; nothing is scored.
+    public static func decodeRealStepsFields(_ rec: OuraRecord) -> OuraRealStepsFields? {
+        let p = rec.payload
+        guard p.count == 14 else { return nil }
+        let off = realStepsFieldOffset(forTag: rec.type)
+        func b(_ i: Int) -> Int { Int(p[off + i]) }
+        var fields: [Int] = [
+            (b(3) >> 7) | (b(0) << 1),
+            b(1) << 1,
+            b(2) << 1,
+            b(3) & 0x7f,
+            b(4), b(5), b(6), b(7),
+            (b(11) >> 7) | (b(8) << 1),
+            b(9) << 1,
+            b(10) << 1,
+            b(11) & 0x7f,
+        ]
+        // Fields 12/13 exist only when the block starts at byte 0 (0x7E); for 0x7F they would read past
+        // the 14-byte body, so they are omitted rather than invented.
+        if off == 0 {
+            fields.append(b(12))
+            fields.append(b(13))
+        }
+        return OuraRealStepsFields(tag: rec.type, ringTimestamp: rec.ringTimestamp, fields: fields)
+    }
 }

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
@@ -431,8 +431,14 @@ public final class OuraDriver {
             return [.tierB(OuraTierBSummary(tag: record.type, ringTimestamp: record.ringTimestamp,
                                             rawPayload: record.payload, kind: "activity"))]
         case .realSteps1, .realSteps2:
-            return [.tierB(OuraTierBSummary(tag: record.type, ringTimestamp: record.ringTimestamp,
-                                            rawPayload: record.payload, kind: "real_steps"))]
+            // Split out of the raw-bytes .tierB wrapper, same as .activityInfo: this tag pair now has a
+            // cited third-party unpack formula (Decoders.decodeRealStepsFields, [oura-rs]). Still Tier B
+            // - only reached behind allowTierB (gated above), and OuraStreamMapping never folds
+            // .realStepsFields into a durable stream. Applies the SAME 14-field unpack to both 0x7E and
+            // 0x7F bodies (the formula is generic over any 14-byte body; NOOP's own investigation found
+            // the movement-correlated fields present in both).
+            guard let fields = OuraDecoders.decodeRealStepsFields(record) else { return [] }
+            return [.realStepsFields(fields)]
         case .spo2Smoothed:
             return [.tierB(OuraTierBSummary(tag: record.type, ringTimestamp: record.ringTimestamp,
                                             rawPayload: record.payload, kind: "spo2_smoothed"))]

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
@@ -295,6 +295,42 @@ public struct OuraActivityInfo: Equatable, Sendable, Codable {
     }
 }
 
+/// One decoded `0x7E`/`0x7F` real_steps_features record: 14 unpacked feature values from a 14-byte
+/// bit-packed body. THIRD-PARTY FORMULA ([oura-rs] - Th0rgal/open_oura `crates/oura-protocol/src/
+/// events.rs`, clean-room fact citation, no code copied; the source itself marks this decode
+/// `"_status": "unvalidated"`): two of the 14 fields (index 0 and 8) are genuine 9-bit values built as
+/// `byte*2 + carry_bit`, where the carry bit is stolen from the MSB of a neighboring byte (index 3 for
+/// field 0, index 11 for field 8); the rest are either plain bytes or a bare `byte<<1` with no carry.
+/// NOOP's OWN investigation (2026-07-30, a 2661-pair real Gen 3 capture cross-correlated against the
+/// already-anchored 0x50 MET corpus) found `fields[0]` and `fields[8]` - the two carry-completed
+/// 9-bit values - are also the ONLY fields with a consistent movement correlation (r≈+0.3 vs mean MET,
+/// effect size +1.5/+1.25 resting-vs-moving), a real convergence between the bit-layout hint and the
+/// empirical signal.
+///
+/// ⛔ **NO FIELD IS A STEP COUNT** - settled by ground truth, not left open (OURA_PROTOCOL.md §6.13):
+/// a measured 13,349-step day tested against 805 paired records found every one of the 14 fields large
+/// and non-zero during sleep (`fields[3]` sums HIGHER asleep than walking), and no byte offset on either
+/// tag yields a monotonic counter across 5,122 records. What these ARE is what the tag name says -
+/// `real_steps_FEATURES`, the *inputs* to Oura's step model, computed every 30 s whether walking or
+/// asleep. `f0`/`f8` rank top by movement discrimination (Cohen's d +2.35/+2.37), which is why they
+/// correlated: genuine movement-intensity features, useless as a count. A count would require
+/// reimplementing Oura's model over them - unvalidatable, and the §194 precedent forbids fitting one.
+///
+/// Stays Tier B end to end: emitted only behind `OuraDriver.allowTierB`, and NEVER folded into
+/// `OuraStreamMapping`/scoring - not even from `fields[0]`/`fields[8]`. `fields` holds all values
+/// verbatim, in the source's own order, as an activity-signal corpus.
+public struct OuraRealStepsFields: Equatable, Sendable, Codable {
+    /// The originating tag byte (`0x7E` realSteps1 or `0x7F` realSteps2) - both route through the same
+    /// decoder and event case, so this is what lets a consumer (or the diagnostic dump) tell which half
+    /// of the pair a given event came from.
+    public let tag: UInt8
+    public let ringTimestamp: UInt32
+    public let fields: [Int]
+    public init(tag: UInt8, ringTimestamp: UInt32, fields: [Int]) {
+        self.tag = tag; self.ringTimestamp = ringTimestamp; self.fields = fields
+    }
+}
+
 // MARK: - The emitted event union
 
 /// What OuraDriver.ingest(record:) emits. A single record can yield several events (e.g. an IBI+amp
@@ -325,11 +361,16 @@ public enum OuraEvent: Equatable, Sendable {
     /// formula, so an investigating consumer can log real MET numbers instead of hex. Same gate
     /// (`allowTierB`), same discipline (never reaches `OuraStreamMapping`).
     case activityInfo(OuraActivityInfo)
+    /// A decoded `0x7E`/`0x7F` real_steps_features record (14 unpacked fields). Still Tier-B (see
+    /// `OuraRealStepsFields` doc) - split out of the raw-bytes `.tierB` wrapper for the same reason
+    /// `.activityInfo` was: a cited third-party unpack formula worth surfacing as real numbers instead
+    /// of hex. Same gate (`allowTierB`), same discipline (never reaches `OuraStreamMapping`).
+    case realStepsFields(OuraRealStepsFields)
 
     /// True for Tier-B events, so a consumer can assert none leaked into a Tier-A-only sink.
     public var isTierB: Bool {
         switch self {
-        case .tierB, .activityInfo: return true
+        case .tierB, .activityInfo, .realStepsFields: return true
         default: return false
         }
     }
@@ -354,6 +395,7 @@ public enum OuraEvent: Equatable, Sendable {
         case .debugText(let rt, _): return rt
         case .tierB(let v): return v.ringTimestamp
         case .activityInfo(let v): return v.ringTimestamp
+        case .realStepsFields(let v): return v.ringTimestamp
         }
     }
 }

--- a/Packages/OuraProtocol/Sources/oura-decode/main.swift
+++ b/Packages/OuraProtocol/Sources/oura-decode/main.swift
@@ -153,6 +153,7 @@ func describe(_ e: OuraEvent) -> String {
     case .debugText(_, let t): return "DEBUG \(t)"
     case .tierB(let v): return "TIER_B[UNVERIFIED] tag=0x\(String(v.tag, radix: 16)) kind=\(v.kind) bytes=\(v.rawPayload.count)"
     case .activityInfo(let v): return "ACTIVITY[TIER-B,UNVERIFIED] state=\(v.state) met=\(v.met) rt=\(v.ringTimestamp)"
+    case .realStepsFields(let v): return "REAL_STEPS[TIER-B,UNVERIFIED] tag=0x\(String(v.tag, radix: 16)) fields=\(v.fields) rt=\(v.ringTimestamp)"
     }
 }
 

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraDriverTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraDriverTests.swift
@@ -505,6 +505,106 @@ final class OuraDriverTests: XCTestCase {
             OuraRecord(type: OuraEventTag.activityInfo.rawValue, ringTimestamp: rt, payload: [])))
     }
 
+    // MARK: - Real steps features (0x7E/0x7F, Tier B, third-party formula) - real Gen 3 capture
+    //
+    // PARITY/PROVENANCE: the two pairs below are byte-for-byte two CONSECUTIVE real_steps pairs from a
+    // real Gen 3 capture (2026-07-30, ring times 3499176-3499474 and their +1 0x7F partners). Expected
+    // fields are RECOMPUTED from the [oura-rs] unpack formula, not copied blind.
+
+    func testRealStepsFieldsDecodesRealCapture0x7E() {
+        let d = OuraDriver(ringGen: .gen3, authKey: key, allowTierB: true)
+        let rec = OuraRecord(type: OuraEventTag.realSteps1.rawValue, ringTimestamp: 3_499_176,
+                             payload: bytes("6feb5e0a633e106865da4c136571"))
+        let events = d.ingest(record: rec)
+        XCTAssertEqual(events, [.realStepsFields(OuraRealStepsFields(tag: OuraEventTag.realSteps1.rawValue, ringTimestamp: 3_499_176,
+            fields: [222, 470, 188, 10, 99, 62, 16, 104, 202, 436, 152, 19, 101, 113]))])
+        XCTAssertTrue(events[0].isTierB, "realStepsFields must still report isTierB - the formula is UNVERIFIED")
+    }
+
+    func testRealStepsFieldsDecodesRealCapture0x7F() {
+        let d = OuraDriver(ringGen: .gen3, authKey: key, allowTierB: true)
+        // The 0x7F partner of the same pair (ring time = the 0x7E record's rt + 1). Its packed block
+        // starts at byte 2, NOT byte 0 (see OuraDecoders.realStepsFieldOffset), so it yields 12 fields:
+        // 12/13 would need record bytes 14/15, which do not exist in a 14-byte body.
+        let rec = OuraRecord(type: OuraEventTag.realSteps2.rawValue, ringTimestamp: 3_499_177,
+                             payload: bytes("24d467b25c127e3721a0a34dbde3"))
+        XCTAssertEqual(d.ingest(record: rec), [.realStepsFields(OuraRealStepsFields(tag: OuraEventTag.realSteps2.rawValue, ringTimestamp: 3_499_177,
+            fields: [206, 356, 184, 18, 126, 55, 33, 160, 327, 154, 378, 99]))])
+    }
+
+    func testRealStepsFieldsDecodesSecondRealPair() {
+        let d = OuraDriver(ringGen: .gen3, authKey: key, allowTierB: true)
+        let recE = OuraRecord(type: OuraEventTag.realSteps1.rawValue, ringTimestamp: 3_499_474,
+                              payload: bytes("6b556d05356b1d6faa2c85aa2368"))
+        XCTAssertEqual(d.ingest(record: recE), [.realStepsFields(OuraRealStepsFields(tag: OuraEventTag.realSteps1.rawValue, ringTimestamp: 3_499_474,
+            fields: [214, 170, 218, 5, 53, 107, 29, 111, 341, 88, 266, 42, 35, 104]))])
+
+        let recF = OuraRecord(type: OuraEventTag.realSteps2.rawValue, ringTimestamp: 3_499_475,
+                              payload: bytes("213590eb62a4515c22b4c381512c"))
+        XCTAssertEqual(d.ingest(record: recF), [.realStepsFields(OuraRealStepsFields(tag: OuraEventTag.realSteps2.rawValue, ringTimestamp: 3_499_475,
+            fields: [289, 470, 196, 36, 81, 92, 34, 180, 390, 258, 162, 44]))])
+    }
+
+    // MARK: - 0x7F's +2 block offset (NOOP finding, 2026-08-01)
+
+    func testRealStepsBlockOffsetIsTagDependent() {
+        XCTAssertEqual(OuraDecoders.realStepsFieldOffset(forTag: OuraEventTag.realSteps1.rawValue), 0)
+        XCTAssertEqual(OuraDecoders.realStepsFieldOffset(forTag: OuraEventTag.realSteps2.rawValue), 2,
+                       "0x7F's packed block starts 2 bytes later than 0x7E's - see OURA_PROTOCOL.md s6.13")
+    }
+
+    func testRealStepsFields0x7FYields12Fields0x7EYields14() {
+        // 0x7F drops fields 12/13 rather than zero-filling them: they would read past the 14-byte body,
+        // and a fabricated zero is indistinguishable from a real one (honest-data invariant).
+        let e = OuraRecord(type: OuraEventTag.realSteps1.rawValue, ringTimestamp: 3_499_176,
+                           payload: bytes("6feb5e0a633e106865da4c136571"))
+        let f = OuraRecord(type: OuraEventTag.realSteps2.rawValue, ringTimestamp: 3_499_177,
+                           payload: bytes("24d467b25c127e3721a0a34dbde3"))
+        XCTAssertEqual(OuraDecoders.decodeRealStepsFields(e)?.fields.count, 14)
+        XCTAssertEqual(OuraDecoders.decodeRealStepsFields(f)?.fields.count, 12)
+    }
+
+    func testRealSteps0x7FOffsetReadsTheCarryBitFromTheRightByte() {
+        // The regression this offset fixes: fields 0/8 take their 9th bit from the block's byte 3 / byte 11
+        // MSB. For 0x7F those are RECORD bytes 5 and 13. Craft a body where the OLD (unshifted) read would
+        // see a clear carry and the CORRECT (shifted) read sees a set one - the two decodes cannot agree.
+        var payload = [UInt8](repeating: 0, count: 14)
+        payload[2] = 0xFF     // block byte 0 for 0x7F -> field0's high bits
+        payload[5] = 0x80     // block byte 3 for 0x7F -> field0's carry bit SET; old read would use byte 3 (=0)
+        let rec = OuraRecord(type: OuraEventTag.realSteps2.rawValue, ringTimestamp: rt, payload: payload)
+        let fields = OuraDecoders.decodeRealStepsFields(rec)?.fields
+        XCTAssertEqual(fields?[0], 511, "0xFF<<1 | carry(1) - the carry must come from record byte 5, not byte 3")
+        XCTAssertEqual(fields?[3], 0, "block byte 3 (record byte 5) = 0x80, & 0x7f = 0")
+    }
+
+    func testRealStepsFieldsCarryBitCombinesWithNeighborByte() {
+        // Synthetic, isolating the carry-bit mechanic the [oura-rs] source documents: byte0=0xFF (all
+        // ones) with byte3's MSB SET must read field0 = 0xFF*2 + 1 = 511 (the 9-bit max), and byte3's
+        // own value (field3) must read only its low 7 bits (the MSB was consumed by field0's carry).
+        let rec = OuraRecord(type: OuraEventTag.realSteps1.rawValue, ringTimestamp: rt, payload: [
+            0xFF, 0x00, 0x00, 0x80, 0, 0, 0, 0, 0x00, 0x00, 0x00, 0x00, 0, 0,
+        ])
+        let fields = OuraDecoders.decodeRealStepsFields(rec)?.fields
+        XCTAssertEqual(fields?[0], 511)   // 0xFF<<1 | 1
+        XCTAssertEqual(fields?[3], 0)     // byte3 = 0x80, & 0x7f = 0
+        XCTAssertEqual(fields?[8], 0)     // byte11's MSB is clear -> no carry
+    }
+
+    func testRealStepsFieldsDroppedByDefaultLikeOtherTierB() {
+        let d = OuraDriver(ringGen: .gen3, authKey: key)   // allowTierB defaults to false
+        let rec = OuraRecord(type: OuraEventTag.realSteps1.rawValue, ringTimestamp: rt,
+                             payload: bytes("6feb5e0a633e106865da4c136571"))
+        XCTAssertEqual(d.ingest(record: rec), [], "the Tier-B gate must cover .realStepsFields too")
+    }
+
+    func testRealStepsFieldsWrongLengthDecodesToNil() {
+        // The source's own length gate: anything other than exactly 14 bytes -> honest nil, never a guess.
+        XCTAssertNil(OuraDecoders.decodeRealStepsFields(
+            OuraRecord(type: OuraEventTag.realSteps1.rawValue, ringTimestamp: rt, payload: bytes("00"))))
+        XCTAssertNil(OuraDecoders.decodeRealStepsFields(
+            OuraRecord(type: OuraEventTag.realSteps1.rawValue, ringTimestamp: rt, payload: [])))
+    }
+
     // MARK: - Live-HR push routing + decode
 
     func testHandleSecureFrameRoutesNonceStatusAndPush() {

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraRealStepsDumpLine.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraRealStepsDumpLine.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Pure, deterministic encoder for ONE line of the Oura real_steps_features (0x7E/0x7F) research corpus
+/// — a diagnostic JSONL sidecar, NOT a datastore row.
+///
+/// WHY a sidecar and not a stream/table: the decode is Tier-B (a cited third-party unpack formula,
+/// [oura-rs], not ground-truth-validated against a known step count — OURA_PROTOCOL.md s6.13). The
+/// honest-data invariant forbids Tier-B ever minting a durable scoring row, so it must never touch
+/// `Streams`/SQLite. This corpus is a separate, clearly-labeled file the app appends to as a
+/// **movement-feature** record — the step-count question is CLOSED (ground truth: no field is a count,
+/// they are the inputs to Oura's step model), so nothing here may ever be turned into steps. It never
+/// feeds scoring and is safe to delete. Parallels `OuraActivityDumpLine` / `OuraCvaPpgDumpLine`.
+public enum OuraRealStepsDumpLine {
+    /// Bump when the record shape changes so a downstream reader can branch on `schema`.
+    public static let schema = 1
+
+    /// One JSONL record (NO trailing newline — the writer adds it). `deviceId` is a controlled registry id
+    /// (e.g. `oura-<serial>`) and `iso`/`tag` are app-generated, so none need JSON string-escaping here.
+    ///   - tag:    "0x7e" or "0x7f" (which half of the paired record this is).
+    ///   - ringTs: the record's raw ring-clock timestamp (the dedup key: strictly increases per record).
+    ///   - utc:    the anchored wall-clock (unix seconds) for the record envelope.
+    ///   - iso:    human-readable UTC of `utc` (convenience for eyeballing).
+    ///   - fields: the 14 decoded fields this ONE record contributed, verbatim, in the source's own order.
+    public static func encode(deviceId: String, tag: String, ringTs: UInt32, utc: Int, iso: String,
+                              fields: [Int]) -> String {
+        let fieldsStr = fields.map { String($0) }.joined(separator: ",")
+        return "{\"schema\":\(schema),\"deviceId\":\"\(deviceId)\",\"tag\":\"\(tag)\",\"ringTs\":\(ringTs),"
+             + "\"utc\":\(utc),\"iso\":\"\(iso)\",\"fields\":[\(fieldsStr)]}"
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -192,10 +192,12 @@ public enum OuraStreamMapping {
                 if let hi = m.highIntensity { payload["high_intensity"] = .int(hi) }
                 out.events.append(WhoopEvent(ts: ts, kind: motionEventKind, payload: payload))
 
-            case .motion, .state, .timeSync, .rtcBeacon, .debugText, .tierB, .activityInfo:
+            case .motion, .state, .timeSync, .rtcBeacon, .debugText, .tierB, .activityInfo, .realStepsFields:
                 // Not a durable per-device stream row (timeSync/rtcBeacon anchor the transport's clock;
-                // motion/state/debug are diagnostics; Tier-B / .activityInfo are UNVERIFIED and must
-                // never feed scoring or the steps stream).
+                // motion/state/debug are diagnostics; Tier-B / .activityInfo / .realStepsFields are
+                // UNVERIFIED and must never feed scoring or the steps stream - in particular
+                // .realStepsFields must never mint a `steps` row on its own: ground truth showed no
+                // field is a count, they are the inputs to Oura's step model; see OuraRealStepsFields).
                 continue
             }
         }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraRealStepsDumpLineTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraRealStepsDumpLineTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import WhoopStore
+
+final class OuraRealStepsDumpLineTests: XCTestCase {
+    func testEncodeFixedKeyOrderAndValues() {
+        let line = OuraRealStepsDumpLine.encode(
+            deviceId: "oura-2H3B2405003655", tag: "0x7e", ringTs: 3_499_176, utc: 1_753_440_000,
+            iso: "2026-07-30T09:09:01Z",
+            fields: [222, 470, 188, 10, 99, 62, 16, 104, 202, 436, 152, 19, 101, 113])
+        XCTAssertEqual(line,
+            "{\"schema\":1,\"deviceId\":\"oura-2H3B2405003655\",\"tag\":\"0x7e\",\"ringTs\":3499176,"
+          + "\"utc\":1753440000,\"iso\":\"2026-07-30T09:09:01Z\","
+          + "\"fields\":[222,470,188,10,99,62,16,104,202,436,152,19,101,113]}")
+    }
+
+    func testEncodeEmptyFieldsIsValidJSON() throws {
+        let line = OuraRealStepsDumpLine.encode(deviceId: "oura-x", tag: "0x7f", ringTs: 1, utc: 2,
+                                                iso: "i", fields: [])
+        let obj = try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+        XCTAssertEqual(obj?["schema"] as? Int, OuraRealStepsDumpLine.schema)
+        XCTAssertEqual(obj?["tag"] as? String, "0x7f")
+        XCTAssertEqual((obj?["fields"] as? [Any])?.count, 0)
+    }
+}

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
@@ -258,9 +258,12 @@ final class OuraStreamMappingTests: XCTestCase {
             // 0x50 activity/MET (PR #960): decoded but Tier-B/unvalidated - in particular it must never
             // mint a `steps` row (MET is not a step count; the per-source day-owner rules stay intact).
             .activityInfo(OuraActivityInfo(ringTimestamp: 100, state: 0x41, met: [1.8, 1.9])),
+            // 0x7E/0x7F real_steps_features: decoded but Tier-B - must never mint a `steps` row either.
+            // Ground truth showed no field is a count; they are model inputs (see OuraRealStepsFields).
+            .realStepsFields(OuraRealStepsFields(tag: 0x7E, ringTimestamp: 100, fields: Array(0..<14))),
         ], at: ts)
         XCTAssertTrue(s.isEmpty, "Tier-B and diagnostic events must not produce any durable stream row")
-        XCTAssertTrue(s.steps.isEmpty, "activity/MET must never fabricate a steps row")
+        XCTAssertTrue(s.steps.isEmpty, "activity/MET/real_steps must never fabricate a steps row")
     }
 
     // MARK: - Batching a record's events into one insert (#1072, root cause for #823)

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -281,6 +281,9 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     private let activityDump: OuraActivityDump?
     /// Append-only JSONL sidecar for the 0x47 motion vectors (Tier-A), for offline LSB→g calibration (#804).
     private let motionDump: OuraMotionDump?
+    /// Append-only JSONL research corpus for 0x7E/0x7F real_steps_features (Tier-B, third-party
+    /// [oura-rs] unpack formula, never scored/persisted to SQLite). See OuraRealStepsDump.
+    private let realStepsDump: OuraRealStepsDump?
     /// Append-only JSONL capture of the RAW, undecoded history-drain notification bytes (`oura-raw-<id>.jsonl`).
     /// Complement to the decoded sidecars above: those show what NOOP interpreted, this shows exactly what the
     /// ring sent, so after a full connect a hole in a decoded file can be pinned as a decode drop vs ring-side.
@@ -955,6 +958,8 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         self.motionDump = feedsLive && !deviceId.isEmpty ? OuraMotionDump(deviceId: deviceId, log: log) : nil
         // RAW undecoded history-drain capture: same live/persisting gate; complements the decoded sidecars.
         self.rawDump = feedsLive && !deviceId.isEmpty ? OuraRawDump(deviceId: deviceId, log: log) : nil
+        // 0x7E/0x7F real_steps research corpus: same gate as the other Tier-B dumps.
+        self.realStepsDump = feedsLive && !deviceId.isEmpty ? OuraRealStepsDump(deviceId: deviceId, log: log) : nil
         super.init()
         // Dedicated queue-less central -> callbacks arrive on the main queue, matching @MainActor.
         #if os(iOS)
@@ -1588,6 +1593,23 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                     }
                     lastActivityUtc = utc
                     lastActivitySampleCount = info.met.count
+                }
+
+            case .realStepsFields(let steps):
+                // INVESTIGATION ONLY (0x7E/0x7F real_steps_features, Tier B - a cited third-party unpack
+                // formula [oura-rs], NOT ground-truth-validated; see OuraRealStepsFields). Logged once per
+                // kind (like the other raw Tier-B tags) rather than every occurrence - this stream runs at
+                // a much higher rate than 0x50 MET, so the JSONL corpus is the real record; the strap log
+                // just confirms the ring sends it at all. Never persisted, never scored, and NEVER
+                // converted into steps (OuraStreamMapping drops .realStepsFields unconditionally) - not
+                // even from fields[0]/fields[8], which ground truth showed are movement FEATURES, not a
+                // count (a 13,349-step day; every field large and non-zero asleep - OURA_PROTOCOL.md §6.13).
+                if !loggedTierBKinds.contains("real_steps_fields") {
+                    loggedTierBKinds.insert("real_steps_fields")
+                    log("Oura: Tier-B real_steps_fields seen (tag 0x\(String(steps.tag, radix: 16))) - first fields: \(steps.fields)")
+                }
+                if let utc = driver.unixSeconds(forRingTimestamp: steps.ringTimestamp) {
+                    realStepsDump?.record(tag: steps.tag, ringTs: steps.ringTimestamp, utc: utc, fields: steps.fields)
                 }
 
             case .state(let s):

--- a/Strand/BLE/OuraRealStepsDump.swift
+++ b/Strand/BLE/OuraRealStepsDump.swift
@@ -1,0 +1,115 @@
+import Foundation
+import WhoopStore
+
+/// Append-only JSONL sidecar for the Oura 0x7E/0x7F real_steps_features stream — a Tier-B RESEARCH
+/// corpus for investigation, NOT a datastore row (see `OuraRealStepsDumpLine` for the rationale). Direct
+/// twin of `OuraActivityDump` / `OuraCvaPpgDump`: owns the file handle, the on-disk path, the
+/// once-per-launch "here is the file" log line, and a persistent ring-time high-water so records the
+/// ring re-serves across reconnects are written exactly once instead of duplicating the corpus.
+///
+/// Location: `<Application Support>/OpenWhoop/Diagnostics/oura-real-steps-<deviceId>.jsonl` — beside the
+/// app's SQLite so the user can find it. Purely diagnostic and safe to delete; nothing reads it back.
+///
+/// It is NOT a step-decode corpus: ground truth closed that question (no field is a count — see
+/// `OuraRealStepsFields` and OURA_PROTOCOL.md §6.13). It exists as a **movement-feature** corpus — `f0`
+/// and `f8` discriminate movement strongly (Cohen's d ≈ +2.35), so the file is useful for activity work
+/// and for cross-checking the `0x7F` +2-byte offset against `0x7E` on new firmware. Nothing here may be
+/// turned into steps.
+final class OuraRealStepsDump {
+    private let deviceId: String
+    private let log: (String) -> Void
+    private let highWaterKey: String
+    /// Only records with `ringTs` STRICTLY above this are written; re-served (older) records are dropped.
+    /// Persisted in UserDefaults so the dedup survives app relaunches (a fresh drain re-emits old records).
+    private var highWater: UInt32
+    private var fileURL: URL?
+    private var resolveFailed = false
+    private var announced = false
+
+    /// Rotate the sidecar past this size (keeping one previous ".1"), so an always-on research corpus is
+    /// bounded to ~2× this on disk instead of growing forever. Matches the other Oura Tier-B dumps.
+    private static let maxBytes = 25 * 1024 * 1024
+
+    private static let iso: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.timeZone = TimeZone(identifier: "UTC")
+        return f
+    }()
+
+    init(deviceId: String, log: @escaping (String) -> Void) {
+        self.deviceId = deviceId
+        self.log = log
+        self.highWaterKey = "oura.realStepsDump.highwater.\(deviceId)"
+        let stored = UserDefaults.standard.integer(forKey: highWaterKey)   // 0 when unset → writes everything
+        self.highWater = stored > 0 ? UInt32(truncatingIfNeeded: stored) : 0
+    }
+
+    /// Append one anchored real_steps record. No-op when `ringTs` is not above the high-water (a
+    /// re-serve), so the corpus stays deduped. Best-effort: any file error is logged once and never
+    /// disrupts the BLE path. Call ONLY with an anchored `utc` (an un-anchored record has no real time
+    /// axis and re-arrives anchored on the next drain).
+    func record(tag: UInt8, ringTs: UInt32, utc: Int, fields: [Int]) {
+        guard ringTs > highWater else { return }
+        guard var url = resolveURL() else { return }
+        // Bound the corpus (rotate to a single ".1", dropping the prior one) so an always-on research
+        // sidecar can't grow unbounded — same rotation as the other Oura Tier-B dumps. Read the size via
+        // a fresh FileManager stat rather than URL.resourceValues, whose cache on the reused URL can
+        // return a stale small size.
+        let size = ((try? FileManager.default.attributesOfItem(atPath: url.path))?[.size] as? Int) ?? 0
+        if size > Self.maxBytes {
+            let old = url.deletingLastPathComponent().appendingPathComponent(url.lastPathComponent + ".1")
+            try? FileManager.default.removeItem(at: old)
+            try? FileManager.default.moveItem(at: url, to: old)
+            fileURL = nil
+            guard let fresh = resolveURL() else { return }
+            url = fresh
+        }
+
+        let tagStr = "0x" + String(tag, radix: 16)
+        let line = OuraRealStepsDumpLine.encode(
+            deviceId: deviceId, tag: tagStr, ringTs: ringTs, utc: utc,
+            iso: Self.iso.string(from: Date(timeIntervalSince1970: TimeInterval(utc))), fields: fields)
+
+        guard let data = (line + "\n").data(using: .utf8) else { return }
+        do {
+            let handle = try FileHandle(forWritingTo: url)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            handle.write(data)
+        } catch {
+            log("Oura: real_steps dump write failed - \(error.localizedDescription)")
+            return
+        }
+
+        highWater = ringTs
+        UserDefaults.standard.set(Int(ringTs), forKey: highWaterKey)
+        if !announced {
+            announced = true
+            log("Oura: real_steps 0x7E/0x7F dump → \(url.path) [Tier-B research corpus, JSONL, deduped by ring-time]")
+        }
+    }
+
+    /// Resolve (and create on first use) the sidecar file + its parent directory. Cached; a failure is
+    /// logged once and latched so we never spam the strap log on a read-only volume.
+    private func resolveURL() -> URL? {
+        if let fileURL { return fileURL }
+        if resolveFailed { return nil }
+        do {
+            let base = try FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask,
+                                                   appropriateFor: nil, create: true)
+            let dir = base.appendingPathComponent("OpenWhoop/Diagnostics", isDirectory: true)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let safeId = deviceId.replacingOccurrences(of: "/", with: "_")
+            let url = dir.appendingPathComponent("oura-real-steps-\(safeId).jsonl")
+            if !FileManager.default.fileExists(atPath: url.path) {
+                FileManager.default.createFile(atPath: url.path, contents: nil)
+            }
+            fileURL = url
+            return url
+        } catch {
+            resolveFailed = true
+            log("Oura: real_steps dump unavailable - \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -249,6 +249,11 @@ class OuraLiveSource(
      *  of the Swift `OuraMotionDump`. Null when there is no device id. */
     private val motionDump: OuraMotionDump? =
         if (deviceId.isNotEmpty()) OuraMotionDump(appContext, deviceId, log) else null
+
+    /** 0x7E/0x7F real_steps research corpus (Tier-B), for offline investigation. Kotlin twin of the Swift
+     *  `OuraRealStepsDump`. Null when there is no device id. */
+    private val realStepsDump: OuraRealStepsDump? =
+        if (deviceId.isNotEmpty()) OuraRealStepsDump(appContext, deviceId, log) else null
     private val scanner: BluetoothLeScanner? get() = adapter?.bluetoothLeScanner
 
     private var gatt: BluetoothGatt? = null
@@ -1784,6 +1789,22 @@ class OuraLiveSource(
                         ringTs = e.value.ringTimestamp, utc = utc, state = e.value.state,
                         secPerSample = 60, met = e.value.met, // 60 s = assumed MET cadence (s6.13)
                     )
+                }
+            }
+            is OuraEvent.RealStepsFields -> {
+                // INVESTIGATION ONLY (0x7E/0x7F real_steps_features, Tier B - a cited third-party unpack
+                // formula [oura-rs], NOT ground-truth-validated; see OuraRealStepsFields). Logged once per
+                // kind (like the other raw Tier-B tags) rather than every occurrence - this stream runs at
+                // a much higher rate than 0x50 MET, so the JSONL corpus is the real record; the strap log
+                // just confirms the ring sends it at all. Never persisted, never scored, and NEVER
+                // converted into steps (OuraStreamMapping drops RealStepsFields unconditionally) - not
+                // even from fields[0]/fields[8], which ground truth showed are movement FEATURES, not a
+                // count (a 13,349-step day; every field large and non-zero asleep - OURA_PROTOCOL.md s6.13).
+                if (loggedTierBKinds.add("real_steps_fields")) {
+                    log("Oura: Tier-B real_steps_fields seen (tag 0x${e.value.tag.toString(16)}) - first fields: ${e.value.fields}")
+                }
+                d.unixSeconds(forRingTimestamp = e.value.ringTimestamp)?.let { utc ->
+                    realStepsDump?.record(tag = e.value.tag, ringTs = e.value.ringTimestamp, utc = utc, fields = e.value.fields)
                 }
             }
             is OuraEvent.MotionVectorEvent -> {

--- a/android/app/src/main/java/com/noop/ble/OuraRealStepsDump.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraRealStepsDump.kt
@@ -1,0 +1,105 @@
+package com.noop.ble
+
+import android.content.Context
+import com.noop.oura.OuraRealStepsDumpLine
+import java.io.File
+import java.time.Instant
+
+/**
+ * Append-only JSONL sidecar for the Oura 0x7E/0x7F real_steps_features stream — the Kotlin twin of Swift
+ * `OuraRealStepsDump`. A Tier-B RESEARCH corpus for investigation, never a datastore row (see
+ * [OuraRealStepsDumpLine] for the rationale). Owns the file, the once-per-launch "here is the file" log
+ * line, and a persistent ring-time high-water so records the ring re-serves across reconnects are
+ * written exactly once instead of duplicating the corpus.
+ *
+ * Location: `<filesDir>/diagnostics/oura-real-steps-<deviceId>.jsonl` (app-private). Purely diagnostic
+ * and safe to delete; nothing reads it back.
+ *
+ * It is NOT a step-decode corpus: ground truth closed that question (no field is a count — see
+ * [OuraRealStepsFields] and OURA_PROTOCOL.md s6.13). It exists as a MOVEMENT-FEATURE corpus — f0 and f8
+ * discriminate movement strongly (Cohen's d ~ +2.35), so the file is useful for activity work and for
+ * cross-checking the 0x7F +2-byte offset against 0x7E on new firmware. Nothing here may be turned into
+ * steps. The LINE content is byte-identical to the Swift corpus — that is the parity-relevant part.
+ */
+class OuraRealStepsDump(
+    context: Context,
+    private val deviceId: String,
+    private val log: (String) -> Unit,
+) {
+    private val appContext = context.applicationContext
+    private val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val highWaterKey = "highwater.$deviceId"
+
+    /** Only records with `ringTs` STRICTLY above this are written; re-served (older) records are dropped.
+     *  Persisted so the dedup survives relaunches (a fresh drain re-emits old records). */
+    private var highWater: Long = prefs.getLong(highWaterKey, 0L)
+    private var file: File? = null
+    private var resolveFailed = false
+    private var announced = false
+
+    /**
+     * Append one anchored real_steps record. No-op when [ringTs] is not above the high-water (a
+     * re-serve), so the corpus stays deduped. Best-effort: any file error is logged once and never
+     * disrupts the BLE path. Call ONLY with an anchored [utc].
+     */
+    fun record(tag: Int, ringTs: Long, utc: Long, fields: List<Int>) {
+        if (ringTs <= highWater) return
+        var f = resolveFile() ?: return
+        // Bound the corpus so it can't grow unbounded (always-on for every paired ring). At the cap, rotate
+        // to a single ".1" (dropping the prior one) and continue in a fresh file — same as the other dumps.
+        if (f.length() > MAX_BYTES) {
+            runCatching {
+                val old = File(f.parentFile, "${f.name}.1")
+                old.delete()
+                f.renameTo(old)
+            }
+            file = null
+            f = resolveFile() ?: return
+        }
+
+        val tagStr = "0x" + tag.toString(16)
+        val line = OuraRealStepsDumpLine.encode(
+            deviceId = deviceId, tag = tagStr, ringTs = ringTs, utc = utc,
+            iso = Instant.ofEpochSecond(utc).toString(), fields = fields,
+        )
+        try {
+            f.appendText(line + "\n")
+        } catch (e: Exception) {
+            log("Oura: real_steps dump write failed - ${e.message}")
+            return
+        }
+
+        highWater = ringTs
+        prefs.edit().putLong(highWaterKey, ringTs).apply()
+        if (!announced) {
+            announced = true
+            log("Oura: real_steps 0x7E/0x7F dump → ${f.absolutePath} [Tier-B research corpus, JSONL, deduped by ring-time]")
+        }
+    }
+
+    /** Resolve (and create on first use) the sidecar file + its parent directory. Cached; a failure is
+     *  logged once and latched so we never spam the strap log on a read-only volume. */
+    private fun resolveFile(): File? {
+        file?.let { return it }
+        if (resolveFailed) return null
+        return try {
+            val dir = File(appContext.filesDir, "diagnostics").apply { mkdirs() }
+            val safeId = deviceId.replace("/", "_")
+            File(dir, "oura-real-steps-$safeId.jsonl").also {
+                if (!it.exists()) it.createNewFile()
+                file = it
+            }
+        } catch (e: Exception) {
+            resolveFailed = true
+            log("Oura: real_steps dump unavailable - ${e.message}")
+            null
+        }
+    }
+
+    private companion object {
+        const val PREFS_NAME = "oura_real_steps_dump"
+
+        /** Rotate the sidecar past this size (keeping one previous ".1"), bounding it to ~2× on disk. */
+        const val MAX_BYTES = 25L * 1024 * 1024
+    }
+}

--- a/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
+++ b/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
@@ -207,11 +207,13 @@ object OuraStreamMapping {
                     out.events.add(WhoopEvent(ts = ts, kind = EVENT_MOTION, payload = payload))
                 }
 
-                // Motion / state / time-sync / rtc / debug / TierB / ActivityInfo never map onto a
-                // scored stream. In particular the 0x50 activity/MET decode (PR #960) NEVER mints a
-                // `steps` row: the formula is third-party and unvalidated (Tier B, OURA_PROTOCOL.md
+                // Motion / state / time-sync / rtc / debug / TierB / ActivityInfo / RealStepsFields never
+                // map onto a scored stream. In particular the 0x50 activity/MET decode (PR #960) NEVER
+                // mints a `steps` row: the formula is third-party and unvalidated (Tier B, OURA_PROTOCOL.md
                 // s6.13), and MET is not a step count - fabricating one would break the honest-data
-                // invariant and the per-source day-owner rules.
+                // invariant and the per-source day-owner rules. Same discipline for 0x7E/0x7F real_steps
+                // (s6.13) - decoded, logged, never scored: ground truth showed no field is a step count,
+                // they are the inputs to Oura's step model.
                 else -> Unit
             }
         }

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -691,4 +691,76 @@ object OuraDecoders {
         }
         return OuraActivityInfo(ringTimestamp = rec.ringTimestamp, state = b[0], met = met)
     }
+
+    // MARK: - Real steps features (0x7E/0x7F; s6.13) - Tier B, third-party formula
+
+    /**
+     * The byte offset at which a real_steps record's packed field block starts, per tag.
+     *
+     * `0x7E` starts at byte 0. **`0x7F` starts at byte 2** - its block is shifted by two bytes, so
+     * applying `0x7E`'s layout to it (what this decoder did until 2026-08-01) mis-assembles every
+     * field. Established from a real 5,122-record capture:
+     * - Aligning `0x7F`'s per-byte statistics onto `0x7E`'s scores a **+2** shift at total error 19.0
+     *   vs 58.6 for the next-best offset (a 3x separation); at +2 the per-byte mean, standard
+     *   deviation AND MSB-set rate all match.
+     * - The carry-bit test is decisive: fields 0/8 take their 9th bit from a neighbouring byte's MSB,
+     *   which for a real carry bit sits near 50% set. `0x7E` reads 49.7% and 49.0%; `0x7F` at the OLD
+     *   (unshifted) offsets read 41.6% and **17.5%** - byte 11 at 17.5% is plainly a data byte, not a
+     *   carry bit - and at +2 reads 51.6% and 45.3%.
+     * - Behaviourally, `0x7F`'s field 0 decoded to an INVERTED movement signal (Cohen's d = -1.72
+     *   against a sleep-vs-activity contrast, i.e. higher at rest); at +2 it reads +2.36, matching
+     *   `0x7E`'s own +2.35, and paired-window agreement goes r = -0.557 -> **+0.790**.
+     *
+     * See OURA_PROTOCOL.md s6.13. NOOP's own finding - not in the [oura-rs] source, which applies one
+     * layout to both tags. Byte-identical twin of Swift's `realStepsFieldOffset`.
+     */
+    internal fun realStepsFieldOffset(tag: Int): Int = if (tag == OuraEventTag.REAL_STEPS_2.raw) 2 else 0
+
+    /**
+     * Decode a `0x7E`/`0x7F` real_steps_features record's bit-packed field block.
+     * Formula ([oura-rs] - Th0rgal/open_oura `crates/oura-protocol/src/events.rs`, clean-room fact
+     * citation, no code copied): fields 0 and 8 are 9-bit values built as `byte*2 + carry_bit`, where
+     * the carry bit is the MSB of a neighboring byte (block byte 3's MSB for field 0, block byte 11's
+     * MSB for field 8) - the same byte then also supplies field 3 / field 11 from its own low 7 bits.
+     * Fields 1, 2, 9, 10 are a bare `byte<<1` (no carry completion). Fields 4-7 and 12-13 are plain
+     * bytes. Returns null unless the body is exactly 14 bytes (the source's own length gate).
+     *
+     * TAG-DEPENDENT OFFSET (NOOP, 2026-08-01): the block starts at byte 0 for `0x7E` but at **byte 2**
+     * for `0x7F` - see [realStepsFieldOffset] for the evidence. Consequences for `0x7F`:
+     * - It yields **12 fields, not 14**: fields 12/13 would need block bytes 12/13 = record bytes
+     *   14/15, which do not exist in a 14-byte body. They are OMITTED rather than zero-filled - a
+     *   fabricated zero would be indistinguishable from a real one (honest-data invariant).
+     * - CONFIDENCE TIERS on the 12 it does yield, from the same capture: **fields 0-7 are validated**
+     *   (mean and standard deviation match `0x7E`'s to ~1%, and the sleep-vs-activity effect size
+     *   matches within 0.13 on two independent contrasts); **field 8 is likely right** (effect +2.82 vs
+     *   `0x7E`'s +2.33, r = +0.854, but its mean is offset); **fields 9-11 remain uncertain** (they
+     *   improve but do not converge, consistent with the block being truncated by the record boundary).
+     *   All 12 are emitted because the only consumer is the Tier-B research sidecar; nothing is scored.
+     *
+     * Byte-identical twin of Swift's `decodeRealStepsFields`.
+     */
+    fun decodeRealStepsFields(rec: OuraRecord): OuraRealStepsFields? {
+        val p = rec.payload
+        if (p.size != 14) return null
+        val off = realStepsFieldOffset(rec.type)
+        fun b(i: Int): Int = p[off + i]
+        val fields = mutableListOf(
+            (b(3) shr 7) or (b(0) shl 1),
+            b(1) shl 1,
+            b(2) shl 1,
+            b(3) and 0x7f,
+            b(4), b(5), b(6), b(7),
+            (b(11) shr 7) or (b(8) shl 1),
+            b(9) shl 1,
+            b(10) shl 1,
+            b(11) and 0x7f,
+        )
+        // Fields 12/13 exist only when the block starts at byte 0 (0x7E); for 0x7F they would read past
+        // the 14-byte body, so they are omitted rather than invented.
+        if (off == 0) {
+            fields.add(b(12))
+            fields.add(b(13))
+        }
+        return OuraRealStepsFields(tag = rec.type, ringTimestamp = rec.ringTimestamp, fields = fields)
+    }
 }

--- a/android/app/src/main/java/com/noop/oura/OuraDriver.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraDriver.kt
@@ -508,15 +508,16 @@ class OuraDriver(
                         ),
                     ),
                 )
-            OuraEventTag.REAL_STEPS_1, OuraEventTag.REAL_STEPS_2 ->
-                listOf(
-                    OuraEvent.TierB(
-                        OuraTierBSummary(
-                            tag = record.type, ringTimestamp = record.ringTimestamp,
-                            rawPayload = record.payload, kind = "real_steps",
-                        ),
-                    ),
-                )
+            OuraEventTag.REAL_STEPS_1, OuraEventTag.REAL_STEPS_2 -> {
+                // Split out of the raw-bytes TierB wrapper, same as ActivityInfo: this tag pair now has a
+                // cited third-party unpack formula (OuraDecoders.decodeRealStepsFields, [oura-rs]). Still
+                // Tier B - only reached behind allowTierB (gated above), and OuraStreamMapping never folds
+                // RealStepsFields into a durable stream. Applies the SAME 14-field unpack to both 0x7E and
+                // 0x7F bodies (the formula is generic over any 14-byte body; NOOP's own investigation
+                // found the movement-correlated fields present in both).
+                val fields = OuraDecoders.decodeRealStepsFields(record) ?: return emptyList()
+                listOf(OuraEvent.RealStepsFields(fields))
+            }
             OuraEventTag.SPO2_SMOOTHED ->
                 listOf(
                     OuraEvent.TierB(

--- a/android/app/src/main/java/com/noop/oura/OuraEvents.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraEvents.kt
@@ -275,6 +275,35 @@ data class OuraTierBSummary(
  */
 data class OuraActivityInfo(val ringTimestamp: Long, val state: Int, val met: List<Double>)
 
+/**
+ * One decoded `0x7E`/`0x7F` real_steps_features record: 14 unpacked feature values from a 14-byte
+ * bit-packed body. THIRD-PARTY FORMULA ([oura-rs] - Th0rgal/open_oura `crates/oura-protocol/src/
+ * events.rs`, clean-room fact citation, no code copied; the source itself marks this decode
+ * `"_status": "unvalidated"`): two of the 14 fields (index 0 and 8) are genuine 9-bit values built as
+ * `byte*2 + carry_bit`, where the carry bit is stolen from the MSB of a neighboring byte (index 3 for
+ * field 0, index 11 for field 8); the rest are either plain bytes or a bare `byte<<1` with no carry.
+ * NOOP's OWN investigation (2026-07-30, a 2661-pair real Gen 3 capture cross-correlated against the
+ * already-anchored 0x50 MET corpus) found `fields[0]` and `fields[8]` - the two carry-completed 9-bit
+ * values - are also the ONLY fields with a consistent movement correlation (r~+0.3 vs mean MET, effect
+ * size +1.5/+1.25 resting-vs-moving), a real convergence between the bit-layout hint and the empirical
+ * signal.
+ *
+ * NO FIELD IS A STEP COUNT - settled by ground truth, not left open (OURA_PROTOCOL.md s6.13): a
+ * measured 13,349-step day tested against 805 paired records found every one of the 14 fields large and
+ * non-zero during sleep (`fields[3]` sums HIGHER asleep than walking), and no byte offset on either tag
+ * yields a monotonic counter across 5,122 records. What these ARE is what the tag name says -
+ * `real_steps_FEATURES`, the *inputs* to Oura's step model, computed every 30 s whether walking or
+ * asleep. `f0`/`f8` rank top by movement discrimination (Cohen's d +2.35/+2.37), which is why they
+ * correlated: genuine movement-intensity features, useless as a count. A count would require
+ * reimplementing Oura's model over them - unvalidatable, and the s194 precedent forbids fitting one.
+ *
+ * Stays Tier B end to end: emitted only behind `OuraDriver.allowTierB`, and NEVER folded into
+ * `OuraStreamMapping`/scoring - not even from `fields[0]`/`fields[8]`. `fields` holds all values
+ * verbatim, in the source's own order, as an activity-signal corpus. Kotlin twin of the Swift
+ * `OuraRealStepsFields`.
+ */
+data class OuraRealStepsFields(val tag: Int, val ringTimestamp: Long, val fields: List<Int>)
+
 // MARK: - The emitted event union
 
 /**
@@ -319,8 +348,16 @@ sealed class OuraEvent {
      */
     data class ActivityInfo(val value: OuraActivityInfo) : OuraEvent()
 
+    /**
+     * A decoded `0x7E`/`0x7F` real_steps_features record (14 unpacked fields). Still Tier-B (see
+     * [OuraRealStepsFields] doc) - split out of the raw-bytes [TierB] wrapper for the same reason
+     * [ActivityInfo] was: a cited third-party unpack formula worth surfacing as real numbers instead of
+     * hex. Same gate (`allowTierB`), same discipline (never reaches `OuraStreamMapping`).
+     */
+    data class RealStepsFields(val value: OuraRealStepsFields) : OuraEvent()
+
     /** True for Tier-B events, so a consumer can assert none leaked into a Tier-A-only sink. */
-    val isTierB: Boolean get() = this is TierB || this is ActivityInfo
+    val isTierB: Boolean get() = this is TierB || this is ActivityInfo || this is RealStepsFields
 
     /**
      * The record's envelope ring-time, when it carries one (battery is a plain response, not a log
@@ -345,5 +382,6 @@ sealed class OuraEvent {
             is DebugTextEvent -> ringTimestamp
             is TierB -> value.ringTimestamp
             is ActivityInfo -> value.ringTimestamp
+            is RealStepsFields -> value.ringTimestamp
         }
 }

--- a/android/app/src/main/java/com/noop/oura/OuraRealStepsDumpLine.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraRealStepsDumpLine.kt
@@ -1,0 +1,34 @@
+package com.noop.oura
+
+/**
+ * Pure, deterministic encoder for ONE line of the Oura real_steps_features (0x7E/0x7F) research corpus —
+ * the Kotlin twin of Swift `OuraRealStepsDumpLine`. Byte-identical output (fixed key order), so the two
+ * platforms' JSONL corpora are interchangeable.
+ *
+ * WHY a sidecar and not a stream/table: the decode is Tier-B (a cited third-party unpack formula,
+ * [oura-rs], not ground-truth-validated against a known step count — OURA_PROTOCOL.md s6.13). The
+ * honest-data invariant forbids Tier-B ever minting a durable scoring row, so it must never touch
+ * Streams/the DB. This corpus is a separate, clearly-labelled diagnostic file kept as a MOVEMENT-FEATURE
+ * record — the step-count question is CLOSED (ground truth: no field is a count, they are the inputs to
+ * Oura's step model), so nothing here may ever be turned into steps.
+ * Parallels [OuraActivityDumpLine] / [OuraCvaPpgDumpLine].
+ */
+object OuraRealStepsDumpLine {
+    /** Bump when the record shape changes so a downstream reader can branch on `schema`. */
+    const val SCHEMA = 1
+
+    /**
+     * One JSONL record (NO trailing newline — the writer adds it). `deviceId` is a controlled registry id
+     * (e.g. `oura-<serial>`) and `iso`/`tag` are app-generated, so none need JSON string-escaping here.
+     *   - tag:    "0x7e" or "0x7f" (which half of the paired record this is).
+     *   - ringTs: the record's raw ring-clock timestamp (the dedup key: strictly increases per record).
+     *   - utc:    the anchored wall-clock (unix seconds) for the record envelope.
+     *   - iso:    human-readable UTC of `utc` (convenience for eyeballing).
+     *   - fields: the 14 decoded fields this ONE record contributed, verbatim, in the source's own order.
+     */
+    fun encode(deviceId: String, tag: String, ringTs: Long, utc: Long, iso: String, fields: List<Int>): String {
+        val fieldsStr = fields.joinToString(",")
+        return "{\"schema\":$SCHEMA,\"deviceId\":\"$deviceId\",\"tag\":\"$tag\",\"ringTs\":$ringTs," +
+            "\"utc\":$utc,\"iso\":\"$iso\",\"fields\":[$fieldsStr]}"
+    }
+}

--- a/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
+++ b/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
@@ -366,6 +366,11 @@ class OuraStreamMappingTest {
                 OuraEvent.ActivityInfo(
                     com.noop.oura.OuraActivityInfo(ringTimestamp = 100, state = 0x41, met = listOf(1.8, 1.9)),
                 ),
+                // 0x7E/0x7F real_steps_features: decoded but Tier-B - must never mint a `steps` row
+                // either. Ground truth showed no field is a count; they are model inputs (s6.13).
+                OuraEvent.RealStepsFields(
+                    com.noop.oura.OuraRealStepsFields(tag = 0x7E, ringTimestamp = 100, fields = (0..13).toList()),
+                ),
             ),
             anchor,
         )

--- a/android/app/src/test/java/com/noop/oura/OuraDriverTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraDriverTest.kt
@@ -567,6 +567,164 @@ class OuraDriverTest {
         )
     }
 
+    // MARK: - Real steps features (0x7E/0x7F, Tier B, third-party formula) - real Gen 3 capture
+    //
+    // PARITY/PROVENANCE: the two pairs below are byte-for-byte the same two CONSECUTIVE real_steps pairs
+    // pinned in the Swift OuraDriverTests (real capture, ring times 3499176-3499474 and their +1 0x7F
+    // partners). Expected fields are RECOMPUTED from the [oura-rs] unpack formula, not copied blind.
+
+    @Test
+    fun testRealStepsFieldsDecodesRealCapture0x7E() {
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key, allowTierB = true)
+        val rec = OuraRecord(type = OuraEventTag.REAL_STEPS_1.raw, ringTimestamp = 3_499_176,
+                             payload = bytes("6feb5e0a633e106865da4c136571"))
+        val events = d.ingest(rec)
+        assertEquals(
+            listOf<OuraEvent>(
+                OuraEvent.RealStepsFields(
+                    OuraRealStepsFields(
+                        tag = OuraEventTag.REAL_STEPS_1.raw, ringTimestamp = 3_499_176,
+                        fields = listOf(222, 470, 188, 10, 99, 62, 16, 104, 202, 436, 152, 19, 101, 113),
+                    ),
+                ),
+            ),
+            events,
+        )
+        assertTrue("realStepsFields must still report isTierB - the formula is UNVERIFIED", events[0].isTierB)
+    }
+
+    @Test
+    fun testRealStepsFieldsDecodesRealCapture0x7F() {
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key, allowTierB = true)
+        // The 0x7F partner of the same pair (ring time = the 0x7E record's rt + 1). Its packed block
+        // starts at byte 2, NOT byte 0 (see OuraDecoders.realStepsFieldOffset), so it yields 12 fields:
+        // 12/13 would need record bytes 14/15, which do not exist in a 14-byte body.
+        val rec = OuraRecord(type = OuraEventTag.REAL_STEPS_2.raw, ringTimestamp = 3_499_177,
+                             payload = bytes("24d467b25c127e3721a0a34dbde3"))
+        assertEquals(
+            listOf<OuraEvent>(
+                OuraEvent.RealStepsFields(
+                    OuraRealStepsFields(
+                        tag = OuraEventTag.REAL_STEPS_2.raw, ringTimestamp = 3_499_177,
+                        fields = listOf(206, 356, 184, 18, 126, 55, 33, 160, 327, 154, 378, 99),
+                    ),
+                ),
+            ),
+            d.ingest(rec),
+        )
+    }
+
+    // MARK: - 0x7F's +2 block offset (NOOP finding, 2026-08-01)
+
+    @Test
+    fun testRealStepsBlockOffsetIsTagDependent() {
+        assertEquals(0, OuraDecoders.realStepsFieldOffset(OuraEventTag.REAL_STEPS_1.raw))
+        assertEquals(
+            "0x7F's packed block starts 2 bytes later than 0x7E's - see OURA_PROTOCOL.md s6.13",
+            2, OuraDecoders.realStepsFieldOffset(OuraEventTag.REAL_STEPS_2.raw),
+        )
+    }
+
+    @Test
+    fun testRealStepsFields0x7FYields12Fields0x7EYields14() {
+        // 0x7F drops fields 12/13 rather than zero-filling them: they would read past the 14-byte body,
+        // and a fabricated zero is indistinguishable from a real one (honest-data invariant).
+        val e = OuraRecord(type = OuraEventTag.REAL_STEPS_1.raw, ringTimestamp = 3_499_176,
+                           payload = bytes("6feb5e0a633e106865da4c136571"))
+        val f = OuraRecord(type = OuraEventTag.REAL_STEPS_2.raw, ringTimestamp = 3_499_177,
+                           payload = bytes("24d467b25c127e3721a0a34dbde3"))
+        assertEquals(14, OuraDecoders.decodeRealStepsFields(e)?.fields?.size)
+        assertEquals(12, OuraDecoders.decodeRealStepsFields(f)?.fields?.size)
+    }
+
+    @Test
+    fun testRealSteps0x7FOffsetReadsTheCarryBitFromTheRightByte() {
+        // The regression this offset fixes: fields 0/8 take their 9th bit from the block's byte 3 / byte 11
+        // MSB. For 0x7F those are RECORD bytes 5 and 13. Craft a body where the OLD (unshifted) read would
+        // see a clear carry and the CORRECT (shifted) read sees a set one - the two decodes cannot agree.
+        val payload = IntArray(14)
+        payload[2] = 0xFF     // block byte 0 for 0x7F -> field0's high bits
+        payload[5] = 0x80     // block byte 3 for 0x7F -> field0's carry bit SET; old read would use byte 3 (=0)
+        val rec = OuraRecord(type = OuraEventTag.REAL_STEPS_2.raw, ringTimestamp = rt, payload = payload)
+        val fields = OuraDecoders.decodeRealStepsFields(rec)?.fields
+        assertEquals("0xFF<<1 | carry(1) - the carry must come from record byte 5, not byte 3", 511, fields?.get(0))
+        assertEquals("block byte 3 (record byte 5) = 0x80, & 0x7f = 0", 0, fields?.get(3))
+    }
+
+    @Test
+    fun testRealStepsFieldsDecodesSecondRealPair() {
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key, allowTierB = true)
+        val recE = OuraRecord(type = OuraEventTag.REAL_STEPS_1.raw, ringTimestamp = 3_499_474,
+                              payload = bytes("6b556d05356b1d6faa2c85aa2368"))
+        assertEquals(
+            listOf<OuraEvent>(
+                OuraEvent.RealStepsFields(
+                    OuraRealStepsFields(
+                        tag = OuraEventTag.REAL_STEPS_1.raw, ringTimestamp = 3_499_474,
+                        fields = listOf(214, 170, 218, 5, 53, 107, 29, 111, 341, 88, 266, 42, 35, 104),
+                    ),
+                ),
+            ),
+            d.ingest(recE),
+        )
+
+        val recF = OuraRecord(type = OuraEventTag.REAL_STEPS_2.raw, ringTimestamp = 3_499_475,
+                              payload = bytes("213590eb62a4515c22b4c381512c"))
+        assertEquals(
+            listOf<OuraEvent>(
+                OuraEvent.RealStepsFields(
+                    OuraRealStepsFields(
+                        tag = OuraEventTag.REAL_STEPS_2.raw, ringTimestamp = 3_499_475,
+                        fields = listOf(289, 470, 196, 36, 81, 92, 34, 180, 390, 258, 162, 44),
+                    ),
+                ),
+            ),
+            d.ingest(recF),
+        )
+    }
+
+    @Test
+    fun testRealStepsFieldsCarryBitCombinesWithNeighborByte() {
+        // Synthetic, isolating the carry-bit mechanic the [oura-rs] source documents: byte0=0xFF (all
+        // ones) with byte3's MSB SET must read field0 = 0xFF*2 + 1 = 511 (the 9-bit max), and byte3's
+        // own value (field3) must read only its low 7 bits (the MSB was consumed by field0's carry).
+        val rec = OuraRecord(
+            type = OuraEventTag.REAL_STEPS_1.raw, ringTimestamp = rt,
+            payload = intArrayOf(0xFF, 0x00, 0x00, 0x80, 0, 0, 0, 0, 0x00, 0x00, 0x00, 0x00, 0, 0),
+        )
+        val fields = OuraDecoders.decodeRealStepsFields(rec)?.fields
+        assertEquals(511, fields?.get(0))   // 0xFF<<1 | 1
+        assertEquals(0, fields?.get(3))     // byte3 = 0x80, & 0x7f = 0
+        assertEquals(0, fields?.get(8))     // byte11's MSB is clear -> no carry
+    }
+
+    @Test
+    fun testRealStepsFieldsDroppedByDefaultLikeOtherTierB() {
+        val d = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = key)   // allowTierB defaults to false
+        val rec = OuraRecord(type = OuraEventTag.REAL_STEPS_1.raw, ringTimestamp = rt,
+                             payload = bytes("6feb5e0a633e106865da4c136571"))
+        assertEquals(
+            "the Tier-B gate must cover RealStepsFields too",
+            emptyList<OuraEvent>(),
+            d.ingest(rec),
+        )
+    }
+
+    @Test
+    fun testRealStepsFieldsWrongLengthDecodesToNull() {
+        // The source's own length gate: anything other than exactly 14 bytes -> honest null, never a guess.
+        assertNull(
+            OuraDecoders.decodeRealStepsFields(
+                OuraRecord(type = OuraEventTag.REAL_STEPS_1.raw, ringTimestamp = rt, payload = bytes("00")),
+            ),
+        )
+        assertNull(
+            OuraDecoders.decodeRealStepsFields(
+                OuraRecord(type = OuraEventTag.REAL_STEPS_1.raw, ringTimestamp = rt, payload = intArrayOf()),
+            ),
+        )
+    }
+
     // MARK: - Live-HR push routing + decode
 
     @Test

--- a/android/app/src/test/java/com/noop/oura/OuraRealStepsDumpLineTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraRealStepsDumpLineTest.kt
@@ -1,0 +1,34 @@
+package com.noop.oura
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The Tier-B real_steps research-corpus JSONL line encoder. The line is asserted verbatim so the format
+ * is pinned byte-for-byte AND stays interchangeable with the Swift `OuraRealStepsDumpLine` corpus (same
+ * key order, same `fields` formatting).
+ */
+class OuraRealStepsDumpLineTest {
+
+    @Test
+    fun encodesFixedShapeVerbatim() {
+        val line = OuraRealStepsDumpLine.encode(
+            deviceId = "oura-2H3B2405003655", tag = "0x7e", ringTs = 3_499_176, utc = 1_753_440_000,
+            iso = "2026-07-30T09:09:01Z",
+            fields = listOf(222, 470, 188, 10, 99, 62, 16, 104, 202, 436, 152, 19, 101, 113),
+        )
+        assertEquals(
+            "{\"schema\":1,\"deviceId\":\"oura-2H3B2405003655\",\"tag\":\"0x7e\",\"ringTs\":3499176," +
+                "\"utc\":1753440000,\"iso\":\"2026-07-30T09:09:01Z\"," +
+                "\"fields\":[222,470,188,10,99,62,16,104,202,436,152,19,101,113]}",
+            line,
+        )
+    }
+
+    @Test
+    fun emptyFieldsIsEmptyArray() {
+        val line = OuraRealStepsDumpLine.encode("d", "0x7f", 1, 2, "x", emptyList())
+        assertTrue(line.endsWith("\"fields\":[]}"))
+    }
+}


### PR DESCRIPTION

**Title:** `feat(oura): decode 0x7E/0x7F real_steps_features as Tier-B instrumentation`

## Why now: `main` documents this code, and the code isn't there

`docs/OURA_PROTOCOL.md` §6.13 on `main` already describes the decode in full — the ground-truth test, the
`0x7F` +2-byte offset, the confidence tiers — and names the implementation:

> **NOOP applies the +2 offset for `0x7F`** (`OuraDecoders.realStepsFieldOffset`, both platforms) […]
> `OuraDecoders.decodeRealStepsFields` (Swift) / `Decoders.decodeRealStepsFields` (Kotlin)

Neither symbol exists on `main`, on either platform. The investigation's write-up landed; the decoder it
describes did not. **This PR is the code half only** — the `docs/` diff is empty by design.

## ⛔ It is NOT a step count, and this PR is the one that says so in code

Stating this up front because the tag name invites the opposite reading, and because an earlier revision
of this very branch got it wrong.

Ground truth (a measured **13,349-step day** — independent device, same wrist — tested against 805 paired
records, with that night's sleep as the control) shows:

- **Every one of the 14 fields is large and non-zero during sleep.** `fields[3]` sums **38,845 asleep vs
  15,095 walking** — higher asleep. No scaling, offset or unit conversion reconciles any field with 13,349.
- **No cumulative counter exists on the wire.** Every byte offset read as u8/u16LE/u16BE/u24LE/u32LE, both
  tags, 5,122 records: **zero** monotonic sequences.
- **What they ARE is the tag's own name** — `real_steps_FEATURES`, the *inputs* to Oura's step model,
  computed every 30 s whether walking or asleep. `f0`/`f8` lead on movement discrimination (Cohen's d
  **+2.35**/**+2.37**), which is exactly why they correlate: genuine movement-intensity features, useless
  as a count.

Recovering a count would mean reimplementing Oura's model over these features and fitting it to one
ground-truth day — which is what the **#194 precedent** forbids. So the decode lands as instrumentation
and can never become steps:

- gated behind `OuraDriver.allowTierB`;
- logged once per session, appended to a JSONL sidecar;
- **dropped unconditionally by `OuraStreamMapping` on both platforms** — `.realStepsFields` sits in the
  `continue` arm alongside the other diagnostics, pinned by a test on each platform. (Swift asserts
  `s.steps.isEmpty` explicitly; Android's `Streams` has **no `steps` field at all**, so the twin asserts
  every stream list is empty and a steps row is unreachable there by construction.)

Included in the commit: a sweep retiring the **stale "leading candidate for the step field" framing**
from every decoder/dump comment on both platforms. Those comments predated the ground-truth test and
still described `fields[0]`/`fields[8]` as the likely step field, with the sidecar's stated purpose being
"a future controlled-walk capture to settle it" — i.e. they contradicted the spec they cite. They now
describe a **movement-feature** corpus.

## The `0x7F` +2-byte offset — the substantive decode finding

`0x7F` is **not** the same layout as `0x7E`. The pairing is exact (2561/2561 records, `0x7F` always at the
`0x7E` record's `rt + 1`) and both bodies are 14 B, but the field block starts **+2 bytes later**.

- Aligning `0x7F`'s per-byte statistics onto `0x7E`'s over 5,122 records scores **+2 at total error 19.0**
  vs **58.6** for next-best — a 3× separation.
- **The carry-bit test is decisive.** The unpack takes field 0's 9th bit from byte 3's MSB and field 8's
  from byte 11's; a real carry bit is ~50 % set. `0x7E` reads **49.7 % / 49.0 %** ✓. `0x7F` unshifted reads
  **41.6 % / 17.5 %** ✗ — byte 11 at 17.5 % is plainly a data byte. At +2, `0x7F` reads **51.6 % / 45.3 %** ✓.
- What the unshifted decode produced was **inverted**: `0x7F.fields[0]` gave d = **−1.72** (sleep > walking);
  re-unpacked at +2 it becomes **+2.36**, statistically identical to `0x7E`'s own +2.35. Paired agreement
  `7E.f0` vs `7F.f0` goes from **r = −0.557** to **r = +0.790**.

At that offset `0x7F` yields **12 fields, not 14** — fields 12/13 would need record bytes 14/15, which do
not exist. They are **omitted, not zero-filled**: a fabricated zero is indistinguishable from a real one.

## Cross-platform

Full Swift/Kotlin twins: decoder, event type, driver wiring, stream-mapping exclusion, sidecar writer and
its line codec, plus tests on both sides. The **JSONL line content is byte-identical** across platforms —
that is the parity-relevant surface, since the file is the research artifact.

## Verification

- `swift test` `OuraProtocol` — **193 tests, 0 failures**.
- `swift test` `WhoopStore` — **384 tests, 0 failures**.
- Android `testFullDebugUnitTest` (full suite, `--rerun-tasks`) — **3,855 tests, 0 failures**, 5 skipped.
- **macOS `Strand` and iOS `NOOPiOS` both build.** This touches app-target Swift (`Strand/BLE/`), which
  **no default CI compiles** (`app-build.yml` is disabled) — so it was built locally rather than trusted
  to a green tick.
- Not hardware-validated in this session: the tags are server-gated and only appear on an Advanced-key
  pairing with an active membership (§3.7). The decode evidence above comes from the 5,122-record capture
  already described in §6.13.