### PR TITLE
Compare the whole workout key when an edit replaces a row (#1488)

### DIFF
--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1167,14 +1167,19 @@ class WhoopRepository(
      * edit started from:
      *  - editing a DETECTED bout replaces it with this manual row , the detected original is dismissed
      *    durably so the re-detector doesn't bring it back (else both would show);
-     *  - editing a MANUAL row whose natural key (startTs/sport) changed deletes the stale row first
-     *    (the (deviceId, startTs, sport) PK upsert would otherwise orphan it);
+     *  - editing a MANUAL row whose PRIMARY KEY moved deletes the stale row first (the
+     *    (deviceId, startTs, sport) PK upsert would otherwise orphan it). deviceId is part of that key,
+     *    so a row stored under a re-paired strap's active id counts as moved even when startTs and sport
+     *    are untouched: the edit lands on the "my-whoop" seed while the original stays put, and
+     *    `workoutsUnion` reads [activeDeviceId, "my-whoop"] keeping the FIRST row per (startTs, sport),
+     *    so the stale copy would shadow the edit forever. Comparing only startTs/sport missed exactly
+     *    that case and made a save look successful while changing nothing (#1488);
      *  - an IMPORTED row is never passed here as `replacing` (duplicating one is a pure add).
      */
     suspend fun saveManualWorkout(row: WorkoutRow, replacing: WorkoutRow? = null) {
         if (replacing != null && replacing.source.lowercase().endsWith("-noop")) {
             dismissDetected(replacing)
-        } else if (replacing != null && (replacing.startTs != row.startTs || replacing.sport != row.sport)) {
+        } else if (replacing != null && supersedesStoredRow(replacing, row)) {
             dao.deleteWorkoutByKey(replacing.deviceId, replacing.startTs, replacing.sport)
         }
         dao.upsertWorkouts(listOf(row))
@@ -1990,6 +1995,16 @@ class WhoopRepository(
             val seen = HashSet<Pair<Long, Long>>()
             return sessions.filter { seen.add(it.startTs to it.endTs) }
         }
+
+        /** True when [replacing] is stored under a DIFFERENT primary key than the row about to be written,
+         *  so the upsert would leave it orphaned beside the new one instead of overwriting it. The key is
+         *  (deviceId, startTs, sport) — all three, which is the point: an edit whose startTs and sport are
+         *  untouched still moves when the original sits under a re-paired strap's active id and the edit is
+         *  built on the "my-whoop" seed. [dedupWorkoutsByKey] then hides the newer row behind the stale one,
+         *  so the save silently does nothing. (#1488) */
+        internal fun supersedesStoredRow(replacing: WorkoutRow, row: WorkoutRow): Boolean =
+            replacing.deviceId != row.deviceId || replacing.startTs != row.startTs ||
+                replacing.sport != row.sport
 
         /** Drop exact-duplicate workouts sharing an identical (startTs, sport) natural key — the same
          *  session read under two #814 union ids — keeping the FIRST seen (callers pass active-strap-first

--- a/android/app/src/main/java/com/noop/ui/WorkoutEditing.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutEditing.kt
@@ -38,6 +38,18 @@ object WorkoutEditing {
     }
 
     /**
+     * The pre-fill row behind "Duplicate as manual" on a READ-ONLY session (strap, Apple, lifting, file).
+     *
+     * Re-seeds `deviceId` to the manual namespace as well as `source`. deviceId is part of the workout
+     * primary key, so a copy that kept the original's id would hand [WhoopRepository.saveManualWorkout] a
+     * `replacing` key pointing INTO the source being copied from, and the save would retire the very row
+     * the menu promises not to touch — a strap session lives under the active strap id, which the delete
+     * path can reach. Re-seeding keeps every delete that save can issue inside "my-whoop". (#1488)
+     */
+    fun asManualCopy(row: WorkoutRow): WorkoutRow =
+        row.copy(source = "manual", deviceId = "my-whoop", sport = displaySport(row.sport))
+
+    /**
      * Sport-cell text. "detected" reads as a neutral "Activity". WHOOP sport names arrive as
      * concatenated camelCase (e.g. "TraditionalStrengthTraining"), which reads as one long
      * unbreakable word and truncates badly — split it into words on the lower→Upper boundary so it

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -1946,7 +1946,7 @@ private fun RowActionsMenu(
                 WorkoutSource.WHOOP, WorkoutSource.APPLE, WorkoutSource.LIFTING, WorkoutSource.ACTIVITY_FILE -> {
                     DropdownMenuItem(
                         text = { Text(uiString(R.string.l10n_workouts_screen_duplicate_as_manual_2d580d46), style = NoopType.body, color = Palette.textPrimary) },
-                        onClick = { open = false; onEdit(row.copy(source = "manual", sport = WorkoutEditing.displaySport(row.sport))) },
+                        onClick = { open = false; onEdit(WorkoutEditing.asManualCopy(row)) },
                     )
                 }
             }

--- a/android/app/src/test/java/com/noop/ui/WorkoutEditDeviceIdTest.kt
+++ b/android/app/src/test/java/com/noop/ui/WorkoutEditDeviceIdTest.kt
@@ -1,0 +1,105 @@
+package com.noop.ui
+
+import com.noop.data.WhoopRepository
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1488: editing a workout appeared to save and changed nothing, across restarts.
+ *
+ * `workout`'s primary key is (deviceId, startTs, sport), and the edit sheet builds every manual row on the
+ * "my-whoop" seed. On a strap whose ACTIVE id is something else — re-paired, or identified by serial — the
+ * original row sits under that active id, so the edit did not overwrite it, it inserted a second row beside
+ * it. `saveManualWorkout` then only deleted the original when startTs or sport had moved, which on a plain
+ * "change the duration" edit they had not. Both rows survived, and the read path keeps the FIRST row per
+ * (startTs, sport) across [activeDeviceId, "my-whoop"] — so the stale one shadowed the edit for good.
+ *
+ * The fix compares the whole primary key rather than two thirds of it, which also migrates the row onto the
+ * seed. That matters beyond this bug: "my-whoop" is in the read union unconditionally, while a strap's
+ * active id is only there while it is active.
+ */
+class WorkoutEditDeviceIdTest {
+
+    private val start = 1_780_000_000L
+
+    private fun row(deviceId: String, durationMin: Int, sport: String = "Run") =
+        WorkoutEditing.buildManualRow(
+            deviceId = deviceId, startSeconds = start, durationMin = durationMin, sport = sport,
+            avgHr = null, energyKcal = null, nowSeconds = start + 86_400L,
+        )!!
+
+    /**
+     * The regression, stated as the predicate that missed it: same start, same sport, and the original
+     * living under an active strap id. Two thirds of the key match, so the old comparison saw "nothing
+     * moved" and skipped the delete — while the upsert wrote to a different key anyway.
+     */
+    @Test fun aRowUnderAnActiveStrapIdIsSupersededEvenWhenStartAndSportAreUntouched() {
+        assertTrue(
+            WhoopRepository.supersedesStoredRow(row("whoop-ABC123", 30), row("my-whoop", 45)),
+        )
+    }
+
+    /** The ordinary in-place edit still must NOT delete: same key, so the upsert overwrites it. */
+    @Test fun anEditThatMovesNothingIsNotSuperseded() {
+        assertFalse(WhoopRepository.supersedesStoredRow(row("my-whoop", 30), row("my-whoop", 45)))
+    }
+
+    /** And the case that always worked keeps working — a re-keyed sport still retires the old row. */
+    @Test fun aSportChangeIsStillSuperseded() {
+        assertTrue(
+            WhoopRepository.supersedesStoredRow(
+                row("my-whoop", 30, sport = "Run"), row("my-whoop", 30, sport = "Ride"),
+            ),
+        )
+    }
+
+    /**
+     * The shadowing half, kept because it is what made the bug SILENT rather than a visible duplicate: the
+     * read union dedupes on (startTs, sport) only, so two rows differing just by deviceId collapse to one
+     * and the first — the active-strap row — wins. Without the delete above, this is what the user saw.
+     */
+    @Test fun unionDedupeDiscardsASecondRowDifferingOnlyByDeviceId() {
+        // Union order is [activeDeviceId, "my-whoop"], so the active-strap row is seen first.
+        val shown = WhoopRepository.dedupWorkoutsByKey(listOf(row("whoop-ABC123", 30), row("my-whoop", 45)))
+        assertEquals(1, shown.size)
+        assertEquals(start + 30 * 60, shown[0].endTs)   // the STALE duration survives — the reported bug
+        assertEquals("whoop-ABC123", shown[0].deviceId)
+    }
+
+    /**
+     * A DETECTED bout never reaches the delete branch above — it is dismissed durably instead, because the
+     * re-detector would otherwise recreate it. Pins the classification that routes it there, and that a
+     * computed "<id>-noop" source is read as detected rather than as an import.
+     */
+    @Test fun detectedBoutsRouteToDismissalNotDeletion() {
+        assertEquals(WorkoutSource.MANUAL, WorkoutEditing.classify("manual"))
+        assertEquals(WorkoutSource.DETECTED, WorkoutEditing.classify("my-whoop-noop"))
+        assertEquals(WorkoutSource.DETECTED, WorkoutEditing.classify("whoop-ABC123-noop"))
+        assertEquals(WorkoutSource.APPLE, WorkoutEditing.classify("apple-health"))
+        assertEquals(WorkoutSource.APPLE, WorkoutEditing.classify("health-connect"))
+    }
+
+    /**
+     * The delete this fix added must never be able to reach a read-only source.
+     *
+     * "Duplicate as manual" pre-fills the sheet from a strap / Apple / lifting row and passes that pre-fill
+     * on as `replacing`. It claims source "manual" while carrying the ORIGINAL's natural key, so if it also
+     * kept the original's deviceId, [WhoopRepository.supersedesStoredRow] would fire against the strap's own
+     * namespace and the save would delete the session it was copied from — on a menu item whose whole
+     * promise is that it does not touch the original.
+     */
+    @Test fun aDuplicateOfAReadOnlyRowCannotDeleteTheOriginal() {
+        val strapSession = row("whoop-ABC123", 60, sport = "Run").copy(source = "whoop")
+        val copy = WorkoutEditing.asManualCopy(strapSession)
+        assertEquals("my-whoop", copy.deviceId)          // re-seeded out of the strap namespace
+        assertEquals(strapSession.startTs, copy.startTs) // ...while still pre-filling from the original
+        // Whatever the user then edits, the key the save could delete stays inside "my-whoop".
+        val edited = row("my-whoop", 75, sport = "Ride")
+        assertTrue(WhoopRepository.supersedesStoredRow(copy, edited))
+        assertEquals("my-whoop", copy.deviceId)
+        // The strap's own row is a different key entirely, so no delete this save issues can name it.
+        assertTrue(copy.deviceId != strapSession.deviceId)
+    }
+}


### PR DESCRIPTION
Editing a workout looked like it saved and changed nothing, across restarts (#1488).

## Cause

`workout`'s primary key is `(deviceId, startTs, sport)`, and the edit sheet builds every manual row on the
`"my-whoop"` seed. On a strap whose **active** id is something else — re-paired, or identified by serial —
the original row sits under that active id, so the edit didn't overwrite it: it inserted a second row
beside it.

`saveManualWorkout` then only deleted the original when `startTs` or `sport` had moved — which on a plain
"change the duration" edit they hadn't. It compared two thirds of the primary key and skipped the delete,
while the upsert wrote to a different key anyway. Both rows survived, and `workoutsUnion` reads
`[activeDeviceId, "my-whoop"]` keeping the **first** row per `(startTs, sport)` — so the stale one shadowed
the edit permanently. That's why a restart didn't help: both rows were on disk.

## Fix

`supersedesStoredRow` compares the whole primary key, so a row sitting under an active strap id counts as
moved even when `startTs` and `sport` are untouched. It lives beside `dedupWorkoutsByKey` so the predicate
is unit-testable rather than buried in a suspend function.

Landing on `"my-whoop"` is also the durable choice: it's in the read union unconditionally, while a strap's
active id is only there while that strap is active.

A safety pass on that widened delete found it could reach a **read-only** session. "Duplicate as manual"
pre-fills the sheet from a strap / Apple / lifting row and passes the pre-fill on as `replacing`; the copy
claimed `source: "manual"` while still carrying the original's `deviceId`, so the delete would have named
the strap's own namespace and retired the session it was copied from — on a menu item whose whole promise
is that it doesn't touch the original. The copy now re-seeds `deviceId` alongside `source`, so every delete
`saveManualWorkout` can issue is confined to `"my-whoop"` — the store's delete is keyed by `deviceId`.
Extracted as `WorkoutEditing.asManualCopy` so that's testable.

That covers the store and nothing else. `replacing` also reaches the Health Connect write-back, which
deletes by `startTs` alone (`noop-workout-<startTs>`, no `deviceId` in the key), where no namespace
re-seeding can help. Stopping the copy travelling as `replacing` at all is the fix that covers both
consumers, and it ships with the Apple twin in #1500.

## Android only

The Apple half was removed after an enumeration of every site that reads, writes or deletes a workout by
`deviceId`. The two platforms disagree about what "the strap source" is: Android's `importedDeviceId` is
`"my-whoop"` — the engine reads there and manual rows have always been written there — while Apple's
`IntelligenceEngine` is injected the **active** strap id. Moving Apple's writes to canonical while its
reads stayed on the active id would have made the #107 cross-source dedup guard and `rescoreManualWorkouts`
silently miss every manual row. Android needs none of that; its rows carry their own `deviceId` and nothing
reconstructs it.

Apple's own defects — an edit stored under an active id stops being read once that id changes, and
`deleteWorkout` can't find a manual row under any other id — are pre-existing, filed as #1501, and are a
design decision rather than a bug fix.

## Verification

`./gradlew compileFullDebugKotlin testFullDebugUnitTest` — 6 tests, 0 failures: the regression case, the
in-place edit that must **not** delete, the sport re-key that always worked, the union dedupe that made the
bug silent, the detected routing, and that a duplicate of a read-only row cannot name the original's key.

Not yet exercised on hardware: edit a workout on a re-paired strap and confirm the change sticks.
