### PR TITLE
fix(recovery): preserve signed zero in forecast clamp

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryForecast.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryForecast.swift
@@ -226,6 +226,10 @@ public enum RecoveryForecaster {
     }
 
     static func clamp(_ x: Double, _ lo: Double, _ hi: Double) -> Double {
-        Swift.min(Swift.max(x, lo), hi)
+        // Inclusive-bound equality is already in range: return x itself so Swift
+        // and Kotlin preserve the same IEEE signed-zero bit (#56).
+        if x < lo { return lo }
+        if x > hi { return hi }
+        return x
     }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryForecastTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryForecastTests.swift
@@ -169,4 +169,25 @@ final class RecoveryForecastTests: XCTestCase {
         XCTAssertEqual(RecoveryForecaster.leastSquaresSlope([1, 2, 3, 4]), 1, accuracy: 1e-9)
         XCTAssertEqual(RecoveryForecaster.leastSquaresSlope([5]), 0, accuracy: 1e-9)
     }
+
+    func testClampPreservesInputSignedZeroAtInclusiveBounds() {
+        // Cross-platform contract (#56): a value numerically equal to either bound is
+        // already in range, so clamp returns x itself and preserves x's IEEE sign bit.
+        let cases: [(x: Double, lo: Double, hi: Double)] = [
+            (+0.0, -0.0, 1.0),
+            (-0.0, +0.0, 1.0),
+            (+0.0, -1.0, -0.0),
+            (-0.0, -1.0, +0.0),
+        ]
+        for value in cases {
+            XCTAssertEqual(
+                RecoveryForecaster.clamp(value.x, value.lo, value.hi).bitPattern,
+                value.x.bitPattern
+            )
+        }
+
+        XCTAssertEqual(RecoveryForecaster.clamp(-1.01, -1.0, 1.0), -1.0)
+        XCTAssertEqual(RecoveryForecaster.clamp(0.25, -1.0, 1.0), 0.25)
+        XCTAssertEqual(RecoveryForecaster.clamp(1.01, -1.0, 1.0), 1.0)
+    }
 }

--- a/android/app/src/main/java/com/noop/analytics/RecoveryForecast.kt
+++ b/android/app/src/main/java/com/noop/analytics/RecoveryForecast.kt
@@ -238,5 +238,11 @@ object RecoveryForecaster {
         return if (den == 0.0) 0.0 else num / den
     }
 
-    internal fun clamp(x: Double, lo: Double, hi: Double): Double = min(max(x, lo), hi)
+    internal fun clamp(x: Double, lo: Double, hi: Double): Double {
+        // Inclusive-bound equality is already in range: return x itself so Swift
+        // and Kotlin preserve the same IEEE signed-zero bit (#56).
+        if (x < lo) return lo
+        if (x > hi) return hi
+        return x
+    }
 }

--- a/android/app/src/test/java/com/noop/analytics/RecoveryForecastTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RecoveryForecastTest.kt
@@ -195,4 +195,23 @@ class RecoveryForecastTest {
         assertEquals(1.0, RecoveryForecaster.leastSquaresSlope(listOf(1.0, 2.0, 3.0, 4.0)), 1e-9)
         assertEquals(0.0, RecoveryForecaster.leastSquaresSlope(listOf(5.0)), 1e-9)
     }
+
+    @Test
+    fun clampPreservesInputSignedZeroAtInclusiveBounds() {
+        // Cross-platform contract (#56): a value numerically equal to either bound is
+        // already in range, so clamp returns x itself and preserves x's IEEE sign bit.
+        val cases = listOf(
+            Triple(+0.0, -0.0, 1.0),
+            Triple(-0.0, +0.0, 1.0),
+            Triple(+0.0, -1.0, -0.0),
+            Triple(-0.0, -1.0, +0.0),
+        )
+        cases.forEach { (x, lo, hi) ->
+            assertEquals(x.toRawBits(), RecoveryForecaster.clamp(x, lo, hi).toRawBits())
+        }
+
+        assertEquals(-1.0, RecoveryForecaster.clamp(-1.01, -1.0, 1.0), 0.0)
+        assertEquals(0.25, RecoveryForecaster.clamp(0.25, -1.0, 1.0), 0.0)
+        assertEquals(1.0, RecoveryForecaster.clamp(1.01, -1.0, 1.0), 0.0)
+    }
 }


### PR DESCRIPTION
## What this PR does

Defines and implements one exact cross-platform contract for `RecoveryForecaster.clamp`: for finite ordered bounds, a value numerically equal to an inclusive bound is already in range, so clamp returns `x` itself and preserves its IEEE-754 signed-zero bit. This removes the Swift/Kotlin drift reported in bhelm/noop#56 with the minimal mirrored production change.

Mirrored tests cover all four `x = ±0.0` lower/upper boundary shapes and adjacent below/interior/above ordinary values.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- Red first on the fork baseline: the new focused Swift and Kotlin tests both failed against the original implementations on the signed-zero bit assertions.
- Clean branch created from current `origin/main` (`d347cbf668ee619dcd0850ed94bacdec461b87b9`).
- Focused Swift test passed on this upstream branch: 1 test, 0 failures.
- Focused Android test passed on this upstream branch under JDK 17 with one worker, no parallel execution, in-process Kotlin compilation, and `-Xmx1536m`.
- The equivalent fork branch passed the full `StrandAnalytics` suite (1,436 tests, 2 skipped, 0 failures) and full Android `:app:testFullDebugUnitTest`.
- Independent delta review found no P0/P1/P2 issues in the documented finite `lo <= hi` domain, and verified the fork/upstream patch IDs are identical.

## Checklist

- [ ] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`) — focused test passed here; full suite passed on the equivalent fork patch and CI will run this branch
- [ ] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`) — focused test passed here; full suite passed on the equivalent fork patch and CI will run this branch
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Addresses https://github.com/bhelm/noop/issues/56