### PR TITLE
feat(backup): save custom journal behaviours to the .noopbak (#1361)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/BackupSettings.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/BackupSettings.swift
@@ -59,6 +59,13 @@ public enum BackupSettings {
         "units.temperature": .string,
         "effort.scale": .string,
         "today.hostedCards": .string,
+        // #1361: the user's own custom journal BEHAVIOURS (newline-joined names). Deliberately NOT in
+        // `appleDefaultsKey` below — it isn't a flat UserDefaults key (customs are derived from the
+        // catalog items blob), so the app layer (`DataBackup`) bridges this one on export and restore.
+        // Byte-identical newline value to the Android bridge.
+        // SCOPE: NAMES only — the wire carries no kind/group, so a numeric custom behaviour restores as a
+        // plain .bool toggle (identical on both platforms; historical entries keep their DB numericValue).
+        "journal.customBehaviors": .string,
     ]
 
     /// Canonical JSON key → this platform's UserDefaults key. Identity everywhere except

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/BackupSettingsTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/BackupSettingsTests.swift
@@ -23,6 +23,9 @@ final class BackupSettingsTests: XCTestCase {
             "effort.scale": "whoop",
             // #today-hosted-cards: the one layout pref carried, a JSON [String] stored under the String kind.
             "today.hostedCards": "[\"sleep.sleepMarks\"]",
+            // #1361: custom journal behaviours, a newline-joined name list — the embedded newline must
+            // survive the JSON round-trip (and stay byte-identical to Android's pref value).
+            "journal.customBehaviors": "Cold plunge\nMagnesium",
         ]
         let data = try XCTUnwrap(BackupSettings.encode(values))
         let back = BackupSettings.decode(data)
@@ -38,6 +41,7 @@ final class BackupSettingsTests: XCTestCase {
         XCTAssertEqual(back["units.temperature"] as? String, "celsius")
         XCTAssertEqual(back["effort.scale"] as? String, "whoop")
         XCTAssertEqual(back["today.hostedCards"] as? String, "[\"sleep.sleepMarks\"]")
+        XCTAssertEqual(back["journal.customBehaviors"] as? String, "Cold plunge\nMagnesium")
         XCTAssertEqual(back.count, values.count, "Nothing extra should appear")
     }
 

--- a/Strand/Data/DataBackup.swift
+++ b/Strand/Data/DataBackup.swift
@@ -190,7 +190,18 @@ enum DataBackup {
     /// exports a legacy DB-only ZIP, which is the right degrade). UserDefaults is thread-safe, so
     /// the detached export tasks may call this off the main actor.
     private static func currentSettingsJSON() -> Data? {
-        BackupSettings.encode(BackupSettings.snapshot(from: .standard))
+        var values = BackupSettings.snapshot(from: .standard)
+        // #1361: bridge the user's custom journal BEHAVIOURS into the whitelisted `journal.customBehaviors`
+        // as a newline-joined name list (byte-identical to Android's `noop.journalCustomQuestions`). The
+        // journal EFFECTS ride the DB backup, but the DEFINITIONS live only here. `JournalCatalogStore`
+        // is @MainActor and this may run off it, so decode the items blob directly and take the custom
+        // canonicals. Skipped when there are none.
+        if let blob = UserDefaults.standard.data(forKey: JournalCatalogBackupKeys.items),
+           let items = try? JSONDecoder().decode([JournalCatalogItem].self, from: blob) {
+            let customs = items.filter(\.custom).map(\.canonical)
+            if !customs.isEmpty { values["journal.customBehaviors"] = customs.joined(separator: "\n") }
+        }
+        return BackupSettings.encode(values)
     }
 
     /// (Backup & Sync) Write a `.noopbak` to a SPECIFIC `dest` URL with NO save panel: the folder /
@@ -438,7 +449,19 @@ enum DataBackup {
             if let extractedDir {
                 let settingsURL = extractedDir.appendingPathComponent(BackupSettings.entryName)
                 if let data = try? Data(contentsOf: settingsURL) {
-                    BackupSettings.apply(BackupSettings.decode(data), to: settingsDefaults)
+                    let decoded = BackupSettings.decode(data)
+                    BackupSettings.apply(decoded, to: settingsDefaults)
+                    // #1361: restore custom journal behaviours. `JournalCatalogStore` is @MainActor and
+                    // this runs off it, so write the restored names to the legacy `journal.customQuestions`
+                    // array, clear any stale hidden list, and drop the v2 items blob — on the relaunch a
+                    // restore forces, the store's init migrates those names into fresh v2 items (the same
+                    // path a pre-v2 install takes). Only when the backup carried them.
+                    if let joined = decoded["journal.customBehaviors"] as? String {
+                        let names = joined.split(separator: "\n").map(String.init).filter { !$0.isEmpty }
+                        settingsDefaults.set(names, forKey: JournalCatalogBackupKeys.legacyCustom)
+                        settingsDefaults.set([String](), forKey: JournalCatalogBackupKeys.legacyHidden)
+                        settingsDefaults.removeObject(forKey: JournalCatalogBackupKeys.items)
+                    }
                 }
             }
             // #57 debug: record when a restore swapped the DB, so the export can correlate a restore with a

--- a/Strand/Data/JournalCatalog.swift
+++ b/Strand/Data/JournalCatalog.swift
@@ -11,6 +11,17 @@ import Foundation
 /// `canonical` string is the verbatim DB/engine key and is NEVER localised or rewritten; only
 /// `displayName` changes on a rename. The legacy custom/hidden UserDefaults arrays are folded into
 /// the v2 items once, then read-only.
+/// The UserDefaults keys `JournalCatalogStore` persists under, exposed so the backup bridge
+/// (`DataBackup`, which runs OFF the main actor) can read/write them directly without driving the
+/// `@MainActor` store. Kept beside the store so the key strings can never drift (#1361). A restore
+/// writes the restored custom names to `legacyCustom` and clears `items`; the store's init then
+/// re-migrates them into v2 on the relaunch a restore forces.
+enum JournalCatalogBackupKeys {
+    static let items = "journal.catalog.v2"
+    static let legacyCustom = "journal.customQuestions"
+    static let legacyHidden = "journal.hiddenQuestions"
+}
+
 @MainActor
 final class JournalCatalogStore: ObservableObject {
 
@@ -53,10 +64,10 @@ final class JournalCatalogStore: ObservableObject {
 
     private let d = UserDefaults.standard
     private enum K {
-        static let items = "journal.catalog.v2"
+        static let items = JournalCatalogBackupKeys.items
         // Legacy (v1) keys, read once for the one-time migration, never written again.
-        static let custom = "journal.customQuestions"
-        static let hidden = "journal.hiddenQuestions"
+        static let custom = JournalCatalogBackupKeys.legacyCustom
+        static let hidden = JournalCatalogBackupKeys.legacyHidden
     }
 
     init() {

--- a/android/app/src/main/java/com/noop/data/BackupSettings.kt
+++ b/android/app/src/main/java/com/noop/data/BackupSettings.kt
@@ -61,6 +61,13 @@ object BackupSettingsCodec {
         // built and expects across a restore. Its POSITION (the addedCards slot in today.sectionOrder) is
         // not carried, so on restore the set + internal order return but the section sits at its default.
         HostedCardPrefs.KEY_SELECTION to Kind.STRING,
+        // #1361: the user's own custom journal BEHAVIOURS (a newline-joined list of names). The journal
+        // EFFECTS ride the DB backup, but the behaviour DEFINITIONS live only in prefs, so a restore left
+        // the entries referencing behaviours the logging catalog no longer offered. Platform-neutral key;
+        // the same newline value is bridged out of the catalog on both platforms.
+        // SCOPE: NAMES only — the wire carries no kind/group, so a numeric custom behaviour restores as a
+        // plain .bool toggle (identical on both platforms; historical entries keep their DB numericValue).
+        "journal.customBehaviors" to Kind.STRING,
     )
 
     /**
@@ -117,6 +124,16 @@ object BackupSettingsCodec {
  */
 object BackupSettingsBridge {
 
+    /** Journal-catalog storage keys in `noop_prefs` (#1361). The v2 items blob is the LIVE store; the
+     *  legacy custom/hidden keys are read ONCE by `JournalCatalog.loadJournalCatalogItems` to migrate into
+     *  v2, then never again. So export pulls custom names out of the v2 blob (parsed raw here to avoid a
+     *  data→ui dependency — the JSON shape mirrors `JournalCatalog.encodeJournalCatalog`), and restore
+     *  writes the names to the legacy custom key and CLEARS the v2 blob so the next load re-migrates them
+     *  (a restore requires an app restart, #57). Must match `JournalCatalog`. Mirrors the iOS bridge. */
+    private const val JOURNAL_CATALOG_V2_PREF = "noop.journalCatalogV2"
+    private const val JOURNAL_LEGACY_CUSTOM_PREF = "noop.journalCustomQuestions"
+    private const val JOURNAL_LEGACY_HIDDEN_PREF = "noop.journalHiddenQuestions"
+
     /** The whitelisted, user-SET settings of this device as the `settings.json` string, or null. */
     fun snapshotJson(context: Context): String? {
         val values = LinkedHashMap<String, Any>()
@@ -133,6 +150,18 @@ object BackupSettingsBridge {
         }
         if (noop.contains(HostedCardPrefs.KEY_SELECTION)) {
             noop.getString(HostedCardPrefs.KEY_SELECTION, null)?.let { values[HostedCardPrefs.KEY_SELECTION] = it }
+        }
+        // #1361: custom journal behaviours from the LIVE v2 catalog blob (the legacy key is read-once-
+        // then-stale). Parse raw to avoid a data→ui dependency; shape mirrors JournalCatalog.
+        noop.getString(JOURNAL_CATALOG_V2_PREF, null)?.let { blob ->
+            val names = runCatching {
+                val arr = org.json.JSONArray(blob)
+                (0 until arr.length()).mapNotNull { i ->
+                    arr.optJSONObject(i)?.takeIf { it.optBoolean("custom", false) }
+                        ?.optString("canonical", "")?.takeIf { it.isNotEmpty() }
+                }
+            }.getOrDefault(emptyList())
+            if (names.isNotEmpty()) values["journal.customBehaviors"] = names.joinToString("\n")
         }
         return BackupSettingsCodec.encode(values)
     }
@@ -158,6 +187,13 @@ object BackupSettingsBridge {
         }
         (values["effort.scale"] as? String)?.let { editor.putString(UnitPrefs.KEY_EFFORT_SCALE, it) }
         (values[HostedCardPrefs.KEY_SELECTION] as? String)?.let { editor.putString(HostedCardPrefs.KEY_SELECTION, it) }
+        // #1361: restore custom behaviours — write the names to the legacy custom key, clear stale hidden,
+        // and drop the v2 blob so the next catalog load re-migrates them (restart-gated, #57). Mirrors iOS.
+        (values["journal.customBehaviors"] as? String)?.let { joined ->
+            editor.putString(JOURNAL_LEGACY_CUSTOM_PREF, joined)
+            editor.remove(JOURNAL_LEGACY_HIDDEN_PREF)
+            editor.remove(JOURNAL_CATALOG_V2_PREF)
+        }
         editor.apply()
     }
 }

--- a/android/app/src/test/java/com/noop/data/BackupSettingsCodecTest.kt
+++ b/android/app/src/test/java/com/noop/data/BackupSettingsCodecTest.kt
@@ -41,6 +41,9 @@ class BackupSettingsCodecTest {
             "effort.scale" to "whoop",
             // #today-hosted-cards: the one layout pref carried, a JSON [String] stored under the String kind.
             "today.hostedCards" to "[\"sleep.sleepMarks\"]",
+            // #1361: custom journal behaviours, a newline-joined name list — the embedded newline must
+            // survive the JSON round-trip (and stay byte-identical to the Apple value).
+            "journal.customBehaviors" to "Cold plunge\nMagnesium",
         )
         val json = requireNotNull(BackupSettingsCodec.encode(values))
         val back = BackupSettingsCodec.decode(json)
@@ -56,6 +59,7 @@ class BackupSettingsCodecTest {
         assertEquals("celsius", back["units.temperature"])
         assertEquals("whoop", back["effort.scale"])
         assertEquals("[\"sleep.sleepMarks\"]", back["today.hostedCards"])
+        assertEquals("Cold plunge\nMagnesium", back["journal.customBehaviors"])
         assertEquals(values.size, back.size)
     }
 


### PR DESCRIPTION
Closes #1361.

## The gap
Exports carried behaviour **effects** (journal entries — in the `journal` DB table, backed up with the DB) but not the behaviour **definitions** (your custom questions), which live only in prefs (`noop.journalCustomQuestions` on Android; the `JournalCatalogStore` items blob on iOS). Neither was in the `.noopbak` settings whitelist, so a restore left entries referencing behaviours the logging catalog no longer offered — you had to recreate each by hand.

## The fix (Option A — canonical whitelisted key)
Adds a platform-neutral **`journal.customBehaviors`** key to the byte-identical settings.json whitelist: a **newline-joined list of behaviour names**, identical across platforms. Because the `WhoopStore` `BackupSettings` package can't see the app's catalog types, the bridging lives in the **app layer** on both sides:
- **Android** — `BackupSettingsBridge` reads/writes the `noop.journalCustomQuestions` pref (same `noop_prefs` file it already touches).
- **iOS** — `DataBackup` (runs off the main actor; `JournalCatalogStore` is `@MainActor`) decodes the items blob for the custom canonicals on export; on restore it writes the names to the legacy custom-questions key and clears the v2 blob, so the relaunch a restore forces re-migrates them into fresh items (the same path a pre-v2 install takes). Storage keys centralised in `JournalCatalogBackupKeys` so they can't drift.

## Scope / parity
- Behaviour **names** round-trip cross-platform (Android↔iOS) — that's what the journal entries key on. iOS renames and hidden-starter state are same-platform niceties, out of scope (a restore is a full replace, and the whitelist is scalar String only).
- Order can differ (Android insertion vs iOS `sortIndex`), but the *set* is preserved.

## Verification
- Android `compileFullDebugKotlin` clean; `BackupSettingsCodecTest` 9/9 (round-trip now asserts the embedded newline survives the JSON).
- Swift `BackupSettingsTests` round-trip updated the same way — runs in swift-packages CI (`WhoopStore`, macOS).
- `DataBackup.swift`/`JournalCatalog.swift` are app-target Swift → validated via the app-build gate. doc-lint + i18n pass.

Requested by @riebschlaegerstar-sys.
