### PR TITLE
fix(connection): make duration rounding deterministic

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
@@ -22,12 +22,13 @@ public enum ConnectionTrace {
     /// before anyone could start on it.
     ///
     /// An unknown start yields NO suffix rather than `after 0.0s` — "instant drop" and "we do not know"
-    /// are different diagnoses. Locale-fixed so a decimal comma cannot follow the phone language into a
-    /// log people paste into issues. Twin of the Kotlin `ConnectionTrace.sessionHeldSuffix`.
+    /// are different diagnoses. Integer half-up quantization makes exact 50 ms ties deterministic, and
+    /// rendering the whole and fractional digits directly keeps locale out of pasted logs. Twin of the
+    /// Kotlin `ConnectionTrace.sessionHeldSuffix`.
     public static func sessionHeldSuffix(millis: Int) -> String {
         guard millis >= 0 else { return "" }
-        return " after " + String(format: "%.1f", locale: Locale(identifier: "en_US_POSIX"),
-                                  Double(millis) / 1000.0) + "s"
+        let tenths = millis / 100 + (millis % 100 >= 50 ? 1 : 0)
+        return " after \(tenths / 10).\(tenths % 10)s"
     }
 
 

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SessionHeldSuffixTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SessionHeldSuffixTests.swift
@@ -18,6 +18,14 @@ final class SessionHeldSuffixTests: XCTestCase {
         XCTAssertEqual(ConnectionTrace.sessionHeldSuffix(millis: 432), " after 0.4s")
     }
 
+    /// Exact half-ties round up to the next tenth on both platforms. This is an integer-millisecond
+    /// trace contract, so its result must not depend on the host runtime's floating-point formatter.
+    func testHalfTiesRoundUpToTheNextTenth() {
+        XCTAssertEqual(ConnectionTrace.sessionHeldSuffix(millis: 50), " after 0.1s")
+        XCTAssertEqual(ConnectionTrace.sessionHeldSuffix(millis: 150), " after 0.2s")
+        XCTAssertEqual(ConnectionTrace.sessionHeldSuffix(millis: 250), " after 0.3s")
+    }
+
     /// An unknown start yields NO suffix rather than `after 0.0s` — "dropped instantly" and "we do not
     /// know when it came up" are different diagnoses and must not render alike.
     func testAnUnknownStartAddsNothing() {

--- a/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
+++ b/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
@@ -22,11 +22,15 @@ object ConnectionTrace {
      * before anyone could start on it.
      *
      * An unknown start yields NO suffix rather than `after 0.0s` — "instant drop" and "we do not know"
-     * are different diagnoses. Locale-fixed so a decimal comma cannot follow the phone language into a
-     * log people paste into issues. Twin of the Swift `ConnectionTrace.sessionHeldSuffix`.
+     * are different diagnoses. Integer half-up quantization makes exact 50 ms ties deterministic, and
+     * rendering the whole and fractional digits directly keeps locale out of pasted logs. Twin of the
+     * Swift `ConnectionTrace.sessionHeldSuffix`.
      */
-    fun sessionHeldSuffix(millis: Long): String =
-        if (millis < 0L) "" else " after ${"%.1f".format(java.util.Locale.US, millis / 1000.0)}s"
+    fun sessionHeldSuffix(millis: Long): String {
+        if (millis < 0L) return ""
+        val tenths = millis / 100L + if (millis % 100L >= 50L) 1L else 0L
+        return " after ${tenths / 10L}.${tenths % 10L}s"
+    }
 
 
     /**

--- a/android/app/src/test/java/com/noop/ble/ConnectionDownReasonTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ConnectionDownReasonTest.kt
@@ -64,11 +64,23 @@ class ConnectionDownReasonTest {
         assertEquals(" after 0.4s", ConnectionTrace.sessionHeldSuffix(432))
     }
 
+    /** Exact half-ties round up on both platforms, independently of the host runtime's formatter. */
+    @Test fun sessionLengthHalfTiesRoundUpToTheNextTenth() {
+        assertEquals(" after 0.1s", ConnectionTrace.sessionHeldSuffix(50))
+        assertEquals(" after 0.2s", ConnectionTrace.sessionHeldSuffix(150))
+        assertEquals(" after 0.3s", ConnectionTrace.sessionHeldSuffix(250))
+    }
+
     /**
      * Unknown session start yields no suffix rather than a misleading zero — "after 0.0s" would read as
      * an instant drop, which is a different diagnosis from "we do not know".
      */
     @Test fun anUnknownSessionStartYieldsNoSuffix() {
         assertEquals("", ConnectionTrace.sessionHeldSuffix(-1))
+    }
+
+    /** Zero is a measured instant drop, not the negative unknown-start sentinel. */
+    @Test fun anInstantDropIsStillReported() {
+        assertEquals(" after 0.0s", ConnectionTrace.sessionHeldSuffix(0))
     }
 }


### PR DESCRIPTION
## Summary

- make `ConnectionTrace.sessionHeldSuffix` use explicit integer HALF-UP quantization to one decimal on Swift and Android
- remove runtime-dependent `printf`/Locale/Double tie rounding from the shared diagnostic contract
- preserve unknown, zero, and ordinary session-duration output
- add mirrored public tests for 50/150/250 ms half-ties and the existing boundary set

## Verification

- Swift RED: exactly 50 ms (`0.0` vs `0.1`) and 250 ms (`0.2` vs `0.3`) failed; 150 ms and existing values passed
- Kotlin unchanged control: passed
- Swift focused and affected: passed
- Swift full StrandAnalytics: 1,497 tests, 0 failures
- Kotlin focused and affected: passed
- Kotlin fullDebug: 4,093 tests, 0 failures, 0 errors, 6 skipped
- independent frozen-delta review: no P0-P2 findings
- exact vectors: -1, 0, 50, 150, 250, 432, 6,800, 120,000
- `git diff --check`: clean

Android execution was serial and bounded: JDK 17, no daemon, one worker, no parallel execution, Kotlin in-process, 1536 MiB heap. Temporary Linux-only Swift gates were fully reverted before commit.

Fixes the parity contract tracked at https://github.com/bhelm/noop/issues/87.
Provenance: ryanbr/noop#1023 / #1020.