### PR TITLE
perf(explore): stop reading sixty histories before drawing one metric

### DIFF
--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -2116,6 +2116,67 @@ final class Repository: ObservableObject {
         }
     }
 
+    /// Which of `catalog`'s metrics hold at least one reading — the question the Explore catalog list asks
+    /// to decide which rows get the faint "no data" dot.
+    ///
+    /// PERF: the list used to answer it by calling `exploreSeries` once PER METRIC and throwing the series
+    /// away, keeping only `isEmpty`. That is ~60 full-history reads, each walking `self.days`, building a
+    /// dictionary and sorting it on the main actor, to produce 60 booleans. This asks the cheap question
+    /// instead: one DISTINCT-key query per source (a handful in total), plus one in-memory pass for the
+    /// daily-column layer.
+    ///
+    /// The source precedence MIRRORS `exploreSeries` / `series` deliberately, or the dots would disagree
+    /// with the screens they point at:
+    /// - the canonical WHOOP source unions the imported AND computed read ids (`exploreSeries` reads both;
+    ///   note `availableKeys` below unions only the imported ones, which is why this does not reuse it);
+    /// - the daily-column fallback applies to the WHOOP source ONLY, exactly as `exploreSeries` gates it;
+    /// - every other source reads its own key set verbatim.
+    ///
+    /// One deliberate difference: `metricKeys` has no day window, while the old probe used
+    /// `exploreSeries`'s ~11-year default. A metric whose only rows predate that window now reads as
+    /// "has data" rather than showing the dot. That can only ever REMOVE a dot, never add a wrong one,
+    /// and "we hold readings for this, just very old ones" is the more truthful answer anyway.
+    ///
+    /// A store that will not open returns every id (i.e. "has data"), matching the old probe's
+    /// failures-default-to-no-dot behaviour: a diagnostic dot on every row would read as data loss.
+    func nonEmptyMetricIDs(_ catalog: [MetricDescriptor]) async -> Set<String> {
+        guard let store = await ensureStore() else { return Set(catalog.map(\.id)) }
+
+        // One DISTINCT-key query per distinct source (the WHOOP one fans out over its read ids).
+        var keysBySource: [String: Set<String>] = [:]
+        for source in Set(catalog.map(\.source)) {
+            var keys = Set<String>()
+            if source == canonicalDeviceId {
+                for id in importedReadIds + computedReadIds {
+                    keys.formUnion((try? await store.metricKeys(deviceId: id)) ?? [])
+                }
+            } else {
+                keys.formUnion((try? await store.metricKeys(deviceId: source)) ?? [])
+            }
+            keysBySource[source] = keys
+        }
+
+        // The merged daily column, which `exploreSeries` layers under the WHOOP series, is handled by the
+        // pure half below: in-memory over the already-published `days`, with `contains` short-circuiting
+        // on the first day that carries the key — nothing like the 60 full merges it replaces.
+        return Self.nonEmptyMetricIDs(catalog, keysBySource: keysBySource, days: days,
+                                      whoopSource: canonicalDeviceId)
+    }
+
+    /// The decision itself, split out from the queries so it is testable with no store and no app: given
+    /// which keys each source holds and the merged daily rows, which catalog ids have data.
+    nonisolated static func nonEmptyMetricIDs(_ catalog: [MetricDescriptor],
+                                              keysBySource: [String: Set<String>],
+                                              days: [DailyMetric],
+                                              whoopSource: String = Repository.whoopSource) -> Set<String> {
+        Set(catalog.lazy.filter { metric in
+            if keysBySource[metric.source]?.contains(metric.key) == true { return true }
+            // The daily-column fallback is WHOOP-only, exactly as `exploreSeries` gates it.
+            guard metric.source == whoopSource else { return false }
+            return days.contains { dailyColumn(key: metric.key, day: $0) != nil }
+        }.map(\.id))
+    }
+
     func availableKeys(source: String) async -> [String] {
         guard let store = await ensureStore() else { return [] }
         // For the canonical WHOOP source, UNION the keys present under the active strap too, so a re-added

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -199728,6 +199728,70 @@
           }
         }
       }
+    },
+    "Scanning the catalog…": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Katalog wird durchsucht …"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scanning the catalog…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analizando el catálogo…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse du catalogue…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scansione del catalogo…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przeszukiwanie katalogu…"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A analisar o catálogo…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сканирование каталога…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在扫描指标目录…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在掃描指標目錄…"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -366,25 +366,24 @@ struct MetricExplorerView: View {
     /// One lightweight pass to learn which metrics have no series, so rows can flag them with the
     /// faint trailing dot. Failures default to "has data" (no dot).
     ///
-    /// Crucially this assigns into `emptyByID` PER METRIC, not in one final batch (#199): the previous
-    /// version ran ~35 sequential `exploreSeries` reads — each hopping back to the @MainActor Repository
-    /// — before publishing a single result, so on iOS the main thread stayed busy and the freshly-pushed
-    /// list painted blank until the whole sweep finished. Publishing each result (with a `Task.yield()`
-    /// between reads so the run loop can lay the rows out) lets the catalog rows render immediately and
-    /// the dots fill in as the probe lands. Rows already render their label/icon/unit without waiting on
-    /// this — the map only ever ADDS a trailing dot.
+    /// #199 originally fixed this by publishing PER METRIC rather than in one final batch, because the
+    /// sweep ran ~60 sequential `exploreSeries` reads — each hopping back to the @MainActor Repository —
+    /// and the freshly-pushed list painted blank until it finished. That made the symptom bearable
+    /// without addressing the cost: the sweep still read sixty full histories, built sixty dictionaries
+    /// and sorted them, only to keep sixty booleans.
+    ///
+    /// `Repository.nonEmptyMetricIDs` asks the cheap question instead — one DISTINCT-key query per
+    /// source plus one in-memory pass — so the whole probe is now a single await. The per-metric
+    /// publishing and the `Task.yield()` are gone with it: there is no longer a long sweep to interleave
+    /// with layout, and one assignment publishes the lot. Rows still render their label / icon / unit
+    /// without waiting on this — the map only ever ADDS a trailing dot.
     private func probeEmptiness(refreshSeq: Int) async {
         guard probedRefreshSeq != refreshSeq || emptyByID.isEmpty else { probing = false; return }
         probedRefreshSeq = refreshSeq
-        emptyByID = [:]
         probing = true
-        for metric in MetricCatalog.all {
-            guard !Task.isCancelled else { return }
-            let s = await repo.exploreSeries(key: metric.key, source: metric.source)
-            guard !Task.isCancelled else { return }
-            emptyByID[metric.id] = s.isEmpty
-            await Task.yield()
-        }
+        let nonEmpty = await repo.nonEmptyMetricIDs(MetricCatalog.all)
+        guard !Task.isCancelled else { return }
+        emptyByID = Dictionary(uniqueKeysWithValues: MetricCatalog.all.map { ($0.id, !nonEmpty.contains($0.id)) })
         probing = false
     }
 }
@@ -508,8 +507,16 @@ struct MetricDetailView: View {
     /// (which rides `series`/`exploreSeries`) is never changed by adding source labels.
     @State private var sourceByDay: [String: String] = [:]
     /// Every OTHER catalog series, loaded once for the correlation scan.
+    ///
+    /// Filled by a SECOND load phase, after the screen is already on screen — see `load()`. Nothing above
+    /// the correlation card reads it, so nothing above the correlation card waits for it.
     @State private var others: [(metric: MetricDescriptor, series: [(day: String, value: Double)])] = []
+    /// True once THIS metric's own series is in — the gate for the whole screen (hero, chart, stats,
+    /// readings). Deliberately not "everything is in": see `load()`.
     @State private var loaded = false
+    /// True once the cross-catalog scan behind the correlation card has finished. Only that one card
+    /// reads it, so it can lag the rest of the screen by a second without anyone noticing.
+    @State private var correlationsLoaded = false
 
     /// Cached correlation scan, keyed by its inputs (selected range + the metric id),
     /// so the full cross-catalog Pearson sweep runs ONLY when those change — not on
@@ -720,7 +727,20 @@ struct MetricDetailView: View {
         .onChangeCompat(of: range) { _ in recomputeCorrelations() }
     }
 
+    /// Two phases, because the screen used to wait for data it does not draw.
+    ///
+    /// PERF: `loaded` gates the ENTIRE screen — hero, chart, stat tiles, readings table — and it used to be
+    /// set only after the cross-catalog scan had read all 59 OTHER metrics in the catalog, one sequential
+    /// `exploreSeries` each. Every one of those walks `repo.days` and sorts on the main actor
+    /// (`Repository` is `@MainActor`), and none of them feeds anything above the correlation card at the
+    /// very bottom. So opening any metric detail paid ~60 full-history reads before drawing its first
+    /// pixel, to satisfy one card most readers never scroll to.
+    ///
+    /// Phase 1 is this metric's own series + provenance — everything the visible screen needs. `loaded`
+    /// flips there. Phase 2 is the catalog scan, awaited afterwards, and only the correlation card waits
+    /// on it. Same reads, same results, same order; only the gate moved.
     private func load() async {
+        // Phase 1 — what the screen actually draws.
         series = await repo.exploreSeries(key: metric.key, source: metric.source)
         // Per-day provenance for the readings table (task #8). resolvedSeries names the source that
         // actually supplied each day (imported strap / on-device / Apple Health / Health Connect); the
@@ -728,17 +748,25 @@ struct MetricDetailView: View {
         let resolution = await repo.resolvedSeries(key: metric.key, source: metric.source)
         sourceByDay = Dictionary(resolution.points.map { ($0.day, $0.source) },
                                  uniquingKeysWith: { first, _ in first })
-        var loadedOthers: [(metric: MetricDescriptor, series: [(day: String, value: Double)])] = []
-        for other in MetricCatalog.all where other.id != metric.id {
-            let s = await repo.exploreSeries(key: other.key, source: other.source)
-            if !s.isEmpty { loadedOthers.append((other, s)) }
-        }
-        others = loadedOthers
-        loaded = true
         // #943 selection seam: a locked default (.month with under a week of history) no longer
         // OVERWRITES @State range - it renders through `coercedSelection` instead (non-destructive,
         // recomputed every body eval), so a shrinking history re-coerces and a growing one un-coerces
         // with no snap-back. See `coercedSelection`.
+        loaded = true
+
+        // Phase 2 — the cross-catalog scan behind the correlation card, now that the screen is up.
+        // `Task.isCancelled` is checked per metric so navigating away mid-scan stops it: the task is
+        // bound to `loadTaskID`, and without the check a quick in-and-out would keep 59 main-actor
+        // merges running for a screen nobody is looking at.
+        var loadedOthers: [(metric: MetricDescriptor, series: [(day: String, value: Double)])] = []
+        for other in MetricCatalog.all where other.id != metric.id {
+            guard !Task.isCancelled else { return }
+            let s = await repo.exploreSeries(key: other.key, source: other.source)
+            if !s.isEmpty { loadedOthers.append((other, s)) }
+        }
+        guard !Task.isCancelled else { return }
+        others = loadedOthers
+        correlationsLoaded = true
         // First correlation build, now that `series`/`others` exist.
         recomputeCorrelations()
     }
@@ -1142,7 +1170,11 @@ struct MetricDetailView: View {
     /// when its key (metric id + selected range) actually changed — so re-evals that
     /// don't alter the inputs (hover / HR ticks) are no-ops.
     private func recomputeCorrelations() {
-        let key = "\(metric.id)|\(range.rawValue)"
+        // `others.count` belongs in the key, not just the metric and range. The catalog scan now lands
+        // AFTER the screen (see `load()`), so a range change during the scan would otherwise compute
+        // against a still-empty `others`, cache that empty result under this key, and then skip the
+        // recompute the scan itself triggers — leaving the card permanently blank.
+        let key = "\(metric.id)|\(range.rawValue)|\(others.count)"
         guard correlationKey != key else { return }
         correlationKey = key
         correlationCache = computeCorrelationRows(windowed: slice(for: effectiveRange))
@@ -1158,7 +1190,13 @@ struct MetricDetailView: View {
                         .font(StrandFont.footnote)
                         .foregroundStyle(StrandPalette.textTertiary)
                 }
-                if rows.isEmpty {
+                if !correlationsLoaded {
+                    // The scan now lands after the rest of the screen, so this card has a real "still
+                    // working" state. Without it the card would assert "nothing correlates" for the
+                    // second or two before the catalog is in — a confident, wrong answer.
+                    StatePill("Scanning the catalog…", tone: .accent, pulsing: true)
+                        .frame(maxWidth: .infinity, minHeight: 56, alignment: .leading)
+                } else if rows.isEmpty {
                     Text("Nothing in the catalog moves clearly with \(metric.title.lowercased()) over this window. Widen the range to surface relationships.")
                         .font(StrandFont.subhead)
                         .foregroundStyle(StrandPalette.textTertiary)

--- a/StrandTests/MetricEmptinessProbeTests.swift
+++ b/StrandTests/MetricEmptinessProbeTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+import WhoopStore
+@testable import Strand
+
+/// `Repository.nonEmptyMetricIDs` answers "which catalog rows get the faint no-data dot" from a handful of
+/// DISTINCT-key queries instead of one full series read per metric. That is only safe while it mirrors
+/// `exploreSeries`' source precedence exactly — the two are separate code paths that must agree, or the
+/// Explore list marks a metric empty and then opens a detail screen full of readings.
+///
+/// These pin the three rules that make them agree.
+final class MetricEmptinessProbeTests: XCTestCase {
+
+    private let whoop = Repository.whoopSource
+
+    private func metric(_ key: String, source: String) -> MetricDescriptor {
+        MetricDescriptor(key: key, title: key, category: "Test", unit: "", source: source,
+                         icon: "circle", decimals: 0, higherIsBetter: nil)
+    }
+
+    /// A day carrying only `avgHrv`, so the daily-column layer has exactly one key to find.
+    private func dayWithHRV(_ dayStr: String, avgHrv: Double?) -> DailyMetric {
+        DailyMetric(day: dayStr, totalSleepMin: nil, efficiency: nil, deepMin: nil, remMin: nil,
+                    lightMin: nil, disturbances: nil, restingHr: nil, avgHrv: avgHrv,
+                    recovery: nil, strain: nil, exerciseCount: nil)
+    }
+
+    // MARK: Stored series
+
+    func testAStoredKeyCountsAsNonEmpty() {
+        let m = metric("steps", source: whoop)
+        let ids = Repository.nonEmptyMetricIDs([m], keysBySource: [whoop: ["steps"]], days: [],
+                                               whoopSource: whoop)
+        XCTAssertEqual(ids, [m.id])
+    }
+
+    func testAKeyNoSourceHoldsIsEmpty() {
+        let m = metric("vo2max", source: whoop)
+        let ids = Repository.nonEmptyMetricIDs([m], keysBySource: [whoop: ["steps"]], days: [],
+                                               whoopSource: whoop)
+        XCTAssertTrue(ids.isEmpty)
+    }
+
+    // MARK: Source isolation
+
+    func testAKeyIsOnlyFoundUnderItsOwnSource() {
+        // The same key under a DIFFERENT source must not satisfy this metric — Explore lists
+        // "Steps · Whoop" and "Steps · Mi Band" as separate rows, and each has its own answer.
+        let mi = metric("steps", source: "xiaomi-band")
+        let ids = Repository.nonEmptyMetricIDs([mi], keysBySource: [whoop: ["steps"]], days: [],
+                                               whoopSource: whoop)
+        XCTAssertTrue(ids.isEmpty)
+    }
+
+    func testEachSourceIsAnsweredFromItsOwnKeySet() {
+        let a = metric("steps", source: whoop)
+        let b = metric("steps", source: "xiaomi-band")
+        let ids = Repository.nonEmptyMetricIDs([a, b],
+                                               keysBySource: [whoop: [], "xiaomi-band": ["steps"]],
+                                               days: [], whoopSource: whoop)
+        XCTAssertEqual(ids, [b.id])
+    }
+
+    // MARK: The daily-column fallback
+
+    func testADailyColumnValueCountsEvenWithNoStoredSeries() {
+        // `exploreSeries` layers the merged daily column under the WHOOP series, so a metric backed ONLY
+        // by that column has data. Missing this was the trap in replacing the old probe: a DISTINCT-key
+        // query alone would have marked HRV empty for every strap-only user.
+        let m = metric("hrv", source: whoop)
+        let ids = Repository.nonEmptyMetricIDs([m], keysBySource: [whoop: []],
+                                               days: [dayWithHRV("2026-08-01", avgHrv: 48)],
+                                               whoopSource: whoop)
+        XCTAssertEqual(ids, [m.id])
+    }
+
+    func testDaysWithOnlyNilsDoNotCount() {
+        let m = metric("hrv", source: whoop)
+        let ids = Repository.nonEmptyMetricIDs([m], keysBySource: [whoop: []],
+                                               days: [dayWithHRV("2026-08-01", avgHrv: nil)],
+                                               whoopSource: whoop)
+        XCTAssertTrue(ids.isEmpty)
+    }
+
+    func testTheDailyColumnFallbackIsWhoopOnly() {
+        // `exploreSeries` gates the daily layer on the WHOOP source; every other source goes through
+        // `series(...)`, which reads that source's rows verbatim. An Apple-Health metric must therefore
+        // NOT inherit data from the merged daily column.
+        let apple = metric("hrv", source: "apple-health")
+        let ids = Repository.nonEmptyMetricIDs([apple], keysBySource: ["apple-health": []],
+                                               days: [dayWithHRV("2026-08-01", avgHrv: 48)],
+                                               whoopSource: whoop)
+        XCTAssertTrue(ids.isEmpty)
+    }
+
+    func testAKeyWithNoDailyColumnFallsBackToNothing() {
+        // `sleep_latency` has no daily column, so days full of other values must not rescue it.
+        let m = metric("sleep_latency", source: whoop)
+        let ids = Repository.nonEmptyMetricIDs([m], keysBySource: [whoop: []],
+                                               days: [dayWithHRV("2026-08-01", avgHrv: 48)],
+                                               whoopSource: whoop)
+        XCTAssertTrue(ids.isEmpty)
+    }
+
+    // MARK: Degenerate input
+
+    func testAnUnknownSourceIsTreatedAsEmptyRatherThanCrashing() {
+        let m = metric("steps", source: "nutrition-csv")
+        let ids = Repository.nonEmptyMetricIDs([m], keysBySource: [:], days: [], whoopSource: whoop)
+        XCTAssertTrue(ids.isEmpty)
+    }
+
+    func testAnEmptyCatalogYieldsAnEmptySet() {
+        XCTAssertTrue(Repository.nonEmptyMetricIDs([], keysBySource: [whoop: ["steps"]], days: [],
+                                                   whoopSource: whoop).isEmpty)
+    }
+}


### PR DESCRIPTION
Cherry-picked from @DX23876's fork (authorship intact). A no-behaviour-change latency win on the Explore screen, in two parts:

## 1. `MetricDetailView` — two-phase load
`loaded` gated the **entire** detail screen (hero, chart, stat tiles, readings table), but was only set after the cross-catalog correlation scan read all 59 **other** metrics — one sequential `exploreSeries` each, every one walking `repo.days` and sorting on the @MainActor. None of them feeds anything above the correlation card at the very bottom. So opening any metric detail paid **~60 full-history reads before its first pixel**, for a card most readers never scroll to.

Now Phase 1 (this metric's own series + provenance) flips `loaded` and the screen renders; Phase 2 (the catalog scan) runs behind it, and only the correlation card waits on it (with a "Scanning the catalog…" pill instead of a false "nothing correlates"). **Same reads, same results, same order — only the gate moved.** Includes a race fix: `recomputeCorrelations`'s cache key now folds in `others.count`, so a range change mid-scan can't cache an empty result and skip the real recompute.

## 2. Catalog "no-data dot" probe — cheap DISTINCT query
`probeEmptiness` ran ~60 `exploreSeries` reads (full history each, building + sorting 60 dictionaries) only to keep 60 booleans. Replaced with `Repository.nonEmptyMetricIDs`: one `metricKeys` DISTINCT-key query per source + one in-memory pass over `days`. Source precedence mirrors `exploreSeries` exactly (WHOOP unions imported+computed ids; daily-column fallback WHOOP-only; other sources verbatim), pinned by `MetricEmptinessProbeTests` against a pure `nonisolated static` overload. One documented, benign behaviour change: a metric whose only rows predate the ~11-year window now reads "has data" rather than showing the dot (can only ever *remove* a dot, never add a wrong one).

## Scope / parity
- **iOS/macOS only** — Android's Explore (`TrendsExploreScreen.kt`) has no cross-catalog correlation sweep, so it never had this slowdown. No twin owed.
- i18n complete (the one new string carries all 8 locales). App-target Swift (`MetricExplorerView`/`Repository`) → validated via the on-demand app-build gate.

Thanks to @DX23876 for the fix.
