### PR TITLE
docs(oura): correct 0x6A comments that still claim breath feeds respRateBpm (#1384 follow-up)

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/EventTags.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/EventTags.swift
@@ -94,7 +94,9 @@ public enum OuraEventTag: UInt8, Sendable, CaseIterable, Codable {
              // ([open_ring]); NOOP's own captures confirm the layout's declared invariants and the
              // fixed-point scales. Tier B on DECODE PROVENANCE — third-party names, not Oura
              // documentation — not on doubt that the ring measures respiration: `breath` is the ring's
-             // own value read off the wire, and it feeds respRateBpm (see OuraSleepPeriodInfo).
+             // own value read off the wire. It is INSTRUMENTATION — stored as a `respSample` row and shown
+             // on the respiration track, but NOT scored: `dailyMetric.respRateBpm` is untouched (see
+             // OuraSleepPeriodInfo).
              .sleepPeriodInfo,
              // #287: 0x71 green_ibi_and_amp is NOT corpus-verified — there is no captured 0x71 fixture,
              // and OURA_PROTOCOL.md §6.2 documents a DIFFERENT layout (5 IBI deltas + 6 amplitudes,

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
@@ -444,11 +444,11 @@ public final class OuraDriver {
             // third-party layout ([open_ring]) whose field NAMES are what our own §6.12 was missing, and
             // whose declared invariants our captures uphold. Still Tier B - only reached behind
             // allowTierB (gated above). ONE field of it is durable: OuraStreamMapping maps `breathsPerMin`
-            // to a respSample row under the ring's OWN deviceId, and on a ring night AnalyticsEngine takes
-            // the night's median of those rows as dailyMetric.respRateBpm (the ring measures it; NOOP does
-            // not derive it). It is still refused at the STAGING read by provenance
-            // (`OuraRespScale.forScoring`) - that path reads the stream as a ~1 Hz raw ADC waveform and a
-            // per-window rate is the wrong shape for a peak detector. `averageHrBpm` and every other field
+            // to a respSample row under the ring's OWN deviceId, shown on the respiration track. It is NOT
+            // scored: `dailyMetric.respRateBpm` is untouched (it stays the RSA estimate), and
+            // `OuraRespScale.forScoring` refuses the ring's rows at EVERY scoring read — staging included,
+            // because that path reads the stream as a ~1 Hz raw ADC waveform and a per-window rate is the
+            // wrong shape for a peak detector. `averageHrBpm` and every other field
             // stay diagnostic-only - in particular the HR must not join the beat-derived series at a
             // different cadence.
             guard let info = OuraDecoders.decodeSleepPeriodInfo(record) else { return [] }

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
@@ -450,8 +450,9 @@ public enum OuraEvent: Equatable, Sendable {
     /// `OuraSleepPeriodInfo` doc) - split out of the raw-bytes `.tierB` wrapper for the same reason
     /// `.activityInfo` was: a cited third-party layout worth surfacing as real numbers instead of hex.
     /// Same gate (`allowTierB`); its `breathsPerMin` — alone among the record's fields — is mapped to a
-    /// durable `respSample` row and, on a ring night, supplies `dailyMetric.respRateBpm` (see the type
-    /// doc). Every other field of the record stays diagnostic-only.
+    /// durable `respSample` row and shown on the respiration track. It is NOT scored: `dailyMetric.respRateBpm`
+    /// is untouched, and `OuraRespScale.forScoring` refuses the ring's rows at every scoring read (see the
+    /// type doc). Every other field of the record stays diagnostic-only.
     case sleepPeriodInfo(OuraSleepPeriodInfo)
 
     /// True for Tier-B events, so a consumer can assert none leaked into a Tier-A-only sink.

--- a/android/app/src/main/java/com/noop/oura/EventTags.kt
+++ b/android/app/src/main/java/com/noop/oura/EventTags.kt
@@ -101,7 +101,9 @@ enum class OuraEventTag(val raw: Int) {
             // ([open_ring]); NOOP's own captures confirm the layout's declared invariants and the
             // fixed-point scales. Tier B on DECODE PROVENANCE - third-party names, not Oura
             // documentation - not on doubt that the ring measures respiration: `breath` is the ring's
-            // own value read off the wire, and it feeds respRateBpm (see OuraSleepPeriodInfo).
+            // own value read off the wire. It is INSTRUMENTATION - stored as a `respSample` row and shown
+            // on the respiration track, but NOT scored: `dailyMetric.respRateBpm` is untouched (see
+            // OuraSleepPeriodInfo).
             SLEEP_PERIOD_INFO,
             // #287: 0x71 green_ibi_and_amp is NOT corpus-verified — no captured 0x71 fixture, and
             // OURA_PROTOCOL.md §6.2 documents a DIFFERENT layout (5 IBI deltas + 6 amplitudes, shift

--- a/android/app/src/main/java/com/noop/oura/OuraDriver.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraDriver.kt
@@ -523,11 +523,11 @@ class OuraDriver(
                 // third-party layout ([open_ring]) whose field NAMES are what our own s6.12 was missing,
                 // and whose declared invariants our captures uphold. Still Tier B - only reached behind
                 // allowTierB (gated above). ONE field of it is durable: OuraStreamMapping maps
-                // `breathsPerMin` to a respSample row under the ring's OWN deviceId, and on a ring night
-                // AnalyticsEngine takes the night's median of those rows as dailyMetric.respRateBpm (the
-                // ring measures it; NOOP does not derive it). It is still refused at the STAGING read by
-                // provenance (OuraRespScale.forScoring) - that path reads the stream as a ~1 Hz raw ADC
-                // waveform and a per-window rate is the wrong shape for a peak detector. `averageHrBpm`
+                // `breathsPerMin` to a respSample row under the ring's OWN deviceId, shown on the
+                // respiration track. It is NOT scored: dailyMetric.respRateBpm is untouched (it stays the
+                // RSA estimate), and OuraRespScale.forScoring refuses the ring's rows at EVERY scoring read
+                // - staging included, because that path reads the stream as a ~1 Hz raw ADC waveform and a
+                // per-window rate is the wrong shape for a peak detector. `averageHrBpm`
                 // and every other field stay diagnostic-only - in particular the HR must not join the
                 // beat-derived series at a different cadence.
                 val info = OuraDecoders.decodeSleepPeriodInfo(record) ?: return emptyList()

--- a/android/app/src/main/java/com/noop/oura/OuraEvents.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraEvents.kt
@@ -434,8 +434,9 @@ sealed class OuraEvent {
      * (see [OuraSleepPeriodInfo] doc) - split out of the raw-bytes [TierB] wrapper for the same reason
      * [ActivityInfo] was: a cited third-party layout worth surfacing as real numbers instead of hex.
      * Same gate (`allowTierB`); its `breathsPerMin` - alone among the record's fields - is mapped to a
-     * durable `respSample` row and, on a ring night, supplies `dailyMetric.respRateBpm` (see the type
-     * doc). Every other field of the record stays diagnostic-only.
+     * durable `respSample` row and shown on the respiration track. It is NOT scored: `dailyMetric.respRateBpm`
+     * is untouched, and `OuraRespScale.forScoring` refuses the ring's rows at every scoring read (see the
+     * type doc). Every other field of the record stays diagnostic-only.
      */
     data class SleepPeriodInfo(val value: OuraSleepPeriodInfo) : OuraEvent()
 


### PR DESCRIPTION
Follow-up to #1384. That PR made Oura `0x6A` `breath` **pure instrumentation** — a `respSample` row, shown on the respiration track, refused at every scoring read by `OuraRespScale.forScoring`, with `dailyMetric.respRateBpm` left untouched. But **six comments**, carried over from an earlier draft that *did* write the scored slot, still claimed `breath` **feeds / supplies / becomes** `respRateBpm`:

- `EventTags.swift` / `EventTags.kt` — "…and it feeds respRateBpm"
- `OuraEvents.swift` / `OuraEvents.kt` — "…supplies `dailyMetric.respRateBpm`"
- `OuraDriver.swift` / `OuraDriver.kt` — "AnalyticsEngine takes the night's median of those rows as `dailyMetric.respRateBpm`"

These sit in the decoder/driver/event files a maintainer reads first, and contradict the **correct** `OuraSleepPeriodInfo` type-doc in the very same files ("nothing writes `dailyMetric.respRateBpm`"). Believing the stale version could justify "reconciling" the `forScoring` exclusion away and reintroducing the exact scored write #1384 removed — so this is worth correcting even though it's comments only.

All six now state the instrumentation disposition: **stored + shown, NOT scored, `respRateBpm` untouched, refused at every scoring read.** Consistent across the Swift/Kotlin twins.

**Comments only — no code or behaviour change.** Kotlin compiles, `doc_comment_lint.py` clean. (Surfaced by an independent review of #1384; @pipiche38's code was correct — only these leftover comments lagged.)