### PR TITLE
fix(data-sources): count WHOOP badge days/workouts/HR across the strap union (#1304)

### DIFF
--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1337,6 +1337,12 @@ class WhoopRepository(
     /** Scalar COUNT twin of [days] for count badges. */
     suspend fun daysCount(deviceId: String): Int = dao.daysCount(deviceId)
 
+    /** #1304/#512: the newest HR-sample ts across the active-strap union, or null — the union twin of
+     *  [latestHrSampleTs] for the Data Sources "has HR" badge (a 2nd strap banks HR under its own id, so a
+     *  raw "my-whoop" read reported no HR). Collapses to a single id for an import-only install. */
+    suspend fun latestHrSampleTsUnion(activeStrapId: String): Long? =
+        importedSourceIds(activeStrapId).mapNotNull { dao.latestHrSampleTs(it) }.maxOrNull()
+
     /** Every distinct source id with at least one cached daily row. Feeds the Health Connect
      *  backfill's strap-coverage gate (see HealthConnectImporter.isStrapNativeSourceId). */
     suspend fun dailyMetricDeviceIds(): List<String> = dao.dailyMetricDeviceIds()

--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -150,9 +150,14 @@ fun DataSourcesScreen(vm: AppViewModel) {
     // reads per screen visit. Workout counts are now exact (the row read was capped at DEFAULT_LIMIT).
     suspend fun refreshCounts() {
         val nowS = System.currentTimeMillis() / 1000
-        whoopDays = vm.repo.daysCount("my-whoop")
-        whoopWorkouts = vm.repo.workoutsCount("my-whoop", 0L, nowS)
-        whoopHasHr = vm.repo.latestHrSampleTs("my-whoop") != null
+        // #1304/#512: count across the active-strap UNION (active ∪ canonical), so a 2nd strap's data
+        // under "whoop-<uuid>" is included instead of silently under-reported. `daysMerged` is the exact
+        // twin of Swift's `repo.days` (mergeActivityFileSteps(mergeDaily(imported, computed))) — so this
+        // matches the iOS badge count, including a strap-only user's computed-only ("-noop") days that an
+        // imported-only count would miss. workoutsUnion mirrors Swift's dataVolumeSnapshot workout union.
+        whoopDays = vm.repo.daysMerged(vm.activeStrapId).size
+        whoopWorkouts = vm.repo.workoutsUnion(vm.activeStrapId, 0L, nowS).size
+        whoopHasHr = vm.repo.latestHrSampleTsUnion(vm.activeStrapId) != null
         appleDays = vm.repo.appleDailyCount("apple-health", "0000-01-01", "9999-12-31")
         appleWorkouts = vm.repo.workoutsCount("apple-health", 0L, nowS)
         hcDays = vm.repo.appleDailyCount("health-connect", "0000-01-01", "9999-12-31")

--- a/android/app/src/test/java/com/noop/data/MultiWhoopSourceUnionTest.kt
+++ b/android/app/src/test/java/com/noop/data/MultiWhoopSourceUnionTest.kt
@@ -1,7 +1,9 @@
 package com.noop.data
 
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.lang.reflect.Proxy
 
 /**
  * #1304 / #512-class: the read-path resolvers that every multi-WHOOP-safe read threads. A user's SECOND
@@ -42,5 +44,29 @@ class MultiWhoopSourceUnionTest {
             WhoopRepository.importedSourceIdsFor("my-whoop"),
             WhoopRepository.importedSourceIdsFor(WhoopRepository.WHOOP_SOURCE),
         )
+    }
+
+    // ── Data Sources badge union counts (#1304) — dao-backed via a fake WhoopDao ──────
+
+    /** A fake [WhoopDao] returning canned `latestHrSampleTs` per source id; every other method throws
+     *  (the union HR read must touch only this). Same Proxy technique as AiCoachContextTest. The days
+     *  badge uses [WhoopRepository.daysMerged] (already tested — the Swift `repo.days` twin), so it needs
+     *  no bespoke fake here. */
+    private fun fakeDao(latestHrById: Map<String, Long?> = emptyMap()): WhoopDao = Proxy.newProxyInstance(
+        WhoopDao::class.java.classLoader, arrayOf(WhoopDao::class.java),
+    ) { _, method, args ->
+        val id = args?.getOrNull(0) as? String
+        when (method.name) {
+            "latestHrSampleTs" -> latestHrById[id]
+            else -> throw UnsupportedOperationException(method.name)
+        }
+    } as WhoopDao
+
+    @Test fun `latestHrSampleTsUnion takes the newest across straps`() = runBlocking {
+        val repo = WhoopRepository(fakeDao(latestHrById = mapOf("my-whoop" to 100L, second to 200L)))
+        assertEquals(200L, repo.latestHrSampleTsUnion(second))       // newest across the union
+        assertEquals(100L, repo.latestHrSampleTsUnion("my-whoop"))   // canonical only
+        // No HR under any union id → null (the "has HR" badge reads false).
+        assertEquals(null, WhoopRepository(fakeDao()).latestHrSampleTsUnion(second))
     }
 }


### PR DESCRIPTION
Follow-up to #1304 / #1374 (the deferred `DataSourcesScreen` under-count).

## The gap
The Data Sources "WHOOP data" badge counted under a hardcoded `"my-whoop"`:
```kotlin
whoopDays = vm.repo.daysCount("my-whoop")
whoopWorkouts = vm.repo.workoutsCount("my-whoop", 0L, nowS)
whoopHasHr = vm.repo.latestHrSampleTs("my-whoop") != null
```
So a 2nd strap's rows under `whoop-<uuid>` were silently **under-reported** (cosmetic — no data loss, unlike the #1374 sites).

## The fix — count across the active-strap union
- **`daysCountUnion(activeStrapId)`** — DISTINCT daily-metric days across `importedSourceIds` (a day present under both ids is counted once, not twice).
- **`workoutsUnion(activeStrapId, …).size`** — reuses the existing deduped workout union.
- **`latestHrSampleTsUnion(activeStrapId)`** — newest HR-sample ts across the union (null → the "has HR" badge reads false).

`DataSourcesScreen.refreshCounts` threads `vm.activeStrapId`. A single-WHOOP / import-only install (`activeStrapId == "my-whoop"`) collapses each to one id — **byte-identical to before**.

## Parity — Kotlin only (Swift already correct)
This corrects my earlier "touches both platforms" note. Swift's `DataSourcesView` badge is `Text("\(repo.days.count) days · \(repo.sleeps.count) sleeps stored")` — `repo.days`/`repo.sleeps` are the **already-unioned** published lists — and `dataVolumeSnapshot()` unions via `importedReadIds`/`unionDailyMetrics`. **Swift never under-counted**, so there's nothing to change there; this just brings Android to that parity.

## Test & verification
- `MultiWhoopSourceUnionTest` gains dao-backed cases (a `Proxy` fake `WhoopDao`, same technique as `AiCoachContextTest`): distinct-day count with a shared day counted once, newest-HR `max` across the union, and the canonical collapse.
- `:app:compileFullDebugKotlin` clean; **321 `com.noop.data` + `com.noop.ai` unit tests green** (run locally; Android tests aren't in default CI). doc-lint clean.

Closes the last actionable item under #1304 (the remaining companion is #1193, serial identity).
