### PR TITLE
Fix activity route distance rounding parity

### DIFF
--- a/Packages/StrandImport/Tests/StrandImportTests/ActivityFileImporterTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/ActivityFileImporterTests.swift
@@ -6,6 +6,28 @@ import XCTest
 /// contract (must not crash, must reject gracefully) and the security guards (XXE entity, bad coords).
 final class ActivityFileImporterTests: XCTestCase {
 
+    func testRouteDistanceOrderedThreePointsUsesCanonicalBitPattern() {
+        // Fork governance #99: exact twin parity matters even when the numerical delta is too small
+        // to survive UI formatting. Keep point order and assert the binary64 result, not a tolerance.
+        let route = [
+            RoutePoint(lat: 52.5, lon: 13.4),
+            RoutePoint(lat: 52.5001, lon: 13.4001),
+            RoutePoint(lat: 52.5002, lon: 13.4003),
+        ]
+
+        XCTAssertEqual(ActivityFileImporter.routeDistanceM(route).bitPattern, 0x403e89813f76c75c)
+    }
+
+    func testRouteDistanceOneSegmentKeepsAdjacentControlBitPattern() {
+        // Adjacent control: this first segment is already identical on both twins and must stay so.
+        let route = [
+            RoutePoint(lat: 52.5, lon: 13.4),
+            RoutePoint(lat: 52.5001, lon: 13.4001),
+        ]
+
+        XCTAssertEqual(ActivityFileImporter.routeDistanceM(route).bitPattern, 0x402a0921667f2bac)
+    }
+
     // MARK: - GPX
 
     func testGpxTrackWithHrExtension() {

--- a/android/app/src/main/java/com/noop/analytics/RouteMath.kt
+++ b/android/app/src/main/java/com/noop/analytics/RouteMath.kt
@@ -16,10 +16,11 @@ object RouteMath {
     private const val EARTH_R = 6_371_000.0 // metres
 
     fun haversineMeters(a: LatLng, b: LatLng): Double {
-        val dLat = Math.toRadians(b.lat - a.lat)
-        val dLon = Math.toRadians(b.lon - a.lon)
+        // Keep multiply-then-divide ordering identical to Swift's `x * .pi / 180`.
+        val dLat = (b.lat - a.lat) * Math.PI / 180.0
+        val dLon = (b.lon - a.lon) * Math.PI / 180.0
         val s = sin(dLat / 2) * sin(dLat / 2) +
-            cos(Math.toRadians(a.lat)) * cos(Math.toRadians(b.lat)) * sin(dLon / 2) * sin(dLon / 2)
+            cos(a.lat * Math.PI / 180.0) * cos(b.lat * Math.PI / 180.0) * sin(dLon / 2) * sin(dLon / 2)
         return EARTH_R * 2 * atan2(sqrt(s), sqrt(1 - s))
     }
 

--- a/android/app/src/test/java/com/noop/ingest/ActivityFileImporterTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/ActivityFileImporterTest.kt
@@ -16,6 +16,30 @@ import java.io.ByteArrayOutputStream
  */
 class ActivityFileImporterTest {
 
+    @Test
+    fun routeDistanceOrderedThreePointsUsesCanonicalBitPattern() {
+        // Fork governance #99: exact twin parity matters even when the numerical delta is too small
+        // to survive UI formatting. Keep point order and assert the binary64 result, not a tolerance.
+        val route = listOf(
+            ActivityFileImporter.RoutePoint(lat = 52.5, lon = 13.4),
+            ActivityFileImporter.RoutePoint(lat = 52.5001, lon = 13.4001),
+            ActivityFileImporter.RoutePoint(lat = 52.5002, lon = 13.4003),
+        )
+
+        assertEquals(0x403e89813f76c75cL, ActivityFileImporter.routeDistanceM(route).toRawBits())
+    }
+
+    @Test
+    fun routeDistanceOneSegmentKeepsAdjacentControlBitPattern() {
+        // Adjacent control: this first segment is already identical on both twins and must stay so.
+        val route = listOf(
+            ActivityFileImporter.RoutePoint(lat = 52.5, lon = 13.4),
+            ActivityFileImporter.RoutePoint(lat = 52.5001, lon = 13.4001),
+        )
+
+        assertEquals(0x402a0921667f2bacL, ActivityFileImporter.routeDistanceM(route).toRawBits())
+    }
+
     @Before
     fun installRealParser() {
         ActivityFileImporter.newPullParser = {


### PR DESCRIPTION
## Summary

- make Kotlin degree-to-radian conversion use the same multiply-then-divide operation order as Swift
- preserve the earth radius, haversine expression, point order, and route accumulation order
- add mirrored exact-bit tests for the reachable three-point route and an adjacent one-segment control

## Root cause

Swift computes radians as `x * pi / 180`, while Kotlin used `Math.toRadians`, whose different intermediate rounding changes the second segment and final three-point distance by one binary64 ULP. Kotlin now spells out Swift's operation order; Swift production is unchanged.

## Validation

- RED before fix: the three-point Kotlin result was `0x403e89813f76c75d`, while Swift and the independent oracle produced `0x403e89813f76c75c`
- frozen three-file diff is an exact semantic subset of the independently reviewed product-fix union
- Swift exact focused tests: 2 passed
- Swift affected StrandImport suite: 28 tests passed
- Swift full StrandImport suite: 241 tests passed, 0 failures, 1 environment-dependent skip
- Kotlin exact focused tests: 2 passed
- Kotlin affected importer suite: 35 tests passed across the union's affected classes
- Kotlin FullDebug: 4,157 tests passed, 0 failures/errors, 6 skipped
- `git diff --check`: pass
- independent static review: pass, no P0/P1/P2

Fixes bhelm/noop#99.
