### PR TITLE
Oura: hand the ring out of daytime mode on teardown, not only on suspend

### DIFF
--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -1015,7 +1015,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     private var loggedLiveHRSuspend = false
 
     /// Logged-once latch (per suspend episode) for a live-HR push arriving AFTER we believe the ring is
-    /// suspended — the direct falsification signal for `disableLiveHRForSuspend`. 08-17/18 found the
+    /// suspended — the direct falsification signal for `disableLiveHR`. 08-17/18 found the
     /// PREVIOUS design (stop re-engaging, rely on the ring's daytime-HR mode auto-reverting ~20 s after
     /// the last keep-alive per OURA_PROTOCOL.md s5.7) does not stop the stream: green 0x80 ran 1,700-3,600
     /// per hour all night, including inside a genuinely stable, reconnect-free 3.5 h stretch, so nothing
@@ -1270,6 +1270,20 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         pendingConnectID = nil
         stopReengageTimer()
         stopHistoryFetchTimer()
+        // #1526 follow-up: stopping the re-engage is NOT enough to stop the ring. That is the same
+        // "just stop poking it" assumption #1526's own captures falsified — with daytime-HR left in
+        // mode 0x01 the green 0x80 pushes kept arriving all night, and the ring's ~20 s auto-revert
+        // never fired on that build. So a teardown that only cancels the timer hands back a ring still
+        // in daytime mode, blocking its own sleep suite exactly as the unattended case did; the suspend
+        // path is simply the only exit that was wired to say so. Send the same disable + unsubscribe
+        // pair here before the link goes.
+        //
+        // Best-effort by nature: these are WRITE_WITHOUT_RESPONSE, so they are handed to the controller
+        // immediately, but an intentional teardown cancels the connection in the next statement and
+        // CoreBluetooth makes no flush guarantee. It costs two queued writes and closes the common
+        // cases -- user disconnect, source switch, Bluetooth off. A process kill cannot be covered at
+        // all, which is a limit of the transport rather than of this fix.
+        disableLiveHR()
         if let p = peripheral { central.cancelPeripheralConnection(p) }
         peripheral = nil
         writeCharacteristic = nil
@@ -1609,7 +1623,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
             switch e {
             case .hr(let hr):
                 guard hr.bpm >= 30, hr.bpm <= 220 else { continue }   // physiological gate
-                // Direct falsification signal for `disableLiveHRForSuspend`, AND the self-heal for the one
+                // Direct falsification signal for `disableLiveHR`, AND the self-heal for the one
                 // gap 2026-08-21's hardware run found: enforcement is polled on `reengageLiveHR`'s 15 s
                 // tick (deliberately, see that function's doc — a one-shot timer at grace-expiry is not
                 // trustworthy backgrounded on iOS), so there is an up-to-15 s window right as the grace
@@ -1620,7 +1634,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 // stop-and-disable transition `reengageLiveHR()` would eventually run anyway; calling it
                 // here just runs it now instead of up to 15 s late, closing the gap without touching the
                 // grace period itself. Log line stays latched once per suspend episode (strap log clip
-                // budget); the resend is not — safe to repeat, `disableLiveHRForSuspend` is a harmless
+                // budget); the resend is not — safe to repeat, `disableLiveHR` is a harmless
                 // read-only-shaped write when already streaming-or-not per its own doc.
                 if liveHRSuspended {
                     if !loggedUnexpectedLiveHRWhileSuspended {
@@ -1984,7 +1998,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         stopReengageTimer()
         guard !liveHRSuspended else {
             logLiveHRSuspendOnce()
-            disableLiveHRForSuspend()
+            disableLiveHR()
             return
         }
         let t = Timer.scheduledTimer(withTimeInterval: reengageInterval, repeats: true) { [weak self] _ in
@@ -2037,7 +2051,11 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// true but before the next tick gets here. Closed by having the push handler itself (the `.hr` case
     /// in `ingest`) call `startReengageTimer()` - which runs this exact stop-and-disable transition - the
     /// moment it sees a stale push, instead of waiting for the tick. Not yet hardware-validated.
-    private func disableLiveHRForSuspend() {
+    /// Also called from `stop()` (#1526 follow-up), so the name is no longer suspend-specific: an
+    /// intentional teardown must hand the ring back out of daytime mode for the same reason a suspend
+    /// must. The `.streaming` guard covers both callers -- there is nothing to disable if the session
+    /// never got that far.
+    private func disableLiveHR() {
         guard let driver, driver.phase == .streaming else { return }
         write([OuraCommands.liveHRDisable(), OuraCommands.liveHRUnsubscribe()])
         if feedsLive { live.streamingLiveHR = false }
@@ -2057,7 +2075,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         if liveHRSuspended {
             stopReengageTimer()
             logLiveHRSuspendOnce()
-            disableLiveHRForSuspend()
+            disableLiveHR()
             return
         }
         guard let driver, reachedStreaming, driver.phase != .fetchingHistory else { return }

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -996,6 +996,18 @@ class OuraLiveSource(
         hypnogramAssembler.flush()?.let { persistHypnogramBurst(it) }
         drainPendingAnchorEvents()
         dropUnanchoredHypnogramBursts()
+        // #1526 follow-up, twin of the Swift `stop()` call: cancelling the re-engage does NOT stop the
+        // ring. That is the "just stop poking it" assumption #1526's captures falsified -- daytime-HR
+        // left in mode 0x01 kept pushing green 0x80 all night, and the ring's ~20 s auto-revert never
+        // fired. A teardown that only cancels the timer therefore hands back a ring still in daytime
+        // mode, blocking its own sleep suite. Send the same disable + unsubscribe pair before the link
+        // goes, and BEFORE driver.stop() so the phase check below still sees Streaming.
+        //
+        // Best-effort by nature: WRITE_TYPE_NO_RESPONSE goes to the controller immediately, but the
+        // disconnect follows in the next statement and nothing guarantees a flush. It closes the common
+        // cases -- user disconnect, source switch, Bluetooth off -- and a process kill cannot be covered
+        // at all, which is a transport limit rather than a gap in this fix.
+        disableLiveHR()
         driver?.stop()
         gatt?.let { runCatching { it.disconnect(); it.close() } }
         gatt = null
@@ -1399,6 +1411,22 @@ class OuraLiveSource(
             log("Oura: the ring did not accept the key (status=${status ?: "none"}) - cannot adopt this ring")
             announceNeedsPairing(KEY_INSTALL_MESSAGE)
         }
+    }
+
+    /**
+     * Hand the ring back out of daytime-HR mode: the feature-mode write plus the unsubscribe the enable
+     * triplet leaves standing. Twin of Swift `OuraLiveSource.disableLiveHR`.
+     *
+     * `liveHRDisable` alone only touches the MODE byte, so without the unsubscribe the notification
+     * channel stays open for the ring's own adaptive sampling to push through -- which is why #1526
+     * corrected the byte (0x01 "automatic" was never "off") and added the pair. The Streaming guard
+     * covers the callers: there is nothing to disable if the session never got that far.
+     */
+    private fun disableLiveHR() {
+        val d = driver ?: return
+        if (d.phase != OuraDriverPhase.Streaming) return
+        write(OuraCommands.liveHRDisable())
+        write(OuraCommands.liveHRUnsubscribe())
     }
 
     /** Write one built command to the ring's write characteristic (Write Without Response). Logged by its


### PR DESCRIPTION
Follow-up to #1526 (@pipiche38). Same bug, different exit.

## The gap

#1526 established that the ring must be **actively disabled**, not merely left alone — its commit 4 says so directly:

> "just stop poking it" doesn't work: the ring's own ~20s auto-revert never actually fired on this build (08-17/18 capture: green `0x80` never collapsed, any hour). Send an explicit disable.

But the disable was wired to exactly one exit. `disableLiveHRForSuspend()` had two callers, both on the screen-dark suspend path, and `stop()` does this:

```swift
stopReengageTimer()
if let p = peripheral { central.cancelPeripheralConnection(p) }
```

Cancels the timer, drops the link, sends nothing. That is the falsified assumption, still live on every teardown that isn't a suspend — user disconnect, source switch, Bluetooth off. The ring is handed back still in daytime-HR mode, blocking its own sleep suite exactly as the unattended case did.

So the bug #1526 fixed remained reachable; just not by the path it was measured on.

## The fix

Send the same disable + unsubscribe pair from `stop()` on both platforms, before the link goes and before `driver.stop()` clears the phase the guard reads.

**Best-effort, and said so in both files.** These are write-without-response, so they reach the controller immediately, but the disconnect follows in the next statement and neither CoreBluetooth nor Android guarantees a flush. It closes the intentional teardowns. A process kill cannot be covered at all — a transport limit, not a gap in the fix.

## Parity

Same call site (before `driver.stop()`), same `Streaming` guard, same command pair, same write-without-response semantics on both sides. Checked concretely rather than assumed:

- Swift runs while `peripheral` / `writeCharacteristic` are still set — they are nulled two statements later.
- Kotlin's `guardedCallback` is a synchronous `runCatching`, not a post, so the write is issued inline before `gatt.disconnect()`.

Swift's helper is renamed `disableLiveHRForSuspend` → `disableLiveHR`, since it is no longer suspend-specific. **Kotlin gains the twin it never had** — #1526 added `liveHRDisable` / `liveHRUnsubscribe` to `Commands.kt` with no callers, so this is also what stops them being dead code on that side.

#1546 (the Android screen-state suspend) is unaffected and still outstanding. This is the teardown exit only, on both platforms.

## Verification

- Android **4,223 tests, 0 failures** (`--no-build-cache --rerun-tasks`, matching main), `Packages/OuraProtocol` **206 tests**
- **app-build [32609395602](https://github.com/ryanbr/noop/actions/runs/32609395602) green on both legs**
- doc lint and i18n clean

**Not hardware-validated.** The commands are the pair @pipiche38 validated across three captures on the suspend path, sent from a different exit. That a stopped-but-not-disabled ring really stays in daytime mode is read from #1526's own evidence rather than measured here — @pipiche38, if you have the ring on and can stop a session then watch for green `0x80`, that is the observation that would confirm it.