### PR TITLE
Fix Rest trace when analyzeDay has no Rest score

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -574,11 +574,13 @@ public enum AnalyticsEngine {
         // `subScoreLine` itself reuses `Rest.composite` for the final value. Side-effect-only; emitted
         // only when a trace is requested and this day actually scored a night.
         if let traceSink, !matched.isEmpty {
-            traceSink(Rest.subScoreLine(
-                tstSeconds: tstS, inBedSeconds: inBedS, efficiency: efficiency,
-                restorativeSeconds: deepS + remS, needHours: sleepNeedHours,
-                consistency: sleepConsistency, deepSeconds: deepS,
-                groupFragments: mainGroup.count, groupInBedSeconds: inBedS))
+            if restScore != nil {
+                traceSink(Rest.subScoreLine(
+                    tstSeconds: tstS, inBedSeconds: inBedS, efficiency: efficiency,
+                    restorativeSeconds: deepS + remS, needHours: sleepNeedHours,
+                    consistency: sleepConsistency, deepSeconds: deepS,
+                    groupFragments: mainGroup.count, groupInBedSeconds: inBedS))
+            }
             // #319: the motion-coverage + staging context behind the Rest number, so a high score on a poor
             // night can be explained from an export (WHOOP 4.0 banks motion coarsely → sparse=true → most
             // epochs default to sleep → over-counted duration → high Rest). `stager` says whether V1/V2 ran.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyticsEngineRestTraceContractTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyticsEngineRestTraceContractTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import StrandAnalytics
+
+final class AnalyticsEngineRestTraceContractTests: XCTestCase {
+    private let day = "2025-06-10"
+
+    private func analyze(stage: String, efficiency: Double) -> (AnalyticsEngine.DayResult, [String]) {
+        let start = AnalyticsEngine.dayStartUtcSeconds(day) + 3_600
+        let end = start + 1_800
+        let provided = SleepSession(
+            start: start,
+            end: end,
+            efficiency: efficiency,
+            stages: [StageSegment(start: start, end: end, stage: stage)],
+            restingHR: nil,
+            avgHRV: nil
+        )
+        var lines: [String] = []
+        let result = AnalyticsEngine.analyzeDay(
+            day: day,
+            profile: UserProfile(),
+            providedSleep: [provided],
+            traceSink: { lines.append($0) }
+        )
+        return (result, lines)
+    }
+
+    func testWakeOnlySessionOmitsRestScoreAndRestTrace() {
+        let result = analyze(stage: "wake", efficiency: 0.0)
+        XCTAssertNil(result.0.restScore)
+        XCTAssertEqual(result.1.filter { $0.hasPrefix("rest ") }, [])
+        XCTAssertTrue(result.1.contains(
+            "sleep-motion day=2025-06-10 grav=0 hr=0 sparse=false stager=V1 family=whoop5"
+        ), "non-Rest diagnostics must remain available when Rest is absent")
+    }
+
+    func testPositiveSleepKeepsExactRestTrace() {
+        let result = analyze(stage: "light", efficiency: 1.0)
+        XCTAssertEqual(result.0.restScore, 28.13)
+        XCTAssertEqual(result.1.filter { $0.hasPrefix("rest ") }, [
+            "rest composite=28.13 dur=0.06*wDur=0.5 eff=1.0*wEff=0.2 "
+                + "restor=0.0*wRestor=0.2 deepFactor=0.5 consist=0.5*wConsist=0.1 "
+                + "group=1 groupInBedMin=30",
+        ])
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -649,12 +649,14 @@ object AnalyticsEngine {
         // IDENTICAL inputs `rest` consumed above so the trace can never disagree with the score. Emitted
         // only when a trace is requested and this day scored a night. Mirrors Swift.
         if (traceSink != null && matched.isNotEmpty()) {
-            traceSink(RestScorer.subScoreLine(
-                tstSeconds = tstS, inBedSeconds = inBedS, efficiency = efficiency,
-                restorativeSeconds = deepS + remS,
-                needHours = sleepNeedHours ?: RestScorer.defaultSleepNeedHours,
-                consistency = sleepConsistency, deepSeconds = deepS,
-                groupFragments = mainGroup.size, groupInBedSeconds = inBedS))
+            if (rest != null) {
+                traceSink(RestScorer.subScoreLine(
+                    tstSeconds = tstS, inBedSeconds = inBedS, efficiency = efficiency,
+                    restorativeSeconds = deepS + remS,
+                    needHours = sleepNeedHours ?: RestScorer.defaultSleepNeedHours,
+                    consistency = sleepConsistency, deepSeconds = deepS,
+                    groupFragments = mainGroup.size, groupInBedSeconds = inBedS))
+            }
             // #319: the motion-coverage + staging context behind the Rest number, so a high score on a poor
             // night can be explained from an export — WHOOP 4.0 banks motion coarsely (sparse=true), so most
             // epochs default to sleep → over-counted duration → high Rest; `stager` says whether V1/V2 ran.

--- a/android/app/src/test/java/com/noop/analytics/AnalyticsEngineRestTraceContractTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/AnalyticsEngineRestTraceContractTest.kt
@@ -1,0 +1,60 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+class AnalyticsEngineRestTraceContractTest {
+    private val day = "2025-06-10"
+
+    private fun analyze(stage: String, efficiency: Double): Pair<DayResult, List<String>> {
+        val start = LocalDate.parse(day).atStartOfDay(ZoneOffset.UTC).toEpochSecond() + 3_600
+        val end = start + 1_800
+        val provided = DetectedSleep(
+            start = start,
+            end = end,
+            efficiency = efficiency,
+            stages = listOf(StageSegment(start, end, stage)),
+            restingHR = null,
+            avgHRV = null,
+        )
+        val lines = mutableListOf<String>()
+        val result = AnalyticsEngine.analyzeDay(
+            day = day,
+            profile = UserProfile(),
+            providedSleep = listOf(provided),
+            traceSink = { lines.add(it) },
+        )
+        return result to lines
+    }
+
+    @Test
+    fun wakeOnlySessionOmitsRestScoreAndRestTrace() {
+        val result = analyze(stage = "wake", efficiency = 0.0)
+        assertNull(result.first.rest)
+        assertEquals(emptyList<String>(), result.second.filter { it.startsWith("rest ") })
+        assertTrue(
+            "non-Rest diagnostics must remain available when Rest is absent",
+            result.second.contains(
+                "sleep-motion day=2025-06-10 grav=0 hr=0 sparse=false stager=V1 family=whoop5",
+            ),
+        )
+    }
+
+    @Test
+    fun positiveSleepKeepsExactRestTrace() {
+        val result = analyze(stage = "light", efficiency = 1.0)
+        assertEquals(28.13, result.first.rest!!, 0.0)
+        assertEquals(
+            listOf(
+                "rest composite=28.13 dur=0.06*wDur=0.5 eff=1.0*wEff=0.2 " +
+                    "restor=0.0*wRestor=0.2 deepFactor=0.5 consist=0.5*wConsist=0.1 " +
+                    "group=1 groupInBedMin=30",
+            ),
+            result.second.filter { it.startsWith("rest ") },
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- emit the `rest ` diagnostic line only when the actual `analyzeDay` Rest result exists
- preserve the surrounding sleep-motion/provenance/onset diagnostics for matched wake-only sessions
- add mirrored public named-argument Swift/Kotlin contract tests with a positive Light-sleep control

Closes the confirmed fork finding [bhelm/noop#76](https://github.com/bhelm/noop/issues/76). This is the deliberately separate pre-existing trace scope noted by #1461.

## Red evidence

Two independent native probe implementations reproduced the pre-fix drift:

- Swift wake-only: Rest `5.0`, trace `rest composite=5.0 ...`
- Kotlin wake-only: Rest `null`, trace `rest composite=0.0 ...`
- both Light controls: Rest `28.13` and the same byte-stable trace

After #1461 merged, a fresh current-main Swift RED confirmed Rest is now nil while the unchanged `rest composite=5.0` line is still emitted. Kotlin production remained trace-equivalent: its scorer result is null and `subScoreLine` coalesces it to `0.0`.

## Green evidence

On exact current-main base `7a75136a6d4db34d6ebb15672fe8306b336bf1ea`, strictly serial native focused tests passed after this patch:

- Swift: 2 tests, 0 failures
- Android/Kotlin: BUILD SUCCESSFUL, 2 tests, 0 failures (JDK 17, max-workers 1, no parallel, Kotlin in-process, Xmx1536m)

The positive 30-minute Light session remains Rest `28.13` with the exact common trace; the wake-only session retains `sleep-motion` while omitting only the nonexistent Rest line.

Independent delta review and final commit-boundary review both passed with no P0/P1/P2. The final commit contains exactly the two AnalyticsEngine sources and two mirrored tests; temporary Linux build shims are absent. Full platform suites are CI-gated.