### PR TITLE
Align Kotlin Rest sleep-need floor with Swift

### DIFF
--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyticsEngineSleepNeedFloorTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyticsEngineSleepNeedFloorTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import StrandAnalytics
+import WhoopProtocol
+import WhoopStore
+
+/// Public `analyzeDay` contract for degenerate sleep-need inputs. The mirrored Android test uses the
+/// same provided 30-second light-sleep session and asserts the same rounded Rest projection.
+final class AnalyticsEngineSleepNeedFloorTests: XCTestCase {
+    private let profile = UserProfile(weightKg: 75, heightCm: 178, age: 30, sex: "male")
+    private let day = "2025-06-10"
+    private let sessionStart = 1_749_517_200
+
+    private func rest(sleepNeedHours: Double) throws -> Double {
+        let provided = SleepSession(
+            start: sessionStart,
+            end: sessionStart + 30,
+            efficiency: 1,
+            stages: [StageSegment(start: sessionStart, end: sessionStart + 30, stage: "light")],
+            restingHR: nil,
+            avgHRV: nil)
+
+        return try XCTUnwrap(AnalyticsEngine.analyzeDay(
+            day: day,
+            profile: profile,
+            sleepNeedHours: sleepNeedHours,
+            providedSleep: [provided]
+        ).restScore)
+    }
+
+    func testSleepNeedUsesPointOneHourFloorAtAndAcrossBoundary() throws {
+        let cases: [(need: Double, expectedRest: Double)] = [
+            (-1.0, 29.17),
+            (0.0, 29.17),
+            (0.099, 29.17),
+            (0.1, 29.17),
+            (0.101, 29.13),
+        ]
+
+        let actual = try cases.map { try rest(sleepNeedHours: $0.need) }
+        XCTAssertEqual(actual, cases.map(\.expectedRest))
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -1281,7 +1281,8 @@ object RestScorer {
         if (asleepSeconds <= 0.0) return null
 
         val asleepHours = asleepSeconds / 3600.0
-        val needHours = (sleepNeedHours ?: defaultSleepNeedHours).coerceAtLeast(1e-9)
+        // Parity: Swift Rest.composite and Kotlin's own subScoreLine both floor need at 0.1 h (not 1e-9).
+        val needHours = (sleepNeedHours ?: defaultSleepNeedHours).coerceAtLeast(0.1)
 
         // Duration vs personal need (clamped at 100 — sleeping past need does not over-credit).
         val durationScore = min(100.0, asleepHours / needHours * 100.0)

--- a/android/app/src/test/java/com/noop/analytics/AnalyticsEngineSleepNeedFloorTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/AnalyticsEngineSleepNeedFloorTest.kt
@@ -1,0 +1,48 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+/**
+ * Public [AnalyticsEngine.analyzeDay] contract for degenerate sleep-need inputs. The Swift twin uses
+ * the same provided 30-second light-sleep session and asserts the same rounded Rest projection.
+ */
+class AnalyticsEngineSleepNeedFloorTest {
+    private val profile = UserProfile(weightKg = 75.0, heightCm = 178.0, age = 30.0, sex = "male")
+    private val day = "2025-06-10"
+    private val sessionStart = 1_749_517_200L
+
+    private fun rest(sleepNeedHours: Double): Double {
+        val provided = DetectedSleep(
+            start = sessionStart,
+            end = sessionStart + 30L,
+            efficiency = 1.0,
+            stages = listOf(StageSegment(sessionStart, sessionStart + 30L, "light")),
+            restingHR = null,
+            avgHRV = null,
+        )
+
+        val result = AnalyticsEngine.analyzeDay(
+            day = day,
+            profile = profile,
+            sleepNeedHours = sleepNeedHours,
+            providedSleep = listOf(provided),
+        ).rest
+        assertNotNull(result)
+        return result!!
+    }
+
+    @Test
+    fun sleepNeedUsesPointOneHourFloorAtAndAcrossBoundary() {
+        val cases = listOf(
+            -1.0 to 29.17,
+            0.0 to 29.17,
+            0.099 to 29.17,
+            0.1 to 29.17,
+            0.101 to 29.13,
+        )
+
+        assertEquals(cases.map { it.second }, cases.map { rest(it.first) })
+    }
+}


### PR DESCRIPTION
## Summary

- use the same 0.1-hour minimum sleep need in Kotlin Rest scoring that Swift and Kotlin trace scoring already use
- add mirrored Swift/Kotlin public `AnalyticsEngine.analyzeDay` boundary tests for negative, zero, 0.099, 0.1, and 0.101 hours
- preserve normal positive sleep-need behavior

## Provenance

This ports the exact Rest need-floor hunk already authored by @ryanbr in [maintainer commit `1c96c654`](https://github.com/ryanbr/noop/commit/1c96c65475d2b0a14b1d20ab91d4e880d0be1ee0). The cross-platform drift was independently reproduced and tracked in [bhelm/noop#75](https://github.com/bhelm/noop/issues/75).

## Red-to-green evidence

Before the production change, the mirrored expected Rest vector was:

`[29.17, 29.17, 29.17, 29.17, 29.13]`

Swift matched it. Kotlin returned:

`[75.0, 75.0, 29.21, 29.17, 29.13]`

After changing only `coerceAtLeast(1e-9)` to `coerceAtLeast(0.1)`, both focused tests pass.

## Verification

- Swift focused: 1 test / 5 cases, 0 failures
- Android focused: 1 test / 5 cases, 0 failures
- Swift full `StrandAnalytics`: 1,491 tests, 1 expected Linux skip, 0 failures
- Android `testFullDebugUnitTest`: 4,086 tests, 6 skips, 0 failures/errors
- independent delta review: no P0/P1/P2 findings
