### PR TITLE
Count deliveries per stored second across a whole night (#1331/#1008)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -703,9 +703,18 @@ public enum HRVAnalyzer {
         let secsNoStart = secsSeen.count - secs
         return "rr deliveries secs[1/2/3/4+]=\(hist[0])/\(hist[1])/\(hist[2])/\(hist[3])"
             + " multiSec=\(pct(multiSecs, secs))% multiRows=\(pct(multiRows, known))%"
-            + " multiMs=\(pct(Int(multiMs.rounded()), Int(knownMs.rounded())))%"
+            + " multiMs=\(pct(msToInt(multiMs), msToInt(knownMs)))%"
             + " maxDeliv=\(maxDeliv) secsNoStart=\(secsNoStart) ordUnknown=\(unknown)"
     }
+
+    /// Beat-time milliseconds to a whole number, half-up, WITHOUT `rounded()` or `round()`.
+    ///
+    /// Swift's `.rounded()` is half-away-from-zero and Kotlin's `kotlin.math.round` is half-toward-positive
+    /// -infinity. They agree here only because these sums are positive — the same "agrees until it doesn't"
+    /// shape as the `%.1f` divergence in #1473, where one platform's formatter rounded a tie the other way.
+    /// `x + 0.5` truncated is half-up on both, with no stdlib rounding involved, so the agreement is by
+    /// construction rather than by luck. Byte-parity twin of Kotlin `HrvAnalyzer.msToInt`.
+    static func msToInt(_ ms: Double) -> Int { ms > 0 ? Int(ms + 0.5) : 0 }
 
     /// Whole-percent, integer half-up, so both platforms round a tie the same way. 0 when `total` is 0.
     static func pct(_ part: Int, _ total: Int) -> Int {

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -639,6 +639,18 @@ public enum HRVAnalyzer {
         return rrCoverage(tsSec: keptTs, rrMs: keptRr)
     }
 
+    /// One second's tallies for `deliveryHistogram` — kept in a single dictionary so each row costs one
+    /// hash lookup rather than one per metric.
+    ///
+    /// A CLASS, not a struct, deliberately: a struct is a value type, so accumulating into it would mean
+    /// read-modify-write-back — two lookups per row, which is half the saving thrown away. Mutating through
+    /// a reference keeps it at one, and matches the Kotlin twin's shape exactly.
+    final class SecondTally {
+        var knownRows = 0
+        var ms = 0.0
+        var deliveries = 0
+    }
+
     /// #1331/#1008: how many separate DELIVERIES wrote each stored second, across a whole night.
     ///
     /// `ord` restarts at 0 on every delivery, so two rows on one second both carrying `ord == 0` came from
@@ -665,42 +677,53 @@ public enum HRVAnalyzer {
     public static func deliveryHistogram(tsSec: [Int], rrMs: [Double], ords: [Int?]) -> String {
         let n = min(tsSec.count, rrMs.count)
         guard n > 0 else { return "" }
-        var deliveriesPerSec: [Int: Int] = [:]   // second -> count of ord==0 rows
-        var knownRowsPerSec: [Int: Int] = [:]    // rows we can attribute (ord present)
-        var knownMsPerSec: [Int: Double] = [:]   // and their beat-time, which is what coverage counts
+        // ONE dictionary keyed by the second, not four. An earlier revision kept `secsSeen`,
+        // `knownRowsPerSec`, `knownMsPerSec` and `deliveriesPerSec` in parallel — 3-4 hash lookups per row,
+        // on a path that runs once per over-counted night and so ~21 times per `analyzeRecent` cycle, every
+        // 15 minutes. At ~70k rows a night that is several million redundant lookups for a diagnostic.
+        var bySec: [Int: SecondTally] = [:]
         var unknown = 0
         var known = 0
         var knownMs = 0.0
-        var secsSeen = Set<Int>()
         for i in 0 ..< n {
-            secsSeen.insert(tsSec[i])
-            guard i < ords.count, let o = ords[i] else { unknown += 1; continue }
-            known += 1
-            knownMs += rrMs[i]
-            knownRowsPerSec[tsSec[i], default: 0] += 1
-            knownMsPerSec[tsSec[i], default: 0] += rrMs[i]
-            if o == 0 { deliveriesPerSec[tsSec[i], default: 0] += 1 }
+            let tally: SecondTally
+            if let existing = bySec[tsSec[i]] {
+                tally = existing
+            } else {
+                tally = SecondTally()
+                bySec[tsSec[i]] = tally
+            }
+            if i < ords.count, let o = ords[i] {
+                known += 1
+                knownMs += rrMs[i]
+                tally.knownRows += 1
+                tally.ms += rrMs[i]
+                if o == 0 { tally.deliveries += 1 }
+            } else {
+                unknown += 1
+            }
         }
         var hist = [0, 0, 0, 0]      // 1, 2, 3, 4+
         var multiSecs = 0
         var multiRows = 0
         var multiMs = 0.0
         var maxDeliv = 0
-        for (sec, count) in deliveriesPerSec where count > 0 {
-            hist[min(count, 4) - 1] += 1
-            if count > maxDeliv { maxDeliv = count }
-            if count >= 2 {
+        var secs = 0
+        for (_, tally) in bySec where tally.deliveries > 0 {
+            secs += 1
+            hist[min(tally.deliveries, 4) - 1] += 1
+            if tally.deliveries > maxDeliv { maxDeliv = tally.deliveries }
+            if tally.deliveries >= 2 {
                 multiSecs += 1
-                multiRows += knownRowsPerSec[sec] ?? 0
-                multiMs += knownMsPerSec[sec] ?? 0
+                multiRows += tally.knownRows
+                multiMs += tally.ms
             }
         }
-        let secs = deliveriesPerSec.count
         // Seconds carrying rows but NO ord==0 row at all. Reachable: the primary key absorbs a cross-batch
         // exact duplicate, and the row it drops can be the delivery's first on that second. Reported rather
         // than folded into the histogram, so `secs` staying below the night's real second count is visible
         // instead of quietly shrinking the denominator underneath `multiSec`.
-        let secsNoStart = secsSeen.count - secs
+        let secsNoStart = bySec.count - secs
         return "rr deliveries secs[1/2/3/4+]=\(hist[0])/\(hist[1])/\(hist[2])/\(hist[3])"
             + " multiSec=\(pct(multiSecs, secs))% multiRows=\(pct(multiRows, known))%"
             + " multiMs=\(pct(msToInt(multiMs), msToInt(knownMs)))%"

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -639,6 +639,67 @@ public enum HRVAnalyzer {
         return rrCoverage(tsSec: keptTs, rrMs: keptRr)
     }
 
+    /// #1331/#1008: how many separate DELIVERIES wrote each stored second, across a whole night.
+    ///
+    /// `ord` restarts at 0 on every delivery, so two rows on one second both carrying `ord == 0` came from
+    /// two different offloads writing the same wall second. `densestSecondWindowSample` already shows that
+    /// — but only for the 5-8 seconds around the densest one, which is a sample, not a measurement. This
+    /// aggregates it over the night, because the fix turns on a question a sample cannot answer: is the
+    /// over-count mostly seconds touched by SEVERAL deliveries, or genuinely too many beats inside one?
+    ///
+    /// `multiRows` is a share of ATTRIBUTABLE rows (those carrying an `ord`), not of every row — dividing
+    /// by the total would let a night that half-predates `ord` read artificially benign, which is precisely
+    /// the conclusion this exists to prevent.
+    ///
+    /// Rows whose `ord` is nil are counted in `ordUnknown` and excluded from the histogram rather than
+    /// assumed to be first-of-delivery: `ord` was added later, so a night that predates it would otherwise
+    /// read as "every second written once" and quietly argue against the mechanism it cannot see.
+    ///
+    /// Percentages are integer half-up on both platforms — no float formatting, so the two logs cannot
+    /// disagree on a tie (the #1473 lesson). Byte-parity twin of Kotlin `HrvAnalyzer.deliveryHistogram`.
+    public static func deliveryHistogram(tsSec: [Int], rrMs: [Double], ords: [Int?]) -> String {
+        let n = min(tsSec.count, rrMs.count)
+        guard n > 0 else { return "" }
+        var deliveriesPerSec: [Int: Int] = [:]   // second -> count of ord==0 rows
+        var knownRowsPerSec: [Int: Int] = [:]    // rows we can attribute (ord present)
+        var unknown = 0
+        var known = 0
+        var secsSeen = Set<Int>()
+        for i in 0 ..< n {
+            secsSeen.insert(tsSec[i])
+            guard i < ords.count, let o = ords[i] else { unknown += 1; continue }
+            known += 1
+            knownRowsPerSec[tsSec[i], default: 0] += 1
+            if o == 0 { deliveriesPerSec[tsSec[i], default: 0] += 1 }
+        }
+        var hist = [0, 0, 0, 0]      // 1, 2, 3, 4+
+        var multiSecs = 0
+        var multiRows = 0
+        var maxDeliv = 0
+        for (sec, count) in deliveriesPerSec where count > 0 {
+            hist[min(count, 4) - 1] += 1
+            if count > maxDeliv { maxDeliv = count }
+            if count >= 2 {
+                multiSecs += 1
+                multiRows += knownRowsPerSec[sec] ?? 0
+            }
+        }
+        let secs = deliveriesPerSec.count
+        // Seconds carrying rows but NO ord==0 row at all. Reachable: the primary key absorbs a cross-batch
+        // exact duplicate, and the row it drops can be the delivery's first on that second. Reported rather
+        // than folded into the histogram, so `secs` staying below the night's real second count is visible
+        // instead of quietly shrinking the denominator underneath `multiSec`.
+        let secsNoStart = secsSeen.count - secs
+        return "rr deliveries secs[1/2/3/4+]=\(hist[0])/\(hist[1])/\(hist[2])/\(hist[3])"
+            + " multiSec=\(pct(multiSecs, secs))% multiRows=\(pct(multiRows, known))%"
+            + " maxDeliv=\(maxDeliv) secsNoStart=\(secsNoStart) ordUnknown=\(unknown)"
+    }
+
+    /// Whole-percent, integer half-up, so both platforms round a tie the same way. 0 when `total` is 0.
+    static func pct(_ part: Int, _ total: Int) -> Int {
+        total > 0 ? (part * 200 + total) / (total * 2) : 0
+    }
+
     /// #1008: a compact, deterministic RAW-ROW sample of the beats around the DENSEST second, for the
     /// always-on `hrv diag` log — emitted ONLY on an over-count night, so the mechanism of a `coverage>1`
     /// verdict can be READ off the log instead of guessed at. The coverage stats above say THAT a night is

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -647,6 +647,11 @@ public enum HRVAnalyzer {
     /// aggregates it over the night, because the fix turns on a question a sample cannot answer: is the
     /// over-count mostly seconds touched by SEVERAL deliveries, or genuinely too many beats inside one?
     ///
+    /// `multiMs` is the share of attributable BEAT-TIME on those seconds, and it is the number the fix is
+    /// sized against: coverage is Σ(rrMs) over wall span, so beat-time is what inflates it. A high
+    /// `multiRows` with a low `multiMs` would mean the extra rows are short and barely move coverage —
+    /// a different problem from the one this is chasing.
+    ///
     /// `multiRows` is a share of ATTRIBUTABLE rows (those carrying an `ord`), not of every row — dividing
     /// by the total would let a night that half-predates `ord` read artificially benign, which is precisely
     /// the conclusion this exists to prevent.
@@ -662,19 +667,24 @@ public enum HRVAnalyzer {
         guard n > 0 else { return "" }
         var deliveriesPerSec: [Int: Int] = [:]   // second -> count of ord==0 rows
         var knownRowsPerSec: [Int: Int] = [:]    // rows we can attribute (ord present)
+        var knownMsPerSec: [Int: Double] = [:]   // and their beat-time, which is what coverage counts
         var unknown = 0
         var known = 0
+        var knownMs = 0.0
         var secsSeen = Set<Int>()
         for i in 0 ..< n {
             secsSeen.insert(tsSec[i])
             guard i < ords.count, let o = ords[i] else { unknown += 1; continue }
             known += 1
+            knownMs += rrMs[i]
             knownRowsPerSec[tsSec[i], default: 0] += 1
+            knownMsPerSec[tsSec[i], default: 0] += rrMs[i]
             if o == 0 { deliveriesPerSec[tsSec[i], default: 0] += 1 }
         }
         var hist = [0, 0, 0, 0]      // 1, 2, 3, 4+
         var multiSecs = 0
         var multiRows = 0
+        var multiMs = 0.0
         var maxDeliv = 0
         for (sec, count) in deliveriesPerSec where count > 0 {
             hist[min(count, 4) - 1] += 1
@@ -682,6 +692,7 @@ public enum HRVAnalyzer {
             if count >= 2 {
                 multiSecs += 1
                 multiRows += knownRowsPerSec[sec] ?? 0
+                multiMs += knownMsPerSec[sec] ?? 0
             }
         }
         let secs = deliveriesPerSec.count
@@ -692,6 +703,7 @@ public enum HRVAnalyzer {
         let secsNoStart = secsSeen.count - secs
         return "rr deliveries secs[1/2/3/4+]=\(hist[0])/\(hist[1])/\(hist[2])/\(hist[3])"
             + " multiSec=\(pct(multiSecs, secs))% multiRows=\(pct(multiRows, known))%"
+            + " multiMs=\(pct(Int(multiMs.rounded()), Int(knownMs.rounded())))%"
             + " maxDeliv=\(maxDeliv) secsNoStart=\(secsNoStart) ordUnknown=\(unknown)"
     }
 

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerSampleOrdTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerSampleOrdTests.swift
@@ -43,7 +43,7 @@ final class HRVAnalyzerSampleOrdTests: XCTestCase {
         let ords: [Int?] = [0, 0, 0, 0, 1, 2]   // 100 written twice; 102 is one delivery of three beats
         let line = HRVAnalyzer.deliveryHistogram(tsSec: ts, rrMs: rr, ords: ords)
         XCTAssertEqual(line, "rr deliveries secs[1/2/3/4+]=2/1/0/0 multiSec=33% multiRows=33%"
-                       + " maxDeliv=2 secsNoStart=0 ordUnknown=0")
+                       + " multiMs=36% maxDeliv=2 secsNoStart=0 ordUnknown=0")
     }
 
     /// A clean night: every second written by exactly one delivery, so nothing is flagged.
@@ -52,7 +52,7 @@ final class HRVAnalyzerSampleOrdTests: XCTestCase {
         let line = HRVAnalyzer.deliveryHistogram(tsSec: ts, rrMs: ts.map { _ in 1000.0 },
                                                  ords: ts.map { _ in Int?(0) })
         XCTAssertEqual(line, "rr deliveries secs[1/2/3/4+]=10/0/0/0 multiSec=0% multiRows=0%"
-                       + " maxDeliv=1 secsNoStart=0 ordUnknown=0")
+                       + " multiMs=0% maxDeliv=1 secsNoStart=0 ordUnknown=0")
     }
 
     /// Rows predating the `ord` column must NOT read as "written once" — that would argue against the
@@ -62,7 +62,7 @@ final class HRVAnalyzerSampleOrdTests: XCTestCase {
                                                  rrMs: [900.0, 910.0, 920.0],
                                                  ords: [nil, nil, 0])
         XCTAssertEqual(line, "rr deliveries secs[1/2/3/4+]=1/0/0/0 multiSec=0% multiRows=0%"
-                       + " maxDeliv=1 secsNoStart=1 ordUnknown=2")
+                       + " multiMs=0% maxDeliv=1 secsNoStart=1 ordUnknown=2")
     }
 
     /// Percentages round half-up by integer maths, so a tie cannot render differently per platform.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerSampleOrdTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerSampleOrdTests.swift
@@ -31,4 +31,44 @@ final class HRVAnalyzerSampleOrdTests: XCTestCase {
             tsSec: [100, 100], rrMs: [700, 800], srcCodes: [nil, nil])
         XCTAssertFalse(out.contains("#"), out)
     }
+
+    // MARK: - #1331/#1008 delivery histogram
+
+    /// The shape today's 5/MG log shows: one second written by TWO deliveries (two rows at ord 0 with
+    /// different values), beside seconds written once. That is the mechanism the night-wide count exists
+    /// to size, and it is invisible to an exact-duplicate check because the values differ.
+    func testTwoDeliveriesOnOneSecondAreCounted() {
+        let ts =   [100, 100, 101, 102, 102, 102]
+        let rr = [872.0, 893.0, 800.0, 500.0, 537.0, 1309.0]
+        let ords: [Int?] = [0, 0, 0, 0, 1, 2]   // 100 written twice; 102 is one delivery of three beats
+        let line = HRVAnalyzer.deliveryHistogram(tsSec: ts, rrMs: rr, ords: ords)
+        XCTAssertEqual(line, "rr deliveries secs[1/2/3/4+]=2/1/0/0 multiSec=33% multiRows=33%"
+                       + " maxDeliv=2 secsNoStart=0 ordUnknown=0")
+    }
+
+    /// A clean night: every second written by exactly one delivery, so nothing is flagged.
+    func testSingleDeliveryPerSecondReadsClean() {
+        let ts = Array(200 ..< 210)
+        let line = HRVAnalyzer.deliveryHistogram(tsSec: ts, rrMs: ts.map { _ in 1000.0 },
+                                                 ords: ts.map { _ in Int?(0) })
+        XCTAssertEqual(line, "rr deliveries secs[1/2/3/4+]=10/0/0/0 multiSec=0% multiRows=0%"
+                       + " maxDeliv=1 secsNoStart=0 ordUnknown=0")
+    }
+
+    /// Rows predating the `ord` column must NOT read as "written once" — that would argue against the
+    /// mechanism the histogram exists to detect. They are excluded and counted separately instead.
+    func testNilOrdsAreExcludedNotAssumedFirst() {
+        let line = HRVAnalyzer.deliveryHistogram(tsSec: [300, 300, 301],
+                                                 rrMs: [900.0, 910.0, 920.0],
+                                                 ords: [nil, nil, 0])
+        XCTAssertEqual(line, "rr deliveries secs[1/2/3/4+]=1/0/0/0 multiSec=0% multiRows=0%"
+                       + " maxDeliv=1 secsNoStart=1 ordUnknown=2")
+    }
+
+    /// Percentages round half-up by integer maths, so a tie cannot render differently per platform.
+    func testPercentIsIntegerHalfUp() {
+        XCTAssertEqual(HRVAnalyzer.pct(1, 8), 13)    // 12.5 -> 13, not 12
+        XCTAssertEqual(HRVAnalyzer.pct(3, 8), 38)    // 37.5 -> 38
+        XCTAssertEqual(HRVAnalyzer.pct(0, 0), 0)
+    }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerSampleOrdTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerSampleOrdTests.swift
@@ -65,6 +65,17 @@ final class HRVAnalyzerSampleOrdTests: XCTestCase {
                        + " multiMs=0% maxDeliv=1 secsNoStart=1 ordUnknown=2")
     }
 
+    /// Beat-time rounds half-UP on both platforms. `.rounded()` (Swift, half-away-from-zero) and
+    /// `kotlin.math.round` (half-toward-+infinity) agree only for positive values; this pins the explicit
+    /// behaviour so the agreement cannot quietly become a coincidence again (#1473).
+    func testMsRoundsHalfUpWithoutStdlibRounding() {
+        XCTAssertEqual(HRVAnalyzer.msToInt(0.5), 1)
+        XCTAssertEqual(HRVAnalyzer.msToInt(1.5), 2)
+        XCTAssertEqual(HRVAnalyzer.msToInt(2.5), 3)   // half-to-even would give 2
+        XCTAssertEqual(HRVAnalyzer.msToInt(2.4), 2)
+        XCTAssertEqual(HRVAnalyzer.msToInt(0), 0)
+    }
+
     /// Percentages round half-up by integer maths, so a tie cannot render differently per platform.
     func testPercentIsIntegerHalfUp() {
         XCTAssertEqual(HRVAnalyzer.pct(1, 8), 13)    // 12.5 -> 13, not 12

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1086,6 +1086,12 @@ final class IntelligenceEngine: ObservableObject {
                             tsSec: ts, rrMs: sleepRr, srcCodes: sleepRrRows.map { $0.srcChannel?.rawValue },
                             ords: sleepRrRows.map { $0.ord })
                         if !sample.isEmpty { diagLine += "\nhrv rrsample day=\(res.daily.day) \(sample)" }
+                        // #1331/#1008: the sample above shows ords for a handful of seconds; this counts
+                        // them across the WHOLE night, which is what decides whether the fix belongs at
+                        // ingest. Kotlin twin.
+                        let deliveries = HRVAnalyzer.deliveryHistogram(
+                            tsSec: ts, rrMs: sleepRr, ords: sleepRrRows.map { $0.ord })
+                        if !deliveries.isEmpty { diagLine += "\n\(deliveries) day=\(res.daily.day)" }
                         // #1331/#1008/#1118 SHADOW: log the DEDUPED stream's HRV + coverage + beat-accuracy
                         // beside the raw (above), so the candidate two-channel de-dup can be validated
                         // against WHOOP's own numbers and @artemc's Polar H10 BEFORE it becomes the read

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -577,6 +577,16 @@ object HrvAnalyzer {
     }
 
     /**
+     * One second's tallies for [deliveryHistogram] — kept in a single map so each row costs one hash lookup
+     * rather than one per metric. Twin of the Swift `SecondTally`.
+     */
+    internal class SecondTally {
+        var knownRows = 0
+        var ms = 0.0
+        var deliveries = 0
+    }
+
+    /**
      * #1331/#1008: how many separate DELIVERIES wrote each stored second, across a whole night.
      *
      * `ord` restarts at 0 on every delivery, so two rows on one second both carrying `ord == 0` came from
@@ -604,44 +614,49 @@ object HrvAnalyzer {
     fun deliveryHistogram(tsSec: List<Long>, rrMs: List<Double>, ords: List<Int?>): String {
         val n = minOf(tsSec.size, rrMs.size)
         if (n == 0) return ""
-        val deliveriesPerSec = HashMap<Long, Int>()
-        val knownRowsPerSec = HashMap<Long, Int>()   // rows we can attribute (ord present)
-        val knownMsPerSec = HashMap<Long, Double>()  // and their beat-time, which is what coverage counts
-        val secsSeen = HashSet<Long>()
+        // ONE map keyed by the second, not four. An earlier revision kept `secsSeen`, `knownRowsPerSec`,
+        // `knownMsPerSec` and `deliveriesPerSec` in parallel — 3-4 hash lookups per row, on a path that runs
+        // once per over-counted night and so ~21 times per analyzeRecent cycle, every 15 minutes. At ~70k
+        // rows a night that is several million redundant lookups for a diagnostic.
+        val bySec = HashMap<Long, SecondTally>()
         var unknown = 0
         var known = 0
         var knownMs = 0.0
         for (i in 0 until n) {
-            secsSeen.add(tsSec[i])
+            val tally = bySec.getOrPut(tsSec[i]) { SecondTally() }
             val o = ords.getOrNull(i)
-            if (o == null) { unknown += 1; continue }
-            known += 1
-            knownMs += rrMs[i]
-            knownRowsPerSec[tsSec[i]] = (knownRowsPerSec[tsSec[i]] ?: 0) + 1
-            knownMsPerSec[tsSec[i]] = (knownMsPerSec[tsSec[i]] ?: 0.0) + rrMs[i]
-            if (o == 0) deliveriesPerSec[tsSec[i]] = (deliveriesPerSec[tsSec[i]] ?: 0) + 1
+            if (o == null) {
+                unknown += 1
+            } else {
+                known += 1
+                knownMs += rrMs[i]
+                tally.knownRows += 1
+                tally.ms += rrMs[i]
+                if (o == 0) tally.deliveries += 1
+            }
         }
         val hist = intArrayOf(0, 0, 0, 0) // 1, 2, 3, 4+
         var multiSecs = 0
         var multiRows = 0
         var multiMs = 0.0
         var maxDeliv = 0
-        for ((sec, count) in deliveriesPerSec) {
-            if (count <= 0) continue
-            hist[minOf(count, 4) - 1] += 1
-            if (count > maxDeliv) maxDeliv = count
-            if (count >= 2) {
+        var secs = 0
+        for (tally in bySec.values) {
+            if (tally.deliveries <= 0) continue
+            secs += 1
+            hist[minOf(tally.deliveries, 4) - 1] += 1
+            if (tally.deliveries > maxDeliv) maxDeliv = tally.deliveries
+            if (tally.deliveries >= 2) {
                 multiSecs += 1
-                multiRows += knownRowsPerSec[sec] ?: 0
-                multiMs += knownMsPerSec[sec] ?: 0.0
+                multiRows += tally.knownRows
+                multiMs += tally.ms
             }
         }
-        val secs = deliveriesPerSec.size
         // Seconds carrying rows but NO ord==0 row at all. Reachable: the primary key absorbs a cross-batch
         // exact duplicate, and the row it drops can be the delivery's first on that second. Reported rather
         // than folded into the histogram, so `secs` staying below the night's real second count is visible
         // instead of quietly shrinking the denominator underneath `multiSec`.
-        val secsNoStart = secsSeen.size - secs
+        val secsNoStart = bySec.size - secs
         return "rr deliveries secs[1/2/3/4+]=${hist[0]}/${hist[1]}/${hist[2]}/${hist[3]}" +
             " multiSec=${pct(multiSecs, secs)}% multiRows=${pct(multiRows, known)}%" +
             " multiMs=${pct(msToInt(multiMs), msToInt(knownMs))}%" +

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -644,9 +644,20 @@ object HrvAnalyzer {
         val secsNoStart = secsSeen.size - secs
         return "rr deliveries secs[1/2/3/4+]=${hist[0]}/${hist[1]}/${hist[2]}/${hist[3]}" +
             " multiSec=${pct(multiSecs, secs)}% multiRows=${pct(multiRows, known)}%" +
-            " multiMs=${pct(kotlin.math.round(multiMs).toInt(), kotlin.math.round(knownMs).toInt())}%" +
+            " multiMs=${pct(msToInt(multiMs), msToInt(knownMs))}%" +
             " maxDeliv=$maxDeliv secsNoStart=$secsNoStart ordUnknown=$unknown"
     }
+
+    /**
+     * Beat-time milliseconds to a whole number, half-up, WITHOUT `round()` or `.rounded()`.
+     *
+     * `kotlin.math.round` is half-toward-positive-infinity and Swift's `.rounded()` is half-away-from-zero.
+     * They agree here only because these sums are positive — the same "agrees until it doesn't" shape as
+     * the `%.1f` divergence in #1473, where one platform's formatter rounded a tie the other way.
+     * `x + 0.5` truncated is half-up on both, with no stdlib rounding involved, so the agreement is by
+     * construction rather than by luck. Byte-parity twin of Swift `HRVAnalyzer.msToInt`.
+     */
+    internal fun msToInt(ms: Double): Int = if (ms > 0) (ms + 0.5).toInt() else 0
 
     /** Whole-percent, integer half-up, so both platforms round a tie the same way. 0 when [total] is 0. */
     internal fun pct(part: Int, total: Int): Int =

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -577,6 +577,70 @@ object HrvAnalyzer {
     }
 
     /**
+     * #1331/#1008: how many separate DELIVERIES wrote each stored second, across a whole night.
+     *
+     * `ord` restarts at 0 on every delivery, so two rows on one second both carrying `ord == 0` came from
+     * two different offloads writing the same wall second. [densestSecondWindowSample] already shows that —
+     * but only for the 5-8 seconds around the densest one, which is a sample, not a measurement. This
+     * aggregates it over the night, because the fix turns on a question a sample cannot answer: is the
+     * over-count mostly seconds touched by SEVERAL deliveries, or genuinely too many beats inside one?
+     *
+     * `multiRows` is a share of ATTRIBUTABLE rows (those carrying an `ord`), not of every row — dividing
+     * by the total would let a night that half-predates `ord` read artificially benign, which is precisely
+     * the conclusion this exists to prevent.
+     *
+     * Rows whose `ord` is null are counted in `ordUnknown` and excluded from the histogram rather than
+     * assumed to be first-of-delivery: `ord` was added later, so a night that predates it would otherwise
+     * read as "every second written once" and quietly argue against the mechanism it cannot see.
+     *
+     * Percentages are integer half-up on both platforms — no float formatting, so the two logs cannot
+     * disagree on a tie (the #1473 lesson). Byte-parity twin of Swift `HRVAnalyzer.deliveryHistogram`.
+     */
+    fun deliveryHistogram(tsSec: List<Long>, rrMs: List<Double>, ords: List<Int?>): String {
+        val n = minOf(tsSec.size, rrMs.size)
+        if (n == 0) return ""
+        val deliveriesPerSec = HashMap<Long, Int>()
+        val knownRowsPerSec = HashMap<Long, Int>()   // rows we can attribute (ord present)
+        val secsSeen = HashSet<Long>()
+        var unknown = 0
+        var known = 0
+        for (i in 0 until n) {
+            secsSeen.add(tsSec[i])
+            val o = ords.getOrNull(i)
+            if (o == null) { unknown += 1; continue }
+            known += 1
+            knownRowsPerSec[tsSec[i]] = (knownRowsPerSec[tsSec[i]] ?: 0) + 1
+            if (o == 0) deliveriesPerSec[tsSec[i]] = (deliveriesPerSec[tsSec[i]] ?: 0) + 1
+        }
+        val hist = intArrayOf(0, 0, 0, 0) // 1, 2, 3, 4+
+        var multiSecs = 0
+        var multiRows = 0
+        var maxDeliv = 0
+        for ((sec, count) in deliveriesPerSec) {
+            if (count <= 0) continue
+            hist[minOf(count, 4) - 1] += 1
+            if (count > maxDeliv) maxDeliv = count
+            if (count >= 2) {
+                multiSecs += 1
+                multiRows += knownRowsPerSec[sec] ?: 0
+            }
+        }
+        val secs = deliveriesPerSec.size
+        // Seconds carrying rows but NO ord==0 row at all. Reachable: the primary key absorbs a cross-batch
+        // exact duplicate, and the row it drops can be the delivery's first on that second. Reported rather
+        // than folded into the histogram, so `secs` staying below the night's real second count is visible
+        // instead of quietly shrinking the denominator underneath `multiSec`.
+        val secsNoStart = secsSeen.size - secs
+        return "rr deliveries secs[1/2/3/4+]=${hist[0]}/${hist[1]}/${hist[2]}/${hist[3]}" +
+            " multiSec=${pct(multiSecs, secs)}% multiRows=${pct(multiRows, known)}%" +
+            " maxDeliv=$maxDeliv secsNoStart=$secsNoStart ordUnknown=$unknown"
+    }
+
+    /** Whole-percent, integer half-up, so both platforms round a tie the same way. 0 when [total] is 0. */
+    internal fun pct(part: Int, total: Int): Int =
+        if (total > 0) (part * 200 + total) / (total * 2) else 0
+
+    /**
      * #1008: a compact, deterministic RAW-ROW sample of the beats around the DENSEST second, for the
      * always-on `hrv diag` log — emitted ONLY on an over-count night, so the mechanism of a `coverage>1`
      * verdict can be READ off the log instead of guessed at. The coverage stats above say THAT a night is

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -585,6 +585,11 @@ object HrvAnalyzer {
      * aggregates it over the night, because the fix turns on a question a sample cannot answer: is the
      * over-count mostly seconds touched by SEVERAL deliveries, or genuinely too many beats inside one?
      *
+     * `multiMs` is the share of attributable BEAT-TIME on those seconds, and it is the number the fix is
+     * sized against: coverage is Σ(rrMs) over wall span, so beat-time is what inflates it. A high
+     * `multiRows` with a low `multiMs` would mean the extra rows are short and barely move coverage —
+     * a different problem from the one this is chasing.
+     *
      * `multiRows` is a share of ATTRIBUTABLE rows (those carrying an `ord`), not of every row — dividing
      * by the total would let a night that half-predates `ord` read artificially benign, which is precisely
      * the conclusion this exists to prevent.
@@ -601,20 +606,25 @@ object HrvAnalyzer {
         if (n == 0) return ""
         val deliveriesPerSec = HashMap<Long, Int>()
         val knownRowsPerSec = HashMap<Long, Int>()   // rows we can attribute (ord present)
+        val knownMsPerSec = HashMap<Long, Double>()  // and their beat-time, which is what coverage counts
         val secsSeen = HashSet<Long>()
         var unknown = 0
         var known = 0
+        var knownMs = 0.0
         for (i in 0 until n) {
             secsSeen.add(tsSec[i])
             val o = ords.getOrNull(i)
             if (o == null) { unknown += 1; continue }
             known += 1
+            knownMs += rrMs[i]
             knownRowsPerSec[tsSec[i]] = (knownRowsPerSec[tsSec[i]] ?: 0) + 1
+            knownMsPerSec[tsSec[i]] = (knownMsPerSec[tsSec[i]] ?: 0.0) + rrMs[i]
             if (o == 0) deliveriesPerSec[tsSec[i]] = (deliveriesPerSec[tsSec[i]] ?: 0) + 1
         }
         val hist = intArrayOf(0, 0, 0, 0) // 1, 2, 3, 4+
         var multiSecs = 0
         var multiRows = 0
+        var multiMs = 0.0
         var maxDeliv = 0
         for ((sec, count) in deliveriesPerSec) {
             if (count <= 0) continue
@@ -623,6 +633,7 @@ object HrvAnalyzer {
             if (count >= 2) {
                 multiSecs += 1
                 multiRows += knownRowsPerSec[sec] ?: 0
+                multiMs += knownMsPerSec[sec] ?: 0.0
             }
         }
         val secs = deliveriesPerSec.size
@@ -633,6 +644,7 @@ object HrvAnalyzer {
         val secsNoStart = secsSeen.size - secs
         return "rr deliveries secs[1/2/3/4+]=${hist[0]}/${hist[1]}/${hist[2]}/${hist[3]}" +
             " multiSec=${pct(multiSecs, secs)}% multiRows=${pct(multiRows, known)}%" +
+            " multiMs=${pct(kotlin.math.round(multiMs).toInt(), kotlin.math.round(knownMs).toInt())}%" +
             " maxDeliv=$maxDeliv secsNoStart=$secsNoStart ordUnknown=$unknown"
     }
 

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -896,6 +896,10 @@ object IntelligenceEngine {
                         sleepRrRows.map { it.ord },
                     )
                     if (sample.isNotEmpty()) dayDiag("hrv rrsample day=${res.daily.day} $sample")
+                    // #1331/#1008: the sample above shows ords for a handful of seconds; this counts them
+                    // across the WHOLE night, which is what decides whether the fix belongs at ingest.
+                    val deliveries = HrvAnalyzer.deliveryHistogram(ts, sleepRr, sleepRrRows.map { it.ord })
+                    if (deliveries.isNotEmpty()) dayDiag("$deliveries day=${res.daily.day}")
                     // #1331/#1008/#1118 SHADOW: log the DEDUPED stream's HRV + coverage + beat-accuracy
                     // beside the raw so the candidate de-dup can be validated vs WHOOP + @artemc's Polar
                     // before it becomes the read path. Instrumentation only — shipped HRV/resp unchanged.

--- a/android/app/src/test/java/com/noop/analytics/HrvAnalyzerSampleOrdTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvAnalyzerSampleOrdTest.kt
@@ -56,7 +56,7 @@ class HrvAnalyzerSampleOrdTest {
         val rr = listOf(872.0, 893.0, 800.0, 500.0, 537.0, 1309.0)
         val ords = listOf<Int?>(0, 0, 0, 0, 1, 2)
         assertEquals(
-            "rr deliveries secs[1/2/3/4+]=2/1/0/0 multiSec=33% multiRows=33% maxDeliv=2 secsNoStart=0 ordUnknown=0",
+            "rr deliveries secs[1/2/3/4+]=2/1/0/0 multiSec=33% multiRows=33% multiMs=36% maxDeliv=2 secsNoStart=0 ordUnknown=0",
             HrvAnalyzer.deliveryHistogram(ts, rr, ords),
         )
     }
@@ -65,7 +65,7 @@ class HrvAnalyzerSampleOrdTest {
     @Test fun singleDeliveryPerSecondReadsClean() {
         val ts = (200L until 210L).toList()
         assertEquals(
-            "rr deliveries secs[1/2/3/4+]=10/0/0/0 multiSec=0% multiRows=0% maxDeliv=1 secsNoStart=0 ordUnknown=0",
+            "rr deliveries secs[1/2/3/4+]=10/0/0/0 multiSec=0% multiRows=0% multiMs=0% maxDeliv=1 secsNoStart=0 ordUnknown=0",
             HrvAnalyzer.deliveryHistogram(ts, ts.map { 1000.0 }, ts.map { 0 }),
         )
     }
@@ -76,7 +76,7 @@ class HrvAnalyzerSampleOrdTest {
      */
     @Test fun nilOrdsAreExcludedNotAssumedFirst() {
         assertEquals(
-            "rr deliveries secs[1/2/3/4+]=1/0/0/0 multiSec=0% multiRows=0% maxDeliv=1 secsNoStart=1 ordUnknown=2",
+            "rr deliveries secs[1/2/3/4+]=1/0/0/0 multiSec=0% multiRows=0% multiMs=0% maxDeliv=1 secsNoStart=1 ordUnknown=2",
             HrvAnalyzer.deliveryHistogram(
                 listOf(300L, 300L, 301L), listOf(900.0, 910.0, 920.0), listOf(null, null, 0),
             ),

--- a/android/app/src/test/java/com/noop/analytics/HrvAnalyzerSampleOrdTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvAnalyzerSampleOrdTest.kt
@@ -1,5 +1,6 @@
 package com.noop.analytics
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -42,5 +43,50 @@ class HrvAnalyzerSampleOrdTest {
         val rr = listOf(700.0, 800.0)
         val out = HrvAnalyzer.densestSecondWindowSample(ts, rr, srcCodes = listOf(null, null))
         assertTrue(out, !out.contains("#"))
+    }
+
+    // #1331/#1008 delivery histogram — twins of the Swift HRVAnalyzerSampleOrdTests cases.
+
+    /**
+     * The shape today's 5/MG log shows: one second written by TWO deliveries (two rows at ord 0 with
+     * different values), beside seconds written once. Invisible to an exact-duplicate check.
+     */
+    @Test fun twoDeliveriesOnOneSecondAreCounted() {
+        val ts = listOf(100L, 100L, 101L, 102L, 102L, 102L)
+        val rr = listOf(872.0, 893.0, 800.0, 500.0, 537.0, 1309.0)
+        val ords = listOf<Int?>(0, 0, 0, 0, 1, 2)
+        assertEquals(
+            "rr deliveries secs[1/2/3/4+]=2/1/0/0 multiSec=33% multiRows=33% maxDeliv=2 secsNoStart=0 ordUnknown=0",
+            HrvAnalyzer.deliveryHistogram(ts, rr, ords),
+        )
+    }
+
+    /** A clean night: every second written by exactly one delivery. */
+    @Test fun singleDeliveryPerSecondReadsClean() {
+        val ts = (200L until 210L).toList()
+        assertEquals(
+            "rr deliveries secs[1/2/3/4+]=10/0/0/0 multiSec=0% multiRows=0% maxDeliv=1 secsNoStart=0 ordUnknown=0",
+            HrvAnalyzer.deliveryHistogram(ts, ts.map { 1000.0 }, ts.map { 0 }),
+        )
+    }
+
+    /**
+     * Rows predating the `ord` column must NOT read as "written once" — that would argue against the
+     * mechanism the histogram exists to detect.
+     */
+    @Test fun nilOrdsAreExcludedNotAssumedFirst() {
+        assertEquals(
+            "rr deliveries secs[1/2/3/4+]=1/0/0/0 multiSec=0% multiRows=0% maxDeliv=1 secsNoStart=1 ordUnknown=2",
+            HrvAnalyzer.deliveryHistogram(
+                listOf(300L, 300L, 301L), listOf(900.0, 910.0, 920.0), listOf(null, null, 0),
+            ),
+        )
+    }
+
+    /** Percentages round half-up by integer maths, so a tie cannot render differently per platform. */
+    @Test fun percentIsIntegerHalfUp() {
+        assertEquals(13, HrvAnalyzer.pct(1, 8))
+        assertEquals(38, HrvAnalyzer.pct(3, 8))
+        assertEquals(0, HrvAnalyzer.pct(0, 0))
     }
 }

--- a/android/app/src/test/java/com/noop/analytics/HrvAnalyzerSampleOrdTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvAnalyzerSampleOrdTest.kt
@@ -83,6 +83,19 @@ class HrvAnalyzerSampleOrdTest {
         )
     }
 
+    /**
+     * Beat-time rounds half-UP on both platforms. `kotlin.math.round` (half-toward-+infinity) and Swift's
+     * `.rounded()` (half-away-from-zero) agree only for positive values; this pins the explicit behaviour
+     * so the agreement cannot quietly become a coincidence again (#1473).
+     */
+    @Test fun msRoundsHalfUpWithoutStdlibRounding() {
+        assertEquals(1, HrvAnalyzer.msToInt(0.5))
+        assertEquals(2, HrvAnalyzer.msToInt(1.5))
+        assertEquals(3, HrvAnalyzer.msToInt(2.5))   // half-to-even would give 2
+        assertEquals(2, HrvAnalyzer.msToInt(2.4))
+        assertEquals(0, HrvAnalyzer.msToInt(0.0))
+    }
+
     /** Percentages round half-up by integer maths, so a tie cannot render differently per platform. */
     @Test fun percentIsIntegerHalfUp() {
         assertEquals(13, HrvAnalyzer.pct(1, 8))


### PR DESCRIPTION
Instrumentation for #1331 / #1008 / #1118 / #1451 — which are one defect.

### Why a sample isn't enough

`ord` restarts at 0 on every delivery, so two rows on one second **both carrying `ord 0`** came from two different offloads writing the same wall second. Today's 5/MG log (#1451) shows exactly that:

```
-1s[872#0, 893#0]     two intervals, one second, both ord 0
```

But `densestSecondWindowSample` only dumps the 5–8 seconds around the densest one. That's a sample, not a measurement — and the fix turns on a question it cannot answer:

> Is the over-count mostly seconds touched by **several deliveries**, or genuinely **too many beats inside one**?

If it's the former, the fix belongs at ingest and this sizes it. If it isn't, we were about to write the wrong fix.

### The line

```
rr deliveries secs[1/2/3/4+]=2/1/0/0 multiSec=33% multiRows=33% maxDeliv=2 secsNoStart=0 ordUnknown=0
```

**Read-side only** — no new capture, no write-path change. It lights up on data already stored the moment someone opens the app on a build carrying it.

### Two things it deliberately refuses to flatter

Both found on re-review, both cases where a convenient denominator would have argued *against* the mechanism:

- **`multiRows` divides by attributable rows** (those carrying an `ord`), not by every row. Dividing by the total would let a night that half-predates the `ord` column read artificially benign — precisely the conclusion this exists to prevent.
- **`secsNoStart`** counts seconds carrying rows but no `ord 0` row at all. That's reachable: the primary key absorbs a cross-batch exact duplicate, and the row it drops can be the delivery's first on that second. Reporting it stops `secs` quietly shrinking the denominator underneath `multiSec`.

Percentages are integer half-up on both platforms, so a tie can't render differently per platform (the #1473 lesson).

### Verification

- Mirrored tests on both platforms asserting the rendered line **verbatim**: the two-delivery shape from the field log, a clean night, and the nil-`ord` case.
- The three expected strings were extracted from both suites and compared — **identical**.
- `compileFullDebugKotlin` clean, full Android unit suite green, `HrvAnalyzerSampleOrdTest` 7, `doc_comment_lint` clean.
- `StrandAnalytics` needs macOS, so its suite runs in CI rather than locally.

No behaviour change: nothing here feeds a stored value, a gate or a score.
