### PR TITLE
Enable StrandAnalytics SwiftPM tests on Linux

### DIFF
--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BackupSettingsLinuxTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BackupSettingsLinuxTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+import WhoopStore
+
+/// Exercises the Corelibs Foundation NSNumber distinction used by BackupSettings on Linux.
+final class BackupSettingsLinuxTests: XCTestCase {
+    func testBooleanAndNumericJSONValuesKeepDistinctContracts() throws {
+        let payload = Data(#"{"profile.age":true,"profile.hrMax":1,"profile.weightKg":false,"profile.heightCm":1}"#.utf8)
+
+        let decoded = BackupSettings.decode(payload)
+
+        XCTAssertNil(decoded["profile.age"], "A JSON boolean must not be accepted as numeric 1")
+        XCTAssertNil(decoded["profile.weightKg"], "A JSON boolean must not be accepted as numeric 0")
+        XCTAssertEqual(decoded["profile.hrMax"] as? Int, 1)
+        XCTAssertEqual(decoded["profile.heightCm"] as? Double, 1.0)
+
+        let roundTrip = try XCTUnwrap(BackupSettings.encode(decoded))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: roundTrip) as? [String: Any])
+        XCTAssertEqual((json["profile.hrMax"] as? NSNumber)?.intValue, 1)
+        XCTAssertEqual((json["profile.heightCm"] as? NSNumber)?.doubleValue, 1.0)
+        XCTAssertNil(json["profile.age"])
+        XCTAssertNil(json["profile.weightKg"])
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Live5RestFrozenTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Live5RestFrozenTests.swift
@@ -88,12 +88,16 @@ final class Live5RestFrozenTests: XCTestCase {
     ///
     /// This intentionally FAILS against today's code (Rest.composite(daily:) returns nil for such a
     /// day). Delete the XCTExpectFailure wrapper when the fix lands.
-    func testChargeableDayShouldYieldAdvancingRestSignal_FIX() {
+    func testChargeableDayShouldYieldAdvancingRestSignal_FIX() throws {
+#if canImport(Darwin)
         XCTExpectFailure("#977 not yet fixed: a chargeable-but-unslept live-5.0 day yields a nil Rest signal") {
             let daily = chargeableButUnsleptDaily(day: "2026-07-02")
             XCTAssertNotNil(AnalyticsEngine.Rest.composite(daily: daily),
                             "A day that can score Charge must also surface SOME Rest signal, not freeze")
         }
+#else
+        throw XCTSkip("XCTExpectFailure is unavailable in corelibs XCTest")
+#endif
     }
 
     func testTodayRestFreezesOnTailFallbackWhenNoNewPointWritten() {

--- a/Packages/WhoopStore/Sources/WhoopStore/BackupSettings.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/BackupSettings.swift
@@ -177,6 +177,11 @@ public enum BackupSettings {
     }
 
     private static func isBoolean(_ n: NSNumber) -> Bool {
+#if canImport(Darwin)
         CFGetTypeID(n) == CFBooleanGetTypeID()
+#else
+        // corelibs Foundation boxes JSON booleans with the Objective-C `c` type encoding.
+        String(cString: n.objCType) == "c"
+#endif
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/RawOutbox.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/RawOutbox.swift
@@ -1,3 +1,4 @@
+#if canImport(Compression)
 import Foundation
 import Compression
 import GRDB
@@ -252,3 +253,4 @@ extension WhoopStore {
         }
     }
 }
+#endif

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/RawOutboxTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/RawOutboxTests.swift
@@ -1,3 +1,4 @@
+#if canImport(Compression)
 import XCTest
 import WhoopProtocol
 @testable import WhoopStore
@@ -85,3 +86,4 @@ final class RawOutboxTests: XCTestCase {
         XCTAssertEqual(gotZeros, zeros)
     }
 }
+#endif

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -95,15 +95,16 @@ which distribution builds commonly omit, so build a private snapshot-enabled lib
 SQLITE_SNAPSHOT_DIR="$(mktemp -d)"
 curl -fsSLo "$SQLITE_SNAPSHOT_DIR/sqlite.zip" https://sqlite.org/2026/sqlite-amalgamation-3530400.zip
 unzip -p "$SQLITE_SNAPSHOT_DIR/sqlite.zip" sqlite-amalgamation-3530400/sqlite3.c > "$SQLITE_SNAPSHOT_DIR/sqlite3.c"
+unzip -p "$SQLITE_SNAPSHOT_DIR/sqlite.zip" sqlite-amalgamation-3530400/sqlite3.h > "$SQLITE_SNAPSHOT_DIR/sqlite3.h"
 echo "b1dd5d74ec7f29055a6684fa06fb3c2f6821c87dd38f9a458dfd2e8a1db28189  $SQLITE_SNAPSHOT_DIR/sqlite3.c" | sha256sum --check
 cc -shared -fPIC -DSQLITE_ENABLE_SNAPSHOT=1 "$SQLITE_SNAPSHOT_DIR/sqlite3.c" -o "$SQLITE_SNAPSHOT_DIR/libsqlite3.so.0"
 ln -s libsqlite3.so.0 "$SQLITE_SNAPSHOT_DIR/libsqlite3.so"
 cd Packages/StrandAnalytics
 LD_LIBRARY_PATH="$SQLITE_SNAPSHOT_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
-  swift test -Xlinker -L"$SQLITE_SNAPSHOT_DIR"
+  swift test -Xcc -I"$SQLITE_SNAPSHOT_DIR" -Xlinker -L"$SQLITE_SNAPSHOT_DIR"
 ```
 
-This currently runs 1,522 platform-neutral package tests with one intentional skip. It does not run
+This currently runs 1,523 platform-neutral package tests with one intentional skip. It does not run
 iOS simulator/UI tests, Darwin's Compression-backed raw outbox, or the standalone `WhoopStore`
 test target. The existing package CI remains macOS-only.
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -86,6 +86,27 @@ brew install xcodegen
 The packages themselves only need a Swift toolchain — they build and test with plain `swift build`
 / `swift test`, no Xcode project required.
 
+### StrandAnalytics tests on Linux
+
+Install Swift 6 or newer plus a C compiler, `curl`, and `unzip`. GRDB uses SQLite's snapshot API,
+which distribution builds commonly omit, so build a private snapshot-enabled library:
+
+```bash
+SQLITE_SNAPSHOT_DIR="$(mktemp -d)"
+curl -fsSLo "$SQLITE_SNAPSHOT_DIR/sqlite.zip" https://sqlite.org/2026/sqlite-amalgamation-3530400.zip
+unzip -p "$SQLITE_SNAPSHOT_DIR/sqlite.zip" sqlite-amalgamation-3530400/sqlite3.c > "$SQLITE_SNAPSHOT_DIR/sqlite3.c"
+echo "b1dd5d74ec7f29055a6684fa06fb3c2f6821c87dd38f9a458dfd2e8a1db28189  $SQLITE_SNAPSHOT_DIR/sqlite3.c" | sha256sum --check
+cc -shared -fPIC -DSQLITE_ENABLE_SNAPSHOT=1 "$SQLITE_SNAPSHOT_DIR/sqlite3.c" -o "$SQLITE_SNAPSHOT_DIR/libsqlite3.so.0"
+ln -s libsqlite3.so.0 "$SQLITE_SNAPSHOT_DIR/libsqlite3.so"
+cd Packages/StrandAnalytics
+LD_LIBRARY_PATH="$SQLITE_SNAPSHOT_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+  swift test -Xlinker -L"$SQLITE_SNAPSHOT_DIR"
+```
+
+This currently runs 1,522 platform-neutral package tests with one intentional skip. It does not run
+iOS simulator/UI tests, Darwin's Compression-backed raw outbox, or the standalone `WhoopStore`
+test target. The existing package CI remains macOS-only.
+
 ---
 
 ## macOS build & run (reference implementation)


### PR DESCRIPTION
## Summary

- gate the Apple Compression-backed raw-outbox surface on platforms that provide `Compression`
- preserve JSON boolean detection under corelibs Foundation
- skip the existing expected-failure contract where corelibs XCTest has no `XCTExpectFailure`
- document a reproducible snapshot-enabled SQLite setup and the exact Linux test command

Darwin behavior is unchanged. This enables the platform-neutral `StrandAnalytics` SwiftPM suite on Linux; it does not claim iOS simulator/UI coverage, Darwin raw-outbox coverage, or standalone `WhoopStore` test support. The existing package CI remains macOS-only.

## Verification

- unchanged base: Linux build fails with `no such module Compression`
- patched clean Linux run: 1,522 tests, 1 intentional skip, 0 failures
- `git diff --check`
- independent review: P0=0, P1=0, P2=0

Context: [bhelm/noop#17](https://github.com/bhelm/noop/issues/17).