### PR TITLE
fix(steps): distinguish missing day rows

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StepsEstimateEngine+Trace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StepsEstimateEngine+Trace.swift
@@ -95,15 +95,22 @@ extension StepsEstimateEngine {
             .sorted { $0.ts < $1.ts }
 
         var lines: [String] = []
-        // #810: a WHOOP 4.0 sends NO raw step counter over BLE at all, so `sorted` is empty for it; its
+        // #810: a WHOOP 4.0 sends NO raw step counter over BLE at all, so `daySteps` is empty for it; its
         // steps are MOTION-ESTIMATED (the calibrationTrace path), not counted. Emitting the bare
         // "counterSamples=0 (need >=2 for a delta)" line made a 4.0 export read as BROKEN. When there is
         // no counter sample at all, say so honestly so the trace reflects the model, not a fault. (A 5/MG
         // with a single counter sample still falls through to the "need >=2" line: it HAS a counter, just
         // one read this window.) The Kotlin twin emits the same branch first; keep them byte-identical.
-        if sorted.isEmpty {
+        if daySteps.isEmpty {
             lines.append("stepsRaw day=\(dayKey) counterSamples=0 noRawCounter "
                 + "(no step counter on this device; steps are motion-estimated, e.g. WHOOP 4.0)")
+            return lines
+        }
+        // A non-empty input proves a counter exists. If its rows all fall outside the requested local day,
+        // report only that window mismatch; never infer device capability or motion-estimation semantics.
+        if sorted.isEmpty {
+            lines.append("stepsRaw day=\(dayKey) counterSamples=0 inputSamples=\(daySteps.count) noRowsForDay "
+                + "(no counter rows matched the requested local day)")
             return lines
         }
         guard sorted.count >= 2 else {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StepsEstimateEngineTraceTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StepsEstimateEngineTraceTests.swift
@@ -88,9 +88,7 @@ final class StepsEstimateEngineTraceTests: XCTestCase {
     func testFewerThanTwoSamplesReportsNoDelta() {
         let lines = StepsEstimateEngine.rawCounterTrace(
             daySteps: [step(0, 100)], dayKey: dayUtc, tzOffsetSeconds: 0, ticksPerStep: 1.0)
-        XCTAssertEqual(lines.count, 1)
-        XCTAssertTrue(lines[0].contains("counterSamples=1"))
-        XCTAssertTrue(lines[0].contains("need >=2"))
+        XCTAssertEqual(lines, ["stepsRaw day=2026-01-02 counterSamples=1 (need >=2 for a delta)"])
     }
 
     func testEmptyCounterReportsNoRawCounterNotBroken() {
@@ -100,24 +98,26 @@ final class StepsEstimateEngineTraceTests: XCTestCase {
         // emptyCounterReportsNoRawCounterNotBroken.
         let lines = StepsEstimateEngine.rawCounterTrace(
             daySteps: [], dayKey: dayUtc, tzOffsetSeconds: 0, ticksPerStep: 1.0)
-        XCTAssertEqual(lines.count, 1)
-        XCTAssertTrue(lines[0].contains("counterSamples=0"))
-        XCTAssertTrue(lines[0].contains("noRawCounter"))
-        XCTAssertTrue(lines[0].contains("motion-estimated"))
-        XCTAssertFalse(lines[0].contains("need >=2"))  // not the misleading "broken" line
-        XCTAssertFalse(lines[0].contains("\u{2014}"))   // no em-dash
+        XCTAssertEqual(lines, [
+            "stepsRaw day=2026-01-02 counterSamples=0 noRawCounter "
+                + "(no step counter on this device; steps are motion-estimated, e.g. WHOOP 4.0)",
+        ])
     }
 
-    func testEmptyAfterDayFilterAlsoReportsNoRawCounter() {
-        // daySteps has rows, but none fall on the requested day (e.g. all on a neighbouring day). After the
-        // local-day filter the sorted list is empty, so the same honest noRawCounter line is emitted rather
-        // than a broken-looking counterSamples=0 ... need >=2. Twin of the Android
-        // emptyAfterDayFilterAlsoReportsNoRawCounter.
+    func testNonemptyInputWithNoRowsForDayReportsOnlyThatMismatch() {
+        // The supplied rows prove that a raw counter exists; they merely do not match the requested local day.
+        // Never turn that day-window mismatch into a device-capability or motion-estimation claim. Twin of the
+        // Android nonemptyInputWithNoRowsForDayReportsOnlyThatMismatch.
         let otherDay = [step(2 * 86_400, 100), step(2 * 86_400 + 60, 150)]
         let lines = StepsEstimateEngine.rawCounterTrace(
             daySteps: otherDay, dayKey: dayUtc, tzOffsetSeconds: 0, ticksPerStep: 1.0)
-        XCTAssertEqual(lines.count, 1)
-        XCTAssertTrue(lines[0].contains("noRawCounter"))
+        XCTAssertEqual(lines, [
+            "stepsRaw day=2026-01-02 counterSamples=0 inputSamples=2 noRowsForDay "
+                + "(no counter rows matched the requested local day)",
+        ])
+        XCTAssertFalse(lines[0].contains("noRawCounter"))
+        XCTAssertFalse(lines[0].contains("no step counter on this device"))
+        XCTAssertFalse(lines[0].contains("motion-estimated"))
     }
 
     // MARK: - WHOOP-4 calibration trace

--- a/android/app/src/main/java/com/noop/analytics/StepsEstimateEngineTrace.kt
+++ b/android/app/src/main/java/com/noop/analytics/StepsEstimateEngineTrace.kt
@@ -113,10 +113,19 @@ object StepsEstimateEngineTrace {
         // no counter sample at all, say so honestly so the trace reflects the model, not a fault. (A 5/MG
         // with a single counter sample still falls through to the "need >=2" line: it HAS a counter, just
         // one read this window.)
-        if (sorted.isEmpty()) {
+        if (daySteps.isEmpty()) {
             lines.add(
                 "stepsRaw day=$dayKey counterSamples=0 noRawCounter " +
                     "(no step counter on this device; steps are motion-estimated, e.g. WHOOP 4.0)",
+            )
+            return lines
+        }
+        // A non-empty input proves a counter exists. If its rows all fall outside the requested local day,
+        // report only that window mismatch; never infer device capability or motion-estimation semantics.
+        if (sorted.isEmpty()) {
+            lines.add(
+                "stepsRaw day=$dayKey counterSamples=0 inputSamples=${daySteps.size} noRowsForDay " +
+                    "(no counter rows matched the requested local day)",
             )
             return lines
         }

--- a/android/app/src/test/java/com/noop/analytics/StepsEstimateEngineTraceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StepsEstimateEngineTraceTest.kt
@@ -94,9 +94,7 @@ class StepsEstimateEngineTraceTest {
         val lines = StepsEstimateEngineTrace.rawCounterTrace(
             daySteps = listOf(step(0, 100)), dayKey = dayUtc, tzOffsetSeconds = 0L, ticksPerStep = 1.0,
         )
-        assertEquals(1, lines.size)
-        assertTrue(lines[0].contains("counterSamples=1"))
-        assertTrue(lines[0].contains("need >=2"))
+        assertEquals(listOf("stepsRaw day=2026-01-02 counterSamples=1 (need >=2 for a delta)"), lines)
     }
 
     @Test fun emptyCounterReportsNoRawCounterNotBroken() {
@@ -106,24 +104,32 @@ class StepsEstimateEngineTraceTest {
         val lines = StepsEstimateEngineTrace.rawCounterTrace(
             daySteps = emptyList(), dayKey = dayUtc, tzOffsetSeconds = 0L, ticksPerStep = 1.0,
         )
-        assertEquals(1, lines.size)
-        assertTrue(lines[0].contains("counterSamples=0"))
-        assertTrue(lines[0].contains("noRawCounter"))
-        assertTrue(lines[0].contains("motion-estimated"))
-        assertFalse(lines[0].contains("need >=2")) // not the misleading "broken" line
-        assertFalse(lines[0].contains("\u2014")) // no em-dash
+        assertEquals(
+            listOf(
+                "stepsRaw day=2026-01-02 counterSamples=0 noRawCounter " +
+                    "(no step counter on this device; steps are motion-estimated, e.g. WHOOP 4.0)",
+            ),
+            lines,
+        )
     }
 
-    @Test fun emptyAfterDayFilterAlsoReportsNoRawCounter() {
-        // daySteps has rows, but none fall on the requested day (e.g. all on a neighbouring day). After the
-        // local-day filter the sorted list is empty, so the same honest noRawCounter line is emitted rather
-        // than a broken-looking counterSamples=0 ... need >=2.
+    @Test fun nonemptyInputWithNoRowsForDayReportsOnlyThatMismatch() {
+        // The supplied rows prove that a raw counter exists; they merely do not match the requested local day.
+        // Never turn that day-window mismatch into a device-capability or motion-estimation claim.
         val otherDay = listOf(step(2 * 86_400L, 100), step(2 * 86_400L + 60, 150))
         val lines = StepsEstimateEngineTrace.rawCounterTrace(
             daySteps = otherDay, dayKey = dayUtc, tzOffsetSeconds = 0L, ticksPerStep = 1.0,
         )
-        assertEquals(1, lines.size)
-        assertTrue(lines[0].contains("noRawCounter"))
+        assertEquals(
+            listOf(
+                "stepsRaw day=2026-01-02 counterSamples=0 inputSamples=2 noRowsForDay " +
+                    "(no counter rows matched the requested local day)",
+            ),
+            lines,
+        )
+        assertFalse(lines[0].contains("noRawCounter"))
+        assertFalse(lines[0].contains("no step counter on this device"))
+        assertFalse(lines[0].contains("motion-estimated"))
     }
 
     // MARK: WHOOP-4 calibration trace


### PR DESCRIPTION
## Summary

- preserve the existing no-step-counter explanation for truly empty input
- emit an honest `noRowsForDay` trace when non-empty input contains no rows for the requested local day
- avoid device-absence and motion-estimation claims in that filtered-empty case
- add mirrored Swift and Android public-contract tests for empty, out-of-day, one-row, and normal-total behavior

The current production live path remains guarded by day-bounded inputs and a non-empty check; this fixes the public helper contract without changing production wiring.

## Verification

- Swift RED: out-of-day case produced `noRawCounter` plus three misleading device/motion claims
- Kotlin unchanged RED control: focused test failed on the same contract
- Swift focused: passed
- Swift trace class: 14/14 passed
- Swift full StrandAnalytics: 1,496/1,496 passed
- Kotlin focused and trace class: passed
- Kotlin full `:app:testFullDebugUnitTest`: 4,091/4,091 passed
- independent frozen-delta review: no P0-P2 findings
- `git diff --check`: clean

Android execution was serial and bounded: JDK 17, no daemon, one worker, no parallel execution, Kotlin in-process, 1536 MiB heap. Temporary Linux-only Swift build gates were fully reverted before commit.

Tracks https://github.com/bhelm/noop/issues/85