### PR TITLE
Baseline-relative daytime stress (revives #463) — opt-in + full parity

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
@@ -223,6 +223,24 @@ public enum Baselines {
         // so personal spread drives the z while an ultra-stable baseline is floored against saturation.
         "readiness_hrv_ln": MetricCfg(minVal: 2.079, maxVal: 5.521, floorSpread: 0.08,
                                       halfLifeB: 14.0, halfLifeS: 21.0),
+
+        // Daytime/waking-hours configs (DaytimeStress baseline-relative mode, added alongside
+        // the day-relative default). Distinct from "resting_hr"/"hrv" above, which each fold ONE
+        // NIGHTLY value (sleep). These fold ONE DAYTIME aggregate per day (e.g. that day's own
+        // calm-hour HR / RMSSD reference — see DaytimeStress.calmReference) into a cross-day
+        // PERSONAL baseline, so a caller can hand the resulting BaselineState to
+        // `DaytimeStress.analyze(mode: .baselineRelative(hr:rmssd:))` and z-score each waking
+        // hour against "how MY days usually run" rather than "how today's own calm hours ran".
+        // TUNING SEAM: minVal/maxVal/floorSpread/half-life below are a documented first pass —
+        // daytime HR/RMSSD are not yet validated against Oura's own baseline windows. A
+        // validation pass against real Oura export data may refine these. floorSpread is wider
+        // than the nightly "hrv" config for RMSSD: daytime RMSSD carries more incidental noise
+        // (posture changes, talking, movement between "calm" hours) than overnight recumbent
+        // HRV, so its floor tolerates more day-to-day spread before flagging a real deviation.
+        "daytime_hr": MetricCfg(minVal: 35.0, maxVal: 160.0, floorSpread: 3.0,
+                                halfLifeB: 14.0, halfLifeS: 21.0),
+        "daytime_rmssd": MetricCfg(minVal: 5.0, maxVal: 250.0, floorSpread: 7.0,
+                                   halfLifeB: 14.0, halfLifeS: 21.0),
     ]
 
     /// Convenience accessors for the standard configs.
@@ -234,6 +252,10 @@ public enum Baselines {
     public static var readinessHRVLnCfg: MetricCfg { metricCfg["readiness_hrv_ln"]! }
     /// Baseline config for the RecoveryScorer Activity-Balance / previous-day-Effort term.
     public static var strainCfg: MetricCfg { metricCfg["strain"]! }
+    /// Personal daytime/waking HR baseline config — see the `daytime_hr` comment above.
+    public static var daytimeHRCfg: MetricCfg { metricCfg["daytime_hr"]! }
+    /// Personal daytime/waking RMSSD baseline config — see the `daytime_rmssd` comment above.
+    public static var daytimeRMSSDCfg: MetricCfg { metricCfg["daytime_rmssd"]! }
 
     /// Convert a half-life in nights to an EWMA smoothing factor.
     static func lambda(halfLife: Double) -> Double {
@@ -545,12 +567,20 @@ public enum Baselines {
 
     // MARK: - Deviation
 
+    /// Convert a state's EWMA-abs-dev spread to an approximate Gaussian σ: 1.253 × spread,
+    /// floored so a caller never divides by ~0. 1.253 is E[|X−μ|] = σ·√(2/π) inverted
+    /// (E[|X−μ|] ≈ σ/1.253 for a Gaussian). Shared by `deviation()` below and by any other
+    /// z-scoring caller (e.g. `DaytimeStress`'s baseline-relative mode) so the conversion has
+    /// exactly one definition.
+    public static func sigma(_ state: BaselineState) -> Double {
+        max(1.253 * state.spread, 1e-9)
+    }
+
     /// Compute z / delta / ratio / in-normal-range for a value vs a baseline.
-    /// z uses (value − baseline) / (1.253 × spread); 1.253 converts EWMA-abs-dev
-    /// to an approximate Gaussian σ (E[|X−μ|] = σ·√(2/π) ≈ σ/1.253).
+    /// z uses (value − baseline) / sigma(state); see `sigma(_:)` for the 1.253 conversion.
     public static func deviation(_ value: Double, state: BaselineState) -> Deviation {
-        let sigma = max(1.253 * state.spread, 1e-9)
-        let z = (value - state.baseline) / sigma
+        let sig = sigma(state)
+        let z = (value - state.baseline) / sig
         let delta = value - state.baseline
         let ratio = state.baseline != 0 ? (value / state.baseline - 1.0) : 0.0
         return Deviation(z: z, delta: delta, ratio: ratio, inNormalRange: abs(z) <= 1.0)

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
@@ -226,17 +226,21 @@ public enum Baselines {
 
         // Daytime/waking-hours configs (DaytimeStress baseline-relative mode, added alongside
         // the day-relative default). Distinct from "resting_hr"/"hrv" above, which each fold ONE
-        // NIGHTLY value (sleep). These fold ONE DAYTIME aggregate per day (e.g. that day's own
-        // calm-hour HR / RMSSD reference — see DaytimeStress.calmReference) into a cross-day
+        // NIGHTLY value (sleep). These fold ONE DAYTIME aggregate per day into a cross-day
         // PERSONAL baseline, so a caller can hand the resulting BaselineState to
         // `DaytimeStress.analyze(mode: .baselineRelative(hr:rmssd:))` and z-score each waking
         // hour against "how MY days usually run" rather than "how today's own calm hours ran".
-        // TUNING SEAM: minVal/maxVal/floorSpread/half-life below are a documented first pass —
-        // daytime HR/RMSSD are not yet validated against Oura's own baseline windows. A
-        // validation pass against real Oura export data may refine these. floorSpread is wider
-        // than the nightly "hrv" config for RMSSD: daytime RMSSD carries more incidental noise
-        // (posture changes, talking, movement between "calm" hours) than overnight recumbent
-        // HRV, so its floor tolerates more day-to-day spread before flagging a real deviation.
+        //
+        // VALIDATED (26-day Oura-reference correlation, HR-only, r≈0.6): the per-day value to
+        // fold for "daytime_hr" is that day's 10th-percentile daytime HR (~65 bpm pooled across
+        // the reference set) — NOT the day-relative calmReference's 25th-percentile quartile.
+        // The "high stress" cutoff itself is a validated fixed bpm margin over this baseline,
+        // NOT this config's floorSpread — see DaytimeStress.baselineRelativeHighMarginBPM.
+        // TUNING SEAM: minVal/maxVal/half-life below (and all of "daytime_rmssd" — RMSSD wasn't
+        // part of the validated HR-only comparison) are a documented first pass, refinable once
+        // an HR+HRV comparison exists. floorSpread is wider than the nightly "hrv" config for
+        // RMSSD: daytime RMSSD carries more incidental noise (posture changes, talking, movement
+        // between "calm" hours) than overnight recumbent HRV.
         "daytime_hr": MetricCfg(minVal: 35.0, maxVal: 160.0, floorSpread: 3.0,
                                 halfLifeB: 14.0, halfLifeS: 21.0),
         "daytime_rmssd": MetricCfg(minVal: 5.0, maxVal: 250.0, floorSpread: 7.0,

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeBaselines.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeBaselines.swift
@@ -140,6 +140,10 @@ public extension DaytimeStress {
     static func scoringMode(history days: [DaytimeDayStreams]) -> ScoringMode {
         let baselines = foldDaytimeBaselines(days: days)
         guard baselines.hr.usable else { return .dayRelative }
-        return .baselineRelative(hr: baselines.hr, rmssd: baselines.rmssd)
+        // RMSSD stays out of the LIVE score until it has its own validation pass — see
+        // `DaytimeStress.daytimeRMSSDScoringEnabled`. The baseline is still folded above (so the
+        // machinery + tests exercise the real path); it just doesn't reach scoring while gated off.
+        let rmssd = DaytimeStress.daytimeRMSSDScoringEnabled ? baselines.rmssd : nil
+        return .baselineRelative(hr: baselines.hr, rmssd: rmssd)
     }
 }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeBaselines.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeBaselines.swift
@@ -1,0 +1,145 @@
+import Foundation
+import WhoopProtocol
+
+// DaytimeBaselines.swift — the CALLER-side folding path that turns a person's past DAYTIME history
+// into the personal rolling baselines `DaytimeStress.analyze(mode: .baselineRelative(hr:rmssd:))`
+// scores today's waking hours against.
+//
+// `.baselineRelative` (see DaytimeStress.ScoringMode) is deliberately caller-fed: the scorer takes a
+// finished `BaselineState` and never fetches history itself. This file is that missing caller — it
+// computes ONE daytime aggregate per past day and folds the ordered series through the SAME
+// Winsorized-EWMA machinery (`Baselines.foldHistory`) the nightly resting-HR / HRV baselines use, with
+// the daytime-specific `Baselines.daytimeHRCfg` / `daytimeRMSSDCfg` configs.
+//
+// The per-day aggregate is defined in terms of EXACTLY the hourly means the scorer references: it reuses
+// `DaytimeStress`'s own `floorDiv` / `bucketSeconds` / `isWakingHour` / `minHourHRSamples` /
+// `HRVAnalyzer` so "the value we fold into the baseline" and "the value we later z-score against that
+// baseline" are the same quantity, never two drifting definitions.
+
+public extension DaytimeStress {
+
+    // MARK: - Per-day daytime aggregate
+
+    /// Percentile of a day's waking-hour mean HRs used as that day's daytime-HR aggregate: the 10th,
+    /// i.e. the CALM FLOOR ("how low does my HR run when I'm calm and awake"). VALIDATED — this is the
+    /// ~65 bpm pooled figure from the 26-day Oura-reference correlation behind
+    /// `baselineRelativeHighMarginBPM`. It is intentionally the floor (not the median) because the HR
+    /// term pairs it with a FIXED bpm margin (a large effective spread via `marginToSigma`), so anchoring
+    /// at the floor makes "floor + margin" the exact HIGH cutoff.
+    static let daytimeHRAggregatePercentile: Double = 0.10
+
+    /// Percentile of a day's waking-hour RMSSDs used as that day's daytime-RMSSD aggregate: the 50th
+    /// (MEDIAN / typical), NOT the symmetric calm-ceiling percentile. The asymmetry with HR above is
+    /// deliberate and load-bearing: the RMSSD term is scaled by the person's OWN spread
+    /// (`Baselines.sigma`), not a fixed margin, so `(baseline − hourRMSSD) / σ` is only meaningful when
+    /// `baseline` is the TYPICAL daytime RMSSD — then a typical hour reads neutral and only genuine HRV
+    /// suppression reads stressed. Anchoring at a calm-ceiling percentile (the direct mirror of HR's
+    /// floor) would make an ordinary median hour sit ~1–2σ "below baseline" and stack a large false
+    /// stress term on top of the HR term. TUNING SEAM: like every RMSSD figure in this mode, the median
+    /// choice is a first pass pending an HR+HRV validation pass (the validated study was HR-only).
+    static let daytimeRMSSDAggregatePercentile: Double = 0.50
+
+    /// One local day's waking HR + R-R streams, the input to the daytime-baseline fold. `hr`/`rr` carry
+    /// wall-clock `ts`; `tzOffsetSeconds` (seconds east of UTC for THAT day) places them on the local
+    /// clock exactly as `analyze`'s `tzOffsetSeconds` does, so DST-varying days can each carry their own
+    /// offset.
+    ///
+    /// Not `Sendable`: `HRSample` / `RRInterval` (WhoopProtocol) aren't `Sendable`, and this is a plain
+    /// pure-function input built and consumed within one context — it is never sent across actors.
+    struct DaytimeDayStreams: Equatable {
+        public let hr: [HRSample]
+        public let rr: [RRInterval]
+        public let tzOffsetSeconds: Int
+        public init(hr: [HRSample], rr: [RRInterval], tzOffsetSeconds: Int) {
+            self.hr = hr; self.rr = rr; self.tzOffsetSeconds = tzOffsetSeconds
+        }
+    }
+
+    /// One day's daytime aggregates, computed with the SCORER's own hourly bucketing so the folded value
+    /// matches what `.baselineRelative` later references:
+    ///   - `hr`: the `daytimeHRAggregatePercentile` (P10) of the day's WAKING-hour mean HRs, where each
+    ///     hour's mean HR is gated at `minHourHRSamples` exactly like the scorer (a sparse/imported day
+    ///     whose hours never clear the gate yields `nil` — it contributes no daytime-HR floor, honestly).
+    ///   - `rmssd`: the `daytimeRMSSDAggregatePercentile` (P50) of the day's WAKING-hour RMSSDs, each run
+    ///     through the same `HRVAnalyzer.analyze(rawRR:)` cleaner the scorer uses (so ectopic beats can't
+    ///     fabricate variability); `nil` when no waking hour had enough clean R-R (e.g. an HR-only day).
+    /// Either field is `nil` independently. Bucketing keys off the HR buckets (like the scorer), so an
+    /// hour with R-R but no HR contributes neither.
+    static func dayDaytimeAggregate(hr: [HRSample], rr: [RRInterval],
+                                    tzOffsetSeconds: Int) -> (hr: Double?, rmssd: Double?) {
+        guard !hr.isEmpty else { return (nil, nil) }
+
+        // Bucket HR + R-R into LOCAL hour-of-day buckets, byte-for-byte the scorer's step 1.
+        var hrByBucket: [Int: [Double]] = [:]
+        for s in hr {
+            let local = s.ts + tzOffsetSeconds
+            let bucket = floorDiv(local, bucketSeconds) * bucketSeconds
+            hrByBucket[bucket, default: []].append(Double(s.bpm))
+        }
+        var rrByBucket: [Int: [Double]] = [:]
+        for s in rr {
+            let local = s.ts + tzOffsetSeconds
+            let bucket = floorDiv(local, bucketSeconds) * bucketSeconds
+            rrByBucket[bucket, default: []].append(Double(s.rrMs))
+        }
+
+        // Per WAKING hour: the gated mean HR + the cleaned RMSSD, mirroring the scorer's step 2 + waking
+        // filter. Keyed off HR buckets so an R-R-only hour is ignored exactly as the scorer ignores it.
+        var wakingMeanHRs: [Double] = []
+        var wakingRMSSDs: [Double] = []
+        for (bucket, hrs) in hrByBucket where isWakingHour(bucket) {
+            if hrs.count >= minHourHRSamples, let m = mean(hrs) { wakingMeanHRs.append(m) }
+            if let rmssd = HRVAnalyzer.analyze(rawRR: rrByBucket[bucket] ?? []).rmssd {
+                wakingRMSSDs.append(rmssd)
+            }
+        }
+
+        let hrAgg = wakingMeanHRs.isEmpty
+            ? nil : quantile(wakingMeanHRs.sorted(), daytimeHRAggregatePercentile)
+        let rmssdAgg = wakingRMSSDs.isEmpty
+            ? nil : quantile(wakingRMSSDs.sorted(), daytimeRMSSDAggregatePercentile)
+        return (hrAgg, rmssdAgg)
+    }
+
+    // MARK: - Fold the trailing history into personal baselines
+
+    /// Fold a person's trailing per-day daytime streams (OLDEST → NEWEST, TODAY EXCLUDED — today is the
+    /// day being scored, not part of its own baseline) into the personal baselines `.baselineRelative`
+    /// consumes.
+    ///
+    /// Each day contributes one `dayDaytimeAggregate`; the ordered series is replayed through
+    /// `Baselines.foldHistory` (the identical Winsorized-EWMA path as the nightly baselines) with
+    /// `daytimeHRCfg` / `daytimeRMSSDCfg`. `nil` aggregates (sparse/HR-only days) become skip-and-hold
+    /// nights, exactly like a missing nightly value.
+    ///
+    /// The HR baseline is always returned (it may be `.calibrating`; the caller checks `.usable` to
+    /// decide whether to use `.baselineRelative` at all). The RMSSD baseline is returned ONLY when it is
+    /// `.usable` (≥ `Baselines.minNightsSeed` days actually carried a daytime RMSSD); otherwise `nil`, so
+    /// the scorer honestly runs HR-only rather than z-scoring against a 1–2-day, untrustworthy HRV
+    /// baseline — the whole-baseline grain of the per-hour graceful-nil already in `rawScore`.
+    static func foldDaytimeBaselines(days: [DaytimeDayStreams]) -> (hr: BaselineState, rmssd: BaselineState?) {
+        var hrAggs: [Double?] = []
+        var rmssdAggs: [Double?] = []
+        hrAggs.reserveCapacity(days.count)
+        rmssdAggs.reserveCapacity(days.count)
+        for d in days {
+            let agg = dayDaytimeAggregate(hr: d.hr, rr: d.rr, tzOffsetSeconds: d.tzOffsetSeconds)
+            hrAggs.append(agg.hr)
+            rmssdAggs.append(agg.rmssd)
+        }
+        let hrState = Baselines.foldHistory(hrAggs, cfg: Baselines.daytimeHRCfg)
+        let rmssdState = Baselines.foldHistory(rmssdAggs, cfg: Baselines.daytimeRMSSDCfg)
+        return (hrState, rmssdState.usable ? rmssdState : nil)
+    }
+
+    /// The scoring mode to hand `analyze` for TODAY, decided from the trailing daytime `history`:
+    /// `.baselineRelative` once the personal HR baseline is `.usable` (≥ `Baselines.minNightsSeed` days
+    /// of real daytime HR aggregates — the Oura-style, validated-r≈0.6 path), else `.dayRelative` (the
+    /// unchanged default). This is the single graceful-degradation gate: a cold start, or a trailing
+    /// window that is all sparse/imported days, keeps EXACTLY today's pre-existing day-relative behaviour.
+    static func scoringMode(history days: [DaytimeDayStreams]) -> ScoringMode {
+        let baselines = foldDaytimeBaselines(days: days)
+        guard baselines.hr.usable else { return .dayRelative }
+        return .baselineRelative(hr: baselines.hr, rmssd: baselines.rmssd)
+    }
+}

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeStress.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeStress.swift
@@ -70,11 +70,35 @@ public enum DaytimeStress {
     /// away. Range ≥ 0.
     public static let postActivityShadowBPM: Double = 8.0
 
+    /// VALIDATED (26-day Oura-reference correlation, HR-only): a personal daytime-HR elevation
+    /// of ~15 bpm over a POOLED/ROLLING baseline — the 10th-percentile daytime HR pooled across
+    /// days, ~65 bpm in the reference set — is where elevated HR starts reading as
+    /// Oura-comparable "high" stress (r≈0.6 against Oura's own stress signal). A PER-DAY
+    /// (day-relative) baseline scored WORSE in the same comparison (r 0.43–0.53): an all-day
+    /// elevated day pulls its own floor up and masks the stress, which is exactly why
+    /// `.baselineRelative` leans on `Baselines`' cross-day rolling EWMA instead of a day-local
+    /// reference. TUNING SEAM: this is HR-only; HR+HRV (WHOOP-era, RMSSD included) is expected
+    /// to beat this r≈0.6 ceiling — re-validate this margin once that comparison exists. See
+    /// `marginToSigma` for how it's translated onto the shared 0–3 squash curve.
+    public static let baselineRelativeHighMarginBPM: Double = 15.0
+
     // MARK: - Scoring mode
 
     /// WHERE each hour's "calm" reference point + spread come from. Every other step —
     /// bucketing, the waking-hour filter, the squash curve, sustained-high, high-stress-minutes
     /// — is identical between modes; only the reference differs.
+    ///
+    /// Relationship to the rest of the Stress screen (StressView.swift): the DAILY 0–3 score
+    /// (`StressModel`) already compares last night's NIGHTLY resting-HR/HRV to a plain trailing
+    /// 30-day mean/SD, computed locally in StressView (not via `Baselines`) — that's a
+    /// once-a-day number from SLEEP vitals. The Advanced HRV card (`StressIndex`,
+    /// `HRVFreqDomain`) is a today-only descriptive lens with no baseline at all. `.baselineRelative`
+    /// is neither: it's an HOURLY breakdown of TODAY from DAYTIME/waking-hours HR+RMSSD against a
+    /// PERSONAL cross-day rolling baseline. Daytime HR runs warmer than nocturnal resting HR
+    /// (posture, thermic effect), so it needs its OWN baseline (`daytime_hr`/`daytime_rmssd`,
+    /// below) rather than reusing the nightly `resting_hr`/`hrv` configs — reusing the nightly
+    /// ones would systematically over-read stress. The three surfaces are complementary lenses
+    /// on the same underlying autonomic signal, not competing implementations of one baseline.
     public enum ScoringMode: Equatable, Sendable {
         /// DEFAULT — unchanged from before this mode existed. Each hour is z-scored against
         /// THIS DAY's own calm-hour reference (`calmReference`): the lower quartile of the
@@ -89,14 +113,23 @@ public enum DaytimeStress {
         /// resting-HR baselines elsewhere in the app, using `Baselines.metricCfg["daytime_hr"]`
         /// / `["daytime_rmssd"]` (see `Baselines.daytimeHRCfg` / `daytimeRMSSDCfg`). A caller
         /// builds `hr` (and, when it has the history, `rmssd`) by folding this person's past
-        /// daytime aggregates — e.g. day N's `calmReference` output — the same way the nightly
+        /// daytime aggregates — VALIDATED as each day's 10th-percentile daytime HR (a pooled
+        /// "how low does my HR run when I'm calm and awake" floor), the same way the nightly
         /// baselines are folded from past nights.
+        ///
+        /// The HR reference point is `hr.baseline`, but the HIGH-band threshold does NOT scale
+        /// with this person's own day-to-day `hr.spread` — see `baselineRelativeHighMarginBPM`:
+        /// the validated model is a roughly FIXED bpm margin over the personal floor, not a
+        /// variability-scaled one. `hr.spread` still rides along on the passed-in state for
+        /// other consumers; this mode simply doesn't read it for the HR term.
         ///
         /// `rmssd` is `nil` when no personal RMSSD baseline exists yet — e.g. an imported,
         /// Oura-era day with no R-R stream, so there is no history to fold one from. The
         /// stressor then honestly falls back to HR-only scoring for the whole read and flags
         /// `Result.hrOnlyFallback`; this mirrors the per-hour graceful-nil already in
-        /// `rawScore`, just at the whole-baseline grain instead of the single-hour grain.
+        /// `rawScore`, just at the whole-baseline grain instead of the single-hour grain. The
+        /// RMSSD term (when present) DOES still scale by `rmssd.spread` via `Baselines.sigma` —
+        /// only the HR term has a validated fixed-margin figure so far.
         case baselineRelative(hr: BaselineState, rmssd: BaselineState?)
     }
 
@@ -221,6 +254,19 @@ public enum DaytimeStress {
     static func squash(_ raw: Double) -> Double {
         let s = 3.0 / (1.0 + exp(-raw))
         return min(max(s, 0), 3)
+    }
+
+    /// Solve for the z-score spread `sd` such that a raw elevation of exactly `marginBPM` (or any
+    /// unit — this is unit-agnostic) squashes to exactly `band` on the shared 0–3 curve:
+    /// `band = 3 / (1 + e^(−marginBPM/sd))`. Used to translate `baselineRelativeHighMarginBPM`'s
+    /// validated bpm figure into the `sd` the shared `squash` curve expects, so "baseline +
+    /// margin" lands exactly on `band` by construction rather than by a second, separate
+    /// threshold check. Defensive fallback (never divides by zero/negative-log) if `band` is
+    /// ever configured at or outside the curve's open range (0, 3).
+    static func marginToSigma(marginBPM: Double, atBand band: Double) -> Double {
+        let ratio = 3.0 / band - 1.0
+        guard ratio > 0, marginBPM > 0 else { return max(marginBPM, 1e-9) }
+        return marginBPM / (-log(ratio))
     }
 
     // MARK: - Public API
@@ -383,13 +429,20 @@ public enum DaytimeStress {
         case .baselineRelative(let hrBaseline, let rmssdBaseline):
             // The PERSONAL cross-day baseline, folded by the caller from past daytime
             // aggregates via `Baselines.update`/`foldHistory` (see the `ScoringMode` doc).
-            // `sigma` is the SAME abs-dev-to-Gaussian-σ conversion `Baselines.deviation` uses.
             // Ambulatory hours are still masked out of the SCORE in step 4 (the motion gate),
             // but the reference itself is external, so it needs no ambulatory exclusion here.
             refHR = hrBaseline.baseline
-            sdHR = Baselines.sigma(hrBaseline)
+            // VALIDATED tuning, not `Baselines.sigma(hrBaseline)`: the correlation study behind
+            // `baselineRelativeHighMarginBPM` found a roughly FIXED bpm margin over the personal
+            // floor — not one scaled by this person's own day-to-day spread — best matched
+            // Oura's stress signal. `marginToSigma` solves for the sd that makes exactly
+            // `refHR + baselineRelativeHighMarginBPM` land on `highBandFloor` on the shared
+            // squash curve, so the validated margin IS the "high" cutoff by construction.
+            sdHR = Self.marginToSigma(marginBPM: baselineRelativeHighMarginBPM, atBand: highBandFloor)
             if let rmssdBaseline {
                 refRMSSD = rmssdBaseline.baseline
+                // No independently validated RMSSD margin yet (see the constant's doc) — this
+                // term still scales by the person's own spread via the shared σ conversion.
                 sdRMSSD = Baselines.sigma(rmssdBaseline)
                 hrOnlyFallback = false
             } else {

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeStress.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeStress.swift
@@ -82,6 +82,22 @@ public enum DaytimeStress {
     /// `marginToSigma` for how it's translated onto the shared 0–3 squash curve.
     public static let baselineRelativeHighMarginBPM: Double = 15.0
 
+    /// Gate for whether the personal daytime-RMSSD baseline feeds the live 0–3 score. `false`:
+    /// `.baselineRelative` scores HR-only, exactly the channel the r≈0.6 margin above was validated
+    /// on. The RMSSD half of the pipeline — `dayDaytimeAggregate`, `foldDaytimeBaselines`, the
+    /// `daytime_rmssd` config, and `rawScore`'s HRV term — is built and unit-tested, but stays OUT
+    /// of the live score until it has its OWN Oura-reference validation pass.
+    ///
+    /// WHY OFF (validated against real WHOOP data, 2026-07): daytime RMSSD off the wrist is
+    /// artifact-dominated — hourly values swing ~40→430 ms as posture / motion / talking break the
+    /// R-R stream, an order of magnitude noisier than the overnight recumbent HRV the nightly
+    /// baselines use. `rawScore` sums the HRV z EQUAL-WEIGHT with the HR z, so an artifact hour can
+    /// swing the combined score by ±3 (the full band) on noise alone. Enabling it before it is shown
+    /// to IMPROVE the correlation risks pushing the combined score BELOW the HR-only r≈0.6 ceiling —
+    /// the exact regression `baselineRelativeHighMarginBPM`'s comment warns against. Flip to `true`
+    /// only once daytime HR+RMSSD is validated to beat HR-only on an Oura-style stress reference.
+    public static let daytimeRMSSDScoringEnabled: Bool = false
+
     // MARK: - Scoring mode
 
     /// WHERE each hour's "calm" reference point + spread come from. Every other step —

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeStress.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeStress.swift
@@ -50,7 +50,8 @@ public enum DaytimeStress {
     // that was substantially ambulatory is MASKED (`level == nil`, `HourPoint.maskedForActivity ==
     // true`) rather than scored, and it is excluded from the calm reference and the coverage totals.
     // No gravity → no masking → byte-identical prior behaviour, so the gate only applies when motion
-    // is actually observable.
+    // is actually observable. Orthogonal to `ScoringMode` below: masking decides WHICH hours score,
+    // the mode decides WHAT reference they score against.
 
     /// An hour whose gravity-derived activity is ambulatory for at least this fraction of its records
     /// is EXERTION, not stress — masked, not scored. "Ambulatory" = a per-record activity intensity
@@ -68,6 +69,36 @@ public enum DaytimeStress {
     /// prior shadows) so a genuinely tense afternoon that happens to follow a workout is not masked
     /// away. Range ≥ 0.
     public static let postActivityShadowBPM: Double = 8.0
+
+    // MARK: - Scoring mode
+
+    /// WHERE each hour's "calm" reference point + spread come from. Every other step —
+    /// bucketing, the waking-hour filter, the squash curve, sustained-high, high-stress-minutes
+    /// — is identical between modes; only the reference differs.
+    public enum ScoringMode: Equatable, Sendable {
+        /// DEFAULT — unchanged from before this mode existed. Each hour is z-scored against
+        /// THIS DAY's own calm-hour reference (`calmReference`): the lower quartile of the
+        /// day's own waking-hour mean HR, the upper quartile of its own waking-hour RMSSD. No
+        /// personal history needed — the day is its own baseline. Byte-identical output to the
+        /// pre-existing single-mode `analyze` for the same hr/rr/tzOffsetSeconds.
+        case dayRelative
+
+        /// Oura-style — each hour is z-scored against the PERSONAL rolling baseline for daytime
+        /// HR (and, when available, daytime RMSSD): the SAME Winsorized-EWMA machinery
+        /// (`Baselines.update` / `Baselines.foldHistory`) that backs the nightly HRV /
+        /// resting-HR baselines elsewhere in the app, using `Baselines.metricCfg["daytime_hr"]`
+        /// / `["daytime_rmssd"]` (see `Baselines.daytimeHRCfg` / `daytimeRMSSDCfg`). A caller
+        /// builds `hr` (and, when it has the history, `rmssd`) by folding this person's past
+        /// daytime aggregates — e.g. day N's `calmReference` output — the same way the nightly
+        /// baselines are folded from past nights.
+        ///
+        /// `rmssd` is `nil` when no personal RMSSD baseline exists yet — e.g. an imported,
+        /// Oura-era day with no R-R stream, so there is no history to fold one from. The
+        /// stressor then honestly falls back to HR-only scoring for the whole read and flags
+        /// `Result.hrOnlyFallback`; this mirrors the per-hour graceful-nil already in
+        /// `rawScore`, just at the whole-baseline grain instead of the single-hour grain.
+        case baselineRelative(hr: BaselineState, rmssd: BaselineState?)
+    }
 
     // MARK: - Output
 
@@ -121,15 +152,31 @@ public enum DaytimeStress {
         /// ("N hours excluded — you were moving") instead of a silently short timeline. 0 when no
         /// gravity was supplied or nothing was masked; 0 for `.empty`.
         public let activityMaskedHours: Int
+        /// ADDITIVE — total minutes across SCORED waking hours at/above `highBandFloor`, the
+        /// Oura-comparable "time in high stress" figure. Each scored hour is one `bucketSeconds`
+        /// bucket, so this is `(# high-band scored hours) * bucketSeconds / 60`. Compare against
+        /// Oura's `stress_high_s / 60` — NOOP's timeline is hourly-grain vs Oura's ~5-minute
+        /// grain, so treat this as a coarse approximation, not a precise match. 0 for `.empty`
+        /// and for any day with no scored hours.
+        public let highStressMinutes: Int
+        /// ADDITIVE — true when `.baselineRelative` mode was requested but had no personal RMSSD
+        /// baseline to score against (e.g. an imported Oura-era day with no R-R history), so the
+        /// whole read honestly fell back to HR-only scoring. Always false in `.dayRelative` mode
+        /// (there, a missing RMSSD is already handled per-hour by `rawScore`, not flagged
+        /// day-wide) and false for `.empty`.
+        public let hrOnlyFallback: Bool
 
         public init(hours: [HourPoint], sustainedHigh: Bool, sustainedRun: Int,
-                    dayMean: Double?, peak: HourPoint?, activityMaskedHours: Int = 0) {
+                    dayMean: Double?, peak: HourPoint?, activityMaskedHours: Int = 0,
+                    highStressMinutes: Int = 0, hrOnlyFallback: Bool = false) {
             self.hours = hours
             self.sustainedHigh = sustainedHigh
             self.sustainedRun = sustainedRun
             self.dayMean = dayMean
             self.peak = peak
             self.activityMaskedHours = activityMaskedHours
+            self.highStressMinutes = highStressMinutes
+            self.hrOnlyFallback = hrOnlyFallback
         }
 
         /// The scored hours only (level non-nil), in time order.
@@ -137,7 +184,8 @@ public enum DaytimeStress {
 
         /// Empty read — used when the day had no usable intraday HR at all.
         public static let empty = Result(hours: [], sustainedHigh: false, sustainedRun: 0,
-                                         dayMean: nil, peak: nil, activityMaskedHours: 0)
+                                         dayMean: nil, peak: nil, activityMaskedHours: 0,
+                                         highStressMinutes: 0, hrOnlyFallback: false)
     }
 
     // MARK: - Shared stress math (identical formula to the daily StressModel)
@@ -187,14 +235,28 @@ public enum DaytimeStress {
     ///     present, ambulatory hours are masked out of the score (see the motion-gate constants).
     ///   - tzOffsetSeconds: seconds east of UTC, for placing each bucket on the LOCAL
     ///     clock (so "waking hours" and the hour labels are local). Defaults to UTC.
+    ///   - mode: `.dayRelative` (DEFAULT — unchanged existing behaviour) or
+    ///     `.baselineRelative` (Oura-style, vs a personal rolling baseline). ADDITIVE and
+    ///     opt-in: existing callers that don't pass `mode` keep the exact prior behaviour.
     ///
     /// Returns `.empty` when there isn't a single hour with enough HR to score.
     public static func analyze(hr: [HRSample], rr: [RRInterval],
                                gravity: [GravitySample] = [],
-                               tzOffsetSeconds: Int = 0) -> Result {
+                               tzOffsetSeconds: Int = 0,
+                               mode: ScoringMode = .dayRelative) -> Result {
         // v7.0.2 perf (#707): buckets the day's full HR + R-R streams into per-hour aggregates and runs an
         // RMSSD per hour — invoked from the Stress view, so a `body` re-evaluation re-buckets the whole day.
-        // Memoize on the streams' fingerprint + tz offset; result is a small `Result`, raw arrays not held.
+        // Memoize on the streams' fingerprint + tz offset + scoring mode; result is a small `Result`, raw
+        // arrays not held. The mode key folds in only (baseline, spread) for baseline-relative — the two
+        // fields that can change the score — not the whole BaselineState (nValid/status/etc. never do).
+        let modeKey: ModeKey
+        switch mode {
+        case .dayRelative:
+            modeKey = .dayRelative
+        case .baselineRelative(let hrBaseline, let rmssdBaseline):
+            modeKey = .baselineRelative(hrBaseline: hrBaseline.baseline, hrSpread: hrBaseline.spread,
+                                        rmssdBaseline: rmssdBaseline?.baseline, rmssdSpread: rmssdBaseline?.spread)
+        }
         let key = StressKey(
             hr: StreamFingerprint.of(hr, ts: { $0.ts }, quant: { Int($0.bpm) }),
             rr: StreamFingerprint.of(rr, ts: { $0.ts }, quant: { Int($0.rrMs) }),
@@ -204,20 +266,30 @@ public enum DaytimeStress {
                 Int(($0.x * 128).rounded()) &+ Int(($0.y * 128).rounded()) &* 257
                     &+ Int(($0.z * 128).rounded()) &* 66_049
             }),
-            tz: tzOffsetSeconds)
+            tz: tzOffsetSeconds, mode: modeKey)
         return analyzeCache.value(key) {
-            analyzeUncached(hr: hr, rr: rr, gravity: gravity, tzOffsetSeconds: tzOffsetSeconds)
+            analyzeUncached(hr: hr, rr: rr, gravity: gravity, tzOffsetSeconds: tzOffsetSeconds, mode: mode)
         }
     }
 
     private struct StressKey: Hashable {
-        let hr: StreamFingerprint; let rr: StreamFingerprint; let gravity: StreamFingerprint; let tz: Int
+        let hr: StreamFingerprint; let rr: StreamFingerprint; let gravity: StreamFingerprint
+        let tz: Int; let mode: ModeKey
     }
+
+    /// Hashable fingerprint of `ScoringMode` for the memo cache — `BaselineState` itself isn't
+    /// `Hashable`, and only its `baseline`/`spread` can change the score, so those are what get
+    /// folded in (see the `analyze` doc above).
+    private enum ModeKey: Hashable {
+        case dayRelative
+        case baselineRelative(hrBaseline: Double, hrSpread: Double, rmssdBaseline: Double?, rmssdSpread: Double?)
+    }
+
     private static let analyzeCache = AnalyticsMemoCache<StressKey, Result>(capacity: 8)
 
     private static func analyzeUncached(hr: [HRSample], rr: [RRInterval],
                                         gravity: [GravitySample],
-                                        tzOffsetSeconds: Int) -> Result {
+                                        tzOffsetSeconds: Int, mode: ScoringMode) -> Result {
         guard !hr.isEmpty else { return .empty }
 
         // 1) Bucket HR + R-R into LOCAL hour-of-day buckets, keyed by the bucket start
@@ -273,28 +345,63 @@ public enum DaytimeStress {
             (activeFracByBucket[bucket] ?? 0) >= activityMaskFraction
         }
 
-        // 3) The day's OWN quiet reference: centre on the CALM end (the lower quartile of
-        //    hourly mean HR, the upper quartile of hourly RMSSD), and spread from the
-        //    across-hour SD. This makes a flat day read ~baseline and a spiky day surface
-        //    its tense hours — without any cross-day history. Falls back to the plain mean
-        //    when there are too few scored hours for a quartile.
-        //
-        //    Built from the WAKING hours only — the same hours scored in step 4. Sleep is the
-        //    calmest, lowest-HR / highest-HRV stretch of the day, and the analysis window
-        //    always begins at local midnight, so the current day routinely carries several
-        //    hours of it. Letting those night hours into the reference drags the "calm" anchor
-        //    far beneath every waking hour, inflating an ordinary calm day toward HIGH and
-        //    falsely tripping the sustained-high Breathe nudge.
-        //    Ambulatory hours are excluded from the day's OWN calm reference too: an exertion hour's
-        //    elevated HR / suppressed HRV must not pull the calm anchor up or inflate the across-hour
-        //    spread the z-scores divide by.
-        let referenceAggs = aggs.filter { isWakingHour($0.bucket) && !isAmbulatory($0.bucket) }
-        let hrMeans = referenceAggs.compactMap { $0.meanHR }
-        let rmssdVals = referenceAggs.compactMap { $0.rmssd }
-        let refHR = calmReference(hrMeans, calmIsLow: true)         // calm HR is LOW
-        let refRMSSD = calmReference(rmssdVals, calmIsLow: false)   // calm HRV is HIGH
-        let sdHR = std(hrMeans, mean: mean(hrMeans))
-        let sdRMSSD = std(rmssdVals, mean: mean(rmssdVals))
+        // 3) The reference point + spread for each signal — WHERE they come from depends on
+        //    `mode`. Every other step (bucketing above incl. the motion gate, the waking-hour
+        //    filter, the squash curve, sustained-high, high-stress-minutes below) is identical
+        //    between modes; only the reference differs.
+        let refHR: Double?
+        let sdHR: Double
+        let refRMSSD: Double?
+        let sdRMSSD: Double
+        let hrOnlyFallback: Bool
+        switch mode {
+        case .dayRelative:
+            // The day's OWN quiet reference: centre on the CALM end (the lower quartile of
+            // hourly mean HR, the upper quartile of hourly RMSSD), and spread from the
+            // across-hour SD. This makes a flat day read ~baseline and a spiky day surface
+            // its tense hours — without any cross-day history. Falls back to the plain mean
+            // when there are too few scored hours for a quartile.
+            //
+            // Built from the WAKING hours only — the same hours scored in step 4. Sleep is the
+            // calmest, lowest-HR / highest-HRV stretch of the day, and the analysis window
+            // always begins at local midnight, so the current day routinely carries several
+            // hours of it. Letting those night hours into the reference drags the "calm" anchor
+            // far beneath every waking hour, inflating an ordinary calm day toward HIGH and
+            // falsely tripping the sustained-high Breathe nudge.
+            // Ambulatory hours are excluded from the day's OWN calm reference too (the motion
+            // gate): an exertion hour's elevated HR / suppressed HRV must not pull the calm
+            // anchor up or inflate the across-hour spread the z-scores divide by.
+            let referenceAggs = aggs.filter { isWakingHour($0.bucket) && !isAmbulatory($0.bucket) }
+            let hrMeans = referenceAggs.compactMap { $0.meanHR }
+            let rmssdVals = referenceAggs.compactMap { $0.rmssd }
+            refHR = calmReference(hrMeans, calmIsLow: true)         // calm HR is LOW
+            refRMSSD = calmReference(rmssdVals, calmIsLow: false)   // calm HRV is HIGH
+            sdHR = std(hrMeans, mean: mean(hrMeans))
+            sdRMSSD = std(rmssdVals, mean: mean(rmssdVals))
+            hrOnlyFallback = false
+
+        case .baselineRelative(let hrBaseline, let rmssdBaseline):
+            // The PERSONAL cross-day baseline, folded by the caller from past daytime
+            // aggregates via `Baselines.update`/`foldHistory` (see the `ScoringMode` doc).
+            // `sigma` is the SAME abs-dev-to-Gaussian-σ conversion `Baselines.deviation` uses.
+            // Ambulatory hours are still masked out of the SCORE in step 4 (the motion gate),
+            // but the reference itself is external, so it needs no ambulatory exclusion here.
+            refHR = hrBaseline.baseline
+            sdHR = Baselines.sigma(hrBaseline)
+            if let rmssdBaseline {
+                refRMSSD = rmssdBaseline.baseline
+                sdRMSSD = Baselines.sigma(rmssdBaseline)
+                hrOnlyFallback = false
+            } else {
+                // No personal RMSSD baseline exists (e.g. an Oura-era day with no R-R history to
+                // fold one from). `rawScore` already treats a nil meanRMSSD as "skip this term",
+                // so passing nil here gracefully degrades to HR-only scoring — flagged honestly
+                // in the output rather than silently.
+                refRMSSD = nil
+                sdRMSSD = 0
+                hrOnlyFallback = true
+            }
+        }
 
         // 4) Score each waking-hour bucket on the shared 0–3 curve.
         var points: [HourPoint] = []
@@ -328,10 +435,13 @@ public enum DaytimeStress {
         let scored = points.compactMap { p -> (HourPoint, Double)? in p.level.map { (p, $0) } }
         guard !scored.isEmpty else {
             // No scorable waking hour — still return the (unscored) timeline so the UI can
-            // show "not enough data" rather than nothing.
+            // show "not enough data" rather than nothing. `hrOnlyFallback` is a MODE property
+            // (whether a personal RMSSD baseline existed to score against), so it's still worth
+            // reporting even though nothing ended up scored.
             return points.isEmpty ? .empty
                 : Result(hours: points, sustainedHigh: false, sustainedRun: 0,
-                         dayMean: nil, peak: nil, activityMaskedHours: activityMaskedHours)
+                         dayMean: nil, peak: nil, activityMaskedHours: activityMaskedHours,
+                         highStressMinutes: 0, hrOnlyFallback: hrOnlyFallback)
         }
 
         // 5) Sustained-high flag: walk back from the latest SCORED hour while each is HIGH.
@@ -344,8 +454,15 @@ public enum DaytimeStress {
         let dayMean = mean(scored.map { $0.1 })
         let peak = scored.max { $0.1 < $1.1 }?.0
 
+        // 6) Oura-comparable "time in high stress": each scored hour at/above `highBandFloor`
+        //    is one full `bucketSeconds` bucket, converted to minutes. Uses the SAME threshold
+        //    `StressBand.high` (StressView) and the sustained-high check above already use, so
+        //    all three stay in lockstep by construction.
+        let highStressMinutes = scored.filter { $0.1 >= highBandFloor }.count * (bucketSeconds / 60)
+
         return Result(hours: points, sustainedHigh: sustained, sustainedRun: run,
-                      dayMean: dayMean, peak: peak, activityMaskedHours: activityMaskedHours)
+                      dayMean: dayMean, peak: peak, activityMaskedHours: activityMaskedHours,
+                      highStressMinutes: highStressMinutes, hrOnlyFallback: hrOnlyFallback)
     }
 
     // MARK: - Helpers

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BaselinesTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BaselinesTests.swift
@@ -328,4 +328,26 @@ final class BaselinesTests: XCTestCase {
         let hardDay = Baselines.deviation(85.0, state: s)
         XCTAssertGreaterThan(hardDay.z, 0, "a much-harder-than-normal day must read ABOVE the effort baseline")
     }
+
+    // MARK: - sigma() + daytime configs (DaytimeStress baseline-relative mode)
+
+    /// `sigma(_:)` is a pure extraction of `deviation()`'s internal conversion — must match it
+    /// exactly and stay internally consistent (deviation at baseline + sigma is z == 1.0).
+    func testSigmaMatchesDeviationsInternalConversion() {
+        let s = Baselines.foldHistory(Array(repeating: 50.0, count: 14), cfg: Baselines.hrvCfg)
+        let sigma = Baselines.sigma(s)
+        XCTAssertEqual(sigma, max(1.253 * s.spread, 1e-9), accuracy: 1e-9)
+        let dev = Baselines.deviation(s.baseline + sigma, state: s)
+        XCTAssertEqual(dev.z, 1.0, accuracy: 1e-6)
+    }
+
+    /// The new daytime_hr / daytime_rmssd configs exist, are reachable via both the dictionary
+    /// and the convenience accessor, and are distinct from the nightly resting_hr/hrv configs
+    /// they sit alongside (different bounds/floor — daytime HR runs warmer than nocturnal RHR).
+    func testDaytimeConfigsExistAndAreDistinctFromNightlyConfigs() {
+        XCTAssertEqual(Baselines.metricCfg["daytime_hr"], Baselines.daytimeHRCfg)
+        XCTAssertEqual(Baselines.metricCfg["daytime_rmssd"], Baselines.daytimeRMSSDCfg)
+        XCTAssertNotEqual(Baselines.daytimeHRCfg, Baselines.restingHRCfg)
+        XCTAssertNotEqual(Baselines.daytimeRMSSDCfg, Baselines.hrvCfg)
+    }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeBaselinesTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeBaselinesTests.swift
@@ -187,11 +187,14 @@ final class DaytimeBaselinesTests: XCTestCase {
             DaytimeStress.DaytimeDayStreams(hr: flatDayHR($0, bpm: 65),
                                             rr: flatDayRR($0, rrMs: 900, jitter: 40), tzOffsetSeconds: 0)
         }
-        let mode = DaytimeStress.scoringMode(history: history)
-        guard case let .baselineRelative(_, rmssd) = mode else {
-            return XCTFail("expected baseline-relative with an RMSSD baseline")
-        }
-        XCTAssertNotNil(rmssd, "20 days of daytime R-R should yield a usable RMSSD baseline")
+        // Build the RMSSD-active mode DIRECTLY from the fold, bypassing the `scoringMode` gate that
+        // holds RMSSD out of LIVE scoring until validated (`DaytimeStress.daytimeRMSSDScoringEnabled`
+        // is false). This test pins the anti-stacking guarantee of the RMSSD-active scoring path
+        // itself, so it must exercise that path regardless of the production gate. `scoringMode`'s
+        // own gating is covered by `testScoringModeHoldsRMSSDOutOfLiveScoreWhileGated` below.
+        let baselines = DaytimeStress.foldDaytimeBaselines(days: history)
+        XCTAssertNotNil(baselines.rmssd, "20 days of daytime R-R should yield a usable RMSSD baseline")
+        let mode = DaytimeStress.ScoringMode.baselineRelative(hr: baselines.hr, rmssd: baselines.rmssd)
 
         // Today: HR at the floor, HRV at the SAME typical variability as history.
         let today = flatDayHR(0, bpm: 65)
@@ -202,6 +205,30 @@ final class DaytimeBaselinesTests: XCTestCase {
         for p in r.scored {
             XCTAssertLessThan(p.level!, DaytimeStress.highBandFloor,
                 "a normal hour with an RMSSD baseline must not stack into the HIGH band")
+        }
+    }
+
+    func testScoringModeHoldsRMSSDOutOfLiveScoreWhileGated() {
+        // The live-scoring gate: even with a full daytime-RR history that folds a USABLE RMSSD
+        // baseline, `scoringMode` (the production entry point) keeps RMSSD OUT of the mode while
+        // `DaytimeStress.daytimeRMSSDScoringEnabled` is false — so production scores HR-only, the
+        // validated r≈0.6 channel. The fold still produces the usable baseline (the machinery is
+        // live + tested); only its arrival at the score is gated. Flip the flag → this expectation
+        // inverts, which is the intended tripwire for when RMSSD is validated on.
+        let history = (0..<20).map {
+            DaytimeStress.DaytimeDayStreams(hr: flatDayHR($0, bpm: 65),
+                                            rr: flatDayRR($0, rrMs: 900, jitter: 40), tzOffsetSeconds: 0)
+        }
+        XCTAssertNotNil(DaytimeStress.foldDaytimeBaselines(days: history).rmssd,
+                        "precondition: the history must fold a usable RMSSD baseline")
+        guard case let .baselineRelative(hr, rmssd) = DaytimeStress.scoringMode(history: history) else {
+            return XCTFail("usable HR history must still select .baselineRelative")
+        }
+        XCTAssertTrue(hr.usable, "HR baseline still drives the mode")
+        if DaytimeStress.daytimeRMSSDScoringEnabled {
+            XCTAssertNotNil(rmssd, "flag on: the usable RMSSD baseline should reach live scoring")
+        } else {
+            XCTAssertNil(rmssd, "flag off: RMSSD is held out of the live score despite a usable baseline")
         }
     }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeBaselinesTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeBaselinesTests.swift
@@ -1,0 +1,207 @@
+import XCTest
+@testable import StrandAnalytics
+import WhoopProtocol
+
+/// Coverage for the CALLER-side daytime-baseline fold (DaytimeBaselines.swift) that feeds
+/// `DaytimeStress.analyze(mode: .baselineRelative(hr:rmssd:))`: the per-day aggregate definition, the
+/// trailing-history fold, the graceful-degradation `scoringMode` gate, and the fold→score round trip.
+final class DaytimeBaselinesTests: XCTestCase {
+
+    // MARK: - Fixtures (multi-day: day `d` is offset by d·86 400 s; local hour-of-day is preserved)
+
+    /// One local day of HR: every hour in `hours` filled with `n` 1 Hz samples at a per-hour bpm.
+    /// `bpms` maps to `hours` in order. tz offset 0, so local hour-of-day == wall-clock hour.
+    private func dayHR(_ dayIndex: Int, hours: [Int], bpms: [Int],
+                       n: Int = DaytimeStress.minHourHRSamples) -> [HRSample] {
+        let dayBase = dayIndex * 86_400
+        var out: [HRSample] = []
+        for (h, bpm) in zip(hours, bpms) {
+            let base = dayBase + h * 3_600
+            out += (0..<n).map { HRSample(ts: base + $0, bpm: bpm) }
+        }
+        return out
+    }
+
+    /// One local day flat at a single bpm across waking hours 8…17 (ten scored hours).
+    private func flatDayHR(_ dayIndex: Int, bpm: Int) -> [HRSample] {
+        dayHR(dayIndex, hours: Array(8...17), bpms: Array(repeating: bpm, count: 10))
+    }
+
+    /// R-R for one local hour with a controllable beat-to-beat jitter (drives RMSSD).
+    private func hourRR(_ dayIndex: Int, hour: Int, rrMs: Int, jitter: Int, n: Int = 120) -> [RRInterval] {
+        let base = dayIndex * 86_400 + hour * 3_600
+        return (0..<n).map { RRInterval(ts: base + $0 * 30, rrMs: rrMs + ($0 % 2 == 0 ? jitter : -jitter)) }
+    }
+
+    private func flatDayRR(_ dayIndex: Int, rrMs: Int, jitter: Int) -> [RRInterval] {
+        (8...17).flatMap { hourRR(dayIndex, hour: $0, rrMs: rrMs, jitter: jitter) }
+    }
+
+    // MARK: - Per-day aggregate
+
+    func testDayHRAggregateIsTheTenthPercentileOfWakingHourMeanHRs() {
+        // Ten waking hours (08…17) with a spread of constant per-hour HRs; each hour's MEAN HR is just
+        // its bpm. P10 of [60,62,64,66,68,70,72,74,76,78] via the shared linear-interp quantile is
+        // 60 + 0.9·(62−60) = 61.8 — the calm floor, well below the day's median.
+        let bpms = [60, 62, 64, 66, 68, 70, 72, 74, 76, 78]
+        let hr = dayHR(0, hours: Array(8...17), bpms: bpms)
+        let agg = DaytimeStress.dayDaytimeAggregate(hr: hr, rr: [], tzOffsetSeconds: 0)
+        XCTAssertNotNil(agg.hr)
+        XCTAssertEqual(agg.hr!, 61.8, accuracy: 1e-6)
+        XCTAssertNil(agg.rmssd, "no R-R → no daytime RMSSD aggregate")
+    }
+
+    func testDayHRAggregateAppliesTheSameMinSamplesGateAsTheScorer() {
+        // An under-gate sparse hour at a very low bpm must NOT drag the P10 floor down — the scorer would
+        // never score it, so the aggregate must not reference it either.
+        let dense = dayHR(0, hours: Array(8...17), bpms: [60, 62, 64, 66, 68, 70, 72, 74, 76, 78])
+        let sparse = dayHR(0, hours: [7], bpms: [40], n: DaytimeStress.minHourHRSamples - 1)
+        let withSparse = DaytimeStress.dayDaytimeAggregate(hr: dense + sparse, rr: [], tzOffsetSeconds: 0)
+        let denseOnly = DaytimeStress.dayDaytimeAggregate(hr: dense, rr: [], tzOffsetSeconds: 0)
+        XCTAssertEqual(withSparse.hr!, denseOnly.hr!, accuracy: 1e-9,
+            "a below-gate hour leaked into the daytime-HR floor")
+    }
+
+    func testDayHRAggregateExcludesNonWakingHours() {
+        // A very low 03:00 hour (outside 06:00–22:00) must not become the calm floor.
+        let waking = dayHR(0, hours: Array(8...17), bpms: [60, 62, 64, 66, 68, 70, 72, 74, 76, 78])
+        let night = dayHR(0, hours: [3], bpms: [45])
+        let withNight = DaytimeStress.dayDaytimeAggregate(hr: waking + night, rr: [], tzOffsetSeconds: 0)
+        XCTAssertEqual(withNight.hr!, 61.8, accuracy: 1e-6,
+            "a non-waking hour leaked into the daytime-HR floor")
+    }
+
+    func testDayRMSSDAggregateIsPresentWithRRAndTracksVariability() {
+        // A relaxed day (high jitter → high RMSSD) vs a suppressed day (low jitter → low RMSSD): both
+        // produce a non-nil median RMSSD aggregate, and the relaxed day's is clearly higher.
+        let hr = flatDayHR(0, bpm: 65)
+        let relaxed = DaytimeStress.dayDaytimeAggregate(hr: hr, rr: flatDayRR(0, rrMs: 900, jitter: 45),
+                                                        tzOffsetSeconds: 0)
+        let suppressed = DaytimeStress.dayDaytimeAggregate(hr: hr, rr: flatDayRR(0, rrMs: 900, jitter: 5),
+                                                           tzOffsetSeconds: 0)
+        XCTAssertNotNil(relaxed.rmssd)
+        XCTAssertNotNil(suppressed.rmssd)
+        XCTAssertGreaterThan(relaxed.rmssd!, suppressed.rmssd!,
+            "the higher-variability day should carry a higher median daytime RMSSD")
+    }
+
+    // MARK: - Fold trailing history
+
+    func testFoldConvergesHRBaselineToThePersonalDaytimeFloor() {
+        // Twelve identical days whose P10 daytime HR is exactly 65 → the EWMA center converges to 65 and
+        // the baseline is usable (12 ≥ minNightsSeed). No R-R anywhere → RMSSD baseline is nil.
+        let days = (0..<12).map { DaytimeStress.DaytimeDayStreams(hr: flatDayHR($0, bpm: 65), rr: [],
+                                                                  tzOffsetSeconds: 0) }
+        let b = DaytimeStress.foldDaytimeBaselines(days: days)
+        XCTAssertEqual(b.hr.baseline, 65.0, accuracy: 1e-6)
+        XCTAssertTrue(b.hr.usable)
+        XCTAssertNil(b.rmssd, "no daytime R-R history → HR-only baseline")
+    }
+
+    func testFoldReturnsRMSSDBaselineOnlyWhenEnoughDaytimeRRDays() {
+        // Two days of R-R is below minNightsSeed → RMSSD baseline withheld (nil → HR-only). Eight days
+        // clears the seed → a usable RMSSD baseline is returned.
+        let twoDays = (0..<2).map {
+            DaytimeStress.DaytimeDayStreams(hr: flatDayHR($0, bpm: 65),
+                                            rr: flatDayRR($0, rrMs: 900, jitter: 40), tzOffsetSeconds: 0)
+        }
+        XCTAssertNil(DaytimeStress.foldDaytimeBaselines(days: twoDays).rmssd,
+            "an untrustworthy 2-day RMSSD baseline must be withheld")
+
+        let eightDays = (0..<8).map {
+            DaytimeStress.DaytimeDayStreams(hr: flatDayHR($0, bpm: 65),
+                                            rr: flatDayRR($0, rrMs: 900, jitter: 40), tzOffsetSeconds: 0)
+        }
+        let rmssd = DaytimeStress.foldDaytimeBaselines(days: eightDays).rmssd
+        XCTAssertNotNil(rmssd, "eight days of daytime R-R should yield a usable RMSSD baseline")
+        XCTAssertTrue(rmssd!.usable)
+    }
+
+    // MARK: - scoringMode graceful degradation
+
+    func testScoringModeFallsBackToDayRelativeOnColdStartAndSparseHistory() {
+        // No history → day-relative (cold start unchanged).
+        guard case .dayRelative = DaytimeStress.scoringMode(history: []) else {
+            return XCTFail("empty history must fall back to .dayRelative")
+        }
+        // Three days is below minNightsSeed → still day-relative.
+        let threeDays = (0..<3).map { DaytimeStress.DaytimeDayStreams(hr: flatDayHR($0, bpm: 65), rr: [],
+                                                                      tzOffsetSeconds: 0) }
+        guard case .dayRelative = DaytimeStress.scoringMode(history: threeDays) else {
+            return XCTFail("sub-seed history must fall back to .dayRelative")
+        }
+    }
+
+    func testScoringModeUsesBaselineRelativeOnceHistoryIsUsable() {
+        // Six days of real daytime HR clears the seed → the Oura-style baseline-relative mode, carrying
+        // the folded HR baseline (~65) and a nil RMSSD baseline (no R-R history here).
+        let days = (0..<6).map { DaytimeStress.DaytimeDayStreams(hr: flatDayHR($0, bpm: 65), rr: [],
+                                                                 tzOffsetSeconds: 0) }
+        guard case let .baselineRelative(hr, rmssd) = DaytimeStress.scoringMode(history: days) else {
+            return XCTFail("usable history must select .baselineRelative")
+        }
+        XCTAssertEqual(hr.baseline, 65.0, accuracy: 1e-6)
+        XCTAssertNil(rmssd)
+    }
+
+    // MARK: - Fold → score round trip (the whole point)
+
+    func testFoldedBaselineScoresElevationAgainstThePersonalFloorNotTheDaysOwnHours() {
+        // Personal floor folded from history = 65 bpm. TODAY is elevated ALL day (every waking hour 80 =
+        // 65 + the validated 15 bpm margin). A DAY-relative read would anchor on the day's OWN hours and
+        // miss an all-day-high day; the baseline-relative read scores it against the personal 65 floor,
+        // so every hour lands at/above the HIGH band and the day logs high-stress minutes.
+        let history = (0..<20).map { DaytimeStress.DaytimeDayStreams(hr: flatDayHR($0, bpm: 65), rr: [],
+                                                                     tzOffsetSeconds: 0) }
+        let mode = DaytimeStress.scoringMode(history: history)
+        guard case .baselineRelative = mode else { return XCTFail("expected baseline-relative") }
+
+        let today = flatDayHR(0, bpm: 80)
+        let r = DaytimeStress.analyze(hr: today, rr: [], tzOffsetSeconds: 0, mode: mode)
+        XCTAssertFalse(r.scored.isEmpty)
+        XCTAssertTrue(r.hrOnlyFallback, "no RMSSD baseline → HR-only, honestly flagged")
+        XCTAssertGreaterThan(r.highStressMinutes, 0, "an all-day-elevated day must log high-stress time")
+        for p in r.scored {
+            XCTAssertGreaterThanOrEqual(p.level!, DaytimeStress.highBandFloor - 0.05,
+                "80 bpm is the personal floor + the validated 15 bpm margin → the HIGH band")
+        }
+    }
+
+    func testFoldedBaselineCalmDayAtThePersonalFloorReadsNeutralNotHigh() {
+        // TODAY sits exactly at the personal 65 floor all day → each hour reads ~1.5 (neutral), never
+        // high. Guards the calm end of the scale end-to-end through the fold.
+        let history = (0..<20).map { DaytimeStress.DaytimeDayStreams(hr: flatDayHR($0, bpm: 65), rr: [],
+                                                                     tzOffsetSeconds: 0) }
+        let mode = DaytimeStress.scoringMode(history: history)
+        let r = DaytimeStress.analyze(hr: flatDayHR(0, bpm: 65), rr: [], tzOffsetSeconds: 0, mode: mode)
+        XCTAssertEqual(r.highStressMinutes, 0)
+        for p in r.scored { XCTAssertEqual(p.level!, 1.5, accuracy: 0.05) }
+    }
+
+    func testMedianRMSSDBaselineKeepsANormalHourNeutralNoStacking() {
+        // The anti-stacking guarantee behind anchoring the RMSSD aggregate at the MEDIAN (not a calm
+        // ceiling): with BOTH a HR baseline (65) and an RMSSD baseline folded from history, a TODAY that
+        // sits at the HR floor AND at its typical daytime HRV must stay out of the HIGH band. A ceiling
+        // anchor would make this ordinary hour read ~1–2σ "below baseline" and stack a false stress term.
+        let history = (0..<20).map {
+            DaytimeStress.DaytimeDayStreams(hr: flatDayHR($0, bpm: 65),
+                                            rr: flatDayRR($0, rrMs: 900, jitter: 40), tzOffsetSeconds: 0)
+        }
+        let mode = DaytimeStress.scoringMode(history: history)
+        guard case let .baselineRelative(_, rmssd) = mode else {
+            return XCTFail("expected baseline-relative with an RMSSD baseline")
+        }
+        XCTAssertNotNil(rmssd, "20 days of daytime R-R should yield a usable RMSSD baseline")
+
+        // Today: HR at the floor, HRV at the SAME typical variability as history.
+        let today = flatDayHR(0, bpm: 65)
+        let todayRR = flatDayRR(0, rrMs: 900, jitter: 40)
+        let r = DaytimeStress.analyze(hr: today, rr: todayRR, tzOffsetSeconds: 0, mode: mode)
+        XCTAssertFalse(r.hrOnlyFallback, "an RMSSD baseline was supplied")
+        XCTAssertEqual(r.highStressMinutes, 0, "a typical HR+HRV day must not read as high stress")
+        for p in r.scored {
+            XCTAssertLessThan(p.level!, DaytimeStress.highBandFloor,
+                "a normal hour with an RMSSD baseline must not stack into the HIGH band")
+        }
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeStressTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeStressTests.swift
@@ -283,4 +283,135 @@ final class DaytimeStressTests: XCTestCase {
         XCTAssertEqual(a.activityMaskedHours, 0)
         XCTAssertEqual(b.activityMaskedHours, 1, "the memo key ignored gravity and returned a stale Result")
     }
+
+    // MARK: - Additivity: the `mode` parameter is opt-in, day-relative stays the default
+
+    func testDayRelativeDefaultIsByteIdenticalToExplicitMode() {
+        // The additive `mode` parameter defaults to `.dayRelative`. Confirms the implicit call
+        // (every pre-existing call site, unmodified) and the explicit `.dayRelative` case
+        // produce a BYTE-IDENTICAL `Result` — every field, not just the pre-existing ones —
+        // proving the new mode is purely additive and never a silent behaviour change.
+        var hr: [HRSample] = []
+        for h in [8, 9, 10] { hr += hourHR(h, bpm: 58) }
+        hr += hourHR(13, bpm: 120)
+        hr += hourHR(14, bpm: 125)
+        hr += hourHR(15, bpm: 130)
+        var rr: [RRInterval] = []
+        rr += hourRRVariable(9, rrMs: 900, jitter: 40)
+        rr += hourRRVariable(14, rrMs: 900, jitter: 5)
+
+        let implicit = DaytimeStress.analyze(hr: hr, rr: rr, tzOffsetSeconds: 3_600)
+        let explicit = DaytimeStress.analyze(hr: hr, rr: rr, tzOffsetSeconds: 3_600, mode: .dayRelative)
+        XCTAssertEqual(implicit, explicit,
+            "omitting `mode` must be byte-identical to passing `.dayRelative` explicitly")
+    }
+
+    func testHighStressMinutesCountsAllHighBandHoursNotJustTheTrailingRun() {
+        // An isolated morning spike, then a calm run ending the day: sustainedHigh only cares
+        // about the TRAILING run (and must be false here, since the day ends calm), but
+        // highStressMinutes is a day-wide tally and must still count the earlier spike hour —
+        // proving it is computed independently, not derived from sustainedRun.
+        var hr: [HRSample] = []
+        hr += hourHR(7, bpm: 130)   // isolated high spike
+        hr += hourHR(8, bpm: 60)
+        hr += hourHR(9, bpm: 60)
+        hr += hourHR(10, bpm: 60)
+        hr += hourHR(11, bpm: 60)   // trailing hour is calm -> NOT sustained
+        let r = DaytimeStress.analyze(hr: hr, rr: [])
+
+        XCTAssertFalse(r.sustainedHigh, "the trailing hour is calm, so sustained-high must not fire")
+        let expectedHighHours = r.scored.filter { $0.level! >= DaytimeStress.highBandFloor }.count
+        XCTAssertGreaterThan(expectedHighHours, 0, "the isolated morning spike should read as high band")
+        XCTAssertEqual(r.highStressMinutes, expectedHighHours * (DaytimeStress.bucketSeconds / 60))
+        XCTAssertFalse(r.hrOnlyFallback, "day-relative mode never sets the baseline-relative fallback flag")
+    }
+
+    // MARK: - Baseline-relative mode (Oura-style, vs a PERSONAL rolling baseline)
+
+    func testBaselineRelativeModeRecoversMultipleInjectedElevations() {
+        // Personal daytime-HR baseline: 20 constant "days" at 60 bpm converges the EWMA center
+        // to exactly 60 with spread pinned at the daytime_hr floor (no cross-day variability).
+        let hrBaseline = Baselines.foldHistory(Array(repeating: 60.0, count: 20), cfg: Baselines.daytimeHRCfg)
+        XCTAssertEqual(hrBaseline.baseline, 60.0, accuracy: 1e-6)
+        XCTAssertEqual(hrBaseline.spread, Baselines.daytimeHRCfg.floorSpread, accuracy: 1e-9)
+
+        // FOUR distinct injected HR elevations across the SAME day's waking hours — the repo's
+        // derived-signal rule (CLAUDE.md "validate against the artifact, not one match") requires
+        // recovering MULTIPLE injected values, not a single high-vs-low pair.
+        let levels: [(hour: Int, bpm: Int)] = [(8, 60), (10, 64), (13, 68), (16, 72)]
+        var hr: [HRSample] = []
+        for (h, bpm) in levels { hr += hourHR(h, bpm: bpm) }
+
+        let r = DaytimeStress.analyze(hr: hr, rr: [], mode: .baselineRelative(hr: hrBaseline, rmssd: nil))
+        let scores = levels.map { pair in r.scored.first { $0.hour == pair.hour }!.level! }
+
+        // Strictly increasing with the injected elevation — all four levels recovered, in order.
+        for i in 1..<scores.count {
+            XCTAssertGreaterThan(scores[i], scores[i - 1],
+                "hour \(levels[i].hour) (\(levels[i].bpm) bpm) should score higher than hour \(levels[i - 1].hour) (\(levels[i - 1].bpm) bpm)")
+        }
+        // The at-baseline hour reads at the 1.5 midpoint; the most-elevated hour clears HIGH.
+        XCTAssertEqual(scores[0], 1.5, accuracy: 0.05)
+        XCTAssertGreaterThanOrEqual(scores.last!, DaytimeStress.highBandFloor)
+        XCTAssertTrue(r.hrOnlyFallback, "rmssd: nil must flag the HR-only fallback")
+    }
+
+    func testBaselineRelativeCalmDayAtPersonalBaselineReadsLowNotHigh() {
+        let hrBaseline = Baselines.foldHistory(Array(repeating: 60.0, count: 20), cfg: Baselines.daytimeHRCfg)
+        var hr: [HRSample] = []
+        for h in [8, 10, 13, 16] { hr += hourHR(h, bpm: 60) }   // every hour sits exactly at baseline
+        let r = DaytimeStress.analyze(hr: hr, rr: [], mode: .baselineRelative(hr: hrBaseline, rmssd: nil))
+
+        for p in r.scored {
+            XCTAssertEqual(p.level!, 1.5, accuracy: 0.05,
+                "a day flat at the personal baseline should read ~1.5, not elevated")
+        }
+        XCTAssertEqual(r.highStressMinutes, 0)
+        XCTAssertFalse(r.sustainedHigh)
+    }
+
+    func testBaselineRelativeElevatedDayProducesHighStressMinutes() {
+        let hrBaseline = Baselines.foldHistory(Array(repeating: 60.0, count: 20), cfg: Baselines.daytimeHRCfg)
+        var hr: [HRSample] = []
+        for h in 8...16 { hr += hourHR(h, bpm: 95) }   // every waking hour well above the personal baseline
+        let r = DaytimeStress.analyze(hr: hr, rr: [], mode: .baselineRelative(hr: hrBaseline, rmssd: nil))
+
+        XCTAssertGreaterThan(r.highStressMinutes, 0)
+        XCTAssertEqual(r.highStressMinutes,
+                      r.scored.filter { $0.level! >= DaytimeStress.highBandFloor }.count * (DaytimeStress.bucketSeconds / 60))
+        for p in r.scored { XCTAssertGreaterThanOrEqual(p.level!, DaytimeStress.highBandFloor) }
+    }
+
+    func testBaselineRelativeNilRMSSDFallsBackToHROnlyAndFlagsDegraded() {
+        // An imported, Oura-era day: no personal RMSSD baseline exists yet (rmssd: nil) and no
+        // R-R stream is available either. The read must still complete honestly, never crash.
+        let hrBaseline = Baselines.foldHistory(Array(repeating: 60.0, count: 20), cfg: Baselines.daytimeHRCfg)
+        var hr: [HRSample] = []
+        for h in [9, 14] { hr += hourHR(h, bpm: 80) }
+        let r = DaytimeStress.analyze(hr: hr, rr: [], mode: .baselineRelative(hr: hrBaseline, rmssd: nil))
+
+        XCTAssertTrue(r.hrOnlyFallback)
+        XCTAssertFalse(r.scored.isEmpty, "HR-only scoring must still produce a timeline")
+        for p in r.scored { XCTAssertNotNil(p.level) }
+    }
+
+    func testBaselineRelativeUsesRMSSDBaselineWhenAvailable() {
+        // Personal baselines: HR steady at 65 bpm, RMSSD steady at 40 ms (both spread-floored).
+        let hrBaseline = Baselines.foldHistory(Array(repeating: 65.0, count: 20), cfg: Baselines.daytimeHRCfg)
+        let rmssdBaseline = Baselines.foldHistory(Array(repeating: 40.0, count: 20), cfg: Baselines.daytimeRMSSDCfg)
+
+        var hr: [HRSample] = []
+        var rr: [RRInterval] = []
+        for h in [9, 14] { hr += hourHR(h, bpm: 65) }        // HR AT baseline in both hours — isolates RMSSD
+        rr += hourRRVariable(9, rrMs: 900, jitter: 40)        // normal variability
+        rr += hourRRVariable(14, rrMs: 900, jitter: 2)        // suppressed HRV -> more stressed
+
+        let r = DaytimeStress.analyze(hr: hr, rr: rr,
+                                      mode: .baselineRelative(hr: hrBaseline, rmssd: rmssdBaseline))
+        XCTAssertFalse(r.hrOnlyFallback, "an RMSSD baseline was supplied — no fallback")
+        let normal = r.scored.first { $0.hour == 9 }!.level!
+        let suppressed = r.scored.first { $0.hour == 14 }!.level!
+        XCTAssertGreaterThan(suppressed, normal,
+            "suppressed RMSSD vs. the personal baseline should read MORE stressed than normal variability")
+    }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeStressTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeStressTests.swift
@@ -327,18 +327,33 @@ final class DaytimeStressTests: XCTestCase {
     }
 
     // MARK: - Baseline-relative mode (Oura-style, vs a PERSONAL rolling baseline)
+    //
+    // Fixtures below use a 65 bpm personal HR baseline (matching the ~65 bpm pooled
+    // 10th-percentile figure from the validated 26-day Oura-reference correlation — see
+    // `DaytimeStress.baselineRelativeHighMarginBPM`) and elevations measured from it in terms of
+    // that validated ~15 bpm margin, so the expected band crossings are exact, not approximate.
+
+    func testMarginToSigmaLandsExactlyOnBand() {
+        // The validated 15 bpm margin over baseline must land EXACTLY on highBandFloor (2.0) on
+        // the shared squash curve — the core identity `.baselineRelative` scoring relies on.
+        let sd = DaytimeStress.marginToSigma(marginBPM: DaytimeStress.baselineRelativeHighMarginBPM,
+                                             atBand: DaytimeStress.highBandFloor)
+        XCTAssertEqual(DaytimeStress.squash(DaytimeStress.baselineRelativeHighMarginBPM / sd),
+                      DaytimeStress.highBandFloor, accuracy: 1e-9)
+    }
 
     func testBaselineRelativeModeRecoversMultipleInjectedElevations() {
-        // Personal daytime-HR baseline: 20 constant "days" at 60 bpm converges the EWMA center
-        // to exactly 60 with spread pinned at the daytime_hr floor (no cross-day variability).
-        let hrBaseline = Baselines.foldHistory(Array(repeating: 60.0, count: 20), cfg: Baselines.daytimeHRCfg)
-        XCTAssertEqual(hrBaseline.baseline, 60.0, accuracy: 1e-6)
-        XCTAssertEqual(hrBaseline.spread, Baselines.daytimeHRCfg.floorSpread, accuracy: 1e-9)
+        // Personal daytime-HR baseline: 20 constant "days" at 65 bpm converges the EWMA center
+        // to exactly 65 (spread is folded but NOT used for the HR high-band threshold — see
+        // baselineRelativeHighMarginBPM).
+        let hrBaseline = Baselines.foldHistory(Array(repeating: 65.0, count: 20), cfg: Baselines.daytimeHRCfg)
+        XCTAssertEqual(hrBaseline.baseline, 65.0, accuracy: 1e-6)
 
         // FOUR distinct injected HR elevations across the SAME day's waking hours — the repo's
         // derived-signal rule (CLAUDE.md "validate against the artifact, not one match") requires
-        // recovering MULTIPLE injected values, not a single high-vs-low pair.
-        let levels: [(hour: Int, bpm: Int)] = [(8, 60), (10, 64), (13, 68), (16, 72)]
+        // recovering MULTIPLE injected values, not a single high-vs-low pair. 65 (at baseline),
+        // 72 (+7, mild), 80 (+15, exactly the validated margin), 95 (+30, well past it).
+        let levels: [(hour: Int, bpm: Int)] = [(8, 65), (10, 72), (13, 80), (16, 95)]
         var hr: [HRSample] = []
         for (h, bpm) in levels { hr += hourHR(h, bpm: bpm) }
 
@@ -350,16 +365,19 @@ final class DaytimeStressTests: XCTestCase {
             XCTAssertGreaterThan(scores[i], scores[i - 1],
                 "hour \(levels[i].hour) (\(levels[i].bpm) bpm) should score higher than hour \(levels[i - 1].hour) (\(levels[i - 1].bpm) bpm)")
         }
-        // The at-baseline hour reads at the 1.5 midpoint; the most-elevated hour clears HIGH.
+        // The at-baseline hour reads at the 1.5 midpoint; +15 bpm (the validated margin) lands
+        // exactly on highBandFloor; the most-elevated hour clears well past it.
         XCTAssertEqual(scores[0], 1.5, accuracy: 0.05)
-        XCTAssertGreaterThanOrEqual(scores.last!, DaytimeStress.highBandFloor)
+        XCTAssertEqual(scores[2], DaytimeStress.highBandFloor, accuracy: 0.01,
+            "the validated +15 bpm margin should land exactly on highBandFloor")
+        XCTAssertGreaterThan(scores.last!, DaytimeStress.highBandFloor)
         XCTAssertTrue(r.hrOnlyFallback, "rmssd: nil must flag the HR-only fallback")
     }
 
     func testBaselineRelativeCalmDayAtPersonalBaselineReadsLowNotHigh() {
-        let hrBaseline = Baselines.foldHistory(Array(repeating: 60.0, count: 20), cfg: Baselines.daytimeHRCfg)
+        let hrBaseline = Baselines.foldHistory(Array(repeating: 65.0, count: 20), cfg: Baselines.daytimeHRCfg)
         var hr: [HRSample] = []
-        for h in [8, 10, 13, 16] { hr += hourHR(h, bpm: 60) }   // every hour sits exactly at baseline
+        for h in [8, 10, 13, 16] { hr += hourHR(h, bpm: 65) }   // every hour sits exactly at baseline
         let r = DaytimeStress.analyze(hr: hr, rr: [], mode: .baselineRelative(hr: hrBaseline, rmssd: nil))
 
         for p in r.scored {
@@ -371,9 +389,9 @@ final class DaytimeStressTests: XCTestCase {
     }
 
     func testBaselineRelativeElevatedDayProducesHighStressMinutes() {
-        let hrBaseline = Baselines.foldHistory(Array(repeating: 60.0, count: 20), cfg: Baselines.daytimeHRCfg)
+        let hrBaseline = Baselines.foldHistory(Array(repeating: 65.0, count: 20), cfg: Baselines.daytimeHRCfg)
         var hr: [HRSample] = []
-        for h in 8...16 { hr += hourHR(h, bpm: 95) }   // every waking hour well above the personal baseline
+        for h in 8...16 { hr += hourHR(h, bpm: 95) }   // +30 bpm — twice the validated high-band margin
         let r = DaytimeStress.analyze(hr: hr, rr: [], mode: .baselineRelative(hr: hrBaseline, rmssd: nil))
 
         XCTAssertGreaterThan(r.highStressMinutes, 0)
@@ -385,9 +403,9 @@ final class DaytimeStressTests: XCTestCase {
     func testBaselineRelativeNilRMSSDFallsBackToHROnlyAndFlagsDegraded() {
         // An imported, Oura-era day: no personal RMSSD baseline exists yet (rmssd: nil) and no
         // R-R stream is available either. The read must still complete honestly, never crash.
-        let hrBaseline = Baselines.foldHistory(Array(repeating: 60.0, count: 20), cfg: Baselines.daytimeHRCfg)
+        let hrBaseline = Baselines.foldHistory(Array(repeating: 65.0, count: 20), cfg: Baselines.daytimeHRCfg)
         var hr: [HRSample] = []
-        for h in [9, 14] { hr += hourHR(h, bpm: 80) }
+        for h in [9, 14] { hr += hourHR(h, bpm: 80) }   // right at the validated +15 bpm margin
         let r = DaytimeStress.analyze(hr: hr, rr: [], mode: .baselineRelative(hr: hrBaseline, rmssd: nil))
 
         XCTAssertTrue(r.hrOnlyFallback)

--- a/Strand/BLE/PuffinExperiment.swift
+++ b/Strand/BLE/PuffinExperiment.swift
@@ -66,6 +66,17 @@ enum PuffinExperiment {
 
     static var spo2CandidateDisplayEnabled: Bool { UserDefaults.standard.bool(forKey: spo2CandidateDisplayKey) }
 
+    /// Opt-in "Personal daytime-stress baseline" (#463): score TODAY's intraday stress timeline against a
+    /// PERSONAL cross-day rolling baseline (Oura-style `.baselineRelative`) instead of the day's own calm
+    /// hours (`.dayRelative`, the default). Default OFF — the validated r≈0.6 HR-only margin is so far
+    /// SINGLE-SUBJECT (see `DaytimeStress.baselineRelativeHighMarginBPM`), so this stays a chooseable lens,
+    /// not a silent default, until it is validated on more subjects. When OFF, `StressView` /
+    /// `StressScreen` pass no mode and the read is byte-identical to before. Mirrors the Android
+    /// `NoopPrefs.KEY_STRESS_PERSONAL_BASELINE`.
+    static let stressPersonalBaselineKey = "noopStressPersonalBaseline"
+
+    static var stressPersonalBaselineEnabled: Bool { UserDefaults.standard.bool(forKey: stressPersonalBaselineKey) }
+
     /// Opt-in "Continuous HRV capture": hold the dense realtime HR stream armed even with no Live screen
     /// open, so the strap banks beat-to-beat R-R intervals 24/7 for far better overnight HRV/recovery/
     /// sleep (vs the sparse history offload). Uses more battery (continuous HR streaming). Default OFF;

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -67,6 +67,12 @@ struct SettingsView: View {
     /// writes nothing to the strap. See [PuffinExperiment.spo2CandidateDisplayKey].
     @AppStorage(PuffinExperiment.spo2CandidateDisplayKey) private var spo2CandidateDisplayEnabled = false
 
+    /// #463 opt-in: score the intraday stress timeline against a PERSONAL cross-day baseline
+    /// (`.baselineRelative`) instead of the day's own calm hours. Default off — the r≈0.6 margin is
+    /// single-subject so far. Display-only; never feeds recovery/illness. See
+    /// [PuffinExperiment.stressPersonalBaselineKey].
+    @AppStorage(PuffinExperiment.stressPersonalBaselineKey) private var stressPersonalBaselineEnabled = false
+
     /// True when the connected strap has positively attested itself a WHOOP MG. The variant is published as
     /// its label string (`LiveState.whoop5Variant`); "MG" is `Whoop5Variant.mg.label`. nil / not-yet-
     /// identified / a plain 5.0 is not an MG.
@@ -2048,6 +2054,22 @@ struct SettingsView: View {
                     Task { await model.intelligence.analyzeRecent(); await model.repo.refresh() }
                 }
                 Text("Your WHOOP 5.0/MG sends a strap-computed SpO₂ percentage (the @82 candidate byte) every second. An 8-night independent validation tracked it at corr +0.99 against the WHOOP app, but two nights on the original test device moved the OPPOSITE direction — device/firmware variance is unresolved. Turning this on surfaces the nightly mean in the Blood Oxygen tile as \"strap estimate (unverified)\" when no calibrated import exists. It never feeds recovery or illness scoring. WHOOP 4.0 has no @82 stream, so this does nothing there.")
+                    .font(StrandFont.caption)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                // MARK: #463 Personal daytime-stress baseline — score today's timeline vs a personal
+                //       cross-day baseline instead of the day's own calm hours. Off by default.
+                Divider().overlay(StrandPalette.hairline)
+
+                Toggle(isOn: $stressPersonalBaselineEnabled) {
+                    Text("Stress: personal daytime baseline")
+                        .font(StrandFont.subhead)
+                        .foregroundStyle(StrandPalette.textPrimary)
+                }
+                .toggleStyle(.switch)
+                .tint(StrandPalette.accent)
+                Text("Scores your hour-by-hour stress timeline against YOUR own cross-day baseline (how your days usually run, Oura-style) instead of the day's own calm hours. Needs a few worn days; until then it stays on the default. The high-stress cutoff is tuned from a single-subject reference so far, so it's an alternative lens rather than the default. HR-only, and it never feeds recovery or illness scoring. Off by default.")
                     .font(StrandFont.caption)
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/Strand/Screens/StressView.swift
+++ b/Strand/Screens/StressView.swift
@@ -40,6 +40,10 @@ struct StressView: View {
     /// from the day's banked HR + R-R via the SAME 0–3 proxy the daily score uses. Nil
     /// until the async read completes; `.empty` when the day has no usable intraday HR.
     @State private var daytime: DaytimeStress.Result?
+    /// Whether TODAY's intraday timeline is scored against the PERSONAL cross-day daytime baseline
+    /// (`.baselineRelative`, once enough worn history exists) instead of the day's own calm hours
+    /// (`.dayRelative`). Drives only the explanatory copy — the 0–3 scale + bands are identical either way.
+    @State private var daytimeUsesPersonalBaseline = false
     /// Drives the Breathe sheet presented from the sustained-stress suggestion.
     @State private var showBreathe = false
 
@@ -117,7 +121,14 @@ struct StressView: View {
         let gravity = (try? await repo.storeHandle()?.gravitySamples(
             deviceId: repo.deviceId, from: from, to: to, limit: 200_000)) ?? []
 
-        daytime = DaytimeStress.analyze(hr: hr, rr: rr, gravity: gravity, tzOffsetSeconds: tz)
+        // Score today's hours against the PERSONAL cross-day daytime baseline when enough worn history
+        // exists (Oura-style `.baselineRelative`, validated r≈0.6), else the day's own calm hours
+        // (`.dayRelative`, the unchanged default). The mode is resolved only AFTER the HR-count guard
+        // above, so the trailing-history reads are never paid on a day with no scorable timeline.
+        let mode = await daytimeScoringMode(startOfToday: startOfDay)
+        if case .baselineRelative = mode { daytimeUsesPersonalBaseline = true }
+        else { daytimeUsesPersonalBaseline = false }
+        daytime = DaytimeStress.analyze(hr: hr, rr: rr, gravity: gravity, tzOffsetSeconds: tz, mode: mode)
 
         // ADDITIVE advanced readouts, computed on-demand from the SAME `rr` (no extra fetch, no
         // DB / schema change, and no effect on the 0..3 score above). Each engine returns nil when
@@ -125,6 +136,43 @@ struct StressView: View {
         // in which case its row is simply hidden.
         stressIndex = StressIndex.components(rr: rr)
         freqHRV = HRVFreqDomain.freqDomain(rr: rr)
+    }
+
+    /// Trailing local days folded into the personal daytime baselines the `.baselineRelative` mode
+    /// scores against. 30 mirrors the app's other rolling baselines (nightly resting-HR / HRV) and the
+    /// illness engine's ~28-day base.
+    private static let baselineHistoryDays = 30
+
+    /// Build the personal daytime baselines from the trailing `baselineHistoryDays` local days (TODAY
+    /// EXCLUDED — it's the day being scored, not part of its own baseline) and return the scoring mode
+    /// for today's intraday read: `.baselineRelative` once there's enough real worn daytime-HR history
+    /// for a usable baseline, else `.dayRelative` (the unchanged default). The only behavioural change
+    /// vs. before is that a user with a few worn days now scores today's hours against their own
+    /// cross-day floor instead of the day's own calm hours; a cold-start / sparse-history user is
+    /// byte-identical to before (`DaytimeStress.scoringMode` is the single degradation gate).
+    ///
+    /// PERF: reads each past day's raw HR (and, only when that day was worn, R-R) once, bounded per day,
+    /// off the main actor via `repo` — riding the same async `load()` the today-timeline already runs on.
+    /// Unworn days are skipped without an R-R read. The `DaytimeStress` analyze memo is untouched; the
+    /// fold itself is O(days).
+    private func daytimeScoringMode(startOfToday: Date) async -> DaytimeStress.ScoringMode {
+        let cal = Calendar.current
+        var days: [DaytimeStress.DaytimeDayStreams] = []
+        days.reserveCapacity(Self.baselineHistoryDays)
+        // Oldest → newest so the EWMA fold replays the history in order.
+        for back in stride(from: Self.baselineHistoryDays, through: 1, by: -1) {
+            guard let dayStart = cal.date(byAdding: .day, value: -back, to: startOfToday),
+                  let dayEnd = cal.date(byAdding: .day, value: 1, to: dayStart) else { continue }
+            let from = Int(dayStart.timeIntervalSince1970)
+            let to = Int(dayEnd.timeIntervalSince1970) - 1
+            let dayTz = TimeZone.current.secondsFromGMT(for: dayStart)
+            let dayHR = await repo.hrSamples(from: from, to: to, limit: 200_000)
+            guard !dayHR.isEmpty else { continue }   // unworn day — no floor to learn, skip the R-R read
+            let dayRR = (try? await repo.storeHandle()?.rrIntervals(
+                deviceId: repo.deviceId, from: from, to: to, limit: 200_000)) ?? []
+            days.append(.init(hr: dayHR, rr: dayRR, tzOffsetSeconds: dayTz))
+        }
+        return DaytimeStress.scoringMode(history: days)
     }
 
     /// Recompute the cached `StressModel` only when (repo.days, storedSeries)
@@ -238,7 +286,7 @@ struct StressView: View {
                     // bar split by how many waking hours sat in each band, with durations.
                     StressTotalsBar(totals: StressTotals(hours: day.hours))
 
-                    Text("The line is each waking hour's 0-3 proxy, scored against your own calm hours today. The bar below splits your day into calm, moderate and high stress time.")
+                    Text(daytimeTimelineCaption)
                         .font(StrandFont.footnote)
                         .foregroundStyle(StrandPalette.textTertiary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -255,6 +303,16 @@ struct StressView: View {
         let n = day.scored.count
         guard let mean = day.dayMean else { return String(localized: "\(n)h") }
         return String(localized: "avg \(String(format: "%.1f", mean)) · \(n)h")
+    }
+
+    /// The timeline's explanatory line, honest about WHICH reference each hour was scored against —
+    /// the personal cross-day baseline (`.baselineRelative`) or the day's own calm hours (`.dayRelative`).
+    /// Explicit `LocalizedStringKey` so BOTH variants stay in the string catalog (a ternary inside
+    /// `Text(_:)` would resolve to the verbatim, non-localized `String` overload).
+    private var daytimeTimelineCaption: LocalizedStringKey {
+        daytimeUsesPersonalBaseline
+            ? "The line is each waking hour's 0-3 proxy, scored against your personal daytime baseline (how your own days usually run). The bar below splits your day into calm, moderate and high stress time."
+            : "The line is each waking hour's 0-3 proxy, scored against your own calm hours today. The bar below splits your day into calm, moderate and high stress time."
     }
 
     /// A passive, in-app nudge to run a Breathe session after a sustained high-stress run.

--- a/Strand/Screens/StressView.swift
+++ b/Strand/Screens/StressView.swift
@@ -121,11 +121,16 @@ struct StressView: View {
         let gravity = (try? await repo.storeHandle()?.gravitySamples(
             deviceId: repo.deviceId, from: from, to: to, limit: 200_000)) ?? []
 
-        // Score today's hours against the PERSONAL cross-day daytime baseline when enough worn history
-        // exists (Oura-style `.baselineRelative`, validated r≈0.6), else the day's own calm hours
-        // (`.dayRelative`, the unchanged default). The mode is resolved only AFTER the HR-count guard
-        // above, so the trailing-history reads are never paid on a day with no scorable timeline.
-        let mode = await daytimeScoringMode(startOfToday: startOfDay)
+        // Score today's hours against the PERSONAL cross-day daytime baseline ONLY when the user has
+        // opted in (Settings → Experimental) AND enough worn history exists (Oura-style
+        // `.baselineRelative`), else the day's own calm hours (`.dayRelative`, the default). The opt-in
+        // gate is deliberate: the validated r≈0.6 margin is single-subject so far (#463), so this stays a
+        // chooseable lens, not a silent default. The mode is resolved only AFTER the HR-count guard above,
+        // so the trailing-history reads are never paid on a day with no scorable timeline — and are never
+        // paid at all while the toggle is OFF (the default), keeping the read byte-identical to before.
+        let mode = PuffinExperiment.stressPersonalBaselineEnabled
+            ? await daytimeScoringMode(startOfToday: startOfDay)
+            : .dayRelative
         if case .baselineRelative = mode { daytimeUsesPersonalBaseline = true }
         else { daytimeUsesPersonalBaseline = false }
         daytime = DaytimeStress.analyze(hr: hr, rr: rr, gravity: gravity, tzOffsetSeconds: tz, mode: mode)

--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -590,6 +590,10 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Scores today's hour-by-hour stress timeline against YOUR own cross-day baseline "
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Searching…"
     ],
     [
@@ -599,6 +603,10 @@
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Sleep chart"
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Stress: personal daytime baseline"
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
@@ -1093,6 +1101,14 @@
     [
       "Strand/Screens/SettingsView.swift",
       "NOOP estimates your steps from your WHOOP's motion, calibrated to your phone's step count. It's an estimate, not a step counter — a WHOOP 5.0 / MG streams motion (not a step count) only with deep data on."
+    ],
+    [
+      "Strand/Screens/SettingsView.swift",
+      "Scores your hour-by-hour stress timeline against YOUR own cross-day baseline (how your days usually run, Oura-style) instead of the day's own calm hours. Needs a few worn days; until then it stays on the default. The high-stress cutoff is tuned from a single-subject reference so far, so it's an alternative lens rather than the default. HR-only, and it never feeds recovery or illness scoring. Off by default."
+    ],
+    [
+      "Strand/Screens/SettingsView.swift",
+      "Stress: personal daytime baseline"
     ],
     [
       "Strand/Screens/SettingsView.swift",

--- a/android/app/src/main/java/com/noop/analytics/Baselines.kt
+++ b/android/app/src/main/java/com/noop/analytics/Baselines.kt
@@ -174,6 +174,32 @@ object Baselines {
             minVal = 2.079, maxVal = 5.521, floorSpread = 0.08,
             halfLifeB = 14.0, halfLifeS = 21.0,
         ),
+
+        // Daytime/waking-hours configs (DaytimeStress baseline-relative mode, added alongside
+        // the day-relative default). Distinct from "resting_hr"/"hrv" above, which each fold ONE
+        // NIGHTLY value (sleep). These fold ONE DAYTIME aggregate per day into a cross-day
+        // PERSONAL baseline, so a caller can hand the resulting BaselineState to
+        // DaytimeStress.analyze(mode = ScoringMode.BaselineRelative(hr, rmssd)) and z-score each
+        // waking hour against "how MY days usually run" rather than "how today's own calm hours ran".
+        //
+        // VALIDATED (26-day Oura-reference correlation, HR-only, r≈0.6): the per-day value to
+        // fold for "daytime_hr" is that day's 10th-percentile daytime HR (~65 bpm pooled across
+        // the reference set) — NOT the day-relative calmReference's 25th-percentile quartile.
+        // The "high stress" cutoff itself is a validated fixed bpm margin over this baseline,
+        // NOT this config's floorSpread — see DaytimeStress.baselineRelativeHighMarginBPM.
+        // TUNING SEAM: minVal/maxVal/half-life below (and all of "daytime_rmssd" — RMSSD wasn't
+        // part of the validated HR-only comparison) are a documented first pass, refinable once
+        // an HR+HRV comparison exists. floorSpread is wider than the nightly "hrv" config for
+        // RMSSD: daytime RMSSD carries more incidental noise (posture changes, talking, movement
+        // between "calm" hours) than overnight recumbent HRV.
+        "daytime_hr" to MetricCfg(
+            minVal = 35.0, maxVal = 160.0, floorSpread = 3.0,
+            halfLifeB = 14.0, halfLifeS = 21.0,
+        ),
+        "daytime_rmssd" to MetricCfg(
+            minVal = 5.0, maxVal = 250.0, floorSpread = 7.0,
+            halfLifeB = 14.0, halfLifeS = 21.0,
+        ),
     )
 
     /** Convenience accessor for the standard HRV config. */
@@ -191,6 +217,12 @@ object Baselines {
 
     /** Baseline config for the RecoveryScorer Activity-Balance / previous-day-Effort term. */
     val strainCfg: MetricCfg get() = metricCfg.getValue("strain")
+
+    /** Personal daytime/waking HR baseline config — see the `daytime_hr` comment above. */
+    val daytimeHRCfg: MetricCfg get() = metricCfg.getValue("daytime_hr")
+
+    /** Personal daytime/waking RMSSD baseline config — see the `daytime_rmssd` comment above. */
+    val daytimeRMSSDCfg: MetricCfg get() = metricCfg.getValue("daytime_rmssd")
 
     /** Convert a half-life in nights to an EWMA smoothing factor. */
     internal fun lambda(halfLife: Double): Double = 1.0 - 0.5.pow(1.0 / halfLife)
@@ -486,12 +518,20 @@ object Baselines {
     // ─────────────────────────────────────────────────────────────────────────
 
     /**
+     * Convert a state's EWMA-abs-dev spread to an approximate Gaussian σ: 1.253 × spread,
+     * floored so a caller never divides by ~0. 1.253 is E[|X−μ|] = σ·√(2/π) inverted
+     * (E[|X−μ|] ≈ σ/1.253 for a Gaussian). Shared by [deviation] below and by any other
+     * z-scoring caller (e.g. [DaytimeStress]'s baseline-relative mode) so the conversion has
+     * exactly one definition.
+     */
+    fun sigma(state: BaselineState): Double = max(1.253 * state.spread, 1e-9)
+
+    /**
      * Compute z / delta / ratio / in-normal-range for a value vs a baseline.
-     * z uses (value − baseline) / (1.253 × spread); 1.253 converts EWMA-abs-dev
-     * to an approximate Gaussian σ (E[|X−μ|] = σ·√(2/π) ≈ σ/1.253).
+     * z uses (value − baseline) / sigma(state); see [sigma] for the 1.253 conversion.
      */
     fun deviation(value: Double, state: BaselineState): Deviation {
-        val sigma = max(1.253 * state.spread, 1e-9)
+        val sigma = sigma(state)
         val z = (value - state.baseline) / sigma
         val delta = value - state.baseline
         val ratio = if (state.baseline != 0.0) (value / state.baseline - 1.0) else 0.0

--- a/android/app/src/main/java/com/noop/analytics/DaytimeBaselines.kt
+++ b/android/app/src/main/java/com/noop/analytics/DaytimeBaselines.kt
@@ -1,0 +1,169 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import com.noop.data.RrInterval
+
+/*
+ * DaytimeBaselines.kt — the CALLER-side folding path that turns a person's past DAYTIME history
+ * into the personal rolling baselines DaytimeStress.analyze(mode = BaselineRelative(hr, rmssd))
+ * scores today's waking hours against.
+ *
+ * Faithful Kotlin port of StrandAnalytics/DaytimeBaselines.swift (an extension on DaytimeStress;
+ * here a sibling object so it can reuse DaytimeStress's internal bucketing helpers).
+ *
+ * BaselineRelative (see DaytimeStress.ScoringMode) is deliberately caller-fed: the scorer takes a
+ * finished BaselineState and never fetches history itself. This is that missing caller — it
+ * computes ONE daytime aggregate per past day and folds the ordered series through the SAME
+ * Winsorized-EWMA machinery (Baselines.foldHistory) the nightly resting-HR / HRV baselines use,
+ * with the daytime-specific Baselines.daytimeHRCfg / daytimeRMSSDCfg configs.
+ *
+ * The per-day aggregate is defined in terms of EXACTLY the hourly means the scorer references: it
+ * reuses DaytimeStress's own floorDiv / bucketSeconds / isWakingHour / minHourHrSamples /
+ * HrvAnalyzer so "the value we fold into the baseline" and "the value we later z-score against that
+ * baseline" are the same quantity, never two drifting definitions.
+ */
+object DaytimeBaselines {
+
+    // MARK: - Per-day daytime aggregate
+
+    /**
+     * Percentile of a day's waking-hour mean HRs used as that day's daytime-HR aggregate: the 10th,
+     * i.e. the CALM FLOOR ("how low does my HR run when I'm calm and awake"). VALIDATED — this is
+     * the ~65 bpm pooled figure from the 26-day Oura-reference correlation behind
+     * DaytimeStress.baselineRelativeHighMarginBPM. It is intentionally the floor (not the median)
+     * because the HR term pairs it with a FIXED bpm margin (a large effective spread via
+     * marginToSigma), so anchoring at the floor makes "floor + margin" the exact HIGH cutoff.
+     */
+    const val daytimeHRAggregatePercentile: Double = 0.10
+
+    /**
+     * Percentile of a day's waking-hour RMSSDs used as that day's daytime-RMSSD aggregate: the 50th
+     * (MEDIAN / typical), NOT the symmetric calm-ceiling percentile. The asymmetry with HR above is
+     * deliberate and load-bearing: the RMSSD term is scaled by the person's OWN spread
+     * (Baselines.sigma), not a fixed margin, so (baseline − hourRMSSD) / σ is only meaningful when
+     * baseline is the TYPICAL daytime RMSSD — then a typical hour reads neutral and only genuine HRV
+     * suppression reads stressed. Anchoring at a calm-ceiling percentile (the direct mirror of HR's
+     * floor) would make an ordinary median hour sit ~1–2σ "below baseline" and stack a large false
+     * stress term on top of the HR term. TUNING SEAM: like every RMSSD figure in this mode, the
+     * median choice is a first pass pending an HR+HRV validation pass (the validated study was
+     * HR-only).
+     */
+    const val daytimeRMSSDAggregatePercentile: Double = 0.50
+
+    /**
+     * One local day's waking HR + R-R streams, the input to the daytime-baseline fold. [hr]/[rr]
+     * carry wall-clock ts; [tzOffsetSeconds] (seconds east of UTC for THAT day) places them on the
+     * local clock exactly as DaytimeStress.analyze's tzOffsetSeconds does, so DST-varying days can
+     * each carry their own offset.
+     */
+    data class DaytimeDayStreams(
+        val hr: List<HrSample>,
+        val rr: List<RrInterval>,
+        val tzOffsetSeconds: Long,
+    )
+
+    /** One day's daytime aggregates. Either field is null independently. */
+    data class DayAggregate(val hr: Double?, val rmssd: Double?)
+
+    /** A folded personal daytime baseline pair; [rmssd] is null when withheld (thin history). */
+    data class DaytimeBaselineStates(val hr: BaselineState, val rmssd: BaselineState?)
+
+    /**
+     * One day's daytime aggregates, computed with the SCORER's own hourly bucketing so the folded
+     * value matches what BaselineRelative later references:
+     *   - hr: the [daytimeHRAggregatePercentile] (P10) of the day's WAKING-hour mean HRs, where each
+     *     hour's mean HR is gated at DaytimeStress.minHourHrSamples exactly like the scorer (a
+     *     sparse/imported day whose hours never clear the gate yields null — it contributes no
+     *     daytime-HR floor, honestly).
+     *   - rmssd: the [daytimeRMSSDAggregatePercentile] (P50) of the day's WAKING-hour RMSSDs, each
+     *     run through the same HrvAnalyzer.analyzeRaw cleaner the scorer uses (so ectopic beats
+     *     can't fabricate variability); null when no waking hour had enough clean R-R.
+     * Bucketing keys off the HR buckets (like the scorer), so an hour with R-R but no HR contributes
+     * neither.
+     */
+    fun dayDaytimeAggregate(hr: List<HrSample>, rr: List<RrInterval>, tzOffsetSeconds: Long): DayAggregate {
+        if (hr.isEmpty()) return DayAggregate(null, null)
+
+        // Bucket HR + R-R into LOCAL hour-of-day buckets, byte-for-byte the scorer's step 1.
+        val hrByBucket = HashMap<Long, MutableList<Double>>()
+        for (s in hr) {
+            val local = s.ts + tzOffsetSeconds
+            val bucket = DaytimeStress.floorDiv(local, DaytimeStress.bucketSeconds) * DaytimeStress.bucketSeconds
+            hrByBucket.getOrPut(bucket) { ArrayList() }.add(s.bpm.toDouble())
+        }
+        val rrByBucket = HashMap<Long, MutableList<Double>>()
+        for (s in rr) {
+            val local = s.ts + tzOffsetSeconds
+            val bucket = DaytimeStress.floorDiv(local, DaytimeStress.bucketSeconds) * DaytimeStress.bucketSeconds
+            rrByBucket.getOrPut(bucket) { ArrayList() }.add(s.rrMs.toDouble())
+        }
+
+        // Per WAKING hour: the gated mean HR + the cleaned RMSSD, mirroring the scorer's step 2 +
+        // waking filter. Keyed off HR buckets so an R-R-only hour is ignored exactly as the scorer
+        // ignores it.
+        val wakingMeanHRs = ArrayList<Double>()
+        val wakingRMSSDs = ArrayList<Double>()
+        for ((bucket, hrs) in hrByBucket) {
+            if (!DaytimeStress.isWakingHour(bucket)) continue
+            if (hrs.size >= DaytimeStress.minHourHrSamples) {
+                DaytimeStress.mean(hrs)?.let { wakingMeanHRs.add(it) }
+            }
+            HrvAnalyzer.analyzeRaw(rrByBucket[bucket] ?: emptyList()).rmssd?.let { wakingRMSSDs.add(it) }
+        }
+
+        val hrAgg = if (wakingMeanHRs.isEmpty()) null
+            else DaytimeStress.quantile(wakingMeanHRs.sorted(), daytimeHRAggregatePercentile)
+        val rmssdAgg = if (wakingRMSSDs.isEmpty()) null
+            else DaytimeStress.quantile(wakingRMSSDs.sorted(), daytimeRMSSDAggregatePercentile)
+        return DayAggregate(hrAgg, rmssdAgg)
+    }
+
+    // MARK: - Fold the trailing history into personal baselines
+
+    /**
+     * Fold a person's trailing per-day daytime streams (OLDEST → NEWEST, TODAY EXCLUDED — today is
+     * the day being scored, not part of its own baseline) into the personal baselines
+     * BaselineRelative consumes.
+     *
+     * Each day contributes one [dayDaytimeAggregate]; the ordered series is replayed through
+     * Baselines.foldHistory (the identical Winsorized-EWMA path as the nightly baselines) with
+     * daytimeHRCfg / daytimeRMSSDCfg. null aggregates (sparse/HR-only days) become skip-and-hold
+     * nights, exactly like a missing nightly value.
+     *
+     * The HR baseline is always returned (it may be calibrating; the caller checks usable to decide
+     * whether to use BaselineRelative at all). The RMSSD baseline is returned ONLY when it is usable
+     * (≥ Baselines.minNightsSeed days actually carried a daytime RMSSD); otherwise null, so the
+     * scorer honestly runs HR-only rather than z-scoring against a 1–2-day, untrustworthy HRV
+     * baseline — the whole-baseline grain of the per-hour graceful-null already in rawScore.
+     */
+    fun foldDaytimeBaselines(days: List<DaytimeDayStreams>): DaytimeBaselineStates {
+        val hrAggs = ArrayList<Double?>(days.size)
+        val rmssdAggs = ArrayList<Double?>(days.size)
+        for (d in days) {
+            val agg = dayDaytimeAggregate(d.hr, d.rr, d.tzOffsetSeconds)
+            hrAggs.add(agg.hr)
+            rmssdAggs.add(agg.rmssd)
+        }
+        val hrState = Baselines.foldHistory(hrAggs, Baselines.daytimeHRCfg)
+        val rmssdState = Baselines.foldHistory(rmssdAggs, Baselines.daytimeRMSSDCfg)
+        return DaytimeBaselineStates(hrState, if (rmssdState.usable) rmssdState else null)
+    }
+
+    /**
+     * The scoring mode to hand DaytimeStress.analyze for TODAY, decided from the trailing daytime
+     * [days] history: BaselineRelative once the personal HR baseline is usable (≥
+     * Baselines.minNightsSeed days of real daytime HR aggregates — the Oura-style, validated-r≈0.6
+     * path), else DayRelative (the unchanged default). This is the single graceful-degradation gate:
+     * a cold start, or a trailing window that is all sparse/imported days, keeps EXACTLY today's
+     * pre-existing day-relative behaviour.
+     */
+    fun scoringMode(days: List<DaytimeDayStreams>): DaytimeStress.ScoringMode {
+        val baselines = foldDaytimeBaselines(days)
+        if (!baselines.hr.usable) return DaytimeStress.ScoringMode.DayRelative
+        // RMSSD stays out of the LIVE score until it has its own validation pass — see
+        // DaytimeStress.daytimeRMSSDScoringEnabled. The baseline is still folded above (so the
+        // machinery + tests exercise the real path); it just doesn't reach scoring while gated off.
+        val rmssd = if (DaytimeStress.daytimeRMSSDScoringEnabled) baselines.rmssd else null
+        return DaytimeStress.ScoringMode.BaselineRelative(baselines.hr, rmssd)
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/DaytimeStress.kt
+++ b/android/app/src/main/java/com/noop/analytics/DaytimeStress.kt
@@ -99,6 +99,25 @@ object DaytimeStress {
      */
     const val baselineRelativeHighMarginBPM: Double = 15.0
 
+    /**
+     * Gate for whether the personal daytime-RMSSD baseline feeds the live 0–3 score. `false`:
+     * [ScoringMode.BaselineRelative] scores HR-only, exactly the channel the r≈0.6 margin above was
+     * validated on. The RMSSD half of the pipeline — [DaytimeBaselines.dayDaytimeAggregate],
+     * [DaytimeBaselines.foldDaytimeBaselines], the `daytime_rmssd` config, and [rawScore]'s HRV
+     * term — is built and unit-tested, but stays OUT of the live score until it has its OWN
+     * Oura-reference validation pass.
+     *
+     * WHY OFF (validated against real WHOOP data, 2026-07): daytime RMSSD off the wrist is
+     * artifact-dominated — hourly values swing ~40→430 ms as posture / motion / talking break the
+     * R-R stream, an order of magnitude noisier than the overnight recumbent HRV the nightly
+     * baselines use. [rawScore] sums the HRV z EQUAL-WEIGHT with the HR z, so an artifact hour can
+     * swing the combined score by ±3 (the full band) on noise alone. Enabling it before it is shown
+     * to IMPROVE the correlation risks pushing the combined score BELOW the HR-only r≈0.6 ceiling —
+     * the exact regression [baselineRelativeHighMarginBPM]'s comment warns against. Flip to `true`
+     * only once daytime HR+RMSSD is validated to beat HR-only on an Oura-style stress reference.
+     */
+    const val daytimeRMSSDScoringEnabled: Boolean = false
+
     // MARK: - Scoring mode
 
     /**
@@ -227,7 +246,7 @@ object DaytimeStress {
 
     // MARK: - Shared stress math (identical formula to the daily StressModel)
 
-    private fun mean(xs: List<Double>): Double? =
+    internal fun mean(xs: List<Double>): Double? =
         if (xs.isEmpty()) null else xs.sum() / xs.size
 
     /** Population standard deviation; 0 when there's no spread. (Matches StressMath.std.) */
@@ -488,7 +507,7 @@ object DaytimeStress {
      * Floor-division that is correct for negative numerators (so a local time just before
      * the UTC epoch still buckets to the hour below, not toward zero).
      */
-    private fun floorDiv(a: Long, b: Long): Long {
+    internal fun floorDiv(a: Long, b: Long): Long {
         val q = a / b
         val r = a % b
         return if (r != 0L && (r < 0L) != (b < 0L)) q - 1 else q
@@ -499,7 +518,7 @@ object DaytimeStress {
      * (06:00–22:00). The single source of truth for "waking" — used both to build the calm
      * reference and to pick the hours to score, so the two can never drift apart.
      */
-    private fun isWakingHour(bucket: Long): Boolean {
+    internal fun isWakingHour(bucket: Long): Boolean {
         val hourOfDay = (floorDiv(bucket, bucketSeconds) % 24).toInt()
         return hourOfDay >= wakingStartHour && hourOfDay < wakingEndHour
     }
@@ -517,7 +536,7 @@ object DaytimeStress {
     }
 
     /** Linear-interpolated quantile of an already-sorted, non-empty list. */
-    private fun quantile(sorted: List<Double>, q: Double): Double {
+    internal fun quantile(sorted: List<Double>, q: Double): Double {
         val n = sorted.size
         if (n == 0) return 0.0   // defensive: callers guard emptiness; never index []
         if (n == 1) return sorted[0]

--- a/android/app/src/main/java/com/noop/analytics/DaytimeStress.kt
+++ b/android/app/src/main/java/com/noop/analytics/DaytimeStress.kt
@@ -4,6 +4,7 @@ import com.noop.data.GravitySample
 import com.noop.data.HrSample
 import com.noop.data.RrInterval
 import kotlin.math.exp
+import kotlin.math.ln
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.sqrt
@@ -84,6 +85,69 @@ object DaytimeStress {
      */
     const val postActivityShadowBpm: Double = 8.0
 
+    /**
+     * VALIDATED (26-day Oura-reference correlation, HR-only): a personal daytime-HR elevation
+     * of ~15 bpm over a POOLED/ROLLING baseline — the 10th-percentile daytime HR pooled across
+     * days, ~65 bpm in the reference set — is where elevated HR starts reading as
+     * Oura-comparable "high" stress (r≈0.6 against Oura's own stress signal). A PER-DAY
+     * (day-relative) baseline scored WORSE in the same comparison (r 0.43–0.53): an all-day
+     * elevated day pulls its own floor up and masks the stress, which is exactly why
+     * [ScoringMode.BaselineRelative] leans on [Baselines]' cross-day rolling EWMA instead of a
+     * day-local reference. TUNING SEAM: this is HR-only; HR+HRV (WHOOP-era, RMSSD included) is
+     * expected to beat this r≈0.6 ceiling — re-validate this margin once that comparison exists.
+     * See [marginToSigma] for how it's translated onto the shared 0–3 squash curve.
+     */
+    const val baselineRelativeHighMarginBPM: Double = 15.0
+
+    // MARK: - Scoring mode
+
+    /**
+     * WHERE each hour's "calm" reference point + spread come from. Every other step —
+     * bucketing, the waking-hour filter, the squash curve, sustained-high, high-stress-minutes
+     * — is identical between modes; only the reference differs.
+     *
+     * Relationship to the rest of the Stress screen: the DAILY 0–3 score already compares last
+     * night's NIGHTLY resting-HR/HRV to a plain trailing 30-day mean/SD (a once-a-day number
+     * from SLEEP vitals). The Advanced HRV card ([StressIndex], [HrvFreqDomain]) is a today-only
+     * descriptive lens with no baseline at all. [BaselineRelative] is neither: it's an HOURLY
+     * breakdown of TODAY from DAYTIME/waking-hours HR+RMSSD against a PERSONAL cross-day rolling
+     * baseline. Daytime HR runs warmer than nocturnal resting HR (posture, thermic effect), so it
+     * needs its OWN baseline (`daytime_hr`/`daytime_rmssd`) rather than reusing the nightly
+     * `resting_hr`/`hrv` configs — reusing the nightly ones would systematically over-read stress.
+     * The three surfaces are complementary lenses on the same underlying autonomic signal, not
+     * competing implementations of one baseline.
+     */
+    sealed interface ScoringMode {
+        /**
+         * DEFAULT — unchanged from before this mode existed. Each hour is z-scored against
+         * THIS DAY's own calm-hour reference: the lower quartile of the day's own waking-hour
+         * mean HR, the upper quartile of its own waking-hour RMSSD. No personal history needed —
+         * the day is its own baseline. Byte-identical output to the pre-existing single-mode
+         * `analyze` for the same hr/rr/tzOffsetSeconds.
+         */
+        object DayRelative : ScoringMode
+
+        /**
+         * Oura-style — each hour is z-scored against the PERSONAL rolling baseline for daytime
+         * HR (and, when available, daytime RMSSD): the SAME Winsorized-EWMA machinery
+         * ([Baselines.update] / [Baselines.foldHistory]) that backs the nightly HRV / resting-HR
+         * baselines elsewhere, using [Baselines.daytimeHRCfg] / [Baselines.daytimeRMSSDCfg].
+         *
+         * The HR reference point is [hr]'s baseline, but the HIGH-band threshold does NOT scale
+         * with this person's own day-to-day spread — see [baselineRelativeHighMarginBPM]: the
+         * validated model is a roughly FIXED bpm margin over the personal floor, not a
+         * variability-scaled one.
+         *
+         * [rmssd] is null when no personal RMSSD baseline exists yet — e.g. an imported, Oura-era
+         * day with no R-R stream. The stressor then honestly falls back to HR-only scoring for the
+         * whole read and flags [Result.hrOnlyFallback]; this mirrors the per-hour graceful-null
+         * already in [rawScore], just at the whole-baseline grain. The RMSSD term (when present)
+         * DOES still scale by [rmssd]'s spread via [Baselines.sigma] — only the HR term has a
+         * validated fixed-margin figure so far.
+         */
+        data class BaselineRelative(val hr: BaselineState, val rmssd: BaselineState?) : ScoringMode
+    }
+
     // MARK: - Output
 
     /**
@@ -132,6 +196,23 @@ object DaytimeStress {
          * gravity was supplied or nothing was masked; 0 for [EMPTY].
          */
         val activityMaskedHours: Int = 0,
+        /**
+         * ADDITIVE — total minutes across SCORED waking hours at/above [highBandFloor], the
+         * Oura-comparable "time in high stress" figure. Each scored hour is one [bucketSeconds]
+         * bucket, so this is `(# high-band scored hours) * bucketSeconds / 60`. Compare against
+         * Oura's `stress_high_s / 60` — NOOP's timeline is hourly-grain vs Oura's ~5-minute grain,
+         * so treat this as a coarse approximation, not a precise match. 0 for [EMPTY] and for any
+         * day with no scored hours.
+         */
+        val highStressMinutes: Int = 0,
+        /**
+         * ADDITIVE — true when [ScoringMode.BaselineRelative] mode was requested but had no
+         * personal RMSSD baseline to score against (e.g. an imported Oura-era day with no R-R
+         * history), so the whole read honestly fell back to HR-only scoring. Always false in
+         * [ScoringMode.DayRelative] mode (there, a missing RMSSD is already handled per-hour by
+         * [rawScore], not flagged day-wide) and false for [EMPTY].
+         */
+        val hrOnlyFallback: Boolean = false,
     ) {
         /** The scored hours only (level non-null), in time order. */
         val scored: List<HourPoint> get() = hours.filter { it.level != null }
@@ -139,7 +220,8 @@ object DaytimeStress {
         companion object {
             /** Empty read — used when the day had no usable intraday HR at all. */
             val EMPTY = Result(emptyList(), sustainedHigh = false, sustainedRun = 0,
-                dayMean = null, peak = null, activityMaskedHours = 0)
+                dayMean = null, peak = null, activityMaskedHours = 0,
+                highStressMinutes = 0, hrOnlyFallback = false)
         }
     }
 
@@ -177,8 +259,23 @@ object DaytimeStress {
      * Logistic squash of the raw z-sum onto 0–3 (baseline 0 → 1.5). Identical to
      * StressMath.squash, so an hourly point shares the daily score's scale and bands.
      */
-    private fun squash(raw: Double): Double =
+    internal fun squash(raw: Double): Double =
         (3.0 / (1.0 + exp(-raw))).coerceIn(0.0, 3.0)
+
+    /**
+     * Solve for the z-score spread `sd` such that a raw elevation of exactly [marginBPM] (or any
+     * unit — this is unit-agnostic) squashes to exactly [band] on the shared 0–3 curve:
+     * `band = 3 / (1 + e^(−marginBPM/sd))`. Used to translate [baselineRelativeHighMarginBPM]'s
+     * validated bpm figure into the `sd` the shared [squash] curve expects, so "baseline + margin"
+     * lands exactly on [band] by construction rather than by a second, separate threshold check.
+     * Defensive fallback (never divides by zero/negative-log) if [band] is ever configured at or
+     * outside the curve's open range (0, 3).
+     */
+    internal fun marginToSigma(marginBPM: Double, band: Double): Double {
+        val ratio = 3.0 / band - 1.0
+        if (ratio <= 0.0 || marginBPM <= 0.0) return max(marginBPM, 1e-9)
+        return marginBPM / (-ln(ratio))
+    }
 
     // MARK: - Public API
 
@@ -192,6 +289,9 @@ object DaytimeStress {
      *   present, ambulatory hours are masked out of the score (see the motion-gate constants).
      * @param tzOffsetSeconds seconds east of UTC, for placing each bucket on the LOCAL clock
      *   (so "waking hours" and the hour labels are local). Defaults to UTC.
+     * @param mode [ScoringMode.DayRelative] (DEFAULT — unchanged existing behaviour) or
+     *   [ScoringMode.BaselineRelative] (Oura-style, vs a personal rolling baseline). ADDITIVE and
+     *   opt-in: existing callers that don't pass `mode` keep the exact prior behaviour.
      *
      * Returns [Result.EMPTY] when there isn't a single hour with enough HR to score.
      */
@@ -200,6 +300,7 @@ object DaytimeStress {
         rr: List<RrInterval>,
         gravity: List<GravitySample> = emptyList(),
         tzOffsetSeconds: Long = 0L,
+        mode: ScoringMode = ScoringMode.DayRelative,
     ): Result {
         if (hr.isEmpty()) return Result.EMPTY
 
@@ -255,28 +356,72 @@ object DaytimeStress {
         fun isAmbulatory(bucket: Long): Boolean =
             (activeFracByBucket[bucket] ?: 0.0) >= activityMaskFraction
 
-        // 3) The day's OWN quiet reference: centre on the CALM end (the lower quartile of
-        //    hourly mean HR, the upper quartile of hourly RMSSD), and spread from the
-        //    across-hour SD. This makes a flat day read ~baseline and a spiky day surface its
-        //    tense hours — without any cross-day history. Falls back to the plain mean when
-        //    there are too few scored hours for a quartile.
-        //
-        //    Built from the WAKING hours only — the same hours scored in step 4. Sleep is the
-        //    calmest, lowest-HR / highest-HRV stretch of the day, and the analysis window
-        //    always begins at local midnight, so the current day routinely carries several
-        //    hours of it. Letting those night hours into the reference drags the "calm" anchor
-        //    far beneath every waking hour, inflating an ordinary calm day toward HIGH and
-        //    falsely tripping the sustained-high Breathe nudge.
-        //    Ambulatory hours are excluded from the day's OWN calm reference too: an exertion hour's
-        //    elevated HR / suppressed HRV must not pull the calm anchor up or inflate the across-hour
-        //    spread the z-scores divide by.
-        val referenceAggs = aggs.filter { isWakingHour(it.bucket) && !isAmbulatory(it.bucket) }
-        val hrMeans = referenceAggs.mapNotNull { it.meanHr }
-        val rmssdVals = referenceAggs.mapNotNull { it.rmssd }
-        val refHr = calmReference(hrMeans, calmIsLow = true)         // calm HR is LOW
-        val refRmssd = calmReference(rmssdVals, calmIsLow = false)   // calm HRV is HIGH
-        val sdHr = std(hrMeans, mean(hrMeans))
-        val sdRmssd = std(rmssdVals, mean(rmssdVals))
+        // 3) The reference point + spread for each signal — WHERE they come from depends on
+        //    `mode`. Every other step (bucketing above incl. the motion gate, the waking-hour
+        //    filter, the squash curve, sustained-high, high-stress-minutes below) is identical
+        //    between modes; only the reference differs.
+        val refHr: Double?
+        val sdHr: Double
+        val refRmssd: Double?
+        val sdRmssd: Double
+        val hrOnlyFallback: Boolean
+        when (mode) {
+            is ScoringMode.DayRelative -> {
+                // The day's OWN quiet reference: centre on the CALM end (the lower quartile of
+                // hourly mean HR, the upper quartile of hourly RMSSD), and spread from the
+                // across-hour SD. This makes a flat day read ~baseline and a spiky day surface its
+                // tense hours — without any cross-day history. Falls back to the plain mean when
+                // there are too few scored hours for a quartile.
+                //
+                // Built from the WAKING hours only — the same hours scored in step 4. Sleep is the
+                // calmest, lowest-HR / highest-HRV stretch of the day, and the analysis window
+                // always begins at local midnight, so the current day routinely carries several
+                // hours of it. Letting those night hours into the reference drags the "calm" anchor
+                // far beneath every waking hour, inflating an ordinary calm day toward HIGH and
+                // falsely tripping the sustained-high Breathe nudge.
+                // Ambulatory hours are excluded from the day's OWN calm reference too (the motion
+                // gate): an exertion hour's elevated HR / suppressed HRV must not pull the calm
+                // anchor up or inflate the across-hour spread the z-scores divide by.
+                val referenceAggs = aggs.filter { isWakingHour(it.bucket) && !isAmbulatory(it.bucket) }
+                val hrMeans = referenceAggs.mapNotNull { it.meanHr }
+                val rmssdVals = referenceAggs.mapNotNull { it.rmssd }
+                refHr = calmReference(hrMeans, calmIsLow = true)         // calm HR is LOW
+                refRmssd = calmReference(rmssdVals, calmIsLow = false)   // calm HRV is HIGH
+                sdHr = std(hrMeans, mean(hrMeans))
+                sdRmssd = std(rmssdVals, mean(rmssdVals))
+                hrOnlyFallback = false
+            }
+            is ScoringMode.BaselineRelative -> {
+                // The PERSONAL cross-day baseline, folded by the caller from past daytime
+                // aggregates via Baselines.update/foldHistory (see the ScoringMode doc).
+                // Ambulatory hours are still masked out of the SCORE in step 4 (the motion gate),
+                // but the reference itself is external, so it needs no ambulatory exclusion here.
+                refHr = mode.hr.baseline
+                // VALIDATED tuning, not Baselines.sigma(mode.hr): the correlation study behind
+                // baselineRelativeHighMarginBPM found a roughly FIXED bpm margin over the personal
+                // floor — not one scaled by this person's own day-to-day spread — best matched
+                // Oura's stress signal. marginToSigma solves for the sd that makes exactly
+                // refHr + baselineRelativeHighMarginBPM land on highBandFloor on the shared squash
+                // curve, so the validated margin IS the "high" cutoff by construction.
+                sdHr = marginToSigma(baselineRelativeHighMarginBPM, highBandFloor)
+                val rmssdBaseline = mode.rmssd
+                if (rmssdBaseline != null) {
+                    refRmssd = rmssdBaseline.baseline
+                    // No independently validated RMSSD margin yet (see the constant's doc) — this
+                    // term still scales by the person's own spread via the shared σ conversion.
+                    sdRmssd = Baselines.sigma(rmssdBaseline)
+                    hrOnlyFallback = false
+                } else {
+                    // No personal RMSSD baseline exists (e.g. an Oura-era day with no R-R history to
+                    // fold one from). rawScore already treats a null meanRmssd as "skip this term",
+                    // so passing null here gracefully degrades to HR-only scoring — flagged honestly
+                    // in the output rather than silently.
+                    refRmssd = null
+                    sdRmssd = 0.0
+                    hrOnlyFallback = true
+                }
+            }
+        }
 
         // 4) Score each waking-hour bucket on the shared 0–3 curve.
         val points = ArrayList<HourPoint>(aggs.size)
@@ -308,10 +453,13 @@ object DaytimeStress {
         val scored = points.mapNotNull { p -> p.level?.let { p to it } }
         if (scored.isEmpty()) {
             // No scorable waking hour — still return the (unscored) timeline so the UI can
-            // show "not enough data" rather than nothing.
+            // show "not enough data" rather than nothing. hrOnlyFallback is a MODE property
+            // (whether a personal RMSSD baseline existed to score against), so it's still worth
+            // reporting even though nothing ended up scored.
             return if (points.isEmpty()) Result.EMPTY
             else Result(points, sustainedHigh = false, sustainedRun = 0, dayMean = null, peak = null,
-                activityMaskedHours = activityMaskedHours)
+                activityMaskedHours = activityMaskedHours,
+                highStressMinutes = 0, hrOnlyFallback = hrOnlyFallback)
         }
 
         // 5) Sustained-high flag: walk back from the latest SCORED hour while each is HIGH.
@@ -324,7 +472,14 @@ object DaytimeStress {
         val dayMean = mean(scored.map { it.second })
         val peak = scored.maxByOrNull { it.second }?.first
 
-        return Result(points, sustained, run, dayMean, peak, activityMaskedHours)
+        // 6) Oura-comparable "time in high stress": each scored hour at/above highBandFloor is one
+        //    full bucketSeconds bucket, converted to minutes. Uses the SAME threshold the
+        //    sustained-high check above already uses, so all stay in lockstep by construction.
+        val highStressMinutes = scored.count { it.second >= highBandFloor } * (bucketSeconds / 60L).toInt()
+
+        return Result(points, sustained, run, dayMean, peak,
+            activityMaskedHours = activityMaskedHours,
+            highStressMinutes = highStressMinutes, hrOnlyFallback = hrOnlyFallback)
     }
 
     // MARK: - Helpers

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -204,6 +204,13 @@ object NoopPrefs {
      *  Mirrors iOS `PuffinExperiment.spo2CandidateDisplayKey`. */
     const val KEY_SPO2_CANDIDATE_DISPLAY = "noop.spo2CandidateDisplay"
 
+    /** "Personal daytime-stress baseline" (#463). When ON, the intraday stress timeline scores TODAY
+     *  against a PERSONAL cross-day rolling baseline (Oura-style `.baselineRelative`) instead of the
+     *  day's own calm hours (`.dayRelative`, the default). Default OFF — the validated r≈0.6 HR-only
+     *  margin is single-subject so far, so it ships as a chooseable lens, not a silent default, per the
+     *  derived-biosignal rule (CLAUDE.md). Mirrors iOS `PuffinExperiment.stressPersonalBaselineKey`. */
+    const val KEY_STRESS_PERSONAL_BASELINE = "noop.stressPersonalBaseline"
+
     /** The calendar day (yyyy-MM-dd) on which the morning-journal nudge was last shown, keeps the
      *  Sleep screen's "Good morning" sheet to at most once per day. */
     const val KEY_LAST_JOURNAL_PROMPT = "noop.lastJournalPromptDay"
@@ -459,6 +466,16 @@ object NoopPrefs {
 
     fun setSpo2CandidateDisplay(context: Context, enabled: Boolean) {
         of(context).edit().putBoolean(KEY_SPO2_CANDIDATE_DISPLAY, enabled).apply()
+    }
+
+    /** #463: whether the intraday stress timeline scores against a PERSONAL cross-day baseline
+     *  (`.baselineRelative`) instead of the day's own calm hours. Default false — single-subject
+     *  validated so far, so it ships behind a toggle. Mirrors iOS `stressPersonalBaselineEnabled`. */
+    fun stressPersonalBaseline(context: Context): Boolean =
+        of(context).getBoolean(KEY_STRESS_PERSONAL_BASELINE, false)
+
+    fun setStressPersonalBaseline(context: Context, enabled: Boolean) {
+        of(context).edit().putBoolean(KEY_STRESS_PERSONAL_BASELINE, enabled).apply()
     }
 
     /** Whether the strap log is mirrored to logcat. Default false (normal users don't log to adb). */

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -2724,6 +2724,48 @@ fun SettingsScreen(
                     color = Palette.textTertiary,
                 )
 
+                // --- #463: Personal daytime-stress baseline — OFF by default. ---
+                // Scores today's intraday stress timeline against a PERSONAL cross-day rolling baseline
+                // (Oura-style) instead of the day's own calm hours. The validated r≈0.6 HR-only margin is
+                // single-subject so far, so it ships behind a default-off toggle per the derived-biosignal
+                // rule. Display-only: never fed into recovery/illness. Mirrors the iOS toggle.
+                SettingsRowDivider()
+                var stressPersonalBaseline by remember { mutableStateOf(NoopPrefs.stressPersonalBaseline(context)) }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    Text(
+                        "Stress: personal daytime baseline",
+                        style = NoopType.subhead,
+                        color = Palette.textPrimary,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Switch(
+                        checked = stressPersonalBaseline,
+                        onCheckedChange = {
+                            stressPersonalBaseline = it
+                            NoopPrefs.setStressPersonalBaseline(context, it)
+                        },
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = Palette.surfaceBase,
+                            checkedTrackColor = Palette.accent,
+                            uncheckedThumbColor = Palette.textSecondary,
+                            uncheckedTrackColor = Palette.surfaceInset,
+                            uncheckedBorderColor = Palette.hairline,
+                        ),
+                    )
+                }
+                Text(
+                    "Scores today's hour-by-hour stress timeline against YOUR own cross-day baseline " +
+                        "(how your days usually run, Oura-style) instead of the day's own calm hours. The " +
+                        "cutoff is tuned from a single-subject reference so far, so it's an alternative lens, " +
+                        "not the default. HR-only; never fed into recovery or illness scoring. Off by default.",
+                    style = NoopType.caption,
+                    color = Palette.textTertiary,
+                )
+
                 // Diagnostics: dump the decoded per-sample sensor streams (last 24h) to one long-format
                 // CSV so power users / external devs can prototype sleep/activity/VBT algorithms on real
                 // data without a BLE stream (#308/#276/#322). On-device only; plain text, no BLE hex.

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.noop.analytics.DaytimeBaselines
 import com.noop.analytics.DaytimeStress
 import com.noop.analytics.HrvFreqDomain
 import com.noop.analytics.StressIndex
@@ -121,7 +122,7 @@ fun StressScreen(vm: AppViewModel, onBreathe: () -> Unit = {}) {
     var stressIndex by remember { mutableStateOf<StressIndex.Components?>(null) }
     var freqHrv by remember { mutableStateOf<HrvFreqDomain.Bands?>(null) }
     androidx.compose.runtime.LaunchedEffect(Unit) {
-        val read = runCatching { loadDaytimeStress(vm) }
+        val read = runCatching { loadDaytimeStress(vm, NoopPrefs.stressPersonalBaseline(context)) }
             .getOrDefault(DaytimeReadout(DaytimeStress.Result.EMPTY, null, null))
         daytime = read.daytime
         stressIndex = read.stressIndex
@@ -171,7 +172,7 @@ private data class DaytimeReadout(
  * score's math, so this is the same proxy at a finer grain (never a new score). The SAME `rr` is
  * then fed to the two additive HRV engines (no extra fetch, no DB / schema change).
  */
-private suspend fun loadDaytimeStress(vm: AppViewModel): DaytimeReadout {
+private suspend fun loadDaytimeStress(vm: AppViewModel, personalBaseline: Boolean): DaytimeReadout {
     val nowSeconds = System.currentTimeMillis() / 1000L
     val tzOffsetSeconds = java.util.TimeZone.getDefault().getOffset(nowSeconds * 1_000L) / 1_000L
     // Local midnight (wall-clock seconds): floor the LOCAL time to the day, then undo the
@@ -187,12 +188,43 @@ private suspend fun loadDaytimeStress(vm: AppViewModel): DaytimeReadout {
     // masked rather than scored (DaytimeStress). Same repo read as R-R; empty on hardware or imports
     // with no gravity, which is exactly the "no masking, prior behaviour" degradation.
     val gravity = vm.repo.gravitySamples("my-whoop", from, nowSeconds, limit = 200_000)
-    val daytime = DaytimeStress.analyze(hr, rr, gravity, tzOffsetSeconds)
+    // Score against the PERSONAL cross-day baseline only when the user opted in (#463) AND enough worn
+    // history exists (DaytimeBaselines.scoringMode is the degradation gate); else the day's own calm
+    // hours (DayRelative, the default). The trailing-history reads happen only past the HR-count guard
+    // above and only while the toggle is ON, so the default read is byte-identical to before. Twin of
+    // the iOS StressView daytimeScoringMode.
+    val mode = if (personalBaseline) daytimeScoringMode(vm, todayLocalMidnight = from) else DaytimeStress.ScoringMode.DayRelative
+    val daytime = DaytimeStress.analyze(hr, rr, gravity, tzOffsetSeconds, mode)
     // ADDITIVE advanced readouts from the SAME `rr`. Each engine self-gates and returns null when
     // its requirement is not met, in which case its row is simply hidden in the UI.
     val si = StressIndex.components(rr)
     val freq = HrvFreqDomain.freqDomain(rr)
     return DaytimeReadout(daytime, si, freq)
+}
+
+/**
+ * Build the personal daytime baselines from the trailing [baselineHistoryDays] local days (TODAY
+ * EXCLUDED — it's the day being scored, not part of its own baseline) and return the scoring mode for
+ * today's intraday read: BaselineRelative once there's enough real worn daytime-HR history for a usable
+ * baseline, else DayRelative (the unchanged default). Reads each past day's raw HR once (bounded per
+ * day) via [vm].repo; unworn days (no HR) are skipped without an R-R read. Faithful twin of the iOS
+ * StressView.daytimeScoringMode. [todayLocalMidnight] is today's local-midnight wall-clock second.
+ */
+private suspend fun daytimeScoringMode(vm: AppViewModel, todayLocalMidnight: Long): DaytimeStress.ScoringMode {
+    // 30 mirrors the app's other rolling baselines (nightly resting-HR / HRV) and the iOS baselineHistoryDays.
+    val baselineHistoryDays = 30
+    val days = ArrayList<DaytimeBaselines.DaytimeDayStreams>(baselineHistoryDays)
+    // Oldest → newest so the EWMA fold replays the history in order.
+    for (back in baselineHistoryDays downTo 1) {
+        val dayStart = todayLocalMidnight - back * 86_400L
+        val dayEnd = dayStart + 86_400L - 1L
+        val dayTz = java.util.TimeZone.getDefault().getOffset(dayStart * 1_000L) / 1_000L
+        val dayHr = vm.repo.hrSamples("my-whoop", dayStart, dayEnd, limit = 200_000)
+        if (dayHr.isEmpty()) continue   // unworn day — no floor to learn, skip the R-R read
+        val dayRr = vm.repo.rrIntervals("my-whoop", dayStart, dayEnd, limit = 200_000)
+        days.add(DaytimeBaselines.DaytimeDayStreams(hr = dayHr, rr = dayRr, tzOffsetSeconds = dayTz))
+    }
+    return DaytimeBaselines.scoringMode(days)
 }
 
 // MARK: - Loaded content

--- a/android/app/src/test/java/com/noop/analytics/BaselinesSigmaDaytimeTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/BaselinesSigmaDaytimeTest.kt
@@ -1,0 +1,39 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import kotlin.math.max
+
+/**
+ * Kotlin twin of the sigma() + daytime-config additions in BaselinesTests.swift (PR #413).
+ * Pure-function tests; no DB.
+ */
+class BaselinesSigmaDaytimeTest {
+
+    /**
+     * sigma() is a pure extraction of deviation()'s internal conversion — must match it exactly
+     * and stay internally consistent (deviation at baseline + sigma is z == 1.0).
+     */
+    @Test
+    fun sigmaMatchesDeviationsInternalConversion() {
+        val s = Baselines.foldHistory(List(14) { 50.0 }, Baselines.hrvCfg)
+        val sigma = Baselines.sigma(s)
+        assertEquals(max(1.253 * s.spread, 1e-9), sigma, 1e-9)
+        val dev = Baselines.deviation(s.baseline + sigma, s)
+        assertEquals(1.0, dev.z, 1e-6)
+    }
+
+    /**
+     * The new daytime_hr / daytime_rmssd configs exist, are reachable via both the map and the
+     * convenience accessor, and are distinct from the nightly resting_hr/hrv configs they sit
+     * alongside (different bounds/floor — daytime HR runs warmer than nocturnal RHR).
+     */
+    @Test
+    fun daytimeConfigsExistAndAreDistinctFromNightlyConfigs() {
+        assertEquals(Baselines.daytimeHRCfg, Baselines.metricCfg["daytime_hr"])
+        assertEquals(Baselines.daytimeRMSSDCfg, Baselines.metricCfg["daytime_rmssd"])
+        assertNotEquals(Baselines.daytimeHRCfg, Baselines.restingHRCfg)
+        assertNotEquals(Baselines.daytimeRMSSDCfg, Baselines.hrvCfg)
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/DaytimeBaselinesTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DaytimeBaselinesTest.kt
@@ -1,0 +1,245 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import com.noop.data.RrInterval
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Kotlin twin of StrandAnalytics DaytimeBaselinesTests (PR #463): coverage for the CALLER-side
+ * daytime-baseline fold (DaytimeBaselines) that feeds DaytimeStress.analyze(mode = BaselineRelative)
+ * — the per-day aggregate definition, the trailing-history fold, the graceful-degradation
+ * scoringMode gate, and the fold→score round trip. Pure-function tests; no DB.
+ */
+class DaytimeBaselinesTest {
+
+    // MARK: - Fixtures (multi-day: day `d` is offset by d·86 400 s; local hour-of-day is preserved)
+
+    /** One local day of HR: every hour in [hours] filled with [n] 1 Hz samples at a per-hour bpm. */
+    private fun dayHr(dayIndex: Int, hours: List<Int>, bpms: List<Int>,
+                      n: Int = DaytimeStress.minHourHrSamples): List<HrSample> {
+        val dayBase = dayIndex.toLong() * 86_400L
+        val out = ArrayList<HrSample>()
+        for ((h, bpm) in hours.zip(bpms)) {
+            val base = dayBase + h.toLong() * 3_600L
+            for (i in 0 until n) out.add(HrSample(deviceId = "t", ts = base + i, bpm = bpm))
+        }
+        return out
+    }
+
+    /** One local day flat at a single bpm across waking hours 8…17 (ten scored hours). */
+    private fun flatDayHr(dayIndex: Int, bpm: Int): List<HrSample> =
+        dayHr(dayIndex, (8..17).toList(), List(10) { bpm })
+
+    /** R-R for one local hour with a controllable beat-to-beat jitter (drives RMSSD). */
+    private fun hourRr(dayIndex: Int, hour: Int, rrMs: Int, jitter: Int, n: Int = 120): List<RrInterval> {
+        val base = dayIndex.toLong() * 86_400L + hour.toLong() * 3_600L
+        return (0 until n).map {
+            RrInterval(deviceId = "t", ts = base + it * 30L, rrMs = rrMs + if (it % 2 == 0) jitter else -jitter)
+        }
+    }
+
+    private fun flatDayRr(dayIndex: Int, rrMs: Int, jitter: Int): List<RrInterval> =
+        (8..17).flatMap { hourRr(dayIndex, it, rrMs, jitter) }
+
+    // MARK: - Per-day aggregate
+
+    @Test
+    fun dayHRAggregateIsTheTenthPercentileOfWakingHourMeanHRs() {
+        // Ten waking hours (08…17) with a spread of constant per-hour HRs; each hour's MEAN HR is
+        // just its bpm. P10 of [60,62,64,66,68,70,72,74,76,78] via the shared linear-interp quantile
+        // is 60 + 0.9·(62−60) = 61.8 — the calm floor, well below the day's median.
+        val bpms = listOf(60, 62, 64, 66, 68, 70, 72, 74, 76, 78)
+        val hr = dayHr(0, (8..17).toList(), bpms)
+        val agg = DaytimeBaselines.dayDaytimeAggregate(hr, emptyList(), 0L)
+        assertNotNull(agg.hr)
+        assertEquals(61.8, agg.hr!!, 1e-6)
+        assertNull("no R-R → no daytime RMSSD aggregate", agg.rmssd)
+    }
+
+    @Test
+    fun dayHRAggregateAppliesTheSameMinSamplesGateAsTheScorer() {
+        // An under-gate sparse hour at a very low bpm must NOT drag the P10 floor down — the scorer
+        // would never score it, so the aggregate must not reference it either.
+        val dense = dayHr(0, (8..17).toList(), listOf(60, 62, 64, 66, 68, 70, 72, 74, 76, 78))
+        val sparse = dayHr(0, listOf(7), listOf(40), n = DaytimeStress.minHourHrSamples - 1)
+        val withSparse = DaytimeBaselines.dayDaytimeAggregate(dense + sparse, emptyList(), 0L)
+        val denseOnly = DaytimeBaselines.dayDaytimeAggregate(dense, emptyList(), 0L)
+        assertEquals("a below-gate hour leaked into the daytime-HR floor",
+            denseOnly.hr!!, withSparse.hr!!, 1e-9)
+    }
+
+    @Test
+    fun dayHRAggregateExcludesNonWakingHours() {
+        // A very low 03:00 hour (outside 06:00–22:00) must not become the calm floor.
+        val waking = dayHr(0, (8..17).toList(), listOf(60, 62, 64, 66, 68, 70, 72, 74, 76, 78))
+        val night = dayHr(0, listOf(3), listOf(45))
+        val withNight = DaytimeBaselines.dayDaytimeAggregate(waking + night, emptyList(), 0L)
+        assertEquals("a non-waking hour leaked into the daytime-HR floor", 61.8, withNight.hr!!, 1e-6)
+    }
+
+    @Test
+    fun dayRMSSDAggregateIsPresentWithRRAndTracksVariability() {
+        // A relaxed day (high jitter → high RMSSD) vs a suppressed day (low jitter → low RMSSD):
+        // both produce a non-null median RMSSD aggregate, and the relaxed day's is clearly higher.
+        val hr = flatDayHr(0, 65)
+        val relaxed = DaytimeBaselines.dayDaytimeAggregate(hr, flatDayRr(0, 900, 45), 0L)
+        val suppressed = DaytimeBaselines.dayDaytimeAggregate(hr, flatDayRr(0, 900, 5), 0L)
+        assertNotNull(relaxed.rmssd)
+        assertNotNull(suppressed.rmssd)
+        assertTrue("the higher-variability day should carry a higher median daytime RMSSD",
+            relaxed.rmssd!! > suppressed.rmssd!!)
+    }
+
+    // MARK: - Fold trailing history
+
+    @Test
+    fun foldConvergesHRBaselineToThePersonalDaytimeFloor() {
+        // Twelve identical days whose P10 daytime HR is exactly 65 → the EWMA center converges to 65
+        // and the baseline is usable (12 ≥ minNightsSeed). No R-R anywhere → RMSSD baseline is null.
+        val days = (0 until 12).map { DaytimeBaselines.DaytimeDayStreams(flatDayHr(it, 65), emptyList(), 0L) }
+        val b = DaytimeBaselines.foldDaytimeBaselines(days)
+        assertEquals(65.0, b.hr.baseline, 1e-6)
+        assertTrue(b.hr.usable)
+        assertNull("no daytime R-R history → HR-only baseline", b.rmssd)
+    }
+
+    @Test
+    fun foldReturnsRMSSDBaselineOnlyWhenEnoughDaytimeRRDays() {
+        // Two days of R-R is below minNightsSeed → RMSSD baseline withheld (null → HR-only). Eight
+        // days clears the seed → a usable RMSSD baseline is returned.
+        val twoDays = (0 until 2).map {
+            DaytimeBaselines.DaytimeDayStreams(flatDayHr(it, 65), flatDayRr(it, 900, 40), 0L)
+        }
+        assertNull("an untrustworthy 2-day RMSSD baseline must be withheld",
+            DaytimeBaselines.foldDaytimeBaselines(twoDays).rmssd)
+
+        val eightDays = (0 until 8).map {
+            DaytimeBaselines.DaytimeDayStreams(flatDayHr(it, 65), flatDayRr(it, 900, 40), 0L)
+        }
+        val rmssd = DaytimeBaselines.foldDaytimeBaselines(eightDays).rmssd
+        assertNotNull("eight days of daytime R-R should yield a usable RMSSD baseline", rmssd)
+        assertTrue(rmssd!!.usable)
+    }
+
+    // MARK: - scoringMode graceful degradation
+
+    @Test
+    fun scoringModeFallsBackToDayRelativeOnColdStartAndSparseHistory() {
+        // No history → day-relative (cold start unchanged).
+        assertTrue("empty history must fall back to DayRelative",
+            DaytimeBaselines.scoringMode(emptyList()) is DaytimeStress.ScoringMode.DayRelative)
+        // Three days is below minNightsSeed → still day-relative.
+        val threeDays = (0 until 3).map { DaytimeBaselines.DaytimeDayStreams(flatDayHr(it, 65), emptyList(), 0L) }
+        assertTrue("sub-seed history must fall back to DayRelative",
+            DaytimeBaselines.scoringMode(threeDays) is DaytimeStress.ScoringMode.DayRelative)
+    }
+
+    @Test
+    fun scoringModeUsesBaselineRelativeOnceHistoryIsUsable() {
+        // Six days of real daytime HR clears the seed → the Oura-style baseline-relative mode,
+        // carrying the folded HR baseline (~65) and a null RMSSD baseline (no R-R history here).
+        val days = (0 until 6).map { DaytimeBaselines.DaytimeDayStreams(flatDayHr(it, 65), emptyList(), 0L) }
+        val mode = DaytimeBaselines.scoringMode(days)
+        if (mode !is DaytimeStress.ScoringMode.BaselineRelative) {
+            fail("usable history must select BaselineRelative"); return
+        }
+        assertEquals(65.0, mode.hr.baseline, 1e-6)
+        assertNull(mode.rmssd)
+    }
+
+    // MARK: - Fold → score round trip (the whole point)
+
+    @Test
+    fun foldedBaselineScoresElevationAgainstThePersonalFloorNotTheDaysOwnHours() {
+        // Personal floor folded from history = 65 bpm. TODAY is elevated ALL day (every waking hour
+        // 80 = 65 + the validated 15 bpm margin). A DAY-relative read would anchor on the day's OWN
+        // hours and miss an all-day-high day; the baseline-relative read scores it against the
+        // personal 65 floor, so every hour lands at/above the HIGH band and logs high-stress minutes.
+        val history = (0 until 20).map { DaytimeBaselines.DaytimeDayStreams(flatDayHr(it, 65), emptyList(), 0L) }
+        val mode = DaytimeBaselines.scoringMode(history)
+        if (mode !is DaytimeStress.ScoringMode.BaselineRelative) { fail("expected baseline-relative"); return }
+
+        val today = flatDayHr(0, 80)
+        val r = DaytimeStress.analyze(today, emptyList(), tzOffsetSeconds = 0L, mode = mode)
+        assertFalse(r.scored.isEmpty())
+        assertTrue("no RMSSD baseline → HR-only, honestly flagged", r.hrOnlyFallback)
+        assertTrue("an all-day-elevated day must log high-stress time", r.highStressMinutes > 0)
+        for (p in r.scored) {
+            assertTrue("80 bpm is the personal floor + the validated 15 bpm margin → the HIGH band",
+                p.level!! >= DaytimeStress.highBandFloor - 0.05)
+        }
+    }
+
+    @Test
+    fun foldedBaselineCalmDayAtThePersonalFloorReadsNeutralNotHigh() {
+        // TODAY sits exactly at the personal 65 floor all day → each hour reads ~1.5 (neutral),
+        // never high. Guards the calm end of the scale end-to-end through the fold.
+        val history = (0 until 20).map { DaytimeBaselines.DaytimeDayStreams(flatDayHr(it, 65), emptyList(), 0L) }
+        val mode = DaytimeBaselines.scoringMode(history)
+        val r = DaytimeStress.analyze(flatDayHr(0, 65), emptyList(), tzOffsetSeconds = 0L, mode = mode)
+        assertEquals(0, r.highStressMinutes)
+        for (p in r.scored) assertEquals(1.5, p.level!!, 0.05)
+    }
+
+    @Test
+    fun medianRMSSDBaselineKeepsANormalHourNeutralNoStacking() {
+        // The anti-stacking guarantee behind anchoring the RMSSD aggregate at the MEDIAN (not a calm
+        // ceiling): with BOTH a HR baseline (65) and an RMSSD baseline folded from history, a TODAY
+        // that sits at the HR floor AND at its typical daytime HRV must stay out of the HIGH band. A
+        // ceiling anchor would make this ordinary hour read ~1–2σ "below baseline" and stack a false
+        // stress term.
+        val history = (0 until 20).map {
+            DaytimeBaselines.DaytimeDayStreams(flatDayHr(it, 65), flatDayRr(it, 900, 40), 0L)
+        }
+        // Build the RMSSD-active mode DIRECTLY from the fold, bypassing the scoringMode gate that
+        // holds RMSSD out of LIVE scoring until validated (DaytimeStress.daytimeRMSSDScoringEnabled
+        // is false). This test pins the anti-stacking guarantee of the RMSSD-active scoring path
+        // itself, so it must exercise that path regardless of the production gate. scoringMode's own
+        // gating is covered by scoringModeHoldsRMSSDOutOfLiveScoreWhileGated below.
+        val baselines = DaytimeBaselines.foldDaytimeBaselines(history)
+        assertNotNull("20 days of daytime R-R should yield a usable RMSSD baseline", baselines.rmssd)
+        val mode = DaytimeStress.ScoringMode.BaselineRelative(baselines.hr, baselines.rmssd)
+
+        // Today: HR at the floor, HRV at the SAME typical variability as history.
+        val today = flatDayHr(0, 65)
+        val todayRr = flatDayRr(0, 900, 40)
+        val r = DaytimeStress.analyze(today, todayRr, tzOffsetSeconds = 0L, mode = mode)
+        assertFalse("an RMSSD baseline was supplied", r.hrOnlyFallback)
+        assertEquals("a typical HR+HRV day must not read as high stress", 0, r.highStressMinutes)
+        for (p in r.scored) {
+            assertTrue("a normal hour with an RMSSD baseline must not stack into the HIGH band",
+                p.level!! < DaytimeStress.highBandFloor)
+        }
+    }
+
+    @Test
+    fun scoringModeHoldsRMSSDOutOfLiveScoreWhileGated() {
+        // The live-scoring gate: even with a full daytime-RR history that folds a USABLE RMSSD
+        // baseline, scoringMode (the production entry point) keeps RMSSD OUT of the mode while
+        // DaytimeStress.daytimeRMSSDScoringEnabled is false — so production scores HR-only, the
+        // validated r≈0.6 channel. The fold still produces the usable baseline (the machinery is
+        // live + tested); only its arrival at the score is gated. Flip the flag → this expectation
+        // inverts, which is the intended tripwire for when RMSSD is validated on.
+        val history = (0 until 20).map {
+            DaytimeBaselines.DaytimeDayStreams(flatDayHr(it, 65), flatDayRr(it, 900, 40), 0L)
+        }
+        assertNotNull("precondition: the history must fold a usable RMSSD baseline",
+            DaytimeBaselines.foldDaytimeBaselines(history).rmssd)
+        val mode = DaytimeBaselines.scoringMode(history)
+        if (mode !is DaytimeStress.ScoringMode.BaselineRelative) {
+            fail("usable HR history must still select BaselineRelative"); return
+        }
+        assertTrue("HR baseline still drives the mode", mode.hr.usable)
+        if (DaytimeStress.daytimeRMSSDScoringEnabled) {
+            assertNotNull("flag on: the usable RMSSD baseline should reach live scoring", mode.rmssd)
+        } else {
+            assertNull("flag off: RMSSD is held out of the live score despite a usable baseline", mode.rmssd)
+        }
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/DaytimeStressTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DaytimeStressTest.kt
@@ -22,6 +22,14 @@ class DaytimeStressTest {
         return (0 until n).map { HrSample(deviceId = "t", ts = base + it, bpm = bpm) }
     }
 
+    /** R-R for one hour with a controllable beat-to-beat jitter (drives RMSSD). */
+    private fun hourRrVariable(hour: Int, rrMs: Int, jitter: Int, n: Int = 60): List<RrInterval> {
+        val base = hour.toLong() * 3_600L
+        return (0 until n).map {
+            RrInterval(deviceId = "t", ts = base + it * 50L, rrMs = rrMs + if (it % 2 == 0) jitter else -jitter)
+        }
+    }
+
     @Test
     fun sleepHoursInTheWindow_doNotShiftTheWakingTimeline() {
         // Regression (#357): the calm reference is built from the WAKING hours that are actually
@@ -195,6 +203,179 @@ class DaytimeStressTest {
         assertEquals(
             "a masked exertion hour leaked into the calm reference and moved an unrelated hour's score",
             before!!, after!!, 1e-9,
+        )
+    }
+
+    // MARK: - Additivity: the `mode` parameter is opt-in, day-relative stays the default
+
+    @Test
+    fun dayRelativeDefaultIsByteIdenticalToExplicitMode() {
+        // The additive `mode` parameter defaults to DayRelative. Confirms the implicit call
+        // (every pre-existing call site, unmodified) and the explicit DayRelative case produce a
+        // BYTE-IDENTICAL Result — every field, not just the pre-existing ones — proving the new
+        // mode is purely additive and never a silent behaviour change.
+        val hr = ArrayList<HrSample>()
+        for (h in listOf(8, 9, 10)) hr += hourHr(h, 58)
+        hr += hourHr(13, 120)
+        hr += hourHr(14, 125)
+        hr += hourHr(15, 130)
+        val rr = ArrayList<RrInterval>()
+        rr += hourRrVariable(9, 900, 40)
+        rr += hourRrVariable(14, 900, 5)
+
+        val implicit = DaytimeStress.analyze(hr, rr, tzOffsetSeconds = 3_600L)
+        val explicit = DaytimeStress.analyze(hr, rr, tzOffsetSeconds = 3_600L,
+            mode = DaytimeStress.ScoringMode.DayRelative)
+        assertEquals(
+            "omitting `mode` must be byte-identical to passing DayRelative explicitly",
+            implicit, explicit,
+        )
+    }
+
+    @Test
+    fun highStressMinutesCountsAllHighBandHoursNotJustTheTrailingRun() {
+        // An isolated morning spike, then a calm run ending the day: sustainedHigh only cares about
+        // the TRAILING run (and must be false here, since the day ends calm), but highStressMinutes
+        // is a day-wide tally and must still count the earlier spike hour — proving it is computed
+        // independently, not derived from sustainedRun.
+        val hr = ArrayList<HrSample>()
+        hr += hourHr(7, 130)   // isolated high spike
+        hr += hourHr(8, 60)
+        hr += hourHr(9, 60)
+        hr += hourHr(10, 60)
+        hr += hourHr(11, 60)   // trailing hour is calm -> NOT sustained
+        val r = DaytimeStress.analyze(hr, emptyList())
+
+        assertFalse("the trailing hour is calm, so sustained-high must not fire", r.sustainedHigh)
+        val expectedHighHours = r.scored.count { it.level!! >= DaytimeStress.highBandFloor }
+        assertTrue("the isolated morning spike should read as high band", expectedHighHours > 0)
+        assertEquals(expectedHighHours * (DaytimeStress.bucketSeconds / 60L).toInt(), r.highStressMinutes)
+        assertFalse("day-relative mode never sets the baseline-relative fallback flag", r.hrOnlyFallback)
+    }
+
+    // MARK: - Baseline-relative mode (Oura-style, vs a PERSONAL rolling baseline)
+    //
+    // Fixtures below use a 65 bpm personal HR baseline (matching the ~65 bpm pooled
+    // 10th-percentile figure from the validated 26-day Oura-reference correlation — see
+    // DaytimeStress.baselineRelativeHighMarginBPM) and elevations measured from it in terms of that
+    // validated ~15 bpm margin, so the expected band crossings are exact, not approximate.
+
+    @Test
+    fun marginToSigmaLandsExactlyOnBand() {
+        // The validated 15 bpm margin over baseline must land EXACTLY on highBandFloor (2.0) on the
+        // shared squash curve — the core identity baseline-relative scoring relies on.
+        val sd = DaytimeStress.marginToSigma(DaytimeStress.baselineRelativeHighMarginBPM, DaytimeStress.highBandFloor)
+        assertEquals(
+            DaytimeStress.highBandFloor,
+            DaytimeStress.squash(DaytimeStress.baselineRelativeHighMarginBPM / sd),
+            1e-9,
+        )
+    }
+
+    @Test
+    fun baselineRelativeModeRecoversMultipleInjectedElevations() {
+        // Personal daytime-HR baseline: 20 constant "days" at 65 bpm converges the EWMA center to
+        // exactly 65 (spread is folded but NOT used for the HR high-band threshold).
+        val hrBaseline = Baselines.foldHistory(List(20) { 65.0 }, Baselines.daytimeHRCfg)
+        assertEquals(65.0, hrBaseline.baseline, 1e-6)
+
+        // FOUR distinct injected HR elevations across the SAME day's waking hours — the repo's
+        // derived-signal rule requires recovering MULTIPLE injected values, not a single high-vs-low
+        // pair. 65 (at baseline), 72 (+7, mild), 80 (+15, exactly the validated margin), 95 (+30).
+        val levels = listOf(8 to 65, 10 to 72, 13 to 80, 16 to 95)
+        val hr = ArrayList<HrSample>()
+        for ((h, bpm) in levels) hr += hourHr(h, bpm)
+
+        val r = DaytimeStress.analyze(hr, emptyList(),
+            mode = DaytimeStress.ScoringMode.BaselineRelative(hrBaseline, null))
+        val scores = levels.map { pair -> r.scored.first { it.hour == pair.first }.level!! }
+
+        // Strictly increasing with the injected elevation — all four levels recovered, in order.
+        for (i in 1 until scores.size) {
+            assertTrue(
+                "hour ${levels[i].first} (${levels[i].second} bpm) should score higher than hour " +
+                    "${levels[i - 1].first} (${levels[i - 1].second} bpm)",
+                scores[i] > scores[i - 1],
+            )
+        }
+        // The at-baseline hour reads at the 1.5 midpoint; +15 bpm (the validated margin) lands
+        // exactly on highBandFloor; the most-elevated hour clears well past it.
+        assertEquals(1.5, scores[0], 0.05)
+        assertEquals(
+            "the validated +15 bpm margin should land exactly on highBandFloor",
+            DaytimeStress.highBandFloor, scores[2], 0.01,
+        )
+        assertTrue(scores.last() > DaytimeStress.highBandFloor)
+        assertTrue("rmssd = null must flag the HR-only fallback", r.hrOnlyFallback)
+    }
+
+    @Test
+    fun baselineRelativeCalmDayAtPersonalBaselineReadsLowNotHigh() {
+        val hrBaseline = Baselines.foldHistory(List(20) { 65.0 }, Baselines.daytimeHRCfg)
+        val hr = ArrayList<HrSample>()
+        for (h in listOf(8, 10, 13, 16)) hr += hourHr(h, 65)   // every hour sits exactly at baseline
+        val r = DaytimeStress.analyze(hr, emptyList(),
+            mode = DaytimeStress.ScoringMode.BaselineRelative(hrBaseline, null))
+
+        for (p in r.scored) {
+            assertEquals("a day flat at the personal baseline should read ~1.5, not elevated",
+                1.5, p.level!!, 0.05)
+        }
+        assertEquals(0, r.highStressMinutes)
+        assertFalse(r.sustainedHigh)
+    }
+
+    @Test
+    fun baselineRelativeElevatedDayProducesHighStressMinutes() {
+        val hrBaseline = Baselines.foldHistory(List(20) { 65.0 }, Baselines.daytimeHRCfg)
+        val hr = ArrayList<HrSample>()
+        for (h in 8..16) hr += hourHr(h, 95)   // +30 bpm — twice the validated high-band margin
+        val r = DaytimeStress.analyze(hr, emptyList(),
+            mode = DaytimeStress.ScoringMode.BaselineRelative(hrBaseline, null))
+
+        assertTrue(r.highStressMinutes > 0)
+        assertEquals(
+            r.scored.count { it.level!! >= DaytimeStress.highBandFloor } * (DaytimeStress.bucketSeconds / 60L).toInt(),
+            r.highStressMinutes,
+        )
+        for (p in r.scored) assertTrue(p.level!! >= DaytimeStress.highBandFloor)
+    }
+
+    @Test
+    fun baselineRelativeNilRMSSDFallsBackToHROnlyAndFlagsDegraded() {
+        // An imported, Oura-era day: no personal RMSSD baseline exists yet (rmssd = null) and no R-R
+        // stream is available either. The read must still complete honestly, never crash.
+        val hrBaseline = Baselines.foldHistory(List(20) { 65.0 }, Baselines.daytimeHRCfg)
+        val hr = ArrayList<HrSample>()
+        for (h in listOf(9, 14)) hr += hourHr(h, 80)   // right at the validated +15 bpm margin
+        val r = DaytimeStress.analyze(hr, emptyList(),
+            mode = DaytimeStress.ScoringMode.BaselineRelative(hrBaseline, null))
+
+        assertTrue(r.hrOnlyFallback)
+        assertFalse("HR-only scoring must still produce a timeline", r.scored.isEmpty())
+        for (p in r.scored) assertNotNull(p.level)
+    }
+
+    @Test
+    fun baselineRelativeUsesRMSSDBaselineWhenAvailable() {
+        // Personal baselines: HR steady at 65 bpm, RMSSD steady at 40 ms (both spread-floored).
+        val hrBaseline = Baselines.foldHistory(List(20) { 65.0 }, Baselines.daytimeHRCfg)
+        val rmssdBaseline = Baselines.foldHistory(List(20) { 40.0 }, Baselines.daytimeRMSSDCfg)
+
+        val hr = ArrayList<HrSample>()
+        val rr = ArrayList<RrInterval>()
+        for (h in listOf(9, 14)) hr += hourHr(h, 65)     // HR AT baseline in both hours — isolates RMSSD
+        rr += hourRrVariable(9, 900, 40)                  // normal variability
+        rr += hourRrVariable(14, 900, 2)                  // suppressed HRV -> more stressed
+
+        val r = DaytimeStress.analyze(hr, rr,
+            mode = DaytimeStress.ScoringMode.BaselineRelative(hrBaseline, rmssdBaseline))
+        assertFalse("an RMSSD baseline was supplied — no fallback", r.hrOnlyFallback)
+        val normal = r.scored.first { it.hour == 9 }.level!!
+        val suppressed = r.scored.first { it.hour == 14 }.level!!
+        assertTrue(
+            "suppressed RMSSD vs. the personal baseline should read MORE stressed than normal variability",
+            suppressed > normal,
         )
     }
 }


### PR DESCRIPTION
Revives **#463** (baseline-relative daytime stress, **@vishk23**) onto current `main`, un-stacked from its old base and rebased past the now-merged motion gate (#1114), with two review-driven corrections on top.

## What #463 does

Adds a second scoring mode to `DaytimeStress.analyze`. Instead of z-scoring each waking hour against **the day's own calm hours** (`.dayRelative`, the incumbent), `.baselineRelative` scores against a **personal cross-day rolling baseline** (Oura-style): HR baseline = P10 of waking-hour mean HRs (~65 bpm calm floor), folded via the same Winsorized-EWMA path as the nightly baselines; the HIGH cutoff is a validated fixed **15 bpm** margin over that floor (`marginToSigma`). The RMSSD term is built + tested but **gated out of live scoring** (`daytimeRMSSDScoringEnabled = false`) because raw daytime RMSSD is artifact-dominated — vishk23's own instrument-first call.

The first 6 commits are **@vishk23's**, cherry-picked with authorship intact (conflicts with #1114 resolved: the motion gate masks *which* hours score, the mode picks *what* reference they score against — orthogonal, they compose).

## Review-driven corrections (final commit, mine)

1. **Opt-in, not silent default.** #463 auto-switched every user with a few worn days onto the personal baseline. The validated r≈0.6 margin is **single-subject** so far, so per the derived-biosignal rule (CLAUDE.md: *never make it the default on thin evidence*) it must not silently become the default. Gated behind a **default-off toggle** (Settings → Experimental, both platforms). OFF (default) → `.dayRelative` → **byte-identical to before**, and the trailing-history reads are never paid.

2. **Cross-platform parity.** #463 wired only the iOS `StressView`; the Android `StressScreen` never used the (built + tested) Kotlin pipeline, so the feature was Apple-only. Wired `StressScreen` behind the **same** toggle with a faithful twin of `daytimeScoringMode` (fold trailing 30 local days, today excluded, unworn days skipped). Opted-in users now get the same lens on both platforms; the default stays identical.

## Verification

- **Android**: `compileFullDebugKotlin` clean; `DaytimeStress` (15) + `DaytimeBaselines` (12) + `BaselinesSigmaDaytime` (2) suites **green** — the merged motion-gate × baseline-relative analytics pass together.
- **Parity**: constants byte-identical Swift/Kotlin (margin 15.0, RMSSD-gate false, highBandFloor 2.0, mask 0.30, shadow 8.0); daytime configs identical (35/160/3.0, 5/250/7.0); `.dayRelative` keeps the motion gate's ambulatory-exclusion on both. Toggle prefs are device-local (not in the `.noopbak` whitelist, matching the spo2-candidate toggle).
- **iOS/macOS app target** (`StressView`/`SettingsView`): validated via the app-build gate (default CI doesn't compile app targets).

## Not in scope / honest limits

- The 15 bpm HIGH cutoff is tuned on **one subject's** 26-day Oura correlation — hence opt-in, not default. Multi-subject validation would justify promoting it.
- RMSSD stays gated off pending its own validation pass.

Credit: **@vishk23** (design, validation, Kotlin twins). Supersedes #467 (its motion gate already merged as #1114) and #413 (subset of #463).