### PR TITLE
fix(hrv): hold the spot capture to a real 60-second window

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -429,6 +429,14 @@ public enum HRVAnalyzer {
         }
     }
 
+    /// Whether a live spot capture collected more beat time than the wall clock allows (no per-beat
+    /// timestamps for `rrCoverage`, but the capture knows how long it ran). Only over-count rejects;
+    /// sparse windows stay with the `minBeats` gate. Pure. Byte-parity twin of Kotlin
+    /// `spotCaptureOverCounted`.
+    public static func spotCaptureOverCounted(beatTimeMs: Double, captureMs: Double) -> Bool {
+        captureMs > 0 && beatTimeMs > captureMs * coveragePlausibleCeiling
+    }
+
     /// How closely a beat's own wall-clock gap matches its own R-R value: the fraction of consecutive
     /// beats whose `ts` step is within `beatAccuracyToleranceS` of their interval. Pure. Byte-parity twin
     /// of Kotlin `beatAccurateFraction`. Returns 1.0 for fewer than 2 beats — absence of evidence is not

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrCoverageVerdictTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrCoverageVerdictTests.swift
@@ -218,4 +218,31 @@ final class RrCoverageVerdictTests: XCTestCase {
         XCTAssertFalse(HRVAnalyzer.beatValuesAreTrustworthy(
             beatAccurateFraction: HRVAnalyzer.beatAccuracyMinFraction - 0.01))
     }
+
+    // MARK: - Spot-capture beat time vs. wall clock
+
+    /// ~700 beats of ~850 ms ≈ 595 s of beat time — impossible in a 60-second window. Twin of
+    /// Kotlin `spotCaptureRejectsMoreBeatTimeThanElapsedTime`.
+    func testSpotCaptureRejectsMoreBeatTimeThanElapsedTime() {
+        let beatTimeMs = (0..<700).reduce(0.0) { sum, i in sum + 830.0 + Double(i % 5) * 10.0 }
+        XCTAssertTrue(HRVAnalyzer.spotCaptureOverCounted(beatTimeMs: beatTimeMs, captureMs: 60_000))
+    }
+
+    /// ~70 beats of 850 ms ≈ 59.5 s of beat time in 60 s — a normal seated reading stays trusted.
+    func testSpotCaptureAcceptsAPlausibleWindow() {
+        XCTAssertFalse(HRVAnalyzer.spotCaptureOverCounted(beatTimeMs: 70 * 850.0, captureMs: 60_000))
+    }
+
+    /// Exactly at the shared `coveragePlausibleCeiling` stays trusted — the ceiling is a rounding
+    /// allowance and the gate uses strict `>` like `classifyCoverage`.
+    func testSpotCaptureToleratesTheRoundingAllowance() {
+        let atCeiling = 60_000 * HRVAnalyzer.coveragePlausibleCeiling
+        XCTAssertFalse(HRVAnalyzer.spotCaptureOverCounted(beatTimeMs: atCeiling, captureMs: 60_000))
+        XCTAssertTrue(HRVAnalyzer.spotCaptureOverCounted(beatTimeMs: atCeiling + 1, captureMs: 60_000))
+    }
+
+    /// No wall clock to hold the beats against — never reject on a degenerate duration.
+    func testSpotCaptureWithZeroElapsedTimeIsNotJudged() {
+        XCTAssertFalse(HRVAnalyzer.spotCaptureOverCounted(beatTimeMs: 1_000, captureMs: 0))
+    }
 }

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -54,6 +54,10 @@ public final class LiveState: ObservableObject {
     /// surface for stress/breathing logic that reacts to the most recent arrival (and the standard
     /// 0x2A37 profile, which is the reliable R-R source). Drive it ONLY via `setRRIntervals(_:)`.
     @Published public var rr: [Int] = []
+    /// Monotonic count of R-R packet arrivals, bumped by every `setRRIntervals(_:)` call. Consume
+    /// packets via `onRRPackets` (keyed on this), never by watching `rr` — see RRPacketObserver.swift.
+    /// Twin of Android LiveState.rrSeq.
+    @Published public private(set) var rrSeq: Int = 0
     /// Rolling UI buffer of recent R-R intervals (capped, oldest dropped first). Standard BLE HR
     /// notifications usually carry only one or two intervals per packet, so the Live console needs a
     /// separate short history to render an actually-moving R-R strip / rolling RMSSD. Appended (never
@@ -519,6 +523,7 @@ public final class LiveState: ObservableObject {
     /// rolling buffer. `recentLimit` caps the buffer; the oldest intervals fall off first.
     public func setRRIntervals(_ intervals: [Int], recentLimit: Int = 60) {
         rr = intervals
+        rrSeq += 1
         let valid = intervals.filter { $0 > 0 }
         guard !valid.isEmpty else { return }
         rrRecent.append(contentsOf: valid)

--- a/Strand/Screens/BreathingView.swift
+++ b/Strand/Screens/BreathingView.swift
@@ -205,7 +205,8 @@ private struct BreathingContent: View {
                 stop()
             }
         }
-        .onChangeCompat(of: live.rr) { rr in
+        // rrSeq-keyed: equal consecutive packets both count (see RRPacketObserver.swift).
+        .onRRPackets(live) { rr in
             ingest(rr)
         }
         .onChangeCompat(of: pace) { newPace in

--- a/Strand/Screens/HRVSnapshotView.swift
+++ b/Strand/Screens/HRVSnapshotView.swift
@@ -13,9 +13,9 @@ import WhoopStore
 /// the generic metric series ("hrv_snapshot", source "manual-hrv") so it sits beside every other
 /// source for the explorer/trends.
 ///
-/// The live ingest mirrors BreathingView exactly — `.onChangeCompat(of: live.rr)` appends onto a
-/// `@State` buffer — so this reuses the proven path rather than touching BLE. The capture buffer is
-/// uncapped (unlike Breathe's rolling 30) because the analysis wants every clean beat in the window.
+/// The live ingest uses the shared `onRRPackets` observer; the capture buffer is uncapped (unlike
+/// Breathe's rolling 30) because the analysis wants every clean beat. The window is a monotonic
+/// 60-second deadline — countdown display and ingest cutoff both derive from it.
 struct HRVSnapshotView: View {
 
     @EnvironmentObject private var model: AppModel
@@ -50,6 +50,10 @@ struct HRVSnapshotView: View {
     @State private var captureBuffer: [Int] = []
     @State private var secondsRemaining = HRVSnapshotView.captureSeconds
 
+    /// Monotonic start of the active capture — the single time base for the countdown display, the
+    /// ingest cutoff, and the finish deadline. Nil outside a capture.
+    @State private var captureStart: ContinuousClock.Instant? = nil
+
     /// Live RMSSD over the beats gathered so far (a running indicator while capturing; the final
     /// figure comes from the cleaned `HRVAnalyzer.analyze`).
     @State private var runningRMSSD: Double? = nil
@@ -74,8 +78,8 @@ struct HRVSnapshotView: View {
             methodologyCard
             if !bonded { notBondedHint }
         }
-        // Pull new R-R intervals into the capture buffer as they arrive — same path as BreathingView.
-        .onChangeCompat(of: live.rr) { rr in
+        // rrSeq-keyed: equal consecutive packets both count (see RRPacketObserver.swift).
+        .onRRPackets(live) { rr in
             ingest(rr)
         }
         // Capture countdown — only ticks while capturing.
@@ -384,6 +388,7 @@ struct HRVSnapshotView: View {
 
     private func start() {
         guard bonded else { return }
+        captureStart = ContinuousClock().now
         phase = .capturing
         captureBuffer.removeAll()
         secondsRemaining = Self.captureSeconds
@@ -395,14 +400,24 @@ struct HRVSnapshotView: View {
 
     private func cancel() {
         phase = .idle
+        captureStart = nil
         secondsRemaining = Self.captureSeconds
         runningRMSSD = nil
         ScreenIdle.keepAwake(false)
     }
 
+    /// Milliseconds of monotonic time since the capture started (nil outside a capture).
+    private func captureElapsedMs() -> Int? {
+        guard let start = captureStart else { return nil }
+        let c = (ContinuousClock().now - start).components
+        return Int(c.seconds) * 1000 + Int(c.attoseconds / 1_000_000_000_000_000)
+    }
+
+    /// Derive the countdown from the monotonic clock — a late timer fire jumps to the correct
+    /// remaining value instead of stretching the window (the old per-callback decrement did).
     private func tick() {
-        guard secondsRemaining > 0 else { return }
-        secondsRemaining -= 1
+        guard let ms = captureElapsedMs() else { return }
+        secondsRemaining = Self.remainingSeconds(elapsedMs: ms)
         if secondsRemaining == 0 {
             finish()
         }
@@ -411,7 +426,18 @@ struct HRVSnapshotView: View {
     /// End the capture and run the full cleaning analysis over everything collected.
     private func finish() {
         ScreenIdle.keepAwake(false)
+        let captureMs = captureElapsedMs() ?? Self.captureSeconds * 1000
+        captureStart = nil
         let raw = captureBuffer.map(Double.init)
+        // A capture whose collected beat time exceeds the wall clock it ran for held duplicated
+        // beats (e.g. overlapping live sources) — refuse the number rather than publish it.
+        if HRVAnalyzer.spotCaptureOverCounted(beatTimeMs: raw.reduce(0, +),
+                                              captureMs: Double(captureMs)) {
+            result = HRVAnalyzer.HRVResult(rmssd: nil, sdnn: nil, meanNN: nil, pnn50: nil,
+                                           nInput: raw.count, nClean: 0)
+            phase = .done
+            return
+        }
         // HRV & Autonomic test mode (Group G): when the mode is on, emit the cleaning trace (nInput /
         // nClean / rejected fraction, the range + Malik ectopic counts, the minBeats + spot gates,
         // RMSSD/SDNN/meanNN) tagged `.hrv`. analyzeTrace returns the SAME HRVResult `analyze` would
@@ -435,7 +461,8 @@ struct HRVSnapshotView: View {
     /// Append newly-arrived R-R intervals to the capture buffer (only while capturing) and refresh the
     /// running RMSSD indicator. The published `rr` is the latest set of intervals.
     private func ingest(_ rr: [Int]) {
-        guard phase == .capturing, !rr.isEmpty else { return }
+        guard phase == .capturing, !rr.isEmpty,
+              let ms = captureElapsedMs(), Self.captureWindowOpen(elapsedMs: ms) else { return }
         captureBuffer.append(contentsOf: rr)
         runningRMSSD = HRVAnalyzer.rmssdRaw(captureBuffer.map(Double.init))
     }
@@ -476,6 +503,18 @@ struct HRVSnapshotView: View {
     static func meanHR(meanNN: Double?) -> Double? {
         guard let meanNN, meanNN > 0 else { return nil }
         return 60_000.0 / meanNN
+    }
+
+    /// Whole seconds left for a monotonic elapsed time, never negative. Mirrors Android
+    /// `remainingCaptureSeconds`.
+    static func remainingSeconds(elapsedMs: Int) -> Int {
+        max(0, captureSeconds - elapsedMs / 1000)
+    }
+
+    /// The ingest gate: intervals on or after the 60-second deadline stay out, however late the
+    /// countdown timer fires. Mirrors Android `captureWindowOpen`.
+    static func captureWindowOpen(elapsedMs: Int) -> Bool {
+        elapsedMs < captureSeconds * 1000
     }
 }
 

--- a/Strand/Screens/RRPacketObserver.swift
+++ b/Strand/Screens/RRPacketObserver.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import StrandDesign
+
+/// The one way to consume live R-R packets: observe `rrSeq`, deliver `rr`. Watching the `rr` value
+/// instead silently drops a second identical consecutive packet — lost real beats for anything that
+/// accumulates successive differences (spot HRV, Breathe's session RMSSD). Filters empty packets.
+/// Removes the value-equality drop, not run-loop coalescing. Twin of Kotlin `Flow<LiveState>.rrPackets()`.
+extension View {
+    func onRRPackets(_ live: LiveState, perform ingest: @escaping ([Int]) -> Void) -> some View {
+        onChangeCompat(of: live.rrSeq) { _ in
+            if !live.rr.isEmpty { ingest(live.rr) }
+        }
+    }
+}

--- a/StrandTests/HRVSnapshotViewTests.swift
+++ b/StrandTests/HRVSnapshotViewTests.swift
@@ -34,6 +34,27 @@ final class HRVSnapshotViewTests: XCTestCase {
         XCTAssertEqual(HRVSnapshotView.format(42.6, "%.0f"), "43")
     }
 
+    // MARK: - Capture window (monotonic deadline)
+
+    func testRemainingSecondsDerivesFromElapsedTime() {
+        XCTAssertEqual(HRVSnapshotView.remainingSeconds(elapsedMs: 0), 60)
+        XCTAssertEqual(HRVSnapshotView.remainingSeconds(elapsedMs: 1_000), 59)
+        XCTAssertEqual(HRVSnapshotView.remainingSeconds(elapsedMs: 59_999), 1)
+        XCTAssertEqual(HRVSnapshotView.remainingSeconds(elapsedMs: 60_000), 0)
+    }
+
+    func testACallbackDelayedPastTheDeadlineFinishesImmediately() {
+        // A delayed callback at 75 s jumps to done — no decrementing a stale counter.
+        XCTAssertEqual(HRVSnapshotView.remainingSeconds(elapsedMs: 75_000), 0)
+    }
+
+    func testIngestWindowClosesExactlyAtTheDeadline() {
+        XCTAssertTrue(HRVSnapshotView.captureWindowOpen(elapsedMs: 0))
+        XCTAssertTrue(HRVSnapshotView.captureWindowOpen(elapsedMs: 59_999))
+        XCTAssertFalse(HRVSnapshotView.captureWindowOpen(elapsedMs: 60_000))
+        XCTAssertFalse(HRVSnapshotView.captureWindowOpen(elapsedMs: 75_000))
+    }
+
     // MARK: - Snapshot constants match the Android twin
 
     func testSnapshotKeyAndSourceAreStable() {

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -391,6 +391,15 @@ object HrvAnalyzer {
     }
 
     /**
+     * Whether a live spot capture collected more beat time than the wall clock allows (no per-beat
+     * timestamps for [rrCoverage], but the capture knows how long it ran). Only over-count rejects;
+     * sparse windows stay with the [MIN_BEATS] gate. Pure. Byte-parity twin of Swift
+     * `spotCaptureOverCounted`.
+     */
+    fun spotCaptureOverCounted(beatTimeMs: Double, captureMs: Long): Boolean =
+        captureMs > 0 && beatTimeMs > captureMs * COVERAGE_PLAUSIBLE_CEILING
+
+    /**
      * How closely a beat's own wall-clock gap matches its own R-R value: the fraction of consecutive
      * beats whose `ts` step is within [BEAT_ACCURACY_TOLERANCE_S] of their interval. Pure. Byte-parity
      * twin of Swift `beatAccurateFraction`. Returns 1.0 for fewer than 2 beats — absence of evidence is

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -128,6 +128,10 @@ data class LiveState(
     val streamingLiveHR: Boolean = false,
     val heartRate: Int? = null,
     val rr: List<Int> = emptyList(),
+    /** Monotonic count of R-R packet arrivals, bumped by every [withRRIntervals] call. Consume
+     *  packets via `Flow<LiveState>.rrPackets()` (keyed on this), never by watching [rr] — see
+     *  LiveRrPackets.kt. Twin of macOS LiveState.rrSeq. */
+    val rrSeq: Long = 0,
     /** Rolling UI buffer of recent R-R intervals (capped, oldest dropped first). The standard BLE HR
      *  notification usually carries only one or two intervals per packet, so the Live console needs a
      *  short history to render a moving R-R strip / rolling RMSSD. Appended (never replaced) via
@@ -228,10 +232,10 @@ data class LiveState(
      *  Twin of macOS LiveState.setRRIntervals (PR#191). */
     fun withRRIntervals(intervals: List<Int>, recentLimit: Int = 60): LiveState {
         val valid = intervals.filter { it > 0 }
-        if (valid.isEmpty()) return copy(rr = intervals)
+        if (valid.isEmpty()) return copy(rr = intervals, rrSeq = rrSeq + 1)
         val merged = rrRecent + valid
         val capped = if (merged.size > recentLimit) merged.takeLast(recentLimit) else merged
-        return copy(rr = intervals, rrRecent = capped)
+        return copy(rr = intervals, rrSeq = rrSeq + 1, rrRecent = capped)
     }
 
     /** Blank all live biometric readouts (HR + R-R + the rolling buffer) so a stale heart rate or R-R

--- a/android/app/src/main/java/com/noop/ui/BreatheScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BreatheScreen.kt
@@ -87,8 +87,6 @@ import com.noop.analytics.BreathStage
 import com.noop.analytics.Hrv
 import com.noop.analytics.ResonanceEngine
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.map
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -372,14 +370,12 @@ fun BreatheScreen(viewModel: AppViewModel) {
         label = "orb",
     )
 
-    // Ingest new R-R intervals into the rolling buffer and recompute RMSSD.
-    // Collect the BLE state flow directly so updates are observed reactively.
+    // Ingest new R-R intervals into the rolling buffer and recompute RMSSD. rrSeq-keyed: equal
+    // consecutive packets both count (see LiveRrPackets.kt).
     LaunchedEffect(Unit) {
         viewModel.live
-            .map { it.rr }
-            .distinctUntilChanged()
+            .rrPackets()
             .collect { rr ->
-                if (rr.isEmpty()) return@collect
                 val merged = (rrBuffer.value + rr).takeLast(rrWindow)
                 rrBuffer.value = merged
                 val r = if (merged.size >= 2) Hrv.rmssd(merged) else null

--- a/android/app/src/main/java/com/noop/ui/HrvSnapshotScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HrvSnapshotScreen.kt
@@ -60,9 +60,8 @@ import com.noop.analytics.HrvAnalyzerTrace
 import com.noop.analytics.SpotHrvReading
 import com.noop.data.MetricSeriesRow
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlin.time.TimeSource
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -79,9 +78,9 @@ import java.util.TimeZone
  * the generic metric series ("hrv_snapshot", source "manual-hrv") so it sits beside every other
  * source for the explorer/trends.
  *
- * The live ingest mirrors BreatheScreen exactly — a flow collector appends onto a buffer — so this
- * reuses the proven path rather than touching BLE. The capture buffer is uncapped (unlike Breathe's
- * rolling 30) because the analysis wants every clean beat in the window.
+ * The live ingest uses the shared [rrPackets] stream; the capture buffer is uncapped (unlike
+ * Breathe's rolling 30) because the analysis wants every clean beat. The window is a monotonic
+ * 60-second deadline — countdown display and ingest cutoff both derive from it.
  */
 @Composable
 fun HrvSnapshotScreen(
@@ -98,6 +97,9 @@ fun HrvSnapshotScreen(
     // analyzer wants the whole window.
     val captureBuffer = remember { mutableStateOf<List<Int>>(emptyList()) }
     var secondsRemaining by remember { mutableIntStateOf(HRV_CAPTURE_SECONDS) }
+    // Monotonic start of the active capture — the single time base for the countdown display, the
+    // ingest cutoff, and the finish deadline. Null outside a capture.
+    var captureStart by remember { mutableStateOf<TimeSource.Monotonic.ValueTimeMark?>(null) }
     // Live RMSSD over the beats gathered so far (a running indicator while capturing; the final figure
     // comes from the cleaned HrvAnalyzer.analyzeRaw).
     var runningRmssd by remember { mutableStateOf<Double?>(null) }
@@ -114,29 +116,44 @@ fun HrvSnapshotScreen(
         onDispose { viewModel.releaseRealtimeHr() }
     }
 
-    // Pull new R-R intervals into the capture buffer as they arrive — same path as BreatheScreen.
+    // Pull new R-R intervals into the capture buffer as they arrive. rrSeq-keyed: equal
+    // consecutive packets both count (see LiveRrPackets.kt).
     LaunchedEffect(Unit) {
         viewModel.live
-            .map { it.rr }
-            .distinctUntilChanged()
+            .rrPackets()
             .collect { rr ->
-                if (rr.isEmpty()) return@collect
                 if (phase != HrvPhase.Capturing) return@collect
+                // Deadline gate: intervals on or after the 60-second mark stay out.
+                val start = captureStart ?: return@collect
+                if (!captureWindowOpen(start.elapsedNow().inWholeMilliseconds)) return@collect
                 val merged = captureBuffer.value + rr
                 captureBuffer.value = merged
                 runningRmssd = HrvAnalyzer.rmssdRaw(merged.map { it.toDouble() })
             }
     }
 
-    // Capture countdown — only ticks while capturing. On reaching 0, run the cleaning analysis.
+    // Capture countdown — only ticks while capturing; on the deadline, run the cleaning analysis.
+    // Derived from the monotonic clock: a late resume jumps to the correct remaining value instead
+    // of stretching the window (the old per-callback decrement did).
     LaunchedEffect(phase) {
         if (phase != HrvPhase.Capturing) return@LaunchedEffect
-        while (secondsRemaining > 0) {
-            delay(1000)
-            secondsRemaining -= 1
+        val start = captureStart ?: return@LaunchedEffect
+        while (true) {
+            val elapsedMs = start.elapsedNow().inWholeMilliseconds
+            secondsRemaining = remainingCaptureSeconds(elapsedMs)
+            if (secondsRemaining <= 0) break
+            delay(1000 - elapsedMs % 1000)   // sleep to the next whole-second boundary
         }
         // End the capture and run the full cleaning analysis over everything collected.
+        val captureMs = start.elapsedNow().inWholeMilliseconds
         val raw = captureBuffer.value.map { it.toDouble() }
+        // A capture whose collected beat time exceeds the wall clock it ran for held duplicated
+        // beats (e.g. overlapping live sources) — refuse the number rather than publish it.
+        if (HrvAnalyzer.spotCaptureOverCounted(raw.sum(), captureMs)) {
+            result = HrvAnalyzer.HrvResult.empty(raw.size)
+            phase = HrvPhase.Done
+            return@LaunchedEffect
+        }
         // HRV & Autonomic test mode (Test Centre Group G): when the mode is on, emit the cleaning trace
         // (nInput / nClean / rejected fraction, the range + Malik ectopic counts, the minBeats + spot
         // gates, RMSSD/SDNN/meanNN) tagged HRV. analyzeTrace returns the SAME HrvResult analyzeRaw would
@@ -237,6 +254,7 @@ fun HrvSnapshotScreen(
                     if (phase == HrvPhase.Capturing) {
                         // Cancel.
                         phase = HrvPhase.Idle
+                        captureStart = null
                         secondsRemaining = HRV_CAPTURE_SECONDS
                         runningRmssd = null
                     } else {
@@ -246,6 +264,7 @@ fun HrvSnapshotScreen(
                         runningRmssd = null
                         result = null
                         saved = false
+                        captureStart = TimeSource.Monotonic.markNow()
                         phase = HrvPhase.Capturing
                     }
                 },
@@ -482,6 +501,19 @@ const val HRV_SNAPSHOT_METRIC_KEY = "hrv_snapshot"
  * the per-source explorer (matches Swift `HRVSnapshot.sourceId`).
  */
 const val HRV_SNAPSHOT_SOURCE_ID = "manual-hrv"
+
+/**
+ * Whole seconds left for a monotonic elapsed time, never negative. Mirrors
+ * HRVSnapshotView.remainingSeconds.
+ */
+fun remainingCaptureSeconds(elapsedMs: Long): Int =
+    (HRV_CAPTURE_SECONDS - elapsedMs / 1000).coerceAtLeast(0L).toInt()
+
+/**
+ * The ingest gate: intervals on or after the 60-second deadline stay out, however late the
+ * countdown coroutine runs. Mirrors HRVSnapshotView.captureWindowOpen.
+ */
+fun captureWindowOpen(elapsedMs: Long): Boolean = elapsedMs < HRV_CAPTURE_SECONDS * 1000L
 
 private fun captureFraction(phase: HrvPhase, secondsRemaining: Int): Float = when (phase) {
     HrvPhase.Idle -> 0f

--- a/android/app/src/main/java/com/noop/ui/LiveRrPackets.kt
+++ b/android/app/src/main/java/com/noop/ui/LiveRrPackets.kt
@@ -1,0 +1,19 @@
+package com.noop.ui
+
+import com.noop.ble.LiveState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+
+/**
+ * The one way to consume live R-R packets: key on [LiveState.rrSeq], deliver [LiveState.rr]. Keying
+ * on the `rr` value instead silently drops a second identical consecutive packet — lost real beats
+ * for anything that accumulates successive differences (spot HRV, Breathe's session RMSSD). Filters
+ * empty packets. Removes the value-equality drop, not StateFlow conflation. Twin of Swift
+ * `View.onRRPackets`.
+ */
+fun Flow<LiveState>.rrPackets(): Flow<List<Int>> =
+    map { it.rrSeq to it.rr }
+        .distinctUntilChanged()
+        .mapNotNull { (_, rr) -> rr.takeIf { it.isNotEmpty() } }

--- a/android/app/src/test/java/com/noop/ui/HrvCaptureWindowTest.kt
+++ b/android/app/src/test/java/com/noop/ui/HrvCaptureWindowTest.kt
@@ -1,0 +1,113 @@
+package com.noop.ui
+
+import com.noop.analytics.HrvAnalyzer
+import com.noop.ble.LiveState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the spot-HRV capture window contract: monotonic deadline math, lossless [rrPackets] ingest,
+ * and the beat-time-vs-wall-clock gate. Mirrors the Swift HRVSnapshotView / HRVAnalyzer twins
+ * case-for-case.
+ */
+class HrvCaptureWindowTest {
+
+    // ── Deadline math: a late tick jumps, never stretches ────────────────────
+
+    @Test
+    fun remainingSecondsDerivesFromElapsedTime() {
+        assertEquals(60, remainingCaptureSeconds(0))
+        assertEquals(59, remainingCaptureSeconds(1_000))
+        assertEquals(1, remainingCaptureSeconds(59_999))
+        assertEquals(0, remainingCaptureSeconds(60_000))
+    }
+
+    @Test
+    fun aCallbackDelayedPastTheDeadlineFinishesImmediately() {
+        // A delayed callback at 75 s jumps to done — no decrementing a stale counter.
+        assertEquals(0, remainingCaptureSeconds(75_000))
+    }
+
+    @Test
+    fun ingestWindowClosesExactlyAtTheDeadline() {
+        assertTrue(captureWindowOpen(0))
+        assertTrue(captureWindowOpen(59_999))
+        assertFalse(captureWindowOpen(60_000))
+        assertFalse(captureWindowOpen(75_000))
+    }
+
+    // ── Packet stream: identical consecutive packets both count ─────────────
+
+    /** Equal interval values in two distinct packets: both must survive the StateFlow equality
+     *  conflation that used to drop the second one. */
+    @Test
+    fun identicalConsecutivePacketsBothReachTheBuffer() = runTest {
+        val live = MutableStateFlow(LiveState())
+        val captureBuffer = mutableListOf<Int>()
+
+        val collector = launch(UnconfinedTestDispatcher(testScheduler)) {
+            live.rrPackets().collect { rr -> captureBuffer += rr }
+        }
+
+        live.update { it.withRRIntervals(listOf(802)) }
+        live.update { it.withRRIntervals(listOf(802)) }   // equal values, distinct packet
+        live.update { it.withRRIntervals(listOf(913)) }
+        collector.cancel()
+
+        assertEquals(listOf(802, 802, 913), captureBuffer)
+    }
+
+    /** Sentinel-only packets (non-positive placeholders) are filtered by the shared stream. */
+    @Test
+    fun emptyPacketsAreFiltered() = runTest {
+        val live = MutableStateFlow(LiveState())
+        val seen = mutableListOf<List<Int>>()
+
+        val collector = launch(UnconfinedTestDispatcher(testScheduler)) {
+            live.rrPackets().collect { seen += it }
+        }
+
+        live.update { it.withRRIntervals(emptyList()) }
+        live.update { it.withRRIntervals(listOf(788)) }
+        collector.cancel()
+
+        assertEquals(listOf(listOf(788)), seen)
+    }
+
+    // ── Beat-time plausibility: more beat time than wall clock is refused ────
+
+    @Test
+    fun spotCaptureRejectsMoreBeatTimeThanElapsedTime() {
+        // ~700 beats of ~850 ms ≈ 595 s of beat time from a 60 s window — physically impossible.
+        val beatTimeMs = List(700) { 830.0 + (it % 5) * 10.0 }.sum()
+        assertTrue(HrvAnalyzer.spotCaptureOverCounted(beatTimeMs, captureMs = 60_000))
+    }
+
+    @Test
+    fun spotCaptureAcceptsAPlausibleWindow() {
+        // ~70 beats of 850 ms ≈ 59.5 s of beat time in 60 s — a normal seated reading.
+        assertFalse(HrvAnalyzer.spotCaptureOverCounted(70 * 850.0, captureMs = 60_000))
+    }
+
+    @Test
+    fun spotCaptureToleratesTheRoundingAllowance() {
+        // Exactly at the shared COVERAGE_PLAUSIBLE_CEILING (1.10): still trusted — the ceiling is a
+        // rounding allowance, and the gate uses strict `>` like classifyCoverage.
+        val atCeiling = 60_000 * HrvAnalyzer.COVERAGE_PLAUSIBLE_CEILING
+        assertFalse(HrvAnalyzer.spotCaptureOverCounted(atCeiling, captureMs = 60_000))
+        assertTrue(HrvAnalyzer.spotCaptureOverCounted(atCeiling + 1.0, captureMs = 60_000))
+    }
+
+    @Test
+    fun spotCaptureWithZeroElapsedTimeIsNotJudged() {
+        // No wall clock to hold the beats against — never reject on a degenerate duration.
+        assertFalse(HrvAnalyzer.spotCaptureOverCounted(1_000.0, captureMs = 0))
+    }
+}


### PR DESCRIPTION
## What this PR does

The manual "Take an HRV reading" advertised 60 seconds but enforced none of it — reported via Discord (#dev-talk) on iOS with a WHOOP 4.0: the countdown subtracted one second per delivered timer callback (a congested main thread stretched the reading to minutes), the ingest consumed the mutable latest-R-R-packet state as if it were a lossless event stream (two genuine consecutive packets with equal intervals collapsed to one), and the final analysis accepted any buffered beat count — a capture holding several minutes of beat time still published an RMSSD.

Three fixes, Swift + Kotlin in lockstep:

- The capture runs on a monotonic start/deadline. Countdown display and ingest cutoff both derive from it: a late tick jumps to the correct remaining value (or finishes immediately), and intervals arriving on or after the deadline stay out of the buffer.
- `LiveState` gains `rrSeq`, bumped by the single R-R funnel on every packet, and each platform gets one shared packet-consumer idiom (`View.onRRPackets` / `Flow<LiveState>.rrPackets`) keyed on it. The spot ingest and the Breathe ingest use it, so equal consecutive packets both count — Breathe feeds its session RMSSD/baseline/peak from the same buffer and shared the fault. This removes the value-equality drop, not coalescing; a buffered event stream is left for the source-arbitration follow-up.
- `HRVAnalyzer.spotCaptureOverCounted` (Swift/Kotlin twins) refuses a capture whose collected beat time exceeds the wall clock it ran for, reusing the existing `coveragePlausibleCeiling` — a live capture has no per-beat timestamps for `rrCoverage`, but it does know how long it ran. Only over-count rejects; sparse windows stay with the `minBeats` gate.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

**Real hardware (Android, WHOOP 5.0):** full spot captures on the fork testing build — the countdown now tracks the wall clock independently of packet arrivals, the reading closes at 60 s, and results land in the plausible range with beats ≈ heart rate. The Breathe screen's session RMSSD still streams live through the new shared consumer.

**Original fault (iOS, WHOOP 4.0):** reported via Discord, needs main-thread congestion to trigger, and was therefore reproduced synthetically: the new `HrvCaptureWindowTest` pins each failure mode — deadline math with the delayed-callback-at-75s criterion, rrSeq ingest through the real `withRRIntervals` funnel + `rrPackets` stream (equal consecutive packets both counted), and the beat-time gate boundary cases (~700 beats / ~595 s of beat time from a 60 s window is refused). Swift twins in `RrCoverageVerdictTests` + `HRVSnapshotViewTests`.

**CI (fork Actions, this head):** android `testFullDebugUnitTest` 3944/0, swift-packages (package tests), and app-build (macOS + iOS compile) all green. iOS runtime is the same shared `Strand/` source as macOS; not separately hardware-tested.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Reported via Discord #dev-talk (no GitHub issue filed; iOS + WHOOP 4.0, "60-second reading ran for minutes and collected ~700 beats").

🤖 Generated with [Claude Code](https://claude.com/claude-code) (but reviewed by me ;) ).
