### PR TITLE
Fix activity import distance half-tie rounding

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/ActivityFileImporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/ActivityFileImporter.swift
@@ -27,6 +27,16 @@ import Foundation
 
 // MARK: - Normalized model
 
+/// Shared display formatter for imported-activity distance. Distances are nonnegative, so explicit
+/// ties-away-from-zero is the same half-up policy as Kotlin's `roundToInt()` (10.5 km → 11 km).
+/// Keep the sub-10 km two-decimal path unchanged; this formats text only and never mutates `distanceM`.
+private func activityDistanceText(_ distanceM: Double) -> String {
+    let km = distanceM / 1000.0
+    return km >= 10
+        ? String(format: "%.0f km", km.rounded(.toNearestOrAwayFromZero))
+        : String(format: "%.2f km", km)
+}
+
 /// One imported activity (the shape the app layer maps onto a `WorkoutRow`, plus optional
 /// activity-file daily metrics when present). Distances are metres, HR is bpm, energy is kcal.
 /// Times are UTC `Date`s. A field is `nil` when the file didn't carry it — never fabricated.
@@ -116,8 +126,7 @@ public struct ActivityFile: Sendable, Equatable {
     public func importNote() -> String {
         var parts: [String] = ["Imported \(kind.rawValue.uppercased())"]
         if let d = distanceM, d > 0 {
-            let km = d / 1000.0
-            parts.append(String(format: km >= 10 ? "%.0f km" : "%.2f km", km))
+            parts.append(activityDistanceText(d))
         }
         if gpsPointCount > 0 { parts.append("\(gpsPointCount) GPS points") }
         if hrSampleCount > 0 { parts.append("\(hrSampleCount) HR samples") }
@@ -440,8 +449,7 @@ public enum ActivityFileImporter {
     public static func summaryText(_ a: ActivityFile) -> String {
         var head = "Imported"
         if let d = a.distanceM, d > 0 {
-            let km = d / 1000.0
-            head += String(format: km >= 10 ? " a %.0f km" : " a %.2f km", km)
+            head += " a \(activityDistanceText(d))"
         } else {
             head += " an"
         }

--- a/Packages/StrandImport/Tests/StrandImportTests/ActivityFileImporterTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/ActivityFileImporterTests.swift
@@ -293,6 +293,32 @@ final class ActivityFileImporterTests: XCTestCase {
             base + " · 2350 steps"
         )
     }
+
+    func testDistanceTextUsesExplicitHalfUpRoundingWithKotlinParity() {
+        func activity(_ distanceM: Double) -> ActivityFile {
+            ActivityFile(
+                kind: .gpx,
+                start: Date(timeIntervalSince1970: 1_000),
+                end: Date(timeIntervalSince1970: 1_060),
+                sport: "running",
+                distanceM: distanceM
+            )
+        }
+
+        let cases: [(metres: Double, distance: String)] = [
+            (9_500, "9.50 km"),
+            (10_500, "11 km"),
+            (11_500, "12 km"),
+        ]
+        for item in cases {
+            let value = activity(item.metres)
+            XCTAssertEqual(value.importNote(), "Imported GPX · \(item.distance)")
+            XCTAssertEqual(
+                ActivityFileImporter.summaryText(value),
+                "Imported a \(item.distance) Running activity"
+            )
+        }
+    }
 }
 
 // MARK: - FIT byte fixture builder (little-endian, test-only)

--- a/android/app/src/test/java/com/noop/ingest/ActivityFileImporterTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/ActivityFileImporterTest.kt
@@ -304,6 +304,39 @@ class ActivityFileImporterTest {
             ActivityFileImporter.summaryText(activity(2_350)),
         )
     }
+
+    @Test
+    fun distanceTextUsesExplicitHalfUpRoundingWithSwiftParity() {
+        fun activity(distanceM: Double) = ActivityFileImporter.Activity(
+            kind = ActivityFileImporter.Kind.GPX,
+            startTs = 1_000,
+            endTs = 1_060,
+            sport = "running",
+            distanceM = distanceM,
+            energyKcal = null,
+            steps = null,
+            avgHr = null,
+            maxHr = null,
+            ascentM = null,
+            gpsPointCount = 0,
+            hrSampleCount = 0,
+            route = emptyList(),
+        )
+
+        val cases = listOf(
+            9_500.0 to "9.50 km",
+            10_500.0 to "11 km",
+            11_500.0 to "12 km",
+        )
+        for ((metres, distance) in cases) {
+            val value = activity(metres)
+            assertEquals("Imported GPX · $distance", value.importNote())
+            assertEquals(
+                "Imported a $distance Running activity",
+                ActivityFileImporter.summaryText(value),
+            )
+        }
+    }
 }
 
 // MARK: - FIT byte fixture builder (little-endian, test-only). Mirrors the Swift FitFixture.


### PR DESCRIPTION
## Summary

- give Swift activity-import distance text an explicit nearest-with-ties-away-from-zero policy above 10 km, matching Kotlin for nonnegative distances
- share the formatter between the persisted import note and visible summary without changing stored `distanceM`
- add mirrored 9.5, 10.5, and 11.5 km tests for both public text paths

## Root cause

Swift's `String(format: "%.0f")` uses ties-to-even, while Kotlin's `roundToInt()` rounds these nonnegative half ties upward. At the exactly representable 10.5 km boundary, Swift printed 10 km and Kotlin printed 11 km. Swift now rounds explicitly before formatting; Kotlin production is unchanged.

## Validation

- RED before fix: unchanged Swift source contradicted the mirrored 10.5 km → 11 km contract on both public text paths
- frozen three-file diff is an exact semantic subset of the independently reviewed product-fix union
- Swift exact focused distance-text test: passed
- Swift affected StrandImport suite: 28 tests passed
- Swift full StrandImport suite: 241 tests passed, 0 failures, 1 environment-dependent skip
- Kotlin focused/affected mirrored test: passed
- Kotlin FullDebug: 4,157 tests passed, 0 failures/errors, 6 skipped
- `git diff --check`: pass
- independent final review: pass, no P0/P1/P2

Fixes bhelm/noop#96.
