### PR TITLE
fix(sleep): align reclip segment validation

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepWindowReclip.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepWindowReclip.swift
@@ -42,7 +42,8 @@ public enum SleepWindowReclip {
         for seg in arr {
             guard let start = (seg["start"] as? NSNumber)?.intValue,
                   let end = (seg["end"] as? NSNumber)?.intValue,
-                  let stage = seg["stage"] as? String, end > start else { continue }
+                  let stage = seg["stage"] as? String,
+                  start >= 0, end > start, !stage.isEmpty else { continue }
             if start >= newEnd { continue }                 // wholly after the new wake → drop
             if end <= newStart { continue }                 // wholly before the new bed time → drop
             let clippedStart = max(start, newStart)         // clip the segment spanning the new bed time

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepWindowReclipTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepWindowReclipTests.swift
@@ -4,13 +4,19 @@ import Foundation
 
 final class SleepWindowReclipTests: XCTestCase {
 
-    private func segments(_ json: String) -> [(start: Int, end: Int, stage: String)] {
+    private struct Segment: Equatable {
+        let start: Int
+        let end: Int
+        let stage: String
+    }
+
+    private func segments(_ json: String) -> [Segment] {
         let arr = (try? JSONSerialization.jsonObject(with: Data(json.utf8))) as? [[String: Any]] ?? []
         return arr.compactMap {
             guard let s = ($0["start"] as? NSNumber)?.intValue,
                   let e = ($0["end"] as? NSNumber)?.intValue,
                   let st = $0["stage"] as? String else { return nil }
-            return (s, e, st)
+            return Segment(start: s, end: e, stage: st)
         }
     }
 
@@ -20,6 +26,43 @@ final class SleepWindowReclipTests: XCTestCase {
     }
 
     // MARK: - segment array (computed nights)
+
+    func testSegmentValidationMatchesCanonicalDecodedJSON() throws {
+        let cases: [(json: String, newStart: Int, newEnd: Int, expected: [Segment])] = [
+            (
+                #"[{"start":-10,"end":10,"stage":"light"}]"#,
+                0,
+                20,
+                [Segment(start: 0, end: 20, stage: "wake")]
+            ),
+            (
+                #"[{"start":100,"end":200,"stage":""}]"#,
+                100,
+                300,
+                [Segment(start: 100, end: 300, stage: "wake")]
+            ),
+            (
+                #"[{"start":50,"end":200,"stage":"light"}]"#,
+                100,
+                300,
+                [
+                    Segment(start: 100, end: 200, stage: "light"),
+                    Segment(start: 200, end: 300, stage: "wake"),
+                ]
+            ),
+        ]
+
+        for testCase in cases {
+            let output = try XCTUnwrap(SleepWindowReclip.reclip(
+                stagesJSON: testCase.json,
+                sessionStart: testCase.newStart,
+                oldEnd: testCase.newEnd,
+                newStart: testCase.newStart,
+                newEnd: testCase.newEnd
+            ))
+            XCTAssertEqual(segments(output), testCase.expected)
+        }
+    }
 
     func testSegmentTrimDropsAndClips() throws {
         let json = """

--- a/android/app/src/test/java/com/noop/analytics/SleepWindowReclipTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepWindowReclipTest.kt
@@ -35,6 +35,43 @@ class SleepWindowReclipTest {
     // ── segment array (computed nights) ──────────────────────────────────────────────────────────
 
     @Test
+    fun segmentValidationMatchesCanonicalDecodedJson() {
+        data class Case(val json: String, val newStart: Long, val newEnd: Long, val expected: List<Seg>)
+
+        val cases = listOf(
+            Case(
+                json = """[{"start":-10,"end":10,"stage":"light"}]""",
+                newStart = 0,
+                newEnd = 20,
+                expected = listOf(Seg(0, 20, "wake")),
+            ),
+            Case(
+                json = """[{"start":100,"end":200,"stage":""}]""",
+                newStart = 100,
+                newEnd = 300,
+                expected = listOf(Seg(100, 300, "wake")),
+            ),
+            Case(
+                json = """[{"start":50,"end":200,"stage":"light"}]""",
+                newStart = 100,
+                newEnd = 300,
+                expected = listOf(Seg(100, 200, "light"), Seg(200, 300, "wake")),
+            ),
+        )
+
+        cases.forEach { case ->
+            val output = SleepWindowReclip.reclip(
+                case.json,
+                case.newStart,
+                case.newEnd,
+                case.newStart,
+                case.newEnd,
+            )!!
+            assertEquals(case.expected, segments(output))
+        }
+    }
+
+    @Test
     fun segmentTrimDropsAndClips() {
         val json = """
             [{"start":1000,"end":2000,"stage":"light"},


### PR DESCRIPTION
## What this PR does

Aligns Swift `SleepWindowReclip` validation with Kotlin by rejecting negative segment starts and empty stage labels before clipping.

Mirrored tests compare decoded canonical segments for both invalid forms and preserve valid clipping plus trailing-wake behavior.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- `cd Packages/StrandAnalytics && swift test --filter SleepWindowReclipTests` — 9 tests passed
- `cd android && ./gradlew :app:testFullDebugUnitTest --tests "com.noop.analytics.SleepWindowReclipTest" --no-daemon --max-workers=1 --no-parallel` — 10 tests passed

Only the focused suites were run. No manual, device, or strap testing was performed; this is deterministic JSON/analytics behavior.

## Checklist

- [ ] Swift package tests pass for any package I touched — focused suite passed; full package suite was not run
- [ ] Android unit tests pass if I touched `android/` — focused suite passed; full suite was not run
- [ ] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — not applicable
- [x] No hardcoded protocol bytes — not applicable
- [x] Follows `docs/CONTRIBUTING.md`
- [x] No generated output or secrets committed

## Related issues

Related: https://github.com/bhelm/noop/issues/42