### PR TITLE
Finish the #1532 sweep: the four production ScrollViews it missed (iOS)

### DIFF
--- a/Strand/Screens/BreathingView.swift
+++ b/Strand/Screens/BreathingView.swift
@@ -449,6 +449,14 @@ private struct BreathingContent: View {
                 .padding(20)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
+            // #697 parity: this screen builds its OWN ScrollView rather than going through
+            // ScreenScaffold, so it never inherited the scaffold's horizontal-bounce suppression and
+            // could still rubber-band left-right on a purely vertical scroll. Same modifier, same
+            // guard. `.basedOnSize` permits horizontal bounce only when content genuinely overflows
+            // the width, so nothing that is meant to scroll sideways is affected. (#1532 follow-up)
+            #if os(iOS)
+            .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
+            #endif
             .navigationTitle(String(localized: "About this pace"))
             #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)

--- a/Strand/Screens/CoachView.swift
+++ b/Strand/Screens/CoachView.swift
@@ -423,6 +423,14 @@ struct CoachView: View {
                         .padding(.vertical, 2)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     }
+                    // #697 parity: this screen builds its OWN ScrollView rather than going through
+                    // ScreenScaffold, so it never inherited the scaffold's horizontal-bounce suppression and
+                    // could still rubber-band left-right on a purely vertical scroll. Same modifier, same
+                    // guard. `.basedOnSize` permits horizontal bounce only when content genuinely overflows
+                    // the width, so nothing that is meant to scroll sideways is affected. (#1532 follow-up)
+                    #if os(iOS)
+                    .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
+                    #endif
                     .frame(minHeight: 220, maxHeight: 460)
                     .onChangeCompat(of: coach.messages.count) { _ in
                         scrollToEnd(proxy)

--- a/Strand/Screens/ManualWorkoutSheet.swift
+++ b/Strand/Screens/ManualWorkoutSheet.swift
@@ -252,6 +252,14 @@ struct ManualWorkoutSheet: View {
                 Color.clear.preference(key: SuggestionsHeightKey.self, value: geo.size.height)
             })
         }
+        // #697 parity: this screen builds its OWN ScrollView rather than going through
+        // ScreenScaffold, so it never inherited the scaffold's horizontal-bounce suppression and
+        // could still rubber-band left-right on a purely vertical scroll. Same modifier, same
+        // guard. `.basedOnSize` permits horizontal bounce only when content genuinely overflows
+        // the width, so nothing that is meant to scroll sideways is affected. (#1532 follow-up)
+        #if os(iOS)
+        .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
+        #endif
         .frame(height: min(max(suggestionsHeight, 1), 168))
         .onPreferenceChange(SuggestionsHeightKey.self) { suggestionsHeight = $0 }
         .background(StrandPalette.surfaceInset, in: inputShape)

--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -700,6 +700,14 @@ struct MetricDetailView: View {
             .padding(NoopMetrics.screenPadding)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        // #697 parity: this screen builds its OWN ScrollView rather than going through
+        // ScreenScaffold, so it never inherited the scaffold's horizontal-bounce suppression and
+        // could still rubber-band left-right on a purely vertical scroll. Same modifier, same
+        // guard. `.basedOnSize` permits horizontal bounce only when content genuinely overflows
+        // the width, so nothing that is meant to scroll sideways is affected. (#1532 follow-up)
+        #if os(iOS)
+        .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
+        #endif
         // Day-cycle-aware backdrop (#430 parity): the top sky band every liquid screen uses when the
         // setting is on — or the FULL-viewport sky with the softer settle when "Sky behind cards" is also
         // on (the LiquidTodayView treatment, so the transparent cards reveal it the whole way down); the


### PR DESCRIPTION
Follow-up to #1532 (@evoveotech), which established the rule — every screen that builds its **own** `ScrollView` gets the horizontal-bounce suppression `ScreenScaffold` has carried since #697 — and applied it to 28 scroll views. Four production sites were left behind.

## What was missed

| screen | scroller |
|---|---|
| `CoachView` | the chat transcript |
| `BreathingView` | the technique/detail column |
| `MetricExplorerView` | the metric list |
| `ManualWorkoutSheet` | its **second** ScrollView — the first got the modifier |

**Coach is the interesting one.** It is the screen a recurrence was actually reported on, and it renders through `ScreenScaffold` *and* nests its own `ScrollView`. The scaffold's modifier applies only to the scaffold's own scroller, so it never reached the one the user was touching. That is exactly the case #1532 was widened to address, and it is the case that stayed open.

## What I deliberately did not touch

A raw scan flags six further sites. All of them live in `#Preview` or `#if DEBUG` blocks — `ChargeBreakdownFormat` (×2), `WeeklyDigestView`, `TrendsReportView`, `SkinTempCardsView`, `StressView`. Preview code does not ship, and adding a behaviour modifier there would be noise that reads as coverage.

Worth stating plainly: my first pass at this counted **nine files** by regex and I reported that number before checking what the sites were. Six of the ten were previews. The real gap was four.

## Scope

Same modifier, same `#if os(iOS)` guard as #1532 — `.scrollBounceBehavior(_:axes:)` is macOS 13.3+ against this project's macOS 13.0 target, so the guard is load-bearing rather than stylistic. `.basedOnSize` permits horizontal bounce only when content genuinely overflows the width, so nothing meant to scroll sideways changes. No horizontal `ScrollView` was touched; I checked each insertion's enclosing scroller first.

**No Android twin.** This is a SwiftUI quirk: a purely-vertical `ScrollView` rubber-banding left-right. Compose scroll axes are explicit — a `verticalScroll` column cannot drift horizontally without an explicit `horizontalScroll`, and `TodayScreen` has none — so there is no equivalent defect to fix. A "twin" here would be code with no bug behind it.

## Verification

- **app-build [32607926540](https://github.com/ryanbr/noop/actions/runs/32607926540) green on both legs**, `Test Strand` 1,195/0. `app-build.yml` is disabled by default, so nothing else compiles these files.
- Doc lint clean. Each insertion placed after its `ScrollView`'s matching closing brace, verified by brace-matching rather than by eye.

Not hardware-tested: whether each of these four could actually be made to drift needs a device, which is the same limit #1532 hit. The change is the same one-line modifier already shipped on 28 scrollers.