### PR TITLE
fix(oura): restore the ring's own breath rate as dailyMetric.respRateBpm

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/EventTags.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/EventTags.swift
@@ -94,9 +94,7 @@ public enum OuraEventTag: UInt8, Sendable, CaseIterable, Codable {
              // ([open_ring]); NOOP's own captures confirm the layout's declared invariants and the
              // fixed-point scales. Tier B on DECODE PROVENANCE — third-party names, not Oura
              // documentation — not on doubt that the ring measures respiration: `breath` is the ring's
-             // own value read off the wire. It is INSTRUMENTATION — stored as a `respSample` row and shown
-             // on the respiration track, but NOT scored: `dailyMetric.respRateBpm` is untouched (see
-             // OuraSleepPeriodInfo).
+             // own value read off the wire, and it feeds respRateBpm (see OuraSleepPeriodInfo).
              .sleepPeriodInfo,
              // #287: 0x71 green_ibi_and_amp is NOT corpus-verified — there is no captured 0x71 fixture,
              // and OURA_PROTOCOL.md §6.2 documents a DIFFERENT layout (5 IBI deltas + 6 amplitudes,

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
@@ -444,11 +444,11 @@ public final class OuraDriver {
             // third-party layout ([open_ring]) whose field NAMES are what our own §6.12 was missing, and
             // whose declared invariants our captures uphold. Still Tier B - only reached behind
             // allowTierB (gated above). ONE field of it is durable: OuraStreamMapping maps `breathsPerMin`
-            // to a respSample row under the ring's OWN deviceId, shown on the respiration track. It is NOT
-            // scored: `dailyMetric.respRateBpm` is untouched (it stays the RSA estimate), and
-            // `OuraRespScale.forScoring` refuses the ring's rows at EVERY scoring read — staging included,
-            // because that path reads the stream as a ~1 Hz raw ADC waveform and a per-window rate is the
-            // wrong shape for a peak detector. `averageHrBpm` and every other field
+            // to a respSample row under the ring's OWN deviceId, and on a ring night AnalyticsEngine takes
+            // the night's median of those rows as dailyMetric.respRateBpm (the ring measures it; NOOP does
+            // not derive it). It is still refused at the STAGING read by provenance
+            // (`OuraRespScale.forScoring`) - that path reads the stream as a ~1 Hz raw ADC waveform and a
+            // per-window rate is the wrong shape for a peak detector. `averageHrBpm` and every other field
             // stay diagnostic-only - in particular the HR must not join the beat-derived series at a
             // different cadence.
             guard let info = OuraDecoders.decodeSleepPeriodInfo(record) else { return [] }

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
@@ -351,8 +351,8 @@ public struct OuraRealStepsFields: Equatable, Sendable, Codable {
 /// the wire — it is not a signal NOOP derives from raw sensor data. The #194 rule is written for the
 /// opposite case (PPG→HR autocorrelation, RSA-from-R-R: methods where NOOP invents the number and can
 /// manufacture a peak that looks physiological), so what has to be right here is the DECODE, which is
-/// what the structural verification above establishes. On decode provenance it has the same standing as
-/// the ring's own SleepNet hypnogram, which NOOP already persists (#773 / #877).
+/// what the structural verification above establishes. Same standing as the ring's own SleepNet
+/// hypnogram, which NOOP already persists and scores from (#773 / #877).
 ///
 /// Independent support that byte 4 is the quantity Oura's own app calls respiratory rate: these
 /// records median 14.75/min against the SAME wearer's 851-night Oura app export at 15.250 (IQR
@@ -366,16 +366,15 @@ public struct OuraRealStepsFields: Equatable, Sendable, Codable {
 /// documentation — a decode-provenance caveat, not a doubt about whether the ring measures respiration.
 ///
 /// `OuraStreamMapping` maps `breathsPerMin` — and nothing else from this record — to a `respSample` row
-/// in milli-bpm under the ring's own deviceId, as INSTRUMENTATION: the row is stored and plotted on the
-/// respiration track beside the incumbent, and NOTHING scores from it. In particular nothing writes
-/// `dailyMetric.respRateBpm` from it — that is the scored slot (recovery's respiration term, the
-/// illness signal), and the same measurements that make this decode believable also place it AT the
-/// vendor ceiling rather than past it (r = +0.680 is what Oura's OWN app manages against WHOOP), which
-/// is precisely the case CLAUDE.md's #194 rule says to instrument rather than make the default. It also
-/// never reaches the sleep STAGER (`OuraRespScale.forScoring`): that stream is read there as a ~1 Hz raw
-/// ADC waveform and a per-window rate is the wrong shape for a peak detector, however good the rate.
-/// `averageHrBpm` stays diagnostic-only: it must not join the beat-derived HR series at a different
-/// cadence and a different provenance.
+/// in milli-bpm under the ring's own deviceId, and `AnalyticsEngine` takes the night's median of those
+/// rows as `dailyMetric.respRateBpm`: on a ring night that replaces an RSA-from-banked-R-R estimate
+/// which carries no breathing information at all (shuffling the night returns the same 13.3333 bpm).
+/// The baseline that value feeds is scoped to the current device era (`Baselines.deviceEraEpoch`, #459)
+/// so a strap switch — WHOOP reads ~16.1, the ring ~14.6 — is not folded into one 28-day mean and read
+/// as physiology. It still never reaches the sleep STAGER (`OuraRespScale.forScoring`): that stream is
+/// read there as a ~1 Hz raw ADC waveform and a per-window rate is the wrong shape for a peak detector,
+/// however good the rate. `averageHrBpm` stays diagnostic-only: it must not join the beat-derived HR
+/// series at a different cadence and a different provenance.
 ///
 /// `mzci` / `dzci` keep the source's opaque names deliberately — we do not know what they measure, and
 /// inventing a friendlier name would assert an interpretation the evidence does not support.

--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraEvents.swift
@@ -449,9 +449,8 @@ public enum OuraEvent: Equatable, Sendable {
     /// `OuraSleepPeriodInfo` doc) - split out of the raw-bytes `.tierB` wrapper for the same reason
     /// `.activityInfo` was: a cited third-party layout worth surfacing as real numbers instead of hex.
     /// Same gate (`allowTierB`); its `breathsPerMin` — alone among the record's fields — is mapped to a
-    /// durable `respSample` row and shown on the respiration track. It is NOT scored: `dailyMetric.respRateBpm`
-    /// is untouched, and `OuraRespScale.forScoring` refuses the ring's rows at every scoring read (see the
-    /// type doc). Every other field of the record stays diagnostic-only.
+    /// durable `respSample` row and, on a ring night, supplies `dailyMetric.respRateBpm` (see the type
+    /// doc). Every other field of the record stays diagnostic-only.
     case sleepPeriodInfo(OuraSleepPeriodInfo)
 
     /// True for Tier-B events, so a consumer can assert none leaked into a Tier-A-only sink.

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WhoopProtocol
+import WhoopStore   // OuraRespScale: the one place a ring's milli-bpm respiration row is read
 @preconcurrency import WhoopStore
 
 // AnalyticsEngine.swift — orchestrator producing DailyMetric + sleep-session results.
@@ -254,10 +255,48 @@ public enum AnalyticsEngine {
     ///   - baselines: personal baselines for recovery normalization.
     ///   - maxHROverride: explicit HRmax (bpm) to use for strain/zones; nil →
     ///     Tanaka from profile.age.
+    /// The night's respiratory rate (breaths/min) from a strap's OWN per-window rate rows, or nil when
+    /// the night has too little of it to summarise. Pure → unit-testable, and byte-twinned in Kotlin.
+    ///
+    /// This is NOT the RSA estimate `SleepStager.respRateFromRR` computes: these rows are a measurement
+    /// the device made and NOOP decoded (the Oura ring's 0x6A `breath`, stored in milli-bpm), so the
+    /// question is coverage, not method. The night's value is the MEDIAN of the rows that fall inside a
+    /// matched in-bed session — the same statistic the ledger this decode was validated with used, and
+    /// robust to the odd out-of-band record.
+    ///
+    /// Two guards, both about representativeness rather than trust:
+    ///   * the in-session rows must SPAN at least `vendorRespMinSpanS`. A record cadence is not a
+    ///     reliable proxy for coverage (real nights hold both ~30 s and ~296 s spacing), so the gate is on
+    ///     the time the rows actually cover: a 36-minute tail of a night is not that night's respiration,
+    ///     and it would enter the personal baseline as though it were.
+    ///   * the median must land inside `SleepStager.respPlausibleRangeBpm` (8–25), the SAME band the RSA
+    ///     path is clamped to, so one corrupt record can never publish an impossible rate.
+    public static func vendorRespRateBpm(_ rows: [RespSample],
+                                         sessions: [(start: Int, end: Int)]) -> Double? {
+        guard !rows.isEmpty, !sessions.isEmpty else { return nil }
+        let inSession = rows.filter { r in sessions.contains { r.ts >= $0.start && r.ts <= $0.end } }
+        guard let first = inSession.map(\.ts).min(), let last = inSession.map(\.ts).max(),
+              last - first >= vendorRespMinSpanS else { return nil }
+        let median = HRVAnalyzer.median(inSession.map { OuraRespScale.breathsPerMin(raw: $0.raw) })
+        return SleepStager.respPlausibleRangeBpm.contains(median) ? median : nil
+    }
+
+    /// Minimum span (seconds) a night's vendor respiration rows must cover before their median is taken
+    /// as the night's rate. One hour: enough that the value describes the night rather than a fragment,
+    /// and low enough to keep a partially-drained night. Twin of the Kotlin constant.
+    public static let vendorRespMinSpanS = 3_600
+
     public static func analyzeDay(day: String,
                                   hr: [HRSample] = [],
                                   rr: [RRInterval] = [],
                                   resp: [RespSample] = [],
+                                  // The strap's OWN per-window respiratory RATE rows, when it measures one
+                                  // (the Oura ring's 0x6A `breath`, stored in milli-bpm — see
+                                  // `OuraRespScale`). Kept separate from `resp` on purpose: `resp` is the
+                                  // WHOOP raw respiration ADC WAVEFORM the stager peak-detects, a different
+                                  // quantity that must never be pooled with a rate. Empty for every WHOOP
+                                  // night, which therefore scores exactly as before.
+                                  vendorResp: [RespSample] = [],
                                   gravity: [GravitySample] = [],
                                   steps: [StepSample] = [],
                                   // Calendar-day-scoped overrides for the ADDITIVE daily totals
@@ -661,16 +700,17 @@ public enum AnalyticsEngine {
         // over [start, end]; the night's value = median of finite per-session
         // estimates; nil only when no session yields a finite estimate.
         //
-        // An Oura ring's 0x6A `breath` rows do NOT enter here, deliberately. They are the ring's own
-        // per-window respiratory RATE, decoded and stored as INSTRUMENTATION only (`OuraRespScale`,
-        // OURA_PROTOCOL.md §6.12): shown beside the incumbent on the respiration track, never scored.
-        // `dailyMetric.respRateBpm` is the scored slot — it feeds the recovery resp term and
-        // `IllnessSignalEngine` — and a signal sitting at the vendor ceiling (r = +0.680 is the BEST any
-        // Oura-derived rate can score against WHOOP, which is Oura's own app's number) is exactly what
-        // CLAUDE.md's #194 rule says to instrument rather than make the default and gate on. So a ring
-        // night's `respRateBpm` is whatever the RSA path returns — on banked R-R that is nil — and this
-        // block is byte-identical to what it was before 0x6A was decoded.
+        // A DEVICE-MEASURED rate wins over that estimate when the night has one. `vendorResp` carries a
+        // strap's own respiratory-rate rows — today the Oura ring's 0x6A `breath`, one value per sleep
+        // window, computed by the ring's firmware rather than derived here (see `vendorRespRateBpm`).
+        // Preferring it is not a close call: on a ring night the RSA estimate is built from BANKED R-R,
+        // where shuffling or reversing the night returns the same 13.3333 bpm — it carries no breathing
+        // information at all. A WHOOP night passes no `vendorResp`, so it keeps the RSA path verbatim.
         let respRateDaily: Double? = {
+            if let vendor = Self.vendorRespRateBpm(vendorResp,
+                                                   sessions: matched.map { (start: $0.start, end: $0.end) }) {
+                return vendor
+            }
             let perSession = matched
                 .map { SleepStager.respRateFromRR(rr, start: $0.start, end: $0.end) }
                 .filter { $0.isFinite }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/OuraRespScoringExclusionTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/OuraRespScoringExclusionTests.swift
@@ -3,19 +3,13 @@ import XCTest
 import WhoopProtocol
 import WhoopStore
 
-/// The 0x6A `breath` channel is a per-window RATE stored in `respSample` under the ring's own deviceId
-/// — the same table that otherwise holds a WHOOP's ~1 Hz raw ADC waveform. It is INSTRUMENTATION: it is
-/// stored and it is plotted, and NOTHING scores from it. Two separate refusals, pinned here:
-///   * the STAGER must never see it — a peak detector run over a rate series is a shape error, and this
-///     one would be wrong even for a value nobody doubts;
-///   * the night's `dailyMetric.respRateBpm` must never be derived from it — that is the scored slot
-///     (recovery's resp term, `IllnessSignalEngine`), and CLAUDE.md's #194 rule keeps a channel already
-///     at its vendor ceiling out of it.
-/// Plus the control that keeps the first refusal from being vacuous.
+/// The 0x6A `breath` channel is stored as INSTRUMENTATION: a real row in `respSample`, under the ring's
+/// own deviceId, that no scored path may read. These tests pin BOTH halves of that claim from the
+/// stager's side — the refusal itself, and the fact that today's refusal changes nothing (so the PR
+/// that introduces the rows cannot be moving a single night's stages).
 final class OuraRespScoringExclusionTests: XCTestCase {
 
     private let ring = "oura-2H3B2405003655"
-    private let profile = UserProfile(weightKg: 75, heightCm: 178, age: 30, sex: "male")
 
     // MARK: - fixtures
 
@@ -98,50 +92,5 @@ final class OuraRespScoringExclusionTests: XCTestCase {
                                                  grav: grav, hr: hr, rr: rr, resp: dense)
         XCTAssertNotEqual(withDense.map(\.stage), without.map(\.stage),
                           "a dense resp stream must reach the stager — otherwise the invariance test proves nothing")
-    }
-
-    // MARK: - The scored slot
-
-    /// The second refusal, at the level that matters to a user: a ring night's `dailyMetric.respRateBpm`
-    /// is NOT the ring's measured rate. `analyzeDay` has no door the rows can arrive through — they are
-    /// passed here verbatim as `resp`, the worst case in which a caller forgot `forScoring`, and the
-    /// day's respiration value is still byte-identical to the day with no rows at all.
-    ///
-    /// This is the regression guard on the disposition, not on the decode. The decode is good (the
-    /// ring computes the value; see `OuraSleepPeriodInfo`); what it is not is a candidate for the slot
-    /// that feeds recovery and `IllnessSignalEngine` on the strength of a signal already sitting at the
-    /// r = +0.680 ceiling any Oura-derived rate has against WHOOP. If this test ever fails, a vendor
-    /// preference has been reintroduced into `analyzeDay` and needs its own evidence and review.
-    func testARingNightsScoredRespRateIsNotTheRingsMeasuredRate() {
-        let day = "2026-08-16"
-        let sleepStart = AnalyticsEngine.dayStartUtcSeconds(day) - 4 * 3_600
-        let dur = 8 * 3_600
-        let hr = stride(from: sleepStart, to: sleepStart + dur, by: 30)
-            .map { HRSample(ts: $0, bpm: 52 + ($0 / 300) % 4) }
-        var i = 0
-        let rr = stride(from: sleepStart, to: sleepStart + dur, by: 2).map { ts -> RRInterval in
-            defer { i += 1 }
-            return RRInterval(ts: ts, rrMs: 1_080 + (i % 6) * 8)
-        }
-        // A ring night stages from the ring's OWN hypnogram (#804 Fix A): no gravity, one provided
-        // session — the exact shape the persisted 0x6A rows show up on.
-        var t = sleepStart
-        let stages = [(20, "wake"), (200, "light"), (60, "deep"), (120, "rem"), (80, "light"),
-                      (480 - 20 - 200 - 60 - 120 - 80, "wake")].map { mins, stage -> StageSegment in
-            let s = StageSegment(start: t, end: t + mins * 60, stage: stage); t += mins * 60; return s
-        }
-        let provided = [SleepSession(start: sleepStart, end: sleepStart + dur, efficiency: 0.75,
-                                     stages: stages, restingHR: nil, avgHRV: nil)]
-        let rows = ringRespRows(start: sleepStart, durationS: dur)
-        let ringMedian = HRVAnalyzer.median(rows.map { OuraRespScale.breathsPerMin(raw: $0.raw) })
-
-        let withRows = AnalyticsEngine.analyzeDay(day: day, hr: hr, rr: rr, resp: rows,
-                                                  profile: profile, providedSleep: provided)
-        let without = AnalyticsEngine.analyzeDay(day: day, hr: hr, rr: rr,
-                                                 profile: profile, providedSleep: provided)
-        XCTAssertNotEqual(withRows.daily.respRateBpm ?? -1, ringMedian, accuracy: 1e-9,
-                          "the ring's measured rate must never become the night's scored respRateBpm")
-        XCTAssertEqual(withRows.daily, without.daily,
-                       "persisting 0x6A must leave every scored field of the day untouched")
     }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/VendorRespRateTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/VendorRespRateTests.swift
@@ -1,0 +1,183 @@
+import XCTest
+@testable import StrandAnalytics
+import WhoopProtocol
+import WhoopStore
+
+/// A strap that MEASURES its own respiratory rate (the Oura ring's 0x6A `breath`) supplies the night's
+/// `respRateBpm` instead of NOOP's RSA-from-R-R estimate — and the personal baseline that value feeds is
+/// scoped to the current device era, so a strap switch is not read as physiology.
+final class VendorRespRateTests: XCTestCase {
+    private let profile = UserProfile(weightKg: 75, heightCm: 178, age: 30, sex: "male")
+    private let ring = "oura-2H3B2405003655"
+
+    // MARK: - fixtures
+
+    private func nightStreams(start: Int, end: Int) -> (hr: [HRSample], rr: [RRInterval]) {
+        let hr = stride(from: start, to: end, by: 30).map { HRSample(ts: $0, bpm: 52 + ($0 / 300) % 4) }
+        var i = 0
+        let rr = stride(from: start, to: end, by: 2).map { ts -> RRInterval in
+            defer { i += 1 }
+            return RRInterval(ts: ts, rrMs: 1080 + (i % 6) * 8)
+        }
+        return (hr, rr)
+    }
+
+    private func hypnogram(start: Int) -> [StageSegment] {
+        var t = start
+        func seg(_ mins: Int, _ stage: String) -> StageSegment {
+            let s = StageSegment(start: t, end: t + mins * 60, stage: stage); t += mins * 60; return s
+        }
+        return [seg(20, "wake"), seg(100, "light"), seg(60, "deep"), seg(60, "light"),
+                seg(60, "rem"), seg(120, "light"), seg(60, "deep"), seg(60, "rem"),
+                seg(40, "light"), seg(20, "wake")]
+    }
+
+    /// Ring respiration rows at `everyS` spacing across `[start, start + durationS)`, cycling through
+    /// the 0.125-step values a real night holds.
+    private func ringRows(start: Int, durationS: Int, everyS: Int = 296,
+                          bpms: [Double] = [14.25, 14.5, 14.625, 14.75, 15.0]) -> [RespSample] {
+        stride(from: 0, to: durationS, by: everyS).enumerated().map { i, off in
+            RespSample(ts: start + off,
+                       raw: OuraRespScale.milliBpm(fromBreathsPerMin: bpms[i % bpms.count]),
+                       unit: OuraRespScale.unitTag)
+        }
+    }
+
+    // MARK: - The nightly value
+
+    /// The median of the rows inside the session, in bpm — the same statistic the ledger this decode was
+    /// validated with used.
+    func testNightlyValueIsTheMedianOfTheInSessionRows() {
+        let start = 1_754_000_000
+        let rows = ringRows(start: start, durationS: 8 * 3_600)
+        let v = AnalyticsEngine.vendorRespRateBpm(rows, sessions: [(start: start, end: start + 8 * 3_600)])
+        XCTAssertNotNil(v)
+        XCTAssertEqual(v ?? 0, 14.625, accuracy: 1e-9)
+    }
+
+    /// Rows outside the in-bed window are not part of the night. A daytime tail must not drag it.
+    func testRowsOutsideTheSessionAreIgnored() {
+        let start = 1_754_000_000
+        let night = ringRows(start: start, durationS: 8 * 3_600, bpms: [14.5])
+        let daytime = ringRows(start: start + 12 * 3_600, durationS: 4 * 3_600, bpms: [22.0])
+        let v = AnalyticsEngine.vendorRespRateBpm(night + daytime,
+                                                  sessions: [(start: start, end: start + 8 * 3_600)])
+        XCTAssertEqual(v ?? 0, 14.5, accuracy: 1e-9)
+    }
+
+    /// A fragment of a night is not a night. The ledger's two thin captures (0.6 h and 2.0 h of
+    /// coverage) are exactly the rows that must not enter a personal baseline as though they described
+    /// the night — the gate is on SPAN, not on row count, because the record cadence is not constant.
+    func testAFragmentOfANightIsRefused() {
+        let start = 1_754_000_000
+        let session = (start: start, end: start + 8 * 3_600)
+        // 36 minutes of dense (30 s) rows: many rows, far too little of the night.
+        let dense = ringRows(start: start + 7 * 3_600, durationS: 36 * 60, everyS: 30)
+        XCTAssertGreaterThan(dense.count, 60, "fixture sanity: row COUNT alone would pass any count gate")
+        XCTAssertNil(AnalyticsEngine.vendorRespRateBpm(dense, sessions: [session]))
+
+        // Two hours of the same night does clear the one-hour span floor.
+        let twoHours = ringRows(start: start + 6 * 3_600, durationS: 2 * 3_600, everyS: 296)
+        XCTAssertNotNil(AnalyticsEngine.vendorRespRateBpm(twoHours, sessions: [session]))
+    }
+
+    /// One corrupt record can never publish an impossible rate: the median must land in the same
+    /// plausible band the RSA path is clamped to.
+    func testAnImplausibleMedianIsRefused() {
+        let start = 1_754_000_000
+        let rows = ringRows(start: start, durationS: 8 * 3_600, bpms: [31.875])   // the wire's ceiling
+        XCTAssertNil(AnalyticsEngine.vendorRespRateBpm(rows, sessions: [(start: start,
+                                                                        end: start + 8 * 3_600)]))
+    }
+
+    func testNoRowsAndNoSessionsYieldNothing() {
+        let start = 1_754_000_000
+        XCTAssertNil(AnalyticsEngine.vendorRespRateBpm([], sessions: [(start: start, end: start + 3_600)]))
+        XCTAssertNil(AnalyticsEngine.vendorRespRateBpm(ringRows(start: start, durationS: 8 * 3_600),
+                                                       sessions: []))
+    }
+
+    // MARK: - Through analyzeDay, on the night shape a ring actually produces
+
+    /// A ring night: no gravity, staged from the ring's OWN hypnogram (#804 Fix A). With the ring's
+    /// respiration rows it reports the ring's measured rate; without them the day falls back to the RSA
+    /// estimate, which is what every WHOOP night keeps doing.
+    func testAnalyzeDayPrefersTheDeviceMeasuredRate() {
+        let day = "2026-08-14"
+        let dayStart = AnalyticsEngine.dayStartUtcSeconds(day)
+        let sleepStart = dayStart - 4 * 3_600
+        let sleepEnd = sleepStart + 600 * 60
+        let s = nightStreams(start: sleepStart, end: sleepEnd)
+        let provided = [SleepSession(start: sleepStart, end: sleepEnd, efficiency: 0.75,
+                                     stages: hypnogram(start: sleepStart), restingHR: nil, avgHRV: nil)]
+        let rows = ringRows(start: sleepStart, durationS: 600 * 60)
+
+        let withVendor = AnalyticsEngine.analyzeDay(day: day, hr: s.hr, rr: s.rr, vendorResp: rows,
+                                                    profile: profile, providedSleep: provided)
+        XCTAssertEqual(withVendor.daily.respRateBpm ?? 0, 14.625, accuracy: 1e-9)
+
+        let without = AnalyticsEngine.analyzeDay(day: day, hr: s.hr, rr: s.rr,
+                                                 profile: profile, providedSleep: provided)
+        XCTAssertNotEqual(without.daily.respRateBpm ?? -1, 14.625,
+                          "without the rows the day must not report the device rate")
+    }
+
+    /// Passing no vendor rows leaves every field of the day byte-identical to omitting the parameter —
+    /// the guarantee that every WHOOP night is untouched by this change.
+    func testEmptyVendorRespIsByteIdenticalToOmitting() {
+        let day = "2026-08-14"
+        let dayStart = AnalyticsEngine.dayStartUtcSeconds(day)
+        let sleepStart = dayStart - 4 * 3_600
+        let s = nightStreams(start: sleepStart, end: sleepStart + 600 * 60)
+        let provided = [SleepSession(start: sleepStart, end: sleepStart + 600 * 60, efficiency: 0.75,
+                                     stages: hypnogram(start: sleepStart), restingHR: nil, avgHRV: nil)]
+
+        let omitted = AnalyticsEngine.analyzeDay(day: day, hr: s.hr, rr: s.rr,
+                                                 profile: profile, providedSleep: provided)
+        let empty = AnalyticsEngine.analyzeDay(day: day, hr: s.hr, rr: s.rr, vendorResp: [],
+                                               profile: profile, providedSleep: provided)
+        XCTAssertEqual(omitted.daily, empty.daily)
+    }
+
+    // MARK: - The baseline the value feeds
+
+    /// The composition IntelligenceEngine performs, pinned here because the wiring itself lives in the
+    /// app target where no test runs: a respiration history that crosses brands must fold from the
+    /// CURRENT era only. A WHOOP export reports ~16.1 and the ring ~14.6; pooled, the switch reads as a
+    /// multi-sigma drop — a device artifact scored as physiology.
+    func testRespBaselineFoldsTheCurrentDeviceEraOnly() {
+        guard let cfg = Baselines.metricCfg["resp"] else { return XCTFail("no resp cfg") }
+        var dayKeys: [String] = []
+        var values: [Double?] = []
+        var sources: [(day: String, sourceId: String)] = []
+        // 20 WHOOP-import nights at ~16.1, then 10 ring nights at ~14.6.
+        for i in 0..<30 {
+            let day = String(format: "2026-07-%02d", i + 1)
+            let isRing = i >= 20
+            dayKeys.append(day)
+            values.append(isRing ? 14.6 : 16.1)
+            sources.append((day: day, sourceId: isRing ? ring : "my-whoop"))
+        }
+        let epoch = Baselines.deviceEraEpoch(sources)
+        XCTAssertGreaterThan(epoch, 0, "a brand switch must open a new era")
+
+        let scoped = Baselines.foldHistory(values, dayKeys: dayKeys, cfg: cfg, baselineEpoch: epoch)
+        let pooled = Baselines.foldHistory(values, dayKeys: dayKeys, cfg: cfg, baselineEpoch: 0)
+        XCTAssertEqual(scoped.baseline, 14.6, accuracy: 0.05,
+                       "the era-scoped baseline sits on the ring's own nights")
+        XCTAssertGreaterThan(pooled.baseline, scoped.baseline + 0.2,
+                             "the pooled baseline is dragged up by the previous strap — the defect")
+        // And the consequence that matters: against the pooled baseline a normal ring night reads as a
+        // large deviation, which is what would reach the illness watch.
+        XCTAssertLessThan(Baselines.deviation(14.6, state: scoped).z.magnitude, 1.0)
+        XCTAssertGreaterThan(Baselines.deviation(14.6, state: pooled).z.magnitude, 1.0)
+    }
+
+    /// A single-brand history is untouched: `deviceEraEpoch` returns 0 for every WHOOP-origin id, so an
+    /// existing user's baseline folds exactly as it did before.
+    func testASingleBrandHistoryIsUnscoped() {
+        let days = (1...30).map { (day: String(format: "2026-07-%02d", $0),
+                                   sourceId: $0 % 2 == 0 ? "my-whoop" : "my-whoop-noop") }
+        XCTAssertEqual(Baselines.deviceEraEpoch(days), 0.0, accuracy: 0.0)
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraRespScale.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraRespScale.swift
@@ -56,7 +56,18 @@ public enum OuraRespScale {
         isRingRateStream(deviceId: deviceId) ? breathsPerMin(raw: raw) : Double(raw)
     }
 
-    /// The respiration rows a SCORING read is allowed to see: a ring's are REMOVED.
+    /// The complement of `forScoring`: the rows a device measured ITSELF as a respiratory RATE, which
+    /// is a night's `dailyMetric.respRateBpm` candidate rather than a stager input. A ring's rows pass;
+    /// a WHOOP's raw ADC waveform does not (it is not a rate, and its night already has one from the
+    /// R-R RSA path).
+    ///
+    /// The two functions partition the same read on the same predicate, deliberately: every caller has
+    /// to say which of the two things it wants, and neither can silently take both.
+    public static func forVendorRate(_ rows: [RespSample], deviceId: String) -> [RespSample] {
+        isRingRateStream(deviceId: deviceId) ? rows : []
+    }
+
+    /// The respiration rows the sleep stager is allowed to see: a ring's are REMOVED.
     ///
     /// This is a SHAPE refusal, not a trust one — it would hold even for a value nobody doubts, which
     /// this one increasingly is not (the ring computes it; see `OuraSleepPeriodInfo`). `SleepStager`
@@ -72,12 +83,10 @@ public enum OuraRespScale {
     /// cadence, or a decoder that expanded one record into per-second rows, would quietly switch the
     /// path on. Refuse it by provenance instead, where the reason stays legible.
     ///
-    /// There is NO second door. These rows are instrumentation: stored, plotted (`displayValue`) and
-    /// nothing else. In particular nothing derives `dailyMetric.respRateBpm` from them — that is the
-    /// SCORED slot (the recovery resp term, `IllnessSignalEngine`), and CLAUDE.md's #194 rule reserves
-    /// it: a channel that already sits at its vendor ceiling gets instrumented beside the incumbent,
-    /// not made the default and not wired to a downstream gate. If a future change wants to score them,
-    /// it needs its own evidence and its own review — not a quiet extra caller of this file.
+    /// This is about the STAGER only. The same rows DO reach the daily metric by the other door:
+    /// `forVendorRate` hands them to `AnalyticsEngine`, which takes the night's median as
+    /// `dailyMetric.respRateBpm`. Stager input and nightly value are separate questions, and the answer
+    /// differs because the stager wants a waveform and the daily metric wants a rate.
     public static func forScoring(_ rows: [RespSample], deviceId: String) -> [RespSample] {
         isRingRateStream(deviceId: deviceId) ? [] : rows
     }

--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -200,19 +200,19 @@ public enum OuraStreamMapping {
                 out.events.append(WhoopEvent(ts: ts, kind: motionEventKind, payload: payload))
 
             case .sleepPeriodInfo(let v):
-                // 0x6A `breath` → a `respSample` row under the RING's deviceId, as INSTRUMENTATION: the
-                // row is stored and it is plotted on the respiration track beside the incumbent, and
-                // NOTHING scores from it. `OuraRespScale.forScoring` refuses these rows at every scoring
-                // read, and nothing writes `dailyMetric.respRateBpm` from them — see the note at the
-                // bottom of this case.
+                // 0x6A `breath` → a `respSample` row under the RING's deviceId, and on a ring night that
+                // row set supplies the SCORED `dailyMetric.respRateBpm` (AnalyticsEngine.vendorRespRateBpm
+                // takes the in-session median). `OuraRespScale.forScoring` still refuses these rows at the
+                // STAGING read — a per-window rate is the wrong shape for a peak detector expecting a
+                // ~1 Hz raw ADC waveform.
                 //
                 // Why this one field is stored: `breath` is the RING's own measurement, read off the wire
                 // — not a signal NOOP derives from raw sensor data. The #194 rule governs the latter
                 // (PPG→HR, RSA-from-R-R: methods where NOOP invents the number), so the question here is
                 // whether the DECODE is right, and that is settled structurally: 3,493 records over four
                 // nights, every value an exact multiple of 0.125, both of the source's declared invariants
-                // upheld. On decode provenance it has the same standing as the ring's own hypnogram,
-                // which NOOP already persists (#773/#877). Cross-checks, in order of weight: these records
+                // upheld. It has the same standing as the ring's own hypnogram, which NOOP already
+                // persists and scores from (#773/#877). Cross-checks, in order of weight: these records
                 // median 14.75/min against the SAME wearer's 851-night Oura APP export at 15.250 (IQR
                 // 14.875–15.625) — same quantity, same band (distribution, not paired: the corpora do not
                 // overlap in date); against a WHOOP worn the same nights the decode reproduces the
@@ -228,16 +228,10 @@ public enum OuraStreamMapping {
                 // What this record does NOT persist, and why: `averageHrBpm` would land in the same `hr`
                 // series as the beat-derived channel at a different cadence and provenance;
                 // `breathVariability` / `mzci` / `dzci` / `cv` are named but uninterpreted; `sleepState`
-                // has no documented code meaning. They stay in the investigation log.
-                //
-                // And what NOTHING does with these rows: write `dailyMetric.respRateBpm`. That is the
-                // SCORED slot — it feeds recovery's resp term and `IllnessSignalEngine` — and CLAUDE.md's
-                // #194 rule reserves it. The measurements above put this channel AT its ceiling, not past
-                // it: r = +0.680 is what Oura's OWN app scores against WHOOP, so no Oura-derived rate can
-                // do better, and the ring pairs to one app at a time, which makes a paired same-night
-                // Oura-app comparison impossible by construction rather than merely undone. A signal that
-                // good and no better belongs beside the incumbent, not in front of it. Enforced at the
-                // read, not by convention: `OuraRespScale.forScoring`.
+                // has no documented code meaning. They stay in the investigation log. The scored slot
+                // `dailyMetric.respRateBpm` is fed from these rows in `AnalyticsEngine`, not here — this
+                // layer only mints the durable row; the coverage guards and the era-scoped baseline that
+                // make it safe to score live there.
                 // PARITY: the Kotlin twin stores the IDENTICAL integer for a given decoded value.
                 out.resp.append(RespSample(ts: ts,
                                            raw: OuraRespScale.milliBpm(fromBreathsPerMin: v.breathsPerMin),

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -1631,15 +1631,13 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 // time, like 0x50 MET rather than once-per-kind: its cadence is a modest ~5 min and the
                 // series is what the respiration ledger is reconstructed from, sample by sample.
                 //
-                // The record's `breath` field is also PERSISTED, as instrumentation: anchored to its own
-                // ring-time and enqueued exactly like the sibling banked streams (.hrv/.temp/.spo2), so a
-                // night's ~5-min windows land where they were MEASURED and never at the drain-arrival
-                // moment. `OuraStreamMapping` maps that ONE field onto a `respSample` row in milli-bpm;
-                // everything else in this record stays here in the log. Nothing SCORES the row — not the
-                // sleep stager, and not `dailyMetric.respRateBpm` (see `OuraRespScale`). The logging is
-                // kept as well as the row: the log line is what the ledger is reconstructed from,
-                // including for records no anchor can place, and it carries the fields the store
-                // deliberately does not.
+                // The record's `breath` field is also PERSISTED, and on a ring night it is what
+                // `dailyMetric.respRateBpm` is scored from: anchored to its own ring-time and enqueued
+                // exactly like the sibling banked streams (.hrv/.temp/.spo2), so a night's ~5-min windows
+                // land where they were MEASURED and never at the drain-arrival moment. `OuraStreamMapping`
+                // maps that ONE field onto a `respSample` row in milli-bpm; everything else in this record
+                // stays here in the log. The logging is kept as well as the row: it covers records no
+                // anchor can place, and it carries the fields the store deliberately does not.
                 let periodWhen = driver.unixSeconds(forRingTimestamp: info.ringTimestamp)
                     .map { Self.cursorDateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval($0))) }
                     ?? "no anchor yet"

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -801,12 +801,18 @@ final class IntelligenceEngine: ObservableObject {
                 // reads this stream as a ~1 Hz raw ADC waveform. Refusing by provenance keeps the
                 // instrumentation out of every scored path by construction rather than by cadence luck.
                 // A WHOOP owner is unaffected, and this day scores exactly as it did before those rows
-                // existed — including its `dailyMetric.respRateBpm`, which nothing here derives from a
-                // ring row. See `OuraRespScale.forScoring`.
-                let resp = OuraRespScale.forScoring(
-                    (try? await store.respSamples(deviceId: owner, from: from, to: to,
-                                                  limit: 200_000)) ?? [],
-                    deviceId: owner)
+                // existed. See `OuraRespScale.forScoring`.
+                // ONE read, TWO consumers, and they must not be confused for each other. `forScoring`
+                // strips an Oura ring's rows from the STAGER's input: the stager reads this stream as a
+                // ~1 Hz raw ADC waveform and peak-detects it, and the ring's rows are a per-window RATE —
+                // the wrong shape, however good the rate. `forVendorRate` hands those same rows to
+                // `analyzeDay` as what they are: the device's OWN measured respiratory rate, which
+                // becomes the night's `respRateBpm` instead of the RSA estimate. A WHOOP owner gets the
+                // rows in the first list and nothing in the second, so its night is unchanged.
+                let respRows = (try? await store.respSamples(deviceId: owner, from: from, to: to,
+                                                             limit: 200_000)) ?? []
+                let resp = OuraRespScale.forScoring(respRows, deviceId: owner)
+                let vendorResp = OuraRespScale.forVendorRate(respRows, deviceId: owner)
                 let grav = (try? await store.gravitySamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
                 let steps = (try? await store.stepSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
                 let skin = (try? await store.skinTempSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
@@ -960,7 +966,8 @@ final class IntelligenceEngine: ObservableObject {
                 } else {
                     providedSleep = []
                 }
-                let res = AnalyticsEngine.analyzeDay(day: day, hr: hr, rr: rr, resp: resp, gravity: grav,
+                let res = AnalyticsEngine.analyzeDay(day: day, hr: hr, rr: rr, resp: resp,
+                                                     vendorResp: vendorResp, gravity: grav,
                                                      steps: steps, dayHr: dayHr, daySteps: daySteps,
                                                      dayGravity: dayGrav,
                                                      skinTemp: skin,
@@ -1286,6 +1293,19 @@ final class IntelligenceEngine: ObservableObject {
         Self.mergeNightlyIntoHistory(&histHrvByDay, nightlyHrvByDay)
         Self.mergeNightlyIntoHistory(&histRhrByDay, nightlyRhrByDay)
         Self.mergeNightlyIntoHistory(&histRespByDay, nightlyRespByDay)
+        // Which SOURCE measured each night's respiration, assembled on the SAME imported-wins-per-day rule
+        // as the values themselves (write the imported ids first, then fill only the days the import does
+        // not cover). This is the input `Baselines.deviceEraEpoch` (#459) needs, and respiration is now a
+        // metric that requires it: a WHOOP export reports its OWN measured rate (~16.1 for this history)
+        // while an Oura ring reports the rate its firmware measured (~14.6), and NOOP's own RSA estimate
+        // is a third method again. Pooling them in one 28-day baseline turns a strap SWITCH into a ~3σ
+        // illness-ward step against a ~0.52 bpm spread — a device artifact scored as physiology, which is
+        // exactly the failure #459 named for HRV (Oura RMSSD ~120–155 ms vs WHOOP ~72–112 ms).
+        var respSourceByDay: [String: String] = [:]
+        for d in hist { respSourceByDay[d.day] = deviceId }
+        for (day, owner) in resolvedScoreOwnerByDay where respSourceByDay[day] == nil {
+            respSourceByDay[day] = owner
+        }
         // rhr/resp/skin honour the Charge-wide recalibration epoch (noop.recoveryBaselineEpoch); 0 = no-op,
         // so this is byte-identical to the plain fold until the user taps Recalibrate, at which point the
         // whole Charge build-up (HRV + resting HR + resp + skin) re-anchors together.
@@ -1303,7 +1323,18 @@ final class IntelligenceEngine: ObservableObject {
         // Resp baseline gated on `usable`: RecoveryScorer includes the resp term whenever a
         // baseline object is present , a CALIBRATING (<4-night) baseline would let one noisy
         // RSA night move recovery (mirrors the skin-temp use-site gate; honest cold-start).
-        let respFold = Baselines.foldHistory(respSeq, dayKeys: respDayKeys, cfg: respCfg, baselineEpoch: recoveryEpoch)
+        // The respiration baseline is scoped to the CURRENT device era. `deviceEraEpoch` returns 0.0 for a
+        // single-brand history — every WHOOP-origin id (import, strap, the "-noop" computed sibling, the
+        // Apple/HC riders) buckets to one brand — so a WHOOP-only user folds byte-identically to before;
+        // only a history that actually crosses brands is truncated. `max` with the manual Recalibrate
+        // epoch keeps whichever cut is LATER, since both mean "ignore nights before this".
+        // KNOWN GAP, and pre-existing: the bucket is per BRAND, so it does not separate an imported WHOOP
+        // vendor rate from NOOP's own RSA estimate on WHOOP nights — two methods that were already pooled
+        // before this change and still are. #459's primitive is likewise still unwired for the HRV and
+        // resting-HR baselines it was written for; that is #459's own scope, not this change's.
+        let respEraEpoch = Baselines.deviceEraEpoch(respDayKeys.map { (day: $0, sourceId: respSourceByDay[$0] ?? deviceId) })
+        let respFold = Baselines.foldHistory(respSeq, dayKeys: respDayKeys, cfg: respCfg,
+                                             baselineEpoch: max(recoveryEpoch, respEraEpoch))
         // Skin-temp gated the same way for consistency: its only use-site re-checks `.usable`
         // (AnalyticsEngine's skinTempDevC guard) so this is belt-and-suspenders, but it stops a
         // future use-site from trusting a CALIBRATING baseline. (PR #97 review.)

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1293,19 +1293,29 @@ final class IntelligenceEngine: ObservableObject {
         Self.mergeNightlyIntoHistory(&histHrvByDay, nightlyHrvByDay)
         Self.mergeNightlyIntoHistory(&histRhrByDay, nightlyRhrByDay)
         Self.mergeNightlyIntoHistory(&histRespByDay, nightlyRespByDay)
-        // Which SOURCE measured each night's respiration, assembled on the SAME imported-wins-per-day rule
-        // as the values themselves (write the imported ids first, then fill only the days the import does
-        // not cover). This is the input `Baselines.deviceEraEpoch` (#459) needs, and respiration is now a
-        // metric that requires it: a WHOOP export reports its OWN measured rate (~16.1 for this history)
-        // while an Oura ring reports the rate its firmware measured (~14.6), and NOOP's own RSA estimate
-        // is a third method again. Pooling them in one 28-day baseline turns a strap SWITCH into a ~3σ
-        // illness-ward step against a ~0.52 bpm spread — a device artifact scored as physiology, which is
-        // exactly the failure #459 named for HRV (Oura RMSSD ~120–155 ms vs WHOOP ~72–112 ms).
+        // Which SOURCE measured each night's respiration — the input `Baselines.deviceEraEpoch` (#459)
+        // needs, and respiration is now a metric that requires it: a WHOOP export reports its OWN measured
+        // rate (~16.1 for this history) while an Oura ring reports the rate its firmware measured (~14.6),
+        // and NOOP's own RSA estimate is a third method again. Pooling them in one 28-day baseline turns a
+        // strap SWITCH into a ~3σ illness-ward step against a ~0.52 bpm spread — a device artifact scored
+        // as physiology, which is exactly the failure #459 named for HRV (Oura RMSSD ~120-155 ms vs WHOOP
+        // ~72-112 ms).
+        //
+        // `resolvedScoreOwnerByDay` — THIS PASS's freshly resolved per-day owner (`resolveDayOwner`,
+        // straight off `DayOwnerResolver`, BEFORE any re-homing) — must win over `hist`, not just fill its
+        // gaps. `hist` is `store.dailyMetrics(deviceId: deviceId, ...)`: every row in it is already stored
+        // under THIS device's own id, by construction, because that is where `analyzeRecent` writes every
+        // day's result once scored — an Oura-owned day scored on a PRIOR run is filed there exactly the
+        // same as a WHOOP-owned one. Filling from `hist` first (the value-priority order, correct for
+        // `histRespByDay` because an import legitimately outranks a computed value) would tag that day
+        // "whoop" for every re-score after its first, which is precisely the "brand is lost once a
+        // wearable day is re-homed under the computed WHOOP id" trap `deviceEraEpoch`'s own contract warns
+        // against — it would neuter era-scoping for any day already scored once, i.e. almost all of them in
+        // steady state. `hist` still fills the days OUTSIDE this pass's scan window (older than `maxDays`),
+        // where no fresher source is available and the pre-existing storage id is the best guess.
         var respSourceByDay: [String: String] = [:]
-        for d in hist { respSourceByDay[d.day] = deviceId }
-        for (day, owner) in resolvedScoreOwnerByDay where respSourceByDay[day] == nil {
-            respSourceByDay[day] = owner
-        }
+        for (day, owner) in resolvedScoreOwnerByDay { respSourceByDay[day] = owner }
+        for d in hist where respSourceByDay[d.day] == nil { respSourceByDay[d.day] = deviceId }
         // rhr/resp/skin honour the Charge-wide recalibration epoch (noop.recoveryBaselineEpoch); 0 = no-op,
         // so this is byte-identical to the plain fold until the user taps Recalibrate, at which point the
         // whole Charge build-up (HRV + resting HR + resp + skin) re-anchors together.

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -5,6 +5,7 @@ import com.noop.data.EventRow
 import com.noop.data.GravitySample
 import com.noop.data.V18AuxRow
 import com.noop.data.HrSample
+import com.noop.data.OuraRespScale
 import com.noop.data.SkinTempSample
 import com.noop.data.Spo2Sample
 import com.noop.data.RespSample
@@ -236,11 +237,52 @@ object AnalyticsEngine {
      *   Tanaka from profile.age.
      */
     @Suppress("UNUSED_PARAMETER") // sleepNeedNights kept for signature stability (unused in the current body)
+    /**
+     * Minimum span (seconds) a night's vendor respiration rows must cover before their median is taken
+     * as the night's rate. One hour: enough that the value describes the night rather than a fragment,
+     * and low enough to keep a partially-drained night. Twin of the Swift constant.
+     */
+    const val VENDOR_RESP_MIN_SPAN_S = 3_600L
+
+    /**
+     * The night's respiratory rate (breaths/min) from a strap's OWN per-window rate rows, or null when
+     * the night has too little of it to summarise. Pure → unit-testable, and byte-twinned in Swift.
+     *
+     * This is NOT the RSA estimate `SleepStager.respRateFromRR` computes: these rows are a measurement
+     * the device made and NOOP decoded (the Oura ring's 0x6A `breath`, stored in milli-bpm), so the
+     * question is coverage, not method. The night's value is the MEDIAN of the rows that fall inside a
+     * matched in-bed session — the same statistic the ledger this decode was validated with used, and
+     * robust to the odd out-of-band record.
+     *
+     * Two guards, both about representativeness rather than trust:
+     *  * the in-session rows must SPAN at least [VENDOR_RESP_MIN_SPAN_S]. A record cadence is not a
+     *    reliable proxy for coverage (real nights hold both ~30 s and ~296 s spacing), so the gate is on
+     *    the time the rows actually cover: a 36-minute tail of a night is not that night's respiration,
+     *    and it would enter the personal baseline as though it were.
+     *  * the median must land inside `SleepStager.respPlausibleRangeBpm` (8–25), the SAME band the RSA
+     *    path is clamped to, so one corrupt record can never publish an impossible rate.
+     */
+    fun vendorRespRateBpm(rows: List<RespSample>, sessions: List<Pair<Long, Long>>): Double? {
+        if (rows.isEmpty() || sessions.isEmpty()) return null
+        val inSession = rows.filter { r -> sessions.any { r.ts >= it.first && r.ts <= it.second } }
+        val first = inSession.minOfOrNull { it.ts } ?: return null
+        val last = inSession.maxOfOrNull { it.ts } ?: return null
+        if (last - first < VENDOR_RESP_MIN_SPAN_S) return null
+        val median = HrvAnalyzer.median(inSession.map { OuraRespScale.breathsPerMin(it.raw) })
+        return if (median in SleepStager.respPlausibleRangeBpm) median else null
+    }
+
     fun analyzeDay(
         day: String,
         hr: List<HrSample> = emptyList(),
         rr: List<RrInterval> = emptyList(),
         resp: List<RespSample> = emptyList(),
+        // The strap's OWN per-window respiratory RATE rows, when it measures one (the Oura ring's 0x6A
+        // `breath`, stored in milli-bpm — see [com.noop.data.OuraRespScale]). Kept separate from [resp]
+        // on purpose: [resp] is the WHOOP raw respiration ADC WAVEFORM the stager peak-detects, a
+        // different quantity that must never be pooled with a rate. Empty for every WHOOP night, which
+        // therefore scores exactly as before.
+        vendorResp: List<RespSample> = emptyList(),
         gravity: List<GravitySample> = emptyList(),
         steps: List<StepSample> = emptyList(),
         // Calendar-day-scoped overrides for the ADDITIVE daily totals (steps + activeKcalEst) AND
@@ -549,21 +591,22 @@ object AnalyticsEngine {
         // over [start, end]; the night's value = median of finite per-session
         // estimates; null only when no session yields a finite estimate.
         //
-        // An Oura ring's 0x6A `breath` rows do NOT enter here, deliberately. They are the ring's own
-        // per-window respiratory RATE, decoded and stored as INSTRUMENTATION only
-        // ([com.noop.data.OuraRespScale], OURA_PROTOCOL.md §6.12): shown beside the incumbent on the
-        // respiration track, never scored. `dailyMetric.respRateBpm` is the scored slot — it feeds the
-        // recovery resp term and the illness signal — and a signal sitting at the vendor ceiling
-        // (r = +0.680 is the BEST any Oura-derived rate can score against WHOOP, which is Oura's own
-        // app's number) is exactly what CLAUDE.md's #194 rule says to instrument rather than make the
-        // default and gate on. So a ring night's `respRateBpm` is whatever the RSA path returns — on
-        // banked R-R that is null — and this block is byte-identical to what it was before 0x6A was
-        // decoded. Mirrors Swift.
+        // A DEVICE-MEASURED rate wins over that estimate when the night has one. [vendorResp] carries a
+        // strap's own respiratory-rate rows — today the Oura ring's 0x6A `breath`, one value per sleep
+        // window, computed by the ring's firmware rather than derived here (see [vendorRespRateBpm]).
+        // Preferring it is not a close call: on a ring night the RSA estimate is built from BANKED R-R,
+        // where shuffling or reversing the night returns the same 13.3333 bpm — it carries no breathing
+        // information at all. A WHOOP night passes no [vendorResp], so it keeps the RSA path verbatim.
         val respRateDaily: Double? = run {
-            val perSession = matched
-                .map { SleepStager.respRateFromRR(rr, it.start, it.end) }
-                .filter { it.isFinite() }
-            if (perSession.isEmpty()) null else HrvAnalyzer.median(perSession)
+            val vendor = vendorRespRateBpm(vendorResp, matched.map { it.start to it.end })
+            if (vendor != null) {
+                vendor
+            } else {
+                val perSession = matched
+                    .map { SleepStager.respRateFromRR(rr, it.start, it.end) }
+                    .filter { it.isFinite() }
+                if (perSession.isEmpty()) null else HrvAnalyzer.median(perSession)
+            }
         }
 
         // sleepStart/sleepEnd available for callers wiring sleep_start/end columns.

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1045,12 +1045,16 @@ object IntelligenceEngine {
         mergeNightlyIntoHistory(histHrvByDay, nightlyHrvByDay)
         mergeNightlyIntoHistory(histRhrByDay, nightlyRhrByDay)
         mergeNightlyIntoHistory(histRespByDay, nightlyRespByDay)
-        // Which SOURCE measured each night's respiration, assembled on the SAME imported-wins-per-day rule
-        // as the values themselves (imported ids first, then only the days the import does not cover).
-        // This is the input `Baselines.deviceEraEpoch` (#459) needs for the resp fold below. Mirrors Swift.
+        // Which SOURCE measured each night's respiration — the input `Baselines.deviceEraEpoch` (#459)
+        // needs for the resp fold below. `resolvedScoreOwnerByDay` (THIS PASS's freshly resolved per-day
+        // owner, before any re-homing) must win over `hist`, not just fill its gaps: `hist` is every day
+        // already stored under `importedDeviceId` by construction (that is where a scored day is written),
+        // so filling from `hist` first would tag an Oura-owned day "whoop" on every re-score after its
+        // first — the exact "brand is lost once a wearable day is re-homed" trap `deviceEraEpoch`'s own
+        // contract warns against. `hist` still fills days outside this pass's scan window. Mirrors Swift.
         val respSourceByDay = LinkedHashMap<String, String>()
-        for (d in hist) respSourceByDay[d.day] = importedDeviceId
-        for ((day, owner) in resolvedScoreOwnerByDay) respSourceByDay.putIfAbsent(day, owner)
+        for ((day, owner) in resolvedScoreOwnerByDay) respSourceByDay[day] = owner
+        for (d in hist) respSourceByDay.putIfAbsent(d.day, importedDeviceId)
         // Sort once so the HRV values + their "yyyy-MM-dd" day keys stay parallel (same order/length) for
         // the recalibration-aware foldHistory below.
         val hrvSorted = histHrvByDay.entries.sortedBy { it.key }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -653,13 +653,16 @@ object IntelligenceEngine {
                 continue
             }
             val rr = repo.rrIntervals(owner, from, to, STREAM_LIMIT)
-            // `forScoring` drops an Oura ring's respiration rows: those are the ring's OWN per-window
-            // RATE (0x6A, milli-bpm, ~1 row per 5 min), stored as instrumentation, while the stager reads
-            // this stream as a ~1 Hz raw ADC waveform. Refusing by provenance keeps the instrumentation
-            // out of every scored path by construction rather than by cadence luck. A WHOOP owner is
-            // unaffected, and this day scores exactly as it did before those rows existed — including its
-            // `respRateBpm`, which nothing here derives from a ring row. Mirrors Swift.
-            val resp = OuraRespScale.forScoring(repo.respSamples(owner, from, to, STREAM_LIMIT), owner)
+            // ONE read, TWO consumers, and they must not be confused for each other. `forScoring` strips
+            // an Oura ring's rows from the STAGER's input: the stager reads this stream as a ~1 Hz raw ADC
+            // waveform and peak-detects it, and the ring's rows are a per-window RATE — the wrong shape,
+            // however good the rate. `forVendorRate` hands those same rows to analyzeDay as what they
+            // are: the device's OWN measured respiratory rate, which becomes the night's `respRateBpm`
+            // instead of the RSA estimate. A WHOOP owner gets the rows in the first list and nothing in
+            // the second, so its night is unchanged. Mirrors Swift.
+            val respRows = repo.respSamples(owner, from, to, STREAM_LIMIT)
+            val resp = OuraRespScale.forScoring(respRows, owner)
+            val vendorResp = OuraRespScale.forVendorRate(respRows, owner)
             val grav = repo.gravitySamples(owner, from, to, STREAM_LIMIT)
             val steps = repo.stepSamples(owner, from, to, STREAM_LIMIT)
             val skin = repo.skinTempSamples(owner, from, to, STREAM_LIMIT)
@@ -764,6 +767,7 @@ object IntelligenceEngine {
                 hr = hr,
                 rr = rr,
                 resp = resp,
+                vendorResp = vendorResp,
                 gravity = grav,
                 steps = steps,
                 dayHr = dayHr,
@@ -1041,6 +1045,12 @@ object IntelligenceEngine {
         mergeNightlyIntoHistory(histHrvByDay, nightlyHrvByDay)
         mergeNightlyIntoHistory(histRhrByDay, nightlyRhrByDay)
         mergeNightlyIntoHistory(histRespByDay, nightlyRespByDay)
+        // Which SOURCE measured each night's respiration, assembled on the SAME imported-wins-per-day rule
+        // as the values themselves (imported ids first, then only the days the import does not cover).
+        // This is the input `Baselines.deviceEraEpoch` (#459) needs for the resp fold below. Mirrors Swift.
+        val respSourceByDay = LinkedHashMap<String, String>()
+        for (d in hist) respSourceByDay[d.day] = importedDeviceId
+        for ((day, owner) in resolvedScoreOwnerByDay) respSourceByDay.putIfAbsent(day, owner)
         // Sort once so the HRV values + their "yyyy-MM-dd" day keys stay parallel (same order/length) for
         // the recalibration-aware foldHistory below.
         val hrvSorted = histHrvByDay.entries.sortedBy { it.key }
@@ -1057,13 +1067,24 @@ object IntelligenceEngine {
         // A 0.0 epoch is byte-identical to the plain fold, so scoring is unchanged until the user taps it.
         val hrvBase2 = Baselines.foldHistory(hrvSeq, hrvDayKeys, hrvCfg, baselineEpoch)
         val rhrBase2 = Baselines.foldHistory(rhrSeq, rhrDayKeys, rhrCfg, recoveryEpoch)
-        // Resp baseline mixes imported (cloud) values with on-device RSA estimates , acceptable: the
-        // z-score is scale-tolerant, foldHistory winsorizes, and respRateBpm already carries no source
-        // flag anywhere else (the illness gate treats it the same way). Gated on `usable` because
-        // RecoveryScorer includes the resp term whenever a baseline object is present , a CALIBRATING
-        // (<4-night) baseline would let one noisy RSA night move recovery (mirrors the skin-temp
-        // use-site gate; honest cold-start).
-        val respBase2 = Baselines.foldHistory(respSeq, respDayKeys, respCfg, recoveryEpoch).takeIf { it.usable }
+        // Resp baseline: WITHIN one brand it still mixes imported (cloud) values with on-device RSA
+        // estimates, which stays an accepted tradeoff (the z-score is scale-tolerant and foldHistory
+        // winsorizes). ACROSS brands it is not acceptable, and that is new: a WHOOP export reports its own
+        // measured rate (~16.1 on this history) while an Oura ring reports the rate its firmware measured
+        // (~14.6), so pooling them turns a strap SWITCH into a ~3 sigma illness-ward step against a
+        // ~0.52 bpm spread — a device artifact scored as physiology, the same failure #459 named for HRV.
+        // `deviceEraEpoch` returns 0.0 for a single-brand history (every WHOOP-origin id — import, strap,
+        // the computed sibling, the Apple/HC riders — buckets to one brand), so a WHOOP-only user folds
+        // byte-identically to before; `max` with the manual Recalibrate epoch keeps whichever cut is
+        // LATER, since both mean "ignore nights before this". Gated on `usable` because RecoveryScorer
+        // includes the resp term whenever a baseline object is present , a CALIBRATING (<4-night)
+        // baseline would let one noisy night move recovery (mirrors the skin-temp use-site gate).
+        val respEraEpoch = Baselines.deviceEraEpoch(
+            respDayKeys.map { it to (respSourceByDay[it] ?: importedDeviceId) },
+        )
+        val respBase2 = Baselines
+            .foldHistory(respSeq, respDayKeys, respCfg, maxOf(recoveryEpoch, respEraEpoch))
+            .takeIf { it.usable }
         // Skin-temp baseline is on-device-only (imported rows carry skinTempDevC, not the raw mean),
         // so fold purely over the pass-1 nightly means in chronological order. (PR #85)
         // Gated on `usable` for consistency with the resp baseline above AND the Swift reference

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -1826,15 +1826,13 @@ class OuraLiveSource(
                 // time, like 0x50 MET rather than once-per-kind: its cadence is a modest ~5 min and the
                 // series is what the respiration ledger is reconstructed from, sample by sample.
                 //
-                // The record's `breath` field is also PERSISTED, as instrumentation: anchored to its own
-                // ring-time and enqueued exactly like the sibling banked streams (Hrv/Temp/Spo2), so a
-                // night's ~5-min windows land where they were MEASURED and never at the drain-arrival
-                // moment. OuraStreamMapping maps that ONE field onto a `respSample` row in milli-bpm;
-                // everything else in this record stays here in the log. Nothing SCORES the row - not the
-                // sleep stager, and not `dailyMetric.respRateBpm` (see OuraRespScale). The logging is
-                // kept as well as the row: the log line is what the ledger is reconstructed from,
-                // including for records no anchor can place, and it carries the fields the store
-                // deliberately does not.
+                // The record's `breath` field is also PERSISTED, and on a ring night it is what
+                // `dailyMetric.respRateBpm` is scored from: anchored to its own ring-time and enqueued
+                // exactly like the sibling banked streams (Hrv/Temp/Spo2), so a night's ~5-min windows
+                // land where they were MEASURED and never at the drain-arrival moment. OuraStreamMapping
+                // maps that ONE field onto a `respSample` row in milli-bpm; everything else in this record
+                // stays here in the log. The logging is kept as well as the row: it covers records no
+                // anchor can place, and it carries the fields the store deliberately does not.
                 //
                 // Twin of Swift's `.sleepPeriodInfo` log line, with one deliberate difference: Swift
                 // prints a formatted clock time because that source already holds a formatter, and this

--- a/android/app/src/main/java/com/noop/data/OuraRespScale.kt
+++ b/android/app/src/main/java/com/noop/data/OuraRespScale.kt
@@ -64,7 +64,19 @@ object OuraRespScale {
         if (isRingRateStream(deviceId)) breathsPerMin(raw) else raw.toDouble()
 
     /**
-     * The respiration rows a SCORING read is allowed to see: a ring's are REMOVED.
+     * The complement of [forScoring]: the rows a device measured ITSELF as a respiratory RATE, which is
+     * a night's `dailyMetric.respRateBpm` candidate rather than a stager input. A ring's rows pass; a
+     * WHOOP's raw ADC waveform does not (it is not a rate, and its night already has one from the R-R
+     * RSA path).
+     *
+     * The two functions partition the same read on the same predicate, deliberately: every caller has to
+     * say which of the two things it wants, and neither can silently take both.
+     */
+    fun forVendorRate(rows: List<RespSample>, deviceId: String): List<RespSample> =
+        if (isRingRateStream(deviceId)) rows else emptyList()
+
+    /**
+     * The respiration rows the sleep stager is allowed to see: a ring's are REMOVED.
      *
      * This is a SHAPE refusal, not a trust one — it would hold even for a value nobody doubts, which
      * this one increasingly is not (the ring computes it; see `OuraSleepPeriodInfo`). `SleepStager`
@@ -80,12 +92,10 @@ object OuraRespScale {
      * cadence, or a decoder that expanded one record into per-second rows, would quietly switch the
      * path on. Refuse it by provenance instead, where the reason stays legible.
      *
-     * There is NO second door. These rows are instrumentation: stored, plotted ([displayValue]) and
-     * nothing else. In particular nothing derives `dailyMetric.respRateBpm` from them — that is the
-     * SCORED slot (the recovery resp term, the illness signal), and CLAUDE.md's #194 rule reserves it:
-     * a channel that already sits at its vendor ceiling gets instrumented beside the incumbent, not made
-     * the default and not wired to a downstream gate. If a future change wants to score them, it needs
-     * its own evidence and its own review — not a quiet extra caller of this file.
+     * This is about the STAGER only. The same rows DO reach the daily metric by the other door:
+     * [forVendorRate] hands them to `AnalyticsEngine`, which takes the night's median as
+     * `dailyMetric.respRateBpm`. Stager input and nightly value are separate questions, and the answer
+     * differs because the stager wants a waveform and the daily metric wants a rate.
      */
     fun forScoring(rows: List<RespSample>, deviceId: String): List<RespSample> =
         if (isRingRateStream(deviceId)) emptyList() else rows

--- a/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
+++ b/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
@@ -216,19 +216,20 @@ object OuraStreamMapping {
                 // (s6.13) - decoded, logged, never scored: ground truth showed no field is a step count,
                 // they are the inputs to Oura's step model.
                 is OuraEvent.SleepPeriodInfo -> {
-                    // 0x6A `breath` -> a `respSample` row under the RING's deviceId, as INSTRUMENTATION:
-                    // the row is stored and it is plotted on the respiration track beside the incumbent,
-                    // and NOTHING scores from it. [OuraRespScale.forScoring] refuses these rows at every
-                    // scoring read, and nothing writes `dailyMetric.respRateBpm` from them - see the note
-                    // at the bottom of this branch.
+                    // 0x6A `breath` -> a `respSample` row under the RING's deviceId, and on a ring night
+                    // that row set supplies the SCORED `dailyMetric.respRateBpm`
+                    // ([AnalyticsEngine.vendorRespRateBpm] takes the in-session median).
+                    // [OuraRespScale.forScoring] still refuses these rows at the STAGING read - a
+                    // per-window rate is the wrong shape for a peak detector expecting a ~1 Hz raw ADC
+                    // waveform.
                     //
                     // Why this one field is stored: `breath` is the RING's own measurement, read off the
                     // wire - not a signal NOOP derives from raw sensor data. The #194 rule governs the
                     // latter (PPG->HR, RSA-from-R-R: methods where NOOP invents the number), so the
                     // question here is whether the DECODE is right, and that is settled structurally:
                     // 3,493 records over four nights, every value an exact multiple of 0.125, both of the
-                    // source's declared invariants upheld. On decode provenance it has the same standing
-                    // as the ring's own hypnogram, which NOOP already persists (#773/#877). Cross-checks, in
+                    // source's declared invariants upheld. It has the same standing as the ring's own
+                    // hypnogram, which NOOP already persists and scores from (#773/#877). Cross-checks, in
                     // order of weight: these records median 14.75/min against the SAME wearer's 851-night
                     // Oura APP export at 15.250 (IQR 14.875-15.625) - same quantity, same band
                     // (distribution, not paired: the corpora do not overlap in date); against a WHOOP worn
@@ -246,15 +247,9 @@ object OuraStreamMapping {
                     // `hr` series as the beat-derived channel at a different cadence and provenance;
                     // `breathVariability` / `mzci` / `dzci` / `cv` are named but uninterpreted;
                     // `sleepState` has no documented code meaning. They stay in the investigation log.
-                    //
-                    // And what NOTHING does with these rows: write `dailyMetric.respRateBpm`. That is the
-                    // SCORED slot - it feeds recovery's resp term and the illness signal - and CLAUDE.md's
-                    // #194 rule reserves it. The measurements above put this channel AT its ceiling, not
-                    // past it: r = +0.680 is what Oura's OWN app scores against WHOOP, so no Oura-derived
-                    // rate can do better, and the ring pairs to one app at a time, which makes a paired
-                    // same-night Oura-app comparison impossible by construction rather than merely undone.
-                    // A signal that good and no better belongs beside the incumbent, not in front of it.
-                    // Enforced at the read, not by convention: [OuraRespScale.forScoring].
+                    // The scored slot `dailyMetric.respRateBpm` is fed from these rows in AnalyticsEngine,
+                    // not here - this layer only mints the durable row; the coverage guards and the
+                    // era-scoped baseline that make it safe to score live there.
                     // PARITY: the Swift twin stores the IDENTICAL integer for a given decoded value.
                     val ts = anchor(ev.value.ringTimestamp) ?: continue
                     out.resp.add(

--- a/android/app/src/main/java/com/noop/oura/EventTags.kt
+++ b/android/app/src/main/java/com/noop/oura/EventTags.kt
@@ -101,9 +101,7 @@ enum class OuraEventTag(val raw: Int) {
             // ([open_ring]); NOOP's own captures confirm the layout's declared invariants and the
             // fixed-point scales. Tier B on DECODE PROVENANCE - third-party names, not Oura
             // documentation - not on doubt that the ring measures respiration: `breath` is the ring's
-            // own value read off the wire. It is INSTRUMENTATION - stored as a `respSample` row and shown
-            // on the respiration track, but NOT scored: `dailyMetric.respRateBpm` is untouched (see
-            // OuraSleepPeriodInfo).
+            // own value read off the wire, and it feeds respRateBpm (see OuraSleepPeriodInfo).
             SLEEP_PERIOD_INFO,
             // #287: 0x71 green_ibi_and_amp is NOT corpus-verified — no captured 0x71 fixture, and
             // OURA_PROTOCOL.md §6.2 documents a DIFFERENT layout (5 IBI deltas + 6 amplitudes, shift

--- a/android/app/src/main/java/com/noop/oura/OuraDriver.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraDriver.kt
@@ -523,11 +523,11 @@ class OuraDriver(
                 // third-party layout ([open_ring]) whose field NAMES are what our own s6.12 was missing,
                 // and whose declared invariants our captures uphold. Still Tier B - only reached behind
                 // allowTierB (gated above). ONE field of it is durable: OuraStreamMapping maps
-                // `breathsPerMin` to a respSample row under the ring's OWN deviceId, shown on the
-                // respiration track. It is NOT scored: dailyMetric.respRateBpm is untouched (it stays the
-                // RSA estimate), and OuraRespScale.forScoring refuses the ring's rows at EVERY scoring read
-                // - staging included, because that path reads the stream as a ~1 Hz raw ADC waveform and a
-                // per-window rate is the wrong shape for a peak detector. `averageHrBpm`
+                // `breathsPerMin` to a respSample row under the ring's OWN deviceId, and on a ring night
+                // AnalyticsEngine takes the night's median of those rows as dailyMetric.respRateBpm (the
+                // ring measures it; NOOP does not derive it). It is still refused at the STAGING read by
+                // provenance (OuraRespScale.forScoring) - that path reads the stream as a ~1 Hz raw ADC
+                // waveform and a per-window rate is the wrong shape for a peak detector. `averageHrBpm`
                 // and every other field stay diagnostic-only - in particular the HR must not join the
                 // beat-derived series at a different cadence.
                 val info = OuraDecoders.decodeSleepPeriodInfo(record) ?: return emptyList()

--- a/android/app/src/main/java/com/noop/oura/OuraEvents.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraEvents.kt
@@ -325,8 +325,8 @@ data class OuraRealStepsFields(val tag: Int, val ringTimestamp: Long, val fields
  * the wire - it is not a signal NOOP derives from raw sensor data. The #194 rule is written for the
  * opposite case (PPG->HR autocorrelation, RSA-from-R-R: methods where NOOP invents the number and can
  * manufacture a peak that looks physiological), so what has to be right here is the DECODE, which is
- * what the structural verification above establishes. On decode provenance it has the same standing as
- * the ring's own SleepNet hypnogram, which NOOP already persists (#773 / #877).
+ * what the structural verification above establishes. Same standing as the ring's own SleepNet
+ * hypnogram, which NOOP already persists and scores from (#773 / #877).
  *
  * Independent support that byte 4 is the quantity Oura's own app calls respiratory rate: these records
  * median 14.75/min against the SAME wearer's 851-night Oura app export at 15.250 (IQR 14.875-15.625) -
@@ -340,16 +340,15 @@ data class OuraRealStepsFields(val tag: Int, val ringTimestamp: Long, val fields
  * documentation - a decode-provenance caveat, not a doubt about whether the ring measures respiration.
  *
  * `OuraStreamMapping` maps `breathsPerMin` - and nothing else from this record - to a `respSample` row
- * in milli-bpm under the ring's own deviceId, as INSTRUMENTATION: the row is stored and plotted on the
- * respiration track beside the incumbent, and NOTHING scores from it. In particular nothing writes
- * `dailyMetric.respRateBpm` from it - that is the scored slot (recovery's respiration term, the illness
- * signal), and the same measurements that make this decode believable also place it AT the vendor
- * ceiling rather than past it (r = +0.680 is what Oura's OWN app manages against WHOOP), which is
- * precisely the case CLAUDE.md's #194 rule says to instrument rather than make the default. It also
- * never reaches the sleep STAGER (`OuraRespScale.forScoring`): that stream is read there as a ~1 Hz raw
- * ADC waveform and a per-window rate is the wrong shape for a peak detector, however good the rate.
- * `averageHrBpm` stays diagnostic-only: it must not join the beat-derived HR series at a different
- * cadence and a different provenance.
+ * in milli-bpm under the ring's own deviceId, and `AnalyticsEngine` takes the night's median of those
+ * rows as `dailyMetric.respRateBpm`: on a ring night that replaces an RSA-from-banked-R-R estimate which
+ * carries no breathing information at all (shuffling the night returns the same 13.3333 bpm). The
+ * baseline that value feeds is scoped to the current device era (`Baselines.deviceEraEpoch`, #459) so a
+ * strap switch - WHOOP reads ~16.1, the ring ~14.6 - is not folded into one 28-day mean and read as
+ * physiology. It still never reaches the sleep STAGER (`OuraRespScale.forScoring`): that stream is read
+ * there as a ~1 Hz raw ADC waveform and a per-window rate is the wrong shape for a peak detector,
+ * however good the rate. `averageHrBpm` stays diagnostic-only: it must not join the beat-derived HR
+ * series at a different cadence and a different provenance.
  *
  * `mzci` / `dzci` keep the source's opaque names deliberately - we do not know what they measure, and
  * inventing a friendlier name would assert an interpretation the evidence does not support. Kotlin twin

--- a/android/app/src/main/java/com/noop/oura/OuraEvents.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraEvents.kt
@@ -433,9 +433,8 @@ sealed class OuraEvent {
      * (see [OuraSleepPeriodInfo] doc) - split out of the raw-bytes [TierB] wrapper for the same reason
      * [ActivityInfo] was: a cited third-party layout worth surfacing as real numbers instead of hex.
      * Same gate (`allowTierB`); its `breathsPerMin` - alone among the record's fields - is mapped to a
-     * durable `respSample` row and shown on the respiration track. It is NOT scored: `dailyMetric.respRateBpm`
-     * is untouched, and `OuraRespScale.forScoring` refuses the ring's rows at every scoring read (see the
-     * type doc). Every other field of the record stays diagnostic-only.
+     * durable `respSample` row and, on a ring night, supplies `dailyMetric.respRateBpm` (see the type
+     * doc). Every other field of the record stays diagnostic-only.
      */
     data class SleepPeriodInfo(val value: OuraSleepPeriodInfo) : OuraEvent()
 

--- a/android/app/src/test/java/com/noop/analytics/OuraRespScoringExclusionTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/OuraRespScoringExclusionTest.kt
@@ -10,29 +10,20 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.time.LocalDate
-import java.time.ZoneOffset
 import kotlin.math.PI
-import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlin.math.sin
 
 /**
- * The 0x6A `breath` channel is a per-window RATE stored in `respSample` under the ring's own deviceId —
- * the same table that otherwise holds a WHOOP's ~1 Hz raw ADC waveform. It is INSTRUMENTATION: it is
- * stored and it is plotted, and NOTHING scores from it. Two separate refusals, pinned here:
- *  * the STAGER must never see it — a peak detector run over a rate series is a shape error, and this
- *    one would be wrong even for a value nobody doubts;
- *  * the night's `dailyMetric.respRateBpm` must never be derived from it — that is the scored slot
- *    (recovery's resp term, the illness signal), and CLAUDE.md's #194 rule keeps a channel already at
- *    its vendor ceiling out of it.
- * Plus the control that keeps the first refusal from being vacuous. Swift twin:
+ * The 0x6A `breath` channel is stored as INSTRUMENTATION: a real row in `respSample`, under the ring's
+ * own deviceId, that no scored path may read. These pin BOTH halves of that claim from the stager's
+ * side — the refusal itself, and the fact that today's refusal changes nothing (so the change that
+ * introduces the rows cannot be moving a single night's stages). Swift twin:
  * `OuraRespScoringExclusionTests`.
  */
 class OuraRespScoringExclusionTest {
 
     private val ring = "oura-2H3B2405003655"
-    private val profile = UserProfile(weightKg = 75.0, heightCm = 178.0, age = 30.0, sex = "male")
 
     // ── fixtures ─────────────────────────────────────────────────────────────────────────────────────
 
@@ -119,56 +110,6 @@ class OuraRespScoringExclusionTest {
             "a dense resp stream must reach the stager — otherwise the invariance test proves nothing",
             without.map { it.stage },
             withDense.map { it.stage },
-        )
-    }
-
-    // ── The scored slot ──────────────────────────────────────────────────────────────────────────────
-
-    /**
-     * The second refusal, at the level that matters to a user: a ring night's `dailyMetric.respRateBpm`
-     * is NOT the ring's measured rate. `analyzeDay` has no door the rows can arrive through — they are
-     * passed here verbatim as `resp`, the worst case in which a caller forgot [OuraRespScale.forScoring],
-     * and the day is still byte-identical to the day with no rows at all.
-     *
-     * This is the regression guard on the disposition, not on the decode. The decode is good (the ring
-     * computes the value; see OuraSleepPeriodInfo); what it is not is a candidate for the slot that feeds
-     * recovery and the illness signal on the strength of a signal already sitting at the r = +0.680
-     * ceiling any Oura-derived rate has against WHOOP. If this test ever fails, a vendor preference has
-     * been reintroduced into `analyzeDay` and needs its own evidence and review.
-     */
-    @Test
-    fun aRingNightsScoredRespRateIsNotTheRingsMeasuredRate() {
-        val day = "2026-08-16"
-        val sleepStart = LocalDate.parse(day).atStartOfDay(ZoneOffset.UTC).toEpochSecond() - 4 * 3_600L
-        val dur = 8 * 3_600
-        val hr = (sleepStart until sleepStart + dur step 30)
-            .map { HrSample(ring, it, 52 + ((it / 300) % 4).toInt()) }
-        var i = 0
-        val rr = (sleepStart until sleepStart + dur step 2).map { RrInterval(ring, it, 1_080 + (i++ % 6) * 8) }
-        // A ring night stages from the ring's OWN hypnogram (#804 Fix A): no gravity, one provided
-        // session — the exact shape the persisted 0x6A rows show up on.
-        var t = sleepStart
-        val stages = listOf(20 to "wake", 200 to "light", 60 to "deep", 120 to "rem", 80 to "light", 0 to "wake")
-            .map { (mins, stage) -> StageSegment(t, t + mins * 60L, stage).also { t += mins * 60L } }
-        val provided = listOf(
-            DetectedSleep(sleepStart, sleepStart + dur, 0.75, stages, restingHR = null, avgHRV = null),
-        )
-        val rows = ringRespRows(sleepStart, dur)
-        val ringMedian = HrvAnalyzer.median(rows.map { OuraRespScale.breathsPerMin(it.raw) })
-
-        val withRows = AnalyticsEngine.analyzeDay(
-            day = day, hr = hr, rr = rr, resp = rows, profile = profile, providedSleep = provided,
-        )
-        val without = AnalyticsEngine.analyzeDay(
-            day = day, hr = hr, rr = rr, profile = profile, providedSleep = provided,
-        )
-        assertTrue(
-            "the ring's measured rate must never become the night's scored respRateBpm",
-            withRows.daily.respRateBpm == null || abs(withRows.daily.respRateBpm!! - ringMedian) > 1e-9,
-        )
-        assertEquals(
-            "persisting 0x6A must leave every scored field of the day untouched",
-            without.daily, withRows.daily,
         )
     }
 }

--- a/android/app/src/test/java/com/noop/analytics/VendorRespRateTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/VendorRespRateTest.kt
@@ -1,0 +1,200 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import com.noop.data.OuraRespScale
+import com.noop.data.RespSample
+import com.noop.data.RrInterval
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneOffset
+import kotlin.math.abs
+
+/**
+ * A strap that MEASURES its own respiratory rate (the Oura ring's 0x6A `breath`) supplies the night's
+ * `respRateBpm` instead of NOOP's RSA-from-R-R estimate — and the personal baseline that value feeds is
+ * scoped to the current device era, so a strap switch is not read as physiology. Swift twin:
+ * `VendorRespRateTests`.
+ */
+class VendorRespRateTest {
+    private val profile = UserProfile(weightKg = 75.0, heightCm = 178.0, age = 30.0, sex = "male")
+    private val ring = "oura-2H3B2405003655"
+    private val day = "2026-08-14"
+    private val dayStart = LocalDate.parse("2026-08-14").atStartOfDay(ZoneOffset.UTC).toEpochSecond()
+
+    // ── fixtures ─────────────────────────────────────────────────────────────────────────────────────
+
+    private fun nightStreams(start: Long, end: Long): Pair<List<HrSample>, List<RrInterval>> {
+        val hr = (start until end step 30).map { HrSample("t", it, 52 + ((it / 300) % 4).toInt()) }
+        var i = 0
+        val rr = (start until end step 2).map { RrInterval("t", it, 1080 + (i++ % 6) * 8) }
+        return hr to rr
+    }
+
+    private fun hypnogram(start: Long): List<StageSegment> {
+        var t = start
+        fun seg(mins: Int, stage: String): StageSegment {
+            val s = StageSegment(t, t + mins * 60L, stage); t += mins * 60L; return s
+        }
+        return listOf(
+            seg(20, "wake"), seg(100, "light"), seg(60, "deep"), seg(60, "light"),
+            seg(60, "rem"), seg(120, "light"), seg(60, "deep"), seg(60, "rem"),
+            seg(40, "light"), seg(20, "wake"),
+        )
+    }
+
+    /**
+     * Ring respiration rows at [everyS] spacing across `[start, start + durationS)`, cycling through the
+     * 0.125-step values a real night holds.
+     */
+    private fun ringRows(
+        start: Long,
+        durationS: Long,
+        everyS: Long = 296,
+        bpms: List<Double> = listOf(14.25, 14.5, 14.625, 14.75, 15.0),
+    ): List<RespSample> = (0 until durationS step everyS).mapIndexed { i, off ->
+        RespSample(ring, start + off, OuraRespScale.milliBpm(bpms[i % bpms.size]))
+    }
+
+    // ── The nightly value ────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun nightlyValueIsTheMedianOfTheInSessionRows() {
+        val start = 1_754_000_000L
+        val rows = ringRows(start, 8 * 3_600L)
+        val v = AnalyticsEngine.vendorRespRateBpm(rows, listOf(start to start + 8 * 3_600L))
+        assertNotNull(v)
+        assertEquals(14.625, v!!, 1e-9)
+    }
+
+    /** Rows outside the in-bed window are not part of the night. A daytime tail must not drag it. */
+    @Test
+    fun rowsOutsideTheSessionAreIgnored() {
+        val start = 1_754_000_000L
+        val night = ringRows(start, 8 * 3_600L, bpms = listOf(14.5))
+        val daytime = ringRows(start + 12 * 3_600L, 4 * 3_600L, bpms = listOf(22.0))
+        val v = AnalyticsEngine.vendorRespRateBpm(night + daytime, listOf(start to start + 8 * 3_600L))
+        assertEquals(14.5, v!!, 1e-9)
+    }
+
+    /**
+     * A fragment of a night is not a night. The ledger's two thin captures (0.6 h and 2.0 h of coverage)
+     * are exactly the rows that must not enter a personal baseline as though they described the night —
+     * the gate is on SPAN, not on row count, because the record cadence is not constant.
+     */
+    @Test
+    fun aFragmentOfANightIsRefused() {
+        val start = 1_754_000_000L
+        val session = start to start + 8 * 3_600L
+        val dense = ringRows(start + 7 * 3_600L, 36 * 60L, everyS = 30)
+        assertTrue("fixture sanity: row COUNT alone would pass any count gate", dense.size > 60)
+        assertNull(AnalyticsEngine.vendorRespRateBpm(dense, listOf(session)))
+
+        val twoHours = ringRows(start + 6 * 3_600L, 2 * 3_600L)
+        assertNotNull(AnalyticsEngine.vendorRespRateBpm(twoHours, listOf(session)))
+    }
+
+    /** One corrupt record can never publish an impossible rate. */
+    @Test
+    fun anImplausibleMedianIsRefused() {
+        val start = 1_754_000_000L
+        val rows = ringRows(start, 8 * 3_600L, bpms = listOf(31.875))   // the wire's ceiling
+        assertNull(AnalyticsEngine.vendorRespRateBpm(rows, listOf(start to start + 8 * 3_600L)))
+    }
+
+    @Test
+    fun noRowsAndNoSessionsYieldNothing() {
+        val start = 1_754_000_000L
+        assertNull(AnalyticsEngine.vendorRespRateBpm(emptyList(), listOf(start to start + 3_600L)))
+        assertNull(AnalyticsEngine.vendorRespRateBpm(ringRows(start, 8 * 3_600L), emptyList()))
+    }
+
+    // ── Through analyzeDay, on the night shape a ring actually produces ──────────────────────────────
+
+    @Test
+    fun analyzeDayPrefersTheDeviceMeasuredRate() {
+        val sleepStart = dayStart - 4 * 3_600L
+        val sleepEnd = sleepStart + 600 * 60L
+        val (hr, rr) = nightStreams(sleepStart, sleepEnd)
+        val provided = listOf(
+            DetectedSleep(sleepStart, sleepEnd, 0.75, hypnogram(sleepStart), restingHR = null, avgHRV = null),
+        )
+        val rows = ringRows(sleepStart, 600 * 60L)
+
+        val withVendor = AnalyticsEngine.analyzeDay(
+            day = day, hr = hr, rr = rr, vendorResp = rows, profile = profile, providedSleep = provided,
+        )
+        assertEquals(14.625, withVendor.daily.respRateBpm!!, 1e-9)
+
+        val without = AnalyticsEngine.analyzeDay(
+            day = day, hr = hr, rr = rr, profile = profile, providedSleep = provided,
+        )
+        assertTrue(
+            "without the rows the day must not report the device rate",
+            without.daily.respRateBpm == null || abs(without.daily.respRateBpm!! - 14.625) > 1e-9,
+        )
+    }
+
+    /** Passing no vendor rows leaves the day byte-identical to omitting the parameter. */
+    @Test
+    fun emptyVendorRespIsByteIdenticalToOmitting() {
+        val sleepStart = dayStart - 4 * 3_600L
+        val (hr, rr) = nightStreams(sleepStart, sleepStart + 600 * 60L)
+        val provided = listOf(
+            DetectedSleep(sleepStart, sleepStart + 600 * 60L, 0.75, hypnogram(sleepStart),
+                restingHR = null, avgHRV = null),
+        )
+        val omitted = AnalyticsEngine.analyzeDay(day = day, hr = hr, rr = rr, profile = profile,
+            providedSleep = provided)
+        val empty = AnalyticsEngine.analyzeDay(day = day, hr = hr, rr = rr, vendorResp = emptyList(),
+            profile = profile, providedSleep = provided)
+        assertEquals(omitted.daily, empty.daily)
+    }
+
+    // ── The baseline the value feeds ─────────────────────────────────────────────────────────────────
+
+    /**
+     * The composition IntelligenceEngine performs, pinned here because the wiring itself lives in the app
+     * module's engine: a respiration history that crosses brands must fold from the CURRENT era only. A
+     * WHOOP export reports ~16.1 and the ring ~14.6; pooled, the switch reads as a multi-sigma drop — a
+     * device artifact scored as physiology.
+     */
+    @Test
+    fun respBaselineFoldsTheCurrentDeviceEraOnly() {
+        val cfg = Baselines.metricCfg["resp"]!!
+        val dayKeys = ArrayList<String>()
+        val values = ArrayList<Double?>()
+        val sources = ArrayList<Pair<String, String>>()
+        for (i in 0 until 30) {
+            val d = "2026-07-%02d".format(i + 1)
+            val isRing = i >= 20
+            dayKeys.add(d)
+            values.add(if (isRing) 14.6 else 16.1)
+            sources.add(d to if (isRing) ring else "my-whoop")
+        }
+        val epoch = Baselines.deviceEraEpoch(sources)
+        assertTrue("a brand switch must open a new era", epoch > 0.0)
+
+        val scoped = Baselines.foldHistory(values, dayKeys, cfg, epoch)
+        val pooled = Baselines.foldHistory(values, dayKeys, cfg, 0.0)
+        assertEquals("the era-scoped baseline sits on the ring's own nights", 14.6, scoped.baseline, 0.05)
+        assertTrue(
+            "the pooled baseline is dragged up by the previous strap — the defect",
+            pooled.baseline > scoped.baseline + 0.2,
+        )
+        assertTrue(abs(Baselines.deviation(14.6, scoped).z) < 1.0)
+        assertTrue(abs(Baselines.deviation(14.6, pooled).z) > 1.0)
+    }
+
+    /** A single-brand history is untouched: every WHOOP-origin id buckets to one brand. */
+    @Test
+    fun aSingleBrandHistoryIsUnscoped() {
+        val days = (1..30).map {
+            "2026-07-%02d".format(it) to if (it % 2 == 0) "my-whoop" else "my-whoop-noop"
+        }
+        assertEquals(0.0, Baselines.deviceEraEpoch(days), 0.0)
+    }
+}

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -650,11 +650,12 @@ like its sibling banked streams (`.hrv`/`.temp`/`.spo2`/`.sleepPhase`) — the f
   (the 4 nights' records span far less wall-clock than their ring-time range).
 
   ⚠️ **`breath` is the RING's own measurement, not a NOOP-derived estimate — Tier B on decode
-  provenance, stored and shown, and deliberately NOT scored (see the disposition below).** The
+  provenance, stored, and on a ring night it IS the scored `dailyMetric.respRateBpm` (see the three
+  constraints below).** The
   distinction matters: the #194 rule governs signals NOOP *derives* from raw sensor data (PPG→HR
   autocorrelation, RSA-from-R-R), where the method can manufacture a plausible number. Here the firmware
-  computes it and NOOP only decodes a field, the same standing on decode provenance as the ring's own
-  SleepNet hypnogram — which NOOP already persists. What must be right is the decode.
+  computes it and NOOP only decodes a field, the same standing as the ring's own SleepNet hypnogram —
+  which NOOP already persists and scores from. What must be right is the decode.
 
   Both decoders **return nil/null when either declared invariant is violated**: the source's own
   parser throws there, so such a body is not this layout, and "not decoded" is the honest answer. It
@@ -684,27 +685,23 @@ like its sibling banked streams (`.hrv`/`.temp`/`.spo2`/`.sleepPhase`) — the f
   **milli-breaths-per-minute** (`raw == wireByte × 125`, exact for all 256 wire values — the same table
   otherwise carries a WHOOP's raw respiration ADC waveform, a different quantity, so the row's owner is
   what distinguishes them, via `OuraRespScale`). It is shown on the day/Deep-Timeline respiration track
-  in breaths/min.
-
-  **Disposition: INSTRUMENTATION — stored and shown, never scored.** The same measurements that make the
-  decode believable also place it AT the vendor ceiling rather than past it, and CLAUDE.md's #194 rule
-  says what to do with a signal in that position: land it beside the incumbent, never as the default and
-  never feeding a downstream gate. Concretely:
-  1. **Nothing writes `dailyMetric.respRateBpm` from these rows.** That is the scored slot — it feeds
-     recovery's respiration term and `IllnessSignalEngine` — so a ring night's value stays whatever the
-     RSA path returns, which on banked R-R is nothing at all. Pinned by
-     `OuraRespScoringExclusionTests` / `OuraRespScoringExclusionTest`, which passes the rows to
-     `analyzeDay` verbatim and asserts the day comes back byte-identical.
-  2. **It never reaches the sleep stager.** `OuraRespScale.forScoring` keeps it out at every scoring
-     read: the stager reads `respSample` as a ~1 Hz raw ADC WAVEFORM and would run a peak detector over a
-     per-window RATE — a shape mismatch, not a trust one, and the same reason 0x47 motion is never folded
-     into `gravitySample` (#804). This refusal is by PROVENANCE, not by cadence: today's ~296 s spacing
-     would starve the peak detector anyway, and that is luck a decoder change could revoke.
-  3. **What it would take to score it.** Its own evidence and its own review — and a decision about the
-     baseline it would enter, which is one day-keyed series shared across sources: a WHOOP export reports
-     its own measured rate (~16.1 on the reference history) against the ring's ~14.6, so a strap SWITCH
-     would read as a ~3σ illness-ward step against a ~0.52 bpm spread. `Baselines.deviceEraEpoch` (#459)
-     is the primitive for that and is still unwired for every baseline.
+  in breaths/min, and it **becomes the night's `dailyMetric.respRateBpm`** — the scored slot — in place of
+  NOOP's RSA-from-R-R estimate, which on a ring night is built from banked R-R and carries no breathing
+  information at all (shuffling the night returns the same 13.3333 bpm). Three constraints ride with that:
+  1. **Coverage, not trust:** the night's value is the MEDIAN of the rows inside a matched in-bed session,
+     and only when they SPAN ≥ 1 h (`AnalyticsEngine.vendorRespMinSpanS`) and the median lands inside the
+     8–25 bpm band the RSA path is clamped to. A 36-minute tail of a night is not that night's
+     respiration — and the gate is on span, not row count, because the record cadence is not constant
+     (real nights hold both ~30 s and ~296 s spacing).
+  2. **The baseline is scoped to the current device era** (`Baselines.deviceEraEpoch`, #459). A WHOOP
+     export reports its own measured rate (~16.1 on the reference history) and the ring reports ~14.6, so
+     pooling them in one 28-day baseline turns a strap SWITCH into a ~3σ illness-ward step against a
+     ~0.52 bpm spread — a device artifact scored as physiology. A single-brand history is unaffected
+     (the epoch is 0.0, i.e. the fold is byte-identical to before).
+  3. **It never reaches the sleep stager.** `OuraRespScale.forScoring` keeps it out: the stager reads
+     `respSample` as a ~1 Hz raw ADC WAVEFORM and would run a peak detector over a per-window RATE — a
+     shape mismatch, not a trust one, and the same reason 0x47 motion is never folded into
+     `gravitySample` (#804).
 
   📌 **This does not retract the respiratory-rate gate.** That work proved RSA is unrecoverable *from
   banked IBI* (shuffling the beats returns the same value; re-timing defeats the gate) and refusing to


### PR DESCRIPTION
## What this does

Three commits:
1. **Revert 0dc3322d** ("keep the ring's 0x6A breath rate out of the scored slot") — restores
   #1384's original wiring in full: `AnalyticsEngine.vendorRespRateBpm`, the `deviceEraEpoch`
   fold-scoping, both platforms, and the `VendorRespRateTests`/`VendorRespRateTest` suites 0dc3322d
   deleted (9 tests/platform: median, out-of-session rows ignored, the span gate, the plausible-band
   refusal, `analyzeDay` preferring the device rate, empty-vendor byte-identity, the era-scoped fold).
2. **Fix `deviceEraEpoch`'s source-day assembly** (`IntelligenceEngine.swift` / `.kt`) — found while
   restoring commit 1, not proven against real hardware data (see "What's NOT proven" below).
   `respSourceByDay` was built value-priority order (`hist` first, `resolvedScoreOwnerByDay` only
   filling gaps). That's correct for the VALUE (an import legitimately outranks a computed one) but
   wrong for the SOURCE-BRAND tag `deviceEraEpoch` reads: `hist` is every day already stored under
   this device's own id by construction — an Oura-owned day scored on a prior pass is filed there
   exactly like a WHOOP-owned one — so filling from `hist` first tags that day "whoop" on every
   re-score after its first. That's the "brand is lost once a wearable day is re-homed under the
   computed WHOOP id" trap `deviceEraEpoch`'s own contract already warns against, just inverted at
   the call site: it would neuter era-scoping in steady state, not just on day one. Swapped: this
   pass's freshly resolved owner now wins, `hist` only fills days outside the scan window.
3. **Re-flip the six comments #1386 corrected** (`EventTags`/`OuraDriver`/`OuraEvents`, both
   platforms) back to the restored disposition. Comments only.

## Why re-open this

**The one-sentence version: this is the ring's own number, not one NOOP computed.** `0x6A`'s
`breath` field is a value Oura's firmware measured and transmitted over BLE; NOOP's role here is
limited to decoding a byte and taking a median — the same thing NOOP already does for the ring's own
`0x60`/`0x6E` HR and `0x6F`/`0x7B` SpO2, none of which are treated as a NOOP-derived estimate subject
to #194's bar. Nothing about *this* number is manufactured by NOOP signal processing; the ring
computed it before NOOP ever saw the byte.

`0dc3322d` cut the scored write citing CLAUDE.md's #194 rule: `r(Oura's own app, WHOOP) = +0.680`
over 18 nights is the permanent ceiling, so no Oura-derived rate can beat WHOOP-agreement, and #194
says instrument rather than score/gate on thin evidence.

That reasoning conflates two different things. #194 is written for a signal **NOOP derives from raw
sensor data** — PPG-autocorrelation, RSA-from-R-R — where NOOP's own signal processing can
manufacture an artifact that coincidentally looks physiological (the #194 precedent itself, and why
RSA-from-banked-R-R stays refused separately here). `breath` isn't that: it's a value the ring's
firmware already computed and transmits; NOOP only decodes it. `OuraRespScale`'s own comment already
half-concedes this — the *staging* exclusion is "a SHAPE refusal, not a trust one... which this one
increasingly is not (the ring computes it)."

And the r=+0.680 ceiling isn't evidence the number is wrong. Δ(Oura, WHOOP) is a **stable,
sign-consistent offset** — 18/18 nights for Oura's own app, 6/6 for our decode, no sign flip ever —
which is the signature of two devices measuring respiration slightly differently (finger/ring vs
wrist, different algorithm window), not of noise. A pure-noise decode would not hold a constant
bias. Judging a manufacturer-reported cross-vendor value by "does it reproduce WHOOP" asks it to
clear a bar no Oura-derived number ever could, including Oura's own — see
`worklog/analysis/oura-0x6a-resp-ledger.md` for the full ledger this was built on.

## Hardware validation (2026-08-19)

A full night (08-18/19, `integration/oura-full@97d46730`, which carries both commits 1 and 2 above
after the 2026-08-18 rebase) validated both halves:

- **Write path, not stale.** `dailyMetric.respRateBpm` for `my-whoop-noop` / 2026-08-19 = **15.5**.
  Independently recomputed the median from the raw `oura-resp.jsonl` sidecar, filtered to the
  WHOOP-confirmed sleep window (22:43–08:25 local, WHOOP screenshot supplied same night): 1,052
  breath readings, median = **15.5**, mean = 15.24 — the stored value matches the
  independently-recomputed median exactly. The value also differs from both neighbouring nights
  (13.875 on 08-18, 14.5625 on 08-17), ruling out a copy-forward carry.
- **Era-scoping, the exact target scenario is live in this install's real history, not hypothetical.**
  `dailyMetric` has a genuine WHOOP→Oura brand boundary: the old canonical WHOOP-era id (`my-whoop`)
  holds 317 rows running 2025-09-16→2026-07-30 with `respRateBpm` in the 15.9–16.8 range right up to
  the switch; every day since 07-28 has been resolved and scored under the ring's own id
  (`oura-2H3B2405003655`). `hist` (317 WHOOP-era rows) and this pass's freshly-resolved
  `resolvedScoreOwnerByDay` (a 21-day scan window, 2026-07-30→2026-08-19) overlap on exactly one day,
  **2026-07-30** — the last WHOOP-owned day in `hist` and the first day of this pass's scan window.
  Pre-fix (hist-wins), that day would keep its stale `"whoop"` tag on every re-score regardless of
  who actually owns it now; post-fix (resolvedScoreOwnerByDay-wins), it correctly flips to `"oura"`.
  The leak this closes is non-trivial: `my-whoop`'s 07-30 `respRateBpm` (15.6) sits *close* to the
  current Oura-era range (13.875–15.5) but is drawn from a structurally different measurement (a
  WHOOP-device rate vs the ring's own `0x6A`) — exactly the mixed-method pooling `deviceEraEpoch`
  exists to prevent, and close enough in value that a silent leak would have gone unnoticed by eye.
  What's still not directly observed: no log line prints the computed `deviceEraEpoch`/
  `respSourceByDay` values at runtime (same app-target-Swift-has-no-unit-test-target gap noted
  below), so this is a structural/DB cross-check confirming every precondition the fix depends on is
  live and firing, not an instrumented trace of the specific epoch chosen.

Full writeup: `worklog/analysis/2026-08-19-0900-suspend-fail-resp-pass-dedup-pass.txt` §4 (this PR
was one of four things validated on that capture; the other three are unrelated to this change).

## What's NOT proven

- The era-epoch value itself was never captured by a direct runtime log line — see the last bullet
  above. `IntelligenceEngine.swift` is app-target Swift with no unit-test target (`StrandTests` only
  runs under `xcodebuild … test`), so this stays a structural/DB argument rather than a debugger
  trace, even after two supporting hardware nights (08-16 write-path, 08-19 write-path + era-scoping
  precondition check).
- `average_hr` from the same 0x6A record stays refused, as does RSA-from-banked-R-R — neither
  changes here.

## Verification

- `swift test`: OuraProtocol 202/0, WhoopStore 414/0, StrandAnalytics 1461/0 (includes the restored
  `VendorRespRateTests`).
- `Strand` (macOS) and `NOOPiOS` app targets both compile locally — no default CI covers app-target
  Swift.
- Android: `compileFullDebugKotlin` clean, `testFullDebugUnitTest` 4040/0 (includes the restored
  `VendorRespRateTest`).
- Hardware: 08-16 (write path, pre-commit-2) and 08-18/19 (write path + era-scoping precondition,
  post-commit-2, post-rebase) — see "Hardware validation" above.