### PR TITLE
5/MG haptics: carry the repeat count into overallLoop — BuzzPattern works on a 5/MG (#926)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -465,6 +465,36 @@ class WhoopBleClient(
          */
         const val DEFAULT_DEVICE_ID = "my-whoop"
 
+        /**
+         * Build the WHOOP 5/MG ("maverick") haptic body from a 4.0-shaped `[patternId, loops, 0, 0, 0]`
+         * payload, carrying the repeat count through to the wire.
+         *
+         * Layout (docs/BLE_REVERSE_ENGINEERING.md:771):
+         * ```
+         *   [0]      REVISION_1 = 0x01
+         *   [1..8]   effects x8 — the "notify" preset (47, 152, then 0)
+         *   [9..10]  loopControl, u16 LE  — left 0, as in the shipped alarm body
+         *   [11]     overallLoop          — the repeat count (was hardcoded 0)
+         * ```
+         *
+         * EXPERIMENT (#926): byte 11 used to be 0 unconditionally, which is why every BuzzPattern felt
+         * the same on a 5/MG. `AlarmPayload` already ships this exact effects pair with overallLoop=7
+         * (pinned by AlarmPayloadTest), so a non-zero overallLoop is established in a real body — but
+         * that it drives the *notify* buzz's repeat count is HARDWARE-UNVERIFIED. A malformed/oversized
+         * value is not written: the count is clamped to 1..7, the range the alarm body is known to use.
+         *
+         * Defensive: a payload shorter than 2 bytes (never emitted by [buzz], but [send] is generic)
+         * falls back to 1 rather than indexing out of bounds.
+         */
+        internal fun maverickHapticBody(payload: ByteArray): ByteArray {
+            val loops = if (payload.size >= 2) (payload[1].toInt() and 0xFF).coerceIn(1, 7) else 1
+            return byteArrayOf(
+                0x01,                                   // [0]     REVISION_1
+                47, 152.toByte(), 0, 0, 0, 0, 0, 0,     // [1..8]  effects x8 ("notify" preset)
+                0, 0,                                   // [9..10] loopControl u16 LE
+                loops.toByte(),                         // [11]    overallLoop
+            )
+        }
 
         // MARK: GATT UUIDs (authoritative, from BLEManager.swift / FINDINGS.md).
         //
@@ -3327,10 +3357,17 @@ class WhoopBleClient(
             // haptic body [0x01, effects(8), loopControl(u16 LE), overallLoop] — here the "notify" preset
             // (effects 47,152), NOT the 4.0 [patternId, loops, …]. puffinCommandFrame pads the inner to a
             // 4-byte boundary, which this 12-byte payload needs. WHOOP 4.0 is untouched (79 + its own frame).
+            //
+            // EXPERIMENT (#926): the literal above pinned overallLoop (byte 11) to 0, so the caller's
+            // repeat count never reached the wire and every BuzzPattern — plus the Breathe inhale/exhale
+            // and live-session long/short cues — felt identical on a 5/MG. This carries `loops` through
+            // into overallLoop instead. The prior is not a guess: AlarmPayload already ships the SAME
+            // effects (47,152) with loopControl=0 and overallLoop=7 (AlarmPayloadTest:62), so a non-zero
+            // overallLoop is an established part of a real maverick body. HARDWARE-UNVERIFIED until a
+            // real 5/MG confirms the buzz count actually changes — see mavericHapticBody.
             val isHaptics = cmd == CommandNumber.RUN_HAPTICS_PATTERN
             val puffinCmd = if (isHaptics) 0x13 else cmd.rawValue
-            val puffinPayload = if (isHaptics)
-                byteArrayOf(0x01, 47, 152.toByte(), 0, 0, 0, 0, 0, 0, 0, 0, 0) else payload
+            val puffinPayload = if (isHaptics) maverickHapticBody(payload) else payload
             val s = seq.incrementAndGet() and 0xFF
             val frame = Framing.puffinCommandFrame(cmd = puffinCmd, seq = s, payload = puffinPayload)
             enqueueWrite(PendingWrite(frame, withResponse, cmd))

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -477,22 +477,30 @@ class WhoopBleClient(
          *   [11]     overallLoop          — the repeat count (was hardcoded 0)
          * ```
          *
-         * EXPERIMENT (#926): byte 11 used to be 0 unconditionally, which is why every BuzzPattern felt
-         * the same on a 5/MG. `AlarmPayload` already ships this exact effects pair with overallLoop=7
-         * (pinned by AlarmPayloadTest), so a non-zero overallLoop is established in a real body — but
-         * that it drives the *notify* buzz's repeat count is HARDWARE-UNVERIFIED. A malformed/oversized
-         * value is not written: the count is clamped to 1..7, the range the alarm body is known to use.
+         * #926: byte 11 used to be 0 unconditionally, which is why every BuzzPattern felt the same on a
+         * 5/MG.
          *
+         * HARDWARE-CONFIRMED on a WHOOP 5/MG: `overallLoop` counts the repeats that follow the FIRST
+         * pulse, not the total — writing 3 produced FOUR buzzes. So it is written as `loops - 1`, and
+         * the model explains the old behaviour exactly: the shipped 0 meant "no repeats" = the single
+         * buzz every pattern used to give. It also matches `AlarmPayload`, which ships this same effects
+         * pair with overallLoop=7 (pinned by AlarmPayloadTest) for an alarm's long buzz train.
+         *
+         * Note the consequence: `loops = 1` reproduces the previously shipped, hardware-verified
+         * constant byte-for-byte, so this change is strictly additive — it only moves byte 11, and only
+         * when the caller asked for more than one pulse.
+         *
+         * Clamped to 1..8 (overallLoop 0..7), 7 being the largest value evidenced by the alarm body.
          * Defensive: a payload shorter than 2 bytes (never emitted by [buzz], but [send] is generic)
-         * falls back to 1 rather than indexing out of bounds.
+         * falls back to a single pulse rather than indexing out of bounds.
          */
         internal fun maverickHapticBody(payload: ByteArray): ByteArray {
-            val loops = if (payload.size >= 2) (payload[1].toInt() and 0xFF).coerceIn(1, 7) else 1
+            val loops = if (payload.size >= 2) (payload[1].toInt() and 0xFF).coerceIn(1, 8) else 1
             return byteArrayOf(
                 0x01,                                   // [0]     REVISION_1
                 47, 152.toByte(), 0, 0, 0, 0, 0, 0,     // [1..8]  effects x8 ("notify" preset)
                 0, 0,                                   // [9..10] loopControl u16 LE
-                loops.toByte(),                         // [11]    overallLoop
+                (loops - 1).toByte(),                   // [11]    overallLoop = repeats AFTER the first
             )
         }
 

--- a/android/app/src/main/java/com/noop/ui/NotificationsSettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/NotificationsSettingsScreen.kt
@@ -65,7 +65,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.noop.ble.WhoopModel
 import com.noop.notif.CallAlertController
 import com.noop.notif.CallAlertSource
 import java.util.Calendar
@@ -381,27 +380,12 @@ fun NotificationsSettingsScreen(vm: AppViewModel) {
             }
         }
 
-        // #926: on a 5/MG the buzz payload is a hardcoded 12-byte literal and byte[11] (overallLoop) is
-        // 0, so the caller's repeat count never reaches the wire — every BuzzPattern produces the same
-        // buzz. The picker still offers all four because the choice is stored per app and DOES apply to a
-        // WHOOP 4.0, so hiding it would lose a real setting. Say so instead, the way SmartAlarmScreen
-        // handles its own 5/MG-unconfirmed case, rather than leaving a control that silently does nothing.
-        // Match the Settings #22 gate (SettingsScreen showFiveMGControls, mirrored in TestCentreScreen:87):
-        // the stored model OR a live-detected 5/MG this session. `live.whoop5Detected` alone is reset on
-        // every scan and disconnect, so keying on it would hide this note whenever the strap is offline —
-        // which is exactly when someone browses notification settings. The Apple side reads `selectedModel`,
-        // which persists, so gating on live detection here would also make the two platforms disagree.
-        val fiveMgSelected = remember {
-            NoopPrefs.of(context).getString("noop.selectedWhoopModel", null) == WhoopModel.WHOOP5_MG.name
-        }
-        if (fiveMgSelected || live.whoop5Detected) {
-            Text(
-                uiString(R.string.l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6),
-                style = NoopType.caption,
-                color = Palette.textSecondary,
-                modifier = Modifier.padding(horizontal = Metrics.space16, vertical = Metrics.space8),
-            )
-        }
+        // #926: the "every pattern buzzes the same on a 5/MG" note that used to sit here is GONE — the
+        // limitation it described is fixed. overallLoop (byte 11 of the maverick haptic body) is now
+        // written as `loops - 1` in WhoopBleClient.maverickHapticBody, hardware-confirmed on a real
+        // 5/MG, so all four patterns are distinct on that family too. Leaving the note would be worse
+        // than never having had it: a caption telling the user their setting does nothing, next to a
+        // control that now works.
 
         // MARK: Category cards
         activeCategories.forEach { cat ->

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1859,7 +1859,6 @@
     <string name="l10n_settings_screen_r22disable_confirm_cancel">Nur nicht mehr senden</string>
     <string name="l10n_settings_screen_r22_accepted_all">✓ Band hat alle %1$d R22-Flags akzeptiert</string>
     <string name="l10n_settings_screen_r22_accepted_partial">Band hat %1$d/%2$d R22-Flags akzeptiert…</string>
-    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">Auf einer WHOOP 5/MG vibriert jedes Muster gleich — die Wiederholungszahl wird an dieses Band nicht gesendet. Deine Auswahl wird gespeichert und gilt für eine WHOOP 4.0.</string>
     <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">Wasser und Koffein aus Apple Health, ein genaueres Effort-Ergebnis und ein Oura-Ruhepuls-Fix</string>
     <!-- First-run onboarding copy. -->
     <string name="onboarding_cta_begin">Loslegen</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1826,7 +1826,6 @@
     <string name="l10n_settings_screen_r22disable_confirm_cancel">Solo dejar de enviar</string>
     <string name="l10n_settings_screen_r22_accepted_all">✓ La pulsera aceptó las %1$d marcas R22</string>
     <string name="l10n_settings_screen_r22_accepted_partial">La pulsera aceptó %1$d/%2$d marcas R22…</string>
-    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">En una WHOOP 5/MG todos los patrones vibran igual: el número de repeticiones no se envía a esa correa. Tu elección se guarda y se aplica a una WHOOP 4.0.</string>
     <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">Agua y cafeína desde Apple Health, una puntuación de Effort más precisa y una corrección del pulso en reposo de Oura</string>
     <!-- Textos de la configuración inicial. -->
     <string name="onboarding_cta_begin">Empezar</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1844,7 +1844,6 @@
     <string name="l10n_settings_screen_r22disable_confirm_cancel">Cesser seulement d’envoyer</string>
     <string name="l10n_settings_screen_r22_accepted_all">✓ Le bracelet a accepté les %1$d indicateurs R22</string>
     <string name="l10n_settings_screen_r22_accepted_partial">Le bracelet a accepté %1$d/%2$d indicateurs R22…</string>
-    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">Sur un WHOOP 5/MG, tous les motifs vibrent de la même façon — le nombre de répétitions n\'est pas envoyé à ce bracelet. Votre choix est enregistré et s\'applique à un WHOOP 4.0.</string>
     <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">L\'eau et la caféine depuis Apple Santé, un score Effort plus précis et un correctif de la FC au repos Oura</string>
     <!-- Textes de la configuration initiale. -->
     <string name="onboarding_cta_begin">Commencer</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -1813,7 +1813,6 @@
     <string name="l10n_settings_screen_r22disable_confirm_cancel">Po prostu przestań wysyłać</string>
     <string name="l10n_settings_screen_r22_accepted_all">✓ Pasek akceptuje wszystkie flagi %1$d R22</string>
     <string name="l10n_settings_screen_r22_accepted_partial">Pasek akceptowany %1$d/%2$d Flagi R22…</string>
-    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">Każdy wzór brzęczy tak samo na WHOOP 5/MG — liczba powtórzeń nie jest wysyłana do tego paska. Twój wybór został zapisany i dotyczy WHOOP 4.0.</string>
     <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">Woda i kofeina z Apple Health, ostrzejszy wynik Wysiłek i poprawka tętna spoczynkowego Oura</string>
     <string name="onboarding_cta_begin">Zaczynać</string>
     <string name="onboarding_cta_continue">Dalej</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1820,7 +1820,6 @@
     <string name="l10n_settings_screen_r22disable_confirm_cancel">Apenas parar de enviar</string>
     <string name="l10n_settings_screen_r22_accepted_all">✓ A pulseira aceitou as %1$d marcas R22</string>
     <string name="l10n_settings_screen_r22_accepted_partial">A pulseira aceitou %1$d/%2$d marcas R22…</string>
-    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">Numa WHOOP 5/MG todos os padrões vibram igual — a contagem de repetições não é enviada para essa bracelete. A tua escolha fica guardada e aplica-se a uma WHOOP 4.0.</string>
     <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">Água e cafeína a partir do Apple Health, uma pontuação de Effort mais precisa e uma correção da FC em repouso do Oura</string>
     <!-- Textos da configuração inicial. -->
     <string name="onboarding_cta_begin">Começar</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1754,7 +1754,6 @@
     <string name="l10n_settings_screen_r22disable_confirm_body">关闭此开关只会让 NOOP 停止发送解锁序列。已写入的标记会留在手环上，直到有东西清除它们。NOOP 现在可以向全部 16 个标记写入关闭值并逐一读回，让你看到手环实际存储的内容。需要手环已连接并完成配对。</string>
     <string name="l10n_settings_screen_r22disable_confirm_action">清除手环上的标记</string>
     <string name="l10n_settings_screen_r22disable_confirm_cancel">仅停止发送</string>
-    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">在 WHOOP 5/MG 上所有模式的震动都相同——重复次数不会发送到该手环。你的选择会被保存，并在 WHOOP 4.0 上生效。</string>
     <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">从 Apple 健康导入饮水与咖啡因、更精确的 Effort 分数，以及 Oura 静息心率修复</string>
     <!-- 首次设置文本。 -->
     <string name="onboarding_cta_begin">开始</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1870,7 +1870,6 @@
     <string name="l10n_settings_screen_r22disable_confirm_cancel">Just stop sending</string>
     <string name="l10n_settings_screen_r22_accepted_all">✓ Strap accepted all %1$d R22 flags</string>
     <string name="l10n_settings_screen_r22_accepted_partial">Strap accepted %1$d/%2$d R22 flags…</string>
-    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">Every pattern buzzes the same on a WHOOP 5/MG — the repeat count isn\'t sent to that strap. Your choice is saved and applies to a WHOOP 4.0.</string>
     <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">Water and caffeine from Apple Health, a sharper Effort score, and an Oura resting-heart-rate fix</string>
     <!-- First-run onboarding copy. Kept in resources so every visible setup string is localizable. -->
     <string name="onboarding_cta_begin">Begin</string>

--- a/android/app/src/test/java/com/noop/protocol/MaverickHapticBodyTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/MaverickHapticBodyTest.kt
@@ -1,0 +1,74 @@
+package com.noop.protocol
+
+import com.noop.ble.WhoopBleClient
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins [WhoopBleClient.maverickHapticBody] — the WHOOP 5/MG haptic body built from a 4.0-shaped
+ * `[patternId, loops, 0, 0, 0]` payload.
+ *
+ * EXPERIMENT (#926): byte 11 (overallLoop) was hardcoded 0, so the caller's repeat count never
+ * reached the wire and every BuzzPattern felt identical on a 5/MG. These cases pin the layout and
+ * the clamp; whether the strap ACTUALLY repeats the buzz is a hardware question this cannot answer.
+ */
+class MaverickHapticBodyTest {
+
+    private fun body(loops: Int) =
+        WhoopBleClient.maverickHapticBody(byteArrayOf(2, loops.toByte(), 0, 0, 0))
+
+    @Test
+    fun bodyIsTwelveBytesWithTheNotifyPreset() {
+        val b = body(1)
+        assertEquals(12, b.size)
+        assertEquals(0x01, b[0].toInt())            // REVISION_1
+        assertEquals(47, b[1].toInt())              // effects[0]
+        assertEquals(152, b[2].toInt() and 0xFF)    // effects[1]
+        for (i in 3..8) assertEquals("effects[$i] padding", 0, b[i].toInt())
+        assertEquals("loopControl lo", 0, b[9].toInt())
+        assertEquals("loopControl hi", 0, b[10].toInt())
+    }
+
+    @Test
+    fun overallLoopCarriesTheRepeatCount() {
+        assertEquals(1, body(1)[11].toInt())
+        assertEquals(2, body(2)[11].toInt())
+        assertEquals(3, body(3)[11].toInt())
+        assertEquals(5, body(5)[11].toInt())
+    }
+
+    @Test
+    fun loopsAreClampedToTheRangeTheAlarmBodyIsKnownToUse() {
+        // AlarmPayload ships overallLoop=7; nothing above that is evidenced, and 0 would reproduce
+        // the very bug this experiment is testing.
+        assertEquals(7, body(99)[11].toInt())
+        assertEquals(1, body(0)[11].toInt())
+    }
+
+    @Test
+    fun theLoopByteIsReadUnsigned() {
+        // A payload byte is a raw wire value, so 0xFD must read as 253 (then clamp to 7), NOT as the
+        // signed -3 it would be in Kotlin. Reading it signed would make any count above 127 collapse
+        // to the minimum — the opposite of what the clamp is for.
+        assertEquals(7, body(0xFD)[11].toInt())
+        assertEquals(7, body(0xFF)[11].toInt())
+    }
+
+    @Test
+    fun singleLoopReproducesTheOldShippedConstant() {
+        // The literal this replaced was [0x01, 47, 152, 0*8, 0] — i.e. exactly the loops=1 case with
+        // overallLoop still 0. Proves the change is additive: nothing but byte 11 moved.
+        val old = byteArrayOf(0x01, 47, 152.toByte(), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        val new = body(1)
+        assertArrayEquals(old.copyOfRange(0, 11), new.copyOfRange(0, 11))
+        assertEquals("only overallLoop differs", 0, old[11].toInt())
+        assertEquals("only overallLoop differs", 1, new[11].toInt())
+    }
+
+    @Test
+    fun shortPayloadDoesNotCrash() {
+        assertEquals(1, WhoopBleClient.maverickHapticBody(byteArrayOf())[11].toInt())
+        assertEquals(1, WhoopBleClient.maverickHapticBody(byteArrayOf(2))[11].toInt())
+    }
+}

--- a/android/app/src/test/java/com/noop/protocol/MaverickHapticBodyTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/MaverickHapticBodyTest.kt
@@ -9,9 +9,12 @@ import org.junit.Test
  * Pins [WhoopBleClient.maverickHapticBody] — the WHOOP 5/MG haptic body built from a 4.0-shaped
  * `[patternId, loops, 0, 0, 0]` payload.
  *
- * EXPERIMENT (#926): byte 11 (overallLoop) was hardcoded 0, so the caller's repeat count never
- * reached the wire and every BuzzPattern felt identical on a 5/MG. These cases pin the layout and
- * the clamp; whether the strap ACTUALLY repeats the buzz is a hardware question this cannot answer.
+ * #926: byte 11 (overallLoop) was hardcoded 0, so the caller's repeat count never reached the wire
+ * and every BuzzPattern felt identical on a 5/MG.
+ *
+ * HARDWARE-CONFIRMED on a real 5/MG: overallLoop counts the repeats AFTER the first pulse — writing
+ * 3 produced four buzzes — so it is written as `loops - 1`. That model also explains the old
+ * behaviour: the shipped 0 meant "no repeats", i.e. the single buzz every pattern used to give.
  */
 class MaverickHapticBodyTest {
 
@@ -31,44 +34,51 @@ class MaverickHapticBodyTest {
     }
 
     @Test
-    fun overallLoopCarriesTheRepeatCount() {
-        assertEquals(1, body(1)[11].toInt())
-        assertEquals(2, body(2)[11].toInt())
-        assertEquals(3, body(3)[11].toInt())
-        assertEquals(5, body(5)[11].toInt())
+    fun overallLoopIsTheRepeatCountAfterTheFirstPulse() {
+        // The wire value is one LESS than the number of buzzes the wrist feels.
+        assertEquals("1 buzz", 0, body(1)[11].toInt())
+        assertEquals("2 buzzes", 1, body(2)[11].toInt())
+        assertEquals("3 buzzes", 2, body(3)[11].toInt())
+        assertEquals("5 buzzes (BuzzPattern.Long)", 4, body(5)[11].toInt())
     }
 
     @Test
-    fun loopsAreClampedToTheRangeTheAlarmBodyIsKnownToUse() {
-        // AlarmPayload ships overallLoop=7; nothing above that is evidenced, and 0 would reproduce
-        // the very bug this experiment is testing.
+    fun theFourBuzzPatternsAllDiffer() {
+        // The whole point of #926: Single/Double/Triple/Long must not collapse to one value.
+        val wire = listOf(1, 2, 3, 5).map { body(it)[11].toInt() }
+        assertEquals(listOf(0, 1, 2, 4), wire)
+        assertEquals("no two patterns share a wire value", 4, wire.toSet().size)
+    }
+
+    @Test
+    fun loopsAreClampedToTheRangeTheAlarmBodyEvidences() {
+        // AlarmPayload ships overallLoop=7, the largest value evidenced, so loops caps at 8.
         assertEquals(7, body(99)[11].toInt())
-        assertEquals(1, body(0)[11].toInt())
+        assertEquals(7, body(8)[11].toInt())
+        assertEquals(0, body(0)[11].toInt())
     }
 
     @Test
     fun theLoopByteIsReadUnsigned() {
-        // A payload byte is a raw wire value, so 0xFD must read as 253 (then clamp to 7), NOT as the
-        // signed -3 it would be in Kotlin. Reading it signed would make any count above 127 collapse
-        // to the minimum — the opposite of what the clamp is for.
+        // A payload byte is a raw wire value, so 0xFD must read as 253 (then clamp), NOT as the signed
+        // -3 it would be in Kotlin. Reading it signed would make any count above 127 collapse to the
+        // minimum — the opposite of what the clamp is for.
         assertEquals(7, body(0xFD)[11].toInt())
         assertEquals(7, body(0xFF)[11].toInt())
     }
 
     @Test
-    fun singleLoopReproducesTheOldShippedConstant() {
-        // The literal this replaced was [0x01, 47, 152, 0*8, 0] — i.e. exactly the loops=1 case with
-        // overallLoop still 0. Proves the change is additive: nothing but byte 11 moved.
+    fun singleBuzzReproducesTheOldShippedConstantExactly() {
+        // The literal this replaced was [0x01, 47, 152, 0*8, 0]. With overallLoop = loops-1, a
+        // single-buzz request rebuilds it byte-for-byte — so the previously shipped, hardware-verified
+        // frame is preserved and the change only takes effect when more than one pulse was asked for.
         val old = byteArrayOf(0x01, 47, 152.toByte(), 0, 0, 0, 0, 0, 0, 0, 0, 0)
-        val new = body(1)
-        assertArrayEquals(old.copyOfRange(0, 11), new.copyOfRange(0, 11))
-        assertEquals("only overallLoop differs", 0, old[11].toInt())
-        assertEquals("only overallLoop differs", 1, new[11].toInt())
+        assertArrayEquals(old, body(1))
     }
 
     @Test
-    fun shortPayloadDoesNotCrash() {
-        assertEquals(1, WhoopBleClient.maverickHapticBody(byteArrayOf())[11].toInt())
-        assertEquals(1, WhoopBleClient.maverickHapticBody(byteArrayOf(2))[11].toInt())
+    fun shortPayloadFallsBackToASinglePulse() {
+        assertEquals(0, WhoopBleClient.maverickHapticBody(byteArrayOf())[11].toInt())
+        assertEquals(0, WhoopBleClient.maverickHapticBody(byteArrayOf(2))[11].toInt())
     }
 }


### PR DESCRIPTION
## What this PR does

Fixes the three things #926 documented as no-ops on a WHOOP 5/MG: `BuzzPattern` (Single/Double/Triple/Long), the live-session long/short intensity cues, and the Breathe inhale/exhale distinction.

`send()` replaced the caller's payload with a fixed 12-byte literal whose byte 11 (`overallLoop`) was `0`, so the repeat count never reached the wire. Every pattern produced one identical buzz.

### The hardware finding

Measured on a real WHOOP 5/MG: **`overallLoop` counts the repeats that follow the first pulse, not the total.** Writing `3` produced **four** buzzes. So it is written as `loops - 1`.

That model also explains the original behaviour exactly: the shipped `0` meant "no repeats" — the single buzz every pattern used to give. And it is consistent with `AlarmPayload`, which ships this same effects pair (47, 152) with `overallLoop=7` for an alarm's long buzz train, pinned by `AlarmPayloadTest`.

### On the regression-risk concern

This was held once before, for a good reason recorded in `CHANGELOG:2218`:

> The buzz already works; changing a proven payload for a refactor is regression risk for zero user value.

Both halves of that now look different:

- **The risk is nil.** With `overallLoop = loops - 1`, a single-buzz request rebuilds the previously shipped, hardware-verified constant **byte-for-byte**. Pinned by `singleBuzzReproducesTheOldShippedConstantExactly`. Byte 11 moves only when the caller asked for more than one pulse — nothing else in the body changes.
- **The value is not zero.** Four notification patterns, the live-session intensity cues, and the Breathe pacer's inhale/exhale cue all become distinguishable on a 5/MG. The Breathe one is the real loss today: haptic breathing pacing cannot tell you which way to breathe on that hardware.

The now-false *"every pattern buzzes the same on a WHOOP 5/MG"* caption in the notification settings goes with it, along with its string in all seven locales (rather than orphaning six translations behind a deleted source) and the `WhoopModel` import it was the only user of.

Clamped to `loops` 1..8 (`overallLoop` 0..7), 7 being the largest value the alarm body evidences. A payload shorter than 2 bytes falls back to a single pulse rather than indexing out of bounds.

## Type of change

- [x] Bug fix

## How it was tested

**On real hardware: a WHOOP 5.0/MG.** Built the Android app from this branch, connected the strap, and used the per-pattern **Test** buttons in Settings → Notifications:

| Pattern | `overallLoop` on the wire | buzzes felt |
|---|---|---|
| Single (1) | 0 | 1 |
| Double (2) | 1 | 2 |
| Triple (3) | 2 | 3 |
| Long (5) | 4 | 5 |

The off-by-one was caught this way too: a first build wrote `loops` directly and Triple gave **four** buzzes, which is what established the "repeats after the first pulse" semantics.

Also:
- New `MaverickHapticBodyTest` (7 cases) pins the byte layout, the clamp, unsigned byte reading, that all four patterns map to distinct wire values, and the byte-for-byte match with the old constant at `loops = 1`.
- `./gradlew testFullDebugUnitTest` — **4196 tests, 0 failures**.
- `python3 Tools/i18n_audit.py --ci` passes after the string removal.
- The maverick golden-frame test is untouched by design: it builds its own payload and pins `Framing.puffinCommandFrame`, not `send()`'s construction.

## Checklist

- [x] Swift package tests pass for any package I touched — n/a, no package touched
- [x] Android unit tests pass (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only design tokens — the only UI change is a deletion
- [x] No hardcoded hex frame bytes — see note below
- [x] Follows the conventions in `docs/CONTRIBUTING.md`
- [x] I did not commit generated output or any secrets/keystores

On the hex-bytes rule: this introduces no new literal. The existing inline constant moves into a named, documented, unit-tested builder (`maverickHapticBody`) with the field layout from `docs/BLE_REVERSE_ENGINEERING.md:771` spelled out per byte — closer to the rule's intent than the inline array it replaces.

## Cross-platform parity — not done, and why

The Swift side has the identical line at `Strand/BLE/BLEManager.swift:1552`, so an iPhone/Mac user on a 5/MG has this bug unchanged.

I did not include it: that is app-target Swift, which needs Xcode on macOS to compile, and I could not build it. Per CLAUDE.md I would rather name the gap than ship Swift that no default CI validates. The change is one expression, so twinning it should be small for anyone with a Mac — and the hardware semantics above apply unchanged.

## Related issues

Resolves the open question in #926 (closed as a capability finding). The mechanism, the affected call sites, and the reasoning for the original hold are all described there; this adds the hardware answer.