### PR TITLE
diag(rr): log the record cadence and per-record fill the census could not show (#1451)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RrEmissionStats.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RrEmissionStats.swift
@@ -45,15 +45,38 @@ public enum RrEmissionStats {
         /// Histogram of intervals-per-second: index 0 = seconds with exactly 1, 1 = exactly 2,
         /// 2 = exactly 3, 3 = 4 or more.
         public let perSecond: [Int]
+        /// Histogram of the gap between CONSECUTIVE record timestamps, in seconds: index 0 = 1 s,
+        /// … index 6 = 7 s, index 7 = 8 s or more. Its mode is the strap's record cadence, which is the
+        /// baseline `ratioRep` has to be read against — a strap banking one record every 5 s reads
+        /// `ratioRep` ≈ 5 while perfectly healthy (#1451).
+        public let gapHist: [Int]
+        /// Histogram of per-record FILL: that record's Σ(rrMs) over its own slot (the gap to the next
+        /// record). Index 0 = ≤1.0, 1 = ≤1.5, 2 = ≤2.0, 3 = >2.0. This is the measurement a timeline fix
+        /// needs and no aggregate can supply: whether ONE record carries more beat-time than the interval
+        /// it covers. Fill ~1.0 means records tile the timeline and each interval can be placed at its own
+        /// reconstructed beat time; a fat tail means the records themselves overflow and no placement
+        /// scheme built on the record timestamp can be correct. The final record has no successor and is
+        /// excluded.
+        public let fill: [Int]
 
         public init(secondsWithRr: Int, intervals: Int, sumRrMs: Int, spanSec: Int,
-                    ratio: Double, perSecond: [Int]) {
+                    ratio: Double, perSecond: [Int],
+                    gapHist: [Int] = [0, 0, 0, 0, 0, 0, 0, 0], fill: [Int] = [0, 0, 0, 0]) {
             self.secondsWithRr = secondsWithRr
             self.intervals = intervals
             self.sumRrMs = sumRrMs
             self.spanSec = spanSec
             self.ratio = ratio
             self.perSecond = perSecond
+            self.gapHist = gapHist
+            self.fill = fill
+        }
+
+        /// The modal record gap in seconds — the mode of `gapHist`, with 8 meaning "8 or more".
+        /// 0 when the batch held fewer than two records. This is the healthy baseline for `ratioRep`.
+        public var modalGapSec: Int {
+            guard let m = gapHist.max(), m > 0, let i = gapHist.firstIndex(of: m) else { return 0 }
+            return i + 1
         }
     }
 
@@ -80,9 +103,24 @@ public enum RrEmissionStats {
             let i = min(vals.count, 4) - 1
             if i >= 0 { hist[i] += 1 }
         }
+        // Per-record cadence and fill (#1451). A record's SLOT is the gap to the next record, so the last
+        // record is excluded — it has no successor to bound it.
+        let stamps = bySecond.keys.sorted()
+        var gapHist = [0, 0, 0, 0, 0, 0, 0, 0]
+        var fill = [0, 0, 0, 0]
+        if stamps.count >= 2 {
+            for i in 0..<(stamps.count - 1) {
+                let gap = stamps[i + 1] - stamps[i]
+                guard gap >= 1 else { continue }
+                gapHist[min(gap, 8) - 1] += 1
+                let recSum = (bySecond[stamps[i]] ?? []).reduce(0, +)
+                let f = Double(recSum) / 1000.0 / Double(gap)
+                fill[f <= 1.0 ? 0 : (f <= 1.5 ? 1 : (f <= 2.0 ? 2 : 3))] += 1
+            }
+        }
         let ratio = span > 0 ? Double(sum) / 1000.0 / Double(span) : 0
         return Result(secondsWithRr: bySecond.count, intervals: rr.count, sumRrMs: sum,
-                      spanSec: span, ratio: ratio, perSecond: hist)
+                      spanSec: span, ratio: ratio, perSecond: hist, gapHist: gapHist, fill: fill)
     }
 
     /// One compact log line. `offered`/`inserted` come from the caller: `inserted` is what the store
@@ -105,6 +143,8 @@ public enum RrEmissionStats {
         return "rr emit path=\(path) offered=\(offered) inserted=\(inserted) secs=\(r.secondsWithRr) "
             + "sumRr=\(r.sumRrMs / 1000)s span=\(r.spanSec)s ratio=\(ratio) "
             + "ratioRep=\(String(format: "%.2f", rep)) "
-            + "perSec[1/2/3/4+]=\(h[0])/\(h[1])/\(h[2])/\(h[3])"
+            + "perSec[1/2/3/4+]=\(h[0])/\(h[1])/\(h[2])/\(h[3]) "
+            + "modalGap=\(r.modalGapSec)s "
+            + "fill[<=1/<=1.5/<=2/>2]=\(r.fill[0])/\(r.fill[1])/\(r.fill[2])/\(r.fill[3])"
     }
 }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RrEmissionStats.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RrEmissionStats.swift
@@ -45,10 +45,12 @@ public enum RrEmissionStats {
         /// Histogram of intervals-per-second: index 0 = seconds with exactly 1, 1 = exactly 2,
         /// 2 = exactly 3, 3 = 4 or more.
         public let perSecond: [Int]
-        /// Histogram of the gap between CONSECUTIVE record timestamps, in seconds: index 0 = 1 s,
-        /// … index 6 = 7 s, index 7 = 8 s or more. Its mode is the strap's record cadence, which is the
-        /// baseline `ratioRep` has to be read against — a strap banking one record every 5 s reads
-        /// `ratioRep` ≈ 5 while perfectly healthy (#1451).
+        /// Histogram of the gap between consecutive records THAT CARRIED R-R, in seconds: index 0 = 1 s,
+        /// … index 6 = 7 s, index 7 = 8 s or more. Not the strap's raw record cadence — a record banking
+        /// no interval is invisible here — but that is exactly the right set, because `ratioRep` divides
+        /// by the same one: healthy `ratioRep` ≈ the mean of these gaps, whose mode this reports. A strap
+        /// banking R-R every 5 s reads `ratioRep` ≈ 5 while perfectly healthy, so reading it against 1.0
+        /// would invent a defect (#1451). Ties resolve to the smaller gap on both platforms.
         public let gapHist: [Int]
         /// Histogram of per-record FILL: that record's Σ(rrMs) over its own slot (the gap to the next
         /// record). Index 0 = ≤1.0, 1 = ≤1.5, 2 = ≤2.0, 3 = >2.0. This is the measurement a timeline fix
@@ -56,7 +58,9 @@ public enum RrEmissionStats {
         /// it covers. Fill ~1.0 means records tile the timeline and each interval can be placed at its own
         /// reconstructed beat time; a fat tail means the records themselves overflow and no placement
         /// scheme built on the record timestamp can be correct. The final record has no successor and is
-        /// excluded.
+        /// excluded. Known bias: the slot is the gap to the next R-R-carrying record, so if a strap
+        /// interleaves records without intervals the slot spans more than one record period and fill reads
+        /// LOW. It can therefore understate overflow, never manufacture it.
         public let fill: [Int]
 
         public init(secondsWithRr: Int, intervals: Int, sumRrMs: Int, spanSec: Int,

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrEmissionStatsTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrEmissionStatsTests.swift
@@ -74,6 +74,35 @@ final class RrEmissionStatsTests: XCTestCase {
         XCTAssertEqual(RrEmissionStats.compute(rr).perSecond, [0, 0, 0, 1])
     }
 
+    /// #1451: a strap banking one record every 5 s is HEALTHY, but its reporting-second ratio reads ~5.
+    /// `modalGap` states the cadence so that ratio is read against the right baseline instead of against
+    /// 1.0, and `fill` shows each record's beat-time fits the slot it covers. Kotlin twin:
+    /// `modalGapReportsRecordCadenceAndFillFitsOnAHealthyMultiSecondStrap`.
+    func testModalGapReportsRecordCadenceAndFillFitsOnAHealthyMultiSecondStrap() {
+        // Six records, 5 s apart, each carrying 5 s of beat-time in 6 intervals (~833 ms each).
+        var rr: [(ts: Int, rrMs: Int)] = []
+        for rec in 0..<6 { for _ in 0..<6 { rr.append((ts: rec * 5, rrMs: 833)) } }
+        let r = RrEmissionStats.compute(rr)
+        XCTAssertEqual(r.modalGapSec, 5)               // cadence discovered, not assumed
+        XCTAssertEqual(r.fill, [5, 0, 0, 0])           // every bounded record fits its own slot
+        let line = RrEmissionStats.logLine(path: "historical", offered: rr.count, inserted: rr.count, r)
+        XCTAssertTrue(line.contains("modalGap=5s"), line)
+        XCTAssertTrue(line.contains("fill[<=1/<=1.5/<=2/>2]=5/0/0/0"), line)
+    }
+
+    /// #1451: the measurement a timeline fix needs. Records 1 s apart each carrying ~1.7 s of beat-time
+    /// overflow the interval they cover, so no scheme that places beats inside a record's own slot can be
+    /// correct. Kotlin twin: `fillCatchesRecordsCarryingMoreBeatTimeThanTheirSlot`.
+    func testFillCatchesRecordsCarryingMoreBeatTimeThanTheirSlot() {
+        var rr: [(ts: Int, rrMs: Int)] = []
+        for t in 0..<5 { rr.append((ts: t, rrMs: 850)); rr.append((ts: t, rrMs: 850)) }
+        let r = RrEmissionStats.compute(rr)
+        XCTAssertEqual(r.modalGapSec, 1)
+        XCTAssertEqual(r.fill, [0, 0, 4, 0])           // 1.7 lands in the <=2.0 bucket, four bounded records
+        let line = RrEmissionStats.logLine(path: "historical", offered: 10, inserted: 10, r)
+        XCTAssertTrue(line.contains("fill[<=1/<=1.5/<=2/>2]=0/0/4/0"), line)
+    }
+
     /// The log line is what a strap capture actually carries, so its shape is pinned too.
     func testLogLineShape() {
         let r = RrEmissionStats.compute([(ts: 10, rrMs: 800), (ts: 10, rrMs: 820), (ts: 11, rrMs: 810)])

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrEmissionStatsTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrEmissionStatsTests.swift
@@ -99,6 +99,9 @@ final class RrEmissionStatsTests: XCTestCase {
         let r = RrEmissionStats.compute(rr)
         XCTAssertEqual(r.modalGapSec, 1)
         XCTAssertEqual(r.fill, [0, 0, 4, 0])           // 1.7 lands in the <=2.0 bucket, four bounded records
+        // The two measures are coupled, and that is the point: if every record fitted its slot the totals
+        // could not exceed the span either. `ratio` says the session over-counts; `fill` says WHICH records.
+        XCTAssertGreaterThan(r.ratio, 1.0)
         let line = RrEmissionStats.logLine(path: "historical", offered: 10, inserted: 10, r)
         XCTAssertTrue(line.contains("fill[<=1/<=1.5/<=2/>2]=0/0/4/0"), line)
     }

--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -96,6 +96,8 @@ final class Backfiller {
     private(set) var sessionRrMinTs: Int?
     private(set) var sessionRrMaxTs: Int?
     private(set) var sessionRrHist = [0, 0, 0, 0]
+    private(set) var sessionRrGapHist = [0, 0, 0, 0, 0, 0, 0, 0]
+    private(set) var sessionRrFill = [0, 0, 0, 0]
 
     /// "persisted N rows (M with motion) across K night(s)". Nights are day-keys (ts / 86400).
     private(set) var sessionRowsPersisted = 0
@@ -251,6 +253,8 @@ final class Backfiller {
         sessionRrMinTs = nil
         sessionRrMaxTs = nil
         sessionRrHist = [0, 0, 0, 0]
+        sessionRrGapHist = [0, 0, 0, 0, 0, 0, 0, 0]
+        sessionRrFill = [0, 0, 0, 0]
         sessionMotionRows = 0
         sessionSkinTempRows = 0
         sessionNightKeys.removeAll(keepingCapacity: true)
@@ -333,7 +337,8 @@ final class Backfiller {
         let ratio = Double(sessionRrSumMs) / 1000.0 / Double(span)
         let r = RrEmissionStats.Result(secondsWithRr: sessionRrHist.reduce(0, +),
                                        intervals: sessionRrOffered, sumRrMs: sessionRrSumMs,
-                                       spanSec: span, ratio: ratio, perSecond: sessionRrHist)
+                                       spanSec: span, ratio: ratio, perSecond: sessionRrHist,
+                                       gapHist: sessionRrGapHist, fill: sessionRrFill)
         return RrEmissionStats.logLine(path: "historical", offered: sessionRrOffered,
                                        inserted: sessionRrInserted, r)
     }
@@ -651,6 +656,8 @@ final class Backfiller {
                 sessionRrMinTs = min(sessionRrMinTs ?? lo, lo)
                 sessionRrMaxTs = max(sessionRrMaxTs ?? hi, hi)
                 for i in 0..<4 { sessionRrHist[i] += rrCensus.perSecond[i] }
+                for i in 0..<8 { sessionRrGapHist[i] += rrCensus.gapHist[i] }
+                for i in 0..<4 { sessionRrFill[i] += rrCensus.fill[i] }
             }
             sessionMotionRows += tally.motion
             sessionSkinTempRows += counts.skinTemp

--- a/android/app/src/main/java/com/noop/analytics/RrEmissionStats.kt
+++ b/android/app/src/main/java/com/noop/analytics/RrEmissionStats.kt
@@ -41,9 +41,12 @@ object RrEmissionStats {
         /** Intervals-per-second histogram: index 0 = exactly 1, 1 = 2, 2 = 3, 3 = 4 or more. */
         val perSecond: List<Int>,
         /**
-         * Gap between CONSECUTIVE record timestamps, in seconds: index 0 = 1 s … index 7 = 8 s or more.
-         * Its mode is the strap's record cadence, which is the baseline [ratio]'s reporting-second twin has
-         * to be read against — a strap banking one record every 5 s reads ratioRep ~5 while healthy (#1451).
+         * Gap between consecutive records THAT CARRIED R-R, in seconds: index 0 = 1 s … index 7 = 8 s or
+         * more. Not the strap's raw record cadence — a record banking no interval is invisible here — but
+         * that is exactly the right set, because ratioRep divides by the same one: healthy ratioRep ~ the
+         * mean of these gaps, whose mode this reports. A strap banking R-R every 5 s reads ratioRep ~5
+         * while perfectly healthy, so reading it against 1.0 would invent a defect (#1451). Ties resolve to
+         * the smaller gap on both platforms.
          */
         val gapHist: List<Int> = listOf(0, 0, 0, 0, 0, 0, 0, 0),
         /**
@@ -53,6 +56,9 @@ object RrEmissionStats {
          * Fill ~1.0 means records tile the timeline and each interval can be placed at its own
          * reconstructed beat time; a fat tail means the records themselves overflow and no placement scheme
          * built on the record timestamp can be correct. The final record has no successor and is excluded.
+         * Known bias: the slot is the gap to the next R-R-carrying record, so if a strap interleaves
+         * records without intervals the slot spans more than one record period and fill reads LOW. It can
+         * therefore understate overflow, never manufacture it.
          */
         val fill: List<Int> = listOf(0, 0, 0, 0),
     ) {

--- a/android/app/src/main/java/com/noop/analytics/RrEmissionStats.kt
+++ b/android/app/src/main/java/com/noop/analytics/RrEmissionStats.kt
@@ -40,7 +40,32 @@ object RrEmissionStats {
         val ratio: Double,
         /** Intervals-per-second histogram: index 0 = exactly 1, 1 = 2, 2 = 3, 3 = 4 or more. */
         val perSecond: List<Int>,
-    )
+        /**
+         * Gap between CONSECUTIVE record timestamps, in seconds: index 0 = 1 s … index 7 = 8 s or more.
+         * Its mode is the strap's record cadence, which is the baseline [ratio]'s reporting-second twin has
+         * to be read against — a strap banking one record every 5 s reads ratioRep ~5 while healthy (#1451).
+         */
+        val gapHist: List<Int> = listOf(0, 0, 0, 0, 0, 0, 0, 0),
+        /**
+         * Per-record FILL: that record's sum of rrMs over its own slot (the gap to the next record).
+         * Index 0 = <=1.0, 1 = <=1.5, 2 = <=2.0, 3 = >2.0. This is the measurement a timeline fix needs and
+         * no aggregate can supply: whether ONE record carries more beat-time than the interval it covers.
+         * Fill ~1.0 means records tile the timeline and each interval can be placed at its own
+         * reconstructed beat time; a fat tail means the records themselves overflow and no placement scheme
+         * built on the record timestamp can be correct. The final record has no successor and is excluded.
+         */
+        val fill: List<Int> = listOf(0, 0, 0, 0),
+    ) {
+        /**
+         * Modal record gap in seconds — the mode of [gapHist], 8 meaning "8 or more". 0 when the batch held
+         * fewer than two records. This is the healthy baseline for the reporting-second ratio.
+         */
+        val modalGapSec: Int
+            get() {
+                val m = gapHist.maxOrNull() ?: 0
+                return if (m <= 0) 0 else gapHist.indexOf(m) + 1
+            }
+    }
 
     /** Census a decoded batch. [rr] is the decoder's output order; nothing is mutated or sorted in place. */
     fun compute(rr: List<Pair<Int, Int>>): Result {
@@ -64,8 +89,22 @@ object RrEmissionStats {
             val i = minOf(vals.size, 4) - 1
             if (i >= 0) hist[i] = hist[i] + 1
         }
+        // Per-record cadence and fill (#1451). A record's SLOT is the gap to the next record, so the last
+        // record is excluded — it has no successor to bound it.
+        val stamps = bySecond.keys.sorted()
+        val gapHist = mutableListOf(0, 0, 0, 0, 0, 0, 0, 0)
+        val fill = mutableListOf(0, 0, 0, 0)
+        for (i in 0 until maxOf(stamps.size - 1, 0)) {
+            val gap = stamps[i + 1] - stamps[i]
+            if (gap < 1) continue
+            gapHist[minOf(gap, 8) - 1] = gapHist[minOf(gap, 8) - 1] + 1
+            val recSum = bySecond[stamps[i]]?.sum() ?: 0
+            val f = recSum / 1000.0 / gap
+            val b = if (f <= 1.0) 0 else if (f <= 1.5) 1 else if (f <= 2.0) 2 else 3
+            fill[b] = fill[b] + 1
+        }
         val ratio = if (span > 0) sum / 1000.0 / span else 0.0
-        return Result(bySecond.size, rr.size, sum, span, ratio, hist)
+        return Result(bySecond.size, rr.size, sum, span, ratio, hist, gapHist, fill)
     }
 
     /**
@@ -88,6 +127,8 @@ object RrEmissionStats {
         return "rr emit path=$path offered=$offered inserted=$inserted secs=${r.secondsWithRr} " +
             "sumRr=${r.sumRrMs / 1000}s span=${r.spanSec}s ratio=$ratio " +
             "ratioRep=${String.format(java.util.Locale.US, "%.2f", rep)} " +
-            "perSec[1/2/3/4+]=${h[0]}/${h[1]}/${h[2]}/${h[3]}"
+            "perSec[1/2/3/4+]=${h[0]}/${h[1]}/${h[2]}/${h[3]} " +
+            "modalGap=${r.modalGapSec}s " +
+            "fill[<=1/<=1.5/<=2/>2]=${r.fill[0]}/${r.fill[1]}/${r.fill[2]}/${r.fill[3]}"
     }
 }

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -190,6 +190,8 @@ class Backfiller(
     var sessionRrMinTs: Int? = null
     var sessionRrMaxTs: Int? = null
     val sessionRrHist = mutableListOf(0, 0, 0, 0)
+    val sessionRrGapHist = mutableListOf(0, 0, 0, 0, 0, 0, 0, 0)
+    val sessionRrFill = mutableListOf(0, 0, 0, 0)
 
     /** #42: set by [begin] when this session continues an auto-continue burst (#364) that already banked
      *  rows in an earlier session, so a trim=0xFFFFFFFF END here reads as "caught up", not "no history".
@@ -304,6 +306,8 @@ class Backfiller(
         sessionRrMinTs = null
         sessionRrMaxTs = null
         for (i in 0 until 4) sessionRrHist[i] = 0
+        for (i in 0 until 8) sessionRrGapHist[i] = 0
+        for (i in 0 until 4) sessionRrFill[i] = 0
         sessionMotionRows = 0
         sessionSkinTempRows = 0
         sessionNightKeys.clear()
@@ -560,6 +564,8 @@ class Backfiller(
                     sessionRrMinTs = minOf(sessionRrMinTs ?: lo, lo)
                     sessionRrMaxTs = maxOf(sessionRrMaxTs ?: hi, hi)
                     for (i in 0 until 4) sessionRrHist[i] = sessionRrHist[i] + rrCensus.perSecond[i]
+                    for (i in 0 until 8) sessionRrGapHist[i] = sessionRrGapHist[i] + rrCensus.gapHist[i]
+                    for (i in 0 until 4) sessionRrFill[i] = sessionRrFill[i] + rrCensus.fill[i]
                 }
                 sessionMotionRows += motion
                 sessionSkinTempRows += counts.skinTemp
@@ -677,6 +683,8 @@ class Backfiller(
             spanSec = span,
             ratio = ratio,
             perSecond = sessionRrHist.toList(),
+            gapHist = sessionRrGapHist.toList(),
+            fill = sessionRrFill.toList(),
         )
         return com.noop.analytics.RrEmissionStats.logLine("historical", sessionRrOffered, sessionRrInserted, r)
     }

--- a/android/app/src/test/java/com/noop/analytics/RrEmissionStatsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RrEmissionStatsTest.kt
@@ -110,6 +110,9 @@ class RrEmissionStatsTest {
         val r = RrEmissionStats.compute(rr)
         assertEquals(1, r.modalGapSec)
         assertEquals(listOf(0, 0, 4, 0), r.fill)       // 1.7 lands in the <=2.0 bucket, four bounded records
+        // The two measures are coupled, and that is the point: if every record fitted its slot the totals
+        // could not exceed the span either. `ratio` says the session over-counts; `fill` says WHICH records.
+        assertTrue("ratio=${r.ratio}", r.ratio > 1.0)
         assertTrue(RrEmissionStats.logLine("historical", 10, 10, r).contains("fill[<=1/<=1.5/<=2/>2]=0/0/4/0"))
     }
 

--- a/android/app/src/test/java/com/noop/analytics/RrEmissionStatsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RrEmissionStatsTest.kt
@@ -74,6 +74,45 @@ class RrEmissionStatsTest {
         assertEquals(listOf(0, 0, 0, 1), RrEmissionStats.compute(rr).perSecond)
     }
 
+    /**
+     * #1451: a strap banking one record every 5 s is HEALTHY, but its reporting-second ratio reads ~5.
+     * modalGap states the cadence so that ratio is read against the right baseline instead of against 1.0,
+     * and fill shows each record's beat-time fits the slot it covers. Twin of Swift
+     * `testModalGapReportsRecordCadenceAndFillFitsOnAHealthyMultiSecondStrap`.
+     */
+    @Test
+    fun modalGapReportsRecordCadenceAndFillFitsOnAHealthyMultiSecondStrap() {
+        // Six records, 5 s apart, each carrying 5 s of beat-time in 6 intervals (~833 ms each).
+        val rr = mutableListOf<Pair<Int, Int>>()
+        for (rec in 0 until 6) {
+            repeat(6) { rr.add(rec * 5 to 833) }
+        }
+        val r = RrEmissionStats.compute(rr)
+        assertEquals(5, r.modalGapSec)                 // cadence discovered, not assumed
+        assertEquals(listOf(5, 0, 0, 0), r.fill)       // every bounded record fits its own slot
+        val line = RrEmissionStats.logLine("historical", rr.size, rr.size, r)
+        assertTrue(line, line.contains("modalGap=5s"))
+        assertTrue(line, line.contains("fill[<=1/<=1.5/<=2/>2]=5/0/0/0"))
+    }
+
+    /**
+     * #1451: the measurement a timeline fix needs. Records 1 s apart each carrying ~1.7 s of beat-time
+     * overflow the interval they cover, so no scheme that places beats inside a record's own slot can be
+     * correct. Twin of Swift `testFillCatchesRecordsCarryingMoreBeatTimeThanTheirSlot`.
+     */
+    @Test
+    fun fillCatchesRecordsCarryingMoreBeatTimeThanTheirSlot() {
+        val rr = mutableListOf<Pair<Int, Int>>()
+        for (t in 0 until 5) {
+            rr.add(t to 850)
+            rr.add(t to 850)   // two full beats stamped on one 1 s record = 1.7x fill
+        }
+        val r = RrEmissionStats.compute(rr)
+        assertEquals(1, r.modalGapSec)
+        assertEquals(listOf(0, 0, 4, 0), r.fill)       // 1.7 lands in the <=2.0 bucket, four bounded records
+        assertTrue(RrEmissionStats.logLine("historical", 10, 10, r).contains("fill[<=1/<=1.5/<=2/>2]=0/0/4/0"))
+    }
+
     @Test
     fun logLineShape() {
         val r = RrEmissionStats.compute(listOf(Pair(10, 800), Pair(10, 820), Pair(11, 810)))


### PR DESCRIPTION
Follow-up to #1443. The pre-storage census aggregates a whole session — enough to compare straps, not
enough to design the fix — and its reporting-second ratio turned out to be **uninterpretable on a strap we
have never measured**.

## `modalGap` — the baseline `ratioRep` has to be read against

`ratioRep`'s healthy value is the **mean record spacing, not 1.0**. On a 1 Hz-record strap the two
coincide, which is why this never bit on a WHOOP 4.0. A strap banking one record every 5 s reads
`ratioRep` ≈ 5 **while perfectly healthy**.

5.0/MG variant records carry multi-sample IMU blocks, so that is precisely the strap #1451 asks about —
the comparison I set up could have manufactured a defect out of nothing more than a different cadence.
The mean was already derivable as `span / secs`; now the line states it outright.

## `fill` — the measurement a timeline fix turns on

Each record's own Σ(rrMs) over **its own slot** (the gap to the next record), bucketed ≤1.0 / ≤1.5 / ≤2.0 /
>2.0. No aggregate can supply this: the census can say a session carries 1.7× the beat-time it should
without saying whether that is *one record overflowing* or *records tiling correctly and being counted
twice*.

That distinction decides the leading candidate fix — placing each interval at its own reconstructed beat
time by walking the cumulative sum back from the record stamp:

- **fill ~1.0** → records tile the timeline, the reconstruction is well-defined, and the fix is viable
- **fat tail** → the records themselves overflow their slot, and no placement scheme built on the record
  timestamp can be correct

Knowing that *before* building it is the entire point. It also keeps this honest about what it does **not**
settle: whether the record stamp is the start or the end of the period it covers. If fill reads ~1.0 that
ambiguity stops mattering for reconstruction; if it doesn't, the reconstruction is dead either way.

## Scope and caveats

Instrumentation only — nothing in the shipped path reads either field. The final record of a batch is
excluded from both (no successor to bound it), and a second split across a chunk boundary stays uncounted,
as before.

## Verification

- Mirrored vectors on both platforms, including the case that motivated this: a healthy strap on a 5 s
  cadence reads `modalGap=5s` with every record fitting, and records carrying 1.7 s of beat-time in a 1 s
  slot land in the >1.5 bucket
- Android **4,072 tests / 0 failures**; Kotlin compile, i18n and doc-comment gates clean
- `swift-packages` executes the Swift twins; app-build dispatched because `Strand/Collect/Backfiller.swift`
  is app-target Swift that no default CI compiles