### PR TITLE
fix(settings): waist row label vanished behind ~300dp of dead space (+ copy parity)

### DIFF
--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -558,10 +558,6 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
-      "Optional · VO₂max builds from ~4 nights of heart rate; a waist makes it more accurate"
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
       "Put the strap on first. The deep stream is on-wrist only."
     ],
     [
@@ -625,10 +621,6 @@
       "Wear the strap, tap once, then let it sync and share your strap log."
     ],
     [
-      "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
-      "Your VO₂max uses your waist for a more accurate estimate"
-    ],
-    [
       "android/app/src/main/java/com/noop/ui/SkinTempCardsScreen.kt",
       "Plan a trip or shift"
     ],
@@ -647,14 +639,6 @@
     [
       "android/app/src/main/java/com/noop/ui/SleepScreen.kt",
       "Raw on-device stages"
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/SleepScreen.kt",
-      "Removes this recorded sleep and recomputes the day without it. NOOP won't re-detect sleep in this window. You can undo for a few seconds after."
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/SleepScreen.kt",
-      "Removes this sleep and recomputes the day without it. You can undo for a few seconds after."
     ],
     [
       "android/app/src/main/java/com/noop/ui/SleepScreen.kt",

--- a/android/app/src/main/java/com/noop/ui/SettingsComponents.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsComponents.kt
@@ -165,7 +165,17 @@ internal fun SettingsToggleRow(
 
 // MARK: - Two-column form row (ports SettingsView's private FormRow)
 
-/** Label on the left, control on the right — the two-column form feel. */
+/**
+ * Label on the left, control on the right — the two-column form feel.
+ *
+ * KEEP THE CONTROL NARROW. Only the label is weighted, so Compose measures [control] FIRST against the
+ * full row width and the label gets whatever is left. A control that wants the whole width (e.g. a
+ * full-sentence helper text stacked under a stepper) starves the label to ~0 width, where it wraps one
+ * character per line — rendering blank while inflating the row into a screen of dead space. Put
+ * sentence-length copy in a sibling `Text` BELOW the row instead (see the Step-calibration and Waist
+ * rows in SettingsScreen); a SHORT right-aligned sub-value under the control (e.g. "Auto · 173 bpm") is
+ * fine.
+ */
 @Composable
 internal fun SettingsFormRow(label: String, control: @Composable () -> Unit) {
     Row(

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -951,9 +951,13 @@ fun SettingsScreen(
                 // estimate. Unset (0) by design — the headline Fitness Age never needs it — so it shows
                 // "Add" until entered, then steps like Height (inches in imperial, cm in metric).
                 // First tap from unset seeds a typical adult waist rather than 1 cm.
+                // The footnote sits BELOW the row (like Step calibration), never inside the control
+                // column: SettingsFormRow weights the LABEL and measures the control first, so a
+                // full-width helper text in the control starves the label to ~0 width — it then wrapped
+                // one character per line, rendering blank while inflating the row to ~300dp of dead space.
+                val hasWaist = profile.waistCm > 0.0
                 SettingsFormRow(label = uiString(R.string.l10n_settings_screen_waist_optional_d5356703)) {
                     Column(horizontalAlignment = Alignment.End) {
-                        val hasWaist = profile.waistCm > 0.0
                         if (unitSystem == UnitSystem.IMPERIAL) {
                             val totalInches = UnitFormatter.cmToInches(profile.waistCm).roundToInt()
                             StepperField(
@@ -961,7 +965,10 @@ fun SettingsScreen(
                                 accessibility = if (hasWaist) {
                                     "Waist, $totalInches inches"
                                 } else {
-                                    "Waist, not set. Optional: adds your VO₂max estimate"
+                                    // #1391: a waist does NOT unlock VO₂max (the Uth HR-ratio fallback
+                                    // needs none) — it upgrades it. The visible footnote was corrected
+                                    // for this; this screen-reader copy had been left behind.
+                                    "Waist, not set. Optional: your VO₂max is more accurate with it"
                                 },
                                 valueColor = if (hasWaist) Palette.textPrimary else Palette.textTertiary,
                                 onMinus = { mutate { profile.waistCm = waistInchesStep(profile.waistCm, up = false) } },
@@ -974,25 +981,32 @@ fun SettingsScreen(
                                 accessibility = if (hasWaist) {
                                     "Waist in centimetres"
                                 } else {
-                                    "Waist, not set. Optional: adds your VO₂max estimate"
+                                    // #1391: a waist does NOT unlock VO₂max (the Uth HR-ratio fallback
+                                    // needs none) — it upgrades it. The visible footnote was corrected
+                                    // for this; this screen-reader copy had been left behind.
+                                    "Waist, not set. Optional: your VO₂max is more accurate with it"
                                 },
                                 valueColor = if (hasWaist) Palette.textPrimary else Palette.textTertiary,
                                 onMinus = { mutate { profile.waistCm = waistCmStep(profile.waistCm, up = false) } },
                                 onPlus = { mutate { profile.waistCm = waistCmStep(profile.waistCm, up = true) } },
                             )
                         }
-                        Spacer(Modifier.height(6.dp))
-                        Text(
-                            // #1391: VO₂max is offered from heart rate alone (Uth HR-ratio) even without a
-                            // waist; a waist switches it to the more accurate body-composition estimate. So the
-                            // sub-text now says what's used + how a waist helps, not "adds/unlocks".
-                            text = if (hasWaist) "Your VO₂max uses your waist for a more accurate estimate"
-                                   else "Optional · VO₂max builds from ~4 nights of heart rate; a waist makes it more accurate",
-                            style = NoopType.footnote,
-                            color = if (hasWaist) Palette.accent else Palette.textTertiary,
-                        )
                     }
                 }
+                Text(
+                    // #1391: VO₂max is offered from heart rate alone (Uth HR-ratio) even without a
+                    // waist; a waist switches it to the more accurate body-composition estimate. So the
+                    // sub-text says what's used + how a waist helps, not "adds/unlocks". The unset copy
+                    // now also carries the Apple twin's two missing beats: the Fitness Age doesn't need a
+                    // waist, and WHERE to measure.
+                    text = if (hasWaist) {
+                        uiString(R.string.settings_waist_footnote_set)
+                    } else {
+                        uiString(R.string.settings_waist_footnote_unset)
+                    },
+                    style = NoopType.footnote,
+                    color = if (hasWaist) Palette.accent else Palette.textTertiary,
+                )
                 SettingsRowDivider()
                 SettingsFormRow(label = uiString(R.string.l10n_settings_screen_max_heart_rate_3d4ed858)) {
                     Column(horizontalAlignment = Alignment.End) {

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2141,4 +2141,6 @@
     <string name="trends_tl_form">Tagesform</string>
     <string name="sleep_delete_user_edited_body">Entfernt diesen Schlaf und berechnet den Tag ohne ihn neu. Du kannst dies für ein paar Sekunden rückgängig machen.</string>
     <string name="sleep_delete_recorded_body">Entfernt diesen aufgezeichneten Schlaf und berechnet den Tag ohne ihn neu. NOOP erkennt in diesem Zeitfenster keinen Schlaf mehr. Du kannst dies für ein paar Sekunden rückgängig machen.</string>
+    <string name="settings_waist_footnote_unset">Optional · VO₂max entsteht aus ~4 Nächten Herzfrequenz; ein Taillenumfang macht ihn genauer. Das Fitness-Alter selbst braucht ihn nicht. Miss um deine Körpermitte, auf Höhe des Bauchnabels.</string>
+    <string name="settings_waist_footnote_set">Dein VO₂max nutzt deinen Taillenumfang für eine genauere Schätzung</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2127,4 +2127,6 @@
     <string name="trends_tl_form">Forma</string>
     <string name="sleep_delete_user_edited_body">Elimina este sueño y recalcula el día sin él. Puedes deshacerlo durante unos segundos.</string>
     <string name="sleep_delete_recorded_body">Elimina este sueño registrado y recalcula el día sin él. NOOP no volverá a detectar sueño en esta ventana. Puedes deshacerlo durante unos segundos.</string>
+    <string name="settings_waist_footnote_unset">Opcional · El VO₂max se construye a partir de ~4 noches de frecuencia cardíaca; la cintura lo hace más preciso. La Edad de forma física no la necesita. Mide alrededor de tu cintura, a la altura del ombligo.</string>
+    <string name="settings_waist_footnote_set">Tu VO₂max usa tu cintura para una estimación más precisa</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2126,4 +2126,6 @@
     <string name="trends_tl_form">Forme</string>
     <string name="sleep_delete_user_edited_body">Supprime ce sommeil et recalcule la journée sans lui. Vous pouvez annuler pendant quelques secondes.</string>
     <string name="sleep_delete_recorded_body">Supprime ce sommeil enregistré et recalcule la journée sans lui. NOOP ne redétectera pas de sommeil dans cette fenêtre. Vous pouvez annuler pendant quelques secondes.</string>
+    <string name="settings_waist_footnote_unset">Facultatif · La VO₂max se construit à partir d’environ 4 nuits de fréquence cardiaque ; le tour de taille la rend plus précise. L’Âge de forme n’en a pas besoin. Mesurez autour de votre taille, au niveau du nombril.</string>
+    <string name="settings_waist_footnote_set">Votre VO₂max utilise votre tour de taille pour une estimation plus précise</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2120,4 +2120,6 @@
     <string name="trends_tl_form">Forma</string>
     <string name="sleep_delete_user_edited_body">Usuwa ten sen i przelicza dzień bez niego. Możesz cofnąć przez kilka sekund.</string>
     <string name="sleep_delete_recorded_body">Usuwa ten zarejestrowany sen i przelicza dzień bez niego. NOOP nie wykryje ponownie snu w tym oknie. Możesz cofnąć przez kilka sekund.</string>
+    <string name="settings_waist_footnote_unset">Opcjonalnie · VO₂max powstaje z ~4 nocy pomiaru tętna; obwód talii zwiększa dokładność. Wiek sprawnościowy go nie potrzebuje. Zmierz w pasie, na wysokości pępka.</string>
+    <string name="settings_waist_footnote_set">Twój VO₂max korzysta z obwodu talii, aby oszacowanie było dokładniejsze</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2120,4 +2120,6 @@
     <string name="trends_tl_form">Forma</string>
     <string name="sleep_delete_user_edited_body">Remove este sono e recalcula o dia sem ele. Podes anular durante alguns segundos.</string>
     <string name="sleep_delete_recorded_body">Remove este sono registado e recalcula o dia sem ele. O NOOP não vai voltar a detetar sono nesta janela. Podes anular durante alguns segundos.</string>
+    <string name="settings_waist_footnote_unset">Opcional · O VO₂max é construído a partir de ~4 noites de frequência cardíaca; a cintura torna-o mais preciso. A Idade de forma física não precisa dela. Mede à volta da tua cintura, à altura do umbigo.</string>
+    <string name="settings_waist_footnote_set">O teu VO₂max usa a tua cintura para uma estimativa mais precisa</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2046,4 +2046,6 @@
     <string name="l10n_breathe_screen_calm_me_a1b2c3d4">让我平静</string>
     <string name="sleep_delete_user_edited_body">移除此次睡眠并重新计算当天数据。之后几秒内可以撤销。</string>
     <string name="sleep_delete_recorded_body">移除此次已记录的睡眠并重新计算当天数据。NOOP 不会在此时间段内重新检测睡眠。之后几秒内可以撤销。</string>
+    <string name="settings_waist_footnote_unset">可选 · VO₂max 由约 4 晚的心率数据构建；腰围可让它更准确。健康年龄本身并不需要它。请在肚脐高度绕腰一周测量。</string>
+    <string name="settings_waist_footnote_set">你的 VO₂max 使用腰围来获得更准确的估算</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2153,4 +2153,6 @@
     <string name="trends_tl_form">Form</string>
     <string name="sleep_delete_user_edited_body">Removes this sleep and recomputes the day without it. You can undo for a few seconds after.</string>
     <string name="sleep_delete_recorded_body">Removes this recorded sleep and recomputes the day without it. NOOP won\'t re-detect sleep in this window. You can undo for a few seconds after.</string>
+    <string name="settings_waist_footnote_unset">Optional · VO₂max builds from ~4 nights of heart rate; a waist makes it more accurate. The Fitness Age itself doesn’t need it. Measure around your middle, at the navel.</string>
+    <string name="settings_waist_footnote_set">Your VO₂max uses your waist for a more accurate estimate</string>
 </resources>


### PR DESCRIPTION
## The bug

On Android Profile settings, the **Waist (optional)** row rendered with **no label** and a screen-tall block of empty space between *Height* and the stepper — "Add − +" floated alone at the bottom of the gap.

## Cause

The row stacked its full-sentence VO₂max footnote **inside the row's control column**. `SettingsFormRow` weights only the label:

```kotlin
Text(label, modifier = Modifier.weight(1f))   // gets whatever is LEFT
control()                                      // unweighted → measured FIRST, greedily
```

The sentence-length helper consumed essentially the whole width, starving the label to ~0 width. At that width `"Waist (optional)"` wrapped **one character per line** — clipped invisible, while those line counts inflated the row height into the dead space.

## Fix

Footnote moves to a sibling `Text` **below** the row — matching the neighbouring **Step calibration** row and the **iOS twin**, whose `FormRow(label: "Waist (optional)")` already holds only the stepper with the footnote below.

Apple gives its control `.layoutPriority(1)` — the **same control-first precedence** — so "keep the control narrow" is a genuine cross-platform invariant. It is now documented on `SettingsFormRow` so a future caller cannot reintroduce this.

## Copy parity (found in re-review, same row)

- **Stale a11y claim (correctness):** the screen-reader string still said a waist *"adds your VO₂max estimate"* — the pre-#1391 gate. VO₂max is **always** offered (Uth HR-ratio needs no waist); a waist *upgrades* it. The visible footnote was corrected for #1391 but this string was left behind, so blind users got the outdated claim.
- **Missing guidance:** the unset footnote lacked the Apple twin's two beats — that the **Fitness Age itself doesn't need** a waist, and **where to measure** it.

Both footnotes now route through `strings.xml` with **de/es/fr/pl/pt-PT/zh**, which also takes them **out of the hardcoded-literal backlog** — the i18n baseline ratchets **243 → 239** (pure deletions, nothing grandfathered).

## Audit

Every `SettingsFormRow` call site checked: **Max heart rate** is the only other row with a `Text` in its control, and it is a short sub-value that renders correctly. No other row affected. Recomposition verified too — `hasWaist` is hoisted out of the row lambda, but the `rev` counter is read in the enclosing scaffold scope, so profile writes still recompose it live.

## Validation

`compileFullDebugKotlin` ✓ · `processFullDebugResources` (aapt) ✓ · `Tools/i18n_audit.py --ci origin/main` ✓. Android-only, no Swift. Layout + copy only — no values or behaviour changed. The visual result wants a quick look on the next build.
