### PR TITLE
Measure how a duplicated second's two copies compare (#1505)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -737,6 +737,22 @@ public enum HRVAnalyzer {
     /// shape as the `%.1f` divergence in #1473, where one platform's formatter rounded a tie the other way.
     /// `x + 0.5` truncated is half-up on both, with no stdlib rounding involved, so the agreement is by
     /// construction rather than by luck. Byte-parity twin of Kotlin `HrvAnalyzer.msToInt`.
+    /// One second's worth of duplicate-pair bookkeeping: how many rows landed on it, the first two
+    /// intervals, and whether every row claimed `ord == 0`. Only a second with EXACTLY two rows, both
+    /// `ord 0`, is an unambiguous two-delivery pair — see `duplicatePairRatios`.
+    final class PairTally {
+        var count = 0
+        var first = 0
+        var second = 0
+        var allOrdZero = true
+        var qualifies: Bool { count == 2 && allOrdZero }
+        func add(ms: Int, ord: Int) {
+            count += 1
+            if count == 1 { first = ms } else if count == 2 { second = ms }
+            if ord != 0 { allOrdZero = false }
+        }
+    }
+
     /// #1505: when two deliveries wrote the same second, how do their two intervals COMPARE?
     ///
     /// `deliveryHistogram` counts how many deliveries wrote each second; it never looks at what they wrote.
@@ -757,19 +773,25 @@ public enum HRVAnalyzer {
     public static func duplicatePairRatios(tsSec: [Int], rrMs: [Double], ords: [Int?]) -> String {
         let n = min(tsSec.count, rrMs.count, ords.count)
         guard n > 0 else { return "" }
-        var bySec: [Int: [(ms: Int, ord: Int)]] = [:]
+        // A tally per second rather than an array per second, matching `SecondTally` above: this runs over
+        // a whole night's beats on the same path, and the histogram beside it was deliberately reduced to
+        // one dictionary and no per-second allocation for exactly that reason.
+        var bySec: [Int: PairTally] = [:]
         for i in 0 ..< n {
             guard let o = ords[i] else { continue }
             let ms = msToInt(rrMs[i])
             guard ms > 0 else { continue }
-            bySec[tsSec[i], default: []].append((ms, o))
+            let tally: PairTally
+            if let t = bySec[tsSec[i]] { tally = t } else { tally = PairTally(); bySec[tsSec[i]] = tally }
+            tally.add(ms: ms, ord: o)
         }
         var ppts: [Int] = []
-        for (_, rows) in bySec where rows.count == 2 && rows[0].ord == 0 && rows[1].ord == 0 {
-            let lo = min(rows[0].ms, rows[1].ms)
-            let hi = max(rows[0].ms, rows[1].ms)
+        for (_, t) in bySec where t.qualifies {
+            let lo = min(t.first, t.second), hi = max(t.first, t.second)
             guard lo > 0 else { continue }
-            ppts.append((hi * 1000 + lo / 2) / lo)   // integer half-up, parts per thousand
+            // Int64 so the multiply cannot overflow on a corrupt row — Kotlin's Int is 32-bit and would
+            // wrap where Swift's would not, and a diagnostic that disagrees across platforms is worthless.
+            ppts.append(Int((Int64(hi) * 1_000 + Int64(lo) / 2) / Int64(lo)))   // half-up, parts per thousand
         }
         guard !ppts.isEmpty else { return "rr dupPairs n=0" }
         ppts.sort()

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -737,6 +737,52 @@ public enum HRVAnalyzer {
     /// shape as the `%.1f` divergence in #1473, where one platform's formatter rounded a tie the other way.
     /// `x + 0.5` truncated is half-up on both, with no stdlib rounding involved, so the agreement is by
     /// construction rather than by luck. Byte-parity twin of Kotlin `HrvAnalyzer.msToInt`.
+    /// #1505: when two deliveries wrote the same second, how do their two intervals COMPARE?
+    ///
+    /// `deliveryHistogram` counts how many deliveries wrote each second; it never looks at what they wrote.
+    /// That is the measurement the R-R unit question turns on. A WHOOP 5 emits the beat train live over
+    /// `0x2A37` (spec-fixed 1/1024-second units, converted on the way in) and again inside its v18
+    /// historical record (stored as read). If those are the same beat in two units, a duplicated second
+    /// holds two values 1024/1000 apart. If they are genuinely different beats, the ratios scatter.
+    ///
+    /// Restricted to the unambiguous case: seconds carrying EXACTLY two rows, both `ord == 0`. `ord`
+    /// restarts per delivery, so that is two deliveries each contributing their first beat — not two
+    /// consecutive beats from one record's array, which would read `0` then `1`.
+    ///
+    /// A single such pair proves nothing: 872 vs 893 ms is both the 1024/1000 ratio and an utterly ordinary
+    /// beat-to-beat difference. A POPULATION of them separates the two — a tight cluster at 1.024 is a unit
+    /// mismatch, a broad spread is normal variability. This reports the distribution and takes no view.
+    ///
+    /// Parts-per-thousand in integer arithmetic so Swift and Kotlin cannot round a tie differently.
+    public static func duplicatePairRatios(tsSec: [Int], rrMs: [Double], ords: [Int?]) -> String {
+        let n = min(tsSec.count, rrMs.count, ords.count)
+        guard n > 0 else { return "" }
+        var bySec: [Int: [(ms: Int, ord: Int)]] = [:]
+        for i in 0 ..< n {
+            guard let o = ords[i] else { continue }
+            let ms = msToInt(rrMs[i])
+            guard ms > 0 else { continue }
+            bySec[tsSec[i], default: []].append((ms, o))
+        }
+        var ppts: [Int] = []
+        for (_, rows) in bySec where rows.count == 2 && rows[0].ord == 0 && rows[1].ord == 0 {
+            let lo = min(rows[0].ms, rows[1].ms)
+            let hi = max(rows[0].ms, rows[1].ms)
+            guard lo > 0 else { continue }
+            ppts.append((hi * 1000 + lo / 2) / lo)   // integer half-up, parts per thousand
+        }
+        guard !ppts.isEmpty else { return "rr dupPairs n=0" }
+        ppts.sort()
+        // Identical (both deliveries stored the same number), the 1024/1000 signature, or neither.
+        let same = ppts.filter { $0 <= 1_005 }.count
+        let tick = ppts.filter { $0 >= 1_019 && $0 <= 1_029 }.count
+        let med = ppts.count % 2 == 1
+            ? ppts[ppts.count / 2]
+            : (ppts[ppts.count / 2 - 1] + ppts[ppts.count / 2]) / 2
+        return "rr dupPairs n=\(ppts.count) same=\(same) tick=\(tick)"
+            + " other=\(ppts.count - same - tick) medPPT=\(med) spread=\(ppts[0])-\(ppts[ppts.count - 1])"
+    }
+
     static func msToInt(_ ms: Double) -> Int { ms > 0 ? Int(ms + 0.5) : 0 }
 
     /// Whole-percent, integer half-up, so both platforms round a tie the same way. 0 when `total` is 0.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerDuplicatePairTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HRVAnalyzerDuplicatePairTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// #1505: measure how the two copies of a duplicated second COMPARE, not merely that there are two.
+///
+/// A WHOOP 5 emits the beat train live over `0x2A37` — spec-fixed 1/1024-second units, converted on the way
+/// in — and again inside its v18 historical record, stored as read. If those are the same beat in two
+/// units, a second written by two deliveries holds values 1024/1000 apart. If they are genuinely two beats,
+/// the ratios scatter across normal beat-to-beat variability.
+///
+/// The field pair that raised the question, from #1451, is `-1s[872#0, 893#0]` — and 893 × 1000/1024 =
+/// 872.07. That single pair cannot decide anything: 21 ms is also an ordinary difference between
+/// consecutive beats. These pin that the measurement reports the distribution honestly in both directions,
+/// so a night's worth of pairs can answer what one pair cannot.
+///
+/// Twin of Kotlin `DuplicatePairRatioTest`.
+final class HRVAnalyzerDuplicatePairTests: XCTestCase {
+
+    private let t0 = 1_780_000_000
+
+    private func run(_ rows: [(Int, Double, Int?)]) -> String {
+        HRVAnalyzer.duplicatePairRatios(
+            tsSec: rows.map { $0.0 }, rrMs: rows.map { $0.1 }, ords: rows.map { $0.2 })
+    }
+
+    private func field(_ out: String, _ key: String) -> Int? {
+        guard let r = out.range(of: "\(key)=") else { return nil }
+        return Int(out[r.upperBound...].prefix { $0.isNumber })
+    }
+
+    /// The real #1451 pair: two deliveries, one second, values exactly the 1024/1000 ratio apart.
+    func testTheFieldPairIsCountedAsATickSignature() {
+        let out = run([(t0, 872.0, 0), (t0, 893.0, 0)])
+        XCTAssertEqual(field(out, "n"), 1, out)
+        XCTAssertEqual(field(out, "tick"), 1, out)
+        XCTAssertEqual(field(out, "other"), 0, out)
+        XCTAssertEqual(field(out, "medPPT"), 1024, out)
+    }
+
+    /// The honesty requirement: an ordinary pair of DIFFERENT beats must not read as a unit mismatch.
+    func testAnOrdinaryBeatToBeatDifferenceIsNotATickSignature() {
+        let out = run([(t0, 872.0, 0), (t0, 940.0, 0)])
+        XCTAssertEqual(field(out, "tick"), 0, out)
+        XCTAssertEqual(field(out, "other"), 1, out)
+    }
+
+    /// Two deliveries that stored the SAME number are exact duplicates, a different finding again.
+    func testAnExactDuplicateIsCountedSeparately() {
+        let out = run([(t0, 872.0, 0), (t0, 872.0, 0)])
+        XCTAssertEqual(field(out, "same"), 1, out)
+        XCTAssertEqual(field(out, "tick"), 0, out)
+    }
+
+    /// Two CONSECUTIVE beats from one record's array read `ord` 0 then 1 and must be excluded — they are
+    /// one delivery, so comparing them measures physiology rather than transports.
+    func testConsecutiveBeatsFromOneDeliveryAreExcluded() {
+        XCTAssertEqual(run([(t0, 872.0, 0), (t0, 893.0, 1)]), "rr dupPairs n=0")
+    }
+
+    /// A second carrying more than two rows is ambiguous about which copy pairs with which — skip it.
+    func testSecondsWithMoreThanTwoRowsAreSkipped() {
+        XCTAssertEqual(run([(t0, 872.0, 0), (t0, 893.0, 0), (t0, 880.0, 0)]), "rr dupPairs n=0")
+    }
+
+    /// Rows with no `ord` (written before the column was surfaced) can't be attributed to a delivery.
+    func testRowsWithoutAnOrdAreIgnored() {
+        XCTAssertEqual(run([(t0, 872.0, nil), (t0, 893.0, nil)]), "rr dupPairs n=0")
+    }
+
+    /// The shape that would actually settle #1505: many pairs, all clustering at the ratio.
+    func testAPopulationOfTickPairsReportsATightSpread() {
+        var rows: [(Int, Double, Int?)] = []
+        for i in 0 ..< 10 {
+            let live = 850.0 + Double(i) * 7
+            rows.append((t0 + i, live, 0))
+            rows.append((t0 + i, live * 1024.0 / 1000.0, 0))   // the same beat, unconverted
+        }
+        let out = run(rows)
+        XCTAssertEqual(field(out, "n"), 10, out)
+        XCTAssertEqual(field(out, "tick"), 10, out)
+    }
+
+    /// ...and a population of genuinely different beats must NOT read as a cluster.
+    func testAPopulationOfRealBeatsDoesNotReadAsTicks() {
+        let second = [910.0, 845.0, 990.0, 870.0, 935.0, 820.0, 960.0, 885.0, 1015.0, 830.0]
+        var rows: [(Int, Double, Int?)] = []
+        for i in 0 ..< 10 {
+            rows.append((t0 + i, 900.0, 0))
+            rows.append((t0 + i, second[i], 0))
+        }
+        let out = run(rows)
+        XCTAssertEqual(field(out, "n"), 10, out)
+        XCTAssertLessThanOrEqual(field(out, "tick") ?? 99, 2, out)
+    }
+
+    /// Parity: the Kotlin twin must produce the SAME string for the same input, so a capture read on either
+    /// platform is comparable. Pinned by value here and in `DuplicatePairRatioTest`.
+    func testOutputStringIsPinnedForParity() {
+        XCTAssertEqual(run([(t0, 872.0, 0), (t0, 893.0, 0)]),
+                       "rr dupPairs n=1 same=0 tick=1 other=0 medPPT=1024 spread=1024-1024")
+    }
+}

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1092,6 +1092,14 @@ final class IntelligenceEngine: ObservableObject {
                         let deliveries = HRVAnalyzer.deliveryHistogram(
                             tsSec: ts, rrMs: sleepRr, ords: sleepRrRows.map { $0.ord })
                         if !deliveries.isEmpty { diagLine += "\n\(deliveries) day=\(res.daily.day)" }
+                        // #1505: the histogram above counts deliveries per second but never compares what
+                        // they wrote. If the live and historical copies are the same beat in two units, a
+                        // duplicated second holds two values 1024/1000 apart; if they are different beats,
+                        // the ratios scatter. One pair cannot tell those apart — a night's worth can.
+                        // Measurement only, takes no view on the answer. Kotlin twin.
+                        let dupPairs = HRVAnalyzer.duplicatePairRatios(
+                            tsSec: ts, rrMs: sleepRr, ords: sleepRrRows.map { $0.ord })
+                        if !dupPairs.isEmpty { diagLine += "\n\(dupPairs) day=\(res.daily.day)" }
                         // #1331/#1008/#1118 SHADOW: log the DEDUPED stream's HRV + coverage + beat-accuracy
                         // beside the raw (above), so the candidate two-channel de-dup can be validated
                         // against WHOOP's own numbers and @artemc's Polar H10 BEFORE it becomes the read

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -664,6 +664,55 @@ object HrvAnalyzer {
     }
 
     /**
+     * #1505: when two deliveries wrote the same second, how do their two intervals COMPARE?
+     *
+     * [deliveryHistogram] counts how many deliveries wrote each second; it never looks at what they wrote.
+     * That is the measurement the R-R unit question turns on. A WHOOP 5 emits the beat train live over
+     * `0x2A37` (spec-fixed 1/1024-second units, converted on the way in) and again inside its v18
+     * historical record (stored as read). If those are the same beat in two units, a duplicated second
+     * holds two values 1024/1000 apart. If they are genuinely different beats, the ratios scatter.
+     *
+     * Restricted to the unambiguous case: seconds carrying EXACTLY two rows, both `ord == 0`. `ord`
+     * restarts per delivery, so that is two deliveries each contributing their first beat — not two
+     * consecutive beats from one record's array, which would read `0` then `1`.
+     *
+     * A single such pair proves nothing: 872 vs 893 ms is both the 1024/1000 ratio and an utterly ordinary
+     * beat-to-beat difference. A POPULATION of them separates the two — a tight cluster at 1.024 is a unit
+     * mismatch, a broad spread is normal variability. This reports the distribution and takes no view.
+     *
+     * Parts-per-thousand in integer arithmetic so Kotlin and Swift cannot round a tie differently.
+     * Twin of Swift `HRVAnalyzer.duplicatePairRatios`.
+     */
+    fun duplicatePairRatios(tsSec: List<Long>, rrMs: List<Double>, ords: List<Int?>): String {
+        val n = minOf(tsSec.size, rrMs.size, ords.size)
+        if (n == 0) return ""
+        val bySec = HashMap<Long, MutableList<Pair<Int, Int>>>()
+        for (i in 0 until n) {
+            val o = ords[i] ?: continue
+            val ms = msToInt(rrMs[i])
+            if (ms <= 0) continue
+            bySec.getOrPut(tsSec[i]) { ArrayList() }.add(ms to o)
+        }
+        val ppts = ArrayList<Int>()
+        for ((_, rows) in bySec) {
+            if (rows.size != 2 || rows[0].second != 0 || rows[1].second != 0) continue
+            val lo = minOf(rows[0].first, rows[1].first)
+            val hi = maxOf(rows[0].first, rows[1].first)
+            if (lo <= 0) continue
+            ppts.add((hi * 1000 + lo / 2) / lo)   // integer half-up, parts per thousand
+        }
+        if (ppts.isEmpty()) return "rr dupPairs n=0"
+        ppts.sort()
+        // Identical (both deliveries stored the same number), the 1024/1000 signature, or neither.
+        val same = ppts.count { it <= 1_005 }
+        val tick = ppts.count { it in 1_019..1_029 }
+        val med = if (ppts.size % 2 == 1) ppts[ppts.size / 2]
+                  else (ppts[ppts.size / 2 - 1] + ppts[ppts.size / 2]) / 2
+        return "rr dupPairs n=${ppts.size} same=$same tick=$tick" +
+            " other=${ppts.size - same - tick} medPPT=$med spread=${ppts[0]}-${ppts[ppts.size - 1]}"
+    }
+
+    /**
      * Beat-time milliseconds to a whole number, half-up, WITHOUT `round()` or `.rounded()`.
      *
      * `kotlin.math.round` is half-toward-positive-infinity and Swift's `.rounded()` is half-away-from-zero.

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -664,6 +664,24 @@ object HrvAnalyzer {
     }
 
     /**
+     * One second's worth of duplicate-pair bookkeeping: how many rows landed on it, the first two
+     * intervals, and whether every row claimed `ord == 0`. Only a second with EXACTLY two rows, both
+     * `ord 0`, is an unambiguous two-delivery pair — see [duplicatePairRatios]. Twin of Swift `PairTally`.
+     */
+    private class PairTally {
+        var count = 0
+        var first = 0
+        var second = 0
+        var allOrdZero = true
+        fun qualifies(): Boolean = count == 2 && allOrdZero
+        fun add(ms: Int, ord: Int) {
+            count += 1
+            if (count == 1) first = ms else if (count == 2) second = ms
+            if (ord != 0) allOrdZero = false
+        }
+    }
+
+    /**
      * #1505: when two deliveries wrote the same second, how do their two intervals COMPARE?
      *
      * [deliveryHistogram] counts how many deliveries wrote each second; it never looks at what they wrote.
@@ -686,20 +704,25 @@ object HrvAnalyzer {
     fun duplicatePairRatios(tsSec: List<Long>, rrMs: List<Double>, ords: List<Int?>): String {
         val n = minOf(tsSec.size, rrMs.size, ords.size)
         if (n == 0) return ""
-        val bySec = HashMap<Long, MutableList<Pair<Int, Int>>>()
+        // A tally per second rather than a list per second, matching `SecondTally` above: this runs over a
+        // whole night's beats on the same path, and the histogram beside it was deliberately reduced to one
+        // map and no per-second allocation for exactly that reason.
+        val bySec = HashMap<Long, PairTally>()
         for (i in 0 until n) {
             val o = ords[i] ?: continue
             val ms = msToInt(rrMs[i])
             if (ms <= 0) continue
-            bySec.getOrPut(tsSec[i]) { ArrayList() }.add(ms to o)
+            bySec.getOrPut(tsSec[i]) { PairTally() }.add(ms, o)
         }
         val ppts = ArrayList<Int>()
-        for ((_, rows) in bySec) {
-            if (rows.size != 2 || rows[0].second != 0 || rows[1].second != 0) continue
-            val lo = minOf(rows[0].first, rows[1].first)
-            val hi = maxOf(rows[0].first, rows[1].first)
+        for ((_, t) in bySec) {
+            if (!t.qualifies()) continue
+            val lo = minOf(t.first, t.second)
+            val hi = maxOf(t.first, t.second)
             if (lo <= 0) continue
-            ppts.add((hi * 1000 + lo / 2) / lo)   // integer half-up, parts per thousand
+            // Long so the multiply cannot overflow on a corrupt row — Kotlin's Int is 32-bit and would wrap
+            // where Swift's would not, and a diagnostic that disagrees across platforms is worthless.
+            ppts.add(((hi.toLong() * 1000L + lo / 2L) / lo.toLong()).toInt())   // half-up, parts per thousand
         }
         if (ppts.isEmpty()) return "rr dupPairs n=0"
         ppts.sort()

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -900,6 +900,13 @@ object IntelligenceEngine {
                     // across the WHOLE night, which is what decides whether the fix belongs at ingest.
                     val deliveries = HrvAnalyzer.deliveryHistogram(ts, sleepRr, sleepRrRows.map { it.ord })
                     if (deliveries.isNotEmpty()) dayDiag("$deliveries day=${res.daily.day}")
+                    // #1505: the histogram above counts deliveries per second but never compares what they
+                    // wrote. If the live and historical copies are the same beat in two units, a duplicated
+                    // second holds two values 1024/1000 apart; if they are different beats, the ratios
+                    // scatter. One pair cannot tell those apart — a night's worth can. Measurement only,
+                    // takes no view on the answer. Swift twin.
+                    val dupPairs = HrvAnalyzer.duplicatePairRatios(ts, sleepRr, sleepRrRows.map { it.ord })
+                    if (dupPairs.isNotEmpty()) dayDiag("$dupPairs day=${res.daily.day}")
                     // #1331/#1008/#1118 SHADOW: log the DEDUPED stream's HRV + coverage + beat-accuracy
                     // beside the raw so the candidate de-dup can be validated vs WHOOP + @artemc's Polar
                     // before it becomes the read path. Instrumentation only — shipped HRV/resp unchanged.

--- a/android/app/src/test/java/com/noop/analytics/DuplicatePairRatioTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DuplicatePairRatioTest.kt
@@ -1,0 +1,119 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1505: measure how the two copies of a duplicated second COMPARE, not merely that there are two.
+ *
+ * A WHOOP 5 emits the beat train live over `0x2A37` — spec-fixed 1/1024-second units, converted on the way
+ * in — and again inside its v18 historical record, stored as read. If those are the same beat in two units,
+ * a second written by two deliveries holds values 1024/1000 apart. If they are genuinely two beats, the
+ * ratios scatter across normal beat-to-beat variability.
+ *
+ * The field pair that raised the question, from #1451, is `-1s[872#0, 893#0]` — and 893 × 1000/1024 =
+ * 872.07. That single pair cannot decide anything: 21 ms is also an ordinary difference between consecutive
+ * beats. These tests pin that the measurement reports the distribution honestly in both directions, so a
+ * night's worth of pairs can answer what one cannot.
+ *
+ * Twin of Swift `HRVAnalyzerDuplicatePairTests`.
+ */
+class DuplicatePairRatioTest {
+
+    private val t0 = 1_780_000_000L
+
+    private fun run(rows: List<Triple<Long, Double, Int?>>) = HrvAnalyzer.duplicatePairRatios(
+        rows.map { it.first }, rows.map { it.second }, rows.map { it.third },
+    )
+
+    /** The real #1451 pair: two deliveries, one second, values exactly the 1024/1000 ratio apart. */
+    @Test fun theFieldPairIsCountedAsATickSignature() {
+        val out = run(listOf(Triple(t0, 872.0, 0), Triple(t0, 893.0, 0)))
+        assertTrue(out, out.contains("n=1"))
+        assertTrue(out, out.contains("tick=1"))
+        assertTrue(out, out.contains("other=0"))
+        assertEquals("1024", Regex("medPPT=(\\d+)").find(out)!!.groupValues[1])
+    }
+
+    /**
+     * The honesty requirement: an ordinary pair of DIFFERENT beats must not read as a unit mismatch. 872 vs
+     * 940 is a normal difference and lands outside the band — the measurement has to be able to say "no".
+     */
+    @Test fun anOrdinaryBeatToBeatDifferenceIsNotATickSignature() {
+        val out = run(listOf(Triple(t0, 872.0, 0), Triple(t0, 940.0, 0)))
+        assertTrue(out, out.contains("tick=0"))
+        assertTrue(out, out.contains("other=1"))
+    }
+
+    /** Two deliveries that stored the SAME number are exact duplicates, a different finding again. */
+    @Test fun anExactDuplicateIsCountedSeparately() {
+        val out = run(listOf(Triple(t0, 872.0, 0), Triple(t0, 872.0, 0)))
+        assertTrue(out, out.contains("same=1"))
+        assertTrue(out, out.contains("tick=0"))
+    }
+
+    /**
+     * Two CONSECUTIVE beats from one record's array read `ord` 0 then 1, and must be excluded — they are
+     * one delivery, so comparing them measures physiology rather than transports. This is the whole reason
+     * the pair test keys on `ord` rather than on "two rows share a second".
+     */
+    @Test fun consecutiveBeatsFromOneDeliveryAreExcluded() {
+        assertEquals("rr dupPairs n=0", run(listOf(Triple(t0, 872.0, 0), Triple(t0, 893.0, 1))))
+    }
+
+    /** A second carrying more than two rows is ambiguous about which copy pairs with which — skip it. */
+    @Test fun secondsWithMoreThanTwoRowsAreSkipped() {
+        assertEquals(
+            "rr dupPairs n=0",
+            run(listOf(Triple(t0, 872.0, 0), Triple(t0, 893.0, 0), Triple(t0, 880.0, 0))),
+        )
+    }
+
+    /** Rows with no `ord` (written before the column was surfaced) can't be attributed to a delivery. */
+    @Test fun rowsWithoutAnOrdAreIgnored() {
+        assertEquals("rr dupPairs n=0", run(listOf(Triple(t0, 872.0, null), Triple(t0, 893.0, null))))
+    }
+
+    /**
+     * Parity: the Swift twin must produce the SAME string for the same input, so a capture read on either
+     * platform is comparable. Pinned by value here and in `HRVAnalyzerDuplicatePairTests`.
+     */
+    @Test fun outputStringIsPinnedForParity() {
+        assertEquals(
+            "rr dupPairs n=1 same=0 tick=1 other=0 medPPT=1024 spread=1024-1024",
+            run(listOf(Triple(t0, 872.0, 0), Triple(t0, 893.0, 0))),
+        )
+    }
+
+    /**
+     * The shape that would actually settle #1505: many pairs, all clustering at the ratio. The spread is
+     * reported alongside the median so a tight cluster is distinguishable from a coincidental average.
+     */
+    @Test fun aPopulationOfTickPairsReportsATightSpread() {
+        val rows = ArrayList<Triple<Long, Double, Int?>>()
+        for (i in 0 until 10) {
+            val live = 850.0 + i * 7
+            rows.add(Triple(t0 + i, live, 0))
+            rows.add(Triple(t0 + i, live * 1024.0 / 1000.0, 0))   // the same beat, unconverted
+        }
+        val out = run(rows)
+        assertTrue(out, out.contains("n=10"))
+        assertTrue(out, out.contains("tick=10"))
+        val spread = Regex("spread=(\\d+)-(\\d+)").find(out)!!
+        assertTrue(out, spread.groupValues[2].toInt() - spread.groupValues[1].toInt() <= 2)
+    }
+
+    /** ...and a population of genuinely different beats must NOT read as a cluster. */
+    @Test fun aPopulationOfRealBeatsDoesNotReadAsTicks() {
+        val rows = ArrayList<Triple<Long, Double, Int?>>()
+        val second = listOf(910.0, 845.0, 990.0, 870.0, 935.0, 820.0, 960.0, 885.0, 1015.0, 830.0)
+        for (i in 0 until 10) {
+            rows.add(Triple(t0 + i, 900.0, 0))
+            rows.add(Triple(t0 + i, second[i], 0))
+        }
+        val out = run(rows)
+        assertTrue(out, out.contains("n=10"))
+        assertTrue(out, Regex("tick=(\\d+)").find(out)!!.groupValues[1].toInt() <= 2)
+    }
+}


### PR DESCRIPTION
Instrumentation for #1505. **No behaviour change, no storage change, nothing scored differently.**

## What it measures

#1505 asks whether WHOOP 5 v18 historical R-R is in 1/1024-second ticks rather than milliseconds. The
strap emits the beat train twice — live over `0x2A37`, which the BLE spec fixes at 1/1024 s and we convert
on the way in, and again inside its v18 record, which we store as read. If those are the same beat in two
units, a second written by two deliveries holds two values **1024/1000 apart**. If they're genuinely two
beats, the ratios scatter.

`deliveryHistogram` already counts *how many* deliveries wrote each second. It has never looked at *what
they wrote* — which is the measurement the question turns on.

`duplicatePairRatios` reports the distribution of those ratios and takes no view on the answer:

```
rr dupPairs n=14 same=0 tick=12 other=2 medPPT=1024 spread=1019-1043
```

Restricted to the unambiguous case — seconds carrying **exactly two rows, both `ord 0`**. `ord` restarts
per delivery, so that's two deliveries each contributing their first beat, not two consecutive beats from
one record's array (which read `0` then `1`).

## Why a measurement rather than the fix

One pair can't settle it. The field pair in #1451 is `-1s[872#0, 893#0]`, and 893 × 1000/1024 = 872.07 — an
exact hit. But 21 ms is also an entirely ordinary difference between consecutive beats, so **both readings
explain it**. A population separates them: a tight cluster at 1.024 is a unit mismatch, a broad spread is
physiology.

That's the discipline the PPG→HR estimate failed in #194, where one matching night looked like validation.
A 2.4% shift to stored R-R moves HRV and the RSA-derived respiratory rate on both platforms; it should
follow evidence, not precede it.

## Parity

Parts-per-thousand in integer arithmetic, and the output string is **pinned by value in both test suites**,
so a capture read on either platform is directly comparable and the twins can't drift. Deliberate: the
rounding of a tie has silently diverged between these two platforms twice before (#1476, #1486).

## Verification

9 Kotlin tests and 9 Swift twins — the real field pair, an ordinary beat-to-beat difference that must
**not** read as a mismatch, exact duplicates, consecutive beats from one delivery excluded, ambiguous
>2-row seconds skipped, rows with no `ord` ignored, and both population shapes.

Full Android suite: 4,182 tests, 0 failures. `doc_comment_lint` and `i18n_audit --ci` clean.

The Swift half lives in `StrandAnalytics`, which doesn't build on Linux (GRDB / `sqlite3.h`), so it's
validated by `swift-packages` CI rather than locally.

## What this doesn't do

It doesn't convert anything, and it doesn't touch the transport-tagging work @gdorgian has for #1008/#1118
— that stays theirs. It just produces the evidence both of those are waiting on.
