### PR TITLE
perf(analyzeRecent): per-day in-memory reuse cache — fix #1005 re-score battery drain

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyzeRecentDayCache.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyzeRecentDayCache.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Per-day reuse identity for `IntelligenceEngine.analyzeRecent`'s pass-1 loop.
+///
+/// The drain this closes (#1005): on a heavy user (21 nights of history, ~178 k HR rows/night, a 1.26 GB
+/// store) every `newData` re-score re-read *every* night's raw streams and re-ran `analyzeDay`, even though
+/// a post-offload only ever adds rows to the 1–2 most-recent days — measured at a median ~4.6 min / pass,
+/// all CPU, and it fires back-to-back through an offload storm. Pass 1 already keeps only each night's small
+/// result and NOT the raw streams, and — by that loop's own design note — "every field except recovery is
+/// baseline-independent, so pass 2 only re-scores the cheap recovery composite". So a night whose scored
+/// inputs are unchanged since it was last scored re-produces a byte-identical result: the engine keeps an
+/// in-memory `[day: (key, DayScan)]` cache and reuses the scan when this key matches, skipping the reads +
+/// `analyzeDay`. A miss is byte-for-byte the current full path; the cache never touches banking (every day
+/// still flows into pass 2), so there is no data-loss surface.
+///
+/// The cache is in-memory and per-device — it never persists and never crosses the `.noopbak` boundary — so
+/// it only has to invalidate correctly on one platform; the Kotlin twin (`AnalyzeRecentDayCache`) mirrors
+/// the shape but the two key strings are NOT required to match byte-for-byte across platforms.
+public enum AnalyzeRecentDayCache {
+    /// The per-day reuse key. Reuse a cached day iff this string is unchanged since the scan was cached.
+    ///
+    /// - `hrCount` / `hrMaxTs`: the night-window HR fingerprint (row count + newest timestamp) — the SAME
+    ///   change witness the whole-pass gate at the top of `analyzeRecent` already trusts, applied here at
+    ///   day granularity. Any new/removed HR row moves one of the two.
+    /// - `skinAnchorRaw`: the WHOOP 4.0 window-wide skin-temp anchor (nil for a 5/MG, or when unresolved).
+    ///   It is window-wide, so a re-anchor caused by *another* night's skin data shifts this night's skin
+    ///   conversion without moving this night's HR fingerprint — folding it in makes that invalidate reuse.
+    ///   Encoded by raw bit-pattern so the equality check is exact and locale-free.
+    /// - `owner`: the resolved owning device id the fingerprint was measured against. The fingerprint is
+    ///   already device-scoped, so this is belt-and-suspenders for the **multi-strap** case (a user with
+    ///   both a 4.0 and a 5/MG): when a day's resolved owner flips between straps, keying on the owner makes
+    ///   the reuse invalidate **explicitly**, rather than relying on two different devices never producing an
+    ///   identical `count`+`maxTs` for the same window.
+    ///
+    /// Inputs that feed `analyzeDay` but are pass-global rather than per-day (profile, baselines1, sleep
+    /// need / consistency, habitual midsleep, tz, stager toggles) are NOT in this key — the engine drops the
+    /// whole cache when its pass config signature changes, which covers them.
+    public static func cacheKey(owner: String, hrCount: Int, hrMaxTs: Int, skinAnchorRaw: Double?) -> String {
+        let anchor = skinAnchorRaw.map { String($0.bitPattern) } ?? "nil"
+        return "\(owner)|\(hrCount):\(hrMaxTs):\(anchor)"
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyzeRecentDayCacheTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyzeRecentDayCacheTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// `AnalyzeRecentDayCache.cacheKey` — the per-day reuse identity for `analyzeRecent`'s pass-1 loop.
+/// Oracle for the Android `AnalyzeRecentDayCacheTest`; keep the two in lockstep on the invalidation rules
+/// (the exact key STRING may differ across platforms — the cache is in-memory and per-platform — but the
+/// set of changes that must / must not invalidate a reused day is a shared contract).
+final class AnalyzeRecentDayCacheTests: XCTestCase {
+    // Unchanged inputs → identical key → the day is reused.
+    func testStableInputsReuse() {
+        let a = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290)
+        let b = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290)
+        XCTAssertEqual(a, b)
+    }
+
+    // A new HR row (count moves) OR a later newest-ts must invalidate — the day changed.
+    func testHrChangeInvalidates() {
+        let base = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290)
+        let moreRows = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_001, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290)
+        let laterTs = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000, hrMaxTs: 1_700_000_060, skinAnchorRaw: 1290)
+        XCTAssertNotEqual(base, moreRows)
+        XCTAssertNotEqual(base, laterTs)
+    }
+
+    // A shifted window-wide skin anchor (another night's skin changed the 4.0 median) must invalidate even
+    // when this night's HR fingerprint is identical — the skin conversion changed.
+    func testAnchorShiftInvalidates() {
+        let a = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290)
+        let b = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290.5)
+        XCTAssertNotEqual(a, b)
+    }
+
+    // A 5/MG night (no anchor) is a distinct, self-consistent key: nil reuses nil, and nil ≠ a real anchor
+    // (so a 4.0 and a 5/MG night with the same fingerprint never alias to each other's scan).
+    func testNilAnchorDistinctButStable() {
+        let nilA = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 5_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: nil)
+        let nilB = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 5_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: nil)
+        let real = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 5_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 0)
+        XCTAssertEqual(nilA, nilB)
+        XCTAssertNotEqual(nilA, real)
+    }
+
+    // Multi-strap (4.0 + 5/MG): if a day's resolved owner flips between straps, the key must invalidate
+    // EXPLICITLY — even in the astronomically-unlikely case that the two straps produced an identical
+    // count+maxTs for the same window. The owner id is part of the key, so it never falsely reuses one
+    // strap's scan for the other.
+    func testDifferentOwnerInvalidates() {
+        let whoop4 = AnalyzeRecentDayCache.cacheKey(owner: "whoop4-A", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290)
+        let whoop5 = AnalyzeRecentDayCache.cacheKey(owner: "whoop5-B", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290)
+        XCTAssertNotEqual(whoop4, whoop5)
+    }
+}

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -39,6 +39,26 @@ final class IntelligenceEngine: ObservableObject {
     /// re-pass; this mirrors it). Reset by any pass whose heal finds nothing, restoring the budget.
     private var healRearmedThisCycle = false
 
+    /// #1005 BATTERY: in-memory per-day reuse for `analyzeRecent`'s pass-1 loop, keyed by day → (per-day
+    /// cache key, the scored `DayScan`). On a heavy user (21 nights, ~178 k HR rows/night, a 1.26 GB store)
+    /// every `newData` re-score re-read *every* night's raw streams and re-ran `analyzeDay`, even though a
+    /// post-offload only ever adds rows to the 1–2 most-recent days — median ~4.6 min / pass, all CPU, fired
+    /// back-to-back through an offload storm. Pass 1 already keeps only each night's small result (NOT the
+    /// raw streams) and every field except recovery is baseline-independent, so a night whose scored inputs
+    /// are unchanged since it was last scored re-produces a byte-identical `DayScan`: reuse it and skip the 7
+    /// stream reads + `analyzeDay`. FAIL-SAFE — a miss, any un-cacheable owner, any active Test-Centre
+    /// trace, or a config change all fall through to the identical full path; the cache only ever skips the
+    /// analyzeDay STAGE, so pass 2 (baselines, recovery recompute, stale-day eviction, heal) is byte-
+    /// unaffected and there is no banking / data-loss surface. In-memory + per-device; never persisted,
+    /// never crosses `.noopbak`. The engine is a single long-lived instance (AppModel), so this survives the
+    /// storm's back-to-back passes the drain is made of. See `AnalyzeRecentDayCache` (StrandAnalytics).
+    private var dayScanCache: [String: (key: String, scan: DayScan)] = [:]
+    /// The scoring-config signature the `dayScanCache` entries were produced under (profile / baselines1 /
+    /// tz / sleep need+consistency / habitual midsleep / stager toggles). Those feed `analyzeDay` but are
+    /// pass-global, not in the per-day key, so when the current pass's signature differs every cached scan is
+    /// potentially stale and the whole cache is dropped. Empty until the first pass.
+    private var dayScanCacheConfigSig = ""
+
     /// Who supplies the dashboard headline for a By-Day row. The By-Day card always shows NOOP's OWN
     /// on-device numbers, but the WHOLE-DASHBOARD value for the same day can come from an IMPORTED row
     /// that won the per-day merge (imports win field-by-field over computed , see Repository.mergeDaily).
@@ -644,7 +664,45 @@ final class IntelligenceEngine: ObservableObject {
         // so the Blood Oxygen tile can surface it as a "strap estimate (unverified)" fallback. Default OFF
         // per the derived-biosignal rule (CLAUDE.md) — the @82 candidate has split cross-device evidence.
         let spo2CandidateDisplayOn = PuffinExperiment.spo2CandidateDisplayEnabled
-        let (scanned, skippedDayLines): ([DayScan], [String]) = await Task.detached(priority: .utility) {
+
+        // ── #1005 BATTERY: per-day reuse cache setup (see `dayScanCache`) ────────────────────────────
+        // The stager toggles are read per-day inside the loop below, but they are global (same value every
+        // day); read them ONCE here too so the config signature can fold them without reaching into the
+        // detached loop.
+        let useSleepStagerV2Global = PuffinExperiment.experimentalSleepV2Enabled
+        let useMotionAwareWakeGlobal = PuffinExperiment.motionAwareWakeEnabled
+        // Cache eligibility for the whole pass: never reuse while a Test-Centre trace is active (a cached
+        // scan carries no fresh gate trace). Owner-level eligibility (registered WHOOP) is checked per day.
+        let dayCacheEligible = !(sleepTraceActive || hrvTraceActive || stepsTraceActive)
+        // The pass config signature — every input that feeds `analyzeDay` but is NOT in the per-day key, so
+        // a change to any of them must invalidate every cached night. All are pass-global 28-night / profile
+        // / toggle values (stable across an offload storm; they move only on a settings/profile/import edit
+        // or at midnight), so the cache survives the back-to-back passes. baselines1 is signed structurally
+        // (any BaselineState field change ⇒ a different string); Doubles by raw bit-pattern (exact, locale-
+        // free). Only ever compared to itself in memory, so cross-platform string identity isn't required.
+        let dayCacheConfigSig = [
+            String(describing: baselines1.hrv),
+            String(describing: baselines1.restingHR),
+            String(up.age.bitPattern), up.sex, String(up.stepTicksPerStep.bitPattern),
+            maxHR.map { String($0.bitPattern) } ?? "nil",
+            "\(tzOffset)",
+            String(sleepNeedHours.bitPattern),
+            sleepConsistency.map { String($0.bitPattern) } ?? "nil",
+            habitualMidsleepSec.map { "\($0)" } ?? "nil",
+            "\(useSleepStagerV2Global)", "\(useMotionAwareWakeGlobal)", "\(deepHrvWindow)",
+            "\(spo2CandidateDisplayOn)",
+        ].joined(separator: "|")
+        // Drop the whole cache on a config change, then snapshot it into a Sendable `let` for the detached
+        // loop (the engine is @MainActor; the loop can't touch `self`). The loop returns the updated cache
+        // and we write it back after `.value`.
+        if dayCacheConfigSig != dayScanCacheConfigSig {
+            dayScanCache.removeAll()
+            dayScanCacheConfigSig = dayCacheConfigSig
+        }
+        let inDayScanCache = dayScanCache
+
+        let (scanned, skippedDayLines, updatedDayScanCache):
+            ([DayScan], [String], [String: (key: String, scan: DayScan)]) = await Task.detached(priority: .utility) {
             var out: [DayScan] = []
             // Days skipped below (too few HR samples) never get a DayScan, so this diagnostic can't ride
             // along on one; carried out alongside `out` and replayed through `diagnosticSink` on the main
@@ -656,6 +714,11 @@ final class IntelligenceEngine: ObservableObject {
             let skinAnchorScanTo = nowLocalMidnight + 18 * 3_600
             var skinAnchorByOwner: [String: Double] = [:]
             var skinAnchorResolvedOwners = Set<String>()
+            // #1005: the reuse cache, snapshotted in from the main-actor stored property; mutated here and
+            // returned so it can be written back after `.value`. `dayCacheReused` counts hits for a one-line
+            // diagnostic carried on `skippedDayLines`.
+            var dayScanCacheLocal = inDayScanCache
+            var dayCacheReused = 0
             for offset in 0..<maxDays {
                 let dayStart = nowLocalMidnight - offset * 86_400
                 let day = AnalyticsEngine.dayString(dayStart, offsetSec: tzOffset)
@@ -673,6 +736,50 @@ final class IntelligenceEngine: ObservableObject {
                 let owner = await Self.resolveDayOwner(day: day, from: from, to: to, store: store,
                                                        devices: regDevices, activeId: regActiveId,
                                                        registry: registry, fallbackDeviceId: ownerFallbackId)
+
+                // ── #1005 BATTERY: per-day reuse (see `dayScanCache`) ───────────────────────────────
+                // Reuse this night's already-scored `DayScan` when its scored inputs are provably unchanged
+                // since we last scored it THIS session, skipping the 7 stream reads + `analyzeDay`. Gated to a
+                // registered WHOOP 4.0 owner — the reported drain (a 4.0 with a 1.26 GB store) and the ONE
+                // family whose classification is unambiguous and identical on both platforms (a 4.0 always
+                // streams gravity, so its `providedSleep` is empty and the reuse is byte-identical; a ring's
+                // `providedSleep` could change a day without an HR move). 5/MG is a deliberate follow-up, not
+                // cached here, so this stays conservative on a data-loss-sensitive path. The per-day key folds
+                // the night's HR fingerprint (the SAME witness the whole-pass gate at the top trusts) and the
+                // window-wide skin anchor (a re-anchor from another night shifts this night's skin conversion
+                // without moving its HR). Pass-global inputs (profile/baselines1/toggles) already dropped the
+                // whole cache above on change. A miss falls straight through to the identical full path.
+                var dayCacheKey: String? = nil
+                if dayCacheEligible,
+                   DeviceFamily.forRegistryDevice(
+                        model: regDevices.first(where: { $0.id == owner })?.model,
+                        brand: regDevices.first(where: { $0.id == owner })?.brand) == .whoop4 {
+                    // Resolve the window-wide anchor BEFORE the gate (it's a key input); once per owner, reads
+                    // the sparse skin stream — not the big HR one. This pre-populates `skinAnchorByOwner`, so
+                    // the existing per-day anchor block below sees the owner already resolved and is a no-op —
+                    // byte-identical anchor either way.
+                    if !skinAnchorResolvedOwners.contains(owner) {
+                        let windowSkin = (try? await store.skinTempSamples(deviceId: owner,
+                                                                           from: skinAnchorScanFrom,
+                                                                           to: skinAnchorScanTo,
+                                                                           limit: 200_000)) ?? []
+                        if let anchor = Whoop4SkinTemp.deviceAnchorRaw(windowSkin.map { $0.raw }) {
+                            skinAnchorByOwner[owner] = anchor
+                        }
+                        skinAnchorResolvedOwners.insert(owner)
+                    }
+                    if let fp = try? await store.hrFingerprint(deviceId: owner, from: from, to: to) {
+                        let key = AnalyzeRecentDayCache.cacheKey(owner: owner, hrCount: fp.count,
+                                                                 hrMaxTs: fp.maxTs,
+                                                                 skinAnchorRaw: skinAnchorByOwner[owner])
+                        dayCacheKey = key
+                        if let cached = dayScanCacheLocal[day], cached.key == key {
+                            out.append(cached.scan)
+                            dayCacheReused += 1
+                            continue
+                        }
+                    }
+                }
 
                 let hr = (try? await store.hrSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
                 guard hr.count >= 200 else {
@@ -1047,16 +1154,31 @@ final class IntelligenceEngine: ObservableObject {
                 // windowing + delegation lives in the byte-identical, tested `AnalyticsEngine`.
                 let (primarySessionRHR, primarySessionRHRCoverage) =
                     AnalyticsEngine.primarySessionRestingHRWithCoverage(sessions: res.sleepSessions, hr: hr)
-                out.append(DayScan(result: res, rhrLine: rhrLine, respLine: respLine,
+                let scan = DayScan(result: res, rhrLine: rhrLine, respLine: respLine,
                                    readOwner: owner, hrRows: hr.count,
                                    sleepTrace: sleepTrace, stepsTrace: stepsTrace, hrvTrace: hrvTrace,
                                    hrvDiag: hrvDiag, spo2Candidate: spo2CandidateMean,
                                    hrvOverCounted: hrvOverCounted,
                                    primarySessionRHR: primarySessionRHR,
-                                   primarySessionRHRCoverage: primarySessionRHRCoverage))
+                                   primarySessionRHRCoverage: primarySessionRHRCoverage)
+                // #1005: cache this freshly-scored scan under its per-day key (only when the day was
+                // cache-eligible this pass, i.e. a registered WHOOP owner with no trace active). Reused
+                // days `continue`d above and never reach here, so the cache only ever holds fresh scans.
+                if let key = dayCacheKey { dayScanCacheLocal[day] = (key: key, scan: scan) }
+                out.append(scan)
             }
-            return (out, skippedDayLines)
+            // #1005: prune the reuse cache to the current 21-day window (the oldest day ages out at
+            // midnight) and carry a one-line reuse diagnostic on the same channel as the skipped-day lines.
+            let dayCacheWindow = Set((0..<maxDays).map {
+                AnalyticsEngine.dayString(nowLocalMidnight - $0 * 86_400, offsetSec: tzOffset) })
+            dayScanCacheLocal = dayScanCacheLocal.filter { dayCacheWindow.contains($0.key) }
+            skippedDayLines.append("analyzeRecent dayCache reused=\(dayCacheReused)/\(maxDays) "
+                                   + "size=\(dayScanCacheLocal.count)")
+            return (out, skippedDayLines, dayScanCacheLocal)
         }.value
+        // #1005: write the loop's updated reuse cache back to the (main-actor) stored property. The pass ran
+        // to completion above (`.value` awaited), so there is no concurrent access.
+        dayScanCache = updatedDayScanCache
 
         // #714: replay each skipped day's diagnostic now that we're back on the main actor (diagnosticSink
         // is MainActor-bound). Always-on , not gated behind a test mode, mirroring the Kotlin `diag` sink.

--- a/android/app/src/main/java/com/noop/analytics/AnalyzeRecentDayCache.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyzeRecentDayCache.kt
@@ -1,0 +1,47 @@
+package com.noop.analytics
+
+/**
+ * Per-day reuse identity for [IntelligenceEngine.analyzeRecent]'s pass-1 loop. Kotlin twin of the Swift
+ * `AnalyzeRecentDayCache`.
+ *
+ * The drain this closes (#1005): on a heavy user (21 nights of history, ~178 k HR rows/night, a 1.26 GB
+ * store) every re-score re-read *every* night's raw streams and re-ran `analyzeDay`, even though a
+ * post-offload only ever adds rows to the 1–2 most-recent days — a median ~4.6 min / pass, all CPU, fired
+ * back-to-back through an offload storm. Pass 1 already keeps only each night's small result (NOT the raw
+ * streams), and every field except recovery is baseline-independent, so a night whose scored inputs are
+ * unchanged since it was last scored re-produces a byte-identical result: the engine keeps an in-memory
+ * `day -> (key, scored night)` cache and reuses the night when this key matches, skipping the reads +
+ * `analyzeDay`. A miss is byte-for-byte the current full path; the cache never touches banking (every night
+ * still flows into pass 2), so there is no data-loss surface.
+ *
+ * The cache is in-memory and per-process — it never persists and never crosses the `.noopbak` boundary — so
+ * it only has to invalidate correctly within one platform; the two key strings are NOT required to match the
+ * Swift ones byte-for-byte. The set of changes that must / must not invalidate a reused night IS a shared
+ * contract (see the tests, kept in lockstep with the Swift oracle).
+ */
+object AnalyzeRecentDayCache {
+    /**
+     * The per-day reuse key. Reuse a cached night iff this string is unchanged since the scan was cached.
+     *
+     * - [hrCount] / [hrMaxTs]: the night-window HR fingerprint (row count + newest timestamp) — the SAME
+     *   change witness the whole-pass gate at the top of `analyzeRecent` already trusts, applied here at day
+     *   granularity. Any new/removed HR row moves one of the two.
+     * - [skinAnchorRaw]: the WHOOP 4.0 window-wide skin-temp anchor (null when unresolved). It is
+     *   window-wide, so a re-anchor caused by *another* night's skin data shifts this night's skin conversion
+     *   without moving this night's HR fingerprint — folding it in makes that invalidate reuse. Encoded by
+     *   raw bit-pattern so the equality check is exact and locale-free.
+     * - [owner]: the resolved owning device id the fingerprint was measured against. The fingerprint is
+     *   already device-scoped, so this is belt-and-suspenders for the **multi-strap** case (a user with both
+     *   a 4.0 and a 5/MG): when a day's resolved owner flips between straps, keying on the owner makes the
+     *   reuse invalidate **explicitly**, rather than relying on two different devices never producing an
+     *   identical `count`+`maxTs` for the same window.
+     *
+     * Inputs that feed `analyzeDay` but are pass-global rather than per-day (profile, baselines1, sleep need
+     * / consistency, habitual midsleep, tz, stager toggles) are NOT in this key — the engine drops the whole
+     * cache when its pass config signature changes, which covers them.
+     */
+    fun cacheKey(owner: String, hrCount: Int, hrMaxTs: Long, skinAnchorRaw: Double?): String {
+        val anchor = skinAnchorRaw?.toRawBits()?.toString() ?: "nil"
+        return "$owner|$hrCount:$hrMaxTs:$anchor"
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -60,6 +60,41 @@ object IntelligenceEngine {
     private val analyzeGate = Mutex()
 
     /**
+     * #1005 BATTERY: in-memory per-day reuse for [analyzeRecent]'s pass-1 loop, keyed by day. On a heavy user
+     * (21 nights, ~178 k HR rows/night, a 1.26 GB store) every re-score re-read *every* night's raw streams
+     * and re-ran `analyzeDay`, even though a post-offload only ever adds rows to the 1–2 most-recent days —
+     * median ~4.6 min / pass, all CPU, fired back-to-back through an offload storm. Pass 1 already keeps only
+     * each night's small result (NOT the raw streams) and every field except recovery is baseline-independent,
+     * so a night whose scored inputs are unchanged since it was last scored re-produces a byte-identical
+     * result: reuse it and skip the 7 stream reads + `analyzeDay`. FAIL-SAFE — a miss, any non-4.0 owner, any
+     * active Test-Centre trace, or a config change all fall through to the identical full path; the cache only
+     * ever skips the analyzeDay STAGE, so pass 2 (baselines, recovery, stale-day eviction, heal) is byte-
+     * unaffected and there is no banking / data-loss surface. In-memory + per-process; never persisted, never
+     * crosses `.noopbak`. Guarded by [analyzeGate] (every pass runs under the lock), so no concurrent access.
+     * The Swift twin lives on the long-lived AppModel engine instance; here the object IS the process
+     * singleton. See [AnalyzeRecentDayCache]. [dayScanCacheConfigSig] is the pass-global config the entries
+     * were produced under; a change drops the whole cache. The cached fields mirror the Swift `DayScan` +
+     * the pass-1 diagnostic lines the day emitted (replayed on a hit so the strap log is unchanged). */
+    private var dayScanCache = HashMap<String, CachedDayScan>()
+    private var dayScanCacheConfigSig = ""
+
+    /** One reused night: its per-day cache [key], the scored [res], and everything the pass-1 loop otherwise
+     *  writes into function-scoped per-day maps that pass 2 reads (owner/hrRows/primary-session RHR/SpO₂
+     *  candidate/HRV over-count), plus the always-on per-day [diagLines] to replay so a reused pass logs the
+     *  same lines a fresh scoring pass would. (#1005) */
+    private data class CachedDayScan(
+        val key: String,
+        val res: DayResult,
+        val owner: String,
+        val hrRows: Int,
+        val primaryRhr: Double?,
+        val primaryRhrCoverage: PrimarySessionRestingHR.Coverage?,
+        val spo2Candidate: Int?,
+        val hrvOverCount: Boolean?,
+        val diagLines: List<String>,
+    )
+
+    /**
      * Per-day owner resolution source (invariant I2 , a day's scores come from exactly ONE device).
      * Pure abstraction so [analyzeRecent] resolves the owning device without taking an Android Context
      * or a Room dependency (mirrors how the engine already stays pure-JVM testable). A null source
@@ -481,9 +516,45 @@ object IntelligenceEngine {
         val skinAnchorByOwner = HashMap<String, Double>()
         val skinAnchorResolvedOwners = HashSet<String>()
 
+        // ── #1005 BATTERY: per-day reuse cache setup (see [dayScanCache]) ────────────────────────────
+        // Never reuse while a PER-DAY trace that PASS 1 builds is active (sleep/hrv/steps are threaded into
+        // analyzeDay or emitted inside the loop, so a reused night would drop them). recovery/workouts are
+        // pass-2 (emitted for cached nights too), and universal's only pass-1 write (readOwnerByDay) is
+        // repopulated on a hit below — so those DON'T disable caching. Matches the Swift `dayCacheEligible`
+        // (sleep/hrv/steps), so cache activation is identical on both platforms. (#1005)
+        val dayCacheEligible = sleepTraceSink == null && hrvTraceSink == null && stepsTraceSink == null
+        // The pass config signature — every input that feeds `analyzeDay` but is NOT in the per-day key, so a
+        // change to any of them must invalidate every cached night. All are pass-global 28-night / profile /
+        // toggle values (stable across an offload storm; they move only on a settings/profile/import edit or
+        // at midnight), so the cache survives the back-to-back passes. Deterministic within-process strings
+        // (compared only to itself in memory, so cross-platform identity isn't required); baselines1 is signed
+        // via its data-class toString (any field change ⇒ a different string).
+        val dayCacheConfigSig = listOf(
+            baselines1.hrv.toString(), baselines1.restingHR.toString(),
+            profile.age.toString(), profile.sex.toString(), profile.stepTicksPerStep.toString(),
+            maxHROverride?.toString() ?: "nil",
+            tzOffsetSeconds.toString(), sleepNeedHours.toString(),
+            sleepConsistency?.toString() ?: "nil", habitualMidsleepSec?.toString() ?: "nil",
+            useExperimentalSleepV2.toString(), useMotionAwareWake.toString(),
+            deepHrvWindow.toString(), spo2CandidateDisplay.toString(),
+        ).joinToString("|")
+        // Drop the whole cache on a config change. Under [analyzeGate] (this whole pass runs holding the
+        // lock), so mutating the object-level cache here is race-free.
+        if (dayCacheConfigSig != dayScanCacheConfigSig) {
+            dayScanCache = HashMap()
+            dayScanCacheConfigSig = dayCacheConfigSig
+        }
+        var dayCacheReused = 0
+
         for (offset in 0 until maxDays) {
             val dayStart = nowLocalMidnight - offset * SECONDS_PER_DAY
             val day = AnalyticsEngine.dayString(dayStart, tzOffsetSeconds)
+            // #1005: collect this night's ALWAYS-ON per-day diag lines so a cache HIT can replay them and the
+            // strap log is byte-identical to a fresh scoring pass (the Swift twin carries them on its DayScan
+            // and replays them in pass 2 the same way). Route each scored-day diag through [dayDiag]; the
+            // <200-HR SKIPPED line below stays a plain diag (that day is never cached).
+            val dayDiagLines = ArrayList<String>()
+            fun dayDiag(line: String) { dayDiagLines.add(line); diag(line) }
             // Read a generous window around the night that ends on `day`; the stager finds the span.
             val from = dayStart - 30 * 3_600L
             // Sleep read-window END — see `sleepReadWindowEnd`. A PAST day reads through to the next
@@ -499,6 +570,57 @@ object IntelligenceEngine {
             // live straps > imports, or a locked override). Falls back to [importedDeviceId] when no
             // owner source is supplied or the registry yields no owner.
             val owner = resolveDayOwner(repo, ownerSource, candidatePriorities, day, from, to, importedDeviceId)
+
+            // ── #1005 BATTERY: per-day reuse (see [dayScanCache]) ───────────────────────────────────
+            // Reuse this night's already-scored result when its scored inputs are provably unchanged since we
+            // last scored it THIS process, skipping the 7 stream reads + `analyzeDay`. Gated to a WHOOP 4.0
+            // owner — the reported drain and the one family classified unambiguously & identically on both
+            // platforms (a 4.0 always streams gravity, so its providedSleep is empty and the reuse is byte-
+            // identical). The per-day key folds the night's HR fingerprint (the SAME witness the whole-pass
+            // gate at the top trusts) and the window-wide skin anchor. Pass-global inputs (profile/
+            // baselines1/toggles) already dropped the whole cache above on change. A miss falls straight
+            // through to the identical full path.
+            var dayCacheKey: String? = null
+            if (dayCacheEligible &&
+                skinFamilyByOwner.getOrPut(owner) {
+                    ownerSource?.skinTempFamily(owner) ?: DeviceFamily.WHOOP5
+                } == DeviceFamily.WHOOP4
+            ) {
+                // Resolve the window-wide anchor BEFORE the gate (a key input); once per owner, reads the
+                // sparse skin stream — not the big HR one. Pre-populates [skinAnchorByOwner] so the existing
+                // per-day anchor block below is a no-op — byte-identical anchor either way.
+                if (!skinAnchorResolvedOwners.contains(owner)) {
+                    val windowSkin = repo.skinTempSamples(owner, skinAnchorScanFrom, skinAnchorScanTo, STREAM_LIMIT)
+                    Whoop4SkinTemp.deviceAnchorRaw(windowSkin.map { it.raw })?.let { skinAnchorByOwner[owner] = it }
+                    skinAnchorResolvedOwners.add(owner)
+                }
+                val (fpCount, fpMaxTs) = repo.hrFingerprintWindow(owner, from, to)
+                val key = AnalyzeRecentDayCache.cacheKey(owner, fpCount, fpMaxTs, skinAnchorByOwner[owner])
+                dayCacheKey = key
+                val cached = dayScanCache[day]
+                if (cached != null && cached.key == key) {
+                    // Repopulate every per-day map pass 2 reads (mirror of the loop's own writes below),
+                    // replay the day's diag lines, and continue — the reused night is downstream-
+                    // indistinguishable from a freshly-scored one. readOwnerByDay is the universal CAPTURE-B
+                    // owner/hrRows the pass-2 dayOwner line reads; the Swift twin carries it on the DayScan,
+                    // so we repopulate it here from the cached values (only when the universal sink is active,
+                    // matching the loop's own guard).
+                    if (universalSink != null) readOwnerByDay[day] = OwnerRead(cached.owner, cached.hrRows)
+                    cached.hrvOverCount?.let { hrvOverCountByDay[day] = it }
+                    nightlyHrvByDay[day] = cached.res.daily.avgHrv
+                    nightlyRhrByDay[day] = cached.res.daily.restingHr?.toDouble()
+                    nightlySkinByDay[day] = cached.res.nightlySkinTempC
+                    nightlyRespByDay[day] = cached.res.daily.respRateBpm
+                    cached.spo2Candidate?.let { spo2CandidateByDay[day] = it }
+                    cached.primaryRhr?.let { primarySessionRHRByDay[day] = it }
+                    cached.primaryRhrCoverage?.let { primarySessionRHRCoverageByDay[day] = it }
+                    scoredNights.add(cached.res)
+                    resolvedScoreOwnerByDay[day] = cached.owner
+                    for (line in cached.diagLines) diag(line)
+                    dayCacheReused++
+                    continue
+                }
+            }
 
             val hr = repo.hrSamples(owner, from, to, STREAM_LIMIT)
             // CAPTURE-B: capture this day's resolved read owner + HR-row count so PASS 2 can emit the
@@ -716,7 +838,7 @@ object IntelligenceEngine {
                 val sdnnField =
                     if (HrvAnalyzer.beatSpreadIsTrustworthy(verdict) &&
                         HrvAnalyzer.beatValuesAreTrustworthy(accVal)) "${ms(h.sdnn)}ms" else "withheld"
-                diag("hrv diag day=${res.daily.day} rmssd=${ms(h.rmssd)}ms sdnn=$sdnnField meanNN=${ms(h.meanNN)}ms " +
+                dayDiag("hrv diag day=${res.daily.day} rmssd=${ms(h.rmssd)}ms sdnn=$sdnnField meanNN=${ms(h.meanNN)}ms " +
                     "rr=${h.nInput}/${h.nClean} rejected=$rej% coverage=$cov collapsedCov=$colCov dupBeats=$dup " +
                     "beatAccurate=$acc " +
                     "rrIntegrity=${verdict.raw}")
@@ -733,7 +855,7 @@ object IntelligenceEngine {
                     val sample = HrvAnalyzer.densestSecondWindowSample(
                         ts, sleepRr, sleepRrRows.map { it.srcChannel },
                     )
-                    if (sample.isNotEmpty()) diag("hrv rrsample day=${res.daily.day} $sample")
+                    if (sample.isNotEmpty()) dayDiag("hrv rrsample day=${res.daily.day} $sample")
                     // #1331/#1008/#1118 SHADOW: log the DEDUPED stream's HRV + coverage + beat-accuracy
                     // beside the raw so the candidate de-dup can be validated vs WHOOP + @artemc's Polar
                     // before it becomes the read path. Instrumentation only — shipped HRV/resp unchanged.
@@ -749,7 +871,7 @@ object IntelligenceEngine {
                     val covEx = HrvAnalyzer.rrCoverage(ex.first, ex.second)
                     val covDd = HrvAnalyzer.rrCoverage(dd.first, dd.second)
                     val accDd = HrvAnalyzer.beatAccurateFraction(dd.first, dd.second)
-                    diag("hrv dedup day=${res.daily.day} exactN=${ex.second.size}/${sleepRr.size} " +
+                    dayDiag("hrv dedup day=${res.daily.day} exactN=${ex.second.size}/${sleepRr.size} " +
                         "covExact=${String.format(java.util.Locale.US, "%.2f", covEx)} | ch40N=${dd.second.size} " +
                         "cov40=${String.format(java.util.Locale.US, "%.2f", covDd)} " +
                         "beatAcc40=${String.format(java.util.Locale.US, "%.2f", accDd)} " +
@@ -761,7 +883,7 @@ object IntelligenceEngine {
                 // report says WHY nothing staged. `window` is the read span in whole hours (30 h back → next
                 // local midnight, or +18 h for today). Byte-identical to the Swift line.
                 val windowHours = ((to - from) / 3_600L).toInt()
-                diag(
+                dayDiag(
                     sleepDetectNoNightLogLine(
                         day = day, hrCount = hr.size, rrCount = rr.size, respCount = resp.size,
                         gravCount = grav.size, stepCount = steps.size, providedCount = providedSleep.size,
@@ -799,7 +921,7 @@ object IntelligenceEngine {
             // #1331 respiratory diagnostic: log each night's breaths/min (or "nil") so a "respiratory not
             // showing" report is explainable from the strap log — a run of nil nights localises when it
             // stopped. Logging only; no scoring change. The Swift diag twin lands with the iOS carry (#1331 follow-up).
-            diag(respRateLogLine(day, res.daily.respRateBpm))
+            dayDiag(respRateLogLine(day, res.daily.respRateBpm))
             // ── RHR floor-vs-mean diagnostic (#691) ────────────────────────────────────────────────
             // Make the recurring "NOOP's resting HR reads LOWER than my sleeping-HR app" reports
             // explainable from the strap log instead of a guess. The two numbers measure different
@@ -815,7 +937,7 @@ object IntelligenceEngine {
             if (rhrFloor != null) {
                 val inBedBpms = hr.filter { s -> res.sleepSessions.any { s.ts >= it.start && s.ts < it.end } }
                     .map { it.bpm }
-                diag(rhrFloorMeanLogLine(day, rhrFloor, inBedBpms))
+                dayDiag(rhrFloorMeanLogLine(day, rhrFloor, inBedBpms))
             }
             // #103: SpO₂ candidate @82 nightly mean. Only computed when the display toggle is ON.
             // Reads the V18AuxSample stream for this night's owner and averages the in-band (70–100)
@@ -841,7 +963,25 @@ object IntelligenceEngine {
             primaryRhrCoverage?.let { primarySessionRHRCoverageByDay[res.daily.day] = it }
             scoredNights.add(res)
             resolvedScoreOwnerByDay[res.daily.day] = owner
+            // #1005: cache this freshly-scored night under its per-day key (only when it was cache-eligible
+            // this pass — a WHOOP 4.0 owner with no trace active — hence dayCacheKey != null). Reused days
+            // continue'd above and never reach here, so the cache only ever holds fresh scans. Carries the
+            // per-day maps' values (read back from the maps just written) + the diag lines to replay.
+            dayCacheKey?.let { key ->
+                dayScanCache[day] = CachedDayScan(
+                    key = key, res = res, owner = owner, hrRows = hr.size,
+                    primaryRhr = primaryRhr, primaryRhrCoverage = primaryRhrCoverage,
+                    spo2Candidate = spo2CandidateByDay[day], hrvOverCount = hrvOverCountByDay[day],
+                    diagLines = dayDiagLines.toList(),
+                )
+            }
         }
+        // #1005: prune the reuse cache to the current window (the oldest day ages out at midnight) and log a
+        // one-line reuse count on the same diag channel as the per-day lines.
+        val dayCacheWindow = (0 until maxDays)
+            .map { AnalyticsEngine.dayString(nowLocalMidnight - it * SECONDS_PER_DAY, tzOffsetSeconds) }.toHashSet()
+        dayScanCache.keys.retainAll(dayCacheWindow)
+        diag("analyzeRecent dayCache reused=$dayCacheReused/$maxDays size=${dayScanCache.size}")
 
         // ── Seed the baseline from the UNION of imported nightly history + the nightly
         // values just computed. This is the recovery fix: the "-noop" nightly avgHrv/

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -858,6 +858,13 @@ interface WhoopDao : DeviceRegistryDao {
     // #836: max raw-HR timestamp across all devices. Paired with countHr() as a cheap whole-history change
     // fingerprint so the 15-min idle rescore can skip when nothing new has landed (COALESCE → 0 when empty).
     @Query("SELECT COALESCE(MAX(ts), 0) FROM hrSample") suspend fun maxHrTs(): Long
+    // #1005: per-day (device + window) HR fingerprint — row count + newest ts — for analyzeRecent's per-day
+    // reuse cache. Cheap COUNT/MAX aggregate over the (deviceId, ts) index, never a row fetch; mirrors Swift
+    // WhoopStore.hrFingerprint(deviceId:from:to:). COALESCE(MAX) → 0 for an empty window.
+    @Query("SELECT COUNT(*) FROM hrSample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to")
+    suspend fun countHrInWindow(deviceId: String, from: Long, to: Long): Int
+    @Query("SELECT COALESCE(MAX(ts), 0) FROM hrSample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to")
+    suspend fun maxHrTsInWindow(deviceId: String, from: Long, to: Long): Long
     @Query("SELECT COUNT(*) FROM rrInterval") suspend fun countRr(): Int
     @Query("SELECT COUNT(*) FROM event") suspend fun countEvents(): Int
     @Query("SELECT COUNT(*) FROM battery") suspend fun countBattery(): Int

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -558,6 +558,12 @@ class WhoopRepository(
      *  moves it (count or maxTs), so a real change always rescores; mirrors Swift WhoopStore.hrFingerprint. */
     suspend fun hrFingerprint(): String = "${dao.countHr()}:${dao.maxHrTs()}"
 
+    /** #1005 — per-day (device + window) HR fingerprint as (count, newestTs) for analyzeRecent's per-day
+     *  reuse cache. Cheap COUNT/MAX aggregate, never a row fetch; mirrors Swift
+     *  WhoopStore.hrFingerprint(deviceId:from:to:). */
+    suspend fun hrFingerprintWindow(deviceId: String, from: Long, to: Long): Pair<Int, Long> =
+        Pair(dao.countHrInWindow(deviceId, from, to), dao.maxHrTsInWindow(deviceId, from, to))
+
     // MARK: - Server-derived caches (latest value wins on conflict)
 
     suspend fun upsertDailyMetrics(days: List<DailyMetric>) = dao.upsertDailyMetrics(days)

--- a/android/app/src/test/java/com/noop/analytics/AnalyzeRecentDayCacheTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/AnalyzeRecentDayCacheTest.kt
@@ -1,0 +1,57 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * [AnalyzeRecentDayCache.cacheKey] — the per-day reuse identity for `analyzeRecent`'s pass-1 loop. Twin of
+ * the Swift `AnalyzeRecentDayCacheTests`; keep the two in lockstep on the invalidation rules (the exact key
+ * STRING may differ across platforms — the cache is in-memory and per-platform — but the set of changes that
+ * must / must not invalidate a reused day is a shared contract).
+ */
+class AnalyzeRecentDayCacheTest {
+    // Unchanged inputs -> identical key -> the day is reused.
+    @Test fun stableInputsReuse() {
+        val a = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_000L, 1290.0)
+        val b = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_000L, 1290.0)
+        assertEquals(a, b)
+    }
+
+    // A new HR row (count moves) OR a later newest-ts must invalidate — the day changed.
+    @Test fun hrChangeInvalidates() {
+        val base = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_000L, 1290.0)
+        val moreRows = AnalyzeRecentDayCache.cacheKey("dev1", 178_001, 1_700_000_000L, 1290.0)
+        val laterTs = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_060L, 1290.0)
+        assertNotEquals(base, moreRows)
+        assertNotEquals(base, laterTs)
+    }
+
+    // A shifted window-wide skin anchor (another night's skin changed the 4.0 median) must invalidate even
+    // when this night's HR fingerprint is identical — the skin conversion changed.
+    @Test fun anchorShiftInvalidates() {
+        val a = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_000L, 1290.0)
+        val b = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_000L, 1290.5)
+        assertNotEquals(a, b)
+    }
+
+    // A night with no anchor (null) is a distinct, self-consistent key: null reuses null, and null != a real
+    // anchor (so it never aliases to a real-anchor night's scan).
+    @Test fun nullAnchorDistinctButStable() {
+        val nilA = AnalyzeRecentDayCache.cacheKey("dev1", 5_000, 1_700_000_000L, null)
+        val nilB = AnalyzeRecentDayCache.cacheKey("dev1", 5_000, 1_700_000_000L, null)
+        val real = AnalyzeRecentDayCache.cacheKey("dev1", 5_000, 1_700_000_000L, 0.0)
+        assertEquals(nilA, nilB)
+        assertNotEquals(nilA, real)
+    }
+
+    // Multi-strap (4.0 + 5/MG): if a day's resolved owner flips between straps, the key must invalidate
+    // EXPLICITLY — even in the astronomically-unlikely case that the two straps produced an identical
+    // count+maxTs for the same window. The owner id is part of the key, so it never falsely reuses one
+    // strap's scan for the other.
+    @Test fun differentOwnerInvalidates() {
+        val whoop4 = AnalyzeRecentDayCache.cacheKey("whoop4-A", 178_000, 1_700_000_000L, 1290.0)
+        val whoop5 = AnalyzeRecentDayCache.cacheKey("whoop5-B", 178_000, 1_700_000_000L, 1290.0)
+        assertNotEquals(whoop4, whoop5)
+    }
+}


### PR DESCRIPTION
## What

Closes the `analyzeRecent` re-score battery drain reported on a heavy WHOOP 4.0 user (21 nights of history, ~178k HR rows/night, a **1.26 GB** store). Every `newData` re-score re-read **every** night's raw streams and re-ran `analyzeDay`, even though a post-offload only ever adds rows to the **1–2 most-recent** days — measured at a **median ~4.6 min/pass, all CPU**, fired back-to-back through an offload storm.

## How

Pass 1 already keeps only each night's small result (not the raw streams), and — by the loop's own design note — *"every field except recovery is baseline-independent, so pass 2 only re-scores the cheap recovery composite"*. So a night whose scored inputs are unchanged since it was last scored re-produces a **byte-identical** result: the engine keeps an **in-memory `day → (key, scan)` cache** and reuses the scan when the key matches, skipping the 7 stream reads + `analyzeDay`.

**Fail-safe by construction.** A miss, a non-4.0 owner, an active Test-Centre trace, or a config change all fall through to the identical full path. The cache only ever skips the `analyzeDay` **stage** — every night still flows into pass 2, so baselines, the recovery recompute, the stale-day eviction and the #899 heal are **byte-unaffected**. There is **no banking / data-loss surface** (this deliberately avoids the #836/#841 partial-skip trap: a skipped night is never absent from the fresh set, so the stale-day eviction can't delete it).

### Cache identity
- **Per-day key** = the night's HR fingerprint (`count` + newest `ts`, the *same* change witness the whole-pass gate at the top already trusts) + the WHOOP 4.0 window-wide skin anchor (a re-anchor from another night shifts this night's skin conversion without moving its HR).
- **Pass-global inputs** that feed `analyzeDay` but aren't per-day (profile, `baselines1`, sleep need/consistency, habitual midsleep, tz, stager toggles) drop the whole cache via a per-pass **config signature**. These are robust 28-night / profile / toggle values, stable across an offload storm, so the cache survives the back-to-back passes.
- **Gated to registered WHOOP 4.0 owners** — the reported drain, and the one family classified unambiguously and **identically on both platforms** (a 4.0 always streams gravity, so its `providedSleep` is empty and the reuse is byte-identical; a ring's `providedSleep` could change a day without an HR move). 5/MG is a deliberate, conservative follow-up.
- Reused nights **re-emit their per-day diagnostics**, so the strap log is unchanged.

## Parity (both platforms)
- **Swift**: carries it on the `DayScan` the pass-1 loop already builds; cache lives on the long-lived `AppModel` engine instance.
- **Kotlin**: adds a `CachedDayScan` on the `object` singleton (guarded by the existing `analyzeGate` mutex) + a windowed `hrFingerprint` DAO query (twin of `WhoopStore.hrFingerprint(deviceId:from:to:)`).
- The pure key helper `AnalyzeRecentDayCache` is unit-tested on **both** (`AnalyzeRecentDayCacheTests` / `AnalyzeRecentDayCacheTest`) — same invalidation contract. The cache is in-memory + per-platform and never crosses `.noopbak`, so the key *string* needn't match byte-for-byte across platforms; the invalidation *rules* do.

## Verification
- **Android**: `:app:compileFullDebugKotlin` clean (`--no-build-cache --rerun-tasks`, DAO regen); the new `AnalyzeRecentDayCacheTest` + the full `Intelligence*` / `HrFingerprintTest` / `ManualWorkoutRescore*` suites are **green**.
- **Swift**: app-target file (no default CI) — validated via the on-demand app-build gate (compile); the `AnalyzeRecentDayCache` helper + test run under `swift-packages` (StrandAnalytics, macOS).
- **On-device (the real proof, BLE/perf path):** to confirm on the reporting user's 4.0 — the storm's per-pass CPU should collapse to the 1–2 changed nights; the `analyzeRecent dayCache reused=N/21` diagnostic line reports the hit rate per pass.

No schema/migration change (the DAO additions are new `@Query`s, not table changes); nothing bumped (behavioral perf fix).