### PR TITLE
fix(android): wire the VO₂max card's trend tap-through (#1391)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -2142,6 +2142,21 @@ private suspend fun buildSeriesVitalDetail(vm: AppViewModel, key: String): Vital
             .map { VitalReading(it.day, it.value, it.deviceId) },
         format = { it.roundToInt().toString() },
     )
+    // #1391: the VO₂max card (opt-in, #1393) taps through here. Like its sibling computed metrics
+    // (fitness_age / vitality above), the weekly estimate is persisted under the "-noop" computed spine
+    // (IntelligenceEngine writes "vo2max_est"), so its trend reads the COMPUTED union — not the raw
+    // resolvedSeries the imported vitals use, which carries no vo2max_est. Without this case the tap-through
+    // fell to the default and the trend chart was empty (the reported bug). Parity with iOS, which handles
+    // `.vo2max` alongside `.fitnessAge` / `.vitality` and reads `exploreSeries("vo2max_est")`.
+    "vo2max_est" -> VitalDetailModel(
+        key = key,
+        title = uiString(R.string.l10n_health_screen_vo2max_21214fb6),
+        unit = "ml/kg",
+        color = Palette.chargeColor,
+        readings = vm.repo.metricSeriesComputedUnion(vm.activeStrapId, "vo2max_est", "0000-01-01", "9999-12-31")
+            .map { VitalReading(it.day, it.value, it.deviceId) },
+        format = { it.roundToInt().toString() },
+    )
     "steps_est" -> {
         // #377: the Today Steps tile resolves a REAL step count FIRST — the WHOOP 5/MG on-device @57
         // counter (DailyMetric.steps) ?: imported Health Connect / Apple Health ?: the motion-model

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1397,6 +1397,7 @@
     <string name="l10n_health_screen_unlocks_your_vo_max_b3c67dda">Schaltet deine VO₂max frei</string>
     <string name="l10n_health_screen_vital_signs_e7d9e1b1">Vitalwerte</string>
     <string name="l10n_health_screen_vitality_be320b06">Vitalität</string>
+    <string name="l10n_health_screen_vo2max_21214fb6">VO₂max</string>
     <string name="l10n_health_screen_weight_height_and_waist_add_a_fd2699f5">Gewicht, Höhe und Taille fügen eine VO2max Schätzung hinzu. Sie ändern das Fitness-Zeitalter selbst nicht.</string>
     <string name="l10n_how_noop_works_screen_how_your_scores_are_computed_1b2d6c30">So werden deine Werte berechnet</string>
     <string name="l10n_how_noop_works_screen_how_your_scores_work_21a0e2be">So funktionieren deine Werte</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1194,6 +1194,7 @@
     <string name="l10n_health_screen_unlocks_your_vo_max_b3c67dda">Desbloquea tu VO₂max</string>
     <string name="l10n_health_screen_vital_signs_e7d9e1b1">Signos vitales</string>
     <string name="l10n_health_screen_vitality_be320b06">Vitalidad</string>
+    <string name="l10n_health_screen_vo2max_21214fb6">VO₂ máx.</string>
     <string name="l10n_health_screen_weight_height_and_waist_add_a_fd2699f5">Peso, altura y cintura añadir una estimación VO2max. No cambian la edad de fitness en sí.</string>
     <string name="l10n_how_noop_works_screen_how_your_scores_are_computed_1b2d6c30">Cómo se calculan tus puntuaciones</string>
     <string name="l10n_how_noop_works_screen_how_your_scores_work_21a0e2be">Cómo funcionan tus puntuaciones</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1212,6 +1212,7 @@
     <string name="l10n_health_screen_unlocks_your_vo_max_b3c67dda">Débloque votre VO₂max</string>
     <string name="l10n_health_screen_vital_signs_e7d9e1b1">Signes vitaux</string>
     <string name="l10n_health_screen_vitality_be320b06">Vitalité</string>
+    <string name="l10n_health_screen_vo2max_21214fb6">VO₂ max</string>
     <string name="l10n_health_screen_weight_height_and_waist_add_a_fd2699f5">Poids, taille et taille ajouter une estimation de VO2max. Ils ne changent pas l\'âge de la condition physique.</string>
     <string name="l10n_how_noop_works_screen_how_your_scores_are_computed_1b2d6c30">Comment vos scores sont calculés</string>
     <string name="l10n_how_noop_works_screen_how_your_scores_work_21a0e2be">Comment fonctionnent vos scores</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -1354,6 +1354,7 @@
     <string name="l10n_health_screen_unlocks_your_vo_max_b3c67dda">Odblokowuje VO₂max</string>
     <string name="l10n_health_screen_vital_signs_e7d9e1b1">Znaki życiowe</string>
     <string name="l10n_health_screen_vitality_be320b06">Witalność</string>
+    <string name="l10n_health_screen_vo2max_21214fb6">VO₂max</string>
     <string name="l10n_health_screen_weight_height_and_waist_add_a_fd2699f5">Waga, wzrost i talia uwzględniają szacunkową wartość VO₂max. Nie zmieniają samego Wieku Fitness.</string>
     <string name="l10n_how_noop_works_screen_how_your_scores_are_computed_1b2d6c30">Jak obliczane są Twoje wyniki</string>
     <string name="l10n_how_noop_works_screen_how_your_scores_work_21a0e2be">Jak działają Twoje wyniki</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1360,6 +1360,7 @@
     <string name="l10n_health_screen_unlocks_your_vo_max_b3c67dda">Desbloqueia o teu VO₂max</string>
     <string name="l10n_health_screen_vital_signs_e7d9e1b1">Sinais vitais</string>
     <string name="l10n_health_screen_vitality_be320b06">Vitalidade</string>
+    <string name="l10n_health_screen_vo2max_21214fb6">VO₂ máx.</string>
     <string name="l10n_health_screen_weight_height_and_waist_add_a_fd2699f5">O peso, a altura e a cintura acrescentam uma estimativa do VO₂max. Não mudam a Idade do Fitness em ti.</string>
     <string name="l10n_how_noop_works_screen_how_your_scores_are_computed_1b2d6c30">Como são calculadas as tuas pontuações</string>
     <string name="l10n_how_noop_works_screen_how_your_scores_work_21a0e2be">Como funcionam as tuas pontuações</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1340,6 +1340,7 @@
     <string name="l10n_health_screen_unlocks_your_vo_max_b3c67dda">解锁您的最大摄氧量(VO₂max)预估</string>
     <string name="l10n_health_screen_vital_signs_e7d9e1b1">生命体征</string>
     <string name="l10n_health_screen_vitality_be320b06">生命力指数</string>
+    <string name="l10n_health_screen_vo2max_21214fb6">VO₂max</string>
     <string name="l10n_health_screen_weight_height_and_waist_add_a_fd2699f5">体重、身高和腰围有助于提供更精准的 VO₂max 估算值。它们本身不会改变您的体能年龄得分。</string>
     <string name="l10n_how_noop_works_screen_how_your_scores_are_computed_1b2d6c30">各项分数是如何计算的</string>
     <string name="l10n_how_noop_works_screen_how_your_scores_work_21a0e2be">各项分数的工作原理</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1406,6 +1406,7 @@
     <string name="l10n_health_screen_unlocks_your_vo_max_b3c67dda">Unlocks your VO₂max</string>
     <string name="l10n_health_screen_vital_signs_e7d9e1b1">Vital Signs</string>
     <string name="l10n_health_screen_vitality_be320b06">Vitality</string>
+    <string name="l10n_health_screen_vo2max_21214fb6">VO₂ Max</string>
     <string name="l10n_health_screen_weight_height_and_waist_add_a_fd2699f5">Weight, height and waist add a VO₂max estimate. They don\'t change the Fitness Age itself.</string>
     <string name="l10n_how_noop_works_screen_how_your_scores_are_computed_1b2d6c30">How your scores are computed</string>
     <string name="l10n_how_noop_works_screen_how_your_scores_work_21a0e2be">How your scores work</string>


### PR DESCRIPTION
Fixes the follow-up bug on #1391: the opt-in **VO₂max card** (#1393) shows its latest value fine ("Card works perfect") but **tapping it opens an empty trend chart** — reported by @bartmuskala.

## Root cause (Android-only)

The card taps through to `vital_detail/vo2max_est`, but Android's `HealthScreen` vital-detail `when (key)` switch had **no `"vo2max_est"` case** — only its sibling *computed* metrics `fitness_age` and `vitality` were wired (via `metricSeriesComputedUnion`). So the tap-through fell to the default → no readings → empty chart. The card's *latest value* worked because it reads `latestMetricComputedUnion`; the *trend* needs the series.

## Fix

Add the `"vo2max_est"` case, mirroring `fitness_age`/`vitality`: read `metricSeriesComputedUnion(activeStrapId, "vo2max_est", …)` — `vo2max_est` is persisted under the `-noop` computed spine by `IntelligenceEngine` (`:2074`), which the raw `resolvedSeries` the imported vitals use doesn't carry. Colour `chargeColor`.

## Parity

iOS already handles `.vo2max` as a first-class case — grouped with `.fitnessAge`/`.vitality` (`TodayView.swift:2332`), colour `StrandPalette.chargeColor` (`:2364`, matched), series `exploreSeries("vo2max_est")` (`:4056`). This brings Android to that parity. Android-only change — no Swift needed.

## Notes

- New `VO₂ Max` title string added across **all Android locales** (de/es/fr/pl/pt-rPT/zh); `i18n_audit.py --ci` is green (locale forms differ from English, so no new echoes).
- Data already exists (`vo2max_est` persisted per day), so the chart populates immediately for anyone with **waist + resting HR** set — like @bartmuskala.

Verification: `compileFullDebugKotlin` clean; i18n audit green. Thanks @bartmuskala for the report.
