### PR TITLE
fix(recovery): align trace half-tie rounding

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer+Trace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer+Trace.swift
@@ -34,7 +34,10 @@ extension RecoveryScorer {
                                      skinTempDev: Double? = nil)
         -> (score: Double?, trace: [String]) {
 
-        func r2(_ x: Double) -> Double { (x * 100.0).rounded() / 100.0 }
+        // Trace numbers use nearest rounding with half-ties away from zero on both platforms.
+        func r2(_ x: Double) -> Double {
+            (x * 100.0).rounded(.toNearestOrAwayFromZero) / 100.0
+        }
 
         var lines: [String] = []
         var nilTerms: [String] = []

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryScorerTraceTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryScorerTraceTests.swift
@@ -82,4 +82,40 @@ final class RecoveryScorerTraceTests: XCTestCase {
         XCTAssertTrue(base!.contains("nValid=9"))
         XCTAssertTrue(base!.contains("status=provisional"))
     }
+
+    func testTraceRoundsHalfTiesAwayFromZeroWithoutChangingScore() {
+        let hrvB = baseline(mean: 50, sigma: 6)
+        let plain = RecoveryScorer.recovery(
+            hrv: 50, rhr: 55, resp: nil,
+            hrvBaseline: hrvB, rhrBaseline: nil, respBaseline: nil,
+            sleepPerf: nil, skinTempDev: 0.125)
+        let (traced, lines) = RecoveryScorer.recoveryTrace(
+            hrv: 50, rhr: 55, resp: nil,
+            hrvBaseline: hrvB, rhrBaseline: nil, respBaseline: nil,
+            sleepPerf: nil, skinTempDev: 0.125)
+
+        XCTAssertEqual(traced, plain)
+        XCTAssertEqual(
+            lines.first { $0.hasPrefix("charge term skinTempDev ") },
+            "charge term skinTempDev z=-0.13 w=0.05 (dev=0.13C penalty=-|dev|/1.0)"
+        )
+    }
+
+    func testTracePreservesNonTieRounding() {
+        let hrvB = baseline(mean: 50, sigma: 6)
+        let plain = RecoveryScorer.recovery(
+            hrv: 50, rhr: 55, resp: nil,
+            hrvBaseline: hrvB, rhrBaseline: nil, respBaseline: nil,
+            sleepPerf: nil, skinTempDev: 0.124)
+        let (traced, lines) = RecoveryScorer.recoveryTrace(
+            hrv: 50, rhr: 55, resp: nil,
+            hrvBaseline: hrvB, rhrBaseline: nil, respBaseline: nil,
+            sleepPerf: nil, skinTempDev: 0.124)
+
+        XCTAssertEqual(traced, plain)
+        XCTAssertEqual(
+            lines.first { $0.hasPrefix("charge term skinTempDev ") },
+            "charge term skinTempDev z=-0.12 w=0.05 (dev=0.12C penalty=-|dev|/1.0)"
+        )
+    }
 }

--- a/android/app/src/main/java/com/noop/analytics/RecoveryScorerTrace.kt
+++ b/android/app/src/main/java/com/noop/analytics/RecoveryScorerTrace.kt
@@ -14,7 +14,11 @@ import kotlin.math.abs
 
 object RecoveryScorerTrace {
 
-    private fun r2(x: Double): Double = Math.round(x * 100.0) / 100.0
+    /** Trace numbers use nearest rounding with half-ties away from zero on both platforms. */
+    private fun r2(x: Double): Double {
+        val scaled = x * 100.0
+        return if (scaled < 0.0) -Math.round(-scaled) / 100.0 else Math.round(scaled) / 100.0
+    }
 
     /**
      * Side-effect-free diagnostic twin of [RecoveryScorer.recovery]: returns the SAME score recovery(...)

--- a/android/app/src/test/java/com/noop/analytics/RecoveryScorerTraceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RecoveryScorerTraceTest.kt
@@ -92,4 +92,44 @@ class RecoveryScorerTraceTest {
         assertTrue(base.contains("nValid=9"))
         assertTrue(base.contains("status=provisional"))
     }
+
+    @Test fun traceRoundsHalfTiesAwayFromZeroWithoutChangingScore() {
+        val hrvB = baseline(50.0, 6.0)
+        val plain = RecoveryScorer.recovery(
+            hrv = 50.0, rhr = 55.0, resp = null,
+            hrvBaseline = hrvB, rhrBaseline = null, respBaseline = null,
+            sleepPerf = null, skinTempDev = 0.125,
+        )
+        val (traced, lines) = RecoveryScorerTrace.recoveryTrace(
+            hrv = 50.0, rhr = 55.0, resp = null,
+            hrvBaseline = hrvB, rhrBaseline = null, respBaseline = null,
+            sleepPerf = null, skinTempDev = 0.125,
+        )
+
+        assertEquals(plain, traced)
+        assertEquals(
+            "charge term skinTempDev z=-0.13 w=0.05 (dev=0.13C penalty=-|dev|/1.0)",
+            lines.first { it.startsWith("charge term skinTempDev ") },
+        )
+    }
+
+    @Test fun tracePreservesNonTieRounding() {
+        val hrvB = baseline(50.0, 6.0)
+        val plain = RecoveryScorer.recovery(
+            hrv = 50.0, rhr = 55.0, resp = null,
+            hrvBaseline = hrvB, rhrBaseline = null, respBaseline = null,
+            sleepPerf = null, skinTempDev = 0.124,
+        )
+        val (traced, lines) = RecoveryScorerTrace.recoveryTrace(
+            hrv = 50.0, rhr = 55.0, resp = null,
+            hrvBaseline = hrvB, rhrBaseline = null, respBaseline = null,
+            sleepPerf = null, skinTempDev = 0.124,
+        )
+
+        assertEquals(plain, traced)
+        assertEquals(
+            "charge term skinTempDev z=-0.12 w=0.05 (dev=0.12C penalty=-|dev|/1.0)",
+            lines.first { it.startsWith("charge term skinTempDev ") },
+        )
+    }
 }


### PR DESCRIPTION
## What this PR does

Aligns Kotlin Recovery diagnostic trace rounding with Swift for positive and negative half-ties by using an explicit nearest, ties-away-from-zero rule.

The Recovery score is unchanged; only trace formatting is affected. Mirrored tests also pin ordinary non-ties and score neutrality.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- `cd Packages/StrandAnalytics && swift test --filter RecoveryScorerTraceTests` — 6 tests passed
- `cd android && ./gradlew :app:testFullDebugUnitTest --tests "com.noop.analytics.RecoveryScorerTraceTest" --no-daemon --max-workers=1 --no-parallel` — 6 tests passed

Only the focused suites were run. No manual, device, or strap testing was performed; this is pure diagnostic formatting.

## Checklist

- [ ] Swift package tests pass for any package I touched — focused suite passed; full package suite was not run
- [ ] Android unit tests pass if I touched `android/` — focused suite passed; full suite was not run
- [ ] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — not applicable
- [x] No hardcoded protocol bytes — not applicable
- [x] Follows `docs/CONTRIBUTING.md`
- [x] No generated output or secrets committed

## Related issues

Related: https://github.com/bhelm/noop/issues/38
Follow-up rounding bounds: https://github.com/bhelm/noop/issues/47