### PR TITLE
fix(steps): honest "connect a phone step source" prompt when a 4.0 has no step reference

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StepsEstimateEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StepsEstimateEngine.swift
@@ -116,6 +116,13 @@ public enum StepsEstimateEngine {
             case let .calibrated(_, sampleDays, _):
                 return "Estimated from \(sampleDays) day\(sampleDays == 1 ? "" : "s") your phone also counted"
             case let .needsMoreDays(have, need):
+                // #589 follow-up: `have == 0` means NO day yet had BOTH strap motion and a phone-counted step
+                // total. A WHOOP 4.0 always streams motion, so on a 4.0 this is really "no phone step source
+                // connected" — the "Need N more days" countdown would never advance (no day will ever gain a
+                // phone step count). Say what actually unblocks it instead of a frozen counter.
+                if have == 0 {
+                    return "Connect your phone's step count to estimate steps"
+                }
                 let more = Swift.max(0, need - have)
                 return "Need \(more) more day\(more == 1 ? "" : "s") where your phone also counted steps"
             }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StepsEstimateEngineTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StepsEstimateEngineTests.swift
@@ -136,6 +136,19 @@ final class StepsEstimateEngineTests: XCTestCase {
         XCTAssertEqual(status.headline, "Need 1 more day where your phone also counted steps")
     }
 
+    func testStatusHeadlineNoPhoneSourceIsActionableNotAFrozenCountdown() {
+        // #589 follow-up: ZERO usable days (no day had both strap motion and a phone step count) — the case a
+        // WHOOP 4.0 user with no phone step source connected hits. A "Need 3 more days" countdown would never
+        // advance, so the headline must say what actually unblocks it. Verified via an empty set and via a set
+        // whose only days are unusable (below-motion / zero-step), both of which yield have=0.
+        for pts in [[StepsEstimateEngine.CalibrationPoint](),
+                    [(0.2, 5000.0), (10.0, 0.0)].map { StepsEstimateEngine.CalibrationPoint(motion: $0.0, steps: $0.1) }] {
+            let status = StepsEstimateEngine.status(pts)
+            XCTAssertEqual(status, .needsMoreDays(have: 0, need: 3))
+            XCTAssertEqual(status.headline, "Connect your phone's step count to estimate steps")
+        }
+    }
+
     func testStatusCalibratedOnceEnoughDays() {
         let pts = (0..<3).map { _ in StepsEstimateEngine.CalibrationPoint(motion: 10, steps: 1000) }
         let status = StepsEstimateEngine.status(pts)

--- a/android/app/src/main/java/com/noop/analytics/StepsEstimateEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/StepsEstimateEngine.kt
@@ -114,6 +114,13 @@ object StepsEstimateEngine {
             override val canEstimate: Boolean get() = false
             override val headline: String
                 get() {
+                    // #589 follow-up: have == 0 means NO day yet had BOTH strap motion and a phone-counted step
+                    // total. A WHOOP 4.0 always streams motion, so on a 4.0 this is really "no phone step source
+                    // connected" - the "Need N more days" countdown would never advance (no day will ever gain a
+                    // phone step count). Say what actually unblocks it instead of a frozen counter.
+                    if (have == 0) {
+                        return "Connect your phone's step count to estimate steps"
+                    }
                     val more = maxOf(0, need - have)
                     return "Need $more more day${if (more == 1) "" else "s"} where your phone also counted steps"
                 }

--- a/android/app/src/test/java/com/noop/analytics/StepsEstimateEngineTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StepsEstimateEngineTest.kt
@@ -114,6 +114,19 @@ class StepsEstimateEngineTest {
         assertEquals("Need 1 more day where your phone also counted steps", status.headline)
     }
 
+    @Test fun statusHeadlineNoPhoneSourceIsActionableNotAFrozenCountdown() {
+        // #589 follow-up: ZERO usable days (no day had both strap motion and a phone step count) - the case a
+        // WHOOP 4.0 user with no phone step source connected hits. A "Need 3 more days" countdown would never
+        // advance, so the headline must say what actually unblocks it. Verified via an empty set and via a set
+        // whose only days are unusable (below-motion / zero-step), both of which yield have=0.
+        for (pts in listOf(emptyList<StepsEstimateEngine.CalibrationPoint>(), listOf(p(0.2, 5000.0), p(10.0, 0.0)))) {
+            val status = StepsEstimateEngine.status(pts)
+            status as StepsEstimateEngine.CalibrationStatus.NeedsMoreDays
+            assertEquals(0, status.have)
+            assertEquals("Connect your phone's step count to estimate steps", status.headline)
+        }
+    }
+
     @Test fun statusCalibratedOnceEnoughDays() {
         val pts = (0 until 3).map { p(10.0, 1000.0) }
         val status = StepsEstimateEngine.status(pts)


### PR DESCRIPTION
## The gap (from a real capture)

A heavy WHOOP 4.0 user's diagnostics showed **0 step rows across 40 days** despite full HR/gravity (3.46 M rows each). A 4.0 has **no native step counter** — its steps are *estimated* from strap motion, calibrated against days the phone **also** counted steps (min 3 overlapping days, via Apple Health / Health Connect).

When no phone step source has ever been connected, the calibration status is `NeedsMoreDays(have = 0)`, and every surface — the Today steps tile **and** the Steps calibration screen, on **both** platforms — renders the engine headline:

> "Need 3 more days where your phone also counted steps"

That's a **countdown that can never advance**: no day will ever gain a phone step count, so the user is stuck reading a frozen counter with no hint that *connecting a source* is what's missing. (There's already a `NoMotionNote` for the no-motion case, but nothing for the no-phone-source case.)

## The fix

A 4.0 always streams motion, so `have == 0` usable calibration days means there is **no phone step reference at all**. Special-case the engine `CalibrationStatus.NeedsMoreDays.headline` for `have == 0` to say what actually unblocks it:

> "Connect your phone's step count to estimate steps"

Every renderer already pulls this headline straight from the engine (the #589 single-source pattern, so wording stays consistent across the tile, the calibration screen, and both platforms), so **one engine change** fixes them all — no persist/UI/i18n change. `have > 0` keeps the existing countdown; calibrated/manual states are untouched.

## Scope / verification
- **Pure engine + tests only** — `StepsEstimateEngine` (Swift + Kotlin) + a test on each side asserting `have==0` yields the actionable headline (via an empty set and an all-unusable set) while `have>0` keeps the countdown.
- No app-target Swift, no UI, no i18n resource change → **swift-packages** (StrandAnalytics) + **Android CI** fully cover it; no app-build gate needed.
- Android validated locally (compile + `StepsEstimateEngineTest` green).

Note: this makes the *guidance* honest; it doesn't itself produce steps — the user still needs to connect a phone step source for the estimate to calibrate. Auto-reading the phone's native step counter (so no manual connect is needed) would be a separate, larger change.