### PR TITLE
fix: give the bond-loop pause an escape that works while backgrounded

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1005,6 +1005,14 @@ public final class BLEManager: NSObject, ObservableObject {
             return peripheral
         }()
         guard let p = target else {
+            // #1539: while the bond-loop pause is latched this must stay PASSIVE. The scanning fallback is
+            // active radio work, which is precisely what the pause exists to stop, so with no cached
+            // peripheral to park against there is nothing safe to do here — the foreground probe remains
+            // the escape, exactly as on Android. Outside the pause the fallback is unchanged.
+            guard !whilePausedForBondLoop else {
+                log("Bond-loop pause: no cached strap to park a standing connect against — staying passive (#1539)")
+                return
+            }
             // No cached peripheral to hand CoreBluetooth — fall back to the scanning connect path.
             log("No cached strap for a standing connect — scanning instead")
             connectFromSystem()
@@ -5069,6 +5077,12 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         // when the strap returns; this callback is where the overnight reconnect died. Out-of-range
         // hammering is held off by the bond-loop pause and the refusal streak rather than by a timer,
         // because a passive `central.connect` is not what hammers a strap.
+        // #1539: while the pause is latched `scheduleReconnect` below is a no-op, so a parked connect that
+        // FAILED — rather than staying parked, which is what happens when the strap is reachable but the
+        // handshake dies — would consume the request and strand us again with no disconnect callback ever
+        // coming to re-arm it. Re-park it here, floored, so the instantly-failing shape this callback warns
+        // about above cannot hot-loop. Inert when the pause is not latched (the gate checks it).
+        standingConnectWhilePausedIfDue()
         scheduleReconnect()
     }
 

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -989,8 +989,11 @@ public final class BLEManager: NSObject, ObservableObject {
     /// wakes the app when the strap advertises again, including while SUSPENDED — the whole point. Same call
     /// `connectFromSystem`'s targeted path already makes: no new outbound command, nothing written to the
     /// strap, so the BLE safety contract is unaffected. Twin of `OuraLiveSource.issueStandingConnect`.
-    private func issueStandingConnect() {
-        guard !intentionalDisconnect, !autoReconnectPausedForBondLoop else { return }
+    private func issueStandingConnect(whilePausedForBondLoop: Bool = false) {
+        guard !intentionalDisconnect else { return }
+        // #1539: the bond-loop pause suppresses this by default, but the paused paths deliberately opt in —
+        // a parked, timeout-free connect is what lets that pause end without the user.
+        guard whilePausedForBondLoop || !autoReconnectPausedForBondLoop else { return }
         guard central.state == .poweredOn else {
             log("Standing reconnect deferred — Bluetooth not powered on (state=\(central.state.rawValue))")
             return
@@ -1480,6 +1483,29 @@ public final class BLEManager: NSObject, ObservableObject {
         return s >= bondLoopSalvageFloorSeconds
     }
 
+    /// #1539: may the bond-loop pause hand CoreBluetooth a STANDING connect right now?
+    ///
+    /// The pause deliberately stops active rescanning, but before this it also suppressed
+    /// `issueStandingConnect`, which removed the one mechanism capable of ending it without the user: the
+    /// salvage probe fires on app-foreground, so a phone in a pocket at 23:19 never runs it. A strap freed
+    /// at midnight stayed unclaimed until someone opened the app — six hours in the report, and unbounded
+    /// in principle, which becomes real data loss once the gap outlives the strap's own buffer.
+    ///
+    /// A standing connect is the right escape because it is NOT hammering: `central.connect` has no
+    /// timeout, so it is one request the OS parks until the strap is reachable, with nothing written to the
+    /// strap and no wakeups in between. The floor still applies to REFRESHES, so a strap that is reachable
+    /// and keeps refusing the bond cannot spin connect → refuse → pause → connect; it gets one attempt per
+    /// window exactly as the foreground probe does. A nil elapsed time means the pause has only just
+    /// tripped, which is when the first standing connect must be armed.
+    nonisolated static func shouldStandingConnectWhilePaused(pausedForBondLoop: Bool,
+                                                             connected: Bool,
+                                                             intentionalDisconnect: Bool,
+                                                             secondsSincePauseTripped: TimeInterval?) -> Bool {
+        guard pausedForBondLoop, !connected, !intentionalDisconnect else { return false }
+        guard let s = secondsSincePauseTripped else { return true }
+        return s >= bondLoopSalvageFloorSeconds
+    }
+
     /// #78 hole-1: classify a "the strap refused the encrypted bond" error by its ATT CODE first,
     /// locale-proof. Foundation LOCALIZES CoreBluetooth error strings, so the old
     /// `localizedDescription.contains("encryption"/"authentication")` check silently never matched on a
@@ -1514,6 +1540,23 @@ public final class BLEManager: NSObject, ObservableObject {
         bondLoopPausedAt = now   // re-floor: max one probe per foreground AND per 10-min window
         log("Bond-loop pause: one salvage probe (the strap may have been freed since the give-up) - the give-up stays latched")
         connectFromSystem()
+    }
+
+    /// #1539: park a standing connect while the bond-loop pause is latched, so the pause can end without
+    /// the user. Called from the paused disconnect branch and from the trip itself — both run while the app
+    /// is backgrounded, which is exactly where the foreground probe cannot reach. Re-stamps
+    /// `bondLoopPausedAt` so a strap that is reachable and still refusing gets one attempt per window
+    /// rather than a connect/refuse spin.
+    func standingConnectWhilePausedIfDue(now: Date = Date(), justTripped: Bool = false) {
+        let since = justTripped ? nil : bondLoopPausedAt.map { now.timeIntervalSince($0) }
+        guard BLEManager.shouldStandingConnectWhilePaused(
+            pausedForBondLoop: autoReconnectPausedForBondLoop,
+            connected: state.connected,
+            intentionalDisconnect: intentionalDisconnect,
+            secondsSincePauseTripped: since) else { return }
+        bondLoopPausedAt = now
+        log("Bond-loop pause: parking a standing connect so the strap is claimed the moment it is reachable (#1539) - the give-up stays latched")
+        issueStandingConnect(whilePausedForBondLoop: true)
     }
 
     /// Observe the app-foreground notification and run the salvage probe. Installed once per manager from
@@ -4816,6 +4859,10 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
             // is real; the stale OS pairing is the problem, which the guide tells the user how to clear.
             autoReconnectPausedForBondLoop = true
             bondLoopPausedAt = Date()   // the #78 hole-4 salvage probe covers this pause too (one bounded cycle)
+            // #1539: arm the parked connect in the same breath as the pause. The salvage probe only fires on
+            // app-foreground, so without this a pause tripped with the phone in a pocket strands the strap
+            // until someone opens the app.
+            standingConnectWhilePausedIfDue(justTripped: true)
             if TestCentre.active(.connection) {
                 state.append(log: "reconnect paused=bondLoop (#617: \(postBondLoop.consecutiveBondTimeouts) bond-then-timeout cycles)", domain: .connection)
             }
@@ -4943,6 +4990,9 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
             // can't bond (the epitaph + paused hint were already surfaced when the give-up tripped). The user
             // re-arms it by tapping Connect. We do NOT schedule a rescan here.
             log("Disconnected\(error.map { ": \($0.localizedDescription)" } ?? ""); auto-reconnect paused (strap keeps refusing to pair; tap Connect once it's free)")
+            // #1539: a connect attempt CONSUMES the parked request, so re-park it — floored, so a reachable
+            // strap that keeps refusing gets one attempt per window instead of a connect/refuse spin.
+            standingConnectWhilePausedIfDue()
             if TestCentre.active(.connection) {
                 state.append(log: "connect down (uptime ends)", domain: .connection)
                 state.append(log: "reconnect paused=bondLoop (strap refusing bond)", domain: .connection)
@@ -5278,6 +5328,9 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                 if bondGiveUp.recordRefusal() {
                     autoReconnectPausedForBondLoop = true
                     bondLoopPausedAt = Date()   // starts the #78 hole-4 salvage-probe floor
+                    // #1539: same reasoning as the #617 trip — park a connect now so this pause can end
+                    // while the app is backgrounded, not only when the user next opens it.
+                    standingConnectWhilePausedIfDue(justTripped: true)
                     let opaque = BondRefusalGiveUp.opaqueId(fromLocalUUID: peripheral.identifier.uuidString)
                     log(BondRefusalGiveUp.epitaphLine(refusals: bondGiveUp.refusals, opaqueId: opaque))
                     state.pairingHint = BondRefusalGiveUp.pausedHint()

--- a/StrandTests/BondLoopHardeningTests.swift
+++ b/StrandTests/BondLoopHardeningTests.swift
@@ -104,4 +104,50 @@ final class BondLoopHardeningTests: XCTestCase {
                                                      intentionalDisconnect: true,
                                                      secondsSincePauseTripped: floor))
     }
+
+    // MARK: shouldStandingConnectWhilePaused (#1539)
+
+    /// The regression: a pause tripped while the app is backgrounded had no escape at all. The salvage
+    /// probe fires on app-foreground, so a phone in a pocket never ran it, and the paused branch suppressed
+    /// the one passive mechanism that could end the pause. `nil` elapsed means "just tripped" — that is the
+    /// moment the parked connect must be armed, not skipped.
+    func testJustTrippedArmsTheParkedConnectImmediately() {
+        XCTAssertTrue(BLEManager.shouldStandingConnectWhilePaused(
+            pausedForBondLoop: true, connected: false, intentionalDisconnect: false,
+            secondsSincePauseTripped: nil))
+    }
+
+    /// Refreshes are floored, so a reachable strap that keeps refusing gets one attempt per window instead
+    /// of spinning connect -> refuse -> pause -> connect. This is the anti-hammering property the pause was
+    /// added for, and it has to survive the escape.
+    func testARefreshInsideTheFloorIsRefused() {
+        XCTAssertFalse(BLEManager.shouldStandingConnectWhilePaused(
+            pausedForBondLoop: true, connected: false, intentionalDisconnect: false,
+            secondsSincePauseTripped: 0))
+        XCTAssertFalse(BLEManager.shouldStandingConnectWhilePaused(
+            pausedForBondLoop: true, connected: false, intentionalDisconnect: false,
+            secondsSincePauseTripped: BLEManager.bondLoopSalvageFloorSeconds - 1))
+    }
+
+    /// ...and is allowed once the floor has elapsed, which is what makes recovery eventual rather than
+    /// dependent on the user.
+    func testARefreshAtOrPastTheFloorIsAllowed() {
+        XCTAssertTrue(BLEManager.shouldStandingConnectWhilePaused(
+            pausedForBondLoop: true, connected: false, intentionalDisconnect: false,
+            secondsSincePauseTripped: BLEManager.bondLoopSalvageFloorSeconds))
+    }
+
+    /// Never parks a connect when the pause is not latched, when a link is already up, or when the user
+    /// tore the link down deliberately — the same three refusals the foreground probe makes.
+    func testTheThreeRefusalsMatchTheForegroundProbe() {
+        XCTAssertFalse(BLEManager.shouldStandingConnectWhilePaused(
+            pausedForBondLoop: false, connected: false, intentionalDisconnect: false,
+            secondsSincePauseTripped: nil))
+        XCTAssertFalse(BLEManager.shouldStandingConnectWhilePaused(
+            pausedForBondLoop: true, connected: true, intentionalDisconnect: false,
+            secondsSincePauseTripped: nil))
+        XCTAssertFalse(BLEManager.shouldStandingConnectWhilePaused(
+            pausedForBondLoop: true, connected: false, intentionalDisconnect: true,
+            secondsSincePauseTripped: nil))
+    }
 }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -710,6 +710,30 @@ class WhoopBleClient(
         ): Boolean = pausedForBondLoop && !connected && !intentionalDisconnect &&
             msSincePauseTripped != null && msSincePauseTripped >= BOND_LOOP_SALVAGE_FLOOR_MS
 
+        /**
+         * #1539: may the bond-loop pause hand the OS a STANDING connect right now?
+         *
+         * The pause deliberately stops active rescanning, but it also suppressed the one passive mechanism
+         * capable of ending it without the user: [salvageProbeIfBondLoopPaused] runs from
+         * onActivityResumed, so a phone in a pocket never reaches it. A strap freed at midnight then stays
+         * unclaimed until someone opens the app, which becomes real data loss once the gap outlives the
+         * strap's own buffer.
+         *
+         * A standing connect is the right escape because it is not hammering: connectGatt(autoConnect=true)
+         * is one request the OS parks until the strap is reachable, writing nothing to the strap. The floor
+         * still applies to REFRESHES, so a reachable strap that keeps refusing cannot spin
+         * connect -> refuse -> pause -> connect. A null elapsed time means the pause has only just tripped,
+         * which is exactly when the first parked connect must be armed. Twin of the Swift
+         * `BLEManager.shouldStandingConnectWhilePaused`.
+         */
+        fun shouldStandingConnectWhilePaused(
+            pausedForBondLoop: Boolean,
+            connected: Boolean,
+            intentionalDisconnect: Boolean,
+            msSincePauseTripped: Long?,
+        ): Boolean = pausedForBondLoop && !connected && !intentionalDisconnect &&
+            (msSincePauseTripped == null || msSincePauseTripped >= BOND_LOOP_SALVAGE_FLOOR_MS)
+
         /** Give up a scan after this long with no strap found, and tell the user why. */
         private const val SCAN_TIMEOUT_MS = 20_000L
         /** Rotate to the other WHOOP family after this long with no discovery, in case the persisted
@@ -3022,6 +3046,34 @@ class WhoopBleClient(
     }
 
     /**
+     * #1539: park a standing connect while the bond-loop pause is latched, so the pause can end without the
+     * user. Called from every trip site and from the paused branch of [handleDisconnect] — all of which run
+     * with the app backgrounded, which is exactly where [salvageProbeIfBondLoopPaused] cannot reach
+     * (onActivityResumed never fires for a phone in a pocket).
+     *
+     * PASSIVE ONLY. Unlike the foreground probe this never falls back to [connect]'s scan: a scan is active
+     * radio work and the pause exists to stop exactly that. If there is no preferred last device to park a
+     * connect against, this does nothing and the foreground probe remains the escape. Re-stamps
+     * [bondLoopPausedAtMs] so a reachable strap that keeps refusing gets one attempt per window rather than
+     * a connect/refuse spin. Twin of Swift `BLEManager.standingConnectWhilePausedIfDue`.
+     */
+    fun standingConnectWhilePausedIfDue(justTripped: Boolean = false) {
+        handler.post {
+            val since =
+                if (justTripped) null else bondLoopPausedAtMs?.let { System.currentTimeMillis() - it }
+            if (!shouldStandingConnectWhilePaused(autoReconnectPausedForBondLoop, _state.value.connected,
+                                                  intentionalDisconnect, since)) return@post
+            if (gatt != null || scanning) return@post   // an attempt is already in flight - never stack one
+            val dev = lastDevice ?: return@post
+            if (!isPreferred(dev)) return@post
+            bondLoopPausedAtMs = System.currentTimeMillis()
+            log("Bond-loop pause: parking a standing connect so the strap is claimed the moment it is reachable (#1539) - the give-up stays latched")
+            intentionalDisconnect = false
+            connectToDevice(dev, autoConnect = true)
+        }
+    }
+
+    /**
      * Switch which strap we'll connect to next: drop the current strap and clear the **sticky** bond
      * state so a newly-picked model bonds fresh. Without this, `bonded` stayed true from the first strap,
      * which hid the strap picker and kept the scan pointed at the old family's service — so a user with
@@ -4563,6 +4615,8 @@ class WhoopBleClient(
                 bondWatchdogContext() + " — pausing auto-reconnect and surfacing the re-pair guide (#971)")
             autoReconnectPausedForBondLoop = true
             bondLoopPausedAtMs = System.currentTimeMillis()   // the #78 hole-4 salvage probe covers this pause too
+                // #1539: park the connect in the same breath as the pause, so this can end while backgrounded.
+                standingConnectWhilePausedIfDue(justTripped = true)
             if (_state.value.reconnectGuide == null) {
                 _state.update { it.copy(
                     reconnectGuide = """
@@ -4772,6 +4826,8 @@ class WhoopBleClient(
         if (bondGiveUp.recordRefusal()) {
             autoReconnectPausedForBondLoop = true
             bondLoopPausedAtMs = System.currentTimeMillis()   // starts the #78 hole-4 salvage-probe floor
+                // #1539: park the connect in the same breath as the pause, so this can end while backgrounded.
+                standingConnectWhilePausedIfDue(justTripped = true)
             val opaque = BondRefusalGiveUp.opaqueId(failedAddress ?: "device")
             log(BondRefusalGiveUp.epitaphLine(bondGiveUp.refusals, opaque))
             _state.update { it.copy(pairingHint = BondRefusalGiveUp.pausedHint()) }
@@ -7846,6 +7902,8 @@ class WhoopBleClient(
             // Swift BLEManager #844 fix.
             autoReconnectPausedForBondLoop = true
             bondLoopPausedAtMs = System.currentTimeMillis()   // the #78 hole-4 salvage probe covers this pause too (one bounded cycle)
+                // #1539: park the connect in the same breath as the pause, so this can end while backgrounded.
+                standingConnectWhilePausedIfDue(justTripped = true)
             if (_state.value.reconnectGuide == null) {
                 _state.update { it.copy(
                     reconnectGuide = """
@@ -7882,6 +7940,8 @@ class WhoopBleClient(
                 bondWatchdogContext() + " — pausing auto-reconnect and surfacing the re-pair guide (#982/#971)")
             autoReconnectPausedForBondLoop = true
             bondLoopPausedAtMs = System.currentTimeMillis()   // the #78 hole-4 salvage probe covers this pause too
+                // #1539: park the connect in the same breath as the pause, so this can end while backgrounded.
+                standingConnectWhilePausedIfDue(justTripped = true)
             if (_state.value.reconnectGuide == null) {
                 _state.update { it.copy(
                     reconnectGuide = """
@@ -7960,6 +8020,9 @@ class WhoopBleClient(
             // can't bond (the epitaph + paused hint were already surfaced when the give-up tripped). The user
             // re-arms it by tapping Connect (clearPairingHintForUserConnect). We do NOT schedule a reconnect.
             log("Disconnected (status=$status); auto-reconnect paused (strap keeps refusing to pair; tap Connect once it's free)")
+            // #1539: a connect attempt CONSUMES the parked request, so re-park it — floored, so a reachable
+            // strap that keeps refusing gets one attempt per window instead of a connect/refuse spin.
+            standingConnectWhilePausedIfDue()
             if (testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)) {
                 log("connect down (uptime ends)", com.noop.testcentre.TestDomain.CONNECTION)
                 log("reconnect paused=bondLoop (strap refusing bond)", com.noop.testcentre.TestDomain.CONNECTION)

--- a/android/app/src/test/java/com/noop/ble/BondLoopSalvageProbeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BondLoopSalvageProbeTest.kt
@@ -62,4 +62,55 @@ class BondLoopSalvageProbeTest {
             pausedForBondLoop = true, connected = false,
             intentionalDisconnect = true, msSincePauseTripped = floor))
     }
+
+    // #1539: the background escape.
+
+    /**
+     * The regression: a pause tripped while backgrounded had no escape at all. The foreground probe runs
+     * from onActivityResumed, so a phone in a pocket never reaches it, and the paused branch suppressed the
+     * one passive mechanism that could end the pause. A null elapsed time means "just tripped" — the moment
+     * the parked connect must be armed, not skipped, which is where this gate differs from the probe's.
+     */
+    @Test
+    fun justTrippedArmsTheParkedConnectImmediately() {
+        assertTrue(WhoopBleClient.shouldStandingConnectWhilePaused(
+            pausedForBondLoop = true, connected = false,
+            intentionalDisconnect = false, msSincePauseTripped = null))
+        // The foreground probe refuses the same input: it has no "first" attempt to arm.
+        assertFalse(WhoopBleClient.shouldSalvageProbe(
+            pausedForBondLoop = true, connected = false,
+            intentionalDisconnect = false, msSincePauseTripped = null))
+    }
+
+    /**
+     * Refreshes stay floored, so a reachable strap that keeps refusing gets one attempt per window rather
+     * than spinning connect -> refuse -> pause -> connect. The anti-hammering property the pause exists for
+     * has to survive the escape.
+     */
+    @Test
+    fun refreshesRemainFloored() {
+        assertFalse(WhoopBleClient.shouldStandingConnectWhilePaused(
+            pausedForBondLoop = true, connected = false,
+            intentionalDisconnect = false, msSincePauseTripped = 0L))
+        assertFalse(WhoopBleClient.shouldStandingConnectWhilePaused(
+            pausedForBondLoop = true, connected = false,
+            intentionalDisconnect = false, msSincePauseTripped = floor - 1))
+        assertTrue(WhoopBleClient.shouldStandingConnectWhilePaused(
+            pausedForBondLoop = true, connected = false,
+            intentionalDisconnect = false, msSincePauseTripped = floor))
+    }
+
+    /** The same three refusals the foreground probe makes: not paused, already linked, user teardown. */
+    @Test
+    fun theThreeRefusalsMatchTheForegroundProbe() {
+        assertFalse(WhoopBleClient.shouldStandingConnectWhilePaused(
+            pausedForBondLoop = false, connected = false,
+            intentionalDisconnect = false, msSincePauseTripped = null))
+        assertFalse(WhoopBleClient.shouldStandingConnectWhilePaused(
+            pausedForBondLoop = true, connected = true,
+            intentionalDisconnect = false, msSincePauseTripped = null))
+        assertFalse(WhoopBleClient.shouldStandingConnectWhilePaused(
+            pausedForBondLoop = true, connected = false,
+            intentionalDisconnect = true, msSincePauseTripped = null))
+    }
 }


### PR DESCRIPTION
Fixes #1539, reported by @justinjor-bit with a full trace. **This is a BLE change and I have not run it on a strap — see Verification before merging.**

## The bug

The #617 pause tripped at 23:19 with the phone in a pocket, and nothing cleared it until 05:37, when the process happened to be relaunched. Six hours with nothing collecting.

The self-heal could not fire from the state it exists to rescue. `salvageProbeIfBondLoopPaused` has exactly one call site — an observer on `didBecomeActiveNotification` (`onActivityResumed` on Android) — so a phone nobody picks up never runs it. Every other exit was guarded upstream:

- `scheduleReconnect()` opens on `!autoReconnectPausedForBondLoop`
- `issueStandingConnect()` carried the **same guard**, so #1413's mechanism was unreachable too
- the paused disconnect branch says outright: *"We do NOT schedule a rescan here"*

All three exits therefore required the user.

**One correction to the report's framing**, which strengthens the case: the log shows the night was *recovered* — `Backfill: session persisted 90926 rows` once something finally connected. So this instance cost a collection gap, not the data. The hazard is that the latch has no upper bound: six hours fit in the strap's buffer, and a pause tripping on a Friday evening does not. That makes this latent data loss rather than one bad night.

## The fix

Park a standing connect while paused, instead of nothing.

It is the right escape precisely **because it is not hammering**. `central.connect` has no timeout, and `connectGatt(autoConnect = true)` is the same shape: one request the OS holds until the strap is reachable, nothing written to the strap, no wakeups in between — the property #1413 exists for. Armed at every trip site and re-armed on each paused disconnect, since a connect attempt consumes the parked request.

**The anti-hammering property survives.** Refreshes are floored by the existing 10-minute window, so a strap that is reachable and still refusing gets one attempt per window rather than spinning connect → refuse → pause → connect. The give-up stays latched throughout; the only thing that changes is whether the pause can end without the user.

The gate is pure and `nonisolated` on both sides, mirroring `shouldSalvageProbe`, and differs from it in exactly one respect: a nil elapsed time means "just tripped", which is when the first parked connect must be **armed** rather than skipped. There is a test asserting the two gates disagree on precisely that input, so the difference is deliberate rather than a copy that drifted.

**Android's variant is passive-only.** Unlike the foreground probe it never falls back to `connect()`'s scan — a scan is the active radio work the pause exists to stop. If there is no preferred last device to park against it does nothing, and the foreground probe remains the escape.

## Verification

- **4 Swift gate tests, 3 Kotlin twins**; full Android suite **4,214 tests, 0 failures** (`--no-build-cache --rerun-tasks`; main was 4,211).
- **app-build [32573145066](https://github.com/ryanbr/noop/actions/runs/32573145066) green on both legs**, `Test Strand` at **1,195 tests, 0 failures** (1,191 before, so the new tests ran).
- Doc lint and i18n clean.

**What none of that proves.** Per CLAUDE.md, compile-success says nothing about connection behaviour, and this touches the reconnect path on both platforms. What needs a strap:

1. that a pause tripped with the app backgrounded now recovers when the strap becomes reachable, without the user opening the app — the whole point;
2. that a strap which genuinely keeps refusing does **not** spin, i.e. the 10-minute floor holds in practice and the battery cost stays where it was;
3. that a normal, healthy reconnect is unchanged.

@justinjor-bit — you have the failing hardware and clearly know your way around the log. If you are willing to run a build of this branch, (1) is the one that matters; the `Bond-loop pause: parking a standing connect` line marks each arm.