### PR TITLE
fix(ui): respiratory rate is an on-device estimate on BOTH gens, not read off the strap (supersedes #1365)

### DIFF
--- a/Strand/Screens/NoopLimitationsView.swift
+++ b/Strand/Screens/NoopLimitationsView.swift
@@ -58,7 +58,11 @@ struct NoopLimitationsView: View {
         LimitRow(feature: "HRV (rMSSD)", spokenFeature: "HRV", whoop4: .full, whoop5: .full),
         LimitRow(feature: "Sleep staging", spokenFeature: "Sleep staging", whoop4: .full, whoop5: .full),
         LimitRow(feature: "Recovery & strain", spokenFeature: "Recovery and strain", whoop4: .full, whoop5: .full),
-        LimitRow(feature: "Respiratory rate", spokenFeature: "Respiratory rate", whoop4: .full, whoop5: .full),
+        // 5.0/MG: `.partial`, not `.full`. The v18 wire carries no respiratory channel at all —
+        // `Whoop5HistoricalTests.testHistoricalV18OpticalFieldsAreNotNamedPhysiologically` pins
+        // `resp_rate_raw` as nil — so the displayed value is always `SleepStager.respRateFromRR`,
+        // an on-device RSA estimate off the R-R stream, which is what `.partial` means.
+        LimitRow(feature: "Respiratory rate", spokenFeature: "Respiratory rate", whoop4: .full, whoop5: .partial),
         LimitRow(feature: "Stress (on-device)", spokenFeature: "Stress", whoop4: .full, whoop5: .full),
         LimitRow(feature: "Workout detection", spokenFeature: "Workout detection", whoop4: .full, whoop5: .full),
         LimitRow(feature: "Skin temperature", spokenFeature: "Skin temperature", whoop4: .partial, whoop5: .full),

--- a/Strand/Screens/NoopLimitationsView.swift
+++ b/Strand/Screens/NoopLimitationsView.swift
@@ -58,11 +58,15 @@ struct NoopLimitationsView: View {
         LimitRow(feature: "HRV (rMSSD)", spokenFeature: "HRV", whoop4: .full, whoop5: .full),
         LimitRow(feature: "Sleep staging", spokenFeature: "Sleep staging", whoop4: .full, whoop5: .full),
         LimitRow(feature: "Recovery & strain", spokenFeature: "Recovery and strain", whoop4: .full, whoop5: .full),
-        // 5.0/MG: `.partial`, not `.full`. The v18 wire carries no respiratory channel at all —
-        // `Whoop5HistoricalTests.testHistoricalV18OpticalFieldsAreNotNamedPhysiologically` pins
-        // `resp_rate_raw` as nil — so the displayed value is always `SleepStager.respRateFromRR`,
-        // an on-device RSA estimate off the R-R stream, which is what `.partial` means.
-        LimitRow(feature: "Respiratory rate", spokenFeature: "Respiratory rate", whoop4: .full, whoop5: .partial),
+        // `.partial` on BOTH generations: the displayed respiratory rate is always
+        // `SleepStager.respRateFromRR` — an on-device RSA estimate off the R-R stream, which is what
+        // `.partial` means — computed with NO family branch (`AnalyticsEngine`'s `respRateDaily`). The
+        // 5.0/MG v18 wire carries no respiratory channel at all (`Whoop5HistoricalTests…` pins
+        // `resp_rate_raw` nil); the 4.0 v24 layout DOES carry `resp_rate_raw`, but it is a raw ADC stored
+        // unconverted (schema: "resp rate computed server-side", `HistoricalStreams` keeps it as a raw
+        // `RespSample`) and never becomes the shown value. Neither is "read live off the strap" (`.full`)
+        // — which is also why an over-counted-R-R 4.0 night (#1331) blanks it.
+        LimitRow(feature: "Respiratory rate", spokenFeature: "Respiratory rate", whoop4: .partial, whoop5: .partial),
         LimitRow(feature: "Stress (on-device)", spokenFeature: "Stress", whoop4: .full, whoop5: .full),
         LimitRow(feature: "Workout detection", spokenFeature: "Workout detection", whoop4: .full, whoop5: .full),
         LimitRow(feature: "Skin temperature", spokenFeature: "Skin temperature", whoop4: .partial, whoop5: .full),

--- a/android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt
@@ -47,11 +47,14 @@ private val LIMIT_ROWS: List<LimitRow> = listOf(
     LimitRow("HRV (rMSSD)", LimitState.FULL, LimitState.FULL),
     LimitRow("Sleep staging", LimitState.FULL, LimitState.FULL),
     LimitRow("Recovery & strain", LimitState.FULL, LimitState.FULL),
-    // 5.0/MG: PARTIAL, not FULL. The v18 wire carries no respiratory channel at all —
-    // Whoop5HistoricalDecodeTest pins resp_rate_raw as null — so the displayed value is always
-    // SleepStager.respRateFromRR, an on-device RSA estimate off the R-R stream, which is what
-    // PARTIAL means. Twin of the Swift NoopLimitationsView row.
-    LimitRow("Respiratory rate", LimitState.FULL, LimitState.PARTIAL),
+    // PARTIAL on BOTH generations: the displayed respiratory rate is always SleepStager.respRateFromRR
+    // — an on-device RSA estimate off the R-R stream, which is what PARTIAL means — computed with NO
+    // family branch (AnalyticsEngine respRateDaily). The 5.0/MG v18 wire carries no respiratory channel
+    // (Whoop5HistoricalDecodeTest pins resp_rate_raw null); the 4.0 v24 layout DOES carry resp_rate_raw,
+    // but it is a raw ADC stored unconverted (schema: "resp rate computed server-side") and never shown.
+    // Neither is "read live off the strap" (FULL) — also why an over-counted-R-R 4.0 night (#1331) blanks
+    // it. Twin of the Swift NoopLimitationsView row.
+    LimitRow("Respiratory rate", LimitState.PARTIAL, LimitState.PARTIAL),
     LimitRow("Stress (on-device)", LimitState.FULL, LimitState.FULL),
     LimitRow("Workout detection", LimitState.FULL, LimitState.FULL),
     LimitRow("Skin temperature", LimitState.PARTIAL, LimitState.FULL),

--- a/android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/NoopLimitationsScreen.kt
@@ -47,7 +47,11 @@ private val LIMIT_ROWS: List<LimitRow> = listOf(
     LimitRow("HRV (rMSSD)", LimitState.FULL, LimitState.FULL),
     LimitRow("Sleep staging", LimitState.FULL, LimitState.FULL),
     LimitRow("Recovery & strain", LimitState.FULL, LimitState.FULL),
-    LimitRow("Respiratory rate", LimitState.FULL, LimitState.FULL),
+    // 5.0/MG: PARTIAL, not FULL. The v18 wire carries no respiratory channel at all —
+    // Whoop5HistoricalDecodeTest pins resp_rate_raw as null — so the displayed value is always
+    // SleepStager.respRateFromRR, an on-device RSA estimate off the R-R stream, which is what
+    // PARTIAL means. Twin of the Swift NoopLimitationsView row.
+    LimitRow("Respiratory rate", LimitState.FULL, LimitState.PARTIAL),
     LimitRow("Stress (on-device)", LimitState.FULL, LimitState.FULL),
     LimitRow("Workout detection", LimitState.FULL, LimitState.FULL),
     LimitRow("Skin temperature", LimitState.PARTIAL, LimitState.FULL),


### PR DESCRIPTION
Supersedes #1365 (by @gdorgian, cherry-picked with authorship intact) and completes it across **both** WHOOP generations.

## Why

`NoopLimitationsView` marked "Respiratory rate" `.full` ("read live off the strap") on both 4.0 and 5.0/MG. On **neither** generation is respiratory rate read off the strap — the displayed value is always `SleepStager.respRateFromRR`, an **on-device RSA estimate** off the R-R stream, which is what `.partial` ("on-device estimate, or experimental / firmware-gated") describes.

## The 4.0 column (gdorgian's open question — confirmed)

@gdorgian fixed 5.0/MG and flagged that 4.0 might be wrong for the same reason but couldn't confirm without hardware. Traced it — it is:
- `AnalyticsEngine`'s `respRateDaily` calls `SleepStager.respRateFromRR(...)` with **no family branch** — both generations get the RSA estimate.
- 4.0's v24 layout *does* carry `resp_rate_raw`, but `HistoricalStreams` stores it as a raw `RespSample` and **never converts it** (schema: `"raw; resp rate computed server-side"`).
- **#1331 is the proof**: the shown 4.0 resp is RSA-derived, which is the only reason the #1127 RSA gate blanks it on an over-counted-R-R night. If it were read off a strap channel, #1331 couldn't exist.

So both columns → `.partial`. Same reasoning as #548 (advertising a capability the strap doesn't deliver makes an empty tile read as a fault, not design).

## Changes
Swift row + Kotlin twin, both columns `.partial` (parity contract). No new i18n string — `.partial`'s label already exists.

## Verification
- Android `compileFullDebugKotlin` clean; `i18n_audit --ci` + `doc_comment_lint` pass.
- App-target Swift (`NoopLimitationsView.swift`) validated via the on-demand app-build gate.

Thanks to @gdorgian for the fix and for flagging the 4.0 column.
