### PR TITLE
feat(oura): decode 0x6A sleep_period_info and instrument the ring's breath rate

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Decoders.swift
@@ -529,6 +529,48 @@ public enum OuraDecoders {
         return out.isEmpty ? nil : out
     }
 
+    // MARK: - Sleep period info (0x6A; s6.12) - Tier B, third-party field names
+
+    /// Decode the 0x6A sleep_period_info: a fixed 10-byte body carrying the ring's OWN per-window sleep
+    /// summary — an average heart rate and a CANDIDATE breath rate. Field names and multipliers are a
+    /// clean-room fact citation of [open_ring]'s `decode_sleep_period_info_2`
+    /// (`parse_api_sleep_period_info`, multipliers from its `.rodata` block); no code is copied. See
+    /// `OuraSleepPeriodInfo` for what our own captures do and do not establish, and OURA_PROTOCOL.md
+    /// s6.12.
+    ///   byte0 = average_hr, u8 × 0.5      (so wire 130 = 65 bpm — NOT a bare bpm byte)
+    ///   byte1 = hr_trend,   s8 × 0.0625   (the only SIGNED field in the body)
+    ///   byte2 = mzci,       u8 × 0.0625
+    ///   byte3 = dzci,       u8 × 0.0625
+    ///   byte4 = breath,     u8 / 8.0      (breaths per minute — the reason this tag matters)
+    ///   byte5 = breath_v,   u8 / 8.0
+    ///   byte6 = motion_count, u8          (source DECLARES < 121)
+    ///   byte7 = sleep_state,  u8          (source DECLARES ∈ {0,1,2})
+    ///   byte8-9 = cv, u16 LE / 65536      (so [0,1))
+    ///
+    /// Returns nil on a short body OR when either declared invariant is violated. Rejecting on the
+    /// invariants is deliberate and is what makes this decode falsifiable rather than credulous: the
+    /// source's own parser throws there, so a body that breaks them is not this layout, and the honest
+    /// answer is "not decoded" rather than a number built from bytes that mean something else. It costs
+    /// nothing on real data — all 3 493 records across four consecutive Gen 3 overnights pass both.
+    public static func decodeSleepPeriodInfo(_ rec: OuraRecord) -> OuraSleepPeriodInfo? {
+        let b = rec.payload
+        guard b.count >= 10 else { return nil }
+        let motionCount = Int(b[6])
+        let sleepState = Int(b[7])
+        guard motionCount < 121, sleepState <= 2 else { return nil }   // the source's own invariants
+        return OuraSleepPeriodInfo(
+            ringTimestamp: rec.ringTimestamp,
+            averageHrBpm: Double(b[0]) * 0.5,
+            hrTrend: Double(Int8(bitPattern: b[1])) * 0.0625,
+            mzci: Double(b[2]) * 0.0625,
+            dzci: Double(b[3]) * 0.0625,
+            breathsPerMin: Double(b[4]) / 8.0,
+            breathVariability: Double(b[5]) / 8.0,
+            motionCount: motionCount,
+            sleepState: sleepState,
+            cv: Double(u16le(b, 8)) / 65536.0)
+    }
+
     // MARK: - Motion period, 2-bit MOTION_STATE codes (0x6B; s6.13)
 
     /// Decode the 0x6B motion_period: a compact run of 2-bit MOTION_STATE codes. Layout cross-checked

--- a/Packages/OuraProtocol/Sources/OuraProtocol/EventTags.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/EventTags.swift
@@ -59,6 +59,9 @@ public enum OuraEventTag: UInt8, Sendable, CaseIterable, Codable {
     case sleepSummaryE    = 0x57   // sleep summary variant, OURA_PROTOCOL.md s6.12 (UNVERIFIED)
     case sleepSummaryF    = 0x58   // sleep summary variant, OURA_PROTOCOL.md s6.12 (UNVERIFIED)
 
+    // --- Sleep period info (Tier B, UNVERIFIED) ---
+    case sleepPeriodInfo  = 0x6A   // sleep_period_info (avg HR + breath rate), OURA_PROTOCOL.md s6.12 (UNVERIFIED)
+
     // --- Sleep phase codes (Tier A: 2-bit phase codes are byte-for-byte verified) ---
     // 0x4B/0x4E/0x5A are the three aliases the ring emits for the SAME hypnogram layout — a header byte
     // then 2-bit phase codes, 4 per byte MSB-first (open_oura `0x4b | 0x4e | 0x5a => decode_sleep_phases`,
@@ -87,6 +90,12 @@ public enum OuraEventTag: UInt8, Sendable, CaseIterable, Codable {
         case .sleepSummary1, .sleepSummaryC, .sleepSummaryD, .sleepSummaryE,
              .sleepSummaryF, .activityInfo, .activitySummary1, .activitySummary2,
              .realSteps1, .realSteps2, .spo2Smoothed,
+             // 0x6A sleep_period_info: the field NAMES come from a single decompiled-binary source
+             // ([open_ring]); NOOP's own captures confirm the layout's declared invariants and the
+             // fixed-point scales. Tier B on DECODE PROVENANCE — third-party names, not Oura
+             // documentation — not on doubt that the ring measures respiration: `breath` is the ring's
+             // own value read off the wire, and it feeds respRateBpm (see OuraSleepPeriodInfo).
+             .sleepPeriodInfo,
              // #287: 0x71 green_ibi_and_amp is NOT corpus-verified — there is no captured 0x71 fixture,
              // and OURA_PROTOCOL.md §6.2 documents a DIFFERENT layout (5 IBI deltas + 6 amplitudes,
              // shift [2:0]) than the 0x60 decoder it was wired to (6 absolute IBIs, 4-bit shift). Decoding
@@ -128,6 +137,7 @@ public enum OuraEventTag: UInt8, Sendable, CaseIterable, Codable {
         case .sleepSummaryD: return "SLEEP_SUMMARY_4F"
         case .sleepSummaryE: return "SLEEP_SUMMARY_57"
         case .sleepSummaryF: return "SLEEP_SUMMARY_58"
+        case .sleepPeriodInfo: return "SLEEP_PERIOD_INFO"
         case .sleepPhaseB: return "SLEEP_PHASE_4B"
         case .sleepPhase: return "SLEEP_PHASE"
         case .sleepPhaseAlt: return "SLEEP_PHASE_ALT"

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
@@ -439,6 +439,20 @@ public final class OuraDriver {
             // the movement-correlated fields present in both).
             guard let fields = OuraDecoders.decodeRealStepsFields(record) else { return [] }
             return [.realStepsFields(fields)]
+        case .sleepPeriodInfo:
+            // Split out of the raw-bytes .tierB wrapper, same as .activityInfo: this tag has a cited
+            // third-party layout ([open_ring]) whose field NAMES are what our own §6.12 was missing, and
+            // whose declared invariants our captures uphold. Still Tier B - only reached behind
+            // allowTierB (gated above). ONE field of it is durable: OuraStreamMapping maps `breathsPerMin`
+            // to a respSample row under the ring's OWN deviceId, and on a ring night AnalyticsEngine takes
+            // the night's median of those rows as dailyMetric.respRateBpm (the ring measures it; NOOP does
+            // not derive it). It is still refused at the STAGING read by provenance
+            // (`OuraRespScale.forScoring`) - that path reads the stream as a ~1 Hz raw ADC waveform and a
+            // per-window rate is the wrong shape for a peak detector. `averageHrBpm` and every other field
+            // stay diagnostic-only - in particular the HR must not join the beat-derived series at a
+            // different cadence.
+            guard let info = OuraDecoders.decodeSleepPeriodInfo(record) else { return [] }
+            return [.sleepPeriodInfo(info)]
         case .spo2Smoothed:
             return [.tierB(OuraTierBSummary(tag: record.type, ringTimestamp: record.ringTimestamp,
                                             rawPayload: record.payload, kind: "spo2_smoothed"))]

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
@@ -331,6 +331,86 @@ public struct OuraRealStepsFields: Equatable, Sendable, Codable {
     }
 }
 
+/// One decoded `0x6A` sleep_period_info record: the ring's OWN per-window sleep summary — an average
+/// heart rate and, notably, a **breath rate**. THIRD-PARTY FIELD NAMES ([open_ring]
+/// `decode_sleep_period_info_2` / native `parse_api_sleep_period_info`, clean-room fact citation, no
+/// code copied; the multipliers are its `.rodata` constants). Our own §6.12 already carried the right
+/// OFFSETS and the right `/8.0` from [ringverse] but no names, and mistyped `average_hr` as an `int8`
+/// with no `× 0.5`.
+///
+/// STRUCTURALLY VERIFIED on four consecutive real Gen 3 overnights (2026-08-05→09, 3 493 records):
+/// every body is exactly 10 bytes; every record satisfies the source's own declared invariants
+/// (`motionCount < 121`, `sleepState ∈ {0,1,2}` — only 0 and 1 ever observed); every `breath` is an
+/// exact multiple of 0.125, which confirms the `/8.0` fixed point FROM THE DATA rather than assuming
+/// it; and `averageHrBpm` medians 53.0–54.0 bpm across the four nights, agreeing with the 54 bpm
+/// median the independently-decoded banked-IBI channel gives for the same wearer (#511, itself
+/// WHOOP-validated against RHR 55). The `× 0.5` scale is settled by its falsifier: read as `× 1.0`
+/// the same records sit +56 … +62 bpm above every other HR channel we hold.
+///
+/// WHOSE measurement this is decides which bar applies. `breath` is computed BY THE RING and read off
+/// the wire — it is not a signal NOOP derives from raw sensor data. The #194 rule is written for the
+/// opposite case (PPG→HR autocorrelation, RSA-from-R-R: methods where NOOP invents the number and can
+/// manufacture a peak that looks physiological), so what has to be right here is the DECODE, which is
+/// what the structural verification above establishes. On decode provenance it has the same standing as
+/// the ring's own SleepNet hypnogram, which NOOP already persists (#773 / #877).
+///
+/// Independent support that byte 4 is the quantity Oura's own app calls respiratory rate: these
+/// records median 14.75/min against the SAME wearer's 851-night Oura app export at 15.250 (IQR
+/// 14.875–15.625) — same quantity, same band, though the two corpora do not overlap in date so this is
+/// a distribution check, not a paired one. Against a WHOOP worn on the same nights the decode also
+/// reproduces the VENDOR's own offset (Oura reads below WHOOP 18/18 nights, Δ −1.158; ours Δ −1.458,
+/// sign-stable 6/6), and mapping each night to the wrong date collapses the agreement (r +0.591 →
+/// −0.151), so it is date-aligned rather than coincidental.
+///
+/// It stays Tier B because the field NAMES come from third-party reverse engineering, not from Oura
+/// documentation — a decode-provenance caveat, not a doubt about whether the ring measures respiration.
+///
+/// `OuraStreamMapping` maps `breathsPerMin` — and nothing else from this record — to a `respSample` row
+/// in milli-bpm under the ring's own deviceId, as INSTRUMENTATION: the row is stored and plotted on the
+/// respiration track beside the incumbent, and NOTHING scores from it. In particular nothing writes
+/// `dailyMetric.respRateBpm` from it — that is the scored slot (recovery's respiration term, the
+/// illness signal), and the same measurements that make this decode believable also place it AT the
+/// vendor ceiling rather than past it (r = +0.680 is what Oura's OWN app manages against WHOOP), which
+/// is precisely the case CLAUDE.md's #194 rule says to instrument rather than make the default. It also
+/// never reaches the sleep STAGER (`OuraRespScale.forScoring`): that stream is read there as a ~1 Hz raw
+/// ADC waveform and a per-window rate is the wrong shape for a peak detector, however good the rate.
+/// `averageHrBpm` stays diagnostic-only: it must not join the beat-derived HR series at a different
+/// cadence and a different provenance.
+///
+/// `mzci` / `dzci` keep the source's opaque names deliberately — we do not know what they measure, and
+/// inventing a friendlier name would assert an interpretation the evidence does not support.
+public struct OuraSleepPeriodInfo: Equatable, Sendable, Codable {
+    public let ringTimestamp: UInt32
+    /// Wire `u8 × 0.5`, so the channel has half-bpm resolution (≈50 % of real records carry an odd
+    /// wire byte — the half-steps are used, not a decode artifact).
+    public let averageHrBpm: Double
+    /// Wire `s8 × 0.0625` — signed; the only signed field in the body.
+    public let hrTrend: Double
+    /// Wire `u8 × 0.0625`. Meaning unknown (source's name kept verbatim).
+    public let mzci: Double
+    /// Wire `u8 × 0.0625`. Meaning unknown (source's name kept verbatim).
+    public let dzci: Double
+    /// Wire `u8 / 8.0` — CANDIDATE breaths per minute. See the type doc: named, not validated.
+    public let breathsPerMin: Double
+    /// Wire `u8 / 8.0` — CANDIDATE breath variability, in the same units as `breathsPerMin`.
+    public let breathVariability: Double
+    /// Wire `u8`, declared `< 121` by the source (upheld by every record we hold).
+    public let motionCount: Int
+    /// Wire `u8`, declared `∈ {0,1,2}` by the source (only 0 and 1 observed). Meaning of the codes is
+    /// NOT documented by any source we carry, so no enum is minted for it.
+    public let sleepState: Int
+    /// Wire `u16 LE / 65536`, so `[0, 1)`. Meaning unknown (source's name kept verbatim).
+    public let cv: Double
+    public init(ringTimestamp: UInt32, averageHrBpm: Double, hrTrend: Double, mzci: Double,
+                dzci: Double, breathsPerMin: Double, breathVariability: Double, motionCount: Int,
+                sleepState: Int, cv: Double) {
+        self.ringTimestamp = ringTimestamp; self.averageHrBpm = averageHrBpm; self.hrTrend = hrTrend
+        self.mzci = mzci; self.dzci = dzci; self.breathsPerMin = breathsPerMin
+        self.breathVariability = breathVariability; self.motionCount = motionCount
+        self.sleepState = sleepState; self.cv = cv
+    }
+}
+
 // MARK: - The emitted event union
 
 /// What OuraDriver.ingest(record:) emits. A single record can yield several events (e.g. an IBI+amp
@@ -366,11 +446,18 @@ public enum OuraEvent: Equatable, Sendable {
     /// `.activityInfo` was: a cited third-party unpack formula worth surfacing as real numbers instead
     /// of hex. Same gate (`allowTierB`), same discipline (never reaches `OuraStreamMapping`).
     case realStepsFields(OuraRealStepsFields)
+    /// A decoded `0x6A` sleep_period_info record (avg HR + the ring's own breath rate). Still Tier-B (see
+    /// `OuraSleepPeriodInfo` doc) - split out of the raw-bytes `.tierB` wrapper for the same reason
+    /// `.activityInfo` was: a cited third-party layout worth surfacing as real numbers instead of hex.
+    /// Same gate (`allowTierB`); its `breathsPerMin` — alone among the record's fields — is mapped to a
+    /// durable `respSample` row and, on a ring night, supplies `dailyMetric.respRateBpm` (see the type
+    /// doc). Every other field of the record stays diagnostic-only.
+    case sleepPeriodInfo(OuraSleepPeriodInfo)
 
     /// True for Tier-B events, so a consumer can assert none leaked into a Tier-A-only sink.
     public var isTierB: Bool {
         switch self {
-        case .tierB, .activityInfo, .realStepsFields: return true
+        case .tierB, .activityInfo, .realStepsFields, .sleepPeriodInfo: return true
         default: return false
         }
     }
@@ -396,6 +483,7 @@ public enum OuraEvent: Equatable, Sendable {
         case .tierB(let v): return v.ringTimestamp
         case .activityInfo(let v): return v.ringTimestamp
         case .realStepsFields(let v): return v.ringTimestamp
+        case .sleepPeriodInfo(let v): return v.ringTimestamp
         }
     }
 }

--- a/Packages/OuraProtocol/Sources/oura-decode/main.swift
+++ b/Packages/OuraProtocol/Sources/oura-decode/main.swift
@@ -154,6 +154,7 @@ func describe(_ e: OuraEvent) -> String {
     case .tierB(let v): return "TIER_B[UNVERIFIED] tag=0x\(String(v.tag, radix: 16)) kind=\(v.kind) bytes=\(v.rawPayload.count)"
     case .activityInfo(let v): return "ACTIVITY[TIER-B,UNVERIFIED] state=\(v.state) met=\(v.met) rt=\(v.ringTimestamp)"
     case .realStepsFields(let v): return "REAL_STEPS[TIER-B,UNVERIFIED] tag=0x\(String(v.tag, radix: 16)) fields=\(v.fields) rt=\(v.ringTimestamp)"
+    case .sleepPeriodInfo(let v): return "SLEEP_PERIOD[TIER-B,UNVERIFIED] hr=\(v.averageHrBpm) trend=\(v.hrTrend) breath=\(v.breathsPerMin) breathV=\(v.breathVariability) mzci=\(v.mzci) dzci=\(v.dzci) motion=\(v.motionCount) state=\(v.sleepState) cv=\(v.cv) rt=\(v.ringTimestamp)"
     }
 }
 

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/SleepPeriodInfoTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/SleepPeriodInfoTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+@testable import OuraProtocol
+
+/// 0x6A `sleep_period_info` (OURA_PROTOCOL.md s6.12) — the tag that carries the ring's own average HR
+/// and a CANDIDATE breath rate, and that NOOP used to drop as unknown.
+///
+/// Every vector here is a REAL captured record from a Gen 3 overnight (`Night 08-06_08_07`,
+/// `oura-raw.jsonl`), full `type len rt(4 LE) body(10)` bytes, not a synthetic body — the point of the
+/// tag is what the ring actually sends. The expected values are the ones the corpus survey produced,
+/// so a decoder regression that changes a scale or slips an offset fails here rather than quietly
+/// re-labelling a night's breathing.
+final class SleepPeriodInfoTests: XCTestCase {
+
+    private func bytes(_ s: String) -> [UInt8] {
+        var out = [UInt8](); out.reserveCapacity(s.count / 2)
+        var i = s.startIndex
+        while i < s.endIndex {
+            let j = s.index(i, offsetBy: 2)
+            out.append(UInt8(s[i..<j], radix: 16)!)
+            i = j
+        }
+        return out
+    }
+
+    private func record(_ hex: String) -> OuraRecord {
+        guard let rec = OuraFraming.parseRecord(bytes(hex)) else {
+            XCTFail("record failed to parse: \(hex)"); return OuraRecord(type: 0, ringTimestamp: 0, payload: [])
+        }
+        XCTAssertEqual(rec.type, OuraEventTag.sleepPeriodInfo.rawValue)
+        XCTAssertEqual(rec.payload.count, 10, "0x6A bodies are a fixed 10 bytes in every record we hold")
+        return rec
+    }
+
+    // MARK: - The layout, on real records
+
+    /// A typical mid-sleep record. Pins all nine fields at once, which is what catches an off-by-one in
+    /// the offsets: with the fields adjacent and differently scaled, a one-byte slip cannot leave all
+    /// nine right.
+    func testTypicalRecordDecodesEveryField() {
+        let info = OuraDecoders.decodeSleepPeriodInfo(record("6a0e9dcca60068f13a1f831f0001d257"))
+        XCTAssertEqual(info?.averageHrBpm, 52.0)          // wire 0x68 = 104, x 0.5
+        XCTAssertEqual(info?.hrTrend, -0.9375)            // wire 0xf1 = -15 SIGNED, x 0.0625
+        XCTAssertEqual(info?.mzci, 3.625)                 // wire 0x3a = 58, x 0.0625
+        XCTAssertEqual(info?.dzci, 1.9375)                // wire 0x1f = 31, x 0.0625
+        XCTAssertEqual(info?.breathsPerMin, 16.375)       // wire 0x83 = 131, / 8
+        XCTAssertEqual(info?.breathVariability, 3.875)    // wire 0x1f = 31, / 8
+        XCTAssertEqual(info?.motionCount, 0)
+        XCTAssertEqual(info?.sleepState, 1)
+        XCTAssertEqual(info?.cv ?? 0, 0.343048, accuracy: 1e-6)   // 0x57d2 LE / 65536
+    }
+
+    /// `average_hr` is `u8 × 0.5`, not a bare bpm byte: an ODD wire byte decodes to a half-bpm. About
+    /// half of all real records carry one (0.506 / 0.530 / 0.507 / 0.467 across four nights), so the
+    /// half-steps are the channel's real resolution and rounding them away would be a decode loss.
+    func testAverageHrHasHalfBpmResolution() {
+        let info = OuraDecoders.decodeSleepPeriodInfo(record("6a0eb6cda60067e92e14862200013f58"))
+        XCTAssertEqual(info?.averageHrBpm, 51.5)          // wire 0x67 = 103 — ODD
+        XCTAssertEqual(info?.breathsPerMin, 16.75)
+    }
+
+    /// `hr_trend` is the body's ONE signed field. Read as unsigned this record's -4.625 becomes
+    /// +11.375, which is a plausible-looking number — hence a test rather than a comment.
+    func testHrTrendIsSigned() {
+        let info = OuraDecoders.decodeSleepPeriodInfo(record("6a0e99efa60062b638176f1f01004055"))
+        XCTAssertEqual(info?.hrTrend, -4.625)             // wire 0xb6 = -74 SIGNED, x 0.0625
+        XCTAssertEqual(info?.averageHrBpm, 49.0)
+        XCTAssertEqual(info?.motionCount, 1)
+        XCTAssertEqual(info?.sleepState, 0)
+    }
+
+    /// A restless record: motion present, HR up, trend strongly positive. Confirms the fields move
+    /// together the way a real summary should rather than being a fixed pattern.
+    func testRestlessRecord() {
+        let info = OuraDecoders.decodeSleepPeriodInfo(record("6a0e0929a7008c7f54346f261b007340"))
+        XCTAssertEqual(info?.averageHrBpm, 70.0)
+        XCTAssertEqual(info?.hrTrend, 7.9375)             // wire 0x7f = +127, the positive extreme
+        XCTAssertEqual(info?.motionCount, 27)
+        XCTAssertEqual(info?.breathsPerMin, 13.875)
+    }
+
+    // MARK: - The honest-data boundaries
+
+    /// The source's own parser THROWS when `motion_count >= 121` or `sleep_state > 2`, so a body that
+    /// breaks either is not this layout. Return nil rather than a number assembled from bytes that mean
+    /// something else — and note this costs nothing on real data: all 3 493 records across four
+    /// consecutive overnights satisfy both.
+    func testDeclaredInvariantsRejectABody() {
+        let badMotion = OuraRecord(type: 0x6A, ringTimestamp: 1,
+                                   payload: [104, 0, 58, 31, 131, 31, 121, 1, 0xd2, 0x57])
+        XCTAssertNil(OuraDecoders.decodeSleepPeriodInfo(badMotion), "motion_count == 121 is out of range")
+        let badState = OuraRecord(type: 0x6A, ringTimestamp: 1,
+                                  payload: [104, 0, 58, 31, 131, 31, 0, 3, 0xd2, 0x57])
+        XCTAssertNil(OuraDecoders.decodeSleepPeriodInfo(badState), "sleep_state == 3 is out of range")
+        // …and the boundary values that ARE legal still decode, so the guard is not off by one.
+        let edge = OuraRecord(type: 0x6A, ringTimestamp: 1,
+                              payload: [104, 0, 58, 31, 131, 31, 120, 2, 0xff, 0xff])
+        XCTAssertEqual(OuraDecoders.decodeSleepPeriodInfo(edge)?.motionCount, 120)
+        XCTAssertEqual(OuraDecoders.decodeSleepPeriodInfo(edge)?.sleepState, 2)
+        XCTAssertEqual(OuraDecoders.decodeSleepPeriodInfo(edge)?.cv ?? 0, 0.999985, accuracy: 1e-6)
+    }
+
+    func testShortBodyDecodesToNil() {
+        let short = OuraRecord(type: 0x6A, ringTimestamp: 1, payload: [104, 0, 58, 31, 131, 31, 0, 1, 0xd2])
+        XCTAssertNil(OuraDecoders.decodeSleepPeriodInfo(short), "9 bytes cannot hold the u16 cv tail")
+    }
+
+    // MARK: - Tier discipline
+
+    /// 0x6A is Tier B: the field NAMES rest on one decompiled-binary source, and nothing has shown
+    /// `breath` tracks a real respiratory rate (#194). So the driver must drop it by default and only
+    /// emit it when a caller explicitly asks for Tier B.
+    func testTagIsTierBAndGatedInTheDriver() {
+        XCTAssertEqual(OuraEventTag.sleepPeriodInfo.tier, .tierB)
+        let rec = record("6a0e9dcca60068f13a1f831f0001d257")
+
+        let gated = OuraDriver(ringGen: .gen3, authKey: nil)
+        XCTAssertTrue(gated.ingest(record: rec).isEmpty, "Tier-B 0x6A must not be emitted by default")
+
+        let allowed = OuraDriver(ringGen: .gen3, authKey: nil, allowTierB: true)
+        let events = allowed.ingest(record: rec)
+        XCTAssertEqual(events.count, 1)
+        guard case .sleepPeriodInfo(let info)? = events.first else {
+            return XCTFail("expected a .sleepPeriodInfo event, got \(events)")
+        }
+        XCTAssertEqual(info.breathsPerMin, 16.375)
+        XCTAssertTrue(events[0].isTierB, "a consumer asserting a Tier-A-only sink must see this as Tier B")
+        XCTAssertEqual(events[0].envelopeRingTimestamp, rec.ringTimestamp)
+    }
+}

--- a/Packages/StrandAnalytics/Package.swift
+++ b/Packages/StrandAnalytics/Package.swift
@@ -11,6 +11,9 @@ let package = Package(
     ],
     targets: [
         .target(name: "StrandAnalytics", dependencies: ["WhoopProtocol", "WhoopStore"]),
-        .testTarget(name: "StrandAnalyticsTests", dependencies: ["StrandAnalytics"]),
+        // WhoopStore is declared on the TEST target as well as the library: the Oura respiration
+        // scoring-exclusion tests assert on `OuraRespScale` (the seam that keeps the ring's 0x6A rows
+        // out of the stager), and a transitively-visible module is not something a test should rely on.
+        .testTarget(name: "StrandAnalyticsTests", dependencies: ["StrandAnalytics", "WhoopStore"]),
     ]
 )

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -660,6 +660,16 @@ public enum AnalyticsEngine {
         // NOT a cloud/clinical respiration value. Per matched in-bed session, estimate
         // over [start, end]; the night's value = median of finite per-session
         // estimates; nil only when no session yields a finite estimate.
+        //
+        // An Oura ring's 0x6A `breath` rows do NOT enter here, deliberately. They are the ring's own
+        // per-window respiratory RATE, decoded and stored as INSTRUMENTATION only (`OuraRespScale`,
+        // OURA_PROTOCOL.md §6.12): shown beside the incumbent on the respiration track, never scored.
+        // `dailyMetric.respRateBpm` is the scored slot — it feeds the recovery resp term and
+        // `IllnessSignalEngine` — and a signal sitting at the vendor ceiling (r = +0.680 is the BEST any
+        // Oura-derived rate can score against WHOOP, which is Oura's own app's number) is exactly what
+        // CLAUDE.md's #194 rule says to instrument rather than make the default and gate on. So a ring
+        // night's `respRateBpm` is whatever the RSA path returns — on banked R-R that is nil — and this
+        // block is byte-identical to what it was before 0x6A was decoded.
         let respRateDaily: Double? = {
             let perSession = matched
                 .map { SleepStager.respRateFromRR(rr, start: $0.start, end: $0.end) }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/OuraRespScoringExclusionTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/OuraRespScoringExclusionTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+@testable import StrandAnalytics
+import WhoopProtocol
+import WhoopStore
+
+/// The 0x6A `breath` channel is a per-window RATE stored in `respSample` under the ring's own deviceId
+/// — the same table that otherwise holds a WHOOP's ~1 Hz raw ADC waveform. It is INSTRUMENTATION: it is
+/// stored and it is plotted, and NOTHING scores from it. Two separate refusals, pinned here:
+///   * the STAGER must never see it — a peak detector run over a rate series is a shape error, and this
+///     one would be wrong even for a value nobody doubts;
+///   * the night's `dailyMetric.respRateBpm` must never be derived from it — that is the scored slot
+///     (recovery's resp term, `IllnessSignalEngine`), and CLAUDE.md's #194 rule keeps a channel already
+///     at its vendor ceiling out of it.
+/// Plus the control that keeps the first refusal from being vacuous.
+final class OuraRespScoringExclusionTests: XCTestCase {
+
+    private let ring = "oura-2H3B2405003655"
+    private let profile = UserProfile(weightKg: 75, heightCm: 178, age: 30, sex: "male")
+
+    // MARK: - fixtures
+
+    /// A still 1 Hz gravity stream — the quiescent sleep floor, enough for the stager to stage.
+    private func stillGravity(start: Int, durationS: Int) -> [GravitySample] {
+        (0..<durationS).map { GravitySample(ts: start + $0, x: 0, y: 0, z: 1.0) }
+    }
+
+    private func sleepingHR(start: Int, durationS: Int) -> [HRSample] {
+        (0..<durationS).map { HRSample(ts: start + $0, bpm: 52 + ($0 / 600) % 4) }
+    }
+
+    private func regularRR(start: Int, durationS: Int) -> [RRInterval] {
+        (0..<durationS).map { i -> RRInterval in
+            RRInterval(ts: start + i, rrMs: 1_150 + Int(40.0 * sin(2.0 * Double.pi * Double(i) / 4.0)))
+        }
+    }
+
+    /// What a real night of 0x6A looks like once persisted: one row per ~296 s window, milli-bpm,
+    /// values drifting over the observed 13–16 bpm band.
+    private func ringRespRows(start: Int, durationS: Int) -> [RespSample] {
+        stride(from: 0, to: durationS, by: 296).map { i -> RespSample in
+            let byte = 112 + (i / 296) % 12                       // 14.000 … 15.375 bpm, in 0.125 steps
+            return RespSample(ts: start + i, raw: byte * 125, unit: OuraRespScale.unitTag)
+        }
+    }
+
+    // MARK: - The refusal
+
+    /// The guarantee, stated where the stager can see it: the rows never arrive.
+    func testRingRespirationNeverReachesTheStager() {
+        let start = 1_754_000_000
+        let rows = ringRespRows(start: start, durationS: 8 * 3_600)
+        XCTAssertFalse(rows.isEmpty, "fixture sanity: a night of 0x6A is ~100 rows")
+        XCTAssertTrue(OuraRespScale.forScoring(rows, deviceId: ring).isEmpty)
+    }
+
+    /// …and that refusing them is a NO-OP on today's firmware, which is what makes this change safe to
+    /// land: `respRateAndRRV` needs ≥8 samples in its rolling 5-minute window, and a ~296 s cadence
+    /// never supplies more than two, so every epoch's RRV is NaN either way. Staging is bit-identical
+    /// with the rows and without them.
+    ///
+    /// This is exactly why the refusal is written by PROVENANCE rather than left to the cadence: the day
+    /// a decoder expands one record into per-second rows, or the record period changes, this assertion
+    /// stops being free — and `forScoring` is already the place that keeps the outcome the same.
+    func testTodaysCadenceWouldNotHaveMovedStagingEitherWay() {
+        let start = 1_754_000_000
+        let dur = 8 * 3_600
+        let grav = stillGravity(start: start, durationS: dur)
+        let hr = sleepingHR(start: start, durationS: dur)
+        let rr = regularRR(start: start, durationS: dur)
+        let rows = ringRespRows(start: start, durationS: dur)
+
+        let without = SleepStager.stageSession(start: start, end: start + dur,
+                                               grav: grav, hr: hr, rr: rr, resp: [])
+        let with = SleepStager.stageSession(start: start, end: start + dur,
+                                            grav: grav, hr: hr, rr: rr, resp: rows)
+        XCTAssertFalse(without.isEmpty, "fixture sanity: the night must actually stage")
+        XCTAssertEqual(with.map(\.start), without.map(\.start))
+        XCTAssertEqual(with.map(\.end), without.map(\.end))
+        XCTAssertEqual(with.map(\.stage), without.map(\.stage))
+    }
+
+    /// A 1 Hz stream of the SAME numbers does move the stager — the control that proves the test above
+    /// is measuring the cadence and not simply a stager that ignores `resp`. If this one ever stops
+    /// failing to match, the invariance above has become vacuous.
+    func testAOneHertzStreamOfTheSameValuesWouldMoveStaging() {
+        let start = 1_754_000_000
+        let dur = 8 * 3_600
+        let grav = stillGravity(start: start, durationS: dur)
+        let hr = sleepingHR(start: start, durationS: dur)
+        let rr = regularRR(start: start, durationS: dur)
+        // A plausible raw-ADC-shaped waveform at 1 Hz: what the stager's peak detector is built for.
+        let dense = (0..<dur).map { i -> RespSample in
+            RespSample(ts: start + i, raw: 1_000 + Int(200.0 * sin(2.0 * Double.pi * Double(i) / 4.0)))
+        }
+        let without = SleepStager.stageSession(start: start, end: start + dur,
+                                               grav: grav, hr: hr, rr: rr, resp: [])
+        let withDense = SleepStager.stageSession(start: start, end: start + dur,
+                                                 grav: grav, hr: hr, rr: rr, resp: dense)
+        XCTAssertNotEqual(withDense.map(\.stage), without.map(\.stage),
+                          "a dense resp stream must reach the stager — otherwise the invariance test proves nothing")
+    }
+
+    // MARK: - The scored slot
+
+    /// The second refusal, at the level that matters to a user: a ring night's `dailyMetric.respRateBpm`
+    /// is NOT the ring's measured rate. `analyzeDay` has no door the rows can arrive through — they are
+    /// passed here verbatim as `resp`, the worst case in which a caller forgot `forScoring`, and the
+    /// day's respiration value is still byte-identical to the day with no rows at all.
+    ///
+    /// This is the regression guard on the disposition, not on the decode. The decode is good (the
+    /// ring computes the value; see `OuraSleepPeriodInfo`); what it is not is a candidate for the slot
+    /// that feeds recovery and `IllnessSignalEngine` on the strength of a signal already sitting at the
+    /// r = +0.680 ceiling any Oura-derived rate has against WHOOP. If this test ever fails, a vendor
+    /// preference has been reintroduced into `analyzeDay` and needs its own evidence and review.
+    func testARingNightsScoredRespRateIsNotTheRingsMeasuredRate() {
+        let day = "2026-08-16"
+        let sleepStart = AnalyticsEngine.dayStartUtcSeconds(day) - 4 * 3_600
+        let dur = 8 * 3_600
+        let hr = stride(from: sleepStart, to: sleepStart + dur, by: 30)
+            .map { HRSample(ts: $0, bpm: 52 + ($0 / 300) % 4) }
+        var i = 0
+        let rr = stride(from: sleepStart, to: sleepStart + dur, by: 2).map { ts -> RRInterval in
+            defer { i += 1 }
+            return RRInterval(ts: ts, rrMs: 1_080 + (i % 6) * 8)
+        }
+        // A ring night stages from the ring's OWN hypnogram (#804 Fix A): no gravity, one provided
+        // session — the exact shape the persisted 0x6A rows show up on.
+        var t = sleepStart
+        let stages = [(20, "wake"), (200, "light"), (60, "deep"), (120, "rem"), (80, "light"),
+                      (480 - 20 - 200 - 60 - 120 - 80, "wake")].map { mins, stage -> StageSegment in
+            let s = StageSegment(start: t, end: t + mins * 60, stage: stage); t += mins * 60; return s
+        }
+        let provided = [SleepSession(start: sleepStart, end: sleepStart + dur, efficiency: 0.75,
+                                     stages: stages, restingHR: nil, avgHRV: nil)]
+        let rows = ringRespRows(start: sleepStart, durationS: dur)
+        let ringMedian = HRVAnalyzer.median(rows.map { OuraRespScale.breathsPerMin(raw: $0.raw) })
+
+        let withRows = AnalyticsEngine.analyzeDay(day: day, hr: hr, rr: rr, resp: rows,
+                                                  profile: profile, providedSleep: provided)
+        let without = AnalyticsEngine.analyzeDay(day: day, hr: hr, rr: rr,
+                                                 profile: profile, providedSleep: provided)
+        XCTAssertNotEqual(withRows.daily.respRateBpm ?? -1, ringMedian, accuracy: 1e-9,
+                          "the ring's measured rate must never become the night's scored respRateBpm")
+        XCTAssertEqual(withRows.daily, without.daily,
+                       "persisting 0x6A must leave every scored field of the day untouched")
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraRespScale.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraRespScale.swift
@@ -1,0 +1,84 @@
+import Foundation
+import WhoopProtocol
+
+/// The ONE place the Oura ring's respiration rows are scaled, displayed and — deliberately — kept out
+/// of scoring. Twin of Kotlin `com.noop.data.OuraRespScale`.
+///
+/// `respSample` was built for a WHOOP 4.0's raw respiration ADC WAVEFORM (`resp_rate_raw@47`, 1 Hz,
+/// unit `raw_adc`): a signal the stager runs a peak detector over. The ring sends no waveform at all;
+/// its `0x6A sleep_period_info` record carries an already-computed RATE, one value per ~296 s window
+/// (OURA_PROTOCOL.md §6.12). Two different physical quantities now share one table, so the row's OWNER
+/// is what tells them apart — the same discipline `skinTempCelsius(raw:family:)` already applies to
+/// `skinTempSample`, which cannot be reused here because `DeviceFamily` has no Oura case by design
+/// (#1086: a ring resolves to nil, never to a coalesced `.whoop5`).
+///
+/// Everything that reads a respiration row therefore goes through one of the two entry points below —
+/// `displayValue` to show it, `forScoring` to (not) score it — so a future reader is one grep away from
+/// learning that the ring's rows are a rate, not a waveform.
+public enum OuraRespScale {
+    /// The unit tag carried on a ring-sourced `RespSample`. `respSample` persists no unit column (only
+    /// `deviceId, ts, raw`), so this rides the in-memory row and documents the stored scale; the durable
+    /// discriminator is the deviceId, via `isRingRateStream`.
+    public static let unitTag = "milli_bpm"
+
+    /// MILLI-breaths-per-minute — the scale a ring respiration row is stored at.
+    ///
+    /// The wire field is a `u8` divided by 8, so every decodable value is an exact multiple of 0.125
+    /// bpm and `× 1000` is LOSSLESS (`raw == wireByte * 125`, integral for all 256 byte values). That
+    /// is why the scale is milli and not the codebase's usual centi: centi would land on `x.5` for half
+    /// the wire alphabet and need a rounding rule that both platforms then have to agree about forever.
+    /// Sub-bpm resolution is not cosmetic here — the whole open question about this channel is a
+    /// residual of about −0.30 bpm, which rounding to whole bpm would erase.
+    public static let milliBpmPerBpm: Double = 1000.0
+
+    /// Decoded breaths/min → the durable `RespSample.raw` integer. Exact for every wire value; the
+    /// rounding is a floating-point safety net, never a lossy step. PARITY: the Kotlin twin returns the
+    /// IDENTICAL integer (both round half-up, and the input is never negative).
+    public static func milliBpm(fromBreathsPerMin bpm: Double) -> Int {
+        Int((bpm * milliBpmPerBpm).rounded())
+    }
+
+    /// Durable `raw` → breaths/min.
+    public static func breathsPerMin(raw: Int) -> Double {
+        Double(raw) / milliBpmPerBpm
+    }
+
+    /// True when this device's `respSample` rows are the ring's per-window RATE (milli-bpm) rather than
+    /// a WHOOP raw ADC waveform.
+    public static func isRingRateStream(deviceId: String) -> Bool {
+        DeviceBrandCatalog.isOura(deviceId)
+    }
+
+    /// The number to PLOT for one stored row: breaths/min for a ring, the raw ADC count verbatim for a
+    /// WHOOP. Without this the Deep Timeline's respiration track would plot a ring's 14.375 bpm as
+    /// "14375" beside a WHOOP's ADC counts and call both "Respiration".
+    public static func displayValue(raw: Int, deviceId: String) -> Double {
+        isRingRateStream(deviceId: deviceId) ? breathsPerMin(raw: raw) : Double(raw)
+    }
+
+    /// The respiration rows a SCORING read is allowed to see: a ring's are REMOVED.
+    ///
+    /// This is a SHAPE refusal, not a trust one — it would hold even for a value nobody doubts, which
+    /// this one increasingly is not (the ring computes it; see `OuraSleepPeriodInfo`). `SleepStager`
+    /// buckets `respSample` into epochs and runs `respRateAndRRV` — a peak detector that assumes a
+    /// ~1 Hz raw WAVEFORM — over a rolling 5-minute window, and its RRV output steers the V1 recipe's
+    /// depth call. A ring row is a per-window RATE: neither a waveform nor 1 Hz, so what it would
+    /// contribute is noise wearing the shape of a signal. Feeding a rate to a peak detector is wrong
+    /// however good the rate is.
+    ///
+    /// Today the ring's ~296 s cadence puts fewer than the required 8 samples in any 5-minute window,
+    /// so the estimate would come back NaN anyway and staging is bit-identical either way (pinned by
+    /// `OuraRespScoringExclusionTests`). That is luck, not a guarantee: a later change to the record
+    /// cadence, or a decoder that expanded one record into per-second rows, would quietly switch the
+    /// path on. Refuse it by provenance instead, where the reason stays legible.
+    ///
+    /// There is NO second door. These rows are instrumentation: stored, plotted (`displayValue`) and
+    /// nothing else. In particular nothing derives `dailyMetric.respRateBpm` from them — that is the
+    /// SCORED slot (the recovery resp term, `IllnessSignalEngine`), and CLAUDE.md's #194 rule reserves
+    /// it: a channel that already sits at its vendor ceiling gets instrumented beside the incumbent,
+    /// not made the default and not wired to a downstream gate. If a future change wants to score them,
+    /// it needs its own evidence and its own review — not a quiet extra caller of this file.
+    public static func forScoring(_ rows: [RespSample], deviceId: String) -> [RespSample] {
+        isRingRateStream(deviceId: deviceId) ? [] : rows
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -22,7 +22,12 @@ import OuraProtocol
 /// missing stream stays empty here, never faked (Huami precedent).
 ///
 /// Tier-B (UNVERIFIED) events are dropped: only Tier-A decoded signals map into `Streams`, so an
-/// unverified summary can never silently feed scoring.
+/// unverified summary can never silently feed scoring. ONE exception, and it is explicit rather than
+/// silent: `.sleepPeriodInfo`'s `breath` field maps to `resp` (see the case below). That value is the
+/// RING's own measurement, not something NOOP derives, so keeping it is a decode question rather than a
+/// method question — but it is kept OUT of the sleep stager at the read (`OuraRespScale.forScoring`)
+/// rather than out of the database, because the stager reads this stream as a 1 Hz raw ADC waveform and
+/// a per-window rate is the wrong SHAPE for it, however good the rate is.
 public enum OuraStreamMapping {
     /// WhoopEvent.kind for the ring's own HRV 0x5D tag. The payload carries the honestly-labelled decoded
     /// fields `pair_index` / `hr_bpm` / `rmssd_ms` — the 0x5D body is a run of `(u8 avg HR bpm, u8 avg
@@ -52,6 +57,8 @@ public enum OuraStreamMapping {
     ///   - `.temp`       (0x46/0x75)                    → `skinTemp:[SkinTempSample(raw_adc)]`
     ///   - `.sleepPhase` (0x4E/0x5A 2-bit codes)        → `events:[WhoopEvent(kind: OURA_SLEEP_PHASE)]`
     ///   - `.battery`                                   → `battery:[BatterySample]`
+    ///   - `.sleepPeriodInfo` (0x6A, Tier B)            → `resp:[RespSample(milli_bpm)]` — `breath` ONLY,
+    ///     as instrumentation; every other field of the record stays in the investigation log.
     /// Every other event case (`.motion`, `.state`, `.timeSync`, `.rtcBeacon`, `.debugText`, `.tierB`,
     /// `.activityInfo`) is intentionally not folded into a durable stream here. In particular the 0x50
     /// activity/MET decode NEVER mints a `steps` row: the formula is third-party and unvalidated (Tier B,
@@ -192,12 +199,64 @@ public enum OuraStreamMapping {
                 if let hi = m.highIntensity { payload["high_intensity"] = .int(hi) }
                 out.events.append(WhoopEvent(ts: ts, kind: motionEventKind, payload: payload))
 
-            case .motion, .state, .timeSync, .rtcBeacon, .debugText, .tierB, .activityInfo, .realStepsFields:
+            case .sleepPeriodInfo(let v):
+                // 0x6A `breath` → a `respSample` row under the RING's deviceId, as INSTRUMENTATION: the
+                // row is stored and it is plotted on the respiration track beside the incumbent, and
+                // NOTHING scores from it. `OuraRespScale.forScoring` refuses these rows at every scoring
+                // read, and nothing writes `dailyMetric.respRateBpm` from them — see the note at the
+                // bottom of this case.
+                //
+                // Why this one field is stored: `breath` is the RING's own measurement, read off the wire
+                // — not a signal NOOP derives from raw sensor data. The #194 rule governs the latter
+                // (PPG→HR, RSA-from-R-R: methods where NOOP invents the number), so the question here is
+                // whether the DECODE is right, and that is settled structurally: 3,493 records over four
+                // nights, every value an exact multiple of 0.125, both of the source's declared invariants
+                // upheld. On decode provenance it has the same standing as the ring's own hypnogram,
+                // which NOOP already persists (#773/#877). Cross-checks, in order of weight: these records
+                // median 14.75/min against the SAME wearer's 851-night Oura APP export at 15.250 (IQR
+                // 14.875–15.625) — same quantity, same band (distribution, not paired: the corpora do not
+                // overlap in date); against a WHOOP worn the same nights the decode reproduces the
+                // VENDOR's own offset (Oura below WHOOP 18/18, Δ −1.158; ours Δ −1.458 sign-stable 6/6,
+                // r = +0.599 / +0.748 well-covered, against Oura's own +0.680 ceiling); and the date
+                // falsifier passed (wrong mapping collapses r to −0.151).
+                //
+                // Scale: `raw` is MILLI-breaths-per-minute (`OuraRespScale`), which is exact for every
+                // wire value rather than merely close. `respSample.raw` otherwise carries a WHOOP raw ADC
+                // WAVEFORM sample — a different physical quantity in the same table — so the row's owner
+                // is what tells the two apart, and `OuraRespScale` is the one place that knows it.
+                //
+                // What this record does NOT persist, and why: `averageHrBpm` would land in the same `hr`
+                // series as the beat-derived channel at a different cadence and provenance;
+                // `breathVariability` / `mzci` / `dzci` / `cv` are named but uninterpreted; `sleepState`
+                // has no documented code meaning. They stay in the investigation log.
+                //
+                // And what NOTHING does with these rows: write `dailyMetric.respRateBpm`. That is the
+                // SCORED slot — it feeds recovery's resp term and `IllnessSignalEngine` — and CLAUDE.md's
+                // #194 rule reserves it. The measurements above put this channel AT its ceiling, not past
+                // it: r = +0.680 is what Oura's OWN app scores against WHOOP, so no Oura-derived rate can
+                // do better, and the ring pairs to one app at a time, which makes a paired same-night
+                // Oura-app comparison impossible by construction rather than merely undone. A signal that
+                // good and no better belongs beside the incumbent, not in front of it. Enforced at the
+                // read, not by convention: `OuraRespScale.forScoring`.
+                // PARITY: the Kotlin twin stores the IDENTICAL integer for a given decoded value.
+                out.resp.append(RespSample(ts: ts,
+                                           raw: OuraRespScale.milliBpm(fromBreathsPerMin: v.breathsPerMin),
+                                           unit: OuraRespScale.unitTag))
+
+            case .motion, .state, .timeSync, .rtcBeacon, .debugText, .tierB, .activityInfo,
+                 .realStepsFields:
                 // Not a durable per-device stream row (timeSync/rtcBeacon anchor the transport's clock;
                 // motion/state/debug are diagnostics; Tier-B / .activityInfo / .realStepsFields are
-                // UNVERIFIED and must never feed scoring or the steps stream - in particular
-                // .realStepsFields must never mint a `steps` row on its own: ground truth showed no
-                // field is a count, they are the inputs to Oura's step model; see OuraRealStepsFields).
+                // UNVERIFIED and must never feed scoring or the steps stream). In particular the 0x50
+                // activity/MET decode NEVER mints a `steps` row: the formula is third-party and
+                // unvalidated, and MET is not a step count — fabricating one would break the honest-data
+                // invariant. Nor may .realStepsFields mint one: ground truth showed no field is a count,
+                // they are the inputs to Oura's step model (see OuraRealStepsFields).
+                //
+                // `.sleepPeriodInfo` used to be dropped here too. It is now mapped above, to ONE stream
+                // and one field: `breath` → `resp`. Its `averageHrBpm` is still refused, for the reason
+                // that kept the whole record out — it would land in the same HR series as the
+                // beat-derived channel at a DIFFERENT cadence and a different provenance.
                 continue
             }
         }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraRespScaleTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraRespScaleTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+import WhoopProtocol
+@testable import WhoopStore
+
+/// `OuraRespScale` is the single seam between two different physical quantities that share the
+/// `respSample` table: a WHOOP's raw respiration ADC waveform and an Oura ring's own per-window
+/// RATE (0x6A `breath`). These pin the scale, and pin that a ring's rows are refused for scoring by
+/// PROVENANCE — not by happening to be too sparse for the stager's window.
+final class OuraRespScaleTests: XCTestCase {
+
+    private let ring = "oura-2H3B2405003655"
+    private let strap = "whoop-AABBCCDD"
+
+    // MARK: - The scale
+
+    /// The wire field is `u8 / 8`, so its whole alphabet is 0…31.875 bpm in 0.125 steps, and milli-bpm
+    /// represents every one of them EXACTLY (`wireByte × 125`). This is the reason the scale is milli
+    /// and not the codebase's usual centi: at centi, half the alphabet lands on `x.5` and needs a
+    /// rounding rule both platforms would then have to agree about forever.
+    func testEveryWireValueIsExactInMilliBpm() {
+        for byte in 0...255 {
+            let bpm = Double(byte) / 8.0
+            let raw = OuraRespScale.milliBpm(fromBreathsPerMin: bpm)
+            XCTAssertEqual(raw, byte * 125)
+            XCTAssertEqual(OuraRespScale.breathsPerMin(raw: raw), bpm, accuracy: 1e-12)
+        }
+    }
+
+    /// The values actually observed on real nights, spelled out so a scale change cannot pass quietly.
+    func testObservedNightMediansMapAsWritten() {
+        XCTAssertEqual(OuraRespScale.milliBpm(fromBreathsPerMin: 14.250), 14_250)
+        XCTAssertEqual(OuraRespScale.milliBpm(fromBreathsPerMin: 14.375), 14_375)
+        XCTAssertEqual(OuraRespScale.milliBpm(fromBreathsPerMin: 14.625), 14_625)
+        XCTAssertEqual(OuraRespScale.milliBpm(fromBreathsPerMin: 15.000), 15_000)
+    }
+
+    // MARK: - Which owner's rows are a rate
+
+    func testOnlyARingsRowsAreARate() {
+        XCTAssertTrue(OuraRespScale.isRingRateStream(deviceId: ring))
+        XCTAssertFalse(OuraRespScale.isRingRateStream(deviceId: strap))
+        XCTAssertFalse(OuraRespScale.isRingRateStream(deviceId: "my-whoop"))
+        XCTAssertFalse(OuraRespScale.isRingRateStream(deviceId: ""))
+    }
+
+    /// A ring row plots as breaths/min; a WHOOP row plots as the ADC count it always did. Without the
+    /// scaling the Deep Timeline would draw a ring's 14.375 bpm as 14,375 on a track it labels
+    /// "Respiration".
+    func testDisplayValueScalesOnlyTheRingsRows() {
+        XCTAssertEqual(OuraRespScale.displayValue(raw: 14_375, deviceId: ring), 14.375, accuracy: 1e-12)
+        XCTAssertEqual(OuraRespScale.displayValue(raw: 14_375, deviceId: strap), 14_375, accuracy: 1e-12)
+    }
+
+    // MARK: - The scoring refusal
+
+    /// The instrumentation disposition's hard half: stored, shown, never scored. The stager reads this
+    /// stream as a ~1 Hz raw ADC waveform and runs a peak detector over it, which a per-window rate is
+    /// not. A WHOOP's rows pass through untouched, so no existing night changes.
+    func testRingRespirationIsRefusedForScoringAndWhoopIsUntouched() {
+        let rows = [RespSample(ts: 1_000, raw: 14_375, unit: OuraRespScale.unitTag),
+                    RespSample(ts: 1_296, raw: 14_500, unit: OuraRespScale.unitTag)]
+        XCTAssertTrue(OuraRespScale.forScoring(rows, deviceId: ring).isEmpty)
+        XCTAssertEqual(OuraRespScale.forScoring(rows, deviceId: strap), rows)
+        XCTAssertEqual(OuraRespScale.forScoring([], deviceId: ring), [])
+    }
+}

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
@@ -266,6 +266,65 @@ final class OuraStreamMappingTests: XCTestCase {
         XCTAssertTrue(s.steps.isEmpty, "activity/MET/real_steps must never fabricate a steps row")
     }
 
+    // MARK: - 0x6A sleep_period_info → respiration instrumentation
+
+    /// `breath` becomes ONE `resp` row, in milli-bpm, at the record's own ts — and nothing else about
+    /// the record reaches a durable stream. The other fields are the whole reason the record was
+    /// dropped wholesale before: `averageHrBpm` at a ~5-min cadence would sit in the same series as the
+    /// beat-derived HR channel with no way to tell them apart afterwards.
+    func testSleepPeriodInfoMapsBreathToRespirationAndNothingElse() {
+        let s = OuraStreamMapping.streams(from: [
+            .sleepPeriodInfo(OuraSleepPeriodInfo(ringTimestamp: 100, averageHrBpm: 53.0, hrTrend: -0.625,
+                                                 mzci: 3.75, dzci: 1.75, breathsPerMin: 14.375,
+                                                 breathVariability: 4.625, motionCount: 0, sleepState: 1,
+                                                 cv: 0.25)),
+        ], at: ts)
+        XCTAssertEqual(s.resp.count, 1)
+        XCTAssertEqual(s.resp[0].ts, ts)
+        XCTAssertEqual(s.resp[0].raw, 14_375, "breath is stored in milli-bpm, exactly (14.375 → 14375)")
+        XCTAssertEqual(s.resp[0].unit, "milli_bpm")
+        XCTAssertTrue(s.hr.isEmpty, "0x6A average_hr must never land in the beat-derived HR series")
+        XCTAssertTrue(s.rr.isEmpty)
+        XCTAssertTrue(s.events.isEmpty, "no event row: breath is a stream value, the rest stays in the log")
+        XCTAssertTrue(s.steps.isEmpty)
+        XCTAssertTrue(s.skinTemp.isEmpty)
+        XCTAssertTrue(s.spo2.isEmpty)
+    }
+
+    /// Every value the wire can express survives the round trip exactly — the point of the milli scale.
+    /// The field is a `u8 / 8`, so the whole alphabet is 0…31.875 bpm in 0.125 steps.
+    func testEveryWireBreathValueRoundTripsExactly() {
+        for byte in 0...255 {
+            let bpm = Double(byte) / 8.0
+            let s = OuraStreamMapping.streams(from: [
+                .sleepPeriodInfo(OuraSleepPeriodInfo(ringTimestamp: 100, averageHrBpm: 53.0, hrTrend: 0,
+                                                     mzci: 0, dzci: 0, breathsPerMin: bpm,
+                                                     breathVariability: 0, motionCount: 0, sleepState: 0,
+                                                     cv: 0)),
+            ], at: ts)
+            XCTAssertEqual(s.resp[0].raw, byte * 125, "raw must be the wire byte × 125, losslessly")
+            XCTAssertEqual(OuraRespScale.breathsPerMin(raw: s.resp[0].raw), bpm, accuracy: 1e-12)
+        }
+    }
+
+    /// Each record keeps its OWN anchored second, so a night's ~5-min windows land where they were
+    /// measured. The rows are keyed (deviceId, ts), so two records sharing a second would collapse to
+    /// one — the failure mode that cost 92 % of an overnight's SpO2 before #1070.
+    func testSleepPeriodInfoRecordsKeepTheirOwnTimestamps() {
+        let batches = [(ts, 14.375), (ts + 296, 14.5), (ts + 592, 15.0)]
+        var rows: [RespSample] = []
+        for (at, bpm) in batches {
+            rows += OuraStreamMapping.streams(from: [
+                .sleepPeriodInfo(OuraSleepPeriodInfo(ringTimestamp: 100, averageHrBpm: 53.0, hrTrend: 0,
+                                                     mzci: 0, dzci: 0, breathsPerMin: bpm,
+                                                     breathVariability: 0, motionCount: 0, sleepState: 0,
+                                                     cv: 0)),
+            ], at: at).resp
+        }
+        XCTAssertEqual(rows.map(\.ts), [ts, ts + 296, ts + 592])
+        XCTAssertEqual(rows.map(\.raw), [14_375, 14_500, 15_000])
+    }
+
     // MARK: - Batching a record's events into one insert (#1072, root cause for #823)
 
     /// The defect's shape: the store's `ord` counter is batch-local, so a record's beats only get a

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -1612,6 +1612,34 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                     realStepsDump?.record(tag: steps.tag, ringTs: steps.ringTimestamp, utc: utc, fields: steps.fields)
                 }
 
+            case .sleepPeriodInfo(let info):
+                // 0x6A sleep_period_info (Tier B - third-party field NAMES [open_ring] over offsets our
+                // own §6.12 already had; see OuraSleepPeriodInfo). Logged with the DECODED values every
+                // time, like 0x50 MET rather than once-per-kind: its cadence is a modest ~5 min and the
+                // series is what the respiration ledger is reconstructed from, sample by sample.
+                //
+                // The record's `breath` field is also PERSISTED, as instrumentation: anchored to its own
+                // ring-time and enqueued exactly like the sibling banked streams (.hrv/.temp/.spo2), so a
+                // night's ~5-min windows land where they were MEASURED and never at the drain-arrival
+                // moment. `OuraStreamMapping` maps that ONE field onto a `respSample` row in milli-bpm;
+                // everything else in this record stays here in the log. Nothing SCORES the row — not the
+                // sleep stager, and not `dailyMetric.respRateBpm` (see `OuraRespScale`). The logging is
+                // kept as well as the row: the log line is what the ledger is reconstructed from,
+                // including for records no anchor can place, and it carries the fields the store
+                // deliberately does not.
+                let periodWhen = driver.unixSeconds(forRingTimestamp: info.ringTimestamp)
+                    .map { Self.cursorDateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval($0))) }
+                    ?? "no anchor yet"
+                log("Oura: sleep_period (Tier-B) [\(periodWhen)] hr=\(info.averageHrBpm) "
+                    + "trend=\(info.hrTrend) breath=\(info.breathsPerMin) "
+                    + "breathV=\(info.breathVariability) motion=\(info.motionCount) state=\(info.sleepState)")
+                if let ts = driver.unixSeconds(forRingTimestamp: info.ringTimestamp) {
+                    enqueue([e], ts: ts)
+                    noteStoredHistoryRingTime(info.ringTimestamp)
+                } else {
+                    pendingAnchorEvents.append((e, info.ringTimestamp))
+                }
+
             case .state(let s):
                 // The ring's own lifecycle strings (0x45/0x53). Charger transitions drive the wear badge;
                 // never a durable Streams row. Only the LIVE stream updates the indicator (a history

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -675,7 +675,17 @@ final class IntelligenceEngine: ObservableObject {
                     continue
                 }
                 let rr = (try? await store.rrIntervals(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
-                let resp = (try? await store.respSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
+                // `forScoring` drops an Oura ring's respiration rows: those are the ring's OWN per-window
+                // RATE (0x6A, milli-bpm, ~1 row per 5 min), stored as instrumentation, while the stager
+                // reads this stream as a ~1 Hz raw ADC waveform. Refusing by provenance keeps the
+                // instrumentation out of every scored path by construction rather than by cadence luck.
+                // A WHOOP owner is unaffected, and this day scores exactly as it did before those rows
+                // existed — including its `dailyMetric.respRateBpm`, which nothing here derives from a
+                // ring row. See `OuraRespScale.forScoring`.
+                let resp = OuraRespScale.forScoring(
+                    (try? await store.respSamples(deviceId: owner, from: from, to: to,
+                                                  limit: 200_000)) ?? [],
+                    deviceId: owner)
                 let grav = (try? await store.gravitySamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
                 let steps = (try? await store.stepSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
                 let skin = (try? await store.skinTempSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1448,7 +1448,12 @@ final class Repository: ObservableObject {
         guard inWindowGravity >= max(20, windowSeconds / 120) else { return nil }
         let hr = (try? await store.hrSamples(deviceId: deviceId, from: lo, to: hi, limit: 200_000)) ?? []
         let rr = (try? await store.rrIntervals(deviceId: deviceId, from: lo, to: hi, limit: 200_000)) ?? []
-        let resp = (try? await store.respSamples(deviceId: deviceId, from: lo, to: hi, limit: 200_000)) ?? []
+        // Same provenance refusal as the nightly scan (`IntelligenceEngine`): an Oura ring's respiration
+        // rows are its own per-window RATE stored as instrumentation, not the ~1 Hz raw ADC waveform this
+        // stager reads, so they never reach a re-stage either. See `OuraRespScale.forScoring`.
+        let resp = OuraRespScale.forScoring(
+            (try? await store.respSamples(deviceId: deviceId, from: lo, to: hi, limit: 200_000)) ?? [],
+            deviceId: deviceId)
         // Read only when the refinement below might actually use it (see `useMotionAwareWake`) — a plain
         // read cost, but no point paying it on the (default) off path.
         let useMotionAwareWake = PuffinExperiment.motionAwareWakeEnabled
@@ -1761,9 +1766,13 @@ final class Repository: ObservableObject {
                 s.map { Self.timelinePoint($0.ts, skinTempCelsius(raw: $0.raw, family: family)) }
             }.value
         case .respiration:
+            // Two quantities share this table: a WHOOP's raw respiration ADC waveform (plotted verbatim,
+            // as before) and an Oura ring's own per-window RATE in milli-bpm (0x6A instrumentation), which
+            // is scaled back to breaths/min so the track reads as ~14–16 instead of ~14,375.
+            // `OuraRespScale` is the single place that mapping lives.
             let s = (try? await store.respSamples(deviceId: source, from: from, to: to, limit: 200_000)) ?? []
             return await Task.detached(priority: .utility) {
-                s.map { Self.timelinePoint($0.ts, Double($0.raw)) }
+                s.map { Self.timelinePoint($0.ts, OuraRespScale.displayValue(raw: $0.raw, deviceId: source)) }
             }.value
         case .motion:
             // Gravity vector magnitude as a coarse movement signal (1 g at rest).

--- a/Tools/SleepBench/Package.swift
+++ b/Tools/SleepBench/Package.swift
@@ -16,9 +16,13 @@ let package = Package(
     dependencies: [
         .package(path: "../../Packages/StrandAnalytics"),
         .package(path: "../../Packages/WhoopProtocol"),
+        // For `OuraRespScale` only: the one seam that decides which respiration rows a stager may read.
+        // A bench that fed an Oura ring's per-window RATE rows to the stager as if they were a WHOOP's
+        // raw ADC waveform would report numbers the app can never produce.
+        .package(path: "../../Packages/WhoopStore"),
     ],
     targets: [
-        .executableTarget(name: "sleepbench", dependencies: ["StrandAnalytics", "WhoopProtocol"]),
+        .executableTarget(name: "sleepbench", dependencies: ["StrandAnalytics", "WhoopProtocol", "WhoopStore"]),
         // The scoring primitives are pure functions over label arrays, so they are unit-testable without a
         // database. `swift test` here needs no health data and no `--db` argument.
         .testTarget(name: "sleepbenchTests", dependencies: ["sleepbench"]),

--- a/Tools/SleepBench/Sources/sleepbench/DB.swift
+++ b/Tools/SleepBench/Sources/sleepbench/DB.swift
@@ -2,6 +2,7 @@ import Foundation
 import SQLite3
 import StrandAnalytics
 import WhoopProtocol
+import WhoopStore
 
 /// Minimal read-only SQLite reader. Deliberately not GRDB: this tool must be able to open a COPY of a
 /// device database taken at any schema version, including one older or newer than `WhoopStore`'s current
@@ -119,8 +120,14 @@ extension ReadOnlyDB {
                 z: ReadOnlyDB.dbl(s, 3), unit: "g",
                 dynAccel: ReadOnlyDB.isNull(s, 4) ? nil : ReadOnlyDB.dbl(s, 4)))
         }
-        try query("SELECT ts, raw FROM respSample WHERE \(w) ORDER BY ts") { s in
-            st.resp.append(RespSample(ts: ReadOnlyDB.int(s, 0), raw: ReadOnlyDB.int(s, 1)))
+        // An Oura ring's respiration rows are its OWN per-window rate (0x6A, milli-bpm), stored as
+        // instrumentation; the stagers read this stream as a ~1 Hz raw ADC waveform. The app refuses
+        // them by provenance at every scoring read, so the bench must refuse them the same way or it
+        // would score a night the app cannot produce. Same seam, one line: `OuraRespScale.forScoring`.
+        if !OuraRespScale.isRingRateStream(deviceId: device) {
+            try query("SELECT ts, raw FROM respSample WHERE \(w) ORDER BY ts") { s in
+                st.resp.append(RespSample(ts: ReadOnlyDB.int(s, 0), raw: ReadOnlyDB.int(s, 1)))
+            }
         }
         try query("SELECT ts, counter, activityClass FROM stepSample WHERE \(w) ORDER BY ts") { s in
             st.steps.append(StepSample(

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -548,6 +548,17 @@ object AnalyticsEngine {
         // NOT a cloud/clinical respiration value. Per matched in-bed session, estimate
         // over [start, end]; the night's value = median of finite per-session
         // estimates; null only when no session yields a finite estimate.
+        //
+        // An Oura ring's 0x6A `breath` rows do NOT enter here, deliberately. They are the ring's own
+        // per-window respiratory RATE, decoded and stored as INSTRUMENTATION only
+        // ([com.noop.data.OuraRespScale], OURA_PROTOCOL.md §6.12): shown beside the incumbent on the
+        // respiration track, never scored. `dailyMetric.respRateBpm` is the scored slot — it feeds the
+        // recovery resp term and the illness signal — and a signal sitting at the vendor ceiling
+        // (r = +0.680 is the BEST any Oura-derived rate can score against WHOOP, which is Oura's own
+        // app's number) is exactly what CLAUDE.md's #194 rule says to instrument rather than make the
+        // default and gate on. So a ring night's `respRateBpm` is whatever the RSA path returns — on
+        // banked R-R that is null — and this block is byte-identical to what it was before 0x6A was
+        // decoded. Mirrors Swift.
         val respRateDaily: Double? = run {
             val perSession = matched
                 .map { SleepStager.respRateFromRR(rr, it.start, it.end) }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -3,6 +3,7 @@ package com.noop.analytics
 import java.util.Locale
 import com.noop.data.DailyMetric
 import com.noop.data.MetricSeriesRow
+import com.noop.data.OuraRespScale
 import com.noop.data.ScoreInputProvenanceRow
 import com.noop.data.SleepSession
 import com.noop.data.WhoopRepository
@@ -510,7 +511,13 @@ object IntelligenceEngine {
                 continue
             }
             val rr = repo.rrIntervals(owner, from, to, STREAM_LIMIT)
-            val resp = repo.respSamples(owner, from, to, STREAM_LIMIT)
+            // `forScoring` drops an Oura ring's respiration rows: those are the ring's OWN per-window
+            // RATE (0x6A, milli-bpm, ~1 row per 5 min), stored as instrumentation, while the stager reads
+            // this stream as a ~1 Hz raw ADC waveform. Refusing by provenance keeps the instrumentation
+            // out of every scored path by construction rather than by cadence luck. A WHOOP owner is
+            // unaffected, and this day scores exactly as it did before those rows existed — including its
+            // `respRateBpm`, which nothing here derives from a ring row. Mirrors Swift.
+            val resp = OuraRespScale.forScoring(repo.respSamples(owner, from, to, STREAM_LIMIT), owner)
             val grav = repo.gravitySamples(owner, from, to, STREAM_LIMIT)
             val steps = repo.stepSamples(owner, from, to, STREAM_LIMIT)
             val skin = repo.skinTempSamples(owner, from, to, STREAM_LIMIT)

--- a/android/app/src/main/java/com/noop/analytics/SleepStageHealer.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStageHealer.kt
@@ -2,6 +2,7 @@ package com.noop.analytics
 
 import com.noop.data.GravitySample
 import com.noop.data.HrSample
+import com.noop.data.OuraRespScale
 import com.noop.data.RespSample
 import com.noop.data.RrInterval
 import com.noop.data.SleepSession
@@ -73,7 +74,12 @@ object SleepStageHealer {
         if (!isDense(grav, start, end)) return null
         val hr = repo.hrSamples(deviceId, lo, hi, IntelligenceEngine.STREAM_LIMIT)
         val rr = repo.rrIntervals(deviceId, lo, hi, IntelligenceEngine.STREAM_LIMIT)
-        val resp = repo.respSamples(deviceId, lo, hi, IntelligenceEngine.STREAM_LIMIT)
+        // Same provenance refusal as the nightly scan: an Oura ring's respiration rows are its own
+        // per-window RATE stored as instrumentation, not the ~1 Hz raw ADC waveform this stager reads,
+        // so they never reach a re-stage either. See `OuraRespScale.forScoring`. Mirrors Swift.
+        val resp = OuraRespScale.forScoring(
+            repo.respSamples(deviceId, lo, hi, IntelligenceEngine.STREAM_LIMIT), deviceId,
+        )
         // Only read when the refinement might actually use it — no point paying for it on the (default) off path.
         val steps = if (useMotionAwareWake) repo.stepSamples(deviceId, lo, hi, IntelligenceEngine.STREAM_LIMIT) else emptyList()
         return restageFromSamples(start, end, grav, hr, rr, resp, useExperimentalSleepV2, steps, useMotionAwareWake)

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -1807,6 +1807,35 @@ class OuraLiveSource(
                     realStepsDump?.record(tag = e.value.tag, ringTs = e.value.ringTimestamp, utc = utc, fields = e.value.fields)
                 }
             }
+            is OuraEvent.SleepPeriodInfo -> {
+                // 0x6A sleep_period_info (Tier B - third-party field NAMES [open_ring] over offsets our
+                // own s6.12 already had; see OuraSleepPeriodInfo). Logged with the DECODED values every
+                // time, like 0x50 MET rather than once-per-kind: its cadence is a modest ~5 min and the
+                // series is what the respiration ledger is reconstructed from, sample by sample.
+                //
+                // The record's `breath` field is also PERSISTED, as instrumentation: anchored to its own
+                // ring-time and enqueued exactly like the sibling banked streams (Hrv/Temp/Spo2), so a
+                // night's ~5-min windows land where they were MEASURED and never at the drain-arrival
+                // moment. OuraStreamMapping maps that ONE field onto a `respSample` row in milli-bpm;
+                // everything else in this record stays here in the log. Nothing SCORES the row - not the
+                // sleep stager, and not `dailyMetric.respRateBpm` (see OuraRespScale). The logging is
+                // kept as well as the row: the log line is what the ledger is reconstructed from,
+                // including for records no anchor can place, and it carries the fields the store
+                // deliberately does not.
+                //
+                // Twin of Swift's `.sleepPeriodInfo` log line, with one deliberate difference: Swift
+                // prints a formatted clock time because that source already holds a formatter, and this
+                // one holds none - the anchored epoch seconds correlate just as well, and adding a
+                // formatter here only to match a log string would be the wrong kind of parity.
+                val v = e.value
+                val whenUtc = d.unixSeconds(forRingTimestamp = v.ringTimestamp)?.toString() ?: "no anchor yet"
+                log(
+                    "Oura: sleep_period (Tier-B) [$whenUtc] hr=${v.averageHrBpm} trend=${v.hrTrend} " +
+                        "breath=${v.breathsPerMin} breathV=${v.breathVariability} " +
+                        "motion=${v.motionCount} state=${v.sleepState}",
+                )
+                enqueueAnchoredOrPark(e, v.ringTimestamp, d)
+            }
             is OuraEvent.MotionVectorEvent -> {
                 // 0x47 averaged accel vector (Tier-A). Persisted as an OURA_MOTION event (same event-table
                 // path as OURA_HRV / OURA_SLEEP_PHASE — see OuraStreamMapping), AND appended to the raw

--- a/android/app/src/main/java/com/noop/data/OuraRespScale.kt
+++ b/android/app/src/main/java/com/noop/data/OuraRespScale.kt
@@ -1,0 +1,92 @@
+package com.noop.data
+
+/**
+ * The ONE place the Oura ring's respiration rows are scaled, displayed and — deliberately — kept out
+ * of scoring. Twin of Swift `WhoopStore.OuraRespScale`.
+ *
+ * `respSample` was built for a WHOOP 4.0's raw respiration ADC WAVEFORM (`resp_rate_raw@47`, 1 Hz,
+ * unit `raw_adc`): a signal the stager runs a peak detector over. The ring sends no waveform at all;
+ * its `0x6A sleep_period_info` record carries an already-computed RATE, one value per ~296 s window
+ * (OURA_PROTOCOL.md s6.12). Two different physical quantities now share one table, so the row's OWNER
+ * is what tells them apart — the same discipline `skinTempCelsius(raw, family)` already applies to
+ * `skinTempSample`, which cannot be reused here because `DeviceFamily` has no Oura case by design
+ * (#1086: a ring resolves to null, never to a coalesced whoop5).
+ *
+ * Everything that reads a respiration row therefore goes through one of the two entry points below —
+ * [displayValue] to show it, [forScoring] to (not) score it — so a future reader is one grep away from
+ * learning that the ring's rows are a rate, not a waveform.
+ */
+object OuraRespScale {
+
+    /**
+     * The unit tag a ring-sourced respiration row is stored at. `respSample` persists no unit column
+     * (only `deviceId, ts, raw`) on either platform, so this documents the scale; the durable
+     * discriminator is the deviceId, via [isRingRateStream]. Swift carries the same string on its
+     * in-memory `RespSample.unit`; the Kotlin row shape ([RespRow]) has no unit field, which is an
+     * in-memory asymmetry only — nothing about the STORED bytes differs.
+     */
+    const val UNIT_TAG = "milli_bpm"
+
+    /**
+     * MILLI-breaths-per-minute — the scale a ring respiration row is stored at.
+     *
+     * The wire field is a `u8` divided by 8, so every decodable value is an exact multiple of 0.125
+     * bpm and `* 1000` is LOSSLESS (`raw == wireByte * 125`, integral for all 256 byte values). That
+     * is why the scale is milli and not the codebase's usual centi: centi would land on `x.5` for half
+     * the wire alphabet and need a rounding rule both platforms then have to agree about forever.
+     * Sub-bpm resolution is not cosmetic here — the whole open question about this channel is a
+     * residual of about -0.30 bpm, which rounding to whole bpm would erase.
+     */
+    const val MILLI_BPM_PER_BPM = 1000.0
+
+    /**
+     * Decoded breaths/min -> the durable `respSample.raw` integer. Exact for every wire value; the
+     * rounding is a floating-point safety net, never a lossy step. PARITY: the Swift twin returns the
+     * IDENTICAL integer (both round half-up, and the input is never negative).
+     */
+    fun milliBpm(breathsPerMin: Double): Int = Math.round(breathsPerMin * MILLI_BPM_PER_BPM).toInt()
+
+    /** Durable `raw` -> breaths/min. */
+    fun breathsPerMin(raw: Int): Double = raw / MILLI_BPM_PER_BPM
+
+    /**
+     * True when this device's `respSample` rows are the ring's per-window RATE (milli-bpm) rather than
+     * a WHOOP raw ADC waveform.
+     */
+    fun isRingRateStream(deviceId: String): Boolean = DeviceBrandCatalog.isOura(deviceId)
+
+    /**
+     * The number to PLOT for one stored row: breaths/min for a ring, the raw ADC count verbatim for a
+     * WHOOP. Without this the day chart's respiration track would plot a ring's 14.375 bpm as "14375"
+     * beside a WHOOP's ADC counts and call both "Respiration".
+     */
+    fun displayValue(raw: Int, deviceId: String): Double =
+        if (isRingRateStream(deviceId)) breathsPerMin(raw) else raw.toDouble()
+
+    /**
+     * The respiration rows a SCORING read is allowed to see: a ring's are REMOVED.
+     *
+     * This is a SHAPE refusal, not a trust one — it would hold even for a value nobody doubts, which
+     * this one increasingly is not (the ring computes it; see `OuraSleepPeriodInfo`). `SleepStager`
+     * buckets `respSample` into epochs and runs `respRateAndRRV` — a peak detector that assumes a
+     * ~1 Hz raw WAVEFORM — over a rolling 5-minute window, and its RRV output steers the V1 recipe's
+     * depth call. A ring row is a per-window RATE: neither a waveform nor 1 Hz, so what it would
+     * contribute is noise wearing the shape of a signal. Feeding a rate to a peak detector is wrong
+     * however good the rate is.
+     *
+     * Today the ring's ~296 s cadence puts fewer than the required 8 samples in any 5-minute window,
+     * so the estimate would come back NaN anyway and staging is bit-identical either way (pinned by
+     * `OuraRespScoringExclusionTest`). That is luck, not a guarantee: a later change to the record
+     * cadence, or a decoder that expanded one record into per-second rows, would quietly switch the
+     * path on. Refuse it by provenance instead, where the reason stays legible.
+     *
+     * There is NO second door. These rows are instrumentation: stored, plotted ([displayValue]) and
+     * nothing else. In particular nothing derives `dailyMetric.respRateBpm` from them — that is the
+     * SCORED slot (the recovery resp term, the illness signal), and CLAUDE.md's #194 rule reserves it:
+     * a channel that already sits at its vendor ceiling gets instrumented beside the incumbent, not made
+     * the default and not wired to a downstream gate. If a future change wants to score them, it needs
+     * its own evidence and its own review — not a quiet extra caller of this file.
+     */
+    fun forScoring(rows: List<RespSample>, deviceId: String): List<RespSample> =
+        if (isRingRateStream(deviceId)) emptyList() else rows
+}

--- a/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
+++ b/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
@@ -2,6 +2,7 @@ package com.noop.data
 
 import com.noop.oura.OuraEvent
 import com.noop.oura.OuraIbiChannel
+import com.noop.protocol.RespSample
 import com.noop.protocol.RrSourceChannel
 import com.noop.protocol.SkinTempSample
 import com.noop.protocol.Spo2Sample
@@ -214,6 +215,65 @@ object OuraStreamMapping {
                 // invariant and the per-source day-owner rules. Same discipline for 0x7E/0x7F real_steps
                 // (s6.13) - decoded, logged, never scored: ground truth showed no field is a step count,
                 // they are the inputs to Oura's step model.
+                is OuraEvent.SleepPeriodInfo -> {
+                    // 0x6A `breath` -> a `respSample` row under the RING's deviceId, as INSTRUMENTATION:
+                    // the row is stored and it is plotted on the respiration track beside the incumbent,
+                    // and NOTHING scores from it. [OuraRespScale.forScoring] refuses these rows at every
+                    // scoring read, and nothing writes `dailyMetric.respRateBpm` from them - see the note
+                    // at the bottom of this branch.
+                    //
+                    // Why this one field is stored: `breath` is the RING's own measurement, read off the
+                    // wire - not a signal NOOP derives from raw sensor data. The #194 rule governs the
+                    // latter (PPG->HR, RSA-from-R-R: methods where NOOP invents the number), so the
+                    // question here is whether the DECODE is right, and that is settled structurally:
+                    // 3,493 records over four nights, every value an exact multiple of 0.125, both of the
+                    // source's declared invariants upheld. On decode provenance it has the same standing
+                    // as the ring's own hypnogram, which NOOP already persists (#773/#877). Cross-checks, in
+                    // order of weight: these records median 14.75/min against the SAME wearer's 851-night
+                    // Oura APP export at 15.250 (IQR 14.875-15.625) - same quantity, same band
+                    // (distribution, not paired: the corpora do not overlap in date); against a WHOOP worn
+                    // the same nights the decode reproduces the VENDOR's own offset (Oura below WHOOP
+                    // 18/18, delta -1.158; ours delta -1.458 sign-stable 6/6, r = +0.599 / +0.748
+                    // well-covered, against Oura's own +0.680 ceiling); and the date falsifier passed
+                    // (wrong mapping collapses r to -0.151).
+                    //
+                    // Scale: `raw` is MILLI-breaths-per-minute ([OuraRespScale]), exact for every wire
+                    // value rather than merely close. `respSample.raw` otherwise carries a WHOOP raw ADC
+                    // WAVEFORM sample - a different physical quantity in the same table - so the row's
+                    // owner is what tells the two apart, and [OuraRespScale] is the one place that knows.
+                    //
+                    // What this record does NOT persist, and why: `averageHrBpm` would land in the same
+                    // `hr` series as the beat-derived channel at a different cadence and provenance;
+                    // `breathVariability` / `mzci` / `dzci` / `cv` are named but uninterpreted;
+                    // `sleepState` has no documented code meaning. They stay in the investigation log.
+                    //
+                    // And what NOTHING does with these rows: write `dailyMetric.respRateBpm`. That is the
+                    // SCORED slot - it feeds recovery's resp term and the illness signal - and CLAUDE.md's
+                    // #194 rule reserves it. The measurements above put this channel AT its ceiling, not
+                    // past it: r = +0.680 is what Oura's OWN app scores against WHOOP, so no Oura-derived
+                    // rate can do better, and the ring pairs to one app at a time, which makes a paired
+                    // same-night Oura-app comparison impossible by construction rather than merely undone.
+                    // A signal that good and no better belongs beside the incumbent, not in front of it.
+                    // Enforced at the read, not by convention: [OuraRespScale.forScoring].
+                    // PARITY: the Swift twin stores the IDENTICAL integer for a given decoded value.
+                    val ts = anchor(ev.value.ringTimestamp) ?: continue
+                    out.resp.add(
+                        RespSample(
+                            ts = ts,
+                            raw = OuraRespScale.milliBpm(ev.value.breathsPerMin),
+                            unit = OuraRespScale.UNIT_TAG,
+                        ),
+                    )
+                }
+
+                // Motion / state / time-sync / rtc / debug / TierB / ActivityInfo never map onto a
+                // scored stream. In particular the 0x50 activity/MET decode (PR #960) NEVER mints a
+                // `steps` row: the formula is third-party and unvalidated (Tier B, OURA_PROTOCOL.md
+                // s6.13), and MET is not a step count - fabricating one would break the honest-data
+                // invariant and the per-source day-owner rules. 0x6A used to be dropped here too; it is
+                // now mapped above, to ONE stream and one field. Its `averageHrBpm` is still refused,
+                // for the reason that kept the whole record out - it would join the beat-derived HR
+                // series at a different cadence and a different provenance.
                 else -> Unit
             }
         }

--- a/android/app/src/main/java/com/noop/data/StreamPersistence.kt
+++ b/android/app/src/main/java/com/noop/data/StreamPersistence.kt
@@ -38,7 +38,12 @@ object StreamPersistence {
         // protocol carriers, so a missing column never causes a misread until a migration adds one.
         spo2 = streams.spo2.map { Spo2Row(it.ts.toLong(), it.red, it.ir) },
         skinTemp = streams.skinTemp.map { SkinTempRow(it.ts.toLong(), it.raw) },
-        // resp/gravity/steps/ppgHr remain type-47-only (historical offload), unchanged.
+        // resp is populated by a live source that decodes a respiration value itself — the Oura ring's
+        // 0x6A `breath`, stored in milli-bpm under the ring's own deviceId (`OuraRespScale`). It stays
+        // empty for a WHOOP live batch, whose respiration rows arrive on the historical-offload path.
+        // The rows already carry the Room shape, so this is a pass-through, not a re-map.
+        resp = streams.resp.map { RespRow(it.ts.toLong(), it.raw) },
+        // gravity/steps/ppgHr remain type-47-only (historical offload), unchanged.
     )
 
     /**

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -598,6 +598,52 @@ object OuraDecoders {
         return if (out.isEmpty()) null else out
     }
 
+    // MARK: - Sleep period info (0x6A; s6.12) - Tier B, third-party field names
+
+    /**
+     * Decode the 0x6A sleep_period_info: a fixed 10-byte body carrying the ring's OWN per-window sleep
+     * summary - an average heart rate and a CANDIDATE breath rate. Field names and multipliers are a
+     * clean-room fact citation of [open_ring]'s `decode_sleep_period_info_2`
+     * (`parse_api_sleep_period_info`, multipliers from its `.rodata` block); no code is copied. See
+     * [OuraSleepPeriodInfo] for what our own captures do and do not establish, and OURA_PROTOCOL.md
+     * s6.12.
+     *   byte0 = average_hr, u8 * 0.5      (so wire 130 = 65 bpm - NOT a bare bpm byte)
+     *   byte1 = hr_trend,   s8 * 0.0625   (the only SIGNED field in the body)
+     *   byte2 = mzci,       u8 * 0.0625
+     *   byte3 = dzci,       u8 * 0.0625
+     *   byte4 = breath,     u8 / 8.0      (breaths per minute - the reason this tag matters)
+     *   byte5 = breath_v,   u8 / 8.0
+     *   byte6 = motion_count, u8          (source DECLARES < 121)
+     *   byte7 = sleep_state,  u8          (source DECLARES in {0,1,2})
+     *   byte8-9 = cv, u16 LE / 65536      (so [0,1))
+     *
+     * Returns null on a short body OR when either declared invariant is violated. Rejecting on the
+     * invariants is deliberate and is what makes this decode falsifiable rather than credulous: the
+     * source's own parser throws there, so a body that breaks them is not this layout, and the honest
+     * answer is "not decoded" rather than a number built from bytes that mean something else. It costs
+     * nothing on real data - all 3,493 records across four consecutive Gen 3 overnights pass both.
+     * Byte-identical twin of Swift's `decodeSleepPeriodInfo`.
+     */
+    fun decodeSleepPeriodInfo(rec: OuraRecord): OuraSleepPeriodInfo? {
+        val b = rec.payload
+        if (b.size < 10) return null
+        val motionCount = b[6]
+        val sleepState = b[7]
+        if (motionCount >= 121 || sleepState > 2) return null   // the source's own invariants
+        return OuraSleepPeriodInfo(
+            ringTimestamp = rec.ringTimestamp,
+            averageHrBpm = b[0] * 0.5,
+            hrTrend = i8(b[1]) * 0.0625,
+            mzci = b[2] * 0.0625,
+            dzci = b[3] * 0.0625,
+            breathsPerMin = b[4] / 8.0,
+            breathVariability = b[5] / 8.0,
+            motionCount = motionCount,
+            sleepState = sleepState,
+            cv = u16le(b, 8).toDouble() / 65536.0,
+        )
+    }
+
     // MARK: - Motion period, 2-bit MOTION_STATE codes (0x6B; s6.13)
 
     /**

--- a/android/app/src/main/java/com/noop/oura/EventTags.kt
+++ b/android/app/src/main/java/com/noop/oura/EventTags.kt
@@ -64,6 +64,9 @@ enum class OuraEventTag(val raw: Int) {
     SLEEP_SUMMARY_E(0x57),    // sleep summary variant, OURA_PROTOCOL.md s6.12 (UNVERIFIED)
     SLEEP_SUMMARY_F(0x58),    // sleep summary variant, OURA_PROTOCOL.md s6.12 (UNVERIFIED)
 
+    // --- Sleep period info (Tier B, UNVERIFIED) ---
+    SLEEP_PERIOD_INFO(0x6A),  // sleep_period_info (avg HR + breath rate), OURA_PROTOCOL.md s6.12 (UNVERIFIED)
+
     // --- Sleep phase codes (Tier A: 2-bit phase codes are byte-for-byte verified) ---
     // 0x4B/0x4E/0x5A are the three aliases the ring emits for the SAME hypnogram layout — a header
     // byte then 2-bit stage codes, 4/byte MSB-first (open_oura decode_sleep_phases routes all three,
@@ -94,6 +97,12 @@ enum class OuraEventTag(val raw: Int) {
             SLEEP_SUMMARY_1, SLEEP_SUMMARY_C, SLEEP_SUMMARY_D, SLEEP_SUMMARY_E,
             SLEEP_SUMMARY_F, ACTIVITY_INFO, ACTIVITY_SUMMARY_1, ACTIVITY_SUMMARY_2,
             REAL_STEPS_1, REAL_STEPS_2, SPO2_SMOOTHED,
+            // 0x6A sleep_period_info: the field NAMES come from a single decompiled-binary source
+            // ([open_ring]); NOOP's own captures confirm the layout's declared invariants and the
+            // fixed-point scales. Tier B on DECODE PROVENANCE - third-party names, not Oura
+            // documentation - not on doubt that the ring measures respiration: `breath` is the ring's
+            // own value read off the wire, and it feeds respRateBpm (see OuraSleepPeriodInfo).
+            SLEEP_PERIOD_INFO,
             // #287: 0x71 green_ibi_and_amp is NOT corpus-verified — no captured 0x71 fixture, and
             // OURA_PROTOCOL.md §6.2 documents a DIFFERENT layout (5 IBI deltas + 6 amplitudes, shift
             // [2:0]) than the 0x60 decoder it was wired to (6 absolute IBIs, 4-bit shift). Decoding it
@@ -127,6 +136,7 @@ enum class OuraEventTag(val raw: Int) {
             SLEEP_TEMP -> "SLEEP_TEMP"
             MOTION -> "MOTION"
             MOTION_PERIOD -> "MOTION_PERIOD"
+            SLEEP_PERIOD_INFO -> "SLEEP_PERIOD_INFO"
             SLEEP_SUMMARY_1 -> "SLEEP_SUMMARY_1"
             SLEEP_PHASE_B -> "SLEEP_PHASE_4B"
             SLEEP_SUMMARY_C -> "SLEEP_SUMMARY_4C"

--- a/android/app/src/main/java/com/noop/oura/OuraDriver.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraDriver.kt
@@ -518,6 +518,21 @@ class OuraDriver(
                 val fields = OuraDecoders.decodeRealStepsFields(record) ?: return emptyList()
                 listOf(OuraEvent.RealStepsFields(fields))
             }
+            OuraEventTag.SLEEP_PERIOD_INFO -> {
+                // Split out of the raw-bytes TierB wrapper, same as ActivityInfo: this tag has a cited
+                // third-party layout ([open_ring]) whose field NAMES are what our own s6.12 was missing,
+                // and whose declared invariants our captures uphold. Still Tier B - only reached behind
+                // allowTierB (gated above). ONE field of it is durable: OuraStreamMapping maps
+                // `breathsPerMin` to a respSample row under the ring's OWN deviceId, and on a ring night
+                // AnalyticsEngine takes the night's median of those rows as dailyMetric.respRateBpm (the
+                // ring measures it; NOOP does not derive it). It is still refused at the STAGING read by
+                // provenance (OuraRespScale.forScoring) - that path reads the stream as a ~1 Hz raw ADC
+                // waveform and a per-window rate is the wrong shape for a peak detector. `averageHrBpm`
+                // and every other field stay diagnostic-only - in particular the HR must not join the
+                // beat-derived series at a different cadence.
+                val info = OuraDecoders.decodeSleepPeriodInfo(record) ?: return emptyList()
+                listOf(OuraEvent.SleepPeriodInfo(info))
+            }
             OuraEventTag.SPO2_SMOOTHED ->
                 listOf(
                     OuraEvent.TierB(

--- a/android/app/src/main/java/com/noop/oura/OuraEvents.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraEvents.kt
@@ -304,6 +304,79 @@ data class OuraActivityInfo(val ringTimestamp: Long, val state: Int, val met: Li
  */
 data class OuraRealStepsFields(val tag: Int, val ringTimestamp: Long, val fields: List<Int>)
 
+/**
+ * One decoded `0x6A` sleep_period_info record: the ring's OWN per-window sleep summary - an average
+ * heart rate and, notably, a **breath rate**. THIRD-PARTY FIELD NAMES ([open_ring]
+ * `decode_sleep_period_info_2` / native `parse_api_sleep_period_info`, clean-room fact citation, no code
+ * copied; the multipliers are its `.rodata` constants). Our own s6.12 already carried the right OFFSETS
+ * and the right `/8.0` from [ringverse] but no names, and mistyped `average_hr` as an `int8` with no
+ * `* 0.5`.
+ *
+ * STRUCTURALLY VERIFIED on four consecutive real Gen 3 overnights (2026-08-05->09, 3,493 records): every
+ * body is exactly 10 bytes; every record satisfies the source's own declared invariants
+ * (`motionCount < 121`, `sleepState in {0,1,2}` - only 0 and 1 ever observed); every `breath` is an exact
+ * multiple of 0.125, which confirms the `/8.0` fixed point FROM THE DATA rather than assuming it; and
+ * `averageHrBpm` medians 53.0-54.0 bpm across the four nights, agreeing with the 54 bpm median the
+ * independently-decoded banked-IBI channel gives for the same wearer (#511, itself WHOOP-validated
+ * against RHR 55). The `* 0.5` scale is settled by its falsifier: read as `* 1.0` the same records sit
+ * +56 ... +62 bpm above every other HR channel we hold.
+ *
+ * WHOSE measurement this is decides which bar applies. `breath` is computed BY THE RING and read off
+ * the wire - it is not a signal NOOP derives from raw sensor data. The #194 rule is written for the
+ * opposite case (PPG->HR autocorrelation, RSA-from-R-R: methods where NOOP invents the number and can
+ * manufacture a peak that looks physiological), so what has to be right here is the DECODE, which is
+ * what the structural verification above establishes. On decode provenance it has the same standing as
+ * the ring's own SleepNet hypnogram, which NOOP already persists (#773 / #877).
+ *
+ * Independent support that byte 4 is the quantity Oura's own app calls respiratory rate: these records
+ * median 14.75/min against the SAME wearer's 851-night Oura app export at 15.250 (IQR 14.875-15.625) -
+ * same quantity, same band, though the two corpora do not overlap in date so this is a distribution
+ * check, not a paired one. Against a WHOOP worn on the same nights the decode also reproduces the
+ * VENDOR's own offset (Oura reads below WHOOP 18/18 nights, delta -1.158; ours delta -1.458,
+ * sign-stable 6/6), and mapping each night to the wrong date collapses the agreement (r +0.591 ->
+ * -0.151), so it is date-aligned rather than coincidental.
+ *
+ * It stays Tier B because the field NAMES come from third-party reverse engineering, not from Oura
+ * documentation - a decode-provenance caveat, not a doubt about whether the ring measures respiration.
+ *
+ * `OuraStreamMapping` maps `breathsPerMin` - and nothing else from this record - to a `respSample` row
+ * in milli-bpm under the ring's own deviceId, as INSTRUMENTATION: the row is stored and plotted on the
+ * respiration track beside the incumbent, and NOTHING scores from it. In particular nothing writes
+ * `dailyMetric.respRateBpm` from it - that is the scored slot (recovery's respiration term, the illness
+ * signal), and the same measurements that make this decode believable also place it AT the vendor
+ * ceiling rather than past it (r = +0.680 is what Oura's OWN app manages against WHOOP), which is
+ * precisely the case CLAUDE.md's #194 rule says to instrument rather than make the default. It also
+ * never reaches the sleep STAGER (`OuraRespScale.forScoring`): that stream is read there as a ~1 Hz raw
+ * ADC waveform and a per-window rate is the wrong shape for a peak detector, however good the rate.
+ * `averageHrBpm` stays diagnostic-only: it must not join the beat-derived HR series at a different
+ * cadence and a different provenance.
+ *
+ * `mzci` / `dzci` keep the source's opaque names deliberately - we do not know what they measure, and
+ * inventing a friendlier name would assert an interpretation the evidence does not support. Kotlin twin
+ * of the Swift `OuraSleepPeriodInfo`.
+ */
+data class OuraSleepPeriodInfo(
+    val ringTimestamp: Long,
+    /** Wire `u8 * 0.5`, so the channel has half-bpm resolution (~50 % of real records carry an odd byte). */
+    val averageHrBpm: Double,
+    /** Wire `s8 * 0.0625` - signed; the only signed field in the body. */
+    val hrTrend: Double,
+    /** Wire `u8 * 0.0625`. Meaning unknown (source's name kept verbatim). */
+    val mzci: Double,
+    /** Wire `u8 * 0.0625`. Meaning unknown (source's name kept verbatim). */
+    val dzci: Double,
+    /** Wire `u8 / 8.0` - CANDIDATE breaths per minute. See the type doc: named, not validated. */
+    val breathsPerMin: Double,
+    /** Wire `u8 / 8.0` - CANDIDATE breath variability, same units as [breathsPerMin]. */
+    val breathVariability: Double,
+    /** Wire `u8`, declared `< 121` by the source (upheld by every record we hold). */
+    val motionCount: Int,
+    /** Wire `u8`, declared `in {0,1,2}` (only 0 and 1 observed). Code meanings undocumented - no enum. */
+    val sleepState: Int,
+    /** Wire `u16 LE / 65536`, so `[0, 1)`. Meaning unknown (source's name kept verbatim). */
+    val cv: Double,
+)
+
 // MARK: - The emitted event union
 
 /**
@@ -356,8 +429,20 @@ sealed class OuraEvent {
      */
     data class RealStepsFields(val value: OuraRealStepsFields) : OuraEvent()
 
+    /**
+     * A decoded `0x6A` sleep_period_info record (avg HR + the ring's own breath rate). Still Tier-B
+     * (see [OuraSleepPeriodInfo] doc) - split out of the raw-bytes [TierB] wrapper for the same reason
+     * [ActivityInfo] was: a cited third-party layout worth surfacing as real numbers instead of hex.
+     * Same gate (`allowTierB`); its `breathsPerMin` - alone among the record's fields - is mapped to a
+     * durable `respSample` row and, on a ring night, supplies `dailyMetric.respRateBpm` (see the type
+     * doc). Every other field of the record stays diagnostic-only.
+     */
+    data class SleepPeriodInfo(val value: OuraSleepPeriodInfo) : OuraEvent()
+
     /** True for Tier-B events, so a consumer can assert none leaked into a Tier-A-only sink. */
-    val isTierB: Boolean get() = this is TierB || this is ActivityInfo || this is RealStepsFields
+    val isTierB: Boolean
+        get() = this is TierB || this is ActivityInfo || this is RealStepsFields ||
+            this is SleepPeriodInfo
 
     /**
      * The record's envelope ring-time, when it carries one (battery is a plain response, not a log
@@ -383,5 +468,6 @@ sealed class OuraEvent {
             is TierB -> value.ringTimestamp
             is ActivityInfo -> value.ringTimestamp
             is RealStepsFields -> value.ringTimestamp
+            is SleepPeriodInfo -> value.ringTimestamp
         }
 }

--- a/android/app/src/main/java/com/noop/protocol/Streams.kt
+++ b/android/app/src/main/java/com/noop/protocol/Streams.kt
@@ -100,6 +100,20 @@ data class Spo2Sample(val ts: Int, val red: Int, val ir: Int, val unit: String =
 data class SkinTempSample(val ts: Int, val raw: Int, val unit: String = "raw_adc")
 
 /**
+ * A respiration sample at wall-clock unix seconds [ts]. Mirrors the Room `RespSample` and the Swift
+ * `RespSample(ts:raw:unit:)` shape.
+ *
+ * UNIT CONVENTION, and it is not one convention: [raw] is a WHOOP 4.0's raw respiration ADC WAVEFORM
+ * sample (`resp_rate_raw@47`, ~1 Hz, `raw_adc`) — the signal the stager runs a peak detector over — OR,
+ * for an Oura ring, that ring's own already-computed per-window RATE in MILLI-breaths-per-minute
+ * (`0x6A breath`, one value per ~296 s, `milli_bpm`). Two physical quantities in one table, told apart
+ * by the row's OWNER: `com.noop.data.OuraRespScale` is the single place that conversion and the
+ * accompanying scoring refusal live. [unit] carries the scale tag for fidelity; as with SkinTempSample
+ * the Room entity has no unit column, so the deviceId is the durable discriminator.
+ */
+data class RespSample(val ts: Int, val raw: Int, val unit: String = "raw_adc")
+
+/**
  * WHOOP 4.0 (v24) skin-temp mapping constants (#938). The single provisional slope + anchor live in ONE
  * place so the two-point-calibration TODO has an obvious home. Kept in lockstep with the Swift
  * `Whoop4SkinTemp`.
@@ -246,6 +260,11 @@ data class Streams(
     // unchanged; only a source that decodes these biometric signals live (the Oura ring) populates them.
     val spo2: MutableList<Spo2Sample> = mutableListOf(),
     val skinTemp: MutableList<SkinTempSample> = mutableListOf(),
+    // Same reasoning as spo2/skinTemp above: empty for every WHOOP live batch (a WHOOP's respiration
+    // rows arrive on the historical-offload path, which builds a StreamBatch directly), populated only
+    // by a live source that decodes a respiration value itself — today the Oura ring's 0x6A `breath`
+    // (see `OuraStreamMapping`, and `OuraRespScale` for the scale it is stored at).
+    val resp: MutableList<RespSample> = mutableListOf(),
 ) {
     companion object {
         val EMPTY: Streams get() = Streams()

--- a/android/app/src/main/java/com/noop/ui/FullDayChartScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/FullDayChartScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.noop.R
 import com.noop.analytics.HrvAnalyzer
+import com.noop.data.OuraRespScale
 import com.noop.protocol.DeviceFamily
 import com.noop.protocol.skinTempCelsius
 import kotlinx.coroutines.Dispatchers
@@ -411,8 +412,12 @@ private suspend fun readTimeline(
                 .map { TimelinePoint(it.ts, skinTempCelsius(it.raw, family)) }
         }
         TimelineMetric.Respiration ->
+            // Two quantities share this table: a WHOOP's raw respiration ADC waveform (plotted verbatim,
+            // as before) and an Oura ring's own per-window RATE in milli-bpm (0x6A instrumentation), which
+            // is scaled back to breaths/min so the track reads as ~14-16 instead of ~14,375.
+            // `OuraRespScale` is the single place that mapping lives. Mirrors Swift.
             runCatching { repo.respSamples(deviceId, from, to, 200_000) }.getOrDefault(emptyList())
-                .map { TimelinePoint(it.ts, it.raw.toDouble()) }
+                .map { TimelinePoint(it.ts, OuraRespScale.displayValue(it.raw, deviceId)) }
         TimelineMetric.Motion ->
             runCatching { repo.gravitySamples(deviceId, from, to, 200_000) }.getOrDefault(emptyList())
                 .map { TimelinePoint(it.ts, kotlin.math.sqrt(it.x * it.x + it.y * it.y + it.z * it.z)) }

--- a/android/app/src/test/java/com/noop/analytics/OuraRespScoringExclusionTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/OuraRespScoringExclusionTest.kt
@@ -1,0 +1,174 @@
+package com.noop.analytics
+
+import com.noop.data.GravitySample
+import com.noop.data.HrSample
+import com.noop.data.OuraRespScale
+import com.noop.data.RespSample
+import com.noop.data.RrInterval
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneOffset
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.roundToInt
+import kotlin.math.sin
+
+/**
+ * The 0x6A `breath` channel is a per-window RATE stored in `respSample` under the ring's own deviceId —
+ * the same table that otherwise holds a WHOOP's ~1 Hz raw ADC waveform. It is INSTRUMENTATION: it is
+ * stored and it is plotted, and NOTHING scores from it. Two separate refusals, pinned here:
+ *  * the STAGER must never see it — a peak detector run over a rate series is a shape error, and this
+ *    one would be wrong even for a value nobody doubts;
+ *  * the night's `dailyMetric.respRateBpm` must never be derived from it — that is the scored slot
+ *    (recovery's resp term, the illness signal), and CLAUDE.md's #194 rule keeps a channel already at
+ *    its vendor ceiling out of it.
+ * Plus the control that keeps the first refusal from being vacuous. Swift twin:
+ * `OuraRespScoringExclusionTests`.
+ */
+class OuraRespScoringExclusionTest {
+
+    private val ring = "oura-2H3B2405003655"
+    private val profile = UserProfile(weightKg = 75.0, heightCm = 178.0, age = 30.0, sex = "male")
+
+    // ── fixtures ─────────────────────────────────────────────────────────────────────────────────────
+
+    /** A still 1 Hz gravity stream — the quiescent sleep floor, enough for the stager to stage. */
+    private fun stillGravity(start: Long, durationS: Int): List<GravitySample> =
+        (0 until durationS).map { GravitySample(ring, start + it, 0.0, 0.0, 1.0) }
+
+    private fun sleepingHr(start: Long, durationS: Int): List<HrSample> =
+        (0 until durationS).map { HrSample(ring, start + it, 52 + (it / 600) % 4) }
+
+    private fun regularRr(start: Long, durationS: Int): List<RrInterval> =
+        (0 until durationS).map {
+            RrInterval(ring, start + it, 1_150 + (40.0 * sin(2.0 * PI * it / 4.0)).roundToInt())
+        }
+
+    /**
+     * What a real night of 0x6A looks like once persisted: one row per ~296 s window, milli-bpm, values
+     * drifting over the observed 13-16 bpm band.
+     */
+    private fun ringRespRows(start: Long, durationS: Int): List<RespSample> =
+        (0 until durationS step 296).map { i ->
+            val byte = 112 + (i / 296) % 12                      // 14.000 .. 15.375 bpm, in 0.125 steps
+            RespSample(ring, start + i, byte * 125)
+        }
+
+    // ── The refusal ──────────────────────────────────────────────────────────────────────────────────
+
+    /** The guarantee, stated where the stager can see it: the rows never arrive. */
+    @Test
+    fun ringRespirationNeverReachesTheStager() {
+        val start = 1_754_000_000L
+        val rows = ringRespRows(start, 8 * 3_600)
+        assertFalse("fixture sanity: a night of 0x6A is ~100 rows", rows.isEmpty())
+        assertTrue(OuraRespScale.forScoring(rows, ring).isEmpty())
+    }
+
+    /**
+     * ...and that refusing them is a NO-OP on today's firmware, which is what makes this change safe to
+     * land: `respRateAndRRV` needs >= 8 samples in its rolling 5-minute window, and a ~296 s cadence
+     * never supplies more than two, so every epoch's RRV is NaN either way. Staging is bit-identical
+     * with the rows and without them.
+     *
+     * This is exactly why the refusal is written by PROVENANCE rather than left to the cadence: the day
+     * a decoder expands one record into per-second rows, or the record period changes, this assertion
+     * stops being free — and [OuraRespScale.forScoring] is already the place that keeps the outcome the
+     * same.
+     */
+    @Test
+    fun todaysCadenceWouldNotHaveMovedStagingEitherWay() {
+        val start = 1_754_000_000L
+        val dur = 8 * 3_600
+        val grav = stillGravity(start, dur)
+        val hr = sleepingHr(start, dur)
+        val rr = regularRr(start, dur)
+        val rows = ringRespRows(start, dur)
+
+        val without = SleepStager.stageSession(start, start + dur, grav, hr, rr, emptyList())
+        val with = SleepStager.stageSession(start, start + dur, grav, hr, rr, rows)
+        assertFalse("fixture sanity: the night must actually stage", without.isEmpty())
+        assertEquals(without.map { it.start }, with.map { it.start })
+        assertEquals(without.map { it.end }, with.map { it.end })
+        assertEquals(without.map { it.stage }, with.map { it.stage })
+    }
+
+    /**
+     * A 1 Hz stream of the SAME numbers does move the stager — the control that proves the test above is
+     * measuring the cadence and not simply a stager that ignores `resp`. If this one ever stops failing
+     * to match, the invariance above has become vacuous.
+     */
+    @Test
+    fun aOneHertzStreamOfTheSameValuesWouldMoveStaging() {
+        val start = 1_754_000_000L
+        val dur = 8 * 3_600
+        val grav = stillGravity(start, dur)
+        val hr = sleepingHr(start, dur)
+        val rr = regularRr(start, dur)
+        // A plausible raw-ADC-shaped waveform at 1 Hz: what the stager's peak detector is built for.
+        val dense = (0 until dur).map {
+            RespSample(ring, start + it, 1_000 + (200.0 * sin(2.0 * PI * it / 4.0)).roundToInt())
+        }
+        val without = SleepStager.stageSession(start, start + dur, grav, hr, rr, emptyList())
+        val withDense = SleepStager.stageSession(start, start + dur, grav, hr, rr, dense)
+        assertNotEquals(
+            "a dense resp stream must reach the stager — otherwise the invariance test proves nothing",
+            without.map { it.stage },
+            withDense.map { it.stage },
+        )
+    }
+
+    // ── The scored slot ──────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * The second refusal, at the level that matters to a user: a ring night's `dailyMetric.respRateBpm`
+     * is NOT the ring's measured rate. `analyzeDay` has no door the rows can arrive through — they are
+     * passed here verbatim as `resp`, the worst case in which a caller forgot [OuraRespScale.forScoring],
+     * and the day is still byte-identical to the day with no rows at all.
+     *
+     * This is the regression guard on the disposition, not on the decode. The decode is good (the ring
+     * computes the value; see OuraSleepPeriodInfo); what it is not is a candidate for the slot that feeds
+     * recovery and the illness signal on the strength of a signal already sitting at the r = +0.680
+     * ceiling any Oura-derived rate has against WHOOP. If this test ever fails, a vendor preference has
+     * been reintroduced into `analyzeDay` and needs its own evidence and review.
+     */
+    @Test
+    fun aRingNightsScoredRespRateIsNotTheRingsMeasuredRate() {
+        val day = "2026-08-16"
+        val sleepStart = LocalDate.parse(day).atStartOfDay(ZoneOffset.UTC).toEpochSecond() - 4 * 3_600L
+        val dur = 8 * 3_600
+        val hr = (sleepStart until sleepStart + dur step 30)
+            .map { HrSample(ring, it, 52 + ((it / 300) % 4).toInt()) }
+        var i = 0
+        val rr = (sleepStart until sleepStart + dur step 2).map { RrInterval(ring, it, 1_080 + (i++ % 6) * 8) }
+        // A ring night stages from the ring's OWN hypnogram (#804 Fix A): no gravity, one provided
+        // session — the exact shape the persisted 0x6A rows show up on.
+        var t = sleepStart
+        val stages = listOf(20 to "wake", 200 to "light", 60 to "deep", 120 to "rem", 80 to "light", 0 to "wake")
+            .map { (mins, stage) -> StageSegment(t, t + mins * 60L, stage).also { t += mins * 60L } }
+        val provided = listOf(
+            DetectedSleep(sleepStart, sleepStart + dur, 0.75, stages, restingHR = null, avgHRV = null),
+        )
+        val rows = ringRespRows(sleepStart, dur)
+        val ringMedian = HrvAnalyzer.median(rows.map { OuraRespScale.breathsPerMin(it.raw) })
+
+        val withRows = AnalyticsEngine.analyzeDay(
+            day = day, hr = hr, rr = rr, resp = rows, profile = profile, providedSleep = provided,
+        )
+        val without = AnalyticsEngine.analyzeDay(
+            day = day, hr = hr, rr = rr, profile = profile, providedSleep = provided,
+        )
+        assertTrue(
+            "the ring's measured rate must never become the night's scored respRateBpm",
+            withRows.daily.respRateBpm == null || abs(withRows.daily.respRateBpm!! - ringMedian) > 1e-9,
+        )
+        assertEquals(
+            "persisting 0x6A must leave every scored field of the day untouched",
+            without.daily, withRows.daily,
+        )
+    }
+}

--- a/android/app/src/test/java/com/noop/data/OuraRespScaleTest.kt
+++ b/android/app/src/test/java/com/noop/data/OuraRespScaleTest.kt
@@ -1,0 +1,84 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [OuraRespScale] is the single seam between two different physical quantities that share the
+ * `respSample` table: a WHOOP's raw respiration ADC waveform and an Oura ring's own per-window RATE
+ * (0x6A `breath`). These pin the scale, and pin that a ring's rows are refused for scoring by
+ * PROVENANCE — not by happening to be too sparse for the stager's window. Swift twin:
+ * `OuraRespScaleTests`.
+ */
+class OuraRespScaleTest {
+
+    private val ring = "oura-2H3B2405003655"
+    private val strap = "whoop-AABBCCDD"
+
+    // ── The scale ────────────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * The wire field is `u8 / 8`, so its whole alphabet is 0..31.875 bpm in 0.125 steps, and milli-bpm
+     * represents every one of them EXACTLY (`wireByte * 125`). This is the reason the scale is milli and
+     * not the codebase's usual centi: at centi, half the alphabet lands on `x.5` and needs a rounding
+     * rule both platforms would then have to agree about forever.
+     */
+    @Test
+    fun everyWireValueIsExactInMilliBpm() {
+        for (byte in 0..255) {
+            val bpm = byte / 8.0
+            val raw = OuraRespScale.milliBpm(bpm)
+            assertEquals(byte * 125, raw)
+            assertEquals(bpm, OuraRespScale.breathsPerMin(raw), 1e-12)
+        }
+    }
+
+    /** The values actually observed on real nights, spelled out so a scale change cannot pass quietly. */
+    @Test
+    fun observedNightMediansMapAsWritten() {
+        assertEquals(14_250, OuraRespScale.milliBpm(14.250))
+        assertEquals(14_375, OuraRespScale.milliBpm(14.375))
+        assertEquals(14_625, OuraRespScale.milliBpm(14.625))
+        assertEquals(15_000, OuraRespScale.milliBpm(15.000))
+    }
+
+    // ── Which owner's rows are a rate ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun onlyARingsRowsAreARate() {
+        assertTrue(OuraRespScale.isRingRateStream(ring))
+        assertFalse(OuraRespScale.isRingRateStream(strap))
+        assertFalse(OuraRespScale.isRingRateStream("my-whoop"))
+        assertFalse(OuraRespScale.isRingRateStream(""))
+    }
+
+    /**
+     * A ring row plots as breaths/min; a WHOOP row plots as the ADC count it always did. Without the
+     * scaling the day chart would draw a ring's 14.375 bpm as 14,375 on a track it labels "Respiration".
+     */
+    @Test
+    fun displayValueScalesOnlyTheRingsRows() {
+        assertEquals(14.375, OuraRespScale.displayValue(14_375, ring), 1e-12)
+        assertEquals(14_375.0, OuraRespScale.displayValue(14_375, strap), 1e-12)
+    }
+
+    // ── The scoring refusal ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * The instrumentation disposition's hard half: stored, shown, never scored. The stager reads this
+     * stream as a ~1 Hz raw ADC waveform and runs a peak detector over it, which a per-window rate is
+     * not. A WHOOP's rows pass through untouched, so no existing night changes.
+     */
+    @Test
+    fun ringRespirationIsRefusedForScoringAndWhoopIsUntouched() {
+        val rows = listOf(
+            RespSample(deviceId = ring, ts = 1_000L, raw = 14_375),
+            RespSample(deviceId = ring, ts = 1_296L, raw = 14_500),
+        )
+        assertTrue(OuraRespScale.forScoring(rows, ring).isEmpty())
+        assertEquals(rows, OuraRespScale.forScoring(rows, strap))
+        assertTrue(OuraRespScale.forScoring(emptyList(), ring).isEmpty())
+    }
+}

--- a/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
+++ b/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
@@ -380,5 +380,67 @@ class OuraStreamMappingTest {
         assertTrue(s.battery.isEmpty())
         assertTrue(s.spo2.isEmpty())
         assertTrue(s.skinTemp.isEmpty())
+        assertTrue(s.resp.isEmpty())
+    }
+
+    // MARK: - 0x6A sleep_period_info -> respiration instrumentation
+
+    private fun sleepPeriod(bpm: Double, ringTimestamp: Long = 100) = OuraEvent.SleepPeriodInfo(
+        com.noop.oura.OuraSleepPeriodInfo(
+            ringTimestamp = ringTimestamp, averageHrBpm = 53.0, hrTrend = -0.625, mzci = 3.75,
+            dzci = 1.75, breathsPerMin = bpm, breathVariability = 4.625,
+            motionCount = 0, sleepState = 1, cv = 0.25,
+        ),
+    )
+
+    /**
+     * `breath` becomes ONE resp row, in milli-bpm, at the record's own ts - and nothing else about the
+     * record reaches a durable stream. The other fields are the whole reason the record was dropped
+     * wholesale before: `averageHrBpm` at a ~5-min cadence would sit in the same series as the
+     * beat-derived HR channel with no way to tell them apart afterwards. Swift twin:
+     * `testSleepPeriodInfoMapsBreathToRespirationAndNothingElse`.
+     */
+    @Test
+    fun sleepPeriodInfoMapsBreathToRespirationAndNothingElse() {
+        val s = OuraStreamMapping.streams(listOf(sleepPeriod(14.375)), anchor)
+        assertEquals(1, s.resp.size)
+        assertEquals(base + 100, s.resp[0].ts)
+        assertEquals(14_375, s.resp[0].raw)
+        assertTrue(s.hr.isEmpty())
+        assertTrue(s.rr.isEmpty())
+        assertTrue(s.events.isEmpty())
+        assertTrue(s.skinTemp.isEmpty())
+        assertTrue(s.spo2.isEmpty())
+    }
+
+    /**
+     * Every value the wire can express survives the round trip exactly - the point of the milli scale,
+     * and the property that makes the two platforms agree without a rounding rule. The field is a
+     * `u8 / 8`, so the whole alphabet is 0..31.875 bpm in 0.125 steps. Swift twin:
+     * `testEveryWireBreathValueRoundTripsExactly`.
+     */
+    @Test
+    fun everyWireBreathValueRoundTripsExactly() {
+        for (byte in 0..255) {
+            val bpm = byte / 8.0
+            val s = OuraStreamMapping.streams(listOf(sleepPeriod(bpm)), anchor)
+            assertEquals(byte * 125, s.resp[0].raw)
+            assertEquals(bpm, OuraRespScale.breathsPerMin(s.resp[0].raw), 1e-12)
+        }
+    }
+
+    /**
+     * Each record keeps its OWN anchored second, so a night's ~5-min windows land where they were
+     * measured. The rows are keyed (deviceId, ts), so two records sharing a second would collapse to
+     * one - the failure mode that cost 92% of an overnight's SpO2 before #1070.
+     */
+    @Test
+    fun sleepPeriodInfoRecordsKeepTheirOwnTimestamps() {
+        val s = OuraStreamMapping.streams(
+            listOf(sleepPeriod(14.375, 100), sleepPeriod(14.5, 396), sleepPeriod(15.0, 692)),
+            anchor,
+        )
+        assertEquals(listOf(base + 100, base + 396, base + 692), s.resp.map { it.ts })
+        assertEquals(listOf(14_375, 14_500, 15_000), s.resp.map { it.raw })
     }
 }

--- a/android/app/src/test/java/com/noop/oura/SleepPeriodInfoTest.kt
+++ b/android/app/src/test/java/com/noop/oura/SleepPeriodInfoTest.kt
@@ -1,0 +1,151 @@
+package com.noop.oura
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * 0x6A `sleep_period_info` (OURA_PROTOCOL.md s6.12) — the tag that carries the ring's own average HR
+ * and a CANDIDATE breath rate, and that NOOP used to drop as unknown. Kotlin twin of the Swift
+ * SleepPeriodInfoTests.swift.
+ *
+ * PARITY NOTE: every fixture hex string below is byte-for-byte identical to the Swift fixtures, so the
+ * SAME raw record bytes must decode to the SAME values on both platforms. They are REAL captured
+ * records from a Gen 3 overnight (`Night 08-06_08_07`, `oura-raw.jsonl`), full `type len rt(4 LE)
+ * body(10)` bytes, not synthetic bodies — the point of the tag is what the ring actually sends.
+ */
+class SleepPeriodInfoTest {
+    private val eps = 1e-9
+
+    private fun record(hex: String): OuraRecord {
+        val rec = OuraFraming.parseRecord(OuraTestHex.bytes(hex))
+            ?: throw AssertionError("record failed to parse: $hex")
+        assertEquals(OuraEventTag.SLEEP_PERIOD_INFO.raw, rec.type)
+        assertEquals("0x6A bodies are a fixed 10 bytes in every record we hold", 10, rec.payload.size)
+        return rec
+    }
+
+    // MARK: - The layout, on real records
+
+    /**
+     * A typical mid-sleep record. Pins all nine fields at once, which is what catches an off-by-one in
+     * the offsets: with the fields adjacent and differently scaled, a one-byte slip cannot leave all
+     * nine right.
+     */
+    @Test
+    fun testTypicalRecordDecodesEveryField() {
+        val info = OuraDecoders.decodeSleepPeriodInfo(record("6a0e9dcca60068f13a1f831f0001d257"))!!
+        assertEquals(52.0, info.averageHrBpm, eps)          // wire 0x68 = 104, x 0.5
+        assertEquals(-0.9375, info.hrTrend, eps)            // wire 0xf1 = -15 SIGNED, x 0.0625
+        assertEquals(3.625, info.mzci, eps)                 // wire 0x3a = 58, x 0.0625
+        assertEquals(1.9375, info.dzci, eps)                // wire 0x1f = 31, x 0.0625
+        assertEquals(16.375, info.breathsPerMin, eps)       // wire 0x83 = 131, / 8
+        assertEquals(3.875, info.breathVariability, eps)    // wire 0x1f = 31, / 8
+        assertEquals(0, info.motionCount)
+        assertEquals(1, info.sleepState)
+        assertEquals(0.343048, info.cv, 1e-6)               // 0x57d2 LE / 65536
+    }
+
+    /**
+     * `average_hr` is `u8 * 0.5`, not a bare bpm byte: an ODD wire byte decodes to a half-bpm. About
+     * half of all real records carry one (0.506 / 0.530 / 0.507 / 0.467 across four nights), so the
+     * half-steps are the channel's real resolution and rounding them away would be a decode loss.
+     */
+    @Test
+    fun testAverageHrHasHalfBpmResolution() {
+        val info = OuraDecoders.decodeSleepPeriodInfo(record("6a0eb6cda60067e92e14862200013f58"))!!
+        assertEquals(51.5, info.averageHrBpm, eps)          // wire 0x67 = 103 — ODD
+        assertEquals(16.75, info.breathsPerMin, eps)
+    }
+
+    /**
+     * `hr_trend` is the body's ONE signed field. Read as unsigned this record's -4.625 becomes +11.375,
+     * which is a plausible-looking number — hence a test rather than a comment.
+     */
+    @Test
+    fun testHrTrendIsSigned() {
+        val info = OuraDecoders.decodeSleepPeriodInfo(record("6a0e99efa60062b638176f1f01004055"))!!
+        assertEquals(-4.625, info.hrTrend, eps)             // wire 0xb6 = -74 SIGNED, x 0.0625
+        assertEquals(49.0, info.averageHrBpm, eps)
+        assertEquals(1, info.motionCount)
+        assertEquals(0, info.sleepState)
+    }
+
+    /**
+     * A restless record: motion present, HR up, trend strongly positive. Confirms the fields move
+     * together the way a real summary should rather than being a fixed pattern.
+     */
+    @Test
+    fun testRestlessRecord() {
+        val info = OuraDecoders.decodeSleepPeriodInfo(record("6a0e0929a7008c7f54346f261b007340"))!!
+        assertEquals(70.0, info.averageHrBpm, eps)
+        assertEquals(7.9375, info.hrTrend, eps)             // wire 0x7f = +127, the positive extreme
+        assertEquals(27, info.motionCount)
+        assertEquals(13.875, info.breathsPerMin, eps)
+    }
+
+    // MARK: - The honest-data boundaries
+
+    /**
+     * The source's own parser THROWS when `motion_count >= 121` or `sleep_state > 2`, so a body that
+     * breaks either is not this layout. Return null rather than a number assembled from bytes that mean
+     * something else — and note this costs nothing on real data: all 3,493 records across four
+     * consecutive overnights satisfy both.
+     */
+    @Test
+    fun testDeclaredInvariantsRejectABody() {
+        val badMotion = OuraRecord(
+            type = 0x6A, ringTimestamp = 1L,
+            payload = intArrayOf(104, 0, 58, 31, 131, 31, 121, 1, 0xd2, 0x57),
+        )
+        assertNull("motion_count == 121 is out of range", OuraDecoders.decodeSleepPeriodInfo(badMotion))
+        val badState = OuraRecord(
+            type = 0x6A, ringTimestamp = 1L,
+            payload = intArrayOf(104, 0, 58, 31, 131, 31, 0, 3, 0xd2, 0x57),
+        )
+        assertNull("sleep_state == 3 is out of range", OuraDecoders.decodeSleepPeriodInfo(badState))
+        // …and the boundary values that ARE legal still decode, so the guard is not off by one.
+        val edge = OuraRecord(
+            type = 0x6A, ringTimestamp = 1L,
+            payload = intArrayOf(104, 0, 58, 31, 131, 31, 120, 2, 0xff, 0xff),
+        )
+        val ok = OuraDecoders.decodeSleepPeriodInfo(edge)!!
+        assertEquals(120, ok.motionCount)
+        assertEquals(2, ok.sleepState)
+        assertEquals(0.999985, ok.cv, 1e-6)
+    }
+
+    @Test
+    fun testShortBodyDecodesToNull() {
+        val short = OuraRecord(
+            type = 0x6A, ringTimestamp = 1L,
+            payload = intArrayOf(104, 0, 58, 31, 131, 31, 0, 1, 0xd2),
+        )
+        assertNull("9 bytes cannot hold the u16 cv tail", OuraDecoders.decodeSleepPeriodInfo(short))
+    }
+
+    // MARK: - Tier discipline
+
+    /**
+     * 0x6A is Tier B: the field NAMES rest on one decompiled-binary source, and nothing has shown
+     * `breath` tracks a real respiratory rate (#194). So the driver must drop it by default and only
+     * emit it when a caller explicitly asks for Tier B.
+     */
+    @Test
+    fun testTagIsTierBAndGatedInTheDriver() {
+        assertEquals(TrustTier.TIER_B, OuraEventTag.SLEEP_PERIOD_INFO.tier)
+        val rec = record("6a0e9dcca60068f13a1f831f0001d257")
+
+        val gated = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = null)
+        assertTrue("Tier-B 0x6A must not be emitted by default", gated.ingest(rec).isEmpty())
+
+        val allowed = OuraDriver(ringGen = OuraRingGen.GEN3, authKey = null, allowTierB = true)
+        val events = allowed.ingest(rec)
+        assertEquals(1, events.size)
+        val e = events[0] as OuraEvent.SleepPeriodInfo
+        assertEquals(16.375, e.value.breathsPerMin, eps)
+        assertTrue("a consumer asserting a Tier-A-only sink must see this as Tier B", e.isTierB)
+        assertEquals(rec.ringTimestamp, e.envelopeRingTimestamp)
+    }
+}

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -612,7 +612,105 @@ like its sibling banked streams (`.hrv`/`.temp`/`.spo2`/`.sleepPhase`) — the f
 
 ### 6.12 Sleep architecture
 - **`0x4B` / `0x4E` / `0x5A` `sleep_phase_details`** (≥19 B): byte6 = header; phase codes are **2-bit**, 4 per byte (bits `[7:6][5:4][3:2][1:0]`); codes **0=deep, 1=light, 2=rem, 3=awake** per open_oura's VALIDATED `decode_sleep_phases` (events.rs `PHASE = ["deep","light","rem","awake"]`). **CORRECTION:** an earlier revision of this line taught `0=awake, 1=light, 2=deep, 3=REM` from [ringverse] (unverified); live captures contradicted it (records decoded at wake carry code 3 = awake under open_oura's mapping), and both platform decoders inherited the bug from this exact text. [open_oura]
-- **`0x6A` `sleep_period_info`** (14 B): bytes6–9 four int8 metrics; bytes10–11 `uint8/8.0`; byte12 motion-seconds uint8; byte13 sleep-state int8; bytes14–15 `uint16 LE / 65536`. [ringverse]
+- **`0x6A` `sleep_period_info`** (14 B declared length ⇒ a fixed **10-byte body**) — **the ring's own
+  average HR and a breath rate.** Body offsets, names and multipliers per [open_ring]
+  (`decode_sleep_period_info_2` / `parse_api_sleep_period_info`; the four `× …` constants are its
+  `.rodata` block):
+
+  | body byte | field | type | scale | note |
+  |---|---|---|---|---|
+  | 0 | `average_hr` | u8 | **× 0.5** | wire 130 = 65 bpm — **not** a bare bpm byte |
+  | 1 | `hr_trend` | **s8** | × 0.0625 | the only SIGNED field in the body |
+  | 2 | `mzci` | u8 | × 0.0625 | meaning undocumented |
+  | 3 | `dzci` | u8 | × 0.0625 | meaning undocumented |
+  | 4 | **`breath`** | u8 | **/ 8.0** | **breaths per minute** |
+  | 5 | `breath_v` | u8 | / 8.0 | breath variability |
+  | 6 | `motion_count` | u8 | — | source's parser THROWS if ≥ 121 |
+  | 7 | `sleep_state` | u8 | — | source's parser THROWS if ∉ {0,1,2} |
+  | 8–9 | `cv` | u16 LE | / 65536 | ⇒ [0,1) |
+
+  **CORRECTION to this line's previous revision**, which read *"bytes6–9 four int8 metrics; bytes10–11
+  `uint8/8.0`; byte12 motion-seconds; byte13 sleep-state int8; bytes14–15 uint16 LE/65536"* [ringverse]:
+  the OFFSETS were right and the `/8.0` was right, but there were **no names** — so the tag looked like
+  four anonymous metrics rather than a heart rate and a respiration channel — and `average_hr` was typed
+  `int8` with **no `× 0.5`**, which reads every value above 63.5 bpm as a negative number. [ringverse]
+  calls bytes 4/5 `field_a` / `field_b`; neither source NOOP already carried named them.
+
+  **NOOP verification, four consecutive real Gen 3 overnights (2026-08-05 → 08-09, 3 493 records):**
+  every body is exactly 10 bytes; **every** record satisfies both declared invariants (`motion_count <
+  121`; `sleep_state ∈ {0,1,2}`, and only 0 and 1 ever occur); **every** `breath` value is an exact
+  multiple of 0.125 across 78–84 distinct values per night, which confirms the `/8.0` fixed point *from
+  the data* rather than assuming it. Per-night medians: `average_hr` **54.0 / 53.0 / 53.5 / 54.0 bpm**,
+  `breath` **14.75 / 14.375 / 14.625 / 15.0 /min** (IQR ≈ 13.1–15.9), `breath_v` ≈ 4.2–5.0.
+  The `× 0.5` scale is settled by its **falsifier**: read as `× 1.0` the same records sit **+56 … +62
+  bpm** above every other HR channel we hold for the same wearer, and the independently-decoded banked
+  IBI (§6.1, WHOOP-validated at RHR 55 in #511) medians 54 bpm — which `× 0.5` reproduces. ~50 % of
+  records carry an ODD wire byte (0.506 / 0.530 / 0.507 / 0.467), so the half-bpm steps are real
+  resolution, not an artifact. Cadence ≈ **296 s**, and the tag is emitted only during sleep periods
+  (the 4 nights' records span far less wall-clock than their ring-time range).
+
+  ⚠️ **`breath` is the RING's own measurement, not a NOOP-derived estimate — Tier B on decode
+  provenance, stored and shown, and deliberately NOT scored (see the disposition below).** The
+  distinction matters: the #194 rule governs signals NOOP *derives* from raw sensor data (PPG→HR
+  autocorrelation, RSA-from-R-R), where the method can manufacture a plausible number. Here the firmware
+  computes it and NOOP only decodes a field, the same standing on decode provenance as the ring's own
+  SleepNet hypnogram — which NOOP already persists. What must be right is the decode.
+
+  Both decoders **return nil/null when either declared invariant is violated**: the source's own
+  parser throws there, so such a body is not this layout, and "not decoded" is the honest answer. It
+  costs nothing — all 3 493 real records pass. `average_hr` is still **never** folded into a stream: it
+  would join the beat-derived HR series at a different cadence and a different provenance.
+
+  **What the cross-checks say.** The strongest one is not against WHOOP: these records median
+  **14.75/min** against the SAME wearer's **851-night Oura APP export** at median 15.250 (IQR
+  14.875–15.625) — the same quantity in the same band, which is byte 4 checked against Oura's own
+  reported respiratory rate. ⚠️ Distribution, NOT paired: the export ends 2026-07-07 and these records
+  start 2026-08-05, and a paired test is impossible by construction (the ring pairs to ONE app at a
+  time, so while NOOP holds it nothing reaches Oura's cloud). Against a WHOOP worn on the same nights,
+  measured over 18 nights of that wearer's history carrying both vendors, **Oura's own app scores
+  r = +0.680 against WHOOP**, with Oura below
+  WHOOP on 18/18 nights (Δ −1.158, sd 0.359). That is a **ceiling** on any Oura-derived respiratory
+  rate, not a target — and this decode already sits at it: **r = +0.599** over 6 paired nights (**+0.748**
+  over the 4 with good coverage), Δ −1.458 with the sign stable 6/6, of which −1.158 is the measured
+  vendor offset and only **~−0.30** is this decode's own residual. That residual is *implied*, never
+  pairable, because the two references are mutually exclusive per night. The internal falsifier passed:
+  mapping each night to the WRONG date collapses r from +0.591 to **−0.151**, so the agreement is
+  date-aligned rather than coincidental. Within the Oura-app distribution above, our medians sit on the
+  **low side** (~12th pct) — inside the band, not centred in it.
+
+  ⇒ Judging this decode by "does it beat WHOOP" would ask it to beat **Oura's own app** at reproducing
+  WHOOP — the wrong test for a vendor-computed value, and an impossible one. So NOOP maps **`breath`
+  only** onto a `respSample` row under the RING's deviceId (`OuraStreamMapping`, both platforms), in
+  **milli-breaths-per-minute** (`raw == wireByte × 125`, exact for all 256 wire values — the same table
+  otherwise carries a WHOOP's raw respiration ADC waveform, a different quantity, so the row's owner is
+  what distinguishes them, via `OuraRespScale`). It is shown on the day/Deep-Timeline respiration track
+  in breaths/min.
+
+  **Disposition: INSTRUMENTATION — stored and shown, never scored.** The same measurements that make the
+  decode believable also place it AT the vendor ceiling rather than past it, and CLAUDE.md's #194 rule
+  says what to do with a signal in that position: land it beside the incumbent, never as the default and
+  never feeding a downstream gate. Concretely:
+  1. **Nothing writes `dailyMetric.respRateBpm` from these rows.** That is the scored slot — it feeds
+     recovery's respiration term and `IllnessSignalEngine` — so a ring night's value stays whatever the
+     RSA path returns, which on banked R-R is nothing at all. Pinned by
+     `OuraRespScoringExclusionTests` / `OuraRespScoringExclusionTest`, which passes the rows to
+     `analyzeDay` verbatim and asserts the day comes back byte-identical.
+  2. **It never reaches the sleep stager.** `OuraRespScale.forScoring` keeps it out at every scoring
+     read: the stager reads `respSample` as a ~1 Hz raw ADC WAVEFORM and would run a peak detector over a
+     per-window RATE — a shape mismatch, not a trust one, and the same reason 0x47 motion is never folded
+     into `gravitySample` (#804). This refusal is by PROVENANCE, not by cadence: today's ~296 s spacing
+     would starve the peak detector anyway, and that is luck a decoder change could revoke.
+  3. **What it would take to score it.** Its own evidence and its own review — and a decision about the
+     baseline it would enter, which is one day-keyed series shared across sources: a WHOOP export reports
+     its own measured rate (~16.1 on the reference history) against the ring's ~14.6, so a strap SWITCH
+     would read as a ~3σ illness-ward step against a ~0.52 bpm spread. `Baselines.deviceEraEpoch` (#459)
+     is the primitive for that and is still unwired for every baseline.
+
+  📌 **This does not retract the respiratory-rate gate.** That work proved RSA is unrecoverable *from
+  banked IBI* (shuffling the beats returns the same value; re-timing defeats the gate) and refusing to
+  publish a fabricated number is right regardless. What it corrects is that finding's *second* clause —
+  "the app must use a channel we never receive". We do receive one; we had simply never decoded the tag.
+  0x6A changes what may eventually sit behind the gate, not whether the gate belongs there.
 - **`0x72` `sleep_acm_period`** (16 B): values0–2 = `whole(8)+frac(8)/255`; values3–5 = `whole(4)+frac(12)/4095`. [ringverse]
 - **`0x49` `sleep_summary_1`**: `start_offset_min` / `end_offset_min`, both uint16 LE **minutes
   before the event time** — the ring's tracked sleep window is
@@ -1033,7 +1131,7 @@ Tags that appear in the banked stream but NOOP does not decode. Payloads are the
 | `0x61` | 28760 | 3–14 | `1a18009c3700007c150000cb` | **SOLVED as a channel, see §9.1** — a subtype-multiplexed firmware DIAGNOSTIC stream, not one message and not a physiological signal. **NOT battery** — the `[open_oura-act]`-adjacent "`0x61` battery" label does not match here (non-percent, high-frequency) |
 | `0x4a` | 8416 | 10 | `00000000000000000000` | payload observed all-zero — likely a keepalive / placeholder |
 | `0x72` | 5723 | 12 | `120027000100150018000200` | six int16-LE small values — a vector (motion / accel?) |
-| `0x6a` | 5689 | 10 | `7e00230b90140001f8b0` | mixed; a `0001f8b0` / `0001feb8` trailer recurs |
+| `0x6a` | 5689 | 10 | `7e00230b90140001f8b0` | **SOLVED, see §6.12** — `sleep_period_info`: the example decodes to `average_hr` 63.0 bpm, `breath` 18.0/min, `motion_count` 0, `sleep_state` 1, `cv` 0.691. The "recurring `0001f8b0` / `0001feb8` trailer" noted here was never a trailer: it is `motion_count`=0, `sleep_state`=1 and the 2-byte `cv`, and it recurs because a still sleeper produces those three over and over |
 | `0x6d` | 3042 | 13 | `00c4ffffb5ffffd2ffffeaffff` | **`measurement_quality`** (24-bit signed) per [ring4-ble] — supersedes the earlier gravity/accel guess; our capture reads `00` + int16-LE-looking negatives |
 | `0x6c` | 1750 | 4 | `02020400` | `02 NN 04 00` — small state / counter |
 | `0x5b` | 416 | 10–13 | `030093dd10dbc7c00000` | variable, leading sub-type byte |


### PR DESCRIPTION
## What this is

NOOP receives tag `0x6A` and drops it as unknown. It carries the ring's own per-window sleep summary —
an average heart rate and **a breath rate**. This decodes it on both platforms and persists **one field
of it**, `breath`, as a `respSample` row under the **ring's** deviceId, shown on the respiration track.
It is **instrumentation**: stored and shown beside the incumbent, and **nothing scores from it**.

Until now `respSample` had **zero rows on every Oura night**, so no screen could show the ring's own
respiratory rate at all. `dailyMetric.respRateBpm` — the scored slot — is left exactly as it was.

## Part 1 — the decode

`docs/OURA_PROTOCOL.md` §6.12 already carried the right **offsets** and the right `/8.0` from
[ringverse] — but **no field names**, so the tag read as "four int8 metrics" rather than a heart rate
and a respiration channel. It also typed `average_hr` as `int8` with no `× 0.5`, which reads every value
above 63.5 bpm as a negative number. [ringverse] calls bytes 4/5 `field_a` / `field_b`.

[open_ring]'s `decode_sleep_period_info_2` (`parse_api_sleep_period_info`) supplies the names and the
`.rodata` multipliers. Clean-room fact citation per `CLAUDE.md` — **no code copied**, the layout
re-derived and then checked against our own captures:

| body byte | field | type | scale | note |
|---|---|---|---|---|
| 0 | `average_hr` | u8 | **× 0.5** | wire 130 = 65 bpm |
| 1 | `hr_trend` | **s8** | × 0.0625 | the only signed field |
| 2 | `mzci` | u8 | × 0.0625 | meaning undocumented |
| 3 | `dzci` | u8 | × 0.0625 | meaning undocumented |
| 4 | **`breath`** | u8 | **/ 8.0** | breaths per minute |
| 5 | `breath_v` | u8 | / 8.0 | breath variability |
| 6 | `motion_count` | u8 | — | source's parser throws if ≥ 121 |
| 7 | `sleep_state` | u8 | — | source's parser throws if ∉ {0,1,2} |
| 8–9 | `cv` | u16 LE | / 65536 | ⇒ [0,1) |

`mzci` / `dzci` keep the source's opaque names on purpose: we do not know what they measure, and a
friendlier name would assert an interpretation the evidence does not support.

### Verification — four consecutive real Gen 3 overnights, 3,493 records

2026-08-05 → 08-09, decoded from the `oura-raw.jsonl` diagnostic sidecars:

| night | n | `average_hr` med | `breath` med | invariants | `breath` ≡ 0 (mod 0.125) |
|---|---|---|---|---|---|
| 08-05→06 | 879 | 54.0 | 14.750 | all pass | yes (78 distinct) |
| 08-06→07 | 1,218 | 53.0 | 14.375 | all pass | yes (84 distinct) |
| 08-07→08 | 1,321 | 53.5 | 14.625 | all pass | yes (79 distinct) |
| 08-08→09 | 75 | 54.0 | 15.000 | all pass | yes (36 distinct) |

- Every body is exactly **10 bytes**; `motion_count < 121` and `sleep_state ∈ {0,1}` hold on **all
  3,493** records. A wrong layout would violate these on a corpus this size.
- **Every `breath` value is an exact multiple of 0.125**, across 78–84 distinct values per night — the
  `/8.0` fixed point confirmed *from the data*, not assumed.
- **The `× 0.5` scale is settled by its falsifier:** read as `× 1.0` these records sit **+56 … +62 bpm**
  above every other HR channel we hold for this wearer. Read as `× 0.5` they median 53–54 bpm, matching
  the independently-decoded banked-IBI channel's 54 (#511, itself WHOOP-validated against RHR 55).
  Independently, **~50 % of records carry an odd wire byte**, so the half-bpm steps are real resolution
  — `× 1.0` would have to explain why half the values are unreachable.
- Cadence ≈ **296 s**, and the tag fires **only during sleep periods**.
- **Both decoders reject a body that breaks the declared invariants** (`nil` / `null`, never a guess):
  the source's own parser throws there, so such a body is not this layout, and "not decoded" is the
  honest answer. It costs nothing on real data — all 3,493 pass.

## Part 2 — why `breath` is worth storing

**`breath` is computed by the ring and read off the wire — NOOP derives nothing.** The #194 rule is
written for the opposite case (PPG→HR autocorrelation, RSA-from-R-R: methods where NOOP invents the
number and can manufacture a peak that looks physiological). Here the only thing NOOP does is decode a
field, so what has to be right is the **decode** — which is what Part 1 establishes. On decode
provenance that is the same standing as the ring's own SleepNet hypnogram, which NOOP already
persists (#773 / #877).

**The strongest cross-check is not against WHOOP.** These records median **14.75/min** against the SAME
wearer's **851-night Oura app export** at median 15.250 (IQR 14.875–15.625) — byte 4 checked against
Oura's *own* reported respiratory rate: same quantity, same band, our medians on the low side (~12th
pct). ⚠️ **Distribution, NOT paired** — the export ends 2026-07-07 and these records start 2026-08-05,
and a paired test is impossible by construction: **the ring pairs to one app at a time**, so while NOOP
holds it nothing reaches Oura's cloud.

**Against a WHOOP worn the same nights, the decode reproduces the *vendor's* offset:**

| comparison | n | r | Δ (bpm) | sign stability |
|---|---:|---:|---:|---|
| **Oura's own app vs WHOOP** | 18 | **+0.680** | −1.158 (sd 0.359) | Oura below WHOOP **18/18** |
| **our `0x6A` vs WHOOP** | 6 | **+0.599** | −1.458 | same sign **6/6** |
| our `0x6A`, well-covered nights | 4 | **+0.748** | — | — |
| ⚑ falsifier: WRONG date mapping | 4 | **−0.151** | — | — |

The bias decomposes as **−1.158 vendor + ~−0.30 ours**: ~80 % of the gap to WHOOP is Oura being Oura.
The date falsifier passed — mapping each night to the wrong date collapses r from +0.591 to **−0.151**,
so the agreement is date-aligned rather than two series drifting past each other.

⇒ Judging this decode by *"does it beat WHOOP"* would ask it to beat **Oura's own app** at reproducing
WHOOP: the wrong test for a vendor-computed value, and an impossible one.

## What the value is wired to — and what it deliberately is not

### Why it is NOT scored

The very table above is the argument. Our `r = +0.599` is not a *weak* result on the way to a strong
one: **`+0.680` is the ceiling**, because that is what **Oura's own app** scores against WHOOP, and the
ring pairs to one app at a time, so a paired same-night Oura-app comparison is impossible *by
construction* rather than merely undone. A channel sitting at its vendor ceiling with no path to more
evidence is exactly the case CLAUDE.md's #194 rule addresses: *land it as instrumentation … never make
it the default and never feed it a downstream gate.*

⇒ **`dailyMetric.respRateBpm` is untouched.** It is the scored slot — it carries recovery's respiration
term and `IllnessSignalEngine` reads it with `illnessUp: true` — so on a ring night it stays whatever
the RSA path returns, which on banked R-R is nothing at all. An earlier draft of this branch *did* write
it (with a span gate, a plausible-band gate, and an era-scoped baseline); that write is **removed**, and
what remains is the row, the display, and two refusals enforced at the read rather than by convention:

- **Kept out of the sleep stager — a SHAPE refusal, not a trust one.** `respSample` otherwise carries a
  WHOOP 4.0's raw respiration ADC **waveform**, which the stager runs a peak detector over; the ring's
  rows are a per-window **rate**, so feeding them in is wrong *however good the rate is* — the same
  reason 0x47 motion is never folded into `gravitySample` (#804). `OuraRespScale.forScoring` drops them
  at **every** scoring read (nightly scan, re-stage/self-heal, offline `SleepBench`). Today's ~296 s
  cadence would have yielded NaN anyway; the tests pin that staging is **bit-identical** with and
  without the rows, **plus a control** proving a dense 1 Hz stream *does* move staging, so the
  invariance is not vacuous. Provenance is what keeps it true if the cadence ever changes.
- **Kept out of the daily metric.** `analyzeDay` has no parameter these rows can arrive through. The pin
  passes them in verbatim as `resp` — the worst case, a caller who forgot `forScoring` — and asserts the
  day comes back **byte-identical** to the day with no rows at all, and that the night's `respRateBpm`
  is never the rows' median.

**What scoring it would take, if a reviewer wants to argue for it.** Its own evidence, and a decision
about the baseline this change deliberately leaves alone: `respRateBpm`'s 28-day baseline is a **single
day-keyed series shared across sources**, so a WHOOP-import day at ~16.1 beside a ring night at ~14.6
would be a **~3σ illness-ward step** against a ~0.52 bpm spread — a strap switch read as physiology.
`Baselines.deviceEraEpoch` (#459) is the primitive for exactly that; it was implemented, unit-tested and
**never wired to anything**, and this PR leaves it that way rather than wiring it for one metric on the
side.

### What it IS wired to

- **Stored.** `breath` → `respSample.raw` in **milli-breaths-per-minute**. The wire field is a `u8 / 8`,
  so `raw == wireByte × 125` **exactly** for all 256 values — no rounding, so no rounding rule for the
  two platforms to disagree about. (Centi lands on `x.5` for half the alphabet; whole bpm would erase
  the ~0.30 bpm the entire question is about.)
- **Shown.** The day / Deep-Timeline respiration track scales a ring's rows back to breaths/min (~14–16,
  not ~14,375). `OuraRespScale` is the single place both the display conversion and the scoring refusal
  live, because `DeviceFamily` has no Oura case by design (#1086) and cannot carry the distinction.

Still refused, deliberately: **`average_hr`** from the same record (it would join the beat-derived HR
series at a different cadence and a different provenance), and `breath_v` / `mzci` / `dzci` / `cv` /
`sleep_state`, which stay in the investigation log beside the stored row. **RSA-from-banked-R-R stays
refused** separately — and *that* one is a #194 failure in the proper sense: NOOP computes it, and
shuffling or reversing the night's R-R returns the same 13.3333 bpm.

### This does not retract the respiratory-rate gate

That work proved RSA is unrecoverable *from banked IBI* (shuffling the beats returns the same value) and
refusing to publish a fabricated number is right regardless. What `0x6A` corrects is that finding's
**second clause** — "the app must use a channel we never receive". We do receive one; we had simply
never decoded the tag.

### What the incumbent actually is — #1367 is the frame, not a contradiction

Worth stating plainly, because it is easy to read this change as putting a decoded vendor number beside
a strap-**measured** one. It is not.

**#1367** (`b894a391`, in this PR's base) settled that the respiratory rate NOOP displays for WHOOP is
an **on-device estimate on BOTH generations**: the shown value is always `SleepStager.respRateFromRR`,
an RSA estimate off the R-R stream, with no family branch. 5.0/MG's v18 wire carries no respiratory
channel at all, and 4.0's v24 `resp_rate_raw` ADC is stored unconverted and never shown. That is also
why an over-counted-R-R 4.0 night (#1331) blanks it.

Two consequences for reading this PR:

- **Both sides of the comparison are estimates.** `0x6A` is in fact the first respiratory rate NOOP has
  decoded that the **device** computed rather than the app.
- **That is not an argument for scoring it, and this PR does not make it.** The rows stay out of the
  scored slot because of the measurement — `r = +0.680` is what Oura's OWN app scores against WHOOP, so
  no Oura-derived rate can beat it, and the one-app-at-a-time pairing makes a same-night Oura-app
  comparison impossible by construction rather than merely undone. AT the vendor ceiling is exactly
  where #194 says instrumentation belongs.

⚠️ One framing from the earlier respiration work should **not** be carried forward: NOOP's WHOOP
respiratory number was never the "read off the strap" reference a decoded ring value had to justify
itself against. Neither number is read off a strap.

## Also in this PR

- §6.12 rewritten: the layout table, the `× 0.5` correction called out **as a correction**, the
  four-night verification, the vendor-ceiling measurement, and the instrumentation disposition.
- §9's observed-but-undecoded census row for `0x6a` marked **SOLVED**. Its old note about a "recurring
  `0001f8b0` / `0001feb8` trailer" was never a trailer: that is `motion_count`=0, `sleep_state`=1 and the
  2-byte `cv`, recurring because a still sleeper produces those three over and over.

## Verification performed

- **7 real-record decode fixtures per platform**, byte-for-byte the same hex on both (typical record;
  half-bpm resolution on an odd wire byte; signed `hr_trend`; a restless record; both invariant
  rejections plus the legal boundary values; a short body; Tier-B driver gating on and off).
- New twinned suites for the persist half: mapping (`breath` → one row, exact milli-bpm, its own ts, and
  nothing else from the record), every one of the 256 wire values round-tripping exactly, the scale/brand
  seam, and the staging-invariance pair (with its control).
- New twinned scoring-exclusion suite (`OuraRespScoringExclusionTests` / `…Test`, 4 tests each): the
  stager refusal, the staging invariance, the dense-stream **control** that keeps the invariance from
  being vacuous, and the `analyzeDay` pin — a ring night's rows passed in verbatim, day byte-identical.
- Swift: **WhoopStore 392/0**, **StrandAnalytics 1387/0**, **OuraProtocol 202/0**, **SleepBench 13/0**
  (counts as of the `211557b4` rebase — see below for the `eebc7327` re-verification).
- Android: **3911/0** (`testFullDebugUnitTest`, 5 skipped).
- macOS `Strand` built **and** `StrandTests` **1146/0** (1 skipped); iOS `NOOPiOS` built —
  `app-build.yml` is disabled and this touches `Strand/BLE/OuraLiveSource.swift`.
- ↑ All re-run **2026-08-16 on the `211557b4` rebase**, so these are the counts for the commit as it
  now stands, not the pre-rebase ones (which were WhoopStore 390, StrandAnalytics 1365, OuraProtocol
  191, Android 3860, StrandTests 1120 — the deltas are upstream's own new tests, not this branch's).
- **Re-verified after the `eebc7327` rebase (2026-08-16, same day):** `OuraProtocol` **202/0**,
  `StrandAnalytics` **1387/0** (both unchanged from the `211557b4` numbers — the branch's one commit
  applied clean, no adjacent-file conflict), macOS `Strand` app target **BUILD SUCCEEDED**.
  `WhoopStoreTests` could not be run at this base — see the CI-red note above; that failure is in
  `SleepSessionDedupTests.swift` (added by #1382, unrelated to `respSample`/`OuraRespScale`) and
  reproduces identically on a clean `main` with no branch changes at all.
- **No new user-facing strings**, so no i18n work on either platform.
- ✅ **HARDWARE-VALIDATED — one overnight, 2026-08-15/16, iPhone + Gen 3 ring.** No new outbound command
  and no change to the connection path; the live arm anchors and enqueues `0x6A` like its banked
  siblings (`.hrv` / `.temp` / `.spo2`) and, on Apple, advances the drain resume cursor with them. The
  drain produced **219 `respSample` rows** under `oura-2H3B2405003655`, 08-15 14:54:33 → 08-16 06:16:57
  local. Cross-checked against the diagnostics sidecar the same build wrote:

  | check | result |
  |---|---|
  | rows matching a sidecar record on **both** ts and value | **219 / 219** |
  | sidecar records inside the span with no stored row | **0** (nothing lost, nothing invented) |
  | stored `raw` an exact multiple of 125 | **219 / 219** |
  | DB median vs sidecar median over the span | **14.375 = 14.375 bpm** |
  | anchor spread (`utc − ringTs/10`) across the night | **3.8 s** |
  | rows inside the persisted sleep session | **157**, span 4.87 h, median **14.875** |
  | `dailyMetric.respRateBpm` for the ring night | **NULL** — which is the point |

  (That session is the known short block — 368 min laid backward from an end that chases wall-clock —
  so the in-session subset is truncated and its median is quoted only to show the arithmetic, not as
  the night's respiratory rate. The persist checks above do not depend on it.)

  So the ~5-min windows land where they were **measured**, not at drain-arrival, and the persist is a
  lossless copy of what the ring sent. The log line is kept as well as the row.

## Reviewer notes

- **Two quantities now share `respSample`.** There is no unit column on either platform, so the durable
  discriminator is the deviceId. The alternative — an `OURA_RESP` event row, matching how the ring's
  0x47 motion is instrumented — was considered and not taken: `respSample` is where a respiration
  reading belongs, and the display/scoring seam is one small file either way. If you prefer the event
  table, this is the design decision to argue about.
- `Streams.resp` gains a protocol carrier on Android (`com.noop.protocol.RespSample`) to mirror Swift's
  shape; `StreamPersistence` widens it onto the existing Room `RespRow` insert, which already existed.
- **`Baselines.deviceEraEpoch` still has no production caller.** #459 built and unit-tested the
  primitive on both platforms and nothing ever called it. An earlier draft of this branch wired it for
  the respiration fold, as cover for scoring `breath`; with the scored write removed that wiring had
  nothing to protect and was dropped rather than landed as a silent side-change. Wiring it — for HRV and
  resting HR too, which is what #459 was actually written for — is worth its own PR.
- **Known gap, stated plainly:** an HR cross-check against the 0x5D-vs-0x60 reconstruction used to
  validate #1167 was attempted and is **inconclusive** — a fresh re-implementation of that reference
  scored 0x5D itself at +0.107/+0.238/+0.312 against the published +0.970/+0.959/+0.894, so the
  reference is not the published one and nothing measured against it means anything yet. Only the
  scale-level result survives (mean error +0.05/+0.11/+0.08 bpm, MAE ≈ 4). Reconciling the two
  reconstructions is worth doing separately; **no tracking correlation against that reconstruction is
  claimed anywhere in this PR.**