### PR TITLE
Polar strap-identity diagnostic behind a paired-only debug toggle

### DIFF
--- a/Packages/PolarProtocol/Sources/PolarProtocol/PmdDecoder.swift
+++ b/Packages/PolarProtocol/Sources/PolarProtocol/PmdDecoder.swift
@@ -34,6 +34,19 @@ public enum PolarPmdMeasurement: UInt8, Sendable, Equatable, CaseIterable {
     case ppi = 0x03
     case gyro = 0x05
     case magnetometer = 0x06
+
+    /// Short lower-case token for diagnostics / the debug strap log (e.g. "ecg", "ppi"). Engineer-facing,
+    /// not localised.
+    public var label: String {
+        switch self {
+        case .ecg:          return "ecg"
+        case .ppg:          return "ppg"
+        case .acc:          return "acc"
+        case .ppi:          return "ppi"
+        case .gyro:         return "gyro"
+        case .magnetometer: return "mag"
+        }
+    }
 }
 
 /// The parsed 10-byte PMD data-frame header, common to every measurement type.

--- a/Packages/PolarProtocol/Sources/PolarProtocol/PolarModel.swift
+++ b/Packages/PolarProtocol/Sources/PolarProtocol/PolarModel.swift
@@ -66,4 +66,51 @@ public enum PolarModel: String, Sendable, Equatable, CaseIterable {
         if n.hasPrefix("polar sense") { return .veritySense }
         return .unknown
     }
+
+    /// Whether an advertised name belongs to a Polar sensor AT ALL — the public "Polar " name prefix.
+    /// Distinct from ``from(advertisedName:)``, which returns `.unknown` for BOTH a non-Polar strap and an
+    /// unrecognised Polar one; this separates "not a Polar device" from "a Polar device we can't name yet",
+    /// so Polar-only diagnostics never fire for a Wahoo/Garmin strap. Case- and whitespace-insensitive.
+    /// Works on either a live scan name or a stored `PairedDevice.model`, so a paired strap auto-detects
+    /// without a live connection.
+    public static func isPolar(advertisedName name: String?) -> Bool {
+        guard let n = name?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() else { return false }
+        return n.hasPrefix("polar ")
+    }
+
+    /// Engineer-facing model label for the debug strap log (not localised). `.unknown` reads as
+    /// "(unrecognised model)" so it composes into "Polar (unrecognised model)".
+    public var displayLabel: String {
+        switch self {
+        case .h10:         return "H10"
+        case .h9:          return "H9"
+        case .oh1:         return "OH1"
+        case .veritySense: return "Verity Sense"
+        case .unknown:     return "(unrecognised model)"
+        }
+    }
+
+    /// One-line PMD / HRV-route capability summary for the debug strap log — a pure restatement of
+    /// ``pmdStreams`` / ``hrvPmdStream`` (no behaviour gates on it). Streams are ordered by their PMD type
+    /// byte for a stable, protocol-natural order, e.g. "PMD ecg,acc; HRV via standard R-R" (H10) or
+    /// "PMD ppg,acc,ppi,gyro; HRV via PMD PPI" (Verity Sense).
+    public var pmdDebugSummary: String {
+        let streams: String
+        if pmdStreams.isEmpty {
+            streams = (self == .unknown) ? "PMD unknown (probe)" : "no PMD service"
+        } else {
+            streams = "PMD " + pmdStreams.sorted { $0.rawValue < $1.rawValue }.map(\.label).joined(separator: ",")
+        }
+        return "\(streams); \(hrvPmdStream == nil ? "HRV via standard R-R" : "HRV via PMD PPI")"
+    }
+
+    /// The full one-line identification for the debug strap log / Test Centre when a Polar strap is seen —
+    /// e.g. "Polar H10 identified — PMD ecg,acc; HRV via standard R-R". Auto-detected from any advertised
+    /// name, whether a live scan result or a stored `PairedDevice.model`. Returns `nil` for a non-Polar
+    /// name, so a caller emits nothing at all for a Wahoo/Garmin strap. The caller adds its own tag prefix.
+    public static func debugIdentification(advertisedName name: String?) -> String? {
+        guard isPolar(advertisedName: name) else { return nil }
+        let model = from(advertisedName: name)
+        return "Polar \(model.displayLabel) identified — \(model.pmdDebugSummary)"
+    }
 }

--- a/Packages/PolarProtocol/Tests/PolarProtocolTests/PolarModelTests.swift
+++ b/Packages/PolarProtocol/Tests/PolarProtocolTests/PolarModelTests.swift
@@ -45,4 +45,45 @@ final class PolarModelTests: XCTestCase {
         // happens to contain "h10" must stay an OH1 (a `contains` matcher wrongly returned .h10 here).
         XCTAssertEqual(PolarModel.from(advertisedName: "Polar OH1 H10ABCDE"), .oh1)
     }
+
+    // MARK: - Debug identification (Test Centre / strap-log diagnostics)
+
+    func testIsPolarSeparatesPolarFromUnrecognisedAndForeign() {
+        // A Polar device we can't name yet is still a Polar device (unlike `from`, which collapses both to
+        // .unknown) — so the Polar-only diagnostics fire for it but never for a foreign strap.
+        XCTAssertTrue(PolarModel.isPolar(advertisedName: "Polar H10 A1B2C3D4"))
+        XCTAssertTrue(PolarModel.isPolar(advertisedName: "Polar Grit X"))       // real Polar, no catalog entry
+        XCTAssertTrue(PolarModel.isPolar(advertisedName: "polar sense 99AA"))   // case-insensitive
+        XCTAssertFalse(PolarModel.isPolar(advertisedName: "Wahoo TICKR"))
+        XCTAssertFalse(PolarModel.isPolar(advertisedName: "Polaris X"))         // prefix must be "polar " + space
+        XCTAssertFalse(PolarModel.isPolar(advertisedName: nil))
+        XCTAssertFalse(PolarModel.isPolar(advertisedName: ""))
+    }
+
+    func testPmdDebugSummaryStatesStreamsAndHrvRoute() {
+        // Chest strap: PMD ecg+acc (ordered by PMD type byte), HRV off the standard HR service.
+        XCTAssertEqual(PolarModel.h10.pmdDebugSummary, "PMD ecg,acc; HRV via standard R-R")
+        // HR-only strap: no PMD service at all, still HRV via standard R-R.
+        XCTAssertEqual(PolarModel.h9.pmdDebugSummary, "no PMD service; HRV via standard R-R")
+        // Optical bands: PPI is the HRV route; streams ordered by type byte (ppg,acc,ppi[,gyro]).
+        XCTAssertEqual(PolarModel.oh1.pmdDebugSummary, "PMD ppg,acc,ppi; HRV via PMD PPI")
+        XCTAssertEqual(PolarModel.veritySense.pmdDebugSummary, "PMD ppg,acc,ppi,gyro; HRV via PMD PPI")
+        // Unrecognised Polar: probe rather than assume; R-R route is the safe default.
+        XCTAssertEqual(PolarModel.unknown.pmdDebugSummary, "PMD unknown (probe); HRV via standard R-R")
+    }
+
+    func testDebugIdentificationAutoDetectsFromAnyName() {
+        // The same helper works on a live scan name OR a stored PairedDevice.model, so a paired strap
+        // auto-detects without a live connection.
+        XCTAssertEqual(PolarModel.debugIdentification(advertisedName: "Polar H10 A1B2C3D4"),
+                       "Polar H10 identified — PMD ecg,acc; HRV via standard R-R")
+        XCTAssertEqual(PolarModel.debugIdentification(advertisedName: "Polar Sense 99AABBCC"),
+                       "Polar Verity Sense identified — PMD ppg,acc,ppi,gyro; HRV via PMD PPI")
+        // Unrecognised Polar still identifies (as a probe candidate) — that's the useful debug signal.
+        XCTAssertEqual(PolarModel.debugIdentification(advertisedName: "Polar Grit X"),
+                       "Polar (unrecognised model) identified — PMD unknown (probe); HRV via standard R-R")
+        // Foreign / empty → nil, so the caller emits nothing at all.
+        XCTAssertNil(PolarModel.debugIdentification(advertisedName: "Wahoo TICKR"))
+        XCTAssertNil(PolarModel.debugIdentification(advertisedName: nil))
+    }
 }

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -1666,6 +1666,16 @@ final class AppModel: ObservableObject {
         set { UserDefaults.standard.set(newValue, forKey: Self.cycleAwarenessHiddenKey) }
     }
 
+    /// #polar-debug: whether a connecting Polar strap logs the model NOOP identifies it as (+ its PMD/HRV
+    /// capability summary) to the strap log. Default off; the Test Centre only exposes the toggle when a
+    /// Polar strap is paired. Diagnostic-only — nothing gates behaviour on it. Twin of Android
+    /// `NoopPrefs.KEY_POLAR_DEBUG_LOGGING`.
+    static let polarDebugLoggingKey = "noopPolarDebugLogging"
+    var polarDebugLogging: Bool {
+        get { UserDefaults.standard.bool(forKey: Self.polarDebugLoggingKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Self.polarDebugLoggingKey) }
+    }
+
     /// Recompute the v5 skin-temp suite snapshots (cycle phase + body clock) from the current history.
     /// Called from the analytics pass and when the cycle opt-in flips. Honest-nil throughout: cycle is
     /// nil unless opted in; circadian is nil unless a usable activity profile exists.

--- a/Strand/BLE/SourceCoordinator.swift
+++ b/Strand/BLE/SourceCoordinator.swift
@@ -303,7 +303,10 @@ final class SourceCoordinator: ObservableObject {
             log: straplog,   // generic-HR lifecycle → the SAME exported strap log (issue #421)
             // Surface the generic strap's standard Battery Service (0x180F) charge the SAME place the
             // WHOOP strap battery shows (the Live/device status), via the shared LiveState funnel.
-            onBattery: { [live] pct in live.setBattery(Double(pct)) })
+            onBattery: { [live] pct in live.setBattery(Double(pct)) },
+            // #polar-debug: read the toggle live at connect so a Polar strap logs its identified model
+            // (default off; the Test Centre only exposes the toggle when a Polar strap is paired).
+            polarDebug: { UserDefaults.standard.bool(forKey: AppModel.polarDebugLoggingKey) })
     }
 
     /// Build the isolated `FTMSSource` for a gym machine `id`. HR (when the machine reports it) rides the

--- a/Strand/BLE/StandardHRSource.swift
+++ b/Strand/BLE/StandardHRSource.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Combine
 import CoreBluetooth
+import PolarProtocol
 import WhoopProtocol
 import WhoopStore
 
@@ -101,8 +102,18 @@ public final class StandardHRSource: NSObject, ObservableObject {
     /// Default no-op keeps existing call sites compiling and the discovery-only scanner silent.
     private let log: (String) -> Void
 
+    /// #polar-debug: read live at connect. When it returns true AND the connected strap identifies as Polar,
+    /// the model NOOP resolves it to (+ its PMD/HRV capability summary) is logged ONCE per connection.
+    /// Gated by the Test Centre "Polar debug logging" toggle (only shown when a Polar strap is paired).
+    /// Diagnostic-only — nothing gates behaviour on it. Default off keeps existing call sites / tests silent.
+    private let polarDebug: () -> Bool
+
     /// Logs the FIRST HR sample of a connection only (never every notification); reset on stop/disconnect.
     private var loggedFirstHR = false
+
+    /// #polar-debug: guards the one-per-connection Polar identity line (reset on stop/disconnect, like
+    /// `loggedFirstHR`).
+    private var loggedPolarIdentity = false
 
     // MARK: - CoreBluetooth state (OWN central, separate from WHOOP)
 
@@ -136,12 +147,14 @@ public final class StandardHRSource: NSObject, ObservableObject {
                 deviceId: String,
                 persist: @escaping (Streams) -> Void,
                 log: @escaping (String) -> Void = { _ in },
-                onBattery: @escaping (Int) -> Void = { _ in }) {
+                onBattery: @escaping (Int) -> Void = { _ in },
+                polarDebug: @escaping () -> Bool = { false }) {
         self.live = live
         self.deviceId = deviceId
         self.persist = persist
         self.log = log
         self.onBattery = onBattery
+        self.polarDebug = polarDebug
         super.init()
         // Dedicated queue-less central → callbacks arrive on the main queue, matching @MainActor.
         self.central = CBCentralManager(delegate: self, queue: nil)
@@ -302,8 +315,20 @@ extension StandardHRSource: @preconcurrency CBCentralManagerDelegate {
         }
     }
 
+    /// #polar-debug: when the toggle is on and the connected strap identifies as Polar, log the model NOOP
+    /// resolves it to (+ PMD/HRV capability summary) ONCE per connection. Auto-detected from the advertised
+    /// name via the pure `PolarModel` helper (the same one the Test Centre uses on the paired record); a
+    /// non-Polar strap returns nil and logs nothing. Diagnostic-only. Twin of the Android StandardHrSource hook.
+    private func logPolarIdentityOnce(_ peripheral: CBPeripheral) {
+        guard !loggedPolarIdentity, polarDebug(),
+              let line = PolarModel.debugIdentification(advertisedName: peripheral.name) else { return }
+        loggedPolarIdentity = true
+        log("HR-strap: \(line)")
+    }
+
     public func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
         log("HR-strap: connected — discovering services")
+        logPolarIdentityOnce(peripheral)
         peripheral.delegate = self
         // Discover the HR service (unchanged) AND, additively, the standard Battery Service + the three
         // fitness-sensor services (RSC/CSC/CPS) so a generic strap's charge AND a connected footpod / bike
@@ -327,6 +352,7 @@ extension StandardHRSource: @preconcurrency CBCentralManagerDelegate {
             log("HR-strap: disconnected (clean)")
         }
         loggedFirstHR = false   // a reconnect should log its first sample again
+        loggedPolarIdentity = false
         loggedFirstSensor = false
         batteryPct = nil        // a stale charge must not outlive the link
         flush()

--- a/Strand/Screens/TestCentreView.swift
+++ b/Strand/Screens/TestCentreView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import StrandDesign
 import StrandAnalytics
 import StrandImport
+import PolarProtocol
 import WhoopStore
 
 /// Settings -> Test Centre. The single home for every diagnostic, log and test control (spec section 7).
@@ -37,6 +38,17 @@ struct TestCentreView: View {
 
     /// The strap model the user last picked, the same key SettingsView's showFiveMGControls gate reads.
     @AppStorage("selectedWhoopModel") private var selectedWhoopModelRaw = WhoopModel.whoop4.rawValue
+
+    // #polar-debug: the Polar strap-identity diagnostic toggle. Only rendered when a Polar strap is paired.
+    @AppStorage(AppModel.polarDebugLoggingKey) private var polarDebugLogging = false
+
+    /// The model NOOP auto-detects for a PAIRED Polar strap, from its stored advertised name (no live
+    /// connection needed) — e.g. "Polar H10 identified — PMD ecg,acc; HRV via standard R-R". `nil` when no
+    /// Polar strap is paired, which hides the whole toggle so a non-Polar user never sees Polar debug.
+    private var polarIdentity: String? {
+        let name = model.deviceRegistry?.devices.first { PolarModel.isPolar(advertisedName: $0.model) }?.model
+        return PolarModel.debugIdentification(advertisedName: name)
+    }
 
     // Section 4: Experimental algorithms. Bound to the SAME PuffinExperiment keys the Android card writes, so
     // the platforms stay in lockstep. The PPG-HR sub-lag interpolation variant and the HRV-readiness readout,
@@ -160,6 +172,21 @@ struct TestCentreView: View {
                 // surfaced as a copyable readout (spec section 3.4).
                 NoopButton("Copy environment dump", systemImage: "info.circle", kind: .secondary) {
                     PlatformPasteboard.copy(live.exportableLogText())
+                }
+
+                // #polar-debug: only when a Polar strap is paired. The caption is the model auto-detected
+                // from the paired record; the toggle also writes it to the strap log on each connect.
+                if let identity = polarIdentity {
+                    Divider().overlay(StrandPalette.hairline)
+                    Toggle(isOn: $polarDebugLogging) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Polar debug logging").font(StrandFont.body)
+                            Text("\(identity). Logs this to the strap log on each connect, so a Polar bug report shows the model NOOP resolved your strap to.")
+                                .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                    .tint(StrandPalette.accent)
                 }
             }
         }

--- a/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
+++ b/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
@@ -9,6 +9,7 @@ import com.noop.data.StreamBatch
 import com.noop.data.WhoopRepository
 import com.noop.oura.OuraRingGen
 import com.noop.oura.OuraWearState
+import com.noop.ui.NoopPrefs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -387,6 +388,9 @@ class SourceCoordinator(
                         _sensorMetrics.value = metrics
                         sensorSink(metrics)
                     },
+                    // #polar-debug: read the toggle live at connect so a Polar strap logs its identified
+                    // model (default off; the Test Centre only exposes the toggle when a Polar strap is paired).
+                    polarDebug = { NoopPrefs.polarDebugLogging(ctx) },
                 )
             }
         }

--- a/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
+++ b/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
@@ -22,6 +22,7 @@ import android.os.ParcelUuid
 import com.noop.data.HrRow
 import com.noop.data.RrRow
 import com.noop.data.StreamBatch
+import com.noop.polar.PolarModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -73,6 +74,11 @@ class StandardHrSource(
      *  in-exercise readout — it never touches HR/R-R/persistence/scoring. Called on the main looper.
      *  Mirrors [FtmsSource.readingSink]. Default no-op keeps existing call sites compiling. */
     private val sensorSink: (SensorMetrics) -> Unit = {},
+    /** #polar-debug: read live at connect. When true AND the connected strap identifies as Polar, the
+     *  model NOOP resolves it to (+ its PMD/HRV capability summary) is logged ONCE per connection. Gated by
+     *  the Test Centre "Polar debug logging" toggle (only shown when a Polar strap is paired). Diagnostic-
+     *  only — nothing gates behaviour on it. Default off keeps existing call sites / tests silent. */
+    private val polarDebug: () -> Boolean = { false },
 ) : LiveHrSource {
 
     /** Live instantaneous fitness-sensor metrics surfaced via [sensorSink]. Any field is null when it
@@ -123,6 +129,10 @@ class StandardHrSource(
     private var retried133 = false
     /** Logs the FIRST HR sample of a connection only (not every notification); reset on stop/disconnect. */
     private var loggedFirstHr = false
+
+    /** #polar-debug: guards the one-per-connection Polar identity line (reset on disconnect, like
+     *  [loggedFirstHr]). */
+    private var loggedPolarIdentity = false
 
     /** Derives instantaneous speed/cadence from successive CSC/CPS cumulative counters. Per-source so a
      *  reconnect starts fresh (reset on stop/disconnect). Pure value type. */
@@ -281,6 +291,18 @@ class StandardHrSource(
         }
     }
 
+    /** #polar-debug: when the toggle is on and the connected strap identifies as Polar, log the model NOOP
+     *  resolves it to (+ PMD/HRV capability summary) ONCE per connection. Auto-detected from the advertised
+     *  name via the pure [PolarModel] helper (same one the Test Centre uses on the paired record); a non-
+     *  Polar strap returns null and logs nothing. Diagnostic-only. Twin of the iOS StandardHRSource hook. */
+    private fun logPolarIdentityOnce(device: BluetoothDevice?) {
+        if (loggedPolarIdentity || !polarDebug()) return
+        val name = runCatching { device?.name }.getOrNull()
+        val line = PolarModel.debugIdentification(name) ?: return
+        loggedPolarIdentity = true
+        log("HR-strap: $line")
+    }
+
     // MARK: - GATT callback
 
     private val gattCallback = object : BluetoothGattCallback() {
@@ -293,11 +315,13 @@ class StandardHrSource(
                     }
                     retried133 = false   // a real connection clears the one-shot 133 retry guard
                     log("HR-strap: connected (status=$status) — discovering services")
+                    logPolarIdentityOnce(g.device)
                     g.discoverServices()
                 }
                 BluetoothProfile.STATE_DISCONNECTED -> {
                     log("HR-strap: disconnected (status=$status)")
                     loggedFirstHr = false   // a reconnect should log its first sample again
+                    loggedPolarIdentity = false
                     loggedFirstSensor = false
                     _batteryPct.value = null // a stale charge must not outlive the link
                     flush()

--- a/android/app/src/main/java/com/noop/polar/PmdDecoder.kt
+++ b/android/app/src/main/java/com/noop/polar/PmdDecoder.kt
@@ -23,6 +23,18 @@ enum class PolarPmdMeasurement(val raw: Int) {
     GYRO(0x05),
     MAGNETOMETER(0x06);
 
+    /** Short lower-case token for diagnostics / the debug strap log (e.g. "ecg", "ppi"). Engineer-facing,
+     *  not localised. Twin of Swift PolarPmdMeasurement.label. */
+    val label: String
+        get() = when (this) {
+            ECG -> "ecg"
+            PPG -> "ppg"
+            ACC -> "acc"
+            PPI -> "ppi"
+            GYRO -> "gyro"
+            MAGNETOMETER -> "mag"
+        }
+
     companion object {
         fun fromRaw(raw: Int): PolarPmdMeasurement? = entries.firstOrNull { it.raw == raw }
     }

--- a/android/app/src/main/java/com/noop/polar/PolarModel.kt
+++ b/android/app/src/main/java/com/noop/polar/PolarModel.kt
@@ -44,6 +44,30 @@ enum class PolarModel {
     val hrvPmdStream: PolarPmdMeasurement?
         get() = if (pmdStreams.contains(PolarPmdMeasurement.PPI)) PolarPmdMeasurement.PPI else null
 
+    /** Engineer-facing model label for the debug strap log (not localised). UNKNOWN reads as
+     *  "(unrecognised model)" so it composes into "Polar (unrecognised model)". Twin of Swift displayLabel. */
+    val displayLabel: String
+        get() = when (this) {
+            H10 -> "H10"
+            H9 -> "H9"
+            OH1 -> "OH1"
+            VERITY_SENSE -> "Verity Sense"
+            UNKNOWN -> "(unrecognised model)"
+        }
+
+    /** One-line PMD / HRV-route capability summary for the debug strap log — a pure restatement of
+     *  pmdStreams / hrvPmdStream (no behaviour gates on it). Streams are ordered by their PMD type byte for
+     *  a stable, protocol-natural order. Twin of Swift pmdDebugSummary. */
+    val pmdDebugSummary: String
+        get() {
+            val streams = if (pmdStreams.isEmpty()) {
+                if (this == UNKNOWN) "PMD unknown (probe)" else "no PMD service"
+            } else {
+                "PMD " + pmdStreams.sortedBy { it.raw }.joinToString(",") { it.label }
+            }
+            return "$streams; ${if (hrvPmdStream == null) "HRV via standard R-R" else "HRV via PMD PPI"}"
+        }
+
     companion object {
         /** Identify the model from a peripheral's advertised name (case-insensitive on the "Polar <MODEL>"
          *  prefix). A non-Polar or unrecognised name → UNKNOWN. "Polar Sense" is the Verity Sense's
@@ -63,6 +87,26 @@ enum class PolarModel {
                 n.startsWith("polar sense") -> VERITY_SENSE
                 else -> UNKNOWN
             }
+        }
+
+        /** Whether an advertised name belongs to a Polar sensor AT ALL — the public "Polar " prefix.
+         *  Distinct from [fromAdvertisedName], which returns UNKNOWN for BOTH a non-Polar strap and an
+         *  unrecognised Polar one; this separates "not a Polar device" from "a Polar device we can't name
+         *  yet", so Polar-only diagnostics never fire for a Wahoo/Garmin strap. Works on a live scan name OR
+         *  a stored PairedDevice model, so a paired strap auto-detects without a live connection.
+         *  Twin of Swift PolarModel.isPolar. */
+        fun isPolar(name: String?): Boolean =
+            name?.trim()?.lowercase()?.startsWith("polar ") == true
+
+        /** The full one-line identification for the debug strap log / Test Centre when a Polar strap is
+         *  seen — e.g. "Polar H10 identified — PMD ecg,acc; HRV via standard R-R". Auto-detected from any
+         *  advertised name, whether a live scan result or a stored PairedDevice model. Returns null for a
+         *  non-Polar name, so a caller emits nothing for a Wahoo/Garmin strap. Twin of Swift
+         *  debugIdentification. */
+        fun debugIdentification(name: String?): String? {
+            if (!isPolar(name)) return null
+            val model = fromAdvertisedName(name)
+            return "Polar ${model.displayLabel} identified — ${model.pmdDebugSummary}"
         }
     }
 }

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -2049,6 +2049,12 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         ble.debugLogcat = enabled
     }
 
+    /** #polar-debug: toggle the Polar strap-identity diagnostic. Read live at connect by the strap source
+     *  (via [SourceCoordinator]); no restart needed. Diagnostic-only — nothing gates behaviour on it. */
+    fun setPolarDebugLogging(enabled: Boolean) {
+        NoopPrefs.setPolarDebugLogging(appContext, enabled)
+    }
+
     /** #1121: toggle the opt-in rolling "detailed capture" strap-log file. Persisted so it survives a
      *  process kill (re-armed in [init] below). */
     fun setDetailedCapture(enabled: Boolean) {

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -469,6 +469,18 @@ object NoopPrefs {
         of(context).edit().putBoolean(KEY_DEBUG_LOGGING, enabled).apply()
     }
 
+    /** Whether a connecting Polar strap logs the model NOOP identifies it as (+ its PMD/HRV capability
+     *  summary) to the strap log. Default off; the Test Centre only exposes it when a Polar strap is
+     *  paired. Diagnostic-only — nothing gates behaviour on it. Twin of iOS AppModel.polarDebugLoggingKey. */
+    const val KEY_POLAR_DEBUG_LOGGING = "noop.polarDebugLogging"
+
+    fun polarDebugLogging(context: Context): Boolean =
+        of(context).getBoolean(KEY_POLAR_DEBUG_LOGGING, false)
+
+    fun setPolarDebugLogging(context: Context, enabled: Boolean) {
+        of(context).edit().putBoolean(KEY_POLAR_DEBUG_LOGGING, enabled).apply()
+    }
+
     /** #1121: whether the opt-in "detailed capture" rolling strap-log file is on. Persisted so capture
      *  RESUMES after the process is killed (AppViewModel re-arms the BLE client from this on launch). */
     const val KEY_DETAILED_CAPTURE = "noop.detailedCapture"

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -47,6 +47,7 @@ import com.noop.analytics.ReadinessTier
 import com.noop.ble.PuffinExperiment
 import com.noop.ble.WhoopModel
 import com.noop.data.DailyMetric
+import com.noop.polar.PolarModel
 import com.noop.testcentre.CaptureAccumulator
 import com.noop.testcentre.CaptureKind
 import com.noop.testcentre.DisplayPerformanceMonitor
@@ -346,6 +347,16 @@ private fun DiagnosticToolsCard(vm: AppViewModel) {
     var showRecalibrate by remember { mutableStateOf(false) }
     // "Debug logging" moved here from Settings: dev-only, mirrors the strap log to logcat over adb.
     var debugLogging by remember { mutableStateOf(NoopPrefs.debugLogging(context)) }
+    // #polar-debug: the model NOOP auto-detects for a PAIRED Polar strap, from its stored advertised name
+    // (no live connection needed). null when no Polar strap is paired → the whole toggle stays hidden, so a
+    // non-Polar user never sees Polar debug. Loaded once from the registry.
+    var polarIdentity by remember { mutableStateOf<String?>(null) }
+    var polarDebugLogging by remember { mutableStateOf(NoopPrefs.polarDebugLogging(context)) }
+    LaunchedEffect(Unit) {
+        val name = runCatching { vm.pairedDevices() }.getOrDefault(emptyList())
+            .firstOrNull { PolarModel.isPolar(it.model) }?.model
+        polarIdentity = PolarModel.debugIdentification(name)
+    }
     var detailedCapture by remember { mutableStateOf(NoopPrefs.detailedCapture(context)) }
     var captureShareBusy by remember { mutableStateOf(false) }
     // #646/#651: LogExport.shareStrapLog's file write now runs on Dispatchers.IO instead of blocking the
@@ -408,6 +419,18 @@ private fun DiagnosticToolsCard(vm: AppViewModel) {
                     checked = debugLogging,
                     onCheckedChange = { debugLogging = it; vm.setDebugLogging(it) },
                     colors = settingsSwitchColors(),
+                )
+            }
+            // #polar-debug: only shown when a Polar strap is paired (polarIdentity != null). The subtitle is
+            // the model auto-detected from the paired record; the toggle also writes it to the strap log on
+            // each connect. Off by default. Diagnostic-only — nothing gates behaviour on it.
+            polarIdentity?.let { identity ->
+                ToggleRowTC(
+                    title = "Polar debug logging",
+                    description = "$identity.\nLogs this identification to the strap log on each connect, " +
+                        "so a Polar bug report shows the model NOOP resolved your strap to.",
+                    checked = polarDebugLogging,
+                    onCheckedChange = { polarDebugLogging = it; vm.setPolarDebugLogging(it) },
                 )
             }
             // #1121 Detailed capture: an adb-like rolling on-device log, no computer needed. Off by default.

--- a/android/app/src/test/java/com/noop/polar/PolarModelTest.kt
+++ b/android/app/src/test/java/com/noop/polar/PolarModelTest.kt
@@ -50,4 +50,43 @@ class PolarModelTest {
         // happens to contain "h10" must stay an OH1 (a `contains` matcher wrongly returned H10 here).
         assertEquals(PolarModel.OH1, PolarModel.fromAdvertisedName("Polar OH1 H10ABCDE"))
     }
+
+    // Debug identification (Test Centre / strap-log diagnostics) — parity with the Swift twin.
+
+    @Test fun isPolarSeparatesPolarFromUnrecognisedAndForeign() {
+        assertTrue(PolarModel.isPolar("Polar H10 A1B2C3D4"))
+        assertTrue(PolarModel.isPolar("Polar Grit X"))       // real Polar, no catalog entry
+        assertTrue(PolarModel.isPolar("polar sense 99AA"))   // case-insensitive
+        assertFalse(PolarModel.isPolar("Wahoo TICKR"))
+        assertFalse(PolarModel.isPolar("Polaris X"))         // prefix must be "polar " + space
+        assertFalse(PolarModel.isPolar(null))
+        assertFalse(PolarModel.isPolar(""))
+    }
+
+    @Test fun pmdDebugSummaryStatesStreamsAndHrvRoute() {
+        assertEquals("PMD ecg,acc; HRV via standard R-R", PolarModel.H10.pmdDebugSummary)
+        assertEquals("no PMD service; HRV via standard R-R", PolarModel.H9.pmdDebugSummary)
+        assertEquals("PMD ppg,acc,ppi; HRV via PMD PPI", PolarModel.OH1.pmdDebugSummary)
+        assertEquals("PMD ppg,acc,ppi,gyro; HRV via PMD PPI", PolarModel.VERITY_SENSE.pmdDebugSummary)
+        assertEquals("PMD unknown (probe); HRV via standard R-R", PolarModel.UNKNOWN.pmdDebugSummary)
+    }
+
+    @Test fun debugIdentificationAutoDetectsFromAnyName() {
+        // Same helper works on a live scan name OR a stored PairedDevice model — a paired strap
+        // auto-detects without a live connection.
+        assertEquals(
+            "Polar H10 identified — PMD ecg,acc; HRV via standard R-R",
+            PolarModel.debugIdentification("Polar H10 A1B2C3D4"),
+        )
+        assertEquals(
+            "Polar Verity Sense identified — PMD ppg,acc,ppi,gyro; HRV via PMD PPI",
+            PolarModel.debugIdentification("Polar Sense 99AABBCC"),
+        )
+        assertEquals(
+            "Polar (unrecognised model) identified — PMD unknown (probe); HRV via standard R-R",
+            PolarModel.debugIdentification("Polar Grit X"),
+        )
+        assertNull(PolarModel.debugIdentification("Wahoo TICKR"))
+        assertNull(PolarModel.debugIdentification(null))
+    }
 }

--- a/project.yml
+++ b/project.yml
@@ -60,6 +60,12 @@ packages:
   # zero CoreBluetooth, so it stays headless/JVM-testable; the app target imports it for OuraLiveSource.
   OuraProtocol:
     path: Packages/OuraProtocol
+  # Clean-room local Polar sensor facts: model identification + PMD stream capability catalog (pure value
+  # types, zero CoreBluetooth, headless/JVM-testable). The app target imports it so StandardHRSource can
+  # log which Polar model a connecting strap is, and the Test Centre can auto-detect it from the paired
+  # record. The live PMD data path is not wired yet — this is identification/diagnostics only.
+  PolarProtocol:
+    path: Packages/PolarProtocol
   # Compresses the full-database `.noopbak` backup (single-entry deflate ZIP) in DataBackup.swift.
   # Already resolved transitively via StrandImport; linked directly so the app target can
   # `import ZIPFoundation`. Same exact version as StrandImport's, so SPM resolves one copy.
@@ -148,6 +154,7 @@ targets:
       - package: MarkdownUI
       - package: ZIPFoundation
       - package: OuraProtocol
+      - package: PolarProtocol
   StrandTests:
     type: bundle.unit-test
     platform: macOS
@@ -314,6 +321,7 @@ targets:
       - package: StrandDesign
       - package: MarkdownUI
       - package: ZIPFoundation
+      - package: PolarProtocol
       - target: NOOPiOSWidgets
       # Embed the watchOS app so the iPhone app carries it (NOOP.app/Watch/NOOPWatch.app). A watch app
       # installs by riding inside its iOS companion; without this it would never reach a paired watch.


### PR DESCRIPTION
## What & why

When a Polar strap connects it uses the standard-HR path, which never records **which** Polar model it is — so a bug report can't show whether NOOP saw an H10 / OH1 / Verity Sense / unrecognised model, nor what PMD/HRV route that implies. `PolarModel.from` (the resolver whose matcher was fixed in #1378) was, until now, **never exercised on a live path**.

This wires Polar model identification in as **diagnostics only** — no live PMD data path, nothing gates behaviour on it.

## How

- **Pure layer** (`PolarProtocol` / `com.noop.polar`, both platforms): `PolarModel.isPolar` (separates "a Polar we can't name yet" from "not a Polar device", so Polar-only diagnostics never fire for a Wahoo/Garmin strap), `displayLabel`, a `pmdDebugSummary` capability line, and a `debugIdentification(name)` one-liner. All pure + unit-tested; they work on a live scan name **or** a stored `PairedDevice.model`, so a **paired** strap auto-detects with no live connection.
- **Toggle**: new `polarDebugLogging` pref (default **off**), shown in the **Test Centre only when a Polar strap is paired** — a non-Polar user never sees it. Its subtitle is the model auto-detected from the paired record; when on, the same line is written to the strap log **once per connect**, so it lands in any Polar bug report.

Example strap-log line:
```
HR-strap: Polar H10 identified — PMD ecg,acc; HRV via standard R-R
```

## Parity

| | iOS | Android |
|---|---|---|
| pure helpers | `PolarModel.isPolar` / `debugIdentification` | twin |
| pref | `AppModel.polarDebugLoggingKey` | `NoopPrefs.KEY_POLAR_DEBUG_LOGGING` |
| live hook | `StandardHRSource` (+ `SourceCoordinator`) | `StandardHrSource` (+ `SourceCoordinator`) |
| toggle | `TestCentreView` | `TestCentreScreen` (+ `AppViewModel`) |

`PolarProtocol` was a **dormant package** (linked nowhere), so `project.yml` now links it into the `Strand` + `NOOPiOS` app targets.

## Verification

- Pure layer: `cd Packages/PolarProtocol && swift test` — 25 pass (incl. the new `isPolar` / `pmdDebugSummary` / `debugIdentification` cases). Runs in `swift-packages` CI.
- Android: `:app:compileFullDebugKotlin` + unit-test compile clean; `com.noop.polar.PolarModelTest` 8/8; `i18n_audit.py --ci main` + `doc_comment_lint.py` clean.
- iOS app-target Swift (`StandardHRSource`, `SourceCoordinator`, `TestCentreView`, `AppModel`) + the new `project.yml` linkage — validated via the on-demand **app-build gate** (default CI doesn't compile app targets).
- **On hardware (not yet):** the toggle + strap-log line want a real Polar strap connect to confirm end-to-end; the identification logic itself is unit-tested.

Diagnostic-only; no schema/migration, no version bump. The live PMD data path remains unbuilt (per the Polar PMD-direction discussion).