### PR TITLE
fix(ble): pair WHOOP4 clock correlation with its capture wall, not now

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2542,6 +2542,11 @@ class WhoopBleClient(
     /** Newest unix the strap reports having (from GET_DATA_RANGE); refreshed each connect. */
     @Volatile
     private var strapNewestTs: Long? = null
+    /** Wall-clock (unix s) captured at the SAME instant [strapNewestTs] was read from a GET_DATA_RANGE
+     *  reply. The backfiller clock correlation must pair the strap's device time with the wall time of
+     *  that same reading — pairing it with a later `now` inflates the offset by all the elapsed wall time
+     *  since the fetch (WHOOP4 doesn't re-fetch the range at each offload). */
+    private var strapNewestTsWall: Long? = null
 
     // --- Live-persistence buffer (port of Swift Collector: custom realtime/event/battery frames) ---
 
@@ -5372,6 +5377,9 @@ class WhoopBleClient(
                         }
                         dataRangeNewestUnix(frame)?.let {
                             strapNewestTs = it
+                            // Capture the wall clock of THIS reading so the backfiller correlation pairs
+                            // the strap's device time with the wall time of the same instant (see field doc).
+                            strapNewestTsWall = System.currentTimeMillis() / 1000L
                             // #34: persist the strap's newest banked record so the debug export can flag a reset clock.
                             runCatching { NoopPrefs.of(context).edit().putLong("strap.newestRecordTs", it).apply() }
                             // #928: flag an implausibly FUTURE "newest" (strap clock set ahead) right where
@@ -6999,7 +7007,12 @@ class WhoopBleClient(
         // mis-date nights when the strap's RTC has drifted. No-op when strapNewestTs is null (no Data
         // Range received yet) — the Backfiller keeps its identity default, same as today.
         strapNewestTs?.let { newest ->
-            val wall = (System.currentTimeMillis() / 1000L).toInt()
+            // Pair the strap's newest-record device time with the wall clock CAPTURED WHEN IT WAS READ,
+            // not `now`. WHOOP4 doesn't re-fetch the Data Range at each offload, so `now` inflated the
+            // offset by all the elapsed wall time since the last fetch (observed 46s → ~3700s over 30 min).
+            // Pairing with the capture wall keeps the offset at the strap's true RTC skew regardless of how
+            // stale [strapNewestTs] is. Fallback to now only if we somehow have the ts without its wall.
+            val wall = (strapNewestTsWall ?: (System.currentTimeMillis() / 1000L)).toInt()
             backfiller.clockRef = ClockRef(device = newest.toInt(), wall = wall)
             log("Clock: seeded backfiller correlation from Data Range (device=$newest wall=$wall, offset ${wall - newest}s)")
         }
@@ -7985,6 +7998,7 @@ class WhoopBleClient(
         backfilling = false
         backfillDrain.reset()
         strapNewestTs = null
+        strapNewestTsWall = null
         offloadFramesThisSession = 0
         lastOffloadFrameAtMs = 0L   // #174: don't carry a stale cooldown reference into the next session
         historicalKickSent = false


### PR DESCRIPTION
## The bug (found tracing a v10.1.1-staging strap log)

The Android backfiller clock correlation is re-seeded on **every offload** from `(strapNewestTs, now)`. WHOOP4 doesn't re-fetch `GET_DATA_RANGE` at each offload (only WHOOP5 does), so `strapNewestTs` stays frozen between fetches while `now` advances — **inflating the offset by all the elapsed wall time since the last fetch**. Straight from the log:

```
13:49:33  device=1787017727  offset 46s      ← true RTC skew, right after GET_DATA_RANGE
14:20:01  device=1787017727  offset 1874s    ← device frozen, offset grew with wall time
14:49:09  device=1787017727  offset 3622s
14:50:18  device=1787017727  offset 3691s     ← ~1h of pure staleness
```

The offset should be the strap's constant RTC skew (~46s), not a number that climbs with elapsed time.

## The fix

Capture the wall clock at the **same instant** `strapNewestTs` is read from the `GET_DATA_RANGE` reply, and pair *that* with the device time when seeding the correlation — instead of a later `now`. The offset then reflects the true skew regardless of how stale `strapNewestTs` is. No extra BLE round-trip.

## Scope (deliberately narrow)

- **Stored offload data is unaffected** — type-47 historical records carry their own unix timestamp, so the correlation offset is a no-op for them. This is **not** the cause of the offload stalls (those are benign strap-side chunking + idle-cap, handled by auto-continue #364/#451).
- What it *does* fix: the `REALTIME_RAW_DATA` fallback stamping, and — concretely — the **strap-log diagnostics** the inflated offset was making unreadable (it read as a ~1h clock skew that isn't real).
- **Android-only:** Swift reads the real clock via `GET_CLOCK` and derives its `strapNewestTs` fallback **once** (sticky), so it has no per-offload re-seed inflation. No parity change.

## Validation

Compiles clean (`compileFullDebugKotlin`). BLE path → hardware-confirmed by a strap log showing the offset holding at the true ~46s skew across an offload burst (per CLAUDE.md's BLE-validation rule; no CI/unit coverage for the CoreBluetooth path).