### PR TITLE
fix(stress): use calendar-day windows across DST

### DIFF
--- a/android/app/src/main/java/com/noop/ui/StressLocalDayWindow.kt
+++ b/android/app/src/main/java/com/noop/ui/StressLocalDayWindow.kt
@@ -1,0 +1,35 @@
+package com.noop.ui
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+/** Inclusive epoch-second bounds for one calendar day in a specific device time zone. */
+internal data class StressLocalDayWindow(
+    val day: LocalDate,
+    val fromEpochSecond: Long,
+    val toEpochSecondInclusive: Long,
+    val offsetSeconds: Int,
+) {
+    val durationSeconds: Long get() = toEpochSecondInclusive - fromEpochSecond + 1L
+}
+
+/**
+ * Resolve a local calendar day through the zone's rules instead of assuming every day is 86,400 s.
+ * This mirrors Calendar.startOfDay/date(byAdding: .day) used by the Swift stress screen.
+ */
+internal fun stressLocalDayWindow(day: LocalDate, zone: ZoneId): StressLocalDayWindow {
+    val start = day.atStartOfDay(zone)
+    val nextStart = day.plusDays(1).atStartOfDay(zone)
+    return StressLocalDayWindow(
+        day = day,
+        fromEpochSecond = start.toEpochSecond(),
+        toEpochSecondInclusive = nextStart.toEpochSecond() - 1L,
+        offsetSeconds = start.offset.totalSeconds,
+    )
+}
+
+internal fun stressLocalDayWindowContaining(epochSecond: Long, zone: ZoneId): StressLocalDayWindow {
+    val day = Instant.ofEpochSecond(epochSecond).atZone(zone).toLocalDate()
+    return stressLocalDayWindow(day, zone)
+}

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -61,6 +61,9 @@ import com.noop.analytics.DaytimeStress
 import com.noop.analytics.HrvFreqDomain
 import com.noop.analytics.StressIndex
 import com.noop.data.DailyMetric
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 import java.util.Locale
 import kotlin.math.exp
 import kotlin.math.roundToInt
@@ -174,11 +177,10 @@ private data class DaytimeReadout(
  */
 private suspend fun loadDaytimeStress(vm: AppViewModel, personalBaseline: Boolean): DaytimeReadout {
     val nowSeconds = System.currentTimeMillis() / 1000L
-    val tzOffsetSeconds = java.util.TimeZone.getDefault().getOffset(nowSeconds * 1_000L) / 1_000L
-    // Local midnight (wall-clock seconds): floor the LOCAL time to the day, then undo the
-    // offset so the bound is back on the wall clock the samples are stored in.
-    val localNow = nowSeconds + tzOffsetSeconds
-    val from = (localNow - Math.floorMod(localNow, 86_400L)) - tzOffsetSeconds
+    val zone = ZoneId.systemDefault()
+    val todayWindow = stressLocalDayWindowContaining(nowSeconds, zone)
+    val from = todayWindow.fromEpochSecond
+    val tzOffsetSeconds = zone.rules.getOffset(Instant.ofEpochSecond(nowSeconds)).totalSeconds.toLong()
     val hr = vm.repo.hrSamples("my-whoop", from, nowSeconds, limit = 200_000)
     if (hr.size < DaytimeStress.minHourHrSamples) {
         return DaytimeReadout(DaytimeStress.Result.EMPTY, null, null)
@@ -193,7 +195,11 @@ private suspend fun loadDaytimeStress(vm: AppViewModel, personalBaseline: Boolea
     // hours (DayRelative, the default). The trailing-history reads happen only past the HR-count guard
     // above and only while the toggle is ON, so the default read is byte-identical to before. Twin of
     // the iOS StressView daytimeScoringMode.
-    val mode = if (personalBaseline) daytimeScoringMode(vm, todayLocalMidnight = from) else DaytimeStress.ScoringMode.DayRelative
+    val mode = if (personalBaseline) {
+        daytimeScoringMode(vm, todayWindow.day, zone)
+    } else {
+        DaytimeStress.ScoringMode.DayRelative
+    }
     val daytime = DaytimeStress.analyze(hr, rr, gravity, tzOffsetSeconds, mode)
     // ADDITIVE advanced readouts from the SAME `rr`. Each engine self-gates and returns null when
     // its requirement is not met, in which case its row is simply hidden in the UI.
@@ -208,21 +214,39 @@ private suspend fun loadDaytimeStress(vm: AppViewModel, personalBaseline: Boolea
  * today's intraday read: BaselineRelative once there's enough real worn daytime-HR history for a usable
  * baseline, else DayRelative (the unchanged default). Reads each past day's raw HR once (bounded per
  * day) via [vm].repo; unworn days (no HR) are skipped without an R-R read. Faithful twin of the iOS
- * StressView.daytimeScoringMode. [todayLocalMidnight] is today's local-midnight wall-clock second.
+ * StressView.daytimeScoringMode. [todayLocalDay] is today's date in [zone].
  */
-private suspend fun daytimeScoringMode(vm: AppViewModel, todayLocalMidnight: Long): DaytimeStress.ScoringMode {
+private suspend fun daytimeScoringMode(
+    vm: AppViewModel,
+    todayLocalDay: LocalDate,
+    zone: ZoneId,
+): DaytimeStress.ScoringMode {
     // 30 mirrors the app's other rolling baselines (nightly resting-HR / HRV) and the iOS baselineHistoryDays.
     val baselineHistoryDays = 30
     val days = ArrayList<DaytimeBaselines.DaytimeDayStreams>(baselineHistoryDays)
     // Oldest → newest so the EWMA fold replays the history in order.
     for (back in baselineHistoryDays downTo 1) {
-        val dayStart = todayLocalMidnight - back * 86_400L
-        val dayEnd = dayStart + 86_400L - 1L
-        val dayTz = java.util.TimeZone.getDefault().getOffset(dayStart * 1_000L) / 1_000L
-        val dayHr = vm.repo.hrSamples("my-whoop", dayStart, dayEnd, limit = 200_000)
+        val window = stressLocalDayWindow(todayLocalDay.minusDays(back.toLong()), zone)
+        val dayHr = vm.repo.hrSamples(
+            "my-whoop",
+            window.fromEpochSecond,
+            window.toEpochSecondInclusive,
+            limit = 200_000,
+        )
         if (dayHr.isEmpty()) continue   // unworn day — no floor to learn, skip the R-R read
-        val dayRr = vm.repo.rrIntervals("my-whoop", dayStart, dayEnd, limit = 200_000)
-        days.add(DaytimeBaselines.DaytimeDayStreams(hr = dayHr, rr = dayRr, tzOffsetSeconds = dayTz))
+        val dayRr = vm.repo.rrIntervals(
+            "my-whoop",
+            window.fromEpochSecond,
+            window.toEpochSecondInclusive,
+            limit = 200_000,
+        )
+        days.add(
+            DaytimeBaselines.DaytimeDayStreams(
+                hr = dayHr,
+                rr = dayRr,
+                tzOffsetSeconds = window.offsetSeconds.toLong(),
+            ),
+        )
     }
     return DaytimeBaselines.scoringMode(days)
 }

--- a/android/app/src/test/java/com/noop/ui/StressLocalDayWindowTest.kt
+++ b/android/app/src/test/java/com/noop/ui/StressLocalDayWindowTest.kt
@@ -1,0 +1,48 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+class StressLocalDayWindowTest {
+    private val berlin = ZoneId.of("Europe/Berlin")
+
+    @Test
+    fun springForwardDayEndsAtNextLocalMidnight() {
+        val window = stressLocalDayWindow(LocalDate.of(2026, 3, 29), berlin)
+
+        assertEquals(Instant.parse("2026-03-28T23:00:00Z").epochSecond, window.fromEpochSecond)
+        assertEquals(Instant.parse("2026-03-29T21:59:59Z").epochSecond, window.toEpochSecondInclusive)
+        assertEquals(23 * 60 * 60L, window.durationSeconds)
+        assertEquals(60 * 60, window.offsetSeconds)
+    }
+
+    @Test
+    fun fallBackDayEndsAtNextLocalMidnight() {
+        val window = stressLocalDayWindow(LocalDate.of(2026, 10, 25), berlin)
+
+        assertEquals(Instant.parse("2026-10-24T22:00:00Z").epochSecond, window.fromEpochSecond)
+        assertEquals(Instant.parse("2026-10-25T22:59:59Z").epochSecond, window.toEpochSecondInclusive)
+        assertEquals(25 * 60 * 60L, window.durationSeconds)
+        assertEquals(2 * 60 * 60, window.offsetSeconds)
+    }
+
+    @Test
+    fun ordinaryDayRemainsTwentyFourHours() {
+        val window = stressLocalDayWindow(LocalDate.of(2026, 2, 10), berlin)
+
+        assertEquals(24 * 60 * 60L, window.durationSeconds)
+    }
+
+    @Test
+    fun containingWindowUsesTheSuppliedDeviceZone() {
+        val instant = Instant.parse("2026-03-29T22:30:00Z")
+
+        val window = stressLocalDayWindowContaining(instant.epochSecond, berlin)
+
+        assertEquals(LocalDate.of(2026, 3, 30), window.day)
+        assertEquals(Instant.parse("2026-03-29T22:00:00Z").epochSecond, window.fromEpochSecond)
+    }
+}


### PR DESCRIPTION
## What this PR does

Makes Android daytime-stress reads resolve local calendar-day boundaries through the device time zone instead of assuming every day is exactly 86,400 seconds.

This applies to both today's stress window and the 30-day personal-baseline history. Spring-forward and fall-back days now end at the next local midnight and use the offset for that specific day, matching the existing Swift `Calendar` behavior.

Deterministic tests cover 23-hour, 24-hour, and 25-hour days plus local-day selection in the supplied device zone.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- `cd android && ./gradlew :app:testFullDebugUnitTest --tests "com.noop.ui.StressLocalDayWindowTest" --no-daemon --max-workers=1 --no-parallel` — 4 tests passed

Only the focused test class was run. No manual, device, or strap testing was performed; the boundary behavior is covered by deterministic JVM fixtures.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`) — not applicable; Swift was not changed
- [ ] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`) — focused `StressLocalDayWindowTest` passed; the full Android suite was not run
- [ ] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — not applicable; no visual styling changed
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders — not applicable; no protocol code changed
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Related: https://github.com/bhelm/noop/issues/31