### PR TITLE
fix(breath): clamp negative stage durations

### DIFF
--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BreathProtocolPlayerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BreathProtocolPlayerTests.swift
@@ -4,6 +4,24 @@ import XCTest
 /// Golden vectors for content-driven breath protocols (holds + Presence tempos).
 final class BreathProtocolPlayerTests: XCTestCase {
 
+    func test_negative_stage_duration_clamps_and_schedules_safely() {
+        let stage = BreathStage(type: .inhale, durationMs: -1)
+        let proto = BreathProtocol(
+            id: "negative_duration",
+            title: "Negative duration",
+            subtitle: "",
+            edu: "",
+            mode: .playable,
+            category: .ans,
+            recommendedDurationMs: 1_000,
+            stages: [stage]
+        )
+
+        XCTAssertEqual(stage.durationMs, 0)
+        XCTAssertEqual(proto.cycleDurationMs, 0)
+        XCTAssertTrue(BreathProtocolPlayer.schedule(proto, sessionMs: 1_000).isEmpty)
+    }
+
     func test_box_one_cycle_cues() {
         let proto = BreathProtocolCatalog.protocolById("box_4_4_4_4")!
         let cues = BreathProtocolPlayer.schedule(proto, sessionMs: 16_000)

--- a/android/app/src/main/java/com/noop/analytics/BreathProtocol.kt
+++ b/android/app/src/main/java/com/noop/analytics/BreathProtocol.kt
@@ -20,13 +20,21 @@ enum class BreathProtocolCategory {
     BIOFEEDBACK,
 }
 
-data class BreathStage(
+data class BreathStage private constructor(
     val type: BreathPhase,
     val durationMs: Int,
     val label: String? = null,
 ) {
     init {
         require(durationMs >= 0)
+    }
+
+    companion object {
+        operator fun invoke(
+            type: BreathPhase,
+            durationMs: Int,
+            label: String? = null,
+        ): BreathStage = BreathStage(type, durationMs.coerceAtLeast(0), label)
     }
 }
 

--- a/android/app/src/test/java/com/noop/analytics/BreathProtocolPlayerTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/BreathProtocolPlayerTest.kt
@@ -11,6 +11,25 @@ import org.junit.Test
 class BreathProtocolPlayerTest {
 
     @Test
+    fun test_negative_stage_duration_clamps_and_schedules_safely() {
+        val stage = BreathStage(BreathPhase.INHALE, -1)
+        val proto = BreathProtocol(
+            id = "negative_duration",
+            title = "Negative duration",
+            subtitle = "",
+            edu = "",
+            mode = BreathProtocolMode.PLAYABLE,
+            category = BreathProtocolCategory.ANS,
+            recommendedDurationMs = 1_000,
+            stages = listOf(stage),
+        )
+
+        assertEquals(0, stage.durationMs)
+        assertEquals(0, proto.cycleDurationMs)
+        assertTrue(BreathProtocolPlayer.schedule(proto, sessionMs = 1_000).isEmpty())
+    }
+
+    @Test
     fun test_box_one_cycle_cues() {
         val proto = BreathProtocolCatalog.protocolById("box_4_4_4_4")!!
         val cues = BreathProtocolPlayer.schedule(proto, sessionMs = 16_000)


### PR DESCRIPTION
## What this PR does

Aligns Android breath-stage duration handling with Swift by normalizing negative stage durations to zero at construction time.

The Kotlin model remains immutable and retains its data-class value semantics. Mirrored Swift and Kotlin regression tests verify the stored duration, zero cycle duration, and empty scheduling result for a negative stage.

This addresses only the negative-duration parity finding in https://github.com/bhelm/noop/issues/32. The other findings in that issue remain out of scope.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- `cd Packages/StrandAnalytics && swift test --filter BreathProtocolPlayerTests` — 7 tests passed
- `cd android && ./gradlew :app:testFullDebugUnitTest --tests "com.noop.analytics.BreathProtocolPlayerTest" --no-daemon --max-workers=1 --no-parallel` — 7 tests passed

Only the focused suites were run. No manual, device, or strap testing was performed; the behavior is covered by deterministic unit fixtures.

## Checklist

- [ ] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`) — focused `BreathProtocolPlayerTests` passed; the full package suite was not run
- [ ] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`) — focused `BreathProtocolPlayerTest` passed; the full Android suite was not run
- [ ] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — not applicable; no UI changed
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders — not applicable; no protocol code changed
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Related: https://github.com/bhelm/noop/issues/32