### PR TITLE
feat(ble): order the discovered HR-strap list by proximity (strongest RSSI first)

### DIFF
--- a/Strand/BLE/StandardHRSource.swift
+++ b/Strand/BLE/StandardHRSource.swift
@@ -26,8 +26,26 @@ public final class StandardHRSource: NSObject, ObservableObject {
         public let rssi: Int
     }
 
-    /// Straps discovered during the current scan, keyed by peripheral identifier.
+    /// Straps discovered during the current scan, keyed by peripheral identifier, ordered by proximity —
+    /// strongest signal (closest) FIRST — so the strap the user is standing next to surfaces at the top of
+    /// a crowded gym list. Maintained by `upsertByProximity`.
     @Published public private(set) var discovered: [DiscoveredStrap] = []
+
+    /// Upsert a freshly-seen strap into the discovered list (same peripheral id updates in place with the
+    /// newest RSSI) and keep it ordered by proximity — strongest RSSI first. Pure so the dedup + ordering
+    /// contract is unit-testable without CoreBluetooth. Live RSSI is noisy, so a busy list can reorder as
+    /// signals fluctuate; that's the accepted cost of "closest first" and matches every BLE scanner UI.
+    static func upsertByProximity(_ list: [DiscoveredStrap], _ strap: DiscoveredStrap) -> [DiscoveredStrap] {
+        var out = list
+        if let idx = out.firstIndex(where: { $0.id == strap.id }) {
+            out[idx] = strap
+        } else {
+            out.append(strap)
+        }
+        // Stable descending by RSSI: a higher (less negative) dBm is closer. `sorted` is a stable sort in
+        // Swift, so straps at equal RSSI keep their existing relative order (no needless churn).
+        return out.sorted { $0.rssi > $1.rssi }
+    }
     /// True while a scan is running (UI affordance).
     @Published public private(set) var scanning: Bool = false
     /// The connected strap's standard Battery Service (0x180F) level, 0–100, once read. nil until then
@@ -275,11 +293,7 @@ extension StandardHRSource: @preconcurrency CBCentralManagerDelegate {
         let name = advName ?? peripheral.name ?? "Heart Rate Strap"
         if firstSight { log("HR-strap: found \(name) (\(id)) rssi \(RSSI.intValue)") }
         let strap = DiscoveredStrap(id: id, name: name, rssi: RSSI.intValue)
-        if let idx = discovered.firstIndex(where: { $0.id == id }) {
-            discovered[idx] = strap
-        } else {
-            discovered.append(strap)
-        }
+        discovered = Self.upsertByProximity(discovered, strap)
         // If we were scanning specifically to reach this strap (a not-yet-cached active strap), connect now
         // that it's been seen — the switchToStrap path (#421).
         if pendingConnectID == id {

--- a/Strand/BLE/StandardHRSource.swift
+++ b/Strand/BLE/StandardHRSource.swift
@@ -35,7 +35,7 @@ public final class StandardHRSource: NSObject, ObservableObject {
     /// newest RSSI) and keep it ordered by proximity — strongest RSSI first. Pure so the dedup + ordering
     /// contract is unit-testable without CoreBluetooth. Live RSSI is noisy, so a busy list can reorder as
     /// signals fluctuate; that's the accepted cost of "closest first" and matches every BLE scanner UI.
-    static func upsertByProximity(_ list: [DiscoveredStrap], _ strap: DiscoveredStrap) -> [DiscoveredStrap] {
+    nonisolated static func upsertByProximity(_ list: [DiscoveredStrap], _ strap: DiscoveredStrap) -> [DiscoveredStrap] {
         var out = list
         if let idx = out.firstIndex(where: { $0.id == strap.id }) {
             out[idx] = strap

--- a/StrandTests/StandardHRProximityTests.swift
+++ b/StrandTests/StandardHRProximityTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import Strand
+
+/// Proximity ordering + dedup of the standard-HR discovery list (`StandardHRSource.upsertByProximity`):
+/// strongest RSSI first, and the same peripheral updates in place. Pure — no CoreBluetooth. Twin of the
+/// Kotlin `StandardHrProximityTest`.
+final class StandardHRProximityTests: XCTestCase {
+
+    private func strap(_ id: UUID, _ rssi: Int) -> StandardHRSource.DiscoveredStrap {
+        StandardHRSource.DiscoveredStrap(id: id, name: "s", rssi: rssi)
+    }
+
+    func testSortsByProximityStrongestFirst() {
+        let a = UUID(), b = UUID(), c = UUID()
+        var list: [StandardHRSource.DiscoveredStrap] = []
+        list = StandardHRSource.upsertByProximity(list, strap(a, -80))
+        list = StandardHRSource.upsertByProximity(list, strap(b, -50))
+        list = StandardHRSource.upsertByProximity(list, strap(c, -65))
+        XCTAssertEqual(list.map(\.id), [b, c, a])   // -50 > -65 > -80 → closest first
+    }
+
+    func testSamePeripheralUpdatesInPlaceWithNewestRssiAndReorders() {
+        let a = UUID(), b = UUID()
+        var list: [StandardHRSource.DiscoveredStrap] = []
+        list = StandardHRSource.upsertByProximity(list, strap(a, -80))
+        list = StandardHRSource.upsertByProximity(list, strap(b, -60))
+        list = StandardHRSource.upsertByProximity(list, strap(a, -40))   // A re-seen, now closer
+        XCTAssertEqual(list.count, 2)                                    // updated in place, no duplicate
+        XCTAssertEqual(list.map(\.id), [a, b])                           // A jumps ahead of B
+        XCTAssertEqual(list.first(where: { $0.id == a })?.rssi, -40)     // newest RSSI kept
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
+++ b/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
@@ -272,10 +272,7 @@ class StandardHrSource(
                 ?: "Heart Rate Strap"
             if (firstSight) log("HR-strap: found $name ($address) rssi ${result.rssi}")
             val strap = DiscoveredStrap(address = address, name = name, rssi = result.rssi)
-            val list = _discovered.value.toMutableList()
-            val i = list.indexOfFirst { it.address == address }
-            if (i >= 0) list[i] = strap else list.add(strap)
-            _discovered.value = list
+            _discovered.value = upsertByProximity(_discovered.value, strap)
             // Replay a connect intent that arrived before the device was discovered.
             if (pendingConnectAddress == address) {
                 pendingConnectAddress = null
@@ -512,6 +509,18 @@ class StandardHrSource(
     }
 
     companion object {
+        /** Upsert a freshly-seen strap into the discovered list (same address updates in place with the
+         *  newest RSSI) and keep it ordered by proximity — strongest RSSI (closest) FIRST — so the strap
+         *  the user is next to surfaces at the top of a crowded gym list. Pure so the dedup + ordering
+         *  contract is unit-testable without android.bluetooth. `sortedByDescending` is stable, so straps
+         *  at equal RSSI keep their relative order (no needless churn). Twin of the Swift helper. */
+        fun upsertByProximity(list: List<DiscoveredStrap>, strap: DiscoveredStrap): List<DiscoveredStrap> {
+            val out = list.toMutableList()
+            val idx = out.indexOfFirst { it.address == strap.address }
+            if (idx >= 0) out[idx] = strap else out.add(strap)
+            return out.sortedByDescending { it.rssi }
+        }
+
         /** Standard BLE Heart Rate service + measurement characteristic + the CCCD. */
         val HEART_RATE_SERVICE: UUID = UUID.fromString("0000180d-0000-1000-8000-00805f9b34fb")
         val HEART_RATE_CHAR: UUID = UUID.fromString("00002a37-0000-1000-8000-00805f9b34fb")

--- a/android/app/src/test/java/com/noop/ble/StandardHrProximityTest.kt
+++ b/android/app/src/test/java/com/noop/ble/StandardHrProximityTest.kt
@@ -1,0 +1,28 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Proximity ordering + dedup of the standard-HR discovery list (`StandardHrSource.upsertByProximity`):
+ *  strongest RSSI first, same address updates in place. Pure — no android.bluetooth. Twin of the Swift
+ *  `StandardHRProximityTests`. */
+class StandardHrProximityTest {
+
+    private fun strap(addr: String, rssi: Int) = StandardHrSource.DiscoveredStrap(addr, "s-$addr", rssi)
+
+    @Test fun sortsByProximityStrongestFirst() {
+        var list = StandardHrSource.upsertByProximity(emptyList(), strap("A", -80))
+        list = StandardHrSource.upsertByProximity(list, strap("B", -50))
+        list = StandardHrSource.upsertByProximity(list, strap("C", -65))
+        assertEquals(listOf("B", "C", "A"), list.map { it.address })   // -50 > -65 > -80 → closest first
+    }
+
+    @Test fun sameAddressUpdatesInPlaceWithNewestRssiAndReorders() {
+        var list = StandardHrSource.upsertByProximity(emptyList(), strap("A", -80))
+        list = StandardHrSource.upsertByProximity(list, strap("B", -60))
+        list = StandardHrSource.upsertByProximity(list, strap("A", -40))   // A re-seen, now closer
+        assertEquals(2, list.size)                                         // updated in place, no duplicate
+        assertEquals(listOf("A", "B"), list.map { it.address })            // A jumps ahead of B
+        assertEquals(-40, list.first { it.address == "A" }.rssi)           // newest RSSI kept
+    }
+}


### PR DESCRIPTION
## What
The standard-HR strap scan listed discovered straps in **discovery order**, so in a gym with several straps advertising, the one you're standing next to wasn't surfaced first. Now the list is **ordered by RSSI descending — closest first**.

Generic by design: this benefits **every `0x180D` strap** (Polar, Wahoo, Coospo, Garmin HRM, Amazfit Helio broadcast), not just Polar — it came out of the Polar-scanning review but isn't Polar-specific.

## How
Extracted a pure `upsertByProximity(list, strap)` on both platforms — upsert by peripheral id / address (same device updates in place with the newest RSSI), then sort by RSSI. Pure, so the dedup + ordering contract is unit-testable without CoreBluetooth / android.bluetooth. Stable sort → straps at equal RSSI keep their order (no churn); live RSSI is noisy, so a busy list can still reorder as signals move — the accepted cost of "closest first", and what every BLE scanner UI does.

## Verification
- Byte-identical Swift (`StandardHRSource`) / Kotlin (`StandardHrSource`) helper.
- Tests both platforms (sort order + same-device-updates-in-place-and-reorders). **Android 2/2 green** (run locally); the Swift twin (`StrandTests`) runs under the **app-build gate** (StandardHRSource is app-target Swift — default CI doesn't compile the app targets).
- doc-lint clean; no new UI strings.

No scanning behavior changes beyond the display order — same services scanned, same connect path.
