### PR TITLE
fix(workouts): carry per-session steps through every row rebuild (#1444)

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -2177,7 +2177,8 @@ final class IntelligenceEngine: ObservableObject {
             updated.append(WorkoutRow(
                 startTs: row.startTs, endTs: row.endTs, sport: row.sport, source: row.source,
                 durationS: row.durationS, energyKcal: energyKcal, avgHr: s.avgHr, maxHr: s.maxHr,
-                strain: s.strain, distanceM: row.distanceM, zonesJSON: row.zonesJSON, notes: row.notes))
+                strain: s.strain, distanceM: row.distanceM, zonesJSON: row.zonesJSON, notes: row.notes,
+                steps: row.steps))
         }
         if !updated.isEmpty { _ = try? await store.upsertWorkouts(updated, deviceId: deviceId) }
     }

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -2486,7 +2486,7 @@ final class Repository: ObservableObject {
             return WorkoutRow(startTs: row.startTs, endTs: row.endTs, sport: row.sport,
                               source: row.source, durationS: row.durationS, energyKcal: row.energyKcal,
                               avgHr: r.avg, maxHr: newMax, strain: newStrain, distanceM: row.distanceM,
-                              zonesJSON: row.zonesJSON, notes: row.notes)
+                              zonesJSON: row.zonesJSON, notes: row.notes, steps: row.steps)
         }
     }
 
@@ -2569,7 +2569,8 @@ final class Repository: ObservableObject {
         let manual = WorkoutRow(startTs: row.startTs, endTs: row.endTs, sport: trimmed, source: "manual",
                                 durationS: row.durationS, energyKcal: row.energyKcal,
                                 avgHr: row.avgHr, maxHr: row.maxHr, strain: row.strain,
-                                distanceM: row.distanceM, zonesJSON: row.zonesJSON, notes: row.notes)
+                                distanceM: row.distanceM, zonesJSON: row.zonesJSON, notes: row.notes,
+                                steps: row.steps)
         _ = try? await store.upsertWorkouts([manual], deviceId: deviceId)
         _ = try? await store.deleteWorkouts(deviceId: computedDeviceId, sport: "detected",
                                             from: row.startTs, to: row.startTs)

--- a/Strand/Data/WorkoutSource.swift
+++ b/Strand/Data/WorkoutSource.swift
@@ -320,19 +320,20 @@ enum WorkoutSource: Equatable {
 
     // MARK: - Building / preserving rows
 
-    /// Carry the captured fields the add/edit sheet does NOT expose (maxHr, strain, zonesJSON, notes)
-    /// over from the row being edited. A v1.67 live-tracked session has real captured strain/maxHr;
-    /// rebuilding the row from the sheet's inputs alone would silently wipe them on an edit. No-op for a
-    /// fresh add (`old == nil`). `distanceM` is NOW a sheet field (#1195), so it comes from the freshly
-    /// built `row` (the sheet pre-fills it from the edited row, so an untouched field preserves the
-    /// captured GPS distance and a cleared one clears it) rather than being force-carried from `old`.
+    /// Carry the captured fields the add/edit sheet does NOT expose (maxHr, strain, zonesJSON, notes,
+    /// steps) over from the row being edited. A v1.67 live-tracked session has real captured
+    /// strain/maxHr; rebuilding the row from the sheet's inputs alone would silently wipe them on an
+    /// edit. No-op for a fresh add (`old == nil`). `distanceM` is NOW a sheet field (#1195), so it comes
+    /// from the freshly built `row` (the sheet pre-fills it from the edited row, so an untouched field
+    /// preserves the captured GPS distance and a cleared one clears it) rather than being force-carried
+    /// from `old`. `steps` (#1058) has no sheet field at all, so it is carried like the others (#1444).
     static func preservingCaptured(_ row: WorkoutRow, from old: WorkoutRow?) -> WorkoutRow {
         guard let old else { return row }
         return WorkoutRow(startTs: row.startTs, endTs: row.endTs, sport: row.sport,
                           source: row.source, durationS: row.durationS,
                           energyKcal: row.energyKcal, avgHr: row.avgHr,
                           maxHr: old.maxHr, strain: old.strain, distanceM: row.distanceM,
-                          zonesJSON: old.zonesJSON, notes: old.notes)
+                          zonesJSON: old.zonesJSON, notes: old.notes, steps: old.steps)
     }
 
     /// Build a retroactive manual workout (source "manual", persisted under the strap deviceId by the

--- a/Strand/Screens/WorkoutsView.swift
+++ b/Strand/Screens/WorkoutsView.swift
@@ -1584,7 +1584,7 @@ struct WorkoutsView: View {
         WorkoutRow(startTs: row.startTs, endTs: row.endTs, sport: WorkoutSource.displaySport(row.sport),
                    source: "manual", durationS: row.durationS, energyKcal: row.energyKcal,
                    avgHr: row.avgHr, maxHr: row.maxHr, strain: row.strain, distanceM: row.distanceM,
-                   zonesJSON: row.zonesJSON, notes: row.notes)
+                   zonesJSON: row.zonesJSON, notes: row.notes, steps: row.steps)
     }
 
     /// #796 - the per-session Effort cell label: the stored 0-100 strain mapped to the user's Effort scale

--- a/StrandTests/WorkoutSourceTests.swift
+++ b/StrandTests/WorkoutSourceTests.swift
@@ -323,6 +323,17 @@ final class WorkoutSourceTests: XCTestCase {
         XCTAssertNil(WorkoutSource.preservingCaptured(cleared, from: old).distanceM)
     }
 
+    /// #1444: per-session steps (#1058) has NO sheet field, so an edit rebuilds the row without it and
+    /// the merged row used to come back with `steps` nil — silently wiping a value the user never saw
+    /// and never touched, just by renaming the sport. Kotlin twin:
+    /// `preservingCaptured_carriesStepsFromOld`.
+    func testPreservingCapturedCarriesStepsFromOld() {
+        let old = fullRow(start: 100, end: 3700, sport: "Running", source: "manual", steps: 4_200)
+        let edited = fullRow(start: 100, end: 3700, sport: "Trail Running", source: "manual")
+        XCTAssertNil(edited.steps, "the sheet cannot supply steps, so the rebuilt row starts without it")
+        XCTAssertEqual(WorkoutSource.preservingCaptured(edited, from: old).steps, 4_200)
+    }
+
     func testPreservingCapturedCarriesUnexposedFieldsOnEdit() {
         // The sheet rebuilds a row from its 5 inputs; an edit must keep the original's captured
         // maxHr/strain (a live-tracked session has real values the sheet never shows).
@@ -345,10 +356,11 @@ final class WorkoutSourceTests: XCTestCase {
 
     private func fullRow(start: Int, end: Int, sport: String, source: String,
                          avgHr: Int? = nil, kcal: Double? = nil, dist: Double? = nil,
-                         strain: Double? = nil, maxHr: Int? = nil, notes: String? = nil) -> WorkoutRow {
+                         strain: Double? = nil, maxHr: Int? = nil, notes: String? = nil,
+                         steps: Int? = nil) -> WorkoutRow {
         WorkoutRow(startTs: start, endTs: end, sport: sport, source: source,
                    durationS: Double(end - start), energyKcal: kcal, avgHr: avgHr, maxHr: maxHr,
-                   strain: strain, distanceM: dist, zonesJSON: nil, notes: notes)
+                   strain: strain, distanceM: dist, zonesJSON: nil, notes: notes, steps: steps)
     }
 
     func testFilterInactiveWhenEmptyPassesEverythingUntouched() {

--- a/android/app/src/main/java/com/noop/ui/WorkoutEditing.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutEditing.kt
@@ -327,6 +327,11 @@ object WorkoutEditing {
             zonesJSON = old.zonesJSON,
             notes = old.notes,
             routePolyline = old.routePolyline,
+            // #1444: `row` here is the sheet-built row, NOT the stored one, so copy() alone does not
+            // carry this — buildManualRow has no steps input and leaves it null. Per-session steps
+            // (#1058) is a captured field the sheet never exposes, so it is restored from `old` like
+            // the rest. Twin of Swift WorkoutSource.preservingCaptured.
+            steps = old.steps,
         )
     }
 

--- a/android/app/src/test/java/com/noop/ui/WorkoutEditingTest.kt
+++ b/android/app/src/test/java/com/noop/ui/WorkoutEditingTest.kt
@@ -378,6 +378,20 @@ class WorkoutEditingTest {
         assertNull(WorkoutEditing.preservingCaptured(cleared, old).distanceM)
     }
 
+    /**
+     * #1444: per-session steps (#1058) has NO sheet field, so buildManualRow leaves it null and copy()
+     * carries the NEW row's null rather than the stored value — copy() only protects a field when the
+     * row being copied IS the stored one. Renaming the sport silently wiped a value the user never saw
+     * and never touched. Twin of Swift `testPreservingCapturedCarriesStepsFromOld`.
+     */
+    @Test
+    fun preservingCaptured_carriesStepsFromOld() {
+        val old = row("my-whoop", 100, 3700, "Running", "manual").copy(steps = 4_200)
+        val edited = row("my-whoop", 100, 3700, "Trail Running", "manual")
+        assertNull(edited.steps)   // the sheet cannot supply steps
+        assertEquals(4_200, WorkoutEditing.preservingCaptured(edited, old).steps)
+    }
+
     @Test
     fun preservingCaptured_carriesUnexposedFieldsOnEdit() {
         val old = row("my-whoop", 100, 3700, "Workout", "manual", avgHr = 130, maxHr = 175, strain = 13.5)


### PR DESCRIPTION
Closes #1444. Follow-up to @bhelm's #1434, which fixed the first instance of this.

## The defect

`steps` (#1058) is a trailing parameter defaulted to nil/null on both platforms, so every row
construction site that predates it kept compiling unchanged and silently began writing nothing. Nothing
in the read path can distinguish "never had steps" from "had steps, then lost them".

## Swift — five sites

Swift rebuilds a `WorkoutRow` field by field, so an unlisted field is quietly defaulted:

| Site | Effect |
|---|---|
| `WorkoutSource.preservingCaptured` | The function whose entire job is carrying fields the edit sheet does not expose. **Renaming a workout's sport wiped its steps.** |
| `Repository.relabelDetected` | Re-labelling a detected bout to manual, then upserting. |
| `Repository` post-reduction reassembly | The displayed row lost steps even while stored. |
| `IntelligenceEngine` manual rescore | Rebuilt, then upserted. |
| `WorkoutsView.asManualCopy` | "Duplicate as manual" dropped it from the copy. |

## Android is NOT immune — #1444 got this wrong

I filed #1444 claiming this was a Swift-only family because the Kotlin twins use `copy()`. That is only
half true, and worth stating precisely: **`copy()` protects a field only when the row being copied IS
the stored one.** That holds for `backfillWorkoutFromDetectedBout` and `relabelDetected`, which were
always correct.

It does not hold for `WorkoutEditing.preservingCaptured`, which copies the **sheet-built** row —
`buildManualRow` has no steps input, so `copy()` faithfully carried a null and the edit wiped the stored
value exactly as Swift did. Same user-visible bug, reached by a different route.

## Tests

Mirrored regression tests on both platforms pin that an edit which cannot supply steps still returns the
stored value. The Kotlin test runs in default CI; the Swift twin is app-target, so the app-build gate
compiles it rather than executing it.

## Verification

- Android 4,065 tests / 0 failures (`--rerun-tasks`, new test confirmed present by name)
- i18n and doc-comment gates clean
- app-build dispatched for the app-target Swift, which no default CI compiles
- No schema, migration or stored-format change: this stops a field being overwritten with null, and does
  not alter any value that survived