### PR TITLE
fix(data-sources): correct + fold the phone HR-broadcast enabled warning, clarify the card (#159)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -741,7 +741,8 @@ fun DataSourcesScreen(vm: AppViewModel) {
             subtitle = "Re-share your live strap heart rate over Bluetooth as a standard heart-rate " +
                 "sensor, so a gym treadmill, bike, Zwift, Peloton or any fitness app nearby can read " +
                 "it. Works on any WHOOP (4.0 or 5.0/MG) because your phone does the broadcasting. " +
-                "Local Bluetooth only. Nothing leaves your phone. Off by default.",
+                "If your strap or watch already broadcasts heart rate directly to another device, " +
+                "you can leave this off. Local Bluetooth only. Nothing leaves your phone. Off by default.",
         ) {
             if (hrBroadcast) {
                 val (label, tone) =
@@ -815,9 +816,7 @@ fun DataSourcesScreen(vm: AppViewModel) {
                         modifier = Modifier.size(16.dp),
                     )
                     Text(
-                        uiString(R.string.l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a) +
-                            "which keeps its radio hot and drains the battery faster. Turn it off when " +
-                            "you're not using it with another device.",
+                        uiString(R.string.l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a),
                         style = NoopType.caption,
                         color = Palette.statusWarning,
                     )

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -379,7 +379,7 @@
     <string name="l10n_data_sources_screen_auto_sync_periodically_5f3041e8">Auto-Sync periodisch</string>
     <string name="l10n_data_sources_screen_broadcast_heart_rate_as_a_bluetooth_6a44fdb4">Herzfrequenz als Bluetooth-Sensor senden</string>
     <string name="l10n_data_sources_screen_broadcast_hr_from_this_phone_10e5605c">Broadcast HR von diesem Telefon</string>
-    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">Broadcast HR ist an. Dein Riemen wirbt ständig für seine Herzfrequenz,</string>
+    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">Herzfrequenzübertragung ist EIN. Dieses Smartphone sendet kontinuierlich die Herzfrequenz, wodurch Bluetooth aktiv bleibt und der Akku schneller entladen wird. Schalte die Funktion aus, wenn du sie nicht mit einem anderen Gerät verwendest.</string>
     <string name="l10n_data_sources_screen_cancel_77dfd213">Abbrechen</string>
     <string name="l10n_data_sources_screen_data_sources_5e43d6bb">Datenquellen</string>
     <string name="l10n_data_sources_screen_every_3560d90b">Alle</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -194,7 +194,7 @@
     <string name="l10n_data_sources_screen_auto_sync_periodically_5f3041e8">Auto-sinc periódicamente</string>
     <string name="l10n_data_sources_screen_broadcast_heart_rate_as_a_bluetooth_6a44fdb4">Difundir la frecuencia cardíaca como sensor Bluetooth</string>
     <string name="l10n_data_sources_screen_broadcast_hr_from_this_phone_10e5605c">Broadcast HR desde este teléfono</string>
-    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">RRHH está encendida. Su correa está publicando su frecuencia cardíaca continuamente,</string>
+    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">La transmisión de frecuencia cardíaca está ACTIVADA. Este teléfono transmite la frecuencia cardíaca continuamente, lo que mantiene Bluetooth activo y consume la batería más rápido. Desactívala cuando no la uses con otro dispositivo.</string>
     <string name="l10n_data_sources_screen_cancel_77dfd213">Cancelar</string>
     <string name="l10n_data_sources_screen_data_sources_5e43d6bb">Fuentes de datos</string>
     <string name="l10n_data_sources_screen_every_3560d90b">Cada uno</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -194,7 +194,7 @@
     <string name="l10n_data_sources_screen_auto_sync_periodically_5f3041e8">Auto-sync périodiquement</string>
     <string name="l10n_data_sources_screen_broadcast_heart_rate_as_a_bluetooth_6a44fdb4">Diffuser la fréquence cardiaque comme capteur Bluetooth</string>
     <string name="l10n_data_sources_screen_broadcast_hr_from_this_phone_10e5605c">Diffusion de la fréquence cardiaque depuis ce téléphone</string>
-    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">Diffusion de la fréquence cardiaque en direct. Votre bracelet annonce sa fréquence cardiaque en continu, </string>
+    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">La diffusion de la fréquence cardiaque est ACTIVÉE. Ce téléphone diffuse la fréquence cardiaque en continu, ce qui maintient le Bluetooth actif et décharge plus vite la batterie. Désactivez-la lorsque vous ne l\'utilisez pas avec un autre appareil.</string>
     <string name="l10n_data_sources_screen_cancel_77dfd213">Annuler</string>
     <string name="l10n_data_sources_screen_data_sources_5e43d6bb">Sources de données</string>
     <string name="l10n_data_sources_screen_every_3560d90b">Chaque</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -362,7 +362,7 @@
     <string name="l10n_data_sources_screen_auto_sync_periodically_5f3041e8">Okresowo przeprowadzaj automatyczną synchronizację</string>
     <string name="l10n_data_sources_screen_broadcast_heart_rate_as_a_bluetooth_6a44fdb4">Transmisja tętna jako czujnik Bluetooth</string>
     <string name="l10n_data_sources_screen_broadcast_hr_from_this_phone_10e5605c">Transmituj HR z tego telefonu</string>
-    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">Transmisja HR jest WŁĄCZONA. Twój pasek stale wyświetla swoje tętno,</string>
+    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">Transmisja tętna jest WŁĄCZONA. Ten telefon stale nadaje tętno, przez co Bluetooth pozostaje aktywny i szybciej rozładowuje baterię. Wyłącz ją, gdy nie używasz jej z innym urządzeniem.</string>
     <string name="l10n_data_sources_screen_cancel_77dfd213">Anuluj</string>
     <string name="l10n_data_sources_screen_data_sources_5e43d6bb">Źródła danych</string>
     <string name="l10n_data_sources_screen_every_3560d90b">Każdy</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -362,7 +362,7 @@
     <string name="l10n_data_sources_screen_auto_sync_periodically_5f3041e8">Sincronizar automaticamente periodicamente</string>
     <string name="l10n_data_sources_screen_broadcast_heart_rate_as_a_bluetooth_6a44fdb4">Transmita a frequência cardíaca como um sensor Bluetooth</string>
     <string name="l10n_data_sources_screen_broadcast_hr_from_this_phone_10e5605c">Transmitir RH a partir deste telefone</string>
-    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">A transmissão de RH está LIGADA. A tua bracelete está a anunciar a tua frequência cardíaca continuamente, </string>
+    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">A transmissão da frequência cardíaca está LIGADA. Este telemóvel transmite a frequência cardíaca continuamente, o que mantém o Bluetooth ativo e descarrega a bateria mais depressa. Desliga-a quando não a estiveres a usar com outro dispositivo.</string>
     <string name="l10n_data_sources_screen_cancel_77dfd213">Cancelar</string>
     <string name="l10n_data_sources_screen_data_sources_5e43d6bb">Fontes de dados</string>
     <string name="l10n_data_sources_screen_every_3560d90b">Cada</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -359,7 +359,7 @@
     <string name="l10n_data_sources_screen_auto_sync_periodically_5f3041e8">定期自动同步</string>
     <string name="l10n_data_sources_screen_broadcast_heart_rate_as_a_bluetooth_6a44fdb4">作为蓝牙心率传感器广播心率</string>
     <string name="l10n_data_sources_screen_broadcast_hr_from_this_phone_10e5605c">从此手机广播心率</string>
-    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">心率广播已开启。您的手环正在持续广播实时心率，...</string>
+    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">心率广播已开启。此手机正在持续广播心率，这会使蓝牙保持活跃并更快耗电。当你不与其他设备一起使用时，请将其关闭。</string>
     <string name="l10n_data_sources_screen_cancel_77dfd213">取消</string>
     <string name="l10n_data_sources_screen_data_sources_5e43d6bb">数据源</string>
     <string name="l10n_data_sources_screen_every_3560d90b">每隔</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -388,7 +388,7 @@
     <string name="l10n_data_sources_screen_auto_sync_periodically_5f3041e8">Auto-sync periodically</string>
     <string name="l10n_data_sources_screen_broadcast_heart_rate_as_a_bluetooth_6a44fdb4">Broadcast heart rate as a Bluetooth sensor</string>
     <string name="l10n_data_sources_screen_broadcast_hr_from_this_phone_10e5605c">Broadcast HR from this phone</string>
-    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">Broadcast HR is ON. Your strap is advertising its heart rate continuously, </string>
+    <string name="l10n_data_sources_screen_broadcast_hr_is_on_your_strap_0ad5368a">Broadcast HR is ON. This phone is advertising heart rate continuously, which keeps its Bluetooth radio active and drains the battery faster. Turn it off when you\'re not using it with another device.</string>
     <string name="l10n_data_sources_screen_cancel_77dfd213">Cancel</string>
     <string name="l10n_data_sources_screen_data_sources_5e43d6bb">Data Sources</string>
     <string name="l10n_data_sources_screen_every_3560d90b">Every</string>


### PR DESCRIPTION
Supersedes #508 (@kavemang), rebased onto current `main` and trimmed to the part that isn't already fixed. Closes #159.

## The bugs (Android "Broadcast HR" enabled warning — all six locales)
The warning string `…broadcast_hr_is_on_your_strap_0ad5368a` was wrong three ways at once, and shipping:
1. **Factually wrong** — *"Your strap is advertising its heart rate continuously"*. It's the **phone** that rebroadcasts, not the strap. → *"This phone is advertising…"*
2. **Mistranslated** — Spanish rendered "HR" as **"RRHH"** (Recursos Humanos = the *Human Resources dept*) and Portuguese as **"RH"** (same). → `frecuencia cardíaca` / `frequência cardíaca`.
3. **Truncated** — the second half was a hardcoded English string concatenated in Kotlin (`uiString(…) + "which keeps its radio hot…"`), so DE/FR/ES/PL/PT/ZH users saw a partial sentence followed by an English tail. Folded the whole sentence into the localized resource.

## #159 — why the card exists
The reporter (WHOOP 4.0 broadcasting natively to a Suunto watch) didn't understand why the phone-broadcast option exists. Added to the subtitle: *"If your strap or watch already broadcasts heart rate directly to another device, you can leave this off."*

## Why this supersedes #508
#508 also edited `…acts_as_a_standard_bluetooth_heart_f8d13439`, but `main` **already folded that string and fixed its FR/ES `ressources humaines` mistranslation** (different wording) — which is what made #508 conflict. This PR drops that now-redundant half and keeps only the still-broken `_0ad5368a` warning + the #159 subtitle. I reused @kavemang's DE/FR/ES wording and added the missing **PL/PT/ZH** translations (which #508 didn't touch — and PT had the same "RH = Human Resources" bug).

## Parity (checked)
The enabled warning is **Android-only** — iOS's broadcast card (`DataSourcesView.swift`) has no equivalent warning string (its "Acts as a standard Bluetooth heart-rate strap" footnote is already the folded/correct form on iOS), so there is **no Swift twin to change**. The iOS subtitle is a separate localized string that already conveys optionality ("Off by default"); adding the exact #159 clause there is a minor localized follow-up, not a parity gap. Key ids kept stable across the copy change, matching how `main` folds these strings.

## Verification
- `Tools/i18n_audit.py --ci main` — clean (no new literals / echoes / locale gaps; `_0ad5368a` present + non-echo in all six locales).
- `:app:compileFullDebugKotlin` clean; `GermanLocalizationTest` 2/2.
- Android-only, no app-target Swift — default CI covers what CI can (Android unit tests aren't in default CI; run locally).
