### PR TITLE
5/MG haptics: carry the repeat count into overallLoop, on both platforms (#926)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/HapticPayloads.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/HapticPayloads.swift
@@ -18,19 +18,28 @@ import Foundation
 private let waveformEffects: [UInt8] = [47, 152, 0, 0, 0, 0, 0, 0]
 
 public enum MaverickHaptics {
-    /// 12-byte payload for RUN_HAPTIC_PATTERN_MAVERICK (cmd 19/0x13) — a one-shot buzz on a 5/MG
-    /// strap: `[REVISION_1][waveFormEffect1..8][loopControlForEffects u16 LE = 0][overallLoop]`.
-    /// `loops` maps to overallWaveformLoopControl; the official "buzz once" notification is 1.
+    /// 12-byte payload for RUN_HAPTIC_PATTERN_MAVERICK (cmd 19/0x13) — a buzz on a 5/MG strap:
+    /// `[REVISION_1][waveFormEffect1..8][loopControlForEffects u16 LE = 0][overallLoop]`.
     ///
-    /// NOTHING SHIPS THIS (#926). `BLEManager.send` / `WhoopBleClient.send` substitute their own literal
-    /// `[0x01, 47, 152, 0, …, 0]` for a 5/MG buzz, whose `overallLoop` is 0 — so the caller's repeat count
-    /// never reaches the wire and this function's only callers are two assertions in
-    /// `DeviceFamilyFramingTests`. There is no Kotlin twin. Kept because it is the only code that knows how
-    /// to build a VARIABLE-loop buzz body, which is exactly what a future test of `overallLoop != 0` would
-    /// need; the shipped literal is hardware-confirmed at 0 and deliberately unchanged until someone probes
-    /// it (the alarm path already ships 7, so the field itself is accepted non-zero).
+    /// `overallLoop` counts the repeats that follow the FIRST pulse, not the total, so `loops` is written
+    /// as `loops - 1`. HARDWARE-CONFIRMED on a real WHOOP 5/MG by @dwehrmann (#926): writing 3 produced
+    /// FOUR buzzes. The model also explains the behaviour that shipped for years — the hardcoded `0` in
+    /// `BLEManager.send` / `WhoopBleClient.send` meant "no repeats", which is exactly the single identical
+    /// buzz every BuzzPattern used to give; a reading where 0 meant "zero buzzes" would predict silence.
+    ///
+    /// This function ENCODED THE OPPOSITE convention until that measurement existed — it wrote `loops`
+    /// straight into the byte, so asking it for one buzz would have produced two. It was documented as the
+    /// only code that knew how to build a variable-loop body, which is precisely why the error mattered:
+    /// the next caller to adopt it would have inherited a silent off-by-one from the file that claims
+    /// authority over this field.
+    ///
+    /// Clamped to 1...8 (`overallLoop` 0...7), 7 being the largest value any captured body evidences — the
+    /// alarm's long wake train (`AlarmPayload.setAlarmRev4`, pinned in `DeviceFamilyFramingTests`). The old
+    /// `UInt8(clamping:)` admitted 255, a value nothing has ever observed on the wire.
+    ///
+    /// Kotlin twin: `WhoopBleClient.maverickHapticBody`.
     public static func notificationBuzz(loops: Int) -> [UInt8] {
-        [0x01] + waveformEffects + [0x00, 0x00, UInt8(clamping: loops)]
+        [0x01] + waveformEffects + [0x00, 0x00, UInt8(min(max(loops, 1), 8) - 1)]
     }
 }
 

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DeviceFamilyFramingTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DeviceFamilyFramingTests.swift
@@ -319,9 +319,24 @@ final class DeviceFamilyFramingTests: XCTestCase {
         XCTAssertEqual(body, Self.hex("040100f15365be0f2f980000000000000000071e"))
         XCTAssertEqual(AlarmPayload.disableRev2(), [0x02, 0xFF])
         XCTAssertEqual(AlarmPayload.runAlarmRev2(), [0x02, 0x01])
+        // #926: overallLoop counts the repeats AFTER the first pulse (hardware-confirmed on a 5/MG by
+        // @dwehrmann), so ONE buzz is 0 — and that is byte-for-byte the literal both send() paths shipped
+        // for years, which is why the old single buzz was the observed behaviour.
         XCTAssertEqual(MaverickHaptics.notificationBuzz(loops: 1),
-                       [0x01, 47, 152, 0, 0, 0, 0, 0, 0, 0, 0, 1])
-        XCTAssertEqual(MaverickHaptics.notificationBuzz(loops: 999).last, 255)   // clamped
+                       [0x01, 47, 152, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        // The SAME vectors the Kotlin twin pins (MaverickHapticBodyTest), so the two reimplementations
+        // cannot drift on what this byte means.
+        XCTAssertEqual(MaverickHaptics.notificationBuzz(loops: 2).last, 1)       // 2 buzzes = 1 repeat
+        XCTAssertEqual(MaverickHaptics.notificationBuzz(loops: 3).last, 2)       // 3 buzzes
+        XCTAssertEqual(MaverickHaptics.notificationBuzz(loops: 5).last, 4)       // BuzzPattern.Long
+        XCTAssertEqual(MaverickHaptics.notificationBuzz(loops: 999).last, 7)     // clamped to the alarm's 7
+        XCTAssertEqual(MaverickHaptics.notificationBuzz(loops: 0).last, 0)       // never underflows
+        // Everything except byte 11 is the shipped constant, at every loop count.
+        for n in 1...8 {
+            let body = MaverickHaptics.notificationBuzz(loops: n)
+            XCTAssertEqual(body.count, 12)
+            XCTAssertEqual(Array(body[0..<11]), [0x01, 47, 152, 0, 0, 0, 0, 0, 0, 0, 0])
+        }
     }
 
     func testPuffinAlarmFramesMatchKotlinParityGoldens() {

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1885,7 +1885,16 @@ public final class BLEManager: NSObject, ObservableObject {
             // 4-byte boundary, which this 12-byte payload needs. WHOOP 4.0 is untouched (79 + its own frame).
             let isHaptics = command == .runHapticsPattern
             let puffinCmd: UInt8 = isHaptics ? 0x13 : command.rawValue
-            let puffinPayload: [UInt8] = isHaptics ? [0x01, 47, 152, 0, 0, 0, 0, 0, 0, 0, 0, 0] : payload
+            // #926: build the body through the shared `MaverickHaptics.notificationBuzz` rather than a
+            // literal, so the caller's repeat count reaches the wire. The literal that used to sit here
+            // pinned overallLoop to 0, which is why every BuzzPattern — and the Breathe inhale/exhale cue,
+            // and the live-session long/short cues — felt identical on a 5/MG. The 4.0 payload this
+            // substitutes for is `[patternId, loops, …]`, so the count is byte 1. A single buzz still
+            // rebuilds the old literal EXACTLY (overallLoop = 1 - 1 = 0), so nothing changes for a caller
+            // that asked for one. Kotlin twin: `WhoopBleClient.maverickHapticBody`.
+            let buzzLoops = payload.count >= 2 ? Int(payload[1]) : 1
+            let puffinPayload: [UInt8] = isHaptics
+                ? MaverickHaptics.notificationBuzz(loops: buzzLoops) : payload
             seq = seq &+ 1
             let frame = puffinCommandFrame(cmd: puffinCmd, seq: seq, payload: puffinPayload)
             p.writeValue(Data(frame), for: ch, type: writeType)

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -65259,65 +65259,6 @@
         }
       }
     },
-    "Every pattern buzzes the same on a WHOOP 5/MG — the repeat count isn't sent to that strap. Your choice is saved and applies to a WHOOP 4.0.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auf einer WHOOP 5/MG vibriert jedes Muster gleich — die Wiederholungszahl wird an dieses Band nicht gesendet. Deine Auswahl wird gespeichert und gilt für eine WHOOP 4.0."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "En una WHOOP 5/MG todos los patrones vibran igual: el número de repeticiones no se envía a esa correa. Tu elección se guarda y se aplica a una WHOOP 4.0."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sur un WHOOP 5/MG, tous les motifs vibrent de la même façon — le nombre de répétitions n'est pas envoyé à ce bracelet. Votre choix est enregistré et s'applique à un WHOOP 4.0."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Su un WHOOP 5/MG ogni schema vibra allo stesso modo — il numero di ripetizioni non viene inviato a quel cinturino. La tua scelta viene salvata e si applica a un WHOOP 4.0."
-          }
-        },
-        "pt-PT": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Numa WHOOP 5/MG todos os padrões vibram igual — a contagem de repetições não é enviada para essa bracelete. A tua escolha fica guardada e aplica-se a uma WHOOP 4.0."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "На WHOOP 5/MG все шаблоны вибрируют одинаково — число повторов не отправляется на этот ремешок. Ваш выбор сохраняется и применяется к WHOOP 4.0."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在 WHOOP 5/MG 上所有模式的震动都相同——重复次数不会发送到该手环。你的选择会被保存，并在 WHOOP 4.0 上生效。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在 WHOOP 5/MG 上所有模式的震動都相同——重複次數不會傳送到該手環。你的選擇會被儲存，並在 WHOOP 4.0 上生效。"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Każdy wzór brzęczy tak samo na WHOOP 5/MG — liczba powtórzeń nie jest wysyłana do tego paska. Twój wybór został zapisany i dotyczy WHOOP 4.0."
-          }
-        }
-      }
-    },
     "Every release, mirrored. A fallback if GitHub is ever down.": {
       "localizations": {
         "de": {

--- a/Strand/Screens/NotificationSettingsView.swift
+++ b/Strand/Screens/NotificationSettingsView.swift
@@ -15,19 +15,12 @@ struct NotificationSettingsView: View {
             VStack(alignment: .leading, spacing: NoopMetrics.sectionSpacing) {
                 masterCard
                     .staggeredAppear(index: 0)
-                // #926: on a 5/MG the buzz payload is a hardcoded 12-byte literal whose byte[11]
-                // (overallLoop) is 0, so the caller's repeat count never reaches the wire — every
-                // BuzzPattern produces the same buzz. The picker still offers all four because the choice
-                // is stored per app and DOES apply to a WHOOP 4.0, so hiding it would lose a real setting.
-                // Say so instead, the way SmartAlarmView handles its own 5/MG-unconfirmed case, rather
-                // than leaving a control that silently does nothing.
-                if model.whoop5Detected {
-                    Text("Every pattern buzzes the same on a WHOOP 5/MG — the repeat count isn't sent to that strap. Your choice is saved and applies to a WHOOP 4.0.")
-                        .font(StrandFont.caption)
-                        .foregroundStyle(StrandPalette.textSecondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .staggeredAppear(index: 0)
-                }
+                // #926: the "every pattern buzzes the same on a 5/MG" note that used to sit here is GONE —
+                // the limitation it described is fixed. overallLoop (byte 11 of the maverick haptic body)
+                // is now written as `loops - 1` by `MaverickHaptics.notificationBuzz`, which `send` builds
+                // the 5/MG body with, so all four patterns are distinct on that family too. Leaving the
+                // note would be worse than never having had it: a caption telling the user their setting
+                // does nothing, next to a control that now works. Kotlin twin carries the same note.
                 if store.activeCategories.isEmpty {
                     emptyAppsCard
                         .staggeredAppear(index: 1)

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -465,6 +465,44 @@ class WhoopBleClient(
          */
         const val DEFAULT_DEVICE_ID = "my-whoop"
 
+        /**
+         * Build the WHOOP 5/MG ("maverick") haptic body from a 4.0-shaped `[patternId, loops, 0, 0, 0]`
+         * payload, carrying the repeat count through to the wire.
+         *
+         * Layout (docs/BLE_REVERSE_ENGINEERING.md:771):
+         * ```
+         *   [0]      REVISION_1 = 0x01
+         *   [1..8]   effects x8 — the "notify" preset (47, 152, then 0)
+         *   [9..10]  loopControl, u16 LE  — left 0, as in the shipped alarm body
+         *   [11]     overallLoop          — the repeat count (was hardcoded 0)
+         * ```
+         *
+         * #926: byte 11 used to be 0 unconditionally, which is why every BuzzPattern felt the same on a
+         * 5/MG.
+         *
+         * HARDWARE-CONFIRMED on a WHOOP 5/MG: `overallLoop` counts the repeats that follow the FIRST
+         * pulse, not the total — writing 3 produced FOUR buzzes. So it is written as `loops - 1`, and
+         * the model explains the old behaviour exactly: the shipped 0 meant "no repeats" = the single
+         * buzz every pattern used to give. It also matches `AlarmPayload`, which ships this same effects
+         * pair with overallLoop=7 (pinned by AlarmPayloadTest) for an alarm's long buzz train.
+         *
+         * Note the consequence: `loops = 1` reproduces the previously shipped, hardware-verified
+         * constant byte-for-byte, so this change is strictly additive — it only moves byte 11, and only
+         * when the caller asked for more than one pulse.
+         *
+         * Clamped to 1..8 (overallLoop 0..7), 7 being the largest value evidenced by the alarm body.
+         * Defensive: a payload shorter than 2 bytes (never emitted by [buzz], but [send] is generic)
+         * falls back to a single pulse rather than indexing out of bounds.
+         */
+        internal fun maverickHapticBody(payload: ByteArray): ByteArray {
+            val loops = if (payload.size >= 2) (payload[1].toInt() and 0xFF).coerceIn(1, 8) else 1
+            return byteArrayOf(
+                0x01,                                   // [0]     REVISION_1
+                47, 152.toByte(), 0, 0, 0, 0, 0, 0,     // [1..8]  effects x8 ("notify" preset)
+                0, 0,                                   // [9..10] loopControl u16 LE
+                (loops - 1).toByte(),                   // [11]    overallLoop = repeats AFTER the first
+            )
+        }
 
         // MARK: GATT UUIDs (authoritative, from BLEManager.swift / FINDINGS.md).
         //
@@ -3379,10 +3417,18 @@ class WhoopBleClient(
             // haptic body [0x01, effects(8), loopControl(u16 LE), overallLoop] — here the "notify" preset
             // (effects 47,152), NOT the 4.0 [patternId, loops, …]. puffinCommandFrame pads the inner to a
             // 4-byte boundary, which this 12-byte payload needs. WHOOP 4.0 is untouched (79 + its own frame).
+            //
+            // EXPERIMENT (#926): the literal above pinned overallLoop (byte 11) to 0, so the caller's
+            // repeat count never reached the wire and every BuzzPattern — plus the Breathe inhale/exhale
+            // and live-session long/short cues — felt identical on a 5/MG. This carries `loops` through
+            // into overallLoop instead. The prior is not a guess: AlarmPayload already ships the SAME
+            // effects (47,152) with loopControl=0 and overallLoop=7 (AlarmPayloadTest:62), so a non-zero
+            // overallLoop is an established part of a real maverick body. HARDWARE-CONFIRMED on a real
+            // 5/MG by @dwehrmann: writing 3 produced four buzzes, so the field counts repeats AFTER the
+            // first pulse — see [maverickHapticBody] for the measurement and the byte layout.
             val isHaptics = cmd == CommandNumber.RUN_HAPTICS_PATTERN
             val puffinCmd = if (isHaptics) 0x13 else cmd.rawValue
-            val puffinPayload = if (isHaptics)
-                byteArrayOf(0x01, 47, 152.toByte(), 0, 0, 0, 0, 0, 0, 0, 0, 0) else payload
+            val puffinPayload = if (isHaptics) maverickHapticBody(payload) else payload
             val s = seq.incrementAndGet() and 0xFF
             val frame = Framing.puffinCommandFrame(cmd = puffinCmd, seq = s, payload = puffinPayload)
             enqueueWrite(PendingWrite(frame, withResponse, cmd))

--- a/android/app/src/main/java/com/noop/ui/NotificationsSettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/NotificationsSettingsScreen.kt
@@ -65,7 +65,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.noop.ble.WhoopModel
 import com.noop.notif.CallAlertController
 import com.noop.notif.CallAlertSource
 import java.util.Calendar
@@ -381,27 +380,12 @@ fun NotificationsSettingsScreen(vm: AppViewModel) {
             }
         }
 
-        // #926: on a 5/MG the buzz payload is a hardcoded 12-byte literal and byte[11] (overallLoop) is
-        // 0, so the caller's repeat count never reaches the wire — every BuzzPattern produces the same
-        // buzz. The picker still offers all four because the choice is stored per app and DOES apply to a
-        // WHOOP 4.0, so hiding it would lose a real setting. Say so instead, the way SmartAlarmScreen
-        // handles its own 5/MG-unconfirmed case, rather than leaving a control that silently does nothing.
-        // Match the Settings #22 gate (SettingsScreen showFiveMGControls, mirrored in TestCentreScreen:87):
-        // the stored model OR a live-detected 5/MG this session. `live.whoop5Detected` alone is reset on
-        // every scan and disconnect, so keying on it would hide this note whenever the strap is offline —
-        // which is exactly when someone browses notification settings. The Apple side reads `selectedModel`,
-        // which persists, so gating on live detection here would also make the two platforms disagree.
-        val fiveMgSelected = remember {
-            NoopPrefs.of(context).getString("noop.selectedWhoopModel", null) == WhoopModel.WHOOP5_MG.name
-        }
-        if (fiveMgSelected || live.whoop5Detected) {
-            Text(
-                uiString(R.string.l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6),
-                style = NoopType.caption,
-                color = Palette.textSecondary,
-                modifier = Modifier.padding(horizontal = Metrics.space16, vertical = Metrics.space8),
-            )
-        }
+        // #926: the "every pattern buzzes the same on a 5/MG" note that used to sit here is GONE — the
+        // limitation it described is fixed. overallLoop (byte 11 of the maverick haptic body) is now
+        // written as `loops - 1` in WhoopBleClient.maverickHapticBody, hardware-confirmed on a real
+        // 5/MG, so all four patterns are distinct on that family too. Leaving the note would be worse
+        // than never having had it: a caption telling the user their setting does nothing, next to a
+        // control that now works.
 
         // MARK: Category cards
         activeCategories.forEach { cat ->

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1860,7 +1860,6 @@
     <string name="l10n_settings_screen_r22disable_confirm_cancel">Nur nicht mehr senden</string>
     <string name="l10n_settings_screen_r22_accepted_all">✓ Band hat alle %1$d R22-Flags akzeptiert</string>
     <string name="l10n_settings_screen_r22_accepted_partial">Band hat %1$d/%2$d R22-Flags akzeptiert…</string>
-    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">Auf einer WHOOP 5/MG vibriert jedes Muster gleich — die Wiederholungszahl wird an dieses Band nicht gesendet. Deine Auswahl wird gespeichert und gilt für eine WHOOP 4.0.</string>
     <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">Wasser und Koffein aus Apple Health, ein genaueres Effort-Ergebnis und ein Oura-Ruhepuls-Fix</string>
     <!-- First-run onboarding copy. -->
     <string name="onboarding_cta_begin">Loslegen</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1827,7 +1827,6 @@
     <string name="l10n_settings_screen_r22disable_confirm_cancel">Solo dejar de enviar</string>
     <string name="l10n_settings_screen_r22_accepted_all">✓ La pulsera aceptó las %1$d marcas R22</string>
     <string name="l10n_settings_screen_r22_accepted_partial">La pulsera aceptó %1$d/%2$d marcas R22…</string>
-    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">En una WHOOP 5/MG todos los patrones vibran igual: el número de repeticiones no se envía a esa correa. Tu elección se guarda y se aplica a una WHOOP 4.0.</string>
     <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">Agua y cafeína desde Apple Health, una puntuación de Effort más precisa y una corrección del pulso en reposo de Oura</string>
     <!-- Textos de la configuración inicial. -->
     <string name="onboarding_cta_begin">Empezar</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1845,7 +1845,6 @@
     <string name="l10n_settings_screen_r22disable_confirm_cancel">Cesser seulement d’envoyer</string>
     <string name="l10n_settings_screen_r22_accepted_all">✓ Le bracelet a accepté les %1$d indicateurs R22</string>
     <string name="l10n_settings_screen_r22_accepted_partial">Le bracelet a accepté %1$d/%2$d indicateurs R22…</string>
-    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">Sur un WHOOP 5/MG, tous les motifs vibrent de la même façon — le nombre de répétitions n\'est pas envoyé à ce bracelet. Votre choix est enregistré et s\'applique à un WHOOP 4.0.</string>
     <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">L\'eau et la caféine depuis Apple Santé, un score Effort plus précis et un correctif de la FC au repos Oura</string>
     <!-- Textes de la configuration initiale. -->
     <string name="onboarding_cta_begin">Commencer</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -1814,7 +1814,6 @@
     <string name="l10n_settings_screen_r22disable_confirm_cancel">Po prostu przestań wysyłać</string>
     <string name="l10n_settings_screen_r22_accepted_all">✓ Pasek akceptuje wszystkie flagi %1$d R22</string>
     <string name="l10n_settings_screen_r22_accepted_partial">Pasek akceptowany %1$d/%2$d Flagi R22…</string>
-    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">Każdy wzór brzęczy tak samo na WHOOP 5/MG — liczba powtórzeń nie jest wysyłana do tego paska. Twój wybór został zapisany i dotyczy WHOOP 4.0.</string>
     <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">Woda i kofeina z Apple Health, ostrzejszy wynik Wysiłek i poprawka tętna spoczynkowego Oura</string>
     <string name="onboarding_cta_begin">Zaczynać</string>
     <string name="onboarding_cta_continue">Dalej</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1821,7 +1821,6 @@
     <string name="l10n_settings_screen_r22disable_confirm_cancel">Apenas parar de enviar</string>
     <string name="l10n_settings_screen_r22_accepted_all">✓ A pulseira aceitou as %1$d marcas R22</string>
     <string name="l10n_settings_screen_r22_accepted_partial">A pulseira aceitou %1$d/%2$d marcas R22…</string>
-    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">Numa WHOOP 5/MG todos os padrões vibram igual — a contagem de repetições não é enviada para essa bracelete. A tua escolha fica guardada e aplica-se a uma WHOOP 4.0.</string>
     <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">Água e cafeína a partir do Apple Health, uma pontuação de Effort mais precisa e uma correção da FC em repouso do Oura</string>
     <!-- Textos da configuração inicial. -->
     <string name="onboarding_cta_begin">Começar</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1756,7 +1756,6 @@
     <string name="l10n_settings_screen_r22disable_confirm_body">关闭此开关只会让 NOOP 停止发送解锁序列。已写入的标记会留在手环上，直到有东西清除它们。NOOP 现在可以向全部 16 个标记写入关闭值并逐一读回，让你看到手环实际存储的内容。需要手环已连接并完成配对。</string>
     <string name="l10n_settings_screen_r22disable_confirm_action">清除手环上的标记</string>
     <string name="l10n_settings_screen_r22disable_confirm_cancel">仅停止发送</string>
-    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">在 WHOOP 5/MG 上所有模式的震动都相同——重复次数不会发送到该手环。你的选择会被保存，并在 WHOOP 4.0 上生效。</string>
     <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">从 Apple 健康导入饮水与咖啡因、更精确的 Effort 分数，以及 Oura 静息心率修复</string>
     <!-- 首次设置文本。 -->
     <string name="onboarding_cta_begin">开始</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1871,7 +1871,6 @@
     <string name="l10n_settings_screen_r22disable_confirm_cancel">Just stop sending</string>
     <string name="l10n_settings_screen_r22_accepted_all">✓ Strap accepted all %1$d R22 flags</string>
     <string name="l10n_settings_screen_r22_accepted_partial">Strap accepted %1$d/%2$d R22 flags…</string>
-    <string name="l10n_notifications_settings_screen_every_pattern_buzzes_the_same_on_34e873f6">Every pattern buzzes the same on a WHOOP 5/MG — the repeat count isn\'t sent to that strap. Your choice is saved and applies to a WHOOP 4.0.</string>
     <string name="l10n_app_changelog_water_and_caffeine_from_apple_health_5123b6b0">Water and caffeine from Apple Health, a sharper Effort score, and an Oura resting-heart-rate fix</string>
     <!-- First-run onboarding copy. Kept in resources so every visible setup string is localizable. -->
     <string name="onboarding_cta_begin">Begin</string>

--- a/android/app/src/test/java/com/noop/protocol/MaverickHapticBodyTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/MaverickHapticBodyTest.kt
@@ -1,0 +1,84 @@
+package com.noop.protocol
+
+import com.noop.ble.WhoopBleClient
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins [WhoopBleClient.maverickHapticBody] — the WHOOP 5/MG haptic body built from a 4.0-shaped
+ * `[patternId, loops, 0, 0, 0]` payload.
+ *
+ * #926: byte 11 (overallLoop) was hardcoded 0, so the caller's repeat count never reached the wire
+ * and every BuzzPattern felt identical on a 5/MG.
+ *
+ * HARDWARE-CONFIRMED on a real 5/MG: overallLoop counts the repeats AFTER the first pulse — writing
+ * 3 produced four buzzes — so it is written as `loops - 1`. That model also explains the old
+ * behaviour: the shipped 0 meant "no repeats", i.e. the single buzz every pattern used to give.
+ */
+class MaverickHapticBodyTest {
+
+    private fun body(loops: Int) =
+        WhoopBleClient.maverickHapticBody(byteArrayOf(2, loops.toByte(), 0, 0, 0))
+
+    @Test
+    fun bodyIsTwelveBytesWithTheNotifyPreset() {
+        val b = body(1)
+        assertEquals(12, b.size)
+        assertEquals(0x01, b[0].toInt())            // REVISION_1
+        assertEquals(47, b[1].toInt())              // effects[0]
+        assertEquals(152, b[2].toInt() and 0xFF)    // effects[1]
+        for (i in 3..8) assertEquals("effects[$i] padding", 0, b[i].toInt())
+        assertEquals("loopControl lo", 0, b[9].toInt())
+        assertEquals("loopControl hi", 0, b[10].toInt())
+    }
+
+    @Test
+    fun overallLoopIsTheRepeatCountAfterTheFirstPulse() {
+        // The wire value is one LESS than the number of buzzes the wrist feels.
+        assertEquals("1 buzz", 0, body(1)[11].toInt())
+        assertEquals("2 buzzes", 1, body(2)[11].toInt())
+        assertEquals("3 buzzes", 2, body(3)[11].toInt())
+        assertEquals("5 buzzes (BuzzPattern.Long)", 4, body(5)[11].toInt())
+    }
+
+    @Test
+    fun theFourBuzzPatternsAllDiffer() {
+        // The whole point of #926: Single/Double/Triple/Long must not collapse to one value.
+        val wire = listOf(1, 2, 3, 5).map { body(it)[11].toInt() }
+        assertEquals(listOf(0, 1, 2, 4), wire)
+        assertEquals("no two patterns share a wire value", 4, wire.toSet().size)
+    }
+
+    @Test
+    fun loopsAreClampedToTheRangeTheAlarmBodyEvidences() {
+        // AlarmPayload ships overallLoop=7, the largest value evidenced, so loops caps at 8.
+        assertEquals(7, body(99)[11].toInt())
+        assertEquals(7, body(8)[11].toInt())
+        assertEquals(0, body(0)[11].toInt())
+    }
+
+    @Test
+    fun theLoopByteIsReadUnsigned() {
+        // A payload byte is a raw wire value, so 0xFD must read as 253 (then clamp), NOT as the signed
+        // -3 it would be in Kotlin. Reading it signed would make any count above 127 collapse to the
+        // minimum — the opposite of what the clamp is for.
+        assertEquals(7, body(0xFD)[11].toInt())
+        assertEquals(7, body(0xFF)[11].toInt())
+    }
+
+    @Test
+    fun singleBuzzReproducesTheOldShippedConstantExactly() {
+        // The literal this replaced was [0x01, 47, 152, 0*8, 0]. With overallLoop = loops-1, a
+        // single-buzz request rebuilds it byte-for-byte — so the previously shipped, hardware-verified
+        // frame is preserved and the change only takes effect when more than one pulse was asked for.
+        val old = byteArrayOf(0x01, 47, 152.toByte(), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        assertArrayEquals(old, body(1))
+    }
+
+    @Test
+    fun shortPayloadFallsBackToASinglePulse() {
+        assertEquals(0, WhoopBleClient.maverickHapticBody(byteArrayOf())[11].toInt())
+        assertEquals(0, WhoopBleClient.maverickHapticBody(byteArrayOf(2))[11].toInt())
+    }
+}


### PR DESCRIPTION
Supersedes #1543 — **@dwehrmann did the hard part** and their commits are carried over as-is. This adds the half their PR left out, which I found reviewing it.

## Their finding, which is the thing that makes any of this possible

Measured on a real WHOOP 5/MG: writing `overallLoop = 3` produced **four** buzzes, so the field counts the repeats that *follow* the first pulse and is written as `loops - 1`.

What makes it convincing is that it explains the **old** behaviour rather than merely fitting the new. A hardcoded `0` meaning "no repeats" predicts exactly the single identical buzz every `BuzzPattern` used to give. The competing reading — `0` meaning "zero buzzes" — predicts silence, which is not what shipped for years. That is a genuinely well-formed piece of protocol RE and nobody without the hardware could have produced it.

## What #1543 left, and why it matters

**1. iOS had the identical bug.** `BLEManager.send` substituted the same literal `[0x01, 47, 152, 0, …, 0]` with byte 11 zeroed, so a 5/MG on iOS still felt one buzz for every pattern — including the Breathe inhale/exhale cue, which #1543 rightly identifies as the real loss, since haptic breathing pacing that can't tell you which way to breathe is just a metronome. `overallLoop = loops - 1` is a protocol fact, not a platform behaviour, so it carries straight across.

**2. The shared helper encoded the opposite convention.** `MaverickHaptics.notificationBuzz` wrote `loops` straight into the byte, pinned by a vector asserting one buzz = `1`:

```swift
XCTAssertEqual(MaverickHaptics.notificationBuzz(loops: 1),
               [0x01, 47, 152, 0, 0, 0, 0, 0, 0, 0, 0, 1])   // now 0
```

That function's own comment called it *"the only code that knows how to build a VARIABLE-loop buzz body, which is exactly what a future test of `overallLoop != 0` would need"*. #1543 **is** that future — so leaving it inverted would hand the next caller a silent off-by-one from the file documented as the authority on this field. Corrected, and iOS now routes through it instead of carrying its own literal.

**3. A stale comment contradicted the change it introduced.** The call site said `HARDWARE-UNVERIFIED` while the function it called said `HARDWARE-CONFIRMED`, and pointed at `mavericHapticBody` — a name missing its `k`, so the cross-reference was dead as well. In a repo where verification status is load-bearing, that is how a working change gets reverted by someone being careful.

## Safety

A single buzz rebuilds the previously shipped, hardware-verified constant **byte-for-byte on both platforms** — `(1 - 1) = 0`, with the other eleven bytes unchanged. Byte 11 moves only when the caller asked for more than one pulse. Both sides clamp to `1...8` (`overallLoop` 0...7), 7 being the largest value any captured body evidences (the alarm's wake train); the old Swift `UInt8(clamping:)` admitted 255, which nothing has ever observed on the wire.

The Swift and Kotlin tests now pin the **same vectors** — 1→0, 2→1, 3→2, 5→4, clamp→7 — so two independent reimplementations cannot drift on what this byte means.

## Verification

- `Packages/WhoopProtocol`: **619 tests, 0 failures**
- Android: **4,221 tests, 0 failures** (`--no-build-cache --rerun-tasks`; main is 4,214), `MaverickHapticBodyTest` 7/7
- `lintVitalFullRelease -PstagingRelease` clean after the seven-locale string removal; i18n audit and doc lint clean
- **app-build [32604977433](https://github.com/ryanbr/noop/actions/runs/32604977433) green on both legs**, `Test Strand` 1,195/0

**Hardware status, stated precisely:** the Android path is confirmed on a real 5/MG by @dwehrmann's measurement table. The iOS path is the same wire body, built by the same shared function, sent by the same opcode — but it has **not** been run on a 5/MG. That is an inference from a protocol fact, not an observation, and it should be treated as such.

@dwehrmann — this is your work plus the parts I'd have asked for in review; if you'd rather land #1543 as-is and follow up separately, say so and I'll close this instead.