### PR TITLE
Hand off to the standing connect on the first drop, not the third (#1413)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -920,12 +920,22 @@ public final class BLEManager: NSObject, ObservableObject {
     // The old reconnect armed a `DispatchQueue.main.asyncAfter` backoff, which does not fire in a suspended
     // app AND — the real damage — left NOTHING outstanding with CoreBluetooth after a failed connect, so iOS
     // had no reason to ever wake the app. Overnight that meant the strap stayed unreachable for hours
-    // (measured 10h46m on a 5/MG). After a few quick timed retries (the app is demonstrably awake there) the
-    // reconnect now hands off to a STANDING `central.connect`, which has no timeout, stays outstanding, and
-    // lets iOS wake the app when the strap re-advertises — including from suspension.
+    // (measured 10h46m on a 5/MG). The reconnect hands off to a STANDING `central.connect`, which has no
+    // timeout, stays outstanding, and lets iOS wake the app when the strap re-advertises — from suspension.
+    //
+    // #1413 follow-up: it hands off on the FIRST drop, not the third. Gating the handoff behind three
+    // consecutive failures made it unreachable in the case it was written for. A drop while suspended wakes
+    // the app just long enough to run the disconnect callback; that armed a 3-second timer and returned to
+    // suspension, where the timer never fires — so the attempt counter never reached two, let alone three,
+    // and nothing was outstanding with CoreBluetooth in the meantime. The escalation could only be reached
+    // by an app that was already awake, which is exactly when it is least needed. Reported with a measured
+    // overnight failure and this diagnosis by @justinjor-bit.
+    //
+    // A standing connect is passive — no timeout, no scan, nothing written to the strap — so issuing it
+    // immediately costs nothing that a timed retry was protecting against. The one shape that can hot-loop,
+    // a connect that fails near-instantly, is still broken by `standingConnectAfter`, and that can only
+    // happen with the app awake.
 
-    /// After this many consecutive failures, stop scheduling timed retries and leave a standing connect.
-    nonisolated static let standingConnectAfterAttempts = 3
     /// Floor between two standing connects, used ONLY for a near-instant failure (proves the app is awake).
     nonisolated static let standingConnectRetryFloor: TimeInterval = 30
     /// A standing connect that stayed outstanding at least this long before failing was not a hot loop —
@@ -937,20 +947,16 @@ public final class BLEManager: NSObject, ObservableObject {
     /// What to do after an involuntary drop or a failed connect. Pure so the policy is unit-testable with no
     /// CoreBluetooth (`BLEManagerReconnectPolicyTests`). Twin of `OuraLiveSource.ReconnectStep`.
     enum ReconnectStep: Equatable, Sendable {
-        case timedRetry(delay: TimeInterval)
         case standingConnect
         case standingConnectAfter(delay: TimeInterval)
     }
 
-    /// - Parameters:
-    ///   - attempt: 1-based consecutive failure count (`failedConnectAttempts` after incrementing).
-    ///   - secondsSinceStandingConnect: age of the outstanding standing connect, or nil when none is.
-    nonisolated static func reconnectStep(attempt: Int,
-                                          secondsSinceStandingConnect: TimeInterval?) -> ReconnectStep {
-        guard attempt >= standingConnectAfterAttempts else {
-            return .timedRetry(delay: min(60.0, 3.0 * pow(2.0, Double(max(0, attempt - 1)))))
-        }
-        // No standing connect outstanding reads as "long ago", so the first time here we hand off immediately.
+    /// - Parameter secondsSinceStandingConnect: age of the outstanding standing connect, nil when none is.
+    ///
+    /// The consecutive-failure count used to gate this and no longer does: see the note above. It is not a
+    /// parameter any more precisely so the handoff cannot be made conditional on being awake again.
+    nonisolated static func reconnectStep(secondsSinceStandingConnect: TimeInterval?) -> ReconnectStep {
+        // No standing connect outstanding reads as "long ago", so the first drop hands off immediately.
         let since = secondsSinceStandingConnect ?? .greatestFiniteMagnitude
         // Anything but a near-instant failure re-issues NOW, so suspension can never catch us holding nothing.
         guard since < standingConnectFastFailureS else { return .standingConnect }
@@ -963,14 +969,8 @@ public final class BLEManager: NSObject, ObservableObject {
     private func scheduleReconnect() {
         guard !intentionalDisconnect, !autoReconnectPausedForBondLoop else { return }
         failedConnectAttempts += 1
-        switch Self.reconnectStep(attempt: failedConnectAttempts,
-                                  secondsSinceStandingConnect: standingConnectAt.map { Date().timeIntervalSince($0) }) {
-        case .timedRetry(let delay):
-            log("Reconnecting in \(Int(delay))s (attempt \(failedConnectAttempts))")
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-                guard let self, !self.intentionalDisconnect, !self.autoReconnectPausedForBondLoop else { return }
-                self.connectFromSystem()
-            }
+        switch Self.reconnectStep(
+            secondsSinceStandingConnect: standingConnectAt.map { Date().timeIntervalSince($0) }) {
         case .standingConnect:
             issueStandingConnect()
         case .standingConnectAfter(let wait):

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -5012,12 +5012,13 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         }
         // Any other connect failure (e.g. a weak-signal encrypted-handshake timeout on a 5/MG at the
         // edge of range — #414). The disconnect path reschedules a rescan, but didFailToConnect never
-        // did, so the loop died here until a manual reconnect. Reschedule with a capped exponential
-        // backoff (3, 6, 12, 24, 48, 60s…) so a strap that's genuinely out of range doesn't hammer BLE.
+        // did, so the loop died here until a manual reconnect.
         // #747: don't reschedule while the bond-loop pause is active; the user must free the strap first.
-        // #1413: hand off to the shared standing-connect regime. The first few failures still get the short
-        // timed backoff (the app is awake), then a standing central.connect stays outstanding so a suspended
-        // app is still woken when the strap returns — this callback is where the overnight reconnect died.
+        // #1413: hand off to the shared standing-connect regime — from the FIRST failure, not after a few
+        // timed retries. A standing central.connect stays outstanding, so a suspended app is still woken
+        // when the strap returns; this callback is where the overnight reconnect died. Out-of-range
+        // hammering is held off by the bond-loop pause and the refusal streak rather than by a timer,
+        // because a passive `central.connect` is not what hammers a strap.
         scheduleReconnect()
     }
 

--- a/StrandTests/BLEManagerReconnectPolicyTests.swift
+++ b/StrandTests/BLEManagerReconnectPolicyTests.swift
@@ -2,45 +2,57 @@ import XCTest
 @testable import Strand
 
 /// The WHOOP reconnect policy after an involuntary drop or a failed connect — twin of
-/// `OuraReconnectPolicyTests` (#1413, the #1286 fix ported). The old `DispatchQueue.main.asyncAfter` backoff
-/// does not fire in a suspended app and, after `didFailToConnect`, left NOTHING outstanding with
-/// CoreBluetooth — so an overnight drop stayed dead for hours (measured 10h46m50s on a 5/MG). After a few
-/// quick timed retries (the app is awake there) the policy hands off to a standing `central.connect`.
+/// `OuraReconnectPolicyTests` (#1413).
+///
+/// The original `DispatchQueue.main.asyncAfter` backoff does not fire in a suspended app and, after
+/// `didFailToConnect`, left NOTHING outstanding with CoreBluetooth — so an overnight drop stayed dead for
+/// hours (measured 10h46m50s on a 5/MG). The first fix handed off to a standing `central.connect`, but only
+/// after three consecutive failures, which made it unreachable in the case it was written for: a drop while
+/// suspended wakes the app just long enough to arm a 3-second timer that then never fires, so the counter
+/// never reaches three and nothing is outstanding meanwhile. The handoff now happens on the FIRST drop.
 ///
 /// ⚠️ These test the POLICY, not the plumbing. Whether a standing `central.connect` really survives
 /// suspension on a real phone is a hardware question and is owed a strap night.
 final class BLEManagerReconnectPolicyTests: XCTestCase {
 
-    /// The app is awake when the first callbacks land, so the short backoff still gets its chance to fix a
-    /// transient blip (3s, 6s — unchanged from #414).
-    func testEarlyAttemptsUseTheShortTimedBackoff() {
-        XCTAssertEqual(BLEManager.reconnectStep(attempt: 1, secondsSinceStandingConnect: nil),
-                       .timedRetry(delay: 3))
-        XCTAssertEqual(BLEManager.reconnectStep(attempt: 2, secondsSinceStandingConnect: nil),
-                       .timedRetry(delay: 6))
-    }
-
-    /// THE REGRESSION TEST. After `standingConnectAfterAttempts` (3) failures the reconnect must hand off to
-    /// CoreBluetooth, never schedule another swallowed timer — attempt 3 is where the night died.
-    func testThirdFailureHandsOffToAStandingConnect() {
-        XCTAssertEqual(BLEManager.reconnectStep(attempt: 3, secondsSinceStandingConnect: nil),
-                       .standingConnect)
-        XCTAssertEqual(BLEManager.reconnectStep(attempt: 9, secondsSinceStandingConnect: nil),
-                       .standingConnect)
+    /// THE REGRESSION TEST. The first drop must hand off to CoreBluetooth immediately. Anything else is a
+    /// timer, and a timer is what the suspended app swallows — this is the state the night died in.
+    func testFirstDropHandsOffImmediately() {
+        XCTAssertEqual(BLEManager.reconnectStep(secondsSinceStandingConnect: nil), .standingConnect)
     }
 
     /// A standing connect that stayed outstanding a while before failing (the `Failed to encrypt the
     /// connection` shape this strap produces after 7–11s) is re-issued IMMEDIATELY, so a suspension can never
     /// catch us holding nothing.
     func testSlowStandingFailureReissuesImmediately() {
-        XCTAssertEqual(BLEManager.reconnectStep(attempt: 4, secondsSinceStandingConnect: 8),
-                       .standingConnect)
+        XCTAssertEqual(BLEManager.reconnectStep(secondsSinceStandingConnect: 8), .standingConnect)
     }
 
     /// Only a near-instant failure — which proves the app is awake and could hot-loop — gets a timer, floored
     /// so it can't hammer the radio while awake.
     func testInstantStandingFailureIsFlooredWithATimer() {
-        XCTAssertEqual(BLEManager.reconnectStep(attempt: 4, secondsSinceStandingConnect: 1),
+        XCTAssertEqual(BLEManager.reconnectStep(secondsSinceStandingConnect: 1),
                        .standingConnectAfter(delay: BLEManager.standingConnectRetryFloor - 1))
+    }
+
+    /// The boundary itself: at exactly the fast-failure threshold the connect stayed up long enough to count
+    /// as a real attempt, so it re-issues rather than waiting.
+    func testAtTheFastFailureBoundaryItReissues() {
+        XCTAssertEqual(BLEManager.reconnectStep(
+            secondsSinceStandingConnect: BLEManager.standingConnectFastFailureS), .standingConnect)
+    }
+
+    /// No path returns a bare timer any more. The only timer left is floored and reachable only while awake,
+    /// so there is no arrangement of inputs that leaves CoreBluetooth holding nothing.
+    func testNoInputProducesAnUnbackedTimer() {
+        for since in [nil, 0, 0.5, 1.9, 2, 8, 60, 3600] as [TimeInterval?] {
+            switch BLEManager.reconnectStep(secondsSinceStandingConnect: since) {
+            case .standingConnect:
+                continue                                   // something is outstanding
+            case .standingConnectAfter(let d):
+                XCTAssertLessThanOrEqual(d, BLEManager.standingConnectRetryFloor, "since=\(String(describing: since))")
+                XCTAssertGreaterThan(d, 0, "since=\(String(describing: since))")
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes the reachability hole in #1413's own fix: the standing connect could not be reached from the state it
was written for.

## The hole

`reconnectStep` escalated to a standing `central.connect` only at `attempt >= 3`. Attempts 1 and 2 took a
`DispatchQueue.main.asyncAfter` timed retry — the exact mechanism #1286 diagnosed as not firing in a
suspended app.

Trace a drop that happens **while suspended**, which is the whole scenario:

1. The disconnect callback briefly wakes the app → `scheduleReconnect()` → attempt **1** → arms a 3s timer.
2. The app re-suspends. The timer never fires.
3. Nothing was handed to CoreBluetooth — only `issueStandingConnect` calls `central.connect`.
4. iOS has no reason to wake the app. Dead until opened by hand.

The counter never reaches 2, let alone 3. The escalation was reachable only by an app that was **already
awake** — precisely when it is least needed. The code asserted the opposite invariant in a comment
("suspension can never catch us holding nothing"), which held at attempt ≥ 3 and not at 1 or 2.

## How it was caught

@justinjor-bit ran two nights on the identical build. One died; one survived 20:28→05:34 with ~60
uninterrupted offloads. He then pointed out that the surviving night contained **no `Leaving a STANDING
connect outstanding` line at all** — it never entered the state that needs this, so it was not evidence the
handoff works. His structural claim, that the escalation cannot be reached from suspension by construction,
is correct, and the code above is why.

## The change

Hand off on the **first** drop. A standing `central.connect` is passive — no timeout, no scan, nothing
written to the strap — so issuing it immediately costs nothing the timed backoff was protecting against.
The attempt gate is gone, and with it the `timedRetry` case only that gate could return.

The one shape that can hot-loop, a connect failing near-instantly, is still broken by `standingConnectAfter`
— and by construction that only happens with the app awake.

`reconnectStep` no longer takes the attempt count. Not tidiness: it's gone so the handoff can't be made
conditional on being awake again.

## Testability side benefit

The standing connect logs `Leaving a STANDING connect outstanding` whenever it arms, so from now on a strap
log shows the mechanism engaging rather than leaving it to be inferred. That line's *absence* is how the
reporter established his second night hadn't tested it.

## Verification

`app-build` green on both legs. StrandTests ran on the macOS leg: **1,188 executed, 1 skipped, 0 failures**,
and I confirmed the rewritten cases are in the log rather than merely compiled.

Five policy tests, including one that walks the whole input domain and asserts **no** arrangement returns an
unbacked timer.

**Still owed a strap night.** Whether a standing `central.connect` really survives suspension on real
hardware is a hardware question these tests cannot answer — they pin the policy, not the platform.
@justinjor-bit has offered a deliberate "don't touch the app all day" run, which is the only way to enter
the dead state on purpose.

## Related, not fixed here

`OuraLiveSource` has the identical policy with the same `standingConnectAfterAttempts = 3` gate, so #1286
has the same hole. Left alone deliberately: that path has field validation I can't reproduce, and it should
change on its own evidence rather than by analogy. Worth its own issue.
