### PR TITLE
feat(ble): also scan for the 16-bit FD4B advertisement on 5.0/MG

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1617,7 +1617,7 @@ public final class BLEManager: NSObject, ObservableObject {
         central.stopScan()
         // Allow duplicates so the wizard's RSSI/signal readout updates as straps move.
         central.scanForPeripherals(
-            withServices: [selectedModel.scanService],
+            withServices: selectedModel.advertisedScanServices,
             options: [CBCentralManagerScanOptionAllowDuplicatesKey: true]
         )
         log("Add-a-WHOOP scan: presenting nearby \(selectedModel.displayName) straps")
@@ -4006,7 +4006,7 @@ public final class BLEManager: NSObject, ObservableObject {
         configureCollectorFamily()
         central.stopScan()
         log("Scanning for \(model.displayName)…")
-        let diagnosticServices = [model.scanService] + WhoopGattServiceFamily.unsupportedServiceUUIDStrings
+        let diagnosticServices = model.advertisedScanServices + WhoopGattServiceFamily.unsupportedServiceUUIDStrings
             .map { CBUUID(string: $0) }
         central.scanForPeripherals(
             withServices: diagnosticServices,

--- a/Strand/BLE/WhoopModel.swift
+++ b/Strand/BLE/WhoopModel.swift
@@ -50,4 +50,29 @@ public enum WhoopModel: String, CaseIterable, Identifiable, Hashable {
         case .whoop5mg: return CBUUID(string: "fd4b0001-cce1-4033-93ce-002d5875f58a")
         }
     }
+
+    /// The UUIDs that may appear in a strap's ADVERTISEMENT, which is not the same set as `scanService`.
+    ///
+    /// A 128-bit UUID often does not fit the 31-byte advertising payload, so a peripheral may advertise
+    /// the 16-bit SIG member form instead and CoreBluetooth surfaces that as its Bluetooth-base expansion
+    /// (`0000FD4B-…`) — which does NOT equal the vendor UUID `fd4b0001-…`. A scan filtered only on the
+    /// vendor UUID would then never see the strap, and it would read to the owner as "NOOP cannot find my
+    /// 5.0" rather than as a discovery bug.
+    ///
+    /// Advertisement-only, deliberately: after connecting, the strap exposes the real 128-bit service in
+    /// GATT, so `retrieveConnectedPeripherals` and `discoverServices` must keep using `scanService` alone.
+    /// Widening those would be wrong, not merely redundant.
+    ///
+    /// UNCONFIRMED against hardware. The 16-bit `0xFD4B` possibility is a fact re-derived from
+    /// OpenStrap/edge#255 (Dart; no code taken), which ships the same widening while its own test plan
+    /// still asks for the nRF Connect capture that would settle it. NOOP straps do pair today, so the
+    /// vendor UUID demonstrably works at least often — this only removes a way for discovery to fail
+    /// silently, and the discovery log records which form actually matched so the first 5/MG capture
+    /// answers the question for both projects.
+    public var advertisedScanServices: [CBUUID] {
+        switch self {
+        case .whoop4:   return [scanService]
+        case .whoop5mg: return [scanService, CBUUID(string: "FD4B")]
+        }
+    }
 }

--- a/StrandTests/WhoopModelScanServiceTests.swift
+++ b/StrandTests/WhoopModelScanServiceTests.swift
@@ -1,0 +1,37 @@
+import CoreBluetooth
+import XCTest
+@testable import Strand
+
+/// Pins the ADVERTISEMENT/GATT split: a 16-bit member UUID may appear in an advertisement, but only the
+/// 128-bit vendor service exists in GATT, so widening the scan must not widen service discovery.
+/// Kotlin twin: `WhoopModelScanUuidTest`.
+final class WhoopModelScanServiceTests: XCTestCase {
+
+    private let vendor5 = CBUUID(string: "fd4b0001-cce1-4033-93ce-002d5875f58a")
+    private let sig16 = CBUUID(string: "FD4B")
+
+    func testWhoop4AdvertisementSetIsUnchanged() {
+        // The 4.0 gains nothing: its service is not a 16-bit member UUID, and a wider filter would only
+        // cost radio time on the overwhelmingly common path.
+        XCTAssertEqual(WhoopModel.whoop4.advertisedScanServices, [WhoopModel.whoop4.scanService])
+    }
+
+    func testWhoop5AdvertisementSetAddsTheSixteenBitForm() {
+        let uuids = WhoopModel.whoop5mg.advertisedScanServices
+        XCTAssertEqual(uuids.first, vendor5)   // vendor UUID still first: today's behaviour is a subset
+        XCTAssertTrue(uuids.contains(sig16))
+        XCTAssertEqual(uuids.count, 2)
+    }
+
+    func testTheSixteenBitEntryIsNotTheVendorUuid() {
+        // The distinction IS the bug: a band advertising 0xFD4B surfaces as the Bluetooth-base expansion,
+        // which does not equal the vendor UUID, so a filter carrying only the vendor UUID never matches it.
+        XCTAssertNotEqual(sig16, vendor5)
+    }
+
+    func testGattServiceStaysTheVendorUuidAlone() {
+        // After connecting, the strap exposes the real 128-bit service. Widening GATT discovery with an
+        // advertisement-only UUID would be wrong, not merely redundant.
+        XCTAssertEqual(WhoopModel.whoop5mg.scanService, vendor5)
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2803,7 +2803,7 @@ class WhoopBleClient(
         // Filter to the strap we're targeting plus diagnostic-only WHOOP service families. The callback
         // explicitly refuses unsupported families before any persist/connect path, so this broadens
         // visibility without routing unknown framing into GATT.
-        val filters = (listOf(model.service.toString()) + WhoopGattServiceFamily.unsupportedServiceUuidStrings)
+        val filters = (model.advertisedScanUuids.map { it.toString() } + WhoopGattServiceFamily.unsupportedServiceUuidStrings)
             .distinct()
             .map { uuid ->
                 ScanFilter.Builder().setServiceUuid(ParcelUuid(UUID.fromString(uuid))).build()
@@ -3094,9 +3094,9 @@ class WhoopBleClient(
             val n = try { d.name } catch (se: SecurityException) { null }
             _discoveredWhoops.value = listOf(DiscoveredWhoop(address = d.address, name = n, rssi = 0))
         }
-        val filters = listOf(
-            ScanFilter.Builder().setServiceUuid(ParcelUuid(model.service)).build(),
-        )
+        val filters = model.advertisedScanUuids.map {
+            ScanFilter.Builder().setServiceUuid(ParcelUuid(it)).build()
+        }
         // LOW_LATENCY for a snappy wizard; the in-callback accumulation refreshes RSSI as straps move.
         val settings = ScanSettings.Builder()
             .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)

--- a/android/app/src/main/java/com/noop/ble/WhoopModel.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopModel.kt
@@ -26,4 +26,26 @@ enum class WhoopModel(val displayName: String, val service: UUID) {
             WHOOP4 -> WHOOP5_MG
             WHOOP5_MG -> WHOOP4
         }
+
+    /**
+     * The UUIDs that may appear in a strap's ADVERTISEMENT, which is not the same set as [service].
+     *
+     * A 128-bit UUID often does not fit the 31-byte advertising payload, so a peripheral may advertise the
+     * 16-bit SIG member form instead, which expands to `0000FD4B-0000-1000-8000-00805F9B34FB` and does NOT
+     * equal the vendor UUID `fd4b0001-...`. A scan filtered only on the vendor UUID would then never see
+     * the strap, reading to the owner as "NOOP cannot find my 5.0" rather than as a discovery bug.
+     *
+     * Advertisement-only, deliberately: after connecting the strap exposes the real 128-bit service in
+     * GATT, so service discovery must keep using [service] alone. Widening that would be wrong.
+     *
+     * UNCONFIRMED against hardware - a fact re-derived from OpenStrap/edge#255 (Dart; no code taken),
+     * which ships the same widening while its own test plan still asks for the capture that would settle
+     * it. Straps do pair today, so the vendor UUID demonstrably works at least often; this only removes a
+     * way for discovery to fail silently, and the scan log records which form actually matched.
+     */
+    val advertisedScanUuids: List<UUID>
+        get() = when (this) {
+            WHOOP4 -> listOf(service)
+            WHOOP5_MG -> listOf(service, UUID.fromString("0000FD4B-0000-1000-8000-00805F9B34FB"))
+        }
 }

--- a/android/app/src/test/java/com/noop/ble/WhoopModelScanUuidTest.kt
+++ b/android/app/src/test/java/com/noop/ble/WhoopModelScanUuidTest.kt
@@ -1,0 +1,46 @@
+package com.noop.ble
+
+import java.util.UUID
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Twin of the Swift WhoopModelScanServiceTests. Pins the ADVERTISEMENT/GATT split: a 16-bit member UUID
+ * may appear in an advertisement, but only the 128-bit vendor service exists in GATT, so widening the
+ * scan must not widen service discovery.
+ */
+class WhoopModelScanUuidTest {
+
+    private val vendor5 = UUID.fromString("fd4b0001-cce1-4033-93ce-002d5875f58a")
+    private val sig16Expanded = UUID.fromString("0000FD4B-0000-1000-8000-00805F9B34FB")
+
+    @Test fun whoop4AdvertisementSetIsUnchanged() {
+        // The 4.0 gains nothing: its service is not a 16-bit member UUID, and a wider filter would only
+        // cost radio time on the overwhelmingly common path.
+        assertEquals(listOf(WhoopModel.WHOOP4.service), WhoopModel.WHOOP4.advertisedScanUuids)
+    }
+
+    @Test fun whoop5AdvertisementSetAddsTheSixteenBitForm() {
+        val uuids = WhoopModel.WHOOP5_MG.advertisedScanUuids
+        assertTrue(uuids.contains(vendor5))       // vendor UUID still first: today's behaviour is a subset
+        assertEquals(vendor5, uuids.first())
+        assertTrue(uuids.contains(sig16Expanded))
+        assertEquals(2, uuids.size)
+    }
+
+    @Test fun theSixteenBitEntryIsTheBaseExpansionNotTheVendorUuid() {
+        // The distinction IS the bug: a band advertising 0xFD4B surfaces as the Bluetooth-base expansion,
+        // which does not equal the vendor UUID, so a filter carrying only the vendor UUID never matches it.
+        assertFalse(sig16Expanded == vendor5)
+        assertTrue(WhoopModel.WHOOP5_MG.advertisedScanUuids.contains(sig16Expanded))
+    }
+
+    @Test fun gattServiceStaysTheVendorUuidAlone() {
+        // After connecting, the strap exposes the real 128-bit service. Widening GATT discovery with an
+        // advertisement-only UUID would be wrong, not merely redundant.
+        assertEquals(vendor5, WhoopModel.WHOOP5_MG.service)
+        assertEquals(WhoopBleClient.WHOOP5_SERVICE, WhoopModel.WHOOP5_MG.service)
+    }
+}


### PR DESCRIPTION
Removes a way for 5.0/MG discovery to fail silently. **Unconfirmed against hardware** — see the honesty
section, which is the part worth reviewing.

## The gap

A 128-bit UUID often does not fit the 31-byte advertising payload, so a peripheral may advertise the
**16-bit SIG member form** instead. Both CoreBluetooth and Android surface that as its Bluetooth-base
expansion `0000FD4B-0000-1000-8000-00805F9B34FB`, which does **not** equal our vendor UUID
`fd4b0001-cce1-4033-93ce-002d5875f58a`.

Our scans filter on the vendor UUID alone, on both platforms. A strap advertising the 16-bit form would
therefore never appear — and to its owner that reads as *"NOOP cannot find my 5.0"*, not as a discovery
bug worth reporting.

## Advertisement-only, deliberately

After connecting, the strap exposes the real 128-bit service in **GATT**. So `retrieveConnectedPeripherals`
and `discoverServices` keep using the vendor UUID alone — widening those would be **wrong**, not merely
redundant. The new accessor is named for that distinction (`advertisedScanServices` / `advertisedScanUuids`)
and a test pins GATT staying single, because the natural mistake when reading this later is to "finish the
job" by widening service discovery too.

## Honesty about the evidence

The 16-bit possibility is a **fact re-derived** from OpenStrap/edge#255 (Dart; no code taken), which ships
the same widening while **its own test plan still asks** for the nRF Connect capture of primary AD versus
scan response that would settle it. So neither project has confirmed what a real MG advertises.

Straps do pair with NOOP today, so the vendor UUID demonstrably works at least often. What is unknown is
whether it fails for MG specifically, or on particular firmware.

I would normally want the capture first. What makes this shippable without it is that the change is
**strictly additive**: the vendor UUID stays first in the filter, the 4.0 set is untouched, and there is
no case where a strap that pairs today stops pairing. The bounded downside is slightly more scan traffic
on the 5/MG path.

## Verification

- Mirrored tests both platforms: 4.0 set unchanged, 5/MG set gains exactly the base-expanded form, that
  expansion differs from the vendor UUID, GATT stays single
- Android **4,089 tests / 0 failures**; Kotlin compile + doc-comment gates clean
- app-build dispatched for the app-target Swift

## Still worth asking for

An nRF Connect dump of a real MG (primary AD vs scan response) alongside the `rr emit` capture #1451 wants
— one volunteer session would close this question for both projects. If it shows the vendor UUID is always
in the primary AD, this can be reverted as unnecessary rather than left as folklore.