### PR TITLE
fix(android): route vo2max_est to its series trend — completes #1404 (#1391)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1718,7 +1718,11 @@ private data class VitalDetailModel(
  *  (Fitness Age + Vitality under the computed strap, Steps estimate, Apple active energy). Each Today
  *  dashboard card taps through to ITS OWN focused trend here (2026-07-03), so these load their
  *  series from the repo on demand rather than off the cached `days` columns. Mirrors iOS metricDetail. */
-private val SERIES_BACKED_VITAL_KEYS = setOf("fitness_age", "vitality", "steps_est", "active_kcal", "rest")
+// #1391/#1404: vo2max_est is a COMPUTED weekly series under the "-noop" spine, like fitness_age/vitality —
+// so its detail must route to buildSeriesVitalDetail (which reads metricSeriesComputedUnion), NOT the
+// DailyMetric-backed buildVitalDetail. #1404 added the vo2max_est CASE to the series builder but omitted it
+// here, so isSeriesBacked was false and the tap-through fell to the DailyMetric builder → empty trend.
+private val SERIES_BACKED_VITAL_KEYS = setOf("fitness_age", "vitality", "steps_est", "active_kcal", "rest", "vo2max_est")
 
 @Composable
 fun VitalDetailScreen(vm: AppViewModel, key: String) {


### PR DESCRIPTION
**Completes #1404**, which didn't actually fix bartmuskala's empty-trend bug.

## What #1404 missed
The VO₂max card taps through to `vital_detail/vo2max_est`. Android's detail screen dispatches via `isSeriesBacked = key in SERIES_BACKED_VITAL_KEYS`:
- series-backed → `buildSeriesVitalDetail` (reads `metricSeriesComputedUnion` — where `vo2max_est` lives)
- else → `buildVitalDetail` (DailyMetric fields)

#1404 added the `vo2max_est` **case** to `buildSeriesVitalDetail`, but never added `vo2max_est` to **`SERIES_BACKED_VITAL_KEYS`**. So `isSeriesBacked` was **false**, the tap-through routed to `buildVitalDetail` (no vo2max_est case) → **the trend was still empty.**

## Fix
Add `"vo2max_est"` to `SERIES_BACKED_VITAL_KEYS` so it reaches the series builder #1404 wired.

## Audit (the whole point)
I cross-checked **every** dashboard-card tap-through key against the routing + both builders. `vo2max_est` was the **only** broken one; the other nine (hrv, rhr, resp, spo2, skin → `buildVitalDetail`; fitness_age, vitality, steps_est, active_kcal → `buildSeriesVitalDetail`) all resolve correctly. iOS routes `.vo2max` to the Health detail with its siblings — no gap.

Android-only; `compileFullDebugKotlin` clean. Thanks @bartmuskala.