### PR TITLE
fix(today): bound the classic dashboard's vital carry, one skin-temp format (#1331 display facet, both platforms)

### DIFF
--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -202,6 +202,13 @@ struct TodayView: View {
     // Imperial/Metric display preference (D#103). Only the Weight tile carries a convertible unit here.
     @AppStorage(UnitPrefs.systemKey) private var unitSystemRaw = UnitSystem.metric.rawValue
     private var unitSystem: UnitSystem { UnitSystem(rawValue: unitSystemRaw) ?? .metric }
+    /// °C / °F for the Skin Temp card, resolved the way every other screen resolves it (`FullDayChartView`,
+    /// `MetricExplorerView`, Liquid Today): the explicit override when set, else derived from the unit
+    /// system. This screen used to print a bare `%+.1f°` and was the last one ignoring the preference.
+    @AppStorage(UnitPrefs.temperatureKey) private var temperatureRaw = ""
+    private var temperatureUnit: TemperatureUnit {
+        UnitPrefs.resolveTemperature(system: unitSystem, override: temperatureRaw)
+    }
     // Day-cycle scene backdrop (#698). Default ON. When the user turns it off in Settings → Appearance,
     // Today drops the SceneScreenBackground and falls back to the plain dark surfaceBase canvas. The
     // cards already sit on an opaque canvas, so readability is unchanged either way.
@@ -550,6 +557,15 @@ struct TodayView: View {
     private var lastSkinTempDay: DailyMetric? {
         guard selectedDayOffset == 0 else { return nil }
         return Repository.lastSkinTempDay(days: repo.days, todayKey: displayDay?.day ?? selectedDayKey)
+    }
+
+    /// PER-FIELD respiratory carry, and the only one of these that is STALENESS-BOUNDED
+    /// (`Baselines.vitalCarryDays`). SpO₂ and skin temperature are sparse or import-fed, so last-known-of-
+    /// any-age is the honest answer for them. Respiration is measured every night, so a value that old is
+    /// not a missed night — it is a number nobody measured, printed where today's belongs (#1331).
+    private var lastRespDay: DailyMetric? {
+        guard selectedDayOffset == 0 else { return nil }
+        return Repository.lastRespDay(days: repo.days, todayKey: displayDay?.day ?? selectedDayKey)
     }
 
     /// Pure carry-over selector behind `lastScoredRecoveryDay`, extracted so the gate + selection can be
@@ -2380,14 +2396,19 @@ struct TodayView: View {
             #endif
             return withUnit(d?.restingHr.map { "\($0)" } ?? "—")
         case .respiratory:
-            // PER-FIELD carry: today → recovery-INDEPENDENT vitals carry → the sparkline tail. The
-            // vitals carry (not the recovery-gated `lastScoredRecoveryDay`) feeds respiratory so a
-            // night with real R-R but a null recovery still carries, matching the Android dashboard
-            // card (`day?.respRateBpm ?: vitalsDay?.respRateBpm`). The sparkline tail is the last
-            // resort so a sparse-but-recent value still reads.
+            // PER-FIELD carry: today → the STALENESS-BOUNDED prior night (`lastRespDay`). Recovery-
+            // independent, so a night with real R-R but a null recovery still carries.
+            //
+            // Both older fallbacks are gone on purpose. `lastVitalsDay` picks the newest row with ANY
+            // vital and has no age bound at all, and `sparks["resp_rate"].last` is the same
+            // `DailyMetric.respRateBpm` column reached through the series, also unbounded — the two
+            // "latest vital" resolvers that between them printed one CSV import's last value, 15.6, as
+            // today's respiratory rate for a fortnight (#1331). Nothing within the bound is lost: the
+            // bounded carry reads the same column, so anything the tail could still surface is by
+            // definition older than the window deliberately excludes. A gap now reads "—", which is the
+            // truthful answer when nobody measured.
             return withUnit(d?.respRateBpm.map { String(format: "%.1f", $0) }
-                            ?? lastVitalsDay?.respRateBpm.map { String(format: "%.1f", $0) }
-                            ?? sparks["resp_rate"]?.last.map { String(format: "%.1f", $0) } ?? "—")
+                            ?? lastRespDay?.respRateBpm.map { String(format: "%.1f", $0) } ?? "—")
         case .bloodOxygen:
             // PER-FIELD carry: today → whole-row vitals carry → the last row that actually HAS a reading
             // (computed "-noop" rows write spo2Pct = nil), so this card agrees with the Key Metrics tile
@@ -2401,10 +2422,18 @@ struct TodayView: View {
             }
             return "—"
         case .skinTemp:
-            // Stored as a deviation from baseline (°C); show it signed so +/- reads honestly. Same per-field
-            // carry as Blood Oxygen.
-            return (d?.skinTempDevC ?? lastVitalsDay?.skinTempDevC ?? lastSkinTempDay?.skinTempDevC)
-                .map { String(format: "%+.1f°", $0) } ?? "—"
+            // The column is BIMODAL (#622): the live BLE pipeline stores a signed deviation from the
+            // personal baseline (±°C), while CSV / Health imports store an absolute wrist reading (~30-35 °C).
+            // The old `%+.1f°` here printed both as a deviation, so an imported night read "+33.4°" — a
+            // deviation nobody could have — and it ignored the °C/°F preference this screen was the last
+            // one not to honour. `SkinTempDisplay` is the shared resolver every other surface already uses
+            // (Liquid Today, VitalSignsSummary, MetricCatalog): it tells the two kinds apart, signs only the
+            // deviation, and converts a DELTA by the scale factor alone rather than the absolute formula.
+            // The card's own unit is deliberately empty — the value carries "°C" / "Δ°F" itself.
+            // Same per-field carry as Blood Oxygen; both are sparse enough that an old reading is honest.
+            return Self.skinTempCardValue(
+                d?.skinTempDevC ?? lastVitalsDay?.skinTempDevC ?? lastSkinTempDay?.skinTempDevC,
+                fahrenheit: temperatureUnit == .fahrenheit)
         case .sleep:
             return sleepValue(d)
         case .steps:
@@ -4586,6 +4615,13 @@ struct TodayView: View {
     static func emptyVitalCaption(unit: String, isToday: Bool) -> String? {
         guard isToday else { return nil }
         return String(localized: "After tonight's sleep")
+    }
+
+    /// The Skin Temp card's value, extracted so the bimodal-column decision can be unit-tested without a
+    /// live view. Nil (no reading anywhere in the carry chain) reads as an em-dash rather than a number.
+    static func skinTempCardValue(_ value: Double?, fahrenheit: Bool) -> String {
+        guard let value else { return "—" }
+        return SkinTempDisplay.format(value, fahrenheit: fahrenheit)
     }
 
     /// Pure copy/gate behind `buildingHint`, extracted so it can be unit-tested without a live view.

--- a/StrandTests/TodayVitalCardTests.swift
+++ b/StrandTests/TodayVitalCardTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+import StrandAnalytics
+import WhoopStore
+@testable import Strand
+
+/// The classic Today dashboard's two vital cards that were printing something other than what they
+/// claimed. Both defects were invisible to the build and to every existing test, because the shared
+/// resolvers that answer these questions correctly (`SkinTempDisplay`, `Repository.lastRespDay`) were
+/// used by Liquid Today, the Health tab and the Sleep tab — and by this screen alone, not at all.
+final class TodayVitalCardTests: XCTestCase {
+
+    private func day(_ d: String, resp: Double? = nil) -> DailyMetric {
+        DailyMetric(day: d, totalSleepMin: 420, efficiency: 90,
+                    deepMin: 80, remMin: 90, lightMin: 200, disturbances: nil,
+                    restingHr: 60, avgHrv: 45, recovery: nil, strain: nil,
+                    exerciseCount: nil, spo2Pct: nil, skinTempDevC: nil, respRateBpm: resp)
+    }
+
+    // MARK: Skin Temp — a bimodal column, one format
+
+    /// An IMPORTED night stores an absolute wrist temperature in the same column the BLE pipeline uses
+    /// for a deviation. The old `%+.1f°` signed it regardless, so this read "+33.4°" — a deviation from
+    /// baseline that no human body produces.
+    func testAbsoluteImportIsNotPrintedAsADeviation() {
+        let shown = TodayView.skinTempCardValue(33.4, fahrenheit: false)
+        XCTAssertEqual(shown, "33.4 °C")
+        XCTAssertFalse(shown.hasPrefix("+"), "an absolute reading must not be signed")
+    }
+
+    /// A live deviation keeps its sign — that is the whole point of the ± presentation — and says so.
+    func testDeviationKeepsItsSignAndIsLabelled() {
+        XCTAssertEqual(TodayView.skinTempCardValue(-0.1, fahrenheit: false), "-0.1 Δ°C")
+        XCTAssertEqual(TodayView.skinTempCardValue(0.3, fahrenheit: false), "+0.3 Δ°C")
+    }
+
+    /// °F was ignored on this screen alone. A DELTA converts by the scale factor only: +1.0 °C of
+    /// deviation is +1.8 °F, never 33.8 — the offset belongs to absolute readings.
+    func testFahrenheitConvertsDeviationAndAbsoluteDifferently() {
+        XCTAssertEqual(TodayView.skinTempCardValue(1.0, fahrenheit: true), "+1.8 Δ°F")
+        XCTAssertEqual(TodayView.skinTempCardValue(33.4, fahrenheit: true), "92.1 °F")
+    }
+
+    func testNoReadingReadsAsAnEmDash() {
+        XCTAssertEqual(TodayView.skinTempCardValue(nil, fahrenheit: false), "—")
+    }
+
+    // MARK: Respiratory — the carry has to be bounded
+
+    /// The reported regression, on the card this screen shows: a WHOOP CSV import ending 2026-07-30,
+    /// viewed on 2026-08-13, with thirteen live nights after it that recorded pulse and HRV but no
+    /// respiration. The only respiratory value anywhere is a fortnight old, and every unbounded "latest
+    /// respiratory" search — the card's old sparkline tail among them — hands it back as today's. The
+    /// bounded selector refuses it, so the card reads "—".
+    func testFortnightOldImportNoLongerCarries() {
+        var days = [day("2026-07-29", resp: 16.2), day("2026-07-30", resp: 15.6)]
+        days += (1...13).map { day(String(format: "2026-08-%02d", $0)) }
+
+        XCTAssertEqual(days.last(where: { $0.respRateBpm != nil })?.day, "2026-07-30",
+                       "the fixture reproduces the report: the newest respiratory value IS the old import")
+        XCTAssertNil(Repository.lastRespDay(days: days, todayKey: "2026-08-13"))
+    }
+
+    /// The carry still earns its keep: one missed night must not blank the card.
+    func testARecentNightStillCarries() {
+        let days = [day("2026-08-11", resp: 14.1), day("2026-08-12")]
+        XCTAssertEqual(Repository.lastRespDay(days: days, todayKey: "2026-08-13")?.respRateBpm, 14.1)
+    }
+
+    /// Today's own row is never "carried": the bound looks strictly backwards, so a still-forming today
+    /// cannot be picked up as its own prior night.
+    func testTodayIsNotItsOwnCarry() {
+        let days = [day("2026-08-13", resp: 15.0)]
+        XCTAssertNil(Repository.lastRespDay(days: days, todayKey: "2026-08-13"))
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3171,6 +3171,10 @@ private fun YourCardsSection(
     onCustomise: () -> Unit,
     spo2CandidateByDay: Map<String, Double> = emptyMap(),
 ) {
+    // #1331 parity: honor the °C/°F preference on the Skin Temp card, the way Health / Compare (and the
+    // Swift twin) do. The classic dashboard hardcoded Celsius here alone, so a °F user saw °C on this
+    // screen only.
+    val fahrenheit = UnitPrefs.temperature(LocalContext.current) == TemperatureUnit.FAHRENHEIT
     Box(modifier = Modifier.fillMaxWidth().staggeredAppear(2)) {
         Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
             // Header: "YOUR CARDS" overline + a right-aligned blue EDIT action (the WHOOP ✎ affordance).
@@ -3192,6 +3196,7 @@ private fun YourCardsSection(
                         spo2Day = spo2Day,
                         skinTempDay = skinTempDay,
                         respDay = respDay,
+                        fahrenheit = fahrenheit,
                         stress = stress,
                         fitnessAge = fitnessAge,
                         vitality = vitality,
@@ -3351,7 +3356,11 @@ private fun dashboardCardFraction(
         DashboardCard.VITALITY -> over(vitality, 100.0)
         DashboardCard.HRV -> over(day?.avgHrv ?: vitalsDay?.avgHrv, 120.0)
         DashboardCard.RESTING_HR -> over((day?.restingHr ?: vitalsDay?.restingHr)?.toDouble(), 100.0)
-        DashboardCard.RESPIRATORY -> over(day?.respRateBpm ?: vitalsDay?.respRateBpm ?: respDay?.respRateBpm, 24.0)
+        // PER-FIELD carry: today → the STALENESS-BOUNDED prior night (`respDay` = lastRespRow). The
+        // unbounded `vitalsDay?.respRateBpm` is dropped on purpose — it picks the newest row with ANY
+        // vital regardless of age and printed one CSV import's 15.6 as today's rate for a fortnight
+        // (#1331). Byte-twin of the Swift `lastRespDay` card.
+        DashboardCard.RESPIRATORY -> over(day?.respRateBpm ?: respDay?.respRateBpm, 24.0)
         DashboardCard.STEPS -> {
             val steps = (day?.steps ?: importedStepsForDay ?: estimatedStepsForDay)?.toDouble()
             over(steps, 10000.0)
@@ -3394,6 +3403,7 @@ private fun dashboardCardValue(
     hydrationTotalMl: Double,
     hydrationGoalMl: Int,
     spo2CandidateByDay: Map<String, Double> = emptyMap(),
+    fahrenheit: Boolean = false,
 ): String {
     fun withUnit(s: String): String =
         if (s == NO_DATA) NO_DATA else if (card.unit.isEmpty()) s else "$s ${card.unit}"
@@ -3407,7 +3417,11 @@ private fun dashboardCardValue(
         DashboardCard.RESTING_HR ->
             withUnit((day?.restingHr ?: vitalsDay?.restingHr)?.toString() ?: NO_DATA)
         DashboardCard.RESPIRATORY ->
-            withUnit((day?.respRateBpm ?: vitalsDay?.respRateBpm ?: respDay?.respRateBpm)?.let { String.format(Locale.US, "%.1f", it) } ?: NO_DATA)
+            // PER-FIELD carry: today → the STALENESS-BOUNDED `respDay` (lastRespRow). The unbounded
+            // `vitalsDay?.respRateBpm` is dropped on purpose (see the gauge site + Swift `lastRespDay`):
+            // it had no age bound and showed a fortnight-old imported 15.6 as today's rate (#1331). A gap
+            // past the window now reads NO_DATA — the truthful answer when nobody measured.
+            withUnit((day?.respRateBpm ?: respDay?.respRateBpm)?.let { String.format(Locale.US, "%.1f", it) } ?: NO_DATA)
         DashboardCard.BLOOD_OXYGEN ->
             // PER-FIELD carry: the whole-row carries (vd) land on rows whose spo2Pct is null (the engine
             // writes spo2Pct = null on computed rows), so fall through to the last row that HAS one.
@@ -3422,7 +3436,7 @@ private fun dashboardCardValue(
             // Always label the scale; bare "−0.1°" next to a 34° deep-timeline chart looked broken.
             val v = vd?.skinTempDevC ?: skinTempDay?.skinTempDevC
             if (v == null) NO_DATA
-            else com.noop.analytics.SkinTempDisplay.format(v, fahrenheit = false)
+            else com.noop.analytics.SkinTempDisplay.format(v, fahrenheit = fahrenheit)
         }
         DashboardCard.SLEEP -> sleepValue(vd)
         DashboardCard.STEPS -> {

--- a/android/app/src/test/java/com/noop/ui/LastRespRowTest.kt
+++ b/android/app/src/test/java/com/noop/ui/LastRespRowTest.kt
@@ -1,0 +1,48 @@
+package com.noop.ui
+
+import com.noop.data.DailyMetric
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Byte-twin of the Swift `TodayVitalCardTests` respiratory cases (#1331). Pins `lastRespRow` — the
+ * STALENESS-BOUNDED resolver the classic Today dashboard's Respiratory card now reads, instead of the
+ * unbounded whole-row vitals carry that printed one CSV import's last value for a fortnight.
+ */
+class LastRespRowTest {
+
+    private fun day(d: String, resp: Double? = null) =
+        DailyMetric(deviceId = "my-whoop", day = d, restingHr = 60, avgHrv = 45.0, respRateBpm = resp)
+
+    /** The reported regression: a WHOOP CSV import ending 2026-07-30, viewed on 2026-08-13, with
+     * thirteen live nights after it that recorded pulse and HRV but no respiration. The only
+     * respiratory value anywhere is a fortnight old; the bounded selector refuses it, so the card
+     * reads "No Data". */
+    @Test
+    fun fortnightOldImportNoLongerCarries() {
+        val days = listOf(day("2026-07-29", 16.2), day("2026-07-30", 15.6)) +
+            (1..13).map { day("2026-08-%02d".format(it)) }
+
+        assertEquals(
+            "the fixture reproduces the report: the newest respiratory value IS the old import",
+            "2026-07-30", days.lastOrNull { it.respRateBpm != null }?.day,
+        )
+        assertNull(lastRespRow(days, todayKey = "2026-08-13"))
+    }
+
+    /** The carry still earns its keep: one missed night must not blank the card. */
+    @Test
+    fun aRecentNightStillCarries() {
+        val days = listOf(day("2026-08-11", 14.1), day("2026-08-12"))
+        assertEquals(14.1, lastRespRow(days, todayKey = "2026-08-13")?.respRateBpm)
+    }
+
+    /** Today's own row is never "carried": the bound looks strictly backwards, so a still-forming
+     * today cannot be picked up as its own prior night. */
+    @Test
+    fun todayIsNotItsOwnCarry() {
+        val days = listOf(day("2026-08-13", 15.0))
+        assertNull(lastRespRow(days, todayKey = "2026-08-13"))
+    }
+}


### PR DESCRIPTION
Two vital cards on the **classic Today dashboard** printed something other than what they showed, and this screen was the last one still bypassing resolvers every other surface (Liquid Today, Health, Sleep) already uses. Both platforms.

## Swift (by @DX23876, cherry-picked with authorship intact)

- **Skin Temp** — the column is bimodal (#622): BLE stores a *deviation* from baseline, CSV/Health imports store an *absolute* wrist reading. The card signed everything `%+.1f°`, so an imported night read `+33.4°` (a deviation no body produces) and °C/°F was ignored here alone. Now routes through `SkinTempDisplay`, which tells the two kinds apart and converts a delta by the scale factor only.
- **Respiratory** — the carry had no age bound: `lastVitalsDay` (newest row with ANY vital) and the `resp_rate` sparkline tail both reached the same column, so one CSV import's last value (`15.6`) read as today's respiratory rate for a fortnight (#1331). Now reads the staleness-bounded `Repository.lastRespDay`; past `Baselines.vitalCarryDays` the card honestly shows "—".

Adds `TodayVitalCardTests`.

## Android parity twin (this PR)

The Android classic dashboard had the **identical** respiratory bug — the Respiratory card (gauge + value) resolved `day ?: vitalsDay?.respRateBpm ?: respDay?.respRateBpm`, so the **unbounded** `vitalsDay` won before the bounded `respDay` (`lastRespRow`). Dropped the `vitalsDay` term at both sites so the bounded carry wins; a gap past the window now reads `No Data`. Skin-temp needed no change — the Android card already routes through `SkinTempDisplay`. Adds `LastRespRowTest` (byte-twin of the Swift respiratory cases).

## Scope — this is the *display-carry* facet of #1331, not the blank-resp report

#1331 has two distinct causes under one number. This fixes a **stale/mis-formatted value being shown**. It does **not** address @znkandrei's report of respiratory going **blank/ABSENT** on WHOOP 4.0 — that's the RSA gate (#1127) refusing the over-counted R-R (#1008), tracked separately by the #1352 shadow-dedup diagnostic. **Deliberately not auto-closing #1331.**

## Verification

- Android: `compileFullDebugKotlin` clean; `LastRespRowTest` 3/3 green.
- `Tools/i18n_audit.py --ci main` and `Tools/doc_comment_lint.py` both pass.
- Swift app-target (`TodayView.swift`) has no default CI — all referenced symbols (`TemperatureUnit`, `UnitPrefs.temperatureKey`/`resolveTemperature`, `SkinTempDisplay.format`) verified present on main; app-build gate recommended before merge.

Thanks to @DX23876 for the Swift fix and the root-cause write-up.
