### PR TITLE
Port the SDNN index to Android

### DIFF
--- a/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
@@ -1,6 +1,6 @@
 {
   "_readme": "SHARED Room<->GRDB SCHEMA ORACLE (#775). Two byte-identical copies: Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json and android/app/src/test/resources/schema_oracle.json. SchemaOracleTests.swift compares GRDB's PRAGMA table_info/index_list against it; SchemaOracleTest.kt compares Room's exported schema JSON against it. `columns` is the iOS/GRDB shape in GRDB column order (macOS is the reference implementation); every way Android differs is spelled out in an `android` / `iosAbsent` / `androidColumnOrder` override naming a key in `divergenceReasons`. Adding a column, reordering one, or changing a type/nullability on one platform only fails both suites until it is either fixed or written down here.",
-  "roomVersion": 31,
+  "roomVersion": 32,
   "grdbMigrations": [
     "v1",
     "v2",
@@ -44,7 +44,6 @@
   "divergenceReasons": {
     "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android \u2014 the per-row upload flag belongs to an upload path that does not exist there \u2014 so it is dead width, not divergent data. Removing it needs a Room table rebuild.",
     "battery-alter-append-order": "REAL COLUMN-ORDER DRIFT (CLAUDE.md: 'column order in a Room CREATE TABLE must match the entity field order'). GRDB appended `synced` (v5) then `charging` (v6) with ALTER TABLE, which can only append; the Room entity declares `charging` before `synced`. Same columns, same types, different positions \u2014 so any positional copy (INSERT INTO battery SELECT * FROM \u2026) swaps them. Fixing it means reordering the Room entity's fields, which changes Room's identity hash and therefore needs a version bump plus a no-op migration.",
-    "daily-avg-sdnn-ios-only": "REAL COLUMN DRIFT, deliberate and one-directional: `dailyMetric.avgSdnn` (the 5-min SDNN index) is written by the Swift nightly analysis and has no Room twin, because the Android analytics reimplementation computes RMSSD only — there is no Kotlin `sdnnIndex` to persist. Adding the Room column without the computation would store NULL on every Android row, which is a fabricated parity, not a real one; the honest shape is an absent column until the Kotlin twin exists. Consequence: a .noopbak exported from iOS carries a column Android's `dailyMetric` cannot receive, in the same direction as `workout.routePolyline` but reversed. Closing it means porting `HRVAnalyzer.sdnnIndex` to Kotlin plus a Room version bump.",
     "grdb-boolean-affinity": "GRDB's .boolean column type is declared BOOLEAN, which SQLite gives NUMERIC affinity; Room maps Kotlin Boolean to INTEGER. For the 0/1 values both sides write, NUMERIC and INTEGER affinity store bit-identical INTEGERs, so a .noopbak round-trips. Closing it means a GRDB table rebuild.",
     "paired-device-alter-append-order": "REAL COLUMN-ORDER DRIFT, same shape as battery. GRDB's v16-paired-device-peripheral appended `peripheralId` at the end; the Room entity declares it fifth, between `nickname` and `sourceKind`.",
     "ppg-hr-bpm-integer-on-android": "AFFINITY DRIFT, and NOT a data consequence: ppgHrSample.bpm is declared REAL on iOS and INTEGER on Android \u2014 but only the SQLITE COLUMN differs. The ROW type is `Int` on both sides: Swift's `PpgHrSample.bpm` is `Int`, carrying the comment 'the same Int domain as the measured HRSample.bpm and the Android PpgHr.Estimate.bpm, so the stored value and type match across platforms (#219)'. Both platforms also round to whole bpm before that \u2014 Swift `(fsD * 60 / refinedLag).rounded()` then `Int(est.bpm)`, Kotlin `Math.round(fsD * 60 / refinedLag).toInt()` \u2014 and the read path (`CAST(ROUND(p.bpm) AS INTEGER)`) rounds again, a no-op on a whole number. There is one writer and one construction site on each side. So REAL holds the same whole numbers INTEGER does and NO value differs. Recorded because the DECLARED affinity genuinely diverges, and a bpm that ever became fractional would then diverge silently; closing it means a GRDB table rebuild. Deliberately NOT the decoder-oracle (#869) class \u2014 that caught a real value divergence.",
@@ -363,9 +362,7 @@
           "name": "avgSdnn",
           "affinity": "REAL",
           "notNull": false,
-          "default": null,
-          "androidAbsent": true,
-          "divergence": "daily-avg-sdnn-ios-only"
+          "default": null
         }
       ],
       "primaryKey": [

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -550,6 +550,14 @@ object AnalyticsEngine {
             }
         }
 
+        // Five-minute SDNN index over R-R intervals inside the matched sleep sessions. This preserves the
+        // timestamps needed for segmentation and stays distinct from avgHrv (RMSSD). The half-open sleep
+        // bounds match every other in-bed aggregate; no qualifying 20-clean-beat segment means null.
+        val avgSDNNDaily = HrvAnalyzer.sdnnIndex(
+            rr.filter { sample -> matched.any { sample.ts >= it.start && sample.ts < it.end } },
+            segmentSec = 300,
+        )
+
         // ── HRV & Autonomic nightly trace (#141) ──────────────────────────────
         // Per-5-min-window RMSSD tagged by the sleep stage at its center, then a night summary comparing
         // NOOP's whole-night mean (what it reports) against a deep-only mean and a WHOOP-style
@@ -810,6 +818,7 @@ object AnalyticsEngine {
             activeKcalEst = activeKcalEst,
             spo2Red = nightlySpo2Raw?.first,
             spo2Ir = nightlySpo2Raw?.second,
+            avgSdnn = avgSDNNDaily,
         )
 
         // ── Per-score confidence tiers (mirror Swift ScoreConfidence.derive decisions) ──

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -119,6 +119,32 @@ object HrvAnalyzer {
         return sqrt(ss / (nn.size - 1).toDouble())
     }
 
+    /**
+     * Task Force SDNN index: mean sample-SDNN across consecutive [segmentSec]-second segments.
+     * Each segment uses the same range + Malik cleaning as [analyze]; segments with fewer than
+     * [MIN_BEATS] clean intervals are skipped. Timestamps are Unix seconds and segment boundaries are
+     * inclusive, matching the Swift `HRVAnalyzer.sdnnIndex` twin. This is deliberately distinct from
+     * whole-night SDNN, whose slow between-stage heart-rate drift can dominate the result.
+     */
+    fun sdnnIndex(rr: List<RrInterval>, segmentSec: Int = 300): Double? {
+        if (segmentSec <= 0 || rr.isEmpty()) return null
+        val first = rr.minOf { it.ts }
+        val segmentLength = segmentSec.toLong()
+
+        // Bucket in one pass while preserving input order within each segment. This is equivalent to the
+        // Swift twin's repeated inclusive window filters, without rescanning a whole night per segment.
+        val segments = LinkedHashMap<Long, MutableList<RrInterval>>()
+        for (sample in rr) {
+            val bucket = (sample.ts - first) / segmentLength
+            segments.getOrPut(bucket) { ArrayList() }.add(sample)
+        }
+        val values = segments.keys.sorted().mapNotNull { bucket ->
+            val start = first + bucket * segmentLength
+            analyze(segments.getValue(bucket), windowStart = start, windowEnd = start + segmentLength - 1).sdnn
+        }
+        return if (values.isEmpty()) null else values.sum() / values.size.toDouble()
+    }
+
     // ── Cleaning ─────────────────────────────────────────────────────────────
 
     /** Range filter: keep only intervals in [RR_MIN_MS, RR_MAX_MS], preserving order. */

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -318,6 +318,9 @@ data class DailyMetric(
     // (imports/cloud never carry them), so old rows + non-4.0 nights stay null.
     val spo2Red: Int? = null,           // mean raw red PPG ADC during detected sleep
     val spo2Ir: Int? = null,            // mean raw IR PPG ADC during detected sleep
+    // Five-minute SDNN index (ms), separate from avgHrv (RMSSD). Strap rows compute it from in-bed R-R;
+    // Apple Health rows mirror the source SDNN. Health Connect RMSSD does not populate this column.
+    val avgSdnn: Double? = null,
 )
 
 /**

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -53,7 +53,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         V18AuxSampleEntity::class,
         AppleStepHour::class,
     ],
-    version = 31,
+    version = 32,
     // #775: ON so Room's KSP processor writes the generated schema (every table's exact `CREATE TABLE`,
     // columns in declaration order with affinity/NOT NULL/default, PK and indices) as JSON. That export
     // is what lets a plain JVM test — no device, no Robolectric — read Android's REAL schema and compare
@@ -70,7 +70,7 @@ abstract class WhoopDatabase : RoomDatabase() {
         const val DB_NAME = "noop_whoop.db"
         /** Room schema version — MUST equal the `@Database(version = …)` above. Surfaced in the backup
          *  manifest (#1410) so an export states its schema. Bump both together on a migration. */
-        const val SCHEMA_VERSION = 31
+        const val SCHEMA_VERSION = 32
 
         @Volatile
         private var instance: WhoopDatabase? = null
@@ -874,6 +874,20 @@ abstract class WhoopDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * v31 -> v32: append the nullable five-minute SDNN-index column to `dailyMetric`. Existing rows
+         * remain null: avgHrv is RMSSD for native/Health Connect rows and must never be backfilled as SDNN.
+         */
+        internal val DAILY_SDNN_MIGRATION_SQL: List<String> = listOf(
+            "ALTER TABLE `dailyMetric` ADD COLUMN `avgSdnn` REAL",
+        )
+
+        internal val MIGRATION_31_32 = object : Migration(31, 32) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                for (stmt in DAILY_SDNN_MIGRATION_SQL) db.execSQL(stmt)
+            }
+        }
+
         private fun build(appContext: Context): WhoopDatabase =
             Room.databaseBuilder(appContext, WhoopDatabase::class.java, DB_NAME)
                 // #1014: replace ONLY the corruption handling of the default open-helper. The
@@ -892,7 +906,7 @@ abstract class WhoopDatabase : RoomDatabase() {
                     MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
                     MIGRATION_22_23, MIGRATION_23_24, MIGRATION_24_25, MIGRATION_25_26,
                     MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30,
-                    MIGRATION_30_31,
+                    MIGRATION_30_31, MIGRATION_31_32,
                 )
                 // #1037: a FRESH install builds the schema straight at the current version and runs NO
                 // migrations, so the MIGRATION_7_8 "my-whoop" registry seed never fires and the WHOOP,

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -2275,6 +2275,7 @@ class WhoopRepository(
                 // Independent columns: each stands alone, so a plain per-column fill is safe.
                 restingHr = winner.restingHr ?: filler.restingHr,
                 avgHrv = winner.avgHrv ?: filler.avgHrv,
+                avgSdnn = winner.avgSdnn ?: filler.avgSdnn,
                 recovery = winner.recovery ?: filler.recovery,
                 strain = winner.strain ?: filler.strain,
                 exerciseCount = winner.exerciseCount ?: filler.exerciseCount,
@@ -2376,6 +2377,7 @@ class WhoopRepository(
                     disturbances = d.disturbances ?: c.disturbances,
                     restingHr = d.restingHr ?: c.restingHr,
                     avgHrv = d.avgHrv ?: c.avgHrv,
+                    avgSdnn = d.avgSdnn ?: c.avgSdnn,
                     recovery = d.recovery ?: c.recovery,
                     strain = d.strain ?: c.strain,
                     exerciseCount = d.exerciseCount ?: c.exerciseCount,

--- a/android/app/src/main/java/com/noop/ingest/AppleHealthImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/AppleHealthImporter.kt
@@ -405,22 +405,7 @@ object AppleHealthImporter {
                 d.respRate != null || d.asleepMin != null || d.deepMin != null || d.remMin != null ||
                 d.coreMin != null || d.steps != null
             if (hasDailyMetric) {
-                dailyMetricRows += DailyMetric(
-                    deviceId = deviceId,
-                    day = d.day,
-                    totalSleepMin = d.asleepMin,
-                    deepMin = d.deepMin,
-                    remMin = d.remMin,
-                    lightMin = d.coreMin, // Apple "core" sleep is the light-sleep stage
-                    restingHr = d.restingHr?.let { Math.round(it).toInt() },
-                    avgHrv = d.hrvSDNN,
-                    spo2Pct = d.spo2Pct,
-                    respRateBpm = d.respRate,
-                    // #89: Apple Health steps must land in DailyMetric.steps too — FusionDayAdapter reads the
-                    // daily step total via WhoopRepository.dailyColumn("steps") = d.steps, so leaving it null
-                    // (the pre-fix state) meant imported Apple steps never surfaced. `d.steps` is a Double.
-                    steps = d.steps?.let { Math.round(it).toInt() },
-                )
+                dailyMetricRows += dailyMetricRow(d, deviceId)
             }
 
             // Flattened metric points — mirrors AppleHealthAggregator.metricPoints key set.
@@ -508,6 +493,8 @@ object AppleHealthImporter {
     internal class ParseProbe(
         /** Finalized per-day aggregates, ascending by day. */
         val days: List<DailyAggView>,
+        /** DailyMetric rows produced by the same mapping production persists. */
+        val dailyMetrics: List<DailyMetric>,
         val workoutCount: Int,
         /** Finalized workout rows (exposes energy/distance/HR for the WorkoutStatistics tests). */
         val workouts: List<WorkoutRow>,
@@ -527,15 +514,41 @@ object AppleHealthImporter {
     internal fun parseStreamForTest(input: InputStream): ParseProbe {
         val agg = Aggregator()
         parseXml(input, agg)
-        val days = agg.finishDays().map { DailyAggView(it.day, it.avgHr, it.maxHr, it.steps) }
+        val finalized = agg.finishDays()
+        val days = finalized.map { DailyAggView(it.day, it.avgHr, it.maxHr, it.steps) }
+        val dailyMetrics = finalized.filter { d ->
+            d.restingHr != null || d.hrvSDNN != null || d.spo2Pct != null || d.respRate != null ||
+                d.asleepMin != null || d.deepMin != null || d.remMin != null || d.coreMin != null ||
+                d.steps != null
+        }.map { dailyMetricRow(it, DEFAULT_DEVICE_ID) }
         val workouts = agg.finishWorkouts(DEFAULT_DEVICE_ID)
         return ParseProbe(
             days = days,
+            dailyMetrics = dailyMetrics,
             workoutCount = workouts.size,
             workouts = workouts,
             skippedSpans = agg.skippedSpanCount(),
         )
     }
+
+    /** One canonical Apple aggregate -> DailyMetric mapping, shared by production persistence and tests. */
+    private fun dailyMetricRow(d: DailyAgg, deviceId: String): DailyMetric = DailyMetric(
+        deviceId = deviceId,
+        day = d.day,
+        totalSleepMin = d.asleepMin,
+        deepMin = d.deepMin,
+        remMin = d.remMin,
+        lightMin = d.coreMin,
+        restingHr = d.restingHr?.let { Math.round(it).toInt() },
+        // Apple Health's source metric is SDNN. Keep avgHrv populated for existing recovery behaviour,
+        // and also store it under the semantically correct independent field.
+        avgHrv = d.hrvSDNN,
+        avgSdnn = d.hrvSDNN,
+        spo2Pct = d.spo2Pct,
+        respRateBpm = d.respRate,
+        // #89: the daily total must also reach DailyMetric.steps for FusionDayAdapter.
+        steps = d.steps?.let { Math.round(it).toInt() },
+    )
 
     // ------------------------------------------------------------------------
     // Helpers — prefix stripping, dedupe key, sleep-stage mapping.

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -651,6 +651,8 @@ object HealthConnectImporter {
                             day = day,
                             totalSleepMin = sleep,
                             restingHr = rhr,
+                            // Health Connect exposes RMSSD, not SDNN: keep avgSdnn null rather than
+                            // relabelling a different statistic. Apple Health's SDNN importer fills both.
                             avgHrv = hrv,
                             spo2Pct = spo2,
                             respRateBpm = resp,

--- a/android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt
@@ -667,6 +667,7 @@ object WhoopCsvImporter {
         disturbances = base.disturbances ?: fill.disturbances,
         restingHr = base.restingHr ?: fill.restingHr,
         avgHrv = base.avgHrv ?: fill.avgHrv,
+        avgSdnn = base.avgSdnn ?: fill.avgSdnn,
         recovery = base.recovery ?: fill.recovery,
         strain = base.strain ?: fill.strain,
         exerciseCount = base.exerciseCount ?: fill.exerciseCount,

--- a/android/app/src/test/java/com/noop/analytics/AnalyticsEngineProvidedSleepTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/AnalyticsEngineProvidedSleepTest.kt
@@ -64,6 +64,7 @@ class AnalyticsEngineProvidedSleepTest {
         // HRV & resting HR re-derived from THIS day's rr/hr over the provided window (the ring row carried
         // neither) — the crux of #804 (avgHrv was nil despite 36 k rr present).
         assertNotNull("avgHrv must be derived from rr over the provided window", res.daily.avgHrv)
+        assertNotNull("avgSdnn must be derived from rr inside matched sleep", res.daily.avgSdnn)
         assertNotNull(res.daily.restingHr)
     }
 
@@ -77,6 +78,7 @@ class AnalyticsEngineProvidedSleepTest {
         // No gravity + no provided hypnogram = the pre-fix #804 state: the night does not score.
         assertNull(omitted.daily.totalSleepMin)
         assertNull(omitted.daily.avgHrv)
+        assertNull(omitted.daily.avgSdnn)
     }
 
     @Test

--- a/android/app/src/test/java/com/noop/analytics/HrvAnalyzerSdnnIndexTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvAnalyzerSdnnIndexTest.kt
@@ -1,0 +1,60 @@
+package com.noop.analytics
+
+import com.noop.data.RrInterval
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Shared contract vectors for the Swift/Kotlin five-minute SDNN index. */
+class HrvAnalyzerSdnnIndexTest {
+    private fun rr(values: List<Int>, start: Long = 0L): List<RrInterval> =
+        values.mapIndexed { i, value -> RrInterval("t", start + i, value) }
+
+    @Test
+    fun rejectsEmptySparseAndNonPositiveSegments() {
+        assertNull(HrvAnalyzer.sdnnIndex(emptyList(), segmentSec = 100))
+        assertNull(HrvAnalyzer.sdnnIndex(rr(List(19) { 800 }), segmentSec = 100))
+        assertNull(HrvAnalyzer.sdnnIndex(rr(List(20) { 800 }), segmentSec = 0))
+    }
+
+    @Test
+    fun oneQualifyingConstantSegmentIsZero() {
+        assertEquals(0.0, HrvAnalyzer.sdnnIndex(rr(List(20) { 800 }), segmentSec = 100)!!, 0.0)
+    }
+
+    @Test
+    fun oneSegmentMatchesSampleSdnn() {
+        val values = List(20) { if (it % 2 == 0) 790 else 810 }
+        assertEquals(10.25978352085154, HrvAnalyzer.sdnnIndex(rr(values), 100)!!, 1e-12)
+    }
+
+    @Test
+    fun averagesQualifyingSegmentsAndUsesInclusiveBoundaries() {
+        val first = List(20) { if (it % 2 == 0) 790 else 810 }
+            .mapIndexed { i, value -> RrInterval("t", i.toLong(), value) }
+        val boundary = List(20) { RrInterval("t", 100L + it, 800) }
+        assertEquals(5.12989176042577, HrvAnalyzer.sdnnIndex(first + boundary, 100)!!, 1e-12)
+    }
+
+    @Test
+    fun skipsSegmentsThatDoNotHaveTwentyCleanIntervals() {
+        val rejected = List(19) { RrInterval("t", it.toLong(), 800) } +
+            RrInterval("t", 19L, 2_001)
+        val qualifying = List(20) { RrInterval("t", 100L + it, 800) }
+        assertEquals(0.0, HrvAnalyzer.sdnnIndex(rejected + qualifying, 100)!!, 0.0)
+        assertNull(HrvAnalyzer.sdnnIndex(rejected, 100))
+    }
+
+    @Test
+    fun stripsInterSegmentDrift() {
+        val values = buildList {
+            repeat(50) { add(if (it % 2 == 0) 795 else 805) }
+            repeat(50) { add(if (it % 2 == 0) 895 else 905) }
+            repeat(50) { add(if (it % 2 == 0) 995 else 1005) }
+        }
+        val index = HrvAnalyzer.sdnnIndex(rr(values), segmentSec = 50)!!
+        assertEquals(5.050762722761053, index, 1e-12)
+        assertTrue(HrvAnalyzer.analyzeRaw(values.map(Int::toDouble)).sdnn!! > 50.0)
+    }
+}

--- a/android/app/src/test/java/com/noop/data/AppleStepHourMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/AppleStepHourMigrationTest.kt
@@ -52,10 +52,10 @@ class AppleStepHourMigrationTest {
         assertEquals(31, WhoopDatabase.MIGRATION_30_31.endVersion)
     }
 
-    /** The declared schema version must track the `@Database(version = …)` the migration lands on. */
+    /** A later schema bump must keep this migration connected to the next migration in the chain. */
     @Test
-    fun schemaVersionConstant_matchesMigrationTarget() {
-        assertEquals(WhoopDatabase.MIGRATION_30_31.endVersion, WhoopDatabase.SCHEMA_VERSION)
+    fun migrationTarget_matchesNextMigrationStart() {
+        assertEquals(WhoopDatabase.MIGRATION_30_31.endVersion, WhoopDatabase.MIGRATION_31_32.startVersion)
     }
 
     /**

--- a/android/app/src/test/java/com/noop/data/DailySdnnMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/DailySdnnMigrationTest.kt
@@ -1,0 +1,30 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DailySdnnMigrationTest {
+    @Test
+    fun migrationIsOneNullableAdditiveColumn() {
+        val sql = WhoopDatabase.DAILY_SDNN_MIGRATION_SQL
+        assertEquals(listOf("ALTER TABLE `dailyMetric` ADD COLUMN `avgSdnn` REAL"), sql)
+        val upper = sql.single().uppercase()
+        assertTrue(upper.startsWith("ALTER TABLE"))
+        assertTrue(!upper.contains("NOT NULL") && !upper.contains("DEFAULT"))
+        for (banned in listOf("DROP ", "DELETE ", "UPDATE ", "INSERT ", "RENAME ")) {
+            assertTrue("migration must not contain $banned", !upper.contains(banned))
+        }
+    }
+
+    @Test
+    fun migrationAndEntityPreserveOldRowsAsNull() {
+        assertEquals(31, WhoopDatabase.MIGRATION_31_32.startVersion)
+        assertEquals(32, WhoopDatabase.MIGRATION_31_32.endVersion)
+        assertEquals(32, WhoopDatabase.SCHEMA_VERSION)
+        val old = DailyMetric(deviceId = "my-whoop", day = "2026-08-22", avgHrv = 44.0)
+        assertNull(old.avgSdnn)
+        assertEquals(88.4, old.copy(avgSdnn = 88.4).avgSdnn!!, 0.0)
+    }
+}

--- a/android/app/src/test/java/com/noop/data/EditMergePrecedenceTest.kt
+++ b/android/app/src/test/java/com/noop/data/EditMergePrecedenceTest.kt
@@ -73,6 +73,15 @@ class EditMergePrecedenceTest {
     }
 
     @Test
+    fun importedRowGapFillsComputedSdnnWithoutConflatingHrv() {
+        val imported = DailyMetric("apple-health", "2026-06-12", avgHrv = 44.0)
+        val computed = DailyMetric("my-whoop-noop", "2026-06-12", avgHrv = 55.0, avgSdnn = 88.0)
+        val merged = WhoopRepository.mergeDaily(listOf(imported), listOf(computed)).single()
+        assertEquals(44.0, merged.avgHrv!!, 0.0)
+        assertEquals(88.0, merged.avgSdnn!!, 0.0)
+    }
+
+    @Test
     fun userEditedDays_keyedByLocalWakeDay() {
         val endTs = 1_780_000_000L
         val edited = SleepSession(

--- a/android/app/src/test/java/com/noop/data/ReadSpineUnionTest.kt
+++ b/android/app/src/test/java/com/noop/data/ReadSpineUnionTest.kt
@@ -108,7 +108,7 @@ class ReadSpineUnionTest {
         val other = DailyMetric(
             deviceId = "$canonical-noop", day = day,
             totalSleepMin = 435.0, efficiency = 91.0, deepMin = 96.0, remMin = 110.0, lightMin = 229.0,
-            recovery = 93.2, restingHr = 64, avgHrv = 37.06, strain = 8.4,
+            recovery = 93.2, restingHr = 64, avgHrv = 37.06, avgSdnn = 81.5, strain = 8.4,
         )
         val merged = WhoopRepository.unionByDay(listOf(listOf(active), listOf(other))).single()
         assertEquals("the winner's identity is kept", "$reAdded-noop", merged.deviceId)
@@ -118,6 +118,7 @@ class ReadSpineUnionTest {
         assertEquals(93.2, merged.recovery)
         assertEquals(64, merged.restingHr)
         assertEquals(37.06, merged.avgHrv)
+        assertEquals(81.5, merged.avgSdnn)
         assertEquals(8.4, merged.strain)
     }
 

--- a/android/app/src/test/java/com/noop/ingest/AppleHealthImporterToleranceTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/AppleHealthImporterToleranceTest.kt
@@ -129,6 +129,20 @@ class AppleHealthImporterToleranceTest {
         assertEquals(61.0, probe.days.single().avgHr!!, 1e-9)
     }
 
+    @Test
+    fun appleSdnnPopulatesBothLegacyHrvAndExplicitSdnn() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <HealthData>
+             <Record type="HKQuantityTypeIdentifierHeartRateVariabilitySDNN" sourceName="Watch" unit="ms" startDate="2024-01-02 02:00:00 +0000" endDate="2024-01-02 02:01:00 +0000" value="88.4"/>
+            </HealthData>
+        """.trimIndent().toByteArray(Charsets.UTF_8)
+
+        val row = AppleHealthImporter.parseStreamForTest(ByteArrayInputStream(xml)).dailyMetrics.single()
+        assertEquals(88.4, row.avgHrv!!, 1e-9)
+        assertEquals(88.4, row.avgSdnn!!, 1e-9)
+    }
+
     /**
      * TOLERANT PARSE: a hard, structural XML error (a broken tag the sanitizer can't fix) AFTER at
      * least one record keeps the partial result and reports the truncated tail as a skipped span.

--- a/android/app/src/test/resources/schema_oracle.json
+++ b/android/app/src/test/resources/schema_oracle.json
@@ -1,6 +1,6 @@
 {
   "_readme": "SHARED Room<->GRDB SCHEMA ORACLE (#775). Two byte-identical copies: Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json and android/app/src/test/resources/schema_oracle.json. SchemaOracleTests.swift compares GRDB's PRAGMA table_info/index_list against it; SchemaOracleTest.kt compares Room's exported schema JSON against it. `columns` is the iOS/GRDB shape in GRDB column order (macOS is the reference implementation); every way Android differs is spelled out in an `android` / `iosAbsent` / `androidColumnOrder` override naming a key in `divergenceReasons`. Adding a column, reordering one, or changing a type/nullability on one platform only fails both suites until it is either fixed or written down here.",
-  "roomVersion": 31,
+  "roomVersion": 32,
   "grdbMigrations": [
     "v1",
     "v2",
@@ -44,7 +44,6 @@
   "divergenceReasons": {
     "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android \u2014 the per-row upload flag belongs to an upload path that does not exist there \u2014 so it is dead width, not divergent data. Removing it needs a Room table rebuild.",
     "battery-alter-append-order": "REAL COLUMN-ORDER DRIFT (CLAUDE.md: 'column order in a Room CREATE TABLE must match the entity field order'). GRDB appended `synced` (v5) then `charging` (v6) with ALTER TABLE, which can only append; the Room entity declares `charging` before `synced`. Same columns, same types, different positions \u2014 so any positional copy (INSERT INTO battery SELECT * FROM \u2026) swaps them. Fixing it means reordering the Room entity's fields, which changes Room's identity hash and therefore needs a version bump plus a no-op migration.",
-    "daily-avg-sdnn-ios-only": "REAL COLUMN DRIFT, deliberate and one-directional: `dailyMetric.avgSdnn` (the 5-min SDNN index) is written by the Swift nightly analysis and has no Room twin, because the Android analytics reimplementation computes RMSSD only — there is no Kotlin `sdnnIndex` to persist. Adding the Room column without the computation would store NULL on every Android row, which is a fabricated parity, not a real one; the honest shape is an absent column until the Kotlin twin exists. Consequence: a .noopbak exported from iOS carries a column Android's `dailyMetric` cannot receive, in the same direction as `workout.routePolyline` but reversed. Closing it means porting `HRVAnalyzer.sdnnIndex` to Kotlin plus a Room version bump.",
     "grdb-boolean-affinity": "GRDB's .boolean column type is declared BOOLEAN, which SQLite gives NUMERIC affinity; Room maps Kotlin Boolean to INTEGER. For the 0/1 values both sides write, NUMERIC and INTEGER affinity store bit-identical INTEGERs, so a .noopbak round-trips. Closing it means a GRDB table rebuild.",
     "paired-device-alter-append-order": "REAL COLUMN-ORDER DRIFT, same shape as battery. GRDB's v16-paired-device-peripheral appended `peripheralId` at the end; the Room entity declares it fifth, between `nickname` and `sourceKind`.",
     "ppg-hr-bpm-integer-on-android": "AFFINITY DRIFT, and NOT a data consequence: ppgHrSample.bpm is declared REAL on iOS and INTEGER on Android \u2014 but only the SQLITE COLUMN differs. The ROW type is `Int` on both sides: Swift's `PpgHrSample.bpm` is `Int`, carrying the comment 'the same Int domain as the measured HRSample.bpm and the Android PpgHr.Estimate.bpm, so the stored value and type match across platforms (#219)'. Both platforms also round to whole bpm before that \u2014 Swift `(fsD * 60 / refinedLag).rounded()` then `Int(est.bpm)`, Kotlin `Math.round(fsD * 60 / refinedLag).toInt()` \u2014 and the read path (`CAST(ROUND(p.bpm) AS INTEGER)`) rounds again, a no-op on a whole number. There is one writer and one construction site on each side. So REAL holds the same whole numbers INTEGER does and NO value differs. Recorded because the DECLARED affinity genuinely diverges, and a bpm that ever became fractional would then diverge silently; closing it means a GRDB table rebuild. Deliberately NOT the decoder-oracle (#869) class \u2014 that caught a real value divergence.",
@@ -363,9 +362,7 @@
           "name": "avgSdnn",
           "affinity": "REAL",
           "notNull": false,
-          "default": null,
-          "androidAbsent": true,
-          "divergence": "daily-avg-sdnn-ios-only"
+          "default": null
         }
       ],
       "primaryKey": [


### PR DESCRIPTION
## Why

Android currently stores nightly RMSSD but lacks the separate five-minute SDNN index already computed and persisted on iOS. This closes that data and schema gap so native Android nights and cross-platform backups can carry the same distinct metric.

## Scope

- port the cleaned, segmented SDNN-index calculation to Kotlin
- compute it from R-R intervals inside matched sleep sessions
- add nullable `DailyMetric.avgSdnn` and preserve it through merge/coalescing paths
- bump Room 31 to 32 with one additive nullable column
- map Apple Health SDNN to both the legacy `avgHrv` compatibility field and the new semantically correct `avgSdnn`
- keep Health Connect RMSSD in `avgHrv`; it must not be relabelled as SDNN
- remove the resolved Android schema-oracle divergence

Existing rows remain null. There is deliberately no RMSSD-to-SDNN backfill.

## Verification

- exact Kotlin SDNN vectors cover empty/sparse input, cleaning, segment boundaries, inter-segment drift, and qualifying-segment averaging
- analytics sleep-scope, Apple import, merge/union, migration contract, and both schema-oracle copies are covered
- Demo and Full Android unit-test suites pass (4,199 tests in Demo; 6 intentional skips)
- two independent frozen-delta reviews report P0=0 and P1=0

Migration verification is static plus Room KSP schema verification. The repository currently has no Room runtime migration-test harness, so this PR does not claim an exercised on-device SQLite 31-to-32 upgrade.

## Non-goals

No UI, score, baseline, Health Connect export, or trust-gating behavior changes. Shared trust hardening remains a separate cross-platform concern.

Closes bhelm/noop#18