### PR TITLE
fix(i18n): catch translations that are still the English source (both platforms)

### DIFF
--- a/Tools/i18n_audit.py
+++ b/Tools/i18n_audit.py
@@ -917,6 +917,113 @@ def extra_locale_allowance() -> dict[str, int]:
     return out
 
 
+ECHO_BASELINE_PATH = ROOT / "Tools/i18n_echo_baseline.txt"
+
+#: Format specifiers stripped before deciding whether a string has translatable words in it. Covers
+#: both the Apple (`%@`, `%lld`) and Android (`%1$s`, `%d`) conversion shapes.
+FORMAT_SPECIFIER_PATTERN = re.compile(r"%(?:\d+\$)?[@#0\-+ ]*[\d.]*(?:ll|l|h)?[@dfsu]|%%")
+
+
+def _has_translatable_words(text: str) -> bool:
+    """Whether a string carries enough real words that an identical translation is suspicious.
+
+    Strips format specifiers first: "%@ · n = %lld" / "%1$s: %2$s" are placeholders and punctuation
+    with nothing to translate, so a locale repeating them verbatim is CORRECT, not a gap. Two words is
+    the floor — one word is very often a term that legitimately travels ("HRV", "Yoga", a brand name).
+    """
+    stripped = FORMAT_SPECIFIER_PATTERN.sub(" ", text)
+    return len(re.findall(r"[^\W\d_]{2,}", stripped, flags=re.UNICODE)) >= 2
+
+
+def _ios_echoed_counts() -> dict[str, int]:
+    """`<catalog> <lang> -> count` of xcstrings localizations marked `translated` whose value IS the
+    English key (in a String Catalog the key is the source string)."""
+    counts: dict[str, int] = {}
+    for _dirs, catalog_path in CATALOGS:
+        if not catalog_path.is_file():
+            continue
+        try:
+            cat = json.loads(catalog_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        rel = str(catalog_path.relative_to(ROOT))
+        for key, entry in (cat.get("strings") or {}).items():
+            if not _has_translatable_words(key):
+                continue
+            for lang, unit in (entry.get("localizations") or {}).items():
+                if lang == "en":
+                    continue
+                su = unit.get("stringUnit") or {}
+                if su.get("state") == "translated" and su.get("value") == key:
+                    counts[f"{rel} {lang}"] = counts.get(f"{rel} {lang}", 0) + 1
+    return counts
+
+
+def _android_echoed_counts() -> dict[str, int]:
+    """Android twin of `_ios_echoed_counts`: `values-<locale>/strings.xml` entries whose value is the
+    base `values/strings.xml` value VERBATIM. Android keys are identifiers, not the source text, so the
+    echo is `locale_value == base_value` (not value == key), and the translatable-words floor is applied
+    to the BASE value (the English copy)."""
+    base_path = ROOT / "android/app/src/main/res/values/strings.xml"
+    if not base_path.is_file():
+        return {}
+    try:
+        base = {n.attrib["name"]: (n.text or "") for n in ET.parse(base_path).getroot().findall("string")}
+    except ET.ParseError:
+        return {}
+    # Only base keys with real words to translate can be a meaningful echo — precompute once.
+    translatable = {k: v for k, v in base.items() if _has_translatable_words(v)}
+    counts: dict[str, int] = {}
+    res = ROOT / "android/app/src/main/res"
+    for locale_dir in shipped_android_locale_dirs():
+        lang = locale_dir[len("values-"):]
+        path = res / locale_dir / "strings.xml"
+        try:
+            loc = {n.attrib["name"]: (n.text or "") for n in ET.parse(path).getroot().findall("string")}
+        except ET.ParseError:
+            continue
+        rel = str(path.relative_to(ROOT))
+        n = sum(1 for k, base_val in translatable.items() if loc.get(k) == base_val)
+        if n:
+            counts[f"{rel} {lang}"] = n
+    return counts
+
+
+def echoed_translation_counts() -> dict[str, int]:
+    """`<catalog-or-strings.xml> <lang> -> count` of localizations that are still the English source, on
+    BOTH platforms.
+
+    The hole this closes: the coverage gate asks whether a key EXISTS in a language, never whether the
+    value differs from the source. A catalog can therefore be 100% "complete" while a German reader sees
+    English sentences — which is exactly what shipped once (a German goal card whose body read "Add a
+    daily action …").
+
+    Counts rather than a key list, for the reason `extra_locale_allowance` gives: a list goes stale on
+    every edit and trains people to regenerate it unread. NOT every hit is a missing translation — a
+    brand ("Apple Health"), a design-system label ("Headline / Semibold 17") or a term of art
+    legitimately reads the same in every language — which is why this RATCHETS against a baseline instead
+    of demanding zero: the gate's job is to stop the number GROWING, and the residue is a work list to
+    draw down by hand. iOS/xcstrings keys are disjoint from Android strings.xml paths, so the two merge
+    without collision.
+    """
+    return {**_ios_echoed_counts(), **_android_echoed_counts()}
+
+
+def echo_allowance() -> dict[str, int]:
+    """`<catalog-or-strings.xml> <lang> -> allowed echo count`, same shape and ratchet as
+    `extra_locale_allowance`."""
+    if not ECHO_BASELINE_PATH.exists():
+        return {}
+    out: dict[str, int] = {}
+    for raw in ECHO_BASELINE_PATH.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        target, _, count = line.rpartition(" ")
+        out[target.strip()] = int(count)
+    return out
+
+
 BASELINE_PATH = ROOT / "Tools/i18n_audit_baseline.json"
 
 
@@ -1035,6 +1142,30 @@ def ci_check(base_ref: str) -> int:
             if format_gaps:
                 failed = True
                 print(f"FAIL {catalog_path.relative_to(ROOT)} {lang}: {len(format_gaps)} format mismatch(es): {format_gaps[:10]}")
+
+    # A key that EXISTS in a language still says nothing about whether it was TRANSLATED. This section is
+    # the difference between "complete" and "translated": it counts localizations whose value is the
+    # English source verbatim, on BOTH platforms. See `echoed_translation_counts`.
+    print("\n--- Translations that are still the English source (ratcheting allowance) ---")
+    echo_failed = False
+    echoes = echoed_translation_counts()
+    echo_allowed = echo_allowance()
+    echo_improved: list[str] = []
+    for target in sorted(set(echoes) | set(echo_allowed)):
+        found = echoes.get(target, 0)
+        allowed = echo_allowed.get(target, 0)
+        if found > allowed:
+            failed = True
+            echo_failed = True
+            print(f"FAIL {target}: {found} untranslated echo(es) exceeds the allowance of {allowed}")
+        elif found < allowed:
+            echo_improved.append(f"{target}: {allowed} -> {found}")
+    for line in echo_improved:
+        print(f"  IMPROVED {line}")
+    if echo_improved:
+        print(f"  Lower these in {ECHO_BASELINE_PATH.relative_to(ROOT)} to lock the gain in.")
+    if not echo_failed and not echo_improved:
+        print(f"  OK no new English-only translations ({sum(echoes.values())} tracked, ratcheting down)")
 
     # #844: every OTHER shipped locale, gated against a ratcheting allowance. LANGS above stays at zero
     # tolerance; these carry real pre-existing debt (StrandDesign ships 14 of 95 Italian), so the gate

--- a/Tools/i18n_echo_baseline.txt
+++ b/Tools/i18n_echo_baseline.txt
@@ -1,0 +1,25 @@
+# Echo baseline: localizations whose value is still the English source verbatim (i18n_audit.py
+# `echoed_translation_counts`). Ratchets DOWN — lower a number as echoes get real translations;
+# a NEW echo that pushes a count above its line fails CI. Format: <catalog-or-strings.xml> <lang> <count>.
+NOOPWatch/Localizable.xcstrings pl 1
+NOOPWatch/Localizable.xcstrings pt-PT 1
+NOOPWatchComplications/Localizable.xcstrings es 1
+Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings de 2
+Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings es 4
+Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings fr 1
+Packages/StrandDesign/Sources/StrandDesign/Resources/Localizable.xcstrings pt-PT 1
+Strand/Resources/Localizable.xcstrings de 16
+Strand/Resources/Localizable.xcstrings es 20
+Strand/Resources/Localizable.xcstrings fr 16
+Strand/Resources/Localizable.xcstrings it 15
+Strand/Resources/Localizable.xcstrings pl 17
+Strand/Resources/Localizable.xcstrings pt-PT 11
+Strand/Resources/Localizable.xcstrings ru 7
+Strand/Resources/Localizable.xcstrings zh-Hans 8
+Strand/Resources/Localizable.xcstrings zh-Hant 7
+android/app/src/main/res/values-de/strings.xml de 16
+android/app/src/main/res/values-es/strings.xml es 42
+android/app/src/main/res/values-fr/strings.xml fr 12
+android/app/src/main/res/values-pl/strings.xml pl 11
+android/app/src/main/res/values-pt-rPT/strings.xml pt-rPT 8
+android/app/src/main/res/values-zh/strings.xml zh 16

--- a/Tools/test_i18n_audit.py
+++ b/Tools/test_i18n_audit.py
@@ -398,5 +398,39 @@ class Baseline(unittest.TestCase):
         self.assertIn((finding[0], finding[2]), baseline["android"])
 
 
+class EchoDetectionWordFilter(unittest.TestCase):
+    """`_has_translatable_words` is the false-positive guard for the echo gate: it decides whether a
+    string identical across languages is a suspicious untranslated ECHO or a legitimately-identical
+    term. It backs both the iOS (key == source) and Android (base value) echo counts."""
+
+    def test_real_phrase_is_translatable(self):
+        self.assertTrue(ia._has_translatable_words("Add a daily action"))
+        self.assertTrue(ia._has_translatable_words("Predictive runtime warning"))
+
+    def test_format_only_string_is_not(self):
+        # Placeholders + punctuation with nothing to translate — a locale repeating them is CORRECT.
+        self.assertFalse(ia._has_translatable_words("%@ · %lld"))
+        self.assertFalse(ia._has_translatable_words("%1$s: %2$s. %3$s"))
+
+    def test_single_word_term_is_not(self):
+        # One word is very often a term of art / brand that legitimately travels.
+        self.assertFalse(ia._has_translatable_words("HRV"))
+        self.assertFalse(ia._has_translatable_words("Yoga"))
+
+    def test_symbols_and_punctuation_are_not(self):
+        self.assertFalse(ia._has_translatable_words("· • —"))
+
+    def test_android_positional_specifiers_are_stripped(self):
+        # "vs prev %1$s" keeps the words "vs"/"prev" — a Spanish copy repeating it verbatim is an echo.
+        self.assertTrue(ia._has_translatable_words("vs prev %1$s"))
+        # "%1$d%%" is pure format + literal percent — nothing to translate.
+        self.assertFalse(ia._has_translatable_words("%1$d%%"))
+
+    def test_two_word_brand_is_flagged(self):
+        # Deliberately True: "Apple Health" IS caught, and the ratchet baseline absorbs it as an allowed
+        # legitimate echo — the gate's job is to block GROWTH, not to pre-judge every identical string.
+        self.assertTrue(ia._has_translatable_words("Apple Health"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## The hole
The i18n audit checks whether a key **exists** in a language, never whether its **value differs from the English source**. So a catalog reads 100% "complete" while a user sees English sentences — as shipped once (a German goal card whose body was still English).

## The fix — an echo gate, both platforms
Counts localizations whose value **is the English source verbatim**, ratcheted against `Tools/i18n_echo_baseline.txt` exactly like the existing extra-locale allowance: it blocks the count **growing**, leaving the pre-existing residue as a hand-drawn-down work list. Wired into `--ci` (a new echo above its baseline fails the gate; a drop prints `IMPROVED`).

- **iOS/xcstrings** (ported from @DX23876's fork): a String Catalog's key *is* the source, so an echo is `value == key`.
- **Android twin** (added here): keys are identifiers, so an echo is `values-<locale>/strings.xml` value == the base `values/strings.xml` value. Reuses the existing `shipped_android_locale_dirs()` enumeration.
- **False-positive guard** (`_has_translatable_words`): strips format specifiers (covers both `%@`/`%lld` and `%1$s`/`%d`) then requires **≥2 real words**, so placeholder-only strings and 1-word terms of art (`HRV`, `Yoga`, brands) don't trip it. Two-word brands (`Apple Health`) *are* caught but absorbed by the baseline — the gate's job is to stop growth, not pre-judge every identical string.

## What it found
Baseline generated from current counts: **233 echoes** (16 iOS locale-lines + 7 Android). Real hits it now guards against going forward include Spanish `explore_vs_prev_window` ("vs prev …") and `…predictive_runtime_warning` ("Predictive runtime warning"); brands/terms are the absorbed residue.

## Verification
- `python3 -m unittest Tools.test_i18n_audit` — 42 tests pass, incl. new `EchoDetectionWordFilter` cases.
- `python3 Tools/i18n_audit.py --ci main` — passes (echo section: "OK … 233 tracked, ratcheting down").
- Pure tooling (`Tools/`), no app code, runs on Linux.

Thanks to @DX23876 for the iOS echo detector.
