### PR TITLE
Fix untimed single-point activity distance

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/ActivityFileImporter.swift
+++ b/Packages/StrandImport/Sources/StrandImport/ActivityFileImporter.swift
@@ -276,7 +276,7 @@ public enum ActivityFileImporter {
             guard !route.isEmpty else {
                 return ActivityFileImportResult(activity: nil, kind: kind, skipped: skipped)
             }
-            let dist = summaryDistanceM ?? routeDistanceM(route)
+            let dist = summaryDistanceM ?? (route.count >= 2 ? routeDistanceM(route) : nil)
             let now = Date(timeIntervalSince1970: 0)
             let a = ActivityFile(
                 kind: kind, start: now, end: now, sport: sportHint,

--- a/Packages/StrandImport/Tests/StrandImportTests/ActivityFileImporterTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/ActivityFileImporterTests.swift
@@ -111,6 +111,34 @@ final class ActivityFileImporterTests: XCTestCase {
         XCTAssertEqual(r.skipped, 0)               // it still carried a time, so not "skipped"
     }
 
+    func testUntimedGpxRequiresTwoPointsForDerivedDistance() {
+        // bhelm/noop#100: without a summary distance, one coordinate has no measurable segment.
+        // The untimed parser must preserve that absence as nil, matching the timestamped branch.
+        let onePoint = """
+        <gpx><trk><trkseg>
+          <trkpt lat="48.1" lon="11.5"></trkpt>
+        </trkseg></trk></gpx>
+        """
+        let single = try! XCTUnwrap(
+            ActivityFileImporter.parse(data: Data(onePoint.utf8), filename: "route.gpx").activity
+        )
+        XCTAssertEqual(single.gpsPointCount, 1)
+        XCTAssertNil(single.distanceM)
+
+        // Adjacent control: two untimed coordinates do define a segment and retain derived distance.
+        let twoPoints = """
+        <gpx><trk><trkseg>
+          <trkpt lat="48.1" lon="11.5"></trkpt>
+          <trkpt lat="48.1001" lon="11.5001"></trkpt>
+        </trkseg></trk></gpx>
+        """
+        let pair = try! XCTUnwrap(
+            ActivityFileImporter.parse(data: Data(twoPoints.utf8), filename: "route.gpx").activity
+        )
+        XCTAssertEqual(pair.gpsPointCount, 2)
+        XCTAssertGreaterThan(try! XCTUnwrap(pair.distanceM), 0)
+    }
+
     // MARK: - TCX
 
     func testTcxActivityWithLapSummaries() {

--- a/android/app/src/main/java/com/noop/ingest/ActivityFileImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/ActivityFileImporter.kt
@@ -438,7 +438,7 @@ object ActivityFileImporter {
         if (times.isEmpty()) {
             // A pure coordinate track (no timestamps): keep it but with no interval.
             if (route.isEmpty()) return Result(null, kind, skipped)
-            val dist = summaryDistanceM ?: routeDistanceM(route)
+            val dist = summaryDistanceM ?: if (route.size >= 2) routeDistanceM(route) else null
             val a = Activity(kind, 0L, 0L, sportHint, dist, summaryEnergyKcal, null, summaryAvgHr, summaryMaxHr,
                 summaryAscentM, route.size, 0, cappedRoute(route))
             return Result(a, kind, skipped)

--- a/android/app/src/test/java/com/noop/ingest/ActivityFileImporterTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/ActivityFileImporterTest.kt
@@ -2,6 +2,7 @@ package com.noop.ingest
 
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -125,6 +126,33 @@ class ActivityFileImporterTest {
         """.trimIndent()
         val r = ActivityFileImporter.parse(gpx.toByteArray(Charsets.UTF_8), "x.gpx")
         assertEquals(1, r.activity!!.gpsPointCount)
+    }
+
+    @Test
+    fun untimedGpxRequiresTwoPointsForDerivedDistance() {
+        // bhelm/noop#100: without a summary distance, one coordinate has no measurable segment.
+        // The untimed parser must preserve that absence as null, matching the timestamped branch.
+        val onePoint = """
+            <gpx><trk><trkseg>
+              <trkpt lat="48.1" lon="11.5"></trkpt>
+            </trkseg></trk></gpx>
+        """.trimIndent()
+        val single = ActivityFileImporter.parse(onePoint.toByteArray(Charsets.UTF_8), "route.gpx").activity!!
+        assertEquals(1, single.gpsPointCount)
+        assertNull(single.distanceM)
+
+        // Adjacent control: two untimed coordinates do define a segment and retain derived distance.
+        val twoPoints = """
+            <gpx><trk><trkseg>
+              <trkpt lat="48.1" lon="11.5"></trkpt>
+              <trkpt lat="48.1001" lon="11.5001"></trkpt>
+            </trkseg></trk></gpx>
+        """.trimIndent()
+        val pair = ActivityFileImporter.parse(twoPoints.toByteArray(Charsets.UTF_8), "route.gpx").activity!!
+        assertEquals(2, pair.gpsPointCount)
+        val derivedDistance = pair.distanceM
+        assertNotNull(derivedDistance)
+        assertTrue((derivedDistance ?: 0.0) > 0.0)
     }
 
     // MARK: - TCX


### PR DESCRIPTION
Fixes bhelm/noop#100

## Summary
- preserve meaningful distance for untimed single-point activity files
- mirror the behavior in the Swift and Android importers
- add focused regression coverage for both implementations

## Validation
- frozen four-file patch independently reviewed: no P0/P1/P2 findings
- Swift focused: 2 passed; affected importer suite: 12 passed; full StrandImport: 237 passed with 1 established platform skip
- Kotlin focused: 1 passed; affected importer suite: 1 passed; full FullDebug: 506 passed, 6 skipped
- Kotlin Native constraints: JDK 17, Android SDK, in-process compiler, 1 worker, no parallel execution, 1536 MiB heap, no daemon
- frozen patch SHA-256: `104c7eb6f46f32d135dbf4a53510d29e3b0d7f0af187f31571ea5e8534eb1938`