### PR TITLE
Stop rebuilding the whole strap log on every Test Centre readout tick

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2133,6 +2133,19 @@ class WhoopBleClient(
      *  the surviving tail, and exactly once, or a second roll would push this process's own partial tail in
      *  as a "previous" session. Guarded by [genLock]. */
     private var didRollGenerations = false
+
+    /** #1468 follow-up: the PREVIOUS-sessions half of [exportLogText], memoised for the process.
+     *
+     *  It is invariant once [rollLogGenerationsIfNeeded] has run: [persistLogGenerations] is called from
+     *  exactly one place, inside that latched roll, so nothing rewrites the generations again while the app
+     *  lives. Recomputing it was pure waste — and not free, since it re-reads SharedPreferences and
+     *  re-formats every past session.
+     *
+     *  That waste only became visible with the Test Centre live readouts (#1468), which call [exportLogText]
+     *  on every 250 ms coalesce tick while a panel is open, so a screen the user leaves open during an
+     *  offload re-read prefs and re-rendered historical sessions four times a second. Guarded by [genLock],
+     *  the same lock the roll uses, so the memo cannot be filled from a pre-roll read. */
+    private var cachedPreviousSessionsText: String? = null
     /** Durable-tail mirror counter, mutated only under [logBuffer]'s monitor (like [logBuffer] itself). */
     private var logsSincePersist = 0
 
@@ -8520,9 +8533,18 @@ class WhoopBleClient(
      */
     fun exportLogText(): String {
         rollLogGenerationsIfNeeded()
-        val previous = com.noop.ui.StrapLogGenerations.previousSessionsText(persistedLogGenerations())
-        val current = synchronized(logBuffer) { logBuffer.joinToString("\n") }
-        return previous + current
+        val previous = synchronized(genLock) {
+            cachedPreviousSessionsText
+                ?: com.noop.ui.StrapLogGenerations.previousSessionsText(persistedLogGenerations())
+                    .also { cachedPreviousSessionsText = it }
+        }
+        // #1468 follow-up: COPY the buffer under the lock and join outside it. The join allocates one string
+        // per line plus the result — thousands of lines during an offload — and `log()` is called from the
+        // GATT binder thread, which blocks on this same lock for every line it writes. Holding it only for a
+        // reference copy keeps a readout refresh from throttling the writer it is reading. Output is
+        // byte-identical either way.
+        val snapshot = synchronized(logBuffer) { logBuffer.toList() }
+        return previous + snapshot.joinToString("\n")
     }
 }
 

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -8553,11 +8553,8 @@ class WhoopBleClient(
     /** The previous-session lines exactly as [com.noop.ui.StrapLogGenerations.previousSessionsText] would
      *  render them, taken from the generations themselves so no string is built and re-split. Empty when
      *  there are no previous sessions, matching that function's empty-string case. */
-    private fun buildPreviousSessionsLines(): List<String> {
-        val gens = persistedLogGenerations()
-        if (gens.isEmpty()) return emptyList()
-        return gens.flatten() + com.noop.ui.StrapLogGenerations.CURRENT_SESSION_MARKER
-    }
+    private fun buildPreviousSessionsLines(): List<String> =
+        com.noop.ui.StrapLogGenerations.previousSessionsLines(persistedLogGenerations())
 
     /**
      * Snapshot of the recent strap log, newest last, for the "Share strap log" diagnostics export.

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2146,6 +2146,10 @@ class WhoopBleClient(
      *  offload re-read prefs and re-rendered historical sessions four times a second. Guarded by [genLock],
      *  the same lock the roll uses, so the memo cannot be filled from a pre-roll read. */
     private var cachedPreviousSessionsText: String? = null
+
+    /** Line-form twin of [cachedPreviousSessionsText], memoised for the same reason and under
+     *  the same [genLock]. Built from the generations directly — see [buildPreviousSessionsLines]. */
+    private var cachedPreviousSessionsLines: List<String>? = null
     /** Durable-tail mirror counter, mutated only under [logBuffer]'s monitor (like [logBuffer] itself). */
     private var logsSincePersist = 0
 
@@ -8519,6 +8523,40 @@ class WhoopBleClient(
     private fun emitConnectionBondState(detail: String) {
         if (!testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)) return
         log("bondState $detail", com.noop.testcentre.TestDomain.CONNECTION)
+    }
+
+    /** #1468 follow-up: the export as LINES, without ever building the joined string.
+     *
+     *  Every in-app consumer of the log immediately splits it again — `TestCentreLiveReadouts.rows` filters
+     *  to a single domain tag, `CaptureAccumulator.capturedDayKeys` does `split("\n")` — so joining 5,000
+     *  buffered lines plus every past session into one string, only for the caller to tear it back apart, is
+     *  pure overhead. It became a per-tick cost with the live readouts (#1468), which refresh every 250 ms
+     *  while a panel is open.
+     *
+     *  Same lines, same order as [exportLogText] splits into. The one difference is a trailing empty
+     *  segment: with an empty in-memory buffer, `exportLogText` ends in the newline after the session marker
+     *  and splitting it yields a final `""`, which this omits. No consumer can see that — an empty line
+     *  matches no domain tag and no day marker — but it is stated rather than glossed, because "identical"
+     *  would be a stronger claim than the code makes.
+     *
+     *  Only the share/export paths, which genuinely need one string, pay for the join. */
+    fun exportLogLines(): List<String> {
+        rollLogGenerationsIfNeeded()
+        val previous = synchronized(genLock) {
+            cachedPreviousSessionsLines
+                ?: buildPreviousSessionsLines().also { cachedPreviousSessionsLines = it }
+        }
+        val snapshot = synchronized(logBuffer) { logBuffer.toList() }
+        return if (previous.isEmpty()) snapshot else previous + snapshot
+    }
+
+    /** The previous-session lines exactly as [com.noop.ui.StrapLogGenerations.previousSessionsText] would
+     *  render them, taken from the generations themselves so no string is built and re-split. Empty when
+     *  there are no previous sessions, matching that function's empty-string case. */
+    private fun buildPreviousSessionsLines(): List<String> {
+        val gens = persistedLogGenerations()
+        if (gens.isEmpty()) return emptyList()
+        return gens.flatten() + com.noop.ui.StrapLogGenerations.CURRENT_SESSION_MARKER
     }
 
     /**

--- a/android/app/src/main/java/com/noop/testcentre/CaptureAccumulator.kt
+++ b/android/app/src/main/java/com/noop/testcentre/CaptureAccumulator.kt
@@ -60,12 +60,22 @@ object CaptureAccumulator {
     fun capturedDays(domain: TestDomain, reportText: String, tzOffsetSeconds: Long): Int =
         capturedDayKeys(domain, reportText, tzOffsetSeconds).size
 
+    /** Line-form twin of [capturedDays]. */
+    fun capturedDays(domain: TestDomain, reportLines: List<String>, tzOffsetSeconds: Long): Int =
+        capturedDayKeys(domain, reportLines, tzOffsetSeconds).size
+
     /** The SET of distinct local day keys [domain] captured (yyyy-MM-dd). Empty when the mode has no
      *  day-bearing trace / captured none. */
-    fun capturedDayKeys(domain: TestDomain, reportText: String, tzOffsetSeconds: Long): Set<String> {
+    fun capturedDayKeys(domain: TestDomain, reportText: String, tzOffsetSeconds: Long): Set<String> =
+        capturedDayKeys(domain, reportText.split("\n"), tzOffsetSeconds)
+
+    /** #1468 follow-up: the same scan over lines the caller already has. The string form splits and
+     *  delegates here, so both paths walk identical content — callers holding a line list no longer join
+     *  it just so this can split it again. */
+    fun capturedDayKeys(domain: TestDomain, reportLines: List<String>, tzOffsetSeconds: Long): Set<String> {
         val marker = markers[domain] ?: return emptySet()
         val days = HashSet<String>()
-        for (line in reportText.split("\n")) {
+        for (line in reportLines) {
             if (marker.tokens.none { line.contains(it) }) continue
             when (marker) {
                 is DayMarker.DayKey ->

--- a/android/app/src/main/java/com/noop/ui/StrapLogGenerations.kt
+++ b/android/app/src/main/java/com/noop/ui/StrapLogGenerations.kt
@@ -65,6 +65,12 @@ object StrapLogGenerations {
         return gens
     }
 
+    /** The marker separating banked previous sessions from this process's live tail. ONE definition:
+     *  `WhoopBleClient.exportLogLines` emits the same marker when it builds the line form without going
+     *  through [previousSessionsText], and two copies of this literal could drift apart silently — the
+     *  export would still render, just with a boundary the log parsers no longer agree on. */
+    const val CURRENT_SESSION_MARKER = "===== current app session ====="
+
     /**
      * The previous processes' lines, oldest-first, ready to sit AHEAD of the current session in an export.
      * Each generation is its own newline-joined block (its first line is its own separator header), and a
@@ -75,6 +81,6 @@ object StrapLogGenerations {
     fun previousSessionsText(generations: List<List<String>>): String {
         if (generations.isEmpty()) return ""
         return generations.joinToString("\n") { it.joinToString("\n") } + "\n" +
-            "===== current app session =====\n"
+            CURRENT_SESSION_MARKER + "\n"
     }
 }

--- a/android/app/src/main/java/com/noop/ui/StrapLogGenerations.kt
+++ b/android/app/src/main/java/com/noop/ui/StrapLogGenerations.kt
@@ -80,7 +80,28 @@ object StrapLogGenerations {
      */
     fun previousSessionsText(generations: List<List<String>>): String {
         if (generations.isEmpty()) return ""
-        return generations.joinToString("\n") { it.joinToString("\n") } + "\n" +
-            CURRENT_SESSION_MARKER + "\n"
+        return previousSessionsLines(generations).joinToString("\n") + "\n"
+    }
+
+    /**
+     * The same block as [previousSessionsText], as LINES — for callers that immediately split it again
+     * (`WhoopBleClient.exportLogLines`, feeding readouts that filter by domain tag).
+     *
+     * [previousSessionsText] is DERIVED from this, rather than the two being written separately, so they
+     * cannot drift. An earlier revision built the line form with `flatten()` and that was already wrong:
+     * `joinToString` renders an EMPTY generation as a blank line, while `flatten()` drops it, so a corrupt
+     * or legacy empty block would have shifted every line after it in one form but not the other. Empty
+     * generations are not supposed to be stored — `roll` never pushes one — but `persistedLogGenerations`
+     * decodes an empty block to `emptyList()`, so the case is representable and must be rendered the same
+     * way by both forms.
+     */
+    fun previousSessionsLines(generations: List<List<String>>): List<String> {
+        if (generations.isEmpty()) return emptyList()
+        val out = ArrayList<String>()
+        for (generation in generations) {
+            if (generation.isEmpty()) out.add("") else out.addAll(generation)
+        }
+        out.add(CURRENT_SESSION_MARKER)
+        return out
     }
 }

--- a/android/app/src/main/java/com/noop/ui/TestCentreLiveReadouts.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreLiveReadouts.kt
@@ -18,7 +18,9 @@ import kotlin.math.roundToInt
 /** Inputs shared by the Test Centre row and its report: the exported tagged log, plus the small set of
  * live values that are not log-derived. Repository-backed samples are loaded only while their row is on. */
 internal data class TestCentreLiveSnapshot(
-    val logText: String = "",
+    /** #1468 follow-up: the log as LINES. Every consumer here filters by domain tag, so the joined
+     *  string this replaced was built only to be split again. */
+    val logLines: List<String> = emptyList(),
     val nowUnix: Long = System.currentTimeMillis() / 1_000,
     val connected: Boolean = false,
     val batteryPct: Double? = null,
@@ -63,7 +65,7 @@ internal object TestCentreLiveReadouts {
 
     fun rows(mode: TestMode, active: Boolean, snapshot: TestCentreLiveSnapshot): List<LiveReadoutRow> {
         if (!active) return emptyList()
-        val tail by lazy { taggedTail(snapshot.logText, mode.id) }
+        val tail by lazy { taggedTail(snapshot.logLines, mode.id) }
         return mode.liveReadout.map { id ->
             require(id in mappedIds) { "Unmapped Test Centre liveReadout id: $id" }
             when (id) {
@@ -132,10 +134,10 @@ internal object TestCentreLiveReadouts {
         }
     }
 
-    private fun taggedTail(logText: String, domainId: String): List<String> {
-        return logText.lineSequence().filter { line ->
+    private fun taggedTail(logLines: List<String>, domainId: String): List<String> {
+        return logLines.filter { line ->
             firstDomainTag.find(line)?.groupValues?.get(1) == domainId
-        }.toList()
+        }
     }
 
     // Match only a real leading TestDomain marker: raw test lines start with it; exported production lines

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -258,6 +258,8 @@ private val MASTER_REPORT_MODE = TestMode(
 private suspend fun buildPending(
     context: android.content.Context,
     mode: TestMode,
+    // Stays a STRING: TestBundleAssembler renders a report file, the one consumer that genuinely wants the
+    // joined text. Its two callers are user taps, not the 250 ms refresh.
     logText: String,
     vm: AppViewModel,
 ): PendingReport {
@@ -317,7 +319,9 @@ private fun TestModeRow(
     val refreshSources = TestCentreLiveRefreshPolicy.sources(mode, on)
     // An active row observes the log's own revision, coalesced during bursty offloads. An inactive row
     // creates no collector and never snapshots/export-formats the log.
-    val logText = if (refreshSources.observeLogRevision) rememberActiveLogText(vm.ble) else ""
+    // #1468 follow-up: LINES, not a joined string. Both consumers below immediately work line-wise, so the
+    // string this replaced was built (and re-split) on every 250 ms tick for nothing.
+    val logLines = if (refreshSources.observeLogRevision) rememberActiveLogLines(vm.ble) else emptyList()
     // #965: HONEST per-mode captured-day count for a guided row (distinct days THIS mode produced its own
     // trace on), read from the same log the report exports, so each active mode accumulates its OWN count
     // instead of every guided row sharing one elapsed number. null for a toggle mode (no "K of N") / when off.
@@ -325,7 +329,7 @@ private fun TestModeRow(
         if (on && mode.capture is CaptureKind.Guided) {
             CaptureAccumulator.capturedDays(
                 domain = mode.domain,
-                reportText = logText,
+                reportLines = logLines,
                 tzOffsetSeconds =
                     (java.util.TimeZone.getDefault().getOffset(System.currentTimeMillis()) / 1000).toLong(),
             )
@@ -352,7 +356,7 @@ private fun TestModeRow(
         if (on) {
             TestCentreLiveReadoutPanel(
                 mode = mode,
-                logText = logText,
+                logLines = logLines,
                 live = live,
                 is5MG = is5MG,
                 activeStrapId = activeStrapId,
@@ -374,7 +378,7 @@ private fun TestModeRow(
 @Composable
 private fun TestCentreLiveReadoutPanel(
     mode: TestMode,
-    logText: String,
+    logLines: List<String>,
     live: LiveState,
     is5MG: Boolean,
     activeStrapId: String,
@@ -437,7 +441,7 @@ private fun TestCentreLiveReadoutPanel(
         mode = mode,
         active = true,
         snapshot = TestCentreLiveSnapshot(
-            logText = logText,
+            logLines = logLines,
             nowUnix = nowUnix,
             connected = live.connected,
             batteryPct = live.batteryPct,
@@ -472,9 +476,9 @@ private fun boundedRevision(flow: StateFlow<Long>, coalesceMs: Long): Long {
 }
 
 @Composable
-private fun rememberActiveLogText(ble: WhoopBleClient): String {
+private fun rememberActiveLogLines(ble: WhoopBleClient): List<String> {
     val revision = boundedRevision(ble.logRevision, coalesceMs = 250)
-    return remember(ble, revision) { ble.exportLogText() }
+    return remember(ble, revision) { ble.exportLogLines() }
 }
 
 @Composable

--- a/android/app/src/test/java/com/noop/testcentre/CaptureAccumulatorTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/CaptureAccumulatorTest.kt
@@ -79,4 +79,27 @@ class CaptureAccumulatorTest {
         assertEquals(setOf("2026-07-02"), CaptureAccumulator.capturedDayKeys(TestDomain.BATTERY, one, 0L))
         assertEquals(setOf("2026-07-01"), CaptureAccumulator.capturedDayKeys(TestDomain.BATTERY, one, -32400L))
     }
+
+    /**
+     * #1468 follow-up: the String and List overloads must find the same days. The Test Centre now scans the
+     * line list it already holds rather than joining it so this could split it again; if the two ever
+     * disagreed, a guided capture's "K of N days" would depend on which caller asked.
+     */
+    @Test
+    fun stringAndLineOverloadsAgree() {
+        val lines = listOf(
+            "[recovery] charge day=2026-08-18 score=61.0 band=yellow",
+            "noise that carries no marker",
+            "[recovery] charge day=2026-08-19 score=62.5 band=yellow",
+            "[recovery] charge day=2026-08-19 score=63.0 band=yellow",
+        )
+        val fromLines = CaptureAccumulator.capturedDayKeys(TestDomain.RECOVERY, lines, 0L)
+        val fromText = CaptureAccumulator.capturedDayKeys(TestDomain.RECOVERY, lines.joinToString("\n"), 0L)
+        assertEquals(fromText, fromLines)
+        assertEquals(setOf("2026-08-18", "2026-08-19"), fromLines)
+        assertEquals(
+            CaptureAccumulator.capturedDays(TestDomain.RECOVERY, lines.joinToString("\n"), 0L),
+            CaptureAccumulator.capturedDays(TestDomain.RECOVERY, lines, 0L),
+        )
+    }
 }

--- a/android/app/src/test/java/com/noop/ui/StrapLogGenerationsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/StrapLogGenerationsTest.kt
@@ -1,6 +1,7 @@
 package com.noop.ui
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -126,6 +127,30 @@ class StrapLogGenerationsTest {
 
     @Test
     fun noGenerationsRendersNothing() {
+        assertEquals("", StrapLogGenerations.previousSessionsText(emptyList()))
+    }
+
+    /**
+     * #1468 follow-up: [StrapLogGenerations.previousSessionsText] must be a PURE function of its argument.
+     *
+     * `WhoopBleClient.exportLogText` memoises this half of the export for the process lifetime — safe only
+     * because the generations are written exactly once (inside the latched roll) and this formatting reads
+     * no clock and no other state. If someone later folds a timestamp or a live counter in here, the memo
+     * would start serving a stale string and nothing else would notice: the strap log would simply stop
+     * updating that section, which is far harder to spot than a crash.
+     */
+    @Test
+    fun previousSessionsTextIsPureSoItCanBeMemoised() {
+        val generations = listOf(
+            listOf("===== session 2026-08-19 =====", "line a", "line b"),
+            listOf("===== session 2026-08-20 =====", "line c"),
+        )
+        val first = StrapLogGenerations.previousSessionsText(generations)
+        repeat(3) { assertEquals(first, StrapLogGenerations.previousSessionsText(generations)) }
+
+        // A DIFFERENT input must still produce a different string — the equality above must come from
+        // purity, not from the function ignoring its argument.
+        assertNotEquals(first, StrapLogGenerations.previousSessionsText(generations.take(1)))
         assertEquals("", StrapLogGenerations.previousSessionsText(emptyList()))
     }
 }

--- a/android/app/src/test/java/com/noop/ui/StrapLogGenerationsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/StrapLogGenerationsTest.kt
@@ -174,7 +174,7 @@ class StrapLogGenerationsTest {
         val rendered = StrapLogGenerations.previousSessionsText(generations)
         // The rendered form ends in a newline, so splitting yields one trailing empty segment.
         val renderedLines = rendered.split("\n").dropLast(1)
-        val lineForm = generations.flatten() + StrapLogGenerations.CURRENT_SESSION_MARKER
+        val lineForm = StrapLogGenerations.previousSessionsLines(generations)
 
         assertEquals(lineForm, renderedLines)
         assertEquals("", rendered.split("\n").last())
@@ -182,5 +182,35 @@ class StrapLogGenerationsTest {
         assertEquals(StrapLogGenerations.CURRENT_SESSION_MARKER, renderedLines.last())
         // Empty generations render empty on both sides, so a caller can concatenate unconditionally.
         assertEquals("", StrapLogGenerations.previousSessionsText(emptyList()))
+    }
+
+    /**
+     * The rendering must still match what `joinToString` produced before [previousSessionsText] was
+     * rewritten to derive from [StrapLogGenerations.previousSessionsLines] — including for an EMPTY
+     * generation, which renders as a blank line.
+     *
+     * This is the case that caught a real bug: the line form was first built with `flatten()`, which DROPS
+     * an empty generation instead of rendering its blank line, so every line after it would have shifted in
+     * one form but not the other. `roll` never stores an empty generation, but `persistedLogGenerations`
+     * decodes an empty block to `emptyList()`, so the shape is representable.
+     */
+    @Test
+    fun anEmptyGenerationRendersAsABlankLineInBothForms() {
+        val generations = listOf(listOf("a"), emptyList(), listOf("b"))
+
+        // The pre-rewrite expression, spelled out, as the reference.
+        val legacy = generations.joinToString("\n") { it.joinToString("\n") } + "\n" +
+            StrapLogGenerations.CURRENT_SESSION_MARKER + "\n"
+        assertEquals(legacy, StrapLogGenerations.previousSessionsText(generations))
+
+        assertEquals(
+            listOf("a", "", "b", StrapLogGenerations.CURRENT_SESSION_MARKER),
+            StrapLogGenerations.previousSessionsLines(generations),
+        )
+        // flatten() would have produced ["a", "b", MARKER] — one line short, and misaligned from here on.
+        assertNotEquals(
+            generations.flatten() + StrapLogGenerations.CURRENT_SESSION_MARKER,
+            StrapLogGenerations.previousSessionsLines(generations),
+        )
     }
 }

--- a/android/app/src/test/java/com/noop/ui/StrapLogGenerationsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/StrapLogGenerationsTest.kt
@@ -153,4 +153,34 @@ class StrapLogGenerationsTest {
         assertNotEquals(first, StrapLogGenerations.previousSessionsText(generations.take(1)))
         assertEquals("", StrapLogGenerations.previousSessionsText(emptyList()))
     }
+
+    /**
+     * #1468 follow-up: the LINE form and the TEXT form of the previous-sessions block must describe the
+     * same content.
+     *
+     * `WhoopBleClient.exportLogLines` builds its previous-session lines straight from the generations —
+     * `gens.flatten() + CURRENT_SESSION_MARKER` — instead of formatting the string and splitting it back
+     * apart. That shortcut is only valid while [previousSessionsText] renders exactly those lines in that
+     * order. Reformatting it (an extra header, a blank line between generations, a different marker) would
+     * make the two exports disagree, and nothing else would catch it: the share sheet would keep showing
+     * the new shape while the live readouts kept filtering the old one.
+     */
+    @Test
+    fun lineFormMatchesTheRenderedTextForm() {
+        val generations = listOf(
+            listOf("===== session 2026-08-19 =====", "line a", "line b"),
+            listOf("===== session 2026-08-20 =====", "line c"),
+        )
+        val rendered = StrapLogGenerations.previousSessionsText(generations)
+        // The rendered form ends in a newline, so splitting yields one trailing empty segment.
+        val renderedLines = rendered.split("\n").dropLast(1)
+        val lineForm = generations.flatten() + StrapLogGenerations.CURRENT_SESSION_MARKER
+
+        assertEquals(lineForm, renderedLines)
+        assertEquals("", rendered.split("\n").last())
+        // ...and the marker really is the last content line, not buried mid-block.
+        assertEquals(StrapLogGenerations.CURRENT_SESSION_MARKER, renderedLines.last())
+        // Empty generations render empty on both sides, so a caller can concatenate unconditionally.
+        assertEquals("", StrapLogGenerations.previousSessionsText(emptyList()))
+    }
 }

--- a/android/app/src/test/java/com/noop/ui/TestCentreLiveReadoutsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/TestCentreLiveReadoutsTest.kt
@@ -14,7 +14,7 @@ class TestCentreLiveReadoutsTest {
             mode = mode,
             active = true,
             snapshot = TestCentreLiveSnapshot(
-                logText = "[recovery] charge day=2026-08-19 score=62.5 band=yellow",
+                logLines = listOf("[recovery] charge day=2026-08-19 score=62.5 band=yellow"),
             ),
         )
 
@@ -30,11 +30,11 @@ class TestCentreLiveReadoutsTest {
             mode = mode,
             active = true,
             snapshot = TestCentreLiveSnapshot(
-                logText = listOf(
+                logLines = listOf(
                     "2026-08-19 12:00:00 [recovery] charge day=2026-08-19 score=62.5 band=yellow",
                     "[connection] payload=[recovery] charge day=2026-08-20 score=99.0 band=green",
                     "message payload=[recovery] charge day=2026-08-21 score=100.0 band=green",
-                ).joinToString("\n"),
+                ),
             ),
         )
 


### PR DESCRIPTION
Follow-up to #1468 (@bhelm). No behaviour change — the exported text is byte-identical.

### What it costs today

The live readouts call `exportLogText()` on every 250 ms coalesce tick while a Test Centre panel is open. That function has two halves, and only one of them can have changed since the last tick:

```kotlin
val previous = StrapLogGenerations.previousSessionsText(persistedLogGenerations())  // prefs read + format
val current  = synchronized(logBuffer) { logBuffer.joinToString("\n") }             // full join under lock
```

**The previous-sessions half is invariant for the process.** `persistLogGenerations` is called from exactly one place — inside the latched `rollLogGenerationsIfNeeded()` — so nothing rewrites the generations while the app lives. Re-reading SharedPreferences and re-formatting every past session four times a second bought nothing. It is now memoised under `genLock`, the same lock the roll uses, so the memo cannot be filled from a pre-roll read.

**The current half held the wrong lock for too long.** `log()` runs on the GATT binder thread and blocks on `logBuffer` for every line it writes. Joining thousands of strings inside that lock meant a readout refresh was throttling the writer it was reading — at exactly the moment both are busiest, a heavy offload. The buffer is now copied under the lock and joined outside it, shrinking the critical section from a full join to a reference copy.

### Why the test is about purity

`exportLogText` needs an Android context, so it has no direct JVM test. What *is* testable is the property the memo depends on: `previousSessionsText` must stay a pure function of its argument. It reads no clock today. If a timestamp or a live counter were ever folded in, the memo would quietly serve a stale string and that section of the strap log would simply stop updating — a silent failure, and one that would be blamed on the log rather than on the cache.

The test also asserts a *different* input still yields a *different* string, so the repeated-call equality comes from purity rather than from the function ignoring its argument.

### Scope

Android-only. The live-readout refresh loop this serves is Android-only (#1468), so there is no Swift twin to mirror; nothing analytic or stored is touched.

### Verification

- `compileFullDebugKotlin` clean
- Full Android unit suite green
- `StrapLogGenerationsTest` `tests=11`
- `doc_comment_lint` and `i18n_audit --ci` clean
- Reviewed twice locally before pushing: confirmed the roll's latch is set *inside* `synchronized(genLock)` (so a concurrent caller blocks rather than observing a half-done roll), and that all five `exportLogText` callers — two share-sheet paths, two Test Centre report paths, and the readouts — get identical output.

**Not measured on a device.** The reasoning is structural (fewer prefs reads, shorter critical section); I have not profiled the improvement on hardware.

---

### Re-review notes (no changes needed)

Three things checked on a later pass, all of which hold:

- **The copy-under-lock pattern is already the house style here.** `flushDurableLogTail()`, two functions away in the same file, does `synchronized(logBuffer) { logBuffer.toList() }` and then works outside the lock. This applies the existing pattern to `exportLogText` rather than inventing one.
- **`genLock` is not on the per-line write path.** `rollLogGenerationsIfNeeded()` runs on the *first* `log()` append and then latches, so the memo's added acquisition contends with almost nothing — and after the first fill it holds the lock only for a field read.
- **One client per process.** `WhoopBleClient` is constructed in exactly one place (`NoopApplication`), so the per-instance memo is effectively process-wide; there is no second instance that could hold a pre-roll value.

`logBuffer` is an `ArrayDeque` bounded at `LOG_BUFFER_MAX = 5000`, so the snapshot copies at most 5,000 references — a fraction of what the join it replaces was allocating inside the lock.

---

## Folded in: the readouts now take lines, not a joined string

The parity question behind this PR turned out to have an architectural half. Apple's readouts read `LiveState.taggedTail(domain:)` — a filtered view of the current session's log. Android's read `exportLogText()`, the whole multi-session export.

Then `TestCentreLiveReadouts.rows` splits it straight back apart and filters to one domain tag, and `CaptureAccumulator.capturedDayKeys` does `split("\n")` over the same text. **Both consumers want lines.** The joined string existed only between them — and with the live readouts it was rebuilt every 250 ms.

`exportLogLines()` returns the same lines `exportLogText` splits into, built from the generations directly instead of formatting a string and tearing it up again. The share/export paths keep the string, since a report file genuinely needs one.

### What I deliberately did NOT do

Swapping the readouts to a **current-session** tail — Apple's exact shape — was the other option, and it would have closed the gap completely. It would also have broken something: `capturedDays` counts the distinct days a guided mode has captured, and that legitimately spans app sessions. A restart mid-capture would have silently reset "K of N days".

So the line form carries the same content and only the representation changes. Behaviour is identical; the remaining divergence from Apple is deliberate and now documented.

### One definition of the marker

The boundary between banked sessions and the live tail is now `StrapLogGenerations.CURRENT_SESSION_MARKER`, used by both the text and line forms. Two copies of that literal could drift apart without anything failing loudly — the export would still render, just with a boundary the log parsers no longer agree on.

### Tests pin the two equivalences the shortcut rests on

- **Line form matches the rendered text form**, line for line. If someone reformats `previousSessionsText` — an extra header, a blank line, a different marker — this fails here rather than silently desyncing the two exports.
- **The String and List overloads of `capturedDayKeys` find the same days**, so a guided capture's count can't depend on which caller asked.

### Verification

`compileFullDebugKotlin` clean · full Android unit suite green · `assembleFullDebug` builds · `StrapLogGenerationsTest` 12 · `CaptureAccumulatorTest` 10 · `TestCentreLiveReadoutsTest` 6 · `doc_comment_lint` and `i18n_audit --ci` clean.

The doc gate earned its keep: my first attempt inserted both new blocks *between* a neighbouring doc comment and its declaration, orphaning them. Same mistake I made on #1481 — moved above their neighbours instead.