### PR TITLE
Fix sleep cache gravity fingerprint collisions

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsMemo.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsMemo.swift
@@ -102,4 +102,5 @@ struct StreamFingerprint: Hashable {
         if count == 0 { return StreamFingerprint(count: 0, firstTs: 0, lastTs: 0, checksum: 0) }
         return StreamFingerprint(count: count, firstTs: firstTs, lastTs: lastTs, checksum: sum)
     }
+
 }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -983,8 +983,14 @@ public enum SleepStager {
         // that steers detection or staging — the four streams, the tz offset (daytime-guard + onset band),
         // the off-wrist intervals (#500 backstop), the persisted band state (#531 H8), and the V2 toggle (an
         // edit to any re-keys to a fresh compute). Result-only + bounded; the raw arrays are never retained.
+        // Match Android's raw-axis semantics: mix x/y/z IEEE-754 bits in order, never their lossy sum.
         let key = DetectKey(
-            grav: StreamFingerprint.of(gravity, ts: { $0.ts }, quant: { Int(($0.x + $0.y + $0.z) * 1024) }),
+            grav: StreamFingerprint.of(gravity, ts: { $0.ts }, quant: {
+                var bits = (1469598103934665603 ^ $0.x.bitPattern) &* 1099511628211
+                bits = (bits ^ $0.y.bitPattern) &* 1099511628211
+                bits = (bits ^ $0.z.bitPattern) &* 1099511628211
+                return Int(bitPattern: UInt(bits))
+            }),
             hr: StreamFingerprint.of(hr, ts: { $0.ts }, quant: { Int($0.bpm) }),
             rr: StreamFingerprint.of(rr, ts: { $0.ts }, quant: { Int($0.rrMs) }),
             resp: StreamFingerprint.of(resp, ts: { $0.ts }, quant: { $0.raw }),
@@ -1273,7 +1279,12 @@ public enum SleepStager {
         // resp IS consumed here via the epoch grid, unlike V2). Result-only, bounded, no raw arrays retained.
         let key = V1StageKey(
             start: start, end: end,
-            grav: StreamFingerprint.of(grav, ts: { $0.ts }, quant: { Int(($0.x + $0.y + $0.z) * 1024) }),
+            grav: StreamFingerprint.of(grav, ts: { $0.ts }, quant: {
+                var bits = (1469598103934665603 ^ $0.x.bitPattern) &* 1099511628211
+                bits = (bits ^ $0.y.bitPattern) &* 1099511628211
+                bits = (bits ^ $0.z.bitPattern) &* 1099511628211
+                return Int(bitPattern: UInt(bits))
+            }),
             hr: StreamFingerprint.of(hr, ts: { $0.ts }, quant: { Int($0.bpm) }),
             rr: StreamFingerprint.of(rr, ts: { $0.ts }, quant: { Int($0.rrMs) }),
             resp: StreamFingerprint.of(resp, ts: { $0.ts }, quant: { $0.raw }))

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
@@ -62,7 +62,12 @@ public enum SleepStagerV2 {
         let rrW = clipToWindow(rr, lo: start - Self.padLo, hi: end + Self.padHi, ts: { $0.ts })
         let key = V2Key(
             start: start, end: end,
-            grav: StreamFingerprint.of(gravW, ts: { $0.ts }, quant: { Int(($0.x + $0.y + $0.z) * 1024) }),
+            grav: StreamFingerprint.of(gravW, ts: { $0.ts }, quant: {
+                var bits = (1469598103934665603 ^ $0.x.bitPattern) &* 1099511628211
+                bits = (bits ^ $0.y.bitPattern) &* 1099511628211
+                bits = (bits ^ $0.z.bitPattern) &* 1099511628211
+                return Int(bitPattern: UInt(bits))
+            }),
             hr: StreamFingerprint.of(hrW, ts: { $0.ts }, quant: { Int($0.bpm) }),
             rr: StreamFingerprint.of(rrW, ts: { $0.ts }, quant: { Int($0.rrMs) }))
         return stageCache.value(key) {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerCacheFingerprintTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerCacheFingerprintTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import StrandAnalytics
+import WhoopProtocol
+
+/// Regression coverage for gravity streams that have identical per-sample axis sums but different motion.
+final class SleepStagerCacheFingerprintTests: XCTestCase {
+    /// 2025-06-10 00:00:00 UTC, shared with the existing native stager fixtures.
+    private let base = 1_749_513_600
+
+    private func gravity(start: Int, duration: Int, flippingAxes: Bool) -> [GravitySample] {
+        (0..<duration).map { i in
+            if flippingAxes && i.isMultiple(of: 2) {
+                return GravitySample(ts: start + i, x: 1, y: 0, z: 0)
+            }
+            return GravitySample(ts: start + i, x: 0, y: 0, z: 1)
+        }
+    }
+
+    private func heartRate(start: Int, duration: Int) -> [HRSample] {
+        (0..<duration).map { HRSample(ts: start + $0, bpm: 50 + (($0 / 60) % 3)) }
+    }
+
+    private func rr(start: Int, duration: Int) -> [RRInterval] {
+        let wave = [0, 40, 0, -40]
+        return (0..<duration).map { RRInterval(ts: start + $0, rrMs: 1_000 + wave[$0 % wave.count]) }
+    }
+
+    private func shifted(_ samples: [GravitySample], by delta: Int) -> [GravitySample] {
+        samples.map { GravitySample(ts: $0.ts + delta, x: $0.x, y: $0.y, z: $0.z) }
+    }
+
+    private func shifted(_ samples: [HRSample], by delta: Int) -> [HRSample] {
+        samples.map { HRSample(ts: $0.ts + delta, bpm: $0.bpm) }
+    }
+
+    private func shape(_ segments: [StageSegment], relativeTo start: Int) -> [String] {
+        segments.map { "\($0.start - start):\($0.end - start):\($0.stage)" }
+    }
+
+    func testDetectSleepSameSumAxesDoNotAliasMemo() {
+        let start = base + 2 * 3_600
+        let duration = 90 * 60
+        let still = gravity(start: start, duration: duration, flippingAxes: false)
+        let moving = gravity(start: start, duration: duration, flippingAxes: true)
+        let hr = heartRate(start: start, duration: duration)
+
+        // A trace sink bypasses detectSleep's memo and supplies real-path controls.
+        let controlA = SleepStager.detectSleep(hr: hr, gravity: still, traceSink: { _ in })
+        let controlB = SleepStager.detectSleep(hr: hr, gravity: moving, traceSink: { _ in })
+        XCTAssertFalse(controlA.isEmpty, "control A must be a detected still night")
+        XCTAssertTrue(controlB.isEmpty, "control B must be motion, not sleep")
+
+        let cachedA = SleepStager.detectSleep(hr: hr, gravity: still)
+        let cachedB = SleepStager.detectSleep(hr: hr, gravity: moving)
+        let cachedAAgain = SleepStager.detectSleep(hr: hr, gravity: still)
+        XCTAssertEqual(cachedA, controlA)
+        XCTAssertEqual(cachedB, controlB, "same-sum axis changes must invalidate the detect memo")
+        XCTAssertEqual(cachedAAgain, controlA, "A→B→A must not poison the original cache entry")
+    }
+
+    func testV1StageSameSumAxesDoNotAliasMemo() {
+        let start = base + 100_000
+        let duration = 20 * 60
+        let still = gravity(start: start, duration: duration, flippingAxes: false)
+        let moving = gravity(start: start, duration: duration, flippingAxes: true)
+        let hr = heartRate(start: start, duration: duration)
+        let controlShift = 200_000
+
+        // Shifted windows create uncached controls without adding a production reset hook.
+        let controlA = SleepStager.stageSession(
+            start: start + controlShift, end: start + controlShift + duration,
+            grav: shifted(still, by: controlShift), hr: shifted(hr, by: controlShift), rr: [], resp: [])
+        let controlB = SleepStager.stageSession(
+            start: start + 2 * controlShift, end: start + 2 * controlShift + duration,
+            grav: shifted(moving, by: 2 * controlShift), hr: shifted(hr, by: 2 * controlShift), rr: [], resp: [])
+        XCTAssertNotEqual(shape(controlA, relativeTo: start + controlShift),
+                          shape(controlB, relativeTo: start + 2 * controlShift),
+                          "controls must exercise observably different staging")
+
+        let a = SleepStager.stageSession(start: start, end: start + duration,
+                                         grav: still, hr: hr, rr: [], resp: [])
+        let b = SleepStager.stageSession(start: start, end: start + duration,
+                                         grav: moving, hr: hr, rr: [], resp: [])
+        let aAgain = SleepStager.stageSession(start: start, end: start + duration,
+                                              grav: still, hr: hr, rr: [], resp: [])
+        XCTAssertEqual(shape(a, relativeTo: start), shape(controlA, relativeTo: start + controlShift))
+        XCTAssertEqual(shape(b, relativeTo: start), shape(controlB, relativeTo: start + 2 * controlShift),
+                       "same-sum axis changes must invalidate the V1 stage memo")
+        XCTAssertEqual(shape(aAgain, relativeTo: start), shape(controlA, relativeTo: start + controlShift))
+    }
+
+    func testV2StageSameSumAxesDoNotAliasMemo() {
+        let start = base + 1_000_000
+        let duration = 30 * 60
+        let still = gravity(start: start, duration: duration, flippingAxes: false)
+        let moving = (0..<duration).map { i in
+            i % 30 == 15
+                ? GravitySample(ts: start + i, x: 1, y: 1, z: -1)
+                : GravitySample(ts: start + i, x: 0, y: 0, z: 1)
+        }
+        let hr = heartRate(start: start, duration: duration)
+        let beats = rr(start: start, duration: duration)
+        var stillControl = still
+        stillControl.insert(still[0], at: 1)
+        var movingControl = moving
+        movingControl.insert(moving[0], at: 1)
+        movingControl.insert(moving[0], at: 2)
+
+        // Duplicate identical rows change the old key's count without changing per-second inputs.
+        let controlA = SleepStagerV2.stageSession(
+            start: start, end: start + duration, grav: stillControl, hr: hr, rr: beats, resp: [])
+        let controlB = SleepStagerV2.stageSession(
+            start: start, end: start + duration, grav: movingControl, hr: hr, rr: beats, resp: [])
+        XCTAssertNotEqual(shape(controlA, relativeTo: start), shape(controlB, relativeTo: start),
+                          "controls must exercise observably different staging")
+
+        let a = SleepStagerV2.stageSession(start: start, end: start + duration,
+                                           grav: still, hr: hr, rr: beats, resp: [])
+        let b = SleepStagerV2.stageSession(start: start, end: start + duration,
+                                           grav: moving, hr: hr, rr: beats, resp: [])
+        let aAgain = SleepStagerV2.stageSession(start: start, end: start + duration,
+                                                grav: still, hr: hr, rr: beats, resp: [])
+        XCTAssertEqual(shape(a, relativeTo: start), shape(controlA, relativeTo: start))
+        XCTAssertEqual(shape(b, relativeTo: start), shape(controlB, relativeTo: start),
+                       "same-sum axis changes must invalidate the V2 stage memo")
+        XCTAssertEqual(shape(aAgain, relativeTo: start), shape(controlA, relativeTo: start))
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerCacheFingerprintTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerCacheFingerprintTest.kt
@@ -1,0 +1,127 @@
+package com.noop.analytics
+
+import com.noop.data.GravitySample
+import com.noop.data.HrSample
+import com.noop.data.RrInterval
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Mirrored regression coverage for same-sum gravity-axis cache collisions. */
+class SleepStagerCacheFingerprintTest {
+    private val dev = "cache-fingerprint-test"
+    private val base = 1_749_513_600L
+
+    private fun gravity(start: Long, duration: Int, flippingAxes: Boolean): List<GravitySample> =
+        (0 until duration).map { i ->
+            if (flippingAxes && i % 2 == 0) {
+                GravitySample(deviceId = dev, ts = start + i, x = 1.0, y = 0.0, z = 0.0)
+            } else {
+                GravitySample(deviceId = dev, ts = start + i, x = 0.0, y = 0.0, z = 1.0)
+            }
+        }
+
+    private fun heartRate(start: Long, duration: Int): List<HrSample> =
+        (0 until duration).map { HrSample(deviceId = dev, ts = start + it, bpm = 50 + (it / 60) % 3) }
+
+    private fun rr(start: Long, duration: Int): List<RrInterval> {
+        val wave = listOf(0, 40, 0, -40)
+        return (0 until duration).map {
+            RrInterval(deviceId = dev, ts = start + it, rrMs = 1_000 + wave[it % wave.size])
+        }
+    }
+
+    private fun shiftedGravity(rows: List<GravitySample>, delta: Long): List<GravitySample> =
+        rows.map { it.copy(ts = it.ts + delta) }
+    private fun shiftedHeartRate(rows: List<HrSample>, delta: Long): List<HrSample> =
+        rows.map { it.copy(ts = it.ts + delta) }
+    private fun shape(segments: List<StageSegment>, start: Long): List<String> =
+        segments.map { "${it.start - start}:${it.end - start}:${it.stage}" }
+
+    @Test
+    fun detectSleepSameSumAxesDoNotAliasMemo() {
+        val start = base + 2 * 3_600L
+        val duration = 90 * 60
+        val still = gravity(start, duration, flippingAxes = false)
+        val moving = gravity(start, duration, flippingAxes = true)
+        val hr = heartRate(start, duration)
+
+        val controlA = SleepStager.detectSleep(hr = hr, gravity = still, traceSink = { })
+        val controlB = SleepStager.detectSleep(hr = hr, gravity = moving, traceSink = { })
+        assertFalse("control A must be a detected still night", controlA.isEmpty())
+        assertTrue("control B must be motion, not sleep", controlB.isEmpty())
+
+        val cachedA = SleepStager.detectSleep(hr = hr, gravity = still)
+        val cachedB = SleepStager.detectSleep(hr = hr, gravity = moving)
+        val cachedAAgain = SleepStager.detectSleep(hr = hr, gravity = still)
+        assertEquals(controlA, cachedA)
+        assertEquals("same-sum axis changes must invalidate the detect memo", controlB, cachedB)
+        assertEquals("A→B→A must not poison the original cache entry", controlA, cachedAAgain)
+    }
+
+    @Test
+    fun v1StageSameSumAxesDoNotAliasMemo() {
+        val start = base + 100_000L
+        val duration = 20 * 60
+        val still = gravity(start, duration, flippingAxes = false)
+        val moving = gravity(start, duration, flippingAxes = true)
+        val hr = heartRate(start, duration)
+        val controlShift = 200_000L
+
+        val controlA = SleepStager.stageSession(
+            start + controlShift, start + controlShift + duration,
+            shiftedGravity(still, controlShift), shiftedHeartRate(hr, controlShift), emptyList(), emptyList())
+        val controlB = SleepStager.stageSession(
+            start + 2 * controlShift, start + 2 * controlShift + duration,
+            shiftedGravity(moving, 2 * controlShift), shiftedHeartRate(hr, 2 * controlShift),
+            emptyList(), emptyList())
+        assertNotEquals("controls must exercise observably different staging",
+            shape(controlA, start + controlShift), shape(controlB, start + 2 * controlShift))
+
+        val a = SleepStager.stageSession(start, start + duration, still, hr, emptyList(), emptyList())
+        val b = SleepStager.stageSession(start, start + duration, moving, hr, emptyList(), emptyList())
+        val aAgain = SleepStager.stageSession(start, start + duration, still, hr, emptyList(), emptyList())
+        assertEquals(shape(controlA, start + controlShift), shape(a, start))
+        assertEquals("same-sum axis changes must invalidate the V1 stage memo",
+            shape(controlB, start + 2 * controlShift), shape(b, start))
+        assertEquals(shape(controlA, start + controlShift), shape(aAgain, start))
+    }
+
+    @Test
+    fun v2StageSameSumAxesDoNotAliasMemo() {
+        val start = base + 1_000_000L
+        val duration = 30 * 60
+        val still = gravity(start, duration, flippingAxes = false)
+        val moving = (0 until duration).map { i ->
+            if (i % 30 == 15) {
+                GravitySample(deviceId = dev, ts = start + i, x = 1.0, y = 1.0, z = -1.0)
+            } else {
+                GravitySample(deviceId = dev, ts = start + i, x = 0.0, y = 0.0, z = 1.0)
+            }
+        }
+        val hr = heartRate(start, duration)
+        val beats = rr(start, duration)
+        val stillControl = still.toMutableList().apply { add(1, still[0]) }
+        val movingControl = moving.toMutableList().apply {
+            add(1, moving[0])
+            add(2, moving[0])
+        }
+
+        val controlA = SleepStagerV2.stageSession(
+            start, start + duration, stillControl, hr, beats, emptyList())
+        val controlB = SleepStagerV2.stageSession(
+            start, start + duration, movingControl, hr, beats, emptyList())
+        assertNotEquals("controls must exercise observably different staging",
+            shape(controlA, start), shape(controlB, start))
+
+        val a = SleepStagerV2.stageSession(start, start + duration, still, hr, beats, emptyList())
+        val b = SleepStagerV2.stageSession(start, start + duration, moving, hr, beats, emptyList())
+        val aAgain = SleepStagerV2.stageSession(start, start + duration, still, hr, beats, emptyList())
+        assertEquals(shape(controlA, start), shape(a, start))
+        assertEquals("same-sum axis changes must invalidate the V2 stage memo",
+            shape(controlB, start), shape(b, start))
+        assertEquals(shape(controlA, start), shape(aAgain, start))
+    }
+}


### PR DESCRIPTION
## What this PR does

Prevents Swift sleep-stager memo keys from aliasing gravity streams whose x/y/z distributions differ but whose per-sample axis sums match. Gravity fingerprints now fold each axis separately from its raw IEEE-754 bits, matching the Kotlin cache-key semantics. Permanent mirrored tests cover detectSleep, V1 staging, and V2 staging with uncached controls and A→B→A replay.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- RED before fix: all 3 Swift regression tests failed on the stale cached result for detect/V1/V2.
- Clean `origin/main` focused Swift regression: 3 tests passed.
- Clean `origin/main` mirrored Android regression: passed with JDK 17, one worker, Kotlin compiler in-process, 1536 MiB heap.
- Patch-identical fork commit: full StrandAnalytics suite passed (1,439 executed, 2 skipped, 0 failures).
- Patch-identical fork commit: full Android `:app:testFullDebugUnitTest` passed.
- Stable patch ID matches the independently reviewed fork delta.
- Independent delta review: no P0/P1/P2 findings.
- No hardware/manual testing required: this changes pure analytics cache keys only.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Tracked in bhelm/noop#66.