### PR TITLE
fix(altstore): declare healthkit.access, location, and motion permissions

### DIFF
--- a/altstore-source.json
+++ b/altstore-source.json
@@ -1364,12 +1364,15 @@
       "appPermissions": {
         "entitlements": [
           "com.apple.developer.healthkit",
+          "com.apple.developer.healthkit.access",
           "com.apple.security.application-groups"
         ],
         "privacy": {
           "NSBluetoothAlwaysUsageDescription": "NOOP connects directly to your WHOOP strap over Bluetooth to read heart rate, R-R intervals, battery, and sensor data locally on your iPhone. Nothing leaves your device.",
           "NSHealthShareUsageDescription": "NOOP reads your own Apple Health data on-device to compute recovery, strain, and sleep. Nothing leaves your device.",
-          "NSHealthUpdateUsageDescription": "NOOP writes the metrics it computes from your strap back into Apple Health, on-device and only when you allow it."
+          "NSHealthUpdateUsageDescription": "NOOP writes the metrics it computes from your strap back into Apple Health, on-device and only when you allow it.",
+          "NSLocationWhenInUseUsageDescription": "NOOP records your route during an outdoor workout to show distance, pace, and a map, and keeps recording while the screen is off. The route stays on your device. Nothing leaves it.",
+          "NSMotionUsageDescription": "NOOP reads your iPhone's step count for a walking or running workout to show steps in the activity summary. It stays on your device. Nothing leaves it."
         }
       },
       "version": "10.1.0",


### PR DESCRIPTION
## What this PR does

`altstore-source.json` under-declares the iOS app's permissions, so AltStore refuses to
install NOOP from the source with **"Undeclared Permissions"**.

AltStore validates the IPA's actual entitlements and `Info.plist` usage strings against
`appPermissions` and blocks the install on any mismatch. The manifest was missing three
entries that the shipped `v10.1.0` build contains:

- `com.apple.developer.healthkit.access` (entitlement)
- `NSLocationWhenInUseUsageDescription`
- `NSMotionUsageDescription`

This adds those three. The two usage strings are copied verbatim from the `NOOPiOS`
target in `project.yml`, so what AltStore shows matches what iOS shows at the prompt.

No app behaviour changes — this is manifest metadata only.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

Not on the BLE path — no protocol, analytics, or UI code is touched.

- Reproduced the failure: adding the published source to AltStore and installing NOOP
  fails with "Undeclared Permissions", listing exactly the three entries above.
- Cross-checked every entry in `appPermissions` against the `NOOPiOS` target's
  `entitlements` and `info.properties` blocks in `project.yml`; the two lists now match.
- Validated the file parses as JSON and that the diff is confined to the
  `appPermissions` block (3 added lines).

## Checklist

- [x] Swift package tests pass for any package I touched (n/a — no package changes)
- [x] Android unit tests pass if I touched `android/` (n/a — no `android/` changes)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing (n/a)
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders (n/a)
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

<!-- Closes #N -->

---

Note: the same drift can recur whenever a target gains an entitlement or usage string.
Happy to follow up with a CI check that diffs `project.yml`'s `NOOPiOS` permissions
against `altstore-source.json` if that'd be useful.
