### PR TITLE
fix: round the imported Apple step total on Apple, matching Android

### DIFF
--- a/Strand/Data/AppleHealthImport.swift
+++ b/Strand/Data/AppleHealthImport.swift
@@ -7,6 +7,21 @@ import StrandImport
 /// consensus. Populates appleDaily, dailyMetric, the generic metricSeries, and workouts.
 enum AppleHealthImport {
 
+    /// Apple's per-day aggregates arrive as `Double`, and a step total genuinely can be fractional: the
+    /// aggregator accumulates per source (`stepsBySource[…] += v`) before taking the winning source's
+    /// figure, and nothing constrains a source to whole counts.
+    ///
+    /// ROUNDS, for two reasons. It matches every other count/rate converted on the same rows — `avgHr`,
+    /// `maxHr`, `walkingHr`, `restingHr` all use `Int($0.rounded())` — and it matches the Kotlin twin's
+    /// `Math.round(it).toInt()`. Truncating made the same Apple export store a step total one LOWER on
+    /// Apple than on Android for any fractional day, which is stored-data divergence on an imported
+    /// column. (#1535 follow-up)
+    ///
+    /// The two rules agree here because step counts are non-negative: Swift's `.rounded()` is
+    /// half-away-from-zero and Kotlin's `Math.round` is half-up, which differ only for negatives.
+    static func stepsInt(_ v: Double) -> Int { Int(v.rounded()) }
+
+
     /// The Apple Health mapping revision, stamped into the Import test-mode parser line. Bump when this
     /// importer's aggregate->store mapping changes.
     static let importerVersion = 1
@@ -25,7 +40,7 @@ enum AppleHealthImport {
         // Apple-specific daily aggregates (steps/energy/vo2/hr/weight).
         let appleRows = daily.map { d in
             AppleDaily(day: d.day,
-                       steps: d.steps.map { Int($0) },
+                       steps: d.steps.map(stepsInt),
                        activeKcal: d.activeKcal, basalKcal: d.basalKcal, vo2max: d.vo2max,
                        avgHr: d.avgHr.map { Int($0.rounded()) },
                        maxHr: d.maxHr.map { Int($0.rounded()) },
@@ -48,7 +63,7 @@ enum AppleHealthImport {
                         // #89: Apple Health steps must land in DailyMetric.steps too — the sourced-daily
                         // arbitration resolves "steps" via metricValue(d) = d.steps, so leaving it nil (the
                         // pre-fix state) meant imported Apple steps never surfaced there.
-                        steps: d.steps.map { Int($0) },
+                        steps: d.steps.map(stepsInt),
                         avgSdnn: d.hrvSDNN)   // Apple HRV is SDNN — mirror into the SDNN field
         }
         let dmWritten = try await store.upsertDailyMetrics(dm, deviceId: deviceId)

--- a/StrandTests/AppleStepsRoundingTests.swift
+++ b/StrandTests/AppleStepsRoundingTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import Strand
+
+/// #1535 follow-up: the Apple step total must reach storage as the SAME integer on both platforms.
+///
+/// Apple's per-day figures arrive as `Double` and a step total genuinely can be fractional — the
+/// aggregator accumulates per source before the winning source's figure is taken, and nothing constrains
+/// a source to whole counts. Apple truncated where Android rounded, so one fractional day stored a total
+/// one lower on Apple than on Android from the same export.
+///
+/// Pins the rule rather than the symptom: these are the values Kotlin's `Math.round(it).toInt()` produces
+/// for the same inputs.
+final class AppleStepsRoundingTests: XCTestCase {
+
+    /// A whole total is unchanged — the common case must not move.
+    func testWholeTotalsAreUnchanged() {
+        XCTAssertEqual(AppleHealthImport.stepsInt(10_432), 10_432)
+        XCTAssertEqual(AppleHealthImport.stepsInt(0), 0)
+    }
+
+    /// The regression: truncation lost a step here, so Apple stored 10432 against Android's 10433.
+    func testAFractionalTotalRoundsRatherThanTruncating() {
+        XCTAssertEqual(AppleHealthImport.stepsInt(10_432.6), 10_433)
+        XCTAssertEqual(AppleHealthImport.stepsInt(10_432.4), 10_432)
+    }
+
+    /// The half case, where the two languages' rules could have disagreed. Swift's `.rounded()` is
+    /// half-away-from-zero and Kotlin's `Math.round` is half-up; they agree for the non-negative values a
+    /// step count can take, and this pins that agreement rather than assuming it.
+    func testTheHalfCaseMatchesTheKotlinRule() {
+        XCTAssertEqual(AppleHealthImport.stepsInt(10_432.5), 10_433)
+        XCTAssertEqual(AppleHealthImport.stepsInt(0.5), 1)
+    }
+}


### PR DESCRIPTION
Follow-up to #1535. Found while reviewing that PR's Apple import mapping — not introduced by it.

## The divergence

The same Apple Health export stored a different step count on each platform:

```swift
steps: d.steps.map { Int($0) }                      // Apple  — truncates
```
```kotlin
steps = d.steps?.let { Math.round(it).toInt() }     // Android — rounds
```

A fractional daily total is reachable rather than theoretical: `AppleHealthAggregator` accumulates per source (`stepsBySource[…] += v`) before the winning source's figure is taken, and nothing constrains a source to whole counts. On such a day Apple stored a total one lower than Android from the same file — stored-data divergence on an imported column, which is the class the parity contract exists to catch.

## Why rounding is the side to converge on

This is an oversight, not a policy. **Every other count and rate converted on the same rows already rounds** — `avgHr`, `maxHr`, `walkingHr` on the `AppleDaily` row and `restingHr` on the `DailyMetric` row all use `Int($0.rounded())`. `steps` was the only field on the row that didn't, and Android rounds throughout. So Apple was inconsistent with itself before it was inconsistent with Android.

## On the extraction

Both sites now go through one `AppleHealthImport.stepsInt`. I extracted it because the conversion lived inside a file-IO function and had no test seam at all — the same shape #1535 used for `dailyMetricRow`, so the test exercises the production conversion rather than a copy of it.

Swift's `.rounded()` is half-away-from-zero; Kotlin's `Math.round` is half-up. They differ only for negatives, which a step count cannot be — the test pins that agreement rather than assuming it, since it is the one input class where the two languages' rules could part company.

## Scope

- **No Android change.** It already rounds; this brings Apple to it.
- **No backfill.** This corrects future imports. Re-importing an affected export now stores the value both platforms agree on.
- The daily total's *derivation* was already identical and I checked rather than assumed: both platforms take `max` of `stepsBySource` (#589), both accumulate with `+=`. Only the final Double→Int step differed.
- I swept for other truncating conversions — `map { Int($0) }` now appears nowhere in the Swift tree, so these two were the only ones.

## Verification

- **app-build [32568897168](https://github.com/ryanbr/noop/actions/runs/32568897168) green on both legs**, `Test Strand` at **1,191 tests, 0 failures** — 1,188 before, so all three new tests ran rather than being silently skipped.
- Doc lint clean.

One thing stated plainly: I did not revert-and-rerun to prove the tests fail against the old behaviour, as I have on recent PRs. Here it is arithmetic rather than logic — `Int(10432.6)` is 10432 and the test demands 10433 — so a CI cycle would confirm something already certain from the expression.