### PR TITLE
fix(multi-whoop): read the active strap, not a hardcoded "my-whoop", on the Kotlin #512-class paths (#1304)

### DIFF
--- a/android/app/src/main/java/com/noop/ai/AiCoach.kt
+++ b/android/app/src/main/java/com/noop/ai/AiCoach.kt
@@ -32,11 +32,22 @@ import kotlin.math.roundToInt
  * Anonymous: the only branding is the provider name the user selected. The system prompt does
  * not name any app author or model vendor.
  */
-class AiCoach(private val repo: WhoopRepository) {
+class AiCoach(
+    private val repo: WhoopRepository,
+    /** #1304/#512: resolves the ACTIVE strap id. A lambda (not a plain `String`) so it is read at
+     *  call time rather than frozen when `AiCoach` is constructed — the app's active id resolves lazily
+     *  at startup, and the coach may be built first. The strap-telemetry reads below
+     *  ([WhoopRepository.daysMerged] / [WhoopRepository.rrIntervals] / Lab markers) union the active strap
+     *  with the canonical "my-whoop"; a live-BLE strap banks under "whoop-<uuid>", so a raw "my-whoop"
+     *  read would leave the coach reasoning off the wrong strap. Defaults to canonical so an import-only
+     *  install (and any test) is byte-identical to the old behaviour. */
+    private val activeStrapId: () -> String = { WhoopRepository.WHOOP_SOURCE },
+) {
 
-    /** The device key the rest of the app reads/writes daily metrics under. Coach reads go
-     *  through the MERGED raw+computed view ([WhoopRepository.daysMerged]), the same per-field
-     *  coalesce every screen uses, so on-device "-noop" scores are visible too (#124). */
+    /** The canonical bucket the imported journal answers ([WhoopRepository.journal]) live under — the app
+     *  keys journal to "my-whoop" everywhere (it is user-global, not strap telemetry), matching Swift
+     *  `AICoach.journalEntries()`. Daily metrics, R-R and Lab Book markers read the active strap via
+     *  [activeStrapId]. */
     private val deviceId = "my-whoop"
 
     /** The source id native (in-app) journal answers are stored under (matches the UI's
@@ -89,7 +100,7 @@ class AiCoach(private val repo: WhoopRepository) {
         val groundedFull = if (consent) {
             // Merged read, NOT raw days(): a live-strap user's scores live under "my-whoop-noop"
             // and a raw read misses them, the coach then claimed it had no data. (#124)
-            val days = runCatching { repo.daysMerged(deviceId) }.getOrDefault(emptyList())
+            val days = runCatching { repo.daysMerged(activeStrapId()) }.getOrDefault(emptyList())
             // Derived stress: a single Baevsky Stress Index summary line over TODAY's R-R, read the
             // same way StressScreen does (repo.rrIntervals over the local day) and gated UNDER this same
             // `consent` block as the HRV/RHR summary, a derived number, never raw R-R egress. Absent
@@ -148,7 +159,7 @@ class AiCoach(private val repo: WhoopRepository) {
         val tzOffset = java.util.TimeZone.getDefault().getOffset(nowSeconds * 1_000L) / 1_000L
         val localNow = nowSeconds + tzOffset
         val from = (localNow - Math.floorMod(localNow, 86_400L)) - tzOffset
-        val rr = repo.rrIntervals(deviceId, from, nowSeconds, limit = 200_000)
+        val rr = repo.rrIntervals(activeStrapId(), from, nowSeconds, limit = 200_000)
         return stressIndexLine(rr)
     }
 
@@ -297,7 +308,7 @@ class AiCoach(private val repo: WhoopRepository) {
 
         // --- Strongest associations on the user's own logged days (recovery as the outcome) ---
         val behaviours = runCatching { journalBehaviours() }.getOrDefault(emptyMap())
-        val days = runCatching { repo.daysMerged(deviceId) }.getOrDefault(emptyList())
+        val days = runCatching { repo.daysMerged(activeStrapId()) }.getOrDefault(emptyList())
         if (behaviours.isNotEmpty() && days.isNotEmpty()) {
             val recoveryByDay = days.mapNotNull { d -> d.recovery?.let { d.day to it } }.toMap()
             val ranked = runCatching { EffectRanker.rank(behaviours, recoveryByDay, "Charge") }
@@ -341,11 +352,13 @@ class AiCoach(private val repo: WhoopRepository) {
         return out.mapValues { it.value.toSet() }
     }
 
-    /** The latest reading per Lab Book marker key (stored under the strap deviceId). */
+    /** The latest reading per Lab Book marker key (stored under the ACTIVE strap deviceId). #1304/#512:
+     *  read under the active strap id — matching Swift `AICoach` (`labMarkers(deviceId: repo.deviceId)`) —
+     *  so a 2nd strap's markers under "whoop-<uuid>" aren't missed. */
     private suspend fun latestLabMarkers(): List<LabMarkerRow> {
         val all = ArrayList<LabMarkerRow>()
         for (category in LabMarkerCategory.entries) {
-            all += runCatching { repo.labMarkersByCategory(deviceId, category.raw) }.getOrDefault(emptyList())
+            all += runCatching { repo.labMarkersByCategory(activeStrapId(), category.raw) }.getOrDefault(emptyList())
         }
         return all.groupBy { it.markerKey }.values.map { rows -> rows.maxByOrNull { it.takenAt }!! }
             .sortedBy { it.markerKey }

--- a/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
@@ -284,7 +284,9 @@ class WhoopConnectionService : Service() {
                 // flow completes; combine keeps running on ble.state with days frozen.
                 // #797: the bounded merge (recentDaysMergedFlow) is enough here, the notification only reads
                 // today's row; this stops a years-deep import re-merging the whole history on every change.
-                repo.recentDaysMergedFlow("my-whoop").catch { emit(emptyList()) },
+                // #1304/#512: the active strap's live day is under its own id ("whoop-<uuid>"); a raw
+                // "my-whoop" read (which the union method collapses to) misses it. Same accessor as :606.
+                repo.recentDaysMergedFlow((application as NoopApplication).activeDeviceId).catch { emit(emptyList()) },
             ) { state, days ->
                 // #911: resolve the day the way the dashboard does, via the LOGICAL local day (rolls at
                 // 04:00, with the #304 pre-04:00 carve-out), NOT a naive LocalDate.now() that rolls at
@@ -365,7 +367,9 @@ class WhoopConnectionService : Service() {
                     lastRuntimeEvalPct = runtimePct
                     runCatching {
                         val nowS = System.currentTimeMillis() / 1000
-                        val samples = repo.batterySamples("my-whoop", nowS - 14L * 86_400, nowS, limit = 2_000)
+                        // #1304/#512: read the active strap's own SoC (banked under "whoop-<uuid>" for a
+                        // 2nd strap), not the hardcoded canonical id. Same accessor as :606.
+                        val samples = repo.batterySamples((application as NoopApplication).activeDeviceId, nowS - 14L * 86_400, nowS, limit = 2_000)
                             .mapNotNull { s -> s.soc?.let { s.ts to it } }
                         val rated = if (state.whoop5Detected) BatteryEstimator.ratedLifeHoursWhoop5
                                     else BatteryEstimator.ratedLifeHoursWhoop4

--- a/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.noop.NoopApplication
 import com.noop.ai.AiCoach
 import com.noop.ai.AiKeyStore
 import com.noop.ai.AiProvider
@@ -33,7 +34,11 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
     // The networked coach, over the local store. No key is held here; the engine reads it from
     // the encrypted store at call time.
     private val aiCoach = AiCoach(
-        WhoopRepository(WhoopDatabase.get(app.applicationContext))
+        WhoopRepository(WhoopDatabase.get(app.applicationContext)),
+        // #1304/#512: thread the active strap id (resolved lazily by NoopApplication) so the coach reasons
+        // off the active strap's data — daysMerged/R-R/Lab markers union active ∪ canonical — instead of a
+        // hardcoded "my-whoop" that misses a strap banked under "whoop-<uuid>".
+        activeStrapId = { (app as NoopApplication).activeDeviceId },
     )
 
     // MARK: - Transcript

--- a/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
@@ -104,8 +104,11 @@ fun CoupledScreen(
     LaunchedEffect(days) {
         sleeps = runCatching {
             val now = System.currentTimeMillis() / 1000L
-            val imported = vm.repo.sleepSessions("my-whoop", 0L, now)
-            val computed = vm.repo.sleepSessions(vm.repo.computedDeviceId("my-whoop"), 0L, now)
+            // #1304/#512: read across the active-strap UNION (active ∪ canonical "my-whoop"), exactly as
+            // SleepScreen does — a 2nd strap's sleep is banked under "whoop-<uuid>", invisible to a raw
+            // "my-whoop" read. A single-WHOOP install collapses to "my-whoop" only, byte-identical.
+            val imported = vm.repo.sleepSessionsUnion(vm.activeStrapId, 0L, now)
+            val computed = vm.repo.computedSleepSessionsUnion(vm.activeStrapId, 0L, now)
             val importedEnds = imported.map { it.endTs }.toHashSet()
             (imported + computed.filter { it.endTs !in importedEnds }).sortedBy { it.effectiveStartTs }
         }.getOrDefault(emptyList())
@@ -115,7 +118,9 @@ fun CoupledScreen(
     // span below resolves the IDENTICAL block (#294) instead of a screen-local heuristic.
     var habitualMidsleepSec by remember { mutableStateOf<Long?>(null) }
     LaunchedEffect(days) {
-        habitualMidsleepSec = runCatching { vm.repo.habitualMidsleepSec("my-whoop") }.getOrNull()
+        // #1304/#512: thread the active strap id — `habitualMidsleepSec` unions internally, but the
+        // literal "my-whoop" collapses that union and re-drops a 2nd strap's nights (matches SleepScreen).
+        habitualMidsleepSec = runCatching { vm.repo.habitualMidsleepSec(vm.activeStrapId) }.getOrNull()
     }
 
     // Imported export-verbatim sleep figures (sleep_performance / need), preferred over the on-device

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -522,7 +522,9 @@ fun TodayScreen(
                 // A wide window: SoC readings are sparse (~8 min apart), so a few days back is plenty for the
                 // estimator to find the trailing discharge run and still cheap to load.
                 val from = now - 14L * 86_400
-                val samples = viewModel.repo.batterySamples("my-whoop", from, now, limit = 2_000)
+                // #1304/#512: a 2nd active strap banks its SoC under "whoop-<uuid>", so a "my-whoop" read
+                // returned empty and the runtime estimate went blank. Read the active strap's own battery.
+                val samples = viewModel.repo.batterySamples(viewModel.activeStrapId, from, now, limit = 2_000)
                     .mapNotNull { s -> s.soc?.let { s.ts to it } }
                 val rated = if (liveSnap.whoop5) BatteryEstimator.ratedLifeHoursWhoop5
                             else BatteryEstimator.ratedLifeHoursWhoop4
@@ -5147,9 +5149,12 @@ private fun HeartRateTrendCard(
         // that could disagree with the Sleep tab and the Coupled view's bed-wake read for a night stored
         // as more than one block (#294).
         sleepToday = runCatching {
-            val overlapping = viewModel.repo.sleepSessions("my-whoop", start - 18 * 3600L, end)
+            // #1304/#512: union across the active strap (like the hrBucketsUnion read just above) — a 2nd
+            // strap's night is banked under "whoop-<uuid>" and a raw "my-whoop" read misses it, so the
+            // hero showed no sleep band. Single-WHOOP collapses to "my-whoop", byte-identical.
+            val overlapping = viewModel.repo.sleepSessionsUnion(viewModel.activeStrapId, start - 18 * 3600L, end)
                 .filter { it.startTs <= end && it.endTs >= start }   // overlaps the window
-            val habitualMidsleepSec = viewModel.repo.habitualMidsleepSec("my-whoop")
+            val habitualMidsleepSec = viewModel.repo.habitualMidsleepSec(viewModel.activeStrapId)
             mainSleepSpan(overlapping, habitualMidsleepSec)?.let { (spanStart, spanEnd) ->
                 SleepSession(deviceId = "my-whoop", startTs = spanStart, endTs = spanEnd)
             }

--- a/android/app/src/test/java/com/noop/data/MultiWhoopSourceUnionTest.kt
+++ b/android/app/src/test/java/com/noop/data/MultiWhoopSourceUnionTest.kt
@@ -1,0 +1,46 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #1304 / #512-class: the read-path resolvers that every multi-WHOOP-safe read threads. A user's SECOND
+ * strap banks its data under a fresh id ("whoop-<uuid>"), while the canonical import bucket stays
+ * "my-whoop". The union-aware repo methods (`sleepSessionsUnion`, `habitualMidsleepSec`, `daysMerged`,
+ * `recentDaysMergedFlow`, `rrIntervals`, …) resolve their read ids through [WhoopRepository.importedSourceIdsFor]
+ * / [WhoopRepository.computedSourceIdsFor].
+ *
+ * The trap this pins (the bug fixed across CoupledScreen / TodayScreen hero+battery / AiCoach /
+ * WhoopConnectionService): passing the LITERAL "my-whoop" into a union-aware method collapses the union
+ * to the canonical id alone and RE-DROPS the 2nd strap. Callers must pass the ACTIVE strap id instead —
+ * which is exactly what these assertions lock. Pure companion functions, no DB (twin of
+ * [WorkoutHrDeviceKeyTest]).
+ */
+class MultiWhoopSourceUnionTest {
+
+    private val second = "whoop-aabbcc"   // a 2nd strap's live id
+
+    @Test fun `a 2nd strap's active id unions active first then canonical`() {
+        assertEquals(listOf(second, "my-whoop"), WhoopRepository.importedSourceIdsFor(second))
+        assertEquals(
+            listOf("$second-noop", "my-whoop-noop"),
+            WhoopRepository.computedSourceIdsFor(second),
+        )
+    }
+
+    @Test fun `the canonical literal collapses to a single id -- the caller bug this fixes`() {
+        // Passing "my-whoop" (what the fixed callers used to hardcode) yields ONLY the canonical bucket,
+        // so a union-aware method fed this literal never reads the 2nd strap. This is why callers must
+        // thread the active strap id, not the literal.
+        assertEquals(listOf("my-whoop"), WhoopRepository.importedSourceIdsFor("my-whoop"))
+        assertEquals(listOf("my-whoop-noop"), WhoopRepository.computedSourceIdsFor("my-whoop"))
+    }
+
+    @Test fun `an import-only install is byte-identical whichever way it is threaded`() {
+        // Single-WHOOP / import-only users have activeStrapId == "my-whoop", so the fix is a no-op for them.
+        assertEquals(
+            WhoopRepository.importedSourceIdsFor("my-whoop"),
+            WhoopRepository.importedSourceIdsFor(WhoopRepository.WHOOP_SOURCE),
+        )
+    }
+}


### PR DESCRIPTION
Part of #1304 (the #512-class sweep).

## What the sweep found
The Swift side is already union-safe everywhere (`Repository.series/workoutRows/habitualMidsleepSec`, `CsvExport`'s active∪canonical, `MetricCatalog` is display-only). So **every remaining #512-class bug is a Kotlin caller** handing the literal `"my-whoop"` into a union-aware repo method — which collapses the union (`importedSourceIdsFor("my-whoop") == ["my-whoop"]`) and re-drops a 2nd strap's data (banked under `whoop-<uuid>`).

## The fix — thread the active strap id
| Site | Before | After |
|---|---|---|
| `CoupledScreen` sleep + habitual | `sleepSessions("my-whoop")` / `habitualMidsleepSec("my-whoop")` | `sleepSessionsUnion` / `computedSleepSessionsUnion` / `habitualMidsleepSec(vm.activeStrapId)` — matches `SleepScreen` |
| `TodayScreen` sleepToday hero | `sleepSessions("my-whoop")` | `sleepSessionsUnion(viewModel.activeStrapId)` (like the `hrBucketsUnion` read one line above) |
| `TodayScreen` battery estimate | `batterySamples("my-whoop")` | `batterySamples(viewModel.activeStrapId)` |
| `WhoopConnectionService` notification + battery | `recentDaysMergedFlow("my-whoop")` / `batterySamples("my-whoop")` | `(application as NoopApplication).activeDeviceId` — same accessor already used at `:606` |
| `AiCoach` daily + R-R + Lab markers | `daysMerged/rrIntervals/labMarkers("my-whoop")` | active strap id (threaded from `CoachViewModel`) — matches Swift `AICoach` (`repo.deviceId`) |

`AiCoach` journal stays canonical `"my-whoop"` (user-global, not strap telemetry) — matching Swift `AICoach.journalEntries()`.

## Deliberately NOT changed (verified *not* #512-class)
- **`stress` and `sleep_performance`/`sleep_need_min`** (TodayScreen/StressScreen/TrendsReport, CoupledScreen:127) — these are **imported** metrics that live under the canonical `my-whoop` by definition (a 2nd BLE strap produces none; Swift's `series()` union collapses to the same thing). The DemoSeeder comment confirms stress is "derived EXACTLY as a real WHOOP import derives it… under my-whoop." Touching them would fabricate a bug, not fix one.
- **`ShortcutHealthImport.forbiddenSources`** — a *write-target* guard (target is the constant `apple-health`), never enumerates strap ids. Red herring; the guard holds.
- **`DataSourcesScreen` WHOOP badge counts** — under-report a 2nd strap but only cosmetically (no union-aware count variant exists). Left as a minor follow-up, noted in #1304.

## Test & verification
- New **`MultiWhoopSourceUnionTest`** pins the collapse-vs-union contract every fixed caller now depends on (pure companion resolvers, twin of `WorkoutHrDeviceKeyTest`).
- `:app:compileFullDebugKotlin` clean; **319 `com.noop.data` + `com.noop.ai` unit tests green** (run locally — Android tests aren't in default CI).
- Swift untouched (already union-safe), so this is Kotlin-only, no parity twin needed.
- **Not yet exercised on real dual-strap hardware** — the resolver contract is unit-tested, but the on-device confirmation (a 2nd strap's sleep/battery/coach context appearing) is the remaining check.

Follow-ups for #1304: `DataSourcesScreen` counts (needs union-aware count variants), and the companion #1193 (serial identity) which would shrink this surface at the source.
