### PR TITLE
fix(labs): normalize custom marker keys to NFC

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/LabMarkerCsvImport.swift
+++ b/Packages/StrandImport/Sources/StrandImport/LabMarkerCsvImport.swift
@@ -346,7 +346,8 @@ public enum LabMarkerCsvImport {
     /// so a CSV custom marker folds onto a hand-added one. Returns "" for a name with no
     /// usable characters.
     static func customKey(_ name: String) -> String {
-        let lowered = name.trimmingCharacters(in: .whitespaces).lowercased()
+        let lowered = name.precomposedStringWithCanonicalMapping
+            .trimmingCharacters(in: .whitespaces).lowercased()
         let mapped = lowered.map { ch -> Character in
             (ch.isLetter || ch.isNumber) ? ch : "_"
         }

--- a/Packages/StrandImport/Tests/StrandImportTests/LabMarkerCsvImportTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/LabMarkerCsvImportTests.swift
@@ -100,6 +100,39 @@ final class LabMarkerCsvImportTests: XCTestCase {
         XCTAssertEqual(result.customMarkerKeys, ["custom_magnesium"])
     }
 
+    func testCustomMarkerKeyCanonicalizesNFCAndNFDBeforeSlugging() {
+        // Compare UTF-8 bytes: Swift String equality deliberately treats canonically equivalent
+        // spellings as equal and would mask a decomposed persisted identifier.
+        let expected: [UInt8] = [
+            0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x5f, 0x63, 0x61, 0x66,
+            0xc3, 0xa9, 0x5f, 0x6d, 0x61, 0x72, 0x6b, 0x65, 0x72,
+        ]
+        XCTAssertEqual(Array(LabMarkerCsvImport.customKey("Caf\u{e9} Marker").utf8), expected)
+        XCTAssertEqual(Array(LabMarkerCsvImport.customKey("Cafe\u{301} Marker").utf8), expected)
+        XCTAssertEqual(LabMarkerCsvImport.customKey("Apo B"), "custom_apo_b")
+    }
+
+    func testCanonicalEquivalentCustomMarkerRowsShareKeyAndLastRowWins() {
+        let csv = """
+        date,marker,value,unit
+        2026-05-01,Caf\u{e9} Marker,1,mg/L
+        2026-05-01,Cafe\u{301} Marker,2,mg/L
+        """
+        let expected: [UInt8] = [
+            0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x5f, 0x63, 0x61, 0x66,
+            0xc3, 0xa9, 0x5f, 0x6d, 0x61, 0x72, 0x6b, 0x65, 0x72,
+        ]
+        let result = LabMarkerCsvImport.parse(text: csv)
+
+        XCTAssertEqual(result.importedReadings, 1)
+        XCTAssertEqual(result.distinctMarkers, 1)
+        XCTAssertEqual(result.rows.count, 1)
+        XCTAssertEqual(result.rows[0].value, 2)
+        XCTAssertEqual(Array(result.rows[0].markerKey.utf8), expected)
+        XCTAssertEqual(result.customMarkerKeys.count, 1)
+        XCTAssertEqual(Array(result.customMarkerKeys[0].utf8), expected)
+    }
+
     // MARK: - Blood pressure pairs (diastolic must never be dropped)
 
     func testCombinedBloodPressureSplitsIntoPair() {

--- a/Strand/Screens/MarkerEditorView.swift
+++ b/Strand/Screens/MarkerEditorView.swift
@@ -513,7 +513,8 @@ enum MarkerUnits {
 
     /// A lower-cased, underscored slug for a custom marker name → its stable key.
     static func slug(_ name: String) -> String {
-        let lowered = name.trimmingCharacters(in: .whitespaces).lowercased()
+        let lowered = name.precomposedStringWithCanonicalMapping
+            .trimmingCharacters(in: .whitespaces).lowercased()
         let mapped = lowered.map { ch -> Character in
             (ch.isLetter || ch.isNumber) ? ch : "_"
         }

--- a/StrandTests/MarkerUnitsUnicodeTests.swift
+++ b/StrandTests/MarkerUnitsUnicodeTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import Strand
+
+final class MarkerUnitsUnicodeTests: XCTestCase {
+    func testSlugCanonicalizesNFCAndNFDBeforeSlugging() {
+        // Byte comparison prevents Swift's canonical-equivalence String comparison from
+        // accepting an NFD persisted identifier in place of the required NFC identifier.
+        let expected: [UInt8] = [
+            0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x5f, 0x63, 0x61, 0x66,
+            0xc3, 0xa9, 0x5f, 0x6d, 0x61, 0x72, 0x6b, 0x65, 0x72,
+        ]
+        XCTAssertEqual(Array(MarkerUnits.slug("Caf\u{e9} Marker").utf8), expected)
+        XCTAssertEqual(Array(MarkerUnits.slug("Cafe\u{301} Marker").utf8), expected)
+        XCTAssertEqual(MarkerUnits.slug("Apo B"), "custom_apo_b")
+    }
+}

--- a/android/app/src/main/java/com/noop/ingest/LabMarkerCsvImport.kt
+++ b/android/app/src/main/java/com/noop/ingest/LabMarkerCsvImport.kt
@@ -7,6 +7,7 @@ import com.noop.analytics.MarkerCatalog
 import com.noop.data.ImportSummary
 import com.noop.data.LabMarkerRow
 import com.noop.data.WhoopRepository
+import java.text.Normalizer
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
@@ -447,7 +448,7 @@ object LabMarkerCsvImport {
      * marker folds onto a hand-added one. Returns "" for a name with no usable characters.
      */
     internal fun customKey(name: String): String {
-        val lowered = name.trim().lowercase()
+        val lowered = Normalizer.normalize(name, Normalizer.Form.NFC).trim().lowercase()
         val mapped = lowered.map { if (it.isLetterOrDigit()) it else '_' }.joinToString("")
         val collapsed = mapped.replace("__", "_").trim('_')
         return if (collapsed.isEmpty()) "" else "custom_$collapsed"
@@ -596,4 +597,3 @@ object LabMarkerCsvImport {
 }
 
 // MARK: - Stream helper (file-private; the other importers' twins are not visible here)
-

--- a/android/app/src/main/java/com/noop/ui/MarkerEditorScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/MarkerEditorScreen.kt
@@ -43,6 +43,7 @@ import com.noop.analytics.LabMarkerCategory
 import com.noop.analytics.MarkerCatalog
 import com.noop.analytics.MarkerDefinition
 import com.noop.data.LabMarkerRow
+import java.text.Normalizer
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -437,7 +438,7 @@ object MarkerUnits {
 
     /** A lower-cased, underscored slug for a custom marker name → its stable key. */
     fun slug(name: String): String {
-        val lowered = name.trim().lowercase()
+        val lowered = Normalizer.normalize(name, Normalizer.Form.NFC).trim().lowercase()
         val mapped = lowered.map { if (it.isLetterOrDigit()) it else '_' }.joinToString("")
         val collapsed = mapped.replace("__", "_").trim('_')
         return "custom_$collapsed"

--- a/android/app/src/test/java/com/noop/ingest/LabMarkerCsvImportTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/LabMarkerCsvImportTest.kt
@@ -1,6 +1,7 @@
 package com.noop.ingest
 
 import com.noop.analytics.LabMarkerCategory
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -108,6 +109,39 @@ class LabMarkerCsvImportTest {
         assertEquals(LabMarkerCategory.OTHER, row.category)
         assertTrue(row.isCustomMarker)
         assertEquals(listOf("custom_magnesium"), result.customMarkerKeys)
+    }
+
+    @Test fun customMarkerKeyCanonicalizesNfcAndNfdBeforeSlugging() {
+        val expected = byteArrayOf(
+            0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x5f, 0x63, 0x61, 0x66,
+            0xc3.toByte(), 0xa9.toByte(), 0x5f, 0x6d, 0x61, 0x72, 0x6b, 0x65, 0x72,
+        )
+        assertArrayEquals(expected, LabMarkerCsvImport.customKey("Caf\u00e9 Marker").toByteArray())
+        assertArrayEquals(expected, LabMarkerCsvImport.customKey("Cafe\u0301 Marker").toByteArray())
+        assertEquals("custom_apo_b", LabMarkerCsvImport.customKey("Apo B"))
+    }
+
+    @Test fun canonicalEquivalentCustomMarkerRowsShareKeyAndLastRowWins() {
+        val nfc = "Caf\u00e9 Marker"
+        val nfd = "Cafe\u0301 Marker"
+        val csv = """
+            date,marker,value,unit
+            2026-05-01,$nfc,1,mg/L
+            2026-05-01,$nfd,2,mg/L
+        """.trimIndent()
+        val expected = byteArrayOf(
+            0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x5f, 0x63, 0x61, 0x66,
+            0xc3.toByte(), 0xa9.toByte(), 0x5f, 0x6d, 0x61, 0x72, 0x6b, 0x65, 0x72,
+        )
+        val result = LabMarkerCsvImport.parse(csv)
+
+        assertEquals(1, result.importedReadings)
+        assertEquals(1, result.distinctMarkers)
+        assertEquals(1, result.rows.size)
+        assertEquals(2.0, result.rows[0].value, 1e-9)
+        assertArrayEquals(expected, result.rows[0].markerKey.toByteArray())
+        assertEquals(1, result.customMarkerKeys.size)
+        assertArrayEquals(expected, result.customMarkerKeys[0].toByteArray())
     }
 
     // MARK: - Blood pressure pairs (diastolic must never be dropped)

--- a/android/app/src/test/java/com/noop/ui/MarkerUnitsUnicodeTest.kt
+++ b/android/app/src/test/java/com/noop/ui/MarkerUnitsUnicodeTest.kt
@@ -1,0 +1,17 @@
+package com.noop.ui
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MarkerUnitsUnicodeTest {
+    @Test fun slugCanonicalizesNfcAndNfdBeforeSlugging() {
+        val expected = byteArrayOf(
+            0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x5f, 0x63, 0x61, 0x66,
+            0xc3.toByte(), 0xa9.toByte(), 0x5f, 0x6d, 0x61, 0x72, 0x6b, 0x65, 0x72,
+        )
+        assertArrayEquals(expected, MarkerUnits.slug("Caf\u00e9 Marker").toByteArray())
+        assertArrayEquals(expected, MarkerUnits.slug("Cafe\u0301 Marker").toByteArray())
+        assertEquals("custom_apo_b", MarkerUnits.slug("Apo B"))
+    }
+}


### PR DESCRIPTION
## Summary
- NFC-normalize custom lab marker names before the existing slug pipeline on Swift and Kotlin
- keep CSV importer and manual editor keys byte-identical
- fold canonically equivalent NFC/NFD CSV rows onto one key with last-row-wins behavior

## Regression coverage
- byte-exact UTF-8 assertions for Café Marker and decomposed Cafe + U+0301 Marker
- mirrored importer and manual MarkerUnits slug tests on both platforms
- existing ASCII behavior remains pinned

## Validation
- Swift StrandImport full: 234 tests, 0 failures, 1 expected real-database skip
- Android FullDebug JVM: 4094 tests, 0 failures, 0 errors, 6 skips
- independent delta review: PASS, no P0/P1/P2

Fork tracking issue: bhelm/noop#90