### PR TITLE
fix(android): render Test Centre live readouts

### DIFF
--- a/android/app/src/main/java/com/noop/NoopApplication.kt
+++ b/android/app/src/main/java/com/noop/NoopApplication.kt
@@ -118,6 +118,7 @@ class NoopApplication : Application() {
             straplog = { ble.externalLog(it) },
             // A generic strap's standard battery (0x180F) → the same live battery field the WHOOP uses.
             batterySink = { pct -> ble.publishExternalBattery(pct) },
+            initialActiveDeviceId = activeDeviceId,
         )
     }
 

--- a/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
+++ b/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
@@ -103,7 +103,24 @@ class SourceCoordinator(
      *  generic-HR strap path (a footpod / bike sensor / power meter rides StandardHrSource). Default no-op
      *  keeps existing call sites + JVM tests compiling unchanged. */
     private val sensorSink: (StandardHrSource.SensorMetrics) -> Unit = {},
+    /** Initial registry id for process composition. Nullable keeps plain JVM harnesses honest until their
+     * first successful reconcile; production injects its already-resolved startup id. */
+    initialActiveDeviceId: String? = null,
+    /** Move Oura's install key alongside serial-identity adoption. Plain JVM tests inject a no-op;
+     * production retains the encrypted-store behavior through this default. */
+    private val migrateOuraInstallKey: (fromId: String, toId: String) -> Unit = { fromId, toId ->
+        context?.let { ctx ->
+            OuraInstallKeyStore.load(ctx, fromId)?.let { key ->
+                OuraInstallKeyStore.save(ctx, toId, key)
+                OuraInstallKeyStore.clear(ctx, fromId)
+            }
+        }
+    },
 ) {
+
+    /** The single success-only active-id publication for UI and internal identity-adoption consumers. */
+    private val _activeDeviceId = MutableStateFlow(initialActiveDeviceId)
+    val activeDeviceId: StateFlow<String?> = _activeDeviceId.asStateFlow()
 
     /** Latest instantaneous speed/cadence/power from the active standard fitness sensor (RSC/CSC/CPS),
      *  read ADDITIVELY alongside HR by [StandardHrSource]. The in-workout UI observes this to surface the
@@ -170,7 +187,7 @@ class SourceCoordinator(
     fun start() {
         scope.launch {
             val id = registry.activeDeviceId() ?: WhoopBleClient.DEFAULT_DEVICE_ID
-            reconcileLock.withLock { reconcile(id) }
+            reconcileActiveDevice(id)
         }
     }
 
@@ -180,8 +197,20 @@ class SourceCoordinator(
      * repeated call for the same id is dropped (the `removeDuplicates()` equivalent).
      */
     fun onActiveDeviceChanged(id: String) {
-        scope.launch { reconcileLock.withLock { reconcile(id) } }
+        scope.launch { reconcileActiveDevice(id) }
     }
+
+    /**
+     * Await the serialized source switch and report its completed outcome. Callers which publish active
+     * source state must use this API so they never advertise an id whose activation later failed.
+     * Re-selecting the already reconciled id is a successful, idempotent completion.
+     */
+    suspend fun reconcileActiveDevice(id: String): Boolean =
+        reconcileLock.withLock {
+            reconcile(id).also { success ->
+                if (success) _activeDeviceId.value = id
+            }
+        }
 
     /**
      * The BLE engine connected to a WHOOP strap at [address] (null on disconnect). Persist that stable
@@ -228,10 +257,9 @@ class SourceCoordinator(
         }
     }
 
-    private suspend fun reconcile(id: String) {
-        if (id == lastSeenId) return
+    private suspend fun reconcile(id: String): Boolean {
+        if (id == lastSeenId) return true
         lastSeenId = id
-        val devices = registry.all()
         // CONTAIN every device-switch failure here. reconcile is the single entry point for both
         // start() (launch, against the PERSISTED active id) and onActiveDeviceChanged(), and it runs
         // inside a bare `scope.launch {}` — a SupervisorJob does NOT stop an uncaught throw from
@@ -240,13 +268,16 @@ class SourceCoordinator(
         // regression: making a Polar H10 active bricked the app). A strap switch must never crash the
         // app. We log the exception into the EXPORTABLE strap log too, so the next shared log reveals
         // the exact underlying throw, and reset lastSeenId so the user can retry after switching away.
-        try {
+        return try {
+            val devices = registry.all()
             if (isWhoop(id, devices)) switchToWhoop(id, devices) else switchToStrap(id, devices)
+            true
         } catch (t: Throwable) {
             lastSeenId = null
             log("SourceCoordinator: device switch to '$id' failed: ${t.javaClass.simpleName}: ${t.message}")
             straplog("HR-strap: activating this device failed (${t.javaClass.simpleName}: ${t.message}) - " +
                 "staying on the previous source. Please share this log so we can fix it.")
+            false
         }
     }
 
@@ -540,16 +571,12 @@ class SourceCoordinator(
      * off the BLE callback thread; re-checks it is still the active device before acting.
      */
     private fun adoptOuraSerial(currentId: String, serial: String) {
-        val ctx = context ?: return
         val serialId = "${ExperimentalBrand.OURA.idPrefix}-$serial"
         if (currentId == serialId) return
         scope.launch {
             if (registry.activeDeviceId() != currentId) return@launch
             if (registry.adoptSerialIdentity(currentId, serialId)) {
-                OuraInstallKeyStore.load(ctx, currentId)?.let { key ->
-                    OuraInstallKeyStore.save(ctx, serialId, key)
-                    OuraInstallKeyStore.clear(ctx, currentId)
-                }
+                migrateOuraInstallKey(currentId, serialId)
                 straplog("Oura: adopted stable serial id $serialId (was $currentId) - re-pointing onto the ring's serial (#771)")
                 registry.setActive(serialId)
                 onActiveDeviceChanged(serialId)

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1608,6 +1608,11 @@ class WhoopBleClient(
     )
     val state: StateFlow<LiveState> = _state.asStateFlow()
 
+    /** Monotonic event for the in-memory/exportable strap log. Test Centre panels collect it only while
+     * active and coalesce bursts, so a new tagged line refreshes its readout without mutating LiveState. */
+    private val _logRevision = MutableStateFlow(0L)
+    val logRevision: StateFlow<Long> = _logRevision.asStateFlow()
+
     // MARK: Multi-WHOOP (additive — inert on the single-WHOOP path; MW-2/MW-3 parity with iOS BLEManager).
 
     /**
@@ -8302,6 +8307,7 @@ class WhoopBleClient(
                 }
                 line
             }
+            _logRevision.update { it + 1 }
             // #1263: durable-tail mirror (batched), OUTSIDE the logBuffer monitor.
             tailToPersist?.let { persistLogTail(it) }
             // #1121: when detailed capture is on, ALSO append the (already PII-scrubbed) line to the
@@ -8316,6 +8322,7 @@ class WhoopBleClient(
                     logBuffer.addLast("[log error: ${t.javaClass.simpleName}]")
                     while (logBuffer.size > LOG_BUFFER_MAX) logBuffer.removeFirst()
                 }
+                _logRevision.update { it + 1 }
             }
         }
     }

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -5,6 +5,9 @@ import androidx.room.withTransaction
 import com.noop.protocol.DroppedRtcEvent
 import com.noop.protocol.RrSourceChannel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlin.math.roundToInt
 
@@ -314,6 +317,21 @@ data class InsertCounts(
     val gravity: Int = 0,
 )
 
+/** Monotonic event revisions for Test Centre repository-backed readouts. Counts move only after Room
+ * reports at least one newly inserted relevant row; duplicate/no-op inserts leave them unchanged. */
+internal data class ReadoutDataRevisions(
+    val sleepSamples: Long = 0,
+    val battery: Long = 0,
+)
+
+internal fun advanceReadoutDataRevisions(
+    current: ReadoutDataRevisions,
+    inserted: InsertCounts,
+): ReadoutDataRevisions = current.copy(
+    sleepSamples = current.sleepSamples + if (inserted.hr > 0 || inserted.gravity > 0) 1 else 0,
+    battery = current.battery + if (inserted.battery > 0) 1 else 0,
+)
+
 /**
  * A compact snapshot of how much history each source holds, for the Data Sources "Freshness
  * Pipeline" card (PR#196). Counts only , no per-day rows leave the read. Port of macOS
@@ -384,6 +402,13 @@ class WhoopRepository(
      *  path banks v18 rows, so a plain map is enough. Swift twin: `WhoopStore.v18AuxRowsSincePrune`. */
     private val v18AuxRowsSincePrune = mutableMapOf<String, Int>()
 
+    private val _sleepSampleRevision = MutableStateFlow(0L)
+    val sleepSampleRevision: StateFlow<Long> = _sleepSampleRevision.asStateFlow()
+    private val _batteryRevision = MutableStateFlow(0L)
+    val batteryRevision: StateFlow<Long> = _batteryRevision.asStateFlow()
+    private val readoutRevisionLock = Any()
+    private var readoutRevisions = ReadoutDataRevisions()
+
     constructor(db: WhoopDatabase) : this(
         dao = db.whoopDao(),
         transactor = object : Transactor {
@@ -434,13 +459,24 @@ class WhoopRepository(
     ): InsertCounts {
         if (streams.isEmpty) return InsertCounts()
 
-        return transactor.run {
+        val counts = transactor.run {
             insertWithinTransaction(
                 streams = streams,
                 deviceId = deviceId,
                 v18AuxRetentionRows = v18AuxRetentionRows,
                 v18AuxPruneEveryRows = v18AuxPruneEveryRows,
             )
+        }
+        publishReadoutRevisions(counts)
+        return counts
+    }
+
+    private fun publishReadoutRevisions(inserted: InsertCounts) {
+        synchronized(readoutRevisionLock) {
+            val next = advanceReadoutDataRevisions(readoutRevisions, inserted)
+            readoutRevisions = next
+            if (_sleepSampleRevision.value != next.sleepSamples) _sleepSampleRevision.value = next.sleepSamples
+            if (_batteryRevision.value != next.battery) _batteryRevision.value = next.battery
         }
     }
 
@@ -1802,7 +1838,11 @@ class WhoopRepository(
     /** Persist HR samples directly (e.g. a live-tracked workout's 1 Hz series). Dedup-safe:
      *  `insertHr` IGNOREs on the (deviceId, ts) primary key, so re-inserts / a later offload sync
      *  covering the same seconds are no-ops. (#528) */
-    suspend fun insertHr(rows: List<HrSample>) = dao.insertHr(rows)
+    suspend fun insertHr(rows: List<HrSample>): List<Long> {
+        val ids = dao.insertHr(rows)
+        publishReadoutRevisions(InsertCounts(hr = ids.countInserted()))
+        return ids
+    }
 
     suspend fun latestHrSampleTs(deviceId: String): Long? = dao.latestHrSampleTs(deviceId)
     suspend fun latestHr(deviceId: String): HrSample? = dao.latestHr(deviceId)

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -128,9 +128,10 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
 
     val repo: WhoopRepository get() = repository
 
-    /** The registry's active strap id (the same id the read path resolves to). Public so the Test Centre
-     *  can read the right source for the CAPTURE-D data-volume snapshot. */
-    val activeStrapId: String get() = deviceId
+    /** The registry's active strap id (the same id the read path resolves to). The getter stays source
+     * compatible for existing call sites; reactive screens collect [activeStrapIdFlow]. */
+    val activeStrapId: String get() = noopApp.sourceCoordinator.activeDeviceId.value ?: noopApp.activeDeviceId
+    val activeStrapIdFlow: StateFlow<String?> get() = noopApp.sourceCoordinator.activeDeviceId
 
     // MARK: - Devices screen (multi-source Phase 1B)
     //
@@ -169,8 +170,11 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
      *  (a no-op for a single-WHOOP install). Mirrors macOS DevicesView's `registry.setActive`. */
     suspend fun setActiveDevice(id: String) {
         noopApp.deviceRegistry.setActive(id)
-        noopApp.sourceCoordinator.onActiveDeviceChanged(id)
-        refreshActiveDeviceName()
+        // Publish only after BOTH authoritative mutations succeed. A registry/coordinator failure leaves
+        // observers on the last fully-applied id instead of advertising a half-switched source.
+        if (noopApp.sourceCoordinator.reconcileActiveDevice(id)) {
+            refreshActiveDeviceName()
+        }
     }
 
     /** The active band's display name (nickname, else collapsed brand+model), surfaced on the Live screen

--- a/android/app/src/main/java/com/noop/ui/TestCentreLiveReadouts.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreLiveReadouts.kt
@@ -1,0 +1,148 @@
+package com.noop.ui
+
+import com.noop.analytics.BatteryEstimator
+import com.noop.analytics.ConnectionReadout
+import com.noop.analytics.DisplayReadout
+import com.noop.analytics.ImportReadout
+import com.noop.analytics.SleepReadout
+import com.noop.analytics.StepsReadout
+import com.noop.analytics.TestReadout
+import com.noop.analytics.WorkoutsReadout
+import com.noop.data.GravitySample
+import com.noop.data.HrSample
+import com.noop.testcentre.TestDomain
+import com.noop.testcentre.TestMode
+import java.util.Locale
+import kotlin.math.roundToInt
+
+/** Inputs shared by the Test Centre row and its report: the exported tagged log, plus the small set of
+ * live values that are not log-derived. Repository-backed samples are loaded only while their row is on. */
+internal data class TestCentreLiveSnapshot(
+    val logText: String = "",
+    val nowUnix: Long = System.currentTimeMillis() / 1_000,
+    val connected: Boolean = false,
+    val batteryPct: Double? = null,
+    val batteryEstimate: BatteryEstimator.Estimate? = null,
+    val hrSamples: List<HrSample> = emptyList(),
+    val gravitySamples: List<GravitySample> = emptyList(),
+)
+
+internal data class LiveReadoutRow(val id: String, val label: String, val value: String)
+
+/** Observable inputs an active row subscribes to. Null/false means no collector or clock exists. */
+internal data class LiveReadoutRefreshSources(
+    val observeLogRevision: Boolean = false,
+    val observeSleepSampleRevision: Boolean = false,
+    val observeBatteryRevision: Boolean = false,
+    val connectionClockEveryMs: Long? = null,
+)
+
+internal object TestCentreLiveRefreshPolicy {
+    fun sources(mode: TestMode, active: Boolean): LiveReadoutRefreshSources {
+        if (!active) return LiveReadoutRefreshSources()
+        return LiveReadoutRefreshSources(
+            observeLogRevision = mode.liveReadout.isNotEmpty(),
+            observeSleepSampleRevision = mode.domain == TestDomain.SLEEP,
+            observeBatteryRevision = mode.domain == TestDomain.BATTERY,
+            connectionClockEveryMs = 1_000L.takeIf { mode.domain == TestDomain.CONNECTION },
+        )
+    }
+}
+
+/** Exhaustive presentation mapping for every declarative [TestMode.liveReadout] id. Unknown active ids
+ * fail loudly instead of silently disappearing; inactive modes return before parsing or formatting. */
+internal object TestCentreLiveReadouts {
+    val mappedIds: Set<String> = setOf(
+        "hrDensityNow", "gravityCoverageNow", "lastNightGateFired",
+        "connectionUptime", "reconnectCount", "lastOffloadResult",
+        "lastSessionSummary", "deviceMetricsNow", "lastImportSummary",
+        "stepsToday", "calibrationState",
+        "currentSoc", "estimateDaysLeft", "slopeSource",
+        "lastChargeBreakdown", "lastHrvComputation",
+    )
+
+    fun rows(mode: TestMode, active: Boolean, snapshot: TestCentreLiveSnapshot): List<LiveReadoutRow> {
+        if (!active) return emptyList()
+        val tail by lazy { taggedTail(snapshot.logText, mode.id) }
+        return mode.liveReadout.map { id ->
+            require(id in mappedIds) { "Unmapped Test Centre liveReadout id: $id" }
+            when (id) {
+                "hrDensityNow" -> LiveReadoutRow(
+                    id, "HR density (per min)",
+                    if (snapshot.hrSamples.isEmpty()) "no live HR yet"
+                    else String.format(Locale.US, "%.1f", SleepReadout.hrDensityPerMinute(snapshot.hrSamples)),
+                )
+                "gravityCoverageNow" -> LiveReadoutRow(
+                    id, "Gravity coverage",
+                    if (snapshot.gravitySamples.isEmpty()) "no live gravity yet"
+                    else String.format(
+                        Locale.US, "%.0f%%",
+                        SleepReadout.gravityCoverageFraction(snapshot.gravitySamples, snapshot.hrSamples) * 100,
+                    ),
+                )
+                "lastNightGateFired" -> LiveReadoutRow(
+                    id, "Last gate fired", SleepReadout.lastGateFired(tail) ?: "no night yet",
+                )
+                "connectionUptime" -> LiveReadoutRow(
+                    id, "Connection uptime",
+                    if (snapshot.connected) ConnectionReadout.uptimeLabel(tail, snapshot.nowUnix)
+                    else "not connected",
+                )
+                "reconnectCount" -> LiveReadoutRow(
+                    id, "Reconnects this run", ConnectionReadout.reconnectCount(tail).toString(),
+                )
+                "lastOffloadResult" -> LiveReadoutRow(
+                    id, "Last offload result", ConnectionReadout.lastOffloadResult(tail) ?: "no offload yet",
+                )
+                "lastSessionSummary" -> LiveReadoutRow(
+                    id, "Last session", WorkoutsReadout.lastSessionSummary(tail) ?: "no session yet",
+                )
+                "deviceMetricsNow" -> LiveReadoutRow(
+                    id, "Device metrics", DisplayReadout.deviceMetricsNow(tail) ?: "reading...",
+                )
+                "lastImportSummary" -> LiveReadoutRow(
+                    id, "Last import", ImportReadout.lastImportSummary(tail) ?: "no import yet",
+                )
+                "stepsToday" -> LiveReadoutRow(
+                    id, "Steps today", StepsReadout.stepsToday(tail)?.toString() ?: "no estimate yet",
+                )
+                "calibrationState" -> LiveReadoutRow(
+                    id, "Calibration", StepsReadout.calibrationState(tail) ?: "no calibration yet",
+                )
+                "currentSoc" -> LiveReadoutRow(
+                    id, "Current charge", snapshot.batteryPct?.let { "${it.roundToInt()}%" } ?: "--",
+                )
+                "estimateDaysLeft" -> LiveReadoutRow(
+                    id, "Estimated runtime left",
+                    snapshot.batteryEstimate?.let { BatteryEstimator.label(it.remainingHours) } ?: "--",
+                )
+                "slopeSource" -> LiveReadoutRow(
+                    id, "Slope source",
+                    snapshot.batteryEstimate?.source?.name?.lowercase(Locale.US) ?: "--",
+                )
+                "lastChargeBreakdown" -> LiveReadoutRow(
+                    id, "Last Charge breakdown",
+                    TestReadout.lastChargeBreakdown(tail) ?: "no night scored yet",
+                )
+                "lastHrvComputation" -> LiveReadoutRow(
+                    id, "Last HRV reading", TestReadout.lastHrvComputation(tail) ?: "no reading yet",
+                )
+                else -> error("mapped id has no renderer: $id")
+            }
+        }
+    }
+
+    private fun taggedTail(logText: String, domainId: String): List<String> {
+        return logText.lineSequence().filter { line ->
+            firstDomainTag.find(line)?.groupValues?.get(1) == domainId
+        }.toList()
+    }
+
+    // Match only a real leading TestDomain marker: raw test lines start with it; exported production lines
+    // put it immediately after their time/date stamp. Arbitrary payload text before `[recovery]` is not a
+    // stamp and cannot turn an otherwise untagged line into Recovery data.
+    private val firstDomainTag = Regex(
+        "^(?:(?:\\d{4}-\\d{2}-\\d{2}[ T])?\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?\\s+)?" +
+            "\\[(${TestDomain.entries.joinToString("|") { Regex.escape(it.id) }})]\\s",
+    )
+}

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -42,11 +43,16 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.noop.BuildConfig
 import com.noop.analytics.Baselines
+import com.noop.analytics.BatteryEstimator
 import com.noop.analytics.HRVReadiness
 import com.noop.analytics.ReadinessTier
+import com.noop.ble.LiveState
 import com.noop.ble.PuffinExperiment
+import com.noop.ble.WhoopBleClient
 import com.noop.ble.WhoopModel
 import com.noop.data.DailyMetric
+import com.noop.data.GravitySample
+import com.noop.data.HrSample
 import com.noop.polar.PolarModel
 import com.noop.testcentre.CaptureAccumulator
 import com.noop.testcentre.CaptureKind
@@ -60,6 +66,9 @@ import com.noop.testcentre.TestMode
 import com.noop.testcentre.TestModeRegistry
 import com.noop.testcentre.TestReportFlow
 import com.noop.testcentre.TestReportLink
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
@@ -80,6 +89,8 @@ fun TestCentreScreen(vm: AppViewModel) {
 
     // The strap model the Settings #22 gate reads, mirrored here so the 5/MG block shows for a 5/MG only.
     val live by vm.live.collectAsStateWithLifecycle()
+    val publishedActiveStrapId by vm.activeStrapIdFlow.collectAsStateWithLifecycle()
+    val activeStrapId = publishedActiveStrapId ?: vm.activeStrapId
     val selectedModelName = remember {
         NoopPrefs.of(context).getString("noop.selectedWhoopModel", null)
     }
@@ -134,10 +145,10 @@ fun TestCentreScreen(vm: AppViewModel) {
                         mode = mode,
                         active = testCentre.active(mode.domain),
                         startedAtSeconds = testCentre.startedAt(mode.domain),
-                        // #965: the shareable strap log the report exports, so the row's "K of N" is the
-                        // HONEST per-mode captured-day count (CaptureAccumulator), not an elapsed-clock proxy.
-                        // Recomputes with `live` (collected above) so the count updates as new days land.
-                        logText = vm.ble.exportLogText(),
+                        live = live,
+                        activeStrapId = activeStrapId,
+                        is5MG = is5MG,
+                        vm = vm,
                         onToggle = { on ->
                             if (on) testCentre.activate(mode.domain) else testCentre.deactivate(mode.domain)
                             // Display & Performance owns a live frame monitor. It must run ONLY while the
@@ -294,12 +305,19 @@ private fun TestModeRow(
     mode: TestMode,
     active: Boolean,
     startedAtSeconds: Long?,
-    logText: String,
+    live: LiveState,
+    activeStrapId: String,
+    is5MG: Boolean,
+    vm: AppViewModel,
     onToggle: (Boolean) -> Unit,
     onReport: () -> Unit,
 ) {
     var on by remember { mutableStateOf(active) }
     val elapsed = startedAtSeconds?.let { (System.currentTimeMillis() / 1000.0) - it }
+    val refreshSources = TestCentreLiveRefreshPolicy.sources(mode, on)
+    // An active row observes the log's own revision, coalesced during bursty offloads. An inactive row
+    // creates no collector and never snapshots/export-formats the log.
+    val logText = if (refreshSources.observeLogRevision) rememberActiveLogText(vm.ble) else ""
     // #965: HONEST per-mode captured-day count for a guided row (distinct days THIS mode produced its own
     // trace on), read from the same log the report exports, so each active mode accumulates its OWN count
     // instead of every guided row sharing one elapsed number. null for a toggle mode (no "K of N") / when off.
@@ -331,6 +349,16 @@ private fun TestModeRow(
             )
         }
         Text(mode.blurb, style = NoopType.footnote, color = Palette.textTertiary)
+        if (on) {
+            TestCentreLiveReadoutPanel(
+                mode = mode,
+                logText = logText,
+                live = live,
+                is5MG = is5MG,
+                activeStrapId = activeStrapId,
+                vm = vm,
+            )
+        }
         Row {
             Spacer(Modifier.weight(1f))
             TextButton(onClick = onReport) {
@@ -338,6 +366,115 @@ private fun TestModeRow(
             }
         }
     }
+}
+
+/** Registry-driven live diagnostics for an active test row. The common presentation mapping is pure and
+ * JVM-tested; only Sleep and Battery need a small repository snapshot, loaded here while the row is on.
+ * Since this composable does not exist for an inactive row, inactive modes do no parsing or store reads. */
+@Composable
+private fun TestCentreLiveReadoutPanel(
+    mode: TestMode,
+    logText: String,
+    live: LiveState,
+    is5MG: Boolean,
+    activeStrapId: String,
+    vm: AppViewModel,
+) {
+    var hrSamples by remember(mode.id) { mutableStateOf(emptyList<HrSample>()) }
+    var gravitySamples by remember(mode.id) { mutableStateOf(emptyList<GravitySample>()) }
+    var batteryEstimate by remember(mode.id) { mutableStateOf<BatteryEstimator.Estimate?>(null) }
+    var nowUnix by remember(mode.id) { mutableStateOf(System.currentTimeMillis() / 1_000) }
+    val sources = TestCentreLiveRefreshPolicy.sources(mode, active = true)
+    val sleepRevision = if (sources.observeSleepSampleRevision) {
+        boundedRevision(vm.repo.sleepSampleRevision, coalesceMs = 250)
+    } else {
+        0L
+    }
+    val batteryRevision = if (sources.observeBatteryRevision) {
+        boundedRevision(vm.repo.batteryRevision, coalesceMs = 500)
+    } else {
+        0L
+    }
+
+    // Sleep reloads only after Room reports a successful HR/gravity insert or the active strap changes.
+    // Same-BPM HR and gravity-only inserts therefore refresh even when LiveState itself stays equal.
+    LaunchedEffect(mode.domain, activeStrapId, sleepRevision) {
+        if (mode.domain != TestDomain.SLEEP) return@LaunchedEffect
+        val now = System.currentTimeMillis() / 1_000
+        val from = now - 60 * 60
+        hrSamples = runCatching {
+            vm.repo.hrSamples(activeStrapId, from, now, limit = 10_000)
+        }.getOrDefault(emptyList())
+        gravitySamples = runCatching {
+            vm.repo.gravitySamples(activeStrapId, from, now, limit = 10_000)
+        }.getOrDefault(emptyList())
+    }
+
+    // Battery has its own event source and keys. It is deliberately not keyed on HR or Sleep revisions.
+    LaunchedEffect(mode.domain, activeStrapId, batteryRevision, live.batteryPct, is5MG, live.charging) {
+        if (mode.domain != TestDomain.BATTERY) return@LaunchedEffect
+        val now = System.currentTimeMillis() / 1_000
+        val from = now - 14L * 86_400
+        val samples = runCatching {
+            vm.repo.batterySamples(activeStrapId, from, now, limit = 2_000)
+                .mapNotNull { sample -> sample.soc?.let { sample.ts to it } }
+        }.getOrDefault(emptyList())
+        val rated = if (is5MG) BatteryEstimator.ratedLifeHoursWhoop5
+            else BatteryEstimator.ratedLifeHoursWhoop4
+        batteryEstimate = BatteryEstimator.estimate(samples, rated)
+    }
+
+    // Only Connection uptime needs wall-clock movement. Other modes create no timer.
+    LaunchedEffect(sources.connectionClockEveryMs) {
+        val everyMs = sources.connectionClockEveryMs ?: return@LaunchedEffect
+        while (isActive) {
+            nowUnix = System.currentTimeMillis() / 1_000
+            delay(everyMs)
+        }
+    }
+
+    val rows = TestCentreLiveReadouts.rows(
+        mode = mode,
+        active = true,
+        snapshot = TestCentreLiveSnapshot(
+            logText = logText,
+            nowUnix = nowUnix,
+            connected = live.connected,
+            batteryPct = live.batteryPct,
+            batteryEstimate = batteryEstimate,
+            hrSamples = hrSamples,
+            gravitySamples = gravitySamples,
+        ),
+    )
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp), modifier = Modifier.padding(top = 2.dp)) {
+        rows.forEach { row ->
+            Row(Modifier.fillMaxWidth()) {
+                Text(row.label, style = NoopType.footnote, color = Palette.textTertiary)
+                Spacer(Modifier.weight(1f))
+                Text(row.value, style = NoopType.mono, color = Palette.textSecondary)
+            }
+        }
+    }
+}
+
+/** Collect a monotonic source revision while this call is in composition. During an offload burst the
+ * collector emits at most once per [coalesceMs], always converging on the newest revision. No source event,
+ * no wake-up; this is event-driven throttling, not polling. */
+@Composable
+private fun boundedRevision(flow: StateFlow<Long>, coalesceMs: Long): Long {
+    val revision by produceState(initialValue = flow.value, flow, coalesceMs) {
+        flow.collect { next ->
+            value = next
+            delay(coalesceMs)
+        }
+    }
+    return revision
+}
+
+@Composable
+private fun rememberActiveLogText(ble: WhoopBleClient): String {
+    val revision = boundedRevision(ble.logRevision, coalesceMs = 250)
+    return remember(ble, revision) { ble.exportLogText() }
 }
 
 @Composable

--- a/android/app/src/test/java/com/noop/ble/SourceCoordinatorAdoptionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/SourceCoordinatorAdoptionTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -148,6 +149,13 @@ class SourceCoordinatorAdoptionTest {
         peripheralId = peripheralId,
     )
 
+    private fun strapRow(id: String, peripheralId: String) = PairedDeviceRow(
+        id = id, brand = "Polar", model = "H10", nickname = null,
+        sourceKind = SourceKind.liveBLE.name, capabilities = "hr",
+        status = DeviceStatus.paired.name, addedAt = 200, lastSeenAt = 200,
+        peripheralId = peripheralId,
+    )
+
     private fun coordinatorOver(dao: FakeRegistryDao, log: (String) -> Unit = {}): SourceCoordinator =
         SourceCoordinator(
             context = null,                       // adoption path never reaches switchToStrap
@@ -174,6 +182,74 @@ class SourceCoordinatorAdoptionTest {
         stopWhoop = stops,
         scope = CoroutineScope(Dispatchers.Unconfined),
     )
+
+    private fun ouraAdoptionCoordinatorOver(dao: FakeRegistryDao): SourceCoordinator = SourceCoordinator(
+        context = null,
+        registry = registryWith(dao),
+        repository = null,
+        liveSink = { _, _ -> },
+        startWhoop = {},
+        stopWhoop = {},
+        scope = CoroutineScope(Dispatchers.Unconfined),
+        migrateOuraInstallKey = { _, _ -> },
+    )
+
+    @Test
+    fun awaitedReconcileReturnsTrueAfterSuccessIncludingSameId() = runBlocking {
+        val dao = FakeRegistryDao().apply {
+            devices["whoop-a"] = whoopRow("whoop-a", peripheralId = "AA:BB:CC:DD:EE:01")
+        }
+        val coordinator = coordinatorOver(dao)
+
+        assertNull(coordinator.activeDeviceId.value)
+        assertTrue(coordinator.reconcileActiveDevice("whoop-a"))
+        assertEquals("whoop-a", coordinator.activeDeviceId.value)
+        assertTrue("an already-reconciled id is still a successful completion", coordinator.reconcileActiveDevice("whoop-a"))
+        assertEquals("same-id success must keep the single published source stable", "whoop-a", coordinator.activeDeviceId.value)
+    }
+
+    @Test
+    fun awaitedReconcileReturnsFalseWhenStrapActivationFails() = runBlocking {
+        val dao = FakeRegistryDao().apply {
+            devices["whoop-a"] = whoopRow("whoop-a", peripheralId = "AA:BB:CC:DD:EE:01")
+            devices["polar-b"] = strapRow("polar-b", peripheralId = "11:22:33:44:55:66")
+        }
+        val coordinator = coordinatorOver(dao)
+
+        assertTrue(coordinator.reconcileActiveDevice("whoop-a"))
+        assertEquals("whoop-a", coordinator.activeDeviceId.value)
+        assertFalse(
+            "completion must report the context-less makeSource activation failure",
+            coordinator.reconcileActiveDevice("polar-b"),
+        )
+        assertEquals("a failed switch must never publish its requested id", "whoop-a", coordinator.activeDeviceId.value)
+    }
+
+    @Test
+    fun ouraSerialAdoptionPublishesReconciledStableId() = runBlocking {
+        val transientId = "oura-transient-address"
+        val stableId = "oura-S12345678"
+        val dao = FakeRegistryDao().apply {
+            // The direct adoption callback is under test. A liveBLE-shaped row keeps this plain-JVM
+            // harness off Android BLE while exercising the real registry re-key + internal reconcile.
+            devices[transientId] = whoopRow(transientId, peripheralId = "AA:BB:CC:DD:EE:01")
+        }
+        val coordinator = ouraAdoptionCoordinatorOver(dao)
+        assertTrue(coordinator.reconcileActiveDevice(transientId))
+        assertEquals(transientId, coordinator.activeDeviceId.value)
+
+        SourceCoordinator::class.java
+            .getDeclaredMethod("adoptOuraSerial", String::class.java, String::class.java)
+            .apply { isAccessible = true }
+            .invoke(coordinator, transientId, "S12345678")
+
+        assertEquals(stableId, dao.activeDeviceId())
+        assertEquals(
+            "the Oura-internal A→S path must reach the same success-only publication as UI selection",
+            stableId,
+            coordinator.activeDeviceId.value,
+        )
+    }
 
     @Test
     fun nullPeripheralIdRowAdoptsConnectedAddress() = runBlocking {

--- a/android/app/src/test/java/com/noop/data/ReadoutDataRevisionTest.kt
+++ b/android/app/src/test/java/com/noop/data/ReadoutDataRevisionTest.kt
@@ -1,0 +1,29 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReadoutDataRevisionTest {
+
+    @Test fun revisionsAdvanceOnlyForSuccessfullyInsertedRelevantRows() {
+        val initial = ReadoutDataRevisions(sleepSamples = 7, battery = 11)
+
+        assertEquals(initial, advanceReadoutDataRevisions(initial, InsertCounts()))
+        assertEquals(
+            ReadoutDataRevisions(sleepSamples = 8, battery = 11),
+            advanceReadoutDataRevisions(initial, InsertCounts(hr = 1)),
+        )
+        assertEquals(
+            ReadoutDataRevisions(sleepSamples = 8, battery = 11),
+            advanceReadoutDataRevisions(initial, InsertCounts(gravity = 2)),
+        )
+        assertEquals(
+            ReadoutDataRevisions(sleepSamples = 7, battery = 12),
+            advanceReadoutDataRevisions(initial, InsertCounts(battery = 1)),
+        )
+        assertEquals(
+            ReadoutDataRevisions(sleepSamples = 8, battery = 12),
+            advanceReadoutDataRevisions(initial, InsertCounts(hr = 1, gravity = 1, battery = 1)),
+        )
+    }
+}

--- a/android/app/src/test/java/com/noop/ui/TestCentreLiveReadoutsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/TestCentreLiveReadoutsTest.kt
@@ -1,0 +1,110 @@
+package com.noop.ui
+
+import com.noop.testcentre.TestDomain
+import com.noop.testcentre.TestModeRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TestCentreLiveReadoutsTest {
+
+    @Test fun activeRecoveryRowRendersChargeLabelAndParsedValueFromExportLog() {
+        val mode = requireNotNull(TestModeRegistry.mode(TestDomain.RECOVERY))
+        val rows = TestCentreLiveReadouts.rows(
+            mode = mode,
+            active = true,
+            snapshot = TestCentreLiveSnapshot(
+                logText = "[recovery] charge day=2026-08-19 score=62.5 band=yellow",
+            ),
+        )
+
+        assertEquals(
+            listOf(LiveReadoutRow("lastChargeBreakdown", "Last Charge breakdown", "score=62.5 band=yellow")),
+            rows,
+        )
+    }
+
+    @Test fun recoveryUsesTheFirstRealDomainTagAndRejectsEmbeddedTagSpoofing() {
+        val mode = requireNotNull(TestModeRegistry.mode(TestDomain.RECOVERY))
+        val rows = TestCentreLiveReadouts.rows(
+            mode = mode,
+            active = true,
+            snapshot = TestCentreLiveSnapshot(
+                logText = listOf(
+                    "2026-08-19 12:00:00 [recovery] charge day=2026-08-19 score=62.5 band=yellow",
+                    "[connection] payload=[recovery] charge day=2026-08-20 score=99.0 band=green",
+                    "message payload=[recovery] charge day=2026-08-21 score=100.0 band=green",
+                ).joinToString("\n"),
+            ),
+        )
+
+        assertEquals("score=62.5 band=yellow", rows.single().value)
+    }
+
+    @Test fun everyRegistryDeclaredIdHasExactlyOnePresentationMapping() {
+        val declared = TestModeRegistry.all.flatMap { it.liveReadout }.toSet()
+        assertEquals(16, declared.size)
+        assertEquals(declared, TestCentreLiveReadouts.mappedIds)
+
+        TestModeRegistry.all.forEach { mode ->
+            assertEquals(
+                mode.liveReadout,
+                TestCentreLiveReadouts.rows(
+                    mode = mode,
+                    active = true,
+                    snapshot = TestCentreLiveSnapshot(),
+                ).map { it.id },
+            )
+        }
+    }
+
+    @Test fun inactiveRowIsCompactAndDoesNotResolveEvenAnUnknownReadout() {
+        val futureMode = requireNotNull(TestModeRegistry.mode(TestDomain.RECOVERY))
+            .copy(liveReadout = listOf("futureReadout"))
+
+        assertTrue(
+            TestCentreLiveReadouts.rows(
+                mode = futureMode,
+                active = false,
+                snapshot = TestCentreLiveSnapshot(),
+            ).isEmpty(),
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun activeUnknownReadoutFailsVisiblyInsteadOfDisappearing() {
+        val futureMode = requireNotNull(TestModeRegistry.mode(TestDomain.RECOVERY))
+            .copy(liveReadout = listOf("futureReadout"))
+
+        TestCentreLiveReadouts.rows(
+            mode = futureMode,
+            active = true,
+            snapshot = TestCentreLiveSnapshot(),
+        )
+    }
+
+    @Test fun refreshPolicyIsActiveOnlyAndObservesOnlyRelevantSourceRevisions() {
+        val recovery = requireNotNull(TestModeRegistry.mode(TestDomain.RECOVERY))
+        val connection = requireNotNull(TestModeRegistry.mode(TestDomain.CONNECTION))
+        val sleep = requireNotNull(TestModeRegistry.mode(TestDomain.SLEEP))
+        val battery = requireNotNull(TestModeRegistry.mode(TestDomain.BATTERY))
+
+        assertEquals(LiveReadoutRefreshSources(), TestCentreLiveRefreshPolicy.sources(recovery, active = false))
+        assertEquals(
+            LiveReadoutRefreshSources(observeLogRevision = true),
+            TestCentreLiveRefreshPolicy.sources(recovery, active = true),
+        )
+        assertEquals(
+            LiveReadoutRefreshSources(observeLogRevision = true, connectionClockEveryMs = 1_000),
+            TestCentreLiveRefreshPolicy.sources(connection, active = true),
+        )
+        assertEquals(
+            LiveReadoutRefreshSources(observeLogRevision = true, observeSleepSampleRevision = true),
+            TestCentreLiveRefreshPolicy.sources(sleep, active = true),
+        )
+        assertEquals(
+            LiveReadoutRefreshSources(observeLogRevision = true, observeBatteryRevision = true),
+            TestCentreLiveRefreshPolicy.sources(battery, active = true),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- render every registry-declared live readout for the active Android Test Centre mode while keeping inactive rows compact and idle
- refresh from the current log, repository, and live-state sources with bounded source-specific collectors
- use one success-only active-device flow across normal switches and Oura serial adoption, preserving the previous source after failed reconciliation
- add executable mapping, refresh-policy, revision, spoof-resistance, and adoption regression tests

## Verification

- RED: missing presentation boundary failed compilation on the unchanged product path
- RED: stale log/store refresh contracts failed compilation before implementation
- RED: embedded untagged recovery marker selected score 100 instead of the genuine score 62.5
- RED: awaited reconciliation and the shared active-device flow were absent before implementation
- focused SourceCoordinator adoption tests: pass
- affected Android suites: pass
- full `:app:testFullDebugUnitTest`: 4,101 tests, 6 skipped, 0 failures, 0 errors
- `git diff --check`: clean

All Android runs were serial and bounded: JDK 17, no daemon, one worker, no parallel execution, Kotlin in-process, 1536 MiB heap.

Tracks https://github.com/bhelm/noop/issues/82