### PR TITLE
feat(rhythm): a truthful empty state when a device can't support the reading (#1360)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RhythmScreener.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RhythmScreener.swift
@@ -321,6 +321,54 @@ public enum RhythmScreener {
                                   overall: overall)
     }
 
+    // MARK: - Empty-state diagnosis (#1360 — a TRUTHFUL empty state)
+    //
+    // When a night produces nothing to plot, the screen must say WHY honestly. A device that can NEVER
+    // satisfy the read (a structural capture limit) is not the same as a night that merely lacked a
+    // calm, still window — and telling a ring owner "try again tomorrow" every night, when tomorrow is
+    // identical, is the misleading empty state #1360 fixes. These helpers turn the raw night into that
+    // distinction WITHOUT relaxing any gate: the gates stay exactly as strict; we only name the refusal.
+
+    /// Measured over the whole night: are the stored beats BANKED onto record timestamps, so the exact
+    /// per-beat spacing isn't recoverable? Reuses `HRVAnalyzer.beatAccurateFraction` — the fill ratio
+    /// comes from the RECORD TIMESTAMPS, never from the interval values being judged, so it can't be
+    /// gamed by laying beats out cumulatively (the #194 trap the gate exists to avoid). Returns false
+    /// when timestamps are absent or length-mismatched: a live spot capture carries none and is
+    /// perfectly time-accurate, not "banked". This is the device-class (#1108) signal, and it is
+    /// independent of the motion gate — so it is still measurable on a night the motion gate refused.
+    public static func nightBeatsAreBanked(rrMs: [Double], tsSec: [Int]) -> Bool {
+        guard tsSec.count == rrMs.count, !tsSec.isEmpty else { return false }
+        let accurate = HRVAnalyzer.beatAccurateFraction(tsSec: tsSec, rrMs: rrMs)
+        return !HRVAnalyzer.beatValuesAreTrustworthy(beatAccurateFraction: accurate)
+    }
+
+    /// Diagnose WHY a night has nothing to show, so the empty state reads truthfully (#1360). It names
+    /// the refusal the gates already made — it consults no gate and relaxes none:
+    ///   • `.none`             — at least one window was readable (the caller shows the plot, not an empty state).
+    ///   • `.gatheringData`    — the honest default: a device that DOES record a stillness signal (so it can read
+    ///                            in principle), a no-data night, or a genuine restless one. The ONLY state that
+    ///                            means "try again after a settled night".
+    ///   • `.deviceBanksBeats` / `.deviceNoMotion` — a STRUCTURAL limit, reached ONLY when the device recorded
+    ///                            dense R-R yet NO stillness signal at ALL (`gravitySample` empty for the whole
+    ///                            DB, #804 — the ring signature). Gating both verdicts on `!hadMotionSignal` is
+    ///                            deliberate: a WHOOP always writes an accelerometer track, so a WHOOP night
+    ///                            whose banked R-R happens to measure over-counted (#1118) is NEVER mislabelled
+    ///                            "this device can't support it" — it stays on the honest "try again". When the
+    ///                            device is structurally incapable, `beatsAreBanked` picks the more informative
+    ///                            copy (its beats arrive batched) over the plain no-stillness one.
+    /// `hadMotionSignal` = any stillness/gravity sample existed for the night; `beatsAreBanked` = the result
+    /// of `nightBeatsAreBanked` over the night's stored R-R.
+    public static func classifyEmptyState(windows: [WindowResult],
+                                          hadMotionSignal: Bool,
+                                          beatsAreBanked: Bool) -> RhythmEmptyState {
+        if windows.contains(where: { $0.label != .unreadable }) { return .none }
+        // A device WITH a motion signal (WHOOP), or a night with no dense window yet, gets the honest
+        // "try again" — never a permanent "can't support" verdict. Only the ring signature (dense R-R, zero
+        // stillness signal) is structural.
+        guard !hadMotionSignal, !windows.isEmpty else { return .gatheringData }
+        return beatsAreBanked ? .deviceBanksBeats : .deviceNoMotion
+    }
+
     // MARK: - Statistics
 
     /// Bundle of the descriptive statistics over a clean window.
@@ -461,4 +509,19 @@ public enum RhythmConfidence: String, Codable, Sendable, Equatable {
     case calibrating
     case building
     case solid
+}
+
+/// Why the Rhythm screen has nothing to plot, so its empty state can be TRUTHFUL instead of always
+/// reading "try again tomorrow" (#1360). A structural capture limit (`.deviceBanksBeats` /
+/// `.deviceNoMotion`) is PERMANENT for that device and must not be phrased as a one-off bad night;
+/// `.gatheringData` is the only state that means "try again". Produced by `RhythmScreener.classifyEmptyState`.
+public enum RhythmEmptyState: String, Codable, Sendable, Equatable {
+    /// At least one window was readable — the caller shows the plot, not an empty state.
+    case none
+    /// Not enough evidence yet, or a genuine restless night. The only "try again" state.
+    case gatheringData
+    /// The device records no stillness signal at all, so the motion gate can never pass (#804).
+    case deviceNoMotion
+    /// The device banks its beats onto record timestamps, so per-beat spacing is unrecoverable (#1108).
+    case deviceBanksBeats
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RhythmScreenerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RhythmScreenerTests.swift
@@ -303,4 +303,82 @@ final class RhythmScreenerTests: XCTestCase {
         XCTAssertEqual(withoutTs.label, withTs.label)
         XCTAssertEqual(withoutTs.sd2, withTs.sd2)
     }
+
+    // MARK: - Empty-state diagnosis (#1360)
+
+    /// A readable window read via the real screener (steady sinus, still) — for building the mix.
+    private func readableWindow() -> RhythmScreener.WindowResult {
+        RhythmScreener.screenWindow(
+            RhythmScreener.WindowInput(rrMs: Self.regularSinus(), motionStill: true, meanHR: 60))
+    }
+
+    /// An unreadable window (motion gate refused) — the shape every empty night is made of.
+    private func unreadableWindow() -> RhythmScreener.WindowResult {
+        RhythmScreener.screenWindow(
+            RhythmScreener.WindowInput(rrMs: Self.regularSinus(), motionStill: false, meanHR: 60))
+    }
+
+    func testNightBeatsAreBankedDetectsBankedButNotHonestOrAbsentTimestamps() {
+        let rr = Self.regularSinus()
+        // Banked: 6 beats per record, records 5 s apart (mirrors the gate-4 banked fixture).
+        let bankedTs = (0..<rr.count).map { ($0 / 6) * 5 }
+        XCTAssertTrue(RhythmScreener.nightBeatsAreBanked(rrMs: rr, tsSec: bankedTs),
+                      "beats stamped in record batches are banked")
+        // Honestly stamped ~1 s apart (mean ~1000 ms) — a real per-beat train.
+        let honestTs = (0..<rr.count).map { $0 }
+        XCTAssertFalse(RhythmScreener.nightBeatsAreBanked(rrMs: rr, tsSec: honestTs),
+                       "an honestly-stamped train is not banked")
+        // No timestamps / a length mismatch → unmeasurable, which is NOT 'banked'.
+        XCTAssertFalse(RhythmScreener.nightBeatsAreBanked(rrMs: rr, tsSec: []))
+        XCTAssertFalse(RhythmScreener.nightBeatsAreBanked(rrMs: rr, tsSec: [0, 1, 2]))
+    }
+
+    func testClassifyEmptyStateNoneWhenAnyWindowReadable() {
+        let windows = [unreadableWindow(), readableWindow()]
+        // Even with structural flags set, a readable window means the caller shows the plot, not empty copy.
+        XCTAssertEqual(
+            RhythmScreener.classifyEmptyState(windows: windows, hadMotionSignal: false, beatsAreBanked: true),
+            .none)
+    }
+
+    func testClassifyEmptyStateBankedBeatsWhenStructurallyIncapable() {
+        let windows = [unreadableWindow(), unreadableWindow()]
+        // No stillness signal at all (the ring) AND banked beats → the more informative structural copy.
+        XCTAssertEqual(
+            RhythmScreener.classifyEmptyState(windows: windows, hadMotionSignal: false, beatsAreBanked: true),
+            .deviceBanksBeats, "banked capture is the most informative structural answer")
+    }
+
+    /// Regression guard (#1118 × #1360): a WHOOP night reads BANKED R-R too, so `beatsAreBanked` can be
+    /// true — but WHOOP always writes an accelerometer track, so its motion signal is present and it must
+    /// keep the honest "try again", NEVER "this device can't support it".
+    func testClassifyEmptyStateWhoopBankedNightStaysGathering() {
+        let windows = [unreadableWindow(), unreadableWindow()]
+        XCTAssertEqual(
+            RhythmScreener.classifyEmptyState(windows: windows, hadMotionSignal: true, beatsAreBanked: true),
+            .gatheringData, "a device with a motion signal is never declared structurally incapable")
+    }
+
+    func testClassifyEmptyStateNoMotionWhenDenseWindowsButNoStillnessSignal() {
+        let windows = [unreadableWindow(), unreadableWindow()]
+        XCTAssertEqual(
+            RhythmScreener.classifyEmptyState(windows: windows, hadMotionSignal: false, beatsAreBanked: false),
+            .deviceNoMotion)
+    }
+
+    func testClassifyEmptyStateGatheringWhenMotionPresentButNightRefused() {
+        let windows = [unreadableWindow(), unreadableWindow()]
+        // Motion signal exists (a moving/restless night) and beats aren't banked → the genuine 'try again'.
+        XCTAssertEqual(
+            RhythmScreener.classifyEmptyState(windows: windows, hadMotionSignal: true, beatsAreBanked: false),
+            .gatheringData)
+    }
+
+    func testClassifyEmptyStateNoDataIsGatheringNotStructural() {
+        // No dense windows at all (feature just enabled, or a thin night) must NEVER read as a permanent
+        // device limit, even though hadMotionSignal is false because there was nothing to record.
+        XCTAssertEqual(
+            RhythmScreener.classifyEmptyState(windows: [], hadMotionSignal: false, beatsAreBanked: false),
+            .gatheringData)
+    }
 }

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -199792,6 +199792,180 @@
           }
         }
       }
+    },
+    "This device can't support a rhythm reading": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Gerät unterstützt keine Rhythmus-Messung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este dispositivo no admite una lectura de ritmo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cet appareil ne peut pas fournir de lecture du rythme"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questo dispositivo non supporta una lettura del ritmo"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To urządzenie nie obsługuje odczytu rytmu"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este dispositivo não suporta uma leitura de ritmo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Это устройство не поддерживает измерение ритма"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此设备不支持节律读数"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此裝置不支援節律讀數"
+          }
+        }
+      }
+    },
+    "Rhythm needs beat-to-beat timing measured one beat at a time. Your device stores its heartbeats in batches, so the exact spacing between them isn't recoverable. Nothing is wrong with your night.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rhythm benötigt eine Schlag-zu-Schlag-Zeitmessung, die jeden Herzschlag einzeln erfasst. Dein Gerät speichert die Herzschläge in Blöcken, sodass der genaue Abstand zwischen ihnen nicht rekonstruierbar ist. Mit deiner Nacht ist alles in Ordnung."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rhythm necesita una medición latido a latido, tomada de uno en uno. Tu dispositivo guarda los latidos en lotes, así que el espaciado exacto entre ellos no se puede recuperar. No pasa nada con tu noche."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rhythm a besoin d'une mesure battement par battement, prise un battement à la fois. Ton appareil enregistre les battements par lots, si bien que l'espacement exact entre eux n'est pas récupérable. Il n'y a rien d'anormal avec ta nuit."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rhythm ha bisogno di una misurazione battito per battito, presa un battito alla volta. Il tuo dispositivo memorizza i battiti in blocchi, quindi la spaziatura esatta tra loro non è recuperabile. Non c'è nulla che non vada nella tua notte."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rhythm potrzebuje pomiaru uderzenie po uderzeniu, rejestrowanego pojedynczo. Twoje urządzenie zapisuje uderzenia serca partiami, więc dokładnych odstępów między nimi nie da się odtworzyć. Z Twoją nocą wszystko jest w porządku."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Rhythm precisa de uma medição batida a batida, feita uma batida de cada vez. O teu dispositivo guarda as batidas em lotes, pelo que o espaçamento exato entre elas não é recuperável. Não há nada de errado com a tua noite."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rhythm нужны интервалы между отдельными ударами, измеренные по одному удару за раз. Ваше устройство сохраняет удары сердца пакетами, поэтому точные промежутки между ними восстановить невозможно. С вашей ночью всё в порядке."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rhythm 需要逐拍测量的心跳间隔，一次记录一次心跳。你的设备将心跳成批存储，因此无法还原它们之间的精确间隔。你的睡眠没有任何问题。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rhythm 需要逐拍測量的心跳間隔，一次記錄一次心跳。你的裝置將心跳成批儲存，因此無法還原它們之間的精確間隔。你的睡眠沒有任何問題。"
+          }
+        }
+      }
+    },
+    "Rhythm reads only during still, resting windows, and this device doesn't record the stillness signal it needs to find them. Nothing is wrong with your night.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rhythm misst nur in ruhigen, bewegungslosen Phasen, und dieses Gerät zeichnet das dafür nötige Ruhesignal nicht auf. Mit deiner Nacht ist alles in Ordnung."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rhythm solo mide durante ventanas quietas y en reposo, y este dispositivo no registra la señal de quietud que necesita para encontrarlas. No pasa nada con tu noche."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rhythm ne mesure que pendant des fenêtres calmes et immobiles, et cet appareil n'enregistre pas le signal d'immobilité dont il a besoin pour les repérer. Il n'y a rien d'anormal avec ta nuit."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rhythm misura solo durante finestre tranquille e a riposo, e questo dispositivo non registra il segnale di immobilità che gli serve per individuarle. Non c'è nulla che non vada nella tua notte."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rhythm mierzy tylko podczas spokojnych, nieruchomych okien, a to urządzenie nie rejestruje sygnału bezruchu potrzebnego do ich wykrycia. Z Twoją nocą wszystko jest w porządku."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Rhythm só mede durante janelas calmas e em repouso, e este dispositivo não regista o sinal de imobilidade de que precisa para as encontrar. Não há nada de errado com a tua noite."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rhythm измеряет только в спокойные, неподвижные периоды, а это устройство не записывает сигнал неподвижности, необходимый для их поиска. С вашей ночью всё в порядке."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rhythm 只在安静、静息的时段进行测量，而此设备不记录用于识别这些时段所需的静止信号。你的睡眠没有任何问题。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rhythm 只在安靜、靜息的時段進行測量，而此裝置不記錄用於識別這些時段所需的靜止信號。你的睡眠沒有任何問題。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Strand/Screens/RhythmView.swift
+++ b/Strand/Screens/RhythmView.swift
@@ -247,14 +247,20 @@ struct RhythmView: View {
     /// The per-window results for the night, in time order. Their `poincare` clouds are
     /// pooled for the plot and their stats drive the descriptive tiles. May be empty.
     let windows: [RhythmScreener.WindowResult]
+    /// Why the night is empty (#1360) — picks WHICH honest empty-state copy shows when there is nothing
+    /// to plot. `.gatheringData` (the "try again" state) is the default for previews and any caller that
+    /// doesn't diagnose the reason.
+    let emptyReason: RhythmEmptyState
     /// Optional dismissal hook when presented as a sheet.
     var onClose: (() -> Void)? = nil
 
     init(night: RhythmScreener.NightRhythmSummary?,
          windows: [RhythmScreener.WindowResult],
+         emptyReason: RhythmEmptyState = .gatheringData,
          onClose: (() -> Void)? = nil) {
         self.night = night
         self.windows = windows
+        self.emptyReason = emptyReason
         self.onClose = onClose
     }
 
@@ -519,12 +525,25 @@ struct RhythmView: View {
 
     // MARK: Empty / thin-night state
 
+    /// #1360: a TRUTHFUL empty state. When every window was refused for a *capture* reason the device can
+    /// never satisfy — its beats arrive banked, or it records no stillness signal at all — say so, instead
+    /// of the "try again after a settled night" copy that is a lie when tomorrow is structurally identical.
+    /// `.gatheringData`/`.none` keep the original "no clear reading yet" wording (a genuine try-again).
     private var emptyState: some View {
-        DataPendingNote(
-            title: "No clear reading yet",
-            message: "Rhythm only looks during quiet, still, resting windows, so it needs a calm night's worth of steady beats. Once there's a clean window, the scatter and its description show here.",
-            symbol: "waveform.path"
-        )
+        let title: LocalizedStringKey
+        let message: LocalizedStringKey
+        switch emptyReason {
+        case .deviceBanksBeats:
+            title = "This device can't support a rhythm reading"
+            message = "Rhythm needs beat-to-beat timing measured one beat at a time. Your device stores its heartbeats in batches, so the exact spacing between them isn't recoverable. Nothing is wrong with your night."
+        case .deviceNoMotion:
+            title = "This device can't support a rhythm reading"
+            message = "Rhythm reads only during still, resting windows, and this device doesn't record the stillness signal it needs to find them. Nothing is wrong with your night."
+        case .none, .gatheringData:
+            title = "No clear reading yet"
+            message = "Rhythm only looks during quiet, still, resting windows, so it needs a calm night's worth of steady beats. Once there's a clean window, the scatter and its description show here."
+        }
+        return DataPendingNote(title: title, message: message, symbol: "waveform.path")
     }
 
     // MARK: Methodology

--- a/Strand/Screens/V5PillarHosts.swift
+++ b/Strand/Screens/V5PillarHosts.swift
@@ -58,12 +58,15 @@ struct RhythmHost: View {
 
     @State private var night: RhythmScreener.NightRhythmSummary?
     @State private var windows: [RhythmScreener.WindowResult] = []
+    /// #1360: why the night is empty, so the empty state reads truthfully. `.gatheringData` until `load`
+    /// diagnoses it (or when there simply isn't enough data yet — the honest "try again" default).
+    @State private var emptyReason: RhythmEmptyState = .gatheringData
     @State private var loaded = false
 
     private var consentGiven: Bool { enabled && RhythmConsent.isAccepted(acceptedVersion) }
 
     var body: some View {
-        RhythmView(night: night, windows: windows, onClose: onClose)
+        RhythmView(night: night, windows: windows, emptyReason: emptyReason, onClose: onClose)
             // Only compute once consent is given (the view shows the gate otherwise) AND on fresh data.
             .task(id: "\(consentGiven)|\(repo.refreshSeq)") {
                 guard consentGiven, !loaded else { return }
@@ -82,12 +85,16 @@ struct RhythmHost: View {
         guard hi > lo else { return }
         let rr = (try? await store.rrIntervals(deviceId: repo.deviceId, from: lo, to: hi, limit: 200_000)) ?? []
         // BLE-only users have their night under the computed source; fall back to it when the imported
-        // device yields nothing.
-        let rrRows = rr.isEmpty
-            ? ((try? await store.rrIntervals(deviceId: repo.deviceId + "-noop", from: lo, to: hi, limit: 200_000)) ?? [])
+        // device yields nothing. Gravity MUST be read from the SAME source id as the R-R (#1360): otherwise
+        // a fall-back night reads its stillness from the wrong device and every window fails the motion
+        // gate, which the empty-state diagnosis below would then misread as "no stillness signal at all".
+        let usedFallback = rr.isEmpty
+        let sourceId = usedFallback ? repo.deviceId + "-noop" : repo.deviceId
+        let rrRows = usedFallback
+            ? ((try? await store.rrIntervals(deviceId: sourceId, from: lo, to: hi, limit: 200_000)) ?? [])
             : rr
         guard !rrRows.isEmpty else { return }
-        let grav = (try? await store.gravitySamples(deviceId: repo.deviceId, from: lo, to: hi, limit: 200_000)) ?? []
+        let grav = (try? await store.gravitySamples(deviceId: sourceId, from: lo, to: hi, limit: 200_000)) ?? []
 
         // Window the night into 5-minute slices; a slice is "still" when its gravity variance is small.
         let windowSec = 5 * 60
@@ -106,6 +113,14 @@ struct RhythmHost: View {
         }
         windows = results
         night = RhythmScreener.summarizeNight(results)
+        // #1360: diagnose an empty night honestly. `hadMotionSignal` = the strap wrote ANY gravity sample
+        // (a ring writes none, #804); `beatsAreBanked` is measured over the whole night's stored R-R from
+        // the record timestamps (never the interval values), so it also detects the banked-capture class.
+        emptyReason = RhythmScreener.classifyEmptyState(
+            windows: results,
+            hadMotionSignal: !grav.isEmpty,
+            beatsAreBanked: RhythmScreener.nightBeatsAreBanked(
+                rrMs: rrRows.map { Double($0.rrMs) }, tsSec: rrRows.map { $0.ts }))
     }
 
     /// A window is "still" when its accelerometer magnitude varies little (a resting wrist). A coarse,

--- a/android/app/src/main/java/com/noop/analytics/RhythmScreener.kt
+++ b/android/app/src/main/java/com/noop/analytics/RhythmScreener.kt
@@ -247,6 +247,58 @@ object RhythmScreener {
         )
     }
 
+    // ── Empty-state diagnosis (#1360 — a TRUTHFUL empty state) ────────────────────────
+    //
+    // When a night produces nothing to plot, the screen must say WHY honestly. A device that can NEVER
+    // satisfy the read (a structural capture limit) is not the same as a night that merely lacked a calm,
+    // still window — and telling a ring owner "try again tomorrow" every night, when tomorrow is identical,
+    // is the misleading empty state #1360 fixes. These helpers name the refusal WITHOUT relaxing any gate.
+    // Twins of the Swift helpers.
+
+    /**
+     * Measured over the whole night: are the stored beats BANKED onto record timestamps, so the exact
+     * per-beat spacing isn't recoverable? Reuses [HrvAnalyzer.beatAccurateFraction] — the fill ratio comes
+     * from the RECORD TIMESTAMPS, never from the interval values being judged, so it can't be gamed by
+     * laying beats out cumulatively (the #194 trap the gate exists to avoid). Returns false when timestamps
+     * are absent or length-mismatched: a live spot capture carries none and is perfectly time-accurate, not
+     * "banked". The device-class (#1108) signal, independent of the motion gate. Twin of the Swift helper.
+     */
+    fun nightBeatsAreBanked(rrMs: List<Double>, tsSec: List<Int>): Boolean {
+        if (tsSec.size != rrMs.size || tsSec.isEmpty()) return false
+        val accurate = HrvAnalyzer.beatAccurateFraction(tsSec.map { it.toLong() }, rrMs)
+        return !HrvAnalyzer.beatValuesAreTrustworthy(accurate)
+    }
+
+    /**
+     * Diagnose WHY a night has nothing to show, so the empty state reads truthfully (#1360). Names the
+     * refusal the gates already made — consults no gate and relaxes none:
+     *   • [RhythmEmptyState.NONE]           — a window was readable; the caller shows the plot.
+     *   • [RhythmEmptyState.GATHERING_DATA] — the honest default: a device that DOES record a stillness
+     *                                         signal (so it can read in principle), a no-data night, or a
+     *                                         genuine restless one. The only "try again" state.
+     *   • [RhythmEmptyState.DEVICE_BANKS_BEATS] / [RhythmEmptyState.DEVICE_NO_MOTION] — a STRUCTURAL limit,
+     *                                         reached ONLY when the device recorded dense R-R yet NO stillness
+     *                                         signal at ALL (gravitySample empty for the whole DB, #804 — the
+     *                                         ring signature). Gating both on !hadMotionSignal is deliberate:
+     *                                         a WHOOP always writes an accelerometer track, so a WHOOP night
+     *                                         whose banked R-R measures over-counted (#1118) is NEVER
+     *                                         mislabelled "can't support it". When structurally incapable,
+     *                                         [beatsAreBanked] picks the more informative copy.
+     * [hadMotionSignal] = any stillness/gravity sample existed; [beatsAreBanked] = [nightBeatsAreBanked].
+     * Twin of the Swift helper.
+     */
+    fun classifyEmptyState(
+        windows: List<WindowResult>,
+        hadMotionSignal: Boolean,
+        beatsAreBanked: Boolean,
+    ): RhythmEmptyState {
+        if (windows.any { it.label != RhythmRegularity.UNREADABLE }) return RhythmEmptyState.NONE
+        // A device WITH a motion signal (WHOOP), or a night with no dense window yet, gets the honest
+        // "try again" — never a permanent "can't support" verdict. Only the ring signature is structural.
+        if (hadMotionSignal || windows.isEmpty()) return RhythmEmptyState.GATHERING_DATA
+        return if (beatsAreBanked) RhythmEmptyState.DEVICE_BANKS_BEATS else RhythmEmptyState.DEVICE_NO_MOTION
+    }
+
     // ── Statistics ──────────────────────────────────────────────────────────────────
 
     /** Bundle of the descriptive statistics over a clean window. Mirrors Swift `Stats`. */
@@ -391,4 +443,22 @@ enum class RhythmConfidence(val raw: String) {
     CALIBRATING("calibrating"),
     BUILDING("building"),
     SOLID("solid"),
+}
+
+/**
+ * Why the Rhythm screen has nothing to plot, so its empty state can be TRUTHFUL instead of always
+ * reading "try again tomorrow" (#1360). A structural capture limit ([DEVICE_BANKS_BEATS] /
+ * [DEVICE_NO_MOTION]) is PERMANENT for that device and must not be phrased as a one-off bad night;
+ * [GATHERING_DATA] is the only state that means "try again". Produced by [RhythmScreener.classifyEmptyState].
+ * The [raw] string matches Swift's enum raw value.
+ */
+enum class RhythmEmptyState(val raw: String) {
+    /** A window was readable — the caller shows the plot, not an empty state. */
+    NONE("none"),
+    /** Not enough evidence yet, or a genuine restless night. The only "try again" state. */
+    GATHERING_DATA("gatheringData"),
+    /** The device records no stillness signal at all, so the motion gate can never pass (#804). */
+    DEVICE_NO_MOTION("deviceNoMotion"),
+    /** The device banks its beats onto record timestamps, so per-beat spacing is unrecoverable (#1108). */
+    DEVICE_BANKS_BEATS("deviceBanksBeats"),
 }

--- a/android/app/src/main/java/com/noop/ui/RhythmScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/RhythmScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import com.noop.analytics.RhythmConfidence
+import com.noop.analytics.RhythmEmptyState
 import com.noop.analytics.RhythmRegularity
 import com.noop.analytics.RhythmScreener
 import kotlin.math.min
@@ -214,6 +215,7 @@ fun RhythmConsentGate(
 fun RhythmScreen(
     night: RhythmScreener.NightRhythmSummary?,
     windows: List<RhythmScreener.WindowResult>,
+    emptyReason: RhythmEmptyState = RhythmEmptyState.GATHERING_DATA,
     onClose: (() -> Unit)? = null,
 ) {
     val context = LocalContext.current
@@ -232,13 +234,14 @@ fun RhythmScreen(
         return
     }
 
-    RhythmVisualization(night = night, windows = windows, onClose = onClose)
+    RhythmVisualization(night = night, windows = windows, emptyReason = emptyReason, onClose = onClose)
 }
 
 @Composable
 private fun RhythmVisualization(
     night: RhythmScreener.NightRhythmSummary?,
     windows: List<RhythmScreener.WindowResult>,
+    emptyReason: RhythmEmptyState,
     onClose: (() -> Unit)?,
 ) {
     // The headline window: prefer the most-varied readable window so the "what a diffuse
@@ -268,12 +271,7 @@ private fun RhythmVisualization(
         item { SourceBadge("Experimental", tint = Palette.restColor) }
 
         if (allPoints.isEmpty()) {
-            item {
-            DataPendingNote(
-                title = uiString(R.string.l10n_rhythm_screen_no_clear_reading_yet_92f40443),
-                body = "Rhythm only looks during quiet, still, resting windows, so it needs a calm night's worth of steady beats. Once there's a clean window, the scatter and its description show here.",
-            )
-            }
+            item { RhythmEmptyStateNote(emptyReason) }
         } else {
             item { SummaryCard(night = night, headline = headline) }
             item { PlotCard(points = allPoints) }
@@ -285,6 +283,32 @@ private fun RhythmVisualization(
 
         item { MethodologyCard() }
         item { RhythmDisclaimerNote() }
+    }
+}
+
+/**
+ * #1360: a TRUTHFUL empty state. When every window was refused for a *capture* reason the device can
+ * never satisfy — its beats arrive banked, or it records no stillness signal at all — say so, instead of
+ * the "try again after a settled night" copy that is a lie when tomorrow is structurally identical.
+ * GATHERING_DATA/NONE keep the original "no clear reading yet" wording (a genuine try-again). The bodies
+ * are English literals matching the screen's existing empty-state body (localized copy follows when the
+ * Android rhythm loader lands — the screen is not yet fed real windows). Twin of the Swift `emptyState`.
+ */
+@Composable
+private fun RhythmEmptyStateNote(reason: RhythmEmptyState) {
+    when (reason) {
+        RhythmEmptyState.DEVICE_BANKS_BEATS -> DataPendingNote(
+            title = uiString(R.string.l10n_rhythm_screen_this_device_can_t_support_a_bb41aada),
+            body = "Rhythm needs beat-to-beat timing measured one beat at a time. Your device stores its heartbeats in batches, so the exact spacing between them isn't recoverable. Nothing is wrong with your night.",
+        )
+        RhythmEmptyState.DEVICE_NO_MOTION -> DataPendingNote(
+            title = uiString(R.string.l10n_rhythm_screen_this_device_can_t_support_a_bb41aada),
+            body = "Rhythm reads only during still, resting windows, and this device doesn't record the stillness signal it needs to find them. Nothing is wrong with your night.",
+        )
+        RhythmEmptyState.NONE, RhythmEmptyState.GATHERING_DATA -> DataPendingNote(
+            title = uiString(R.string.l10n_rhythm_screen_no_clear_reading_yet_92f40443),
+            body = "Rhythm only looks during quiet, still, resting windows, so it needs a calm night's worth of steady beats. Once there's a clean window, the scatter and its description show here.",
+        )
     }
 }
 

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -758,6 +758,7 @@
     <string name="l10n_rhythm_screen_extra_skipped_4a153489">Extra / übersprungen</string>
     <string name="l10n_rhythm_screen_long_axis_02300830">Langachse</string>
     <string name="l10n_rhythm_screen_no_clear_reading_yet_92f40443">Noch keine klare Messung</string>
+    <string name="l10n_rhythm_screen_this_device_can_t_support_a_bb41aada">Dieses Gerät unterstützt keine Rhythmus-Messung</string>
     <string name="l10n_rhythm_screen_rhythm_c715bb28">Rhythmus</string>
     <string name="l10n_rhythm_screen_short_axis_66a0b7bf">Kurzachse</string>
     <string name="l10n_rhythm_screen_the_numbers_7b3cbf64">Die Zahlen</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -573,6 +573,7 @@
     <string name="l10n_rhythm_screen_extra_skipped_4a153489">Extra / saltado</string>
     <string name="l10n_rhythm_screen_long_axis_02300830">Eje largo</string>
     <string name="l10n_rhythm_screen_no_clear_reading_yet_92f40443">Aún no hay una lectura clara</string>
+    <string name="l10n_rhythm_screen_this_device_can_t_support_a_bb41aada">Este dispositivo no admite una lectura de ritmo</string>
     <string name="l10n_rhythm_screen_rhythm_c715bb28">Ritmo</string>
     <string name="l10n_rhythm_screen_short_axis_66a0b7bf">Eje corto</string>
     <string name="l10n_rhythm_screen_the_numbers_7b3cbf64">Los números</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -573,6 +573,7 @@
     <string name="l10n_rhythm_screen_extra_skipped_4a153489">Extra / décroché</string>
     <string name="l10n_rhythm_screen_long_axis_02300830">Axe long</string>
     <string name="l10n_rhythm_screen_no_clear_reading_yet_92f40443">Aucune lecture claire pour l\'instant</string>
+    <string name="l10n_rhythm_screen_this_device_can_t_support_a_bb41aada">Cet appareil ne peut pas fournir de lecture du rythme</string>
     <string name="l10n_rhythm_screen_rhythm_c715bb28">Rythme</string>
     <string name="l10n_rhythm_screen_short_axis_66a0b7bf">Axe court</string>
     <string name="l10n_rhythm_screen_the_numbers_7b3cbf64">Les chiffres</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -733,6 +733,7 @@
     <string name="l10n_rhythm_screen_extra_skipped_4a153489">Dodatkowe / pominięte</string>
     <string name="l10n_rhythm_screen_long_axis_02300830">Długa oś</string>
     <string name="l10n_rhythm_screen_no_clear_reading_yet_92f40443">Nie ma jeszcze jasnego odczytu</string>
+    <string name="l10n_rhythm_screen_this_device_can_t_support_a_bb41aada">To urządzenie nie obsługuje odczytu rytmu</string>
     <string name="l10n_rhythm_screen_rhythm_c715bb28">Rytm</string>
     <string name="l10n_rhythm_screen_short_axis_66a0b7bf">Krótka oś</string>
     <string name="l10n_rhythm_screen_the_numbers_7b3cbf64">Księga Liczb</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -741,6 +741,7 @@
     <string name="l10n_rhythm_screen_extra_skipped_4a153489">Extra/ignorado</string>
     <string name="l10n_rhythm_screen_long_axis_02300830">Eixo longo</string>
     <string name="l10n_rhythm_screen_no_clear_reading_yet_92f40443">Nenhuma leitura clara ainda</string>
+    <string name="l10n_rhythm_screen_this_device_can_t_support_a_bb41aada">Este dispositivo não suporta uma leitura de ritmo</string>
     <string name="l10n_rhythm_screen_rhythm_c715bb28">Ritmo</string>
     <string name="l10n_rhythm_screen_short_axis_66a0b7bf">Eixo curto</string>
     <string name="l10n_rhythm_screen_the_numbers_7b3cbf64">Os números</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -723,6 +723,7 @@
     <string name="l10n_rhythm_screen_extra_skipped_4a153489">早搏 / 漏搏 (推测)</string>
     <string name="l10n_rhythm_screen_long_axis_02300830">长轴</string>
     <string name="l10n_rhythm_screen_no_clear_reading_yet_92f40443">尚未获得清晰读数</string>
+    <string name="l10n_rhythm_screen_this_device_can_t_support_a_bb41aada">此设备不支持节律读数</string>
     <string name="l10n_rhythm_screen_rhythm_c715bb28">心跳节律</string>
     <string name="l10n_rhythm_screen_short_axis_66a0b7bf">短轴</string>
     <string name="l10n_rhythm_screen_the_numbers_7b3cbf64">具体数值</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -759,6 +759,7 @@
     <string name="l10n_rhythm_screen_extra_skipped_4a153489">Extra / skipped</string>
     <string name="l10n_rhythm_screen_long_axis_02300830">Long axis</string>
     <string name="l10n_rhythm_screen_no_clear_reading_yet_92f40443">No clear reading yet</string>
+    <string name="l10n_rhythm_screen_this_device_can_t_support_a_bb41aada">This device can\'t support a rhythm reading</string>
     <string name="l10n_rhythm_screen_rhythm_c715bb28">Rhythm</string>
     <string name="l10n_rhythm_screen_short_axis_66a0b7bf">Short axis</string>
     <string name="l10n_rhythm_screen_the_numbers_7b3cbf64">The numbers</string>

--- a/android/app/src/test/java/com/noop/analytics/RhythmScreenerTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RhythmScreenerTest.kt
@@ -296,4 +296,69 @@ class RhythmScreenerTest {
         assertEquals(withTs.label, withoutTs.label)
         assertEquals(withTs.sd2, withoutTs.sd2)
     }
+
+    // ── Empty-state diagnosis (#1360) — twin of the Swift tests ───────────────────────
+
+    private fun readableWindow() = RhythmScreener.screenWindow(
+        RhythmScreener.WindowInput(rrMs = regularSinus(), motionStill = true, meanHR = 60.0))
+
+    private fun unreadableWindow() = RhythmScreener.screenWindow(
+        RhythmScreener.WindowInput(rrMs = regularSinus(), motionStill = false, meanHR = 60.0))
+
+    @Test fun nightBeatsAreBanked_detectsBankedButNotHonestOrAbsent() {
+        val rr = regularSinus()
+        // Banked: 6 beats per record, records 5 s apart (mirrors the gate-4 banked fixture).
+        val bankedTs = rr.indices.map { (it / 6) * 5 }
+        assertTrue(RhythmScreener.nightBeatsAreBanked(rr, bankedTs))
+        // Honestly stamped ~1 s apart (mean ~1000 ms) — a real per-beat train.
+        assertFalse(RhythmScreener.nightBeatsAreBanked(rr, rr.indices.toList()))
+        // No timestamps / a length mismatch → unmeasurable, which is NOT 'banked'.
+        assertFalse(RhythmScreener.nightBeatsAreBanked(rr, emptyList()))
+        assertFalse(RhythmScreener.nightBeatsAreBanked(rr, listOf(0, 1, 2)))
+    }
+
+    @Test fun classifyEmptyState_noneWhenAnyWindowReadable() {
+        val windows = listOf(unreadableWindow(), readableWindow())
+        assertEquals(
+            RhythmEmptyState.NONE,
+            RhythmScreener.classifyEmptyState(windows, hadMotionSignal = false, beatsAreBanked = true))
+    }
+
+    @Test fun classifyEmptyState_bankedBeatsWhenStructurallyIncapable() {
+        val windows = listOf(unreadableWindow(), unreadableWindow())
+        // No stillness signal at all (the ring) AND banked beats → the more informative structural copy.
+        assertEquals(
+            RhythmEmptyState.DEVICE_BANKS_BEATS,
+            RhythmScreener.classifyEmptyState(windows, hadMotionSignal = false, beatsAreBanked = true))
+    }
+
+    /** Regression guard (#1118 × #1360): a WHOOP night reads BANKED R-R too, so beatsAreBanked can be
+     *  true — but WHOOP always writes an accelerometer track, so its motion signal is present and it must
+     *  keep the honest "try again", NEVER "this device can't support it". */
+    @Test fun classifyEmptyState_whoopBankedNightStaysGathering() {
+        val windows = listOf(unreadableWindow(), unreadableWindow())
+        assertEquals(
+            RhythmEmptyState.GATHERING_DATA,
+            RhythmScreener.classifyEmptyState(windows, hadMotionSignal = true, beatsAreBanked = true))
+    }
+
+    @Test fun classifyEmptyState_noMotionWhenDenseWindowsButNoStillnessSignal() {
+        val windows = listOf(unreadableWindow(), unreadableWindow())
+        assertEquals(
+            RhythmEmptyState.DEVICE_NO_MOTION,
+            RhythmScreener.classifyEmptyState(windows, hadMotionSignal = false, beatsAreBanked = false))
+    }
+
+    @Test fun classifyEmptyState_gatheringWhenMotionPresentButNightRefused() {
+        val windows = listOf(unreadableWindow(), unreadableWindow())
+        assertEquals(
+            RhythmEmptyState.GATHERING_DATA,
+            RhythmScreener.classifyEmptyState(windows, hadMotionSignal = true, beatsAreBanked = false))
+    }
+
+    @Test fun classifyEmptyState_noDataIsGatheringNotStructural() {
+        assertEquals(
+            RhythmEmptyState.GATHERING_DATA,
+            RhythmScreener.classifyEmptyState(emptyList(), hadMotionSignal = false, beatsAreBanked = false))
+    }
 }


### PR DESCRIPTION
Closes #1360.

## The problem
The **Rhythm** screen showed the same empty state every night — *"No clear reading yet… try again after a calm night"* — for a device that can **never** satisfy the read. On an Oura ring the copy is a lie: `gravitySample` is empty for the whole DB (#804), so the motion gate refuses every window, and the beats are banked onto record timestamps (#1108), so even forcing stillness yields 0 readable windows. Tomorrow is structurally identical. (Full evidence in #1360, from @pipiche38.)

## The fix — name the refusal, don't relax the gate
The gates stay **exactly** as strict (a Poincaré scatter of banked intervals would be fiction — the #194 trap on a screen about heart rhythm). We only describe the refusal honestly.

**Analytics (both platforms, byte-identical):**
- `RhythmScreener.classifyEmptyState(windows:hadMotionSignal:beatsAreBanked:)` → `none` / `gatheringData` / `deviceNoMotion` / `deviceBanksBeats`.
- `RhythmScreener.nightBeatsAreBanked(rrMs:tsSec:)` measures the banked-capture class from the **record timestamps**, never the interval values — so it can't be gamed by a cumulative spread.

A **structural** verdict ("this device can't support a rhythm reading") is reached **only** when the device recorded dense R-R yet **no stillness signal at all** — the ring signature. This deliberately keeps a **WHOOP** on the honest *"try again"*: WHOOP always writes an accelerometer track, and its banked R-R can itself measure over-counted (#1118), so gating on `!hadMotionSignal` prevents a false *"can't support it"* on a WHOOP night. (Covered by a regression test.)

**iOS:** `RhythmView` renders the three-way copy; `V5PillarHosts` diagnoses the night and now reads gravity from the **same source id** as the R-R (a fall-back night otherwise read its stillness from the wrong device — a latent bug this also closes).

**Android:** `RhythmScreener`/`RhythmScreen` carry the twin and the screen is wired for the states. Its loader isn't fed real windows yet (the screen is still fed null/empty), so the two new **body** strings stay English literals matching the screen's existing empty-state body; the shared **title** is localized. Full body localization follows when the Android rhythm loader lands.

## Copy
- **deviceBanksBeats:** *"This device can't support a rhythm reading — Rhythm needs beat-to-beat timing measured one beat at a time. Your device stores its heartbeats in batches, so the exact spacing between them isn't recoverable. Nothing is wrong with your night."*
- **deviceNoMotion:** *"…this device doesn't record the stillness signal it needs to find [still, resting windows]. Nothing is wrong with your night."*
- **gatheringData / none:** unchanged *"No clear reading yet…"*.

Written for the capture-incapable-**class** ("device", not "ring"), per the issue's caveat about imported CSV / Apple Health.

## Verification
- **Android:** `:app:testFullDebugUnitTest --tests com.noop.analytics.RhythmScreenerTest` — **28 pass** (incl. the classifier, the banked detector, and the WHOOP-banked regression guard). `compileFullDebugUnitTestKotlin` clean.
- **iOS analytics:** covered by `test (StrandAnalytics)` in default CI (swift-packages).
- **App-target Swift** (`RhythmView`, `V5PillarHosts`) is compile-validated by the on-demand app-build gate (default CI does not build the app targets).
- `Tools/i18n_audit.py --ci main` and `Tools/doc_comment_lint.py` — clean.
- **Not yet exercised on a real ring/strap** — the diagnosis logic is unit-tested, but on-device confirmation (a ring shows `deviceBanksBeats`; a WHOOP restless night still shows "try again") is the remaining check.

New strings localized across all iOS locales (de/es/fr/it/pl/pt-PT/ru/zh-Hans/zh-Hant) and the Android shared title across all Android locales.

Reported and analysed by @pipiche38 (#1360).
