### PR TITLE
perf(analyzeRecent): extend the per-day reuse cache to WHOOP 5.0 / MG (#1005)

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -740,25 +740,26 @@ final class IntelligenceEngine: ObservableObject {
                 // ── #1005 BATTERY: per-day reuse (see `dayScanCache`) ───────────────────────────────
                 // Reuse this night's already-scored `DayScan` when its scored inputs are provably unchanged
                 // since we last scored it THIS session, skipping the 7 stream reads + `analyzeDay`. Gated to a
-                // registered WHOOP 4.0 owner — the reported drain (a 4.0 with a 1.26 GB store) and the ONE
-                // family whose classification is unambiguous and identical on both platforms (a 4.0 always
-                // streams gravity, so its `providedSleep` is empty and the reuse is byte-identical; a ring's
-                // `providedSleep` could change a day without an HR move). 5/MG is a deliberate follow-up, not
-                // cached here, so this stays conservative on a data-loss-sensitive path. The per-day key folds
-                // the night's HR fingerprint (the SAME witness the whole-pass gate at the top trusts) and the
-                // window-wide skin anchor (a re-anchor from another night shifts this night's skin conversion
-                // without moving its HR). Pass-global inputs (profile/baselines1/toggles) already dropped the
-                // whole cache above on change. A miss falls straight through to the identical full path.
+                // registered WHOOP owner (4.0 or 5/MG) via the UN-coalesced `forRegistryDevice` — which
+                // returns nil for a ring/import/unknown, so the cache never treats one as a WHOOP (a ring's
+                // `providedSleep` could change a day without an HR move; a WHOOP always streams gravity, so
+                // its `providedSleep` is empty and the reuse is byte-identical). The per-day key folds the
+                // night's HR fingerprint (the SAME witness the whole-pass gate at the top trusts) and, for a
+                // 4.0, the window-wide skin anchor (a re-anchor from another night shifts that night's skin
+                // conversion without moving its HR). A 5/MG banks skin-temp centidegrees directly — no
+                // per-device raw anchor — so its anchor slot stays nil. Pass-global inputs (profile/
+                // baselines1/toggles) already dropped the whole cache above on change. A miss falls straight
+                // through to the identical full path.
                 var dayCacheKey: String? = nil
                 if dayCacheEligible,
-                   DeviceFamily.forRegistryDevice(
+                   let ownerFamily = DeviceFamily.forRegistryDevice(
                         model: regDevices.first(where: { $0.id == owner })?.model,
-                        brand: regDevices.first(where: { $0.id == owner })?.brand) == .whoop4 {
-                    // Resolve the window-wide anchor BEFORE the gate (it's a key input); once per owner, reads
-                    // the sparse skin stream — not the big HR one. This pre-populates `skinAnchorByOwner`, so
-                    // the existing per-day anchor block below sees the owner already resolved and is a no-op —
-                    // byte-identical anchor either way.
-                    if !skinAnchorResolvedOwners.contains(owner) {
+                        brand: regDevices.first(where: { $0.id == owner })?.brand) {
+                    // Resolve the 4.0 window-wide anchor BEFORE the gate (it's a key input); once per owner,
+                    // reads the sparse skin stream — not the big HR one. This pre-populates `skinAnchorByOwner`,
+                    // so the existing per-day anchor block below sees the owner already resolved and is a
+                    // no-op — byte-identical anchor either way. Skipped for a 5/MG (anchor stays nil).
+                    if ownerFamily == .whoop4, !skinAnchorResolvedOwners.contains(owner) {
                         let windowSkin = (try? await store.skinTempSamples(deviceId: owner,
                                                                            from: skinAnchorScanFrom,
                                                                            to: skinAnchorScanTo,

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -121,6 +121,15 @@ object IntelligenceEngine {
          *  returns WHOOP5 (the prior /100 behaviour), so legacy/test sources are byte-identical;
          *  [RegistryDayOwnerSource] resolves a positively-identified 4.0 to WHOOP4. */
         suspend fun skinTempFamily(deviceId: String): DeviceFamily = DeviceFamily.WHOOP5
+
+        /** The registered WHOOP family for [deviceId] — WHOOP4 or WHOOP5 for a positively-identified strap,
+         *  or **null** for a non-WHOOP owner (ring / import / unknown). UNLIKE [skinTempFamily], which
+         *  coalesces an unknown to WHOOP5 for the skin-temp scale, this must NOT coalesce — the #1005 reuse
+         *  cache uses it to decide whether a day is safe to reuse, and treating a ring as a WHOOP would let a
+         *  `providedSleep` change slip past the HR fingerprint. The default returns null so legacy/test
+         *  sources are never cached; [RegistryDayOwnerSource] resolves it via DeviceFamily.forRegistryDevice.
+         *  Mirrors the Swift `DeviceFamily.forRegistryDevice(model:brand:)` used inline in the reuse gate. */
+        suspend fun registeredWhoopFamily(deviceId: String): DeviceFamily? = null
     }
 
     /** Minimum HR samples in a day's window before it is worth scoring. */
@@ -545,6 +554,10 @@ object IntelligenceEngine {
             dayScanCacheConfigSig = dayCacheConfigSig
         }
         var dayCacheReused = 0
+        // #1005: memoise the UN-coalesced registered WHOOP family per owner (null = non-WHOOP → never
+        // cached). Kept separate from [skinFamilyByOwner] (which coalesces unknown → WHOOP5 for the skin
+        // scale); this must NOT coalesce so a ring can't be cached as a WHOOP.
+        val cacheFamilyByOwner = HashMap<String, DeviceFamily?>()
 
         for (offset in 0 until maxDays) {
             val dayStart = nowLocalMidnight - offset * SECONDS_PER_DAY
@@ -573,23 +586,30 @@ object IntelligenceEngine {
 
             // ── #1005 BATTERY: per-day reuse (see [dayScanCache]) ───────────────────────────────────
             // Reuse this night's already-scored result when its scored inputs are provably unchanged since we
-            // last scored it THIS process, skipping the 7 stream reads + `analyzeDay`. Gated to a WHOOP 4.0
-            // owner — the reported drain and the one family classified unambiguously & identically on both
-            // platforms (a 4.0 always streams gravity, so its providedSleep is empty and the reuse is byte-
-            // identical). The per-day key folds the night's HR fingerprint (the SAME witness the whole-pass
-            // gate at the top trusts) and the window-wide skin anchor. Pass-global inputs (profile/
-            // baselines1/toggles) already dropped the whole cache above on change. A miss falls straight
-            // through to the identical full path.
+            // last scored it THIS process, skipping the 7 stream reads + `analyzeDay`. Gated to a registered
+            // WHOOP owner (4.0 or 5/MG) — a WHOOP always streams gravity, so its providedSleep is empty and
+            // the reuse is byte-identical, whereas a ring's providedSleep could change a day without an HR
+            // move (the un-coalesced family resolver returns null for non-WHOOP, so a ring is never cached).
+            // The per-day key folds the night's HR fingerprint (the SAME witness the whole-pass gate at the
+            // top trusts) and, for a 4.0, the window-wide skin anchor (a 5/MG banks centidegrees directly,
+            // no anchor). Pass-global inputs (profile/baselines1/toggles) already dropped the whole cache
+            // above on change. A miss falls straight through to the identical full path.
             var dayCacheKey: String? = null
-            if (dayCacheEligible &&
-                skinFamilyByOwner.getOrPut(owner) {
-                    ownerSource?.skinTempFamily(owner) ?: DeviceFamily.WHOOP5
-                } == DeviceFamily.WHOOP4
-            ) {
-                // Resolve the window-wide anchor BEFORE the gate (a key input); once per owner, reads the
+            // UN-coalesced registered WHOOP family (null for a ring/import/unknown → never cached; a ring's
+            // providedSleep could change a day without an HR move), memoised per owner. WHOOP4 and WHOOP5 are
+            // both cacheable. Mirrors the Swift gate's inline DeviceFamily.forRegistryDevice.
+            val cacheOwnerFamily: DeviceFamily? = if (dayCacheEligible) {
+                if (!cacheFamilyByOwner.containsKey(owner)) {
+                    cacheFamilyByOwner[owner] = ownerSource?.registeredWhoopFamily(owner)
+                }
+                cacheFamilyByOwner[owner]
+            } else null
+            if (cacheOwnerFamily != null) {
+                // Resolve the 4.0 window-wide anchor BEFORE the gate (a key input); once per owner, reads the
                 // sparse skin stream — not the big HR one. Pre-populates [skinAnchorByOwner] so the existing
-                // per-day anchor block below is a no-op — byte-identical anchor either way.
-                if (!skinAnchorResolvedOwners.contains(owner)) {
+                // per-day anchor block below is a no-op — byte-identical anchor either way. A 5/MG banks
+                // skin-temp centidegrees directly — no per-device anchor — so its anchor slot stays null.
+                if (cacheOwnerFamily == DeviceFamily.WHOOP4 && !skinAnchorResolvedOwners.contains(owner)) {
                     val windowSkin = repo.skinTempSamples(owner, skinAnchorScanFrom, skinAnchorScanTo, STREAM_LIMIT)
                     Whoop4SkinTemp.deviceAnchorRaw(windowSkin.map { it.raw })?.let { skinAnchorByOwner[owner] = it }
                     skinAnchorResolvedOwners.add(owner)

--- a/android/app/src/main/java/com/noop/analytics/RegistryDayOwnerSource.kt
+++ b/android/app/src/main/java/com/noop/analytics/RegistryDayOwnerSource.kt
@@ -58,4 +58,13 @@ class RegistryDayOwnerSource(private val registry: DeviceRegistry) : Intelligenc
         // as before; brand-awareness just stops it claiming to be a WHOOP (#1086).
         return DeviceFamily.forRegistryDevice(d?.model, d?.brand) ?: DeviceFamily.WHOOP5
     }
+
+    // #1005: the UN-coalesced registered WHOOP family (null for a non-WHOOP owner), for the reuse-cache
+    // eligibility gate. Same registry lookup as skinTempFamily but WITHOUT the WHOOP5 fallback, so a ring /
+    // import / unknown owner resolves to null and is never cached. Mirrors the Swift reuse gate's inline
+    // DeviceFamily.forRegistryDevice(model:brand:).
+    override suspend fun registeredWhoopFamily(deviceId: String): DeviceFamily? {
+        val d = registry.all().firstOrNull { it.id == deviceId }
+        return DeviceFamily.forRegistryDevice(d?.model, d?.brand)
+    }
 }


### PR DESCRIPTION
**Stacked on #1395** (base = its branch, so the diff shows only the 5/MG delta). Merge after #1395; I'll retarget to `main` once #1395 lands.

## What

Extends the per-day `analyzeRecent` reuse cache from #1395 (WHOOP 4.0 only) to **WHOOP 5.0 / MG**, so a heavy 5/MG user gets the same storm-CPU collapse.

## Why it was 4.0-only, and why 5/MG is a small delta

The 4.0 gate was conservative because **classification** was the hard part: `skinTempFamily` coalesces an unknown owner to `WHOOP5` for the skin-temp scale, so a naive `== WHOOP5` eligibility would also match a ring/import and could cache a night whose `providedSleep` changed without an HR move.

Everything else is *simpler* for 5/MG:
- It banks skin-temp **centidegrees directly** → no per-device raw skin anchor → the per-day key's anchor slot is just `nil` (already covered by the helper's `nullAnchorDistinctButStable` test).
- It streams gravity like a 4.0 → `providedSleep` is empty → the reuse is byte-identical.
- No new pass-global inputs — its `analyzeDay` uses the same profile/baselines/toggles (already in the config signature) + raw streams (the HR fingerprint).

## The change

- **Un-coalesced family resolver.** `DeviceFamily.forRegistryDevice(model,brand)` already returns `nil` for a non-WHOOP (brand-gated) on both platforms. Swift uses it inline (`!= nil`). Kotlin gets a new `DayOwnerSource.registeredWhoopFamily` (default `null`; `RegistryDayOwnerSource` resolves it via `forRegistryDevice`) so a ring/import/unknown is **never** cached — the distinction the `isWhoop5Registry` doc-comment already warns about (#171/#1086).
- **Eligibility broadened** to `WHOOP4 || WHOOP5`; the window-wide skin-anchor read stays **4.0-only** (a 5/MG's anchor is `nil`).

## Parity
Identical gate on both platforms (registered-WHOOP, un-coalesced) and identical key (nil anchor for 5/MG). The pure `AnalyzeRecentDayCache` helper is unchanged — its existing nil-anchor test already pins the 5/MG key path.

## Verification
- **Android**: `:app:compileFullDebugKotlin` clean; `AnalyzeRecentDayCache` / `Intelligence*` / `HrFingerprintTest` suites green.
- **Swift**: app-target — via the app-build gate; the helper is unchanged so `swift-packages` is unaffected.
- **On-device**: confirm on a 5/MG that the `analyzeRecent dayCache reused=N/21` line now reports hits for a 5/MG owner (it stayed 0 before this).

No schema/migration change; nothing bumped.