### PR TITLE
feat(fitness): offer a VO₂max without a waist via the Uth HR-ratio fallback (#1391)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/FitnessAgeEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/FitnessAgeEngine.swift
@@ -230,7 +230,9 @@ extension FitnessAgeEngine {
                 detail: "\(activityDays) of last 7 days"),
             FitnessReadinessItem(key: "bodyMetrics", label: "Height & weight",
                 status: hasHeightWeight ? .satisfied : .missing, required: false, role: .unlocksVO2max,
-                detail: hasHeightWeight ? "Unlocks your VO₂max" : "Add to also see VO₂max"),
+                // Height/weight feed calories/BMI, not the VO₂max estimate (Nes uses waist; the Uth
+                // fallback uses HR only). So neutral "Set" — never implying they gate or sharpen VO₂max.
+                detail: hasHeightWeight ? "Set" : "Add it in Settings"),
             FitnessReadinessItem(key: "waist", label: "Waist (optional)",
                 status: hasWaist ? .satisfied : .missing, required: false, role: .unlocksVO2max,
                 detail: hasWaist ? "Sharpens VO₂max" : "Optional - sharpens VO₂max"),

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
@@ -462,7 +462,9 @@ public enum Calories {
     /// with no resting baseline is scored exactly as before. A function of HRmax + resting HR ONLY,
     /// so every call site resolves it locally and day derivation stays deterministic (no cross-day
     /// dependency). (Uth et al. 2004, Eur. J. Appl. Physiol. 91.)
-    static func vo2maxFor(hrmax: Double, restingHR: Double?) -> Double? {
+    // `public`: the app-target IntelligenceEngine reads this shared Uth 2004 estimate for the waist-free
+    // VO₂max fallback (#1391), across the StrandAnalytics module boundary. The Kotlin twin is already public.
+    public static func vo2maxFor(hrmax: Double, restingHR: Double?) -> Double? {
         guard let rhr = restingHR, rhr > 0, hrmax > 0 else { return nil }
         return 15.3 * hrmax / rhr
     }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -347,7 +347,15 @@ final class IntelligenceEngine: ObservableObject {
                     activeDaysPerWeek: strains.count, meanActiveStrain: meanStrain),
                 waistCm: waist) else { return [] }
         var rows = [MetricPoint(day: satKey, key: "fitness_age", value: res.fitnessAge)]
-        if let v = res.vo2max { rows.append(MetricPoint(day: satKey, key: "vo2max_est", value: v)) }
+        // #1391: offer a VO₂max even without a waist. res.vo2max is the Nes 2011 waist-based estimate (nil
+        // when no waist is set). Fall back to the Uth 2004 HR-ratio estimate (15.3·HRmax/RHR — waist-free,
+        // the SAME formula the calorie path already uses), so any user past the age+RHR fitness-age gate gets
+        // a (rougher) VO₂max instead of a blank. HRmax via the shared Tanaka estimator (no HR history here →
+        // age-predicted); RHR = the same median the Nes value used. Both persist under "vo2max_est"; the card
+        // labels it "Estimated". Mirrors the Android twin.
+        let vo2 = res.vo2max
+            ?? Calories.vo2maxFor(hrmax: StrainScorer.estimateHRmax([], age: Double(age)).0, restingHR: medianOf(rhrs))
+        if let v = vo2 { rows.append(MetricPoint(day: satKey, key: "vo2max_est", value: v)) }
         return rows
     }
 

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -199730,7 +199730,7 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Añade tu cintura para una VO₂máx más precisa"
+            "value": "Añade tu cintura para una VO₂max más precisa"
           }
         },
         "fr": {
@@ -199754,7 +199754,7 @@
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adiciona a tua cintura para uma VO₂máx mais precisa"
+            "value": "Adiciona a tua cintura para uma VO₂max mais precisa"
           }
         },
         "ru": {

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -115584,60 +115584,60 @@
         }
       }
     },
-    "Optional: adds your VO₂max estimate. The Fitness Age itself doesn't need it. Measure around your middle, at the navel.": {
+    "Optional: VO₂max already uses your heart rate; a waist makes it more accurate. The Fitness Age itself doesn't need it. Measure around your middle, at the navel.": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Optional: ergänzt deine VO₂max-Schätzung. Das Fitnessalter selbst braucht sie nicht. Miss um deine Mitte, auf Höhe des Bauchnabels."
+            "value": "Optional: Deine VO₂max nutzt bereits deinen Puls; ein Taillenmaß macht sie genauer. Das Fitnessalter selbst braucht sie nicht. Miss um deine Mitte, auf Höhe des Bauchnabels."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Opcional: añade tu estimación de VO₂max. La Edad fitness en sí no lo necesita. Mide alrededor de tu cintura, a la altura del ombligo."
+            "value": "Opcional: tu VO₂max ya usa tu frecuencia cardíaca; la cintura la hace más precisa. La Edad fitness en sí no lo necesita. Mide alrededor de tu cintura, a la altura del ombligo."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Facultatif : ajoute votre estimation de VO₂max. L'Âge fitness lui-même n'en a pas besoin. Mesurez autour de votre taille, au niveau du nombril."
+            "value": "Facultatif : votre VO₂max utilise déjà votre fréquence cardiaque ; le tour de taille la rend plus précise. L'Âge fitness lui-même n'en a pas besoin. Mesurez autour de votre taille, au niveau du nombril."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Facoltativo, aggiunge la tua stima del VO₂max. L'Età di fitness in sé non ne ha bisogno. Misura intorno al punto vita, all'altezza dell'ombelico."
+            "value": "Facoltativo: il tuo VO₂max usa già la frequenza cardiaca; il girovita lo rende più preciso. L'Età di fitness in sé non ne ha bisogno. Misura intorno al punto vita, all'altezza dell'ombelico."
           }
         },
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "Opcional: adiciona a tua estimativa de VO₂máx. A Idade do Fitness em si não precisa disso. Meça à volta do teu meio, no umbigo."
+            "value": "Opcional: a tua VO₂máx já usa a frequência cardíaca; a cintura torna-a mais precisa. A Idade do Fitness em si não precisa disso. Meça à volta do teu meio, no umbigo."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Необязательно: добавляет оценку VO₂max. Самому Фитнес-возрасту это не требуется. Измеряйте в районе талии, на уровне пупка."
+            "value": "Необязательно: VO₂max уже использует ваш пульс; обхват талии делает оценку точнее. Самому Фитнес-возрасту это не требуется. Измеряйте в районе талии, на уровне пупка."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "可选，会加上你的最大摄氧量估算。体能年龄本身并不需要它。请在腰部、肚脐位置测量。"
+            "value": "可选，最大摄氧量已使用你的心率；腰围会让它更准确。体能年龄本身并不需要它。请在腰部、肚脐位置测量。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "可選，會加上你的最大攝氧量估算。體能年齡本身並不需要它。請在腰部、肚臍位置測量。"
+            "value": "可選，最大攝氧量已使用你的心率；腰圍會讓它更準確。體能年齡本身並不需要它。請在腰部、肚臍位置測量。"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Opcjonalnie: dodaje szacunkową wartość VO₂max. Sam wiek fitness tego nie potrzebuje. Zmierz się wokół środka, w pępku."
+            "value": "Opcjonalnie: Twoje VO₂max już korzysta z tętna; obwód w talii zwiększa dokładność. Sam wiek fitness tego nie potrzebuje. Zmierz się wokół środka, w pępku."
           }
         }
       }
@@ -165150,60 +165150,60 @@
         }
       }
     },
-    "Unlocks your VO₂max": {
+    "Sharpens your VO₂max": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Schaltet deine VO₂max frei"
+            "value": "Schärft deine VO₂max"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desbloquea tu VO₂max"
+            "value": "Afina tu VO₂max"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Débloque votre VO₂max"
+            "value": "Affine votre VO₂max"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sblocca il tuo VO₂max"
+            "value": "Affina il tuo VO₂max"
           }
         },
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desbloqueia o teu VO₂max"
+            "value": "Aprimora o teu VO₂max"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Разблокирует ваш VO₂max"
+            "value": "Уточняет ваш VO₂max"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "解锁你的最大摄氧量"
+            "value": "让你的最大摄氧量更准确"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "解鎖你的最大攝氧量"
+            "value": "讓你的最大攝氧量更準確"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Odblokowuje VO₂max"
+            "value": "Uściśla Twoje VO₂max"
           }
         }
       }
@@ -199713,66 +199713,66 @@
         }
       }
     },
-    "Add your waist to unlock your VO₂max": {
+    "Add your waist for a more accurate VO₂max": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Taille eintragen, um deine VO₂max freizuschalten"
+            "value": "Taille eintragen für eine genauere VO₂max"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Add your waist to unlock your VO₂max"
+            "value": "Add your waist for a more accurate VO₂max"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Añade tu cintura para desbloquear tu VO₂máx"
+            "value": "Añade tu cintura para una VO₂máx más precisa"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ajoute ton tour de taille pour débloquer ta VO₂max"
+            "value": "Ajoute ton tour de taille pour une VO₂max plus précise"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aggiungi il girovita per sbloccare la tua VO₂max"
+            "value": "Aggiungi il girovita per una VO₂max più precisa"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Podaj obwód talii, aby odblokować VO₂max"
+            "value": "Podaj obwód talii, aby uzyskać dokładniejszą VO₂max"
           }
         },
         "pt-PT": {
           "stringUnit": {
             "state": "translated",
-            "value": "Adiciona a tua cintura para desbloquear a tua VO₂máx"
+            "value": "Adiciona a tua cintura para uma VO₂máx mais precisa"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Укажите обхват талии, чтобы открыть VO₂max"
+            "value": "Укажите обхват талии для более точного VO₂max"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "添加腰围以解锁你的最大摄氧量"
+            "value": "添加腰围以获得更准确的最大摄氧量"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "新增腰圍以解鎖你的最大攝氧量"
+            "value": "新增腰圍以獲得更準確的最大攝氧量"
           }
         }
       }

--- a/Strand/Screens/HealthView.swift
+++ b/Strand/Screens/HealthView.swift
@@ -643,7 +643,7 @@ private struct ContributorBar: View {
 ///   • no value yet → the checklist card directly, with required-missing inputs deep-linking to Settings.
 ///
 /// The checklist groups inputs by ROLE exactly as the engine reports them: "Drives your Fitness Age"
-/// (age/sex/resting-HR/activity) vs "Unlocks your VO₂max" (height+weight/waist) — never implying the body
+/// (age/sex/resting-HR/activity) vs "Sharpens your VO₂max" (height+weight/waist) — never implying the body
 /// measurements sharpen the age (the body term cancels in the model).
 private struct FitnessAgeSection: View {
     @EnvironmentObject var repo: Repository
@@ -653,7 +653,8 @@ private struct FitnessAgeSection: View {
 
     /// Latest weekly Fitness Age (years) read from the "fitness_age" metricSeries, nil until loaded/computed.
     @State private var fitnessAge: Double?
-    /// Latest estimated VO₂max (ml/kg/min) from "vo2max_est" — only present once a waist is set.
+    /// Latest estimated VO₂max (ml/kg/min) from "vo2max_est" — present even without a waist (the Uth
+    /// HR-ratio fallback, #1391); a waist upgrades it to the more accurate Nes waist-based estimate.
     @State private var vo2max: Double?
     @State private var loaded = false
     /// True while a manual "refresh Fitness Age" recompute is running (spinner in the readiness card).
@@ -725,9 +726,9 @@ private struct FitnessAgeSection: View {
     @ViewBuilder private var content: some View {
         if let age = fitnessAge {
             heroCard(age: age)
-            // Prompt on WAIST being unset (the sole gate), not on vo2max == nil — the latter can be
-            // transiently nil right after waist is set, before the recompute writes vo2max_est.
-            if profile.waistCm <= 0 { vo2maxUnlockPrompt }
+            // Nudge on WAIST being unset (the sole gate). VO₂max is already shown (the Uth fallback), so
+            // the prompt offers to sharpen it to the Nes waist-based estimate, not to reveal a missing number.
+            if profile.waistCm <= 0 { vo2maxSharpenPrompt }
             if showReadiness {
                 ReadinessChecklistCard(readiness: readiness,
                                        lead: nil,
@@ -780,16 +781,16 @@ private struct FitnessAgeSection: View {
     /// The shown-value hero: a scenic Charge-world backdrop, the big Fitness Age number, a
     /// younger/older-than-your-age subtitle, the optional VO₂max, the ±band disclaimer, and the two
     /// affordances (tap-through to the trend + the "How accurate is this?" disclosure).
-    /// Shown when the Fitness Age computes but VO₂max doesn't — the one missing input is a waist
-    /// measurement (the Nes waist-variant needs it). Tapping opens Settings so it's a one-step fix,
-    /// instead of the number silently never appearing (a common "where's my VO₂max?" question).
-    private var vo2maxUnlockPrompt: some View {
+    /// VO₂max is already shown from heart rate alone (the Uth fallback), so this nudges the user to add a
+    /// waist to upgrade it to the more accurate Nes waist-based estimate. Tapping opens Settings — a
+    /// one-step sharpen, shown only while no waist is set.
+    private var vo2maxSharpenPrompt: some View {
         Button { fitnessSheet = .settings } label: {
             HStack(spacing: 8) {
                 Image(systemName: "lungs.fill")
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(StrandPalette.metricCyan)
-                Text("Add your waist to unlock your VO₂max")
+                Text("Add your waist for a more accurate VO₂max")
                     .font(StrandFont.footnote)
                     .foregroundStyle(StrandPalette.textSecondary)
                 Spacer(minLength: 0)
@@ -925,7 +926,7 @@ func fitnessReadyLeadCopy(rhrDays: Int, hasAge: Bool, hasSex: Bool) -> String {
 }
 
 /// The readiness checklist card: an optional lead line, then the engine's `items` as ✓/⚠/○ rows with
-/// their `detail` text, GROUPED by `.role` into "Drives your Fitness Age" and "Unlocks your VO₂max".
+/// their `detail` text, GROUPED by `.role` into "Drives your Fitness Age" and "Sharpens your VO₂max".
 /// A required-but-missing input shows a "Fix in Settings" affordance (the engine's required+missing
 /// rows are age/sex; resting-HR can only be earned by wearing the strap, so it gets no fix button).
 private struct ReadinessChecklistCard: View {
@@ -973,7 +974,7 @@ private struct ReadinessChecklistCard: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 group(title: "Drives your Fitness Age", items: drivesAge)
-                group(title: "Unlocks your VO₂max", items: unlocksVO2)
+                group(title: "Sharpens your VO₂max", items: unlocksVO2)
                 Text("Built from published methods (Nes/HUNT) on \(Platform.deviceNounPhrase). It's a fitness comparison against an average peer your age, not a biological or medical age.")
                     .font(StrandFont.footnote)
                     .foregroundStyle(StrandPalette.textTertiary)

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -459,10 +459,11 @@ struct SettingsView: View {
                     }
                 }
                 rowDivider
-                // Waist (optional). Unlike the rows above it, an empty waist is valid (0 = unset) —
-                // it's the ONE measurement that ADDS the VO₂max estimate alongside Fitness Age. It does
-                // NOT sharpen the Fitness Age itself (the body term cancels in the Nes model), so it sits
-                // apart with an honest "adds your VO₂max estimate" note rather than implying it tunes the age.
+                // Waist (optional). Unlike the rows above it, an empty waist is valid (0 = unset).
+                // VO₂max is ALWAYS offered (the Uth HR-ratio fallback needs no waist, #1391); a waist just
+                // upgrades it to the more accurate Nes waist-based estimate. It does NOT sharpen the Fitness
+                // Age itself (the body term cancels in the Nes model), so the note says it makes VO₂max more
+                // accurate rather than implying it tunes the age.
                 FormRow(label: "Waist (optional)") {
                     // Imperial mode steps in whole inches and stores the cm equivalent; metric steps in cm.
                     if unitSystem == .imperial {
@@ -471,7 +472,7 @@ struct SettingsView: View {
                         waistCentimetresField(waistCm: $profile.waistCm)
                     }
                 }
-                Text("Optional: adds your VO₂max estimate. The Fitness Age itself doesn't need it. Measure around your middle, at the navel.")
+                Text("Optional: VO₂max already uses your heart rate; a waist makes it more accurate. The Fitness Age itself doesn't need it. Measure around your middle, at the navel.")
                     .font(StrandFont.footnote)
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/StrandTests/Vo2maxFallbackTests.swift
+++ b/StrandTests/Vo2maxFallbackTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import Strand
+import StrandAnalytics
+import WhoopStore
+
+/// #1391: VO₂max is offered even WITHOUT a waist. `fitnessAgeRows` persists `vo2max_est` = the Nes 2011
+/// waist-based estimate when a waist is set, else falls back to the Uth 2004 HR-ratio estimate
+/// (15.3·HRmax/RHR, HRmax = Tanaka(age)) — so a user past the age+RHR fitness-age gate gets a VO₂max
+/// instead of a blank. Twin of the Android Vo2maxFallbackTest.
+final class Vo2maxFallbackTests: XCTestCase {
+
+    /// ≥ minCoverageDays (4) RHR nights + strain so the fitness-age gate can compute.
+    private func gate(_ rhr: Int) -> [DailyMetric] {
+        (0..<7).map { i in
+            DailyMetric(day: String(format: "2026-08-%02d", 9 + i), totalSleepMin: nil, efficiency: nil,
+                        deepMin: nil, remMin: nil, lightMin: nil, disturbances: nil, restingHr: rhr,
+                        avgHrv: nil, recovery: nil, strain: 50, exerciseCount: nil)
+        }
+    }
+
+    private func vo2maxEst(waistCm: Double) -> Double? {
+        IntelligenceEngine.fitnessAgeRows(
+            gateDays: gate(60), age: 40, sex: "male", waistCm: waistCm, heightCm: 175, weightKg: 80,
+            computedId: "my-whoop-noop", satKey: "2026-08-15"
+        ).first { $0.key == "vo2max_est" }?.value
+    }
+
+    func testNoWaistFallsBackToUthHrRatioEstimate() {
+        let vo2 = vo2maxEst(waistCm: 0)   // no waist → Nes value is nil
+        XCTAssertNotNil(vo2, "without a waist, VO₂max must still be offered via the Uth fallback")
+        // Uth: 15.3 × Tanaka(40)=180 / RHR 60 = 45.9
+        XCTAssertEqual(vo2!, 15.3 * StrainScorer.tanakaHRmax(age: 40) / 60.0, accuracy: 1e-6)
+    }
+
+    func testWaistSetUsesTheNesWaistBasedEstimate() {
+        let uth = vo2maxEst(waistCm: 0)!
+        let nes = vo2maxEst(waistCm: 90)!
+        let paIndex = FitnessAgeEngine.physicalActivityIndexFromStrain(activeDaysPerWeek: 7, meanActiveStrain: 50)
+        // With a waist the persisted value is the Nes waist-based estimate…
+        XCTAssertEqual(nes, FitnessAgeEngine.estimateVO2max(age: 40, sex: "male", waistCm: 90,
+                                                            restingHR: 60, paIndex: paIndex), accuracy: 1e-6)
+        // …and it differs from the Uth HR-ratio fallback.
+        XCTAssertGreaterThan(abs(nes - uth), 0.01)
+    }
+}

--- a/StrandTests/Vo2maxFallbackTests.swift
+++ b/StrandTests/Vo2maxFallbackTests.swift
@@ -7,6 +7,10 @@ import WhoopStore
 /// waist-based estimate when a waist is set, else falls back to the Uth 2004 HR-ratio estimate
 /// (15.3·HRmax/RHR, HRmax = Tanaka(age)) — so a user past the age+RHR fitness-age gate gets a VO₂max
 /// instead of a blank. Twin of the Android Vo2maxFallbackTest.
+///
+/// `@MainActor`: `IntelligenceEngine.fitnessAgeRows` is main-actor-isolated, so the whole fixture
+/// runs on the main actor to call it from a synchronous test context.
+@MainActor
 final class Vo2maxFallbackTests: XCTestCase {
 
     /// ≥ minCoverageDays (4) RHR nights + strain so the fitness-age gate can compute.

--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -510,10 +510,6 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
-      "Adds your VO₂max estimate"
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Auto · ${profile.hrMaxAuto} bpm (Tanaka)"
     ],
     [
@@ -562,7 +558,7 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
-      "Optional · adds your VO₂max estimate"
+      "Optional · VO₂max already uses your heart rate; a waist makes it more accurate"
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
@@ -627,6 +623,10 @@
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Wear the strap, tap once, then let it sync and share your strap log."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
+      "Your VO₂max uses your waist for a more accurate estimate"
     ],
     [
       "android/app/src/main/java/com/noop/ui/SkinTempCardsScreen.kt",

--- a/android/app/src/main/java/com/noop/analytics/FitnessAgeEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/FitnessAgeEngine.kt
@@ -155,7 +155,9 @@ object FitnessAgeEngine {
             FitnessReadinessItem("bodyMetrics", "Height & weight",
                 if (hasHeightWeight) FitnessReadinessStatus.SATISFIED else FitnessReadinessStatus.MISSING,
                 required = false, role = FitnessReadinessRole.UNLOCKS_VO2MAX,
-                detail = if (hasHeightWeight) "Unlocks your VO₂max" else "Add to also see VO₂max"),
+                // Height/weight feed calories/BMI, not the VO₂max estimate (Nes uses waist; the Uth
+                // fallback uses HR only). So neutral "Set" — never implying they gate or sharpen VO₂max.
+                detail = if (hasHeightWeight) "Set" else "Add it in Settings"),
             FitnessReadinessItem("waist", "Waist (optional)",
                 if (hasWaist) FitnessReadinessStatus.SATISFIED else FitnessReadinessStatus.MISSING,
                 required = false, role = FitnessReadinessRole.UNLOCKS_VO2MAX,

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -2071,7 +2071,17 @@ object IntelligenceEngine {
             paIndex = FitnessAgeEngine.physicalActivityIndexFromStrain(strains.size, meanStrain),
             waistCm = waist) ?: return emptyList()
         val rows = mutableListOf(MetricSeriesRow(deviceId = computedId, day = satKey, key = "fitness_age", value = res.fitnessAge))
-        res.vo2max?.let { rows.add(MetricSeriesRow(deviceId = computedId, day = satKey, key = "vo2max_est", value = it)) }
+        // #1391: offer a VO₂max even without a waist. res.vo2max is the Nes 2011 waist-based estimate (null
+        // when no waist is set). Fall back to the Uth 2004 HR-ratio estimate (15.3·HRmax/RHR — waist-free,
+        // the SAME formula the calorie path already uses), so any user past the age+RHR fitness-age gate gets
+        // a (rougher) VO₂max instead of a blank. HRmax via the shared Tanaka estimator (no HR history here →
+        // age-predicted); RHR = the same median the Nes value used. Both persist under "vo2max_est"; the card
+        // labels it "Estimated". Mirrors the Swift twin.
+        val vo2: Double? = res.vo2max ?: run {
+            val hrmax: Double = StrainScorer.estimateHRmax(emptyList<Double>(), profile.age).first
+            Calories.vo2maxFor(hrmax, medianOfDoubles(rhrs))
+        }
+        if (vo2 != null) rows.add(MetricSeriesRow(deviceId = computedId, day = satKey, key = "vo2max_est", value = vo2))
         return rows
     }
 

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -628,7 +628,7 @@ private fun ContributorBar(
 // latest "fitness_age" the IntelligenceEngine writes into metricSeries under the computed "-noop"
 // source — this section only READS it; it never recomputes the headline. Honest framing throughout:
 // it's a fitness comparison (± 5 yr band), never a biological age, and weight/height/waist live under
-// "Unlocks your VO₂max", never as if they sharpen the age. When no value exists yet we show the
+// "Sharpens your VO₂max", never as if they sharpen the age. When no value exists yet we show the
 // readiness checklist instead, so the user knows exactly what's still needed.
 
 /** Fitness Age readiness from what a screen can see: RHR coverage over the last 7 merged daily rows
@@ -697,9 +697,9 @@ private fun FitnessAgeSection(vm: AppViewModel, days: List<DailyMetric>, profile
                 onHowAccurate = { showChecklist = !showChecklist },
                 checklistOpen = showChecklist,
             )
-            // #1: the weekly Fitness Age computed but VO₂max didn't — the one missing input is a waist
-            // measurement. Key on waist being unset (not vo2max == null, which is transiently null right
-            // after waist is set) — prompt for it (tap → Settings) instead of silently omitting the number.
+            // #1391: VO₂max is shown even without a waist (the Uth HR-ratio fallback), so a waist no longer
+            // "unlocks" the number — it upgrades it to the more accurate Nes waist-based estimate. Key on
+            // waist being unset and nudge for it (tap → Settings) to sharpen the figure already displayed.
             if (profile.waistCm <= 0.0) {
                 Row(
                     modifier = Modifier
@@ -713,7 +713,7 @@ private fun FitnessAgeSection(vm: AppViewModel, days: List<DailyMetric>, profile
                     Icon(Icons.Filled.MonitorHeart, contentDescription = null,
                         tint = Palette.metricCyan, modifier = Modifier.size(16.dp))
                     Text(
-                        uiString(R.string.l10n_health_screen_add_your_waist_to_unlock_your_vo_max_94c646cb),
+                        uiString(R.string.l10n_health_screen_add_your_waist_for_a_more_accurate_vo_max_829f5e1e),
                         style = NoopType.footnote, color = Palette.textSecondary,
                         modifier = Modifier.weight(1f),
                     )
@@ -1027,7 +1027,7 @@ private fun fitnessReadyLead(rhrDays: Int, hasAge: Boolean, hasSex: Boolean): St
 }
 
 /** The readiness checklist card: each input as a ✓ / ⚠ / ○ glyph + its detail, grouped by role into
- *  "Drives your Fitness Age" and "Unlocks your VO₂max". When [headed] (no value yet) it leads with the
+ *  "Drives your Fitness Age" and "Sharpens your VO₂max". When [headed] (no value yet) it leads with the
  *  [lead] countdown and floats the required-missing items to the top of their group. */
 @Composable
 private fun FitnessReadinessCard(
@@ -1088,7 +1088,7 @@ private fun FitnessReadinessCard(
             }
 
             ReadinessGroup(title = uiString(R.string.l10n_health_screen_drives_your_fitness_age_9d0d1219), items = drivesAge, onOpenSettings = onOpenSettings)
-            ReadinessGroup(title = uiString(R.string.l10n_health_screen_unlocks_your_vo_max_b3c67dda), items = unlocksVo2, onOpenSettings = onOpenSettings)
+            ReadinessGroup(title = uiString(R.string.l10n_health_screen_sharpens_your_vo_max_c9d52991), items = unlocksVo2, onOpenSettings = onOpenSettings)
 
             Text(
                 uiString(R.string.l10n_health_screen_weight_height_and_waist_add_a_fd2699f5),

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -983,7 +983,11 @@ fun SettingsScreen(
                         }
                         Spacer(Modifier.height(6.dp))
                         Text(
-                            text = if (hasWaist) "Adds your VO₂max estimate" else "Optional · adds your VO₂max estimate",
+                            // #1391: VO₂max is offered from heart rate alone (Uth HR-ratio) even without a
+                            // waist; a waist switches it to the more accurate body-composition estimate. So the
+                            // sub-text now says what's used + how a waist helps, not "adds/unlocks".
+                            text = if (hasWaist) "Your VO₂max uses your waist for a more accurate estimate"
+                                   else "Optional · VO₂max already uses your heart rate; a waist makes it more accurate",
                             style = NoopType.footnote,
                             color = if (hasWaist) Palette.accent else Palette.textTertiary,
                         )

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1394,7 +1394,7 @@
     <string name="l10n_health_screen_skin_temperature_f59127f6">Hauttemperatur</string>
     <string name="l10n_health_screen_spo_respiratory_rate_and_skin_temperature_0ae0ad8f">SpO2, Atemfrequenz und Hauttemperatur sind Schlaffenster</string>
     <string name="l10n_health_screen_steps_cdde4f20">Schritte</string>
-    <string name="l10n_health_screen_unlocks_your_vo_max_b3c67dda">Schaltet deine VO₂max frei</string>
+    <string name="l10n_health_screen_sharpens_your_vo_max_c9d52991">Schärft deine VO₂max</string>
     <string name="l10n_health_screen_vital_signs_e7d9e1b1">Vitalwerte</string>
     <string name="l10n_health_screen_vitality_be320b06">Vitalität</string>
     <string name="l10n_health_screen_vo2max_21214fb6">VO₂max</string>
@@ -2015,7 +2015,7 @@
     <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Eigene HF-Zonen</string>
     <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Lege die Herzfrequenz fest, bei der jede Zone beginnt. Ausschalten, um die Standardzonen in Prozent der maximalen Herzfrequenz wiederherzustellen.</string>
     <string name="l10n_settings_screen_zone_starts_a0a60d45">Beginn Zone %1$d</string>
-    <string name="l10n_health_screen_add_your_waist_to_unlock_your_vo_max_94c646cb">Taille eintragen, um deine VO₂max freizuschalten</string>
+    <string name="l10n_health_screen_add_your_waist_for_a_more_accurate_vo_max_829f5e1e">Taille eintragen für eine genauere VO₂max</string>
     <string name="l10n_health_screen_fix_in_settings_d7472915">In Einstellungen beheben</string>
     <string name="l10n_app_changelog_personalized_heart_rate_zones_compare_and_8d89ee2a">Personalisierte Herzfrequenzzonen, Gurte vergleichen und wechseln, und ehrlichere HRV-, Schlaf- und Oura-Werte</string>
     <string name="l10n_breathe_screen_elapsed_target_b1c2d3e4">%1$s / %2$s</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1191,7 +1191,7 @@
     <string name="l10n_health_screen_skin_temperature_f59127f6">Temperatura de la piel</string>
     <string name="l10n_health_screen_spo_respiratory_rate_and_skin_temperature_0ae0ad8f">SpO2, la frecuencia respiratoria y la temperatura de la piel son la ventana del sueño</string>
     <string name="l10n_health_screen_steps_cdde4f20">Pasos</string>
-    <string name="l10n_health_screen_unlocks_your_vo_max_b3c67dda">Desbloquea tu VO₂max</string>
+    <string name="l10n_health_screen_sharpens_your_vo_max_c9d52991">Afina tu VO₂máx</string>
     <string name="l10n_health_screen_vital_signs_e7d9e1b1">Signos vitales</string>
     <string name="l10n_health_screen_vitality_be320b06">Vitalidad</string>
     <string name="l10n_health_screen_vo2max_21214fb6">VO₂ máx.</string>
@@ -1982,7 +1982,7 @@
     <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Zonas de FC personalizadas</string>
     <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Define las pulsaciones en las que empieza cada zona. Desactiva para restaurar las zonas predeterminadas por porcentaje de la frecuencia máxima.</string>
     <string name="l10n_settings_screen_zone_starts_a0a60d45">Inicio de la zona %1$d</string>
-    <string name="l10n_health_screen_add_your_waist_to_unlock_your_vo_max_94c646cb">Añade tu cintura para desbloquear tu VO₂máx</string>
+    <string name="l10n_health_screen_add_your_waist_for_a_more_accurate_vo_max_829f5e1e">Añade tu cintura para una VO₂máx más precisa</string>
     <string name="l10n_health_screen_fix_in_settings_d7472915">Corregir en Ajustes</string>
     <string name="l10n_app_changelog_personalized_heart_rate_zones_compare_and_8d89ee2a">Zonas de frecuencia cardíaca personalizadas, comparar y cambiar de correa, y lecturas más honestas de HRV, sueño y Oura</string>
 

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1191,7 +1191,7 @@
     <string name="l10n_health_screen_skin_temperature_f59127f6">Temperatura de la piel</string>
     <string name="l10n_health_screen_spo_respiratory_rate_and_skin_temperature_0ae0ad8f">SpO2, la frecuencia respiratoria y la temperatura de la piel son la ventana del sueño</string>
     <string name="l10n_health_screen_steps_cdde4f20">Pasos</string>
-    <string name="l10n_health_screen_sharpens_your_vo_max_c9d52991">Afina tu VO₂máx</string>
+    <string name="l10n_health_screen_sharpens_your_vo_max_c9d52991">Afina tu VO₂max</string>
     <string name="l10n_health_screen_vital_signs_e7d9e1b1">Signos vitales</string>
     <string name="l10n_health_screen_vitality_be320b06">Vitalidad</string>
     <string name="l10n_health_screen_vo2max_21214fb6">VO₂ máx.</string>
@@ -1982,7 +1982,7 @@
     <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Zonas de FC personalizadas</string>
     <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Define las pulsaciones en las que empieza cada zona. Desactiva para restaurar las zonas predeterminadas por porcentaje de la frecuencia máxima.</string>
     <string name="l10n_settings_screen_zone_starts_a0a60d45">Inicio de la zona %1$d</string>
-    <string name="l10n_health_screen_add_your_waist_for_a_more_accurate_vo_max_829f5e1e">Añade tu cintura para una VO₂máx más precisa</string>
+    <string name="l10n_health_screen_add_your_waist_for_a_more_accurate_vo_max_829f5e1e">Añade tu cintura para una VO₂max más precisa</string>
     <string name="l10n_health_screen_fix_in_settings_d7472915">Corregir en Ajustes</string>
     <string name="l10n_app_changelog_personalized_heart_rate_zones_compare_and_8d89ee2a">Zonas de frecuencia cardíaca personalizadas, comparar y cambiar de correa, y lecturas más honestas de HRV, sueño y Oura</string>
 

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1209,7 +1209,7 @@
     <string name="l10n_health_screen_skin_temperature_f59127f6">Température cutanée</string>
     <string name="l10n_health_screen_spo_respiratory_rate_and_skin_temperature_0ae0ad8f">SpO2, le taux respiratoire et la température de la peau sont la fenêtre du sommeil</string>
     <string name="l10n_health_screen_steps_cdde4f20">Pas</string>
-    <string name="l10n_health_screen_unlocks_your_vo_max_b3c67dda">Débloque votre VO₂max</string>
+    <string name="l10n_health_screen_sharpens_your_vo_max_c9d52991">Affine votre VO₂max</string>
     <string name="l10n_health_screen_vital_signs_e7d9e1b1">Signes vitaux</string>
     <string name="l10n_health_screen_vitality_be320b06">Vitalité</string>
     <string name="l10n_health_screen_vo2max_21214fb6">VO₂ max</string>
@@ -2000,7 +2000,7 @@
     <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Zones FC personnalisées</string>
     <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Définis la fréquence cardiaque à laquelle chaque zone commence. Désactive pour rétablir les zones par défaut en pourcentage de la fréquence maximale.</string>
     <string name="l10n_settings_screen_zone_starts_a0a60d45">Début de la zone %1$d</string>
-    <string name="l10n_health_screen_add_your_waist_to_unlock_your_vo_max_94c646cb">Ajoute ton tour de taille pour débloquer ta VO₂max</string>
+    <string name="l10n_health_screen_add_your_waist_for_a_more_accurate_vo_max_829f5e1e">Ajoute ton tour de taille pour une VO₂max plus précise</string>
     <string name="l10n_health_screen_fix_in_settings_d7472915">Corriger dans les réglages</string>
     <string name="l10n_app_changelog_personalized_heart_rate_zones_compare_and_8d89ee2a">Zones de fréquence cardiaque personnalisées, comparer et changer de sangle, et des lectures HRV, sommeil et Oura plus honnêtes</string>
     <string name="l10n_breathe_screen_elapsed_target_b1c2d3e4">%1$s / %2$s</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -1351,7 +1351,7 @@
     <string name="l10n_health_screen_skin_temperature_f59127f6">Temperatura skóry</string>
     <string name="l10n_health_screen_spo_respiratory_rate_and_skin_temperature_0ae0ad8f">SpO₂, częstość oddechów i temperatura skóry to okno snu</string>
     <string name="l10n_health_screen_steps_cdde4f20">Kroki</string>
-    <string name="l10n_health_screen_unlocks_your_vo_max_b3c67dda">Odblokowuje VO₂max</string>
+    <string name="l10n_health_screen_sharpens_your_vo_max_c9d52991">Uściśla Twoje VO₂max</string>
     <string name="l10n_health_screen_vital_signs_e7d9e1b1">Znaki życiowe</string>
     <string name="l10n_health_screen_vitality_be320b06">Witalność</string>
     <string name="l10n_health_screen_vo2max_21214fb6">VO₂max</string>
@@ -1977,7 +1977,7 @@
     <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Własne strefy HR</string>
     <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Ustaw tętno, przy którym zaczyna się każda strefa. Wyłącz, aby przywrócić domyślne strefy oparte na procencie tętna maksymalnego.</string>
     <string name="l10n_settings_screen_zone_starts_a0a60d45">Początek strefy %1$d</string>
-    <string name="l10n_health_screen_add_your_waist_to_unlock_your_vo_max_94c646cb">Podaj obwód talii, aby odblokować VO₂max</string>
+    <string name="l10n_health_screen_add_your_waist_for_a_more_accurate_vo_max_829f5e1e">Podaj obwód talii, aby uzyskać dokładniejszą VO₂max</string>
     <string name="l10n_health_screen_fix_in_settings_d7472915">Popraw w Ustawieniach</string>
     <string name="l10n_breathe_screen_about_pace_o3p4q5r6">O tym tempie</string>
     <string name="l10n_breathe_screen_breathe_in_a5b6c7d8">Wdech…</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1357,7 +1357,7 @@
     <string name="l10n_health_screen_skin_temperature_f59127f6">Temperatura da pele</string>
     <string name="l10n_health_screen_spo_respiratory_rate_and_skin_temperature_0ae0ad8f">A SpO₂, a frequência respiratória e a temperatura da pele são janelas do sono </string>
     <string name="l10n_health_screen_steps_cdde4f20">Passos</string>
-    <string name="l10n_health_screen_unlocks_your_vo_max_b3c67dda">Desbloqueia o teu VO₂max</string>
+    <string name="l10n_health_screen_sharpens_your_vo_max_c9d52991">Aprimora o teu VO₂máx</string>
     <string name="l10n_health_screen_vital_signs_e7d9e1b1">Sinais vitais</string>
     <string name="l10n_health_screen_vitality_be320b06">Vitalidade</string>
     <string name="l10n_health_screen_vo2max_21214fb6">VO₂ máx.</string>
@@ -1976,7 +1976,7 @@
     <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Zonas de RH personalizadas</string>
     <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Define os batimentos em que cada zona começa. Desativa para repor as zonas predefinidas por percentagem da frequência máxima.</string>
     <string name="l10n_settings_screen_zone_starts_a0a60d45">Início da zona %1$d</string>
-    <string name="l10n_health_screen_add_your_waist_to_unlock_your_vo_max_94c646cb">Adiciona a tua cintura para desbloquear a tua VO₂máx</string>
+    <string name="l10n_health_screen_add_your_waist_for_a_more_accurate_vo_max_829f5e1e">Adiciona a tua cintura para uma VO₂máx mais precisa</string>
     <string name="l10n_health_screen_fix_in_settings_d7472915">Corrigir nas Definições</string>
     <string name="l10n_app_changelog_personalized_heart_rate_zones_compare_and_8d89ee2a">Zonas de frequência cardíaca personalizadas, comparar e trocar de faixa, e leituras mais honestas de HRV, sono e Oura</string>
     <string name="l10n_breathe_screen_about_pace_o3p4q5r6">Sobre este ritmo</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1357,7 +1357,7 @@
     <string name="l10n_health_screen_skin_temperature_f59127f6">Temperatura da pele</string>
     <string name="l10n_health_screen_spo_respiratory_rate_and_skin_temperature_0ae0ad8f">A SpO₂, a frequência respiratória e a temperatura da pele são janelas do sono </string>
     <string name="l10n_health_screen_steps_cdde4f20">Passos</string>
-    <string name="l10n_health_screen_sharpens_your_vo_max_c9d52991">Aprimora o teu VO₂máx</string>
+    <string name="l10n_health_screen_sharpens_your_vo_max_c9d52991">Aprimora o teu VO₂max</string>
     <string name="l10n_health_screen_vital_signs_e7d9e1b1">Sinais vitais</string>
     <string name="l10n_health_screen_vitality_be320b06">Vitalidade</string>
     <string name="l10n_health_screen_vo2max_21214fb6">VO₂ máx.</string>
@@ -1976,7 +1976,7 @@
     <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Zonas de RH personalizadas</string>
     <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Define os batimentos em que cada zona começa. Desativa para repor as zonas predefinidas por percentagem da frequência máxima.</string>
     <string name="l10n_settings_screen_zone_starts_a0a60d45">Início da zona %1$d</string>
-    <string name="l10n_health_screen_add_your_waist_for_a_more_accurate_vo_max_829f5e1e">Adiciona a tua cintura para uma VO₂máx mais precisa</string>
+    <string name="l10n_health_screen_add_your_waist_for_a_more_accurate_vo_max_829f5e1e">Adiciona a tua cintura para uma VO₂max mais precisa</string>
     <string name="l10n_health_screen_fix_in_settings_d7472915">Corrigir nas Definições</string>
     <string name="l10n_app_changelog_personalized_heart_rate_zones_compare_and_8d89ee2a">Zonas de frequência cardíaca personalizadas, comparar e trocar de faixa, e leituras mais honestas de HRV, sono e Oura</string>
     <string name="l10n_breathe_screen_about_pace_o3p4q5r6">Sobre este ritmo</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1337,7 +1337,7 @@
     <string name="l10n_health_screen_skin_temperature_f59127f6">皮肤体温</string>
     <string name="l10n_health_screen_spo_respiratory_rate_and_skin_temperature_0ae0ad8f">血氧、呼吸频率和皮肤体温数据仅在睡眠期间有效</string>
     <string name="l10n_health_screen_steps_cdde4f20">步数</string>
-    <string name="l10n_health_screen_unlocks_your_vo_max_b3c67dda">解锁您的最大摄氧量(VO₂max)预估</string>
+    <string name="l10n_health_screen_sharpens_your_vo_max_c9d52991">让你的最大摄氧量(VO₂max)更准确</string>
     <string name="l10n_health_screen_vital_signs_e7d9e1b1">生命体征</string>
     <string name="l10n_health_screen_vitality_be320b06">生命力指数</string>
     <string name="l10n_health_screen_vo2max_21214fb6">VO₂max</string>
@@ -1910,7 +1910,7 @@
     <string name="l10n_settings_screen_custom_hr_zones_84736ca5">自定义心率区间</string>
     <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">设置每个区间开始时的心率。关闭可恢复按最大心率百分比划分的默认区间。</string>
     <string name="l10n_settings_screen_zone_starts_a0a60d45">区间 %1$d 起点</string>
-    <string name="l10n_health_screen_add_your_waist_to_unlock_your_vo_max_94c646cb">添加腰围以解锁你的最大摄氧量</string>
+    <string name="l10n_health_screen_add_your_waist_for_a_more_accurate_vo_max_829f5e1e">添加腰围以获得更准确的最大摄氧量</string>
     <string name="l10n_health_screen_fix_in_settings_d7472915">在设置中修复</string>
     <string name="l10n_app_changelog_personalized_heart_rate_zones_compare_and_8d89ee2a">自定义心率区间、比较并切换设备，以及更真实的 HRV、睡眠与 Oura 读数</string>
     <string name="l10n_breathe_screen_about_pace_o3p4q5r6">关于此节奏</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1337,7 +1337,7 @@
     <string name="l10n_health_screen_skin_temperature_f59127f6">皮肤体温</string>
     <string name="l10n_health_screen_spo_respiratory_rate_and_skin_temperature_0ae0ad8f">血氧、呼吸频率和皮肤体温数据仅在睡眠期间有效</string>
     <string name="l10n_health_screen_steps_cdde4f20">步数</string>
-    <string name="l10n_health_screen_sharpens_your_vo_max_c9d52991">让你的最大摄氧量(VO₂max)更准确</string>
+    <string name="l10n_health_screen_sharpens_your_vo_max_c9d52991">让你的最大摄氧量更准确</string>
     <string name="l10n_health_screen_vital_signs_e7d9e1b1">生命体征</string>
     <string name="l10n_health_screen_vitality_be320b06">生命力指数</string>
     <string name="l10n_health_screen_vo2max_21214fb6">VO₂max</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1403,7 +1403,7 @@
     <string name="l10n_health_screen_skin_temperature_f59127f6">Skin Temperature</string>
     <string name="l10n_health_screen_spo_respiratory_rate_and_skin_temperature_0ae0ad8f">SpO₂, respiratory rate and skin temperature are sleep-window </string>
     <string name="l10n_health_screen_steps_cdde4f20">Steps</string>
-    <string name="l10n_health_screen_unlocks_your_vo_max_b3c67dda">Unlocks your VO₂max</string>
+    <string name="l10n_health_screen_sharpens_your_vo_max_c9d52991">Sharpens your VO₂max</string>
     <string name="l10n_health_screen_vital_signs_e7d9e1b1">Vital Signs</string>
     <string name="l10n_health_screen_vitality_be320b06">Vitality</string>
     <string name="l10n_health_screen_vo2max_21214fb6">VO₂ Max</string>
@@ -2027,7 +2027,7 @@
     <string name="l10n_settings_screen_custom_hr_zones_84736ca5">Custom HR zones</string>
     <string name="l10n_settings_screen_custom_hr_zones_hint_f7fa3bae">Set the BPM where each zone begins. Turn off to restore the default percentage-of-max zones.</string>
     <string name="l10n_settings_screen_zone_starts_a0a60d45">Zone %1$d starts</string>
-    <string name="l10n_health_screen_add_your_waist_to_unlock_your_vo_max_94c646cb">Add your waist to unlock your VO₂max</string>
+    <string name="l10n_health_screen_add_your_waist_for_a_more_accurate_vo_max_829f5e1e">Add your waist for a more accurate VO₂max</string>
     <string name="l10n_health_screen_fix_in_settings_d7472915">Fix in Settings</string>
     <string name="l10n_app_changelog_personalized_heart_rate_zones_compare_and_8d89ee2a">Personalized heart-rate zones, compare and switch between straps, and more honest HRV, sleep and Oura reads</string>
     <string name="l10n_breathe_screen_elapsed_target_b1c2d3e4">%1$s / %2$s</string>

--- a/android/app/src/test/java/com/noop/analytics/Vo2maxFallbackTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/Vo2maxFallbackTest.kt
@@ -1,0 +1,46 @@
+package com.noop.analytics
+
+import com.noop.data.DailyMetric
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+
+/**
+ * #1391: VO₂max is offered even WITHOUT a waist. `fitnessAgeRows` persists `vo2max_est` = the Nes 2011
+ * waist-based estimate when a waist is set, else falls back to the Uth 2004 HR-ratio estimate
+ * (15.3·HRmax/RHR, HRmax = Tanaka(age)) — so a user past the age+RHR fitness-age gate gets a VO₂max
+ * instead of a blank. Twin of the Swift Vo2maxFallbackTests.
+ */
+class Vo2maxFallbackTest {
+    // ≥ minCoverageDays (4) RHR nights + strain so the fitness-age gate can compute.
+    private fun gate(rhr: Int) = (0 until 7).map {
+        DailyMetric(deviceId = "my-whoop", day = "2026-08-%02d".format(9 + it), restingHr = rhr, strain = 50.0)
+    }
+
+    @Test
+    fun noWaist_fallsBackToUthHrRatioEstimate() {
+        val profile = UserProfile(age = 40.0, sex = "male", waistCm = 0.0)   // no waist → Nes value is null
+        val rows = IntelligenceEngine.fitnessAgeRows(gate(rhr = 60), profile, "my-whoop-noop", "2026-08-15")
+        val vo2 = rows.firstOrNull { it.key == "vo2max_est" }
+        assertNotNull("without a waist, VO₂max must still be offered via the Uth fallback", vo2)
+        // Uth: 15.3 × Tanaka(40)=180 / RHR 60 = 45.9
+        assertEquals(15.3 * StrainScorer.tanakaHRmax(40.0) / 60.0, vo2!!.value, 1e-6)
+    }
+
+    @Test
+    fun waistSet_usesTheNesWaistBasedEstimate() {
+        val noWaist = UserProfile(age = 40.0, sex = "male", waistCm = 0.0)
+        val withWaist = UserProfile(age = 40.0, sex = "male", waistCm = 90.0, heightCm = 175.0, weightKg = 80.0)
+        val uth = IntelligenceEngine.fitnessAgeRows(gate(60), noWaist, "my-whoop-noop", "2026-08-15")
+            .first { it.key == "vo2max_est" }.value
+        val nes = IntelligenceEngine.fitnessAgeRows(gate(60), withWaist, "my-whoop-noop", "2026-08-15")
+            .first { it.key == "vo2max_est" }.value
+        // With a waist the persisted value is the Nes waist-based estimate (waist term present)…
+        val paIndex = FitnessAgeEngine.physicalActivityIndexFromStrain(7, 50.0)
+        assertEquals(FitnessAgeEngine.estimateVO2max(40.0, "male", 90.0, 60.0, paIndex), nes, 1e-6)
+        // …and it is a different number from the Uth HR-ratio fallback.
+        assertTrue("Nes (waist) and Uth (HR-ratio) estimates should differ", abs(nes - uth) > 0.01)
+    }
+}


### PR DESCRIPTION
Follow-on to #1391: VO₂max was **blank until you set a waist**. This offers it to essentially any user with scored nights.

## Why it was gated
The persisted `vo2max_est` is the **Nes 2011 waist-circumference** estimate, which is `nil` without a waist (`FitnessAgeEngine.swift:138`). So VO₂max showed "—" for anyone who hadn't measured their waist.

## The fix
A waist-free estimate **already exists** — the **Uth 2004 HR-ratio** method (`15.3·HRmax/RHR`) that the calorie path uses (`Calories.vo2maxFor`). Fall back to it when the Nes value is unavailable:
```
vo2 = res.vo2max ?? Calories.vo2maxFor(hrmax: Tanaka(age), restingHR: median(rhrs))
```
HRmax via the shared `StrainScorer.estimateHRmax([], age)` (age-predicted Tanaka here, since there's no HR history at this point); RHR = the same median the Nes value already uses. Both persist under `vo2max_est`; the card already labels it "Estimated".

## Safety / no regression
- **Waist-users unchanged** — the Nes value short-circuits the fallback.
- **No existing row changes** — only adds `vo2max_est` where it was previously absent; `fitness_age` untouched.
- Reachable exactly when intended: `canCompute` needs only age + sex + ≥4 RHR nights (waist is `required=false`).

## Parity
Both platforms, **byte-identical** fallback (same `Calories.vo2maxFor`, same `estimateHRmax([], age)` Tanaka, same median RHR).

## Tests
New `Vo2maxFallbackTest`/`Tests` pin: no-waist → the Uth value (`15.3·Tanaka(age)/RHR`), waist → the Nes value, and the two differ. Green: `FitnessAge` (21), `Vo2maxCalories` (6), `Intelligence` suites + the new test (Kotlin 2/2; Swift via the app-build gate).

## Honest note
The HR-ratio estimate is **rougher** than the waist-based one, so the number will refine (shift) when a user adds their waist — an accepted trade-off for offering VO₂max more broadly. Thanks @bartmuskala for the VO₂max thread.
