### PR TITLE
fix(hrv): make the windowed rMSSD gap-aware, like the nightly one already is (#1448)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -363,9 +363,18 @@ public enum HRVAnalyzer {
             if stepSec > 0, let last = lastEmitTs, edgeTs - last < stepSec { continue }
             // Clean the window's raw R-R values with the shared range + Malik ectopic pipeline, then
             // require enough survivors before trusting a windowed rMSSD.
+            //
+            // #1448: GAP-AWARE, exactly as the nightly `analyze` above already is. Dropping a beat joins
+            // two intervals that were never adjacent, and their difference is a splice rather than a
+            // physiological delta — the spurious large delta this analyzer's gap-aware pair (#204/#195)
+            // exists to exclude. `cleaned.nn` is byte-identical to `cleanRR` over the same input, so the
+            // survivor gate is unchanged, and `rmssdGapAware` equals `rmssdRaw` on a window with no gaps:
+            // only windows that actually lost a beat move. A window whose survivors share NO adjacent
+            // pair now emits nothing rather than a number built entirely from splices.
             let windowRaw = sorted[left...right].map { Double($0.rrMs) }
-            let clean = cleanRR(windowRaw)
-            guard clean.count >= minBeatsPerWindow, let r = rmssdRaw(clean) else { continue }
+            let cleaned = cleanRRGapAware(windowRaw)
+            guard cleaned.nn.count >= minBeatsPerWindow,
+                  let r = rmssdGapAware(cleaned.nn, cleaned.contiguous) else { continue }
             out.append(RollingRmssdPoint(ts: edgeTs, rmssd: r))
             lastEmitTs = edgeTs
         }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerTests.swift
@@ -156,6 +156,32 @@ final class HRVAnalyzerTests: XCTestCase {
         for p in pts { XCTAssertEqual(p.rmssd, 0.0, accuracy: 1e-9, "the 1400 ms artifact must be filtered, never spiking a window") }
     }
 
+    /// #1448: a difference that STRADDLES a dropped beat is a splice, not a physiological delta, and the
+    /// nightly `analyze` already excludes it via the gap-aware pair. The rolling trace must too. The
+    /// 2400 ms beat is out of range and removed, joining a 1000 ms run to a 1150 ms run that were never
+    /// adjacent; counting that 150 ms jump yields 50.0 ms of "variability" invented entirely by the
+    /// filter. Kotlin twin: `excludesDifferencesStraddlingADroppedBeat`.
+    func testRollingRmssdExcludesDifferencesStraddlingADroppedBeat() {
+        let raw = [1000, 1000, 1000, 1000, 1000, 2400, 1150, 1150, 1150, 1150, 1150]
+        let rr = raw.enumerated().map { RRInterval(ts: $0.offset, rrMs: $0.element) }
+        let pts = HRVAnalyzer.rollingRmssd(rr: rr, windowSec: 300, stepSec: 0, minBeatsPerWindow: 8)
+        XCTAssertFalse(pts.isEmpty)
+        // Ten survivors, every counted pair identical: the only non-zero difference was the splice.
+        XCTAssertEqual(pts.last!.rmssd, 0.0, accuracy: 1e-9)
+    }
+
+    /// #1448 control: a window with NO dropped beat must be byte-identical to the old behaviour, so this
+    /// is not a numbers-move for clean data. Same two runs without the out-of-range beat between them —
+    /// the 1000 → 1150 step is now a REAL adjacent difference and is counted, giving sqrt(150²/9) = 50.
+    /// Kotlin twin: `gaplessWindowIsUnchanged`.
+    func testRollingRmssdGaplessWindowIsUnchanged() {
+        let raw = [1000, 1000, 1000, 1000, 1000, 1150, 1150, 1150, 1150, 1150]
+        let rr = raw.enumerated().map { RRInterval(ts: $0.offset, rrMs: $0.element) }
+        let pts = HRVAnalyzer.rollingRmssd(rr: rr, windowSec: 300, stepSec: 0, minBeatsPerWindow: 8)
+        XCTAssertFalse(pts.isEmpty)
+        XCTAssertEqual(pts.last!.rmssd, 50.0, accuracy: 1e-9)
+    }
+
     func testRollingRmssdSparseSeriesEmitsNothing() {
         // Fewer beats than minBeatsPerWindow → no point at all (honest absence, no fabricated value).
         let rr = (0..<5).map { RRInterval(ts: 3000 + $0, rrMs: 800) }

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -716,11 +716,19 @@ object HrvAnalyzer {
             if (stepSec > 0 && last != null && tEnd - last < stepSec) continue
             // Clean this raw window in place. Timestamps stay on the samples used to define the window,
             // so no value-based matching back to timestamps is needed after cleaning.
-            val clean = cleanRR(sorted.subList(lo, hi + 1).map { it.rrMs.toDouble() })
+            //
+            // #1448: GAP-AWARE, exactly as the nightly [analyze] above already is. Dropping a beat joins
+            // two intervals that were never adjacent, and their difference is a splice rather than a
+            // physiological delta — the spurious large delta this analyzer's gap-aware pair exists to
+            // exclude. [CleanSeries.nn] is byte-identical to [cleanRR] over the same input, so the
+            // survivor gate is unchanged, and [rmssdGapAware] equals [rmssdRaw] on a window with no gaps:
+            // only windows that actually lost a beat move. A window whose survivors share NO adjacent
+            // pair now emits nothing rather than a number built entirely from splices.
+            val cleaned = cleanRRGapAware(sorted.subList(lo, hi + 1).map { it.rrMs.toDouble() })
             // A window with too few clean beats is a noisy spike, not a trustworthy rMSSD — require
             // [minBeatsPerWindow] survivors (#1035), matching the Swift HRVAnalyzer.rollingRmssd default (8).
-            if (clean.size < minBeatsPerWindow) continue
-            val r = rmssdRaw(clean) ?: continue
+            if (cleaned.nn.size < minBeatsPerWindow) continue
+            val r = rmssdGapAware(cleaned.nn, cleaned.contiguous) ?: continue
             out.add(tEnd to r)
             lastEmitTs = tEnd
         }

--- a/android/app/src/test/java/com/noop/analytics/HrvAnalyzerRollingTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvAnalyzerRollingTest.kt
@@ -61,6 +61,36 @@ class HrvAnalyzerRollingTest {
         }
     }
 
+    /**
+     * #1448: a difference that STRADDLES a dropped beat is a splice, not a physiological delta, and the
+     * nightly [HrvAnalyzer.analyze] already excludes it via the gap-aware pair. The rolling trace must
+     * too. The 2400 ms beat is out of range and removed, joining a 1000 ms run to a 1150 ms run that were
+     * never adjacent; counting that 150 ms jump yields 50.0 ms of "variability" invented entirely by the
+     * filter. Twin of Swift `testRollingRmssdExcludesDifferencesStraddlingADroppedBeat`.
+     */
+    @Test fun excludesDifferencesStraddlingADroppedBeat() {
+        val raw = listOf(1000, 1000, 1000, 1000, 1000, 2400, 1150, 1150, 1150, 1150, 1150)
+        val series = raw.mapIndexed { i, ms -> rr(i.toLong(), ms) }
+        val out = HrvAnalyzer.rollingRmssd(series, windowSec = 300, stepSec = 0, minBeatsPerWindow = 8)
+        assertTrue(out.isNotEmpty())
+        // Ten survivors, every counted pair identical: the only non-zero difference was the splice.
+        assertEquals(0.0, out.last().second, 1e-9)
+    }
+
+    /**
+     * #1448 control: a window with NO dropped beat must be byte-identical to the old behaviour, so this
+     * is not a numbers-move for clean data. Same two runs, without the out-of-range beat between them —
+     * the 1000 -> 1150 step is now a REAL adjacent difference and is counted, giving sqrt(150^2/9) = 50.
+     * Twin of Swift `testRollingRmssdGaplessWindowIsUnchanged`.
+     */
+    @Test fun gaplessWindowIsUnchanged() {
+        val raw = listOf(1000, 1000, 1000, 1000, 1000, 1150, 1150, 1150, 1150, 1150)
+        val series = raw.mapIndexed { i, ms -> rr(i.toLong(), ms) }
+        val out = HrvAnalyzer.rollingRmssd(series, windowSec = 300, stepSec = 0, minBeatsPerWindow = 8)
+        assertTrue(out.isNotEmpty())
+        assertEquals(50.0, out.last().second, 1e-9)
+    }
+
     @Test fun rangeFilterDropsOutOfRangeBeatsFromWindows() {
         // Inject a physiologically-impossible 50 ms RR between clean beats. It must be range-filtered out,
         // so the rMSSD never sees the huge artifact jump (which would spike a raw-RR plot).


### PR DESCRIPTION
Closes #1448.

## The defect

The Deep Timeline's windowed rMSSD took successive differences **across beats the artifact filter had
removed**. Dropping a beat joins two intervals that were never adjacent, and their difference is a
splice, not a physiological delta — the spurious large delta this analyzer's gap-aware pair (#204/#195)
exists to exclude.

The nightly `analyze()` already used `cleanRRGapAware` + `rmssdGapAware`. `rollingRmssd` used
`cleanRR` + `rmssdRaw` **three lines away in the same file** — on both platforms.

| | Swift | Kotlin |
|---|---|---|
| nightly `analyze` | gap-aware ✅ | gap-aware ✅ |
| `rollingRmssd` | raw ❌ | raw ❌ |

The twins agreed with each other while both were wrong, which is exactly why no parity check ever
surfaced it. It bites hardest on the messiest data — on a WHOOP 4.0 that is most of it (#1008) — and the
trace exists specifically to be an *honest* windowed rMSSD (#803) rather than the raw-interval chart it
replaced.

## Why this stays narrow

- `CleanSeries.nn` is documented as **byte-identical to `cleanRR`** over the same input, so the
  `minBeatsPerWindow` survivor gate does not move.
- `rmssdGapAware` is **identical to `rmssdRaw` when there are no gaps**, so a clean window is
  unchanged. Only windows that actually lost a beat move.

**The one visible consequence:** a window whose survivors share *no* adjacent pair now emits nothing
rather than a number assembled entirely from splices. That is honest absence, and consistent with the
existing sparse-window gate that already prefers no point over a noisy one.

## Tests

Mirrored fixtures per platform, built on the **range** filter so the drop is deterministic rather than
depending on Malik's neighbour median:

- five 1000 ms beats, an out-of-range 2400 ms beat, five 1150 ms beats → the 150 ms step is pure splice,
  and the emitted value goes from a filter-invented **50.0 → 0.0**
- **the control is the important half**: the same two runs with no beat between them still read exactly
  **50.0**, proving this is not a numbers-move for clean data

## Verification

- Android **4,070 tests / 0 failures** (`--rerun-tasks`, both new vectors confirmed by name)
- i18n and doc-comment gates clean
- Both changed files sit under `Packages/` and Android, so `swift-packages` **executes** the Swift twin
  — no app-target Swift touched, so no app-build gate needed
- Not device-tested: this is pure analytics with no BLE path, and the fixtures cover it