### PR TITLE
Fix Swift activity summaries to include positive steps

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/ActivityFileImporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/ActivityFileImporter.swift
@@ -452,6 +452,7 @@ public enum ActivityFileImporter {
         if a.gpsPointCount > 0 { parts.append("\(a.gpsPointCount) GPS points") }
         if a.hrSampleCount > 0 { parts.append("\(a.hrSampleCount) HR samples") }
         if let avg = a.avgHr { parts.append("avg \(avg) bpm") }
+        if let steps = a.steps, steps > 0 { parts.append("\(steps) steps") }
         return parts.joined(separator: " · ")
     }
 }

--- a/Packages/StrandImport/Tests/StrandImportTests/ActivityFileImporterTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/ActivityFileImporterTests.swift
@@ -272,6 +272,27 @@ final class ActivityFileImporterTests: XCTestCase {
         XCTAssertEqual(ActivityFileImporter.workoutSport(from: "Trail Run"), "Trail Run") // already spaced
         XCTAssertEqual(ActivityFileImporter.workoutSport(from: "kayaking"), "Kayaking")   // title-cased
     }
+
+    func testSummaryTextIncludesOnlyPositiveStepsWithKotlinParity() {
+        func activity(steps: Int?) -> ActivityFile {
+            ActivityFile(
+                kind: .fit,
+                start: Date(timeIntervalSince1970: 1_000),
+                end: Date(timeIntervalSince1970: 1_060),
+                sport: "walking",
+                distanceM: 1_000,
+                steps: steps
+            )
+        }
+
+        let base = "Imported a 1.00 km Walking activity"
+        XCTAssertEqual(ActivityFileImporter.summaryText(activity(steps: nil)), base)
+        XCTAssertEqual(ActivityFileImporter.summaryText(activity(steps: 0)), base)
+        XCTAssertEqual(
+            ActivityFileImporter.summaryText(activity(steps: 2_350)),
+            base + " · 2350 steps"
+        )
+    }
 }
 
 // MARK: - FIT byte fixture builder (little-endian, test-only)

--- a/android/app/src/test/java/com/noop/ingest/ActivityFileImporterTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/ActivityFileImporterTest.kt
@@ -277,6 +277,33 @@ class ActivityFileImporterTest {
         assertEquals("Trail Run", ActivityFileImporter.workoutSport("Trail Run"))
         assertEquals("Kayaking", ActivityFileImporter.workoutSport("kayaking"))
     }
+
+    @Test
+    fun summaryTextIncludesOnlyPositiveStepsWithSwiftParity() {
+        fun activity(steps: Int?) = ActivityFileImporter.Activity(
+            kind = ActivityFileImporter.Kind.FIT,
+            startTs = 1_000,
+            endTs = 1_060,
+            sport = "walking",
+            distanceM = 1_000.0,
+            energyKcal = null,
+            steps = steps,
+            avgHr = null,
+            maxHr = null,
+            ascentM = null,
+            gpsPointCount = 0,
+            hrSampleCount = 0,
+            route = emptyList(),
+        )
+
+        val base = "Imported a 1.00 km Walking activity"
+        assertEquals(base, ActivityFileImporter.summaryText(activity(null)))
+        assertEquals(base, ActivityFileImporter.summaryText(activity(0)))
+        assertEquals(
+            "$base · 2350 steps",
+            ActivityFileImporter.summaryText(activity(2_350)),
+        )
+    }
 }
 
 // MARK: - FIT byte fixture builder (little-endian, test-only). Mirrors the Swift FitFixture.


### PR DESCRIPTION
## Summary
- append positive step counts to Swift activity import summaries, matching Kotlin
- preserve existing output for nil and zero steps
- add mirrored Swift and Kotlin parity tests

## Validation
- Swift focused: 1 passed
- Swift affected ActivityFileImporterTests: 11 passed
- Swift full StrandImport: 233 passed, 0 failed, 1 environment-dependent skip
- Kotlin focused and affected: passed
- Kotlin FullDebug: 4092 passed, 0 failed, 0 errors, 6 skipped
- independent final delta review: PASS, no P0/P1/P2

Fixes bhelm/noop#91.