### PR TITLE
feat(analytics): CTL/ATL/TSB training-load model (Swift + Kotlin)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ReadinessTrainingLoad.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ReadinessTrainingLoad.swift
@@ -1,0 +1,40 @@
+import WhoopStore
+
+public extension ReadinessEngine {
+    /// Readiness plus descriptive long-horizon training-load state.
+    ///
+    /// The training-load result is deliberately OUTSIDE the Readiness synthesis. CTL/ATL/TSB do not
+    /// change `readiness.level`, signals, confidence, or any headline score; they are contextual trends
+    /// for charts and explanations. This keeps the existing ACWR/monotony behavior intact and makes any
+    /// future decision to feed training-load state into a score an explicit, separately validated change.
+    struct TrainingLoadAnalysis: Sendable, Equatable {
+        public let readiness: Readiness
+        public let trainingLoad: TrainingLoadEngine.Result
+
+        public init(readiness: Readiness, trainingLoad: TrainingLoadEngine.Result) {
+            self.readiness = readiness
+            self.trainingLoad = trainingLoad
+        }
+    }
+
+    /// Evaluate existing Readiness and the CTL/ATL/TSB model over the same daily-metric history.
+    ///
+    /// `today` has the same stale-data semantics as `ReadinessEngine.evaluate`: when supplied, both
+    /// analyses target exactly that YYYY-MM-DD. A missing target therefore yields an insufficient
+    /// Readiness and `trainingLoad.unavailableReason == .missingTargetDay` rather than falling back to an
+    /// older row. With no explicit target, both use the latest row.
+    static func evaluateWithTrainingLoad(
+        days: [DailyMetric],
+        today: String? = nil,
+        trainingLoadConfiguration: TrainingLoadEngine.Configuration = .standard
+    ) -> TrainingLoadAnalysis {
+        let readiness = evaluate(days: days, today: today)
+        let trainingDays = days.map { TrainingLoadEngine.DailyLoad(day: $0.day, load: $0.strain) }
+        let trainingLoad = TrainingLoadEngine.evaluate(
+            days: trainingDays,
+            through: today,
+            configuration: trainingLoadConfiguration
+        )
+        return TrainingLoadAnalysis(readiness: readiness, trainingLoad: trainingLoad)
+    }
+}

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/TrainingLoadEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/TrainingLoadEngine.swift
@@ -1,0 +1,279 @@
+import Foundation
+
+/// Long-horizon training-load model using exponentially weighted daily load.
+///
+/// Complements `ReadinessEngine`'s existing rolling-mean ACWR and Foster monotony without replacing
+/// either and WITHOUT feeding the Readiness level. It keeps chronic load (CTL), acute load (ATL), and
+/// their difference (TSB / "form") in the SAME units as the supplied daily load. NOOP currently supplies
+/// daily Effort/strain, so these values are not TRIMP and must not be relabelled as such.
+///
+/// Model:
+///   alpha = 1 - exp(-1 / tauDays)
+///   state[t] = state[t-1] + alpha * (load[t] - state[t-1])
+///   TSB[t] = CTL[t] - ATL[t]
+///
+/// Standard time constants are 42 days (chronic/fitness) and 7 days (acute/fatigue) — the classic
+/// Banister-style fitness-fatigue horizons. The first `primeDays` contiguous observations are averaged
+/// to seed both states, avoiding the artificial low bias of zero-seeding a new wearer.
+///
+/// Missing calendar days are NEVER silently filled with zero. A real rest day must be a row whose load
+/// is 0; a missing row or a nil load breaks the contiguous suffix the model runs over. This is the same
+/// "don't invent zero, don't compress calendar time" discipline the rest of StrandAnalytics uses.
+public enum TrainingLoadEngine {
+    public struct Configuration: Sendable, Equatable {
+        public let chronicTimeConstantDays: Double
+        public let acuteTimeConstantDays: Double
+        public let primeDays: Int
+        public let minimumDays: Int
+        public let establishedDays: Int
+
+        public init(chronicTimeConstantDays: Double = 42,
+                    acuteTimeConstantDays: Double = 7,
+                    primeDays: Int = 7,
+                    minimumDays: Int = 14,
+                    establishedDays: Int = 42) {
+            self.chronicTimeConstantDays = chronicTimeConstantDays
+            self.acuteTimeConstantDays = acuteTimeConstantDays
+            self.primeDays = primeDays
+            self.minimumDays = minimumDays
+            self.establishedDays = establishedDays
+        }
+
+        public static let standard = Configuration()
+
+        fileprivate var isValid: Bool {
+            chronicTimeConstantDays.isFinite && chronicTimeConstantDays > 0
+                && acuteTimeConstantDays.isFinite && acuteTimeConstantDays > 0
+                && primeDays > 0
+                && minimumDays >= primeDays
+                && establishedDays >= minimumDays
+        }
+    }
+
+    /// Calendar-day input. `load == nil` means the day has no usable load observation; that differs from
+    /// `load == 0`, a measured rest day that stays in the model.
+    public struct DailyLoad: Sendable, Equatable {
+        public let day: String       // strict Gregorian YYYY-MM-DD
+        public let load: Double?
+
+        public init(day: String, load: Double?) {
+            self.day = day
+            self.load = load
+        }
+    }
+
+    public enum State: String, Sendable, Equatable, Codable {
+        /// No trustworthy model is emitted yet. See `unavailableReason` and `contiguousDays`.
+        case unavailable
+        /// Minimum history is present, but the chronic 42-day state is still calibrating.
+        case building
+        /// At least the configured established-history window is contiguous and observed.
+        case established
+    }
+
+    public enum UnavailableReason: String, Sendable, Equatable, Codable {
+        case noData
+        case missingTargetDay
+        case notEnoughContiguousDays
+        case invalidConfiguration
+        case invalidDay
+        case duplicateDay
+        case invalidLoad
+    }
+
+    /// One chart-ready modeled day. The first point is the final priming day; CTL/ATL have no defined
+    /// pre-seed state before then.
+    public struct Point: Sendable, Equatable, Codable {
+        public let day: String
+        public let load: Double
+        public let chronicLoad: Double
+        public let acuteLoad: Double
+        public let balance: Double
+
+        public var ctl: Double { chronicLoad }
+        public var atl: Double { acuteLoad }
+        public var tsb: Double { balance }
+    }
+
+    public struct Result: Sendable, Equatable {
+        public let state: State
+        public let unavailableReason: UnavailableReason?
+        public let contiguousDays: Int
+        public let startDay: String?
+        public let endDay: String?
+        public let points: [Point]
+
+        /// Latest modeled chronic load (CTL), in the same units as input load.
+        public var chronicLoad: Double? { points.last?.chronicLoad }
+        /// Latest modeled acute load (ATL), in the same units as input load.
+        public var acuteLoad: Double? { points.last?.acuteLoad }
+        /// Latest CTL - ATL balance (TSB / form), in the same units as input load.
+        public var balance: Double? { points.last?.balance }
+
+        public var ctl: Double? { chronicLoad }
+        public var atl: Double? { acuteLoad }
+        public var tsb: Double? { balance }
+        public var isAvailable: Bool { state != .unavailable }
+    }
+
+    /// Evaluate the latest day in the input, or an explicit target day. Inputs may be in any order.
+    ///
+    /// Only the longest fully observed CONTIGUOUS suffix ending on the target is modeled. Older history
+    /// before a gap is intentionally ignored rather than compressing calendar time or inventing zero load.
+    public static func evaluate(days: [DailyLoad],
+                                through targetDay: String? = nil,
+                                configuration: Configuration = .standard) -> Result {
+        guard configuration.isValid else {
+            return unavailable(.invalidConfiguration, contiguousDays: 0)
+        }
+        guard !days.isEmpty else { return unavailable(.noData, contiguousDays: 0) }
+
+        var parsed: [(day: String, ordinal: Int, load: Double?)] = []
+        parsed.reserveCapacity(days.count)
+        var seen = Set<Int>()
+        for item in days {
+            guard let ordinal = dayOrdinal(item.day) else {
+                return unavailable(.invalidDay, contiguousDays: 0)
+            }
+            guard seen.insert(ordinal).inserted else {
+                return unavailable(.duplicateDay, contiguousDays: 0)
+            }
+            if let load = item.load, (!load.isFinite || load < 0) {
+                return unavailable(.invalidLoad, contiguousDays: 0)
+            }
+            parsed.append((item.day, ordinal, item.load))
+        }
+        parsed.sort { $0.ordinal < $1.ordinal }
+
+        let targetOrdinal: Int
+        if let targetDay {
+            guard let ordinal = dayOrdinal(targetDay) else {
+                return unavailable(.invalidDay, contiguousDays: 0)
+            }
+            targetOrdinal = ordinal
+        } else {
+            targetOrdinal = parsed.last!.ordinal
+        }
+
+        guard let targetIndex = parsed.lastIndex(where: { $0.ordinal == targetOrdinal }) else {
+            return unavailable(.missingTargetDay, contiguousDays: 0)
+        }
+
+        // Walk backwards from the target until the first calendar gap OR unobserved load. A stored zero
+        // stays valid. Future rows and older history before the break do not affect this target's model.
+        var suffixReversed: [(day: String, ordinal: Int, load: Double)] = []
+        var expectedOrdinal = targetOrdinal
+        var index = targetIndex
+        while index >= 0 {
+            let item = parsed[index]
+            guard item.ordinal == expectedOrdinal, let load = item.load else { break }
+            suffixReversed.append((item.day, item.ordinal, load))
+            expectedOrdinal -= 1
+            if index == 0 { break }
+            index -= 1
+        }
+        let ordered = Array(suffixReversed.reversed())
+        let contiguousDays = ordered.count
+        guard contiguousDays >= configuration.minimumDays else {
+            return unavailable(.notEnoughContiguousDays,
+                               contiguousDays: contiguousDays,
+                               startDay: ordered.first?.day,
+                               endDay: ordered.last?.day)
+        }
+
+        let seedWindow = ordered.prefix(configuration.primeDays)
+        let seed = seedWindow.reduce(0.0) { $0 + $1.load } / Double(configuration.primeDays)
+        let alphaChronic = 1 - exp(-1 / configuration.chronicTimeConstantDays)
+        let alphaAcute = 1 - exp(-1 / configuration.acuteTimeConstantDays)
+
+        var chronic = seed
+        var acute = seed
+        var points: [Point] = []
+        points.reserveCapacity(ordered.count - configuration.primeDays + 1)
+
+        let seedDay = ordered[configuration.primeDays - 1]
+        points.append(Point(day: seedDay.day, load: seedDay.load,
+                            chronicLoad: chronic, acuteLoad: acute, balance: chronic - acute))
+
+        for item in ordered.dropFirst(configuration.primeDays) {
+            chronic += alphaChronic * (item.load - chronic)
+            acute += alphaAcute * (item.load - acute)
+            points.append(Point(day: item.day, load: item.load,
+                                chronicLoad: chronic, acuteLoad: acute, balance: chronic - acute))
+        }
+
+        return Result(
+            state: contiguousDays >= configuration.establishedDays ? .established : .building,
+            unavailableReason: nil,
+            contiguousDays: contiguousDays,
+            startDay: ordered.first?.day,
+            endDay: ordered.last?.day,
+            points: points
+        )
+    }
+
+    /// Convenience for already-dense load arrays used by analytics tests and non-calendar callers. Day
+    /// labels are synthetic but deterministic; the model math is identical to `evaluate(days:)`.
+    public static func evaluateDense(_ loads: [Double],
+                                     configuration: Configuration = .standard) -> Result {
+        let baseOrdinal = dayOrdinal("2000-01-01")!
+        let days = loads.enumerated().map { offset, load in
+            DailyLoad(day: dayString(ordinal: baseOrdinal + offset), load: load)
+        }
+        return evaluate(days: days, configuration: configuration)
+    }
+
+    private static func unavailable(_ reason: UnavailableReason,
+                                    contiguousDays: Int,
+                                    startDay: String? = nil,
+                                    endDay: String? = nil) -> Result {
+        Result(state: .unavailable, unavailableReason: reason,
+               contiguousDays: contiguousDays, startDay: startDay, endDay: endDay, points: [])
+    }
+
+    // MARK: - Strict, timezone-free Gregorian calendar helpers
+
+    /// Gregorian date -> day ordinal using Howard Hinnant's civil-date transform. Integer-only and
+    /// timezone-free so the Swift/Kotlin twins cannot drift around DST or locale boundaries.
+    private static func dayOrdinal(_ value: String) -> Int? {
+        let parts = value.split(separator: "-", omittingEmptySubsequences: false)
+        guard parts.count == 3,
+              parts[0].count == 4, parts[1].count == 2, parts[2].count == 2,
+              let year = Int(parts[0]), let month = Int(parts[1]), let day = Int(parts[2]),
+              year >= 1, (1...12).contains(month) else { return nil }
+        let daysInMonth: [Int] = [31, isLeapYear(year) ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+        guard (1...daysInMonth[month - 1]).contains(day) else { return nil }
+
+        let adjustedYear = year - (month <= 2 ? 1 : 0)
+        let era = floorDiv(adjustedYear, 400)
+        let yearOfEra = adjustedYear - era * 400
+        let shiftedMonth = month + (month > 2 ? -3 : 9)
+        let dayOfYear = (153 * shiftedMonth + 2) / 5 + day - 1
+        let dayOfEra = yearOfEra * 365 + yearOfEra / 4 - yearOfEra / 100 + dayOfYear
+        return era * 146_097 + dayOfEra - 719_468
+    }
+
+    private static func dayString(ordinal: Int) -> String {
+        let z = ordinal + 719_468
+        let era = floorDiv(z, 146_097)
+        let dayOfEra = z - era * 146_097
+        let yearOfEra = (dayOfEra - dayOfEra / 1_460 + dayOfEra / 36_524 - dayOfEra / 146_096) / 365
+        var year = yearOfEra + era * 400
+        let dayOfYear = dayOfEra - (365 * yearOfEra + yearOfEra / 4 - yearOfEra / 100)
+        let monthPrime = (5 * dayOfYear + 2) / 153
+        let day = dayOfYear - (153 * monthPrime + 2) / 5 + 1
+        let month = monthPrime + (monthPrime < 10 ? 3 : -9)
+        year += month <= 2 ? 1 : 0
+        return String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    private static func isLeapYear(_ year: Int) -> Bool {
+        year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
+    }
+
+    private static func floorDiv(_ value: Int, _ divisor: Int) -> Int {
+        let quotient = value / divisor
+        let remainder = value % divisor
+        return remainder < 0 ? quotient - 1 : quotient
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ReadinessTrainingLoadTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ReadinessTrainingLoadTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import XCTest
+@testable import StrandAnalytics
+import WhoopStore
+
+final class ReadinessTrainingLoadTests: XCTestCase {
+    private func metric(day: Int, strain: Double?, hrv: Double = 60, rhr: Int = 52) -> DailyMetric {
+        DailyMetric(
+            day: String(format: "2026-01-%02d", day),
+            totalSleepMin: nil, efficiency: nil, deepMin: nil, remMin: nil, lightMin: nil,
+            disturbances: nil, restingHr: rhr, avgHrv: hrv, recovery: nil, strain: strain,
+            exerciseCount: nil, spo2Pct: nil, skinTempDevC: nil, respRateBpm: 14
+        )
+    }
+
+    func testPairedAPILeavesExistingReadinessExactlyUnchanged() {
+        let days = (1...28).map { day in
+            metric(day: day, strain: day <= 21 ? 5 : 15,
+                   hrv: day.isMultiple(of: 2) ? 62 : 58,
+                   rhr: day.isMultiple(of: 2) ? 54 : 50)
+        }
+
+        let existing = ReadinessEngine.evaluate(days: days)
+        let paired = ReadinessEngine.evaluateWithTrainingLoad(days: days)
+
+        XCTAssertEqual(paired.readiness, existing)
+        XCTAssertTrue(paired.trainingLoad.isAvailable)
+        XCTAssertEqual(paired.trainingLoad.state, .building)
+        XCTAssertNotNil(paired.trainingLoad.ctl)
+        XCTAssertNotNil(paired.trainingLoad.atl)
+        XCTAssertNotNil(paired.trainingLoad.tsb)
+    }
+
+    func testExistingAcwrAndMonotonyRemainOwnedByReadiness() {
+        let days = (1...28).map { day in
+            metric(day: day, strain: day <= 21 ? 5 : Double(12 + day % 3))
+        }
+        let paired = ReadinessEngine.evaluateWithTrainingLoad(days: days)
+
+        XCTAssertNotNil(paired.readiness.acwr)
+        XCTAssertNotNil(paired.readiness.monotony)
+        XCTAssertTrue(paired.trainingLoad.isAvailable)
+        XCTAssertEqual(paired.trainingLoad.endDay, "2026-01-28")
+    }
+
+    func testMissingLoadBreaksTrainingModelWithoutSuppressingReadiness() {
+        var days = (1...28).map { metric(day: $0, strain: 10) }
+        // An unobserved load is not a zero-load rest day. It breaks the model's contiguous suffix, while
+        // the existing Readiness engine can still synthesize its other signals from the same history.
+        days[20] = metric(day: 21, strain: nil)
+
+        let paired = ReadinessEngine.evaluateWithTrainingLoad(days: days)
+        XCTAssertNotEqual(paired.readiness.level, .insufficient)
+        XCTAssertEqual(paired.trainingLoad.state, .unavailable)
+        XCTAssertEqual(paired.trainingLoad.unavailableReason, .notEnoughContiguousDays)
+        XCTAssertEqual(paired.trainingLoad.contiguousDays, 7)
+    }
+
+    func testExplicitMissingTodayFailsClosedForBothAnalyses() {
+        let days = (1...28).map { metric(day: $0, strain: 10) }
+        let paired = ReadinessEngine.evaluateWithTrainingLoad(days: days, today: "2026-02-01")
+
+        XCTAssertEqual(paired.readiness.level, .insufficient)
+        XCTAssertEqual(paired.trainingLoad.state, .unavailable)
+        XCTAssertEqual(paired.trainingLoad.unavailableReason, .missingTargetDay)
+    }
+
+    func testExplicitTodayIgnoresFutureTrainingRows() {
+        let days = (1...28).map { day in metric(day: day, strain: day <= 20 ? 10 : 100) }
+        let paired = ReadinessEngine.evaluateWithTrainingLoad(days: days, today: "2026-01-20")
+
+        XCTAssertEqual(paired.trainingLoad.endDay, "2026-01-20")
+        XCTAssertEqual(paired.trainingLoad.contiguousDays, 20)
+        XCTAssertEqual(paired.trainingLoad.points.last?.load, 10)
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/TrainingLoadEngineTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/TrainingLoadEngineTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import XCTest
+@testable import StrandAnalytics
+
+final class TrainingLoadEngineTests: XCTestCase {
+    func testConstantLoadConvergesExactlyToLoadAndZeroBalance() {
+        let result = TrainingLoadEngine.evaluateDense(Array(repeating: 50, count: 42))
+        XCTAssertEqual(result.state, .established)
+        XCTAssertNil(result.unavailableReason)
+        XCTAssertEqual(result.contiguousDays, 42)
+        XCTAssertEqual(result.points.count, 36)
+        XCTAssertEqual(result.ctl!, 50, accuracy: 1e-12)
+        XCTAssertEqual(result.atl!, 50, accuracy: 1e-12)
+        XCTAssertEqual(result.tsb!, 0, accuracy: 1e-12)
+    }
+
+    func testStepUpRaisesAcuteLoadFasterThanChronicLoad() {
+        let loads = Array(repeating: 50.0, count: 7) + Array(repeating: 100.0, count: 7)
+        let result = TrainingLoadEngine.evaluateDense(loads)
+
+        XCTAssertEqual(result.state, .building)
+        XCTAssertEqual(result.contiguousDays, 14)
+        XCTAssertEqual(result.ctl!, 57.67591375546929, accuracy: 1e-10)
+        XCTAssertEqual(result.atl!, 81.6060279414279, accuracy: 1e-10)
+        XCTAssertEqual(result.tsb!, -23.930114185958608, accuracy: 1e-10)
+        XCTAssertGreaterThan(result.atl!, result.ctl!)
+        XCTAssertLessThan(result.tsb!, 0)
+    }
+
+    func testStepDownProducesPositiveBalanceAsAcuteLoadFallsFaster() {
+        let loads = Array(repeating: 100.0, count: 7) + Array(repeating: 20.0, count: 14)
+        let result = TrainingLoadEngine.evaluateDense(loads)
+        XCTAssertEqual(result.state, .building)
+        XCTAssertGreaterThan(result.ctl!, result.atl!)
+        XCTAssertGreaterThan(result.tsb!, 0)
+    }
+
+    func testMinimumAndEstablishedHistoryBoundariesAreExplicit() {
+        let thirteen = TrainingLoadEngine.evaluateDense(Array(repeating: 40, count: 13))
+        XCTAssertEqual(thirteen.state, .unavailable)
+        XCTAssertEqual(thirteen.unavailableReason, .notEnoughContiguousDays)
+        XCTAssertEqual(thirteen.contiguousDays, 13)
+        XCTAssertTrue(thirteen.points.isEmpty)
+
+        let fourteen = TrainingLoadEngine.evaluateDense(Array(repeating: 40, count: 14))
+        XCTAssertEqual(fourteen.state, .building)
+        XCTAssertEqual(fourteen.contiguousDays, 14)
+
+        let fortyTwo = TrainingLoadEngine.evaluateDense(Array(repeating: 40, count: 42))
+        XCTAssertEqual(fortyTwo.state, .established)
+    }
+
+    func testRealZeroLoadDayIsObservedRatherThanTreatedAsMissing() {
+        var loads = Array(repeating: 50.0, count: 13)
+        loads.append(0)
+        let result = TrainingLoadEngine.evaluateDense(loads)
+        XCTAssertTrue(result.isAvailable)
+        XCTAssertEqual(result.contiguousDays, 14)
+        XCTAssertEqual(result.points.last?.load, 0)
+        XCTAssertLessThan(result.atl!, 50)
+    }
+
+    func testMissingLoadBreaksContiguousSuffixInsteadOfInventingZero() {
+        var days: [TrainingLoadEngine.DailyLoad] = []
+        for day in 1...20 {
+            days.append(.init(day: String(format: "2026-07-%02d", day), load: day == 12 ? nil : 50))
+        }
+        let result = TrainingLoadEngine.evaluate(days: days)
+        XCTAssertEqual(result.state, .unavailable)
+        XCTAssertEqual(result.unavailableReason, .notEnoughContiguousDays)
+        XCTAssertEqual(result.contiguousDays, 8)
+        XCTAssertEqual(result.startDay, "2026-07-13")
+        XCTAssertEqual(result.endDay, "2026-07-20")
+    }
+
+    func testMissingCalendarDayBreaksSuffixRatherThanCompressingTime() {
+        var days: [TrainingLoadEngine.DailyLoad] = []
+        for day in 1...20 where day != 15 {
+            days.append(.init(day: String(format: "2026-06-%02d", day), load: 50))
+        }
+        let result = TrainingLoadEngine.evaluate(days: days)
+        XCTAssertEqual(result.state, .unavailable)
+        XCTAssertEqual(result.unavailableReason, .notEnoughContiguousDays)
+        XCTAssertEqual(result.contiguousDays, 5)
+        XCTAssertEqual(result.startDay, "2026-06-16")
+    }
+
+    func testExplicitTargetUsesOnlyHistoryThroughThatDay() {
+        let days = (1...25).map {
+            TrainingLoadEngine.DailyLoad(day: String(format: "2026-05-%02d", $0), load: Double($0))
+        }
+        let result = TrainingLoadEngine.evaluate(days: days, through: "2026-05-20")
+        XCTAssertEqual(result.contiguousDays, 20)
+        XCTAssertEqual(result.endDay, "2026-05-20")
+        XCTAssertEqual(result.points.last?.day, "2026-05-20")
+    }
+
+    func testMissingExplicitTargetFailsClosed() {
+        let days = (1...20).map {
+            TrainingLoadEngine.DailyLoad(day: String(format: "2026-04-%02d", $0), load: 50)
+        }
+        let result = TrainingLoadEngine.evaluate(days: days, through: "2026-04-25")
+        XCTAssertEqual(result.state, .unavailable)
+        XCTAssertEqual(result.unavailableReason, .missingTargetDay)
+    }
+
+    func testInputOrderDoesNotChangeResult() {
+        let days = (1...20).map {
+            TrainingLoadEngine.DailyLoad(day: String(format: "2026-03-%02d", $0), load: Double(20 + $0))
+        }
+        XCTAssertEqual(TrainingLoadEngine.evaluate(days: days),
+                       TrainingLoadEngine.evaluate(days: Array(days.reversed())))
+    }
+
+    func testMalformedDuplicateNegativeAndNonFiniteInputFailClosed() {
+        XCTAssertEqual(
+            TrainingLoadEngine.evaluate(days: [.init(day: "2026-02-30", load: 10)]).unavailableReason,
+            .invalidDay
+        )
+        XCTAssertEqual(
+            TrainingLoadEngine.evaluate(days: [
+                .init(day: "2026-02-01", load: 10), .init(day: "2026-02-01", load: 11),
+            ]).unavailableReason,
+            .duplicateDay
+        )
+        XCTAssertEqual(
+            TrainingLoadEngine.evaluate(days: [.init(day: "2026-02-01", load: -1)]).unavailableReason,
+            .invalidLoad
+        )
+        XCTAssertEqual(
+            TrainingLoadEngine.evaluate(days: [.init(day: "2026-02-01", load: .nan)]).unavailableReason,
+            .invalidLoad
+        )
+    }
+
+    func testInvalidConfigurationFailsClosed() {
+        let bad = TrainingLoadEngine.Configuration(chronicTimeConstantDays: 0)
+        let result = TrainingLoadEngine.evaluateDense(Array(repeating: 50, count: 42), configuration: bad)
+        XCTAssertEqual(result.state, .unavailable)
+        XCTAssertEqual(result.unavailableReason, .invalidConfiguration)
+    }
+
+    func testLeapDayAndMonthBoundaryStayContiguousWithoutTimezoneMath() {
+        let days = [
+            "2024-02-22", "2024-02-23", "2024-02-24", "2024-02-25", "2024-02-26", "2024-02-27",
+            "2024-02-28", "2024-02-29", "2024-03-01", "2024-03-02", "2024-03-03", "2024-03-04",
+            "2024-03-05", "2024-03-06",
+        ].map { TrainingLoadEngine.DailyLoad(day: $0, load: 30) }
+        let result = TrainingLoadEngine.evaluate(days: days)
+        XCTAssertEqual(result.state, .building)
+        XCTAssertEqual(result.contiguousDays, 14)
+        XCTAssertEqual(result.ctl!, 30, accuracy: 1e-12)
+        XCTAssertEqual(result.atl!, 30, accuracy: 1e-12)
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/ReadinessTrainingLoad.kt
+++ b/android/app/src/main/java/com/noop/analytics/ReadinessTrainingLoad.kt
@@ -1,0 +1,29 @@
+package com.noop.analytics
+
+import com.noop.data.DailyMetric
+
+/**
+ * Readiness plus descriptive long-horizon training-load state.
+ *
+ * CTL/ATL/TSB stay OUTSIDE the Readiness synthesis: this wrapper does not change the existing level,
+ * signals, confidence, ACWR, or monotony. Twin of Swift `ReadinessEngine.evaluateWithTrainingLoad`.
+ */
+data class ReadinessTrainingLoadAnalysis(
+    val readiness: ReadinessEngine.Readiness,
+    val trainingLoad: TrainingLoadEngine.Result,
+)
+
+fun ReadinessEngine.evaluateWithTrainingLoad(
+    days: List<DailyMetric>,
+    today: String? = null,
+    trainingLoadConfiguration: TrainingLoadEngine.Configuration = TrainingLoadEngine.standard,
+): ReadinessTrainingLoadAnalysis {
+    val readiness = evaluate(days, today)
+    val trainingDays = days.map { TrainingLoadEngine.DailyLoad(it.day, it.strain) }
+    val trainingLoad = TrainingLoadEngine.evaluate(
+        trainingDays,
+        through = today,
+        configuration = trainingLoadConfiguration,
+    )
+    return ReadinessTrainingLoadAnalysis(readiness, trainingLoad)
+}

--- a/android/app/src/main/java/com/noop/analytics/TrainingLoadEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/TrainingLoadEngine.kt
@@ -1,0 +1,219 @@
+package com.noop.analytics
+
+import kotlin.math.exp
+
+/**
+ * Long-horizon training-load model using exponentially weighted daily load.
+ *
+ * Complements ReadinessEngine's existing rolling-mean ACWR and Foster monotony without replacing either
+ * and without feeding the Readiness level. CTL, ATL, and TSB stay in the SAME units as the supplied daily
+ * load; NOOP supplies daily Effort/strain, so these are not TRIMP. Missing calendar days are never
+ * silently filled with zero — a real rest day must be present with load=0, and a missing row or a null
+ * load breaks the contiguous suffix. Byte-parity twin of Swift `TrainingLoadEngine`.
+ *
+ * Model: alpha = 1 - exp(-1 / tauDays); state[t] = state[t-1] + alpha * (load[t] - state[t-1]);
+ * TSB = CTL - ATL. Standard 42d chronic / 7d acute Banister-style horizons, seeded from the mean of the
+ * first `primeDays` observed loads to avoid the artificial low bias of zero-seeding a new wearer.
+ */
+object TrainingLoadEngine {
+    data class Configuration(
+        val chronicTimeConstantDays: Double = 42.0,
+        val acuteTimeConstantDays: Double = 7.0,
+        val primeDays: Int = 7,
+        val minimumDays: Int = 14,
+        val establishedDays: Int = 42,
+    ) {
+        val isValid: Boolean
+            get() = chronicTimeConstantDays.isFinite() && chronicTimeConstantDays > 0.0 &&
+                acuteTimeConstantDays.isFinite() && acuteTimeConstantDays > 0.0 &&
+                primeDays > 0 && minimumDays >= primeDays && establishedDays >= minimumDays
+    }
+
+    val standard = Configuration()
+
+    /** Calendar-day input. `load == null` is no usable observation; `load == 0` is a measured rest day. */
+    data class DailyLoad(val day: String, val load: Double?)
+
+    enum class State { UNAVAILABLE, BUILDING, ESTABLISHED }
+
+    enum class UnavailableReason {
+        NO_DATA,
+        MISSING_TARGET_DAY,
+        NOT_ENOUGH_CONTIGUOUS_DAYS,
+        INVALID_CONFIGURATION,
+        INVALID_DAY,
+        DUPLICATE_DAY,
+        INVALID_LOAD,
+    }
+
+    data class Point(
+        val day: String,
+        val load: Double,
+        val chronicLoad: Double,
+        val acuteLoad: Double,
+        val balance: Double,
+    ) {
+        val ctl: Double get() = chronicLoad
+        val atl: Double get() = acuteLoad
+        val tsb: Double get() = balance
+    }
+
+    data class Result(
+        val state: State,
+        val unavailableReason: UnavailableReason?,
+        val contiguousDays: Int,
+        val startDay: String?,
+        val endDay: String?,
+        val points: List<Point>,
+    ) {
+        val chronicLoad: Double? get() = points.lastOrNull()?.chronicLoad
+        val acuteLoad: Double? get() = points.lastOrNull()?.acuteLoad
+        val balance: Double? get() = points.lastOrNull()?.balance
+        val ctl: Double? get() = chronicLoad
+        val atl: Double? get() = acuteLoad
+        val tsb: Double? get() = balance
+        val isAvailable: Boolean get() = state != State.UNAVAILABLE
+    }
+
+    /**
+     * Evaluate the latest day in the input, or an explicit target day. Inputs may be in any order. Only
+     * the longest fully observed contiguous suffix ending on the target is modeled; older history before a
+     * gap is ignored rather than compressing calendar time or inventing zero load.
+     */
+    fun evaluate(
+        days: List<DailyLoad>,
+        through: String? = null,
+        configuration: Configuration = standard,
+    ): Result {
+        if (!configuration.isValid) return unavailable(UnavailableReason.INVALID_CONFIGURATION, 0)
+        if (days.isEmpty()) return unavailable(UnavailableReason.NO_DATA, 0)
+
+        data class Parsed(val day: String, val ordinal: Int, val load: Double?)
+        val parsed = ArrayList<Parsed>(days.size)
+        val seen = HashSet<Int>()
+        for (item in days) {
+            val ordinal = dayOrdinal(item.day) ?: return unavailable(UnavailableReason.INVALID_DAY, 0)
+            if (!seen.add(ordinal)) return unavailable(UnavailableReason.DUPLICATE_DAY, 0)
+            val load = item.load
+            if (load != null && (!load.isFinite() || load < 0.0)) {
+                return unavailable(UnavailableReason.INVALID_LOAD, 0)
+            }
+            parsed += Parsed(item.day, ordinal, load)
+        }
+        parsed.sortBy { it.ordinal }
+
+        val targetOrdinal = if (through != null) {
+            dayOrdinal(through) ?: return unavailable(UnavailableReason.INVALID_DAY, 0)
+        } else {
+            parsed.last().ordinal
+        }
+        val targetIndex = parsed.indexOfLast { it.ordinal == targetOrdinal }
+        if (targetIndex < 0) return unavailable(UnavailableReason.MISSING_TARGET_DAY, 0)
+
+        // Walk backwards from the target until the first calendar gap OR unobserved load. A stored zero
+        // stays valid; future rows and older history before the break do not affect this target's model.
+        val suffixReversed = ArrayList<Parsed>()
+        var expectedOrdinal = targetOrdinal
+        var index = targetIndex
+        while (index >= 0) {
+            val item = parsed[index]
+            val load = item.load
+            if (item.ordinal != expectedOrdinal || load == null) break
+            suffixReversed += item
+            expectedOrdinal -= 1
+            index -= 1
+        }
+        val ordered = suffixReversed.asReversed()
+        val contiguousDays = ordered.size
+        if (contiguousDays < configuration.minimumDays) {
+            return unavailable(
+                UnavailableReason.NOT_ENOUGH_CONTIGUOUS_DAYS,
+                contiguousDays,
+                ordered.firstOrNull()?.day,
+                ordered.lastOrNull()?.day,
+            )
+        }
+
+        val seed = ordered.take(configuration.primeDays).sumOf { it.load!! } / configuration.primeDays.toDouble()
+        val alphaChronic = 1.0 - exp(-1.0 / configuration.chronicTimeConstantDays)
+        val alphaAcute = 1.0 - exp(-1.0 / configuration.acuteTimeConstantDays)
+        var chronic = seed
+        var acute = seed
+        val points = ArrayList<Point>(ordered.size - configuration.primeDays + 1)
+
+        val seedDay = ordered[configuration.primeDays - 1]
+        points += Point(seedDay.day, seedDay.load!!, chronic, acute, chronic - acute)
+        for (item in ordered.drop(configuration.primeDays)) {
+            val load = item.load!!
+            chronic += alphaChronic * (load - chronic)
+            acute += alphaAcute * (load - acute)
+            points += Point(item.day, load, chronic, acute, chronic - acute)
+        }
+
+        return Result(
+            state = if (contiguousDays >= configuration.establishedDays) State.ESTABLISHED else State.BUILDING,
+            unavailableReason = null,
+            contiguousDays = contiguousDays,
+            startDay = ordered.firstOrNull()?.day,
+            endDay = ordered.lastOrNull()?.day,
+            points = points,
+        )
+    }
+
+    /** Convenience for dense load arrays. Day labels are synthetic but deterministic; math is identical. */
+    fun evaluateDense(loads: List<Double>, configuration: Configuration = standard): Result {
+        val baseOrdinal = dayOrdinal("2000-01-01")!!
+        val days = loads.mapIndexed { index, load -> DailyLoad(dayString(baseOrdinal + index), load) }
+        return evaluate(days, configuration = configuration)
+    }
+
+    private fun unavailable(
+        reason: UnavailableReason,
+        contiguousDays: Int,
+        startDay: String? = null,
+        endDay: String? = null,
+    ) = Result(State.UNAVAILABLE, reason, contiguousDays, startDay, endDay, emptyList())
+
+    // Integer-only proleptic-Gregorian (Howard Hinnant) transform. Avoids timezone/DST/locale drift
+    // between platforms so the Swift twin cannot diverge around DST or locale boundaries.
+    private fun dayOrdinal(value: String): Int? {
+        val parts = value.split('-', limit = 3)
+        if (parts.size != 3 || parts[0].length != 4 || parts[1].length != 2 || parts[2].length != 2) return null
+        val year = parts[0].toIntOrNull() ?: return null
+        val month = parts[1].toIntOrNull() ?: return null
+        val day = parts[2].toIntOrNull() ?: return null
+        if (year < 1 || month !in 1..12) return null
+        val daysInMonth = intArrayOf(31, if (isLeapYear(year)) 29 else 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+        if (day !in 1..daysInMonth[month - 1]) return null
+
+        val adjustedYear = year - if (month <= 2) 1 else 0
+        val era = floorDiv(adjustedYear, 400)
+        val yearOfEra = adjustedYear - era * 400
+        val shiftedMonth = month + if (month > 2) -3 else 9
+        val dayOfYear = (153 * shiftedMonth + 2) / 5 + day - 1
+        val dayOfEra = yearOfEra * 365 + yearOfEra / 4 - yearOfEra / 100 + dayOfYear
+        return era * 146_097 + dayOfEra - 719_468
+    }
+
+    private fun dayString(ordinal: Int): String {
+        val z = ordinal + 719_468
+        val era = floorDiv(z, 146_097)
+        val dayOfEra = z - era * 146_097
+        val yearOfEra = (dayOfEra - dayOfEra / 1_460 + dayOfEra / 36_524 - dayOfEra / 146_096) / 365
+        var year = yearOfEra + era * 400
+        val dayOfYear = dayOfEra - (365 * yearOfEra + yearOfEra / 4 - yearOfEra / 100)
+        val monthPrime = (5 * dayOfYear + 2) / 153
+        val day = dayOfYear - (153 * monthPrime + 2) / 5 + 1
+        val month = monthPrime + if (monthPrime < 10) 3 else -9
+        if (month <= 2) year += 1
+        return "%04d-%02d-%02d".format(java.util.Locale.US, year, month, day)
+    }
+
+    private fun isLeapYear(year: Int) = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
+
+    private fun floorDiv(value: Int, divisor: Int): Int {
+        val quotient = value / divisor
+        val remainder = value % divisor
+        return if (remainder < 0) quotient - 1 else quotient
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/ReadinessTrainingLoadTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ReadinessTrainingLoadTest.kt
@@ -1,0 +1,90 @@
+package com.noop.analytics
+
+import com.noop.data.DailyMetric
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Locale
+
+class ReadinessTrainingLoadTest {
+    private fun metric(day: Int, strain: Double?, hrv: Double = 60.0, rhr: Int = 52): DailyMetric =
+        DailyMetric(
+            deviceId = "test-device",
+            day = String.format(Locale.US, "2026-01-%02d", day),
+            restingHr = rhr,
+            avgHrv = hrv,
+            strain = strain,
+            respRateBpm = 14.0,
+        )
+
+    @Test
+    fun pairedApiLeavesExistingReadinessExactlyUnchanged() {
+        val days = (1..28).map { day ->
+            metric(
+                day,
+                strain = if (day <= 21) 5.0 else 15.0,
+                hrv = if (day % 2 == 0) 62.0 else 58.0,
+                rhr = if (day % 2 == 0) 54 else 50,
+            )
+        }
+
+        val existing = ReadinessEngine.evaluate(days)
+        val paired = ReadinessEngine.evaluateWithTrainingLoad(days)
+
+        assertEquals(existing, paired.readiness)
+        assertTrue(paired.trainingLoad.isAvailable)
+        assertEquals(TrainingLoadEngine.State.BUILDING, paired.trainingLoad.state)
+        assertNotNull(paired.trainingLoad.ctl)
+        assertNotNull(paired.trainingLoad.atl)
+        assertNotNull(paired.trainingLoad.tsb)
+    }
+
+    @Test
+    fun existingAcwrAndMonotonyRemainOwnedByReadiness() {
+        val days = (1..28).map { day ->
+            metric(day, if (day <= 21) 5.0 else (12 + day % 3).toDouble())
+        }
+        val paired = ReadinessEngine.evaluateWithTrainingLoad(days)
+
+        assertNotNull(paired.readiness.acwr)
+        assertNotNull(paired.readiness.monotony)
+        assertTrue(paired.trainingLoad.isAvailable)
+        assertEquals("2026-01-28", paired.trainingLoad.endDay)
+    }
+
+    @Test
+    fun missingLoadBreaksTrainingModelWithoutSuppressingReadiness() {
+        val days = (1..28).map { metric(it, if (it == 21) null else 10.0) }
+        val paired = ReadinessEngine.evaluateWithTrainingLoad(days)
+
+        assertNotEquals(ReadinessEngine.Level.INSUFFICIENT, paired.readiness.level)
+        assertEquals(TrainingLoadEngine.State.UNAVAILABLE, paired.trainingLoad.state)
+        assertEquals(
+            TrainingLoadEngine.UnavailableReason.NOT_ENOUGH_CONTIGUOUS_DAYS,
+            paired.trainingLoad.unavailableReason,
+        )
+        assertEquals(7, paired.trainingLoad.contiguousDays)
+    }
+
+    @Test
+    fun explicitMissingTodayFailsClosedForBothAnalyses() {
+        val days = (1..28).map { metric(it, 10.0) }
+        val paired = ReadinessEngine.evaluateWithTrainingLoad(days, today = "2026-02-01")
+
+        assertEquals(ReadinessEngine.Level.INSUFFICIENT, paired.readiness.level)
+        assertEquals(TrainingLoadEngine.State.UNAVAILABLE, paired.trainingLoad.state)
+        assertEquals(TrainingLoadEngine.UnavailableReason.MISSING_TARGET_DAY, paired.trainingLoad.unavailableReason)
+    }
+
+    @Test
+    fun explicitTodayIgnoresFutureTrainingRows() {
+        val days = (1..28).map { day -> metric(day, if (day <= 20) 10.0 else 100.0) }
+        val paired = ReadinessEngine.evaluateWithTrainingLoad(days, today = "2026-01-20")
+
+        assertEquals("2026-01-20", paired.trainingLoad.endDay)
+        assertEquals(20, paired.trainingLoad.contiguousDays)
+        assertEquals(10.0, paired.trainingLoad.points.last().load, 0.0)
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/TrainingLoadEngineTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/TrainingLoadEngineTest.kt
@@ -1,0 +1,152 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TrainingLoadEngineTest {
+    @Test
+    fun constantLoadConvergesExactlyToLoadAndZeroBalance() {
+        val result = TrainingLoadEngine.evaluateDense(List(42) { 50.0 })
+        assertEquals(TrainingLoadEngine.State.ESTABLISHED, result.state)
+        assertNull(result.unavailableReason)
+        assertEquals(42, result.contiguousDays)
+        assertEquals(36, result.points.size)
+        assertEquals(50.0, result.ctl!!, 1e-12)
+        assertEquals(50.0, result.atl!!, 1e-12)
+        assertEquals(0.0, result.tsb!!, 1e-12)
+    }
+
+    @Test
+    fun stepUpRaisesAcuteLoadFasterThanChronicLoad() {
+        val result = TrainingLoadEngine.evaluateDense(List(7) { 50.0 } + List(7) { 100.0 })
+        assertEquals(TrainingLoadEngine.State.BUILDING, result.state)
+        assertEquals(57.67591375546929, result.ctl!!, 1e-10)
+        assertEquals(81.6060279414279, result.atl!!, 1e-10)
+        assertEquals(-23.930114185958608, result.tsb!!, 1e-10)
+        assertTrue(result.atl!! > result.ctl!!)
+        assertTrue(result.tsb!! < 0.0)
+    }
+
+    @Test
+    fun stepDownProducesPositiveBalanceAsAcuteLoadFallsFaster() {
+        val result = TrainingLoadEngine.evaluateDense(List(7) { 100.0 } + List(14) { 20.0 })
+        assertTrue(result.ctl!! > result.atl!!)
+        assertTrue(result.tsb!! > 0.0)
+    }
+
+    @Test
+    fun minimumAndEstablishedBoundariesAreExplicit() {
+        val thirteen = TrainingLoadEngine.evaluateDense(List(13) { 40.0 })
+        assertEquals(TrainingLoadEngine.State.UNAVAILABLE, thirteen.state)
+        assertEquals(TrainingLoadEngine.UnavailableReason.NOT_ENOUGH_CONTIGUOUS_DAYS, thirteen.unavailableReason)
+        assertTrue(thirteen.points.isEmpty())
+
+        assertEquals(
+            TrainingLoadEngine.State.BUILDING,
+            TrainingLoadEngine.evaluateDense(List(14) { 40.0 }).state,
+        )
+        assertEquals(
+            TrainingLoadEngine.State.ESTABLISHED,
+            TrainingLoadEngine.evaluateDense(List(42) { 40.0 }).state,
+        )
+    }
+
+    @Test
+    fun zeroIsARealRestDayButMissingLoadBreaksHistory() {
+        val zeroLoads = MutableList(14) { 50.0 }.also { it[13] = 0.0 }
+        val zero = TrainingLoadEngine.evaluateDense(zeroLoads)
+        assertTrue(zero.isAvailable)
+        assertEquals(0.0, zero.points.last().load, 0.0)
+        assertTrue(zero.atl!! < 50.0)
+
+        val days = (1..20).map { day ->
+            TrainingLoadEngine.DailyLoad("2026-07-%02d".format(day), if (day == 12) null else 50.0)
+        }
+        val missing = TrainingLoadEngine.evaluate(days)
+        assertFalse(missing.isAvailable)
+        assertEquals(8, missing.contiguousDays)
+        assertEquals("2026-07-13", missing.startDay)
+    }
+
+    @Test
+    fun missingCalendarDayBreaksSuffix() {
+        val days = (1..20).filter { it != 15 }.map { day ->
+            TrainingLoadEngine.DailyLoad("2026-06-%02d".format(day), 50.0)
+        }
+        val result = TrainingLoadEngine.evaluate(days)
+        assertEquals(5, result.contiguousDays)
+        assertEquals("2026-06-16", result.startDay)
+        assertEquals(TrainingLoadEngine.UnavailableReason.NOT_ENOUGH_CONTIGUOUS_DAYS, result.unavailableReason)
+    }
+
+    @Test
+    fun explicitTargetIgnoresFutureRowsAndMissingTargetFailsClosed() {
+        val days = (1..25).map { day ->
+            TrainingLoadEngine.DailyLoad("2026-05-%02d".format(day), day.toDouble())
+        }
+        val result = TrainingLoadEngine.evaluate(days, through = "2026-05-20")
+        assertEquals(20, result.contiguousDays)
+        assertEquals("2026-05-20", result.endDay)
+        assertEquals("2026-05-20", result.points.last().day)
+
+        val missing = TrainingLoadEngine.evaluate(days, through = "2026-05-30")
+        assertEquals(TrainingLoadEngine.UnavailableReason.MISSING_TARGET_DAY, missing.unavailableReason)
+    }
+
+    @Test
+    fun inputOrderDoesNotChangeResult() {
+        val days = (1..20).map { day ->
+            TrainingLoadEngine.DailyLoad("2026-03-%02d".format(day), (20 + day).toDouble())
+        }
+        assertEquals(TrainingLoadEngine.evaluate(days), TrainingLoadEngine.evaluate(days.reversed()))
+    }
+
+    @Test
+    fun invalidInputsFailClosed() {
+        assertEquals(
+            TrainingLoadEngine.UnavailableReason.INVALID_DAY,
+            TrainingLoadEngine.evaluate(listOf(TrainingLoadEngine.DailyLoad("2026-02-30", 10.0))).unavailableReason,
+        )
+        assertEquals(
+            TrainingLoadEngine.UnavailableReason.DUPLICATE_DAY,
+            TrainingLoadEngine.evaluate(
+                listOf(
+                    TrainingLoadEngine.DailyLoad("2026-02-01", 10.0),
+                    TrainingLoadEngine.DailyLoad("2026-02-01", 11.0),
+                ),
+            ).unavailableReason,
+        )
+        assertEquals(
+            TrainingLoadEngine.UnavailableReason.INVALID_LOAD,
+            TrainingLoadEngine.evaluate(listOf(TrainingLoadEngine.DailyLoad("2026-02-01", -1.0))).unavailableReason,
+        )
+        assertEquals(
+            TrainingLoadEngine.UnavailableReason.INVALID_LOAD,
+            TrainingLoadEngine.evaluate(listOf(TrainingLoadEngine.DailyLoad("2026-02-01", Double.NaN))).unavailableReason,
+        )
+        assertEquals(
+            TrainingLoadEngine.UnavailableReason.INVALID_CONFIGURATION,
+            TrainingLoadEngine.evaluateDense(
+                List(42) { 50.0 },
+                TrainingLoadEngine.Configuration(chronicTimeConstantDays = 0.0),
+            ).unavailableReason,
+        )
+    }
+
+    @Test
+    fun leapDayAndMonthBoundaryStayContiguous() {
+        val dates = listOf(
+            "2024-02-22", "2024-02-23", "2024-02-24", "2024-02-25", "2024-02-26", "2024-02-27",
+            "2024-02-28", "2024-02-29", "2024-03-01", "2024-03-02", "2024-03-03", "2024-03-04",
+            "2024-03-05", "2024-03-06",
+        )
+        val result = TrainingLoadEngine.evaluate(dates.map { TrainingLoadEngine.DailyLoad(it, 30.0) })
+        assertEquals(TrainingLoadEngine.State.BUILDING, result.state)
+        assertEquals(14, result.contiguousDays)
+        assertEquals(30.0, result.ctl!!, 1e-12)
+        assertEquals(30.0, result.atl!!, 1e-12)
+    }
+}


### PR DESCRIPTION
## What

A pure, deterministic long-horizon **fitness-fatigue training-load** model, mirrored Swift/Kotlin, alongside the existing ACWR + Foster monotony in `ReadinessEngine`:

- **CTL** chronic (42d) load / fitness proxy · **ATL** acute (7d) load / fatigue proxy · **TSB = CTL − ATL** (form)
- EWMA: `alpha = 1 − exp(−1/tau)`, `state[t] = state[t-1] + alpha·(load[t] − state[t-1])`

## Deliberately outside the Readiness score

`ReadinessEngine.evaluateWithTrainingLoad(...)` returns the **existing Readiness result unchanged** (tests assert equality) plus a descriptive `TrainingLoadEngine.Result`. A negative TSB is *not* a recovery penalty — it stays a contextual trend for charts/explanations, so ACWR/monotony ownership is untouched. Any future decision to feed training-load into a score is left as an explicit, separately-validated change.

## Model details

- Seeds both states from the **mean of the first 7 observed days** (avoids the zero-seed early-low bias); CTL/ATL stay in the input load units — NOOP supplies daily Effort/strain, **not** relabelled as TRIMP.
- Explicit calendar semantics: `load == 0` is an observed rest day and stays in the model; `load == null` or a **missing calendar day** breaks the contiguous suffix (never invents zero, never compresses time). `<14` contiguous days ⇒ `unavailable`, `14–41` ⇒ `building`, `42+` ⇒ `established`. Malformed/duplicate/negative/non-finite/bad-config all **fail closed** with machine-readable reasons.
- Integer-only Howard-Hinnant civil-date transform so the Swift/Kotlin twins can't drift around DST/locale. Golden vectors (constant load, step-up/down, boundaries, missing data, leap-day) **pinned identical on both platforms**.

## Tests / validation

- Android `testFullDebugUnitTest`: `TrainingLoadEngineTest` (10) + `ReadinessTrainingLoadTest` (5) — **15/15 green** locally; Kotlin golden values match the pinned Swift expectations.
- Swift `StrandAnalyticsTests`: same suite, validated by `swift-packages` CI (StrandAnalytics needs macOS).
- Pure package + Android analytics only — **no app-target Swift**, no schema/migration.

## Note

Engine is complete + tested but **not yet surfaced** in any screen — this is the analytics foundation; a chart/card is a natural follow-up. Idea from @jonbiro; the CTL/ATL/TSB model is standard Banister/Coggan, re-derived independently.