### PR TITLE
fix(analyze): re-score gate must fingerprint HR across ALL devices, not "my-whoop" (#1392)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -80,6 +80,25 @@ extension WhoopStore {
         }
     }
 
+    /// Cross-device raw-HR fingerprint: `(count, maxTs)` over EVERY `hrSample` row, no `deviceId` filter.
+    /// The `analyzeRecent` re-score gate (#1392) only needs to answer "did the raw stream change AT ALL",
+    /// so it must see HR that lands under ANY id — an Oura ring, an Apple Watch, or a WHOOP re-added under a
+    /// fresh `whoop-<uuid>` — not only the literal "my-whoop" the engine is constructed with. The per-device
+    /// `hrFingerprint(deviceId:from:to:)` above stayed pinned to that literal (there is no setter to
+    /// re-point it when the active strap changes), so on a non-WHOOP install the fingerprint read 0 rows,
+    /// the watermark never advanced, and the idle-tick / post-offload gates always skipped. This mirrors the
+    /// Kotlin twin `WhoopRepository.hrFingerprint()`, which already has no device filter.
+    public func hrFingerprint() async throws -> (count: Int, maxTs: Int) {
+        try syncRead { db in
+            guard let row = try Row.fetchOne(db, sql: """
+                SELECT COUNT(*) AS c, COALESCE(MAX(ts), 0) AS m FROM hrSample
+                """) else { return (0, 0) }
+            let c: Int = row["c"]
+            let m: Int = row["m"]
+            return (c, m)
+        }
+    }
+
     /// Aggregate HR over a window: `(n, avg, max)` computed in SQLite over the same measured-∪-PPG rows
     /// [hrSamples] returns, WITHOUT materialising them and WITHOUT a row limit.
     ///

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/ReadTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/ReadTests.swift
@@ -53,6 +53,21 @@ final class ReadTests: XCTestCase {
         XCTAssertEqual(empty.maxTs, 0)
     }
 
+    // #1392 — the CROSS-DEVICE change-detector the re-score gate must use: NO deviceId filter, so it folds
+    // EVERY device's HR (dev1's 100/200/300 + the "other" decoy's 200). This is what lets a night landing
+    // under a non-"my-whoop" id (an Oura ring, an Apple Watch, a re-added WHOOP) still advance the analyze
+    // watermark — the device-scoped variant read 0 rows for such an install and the gate never fired.
+    func testHrFingerprintCrossDeviceFoldsEveryDevice() async throws {
+        let store = try await seeded()
+        let fp = try await store.hrFingerprint()   // no deviceId → across all devices
+        XCTAssertEqual(fp.count, 4)                 // dev1 (3) + "other" (1)
+        XCTAssertEqual(fp.maxTs, 300)               // dev1's 300 > other's 200
+        // Contrast: the device-scoped variant sees only dev1's rows — the #1392 blind spot when the pinned
+        // id ("my-whoop") doesn't match where the HR actually landed.
+        let scoped = try await store.hrFingerprint(deviceId: "dev1", from: 0, to: 9_999_999_999)
+        XCTAssertEqual(scoped.count, 3)
+    }
+
     func testHrBucketsAveragePerBucketOrderedAndDeviceScoped() async throws {
         let store = try await seeded()
         // 200s buckets over dev1's ts 100/200/300 (bpm 60/61/62):

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -460,7 +460,12 @@ final class IntelligenceEngine: ObservableObject {
         // workout delete) is untouched and no computed history is dropped. Every real update path (sync
         // backfill, import, sleep/workout edit, baseline recalibrate, timestamp heal) calls with the default
         // `force: true` and always rescores, so a skipped tick can never hide new data.
-        let wmKey: String = (try? await store.hrFingerprint(deviceId: deviceId, from: 0, to: 9_999_999_999))
+        // #1392: fingerprint the raw HR stream ACROSS ALL DEVICES, not the engine's construction-time
+        // `deviceId` (a `let` pinned to "my-whoop", never re-pointed when the active strap changes). On an
+        // Oura / Apple Watch / re-added-WHOOP install the per-device read returned 0, so this gate never
+        // fired and a night finishing after launch stayed unscored until relaunch. Scoring below still reads
+        // the registry's ACTIVE device (`owner`); only this change-detector needed to be cross-device.
+        let wmKey: String = (try? await store.hrFingerprint())
             .map { "\($0.count):\($0.maxTs)" } ?? ""
         if !force, !wmKey.isEmpty,
            UserDefaults.standard.string(forKey: Self.analyzeWatermarkKey) == wmKey {


### PR DESCRIPTION
Fixes #1392 (thanks @pipiche38 for the diagnosis + field evidence).

## The bug
`analyzeRecent`'s idle-tick / post-offload **skip-if-unchanged gate** keyed its watermark on `store.hrFingerprint(deviceId:)`, where `deviceId` is `IntelligenceEngine`'s construction-time `let` pinned to `"my-whoop"` — never re-pointed when the active strap changes (there's no setter). So on any install where raw HR lands under a **different** id — an **Oura ring**, an **Apple Watch**, or a WHOOP removed + re-added under a fresh `whoop-<uuid>` — the per-device fingerprint read **0 rows**, the watermark never advanced, and both the idle-tick and post-offload gates always reported "nothing changed" even right after a whole night drained. Only the launch-time **forced** pass ever scored, so a night finishing after it stayed all-NULL (blank Sleep/Today) until relaunch.

I verified in code: scoring itself already reads the registry's **active** device (`IntelligenceEngine:571 regActiveId` → `owner` at `:672-690`), so only the **gate** (`:463`) was pinned to the stale id — exactly as reported.

## The fix
Add a cross-device `WhoopStore.hrFingerprint()` (no `deviceId` filter, `COUNT/MAX(ts)` over every `hrSample`) and use it for the gate. The change-detector only needs *"did the raw stream change at all"* — not *"did this device's stream change"* — so it must see HR under **any** id. This **matches the Kotlin twin** `WhoopRepository.hrFingerprint()`, which already has no device filter (Android was never affected), fixing the parity divergence. The device-scoped `hrFingerprint(deviceId:from:to:)` is kept for its existing tests.

**Safe:** WHOOP-only installs are a subset (the fingerprint still fires on WHOOP HR); the one-time watermark change on upgrade just triggers a single harmless re-score; scoring is device-scoped and unchanged.

## Verification
- New `ReadTests.testHrFingerprintCrossDeviceFoldsEveryDevice` pins it: cross-device `hrFingerprint()` = `(4, 300)` over the seeded dev1(3)+other(1), while the scoped variant still sees only dev1(3). Runs in `swift-packages` CI (WhoopStore).
- `IntelligenceEngine.swift` is app-target → the on-demand app-build gate.
- Swift-only; no Kotlin change, no schema/migration, no version bump. Reproducible without hardware (seed `hrSample` under a non-`my-whoop` id, confirm the watermark advances).