### PR TITLE
fix(health): guard the HealthKit share set against read-only types (a launch-crash footgun)

### DIFF
--- a/StrandiOS/Health/HealthKitBridge.swift
+++ b/StrandiOS/Health/HealthKitBridge.swift
@@ -72,7 +72,8 @@ final class HealthKitBridge: ObservableObject {
 
     private var writeTypes: Set<HKSampleType> {
         var s = Set<HKSampleType>()
-        for id in HealthKitBridge.quantityWriteIds + HealthKitBridge.highResQuantityWriteIds {
+        for id in HealthKitBridge.quantityWriteIds + HealthKitBridge.highResQuantityWriteIds
+            where !HealthKitBridge.writeDenied.contains(id) {
             if let t = HKObjectType.quantityType(forIdentifier: id) { s.insert(t) }
         }
         if let sleep = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) { s.insert(sleep) }
@@ -86,7 +87,9 @@ final class HealthKitBridge: ObservableObject {
     /// because the new types are still `.notDetermined`.
     private var legacyCoreWriteTypes: Set<HKSampleType> {
         var s = Set<HKSampleType>()
-        for id in HealthKitBridge.quantityWriteIds { if let t = HKObjectType.quantityType(forIdentifier: id) { s.insert(t) } }
+        for id in HealthKitBridge.quantityWriteIds where !HealthKitBridge.writeDenied.contains(id) {
+            if let t = HKObjectType.quantityType(forIdentifier: id) { s.insert(t) }
+        }
         if let sleep = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) { s.insert(sleep) }
         return s
     }
@@ -115,6 +118,16 @@ final class HealthKitBridge: ObservableObject {
     private static let quantityWriteIds: [HKQuantityTypeIdentifier] = [
         .restingHeartRate, .heartRateVariabilitySDNN, .oxygenSaturation, .respiratoryRate
     ]
+    /// Identifiers that must NEVER enter a `requestAuthorization(toShare:)` set, filtered out of every
+    /// write set below (#1366). HealthKit reserves some quantity types to Apple Watch —
+    /// `.appleSleepingWristTemperature`, the only type that fits a worn wrist skin temperature, is one —
+    /// and asking to SHARE such a type does not fail softly: it raises an uncatchable ObjC
+    /// `NSInvalidArgumentException` ("Authorization to share the following types is disallowed") that
+    /// terminates the app on launch (verified on device, iOS 27). Swift `try/catch` cannot intercept an
+    /// `NSException`, so the ONLY defense is to keep read-only ids out of the share set. Filtering here
+    /// makes that structural: a read-only id added to a write list by mistake is dropped from the ask
+    /// instead of bricking launch, turning a ship-and-crash into a no-op.
+    private static let writeDenied: Set<HKQuantityTypeIdentifier> = [.appleSleepingWristTemperature]
     // High-res write-back shares: the continuous 1-minute HR stream, and the energy/distance samples
     // attached to written workouts. Kept out of `quantityWriteIds` so `legacyCoreWriteTypes` (the
     // auth-resume set) stays exactly what pre-update users granted.


### PR DESCRIPTION
Fixes the launch-crash footgun @gdorgian found while researching #1366.

## The footgun
`HealthKitBridge` builds its write set from `quantityWriteIds` and hands it to `requestAuthorization(toShare:)`. HealthKit reserves some quantity types to Apple Watch — including `.appleSleepingWristTemperature`, the only type that fits a worn wrist skin temperature — and asking to **share** such a type does **not** fail softly. It raises an uncatchable ObjC `NSInvalidArgumentException` ("Authorization to share the following types is disallowed") that **terminates the app on launch** (signal 6; @gdorgian verified on device, iOS 27). Swift `try/catch` cannot intercept an `NSException`, so there is no in-place recovery.

The practical risk: a well-meaning "let me just write skin temp to Health" change (the natural next step from #1366) that adds a read-only type to a write list would **ship a launch crash** for everyone.

## The guard
Adds a `writeDenied` denylist (`[.appleSleepingWristTemperature]`), filtered out of **every** write set (`writeTypes`, `legacyCoreWriteTypes`). A read-only id that lands in a write list by mistake is now dropped from the ask — a structural no-op — instead of bricking launch. Extend the denylist if another Watch-only write type ever gets referenced.

## Scope / notes
- Pure defensive change; does **not** add or remove any real write type (still RHR / SDNN / SpO₂ / respiratory + high-res + sleep + workouts). No behavior change for existing users.
- Does **not** attempt to write skin temp — per the #1366 discussion there's no honest writable HealthKit type (`.appleSleepingWristTemperature` is read-only; `.bodyTemperature` would mislabel ~31 °C wrist as core-body hypothermia). This PR only stops the crash the attempt would cause.
- App-target Swift (`StrandiOS/Health/HealthKitBridge.swift`, iOS-only) — no default CI, validated via the app-build gate. A unit test isn't practical (iOS-only HealthKit, no iOS test bundle in default CI); the filter is unconditional so it holds structurally.

Thanks to @gdorgian for the report and the on-device repro.
