### PR TITLE
diag(rr): pre-storage R-R census + tolerance sweep (#1008/#1118)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RrEmissionStats.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RrEmissionStats.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// PRE-STORAGE census of a decoded R-R batch (#1008/#1118 instrumentation).
+///
+/// Every existing R-R number — `rrCoverage`, `collapsedCoverage`, the `hrv diag` line — is measured
+/// AFTER the rows are stored, so it cannot distinguish the two candidate causes of the WHOOP 4.0
+/// over-count:
+///
+///   * the strap/decoder EMITS more beat-time than elapsed (a decode or protocol reading), or
+///   * the same beats are STORED twice because two ingest passes both wrote them.
+///
+/// `ratio` settles it. It is Σ(rrMs) over the batch's own wall span, computed on the decoded batch
+/// before a single row reaches SQLite: if it already sits near the ~1.7 the nightly diag reports, no
+/// storage-side de-dup can be the fix, and the defect is upstream of the database. If it sits near 1.0
+/// while the stored night still reads 1.7, the duplication is in ingest and the de-dup work is aimed
+/// correctly. Nothing in the shipped path reads any of this — instrumentation only.
+///
+/// `perSecond` characterises the shape rather than just the size: at ~69 bpm a one-second record should
+/// carry ONE interval (occasionally two, when two beats end inside the same second), so a fat 3-4 tail is
+/// what a rolling/overlapping strap buffer would look like.
+///
+/// There is deliberately NO cross-second repeat counter here. Counting an interval that reappears
+/// verbatim one second later cannot distinguish a re-sent beat from a STEADY HEART — at rest,
+/// consecutive real intervals are near-identical by definition, so such a counter reads high on
+/// perfectly clean data and answers nothing. (Written, tested, and removed when the clean-stream vector
+/// below made it report 9 "repeats" out of 10 honest beats.) `ratio` carries the signal instead: it is
+/// bounded by physics, not by resemblance.
+///
+/// Pure and framework-free. Byte-parity twin of Kotlin `RrEmissionStats`.
+public enum RrEmissionStats {
+
+    public struct Result: Equatable, Sendable {
+        /// Distinct timestamps carrying at least one interval (≈ records that reported R-R).
+        public let secondsWithRr: Int
+        /// Total intervals offered by the decoder, before any storage de-dup.
+        public let intervals: Int
+        /// Σ of every interval, in milliseconds.
+        public let sumRrMs: Int
+        /// Wall span the batch covers, inclusive, in seconds. 0 when fewer than one timestamp.
+        public let spanSec: Int
+        /// `sumRrMs / 1000 / spanSec` — beat-time per second of wall time. >1 means the batch carries
+        /// more beat-time than the clock allows, which is physically impossible and therefore an
+        /// emission or decode defect rather than a heart.
+        public let ratio: Double
+        /// Histogram of intervals-per-second: index 0 = seconds with exactly 1, 1 = exactly 2,
+        /// 2 = exactly 3, 3 = 4 or more.
+        public let perSecond: [Int]
+
+        public init(secondsWithRr: Int, intervals: Int, sumRrMs: Int, spanSec: Int,
+                    ratio: Double, perSecond: [Int]) {
+            self.secondsWithRr = secondsWithRr
+            self.intervals = intervals
+            self.sumRrMs = sumRrMs
+            self.spanSec = spanSec
+            self.ratio = ratio
+            self.perSecond = perSecond
+        }
+    }
+
+    /// Census a decoded batch. `rr` is the decoder's output order; nothing is mutated or sorted in place.
+    public static func compute(_ rr: [(ts: Int, rrMs: Int)]) -> Result {
+        guard !rr.isEmpty else {
+            return Result(secondsWithRr: 0, intervals: 0, sumRrMs: 0, spanSec: 0,
+                          ratio: 0, perSecond: [0, 0, 0, 0])
+        }
+        var bySecond: [Int: [Int]] = [:]
+        var sum = 0
+        var minTs = Int.max
+        var maxTs = Int.min
+        for r in rr {
+            bySecond[r.ts, default: []].append(r.rrMs)
+            sum += r.rrMs
+            if r.ts < minTs { minTs = r.ts }
+            if r.ts > maxTs { maxTs = r.ts }
+        }
+        // Inclusive span: a single-second batch spans 1 s, not 0, so the ratio stays finite.
+        let span = maxTs - minTs + 1
+        var hist = [0, 0, 0, 0]
+        for (_, vals) in bySecond {
+            let i = min(vals.count, 4) - 1
+            if i >= 0 { hist[i] += 1 }
+        }
+        let ratio = span > 0 ? Double(sum) / 1000.0 / Double(span) : 0
+        return Result(secondsWithRr: bySecond.count, intervals: rr.count, sumRrMs: sum,
+                      spanSec: span, ratio: ratio, perSecond: hist)
+    }
+
+    /// One compact log line. `offered`/`inserted` come from the caller: `inserted` is what the store
+    /// actually wrote after its `ON CONFLICT` key, so `offered - inserted` is how much the primary key
+    /// already absorbs — the third number needed to tell emission from ingest.
+    public static func logLine(path: String, offered: Int, inserted: Int, _ r: Result) -> String {
+        let ratio = String(format: "%.2f", r.ratio)
+        let h = r.perSecond
+        return "rr emit path=\(path) offered=\(offered) inserted=\(inserted) secs=\(r.secondsWithRr) "
+            + "sumRr=\(r.sumRrMs / 1000)s span=\(r.spanSec)s ratio=\(ratio) "
+            + "perSec[1/2/3/4+]=\(h[0])/\(h[1])/\(h[2])/\(h[3])"
+    }
+}

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RrEmissionStats.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RrEmissionStats.swift
@@ -88,11 +88,23 @@ public enum RrEmissionStats {
     /// One compact log line. `offered`/`inserted` come from the caller: `inserted` is what the store
     /// actually wrote after its `ON CONFLICT` key, so `offered - inserted` is how much the primary key
     /// already absorbs — the third number needed to tell emission from ingest.
+    ///
+    /// TWO ratios are printed because `ratio` alone can be read the wrong way round on a whole SESSION.
+    /// A session that drains a gap — the strap off the wrist, or on the charger — spans wall time that
+    /// carries no beats at all, which inflates the denominator and pulls `ratio` DOWN. That is the
+    /// dangerous direction of error here: a diluted 0.9 reads as "emission is fine" on the one number
+    /// this instrumentation exists to answer. `ratioRep` divides by the seconds that actually REPORTED
+    /// R-R instead of by the wall span, so it is immune to gaps; the two agreeing means the batch is
+    /// gapless, and `ratioRep` is the one to trust when they disagree. (`ratioRep`'s denominator can
+    /// double-count at most one second per chunk boundary when a session's counts are summed, which is
+    /// negligible against thousands of seconds — and errs the same safe way, low.)
     public static func logLine(path: String, offered: Int, inserted: Int, _ r: Result) -> String {
         let ratio = String(format: "%.2f", r.ratio)
+        let rep = r.secondsWithRr > 0 ? Double(r.sumRrMs) / 1000.0 / Double(r.secondsWithRr) : 0
         let h = r.perSecond
         return "rr emit path=\(path) offered=\(offered) inserted=\(inserted) secs=\(r.secondsWithRr) "
             + "sumRr=\(r.sumRrMs / 1000)s span=\(r.spanSec)s ratio=\(ratio) "
+            + "ratioRep=\(String(format: "%.2f", rep)) "
             + "perSec[1/2/3/4+]=\(h[0])/\(h[1])/\(h[2])/\(h[3])"
     }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrEmissionStatsTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrEmissionStatsTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// Pins the PRE-STORAGE R-R census (#1008/#1118). Its job is to tell an EMISSION defect (the decoder
+/// hands over more beat-time than the clock allows) from an INGEST one (the same beats stored twice),
+/// so the vectors are the two shapes that distinguish them.
+///
+/// `ratio` is the only sound discriminator here, and deliberately so: a cross-second repeat counter was
+/// written first and deleted, because on a resting heart consecutive intervals are near-identical, so it
+/// reported 9 "repeats" out of 10 honest beats. Physics bounds the ratio; resemblance bounds nothing.
+final class RrEmissionStatsTests: XCTestCase {
+
+    /// A physiological clean stream: 860 ms intervals laid end to end, so every moment of the span is
+    /// covered exactly once and the ratio sits at ~1.0. Note this means ~1.16 beats per second, so some
+    /// seconds legitimately carry TWO interval endings — the 2-bucket is normal, not a defect.
+    func testCleanEndToEndStreamRatioIsAboutOne() {
+        var rr: [(ts: Int, rrMs: Int)] = []
+        var tMs = 0
+        while tMs < 60_000 {                      // one minute of beats
+            tMs += 860
+            rr.append((ts: 1_000 + tMs / 1_000, rrMs: 860))
+        }
+        let r = RrEmissionStats.compute(rr)
+        XCTAssertEqual(r.intervals, 70)           // ceil(60_000 / 860): the last beat ends just past the minute
+        XCTAssertEqual(r.ratio, 1.0, accuracy: 0.05)
+        XCTAssertEqual(r.perSecond[2] + r.perSecond[3], 0, "a 60 bpm-ish heart never fills 3+ endings in one second")
+    }
+
+    /// The signature this exists to catch: the same beat-time reported twice, so the batch carries ~2x
+    /// more beat-time than the clock allows. Physically impossible, and visible BEFORE storage — which is
+    /// the whole point, because no ON CONFLICT key can undo an emission defect.
+    func testDoubledEmissionShowsAsRatioAboveOne() {
+        var rr: [(ts: Int, rrMs: Int)] = []
+        var tMs = 0
+        while tMs < 60_000 {
+            tMs += 860
+            let ts = 1_000 + tMs / 1_000
+            rr.append((ts: ts, rrMs: 860))
+            rr.append((ts: ts, rrMs: 860))        // the same beat again
+        }
+        let r = RrEmissionStats.compute(rr)
+        XCTAssertEqual(r.ratio, 2.0, accuracy: 0.1)
+        XCTAssertGreaterThan(r.perSecond[1] + r.perSecond[2] + r.perSecond[3], 0)
+    }
+
+    /// Two optical channels measuring the SAME beat land in one second ~34 ms apart: the ratio inflates
+    /// and the multi-interval buckets fill, which is how the log distinguishes this from a clean stream.
+    func testSameSecondChannelTwinsInflateTheRatio() {
+        var rr: [(ts: Int, rrMs: Int)] = []
+        for i in 0..<30 {
+            rr.append((ts: 1_000 + i, rrMs: 860))
+            rr.append((ts: 1_000 + i, rrMs: 894))   // same beat, other channel (+34 ms)
+        }
+        let r = RrEmissionStats.compute(rr)
+        XCTAssertEqual(r.perSecond, [0, 30, 0, 0])
+        XCTAssertGreaterThan(r.ratio, 1.7)
+    }
+
+    /// Empty and single-sample batches must not divide by zero; a lone second spans 1 s inclusive.
+    func testDegenerateBatches() {
+        let empty = RrEmissionStats.compute([])
+        XCTAssertEqual(empty.intervals, 0)
+        XCTAssertEqual(empty.ratio, 0)
+        XCTAssertEqual(empty.perSecond, [0, 0, 0, 0])
+
+        let one = RrEmissionStats.compute([(ts: 5, rrMs: 900)])
+        XCTAssertEqual(one.spanSec, 1)
+        XCTAssertEqual(one.ratio, 0.9, accuracy: 1e-9)
+    }
+
+    /// A 4+ second buckets into the last histogram slot rather than overflowing it.
+    func testFourOrMoreBucketsTogether() {
+        let rr = (0..<5).map { (ts: 1_000, rrMs: 200 + $0) }
+        XCTAssertEqual(RrEmissionStats.compute(rr).perSecond, [0, 0, 0, 1])
+    }
+
+    /// The log line is what a strap capture actually carries, so its shape is pinned too.
+    func testLogLineShape() {
+        let r = RrEmissionStats.compute([(ts: 10, rrMs: 800), (ts: 10, rrMs: 820), (ts: 11, rrMs: 810)])
+        let line = RrEmissionStats.logLine(path: "historical", offered: 3, inserted: 2, r)
+        XCTAssertTrue(line.hasPrefix("rr emit path=historical offered=3 inserted=2 secs=2 "), line)
+        XCTAssertTrue(line.contains("perSec[1/2/3/4+]=1/1/0/0"), line)
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrEmissionStatsTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrEmissionStatsTests.swift
@@ -81,4 +81,18 @@ final class RrEmissionStatsTests: XCTestCase {
         XCTAssertTrue(line.hasPrefix("rr emit path=historical offered=3 inserted=2 secs=2 "), line)
         XCTAssertTrue(line.contains("perSec[1/2/3/4+]=1/1/0/0"), line)
     }
+
+    /// A GAP must not read as healthy emission. Two doubled seconds an hour apart carry a 2.0 emission
+    /// defect, but the wall span between them dilutes `ratio` to almost nothing — so `ratio` alone would
+    /// report the *opposite* of the truth on exactly the session this instrumentation is meant to judge.
+    /// `ratioRep` divides by the seconds that reported and holds at ~1.6, which is the readable signal.
+    func testGapDilutesSpanRatioButNotReportingRatio() {
+        let rr = [(ts: 0, rrMs: 800), (ts: 0, rrMs: 800), (ts: 3_600, rrMs: 800), (ts: 3_600, rrMs: 800)]
+        let r = RrEmissionStats.compute(rr)
+        XCTAssertEqual(r.secondsWithRr, 2)
+        XCTAssertEqual(r.spanSec, 3_601)
+        XCTAssertLessThan(r.ratio, 0.01, "span ratio is diluted by the gap, as documented")
+        let line = RrEmissionStats.logLine(path: "historical", offered: 4, inserted: 4, r)
+        XCTAssertTrue(line.contains("ratio=0.00 ratioRep=1.60"), line)
+    }
 }

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2109,6 +2109,9 @@ public final class BLEManager: NSObject, ObservableObject {
         if let bf = backfiller,
            let summary = Backfiller.sessionSummaryLine(rows: bf.sessionRowsPersisted, motion: bf.sessionMotionRows, skinTemp: bf.sessionSkinTempRows, nights: bf.sessionNights) {
             log(summary)
+            // #1008/#1118: the pre-storage R-R census for this offload. Emitted next to the persisted
+            // tally so one line pair says what the decoder OFFERED and what the store KEPT.
+            if let rrLine = bf.sessionRrEmissionLine() { log(rrLine) }
             // #67: WHERE the rows landed + WHY (the clock ref that decoded them). A reset-RTC strap banks
             // last night into the past; this line makes the misdating self-evident in the strap log instead
             // of leaving "persisted N rows across 1 night(s)" looking like a clean sync.

--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -85,6 +85,18 @@ final class Backfiller {
     /// Per-session persistence tally — the success-side observability the log forensics flagged as the
     /// blind spot (#150): we logged FAILURES (decoded-to-0) but never SUCCESSES, so a strap log couldn't
     /// tell a banking strap from a broken one. Reset at begin(); read by BLEManager at session end to emit
+    /// #1008/#1118 PRE-STORAGE R-R census, accumulated across the session. `offered` is what the decoder
+    /// handed over; `inserted` is what survived the store's ON CONFLICT key, so the gap is how much the
+    /// primary key already absorbs. The per-second histogram sums per chunk, so a second split across two
+    /// chunks is counted in both — a rounding artifact at chunk edges only, and the ratio below (exact
+    /// sums over the exact span) is the number that decides emission-vs-ingest. Instrumentation only.
+    private(set) var sessionRrOffered = 0
+    private(set) var sessionRrInserted = 0
+    private(set) var sessionRrSumMs = 0
+    private(set) var sessionRrMinTs: Int?
+    private(set) var sessionRrMaxTs: Int?
+    private(set) var sessionRrHist = [0, 0, 0, 0]
+
     /// "persisted N rows (M with motion) across K night(s)". Nights are day-keys (ts / 86400).
     private(set) var sessionRowsPersisted = 0
     /// #42: set by `begin` when this session continues an auto-continue burst (#364) that already banked
@@ -233,6 +245,12 @@ final class Backfiller {
         chunk.removeAll(keepingCapacity: true)
         chunkOpen = true
         sessionRowsPersisted = 0
+        sessionRrOffered = 0
+        sessionRrInserted = 0
+        sessionRrSumMs = 0
+        sessionRrMinTs = nil
+        sessionRrMaxTs = nil
+        sessionRrHist = [0, 0, 0, 0]
         sessionMotionRows = 0
         sessionSkinTempRows = 0
         sessionNightKeys.removeAll(keepingCapacity: true)
@@ -303,6 +321,21 @@ final class Backfiller {
     nonisolated static func sessionSummaryLine(rows: Int, motion: Int, skinTemp: Int, nights: Int) -> String? {
         guard rows > 0 else { return nil }
         return "Backfill: session persisted \(rows) rows (\(motion) with motion, \(skinTemp) skin-temp) across \(nights) night(s)."
+    }
+
+    /// #1008/#1118: the session's PRE-STORAGE R-R census. `ratio` is beat-time per second of wall time
+    /// over the whole session — above 1.0 is physically impossible, and because it is measured on what the
+    /// DECODER produced it separates an emission/decode defect (ratio already high here) from an ingest
+    /// one (ratio ~1 here while the stored night still reads high). nil when the session banked no R-R.
+    func sessionRrEmissionLine() -> String? {
+        guard sessionRrOffered > 0, let lo = sessionRrMinTs, let hi = sessionRrMaxTs else { return nil }
+        let span = max(hi - lo + 1, 1)
+        let ratio = Double(sessionRrSumMs) / 1000.0 / Double(span)
+        let r = RrEmissionStats.Result(secondsWithRr: sessionRrHist.reduce(0, +),
+                                       intervals: sessionRrOffered, sumRrMs: sessionRrSumMs,
+                                       spanSec: span, ratio: ratio, perSecond: sessionRrHist)
+        return RrEmissionStats.logLine(path: "historical", offered: sessionRrOffered,
+                                       inserted: sessionRrInserted, r)
     }
 
     /// #67 diag: the persisted-nights DATE RANGE plus the offload's effective clock state — the two facts
@@ -592,6 +625,10 @@ final class Backfiller {
             // rare insert failure — which returns and re-sends the whole chunk next session — can't
             // leave duplicate lines in the append-only reject archive.
             let counts: (hr: Int, rr: Int, events: Int, battery: Int, spo2: Int, skinTemp: Int, resp: Int, gravity: Int)
+            // #1008/#1118: census the batch BEFORE it is stored — the only place the decoder's own
+            // emission can be measured, since every existing R-R number is taken after the ON CONFLICT key
+            // has already absorbed part of it.
+            let rrCensus = RrEmissionStats.compute(decoded.rr.map { (ts: $0.ts, rrMs: $0.rrMs) })
             do { counts = try await store.insert(decoded, deviceId: deviceId) } catch {
                 // Diag (#601): the decoded rows couldn't be written — this is the "history stalls but live HR
                 // works" class. We return WITHOUT acking so the strap keeps this chunk and re-sends it next
@@ -604,6 +641,17 @@ final class Backfiller {
             // "persisted N rows (M with motion) across K night(s)" — the win-rate signal a log never had.
             let tally = Backfiller.chunkTally(counts: counts, timestamps: decoded.gravity.map(\.ts) + decoded.hr.map(\.ts))
             sessionRowsPersisted += tally.rows
+            // #1008/#1118 census accumulation (pre-storage `offered` vs post-key `inserted`).
+            sessionRrOffered += rrCensus.intervals
+            sessionRrInserted += counts.rr
+            sessionRrSumMs += rrCensus.sumRrMs
+            if rrCensus.intervals > 0 {
+                let lo = decoded.rr.map(\.ts).min() ?? 0
+                let hi = decoded.rr.map(\.ts).max() ?? 0
+                sessionRrMinTs = min(sessionRrMinTs ?? lo, lo)
+                sessionRrMaxTs = max(sessionRrMaxTs ?? hi, hi)
+                for i in 0..<4 { sessionRrHist[i] += rrCensus.perSecond[i] }
+            }
             sessionMotionRows += tally.motion
             sessionSkinTempRows += counts.skinTemp
             sessionNightKeys.formUnion(tally.nights)

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1110,6 +1110,18 @@ final class IntelligenceEngine: ObservableObject {
                             + "rmssd40=\(ms(hDd.rmssd))ms sdnn40=\(ms(hDd.sdnn))ms meanNN40=\(ms(hDd.meanNN))ms "
                             + "| xsecN=\(xs.rrMs.count) covXsec=\(String(format: "%.2f", covXs)) "
                             + "beatAccXsec=\(String(format: "%.2f", accXs)) (1s upper bound)"
+                        // #1118 sweep: the same-second collapse at a range of tolerances, so a capture shows
+                        // WHICH tolerance the over-count actually responds to instead of only the one 40 ms
+                        // point. 34 ms is the two-optical-channel twin spacing; 0 is exact-duplicates-only.
+                        // Instrumentation, and cheap — the same pure function, no extra reads. Twin of Kotlin.
+                        let sweep = [0, 20, 34, 40, 60].map { tol -> String in
+                            let c = HRVAnalyzer.collapseOverCount(tsSec: ts, rrMs: sleepRr, rrTolMs: Double(tol))
+                            let cov = HRVAnalyzer.rrCoverage(tsSec: c.tsSec, rrMs: c.rrMs)
+                            let acc = HRVAnalyzer.beatAccurateFraction(tsSec: c.tsSec, rrMs: c.rrMs)
+                            return "t\(tol)=\(String(format: "%.2f", cov))/\(String(format: "%.2f", acc))"
+                        }.joined(separator: " ")
+                        diagLine += "\nhrv sweep day=\(res.daily.day) n=\(sleepRr.count) "
+                            + "cov/acc by same-second tol: \(sweep)"
                     }
                     hrvDiag = diagLine
                     // #1118: flag this night's HRV as over-counted (same verdict the diag logs) so the

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1113,12 +1113,24 @@ final class IntelligenceEngine: ObservableObject {
                         // #1118 sweep: the same-second collapse at a range of tolerances, so a capture shows
                         // WHICH tolerance the over-count actually responds to instead of only the one 40 ms
                         // point. 34 ms is the two-optical-channel twin spacing; 0 is exact-duplicates-only.
-                        // Instrumentation, and cheap — the same pure function, no extra reads. Twin of Kotlin.
-                        let sweep = [0, 20, 34, 40, 60].map { tol -> String in
+                        // The 0 and 40 points are NOT recomputed: `ex` and `dd` above ARE those collapses
+                        // (`collapseOverCount`'s default tolerance is 40), and each collapse sorts the night's
+                        // intervals — ~50k on an over-count night. Reusing them keeps the sweep to three extra
+                        // passes instead of five on a block that runs for EVERY night of an affected strap,
+                        // inside the per-day rescore loop #836 already had to slim down. Twin of Kotlin.
+                        let accEx = HRVAnalyzer.beatAccurateFraction(tsSec: ex.tsSec, rrMs: ex.rrMs)
+                        func sweepPoint(_ tol: Int) -> (cov: Double, acc: Double) {
                             let c = HRVAnalyzer.collapseOverCount(tsSec: ts, rrMs: sleepRr, rrTolMs: Double(tol))
-                            let cov = HRVAnalyzer.rrCoverage(tsSec: c.tsSec, rrMs: c.rrMs)
-                            let acc = HRVAnalyzer.beatAccurateFraction(tsSec: c.tsSec, rrMs: c.rrMs)
-                            return "t\(tol)=\(String(format: "%.2f", cov))/\(String(format: "%.2f", acc))"
+                            return (HRVAnalyzer.rrCoverage(tsSec: c.tsSec, rrMs: c.rrMs),
+                                    HRVAnalyzer.beatAccurateFraction(tsSec: c.tsSec, rrMs: c.rrMs))
+                        }
+                        let p20 = sweepPoint(20), p34 = sweepPoint(34), p60 = sweepPoint(60)
+                        let points: [(tol: Int, cov: Double, acc: Double)] = [
+                            (0, covEx, accEx), (20, p20.cov, p20.acc), (34, p34.cov, p34.acc),
+                            (40, covDd, accDd), (60, p60.cov, p60.acc),
+                        ]
+                        let sweep = points.map { p -> String in
+                            "t\(p.tol)=\(String(format: "%.2f", p.cov))/\(String(format: "%.2f", p.acc))"
                         }.joined(separator: " ")
                         diagLine += "\nhrv sweep day=\(res.daily.day) n=\(sleepRr.count) "
                             + "cov/acc by same-second tol: \(sweep)"

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -911,11 +911,24 @@ object IntelligenceEngine {
                     // #1118 sweep: the same-second collapse at a range of tolerances, so a capture shows
                     // WHICH tolerance the over-count actually responds to instead of only the one 40 ms
                     // point. 34 ms is the two-optical-channel twin spacing; 0 is exact-duplicates-only.
-                    // Instrumentation, and cheap — the same pure function, no extra reads.
-                    val sweep = listOf(0, 20, 34, 40, 60).joinToString(" ") { tol ->
+                    // The 0 and 40 points are NOT recomputed: `ex` and `dd` above ARE those collapses
+                    // (collapseOverCount's default tolerance is 40), and each collapse sorts the night's
+                    // intervals — ~50k on an over-count night. Reusing them keeps the sweep to three extra
+                    // passes instead of five on a block that runs for EVERY night of an affected strap.
+                    val accEx = HrvAnalyzer.beatAccurateFraction(ex.first, ex.second)
+                    fun sweepPoint(tol: Int): Pair<Double, Double> {
                         val c = HrvAnalyzer.collapseOverCount(ts, sleepRr, tol.toDouble())
-                        val cov = HrvAnalyzer.rrCoverage(c.first, c.second)
-                        val acc = HrvAnalyzer.beatAccurateFraction(c.first, c.second)
+                        return HrvAnalyzer.rrCoverage(c.first, c.second) to
+                            HrvAnalyzer.beatAccurateFraction(c.first, c.second)
+                    }
+                    val p20 = sweepPoint(20)
+                    val p34 = sweepPoint(34)
+                    val p60 = sweepPoint(60)
+                    val sweep = listOf(
+                        Triple(0, covEx, accEx), Triple(20, p20.first, p20.second),
+                        Triple(34, p34.first, p34.second), Triple(40, covDd, accDd),
+                        Triple(60, p60.first, p60.second),
+                    ).joinToString(" ") { (tol, cov, acc) ->
                         "t$tol=${String.format(java.util.Locale.US, "%.2f", cov)}/" +
                             String.format(java.util.Locale.US, "%.2f", acc)
                     }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -908,6 +908,18 @@ object IntelligenceEngine {
                         "rmssd40=${ms(hDd.rmssd)}ms sdnn40=${ms(hDd.sdnn)}ms meanNN40=${ms(hDd.meanNN)}ms " +
                         "| xsecN=${xs.second.size} covXsec=${String.format(java.util.Locale.US, "%.2f", covXs)} " +
                         "beatAccXsec=${String.format(java.util.Locale.US, "%.2f", accXs)} (1s upper bound)")
+                    // #1118 sweep: the same-second collapse at a range of tolerances, so a capture shows
+                    // WHICH tolerance the over-count actually responds to instead of only the one 40 ms
+                    // point. 34 ms is the two-optical-channel twin spacing; 0 is exact-duplicates-only.
+                    // Instrumentation, and cheap — the same pure function, no extra reads.
+                    val sweep = listOf(0, 20, 34, 40, 60).joinToString(" ") { tol ->
+                        val c = HrvAnalyzer.collapseOverCount(ts, sleepRr, tol.toDouble())
+                        val cov = HrvAnalyzer.rrCoverage(c.first, c.second)
+                        val acc = HrvAnalyzer.beatAccurateFraction(c.first, c.second)
+                        "t$tol=${String.format(java.util.Locale.US, "%.2f", cov)}/" +
+                            String.format(java.util.Locale.US, "%.2f", acc)
+                    }
+                    dayDiag("hrv sweep day=${res.daily.day} n=${sleepRr.size} cov/acc by same-second tol: $sweep")
                 }
             } else if (res.sleepSessions.isEmpty()) {
                 // #1244: no in-sleep R-R AND no detected session (past the >=200-HR gate) = the "HR tracked,

--- a/android/app/src/main/java/com/noop/analytics/RrEmissionStats.kt
+++ b/android/app/src/main/java/com/noop/analytics/RrEmissionStats.kt
@@ -72,12 +72,22 @@ object RrEmissionStats {
      * One compact log line. [offered]/[inserted] come from the caller: [inserted] is what the store
      * actually wrote after its conflict key, so `offered - inserted` is how much the primary key already
      * absorbs — the third number needed to tell emission from ingest.
+     *
+     * TWO ratios are printed because [Result.ratio] alone can be read the wrong way round on a whole
+     * SESSION. A session that drains a gap — the strap off the wrist, or on the charger — spans wall time
+     * carrying no beats at all, which inflates the denominator and pulls `ratio` DOWN. That is the
+     * dangerous direction of error: a diluted 0.9 reads as "emission is fine" on the one number this
+     * instrumentation exists to answer. `ratioRep` divides by the seconds that actually REPORTED R-R
+     * rather than by the wall span, so it is immune to gaps; the two agreeing means the batch is gapless,
+     * and `ratioRep` is the one to trust when they disagree.
      */
     fun logLine(path: String, offered: Int, inserted: Int, r: Result): String {
         val ratio = String.format(java.util.Locale.US, "%.2f", r.ratio)
+        val rep = if (r.secondsWithRr > 0) r.sumRrMs / 1000.0 / r.secondsWithRr else 0.0
         val h = r.perSecond
         return "rr emit path=$path offered=$offered inserted=$inserted secs=${r.secondsWithRr} " +
             "sumRr=${r.sumRrMs / 1000}s span=${r.spanSec}s ratio=$ratio " +
+            "ratioRep=${String.format(java.util.Locale.US, "%.2f", rep)} " +
             "perSec[1/2/3/4+]=${h[0]}/${h[1]}/${h[2]}/${h[3]}"
     }
 }

--- a/android/app/src/main/java/com/noop/analytics/RrEmissionStats.kt
+++ b/android/app/src/main/java/com/noop/analytics/RrEmissionStats.kt
@@ -1,0 +1,83 @@
+package com.noop.analytics
+
+/**
+ * PRE-STORAGE census of a decoded R-R batch (#1008/#1118 instrumentation). Byte-parity twin of Swift
+ * `RrEmissionStats`.
+ *
+ * Every existing R-R number — `rrCoverage`, `collapsedCoverage`, the `hrv diag` line — is measured
+ * AFTER the rows are stored, so it cannot distinguish the two candidate causes of the WHOOP 4.0
+ * over-count:
+ *
+ *  * the strap/decoder EMITS more beat-time than elapsed (a decode or protocol reading), or
+ *  * the same beats are STORED twice because two ingest passes both wrote them.
+ *
+ * [Result.ratio] settles it: Σ(rrMs) over the batch's own wall span, computed on the decoded batch
+ * before a single row reaches the database. Near ~1.7 already means no storage-side de-dup can be the
+ * fix and the defect is upstream of the DB; near 1.0 while the stored night still reads 1.7 means the
+ * duplication is in ingest. Nothing in the shipped path reads any of this — instrumentation only.
+ *
+ * [Result.perSecond] characterises the shape rather than the size: at ~69 bpm a one-second record should
+ * carry ONE interval (occasionally two, when two beats end inside the same second), so a fat 3-4 tail is
+ * what a rolling/overlapping strap buffer would look like.
+ *
+ * There is deliberately NO cross-second repeat counter. Counting an interval that reappears verbatim one
+ * second later cannot distinguish a re-sent beat from a STEADY HEART — at rest, consecutive real intervals
+ * are near-identical by definition, so such a counter reads high on perfectly clean data and answers
+ * nothing. [Result.ratio] carries the signal instead: it is bounded by physics, not by resemblance.
+ */
+object RrEmissionStats {
+
+    data class Result(
+        /** Distinct timestamps carrying at least one interval (≈ records that reported R-R). */
+        val secondsWithRr: Int,
+        /** Total intervals offered by the decoder, before any storage de-dup. */
+        val intervals: Int,
+        /** Σ of every interval, in milliseconds. */
+        val sumRrMs: Int,
+        /** Wall span the batch covers, inclusive, in seconds. */
+        val spanSec: Int,
+        /** Beat-time per second of wall time. >1 is physically impossible and so a defect, not a heart. */
+        val ratio: Double,
+        /** Intervals-per-second histogram: index 0 = exactly 1, 1 = 2, 2 = 3, 3 = 4 or more. */
+        val perSecond: List<Int>,
+    )
+
+    /** Census a decoded batch. [rr] is the decoder's output order; nothing is mutated or sorted in place. */
+    fun compute(rr: List<Pair<Int, Int>>): Result {
+        if (rr.isEmpty()) {
+            return Result(0, 0, 0, 0, 0.0, listOf(0, 0, 0, 0))
+        }
+        val bySecond = LinkedHashMap<Int, MutableList<Int>>()
+        var sum = 0
+        var minTs = Int.MAX_VALUE
+        var maxTs = Int.MIN_VALUE
+        for ((ts, rrMs) in rr) {
+            bySecond.getOrPut(ts) { mutableListOf() }.add(rrMs)
+            sum += rrMs
+            if (ts < minTs) minTs = ts
+            if (ts > maxTs) maxTs = ts
+        }
+        // Inclusive span: a single-second batch spans 1 s, not 0, so the ratio stays finite.
+        val span = maxTs - minTs + 1
+        val hist = mutableListOf(0, 0, 0, 0)
+        for (vals in bySecond.values) {
+            val i = minOf(vals.size, 4) - 1
+            if (i >= 0) hist[i] = hist[i] + 1
+        }
+        val ratio = if (span > 0) sum / 1000.0 / span else 0.0
+        return Result(bySecond.size, rr.size, sum, span, ratio, hist)
+    }
+
+    /**
+     * One compact log line. [offered]/[inserted] come from the caller: [inserted] is what the store
+     * actually wrote after its conflict key, so `offered - inserted` is how much the primary key already
+     * absorbs — the third number needed to tell emission from ingest.
+     */
+    fun logLine(path: String, offered: Int, inserted: Int, r: Result): String {
+        val ratio = String.format(java.util.Locale.US, "%.2f", r.ratio)
+        val h = r.perSecond
+        return "rr emit path=$path offered=$offered inserted=$inserted secs=${r.secondsWithRr} " +
+            "sumRr=${r.sumRrMs / 1000}s span=${r.spanSec}s ratio=$ratio " +
+            "perSec[1/2/3/4+]=${h[0]}/${h[1]}/${h[2]}/${h[3]}"
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -179,6 +179,18 @@ class Backfiller(
      */
     var sessionRowsPersisted = 0
         private set
+
+    /** #1008/#1118 PRE-STORAGE R-R census, accumulated across the session. Twin of the Swift fields.
+     *  `offered` is what the decoder handed over; `inserted` is what survived the store's conflict key.
+     *  The per-second histogram sums per chunk (a second split across chunks counts in both — an edge
+     *  artifact only); `ratio`, built from exact sums over the exact span, is the decisive number. */
+    var sessionRrOffered = 0
+    var sessionRrInserted = 0
+    var sessionRrSumMs = 0
+    var sessionRrMinTs: Int? = null
+    var sessionRrMaxTs: Int? = null
+    val sessionRrHist = mutableListOf(0, 0, 0, 0)
+
     /** #42: set by [begin] when this session continues an auto-continue burst (#364) that already banked
      *  rows in an earlier session, so a trim=0xFFFFFFFF END here reads as "caught up", not "no history".
      *  Without it, the fresh session's `sessionRowsPersisted` is 0 and the scary "charge to 100%" line
@@ -286,6 +298,12 @@ class Backfiller(
         this.continuedAfterRows = continuedAfterRows
         isBackfilling = true
         sessionRowsPersisted = 0
+        sessionRrOffered = 0
+        sessionRrInserted = 0
+        sessionRrSumMs = 0
+        sessionRrMinTs = null
+        sessionRrMaxTs = null
+        for (i in 0 until 4) sessionRrHist[i] = 0
         sessionMotionRows = 0
         sessionSkinTempRows = 0
         sessionNightKeys.clear()
@@ -522,12 +540,27 @@ class Backfiller(
             // later firmware-layout mapping triangulates against. (The old archive-first order was a
             // port slip: no data loss either way, but the insert-failure retry archived twice.)
             try {
+                // #1008/#1118: census the batch BEFORE it is stored — the only place the decoder's own
+                // emission can be measured, since every existing R-R number is taken after the conflict
+                // key has already absorbed part of it.
+                val rrCensus = com.noop.analytics.RrEmissionStats.compute(decoded.rr.map { it.ts.toInt() to it.rrMs })
                 val counts = repository.insert(decoded, deviceId)
                 committed = decoded
                 // Success-side observability (#150): tally what actually persisted so the session can emit
                 // "persisted N rows (M with motion) across K night(s)" — the win-rate signal we never logged.
                 val (rows, motion, nights) = chunkTally(counts, decoded.gravity.map { it.ts } + decoded.hr.map { it.ts })
                 sessionRowsPersisted += rows
+                // #1008/#1118 census accumulation (pre-storage offered vs post-key inserted).
+                sessionRrOffered += rrCensus.intervals
+                sessionRrInserted += counts.rr
+                sessionRrSumMs += rrCensus.sumRrMs
+                if (rrCensus.intervals > 0) {
+                    val lo = decoded.rr.minOf { it.ts.toInt() }
+                    val hi = decoded.rr.maxOf { it.ts.toInt() }
+                    sessionRrMinTs = minOf(sessionRrMinTs ?: lo, lo)
+                    sessionRrMaxTs = maxOf(sessionRrMaxTs ?: hi, hi)
+                    for (i in 0 until 4) sessionRrHist[i] = sessionRrHist[i] + rrCensus.perSecond[i]
+                }
                 sessionMotionRows += motion
                 sessionSkinTempRows += counts.skinTemp
                 sessionNightKeys.addAll(nights)
@@ -621,6 +654,31 @@ class Backfiller(
             chunk.clear()
             chunkOpen = false
         }
+    }
+
+
+    /**
+     * #1008/#1118: the session's PRE-STORAGE R-R census. `ratio` is beat-time per second of wall time
+     * over the whole session — above 1.0 is physically impossible, and because it is measured on what the
+     * DECODER produced it separates an emission/decode defect (ratio already high here) from an ingest one
+     * (ratio ~1 here while the stored night still reads high). Null when the session banked no R-R.
+     * Twin of Swift `sessionRrEmissionLine`.
+     */
+    fun sessionRrEmissionLine(): String? {
+        val lo = sessionRrMinTs ?: return null
+        val hi = sessionRrMaxTs ?: return null
+        if (sessionRrOffered <= 0) return null
+        val span = maxOf(hi - lo + 1, 1)
+        val ratio = sessionRrSumMs / 1000.0 / span
+        val r = com.noop.analytics.RrEmissionStats.Result(
+            secondsWithRr = sessionRrHist.sum(),
+            intervals = sessionRrOffered,
+            sumRrMs = sessionRrSumMs,
+            spanSec = span,
+            ratio = ratio,
+            perSecond = sessionRrHist.toList(),
+        )
+        return com.noop.analytics.RrEmissionStats.logLine("historical", sessionRrOffered, sessionRrInserted, r)
     }
 
     companion object {

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7467,6 +7467,9 @@ class WhoopBleClient(
             backfiller.sessionNights,
         )?.let {
             log(it)
+            // #1008/#1118: the pre-storage R-R census for this offload, next to the persisted tally so one
+            // line pair says what the decoder OFFERED and what the store KEPT. Twin of the Swift emit.
+            backfiller.sessionRrEmissionLine()?.let { rrLine -> log(rrLine) }
             // #990: fold this session's drained rows into the persisted ALL-TIME tally at the single
             // summary emit point, so the Connection readout can show install-lifetime progress beside
             // the per-session count (which resets on every reconnect). Unconditional, like the summary

--- a/android/app/src/test/java/com/noop/analytics/RrEmissionStatsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RrEmissionStatsTest.kt
@@ -1,0 +1,84 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Kotlin twin of `RrEmissionStatsTests.swift` — same vectors, same expected numbers, so the two
+ * platforms' pre-storage census cannot drift.
+ *
+ * `ratio` is the only sound discriminator here, and deliberately so: a cross-second repeat counter was
+ * written first and deleted, because on a resting heart consecutive intervals are near-identical, so it
+ * reported 9 "repeats" out of 10 honest beats. Physics bounds the ratio; resemblance bounds nothing.
+ */
+class RrEmissionStatsTest {
+
+    @Test
+    fun cleanEndToEndStreamRatioIsAboutOne() {
+        val rr = mutableListOf<Pair<Int, Int>>()
+        var tMs = 0
+        while (tMs < 60_000) {                      // one minute of beats
+            tMs += 860
+            rr.add(Pair(1_000 + tMs / 1_000, 860))
+        }
+        val r = RrEmissionStats.compute(rr)
+        assertEquals(70, r.intervals)               // ceil(60_000 / 860): the last beat ends just past the minute
+        assertEquals(1.0, r.ratio, 0.05)
+        assertEquals("a 60 bpm-ish heart never fills 3+ endings in one second",
+            0, r.perSecond[2] + r.perSecond[3])
+    }
+
+    @Test
+    fun doubledEmissionShowsAsRatioAboveOne() {
+        val rr = mutableListOf<Pair<Int, Int>>()
+        var tMs = 0
+        while (tMs < 60_000) {
+            tMs += 860
+            val ts = 1_000 + tMs / 1_000
+            rr.add(Pair(ts, 860))
+            rr.add(Pair(ts, 860))                   // the same beat again
+        }
+        val r = RrEmissionStats.compute(rr)
+        assertEquals(2.0, r.ratio, 0.1)
+        assertTrue(r.perSecond[1] + r.perSecond[2] + r.perSecond[3] > 0)
+    }
+
+    @Test
+    fun sameSecondChannelTwinsInflateTheRatio() {
+        val rr = mutableListOf<Pair<Int, Int>>()
+        for (i in 0 until 30) {
+            rr.add(Pair(1_000 + i, 860))
+            rr.add(Pair(1_000 + i, 894))            // same beat, other channel (+34 ms)
+        }
+        val r = RrEmissionStats.compute(rr)
+        assertEquals(listOf(0, 30, 0, 0), r.perSecond)
+        assertTrue(r.ratio > 1.7)
+    }
+
+    @Test
+    fun degenerateBatches() {
+        val empty = RrEmissionStats.compute(emptyList())
+        assertEquals(0, empty.intervals)
+        assertEquals(0.0, empty.ratio, 1e-9)
+        assertEquals(listOf(0, 0, 0, 0), empty.perSecond)
+
+        val one = RrEmissionStats.compute(listOf(Pair(5, 900)))
+        assertEquals(1, one.spanSec)
+        assertEquals(0.9, one.ratio, 1e-9)
+    }
+
+    @Test
+    fun fourOrMoreBucketsTogether() {
+        val rr = (0 until 5).map { Pair(1_000, 200 + it) }
+        assertEquals(listOf(0, 0, 0, 1), RrEmissionStats.compute(rr).perSecond)
+    }
+
+    @Test
+    fun logLineShape() {
+        val r = RrEmissionStats.compute(listOf(Pair(10, 800), Pair(10, 820), Pair(11, 810)))
+        val line = RrEmissionStats.logLine("historical", 3, 2, r)
+        assertTrue(line, line.startsWith("rr emit path=historical offered=3 inserted=2 secs=2 "))
+        assertTrue(line, line.contains("perSec[1/2/3/4+]=1/1/0/0"))
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/RrEmissionStatsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RrEmissionStatsTest.kt
@@ -81,4 +81,21 @@ class RrEmissionStatsTest {
         assertTrue(line, line.startsWith("rr emit path=historical offered=3 inserted=2 secs=2 "))
         assertTrue(line, line.contains("perSec[1/2/3/4+]=1/1/0/0"))
     }
+
+    /**
+     * A GAP must not read as healthy emission. Two doubled seconds an hour apart carry a 2.0 emission
+     * defect, but the wall span between them dilutes `ratio` to almost nothing — so `ratio` alone would
+     * report the OPPOSITE of the truth on exactly the session this instrumentation exists to judge.
+     * `ratioRep` divides by the seconds that reported and holds at ~1.6. Twin of the Swift vector.
+     */
+    @Test
+    fun gapDilutesSpanRatioButNotReportingRatio() {
+        val rr = listOf(Pair(0, 800), Pair(0, 800), Pair(3_600, 800), Pair(3_600, 800))
+        val r = RrEmissionStats.compute(rr)
+        assertEquals(2, r.secondsWithRr)
+        assertEquals(3_601, r.spanSec)
+        assertTrue("span ratio is diluted by the gap, as documented", r.ratio < 0.01)
+        val line = RrEmissionStats.logLine("historical", 4, 4, r)
+        assertTrue(line, line.contains("ratio=0.00 ratioRep=1.60"))
+    }
 }


### PR DESCRIPTION
**Instrumentation only** — nothing in the shipped path reads any of it.

## Why

Every existing R-R number (`rrCoverage`, `collapsedCoverage`, the `hrv diag` line) is measured **after** the rows are stored, so none of them can separate the two candidate causes of the WHOOP 4.0 over-count:

- the decoder **EMITS** more beat-time than elapsed, or
- the same beats are **STORED** twice by two ingest passes.

Eight nights of field captures from a 4.0 make that ambiguity concrete — coverage pinned at **~1.74×** every night, while exact duplicates are only ~200 out of ~50,000 intervals, and a 40 ms same-second collapse removes **57%** of the excess but leaves **1.31×** behind. The current logs cannot say which half to fix.

## What this adds

**1. `RrEmissionStats` — a PRE-storage census** (Swift + Kotlin twins, 6 pinned vectors each).
`ratio` is Σ(rrMs) over the batch's own wall span, computed **before a single row reaches the database**. Above 1.0 is physically impossible, so:

- ratio already ~1.7 there ⇒ the defect is **upstream of storage**, and no de-dup can fix it;
- ratio ~1.0 there while the stored night still reads 1.7 ⇒ the duplication is in **ingest**.

`perSecond` (intervals-per-second histogram) characterises the shape: at ~69 bpm a one-second record should carry one interval, so a fat 3–4 tail is what a rolling/overlapping strap buffer looks like.

**2. Session accumulation + emit.** Both Backfillers accumulate the census per offload session and log it beside the existing persisted-rows summary, carrying `offered` (what the decoder produced) and `inserted` (what survived the `ON CONFLICT` key) — so the line also states how much the primary key already absorbs.

```
rr emit path=historical offered=… inserted=… secs=… sumRr=…s span=…s ratio=… perSec[1/2/3/4+]=…
```

**3. `hrv sweep`** — the existing same-second collapse run at tol **0/20/34/40/60 ms**, logging coverage/beat-accuracy for each. 34 ms is the two-optical-channel twin spacing; today only the single 40 ms point is visible, which cannot show whether *any* tolerance reaches coverage ~1.0. Cheap: same pure function, no extra reads.

## Deliberately NOT included

A cross-second repeat counter. I wrote one first and deleted it: on a resting heart consecutive intervals are near-identical, so it reported **9 "repeats" out of 10 honest beats** on the clean-stream vector — it cannot distinguish a re-sent beat from a steady rhythm. Physics bounds the ratio; resemblance bounds nothing. The removal is documented in both twins so it isn't re-attempted, and the clean vector that exposed it is now a test.

## Validation

- Full Android suite **4,048 tests / 0 failures** (6 new); compile, `i18n --ci`, and doc-comment lint green.
- Swift half is package + app-target, so `swift-packages` and **app-build** are its validators.
- Byte-parity: the two `RrEmissionStats` twins share identical vectors and expected numbers.

## Next

The next 4.0 capture answers the decode-vs-ingest question outright, which is what #1118 has been missing.
