### PR TITLE
Report the strap model that actually advertised, or say unknown

### DIFF
--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -27,12 +27,15 @@ enum DebugDataDiagnostics {
         lines.append(String(repeating: "─", count: 40))
         lines.append("Strap & data")
         let d = UserDefaults.standard
-        let model: String
-        switch d.string(forKey: "selectedWhoopModel") {
-        case "whoop5": model = "WHOOP 5.0 / MG"
-        case "whoop4": model = "WHOOP 4.0"
-        default:       model = "unknown (never paired)"
-        }
+        // Parse through the enum, never against string literals. `selectedWhoopModel` stores
+        // `WhoopModel.rawValue` ("WHOOP 4.0" / "WHOOP 5.0 / MG") — both writers use `.rawValue` — but this
+        // switch tested for "whoop5"/"whoop4", which are the CASE names, not the raw values. Neither ever
+        // matched, so this header reported "unknown (never paired)" for every strap, forever, including one
+        // actively syncing. The sibling block ~270 lines below already compares `.rawValue` and carries a
+        // comment warning about this exact trap; this site never got the same treatment. Going through
+        // `WhoopModel(rawValue:)` makes the enum the single parser, so a future rename cannot re-open it.
+        let model = WhoopModel(rawValue: d.string(forKey: "selectedWhoopModel") ?? "")?.displayName
+            ?? "unknown (never paired)"
         lines.append("Model:       \(model)")
         lines.append("Firmware:    \(d.string(forKey: "noop.lastFirmware") ?? "unknown (connect to record)")")
         let syncSec = d.double(forKey: "lastSyncedAt")

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -158,7 +158,15 @@ enum DebugDataDiagnostics {
         }
         let det = SleepSession(start: cs.startTs, end: cs.endTs, efficiency: cs.efficiency ?? 0,
                                stages: [], restingHR: cs.restingHr, avgHRV: cs.avgHrv)
-        let family: DeviceFamily = (UserDefaults.standard.string(forKey: "selectedWhoopModel") == "whoop5") ? .whoop5 : .whoop4
+        // Third instance of the same literal bug in this file: "whoop5" is the enum CASE name, while the
+        // pref stores `WhoopModel.rawValue` ("WHOOP 5.0 / MG"). It never matched, so this resolved to
+        // `.whoop4` for EVERY strap — and unlike the two header sites, that is not a label. It picks the
+        // WHOOP-4 device anchor and runs `skinTempFunnel` under the wrong family, so the skin-temp funnel
+        // diagnostic has been reporting 4.0 numbers for every 5/MG on Apple. Parse through the enum.
+        // Unknown still resolves to `.whoop4`: this chooses an analysis default, matching the Kotlin twin.
+        let family: DeviceFamily =
+            WhoopModel(rawValue: UserDefaults.standard.string(forKey: "selectedWhoopModel") ?? "") == .whoop5mg
+            ? .whoop5 : .whoop4
         // Mirror the real per-device anchor (#404): learn it from the WHOLE recent window's raws — not just
         // this night — so a single sparse night (<100 in-band) can't misreport under the global fallback when
         // the window as a whole has enough in-band samples for analyzeDay to learn a device anchor.

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -303,11 +303,17 @@ enum DebugDataDiagnostics {
         lines.append("Enabled: \(on ? "yes" : "no") · set \(String(format: "%02d:%02d", mins / 60, mins % 60))")
         // #3: model + the 5/MG experimental gate — a 5/MG firmware alarm is NOT armed unless Experimental is on.
         // (selectedWhoopModel stores the WhoopModel rawValue — "WHOOP 5.0 / MG" / "WHOOP 4.0" — not "whoop5".)
-        let model = d.string(forKey: "selectedWhoopModel") ?? WhoopModel.whoop4.rawValue
-        if model == WhoopModel.whoop5mg.rawValue {
-            lines.append("Model: \(model) · experimental: \(PuffinExperiment.isEnabled ? "on" : "off → firmware alarm NOT armed")")
-        } else {
-            lines.append("Model: \(model)")
+        // Same rule as the header above: parse through the enum, and ABSTAIN when nothing is known. This
+        // defaulted to `whoop4.rawValue`, so an unknown family was reported as a WHOOP 4.0 — the very
+        // fabrication this change removes on Android, and it would have left the two platforms disagreeing
+        // about the one case that matters. Three arms, mirroring the Kotlin `when`.
+        switch WhoopModel(rawValue: d.string(forKey: "selectedWhoopModel") ?? "") {
+        case .whoop5mg:
+            lines.append("Model: \(WhoopModel.whoop5mg.displayName) · experimental: \(PuffinExperiment.isEnabled ? "on" : "off → firmware alarm NOT armed")")
+        case .whoop4:
+            lines.append("Model: \(WhoopModel.whoop4.displayName)")
+        case nil:
+            lines.append("Model: unknown (family not yet detected)")
         }
         // #4 / #67: strap clock health — a reset/stale OR future-dated clock (the #34 / #928 causes) breaks
         // the alarm even when armed, AND misdates offloaded sleep: the strap banks last night with its wrong

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -298,9 +298,14 @@ object AndroidDiagnostics {
             when (reportedModel(context)) {
                 com.noop.ble.WhoopModel.WHOOP5_MG -> {
                     val exp = com.noop.ble.PuffinExperiment.from(context).isEnabled
-                    add("Model: WHOOP 5.0/MG · experimental: ${if (exp) "on" else "off → firmware alarm NOT armed"}")
+                    // displayName, not a literal: this block spelled it "WHOOP 5.0/MG" while the enum (and
+                    // the header a few lines up) says "WHOOP 5.0 / MG", so one export disagreed with itself.
+                    add(
+                        "Model: ${com.noop.ble.WhoopModel.WHOOP5_MG.displayName} · experimental: " +
+                            if (exp) "on" else "off → firmware alarm NOT armed",
+                    )
                 }
-                com.noop.ble.WhoopModel.WHOOP4 -> add("Model: WHOOP 4.0")
+                com.noop.ble.WhoopModel.WHOOP4 -> add("Model: ${com.noop.ble.WhoopModel.WHOOP4.displayName}")
                 null -> add("Model: unknown (family not yet detected)")
             }
             // #4: strap clock health — a reset/stale OR future-dated clock (the #34 / #928 causes) breaks

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -32,6 +32,29 @@ object AndroidDiagnostics {
     }
 
     /**
+     * The strap family a diagnostic export should REPORT — the one that actually advertised, when we know
+     * it, and `null` when we genuinely do not.
+     *
+     * Two prefs hold a model and they disagree. `noop.selectedWhoopModel` is written by
+     * `WhoopBleClient.persistSelectedModel` from the family that actually advertised, so it is the truth.
+     * `noop.lastDeviceModel` is the pair-time memory, and `NoopPrefs.lastDevice` widens a missing value to
+     * `WHOOP4` — a sensible default for RECONNECTING (the code must pick a service to try) but a lie in a
+     * report, which is read as an observation.
+     *
+     * Two field logs from confirmed WHOOP 5 straps were headed "Model: WHOOP 4.0" (#1451, #1464), and both
+     * misdirected triage before the decoded layout version gave them away. A report may say "unknown"; it
+     * may not invent a model. Reads the raw prefs rather than `lastDevice` precisely so that "remembered as
+     * a 4.0" stays distinguishable from "nothing remembered".
+     */
+    private fun reportedModel(context: Context): com.noop.ble.WhoopModel? {
+        val prefs = com.noop.ui.NoopPrefs.of(context)
+        val detected = prefs.getString("noop.selectedWhoopModel", null)
+        val remembered = prefs.getString(com.noop.ui.NoopPrefs.KEY_LAST_DEVICE_MODEL, null)
+        return (detected ?: remembered)
+            ?.let { runCatching { com.noop.ble.WhoopModel.valueOf(it) }.getOrNull() }
+    }
+
+    /**
      * Strap identity + data-state lines for the debug export. Offline-safe: reads persisted prefs and the
      * canonical "my-whoop" daily spine, so it works from the scheduled background export too. Model,
      * last-known firmware, last-sync, timezone, days of history, and the most recent sleep + recovery day.
@@ -42,7 +65,12 @@ object AndroidDiagnostics {
         add("Strap & data")
         runCatching {
             val dev = com.noop.ui.NoopPrefs.lastDevice(context)
-            add("Model:       ${dev?.second?.displayName ?: "unknown (never paired)"}")
+            add(
+                "Model:       " + when {
+                    dev == null -> "unknown (never paired)"
+                    else -> reportedModel(context)?.displayName ?: "unknown (paired, family not yet detected)"
+                },
+            )
             add("Firmware:    ${com.noop.ui.NoopPrefs.lastFirmware(context) ?: "unknown (connect to record)"}")
             val syncSec = com.noop.ui.NoopPrefs.lastSyncAt(context)
             add("Last sync:   ${if (syncSec > 0L) relTime(System.currentTimeMillis() - syncSec * 1000L) else "never"}")
@@ -134,7 +162,9 @@ object AndroidDiagnostics {
                 efficiency = session.efficiency ?: 0.0, stages = emptyList(),
                 restingHR = session.restingHr, avgHRV = session.avgHrv,
             )
-            val family = if (com.noop.ui.NoopPrefs.lastDevice(context)?.second == com.noop.ble.WhoopModel.WHOOP5_MG)
+            // Unknown still resolves to WHOOP4 here: this one picks an analysis default, it does not
+            // report an observation, and every prior export took that branch.
+            val family = if (reportedModel(context) == com.noop.ble.WhoopModel.WHOOP5_MG)
                 com.noop.protocol.DeviceFamily.WHOOP5 else com.noop.protocol.DeviceFamily.WHOOP4
             // Mirror the real per-device anchor (#404): learn it from the WHOLE recent window's raws — not
             // just this night — so a single sparse night (<100 in-band) can't misreport under the global
@@ -265,11 +295,13 @@ object AndroidDiagnostics {
             val mins = com.noop.ui.NoopPrefs.smartAlarmMinutes(context)
             add("Enabled: ${if (on) "yes" else "no"} · set ${"%02d:%02d".format(mins / 60, mins % 60)}")
             // #3: model + the 5/MG experimental gate (a 5/MG firmware alarm is NOT armed unless it's on).
-            if (com.noop.ui.NoopPrefs.lastDevice(context)?.second == com.noop.ble.WhoopModel.WHOOP5_MG) {
-                val exp = com.noop.ble.PuffinExperiment.from(context).isEnabled
-                add("Model: WHOOP 5.0/MG · experimental: ${if (exp) "on" else "off → firmware alarm NOT armed"}")
-            } else {
-                add("Model: WHOOP 4.0")
+            when (reportedModel(context)) {
+                com.noop.ble.WhoopModel.WHOOP5_MG -> {
+                    val exp = com.noop.ble.PuffinExperiment.from(context).isEnabled
+                    add("Model: WHOOP 5.0/MG · experimental: ${if (exp) "on" else "off → firmware alarm NOT armed"}")
+                }
+                com.noop.ble.WhoopModel.WHOOP4 -> add("Model: WHOOP 4.0")
+                null -> add("Model: unknown (family not yet detected)")
             }
             // #4: strap clock health — a reset/stale OR future-dated clock (the #34 / #928 causes) breaks
             // the alarm even when armed.


### PR DESCRIPTION
Two field logs from confirmed **WHOOP 5** straps arrived headed `Model: WHOOP 4.0` (#1451, #1464). Both misdirected triage until the decoded layout version (v18 + puffin framing) gave the hardware away. Each platform had its own reason, and they fail in opposite directions.

### Android: it fabricates a 4.0

Two prefs hold a model and they disagree:

| pref | written by | holds |
|---|---|---|
| `noop.selectedWhoopModel` | `WhoopBleClient.persistSelectedModel` | the family that **actually advertised** |
| `noop.lastDeviceModel` | pair-time `rememberDevice` | what was remembered |

`NoopPrefs.lastDevice` widens a missing model to `WHOOP4`. That is a sensible default for **reconnecting** — the code must pick a service to try — but a lie in a **report**, which is read as an observation.

The export now prefers the detected family and says `unknown` when neither pref knows. It reads the raw prefs rather than `lastDevice`, precisely so "remembered as a 4.0" stays distinguishable from "nothing remembered".

Two sibling call sites took the same wrong value. The analysis-family pick keeps its `WHOOP4` fallback — it chooses a default, it does not report an observation — while the alarm block gains an explicit unknown arm instead of claiming 4.0.

### Apple: it has never reported a model at all

```swift
switch d.string(forKey: "selectedWhoopModel") {
case "whoop5": ...
case "whoop4": ...
default:       model = "unknown (never paired)"
}
```

Those are the enum **case names**. Both writers store `WhoopModel.rawValue` — `"WHOOP 4.0"` / `"WHOOP 5.0 / MG"`. **Neither case can ever match**, so every Apple export has read `unknown (never paired)` for every strap, forever, including one actively syncing.

The sibling block ~270 lines below already compares `.rawValue`, and carries a comment warning about this exact trap. This site never got the same treatment.

It now parses through `WhoopModel(rawValue:)`, so the enum is the only parser and a rename cannot re-open the gap — the same reason the literals drifted in the first place.

### The principle

A report may say **unknown**. It may not invent a model. A diagnostic that guesses is worse than one that abstains, because the guess is read as evidence — which is exactly what happened on two issues today.

### Verification

`compileFullDebugKotlin` clean · full Android unit suite green · `doc_comment_lint` clean.

**The Swift half is app-target and has not been compiled** — it needs an `app-build` run before merge. No CI has been run on this branch yet by request.

No tests: both sites read `SharedPreferences`/`UserDefaults` behind Context, and the Apple fix removes its bug class structurally rather than pinning it with an assertion.
