### PR TITLE
fix(hrv): align rolling rMSSD semantics across platforms

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -331,12 +331,11 @@ public enum HRVAnalyzer {
         public init(ts: Int, rmssd: Double) { self.ts = ts; self.rmssd = rmssd }
     }
 
-    /// Pure rolling/windowed rMSSD over an R-R series (#803). For each input interval, the window is the
-    /// trailing `windowSec` seconds ending at that interval's `ts`; the window's R-R values are cleaned with
-    /// the SAME range filter + Malik ectopic rejection the nightly path uses (`cleanRR`), and a point is
-    /// emitted only when at least `minBeatsPerWindow` clean intervals survive (so a sparse / artifact-heavy
-    /// window emits nothing rather than a noisy spike). The result is one `(ts, rMSSD)` per qualifying
-    /// window, in input order.
+    /// Pure rolling/windowed rMSSD over an R-R series (#803). For each input interval at `ts`, the window is
+    /// `(ts - windowSec, ts]`; that window's raw R-R values are cleaned locally with the SAME range filter +
+    /// Malik ectopic rejection the nightly path uses (`cleanRR`). A point is emitted only when at least
+    /// `minBeatsPerWindow` clean intervals survive (so a sparse / artifact-heavy window emits nothing rather
+    /// than a noisy spike). The result is one `(ts, rMSSD)` per qualifying window, in timestamp order.
     ///
     /// - Parameters:
     ///   - rr: the R-R intervals (each carries its own wall-clock `ts` and `rrMs`). Need not be pre-sorted;
@@ -358,8 +357,8 @@ public enum HRVAnalyzer {
         var left = 0   // index of the oldest interval still inside the trailing window
         for right in 0..<sorted.count {
             let edgeTs = sorted[right].ts
-            // Advance the left edge so [left, right] spans only the trailing `windowSec` ending at edgeTs.
-            while left < right && edgeTs - sorted[left].ts > windowSec { left += 1 }
+            // Advance the left edge so [left, right] contains exactly (edgeTs - windowSec, edgeTs].
+            while left < right && edgeTs - sorted[left].ts >= windowSec { left += 1 }
             // Thinning stride: skip emitting until at least `stepSec` has passed since the last emitted point.
             if stepSec > 0, let last = lastEmitTs, edgeTs - last < stepSec { continue }
             // Clean the window's raw R-R values with the shared range + Malik ectopic pipeline, then

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerTests.swift
@@ -176,6 +176,40 @@ final class HRVAnalyzerTests: XCTestCase {
         for p in pts { XCTAssertEqual(p.rmssd, 10.0, accuracy: 1e-9) }
     }
 
+    func testRollingRmssdUsesExclusiveLeftWindowBoundary() {
+        // Every candidate window has only seven beats under (t - windowSec, t]. Including the beat
+        // exactly at t - windowSec would incorrectly create qualifying eight-beat points at t=7 and t=8.
+        let rr = (0...8).map {
+            RRInterval(ts: $0, rrMs: $0.isMultiple(of: 2) ? 800 : 810)
+        }
+        let pts = HRVAnalyzer.rollingRmssd(
+            rr: rr, windowSec: 7, stepSec: 0, minBeatsPerWindow: 8
+        )
+        XCTAssertTrue(pts.isEmpty)
+    }
+
+    func testRollingRmssdCleansEachRawWindowIndependently() {
+        // The 1006 ms beat is acceptable in the local [845, 1006, 847] window at t=14, but not in
+        // [804, 845, 1006] at t=12. A whole-series clean incorrectly emits the t=12 window too.
+        let values = [800, 821, 812, 783, 804, 845, 1006, 847]
+        let rr = values.enumerated().map { RRInterval(ts: $0.offset * 2, rrMs: $0.element) }
+        let pts = HRVAnalyzer.rollingRmssd(
+            rr: rr, windowSec: 5, stepSec: 0, minBeatsPerWindow: 3
+        )
+        XCTAssertEqual(pts.map(\.ts), [4, 6, 8, 10, 14])
+    }
+
+    func testRollingRmssdRepeatedValuesCannotReattachRejectedTimestamp() {
+        // Whole-series cleaning rejects the first 900 ms beat but keeps the second. Matching survivors
+        // back by RR value reattaches that survivor to t=12 and fabricates a 141.42 ms point there.
+        let values = [700, 700, 700, 700, 700, 700, 900, 900]
+        let rr = values.enumerated().map { RRInterval(ts: $0.offset * 2, rrMs: $0.element) }
+        let pts = HRVAnalyzer.rollingRmssd(
+            rr: rr, windowSec: 5, stepSec: 0, minBeatsPerWindow: 3
+        )
+        XCTAssertEqual(pts.map(\.ts), [4, 6, 8, 10])
+    }
+
     func testAnalyzeWindowFiltersByTimestamp() {
         // RR rows across two windows; only [1000,1010] should be analyzed.
         var rr: [RRInterval] = []

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -660,11 +660,12 @@ object HrvAnalyzer {
     // The Deep Timeline's "HRV" trace used to plot RAW RR-interval values (ms) and label them "HRV",
     // which is dishonest: an RR interval is NOT an HRV number, and the spikiness it shows is just the
     // beat-to-beat heart period, not variability. [rollingRmssd] is the pure, on-device twin of the
-    // Swift HRVAnalyzer.rollingRmssd: it slides a [windowSec] window across the cleaned RR series and,
-    // for each RR sample, emits the Task-Force rMSSD over the beats inside that trailing window. The
-    // SAME Malik/range artifact filter the nightly path uses ([cleanRR]) is applied first, so an
-    // ectopic beat or an out-of-range RR can't inflate the curve. The Deep Timeline plots THIS, relabelled
-    // to honest windowed rMSSD. Pure: no clock, no IO. (#803)
+    // Swift HRVAnalyzer.rollingRmssd: it slides a [windowSec] window across the raw RR series and, for
+    // each RR sample, cleans the beats inside that trailing window before emitting the Task-Force rMSSD.
+    // The SAME Malik/range artifact filter the nightly path uses ([cleanRR]) is applied independently in
+    // each window, so an ectopic beat or an out-of-range RR can't inflate the curve or couple otherwise
+    // separate windows. The Deep Timeline plots THIS, relabelled to honest windowed rMSSD. Pure: no clock,
+    // no IO. (#803)
 
     /** Default rolling-window width (seconds) for the Deep Timeline windowed rMSSD trace. ~5 min, the
      *  shortest span the Task Force calls a short-term recording, so the curve has enough beats to mean
@@ -672,13 +673,12 @@ object HrvAnalyzer {
     const val DEFAULT_ROLLING_WINDOW_SEC: Int = 300
 
     /**
-     * Rolling/windowed rMSSD over an RR series. For each input sample (ascending by ts), computes the
-     * Task-Force rMSSD over the cleaned beats whose ts falls in the trailing window `(ts - windowSec, ts]`,
-     * emitting `(ts, rmssd)` only when at least [minBeatsPerWindow] clean beats survive in that window (a
-     * 2-beat window is one successive difference = a noisy spike, not HRV — matches the Swift twin's
-     * minBeatsPerWindow gate). Range + Malik ectopic filtering ([cleanRR]) is applied to the WHOLE series
-     * once, so artifacts never enter any window. Empty when fewer than [minBeatsPerWindow] input rows.
-     * Pure, deterministic.
+     * Rolling/windowed rMSSD over an RR series. For each input sample at `ts`, the window is
+     * `(ts - windowSec, ts]`; that window's raw RR values are cleaned locally with the same range + Malik
+     * ectopic filter the nightly path uses ([cleanRR]). Emits `(ts, rmssd)` only when at least
+     * [minBeatsPerWindow] clean beats survive (a 2-beat window is one successive difference = a noisy
+     * spike, not HRV — matches the Swift twin's minBeatsPerWindow gate). Empty when fewer than
+     * [minBeatsPerWindow] input rows. Pure, deterministic.
      *
      * @param rr the RR intervals (each carries a ts in unix SECONDS and rrMs); the Android twin of the
      *   Swift `[RRSample]`.
@@ -701,39 +701,26 @@ object HrvAnalyzer {
         // Ascending by ts so the trailing-window scan is monotone (the table read is already ordered, but
         // we don't assume it). Stable on equal ts.
         val sorted = rr.sortedBy { it.ts }
-        // Clean the WHOLE series first (range + Malik ectopic), keeping each surviving beat's ts so a
-        // window can be cut by timestamp. cleanRR works on the raw ms values; we re-pair to ts by walking
-        // the same filters here so the kept ts/ms stay aligned (cleanRR drops items, losing the index map).
-        val ranged = sorted.filter { it.rrMs.toDouble() in RR_MIN_MS..RR_MAX_MS }
-        if (ranged.size < 2) return emptyList()
-        val cleanMs = rejectEctopic(ranged.map { it.rrMs.toDouble() })
-        // rejectEctopic preserves order and only drops items, so re-pair by walking both in lockstep: a
-        // kept ms value corresponds to the next not-yet-consumed ranged beat with that value.
-        val kept = ArrayList<RrInterval>(cleanMs.size)
-        var ri = 0
-        for (ms in cleanMs) {
-            while (ri < ranged.size && ranged[ri].rrMs.toDouble() != ms) ri++
-            if (ri < ranged.size) { kept.add(ranged[ri]); ri++ }
-        }
-        if (kept.size < 2) return emptyList()
         val window = windowSec.toLong()
-        val out = ArrayList<Pair<Long, Double>>(kept.size)
+        val out = ArrayList<Pair<Long, Double>>(sorted.size)
         var lo = 0
         var lastEmitTs: Long? = null
-        for (hi in kept.indices) {
-            val tEnd = kept[hi].ts
+        for (hi in sorted.indices) {
+            val tEnd = sorted[hi].ts
             val tStart = tEnd - window
             // Advance the trailing edge so only beats with ts in (tStart, tEnd] remain.
-            while (lo < hi && kept[lo].ts <= tStart) lo++
+            while (lo < hi && sorted[lo].ts <= tStart) lo++
             // Thinning stride (#1036): skip emitting until at least [stepSec] has passed since the last
             // EMITTED point (measured against emits, not candidates), matching the Swift twin's stepSec branch.
             val last = lastEmitTs
             if (stepSec > 0 && last != null && tEnd - last < stepSec) continue
-            val span = kept.subList(lo, hi + 1).map { it.rrMs.toDouble() }
+            // Clean this raw window in place. Timestamps stay on the samples used to define the window,
+            // so no value-based matching back to timestamps is needed after cleaning.
+            val clean = cleanRR(sorted.subList(lo, hi + 1).map { it.rrMs.toDouble() })
             // A window with too few clean beats is a noisy spike, not a trustworthy rMSSD — require
             // [minBeatsPerWindow] survivors (#1035), matching the Swift HRVAnalyzer.rollingRmssd default (8).
-            if (span.size < minBeatsPerWindow) continue
-            val r = rmssdRaw(span) ?: continue
+            if (clean.size < minBeatsPerWindow) continue
+            val r = rmssdRaw(clean) ?: continue
             out.add(tEnd to r)
             lastEmitTs = tEnd
         }

--- a/android/app/src/test/java/com/noop/analytics/HrvAnalyzerRollingTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvAnalyzerRollingTest.kt
@@ -81,6 +81,38 @@ class HrvAnalyzerRollingTest {
         assertTrue(out.all { (_, v) -> v < 30.0 })
     }
 
+    @Test fun usesExclusiveLeftWindowBoundary() {
+        // Every candidate window has only seven beats under (t - windowSec, t]. Including the beat
+        // exactly at t - windowSec would incorrectly create qualifying eight-beat points at t=7 and t=8.
+        val series = (0L..8L).map { rr(it, if (it % 2L == 0L) 800 else 810) }
+        val out = HrvAnalyzer.rollingRmssd(
+            series, windowSec = 7, stepSec = 0, minBeatsPerWindow = 8,
+        )
+        assertTrue(out.isEmpty())
+    }
+
+    @Test fun cleansEachRawWindowIndependently() {
+        // The 1006 ms beat is acceptable in the local [845, 1006, 847] window at t=14, but not in
+        // [804, 845, 1006] at t=12. A whole-series clean incorrectly emits the t=12 window too.
+        val values = listOf(800, 821, 812, 783, 804, 845, 1006, 847)
+        val series = values.mapIndexed { index, value -> rr(index * 2L, value) }
+        val out = HrvAnalyzer.rollingRmssd(
+            series, windowSec = 5, stepSec = 0, minBeatsPerWindow = 3,
+        )
+        assertEquals(listOf(4L, 6L, 8L, 10L, 14L), out.map { it.first })
+    }
+
+    @Test fun repeatedValuesCannotReattachRejectedTimestamp() {
+        // Whole-series cleaning rejects the first 900 ms beat but keeps the second. Matching survivors
+        // back by RR value reattaches that survivor to t=12 and fabricates a 141.42 ms point there.
+        val values = listOf(700, 700, 700, 700, 700, 700, 900, 900)
+        val series = values.mapIndexed { index, value -> rr(index * 2L, value) }
+        val out = HrvAnalyzer.rollingRmssd(
+            series, windowSec = 5, stepSec = 0, minBeatsPerWindow = 3,
+        )
+        assertEquals(listOf(4L, 6L, 8L, 10L), out.map { it.first })
+    }
+
     @Test fun honestNoEmDashAndNoFabricatedValuesOnEmpty() {
         // Zero rows -> zero points (never a fabricated 0.0 reading). Guards the "honest empty" contract.
         assertTrue(HrvAnalyzer.rollingRmssd(emptyList(), windowSec = 300).isEmpty())


### PR DESCRIPTION
## What this PR does

Aligns Swift and Kotlin rolling rMSSD behavior for three measured parity drifts:

- defines each trailing window as `(t - windowSec, t]`, excluding a beat exactly on the left boundary
- cleans the raw R-R values independently inside each Android window, matching Swift
- removes Kotlin's value-based timestamp rematching, which could reattach a repeated surviving R-R value to a rejected timestamp

Mirrored Swift and Kotlin regression fixtures cover all three cases.

This addresses only those three cross-platform drift findings. The shared gap-aware/rejected-beat splice concern described in https://github.com/bhelm/noop/issues/9 remains out of scope and is not closed by this PR.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

Deterministic analytics unit fixtures were run on both implementations:

- `cd Packages/StrandAnalytics && swift test --filter HRVAnalyzerTests` — 40 tests passed
- `cd android && ./gradlew :app:testFullDebugUnitTest --tests "com.noop.analytics.HrvAnalyzerRollingTest" --no-daemon --max-workers=1 --no-parallel` — 10 tests passed

Only the focused suites were run. No manual, device, or strap testing was performed; the changed behavior is covered by pure unit fixtures.

## Checklist

- [ ] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`) — focused `HRVAnalyzerTests` passed; the full package suite was not run
- [ ] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`) — focused `HrvAnalyzerRollingTest` passed; the full Android suite was not run
- [ ] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — not applicable; no UI changed
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders — not applicable; no protocol code changed
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Related: https://github.com/bhelm/noop/issues/9