### PR TITLE
#1405: de-collide the Charge synthesis word from the readiness verdict

### DIFF
--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -206786,6 +206786,64 @@
           }
         }
       }
+    },
+    "A training read, separate from your Charge score.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Trainingswert, unabhängig von deinem Charge-Score."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una lectura de entrenamiento, independiente de tu puntuación de Charge."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une lecture d'entraînement, distincte de votre score Charge."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una lettura per l'allenamento, separata dal tuo punteggio Charge."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odczyt treningowy, niezależny od Twojego wyniku Charge."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uma leitura de treino, separada da tua pontuação de Charge."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тренировочный показатель, отдельный от вашего показателя Charge."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "训练参考，与你的 Charge 分数无关。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "訓練參考，與你的 Charge 分數無關。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -1607,6 +1607,13 @@ struct TodayView: View {
                                     .help("Acute (7-day) vs chronic (28-day) training load. 0.8-1.3 is the sweet spot.")
                             }
                         }
+                        // #1405: mark this as a DIFFERENT axis from the home Synthesis word (the Charge-%
+                        // band). Stated where the two get compared, so "Primed" here vs "Steady" there
+                        // doesn't read as one value contradicting itself. Keep parity with Kotlin.
+                        Text("A training read, separate from your Charge score.")
+                            .font(StrandFont.footnote)
+                            .foregroundStyle(StrandPalette.textTertiary)
+                            .fixedSize(horizontal: false, vertical: true)
                         Text(LocalizedStringKey(r.summary)).font(StrandFont.subhead)
                             .foregroundStyle(StrandPalette.textSecondary)
                             .fixedSize(horizontal: false, vertical: true)

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -4523,11 +4523,16 @@ struct TodayView: View {
     /// A short recovery state word for the synthesis hero.
     private func synthesisWord(_ score: Double?) -> String {
         guard let s = score else { return String(localized: "No Data") }
+        // #1405: these are CHARGE/recovery-level words, a different axis from the ReadinessEngine training
+        // verdict (Run down / Strained / Balanced / Primed). They must NOT share a word, or the Synthesis
+        // card ("Steady") and the Charge-breakdown Readiness card ("Primed") read as the same thing
+        // contradicting itself. So the [70,88) band is "Strong" (which also matches this card's own "Charge
+        // is strong" detail copy), leaving "Primed" exclusively to the readiness engine. Keep parity with Kotlin.
         switch s {
         case ..<25:  return String(localized: "Depleted")
         case ..<50:  return String(localized: "Low")
         case ..<70:  return String(localized: "Steady")
-        case ..<88:  return String(localized: "Primed")
+        case ..<88:  return String(localized: "Strong")
         default:     return String(localized: "Peak")
         }
     }

--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -722,6 +722,10 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
+      "A training read, separate from your Charge score."
+    ],
+    [
+      "android/app/src/main/java/com/noop/ui/TodayScreen.kt",
       "CALIBRATING"
     ],
     [

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -6096,6 +6096,15 @@ private fun ReadinessSection(days: List<DailyMetric>, carriedDay: DailyMetric? =
                 }
             }
 
+            // #1405: mark this card as a DIFFERENT axis from the home Synthesis word (which bands the
+            // Charge %). Stated at the point the two get compared, so "Primed" here vs "Steady" there
+            // doesn't read as one value contradicting itself. Raw string, matching this card's copy.
+            Text(
+                "A training read, separate from your Charge score.",
+                style = NoopType.footnote,
+                color = Palette.textTertiary,
+            )
+
             // Plain-English summary.
             Text(
                 readiness.summary,

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -6369,11 +6369,16 @@ private fun greetingWord(): String {
 
 private fun synthesisWord(score: Double?): String {
     if (score == null) return "No Data"
+    // #1405: these are CHARGE/recovery-level words, a different axis from the ReadinessEngine training
+    // verdict (Run down / Strained / Balanced / Primed). They must NOT share a word, or the Synthesis
+    // card ("Steady") and the Charge-breakdown Readiness card ("Primed") read as the same thing
+    // contradicting itself. So the [70,88) band is "Strong" (which also matches this card's own "Charge is
+    // strong" detail copy), leaving "Primed" exclusively to the readiness engine. Keep parity with Swift.
     return when {
         score < 25 -> "Depleted"
         score < 50 -> "Low"
         score < 70 -> "Steady"
-        score < 88 -> "Primed"
+        score < 88 -> "Strong"
         else -> "Peak"
     }
 }


### PR DESCRIPTION
Fixes the readiness-label mismatch in #1405 (home Synthesis card vs Charge-details Readiness card).

**Root cause:** two independent computations shared the word "Primed":
- `synthesisWord(recovery)` — a Charge/recovery **%** band (Depleted / Low / Steady / **Primed** / Peak).
- `ReadinessEngine` — a **multi-signal** training verdict (Run down / Strained / Balanced / **Primed**).

A day with recovery ≈ 50–70 % (→ "Steady") but aligned signals + supported load (→ "Primed") showed "Steady" on home and "Primed" in the Charge breakdown — same day, two axes, one shared word, reading as a contradiction. Not staleness; not an Android regression (iOS is byte-identical).

**Fix:** rename the recovery `[70,88)` band `"Primed" → "Strong"`, so the two vocabularies never overlap. "Strong" also matches the card's own "Charge is strong" detail copy. "Primed" stays exclusive to the readiness engine.

- Byte-parity Swift (`TodayView.swift`) + Kotlin (`TodayScreen.kt`) — same thresholds and words.
- iOS reuses the existing fully-localized `"Strong"` key; `"Primed"` still used by the readiness level (not orphaned). Android renders these raw (pre-existing non-localized helper).
- No tests pin it, no logic branches on the word (colors key on score/level). i18n audit green.

App-target Swift touched (`TodayView.swift`) → app-build dispatched.