### PR TITLE
Let users hide cycle awareness entirely (a private choice, never age-based)

### DIFF
--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -1656,6 +1656,16 @@ final class AppModel: ObservableObject {
         set { UserDefaults.standard.set(newValue, forKey: Self.cycleAwarenessKey) }
     }
 
+    /// The user's "not for me" opt-out of cycle awareness — a respectful, USER-controlled hide, never
+    /// age-based (menopause age varies too widely to infer). When true, the cycle-awareness OFFER is
+    /// suppressed on Today and Health; the Automations toggle stays visible so it's reversible. Default
+    /// false. Distinct from `cycleAwarenessEnabled` (active tracking): this hides the invitation itself.
+    static let cycleAwarenessHiddenKey = "noopCycleAwarenessHidden"
+    var cycleAwarenessHidden: Bool {
+        get { UserDefaults.standard.bool(forKey: Self.cycleAwarenessHiddenKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Self.cycleAwarenessHiddenKey) }
+    }
+
     /// Recompute the v5 skin-temp suite snapshots (cycle phase + body clock) from the current history.
     /// Called from the analytics pass and when the cycle opt-in flips. Honest-nil throughout: cycle is
     /// nil unless opted in; circadian is nil unless a usable activity profile exists.

--- a/Strand/Data/Profile.swift
+++ b/Strand/Data/Profile.swift
@@ -234,6 +234,13 @@ final class ProfileStore: ObservableObject {
         sex.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() != "male"
     }
 
+    /// Whether the cycle-awareness OFFER should be VISIBLE for a profile: eligible by sex AND not hidden
+    /// by the user's "not for me" opt-out. `hidden` is USER-controlled and never age-derived — a
+    /// respectful hide, not an assumption about menopause. Pure, so the combined gate is unit-testable.
+    nonisolated static func cycleAwarenessVisible(sex: String, hidden: Bool) -> Bool {
+        cycleAwarenessApplies(sex: sex) && !hidden
+    }
+
     /// Allowed range for the step-calibration divisor (#132). 5/MG straps overcount by
     /// up to ~24×, so the old 4.0 ceiling could never reach the truth.
     static let stepScaleRange: ClosedRange<Double> = 0.5...30.0

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -199966,6 +199966,122 @@
           }
         }
       }
+    },
+    "Show cycle awareness": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zyklusbewusstsein anzeigen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar conciencia del ciclo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher la conscience du cycle"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra consapevolezza del ciclo"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokaż świadomość cyklu"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar consciência do ciclo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показывать осведомлённость о цикле"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示周期感知"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示週期感知"
+          }
+        }
+      }
+    },
+    "Shows the cycle-awareness card on Today and in Health. Turn off to hide it entirely — a private choice, never based on your age. You can turn it back on here any time.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeigt die Zyklus-Karte auf „Heute“ und in „Gesundheit“. Schalte sie aus, um sie ganz auszublenden – eine private Entscheidung, nie auf Basis deines Alters. Du kannst sie hier jederzeit wieder einschalten."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muestra la tarjeta del ciclo en Hoy y en Salud. Desactívala para ocultarla por completo: una decisión privada, nunca basada en tu edad. Puedes volver a activarla aquí cuando quieras."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Affiche la carte de suivi du cycle dans Aujourd’hui et Santé. Désactivez-la pour la masquer entièrement — un choix privé, jamais basé sur votre âge. Vous pouvez la réactiver ici à tout moment."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra la scheda del ciclo in Oggi e in Salute. Disattivala per nasconderla del tutto: una scelta privata, mai basata sulla tua età. Puoi riattivarla qui in qualsiasi momento."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokazuje kartę cyklu na ekranie Dziś i w sekcji Zdrowie. Wyłącz, aby ukryć ją całkowicie — to prywatny wybór, nigdy oparty na wieku. Możesz włączyć ją tu z powrotem w każdej chwili."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra o cartão do ciclo em Hoje e na Saúde. Desativa para o ocultar por completo — uma escolha privada, nunca com base na tua idade. Podes voltar a ativá-lo aqui quando quiseres."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показывает карточку цикла на экране «Сегодня» и в разделе «Здоровье». Выключите, чтобы полностью скрыть её — это личный выбор, никогда не зависящий от возраста. Вы можете снова включить её здесь в любое время."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在“今天”和“健康”中显示周期卡片。关闭即可完全隐藏——这是个人选择，绝不基于年龄。你可以随时在此重新开启。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在「今天」和「健康」中顯示週期卡片。關閉即可完全隱藏——這是個人選擇，絕不基於年齡。你可以隨時在此重新開啟。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Strand/Screens/AutomationsView.swift
+++ b/Strand/Screens/AutomationsView.swift
@@ -16,6 +16,9 @@ struct AutomationsView: View {
 
     /// v5 cycle-awareness opt-in (default OFF — the most sensitive health category, manual-first).
     @AppStorage(AppModel.cycleAwarenessKey) private var cycleAwareness = false
+    /// #hide-cycle: the user's "not for me" opt-out (never age-based). Master visibility control lives here
+    /// so it stays reachable to un-hide even after the offer is gone from Today + Health.
+    @AppStorage(AppModel.cycleAwarenessHiddenKey) private var cycleHidden = false
 
     /// Whether the cycle-awareness opt-in is offered for this profile (#801). Delegates to the shared
     /// ``ProfileStore/cycleAwarenessApplies`` gate (mirrors HealthView's opt-in gate) so a male profile
@@ -352,14 +355,31 @@ struct AutomationsView: View {
                 // not shown for male profiles). Keeps the two surfaces consistent: a profile that can't
                 // see the Health card can't enable the feature from here either.
                 if cycleOptInApplies {
-                    ToggleRow(label: String(localized: "Cycle awareness"),
-                              help: String(localized: "Reads a coarse menstrual-cycle phase from your nightly skin temperature, entirely on \(Platform.deviceNounPhrase). Awareness only: not contraception, not a fertility predictor, not a medical service. The card appears in Health."),
-                              isOn: $cycleAwareness)
-                        .onChangeCompat(of: cycleAwareness) { on in
-                            model.cycleAwarenessEnabled = on
-                            Task { await model.refreshV5Signals() }
-                        }
+                    // #hide-cycle: the master visibility control — a USER opt-out, never age-based. Turning
+                    // it off hides the cycle-awareness offer on Today + Health AND stops active tracking;
+                    // turning it back on re-offers it. Reversible, so it is never a one-way door.
+                    ToggleRow(label: String(localized: "Show cycle awareness"),
+                              help: String(localized: "Shows the cycle-awareness card on Today and in Health. Turn off to hide it entirely — a private choice, never based on your age. You can turn it back on here any time."),
+                              isOn: Binding(get: { !cycleHidden },
+                                            set: { show in
+                                                cycleHidden = !show
+                                                if !show {
+                                                    cycleAwareness = false
+                                                    model.cycleAwarenessEnabled = false
+                                                    Task { await model.refreshV5Signals() }
+                                                }
+                                            }))
                     rowDivider
+                    if !cycleHidden {
+                        ToggleRow(label: String(localized: "Cycle awareness"),
+                                  help: String(localized: "Reads a coarse menstrual-cycle phase from your nightly skin temperature, entirely on \(Platform.deviceNounPhrase). Awareness only: not contraception, not a fertility predictor, not a medical service. The card appears in Health."),
+                                  isOn: $cycleAwareness)
+                            .onChangeCompat(of: cycleAwareness) { on in
+                                model.cycleAwarenessEnabled = on
+                                Task { await model.refreshV5Signals() }
+                            }
+                        rowDivider
+                    }
                 }
                 ToggleRow(label: String(localized: "Rhythm visualization (experimental)"),
                           help: String(localized: "An experimental picture of your beat-to-beat heart timing. Not an ECG and not a diagnosis. You'll read and accept an experimental note before it shows anything."),

--- a/Strand/Screens/HealthView.swift
+++ b/Strand/Screens/HealthView.swift
@@ -1359,12 +1359,15 @@ private struct SkinTempSection: View {
 
     /// The cycle-awareness opt-in (default OFF). The same key AppModel reads, so a flip is consistent.
     @AppStorage(AppModel.cycleAwarenessKey) private var cycleEnabled = false
+    /// #hide-cycle: the user's "not for me" opt-out. When set, the cycle opt-in invitation is suppressed
+    /// here (the section falls back to the generic skin-temp state); reversible from Automations.
+    @AppStorage(AppModel.cycleAwarenessHiddenKey) private var cycleHidden = false
     @State private var cycleTrackerPresented = false
 
     /// Whether the cycle-awareness opt-in is offered for this profile (#801). Delegates to the shared
     /// ``ProfileStore/cycleAwarenessApplies`` gate so Health + Automations stay in lockstep: cycle phase
     /// is read from the menstrual skin-temperature shift, so the opt-in is NOT shown for male profiles.
-    private var cycleOptInApplies: Bool { model.profile.cycleAwarenessApplies }
+    private var cycleOptInApplies: Bool { model.profile.cycleAwarenessApplies && !cycleHidden }
 
     var body: some View {
         VStack(alignment: .leading, spacing: NoopMetrics.gap) {

--- a/Strand/Screens/SkinTempCardsView.swift
+++ b/Strand/Screens/SkinTempCardsView.swift
@@ -283,11 +283,14 @@ struct MenstrualCycleHomeCard: View {
     @EnvironmentObject private var profile: ProfileStore
 
     @AppStorage(AppModel.cycleAwarenessKey) private var cycleEnabled = false
+    /// The user's "not for me" opt-out (#hide-cycle): when set, the card is suppressed entirely,
+    /// reversibly from Automations. USER-controlled, never age-based.
+    @AppStorage(AppModel.cycleAwarenessHiddenKey) private var cycleHidden = false
     @State private var starts: [String] = []
     @State private var showingTracker = false
 
     private var shouldShow: Bool {
-        profile.cycleAwarenessApplies || cycleEnabled || !starts.isEmpty
+        !cycleHidden && (profile.cycleAwarenessApplies || cycleEnabled || !starts.isEmpty)
     }
 
     var body: some View {

--- a/StrandTests/CycleAwarenessGateTests.swift
+++ b/StrandTests/CycleAwarenessGateTests.swift
@@ -45,4 +45,18 @@ final class CycleAwarenessGateTests: XCTestCase {
         store.sex = "female"
         XCTAssertTrue(store.cycleAwarenessApplies)
     }
+
+    /// #hide-cycle: the user's "not for me" opt-out suppresses the offer for an otherwise-eligible profile,
+    /// and the gate is INDEPENDENT of age — it takes only sex + the hidden flag, never a birth date.
+    func testHiddenSuppressesTheOfferForEligibleProfiles() {
+        // Eligible + not hidden → visible (the default).
+        XCTAssertTrue(ProfileStore.cycleAwarenessVisible(sex: "female", hidden: false))
+        XCTAssertTrue(ProfileStore.cycleAwarenessVisible(sex: "nonbinary", hidden: false))
+        // Eligible + hidden → suppressed by the user's own choice.
+        XCTAssertFalse(ProfileStore.cycleAwarenessVisible(sex: "female", hidden: true))
+        XCTAssertFalse(ProfileStore.cycleAwarenessVisible(sex: "nonbinary", hidden: true))
+        // Ineligible (male) stays ineligible whatever the flag — the two conditions compose.
+        XCTAssertFalse(ProfileStore.cycleAwarenessVisible(sex: "male", hidden: false))
+        XCTAssertFalse(ProfileStore.cycleAwarenessVisible(sex: "male", hidden: true))
+    }
 }

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -485,6 +485,10 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     // Cycle awareness (v5 skin-temp suite) — OPT-IN, default OFF (manual-first). Declared BEFORE init for
     // the same reason as _illnessWatchEnabled: the recentDays collector reads it on its synchronous first
     // (cached) emission. Gates whether CyclePhaseEngine actually classifies in the v5 analytics pass.
+    private val _cycleAwarenessHidden = MutableStateFlow(NoopPrefs.cycleAwarenessHidden(appContext))
+    /** #hide-cycle: the user's "not for me" opt-out (never age-based). Twin of iOS AppModel.cycleAwarenessHidden. */
+    val cycleAwarenessHidden: StateFlow<Boolean> = _cycleAwarenessHidden.asStateFlow()
+
     private val _cycleTrackingEnabled = MutableStateFlow(NoopPrefs.cycleTracking(appContext))
     /** Whether cycle-phase awareness is enabled (reads a coarse phase from nightly skin temperature). */
     val cycleTrackingEnabled: StateFlow<Boolean> = _cycleTrackingEnabled.asStateFlow()
@@ -2355,6 +2359,14 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         NoopPrefs.setIllnessWatch(appContext, enabled)
         // Recompute now — the recentDays collector only fires on data changes.
         _healthAlert.value = if (enabled) IllnessWatch.evaluate(recentDays.value) else null
+    }
+
+    /** #hide-cycle: hide/show the cycle-awareness offer. Hiding also stops active tracking, so "hidden"
+     *  means fully gone; showing re-offers it. Reversible. Twin of the iOS Automations master toggle. */
+    fun setCycleAwarenessHidden(hidden: Boolean) {
+        _cycleAwarenessHidden.value = hidden
+        NoopPrefs.setCycleAwarenessHidden(appContext, hidden)
+        if (hidden && _cycleTrackingEnabled.value) setCycleTrackingEnabled(false)
     }
 
     /** Flip cycle awareness (v5 skin-temp suite). Persists and recomputes the v5 signals immediately so

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -122,6 +122,7 @@ fun HealthScreen(
     // analytics pass and published by the ViewModel. Cycle awareness gates on its opt-in pref.
     val v5Signals by vm.v5Signals.collectAsStateWithLifecycle()
     val cycleEnabled by vm.cycleTrackingEnabled.collectAsStateWithLifecycle()
+    val cycleHidden by vm.cycleAwarenessHidden.collectAsStateWithLifecycle()
     val periodStarts by vm.periodStarts.collectAsStateWithLifecycle()
     var showCycleTracker by remember { mutableStateOf(false) }
     val hrMax = profile.hrMax
@@ -214,7 +215,7 @@ fun HealthScreen(
                     // #801: gate the cycle-awareness OPT-IN to profiles it can apply to (sex-gated, pure
                     // helper). Cycle phase is read from the menstrual skin-temperature shift, so the
                     // invitation is NOT offered for male profiles. Matches iOS SkinTempSection.cycleOptInApplies.
-                    cycleOptInApplies = cycleOptInApplies(profile.sex),
+                    cycleOptInApplies = cycleAwarenessVisible(profile.sex, cycleHidden),
                     onEnableCycle = { vm.setCycleTrackingEnabled(true) },
                     onLogPeriod = { vm.logPeriodStart() },
                     onOpenCycleTracker = { showCycleTracker = true },
@@ -456,6 +457,12 @@ private fun RecordRow(
  * (`profile.sex.lowercased() != "male"`). ProfileStore.sex is "male" | "female" | "nonbinary".
  */
 internal fun cycleOptInApplies(sex: String): Boolean = sex.lowercase(Locale.US) != "male"
+
+/** #hide-cycle: whether the cycle-awareness OFFER is VISIBLE — eligible by sex AND not hidden by the
+ *  user's "not for me" opt-out. USER-controlled, never age-based. Pure, unit-tested; twin of iOS
+ *  ProfileStore.cycleAwarenessVisible(sex:hidden:). */
+internal fun cycleAwarenessVisible(sex: String, hidden: Boolean): Boolean =
+    cycleOptInApplies(sex) && !hidden
 
 @Composable
 private fun SkinTempSuiteSection(

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -700,6 +700,18 @@ object NoopPrefs {
         of(context).edit().putBoolean(KEY_CYCLE_TRACKING, enabled).apply()
     }
 
+    /** #hide-cycle: the user's "not for me" opt-out. When true, the cycle-awareness offer is suppressed on
+     *  Today + Health (reversible from Settings). USER-controlled, never age-based. Twin of the iOS
+     *  `AppModel.cycleAwarenessHiddenKey`. */
+    const val KEY_CYCLE_AWARENESS_HIDDEN = "noop.cycleAwarenessHidden"
+
+    fun cycleAwarenessHidden(context: Context): Boolean =
+        of(context).getBoolean(KEY_CYCLE_AWARENESS_HIDDEN, false)
+
+    fun setCycleAwarenessHidden(context: Context, hidden: Boolean) {
+        of(context).edit().putBoolean(KEY_CYCLE_AWARENESS_HIDDEN, hidden).apply()
+    }
+
     /** Hydration tracking (MVP): an opt-in, on-device-only fluid log with a daily goal + quick-add
      *  buttons. OPT-IN, default OFF (manual-first ethos), the Today "Hydration" card and the detail
      *  feature only appear once this is on. Nothing is synced; the day total lives in the local

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -620,6 +620,7 @@ fun SettingsScreen(
     // the engines pick up on the next analytics pass / offload. All opt-in / safe-default per spec.
     var illnessWatch by remember { mutableStateOf(NoopPrefs.illnessWatch(context)) }
     var cycleTracking by remember { mutableStateOf(NoopPrefs.cycleTracking(context)) }
+    var cycleHidden by remember { mutableStateOf(NoopPrefs.cycleAwarenessHidden(context)) }
     var hydrationTracking by remember { mutableStateOf(NoopPrefs.hydrationTracking(context)) }
     var stressCheckIn by remember { mutableStateOf(BiofeedbackPrefs.checkInEnabled(context)) }
     var stressAutoNudge by remember { mutableStateOf(BiofeedbackPrefs.autoNudge(context)) }
@@ -2789,16 +2790,33 @@ fun SettingsScreen(
                 // sister surfaces (Health opt-in, the card's off-control) were sex-gated in v7.3.2; this
                 // Settings toggle was the one surface that was missed, so a male profile could enable it here.
                 if (cycleTracking || cycleOptInApplies(profile.sex)) {
+                    // #hide-cycle — the master "not for me" opt-out. Offered to eligible profiles (and any
+                    // profile that already has it on) so the card can be hidden entirely by choice, never by
+                    // age. Turning it off hides the card AND stops tracking; it stays reversible right here.
+                    // Twin of the iOS Automations "Show cycle awareness" toggle.
                     SettingsToggleRow(
-                        title = uiString(R.string.l10n_settings_screen_cycle_awareness_ffb94783),
-                        detail = "Reads a coarse menstrual-cycle phase from your nightly skin-temperature shift, on this device only. Awareness only: not contraception, not a fertility predictor, not a medical service.",
-                        checked = cycleTracking,
-                        onCheckedChange = {
-                            cycleTracking = it
-                            vm.setCycleTrackingEnabled(it)
+                        title = uiString(R.string.l10n_settings_screen_show_cycle_awareness_59709019),
+                        detail = "Shows the cycle-awareness card on Today and in Health. Turn off to hide it entirely — a private choice, never based on your age. You can turn it back on here any time.",
+                        checked = !cycleHidden,
+                        onCheckedChange = { show ->
+                            cycleHidden = !show
+                            vm.setCycleAwarenessHidden(!show)
+                            if (!show) cycleTracking = false // vm also clears the pref; keep local state in step
                         },
                     )
                     SettingsRowDivider()
+                    if (!cycleHidden) {
+                        SettingsToggleRow(
+                            title = uiString(R.string.l10n_settings_screen_cycle_awareness_ffb94783),
+                            detail = "Reads a coarse menstrual-cycle phase from your nightly skin-temperature shift, on this device only. Awareness only: not contraception, not a fertility predictor, not a medical service.",
+                            checked = cycleTracking,
+                            onCheckedChange = {
+                                cycleTracking = it
+                                vm.setCycleTrackingEnabled(it)
+                            },
+                        )
+                        SettingsRowDivider()
+                    }
                 }
                 SettingsToggleRow(
                     title = uiString(R.string.l10n_settings_screen_hydration_tracking_579a2b32),

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -284,6 +284,7 @@ fun TodayScreen(
     val spo2CandidateByDay by viewModel.spo2CandidateByDay.collectAsStateWithLifecycle()
     val v5Signals by viewModel.v5Signals.collectAsStateWithLifecycle()
     val cycleEnabled by viewModel.cycleTrackingEnabled.collectAsStateWithLifecycle()
+    val cycleHidden by viewModel.cycleAwarenessHidden.collectAsStateWithLifecycle()
     val periodStarts by viewModel.periodStarts.collectAsStateWithLifecycle()
     var showCycleTracker by remember { mutableStateOf(false) }
     val live by viewModel.live.collectAsStateWithLifecycle()
@@ -1371,7 +1372,7 @@ fun TodayScreen(
                 TodaySection.YOUR_CARDS ->
                     selectedDayOffset == 0 && visibleDashboardCards.isNotEmpty()
                 TodaySection.MENSTRUAL_CYCLE ->
-                    selectedDayOffset == 0 &&
+                    selectedDayOffset == 0 && !cycleHidden &&
                         (cycleOptInApplies(profileStore.sex) || cycleEnabled || periodStarts.isNotEmpty())
                 TodaySection.JOURNAL ->
                     selectedDayOffset == 0 && journalReminderOn

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1465,6 +1465,7 @@
     <string name="l10n_settings_screen_continuous_hrv_capture_1f0805d8">Kontinuierliche HRV-Erfassung</string>
     <string name="l10n_settings_screen_couldn_t_check_try_again_b3c885d9">Prüfung fehlgeschlagen. Versuch es erneut.</string>
     <string name="l10n_settings_screen_counter_ticks_per_step_leave_at_3ce8c1d5">Zählerticks pro Schritt. Lass es auf 1,0, außer deine Schritte fallen zu hoch aus. Auf einem WHOOP 5/MG können sie sehr hoch ausfallen (10× oder mehr), daher geht das hier bis 30. Geh bekannte 1.000 Schritte und teile NOOPs Zählung durch die echte Zahl, um deinen Wert zu erhalten.</string>
+    <string name="l10n_settings_screen_show_cycle_awareness_59709019">Zyklusbewusstsein anzeigen</string>
     <string name="l10n_settings_screen_cycle_awareness_ffb94783">Zyklusbewusstsein</string>
     <string name="l10n_settings_screen_day_cycle_background_8c254f01">Tageszyklus-Hintergrund</string>
     <string name="l10n_settings_screen_diagnostics_3af2279f">Diagnose</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1280,6 +1280,7 @@
     <string name="l10n_settings_screen_continuous_hrv_capture_1f0805d8">Captura continua de VFC</string>
     <string name="l10n_settings_screen_couldn_t_check_try_again_b3c885d9">No se pudo comprobar. Inténtalo de nuevo.</string>
     <string name="l10n_settings_screen_counter_ticks_per_step_leave_at_3ce8c1d5">Pulsos del contador por paso. Déjalo en 1.0 salvo que tus pasos salgan altos. En una WHOOP 5/MG pueden salir muy altos (10× o más), por eso llega hasta 30. Camina 1.000 pasos conocidos y divide el conteo de NOOP entre el conteo real para obtener tu valor.</string>
+    <string name="l10n_settings_screen_show_cycle_awareness_59709019">Mostrar conciencia del ciclo</string>
     <string name="l10n_settings_screen_cycle_awareness_ffb94783">Conciencia del ciclo</string>
     <string name="l10n_settings_screen_day_cycle_background_8c254f01">Fondo según el ciclo del día</string>
     <string name="l10n_settings_screen_diagnostics_3af2279f">Diagnósticos</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1280,6 +1280,7 @@
     <string name="l10n_settings_screen_continuous_hrv_capture_1f0805d8">Capture continue de la VFC</string>
     <string name="l10n_settings_screen_couldn_t_check_try_again_b3c885d9">Impossible de vérifier. Réessayez.</string>
     <string name="l10n_settings_screen_counter_ticks_per_step_leave_at_3ce8c1d5">Impulsions du compteur par pas. Laissez à 1,0 sauf si vos pas sont très élevés. Sur un WHOOP 5/MG, ils peuvent être très élevés (10× ou plus), donc ceci va jusqu\'à 30. Marchez un nombre connu de 1 000 pas et divisez le comptage de NOOP par le comptage réel pour obtenir votre valeur.</string>
+    <string name="l10n_settings_screen_show_cycle_awareness_59709019">Afficher la conscience du cycle</string>
     <string name="l10n_settings_screen_cycle_awareness_ffb94783">Conscience du cycle</string>
     <string name="l10n_settings_screen_day_cycle_background_8c254f01">Fond du cycle journalier</string>
     <string name="l10n_settings_screen_diagnostics_3af2279f">Diagnostics</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -1440,6 +1440,7 @@
     <string name="l10n_settings_screen_continuous_hrv_capture_1f0805d8">Ciągłe przechwytywanie HRV</string>
     <string name="l10n_settings_screen_couldn_t_check_try_again_b3c885d9">Nie udało się sprawdzić. Spróbuj ponownie.</string>
     <string name="l10n_settings_screen_counter_ticks_per_step_leave_at_3ce8c1d5">Licznik taktów na krok. Zostaw na 1,0, chyba że Twoje kroki będą wysokie. Na WHOOP 5/MG mogą biegać bardzo wysoko (10× lub więcej), więc liczba ta wzrasta do 30. Przejdź znane 1000 kroków i podziel liczbę NOOP przez liczbę rzeczywistą, aby otrzymać wartość.</string>
+    <string name="l10n_settings_screen_show_cycle_awareness_59709019">Pokaż świadomość cyklu</string>
     <string name="l10n_settings_screen_cycle_awareness_ffb94783">Świadomość rowerowa</string>
     <string name="l10n_settings_screen_day_cycle_background_8c254f01">Tło cyklu dnia</string>
     <string name="l10n_settings_screen_diagnostics_3af2279f">Diagnostyka</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1446,6 +1446,7 @@
     <string name="l10n_settings_screen_continuous_hrv_capture_1f0805d8">Captura contínua de HRV</string>
     <string name="l10n_settings_screen_couldn_t_check_try_again_b3c885d9">Não foi possível verificar. Tente novamente.</string>
     <string name="l10n_settings_screen_counter_ticks_per_step_leave_at_3ce8c1d5">Contador de ticks por etapa. Deixe em 1,0, a menos que os teus passos sejam altos. Num WHOOP 5/MG podem correr muito alto (10× ou mais), por isso isto vai até 30. Caminhe 1.000 passos conhecidos e divida a contagem do NOOP pela contagem real para obter o teu valor.</string>
+    <string name="l10n_settings_screen_show_cycle_awareness_59709019">Mostrar consciência do ciclo</string>
     <string name="l10n_settings_screen_cycle_awareness_ffb94783">Consciência do ciclo</string>
     <string name="l10n_settings_screen_day_cycle_background_8c254f01">Histórico do ciclo diário</string>
     <string name="l10n_settings_screen_diagnostics_3af2279f">Diagnóstico</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1426,6 +1426,7 @@
     <string name="l10n_settings_screen_continuous_hrv_capture_1f0805d8">全天候 HRV 捕获</string>
     <string name="l10n_settings_screen_couldn_t_check_try_again_b3c885d9">检查更新失败。请重试。</string>
     <string name="l10n_settings_screen_counter_ticks_per_step_leave_at_3ce8c1d5">每一步对应的传感器计数(Tick)比例。除非您的计步数据偏高，否则请保持默认值 1.0。在 WHOOP 5/MG 上，传感器数据可能会非常高（是实际步数的 10 倍甚至更多），所以这里的上限可调至 30。您可以走一段已知的 1000 步，用 NOOP 统计出的数字除以 1000，就能得出您专属的比例值了。</string>
+    <string name="l10n_settings_screen_show_cycle_awareness_59709019">显示生理周期感知</string>
     <string name="l10n_settings_screen_cycle_awareness_ffb94783">生理周期感知</string>
     <string name="l10n_settings_screen_day_cycle_background_8c254f01">日夜交替背景</string>
     <string name="l10n_settings_screen_diagnostics_3af2279f">诊断信息</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1474,6 +1474,7 @@
     <string name="l10n_settings_screen_continuous_hrv_capture_1f0805d8">Continuous HRV capture</string>
     <string name="l10n_settings_screen_couldn_t_check_try_again_b3c885d9">Couldn\'t check. Try again.</string>
     <string name="l10n_settings_screen_counter_ticks_per_step_leave_at_3ce8c1d5">Counter ticks per step. Leave at 1.0 unless your steps run high. On a WHOOP 5/MG they can run very high (10× or more), so this goes up to 30. Walk a known 1,000 steps and divide NOOP\'s count by the real count to get your value.</string>
+    <string name="l10n_settings_screen_show_cycle_awareness_59709019">Show cycle awareness</string>
     <string name="l10n_settings_screen_cycle_awareness_ffb94783">Cycle awareness</string>
     <string name="l10n_settings_screen_day_cycle_background_8c254f01">Day-cycle background</string>
     <string name="l10n_settings_screen_diagnostics_3af2279f">Diagnostics</string>

--- a/android/app/src/test/java/com/noop/ui/CycleOptInGateTest.kt
+++ b/android/app/src/test/java/com/noop/ui/CycleOptInGateTest.kt
@@ -29,4 +29,21 @@ class CycleOptInGateTest {
         assertTrue(cycleOptInApplies(""))
         assertTrue(cycleOptInApplies("unspecified"))
     }
+
+    /**
+     * #hide-cycle: the user's "not for me" opt-out ([cycleAwarenessVisible]) suppresses the offer for an
+     * otherwise-eligible profile, and the gate is INDEPENDENT of age — it composes sex + the hidden flag,
+     * never a birth date. Twin of iOS ProfileStore.cycleAwarenessVisible(sex:hidden:).
+     */
+    @Test fun hiddenSuppressesTheOfferForEligibleProfiles() {
+        // Eligible + not hidden → visible (the default).
+        assertTrue(cycleAwarenessVisible("female", hidden = false))
+        assertTrue(cycleAwarenessVisible("nonbinary", hidden = false))
+        // Eligible + hidden → suppressed by the user's own choice.
+        assertFalse(cycleAwarenessVisible("female", hidden = true))
+        assertFalse(cycleAwarenessVisible("nonbinary", hidden = true))
+        // Ineligible (male) stays ineligible whatever the flag — the two conditions compose.
+        assertFalse(cycleAwarenessVisible("male", hidden = false))
+        assertFalse(cycleAwarenessVisible("male", hidden = true))
+    }
 }


### PR DESCRIPTION
## What & why

Cycle awareness (#801) is offered to any non-male profile. That means an older user for whom it is no longer relevant — post-menopausal, or simply uninterested — still sees the Today card and the Health opt-in with **no way to dismiss it**. Gating on age is the wrong lever (menopause spans ~40–60; deciding from a birth date is presumptuous), so this adds a plain **user-controlled** switch instead.

## How

- New pref **`cycleAwarenessHidden`** — default **off**, USER-set, **never derived from age**.
- One pure predicate per platform composes it with the existing sex gate, so every surface stays in lockstep:
  - iOS `ProfileStore.cycleAwarenessVisible(sex:hidden:)`
  - Android `cycleAwarenessVisible(sex, hidden)`
- A **"Show cycle awareness"** master toggle (iOS **Automations**, Android **Settings**) hides the card everywhere. Per #801's *gate-the-offer* philosophy, turning it off also stops active tracking — and it stays **fully reversible** from the same place.
- **Male profiles are unaffected** — they never saw the offer and still don't.

Surfaces gated: the Today `MenstrualCycle` card and the Health opt-in offer.

## Parity

Built as twins:

| | iOS | Android |
|---|---|---|
| pref | `AppModel.cycleAwarenessHidden` | `NoopPrefs.cycleAwarenessHidden` + `AppViewModel` StateFlow |
| predicate | `ProfileStore.cycleAwarenessVisible` | `HealthScreen.cycleAwarenessVisible` |
| surfaces | SkinTemp card, Health, Automations | Today, Health, Settings |
| strings | xcstrings ×9 | strings.xml ×6 |

Pure predicate pinned by a unit test on both platforms (`CycleAwarenessGateTests` / `CycleOptInGateTest`).

## Verification

- Android: `:app:compileFullDebugKotlin` + `:app:compileFullDebugUnitTestKotlin` clean; `CycleOptInGateTest` green; `Tools/i18n_audit.py --ci main` + `Tools/doc_comment_lint.py` clean.
- iOS: touches app-target Swift (AppModel + Views) — validating via the on-demand app-build gate; the Swift predicate test lives in `StrandTests` (runs on that gate).
- No schema/migration change; no version bump.