### PR TITLE
Fix doubled and ungrammatical "ago" suffixes in the synced-at text (#1472)

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -2426,7 +2426,7 @@ private struct LiquidSyncStatusRow: View {
             row(String(localized: "Strap history"), value: chunks, tone: StrandPalette.accent)
         } else if let ts = live.lastSyncedAt {
             row(String(localized: "Strap history"),
-                value: String(localized: "Synced \(relativeAgo(ts)) ago"), tone: StrandPalette.textPrimary)
+                value: String(localized: "Synced \(relativeAgo(ts))"), tone: StrandPalette.textPrimary)
         }
     }
 

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -207368,13 +207368,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已同步 %@"
+            "value": "%@已同步"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "已同步 %@"
+            "value": "%@已同步"
           }
         }
       }

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -207320,6 +207320,122 @@
           }
         }
       }
+    },
+    "Synced %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synchronisiert %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizado %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synchronisé %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizzato %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zsynchronizowano %@"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizado %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Синхронизировано %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已同步 %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已同步 %@"
+          }
+        }
+      }
+    },
+    "Synced %@ ago": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vor %@ synchronisiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizado hace %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synchronisé il y a %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizzato %@ fa"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zsynchronizowano %@ temu"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizado há %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Синхронизировано %@ назад"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已在 %@ 前同步"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已在 %@ 前同步"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -4805,12 +4805,16 @@ enum SyncChipState: Equatable {
         return .hidden
     }
 
-    /// Compact relative age for the status card ("now" / "Nm" / "Nh" / "Nd") — deliberately terse.
-    /// "now" is the only word in here (the rest is digits + a unit letter), so it's the only piece that
-    /// needs a catalog entry to translate; localized here rather than at each of the two call sites.
+    /// Compact relative age for the status card ("<1m" / "Nm" / "Nh" / "Nd") — deliberately terse.
+    ///
+    /// EVERY branch must read correctly with a trailing "ago", because that is the only way this value is
+    /// ever consumed (`DevicesView` wraps it in "Synced %@ ago" and "Strap history synced %@ ago"). The
+    /// sub-minute branch used to return the word "now", which produced the user-visible "Synced now ago"
+    /// for the first minute after any sync (#1472). "<1m" composes; it also needs no catalog entry, being
+    /// digits and symbols in every language.
     private static func shortAgo(_ ts: TimeInterval) -> String {
         let secs = max(0, Int(Date().timeIntervalSince1970 - ts))
-        if secs < 60 { return String(localized: "now") }
+        if secs < 60 { return "<1m" }
         let mins = secs / 60
         if mins < 60 { return "\(mins)m" }
         let hrs = mins / 60

--- a/StrandTests/SyncChipStateTests.swift
+++ b/StrandTests/SyncChipStateTests.swift
@@ -21,6 +21,16 @@ final class SyncChipStateTests: XCTestCase {
         XCTAssertEqual(SyncChipState.resolve(live: live), .synced(agoText: "1m"))
     }
 
+    /// #1472 regression guard. The sub-minute token is wrapped by `DevicesView` in "Synced %@ ago" and
+    /// "Strap history synced %@ ago", so it must compose with a trailing "ago". It used to be the word
+    /// "now", which rendered the user-visible "Synced now ago" for the first minute after every sync;
+    /// "<1m" is the fix and this pins it. Twin of the Android `lastSyncedUnderAMinute_usesSubMinuteToken`.
+    func testLastSyncedUnderAMinute_usesSubMinuteToken() {
+        let live = LiveState()
+        live.lastSyncedAt = Date().timeIntervalSince1970 - 5
+        XCTAssertEqual(SyncChipState.resolve(live: live), .synced(agoText: "<1m"))
+    }
+
     func testHistorySyncExperimental_withNoLastSync_isExperimentalLive() {
         let live = LiveState()
         live.historySyncExperimental = true

--- a/StrandTests/SyncChipStateTests.swift
+++ b/StrandTests/SyncChipStateTests.swift
@@ -1,10 +1,13 @@
 import XCTest
 @testable import Strand
 
-/// #245: `SyncChipState.resolve` is the one place both the classic `SyncStatusChip` and the Liquid
-/// header's `LiquidSyncChip` decide which of the three sync states to show, so a mistake here would
-/// desync the two headers. Covers priority order (backfilling wins over a stale last-sync, which wins
+/// #245: `SyncChipState.resolve` is the one place the sync status is decided, so a mistake here changes
+/// what every consumer shows. Covers priority order (backfilling wins over a stale last-sync, which wins
 /// over the 5/MG experimental fallback) and the cold-start `.hidden` case.
+///
+/// The sole consumer is `DevicesView`'s status card, which wraps `agoText` in "Synced %@ ago" — so every
+/// value the token can take must read correctly with a trailing "ago" (#1472). There is no bare-token
+/// renderer on Apple; the Android twin's chip is the one place a bare token is shown.
 @MainActor
 final class SyncChipStateTests: XCTestCase {
 

--- a/android/app/src/main/java/com/noop/ui/TodayScoring.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScoring.kt
@@ -403,42 +403,42 @@ sealed class SyncChipState {
         /** Pure + unit-tested. Mirrors Swift `SyncChipState.resolve` exactly: backfilling wins over a
          *  known last-sync, which wins over the 5/MG experimental fallback.
          *
-         *  [nowSec] (unix seconds) and [nowLabel] (the already-translated "now" word) are PARAMETERS
-         *  rather than things this function reaches for, which is what keeps "pure" true. Resolving the
-         *  word in here instead cost the twin its own test: it goes through `NoopApplication`, which
-         *  throws `IllegalStateException: NoopApplication is not attached` under a plain JVM unit test —
-         *  these run without Robolectric, so no Application is ever attached. Only the `< 60s` branch of
-         *  [shortSyncAgo] wants a word, so the failure was invisible until a case landed in it. Same
-         *  injected-clock style as [recordingStateFor] just above.
+         *  [nowSec] (unix seconds) is a PARAMETER rather than something this function reaches for, which
+         *  is what keeps "pure" true — same injected-clock style as [recordingStateFor] just above.
          *
-         *  Swift's twin keeps both inside its own `shortAgo` and is fine there — XCTest runs against a
-         *  real bundle, so `String(localized:)` resolves. The two SIGNATURES therefore differ on purpose;
-         *  the decision they encode does not. Don't "restore parity" by moving the lookup back in here. */
+         *  There used to be a `nowLabel` parameter too, carrying the already-translated "now" word for the
+         *  `< 60s` branch, because resolving it in here goes through `NoopApplication` and throws under a
+         *  plain JVM unit test (no Robolectric, so no Application is ever attached). #1472 removed the
+         *  word itself — see [shortSyncAgo] — so there is no lookup left to inject, and this signature now
+         *  matches Swift's. */
         fun resolve(
             backfilling: Boolean,
             chunks: Int,
             lastSyncAtSec: Long?,
             historySyncExperimental: Boolean,
             nowSec: Long,
-            nowLabel: String,
         ): SyncChipState = when {
             backfilling -> Syncing(chunks)
-            lastSyncAtSec != null -> Synced(shortSyncAgo(lastSyncAtSec, nowSec, nowLabel))
+            lastSyncAtSec != null -> Synced(shortSyncAgo(lastSyncAtSec, nowSec))
             historySyncExperimental -> ExperimentalLive
             else -> Hidden
         }
     }
 }
 
-/** Compact relative age for the header chip ("now" / "Nm" / "Nh" / "Nd") from a unix-SECONDS timestamp —
- *  deliberately terse. "now" is the only word in here (the rest is digits + a unit letter), so it's the
- *  only piece that needs a catalog entry to translate; it arrives as [nowLabel], resolved by the
- *  composable that owns the chip, so the bucketing stays framework-free. [nowSec] is unix seconds,
- *  injected for the same reason. Mirrors the iOS `SyncChipState.shortAgo`. */
-internal fun shortSyncAgo(unixSec: Long, nowSec: Long, nowLabel: String): String {
+/** Compact relative age for the header chip ("<1m" / "Nm" / "Nh" / "Nd") from a unix-SECONDS timestamp —
+ *  deliberately terse, and now wordless in every branch.
+ *
+ *  EVERY branch must read correctly with a trailing "ago", because the chip's accessibility description
+ *  wraps it in "Strap history synced %1$s ago". The sub-minute branch used to return the translated word
+ *  "now", which read "Strap history synced now ago" to a screen reader (#1472). "<1m" composes, and being
+ *  digits and symbols it needs no catalog entry in any language — which is what let the `nowLabel`
+ *  parameter and its string resource go. [nowSec] is unix seconds, injected to keep this pure.
+ *  Mirrors the iOS `SyncChipState.shortAgo`. */
+internal fun shortSyncAgo(unixSec: Long, nowSec: Long): String {
     val secs = (nowSec - unixSec).coerceAtLeast(0)
     return when {
-        secs < 60 -> nowLabel
+        secs < 60 -> "<1m"
         secs < 3600 -> "${secs / 60}m"
         secs < 86_400 -> "${secs / 3600}h"
         else -> "${secs / 86_400}d"

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -2248,7 +2248,6 @@ private fun SyncStatusChip(
         lastSyncAtSec = lastSyncAt,
         historySyncExperimental = historySyncExperimental,
         nowSec = System.currentTimeMillis() / 1000L,
-        nowLabel = uiString(R.string.l10n_today_screen_sync_chip_now_c9bc849a),
     )
     when (state) {
         is SyncChipState.Syncing -> ChipCapsule(

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1677,7 +1677,6 @@
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">Profil und Einstellungen</string>
     <string name="l10n_today_screen_recovery_ea924f72">Erholung</string>
-    <string name="l10n_today_screen_sync_chip_now_c9bc849a">jetzt</string>
     <string name="l10n_today_screen_sync_chip_live_98aadb37">Live</string>
     <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">Verlaufssynchronisierung des Straps läuft, %1$d Chunks</string>
     <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">Verlauf des Straps vor %1$s synchronisiert</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1474,7 +1474,6 @@
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">Perfil y ajustes</string>
     <string name="l10n_today_screen_recovery_ea924f72">Recuperación</string>
-    <string name="l10n_today_screen_sync_chip_now_c9bc849a">ahora</string>
     <string name="l10n_today_screen_sync_chip_live_98aadb37">en vivo</string>
     <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">Sincronizando el historial de la pulsera, %1$d bloques</string>
     <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">Historial de la pulsera sincronizado hace %1$s</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1492,7 +1492,6 @@
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">Profil et réglages</string>
     <string name="l10n_today_screen_recovery_ea924f72">Récupération</string>
-    <string name="l10n_today_screen_sync_chip_now_c9bc849a">à l\'instant</string>
     <string name="l10n_today_screen_sync_chip_live_98aadb37">en direct</string>
     <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">Synchronisation de l\'historique du bracelet, %1$d blocs</string>
     <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">Historique du bracelet synchronisé il y a %1$s</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -1634,7 +1634,6 @@
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">Profil i ustawienia</string>
     <string name="l10n_today_screen_recovery_ea924f72">Regeneracja</string>
-    <string name="l10n_today_screen_sync_chip_now_c9bc849a">Teraz</string>
     <string name="l10n_today_screen_sync_chip_live_98aadb37">na żywo</string>
     <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">Synchronizowanie historii pasków, fragmenty %1$d</string>
     <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">Historia paska zsynchronizowana %1$s temu</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1640,7 +1640,6 @@
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">Perfil e definições</string>
     <string name="l10n_today_screen_recovery_ea924f72">Recuperação</string>
-    <string name="l10n_today_screen_sync_chip_now_c9bc849a">agora</string>
     <string name="l10n_today_screen_sync_chip_live_98aadb37">em direto</string>
     <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">A sincronizar o histórico da bracelete, %1$d pedaços</string>
     <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">Histórico da bracelete sincronizado há %1$s</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1620,7 +1620,6 @@
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">个人资料与设置</string>
     <string name="l10n_today_screen_recovery_ea924f72">恢复分数</string>
-    <string name="l10n_today_screen_sync_chip_now_c9bc849a">刚刚</string>
     <string name="l10n_today_screen_sync_chip_live_98aadb37">实时</string>
     <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">正在同步腕带历史记录，%1$d 个数据块</string>
     <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">手环历史记录已在 %1$s 前同步</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1686,7 +1686,6 @@
     <string name="l10n_today_screen_pct_ee63e247">%1$s%%</string>
     <string name="l10n_today_screen_profile_and_settings_9b3d12f2">Profile and settings</string>
     <string name="l10n_today_screen_recovery_ea924f72">Recovery</string>
-    <string name="l10n_today_screen_sync_chip_now_c9bc849a">now</string>
     <string name="l10n_today_screen_sync_chip_live_98aadb37">live</string>
     <string name="l10n_today_screen_sync_chip_syncing_desc_bfc290e7">Syncing strap history, %1$d chunks</string>
     <string name="l10n_today_screen_sync_chip_synced_desc_4d255944">Strap history synced %1$s ago</string>

--- a/android/app/src/test/java/com/noop/ui/SyncChipStateTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SyncChipStateTest.kt
@@ -9,27 +9,23 @@ import org.junit.Test
  * the four sync states to show. Mirrors the iOS `SyncChipStateTests` 1:1 — same priority order (backfilling
  * wins over a known last-sync, which wins over the 5/MG experimental fallback), same cold-start `Hidden` case.
  *
- * Every case pins [NOW] instead of reading the system clock, and passes the "now" word in as [NOW_LABEL]
- * instead of letting `resolve` resolve it: these are plain JVM tests with no Robolectric, so there is no
- * attached `NoopApplication` to read the string catalog from. That is what made the `< 60s` cases below
- * throw `IllegalStateException: NoopApplication is not attached` while every other case passed — only the
- * sub-minute branch of `shortSyncAgo` needs a translated word.
+ * Every case pins [NOW] instead of reading the system clock. There used to be a `NOW_LABEL` parameter too,
+ * because the sub-minute branch returned a translated word and resolving it needed an attached
+ * `NoopApplication` these plain JVM tests do not have. #1472 removed the word, so the injection went with
+ * it — every branch is now digits and symbols.
  */
 class SyncChipStateTest {
 
     private companion object {
         /** Any fixed instant works now that `resolve` takes its clock as an argument. */
         const val NOW = 1_700_000_000L
-
-        /** Stand-in for the `l10n_today_screen_sync_chip_now_*` catalog entry the composable passes in. */
-        const val NOW_LABEL = "now"
     }
 
     @Test
     fun backfilling_isSyncingWithChunkCount() {
         val state = SyncChipState.resolve(
             backfilling = true, chunks = 7, lastSyncAtSec = null, historySyncExperimental = false,
-            nowSec = NOW, nowLabel = NOW_LABEL,
+            nowSec = NOW,
         )
         assertEquals(SyncChipState.Syncing(7), state)
     }
@@ -38,7 +34,7 @@ class SyncChipStateTest {
     fun lastSyncedAt_isSyncedWithAgeText() {
         val state = SyncChipState.resolve(
             backfilling = false, chunks = 0, lastSyncAtSec = NOW - 65, historySyncExperimental = false,
-            nowSec = NOW, nowLabel = NOW_LABEL,
+            nowSec = NOW,
         )
         assertEquals(SyncChipState.Synced("1m"), state)
     }
@@ -47,7 +43,7 @@ class SyncChipStateTest {
     fun historySyncExperimental_withNoLastSync_isExperimentalLive() {
         val state = SyncChipState.resolve(
             backfilling = false, chunks = 0, lastSyncAtSec = null, historySyncExperimental = true,
-            nowSec = NOW, nowLabel = NOW_LABEL,
+            nowSec = NOW,
         )
         assertEquals(SyncChipState.ExperimentalLive, state)
     }
@@ -56,7 +52,7 @@ class SyncChipStateTest {
     fun coldStart_noBackfillNoSyncNoExperimental_isHidden() {
         val state = SyncChipState.resolve(
             backfilling = false, chunks = 0, lastSyncAtSec = null, historySyncExperimental = false,
-            nowSec = NOW, nowLabel = NOW_LABEL,
+            nowSec = NOW,
         )
         assertEquals(SyncChipState.Hidden, state)
     }
@@ -65,7 +61,7 @@ class SyncChipStateTest {
     fun backfilling_takesPriorityOverLastSyncedAt() {
         val state = SyncChipState.resolve(
             backfilling = true, chunks = 2, lastSyncAtSec = NOW - 5, historySyncExperimental = false,
-            nowSec = NOW, nowLabel = NOW_LABEL,
+            nowSec = NOW,
         )
         assertEquals(SyncChipState.Syncing(2), state)
     }
@@ -74,24 +70,23 @@ class SyncChipStateTest {
     fun lastSyncedAt_takesPriorityOverHistorySyncExperimental() {
         val state = SyncChipState.resolve(
             backfilling = false, chunks = 0, lastSyncAtSec = NOW - 5, historySyncExperimental = true,
-            nowSec = NOW, nowLabel = NOW_LABEL,
+            nowSec = NOW,
         )
         assertTrue("A known last-sync should win over the experimental fallback", state is SyncChipState.Synced)
     }
 
     /**
-     * Regression guard for the branch that used to be unreachable from a unit test: a sub-minute sync must
-     * render the caller-supplied word verbatim. This fails to even compile — let alone pass — if the string
-     * lookup ever moves back inside `shortSyncAgo`, which is the whole point of keeping it out. No iOS twin:
-     * Swift's `shortAgo` resolves its own clock and `String(localized:)`, and can afford to because XCTest
-     * runs against a real bundle.
+     * #1472 regression guard. The sub-minute token is wrapped by the chip's accessibility description,
+     * "Strap history synced %1$s ago", so it must compose with a trailing "ago". It used to be the word
+     * "now", which read "Strap history synced now ago"; "<1m" is the fix and this pins it. Twin of the iOS
+     * `lastSyncedUnderAMinute_usesSubMinuteToken`.
      */
     @Test
-    fun lastSyncedUnderAMinute_isSyncedWithTheInjectedNowLabel() {
+    fun lastSyncedUnderAMinute_usesSubMinuteToken() {
         val state = SyncChipState.resolve(
             backfilling = false, chunks = 0, lastSyncAtSec = NOW - 5, historySyncExperimental = false,
-            nowSec = NOW, nowLabel = NOW_LABEL,
+            nowSec = NOW,
         )
-        assertEquals(SyncChipState.Synced("now"), state)
+        assertEquals(SyncChipState.Synced("<1m"), state)
     }
 }


### PR DESCRIPTION
Fixes #1472. Reported by @justinjor-bit, with the call sites already located — the diagnosis was correct and complete for the bug as filed.

### 1. The reported bug

`relativeAgo` returns a complete phrase carrying its own suffix, and `LiquidTodayView` was the only one of six call sites to append another:

```swift
value: String(localized: "Synced \(relativeAgo(ts)) ago")   // "Synced 1 min ago ago"
```

Under a minute it read "Synced **just now** ago". Dropping the trailing word is the whole fix there, exactly as suggested.

### 2. The `now ago` case is visible, not just VoiceOver

The report treats `shortAgo` returning `"now"` as a screen-reader issue. `DevicesView` wraps that value in **visible detail text**:

```swift
detail:        String(localized: "Synced \(agoText) ago"),      // ← on screen
accessibility: String(localized: "Strap history synced \(agoText) ago")
```

So sighted users saw **"Synced now ago"** for the first minute after every sync — the minute you are most likely to be looking at that row. Android has the same defect in the sync chip's accessibility description.

Both are fixed by making every branch of the token compose with a trailing "ago". The sub-minute token is now `"<1m"`, which also matches the shape of the other buckets (`5m` / `2h` / `3d`).

**This changes the Android chip's visible text from "now" to "<1m".** I'd said in review I'd keep "now" and give the sub-minute case its own phrasing; doing that needs `SyncChipState` to carry a "is sub-minute" flag on both platforms, and a uniform token is both smaller and more consistent. Flagging the reversal since it is a visible UI change, not a silent one.

Removing the word also removes the only translated part of the token, so Android's `nowLabel` parameter and its string resource are gone and the Kotlin signature now matches Swift's. The resource is deleted from all seven locale files together — a partial removal is a fatal `ExtraTranslation` at release lint.

### 3. Unreported: both strings were untranslated in all 9 locales

`'Strap history synced %@ ago'` is in the catalogue with all nine languages. **`'Synced %@ ago'` was absent entirely**, so both affected rows fell back to English while the accessibility label beside them was translated.

`Tools/i18n_audit.py` did not catch this because it measures coverage of keys *present* in the catalogue (currently de/es/fr/pt-PT at 0 gaps). A key missing outright is not a gap — it is invisible to the check.

Both keys are now present in all nine, with "ago" placed per language exactly as the existing sibling key does:

| | `Synced %@` (wraps a phrase) | `Synced %@ ago` (wraps a token) |
|---|---|---|
| de | Synchronisiert %@ | Vor %@ synchronisiert |
| ru | Синхронизировано %@ | Синхронизировано %@ назад |
| zh-Hans | 已同步 %@ | 已在 %@ 前同步 |

They differ because `relativeAgo` already yields a complete localized phrase (de "vor 5 Min.", ru "5 мин назад") while `shortAgo` yields a bare token — so only the second key may own the word "ago".

### Verification

- Regression test on **both** platforms pinning the sub-minute token, named as twins.
- Android: full unit suite passes; `SyncChipStateTest` `tests=7`; `compileFullDebugKotlin` clean; **`lintVitalFullRelease` clean** (the point of risk, given the resource removal); `i18n_audit --ci` clean; no locale key gaps.
- The iOS test runs on the `app-build` macOS leg, which executes `StrandTests`.
- Catalogue edit **appends only** — 116 lines added, 0 removed; verified the serializer round-trips the original byte-for-byte first, so no reformatting noise.

**Not verified on a device.** These are string changes with no behaviour attached, but the rendered result is unconfirmed on hardware.

---

### Re-review found two more things (fixed in 4ce121b)

**Chinese word order.** The `Synced %@` wrapper composed to `已同步 5 分钟前` — verb before the time expression, which Chinese does not do. Now `%@已同步`, giving **`5 分钟前已同步`** and **`刚刚已同步`**.

The other eight keep the wrapper word first, deliberately: it reads naturally there *and* keeps a capital letter at the start of the label, because `relativeAgo`'s output is lowercase mid-sentence in several languages (de `vor 5 Min.`, fr `il y a 5 min`). Fronting the placeholder in German would yield "vor 5 Min. synchronisiert" with a lowercase opening. Chinese has no such constraint, so it takes the natural order.

Every one of the nine was checked by composing the wrapper with the actual `%lld min ago` and `just now` translations rather than by reading the template alone.

**A stale test doc.** `SyncChipStateTests` claimed two consumers, named a `LiquidSyncChip` that does not exist anywhere in the tree, and said "three sync states" where the enum has four. Replaced with the fact that matters here: `DevicesView` is the only Apple consumer and it always appends "ago", which is *why* every token value must compose with it — the invariant this PR restores.

### On the check count

Three checks, not the usual fourteen: this PR touches `Strand/` and `android/` but not `Packages/**`, so `swift-packages` is correctly path-filtered out. The Swift side is covered by an on-demand `app-build` run instead — both legs green, and the macOS leg **executed** the new test:

```
Test Case '-[StrandTests.SyncChipStateTests testLastSyncedUnderAMinute_usesSubMinuteToken]' passed
** TEST SUCCEEDED **
```