### PR TITLE
fix(analytics): omit Rest for wake-only sessions

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -78,7 +78,7 @@ public enum AnalyticsEngine {
         public let skinTempRelative: SkinTempRelative?
         /// Day strain / "Effort" [0,100] or nil (insufficient HR samples / invalid HRR).
         public let strain: Double?
-        /// Rest composite [0,100] or nil (no in-bed data). This is the value the
+        /// Rest composite [0,100] or nil (no asleep time). This is the value the
         /// `sleep_performance` metric key carries (duration-vs-need 0.50 + efficiency
         /// 0.20 + restorative share 0.20 + consistency 0.10). The downstream metric-series
         /// builder reads it from here; the Charge "Rest quality" term reads it ÷100.
@@ -555,10 +555,10 @@ public enum AnalyticsEngine {
         // ── Rest composite (Charge/Effort/Rest) ───────────────────────────────
         // The 0–100 sleep score the `sleep_performance` metric key now carries:
         //   duration-vs-personal-need 0.50 + efficiency 0.20 + restorative share 0.20
-        //   + consistency 0.10. nil when there is no in-bed data. The Charge "Rest
+        //   + consistency 0.10. nil when there is no asleep time. The Charge "Rest
         //   quality" term reads it ÷100 (replacing raw efficiency).
         let hasStagedSleep = (deepS + remS) > 0
-        let restScore: Double? = matched.isEmpty ? nil : Rest.composite(
+        let restScore: Double? = tstS <= 0 ? nil : Rest.composite(
             tstSeconds: tstS,
             inBedSeconds: inBedS,
             efficiency: efficiency,

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyticsEngineProvidedSleepTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyticsEngineProvidedSleepTests.swift
@@ -88,4 +88,67 @@ final class AnalyticsEngineProvidedSleepTests: XCTestCase {
         XCTAssertEqual(res.daily.restingHr, 48)
         XCTAssertEqual(res.daily.avgHrv ?? 0, 65, accuracy: 0.001)
     }
+
+    /// Keep the public analyzeDay seam fully named and mirrored by the Kotlin twin.
+    private func analyzeProvided(day: String, provided: [SleepSession]) -> AnalyticsEngine.DayResult {
+        AnalyticsEngine.analyzeDay(
+            day: day,
+            hr: [],
+            rr: [],
+            resp: [],
+            vendorResp: [],
+            gravity: [],
+            steps: [],
+            dayHr: nil,
+            daySteps: nil,
+            dayGravity: nil,
+            skinTemp: [],
+            skinTempFamily: .whoop5,
+            skinTempAnchorRaw: nil,
+            spo2: [],
+            profile: profile,
+            baselines: AnalyticsEngine.ProfileBaselines(),
+            maxHROverride: nil,
+            tzOffsetSeconds: 0,
+            wristOff: [],
+            sleepNeedHours: AnalyticsEngine.Rest.defaultNeedHours,
+            sleepConsistency: nil,
+            habitualMidsleepSec: nil,
+            bandSleepState: [],
+            useSleepStagerV2: false,
+            useMotionAwareWake: false,
+            providedSleep: provided,
+            sleepProvenance: .measured,
+            traceSink: nil,
+            hrvTraceSink: nil,
+            hrvWindowDetail: false,
+            deepHrvWindow: false)
+    }
+
+    /// bhelm/noop#74: a real in-bed session whose hypnogram is entirely wake has no TST,
+    /// so it must not manufacture a Rest score.
+    func testWakeOnlyProvidedSessionHasNoRestScore() {
+        let day = "2025-06-10"
+        let start = AnalyticsEngine.dayStartUtcSeconds(day) + 3600
+        let end = start + 1800
+        let provided = [SleepSession(
+            start: start, end: end, efficiency: 0,
+            stages: [StageSegment(start: start, end: end, stage: "wake")],
+            restingHR: nil, avgHRV: nil)]
+
+        XCTAssertNil(analyzeProvided(day: day, provided: provided).restScore)
+    }
+
+    /// Positive boundary: staged sleep does not require deep or REM to earn a Rest score.
+    func testLightOnlyProvidedSessionHasRestScore() {
+        let day = "2025-06-10"
+        let start = AnalyticsEngine.dayStartUtcSeconds(day) + 3600
+        let end = start + 1800
+        let provided = [SleepSession(
+            start: start, end: end, efficiency: 1,
+            stages: [StageSegment(start: start, end: end, stage: "light")],
+            restingHR: nil, avgHRV: nil)]
+
+        XCTAssertNotNil(analyzeProvided(day: day, provided: provided).restScore)
+    }
 }

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -633,7 +633,7 @@ object AnalyticsEngine {
         // ── Rest (sleep_performance composite, 0–100) ─────────────────────────
         // Replaces the bare efficiency proxy: duration-vs-personal-need 0.50 + efficiency 0.20 +
         // restorative (deep+REM)/asleep 0.20 + consistency 0.10. Stored under the sleep_performance
-        // key. null when no in-bed session. (Charge/Effort/Rest)
+        // key. null when there is no asleep time. (Charge/Effort/Rest)
         val rest: Double? = if (matched.isEmpty()) null else RestScorer.rest(
             asleepSeconds = tstS,
             efficiency = efficiency,

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsModels.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsModels.kt
@@ -254,7 +254,7 @@ data class DayResult(
     /** Effort (strain) score [0,100] or null (insufficient HR samples / invalid HRR). */
     val strain: Double?,
     /**
-     * Rest (sleep_performance) composite [0,100] or null (no in-bed session). The persistence /
+     * Rest (sleep_performance) composite [0,100] or null (no asleep time). The persistence /
      * series layer stores this under the `sleep_performance` key. Replaces the bare efficiency
      * proxy (duration-vs-need 0.50 + efficiency 0.20 + restorative 0.20 + consistency 0.10).
      */

--- a/android/app/src/test/java/com/noop/analytics/AnalyticsEngineProvidedSleepTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/AnalyticsEngineProvidedSleepTest.kt
@@ -2,6 +2,7 @@ package com.noop.analytics
 
 import com.noop.data.HrSample
 import com.noop.data.RrInterval
+import com.noop.protocol.DeviceFamily
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -90,5 +91,81 @@ class AnalyticsEngineProvidedSleepTest {
             providedSleep = provided)
         assertEquals(48, res.daily.restingHr)
         assertEquals(65.0, res.daily.avgHrv!!, 0.001)
+    }
+
+    /** Keep the public analyzeDay seam fully named and mirrored by the Swift twin. */
+    private fun analyzeProvided(fixtureDay: String, provided: List<DetectedSleep>): DayResult =
+        AnalyticsEngine.analyzeDay(
+            day = fixtureDay,
+            hr = emptyList(),
+            rr = emptyList(),
+            resp = emptyList(),
+            vendorResp = emptyList(),
+            gravity = emptyList(),
+            steps = emptyList(),
+            dayHr = null,
+            daySteps = null,
+            dayGravity = null,
+            skinTemp = emptyList(),
+            skinTempFamily = DeviceFamily.WHOOP5,
+            skinTempAnchorRaw = null,
+            spo2 = emptyList(),
+            profile = profile,
+            baselines = ProfileBaselines(),
+            maxHROverride = null,
+            tzOffsetSeconds = 0,
+            wristOff = emptyList(),
+            sleepNeedHours = RestScorer.defaultSleepNeedHours,
+            sleepNeedNights = 0,
+            sleepConsistency = null,
+            habitualMidsleepSec = null,
+            bandSleepState = emptyList(),
+            useSleepStagerV2 = false,
+            useMotionAwareWake = false,
+            providedSleep = provided,
+            traceSink = null,
+            hrvTraceSink = null,
+            hrvWindowDetail = false,
+            deepHrvWindow = false,
+        )
+
+    /** bhelm/noop#74: an all-wake provided session has no TST and therefore no Rest score. */
+    @Test
+    fun wakeOnlyProvidedSessionHasNoRestScore() {
+        val fixtureDay = "2025-06-10"
+        val start = LocalDate.parse(fixtureDay).atStartOfDay(ZoneOffset.UTC).toEpochSecond() + 3600
+        val end = start + 1800
+        val provided = listOf(
+            DetectedSleep(
+                start = start,
+                end = end,
+                efficiency = 0.0,
+                stages = listOf(StageSegment(start, end, "wake")),
+                restingHR = null,
+                avgHRV = null,
+            ),
+        )
+
+        assertNull(analyzeProvided(fixtureDay, provided).rest)
+    }
+
+    /** Positive boundary: staged sleep does not require deep or REM to earn a Rest score. */
+    @Test
+    fun lightOnlyProvidedSessionHasRestScore() {
+        val fixtureDay = "2025-06-10"
+        val start = LocalDate.parse(fixtureDay).atStartOfDay(ZoneOffset.UTC).toEpochSecond() + 3600
+        val end = start + 1800
+        val provided = listOf(
+            DetectedSleep(
+                start = start,
+                end = end,
+                efficiency = 1.0,
+                stages = listOf(StageSegment(start, end, "light")),
+                restingHR = null,
+                avgHRV = null,
+            ),
+        )
+
+        assertNotNull(analyzeProvided(fixtureDay, provided).rest)
     }
 }


### PR DESCRIPTION
## Summary

- return no Swift Rest score when a matched provided session has zero total sleep
- add mirrored, fully named public `AnalyticsEngine.analyzeDay` regression tests for wake-only and light-only sessions
- preserve a Rest score for positive all-light sleep, even without deep or REM

Tracks the confirmed fork parity report: https://github.com/bhelm/noop/issues/74

## Red before fix

The focused Swift public-API regression failed on the unchanged base with:

```
XCTAssertNil failed: "5.0"
```

The mirrored Kotlin test was already green and returned `null`.

## Green after fix

- Swift focused provided-sleep suite: 5 tests, 0 failures
- Kotlin focused provided-sleep suite: `BUILD SUCCESSFUL`
- Swift full StrandAnalytics suite before the test/comment-only review amendment: 1,491 tests, 1 expected Linux skip, 0 failures
- Android full FullDebug unit suite before the test/comment-only review amendment: `BUILD SUCCESSFUL`, 28/28 tasks executed
- post-amendment focused Swift and Kotlin suites both green

The positive all-light fixture kills a `hasStagedSleep ? composite : nil` mutant: it has 1,800 seconds of TST but zero deep and REM.

## Scope

This PR intentionally fixes only the public Rest output drift. A pre-existing diagnostic trace difference for a wake-only session remains separate and out of scope; it is not mixed into this production fix.