### PR TITLE
diag(rr): print each sampled beat's ord, the last field that can localise the over-count (#1008)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -667,6 +667,7 @@ public enum HRVAnalyzer {
         tsSec: [Int],
         rrMs: [Double],
         srcCodes: [Int?],
+        ords: [Int?] = [],
         halfWindowSec: Int = 3,
         maxRowsPerSecond: Int = 24
     ) -> String {
@@ -707,6 +708,12 @@ public enum HRVAnalyzer {
                 let idx = rows[k]
                 out += "\(Int(rrMs[idx] + 0.5))"
                 if idx < srcCodes.count, let c = srcCodes[idx] { out += "@\(c)" }
+                // #1008: `ord` is the per-TIMESTAMP occurrence counter the store assigned when the row
+                // was written, so it restarts at 0 for every delivery. A second delivered ONCE therefore
+                // reads 0,1,2,…; a second built across two offloads reads 0,1,2,0,1 — the repeat is the
+                // tell. This is the only field that can answer it for a strap: WHOOP's wire format has
+                // no channel marker, so `srcChannel` is always nil on a WHOOP row.
+                if idx < ords.count, let o = ords[idx] { out += "#\(o)" }
             }
             if rows.count > shown { out += ",+\(rows.count - shown)" }
             out += "]"

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerSampleOrdTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerSampleOrdTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// #1008: `ord` is the per-TIMESTAMP occurrence counter assigned at write time, so it restarts at 0 for
+/// every delivery. That is what separates the two remaining explanations for a second carrying many beats.
+/// Kotlin twin: `HrvAnalyzerSampleOrdTest`.
+final class HRVAnalyzerSampleOrdTests: XCTestCase {
+
+    func testASecondDeliveredOnceReadsAsOneContiguousRun() {
+        // Four beats on one second, written by a single delivery: ord counts 0,1,2,3.
+        let out = HRVAnalyzer.densestSecondWindowSample(
+            tsSec: [100, 100, 100, 100], rrMs: [700, 750, 800, 850],
+            srcCodes: [nil, nil, nil, nil], ords: [0, 1, 2, 3])
+        XCTAssertTrue(out.contains("700#0"), out)
+        XCTAssertTrue(out.contains("850#3"), out)
+    }
+
+    func testASecondBuiltAcrossTwoDeliveriesRepeatsTheCounter() {
+        // The tell: ord restarts, so the same second shows 0,1 twice. No other stored field says this.
+        let out = HRVAnalyzer.densestSecondWindowSample(
+            tsSec: [100, 100, 100, 100], rrMs: [700, 750, 800, 850],
+            srcCodes: [nil, nil, nil, nil], ords: [0, 1, 0, 1])
+        XCTAssertTrue(out.contains("700#0"), out)
+        XCTAssertTrue(out.contains("800#0"), out)   // the repeat
+        XCTAssertTrue(out.contains("850#1"), out)
+    }
+
+    func testAbsentOrdsLeaveTheLineUnchanged() {
+        // Rows written before reads surfaced ord must not gain a stray marker.
+        let out = HRVAnalyzer.densestSecondWindowSample(
+            tsSec: [100, 100], rrMs: [700, 800], srcCodes: [nil, nil])
+        XCTAssertFalse(out.contains("#"), out)
+    }
+}

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
@@ -47,8 +47,18 @@ public struct RRInterval: Equatable, Codable {
     /// The sensor channel this beat came from, or nil when the source does not distinguish one (every
     /// WHOOP row, and every row written before the column existed). See `RRSourceChannel`.
     public let srcChannel: RRSourceChannel?
-    public init(ts: Int, rrMs: Int, srcChannel: RRSourceChannel? = nil) {
-        self.ts = ts; self.rrMs = rrMs; self.srcChannel = srcChannel
+    /// #1008 diagnostics: this beat's EMISSION ORDER within the batch that delivered it, as stored in
+    /// `rrInterval.ord`. nil on a decode (nothing has been stored yet) and on rows written before the
+    /// column was surfaced to reads.
+    ///
+    /// It is the one field that separates the two remaining explanations for a second carrying seven
+    /// beats: contiguous ords mean ONE record's array carried them all, so the over-count is in the
+    /// record's contents; repeated or non-monotonic ords mean SEPARATE deliveries each contributed to
+    /// that second, so the over-count is accumulation across offloads. WHOOP's wire format has no
+    /// channel field, so `srcChannel` can never answer this for a strap — `ord` is what is left.
+    public let ord: Int?
+    public init(ts: Int, rrMs: Int, srcChannel: RRSourceChannel? = nil, ord: Int? = nil) {
+        self.ts = ts; self.rrMs = rrMs; self.srcChannel = srcChannel; self.ord = ord
     }
 }
 

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -216,7 +216,7 @@ extension WhoopStore {
     public func rrIntervals(deviceId: String, from: Int, to: Int, limit: Int) async throws -> [RRInterval] {
         try syncRead { db in
             try Row.fetchAll(db, sql: """
-                SELECT ts, rrMs, srcChannel FROM rrInterval
+                SELECT ts, rrMs, srcChannel, ord FROM rrInterval
                 WHERE deviceId = ? AND ts >= ? AND ts <= ?
                 AND (srcChannel IS NULL OR srcChannel <> ?)
                 AND (tsSuspect IS NULL OR tsSuspect <> 1)   -- #1073: exclude future-stamped beats
@@ -224,7 +224,8 @@ extension WhoopStore {
                 """, arguments: [deviceId, from, to, RRSourceChannel.spo2Ibi.rawValue, limit])
                 .map { row in
                     RRInterval(ts: row["ts"], rrMs: row["rrMs"],
-                               srcChannel: (row["srcChannel"] as Int?).flatMap(RRSourceChannel.init(rawValue:)))
+                               srcChannel: (row["srcChannel"] as Int?).flatMap(RRSourceChannel.init(rawValue:)),
+                               ord: row["ord"] as Int?)
                 }
         }
     }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/ReadTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/ReadTests.swift
@@ -86,7 +86,12 @@ final class ReadTests: XCTestCase {
     func testRrIntervalsReturnsBothTiedRows() async throws {
         let store = try await seeded()
         let rr = try await store.rrIntervals(deviceId: "dev1", from: 0, to: 1000, limit: 100)
-        XCTAssertEqual(rr, [RRInterval(ts: 100, rrMs: 800), RRInterval(ts: 100, rrMs: 820)])
+        // #1008: `ord` is the per-TIMESTAMP occurrence counter assigned at write time, so two beats
+        // stamped on the same second read back as 0 then 1. Asserting it here rather than dropping to a
+        // field projection pins the property the `hrv rrsample` diagnostic depends on — one delivery
+        // counts 0,1,2,…, whereas a second rebuilt across two offloads repeats (0,1,0,1).
+        XCTAssertEqual(rr, [RRInterval(ts: 100, rrMs: 800, ord: 0),
+                            RRInterval(ts: 100, rrMs: 820, ord: 1)])
     }
 
     // MARK: - hrWindowStats (#836)

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1080,7 +1080,8 @@ final class IntelligenceEngine: ObservableObject {
                     // srcChannel rides from the read model. Byte-identical to the Kotlin `hrv rrsample` line.
                     if verdict == .crossSecondOverCount || verdict == .sameSecondOverCount {
                         let sample = HRVAnalyzer.densestSecondWindowSample(
-                            tsSec: ts, rrMs: sleepRr, srcCodes: sleepRrRows.map { $0.srcChannel?.rawValue })
+                            tsSec: ts, rrMs: sleepRr, srcCodes: sleepRrRows.map { $0.srcChannel?.rawValue },
+                            ords: sleepRrRows.map { $0.ord })
                         if !sample.isEmpty { diagLine += "\nhrv rrsample day=\(res.daily.day) \(sample)" }
                         // #1331/#1008/#1118 SHADOW: log the DEDUPED stream's HRV + coverage + beat-accuracy
                         // beside the raw (above), so the candidate two-channel de-dup can be validated

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -604,6 +604,7 @@ object HrvAnalyzer {
         tsSec: List<Long>,
         rrMs: List<Double>,
         srcCodes: List<Int?>,
+        ords: List<Int?> = emptyList(),
         halfWindowSec: Int = 3,
         maxRowsPerSecond: Int = 24,
     ): String {
@@ -648,6 +649,12 @@ object HrvAnalyzer {
                 val idx = rows[k]
                 sb.append((rrMs[idx] + 0.5).toLong())
                 srcCodes.getOrNull(idx)?.let { sb.append('@').append(it) }
+                // #1008: `ord` is the per-TIMESTAMP occurrence counter the store assigned when the row was
+                // written, so it restarts at 0 for every delivery. A second delivered ONCE reads 0,1,2,...;
+                // a second built across two offloads reads 0,1,2,0,1 - the repeat is the tell. It is the
+                // only field that can answer this for a strap: WHOOP's wire format has no channel marker,
+                // so srcChannel is always null on a WHOOP row.
+                ords.getOrNull(idx)?.let { sb.append('#').append(it) }
             }
             if (rows.size > shown) sb.append(",+").append(rows.size - shown)
             sb.append(']')

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -878,6 +878,7 @@ object IntelligenceEngine {
                     verdict == HrvAnalyzer.RrCoverageVerdict.SAME_SECOND_OVER_COUNT) {
                     val sample = HrvAnalyzer.densestSecondWindowSample(
                         ts, sleepRr, sleepRrRows.map { it.srcChannel },
+                        sleepRrRows.map { it.ord },
                     )
                     if (sample.isNotEmpty()) dayDiag("hrv rrsample day=${res.daily.day} $sample")
                     // #1331/#1008/#1118 SHADOW: log the DEDUPED stream's HRV + coverage + beat-accuracy

--- a/android/app/src/test/java/com/noop/analytics/HrvAnalyzerSampleOrdTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvAnalyzerSampleOrdTest.kt
@@ -1,0 +1,46 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1008: `ord` is the per-TIMESTAMP occurrence counter assigned at write time, so it restarts at 0 for
+ * every delivery. That is what separates the two remaining explanations for a second carrying many beats.
+ * Twin of Swift `HRVAnalyzerSampleOrdTests`.
+ */
+class HrvAnalyzerSampleOrdTest {
+
+    @Test
+    fun aSecondDeliveredOnceReadsAsOneContiguousRun() {
+        // Four beats on one second, written by a single delivery: ord counts 0,1,2,3.
+        val ts = listOf(100L, 100L, 100L, 100L)
+        val rr = listOf(700.0, 750.0, 800.0, 850.0)
+        val out = HrvAnalyzer.densestSecondWindowSample(
+            ts, rr, srcCodes = listOf(null, null, null, null), ords = listOf(0, 1, 2, 3),
+        )
+        assertTrue(out, out.contains("700#0"))
+        assertTrue(out, out.contains("850#3"))
+    }
+
+    @Test
+    fun aSecondBuiltAcrossTwoDeliveriesRepeatsTheCounter() {
+        // The tell: ord restarts, so the same second shows 0,1 twice. No other stored field says this.
+        val ts = listOf(100L, 100L, 100L, 100L)
+        val rr = listOf(700.0, 750.0, 800.0, 850.0)
+        val out = HrvAnalyzer.densestSecondWindowSample(
+            ts, rr, srcCodes = listOf(null, null, null, null), ords = listOf(0, 1, 0, 1),
+        )
+        assertTrue(out, out.contains("700#0"))
+        assertTrue(out, out.contains("800#0"))   // the repeat
+        assertTrue(out, out.contains("850#1"))
+    }
+
+    @Test
+    fun absentOrdsLeaveTheLineUnchanged() {
+        // Rows written before reads surfaced ord must not gain a stray marker.
+        val ts = listOf(100L, 100L)
+        val rr = listOf(700.0, 800.0)
+        val out = HrvAnalyzer.densestSecondWindowSample(ts, rr, srcCodes = listOf(null, null))
+        assertTrue(out, !out.contains("#"))
+    }
+}


### PR DESCRIPTION
Tonight's 4.0 capture on 344/226 measured the emission for the first time and split #1008 cleanly:

| | measured |
|---|---|
| decoder offered | 504 intervals over 429 reporting seconds = **1.17/s**, `ratioRep` **1.03** against a 1 s cadence |
| storage key absorbed | **3** rows (`offered 504 → inserted 501`) |
| stored nights, same log | `coverage` **1.68 – 1.78**, **2.10 – 2.25 beats/second** |

So neither the decode nor the ingest key is creating the over-count on this build. **It is already in the
rows.**

## What is still unknown, and why no existing field answers it

`hrv rrsample`'s densest second shows seven **distinct** values (`742,773,784,792,796,797,828`). That rules
out verbatim duplicates and little else.

And `src=none` on every night is **not a gap to close**: `RRSourceChannel` models Oura event families
(0x80 / 0x6E / 0x60), and WHOOP's wire format carries no channel marker at all — so `srcChannel` is
structurally always nil for a strap. Worth stating so nobody else chases it.

## `ord` can answer it

The store assigns `ord` as the **per-timestamp occurrence counter** at write time, so it restarts at 0 for
every delivery:

- a second delivered **once** reads `0,1,2,…`
- a second built across **two offloads** reads `0,1,2,0,1` — and that repeat is the discriminator

That separates *"one record carried seven beats"* (over-count is in the record's contents) from *"seven
deliveries each contributed to this second"* (over-count is accumulation across offloads). The column has
been stored since v32 and is already used in `ORDER BY`; it was simply never surfaced to a read.

## The part I like most

**It interrogates rows that already exist.** The 07-30 / 08-17 / 08-18 / 08-19 nights answer it on the next
analyze pass — no further capture, no waiting on hardware.

## Platform note

Swift needed `ord` threaded through `RRInterval` and the read, defaulted exactly as `srcChannel` was added
so every construction site compiles unchanged. **Kotlin needed neither** — its engine reads the Room
entity, which already carries the column. A layering difference, not a drift; I reverted an unnecessary
edit to Kotlin's protocol type once I found that.

## Verification

- Mirrored vectors: single-delivery run, repeated-counter case, and that rows without an `ord` gain no
  stray marker
- Android **4,088 tests / 0 failures**; Kotlin compile, i18n, doc-comment gates clean
- app-build dispatched for the app-target Swift call site
- Instrumentation only — nothing in the shipped path reads `ord`