### PR TITLE
Fix lifting note title delimiter parity

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/LiftingImporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/LiftingImporter.swift
@@ -429,7 +429,7 @@ public extension LiftingSession {
         parts.append("\(setCount) set\(setCount == 1 ? "" : "s")")
         if exerciseCount > 0 { parts.append("\(exerciseCount) exercise\(exerciseCount == 1 ? "" : "s")") }
         var note = "Strength · " + parts.joined(separator: " · ")
-        if includeTitle, let title, !title.isEmpty { note = "\(title) - " + note }
+        if includeTitle, let title, !title.isEmpty { note = "\(title): " + note }
         return note
     }
 }

--- a/Packages/StrandImport/Tests/StrandImportTests/LiftingImporterTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/LiftingImporterTests.swift
@@ -182,15 +182,16 @@ final class LiftingImporterTests: XCTestCase {
         XCTAssertEqual(LiftingImporter.detectFormat(data: Data("title,start_time\n".utf8)), .hevyCsv)
     }
 
-    func testVolumeLoadNoteIsHonestlyLabelled() {
-        let s = LiftingSession(start: Date(timeIntervalSince1970: 0), end: Date(timeIntervalSince1970: 0),
-                               volumeLoadKg: 12400, setCount: 18, exerciseCount: 5, totalReps: 120,
-                               topSetKg: 140, title: "Leg Day")
-        let note = s.volumeLoadNote()
-        XCTAssertTrue(note.contains("volume load 12,400 kg"), note)
-        XCTAssertTrue(note.contains("Strength"), note)
-        XCTAssertTrue(note.contains("18 sets"), note)
-        XCTAssertTrue(note.contains("5 exercises"), note)
-        XCTAssertTrue(note.contains("Leg Day"), note)
+    func testVolumeLoadNoteMatchesKotlinForTitledAndUntitledSessions() {
+        func session(title: String?) -> LiftingSession {
+            LiftingSession(start: Date(timeIntervalSince1970: 0), end: Date(timeIntervalSince1970: 0),
+                           volumeLoadKg: 12400, setCount: 18, exerciseCount: 5, totalReps: 120,
+                           topSetKg: 140, title: title)
+        }
+
+        let body = "Strength · volume load 12,400 kg · 18 sets · 5 exercises"
+        XCTAssertEqual(session(title: nil).volumeLoadNote(), body)
+        XCTAssertEqual(session(title: "").volumeLoadNote(), body)
+        XCTAssertEqual(session(title: "Leg Day").volumeLoadNote(), "Leg Day: \(body)")
     }
 }

--- a/android/app/src/test/java/com/noop/ingest/LiftingImporterTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/LiftingImporterTest.kt
@@ -203,16 +203,15 @@ class LiftingImporterTest {
     }
 
     @Test
-    fun volumeLoadNoteIsHonestlyLabelled() {
-        val s = LiftingImporter.Session(
+    fun volumeLoadNoteMatchesSwiftForTitledAndUntitledSessions() {
+        fun session(title: String?) = LiftingImporter.Session(
             startTs = 0, endTs = 0, volumeLoadKg = 12400.0, setCount = 18,
-            exerciseCount = 5, totalReps = 120, topSetKg = 140.0, title = "Leg Day",
+            exerciseCount = 5, totalReps = 120, topSetKg = 140.0, title = title,
         )
-        val note = s.volumeLoadNote()
-        assertTrue(note, note.contains("volume load 12,400 kg"))
-        assertTrue(note, note.contains("Strength"))
-        assertTrue(note, note.contains("18 sets"))
-        assertTrue(note, note.contains("5 exercises"))
-        assertTrue(note, note.contains("Leg Day"))
+
+        val body = "Strength · volume load 12,400 kg · 18 sets · 5 exercises"
+        assertEquals(body, session(null).volumeLoadNote())
+        assertEquals(body, session("").volumeLoadNote())
+        assertEquals("Leg Day: $body", session("Leg Day").volumeLoadNote())
     }
 }


### PR DESCRIPTION
## Summary

Fixes the cross-platform lifting-note title delimiter mismatch documented in [bhelm/noop#93](https://github.com/bhelm/noop/issues/93).

Swift formatted a titled volume-load note with ` - ` while Android used `: `. This changes only the Swift title prefix to `: ` and keeps parsing, calculations, persistence, and untitled-note behavior unchanged.

## Tests

- Adds mirrored exact Swift/Kotlin assertions for titled, nil/null-title, and empty-title notes.
- Fresh independent static review of the exact frozen union delta passed with no P0/P1 findings; this PR's frozen three-file patch is an exact reviewed constituent (patch SHA-256 `5b5d1f86ca41f23b5aa5ca5a39587dad429a468daf84d5ccc24e6e86a7ac98c6`).
- Combined Native validation on the reviewed union (`c7571fd020d6947594eb79198ba88ece7ab4648824c312e0bbee9e14f1150d97`) exercised this exact named test: Swift focused 1/1 passed; Swift affected 28 tests passed; Swift full 241 tests passed with 1 skip. Kotlin focused aggregate 7 tests passed; affected 35 passed; full 4,157 passed with 6 skips and no failures/errors.
- Evidence artifact: `/root/whoop/validation/product-fixes-93-99-union-native/43-final-audit.txt` (recorded 2026-08-20, exact union hash and named-test occurrence audit).
