### PR TITLE
fix(oura): stop the ring's live-HR daytime-HR mode from running while nobody is looking

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Commands.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Commands.swift
@@ -115,10 +115,27 @@ public enum OuraCommands {
         OuraCommand(label: "dhr_subscribe", bytes: [0x2F, 0x03, 0x26, featureDaytimeHR, 0x02])
     }
 
-    /// Disable live HR: `2f 03 22 02 01`. ACK: `2f 03 23 02 00`; stream stops on ACK.
-    /// Per OURA_PROTOCOL.md s5.6.
+    /// Disable live HR: `2f 03 22 02 00`. ACK: `2f 03 23 02 00`.
+    /// Mode byte is **0x00** ("off" per OURA_PROTOCOL.md s7.2's APK-sourced table), not 0x01
+    /// ("automatic") — an earlier build wrote 0x01 here on the mistaken belief it meant "off"; s7.4's
+    /// own worked example shows mode=1 read back while daytime-HR is actively streaming, and two
+    /// consecutive real-hardware nights (08-17/18, 08-18/19) falsified "stream stops on ACK" for that
+    /// byte — green 0x80 kept arriving all night at reduced but non-zero volume, matching "automatic"
+    /// mode's own adaptive/motion-triggered sampling rather than a true off. Per OURA_PROTOCOL.md s5.6.
     public static func liveHRDisable() -> OuraCommand {
-        OuraCommand(label: "dhr_disable", bytes: [0x2F, 0x03, 0x22, featureDaytimeHR, 0x01])
+        OuraCommand(label: "dhr_disable", bytes: [0x2F, 0x03, 0x22, featureDaytimeHR, 0x00])
+    }
+
+    /// Unsubscribe from live-HR pushes: `2f 03 26 02 00`. ACK: `2f 03 27 02 00`.
+    /// The enable triplet's step 3 (`liveHRSubscribe`) leaves the ring subscribed at "latest" (byte2 =
+    /// 2); nothing ever wrote it back to "off" before this — `liveHRDisable` alone only touches the
+    /// feature MODE byte, not the subscription. Send both together when suspending live HR so no
+    /// notification channel is left standing open for the ring's own adaptive sampling to push through.
+    /// Safe to send any time the driver has reached `.streaming`: its ACK shares subop 0x27 with the
+    /// subscribe step's ACK, which `OuraDriver.nextStep(after: .enableAckReceived)` no-ops outside
+    /// `.enablingLiveHR` (same reasoning as `liveHRDisable`'s ACK routing). Per OURA_PROTOCOL.md s5.6/7.2.
+    public static func liveHRUnsubscribe() -> OuraCommand {
+        OuraCommand(label: "dhr_unsubscribe", bytes: [0x2F, 0x03, 0x26, featureDaytimeHR, 0x00])
     }
 
     // MARK: - Feature-status diagnostics (READ-ONLY; s5.6 / s7.1)

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraDriverTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraDriverTests.swift
@@ -696,6 +696,17 @@ final class OuraDriverTests: XCTestCase {
         XCTAssertEqual(OuraCommands.syncTime(unixSeconds: 0, tzHalfHours: -4).bytes.last, 0xFC)
     }
 
+    func testLiveHRDisableWritesModeOffNotAutomatic() {
+        // 0x00 = "off" per OURA_PROTOCOL.md s7.2's APK-sourced feature-mode table; 0x01 is "automatic"
+        // and was falsified on two hardware nights (green 0x28 kept arriving after the old 0x01 write).
+        XCTAssertEqual(OuraCommands.liveHRDisable().bytes, [0x2F, 0x03, 0x22, 0x02, 0x00])
+    }
+
+    func testLiveHRUnsubscribeWritesSubscriptionOff() {
+        // Matching teardown for the enable triplet's step 3 (subscribe "latest" = 0x02).
+        XCTAssertEqual(OuraCommands.liveHRUnsubscribe().bytes, [0x2F, 0x03, 0x26, 0x02, 0x00])
+    }
+
     // MARK: - Dangerous commands are isolated and labelled
 
     func testDangerousCommandsAreClearlyNamed() {

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -1014,6 +1014,14 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// line would evict the very evidence this change exists to capture.
     private var loggedLiveHRSuspend = false
 
+    /// Logged-once latch (per suspend episode) for a live-HR push arriving AFTER we believe the ring is
+    /// suspended — the direct falsification signal for `disableLiveHRForSuspend`. 08-17/18 found the
+    /// PREVIOUS design (stop re-engaging, rely on the ring's daytime-HR mode auto-reverting ~20 s after
+    /// the last keep-alive per OURA_PROTOCOL.md s5.7) does not stop the stream: green 0x80 ran 1,700-3,600
+    /// per hour all night, including inside a genuinely stable, reconnect-free 3.5 h stretch, so nothing
+    /// had ever told the ring to stop. Reset alongside `loggedLiveHRSuspend` in `handleScreenCameBack`.
+    private var loggedUnexpectedLiveHRWhileSuspended = false
+
     /// NotificationCenter tokens for the screen-state observers, removed on deinit.
     private var screenStateObservers: [NSObjectProtocol] = []
 
@@ -1181,6 +1189,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         let wasSuspended = loggedLiveHRSuspend
         screenOffAt = nil
         loggedLiveHRSuspend = false
+        loggedUnexpectedLiveHRWhileSuspended = false
         guard wasSuspended else { return }
         log("Oura: live-HR re-engage RESUMED - screen on")
         guard reachedStreaming, driver != nil else { return }   // a reconnect will arm it at .streaming
@@ -1352,8 +1361,16 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 reachedStreaming = true
                 adoptPhase = .streaming   // re-auth after an install (or a normal auth) reached the stream: adoption complete
                 pendingInstallKey = nil   // an OK ack already persisted the key; nothing left in flight
-                if feedsLive { live.streamingLiveHR = true }   // drive the green menu-bar STREAMING pill (no WHOOP bond)
-                log("Oura: live-HR enabled - streaming HR / IBI")
+                // The driver's own auth-success path (OuraDriver.nextStep, .authCompleted(.success)) has no
+                // suspend awareness - it unconditionally re-runs the live-HR enable triplet on EVERY connect,
+                // including a reconnect during a suspended night (08-17/18: 25 reconnects, green never hit
+                // zero any hour). Only claim the stream is wanted, and only start the keep-alive, when the
+                // screen is actually on; startReengageTimer's own suspended guard sends the explicit disable
+                // that undoes what the triplet above just armed.
+                if !liveHRSuspended {
+                    if feedsLive { live.streamingLiveHR = true }   // drive the green menu-bar STREAMING pill (no WHOOP bond)
+                    log("Oura: live-HR enabled - streaming HR / IBI")
+                }
                 startReengageTimer()
                 startHistoryFetchTimer()
                 // §5.3 step 1 / open_oura sync recipe: hand the ring the current UTC BEFORE draining
@@ -1592,6 +1609,14 @@ public final class OuraLiveSource: NSObject, ObservableObject {
             switch e {
             case .hr(let hr):
                 guard hr.bpm >= 30, hr.bpm <= 220 else { continue }   // physiological gate
+                // Direct falsification signal for `disableLiveHRForSuspend`: a push arriving AFTER we
+                // believe the ring is suspended means the disable did not take (or the ring re-armed on its
+                // own). Logged once per suspend episode, not once per push, per the strap log's clip budget.
+                if liveHRSuspended, !loggedUnexpectedLiveHRWhileSuspended {
+                    loggedUnexpectedLiveHRWhileSuspended = true
+                    log("Oura: live-HR push arrived while SUSPENDED (\(hr.bpm) bpm) - dhr_disable did not "
+                        + "stop the stream")
+                }
                 // Drop the first (settling) live-HR sample of the session — it is frequently an artifact.
                 // The value is never shown or persisted; the NEXT sample becomes the first real reading.
                 if !droppedFirstLiveHR {
@@ -1946,6 +1971,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         stopReengageTimer()
         guard !liveHRSuspended else {
             logLiveHRSuspendOnce()
+            disableLiveHRForSuspend()
             return
         }
         let t = Timer.scheduledTimer(withTimeInterval: reengageInterval, repeats: true) { [weak self] _ in
@@ -1967,6 +1993,23 @@ public final class OuraLiveSource: NSObject, ObservableObject {
             + "ring free to run its own night suite (history fetch continues every \(Int(historyFetchInterval))s)")
     }
 
+    /// Actively turn daytime-HR mode off rather than merely declining to re-arm it. `reengageLiveHR`'s own
+    /// doc cites a ~20 s auto-revert (OURA_PROTOCOL.md s5.7) as the reason "just stop poking it" should be
+    /// enough - 08-17/18 falsified that for THIS build: green 0x80 never collapsed, any hour, including a
+    /// stable 3.5 h stretch with zero reconnects, so nothing was ever telling the ring to stop. `dhr_disable`
+    /// (`OuraCommands.liveHRDisable`, `Commands.swift`) existed but was called from nowhere before this.
+    /// Its ACK shares subop 0x23 with the enable triplet's step-2 ACK, so `handleSecureFrame` routes it to
+    /// the same `.enableAck` case; `OuraDriver.nextStep(after: .enableAckReceived)` no-ops outside
+    /// `.enablingLiveHR`, so sending it while the driver is idle/streaming is a harmless read-only-shaped
+    /// write, not a state-machine hazard. Only fires when the driver actually reached `.streaming` this
+    /// session; there is nothing to disable before then. NOT yet hardware-validated - the next capture
+    /// needs to show green 0x80 actually collapse after SUSPENDED fires, not just that we sent the write.
+    private func disableLiveHRForSuspend() {
+        guard let driver, driver.phase == .streaming else { return }
+        write([OuraCommands.liveHRDisable()])
+        if feedsLive { live.streamingLiveHR = false }
+    }
+
     /// Re-send the live-HR enable+subscribe so the ~20 s auto-revert never silently stops the stream.
     /// Skipped while a history drain is in flight: the Oura app never runs live mode during a sync, and
     /// interleaving enable writes with the batch stream is off-model noise (live HR resumes on the next
@@ -1981,6 +2024,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         if liveHRSuspended {
             stopReengageTimer()
             logLiveHRSuspendOnce()
+            disableLiveHRForSuspend()
             return
         }
         guard let driver, reachedStreaming, driver.phase != .fetchingHistory else { return }

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -933,7 +933,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
 
     /// When the screen went off (iOS: the app was backgrounded — locking the phone does that too; macOS:
     /// the displays slept). nil whenever the user is present. Set on the FIRST such notification and left
-    /// alone by repeats, so the 15-minute clock measures the real absence, not the last notification.
+    /// alone by repeats, so the grace clock measures the real absence, not the last notification.
     ///
     /// ALSO SEEDED AT INIT (`seedScreenOffFromLaunchState`), which is not a nicety: the notification is an
     /// EDGE, and a process launched *into* the background never posts it — it was never in the foreground
@@ -955,10 +955,16 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// those confounded the re-engage with link loss, which is what this change removes: the phone stays
     /// close and connected, the history fetch stays at 300 s, and the ONLY variable is the re-engage.
     ///
-    /// The 15-minute grace is not physiology, it is courtesy: a glance-and-pocket must not cost the user
+    /// The 5-minute grace is not physiology, it is courtesy: a glance-and-pocket must not cost the user
     /// their live HR for the rest of the evening, and the ring re-enters daytime mode within one tick of
     /// the screen coming back. Overnight the grace is irrelevant — the screen is off for hours.
-    private let liveHRSuspendDelay: TimeInterval = 900
+    ///
+    /// Was 900 s (15 min) through the 2026-08-16/17 retest, which validated the SEEDING mechanism but left
+    /// the grace itself unmeasured (the covered window only showed the suspend arming close to a 02:2x
+    /// restart, ~3-3.5 h after a plausible bedtime — consistent with either grace value on that data alone).
+    /// Shortened to narrow the unmeasured pre-suspend window on the next capture; 5 min still comfortably
+    /// exceeds a genuine glance-and-pocket.
+    private let liveHRSuspendDelay: TimeInterval = 300
 
     /// True once the screen has been off long enough that the ring should be left alone. Everything else
     /// keys off this one predicate, so the suspend and the resume can never disagree about the rule.
@@ -971,7 +977,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     ///
     /// - Parameters:
     ///   - screenOffAt: when the screen went dark, nil while the user is present.
-    ///   - now: the clock, injected so a test need not sleep for 15 minutes.
+    ///   - now: the clock, injected so a test need not sleep for the grace window.
     ///   - delay: the grace window.
     nonisolated static func shouldSuspendLiveHR(screenOffAt: Date?, now: Date, delay: TimeInterval) -> Bool {
         guard let off = screenOffAt else { return false }
@@ -986,7 +992,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     ///
     /// GRACE SEMANTICS, chosen deliberately. A background launch inherits an absence of UNKNOWN length —
     /// the screen may have been dark for eight hours. Two readings were available: stamp `now`, giving
-    /// each launch a fresh 15-minute courtesy window; or stamp a time already past the grace, suspending
+    /// each launch a fresh courtesy window; or stamp a time already past the grace, suspending
     /// at the first tick. This returns the LATTER, because the courtesy window exists for a user who
     /// glanced at live HR and pocketed the phone — and that user's app was in the FOREGROUND. A process
     /// iOS woke for BLE has no such user, and the field evidence makes the difference decisive rather
@@ -1935,7 +1941,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// Arm the re-engage tick — unless the screen has already been off past the grace window. That guard
     /// is what makes the suspend survive a reconnect: an overnight drop that re-reaches `.streaming` at
     /// 03:00 comes straight back through here, and without the guard it would silently restart the very
-    /// stream the suspend exists to stop (and then only stop again 15 minutes later, once per drop).
+    /// stream the suspend exists to stop (and then only stop again a grace window later, once per drop).
     private func startReengageTimer() {
         stopReengageTimer()
         guard !liveHRSuspended else {
@@ -1966,7 +1972,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// interleaving enable writes with the batch stream is off-model noise (live HR resumes on the next
     /// 15 s tick after the drain returns to `.streaming`).
     private func reengageLiveHR() {
-        // The tick is its own executioner, and deliberately so. A one-shot Timer armed for +15 min at
+        // The tick is its own executioner, and deliberately so. A one-shot Timer armed for +grace at
         // screen-off is not trustworthy on iOS: a backgrounded app can be suspended and that timer may
         // simply never fire, which would silently produce a night that looks like the old build. This
         // tick, by contrast, is the one thing we have measured running all night (~3,900 commands), so

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -934,6 +934,14 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// When the screen went off (iOS: the app was backgrounded — locking the phone does that too; macOS:
     /// the displays slept). nil whenever the user is present. Set on the FIRST such notification and left
     /// alone by repeats, so the 15-minute clock measures the real absence, not the last notification.
+    ///
+    /// ALSO SEEDED AT INIT (`seedScreenOffFromLaunchState`), which is not a nicety: the notification is an
+    /// EDGE, and a process launched *into* the background never posts it — it was never in the foreground
+    /// to leave it. That is exactly the overnight path this build runs, since #1215's CoreBluetooth
+    /// state-restoration identifier has iOS relaunch NOOP for BLE while the phone is locked. Left nil,
+    /// such a process reads "the user is present" forever and re-engages all night, which is
+    /// indistinguishable from the build that has no suspend at all — the 2026-08-15/16 night was voided
+    /// for exactly that reason.
     private var screenOffAt: Date?
 
     /// How long the screen stays off before the live-HR re-engage is suspended.
@@ -968,6 +976,31 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     nonisolated static func shouldSuspendLiveHR(screenOffAt: Date?, now: Date, delay: TimeInterval) -> Bool {
         guard let off = screenOffAt else { return false }
         return now.timeIntervalSince(off) >= delay
+    }
+
+    /// What `screenOffAt` must be at construction time, given whether the screen is ALREADY dark.
+    ///
+    /// Factored out for the same reason as `shouldSuspendLiveHR`: the class owns a `CBCentralManager` and
+    /// cannot be built in a unit test, so the only way to pin the background-launch case is to test the
+    /// decision rather than the constructor.
+    ///
+    /// GRACE SEMANTICS, chosen deliberately. A background launch inherits an absence of UNKNOWN length —
+    /// the screen may have been dark for eight hours. Two readings were available: stamp `now`, giving
+    /// each launch a fresh 15-minute courtesy window; or stamp a time already past the grace, suspending
+    /// at the first tick. This returns the LATTER, because the courtesy window exists for a user who
+    /// glanced at live HR and pocketed the phone — and that user's app was in the FOREGROUND. A process
+    /// iOS woke for BLE has no such user, and the field evidence makes the difference decisive rather
+    /// than academic: the voided night's `report.txt` holds FOUR separate app sessions, so a fresh grace
+    /// per launch is a relaunch storm resetting the clock forever and never suspending at all.
+    ///
+    /// A background launch while the phone is merely unlocked-and-elsewhere costs nothing: opening NOOP
+    /// posts `didBecomeActive`, which clears this and re-engages immediately (`handleScreenCameBack`).
+    ///
+    /// - Returns: nil when the user is present (the ordinary foreground launch — `handleScreenWentDark`
+    ///   will start the clock honestly when they leave), else a stamp already `delay` old.
+    nonisolated static func seedScreenOffAt(screenIsDark: Bool, now: Date, delay: TimeInterval) -> Date? {
+        guard screenIsDark else { return nil }
+        return now.addingTimeInterval(-delay)
     }
 
     /// Logged-once latch, so the suspend prints a single line per screen-off rather than one per tick.
@@ -1049,6 +1082,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         self.central = CBCentralManager(delegate: self, queue: nil)
         #endif
         installScreenStateObservers()
+        seedScreenOffFromLaunchState()
     }
 
     deinit {
@@ -1088,6 +1122,41 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         screenStateObservers.append(center.addObserver(forName: light, object: nil, queue: .main) { [weak self] _ in
             Task { @MainActor in self?.handleScreenCameBack() }
         })
+        #endif
+    }
+
+    /// Close the hole the notifications leave: they are EDGES, and a process launched straight into the
+    /// background never posts the one we care about. So at construction, ASK the platform for the current
+    /// state instead of assuming the app is on screen.
+    ///
+    /// Only the PERSISTENT source seeds, matching `installScreenStateObservers` — the discovery-only wizard
+    /// scanner never streams live HR and has nothing to suspend. It is called AFTER the observers are
+    /// installed so there is no window in which a state change could be missed, and it writes `screenOffAt`
+    /// exactly once, before any notification can fire on the main actor; `handleScreenWentDark`'s
+    /// `screenOffAt == nil` guard then leaves the seeded value alone, which is what we want — a background
+    /// launch that is later backgrounded again must not restart the clock.
+    private func seedScreenOffFromLaunchState() {
+        guard feedsLive else { return }
+        screenOffAt = Self.seedScreenOffAt(screenIsDark: Self.screenIsDarkNow(),
+                                           now: Date(), delay: liveHRSuspendDelay)
+    }
+
+    /// Is the screen the user would have to be looking at dark RIGHT NOW? The platform question mirrors
+    /// `installScreenStateObservers` exactly, so the seed and the notifications can never disagree.
+    ///
+    /// iOS asks for `.background` specifically, not `!= .active`. A normal foreground cold launch builds
+    /// this source while the app is still `.inactive` and only then becomes active; reading that as "dark"
+    /// would seed a suspend on every ordinary launch. `.background` is the precise question — did this
+    /// process start without ever coming to the foreground — and a background launch reports it.
+    private static func screenIsDarkNow() -> Bool {
+        #if os(iOS)
+        return UIApplication.shared.applicationState == .background
+        #elseif os(macOS)
+        // NSWorkspace publishes screen sleep only as a notification, so the current state comes from
+        // CoreGraphics instead (AppKit re-exports it). Same question the screensDidSleep observer answers.
+        return CGDisplayIsAsleep(CGMainDisplayID()) != 0
+        #else
+        return false
         #endif
     }
 

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -1996,17 +1996,30 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// Actively turn daytime-HR mode off rather than merely declining to re-arm it. `reengageLiveHR`'s own
     /// doc cites a ~20 s auto-revert (OURA_PROTOCOL.md s5.7) as the reason "just stop poking it" should be
     /// enough - 08-17/18 falsified that for THIS build: green 0x80 never collapsed, any hour, including a
-    /// stable 3.5 h stretch with zero reconnects, so nothing was ever telling the ring to stop. `dhr_disable`
-    /// (`OuraCommands.liveHRDisable`, `Commands.swift`) existed but was called from nowhere before this.
-    /// Its ACK shares subop 0x23 with the enable triplet's step-2 ACK, so `handleSecureFrame` routes it to
-    /// the same `.enableAck` case; `OuraDriver.nextStep(after: .enableAckReceived)` no-ops outside
-    /// `.enablingLiveHR`, so sending it while the driver is idle/streaming is a harmless read-only-shaped
-    /// write, not a state-machine hazard. Only fires when the driver actually reached `.streaming` this
-    /// session; there is nothing to disable before then. NOT yet hardware-validated - the next capture
-    /// needs to show green 0x80 actually collapse after SUSPENDED fires, not just that we sent the write.
+    /// stable 3.5 h stretch with zero reconnects, so nothing was ever telling the ring to stop. This
+    /// function was added to send an explicit disable, but 08-18/19's hardware run falsified THAT too:
+    /// green ran in 11 of 12 hours, just at ~3.3x lower volume, including a mid-night resumption with no
+    /// reconnect logged in between - not the connect-time-only leak the first cut assumed.
+    ///
+    /// Root cause found by re-reading OURA_PROTOCOL.md s7.2's APK-sourced feature-mode table:
+    /// `liveHRDisable()` was writing mode byte **0x01**, which that table defines as "automatic", NOT
+    /// "off" (0x00). s7.4's own worked example even shows mode=1 read back while daytime-HR is actively
+    /// streaming. So the old write downgraded the ring from forced-always-on (`connected_live`, mode 3)
+    /// to its own adaptive/motion-triggered sampling mode, not to off - which matches the observed
+    /// pattern (reduced but non-zero volume, scattered through the night, no reconnect needed to resume)
+    /// far better than a keep-alive-wearing-off theory. Fixed at the source (`Commands.swift`): the mode
+    /// byte is now 0x00. Also added `liveHRUnsubscribe()` alongside it: the enable triplet's step 3 left
+    /// the ring subscribed at "latest" and nothing ever unsubscribed, so a live channel stayed open
+    /// independent of the mode byte. Both ACKs share subop with an enable-triplet step (0x23 / 0x27), so
+    /// `handleSecureFrame` routes them to `.enableAck`; `OuraDriver.nextStep(after: .enableAckReceived)`
+    /// no-ops outside `.enablingLiveHR`, so sending them while the driver is idle/streaming is a harmless
+    /// read-only-shaped write, not a state-machine hazard. Only fires when the driver actually reached
+    /// `.streaming` this session; there is nothing to disable before then. NOT yet hardware-validated -
+    /// the next capture needs to show green 0x80 actually collapse after SUSPENDED fires, this time with
+    /// the corrected mode byte and the unsubscribe write both in place.
     private func disableLiveHRForSuspend() {
         guard let driver, driver.phase == .streaming else { return }
-        write([OuraCommands.liveHRDisable()])
+        write([OuraCommands.liveHRDisable(), OuraCommands.liveHRUnsubscribe()])
         if feedsLive { live.streamingLiveHR = false }
     }
 

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -5,6 +5,13 @@ import Security
 import WhoopProtocol
 import WhoopStore
 import OuraProtocol
+// The live-HR suspend listens for the screen going dark, which is a UIKit notification on iOS and an
+// NSWorkspace one on macOS (see installScreenStateObservers).
+#if os(iOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
 
 /// EXPERIMENTAL, ISOLATED live-BLE source for the Oura ring (gen 3/4/5), driven by the clean-room
 /// `OuraProtocol.OuraDriver`.
@@ -922,6 +929,55 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     private var reengageTimer: Timer?
     private let reengageInterval: TimeInterval = 15
 
+    // MARK: - Live-HR suspend while nobody is looking
+
+    /// When the screen went off (iOS: the app was backgrounded — locking the phone does that too; macOS:
+    /// the displays slept). nil whenever the user is present. Set on the FIRST such notification and left
+    /// alone by repeats, so the 15-minute clock measures the real absence, not the last notification.
+    private var screenOffAt: Date?
+
+    /// How long the screen stays off before the live-HR re-engage is suspended.
+    ///
+    /// WHY THIS EXISTS. Re-engaging every 15 s does not merely read the ring — it HOLDS it in daytime-HR
+    /// mode. Across 10 nights the correlation between our overnight re-engage count and the ring running
+    /// its own night suite is r = -0.91: on the nights NOOP re-engaged all night the ring's `0x43` log
+    /// shows `check_sleep -> not needed` every 300 s and `DHR_mode:3` throughout, so it never produced
+    /// SpO2, a hypnogram, or `0x6A` sleep_period. The one night our LINK BROKE is the night the ring
+    /// worked; 2026-08-13/14 (phone deliberately far, same 300 s build) restored the suite x23. Both of
+    /// those confounded the re-engage with link loss, which is what this change removes: the phone stays
+    /// close and connected, the history fetch stays at 300 s, and the ONLY variable is the re-engage.
+    ///
+    /// The 15-minute grace is not physiology, it is courtesy: a glance-and-pocket must not cost the user
+    /// their live HR for the rest of the evening, and the ring re-enters daytime mode within one tick of
+    /// the screen coming back. Overnight the grace is irrelevant — the screen is off for hours.
+    private let liveHRSuspendDelay: TimeInterval = 900
+
+    /// True once the screen has been off long enough that the ring should be left alone. Everything else
+    /// keys off this one predicate, so the suspend and the resume can never disagree about the rule.
+    private var liveHRSuspended: Bool {
+        Self.shouldSuspendLiveHR(screenOffAt: screenOffAt, now: Date(), delay: liveHRSuspendDelay)
+    }
+
+    /// Pure policy so it is testable without a `CBCentralManager` (this class owns one and cannot be built
+    /// in a test — the same reason `reconnectStep` is factored out).
+    ///
+    /// - Parameters:
+    ///   - screenOffAt: when the screen went dark, nil while the user is present.
+    ///   - now: the clock, injected so a test need not sleep for 15 minutes.
+    ///   - delay: the grace window.
+    nonisolated static func shouldSuspendLiveHR(screenOffAt: Date?, now: Date, delay: TimeInterval) -> Bool {
+        guard let off = screenOffAt else { return false }
+        return now.timeIntervalSince(off) >= delay
+    }
+
+    /// Logged-once latch, so the suspend prints a single line per screen-off rather than one per tick.
+    /// The strap log is generation-clipped (a 14 h night once clipped to 21 min), so an all-night periodic
+    /// line would evict the very evidence this change exists to capture.
+    private var loggedLiveHRSuspend = false
+
+    /// NotificationCenter tokens for the screen-state observers, removed on deinit.
+    private var screenStateObservers: [NSObjectProtocol] = []
+
     // MARK: - Init
 
     /// - Parameters:
@@ -992,6 +1048,75 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         // Strand (macOS desktop): no state-restoration identifier (iOS background feature).
         self.central = CBCentralManager(delegate: self, queue: nil)
         #endif
+        installScreenStateObservers()
+    }
+
+    deinit {
+        for token in screenStateObservers {
+            NotificationCenter.default.removeObserver(token)
+            #if os(macOS)
+            NSWorkspace.shared.notificationCenter.removeObserver(token)
+            #endif
+        }
+    }
+
+    // MARK: - Screen-state observers (drive the live-HR suspend)
+
+    /// Watch for the user going away and coming back. Only the PERSISTENT source listens: the discovery-only
+    /// wizard scanner (`feedsLive == false`) never streams live HR, so it has nothing to suspend.
+    ///
+    /// The two platforms ask different questions on purpose. On iOS, backgrounding IS the signal — locking
+    /// the phone backgrounds the app, and so does switching away, and both mean the same thing here (nobody
+    /// is looking at the live HR). On macOS, app-resign would be wrong: switching to another window leaves
+    /// NOOP visible on screen, so the Mac waits for the DISPLAYS to sleep instead. Same rule either way —
+    /// suspend when the screen the user would have to be looking at has gone dark.
+    private func installScreenStateObservers() {
+        guard feedsLive else { return }
+        #if os(iOS)
+        let center = NotificationCenter.default
+        let dark = UIApplication.didEnterBackgroundNotification
+        let light = UIApplication.didBecomeActiveNotification
+        #elseif os(macOS)
+        let center = NSWorkspace.shared.notificationCenter
+        let dark = NSWorkspace.screensDidSleepNotification
+        let light = NSWorkspace.screensDidWakeNotification
+        #endif
+        #if os(iOS) || os(macOS)
+        screenStateObservers.append(center.addObserver(forName: dark, object: nil, queue: .main) { [weak self] _ in
+            Task { @MainActor in self?.handleScreenWentDark() }
+        })
+        screenStateObservers.append(center.addObserver(forName: light, object: nil, queue: .main) { [weak self] _ in
+            Task { @MainActor in self?.handleScreenCameBack() }
+        })
+        #endif
+    }
+
+    /// Start (never restart) the absence clock. Repeat notifications must not push the deadline out, or a
+    /// phone that backgrounds twice would keep re-arming the grace and never actually suspend. Deliberately
+    /// silent: this fires every time the app is backgrounded, and the strap log is clip-budgeted — only the
+    /// suspend itself, which happens once a night, is worth a line.
+    private func handleScreenWentDark() {
+        guard screenOffAt == nil else { return }
+        screenOffAt = Date()
+    }
+
+    /// The user is back: clear the clock, and if we had actually suspended, put live HR back immediately
+    /// rather than making them watch a blank tile for up to 15 s.
+    private func handleScreenCameBack() {
+        let wasSuspended = loggedLiveHRSuspend
+        screenOffAt = nil
+        loggedLiveHRSuspend = false
+        guard wasSuspended else { return }
+        log("Oura: live-HR re-engage RESUMED - screen on")
+        guard reachedStreaming, driver != nil else { return }   // a reconnect will arm it at .streaming
+        // Restart the removal watchdog's grace window from NOW. `lastLivePulseAt` is hours old after a
+        // suspended night — not because the ring came off, but because we stopped asking — so the immediate
+        // re-engage below would otherwise trip the watchdog and flash "Off-wrist" on every morning unlock.
+        // Re-stamping (rather than clearing) keeps the detection alive: 40 s from now with still no beat is
+        // a genuine off-finger and still reports as one.
+        lastLivePulseAt = Date()
+        startReengageTimer()
+        reengageLiveHR()
     }
 
     // MARK: - Scanning
@@ -1738,8 +1863,16 @@ public final class OuraLiveSource: NSObject, ObservableObject {
 
     // MARK: - Re-engagement timer (daytime-HR auto-reverts ~20s)
 
+    /// Arm the re-engage tick — unless the screen has already been off past the grace window. That guard
+    /// is what makes the suspend survive a reconnect: an overnight drop that re-reaches `.streaming` at
+    /// 03:00 comes straight back through here, and without the guard it would silently restart the very
+    /// stream the suspend exists to stop (and then only stop again 15 minutes later, once per drop).
     private func startReengageTimer() {
         stopReengageTimer()
+        guard !liveHRSuspended else {
+            logLiveHRSuspendOnce()
+            return
+        }
         let t = Timer.scheduledTimer(withTimeInterval: reengageInterval, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.reengageLiveHR() }
         }
@@ -1751,11 +1884,30 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         reengageTimer = nil
     }
 
+    /// The suspend announcement, printed once per screen-off rather than once per tick.
+    private func logLiveHRSuspendOnce() {
+        guard !loggedLiveHRSuspend else { return }
+        loggedLiveHRSuspend = true
+        log("Oura: live-HR re-engage SUSPENDED - screen off \(Int(liveHRSuspendDelay / 60)) min, leaving the "
+            + "ring free to run its own night suite (history fetch continues every \(Int(historyFetchInterval))s)")
+    }
+
     /// Re-send the live-HR enable+subscribe so the ~20 s auto-revert never silently stops the stream.
     /// Skipped while a history drain is in flight: the Oura app never runs live mode during a sync, and
     /// interleaving enable writes with the batch stream is off-model noise (live HR resumes on the next
     /// 15 s tick after the drain returns to `.streaming`).
     private func reengageLiveHR() {
+        // The tick is its own executioner, and deliberately so. A one-shot Timer armed for +15 min at
+        // screen-off is not trustworthy on iOS: a backgrounded app can be suspended and that timer may
+        // simply never fire, which would silently produce a night that looks like the old build. This
+        // tick, by contrast, is the one thing we have measured running all night (~3,900 commands), so
+        // hanging the suspend off it makes the suspend as reliable as the behaviour it stops. Cost is at
+        // most one extra tick of overshoot.
+        if liveHRSuspended {
+            stopReengageTimer()
+            logLiveHRSuspendOnce()
+            return
+        }
         guard let driver, reachedStreaming, driver.phase != .fetchingHistory else { return }
         write(driver.reengageLiveHRCommands())
         // Live-HR watchdog: if the stream has gone silent past the grace window while we were WORN, the

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -1609,13 +1609,26 @@ public final class OuraLiveSource: NSObject, ObservableObject {
             switch e {
             case .hr(let hr):
                 guard hr.bpm >= 30, hr.bpm <= 220 else { continue }   // physiological gate
-                // Direct falsification signal for `disableLiveHRForSuspend`: a push arriving AFTER we
-                // believe the ring is suspended means the disable did not take (or the ring re-armed on its
-                // own). Logged once per suspend episode, not once per push, per the strap log's clip budget.
-                if liveHRSuspended, !loggedUnexpectedLiveHRWhileSuspended {
-                    loggedUnexpectedLiveHRWhileSuspended = true
-                    log("Oura: live-HR push arrived while SUSPENDED (\(hr.bpm) bpm) - dhr_disable did not "
-                        + "stop the stream")
+                // Direct falsification signal for `disableLiveHRForSuspend`, AND the self-heal for the one
+                // gap 2026-08-21's hardware run found: enforcement is polled on `reengageLiveHR`'s 15 s
+                // tick (deliberately, see that function's doc — a one-shot timer at grace-expiry is not
+                // trustworthy backgrounded on iOS), so there is an up-to-15 s window right as the grace
+                // expires where `liveHRSuspended` has flipped true but the tick that would send
+                // `dhr_disable` hasn't landed yet. A push arriving in exactly that window used to just get
+                // logged and let through (16/16 OTHER reconnects that same night were clean — this is the
+                // one case the tick-based enforcement can't beat). `startReengageTimer()` runs the exact
+                // stop-and-disable transition `reengageLiveHR()` would eventually run anyway; calling it
+                // here just runs it now instead of up to 15 s late, closing the gap without touching the
+                // grace period itself. Log line stays latched once per suspend episode (strap log clip
+                // budget); the resend is not — safe to repeat, `disableLiveHRForSuspend` is a harmless
+                // read-only-shaped write when already streaming-or-not per its own doc.
+                if liveHRSuspended {
+                    if !loggedUnexpectedLiveHRWhileSuspended {
+                        loggedUnexpectedLiveHRWhileSuspended = true
+                        log("Oura: live-HR push arrived while SUSPENDED (\(hr.bpm) bpm) - dhr_disable did not "
+                            + "stop the stream, self-healing now")
+                    }
+                    startReengageTimer()
                 }
                 // Drop the first (settling) live-HR sample of the session — it is frequently an artifact.
                 // The value is never shown or persisted; the NEXT sample becomes the first real reading.
@@ -2014,9 +2027,16 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// `handleSecureFrame` routes them to `.enableAck`; `OuraDriver.nextStep(after: .enableAckReceived)`
     /// no-ops outside `.enablingLiveHR`, so sending them while the driver is idle/streaming is a harmless
     /// read-only-shaped write, not a state-machine hazard. Only fires when the driver actually reached
-    /// `.streaming` this session; there is nothing to disable before then. NOT yet hardware-validated -
-    /// the next capture needs to show green 0x80 actually collapse after SUSPENDED fires, this time with
-    /// the corrected mode byte and the unsubscribe write both in place.
+    /// `.streaming` this session; there is nothing to disable before then.
+    ///
+    /// 2026-08-21 overnight hardware result: mostly works. 16/16 reconnects during the main overnight
+    /// SUSPENDED window were clean (connect -> enable -> immediate same-second disable, zero leaks) -
+    /// the connect-time race above is fixed. One falsifier hit remained, at a suspend-ARM boundary (not
+    /// a reconnect): `reengageLiveHR`'s 15 s tick is what actually calls this function, so there is an
+    /// up-to-15 s window right as the grace expires where a push can land after `liveHRSuspended` flips
+    /// true but before the next tick gets here. Closed by having the push handler itself (the `.hr` case
+    /// in `ingest`) call `startReengageTimer()` - which runs this exact stop-and-disable transition - the
+    /// moment it sees a stale push, instead of waiting for the tick. Not yet hardware-validated.
     private func disableLiveHRForSuspend() {
         guard let driver, driver.phase == .streaming else { return }
         write([OuraCommands.liveHRDisable(), OuraCommands.liveHRUnsubscribe()])

--- a/StrandTests/OuraLiveHRSuspendPolicyTests.swift
+++ b/StrandTests/OuraLiveHRSuspendPolicyTests.swift
@@ -15,7 +15,7 @@ import XCTest
 /// them.
 final class OuraLiveHRSuspendPolicyTests: XCTestCase {
 
-    private let delay: TimeInterval = 900   // the 15-minute grace
+    private let delay: TimeInterval = 300   // the 5-minute grace
     private let t0 = Date(timeIntervalSince1970: 1_760_000_000)
 
     // MARK: - Presence
@@ -28,10 +28,10 @@ final class OuraLiveHRSuspendPolicyTests: XCTestCase {
 
     func testDoesNotSuspendDuringTheGrace() {
         // A glance-and-pocket must not cost the user their live HR for the evening.
-        for elapsed in [0.0, 1, 60, 600, 899.9] {
+        for elapsed in [0.0, 1, 60, 200, 299.9] {
             XCTAssertFalse(OuraLiveSource.shouldSuspendLiveHR(
                 screenOffAt: t0, now: t0.addingTimeInterval(elapsed), delay: delay),
-                "\(elapsed)s of screen-off is still inside the 15-minute grace")
+                "\(elapsed)s of screen-off is still inside the 5-minute grace")
         }
     }
 
@@ -78,7 +78,7 @@ final class OuraLiveHRSuspendPolicyTests: XCTestCase {
     func testBackgroundLaunchSuspendsImmediatelyRatherThanEarningAFreshGrace() {
         // The grace is courtesy to a user who glanced at live HR and pocketed the phone — and that user's
         // app was in the FOREGROUND. A process iOS woke for BLE has no such user, so it does not get a
-        // fresh 15 minutes. Decisive, not academic: the voided night ran FOUR app sessions, and a fresh
+        // fresh 5 minutes. Decisive, not academic: the voided night ran FOUR app sessions, and a fresh
         // grace per launch is a relaunch storm that resets the clock forever and never suspends.
         let seeded = OuraLiveSource.seedScreenOffAt(screenIsDark: true, now: t0, delay: delay)
         XCTAssertTrue(OuraLiveSource.shouldSuspendLiveHR(screenOffAt: seeded, now: t0, delay: delay),

--- a/StrandTests/OuraLiveHRSuspendPolicyTests.swift
+++ b/StrandTests/OuraLiveHRSuspendPolicyTests.swift
@@ -51,4 +51,55 @@ final class OuraLiveHRSuspendPolicyTests: XCTestCase {
                 "\(hours)h into a screen-off night the re-engage must still be suspended")
         }
     }
+
+    // MARK: - Seeding the clock at construction (the background-launch case)
+
+    // The tests above pin the PREDICATE, and they passed on the build that produced a void night — because
+    // the defect was never in the predicate, it was in what feeds it. `screenOffAt` was written in exactly
+    // one place, from `UIApplication.didEnterBackgroundNotification`, and a process launched *into* the
+    // background never posts that notification: it was never in the foreground to leave it. That is the
+    // overnight path this build runs (#1215 has iOS relaunch NOOP for BLE while the phone is locked), so
+    // the suspend never armed and the night was indistinguishable from the build with no suspend at all.
+    //
+    // These pin the seed instead: constructed while the screen is dark ⇒ suspended, not merely eventually.
+
+    func testForegroundLaunchDoesNotSeedTheClock() {
+        // The ordinary launch: the user is looking at the app. Nothing to suspend, and the notification
+        // path will start the clock honestly when they leave.
+        XCTAssertNil(OuraLiveSource.seedScreenOffAt(screenIsDark: false, now: t0, delay: delay))
+    }
+
+    func testBackgroundLaunchSeedsTheClock() {
+        XCTAssertNotNil(OuraLiveSource.seedScreenOffAt(screenIsDark: true, now: t0, delay: delay),
+                        "a process launched into the background gets no didEnterBackground edge — if the "
+                        + "seed does not stand in for it, nothing ever writes screenOffAt")
+    }
+
+    func testBackgroundLaunchSuspendsImmediatelyRatherThanEarningAFreshGrace() {
+        // The grace is courtesy to a user who glanced at live HR and pocketed the phone — and that user's
+        // app was in the FOREGROUND. A process iOS woke for BLE has no such user, so it does not get a
+        // fresh 15 minutes. Decisive, not academic: the voided night ran FOUR app sessions, and a fresh
+        // grace per launch is a relaunch storm that resets the clock forever and never suspends.
+        let seeded = OuraLiveSource.seedScreenOffAt(screenIsDark: true, now: t0, delay: delay)
+        XCTAssertTrue(OuraLiveSource.shouldSuspendLiveHR(screenOffAt: seeded, now: t0, delay: delay),
+                      "a background launch must read as suspended at the very first check")
+    }
+
+    func testSeededBackgroundLaunchStaysSuspendedAllNight() {
+        // The end-to-end shape of the fix: seed at 22:00 launch, still suspended at every hour of the night.
+        let seeded = OuraLiveSource.seedScreenOffAt(screenIsDark: true, now: t0, delay: delay)
+        for hours in [0.0, 1, 4, 8] {
+            XCTAssertTrue(OuraLiveSource.shouldSuspendLiveHR(
+                screenOffAt: seeded, now: t0.addingTimeInterval(hours * 3600), delay: delay),
+                "\(hours)h after a background launch the re-engage must still be suspended")
+        }
+    }
+
+    func testTheOldBehaviourIsWhatTheSeedReplaces() {
+        // The regression this locks down, stated as the counterfactual: with screenOffAt left nil — which
+        // is what a background launch produced before the seed — no elapsed time ever suspends, so the
+        // 15 s re-engage runs all night and holds the ring in daytime-HR mode.
+        XCTAssertFalse(OuraLiveSource.shouldSuspendLiveHR(
+            screenOffAt: nil, now: t0.addingTimeInterval(8 * 3600), delay: delay))
+    }
 }

--- a/StrandTests/OuraLiveHRSuspendPolicyTests.swift
+++ b/StrandTests/OuraLiveHRSuspendPolicyTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import Strand
+
+/// `OuraLiveSource.shouldSuspendLiveHR` — when the live-HR re-engage stands down because nobody is looking.
+///
+/// The decision is a pure static precisely so it can be tested: `OuraLiveSource` owns a
+/// `CBCentralManager` and cannot be constructed in a unit test. These tests pin the decision only. That suspending the re-engage actually lets the ring run its own night suite is a STRAP
+/// claim — it needs an overnight capture showing `check_sleep` reaching a run and `DHR_mode` leaving 3 —
+/// and is called out as owed in the PR body, not asserted here.
+///
+/// Why the rule exists: across 10 nights the correlation between our overnight re-engage count and the ring
+/// running its night suite is r = -0.91, but both of the nights that broke the pattern also broke the LINK
+/// (one disconnect, one phone deliberately out of range), confounding "we stopped poking the ring" with "we
+/// stopped talking to the ring at all". Suspending the re-engage while staying connected is what separates
+/// them.
+final class OuraLiveHRSuspendPolicyTests: XCTestCase {
+
+    private let delay: TimeInterval = 900   // the 15-minute grace
+    private let t0 = Date(timeIntervalSince1970: 1_760_000_000)
+
+    // MARK: - Presence
+
+    func testNeverSuspendsWhileTheUserIsPresent() {
+        // No screen-off timestamp means the user is here; no elapsed time can change that.
+        XCTAssertFalse(OuraLiveSource.shouldSuspendLiveHR(
+            screenOffAt: nil, now: t0.addingTimeInterval(86_400), delay: delay))
+    }
+
+    func testDoesNotSuspendDuringTheGrace() {
+        // A glance-and-pocket must not cost the user their live HR for the evening.
+        for elapsed in [0.0, 1, 60, 600, 899.9] {
+            XCTAssertFalse(OuraLiveSource.shouldSuspendLiveHR(
+                screenOffAt: t0, now: t0.addingTimeInterval(elapsed), delay: delay),
+                "\(elapsed)s of screen-off is still inside the 15-minute grace")
+        }
+    }
+
+    func testSuspendsAtTheThreshold() {
+        XCTAssertTrue(OuraLiveSource.shouldSuspendLiveHR(
+            screenOffAt: t0, now: t0.addingTimeInterval(delay), delay: delay))
+        XCTAssertTrue(OuraLiveSource.shouldSuspendLiveHR(
+            screenOffAt: t0, now: t0.addingTimeInterval(delay + 15), delay: delay))
+    }
+
+    func testStaysSuspendedAllNight() {
+        // The predicate is elapsed-since-screen-off, not a one-shot edge, so a reconnect at 03:00 that
+        // re-reaches `.streaming` still reads "suspended" and does not silently restart the stream.
+        for hours in [1.0, 4, 8] {
+            XCTAssertTrue(OuraLiveSource.shouldSuspendLiveHR(
+                screenOffAt: t0, now: t0.addingTimeInterval(hours * 3600), delay: delay),
+                "\(hours)h into a screen-off night the re-engage must still be suspended")
+        }
+    }
+}

--- a/android/app/src/main/java/com/noop/oura/Commands.kt
+++ b/android/app/src/main/java/com/noop/oura/Commands.kt
@@ -134,11 +134,27 @@ object OuraCommands {
         OuraCommand("dhr_subscribe", intArrayOf(0x2F, 0x03, 0x26, featureDaytimeHR, 0x02))
 
     /**
-     * Disable live HR: `2f 03 22 02 01`. ACK: `2f 03 23 02 00`; stream stops on ACK.
-     * Per OURA_PROTOCOL.md s5.6.
+     * Disable live HR: `2f 03 22 02 00`. ACK: `2f 03 23 02 00`.
+     * Mode byte is **0x00** ("off" per OURA_PROTOCOL.md s7.2's APK-sourced table), not 0x01
+     * ("automatic") — an earlier build wrote 0x01 here on the mistaken belief it meant "off"; s7.4's
+     * own worked example shows mode=1 read back while daytime-HR is actively streaming, and two
+     * consecutive real-hardware nights (08-17/18, 08-18/19) falsified "stream stops on ACK" for that
+     * byte — green 0x80 kept arriving all night at reduced but non-zero volume, matching "automatic"
+     * mode's own adaptive/motion-triggered sampling rather than a true off. Per OURA_PROTOCOL.md s5.6.
      */
     fun liveHRDisable(): OuraCommand =
-        OuraCommand("dhr_disable", intArrayOf(0x2F, 0x03, 0x22, featureDaytimeHR, 0x01))
+        OuraCommand("dhr_disable", intArrayOf(0x2F, 0x03, 0x22, featureDaytimeHR, 0x00))
+
+    /**
+     * Unsubscribe from live-HR pushes: `2f 03 26 02 00`. ACK: `2f 03 27 02 00`.
+     * The enable triplet's step 3 (`liveHRSubscribe`) leaves the ring subscribed at "latest" (byte2 =
+     * 2); nothing ever wrote it back to "off" before this — `liveHRDisable` alone only touches the
+     * feature MODE byte, not the subscription. Send both together when suspending live HR so no
+     * notification channel is left standing open for the ring's own adaptive sampling to push through.
+     * Per OURA_PROTOCOL.md s5.6/7.2.
+     */
+    fun liveHRUnsubscribe(): OuraCommand =
+        OuraCommand("dhr_unsubscribe", intArrayOf(0x2F, 0x03, 0x26, featureDaytimeHR, 0x00))
 
     // Feature-status diagnostics (READ-ONLY; s5.6 / s7.1)
 

--- a/android/app/src/test/java/com/noop/oura/OuraDriverTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraDriverTest.kt
@@ -219,6 +219,19 @@ class OuraDriverTest {
         )
     }
 
+    @Test
+    fun testLiveHRDisableWritesModeOffNotAutomatic() {
+        // 0x00 = "off" per OURA_PROTOCOL.md s7.2's APK-sourced feature-mode table; 0x01 is "automatic"
+        // and was falsified on two hardware nights (green 0x28 kept arriving after the old 0x01 write).
+        assertArrayEquals(intArrayOf(0x2F, 0x03, 0x22, 0x02, 0x00), OuraCommands.liveHRDisable().bytes)
+    }
+
+    @Test
+    fun testLiveHRUnsubscribeWritesSubscriptionOff() {
+        // Matching teardown for the enable triplet's step 3 (subscribe "latest" = 0x02).
+        assertArrayEquals(intArrayOf(0x2F, 0x03, 0x26, 0x02, 0x00), OuraCommands.liveHRUnsubscribe().bytes)
+    }
+
     // MARK: - Ring-time -> UTC anchor (s5.5)
 
     /**

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -382,7 +382,24 @@ Three writes to `…0002`, each gated on its ACK; daytime-HR feature id = `0x02`
 - **`bpm = round(60000 / ibi_ms)`** [relue]
 - Example `[08,09] = 01 04` → `ibi = 1025 ms` → ≈ 59 BPM. [relue]
 
-**Disable:** `2f 03 22 02 01` → ACK `2f 03 23 02 00`. Stream stops on ACK. [relue][open_oura-r3]
+**Disable:** `2f 03 22 02 00` → ACK `2f 03 23 02 00`.
+
+> **Correction (2026-08-19):** an earlier draft of this line, and NOOP's own `liveHRDisable()`, wrote
+> mode byte **0x01** here on the strength of [relue][open_oura-r3]'s "stream stops on ACK" report. But
+> §7.2's APK-sourced feature-mode table (the citation this doc itself treats as authoritative over
+> earlier drafts) defines `0x01` as **"automatic"**, not "off" — `0x00` is off. §7.4's own worked
+> example shows mode=1 read back *while daytime-HR is actively streaming*, which is hard to square with
+> "disable." Two consecutive real-hardware NOOP nights (08-17/18, 08-18/19) directly falsified "stream
+> stops on ACK" for the 0x01 write: green `0x28` pushes continued all night at reduced-but-non-zero
+> volume, including resumptions with no reconnect in between — the signature of the ring's own
+> adaptive/motion-triggered "automatic" sampling, not a keep-alive wearing off. Byte corrected to
+> `0x00` here and in `Commands.swift`/`Commands.kt`; unvalidated on hardware as of this edit — see the
+> worklog for the next capture's result. [relue][open_oura-r3]'s original report may reflect a
+> transient quiet window inside the ~20 s auto-revert (§5.7) rather than a genuine off state.
+
+Also send the matching unsubscribe when tearing down a live session: `2f 03 26 02 00` → ACK
+`2f 03 27 02 00`. Step 3 of the enable triplet above leaves the ring subscribed at "latest"
+(byte2 = 2); the mode-disable write alone never turns that subscription back off.
 
 > Behaviour caveat: [open_oura-r3] reports that on its Ring-3 unit, realtime `0x06`-based enabling ACK'd but emitted no stream within 60–90 s, whereas the `0x2F`/feature-`0x02` path above produced ~1 Hz IBI. **NOOP must use the feature-`0x02` (`0x2F`) path, not `0x06`,** and treat absence of `0x28` pushes within ~10 s as "not streaming → retry/reseat."
 


### PR DESCRIPTION
## What this PR does

Stops the Oura ring's live-HR stream from running unattended (screen off / app backgrounded), which
holds the ring in daytime-HR mode and blocks its own overnight sleep suite (SpO2, hypnogram, `0x6A`
sleep_period) — measured r = -0.93 between our re-engage volume and the ring's own suite output across
11 nights. Also the leading cost in this ring's overnight battery drain (see `battery-drain-ledger.md`).

The mechanism: suspend the 15 s live-HR re-engage 5 minutes after the screen goes dark (iOS:
backgrounding; macOS: display sleep), resume immediately on the next screen-on. Two earlier attempts at
"stop poking it" (queue 1/9) turned out not to actually stop the ring — the real culprit was a wrong
mode byte on the disable write (`0x01` = "automatic", not `0x00` = "off"), fixed here along with a
missing unsubscribe. A late hardware finding (below) added a self-heal for the one remaining edge case.

**Six commits, oldest to newest:**
1. `suspend the live-HR re-engage 15 min after the screen goes dark` — the mechanism: screen-state
   observers, the suspend predicate, the re-engage-tick-as-enforcer design.
2. `seed the live-HR suspend clock at init, for the background launch` — a process iOS wakes directly
   into the background never sees the "screen went dark" notification edge; without seeding, such a
   night never suspends at all (found voiding a 2026-08-15/16 capture).
3. `shorten the live-HR suspend grace 15 min -> 5 min`.
4. `actively disable live-HR when suspending, not just stop re-arming` — "just stop poking it" doesn't
   work: the ring's own ~20s auto-revert never actually fired on this build (08-17/18 capture: green
   0x80 never collapsed, any hour). Send an explicit disable.
5. `dhr_disable wrote mode=automatic, not off - plus a missing unsubscribe` — root cause of #4 still
   failing (08-18/19: reduced but non-zero volume): the disable command's mode byte was wrong per
   `OURA_PROTOCOL.md` §7.2's own APK-sourced table. Fixed the byte, added the missing unsubscribe.
6. `self-heal the live-HR suspend-arm race, not just log it` — 2026-08-20/21's first full overnight
   test found the connect-time race fixed (16/16 clean) but one narrower race remained: enforcement is
   polled on the 15s re-engage tick, so a push can land in the up-to-15s window right as the grace
   expires, before the tick that would disable it. Self-heals immediately instead of waiting for the
   tick.

## How it was tested

BLE work — real-hardware evidence across three separate captures on an Oura Ring Gen3, in order:

- **2026-08-20/21 overnight** (`integration/oura-full@7b2ab4cf`, pre-selfheal): main overnight
  SUSPENDED window (04:51→08:41, ~3h50m) — **16/16 reconnects clean**, zero live-HR leaks; the
  connect-time race documented in commit 4/5's history did not recur once in a much larger sample than
  the daytime smoke test that first found it. One falsifier hit outside that window, at a second brief
  SUSPENDED arm during the post-wake period — root-caused to the tick-enforcement-lag gap, which
  commit 6 (self-heal) fixes.
- **2026-08-21 post-recharge** (`3a8a13de`, first capture with the selfheal): one real trigger, at
  10:14:42 during an atypically churny post-charge reconnect stretch — self-healed immediately, zero
  repeats across the following ~5 min and 2 more reconnects.
- **2026-08-21 daytime, ~9.2h** (`3a8a13de`): **42 reconnects across two SUSPENDED windows.**
  Connect-time race: 0/42 hits. Timer-expiry race: 1 hit, self-healed, **zero repeats** across the
  remaining ~2h57m and 25 more reconnects, including across an app relaunch. Battery: **0.77%/h —
  below this ring's expected 1.1-1.4%/h band for its age, the best daytime row on record**, beating
  both pre-fix daytime baselines (1.34%/h, 1.00%/h).

Full write-ups: `worklog/analysis/2026-08-21-0900-*.txt`, `2026-08-21-1030-*.txt`,
`2026-08-21-2040-*.txt`. Battery ledger: `worklog/analysis/battery-drain-ledger.md` (8th/9th points).

Swift `OuraProtocol` 206/0. `Strand` (macOS) and `NOOPiOS` both build clean
(`xcodebuild ... build`, compile-only — app-target Swift has no default CI, verified manually after
every commit in this stack). Android `compileFullDebugKotlin` clean, `testFullDebugUnitTest
--tests "com.noop.oura.*"` green (commit 5 touches `Commands.kt` too).

**Not yet done:** a second overnight capture on this exact stack, to confirm the self-heal holds up
over a full night the way it already has over ~9h of daytime use. Not a blocker on the evidence above,
but the obvious next data point.

## Alternative considered: a declared quiet-hours window instead of screen state

Instead of (or alongside) suspending on screen-off, reuse the pattern `#927`
already shipped for WHOOP's Continuous HRV capture (`BLEManager.swift`) — a user-configurable
"quiet hours" window (default 22:00-07:00) that arms/disarms by wall-clock time rather than screen
state, paired with a new "usual sleeping time" setting.

**Considered and not adopted for this PR, for two concrete reasons:**

1. **It would give up the daytime result above.** 0.77%/h came specifically from suspending live-HR
   any time the screen is off for 5+ minutes, all day — meetings, commute, pocket time. A time-window
   approach only suspends inside the declared window; daytime quiet periods keep polling at full rate
   unless the user also declares them, which re-introduces the same settings-surface complexity #927
   needed for WHOOP (window config, DST handling, a manual on-demand-reading override).
2. **It relocates the race rather than removing it.** Something still has to notice the window
   boundary and send the actual disable command; if that's still tied to a periodic tick (as #927's
   is), the same enforcement-lag shape shows up at the window edge instead of the screen-off edge —
   a different trigger for the same underlying gap, not a structurally different one.

Worth a real look as a *complementary* feature later (e.g. a declared window that ALSO forces suspend
during a user's known sleep hours even if they glance at the phone, on top of the screen-state
suspend) — not evaluated here, flagged for a future queue item.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/OuraProtocol`)
- [x] Android unit tests pass — I touched `android/` (`Commands.kt`, commit 5)
- [x] No new build warnings introduced
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
  (`OURA_PROTOCOL.md` §5.6/§7.2/§7.4 corrected with citation history in commit 5)
- [x] Follows the conventions in `docs/CONTRIBUTING.md` — Patrick to confirm before opening
- [x] Did not commit generated output or secrets

## Branch provenance note (why this branch looks the way it does)

These six commits previously only existed stacked inside `integration/oura-full` — none of them ever
had a clean, single-concern branch of their own; they landed straight into that integration branch's
history across several rebases. This branch reconstructs them from scratch on a fresh `upstream/main`
so this PR is reviewable as one concern, not `integration/oura-full`'s other ~25 unrelated commits.

The reconstruction hit one real conflict, in commit 1 (`suspend the live-HR re-engage...`) and
commit 2 (test file only): the original diffs assumed a separate, still-unmerged feature
(`fix/oura-stalled-stream-recovery`, notify-subscription-stall recovery) was already present, because
`integration/oura-full` happens to carry both features stacked together. `upstream/main` has neither.
Resolved by dropping the stalled-recovery content from both commits (reverting to `upstream/main`'s
plain `fetchHistoryIfIdle()` / trimming 3 tests that exercised the now-absent
`shouldToggleSubscription`) — full detail in commit 1's message under "2026-08-21 RECONSTRUCTION
NOTE". That other feature is out of scope here and belongs in its own PR.