### PR TITLE
Reject malformed UTF-8 in Kotlin Oura text decoders

### DIFF
--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/DecoderGoldenTests.swift
@@ -396,11 +396,40 @@ final class DecoderGoldenTests: XCTestCase {
         XCTAssertNil(s?.text)               // body too short for a trailing string
     }
 
+    func testStateMalformedUTF8IsNotReplacementDecoded() {
+        let malformed = OuraRecord(
+            type: OuraEventTag.stateChange.rawValue, ringTimestamp: rt,
+            payload: [0x08, 0x63, 0x68, 0x67, 0x2e, 0x20, 0x64, 0x65,
+                      0x74, 0x65, 0x63, 0x74, 0x65, 0x64, 0xff])
+        let decoded = OuraDecoders.decodeState(malformed)
+        XCTAssertEqual(decoded?.stateCode, 8)
+        XCTAssertNil(decoded?.text)
+
+        // Valid UTF-8 remains decoded and only surrounding NULs are trimmed.
+        let valid = OuraRecord(
+            type: OuraEventTag.stateChange.rawValue, ringTimestamp: rt,
+            payload: [0x04, 0x00, 0x63, 0x61, 0x66, 0xc3, 0xa9, 0x00])
+        XCTAssertEqual(OuraDecoders.decodeState(valid)?.text, "café")
+    }
+
     // MARK: - 0x43 debug text
 
     func testDebugText0x43() {
         let rec = record("4306020001004142")
         XCTAssertEqual(OuraDecoders.decodeDebugText(rec), "AB")
+    }
+
+    func testDebugTextMalformedUTF8IsRejected() {
+        let malformed = OuraRecord(
+            type: OuraEventTag.debugText.rawValue, ringTimestamp: rt,
+            payload: [0x41, 0xff, 0x42])
+        XCTAssertNil(OuraDecoders.decodeDebugText(malformed))
+
+        // The valid ASCII control remains unchanged.
+        let ascii = OuraRecord(
+            type: OuraEventTag.debugText.rawValue, ringTimestamp: rt,
+            payload: [0x41, 0x42])
+        XCTAssertEqual(OuraDecoders.decodeDebugText(ascii), "AB")
     }
 
     // MARK: - 0x0D battery (outer response body; percent at [0], voltage at [4..6] LE)

--- a/android/app/src/main/java/com/noop/oura/Decoders.kt
+++ b/android/app/src/main/java/com/noop/oura/Decoders.kt
@@ -507,7 +507,7 @@ object OuraDecoders {
         if (b.size > 5) {
             val tailBytes = ByteArray(b.size - 1) { b[it + 1].toByte() }
             // Swift trims the NUL character set; match that exactly (trim only U+0000, not whitespace).
-            text = String(tailBytes, Charsets.UTF_8).trim('\u0000')
+            text = strictUtf8(tailBytes)?.trim('\u0000')
         }
         return OuraState(ringTimestamp = rec.ringTimestamp, stateCode = code, text = text)
     }
@@ -534,8 +534,16 @@ object OuraDecoders {
     fun decodeDebugText(rec: OuraRecord): String? {
         if (rec.payload.isEmpty()) return null
         val raw = ByteArray(rec.payload.size) { rec.payload[it].toByte() }
-        return String(raw, Charsets.UTF_8)
+        return strictUtf8(raw)
     }
+
+    private fun strictUtf8(bytes: ByteArray): String? = runCatching {
+        Charsets.UTF_8.newDecoder()
+            .onMalformedInput(java.nio.charset.CodingErrorAction.REPORT)
+            .onUnmappableCharacter(java.nio.charset.CodingErrorAction.REPORT)
+            .decode(java.nio.ByteBuffer.wrap(bytes))
+            .toString()
+    }.getOrNull()
 
     // MARK: - Sleep phase, 2-bit codes (0x4E / 0x5A; s6.12)
 

--- a/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
+++ b/android/app/src/test/java/com/noop/oura/DecoderGoldenTest.kt
@@ -454,12 +454,52 @@ class DecoderGoldenTest {
         assertNull(s?.text)               // body too short for a trailing string
     }
 
+    @Test
+    fun testStateMalformedUTF8IsNotReplacementDecoded() {
+        val malformed = OuraRecord(
+            type = OuraEventTag.STATE_CHANGE.raw,
+            ringTimestamp = rt,
+            payload = intArrayOf(
+                0x08, 0x63, 0x68, 0x67, 0x2e, 0x20, 0x64, 0x65,
+                0x74, 0x65, 0x63, 0x74, 0x65, 0x64, 0xff,
+            ),
+        )
+        // Valid UTF-8 remains decoded and only surrounding NULs are trimmed.
+        val valid = OuraRecord(
+            type = OuraEventTag.STATE_CHANGE.raw,
+            ringTimestamp = rt,
+            payload = intArrayOf(0x04, 0x00, 0x63, 0x61, 0x66, 0xc3, 0xa9, 0x00),
+        )
+        assertEquals("café", OuraDecoders.decodeState(valid)?.text)
+
+        val decoded = OuraDecoders.decodeState(malformed)
+        assertEquals(8, decoded?.stateCode)
+        assertNull(decoded?.text)
+    }
+
     // MARK: - 0x43 debug text
 
     @Test
     fun testDebugText0x43() {
         val rec = record("4306020001004142")
         assertEquals("AB", OuraDecoders.decodeDebugText(rec))
+    }
+
+    @Test
+    fun testDebugTextMalformedUTF8IsRejected() {
+        val malformed = OuraRecord(
+            type = OuraEventTag.DEBUG_TEXT.raw,
+            ringTimestamp = rt,
+            payload = intArrayOf(0x41, 0xff, 0x42),
+        )
+        // The valid ASCII control remains unchanged.
+        val ascii = OuraRecord(
+            type = OuraEventTag.DEBUG_TEXT.raw,
+            ringTimestamp = rt,
+            payload = intArrayOf(0x41, 0x42),
+        )
+        assertEquals("AB", OuraDecoders.decodeDebugText(ascii))
+        assertNull(OuraDecoders.decodeDebugText(malformed))
     }
 
     // MARK: - 0x0D battery (outer response body; percent at [0], voltage at [4..6] LE)


### PR DESCRIPTION
## Summary
- decode Oura State and DebugText with strict UTF-8 on Kotlin, matching Swift
- return null text for malformed input instead of inserting replacement characters
- preserve valid café/NUL trimming and ASCII behavior with mirrored public tests

## Validation
- Swift unchanged focused control: 2 passed
- Kotlin unchanged RED: 2 failed for the malformed State and DebugText assertions, with valid controls passing first
- Kotlin focused GREEN: 2 passed
- Swift affected DecoderGoldenTests: 41 passed
- Swift full OuraProtocol: 204 passed
- Kotlin affected DecoderGoldenTest: passed
- Kotlin FullDebug: 4093 passed, 0 failed, 0 errors, 6 skipped
- independent final delta review: PASS, no P0/P1/P2

Fixes bhelm/noop#92.