### PR TITLE
fix(android): escape backup JSON controls

### DIFF
--- a/Packages/WhoopStore/Tests/WhoopStoreTests/BackupProvenanceTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/BackupProvenanceTests.swift
@@ -22,6 +22,40 @@ final class BackupProvenanceTests: XCTestCase {
         )
     }
 
+    func test_versionEvent_payload_escapes_named_controls_like_kotlin() throws {
+        let from = "10.1\n0"
+        let to = "10.1\t1\u{1}"
+        let json = AppVersionEvent.payloadJson(from: from, to: to, schemaVersion: 30)
+
+        XCTAssertEqual(
+            json,
+            #"{"from":"10.1\n0","schemaVersion":30,"to":"10.1\t1\u0001"}"#
+        )
+        let decoded = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(decoded["from"] as? String, from)
+        XCTAssertEqual(decoded["to"] as? String, to)
+    }
+
+    func test_versionEvent_payload_round_trips_every_json_control_character() throws {
+        var controls = ""
+        for value in 0x00...0x1F {
+            controls.unicodeScalars.append(UnicodeScalar(value)!)
+        }
+        let json = AppVersionEvent.payloadJson(from: controls, to: "ordinary", schemaVersion: 30)
+
+        XCTAssertEqual(
+            json,
+            #"{"from":"\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000b\f\r\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f","schemaVersion":30,"to":"ordinary"}"#
+        )
+        XCTAssertFalse(json.unicodeScalars.contains { $0.value <= 0x1F })
+        let decoded = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(decoded["from"] as? String, controls)
+    }
+
     func test_shouldRecord_only_on_a_real_transition() {
         XCTAssertFalse(AppVersionEvent.shouldRecord(lastSeen: nil, current: "10.1.1"))   // first launch
         XCTAssertFalse(AppVersionEvent.shouldRecord(lastSeen: "", current: "10.1.1"))

--- a/android/app/src/main/java/com/noop/data/BackupProvenance.kt
+++ b/android/app/src/main/java/com/noop/data/BackupProvenance.kt
@@ -11,10 +11,32 @@ package com.noop.data
  * The JSON is a minimal, sorted-key object built by hand so it is byte-identical to Swift's
  * `JSONSerialization(.sortedKeys)` and testable in a plain JVM (no `org.json` stub).
  */
+private fun jsonString(value: String): String = buildString(value.length + 2) {
+    append('"')
+    value.forEach { char ->
+        when (char) {
+            '"' -> append("\\\"")
+            '\\' -> append("\\\\")
+            '\b' -> append("\\b")
+            '\u000c' -> append("\\f")
+            '\n' -> append("\\n")
+            '\r' -> append("\\r")
+            '\t' -> append("\\t")
+            else -> if (char.code in 0x00..0x1f) {
+                append("\\u")
+                append(char.code.toString(radix = 16).padStart(length = 4, padChar = '0'))
+            } else {
+                append(char)
+            }
+        }
+    }
+    append('"')
+}
+
 private fun sortedJsonObject(entries: List<Pair<String, Any>>): String =
     entries.sortedBy { it.first }.joinToString(separator = ",", prefix = "{", postfix = "}") { (k, v) ->
         val value = when (v) {
-            is String -> "\"" + v.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+            is String -> jsonString(v)
             else -> v.toString()   // Int/Long → unquoted numeric literal
         }
         "\"$k\":$value"

--- a/android/app/src/test/java/com/noop/data/BackupProvenanceTest.kt
+++ b/android/app/src/test/java/com/noop/data/BackupProvenanceTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.json.JSONObject
 
 /**
  * Pins the #1410 build-provenance JSON. The expected strings are byte-identical to what Swift's
@@ -27,6 +28,32 @@ class BackupProvenanceTest {
             """{"from":"10.1.0","schemaVersion":30,"to":"10.1.1"}""",
             AppVersionEvent.payloadJson(from = "10.1.0", to = "10.1.1", schemaVersion = 30),
         )
+    }
+
+    @Test fun versionEvent_payload_escapes_named_controls_like_swift() {
+        val from = "10.1\n0"
+        val to = "10.1\t1\u0001"
+        val json = AppVersionEvent.payloadJson(from = from, to = to, schemaVersion = 30)
+
+        assertEquals(
+            """{"from":"10.1\n0","schemaVersion":30,"to":"10.1\t1\u0001"}""",
+            json,
+        )
+        val decoded = JSONObject(json)
+        assertEquals(from, decoded.getString("from"))
+        assertEquals(to, decoded.getString("to"))
+    }
+
+    @Test fun versionEvent_payload_round_trips_every_json_control_character() {
+        val controls = (0x00..0x1f).map(Int::toChar).joinToString("")
+        val json = AppVersionEvent.payloadJson(from = controls, to = "ordinary", schemaVersion = 30)
+
+        assertEquals(
+            """{"from":"\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000b\f\r\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f","schemaVersion":30,"to":"ordinary"}""",
+            json,
+        )
+        assertTrue("JSON must not contain raw control characters", json.none { it.code in 0x00..0x1f })
+        assertEquals(controls, JSONObject(json).getString("from"))
     }
 
     @Test fun shouldRecord_only_on_a_real_transition() {


### PR DESCRIPTION
## Summary

- escape every JSON C0 control character in Android backup provenance strings
- preserve named escapes for backspace, form feed, newline, carriage return, and tab, with canonical lower-case `\u00xx` escapes for the remaining controls
- retain sorted keys, numeric literals, and ordinary manifest/version-event output
- add mirrored Swift and Android byte-contract tests plus Android JSON roundtrip coverage

Normal production values remain build-controlled; the affected inputs require custom/tampered metadata or direct helper use. This keeps the operational scope bounded while restoring the public byte-parity and valid-JSON contract.

## Verification

- Swift canonical control: 5/5 passed
- Kotlin RED: 5 tests, exactly 2 expected failures for named controls and the complete C0 corpus
- Kotlin focused GREEN: 5/5 passed
- Kotlin fullDebug: 4,093 tests, 0 failures
- Android full `:app:test`: 16,372 tests across four variants, 0 failures
- Swift full WhoopStore: 391 tests, 0 failures
- independent frozen-delta review: no P0/P1 findings; functional PASS
- `git diff --check`: clean

Android execution was serial and bounded: JDK 17, no daemon, one worker, no parallel execution, Kotlin in-process, 1536 MiB heap. Temporary Linux-only Swift build gates were fully reverted before commit. Machine-readable RED/GREEN hash manifests were retained outside the worktree.

Provenance: upstream PR #1422 (`d9aae8cb`).
Tracks https://github.com/bhelm/noop/issues/86