### PR TITLE
Trim capability and key-metric tokens on read (#1518)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
@@ -230,7 +230,21 @@ public struct DeviceRegistryStore: Sendable {
     }
 
     private static func decode(_ row: Row) -> PairedDevice {
-        var caps = Set((row["capabilities"] as String).split(separator: ",").compactMap { Metric(rawValue: String($0)) })
+        // #1518: TRIM before matching. `Metric(rawValue:)` is exact, so a stored `"hr, hrv"` decoded to
+        // `{hr}` — the whitespace-bearing token simply failed to parse and `compactMap` dropped it, losing
+        // a real capability with nothing reporting it. Writes here are always canonical
+        // (`map(\.rawValue).sorted().joined`), so a spaced token can only arrive from history: rows the
+        // v36 migration rewrote before #1495 taught it to trim, or a restored backup.
+        //
+        // Fixing it on READ rather than with another migration is deliberate. A migration repairs the rows
+        // that exist when it runs, once; trimming here self-heals every row every time it is read, including
+        // any that arrive later from a restore. Kotlin never needed this — it keeps `capabilities` as a
+        // String and normalises it at the registry layer, so it has no typed decode to lose anything in.
+        var caps = Set(
+            (row["capabilities"] as String)
+                .split(separator: ",")
+                .compactMap { Metric(rawValue: $0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+        )
         // #548: calibrated SpO₂ % is never produced from a live WHOOP path — drop a stale registry bit
         // so Devices / day-owner UI never advertise a capability AnalyticsEngine will not fill.
         let brand = row["brand"] as String

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/DeviceRegistryStoreTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/DeviceRegistryStoreTests.swift
@@ -9,6 +9,28 @@ final class DeviceRegistryStoreTests: XCTestCase {
         return dbq
     }
 
+    /// #1518: a stored row carrying whitespace still names real capabilities, and every one of them must
+    /// survive the decode.
+    ///
+    /// Written with raw SQL on purpose: `add` always joins canonical rawValues, so it cannot reproduce the
+    /// state this guards. A spaced token reaches the column from history — the v36 migration rewrote rows
+    /// in place before #1495 taught it to trim, so an upgraded install can be holding exactly this — or
+    /// from a restored backup.
+    ///
+    /// Before the fix `Metric(rawValue:)` matched exactly, so every spaced token failed to parse and
+    /// `compactMap` dropped it: this row decoded to `{hr}` alone, silently losing three capabilities.
+    func testDecodeTrimsWhitespaceBearingCapabilityTokens() throws {
+        let dbq = try makeDB()
+        try dbq.write { db in
+            try db.execute(sql: "UPDATE pairedDevice SET capabilities = ? WHERE id = 'my-whoop'",
+                           arguments: ["hr, hrv,\tskinTemp , spo2 , sleep"])
+        }
+        let store = DeviceRegistryStore(dbQueue: dbq)
+        let device = try XCTUnwrap(store.all().first(where: { $0.id == "my-whoop" }))
+        // spo2 is absent because a WHOOP row drops calibrated SpO₂ (#548) — not because it failed to parse.
+        XCTAssertEqual(device.capabilities, [.hr, .hrv, .skinTemp, .sleep])
+    }
+
     func testSeededWhoopIsActive() throws {
         let store = DeviceRegistryStore(dbQueue: try makeDB())
         let devices = try store.all()

--- a/Strand/Data/KeyMetricPrefs.swift
+++ b/Strand/Data/KeyMetricPrefs.swift
@@ -72,7 +72,17 @@ enum KeyMetricPrefs {
         var seen = Set<KeyMetric>()
         var result: [KeyMetric] = []
         for token in trimmed.split(separator: ",") {
-            if let m = KeyMetric(rawValue: String(token)), seen.insert(m).inserted {
+            // #1518: trim EACH token, not just the whole string. `KeyMetric(rawValue:)` matches exactly, so
+            // "charge, effort" dropped `effort` on the space alone. Kotlin's twin already does this
+            // (`KeyMetric.fromRaw(token.trim())`), as does `DashboardCards.decodeEnabled`, so Swift was the
+            // only decoder that could lose a tile the user had enabled.
+            //
+            // Latent rather than live: `encode` joins rawValues with no spaces, and this key is not in the
+            // `.noopbak` whitelist, so nothing in the app writes a spaced value today. It is fixed because
+            // a decoder that silently drops what it cannot parse should not also be picky about a space —
+            // the capabilities decoder in this same change was exactly that, and there it WAS reachable.
+            let raw = token.trimmingCharacters(in: .whitespaces)
+            if let m = KeyMetric(rawValue: raw), seen.insert(m).inserted {
                 result.append(m)
             }
         }

--- a/StrandTests/KeyMetricPrefsDecodeTests.swift
+++ b/StrandTests/KeyMetricPrefsDecodeTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import Strand
+
+/// #1518: `decodeEnabled` trimmed the whole string but not each token, so a single space cost the user a
+/// tile they had enabled.
+///
+/// `KeyMetric(rawValue:)` matches exactly, so `"charge, effort"` decoded to `[charge]` — the space made
+/// `" effort"` unparseable and the loop dropped it silently. Kotlin's twin already trimmed per token
+/// (`KeyMetric.fromRaw(token.trim())`), as does `DashboardCards.decodeEnabled`, so Swift was the only
+/// decoder of the three that could lose an enabled tile.
+///
+/// Latent rather than live: `encode` joins rawValues with no spaces and this key is not carried in
+/// `.noopbak`, so nothing in the app writes a spaced value today. These pin the contract anyway, because
+/// the cost of the assumption is silent and the fix is a single call.
+final class KeyMetricPrefsDecodeTests: XCTestCase {
+
+    /// The regression: spaced tokens are real selections and must survive.
+    func testSpacedTokensStillDecode() {
+        XCTAssertEqual(KeyMetricPrefs.decodeEnabled("charge, effort"),
+                       KeyMetricPrefs.decodeEnabled("charge,effort"))
+    }
+
+    /// Order is the user's saved order and must be preserved through the trim.
+    func testOrderSurvivesTrimming() {
+        let spaced = KeyMetricPrefs.decodeEnabled("effort , charge")
+        let tight = KeyMetricPrefs.decodeEnabled("effort,charge")
+        XCTAssertEqual(spaced, tight)
+        XCTAssertEqual(spaced.first, tight.first)
+    }
+
+    /// De-duplication still keys on the metric, not the raw text, so a spaced repeat is still a repeat.
+    func testSpacedDuplicateIsStillDeduped() {
+        XCTAssertEqual(KeyMetricPrefs.decodeEnabled("charge, charge").count, 1)
+    }
+
+    /// An unknown token is still dropped — trimming must not turn junk into a match.
+    func testUnknownTokensAreStillDropped() {
+        XCTAssertEqual(KeyMetricPrefs.decodeEnabled("charge, notAMetric"),
+                       KeyMetricPrefs.decodeEnabled("charge"))
+    }
+
+    /// An empty or whitespace-only string still yields the full default order (a fresh install).
+    func testBlankStringStillYieldsTheDefaultOrder() {
+        XCTAssertEqual(KeyMetricPrefs.decodeEnabled("   "), KeyMetric.defaultOrder)
+        XCTAssertEqual(KeyMetricPrefs.decodeEnabled(""), KeyMetric.defaultOrder)
+    }
+}


### PR DESCRIPTION
Fixes #1518 — the half of the capability-token problem that #1495 couldn't reach.

## The bug

`Metric(rawValue:)` matches exactly, so `DeviceRegistryStore.decode` silently lost metrics:

```swift
Set((row["capabilities"] as String).split(separator: ",").compactMap { Metric(rawValue: String($0)) })
```

A row stored as `"hr, hrv"` decodes to `{hr}` — `" hrv"` fails to parse and `compactMap` drops it. A real
capability disappears with nothing reporting it.

#1495 taught `stripSpo2Token` to trim, which fixed the migration that **writes** the column. This fixes the
**read** that consumes it.

## Where a spaced token comes from

Writes here are always canonical — `map(\.rawValue).sorted().joined(separator: ",")` — so it can't
originate locally. It arrives from history: rows the `v36-whoop-caps-no-spo2` migration rewrote *before*
#1495 taught it to trim, or a restored backup.

`v36` shipped **2026-08-15**, and migrations are one-time and versioned. Any device that has opened the app
since is holding exactly that string, and no migration will visit it again.

## Why a read fix rather than another migration

A migration repairs the rows that exist when it runs, once. Trimming on read self-heals **every** row
**every** time it's read, including rows that arrive later from a restore.

## A second decoder, found by reviewing this one

`KeyMetricPrefs.decodeEnabled` trimmed the whole string and then matched each token exactly, so
`"charge, effort"` decoded to `[charge]` — the space made `" effort"` unparseable and the loop dropped it,
losing a tile the user had enabled. Kotlin's twin already trims per token, as does
`DashboardCards.decodeEnabled`; Swift was the only one of the three that could lose a selection to a space.

**This one is latent, unlike the capabilities case.** `encode` joins rawValues with no spaces and the key
isn't carried in `.noopbak`, so nothing writes a spaced value today — whereas the v36 migration
demonstrably did. Fixed anyway because the failure is silent, and pinned by five tests — of which two (`testSpacedTokensStillDecode`, `testOrderSurvivesTrimming`) fail
on the old code; the other three guard against *over*-trimming and pass either way.

I'd originally written that trimming on read "makes the class impossible". That was too strong: it closes
*this* decode, and the class had another live member I hadn't looked for.

## Swift only, and not for convenience

Kotlin keeps `capabilities` as a `String` throughout and normalises it at the registry layer
(`DeviceRegistry.honestWhoopCapabilities` → `stripSpo2Token`, which trims). It has **no typed decode** to
lose anything in, so there is no twin to write. That asymmetry is the whole reason one trim fixed Kotlin's
entire problem and only part of Swift's.

## A third divergence, considered and declined

`decodeEnabled` also differs on the all-unknown path: Swift returns `[]`, Kotlin returns
`KeyMetric.defaultOrder`. On Apple that would mean an empty Key Metrics grid where Android shows the
defaults.

Left alone deliberately. `encode` only ever emits valid rawValues joined by commas, so reaching it needs
either every case renamed at once — partial staleness doesn't count, both platforms return the surviving
subset — or a corrupt value like `",,,"`. Nothing the app produces gets there, unlike the capabilities case
in this PR, where the v36 migration demonstrably wrote spaced strings to real devices.

Recorded rather than fixed, so it isn't rediscovered as new.

## Verification

The test writes its row with raw SQL on purpose: `add` always joins canonical rawValues and so cannot
reproduce the state being guarded. It **fails on the old code**, where `"hr, hrv,\tskinTemp , spo2 , sleep"`
decodes to `{hr}` alone and three capabilities vanish.

It also pins that `spo2` is absent for the right reason — the #548 WHOOP strip — rather than because it
failed to parse.

`WhoopStore` links GRDB and doesn't build on Linux, so `swift-packages` CI (`test (WhoopStore)`) is what
validates this; `doc_comment_lint` clean.
