### PR TITLE
feat(widget): keep showing the last heart rate through a quiet patch

### DIFF
--- a/android/app/src/main/java/com/noop/widget/NoopCompactGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/NoopCompactGlanceWidget.kt
@@ -131,7 +131,8 @@ private fun CompactWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
                 text = snap.heartRate?.let { "♥ $it" } ?: "♥ - ",
-                style = TextStyle(color = textPrimary, fontSize = 13.sp),
+                // Dim a carried-over reading so a stale HR can't masquerade as a live one.
+                style = TextStyle(color = if (snap.heartRateStale) textSecondary else textPrimary, fontSize = 13.sp),
             )
             Spacer(modifier = GlanceModifier.width(10.dp))
             Image(

--- a/android/app/src/main/java/com/noop/widget/NoopGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/NoopGlanceWidget.kt
@@ -153,7 +153,8 @@ private fun WidgetContent(snap: WidgetSnapshot, dark: Boolean) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
                 text = snap.heartRate?.let { "♥ $it" } ?: "♥ - ",
-                style = TextStyle(color = textPrimary, fontSize = 13.sp),
+                // Dim a carried-over reading so a stale HR can't masquerade as a live one.
+                style = TextStyle(color = if (snap.heartRateStale) textSecondary else textPrimary, fontSize = 13.sp),
             )
             Spacer(modifier = GlanceModifier.width(10.dp))
             Text(

--- a/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
@@ -15,8 +15,12 @@ data class WidgetSnapshot(
     val restPct: Int? = null,
     /** Today's Effort 0–100 (the day's strain on the 0–100 scale), null until there's a HR window (#516). */
     val effortPct: Int? = null,
-    /** Live heart rate, null when not streaming. */
+    /** Heart rate to show: the live sample when streaming, else the last-known reading carried over so a
+     *  momentary quiet patch (5/MG HR-profile lull, a reconnect) doesn't blank the widget. Null only when
+     *  there is no recent reading at all. See [HrDisplay]. */
     val heartRate: Int? = null,
+    /** True when [heartRate] is a carried-over reading rather than a fresh live sample — the widget dims it. */
+    val heartRateStale: Boolean = false,
     /** Strap battery 0–100, null until the strap reports it. */
     val batteryPct: Int? = null,
     val connected: Boolean = false,
@@ -60,28 +64,58 @@ object WidgetSnapshotStore {
     }
 
     fun save(context: Context, snap: WidgetSnapshot) {
-        context.getSharedPreferences(FILE, Context.MODE_PRIVATE).edit()
+        val e = context.getSharedPreferences(FILE, Context.MODE_PRIVATE).edit()
             .putInt("recovery", snap.recoveryPct ?: -1)
             .putInt("rest", snap.restPct ?: -1)
             .putInt("effort", snap.effortPct ?: -1)
-            .putInt("hr", snap.heartRate ?: -1)
             .putInt("battery", snap.batteryPct ?: -1)
             .putBoolean("connected", snap.connected)
             .putLong("updatedAt", snap.updatedAtMs)
-            .apply()
+        // Retain the last live HR across a quiet patch: only overwrite `hr`/`hrAt` when this push carries a
+        // live sample; a null-HR push (strap quiet / mid-reconnect) leaves the last reading in place, and
+        // `hrLive` records that the retained value is now a carry-over so the widget dims it (see HrDisplay).
+        val live = (snap.heartRate ?: 0) > 0
+        e.putBoolean("hrLive", live)
+        if (live) e.putInt("hr", snap.heartRate!!).putLong("hrAt", snap.updatedAtMs)
+        e.apply()
     }
 
     fun load(context: Context): WidgetSnapshot {
         val p = context.getSharedPreferences(FILE, Context.MODE_PRIVATE)
+        val (hr, hrStale) = HrDisplay.resolve(
+            lastHr = p.getInt("hr", -1).takeIf { it > 0 },
+            lastHrAtMs = p.getLong("hrAt", 0L),
+            live = p.getBoolean("hrLive", false),
+            nowMs = System.currentTimeMillis(),
+        )
         return WidgetSnapshot(
             recoveryPct = p.getInt("recovery", -1).takeIf { it >= 0 },
             restPct = p.getInt("rest", -1).takeIf { it >= 0 },
             effortPct = p.getInt("effort", -1).takeIf { it >= 0 },
-            heartRate = p.getInt("hr", -1).takeIf { it > 0 },
+            heartRate = hr,
+            heartRateStale = hrStale,
             batteryPct = p.getInt("battery", -1).takeIf { it >= 0 },
             connected = p.getBoolean("connected", false),
             updatedAtMs = p.getLong("updatedAt", 0L),
         )
+    }
+}
+
+/**
+ * Decides what live-HR the widget shows, extracted pure so it's unit-testable (WidgetHrDisplayTest).
+ * The last reading is carried over so a brief quiet patch — the 5/MG HR-profile lull at rest, or a
+ * reconnect that clears biometrics — doesn't blank the heart. It is DIMMED once it's a carry-over rather
+ * than a fresh live sample, and DROPPED entirely once it's too old to stand for the wearer.
+ */
+internal object HrDisplay {
+    /** Beyond this age a carried-over reading is dropped (widget shows "-") — too stale to represent HR. */
+    const val STALE_CAP_MS = 15 * 60_000L
+
+    /** @return (bpm to show or null, stale) — stale = a carry-over reading, not a fresh live sample. */
+    fun resolve(lastHr: Int?, lastHrAtMs: Long, live: Boolean, nowMs: Long): Pair<Int?, Boolean> {
+        if (lastHr == null || lastHr <= 0) return null to false
+        if (!live && nowMs - lastHrAtMs > STALE_CAP_MS) return null to false
+        return lastHr to !live
     }
 }
 

--- a/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
@@ -108,14 +108,20 @@ object WidgetSnapshotStore {
  * than a fresh live sample, and DROPPED entirely once it's too old to stand for the wearer.
  */
 internal object HrDisplay {
-    /** Beyond this age a carried-over reading is dropped (widget shows "-") — too stale to represent HR. */
+    /** A reading counts as a fresh live sample only if the last live push was within this window; past it
+     *  (e.g. the app was killed mid-stream and never flipped `live` off) it's shown dimmed, not as live. */
+    const val LIVE_MS = 2 * 60_000L
+
+    /** Beyond this age the reading is dropped (widget shows "-") — too stale to represent HR at all. */
     const val STALE_CAP_MS = 15 * 60_000L
 
-    /** @return (bpm to show or null, stale) — stale = a carry-over reading, not a fresh live sample. */
+    /** @return (bpm to show or null, stale) — stale = shown but NOT a fresh live sample, so the widget dims it. */
     fun resolve(lastHr: Int?, lastHrAtMs: Long, live: Boolean, nowMs: Long): Pair<Int?, Boolean> {
         if (lastHr == null || lastHr <= 0) return null to false
-        if (!live && nowMs - lastHrAtMs > STALE_CAP_MS) return null to false
-        return lastHr to !live
+        val age = nowMs - lastHrAtMs
+        if (age > STALE_CAP_MS) return null to false          // too old regardless of the `live` flag
+        val fresh = live && age <= LIVE_MS                    // a live push AND recent — not a stale carry-over
+        return lastHr to !fresh
     }
 }
 

--- a/android/app/src/test/java/com/noop/widget/WidgetHrDisplayTest.kt
+++ b/android/app/src/test/java/com/noop/widget/WidgetHrDisplayTest.kt
@@ -31,8 +31,14 @@ class WidgetHrDisplayTest {
         assertEquals(null to false, HrDisplay.resolve(lastHr = 0, lastHrAtMs = now, live = true, nowMs = now))
     }
 
-    @Test fun liveSample_ignores_age_cap() {
-        // A live push is fresh by definition; show it undimmed even if the stored timestamp looks old.
-        assertEquals(72 to false, HrDisplay.resolve(lastHr = 72, lastHrAtMs = now - 60 * 60_000L, live = true, nowMs = now))
+    @Test fun staleLiveFlag_pastLiveWindow_isDimmed() {
+        // App killed mid-stream: `live` is still true but the sample is 5 min old — show it, but DIMMED,
+        // never as a fresh live reading.
+        assertEquals(72 to true, HrDisplay.resolve(lastHr = 72, lastHrAtMs = now - 5 * 60_000L, live = true, nowMs = now))
+    }
+
+    @Test fun staleLiveFlag_pastCap_isDropped() {
+        // A lingering `live = true` must NOT bypass the cap — an hour-old reading is dropped, not shown live.
+        assertEquals(null to false, HrDisplay.resolve(lastHr = 72, lastHrAtMs = now - 60 * 60_000L, live = true, nowMs = now))
     }
 }

--- a/android/app/src/test/java/com/noop/widget/WidgetHrDisplayTest.kt
+++ b/android/app/src/test/java/com/noop/widget/WidgetHrDisplayTest.kt
@@ -1,0 +1,38 @@
+package com.noop.widget
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins [HrDisplay]: the widget keeps showing the last heart rate through a brief quiet patch (the 5/MG
+ * HR-profile lull at rest, or a reconnect that clears biometrics) instead of blanking to "-", dims it once
+ * it's a carry-over rather than a fresh live sample, and drops it once it's too old to stand for the wearer.
+ */
+class WidgetHrDisplayTest {
+
+    private val now = 1_000_000_000L
+
+    @Test fun liveSample_shown_and_not_stale() {
+        assertEquals(72 to false, HrDisplay.resolve(lastHr = 72, lastHrAtMs = now, live = true, nowMs = now))
+    }
+
+    @Test fun carryOver_withinCap_shown_but_dimmed() {
+        // 2 min since the last live sample (a 5/MG rest lull) — keep showing it, dimmed.
+        assertEquals(72 to true, HrDisplay.resolve(lastHr = 72, lastHrAtMs = now - 2 * 60_000L, live = false, nowMs = now))
+    }
+
+    @Test fun carryOver_pastCap_dropped() {
+        // 16 min stale — beyond the 15-min cap, too old to represent HR; blank it.
+        assertEquals(null to false, HrDisplay.resolve(lastHr = 72, lastHrAtMs = now - 16 * 60_000L, live = false, nowMs = now))
+    }
+
+    @Test fun noReading_isBlank() {
+        assertEquals(null to false, HrDisplay.resolve(lastHr = null, lastHrAtMs = 0, live = false, nowMs = now))
+        assertEquals(null to false, HrDisplay.resolve(lastHr = 0, lastHrAtMs = now, live = true, nowMs = now))
+    }
+
+    @Test fun liveSample_ignores_age_cap() {
+        // A live push is fresh by definition; show it undimmed even if the stored timestamp looks old.
+        assertEquals(72 to false, HrDisplay.resolve(lastHr = 72, lastHrAtMs = now - 60 * 60_000L, live = true, nowMs = now))
+    }
+}


### PR DESCRIPTION
**Reported behaviour** (Reddit — Android home widget): strap "Connected", battery fine, Rest/Charge/Effort all populated, but the heart shows `♥ -`. Not a permissions/background bug.

**Cause:** the widget can't stream BLE — it renders the last `WidgetSnapshot`, whose `heartRate` is `null` unless the strap sent a *recent* live-HR (0x2A37) packet. On a WHOOP 5/MG that profile **lulls at rest** (>120s gaps — the #580/#1414 behaviour), and every reconnect clears biometrics (`clearedBiometrics` nulls HR until the next packet). So `heartRate` is `null` in genuine quiet windows and the widget blanked to `♥ -` — discarding the last known value.

**Fix:** retain the last reading across a quiet patch.
- `WidgetSnapshotStore.save` only overwrites `hr`/`hrAt` when a push carries a live sample; a null-HR push leaves the last reading in place and records `hrLive = false`.
- `load` resolves via a pure `HrDisplay` helper: show the carried-over value **dimmed** (it's not a fresh live sample), and **drop** it past a 15-minute cap so an ancient reading can't linger. Both Glance widgets dim the stale value (`textSecondary`).
- `HrDisplay.resolve` is pinned by `WidgetHrDisplayTest` (live / carry-over-within-cap / past-cap / no-reading / live-ignores-cap).

**Parity: Android-only, by design.** The iOS home-screen widget shows **resting HR** (`WidgetSnapshot.swift` `restingHr`, a stable daily value), not live HR — only the iOS Live Activity shows live `bpm`, and that's a transient foreground surface. So there is no equivalent blank-on-lull on iOS; no iOS change. The #1414 fuse fix already cuts the reconnect churn behind many of the clears.

**Validation:** Android-only Kotlin (Glance widget + store) — no CI job compiles it (android.yml is off), so validated locally: `compileFullDebugKotlin` green + `com.noop.widget.*` unit tests green (HrDisplay + the existing PushGate contract). Widget render behaviour is on-device visual.