### PR TITLE
diag(ble): dump the GET_HELLO_HARVARD (cmd 35) response to locate the WHOOP-4.0 serial (#1303)

### DIFF
--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -181,6 +181,13 @@ public final class FrameRouter {
                     let r = Self.commandResultByte(in: frame)
                     let rhex = r.map { String(format: "0x%02x", UInt8(truncatingIfNeeded: $0)) } ?? "none"
                     state.append(log: "Alarm: strap answered the arm (SET_ALARM_TIME) with result=\(rhex) — log-only, 4.0 result-code meaning unverified")
+                } else if cmd.hasPrefix("GET_HELLO_HARVARD"), TestCentre.active(.connection) {
+                    // #1303: capture aid for WHOOP-4.0 stable-serial identity. The strap serial lives in this
+                    // GET_HELLO_HARVARD (cmd 35) response, but its byte offset is undocumented — so dump the
+                    // raw payload ONCE per connect to locate it against the serial the app shows. Gated behind
+                    // Test Centre → Connection so the full serial + device key never reach a DEFAULT (shareable)
+                    // strap log; only an opted-in diagnostic session sees it. Log-only; decodes/persists nothing.
+                    state.append(log: "HELLO_HARVARD(35) resp raw: \(Self.commandResponsePayloadHex(in: frame) ?? "empty") — locate the strap serial offset (#1303)")
                 }
             }
 

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5580,6 +5580,18 @@ class WhoopBleClient(
                 }
                 val respCmd = parsed.parsed["resp_cmd"] as? String
                 val result = parsed.parsed["result"] as? String
+                // #1303: capture aid for WHOOP-4.0 stable-serial identity — the strap serial lives in the
+                // GET_HELLO_HARVARD (cmd 35) response but its byte offset is undocumented, so dump the raw
+                // payload ONCE per connect to locate it against the serial the app shows. Gated behind Test
+                // Centre → Connection so the full serial + device key never reach a DEFAULT (shareable) strap
+                // log; only an opted-in diagnostic session sees it. Log-only; decodes/persists nothing. Twin
+                // of the Swift FrameRouter dump.
+                if (connectedFamily == DeviceFamily.WHOOP4 && respCmd?.startsWith("GET_HELLO_HARVARD") == true &&
+                    testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)) {
+                    val raw = whoop4CommandResponsePayload(frame)?.takeIf { it.isNotEmpty() }
+                        ?.joinToString(" ") { "%02x".format(it) } ?: "empty"
+                    log("HELLO_HARVARD(35) resp raw: $raw — locate the strap serial offset (#1303)")
+                }
                 // Reboot ack (#166): log the COMMAND_RESPONSE result for a user reboot on BOTH families —
                 // the accept/reject signal (the same one that exposed 5/MG haptics rejection). So a 5/MG
                 // owner's strap log confirms whether the (unverified) puffin reboot frame is accepted. The


### PR DESCRIPTION
Unblocks #1303 (the WHOOP-4.0 stable-serial keystone).

## Why
The 4.0 serial-adoption path needs the strap serial, which lives in the **GET_HELLO_HARVARD (cmd 35)** response the app already sends on every connect (`BLEManager.swift:5215`). But its byte offset is **undocumented** — noop's schema doesn't map it, and the attributed my-whoop source only places it *"after the device-epoch clock"*, not byte-exact. Writing a decode against a guessed offset would be a speculative-BLE footgun, so first: capture a real response and correlate.

## What
On a **WHOOP 4.0**, log the raw cmd-35 response payload hex **once per connect**, so the serial offset can be located against the serial the app/strap shows. Log-only — decodes and persists nothing.

**Privacy — gated behind Test Centre → Connection.** The cmd-35 response carries the **full serial *and* a device key/uuid**, so it must never land in a default (shareable) strap log — users attach those to issues. This mirrors the existing DIS log, which deliberately logs only the serial **prefix** for exactly this reason. Only an opted-in diagnostic session sees the full payload.

## Parity
Swift (`FrameRouter`) + Android (`WhoopBleClient`) twins: same `whoop4` gate, same `TestCentre.active(.connection)` gate, same space-separated hex, same message. Reuses the existing `commandResponsePayloadHex` / `whoop4CommandResponsePayload` helpers — no new plumbing.

## Verification
- Android `:app:compileFullDebugKotlin` clean.
- Swift is app-target (`Strand/BLE`) → validated by the app-build gate (dispatched on this branch); default CI doesn't compile the app targets.
- doc-lint clean. No UI strings (diagnostic log only, not localized).
- **On-device:** enable Test Centre → Connection, connect a 4.0, read the `HELLO_HARVARD(35) resp raw:` line. Log-only and gated, so no behavior/BLE-path change.

Once the offset is located, this is superseded by the real serial decode + `adoptSerialIdentity` wiring (#1303).
