### PR TITLE
Mark respiratory rate as an on-device estimate on 5.0/MG

### DIFF
--- a/Strand/Screens/NoopLimitationsView.swift
+++ b/Strand/Screens/NoopLimitationsView.swift
@@ -58,7 +58,11 @@ struct NoopLimitationsView: View {
         LimitRow(feature: "HRV (rMSSD)", spokenFeature: "HRV", whoop4: .full, whoop5: .full),
         LimitRow(feature: "Sleep staging", spokenFeature: "Sleep staging", whoop4: .full, whoop5: .full),
         LimitRow(feature: "Recovery & strain", spokenFeature: "Recovery and strain", whoop4: .full, whoop5: .full),
-        LimitRow(feature: "Respiratory rate", spokenFeature: "Respiratory rate", whoop4: .full, whoop5: .full),
+        // 5.0/MG: `.partial`, not `.full`. The v18 wire carries no respiratory channel at all —
+        // `Whoop5HistoricalTests.testHistoricalV18OpticalFieldsAreNotNamedPhysiologically` pins
+        // `resp_rate_raw` as nil — so the displayed value is always `SleepStager.respRateFromRR`,
+        // an on-device RSA estimate off the R-R stream, which is what `.partial` means.
+        LimitRow(feature: "Respiratory rate", spokenFeature: "Respiratory rate", whoop4: .full, whoop5: .partial),
         LimitRow(feature: "Stress (on-device)", spokenFeature: "Stress", whoop4: .full, whoop5: .full),
         LimitRow(feature: "Workout detection", spokenFeature: "Workout detection", whoop4: .full, whoop5: .full),
         LimitRow(feature: "Skin temperature", spokenFeature: "Skin temperature", whoop4: .partial, whoop5: .full),

--- a/android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt
@@ -47,7 +47,11 @@ private val LIMIT_ROWS: List<LimitRow> = listOf(
     LimitRow("HRV (rMSSD)", LimitState.FULL, LimitState.FULL),
     LimitRow("Sleep staging", LimitState.FULL, LimitState.FULL),
     LimitRow("Recovery & strain", LimitState.FULL, LimitState.FULL),
-    LimitRow("Respiratory rate", LimitState.FULL, LimitState.FULL),
+    // 5.0/MG: PARTIAL, not FULL. The v18 wire carries no respiratory channel at all —
+    // Whoop5HistoricalDecodeTest pins resp_rate_raw as null — so the displayed value is always
+    // SleepStager.respRateFromRR, an on-device RSA estimate off the R-R stream, which is what
+    // PARTIAL means. Twin of the Swift NoopLimitationsView row.
+    LimitRow("Respiratory rate", LimitState.FULL, LimitState.PARTIAL),
     LimitRow("Stress (on-device)", LimitState.FULL, LimitState.FULL),
     LimitRow("Workout detection", LimitState.FULL, LimitState.FULL),
     LimitRow("Skin temperature", LimitState.PARTIAL, LimitState.FULL),


### PR DESCRIPTION
## The problem

`NoopLimitationsView` marks respiratory rate `.full` on both generations:

```swift
LimitRow(feature: "Respiratory rate", spokenFeature: "Respiratory rate", whoop4: .full, whoop5: .full),
```

and the legend defines that state as **"Read live off the strap"**.

On a 5.0/MG nothing is read off the strap. The v18 wire carries no respiratory channel — pinned by
`Whoop5HistoricalTests.testHistoricalV18OpticalFieldsAreNotNamedPhysiologically`, which asserts
`resp_rate_raw` is nil precisely so a future edit cannot quietly wire one in. The value the app shows
is always `SleepStager.respRateFromRR`, documented in its own header as

> An ON-DEVICE ESTIMATE, NOT a cloud/clinical respiration measurement.

which is what the legend's `.partial` state describes: *"On-device estimate, or experimental /
firmware-gated"*.

The app's own device cards already label this "Resp rate\*" = on-device estimate, so the grid was the
single place in the UI claiming otherwise.

## Why it matters beyond wording

The grid is where a user goes to decide whether a missing number is a bug or a limitation. Marked
`.full`, an absent respiratory rate reads as "my strap or the app is broken". Marked `.partial`, it
reads as "this is derived, and it needs a clean enough R-R stream" — which is the truth, and which is
also the difference between a bug report and an informed user. Same reasoning as #548, where the
registry advertising `spo2` on every paired WHOOP made an empty tile look like a fault rather than
import-only design.

## Changes

Swift row and its Kotlin twin (`NoopLimitationsScreen.kt`) together, per the parity contract.

## Open question — the 4.0 column

Left as `.full`, but it may be wrong for the same reason and I do not have a 4.0 to check.
`whoop_protocol.json` describes the v24 layout's respiratory channel as a raw ADC with
*"Raw ADCs (SpO2/temp/resp) are NOT converted client-side; WHOOP computes them in cloud"*, and
`AnalyticsEngine` calls `respRateFromRR` without branching on family — which would make the displayed
4.0 value an RSA estimate too, and `.partial` correct on both columns.

I have not traced whether another path converts the 4.0 raw resp ADC, so I have not touched it. Happy
to fold that into this PR if you confirm which it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
