### PR TITLE
Fix trailing-dot activity format detection

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/ActivityFileImporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/ActivityFileImporter.swift
@@ -195,7 +195,11 @@ public enum ActivityFileImporter {
     /// Detect the format from the filename extension first, then content magic bytes. FIT has a
     /// definitive ".FIT" signature at offset 8; GPX/TCX are sniffed from their root XML element.
     public static func detectFormat(filename: String?, data: Data) -> Format {
-        if let ext = filename?.split(separator: ".").last?.lowercased() {
+        // Match Kotlin substringAfterLast('.', "") exactly: only text after a literal final dot is
+        // an extension. A missing or trailing dot therefore has no usable extension and falls through
+        // to content detection instead of reusing an earlier non-empty token.
+        if let filename, let dot = filename.lastIndex(of: ".") {
+            let ext = filename[filename.index(after: dot)...].lowercased()
             switch ext {
             case "gpx": return .gpx
             case "tcx": return .tcx

--- a/Packages/StrandImport/Tests/StrandImportTests/ActivityFileImporterTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/ActivityFileImporterTests.swift
@@ -273,6 +273,44 @@ final class ActivityFileImporterTests: XCTestCase {
         XCTAssertEqual(ActivityFileImporter.workoutSport(from: "kayaking"), "Kayaking")   // title-cased
     }
 
+    func testDetectFormatTreatsTrailingDotAsEmptyExtensionWithKotlinParity() {
+        let empty = Data()
+        let unknownXML = Data("<unknown/>".utf8)
+        let fitMagic = Data([0, 0, 0, 0, 0, 0, 0, 0, 46, 70, 73, 84])
+        let gpx = Data("<gpx></gpx>".utf8)
+        let tcx = Data("<TrainingCenterDatabase></TrainingCenterDatabase>".utf8)
+
+        XCTAssertEqual(
+            ActivityFileImporter.detectFormat(filename: "ride.fit.", data: empty), .unknown
+        )
+        XCTAssertEqual(
+            ActivityFileImporter.detectFormat(filename: "ride.fit..", data: empty), .unknown
+        )
+        XCTAssertEqual(
+            ActivityFileImporter.detectFormat(filename: "route.gpx.", data: unknownXML), .unknown
+        )
+        XCTAssertEqual(ActivityFileImporter.detectFormat(filename: "fit", data: empty), .unknown)
+
+        XCTAssertEqual(ActivityFileImporter.detectFormat(filename: "ride.fit", data: empty), .fit)
+        XCTAssertEqual(ActivityFileImporter.detectFormat(filename: "route.gpx", data: empty), .gpx)
+        XCTAssertEqual(ActivityFileImporter.detectFormat(filename: "route.GPX", data: empty), .gpx)
+        XCTAssertEqual(
+            ActivityFileImporter.detectFormat(filename: "ride.fit.", data: fitMagic), .fit
+        )
+        XCTAssertEqual(
+            ActivityFileImporter.detectFormat(filename: "ride.bin", data: fitMagic), .fit
+        )
+        XCTAssertEqual(
+            ActivityFileImporter.detectFormat(filename: "route.gpx.", data: gpx), .gpx
+        )
+        XCTAssertEqual(
+            ActivityFileImporter.detectFormat(filename: "route.bin", data: gpx), .gpx
+        )
+        XCTAssertEqual(
+            ActivityFileImporter.detectFormat(filename: "workout.tcx.", data: tcx), .tcx
+        )
+    }
+
     func testSummaryTextIncludesOnlyPositiveStepsWithKotlinParity() {
         func activity(steps: Int?) -> ActivityFile {
             ActivityFile(

--- a/android/app/src/test/java/com/noop/ingest/ActivityFileImporterTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/ActivityFileImporterTest.kt
@@ -279,6 +279,38 @@ class ActivityFileImporterTest {
     }
 
     @Test
+    fun detectFormatTreatsTrailingDotAsEmptyExtensionWithSwiftParity() {
+        val empty = byteArrayOf()
+        val unknownXml = "<unknown/>".toByteArray(Charsets.UTF_8)
+        val fitMagic = byteArrayOf(0, 0, 0, 0, 0, 0, 0, 0, 46, 70, 73, 84)
+        val gpx = "<gpx></gpx>".toByteArray(Charsets.UTF_8)
+        val tcx = "<TrainingCenterDatabase></TrainingCenterDatabase>".toByteArray(Charsets.UTF_8)
+
+        assertEquals(
+            ActivityFileImporter.Format.UNKNOWN,
+            ActivityFileImporter.detectFormat("ride.fit.", empty),
+        )
+        assertEquals(
+            ActivityFileImporter.Format.UNKNOWN,
+            ActivityFileImporter.detectFormat("ride.fit..", empty),
+        )
+        assertEquals(
+            ActivityFileImporter.Format.UNKNOWN,
+            ActivityFileImporter.detectFormat("route.gpx.", unknownXml),
+        )
+        assertEquals(ActivityFileImporter.Format.UNKNOWN, ActivityFileImporter.detectFormat("fit", empty))
+
+        assertEquals(ActivityFileImporter.Format.FIT, ActivityFileImporter.detectFormat("ride.fit", empty))
+        assertEquals(ActivityFileImporter.Format.GPX, ActivityFileImporter.detectFormat("route.gpx", empty))
+        assertEquals(ActivityFileImporter.Format.GPX, ActivityFileImporter.detectFormat("route.GPX", empty))
+        assertEquals(ActivityFileImporter.Format.FIT, ActivityFileImporter.detectFormat("ride.fit.", fitMagic))
+        assertEquals(ActivityFileImporter.Format.FIT, ActivityFileImporter.detectFormat("ride.bin", fitMagic))
+        assertEquals(ActivityFileImporter.Format.GPX, ActivityFileImporter.detectFormat("route.gpx.", gpx))
+        assertEquals(ActivityFileImporter.Format.GPX, ActivityFileImporter.detectFormat("route.bin", gpx))
+        assertEquals(ActivityFileImporter.Format.TCX, ActivityFileImporter.detectFormat("workout.tcx.", tcx))
+    }
+
+    @Test
     fun summaryTextIncludesOnlyPositiveStepsWithSwiftParity() {
         fun activity(steps: Int?) = ActivityFileImporter.Activity(
             kind = ActivityFileImporter.Kind.FIT,


### PR DESCRIPTION
## Summary

- make Swift treat only the substring after the literal final dot as a filename extension, matching Kotlin
- fall back to content sniffing when a filename has no usable suffix, including trailing and repeated dots
- add mirrored public tests for all issue cases plus case-insensitive, no-dot, FIT/GPX/TCX content controls

## Root cause

Swift used `split(separator: ".")`, which omits empty subsequences, so `ride.fit.` incorrectly reused `fit` as the extension. Kotlin uses the literal substring after the final dot, which is empty and correctly falls back to content detection. The Swift detector now follows that same last-suffix contract; Kotlin production is unchanged.

## Validation

- RED before fix: mirrored acceptance tests were present while the unchanged Swift detector still omitted empty suffixes
- the first review's missing-control finding was reproduced with exactly 3 omissions per platform, then fixed without another product change
- frozen three-file diff is an exact semantic subset of the independently reviewed product-fix union
- Swift exact focused trailing-dot test: passed
- Swift affected StrandImport suite: 28 tests passed
- Swift full StrandImport suite: 241 tests passed, 0 failures, 1 environment-dependent skip
- Kotlin focused/affected mirrored test: passed
- Kotlin FullDebug: 4,157 tests passed, 0 failures/errors, 6 skipped
- exact static acceptance guards and `git diff --check`: pass
- independent final review: pass, no P0/P1/P2

Fixes bhelm/noop#97.
