### PR TITLE
fix(sleep): stop truncating today's sleep read at 18:00 (both platforms, supersedes #1363)

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -238,6 +238,29 @@ final class IntelligenceEngine: ObservableObject {
     /// separates the causes: `grav=0` = no motion offloaded (the in-bed detector can't gate — the WHOOP
     /// 4.0 sparse-motion path has no HR-only fallback); a large `hr` with a night still empty = coverage
     /// gap or the sleep hours fell outside `window`; `provided=` = a persisted hypnogram was (not) available.
+    /// The END of the window the sleep pipeline reads for the night that finishes on `dayStart`'s day.
+    ///
+    /// A PAST day reads through to the next local midnight: the night may end any time before it — late
+    /// sleepers, weekend lie-ins, shift workers who wake well after noon. A hard `dayStart + 18h` (6 PM)
+    /// bound truncated the read at exactly 18:00 and reported a flat 18:00 wake (#500).
+    ///
+    /// **#500 follow-up — the half that was left broken.** TODAY kept the 18:00 cap, on the reasoning that
+    /// "the store clamps to `now` anyway". That holds only for someone who wakes in the MORNING. A
+    /// day-sleeper — asleep ~12:00, awake ~20:00 — is still inside today when they wake, so the cap cut the
+    /// read three hours short and reported a flat 18:00 wake for the entire evening. At the next local
+    /// midnight the day became PAST, the other branch took over, and the SAME night silently re-scored to
+    /// the real time. That is exactly the reported symptom: *"it shows 18:00 every day no matter what time
+    /// I wake up, then as soon as it hits 00:01 it updates to the actual wake time."* Not offload lag, not
+    /// a stager gate, not clock drift — this bound.
+    ///
+    /// Today is now capped at `now`, which keeps the only property the old bound was there for — never read
+    /// past the present — and is what that original comment already assumed was happening. It stops the
+    /// window from asserting that nobody wakes after 6 PM.
+    nonisolated static func sleepReadWindowEnd(dayStart: Int, nowLocalMidnight: Int, now: Int) -> Int {
+        let nextMidnight = dayStart + 86_400
+        return dayStart < nowLocalMidnight ? nextMidnight : min(nextMidnight, now)
+    }
+
     /// Counts + a window length only — same privacy class as the sibling `sleep day=` line, no PII. Pure so
     /// it's unit-tested directly; byte-identical to the Android `sleepDetectNoNightLogLine`.
     nonisolated static func sleepDetectNoNightLogLine(day: String, hrCount: Int, rrCount: Int,
@@ -633,14 +656,10 @@ final class IntelligenceEngine: ObservableObject {
                 let day = AnalyticsEngine.dayString(dayStart, offsetSec: tzOffset)
                 // Read a generous window around the night that ends on `day`; the stager finds the span.
                 let from = dayStart - 30 * 3_600
-                // Sleep read-window END. For a PAST day the night may end any time before the NEXT local
-                // midnight (late sleepers / weekend lie-ins / shift workers wake well after noon), so a
-                // hard `dayStart + 18h` (6 PM) bound TRUNCATED the read at exactly 18:00 , and a real wake
-                // past it was reported as a flat 18:00 wake (#500). Read a PAST day through to the next
-                // local midnight so the stager sees the whole night; TODAY keeps the 18:00 cap (the store
-                // clamps to `now` anyway, and an in-progress nap shouldn't be read as a finished night).
-                let nextMidnight = dayStart + 86_400
-                let to = (dayStart < nowLocalMidnight) ? nextMidnight : dayStart + 18 * 3_600
+                // Sleep read-window END — see `sleepReadWindowEnd`.
+                let to = Self.sleepReadWindowEnd(dayStart: dayStart,
+                                                 nowLocalMidnight: nowLocalMidnight,
+                                                 now: now)
 
                 // I2: pick the single device that owns this day, and read ITS streams below. With one device
                 // this resolves to `deviceId` (active strap, has data → priority 0), so nothing changes; with

--- a/StrandTests/SleepReadWindowTests.swift
+++ b/StrandTests/SleepReadWindowTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import Strand
+
+/// Pins the sleep READ window's end bound.
+///
+/// This one bound has now produced the same user-visible bug twice. #500 fixed it for PAST days but left
+/// TODAY capped at `dayStart + 18h`, so a day-sleeper (asleep ~12:00, awake ~20:00) — still inside today
+/// when they wake — had every wake reported as a flat **18:00** until local midnight, at which point the
+/// day became past, the other branch took over, and the same night silently re-scored to the real time.
+///
+/// It is invisible in a build and invisible in a strap log: the trace shows a perfectly well-formed sleep
+/// run that simply ends at 18:00:00. It cost three wrong diagnoses (offload lag, the `minSleepMin` gate,
+/// clock drift) before the reproduction — "it fixes itself at 00:01" — identified the branch. Hence tests
+/// on the bound itself rather than on the pipeline around it.
+final class SleepReadWindowTests: XCTestCase {
+
+    /// 2026-08-14 00:00 and 2026-08-15 00:00 in Athens (UTC+3) — the night from the reported capture.
+    private let today = 1_786_690_800          // Fri 14 Aug 00:00 +03
+    private var tomorrow: Int { today + 86_400 }
+
+    // MARK: - Today
+
+    /// The regression. The wearer woke at 20:41; the read must reach it.
+    func testTodayReadsPastSixPMWhenTheWearerIsStillAwakeLater() {
+        let wake = today + 20 * 3_600 + 41 * 60      // 20:41
+        let now = wake + 20 * 60                     // they check the app at 21:01
+        let end = IntelligenceEngine.sleepReadWindowEnd(dayStart: today, nowLocalMidnight: today, now: now)
+        XCTAssertGreaterThanOrEqual(end, wake,
+                                    "read window ends before the wake — it would report a flat 18:00")
+        XCTAssertNotEqual(end, today + 18 * 3_600, "the 18:00 cap is back")
+    }
+
+    /// Today must never read into the future — the only property the old bound actually secured.
+    func testTodayNeverReadsPastNow() {
+        let now = today + 9 * 3_600                  // 09:00
+        let end = IntelligenceEngine.sleepReadWindowEnd(dayStart: today, nowLocalMidnight: today, now: now)
+        XCTAssertEqual(end, now)
+    }
+
+    /// …and never past the day's own end, even if `now` has somehow run on.
+    func testTodayIsStillBoundedByTheNextLocalMidnight() {
+        let now = today + 30 * 3_600                 // absurd, but the bound must hold
+        let end = IntelligenceEngine.sleepReadWindowEnd(dayStart: today, nowLocalMidnight: today, now: now)
+        XCTAssertEqual(end, tomorrow)
+    }
+
+    /// Early in the morning the window is still short — nothing here widens it beyond the present.
+    func testTodayEarlyMorningIsCappedAtNowNotAtSixPM() {
+        let now = today + 2 * 3_600                  // 02:00
+        let end = IntelligenceEngine.sleepReadWindowEnd(dayStart: today, nowLocalMidnight: today, now: now)
+        XCTAssertEqual(end, now)
+        XCTAssertLessThan(end, today + 18 * 3_600)
+    }
+
+    // MARK: - Past days
+
+    /// A past day reads the whole day — this is the half #500 already fixed, pinned so it stays fixed.
+    func testAPastDayReadsThroughToTheNextLocalMidnight() {
+        let yesterday = today - 86_400
+        let now = today + 21 * 3_600
+        let end = IntelligenceEngine.sleepReadWindowEnd(dayStart: yesterday,
+                                                       nowLocalMidnight: today, now: now)
+        XCTAssertEqual(end, today, "a past day must read to its own next midnight")
+    }
+
+    /// A past day's window must NOT be shortened by `now` — that would re-truncate old nights.
+    func testAPastDayIsNotClampedByNow() {
+        let longAgo = today - 10 * 86_400
+        let end = IntelligenceEngine.sleepReadWindowEnd(dayStart: longAgo,
+                                                       nowLocalMidnight: today, now: today + 60)
+        XCTAssertEqual(end, longAgo + 86_400)
+    }
+
+    // MARK: - The rollover itself
+
+    /// The reported symptom, expressed directly: the SAME night must not read differently either side of
+    /// local midnight. Before the fix the 00:01 reading reached 20:41 and the 23:59 one stopped at 18:00.
+    func testTheSameNightReadsTheSameJustBeforeAndJustAfterMidnight() {
+        let wake = today + 20 * 3_600 + 41 * 60
+
+        // 23:59, still "today"
+        let before = IntelligenceEngine.sleepReadWindowEnd(dayStart: today, nowLocalMidnight: today,
+                                                          now: today + 86_340)
+        // 00:01, now a past day
+        let after = IntelligenceEngine.sleepReadWindowEnd(dayStart: today, nowLocalMidnight: tomorrow,
+                                                         now: tomorrow + 60)
+
+        XCTAssertGreaterThanOrEqual(before, wake, "pre-midnight read still truncates the wake")
+        XCTAssertGreaterThanOrEqual(after, wake)
+        XCTAssertEqual(after, tomorrow)
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -485,15 +485,12 @@ object IntelligenceEngine {
             val day = AnalyticsEngine.dayString(dayStart, tzOffsetSeconds)
             // Read a generous window around the night that ends on `day`; the stager finds the span.
             val from = dayStart - 30 * 3_600L
-            // Sleep read-window END. For a PAST day the night may end any time before the NEXT local
-            // midnight (late sleepers / weekend lie-ins / shift workers wake well after noon), so a
-            // hard `dayStart + 18h` (6 PM) bound TRUNCATED the read at exactly 18:00 , and a real wake
-            // past it was reported as a flat 18:00 wake (#500). Read a PAST day through to the next
-            // local midnight so the stager sees the whole night; TODAY keeps the 18:00 cap (the DAO
-            // clamps to now anyway, and an in-progress nap shouldn't be read as a finished night).
-            // Matches the Swift window.
-            val nextMidnight = dayStart + SECONDS_PER_DAY
-            val to = if (dayStart < nowLocalMidnight) nextMidnight else dayStart + 18 * 3_600L
+            // Sleep read-window END — see `sleepReadWindowEnd`. A PAST day reads through to the next
+            // local midnight so the stager sees the whole night; TODAY is capped at `now` (never read
+            // the future), NOT a fixed `dayStart + 18h` — that cap reported a flat 18:00 wake for a
+            // day-sleeper (still inside today when they wake) until local midnight flipped the day to
+            // past and it silently re-scored (#500 follow-up). Byte-twin of the Swift window.
+            val to = sleepReadWindowEnd(dayStart, nowLocalMidnight, nowSeconds)
 
             // I2: pick the single device that OWNS this day, and read ITS streams below. With one device
             // this resolves to [importedDeviceId] (active strap, has data → priority 0), so nothing
@@ -2005,6 +2002,20 @@ object IntelligenceEngine {
      */
     internal fun midnightLocal(ts: Long, offsetSec: Long): Long =
         ts - Math.floorMod(ts + offsetSec, SECONDS_PER_DAY)
+
+    /**
+     * The END of the sleep-read window for the night that finishes on [dayStart]'s day. A PAST day reads
+     * through to the next local midnight (late/shift sleepers wake well after noon); TODAY is capped at
+     * [now] — never read the future — NOT a fixed `dayStart + 18h`, which reported a flat 18:00 wake for a
+     * day-sleeper (asleep ~12:00, awake ~20:00, still inside today) until local midnight flipped the day
+     * to past and it silently re-scored to the real time (#500 follow-up). `minOf(nextMidnight, now)`
+     * keeps the window inside the day AND never past the present. Byte-twin of the Swift
+     * `IntelligenceEngine.sleepReadWindowEnd`.
+     */
+    internal fun sleepReadWindowEnd(dayStart: Long, nowLocalMidnight: Long, now: Long): Long {
+        val nextMidnight = dayStart + SECONDS_PER_DAY
+        return if (dayStart < nowLocalMidnight) nextMidnight else minOf(nextMidnight, now)
+    }
 
     /**
      * The per-day diagnostic source token from the imported day-key sets. A WHOOP export covering [day]

--- a/android/app/src/test/java/com/noop/analytics/SleepReadWindowTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepReadWindowTest.kt
@@ -1,0 +1,98 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Kotlin twin of `SleepReadWindowTests.swift` — the two must agree case for case, since this one bound
+ * decides which sleep sessions "today" reads and the platforms may not disagree about a wake time.
+ *
+ * #500 fixed the sleep-read window for PAST days but left TODAY capped at `dayStart + 18h`, so a
+ * day-sleeper (asleep ~12:00, awake ~20:00) — still inside today when they wake — had every wake
+ * reported as a flat 18:00 until local midnight, at which point the day became past, the other branch
+ * took over, and the same night silently re-scored to the real time.
+ */
+class SleepReadWindowTest {
+
+    // 2026-08-14 00:00 and 2026-08-15 00:00 in Athens (UTC+3) — the night from the reported capture.
+    private val today = 1_786_690_800L          // Fri 14 Aug 00:00 +03
+    private val tomorrow = today + 86_400L
+
+    // ── Today ────────────────────────────────────────────────────────────────
+
+    /** The regression. The wearer woke at 20:41; the read must reach it. */
+    @Test
+    fun todayReadsPastSixPMWhenTheWearerIsStillAwakeLater() {
+        val wake = today + 20 * 3_600L + 41 * 60L      // 20:41
+        val now = wake + 20 * 60L                      // they check the app at 21:01
+        val end = IntelligenceEngine.sleepReadWindowEnd(dayStart = today, nowLocalMidnight = today, now = now)
+        assertTrue("read window ends before the wake — it would report a flat 18:00", end >= wake)
+        assertTrue("the 18:00 cap is back", end != today + 18 * 3_600L)
+    }
+
+    /** Today must never read into the future — the only property the old bound actually secured. */
+    @Test
+    fun todayNeverReadsPastNow() {
+        val now = today + 9 * 3_600L                   // 09:00
+        assertEquals(now, IntelligenceEngine.sleepReadWindowEnd(dayStart = today, nowLocalMidnight = today, now = now))
+    }
+
+    /** …and never past the day's own end, even if `now` has somehow run on. */
+    @Test
+    fun todayIsStillBoundedByTheNextLocalMidnight() {
+        val now = today + 30 * 3_600L                  // absurd, but the bound must hold
+        assertEquals(tomorrow, IntelligenceEngine.sleepReadWindowEnd(dayStart = today, nowLocalMidnight = today, now = now))
+    }
+
+    /** Early in the morning the window is still short — nothing here widens it beyond the present. */
+    @Test
+    fun todayEarlyMorningIsCappedAtNowNotAtSixPM() {
+        val now = today + 2 * 3_600L                   // 02:00
+        val end = IntelligenceEngine.sleepReadWindowEnd(dayStart = today, nowLocalMidnight = today, now = now)
+        assertEquals(now, end)
+        assertTrue(end < today + 18 * 3_600L)
+    }
+
+    // ── Past days ──────────────────────────────────────────────────────────────
+
+    /** A past day reads the whole day — the half #500 already fixed, pinned so it stays fixed. */
+    @Test
+    fun aPastDayReadsThroughToTheNextLocalMidnight() {
+        val yesterday = today - 86_400L
+        val now = today + 21 * 3_600L
+        assertEquals(
+            "a past day must read to its own next midnight",
+            today,
+            IntelligenceEngine.sleepReadWindowEnd(dayStart = yesterday, nowLocalMidnight = today, now = now),
+        )
+    }
+
+    /** A past day's window must NOT be shortened by `now` — that would re-truncate old nights. */
+    @Test
+    fun aPastDayIsNotClampedByNow() {
+        val longAgo = today - 10 * 86_400L
+        assertEquals(
+            longAgo + 86_400L,
+            IntelligenceEngine.sleepReadWindowEnd(dayStart = longAgo, nowLocalMidnight = today, now = today + 60L),
+        )
+    }
+
+    // ── The rollover itself ─────────────────────────────────────────────────────
+
+    /**
+     * The reported symptom, expressed directly: the SAME night must not read differently either side of
+     * local midnight. Before the fix the 00:01 reading reached 20:41 and the 23:59 one stopped at 18:00.
+     */
+    @Test
+    fun theSameNightReadsTheSameJustBeforeAndJustAfterMidnight() {
+        val wake = today + 20 * 3_600L + 41 * 60L
+        // 23:59, still "today"
+        val before = IntelligenceEngine.sleepReadWindowEnd(dayStart = today, nowLocalMidnight = today, now = today + 86_340L)
+        // 00:01, now a past day
+        val after = IntelligenceEngine.sleepReadWindowEnd(dayStart = today, nowLocalMidnight = tomorrow, now = tomorrow + 60L)
+        assertTrue("pre-midnight read still truncates the wake", before >= wake)
+        assertTrue(after >= wake)
+        assertEquals(tomorrow, after)
+    }
+}


### PR DESCRIPTION
Supersedes #1363 (by @gdorgian, cherry-picked with authorship intact) and completes it across **both** platforms.

## The bug
`IntelligenceEngine` ends today's sleep-read window at `dayStart + 18h`, so anyone whose sleep ends after 18:00 local — a night-shift worker or any day-sleeper (asleep ~12:00, awake ~20:00, still inside today when they wake) — has every wake reported as a flat **18:00** until local midnight, when the day flips to "past", the other branch takes over, and the same night silently re-scores to the real time. Reported symptom: *"it shows 18:00 every day no matter what time I wake up, then as soon as it hits 00:01 it updates to the actual wake time."* This is the half of #500 left behind.

## The fix
Extract the bound into a pure `sleepReadWindowEnd(dayStart, nowLocalMidnight, now)` and cap today at `now` rather than a fixed hour:
```
dayStart < nowLocalMidnight ? nextMidnight : min(nextMidnight, now)
```
`now` preserves the only property the old bound secured (never read the future); `nextMidnight` keeps the window inside the day.

## Both platforms — this was a parity bug
`IntelligenceEngine.kt:496` had the **identical** `dayStart + 18 * 3_600L` cap, its comment even reading *"Matches the Swift window"* — so a Swift-only fix would leave every Android day-sleeper stuck at 18:00 **and diverge the scored sleep window between platforms**. So:
- **Swift** (by @gdorgian): the fix + `SleepReadWindowTests` (7 cases, incl. the exact 23:59-vs-00:01 symptom).
- **Android twin** (this PR): the same pure `sleepReadWindowEnd` (byte-twin), the call site swapped to it, and `SleepReadWindowTest` — the byte-twin 7 cases. Both call sites pass the current unix-seconds `now`.

## Verification
- Android: `compileFullDebugKotlin` clean; `SleepReadWindowTest` 7/7 green; doc-lint + i18n pass.
- Swift is app-target (`IntelligenceEngine.swift`) — no default CI, validated via the on-demand app-build gate (`SleepReadWindowTests` runs in the "Test Strand" step).

Thanks to @gdorgian for the fix and the reproduction.
