### PR TITLE
DRAFT: generation-side 0x49-onset keying for Oura sleep (#1284 residual 3)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
@@ -45,6 +45,15 @@ public struct CachedSleepSession: Equatable, Codable {
         self.startTsAdjusted = startTsAdjusted
         self.stagingSparse = stagingSparse
     }
+
+    /// A copy re-keyed to `newStartTs`, every other field (including the stage segments) unchanged. Used by
+    /// the #1284 generation-side onset keying to set the session's PK to the rounded 0x49 onset (the stable
+    /// per-night anchor); the onset key differs from the end-anchored first-code time by at most the grid.
+    public func withStartTs(_ newStartTs: Int) -> CachedSleepSession {
+        CachedSleepSession(startTs: newStartTs, endTs: endTs, efficiency: efficiency, restingHr: restingHr,
+                           avgHrv: avgHrv, stagesJSON: stagesJSON, userEdited: userEdited,
+                           startTsAdjusted: startTsAdjusted, stagingSparse: stagingSparse)
+    }
 }
 
 /// One cached daily-metrics row pulled from the server's /v1/daily. Natural key (deviceId, day).

--- a/Packages/WhoopStore/Sources/WhoopStore/SleepSessionDedup.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/SleepSessionDedup.swift
@@ -78,6 +78,16 @@ public enum SleepSessionDedup {
         return isFragment && (overlap > 0 || edgeGapSeconds(a, b) <= nearAdjacentSeconds)
     }
 
+    /// The canonical preference key (see `dedupe`): higher tuple wins. Shared by `dedupe` and the
+    /// at-persist keying (`planBank`) so both adjudicate a night with the IDENTICAL rule.
+    static func rankKey(_ s: CachedSleepSession, freshStarts: Set<Int>) -> (Int, Int, Int, Int, Int) {
+        (s.userEdited ? 1 : 0,
+         freshStarts.contains(s.startTs) ? 1 : 0,
+         s.endTs - s.effectiveStartTs,
+         s.endTs,
+         s.startTs)
+    }
+
     /// Collapse overlapping duplicates to one canonical survivor per night, deterministically.
     ///
     /// Canonical preference, highest first:
@@ -96,14 +106,7 @@ public enum SleepSessionDedup {
     public static func dedupe(_ sessions: [CachedSleepSession], freshStarts: Set<Int> = [])
         -> (kept: [CachedSleepSession], dropped: [CachedSleepSession]) {
         guard sessions.count > 1 else { return (sessions, []) }
-        func rank(_ s: CachedSleepSession) -> (Int, Int, Int, Int, Int) {
-            (s.userEdited ? 1 : 0,
-             freshStarts.contains(s.startTs) ? 1 : 0,
-             s.endTs - s.effectiveStartTs,
-             s.endTs,
-             s.startTs)
-        }
-        let ordered = sessions.sorted { rank($0) > rank($1) }
+        let ordered = sessions.sorted { rankKey($0, freshStarts: freshStarts) > rankKey($1, freshStarts: freshStarts) }
         var kept: [CachedSleepSession] = []
         var dropped: [CachedSleepSession] = []
         for s in ordered {
@@ -115,5 +118,53 @@ public enum SleepSessionDedup {
         }
         return (kept.sorted { $0.startTs < $1.startTs },
                 dropped.sorted { $0.startTs < $1.startTs })
+    }
+
+    // MARK: - #1284 residual 3: generation-side 0x49-onset keying (at-persist, no schema migration)
+
+    /// The grid (seconds) the 0x49 onset is rounded to before it becomes a session's `startTs`. The ring
+    /// re-serves one night's `0x49` summary many times as its END chases wall-clock; the ONSET is stable
+    /// across those re-serves (measured 21 s spread over 11 servings on 08-16), so rounding it to a coarse
+    /// grid gives every re-serve of one night the SAME `startTs` → the `(deviceId, startTs)` PK collapses
+    /// them instead of minting a row per drain. 60 s ≫ the 21 s jitter (re-serves land in one bucket) yet
+    /// keeps the displayed bedtime accurate to the minute — and the bedtime becomes the TRUE onset, fixing
+    /// the current end-anchored drift (`startTs = end − laidCodes·30 s`).
+    public static let onsetKeyGridSeconds = 60
+
+    /// Round a `0x49` onset (Unix seconds) to `onsetKeyGridSeconds` — the stable per-night key. Rounds to
+    /// nearest so a jittering onset lands in one bucket; a rare straddle at a bucket edge is caught by the
+    /// completeness guard (`planBank`), which matches the night by overlap, not by the PK.
+    public static func keyedStart(onsetUnixSeconds: Int, gridSeconds: Int = onsetKeyGridSeconds) -> Int {
+        let g = max(1, gridSeconds)
+        return ((onsetUnixSeconds + g / 2) / g) * g
+    }
+
+    /// Decide, at persist time, whether a freshly reconstructed `candidate` night should be banked and
+    /// which already-stored rows it supersedes — the generation-side twin of the `dedupe` heal, so a
+    /// duplicate is suppressed BEFORE it is banked (closing the window where the wrong night shows until
+    /// the next analyze pass). Same collapse rule as `dedupe` with NO bank-recency witness (ring rows fall
+    /// back to longest-, then latest-end-wins):
+    ///   • bank the candidate unless an existing same-night row is at least as complete (ties keep the
+    ///     stored row — an exact re-serve is a no-op; a partial re-drain never clobbers a fuller night);
+    ///   • when the candidate wins (fuller, or a later-waking copy of the same night), delete the
+    ///     same-night rows it supersedes so exactly one row per night survives.
+    /// Pure; the caller does the actual store delete + upsert only when `bank` is true.
+    /// `existing` MUST be the UNFILTERED stored set for the night's window — INCLUDING a row that already
+    /// sits at the candidate's keyed `startTs`. Since keying rounds re-serves of one night to the same
+    /// bucket, that same-PK row is the *common* collision, and it has to be weighed here: otherwise the
+    /// upsert would replace a fuller stored night with a partial re-drain by PK (the exact clobber this
+    /// guard exists to prevent). The `supersededStarts` deliberately EXCLUDE the candidate's own `startTs` —
+    /// the upsert replaces that row in place, so listing it would delete the row we just banked.
+    public static func planBank(candidate: CachedSleepSession, existing: [CachedSleepSession])
+        -> (bank: Bool, supersededStarts: [Int]) {
+        let sameNight = existing.filter { isDuplicate(candidate, $0) }
+        let candidateRank = rankKey(candidate, freshStarts: [])
+        // Suppress the candidate if any stored same-night row (same PK or not) ties or outranks it.
+        if sameNight.contains(where: { rankKey($0, freshStarts: []) >= candidateRank }) {
+            return (bank: false, supersededStarts: [])
+        }
+        // Candidate is the fullest: bank it (the upsert replaces any same-PK row) and retire the OTHER
+        // same-night rows it supersedes.
+        return (bank: true, supersededStarts: sameNight.filter { $0.startTs != candidate.startTs }.map(\.startTs))
     }
 }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/SleepSessionDedupTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/SleepSessionDedupTests.swift
@@ -211,6 +211,108 @@ final class SleepSessionDedupTests: XCTestCase {
         XCTAssertEqual(result.dropped.map(\.startTs), [partial.startTs])
     }
 
+    // MARK: - #1284 residual 3: generation-side onset keying (keyedStart · planBank)
+
+    func testKeyedStartCollapsesOnsetJitterToOneBucket() {
+        // 08-16: the 0x49 onset jittered 21 s across 11 re-serves. Rounded to the 60 s key they share a
+        // startTs, so the (deviceId, startTs) PK collapses the re-serves instead of minting a row per drain.
+        let a = SleepSessionDedup.keyedStart(onsetUnixSeconds: midnight + 55)
+        let b = SleepSessionDedup.keyedStart(onsetUnixSeconds: midnight + 76)   // +21 s
+        XCTAssertEqual(a, b, "onsets within the jitter round to one key")
+        XCTAssertEqual(a % SleepSessionDedup.onsetKeyGridSeconds, 0, "the key lands on the grid")
+    }
+
+    func testPlanBankSupersedesAShorterStoredCopy() {
+        // The candidate is the fuller 494 min decode; a 234 min partial is already stored → bank + retire it.
+        let candidate = session(start: midnight, end: midnight + 494 * 60)
+        let stored = session(start: midnight + 60, end: midnight + 60 + 234 * 60)
+        let plan = SleepSessionDedup.planBank(candidate: candidate, existing: [stored])
+        XCTAssertTrue(plan.bank)
+        XCTAssertEqual(plan.supersededStarts, [stored.startTs])
+    }
+
+    func testPlanBankSuppressesAPartialAgainstAFullerStoredNight() {
+        // Mode-2 in reverse: a partial re-drain arrives after the full night is banked → suppress it.
+        let stored = session(start: midnight, end: midnight + 494 * 60)
+        let candidate = session(start: midnight + 60, end: midnight + 60 + 234 * 60)
+        let plan = SleepSessionDedup.planBank(candidate: candidate, existing: [stored])
+        XCTAssertFalse(plan.bank)
+        XCTAssertTrue(plan.supersededStarts.isEmpty)
+    }
+
+    func testPlanBankLaterWakingReAnchorSupersedesTheEarlier() {
+        // Mode-1 re-serve: same duration, later end (end chases wall-clock). The later copy wins and retires
+        // the earlier — the table converges to the latest-waking (WHOOP-matching) row.
+        let stored = session(start: midnight, end: midnight + 368 * 60)
+        let candidate = session(start: midnight + 15 * 60, end: midnight + 15 * 60 + 368 * 60)
+        let plan = SleepSessionDedup.planBank(candidate: candidate, existing: [stored])
+        XCTAssertTrue(plan.bank)
+        XCTAssertEqual(plan.supersededStarts, [stored.startTs])
+    }
+
+    func testPlanBankFreshNightWithNoStoredMatchBanksClean() {
+        let candidate = session(start: midnight, end: midnight + 400 * 60)
+        let lastNight = session(start: midnight - 24 * 3600, end: midnight - 16 * 3600)
+        let plan = SleepSessionDedup.planBank(candidate: candidate, existing: [lastNight])
+        XCTAssertTrue(plan.bank)
+        XCTAssertTrue(plan.supersededStarts.isEmpty)
+    }
+
+    func testPlanBankIdenticalReserveIsANoOp() {
+        // An exact re-serve keeps the stored row (idempotent), never churns the PK.
+        let stored = session(start: midnight, end: midnight + 400 * 60)
+        let candidate = session(start: midnight, end: midnight + 400 * 60)
+        XCTAssertFalse(SleepSessionDedup.planBank(candidate: candidate, existing: [stored]).bank)
+    }
+
+    func testKeyedStartRoundsHalfUpAndClampsGrid() {
+        XCTAssertEqual(SleepSessionDedup.keyedStart(onsetUnixSeconds: 1000, gridSeconds: 60), 1020)  // nearest 60
+        XCTAssertEqual(SleepSessionDedup.keyedStart(onsetUnixSeconds: 990, gridSeconds: 60), 1020)   // +30 rounds up
+        XCTAssertEqual(SleepSessionDedup.keyedStart(onsetUnixSeconds: 989, gridSeconds: 60), 960)    // just under → down
+        XCTAssertEqual(SleepSessionDedup.keyedStart(onsetUnixSeconds: 1234, gridSeconds: 0), 1234)   // grid clamp ≥1 = identity
+    }
+
+    func testPlanBankSameBucketFullerStoredRowSuppressesAPartialReserve() {
+        // F1 regression: a partial re-drain keyed to the SAME bucket (same PK) as a fuller banked night must
+        // be SUPPRESSED — the upsert would otherwise replace the fuller night's stages by PK. `existing` is
+        // the UNFILTERED stored set, so the same-PK row is weighed here.
+        let fuller = session(start: midnight, end: midnight + 494 * 60)
+        let partial = session(start: midnight, end: midnight + 234 * 60)   // re-drain at the SAME keyed startTs
+        XCTAssertFalse(SleepSessionDedup.planBank(candidate: partial, existing: [fuller]).bank,
+                       "a partial never overwrites a fuller row at the same keyed PK")
+    }
+
+    func testPlanBankSameBucketFullerCandidateBanksWithoutSelfDeleting() {
+        // The candidate is fuller than the stored row at its OWN key → bank (the upsert replaces that row in
+        // place); it must NOT list its own startTs to delete (that would delete the row it just banked).
+        let stored = session(start: midnight, end: midnight + 234 * 60)
+        let candidate = session(start: midnight, end: midnight + 494 * 60)   // fuller, same key
+        let plan = SleepSessionDedup.planBank(candidate: candidate, existing: [stored])
+        XCTAssertTrue(plan.bank)
+        XCTAssertTrue(plan.supersededStarts.isEmpty, "the same-PK row is replaced by the upsert, never deleted")
+    }
+
+    func testPlanBankSupersedesOtherKeyRowsButNotItsOwn() {
+        // Fuller than BOTH a same-key partial and an earlier different-key fragment: bank, delete only the
+        // different-key one (the same-key row is replaced in place by the upsert).
+        let candidate = session(start: midnight, end: midnight + 494 * 60)
+        let sameKeyPartial = session(start: midnight, end: midnight + 200 * 60)
+        let otherKeyFrag = session(start: midnight - 120, end: midnight - 120 + 180 * 60)
+        let plan = SleepSessionDedup.planBank(candidate: candidate, existing: [sameKeyPartial, otherKeyFrag])
+        XCTAssertTrue(plan.bank)
+        XCTAssertEqual(plan.supersededStarts, [otherKeyFrag.startTs])
+    }
+
+    func testPlanBankNeverClobbersAUserEditedNight() {
+        // Data safety: a hand-corrected night outranks any fresh ring persist (userEdited is rank rule 1),
+        // even a FULLER one — so the candidate is suppressed and the edited row is never replaced OR deleted.
+        let edited = session(start: midnight, end: midnight + 400 * 60, edited: true)
+        let candidate = session(start: midnight + 30, end: midnight + 30 + 420 * 60)   // fuller re-detect
+        let plan = SleepSessionDedup.planBank(candidate: candidate, existing: [edited])
+        XCTAssertFalse(plan.bank, "a fresh persist never overwrites a hand-corrected night")
+        XCTAssertTrue(plan.supersededStarts.isEmpty, "the edited row is never deleted")
+    }
+
     func testOura1284IdenticalReAnchorsResolveByLatestEnd() {
         // Mode 1 (08-16): one rigid block re-anchored at several onsets — same duration, same shape, only the
         // END chases wall-clock. Duration can't adjudicate (all equal), so the tie-break (latest endTs) picks

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -1676,6 +1676,17 @@ final class AppModel: ObservableObject {
         set { UserDefaults.standard.set(newValue, forKey: Self.polarDebugLoggingKey) }
     }
 
+    /// #1284 residual 3 (EXPERIMENTAL, default OFF): generation-side 0x49-onset keying for Oura sleep. When
+    /// on, an Oura hypnogram persist keys its startTs on the rounded 0x49 onset (the stable per-night anchor)
+    /// and a completeness guard suppresses/replaces a duplicate re-serve BEFORE it is banked — closing the
+    /// window where the wrong night shows until the next analyze pass. Off = the shipped end-anchored persist.
+    /// A hardware-validation toggle (Test Centre); no effect for a user with no Oura ring.
+    static let ouraOnsetKeyingKey = "noopOuraOnsetKeying"
+    var ouraOnsetKeying: Bool {
+        get { UserDefaults.standard.bool(forKey: Self.ouraOnsetKeyingKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Self.ouraOnsetKeyingKey) }
+    }
+
     /// Recompute the v5 skin-temp suite snapshots (cycle phase + body clock) from the current history.
     /// Called from the analytics pass and when the cycle opt-in flips. Honest-nil throughout: cycle is
     /// nil unless opted in; circadian is nil unless a usable activity profile exists.

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -141,6 +141,9 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// Wired at the composition root to `store.upsertSleepSessions([_], deviceId:)`; default no-op so the
     /// discovery-only scanner and tests take the byte-identical inert path.
     private let persistSleepSession: (CachedSleepSession) -> Void
+    /// #1284 residual 3 (default OFF): read live at persist — when true, an Oura hypnogram night is keyed on
+    /// its rounded 0x49 onset (stable per-night anchor) instead of the end-anchored first-code time.
+    private let onsetKeying: () -> Bool
     private let log: (String) -> Void
     private let onBattery: (Int) -> Void
     /// Fired with the ring's TRUE model label ("Oura Ring 3/4/5") once the GetProductInfo hardware id resolves
@@ -797,8 +800,16 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         // imported-over-computed rule surfaces Oura's SleepNet staging as the night's stages (#325 persist).
         // Reuses the anchored+0x49-refined `end` via `laid`, so the session end IS the true sleep end. The
         // confirmation line makes the persist self-evident in the strap log for on-device validation.
-        if let session = OuraSleepSessionMapping.session(fromCodes: laid.map { (ts: $0.ts, stage: $0.phase.stage) }) {
-            let start = laid.first!.ts
+        if let mapped = OuraSleepSessionMapping.session(fromCodes: laid.map { (ts: $0.ts, stage: $0.phase.stage) }) {
+            // #1284 residual 3: when onset keying is on and a 0x49 onset was applied, key the session's
+            // startTs on the ROUNDED onset (stable across the ring's re-serves) rather than the end-anchored
+            // first-code time — so re-serves of one night share a PK and the displayed bedtime is the true
+            // onset. The completeness guard in the persist closure then suppresses/replaces any duplicate.
+            let session: CachedSleepSession = {
+                guard onsetKeying(), let onset = sleepStart else { return mapped }
+                return mapped.withStartTs(SleepSessionDedup.keyedStart(onsetUnixSeconds: onset))
+            }()
+            let start = session.startTs
             // #1284 residual 3: log when this persist lands wholly inside — or overlapping — a session already
             // banked this connection (the duplicate GENERATION an early partial drain creates, which the #899
             // heal only cleans up afterward). `sleepStart != nil` = a 0x49 anchor was applied; a persist with
@@ -938,6 +949,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 onBattery: @escaping (Int) -> Void = { _ in },
                 onModel: @escaping (String) -> Void = { _ in },
                 onSerial: @escaping (String) -> Void = { _ in },
+                onsetKeying: @escaping () -> Bool = { false },
                 feedsLive: Bool = true,
                 adoptIntent: Bool = false) {
         self.live = live
@@ -950,6 +962,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         self.onBattery = onBattery
         self.onModel = onModel
         self.onSerial = onSerial
+        self.onsetKeying = onsetKeying
         self.feedsLive = feedsLive
         self.adoptIntent = adoptIntent
         // Tier-B MET research corpus: only on a live/persisting source, never the discovery-only scanner.

--- a/Strand/BLE/SourceCoordinator.swift
+++ b/Strand/BLE/SourceCoordinator.swift
@@ -396,18 +396,44 @@ final class SourceCoordinator: ObservableObject {
                     // this is the corpus the generation-side 0x49-onset keying will be designed against.
                     let from = session.startTs - 16 * 3600 - 3600
                     let to = session.endTs + 3600
-                    let stored = ((try? await store.sleepSessions(deviceId: id, from: from, to: to, limit: 64)) ?? [])
-                        .filter { $0.startTs != session.startTs }
-                    for e in stored where SleepSessionDedup.isDuplicate(session, e) {
+                    // UNFILTERED window read: the keying guard MUST see a row already at the candidate's keyed
+                    // startTs (the common same-bucket collision). The dup-gen diagnostic excludes it inline.
+                    let stored = (try? await store.sleepSessions(deviceId: id, from: from, to: to, limit: 64)) ?? []
+                    for e in stored where e.startTs != session.startTs && SleepSessionDedup.isDuplicate(session, e) {
                         straplog("Oura: dup-gen(#1284) persist \(SourceCoordinator.dupGenShape(session)) duplicates stored \(SourceCoordinator.dupGenShape(e)) startDelta=\(session.startTs - e.startTs)s (end-anchor drift) - cross-connection DB read")
                     }
-                    _ = try? await store.upsertSleepSessions([session], deviceId: id)
+                    if UserDefaults.standard.bool(forKey: AppModel.ouraOnsetKeyingKey) {
+                        // #1284 residual 3 (EXPERIMENTAL): completeness-guarded onset keying — suppress or
+                        // replace a duplicate re-serve BEFORE banking, so the wrong night never shows between
+                        // wake and the next analyze pass. Same collapse rule as the heal (`planBank`); `stored`
+                        // is UNFILTERED so a fuller row at the same keyed PK suppresses this candidate.
+                        let plan = SleepSessionDedup.planBank(candidate: session, existing: stored)
+                        if plan.bank {
+                            // Bank the survivor FIRST, retire the rows it supersedes only after it lands — so a
+                            // failed upsert never leaves the night with NEITHER the candidate nor its (deleted)
+                            // duplicates. On failure the stored rows are kept and the heal reconciles next pass.
+                            do {
+                                try await store.upsertSleepSessions([session], deviceId: id)
+                                for s in plan.supersededStarts {
+                                    _ = try? await store.deleteSleepSession(deviceId: id, startTs: s)
+                                }
+                                straplog("Oura: onset-key(#1284) banked \(SourceCoordinator.dupGenShape(session)) superseded \(plan.supersededStarts.count) stored row(s) - generation keying")
+                            } catch {
+                                straplog("Oura: onset-key(#1284) bank FAILED (\(error.localizedDescription)) - kept \(stored.count) stored row(s); heal will reconcile")
+                            }
+                        } else {
+                            straplog("Oura: onset-key(#1284) suppressed \(SourceCoordinator.dupGenShape(session)) - a stored same-night row is at least as complete")
+                        }
+                    } else {
+                        _ = try? await store.upsertSleepSessions([session], deviceId: id)
+                    }
                 }
             },
             log: straplog,
             onBattery: { [live] pct in live.setBattery(Double(pct)) },
             onModel: { [registry] model in registry.setModel(id, model: model) },   // #772: correct a name-guessed gen
             onSerial: { [weak self] serial in self?.adoptOuraSerial(currentId: id, serial: serial) },  // #771
+            onsetKeying: { UserDefaults.standard.bool(forKey: AppModel.ouraOnsetKeyingKey) },  // #1284 residual 3
             adoptIntent: adoptIntent)
         if adoptIntent { straplog("Oura: adopt consent granted - this session may install NOOP's key") }
         ouraSource = source   // the published typed handle for the adopt mirror (same object as activeSource)

--- a/Strand/Screens/TestCentreView.swift
+++ b/Strand/Screens/TestCentreView.swift
@@ -50,6 +50,10 @@ struct TestCentreView: View {
         return PolarModel.debugIdentification(advertisedName: name)
     }
 
+    // #1284 residual 3: experimental Oura 0x49-onset keying, only offered when an Oura ring is paired.
+    @AppStorage(AppModel.ouraOnsetKeyingKey) private var ouraOnsetKeying = false
+    private var ouraPaired: Bool { model.deviceRegistry?.devices.contains { $0.brand == "Oura" } ?? false }
+
     // Section 4: Experimental algorithms. Bound to the SAME PuffinExperiment keys the Android card writes, so
     // the platforms stay in lockstep. The PPG-HR sub-lag interpolation variant and the HRV-readiness readout,
     // both default OFF.
@@ -182,6 +186,20 @@ struct TestCentreView: View {
                         VStack(alignment: .leading, spacing: 2) {
                             Text("Polar debug logging").font(StrandFont.body)
                             Text("\(identity). Logs this to the strap log on each connect, so a Polar bug report shows the model NOOP resolved your strap to.")
+                                .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                    .tint(StrandPalette.accent)
+                }
+
+                // #1284 residual 3: experimental Oura onset keying, only when an Oura ring is paired.
+                if ouraPaired {
+                    Divider().overlay(StrandPalette.hairline)
+                    Toggle(isOn: $ouraOnsetKeying) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Oura onset keying (experimental)").font(StrandFont.body)
+                            Text("Keys each Oura sleep night on its stable 0x49 onset and suppresses duplicate re-serves at the source, instead of the shipped end-anchored persist (#1284). Off by default — a hardware-validation toggle. Watch the strap log for \u{201C}onset-key(#1284)\u{201D} lines.")
                                 .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
                                 .fixedSize(horizontal: false, vertical: true)
                         }

--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -706,6 +706,10 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/TestCentreScreen.kt",
+      "Oura onset keying (experimental)"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TestCentreScreen.kt",
       "Polar debug logging"
     ],
     [
@@ -1133,6 +1137,14 @@
     [
       "Strand/Screens/StressView.swift",
       "Today's value is your recorded daily stress score (0-3)."
+    ],
+    [
+      "Strand/Screens/TestCentreView.swift",
+      "Keys each Oura sleep night on its stable 0x49 onset and suppresses duplicate re-serves at the source, instead of the shipped end-anchored persist (#1284). Off by default — a hardware-validation toggle. Watch the strap log for \\u{201C}onset-key(#1284)\\u{201D} lines."
+    ],
+    [
+      "Strand/Screens/TestCentreView.swift",
+      "Oura onset keying (experimental)"
     ],
     [
       "Strand/Screens/TestCentreView.swift",

--- a/android/app/src/main/java/com/noop/analytics/SleepSessionDedup.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepSessionDedup.kt
@@ -95,6 +95,15 @@ object SleepSessionDedup {
         return isFragment && (overlap > 0L || edgeGapSeconds(a, b) <= NEAR_ADJACENT_SECONDS)
     }
 
+    /** The canonical preference comparator (see [dedupe]): higher ranks first (descending). Shared by
+     *  [dedupe] and the at-persist keying ([planBank]) so both adjudicate a night with the IDENTICAL rule. */
+    private fun rankComparator(freshStarts: Set<Long>): Comparator<SleepSession> =
+        compareByDescending<SleepSession> { it.userEdited }
+            .thenByDescending { it.startTs in freshStarts }
+            .thenByDescending { it.endTs - it.effectiveStartTs }
+            .thenByDescending { it.endTs }
+            .thenByDescending { it.startTs }
+
     /**
      * Collapse overlapping duplicates to one canonical survivor per night, deterministically.
      *
@@ -115,18 +124,59 @@ object SleepSessionDedup {
      */
     fun dedupe(sessions: List<SleepSession>, freshStarts: Set<Long> = emptySet()): Result {
         if (sessions.size < 2) return Result(sessions, emptyList())
-        val ordered = sessions.sortedWith(
-            compareByDescending<SleepSession> { it.userEdited }
-                .thenByDescending { it.startTs in freshStarts }
-                .thenByDescending { it.endTs - it.effectiveStartTs }
-                .thenByDescending { it.endTs }
-                .thenByDescending { it.startTs },
-        )
+        val ordered = sessions.sortedWith(rankComparator(freshStarts))
         val kept = ArrayList<SleepSession>()
         val dropped = ArrayList<SleepSession>()
         for (s in ordered) {
             if (!s.userEdited && kept.any { isDuplicate(it, s) }) dropped.add(s) else kept.add(s)
         }
         return Result(kept.sortedBy { it.startTs }, dropped.sortedBy { it.startTs })
+    }
+
+    // ── #1284 residual 3: generation-side 0x49-onset keying (at-persist, no schema migration) ─────
+
+    /**
+     * The grid (seconds) the 0x49 onset is rounded to before it becomes a session's startTs. The ring
+     * re-serves one night's 0x49 summary many times as its END chases wall-clock; the ONSET is stable
+     * across those re-serves (measured 21 s spread over 11 servings on 08-16), so rounding it to a coarse
+     * grid gives every re-serve of one night the SAME startTs → the (deviceId, startTs) PK collapses them
+     * instead of minting a row per drain. 60 s >> the 21 s jitter (re-serves land in one bucket) yet keeps
+     * the displayed bedtime accurate to the minute — and the bedtime becomes the TRUE onset, fixing the
+     * current end-anchored drift (startTs = end - laidCodes*30 s).
+     */
+    const val ONSET_KEY_GRID_SECONDS: Long = 60L
+
+    /** Round a 0x49 onset (Unix seconds) to [ONSET_KEY_GRID_SECONDS] — the stable per-night key. Rounds to
+     *  nearest so a jittering onset lands in one bucket; a rare straddle at a bucket edge is caught by the
+     *  completeness guard ([planBank]), which matches the night by overlap, not by the PK. */
+    fun keyedStart(onsetUnixSeconds: Long, gridSeconds: Long = ONSET_KEY_GRID_SECONDS): Long {
+        val g = maxOf(1L, gridSeconds)
+        return ((onsetUnixSeconds + g / 2) / g) * g
+    }
+
+    /** The bank decision, mirroring the Swift twin. */
+    data class BankPlan(val bank: Boolean, val supersededStarts: List<Long>)
+
+    /**
+     * Decide, at persist time, whether a freshly reconstructed [candidate] night should be banked and which
+     * already-stored rows it supersedes — the generation-side twin of the [dedupe] heal, so a duplicate is
+     * suppressed BEFORE it is banked (closing the window where the wrong night shows until the next analyze
+     * pass). Same collapse rule as [dedupe] with NO bank-recency witness (ring rows fall back to longest-,
+     * then latest-end-wins): bank the candidate unless an existing same-night row is at least as complete
+     * (ties keep the stored row); when it wins, delete the same-night rows it supersedes. Pure; the caller
+     * does the store delete + upsert only when [BankPlan.bank] is true.
+     *
+     * [existing] MUST be the UNFILTERED stored set for the night's window — INCLUDING a row already at the
+     * candidate's keyed startTs. Keying rounds re-serves of one night to the same bucket, so that same-PK
+     * row is the common collision and must be weighed here, else the upsert would replace a fuller stored
+     * night with a partial re-drain by PK. [BankPlan.supersededStarts] EXCLUDE the candidate's own startTs —
+     * the upsert replaces that row in place, so listing it would delete the row just banked.
+     */
+    fun planBank(candidate: SleepSession, existing: List<SleepSession>): BankPlan {
+        val sameNight = existing.filter { isDuplicate(candidate, it) }
+        val cmp = rankComparator(emptySet())
+        // Suppress the candidate if any stored same-night row (same PK or not) ties or outranks it.
+        if (sameNight.any { cmp.compare(it, candidate) <= 0 }) return BankPlan(false, emptyList())
+        return BankPlan(true, sameNight.filter { it.startTs != candidate.startTs }.map { it.startTs })
     }
 }

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -105,6 +105,9 @@ class OuraLiveSource(
      *  Oura's SleepNet staging win over NOOP's sparse-motion computed night. Wired to
      *  `repository.upsertSleepSessions`; default no-op so the discovery-only scanner + tests stay inert. */
     private val persistSleepSession: (OuraSleepSession, String) -> Unit = { _, _ -> },
+    /** #1284 residual 3 (default OFF): read live at persist — when true, an Oura hypnogram night is keyed on
+     *  its rounded 0x49 onset (stable per-night anchor) instead of the end-anchored first-code time. */
+    private val onsetKeying: () -> Boolean = { false },
     /** Diagnostic sink for the connect/auth/stream lifecycle - the SAME exportable strap log (#421).
      *  Every line is prefixed "Oura: ". Statuses / UUIDs / counts only, NEVER a device address. Default
      *  no-op keeps existing call sites compiling and tests silent. */
@@ -742,8 +745,18 @@ class OuraLiveSource(
         // breakdown) under the ring's own deviceId, so mergeSleepRichness surfaces Oura's SleepNet staging
         // over NOOP's computed night (#325 persist). Uses the anchored+0x49-refined `end` via `laid`. The
         // confirmation line makes the persist self-evident in the strap log for on-device validation.
-        OuraSleepSessionMapping.session(laid.map { it.ts to it.phase.stage })?.let {
-            val start = laid.first().ts
+        OuraSleepSessionMapping.session(laid.map { m -> m.ts to m.phase.stage })?.let { mapped ->
+            // #1284 residual 3: when onset keying is on and a 0x49 onset was applied, key the session's
+            // startTs on the ROUNDED onset (stable across the ring's re-serves) rather than the end-anchored
+            // first-code time — so re-serves of one night share a PK and the bedtime is the true onset. The
+            // completeness guard in the persist closure then suppresses/replaces any duplicate.
+            val onset = sleepStart
+            val session = if (onsetKeying() && onset != null) {
+                mapped.copy(startTs = com.noop.analytics.SleepSessionDedup.keyedStart(onset))
+            } else {
+                mapped
+            }
+            val start = session.startTs
             // #1284 residual 3: log when this persist lands wholly inside — or overlapping — a session already
             // banked this connection. That is the duplicate GENERATION (an early partial drain banked a short
             // session; this fuller burst nests it), which the #899 heal only cleans up afterward. Include the
@@ -759,17 +772,17 @@ class OuraLiveSource(
             if (recentPersistedSessionWindows.size > RECENT_PERSISTED_SESSIONS_CAP) {
                 recentPersistedSessionWindows.subList(0, recentPersistedSessionWindows.size - RECENT_PERSISTED_SESSIONS_CAP).clear()
             }
-            persistSleepSession(it, deviceId)
-            val effStr = it.efficiency?.let { e -> "${(e * 100).toInt()}%" } ?: "n/a"
+            persistSleepSession(session, deviceId)
+            val effStr = session.efficiency?.let { e -> "${(e * 100).toInt()}%" } ?: "n/a"
             // #1284 residual 3: stamp the 0x49 anchor state on EVERY persist, so an unanchored early-drain row
             // (the prime suspect for the short nested duplicate) is self-evident even when it is the FIRST
             // persist, before the duplicate-gen line above can fire.
             // #1284: log the SESSION's STORED window, not the pre-trim burst window. The #1293
             // trailing-run trim shortens the persisted end, so [$start -> $end] (from the burst) reads
             // ~tens of minutes wider than the row — every future capture then reads the wrong window out
-            // of the log. it.startTs/it.endTs are exactly what persistSleepSession banks.
+            // of the log. session.startTs/.endTs are exactly what persistSleepSession banks.
             val anchorTag = if (sleepStart != null) "0x49-onset" else "no-0x49-onset"
-            log("Oura: sleep session persisted [${it.startTs} -> ${it.endTs}] eff=$effStr [$anchorTag] -> $deviceId (ring-provided night; wins merge over computed)")
+            log("Oura: sleep session persisted [${session.startTs} -> ${session.endTs}] eff=$effStr [$anchorTag] -> $deviceId (ring-provided night; wins merge over computed)")
         }
     }
 

--- a/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
+++ b/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
@@ -476,10 +476,34 @@ class SourceCoordinator(
                                     straplog("Oura: dup-gen(#1284) persist ${dupGenShape(s.startTs, s.endTs, s.stagesJson)} duplicates stored ${dupGenShape(e.startTs, e.endTs, e.stagesJSON)} startDelta=${s.startTs - e.startTs}s (end-anchor drift) - cross-connection DB read")
                                 }
                         }
-                        repo.upsertSleepSessions(listOf(session))
+                        if (NoopPrefs.ouraOnsetKeying(ctx)) {
+                            // #1284 residual 3 (EXPERIMENTAL): completeness-guarded onset keying — suppress or
+                            // replace a duplicate re-serve BEFORE banking. UNFILTERED read so a fuller row at the
+                            // candidate's keyed PK suppresses it; a read failure falls back to empty → bank the
+                            // candidate (safe default). Mirrors the Swift twin's structure + FAILED log.
+                            val from = s.startTs - 16 * 3600 - 3600
+                            val to = s.endTs + 3600
+                            val nearby = runCatching { repo.sleepSessions(deviceId, from, to, 64) }.getOrDefault(emptyList())
+                            val plan = com.noop.analytics.SleepSessionDedup.planBank(session, nearby)
+                            if (plan.bank) {
+                                // Bank the survivor FIRST, retire what it supersedes only after it lands — so a
+                                // failed upsert never leaves the night with neither the candidate nor its deleted
+                                // duplicates; on failure the stored rows are kept and the heal reconciles next pass.
+                                runCatching {
+                                    repo.upsertSleepSessions(listOf(session))
+                                    nearby.filter { it.startTs in plan.supersededStarts }.forEach { row -> runCatching { repo.deleteSleepSessionRowOnly(row) } }
+                                    straplog("Oura: onset-key(#1284) banked ${dupGenShape(s.startTs, s.endTs, s.stagesJson)} superseded ${plan.supersededStarts.size} stored row(s) - generation keying")
+                                }.onFailure { straplog("Oura: onset-key(#1284) bank FAILED (${it.message}) - kept ${nearby.size} stored row(s); heal will reconcile") }
+                            } else {
+                                straplog("Oura: onset-key(#1284) suppressed ${dupGenShape(s.startTs, s.endTs, s.stagesJson)} - a stored same-night row is at least as complete")
+                            }
+                        } else {
+                            repo.upsertSleepSessions(listOf(session))
+                        }
                     }
                 }
             },
+            onsetKeying = { NoopPrefs.ouraOnsetKeying(ctx) },  // #1284 residual 3
             log = straplog,           // Oura connect/auth/stream lifecycle → the SAME exported strap log (#421)
             onBattery = batterySink,  // ring battery → the same live state the WHOOP strap battery uses
             onModel = { model -> scope.launch { runCatching { registry.setModel(id, model) } } },  // #772: correct a name-guessed gen

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -2056,6 +2056,12 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         NoopPrefs.setPolarDebugLogging(appContext, enabled)
     }
 
+    /** #1284 residual 3: toggle EXPERIMENTAL Oura 0x49-onset keying. Read live at persist by the Oura source
+     *  (via [SourceCoordinator]); no restart needed. Off = the shipped end-anchored persist. */
+    fun setOuraOnsetKeying(enabled: Boolean) {
+        NoopPrefs.setOuraOnsetKeying(appContext, enabled)
+    }
+
     /** #1121: toggle the opt-in rolling "detailed capture" strap-log file. Persisted so it survives a
      *  process kill (re-armed in [init] below). */
     fun setDetailedCapture(enabled: Boolean) {

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -481,6 +481,19 @@ object NoopPrefs {
         of(context).edit().putBoolean(KEY_POLAR_DEBUG_LOGGING, enabled).apply()
     }
 
+    /** #1284 residual 3 (EXPERIMENTAL, default OFF): generation-side 0x49-onset keying for Oura sleep. When
+     *  on, an Oura hypnogram persist keys its startTs on the rounded 0x49 onset and a completeness guard
+     *  suppresses/replaces a duplicate re-serve BEFORE it is banked. A hardware-validation toggle; no effect
+     *  without an Oura ring. Twin of iOS AppModel.ouraOnsetKeyingKey. */
+    const val KEY_OURA_ONSET_KEYING = "noop.ouraOnsetKeying"
+
+    fun ouraOnsetKeying(context: Context): Boolean =
+        of(context).getBoolean(KEY_OURA_ONSET_KEYING, false)
+
+    fun setOuraOnsetKeying(context: Context, enabled: Boolean) {
+        of(context).edit().putBoolean(KEY_OURA_ONSET_KEYING, enabled).apply()
+    }
+
     /** #1121: whether the opt-in "detailed capture" rolling strap-log file is on. Persisted so capture
      *  RESUMES after the process is killed (AppViewModel re-arms the BLE client from this on launch). */
     const val KEY_DETAILED_CAPTURE = "noop.detailedCapture"

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -352,10 +352,13 @@ private fun DiagnosticToolsCard(vm: AppViewModel) {
     // non-Polar user never sees Polar debug. Loaded once from the registry.
     var polarIdentity by remember { mutableStateOf<String?>(null) }
     var polarDebugLogging by remember { mutableStateOf(NoopPrefs.polarDebugLogging(context)) }
+    // #1284 residual 3: the experimental Oura onset-keying toggle, shown only when an Oura ring is paired.
+    var ouraPaired by remember { mutableStateOf(false) }
+    var ouraOnsetKeying by remember { mutableStateOf(NoopPrefs.ouraOnsetKeying(context)) }
     LaunchedEffect(Unit) {
-        val name = runCatching { vm.pairedDevices() }.getOrDefault(emptyList())
-            .firstOrNull { PolarModel.isPolar(it.model) }?.model
-        polarIdentity = PolarModel.debugIdentification(name)
+        val paired = runCatching { vm.pairedDevices() }.getOrDefault(emptyList())
+        polarIdentity = PolarModel.debugIdentification(paired.firstOrNull { PolarModel.isPolar(it.model) }?.model)
+        ouraPaired = paired.any { it.brand.equals("Oura", ignoreCase = true) }
     }
     var detailedCapture by remember { mutableStateOf(NoopPrefs.detailedCapture(context)) }
     var captureShareBusy by remember { mutableStateOf(false) }
@@ -431,6 +434,18 @@ private fun DiagnosticToolsCard(vm: AppViewModel) {
                         "so a Polar bug report shows the model NOOP resolved your strap to.",
                     checked = polarDebugLogging,
                     onCheckedChange = { polarDebugLogging = it; vm.setPolarDebugLogging(it) },
+                )
+            }
+            // #1284 residual 3: experimental Oura 0x49-onset keying, only when an Oura ring is paired.
+            if (ouraPaired) {
+                ToggleRowTC(
+                    title = "Oura onset keying (experimental)",
+                    description = "Keys each Oura sleep night on its stable 0x49 onset and suppresses " +
+                        "duplicate re-serves at the source, instead of the shipped end-anchored persist " +
+                        "(#1284). Off by default — a hardware-validation toggle. Watch the strap log for " +
+                        "'onset-key(#1284)' lines.",
+                    checked = ouraOnsetKeying,
+                    onCheckedChange = { ouraOnsetKeying = it; vm.setOuraOnsetKeying(it) },
                 )
             }
             // #1121 Detailed capture: an adb-like rolling on-device log, no computer needed. Off by default.

--- a/android/app/src/test/java/com/noop/analytics/SleepSessionDedupTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepSessionDedupTest.kt
@@ -227,6 +227,105 @@ class SleepSessionDedupTest {
         assertEquals(listOf(partial.startTs), result.dropped.map { it.startTs })
     }
 
+    // ── #1284 residual 3: generation-side onset keying (keyedStart · planBank) ────────────────────
+
+    @Test
+    fun keyedStart_collapsesOnsetJitterToOneBucket() {
+        val a = SleepSessionDedup.keyedStart(midnight + 55L)
+        val b = SleepSessionDedup.keyedStart(midnight + 76L) // +21 s
+        assertEquals(a, b)
+        assertEquals(0L, a % SleepSessionDedup.ONSET_KEY_GRID_SECONDS)
+    }
+
+    @Test
+    fun planBank_supersedesAShorterStoredCopy() {
+        val candidate = session(midnight, midnight + 494 * 60L)
+        val stored = session(midnight + 60L, midnight + 60L + 234 * 60L)
+        val plan = SleepSessionDedup.planBank(candidate, listOf(stored))
+        assertTrue(plan.bank)
+        assertEquals(listOf(stored.startTs), plan.supersededStarts)
+    }
+
+    @Test
+    fun planBank_suppressesAPartialAgainstAFullerStoredNight() {
+        val stored = session(midnight, midnight + 494 * 60L)
+        val candidate = session(midnight + 60L, midnight + 60L + 234 * 60L)
+        val plan = SleepSessionDedup.planBank(candidate, listOf(stored))
+        assertTrue(!plan.bank)
+        assertTrue(plan.supersededStarts.isEmpty())
+    }
+
+    @Test
+    fun planBank_laterWakingReAnchorSupersedesTheEarlier() {
+        val stored = session(midnight, midnight + 368 * 60L)
+        val candidate = session(midnight + 15 * 60L, midnight + 15 * 60L + 368 * 60L)
+        val plan = SleepSessionDedup.planBank(candidate, listOf(stored))
+        assertTrue(plan.bank)
+        assertEquals(listOf(stored.startTs), plan.supersededStarts)
+    }
+
+    @Test
+    fun planBank_freshNightWithNoStoredMatchBanksClean() {
+        val candidate = session(midnight, midnight + 400 * 60L)
+        val lastNight = session(midnight - 24 * 3600L, midnight - 16 * 3600L)
+        val plan = SleepSessionDedup.planBank(candidate, listOf(lastNight))
+        assertTrue(plan.bank)
+        assertTrue(plan.supersededStarts.isEmpty())
+    }
+
+    @Test
+    fun planBank_identicalReserveIsANoOp() {
+        val stored = session(midnight, midnight + 400 * 60L)
+        val candidate = session(midnight, midnight + 400 * 60L)
+        assertTrue(!SleepSessionDedup.planBank(candidate, listOf(stored)).bank)
+    }
+
+    @Test
+    fun keyedStart_roundsHalfUpAndClampsGrid() {
+        assertEquals(1020L, SleepSessionDedup.keyedStart(1000L, 60L))
+        assertEquals(1020L, SleepSessionDedup.keyedStart(990L, 60L))   // +30 rounds up
+        assertEquals(960L, SleepSessionDedup.keyedStart(989L, 60L))    // just under → down
+        assertEquals(1234L, SleepSessionDedup.keyedStart(1234L, 0L))   // grid clamp >=1 = identity
+    }
+
+    @Test
+    fun planBank_sameBucketFullerStoredRow_suppressesAPartialReserve() {
+        // F1 regression: a partial re-drain at the SAME keyed PK as a fuller banked night must be suppressed.
+        val fuller = session(midnight, midnight + 494 * 60L)
+        val partial = session(midnight, midnight + 234 * 60L)
+        assertTrue(!SleepSessionDedup.planBank(partial, listOf(fuller)).bank)
+    }
+
+    @Test
+    fun planBank_sameBucketFullerCandidate_banksWithoutSelfDeleting() {
+        val stored = session(midnight, midnight + 234 * 60L)
+        val candidate = session(midnight, midnight + 494 * 60L)
+        val plan = SleepSessionDedup.planBank(candidate, listOf(stored))
+        assertTrue(plan.bank)
+        assertTrue(plan.supersededStarts.isEmpty())
+    }
+
+    @Test
+    fun planBank_supersedesOtherKeyRowsButNotItsOwn() {
+        val candidate = session(midnight, midnight + 494 * 60L)
+        val sameKeyPartial = session(midnight, midnight + 200 * 60L)
+        val otherKeyFrag = session(midnight - 120L, midnight - 120L + 180 * 60L)
+        val plan = SleepSessionDedup.planBank(candidate, listOf(sameKeyPartial, otherKeyFrag))
+        assertTrue(plan.bank)
+        assertEquals(listOf(otherKeyFrag.startTs), plan.supersededStarts)
+    }
+
+    @Test
+    fun planBank_neverClobbersAUserEditedNight() {
+        // Data safety: a hand-corrected night outranks any fresh ring persist (even a fuller one), so the
+        // candidate is suppressed and the edited row is never replaced OR deleted.
+        val edited = session(midnight, midnight + 400 * 60L, edited = true)
+        val candidate = session(midnight + 30L, midnight + 30L + 420 * 60L)
+        val plan = SleepSessionDedup.planBank(candidate, listOf(edited))
+        assertTrue(!plan.bank)
+        assertTrue(plan.supersededStarts.isEmpty())
+    }
+
     @Test
     fun oura1284_identicalReAnchors_resolveByLatestEnd() {
         // Mode 1 (08-16): one rigid block re-anchored at several onsets — same duration, same shape, only the


### PR DESCRIPTION
**Draft for a hardware run** — the durable fix for #1284 residual 3 (duplicate Oura sleep-session *generation*), behind a **default-OFF** Test Centre toggle. The heal (#1338/#1382) only collapses duplicates *after* an analyze pass; this stops them being banked at the source, closing the window where the wrong night shows until the next pass / app restart.

## Mechanism
Per @pipiche38's 08-16 capture: the `0x49` **onset** is stable to **21 s** across 11 re-serves while the **end** chases wall-clock. So:

1. **Key on the onset** — `OuraLiveSource` sets the session's `startTs` to the **rounded 0x49 onset** (`SleepSessionDedup.keyedStart`, 60 s grid) instead of the end-anchored first-code time. Re-serves of one night then share a PK, and the shown bedtime becomes the *true onset* (fixing the current end-anchor drift `start = end − laidCodes·30 s`).
2. **Completeness guard** — the persist closure runs `SleepSessionDedup.planBank` before banking: the **same** collapse rule as the heal (longest, then latest-end wins). A partial re-drain is **suppressed**; a fuller/later copy **supersedes** and deletes the rows it replaces. A rare onset-bucket straddle is caught here by overlap, not the PK. Any read/logic failure **falls back to a plain upsert** — never loses the night.

**No schema migration** — `startTs` is still the PK, just set to the onset. (Option 2 — keep `startTs` exact + a `sessionKey` column — is the "correct end state" but a bigger migration; deferred until this is validated.)

## What's tested vs what needs hardware
- **Pure core** (`keyedStart` + `planBank`, reusing the shared rank + `isDuplicate`): unit-tested both platforms — `SleepSessionDedupTest` **23/23** (supersede-fuller, suppress-partial, later-waking-supersede, no-match-clean, identical-no-op, jitter→one-bucket).
- **Persist wiring** (`OuraLiveSource` + `SourceCoordinator`, both platforms): BLE path — **compile-only** here (app-build gate); **must be validated on a real ring**. Watch the strap log for `onset-key(#1284) banked … superseded N` / `suppressed …`.

## Parity
`keyedStart` / `planBank` / `rankKey`↔`rankComparator` byte-equivalent Swift↔Kotlin; pref (`AppModel.ouraOnsetKeyingKey` ↔ `NoopPrefs.KEY_OURA_ONSET_KEYING`), the persist keying, and the Test Centre toggle (shown only when an Oura ring is paired) all twinned.

## Open questions for the hardware run
1. the **60 s grid** — does it collapse every re-serve without straddling on real nights?
2. does keying `startTs`=onset read well as the bedtime across a corpus (vs keeping it exact + a `sessionKey` column)?
3. confirm one row per night across an overnight with link drops, and that the completeness guard picks the WHOOP-matching row every night.

Off by default; no effect for a user with no Oura ring. Depends on #1382 (merged). No version bump.