### PR TITLE
Stop telling a calibrated user they need 0 more days, on both platforms (#1515)

### DIFF
--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -3899,7 +3899,18 @@ struct TodayView: View {
     /// #589, the honest one-liner for a blank, not-yet-calibrated Steps tile: how many more days the
     /// phone also has to count steps before an estimate appears. Built from the SAME engine descriptor
     /// Settings uses (`StepsEstimateEngine.CalibrationStatus`) so the wording matches across surfaces.
-    private var stepsCalibrationCaption: String {
+    /// nil once a coefficient exists, because the headline's countdown is `max(0, need - have)` and a
+    /// calibrated user is already past `need` — so this said "Need 0 more days where your phone also
+    /// counted steps" on any day the estimate came out blank. That is a quiet day below the engine's
+    /// motion floor, not a missing input: the fit exists, that day simply did not move enough to earn a
+    /// number, and there is nothing for the user to go and do. `StatTile.caption` is optional, so nil
+    /// renders NO caption rather than falling back to "today" — which would be its own small lie on a past
+    /// day being browsed.
+    /// Twin of the Kotlin `stepsCalibrationPrompt` guard (#1514).
+    private var stepsCalibrationCaption: String? {
+        guard profile.stepsCalibrationCoefficient <= 0, profile.stepsManualCoefficient <= 0 else {
+            return nil
+        }
         let status = StepsEstimateEngine.CalibrationStatus.needsMoreDays(
             have: profile.stepsCalibrationSampleDays,
             need: StepsEstimateEngine.minCalibrationDays)

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3610,7 +3610,17 @@ private fun stepsCalibrationPrompt(context: Context, profileStore: ProfileStore)
     // not move enough to earn a number, and there is nothing for the user to go and do. Saying otherwise
     // would render "Need 0 more days where your phone also counted steps", because the headline's
     // countdown is max(0, need - have) and a calibrated user is already past `need`.
-    if (profileStore.stepsCalibrationCoefficient > 0.0 || profileStore.stepsCalibrationManual) return null
+    // All three, because the first two are ENGINE outputs — written on the next analyze pass — while
+    // [ProfileStore.stepsManualCoefficient] is what the user just typed. Checking only the outputs told
+    // someone who had hand-set a coefficient to go connect a phone step source, for up to a scoring cycle
+    // afterwards. That is the same shape as the bug this whole prompt exists to fix (#1491): gating on
+    // evidence the app produces later, rather than on what the user has already done.
+    if (profileStore.stepsCalibrationCoefficient > 0.0 ||
+        profileStore.stepsCalibrationManual ||
+        profileStore.stepsManualCoefficient > 0.0
+    ) {
+        return null
+    }
     return StepsEstimateEngine.CalibrationStatus.NeedsMoreDays(
         have = profileStore.stepsCalibrationSampleDays,
         need = StepsEstimateEngine.MIN_CALIBRATION_DAYS,


### PR DESCRIPTION
Fixes the iOS half of #1515 — a calibrated user being told they "Need 0 more days".

## The bug

`StepsEstimateEngine.CalibrationStatus.needsMoreDays` renders its countdown as `max(0, need - have)`, and a
user with a fitted or manual coefficient is already past `need`. So on any day the estimate came out blank,
the Steps tile read:

> Need 0 more days where your phone also counted steps

That's not a missing input. It's a quiet day below the engine's motion floor — the fit exists, that day
simply didn't move enough to earn a number, and there is nothing for the user to go and do.

## Fix

`stepsCalibrationCaption` returns nil once a coefficient exists, and the tile falls back to its ordinary
caption.

**Only the wording changes.** `needsCalibration` is untouched, so the ⚙︎ into the calibration sheet still
appears on such a day. The text was wrong; the affordance wasn't. Removing it would have been a second
change wearing the first one's clothes.

`StatTile.caption` is already `String?`, so nil renders **no caption** — the call site is unchanged and the
mixed ternary promotes to `String?`. An earlier cut of this fell back to `"today"`, which is its own small
lie on a past day being browsed.

## Parity

Twin of the Kotlin guard shipped in #1514, which returns null in the same case. Kotlin has no gear on the
tile at all — #1515 tracks that separately — so after this the platforms differ in what *remains* on a
quiet day, not in what they *say*.

## Android too: check what the user set, not only what the engine wrote

The Android guard merged in #1514 tested `stepsCalibrationCoefficient` and `stepsCalibrationManual`. Both
are **engine outputs**, written on the next analyze pass. `stepsManualCoefficient` is the field the user
actually types into.

So between hand-setting a coefficient and the next scoring cycle, a blank day still told them to connect a
phone step source — advice for a state they had just left. That's the same shape as the bug this prompt
exists to fix (#1491): gating on evidence the app produces later rather than on what the user has already
done. I reproduced it inside the fix for it.

The iOS half checks `stepsManualCoefficient` and never had the gap; this brings Kotlin level.

## Verification

`app-build` green on both legs; Android 4,182 tests, 0 failures. `doc_comment_lint` and `i18n_audit --ci`
clean. No new strings.

Not device-verified: reproducing it needs a calibrated WHOOP 4.0 and a day quiet enough to fall below the
motion floor.


