### PR TITLE
Add automatic Apple Health write-back

### DIFF
--- a/Strand/Data/HealthWritebackSchedulePolicy.swift
+++ b/Strand/Data/HealthWritebackSchedulePolicy.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Pure scheduling policy for iOS's best-effort Apple Health write-back refresh.
+///
+/// The BackgroundTasks framework decides the actual delivery time; this interval is only the earliest
+/// time at which NOOP asks to be considered again. Keeping the policy framework-free makes the cadence
+/// and authorization gate testable in the macOS-hosted app test target.
+enum HealthWritebackSchedulePolicy {
+    static let refreshInterval: TimeInterval = 60 * 60
+
+    static func shouldSchedule(isAuthorized: Bool) -> Bool {
+        isAuthorized
+    }
+
+    static func earliestBeginDate(after date: Date) -> Date {
+        date.addingTimeInterval(refreshInterval)
+    }
+}

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -50415,60 +50415,60 @@
         }
       }
     },
-    "Connected. Reading on launch and when you return to NOOP.": {
+    "Connected. New strap data is written automatically, with periodic background refresh when iOS allows it.": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verbunden. Wird beim Start gelesen und wenn du zu NOOP zurückkehrst."
+            "value": "Verbunden. Neue Strap-Daten werden automatisch geschrieben, mit regelmäßiger Aktualisierung im Hintergrund, wenn iOS es zulässt."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Conectada. Se lee al abrir y cuando vuelves a NOOP."
+            "value": "Conectada. Los datos nuevos de la pulsera se escriben automáticamente, con actualización periódica en segundo plano cuando iOS lo permite."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Connecté. Lecture au lancement et lorsque vous revenez sur NOOP."
+            "value": "Connecté. Les nouvelles données du bracelet sont écrites automatiquement, avec une actualisation périodique en arrière-plan lorsque iOS l'autorise."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Collegata. Lettura all'avvio e quando torni in NOOP."
-          }
-        },
-        "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ligado. Leitura no lançamento e quando regressa ao NOOP."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Подключено. Чтение при запуске и при возврате в NOOP."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已连接。在启动时以及你返回 NOOP 时读取。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已連接。在啟動時以及你返回 NOOP 時讀取。"
+            "value": "Collegata. I nuovi dati della fascia vengono scritti automaticamente, con aggiornamento periodico in background quando iOS lo consente."
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Połączony. Odczyt przy uruchomieniu i po powrocie do NOOP."
+            "value": "Połączono. Nowe dane z paska są zapisywane automatycznie, z okresowym odświeżaniem w tle, gdy iOS na to pozwoli."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ligado. Os novos dados da bracelete são escritos automaticamente, com atualização periódica em segundo plano quando o iOS o permitir."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключено. Новые данные браслета записываются автоматически, с периодическим фоновым обновлением, когда iOS это позволяет."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已连接。新的手环数据会自动写入，并在 iOS 允许时定期在后台刷新。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已連線。新的手環資料會自動寫入，並在 iOS 允許時定期在背景重新整理。"
           }
         }
       }

--- a/Strand/Screens/AppleHealthView.swift
+++ b/Strand/Screens/AppleHealthView.swift
@@ -446,7 +446,7 @@ struct AppleHealthView: View {
                             .font(StrandFont.subhead)
                             .foregroundStyle(StrandPalette.textSecondary)
                     } else {
-                        Text("Connected. Reading on launch and when you return to NOOP.")
+                        Text("Connected. New strap data is written automatically, with periodic background refresh when iOS allows it.")
                             .font(StrandFont.subhead)
                             .foregroundStyle(StrandPalette.textSecondary)
                     }

--- a/StrandTests/HealthWritebackSchedulePolicyTests.swift
+++ b/StrandTests/HealthWritebackSchedulePolicyTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import Strand
+
+final class HealthWritebackSchedulePolicyTests: XCTestCase {
+    func testSchedulesOnlyAfterAppleHealthAuthorization() {
+        XCTAssertTrue(HealthWritebackSchedulePolicy.shouldSchedule(isAuthorized: true))
+        XCTAssertFalse(HealthWritebackSchedulePolicy.shouldSchedule(isAuthorized: false))
+    }
+
+    func testRequestsNextRefreshOneHourAfterScheduling() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        XCTAssertEqual(
+            HealthWritebackSchedulePolicy.earliestBeginDate(after: now),
+            now.addingTimeInterval(3_600)
+        )
+    }
+}

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -74,11 +74,26 @@ struct StrandiOSApp: App {
             noopDeviceId: model.deviceId
         )
         _health = StateObject(wrappedValue: bridge)
+        // Register a separate, always-on-while-authorized refresh task for Apple Health write-back.
+        // The operation is write-only and bounded to the bridge's recent window; fresh BLE offloads still
+        // use the immediate hook below. BGTaskScheduler chooses the actual wake time.
+        HealthWritebackBackgroundScheduler.register { [weak bridge] in
+            guard let bridge else { return false }
+            let succeeded = await bridge.writeBackAfterNewData()
+            // A person can revoke every write type in Settings while NOOP is closed. Stop requesting
+            // wakes once the cold-launched bridge can no longer resume a prior share grant.
+            if bridge.auth != .authorized {
+                HealthWritebackBackgroundScheduler.cancel()
+            }
+            return succeeded
+        }
         // #1021: publish to Apple Health when an offload lands, not only on foreground entry - the
         // scenePhase pass below starts the offload and wrote to Health in parallel with it, so a night
         // synced on open only reached Health at the next launch. Weak so the scene owns the bridge's
         // lifetime; the bridge no-ops unless Health was authorized.
-        model.healthWriteBack = { [weak bridge] in await bridge?.writeBackAfterNewData() }
+        model.healthWriteBack = { [weak bridge] in
+            _ = await bridge?.writeBackAfterNewData()
+        }
     }
 
     var body: some Scene {
@@ -188,6 +203,11 @@ struct StrandiOSApp: App {
                     guard scenePhase == .active else { return }
                     Task { await WidgetSnapshot.publish(from: model) }
                 }
+                // Apple Health is explicitly opt-in. Once any write type is authorized, keep one
+                // best-effort BGAppRefresh request armed; revoking all write access cancels it.
+                .onChange(of: health.auth) { _, auth in
+                    HealthWritebackBackgroundScheduler.updateSchedule(isAuthorized: auth == .authorized)
+                }
                 // #581: the `noop://import-health` deep link the iOS Shortcut opens after building the
                 // HealthKit-free payload. Filter on the host so other future schemes don't trip the
                 // importer; macOS never registers the scheme so this stays iOS-only.
@@ -240,6 +260,8 @@ struct StrandiOSApp: App {
                 model.ble.requestSync(.foreground)
                 Task {
                     health.refreshAuthIfPreviouslyGranted()
+                    HealthWritebackBackgroundScheduler.updateSchedule(
+                        isAuthorized: health.auth == .authorized)
                     await HealthSyncRefreshCoordinator.run(
                         sync: { await health.sync() },
                         refresh: {
@@ -254,6 +276,9 @@ struct StrandiOSApp: App {
                     await watch.pushLatest(from: model)
                 }
             } else if phase == .background {
+                // Re-submit on every transition because iOS may discard an old best-effort request.
+                HealthWritebackBackgroundScheduler.updateSchedule(
+                    isAuthorized: health.auth == .authorized)
                 // #114: capture the LAST in-app live state on the way out so the Home widget matches what
                 // the user just saw — its battery/HR/score otherwise lag to the last FOREGROUND refreshSeq
                 // bump. One reload per app-exit is low-frequency and well within WidgetKit's daily budget.

--- a/StrandiOS/Health/HealthKitBridge.swift
+++ b/StrandiOS/Health/HealthKitBridge.swift
@@ -29,6 +29,10 @@ final class HealthKitBridge: ObservableObject {
     @Published private(set) var auth: AuthState = .unknown
     @Published private(set) var lastSync: Date?
     @Published private(set) var syncing = false
+    /// Coalesces a fresh-data notification that arrives while another HealthKit pass owns the bridge.
+    /// Without this, a strap offload finishing during the foreground read/write pass was deferred until
+    /// the next app open even though the newly-banked rows were already available locally.
+    private var writeBackPending = false
     /// The most recent failure surfaced by `sync` / `writeBack`. Cleared on a successful run. UI binds
     /// here so an Apple Health auth revoke, quota hit, or invalid sample is visible instead of silent.
     @Published private(set) var lastError: String?
@@ -81,19 +85,6 @@ final class HealthKitBridge: ObservableObject {
         return s
     }
 
-    /// The write set as it existed before the high-res write-back (4 nightly vitals + sleep). A
-    /// returning user granted THIS set; `refreshAuthIfPreviouslyGranted` must resume off it — checking
-    /// the full `writeTypes` would leave every pre-existing grant stuck at `.unknown` after the update
-    /// because the new types are still `.notDetermined`.
-    private var legacyCoreWriteTypes: Set<HKSampleType> {
-        var s = Set<HKSampleType>()
-        for id in HealthKitBridge.quantityWriteIds where !HealthKitBridge.writeDenied.contains(id) {
-            if let t = HKObjectType.quantityType(forIdentifier: id) { s.insert(t) }
-        }
-        if let sleep = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) { s.insert(sleep) }
-        return s
-    }
-
     // Every id here ends up in the HealthKit permission dialog. Only request what `sync` actually
     // aggregates into `DayAgg`; adding read scopes the app never consumes makes the consent prompt
     // noisier and surfaces a privacy ask we don't honour.
@@ -129,8 +120,8 @@ final class HealthKitBridge: ObservableObject {
     /// instead of bricking launch, turning a ship-and-crash into a no-op.
     private static let writeDenied: Set<HKQuantityTypeIdentifier> = [.appleSleepingWristTemperature]
     // High-res write-back shares: the continuous 1-minute HR stream, and the energy/distance samples
-    // attached to written workouts. Kept out of `quantityWriteIds` so `legacyCoreWriteTypes` (the
-    // auth-resume set) stays exactly what pre-update users granted.
+    // attached to written workouts. Kept separate from the four nightly-vital ids so the permission
+    // expansion and each independently-authorized writer remain explicit.
     private static let highResQuantityWriteIds: [HKQuantityTypeIdentifier] = [
         .heartRate, .activeEnergyBurned, .distanceWalkingRunning, .distanceCycling
     ]
@@ -229,7 +220,10 @@ final class HealthKitBridge: ObservableObject {
     /// status, so no system permission sheet is shown.
     func refreshAuthIfPreviouslyGranted() {
         guard auth == .unknown, HKHealthStore.isHealthDataAvailable() else { return }
-        let granted = legacyCoreWriteTypes.allSatisfy { store.authorizationStatus(for: $0) == .sharingAuthorized }
+        // Share authorization is per type. Resume when at least one write type is granted so a person
+        // who intentionally declined (for example) workouts still gets sleep/vitals exported after a
+        // relaunch. Requiring every legacy type made partial grants look wholly disconnected.
+        let granted = writeTypes.contains { store.authorizationStatus(for: $0) == .sharingAuthorized }
         if granted {
             auth = .authorized
             // A returning user who already granted access should get the live stream re-armed for this
@@ -398,9 +392,15 @@ final class HealthKitBridge: ObservableObject {
     /// upserts keyed by day).
     @discardableResult
     func sync(days: Int = 30) async -> Bool {
-        guard auth == .authorized, !syncing else { return false }
+        guard auth == .authorized else { return false }
+        guard !syncing else {
+            // A full sync includes write-back. If new strap data is landing concurrently, guarantee one
+            // final write-only reconciliation after the current owner releases the bridge.
+            writeBackPending = true
+            return false
+        }
         syncing = true
-        defer { syncing = false }
+        defer { finishHealthPass() }
         // Before reading: pick up any read type this version added that the user was never asked about
         // (#949). No-op once the stored signature matches, which is every sync after the first.
         await requestNewReadTypesIfNeeded()
@@ -629,26 +629,44 @@ final class HealthKitBridge: ObservableObject {
     /// would misreport when NOOP last READ from Health.
     ///
     /// Shares the `syncing` flag with `sync()` on purpose: two write-backs must never interleave, because
-    /// the vitals dedup deletes our prior samples for a key before saving the fresh batch. The cost is
-    /// that a foreground `sync()` arriving during a background write skips that one read pass and picks
-    /// up on the next open - a few seconds' window, and nothing is lost.
-    func writeBackAfterNewData() async {
+    /// the vitals dedup deletes our prior samples for a key before saving the fresh batch. A call that
+    /// arrives while another pass owns the bridge is coalesced into one final reconciliation rather than
+    /// being dropped until the next app open.
+    @discardableResult
+    func writeBackAfterNewData() async -> Bool {
         // A backfill routinely completes in a process that was never foregrounded (a background offload,
         // or a BLE relaunch) - the case this exists for. `auth` is still `.unknown` there, because the
         // only resume runs on scenePhase == .active, so without this the guard below would silently drop
         // exactly the writes this is meant to deliver. Idempotent, and never prompts: it reads share
         // status, and its re-request for new types is foreground-gated.
         refreshAuthIfPreviouslyGranted()
-        guard auth == .authorized, !syncing else { return }
+        // No authorization is a successful no-op for a background task. The scheduler is cancelled by
+        // its app-owned operation after observing this state, so it does not keep waking unnecessarily.
+        guard auth == .authorized else { return true }
+        guard !syncing else {
+            writeBackPending = true
+            return true
+        }
         syncing = true
-        defer { syncing = false }
-        guard let store = await repo.storeHandle() else { return }
+        defer { finishHealthPass() }
+        guard let store = await repo.storeHandle() else { return false }
         do {
             try await writeBack(whoopStore: store)
             lastError = nil
+            return true
         } catch {
             lastError = String(localized: "Apple Health sync failed: \(error.localizedDescription)")
+            return false
         }
+    }
+
+    /// Release the single-flight gate and service one coalesced fresh-data signal. Scheduling a new task
+    /// (rather than recursing in the defer) guarantees the current pass has fully returned first.
+    private func finishHealthPass() {
+        syncing = false
+        guard writeBackPending else { return }
+        writeBackPending = false
+        Task { await writeBackAfterNewData() }
     }
 
     // MARK: - Write back (NOOP → Health)

--- a/StrandiOS/Health/HealthWritebackBackgroundScheduler.swift
+++ b/StrandiOS/Health/HealthWritebackBackgroundScheduler.swift
@@ -1,0 +1,74 @@
+#if os(iOS)
+import BackgroundTasks
+import Foundation
+
+/// Best-effort periodic fallback for exporting locally-banked strap data to Apple Health.
+///
+/// Fresh WHOOP offloads still use the immediate completion hook in `AppModel`; this scheduler covers
+/// data already in the local store when the app remains closed. `BGAppRefreshTaskRequest` does not
+/// guarantee an exact cadence, so the one-hour date is deliberately only an earliest-begin request.
+@MainActor
+enum HealthWritebackBackgroundScheduler {
+    static let taskIdentifier = (Bundle.main.bundleIdentifier ?? "com.noopapp.noop") + ".healthwriteback"
+
+    /// Register at launch, before the first scene finishes connecting. The operation returns whether
+    /// the HealthKit write completed; authorization absence is a successful no-op and cancels the next
+    /// request in the app-owned closure.
+    static func register(perform operation: @escaping @MainActor () async -> Bool) {
+        BGTaskScheduler.shared.register(forTaskWithIdentifier: taskIdentifier, using: nil) { task in
+            let completion = TaskCompletionGuard(task: task)
+            let worker = Task { @MainActor in
+                // Refresh requests are single-shot. Arm the successor before doing any HealthKit work so
+                // expiration cannot leave periodic export permanently unscheduled.
+                schedule()
+                let succeeded = await operation()
+                guard !Task.isCancelled else { return }
+                completion.finish(success: succeeded)
+            }
+            task.expirationHandler = {
+                worker.cancel()
+                completion.finish(success: false)
+            }
+        }
+    }
+
+    /// Keep exactly one pending request. Calling this on authorization, foreground, and background
+    /// transitions is therefore idempotent and also repairs a request the system discarded.
+    static func schedule(now: Date = Date()) {
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: taskIdentifier)
+        let request = BGAppRefreshTaskRequest(identifier: taskIdentifier)
+        request.earliestBeginDate = HealthWritebackSchedulePolicy.earliestBeginDate(after: now)
+        try? BGTaskScheduler.shared.submit(request)
+    }
+
+    static func cancel() {
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: taskIdentifier)
+    }
+
+    static func updateSchedule(isAuthorized: Bool) {
+        if HealthWritebackSchedulePolicy.shouldSchedule(isAuthorized: isAuthorized) {
+            schedule()
+        } else {
+            cancel()
+        }
+    }
+
+    /// `BGTask` completion is single-shot even when normal completion races expiration.
+    private final class TaskCompletionGuard: @unchecked Sendable {
+        private let task: BGTask
+        private let lock = NSLock()
+        private var finished = false
+
+        init(task: BGTask) { self.task = task }
+
+        func finish(success: Bool) {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !finished else { return }
+            finished = true
+            task.setTaskCompleted(success: success)
+            task.expirationHandler = nil
+        }
+    }
+}
+#endif

--- a/StrandiOS/Resources/Info.plist
+++ b/StrandiOS/Resources/Info.plist
@@ -7,6 +7,7 @@
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER).debugexport</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).healthwriteback</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/StrandiOS/Resources/NOOP.entitlements
+++ b/StrandiOS/Resources/NOOP.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
+	<key>com.apple.developer.healthkit.background-delivery</key>
+	<true/>
 	<key>com.apple.developer.healthkit.access</key>
 	<array/>
 	<key>com.apple.security.application-groups</key>

--- a/docs/IOS.md
+++ b/docs/IOS.md
@@ -415,7 +415,7 @@ This is the biggest *additive* opportunity on iOS.
 |---|---|
 | **Read** | Query HealthKit live (`HKHealthStore`, `HKSampleQuery`, anchored/observer queries) for HR, RHR, HRV SDNN, SpO₂, wrist/body temperature, respiratory rate, sleep stages, workouts, body composition — the same types `relevantTypes` already enumerates in `AppleHealthImporter`. No manual export needed. |
 | **Write** | Write NOOP-computed values back into Apple Health: HR / HRV / SpO₂ / temperature samples decoded from the strap, sleep analysis from `StrandAnalytics.SleepStager`, and workouts from `WorkoutDetector` — so NOOP data shows up across the user's Health ecosystem. |
-| **Background delivery** | `HKObserverQuery` + `enableBackgroundDelivery` to keep the on-device store in sync without opening the app. |
+| **Background delivery** | `HKObserverQuery` + `enableBackgroundDelivery` keep the on-device store current, while a best-effort `BGAppRefreshTaskRequest` periodically writes already-banked strap data back to Health. Fresh WHOOP offloads write immediately from their completion hook. iOS chooses the actual refresh time. |
 
 Because `AppleHealthImporter` already defines the canonical type set, units, and
 `SleepStage` mapping, an iOS `HealthKitImporter` can map `HKSample` objects onto the
@@ -562,10 +562,8 @@ targets:
 - [x] `MenuBarExtra` replaced by a WidgetKit widget + Live Activity (`StrandiOSWidgets`), reusing `StrandDesign`.
 - [x] iOS action layer: `lockScreen` returns false on iOS, `buzzBack`/`markMoment` portable, **App Intents** exposed (`StrandiOS/System/NOOPAppIntents.swift`).
 - [x] Clipboard + URL-open routed through `Platform.swift` (`PlatformPasteboard`/`PlatformOpen`).
-- [x] `HealthKitBridge` two-way Apple Health (read live + write NOOP metrics). _(See the device-id follow-up flagged below.)_
+- [x] `HealthKitBridge` two-way Apple Health (read live + immediate post-offload and periodic background write-back of NOOP metrics).
 - [ ] **Still TODO (needs hardware):** verify BLE on a **physical iPhone** with a real strap — CoreBluetooth has no Simulator. This is the one thing CI/compile can't cover.
-
-> **Open follow-up:** `HealthKitBridge.writeBack` reads NOOP-computed metrics under `deviceId = "my-whoop"`, but the on-device *computed* scores (recovery/HRV/…) are persisted under the **computed** id `"my-whoop-noop"` — so the Apple-Health write-back may read little/nothing for a strap-only user. Behavioural (not a compile issue); fix when the iOS HealthKit path gets device-tested.
 
 ---
 

--- a/project.yml
+++ b/project.yml
@@ -264,12 +264,13 @@ targets:
           # launch in StrandiOSApp.init) or the submit fails gracefully and only the foreground/"Run now"
           # paths run.
           - fetch
-        # #510: permit the scheduled debug auto-export's BGAppRefreshTask identifier. Built from
-        # $(PRODUCT_BUNDLE_IDENTIFIER) so it tracks BUNDLE_ID_PREFIX automatically; MUST still match
-        # ScheduledDebugExport.bgTaskIdentifier EXACTLY (which derives it from Bundle.main the same
-        # way) and be registered at launch (StrandiOSApp.init), or iOS refuses to schedule/deliver it.
+        # Permit both BGAppRefreshTask identifiers. Each derives from Bundle.main at runtime so it
+        # tracks BUNDLE_ID_PREFIX, and each is registered from StrandiOSApp.init before launch finishes.
         BGTaskSchedulerPermittedIdentifiers:
           - $(PRODUCT_BUNDLE_IDENTIFIER).debugexport
+          # Best-effort fallback that writes already-banked WHOOP data to HealthKit when iOS grants
+          # background time. Fresh offloads also write immediately from their completion hook.
+          - $(PRODUCT_BUNDLE_IDENTIFIER).healthwriteback
         NSBluetoothAlwaysUsageDescription: "NOOP connects directly to your WHOOP strap over Bluetooth to read heart rate, R-R intervals, battery, and sensor data locally on your iPhone. Nothing leaves your device."
         NSLocationWhenInUseUsageDescription: "NOOP records your route during an outdoor workout to show distance, pace, and a map, and keeps recording while the screen is off. The route stays on your device. Nothing leaves it."
         NSHealthShareUsageDescription: "NOOP reads your own Apple Health data on-device to compute recovery, strain, and sleep. Nothing leaves your device."
@@ -299,6 +300,8 @@ targets:
       path: StrandiOS/Resources/NOOP.entitlements
       properties:
         com.apple.developer.healthkit: true
+        # Required by HealthKit on iOS 15+ for the observer queries registered by HealthKitBridge.
+        com.apple.developer.healthkit.background-delivery: true
         com.apple.developer.healthkit.access: []
         com.apple.security.application-groups:
           - $(APP_GROUP_ID)


### PR DESCRIPTION
## What changed

- write freshly offloaded WHOOP data to Apple Health immediately, including offloads completed in the background
- coalesce a pending write-back when another HealthKit pass is already running
- add a self-renewing, authorization-gated `BGAppRefreshTaskRequest` as a periodic fallback
- resume correctly after partial Apple Health write authorization
- add the required HealthKit background-delivery entitlement and task identifier
- document the best-effort iOS cadence and update the connected-state copy

## Why

The foreground HealthKit pass could race the WHOOP offload it started, leaving fresh sleep and vitals unwritten until the next app open. iOS also had no independent fallback for already-banked data while the app remained closed.

## Impact

Users who opt into Apple Health get immediate write-back after a completed WHOOP offload and an hourly-earliest background refresh request when iOS grants execution time. iOS still controls the actual background cadence.

## Validation

- `git diff --check`
- parsed `StrandiOS/Resources/Info.plist` as XML
- parsed `StrandiOS/Resources/NOOP.entitlements` as XML
- added scheduling-policy unit tests

An Xcode/iOS build and physical-device verification were not available in the Windows workspace.
