### PR TITLE
fix(live-session): guard the upsert so a late start-write can't erase the final row

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/LiveSessionStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/LiveSessionStore.swift
@@ -40,6 +40,12 @@ extension WhoopStore {
 
     /// Upsert one Live Session. Natural key (deviceId, startTs) — called once at start (endTs nil) and
     /// again at end with the final totals. Returns rows changed.
+    ///
+    /// The `WHERE excluded.endTs IS NOT NULL OR liveSession.endTs IS NULL` guard makes a start-write
+    /// (endTs nil) refuse to overwrite an already-ended row: start/end persist as independent, unordered
+    /// tasks, so a late start-write could otherwise clobber the final row back to "in progress" and lose
+    /// the totals. Ordering-independent; the normal start→end order still updates (the row's endTs was
+    /// nil). Byte-parity with the Android Room upsert. (@bhelm)
     @discardableResult
     public func upsertLiveSession(_ r: LiveSessionRow, deviceId: String) async throws -> Int {
         try syncWrite { db in
@@ -59,6 +65,7 @@ extension WhoopStore {
                     pushCount = excluded.pushCount,
                     easeCount = excluded.easeCount,
                     hrSource = excluded.hrSource
+                WHERE excluded.endTs IS NOT NULL OR liveSession.endTs IS NULL
                 """, arguments: [deviceId, r.startTs, r.endTs, r.chargeAtStart, r.floorBpm, r.ceilingBpm,
                                  r.inBandSec, r.belowSec, r.aboveSec, r.pushCount, r.easeCount, r.hrSource])
             return db.changesCount

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/LiveSessionStoreTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/LiveSessionStoreTests.swift
@@ -27,6 +27,44 @@ final class LiveSessionStoreTests: XCTestCase {
         XCTAssertEqual(rows.first?.inBandSec, 1800)
     }
 
+    func test_late_start_write_cannot_overwrite_an_ended_row() async throws {
+        // The start/end persists race as independent tasks. If the start-write (endTs nil) lands AFTER the
+        // end-write, the endTs-guard must refuse it — otherwise the session reverts to "in progress" and
+        // the totals are lost. (@bhelm)
+        let store = try await WhoopStore.inMemory()
+        _ = try await store.upsertLiveSession(started(1000), deviceId: "my-whoop")
+        let ended = LiveSessionRow(startTs: 1000, endTs: 3400, chargeAtStart: 41, floorBpm: 128, ceilingBpm: 148,
+                                   inBandSec: 1800, belowSec: 300, aboveSec: 120, pushCount: 2, easeCount: 1,
+                                   hrSource: "whoop")
+        _ = try await store.upsertLiveSession(ended, deviceId: "my-whoop")
+
+        // Replay the stale start-write against the already-ended row: the guard makes it a no-op.
+        let changed = try await store.upsertLiveSession(started(1000), deviceId: "my-whoop")
+        XCTAssertEqual(changed, 0, "a start-write against an ended row changes nothing")
+
+        let rows = try await store.recentLiveSessions(deviceId: "my-whoop", limit: 10)
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows.first, ended, "the final row survives intact")
+        XCTAssertEqual(rows.first?.endTs, 3400)
+        XCTAssertEqual(rows.first?.inBandSec, 1800)
+    }
+
+    func test_in_progress_row_still_accepts_updates() async throws {
+        // The guard must NOT block legitimate writes while the row is still open (endTs nil): a re-persisted
+        // start row updates, and the end-write then fills the totals.
+        let store = try await WhoopStore.inMemory()
+        _ = try await store.upsertLiveSession(started(2000), deviceId: "my-whoop")
+        _ = try await store.upsertLiveSession(started(2000), deviceId: "my-whoop")   // re-persist while open → OK
+        let ended = LiveSessionRow(startTs: 2000, endTs: 4000, chargeAtStart: 41, floorBpm: 128, ceilingBpm: 148,
+                                   inBandSec: 900, belowSec: 60, aboveSec: 30, pushCount: 1, easeCount: 0,
+                                   hrSource: "whoop")
+        _ = try await store.upsertLiveSession(ended, deviceId: "my-whoop")
+        let rows = try await store.recentLiveSessions(deviceId: "my-whoop", limit: 10)
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows.first?.endTs, 4000)
+        XCTAssertEqual(rows.first?.inBandSec, 900)
+    }
+
     func test_recent_is_newest_first_and_device_scoped() async throws {
         let store = try await WhoopStore.inMemory()
         _ = try await store.upsertLiveSession(started(1000), deviceId: "my-whoop")

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -65,9 +65,46 @@ interface WhoopDao : DeviceRegistryDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertSleepState(rows: List<SleepStateSampleEntity>): List<Long>
 
-    /** Upsert one Live Session (v22). Natural key (deviceId, startTs) — start (endTs null) then end. */
-    @Upsert
-    suspend fun upsertLiveSession(row: LiveSessionRow)
+    /** Upsert one Live Session (v22). Natural key (deviceId, startTs) — start (endTs null) then end.
+     *  The `WHERE excluded.endTs IS NOT NULL OR liveSession.endTs IS NULL` guard makes a start-write
+     *  refuse to overwrite an already-ended row: start/end persist as independent, unordered coroutines,
+     *  so a late start-write would otherwise clobber the final row back to "in progress" and lose the
+     *  totals. Ordering-independent. Byte-parity with the Swift LiveSessionStore upsert. (@bhelm) */
+    @Query(
+        """
+        INSERT INTO liveSession
+            (deviceId, startTs, endTs, chargeAtStart, floorBpm, ceilingBpm,
+             inBandSec, belowSec, aboveSec, pushCount, easeCount, hrSource)
+        VALUES (:deviceId, :startTs, :endTs, :chargeAtStart, :floorBpm, :ceilingBpm,
+                :inBandSec, :belowSec, :aboveSec, :pushCount, :easeCount, :hrSource)
+        ON CONFLICT(deviceId, startTs) DO UPDATE SET
+            endTs = excluded.endTs,
+            chargeAtStart = excluded.chargeAtStart,
+            floorBpm = excluded.floorBpm,
+            ceilingBpm = excluded.ceilingBpm,
+            inBandSec = excluded.inBandSec,
+            belowSec = excluded.belowSec,
+            aboveSec = excluded.aboveSec,
+            pushCount = excluded.pushCount,
+            easeCount = excluded.easeCount,
+            hrSource = excluded.hrSource
+        WHERE excluded.endTs IS NOT NULL OR liveSession.endTs IS NULL
+        """
+    )
+    suspend fun upsertLiveSession(
+        deviceId: String,
+        startTs: Long,
+        endTs: Long?,
+        chargeAtStart: Double?,
+        floorBpm: Double,
+        ceilingBpm: Double,
+        inBandSec: Double,
+        belowSec: Double,
+        aboveSec: Double,
+        pushCount: Int,
+        easeCount: Int,
+        hrSource: String,
+    )
 
     /** Most-recent Live Sessions first, for the look-back summary + streak. */
     @Query("SELECT * FROM liveSession WHERE deviceId = :deviceId ORDER BY startTs DESC LIMIT :limit")

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -848,7 +848,12 @@ class WhoopRepository(
 
     // MARK: - Live Sessions (silent guardian, v22). The runner banks the row at start (endTs null) and
     // again at end (totals); the summary reads the recent rows for its guarded-count / streak line.
-    suspend fun upsertLiveSession(row: LiveSessionRow) = dao.upsertLiveSession(row)
+    suspend fun upsertLiveSession(row: LiveSessionRow) = dao.upsertLiveSession(
+        deviceId = row.deviceId, startTs = row.startTs, endTs = row.endTs,
+        chargeAtStart = row.chargeAtStart, floorBpm = row.floorBpm, ceilingBpm = row.ceilingBpm,
+        inBandSec = row.inBandSec, belowSec = row.belowSec, aboveSec = row.aboveSec,
+        pushCount = row.pushCount, easeCount = row.easeCount, hrSource = row.hrSource,
+    )
     suspend fun recentLiveSessions(deviceId: String, limit: Int): List<LiveSessionRow> =
         dao.recentLiveSessions(deviceId, limit)
 


### PR DESCRIPTION
**Race:** `LiveSessionRunner` persists the start row (`endTs = nil`) and the end row (final totals) as **independent, unordered tasks** — Swift `Task { … }` per `persist()`, Kotlin `scope.launch { persist(…) }` — and the upsert overwrote **unconditionally** (`ON CONFLICT DO UPDATE SET endTs = excluded.endTs, …` / Room `@Upsert`).

On a quick open/dismiss of the live-session screen (`onAppear` → `start()`, `onDisappear` → `end()` back-to-back), the end-write can reach the store first (start-task still awaiting the store handle); the start-write then overwrites the final row with `endTs = nil` + start values → session stuck **"in progress"**, totals and cue counts **lost**. The store being an actor/atomic doesn't help — atomicity doesn't order two independently-spawned tasks. Affects **both platforms**.

**Fix:** add a `WHERE excluded.endTs IS NOT NULL OR liveSession.endTs IS NULL` guard to the upsert — a start-write (`endTs` nil) refuses to overwrite an already-ended row. **Ordering-independent** (fixes the bug whichever task wins); the normal start→end order still updates (the row's `endTs` was nil). Chosen over runner-side serialization because it's atomic in one statement and defends every path.

- **Byte-parity** guard clause: Swift GRDB (`LiveSessionStore`) + Kotlin Room (`WhoopDao` — replaced `@Upsert`, which can't express a condition, with a `@Query` conditional upsert; repo decomposes the row).
- **Tests:** `WhoopStoreTests` pins that a late start-write is a no-op and the final row survives, and that in-progress rows still accept updates (run by the active `swift-packages` CI). Android: KSP validates the `@Query` against the `liveSession` schema; the guard SQL is identical to the behavior-tested Swift twin. No app-target Swift touched → no app-build needed.

Reported by @bhelm.