### PR TITLE
feat(today): add VO₂max as an opt-in dashboard card (#1391)

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -51,6 +51,7 @@ struct LiquidTodayView: View {
     @State private var heroProviderByMetric: [String: ScoreInputProvider] = [:]
     @State private var stress: Double?             // StressModel(...).score, 0–3
     @State private var fitnessAge: Double?         // exploreSeries("fitness_age").last
+    @State private var vo2max: Double?             // exploreSeries("vo2max_est").last (#1391)
     @State private var vitality: Double?           // exploreSeries("vitality").last
     @State private var stepsEst: Double?           // steps_est, day-keyed to the selected day (fallback)
     @State private var importedStepsDay: Int?      // Apple Health steps for the selected day (middle tier)
@@ -839,6 +840,9 @@ struct LiquidTodayView: View {
         case .fitnessAge:
             cardLink(.metric("fitness_age"), title: card.title, sub: card.subtitle,
                      value: unitText(fitnessAge, card.unit), tint: StrandPalette.chargeColor, frac: 0.5)
+        case .vo2max:
+            cardLink(.metric("vo2max_est"), title: card.title, sub: card.subtitle,
+                     value: unitText(vo2max, card.unit), tint: StrandPalette.chargeColor, frac: 0.5)
         case .vitality:
             cardLink(.metric("vitality"), title: card.title, sub: card.subtitle,
                      value: intText(vitality), tint: liquidPurple, frac: frac(vitality))
@@ -1358,6 +1362,7 @@ struct LiquidTodayView: View {
         async let restA = repo.exploreSeries(key: "sleep_performance", source: "my-whoop")
         async let stressA = repo.series(key: "stress", source: "my-whoop")
         async let fitA = repo.exploreSeries(key: "fitness_age", source: "my-whoop")
+        async let vo2A = repo.exploreSeries(key: "vo2max_est", source: "my-whoop")
         async let vitA = repo.exploreSeries(key: "vitality", source: "my-whoop")
         async let stepsA = repo.exploreSeries(key: "steps_est", source: "my-whoop")
         async let appleA = repo.appleDailyRows()
@@ -1434,6 +1439,7 @@ struct LiquidTodayView: View {
             StressModel(days: daysSnapshot, stored: storedStress)?.score
         }.value
         fitnessAge = (await fitA).last?.value   // history-wide latest banked (not day-scoped)
+        vo2max = (await vo2A).last?.value        // #1391: latest banked VO₂max estimate
         vitality = (await vitA).last?.value
         // Steps is a DAILY metric, so key it to the SELECTED day (like restScore above), not the history-wide
         // latest. Without this, swiping to a past day with no strap step count showed today's estimate (the

--- a/Strand/Screens/DashboardCards.swift
+++ b/Strand/Screens/DashboardCards.swift
@@ -24,6 +24,7 @@ enum DashboardCard: String, CaseIterable, Identifiable {
     case steps
     case stress
     case fitnessAge
+    case vo2max
     case vitality
     case bloodOxygen
     case skinTemp
@@ -49,6 +50,7 @@ enum DashboardCard: String, CaseIterable, Identifiable {
         case .steps:       return String(localized: "Steps")
         case .stress:      return String(localized: "Stress")
         case .fitnessAge:  return String(localized: "Fitness Age")
+        case .vo2max:      return String(localized: "VO₂ Max")
         case .vitality:    return String(localized: "Vitality")
         case .bloodOxygen: return String(localized: "Blood Oxygen")
         case .skinTemp:    return String(localized: "Skin Temp")
@@ -69,6 +71,7 @@ enum DashboardCard: String, CaseIterable, Identifiable {
         case .steps:       return String(localized: "Today")
         case .stress:      return String(localized: "Autonomic load")
         case .fitnessAge:  return String(localized: "Updated weekly")
+        case .vo2max:      return String(localized: "Estimated, updated weekly")
         case .vitality:    return String(localized: "Wellness score")
         case .bloodOxygen: return String(localized: "Blood oxygen")
         case .skinTemp:    return String(localized: "Skin temperature")
@@ -88,6 +91,7 @@ enum DashboardCard: String, CaseIterable, Identifiable {
         case .steps:       return "figure.walk"
         case .stress:      return "bolt.heart"
         case .fitnessAge:  return "figure.run"
+        case .vo2max:      return "lungs"
         case .vitality:    return "sparkles"
         case .bloodOxygen: return "drop.fill"
         case .skinTemp:    return "thermometer.medium"
@@ -107,6 +111,7 @@ enum DashboardCard: String, CaseIterable, Identifiable {
         case .steps:       return ""
         case .stress:      return ""
         case .fitnessAge:  return "yrs"
+        case .vo2max:      return ""    // the estimated VO₂max number alone; ml/kg/min is too long for a tile
         case .vitality:    return ""
         case .bloodOxygen: return ""    // value carries the % itself
         case .skinTemp:    return ""    // value carries the ° itself

--- a/Strand/Screens/TodayCustomizationMetadata.swift
+++ b/Strand/Screens/TodayCustomizationMetadata.swift
@@ -69,6 +69,7 @@ extension DashboardCard {
         switch self {
         case .stress, .respiratory: return StrandPalette.accent
         case .fitnessAge: return StrandPalette.chargeColor
+        case .vo2max: return StrandPalette.chargeColor
         case .vitality, .hrv: return StrandPalette.metricPurple
         case .restingHr: return StrandPalette.metricRose
         case .steps, .bloodOxygen, .hydration: return StrandPalette.metricCyan

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -277,6 +277,7 @@ struct TodayView: View {
     // on Today so the buried Explore features sit on the home screen. Loaded in loadAll; nil hides the row.
     @State private var stressToday: Double?
     @State private var fitnessAgeToday: Double?
+    @State private var vo2maxToday: Double?   // #1391
     @State private var vitalityToday: Double?
     /// Distinct days + sleep sessions imported from a Mi Band (Mi Fitness), for the Data Sources row.
     @State private var xiaomiDays = 0
@@ -2328,7 +2329,7 @@ struct TodayView: View {
         case .stress:
             pinnedCardRow(icon: card.icon, tint: tint, title: card.title, subtitle: card.subtitle,
                           value: dashboardValue(card), route: .stress)
-        case .fitnessAge, .vitality, .steps, .calories:
+        case .fitnessAge, .vo2max, .vitality, .steps, .calories:
             pinnedCardRow(icon: card.icon, tint: tint, title: card.title, subtitle: card.subtitle,
                           value: dashboardValue(card), route: .health)
         case .hrv, .restingHr, .respiratory, .bloodOxygen, .skinTemp:
@@ -2360,6 +2361,7 @@ struct TodayView: View {
         switch card {
         case .stress:      return StrandPalette.effortColor
         case .fitnessAge:  return StrandPalette.chargeColor
+        case .vo2max:      return StrandPalette.chargeColor
         case .vitality:    return StrandPalette.restColor
         case .hrv:         return StrandPalette.metricPurple
         case .restingHr:   return StrandPalette.metricRose
@@ -2458,6 +2460,8 @@ struct TodayView: View {
             return stressToday.map { "\(Int($0.rounded()))" } ?? Self.calibratingPlaceholder
         case .fitnessAge:
             return withUnit(fitnessAgeToday.map { "\(Int($0.rounded()))" } ?? "—")
+        case .vo2max:
+            return vo2maxToday.map { "\(Int($0.rounded()))" } ?? "—"
         case .vitality:
             return vitalityToday.map { "\(Int($0.rounded()))" } ?? "—"
         case .hydration:
@@ -4049,6 +4053,7 @@ struct TodayView: View {
         // `repo.refreshSeq` task key (loadAll's TodayLoadKey) and stay in sync.
         async let stressStoredA      = repo.series(key: "stress", source: "my-whoop")
         async let fitnessAgeSeriesA  = repo.exploreSeries(key: "fitness_age", source: "my-whoop")
+        async let vo2maxSeriesA      = repo.exploreSeries(key: "vo2max_est", source: "my-whoop")
         async let vitalitySeriesA    = repo.exploreSeries(key: "vitality", source: "my-whoop")
 
         // Steps ESTIMATE per day (WHOOP 4.0 motion → calibrated steps). exploreSeries reads the computed
@@ -4072,6 +4077,7 @@ struct TodayView: View {
         // placeholder, matching StressView's empty state. Fitness age / Vitality keep their merged reads.
         stressToday = StressModel(days: repo.days, stored: await stressStoredA)?.score
         fitnessAgeToday = (await fitnessAgeSeriesA).last?.value
+        vo2maxToday = (await vo2maxSeriesA).last?.value   // #1391: latest banked VO₂max estimate
         vitalityToday = (await vitalitySeriesA).last?.value
         // Hydration card (opt-in): today's stored total + the sex/Effort goal. Only loaded when the
         // feature is on, so a disabled feature does zero work and the card stays hidden.
@@ -4098,6 +4104,7 @@ struct TodayView: View {
             xiaomiSleeps: xiaomiSleeps,
             stressToday: stressToday,
             fitnessAgeToday: fitnessAgeToday,
+            vo2maxToday: vo2maxToday,
             vitalityToday: vitalityToday
         )
     }
@@ -4116,6 +4123,7 @@ struct TodayView: View {
         xiaomiSleeps = c.xiaomiSleeps
         stressToday = c.stressToday
         fitnessAgeToday = c.fitnessAgeToday
+        vo2maxToday = c.vo2maxToday
         vitalityToday = c.vitalityToday
         // Hydration is deliberately NOT part of the snapshot (#989): logging a drink never bumps
         // refreshSeq, so a restored total could be stale. It is re-read live instead (see loadAll).
@@ -4727,6 +4735,7 @@ struct TodayHistoryWideCache {
     let xiaomiSleeps: Int
     let stressToday: Double?
     let fitnessAgeToday: Double?
+    let vo2maxToday: Double?
     let vitalityToday: Double?
     // Hydration total/goal intentionally absent (#989): mutations don't bump refreshSeq, so a cached
     // value could restore stale. TodayView re-reads hydration live on restore instead.

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -634,6 +634,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     var todayStressCache: Double? = null
     var todayFitnessAgeCache: Double? = null
     var todayVitalityCache: Double? = null
+    var todayVo2maxCache: Double? = null
 
     /**
      * Recent daily metrics (newest last), backing the Today grid + illness watch.

--- a/android/app/src/main/java/com/noop/ui/DashboardCards.kt
+++ b/android/app/src/main/java/com/noop/ui/DashboardCards.kt
@@ -50,6 +50,7 @@ enum class DashboardCard(
     STEPS("steps", "Steps", "Today", "", Icons.AutoMirrored.Filled.DirectionsWalk),
     STRESS("stress", "Stress", "Autonomic load", "", Icons.Filled.Bolt),
     FITNESS_AGE("fitnessAge", "Fitness Age", "Updated weekly", "yrs", Icons.AutoMirrored.Filled.DirectionsRun),
+    VO2MAX("vo2max", "VO₂ Max", "Estimated, updated weekly", "", Icons.Filled.Air),
     VITALITY("vitality", "Vitality", "Wellness score", "", Icons.Filled.AutoAwesome),
     BLOOD_OXYGEN("bloodOxygen", "Blood Oxygen", "Blood oxygen", "", Icons.Filled.WaterDrop),
     SKIN_TEMP("skinTemp", "Skin Temp", "Skin temperature", "", Icons.Filled.Thermostat),

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -465,6 +465,7 @@ fun TodayScreen(
     // dashes while the heavy history-wide read is (now) skipped for unchanged data.
     var stressToday by remember { mutableStateOf(viewModel.todayStressCache) }
     var fitnessAgeToday by remember { mutableStateOf(viewModel.todayFitnessAgeCache) }
+    var vo2maxToday by remember { mutableStateOf(viewModel.todayVo2maxCache) }
     var vitalityToday by remember { mutableStateOf(viewModel.todayVitalityCache) }
     LaunchedEffect(days) {
         // #849 re-mount guard: skip the whole-history scan when `days` is content-identical to the last load
@@ -495,6 +496,9 @@ fun TodayScreen(
         fitnessAgeToday = runCatching {
             viewModel.repo.latestMetricComputedUnion(viewModel.activeStrapId, "fitness_age")?.value
         }.getOrNull()
+        vo2maxToday = runCatching {
+            viewModel.repo.latestMetricComputedUnion(viewModel.activeStrapId, "vo2max_est")?.value
+        }.getOrNull()
         vitalityToday = runCatching {
             viewModel.repo.latestMetricComputedUnion(viewModel.activeStrapId, "vitality")?.value
         }.getOrNull()
@@ -502,6 +506,7 @@ fun TodayScreen(
         // short-circuits the history-wide read above.
         viewModel.todayStressCache = stressToday
         viewModel.todayFitnessAgeCache = fitnessAgeToday
+        viewModel.todayVo2maxCache = vo2maxToday
         viewModel.todayVitalityCache = vitalityToday
         viewModel.todayCardsLoadedSig = sig
     }
@@ -1564,6 +1569,7 @@ fun TodayScreen(
                             respDay = lastRespDay,
                             stress = stressToday,
                             fitnessAge = fitnessAgeToday,
+                            vo2max = vo2maxToday,
                             vitality = vitalityToday,
                             importedStepsForDay = importedStepsForDay,
                             estimatedStepsForDay = stepsEstForDay,
@@ -3160,6 +3166,7 @@ private fun YourCardsSection(
     respDay: DailyMetric?,
     stress: Double?,
     fitnessAge: Double?,
+    vo2max: Double?,
     vitality: Double?,
     importedStepsForDay: Int?,
     estimatedStepsForDay: Int?,
@@ -3202,6 +3209,7 @@ private fun YourCardsSection(
                         fahrenheit = fahrenheit,
                         stress = stress,
                         fitnessAge = fitnessAge,
+                        vo2max = vo2max,
                         vitality = vitality,
                         importedStepsForDay = importedStepsForDay,
                         estimatedStepsForDay = estimatedStepsForDay,
@@ -3219,6 +3227,7 @@ private fun YourCardsSection(
                         respDay = respDay,
                         stress = stress,
                         fitnessAge = fitnessAge,
+                        vo2max = vo2max,
                         vitality = vitality,
                         importedStepsForDay = importedStepsForDay,
                         estimatedStepsForDay = estimatedStepsForDay,
@@ -3273,6 +3282,7 @@ private fun dashboardCardMetricKey(card: DashboardCard): String? = when (card) {
     DashboardCard.BLOOD_OXYGEN -> "spo2"
     DashboardCard.SKIN_TEMP -> "skin"
     DashboardCard.FITNESS_AGE -> "fitness_age"
+    DashboardCard.VO2MAX -> "vo2max_est"
     DashboardCard.VITALITY -> "vitality"
     DashboardCard.STEPS -> "steps_est"
     DashboardCard.CALORIES -> "active_kcal"
@@ -3313,6 +3323,7 @@ private fun dashboardCardTint(card: DashboardCard): Color = when (card) {
     // iOS `liquidCard`: stress → StrandPalette.accent (blue), not the Effort orange.
     DashboardCard.STRESS -> Palette.accent
     DashboardCard.FITNESS_AGE -> Palette.chargeColor
+    DashboardCard.VO2MAX -> Palette.chargeColor
     // iOS vitality → liquidPurple (#9b7bff).
     DashboardCard.VITALITY -> LIQUID_PURPLE
     // iOS hrv → metricCyan (this theme's metricPurple is a blue, cyan reads as the iOS HRV teal).
@@ -3347,6 +3358,7 @@ private fun dashboardCardFraction(
     respDay: DailyMetric?,
     stress: Double?,
     fitnessAge: Double?,
+    vo2max: Double?,
     vitality: Double?,
     importedStepsForDay: Int?,
     estimatedStepsForDay: Int?,
@@ -3356,6 +3368,7 @@ private fun dashboardCardFraction(
     return when (card) {
         DashboardCard.STRESS -> over(stress, 3.0)
         DashboardCard.FITNESS_AGE -> if (fitnessAge != null) 0.5 else null
+        DashboardCard.VO2MAX -> if (vo2max != null) 0.5 else null
         DashboardCard.VITALITY -> over(vitality, 100.0)
         DashboardCard.HRV -> over(day?.avgHrv ?: vitalsDay?.avgHrv, 120.0)
         DashboardCard.RESTING_HR -> over((day?.restingHr ?: vitalsDay?.restingHr)?.toDouble(), 100.0)
@@ -3399,6 +3412,7 @@ private fun dashboardCardValue(
     respDay: DailyMetric?,
     stress: Double?,
     fitnessAge: Double?,
+    vo2max: Double?,
     vitality: Double?,
     importedStepsForDay: Int?,
     estimatedStepsForDay: Int?,
@@ -3458,6 +3472,8 @@ private fun dashboardCardValue(
             stress?.let { it.roundToInt().toString() } ?: STRESS_CALIBRATING
         DashboardCard.FITNESS_AGE ->
             withUnit(fitnessAge?.let { it.roundToInt().toString() } ?: NO_DATA)
+        DashboardCard.VO2MAX ->
+            vo2max?.let { it.roundToInt().toString() } ?: NO_DATA
         DashboardCard.VITALITY ->
             vitality?.let { it.roundToInt().toString() } ?: NO_DATA
         DashboardCard.HYDRATION ->


### PR DESCRIPTION
Closes the actionable half of #1391. VO₂max was only visible inside the Fitness card; this surfaces it as a **"Your cards" dashboard card** the user can add on Today.

## What
- New `DashboardCard.vo2max` / `VO2MAX` — raw id `"vo2max"`, **byte-identical across platforms** (backup parity), title **"VO₂ Max"**, subtitle **"Estimated, updated weekly"**, charge-world tint.
- Value reads the **already-persisted `vo2max_est` daily series** (latest banked estimate) on **both** Today views (Liquid + classic). Tapping the card opens the metric-detail **trend chart** — so the "see the evolution" ask is served too.
- **Opt-in** — deliberately **not** in `defaultSelection`. VO₂max here is a slow-moving fitness-age/Uth estimate (like Fitness Age) that only exists once the unlock inputs (waist, resting HR) are present (#1333), so it's added via CUSTOMISE rather than shown by default.

## Why this shape
It's a decoded/derived-from-known-inputs estimate, not a new scored value — no `dailyMetric` write, no schema change. Honestly labelled "Estimated, updated weekly"; a fresh install with no inputs shows "—".

## Verification
- Android: `compileFullDebugKotlin` clean (compile-driven — the enum forced every `when` branch); `HostedCardPrefsTest` 5/0; i18n + doc-lint green.
- iOS: threaded through every exhaustive `DashboardCard` switch (`DashboardCards`, `LiquidTodayView`, `TodayView` ×3, `TodayCustomizationMetadata`) — verified via the app-build gate (I can't compile app-target Swift locally). `HowNoopWorksView`/`TabRoute` switch other enums, untouched.
- No test asserts an exact card set, so the new case doesn't break `HostedCardPrefs` on either platform.