### PR TITLE
perf(analyzeRecent): stop the #1005 cache churning on baseline drift during a backfill

### DIFF
--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ScoreConfidenceCacheSigTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ScoreConfidenceCacheSigTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// #1005 (backfill storm): the analyzeRecent per-day cache signature folds the HRV baseline's CONFIDENCE
+/// TIER (`ScoreConfidence.charge`), NOT baselines1's raw value, so a value-only drift during a history
+/// backfill no longer drops the whole cache each offload chunk. `chargeConfidence` is the only cached,
+/// non-pass-2-recomputed field that depends on baselines1, and it reads ONLY the HRV baseline's
+/// usable/trusted STATUS. This pins the property the fix relies on: the charge tier is invariant to the
+/// baseline's VALUE (baseline/spread) and changes only on a genuine STATUS/tier transition. If a future
+/// edit makes `charge` depend on the baseline value, this fails — flagging that the cache sig would churn
+/// again. Twin of the Android ScoreConfidenceCacheSigTest.
+final class ScoreConfidenceCacheSigTests: XCTestCase {
+
+    private func hrv(_ baseline: Double, _ spread: Double, _ nValid: Int,
+                     _ status: BaselineStatus) -> BaselineState {
+        BaselineState(baseline: baseline, spread: spread, nValid: nValid,
+                      nightsSinceUpdate: 0, status: status)
+    }
+
+    func testChargeTierInvariantToBaselineValueDrift() {
+        // Same status (trusted), different value — exactly how a rolling baseline moves as a backfill folds
+        // in nights. The tier (and thus the cache signature contribution) must NOT change.
+        let a = hrv(45, 6, 30, .trusted)
+        let b = hrv(52, 9, 41, .trusted)
+        XCTAssertEqual(ScoreConfidence.charge(recovery: 1.0, hrvBaseline: a), .solid)
+        XCTAssertEqual(ScoreConfidence.charge(recovery: 1.0, hrvBaseline: a),
+                       ScoreConfidence.charge(recovery: 1.0, hrvBaseline: b),
+                       "a value-only baseline drift must not change the charge tier (it would drop the #1005 cache)")
+    }
+
+    func testChargeTierChangesOnStatusTransition() {
+        // A real status transition MUST change the tier, so the cache correctly drops and chargeConfidence
+        // is re-derived. (usable=false → calibrating; usable & !trusted → building; trusted → solid.)
+        let trusted = hrv(45, 6, 30, .trusted)
+        let provisional = hrv(45, 6, 6, .provisional)
+        let calibrating = hrv(45, 6, 2, .calibrating)
+        XCTAssertEqual(ScoreConfidence.charge(recovery: 1.0, hrvBaseline: trusted), .solid)
+        XCTAssertEqual(ScoreConfidence.charge(recovery: 1.0, hrvBaseline: provisional), .building)
+        XCTAssertEqual(ScoreConfidence.charge(recovery: 1.0, hrvBaseline: calibrating), .calibrating)
+        XCTAssertNotEqual(ScoreConfidence.charge(recovery: 1.0, hrvBaseline: trusted),
+                          ScoreConfidence.charge(recovery: 1.0, hrvBaseline: provisional))
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/ScoreConfidenceCacheSigTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ScoreConfidenceCacheSigTest.kt
@@ -1,0 +1,46 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * #1005 (backfill storm): the analyzeRecent per-day cache signature folds the HRV baseline's CONFIDENCE
+ * TIER (`ScoreConfidence.forCharge`), NOT baselines1's raw value, so a value-only drift during a history
+ * backfill no longer drops the whole cache each offload chunk. `chargeConfidence` is the only cached,
+ * non-pass-2-recomputed field that depends on baselines1, and it reads ONLY the HRV baseline's
+ * usable/nValid/trusted STATUS. This pins the property the fix relies on: the charge tier is invariant to
+ * the baseline's VALUE (baseline/spread) and changes only on a genuine STATUS/tier transition. If a future
+ * edit makes forCharge depend on the baseline value, this fails — flagging that the cache sig would churn
+ * again. Twin of the Swift ScoreConfidenceCacheSigTests.
+ */
+class ScoreConfidenceCacheSigTest {
+    private fun hrv(baseline: Double, spread: Double, nValid: Int, status: BaselineStatus) =
+        BaselineState(baseline, spread, nValid, 0, status)
+
+    @Test
+    fun forCharge_tierInvariantToBaselineValueDrift() {
+        // Same status (trusted), different value — exactly how a rolling baseline moves as a backfill folds
+        // in nights. The tier (and thus the cache signature contribution) must NOT change.
+        val a = hrv(baseline = 45.0, spread = 6.0, nValid = 30, status = BaselineStatus.TRUSTED)
+        val b = hrv(baseline = 52.0, spread = 9.0, nValid = 41, status = BaselineStatus.TRUSTED)
+        assertEquals(ScoreConfidence.SOLID, ScoreConfidence.forCharge(1.0, a))
+        assertEquals(
+            "a value-only baseline drift must not change the charge tier (it would drop the #1005 cache)",
+            ScoreConfidence.forCharge(1.0, a), ScoreConfidence.forCharge(1.0, b),
+        )
+    }
+
+    @Test
+    fun forCharge_tierChangesOnStatusTransition() {
+        // A real status transition MUST change the tier, so the cache correctly drops and chargeConfidence
+        // is re-derived. (usable=false → CALIBRATING; usable & !trusted → BUILDING; trusted → SOLID.)
+        val trusted = hrv(45.0, 6.0, 30, BaselineStatus.TRUSTED)
+        val provisional = hrv(45.0, 6.0, 6, BaselineStatus.PROVISIONAL)
+        val calibrating = hrv(45.0, 6.0, 2, BaselineStatus.CALIBRATING)
+        assertEquals(ScoreConfidence.SOLID, ScoreConfidence.forCharge(1.0, trusted))
+        assertEquals(ScoreConfidence.BUILDING, ScoreConfidence.forCharge(1.0, provisional))
+        assertEquals(ScoreConfidence.CALIBRATING, ScoreConfidence.forCharge(1.0, calibrating))
+        assertNotEquals(ScoreConfidence.forCharge(1.0, trusted), ScoreConfidence.forCharge(1.0, provisional))
+    }
+}


### PR DESCRIPTION
## The problem (from a real strap log)

A heavy WHOOP 4.0 user's connection export (1.27 GB DB, 3.5M HR / **4.8M R-R** rows) showed `analyzeRecent` re-scoring **all 21 nights in ~5 minutes after *every* offload chunk** during a large history backfill — 8+ full passes back-to-back (`re-score: done — scored 21 night(s) in 287671 ms (#1005)`, repeated). That's the #1005 battery drain, still present in the heavy-backfill case.

## Root cause

The #1005 per-day reuse cache *is* in the build, but it was delivering **no speedup**: the pass config-signature () folds `baselines1`'s **raw value** (`baselines1.hrv/restingHR`). `baselines1` **re-folds on every offload chunk**, so the sig changed each chunk → the **whole cache was dropped** → all 21 nights went cold → the full 5-minute pass, every time.

The sig's own comment says it holds values *"stable across an offload storm"* — but `baselines1` is precisely **not** storm-stable, so it never belonged there.

## The fix

Fold only the HRV baseline's **confidence tier** (`ScoreConfidence.charge`/`forCharge`), not its value.

I verified this is the *complete* baseline dependency of the cached scan:
- `chargeConfidence` is the **only** cached, non-pass-2-recomputed field that depends on `baselines1`, and it reads **only** the HRV baseline's `usable`/`nValid`/`trusted` **status** (/ are baseline-independent).
- **recovery** and **skin-temp deviation** are re-derived in **pass 2** from `baselines2` for *every* scored night (cached or reused) — so they never go stale.
- `baselines1.restingHR` feeds only recovery → dropped from the sig entirely.

Result: a value-only drift keeps the tier → the cache survives the backfill → the 21-night pass collapses to scoring the 1–2 genuinely-changed nights. A real tier transition (baseline crossing usable/trusted) still drops the cache → `chargeConfidence` stays correct. Delegating to `charge`/`forCharge` (a non-nil dummy score isolates the baseline contribution) can't drift from its own logic.

## No breakages / regressions — checked

- **Recovery/skin-temp**: already pass-2-recomputed per night regardless of cache reuse — unchanged by this PR, so nothing baseline-dependent goes stale.
- **Kotlin**:  clean;  /  /  suites **green** — including  (the  consumer) and .
- **New guard test** (both platforms):  pins that the charge tier is **invariant to baseline value drift** and **changes on a status transition** — if a future edit makes  value-sensitive, the sig would churn again and this fails.
- **Swift**: the new  test runs in swift-packages CI; the app-target sig change is validated by the app-build gate.

## Parity

Both platforms; Swift `.charge` / Kotlin `.forCharge` produce **equivalent tiers** (verified: Kotlin's extra `nValid<7` clause is dead when `trusted`, since trusted ⟹ nValid≥14). Sig strings are per-platform, compared only in-memory to themselves.

Fixes the heavy-backfill residual of #1005.