### PR TITLE
Sleep: give Android's Classic view the night's heart-rate line

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import com.noop.data.HrBucket
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -621,9 +622,25 @@ fun SleepScreen(
                     SleepReorderableSection(k, sleepListState, sleepSectionDrag, persistSleepOrder) {
                     Column {
                     Spacer(Modifier.height(Metrics.selectorTopUp))
+                    // #1537: the night's heart rate for the Classic view's line chart. Loaded here
+                    // because Hero takes data rather than a repo, and keyed on the night so paging the
+                    // carousel refetches. 60-second buckets, matching the iOS Sleep tab's hrBuckets call.
+                    val hrFrom = night?.session?.effectiveStartTs
+                    val hrTo = night?.session?.endTs
+                    var nightHr by remember(hrFrom, hrTo) { mutableStateOf(emptyList<HrBucket>()) }
+                    LaunchedEffect(hrFrom, hrTo, vm.activeStrapId) {
+                        nightHr = if (hrFrom != null && hrTo != null && hrTo > hrFrom) {
+                            runCatching {
+                                vm.repo.hrBucketsUnion(vm.activeStrapId, hrFrom, hrTo, bucketSeconds = 60L)
+                            }.getOrDefault(emptyList())
+                        } else {
+                            emptyList()
+                        }
+                    }
                     Hero(
                 display = display,
                 activeIsOura = activeIsOura,
+                nightHr = nightHr,
                 clock = night?.clockLabel ?: model?.clockLabel,
                 nightOffset = nightOffset,
                 lastIndex = max(navDays.lastIndex, 0),
@@ -1126,6 +1143,9 @@ private fun Hero(
     nightLabel: String,
     onNavigate: (Int) -> Unit,
     session: SleepSession? = null,
+    // #1537: the night's HR buckets for the Classic view's heart-rate line, loaded by the caller (which
+    // holds the repo) and passed in like every other input here. Empty = nothing to draw.
+    nightHr: List<HrBucket> = emptyList(),
     // #1492: the bridged night's fragments, forwarded to the editor so it frames itself on the whole
     // night rather than on `session` (the winning fragment, which defines neither displayed bound).
     heroGroup: List<SleepSession> = emptyList(),
@@ -1259,6 +1279,25 @@ private fun Hero(
                     // Reconstructed architecture (light → deep → light → rem → light → awake) as the
                     // flat proportional strip. No MotionStrip and no fake steps here: invented
                     // architecture has no genuine timeline to anchor to (mirrors the iOS else-branch).
+                    // #1537: heart rate across the night, above the stage strip — the twin of the iOS
+                    // Classic view's `sleepHRChart`, which Android never had. Same window as the stage
+                    // strip below (the night's own onset..wake), and the same 60-second buckets iOS asks
+                    // for, so the two platforms plot the same shape from the same rows. Drawn only with
+                    // at least two buckets, matching iOS's `buckets.count >= 2`: one point is not a line,
+                    // and a night the strap never sampled should show nothing rather than a flat stub.
+                    if (nightHr.size >= 2) {
+                        LineChart(
+                            values = nightHr.map { it.avgBpm },
+                            modifier = Modifier.fillMaxWidth().height(Metrics.compactChartHeight)
+                                .semantics {
+                                    contentDescription = uiString(R.string.l10n_sleep_screen_sleep_heart_rate_chart_8ec47ae1)
+                                },
+                            color = Palette.metricRose,
+                            fill = false,
+                            timestamps = nightHr.map { it.bucket },
+                            formatValue = { "${Math.round(it)} bpm" },
+                        )
+                    }
                     val segments = stageSegments(s)
                     if (segments.isNotEmpty()) {
                         HypnogramWithAxis(

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -832,6 +832,7 @@
     <string name="l10n_sleep_screen_sleep_debt_ledger_8cc9a992">Schlafdefizit-Bilanz</string>
     <string name="l10n_sleep_screen_sleep_debt_trend_chart_9e178776">Schlaf Schulden Trend Chart</string>
     <string name="l10n_sleep_screen_sleep_hours_trend_chart_a6fbc46d">Sleep Stunden Trend Chart</string>
+    <string name="l10n_sleep_screen_sleep_heart_rate_chart_8ec47ae1">Schlaf-Herzfrequenz-Diagramm</string>
     <string name="l10n_sleep_screen_sleep_marks_8e9b86f0">Schlafmarken</string>
     <string name="l10n_sleep_screen_sleep_window_over_recent_nights_cc5fd9b8">Schlaffenster in den letzten Nächten</string>
     <string name="l10n_sleep_screen_spec_format_avgv_spec_unit_46bf7fdc">%1$s %2$s</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -629,6 +629,7 @@
     <string name="l10n_sleep_screen_sleep_debt_ledger_8cc9a992">Registro de deuda de sueño</string>
     <string name="l10n_sleep_screen_sleep_debt_trend_chart_9e178776">Gráfico de la tendencia al sueño</string>
     <string name="l10n_sleep_screen_sleep_hours_trend_chart_a6fbc46d">Gráfico de tendencia de horas de sueño</string>
+    <string name="l10n_sleep_screen_sleep_heart_rate_chart_8ec47ae1">Gráfico de frecuencia cardíaca del sueño</string>
     <string name="l10n_sleep_screen_sleep_marks_8e9b86f0">Marcas de sueño</string>
     <string name="l10n_sleep_screen_sleep_window_over_recent_nights_cc5fd9b8">Pareja de dormir por las noches recientes</string>
     <string name="l10n_sleep_screen_spec_format_avgv_spec_unit_46bf7fdc">%1$s %2$s</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -647,6 +647,7 @@
     <string name="l10n_sleep_screen_sleep_debt_ledger_8cc9a992">Registre de la dette de sommeil</string>
     <string name="l10n_sleep_screen_sleep_debt_trend_chart_9e178776">Graphique des tendances de la dette du sommeil</string>
     <string name="l10n_sleep_screen_sleep_hours_trend_chart_a6fbc46d">Tableau de tendance des heures de sommeil</string>
+    <string name="l10n_sleep_screen_sleep_heart_rate_chart_8ec47ae1">Graphique de fréquence cardiaque du sommeil</string>
     <string name="l10n_sleep_screen_sleep_marks_8e9b86f0">Repères de sommeil</string>
     <string name="l10n_sleep_screen_sleep_window_over_recent_nights_cc5fd9b8">Fenêtre de sommeil sur les dernières nuits</string>
     <string name="l10n_sleep_screen_spec_format_avgv_spec_unit_46bf7fdc">%1$s %2$s</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -785,6 +785,7 @@
     <string name="l10n_sleep_screen_sleep_debt_3aec7d9c">Dług snu</string>
     <string name="l10n_sleep_screen_sleep_debt_trend_chart_9e178776">Wykres trendu zadłużenia snu</string>
     <string name="l10n_sleep_screen_sleep_hours_trend_chart_a6fbc46d">Wykres trendu godzin snu</string>
+    <string name="l10n_sleep_screen_sleep_heart_rate_chart_8ec47ae1">Wykres tętna podczas snu</string>
     <string name="l10n_sleep_screen_sleep_marks_8e9b86f0">Znaki snu</string>
     <string name="l10n_sleep_screen_sleep_window_over_recent_nights_cc5fd9b8">Okno snu w ciągu ostatnich nocy</string>
     <string name="l10n_sleep_screen_spec_format_avgv_spec_unit_46bf7fdc">%1$s %2$s</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -797,6 +797,7 @@
     <string name="l10n_sleep_screen_sleep_debt_ledger_8cc9a992">Livro-razão da dívida do sono</string>
     <string name="l10n_sleep_screen_sleep_debt_trend_chart_9e178776">Gráfico de tendências da dívida do sono</string>
     <string name="l10n_sleep_screen_sleep_hours_trend_chart_a6fbc46d">Gráfico de tendências das horas de sono</string>
+    <string name="l10n_sleep_screen_sleep_heart_rate_chart_8ec47ae1">Gráfico da frequência cardíaca do sono</string>
     <string name="l10n_sleep_screen_sleep_marks_8e9b86f0">Marcas de sono</string>
     <string name="l10n_sleep_screen_sleep_window_over_recent_nights_cc5fd9b8">Janela de sono nas últimas noites</string>
     <string name="l10n_sleep_screen_spec_format_avgv_spec_unit_46bf7fdc">%1$s %2$s</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -779,6 +779,7 @@
     <string name="l10n_sleep_screen_sleep_debt_ledger_8cc9a992">睡眠负债账本</string>
     <string name="l10n_sleep_screen_sleep_debt_trend_chart_9e178776">睡眠负债趋势图</string>
     <string name="l10n_sleep_screen_sleep_hours_trend_chart_a6fbc46d">睡眠时长趋势图</string>
+    <string name="l10n_sleep_screen_sleep_heart_rate_chart_8ec47ae1">睡眠心率图表</string>
     <string name="l10n_sleep_screen_sleep_marks_8e9b86f0">睡眠标记打卡</string>
     <string name="l10n_sleep_screen_sleep_window_over_recent_nights_cc5fd9b8">近期睡眠时间窗口</string>
     <string name="l10n_sleep_screen_spec_format_avgv_spec_unit_46bf7fdc">%1$s %2$s</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -833,6 +833,7 @@
     <string name="l10n_sleep_screen_sleep_debt_ledger_8cc9a992">Sleep-debt ledger</string>
     <string name="l10n_sleep_screen_sleep_debt_trend_chart_9e178776">Sleep debt trend chart</string>
     <string name="l10n_sleep_screen_sleep_hours_trend_chart_a6fbc46d">Sleep hours trend chart</string>
+    <string name="l10n_sleep_screen_sleep_heart_rate_chart_8ec47ae1">Sleep heart rate chart</string>
     <string name="l10n_sleep_screen_sleep_marks_8e9b86f0">Sleep marks</string>
     <string name="l10n_sleep_screen_sleep_window_over_recent_nights_cc5fd9b8">Sleep window over recent nights</string>
     <string name="l10n_sleep_screen_spec_format_avgv_spec_unit_46bf7fdc">%1$s %2$s</string>


### PR DESCRIPTION
Fixes #1537, reported by @bartmuskala: with the Classic style selected, a card with a nightly line chart is missing on Android.

## Why it was missing

It was never there. iOS's Classic view renders `sleepHRChart(intervals:)` above the stage tracks — heart rate plotted across the night — and `sleepHRChart` / `SleepHrChart` return nothing anywhere in the Kotlin tree.

## What this needed

Less than expected. Both halves already existed:

```kotlin
WhoopRepository.hrBucketsUnion(deviceId, from, to, bucketSeconds)   // data
LineChart(values, timestamps, …)  // Charts.kt:208, already used by AppleHealthScreen
```

So this wires them together over the night's own `onset..wake` window, at the **same 60-second buckets** the iOS Sleep tab asks for, so the two platforms plot the same shape from the same rows. Drawn only with at least two buckets, matching iOS's `buckets.count >= 2` — one point is not a line, and a night the strap never sampled should show nothing rather than a flat stub.

Loaded by the caller rather than inside `Hero`, because `Hero` takes data and not a repo: every other input it has arrives the same way. Keyed on the night so paging the carousel refetches, and wrapped in `runCatching` so a read failure leaves the chart absent instead of taking the screen down.

## Deliberately not included

The other half of the same divergence. Android's Classic draws **one reconstructed proportional strip** (`HypnogramWithAxis(stages: List<Pair<String, Float>>)`) where iOS draws **four per-stage tracks from real intervals** — and `Units.kt:117` describes Classic as *"the long-standing per-stage-rows timeline (Awake/Light/Deep/REM each on their own track)"*.

So the documentation and the code disagree about what Classic is, and one of them needs correcting. That is a decision about the style's definition rather than a missing chart, and I'd rather it be made deliberately than folded in here. I withdrew an earlier attempt at exactly that after finding it matched neither platform.

## Verification

- Android **4,223 tests, 0 failures** (`--no-build-cache --rerun-tasks`, matching main)
- `lintVitalFullRelease -PstagingRelease` clean with the new accessibility string in **all seven locales**
- i18n audit and doc lint clean
- Android-only diff, so `app-build` does not apply — no app-target Swift is touched

**Not device-checked.** @bartmuskala — this is the card I believe you're missing; if what disappeared showed something other than heart rate over the night, say so on the issue and I'll look again rather than leave this as the answer.