### PR TITLE
Fix FIT coordinate half-tie rounding parity

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/RouteExporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/RouteExporter.swift
@@ -161,7 +161,7 @@ public enum RouteExporter {
     }
 
     private static func semicircles(_ deg: Double) -> Int32 {
-        let v = (deg * semiPerDeg).rounded()
+        let v = (deg * semiPerDeg).rounded(.toNearestOrAwayFromZero)
         if v >= Double(Int32.max) { return Int32.max }
         if v <= Double(Int32.min) { return Int32.min }
         return Int32(v)

--- a/Packages/StrandImport/Tests/StrandImportTests/RouteExporterTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/RouteExporterTests.swift
@@ -61,6 +61,31 @@ final class RouteExporterTests: XCTestCase {
         XCTAssertEqual(RouteExporter.fitCrc(Array(bytes[0..<(bytes.count - 2)])), crc)
     }
 
+    func testFitSemicircleHalfTiesRoundAwayFromZeroOnBothPlatforms() {
+        // One-point FIT layout: record data starts at byte 50, then local header (1), timestamp (4),
+        // and signed little-endian latitude (4). Exercise exact negative half-ties plus positive controls.
+        let semicirclesPerDegree = 2_147_483_648.0 / 180.0
+        let targets = [-1.5, -0.5, 0.5, 1.5]
+        let expected: [Int32] = [-2, -1, 1, 2]
+        let expectedPositionBytes: [[UInt8]] = [
+            [0xfe, 0xff, 0xff, 0xff], [0xff, 0xff, 0xff, 0xff],
+            [0x01, 0x00, 0x00, 0x00], [0x02, 0x00, 0x00, 0x00],
+        ]
+        let expectedCrcBytes: [[UInt8]] = [[0xb6, 0xee], [0xda, 0x25], [0x1d, 0xf4], [0xaa, 0xe9]]
+        let outputs = targets.map { target -> (Int32, [UInt8], [UInt8]) in
+            let point = RoutePoint(lat: target / semicirclesPerDegree, lon: 0)
+            let bytes = [UInt8](RouteExporter.buildFit(
+                route: [point], startTs: startTs, endTs: endTs, sport: "run"
+            ))
+            let raw = UInt32(bytes[55]) | (UInt32(bytes[56]) << 8)
+                | (UInt32(bytes[57]) << 16) | (UInt32(bytes[58]) << 24)
+            return (Int32(bitPattern: raw), Array(bytes[55...58]), Array(bytes.suffix(2)))
+        }
+        XCTAssertEqual(outputs.map(\.0), expected)
+        XCTAssertEqual(outputs.map(\.1), expectedPositionBytes)
+        XCTAssertEqual(outputs.map(\.2), expectedCrcBytes)
+    }
+
     func testFitWithoutHrDoesNotFabricateHr() {
         // Regression: the FIT "no HR" case must decode to nil HR. validHr accepts 1...300, so a 0xFF
         // sentinel would be misread as a real HR of 255 — the fields must be OMITTED, not sentinelled.

--- a/android/app/src/main/java/com/noop/ingest/RouteExport.kt
+++ b/android/app/src/main/java/com/noop/ingest/RouteExport.kt
@@ -2,6 +2,8 @@ package com.noop.ingest
 
 import java.io.ByteArrayOutputStream
 import java.time.Instant
+import kotlin.math.ceil
+import kotlin.math.floor
 import kotlin.math.roundToLong
 
 /**
@@ -169,8 +171,16 @@ object RouteExport {
 
     private fun fitTime(unix: Long): Long = (unix - FIT_EPOCH).coerceIn(0, 0xFFFFFFFFL)
 
-    private fun semicircles(deg: Double): Int =
-        (deg * SEMI_PER_DEG).roundToLong().coerceIn(Int.MIN_VALUE.toLong(), Int.MAX_VALUE.toLong()).toInt()
+    private fun semicircles(deg: Double): Int = roundNearestTiesAwayFromZero(deg * SEMI_PER_DEG)
+        .coerceIn(Int.MIN_VALUE.toLong(), Int.MAX_VALUE.toLong()).toInt()
+
+    /** Deterministic FIT coordinate rounding, matching Swift `.toNearestOrAwayFromZero`. */
+    private fun roundNearestTiesAwayFromZero(value: Double): Long {
+        require(!value.isNaN()) { "Cannot round NaN value." }
+        if (value >= Long.MAX_VALUE.toDouble()) return Long.MAX_VALUE
+        if (value <= Long.MIN_VALUE.toDouble()) return Long.MIN_VALUE
+        return if (value >= 0.0) floor(value + 0.5).toLong() else ceil(value - 0.5).toLong()
+    }
 
     /** ISO-8601 UTC to whole seconds, e.g. `2026-08-11T04:47:38Z`. */
     private fun iso(unix: Long): String = Instant.ofEpochSecond(unix).toString()

--- a/android/app/src/test/java/com/noop/ingest/RouteExportTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/RouteExportTest.kt
@@ -87,6 +87,30 @@ class RouteExportTest {
         assertEquals(RouteExport.fitCrc(bytes.copyOfRange(0, bytes.size - 2)), crc)
     }
 
+    @Test fun fitSemicircleHalfTiesRoundAwayFromZeroOnBothPlatforms() {
+        // One-point FIT layout: record data starts at byte 50, then local header (1), timestamp (4),
+        // and signed little-endian latitude (4). Exercise exact negative half-ties plus positive controls.
+        val semicirclesPerDegree = 2_147_483_648.0 / 180.0
+        val targets = listOf(-1.5, -0.5, 0.5, 1.5)
+        val expectedPositionBytes = listOf(
+            listOf(0xfe, 0xff, 0xff, 0xff), listOf(0xff, 0xff, 0xff, 0xff),
+            listOf(0x01, 0x00, 0x00, 0x00), listOf(0x02, 0x00, 0x00, 0x00),
+        )
+        val expectedCrcBytes = listOf(listOf(0xb6, 0xee), listOf(0xda, 0x25), listOf(0x1d, 0xf4), listOf(0xaa, 0xe9))
+        val outputs = targets.map { target ->
+            val bytes = RouteExport.buildFit(
+                listOf(RouteExport.Point(target / semicirclesPerDegree, 0.0)),
+                startTs, endTs, "run",
+            )
+            val raw = (bytes[55].toInt() and 0xFF) or ((bytes[56].toInt() and 0xFF) shl 8) or
+                ((bytes[57].toInt() and 0xFF) shl 16) or (bytes[58].toInt() shl 24)
+            Triple(raw, bytes.slice(55..58).map { it.toInt() and 0xFF }, bytes.takeLast(2).map { it.toInt() and 0xFF })
+        }
+        assertEquals(listOf(-2, -1, 1, 2), outputs.map { it.first })
+        assertEquals(expectedPositionBytes, outputs.map { it.second })
+        assertEquals(expectedCrcBytes, outputs.map { it.third })
+    }
+
     @Test fun singlePointAndEmptyDegradeGracefully() {
         // One point: still a valid file, one trackpoint at startTs.
         val one = RouteExport.buildFit(listOf(route.first()), startTs, endTs, "walk")


### PR DESCRIPTION
## Summary

- make FIT semicircle rounding explicitly nearest-with-ties-away-from-zero on Swift and Kotlin
- preserve the existing clamp and invalid-number behavior
- add mirrored public tests for -1.5, -0.5, +0.5, and +1.5 semicircles with decoded values, exact little-endian coordinate bytes, and fixed CRC trailers

Closes bhelm/noop#89.

## RED / GREEN evidence

- unchanged Swift RouteExporterTests: 8/8 passed (control; Swift already used the intended default tie rule)
- unchanged Kotlin RouteExportTest: exactly 1/8 failed at fitSemicircleHalfTiesRoundAwayFromZeroOnBothPlatforms; persistent RED log SHA-256 was 7ba2cfa8ea4c0cd0ef2e8db88369161202dae4af178a91398a537efb4ef61c74
- RED evidence qualification: the subsequent GREEN run overwrote Gradle XML, so the RED log retains the exact failing test/count but not the expected/actual rendering; the frozen roundToLong implementation and exact targets independently derive actual [-1, 0, 1, 2]
- focused/affected Swift: 8/8 passed
- focused/affected Kotlin: BUILD SUCCESSFUL
- full Swift StrandImport: 233 tests, 0 failures, 1 documented optional Xiaomi fixture skip
- Kotlin FullDebug: 4092 tests, 0 failures, 0 errors, 6 skips

Fresh independent delta review: PASS, no P0/P1/P2. Temporary Linux compatibility gates were reverted byte-for-byte before commit; the commit contains exactly two production files and two mirrored test files.