### PR TITLE
fix(ble): widen the 5/MG liveness fuse to the whole family (#1414)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -3698,13 +3698,15 @@ public final class BLEManager: NSObject, ObservableObject {
         enableLiveNotifications(reason: "keepalive")
         // Liveness watchdog: if NOTHING has arrived for a while, the stream/link stalled.
         // Bounce the connection — the auto-rescan on disconnect re-bonds and resumes streaming.
-        // #580: a known history-empty 5/MG (firmware serves no offload) gets a far longer fuse. The
-        // standard 0x2A37 HR profile keeps the link genuinely alive, but its packets can lull for >120s
-        // when the strap is off-wrist / resting, and an empty offload leaves the data channel quiet — so
-        // the old 120s rule disconnected/rescanned a perfectly healthy link every ~2 min (the thrash this
-        // fixes). A WHOOP 4 (real "not recording" path) keeps the tight 120s fuse unchanged.
+        // #580 / #1414: the standard 0x2A37 HR profile keeps the link genuinely alive, but its packets can
+        // lull for >120s when the wearer is at rest / off-wrist, so the old 120s rule disconnected/rescanned
+        // a perfectly healthy 5/MG link every ~2 min (the thrash #580 fixed). That lull is a FAMILY trait of
+        // the 5/MG HR profile, independent of whether history offload serves data — #580 mistakenly gated the
+        // wide fuse on `historyEmpty`, so a 5/MG that DID serve history still thrashed on the 120s fuse
+        // (#1414). Widen to the whole 5/MG family; WHOOP 4 (real "not recording" path) keeps the tight 120s.
+        // (`historyEmpty` still gates the battery-backfill interval below — a separate concern, left as-is.)
         let bounceFuse: TimeInterval =
-            (selectedModel.deviceFamily == .whoop5 && whoop5EmptyOffload.historyEmpty) ? 600 : 120
+            selectedModel.deviceFamily == .whoop5 ? 600 : 120
         if Date().timeIntervalSince(lastDataAt) > bounceFuse {
             log("No data for >\(Int(bounceFuse))s — bouncing link to resume streaming")
             if let p = peripheral { central.cancelPeripheralConnection(p) }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5992,12 +5992,14 @@ class WhoopBleClient(
         // of the way — in particular we must NOT bounce, which would abandon the offload mid-session
         // and break the safe-trim cursor.
         if (!backfilling) {
-            // #580: a known history-empty 5/MG (firmware serves no offload) gets a far longer fuse. Live HR
-            // over the standard 0x2A37 profile keeps the link genuinely alive, but its packets can lull for
-            // >120s when the strap is off-wrist / resting, and an empty offload leaves the data channel
-            // quiet — so the old 120s rule disconnected/rescanned a perfectly healthy link every ~2 min (the
-            // thrash this fixes). A WHOOP 4 (real "not recording" path) keeps the tight 120s fuse.
-            val bounceFuse = if (connectedFamily == DeviceFamily.WHOOP5 && whoop5EmptyOffload.historyEmpty)
+            // #580 / #1414: live HR over the standard 0x2A37 profile keeps the link genuinely alive, but its
+            // packets can lull for >120s when the wearer is at rest / off-wrist, so the old 120s rule
+            // disconnected/rescanned a perfectly healthy 5/MG link every ~2 min (the thrash #580 fixed). That
+            // lull is a FAMILY trait of the 5/MG HR profile, independent of whether history offload serves
+            // data — #580 mistakenly gated the wide fuse on `historyEmpty`, so a 5/MG that DID serve history
+            // still thrashed on the 120s fuse (#1414). Widen to the whole 5/MG family; WHOOP 4 keeps 120s.
+            // (`historyEmpty` still gates the battery-backfill interval — a separate concern, left as-is.)
+            val bounceFuse = if (connectedFamily == DeviceFamily.WHOOP5)
                 KEEPALIVE_STALL_5MG_EMPTY_MS else KEEPALIVE_STALL_MS
             if (silentMs > bounceFuse) {
                 // Nothing for the fuse window — the live stream/link stalled. Bounce it: the auto-rescan on


### PR DESCRIPTION
Closes the #580 follow-up in #1414 (thanks @justinjor-bit — detailed report + strap log on real 5/MG hardware).

**Bug:** #580 widened the 120s no-data bounce fuse to 600s for 5/MG (the standard 0x2A37 HR profile lulls at rest and the tight fuse was tearing down healthy links), but gated it on `whoop5EmptyOffload.historyEmpty` — so it only applied to a 5/MG that serves **no** offload. The HR-lull is a **family trait** of the 5/MG profile, independent of whether offload serves data, so a 5/MG that *does* serve history still got the 120s fuse and reproduced the exact thrash: 6 teardown/reconnect cycles in 26 min on a bonded, strong-signal (RSSI −43..−49), actively-offloading link (583/613/580/1525/1193/297 rows persisted across those very cycles).

**Fix:** drop the `historyEmpty` gate from the fuse — `deviceFamily == .whoop5 ? 600 : 120`. Matches #580's stated cause (a family-wide HR-profile trait); WHOOP 4 keeps the tight 120s.

- **Byte-parity** Swift (`BLEManager`) + Kotlin (`WhoopBleClient`) — same 600 s / 120 s.
- `whoop5EmptyOffload.historyEmpty` is **left untouched** for its separate, legitimate use (the battery-backfill interval, `offloadInterval`/`whoop5EmptyHistoryBackfillInterval`); only the `bounceFuse` ternary drops it.
- Chose the reporter's Option 1 (widen to family) over Option 2 (feed the watchdog from offload/battery signals) to stay minimal and match the documented cause; Option 2 is a fine complementary robustness layer for later.

**Validation:** BLE path → not CI-testable. Android compiles; iOS is app-target Swift (shared `BLEManager`) → app-build dispatched. **@justinjor-bit offered to confirm on real 5/MG hardware (5AM / WS50_r00)** — so I'd hold the merge for that hardware confirmation.