### PR TITLE
feat(analytics): sleep-vs-wake HR contrast (Swift + Kotlin)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepHeartRateContrast.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepHeartRateContrast.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// Descriptive primary-sleep vs wake HR contrast.
+///
+/// This is **not** another resting-heart-rate definition. NOOP already ships a floor-style RHR (the
+/// scoring input) and collects a separate primary-session mean RHR candidate (#1174/#1188, evidence in
+/// #1169); this engine leaves both untouched. It answers a different, descriptive question: how does HR
+/// during an explicitly supplied **primary-sleep** window compare with HR during an explicitly supplied
+/// **wake** window?
+///
+/// The result is wellness context only. It deliberately emits **no** dipper / non-dipper / reverse-dipper
+/// / riser label, no cardiovascular-risk category, and no diagnostic threshold — those concepts do not
+/// transfer from blood-pressure/physiology contexts to wearable HR merely because a percent difference
+/// can be computed. Window selection (primary-session detection, local-time semantics, shift schedules)
+/// is the caller's responsibility, where that context is available.
+public enum SleepHeartRateContrast {
+    public static let validMinBpm: Double = 30
+    public static let validMaxBpm: Double = 220
+    public static let defaultMinimumValidSamples: Int = 30
+
+    public struct Result: Equatable, Sendable {
+        /// Arithmetic mean across valid fixed-grid wake epochs.
+        public let wakeMeanBpm: Double
+        /// Arithmetic mean across valid fixed-grid primary-sleep epochs.
+        public let sleepMeanBpm: Double
+        /// `sleepMeanBpm - wakeMeanBpm`. Negative means HR is lower during sleep.
+        public let sleepMinusWakeBpm: Double
+        /// `100 * (wakeMeanBpm - sleepMeanBpm) / wakeMeanBpm`. Positive means lower HR during sleep.
+        public let sleepReductionPercent: Double
+
+        public let wakeValidSamples: Int
+        public let wakeTotalSamples: Int
+        public let wakeCoverage: Double
+        public let sleepValidSamples: Int
+        public let sleepTotalSamples: Int
+        public let sleepCoverage: Double
+
+        public init(wakeMeanBpm: Double, sleepMeanBpm: Double, sleepMinusWakeBpm: Double,
+                    sleepReductionPercent: Double, wakeValidSamples: Int, wakeTotalSamples: Int,
+                    wakeCoverage: Double, sleepValidSamples: Int, sleepTotalSamples: Int,
+                    sleepCoverage: Double) {
+            self.wakeMeanBpm = wakeMeanBpm
+            self.sleepMeanBpm = sleepMeanBpm
+            self.sleepMinusWakeBpm = sleepMinusWakeBpm
+            self.sleepReductionPercent = sleepReductionPercent
+            self.wakeValidSamples = wakeValidSamples
+            self.wakeTotalSamples = wakeTotalSamples
+            self.wakeCoverage = wakeCoverage
+            self.sleepValidSamples = sleepValidSamples
+            self.sleepTotalSamples = sleepTotalSamples
+            self.sleepCoverage = sleepCoverage
+        }
+    }
+
+    /// Compare fixed-grid wake and primary-sleep HR windows, or nil when either side lacks coverage.
+    ///
+    /// Each array is expected equal-duration epochs in the caller's chosen window. `nil` is an unobserved
+    /// epoch, so valid/total is a real coverage fraction rather than a sample-cadence guess. Values
+    /// outside `30...220` bpm are treated as invalid/unobserved for this metric and are never imputed —
+    /// they only lower coverage.
+    ///
+    /// The mean is unweighted across valid epochs; that equals a time-weighted mean only because the
+    /// contract requires a fixed grid. Callers with irregular raw samples should first aggregate onto a
+    /// declared cadence and retain that provenance.
+    ///
+    /// `minimumValidSamples` is parameterized and applied independently to each window. Its default
+    /// mirrors the provisional 30-valid-sample floor of NOOP's primary-session mean RHR experiment; it is
+    /// **not** claimed to be a clinically validated coverage threshold.
+    public static func evaluate(wakeHR: [Double?], primarySleepHR: [Double?],
+                                minimumValidSamples: Int = defaultMinimumValidSamples) -> Result? {
+        guard minimumValidSamples > 0, !wakeHR.isEmpty, !primarySleepHR.isEmpty else { return nil }
+
+        let wake = summarize(wakeHR)
+        let sleep = summarize(primarySleepHR)
+        guard wake.validCount >= minimumValidSamples,
+              sleep.validCount >= minimumValidSamples,
+              wake.mean > 0 else { return nil }
+
+        let delta = sleep.mean - wake.mean
+        let reduction = 100.0 * (wake.mean - sleep.mean) / wake.mean
+        guard delta.isFinite, reduction.isFinite else { return nil }
+
+        return Result(
+            wakeMeanBpm: wake.mean,
+            sleepMeanBpm: sleep.mean,
+            sleepMinusWakeBpm: delta,
+            sleepReductionPercent: reduction,
+            wakeValidSamples: wake.validCount,
+            wakeTotalSamples: wakeHR.count,
+            wakeCoverage: Double(wake.validCount) / Double(wakeHR.count),
+            sleepValidSamples: sleep.validCount,
+            sleepTotalSamples: primarySleepHR.count,
+            sleepCoverage: Double(sleep.validCount) / Double(primarySleepHR.count)
+        )
+    }
+
+    private struct Summary {
+        let mean: Double
+        let validCount: Int
+    }
+
+    private static func summarize(_ values: [Double?]) -> Summary {
+        var sum = 0.0
+        var count = 0
+        for item in values {
+            guard let value = item, value.isFinite,
+                  value >= validMinBpm, value <= validMaxBpm else { continue }
+            sum += value
+            count += 1
+        }
+        return Summary(mean: count > 0 ? sum / Double(count) : 0, validCount: count)
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepHeartRateContrastTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepHeartRateContrastTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import XCTest
+@testable import StrandAnalytics
+
+final class SleepHeartRateContrastTests: XCTestCase {
+    private func filled(_ value: Double, _ count: Int) -> [Double?] { Array(repeating: value, count: count) }
+
+    func testLowerSleepHRProducesPositiveReduction() {
+        let result = SleepHeartRateContrast.evaluate(wakeHR: filled(70, 40), primarySleepHR: filled(56, 40))
+        let r = try! XCTUnwrap(result)
+        XCTAssertEqual(r.wakeMeanBpm, 70, accuracy: 1e-12)
+        XCTAssertEqual(r.sleepMeanBpm, 56, accuracy: 1e-12)
+        XCTAssertEqual(r.sleepMinusWakeBpm, -14, accuracy: 1e-12)
+        XCTAssertEqual(r.sleepReductionPercent, 20, accuracy: 1e-12)   // 100*(70-56)/70
+        XCTAssertEqual(r.wakeCoverage, 1, accuracy: 1e-12)
+        XCTAssertEqual(r.sleepCoverage, 1, accuracy: 1e-12)
+    }
+
+    func testHigherSleepHRProducesNegativeReductionWithoutClassification() {
+        let result = SleepHeartRateContrast.evaluate(wakeHR: filled(60, 40), primarySleepHR: filled(66, 40))
+        let r = try! XCTUnwrap(result)
+        XCTAssertEqual(r.sleepMinusWakeBpm, 6, accuracy: 1e-12)
+        XCTAssertEqual(r.sleepReductionPercent, -10, accuracy: 1e-12)  // 100*(60-66)/60
+    }
+
+    func testMinimumValidSampleGateAppliesIndependentlyToBothWindows() {
+        // Wake has 30 valid, sleep only 29 -> nil (gate per-window).
+        let wake = filled(65, 30)
+        var sleep = filled(55, 29); sleep.append(nil)
+        XCTAssertNil(SleepHeartRateContrast.evaluate(wakeHR: wake, primarySleepHR: sleep))
+        // Both at 30 -> passes.
+        XCTAssertNotNil(SleepHeartRateContrast.evaluate(wakeHR: filled(65, 30), primarySleepHR: filled(55, 30)))
+    }
+
+    func testMissingAndInvalidEpochsAreExcludedAndReduceCoverage() {
+        // 40 slots: 30 valid @60, 5 nil, 5 out-of-range (10 bpm) -> 30 valid, coverage 0.75.
+        let nils: [Double?] = Array(repeating: nil, count: 5)
+        let lows: [Double?] = Array(repeating: 10.0, count: 5)
+        let wake: [Double?] = filled(60, 30) + nils + lows
+        let sleep = filled(50, 40)
+        let r = try! XCTUnwrap(SleepHeartRateContrast.evaluate(wakeHR: wake, primarySleepHR: sleep))
+        XCTAssertEqual(r.wakeValidSamples, 30)
+        XCTAssertEqual(r.wakeTotalSamples, 40)
+        XCTAssertEqual(r.wakeCoverage, 0.75, accuracy: 1e-12)
+        XCTAssertEqual(r.wakeMeanBpm, 60, accuracy: 1e-12)   // out-of-range 10s never entered the mean
+    }
+
+    func testUnequalWindowLengthsAreAllowedAndCoverageIsPerWindow() {
+        let r = try! XCTUnwrap(SleepHeartRateContrast.evaluate(wakeHR: filled(70, 60),
+                                                               primarySleepHR: filled(58, 30)))
+        XCTAssertEqual(r.wakeTotalSamples, 60)
+        XCTAssertEqual(r.sleepTotalSamples, 30)
+        XCTAssertEqual(r.wakeCoverage, 1, accuracy: 1e-12)
+        XCTAssertEqual(r.sleepCoverage, 1, accuracy: 1e-12)
+    }
+
+    func testValidityRangeEdgesAreIncluded() {
+        // 30 and 220 are inclusive; 29.9 and 220.1 are excluded.
+        let lows: [Double?] = Array(repeating: 30.0, count: 15)
+        let highs: [Double?] = Array(repeating: 220.0, count: 15)
+        let edges: [Double?] = [29.9, 220.1]
+        let wake: [Double?] = lows + highs + edges
+        let r = try! XCTUnwrap(SleepHeartRateContrast.evaluate(wakeHR: wake, primarySleepHR: filled(60, 30)))
+        XCTAssertEqual(r.wakeValidSamples, 30)                 // the two out-of-range edges excluded
+        XCTAssertEqual(r.wakeMeanBpm, 125, accuracy: 1e-12)    // (30*15 + 220*15)/30
+    }
+
+    func testEmptyAndInvalidConfigurationFailClosed() {
+        XCTAssertNil(SleepHeartRateContrast.evaluate(wakeHR: [], primarySleepHR: filled(60, 30)))
+        XCTAssertNil(SleepHeartRateContrast.evaluate(wakeHR: filled(60, 30), primarySleepHR: []))
+        XCTAssertNil(SleepHeartRateContrast.evaluate(wakeHR: filled(60, 30), primarySleepHR: filled(60, 30),
+                                                     minimumValidSamples: 0))
+        XCTAssertNil(SleepHeartRateContrast.evaluate(wakeHR: filled(.nan, 40), primarySleepHR: filled(60, 40)))
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/SleepHeartRateContrast.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepHeartRateContrast.kt
@@ -1,0 +1,94 @@
+package com.noop.analytics
+
+/**
+ * Descriptive primary-sleep vs wake HR contrast. Behavioral twin of Swift `SleepHeartRateContrast`.
+ *
+ * This is NOT another resting-heart-rate definition. NOOP already ships a floor-style RHR (the scoring
+ * input) and collects a separate primary-session mean RHR candidate (#1174/#1188, evidence in #1169);
+ * this engine leaves both untouched. It compares explicitly supplied fixed-grid wake and primary-sleep
+ * HR windows and reports how the means differ.
+ *
+ * Descriptive wellness context only. No dipper / non-dipper / reverse-dipper / riser label, no
+ * cardiovascular-risk category, and no diagnostic threshold is produced — those concepts do not transfer
+ * from blood-pressure/physiology contexts to wearable HR merely because a percent difference exists.
+ * Window selection is the caller's responsibility, where primary-session detection and local-time
+ * semantics are available.
+ */
+object SleepHeartRateContrast {
+    const val VALID_MIN_BPM: Double = 30.0
+    const val VALID_MAX_BPM: Double = 220.0
+    const val DEFAULT_MINIMUM_VALID_SAMPLES: Int = 30
+
+    data class Result(
+        val wakeMeanBpm: Double,
+        val sleepMeanBpm: Double,
+        /** sleep - wake; negative means lower HR during sleep. */
+        val sleepMinusWakeBpm: Double,
+        /** 100 * (wake - sleep) / wake. Positive means lower HR during sleep. */
+        val sleepReductionPercent: Double,
+        val wakeValidSamples: Int,
+        val wakeTotalSamples: Int,
+        val wakeCoverage: Double,
+        val sleepValidSamples: Int,
+        val sleepTotalSamples: Int,
+        val sleepCoverage: Double,
+    )
+
+    /**
+     * Compare fixed-grid wake and primary-sleep HR windows, or null when either side lacks coverage.
+     *
+     * Each list is expected equal-duration epochs. null is an unobserved epoch, so valid/total is a real
+     * coverage fraction rather than a sample-cadence guess. Values outside 30..220 bpm are ignored and
+     * never imputed — they only lower coverage. Means are unweighted across valid epochs; callers with
+     * irregular raw samples should first aggregate to a declared fixed cadence.
+     *
+     * `minimumValidSamples` is applied independently to each window; its default mirrors the provisional
+     * 30-valid-sample floor of NOOP's primary-session mean RHR experiment and is not a clinical threshold.
+     */
+    fun evaluate(
+        wakeHR: List<Double?>,
+        primarySleepHR: List<Double?>,
+        minimumValidSamples: Int = DEFAULT_MINIMUM_VALID_SAMPLES,
+    ): Result? {
+        if (minimumValidSamples <= 0 || wakeHR.isEmpty() || primarySleepHR.isEmpty()) return null
+
+        val wake = summarize(wakeHR)
+        val sleep = summarize(primarySleepHR)
+        if (wake.validCount < minimumValidSamples ||
+            sleep.validCount < minimumValidSamples ||
+            wake.mean <= 0.0
+        ) {
+            return null
+        }
+
+        val delta = sleep.mean - wake.mean
+        val reduction = 100.0 * (wake.mean - sleep.mean) / wake.mean
+        if (!delta.isFinite() || !reduction.isFinite()) return null
+
+        return Result(
+            wakeMeanBpm = wake.mean,
+            sleepMeanBpm = sleep.mean,
+            sleepMinusWakeBpm = delta,
+            sleepReductionPercent = reduction,
+            wakeValidSamples = wake.validCount,
+            wakeTotalSamples = wakeHR.size,
+            wakeCoverage = wake.validCount.toDouble() / wakeHR.size.toDouble(),
+            sleepValidSamples = sleep.validCount,
+            sleepTotalSamples = primarySleepHR.size,
+            sleepCoverage = sleep.validCount.toDouble() / primarySleepHR.size.toDouble(),
+        )
+    }
+
+    private data class Summary(val mean: Double, val validCount: Int)
+
+    private fun summarize(values: List<Double?>): Summary {
+        var sum = 0.0
+        var count = 0
+        for (item in values) {
+            if (item == null || !item.isFinite() || item < VALID_MIN_BPM || item > VALID_MAX_BPM) continue
+            sum += item
+            count++
+        }
+        return Summary(if (count > 0) sum / count.toDouble() else 0.0, count)
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/SleepHeartRateContrastTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepHeartRateContrastTest.kt
@@ -1,0 +1,71 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SleepHeartRateContrastTest {
+    private fun filled(value: Double, count: Int): List<Double?> = List(count) { value }
+
+    @Test
+    fun lowerSleepHRProducesPositiveReduction() {
+        val r = SleepHeartRateContrast.evaluate(filled(70.0, 40), filled(56.0, 40))!!
+        assertEquals(70.0, r.wakeMeanBpm, 1e-12)
+        assertEquals(56.0, r.sleepMeanBpm, 1e-12)
+        assertEquals(-14.0, r.sleepMinusWakeBpm, 1e-12)
+        assertEquals(20.0, r.sleepReductionPercent, 1e-12)   // 100*(70-56)/70
+        assertEquals(1.0, r.wakeCoverage, 1e-12)
+        assertEquals(1.0, r.sleepCoverage, 1e-12)
+    }
+
+    @Test
+    fun higherSleepHRProducesNegativeReductionWithoutClassification() {
+        val r = SleepHeartRateContrast.evaluate(filled(60.0, 40), filled(66.0, 40))!!
+        assertEquals(6.0, r.sleepMinusWakeBpm, 1e-12)
+        assertEquals(-10.0, r.sleepReductionPercent, 1e-12)  // 100*(60-66)/60
+    }
+
+    @Test
+    fun minimumValidSampleGateAppliesIndependentlyToBothWindows() {
+        val wake = filled(65.0, 30)
+        val sleep = filled(55.0, 29) + listOf<Double?>(null)
+        assertNull(SleepHeartRateContrast.evaluate(wake, sleep))
+        assertNotNull(SleepHeartRateContrast.evaluate(filled(65.0, 30), filled(55.0, 30)))
+    }
+
+    @Test
+    fun missingAndInvalidEpochsAreExcludedAndReduceCoverage() {
+        val wake = filled(60.0, 30) + List(5) { null } + List(5) { 10.0 }
+        val r = SleepHeartRateContrast.evaluate(wake, filled(50.0, 40))!!
+        assertEquals(30, r.wakeValidSamples)
+        assertEquals(40, r.wakeTotalSamples)
+        assertEquals(0.75, r.wakeCoverage, 1e-12)
+        assertEquals(60.0, r.wakeMeanBpm, 1e-12)             // out-of-range 10s never entered the mean
+    }
+
+    @Test
+    fun unequalWindowLengthsAreAllowedAndCoverageIsPerWindow() {
+        val r = SleepHeartRateContrast.evaluate(filled(70.0, 60), filled(58.0, 30))!!
+        assertEquals(60, r.wakeTotalSamples)
+        assertEquals(30, r.sleepTotalSamples)
+        assertEquals(1.0, r.wakeCoverage, 1e-12)
+        assertEquals(1.0, r.sleepCoverage, 1e-12)
+    }
+
+    @Test
+    fun validityRangeEdgesAreIncluded() {
+        val wake = List(15) { 30.0 } + List(15) { 220.0 } + listOf<Double?>(29.9, 220.1)
+        val r = SleepHeartRateContrast.evaluate(wake, filled(60.0, 30))!!
+        assertEquals(30, r.wakeValidSamples)                 // the two out-of-range edges excluded
+        assertEquals(125.0, r.wakeMeanBpm, 1e-12)            // (30*15 + 220*15)/30
+    }
+
+    @Test
+    fun emptyAndInvalidConfigurationFailClosed() {
+        assertNull(SleepHeartRateContrast.evaluate(emptyList(), filled(60.0, 30)))
+        assertNull(SleepHeartRateContrast.evaluate(filled(60.0, 30), emptyList()))
+        assertNull(SleepHeartRateContrast.evaluate(filled(60.0, 30), filled(60.0, 30), minimumValidSamples = 0))
+        assertNull(SleepHeartRateContrast.evaluate(filled(Double.NaN, 40), filled(60.0, 40)))
+    }
+}

--- a/docs/sleep-heart-rate-contrast.md
+++ b/docs/sleep-heart-rate-contrast.md
@@ -1,0 +1,53 @@
+# Sleep vs wake heart-rate contrast
+
+`SleepHeartRateContrast` (StrandAnalytics + `com.noop.analytics` twin) is a small, descriptive engine
+that compares mean HR during an explicitly supplied **primary-sleep** window against mean HR during an
+explicitly supplied **wake** window. It is wellness context, not a clinical measure.
+
+## What it is not
+
+- **Not a resting-heart-rate definition.** NOOP already ships a floor-style RHR (the scoring input) and
+  collects a separate primary-session mean RHR candidate (#1174/#1188; evidence in #1169, which also
+  records that a lowest-30-minute candidate performed *worse* than the primary-session mean). This engine
+  adds no third RHR and changes neither of the existing ones.
+- **Not a dipping classifier.** It emits no dipper / non-dipper / reverse-dipper / riser label, no
+  cardiovascular-risk category, and no diagnostic threshold. Those concepts do not transfer from
+  blood-pressure/physiology contexts to wearable HR just because a percent difference can be computed.
+- **"Sleep vs wake", not "night vs day".** It does not assume everyone sleeps at night; the caller owns
+  window selection, where primary-session detection, local-time semantics and shift schedules live.
+
+## Input contract
+
+Both inputs are fixed-cadence epoch arrays (`[Double?]` / `List<Double?>`), one element per expected
+equal-duration epoch:
+
+| element | meaning |
+|---|---|
+| valid bpm (`30…220`) | observed HR for that epoch |
+| `nil` / `null` | unobserved epoch |
+| out-of-range bpm | invalid for this metric (treated as unobserved) |
+
+Missing/invalid epochs are **never imputed** — they only lower coverage. The mean is an unweighted
+arithmetic mean over valid epochs, which equals a time-weighted mean only because the grid is fixed;
+irregular raw streams should be aggregated onto a declared cadence first.
+
+## Output
+
+For wake mean `W` and primary-sleep mean `S`:
+
+- `sleepMinusWakeBpm = S − W` (negative ⇒ lower HR during sleep)
+- `sleepReductionPercent = 100 · (W − S) / W` (positive ⇒ lower HR during sleep)
+- per-window `validSamples`, `totalSamples`, `coverage`
+
+## Gating
+
+`minimumValidSamples` (default 30) is applied **independently to each window**; `evaluate` returns nil
+unless both sides clear it. The default mirrors the provisional 30-valid-sample floor of the
+primary-session mean RHR experiment and is **not** a clinically validated coverage threshold — a future
+product surface should weigh cadence, represented duration, and coverage before showing a result.
+
+## Status
+
+Pure engine with cross-platform parity tests. No consumer wires it in yet: something must build the
+fixed-grid wake and primary-sleep HR windows before a result can be shown. That window-construction is
+deliberately out of scope here.


### PR DESCRIPTION
## What

A pure, deterministic engine — mirrored Swift/Kotlin — that compares mean HR over an explicitly supplied **primary-sleep** window against mean HR over an explicitly supplied **wake** window. Reports `sleepMinusWakeBpm`, `sleepReductionPercent = 100·(W−S)/W`, and per-window valid/total/coverage.

## Deliberately not a new RHR, not a dipping classifier

- **No third RHR definition.** The shipped floor RHR (scoring input) and the primary-session mean candidate (#1174/#1188, evidence in #1169 — which also found a lowest-30-min candidate performed *worse*) are untouched.
- **No dipper / non-dipper / reverse-dipper / riser label, no risk category, no diagnostic threshold** — descriptive wellness context only, matching NOOP's non-diagnostic boundary. Says *sleep vs wake*, not *night vs day*; window selection is the caller's responsibility.

## Contract

Fixed-grid epoch arrays: `nil` = unobserved, out-of-`[30,220]`-bpm = invalid; missing/invalid epochs are **never imputed** and only lower coverage. Unweighted mean over valid epochs (a time-weighted mean only because the grid is fixed). The 30-valid-sample gate is parameterized (default mirrors the primary-session RHR experiment) and applied **independently to each window**; `evaluate` returns nil unless both sides clear it.

## Tests / validation

- Android `testFullDebugUnitTest`: `SleepHeartRateContrastTest` **7/7 green** locally (both reduction signs, independent gating, coverage math, range-edge inclusivity, fail-closed).
- Swift `StrandAnalyticsTests`: same suite, validated by `swift-packages` CI (StrandAnalytics needs macOS).
- Pure package + Android analytics only — **no app-target Swift**, no schema/migration.

## Status

Complete + tested but **not yet surfaced** — nothing builds the fixed-grid wake/primary-sleep HR windows yet; that window-construction is deliberately out of scope. Idea from @jonbiro.