### PR TITLE
Edit a bridged night across all its fragments, not just the winning one (#1492)

### DIFF
--- a/android/app/src/main/java/com/noop/analytics/SleepGroupEdit.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepGroupEdit.kt
@@ -1,0 +1,91 @@
+package com.noop.analytics
+
+import com.noop.data.SleepSession
+
+/**
+ * Applying a hand-corrected bed/wake window to a BRIDGED night — every fragment of it, not just one.
+ *
+ * A night the strap split into fragments is displayed as one bridged group: the header's bedtime is the
+ * first fragment's onset and its wake is the group's latest end. The editor, though, was anchored to the
+ * single WINNING fragment, which on a split night is often neither of those. Correcting a night that was
+ * "detected too long" therefore wrote a shorter window onto an interior fragment while the fragments
+ * defining both displayed ends stayed exactly where they were — the save succeeded and nothing the user
+ * was looking at moved. (#1492)
+ *
+ * The planner is pure so the semantics are testable without a database: given the group's fragments and
+ * the window the user drew, decide what each fragment becomes.
+ */
+object SleepGroupEdit {
+
+    /**
+     * What each fragment becomes under the new window. [clipped] survives with its window re-cut (the
+     * outer two to the drawn bounds, the rest narrowed); [dropped] falls entirely outside and must go — a
+     * fragment left in place beyond the new bounds would go on defining the night's displayed start or
+     * end, which is the bug being fixed.
+     */
+    data class Plan(
+        val clipped: List<SleepSession>,
+        val dropped: List<SleepSession>,
+    )
+
+    /**
+     * Narrow [group] to [newStartTs]..[newEndTs].
+     *
+     * The OUTER surviving fragments take the drawn bounds outright; interior ones are narrowed to the
+     * window. Taking them outright is what lets an edit LENGTHEN a night the strap cut short, not only
+     * shorten one it ran long, and it makes the header — which reads the first onset and the latest end —
+     * show exactly what was drawn. Each is marked `userEdited`, with the corrected onset in
+     * `startTsAdjusted` so the immutable `(deviceId, startTs)` key never moves, matching the single-row
+     * edit path. A fragment with no overlap is dropped; the caller retires those through the normal delete
+     * path so a detected one is tombstoned and cannot be re-detected straight back into the night.
+     *
+     * A one-fragment group therefore reproduces the single-row edit exactly — it takes both bounds — so the
+     * two paths cannot drift apart.
+     *
+     * Stage arrays are reclipped per fragment through the same [SleepWindowReclip] the single-row edit
+     * uses, so a shortened fragment's hypnogram matches its new bounds instead of overhanging them.
+     *
+     * Returns an empty plan when the window clears every fragment: that is a window disjoint from the whole
+     * night, which the editor's own confirm gate is there to catch, and silently deleting a night is never
+     * the right reading of a bed/wake correction.
+     */
+    fun plan(group: List<SleepSession>, newStartTs: Long, newEndTs: Long): Plan {
+        if (group.isEmpty() || newEndTs <= newStartTs) return Plan(emptyList(), emptyList())
+        val ordered = group.sortedBy { it.effectiveStartTs }
+        val kept = ordered.filter { minOf(it.endTs, newEndTs) > maxOf(it.effectiveStartTs, newStartTs) }
+        // Never let a bed/wake correction empty the night — see the doc above.
+        if (kept.isEmpty()) return Plan(emptyList(), emptyList())
+        val dropped = ordered - kept.toSet()
+
+        val clipped = kept.mapIndexed { i, frag ->
+            // The OUTER fragments take the user's bounds outright rather than an intersection, so the edit
+            // can lengthen a night the strap cut short as well as shorten one it ran long — and so the
+            // header, which reads the first onset and the latest end, shows exactly what was drawn.
+            // Interior fragments only ever narrow.
+            val start = if (i == 0) newStartTs else maxOf(frag.effectiveStartTs, newStartTs)
+            val end = if (i == kept.lastIndex) newEndTs else minOf(frag.endTs, newEndTs)
+            val reclipped =
+                SleepWindowReclip.reclip(frag.stagesJSON, frag.effectiveStartTs, frag.endTs, start, end)
+            frag.copy(
+                startTsAdjusted = start,
+                endTs = end,
+                userEdited = true,
+                stagesJSON = reclipped ?: frag.stagesJSON,
+            )
+        }
+        return Plan(clipped, dropped)
+    }
+
+    /**
+     * The window the editor should open on and validate against: the whole bridged night, first onset to
+     * latest wake. The editor previously seeded and coverage-tested from the winning fragment, so on a
+     * split night the pickers opened on times that did not match the header the user was correcting, and a
+     * window matching the night they could see could read as DISJOINT from that one fragment — routing a
+     * perfectly ordinary edit into the "outside the recorded coverage" confirm instead of saving it.
+     */
+    fun groupWindow(group: List<SleepSession>): Pair<Long, Long>? {
+        val start = group.minOfOrNull { it.effectiveStartTs } ?: return null
+        val end = group.maxOfOrNull { it.endTs } ?: return null
+        return if (end > start) start to end else null
+    }
+}

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -661,6 +661,31 @@ class WhoopRepository(
         )
     }
 
+    /** Apply a hand-corrected bed/wake window across a BRIDGED night — every fragment, not just one.
+     *
+     *  A split night displays as one group whose bedtime is the FIRST fragment's onset and whose wake is
+     *  the group's LATEST end, while [updateSleepSessionTimes] edits the single winning fragment. On a
+     *  fragmented night that fragment is usually neither end, so correcting a night "detected too long"
+     *  narrowed an interior block and left both displayed bounds untouched: the save worked and nothing
+     *  the user could see changed. (#1492)
+     *
+     *  Fragments overlapping the new window are clipped to it and marked `userEdited`; fragments left
+     *  entirely outside are retired through [deleteSleepSession], so a DETECTED one is tombstoned and the
+     *  next analyzeRecent cannot re-detect it straight back into the night — without that, a shortened
+     *  night simply grows again on the next pass.
+     *
+     *  A one-fragment group reproduces [updateSleepSessionTimes] exactly (the lone fragment takes both
+     *  drawn bounds), so an unfragmented night keeps its previous behaviour through the same code. */
+    suspend fun updateSleepGroupTimes(group: List<SleepSession>, newStartTs: Long, newEndTs: Long) {
+        val (safeStartTs, safeEndTs) = com.noop.analytics.SleepEditGuard.clampedEditWindow(
+            newStartTs, newEndTs, System.currentTimeMillis() / 1000L,
+        ) ?: return
+        val plan = com.noop.analytics.SleepGroupEdit.plan(group, safeStartTs, safeEndTs)
+        if (plan.clipped.isEmpty()) return
+        dao.upsertSleepSessions(plan.clipped)
+        plan.dropped.forEach { deleteSleepSession(it) }
+    }
+
     /** Remove a sleep session entirely , the delete half of [updateSleepSessionTimes] with no
      *  re-insert. (deviceId, startTs) is the primary key, so it uniquely identifies the row, letting
      *  the user clear a misread or spurious night so the day recomputes without it (#281).

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1547,6 +1547,16 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         rescoreAfterEdit()
     }
 
+    /** Persist a bed/wake edit across a BRIDGED night's fragments (#1492), then re-score as
+     *  [updateSleepSessionTimes] does. The single-row call edits the winning fragment only, which on a
+     *  split night defines neither the displayed bedtime nor the displayed wake. */
+    suspend fun updateSleepGroupTimes(
+        group: List<com.noop.data.SleepSession>, newStartTs: Long, newEndTs: Long,
+    ) {
+        runCatching { repository.updateSleepGroupTimes(group, newStartTs, newEndTs) }
+        rescoreAfterEdit()
+    }
+
     /** Delete one sleep session, then re-score the affected day immediately so the dashboard aggregates
      *  recompute as if the misread night were never recorded — matching Swift SleepView's analyzeRecent()
      *  after deleteSleepSession. Swallows persist failures — the Sleep screen already removed it

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1574,6 +1574,18 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         rescoreAfterEdit()
     }
 
+    /** Restore EVERY session the undo strip is holding, then re-score ONCE (#1492).
+     *
+     *  A bed/wake correction can retire several fragments of a bridged night, and the single-session call
+     *  above re-scores on each invocation — looping it would run a full analyzeRecent per restored
+     *  fragment, back to back, on the exact pass #1005/#836 found to be the heaviest thing NOOP does in the
+     *  background. The restores are independent; only the scoring needs to see the finished set. */
+    suspend fun undoDeleteSleepSessions(sessions: List<com.noop.data.SleepSession>) {
+        if (sessions.isEmpty()) return
+        sessions.forEach { runCatching { repository.undoDeleteSleepSession(it) } }
+        rescoreAfterEdit()
+    }
+
     /** Re-open one deliberately deleted sleep window (#515): remove its durable tombstone first, then
      *  immediately run the normal detector/scorer over the stored raw data. Unlike optimistic edits, this
      *  returns false when the marker could not be removed — rescoring while it is still present would keep

--- a/android/app/src/main/java/com/noop/ui/SleepModels.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepModels.kt
@@ -100,6 +100,10 @@ internal data class HeroNight(
     // window row and axis were already whole-night. Null only via the default → session fallback.
     val heroOnsetTs: Long? = null,
     val heroWakeTs: Long? = null,
+    // The bridged night's fragments themselves (#1492). `session` is only the winning one, so an edit
+    // anchored to it moved neither displayed bound on a split night. The editor frames itself on this
+    // list — seeding, coverage-testing and writing across the whole night — instead of one block of it.
+    val heroGroup: List<SleepSession> = emptyList(),
 )
 
 /** What the hero card draws for the selected night — null means no usable stage data

--- a/android/app/src/main/java/com/noop/ui/SleepNightNavUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepNightNavUi.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.noop.analytics.SleepEditGuard
+import com.noop.analytics.SleepGroupEdit
 import com.noop.data.SleepSession
 import java.time.LocalDate
 import java.text.SimpleDateFormat
@@ -129,6 +130,9 @@ internal fun NightNavHeader(
     clock: String?,
     onNavigate: (Int) -> Unit,
     session: SleepSession? = null,
+    // #1492: the bridged night's fragments. The editor seeds, coverage-tests and writes across the WHOLE
+    // night; `session` alone is the winning fragment and on a split night defines neither displayed bound.
+    heroGroup: List<SleepSession> = emptyList(),
     onUpdateTimes: (SleepSession, Long, Long) -> Unit = { _, _, _ -> },
     onDeleteSession: (SleepSession) -> Unit = {},
     onAddNap: (Long, Long) -> Unit = { _, _ -> },
@@ -159,8 +163,13 @@ internal fun NightNavHeader(
     // only Save reaches this function, so an edited bedtime can never be persisted against the old
     // wake (or vice versa). A window outside the recorded coverage still uses #940's explicit confirm.
     fun commitTimes(s: SleepSession, newStart: Long, newEnd: Long) {
-        val coverageStart = minOf(s.startTs, s.effectiveStartTs)
-        if (SleepEditGuard.isDisjoint(newStart, newEnd, coverageStart, s.endTs)) {
+        // #1492: coverage is the WHOLE bridged night, not the winning fragment. Testing one fragment made a
+        // window matching the night the user could see read as disjoint from it, diverting an ordinary edit
+        // into the "outside the recorded coverage" confirm instead of saving it.
+        val groupWindow = SleepGroupEdit.groupWindow(heroGroup)
+        val coverageStart = groupWindow?.first ?: minOf(s.startTs, s.effectiveStartTs)
+        val coverageEnd = groupWindow?.second ?: s.endTs
+        if (SleepEditGuard.isDisjoint(newStart, newEnd, coverageStart, coverageEnd)) {
             pendingDisjointTimes = newStart to newEnd
         } else {
             onUpdateTimes(s, newStart, newEnd)
@@ -507,7 +516,14 @@ internal fun NightNavHeader(
                     contentDescription = uiString(R.string.l10n_sleep_screen_adjust_sleep_times_1e325561),
                     tint = Palette.textTertiary,
                     modifier = Modifier.size(14.dp).clickable {
-                        sleepEditDraft = SleepTimeEditDraft(session.effectiveStartTs, session.endTs)
+                        // #1492: open on the window the header shows (the whole bridged night), not the
+                        // winning fragment's — otherwise a split night's pickers pre-fill with times the
+                        // user never saw and is not trying to correct.
+                        val shown = SleepGroupEdit.groupWindow(heroGroup)
+                        sleepEditDraft = SleepTimeEditDraft(
+                            shown?.first ?: session.effectiveStartTs,
+                            shown?.second ?: session.endTs,
+                        )
                         showTimeChoice = true
                     },
                 )

--- a/android/app/src/main/java/com/noop/ui/SleepNightSelection.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepNightSelection.kt
@@ -115,7 +115,7 @@ internal fun selectNight(
         heroGroup.sumOf { (it.endTs - it.effectiveStartTs).coerceAtLeast(0L) } / 60.0
     } else null
     return HeroNight(session, dayKey, segments, clockLabelFor(heroOnsetTs, heroWakeTs), napBlocks, groupStages,
-        groupSegments, groupMotion, groupInBedMin, heroOnsetTs, heroWakeTs)
+        groupSegments, groupMotion, groupInBedMin, heroOnsetTs, heroWakeTs, heroGroup)
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.noop.analytics.AnalyticsEngine
 import com.noop.analytics.SleepEditGuard
+import com.noop.analytics.SleepGroupEdit
 import com.noop.analytics.SleepStageTotals
 import com.noop.analytics.StagePercentages
 import com.noop.data.DismissedSleep
@@ -627,6 +628,7 @@ fun SleepScreen(
                 nightLabel = nightLabel,
                 onNavigate = { nightOffset = it },
                 session = night?.session,
+                heroGroup = night?.heroGroup.orEmpty(),
                 onUpdateTimes = { s, start, end ->
                     // #940 belt-and-braces: never apply (optimistically OR durably) a future-ending
                     // or inverted window, whatever the pickers produced. The editor's own guards
@@ -643,16 +645,24 @@ fun SleepScreen(
                         // edit while the (deviceId,startTs) key never moves. (PR #260 + #395)
                         // Reclip stagesJSON in-memory so the hypnogram strip updates instantly (same
                         // reclip logic runs again in WhoopRepository for the durable DB copy).
-                        sleeps = sleeps.map {
-                            if (it.deviceId == s.deviceId && it.startTs == s.startTs) {
-                                val reclipped = SleepWindowReclip.reclip(it.stagesJSON, it.effectiveStartTs, it.endTs, safeStart, safeEnd)
-                                it.copy(startTsAdjusted = safeStart, endTs = safeEnd, userEdited = true,
-                                        stagesJSON = reclipped ?: it.stagesJSON)
-                            } else {
-                                it
+                        // #1492: apply across the WHOLE bridged night. Editing only `s` (the winning
+                        // fragment) left the fragments defining the displayed bedtime and wake exactly
+                        // where they were, so a corrected night looked unchanged. ONE plan drives both the
+                        // optimistic copy and the durable write, so they cannot disagree.
+                        val group = night?.heroGroup.orEmpty().ifEmpty { listOf(s) }
+                        val plan = SleepGroupEdit.plan(group, safeStart, safeEnd)
+                        if (plan.clipped.isNotEmpty()) {
+                            val edited = plan.clipped.associateBy { it.deviceId to it.startTs }
+                            val gone = plan.dropped.map { it.deviceId to it.startTs }.toSet()
+                            sleeps = sleeps.mapNotNull { row ->
+                                val key = row.deviceId to row.startTs
+                                when {
+                                    key in gone -> null
+                                    else -> edited[key] ?: row
+                                }
                             }
+                            scope.launch { vm.updateSleepGroupTimes(group, safeStart, safeEnd) }
                         }
-                        scope.launch { vm.updateSleepSessionTimes(s, safeStart, safeEnd) }
                     } else {
                         // The clamp refused a future/inverted window. Never drop an edit silently (the nap
                         // pickers used to do exactly that): tell the user why nothing changed. (#940)
@@ -1092,6 +1102,9 @@ private fun Hero(
     nightLabel: String,
     onNavigate: (Int) -> Unit,
     session: SleepSession? = null,
+    // #1492: the bridged night's fragments, forwarded to the editor so it frames itself on the whole
+    // night rather than on `session` (the winning fragment, which defines neither displayed bound).
+    heroGroup: List<SleepSession> = emptyList(),
     onUpdateTimes: (SleepSession, Long, Long) -> Unit = { _, _, _ -> },
     onDeleteSession: (SleepSession) -> Unit = {},
     onAddNap: (Long, Long) -> Unit = { _, _ -> },
@@ -1121,7 +1134,9 @@ private fun Hero(
     windowWakeTs: Long? = null,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
-        NightNavHeader(nightOffset, nightLabel, lastIndex, clock, onNavigate, session, onUpdateTimes, onDeleteSession, onAddNap, onPickNightDate)
+        NightNavHeader(nightOffset, nightLabel, lastIndex, clock, onNavigate, session,
+            heroGroup = heroGroup, onUpdateTimes = onUpdateTimes, onDeleteSession = onDeleteSession,
+            onAddNap = onAddNap, onPickNightDate = onPickNightDate)
         // The night's clock window — when you fell asleep and when you woke — as its own clearly
         // labelled row. These were only ever in the nav-header's trailing caption, which truncates
         // between the two chevrons on a phone, so in practice the two times people look for first

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -478,7 +478,7 @@ fun SleepScreen(
                     onUndo = {
                         sleepUndo = null
                         scope.launch {
-                            undo.sessions.forEach { vm.undoDeleteSleepSession(it) }
+                            vm.undoDeleteSleepSessions(undo.sessions)
                             // Re-read so the restored night reappears in the ◀/▶ browse. Same
                             // active∪canonical union as the main loader (#814/#1008), so the undo
                             // reload can't snap the browse back to a canonical-only night set.
@@ -858,7 +858,12 @@ internal fun SleepMarkCard(onMark: (SleepMarkType) -> Unit) {
 
 /** What the undo strip is holding: the retired sessions, plus whether they went as an outright delete or
  *  as fragments a bed/wake correction left outside a bridged night (#1492). A delete carries exactly one;
- *  a correction can retire several at once, and every one of them must come back on Undo. */
+ *  a correction can retire several at once, and every one of them must come back on Undo.
+ *
+ *  Undo reverses the REMOVAL, not the whole correction: the retired fragments return with their original
+ *  bounds while the surviving ones keep their corrected ones. That is what the strip offers in words
+ *  ("sleep outside the new times was removed"), and it is the more useful half to be able to take back —
+ *  the corrected bed and wake times were the point of the edit, and only the deletion is unrecoverable. */
 private data class SleepUndoState(val sessions: List<SleepSession>, val fromEdit: Boolean)
 
 /**
@@ -869,7 +874,10 @@ private data class SleepUndoState(val sessions: List<SleepSession>, val fromEdit
  */
 @Composable
 private fun SleepUndoBanner(undo: SleepUndoState, onUndo: () -> Unit) {
-    val session = undo.sessions.first()
+    // Both construction sites are non-empty (a delete carries one row, a correction only raises this when
+    // it retired something), but `first()` on an empty list would take the whole Sleep tab down — too
+    // steep a price for a strip that is only ever informational. Render nothing instead.
+    val session = undo.sessions.firstOrNull() ?: return
     val timeFmt = SimpleDateFormat("HH:mm", Locale.US)
     // effectiveStartTs is the displayed onset (a userEdited night's corrected bed time), matching iOS.
     val startText = timeFmt.format(java.util.Date(session.effectiveStartTs * 1000L))

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -197,7 +197,9 @@ fun SleepScreen(
     // (which still carries its OWNING deviceId + userEdited), so Undo restores it into the original
     // namespace and lifts the tombstone. Auto-cleared after ~7s by a keyed LaunchedEffect; a new delete
     // replaces it. Mirrors the macOS SleepView sleepUndoBanner + WorkoutsView postLogNote idiom.
-    var sleepUndo by remember { mutableStateOf<SleepSession?>(null) }
+    // #1492: a LIST, because a bed/wake correction can retire more than one fragment of a bridged night.
+    // `fromEdit` distinguishes those from an outright delete so the banner says what actually happened.
+    var sleepUndo by remember { mutableStateOf<SleepUndoState?>(null) }
     LaunchedEffect(sleepUndo) {
         if (sleepUndo != null) {
             kotlinx.coroutines.delay(7_000)
@@ -469,14 +471,14 @@ fun SleepScreen(
     ) {
         // #65: the transient UNDO banner after a suppressing delete. Restores the deleted row into its
         // ORIGINAL namespace + lifts the tombstone. Mirrors the macOS SleepView sleepUndoBanner.
-        sleepUndo?.let { deleted ->
+        sleepUndo?.let { undo ->
             item {
                 SleepUndoBanner(
-                    session = deleted,
+                    undo = undo,
                     onUndo = {
                         sleepUndo = null
                         scope.launch {
-                            vm.undoDeleteSleepSession(deleted)
+                            undo.sessions.forEach { vm.undoDeleteSleepSession(it) }
                             // Re-read so the restored night reappears in the ◀/▶ browse. Same
                             // active∪canonical union as the main loader (#814/#1008), so the undo
                             // reload can't snap the browse back to a canonical-only night set.
@@ -661,6 +663,9 @@ fun SleepScreen(
                                     else -> edited[key] ?: row
                                 }
                             }
+                            if (plan.dropped.isNotEmpty()) {
+                                sleepUndo = SleepUndoState(plan.dropped, fromEdit = true)
+                            }
                             scope.launch { vm.updateSleepGroupTimes(group, safeStart, safeEnd) }
                         }
                     } else {
@@ -681,7 +686,7 @@ fun SleepScreen(
                     // #65: offer a transient UNDO. `s` still carries its owning deviceId + userEdited,
                     // everything undo needs to restore it into the original namespace.
                     sleeps = sleeps.filterNot { it.deviceId == s.deviceId && it.startTs == s.startTs }
-                    sleepUndo = s
+                    sleepUndo = SleepUndoState(listOf(s), fromEdit = false)
                     scope.launch {
                         vm.deleteSleepSession(s)
                         dismissedSleeps = runCatching {
@@ -851,6 +856,11 @@ internal fun SleepMarkCard(onMark: (SleepMarkType) -> Unit) {
     }
 }
 
+/** What the undo strip is holding: the retired sessions, plus whether they went as an outright delete or
+ *  as fragments a bed/wake correction left outside a bridged night (#1492). A delete carries exactly one;
+ *  a correction can retire several at once, and every one of them must come back on Undo. */
+private data class SleepUndoState(val sessions: List<SleepSession>, val fromEdit: Boolean)
+
 /**
  * #65: the transient UNDO strip after a suppressing sleep delete. A Rest-tinted card stating the window
  * NOOP won't re-detect + a real Undo button. The banner auto-clears after ~7s (the caller's keyed
@@ -858,7 +868,8 @@ internal fun SleepMarkCard(onMark: (SleepMarkType) -> Unit) {
  * Mirrors the macOS SleepView.sleepUndoBanner (role-alert-ish, explicit Undo label).
  */
 @Composable
-private fun SleepUndoBanner(session: SleepSession, onUndo: () -> Unit) {
+private fun SleepUndoBanner(undo: SleepUndoState, onUndo: () -> Unit) {
+    val session = undo.sessions.first()
     val timeFmt = SimpleDateFormat("HH:mm", Locale.US)
     // effectiveStartTs is the displayed onset (a userEdited night's corrected bed time), matching iOS.
     val startText = timeFmt.format(java.util.Date(session.effectiveStartTs * 1000L))
@@ -866,10 +877,15 @@ private fun SleepUndoBanner(session: SleepSession, onUndo: () -> Unit) {
     // Branch the copy on userEdited: a hand-edited/added (nap) night writes NO tombstone (it is never
     // re-detected), so the suppression promise would be false for it. Only a DETECTED delete tombstones,
     // so only it gets the "won't detect ... again" wording. Mirrors the macOS branch. (#65 banner honesty.)
-    val message = if (session.userEdited) {
-        "Sleep deleted."
-    } else {
-        "Sleep deleted. NOOP won't detect sleep between $startText and $endText again."
+    // #1492: a correction that narrows a bridged night RETIRES the fragments left outside it — otherwise
+    // they keep defining the night's displayed start or end and the edit looks like it did nothing. That is
+    // real recorded sleep going away from an action that reads as "adjust the times", so it must be as
+    // reversible, and as clearly stated, as an outright delete. Count-free wording so one dropped fragment
+    // and several read the same (no plural forms in the Android catalogue yet).
+    val message = when {
+        undo.fromEdit -> uiString(R.string.l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e)
+        session.userEdited -> "Sleep deleted."
+        else -> "Sleep deleted. NOOP won't detect sleep between $startText and $endText again."
     }
     NoopCard(tint = Palette.restColor) {
         Row(

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2146,4 +2146,5 @@
     <string name="power_saving_low_refresh_desc">Synchronisiert im Hintergrund stündlich statt alle 15 Minuten, unabhängig vom Ladestand — weniger Verbindungsaufbauten sind die größte Ersparnis bei einer WHOOP 4.0. Es geht nichts verloren: Das Band speichert alles und übergibt es in größeren Paketen. Manuelles Synchronisieren läuft weiterhin sofort, die Live-Herzfrequenz bleibt unberührt.</string>
     <string name="nav_power_saving">Energiesparen</string>
     <string name="l10n_app_changelog_training_load_a_vo_max_without_f9205a67">Trainingsbelastung, VO₂max ohne Maßband und deutlich weniger Akku fürs Neuberechnen</string>
+    <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">Schlaf außerhalb der neuen Zeiten wurde entfernt. NOOP erkennt ihn nicht erneut.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2132,4 +2132,5 @@
     <string name="power_saving_low_refresh_desc">Sincroniza en segundo plano cada hora en vez de cada 15 minutos, sea cual sea la carga de la banda: menos reconexiones es el mayor ahorro en una WHOOP 4.0. No se pierde nada: la banda lo guarda todo y lo entrega en lotes más grandes. Sincronizar manualmente sigue siendo inmediato y la frecuencia cardíaca en vivo no cambia.</string>
     <string name="nav_power_saving">Ahorro de energía</string>
     <string name="l10n_app_changelog_training_load_a_vo_max_without_f9205a67">Carga de entrenamiento, VO₂max sin cinta métrica y mucha menos batería recalculando</string>
+    <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">Se ha eliminado el sueño fuera del nuevo horario. NOOP no volverá a detectarlo.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2131,4 +2131,5 @@
     <string name="power_saving_low_refresh_desc">Synchronise en arrière-plan toutes les heures au lieu de toutes les 15 minutes, quelle que soit la charge du bracelet : moins de reconnexions, c\'est la plus grosse économie sur une WHOOP 4.0. Rien n\'est perdu : le bracelet enregistre tout et le transmet par lots plus importants. La synchro manuelle reste immédiate et la fréquence cardiaque en direct n\'est pas affectée.</string>
     <string name="nav_power_saving">Économie d’énergie</string>
     <string name="l10n_app_changelog_training_load_a_vo_max_without_f9205a67">Charge d\'entraînement, VO₂max sans mètre ruban, et bien moins de batterie à recalculer</string>
+    <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">Le sommeil en dehors des nouveaux horaires a été supprimé. NOOP ne le détectera plus.</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2125,4 +2125,5 @@
     <string name="power_saving_low_refresh_desc">Synchronizuje w tle co godzinę zamiast co 15 minut, niezależnie od poziomu naładowania opaski — mniej ponownych połączeń to największa oszczędność w WHOOP 4.0. Nic nie ginie: opaska zapisuje wszystko i przekazuje w większych paczkach. Ręczna synchronizacja nadal działa od razu, a tętno na żywo pozostaje bez zmian.</string>
     <string name="nav_power_saving">Oszczędzanie energii</string>
     <string name="l10n_app_changelog_training_load_a_vo_max_without_f9205a67">Obciążenie treningowe, VO₂max bez centymetra i znacznie mniej baterii na przeliczanie</string>
+    <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">Sen poza nowymi godzinami został usunięty. NOOP nie wykryje go ponownie.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2125,4 +2125,5 @@
     <string name="power_saving_low_refresh_desc">Sincroniza em segundo plano a cada hora em vez de a cada 15 minutos, seja qual for a carga da pulseira — menos religações é a maior poupança numa WHOOP 4.0. Nada se perde: a pulseira guarda tudo e entrega em lotes maiores. A sincronização manual continua imediata e a frequência cardíaca em direto não é afetada.</string>
     <string name="nav_power_saving">Poupança de energia</string>
     <string name="l10n_app_changelog_training_load_a_vo_max_without_f9205a67">Carga de treino, VO₂max sem fita métrica e muito menos bateria a recalcular</string>
+    <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">O sono fora dos novos horários foi removido. O NOOP não o voltará a detetar.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2051,4 +2051,5 @@
     <string name="power_saving_low_refresh_desc">无论手环电量如何，后台同步改为每小时一次而非每 15 分钟一次——减少重新连接是 WHOOP 4.0 上最大的省电项。不会丢失任何数据：手环会记录全部内容，并以更大的批次交付。手动同步仍会立即运行，实时心率不受影响。</string>
     <string name="nav_power_saving">省电模式</string>
     <string name="l10n_app_changelog_training_load_a_vo_max_without_f9205a67">训练负荷、无需量腰围的 VO₂max，以及大幅降低的重算耗电</string>
+    <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">新时间范围之外的睡眠已移除。NOOP 不会再次检测到它。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2158,4 +2158,5 @@
     <string name="power_saving_low_refresh_desc">Sync in the background every hour instead of every 15 minutes, whatever the strap\'s charge — fewer reconnections is the biggest saving on a WHOOP 4.0. Nothing is lost: the strap banks everything and hands it over in larger batches. Pull to sync still runs straight away, and live heart rate is untouched.</string>
     <string name="nav_power_saving">Power saving</string>
     <string name="l10n_app_changelog_training_load_a_vo_max_without_f9205a67">Training load, a VO₂max without a tape measure, and far less battery spent re-scoring</string>
+    <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">Sleep outside the new times was removed. NOOP won\'t detect it again.</string>
 </resources>

--- a/android/app/src/test/java/com/noop/analytics/SleepGroupEditTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepGroupEditTest.kt
@@ -1,0 +1,116 @@
+package com.noop.analytics
+
+import com.noop.data.SleepSession
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1492: correcting a night's bed/wake times saved successfully and changed nothing on screen.
+ *
+ * A night the strap split into fragments displays as one bridged group — the header's bedtime is the FIRST
+ * fragment's onset and its wake is the group's LATEST end. The editor was anchored to the single winning
+ * fragment, which on a split night is usually neither. Shortening a night "detected too long" narrowed an
+ * interior block while both fragments defining the displayed ends stayed put.
+ *
+ * These pin the semantics of applying the drawn window across the whole night.
+ */
+class SleepGroupEditTest {
+
+    private val h = 3_600L
+    private val t0 = 1_780_000_000L
+
+    private fun frag(startTs: Long, endTs: Long, deviceId: String = "my-whoop") = SleepSession(
+        deviceId = deviceId, startTs = startTs, endTs = endTs,
+    )
+
+    /** A night split into three, spanning t0 → t0+10h — the shape that reads as "detected too long". */
+    private fun splitNight() = listOf(
+        frag(t0, t0 + 2 * h),
+        frag(t0 + 3 * h, t0 + 5 * h),
+        frag(t0 + 8 * h, t0 + 10 * h),
+    )
+
+    private fun window(p: SleepGroupEdit.Plan) =
+        p.clipped.minOf { it.effectiveStartTs } to p.clipped.maxOf { it.endTs }
+
+    /**
+     * The regression: the drawn window becomes the night's window. Before, the edit landed on one fragment
+     * and the displayed first-onset / latest-end were untouched.
+     */
+    @Test fun theDrawnWindowBecomesTheNightsWindow() {
+        val plan = SleepGroupEdit.plan(splitNight(), t0 + 1 * h, t0 + 6 * h)
+        assertEquals((t0 + 1 * h) to (t0 + 6 * h), window(plan))
+    }
+
+    /**
+     * ...which requires retiring the fragment that fell outside. Leaving it in place is precisely what kept
+     * the night long: it would go on defining the group's latest wake.
+     */
+    @Test fun aFragmentOutsideTheWindowIsDroppedNotLeftBehind() {
+        val plan = SleepGroupEdit.plan(splitNight(), t0 + 1 * h, t0 + 6 * h)
+        assertEquals(1, plan.dropped.size)
+        assertEquals(t0 + 8 * h, plan.dropped[0].startTs)   // the 8h–10h tail
+        assertEquals(2, plan.clipped.size)
+    }
+
+    /** An interior fragment only ever narrows — it must not be stretched out to the drawn bounds. */
+    @Test fun interiorFragmentsAreNarrowedNotStretched() {
+        val plan = SleepGroupEdit.plan(splitNight(), t0 - 1 * h, t0 + 11 * h)
+        val interior = plan.clipped[1]
+        assertEquals(t0 + 3 * h, interior.effectiveStartTs)
+        assertEquals(t0 + 5 * h, interior.endTs)
+    }
+
+    /**
+     * The edit must LENGTHEN a night the strap cut short too, not only shorten a long one — the outer
+     * fragments take the drawn bounds outright rather than intersecting with what was detected.
+     */
+    @Test fun theWindowCanExtendBeyondWhatWasDetected() {
+        val plan = SleepGroupEdit.plan(splitNight(), t0 - 1 * h, t0 + 11 * h)
+        assertEquals((t0 - 1 * h) to (t0 + 11 * h), window(plan))
+        assertTrue(plan.dropped.isEmpty())
+    }
+
+    /**
+     * A one-fragment night must come out exactly as the single-row edit would leave it, so the unfragmented
+     * path keeps its long-standing behaviour through this code rather than beside it.
+     */
+    @Test fun aSingleFragmentReproducesTheSingleRowEdit() {
+        val only = frag(t0, t0 + 8 * h)
+        val plan = SleepGroupEdit.plan(listOf(only), t0 + 1 * h, t0 + 7 * h)
+        assertEquals(1, plan.clipped.size)
+        assertTrue(plan.dropped.isEmpty())
+        assertEquals(t0 + 1 * h, plan.clipped[0].effectiveStartTs)
+        assertEquals(t0 + 7 * h, plan.clipped[0].endTs)
+        assertTrue(plan.clipped[0].userEdited)
+        // The detected key never moves — the correction rides in startTsAdjusted.
+        assertEquals(only.startTs, plan.clipped[0].startTs)
+    }
+
+    /**
+     * A window that clears the whole night is refused outright. A bed/wake correction should never be read
+     * as "delete this night", and the editor's own confirm gate exists to catch a disjoint window first.
+     */
+    @Test fun aWindowMissingTheNightEntirelyChangesNothing() {
+        val plan = SleepGroupEdit.plan(splitNight(), t0 + 20 * h, t0 + 22 * h)
+        assertTrue(plan.clipped.isEmpty())
+        assertTrue(plan.dropped.isEmpty())
+    }
+
+    /** An inverted window is refused rather than persisted as a phantom night. */
+    @Test fun anInvertedWindowIsRefused() {
+        val plan = SleepGroupEdit.plan(splitNight(), t0 + 6 * h, t0 + 1 * h)
+        assertTrue(plan.clipped.isEmpty())
+    }
+
+    /**
+     * The coverage window the editor seeds and validates against spans the WHOLE night. Testing against the
+     * winning fragment alone is what let an ordinary edit read as disjoint and get diverted into a confirm.
+     */
+    @Test fun theGroupWindowSpansEveryFragment() {
+        assertEquals(t0 to (t0 + 10 * h), SleepGroupEdit.groupWindow(splitNight()))
+        assertNull(SleepGroupEdit.groupWindow(emptyList()))
+    }
+}


### PR DESCRIPTION
Fixes #1492 — correcting a night's bed/wake times saves successfully and changes nothing on screen.

## Cause

A night the strap split into fragments is **displayed** as one bridged group (`SleepNightSelection`):

```kotlin
val heroOnsetTs = heroGroup.firstOrNull()?.effectiveStartTs ?: session.effectiveStartTs
val heroWakeTs  = heroGroup.maxOfOrNull { it.endTs }        ?: session.endTs
```

The **editor** was anchored to `session` — the single winning fragment, which the code already labelled
*"the edit anchor only"* — and on a split night that's usually neither the first fragment nor the last. So
shortening a night "detected too long" narrowed an interior block while both fragments defining the
displayed ends stayed exactly where they were. The write landed and `userEdited` was set; nothing the user
was looking at moved.

A single-block night edits fine (the group *is* the session), which is why this isn't universal.

The editor was fragment-scoped in three places:

| | Was | Consequence |
|---|---|---|
| **seed** | winning fragment's times | pickers opened on times the user never saw |
| **gate** | that fragment's coverage | a window matching the night on screen could read as disjoint → diverted into the "outside recorded coverage" confirm → **a second way for a save to do nothing** |
| **write** | that fragment | neither displayed bound moved |

All three now frame on the group.

## Semantics

`SleepGroupEdit.plan` is pure and holds the rules:

- the **outer** surviving fragments take the drawn bounds outright rather than intersecting with what was
  detected — so an edit can **lengthen** a night the strap cut short, not only shorten one it ran long, and
  the header shows exactly what was drawn;
- **interior** fragments only narrow;
- a **one-fragment** group takes both bounds and so reproduces the single-row edit exactly — the
  unfragmented path keeps its behaviour *through* this code rather than beside it;
- a window clearing every fragment is **refused** — a bed/wake correction is never a request to delete.

One plan drives both the optimistic in-memory copy and the durable write, so the two can't disagree — the
property the previous single-row path was careful about.

## Retiring fragments, and undoing it

A fragment left entirely outside the new window is **retired**. Leaving it is what kept the night long — it
would go on defining the group's displayed end. Drops go through the existing `deleteSleepSession`, which
tombstones a **detected** fragment so the next `analyzeRecent` can't re-detect it straight back in. Without
that, a shortened night simply regrows on the next pass.

That's real recorded sleep going away permanently, from an action that reads as "adjust the times" — so it
now offers **Undo**, which the outright delete has had since #65 and this didn't. The strip holds a list
plus where the rows came from, so a correction raises it for every fragment it retired and Undo restores
all of them into their original namespaces, lifting each tombstone. A delete still carries exactly one and
behaves as before.

The wording is its own rather than the delete's: *"Sleep outside the new times was removed. NOOP won't
detect it again."* Count-free deliberately — one retired fragment and several read the same, since the
Android catalogue has no plural forms yet — and localized into all six locales rather than left a bare
literal beside the two the banner already carries.

## Android only

iOS synthesizes a group-spanning session for its merged night (`mergeDay`'s `synth`), so its editor was
already whole-night; the Swift path is untouched. Whether that synth persists cleanly is a separate
question I haven't traced.

## Verification

8 unit tests on the planner, plus the full suite — **506 classes, 4,173 tests, 0 failures**
(`--rerun-tasks`; an earlier "BUILD SUCCESSFUL in 7s" was Gradle reporting up-to-date, not running).
`doc_comment_lint`, `i18n_audit --ci` and `lintVitalFullRelease -PstagingRelease` (the fatal
`ExtraTranslation`/`MissingTranslation` gate that plain compiles miss) all clean.

**Not validated on hardware.** The premise of this diagnosis is that the reporter's night is genuinely
fragmented; his export would confirm it. Worth checking before this is treated as closed.

Reported by @bartmuskala.

