### PR TITLE
Fix Swift SleepStagerV2 shuffled-input clipping

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStagerV2.swift
@@ -53,13 +53,33 @@ public enum SleepStagerV2 {
         // farthest reach of any per-epoch window (the 11-min HR-flatness window: 330 s back, 390 s forward —
         // see `padLo`/`padHi` below). On the first post-sync pass (~21 nights cold) and the full-history Effort
         // rescore (up to 4000 nights cold) those out-of-window rows are what blow the per-second dictionaries
-        // and the sort allocations up to OOM. The streams arrive sorted by ts, so we lower/upper-bound slice
-        // each to the read window BEFORE fingerprinting and BEFORE the uncached recipe. This is output-identical
-        // (we drop only rows `features()` could never touch) and it also tightens the fingerprint to the rows
-        // that matter. PAD_LO/PAD_HI are the SAME values the Android twin (R1) clips with.
-        let gravW = clipToWindow(grav, lo: start - Self.padLo, hi: end + Self.padHi, ts: { $0.ts })
-        let hrW = clipToWindow(hr, lo: start - Self.padLo, hi: end + Self.padHi, ts: { $0.ts })
-        let rrW = clipToWindow(rr, lo: start - Self.padLo, hi: end + Self.padHi, ts: { $0.ts })
+        // and the sort allocations up to OOM. Establish timestamp order defensively, then lower/upper-bound
+        // slice each stream to the read window BEFORE fingerprinting and BEFORE the uncached recipe. This is
+        // output-identical for sorted callers (and stable for same-second rows), drops only rows `features()`
+        // could never touch, and tightens the fingerprint to the rows that matter. PAD_LO/PAD_HI are the SAME
+        // values the Android twin (R1) clips with.
+        let stableOrder: (Int, (Int) -> Int) -> [Int]? = { count, tsAt in
+            if count < 2 { return nil }
+            var hasInversion = false
+            for i in 1..<count where tsAt(i - 1) > tsAt(i) {
+                hasInversion = true
+                break
+            }
+            if !hasInversion { return nil }
+            return (0..<count).sorted { lhs, rhs in
+                let lts = tsAt(lhs), rts = tsAt(rhs)
+                return lts == rts ? lhs < rhs : lts < rts
+            }
+        }
+        let gravO = stableOrder(grav.count, { grav[$0].ts }).map { $0.map { grav[$0] } } ?? grav
+        let hrO = stableOrder(hr.count, { hr[$0].ts }).map { $0.map { hr[$0] } } ?? hr
+        let rrO = stableOrder(rr.count, { rr[$0].ts }).map { $0.map { rr[$0] } } ?? rr
+        let gravW = clipToWindow(gravO,
+                                 lo: start - Self.padLo, hi: end + Self.padHi, ts: { $0.ts })
+        let hrW = clipToWindow(hrO,
+                               lo: start - Self.padLo, hi: end + Self.padHi, ts: { $0.ts })
+        let rrW = clipToWindow(rrO,
+                               lo: start - Self.padLo, hi: end + Self.padHi, ts: { $0.ts })
         let key = V2Key(
             start: start, end: end,
             grav: StreamFingerprint.of(gravW, ts: { $0.ts }, quant: {
@@ -111,13 +131,8 @@ public enum SleepStagerV2 {
     /// in front of it; behaviour is byte-identical (a cache miss runs exactly this).
     private static func stageSessionUncached(start: Int, end: Int, grav: [GravitySample],
                                              hr: [HRSample], rr: [RRInterval], resp: [RespSample]) -> [StageSegment] {
-        // Sort defensively so the windowed features behave regardless of caller ordering (V1's stageSession
-        // assumes its callers pass roughly-sorted streams; we make no such assumption here).
-        let gravS = grav.sorted { $0.ts < $1.ts }
-        let hrS = hr.sorted { $0.ts < $1.ts }
-        let rrS = rr.sortedByTsStable()   // stable: keeps #823 emission order within a second
-
-        let feats = features(start: start, end: end, grav: gravS, hr: hrS, rr: rrS)
+        // The public veneer has already established stable timestamp order before clipping.
+        let feats = features(start: start, end: end, grav: grav, hr: hr, rr: rr)
         if feats.isEmpty { return [StageSegment(start: start, end: end, stage: "light")] }
         let labels = stageEpochs(feats)
 

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerV2Tests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerV2Tests.swift
@@ -31,7 +31,77 @@ final class SleepStagerV2Tests: XCTestCase {
         }
     }
 
+    private func oddEven<T>(_ rows: [T]) -> [T] {
+        stride(from: 0, to: rows.count, by: 2).map { rows[$0] }
+            + stride(from: 1, to: rows.count, by: 2).map { rows[$0] }
+    }
+
     // MARK: - drop-in contract
+
+    /// bhelm/noop#67: the public entry accepts caller streams in any order. Binary-search clipping must not
+    /// run until timestamp order is established, otherwise this deterministic permutation drops valid rows.
+    func testShuffledInputsMatchSortedInputs() {
+        let start = 1_751_513_600
+        let duration = 90 * 60
+        let padding = 600
+        let streamStart = start - padding
+        let streamDuration = duration + 2 * padding
+        let grav = (0..<streamDuration).map { i in
+            i.isMultiple(of: 2)
+                ? GravitySample(ts: streamStart + i, x: 1, y: 0, z: 0)
+                : GravitySample(ts: streamStart + i, x: 0, y: 0, z: 1)
+        }
+        let hr = sleepHR(start: streamStart, durationS: streamDuration, base: 50)
+        let rr = regularRR(start: streamStart, durationS: streamDuration)
+
+        let sorted = SleepStagerV2.stageSession(
+            start: start, end: start + duration, grav: grav, hr: hr, rr: rr, resp: [])
+        XCTAssertEqual(sorted, [StageSegment(start: start, end: start + duration, stage: "light")],
+                       "the sorted-input output is the frozen control")
+
+        let shuffled = SleepStagerV2.stageSession(
+            start: start, end: start + duration,
+            grav: oddEven(grav), hr: oddEven(hr), rr: oddEven(rr), resp: [])
+        XCTAssertEqual(shuffled, sorted,
+                       "clipping must establish timestamp order before binary-search bounds")
+    }
+
+    /// Same-second gravity accumulation is order-sensitive under catastrophic cancellation. Each call uses a
+    /// distinct translated window so the memo cannot answer one permutation from another's cache entry.
+    func testShuffledTimestampGroupsPreserveOrderSensitiveDuplicateOutcomes() {
+        let duration = 90 * 60
+        let padding = 600
+        let streamDuration = duration + 2 * padding
+        func stagedShape(start: Int, signalLast: Bool, shuffled: Bool) -> [String] {
+            let streamStart = start - padding
+            let gravGroups = (0..<streamDuration).map { i -> [GravitySample] in
+                let ts = streamStart + i
+                let signal = i % 30 == 15 ? 0.25 : 0.0
+                let huge = GravitySample(ts: ts, x: 8e15, y: 0, z: 0)
+                let small = GravitySample(ts: ts, x: signal, y: 0, z: 0)
+                let negative = GravitySample(ts: ts, x: -8e15, y: 0, z: 0)
+                return signalLast ? [huge, negative, small] : [huge, small, negative]
+            }
+            let grav = (shuffled ? oddEven(gravGroups) : gravGroups).flatMap { $0 }
+            let hr = sleepHR(start: streamStart, durationS: streamDuration, base: 50)
+            let rr = regularRR(start: streamStart, durationS: streamDuration)
+            let segments = SleepStagerV2.stageSession(
+                start: start, end: start + duration,
+                grav: grav, hr: shuffled ? oddEven(hr) : hr, rr: shuffled ? oddEven(rr) : rr, resp: [])
+            return segments.map { "\($0.start - start):\($0.end - start):\($0.stage)" }
+        }
+        let base = 1_752_513_600
+        let cancelledSorted = stagedShape(start: base, signalLast: false, shuffled: false)
+        let cancelledShuffled = stagedShape(start: base + 10_000_000, signalLast: false, shuffled: true)
+        let retainedSorted = stagedShape(start: base + 20_000_000, signalLast: true, shuffled: false)
+        let retainedShuffled = stagedShape(start: base + 30_000_000, signalLast: true, shuffled: true)
+        let cancelledOracle = ["0:5400:light"]
+        let retainedOracle = ["0:5400:wake"]
+        XCTAssertEqual(cancelledSorted, cancelledOracle)
+        XCTAssertEqual(cancelledShuffled, cancelledOracle)
+        XCTAssertEqual(retainedSorted, retainedOracle)
+        XCTAssertEqual(retainedShuffled, retainedOracle)
+    }
 
     func testStagesTileTheWholeSpanContiguously() {
         let start = 1_700_000_000

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerV2Test.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerV2Test.kt
@@ -43,7 +43,76 @@ class SleepStagerV2Test {
             RrInterval(deviceId = dev, ts = start + i, rrMs = 1000 + rsa)
         }
 
+    private fun <T> oddEven(rows: List<T>): List<T> =
+        rows.filterIndexed { index, _ -> index % 2 == 0 } +
+            rows.filterIndexed { index, _ -> index % 2 == 1 }
+
     // ── drop-in contract ─────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * bhelm/noop#67 mirrored control: Android already sorts before binary-search clipping. The same rows in
+     * this deterministic permutation must produce the frozen sorted-input result on both native twins.
+     */
+    @Test
+    fun shuffledInputsMatchSortedInputs() {
+        val start = refMidnight + 2_000_000L
+        val duration = 90 * 60
+        val padding = 600
+        val streamStart = start - padding
+        val streamDuration = duration + 2 * padding
+        val grav = (0 until streamDuration).map { i ->
+            if (i % 2 == 0) GravitySample(dev, streamStart + i, x = 1.0, y = 0.0, z = 0.0)
+            else GravitySample(dev, streamStart + i, x = 0.0, y = 0.0, z = 1.0)
+        }
+        val hr = sleepHR(streamStart, streamDuration, base = 50)
+        val rr = regularRR(streamStart, streamDuration)
+
+        val sorted = SleepStagerV2.stageSession(start, start + duration, grav, hr, rr, emptyList())
+        assertEquals(
+            "the sorted-input output is the frozen control",
+            listOf(StageSegment(start, start + duration, "light")), sorted)
+
+        val shuffled = SleepStagerV2.stageSession(
+            start, start + duration, oddEven(grav), oddEven(hr), oddEven(rr), emptyList())
+        assertEquals(
+            "clipping must establish timestamp order before binary-search bounds", sorted, shuffled)
+    }
+
+    /**
+     * Same-second gravity accumulation is order-sensitive under catastrophic cancellation. Each call uses a
+     * distinct translated window so the memo cannot answer one permutation from another's cache entry.
+     */
+    @Test
+    fun shuffledTimestampGroupsPreserveOrderSensitiveDuplicateOutcomes() {
+        val duration = 90 * 60
+        val padding = 600
+        val streamDuration = duration + 2 * padding
+        fun stagedShape(start: Long, signalLast: Boolean, shuffled: Boolean): List<String> {
+            val streamStart = start - padding
+            val gravGroups = (0 until streamDuration).map { i ->
+                val ts = streamStart + i
+                val signal = if (i % 30 == 15) 0.25 else 0.0
+                val huge = GravitySample(dev, ts, x = 8e15, y = 0.0, z = 0.0)
+                val small = GravitySample(dev, ts, x = signal, y = 0.0, z = 0.0)
+                val negative = GravitySample(dev, ts, x = -8e15, y = 0.0, z = 0.0)
+                if (signalLast) listOf(huge, negative, small) else listOf(huge, small, negative)
+            }
+            val grav = (if (shuffled) oddEven(gravGroups) else gravGroups).flatten()
+            val hr = sleepHR(streamStart, streamDuration, base = 50)
+            val rr = regularRR(streamStart, streamDuration)
+            return SleepStagerV2.stageSession(
+                start, start + duration, grav,
+                if (shuffled) oddEven(hr) else hr, if (shuffled) oddEven(rr) else rr, emptyList())
+                .map { "${it.start - start}:${it.end - start}:${it.stage}" }
+        }
+        val base = refMidnight + 3_000_000L
+        val cancelledOracle = listOf("0:5400:light")
+        val retainedOracle = listOf("0:5400:wake")
+        assertEquals(cancelledOracle, stagedShape(base, signalLast = false, shuffled = false))
+        assertEquals(cancelledOracle, stagedShape(base + 10_000_000L, signalLast = false, shuffled = true))
+        assertEquals(retainedOracle, stagedShape(base + 20_000_000L, signalLast = true, shuffled = false))
+        assertEquals(retainedOracle, stagedShape(base + 30_000_000L, signalLast = true, shuffled = true))
+    }
 
     @Test
     fun stagesTileTheWholeSpanContiguously() {


### PR DESCRIPTION
## What this PR does

Makes the Swift public `SleepStagerV2.stageSession` establish stable timestamp order before binary-search clipping, matching the Kotlin twin. Already-monotonic streams keep the allocation-free fast path; only genuinely shuffled inputs allocate a stable reorder. The uncached recipe consumes the already-ordered clipped streams directly, preserving same-second emission order.

Permanent mirrored native tests cover deterministic shuffled streams, freeze the existing sorted-input result, and use cache-isolated translated windows to prove two order-sensitive same-timestamp gravity outcomes remain distinct while timestamp-group shuffling preserves each outcome. Padding constants and the parity rollout harness are unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- RED on unchanged `6df88d0d`: the permanent Swift shuffled-input regression failed with sorted all-light versus shuffled light+REM.
- RED mutation check: a legal unstable same-timestamp tie reorder made both retained-signal oracle runs change from wake to light.
- Final focused Swift public outcome regression: passed.
- Final mirrored Kotlin public outcome regression: passed with JDK 17, one worker, Kotlin compilation in-process, and parallelism disabled.
- Production-identical full StrandAnalytics suite: 1,439 tests executed, 2 skipped, 0 failures.
- Production-identical full Android `:app:testFullDebugUnitTest`: passed.
- Clean current-main Kotlin `SleepStagerV2Test`: passed under the same resource limits.
- Clean current-main Swift test invocation is presently blocked before test execution by the unrelated Linux baseline import of the Apple-only `Compression` module in `WhoopStore/RawOutbox.swift`; the fork full Swift suite and focused final Swift regression are green.
- Range-diff from the reviewed fork commit to current main differs only in the already-landed #1453 gravity-fingerprint context; behavior and tests are unchanged.
- Parity ratchet against the exact fork base: 59 differential, 2,605 exempt, 0 errors.
- Independent final delta review: no P0/P1/P2 findings.
- No manual or hardware testing required: this changes pure sleep analytics ordering only.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Tracked in bhelm/noop#67.