### PR TITLE
fix(oura): widen the skin-temp worn-gate timestamp match for devices with independent HR/temp clocks (#1467)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -343,6 +343,11 @@ public enum AnalyticsEngine {
                                   // uses the global `Whoop4SkinTemp.anchorRaw`, so every 5/MG + pure-function
                                   // caller stays byte-identical (`.whoop5` ignores the anchor entirely).
                                   skinTempAnchorRaw: Double? = nil,
+                                  // #1467: 0 (default) keeps every existing caller's skin-temp "worn" gate
+                                  // exact-timestamp, byte-identical. IntelligenceEngine passes a non-zero
+                                  // value for an owner whose HR and skin-temp streams aren't co-sampled at
+                                  // 1 Hz (an Oura ring) — see `AnalyticsEngine.defaultOuraWornToleranceSec`.
+                                  skinTempWornToleranceSec: Int = 0,
                                   // WHOOP 4.0 raw SpO2 PPG ADC samples (red/IR) for the night window
                                   // (#93). The nightly red/IR means over detected sleep are banked on the
                                   // DailyMetric as RAW ADC — honest "the sensor decoded" data, NOT a
@@ -727,7 +732,8 @@ public enum AnalyticsEngine {
         // and the mean is harvested; IntelligenceEngine seeds the baseline from those means
         // and re-derives the deviation in pass 2 (mirrors avgHrv→recovery). APPROXIMATE.
         let nightlySkinTempC = wornNightlySkinTempC(matched, hr: hr, skinTemp: skinTemp,
-                                                    family: skinTempFamily, anchorRaw: skinTempAnchorRaw)
+                                                    family: skinTempFamily, anchorRaw: skinTempAnchorRaw,
+                                                    wornToleranceSec: skinTempWornToleranceSec)
         let skinTempDevC: Double? = nightlySkinTempC.flatMap { (v: Double) -> Double? in
             guard let b = baselines.skinTemp, b.usable else { return nil }
             return round2(Baselines.deviation(v, state: b).delta)
@@ -1091,9 +1097,15 @@ public enum AnalyticsEngine {
                                      // `Whoop4SkinTemp.anchorRaw`, keeping 5/MG + pure-function callers
                                      // byte-identical. Threaded straight to the funnel's conversion.
                                      anchorRaw: Double? = nil,
-                                     minSamples: Int = minSkinTempSamples) -> Double? {
+                                     minSamples: Int = minSkinTempSamples,
+                                     // #1467: how many seconds apart a "worn" HR sample may sit from a
+                                     // skin-temp sample and still count it as concurrent. Default 0 =
+                                     // today's exact-timestamp match, byte-identical for every existing
+                                     // caller. See `skinTempFunnel`'s doc for why a ring needs this > 0.
+                                     wornToleranceSec: Int = 0) -> Double? {
         skinTempFunnel(sessions, hr: hr, skinTemp: skinTemp, family: family,
-                       anchorRaw: anchorRaw, minSamples: minSamples).mean
+                       anchorRaw: anchorRaw, minSamples: minSamples,
+                       wornToleranceSec: wornToleranceSec).mean
     }
 
     /// Nightly means of the WHOOP 4.0 raw SpO2 PPG channels (red/IR ADC) over the detected in-bed
@@ -1288,6 +1300,17 @@ public enum AnalyticsEngine {
     /// `wornNightlySkinTempC` uses (and produces the IDENTICAL mean), additionally counting where each
     /// sample dropped, so an absent skin temp is self-explaining. The public `wornNightlySkinTempC` is a
     /// thin wrapper over this, so the two can never disagree. Pure + deterministic. (#752)
+    /// #1467: how far apart (seconds) a valid HR sample may sit from a skin-temp sample and still mark it
+    /// "worn", when the caller opts in via `wornToleranceSec` > 0. Ground-truthed against a 7-night Oura
+    /// gap: exact-timestamp co-occurrence (tolerance 0) landed every one of those nights just under
+    /// `minSkinTempSamples` (155-296 kept, minSamples=300) despite 269-675 raw skin-temp samples and
+    /// 3,900-14,600 valid HR samples each night — the ring's HR and skin-temp channels are independently
+    /// clocked, unlike a WHOOP strap's single co-sampled per-second stream, so only ~40-55% of timestamps
+    /// coincide exactly by chance. A ±2 s window alone recovered every real (non-fragment) night comfortably
+    /// past the floor (622-635 kept); this default carries margin. See `worklog/BOARD.md` queue 11b and
+    /// `worklog/analysis/2026-08-19-1745-oura-app-skintemp-groundtruth-check.txt`.
+    public static let defaultOuraWornToleranceSec = 5
+
     public static func skinTempFunnel(_ sessions: [SleepSession],
                                       hr: [HRSample],
                                       skinTemp: [SkinTempSample],
@@ -1296,7 +1319,14 @@ public enum AnalyticsEngine {
                                       // global `Whoop4SkinTemp.anchorRaw`, so 5/MG + pure-function callers are
                                       // byte-identical.
                                       anchorRaw: Double? = nil,
-                                      minSamples: Int = minSkinTempSamples) -> SkinTempFunnelDiagnostic {
+                                      minSamples: Int = minSkinTempSamples,
+                                      // #1467: 0 (default) = exact-timestamp "worn" match, byte-identical to
+                                      // every caller before this change. A device whose HR and skin-temp
+                                      // streams aren't co-sampled at 1 Hz (an Oura ring) needs > 0 — see
+                                      // `defaultOuraWornToleranceSec`'s doc for the ground truth behind the
+                                      // value. IntelligenceEngine threads it per the OWNER device, never
+                                      // globally, so WHOOP behavior is untouched by construction.
+                                      wornToleranceSec: Int = 0) -> SkinTempFunnelDiagnostic {
         let total = skinTemp.count
         // #skin-diag: raw-ADC band + resolved anchor — PURE observation of the input, computed once and
         // reported on both return paths. Never touches the mean/gate logic below (byte-parity preserved).
@@ -1320,13 +1350,40 @@ public enum AnalyticsEngine {
                                             inBandCount: inBandCount, resolvedAnchorRaw: usedAnchor,
                                             medianMappedC: medianMappedC)
         }
-        var wornSeconds = Set<Int>(minimumCapacity: hr.count)
-        for h in hr where (30...220).contains(h.bpm) { wornSeconds.insert(h.ts) }
+        // #1467: tolerance 0 keeps the ORIGINAL O(1) exact-second Set lookup, untouched — every caller
+        // before this change, and every WHOOP night today, takes this branch and is byte-identical.
+        // tolerance > 0 (an Oura owner) instead sorts the valid HR timestamps once and binary-searches
+        // each skin-temp sample for the nearest one, so the check stays O(hr log hr + skinTemp log hr)
+        // rather than an O(hr × skinTemp) scan.
+        let wornSeconds: Set<Int>?
+        let sortedValidHrTs: [Int]?
+        if wornToleranceSec <= 0 {
+            var s = Set<Int>(minimumCapacity: hr.count)
+            for h in hr where (30...220).contains(h.bpm) { s.insert(h.ts) }
+            wornSeconds = s
+            sortedValidHrTs = nil
+        } else {
+            wornSeconds = nil
+            sortedValidHrTs = hr.filter { (30...220).contains($0.bpm) }.map { $0.ts }.sorted()
+        }
+        // True when some valid HR reading sits within `wornToleranceSec` of `ts` (inclusive both sides).
+        func isWorn(_ ts: Int) -> Bool {
+            if let wornSeconds { return wornSeconds.contains(ts) }
+            guard let sortedValidHrTs, !sortedValidHrTs.isEmpty else { return false }
+            var lo = 0, hi = sortedValidHrTs.count - 1
+            while lo <= hi {
+                let mid = (lo + hi) / 2
+                let d = sortedValidHrTs[mid] - ts
+                if abs(d) <= wornToleranceSec { return true }
+                if d < 0 { lo = mid + 1 } else { hi = mid - 1 }
+            }
+            return false
+        }
         var sum = 0.0
         var kept = 0
         var notWorn = 0, outOfWindow = 0, outOfRange = 0
         for t in skinTemp {
-            if !wornSeconds.contains(t.ts) { notWorn += 1; continue }
+            if !isWorn(t.ts) { notWorn += 1; continue }
             if !sessions.contains(where: { t.ts >= $0.start && t.ts <= $0.end }) { outOfWindow += 1; continue }
             // WHOOP 4.0 ONLY (#938 second capture): drop raws outside the plausible worn ADC band BEFORE the
             // anchor map. The no-contact floor (~509) and the 11-bit saturation ceiling (2047) are doff /

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -1296,10 +1296,6 @@ public enum AnalyticsEngine {
         }
     }
 
-    /// Read-only skin-temp funnel for one night (#752). Re-runs the SAME wear/window/range gates
-    /// `wornNightlySkinTempC` uses (and produces the IDENTICAL mean), additionally counting where each
-    /// sample dropped, so an absent skin temp is self-explaining. The public `wornNightlySkinTempC` is a
-    /// thin wrapper over this, so the two can never disagree. Pure + deterministic. (#752)
     /// #1467: how far apart (seconds) a valid HR sample may sit from a skin-temp sample and still mark it
     /// "worn", when the caller opts in via `wornToleranceSec` > 0. Ground-truthed against a 7-night Oura
     /// gap: exact-timestamp co-occurrence (tolerance 0) landed every one of those nights just under
@@ -1311,6 +1307,10 @@ public enum AnalyticsEngine {
     /// `worklog/analysis/2026-08-19-1745-oura-app-skintemp-groundtruth-check.txt`.
     public static let defaultOuraWornToleranceSec = 5
 
+    /// Read-only skin-temp funnel for one night (#752). Re-runs the SAME wear/window/range gates
+    /// `wornNightlySkinTempC` uses (and produces the IDENTICAL mean), additionally counting where each
+    /// sample dropped, so an absent skin temp is self-explaining. The public `wornNightlySkinTempC` is a
+    /// thin wrapper over this, so the two can never disagree. Pure + deterministic. (#752)
     public static func skinTempFunnel(_ sessions: [SleepSession],
                                       hr: [HRSample],
                                       skinTemp: [SkinTempSample],

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SkinTempAnalyticsTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SkinTempAnalyticsTests.swift
@@ -87,6 +87,101 @@ final class SkinTempAnalyticsTests: XCTestCase {
         XCTAssertNil(AnalyticsEngine.wornNightlySkinTempC([], hr: [], skinTemp: []))
     }
 
+    // MARK: - worn-gate timestamp tolerance (#1467)
+    //
+    // Ground truth: an Oura ring's HR and skin-temp channels are independently clocked (dense HR,
+    // ~1/min skin-temp), so an exact-second "worn" match only ever caught ~40-55% of real worn
+    // samples — 7 straight real nights landed just under `minSkinTempSamples` despite hundreds of
+    // raw skin-temp samples and thousands of valid HR samples each night. `wornToleranceSec` lets a
+    // caller widen the match to "some valid HR within N seconds"; default 0 keeps the exact-match
+    // behavior above byte-identical (every session in this file uses HR co-sampled every second, so
+    // exact and tolerant agree on those; these tests isolate the case where they diverge).
+
+    // These four tests space skin-temp samples 60 s apart with exactly ONE HR sample per skin-temp
+    // sample (not a dense per-second stream), so an intentional offset creates a REAL gap rather than
+    // incidentally overlapping a neighboring skin-temp sample's own HR window — the same sparse shape
+    // as the ground-truthed night test below, isolated to a smaller sample count.
+
+    func testDefaultToleranceIsExactMatchByteIdentical() {
+        // HR sits exactly 3 s off every skin-temp sample — a real gap, not co-sampled. Tolerance 0
+        // (the default, and every pre-#1467 caller) must NOT rescue these: 0 kept, nil mean.
+        let start = 6_000_000
+        let sampleCount = 400
+        let sess = [session(start: start, durSec: sampleCount * 60)]
+        let temps = (0..<sampleCount).map { skin(start + $0 * 60, rawX100: 3400) }
+        let hrs = (0..<sampleCount).map { hr(start + $0 * 60 + 3) }
+        XCTAssertNil(AnalyticsEngine.wornNightlySkinTempC(sess, hr: hrs, skinTemp: temps))
+    }
+
+    func testNonZeroToleranceRescuesNearbyHr() throws {
+        // Same 3 s-offset HR as above, but wornToleranceSec: 5 covers the gap — every sample kept.
+        let start = 6_100_000
+        let sampleCount = 400
+        let sess = [session(start: start, durSec: sampleCount * 60)]
+        let temps = (0..<sampleCount).map { skin(start + $0 * 60, rawX100: 3400) }
+        let hrs = (0..<sampleCount).map { hr(start + $0 * 60 + 3) }
+        let mean = try XCTUnwrap(AnalyticsEngine.wornNightlySkinTempC(
+            sess, hr: hrs, skinTemp: temps, wornToleranceSec: 5))
+        XCTAssertEqual(mean, 34.0, accuracy: 1e-9)
+    }
+
+    func testToleranceStillExcludesHrBeyondTheWindow() {
+        // HR offset +30 s is outside a 5 s tolerance — still nil, tolerance isn't unlimited.
+        let start = 6_200_000
+        let sampleCount = 400
+        let sess = [session(start: start, durSec: sampleCount * 60)]
+        let temps = (0..<sampleCount).map { skin(start + $0 * 60, rawX100: 3400) }
+        let hrs = (0..<sampleCount).map { hr(start + $0 * 60 + 30) }
+        XCTAssertNil(AnalyticsEngine.wornNightlySkinTempC(
+            sess, hr: hrs, skinTemp: temps, wornToleranceSec: 5))
+    }
+
+    func testToleranceIsSymmetric() throws {
+        // A skin-temp sample with its nearest valid HR BEFORE it (not after) is rescued the same way.
+        let start = 6_300_000
+        let sampleCount = 400
+        let sess = [session(start: start, durSec: sampleCount * 60)]
+        let temps = (0..<sampleCount).map { skin(start + $0 * 60, rawX100: 3400) }
+        let hrs = (0..<sampleCount).map { hr(start + $0 * 60 - 2) }
+        let mean = try XCTUnwrap(AnalyticsEngine.wornNightlySkinTempC(
+            sess, hr: hrs, skinTemp: temps, wornToleranceSec: 5))
+        XCTAssertEqual(mean, 34.0, accuracy: 1e-9)
+    }
+
+    func testToleranceReproducesTheGroundTruthedOuraNightShape() throws {
+        // A shape modeled on the real 08-13/14 night: 644 skin-temp samples every ~60 s, valid HR
+        // covering only ~46 % of the window at unpredictable offsets (not exact seconds) — exact
+        // match kept 296 (< 300 floor, nil); a 5 s tolerance kept 634 (well past it). Model a sparser
+        // HR stream (every 2nd second) offset +1 s from each skin-temp sample's true second, which
+        // exact-match entirely misses but a >=1 s tolerance entirely recovers.
+        let start = 6_400_000
+        let sampleCount = 500
+        let sess = [session(start: start, durSec: sampleCount * 60)]
+        let temps = (0..<sampleCount).map { skin(start + $0 * 60, rawX100: 3400) }
+        let hrs = (0..<sampleCount).map { hr(start + $0 * 60 + 1) }   // 1 s off every skin-temp sample
+        XCTAssertNil(AnalyticsEngine.wornNightlySkinTempC(sess, hr: hrs, skinTemp: temps))
+        let mean = try XCTUnwrap(AnalyticsEngine.wornNightlySkinTempC(
+            sess, hr: hrs, skinTemp: temps, wornToleranceSec: 5))
+        XCTAssertEqual(mean, 34.0, accuracy: 1e-9)
+    }
+
+    func testFunnelToleranceMovesSamplesFromNotWornToKept() {
+        // The funnel's bucket accounting must still sum to totalSamples, and the rescued samples move
+        // specifically from `droppedNotWorn` into `kept` — not from any other bucket.
+        let start = 6_500_000
+        let sampleCount = 400
+        let sess = [session(start: start, durSec: sampleCount * 60)]
+        let temps = (0..<sampleCount).map { skin(start + $0 * 60, rawX100: 3400) }
+        let hrs = (0..<sampleCount).map { hr(start + $0 * 60 + 3) }
+        let exact = AnalyticsEngine.skinTempFunnel(sess, hr: hrs, skinTemp: temps)
+        XCTAssertEqual(exact.droppedNotWorn, sampleCount)
+        XCTAssertEqual(exact.kept, 0)
+        let tolerant = AnalyticsEngine.skinTempFunnel(sess, hr: hrs, skinTemp: temps, wornToleranceSec: 5)
+        XCTAssertEqual(tolerant.droppedNotWorn, 0)
+        XCTAssertEqual(tolerant.kept, sampleCount)
+        XCTAssertEqual(tolerant.totalSamples, exact.totalSamples)
+    }
+
     // MARK: - skin-temp funnel diagnostic (#752)
 
     /// The kept-path: the funnel's mean is byte-identical to `wornNightlySkinTempC`, and the drop buckets +

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -824,6 +824,8 @@ final class IntelligenceEngine: ObservableObject {
                 // registry knows each device's model; unknown/non-WHOOP owners fall back to `.whoop5` (the prior
                 // /100 behaviour), so this only changes the mapping for a device positively identified as a 4.0.
                 let skinFamily = Self.skinTempFamily(forOwner: owner, devices: regDevices)
+                // #1467: the worn-gate timestamp tolerance for this owner (0 for WHOOP, byte-identical).
+                let skinWornToleranceSec = Self.skinTempWornToleranceSec(forOwner: owner, devices: regDevices)
                 // #938 (second capture): learn THIS device's worn skin-temp anchor raw ONCE, WINDOW-WIDE (the
                 // whole scan window's skin samples), not per-night. The @72 skin-temp ADC's register offset is
                 // per-device — a second real 4.0 strap shares the no-contact floor (~509) + 11-bit saturation
@@ -973,6 +975,7 @@ final class IntelligenceEngine: ObservableObject {
                                                      skinTemp: skin,
                                                      skinTempFamily: skinFamily,   // #938
                                                      skinTempAnchorRaw: skinAnchorRaw,   // #938 second capture
+                                                     skinTempWornToleranceSec: skinWornToleranceSec,   // #1467
                                                      spo2: spo2,                   // #93
                                                      profile: up, baselines: baselines1, maxHROverride: maxHR,
                                                      tzOffsetSeconds: tzOffset, wristOff: wristOff,
@@ -2184,6 +2187,19 @@ final class IntelligenceEngine: ObservableObject {
         // Non-WHOOP owner (nil) shares the non-4.0 temp scale, so coalesce to `.whoop5` — same conversion
         // as before; the brand-aware resolver just no longer mislabels the owner as a WHOOP (#1086).
         return DeviceFamily.forRegistryDevice(model: d?.model, brand: d?.brand) ?? .whoop5
+    }
+
+    /// #1467: the skin-temp "worn" gate's timestamp tolerance for `owner` — 0 (exact match) for a WHOOP
+    /// strap, whose HR and skin-temp are one co-sampled 1 Hz stream, so this is byte-identical to before
+    /// this change for every WHOOP night. An Oura ring streams the two on independent clocks (dense HR,
+    /// ~1/min skin-temp), so an exact-second match only ever caught ~40-55% of real worn samples — every
+    /// one of 7 straight real nights landed just under `minSkinTempSamples`, ground-truthed against the
+    /// Oura app's own reported skin-temp trend (queue 11b, `worklog/BOARD.md`). Same registry lookup
+    /// `skinTempFamily` uses; deliberately its own small helper rather than folding into `DeviceFamily`,
+    /// which has no Oura case (#1086) and a tolerance-in-seconds isn't a temperature-scale concern.
+    nonisolated static func skinTempWornToleranceSec(forOwner owner: String, devices: [PairedDevice]) -> Int {
+        devices.first(where: { $0.id == owner })?.brand == "Oura"
+            ? AnalyticsEngine.defaultOuraWornToleranceSec : 0
     }
 
     /// #137: re-score under-sampled manual workouts. A `manual` workout is scored from the live HR

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -1091,12 +1091,6 @@ object AnalyticsEngine {
     }
 
     /**
-     * Read-only skin-temp funnel for one night (#752). Re-runs the SAME wear/window/range gates
-     * [wornNightlySkinTempC] uses (and produces the IDENTICAL mean), additionally counting where each
-     * sample dropped, so an absent skin temp is self-explaining. [wornNightlySkinTempC] is a thin wrapper
-     * over this, so the two can never disagree. Pure + deterministic. Mirrors Swift `skinTempFunnel`. (#752)
-     */
-    /**
      * #1467: how far apart (seconds) a valid HR sample may sit from a skin-temp sample and still mark
      * it "worn", when the caller opts in via [wornToleranceSec] > 0. Ground-truthed against a 7-night
      * Oura gap: exact-timestamp co-occurrence (tolerance 0) landed every one of those nights just under
@@ -1109,6 +1103,12 @@ object AnalyticsEngine {
      */
     const val DEFAULT_OURA_WORN_TOLERANCE_SEC = 5L
 
+    /**
+     * Read-only skin-temp funnel for one night (#752). Re-runs the SAME wear/window/range gates
+     * [wornNightlySkinTempC] uses (and produces the IDENTICAL mean), additionally counting where each
+     * sample dropped, so an absent skin temp is self-explaining. [wornNightlySkinTempC] is a thin wrapper
+     * over this, so the two can never disagree. Pure + deterministic. Mirrors Swift `skinTempFunnel`. (#752)
+     */
     fun skinTempFunnel(
         sessions: List<DetectedSleep>,
         hr: List<HrSample>,

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -315,6 +315,11 @@ object AnalyticsEngine {
         // owner's own worn median. null → the family-aware conversion uses the global Whoop4SkinTemp.ANCHOR_RAW,
         // so every 5/MG + pure-function caller stays byte-identical (WHOOP5 ignores the anchor entirely).
         skinTempAnchorRaw: Double? = null,
+        // #1467: 0 (default) keeps every existing caller's skin-temp "worn" gate exact-timestamp,
+        // byte-identical. IntelligenceEngine passes a non-zero value for an owner whose HR and
+        // skin-temp streams aren't co-sampled at 1 Hz (an Oura ring) — see
+        // [AnalyticsEngine.DEFAULT_OURA_WORN_TOLERANCE_SEC].
+        skinTempWornToleranceSec: Long = 0,
         // WHOOP 4.0 raw SpO2 PPG ADC samples (red/IR) for the night window (#93). The nightly red/IR
         // means over detected sleep are banked on the DailyMetric as RAW ADC — honest "the sensor
         // decoded" data, NOT a calibrated blood-oxygen % (that needs WHOOP's proprietary curve). Default
@@ -619,7 +624,8 @@ object AnalyticsEngine {
         // mean is harvested; IntelligenceEngine seeds the baseline from those means and re-derives the
         // deviation in pass 2 (mirrors avgHrv→recovery). Computed BEFORE Charge so the Charge skin-temp
         // penalty can read it. APPROXIMATE. (PR #85)
-        val nightlySkinTempC = wornNightlySkinTempC(matched, hr, skinTemp, skinTempFamily, skinTempAnchorRaw)
+        val nightlySkinTempC = wornNightlySkinTempC(matched, hr, skinTemp, skinTempFamily, skinTempAnchorRaw,
+            wornToleranceSec = skinTempWornToleranceSec)
         val skinTempDevC: Double? = nightlySkinTempC?.let { v ->
             baselines.skinTemp?.takeIf { it.usable }?.let { round2(Baselines.deviation(v, it).delta) }
         }
@@ -893,7 +899,11 @@ object AnalyticsEngine {
         // 5/MG + pure-function callers byte-identical. Threaded straight to the funnel's conversion.
         anchorRaw: Double? = null,
         minSamples: Int = MIN_SKIN_TEMP_SAMPLES_INLINE,
-    ): Double? = skinTempFunnel(sessions, hr, skinTemp, family, anchorRaw, minSamples).mean
+        // #1467: how many seconds apart a "worn" HR sample may sit from a skin-temp sample and still
+        // count it as concurrent. Default 0 = today's exact-timestamp match, byte-identical for every
+        // existing caller. See [skinTempFunnel]'s doc for why a ring needs this > 0.
+        wornToleranceSec: Long = 0,
+    ): Double? = skinTempFunnel(sessions, hr, skinTemp, family, anchorRaw, minSamples, wornToleranceSec).mean
 
     /**
      * Nightly means of the WHOOP 4.0 raw SpO2 PPG channels (red/IR ADC) over the detected in-bed
@@ -1086,6 +1096,19 @@ object AnalyticsEngine {
      * sample dropped, so an absent skin temp is self-explaining. [wornNightlySkinTempC] is a thin wrapper
      * over this, so the two can never disagree. Pure + deterministic. Mirrors Swift `skinTempFunnel`. (#752)
      */
+    /**
+     * #1467: how far apart (seconds) a valid HR sample may sit from a skin-temp sample and still mark
+     * it "worn", when the caller opts in via [wornToleranceSec] > 0. Ground-truthed against a 7-night
+     * Oura gap: exact-timestamp co-occurrence (tolerance 0) landed every one of those nights just under
+     * [MIN_SKIN_TEMP_SAMPLES_INLINE] (155-296 kept, floor 300) despite 269-675 raw skin-temp samples
+     * and 3,900-14,600 valid HR samples each night — the ring's HR and skin-temp channels are
+     * independently clocked, unlike a WHOOP strap's single co-sampled per-second stream, so only
+     * ~40-55% of timestamps coincide exactly by chance. A ±2 s window alone recovered every real
+     * (non-fragment) night comfortably past the floor (622-635 kept); this default carries margin. See
+     * worklog/BOARD.md queue 11b and worklog/analysis/2026-08-19-1745-oura-app-skintemp-groundtruth-check.txt.
+     */
+    const val DEFAULT_OURA_WORN_TOLERANCE_SEC = 5L
+
     fun skinTempFunnel(
         sessions: List<DetectedSleep>,
         hr: List<HrSample>,
@@ -1095,6 +1118,11 @@ object AnalyticsEngine {
         // Whoop4SkinTemp.ANCHOR_RAW, so 5/MG + pure-function callers are byte-identical.
         anchorRaw: Double? = null,
         minSamples: Int = MIN_SKIN_TEMP_SAMPLES_INLINE,
+        // #1467: 0 (default) = exact-timestamp "worn" match, byte-identical to every caller before this
+        // change. A device whose HR and skin-temp streams aren't co-sampled at 1 Hz (an Oura ring)
+        // needs > 0 — see [DEFAULT_OURA_WORN_TOLERANCE_SEC]'s doc for the ground truth behind the value.
+        // IntelligenceEngine threads it per the OWNER device, never globally, so WHOOP is untouched.
+        wornToleranceSec: Long = 0,
     ): SkinTempFunnelDiagnostic {
         val total = skinTemp.size
         // #skin-diag: raw-ADC band + resolved anchor — PURE observation of the input, computed once and
@@ -1125,15 +1153,43 @@ object AnalyticsEngine {
                 inBandCount = inBandCount, resolvedAnchorRaw = usedAnchor, medianMappedC = medianMappedC,
             )
         }
-        val wornSeconds = HashSet<Long>(hr.size)
-        for (h in hr) if (h.bpm in 30..220) wornSeconds.add(h.ts)
+        // #1467: tolerance 0 keeps the ORIGINAL O(1) exact-second HashSet lookup, untouched — every
+        // caller before this change, and every WHOOP night today, takes this branch and is byte-
+        // identical. tolerance > 0 (an Oura owner) instead sorts the valid HR timestamps once and
+        // binary-searches each skin-temp sample for the nearest one, so the check stays
+        // O(hr log hr + skinTemp log hr) rather than an O(hr × skinTemp) scan.
+        val wornSeconds: HashSet<Long>?
+        val sortedValidHrTs: LongArray?
+        if (wornToleranceSec <= 0) {
+            val s = HashSet<Long>(hr.size)
+            for (h in hr) if (h.bpm in 30..220) s.add(h.ts)
+            wornSeconds = s
+            sortedValidHrTs = null
+        } else {
+            wornSeconds = null
+            sortedValidHrTs = hr.filter { it.bpm in 30..220 }.map { it.ts }.sorted().toLongArray()
+        }
+        // True when some valid HR reading sits within [wornToleranceSec] of [ts] (inclusive both sides).
+        fun isWorn(ts: Long): Boolean {
+            if (wornSeconds != null) return ts in wornSeconds
+            if (sortedValidHrTs == null || sortedValidHrTs.isEmpty()) return false
+            var lo = 0
+            var hi = sortedValidHrTs.size - 1
+            while (lo <= hi) {
+                val mid = (lo + hi) / 2
+                val d = sortedValidHrTs[mid] - ts
+                if (kotlin.math.abs(d) <= wornToleranceSec) return true
+                if (d < 0) lo = mid + 1 else hi = mid - 1
+            }
+            return false
+        }
         var sum = 0.0
         var kept = 0
         var notWorn = 0
         var outOfWindow = 0
         var outOfRange = 0
         for (t in skinTemp) {
-            if (t.ts !in wornSeconds) { notWorn++; continue }
+            if (!isWorn(t.ts)) { notWorn++; continue }
             if (sessions.none { t.ts in it.start..it.end }) { outOfWindow++; continue }
             // WHOOP 4.0 ONLY (#938 second capture): drop raws outside the plausible worn ADC band BEFORE the
             // anchor map. The no-contact floor (~509) and the 11-bit saturation ceiling (2047) are doff /

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -122,6 +122,14 @@ object IntelligenceEngine {
          *  [RegistryDayOwnerSource] resolves a positively-identified 4.0 to WHOOP4. */
         suspend fun skinTempFamily(deviceId: String): DeviceFamily = DeviceFamily.WHOOP5
 
+        /** #1467: the skin-temp "worn" gate's timestamp tolerance (seconds) for [deviceId] — 0 (exact
+         *  match, the default) for a WHOOP strap, whose HR and skin-temp are one co-sampled 1 Hz stream.
+         *  An Oura ring streams the two on independent clocks (dense HR, ~1/min skin-temp), so an exact-
+         *  second match only ever caught a fraction of real worn samples. [RegistryDayOwnerSource]
+         *  resolves a positively-identified Oura device to [AnalyticsEngine.DEFAULT_OURA_WORN_TOLERANCE_SEC].
+         *  Mirrors the Swift `IntelligenceEngine.skinTempWornToleranceSec(forOwner:devices:)`. */
+        suspend fun skinTempWornToleranceSec(deviceId: String): Long = 0
+
         /** The registered WHOOP family for [deviceId] — WHOOP4 or WHOOP5 for a positively-identified strap,
          *  or **null** for a non-WHOOP owner (ring / import / unknown). UNLIKE [skinTempFamily], which
          *  coalesces an unknown to WHOOP5 for the skin-temp scale, this must NOT coalesce — the #1005 reuse
@@ -518,6 +526,8 @@ object IntelligenceEngine {
         // registry is stable for the run (same assumption [candidatePriorities] above already makes), so
         // every day sees the exact value the per-day call would have returned: byte-identical scoring.
         val skinFamilyByOwner = HashMap<String, DeviceFamily>()
+        // #1467: same per-owner memoization as skinFamilyByOwner, for the worn-gate timestamp tolerance.
+        val skinWornToleranceByOwner = HashMap<String, Long>()
         // #938: the WHOOP 4.0 ADC offset is per-device, not per-night. Learn one anchor per owner from the
         // whole scan window and reuse it for every night so cross-night deviations survive.
         val skinAnchorScanFrom = nowLocalMidnight - (maxDays - 1).toLong() * SECONDS_PER_DAY - 30 * 3_600L
@@ -677,6 +687,10 @@ object IntelligenceEngine {
             val skinFamily = skinFamilyByOwner.getOrPut(owner) {
                 ownerSource?.skinTempFamily(owner) ?: DeviceFamily.WHOOP5
             }
+            // #1467: the worn-gate timestamp tolerance for this owner (0 for WHOOP, byte-identical).
+            val skinWornToleranceSec = skinWornToleranceByOwner.getOrPut(owner) {
+                ownerSource?.skinTempWornToleranceSec(owner) ?: 0
+            }
             // #938 (second capture): learn THIS device's worn skin-temp anchor raw ONCE, WINDOW-WIDE (the
             // whole scan window's skin samples), not per-night. The @72 skin-temp ADC's register offset is
             // per-device — a second real 4.0 strap shares the no-contact floor (~509) + 11-bit saturation
@@ -776,6 +790,7 @@ object IntelligenceEngine {
                 skinTemp = skin,
                 skinTempFamily = skinFamily,   // #938
                 skinTempAnchorRaw = skinAnchorRaw,   // #938 second capture: per-device worn anchor
+                skinTempWornToleranceSec = skinWornToleranceSec,   // #1467
                 spo2 = spo2,                   // #93
                 profile = profile,
                 baselines = baselines1,

--- a/android/app/src/main/java/com/noop/analytics/RegistryDayOwnerSource.kt
+++ b/android/app/src/main/java/com/noop/analytics/RegistryDayOwnerSource.kt
@@ -67,4 +67,13 @@ class RegistryDayOwnerSource(private val registry: DeviceRegistry) : Intelligenc
         val d = registry.all().firstOrNull { it.id == deviceId }
         return DeviceFamily.forRegistryDevice(d?.model, d?.brand)
     }
+
+    // #1467: the worn-gate timestamp tolerance for this owner (0 for WHOOP, byte-identical). Same
+    // registry lookup skinTempFamily uses; deliberately its own small helper rather than folding into
+    // DeviceFamily, which has no Oura case (#1086) and a tolerance-in-seconds isn't a temperature-scale
+    // concern. Mirrors the Swift IntelligenceEngine.skinTempWornToleranceSec(forOwner:devices:).
+    override suspend fun skinTempWornToleranceSec(deviceId: String): Long {
+        val d = registry.all().firstOrNull { it.id == deviceId }
+        return if (d?.brand == "Oura") AnalyticsEngine.DEFAULT_OURA_WORN_TOLERANCE_SEC else 0
+    }
 }

--- a/android/app/src/test/java/com/noop/analytics/SkinTempAnalyticsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SkinTempAnalyticsTest.kt
@@ -96,6 +96,99 @@ class SkinTempAnalyticsTest {
         assertNull(AnalyticsEngine.wornNightlySkinTempC(emptyList(), emptyList(), emptyList()))
     }
 
+    // ── worn-gate timestamp tolerance (#1467) ───────────────────────────────
+    //
+    // Ground truth: an Oura ring's HR and skin-temp channels are independently clocked (dense HR,
+    // ~1/min skin-temp), so an exact-second "worn" match only ever caught ~40-55% of real worn
+    // samples — 7 straight real nights landed just under MIN_SKIN_TEMP_SAMPLES_INLINE despite hundreds
+    // of raw skin-temp samples and thousands of valid HR samples each night. wornToleranceSec lets a
+    // caller widen the match to "some valid HR within N seconds"; default 0 keeps the exact-match
+    // behavior above byte-identical. These four tests space skin-temp samples 60 s apart with exactly
+    // ONE HR sample per skin-temp sample (not a dense per-second stream), so an intentional offset
+    // creates a REAL gap rather than incidentally overlapping a neighboring sample's own HR window.
+
+    @Test
+    fun defaultToleranceIsExactMatchByteIdentical() {
+        // HR sits exactly 3 s off every skin-temp sample — a real gap, not co-sampled. Tolerance 0
+        // (the default, and every pre-#1467 caller) must NOT rescue these.
+        val start = 6_000_000L
+        val n = 400
+        val sess = listOf(session(start, n * 60L))
+        val temps = (0 until n).map { skin(start + it * 60L, 3400) }
+        val hrs = (0 until n).map { hr(start + it * 60L + 3) }
+        assertNull(AnalyticsEngine.wornNightlySkinTempC(sess, hrs, temps))
+    }
+
+    @Test
+    fun nonZeroToleranceRescuesNearbyHr() {
+        // Same 3 s-offset HR as above, but wornToleranceSec = 5 covers the gap — every sample kept.
+        val start = 6_100_000L
+        val n = 400
+        val sess = listOf(session(start, n * 60L))
+        val temps = (0 until n).map { skin(start + it * 60L, 3400) }
+        val hrs = (0 until n).map { hr(start + it * 60L + 3) }
+        val mean = AnalyticsEngine.wornNightlySkinTempC(sess, hrs, temps, wornToleranceSec = 5)
+        assertEquals(34.0, mean!!, 1e-9)
+    }
+
+    @Test
+    fun toleranceStillExcludesHrBeyondTheWindow() {
+        // HR offset +30 s is outside a 5 s tolerance — still null, tolerance isn't unlimited.
+        val start = 6_200_000L
+        val n = 400
+        val sess = listOf(session(start, n * 60L))
+        val temps = (0 until n).map { skin(start + it * 60L, 3400) }
+        val hrs = (0 until n).map { hr(start + it * 60L + 30) }
+        assertNull(AnalyticsEngine.wornNightlySkinTempC(sess, hrs, temps, wornToleranceSec = 5))
+    }
+
+    @Test
+    fun toleranceIsSymmetric() {
+        // A skin-temp sample with its nearest valid HR BEFORE it (not after) is rescued the same way.
+        val start = 6_300_000L
+        val n = 400
+        val sess = listOf(session(start, n * 60L))
+        val temps = (0 until n).map { skin(start + it * 60L, 3400) }
+        val hrs = (0 until n).map { hr(start + it * 60L - 2) }
+        val mean = AnalyticsEngine.wornNightlySkinTempC(sess, hrs, temps, wornToleranceSec = 5)
+        assertEquals(34.0, mean!!, 1e-9)
+    }
+
+    @Test
+    fun toleranceReproducesTheGroundTruthedOuraNightShape() {
+        // A shape modeled on the real 08-13/14 night: 644 skin-temp samples every ~60 s, valid HR
+        // covering only ~46% of the window at unpredictable offsets (not exact seconds) — exact match
+        // kept 296 (< 300 floor, null); a 5 s tolerance kept 634 (well past it). Model a sparse HR
+        // stream (one sample per skin-temp sample) offset +1 s, which exact-match entirely misses but
+        // any >=1 s tolerance entirely recovers.
+        val start = 6_400_000L
+        val n = 500
+        val sess = listOf(session(start, n * 60L))
+        val temps = (0 until n).map { skin(start + it * 60L, 3400) }
+        val hrs = (0 until n).map { hr(start + it * 60L + 1) }
+        assertNull(AnalyticsEngine.wornNightlySkinTempC(sess, hrs, temps))
+        val mean = AnalyticsEngine.wornNightlySkinTempC(sess, hrs, temps, wornToleranceSec = 5)
+        assertEquals(34.0, mean!!, 1e-9)
+    }
+
+    @Test
+    fun funnelToleranceMovesSamplesFromNotWornToKept() {
+        // The funnel's bucket accounting must still sum to totalSamples, and the rescued samples move
+        // specifically from droppedNotWorn into kept — not from any other bucket.
+        val start = 6_500_000L
+        val n = 400
+        val sess = listOf(session(start, n * 60L))
+        val temps = (0 until n).map { skin(start + it * 60L, 3400) }
+        val hrs = (0 until n).map { hr(start + it * 60L + 3) }
+        val exact = AnalyticsEngine.skinTempFunnel(sess, hrs, temps)
+        assertEquals(n, exact.droppedNotWorn)
+        assertEquals(0, exact.kept)
+        val tolerant = AnalyticsEngine.skinTempFunnel(sess, hrs, temps, wornToleranceSec = 5)
+        assertEquals(0, tolerant.droppedNotWorn)
+        assertEquals(n, tolerant.kept)
+        assertEquals(exact.totalSamples, tolerant.totalSamples)
+    }
+
     // ── skin-temp funnel diagnostic (#752) ──────────────────────────────────
 
     /** The kept-path: the funnel's mean is identical to [AnalyticsEngine.wornNightlySkinTempC], and the


### PR DESCRIPTION
## Body

The Skin Temp Key Metrics card reads "–" for an Oura-primary install even after 20+ nights of wear.
`AnalyticsEngine.wornNightlySkinTempC` requires a valid HR sample at the **exact same second** as each
skin-temp sample before counting it "worn" — a fine proxy for a WHOOP strap, which streams HR and
skin-temp as one co-sampled 1 Hz channel, but wrong for an Oura ring, whose HR (dense, near-continuous)
and skin-temp (~1/min) are independently clocked streams that only coincide on the exact same second by
chance.

Measured against a real 7-night gap on one wearer's own staging capture
(`oura-2H3B2405003655`, 2026-08-13 through 08-19): every single main night landed just under
`minSkinTempSamples` (155-296 kept, floor 300) despite 269-675 raw skin-temp samples and 3,900-14,600
valid HR samples each night. A ±2s tolerance alone recovered every real (non-fragment) night comfortably
past the floor (622-635 kept); the two genuinely short sessions in that window (135 and 269 total
skin-temp samples) correctly stay under the floor regardless, since they're naps/fragments, not full
nights — cross-checked against the DB directly before writing the fix: every populated day's session
cleared 300 on the exact-match count, every nil day fell short, a clean fully-explained correlation.

**Fix:** a new `wornToleranceSec` parameter on `wornNightlySkinTempC`/`skinTempFunnel` (Swift) and their
Kotlin twins, threaded from `IntelligenceEngine` per the OWNER device rather than globally. Default `0`
preserves the exact-timestamp match byte-identically for every existing caller and every WHOOP night;
`IntelligenceEngine` resolves a positively-identified Oura device (registry `brand == "Oura"`, the same
lookup `skinTempFamily` already uses) to a 5s tolerance
(`AnalyticsEngine.defaultOuraWornToleranceSec` / `DEFAULT_OURA_WORN_TOLERANCE_SEC`). Tolerance 0 keeps
the original O(1) exact-second `Set` lookup; tolerance > 0 sorts the valid HR timestamps once and
binary-searches each skin-temp sample, so the check stays O(hr log hr + skinTemp log hr) rather than an
O(hr × skinTemp) scan.

**Verification**
- New tests (6 Swift, 6 Kotlin, byte-parity) isolate the tolerance behavior: default-0 stays an exact
  match, a real gap gets rescued within tolerance, a gap beyond tolerance still excludes, the match is
  symmetric (HR before or after), a shape modeled directly on the real 08-13/14 night reproduces
  null-then-recovered, and the funnel's drop-bucket accounting still sums to `totalSamples` with the
  rescued samples moving specifically from `droppedNotWorn` to `kept`.
- Built and tested from a clean worktree on this branch's `upstream/main` base: Swift `swift test`
  `Packages/StrandAnalytics` 1502/0 (one pre-existing `XCTExpectFailure` for #977 is expected,
  unrelated). macOS `Strand` scheme builds and `StrandTests` 1172/0. `NOOPiOS` builds
  (`CODE_SIGNING_ALLOWED=NO`, iOS 26.5 simulator). Android `compileFullDebugKotlin` clean,
  `testFullDebugUnitTest` (this file) 29/0.
- **Not yet validated end-to-end on hardware** — the "–" card actually turning into a number needs the
  next real Oura-primary capture with this build flashed. The underlying math is unit-tested and the
  real-data root cause is directly confirmed against a live capture, but I'm flagging the gap per this
  repo's own rule: compile/unit-test success proves the logic, not the on-device behavior.
