### PR TITLE
fix(coupled): carry through the shared selector on BOTH platforms, so the hero and its sheet agree (#1458)

### DIFF
--- a/Strand/Screens/CoupledView.swift
+++ b/Strand/Screens/CoupledView.swift
@@ -68,8 +68,19 @@ struct CoupledView: View {
 
     /// The last strictly-prior scored recovery day, so a just-rolled-over morning carries yesterday's read
     /// rather than blanking, exactly the anchor Today uses for readiness (#543).
+    ///
+    /// #1458: through the SAME selector Today uses, not a local re-derivation. This read
+    /// `repo.days.last(where: { $0.recovery != nil && $0.day < todayKey })`, which has no `todayScored`
+    /// guard — so on a day that HAS a score it still returned a prior day, and the hero's Charge sheet
+    /// opened that older night while the card beside it showed today's number. It also skipped the
+    /// calibrating gate, so a cold-start install could carry a value Today refuses. Reported on Android,
+    /// but the defect was identical here: the twins agreed with each other and were both wrong.
     private var carriedRecoveryDay: DailyMetric? {
-        repo.days.last(where: { $0.recovery != nil && $0.day < todayKey })
+        TodayView.lastScoredRecoveryDay(
+            days: repo.days, selectedDayKey: todayKey,
+            isToday: true,   // the Coupled view has no day selector; it is always today
+            todayScored: day?.recovery != nil,
+            isCalibrating: calibrationNights != nil)
     }
 
     /// The recovery value the ring shows: today's if scored, else the carried prior day's (never fabricated).

--- a/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
@@ -151,8 +151,25 @@ fun CoupledScreen(
                 .toString() == todayKey
         }
     }
-    val carriedRecoveryDay = remember(days, todayKey) {
-        days.lastOrNull { it.recovery != null && it.day < todayKey }
+    val context = LocalContext.current
+    val hrvEpoch = remember { NoopPrefs.of(context).getLong(Baselines.hrvBaselineEpochKey, 0L).toDouble() }
+    // #1458: carry through the SAME helper Today uses, not a local re-derivation. The local copy was
+    // `days.lastOrNull { it.recovery != null && it.day < todayKey }`, which has no `todayScored` guard —
+    // so on a day that HAS a score it still returned a prior day, and the hero's Charge sheet opened that
+    // older night while the card beside it showed today's number. It also missed the #547 upper bound
+    // (a future-dated row from a bad strap clock is how that bug read "12 Jul") and the calibrating gate.
+    // One helper, one answer: the card and its own detail sheet cannot disagree again.
+    val carriedRecoveryDay = remember(days, todayKey, todayRow, hrvEpoch, logicalKey, localKey) {
+        lastScoredRecoveryDay(
+            days = days,
+            selectedDayKey = todayKey,
+            isToday = true,   // the Coupled view has no day selector; it is always today
+            todayScored = todayRow?.recovery != null,
+            isCalibrating = recoveryCalibrationNights(
+                days, hasRecovery = todayRow?.recovery != null, hrvBaselineEpoch = hrvEpoch,
+            ) != null,
+            today = maxOf(logicalKey, localKey),
+        )
     }
     val recovery = todayRow?.recovery ?: carriedRecoveryDay?.recovery
     val isCarrying = todayRow?.recovery == null && carriedRecoveryDay?.recovery != null
@@ -178,8 +195,6 @@ fun CoupledScreen(
     // Recovery cold-start nights (the SAME pure helper Today's ring reads), for the honest calibrating
     // caption + accessibility copy while the HRV baseline still seeds. Threads the persisted
     // "Recalibrate HRV baseline" epoch so N folds the SAME epoch-aware history the engine folds (Bug B).
-    val context = LocalContext.current
-    val hrvEpoch = remember { NoopPrefs.of(context).getLong(Baselines.hrvBaselineEpochKey, 0L).toDouble() }
     val calibrationNights = remember(days, todayRow, hrvEpoch) {
         recoveryCalibrationNights(days, hasRecovery = todayRow?.recovery != null, hrvBaselineEpoch = hrvEpoch)
     }


### PR DESCRIPTION
Fixes #1458, reported by @bartmuskala.

## It is not two different screens

Both taps open the **same** Charge breakdown. The screenshots show different **days**:

| from | header | HRV | sleep |
|---|---|---|---|
| Today | `CHARGE` (no date) | 39 ms, **-32 pts** | 7h36m |
| Coupled | `CHARGE · LAST NIGHT · 18 AUG` | 61 ms, **0 pts** | 7h39m |

The sheet was right — it dates a carried day and leaves today undated. And the Coupled *card* itself shows 7h36m, matching the **Today** sheet, so the Coupled screen disagreed with its own detail view.

## Cause — and it was on BOTH platforms

Each Coupled view re-derived the carry locally:

```kotlin
days.lastOrNull { it.recovery != null && it.day < todayKey }        // Kotlin
```
```swift
repo.days.last(where: { $0.recovery != nil && $0.day < todayKey })  // Swift — identical
```

No `todayScored` guard, so on a day that **has** a score it still returned a prior day. Also missing the calibrating gate, and on Kotlin the **#547** upper bound (a future-dated row from a bad strap clock is exactly how that bug made a header read "12 Jul").

**I initially claimed this was Android-only with no iOS twin. That was wrong** — `Strand/Screens/CoupledView.swift` exists and carried the same defect. It's a shared bug, not a platform drift: reported on Android only because that's the reporter's platform.

## The tell both files already contained

Each carries a comment from #787 stating the carried anchor is *"gated on `isCarrying` (**Today's `!todayScored` gate**)"*. #787 fixed the readiness pill by gating downstream; the Charge sheet read `carriedDay` directly and stayed broken. The comment described an assumption the value never satisfied — on both platforms, identically.

## Fix

Route both through the shared selector Today already uses, whose guard **is** the fix:

```
guard isToday, !todayScored, !isCalibrating else { return nil }
```

Minimal: one call site per platform. Both views already had every input.

## On tests

**No new test, deliberately.** The rule is already pinned by `lastScoredRecoveryDay_nothingCarried_whenTodayIsAlreadyScored`. What was missing was not coverage of the rule but *a caller that used it* — and a Compose/SwiftUI screen reading a value is not reachable from a unit test. That is precisely why re-deriving it locally was the risk, and why routing through the shared helper is the durable fix rather than a second copy of the assertions.

## Verification

- Android **4,091 tests / 0 failures**; Kotlin compile, i18n, doc-comment gates clean
- app-build dispatched — `CoupledView.swift` is app-target Swift that no default CI compiles
- Not device-tested: pure UI state selection, no BLE path

## One question for the reporter

@bartmuskala reports version **10.1.2**, which does not exist (10.1.0 is released, 10.1.1 is staging) — worth confirming which build, since it affects whether this reproduces on current main.