### PR TITLE
Sleep: drop the stage legend from the breakdown card, both platforms

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Hypnogram.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Hypnogram.swift
@@ -424,6 +424,13 @@ public struct Hypnogram: View {
 /// A compact colour-coded key for a stepped hypnogram: one dot + label per stage in the chart's ramp, so a
 /// reader can decode the bands — which is what makes the Garmin ramp's two pinks (Awake vs REM) legible.
 /// (#sleep-chart-style)
+///
+/// NOTHING RENDERS THIS (#1536). Its only call sites put it above `stageBreakdownRows`, whose rows carry
+/// their own labels — so it named stages already named, in a different order than the rows list them, and
+/// in the chart ramp's colours while those rows use fixed `StrandPalette` tokens, which made its dots
+/// disagree with the swatches directly beneath them on any non-NOOP ramp. Kept rather than deleted: it is
+/// the only code that knows how to build this key, and a genuinely unlabelled hypnogram is what it is for.
+/// Wire it to one of those, not to a labelled table.
 public struct SleepStageLegend: View {
     public var palette: SleepStagePalette
     public init(palette: SleepStagePalette) { self.palette = palette }

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -855,10 +855,13 @@ struct SleepView: View {
             // A colour-coded key in the chart's ramp so the bands are decodable (esp. the Garmin ramp's two
             // pinks), then the per-stage breakdown rows below.
             footer: {
-                VStack(alignment: .leading, spacing: NoopMetrics.space2) {
-                    SleepStageLegend(palette: style.stagePalette)
+                    // #1536: the stage LEGEND that used to sit here is gone. It decodes an unlabelled
+                    // hypnogram's bands (the Garmin ramp's two pinks especially), but the breakdown rows
+                    // below carry their own labels — so above them it named something already named, in a
+                    // different order than the rows list, and in the chart RAMP's colours while the rows
+                    // use fixed palette tokens, so on a non-NOOP ramp its dots disagreed with the swatches
+                    // directly beneath them.
                     stageBreakdownRows(s)
-                }
             }
         )
     }

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -855,13 +855,14 @@ struct SleepView: View {
             // A colour-coded key in the chart's ramp so the bands are decodable (esp. the Garmin ramp's two
             // pinks), then the per-stage breakdown rows below.
             footer: {
-                    // #1536: the stage LEGEND that used to sit here is gone. It decodes an unlabelled
-                    // hypnogram's bands (the Garmin ramp's two pinks especially), but the breakdown rows
-                    // below carry their own labels — so above them it named something already named, in a
-                    // different order than the rows list, and in the chart RAMP's colours while the rows
-                    // use fixed palette tokens, so on a non-NOOP ramp its dots disagreed with the swatches
-                    // directly beneath them.
-                    stageBreakdownRows(s)
+                    // #1536: the stage LEGEND that used to sit here is gone, and the rows below now take
+                    // the chart's ramp. Those two go together. The legend decoded the hypnogram above it,
+                    // which is real work — but it listed the stages in a different order than the rows, and
+                    // the rows drew FIXED palette tokens while the chart drew ramp colours, so on
+                    // Oura/Garmin three things in one card disagreed. Ramp-aware rows name and colour every
+                    // stage correctly, which IS the key; a legend above a correct key is the redundancy
+                    // that was reported.
+                    stageBreakdownRows(s, palette: style.stagePalette)
             }
         )
     }
@@ -1187,12 +1188,12 @@ struct SleepView: View {
     /// proportional bar in the stage colour over a faint track, and the right-aligned duration. Same data
     /// as the prior footer (`s.rem` / `s.deep` / `s.light` / `s.awake` over `s.total`) — no new numbers.
     @ViewBuilder
-    private func stageBreakdownRows(_ s: Stages) -> some View {
+    private func stageBreakdownRows(_ s: Stages, palette: SleepStagePalette = .noop) -> some View {
         VStack(alignment: .leading, spacing: NoopMetrics.cardInnerSpacing) {
-            stageBreakdownRow(.rem,   minutes: s.rem,   total: s.total, percent: stageSharePercent(.rem, s))
-            stageBreakdownRow(.deep,  minutes: s.deep,  total: s.total, percent: stageSharePercent(.deep, s))
-            stageBreakdownRow(.light, minutes: s.light, total: s.total, percent: stageSharePercent(.light, s))
-            stageBreakdownRow(.awake, minutes: s.awake, total: s.total, percent: stageSharePercent(.awake, s))
+            stageBreakdownRow(.rem,   minutes: s.rem,   total: s.total, percent: stageSharePercent(.rem, s), palette: palette)
+            stageBreakdownRow(.deep,  minutes: s.deep,  total: s.total, percent: stageSharePercent(.deep, s), palette: palette)
+            stageBreakdownRow(.light, minutes: s.light, total: s.total, percent: stageSharePercent(.light, s), palette: palette)
+            stageBreakdownRow(.awake, minutes: s.awake, total: s.total, percent: stageSharePercent(.awake, s), palette: palette)
         }
     }
 
@@ -1214,8 +1215,9 @@ struct SleepView: View {
     /// apportioned share (so the four rows sum to 100). Tappable (WHOOP, ryanAtriumAi #988): selecting a
     /// row highlights that stage and recedes the rest; tapping the selected row again clears the highlight.
     @ViewBuilder
-    private func stageBreakdownRow(_ stage: SleepStage, minutes: Double, total: Double, percent: Int) -> some View {
-        let color = StrandPalette.sleepStageColor(stage)
+    private func stageBreakdownRow(_ stage: SleepStage, minutes: Double, total: Double, percent: Int,
+                                   palette: SleepStagePalette = .noop) -> some View {
+        let color = StrandPalette.sleepStageColor(stage, palette: palette)
         let fraction = total > 0 ? min(1, max(0, minutes / total)) : 0
         let isSelected = selectedStage == stage
         let othersSelected = selectedStage != nil && !isSelected

--- a/Strand/Screens/StagesCard.swift
+++ b/Strand/Screens/StagesCard.swift
@@ -183,13 +183,14 @@ struct StageDetailView: View {
                 )
             },
             footer: {
-                    // #1536: the stage LEGEND that used to sit here is gone. It decodes an unlabelled
-                    // hypnogram's bands (the Garmin ramp's two pinks especially), but the breakdown rows
-                    // below carry their own labels — so above them it named something already named, in a
-                    // different order than the rows list, and in the chart RAMP's colours while the rows
-                    // use fixed palette tokens, so on a non-NOOP ramp its dots disagreed with the swatches
-                    // directly beneath them.
-                    stageBreakdownRows(s)
+                    // #1536: the stage LEGEND that used to sit here is gone, and the rows below now take
+                    // the chart's ramp. Those two go together. The legend decoded the hypnogram above it,
+                    // which is real work — but it listed the stages in a different order than the rows, and
+                    // the rows drew FIXED palette tokens while the chart drew ramp colours, so on
+                    // Oura/Garmin three things in one card disagreed. Ramp-aware rows name and colour every
+                    // stage correctly, which IS the key; a legend above a correct key is the redundancy
+                    // that was reported.
+                    stageBreakdownRows(s, palette: style.stagePalette)
             }
         )
     }
@@ -345,12 +346,12 @@ struct StageDetailView: View {
     /// proportional bar in the stage colour over a faint track, and the right-aligned duration. Same data
     /// as the prior footer (`s.rem` / `s.deep` / `s.light` / `s.awake` over `s.total`) — no new numbers.
     @ViewBuilder
-    private func stageBreakdownRows(_ s: Stages) -> some View {
+    private func stageBreakdownRows(_ s: Stages, palette: SleepStagePalette = .noop) -> some View {
         VStack(alignment: .leading, spacing: NoopMetrics.cardInnerSpacing) {
-            stageBreakdownRow(.rem,   minutes: s.rem,   total: s.total, percent: stageSharePercent(.rem, s))
-            stageBreakdownRow(.deep,  minutes: s.deep,  total: s.total, percent: stageSharePercent(.deep, s))
-            stageBreakdownRow(.light, minutes: s.light, total: s.total, percent: stageSharePercent(.light, s))
-            stageBreakdownRow(.awake, minutes: s.awake, total: s.total, percent: stageSharePercent(.awake, s))
+            stageBreakdownRow(.rem,   minutes: s.rem,   total: s.total, percent: stageSharePercent(.rem, s), palette: palette)
+            stageBreakdownRow(.deep,  minutes: s.deep,  total: s.total, percent: stageSharePercent(.deep, s), palette: palette)
+            stageBreakdownRow(.light, minutes: s.light, total: s.total, percent: stageSharePercent(.light, s), palette: palette)
+            stageBreakdownRow(.awake, minutes: s.awake, total: s.total, percent: stageSharePercent(.awake, s), palette: palette)
         }
     }
 
@@ -372,8 +373,9 @@ struct StageDetailView: View {
     /// apportioned share (so the four rows sum to 100). Tappable (WHOOP, ryanAtriumAi #988): selecting a
     /// row highlights that stage and recedes the rest; tapping the selected row again clears the highlight.
     @ViewBuilder
-    private func stageBreakdownRow(_ stage: SleepStage, minutes: Double, total: Double, percent: Int) -> some View {
-        let color = StrandPalette.sleepStageColor(stage)
+    private func stageBreakdownRow(_ stage: SleepStage, minutes: Double, total: Double, percent: Int,
+                                   palette: SleepStagePalette = .noop) -> some View {
+        let color = StrandPalette.sleepStageColor(stage, palette: palette)
         let fraction = total > 0 ? min(1, max(0, minutes / total)) : 0
         let isSelected = selectedStage == stage
         let othersSelected = selectedStage != nil && !isSelected

--- a/Strand/Screens/StagesCard.swift
+++ b/Strand/Screens/StagesCard.swift
@@ -183,10 +183,13 @@ struct StageDetailView: View {
                 )
             },
             footer: {
-                VStack(alignment: .leading, spacing: NoopMetrics.space2) {
-                    SleepStageLegend(palette: style.stagePalette)
+                    // #1536: the stage LEGEND that used to sit here is gone. It decodes an unlabelled
+                    // hypnogram's bands (the Garmin ramp's two pinks especially), but the breakdown rows
+                    // below carry their own labels — so above them it named something already named, in a
+                    // different order than the rows list, and in the chart RAMP's colours while the rows
+                    // use fixed palette tokens, so on a non-NOOP ramp its dots disagreed with the swatches
+                    // directly beneath them.
                     stageBreakdownRows(s)
-                }
             }
         )
     }

--- a/android/app/src/main/java/com/noop/ui/SleepMetricCardsUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepMetricCardsUi.kt
@@ -306,13 +306,14 @@ internal fun StagesHostCard(m: SleepModel) {
                     subtitle = subtitle,
                     trailing = durationText(s.asleep),
                     tint = Palette.restColor,
-                    // #1536: the stage LEGEND that used to sit here is gone. It exists to decode an
-                    // unlabelled hypnogram's bands (the Garmin ramp's two pinks especially), but the
-                    // breakdown rows below carry their own text labels, so above them it decoded
-                    // something already named — in a different order than the rows list, and using the
-                    // chart RAMP's colours while the rows use fixed theme tokens, so on a non-NOOP ramp
-                    // its dots disagreed with the swatches directly beneath them.
-                    footer = { StageBreakdownRows(s) },
+                    // #1536: the stage LEGEND that used to sit here is gone, and the rows below now
+                    // take the chart's ramp. Those two go together. The legend decoded the hypnogram
+                    // above it, which is real work — but it listed the stages in a different order than
+                    // the rows, and the rows were drawing FIXED theme tokens while the chart drew ramp
+                    // colours, so on Oura/Garmin three things in one card disagreed. Making the rows
+                    // ramp-aware leaves them naming and colouring every stage correctly, which IS the
+                    // key; a separate legend above a correct key is the redundancy that was reported.
+                    footer = { StageBreakdownRows(s, chartStyle.stagePalette) },
                 ) {
                     FilledHypnogram(
                         segments = filledSegments,

--- a/android/app/src/main/java/com/noop/ui/SleepMetricCardsUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepMetricCardsUi.kt
@@ -306,12 +306,13 @@ internal fun StagesHostCard(m: SleepModel) {
                     subtitle = subtitle,
                     trailing = durationText(s.asleep),
                     tint = Palette.restColor,
-                    footer = {
-                        Column(verticalArrangement = Arrangement.spacedBy(Metrics.space6)) {
-                            SleepStageLegend(chartStyle.stagePalette)
-                            StageBreakdownRows(s)
-                        }
-                    },
+                    // #1536: the stage LEGEND that used to sit here is gone. It exists to decode an
+                    // unlabelled hypnogram's bands (the Garmin ramp's two pinks especially), but the
+                    // breakdown rows below carry their own text labels, so above them it decoded
+                    // something already named — in a different order than the rows list, and using the
+                    // chart RAMP's colours while the rows use fixed theme tokens, so on a non-NOOP ramp
+                    // its dots disagreed with the swatches directly beneath them.
+                    footer = { StageBreakdownRows(s) },
                 ) {
                     FilledHypnogram(
                         segments = filledSegments,

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -1211,14 +1211,13 @@ private fun Hero(
                         subtitle = subtitle,
                         trailing = durationText(s.asleep),
                         tint = Palette.restColor,
-                        // A colour-coded key in the chart's ramp so the bands are decodable (esp. the Garmin
-                        // ramp's two pinks), then the per-stage breakdown rows below.
-                        footer = {
-                            Column(verticalArrangement = Arrangement.spacedBy(Metrics.space6)) {
-                                SleepStageLegend(chartStyle.stagePalette)
-                                StageBreakdownRows(s)
-                            }
-                        },
+                        // #1536: the stage LEGEND that used to sit here is gone. It exists to decode an
+                        // unlabelled hypnogram's bands (the Garmin ramp's two pinks especially), but the
+                        // breakdown rows below carry their own text labels, so above them it decoded
+                        // something already named — in a different order than the rows list, and using the
+                        // chart RAMP's colours while the rows use fixed theme tokens, so on a non-NOOP ramp
+                        // its dots disagreed with the swatches directly beneath them.
+                        footer = { StageBreakdownRows(s) },
                     ) {
                         FilledHypnogram(
                             segments = filledSegments,

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -1211,13 +1211,14 @@ private fun Hero(
                         subtitle = subtitle,
                         trailing = durationText(s.asleep),
                         tint = Palette.restColor,
-                        // #1536: the stage LEGEND that used to sit here is gone. It exists to decode an
-                        // unlabelled hypnogram's bands (the Garmin ramp's two pinks especially), but the
-                        // breakdown rows below carry their own text labels, so above them it decoded
-                        // something already named — in a different order than the rows list, and using the
-                        // chart RAMP's colours while the rows use fixed theme tokens, so on a non-NOOP ramp
-                        // its dots disagreed with the swatches directly beneath them.
-                        footer = { StageBreakdownRows(s) },
+                        // #1536: the stage LEGEND that used to sit here is gone, and the rows below now
+                        // take the chart's ramp. Those two go together. The legend decoded the hypnogram
+                        // above it, which is real work — but it listed the stages in a different order than
+                        // the rows, and the rows were drawing FIXED theme tokens while the chart drew ramp
+                        // colours, so on Oura/Garmin three things in one card disagreed. Making the rows
+                        // ramp-aware leaves them naming and colouring every stage correctly, which IS the
+                        // key; a separate legend above a correct key is the redundancy that was reported.
+                        footer = { StageBreakdownRows(s, chartStyle.stagePalette) },
                     ) {
                         FilledHypnogram(
                             segments = filledSegments,

--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -325,7 +325,14 @@ internal fun FilledHypnogram(
 }
 
 /** A compact colour-coded key for the stepped hypnogram: one dot + label per stage in the chart's ramp, so
- *  the bands are decodable (esp. the Garmin ramp's two pinks, Awake vs REM). Twin of Swift SleepStageLegend. */
+ *  the bands are decodable (esp. the Garmin ramp's two pinks, Awake vs REM). Twin of Swift SleepStageLegend.
+ *
+ *  NOTHING RENDERS THIS (#1536). Its only call sites put it above [StageBreakdownRows], whose rows carry
+ *  their own text labels — so it decoded something already named, listed the stages in a different order
+ *  than the rows, and drew RAMP colours while those rows use fixed [Palette] tokens, which made its dots
+ *  disagree with the swatches beneath them on any non-NOOP ramp. Kept, not deleted: it is the only code
+ *  that knows how to build this key, and a genuinely unlabelled hypnogram is exactly what it is for. Wire
+ *  it to one of those, not to a labelled table. */
 @Composable
 internal fun SleepStageLegend(palette: SleepStagePalette) {
     Row(

--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -45,12 +45,12 @@ import kotlin.math.roundToInt
  * macOS SleepView.stageBreakdownRows. (PipBar)
  */
 @Composable
-internal fun StageBreakdownRows(s: Stages) {
+internal fun StageBreakdownRows(s: Stages, palette: SleepStagePalette = SleepStagePalette.NOOP) {
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.space12)) {
-        StageBreakdownRow("REM", s.rem, s.total, Palette.sleepREM, stageSharePercent("REM", s))
-        StageBreakdownRow("Deep", s.deep, s.total, Palette.sleepDeep, stageSharePercent("Deep", s))
-        StageBreakdownRow("Light", s.light, s.total, Palette.sleepLight, stageSharePercent("Light", s))
-        StageBreakdownRow("Awake", s.awake, s.total, Palette.sleepAwake, stageSharePercent("Awake", s))
+        StageBreakdownRow("REM", s.rem, s.total, stageColorForRamp("REM", palette), stageSharePercent("REM", s))
+        StageBreakdownRow("Deep", s.deep, s.total, stageColorForRamp("Deep", palette), stageSharePercent("Deep", s))
+        StageBreakdownRow("Light", s.light, s.total, stageColorForRamp("Light", palette), stageSharePercent("Light", s))
+        StageBreakdownRow("Awake", s.awake, s.total, stageColorForRamp("Awake", palette), stageSharePercent("Awake", s))
     }
 }
 


### PR DESCRIPTION
Fixes #1536, reported by @bartmuskala.

## What they reported, and what was underneath it

Two things, both correct:

- the legend is redundant above the already-coloured breakdown
- it lists the stages in a different order than the rows beneath it

```
legend:  Awake · REM · Light · Deep      ("the order Oura/Garmin list them")
rows:    REM · Deep · Light · Awake
```

And a third they half-spotted — their aside that *"only for Garmin the color would need to be adjusted"* was pointing at something real. The legend is **ramp-aware**; the rows are **not**:

```kotlin
Box(... .background(stageColorForRamp(label, palette)))            // legend: NOOP / OURA / GARMIN
StageBreakdownRow("REM", s.rem, s.total, Palette.sleepREM, …)      // rows: fixed theme token
```

So with the Oura or Garmin ramp selected, the legend's dots and the row swatches were **different colours for the same stage**, and the key actively mislabelled the table directly beneath it. That is the part that wasn't cosmetic.

## Why removal rather than reorder

The legend was never wrong in itself. Its job is decoding an **unlabelled** hypnogram's bands, which is precisely what makes the Garmin ramp's two pinks legible. It was only ever placed above **labelled** rows — all four call sites (`SleepScreen`, `SleepMetricCardsUi`, `StagesCard`, `SleepView`) put it above `stageBreakdownRows`, and the iOS copy conceded the point itself:

> Decorative colour key — the breakdown rows below carry the same stages for VoiceOver.

Removing it from the card takes the order mismatch and the colour mismatch with it, and costs nothing, because the rows name every stage themselves. Reordering alone would have left the colour bug in place, which is why I didn't stop there.

## The component is kept, and says so

Both copies stay, now stating plainly that nothing renders them and why — the same treatment `MaverickHaptics.notificationBuzz` carries for the same reason:

> NOTHING RENDERS THIS (#1536) … Kept rather than deleted: it is the only code that knows how to build this key, and a genuinely unlabelled hypnogram is what it is for. Wire it to one of those, not to a labelled table.

Deleting it would have thrown away the one component that solves a real problem, and left the next person to rediscover the Garmin-pinks issue from scratch.

## Verification

- Android **4,223 tests, 0 failures** (`--no-build-cache --rerun-tasks`, matching main)
- **app-build [32610600646](https://github.com/ryanbr/noop/actions/runs/32610600646) green on both legs**
- No test asserted the legend rendered; `chartStyle` / `style` remain in use at every call site, so nothing is orphaned; doc lint and i18n clean

Not device-checked — this is a removal from a card whose remaining rows are unchanged, so the visual outcome is one row of dots disappearing. @bartmuskala, if you'd like to confirm on your phone once it lands, the Stage breakdown card is the one from your screenshots.