### PR TITLE
feat(polar): PMD control-point command layer + model capability catalog (both platforms)

### DIFF
--- a/Packages/PolarProtocol/Sources/PolarProtocol/PmdControl.swift
+++ b/Packages/PolarProtocol/Sources/PolarProtocol/PmdControl.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+// MARK: - Polar Measurement Data (PMD) CONTROL POINT — clean-room command builder + response parse
+//
+// Companion to `PmdDecoder` (the DATA side). The PMD Control Point characteristic
+// (FB005C81-02E7-F387-1CAD-8ACD2D8DF0C8, write + indicate) is how a client STARTS / STOPS a
+// measurement stream and reads its supported settings, BEFORE the data notifications arrive on the
+// Data characteristic (FB005C82-…). Byte layout per docs/DEVICE_SUPPORT_ROADMAP.md §PMD — sourced
+// from the official `polarofficial/polar-ble-sdk` (cross-verified). This is NOOP's own byte builder,
+// not Polar code.
+//
+// SCOPE: the pure command/response layer only. The CoreBluetooth / android.bluetooth wiring — discover
+// the PMD service, write these bytes to the control point, subscribe to the data characteristic, and
+// feed the notifications to `PmdDecoder` — is the hardware-gated `PolarPMDSource` still to build. Keeping
+// the byte work here (pure, unit-tested, no BLE) mirrors `PmdDecoder`: the source becomes a thin wrapper.
+//
+// HARDWARE-GATED: the control-point RESPONSE layout (the `0xF0` indicate reply) is per the SDK but not
+// yet confirmed against a real device in this repo — no consumer should treat a parsed `Response` as
+// authoritative until an H10 / Verity Sense settles it, exactly as the roadmap flags the PPI flag polarity.
+
+public enum PolarPmdControl {
+
+    /// Control-point opcodes — the FIRST byte of a control-point WRITE (§PMD).
+    public enum Opcode: UInt8, Sendable, Equatable {
+        case getMeasurementSettings = 0x01
+        case requestMeasurementStart = 0x02
+        case stopMeasurement = 0x03
+    }
+
+    /// A measurement SETTING type inside a start request (`[type, count, u16 LE × count]` blocks, §PMD).
+    /// `sampleRate`/`resolution`/`range` are the three NOOP would ever set; the SDK defines more, added
+    /// only if a future stream needs them.
+    public enum SettingType: UInt8, Sendable, Equatable {
+        case sampleRate = 0x00
+        case resolution = 0x01
+        case range = 0x02
+    }
+
+    /// One setting block: a type plus its u16 values (little-endian on the wire).
+    public struct Setting: Equatable, Sendable {
+        public let type: SettingType
+        public let values: [UInt16]
+        public init(_ type: SettingType, _ values: [UInt16]) {
+            self.type = type
+            self.values = values
+        }
+    }
+
+    /// GET_MEASUREMENT_SETTINGS — ask the sensor which settings a measurement supports: `[0x01, measType]`.
+    /// The reply (an indicate on the control point) carries the supported setting blocks; parsing those
+    /// param blocks is deferred until `PolarPMDSource` needs to negotiate a rate.
+    public static func getSettings(_ measurement: PolarPmdMeasurement) -> [UInt8] {
+        [Opcode.getMeasurementSettings.rawValue, measurement.rawValue]
+    }
+
+    /// REQUEST_MEASUREMENT_START — begin a stream: `[0x02, (recording << 7) | measType, settingBlocks…]`.
+    /// `recording == false` (online streaming — what NOOP uses) leaves bit 7 clear, so the second byte is
+    /// just the measurement type. Each setting serialises as `[type, count, lo, hi, …]` with u16 LE values.
+    public static func start(_ measurement: PolarPmdMeasurement,
+                             recording: Bool = false,
+                             settings: [Setting] = []) -> [UInt8] {
+        var out: [UInt8] = [
+            Opcode.requestMeasurementStart.rawValue,
+            (recording ? 0x80 : 0x00) | (measurement.rawValue & 0x7F),
+        ]
+        for s in settings {
+            out.append(s.type.rawValue)
+            out.append(UInt8(truncatingIfNeeded: s.values.count))
+            for v in s.values {
+                out.append(UInt8(v & 0x00FF))
+                out.append(UInt8(v >> 8))
+            }
+        }
+        return out
+    }
+
+    /// STOP_MEASUREMENT — end a stream: `[0x03, measType]`.
+    public static func stop(_ measurement: PolarPmdMeasurement) -> [UInt8] {
+        [Opcode.stopMeasurement.rawValue, measurement.rawValue]
+    }
+
+    /// The control-point indicate reply, prefixed by `responseMarker`: `[0xF0, reqOpcode, measType,
+    /// status, …]`. `status == 0` is success; the rest (a "more" flag + GET_SETTINGS param blocks) is
+    /// not parsed here. `measurement` is nil when the reply names a type NOOP doesn't recognise.
+    public struct Response: Equatable, Sendable {
+        public let requestOpcode: UInt8
+        public let measurement: PolarPmdMeasurement?
+        public let status: UInt8
+        public var isSuccess: Bool { status == 0x00 }
+        public init(requestOpcode: UInt8, measurement: PolarPmdMeasurement?, status: UInt8) {
+            self.requestOpcode = requestOpcode
+            self.measurement = measurement
+            self.status = status
+        }
+    }
+
+    /// The byte the PMD control point prefixes every indicate reply with (§PMD, SDK response frame).
+    public static let responseMarker: UInt8 = 0xF0
+
+    /// Parse a control-point indicate reply `[0xF0, reqOpcode, measType, status, …]`, or nil when the
+    /// frame is too short or isn't a control-point response. Conservative, matching `PmdDecoder`'s stance.
+    public static func parseResponse(_ data: [UInt8]) -> Response? {
+        guard data.count >= 4, data[0] == responseMarker else { return nil }
+        return Response(requestOpcode: data[1],
+                        measurement: PolarPmdMeasurement(rawValue: data[2] & 0x3F),
+                        status: data[3])
+    }
+}

--- a/Packages/PolarProtocol/Sources/PolarProtocol/PmdDecoder.swift
+++ b/Packages/PolarProtocol/Sources/PolarProtocol/PmdDecoder.swift
@@ -8,7 +8,8 @@ import Foundation
 // PMD data notifications (on the PMD Data characteristic FB005C82-…) share a 10-byte header:
 //
 //   byte  0      measurement type   (0x00 ECG, 0x01 PPG, 0x02 ACC, 0x03 PPI, 0x05 GYRO, 0x06 MAG, …)
-//   bytes 1…8    timestamp          (uint64 LE, nanoseconds, of the LAST sample in the frame)
+//   bytes 1…8    timestamp          (uint64 LE, nanoseconds since 2000-01-01 UTC — the PMD epoch, NOT
+//                                    Unix; of the LAST sample in the frame)
 //   byte  9      frame type         (bit 7 = compressed/delta flag; bits 0…6 = data-format id)
 //   bytes 10…    sample data        (format depends on measurement type + frame type)
 //
@@ -39,12 +40,22 @@ public enum PolarPmdMeasurement: UInt8, Sendable, Equatable, CaseIterable {
 public struct PolarPmdFrameHeader: Equatable, Sendable {
     /// The measurement stream this frame belongs to.
     public let measurement: PolarPmdMeasurement
-    /// Frame timestamp in nanoseconds (applies to the LAST sample in the frame).
+    /// Frame timestamp in nanoseconds since **2000-01-01 UTC** — the PMD epoch, NOT the Unix epoch (a raw
+    /// read is ~30 years behind wall clock). Applies to the LAST sample in the frame. Use `unixTimestampNs`
+    /// for wall clock. Only load-bearing for the fixed-rate streams (ECG/ACC/PPG) when those land — for PPI,
+    /// samples are event-based and callers timestamp on arrival.
     public let timestampNs: UInt64
     /// The data-format id (frame type bits 0…6).
     public let frameType: UInt8
     /// True when the compressed/delta bit (0x80) is set on the frame-type byte.
     public let isCompressed: Bool
+
+    /// Nanoseconds between the Unix epoch (1970-01-01) and the PMD epoch (2000-01-01): 946 684 800 s. Add
+    /// to a PMD `timestampNs` to re-base it onto the Unix epoch.
+    public static let pmdEpochUnixOffsetNs: UInt64 = 946_684_800_000_000_000
+
+    /// `timestampNs` re-based to the Unix epoch (ns since 1970-01-01 UTC), for wall-clock use.
+    public var unixTimestampNs: UInt64 { timestampNs &+ Self.pmdEpochUnixOffsetNs }
 
     public init(measurement: PolarPmdMeasurement, timestampNs: UInt64, frameType: UInt8, isCompressed: Bool) {
         self.measurement = measurement

--- a/Packages/PolarProtocol/Sources/PolarProtocol/PolarModel.swift
+++ b/Packages/PolarProtocol/Sources/PolarProtocol/PolarModel.swift
@@ -57,12 +57,13 @@ public enum PolarModel: String, Sendable, Equatable, CaseIterable {
         }
         let n = raw.lowercased()
         guard n.hasPrefix("polar ") else { return .unknown }
-        // Order matters only where one name prefixes another; these four don't, so a `contains` on the
-        // model token is enough and tolerant of the trailing serial.
-        if n.contains("h10") { return .h10 }
-        if n.contains("h9") { return .h9 }
-        if n.contains("oh1") { return .oh1 }
-        if n.contains("sense") { return .veritySense }
+        // Anchor on the model token — the word right after "Polar " — NOT a substring of the whole name.
+        // A `contains` would misidentify a device whose serial happened to carry a model token (e.g. a
+        // "Polar OH1 H10…" serial matching h10). `hasPrefix` is also order-independent here.
+        if n.hasPrefix("polar h10") { return .h10 }
+        if n.hasPrefix("polar h9") { return .h9 }
+        if n.hasPrefix("polar oh1") { return .oh1 }
+        if n.hasPrefix("polar sense") { return .veritySense }
         return .unknown
     }
 }

--- a/Packages/PolarProtocol/Sources/PolarProtocol/PolarModel.swift
+++ b/Packages/PolarProtocol/Sources/PolarProtocol/PolarModel.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+// MARK: - Polar model identification + PMD stream capability catalog (clean-room, public facts)
+//
+// A Polar sensor advertises a stable BLE name of the form "Polar <MODEL> <serial>" (public — visible in
+// any BLE scanner). This maps that name to the model and to the PMD measurement streams the model is
+// DOCUMENTED to expose, so a future `PolarPMDSource` can pick the right measurement to request per device
+// (PPI for HRV on the optical bands; ECG on the H10) instead of probing blindly. R-R for HRV also arrives
+// on the standard HR service (0x180D) for every model — that path already ships — so a model with no PMD
+// entry here is still a first-class HR/R-R source, just not a PMD one.
+//
+// Facts only: model names are public product identifiers; the per-model PMD stream sets are from
+// docs/DEVICE_SUPPORT_ROADMAP.md §PMD (official polar-ble-sdk). No third-party code.
+//
+// HARDWARE-GATED: the capability sets below are what each model is documented to support; a real device
+// should confirm them before any behaviour gates on them (same stance as the roadmap's PPI-flag caveat).
+// Notably OH1 vs Verity Sense differ on the gyroscope — Verity Sense carries the 9-axis IMU, OH1 does not.
+
+public enum PolarModel: String, Sendable, Equatable, CaseIterable {
+    /// Chest strap: ECG + ACC over PMD, plus HR + R-R on the standard service. No optical (PPG/PPI).
+    case h10
+    /// Chest strap: HR + R-R on the standard service only (no PMD service).
+    case h9
+    /// Optical armband: PPG + PPI + ACC over PMD, plus HR. No ECG, no gyroscope.
+    case oh1
+    /// Optical armband (Verity Sense): PPG + PPI + ACC + GYRO over PMD, plus HR. No ECG.
+    case veritySense
+    /// A Polar device whose model we don't recognise. Still usable as a standard HR/R-R strap; PMD streams
+    /// are unknown, so a source must GET_MEASUREMENT_SETTINGS rather than assume.
+    case unknown
+
+    /// The PMD measurement streams this model is documented to expose. Empty for HR-only models (H9) and
+    /// for `.unknown` — never a guess; an empty set means "read R-R off the standard HR service, or probe".
+    public var pmdStreams: Set<PolarPmdMeasurement> {
+        switch self {
+        case .h10:         return [.ecg, .acc]
+        case .h9:          return []
+        case .oh1:         return [.ppg, .ppi, .acc]
+        case .veritySense: return [.ppg, .ppi, .acc, .gyro]
+        case .unknown:     return []
+        }
+    }
+
+    /// The PMD measurement NOOP would request for HRV on this model: `.ppi` (inter-beat interval) where the
+    /// optical bands expose it, nil on the H10/H9 (their R-R comes off the standard HR service — no PMD
+    /// needed) and on `.unknown`. Keeps the "one signal NOOP actually needs" choice in one place.
+    public var hrvPmdStream: PolarPmdMeasurement? {
+        pmdStreams.contains(.ppi) ? .ppi : nil
+    }
+
+    /// Identify the model from a peripheral's advertised name. Case-insensitive on the "Polar <MODEL>"
+    /// prefix; a non-Polar or unrecognised name resolves to `.unknown` (never a wrong guess). "Polar Sense"
+    /// is the Verity Sense's advertised name (it does NOT advertise "Verity").
+    public static func from(advertisedName name: String?) -> PolarModel {
+        guard let raw = name?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+            return .unknown
+        }
+        let n = raw.lowercased()
+        guard n.hasPrefix("polar ") else { return .unknown }
+        // Order matters only where one name prefixes another; these four don't, so a `contains` on the
+        // model token is enough and tolerant of the trailing serial.
+        if n.contains("h10") { return .h10 }
+        if n.contains("h9") { return .h9 }
+        if n.contains("oh1") { return .oh1 }
+        if n.contains("sense") { return .veritySense }
+        return .unknown
+    }
+}

--- a/Packages/PolarProtocol/Tests/PolarProtocolTests/PmdControlTests.swift
+++ b/Packages/PolarProtocol/Tests/PolarProtocolTests/PmdControlTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import PolarProtocol
+
+/// The PMD control-point command builder + response parse (`PolarPmdControl`). Pure byte work — the
+/// cross-platform contract mirrored by `com.noop.polar.PmdControl`. No CoreBluetooth, no hardware.
+final class PmdControlTests: XCTestCase {
+
+    func testGetSettingsBytes() {
+        XCTAssertEqual(PolarPmdControl.getSettings(.ppi), [0x01, 0x03])
+        XCTAssertEqual(PolarPmdControl.getSettings(.ecg), [0x01, 0x00])
+    }
+
+    func testStartOnlineNoSettings() {
+        // Online streaming (recording=false) → bit 7 clear → the type byte is just the measurement type.
+        XCTAssertEqual(PolarPmdControl.start(.ppi), [0x02, 0x03])
+        XCTAssertEqual(PolarPmdControl.start(.ecg), [0x02, 0x00])
+    }
+
+    func testStartWithSettingsSerialisesU16LEBlocks() {
+        // ACC start with sampleRate=52 Hz + range=8 g → [op, type, {0x00,1,52,0}, {0x02,1,8,0}].
+        let bytes = PolarPmdControl.start(.acc, settings: [
+            .init(.sampleRate, [52]),
+            .init(.range, [8]),
+        ])
+        XCTAssertEqual(bytes, [0x02, 0x02, 0x00, 0x01, 52, 0x00, 0x02, 0x01, 8, 0x00])
+    }
+
+    func testStartRecordingSetsBit7() {
+        // recording=true rides bit 7 of the type byte; ECG(0x00) → 0x80.
+        XCTAssertEqual(PolarPmdControl.start(.ecg, recording: true), [0x02, 0x80])
+        XCTAssertEqual(PolarPmdControl.start(.ppi, recording: true), [0x02, 0x83])
+    }
+
+    func testStopBytes() {
+        XCTAssertEqual(PolarPmdControl.stop(.ppi), [0x03, 0x03])
+    }
+
+    func testParseResponseSuccessAndFailure() {
+        let ok = PolarPmdControl.parseResponse([0xF0, 0x02, 0x03, 0x00, 0x00])
+        XCTAssertEqual(ok?.requestOpcode, 0x02)
+        XCTAssertEqual(ok?.measurement, .ppi)
+        XCTAssertEqual(ok?.status, 0x00)
+        XCTAssertEqual(ok?.isSuccess, true)
+
+        let fail = PolarPmdControl.parseResponse([0xF0, 0x02, 0x03, 0x05])
+        XCTAssertEqual(fail?.isSuccess, false)
+        XCTAssertEqual(fail?.status, 0x05)
+    }
+
+    func testParseResponseRejectsNonResponseFrames() {
+        XCTAssertNil(PolarPmdControl.parseResponse([0x00, 0x02, 0x03, 0x00]))   // not the 0xF0 marker
+        XCTAssertNil(PolarPmdControl.parseResponse([0xF0, 0x02, 0x03]))         // too short
+        XCTAssertNil(PolarPmdControl.parseResponse([]))
+    }
+}

--- a/Packages/PolarProtocol/Tests/PolarProtocolTests/PmdDecoderTests.swift
+++ b/Packages/PolarProtocol/Tests/PolarProtocolTests/PmdDecoderTests.swift
@@ -87,4 +87,12 @@ final class PmdDecoderTests: XCTestCase {
         XCTAssertNotNil(PolarPmdDecoder.header(acc))
         XCTAssertNil(PolarPmdDecoder.decodePPI(acc))
     }
+
+    func testPmdEpochToUnixConversion() {
+        // PMD counts ns since 2000-01-01 UTC, not the Unix epoch; the offset re-bases it to wall clock.
+        XCTAssertEqual(PolarPmdFrameHeader.pmdEpochUnixOffsetNs, 946_684_800_000_000_000)
+        let h = PolarPmdFrameHeader(measurement: .ppi, timestampNs: 1_000_000_000,
+                                    frameType: 0, isCompressed: false)
+        XCTAssertEqual(h.unixTimestampNs, 1_000_000_000 + PolarPmdFrameHeader.pmdEpochUnixOffsetNs)
+    }
 }

--- a/Packages/PolarProtocol/Tests/PolarProtocolTests/PolarModelTests.swift
+++ b/Packages/PolarProtocol/Tests/PolarProtocolTests/PolarModelTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import PolarProtocol
+
+/// Polar model identification + PMD stream capabilities (`PolarModel`). Public-fact catalog; the
+/// cross-platform contract mirrored by `com.noop.polar.PolarModel`.
+final class PolarModelTests: XCTestCase {
+
+    func testIdentifyFromAdvertisedName() {
+        XCTAssertEqual(PolarModel.from(advertisedName: "Polar H10 A1B2C3D4"), .h10)
+        XCTAssertEqual(PolarModel.from(advertisedName: "Polar H9 11223344"), .h9)
+        XCTAssertEqual(PolarModel.from(advertisedName: "Polar OH1 55667788"), .oh1)
+        // Verity Sense advertises "Polar Sense …", never "Verity".
+        XCTAssertEqual(PolarModel.from(advertisedName: "Polar Sense 99AABBCC"), .veritySense)
+        XCTAssertEqual(PolarModel.from(advertisedName: "polar h10 lowercase"), .h10)   // case-insensitive
+    }
+
+    func testUnknownAndNonPolarResolveToUnknown() {
+        XCTAssertEqual(PolarModel.from(advertisedName: "Wahoo TICKR"), .unknown)
+        XCTAssertEqual(PolarModel.from(advertisedName: "Polar Grit X"), .unknown)      // real, but no PMD catalog entry yet
+        XCTAssertEqual(PolarModel.from(advertisedName: nil), .unknown)
+        XCTAssertEqual(PolarModel.from(advertisedName: ""), .unknown)
+    }
+
+    func testPmdStreamsPerModel() {
+        XCTAssertEqual(PolarModel.h10.pmdStreams, [.ecg, .acc])
+        XCTAssertEqual(PolarModel.h9.pmdStreams, [])
+        XCTAssertEqual(PolarModel.oh1.pmdStreams, [.ppg, .ppi, .acc])
+        XCTAssertEqual(PolarModel.veritySense.pmdStreams, [.ppg, .ppi, .acc, .gyro])
+        // OH1 has no gyroscope; Verity Sense does — the one place they diverge.
+        XCTAssertFalse(PolarModel.oh1.pmdStreams.contains(.gyro))
+        XCTAssertTrue(PolarModel.veritySense.pmdStreams.contains(.gyro))
+    }
+
+    func testHrvPmdStreamPicksPpiOnlyWhereExposed() {
+        XCTAssertEqual(PolarModel.veritySense.hrvPmdStream, .ppi)
+        XCTAssertEqual(PolarModel.oh1.hrvPmdStream, .ppi)
+        // H10 / H9 carry R-R on the standard HR service — no PMD PPI stream, so nil (not a guess).
+        XCTAssertNil(PolarModel.h10.hrvPmdStream)
+        XCTAssertNil(PolarModel.h9.hrvPmdStream)
+        XCTAssertNil(PolarModel.unknown.hrvPmdStream)
+    }
+}

--- a/Packages/PolarProtocol/Tests/PolarProtocolTests/PolarModelTests.swift
+++ b/Packages/PolarProtocol/Tests/PolarProtocolTests/PolarModelTests.swift
@@ -39,4 +39,10 @@ final class PolarModelTests: XCTestCase {
         XCTAssertNil(PolarModel.h9.hrvPmdStream)
         XCTAssertNil(PolarModel.unknown.hrvPmdStream)
     }
+
+    func testSerialContainingModelTokenDoesNotMisidentify() {
+        // The matcher anchors on the model position, not a whole-name substring: an OH1 whose serial
+        // happens to contain "h10" must stay an OH1 (a `contains` matcher wrongly returned .h10 here).
+        XCTAssertEqual(PolarModel.from(advertisedName: "Polar OH1 H10ABCDE"), .oh1)
+    }
 }

--- a/android/app/src/main/java/com/noop/polar/PmdControl.kt
+++ b/android/app/src/main/java/com/noop/polar/PmdControl.kt
@@ -1,0 +1,84 @@
+package com.noop.polar
+
+// MARK: - Polar Measurement Data (PMD) CONTROL POINT — clean-room command builder + response parse
+//
+// Faithful Kotlin twin of Packages/PolarProtocol/Sources/PolarProtocol/PmdControl.swift. The PMD Control
+// Point characteristic (FB005C81-…, write + indicate) STARTS / STOPS a measurement stream and reads its
+// supported settings, before data notifications arrive on the Data characteristic (FB005C82-…). Byte
+// layout per docs/DEVICE_SUPPORT_ROADMAP.md §PMD (official polar-ble-sdk, cross-verified) — NOOP's own
+// byte builder, not Polar code.
+//
+// SCOPE: the pure command/response layer only. The android.bluetooth wiring (discover the service, write
+// these bytes, subscribe to the data char, feed PmdDecoder) is the hardware-gated PolarPMDSource still to
+// build. HARDWARE-GATED: the 0xF0 control-point RESPONSE layout is per the SDK but not yet device-confirmed
+// in this repo — no consumer should treat a parsed Response as authoritative until an H10 / Verity settles it.
+
+object PolarPmdControl {
+
+    /** Control-point opcodes — the FIRST byte of a control-point write. */
+    const val OP_GET_MEASUREMENT_SETTINGS = 0x01
+    const val OP_REQUEST_MEASUREMENT_START = 0x02
+    const val OP_STOP_MEASUREMENT = 0x03
+
+    /** Measurement SETTING types inside a start request (`[type, count, u16 LE × count]` blocks). */
+    const val SETTING_SAMPLE_RATE = 0x00
+    const val SETTING_RESOLUTION = 0x01
+    const val SETTING_RANGE = 0x02
+
+    /** The byte the PMD control point prefixes every indicate reply with (§PMD, SDK response frame). */
+    const val RESPONSE_MARKER = 0xF0
+
+    /** One setting block: a type plus its u16 values (little-endian on the wire). */
+    data class Setting(val type: Int, val values: List<Int>)
+
+    /** GET_MEASUREMENT_SETTINGS — ask which settings a measurement supports: `[0x01, measType]`. */
+    fun getSettings(measurement: PolarPmdMeasurement): ByteArray =
+        byteArrayOf(OP_GET_MEASUREMENT_SETTINGS.toByte(), measurement.raw.toByte())
+
+    /**
+     * REQUEST_MEASUREMENT_START — begin a stream: `[0x02, (recording shl 7) or measType, settingBlocks…]`.
+     * recording=false (online streaming — what NOOP uses) leaves bit 7 clear. Each setting serialises as
+     * `[type, count, lo, hi, …]` with u16 LE values.
+     */
+    fun start(
+        measurement: PolarPmdMeasurement,
+        recording: Boolean = false,
+        settings: List<Setting> = emptyList(),
+    ): ByteArray {
+        val out = ArrayList<Byte>()
+        out.add(OP_REQUEST_MEASUREMENT_START.toByte())
+        out.add((((if (recording) 0x80 else 0x00) or (measurement.raw and 0x7F)).toByte()))
+        for (s in settings) {
+            out.add(s.type.toByte())
+            out.add(s.values.size.toByte())
+            for (v in s.values) {
+                out.add((v and 0xFF).toByte())
+                out.add(((v shr 8) and 0xFF).toByte())
+            }
+        }
+        return out.toByteArray()
+    }
+
+    /** STOP_MEASUREMENT — end a stream: `[0x03, measType]`. */
+    fun stop(measurement: PolarPmdMeasurement): ByteArray =
+        byteArrayOf(OP_STOP_MEASUREMENT.toByte(), measurement.raw.toByte())
+
+    /**
+     * The control-point indicate reply `[0xF0, reqOpcode, measType, status, …]`. status==0 is success;
+     * the rest (a "more" flag + GET_SETTINGS param blocks) is not parsed here. measurement is null when the
+     * reply names a type NOOP doesn't recognise.
+     */
+    data class Response(val requestOpcode: Int, val measurement: PolarPmdMeasurement?, val status: Int) {
+        val isSuccess: Boolean get() = status == 0x00
+    }
+
+    /** Parse a control-point indicate reply, or null when too short / not a control-point response. */
+    fun parseResponse(data: ByteArray): Response? {
+        if (data.size < 4 || (data[0].toInt() and 0xFF) != RESPONSE_MARKER) return null
+        return Response(
+            requestOpcode = data[1].toInt() and 0xFF,
+            measurement = PolarPmdMeasurement.fromRaw(data[2].toInt() and 0x3F),
+            status = data[3].toInt() and 0xFF,
+        )
+    }
+}

--- a/android/app/src/main/java/com/noop/polar/PmdDecoder.kt
+++ b/android/app/src/main/java/com/noop/polar/PmdDecoder.kt
@@ -7,7 +7,8 @@ package com.noop.polar
 // parser of the documented byte layout — no Polar code, no firmware, nothing fabricated.
 //
 // PMD data notifications share a 10-byte header: byte 0 = measurement type, bytes 1..8 = timestamp
-// (uint64 LE ns, of the last sample), byte 9 = frame type (bit 7 = compressed flag; bits 0..6 = format).
+// (uint64 LE ns since 2000-01-01 UTC — the PMD epoch, NOT Unix — of the last sample), byte 9 = frame type
+// (bit 7 = compressed flag; bits 0..6 = format).
 // This decodes the PPI stream (0x03): heart rate + peak-to-peak (inter-beat) interval per beat — NOOP's
 // HRV input, the same signal WHOOP R-R gives — so a Polar H10 / OH1 / Verity Sense needs no ECG peak
 // detection. PPI is never compressed: each sample is a fixed 6-byte record (hr u8, ppi u16 LE, error u16
@@ -30,13 +31,25 @@ enum class PolarPmdMeasurement(val raw: Int) {
 /** The parsed 10-byte PMD data-frame header, common to every measurement type. */
 data class PolarPmdFrameHeader(
     val measurement: PolarPmdMeasurement,
-    /** Frame timestamp in nanoseconds (applies to the last sample in the frame). */
+    /** Frame timestamp in nanoseconds since **2000-01-01 UTC** — the PMD epoch, NOT the Unix epoch (a raw
+     *  read is ~30 years behind wall clock). Applies to the last sample in the frame. Use [unixTimestampNs]
+     *  for wall clock. Only load-bearing for the fixed-rate streams (ECG/ACC/PPG) when those land — for PPI,
+     *  samples are event-based and callers timestamp on arrival. */
     val timestampNs: Long,
     /** The data-format id (frame type bits 0..6). */
     val frameType: Int,
     /** True when the compressed/delta bit (0x80) is set on the frame-type byte. */
     val isCompressed: Boolean,
-)
+) {
+    /** [timestampNs] re-based to the Unix epoch (ns since 1970-01-01 UTC), for wall-clock use. */
+    val unixTimestampNs: Long get() = timestampNs + PMD_EPOCH_UNIX_OFFSET_NS
+
+    companion object {
+        /** Nanoseconds between the Unix epoch (1970-01-01) and the PMD epoch (2000-01-01): 946 684 800 s.
+         *  Add to a PMD [timestampNs] to re-base it onto the Unix epoch. */
+        const val PMD_EPOCH_UNIX_OFFSET_NS: Long = 946_684_800_000_000_000L
+    }
+}
 
 /** One decoded PPI (peak-to-peak interval) sample. */
 data class PolarPpiSample(

--- a/android/app/src/main/java/com/noop/polar/PolarModel.kt
+++ b/android/app/src/main/java/com/noop/polar/PolarModel.kt
@@ -53,11 +53,14 @@ enum class PolarModel {
             if (raw.isEmpty()) return UNKNOWN
             val n = raw.lowercase()
             if (!n.startsWith("polar ")) return UNKNOWN
+            // Anchor on the model token — the word right after "Polar " — NOT a substring of the whole
+            // name, so a device whose serial happened to carry a model token (e.g. a "Polar OH1 H10…"
+            // serial matching h10) can't misidentify. startsWith is also order-independent here.
             return when {
-                n.contains("h10") -> H10
-                n.contains("h9") -> H9
-                n.contains("oh1") -> OH1
-                n.contains("sense") -> VERITY_SENSE
+                n.startsWith("polar h10") -> H10
+                n.startsWith("polar h9") -> H9
+                n.startsWith("polar oh1") -> OH1
+                n.startsWith("polar sense") -> VERITY_SENSE
                 else -> UNKNOWN
             }
         }

--- a/android/app/src/main/java/com/noop/polar/PolarModel.kt
+++ b/android/app/src/main/java/com/noop/polar/PolarModel.kt
@@ -1,0 +1,65 @@
+package com.noop.polar
+
+// MARK: - Polar model identification + PMD stream capability catalog (clean-room, public facts)
+//
+// Faithful Kotlin twin of Packages/PolarProtocol/Sources/PolarProtocol/PolarModel.swift. A Polar sensor
+// advertises a stable BLE name "Polar <MODEL> <serial>" (public); this maps that to the model and the PMD
+// streams it is documented to expose, so a future PolarPMDSource picks the right measurement per device
+// (PPI for HRV on the optical bands; ECG on the H10) instead of probing blindly. R-R for HRV also arrives
+// on the standard HR service (0x180D) for every model — that path already ships — so a model with no PMD
+// entry is still a first-class HR/R-R source.
+//
+// Facts only: model names are public product identifiers; per-model PMD stream sets are from
+// docs/DEVICE_SUPPORT_ROADMAP.md §PMD (official polar-ble-sdk). HARDWARE-GATED: confirm capabilities on a
+// real device before gating behaviour. OH1 vs Verity Sense diverge on the gyroscope (Verity has the 9-axis
+// IMU; OH1 does not).
+
+enum class PolarModel {
+    /** Chest strap: ECG + ACC over PMD, plus HR + R-R on the standard service. No optical. */
+    H10,
+    /** Chest strap: HR + R-R on the standard service only (no PMD service). */
+    H9,
+    /** Optical armband: PPG + PPI + ACC over PMD, plus HR. No ECG, no gyroscope. */
+    OH1,
+    /** Optical armband (Verity Sense): PPG + PPI + ACC + GYRO over PMD, plus HR. No ECG. */
+    VERITY_SENSE,
+    /** Unrecognised Polar device. Still a standard HR/R-R strap; PMD streams unknown — probe, don't assume. */
+    UNKNOWN;
+
+    /** The PMD measurement streams this model is documented to expose. Empty for HR-only (H9) / UNKNOWN. */
+    val pmdStreams: Set<PolarPmdMeasurement>
+        get() = when (this) {
+            H10 -> setOf(PolarPmdMeasurement.ECG, PolarPmdMeasurement.ACC)
+            H9 -> emptySet()
+            OH1 -> setOf(PolarPmdMeasurement.PPG, PolarPmdMeasurement.PPI, PolarPmdMeasurement.ACC)
+            VERITY_SENSE -> setOf(
+                PolarPmdMeasurement.PPG, PolarPmdMeasurement.PPI,
+                PolarPmdMeasurement.ACC, PolarPmdMeasurement.GYRO,
+            )
+            UNKNOWN -> emptySet()
+        }
+
+    /** The PMD measurement NOOP would request for HRV: PPI where the optical bands expose it, else null
+     *  (H10/H9 R-R comes off the standard HR service — no PMD needed). */
+    val hrvPmdStream: PolarPmdMeasurement?
+        get() = if (pmdStreams.contains(PolarPmdMeasurement.PPI)) PolarPmdMeasurement.PPI else null
+
+    companion object {
+        /** Identify the model from a peripheral's advertised name (case-insensitive on the "Polar <MODEL>"
+         *  prefix). A non-Polar or unrecognised name → UNKNOWN. "Polar Sense" is the Verity Sense's
+         *  advertised name (it does NOT advertise "Verity"). */
+        fun fromAdvertisedName(name: String?): PolarModel {
+            val raw = name?.trim().orEmpty()
+            if (raw.isEmpty()) return UNKNOWN
+            val n = raw.lowercase()
+            if (!n.startsWith("polar ")) return UNKNOWN
+            return when {
+                n.contains("h10") -> H10
+                n.contains("h9") -> H9
+                n.contains("oh1") -> OH1
+                n.contains("sense") -> VERITY_SENSE
+                else -> UNKNOWN
+            }
+        }
+    }
+}

--- a/android/app/src/test/java/com/noop/polar/PmdControlTest.kt
+++ b/android/app/src/test/java/com/noop/polar/PmdControlTest.kt
@@ -1,0 +1,61 @@
+package com.noop.polar
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Kotlin parity for PolarProtocol/Tests/.../PmdControlTests.swift — the PMD control-point command
+ *  builder + response parse. Pure byte work, no android.bluetooth. */
+class PmdControlTest {
+
+    @Test fun getSettingsBytes() {
+        assertArrayEquals(byteArrayOf(0x01, 0x03), PolarPmdControl.getSettings(PolarPmdMeasurement.PPI))
+        assertArrayEquals(byteArrayOf(0x01, 0x00), PolarPmdControl.getSettings(PolarPmdMeasurement.ECG))
+    }
+
+    @Test fun startOnlineNoSettings() {
+        assertArrayEquals(byteArrayOf(0x02, 0x03), PolarPmdControl.start(PolarPmdMeasurement.PPI))
+        assertArrayEquals(byteArrayOf(0x02, 0x00), PolarPmdControl.start(PolarPmdMeasurement.ECG))
+    }
+
+    @Test fun startWithSettingsSerialisesU16LEBlocks() {
+        val bytes = PolarPmdControl.start(
+            PolarPmdMeasurement.ACC,
+            settings = listOf(
+                PolarPmdControl.Setting(PolarPmdControl.SETTING_SAMPLE_RATE, listOf(52)),
+                PolarPmdControl.Setting(PolarPmdControl.SETTING_RANGE, listOf(8)),
+            ),
+        )
+        assertArrayEquals(byteArrayOf(0x02, 0x02, 0x00, 0x01, 52, 0x00, 0x02, 0x01, 8, 0x00), bytes)
+    }
+
+    @Test fun startRecordingSetsBit7() {
+        assertArrayEquals(byteArrayOf(0x02, 0x80.toByte()), PolarPmdControl.start(PolarPmdMeasurement.ECG, recording = true))
+        assertArrayEquals(byteArrayOf(0x02, 0x83.toByte()), PolarPmdControl.start(PolarPmdMeasurement.PPI, recording = true))
+    }
+
+    @Test fun stopBytes() {
+        assertArrayEquals(byteArrayOf(0x03, 0x03), PolarPmdControl.stop(PolarPmdMeasurement.PPI))
+    }
+
+    @Test fun parseResponseSuccessAndFailure() {
+        val ok = PolarPmdControl.parseResponse(byteArrayOf(0xF0.toByte(), 0x02, 0x03, 0x00, 0x00))!!
+        assertEquals(0x02, ok.requestOpcode)
+        assertEquals(PolarPmdMeasurement.PPI, ok.measurement)
+        assertEquals(0x00, ok.status)
+        assertTrue(ok.isSuccess)
+
+        val fail = PolarPmdControl.parseResponse(byteArrayOf(0xF0.toByte(), 0x02, 0x03, 0x05))!!
+        assertFalse(fail.isSuccess)
+        assertEquals(0x05, fail.status)
+    }
+
+    @Test fun parseResponseRejectsNonResponseFrames() {
+        assertNull(PolarPmdControl.parseResponse(byteArrayOf(0x00, 0x02, 0x03, 0x00)))
+        assertNull(PolarPmdControl.parseResponse(byteArrayOf(0xF0.toByte(), 0x02, 0x03)))
+        assertNull(PolarPmdControl.parseResponse(byteArrayOf()))
+    }
+}

--- a/android/app/src/test/java/com/noop/polar/PmdDecoderTest.kt
+++ b/android/app/src/test/java/com/noop/polar/PmdDecoderTest.kt
@@ -95,4 +95,11 @@ class PmdDecoderTest {
         assertNotNull(PmdDecoder.header(acc))
         assertNull(PmdDecoder.decodePPI(acc))
     }
+
+    @Test fun pmdEpochToUnixConversion() {
+        // PMD counts ns since 2000-01-01 UTC, not the Unix epoch; the offset re-bases it to wall clock.
+        assertEquals(946_684_800_000_000_000L, PolarPmdFrameHeader.PMD_EPOCH_UNIX_OFFSET_NS)
+        val h = PolarPmdFrameHeader(PolarPmdMeasurement.PPI, 1_000_000_000L, 0, false)
+        assertEquals(1_000_000_000L + PolarPmdFrameHeader.PMD_EPOCH_UNIX_OFFSET_NS, h.unixTimestampNs)
+    }
 }

--- a/android/app/src/test/java/com/noop/polar/PolarModelTest.kt
+++ b/android/app/src/test/java/com/noop/polar/PolarModelTest.kt
@@ -44,4 +44,10 @@ class PolarModelTest {
         assertNull(PolarModel.H9.hrvPmdStream)
         assertNull(PolarModel.UNKNOWN.hrvPmdStream)
     }
+
+    @Test fun serialContainingModelTokenDoesNotMisidentify() {
+        // The matcher anchors on the model position, not a whole-name substring: an OH1 whose serial
+        // happens to contain "h10" must stay an OH1 (a `contains` matcher wrongly returned H10 here).
+        assertEquals(PolarModel.OH1, PolarModel.fromAdvertisedName("Polar OH1 H10ABCDE"))
+    }
 }

--- a/android/app/src/test/java/com/noop/polar/PolarModelTest.kt
+++ b/android/app/src/test/java/com/noop/polar/PolarModelTest.kt
@@ -1,0 +1,47 @@
+package com.noop.polar
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Kotlin parity for PolarProtocol/Tests/.../PolarModelTests.swift — Polar model identification + PMD
+ *  stream capabilities. */
+class PolarModelTest {
+
+    @Test fun identifyFromAdvertisedName() {
+        assertEquals(PolarModel.H10, PolarModel.fromAdvertisedName("Polar H10 A1B2C3D4"))
+        assertEquals(PolarModel.H9, PolarModel.fromAdvertisedName("Polar H9 11223344"))
+        assertEquals(PolarModel.OH1, PolarModel.fromAdvertisedName("Polar OH1 55667788"))
+        assertEquals(PolarModel.VERITY_SENSE, PolarModel.fromAdvertisedName("Polar Sense 99AABBCC"))
+        assertEquals(PolarModel.H10, PolarModel.fromAdvertisedName("polar h10 lowercase"))
+    }
+
+    @Test fun unknownAndNonPolarResolveToUnknown() {
+        assertEquals(PolarModel.UNKNOWN, PolarModel.fromAdvertisedName("Wahoo TICKR"))
+        assertEquals(PolarModel.UNKNOWN, PolarModel.fromAdvertisedName("Polar Grit X"))
+        assertEquals(PolarModel.UNKNOWN, PolarModel.fromAdvertisedName(null))
+        assertEquals(PolarModel.UNKNOWN, PolarModel.fromAdvertisedName(""))
+    }
+
+    @Test fun pmdStreamsPerModel() {
+        assertEquals(setOf(PolarPmdMeasurement.ECG, PolarPmdMeasurement.ACC), PolarModel.H10.pmdStreams)
+        assertEquals(emptySet<PolarPmdMeasurement>(), PolarModel.H9.pmdStreams)
+        assertEquals(
+            setOf(PolarPmdMeasurement.PPG, PolarPmdMeasurement.PPI, PolarPmdMeasurement.ACC),
+            PolarModel.OH1.pmdStreams,
+        )
+        // OH1 has no gyroscope; Verity Sense does — the one place they diverge.
+        assertFalse(PolarModel.OH1.pmdStreams.contains(PolarPmdMeasurement.GYRO))
+        assertTrue(PolarModel.VERITY_SENSE.pmdStreams.contains(PolarPmdMeasurement.GYRO))
+    }
+
+    @Test fun hrvPmdStreamPicksPpiOnlyWhereExposed() {
+        assertEquals(PolarPmdMeasurement.PPI, PolarModel.VERITY_SENSE.hrvPmdStream)
+        assertEquals(PolarPmdMeasurement.PPI, PolarModel.OH1.hrvPmdStream)
+        assertNull(PolarModel.H10.hrvPmdStream)
+        assertNull(PolarModel.H9.hrvPmdStream)
+        assertNull(PolarModel.UNKNOWN.hrvPmdStream)
+    }
+}

--- a/docs/DEVICE_SUPPORT_ROADMAP.md
+++ b/docs/DEVICE_SUPPORT_ROADMAP.md
@@ -39,14 +39,29 @@ Polar H10 / Verity Sense / OH1 the user owns, account-free, on top of the standa
 - **Per-model streams:** **H10** = ECG (130 Hz) + ACC + HR + RR (no PPG); **Verity Sense / OH1** =
   PPG + PPI + ACC + GYRO + HR (no ECG).
 
-**Decoder status.** The pure PPI decoder is built and tested on both platforms
-(`Packages/PolarProtocol` / `com.noop.polar.PmdDecoder`): frame header (type `& 0x3F`, ns timestamp,
-frame-type/compressed bit) + PPI samples (HR + peak-to-peak interval + error estimate + flags). PPI is
-the one NOOP needs — HR + inter-beat interval for HRV, no ECG peak detection required. **Still to build:**
-the live `PolarPMDSource: LiveHRSource` (CoreBluetooth / android.bluetooth — hardware-gated, validate on
-an H10/Verity), and ECG/PPG/ACC decode if ever needed. **Confirm on hardware:** the PPI flags' bit1/bit2
-skin-contact polarity — the decoder names them per the Polar SDK, but this doc phrases them oppositely, so
-no consumer should gate on them until a real device settles it.
+- **Control-point response:** the control point INDICATES a reply prefixed `0xF0`:
+  `[0xF0, requestOpcode, measType, status, more, params…]`, `status == 0` = success (a GET_SETTINGS reply
+  then carries the supported setting blocks in `params`). SDK layout — **confirm on hardware** before any
+  consumer trusts a parsed status.
+- **Model catalog (public advertised names → PMD streams):** **H10** `Polar H10 …` = ECG + ACC (R-R on the
+  standard HR service); **H9** `Polar H9 …` = HR + R-R only, no PMD; **OH1** `Polar OH1 …` = PPG + PPI + ACC
+  (no gyroscope); **Verity Sense** `Polar Sense …` = PPG + PPI + ACC + GYRO. R-R for HRV also arrives on the
+  standard HR service for every model, so a no-PMD model is still a first-class HR/R-R source.
+
+**Decoder status.** Built and tested on both platforms (`Packages/PolarProtocol` / `com.noop.polar`):
+- `PmdDecoder` — frame header (type `& 0x3F`, ns timestamp, frame-type/compressed bit) + PPI samples (HR +
+  peak-to-peak interval + error estimate + flags). PPI is the one NOOP needs — HR + inter-beat interval for
+  HRV, no ECG peak detection.
+- `PmdControl` — the control-point command builder (GET_SETTINGS / REQUEST_START / STOP, u16-LE setting
+  blocks, the `(recording<<7)|type` start byte) + `0xF0` response parse. Pure byte work, no BLE.
+- `PolarModel` — advertised-name → model + per-model PMD stream capabilities (the catalog above).
+
+**Still to build:** the live `PolarPMDSource: LiveHRSource` (CoreBluetooth / android.bluetooth — a thin
+wrapper: discover the PMD service, write `PmdControl.start(model.hrvPmdStream)`, subscribe to the data
+char, feed `PmdDecoder`; hardware-gated, validate on an H10/Verity), plus ECG/PPG/ACC decode if ever needed.
+**Confirm on hardware:** (1) the PPI flags' bit1/bit2 skin-contact polarity — the decoder names them per the
+Polar SDK, but this doc phrases them oppositely; (2) the `0xF0` control-point response layout. No consumer
+should gate on either until a real device settles it.
 
 **Open item — #421** ("Polar H10 paired, no live data", Android): the generic-HR plumbing is correct
 (CCCD write + both notification callbacks); the leading theory is the WHOOP auto-reconnect reclaiming


### PR DESCRIPTION
Advances the Polar deep-stream (PMD) roadmap item with the pure, testable pieces the live `PolarPMDSource` will need.

## Provenance (the important part)
Clean-room from the **official `polarofficial/polar-ble-sdk`** — the same authoritative source `PmdDecoder` already used — **not** from any GPL third-party app. This follows the project's own documented stance (roadmap: *"Gadgetbridge-informed, never GPLv3 copy"*): facts are re-derived from the primary source; no incompatible-licensed code crosses in.

## What's here
- **`PolarPmdControl`** (`PolarProtocol` / `com.noop.polar`) — the control-point command builder: `getSettings` / `start` / `stop`, the `(recording<<7)|type` start byte, u16-LE setting blocks, plus the `0xF0` indicate-response parse (status). Pure byte work, no CoreBluetooth / android.bluetooth.
- **`PolarModel`** — advertised-name → model (`H10` / `H9` / `OH1` / `Verity Sense`) + per-model PMD stream capabilities, so a source requests the right measurement (PPI for HRV on the optical bands, ECG on the H10) instead of probing blindly. OH1 vs Verity Sense correctly diverge on the gyroscope. R-R for HRV still arrives on the standard HR service for every model (that path already ships), so a no-PMD model stays a first-class HR/R-R source.

## Why just these two
This is the slice that's **buildable and validatable without hardware**. The remaining PMD gap is the live `PolarPMDSource` — a thin BLE wrapper (discover the PMD service, write `PmdControl.start(model.hrvPmdStream)`, subscribe to the data char, feed `PmdDecoder`) — which is genuinely hardware-gated and must be validated on a real H10 / Verity Sense. Putting the byte work here (like `PmdDecoder`) keeps that wrapper thin.

## Verification
- Swift `PolarProtocol` — **`swift test` 20/20** (7 control + 4 model + 9 existing decoder), run locally.
- Android `com.noop.polar` — **20/20** (byte-identical Swift/Kotlin: same expected bytes in the tests).
- doc-lint clean. Package + non-UI Android only → no app-target Swift, so default CI (`test (PolarProtocol)`) is genuine coverage; no app-build gate.

## Alpha / hardware-gated (flagged in code + roadmap)
The `0xF0` control-point response layout and the PPI skin-contact flag polarity are per the SDK but **not yet device-confirmed** — no consumer gates on them, and `PolarPMDSource` (which would exercise them) is still to build. Roadmap §PMD updated with the response format + model catalog.
