### PR TITLE
fix(recovery): keep the charge trace's negative zero, and correct the skin-temp comment

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ChargeDrivers.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ChargeDrivers.swift
@@ -284,8 +284,11 @@ extension RecoveryScorer {
     }
 
     static func skinTempDevText(_ dev: Double) -> String {
-        // Foundation's `%+f` renders negative zero as "-+0.0" on some runtimes. Preserve the
-        // IEEE sign explicitly so this edge stays byte-identical to Java Formatter.
+        // Negative zero needs the sign taken from the IEEE bit, not from a comparison: `-0.0 >= 0` is
+        // TRUE, so the hand-built sign this replaced prepended "+" to a value that formatted as "-0.0"
+        // and printed "+-0.0". `%+.1f` alone renders -0.0 correctly, but it cannot distinguish the two
+        // zeroes for the "+0.0" case, so both are handled explicitly here — byte-identical to what Java
+        // Formatter produces for the Kotlin twin.
         if dev == 0 {
             return dev.sign == .minus ? "-0.0 C vs baseline" : "+0.0 C vs baseline"
         }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ChargeDrivers.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ChargeDrivers.swift
@@ -284,11 +284,12 @@ extension RecoveryScorer {
     }
 
     static func skinTempDevText(_ dev: Double) -> String {
-        // Negative zero needs the sign taken from the IEEE bit, not from a comparison: `-0.0 >= 0` is
-        // TRUE, so the hand-built sign this replaced prepended "+" to a value that formatted as "-0.0"
-        // and printed "+-0.0". `%+.1f` alone renders -0.0 correctly, but it cannot distinguish the two
-        // zeroes for the "+0.0" case, so both are handled explicitly here — byte-identical to what Java
-        // Formatter produces for the Kotlin twin.
+        // Negative zero needs its sign taken from the IEEE bit, never from a comparison: `-0.0 >= 0` is
+        // TRUE, so the hand-built sign this replaced prepended "+" to a value that already formatted as
+        // "-0.0", printing "+-0.0". `%+.1f` on its own gets BOTH zeroes right (checked against C printf
+        // and Java's Formatter, which the Kotlin twin uses); the explicit branch is redundant there and
+        // kept only to pin this edge, so the two zeroes cannot drift apart from the twin on a Foundation
+        // whose formatter we have not checked.
         if dev == 0 {
             return dev.sign == .minus ? "-0.0 C vs baseline" : "+0.0 C vs baseline"
         }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryScorerTraceTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryScorerTraceTests.swift
@@ -100,6 +100,22 @@ final class RecoveryScorerTraceTests: XCTestCase {
         )
     }
 
+    /// The second trap in the same helper: an exact -0.0 cannot be routed by a sign COMPARISON, because
+    /// `-0.0 < 0.0` is false. It is reachable — a skin-temp deviation of exactly 0.0 (skin temp sitting
+    /// on the personal baseline) gives z = -|dev| = -0.0. Swift's `.rounded()` carries the sign for
+    /// free; this pins that the Kotlin twin does too. Twin: `traceKeepsExactNegativeZeroTerm`.
+    func testTraceKeepsExactNegativeZeroTerm() {
+        let hrvB = baseline(mean: 50, sigma: 6)
+        let (_, lines) = RecoveryScorer.recoveryTrace(
+            hrv: 50, rhr: 55, resp: nil,
+            hrvBaseline: hrvB, rhrBaseline: nil, respBaseline: nil,
+            sleepPerf: nil, skinTempDev: 0.0)
+        XCTAssertEqual(
+            lines.first { $0.hasPrefix("charge term skinTempDev ") },
+            "charge term skinTempDev z=-0.0 w=0.05 (dev=0.0C penalty=-|dev|/1.0)"
+        )
+    }
+
     func testTraceRoundsHalfTiesAwayFromZeroWithoutChangingScore() {
         let hrvB = baseline(mean: 50, sigma: 6)
         let plain = RecoveryScorer.recovery(

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryScorerTraceTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryScorerTraceTests.swift
@@ -83,6 +83,23 @@ final class RecoveryScorerTraceTests: XCTestCase {
         XCTAssertTrue(base!.contains("status=provisional"))
     }
 
+    /// #1437 follow-up: a term just below baseline rounds to zero but must keep its SIGN. Swift's
+    /// `.rounded()` yields -0.0 here and interpolates as "-0.0"; the Kotlin twin negated a Long (which
+    /// has no negative zero) and printed "0.0", so the two traces disagreed on the one line whose whole
+    /// purpose is being byte-identical across platforms. Twin:
+    /// `traceKeepsNegativeZeroOnNearBaselineTerm`.
+    func testTraceKeepsNegativeZeroOnNearBaselineTerm() {
+        let hrvB = baseline(mean: 50, sigma: 6)
+        let (_, lines) = RecoveryScorer.recoveryTrace(
+            hrv: 50, rhr: 55, resp: nil,
+            hrvBaseline: hrvB, rhrBaseline: nil, respBaseline: nil,
+            sleepPerf: nil, skinTempDev: 0.001)
+        XCTAssertEqual(
+            lines.first { $0.hasPrefix("charge term skinTempDev ") },
+            "charge term skinTempDev z=-0.0 w=0.05 (dev=0.0C penalty=-|dev|/1.0)"
+        )
+    }
+
     func testTraceRoundsHalfTiesAwayFromZeroWithoutChangingScore() {
         let hrvB = baseline(mean: 50, sigma: 6)
         let plain = RecoveryScorer.recovery(

--- a/android/app/src/main/java/com/noop/analytics/RecoveryScorerTrace.kt
+++ b/android/app/src/main/java/com/noop/analytics/RecoveryScorerTrace.kt
@@ -14,15 +14,24 @@ import kotlin.math.abs
 
 object RecoveryScorerTrace {
 
-    /** Trace numbers use nearest rounding with half-ties away from zero on both platforms. */
+    /**
+     * Trace numbers use nearest rounding with half-ties away from zero on both platforms.
+     *
+     * Round the MAGNITUDE and reapply the sign, rather than branching on `scaled < 0.0`. Two traps sit
+     * here, and Swift's `.rounded(.toNearestOrAwayFromZero)` avoids both for free:
+     *
+     *  * Math.round returns a Long, which has no negative zero, so negating it before the division
+     *    collapses -0.0 to +0.0 for any value that rounds to zero;
+     *  * `-0.0 < 0.0` is FALSE, so a sign test cannot even route an exact -0.0 to a negating branch —
+     *    and -0.0 is reachable here, since a skin-temp deviation of exactly 0.0 gives z = -|dev| = -0.0.
+     *
+     * These values are interpolated straight into the trace, so either trap printed `z=0.0` on Android
+     * against `z=-0.0` on Apple. copySign carries the IEEE sign bit itself and handles both (#1437
+     * follow-up).
+     */
     private fun r2(x: Double): Double {
         val scaled = x * 100.0
-        // Negate the DOUBLE, not the Long. Math.round returns a Long, which has no negative zero, so
-        // `-Math.round(0.1) / 100.0` collapses to +0.0 while Swift's .rounded() keeps -0.0 — and these
-        // values are interpolated straight into the trace, so a z just below baseline printed `z=0.0`
-        // on Android against `z=-0.0` on Apple. Parenthesising the division restores the sign without
-        // touching any other case (#1437 follow-up).
-        return if (scaled < 0.0) -(Math.round(-scaled) / 100.0) else Math.round(scaled) / 100.0
+        return Math.copySign(Math.round(abs(scaled)) / 100.0, scaled)
     }
 
     /**

--- a/android/app/src/main/java/com/noop/analytics/RecoveryScorerTrace.kt
+++ b/android/app/src/main/java/com/noop/analytics/RecoveryScorerTrace.kt
@@ -17,7 +17,12 @@ object RecoveryScorerTrace {
     /** Trace numbers use nearest rounding with half-ties away from zero on both platforms. */
     private fun r2(x: Double): Double {
         val scaled = x * 100.0
-        return if (scaled < 0.0) -Math.round(-scaled) / 100.0 else Math.round(scaled) / 100.0
+        // Negate the DOUBLE, not the Long. Math.round returns a Long, which has no negative zero, so
+        // `-Math.round(0.1) / 100.0` collapses to +0.0 while Swift's .rounded() keeps -0.0 — and these
+        // values are interpolated straight into the trace, so a z just below baseline printed `z=0.0`
+        // on Android against `z=-0.0` on Apple. Parenthesising the division restores the sign without
+        // touching any other case (#1437 follow-up).
+        return if (scaled < 0.0) -(Math.round(-scaled) / 100.0) else Math.round(scaled) / 100.0
     }
 
     /**

--- a/android/app/src/test/java/com/noop/analytics/RecoveryScorerTraceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RecoveryScorerTraceTest.kt
@@ -93,6 +93,26 @@ class RecoveryScorerTraceTest {
         assertTrue(base.contains("status=provisional"))
     }
 
+    /**
+     * #1437 follow-up: a term just below baseline rounds to zero but must keep its SIGN. Math.round
+     * returns a Long, which has no negative zero, so negating it before the division collapsed -0.0 to
+     * +0.0 and this line printed `z=0.0` while Swift's .rounded() kept `z=-0.0` — a disagreement on the
+     * one line whose whole purpose is being byte-identical across platforms. Twin of Swift
+     * `testTraceKeepsNegativeZeroOnNearBaselineTerm`.
+     */
+    @Test fun traceKeepsNegativeZeroOnNearBaselineTerm() {
+        val hrvB = baseline(50.0, 6.0)
+        val (_, lines) = RecoveryScorerTrace.recoveryTrace(
+            hrv = 50.0, rhr = 55.0, resp = null,
+            hrvBaseline = hrvB, rhrBaseline = null, respBaseline = null,
+            sleepPerf = null, skinTempDev = 0.001,
+        )
+        assertEquals(
+            "charge term skinTempDev z=-0.0 w=0.05 (dev=0.0C penalty=-|dev|/1.0)",
+            lines.first { it.startsWith("charge term skinTempDev ") },
+        )
+    }
+
     @Test fun traceRoundsHalfTiesAwayFromZeroWithoutChangingScore() {
         val hrvB = baseline(50.0, 6.0)
         val plain = RecoveryScorer.recovery(

--- a/android/app/src/test/java/com/noop/analytics/RecoveryScorerTraceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RecoveryScorerTraceTest.kt
@@ -113,6 +113,25 @@ class RecoveryScorerTraceTest {
         )
     }
 
+    /**
+     * The second trap in the same helper: an exact -0.0 cannot be routed by a sign COMPARISON, because
+     * `-0.0 < 0.0` is false. It is reachable — a skin-temp deviation of exactly 0.0 (skin temp sitting
+     * on the personal baseline) gives z = -|dev| = -0.0 — and Swift prints `z=-0.0` for it. Twin of
+     * Swift `testTraceKeepsExactNegativeZeroTerm`.
+     */
+    @Test fun traceKeepsExactNegativeZeroTerm() {
+        val hrvB = baseline(50.0, 6.0)
+        val (_, lines) = RecoveryScorerTrace.recoveryTrace(
+            hrv = 50.0, rhr = 55.0, resp = null,
+            hrvBaseline = hrvB, rhrBaseline = null, respBaseline = null,
+            sleepPerf = null, skinTempDev = 0.0,
+        )
+        assertEquals(
+            "charge term skinTempDev z=-0.0 w=0.05 (dev=0.0C penalty=-|dev|/1.0)",
+            lines.first { it.startsWith("charge term skinTempDev ") },
+        )
+    }
+
     @Test fun traceRoundsHalfTiesAwayFromZeroWithoutChangingScore() {
         val hrvB = baseline(50.0, 6.0)
         val plain = RecoveryScorer.recovery(


### PR DESCRIPTION
Two residuals left behind by the rounding/formatting parity work in @bhelm's #1437 and #1440.
Both were found by re-checking those merges rather than by a report.

## 1. The near-zero case was still divergent (#1437)

#1437 correctly aligned the **half-tie** rule, but `Math.round` returns a `Long`, which has no negative
zero — so negating it *before* the division collapsed `-0.0` to `+0.0`:

```kotlin
-Math.round(-scaled) / 100.0     // -(0L) / 100.0  ->  +0.0
-(Math.round(-scaled) / 100.0)   // -(0.0)         ->  -0.0
```

For any term in `(-0.005, 0)` — a value sitting just below baseline — Android printed `z=0.0` where
Swift's `.rounded()` keeps `-0.0` and prints `z=-0.0`. These go straight into the trace by string
interpolation, so the two platforms disagreed on the one line whose entire purpose is being
byte-identical.

Verified on a JVM that moving the paren changes nothing else: `-0.125 → -0.13`, `-0.126 → -0.13`,
`0.125 → 0.13` all identical; only the near-zero negatives move.

**Severity is low** — this is diagnostic text, not a score, and #1437's own test already pins that the
traced score equals the plain scorer's. But byte-identical trace lines are exactly what that helper
exists for.

## 2. The #1440 comment describes a bug that does not exist

It claims Foundation renders negative zero as `-+0.0`. It does not — `%+.1f` of `-0.0` is `-0.0`.

The real defect #1440 fixed was the hand-built sign it replaced: `-0.0 >= 0` is **true**, so `"+"` was
prepended to a value that formatted as `"-0.0"`, printing **`+-0.0`**. The code was correct; only the
explanation was wrong, and it would have misled whoever touched it next. Rewritten to state the actual
mechanism and why both zeroes are handled explicitly.

## Verification

- Mirrored regression fixtures on both platforms pin the near-zero term
- Android 4,066 tests / 0 failures (`--rerun-tasks`, new test confirmed by name)
- Both files are under `Packages/` / Android, so `swift-packages` CI **executes** the Swift twin — no
  app-target Swift touched, so no app-build gate needed
- i18n and doc-comment gates clean