### PR TITLE
Count rejected Liftosaur history records on Swift

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/LiftingImporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/LiftingImporter.swift
@@ -241,7 +241,8 @@ public enum LiftingImporter {
 
         var sessions: [LiftingSession] = []
         var skipped = 0
-        for case let record as [String: Any] in history {
+        for element in history {
+            guard let record = element as? [String: Any] else { skipped += 1; continue }
             if let s = liftosaurSession(record) { sessions.append(s) } else { skipped += 1 }
         }
         return finish(sessions, skipped: skipped)

--- a/Packages/StrandImport/Tests/StrandImportTests/LiftingImporterTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/LiftingImporterTests.swift
@@ -174,6 +174,36 @@ final class LiftingImporterTests: XCTestCase {
         XCTAssertEqual(LiftingImporter.parseLiftosaur(data: Data(wrapped.utf8)).sessionCount, 1)
     }
 
+    func testLiftosaurHeterogeneousHistoryCountsEveryRejectedRecord() {
+        let json = """
+        { "history": [
+          { "startTime": 1748772000000, "endTime": 1748775600000, "dayName": "Day 1",
+            "entries": [ { "sets": [ { "weight": 80, "completedReps": 5 } ] } ] },
+          7,
+          { "dayName": "Missing timestamp",
+            "entries": [ { "sets": [ { "weight": 60, "completedReps": 8 } ] } ] },
+          "not a record"
+        ] }
+        """
+
+        let r = LiftingImporter.parse(data: Data(json.utf8))
+
+        XCTAssertEqual(r.sessions.map(\.start), [Date(timeIntervalSince1970: 1748772000)])
+        XCTAssertEqual(r.sessionCount, 1)
+        let s = r.sessions[0]
+        XCTAssertEqual(s.end, Date(timeIntervalSince1970: 1748775600))
+        XCTAssertEqual(s.durationS, 3600)
+        XCTAssertEqual(s.volumeLoadKg, 400, accuracy: 1e-6)
+        XCTAssertEqual(s.setCount, 1)
+        XCTAssertEqual(s.exerciseCount, 1)
+        XCTAssertEqual(s.totalReps, 5)
+        XCTAssertEqual(s.topSetKg, 80)
+        XCTAssertEqual(s.title, "Day 1")
+        XCTAssertEqual(r.earliest, Date(timeIntervalSince1970: 1748772000))
+        XCTAssertEqual(r.latest, Date(timeIntervalSince1970: 1748772000))
+        XCTAssertEqual(r.skipped, 3)
+    }
+
     // MARK: - Auto-detection + note
 
     func testDetectFormatRoutesByLeadingByte() {

--- a/android/app/src/test/java/com/noop/ingest/LiftingImporterTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/LiftingImporterTest.kt
@@ -190,6 +190,38 @@ class LiftingImporterTest {
         assertEquals(1, LiftingImporter.parseLiftosaur(wrapped).sessions.size)
     }
 
+    @Test
+    fun liftosaurHeterogeneousHistoryCountsEveryRejectedRecord() {
+        val json =
+            """
+            { "history": [
+              { "startTime": 1748772000000, "endTime": 1748775600000, "dayName": "Day 1",
+                "entries": [ { "sets": [ { "weight": 80, "completedReps": 5 } ] } ] },
+              7,
+              { "dayName": "Missing timestamp",
+                "entries": [ { "sets": [ { "weight": 60, "completedReps": 8 } ] } ] },
+              "not a record"
+            ] }
+            """.trimIndent()
+
+        val r = LiftingImporter.parse(json.toByteArray())
+
+        assertEquals(listOf(1748772000L), r.sessions.map { it.startTs })
+        assertEquals(1, r.sessions.size)
+        val s = r.sessions[0]
+        assertEquals(1748775600L, s.endTs)
+        assertEquals(3600.0, s.durationS!!, 1e-9)
+        assertEquals(400.0, s.volumeLoadKg, 1e-6)
+        assertEquals(1, s.setCount)
+        assertEquals(1, s.exerciseCount)
+        assertEquals(5, s.totalReps)
+        assertEquals(80.0, s.topSetKg!!, 1e-9)
+        assertEquals("Day 1", s.title)
+        assertEquals("2025-06-01", r.firstDay)
+        assertEquals("2025-06-01", r.lastDay)
+        assertEquals(3, r.skipped)
+    }
+
     // MARK: - Auto-detection + note
 
     @Test


### PR DESCRIPTION
## Summary

Fixes the skipped-record undercount documented in [bhelm/noop#94](https://github.com/bhelm/noop/issues/94).

Swift's `for case` loop silently omitted non-object history elements, so they never reached the skipped counter. The loop now visits every element, increments once when an element is not a dictionary, and leaves the existing malformed-object and valid-session paths unchanged. Android already has the intended behavior and remains the unchanged product control.

## Tests

- Adds mirrored exact Swift/Kotlin coverage for a heterogeneous four-element history, including the valid session fields/order and exact `skipped == 3` result.
- Fresh independent static review of the exact frozen union delta passed with no P0/P1 findings; this PR's frozen three-file patch is an exact reviewed constituent (patch SHA-256 `e65b967dc296d09d5ea40776d7b21495b5b75c850917048e3f67091001187f1f`).
- Combined Native validation on the reviewed union (`c7571fd020d6947594eb79198ba88ece7ab4648824c312e0bbee9e14f1150d97`) exercised this exact named test: Swift focused 1/1 passed; Swift affected 28 tests passed; Swift full 241 tests passed with 1 skip. Kotlin focused aggregate 7 tests passed; affected 35 passed; full 4,157 passed with 6 skips and no failures/errors.
- Evidence artifact: `/root/whoop/validation/product-fixes-93-99-union-native/43-final-audit.txt` (recorded 2026-08-20, exact union hash and named-test occurrence audit).
