### PR TITLE
fix(sleep): collapse a grazing pre-onset fragment; stop merging adjacent naps (#1284)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/SleepSessionDedup.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/SleepSessionDedup.swift
@@ -25,14 +25,21 @@ public enum SleepSessionDedup {
     /// the absolute overlap is under the 30 min bar (e.g. a 40 min fragment 60% inside the night).
     public static let minOverlapFractionOfShorter = 0.5
 
-    /// Edge gap (seconds) at or below which two DISJOINT sessions are still one night (#1284 residual 3).
-    /// The Oura SleepNet burst runs a few epochs before the `0x49` onset, so its pre-onset piece can bank
-    /// as a short session ending seconds before the anchored night begins with NO overlap — the overlap
-    /// rule above misses it (measured 69 s on 08-10/11; the pre-onset run is ~7 min / 14 codes per
-    /// `OuraLiveSource`). A gap this small can only be one interrupted night, never two real sleeps: a
-    /// genuine nap is hours from the main sleep, so it never trips this. 15 min is ~2× the observed
-    /// pre-onset span, catching the fragment with margin while staying far below any real inter-sleep gap.
+    /// Edge distance (seconds) at or below which a same-night FRAGMENT is still one night (#1284 residual 3).
+    /// The Oura SleepNet burst runs a few epochs before the `0x49` onset, so its pre-onset piece can bank as
+    /// a short session ending just before — or, when the backward lay overshoots the onset, grazing just
+    /// into — the anchored night. This bar catches it on EITHER side of the touch point (see the fragment
+    /// rule in `isDuplicate`); 15 min is ~2× the observed pre-onset span, well below any real inter-sleep gap.
     public static let nearAdjacentSeconds = 15 * 60
+
+    /// A shorter session at or below this fraction of the longer one is a re-decode FRAGMENT of that night,
+    /// not a second sleep (#1284 residual 3). It is what separates a fragment hugging a night (26 min beside
+    /// a 390 min night = 6.7 % → collapse; a 40 min pre-onset piece beside an 8 h night = 8.3 % → collapse)
+    /// from two GENUINE adjacent naps of comparable length (20 min beside 33 min = 61 % → kept), which must
+    /// never merge. Ratio, not an absolute cap: real naps and re-decode fragments overlap in absolute length
+    /// (both ~20–30 min), so only the ratio to the partner night tells them apart. Deliberately conservative
+    /// (0.10): the durable fix is generation-side `0x49`-onset keying — this only heals what still slips through.
+    public static let fragmentFractionOfLonger = 0.10
 
     /// Seconds of overlap between the two sessions' EFFECTIVE spans (edited onsets honoured,
     /// mirroring how display / day assignment place the block). 0 when disjoint.
@@ -46,19 +53,29 @@ public enum SleepSessionDedup {
         max(0, max(a.effectiveStartTs, b.effectiveStartTs) - min(a.endTs, b.endTs))
     }
 
-    /// True when `a` and `b` are copies of the same night: overlap of at least `minOverlapSeconds`
-    /// absolute, OR at least `minOverlapFractionOfShorter` of the shorter session's duration, OR (when
-    /// disjoint) an edge gap within `nearAdjacentSeconds` (#1284, the non-overlapping pre-onset fragment).
+    /// True when `a` and `b` are copies of the same night: a substantial overlap (`minOverlapSeconds`
+    /// absolute, OR `minOverlapFractionOfShorter` of the shorter session), OR a same-night FRAGMENT — a
+    /// session no more than `fragmentFractionOfLonger` of the longer one — sitting at its edge, whether it
+    /// grazes in (small overlap) or falls just short (gap within `nearAdjacentSeconds`).
+    ///
+    /// The fragment term is deliberately continuous across the overlap==0 seam: a pre-onset piece that
+    /// overshoots the anchored onset by seconds must not be treated as MORE distinct than one ending seconds
+    /// short of it (that discontinuity left a 121 s-grazing fragment un-collapsed on 08-13/14 while a 69 s
+    /// gap collapsed — #1284). The ratio gate keeps two GENUINE adjacent naps (comparable length) apart.
     /// All terms use only (effectiveStartTs, endTs), the only time fields the data model carries.
     public static func isDuplicate(_ a: CachedSleepSession, _ b: CachedSleepSession) -> Bool {
         let overlap = overlapSeconds(a, b)
-        if overlap <= 0 {
-            // Disjoint: a same-night fragment banked just before/after the anchored night (#1284).
-            return edgeGapSeconds(a, b) <= nearAdjacentSeconds
-        }
         if overlap >= minOverlapSeconds { return true }
-        let shorter = min(max(a.endTs - a.effectiveStartTs, 0), max(b.endTs - b.effectiveStartTs, 0))
-        return shorter > 0 && Double(overlap) >= minOverlapFractionOfShorter * Double(shorter)
+        let aDur = max(a.endTs - a.effectiveStartTs, 0)
+        let bDur = max(b.endTs - b.effectiveStartTs, 0)
+        let shorter = min(aDur, bDur)
+        if overlap > 0, shorter > 0, Double(overlap) >= minOverlapFractionOfShorter * Double(shorter) {
+            return true
+        }
+        // Same-night fragment: short relative to the longer night AND hugging its edge (either side).
+        let longer = max(aDur, bDur)
+        let isFragment = shorter > 0 && Double(shorter) <= fragmentFractionOfLonger * Double(longer)
+        return isFragment && (overlap > 0 || edgeGapSeconds(a, b) <= nearAdjacentSeconds)
     }
 
     /// Collapse overlapping duplicates to one canonical survivor per night, deterministically.

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/SleepSessionDedupTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/SleepSessionDedupTests.swift
@@ -152,4 +152,47 @@ final class SleepSessionDedupTests: XCTestCase {
         XCTAssertFalse(SleepSessionDedup.isDuplicate(a, b))
         XCTAssertEqual(SleepSessionDedup.dedupe([a, b]).kept.count, 2)
     }
+
+    // MARK: - #1284 residual 3 (cont.): the overlap==0 cliff, and the adjacent-nap guard
+
+    func testOura1284GrazingFragmentCollapsesAcrossTheOverlapSeam() {
+        // 08-13/14: a 26 min re-decode fragment whose backward lay overshot the onset, so it GRAZES the
+        // 390 min anchored night by 121 s. The old rule collapsed a fragment ending 69 s SHORT but not one
+        // grazing 121 s IN — a discontinuity at overlap==0. The fragment (6.7% of the night) now collapses.
+        let night = session(start: midnight, end: midnight + 390 * 60)
+        let fragEnd = midnight + 121
+        let fragment = session(start: fragEnd - 26 * 60, end: fragEnd)   // 26 min, 121 s into the night
+        XCTAssertEqual(SleepSessionDedup.overlapSeconds(fragment, night), 121, "grazes by 121 s, not disjoint")
+        XCTAssertTrue(SleepSessionDedup.isDuplicate(fragment, night),
+                      "a short fragment grazing the night is one interrupted night, not a second sleep")
+        let result = SleepSessionDedup.dedupe([fragment, night], freshStarts: [night.startTs])
+        XCTAssertEqual(result.kept.map(\.startTs), [night.startTs], "the fuller anchored night survives")
+    }
+
+    func testOura1284AdjacentNapsOfComparableLengthAreKept() {
+        // The guard against over-collapse: two GENUINE consecutive naps (20 min then 33 min, a 471 s gap,
+        // seen in the oura-import corpus) are comparable in length — the shorter is 61% of the longer, far
+        // above the fragment ratio — so they must NOT merge, even though the gap is within the near bar.
+        let nap1 = session(start: midnight, end: midnight + 20 * 60)
+        let nap2 = session(start: midnight + 20 * 60 + 471, end: midnight + 20 * 60 + 471 + 33 * 60)
+        XCTAssertLessThanOrEqual(SleepSessionDedup.edgeGapSeconds(nap1, nap2), SleepSessionDedup.nearAdjacentSeconds,
+                                 "the gap is within the near-adjacent bar — only the ratio keeps them apart")
+        XCTAssertFalse(SleepSessionDedup.isDuplicate(nap1, nap2), "comparable-length naps are two sleeps, not a fragment")
+        XCTAssertEqual(SleepSessionDedup.dedupe([nap1, nap2]).kept.count, 2)
+    }
+
+    func testOura1284MultiplePhantomFragmentsAllCollapseToTheNight() {
+        // 08-14/15: one night re-decoded into several short phantom copies at drifting offsets. Every
+        // phantom is a fragment of the night, so all collapse to it regardless of how they relate to EACH
+        // other — closing the non-transitive, sort-order-dependent survivor set the cliff produced.
+        let night = session(start: midnight, end: midnight + 390 * 60)
+        let phantomA = session(start: midnight - 24 * 60, end: midnight + 2 * 60)   // grazes in by 2 min
+        let phantomB = session(start: midnight + 12 * 60, end: midnight + 38 * 60)  // fully inside the head
+        let phantomC = session(start: midnight + 27 * 60, end: midnight + 53 * 60)  // fully inside the head
+        for order in [[night, phantomA, phantomB, phantomC], [phantomC, phantomA, night, phantomB]] {
+            let result = SleepSessionDedup.dedupe(order, freshStarts: [night.startTs])
+            XCTAssertEqual(result.kept.map(\.startTs), [night.startTs],
+                           "the night is the sole survivor whatever the input order")
+        }
+    }
 }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/SleepSessionDedupTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/SleepSessionDedupTests.swift
@@ -195,4 +195,33 @@ final class SleepSessionDedupTests: XCTestCase {
                            "the night is the sole survivor whatever the input order")
         }
     }
+
+    // MARK: - #1284 residual 3: survivor selection (mode-2 partial drain · mode-1 identical re-anchors)
+
+    func testOura1284PartialDrainKeepsTheFullerOverlappingDecode() {
+        // Mode 2 (08-13/14): two OVERLAPPING decodes of one night at different completeness — a full 494 min
+        // decode and a 234 min partial from an earlier burst (nested inside it). Both are the same night; the
+        // FULLER one must survive (rank rule 3, longest duration) so a partial re-drain never clobbers a
+        // complete night. This is the "completeness adjudication" the generation-side keying will lean on.
+        let full = session(start: midnight, end: midnight + 494 * 60)
+        let partial = session(start: midnight + 242, end: midnight + 242 + 234 * 60)   // nested in `full`
+        XCTAssertTrue(SleepSessionDedup.isDuplicate(full, partial))
+        let result = SleepSessionDedup.dedupe([partial, full])   // no freshStarts → longest-wins decides
+        XCTAssertEqual(result.kept.map(\.startTs), [full.startTs], "the fuller decode of the night survives")
+        XCTAssertEqual(result.dropped.map(\.startTs), [partial.startTs])
+    }
+
+    func testOura1284IdenticalReAnchorsResolveByLatestEnd() {
+        // Mode 1 (08-16): one rigid block re-anchored at several onsets — same duration, same shape, only the
+        // END chases wall-clock. Duration can't adjudicate (all equal), so the tie-break (latest endTs) picks
+        // the row whose wake edge is latest — the one that matched WHOOP's wake on the day it was measured.
+        // Pins that load-bearing order so a future change never retunes the survivor away from ground truth.
+        let r1 = session(start: midnight, end: midnight + 368 * 60)
+        let r2 = session(start: midnight + 15 * 60, end: midnight + 15 * 60 + 368 * 60)
+        let r3 = session(start: midnight + 30 * 60, end: midnight + 30 * 60 + 368 * 60)   // latest end
+        let result = SleepSessionDedup.dedupe([r2, r3, r1])
+        XCTAssertEqual(result.kept.map(\.startTs), [r3.startTs],
+                       "among equal-length re-anchors, the latest-waking row wins")
+        XCTAssertEqual(result.dropped.count, 2)
+    }
 }

--- a/Strand/BLE/SourceCoordinator.swift
+++ b/Strand/BLE/SourceCoordinator.swift
@@ -387,16 +387,19 @@ final class SourceCoordinator: ObservableObject {
                     // blind to the common case: an overnight with link drops mints the duplicate across
                     // DIFFERENT connections. Read the day's stored sessions here instead (cross-connection,
                     // survives an app restart) and log — using the SAME `SleepSessionDedup.isDuplicate` rule
-                    // the heal uses — when this persist duplicates one. `startDelta` ≈ the 0x49 onset jitter
-                    // (a session's startTs IS its anchored onset); the two shapes say WHICH row is fuller.
-                    // One compact line per duplicate, to survive the log head-clip. This is the corpus the
-                    // generation-side 0x49/sleep-day keying will be designed against.
+                    // the heal uses — when this persist duplicates one. `startDelta` is END-ANCHOR DRIFT, NOT
+                    // 0x49 onset jitter: startTs is `end − laidCodes·30 s`, and the 0x49 onset is applied only
+                    // as a one-way PRE-onset clip (OuraLiveSource `sleepStart`), which does not bind when the
+                    // backward lay never reaches it — so every row can be tagged `[0x49-onset]` yet none start
+                    // AT the onset (08-16: 4,206 s startDelta over 21 s of real onset jitter). The two shapes
+                    // say WHICH row is fuller. One compact line per duplicate, to survive the log head-clip;
+                    // this is the corpus the generation-side 0x49-onset keying will be designed against.
                     let from = session.startTs - 16 * 3600 - 3600
                     let to = session.endTs + 3600
                     let stored = ((try? await store.sleepSessions(deviceId: id, from: from, to: to, limit: 64)) ?? [])
                         .filter { $0.startTs != session.startTs }
                     for e in stored where SleepSessionDedup.isDuplicate(session, e) {
-                        straplog("Oura: dup-gen(#1284) persist \(SourceCoordinator.dupGenShape(session)) duplicates stored \(SourceCoordinator.dupGenShape(e)) startDelta=\(session.startTs - e.startTs)s (~0x49 onset jitter) - cross-connection DB read")
+                        straplog("Oura: dup-gen(#1284) persist \(SourceCoordinator.dupGenShape(session)) duplicates stored \(SourceCoordinator.dupGenShape(e)) startDelta=\(session.startTs - e.startTs)s (end-anchor drift) - cross-connection DB read")
                     }
                     _ = try? await store.upsertSleepSessions([session], deviceId: id)
                 }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1777,6 +1777,15 @@ final class IntelligenceEngine: ObservableObject {
         // `freshStarts` (this pass's computed bank witness) only matches the computedId rows; the others
         // fall back to longest-wins, the read-side dedup's own default. Sorted for a deterministic order.
         let healDeviceIds = Self.healDeviceIds(computedId: computedId, registeredIds: regDevices.map { $0.id })
+        // Compact shape of a row for the #1284 heal log — the two measures that adjudicate WHICH copy is
+        // fuller (stage-segment count + decoded JSON length), in the SAME format as the dup-gen diagnostic
+        // (`dupGenShape`) so the two lines parse identically. Window + shape counts only, never stage content
+        // or vitals; the strap log stays local and is shared only when the user exports it (as dup-gen does).
+        func sleepShape(_ s: CachedSleepSession) -> String {
+            let json = s.stagesJSON ?? ""
+            let segs = json.components(separatedBy: "\"stage\"").count - 1
+            return "[\(s.startTs) -> \(s.endTs)] min=\((s.endTs - s.effectiveStartTs) / 60) segs=\(segs) json=\(json.utf8.count)"
+        }
         var healDropped: [CachedSleepSession] = []
         for healId in healDeviceIds {
             let storedSessions = (try? await store.sleepSessions(deviceId: healId, from: windowStart,
@@ -1784,11 +1793,16 @@ final class IntelligenceEngine: ObservableObject {
             let healable = storedSessions.filter {
                 (oldestDay...newestDay).contains(AnalyticsEngine.dayString($0.endTs, offsetSec: tzOffset))
             }
-            let dropped = SleepSessionDedup.dedupe(healable, freshStarts: keptStarts).dropped
-            for stale in dropped {
+            let sweep = SleepSessionDedup.dedupe(healable, freshStarts: keptStarts)
+            for stale in sweep.dropped {
                 _ = try? await store.deleteSleepSession(deviceId: healId, startTs: stale.startTs)
+                // #1284: log which copy was dropped and which survived, so the corpus can confirm the heal
+                // keeps the fuller / end-correct row (the survivor the collapse resolved this stale into).
+                if let survivor = sweep.kept.first(where: { SleepSessionDedup.isDuplicate($0, stale) }) {
+                    diagnosticSink?("Dedup(#1284): dropped \(sleepShape(stale)) kept \(sleepShape(survivor)) - heal", nil)
+                }
             }
-            healDropped.append(contentsOf: dropped)
+            healDropped.append(contentsOf: sweep.dropped)
         }
         // #1284: log the sweep ALWAYS, even at zero removals — a heal that collapsed rows was previously
         // silent (the line below only fired on a non-empty drop), so from the strap log alone it was

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1462,17 +1462,34 @@ object IntelligenceEngine {
         // witness) only matches the computedId rows; the others fall back to longest-wins, the read-side
         // dedup's own default. Sorted for a deterministic order. Mirrors the Swift analyzeRecent heal.
         val healDeviceIds = healDeviceIds(computedId, candidatePriorities.map { it.first })
+        // Compact shape of a row for the #1284 heal log — the two measures that adjudicate WHICH copy is
+        // fuller (stage-segment count + decoded JSON length), in the SAME format as the dup-gen diagnostic
+        // (dupGenShape) so the two lines parse identically. Window + shape counts only, never stage content
+        // or vitals; the strap log stays local and is shared only when the user exports it (as dup-gen does).
+        fun sleepShape(s: SleepSession): String {
+            val json = s.stagesJSON ?: ""
+            val segs = json.split("\"stage\"").size - 1
+            return "[${s.startTs} -> ${s.endTs}] min=${(s.endTs - s.effectiveStartTs) / 60} segs=$segs json=${json.length}"
+        }
         val healDropped = ArrayList<SleepSession>()
         for (healId in healDeviceIds) {
             val storedSessions = repo.sleepSessions(healId, windowStart, nowSeconds, 4000)
             val healable = storedSessions.filter {
                 AnalyticsEngine.dayString(it.endTs, tzOffsetSeconds) in oldestDay..newestDay
             }
-            val dropped = SleepSessionDedup.dedupe(healable, freshStarts = keptStarts).dropped
+            val sweep = SleepSessionDedup.dedupe(healable, freshStarts = keptStarts)
             // Row-only delete: the user-facing deleteSleepSession writes a #33 dismissal tombstone, which
             // would overlap the SURVIVING night's window and permanently suppress its re-detection.
-            for (stale in dropped) repo.deleteSleepSessionRowOnly(stale)
-            healDropped.addAll(dropped)
+            for (stale in sweep.dropped) {
+                repo.deleteSleepSessionRowOnly(stale)
+                // #1284: log which copy was dropped and which survived, so the corpus can confirm the heal
+                // keeps the fuller / end-correct row (the survivor the collapse resolved this stale into).
+                val survivor = sweep.kept.firstOrNull { SleepSessionDedup.isDuplicate(it, stale) }
+                if (survivor != null) {
+                    diag("Dedup(#1284): dropped ${sleepShape(stale)} kept ${sleepShape(survivor)} - heal")
+                }
+            }
+            healDropped.addAll(sweep.dropped)
         }
         // #1284: log the sweep ALWAYS, even at zero removals — a heal that collapsed rows was previously
         // silent (the line below only fired on a non-empty drop), so from the strap log alone it was

--- a/android/app/src/main/java/com/noop/analytics/SleepSessionDedup.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepSessionDedup.kt
@@ -34,14 +34,24 @@ object SleepSessionDedup {
     const val MIN_OVERLAP_FRACTION_OF_SHORTER: Double = 0.5
 
     /**
-     * Edge gap (seconds) at or below which two DISJOINT sessions are still one night (#1284 residual 3).
-     * The Oura SleepNet burst runs a few epochs before the `0x49` onset, so its pre-onset piece can bank
-     * as a short session ending seconds before the anchored night begins with NO overlap — the overlap
-     * rule misses it (measured 69 s on 08-10/11; the pre-onset run is ~7 min / 14 codes per OuraLiveSource).
-     * A gap this small can only be one interrupted night, never two real sleeps: a genuine nap is hours
-     * from the main sleep, so it never trips this. 15 min is ~2x the observed pre-onset span.
+     * Edge distance (seconds) at or below which a same-night FRAGMENT is still one night (#1284 residual 3).
+     * The Oura SleepNet burst runs a few epochs before the `0x49` onset, so its pre-onset piece can bank as
+     * a short session ending just before — or, when the backward lay overshoots the onset, grazing just
+     * into — the anchored night. This bar catches it on EITHER side of the touch point (see the fragment
+     * rule in [isDuplicate]); 15 min is ~2x the observed pre-onset span, well below any real inter-sleep gap.
      */
     const val NEAR_ADJACENT_SECONDS: Long = 15L * 60L
+
+    /**
+     * A shorter session at or below this fraction of the longer one is a re-decode FRAGMENT of that night,
+     * not a second sleep (#1284 residual 3). It separates a fragment hugging a night (26 min beside a
+     * 390 min night = 6.7 % -> collapse; a 40 min pre-onset piece beside an 8 h night = 8.3 % -> collapse)
+     * from two GENUINE adjacent naps of comparable length (20 min beside 33 min = 61 % -> kept), which must
+     * never merge. Ratio, not an absolute cap: real naps and re-decode fragments overlap in absolute length
+     * (both ~20-30 min), so only the ratio to the partner night tells them apart. Deliberately conservative
+     * (0.10): the durable fix is generation-side `0x49`-onset keying — this only heals what still slips through.
+     */
+    const val FRAGMENT_FRACTION_OF_LONGER: Double = 0.10
 
     /** The collapse outcome: canonical survivors + the duplicates dropped, both sorted by startTs. */
     data class Result(val kept: List<SleepSession>, val dropped: List<SleepSession>)
@@ -57,23 +67,32 @@ object SleepSessionDedup {
         maxOf(0L, maxOf(a.effectiveStartTs, b.effectiveStartTs) - minOf(a.endTs, b.endTs))
 
     /**
-     * True when [a] and [b] are copies of the same night: overlap of at least [MIN_OVERLAP_SECONDS]
-     * absolute, OR at least [MIN_OVERLAP_FRACTION_OF_SHORTER] of the shorter session's duration, OR (when
-     * disjoint) an edge gap within [NEAR_ADJACENT_SECONDS] (#1284, the non-overlapping pre-onset fragment).
+     * True when [a] and [b] are copies of the same night: a substantial overlap ([MIN_OVERLAP_SECONDS]
+     * absolute, OR [MIN_OVERLAP_FRACTION_OF_SHORTER] of the shorter session), OR a same-night FRAGMENT — a
+     * session no more than [FRAGMENT_FRACTION_OF_LONGER] of the longer one — sitting at its edge, whether it
+     * grazes in (small overlap) or falls just short (gap within [NEAR_ADJACENT_SECONDS]).
+     *
+     * The fragment term is deliberately continuous across the overlap==0 seam: a pre-onset piece that
+     * overshoots the anchored onset by seconds must not be treated as MORE distinct than one ending seconds
+     * short of it (that discontinuity left a 121 s-grazing fragment un-collapsed on 08-13/14 while a 69 s gap
+     * collapsed — #1284). The ratio gate keeps two GENUINE adjacent naps (comparable length) apart.
      * All terms use only (effectiveStartTs, endTs), the only time fields the data model carries.
      */
     fun isDuplicate(a: SleepSession, b: SleepSession): Boolean {
         val overlap = overlapSeconds(a, b)
-        if (overlap <= 0L) {
-            // Disjoint: a same-night fragment banked just before/after the anchored night (#1284).
-            return edgeGapSeconds(a, b) <= NEAR_ADJACENT_SECONDS
-        }
         if (overlap >= MIN_OVERLAP_SECONDS) return true
-        val shorter = minOf(
-            maxOf(a.endTs - a.effectiveStartTs, 0L),
-            maxOf(b.endTs - b.effectiveStartTs, 0L),
-        )
-        return shorter > 0L && overlap.toDouble() >= MIN_OVERLAP_FRACTION_OF_SHORTER * shorter.toDouble()
+        val aDur = maxOf(a.endTs - a.effectiveStartTs, 0L)
+        val bDur = maxOf(b.endTs - b.effectiveStartTs, 0L)
+        val shorter = minOf(aDur, bDur)
+        if (overlap > 0L && shorter > 0L &&
+            overlap.toDouble() >= MIN_OVERLAP_FRACTION_OF_SHORTER * shorter.toDouble()
+        ) {
+            return true
+        }
+        // Same-night fragment: short relative to the longer night AND hugging its edge (either side).
+        val longer = maxOf(aDur, bDur)
+        val isFragment = shorter > 0L && shorter.toDouble() <= FRAGMENT_FRACTION_OF_LONGER * longer.toDouble()
+        return isFragment && (overlap > 0L || edgeGapSeconds(a, b) <= NEAR_ADJACENT_SECONDS)
     }
 
     /**

--- a/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
+++ b/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
@@ -454,10 +454,13 @@ class SourceCoordinator(
                         // the common case: an overnight with link drops mints the duplicate across DIFFERENT
                         // connections. Read the day's stored sessions here (cross-connection, survives an app
                         // restart) and log — using the SAME SleepSessionDedup.isDuplicate rule the heal uses —
-                        // when this persist duplicates one. startDelta ~ the 0x49 onset jitter (a session's
-                        // startTs IS its anchored onset); the two shapes say WHICH row is fuller. One compact
-                        // line per duplicate, to survive the log head-clip. This is the corpus the
-                        // generation-side 0x49/sleep-day keying will be designed against.
+                        // when this persist duplicates one. startDelta is END-ANCHOR DRIFT, NOT 0x49 onset
+                        // jitter: startTs is `end - laidCodes*30 s`, and the 0x49 onset is applied only as a
+                        // one-way PRE-onset clip (OuraLiveSource sleepStart), which does not bind when the
+                        // backward lay never reaches it — so every row can be tagged [0x49-onset] yet none
+                        // start AT the onset (08-16: 4,206 s startDelta over 21 s of real onset jitter). The
+                        // two shapes say WHICH row is fuller. One compact line per duplicate, to survive the
+                        // log head-clip; this is the corpus the generation-side 0x49-onset keying targets.
                         //
                         // ISOLATED in its own runCatching: log-only means log-only. The read below is a DB
                         // round-trip on the BLE persist path and CAN throw (locked DB, disk I/O, a store
@@ -470,7 +473,7 @@ class SourceCoordinator(
                             repo.sleepSessions(deviceId, from, to, 64)
                                 .filter { it.startTs != s.startTs && com.noop.analytics.SleepSessionDedup.isDuplicate(session, it) }
                                 .forEach { e ->
-                                    straplog("Oura: dup-gen(#1284) persist ${dupGenShape(s.startTs, s.endTs, s.stagesJson)} duplicates stored ${dupGenShape(e.startTs, e.endTs, e.stagesJSON)} startDelta=${s.startTs - e.startTs}s (~0x49 onset jitter) - cross-connection DB read")
+                                    straplog("Oura: dup-gen(#1284) persist ${dupGenShape(s.startTs, s.endTs, s.stagesJson)} duplicates stored ${dupGenShape(e.startTs, e.endTs, e.stagesJSON)} startDelta=${s.startTs - e.startTs}s (end-anchor drift) - cross-connection DB read")
                                 }
                         }
                         repo.upsertSleepSessions(listOf(session))

--- a/android/app/src/test/java/com/noop/analytics/SleepSessionDedupTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepSessionDedupTest.kt
@@ -165,4 +165,50 @@ class SleepSessionDedupTest {
         assertTrue(!SleepSessionDedup.isDuplicate(a, b))
         assertEquals(2, SleepSessionDedup.dedupe(listOf(a, b)).kept.size)
     }
+
+    // ── #1284 residual 3 (cont.): the overlap==0 cliff, and the adjacent-nap guard ───────────────
+
+    @Test
+    fun oura1284_grazingFragment_collapsesAcrossTheOverlapSeam() {
+        // 08-13/14: a 26 min re-decode fragment whose backward lay overshot the onset, so it GRAZES the
+        // 390 min anchored night by 121 s. The old rule collapsed a fragment ending 69 s SHORT but not one
+        // grazing 121 s IN — a discontinuity at overlap==0. The fragment (6.7% of the night) now collapses.
+        val night = session(midnight, midnight + 390 * 60L)
+        val fragEnd = midnight + 121L
+        val fragment = session(fragEnd - 26 * 60L, fragEnd) // 26 min, 121 s into the night
+        assertEquals(121L, SleepSessionDedup.overlapSeconds(fragment, night))
+        assertTrue(SleepSessionDedup.isDuplicate(fragment, night))
+        val result = SleepSessionDedup.dedupe(listOf(fragment, night), freshStarts = setOf(night.startTs))
+        assertEquals(listOf(night.startTs), result.kept.map { it.startTs })
+    }
+
+    @Test
+    fun oura1284_adjacentNapsOfComparableLength_areKept() {
+        // The guard against over-collapse: two GENUINE consecutive naps (20 min then 33 min, a 471 s gap,
+        // seen in the oura-import corpus) are comparable in length — the shorter is 61% of the longer, far
+        // above the fragment ratio — so they must NOT merge, even though the gap is within the near bar.
+        val nap1 = session(midnight, midnight + 20 * 60L)
+        val nap2 = session(midnight + 20 * 60L + 471L, midnight + 20 * 60L + 471L + 33 * 60L)
+        assertTrue(SleepSessionDedup.edgeGapSeconds(nap1, nap2) <= SleepSessionDedup.NEAR_ADJACENT_SECONDS)
+        assertTrue(!SleepSessionDedup.isDuplicate(nap1, nap2))
+        assertEquals(2, SleepSessionDedup.dedupe(listOf(nap1, nap2)).kept.size)
+    }
+
+    @Test
+    fun oura1284_multiplePhantomFragments_allCollapseToTheNight() {
+        // 08-14/15: one night re-decoded into several short phantom copies at drifting offsets. Every
+        // phantom is a fragment of the night, so all collapse to it regardless of how they relate to EACH
+        // other — closing the non-transitive, sort-order-dependent survivor set the cliff produced.
+        val night = session(midnight, midnight + 390 * 60L)
+        val phantomA = session(midnight - 24 * 60L, midnight + 2 * 60L) // grazes in by 2 min
+        val phantomB = session(midnight + 12 * 60L, midnight + 38 * 60L) // fully inside the head
+        val phantomC = session(midnight + 27 * 60L, midnight + 53 * 60L) // fully inside the head
+        for (order in listOf(
+            listOf(night, phantomA, phantomB, phantomC),
+            listOf(phantomC, phantomA, night, phantomB),
+        )) {
+            val result = SleepSessionDedup.dedupe(order, freshStarts = setOf(night.startTs))
+            assertEquals(listOf(night.startTs), result.kept.map { it.startTs })
+        }
+    }
 }

--- a/android/app/src/test/java/com/noop/analytics/SleepSessionDedupTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepSessionDedupTest.kt
@@ -211,4 +211,32 @@ class SleepSessionDedupTest {
             assertEquals(listOf(night.startTs), result.kept.map { it.startTs })
         }
     }
+
+    // ── #1284 residual 3: survivor selection (mode-2 partial drain · mode-1 identical re-anchors) ──
+
+    @Test
+    fun oura1284_partialDrain_keepsTheFullerOverlappingDecode() {
+        // Mode 2 (08-13/14): a full 494 min decode and a 234 min partial (nested inside it) are the same
+        // night; the FULLER one must survive (rank rule 3, longest duration) so a partial re-drain never
+        // clobbers a complete night — the completeness adjudication the generation-side keying will lean on.
+        val full = session(midnight, midnight + 494 * 60L)
+        val partial = session(midnight + 242L, midnight + 242L + 234 * 60L) // nested in full
+        assertTrue(SleepSessionDedup.isDuplicate(full, partial))
+        val result = SleepSessionDedup.dedupe(listOf(partial, full)) // no freshStarts → longest-wins decides
+        assertEquals(listOf(full.startTs), result.kept.map { it.startTs })
+        assertEquals(listOf(partial.startTs), result.dropped.map { it.startTs })
+    }
+
+    @Test
+    fun oura1284_identicalReAnchors_resolveByLatestEnd() {
+        // Mode 1 (08-16): one rigid block re-anchored at several onsets — same duration, same shape, only the
+        // END chases wall-clock. Duration can't adjudicate, so the tie-break (latest endTs) picks the row
+        // whose wake edge is latest — the one that matched WHOOP's wake. Pins that load-bearing order.
+        val r1 = session(midnight, midnight + 368 * 60L)
+        val r2 = session(midnight + 15 * 60L, midnight + 15 * 60L + 368 * 60L)
+        val r3 = session(midnight + 30 * 60L, midnight + 30 * 60L + 368 * 60L) // latest end
+        val result = SleepSessionDedup.dedupe(listOf(r2, r3, r1))
+        assertEquals(listOf(r3.startTs), result.kept.map { it.startTs })
+        assertEquals(2, result.dropped.size)
+    }
 }


### PR DESCRIPTION
Two #1284 residual-3 corrections from @pipiche38's field captures — both heal-side; the durable fix is still generation-side `0x49`-onset keying.

## 1. Heal cliff + adjacent-nap over-collapse (`SleepSessionDedup.isDuplicate`)

The `#1338` near-adjacent branch only fired when two sessions were **exactly disjoint** (`overlap <= 0`):

- A short pre-onset fragment that **overshot** the anchored onset and grazed the night by **121 s** stayed un-collapsed — while the same fragment ending **69 s short** collapsed. A discontinuity at the touch point (a fragment grazing *in* treated as more distinct than one falling *short*), and the source of the non-transitive, sort-order-dependent survivor set on 08-14/15.
- The branch had **no shape guard**, so it also merged two **genuine consecutive naps** (20 + 33 min, 471 s apart) in the `oura-import` corpus.

**Fix:** replace the disjoint-only branch with a same-night **fragment** rule, continuous across the `overlap==0` seam — a session ≤ `fragmentFractionOfLonger` (**0.10**) of the longer one collapses into it whether it grazes (small overlap) or falls just short (gap within `nearAdjacentSeconds`). The **ratio** (not an absolute cap) is what separates a re-decode fragment from two comparable naps:

| case | shorter / longer | result |
|---|---|---|
| 26 min fragment grazing 390 min night | 6.7 % | collapse ✅ |
| 40 min pre-onset piece beside 8 h night | 8.3 % | collapse ✅ |
| 20 min + 33 min adjacent naps | 61 % | **kept** ✅ |
| 1 h nap overlapping night by 15 min (existing test) | 12.5 % | **kept** ✅ |

Every phantom is a fragment of the night, so all collapse to it → the non-transitivity closes. #899 overlap rules unchanged; `my-whoop` has no near-adjacent pairs (0/313), so WHOOP is untouched.

## 2. Diagnostic annotation

The `dup-gen(#1284)` line + comment claimed `startDelta ≈ 0x49 onset jitter` / "startTs IS its anchored onset." Neither holds: `startTs = end − laidCodes·30 s`, and the `0x49` onset is a **one-way pre-onset clip** only (`OuraLiveSource` `sleepStart`), which doesn't bind when the backward lay never reaches it — so a row can be tagged `[0x49-onset]` yet not start at the onset (08-16: **4,206 s** `startDelta` over **21 s** of real onset jitter). Relabelled to **end-anchor drift** so the corpus reads correctly. Both platforms.

## Verification

- Kotlin: `compileFullDebugKotlin` clean; `SleepSessionDedupTest` **15/15** (12 existing + 3 new: grazing-fragment collapse, adjacent-nap guard, multi-phantom order-independence); full `*Sleep*`/`*Intelligence*`/`*Dedup*` suites **0 failures** (no heal regression).
- Swift `SleepSessionDedup` is byte-identical logic → covered by `swift-packages` CI; `SourceCoordinator.swift` (annotation) is app-target → app-build gate.

Heal-side only. No schema/migration, no version bump.