### PR TITLE
Carry the waist into the post-offload pass, so VO₂max stops flipping estimator (#1493)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -65,7 +65,6 @@ import com.noop.analytics.NapPrefs
 import com.noop.analytics.NapVerdict
 import com.noop.analytics.SedentaryDetector
 import com.noop.analytics.StressOnsetDetector
-import com.noop.analytics.UserProfile
 import com.noop.analytics.WorkoutDetector
 import com.noop.data.NapStore
 import com.noop.ingest.HealthConnectWriter
@@ -2339,13 +2338,10 @@ class WhoopBleClient(
             try {
                 delay(POST_BACKFILL_ANALYZE_DELAY_MS) // let trailing chunks of the same session land
                 val profileStore = ProfileStore.from(context)
-                val profile = UserProfile(
-                    weightKg = profileStore.weightKg,
-                    heightCm = profileStore.heightCm,
-                    age = profileStore.age.toDouble(),
-                    sex = profileStore.sex,
-                    stepTicksPerStep = profileStore.stepTicksPerStep,
-                )
+                // #1493: was built longhand here and silently omitted waistCm, so this pass scored VO₂max
+                // with the Uth fallback while the 15-minute pass used the waist-based Nes estimate — the
+                // card flipped between two estimators depending on which ran last.
+                val profile = profileStore.toUserProfile()
                 // #836: the post-backfill pass is a real update path, so it ALWAYS re-scores (mirroring the
                 // Swift `analyzeRecent(force: true)` call `refreshAfterCompletedBackfill` makes) — but it must
                 // ADVANCE the shared HR-fingerprint watermark on success, which it previously did NOT. That

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1235,14 +1235,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     /** Snapshot the user's body profile from SharedPreferences as an analytics [UserProfile]. */
-    private fun currentProfile(): UserProfile = UserProfile(
-        weightKg = profileStore.weightKg,
-        heightCm = profileStore.heightCm,
-        age = profileStore.age.toDouble(),
-        sex = profileStore.sex,
-        stepTicksPerStep = profileStore.stepTicksPerStep,
-        waistCm = profileStore.waistCm,
-    )
+    private fun currentProfile(): UserProfile = profileStore.toUserProfile()
 
     // MARK: - HR smoothing (median filter)
 

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -121,6 +121,7 @@ import com.noop.BuildConfig
 import com.noop.analytics.Baselines
 import com.noop.analytics.HrZoneSet
 import com.noop.analytics.HrZones
+import com.noop.analytics.UserProfile
 import com.noop.analytics.Zones
 import com.noop.R
 import com.noop.ble.PuffinExperiment
@@ -244,6 +245,26 @@ class ProfileStore(private val prefs: SharedPreferences) {
         set(v) = prefs.edit()
             .putFloat(KEY_STEP_SCALE, v.coerceIn(STEP_SCALE_MIN, STEP_SCALE_MAX).toFloat())
             .apply()
+
+    /**
+     * The analytics [UserProfile] for this store — the ONE place the mapping lives.
+     *
+     * Every field matters somewhere and a missing one fails silently rather than loudly. Dropping
+     * [waistCm] does not blank VO₂max, it swaps the estimator: `FitnessAgeEngine.compute` returns a
+     * waist-based Nes value only when a waist is supplied, and `fitnessAgeRows` otherwise falls back to
+     * the Uth HR-ratio formula and writes THAT under the same "vo2max_est" key. Two passes built two
+     * profiles, one of them lost the waist, and the card alternated between the two estimators with no
+     * visible cause — a fit user with a low resting HR saw it swing by ~14 (#1493). Build the profile
+     * here so a caller cannot omit a field by writing one out longhand.
+     */
+    fun toUserProfile(): UserProfile = UserProfile(
+        weightKg = weightKg,
+        heightCm = heightCm,
+        age = age.toDouble(),
+        sex = sex,
+        stepTicksPerStep = stepTicksPerStep,
+        waistCm = waistCm,
+    )
 
     // ── Steps ESTIMATE calibration (WHOOP 4.0; StepsEstimateEngine) ─────────────────────────────
     // Mirror of the macOS ProfileStore fields: the engine writes the auto-fit each analytics pass and

--- a/android/app/src/test/java/com/noop/analytics/Vo2MaxWaistProfileTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/Vo2MaxWaistProfileTest.kt
@@ -1,0 +1,86 @@
+package com.noop.analytics
+
+import com.noop.data.DailyMetric
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+
+/**
+ * #1493: VO₂max jumped between two values with nothing to explain it — "always around 50, all of a sudden
+ * it is 64", then 51 again the same day.
+ *
+ * A missing waist does not blank VO₂max, it silently swaps the estimator. `FitnessAgeEngine.compute`
+ * returns the waist-based Nes value only when a waist is supplied, and `fitnessAgeRows` otherwise falls
+ * back to the Uth HR-ratio formula — writing THAT under the same "vo2max_est" key, with the card labelling
+ * both simply "Estimated".
+ *
+ * Two passes built their own `UserProfile` longhand and one of them omitted `waistCm`, so the post-offload
+ * pass scored with Uth while the 15-minute pass scored with Nes, and the card showed whichever ran last.
+ * Both now build through `ProfileStore.toUserProfile()`.
+ *
+ * These tests pin the mechanism rather than the plumbing, because it is what makes the bug invisible: the
+ * two estimators disagree by a wide margin for exactly the population that sets a waist in the first place.
+ */
+class Vo2MaxWaistProfileTest {
+
+    private val computedId = "my-whoop-noop"
+    private val satKey = "2026-08-15"
+
+    /** Seven nights of wear, comfortably past the 4-day coverage floor, with a fit user's resting HR. */
+    private fun week(restingHr: Int = 43) = (1..7).map { i ->
+        DailyMetric(
+            deviceId = computedId, day = "2026-08-0$i",
+            restingHr = restingHr, strain = 120.0,
+        )
+    }
+
+    private fun profile(waistCm: Double) = UserProfile(
+        weightKg = 78.0, heightCm = 182.0, age = 40.0, sex = "male", waistCm = waistCm,
+    )
+
+    private fun vo2(rows: List<com.noop.data.MetricSeriesRow>): Double? =
+        rows.firstOrNull { it.key == "vo2max_est" }?.value
+
+    /**
+     * The regression, stated as the thing the user actually saw: the same nights, the same person, and the
+     * only difference is whether the pass knew the waist — yet the number moves by more than a real year of
+     * training would. That is two estimators, not one changing its mind.
+     */
+    @Test fun losingTheWaistSilentlyChangesTheEstimatorAndTheNumber() {
+        val withWaist = vo2(IntelligenceEngine.fitnessAgeRows(week(), profile(92.0), computedId, satKey))
+        val without = vo2(IntelligenceEngine.fitnessAgeRows(week(), profile(0.0), computedId, satKey))
+        assertNotNull("a waist-based pass must still produce a value", withWaist)
+        assertNotNull("a waist-free pass must still produce a value (that is #1391)", without)
+        assertTrue(
+            "the two estimators should disagree enough to be visible as a jump: $withWaist vs $without",
+            abs(without!! - withWaist!!) > 5.0,
+        )
+    }
+
+    /**
+     * ...and names which estimator the waist-free pass used, so a future change to either formula fails
+     * here loudly instead of quietly moving one branch of a value the card presents as a single number.
+     */
+    @Test fun theWaistFreeValueIsTheUthHrRatio() {
+        val without = vo2(IntelligenceEngine.fitnessAgeRows(week(), profile(0.0), computedId, satKey))
+        val hrmax = StrainScorer.estimateHRmax(emptyList(), 40.0).first
+        assertEquals(Calories.vo2maxFor(hrmax, 43.0)!!, without!!, 0.001)
+    }
+
+    /**
+     * The fix's actual contract: a profile that carries the waist takes the Nes branch. Pinned by value so
+     * "carries the waist" cannot degrade into "happens to produce something".
+     */
+    @Test fun aProfileCarryingTheWaistTakesTheNesBranch() {
+        val withWaist = vo2(IntelligenceEngine.fitnessAgeRows(week(), profile(92.0), computedId, satKey))
+        val nes = FitnessAgeEngine.compute(
+            age = 40.0, sex = "male", restingHR = 43.0,
+            paIndex = FitnessAgeEngine.physicalActivityIndexFromStrain(7, 120.0),
+            waistCm = 92.0,
+        )?.vo2max
+        assertNotNull(nes)
+        assertEquals(nes!!, withWaist!!, 0.001)
+    }
+}


### PR DESCRIPTION
Fixes #1493 — VO₂max alternating between two values with nothing to explain it.

## Cause

A missing waist doesn't blank VO₂max, it silently **swaps the estimator**. `FitnessAgeEngine.compute`
returns the waist-based Nes value only when a waist is supplied; otherwise `fitnessAgeRows` falls back to
Uth (`15.3 × HRmax / RHR`) and writes *that* under the same `"vo2max_est"` key. The card labels both
"Estimated".

Two passes each built their own `UserProfile` longhand:

| Pass | Trigger | `waistCm` | Estimator |
|---|---|---|---|
| `AppViewModel.currentProfile()` | 15-minute tick | carried | Nes (waist-based) |
| `WhoopBleClient` post-offload | every completed sync | **omitted** | Uth (HR-ratio) |

So the number depended on which pass ran last — sync the strap and the card showed Uth, wait for the timer
and it showed Nes. The reporter is on live Bluetooth, which is exactly what fires the post-offload pass.

Only users who **have** set a waist are affected: without one, both passes produce Uth and nothing moves.
So it specifically hit the people who did the extra setup step.

The gap is wide and upward for that population. Uth is inversely proportional to resting HR against an
age-predicted (Tanaka) HRmax, so it over-reads for the fit — at age 40 with a resting HR of 43 it returns
**64.0**, the number in the report:

| RHR | Uth (age 40) |
|---|---|
| 43 | 64.0 |
| 50 | 55.1 |
| 57 | 48.3 |

## Fix

Rather than adding the missing field, both call sites now build through one `ProfileStore.toUserProfile()`.
The two longhand constructions sat ~1,000 lines apart in different layers, which is how they drifted in the
first place; a single builder means a caller can't omit a field by writing one out by hand.

## Android only

Swift's VO₂max path reads `ProfileStore` directly (`IntelligenceEngine.swift:378`, `:1789`) rather than a
snapshot, so it can't lose the field. Swift does build two `UserProfile` snapshots that omit the waist, but
they feed the Keytel calorie model, which doesn't use it.

## Verification

`compileFullDebugKotlin` + 3 unit tests, pinning the mechanism rather than the plumbing:

- losing the waist moves the number by more than a year of real training would;
- the waist-free branch **is** the Uth formula (asserted by value against `Calories.vo2maxFor`);
- a profile carrying the waist takes the Nes branch (asserted by value against `FitnessAgeEngine.compute`).

Both branches are pinned by value, so neither can drift quietly behind a single "Estimated" label.

## Not fixed here

`vo2max_est` still stores two estimators' outputs with no record of which produced a given point, so a
method change remains indistinguishable from a real fitness change — including across the history already
written, where the stored series may interleave both. Worth its own issue; this PR stops the estimator
flipping, it doesn't make the stored value self-describing.

Reported by @bartmuskala.
