### PR TITLE
feat(ble): adopt a stable whoop-<serial> identity for 5.0/MG (#1303 phase 1)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
@@ -108,6 +108,11 @@ public struct DeviceRegistryStore: Sendable {
         }
     }
 
+    /// Suffix of the COMPUTED sibling every device id owns — the engine writes its derived days, detected
+    /// workouts and metric series under `<deviceId>-noop`. Spelled here so the adoption can carry it with
+    /// the pairing; the Kotlin twin is `WhoopRepository.computedDeviceId`.
+    public static let computedSuffix = "-noop"
+
     /// Every table whose rows are keyed by `deviceId` (the per-device sample/derived tables). This is
     /// the authoritative list `deleteAllData` clears — kept in sync with the `deviceId`-keyed tables in
     /// `Database.swift`. The `pairedDevice` registry row itself is NOT here (a delete-data operation
@@ -198,9 +203,19 @@ public struct DeviceRegistryStore: Sendable {
                 """, arguments: [serialId, activeId])
             }
             // Move the active id's recordings onto the serial id (canonical wins a PK clash), then clear it.
-            for table in Self.deviceScopedTables {
-                try db.execute(sql: "UPDATE OR IGNORE \(table) SET deviceId = ? WHERE deviceId = ?", arguments: [serialId, activeId])
-                try db.execute(sql: "DELETE FROM \(table) WHERE deviceId = ?", arguments: [activeId])
+            //
+            // BOTH id shapes, not just the pairing's own. Every strap also owns a COMPUTED sibling keyed
+            // `<deviceId>-noop` — the scored days, detected workouts and metric series the engine derives
+            // — and that id is never equal to `activeId`, so an exact-match re-key silently left it behind.
+            // The next scoring pass then writes under `<serialId>-noop`, stranding the old computed
+            // history under an id nothing reads again: the orphaned-history failure this adoption exists
+            // to PREVENT, displaced onto the computed half. The ring path never hit it because a ring has
+            // no computed sibling to strand, which is why the shipped migration looked proven.
+            for (from, to) in [(activeId, serialId), (activeId + Self.computedSuffix, serialId + Self.computedSuffix)] {
+                for table in Self.deviceScopedTables {
+                    try db.execute(sql: "UPDATE OR IGNORE \(table) SET deviceId = ? WHERE deviceId = ?", arguments: [to, from])
+                    try db.execute(sql: "DELETE FROM \(table) WHERE deviceId = ?", arguments: [from])
+                }
             }
             // Drop ONLY the provisional CB-UUID registry rows; other oura-* pairings are left as-is.
             try db.execute(sql: "DELETE FROM pairedDevice WHERE id = ?", arguments: [activeId])

--- a/Packages/WhoopStore/Sources/WhoopStore/WhoopSerialIdentity.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/WhoopSerialIdentity.swift
@@ -38,6 +38,20 @@ public enum WhoopSerialIdentity {
         return "\(idPrefix)-\(up)"
     }
 
+    /// Whether this pairing's id may be re-pointed onto a serial id at all.
+    ///
+    /// ONLY a provisional `whoop-<CB-UUID>` id qualifies. The legacy `my-whoop` seed is deliberately
+    /// EXCLUDED, and that exclusion is what makes this safe to ship before #1304: every existing
+    /// single-WHOOP install is still on that seed, ~47 code paths still read the literal `"my-whoop"`
+    /// directly, and `WhoopBleClient.deviceId` documents that the single-WHOOP path never reassigns it.
+    /// Adopting it would migrate the whole history onto `whoop-<serial>` while new samples kept being
+    /// written under `my-whoop` — a split history that reads as data loss.
+    ///
+    /// The legacy seed joins this path as part of #1304, once the literals no longer assume it.
+    public static func mayAdopt(currentId: String) -> Bool {
+        currentId.hasPrefix("\(idPrefix)-")
+    }
+
     /// True when `id` is already the serial id for `serial` — the steady state on every reconnect after the
     /// first adoption, and the cheap early-out that keeps re-adoption from doing database work per connect.
     public static func isAlreadyAdopted(id: String, serial: String?) -> Bool {

--- a/Packages/WhoopStore/Sources/WhoopStore/WhoopSerialIdentity.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/WhoopSerialIdentity.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// The stable WHOOP device id derived from the strap's own serial (#1303).
+///
+/// WHOOP strap identity is otherwise a TRANSIENT CoreBluetooth UUID: a re-pair or factory reset mints a
+/// fresh one, so the same physical strap forks into a second registry row and orphans its history (#1193).
+/// The ring path already solved this — `DeviceRegistryStore.adoptSerialIdentity` re-points a provisional id
+/// onto a serial id and migrates every device-scoped row — and this is the WHOOP half of the same idea.
+///
+/// Pure and store-free so both platforms can pin the composition and, more importantly, the REFUSALS: a
+/// blank or implausible serial must yield nil and leave the existing id alone. Adopting onto a junk id
+/// would be worse than not adopting at all, because the migration moves every row onto it.
+///
+/// Kotlin twin: `WhoopSerialIdentity`.
+public enum WhoopSerialIdentity {
+
+    /// The one place the WHOOP id namespace is spelled. `AddDeviceWizard` mints `whoop-<CB-UUID>` and
+    /// `DeviceRegistryStore` classifies on the same prefix; a serial id joins the same namespace so every
+    /// existing prefix check keeps working unchanged.
+    public static let idPrefix = "whoop"
+
+    /// Shortest serial worth adopting. A 5.0/MG DIS serial is far longer; this only rejects a truncated or
+    /// placeholder read, which a partial GATT response can produce.
+    public static let minSerialLength = 6
+
+    /// The `whoop-<serial>` id for a strap serial, or nil when the serial cannot be trusted to identify it.
+    ///
+    /// Refuses blank/whitespace, anything under `minSerialLength`, and any serial carrying a character
+    /// outside `[A-Z0-9-]` after upper-casing — a DIS read that returns a descriptive string rather than a
+    /// serial should never become a device id. Upper-cased so the same strap read twice, in either case,
+    /// resolves to ONE id rather than two.
+    public static func adoptedId(serial: String?) -> String? {
+        guard let raw = serial?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else { return nil }
+        let up = raw.uppercased()
+        guard up.count >= minSerialLength else { return nil }
+        let allowed = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-")
+        guard up.allSatisfy({ allowed.contains($0) }) else { return nil }
+        return "\(idPrefix)-\(up)"
+    }
+
+    /// True when `id` is already the serial id for `serial` — the steady state on every reconnect after the
+    /// first adoption, and the cheap early-out that keeps re-adoption from doing database work per connect.
+    public static func isAlreadyAdopted(id: String, serial: String?) -> Bool {
+        guard let target = adoptedId(serial: serial) else { return false }
+        return id == target
+    }
+
+    /// What may be written to a SHAREABLE strap log. The serial identifies the device, so only its leading
+    /// characters are ever logged — the same rule `noteWhoop5VariantFromDIS` already applies to the variant
+    /// line. Never log `adoptedId`'s result directly.
+    public static func logSafe(serial: String?) -> String {
+        guard let raw = serial?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else { return "?" }
+        return String(raw.uppercased().prefix(3)) + "…"
+    }
+}

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/DeviceRegistryStoreTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/DeviceRegistryStoreTests.swift
@@ -222,6 +222,52 @@ final class DeviceRegistryStoreTests: XCTestCase {
         XCTAssertEqual(row?.model, "Oura Ring 3")
     }
 
+    /// The computed sibling must travel with the pairing.
+    ///
+    /// Every strap owns a second id, `<deviceId>-noop`, holding the days/workouts/series the engine
+    /// DERIVES. It never equals `activeId`, so an exact-match re-key left it behind while the next scoring
+    /// pass wrote under `<serialId>-noop` — stranding the computed history under an id nothing reads
+    /// again, which is the orphaned-history failure adoption exists to prevent. A ring has no computed
+    /// sibling, so the shipped Oura path could never surface this.
+    func testAdoptSerialCarriesTheComputedSibling() throws {
+        let dbq = try makeDB(); let store = DeviceRegistryStore(dbQueue: dbq)
+        let cbuuid = "whoop-4DD70E24", serial = "whoop-MGB1234567"
+        try addOura(store, cbuuid, peripheralId: "4DD70E24", status: .paired, addedAt: 100)
+        try store.setActive(cbuuid)
+        try dbq.write { db in
+            try db.execute(sql: "INSERT INTO hrSample (deviceId, ts, bpm) VALUES ('whoop-4DD70E24', 10, 55)")
+            // the DERIVED half, under the computed sibling
+            try db.execute(sql: "INSERT INTO hrSample (deviceId, ts, bpm) VALUES ('whoop-4DD70E24-noop', 11, 56)")
+        }
+
+        XCTAssertTrue(try store.adoptSerialIdentity(from: cbuuid, to: serial))
+
+        XCTAssertEqual(try hrCount(dbq, serial), 1)
+        XCTAssertEqual(try hrCount(dbq, cbuuid), 0)
+        XCTAssertEqual(try hrCount(dbq, serial + "-noop"), 1, "computed rows must follow the pairing")
+        XCTAssertEqual(try hrCount(dbq, cbuuid + "-noop"), 0, "and must not be left behind")
+    }
+
+    /// A PK clash on the COMPUTED side resolves the same way as on the real id: canonical wins, source is
+    /// cleared, nothing is duplicated. Worth pinning separately because the clash is reachable only after
+    /// a re-pair that already scored days under the serial's own computed sibling.
+    func testAdoptSerialMergesComputedSiblingsOnClash() throws {
+        let dbq = try makeDB(); let store = DeviceRegistryStore(dbQueue: dbq)
+        let cbuuid = "whoop-0102A826", serial = "whoop-MGB7654321"
+        try addOura(store, serial, peripheralId: "OLDPID", status: .paired, addedAt: 100)
+        try addOura(store, cbuuid, peripheralId: "0102A826", status: .paired, addedAt: 200)
+        try store.setActive(cbuuid)
+        try dbq.write { db in
+            try db.execute(sql: "INSERT INTO hrSample (deviceId, ts, bpm) VALUES ('whoop-MGB7654321-noop', 10, 50)")
+            try db.execute(sql: "INSERT INTO hrSample (deviceId, ts, bpm) VALUES ('whoop-0102A826-noop', 20, 60)")
+        }
+
+        try store.adoptSerialIdentity(from: cbuuid, to: serial)
+
+        XCTAssertEqual(try hrCount(dbq, serial + "-noop"), 2)
+        XCTAssertEqual(try hrCount(dbq, cbuuid + "-noop"), 0)
+    }
+
     func testAdoptSerialMergesWhenSerialAlreadyExists() throws {
         let dbq = try makeDB(); let store = DeviceRegistryStore(dbQueue: dbq)
         let serial = "oura-2H3B2405003655", cbuuid2 = "oura-0102A826"

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/WhoopSerialIdentityTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/WhoopSerialIdentityTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import WhoopStore
+
+/// The REFUSALS matter more than the composition: adoption migrates every device-scoped row onto the id
+/// this returns, so a junk serial must yield nil and leave the strap on its existing id rather than move a
+/// history onto a garbage key (#1303). Kotlin twin: `WhoopSerialIdentityTest`.
+final class WhoopSerialIdentityTests: XCTestCase {
+
+    func testComposesTheSerialId() {
+        XCTAssertEqual(WhoopSerialIdentity.adoptedId(serial: "5AG12345678"), "whoop-5AG12345678")
+    }
+
+    func testUpperCasesSoOneStrapCannotBecomeTwoIds() {
+        XCTAssertEqual(WhoopSerialIdentity.adoptedId(serial: "5ag12345678"),
+                       WhoopSerialIdentity.adoptedId(serial: "5AG12345678"))
+    }
+
+    func testTrimsSurroundingWhitespaceFromTheGattString() {
+        XCTAssertEqual(WhoopSerialIdentity.adoptedId(serial: "  5AG12345678\n"), "whoop-5AG12345678")
+    }
+
+    func testRefusesBlankOrMissing() {
+        XCTAssertNil(WhoopSerialIdentity.adoptedId(serial: nil))
+        XCTAssertNil(WhoopSerialIdentity.adoptedId(serial: ""))
+        XCTAssertNil(WhoopSerialIdentity.adoptedId(serial: "   \n "))
+    }
+
+    func testRefusesATruncatedRead() {
+        // A partial GATT response must not become an id: it would collide across straps.
+        XCTAssertNil(WhoopSerialIdentity.adoptedId(serial: "5AG"))
+    }
+
+    func testRefusesADescriptiveStringThatIsNotASerial() {
+        // Some peripherals answer DIS with prose. Never let that become a device id.
+        XCTAssertNil(WhoopSerialIdentity.adoptedId(serial: "Not Available"))
+        XCTAssertNil(WhoopSerialIdentity.adoptedId(serial: "serial#1234"))
+    }
+
+    func testAlreadyAdoptedIsTheReconnectEarlyOut() {
+        XCTAssertTrue(WhoopSerialIdentity.isAlreadyAdopted(id: "whoop-5AG12345678", serial: "5AG12345678"))
+        XCTAssertFalse(WhoopSerialIdentity.isAlreadyAdopted(id: "whoop-ABCDEF-0123", serial: "5AG12345678"))
+        // An unusable serial is never "already adopted" — otherwise a junk read would silently suppress a
+        // later good one.
+        XCTAssertFalse(WhoopSerialIdentity.isAlreadyAdopted(id: "whoop-5AG12345678", serial: "  "))
+    }
+
+    func testLogSafeNeverLeaksTheFullSerial() {
+        XCTAssertEqual(WhoopSerialIdentity.logSafe(serial: "5AG12345678"), "5AG…")
+        XCTAssertEqual(WhoopSerialIdentity.logSafe(serial: nil), "?")
+        XCTAssertFalse(WhoopSerialIdentity.logSafe(serial: "5AG12345678").contains("12345678"))
+    }
+}

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/WhoopSerialIdentityTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/WhoopSerialIdentityTests.swift
@@ -44,6 +44,20 @@ final class WhoopSerialIdentityTests: XCTestCase {
         XCTAssertFalse(WhoopSerialIdentity.isAlreadyAdopted(id: "whoop-5AG12345678", serial: "  "))
     }
 
+    /// The guard that makes this safe to ship before #1304. Every existing single-WHOOP install is on the
+    /// legacy `my-whoop` seed, ~47 code paths read that literal directly, and `WhoopBleClient` never
+    /// reassigns its deviceId on the single-WHOOP path — so adopting it would migrate the history onto
+    /// `whoop-<serial>` while new samples kept landing under `my-whoop`. A split history reads as data loss.
+    func testRefusesToAdoptTheLegacySingleWhoopSeed() {
+        XCTAssertFalse(WhoopSerialIdentity.mayAdopt(currentId: "my-whoop"))
+        // A provisional pairing id IS adoptable — that is the multi-strap case this ships for.
+        XCTAssertTrue(WhoopSerialIdentity.mayAdopt(currentId: "whoop-6B9F2C11-0000-4000-8000-0000000000AA"))
+        // An already-adopted serial id stays adoptable; the equality check upstream stops the re-migration.
+        XCTAssertTrue(WhoopSerialIdentity.mayAdopt(currentId: "whoop-5AG12345678"))
+        // Another brand's id is never touched by the WHOOP path.
+        XCTAssertFalse(WhoopSerialIdentity.mayAdopt(currentId: "oura-2H3B2405003655"))
+    }
+
     func testLogSafeNeverLeaksTheFullSerial() {
         XCTAssertEqual(WhoopSerialIdentity.logSafe(serial: "5AG12345678"), "5AG…")
         XCTAssertEqual(WhoopSerialIdentity.logSafe(serial: nil), "?")

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -560,6 +560,12 @@ final class AppModel: ObservableObject {
             })
         coordinator.start()
         self.deviceRegistry = registry
+        // #1303: adoption re-points the strap onto its stable `whoop-<serial>` id inside BLEManager (which
+        // holds only the non-observable store), so mirror it onto the OBSERVABLE registry here or the
+        // Devices screen and the source coordinator keep watching an id that no longer exists.
+        self.ble.onSerialIdentityAdopted = { [weak registry] serialId in
+            registry?.setActive(serialId)
+        }
         self.sourceCoordinator = coordinator
         // #814 READ SPINE (HIGH-1): drive the read side off the registry's `activeDeviceId` for the WHOLE
         // session, exactly as SourceCoordinator drives the WRITE side off the SAME publisher. A Devices-

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -4589,6 +4589,7 @@ public final class BLEManager: NSObject, ObservableObject {
         guard let rs = registryStore,
               let serialId = WhoopSerialIdentity.adoptedId(serial: disSerial),
               let active = try? rs.all().first(where: { $0.status == .active }),
+              WhoopSerialIdentity.mayAdopt(currentId: active.id),
               active.id != serialId
         else { return }
         let currentId = active.id

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -561,8 +561,10 @@ public final class BLEManager: NSObject, ObservableObject {
     private let router: FrameRouter
     private var collector: Collector?
     /// #716: stored on bootstrap so the scan callback can fix the seeded "WHOOP" model label.
-    /// #1303: fired after the strap's history has been re-pointed onto its stable `whoop-<serial>` id,
-    /// so the app layer can refresh whatever caches the active device id.
+    /// #1303: fired after the strap's history has been re-pointed onto its stable `whoop-<serial>` id.
+    /// The live persist paths are already re-pointed inline by then; this exists so the OBSERVABLE spine
+    /// (`DeviceRegistry`, and the coordinator that watches it) follows too — the store write above is not
+    /// observable, so without this the UI would keep showing the old id until relaunch.
     var onSerialIdentityAdopted: ((String) -> Void)?
     private var registryStore: DeviceRegistryStore?
     /// #716: true once the seeded "WHOOP" model has been stamped to the correct family.
@@ -4599,6 +4601,13 @@ public final class BLEManager: NSObject, ObservableObject {
             else { return }
             guard (try? rs.adoptSerialIdentity(from: currentId, to: serialId)) == true else { return }
             try? rs.setActive(serialId)
+            // The rows have MOVED to the serial id and the old registry row is gone, so the live persist
+            // paths must follow in the same turn: `deviceId`, the Collector and the Backfiller all stamp
+            // rows at write time, and leaving them on the now-deleted id would write new samples into a
+            // second, orphaned history — the same split this phase exists to prevent, just on the
+            // provisional path instead of the legacy one. Kotlin reaches the identical call through
+            // `SourceCoordinator.pointWhoop`, which re-points any non-legacy id.
+            self.setActiveDeviceId(serialId)
             // Prefix only. `serialId` embeds the full serial, which must never reach a shareable log.
             self.log("Adopted stable serial identity (serialPrefix=\(WhoopSerialIdentity.logSafe(serial: self.disSerial))) - history re-pointed off the transient pairing id (#1303)")
             self.onSerialIdentityAdopted?(serialId)

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -561,6 +561,9 @@ public final class BLEManager: NSObject, ObservableObject {
     private let router: FrameRouter
     private var collector: Collector?
     /// #716: stored on bootstrap so the scan callback can fix the seeded "WHOOP" model label.
+    /// #1303: fired after the strap's history has been re-pointed onto its stable `whoop-<serial>` id,
+    /// so the app layer can refresh whatever caches the active device id.
+    var onSerialIdentityAdopted: ((String) -> Void)?
     private var registryStore: DeviceRegistryStore?
     /// #716: true once the seeded "WHOOP" model has been stamped to the correct family.
     private var modelStamped = false
@@ -4563,6 +4566,42 @@ public final class BLEManager: NSObject, ObservableObject {
         // existing consumer — nothing about framing or decode reads this.
         state.whoop5Variant = variant.label
         reconcileModelFromAttestation(variant)
+        adoptWhoopSerialIdentity()
+    }
+
+    /// #1303: the 5/MG DIS read hands us the strap's OWN serial, so re-point this pairing from its
+    /// transient CoreBluetooth-UUID id onto a stable `whoop-<serial>` id — through the SAME generic
+    /// migration the ring already uses (`adoptSerialIdentity`, #771), so a re-pair or factory reset stops
+    /// forking one physical strap into a second row and orphaning its history (#1193).
+    ///
+    /// A WHOOP 4.0 is deliberately untouched: it does not expose a DIS serial (the read above is gated
+    /// `!= .whoop4`) and the 4.0 serial's source on the wire is not yet identified, so there is nothing
+    /// honest to adopt onto here.
+    ///
+    /// Deferred to the next main-loop turn, mirroring `adoptOuraSerial`: adoption re-points the ACTIVE
+    /// device, and the observers that react tear down and rebuild the very connection this callback is
+    /// running inside, so the current BLE callback must return first. Idempotent — after the first
+    /// adoption the id already equals the serial id, so every later reconnect costs one string compare and
+    /// touches no database. A serial `WhoopSerialIdentity` refuses (blank, truncated, non-serial prose)
+    /// leaves the strap on its existing id: adopting onto a junk id would migrate every device-scoped row
+    /// onto a garbage key, which is worse than not adopting.
+    private func adoptWhoopSerialIdentity() {
+        guard let rs = registryStore,
+              let serialId = WhoopSerialIdentity.adoptedId(serial: disSerial),
+              let active = try? rs.all().first(where: { $0.status == .active }),
+              active.id != serialId
+        else { return }
+        let currentId = active.id
+        Task { @MainActor [weak self] in
+            guard let self, let rs = self.registryStore,
+                  (try? rs.all().first(where: { $0.status == .active }))?.id == currentId
+            else { return }
+            guard (try? rs.adoptSerialIdentity(from: currentId, to: serialId)) == true else { return }
+            try? rs.setActive(serialId)
+            // Prefix only. `serialId` embeds the full serial, which must never reach a shareable log.
+            self.log("Adopted stable serial identity (serialPrefix=\(WhoopSerialIdentity.logSafe(serial: self.disSerial))) - history re-pointed off the transient pairing id (#1303)")
+            self.onSerialIdentityAdopted?(serialId)
+        }
     }
 
     /// The strap's own DIS attestation is ground truth (a WHOOP 4.0 never attests a 5AM/5AG serial). When

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -776,6 +776,20 @@ public final class LiveState: ObservableObject {
         out = out.replacingOccurrences(
             of: "(?![0-9A-Fa-f]{8}-(?:0000-1000-8000-00805f9b34fb|8d6d-82b8-614a-1c8cb0f8dcc6))[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}",
             with: "<device>", options: [.regularExpression, .caseInsensitive])
+        // #1303: an ADOPTED device id (`whoop-<SERIAL>`) is a device identifier in every line that prints
+        // an id. Neither rule above catches it — the MAC rule wants MAC shape and the serial rule wants the
+        // literal "WHOOP " then a DIGIT, while an adopted id is `whoop-` + a serial commonly starting with
+        // a letter. Keeps three characters, matching `WhoopSerialIdentity.logSafe`, so two straps stay
+        // distinguishable; PRESERVES the `-noop` computed-sibling suffix, which is not identifying and is
+        // what lets a reader tell derived rows from measured ones. Six-character minimum matches
+        // `minSerialLength`, so `my-whoop` and `my-whoop-noop` are untouched. Kotlin twin in
+        // `redactStrapLogPii`.
+        out = out.replacingOccurrences(
+            of: "whoop-([A-Za-z0-9]{3})[A-Za-z0-9-]{3,}(-noop)",
+            with: "whoop-$1…$2", options: .regularExpression)
+        out = out.replacingOccurrences(
+            of: "whoop-([A-Za-z0-9]{3})[A-Za-z0-9-]{3,}",
+            with: "whoop-$1…", options: .regularExpression)
         return out
     }
 

--- a/StrandTests/HeaderRedactionTests.swift
+++ b/StrandTests/HeaderRedactionTests.swift
@@ -29,6 +29,27 @@ final class HeaderRedactionTests: XCTestCase {
         XCTAssertFalse(containsRawMac(LiveState.redactPii(line)))
     }
 
+    /// #1303: once a strap ADOPTS its serial the device id IS the serial, and this header enumerates every
+    /// paired device. Neither older rule covers that shape — the MAC rule wants MAC form, the serial rule
+    /// wants the literal "WHOOP " then a digit — so before this the header leaked it verbatim.
+    func testAnAdoptedSerialIdIsMasked() {
+        let line = "  device id=whoop-MGB1234567 status=ACTIVE brand=WHOOP model=5.0 MG lastSeen=1h ago"
+        let safe = LiveState.redactPii(line)
+        XCTAssertFalse(safe.contains("1234567"), "serial survived: \(safe)")
+        XCTAssertTrue(safe.contains("whoop-MGB…"), "three-character prefix should remain: \(safe)")
+    }
+
+    /// The `-noop` suffix is not identifying and is what separates derived rows from measured ones in the
+    /// per-source counts, so it must survive the mask that hides the serial in front of it.
+    func testTheComputedSiblingMarkerSurvives() {
+        XCTAssertEqual(LiveState.redactPii("Days: whoop-MGB1234567-noop=25"), "Days: whoop-MGB…-noop=25")
+    }
+
+    /// Anything too short to be accepted as a serial upstream must not be masked as one here either.
+    func testAnIdTooShortToBeASerialIsUntouched() {
+        XCTAssertEqual(LiveState.redactPii("id=whoop-ABCDE"), "id=whoop-ABCDE")
+    }
+
     func testAnIdWithNoAddressIsUntouched() {
         let line = "  device id=my-whoop status=ACTIVE brand=WHOOP model=WHOOP 4.0 lastSeen=3h 10m ago"
         XCTAssertEqual(LiveState.redactPii(line), line)

--- a/android/app/src/main/java/com/noop/NoopApplication.kt
+++ b/android/app/src/main/java/com/noop/NoopApplication.kt
@@ -60,15 +60,39 @@ class NoopApplication : Application() {
     val deviceRegistry: DeviceRegistry by lazy { DeviceRegistry(WhoopDatabase.get(this)) }
 
     /**
-     * Active device id resolved once at startup from the registry, falling back to the legacy
-     * "my-whoop" if the registry has none yet (so behaviour is unchanged today). Read with a guarded
-     * blocking call — a one-off indexed `LIMIT 1` query at composition time. Any failure (e.g. an early
-     * read before migration) is swallowed and falls back, so startup can never be broken by this.
+     * Active device id, resolved once at startup from the registry and falling back to the legacy
+     * "my-whoop" if the registry has none yet. Read with a guarded blocking call — a one-off indexed
+     * `LIMIT 1` query at composition time. Any failure (e.g. an early read before migration) is swallowed
+     * and falls back, so startup can never be broken by this.
+     *
+     * #1303: NOT a `by lazy`. Serial adoption re-points the ACTIVE device mid-process, and a lazy is
+     * frozen for the life of the process — so every consumer below kept the pre-adoption id until the next
+     * cold start, and the engine went on deriving days under it. Field-confirmed on a 5/MG: the registry
+     * read `whoop-<serial>` while the diagnostics export, and the scoring pass, still used the old
+     * address-based id, splitting the computed history across both until the phone was restarted. Adoption
+     * now calls [onActiveDeviceAdopted] and the handle follows within the process.
      */
-    val activeDeviceId: String by lazy {
-        runCatching { runBlocking { deviceRegistry.activeDeviceId() } }
-            .onFailure { Log.w("NoopApplication", "activeDeviceId resolve failed; using fallback", it) }
-            .getOrNull() ?: WhoopBleClient.DEFAULT_DEVICE_ID
+    @Volatile
+    var activeDeviceId: String = ""
+        get() {
+            if (field.isEmpty()) {
+                field = runCatching { runBlocking { deviceRegistry.activeDeviceId() } }
+                    .onFailure { Log.w("NoopApplication", "activeDeviceId resolve failed; using fallback", it) }
+                    .getOrNull() ?: WhoopBleClient.DEFAULT_DEVICE_ID
+            }
+            return field
+        }
+        private set
+
+    /**
+     * Point this process at the id a strap just adopted (#1303).
+     *
+     * Only the handle moves: the registry write and the row migration have already happened inside
+     * `adoptSerialIdentity`, and the BLE client is re-pointed by its own caller. Kept narrow and
+     * idempotent so a reconnect that re-adopts the same id costs nothing.
+     */
+    fun onActiveDeviceAdopted(newId: String) {
+        if (newId.isNotEmpty() && newId != activeDeviceId) activeDeviceId = newId
     }
 
     /** Process-wide BLE client. Owns the GATT connection and outlives any single Activity/ViewModel. */

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3007,6 +3007,8 @@ class WhoopBleClient(
     // #520 DIS identity — read ONCE per connection, post-handshake, 5/MG only. Serial and hardware
     // revision are immutable, so they are never re-polled (unlike the battery). Reset on disconnect.
     private var disRead = false
+    /** #1303: the strap's DIS serial, once read (5.0/MG only — a 4.0 does not expose one). */
+    var onSerial: ((String) -> Unit)? = null
     private var disSerial: String? = null
     private var disHwRev: String? = null
     /** DIS 0x2A24, the strap's own model number — the authoritative variant signal (#520). */
@@ -4675,6 +4677,10 @@ class WhoopBleClient(
         val prefix = disSerial?.trim()?.uppercase()?.take(3) ?: "?"
         log("DIS: serialPrefix=$prefix hwRev=${disHwRev ?: "?"} -> variant=${variant.label}")
         reconcileModelFromAttestation(variant)
+        // #1303: hand the strap's OWN serial up so the coordinator can re-point this pairing onto a stable
+        // `whoop-<serial>` id. Emitted, not acted on here, mirroring how the Oura source reports its serial:
+        // adoption re-points the ACTIVE device and tears down the very connection this callback runs inside.
+        disSerial?.let { onSerial?.invoke(it) }
     }
 
     /** The strap's own DIS attestation is ground truth (a WHOOP 4.0 never attests a 5AM/5AG serial). When
@@ -9683,6 +9689,13 @@ class WhoopBleClient(
             if (unknown != "none") log("Capture: UNKNOWN type samples — $unknown")
         }
     }
+
+    /**
+     * #1303: let the identity owner write one line into the SAME strap log the connection uses, so an
+     * adoption is visible in the capture beside the DIS line that triggered it. Deliberately narrow —
+     * the general [log] stays private. Callers must pass a serial PREFIX, never a full serial.
+     */
+    fun logIdentity(line: String) = log(line)
 
     private fun log(s: String, domain: com.noop.testcentre.TestDomain? = null) {
         // A diagnostic log line must NEVER be able to crash the app. log() runs on the GATT binder

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -9966,6 +9966,25 @@ private val PII_MAC_RE = Regex("([0-9A-Fa-f]{2}):[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[
 private val PII_WHOOP_SERIAL_RE = Regex("WHOOP (\\d[0-9A-Za-z]{5,})")
 
 /**
+ * #1303: a device id that has ADOPTED its strap serial (`whoop-<SERIAL>`) is a device identifier in every
+ * line that prints an id — the Devices list, each `dayOwner`, the per-source counts. Neither existing rule
+ * catches it: [PII_MAC_RE] wants MAC shape, and [PII_WHOOP_SERIAL_RE] wants the literal word "WHOOP "
+ * followed by a DIGIT, while an adopted id is `whoop-` + a serial that commonly starts with a letter.
+ * Before adoption existed no device id could contain a serial, so this was not a gap; it is one now.
+ *
+ * Keeps the leading three characters, the same rule `WhoopSerialIdentity.logSafe` already applies to the
+ * adoption line, so two straps stay distinguishable in a log. The `-noop` computed-sibling suffix is
+ * PRESERVED: it is not identifying, and it is what lets a reader tell derived rows from measured ones —
+ * the distinction the "Days:"/"Stored:" lines are read for.
+ *
+ * The six-character minimum is not arbitrary: it matches `WhoopSerialIdentity.minSerialLength`, so
+ * anything short enough to be refused as a serial is also too short to be mistaken for one here. That
+ * also leaves `my-whoop`, `my-whoop-noop` and the MAC form (already masked to `whoop-FD:••…`) untouched.
+ */
+private val PII_ADOPTED_ID_NOOP_RE = Regex("whoop-([A-Za-z0-9]{3})[A-Za-z0-9-]{3,}(-noop)")
+private val PII_ADOPTED_ID_RE = Regex("whoop-([A-Za-z0-9]{3})[A-Za-z0-9-]{3,}")
+
+/**
  * Builds the 9-byte WHOOP 4.0 SET_ALARM_TIME (cmd 66) payload.
  * Layout: `[0x01] + u32 LE epoch + [0x00, 0x00]` subseconds + `[0x00, 0x00]` haptic-mode field.
  *
@@ -10110,6 +10129,10 @@ internal fun alarmReadbackLocalTime(epochSec: Long): String =
 internal fun redactStrapLogPii(s: String): String = try {
     s.replace(PII_MAC_RE, "$1:••:••:••:••:$2")
         .replace(PII_WHOOP_SERIAL_RE, "WHOOP <serial>")
+        // MAC first, deliberately: `whoop-<MAC>` is already `whoop-FD:••…` by now and cannot be mistaken
+        // for an adopted id. The -noop form runs before the general one so the sibling suffix survives.
+        .replace(PII_ADOPTED_ID_NOOP_RE, "whoop-$1…$2")
+        .replace(PII_ADOPTED_ID_RE, "whoop-$1…")
 } catch (t: Throwable) {
     "[redaction error - line withheld]"
 }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3007,7 +3007,16 @@ class WhoopBleClient(
     // #520 DIS identity — read ONCE per connection, post-handshake, 5/MG only. Serial and hardware
     // revision are immutable, so they are never re-polled (unlike the battery). Reset on disconnect.
     private var disRead = false
-    /** #1303: the strap's DIS serial, once read (5.0/MG only — a 4.0 does not expose one). */
+    /**
+     * #1303: the strap's DIS serial, once read (5.0/MG only — a 4.0 does not expose one).
+     *
+     * KNOWN ASYMMETRY with the Swift twin, which adopts inline in BLEManager and uses its closure only
+     * to notify. Here the adoption itself lives in the observer (AppViewModel owns the registry handle
+     * and a scope; SourceCoordinator is inert on the WHOOP path by design), so a connect that completes
+     * before any observer is wired emits into a null callback and does not adopt. It is deferred, not
+     * lost: DIS is read on every connect, so the next one with an observer alive adopts. Worth knowing
+     * when reading a capture where iOS shows the adoption line and Android does not.
+     */
     var onSerial: ((String) -> Unit)? = null
     private var disSerial: String? = null
     private var disHwRev: String? = null

--- a/android/app/src/main/java/com/noop/data/DeviceRegistry.kt
+++ b/android/app/src/main/java/com/noop/data/DeviceRegistry.kt
@@ -89,31 +89,15 @@ class DeviceRegistry(
             } else {
                 dao.upsertPairedDevice(active.copy(id = serialId))
             }
-            dao.reKeyHr(activeId, serialId); dao.deleteHrFor(activeId)
-            dao.reKeyRr(activeId, serialId); dao.deleteRrFor(activeId)
-            dao.reKeySpo2(activeId, serialId); dao.deleteSpo2For(activeId)
-            dao.reKeySkinTemp(activeId, serialId); dao.deleteSkinTempFor(activeId)
-            dao.reKeyResp(activeId, serialId); dao.deleteRespFor(activeId)
-            dao.reKeyGravity(activeId, serialId); dao.deleteGravityFor(activeId)
-            dao.reKeySteps(activeId, serialId); dao.deleteStepsFor(activeId)
-            dao.reKeyPpgHr(activeId, serialId); dao.deletePpgHrFor(activeId)
-            dao.reKeyPpgWaveform(activeId, serialId); dao.deletePpgWaveformFor(activeId)
-            dao.reKeyV18Aux(activeId, serialId); dao.deleteV18AuxFor(activeId)
-            dao.reKeyEvents(activeId, serialId); dao.deleteEventsFor(activeId)
-            dao.reKeyBattery(activeId, serialId); dao.deleteBatteryFor(activeId)
-            dao.reKeyDailyMetrics(activeId, serialId); dao.deleteDailyMetricsFor(activeId)
-            dao.reKeySleepSessions(activeId, serialId); dao.deleteSleepSessionsFor(activeId)
-            dao.reKeyJournal(activeId, serialId); dao.deleteJournalFor(activeId)
-            dao.reKeyWorkouts(activeId, serialId); dao.deleteWorkoutsFor(activeId)
-            dao.reKeyAppleDaily(activeId, serialId); dao.deleteAppleDailyFor(activeId)
-            dao.reKeyAppleStepHour(activeId, serialId); dao.deleteAppleStepHoursFor(activeId)
-            dao.reKeyMetricSeries(activeId, serialId); dao.deleteMetricSeriesFor(activeId)
-            dao.reKeyDayOwnership(activeId, serialId); dao.deleteDayOwnershipFor(activeId)
-            dao.reKeySleepStates(activeId, serialId); dao.deleteSleepStatesFor(activeId)
-            dao.reKeyLabMarkers(activeId, serialId); dao.deleteLabMarkersFor(activeId)
-            dao.reKeyLiveSessions(activeId, serialId); dao.deleteLiveSessionsFor(activeId)
-            dao.reKeyDismissedWorkouts(activeId, serialId); dao.deleteDismissedWorkoutsFor(activeId)
-            dao.reKeyDismissedSleeps(activeId, serialId); dao.deleteDismissedSleepsFor(activeId)
+            // BOTH id shapes. Every strap also owns a COMPUTED sibling keyed `<deviceId>-noop` (see
+            // WhoopRepository.computedDeviceId) holding the scored days, detected workouts and metric
+            // series the engine derives. That id never equals activeId, so re-keying only the pairing's
+            // own id left the computed history stranded under an id nothing reads again while the next
+            // scoring pass wrote under `<serialId>-noop` — the orphaned history this adoption exists to
+            // prevent, displaced onto the computed half. A ring has no computed sibling, which is why the
+            // shipped Oura path never surfaced it.
+            reKeyDeviceScopedRows(activeId, serialId)
+            reKeyDeviceScopedRows(activeId + COMPUTED_SUFFIX, serialId + COMPUTED_SUFFIX)
             dao.deletePairedDeviceRow(activeId)
             dao.deleteDeviceRow(activeId)
             true
@@ -124,6 +108,41 @@ class DeviceRegistry(
      *  would be a write per second for no more truth. Twin of Swift `DeviceRegistry.touchLastSeen`. (#1527) */
     suspend fun touchLastSeen(id: String, now: Long = System.currentTimeMillis() / 1000) =
         dao.touchLastSeen(id, now)
+
+    /** Suffix of the COMPUTED sibling every device id owns; twin of `WhoopRepository.computedDeviceId`
+     *  and the Swift `DeviceRegistryStore.computedSuffix`. */
+    private val COMPUTED_SUFFIX = "-noop"
+
+    /** Move every device-scoped row from [from] onto [to], canonical winning a PK clash, then clear the
+     *  source. Registry rows are deliberately NOT touched here: a computed sibling has none, so the
+     *  pairedDevice/device deletions stay with the caller and run once, for the real pairing only. */
+    private suspend fun reKeyDeviceScopedRows(from: String, to: String) {
+        dao.reKeyHr(from, to); dao.deleteHrFor(from)
+        dao.reKeyRr(from, to); dao.deleteRrFor(from)
+        dao.reKeySpo2(from, to); dao.deleteSpo2For(from)
+        dao.reKeySkinTemp(from, to); dao.deleteSkinTempFor(from)
+        dao.reKeyResp(from, to); dao.deleteRespFor(from)
+        dao.reKeyGravity(from, to); dao.deleteGravityFor(from)
+        dao.reKeySteps(from, to); dao.deleteStepsFor(from)
+        dao.reKeyPpgHr(from, to); dao.deletePpgHrFor(from)
+        dao.reKeyPpgWaveform(from, to); dao.deletePpgWaveformFor(from)
+        dao.reKeyV18Aux(from, to); dao.deleteV18AuxFor(from)
+        dao.reKeyEvents(from, to); dao.deleteEventsFor(from)
+        dao.reKeyBattery(from, to); dao.deleteBatteryFor(from)
+        dao.reKeyDailyMetrics(from, to); dao.deleteDailyMetricsFor(from)
+        dao.reKeySleepSessions(from, to); dao.deleteSleepSessionsFor(from)
+        dao.reKeyJournal(from, to); dao.deleteJournalFor(from)
+        dao.reKeyWorkouts(from, to); dao.deleteWorkoutsFor(from)
+        dao.reKeyAppleDaily(from, to); dao.deleteAppleDailyFor(from)
+        dao.reKeyAppleStepHour(from, to); dao.deleteAppleStepHoursFor(from)
+        dao.reKeyMetricSeries(from, to); dao.deleteMetricSeriesFor(from)
+        dao.reKeyDayOwnership(from, to); dao.deleteDayOwnershipFor(from)
+        dao.reKeySleepStates(from, to); dao.deleteSleepStatesFor(from)
+        dao.reKeyLabMarkers(from, to); dao.deleteLabMarkersFor(from)
+        dao.reKeyLiveSessions(from, to); dao.deleteLiveSessionsFor(from)
+        dao.reKeyDismissedWorkouts(from, to); dao.deleteDismissedWorkoutsFor(from)
+        dao.reKeyDismissedSleeps(from, to); dao.deleteDismissedSleepsFor(from)
+    }
 
     /** Archive a device — keeps its row and samples (invariant I4). */
     suspend fun archive(id: String) = dao.archiveDevice(id)

--- a/android/app/src/main/java/com/noop/data/WhoopSerialIdentity.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopSerialIdentity.kt
@@ -1,0 +1,69 @@
+package com.noop.data
+
+/**
+ * The stable WHOOP device id derived from the strap's own serial (#1303). Byte-parity twin of Swift
+ * `WhoopSerialIdentity`.
+ *
+ * WHOOP strap identity is otherwise a TRANSIENT Bluetooth address/UUID: a re-pair or factory reset mints a
+ * fresh one, so the same physical strap forks into a second registry row and orphans its history (#1193).
+ * The ring path already solved this — `DeviceRegistry.adoptSerialIdentity` re-points a provisional id onto
+ * a serial id and migrates every device-scoped row — and this is the WHOOP half of the same idea.
+ *
+ * Pure and store-free so both platforms can pin the composition and, more importantly, the REFUSALS: a
+ * blank or implausible serial must yield null and leave the existing id alone. Adopting onto a junk id
+ * would be worse than not adopting at all, because the migration moves every row onto it.
+ */
+object WhoopSerialIdentity {
+
+    /**
+     * The one place the WHOOP id namespace is spelled. The add-device flow mints `whoop-<address>` and the
+     * registry classifies on the same prefix; a serial id joins the same namespace so every existing prefix
+     * check keeps working unchanged.
+     */
+    const val ID_PREFIX = "whoop"
+
+    /**
+     * Shortest serial worth adopting. A 5.0/MG DIS serial is far longer; this only rejects a truncated or
+     * placeholder read, which a partial GATT response can produce.
+     */
+    const val MIN_SERIAL_LENGTH = 6
+
+    private val ALLOWED = ('A'..'Z').toSet() + ('0'..'9').toSet() + '-'
+
+    /**
+     * The `whoop-<serial>` id for a strap serial, or null when the serial cannot be trusted to identify it.
+     *
+     * Refuses blank/whitespace, anything under [MIN_SERIAL_LENGTH], and any serial carrying a character
+     * outside `[A-Z0-9-]` after upper-casing — a DIS read that returns a descriptive string rather than a
+     * serial should never become a device id. Upper-cased so the same strap read twice, in either case,
+     * resolves to ONE id rather than two.
+     */
+    fun adoptedId(serial: String?): String? {
+        val raw = serial?.trim().orEmpty()
+        if (raw.isEmpty()) return null
+        val up = raw.uppercase()
+        if (up.length < MIN_SERIAL_LENGTH) return null
+        if (!up.all { it in ALLOWED }) return null
+        return "$ID_PREFIX-$up"
+    }
+
+    /**
+     * True when [id] is already the serial id for [serial] — the steady state on every reconnect after the
+     * first adoption, and the cheap early-out that keeps re-adoption from doing database work per connect.
+     */
+    fun isAlreadyAdopted(id: String, serial: String?): Boolean {
+        val target = adoptedId(serial) ?: return false
+        return id == target
+    }
+
+    /**
+     * What may be written to a SHAREABLE strap log. The serial identifies the device, so only its leading
+     * characters are ever logged — the same rule `noteWhoop5VariantFromDis` already applies to the variant
+     * line. Never log [adoptedId]'s result directly.
+     */
+    fun logSafe(serial: String?): String {
+        val raw = serial?.trim().orEmpty()
+        if (raw.isEmpty()) return "?"
+        return raw.uppercase().take(3) + "…"
+    }
+}

--- a/android/app/src/main/java/com/noop/data/WhoopSerialIdentity.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopSerialIdentity.kt
@@ -48,6 +48,20 @@ object WhoopSerialIdentity {
     }
 
     /**
+     * Whether this pairing's id may be re-pointed onto a serial id at all.
+     *
+     * ONLY a provisional `whoop-<address>` id qualifies. The legacy `my-whoop` seed is deliberately
+     * EXCLUDED, and that exclusion is what makes this safe to ship before #1304: every existing
+     * single-WHOOP install is still on that seed, ~47 code paths still read the literal "my-whoop"
+     * directly, and [com.noop.ble.WhoopBleClient] documents that the single-WHOOP path never reassigns its
+     * deviceId. Adopting it would migrate the whole history onto `whoop-<serial>` while new samples kept
+     * being written under "my-whoop" - a split history that reads as data loss.
+     *
+     * The legacy seed joins this path as part of #1304, once the literals no longer assume it.
+     */
+    fun mayAdopt(currentId: String): Boolean = currentId.startsWith("$ID_PREFIX-")
+
+    /**
      * True when [id] is already the serial id for [serial] — the steady state on every reconnect after the
      * first adoption, and the cheap early-out that keeps re-adoption from doing database work per connect.
      */

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -867,6 +867,12 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                             ") - history re-pointed off the transient pairing id (#1303)",
                     )
                     deviceRegistry.setActive(serialId)
+                    // The process-wide handle too, not just the registry and the coordinator. It is read
+                    // by the diagnostics export and threaded into the BLE client and the source
+                    // coordinator at startup; leaving it behind meant the engine kept deriving days under
+                    // the PRE-adoption id until the next cold start, splitting the computed history across
+                    // both ids (field-confirmed on a 5/MG before this line existed).
+                    noopApp.onActiveDeviceAdopted(serialId)
                     noopApp.sourceCoordinator.onActiveDeviceChanged(serialId)
                 }
             }

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -857,6 +857,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                 // truncated, non-serial prose) leaves the strap on its existing id — adopting onto a junk id
                 // would migrate every device-scoped row onto a garbage key, worse than not adopting at all.
                 if (serialId != null && currentId != null && currentId != serialId &&
+                    com.noop.data.WhoopSerialIdentity.mayAdopt(currentId) &&
                     deviceRegistry.adoptSerialIdentity(currentId, serialId)
                 ) {
                     // Prefix only. `serialId` embeds the full serial, which must never reach a shared log.

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -839,6 +839,37 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
             ble.connectedPeripheralAddress
                 .collect { addr -> noopApp.sourceCoordinator.connectedPeripheralChanged(addr) }
         }
+        // #1303: the 5/MG DIS read hands up the strap's OWN serial, so re-point this pairing from its
+        // transient address-based id onto a stable `whoop-<serial>` id, through the SAME migration the ring
+        // already uses (#771) — a re-pair or factory reset then stops forking one physical strap into a
+        // second row and orphaning its history (#1193). Lives here rather than in SourceCoordinator, which
+        // is deliberately inert on the WHOOP path and never touches WhoopBleClient internals; this class
+        // already owns the registry handle and a scope. Twin of Swift `BLEManager.adoptWhoopSerialIdentity`.
+        //
+        // A WHOOP 4.0 never reaches here: it exposes no DIS serial, and the 4.0 serial's source on the wire
+        // is not yet identified, so there is nothing honest to adopt onto.
+        ble.onSerial = { serial ->
+            viewModelScope.launch {
+                val serialId = com.noop.data.WhoopSerialIdentity.adoptedId(serial)
+                val currentId = deviceRegistry.activeDeviceId()
+                // Idempotent: once adopted the id already equals the serial id, so a reconnect costs one
+                // string compare and no database work. A serial WhoopSerialIdentity refuses (blank,
+                // truncated, non-serial prose) leaves the strap on its existing id — adopting onto a junk id
+                // would migrate every device-scoped row onto a garbage key, worse than not adopting at all.
+                if (serialId != null && currentId != null && currentId != serialId &&
+                    deviceRegistry.adoptSerialIdentity(currentId, serialId)
+                ) {
+                    // Prefix only. `serialId` embeds the full serial, which must never reach a shared log.
+                    ble.logIdentity(
+                        "WHOOP: adopted stable serial identity (serialPrefix=" +
+                            com.noop.data.WhoopSerialIdentity.logSafe(serial) +
+                            ") - history re-pointed off the transient pairing id (#1303)",
+                    )
+                    deviceRegistry.setActive(serialId)
+                    noopApp.sourceCoordinator.onActiveDeviceChanged(serialId)
+                }
+            }
+        }
         // Re-arm the strap's firmware alarm once per process-alive day. The firmware alarm is a single
         // absolute instant with NO recurrence and was previously re-armed ONLY on the bond edge — so a
         // strap that stays continuously bonded (a phone in range overnight) would fire once and then

--- a/android/app/src/test/java/com/noop/ble/PiiRedactionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/PiiRedactionTest.kt
@@ -35,6 +35,48 @@ class PiiRedactionTest {
             redactStrapLogPii("Discovered WHOOP 4C1594026 (rssi -63)"))
     }
 
+    /**
+     * #1303: once a strap ADOPTS its serial, its device id IS the serial, and the strap log prints device
+     * ids in the Devices list, every `dayOwner` line and the per-source counts. Before adoption existed no
+     * id could contain a serial, so neither older rule covers this shape.
+     */
+    @Test fun masksAnAdoptedSerialDeviceId() {
+        val out = redactStrapLogPii("device id=whoop-MGB1234567 status=ACTIVE brand=WHOOP")
+        assertEquals("device id=whoop-MGB… status=ACTIVE brand=WHOOP", out)
+        assertFalse("the serial must not survive anywhere", out.contains("1234567"))
+    }
+
+    /**
+     * The `-noop` suffix is NOT identifying and is load-bearing for reading a log: it is what separates
+     * derived rows from measured ones in the "Days:"/"Stored:" lines. Masking it away would take a
+     * diagnostic with it.
+     */
+    @Test fun keepsTheComputedSiblingMarker() {
+        assertEquals("Days: whoop-MGB…-noop=25",
+                     redactStrapLogPii("Days: whoop-MGB1234567-noop=25"))
+    }
+
+    /**
+     * The forms that must survive untouched: the legacy seed and its computed sibling are not serials, and
+     * the provisional MAC id is already masked by the MAC rule before this one sees it.
+     */
+    @Test fun leavesTheLegacySeedAndMaskedMacFormAlone() {
+        assertEquals("readId=my-whoop writeActiveId=my-whoop-noop",
+                     redactStrapLogPii("readId=my-whoop writeActiveId=my-whoop-noop"))
+        // A raw MAC id goes through the MAC rule first and must not then be re-mangled.
+        assertEquals("device id=whoop-FD:••:••:••:••:4A",
+                     redactStrapLogPii("device id=whoop-FD:A1:B2:C3:D4:4A"))
+    }
+
+    /**
+     * Six characters is the floor, matching WhoopSerialIdentity.minSerialLength: anything shorter is
+     * refused as a serial upstream, so it must not be mistaken for one here either.
+     */
+    @Test fun ignoresIdsTooShortToBeASerial() {
+        assertEquals("id=whoop-ABCDE", redactStrapLogPii("id=whoop-ABCDE"))
+        assertEquals("id=whoop-ABC…", redactStrapLogPii("id=whoop-ABCDEF"))
+    }
+
     @Test fun leavesModelNamesAndPlainTextAlone() {
         // "WHOOP 4.0" is a dotted model name, not a serial — must not be scrubbed.
         assertEquals("Auto-reconnecting to your saved WHOOP 4.0…",

--- a/android/app/src/test/java/com/noop/data/WhoopSerialIdentityTest.kt
+++ b/android/app/src/test/java/com/noop/data/WhoopSerialIdentityTest.kt
@@ -69,6 +69,40 @@ class WhoopSerialIdentityTest {
         assertFalse(WhoopSerialIdentity.mayAdopt("oura-2H3B2405003655"))
     }
 
+    /**
+     * The process-wide handle must follow adoption, not wait for a cold start.
+     *
+     * `NoopApplication.activeDeviceId` was a `by lazy`, frozen for the life of the process. Adoption
+     * re-pointed the registry while every consumer of that handle kept the OLD id, so the scoring engine
+     * went on deriving days under the pre-adoption id and the computed history split across both until the
+     * phone was restarted. Confirmed on a real 5/MG: the registry read the serial id while the export
+     * still printed the address id and the old computed bucket kept growing.
+     *
+     * `NoopApplication` needs a Context, so the invariant is pinned against the source the way the other
+     * un-constructable callers are.
+     */
+    @Test fun adoptionRePointsTheProcessWideActiveIdHandle() {
+        var root = java.io.File(System.getProperty("user.dir") ?: ".").canonicalFile
+        var app: String? = null
+        var vm: String? = null
+        repeat(4) {
+            val a = java.io.File(root, "android/app/src/main/java/com/noop/NoopApplication.kt")
+            val v = java.io.File(root, "android/app/src/main/java/com/noop/ui/AppViewModel.kt")
+            if (a.isFile && app == null) app = a.readText()
+            if (v.isFile && vm == null) vm = v.readText()
+            root = root.parentFile ?: root
+        }
+        val application = app ?: error("NoopApplication.kt not found - this test must not pass by default")
+        val viewModel = vm ?: error("AppViewModel.kt not found - this test must not pass by default")
+
+        assertFalse("activeDeviceId must not be a frozen `by lazy` again",
+                    application.contains("val activeDeviceId: String by lazy"))
+        assertTrue("it must expose a way to follow an adoption",
+                   application.contains("fun onActiveDeviceAdopted(newId: String)"))
+        assertTrue("and adoption must actually call it",
+                   viewModel.contains("noopApp.onActiveDeviceAdopted(serialId)"))
+    }
+
     @Test fun logSafeNeverLeaksTheFullSerial() {
         assertEquals("5AG…", WhoopSerialIdentity.logSafe("5AG12345678"))
         assertEquals("?", WhoopSerialIdentity.logSafe(null))

--- a/android/app/src/test/java/com/noop/data/WhoopSerialIdentityTest.kt
+++ b/android/app/src/test/java/com/noop/data/WhoopSerialIdentityTest.kt
@@ -53,6 +53,22 @@ class WhoopSerialIdentityTest {
         assertFalse(WhoopSerialIdentity.isAlreadyAdopted("whoop-5AG12345678", "  "))
     }
 
+    /**
+     * The guard that makes this safe to ship before #1304. Every existing single-WHOOP install is on the
+     * legacy "my-whoop" seed, ~47 code paths read that literal directly, and WhoopBleClient never
+     * reassigns its deviceId on the single-WHOOP path — so adopting it would migrate the history onto
+     * whoop-<serial> while new samples kept landing under "my-whoop". A split history reads as data loss.
+     */
+    @Test fun refusesToAdoptTheLegacySingleWhoopSeed() {
+        assertFalse(WhoopSerialIdentity.mayAdopt("my-whoop"))
+        // A provisional pairing id IS adoptable — that is the multi-strap case this ships for.
+        assertTrue(WhoopSerialIdentity.mayAdopt("whoop-6B9F2C11-0000-4000-8000-0000000000AA"))
+        // An already-adopted serial id stays adoptable; the equality check upstream stops the re-migration.
+        assertTrue(WhoopSerialIdentity.mayAdopt("whoop-5AG12345678"))
+        // Another brand's id is never touched by the WHOOP path.
+        assertFalse(WhoopSerialIdentity.mayAdopt("oura-2H3B2405003655"))
+    }
+
     @Test fun logSafeNeverLeaksTheFullSerial() {
         assertEquals("5AG…", WhoopSerialIdentity.logSafe("5AG12345678"))
         assertEquals("?", WhoopSerialIdentity.logSafe(null))

--- a/android/app/src/test/java/com/noop/data/WhoopSerialIdentityTest.kt
+++ b/android/app/src/test/java/com/noop/data/WhoopSerialIdentityTest.kt
@@ -1,0 +1,61 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Twin of the Swift WhoopSerialIdentityTests. The REFUSALS matter more than the composition: adoption
+ * migrates every device-scoped row onto the id this returns, so a junk serial must yield null and leave
+ * the strap on its existing id rather than move a history onto a garbage key (#1303).
+ */
+class WhoopSerialIdentityTest {
+
+    @Test fun composesTheSerialId() {
+        assertEquals("whoop-5AG12345678", WhoopSerialIdentity.adoptedId("5AG12345678"))
+    }
+
+    @Test fun upperCasesSoOneStrapCannotBecomeTwoIds() {
+        assertEquals(
+            WhoopSerialIdentity.adoptedId("5ag12345678"),
+            WhoopSerialIdentity.adoptedId("5AG12345678"),
+        )
+    }
+
+    @Test fun trimsSurroundingWhitespaceFromTheGattString() {
+        assertEquals("whoop-5AG12345678", WhoopSerialIdentity.adoptedId("  5AG12345678\n"))
+    }
+
+    @Test fun refusesBlankOrMissing() {
+        assertNull(WhoopSerialIdentity.adoptedId(null))
+        assertNull(WhoopSerialIdentity.adoptedId(""))
+        assertNull(WhoopSerialIdentity.adoptedId("   \n "))
+    }
+
+    @Test fun refusesATruncatedRead() {
+        // A partial GATT response must not become an id: it would collide across straps.
+        assertNull(WhoopSerialIdentity.adoptedId("5AG"))
+    }
+
+    @Test fun refusesADescriptiveStringThatIsNotASerial() {
+        // Some peripherals answer DIS with prose. Never let that become a device id.
+        assertNull(WhoopSerialIdentity.adoptedId("Not Available"))
+        assertNull(WhoopSerialIdentity.adoptedId("serial#1234"))
+    }
+
+    @Test fun alreadyAdoptedIsTheReconnectEarlyOut() {
+        assertTrue(WhoopSerialIdentity.isAlreadyAdopted("whoop-5AG12345678", "5AG12345678"))
+        assertFalse(WhoopSerialIdentity.isAlreadyAdopted("whoop-ABCDEF-0123", "5AG12345678"))
+        // An unusable serial is never "already adopted" — otherwise a junk read would silently
+        // suppress a later good one.
+        assertFalse(WhoopSerialIdentity.isAlreadyAdopted("whoop-5AG12345678", "  "))
+    }
+
+    @Test fun logSafeNeverLeaksTheFullSerial() {
+        assertEquals("5AG…", WhoopSerialIdentity.logSafe("5AG12345678"))
+        assertEquals("?", WhoopSerialIdentity.logSafe(null))
+        assertFalse(WhoopSerialIdentity.logSafe("5AG12345678").contains("12345678"))
+    }
+}


### PR DESCRIPTION
**DO NOT MERGE until hardware-validated** — see below. Opening it now so the design can be reviewed
while a 5.0/MG night is arranged.

Phase 1 of #1303, the multi-strap keystone.

## Why this is smaller than it looks

WHOOP identity is a **transient** CoreBluetooth UUID / Bluetooth address, so a re-pair or factory reset
mints a fresh one and the same physical strap forks into a second registry row, orphaning its history
(#1193).

The scary part — re-keying every stored row — **is already written, shipped and proven**:
`adoptSerialIdentity` migrates every `deviceScopedTables` row, is PK-clash-safe, is unit-tested, and has
been running on **both** platforms for the ring since #771. This PR does not add a migration. It calls the
proven one from the WHOOP path.

## Why 5.0/MG only

Their serial is **already read at connect** from DIS `0x2A25` for MG-vs-5.0 discrimination — so this adds
**no BLE traffic whatsoever**, it consumes a value already in hand.

A 4.0 is untouched: the DIS read is explicitly gated `!= .whoop4`, and the 4.0 serial's source on the wire
is **not yet identified** (`REPORT_VERSION_INFO`'s 35 bytes are fully accounted for as firmware). Splitting
the two is precisely what lets this half ship now rather than waiting on a 4.0 protocol capture — that is
Phase 0/2, and it needs a capture, not speculative code.

## The refusals are the feature

Adoption migrates every device-scoped row onto whatever id is returned, so `WhoopSerialIdentity` refuses a
blank, truncated, or descriptive-prose DIS read and returns nil, leaving the strap on its existing id.
**Moving a history onto a garbage key is worse than not adopting.** Serials are upper-cased so one strap
read in two cases cannot become two ids, and `isAlreadyAdopted` is the reconnect early-out — after the
first adoption it is one string compare and no database work.

## Design notes worth reviewing

- Both platforms **defer off the BLE callback**, mirroring `adoptOuraSerial`: adoption re-points the ACTIVE
  device, and the observers that react tear down the very connection the callback is running inside.
- On Android it lives in `AppViewModel`, **not** `SourceCoordinator` — that file is documented as inert on
  the WHOOP path and never touches `WhoopBleClient` internals. `AppViewModel` already owns the registry
  handle and a scope. (I wired it into SourceCoordinator first and reverted; the file's own header says why.)
- The serial is a device identifier: **only its 3-char prefix is ever logged**, the rule
  `noteWhoop5VariantFromDIS` already applies. `logSafe` enforces it and a test pins that the full serial
  cannot appear in a shareable strap log.

## Verification

- 8 mirrored test vectors per platform on the pure core (composition, case-folding, trim, and five refusal
  cases)
- Android **4,091 tests / 0 failures**; Kotlin compile, i18n, doc-comment gates clean
- app-build dispatched for the app-target Swift

## What must happen before merge

This is the BLE path — compiling proves nothing. A 5.0/MG night must confirm:

1. the strap adopts **once**, and the strap log shows the prefix-only line beside the DIS line
2. a **reconnect is a no-op** (no repeated adoption, no database churn)
3. a **re-pair re-anchors** onto the existing serial row rather than forking a new one — the actual #1193
   scenario