### PR TITLE
Assert the widened unix as a Long (#869 follow-up)

### DIFF
--- a/android/app/src/test/java/com/noop/protocol/UnmappedHistoricalLayoutTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/UnmappedHistoricalLayoutTest.kt
@@ -56,7 +56,11 @@ class UnmappedHistoricalLayoutTest {
     @Test fun unmappedLayoutIsArchivedEvenThoughItsBytesDecodeCleanlyAsV18() {
         // Precondition: read as its true version, this record decodes everything the old screen wanted.
         val asV18 = decodeHistorical(bytes(whoop5V18Hex), DeviceFamily.WHOOP5)!!
-        assertEquals("precondition: these bytes DO decode a unix", 1780916150, asV18["unix"])
+        // #869 widened the decoded `unix` from Int to Long — a u32 with bit 31 set narrowed to a NEGATIVE
+        // Int, which the #547 plausibility gate then dropped, silently losing all history from 2038-01-19
+        // (and today on a future-dated strap). The value here is unchanged; only its type is wider, so the
+        // literal needs the L or assertEquals compares Integer against Long and fails on the box.
+        assertEquals("precondition: these bytes DO decode a unix", 1780916150L, asV18["unix"])
         assertEquals("precondition: these bytes DO decode a heart rate", 102, asV18["heart_rate"])
         assertTrue("precondition: these bytes DO decode a gravity vector", asV18["gravity_x"] is Double)
 


### PR DESCRIPTION
Follow-up to #869 (@vishk23), which widened the decoded `unix` from `Int` to `Long`.

That widening is the whole point of it: a u32 with bit 31 set narrowed to a **negative** `Int` on Kotlin, and the #547 plausibility gate then dropped the record — silently losing all history from 2038-01-19, and today on a future-dated strap.

`UnmappedHistoricalLayoutTest` asserts the decoded value with an `Int` literal, so `assertEquals` compared `Integer` against `Long` and failed on the box. Same number, wider type; the literal needs the `L`.

### Nobody missed this

#869's own Android CI passed on **2026-07-29**. The test it trips was created by #1101 on **2026-08-06** — eight days later. Git merges the two cleanly because the conflict is *semantic*, not textual: a new test asserting the type the older PR changes.

Neither the PR's green checks nor a clean merge can reveal that. Only building the merge result does — worth remembering for the other long-lived PRs in the queue.

### Verification

Full Android unit suite: **4146 tests, 0 failures**. `UnmappedHistoricalLayoutTest` 6.