### PR TITLE
fix(sleep): trim newline wake labels consistently

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStageVocabulary.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStageVocabulary.swift
@@ -24,7 +24,7 @@ public enum SleepStageVocabulary {
     /// Use on a SEGMENT stage string. Minutes dictionaries are keyed `"awake"` by construction and do
     /// not need it.
     public static func isWake(_ stage: String) -> Bool {
-        let s = stage.trimmingCharacters(in: .whitespaces).lowercased()
+        let s = stage.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return s == "wake" || s == "awake"
     }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStageVocabularyTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStageVocabularyTests.swift
@@ -29,6 +29,8 @@ final class SleepStageVocabularyTests: XCTestCase {
         XCTAssertTrue(SleepStageVocabulary.isWake("Awake"))
         XCTAssertTrue(SleepStageVocabulary.isWake("  WAKE "))
         XCTAssertTrue(SleepStageVocabulary.isWake("\tAwAkE"))
+        XCTAssertTrue(SleepStageVocabulary.isWake("\nwake\n"))
+        XCTAssertTrue(SleepStageVocabulary.isWake("\rawake\r"))
     }
 
     /// An absent or unknown stage is NOT wake, which preserves the existing behaviour of the callers

--- a/android/app/src/test/java/com/noop/analytics/SleepStageVocabularyTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStageVocabularyTest.kt
@@ -35,6 +35,8 @@ class SleepStageVocabularyTest {
         assertTrue(SleepStageVocabulary.isWake("Awake"))
         assertTrue(SleepStageVocabulary.isWake("  WAKE "))
         assertTrue(SleepStageVocabulary.isWake("\tAwAkE"))
+        assertTrue(SleepStageVocabulary.isWake("\nwake\n"))
+        assertTrue(SleepStageVocabulary.isWake("\rawake\r"))
     }
 
     /**


### PR DESCRIPTION
## What this PR does

Aligns Swift `SleepStageVocabulary.isWake` with Kotlin for wake labels surrounded by LF or CR characters. Swift now trims whitespace and newlines before case normalization.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- `cd Packages/StrandAnalytics && swift test --filter SleepStageVocabularyTests` — 7 tests passed
- `cd android && ./gradlew :app:testFullDebugUnitTest --tests "com.noop.analytics.SleepStageVocabularyTest" --no-daemon --max-workers=1 --no-parallel` — 7 tests passed

Only the focused suites were run. No manual, device, or strap testing was performed; this is a pure string predicate.

## Checklist

- [ ] Swift package tests pass for any package I touched — focused suite passed; full package suite was not run
- [ ] Android unit tests pass if I touched `android/` — focused suite passed; full suite was not run
- [ ] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — not applicable
- [x] No hardcoded protocol bytes — not applicable
- [x] Follows `docs/CONTRIBUTING.md`
- [x] No generated output or secrets committed

## Related issues

Related: https://github.com/bhelm/noop/issues/41