### PR TITLE
diag(hrv): size the cross-second R-R over-count with a windowed shadow candidate (#1331/#1118)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -571,7 +571,16 @@ public enum HRVAnalyzer {
     /// validated against WHOOP's own numbers and @artemc's Polar H10 (#1118) BEFORE it ever becomes the
     /// read path (the "validate against the artifact, not one match" rule). Pure. Mirrors Kotlin
     /// `HrvAnalyzer.collapseOverCount`.
-    public static func collapseOverCount(tsSec: [Int], rrMs: [Double], rrTolMs: Double = 40)
+    /// `windowSec` widens the de-dup horizon: `0` (the default) compares only beats in the SAME second (the
+    /// original behaviour, byte-identical for every existing caller); `> 0` also collapses a near-identical
+    /// interval that recurs within `windowSec` seconds — the CROSS-second twins the `crossSecondOverCount`
+    /// verdict flags and a same-second collapse structurally cannot reach. INSTRUMENTATION ONLY, and a
+    /// cross-second window is an AGGRESSIVE UPPER BOUND: a steady real HR has near-identical intervals one
+    /// second apart, so `windowSec > 0` WILL over-merge real neighbours — it exists to size how much of a
+    /// night's over-count is cross-second (does coverage fall to ~1.0, does beat-accuracy clear #1127's
+    /// gate?), NOT as a shippable de-dup. The real fix is density/timeline-based and must be validated
+    /// against ground truth (@artemc's H10) before it becomes the read path. (#1118/#1331)
+    public static func collapseOverCount(tsSec: [Int], rrMs: [Double], rrTolMs: Double = 40, windowSec: Int = 0)
         -> (tsSec: [Int], rrMs: [Double]) {
         let n = min(tsSec.count, rrMs.count)
         guard n >= 2 else { return (tsSec, rrMs) }
@@ -583,7 +592,7 @@ public enum HRVAnalyzer {
             let r = rrMs[idx]
             var dup = false
             var j = keptTs.count - 1
-            while j >= 0 && keptTs[j] == t {      // only beats already kept in the SAME second
+            while j >= 0 && t - keptTs[j] <= windowSec {   // beats kept within `windowSec` (0 ⇒ same second)
                 if abs(keptRr[j] - r) <= rrTolMs { dup = true; break }
                 j -= 1
             }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HrvCollapseOverCountTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HrvCollapseOverCountTests.swift
@@ -55,4 +55,26 @@ final class HrvCollapseOverCountTests: XCTestCase {
         XCTAssertEqual(dd.rrMs.count, 60)
         XCTAssertEqual(dd.tsSec, ts)
     }
+
+    func testWindowSecCrossSecondIsAnAggressiveUpperBoundThatOverMergesRealBeats() {
+        // #1331: the cross-second window (windowSec > 0) catches boundary-straddling twins a same-second
+        // collapse can't reach — but it is a strict UPPER BOUND, not a shippable de-dup: it also over-merges
+        // a STEADY real HR whose intervals repeat one second apart. That's why it's shadow-instrumentation
+        // only (sizing how much of a night is cross-second), never the read path.
+
+        // Steady 60 bpm — one real beat/sec at 1000 ms, beat-accurate, nothing legitimately to remove.
+        let steadyTs = Array(0..<10)
+        let steadyRr = [Double](repeating: 1000.0, count: 10)
+        XCTAssertEqual(HRVAnalyzer.collapseOverCount(tsSec: steadyTs, rrMs: steadyRr, windowSec: 0).rrMs.count,
+                       10, "windowSec 0 leaves a steady stream untouched (the safe default)")
+        XCTAssertEqual(HRVAnalyzer.collapseOverCount(tsSec: steadyTs, rrMs: steadyRr, windowSec: 1).rrMs.count,
+                       5, "windowSec 1 over-merges every other real beat — an upper bound, not shippable")
+
+        // A boundary-straddling duplicate (the crossSecondOverCount signature): the same 500 ms beat emitted
+        // at second 0 AND second 1. Same-second keeps both (different seconds); the 1-second window drops it.
+        XCTAssertEqual(HRVAnalyzer.collapseOverCount(tsSec: [0, 1], rrMs: [500, 500], windowSec: 0).rrMs.count, 2)
+        XCTAssertEqual(HRVAnalyzer.collapseOverCount(tsSec: [0, 1], rrMs: [500, 500], windowSec: 1).rrMs.count, 1)
+        // Distinct values one second apart are real neighbours (|Δ| > tol) — never merged, even cross-second.
+        XCTAssertEqual(HRVAnalyzer.collapseOverCount(tsSec: [0, 1], rrMs: [500, 900], windowSec: 1).rrMs.count, 2)
+    }
 }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1078,16 +1078,30 @@ final class IntelligenceEngine: ObservableObject {
                         // same-second collapse is the aggressive UPPER BOUND (it also catches the two-channel
                         // twins but can over-merge two real neighbours whose values sit within 40 ms). The
                         // real de-dup lives between them; the log shows both so we can see where.
+                        // #1331: a THIRD candidate, `xsec` — the 40 ms collapse widened to a 1-second WINDOW.
+                        // Every night here reads `crossSecondOverCount`, meaning the same-second collapses
+                        // above CAN'T reach the duplicates (they straddle the second boundary), so `cov40`
+                        // stays ~1.7-2.0 on the heavy nights and respiratory stays blanked. `xsec` measures
+                        // how far a cross-second collapse WOULD get (does coverage fall to ~1.0, does
+                        // beat-accuracy clear #1127's 0.5 gate?). It is a strict UPPER BOUND, not a shippable
+                        // de-dup: a steady real HR has ~identical intervals one second apart, so this
+                        // over-merges real beats. Sizing only; the real fix is density/timeline-based +
+                        // ground-truth-validated (@artemc's H10). Instrumentation, shipped path unchanged.
                         let ex = HRVAnalyzer.collapseOverCount(tsSec: ts, rrMs: sleepRr, rrTolMs: 0)
                         let dd = HRVAnalyzer.collapseOverCount(tsSec: ts, rrMs: sleepRr)
+                        let xs = HRVAnalyzer.collapseOverCount(tsSec: ts, rrMs: sleepRr, rrTolMs: 40, windowSec: 1)
                         let hDd = HRVAnalyzer.analyze(rawRR: dd.rrMs)
                         let covEx = HRVAnalyzer.rrCoverage(tsSec: ex.tsSec, rrMs: ex.rrMs)
                         let covDd = HRVAnalyzer.rrCoverage(tsSec: dd.tsSec, rrMs: dd.rrMs)
                         let accDd = HRVAnalyzer.beatAccurateFraction(tsSec: dd.tsSec, rrMs: dd.rrMs)
+                        let covXs = HRVAnalyzer.rrCoverage(tsSec: xs.tsSec, rrMs: xs.rrMs)
+                        let accXs = HRVAnalyzer.beatAccurateFraction(tsSec: xs.tsSec, rrMs: xs.rrMs)
                         diagLine += "\nhrv dedup day=\(res.daily.day) exactN=\(ex.rrMs.count)/\(sleepRr.count) "
                             + "covExact=\(String(format: "%.2f", covEx)) | ch40N=\(dd.rrMs.count) "
                             + "cov40=\(String(format: "%.2f", covDd)) beatAcc40=\(String(format: "%.2f", accDd)) "
-                            + "rmssd40=\(ms(hDd.rmssd))ms sdnn40=\(ms(hDd.sdnn))ms meanNN40=\(ms(hDd.meanNN))ms"
+                            + "rmssd40=\(ms(hDd.rmssd))ms sdnn40=\(ms(hDd.sdnn))ms meanNN40=\(ms(hDd.meanNN))ms "
+                            + "| xsecN=\(xs.rrMs.count) covXsec=\(String(format: "%.2f", covXs)) "
+                            + "beatAccXsec=\(String(format: "%.2f", accXs)) (1s upper bound)"
                     }
                     hrvDiag = diagLine
                     // #1118: flag this night's HRV as over-counted (same verdict the diag logs) so the

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -508,8 +508,16 @@ object HrvAnalyzer {
      * the shipped HRV/resp path is unchanged; the always-on `hrv diag` logs BOTH raw and deduped so the
      * de-dup can be validated vs WHOOP + @artemc's Polar (#1118) before it becomes the read path. Pure.
      * Mirrors Swift `HRVAnalyzer.collapseOverCount`.
+     *
+     * [windowSec] widens the de-dup horizon: 0 (the default) compares only beats in the SAME second (the
+     * original behaviour, byte-identical for every existing caller); > 0 also collapses a near-identical
+     * interval that recurs within [windowSec] seconds — the CROSS-second twins the `crossSecondOverCount`
+     * verdict flags and a same-second collapse structurally cannot reach. INSTRUMENTATION ONLY, and a
+     * cross-second window is an AGGRESSIVE UPPER BOUND: a steady real HR has near-identical intervals one
+     * second apart, so [windowSec] > 0 WILL over-merge real neighbours — it exists to SIZE how much of a
+     * night's over-count is cross-second, NOT as a shippable de-dup. (#1118/#1331)
      */
-    fun collapseOverCount(tsSec: List<Long>, rrMs: List<Double>, rrTolMs: Double = 40.0): Pair<List<Long>, List<Double>> {
+    fun collapseOverCount(tsSec: List<Long>, rrMs: List<Double>, rrTolMs: Double = 40.0, windowSec: Long = 0L): Pair<List<Long>, List<Double>> {
         val n = minOf(tsSec.size, rrMs.size)
         if (n < 2) return Pair(tsSec, rrMs)
         val order = (0 until n).sortedWith(compareBy({ tsSec[it] }, { rrMs[it] }, { it }))
@@ -520,7 +528,7 @@ object HrvAnalyzer {
             val r = rrMs[idx]
             var dup = false
             var j = keptTs.size - 1
-            while (j >= 0 && keptTs[j] == t) {      // only beats already kept in the SAME second
+            while (j >= 0 && t - keptTs[j] <= windowSec) {   // beats kept within `windowSec` (0 ⇒ same second)
                 if (abs(keptRr[j] - r) <= rrTolMs) { dup = true; break }
                 j--
             }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -885,17 +885,29 @@ object IntelligenceEngine {
                     // ts AND value, no real-beat loss) is the safe floor; the ~40 ms collapse is the
                     // aggressive UPPER BOUND (catches the two-channel twins but can over-merge two real
                     // neighbours within 40 ms). Log both so we can see where the real de-dup sits. Twin.
+                    // #1331: a THIRD candidate, `xsec` — the 40 ms collapse widened to a 1-second WINDOW.
+                    // crossSecondOverCount means the same-second collapses above can't reach the boundary-
+                    // straddling twins (cov40 stays ~1.7-2.0 on heavy nights, resp blanked); `xsec` sizes how
+                    // far a cross-second collapse WOULD get (coverage → ~1.0? beat-accuracy clears the 0.5
+                    // gate?). Strict UPPER BOUND, not shippable (a steady HR has ~identical intervals one
+                    // second apart, so it over-merges real beats); the real fix is density/timeline-based +
+                    // H10-validated. Instrumentation only, shipped path unchanged. Twin of the Swift line.
                     val ex = HrvAnalyzer.collapseOverCount(ts, sleepRr, 0.0)
                     val dd = HrvAnalyzer.collapseOverCount(ts, sleepRr)
+                    val xs = HrvAnalyzer.collapseOverCount(ts, sleepRr, 40.0, 1L)
                     val hDd = HrvAnalyzer.analyzeRaw(dd.second)
                     val covEx = HrvAnalyzer.rrCoverage(ex.first, ex.second)
                     val covDd = HrvAnalyzer.rrCoverage(dd.first, dd.second)
                     val accDd = HrvAnalyzer.beatAccurateFraction(dd.first, dd.second)
+                    val covXs = HrvAnalyzer.rrCoverage(xs.first, xs.second)
+                    val accXs = HrvAnalyzer.beatAccurateFraction(xs.first, xs.second)
                     dayDiag("hrv dedup day=${res.daily.day} exactN=${ex.second.size}/${sleepRr.size} " +
                         "covExact=${String.format(java.util.Locale.US, "%.2f", covEx)} | ch40N=${dd.second.size} " +
                         "cov40=${String.format(java.util.Locale.US, "%.2f", covDd)} " +
                         "beatAcc40=${String.format(java.util.Locale.US, "%.2f", accDd)} " +
-                        "rmssd40=${ms(hDd.rmssd)}ms sdnn40=${ms(hDd.sdnn)}ms meanNN40=${ms(hDd.meanNN)}ms")
+                        "rmssd40=${ms(hDd.rmssd)}ms sdnn40=${ms(hDd.sdnn)}ms meanNN40=${ms(hDd.meanNN)}ms " +
+                        "| xsecN=${xs.second.size} covXsec=${String.format(java.util.Locale.US, "%.2f", covXs)} " +
+                        "beatAccXsec=${String.format(java.util.Locale.US, "%.2f", accXs)} (1s upper bound)")
                 }
             } else if (res.sleepSessions.isEmpty()) {
                 // #1244: no in-sleep R-R AND no detected session (past the >=200-HR gate) = the "HR tracked,

--- a/android/app/src/test/java/com/noop/analytics/HrvCollapseOverCountTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvCollapseOverCountTest.kt
@@ -65,4 +65,24 @@ class HrvCollapseOverCountTest {
         assertEquals(60, ddRr.size)
         assertEquals(ts, ddTs)
     }
+
+    @Test
+    fun collapseOverCount_windowSecCrossSecondIsAnAggressiveUpperBound() {
+        // #1331: the cross-second window (windowSec > 0) catches boundary-straddling twins a same-second
+        // collapse can't reach — but it is a strict UPPER BOUND, not a shippable de-dup: it also over-merges
+        // a STEADY real HR whose intervals repeat one second apart. Shadow-instrumentation only. Twin of Swift.
+        val steadyTs = (0L until 10L).toList()
+        val steadyRr = List(10) { 1000.0 }
+        assertEquals("windowSec 0 leaves a steady stream untouched (safe default)",
+            10, HrvAnalyzer.collapseOverCount(steadyTs, steadyRr, 40.0, 0L).second.size)
+        assertEquals("windowSec 1 over-merges every other real beat — upper bound, not shippable",
+            5, HrvAnalyzer.collapseOverCount(steadyTs, steadyRr, 40.0, 1L).second.size)
+
+        // Boundary-straddling duplicate (the crossSecondOverCount signature): same 500 ms beat at second 0
+        // AND second 1. Same-second keeps both; the 1-second window drops the twin.
+        assertEquals(2, HrvAnalyzer.collapseOverCount(listOf(0L, 1L), listOf(500.0, 500.0), 40.0, 0L).second.size)
+        assertEquals(1, HrvAnalyzer.collapseOverCount(listOf(0L, 1L), listOf(500.0, 500.0), 40.0, 1L).second.size)
+        // Distinct values one second apart are real neighbours (|Δ| > tol) — never merged, even cross-second.
+        assertEquals(2, HrvAnalyzer.collapseOverCount(listOf(0L, 1L), listOf(500.0, 900.0), 40.0, 1L).second.size)
+    }
 }


### PR DESCRIPTION
## Why
The latest #1331 4.0 logs read **`crossSecondOverCount` every night**. #1352's shadow de-dup only tests **same-second** collapses (exact + 40 ms), which by definition *can't reach* duplicates that straddle the second boundary — so `cov40` stays ~1.7–2.0 on the heavy nights, `beatAccurate` stays ~0.46, and RSA-respiration stays blanked by #1127's 0.5 gate. Nothing currently **measures** how much of the over-count is cross-second.

## What
Adds a **third shadow candidate**, `xsec` — the 40 ms collapse widened to a **1-second window** — logged beside the existing ones in the `hrv dedup` line, so a capture shows whether a cross-second collapse would drive coverage → ~1.0 and clear the beat-accuracy gate. `collapseOverCount` gains a `windowSec` param (**default 0 = same-second, byte-identical for every existing caller**).

## Deliberately instrumentation-only (not the fix)
The shipped HRV/resp path is **unchanged**. A cross-second window is a strict **UPPER BOUND**, *not* a shippable de-dup: a steady real HR has near-identical intervals one second apart, so it over-merges real beats — the test pins this (a 10-beat steady stream drops to 5 at `windowSec=1`). The real fix is **density/timeline-based** and must be validated against ground truth (@artemc's H10) before it touches the read path; this just quantifies the target, matching #1352's "validate before it becomes the read path" pattern.

## Verification
- Both platforms, **byte-identical** `hrv dedup` line + twin tests (`HrvCollapseOverCount*` gets a `windowSec` case on each side).
- Android: compiles clean + `HrvCollapseOverCount`/`HrvRrCoverage` tests green locally.
- Swift: `StrandAnalytics` (swift-packages) covers the function + test; app-target `IntelligenceEngine.swift` via the app-build gate (below).
- No shipped-scoring / stored-data / BLE change.