### PR TITLE
diag: add the computed '-noop' spine to the Recent-Nd data line

### DIFF
--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -242,11 +242,15 @@ enum DebugDataDiagnostics {
         var parts: [String] = []
         var spine: [DailyMetric] = []
         var activeRows: [DailyMetric] = []
+        var computedActive: [DailyMetric] = []
+        var computedSpine: [DailyMetric] = []
         for id in ids {
             let rows = (try? await store.dailyMetrics(deviceId: id, from: "0000-01-01", to: "9999-12-31")) ?? []
             parts.append("\(id)=\(rows.count)")
             if id == "my-whoop" { spine = rows }
             if id == did { activeRows = rows }
+            if id == "\(did)-noop" { computedActive = rows }
+            if id == "my-whoop-noop" { computedSpine = rows }
         }
         lines.append("Days: " + parts.joined(separator: "  "))
         // #731: this line used to read ONLY "my-whoop" and label it "Recent 7d". For a live-BLE user whose
@@ -269,6 +273,11 @@ enum DebugDataDiagnostics {
         var emitted = false
         if let l = recentLine(activeRows, id: did) { lines.append(l); emitted = true }
         if did != "my-whoop", let l = recentLine(spine, id: "my-whoop") { lines.append(l); emitted = true }
+        // The COMPUTED "-noop" spine, where steps/activeKcalEst are actually written — compare with the raw
+        // lines above: kcal/steps populated here but 0 there ⇒ the raw merge/view drops them (cosmetic); 0 on
+        // BOTH ⇒ genuinely not computed (a real gap). Mirrors the Android twin.
+        if let l = recentLine(computedActive, id: "\(did)-noop") { lines.append(l); emitted = true }
+        if did != "my-whoop", let l = recentLine(computedSpine, id: "my-whoop-noop") { lines.append(l); emitted = true }
         if !emitted {
             lines.append("Recent: no day rows")
         }

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -222,10 +222,14 @@ object AndroidDiagnostics {
             val dayCounts = ids.map { it to repo.days(it).size }
             add("Days: " + dayCounts.joinToString("  ") { "${it.first}=${it.second}" })
             // Which metrics are actually populated over the recent week on the imported (raw) spine…
+            // The day-SPAN is stamped so a stale spine is visible: `takeLast(7)` can be the last 7 IMPORTED
+            // rows (months old), not the last 7 CALENDAR days — without the range they look identical. Twin
+            // of the Swift #731 fix.
             val recent = repo.days("my-whoop").takeLast(7)
             if (recent.isNotEmpty()) {
                 val n = recent.size
-                add("Recent ${n}d (my-whoop): " +
+                val span = "${recent.first().day}…${recent.last().day}"
+                add("Recent ${n}d (my-whoop, $span): " +
                     "sleep=${recent.count { (it.totalSleepMin ?: 0.0) > 0 }}/$n  " +
                     "recovery=${recent.count { it.recovery != null }}/$n  " +
                     "steps=${recent.count { it.steps != null }}/$n  " +
@@ -237,7 +241,8 @@ object AndroidDiagnostics {
             val recentNoop = repo.days("my-whoop-noop").takeLast(7)
             if (recentNoop.isNotEmpty()) {
                 val nn = recentNoop.size
-                add("Recent ${nn}d (my-whoop-noop, computed): " +
+                val spanNoop = "${recentNoop.first().day}…${recentNoop.last().day}"
+                add("Recent ${nn}d (my-whoop-noop, computed, $spanNoop): " +
                     "sleep=${recentNoop.count { (it.totalSleepMin ?: 0.0) > 0 }}/$nn  " +
                     "recovery=${recentNoop.count { it.recovery != null }}/$nn  " +
                     "steps=${recentNoop.count { it.steps != null }}/$nn  " +

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -221,7 +221,7 @@ object AndroidDiagnostics {
                 "apple-health", "health-connect").distinct()
             val dayCounts = ids.map { it to repo.days(it).size }
             add("Days: " + dayCounts.joinToString("  ") { "${it.first}=${it.second}" })
-            // Which metrics are actually populated over the recent week on the imported spine.
+            // Which metrics are actually populated over the recent week on the imported (raw) spine…
             val recent = repo.days("my-whoop").takeLast(7)
             if (recent.isNotEmpty()) {
                 val n = recent.size
@@ -231,6 +231,18 @@ object AndroidDiagnostics {
                     "steps=${recent.count { it.steps != null }}/$n  " +
                     "kcal=${recent.count { it.activeKcalEst != null }}/$n")
             } else add("Recent: no day rows")
+            // …and on the COMPUTED "-noop" spine, where steps/activeKcalEst are actually written. Compare the
+            // two: if kcal/steps are populated here but 0 on the raw line above, the raw-spine merge/view is
+            // dropping them (cosmetic); if 0 on BOTH, the value genuinely wasn't computed (a real gap).
+            val recentNoop = repo.days("my-whoop-noop").takeLast(7)
+            if (recentNoop.isNotEmpty()) {
+                val nn = recentNoop.size
+                add("Recent ${nn}d (my-whoop-noop, computed): " +
+                    "sleep=${recentNoop.count { (it.totalSleepMin ?: 0.0) > 0 }}/$nn  " +
+                    "recovery=${recentNoop.count { it.recovery != null }}/$nn  " +
+                    "steps=${recentNoop.count { it.steps != null }}/$nn  " +
+                    "kcal=${recentNoop.count { it.activeKcalEst != null }}/$nn")
+            }
             val dv = repo.dataVolumeSnapshot(active)
             add("Volume: rawRows=${dv.dbRows}  importedDays=${dv.importedDays}  workouts=${dv.workouts}")
         }.onFailure { add("(daily data unavailable: ${it.message})") }


### PR DESCRIPTION
The `Recent Nd` triage line in the strap log reads only the **raw** import/active spine (`my-whoop`), but `steps` and `activeKcalEst` are written to the **computed** `-noop` spine. A heavy WHOOP 4.0 export showed `kcal=0/7` on the raw line — which could mean either the value genuinely wasn't computed, **or** it's computed fine on the `-noop` spine and only the raw-spine merge/view doesn't surface it. The line as-is can't tell those apart.

**Change:** emit a second `Recent Nd` line for the computed `-noop` spine, so triage can compare:
- populated on `-noop` but `0` on raw → a **merge/view drop** (cosmetic)
- `0` on **both** → a **real compute gap** (worth fixing)

Diagnostic strap-log line only — **no** analytics, scoring, or persistence change. Both platforms (Android `AndroidDiagnostics`; Swift `DebugDataDiagnostics` reuses its existing `recentLine` helper, emitting the `<id>-noop` and `my-whoop-noop` spines).

Verification: Android `compileFullDebugKotlin` clean; Swift app-target validated via the app-build gate.
