### PR TITLE
Mark the orphaned 'now' catalogue key stale (#1472 follow-up)

### DIFF
--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -188366,6 +188366,7 @@
       }
     },
     "now": {
+      "extractionState": "stale",
       "localizations": {
         "de": {
           "stringUnit": {


### PR DESCRIPTION
Post-merge re-review of 8e1633a.

Replacing `shortAgo`'s sub-minute word with `<1m` removed the only `String(localized: "now")` in the tree, orphaning the catalogue key and its nine translations. The Android half of that commit deleted its equivalent resource from all seven locale files; the Apple half left its key looking live.

The catalogue already carries **69 keys marked `extractionState: stale`**, so that — not deletion — is how this project records an orphan, and it is what Xcode sets on the next extraction anyway. Marking it by hand keeps the committed catalogue honest in the meantime, and deleting instead would throw away nine translations that a future caller could reuse.

One line, metadata only. No translation touched, no key removed. `i18n_audit --ci` clean.

Not a behaviour change — nothing reads this key.