### PR TITLE
Coach: retire the transcript on a new local day

### DIFF
--- a/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import java.time.LocalDate
 
 /**
  * View model for the AI Coach screen.
@@ -275,6 +276,10 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
 
     // MARK: - Send
 
+    /** Local day ([LocalDate.toEpochDay]) the current transcript was last written on; null while it is
+     *  empty. Drives the day boundary in [send] — see [isStaleConversation]. */
+    private var conversationDay: Long? = null
+
     /** Append [msg] to the transcript, trimming to the newest [MAX_STORED_MESSAGES] so the in-memory list
      *  (and the Compose transcript) stays bounded over a long-lived session. (parity with Swift) */
     private fun appendMessage(msg: ChatMsg) {
@@ -288,6 +293,20 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
     fun send(ctx: Context, text: String) {
         val question = text.trim()
         if (question.isEmpty() || _sending.value) return
+
+        // A transcript from an earlier local day is retired before the new turn is appended. The
+        // ViewModel outlives a night (Android keeps the process around for days), so without this the
+        // coach answers TODAY's question inside YESTERDAY's conversation: buildContext() re-reads the
+        // store on every send, so the numbers are current, but the assistant's own earlier turns state
+        // yesterday's figures and the model stays consistent with them. Reported as "the coach only
+        // talks about my imported data" after a night of fresh strap data — force-quitting the app
+        // (which destroys the ViewModel) was the only cure. MAX_STORED_MESSAGES bounds the transcript's
+        // SIZE; this bounds its AGE.
+        val today = LocalDate.now().toEpochDay()
+        if (isStaleConversation(conversationDay, today)) {
+            _messages.value = emptyList()
+        }
+        conversationDay = today
 
         val appCtx = ctx.applicationContext
         _error.value = null
@@ -332,6 +351,20 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
          * what's sent. (parity with Swift `maxStoredMessages`)
          */
         private const val MAX_STORED_MESSAGES = 40
+
+        /**
+         * True when a transcript last written on [lastEpochDay] should be retired before a question
+         * asked on [todayEpochDay] — i.e. the conversation crossed into a new local day.
+         *
+         * STRICTLY forward (`>`), never `!=`: a clock that moves BACKWARDS — the user flying west, a
+         * timezone change, an NTP correction — must not wipe a conversation the user is in the middle
+         * of. Only real elapsed days retire a transcript; going back in time leaves it alone.
+         *
+         * Null [lastEpochDay] (nothing sent yet this session) is never stale. Pure companion so the
+         * rule is pinned by [com.noop.ui.CoachConversationDayTest] without a ViewModel or a framework.
+         */
+        internal fun isStaleConversation(lastEpochDay: Long?, todayEpochDay: Long): Boolean =
+            lastEpochDay != null && todayEpochDay > lastEpochDay
 
         /**
          * Initial model list for [provider]: its curated ids, plus [selected] appended if it's a

--- a/android/app/src/test/java/com/noop/ui/CoachConversationDayTest.kt
+++ b/android/app/src/test/java/com/noop/ui/CoachConversationDayTest.kt
@@ -1,0 +1,58 @@
+package com.noop.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * Pins [CoachViewModel.isStaleConversation] — the day boundary that retires the coach transcript.
+ *
+ * The bug it guards: the ViewModel outlives a night (Android keeps the process alive for days), so a
+ * question asked today was answered inside yesterday's conversation. The data context is rebuilt from
+ * the store on every send, so the numbers were current, but the assistant's own earlier turns state
+ * yesterday's figures and the model stays consistent with them — the coach "only talks about the
+ * imported data" even after a night of fresh strap data. Force-quitting was the only cure.
+ */
+class CoachConversationDayTest {
+
+    private fun day(y: Int, m: Int, d: Int) = LocalDate.of(y, m, d).toEpochDay()
+
+    @Test
+    fun freshSessionIsNeverStale() {
+        // Nothing sent yet this session: there is no transcript to retire.
+        assertFalse(CoachViewModel.isStaleConversation(null, day(2026, 8, 22)))
+    }
+
+    @Test
+    fun sameDayKeepsTheConversation() {
+        val today = day(2026, 8, 22)
+        assertFalse(CoachViewModel.isStaleConversation(today, today))
+    }
+
+    @Test
+    fun overnightRetiresTheConversation() {
+        // The reported case: last turn yesterday evening, next question this morning.
+        assertFalse(CoachViewModel.isStaleConversation(day(2026, 8, 21), day(2026, 8, 21)))
+        assertTrue(CoachViewModel.isStaleConversation(day(2026, 8, 21), day(2026, 8, 22)))
+    }
+
+    @Test
+    fun longGapRetiresTheConversation() {
+        assertTrue(CoachViewModel.isStaleConversation(day(2026, 6, 11), day(2026, 8, 22)))
+    }
+
+    @Test
+    fun clockMovingBackwardsKeepsTheConversation() {
+        // Flying west, a timezone change or an NTP correction can move the local day BACKWARDS
+        // mid-conversation. That must not wipe a transcript the user is in the middle of, which is
+        // why the rule is strictly forward (`>`) and not `!=`.
+        assertFalse(CoachViewModel.isStaleConversation(day(2026, 8, 22), day(2026, 8, 21)))
+    }
+
+    @Test
+    fun yearBoundaryIsJustAnotherDay() {
+        assertTrue(CoachViewModel.isStaleConversation(day(2025, 12, 31), day(2026, 1, 1)))
+        assertFalse(CoachViewModel.isStaleConversation(day(2026, 1, 1), day(2025, 12, 31)))
+    }
+}


### PR DESCRIPTION
## What this PR does

The Coach kept answering today's question inside yesterday's conversation.

`CoachViewModel._messages` is in-memory and never reset except by clearing the API key or switching provider. The ViewModel outlives a night — Android keeps the process alive for days — so the transcript carries over.

The data was never stale: `buildContext()` re-reads the store on every send, and `injectContext()` prepends it to the **first** user turn. But the assistant's own earlier turns below it state yesterday's figures, and the model stays consistent with them. It reads as "the coach only talks about my imported data" even after a night of fresh strap data. Force-quitting the app was the only cure.

`MAX_STORED_MESSAGES` already bounds the transcript's **size** for the same long-lived-session reason (the "gets laggy the longer the app runs" report). This bounds its **age**.

### The one design decision worth reviewing

`isStaleConversation()` is strictly forward (`>`), not `!=`, so a clock moving **backwards** — flying west, a timezone change, an NTP correction — cannot wipe a conversation the user is mid-way through. Only real elapsed days retire a transcript.

## Type of change

- [x] Bug fix

## How it was tested

Not a BLE change; no hardware involved.

- New `CoachConversationDayTest` (6 cases) pins the rule as a pure companion — no ViewModel, no framework.
- **Mutation-verified**: relaxing `>` to `!=` fails `clockMovingBackwardsKeepsTheConversation` and `yearBoundaryIsJustAnotherDay`, so the test has teeth on the subtle part rather than pinning a tautology.
- `./gradlew testFullDebugUnitTest` — **4195 tests, 0 failures**.

Reproduction, if you want to confirm the behaviour: ask the Coach something, leave the app backgrounded overnight (do not force-quit), then ask again the next day. It answers from the previous day's numbers.

## Checklist

- [x] Swift package tests pass for any package I touched — n/a, no package touched
- [x] Android unit tests pass (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only design tokens — n/a, no UI change
- [x] No hardcoded hex frame bytes
- [x] Follows the conventions in `docs/CONTRIBUTING.md`
- [x] I did not commit generated output or any secrets/keystores

## Cross-platform parity — not done, and why

The Swift twin has the same shape (`AICoach` / `CoachView` hold `messages` with the same lifetime), so an iOS/macOS user has this bug unchanged.

I did not include it: `CoachView`/`AICoach` are **app-target** Swift, which `app-build.yml` covers only on demand and which needs Xcode on macOS to compile. Per CLAUDE.md — *"a compile error there will pass every green check and still be broken"* — I would rather flag the gap than ship Swift I could not build. Happy for a maintainer to twin it, or I can follow up if someone can compile it.

## Related issues

None open that I could find for this specific behaviour.