### PR TITLE
fix(ble): read the reboot-ack result at the family's offset (5/MG @12)

### DIFF
--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -126,9 +126,15 @@ public final class FrameRouter {
             // POWER_CYCLE_STRAP is matched too: it's the 4.0 reboot probe's candidate B (#235), and its
             // result byte is exactly what tells "opcode rejected (recognized, wrong args)" from "ignored".
             if let cmd = parsed.cmdName, cmd.hasPrefix("REBOOT_STRAP") || cmd.hasPrefix("POWER_CYCLE_STRAP") {
-                let r = Self.commandResultByte(in: frame)
+                // bhelm/noop#4: read the result at the FAMILY's offset (4.0 @8, 5/MG @12) and judge it with
+                // the family's own polarity. 5/MG's CommandResult table is 1=SUCCESS / 0=FAILURE (BodyLocation
+                // Probe, MG vectors), so a raw byte at the fixed 4.0 offset read the inner *type* byte on 5/MG
+                // and printed REJECTED on a successful reboot — the Kotlin twin already judged the decoded
+                // result name and was correct. 4.0's result-code meaning stays the probe's (unverified) 0=accepted.
+                let r = Self.commandResultByte(in: frame, family: family)
                 let rhex = r.map { String(format: "0x%02x", UInt8(truncatingIfNeeded: $0)) } ?? "none"
-                let verdict = r == nil ? "no result byte" : (r == 0 ? "accepted" : "REJECTED")
+                let accepted = (family == .whoop5) ? (r == 1) : (r == 0)
+                let verdict = r == nil ? "no result byte" : (accepted ? "accepted" : "REJECTED")
                 state.append(log: "reboot: strap acked result=\(rhex) (\(verdict))")
             }
             if family == .whoop4, let cmd = parsed.cmdName {
@@ -321,9 +327,14 @@ public final class FrameRouter {
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    /// The result byte of a COMMAND_RESPONSE: inner offset + 4 ([type,seq,cmd,origin_seq] then result).
-    static func commandResultByte(in frame: [UInt8]) -> Int? {
-        let idx = whoop4InnerOffset + 4
+    /// The result byte of a COMMAND_RESPONSE: the family's inner offset + 4 ([type,seq,cmd,origin_seq]
+    /// then result). WHOOP 4.0's inner starts at offset 4 (result @8); WHOOP 5/MG's starts at 8 (result
+    /// @12 — the "+4 shift", Framing/Interpreter). Defaults to `.whoop4` so the WHOOP-4-only callers
+    /// (rename, alarm-SET ack) stay untouched; only the both-families reboot ack passes the live family
+    /// (bhelm/noop#4 — reading @8 on a 5/MG frame hit the inner type byte, not the result).
+    static func commandResultByte(in frame: [UInt8], family: DeviceFamily = .whoop4) -> Int? {
+        let inner = (family == .whoop5) ? 8 : whoop4InnerOffset
+        let idx = inner + 4
         return idx < frame.count ? Int(frame[idx]) : nil
     }
 

--- a/StrandTests/FrameRouterRebootAckTests.swift
+++ b/StrandTests/FrameRouterRebootAckTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import Strand
+import WhoopProtocol
+
+/// bhelm/noop#4: the reboot-ack diagnostic must read the COMMAND_RESPONSE result byte at the FAMILY's
+/// offset — WHOOP 4.0 @8, WHOOP 5/MG @12 (the "+4 shift"). Reading the fixed 4.0 offset on a 5/MG frame
+/// hit the inner *type* byte (non-zero) and logged REJECTED on a successful reboot.
+///
+/// `@MainActor`: `FrameRouter` is a main-actor class, so its static helper is called from the main actor.
+@MainActor
+final class FrameRouterRebootAckTests: XCTestCase {
+
+    func testCommandResultByteReadsTheFamilyOffset() {
+        // Distinct sentinels at the two candidate result positions.
+        var frame = [UInt8](repeating: 0, count: 16)
+        frame[8]  = 0x24   // 5/MG inner TYPE byte (COMMAND_RESPONSE) — what the old fixed offset hit
+        frame[12] = 0x01   // 5/MG result = SUCCESS(1)
+
+        XCTAssertEqual(FrameRouter.commandResultByte(in: frame, family: .whoop5), 1,
+                       "5/MG result lives at byte 12, not the 4.0 offset")
+        XCTAssertEqual(FrameRouter.commandResultByte(in: frame, family: .whoop4), 0x24,
+                       "4.0 result lives at byte 8")
+        XCTAssertEqual(FrameRouter.commandResultByte(in: frame), 0x24,
+                       "default family is .whoop4, so the WHOOP-4-only callers are unaffected")
+    }
+
+    func testShortFrameHasNoResultByte() {
+        // A 5/MG frame too short to carry a byte-12 result → nil (the log prints "no result byte").
+        XCTAssertNil(FrameRouter.commandResultByte(in: [UInt8](repeating: 0, count: 12), family: .whoop5))
+    }
+}


### PR DESCRIPTION
The reboot-ack diagnostic in `FrameRouter` runs for **both** families but extracted the COMMAND_RESPONSE result with the WHOOP-4 offset (fixed byte 8) and judged it with 4.0 polarity (`r == 0 ? accepted`).

On **WHOOP 5/MG** the result byte is at **frame[12]** (the "+4 shift" — `Interpreter.decodeWhoop5CommandResponse`, and `BodyLocationProbe`: "5/MG replies carry an explicit result code @12 (0 FAILURE / 1 SUCCESS / 2 PENDING / 3 UNSUPPORTED)"). So byte 8 read the inner **type** byte (0x24 = 36, non-zero) and the strap log printed **REJECTED on a successful reboot** — inverting the one signal this block exists to give a 5/MG owner. The polarity was doubly wrong there too (non-zero = SUCCESS on 5/MG).

**Fix:** `commandResultByte(in:family:)` now reads at the family's offset (4.0 @8, 5/MG @12), defaulting to `.whoop4` so the WHOOP-4-only callers (rename, alarm-SET ack — both inside the `family == .whoop4` gate) are untouched. The reboot verdict uses the family's own polarity (5/MG: `1 == SUCCESS` → accepted).

- **iOS/macOS only.** The Android twin (`WhoopBleClient`) already judged the *decoded, family-aware* result name (`startsWith("SUCCESS")`) and was correct — so this brings iOS/macOS **back into parity**, it doesn't diverge.
- Log-only; nothing is gated on this. `StrandTests/FrameRouterRebootAckTests` pins the family offset (byte 8 vs 12) + the short-frame guard.

App-target Swift touched → app-build dispatched (compiles the app targets **and** runs StrandTests).

Reported by @bhelm with a pre-verified, multi-pass analysis.