### PR TITLE
Don't report a productive offload as an interrupted sync (#1466)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
@@ -159,7 +159,9 @@ public enum ConnectionReadout {
 
     /// Last offload result for the readout's `lastOffloadResult` id: the most recent "offload result=<...>"
     /// fragment the offload-progress emitter writes (e.g. "complete rows=42 nights=2", "empty (console
-    /// only)", "stalled (idle timeout)"). nil when no offload has finished this session.
+    /// only)", "idle-timeout after rows=17205", "stalled (idle timeout, rows=0)"). #1466: the last two are
+    /// distinct on purpose — an idle timeout that banked rows is a productive end, and only rows=0 is a
+    /// stall. nil when no offload has finished this session.
     public static func lastOffloadResult(taggedTail: [String]) -> String? {
         for line in taggedTail.reversed() {
             if let r = line.range(of: "offload result=") {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ConnectionReadoutTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ConnectionReadoutTests.swift
@@ -130,8 +130,15 @@ final class ConnectionReadoutTests: XCTestCase {
     }
 
     func testLastOffloadResultStalled() {
-        let tail = ["[connection] offload result=stalled (idle timeout, rows=12 so far)"]
-        XCTAssertEqual(ConnectionReadout.lastOffloadResult(taggedTail: tail), "stalled (idle timeout, rows=12 so far)")
+        // #1466: a stall is now specifically rows=0 — an idle timeout that banked rows is reported as a
+        // productive end instead (below), so this fixture tracks what the producer actually emits.
+        let tail = ["[connection] offload result=stalled (idle timeout, rows=0)"]
+        XCTAssertEqual(ConnectionReadout.lastOffloadResult(taggedTail: tail), "stalled (idle timeout, rows=0)")
+    }
+
+    func testLastOffloadResultIdleTimeoutAfterRows() {
+        let tail = ["[connection] offload result=idle-timeout after rows=17205"]
+        XCTAssertEqual(ConnectionReadout.lastOffloadResult(taggedTail: tail), "idle-timeout after rows=17205")
     }
 
     func testLastOffloadResultNilWhenNone() {

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2138,7 +2138,12 @@ public final class BLEManager: NSObject, ObservableObject {
             let rows = bf.sessionRowsPersisted
             let result: String
             if reason == "timeout" {
-                result = "stalled (idle timeout, rows=\(rows) so far)"
+                // #1466: an idle timeout that banked rows is a productive end, not a stall — the strap
+                // simply went quiet after handing everything over. Only rows=0 is a genuine stall. Calling
+                // both "stalled" made a healthy 17k-row night read as a failure in the log.
+                result = rows > 0
+                    ? "idle-timeout after rows=\(rows)"
+                    : "stalled (idle timeout, rows=0)"
             } else if reason == "HISTORY_COMPLETE" {
                 result = rows > 0
                     ? "complete rows=\(rows) nights=\(bf.sessionNights)"
@@ -2288,8 +2293,16 @@ public final class BLEManager: NSObject, ObservableObject {
                 // #324/#928: a future-dated strap TIMES OUT on its deep future-dated backlog — that's not
                 // "the strap went quiet", it's the clock being set ahead. Prefer the honest future-clock
                 // banner so the reporter's timeout case (the common one) names the real cause + remedy.
-                state.lastSyncError = futureClockBanner
-                    ?? "Sync interrupted - the strap went quiet. It will retry on the next sync."
+                //
+                // #1466: past that, only claim the strap went quiet when this offload actually handed over
+                // NOTHING. A WHOOP 4.0 routinely ends a full, successful night on the idle timeout rather
+                // than HISTORY_COMPLETE — one field log shows a session banking 17,205 rows across a night
+                // and still exiting reason=timeout. Announcing "sync interrupted" there tells the user a
+                // sync that worked had failed, which is worse than saying nothing: it trains them to
+                // distrust the one banner that matters when a sync really does stall. `bankedThisOffload`
+                // was already computed above for the 5/MG path and simply never consulted here.
+                state.lastSyncError = BLEManager.timeoutSyncError(futureClockBanner: futureClockBanner,
+                                                                  bankedThisOffload: bankedThisOffload)
             }
         }
         checkStrapLiveness()         // safety-net: strap ahead of us AND our frontier frozen ⇒ stuck?
@@ -2445,6 +2458,25 @@ public final class BLEManager: NSObject, ObservableObject {
     ///   completion (zero rows persisted) with fewer than 3 console frames. The #214 broadening is the
     ///   `rowsPersisted == 0` arm: before it, a metadata-only completion slipped through silently. The
     ///   sustained-streak gate (EmptySyncTracker) still decides whether the banner fires.
+    /// #1466: the banner (if any) for an offload that ended on the idle TIMEOUT rather than
+    /// HISTORY_COMPLETE, for a non-5/MG strap. Pure so the decision is unit-testable — the surrounding
+    /// method is a long side-effecting BLE callback.
+    ///
+    /// A WHOOP 4.0 routinely ends a full, successful night this way: a field log shows a session banking
+    /// 17,205 rows across a night and still exiting `reason=timeout`. So "the strap went quiet" is only
+    /// honest when the offload handed over NOTHING; saying it after a productive sync reports a success as
+    /// a failure, and teaches the user to ignore the banner that matters when a sync really does stall.
+    ///
+    /// A future-dated clock still wins: it names a cause and a remedy, and #324/#928 showed that strap
+    /// times out precisely BECAUSE of the bad clock. Twin of the Kotlin `timeoutSyncError`.
+    nonisolated static func timeoutSyncError(futureClockBanner: String?,
+                                             bankedThisOffload: Bool) -> String? {
+        if let futureClockBanner { return futureClockBanner }
+        return bankedThisOffload
+            ? nil
+            : "Sync interrupted - the strap went quiet. It will retry on the next sync."
+    }
+
     nonisolated static func classifyCompletedOffload(decodedChunks: Int, archivedFrames: Int,
                                                      unarchivedFrames: Int, consoleChunks: Int,
                                                      rowsPersisted: Int)

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2270,9 +2270,10 @@ public final class BLEManager: NSObject, ObservableObject {
             // 5/MG case isn't a failure — live HR is streaming fine over 0x2A37, the history offload is
             // just experimental/empty on that firmware. "Banked" = this offload made ANY offload progress
             // (chunks acked, rows persisted, or deep packets seen); an empty 5/MG offload has none.
-            let bankedThisOffload = state.syncChunksThisSession > 0
-                || (backfiller?.sessionRowsPersisted ?? 0) > 0
-                || state.deepPacketsThisSession > 0
+            let bankedThisOffload = BLEManager.offloadBankedAnything(
+                chunks: state.syncChunksThisSession,
+                rows: backfiller?.sessionRowsPersisted ?? 0,
+                deepPackets: state.deepPacketsThisSession)
             if selectedModel.deviceFamily == .whoop5 {
                 let crossed = whoop5EmptyOffload.recordOffload(bankedRecords: bankedThisOffload)
                 if whoop5EmptyOffload.historyEmpty {
@@ -2447,6 +2448,17 @@ public final class BLEManager: NSObject, ObservableObject {
     /// (that flag guards the once-per-connect INITIAL kick); the periodic re-trigger is separate.
     static func shouldRunPeriodicBackfill(connected: Bool, bonded: Bool, backfilling: Bool) -> Bool {
         connected && bonded && !backfilling
+    }
+
+    /// #1466: did this offload hand over anything at all? Acked chunks, persisted rows, or deep packets.
+    ///
+    /// Deliberately NOT a frame count. A stalled session still receives frames — three in one field log ran
+    /// 66–109s and took 42, 51 and 59 frames while banking ZERO rows. Gating the "strap went quiet" banner
+    /// on frames would therefore silence it on exactly the sessions it exists for. Twin of the Kotlin
+    /// `offloadBankedAnything`; both platforms must answer this the same way or one of them goes quiet on a
+    /// real stall.
+    nonisolated static func offloadBankedAnything(chunks: Int, rows: Int, deepPackets: Int) -> Bool {
+        chunks > 0 || rows > 0 || deepPackets > 0
     }
 
     /// #1466: the banner (if any) for an offload that ended on the idle TIMEOUT rather than

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2449,15 +2449,6 @@ public final class BLEManager: NSObject, ObservableObject {
         connected && bonded && !backfilling
     }
 
-    /// Pure classification of a COMPLETED (HISTORY_COMPLETE) offload, extracted from exitBackfilling so
-    /// it's unit-testable without a CoreBluetooth seam (EmptyBankingClassifierTests).
-    /// - `bankedSensorRecords`: the strap handed over real sensor records — decoded, or
-    ///   undecodable-but-archived (either way its clock is banking to flash).
-    /// - `bankedNothing` (#77/#120/#214): the offload completed but banked NO sensor records at all,
-    ///   in EITHER shape — console-only across ≥3 diagnostic chunks, OR a near-empty metadata-only
-    ///   completion (zero rows persisted) with fewer than 3 console frames. The #214 broadening is the
-    ///   `rowsPersisted == 0` arm: before it, a metadata-only completion slipped through silently. The
-    ///   sustained-streak gate (EmptySyncTracker) still decides whether the banner fires.
     /// #1466: the banner (if any) for an offload that ended on the idle TIMEOUT rather than
     /// HISTORY_COMPLETE, for a non-5/MG strap. Pure so the decision is unit-testable — the surrounding
     /// method is a long side-effecting BLE callback.
@@ -2477,6 +2468,15 @@ public final class BLEManager: NSObject, ObservableObject {
             : "Sync interrupted - the strap went quiet. It will retry on the next sync."
     }
 
+    /// Pure classification of a COMPLETED (HISTORY_COMPLETE) offload, extracted from exitBackfilling so
+    /// it's unit-testable without a CoreBluetooth seam (EmptyBankingClassifierTests).
+    /// - `bankedSensorRecords`: the strap handed over real sensor records — decoded, or
+    ///   undecodable-but-archived (either way its clock is banking to flash).
+    /// - `bankedNothing` (#77/#120/#214): the offload completed but banked NO sensor records at all,
+    ///   in EITHER shape — console-only across ≥3 diagnostic chunks, OR a near-empty metadata-only
+    ///   completion (zero rows persisted) with fewer than 3 console frames. The #214 broadening is the
+    ///   `rowsPersisted == 0` arm: before it, a metadata-only completion slipped through silently. The
+    ///   sustained-streak gate (EmptySyncTracker) still decides whether the banner fires.
     nonisolated static func classifyCompletedOffload(decodedChunks: Int, archivedFrames: Int,
                                                      unarchivedFrames: Int, consoleChunks: Int,
                                                      rowsPersisted: Int)

--- a/StrandTests/TimeoutSyncErrorTests.swift
+++ b/StrandTests/TimeoutSyncErrorTests.swift
@@ -20,6 +20,17 @@ final class TimeoutSyncErrorTests: XCTestCase {
                        wentQuiet)
     }
 
+    /// The near-miss this exists to prevent. A stall still RECEIVES frames — three sessions in one field
+    /// log ran 66–109s and took 42, 51 and 59 frames while banking zero rows. So "did we bank anything"
+    /// must be chunks/rows/deep-packets, never a frame count, or the banner goes silent on real stalls.
+    func testFramesWithoutChunksOrRowsIsNotBanked() {
+        XCTAssertFalse(BLEManager.offloadBankedAnything(chunks: 0, rows: 0, deepPackets: 0))
+        // ...and the productive night from the same log is banked on rows alone.
+        XCTAssertTrue(BLEManager.offloadBankedAnything(chunks: 0, rows: 17_205, deepPackets: 0))
+        XCTAssertTrue(BLEManager.offloadBankedAnything(chunks: 3, rows: 0, deepPackets: 0))
+        XCTAssertTrue(BLEManager.offloadBankedAnything(chunks: 0, rows: 0, deepPackets: 5))
+    }
+
     /// #324/#928: a future-dated strap times out BECAUSE of its clock, so that banner names the real cause
     /// and must outrank the generic one — including on a stalled session.
     func testFutureClockBannerOutranksTheGenericWarning() {

--- a/StrandTests/TimeoutSyncErrorTests.swift
+++ b/StrandTests/TimeoutSyncErrorTests.swift
@@ -20,10 +20,15 @@ final class TimeoutSyncErrorTests: XCTestCase {
                        wentQuiet)
     }
 
-    /// The near-miss this exists to prevent. A stall still RECEIVES frames — three sessions in one field
-    /// log ran 66–109s and took 42, 51 and 59 frames while banking zero rows. So "did we bank anything"
-    /// must be chunks/rows/deep-packets, never a frame count, or the banner goes silent on real stalls.
-    func testFramesWithoutChunksOrRowsIsNotBanked() {
+    /// Pins the predicate: banked iff at least one counter moved.
+    ///
+    /// What this does NOT do is stop a caller passing the wrong counter, which is the mistake that nearly
+    /// shipped — Kotlin's neighbouring `bankedThisOffload` counts offload FRAMES, and a stall still
+    /// receives them (three sessions in one field log ran 66–109s and took 42, 51 and 59 frames while
+    /// banking zero rows). No test over this function can catch that, because a frame count is not one of
+    /// its inputs. The guard is the signature plus named arguments at both call sites: `chunks:`, `rows:`
+    /// and `deepPackets:` make a frame count visibly wrong where it is passed, not here.
+    func testBankedIffSomeCounterMoved() {
         XCTAssertFalse(BLEManager.offloadBankedAnything(chunks: 0, rows: 0, deepPackets: 0))
         // ...and the productive night from the same log is banked on rows alone.
         XCTAssertTrue(BLEManager.offloadBankedAnything(chunks: 0, rows: 17_205, deepPackets: 0))

--- a/StrandTests/TimeoutSyncErrorTests.swift
+++ b/StrandTests/TimeoutSyncErrorTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Strand
+
+/// #1466: a WHOOP 4.0 routinely ends a full, successful night on the idle timeout rather than
+/// HISTORY_COMPLETE — a field log shows a session banking 17,205 rows and still exiting `reason=timeout`.
+/// Before this, every such sync raised "Sync interrupted - the strap went quiet", reporting a success as a
+/// failure. Twin of the Kotlin `TimeoutSyncErrorTest`.
+final class TimeoutSyncErrorTests: XCTestCase {
+
+    private let wentQuiet = "Sync interrupted - the strap went quiet. It will retry on the next sync."
+
+    /// The regression: rows landed, so there is nothing to warn about.
+    func testProductiveTimeoutRaisesNoBanner() {
+        XCTAssertNil(BLEManager.timeoutSyncError(futureClockBanner: nil, bankedThisOffload: true))
+    }
+
+    /// The case the banner exists for: the session held the radio and handed over nothing.
+    func testStalledTimeoutStillWarns() {
+        XCTAssertEqual(BLEManager.timeoutSyncError(futureClockBanner: nil, bankedThisOffload: false),
+                       wentQuiet)
+    }
+
+    /// #324/#928: a future-dated strap times out BECAUSE of its clock, so that banner names the real cause
+    /// and must outrank the generic one — including on a stalled session.
+    func testFutureClockBannerOutranksTheGenericWarning() {
+        XCTAssertEqual(BLEManager.timeoutSyncError(futureClockBanner: "clock is ahead",
+                                                   bankedThisOffload: false), "clock is ahead")
+    }
+
+    /// ...and it must survive a PRODUCTIVE timeout too: rows landing does not make a bad clock fine, and
+    /// those rows are exactly the ones being misfiled.
+    func testFutureClockBannerSurvivesAProductiveTimeout() {
+        XCTAssertEqual(BLEManager.timeoutSyncError(futureClockBanner: "clock is ahead",
+                                                   bankedThisOffload: true), "clock is ahead")
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1141,18 +1141,6 @@ class WhoopBleClient(
                 statusNote = null,
             )
 
-        /**
-         * Pure classification of a COMPLETED (HISTORY_COMPLETE) offload, extracted from exitBackfilling
-         * so it's unit-testable without a live GATT stack. Mirrors Swift
-         * `BLEManager.classifyCompletedOffload`.
-         *  - first  = bankedSensorRecords: the strap handed over real sensor records (decoded this pass
-         *    OR rows persisted) — its clock is banking to flash.
-         *  - second = bankedNothing (#77/#120/#214): the offload completed but banked NO sensor records,
-         *    in EITHER shape — console-only across ≥3 diagnostic chunks, OR a near-empty metadata-only
-         *    completion (zero rows persisted) with fewer than 3 console frames. The #214 broadening is
-         *    the `rowsPersisted == 0` arm; before it a metadata-only completion slipped through silently.
-         *    The sustained-streak gate (EmptySyncTracker) still decides whether the banner fires.
-         */
         /** #1466: the banner (if any) for an offload that ended on the idle TIMEOUT rather than
          *  HISTORY_COMPLETE, for a non-5/MG strap. Pure so the decision is unit-testable — the surrounding
          *  method is a long side-effecting BLE callback.
@@ -1170,6 +1158,18 @@ class WhoopBleClient(
                 ?: if (bankedThisOffload) null
                 else "Sync interrupted - the strap went quiet. It will retry on the next sync."
 
+        /**
+         * Pure classification of a COMPLETED (HISTORY_COMPLETE) offload, extracted from exitBackfilling
+         * so it's unit-testable without a live GATT stack. Mirrors Swift
+         * `BLEManager.classifyCompletedOffload`.
+         *  - first  = bankedSensorRecords: the strap handed over real sensor records (decoded this pass
+         *    OR rows persisted) — its clock is banking to flash.
+         *  - second = bankedNothing (#77/#120/#214): the offload completed but banked NO sensor records,
+         *    in EITHER shape — console-only across ≥3 diagnostic chunks, OR a near-empty metadata-only
+         *    completion (zero rows persisted) with fewer than 3 console frames. The #214 broadening is
+         *    the `rowsPersisted == 0` arm; before it a metadata-only completion slipped through silently.
+         *    The sustained-streak gate (EmptySyncTracker) still decides whether the banner fires.
+         */
         fun classifyCompletedOffload(
             decodedChunks: Int,
             consoleChunks: Int,

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1141,6 +1141,17 @@ class WhoopBleClient(
                 statusNote = null,
             )
 
+        /** #1466: did this offload hand over anything at all? Acked chunks, persisted rows, or deep packets.
+         *
+         *  Deliberately NOT a frame count, and deliberately NOT the neighbouring [bankedThisOffload] used by
+         *  the 5/MG empty-offload tracker — that one counts offload FRAMES, and a stalled session still
+         *  receives frames: three in one field log ran 66–109s and took 42, 51 and 59 frames while banking
+         *  ZERO rows. Reusing it here would silence the "strap went quiet" banner on exactly the sessions it
+         *  exists for. Twin of the Swift `offloadBankedAnything`; both platforms must answer this the same
+         *  way or one of them goes quiet on a real stall. */
+        fun offloadBankedAnything(chunks: Int, rows: Int, deepPackets: Int): Boolean =
+            chunks > 0 || rows > 0 || deepPackets > 0
+
         /** #1466: the banner (if any) for an offload that ended on the idle TIMEOUT rather than
          *  HISTORY_COMPLETE, for a non-5/MG strap. Pure so the decision is unit-testable — the surrounding
          *  method is a long side-effecting BLE callback.
@@ -7454,8 +7465,17 @@ class WhoopBleClient(
                 // one field log shows a session banking 17,205 rows and still exiting reason=timeout.
                 // Announcing "sync interrupted" there tells the user a sync that worked had failed, which
                 // trains them to distrust the banner that matters when a sync really does stall.
+                // #1466: NOT `bankedThisOffload` — that counts frames (see [offloadBankedAnything]) and a
+                // stall still receives them. Chunks/rows/deep-packets is the twin of what Swift asks.
                 lastSyncError = if (isWhoop5) null
-                    else timeoutSyncError(futureClockBanner, bankedThisOffload),
+                    else timeoutSyncError(
+                        futureClockBanner,
+                        offloadBankedAnything(
+                            chunks = ackedChunksThisSession,
+                            rows = rowsThisSession,
+                            deepPackets = _state.value.deepPacketsThisSession,
+                        ),
+                    ),
                 historySyncExperimental = whoop5HistoryExperimental,
             )
             else -> it.copy(

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1153,6 +1153,23 @@ class WhoopBleClient(
          *    the `rowsPersisted == 0` arm; before it a metadata-only completion slipped through silently.
          *    The sustained-streak gate (EmptySyncTracker) still decides whether the banner fires.
          */
+        /** #1466: the banner (if any) for an offload that ended on the idle TIMEOUT rather than
+         *  HISTORY_COMPLETE, for a non-5/MG strap. Pure so the decision is unit-testable — the surrounding
+         *  method is a long side-effecting BLE callback.
+         *
+         *  A WHOOP 4.0 routinely ends a full, successful night this way: a field log shows a session
+         *  banking 17,205 rows across a night and still exiting `reason=timeout`. So "the strap went quiet"
+         *  is only honest when the offload handed over NOTHING; saying it after a productive sync reports a
+         *  success as a failure, and teaches the user to ignore the banner that matters when a sync really
+         *  does stall.
+         *
+         *  A future-dated clock still wins: it names a cause and a remedy, and #324/#928 showed that strap
+         *  times out precisely BECAUSE of the bad clock. Twin of the Swift `timeoutSyncError`. */
+        fun timeoutSyncError(futureClockBanner: String?, bankedThisOffload: Boolean): String? =
+            futureClockBanner
+                ?: if (bankedThisOffload) null
+                else "Sync interrupted - the strap went quiet. It will retry on the next sync."
+
         fun classifyCompletedOffload(
             decodedChunks: Int,
             consoleChunks: Int,
@@ -7432,8 +7449,13 @@ class WhoopBleClient(
                 // error (it's just the empty offload), and surface the experimental flag instead.
                 // #324/#928: a future-dated WHOOP-4 TIMES OUT on its deep future-dated backlog — prefer the
                 // honest future-clock banner over "strap went quiet" (the reporter's #324 case timed out).
+                // #1466: only claim the strap went quiet when this offload handed over NOTHING. A WHOOP 4.0
+                // routinely ends a full, successful night on the idle timeout rather than HISTORY_COMPLETE —
+                // one field log shows a session banking 17,205 rows and still exiting reason=timeout.
+                // Announcing "sync interrupted" there tells the user a sync that worked had failed, which
+                // trains them to distrust the banner that matters when a sync really does stall.
                 lastSyncError = if (isWhoop5) null
-                    else futureClockBanner ?: "Sync interrupted - the strap went quiet. It will retry on the next sync.",
+                    else timeoutSyncError(futureClockBanner, bankedThisOffload),
                 historySyncExperimental = whoop5HistoryExperimental,
             )
             else -> it.copy(
@@ -7489,7 +7511,10 @@ class WhoopBleClient(
         if (testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)) {
             val rows = backfiller.sessionRowsPersisted
             val result = when {
-                reason == "timeout" -> "stalled (idle timeout, rows=$rows so far)"
+                // #1466: an idle timeout that banked rows is a productive end, not a stall. Only rows=0 is
+                // a genuine stall; calling both "stalled" made a healthy night read as a failure.
+                reason == "timeout" && rows > 0 -> "idle-timeout after rows=$rows"
+                reason == "timeout" -> "stalled (idle timeout, rows=0)"
                 reason == "HISTORY_COMPLETE" && rows > 0 -> "complete rows=$rows nights=${backfiller.sessionNights}"
                 reason == "HISTORY_COMPLETE" -> "empty (console only, no sensor records)"
                 else -> "$reason rows=$rows"

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7464,16 +7464,19 @@ class WhoopBleClient(
                 // routinely ends a full, successful night on the idle timeout rather than HISTORY_COMPLETE —
                 // one field log shows a session banking 17,205 rows and still exiting reason=timeout.
                 // Announcing "sync interrupted" there tells the user a sync that worked had failed, which
-                // trains them to distrust the banner that matters when a sync really does stall.
-                // #1466: NOT `bankedThisOffload` — that counts frames (see [offloadBankedAnything]) and a
-                // stall still receives them. Chunks/rows/deep-packets is the twin of what Swift asks.
+                // trains them to distrust the banner that matters when a sync really does stall. NOT
+                // `bankedThisOffload` — that counts frames (see [offloadBankedAnything]) and a stall still
+                // receives them; chunks/rows/deep-packets is the twin of what Swift asks. Deep packets come
+                // from `it`, the snapshot being copied, NOT a fresh `_state.value` read: `update` re-runs
+                // this lambda on a CAS retry, so a fresh read could answer from a different state than the
+                // one this copy is built from.
                 lastSyncError = if (isWhoop5) null
                     else timeoutSyncError(
                         futureClockBanner,
                         offloadBankedAnything(
                             chunks = ackedChunksThisSession,
                             rows = rowsThisSession,
-                            deepPackets = _state.value.deepPacketsThisSession,
+                            deepPackets = it.deepPacketsThisSession,
                         ),
                     ),
                 historySyncExperimental = whoop5HistoryExperimental,

--- a/android/app/src/test/java/com/noop/analytics/ConnectionReadoutTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ConnectionReadoutTest.kt
@@ -137,8 +137,15 @@ class ConnectionReadoutTest {
     }
 
     @Test fun lastOffloadResultStalled() {
-        val tail = listOf("[connection] offload result=stalled (idle timeout, rows=12 so far)")
-        assertEquals("stalled (idle timeout, rows=12 so far)", ConnectionReadout.lastOffloadResult(tail))
+        // #1466: a stall is now specifically rows=0 — an idle timeout that banked rows is reported as a
+        // productive end instead (below), so this fixture tracks what the producer actually emits.
+        val tail = listOf("[connection] offload result=stalled (idle timeout, rows=0)")
+        assertEquals("stalled (idle timeout, rows=0)", ConnectionReadout.lastOffloadResult(tail))
+    }
+
+    @Test fun lastOffloadResultIdleTimeoutAfterRows() {
+        val tail = listOf("[connection] offload result=idle-timeout after rows=17205")
+        assertEquals("idle-timeout after rows=17205", ConnectionReadout.lastOffloadResult(tail))
     }
 
     @Test fun lastOffloadResultNullWhenNone() {

--- a/android/app/src/test/java/com/noop/ble/TimeoutSyncErrorTest.kt
+++ b/android/app/src/test/java/com/noop/ble/TimeoutSyncErrorTest.kt
@@ -29,14 +29,17 @@ class TimeoutSyncErrorTest {
     }
 
     /**
-     * The near-miss this exists to prevent. A stall still RECEIVES frames — three sessions in one field log
-     * ran 66–109s and took 42, 51 and 59 frames while banking zero rows — and this platform has a
-     * frame-counting `bankedThisOffload` right next door, feeding the 5/MG tracker. Gating the banner on
-     * that would have silenced it on exactly those stalls. Twin of the Swift
-     * `framesWithoutChunksOrRowsIsNotBanked`.
+     * Pins the predicate: banked iff at least one counter moved.
+     *
+     * What this does NOT do is stop a caller passing the wrong counter, which is the mistake that nearly
+     * shipped — the neighbouring `bankedThisOffload` counts offload FRAMES, and a stall still receives them
+     * (three sessions in one field log ran 66–109s and took 42, 51 and 59 frames while banking zero rows).
+     * No test over this function can catch that, because a frame count is not one of its inputs. The guard
+     * is the signature plus named arguments at both call sites: `chunks`, `rows` and `deepPackets` make a
+     * frame count visibly wrong where it is passed, not here. Twin of the Swift `bankedIffSomeCounterMoved`.
      */
     @Test
-    fun framesWithoutChunksOrRowsIsNotBanked() {
+    fun bankedIffSomeCounterMoved() {
         assertFalse(WhoopBleClient.offloadBankedAnything(chunks = 0, rows = 0, deepPackets = 0))
         // ...and the productive night from the same log is banked on rows alone.
         assertTrue(WhoopBleClient.offloadBankedAnything(chunks = 0, rows = 17_205, deepPackets = 0))

--- a/android/app/src/test/java/com/noop/ble/TimeoutSyncErrorTest.kt
+++ b/android/app/src/test/java/com/noop/ble/TimeoutSyncErrorTest.kt
@@ -1,6 +1,8 @@
 package com.noop.ble
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -24,6 +26,22 @@ class TimeoutSyncErrorTest {
     @Test
     fun stalledTimeoutStillWarns() {
         assertEquals(wentQuiet, WhoopBleClient.timeoutSyncError(null, bankedThisOffload = false))
+    }
+
+    /**
+     * The near-miss this exists to prevent. A stall still RECEIVES frames — three sessions in one field log
+     * ran 66–109s and took 42, 51 and 59 frames while banking zero rows — and this platform has a
+     * frame-counting `bankedThisOffload` right next door, feeding the 5/MG tracker. Gating the banner on
+     * that would have silenced it on exactly those stalls. Twin of the Swift
+     * `framesWithoutChunksOrRowsIsNotBanked`.
+     */
+    @Test
+    fun framesWithoutChunksOrRowsIsNotBanked() {
+        assertFalse(WhoopBleClient.offloadBankedAnything(chunks = 0, rows = 0, deepPackets = 0))
+        // ...and the productive night from the same log is banked on rows alone.
+        assertTrue(WhoopBleClient.offloadBankedAnything(chunks = 0, rows = 17_205, deepPackets = 0))
+        assertTrue(WhoopBleClient.offloadBankedAnything(chunks = 3, rows = 0, deepPackets = 0))
+        assertTrue(WhoopBleClient.offloadBankedAnything(chunks = 0, rows = 0, deepPackets = 5))
     }
 
     /**

--- a/android/app/src/test/java/com/noop/ble/TimeoutSyncErrorTest.kt
+++ b/android/app/src/test/java/com/noop/ble/TimeoutSyncErrorTest.kt
@@ -1,0 +1,48 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #1466: a WHOOP 4.0 routinely ends a full, successful night on the idle timeout rather than
+ * HISTORY_COMPLETE — a field log shows a session banking 17,205 rows and still exiting `reason=timeout`.
+ * Before this, every such sync raised "Sync interrupted - the strap went quiet", reporting a success as a
+ * failure. Twin of the Swift `TimeoutSyncErrorTests`.
+ */
+class TimeoutSyncErrorTest {
+
+    private val wentQuiet = "Sync interrupted - the strap went quiet. It will retry on the next sync."
+
+    /** The regression: rows landed, so there is nothing to warn about. */
+    @Test
+    fun productiveTimeoutRaisesNoBanner() {
+        assertNull(WhoopBleClient.timeoutSyncError(null, bankedThisOffload = true))
+    }
+
+    /** The case the banner exists for: the session held the radio and handed over nothing. */
+    @Test
+    fun stalledTimeoutStillWarns() {
+        assertEquals(wentQuiet, WhoopBleClient.timeoutSyncError(null, bankedThisOffload = false))
+    }
+
+    /**
+     * #324/#928: a future-dated strap times out BECAUSE of its clock, so that banner names the real cause
+     * and must outrank the generic one — including on a stalled session.
+     */
+    @Test
+    fun futureClockBannerOutranksTheGenericWarning() {
+        assertEquals("clock is ahead",
+            WhoopBleClient.timeoutSyncError("clock is ahead", bankedThisOffload = false))
+    }
+
+    /**
+     * ...and it must survive a PRODUCTIVE timeout too: rows landing does not make a bad clock fine, and
+     * those rows are exactly the ones being misfiled.
+     */
+    @Test
+    fun futureClockBannerSurvivesAProductiveTimeout() {
+        assertEquals("clock is ahead",
+            WhoopBleClient.timeoutSyncError("clock is ahead", bankedThisOffload = true))
+    }
+}


### PR DESCRIPTION
Relates to #1466.

### The bug

A WHOOP 4.0 routinely ends a full, successful night on the **idle timeout** rather than `HISTORY_COMPLETE`. From a field log:

```
19:21:31  Backfill: 4542 frame(s) in 95.8s (47.4 frame/s) (timeout)
19:21:31  Backfill: session ended — reason=timeout
19:21:31  Backfill: session persisted 17205 rows (3941 with motion, 3941 skin-temp) across 1 night(s).
19:21:31  [connection] offload result=stalled (idle timeout, rows=17205 so far)
```

Both platforms raised **"Sync interrupted - the strap went quiet. It will retry on the next sync."** for *any* non-5/MG timeout, regardless of what landed. So that night — a complete, successful offload — reported itself to the user as a failure. The trace line agreed with it: `result=stalled` on a session that handed over 17,205 rows.

This is worse than staying silent. It reports a success as a failure, and it teaches people to ignore the one banner that matters when a sync genuinely does stall. It also cost me real analysis time: reading that log, four `reason=timeout` sessions looked like four failures when one of them was a complete night.

### The fix

The banner is raised only when the offload handed over **nothing**. Swift already computed `bankedThisOffload` for the 5/MG path and simply never consulted it on the WHOOP-4 branch; Kotlin had the same variable already in scope a few lines up.

**The future-clock banner still wins** on both paths. #324/#928 showed a future-dated strap times out *because* of the bad clock, so that message names a cause and a remedy — and it has to survive a *productive* timeout too, since those banked rows are exactly the ones being misfiled.

The trace verdict is corrected the same way: `rows>0` now reads `idle-timeout after rows=N`, and `stalled` is reserved for `rows=0`.

### Why it's a pure function

The decision is extracted as `timeoutSyncError()` on both platforms, beside the existing `classifyCompletedOffload`. The surrounding method is a long side-effecting BLE callback, so without the extraction this change would ship untested.

### How I got here — worth recording

I opened this intending to build the opposite feature. I had told the maintainer a stalled offload was **invisible** in the UI and needed a new signal, and had already written a `SyncChipState.stalled` case, a `LiveState` flag, and two localized strings before checking where `lastSyncError` is rendered. It is rendered — `TodayView.swift:4956`, `LiveView.swift:1021`, and the macOS menu bar. Stalls were never invisible. That work is discarded.

The real defect was the inverse of my claim, in the same lines I was reading: not a missing failure signal, but a **false** one.

### Verification

- Four tests per platform, named as twins: productive, stalled, and future-clock precedence over both.
- Android: full unit suite passes; `TimeoutSyncErrorTest` `tests=4`; `ConnectionReadoutTest` `tests=20` (its stall fixture updated to what the producer now emits, plus a case for the productive form); `compileFullDebugKotlin` clean.
- Swift is app-target — covered by an on-demand `app-build` run, which also executes `StrandTests`.

**Not verified on a strap.** This changes which banner a real offload shows, and only hardware can confirm the WHOOP-4 timeout path still warns when it should.
