### PR TITLE
Poll the strap battery every keep-alive tick while charging

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -581,14 +581,35 @@ public final class BLEManager: NSObject, ObservableObject {
         lowRefresh ? lowRefreshBackfillIntervalSeconds : backfillIntervalSeconds
     }
 
+    /// #battery: is a keep-alive tick due to poll the strap's battery?
+    ///
+    /// Normally every SECOND 30 s tick (~60 s), which is plenty while the charge only creeps downward. A
+    /// CHARGING strap is the exception: the value climbs visibly, the user is usually watching it on the
+    /// puck, and the window is short and bounded — so poll every tick (~30 s) instead. It costs one extra
+    /// read per minute, only while charging, and nothing at all the rest of the time.
+    ///
+    /// The charge state itself rides bit 0 of the BATTERY_LEVEL event, so it is only learned FROM a poll:
+    /// docking is still noticed on the ordinary ~60 s cadence, and the faster rate applies from the next
+    /// tick onward. Twin of the Kotlin `batteryPollDue`.
+    static func batteryPollDue(tick: Int, charging: Bool) -> Bool {
+        charging || tick % 2 == 0
+    }
+
     /// #battery: pure 5/MG battery-read throttle decision, unit-testable without a CoreBluetooth seam.
     /// Returns true when no prior read exists (the first read of a connection, or post-disconnect re-seed)
-    /// OR when at least `whoop5BatteryReadMinIntervalSeconds` has elapsed since the last read. Stops the
-    /// 30 s keep-alive tick from re-reading 0x2A19 every cycle. Twin of the Android `keepAliveTick % 2 == 0`
+    /// OR when at least `whoop5BatteryReadMinIntervalSeconds` has elapsed since the last read — HALVED
+    /// while the strap is charging, for the reason given on `batteryPollDue` above. Stops the 30 s
+    /// keep-alive tick from re-reading 0x2A19 every cycle. Twin of the Android `keepAliveTick % 2 == 0`
     /// ~60 s cadence (WhoopBleClient keepAliveFire).
-    static func shouldPollWhoop5Battery(lastReadAt: Date?, now: Date = Date()) -> Bool {
+    static func shouldPollWhoop5Battery(lastReadAt: Date?, now: Date = Date(),
+                                        charging: Bool = false) -> Bool {
         guard let last = lastReadAt else { return true }
-        return now.timeIntervalSince(last) >= whoop5BatteryReadMinIntervalSeconds
+        // #battery: same reasoning as `batteryPollDue` — a charging strap earns the finer cadence, so the
+        // 5/MG time throttle halves while charging rather than leaving it a minute behind the 4.0.
+        let minInterval = charging
+            ? whoop5BatteryReadMinIntervalSeconds / 2
+            : whoop5BatteryReadMinIntervalSeconds
+        return now.timeIntervalSince(last) >= minInterval
     }
 
     /// #battery: pure periodic-offload interval for a 5/MG whose history is known-empty, unit-testable
@@ -3918,7 +3939,10 @@ public final class BLEManager: NSObject, ObservableObject {
             send(.toggleRealtimeHR, payload: [0x01])
         }   // re-arm so it can't lapse
         keepAliveTick += 1
-        if keepAliveTick % 2 == 0 { send(.getBatteryLevel, payload: []) }  // ~every 60s
+        // #battery: ~60 s normally, ~30 s while charging (see `batteryPollDue`).
+        if BLEManager.batteryPollDue(tick: keepAliveTick, charging: state.charging == true) {
+            send(.getBatteryLevel, payload: [])
+        }
     }
 
     private func startBackfillTimer() {
@@ -4139,7 +4163,8 @@ public final class BLEManager: NSObject, ObservableObject {
         // revert the true reading, #77). The 600 s same-% throttle in LiveState guards the estimator.
         if let b = batteryCharacteristic, b.properties.contains(.read),
            selectedModel.deviceFamily != .whoop4,
-           BLEManager.shouldPollWhoop5Battery(lastReadAt: lastBatteryReadAt) {
+           BLEManager.shouldPollWhoop5Battery(lastReadAt: lastBatteryReadAt,
+                                              charging: state.charging == true) {
             p.readValue(for: b)
             lastBatteryReadAt = Date()
         }

--- a/StrandTests/Whoop5BatteryBackfillThrottleTests.swift
+++ b/StrandTests/Whoop5BatteryBackfillThrottleTests.swift
@@ -91,4 +91,32 @@ final class Whoop5BatteryBackfillThrottleTests: XCTestCase {
             BLEManager.whoop5EmptyHistoryBackfillInterval(baseSeconds: 900, lowSeconds: 300, historyEmpty: true),
             900)
     }
+
+    // MARK: - #battery: charging cadence
+
+    /// A discharging strap keeps the ~60 s cadence: only every SECOND 30 s tick polls.
+    func testDischargingPollsEveryOtherTick() {
+        XCTAssertFalse(BLEManager.batteryPollDue(tick: 1, charging: false))
+        XCTAssertTrue(BLEManager.batteryPollDue(tick: 2, charging: false))
+        XCTAssertFalse(BLEManager.batteryPollDue(tick: 3, charging: false))
+    }
+
+    /// A charging strap polls on EVERY tick (~30 s): the value is climbing and the user is watching it on
+    /// the puck. Bounded to the charging window, so it costs nothing the rest of the time.
+    func testChargingPollsEveryTick() {
+        XCTAssertTrue(BLEManager.batteryPollDue(tick: 1, charging: true))
+        XCTAssertTrue(BLEManager.batteryPollDue(tick: 2, charging: true))
+        XCTAssertTrue(BLEManager.batteryPollDue(tick: 3, charging: true))
+    }
+
+    /// The 5/MG time throttle follows the same rule, so the two families do not sit a minute apart while
+    /// charging. At 35 s elapsed a discharging strap is NOT due (60 s floor) but a charging one IS (30 s).
+    func testWhoop5ThrottleHalvesWhileCharging() {
+        let now = Date()
+        let last = now.addingTimeInterval(-35)
+        XCTAssertFalse(BLEManager.shouldPollWhoop5Battery(lastReadAt: last, now: now, charging: false))
+        XCTAssertTrue(BLEManager.shouldPollWhoop5Battery(lastReadAt: last, now: now, charging: true))
+        // The first read of a connection still always fires, charging or not.
+        XCTAssertTrue(BLEManager.shouldPollWhoop5Battery(lastReadAt: nil, now: now, charging: false))
+    }
 }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -602,6 +602,18 @@ class WhoopBleClient(
             else -> "status$status"
         }
 
+        /** #battery: is a keep-alive tick due to poll the strap's battery?
+         *
+         *  Normally every SECOND 30 s tick (~60 s), which is plenty while the charge only creeps downward.
+         *  A CHARGING strap is the exception: the value climbs visibly, the user is usually watching it on
+         *  the puck, and the window is short and bounded — so poll every tick (~30 s) instead. It costs one
+         *  extra read per minute, only while charging, and nothing at all the rest of the time.
+         *
+         *  The charge state itself rides bit 0 of the BATTERY_LEVEL event, so it is only learned FROM a
+         *  poll: docking is still noticed on the ordinary ~60 s cadence, and the faster rate applies from
+         *  the next tick onward. Twin of the Swift `BLEManager.batteryPollDue`. */
+        fun batteryPollDue(tick: Int, charging: Boolean): Boolean = charging || tick % 2 == 0
+
         /** Pure battery-adaptive gate (#477), unit-testable without a BLE stack. Keyed on the STRAP's
          *  battery (WHOOP/Oura/Fitbit): the lever is ARMED by [thresholdPct] > 0 and engages while the
          *  strap is DISCHARGING at/below [thresholdPct]. The
@@ -6147,8 +6159,11 @@ class WhoopBleClient(
                 }
                 if (connectedFamily == DeviceFamily.WHOOP4) {
                     if (wantsRealtime) { realtimeArmed = true; send(CommandNumber.TOGGLE_REALTIME_HR, byteArrayOf(1)) }
-                    if (keepAliveTick % 2 == 0) send(CommandNumber.GET_BATTERY_LEVEL)
-                } else if (connectedFamily == DeviceFamily.WHOOP5 && keepAliveTick % 2 == 0) {
+                    // #battery: ~60 s normally, ~30 s while charging (see [batteryPollDue]).
+                    if (batteryPollDue(keepAliveTick, s.charging == true)) send(CommandNumber.GET_BATTERY_LEVEL)
+                } else if (connectedFamily == DeviceFamily.WHOOP5 &&
+                    batteryPollDue(keepAliveTick, s.charging == true)
+                ) {
                     // 5/MG battery comes only from a 0x2A19 read and the strap sends no unsolicited battery
                     // notification, so poll it here (about every 60s) rather than only while the Live screen
                     // is open. The ring then stays current on any screen without a manual sync, and the read

--- a/android/app/src/test/java/com/noop/ble/ConnectionPriorityTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ConnectionPriorityTest.kt
@@ -164,4 +164,23 @@ class ConnectionPriorityTest {
     @Test fun whoop5EmptyHistoryNeverShortensBelowBase() {
         assertEquals(base, WhoopBleClient.whoop5EmptyHistoryBackfillIntervalMs(base, lowBatteryMs = 300_000L, historyEmpty = true))
     }
+
+    // #battery: charging cadence. Twins of the Swift Whoop5BatteryBackfillThrottleTests cases.
+
+    /** A discharging strap keeps the ~60 s cadence: only every SECOND 30 s tick polls. */
+    @Test fun batteryPollDischargingPollsEveryOtherTick() {
+        assertFalse(WhoopBleClient.batteryPollDue(1, charging = false))
+        assertTrue(WhoopBleClient.batteryPollDue(2, charging = false))
+        assertFalse(WhoopBleClient.batteryPollDue(3, charging = false))
+    }
+
+    /**
+     * A charging strap polls on EVERY tick (~30 s): the value is climbing and the user is watching it on
+     * the puck. Bounded to the charging window, so it costs nothing the rest of the time.
+     */
+    @Test fun batteryPollChargingPollsEveryTick() {
+        assertTrue(WhoopBleClient.batteryPollDue(1, charging = true))
+        assertTrue(WhoopBleClient.batteryPollDue(2, charging = true))
+        assertTrue(WhoopBleClient.batteryPollDue(3, charging = true))
+    }
 }


### PR DESCRIPTION
Reported on the puck: the battery percent is eventually right, but never looks live while charging.

### It's 60 s by design

The keep-alive polls the strap battery on every **second** 30 s tick. A field log shows it exactly — reads at `08:05:56`, `08:06:56`, `08:07:56`, one per minute.

That's the right trade while the charge only creeps downward. A charging strap is the one case where it isn't: the value moves visibly, the window is short, and the user is usually watching it on the puck.

### The change

While charging, both platforms poll on **every** tick (~30 s):

```
batteryPollDue(tick, charging) = charging || tick % 2 == 0
```

One extra read per minute, only while charging, nothing different the rest of the time.

The 5/MG path on Swift throttles by **time** rather than by tick, so that interval halves while charging too — otherwise a charging 5/MG would sit a minute behind a charging 4.0 on the same screen.

### How docking is noticed (correcting an earlier claim in this PR)

An earlier revision of this description said the charge flag is only learned *from* a poll, so docking would take up to ~60 s to register. **That is wrong**, and the correction makes this fix better than described: the strap raises **`CHARGING_ON(7)` / `CHARGING_OFF(8)` the instant a pack goes on or comes off**, and both platforms already handle those events directly (`WhoopBleClient` on Android, `FrameRouter.swift:273` on Apple). Bit 0 of `BATTERY_LEVEL` is a slower backstop on a ~8-minute cadence, not the primary signal.

So docking flips `charging` immediately, and the first fast poll lands on the next keep-alive tick — **within 30 s**, not 60.

### The remaining gap

That still leaves up to 30 s between docking and the first refreshed reading, because the poll waits for the next tick rather than firing on the `CHARGING_ON` edge itself.

Closing it is trivial on Android — the event handler lives inside `WhoopBleClient`, where `send()` is in scope. It is **not** trivial on Apple: `FrameRouter` mutates `LiveState` directly and has no send capability, so it would need a new seam (a callback, or a Combine sink on `state.$charging` in `BLEManager`). That is more than this fix warrants, so it is deliberately left out rather than done on one platform only — a one-sided version would put Android 30 s ahead of Apple at the exact moment the user is watching.

### Also worth knowing

On the puck the strap is off-wrist, so no HR notifications arrive. If nothing inbound lands for 120 s the keep-alive **bounces the link** rather than polling. The battery poll normally resets that fuse, and at 30 s it resets it twice as often — so this should make the bounce path less likely too, though that's a side effect rather than the aim.

### Verification

- `batteryPollDue` is one expression on both platforms, pinned by mirrored tests for the discharging and charging cases.
- The **pre-existing** `shouldPollWhoop5Battery` tests call it without the new argument, so they now pin that the discharging path is unchanged.
- `compileFullDebugKotlin` clean, full Android unit suite green, `ConnectionPriorityTest` 16, `doc_comment_lint` clean.
- Checked there is no missed poll site: the one remaining `keepAliveTick % 2` is Android's **phone**-battery capture-log sample, which is unrelated.

**The Swift half is app-target and cannot be compiled locally** — it needs an `app-build` run before merge.

**Not verified on hardware.** Whether 30 s reads as "semi-realtime" on the puck is exactly what the reporter has to judge.