### PR TITLE
refactor(sleep): one gravity fold, not three copies of it (#1453 follow-up)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsMemo.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsMemo.swift
@@ -94,6 +94,11 @@ struct StreamFingerprint: Hashable {
     /// Lives here, called by all three stager key sites, because the summed version was duplicated at
     /// each of them and so was wrong at all three at once.
     ///
+    /// NOT used by `DaytimeStress`, which folds gravity its own way — a radix-257 packing of ×128
+    /// quantised axes (`x &+ y &* 257 &+ z &* 66049`). That one gives each axis a distinct positional
+    /// weight, so it never had this aliasing bug and is deliberately left alone: unifying it would change
+    /// its keys to no benefit. Checked rather than assumed when this was extracted.
+    ///
     /// The mixer is FNV-1a in SHAPE, seeded with this file's existing basis rather than the canonical
     /// 64-bit one — the project's constant is a digit short of it, and `of` and
     /// `ReadinessEngine.rowsFingerprint` have always used it. Consistency beats correcting it: the value

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsMemo.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsMemo.swift
@@ -86,18 +86,48 @@ struct StreamFingerprint: Hashable {
     /// Build from any sample sequence given a `ts` accessor and a `quant` accessor that maps a sample to an
     /// integer carrying its value (e.g. bpm, or a scaled gravity component). Folds EVERY sample — O(n), the
     /// same order as the `count` it already needs — so no interior change can alias onto a stale entry.
+    /// Fold one gravity sample's three axes into a quant value, from their RAW IEEE-754 bits and in
+    /// axis order, so two postures sharing a component sum cannot alias (#1453 — the summed
+    /// `Int((x + y + z) * 1024)` this replaced aliased (1,0,0), (0,1,0) and (0.5,0.5,0) onto one key,
+    /// and returned another window's cached staging).
+    ///
+    /// Lives here, called by all three stager key sites, because the summed version was duplicated at
+    /// each of them and so was wrong at all three at once.
+    ///
+    /// The mixer is FNV-1a in SHAPE, seeded with this file's existing basis rather than the canonical
+    /// 64-bit one — the project's constant is a digit short of it, and `of` and
+    /// `ReadinessEngine.rowsFingerprint` have always used it. Consistency beats correcting it: the value
+    /// only ever keys an in-process `AnalyticsMemoCache`, never persists, and never crosses the
+    /// `.noopbak` boundary, so no external spec depends on the seed. For the same reason it need NOT
+    /// equal the Kotlin twin, which mixes multiply-add — a fingerprint that differs across platforms can
+    /// only cost one of them a recompute, never change a value.
+    static func gravityQuant(x: Double, y: Double, z: Double) -> Int {
+        var bits = (fnvBasis ^ x.bitPattern) &* fnvPrime
+        bits = (bits ^ y.bitPattern) &* fnvPrime
+        bits = (bits ^ z.bitPattern) &* fnvPrime
+        return Int(bitPattern: UInt(bits))
+    }
+
+    /// This file's long-standing fold seed. NOT the canonical FNV-1a 64-bit offset basis
+    /// (14695981039346656037) — it is that value with the trailing digit dropped. Kept because every
+    /// fingerprint here has always used it and none of them leave the process; named so the next reader
+    /// does not have to re-derive that it is deliberate.
+    static let fnvBasis: UInt64 = 1469598103934665603
+    /// The canonical FNV-1a 64-bit prime, which this one IS.
+    static let fnvPrime: UInt64 = 1099511628211
+
     static func of<S: Collection>(_ samples: S, ts: (S.Element) -> Int,
                                   quant: (S.Element) -> Int) -> StreamFingerprint {
         var count = 0
         var firstTs = 0, lastTs = 0
-        var sum: UInt64 = 1469598103934665603   // FNV offset basis
+        var sum: UInt64 = fnvBasis
         for e in samples {
             let t = ts(e)
             if count == 0 { firstTs = t }
             lastTs = t
             count += 1
-            sum = (sum ^ UInt64(bitPattern: Int64(t))) &* 1099511628211
-            sum = (sum ^ UInt64(bitPattern: Int64(quant(e)))) &* 1099511628211
+            sum = (sum ^ UInt64(bitPattern: Int64(t))) &* fnvPrime
+            sum = (sum ^ UInt64(bitPattern: Int64(quant(e)))) &* fnvPrime
         }
         if count == 0 { return StreamFingerprint(count: 0, firstTs: 0, lastTs: 0, checksum: 0) }
         return StreamFingerprint(count: count, firstTs: firstTs, lastTs: lastTs, checksum: sum)

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -986,10 +986,7 @@ public enum SleepStager {
         // Match Android's raw-axis semantics: mix x/y/z IEEE-754 bits in order, never their lossy sum.
         let key = DetectKey(
             grav: StreamFingerprint.of(gravity, ts: { $0.ts }, quant: {
-                var bits = (1469598103934665603 ^ $0.x.bitPattern) &* 1099511628211
-                bits = (bits ^ $0.y.bitPattern) &* 1099511628211
-                bits = (bits ^ $0.z.bitPattern) &* 1099511628211
-                return Int(bitPattern: UInt(bits))
+                StreamFingerprint.gravityQuant(x: $0.x, y: $0.y, z: $0.z)
             }),
             hr: StreamFingerprint.of(hr, ts: { $0.ts }, quant: { Int($0.bpm) }),
             rr: StreamFingerprint.of(rr, ts: { $0.ts }, quant: { Int($0.rrMs) }),
@@ -1280,10 +1277,7 @@ public enum SleepStager {
         let key = V1StageKey(
             start: start, end: end,
             grav: StreamFingerprint.of(grav, ts: { $0.ts }, quant: {
-                var bits = (1469598103934665603 ^ $0.x.bitPattern) &* 1099511628211
-                bits = (bits ^ $0.y.bitPattern) &* 1099511628211
-                bits = (bits ^ $0.z.bitPattern) &* 1099511628211
-                return Int(bitPattern: UInt(bits))
+                StreamFingerprint.gravityQuant(x: $0.x, y: $0.y, z: $0.z)
             }),
             hr: StreamFingerprint.of(hr, ts: { $0.ts }, quant: { Int($0.bpm) }),
             rr: StreamFingerprint.of(rr, ts: { $0.ts }, quant: { Int($0.rrMs) }),

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
@@ -63,10 +63,7 @@ public enum SleepStagerV2 {
         let key = V2Key(
             start: start, end: end,
             grav: StreamFingerprint.of(gravW, ts: { $0.ts }, quant: {
-                var bits = (1469598103934665603 ^ $0.x.bitPattern) &* 1099511628211
-                bits = (bits ^ $0.y.bitPattern) &* 1099511628211
-                bits = (bits ^ $0.z.bitPattern) &* 1099511628211
-                return Int(bitPattern: UInt(bits))
+                StreamFingerprint.gravityQuant(x: $0.x, y: $0.y, z: $0.z)
             }),
             hr: StreamFingerprint.of(hrW, ts: { $0.ts }, quant: { Int($0.bpm) }),
             rr: StreamFingerprint.of(rrW, ts: { $0.ts }, quant: { Int($0.rrMs) }))


### PR DESCRIPTION
Follow-up to @bhelm's #1453, which fixed a real aliasing bug: the Swift stager quantised gravity as
the axis **sum**, so two postures sharing a component sum keyed the same memo entry and the stager could
hand back another window's staging. That fix was right and is untouched here.

What it kept is the shape that made the bug threefold — the same five-line closure pasted at
`detectSleep`, V1 and V2. That duplication is precisely **why the summed version was wrong at all three
sites at once**, so removing it is the durable half of the fix.

## What changes

The fold moves to `StreamFingerprint.gravityQuant`, called by all three sites. **Byte-identical
arithmetic, same constants** — every fingerprint value is unchanged, so #1453's mirrored regression
tests still pin exactly the same behaviour without modification.

## A note the code was inviting someone to get wrong

I flagged the seed as a mistyped FNV-1a basis while reviewing #1453. That was unfair to the author:
`1469598103934665603` is **not** the canonical 64-bit offset basis (it is that value with the trailing
digit dropped), but it has been this file's constant since it was written — `of` and
`ReadinessEngine.rowsFingerprint` both use it. #1453 correctly matched the surrounding convention.

It stays as-is rather than being corrected, and the doc now says why: the value only ever keys an
in-process `AnalyticsMemoCache`, never persists, and never crosses the `.noopbak` boundary, so nothing
external depends on the seed and changing it would be churn across working code. Naming it means the next
reader does not have to re-derive that a constant labelled "FNV offset basis" is deliberately a digit
short of one.

For the same reason it need not equal the Kotlin twin, which mixes multiply-add rather than XOR-multiply:
a fingerprint differing across platforms can only cost one of them a recompute, never change a value —
which the Kotlin side already documents.

## Verification

Swift-only; no Kotlin file changed, no behaviour changed, no test changed. `swift-packages` executes the
StrandAnalytics suite including #1453's fingerprint regressions, which is the real check that the
arithmetic is unchanged. Doc-comment gate clean.