### PR TITLE
Show the steps-calibration prompt to the users it was written for (#1491)

### DIFF
--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -3606,10 +3606,13 @@ struct TodayView: View {
             // H6, only an ESTIMATED day (no real strap/phone count, so the on-device estimate filled in)
             // gets the calibration entry; a real measured count needs no calibration.
             let isEstimated = realSteps == nil && estSteps != nil
-            // #589, when the tile would be BLANK on a strap that estimates steps (WHOOP 4.0: the steps
-            // pipeline has run, so there's calibration state recorded) explain WHY rather than a bare ", ",
-            // and still expose the ⚙︎ so the user can reach the sheet to set a manual coefficient.
-            let needsCalibration = realSteps == nil && estSteps == nil && stepsPipelineActive
+            // #589, when the tile would be BLANK on a strap that estimates steps (a WHOOP 4.0 sends no
+            // step count) explain WHY rather than a bare "—", and still expose the ⚙︎ so the user can reach
+            // the sheet to set a manual coefficient. #1491: this used to require calibration state to
+            // already exist, which excluded every 4.0 owner who had not calibrated yet — see
+            // `stepsPipelineActive`.
+            let needsCalibration = realSteps == nil && estSteps == nil
+                && stepsPipelineActive(hasDayData: d != nil)
             StatTile(
                 label: "Steps",
                 value: realSteps ?? estSteps.map { intString(Double($0)) } ?? "—",
@@ -3863,13 +3866,32 @@ struct TodayView: View {
             .help(label)
     }
 
-    /// #589, true once the WHOOP-4.0 steps-ESTIMATE pipeline has run for this user, i.e. the
-    /// IntelligenceEngine has mirrored some calibration state into the profile (a fitted/manual
-    /// coefficient, OR a recorded count of overlapping phone-counted days while still gathering).
-    /// Gates the "needs calibration" affordance so a user whose strap reports real steps (5/MG) or who
-    /// has no strap at all never sees a steps-calibration prompt on a blank tile.
-    private var stepsPipelineActive: Bool {
-        profile.stepsCalibrationCoefficient > 0
+    /// #589, true when the WHOOP-4.0 steps-ESTIMATE pipeline applies to this user. Gates the "needs
+    /// calibration" affordance so a user whose strap reports real steps (5/MG) or who has no strap at all
+    /// never sees a steps-calibration prompt on a blank tile.
+    ///
+    /// #1491: the three profile fields below are all OUTPUTS of calibration — a fitted coefficient, a
+    /// manual one, or a count of overlapping phone-counted days. Testing only those made the affordance
+    /// unreachable for the exact user it was written for: a fresh 4.0 owner with no phone step history has
+    /// all three at zero, so the tile went blank with no explanation and no way through to the sheet that
+    /// would let them set a coefficient by hand. The prompt was gated on evidence that only exists once
+    /// the thing it is prompting for has already started.
+    ///
+    /// The strap itself answers the question that gate was reaching for — a 4.0 sends no step count, so it
+    /// always estimates — and it answers it on day one. The calibration state it is OR-ed with is
+    /// profile-global rather than per-strap, so both halves are measuring the same user either way.
+    ///
+    /// Read straight off the persisted selection rather than through `BLEManager.isWhoop4`: `TodayView`
+    /// holds no `AppModel`, and `BLEManager` writes this same key whenever the model changes
+    /// (`BLEManager.persistSelectedModel`), so the static is the same answer without the dependency.
+    ///
+    /// [hasDayData] is why the family term is not used alone: `WhoopModel.persisted` falls back to
+    /// `.whoop4` when nothing has been selected, so a user who has never paired anything reads as a 4.0
+    /// owner. Requiring a scored day for the date being shown keeps the "no strap at all" case the
+    /// original gate protected — a user with nothing recorded still sees no prompt.
+    private func stepsPipelineActive(hasDayData: Bool) -> Bool {
+        (WhoopModel.persisted.deviceFamily == .whoop4 && hasDayData)
+            || profile.stepsCalibrationCoefficient > 0
             || profile.stepsManualCoefficient > 0
             || profile.stepsCalibrationSampleDays > 0
     }


### PR DESCRIPTION
Fixes #1491 — steps stay blank on a WHOOP 4.0, with nothing on screen explaining why.

## Not a data bug

A WHOOP 4.0 **sends no step count**. NOOP estimates steps from strap motion and calibrates that against a
phone-measured reference, deliberately withholding the estimate until it has enough calibration days or a
manual coefficient. The reporter's WHOOP app import can't help — it supplies no phone step reference, which
is the one input calibration needs.

## The bug is that nothing said so

#589 added exactly the right thing: an explanation on the blank tile, plus the ⚙︎ shortcut into the sheet
where a coefficient can be set by hand. Neither reached the person who needs them.

```swift
private var stepsPipelineActive: Bool {
    profile.stepsCalibrationCoefficient > 0
        || profile.stepsManualCoefficient > 0
        || profile.stepsCalibrationSampleDays > 0
}
```

All three are **outputs of calibration**. A fresh 4.0 owner with no phone step history has all three at
zero — so the tile goes blank with no explanation and no route to the sheet. The prompt was gated on
evidence that only exists once the thing it prompts for has already started.

## Fix

The strap answers the question that gate was reaching for, and answers it on day one: a 4.0 always
estimates.

Guarded by whether a day has actually been scored, which is not incidental. `WhoopModel.persisted` falls
back to `.whoop4` when nothing has been selected, so a user who has never paired anything reads as a 4.0
owner — and the original gate's own comment says a user with no strap must never see this prompt.
Requiring a scored day for the date on screen keeps that promise. Without it this fix would have shown a
steps-calibration prompt to someone with no strap, which is a different bug, not a smaller one.

**Known residual, stated rather than hidden:** someone with no strap, the default model, and a scored day
imported from a source carrying no steps would still see the prompt. Narrow.

## The message this unblocks was already written for them

`StepsEstimateEngine.headline` carries a dedicated branch for the case where no day has both strap motion
and a phone-counted step total:

```swift
// A WHOOP 4.0 always streams motion, so on a 4.0 this is really "no phone step source connected" —
// the "Need N more days" countdown would never advance. Say what actually unblocks it instead.
if have == 0 {
    return "Connect your phone's step count to estimate steps"
}
```

That sentence is the actionable one for a fresh 4.0 owner, and it was **unreachable for exactly that
user**: `stepsCalibrationCaption` renders only when `needsCalibration` is true, which required
`sampleDays > 0` — and at `sampleDays > 0`, `have` is never 0.

Someone anticipated this reporter, wrote them the right sentence, and the gate hid it. This restores
intended behaviour rather than adding new behaviour.

## iOS only

The blank-tile prompt is an iOS feature (#589) Android never had — its steps captioning covers the
*estimated* tile, a different surface. That gap predates this and is untouched here.

## Verification

`app-build` green on both legs. `doc_comment_lint` and `i18n_audit --ci` clean. No new strings.

The first cut used `BLEManager.isWhoop4` and **did not compile** — `TodayView` holds no `AppModel`. It now
reads `WhoopModel.persisted` directly, which `BLEManager` writes on every model change. Worth stating
because `app-build` is the only thing that builds this target; nothing local catches it.

Not verified on a device. What this does for a real 4.0 owner with no phone steps is exactly what
@anwrgo6000-oss is placed to confirm.

Reported by @anwrgo6000-oss.

