### PR TITLE
fix(steps): count usable calibration samples

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StepsEstimateEngine+Trace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StepsEstimateEngine+Trace.swift
@@ -41,7 +41,7 @@ extension StepsEstimateEngine {
 
         // Per-usable-day points: the SAME filter the fit applies (motion >= minMotionForFit && steps > 0),
         // so the trace shows exactly the days that voted. Phone reference count is the calibration anchor.
-        let usable = points.filter { $0.motion >= minMotionForFit && $0.steps > 0 }
+        let usable = points.filter(isUsableCalibrationPoint)
         for p in usable {
             let ratio = p.motion > 0 ? p.steps / p.motion : 0
             lines.append("stepsCal point motion=\(r2(p.motion)) phoneRef=\(Int(p.steps)) "
@@ -50,9 +50,10 @@ extension StepsEstimateEngine {
 
         // The calibration outcome, read from calibrate(...) verbatim so it matches the stored coefficient.
         if let cal = calibrate(points, manualOverride: manualOverride), usable.count >= minCalibrationDays || cal.manual {
+            let source = cal.manual ? "user-set k" : "k = motion-weighted median of steps/motion"
             lines.append("stepsCal fit k=\(r2(cal.coefficient)) sampleDays=\(cal.sampleDays) "
                 + "confidence=\(r2(cal.confidence)) manual=\(cal.manual) "
-                + "(k = motion-weighted median of steps/motion)")
+                + "(\(source))")
         } else {
             // Withheld: name the status the tile shows (the "need N more days" reason), via status(...)
             // verbatim so the trace explains the blank tile with the SAME usable-day filter.

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StepsEstimateEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StepsEstimateEngine.swift
@@ -51,7 +51,7 @@ public enum StepsEstimateEngine {
     public struct Calibration: Equatable {
         /// Steps per unit of motion.
         public let coefficient: Double
-        /// How many days fed the auto-fit (0 when purely manual).
+        /// How many usable auto-fit days exist alongside this model (0 when none).
         public let sampleDays: Int
         /// 0–1: how much to trust the estimate, from sample size and fit spread. 1.0 for a user-set manual `k`.
         public let confidence: Double
@@ -177,7 +177,7 @@ public enum StepsEstimateEngine {
     /// days (same filter the fit uses) and report `.calibrated` once `minCalibrationDays` are met, else
     /// `.needsMoreDays`. Mirror of the Kotlin `status(...)`.
     public static func status(_ points: [CalibrationPoint], manualOverride: Double? = nil) -> CalibrationStatus {
-        let usableDays = points.filter { $0.motion >= minMotionForFit && $0.steps > 0 }.count
+        let usableDays = points.filter(isUsableCalibrationPoint).count
         if let k = manualOverride, k > 0 {
             return .manual(coefficient: k, sampleDays: usableDays)
         }
@@ -214,12 +214,12 @@ public enum StepsEstimateEngine {
     /// volume. Returns nil when there aren't enough usable days AND no manual override is supplied. A non-nil
     /// `manualOverride` always wins (confidence 1.0) — for users with no phone step data.
     public static func calibrate(_ points: [CalibrationPoint], manualOverride: Double? = nil) -> Calibration? {
+        let usable = points.filter(isUsableCalibrationPoint)
         if let k = manualOverride, k > 0 {
-            return Calibration(coefficient: k, sampleDays: points.count, confidence: 1.0, manual: true)
+            return Calibration(coefficient: k, sampleDays: usable.count, confidence: 1.0, manual: true)
         }
         // Usable days carry (ratio, weight) where weight = motion volume: a busier day votes harder.
-        let weighted = points
-            .filter { $0.motion >= minMotionForFit && $0.steps > 0 }
+        let weighted = usable
             .map { (ratio: $0.steps / $0.motion, weight: $0.motion) }
         guard weighted.count >= minCalibrationDays else { return nil }
         let ratios = weighted.map { $0.ratio }
@@ -248,6 +248,10 @@ public enum StepsEstimateEngine {
     }
 
     // MARK: - Helpers
+
+    static func isUsableCalibrationPoint(_ point: CalibrationPoint) -> Bool {
+        point.motion >= minMotionForFit && point.steps > 0
+    }
 
     static func median(_ xs: [Double]) -> Double {
         guard !xs.isEmpty else { return 0 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StepsEstimateEngineTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StepsEstimateEngineTests.swift
@@ -92,6 +92,22 @@ final class StepsEstimateEngineTests: XCTestCase {
         XCTAssertEqual(cal!.confidence, 1.0)
     }
 
+    func testManualOverrideCountsOnlyUsableCalibrationDays() {
+        let points = [
+            StepsEstimateEngine.CalibrationPoint(motion: 0.5, steps: 500),
+            StepsEstimateEngine.CalibrationPoint(motion: 10, steps: 0),
+            StepsEstimateEngine.CalibrationPoint(motion: 10, steps: 1_000),
+        ]
+
+        let cal = StepsEstimateEngine.calibrate(points, manualOverride: 9.5)
+        XCTAssertEqual(cal?.coefficient, 9.5)
+        XCTAssertEqual(cal?.sampleDays, 1)
+        XCTAssertEqual(cal?.confidence, 1.0)
+        XCTAssertEqual(cal?.manual, true)
+        XCTAssertEqual(StepsEstimateEngine.status(points, manualOverride: 9.5),
+                       .manual(coefficient: 9.5, sampleDays: 1))
+    }
+
     func testTightFitMoreConfidentThanScattered() {
         let tight = (0..<14).map { _ in StepsEstimateEngine.CalibrationPoint(motion: 10, steps: 1000) }
         let scattered = (0..<14).map { i in

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StepsEstimateEngineTraceTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StepsEstimateEngineTraceTests.swift
@@ -164,6 +164,25 @@ final class StepsEstimateEngineTraceTests: XCTestCase {
         XCTAssertNotNil(fitLine)
         XCTAssertTrue(fitLine!.contains("manual=true"))
         XCTAssertTrue(fitLine!.contains("k=9.5"))
+        XCTAssertTrue(fitLine!.contains("sampleDays=1"))
+        XCTAssertTrue(fitLine!.contains("(user-set k)"))
+        XCTAssertFalse(fitLine!.contains("motion-weighted median"))
+    }
+
+    func testManualOverrideTraceUsesTheSingleUsablePointAndUserSetSource() {
+        let points = [
+            StepsEstimateEngine.CalibrationPoint(motion: 0.5, steps: 500),
+            StepsEstimateEngine.CalibrationPoint(motion: 10, steps: 0),
+            StepsEstimateEngine.CalibrationPoint(motion: 10, steps: 1_000),
+        ]
+
+        XCTAssertEqual(
+            StepsEstimateEngine.calibrationTrace(points: points, manualOverride: 9.5),
+            [
+                "stepsCal point motion=10.0 phoneRef=1000 ratio=100.0 (steps/motion votes weighted by motion)",
+                "stepsCal fit k=9.5 sampleDays=1 confidence=1.0 manual=true (user-set k)",
+            ]
+        )
     }
 
     // MARK: - Readout parsers

--- a/android/app/src/main/java/com/noop/analytics/StepsEstimateEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/StepsEstimateEngine.kt
@@ -39,6 +39,7 @@ object StepsEstimateEngine {
     /** The fitted (or manually-set) personal model. */
     data class Calibration(
         val coefficient: Double,
+        /** How many usable auto-fit days exist alongside this model (0 when none). */
         val sampleDays: Int,
         val confidence: Double,
         val manual: Boolean,
@@ -142,7 +143,7 @@ object StepsEstimateEngine {
      * are met, else [CalibrationStatus.NeedsMoreDays]. Mirror of Swift `status(...)`.
      */
     fun status(points: List<CalibrationPoint>, manualOverride: Double? = null): CalibrationStatus {
-        val usableDays = points.count { it.motion >= MIN_MOTION_FOR_FIT && it.steps > 0 }
+        val usableDays = points.count(::isUsableCalibrationPoint)
         if (manualOverride != null && manualOverride > 0) {
             return CalibrationStatus.Manual(manualOverride, usableDays)
         }
@@ -180,12 +181,12 @@ object StepsEstimateEngine {
      * null below MIN_CALIBRATION_DAYS unless a positive [manualOverride] is supplied (which always wins, conf 1).
      */
     fun calibrate(points: List<CalibrationPoint>, manualOverride: Double? = null): Calibration? {
+        val usable = points.filter(::isUsableCalibrationPoint)
         if (manualOverride != null && manualOverride > 0) {
-            return Calibration(manualOverride, points.size, 1.0, manual = true)
+            return Calibration(manualOverride, usable.size, 1.0, manual = true)
         }
         // Usable days carry (ratio, weight) where weight = motion volume: a busier day votes harder.
-        val weighted = points
-            .filter { it.motion >= MIN_MOTION_FOR_FIT && it.steps > 0 }
+        val weighted = usable
             .map { Pair(it.steps / it.motion, it.motion) }
         if (weighted.size < MIN_CALIBRATION_DAYS) return null
         val ratios = weighted.map { it.first }
@@ -211,6 +212,9 @@ object StepsEstimateEngine {
         if (motion < MIN_MOTION_FOR_FIT || calibration.coefficient <= 0) return null
         return Math.round(motion * calibration.coefficient).toInt().coerceIn(0, MAX_DAILY_STEPS)
     }
+
+    internal fun isUsableCalibrationPoint(point: CalibrationPoint): Boolean =
+        point.motion >= MIN_MOTION_FOR_FIT && point.steps > 0
 
     internal fun median(xs: List<Double>): Double {
         if (xs.isEmpty()) return 0.0

--- a/android/app/src/main/java/com/noop/analytics/StepsEstimateEngineTrace.kt
+++ b/android/app/src/main/java/com/noop/analytics/StepsEstimateEngineTrace.kt
@@ -42,9 +42,7 @@ object StepsEstimateEngineTrace {
         val lines = ArrayList<String>()
 
         // Per-usable-day points: the SAME filter the fit applies, so the trace shows exactly the days that voted.
-        val usable = points.filter {
-            it.motion >= StepsEstimateEngine.MIN_MOTION_FOR_FIT && it.steps > 0
-        }
+        val usable = points.filter(StepsEstimateEngine::isUsableCalibrationPoint)
         for (p in usable) {
             val ratio = if (p.motion > 0) p.steps / p.motion else 0.0
             lines.add(
@@ -56,10 +54,11 @@ object StepsEstimateEngineTrace {
         // The calibration outcome, read from calibrate(...) verbatim so it matches the stored coefficient.
         val cal = StepsEstimateEngine.calibrate(points, manualOverride)
         if (cal != null && (usable.size >= StepsEstimateEngine.MIN_CALIBRATION_DAYS || cal.manual)) {
+            val source = if (cal.manual) "user-set k" else "k = motion-weighted median of steps/motion"
             lines.add(
                 "stepsCal fit k=${r2(cal.coefficient)} sampleDays=${cal.sampleDays} " +
                     "confidence=${r2(cal.confidence)} manual=${cal.manual} " +
-                    "(k = motion-weighted median of steps/motion)",
+                    "($source)",
             )
         } else {
             // Withheld: name the status the tile shows, via status(...) verbatim (SAME usable-day filter).

--- a/android/app/src/test/java/com/noop/analytics/StepsEstimateEngineTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StepsEstimateEngineTest.kt
@@ -75,6 +75,24 @@ class StepsEstimateEngineTest {
         assertEquals(1.0, cal.confidence, 1e-9)
     }
 
+    @Test fun manualOverrideCountsOnlyUsableCalibrationDays() {
+        val points = listOf(
+            p(0.5, 500.0),
+            p(10.0, 0.0),
+            p(10.0, 1_000.0),
+        )
+
+        val cal = StepsEstimateEngine.calibrate(points, manualOverride = 9.5)
+        assertEquals(9.5, cal!!.coefficient, 1e-9)
+        assertEquals(1, cal.sampleDays)
+        assertEquals(1.0, cal.confidence, 1e-9)
+        assertTrue(cal.manual)
+        assertEquals(
+            StepsEstimateEngine.CalibrationStatus.Manual(coefficient = 9.5, sampleDays = 1),
+            StepsEstimateEngine.status(points, manualOverride = 9.5),
+        )
+    }
+
     @Test fun tightFitMoreConfidentThanScattered() {
         val tight = (0 until 14).map { p(10.0, 1000.0) }
         val scattered = (0 until 14).map { i -> p(10.0, (500 + (i % 2) * 1500).toDouble()) }

--- a/android/app/src/test/java/com/noop/analytics/StepsEstimateEngineTraceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StepsEstimateEngineTraceTest.kt
@@ -165,6 +165,25 @@ class StepsEstimateEngineTraceTest {
         val fit = lines.first { it.startsWith("stepsCal fit ") }
         assertTrue(fit.contains("manual=true"))
         assertTrue(fit.contains("k=9.5"))
+        assertTrue(fit.contains("sampleDays=1"))
+        assertTrue(fit.contains("(user-set k)"))
+        assertFalse(fit.contains("motion-weighted median"))
+    }
+
+    @Test fun manualOverrideTraceUsesTheSingleUsablePointAndUserSetSource() {
+        val points = listOf(
+            StepsEstimateEngine.CalibrationPoint(0.5, 500.0),
+            StepsEstimateEngine.CalibrationPoint(10.0, 0.0),
+            StepsEstimateEngine.CalibrationPoint(10.0, 1_000.0),
+        )
+
+        assertEquals(
+            listOf(
+                "stepsCal point motion=10.0 phoneRef=1000 ratio=100.0 (steps/motion votes weighted by motion)",
+                "stepsCal fit k=9.5 sampleDays=1 confidence=1.0 manual=true (user-set k)",
+            ),
+            StepsEstimateEngineTrace.calibrationTrace(points, manualOverride = 9.5),
+        )
     }
 
     // MARK: readout parsers


### PR DESCRIPTION
## Summary

- count only usable motion/steps points in manual calibration sample metadata on Swift and Android
- keep status and persisted calibration metadata aligned with the visible usable-point count
- label manual calibration traces as user-set while preserving the automatic weighted-median path
- add mirrored public mixed-point and all-usable control tests

## Verification

- Swift RED: 37 selected tests, 4 expected assertion failures for sample count and manual trace source
- Kotlin RED: 35 selected tests, 3 expected failures for the same contracts
- Swift focused: 37/37 passed
- Swift full StrandAnalytics: 1,497/1,497 passed
- Kotlin focused: passed
- Kotlin full `:app:testFullDebugUnitTest`: passed
- independent frozen-delta review: no P0-P3 findings
- `git diff --check`: clean

Android execution was serial and bounded: JDK 17, no daemon, one worker, no parallel execution, Kotlin in-process, 1536 MiB heap. Temporary Linux-only Swift build gates were fully reverted before commit.

Tracks https://github.com/bhelm/noop/issues/84