### PR TITLE
Correct stale cross-platform twin comments

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/CaptureCompleteness.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/CaptureCompleteness.swift
@@ -15,7 +15,9 @@ import Foundation
 // Everything here is PURE and side-effect-free: it takes the active-domain set and the already-redacted
 // report text and returns values. No I/O, no clock, no PII (it only counts token occurrences). The token map
 // is the single declarative source of truth shared by the report renderer and the meta field. No em-dashes.
-// The Kotlin twin is CaptureCompleteness.kt, kept aligned by a parity test (same tokens, same status words).
+// Android's `ReportCompleteness` in
+// `android/app/src/main/java/com/noop/testcentre/ReportCompleteness.kt` is the architectural counterpart;
+// it has its own status vocabulary, token maps, and domain-selection rules.
 
 /// Whether a domain that was active during the capture produced its killer trace.
 public enum CaptureStatus: String, Sendable, Codable, Equatable {

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ChargeDrivers.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ChargeDrivers.swift
@@ -21,7 +21,7 @@ import Foundation
 //   - The score is logistic, so per-term deltas do NOT sum to the headline; they are each an
 //     honest "what this term was worth" marginal, ordered by magnitude (biggest mover first).
 //
-// Pure and side-effect-free: no clock, no I/O. The Kotlin twin is RecoveryScorer.chargeDrivers.
+// Pure and side-effect-free: no clock, no I/O. The Kotlin twin is RecoveryDrivers.chargeDrivers.
 // No em-dashes.
 
 /// One row of the Charge driver breakdown (SHARED CONTRACT shape).
@@ -118,7 +118,7 @@ extension RecoveryScorer {
     /// `recovery(...)`; `*ValueText` closures format each measured value for display so the
     /// engine stays unit-agnostic (the caller supplies "58 bpm" etc.).
     ///
-    /// The Kotlin twin is `RecoveryScorer.chargeDrivers`.
+    /// The Kotlin twin is `RecoveryDrivers.chargeDrivers`.
     public static func chargeDrivers(hrv: Double,
                                      rhr: Double,
                                      resp: Double?,

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer+Trace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer+Trace.swift
@@ -19,7 +19,7 @@ extension HRVAnalyzer {
     ///
     /// The returned result IS `analyze(...)` verbatim, and every count is recomputed with the EXACT same
     /// filters (`rangeFilter` then `rejectEctopic`), so the trace and the headline can never diverge. The
-    /// Kotlin twin is HrvAnalyzer.analyzeTrace.
+    /// Kotlin twin is HrvAnalyzerTrace.analyzeTrace.
     ///
     /// - Parameter maxRejectedFraction: the SPOT-ONLY ceiling (#585). nil (the nightly/continuous default)
     ///   skips the rejected-fraction gate, exactly like `analyze(...)`.

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer+Trace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer+Trace.swift
@@ -20,7 +20,8 @@ extension RecoveryScorer {
     ///
     /// Every number is computed with the EXACT same expressions as `recovery(...)` (the same zScore call,
     /// the same skin-temp penalty, the same weights), and the returned score IS `recovery(...)` verbatim,
-    /// so the trace and the headline can never diverge. The Kotlin twin is RecoveryScorer.recoveryTrace.
+    /// so the trace and the headline can never diverge. The Kotlin twin is
+    /// RecoveryScorerTrace.recoveryTrace.
     ///
     /// - Parameters mirror `recovery(...)` exactly, taking BaselineState so the trace can read each
     ///   driver's nValid / status; the `usable` cold-start gate is enforced through `recovery(...)`.

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/UniversalTrace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/UniversalTrace.swift
@@ -11,7 +11,10 @@ import Foundation
 //
 // Pure + side-effect-free: no clock read of its own, no I/O. The caller (the export assembler) passes the
 // last strap-reported banked-record window and its own wall-now; this formats one line. No PII (ISO dates,
-// counts and a firmware version int only). No em-dashes. The Kotlin twin is UniversalTrace.kt.
+// counts and a firmware version int only). No em-dashes. Android's universal clock diagnostic is built by
+// `ConnectionTrace.clockDriftLine` and emitted by `WhoopBleClient`; its firmware-layout line is separate,
+// emitted by `Backfiller` only in Connection mode. Android has no single `UniversalTrace` declaration that
+// combines them.
 
 public enum UniversalTrace {
 

--- a/android/app/src/main/java/com/noop/analytics/AutoWorkoutDetectorTrace.kt
+++ b/android/app/src/main/java/com/noop/analytics/AutoWorkoutDetectorTrace.kt
@@ -186,7 +186,7 @@ object WorkoutsTrace {
      * session (manual / imported), so the same bout is never counted twice. `verdict` is "persisted" /
      * "droppedOverlap" / "droppedShadow"; `durMin` is the whole-minute bout length; on a drop, `overlapSource`
      * names the real row it collided with. No PII (a source label + minutes + bpm only). Swift twin
-     * AutoWorkoutDetector.detectedBoutLine.
+     * WorkoutsTrace.detectedBoutLine.
      */
     fun detectedBoutLine(
         verdict: String,

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -230,7 +230,8 @@ class OuraLiveSource(
      * connecting, so the fresh per-connection driver is built with `allowKeyInstall == true` and the
      * dangerous install can run for exactly that session. It takes effect on the next connect (the driver
      * is re-created per connection); a connection already mid-flight is not retro-granted. Default-false
-     * everywhere else keeps the dangerous opcode unreachable. Kotlin twin of Swift's `setAdoptIntent`.
+     * everywhere else keeps the dangerous opcode unreachable. On Swift, the architectural counterpart is
+     * the immutable `OuraLiveSource.adoptIntent` initializer input; there is no setter twin.
      */
     fun setAdoptIntent(intent: Boolean) {
         adoptIntent = intent

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -969,7 +969,8 @@ interface WhoopDao : DeviceRegistryDao {
     // bad-clock strap's garbage-ts rows survived in them while every sibling stream above was cleaned.
     // They are keyed by the SAME `ts` from the SAME type-47 ingest path, so there is no reason to exempt
     // them. Legacy-rows only in practice (the #547 ingest gate now rejects an implausible ts before it is
-    // banked), which is why it went unnoticed. Swift twin: TimestampHeal.rawTables.
+    // banked), which is why it went unnoticed. Keep this list synchronized with the `rawTables` local in
+    // Swift `WhoopStore.healImplausibleTimestamps`.
     @Query("DELETE FROM sleepStateSample WHERE ts < :minTs OR ts > :maxTs")
     suspend fun pruneSleepStateByTs(minTs: Long, maxTs: Long): Int
 

--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -151,8 +151,9 @@ fun DataSourcesScreen(vm: AppViewModel) {
     suspend fun refreshCounts() {
         val nowS = System.currentTimeMillis() / 1000
         // #1304/#512: count across the active-strap UNION (active ∪ canonical), so a 2nd strap's data
-        // under "whoop-<uuid>" is included instead of silently under-reported. `daysMerged` is the exact
-        // twin of Swift's `repo.days` (mergeActivityFileSteps(mergeDaily(imported, computed))) — so this
+        // under "whoop-<uuid>" is included instead of silently under-reported. `daysMerged` is Android's
+        // merged-history counterpart to Swift `Repository.days`
+        // (mergeActivityFileSteps(mergeDaily(imported, computed))), so this
         // matches the iOS badge count, including a strap-only user's computed-only ("-noop") days that an
         // imported-only count would miss. workoutsUnion mirrors Swift's dataVolumeSnapshot workout union.
         whoopDays = vm.repo.daysMerged(vm.activeStrapId).size

--- a/android/app/src/test/java/com/noop/ble/TimeoutSyncErrorTest.kt
+++ b/android/app/src/test/java/com/noop/ble/TimeoutSyncErrorTest.kt
@@ -36,7 +36,8 @@ class TimeoutSyncErrorTest {
      * (three sessions in one field log ran 66–109s and took 42, 51 and 59 frames while banking zero rows).
      * No test over this function can catch that, because a frame count is not one of its inputs. The guard
      * is the signature plus named arguments at both call sites: `chunks`, `rows` and `deepPackets` make a
-     * frame count visibly wrong where it is passed, not here. Twin of the Swift `bankedIffSomeCounterMoved`.
+     * frame count visibly wrong where it is passed, not here. Twin of the Swift
+     * `TimeoutSyncErrorTests.testBankedIffSomeCounterMoved`.
      */
     @Test
     fun bankedIffSomeCounterMoved() {


### PR DESCRIPTION
## Summary

- point stale Swift/Kotlin twin comments at the declarations that actually exist
- distinguish architectural counterparts from exact function twins where the platforms intentionally differ
- preserve the now-landed `HrvAnalyzer.sdnnIndex` twin annotation after [#1535](https://github.com/ryanbr/noop/pull/1535) resolved the former platform gap

This is documentation-only: no declaration, runtime, test, schema, or workflow behavior changes. It makes the existing cross-platform annotations truthful and machine-resolvable without pretending differently shaped platform code is identical.

## Verification

- every changed line is a comment
- `python3 Tools/doc_comment_lint.py` — 1,717 files, clean
- `git diff --check`
- independent review: P0=0, P1=0, P2=0

Context: [bhelm/noop#17](https://github.com/bhelm/noop/issues/17). The former Android metric gap in [bhelm/noop#18](https://github.com/bhelm/noop/issues/18) is resolved by [#1535](https://github.com/ryanbr/noop/pull/1535), so this refreshed comment-only delta no longer describes it as an open divergence.
