### PR TITLE
Health Connect: export VO₂ max, which NOOP already computes

### DIFF
--- a/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
@@ -13,6 +13,7 @@ import androidx.health.connect.client.records.RespiratoryRateRecord
 import androidx.health.connect.client.records.RestingHeartRateRecord
 import androidx.health.connect.client.records.SleepSessionRecord
 import androidx.health.connect.client.records.Vo2MaxRecord
+import com.noop.data.MetricSeriesRow
 import androidx.health.connect.client.records.metadata.Metadata
 import androidx.health.connect.client.units.Length
 import androidx.health.connect.client.units.Percentage
@@ -329,20 +330,35 @@ object HealthConnectWriter {
         val cutoff = LocalDate.now().minusDays(WINDOW_DAYS).toString()
         val today = LocalDate.now().toString()
         val rows = repo.metricSeriesComputedUnion(deviceId, "vo2max_est", cutoff, today)
-        val records = rows.mapNotNull { row ->
-            val date = runCatching { LocalDate.parse(row.day) }.getOrNull() ?: return@mapNotNull null
-            if (row.value <= 0.0) return@mapNotNull null   // never export a zero as a fitness reading
-            val time = date.atTime(LocalTime.NOON).atZone(zone)
-            Vo2MaxRecord(
-                time = time.toInstant(),
-                zoneOffset = time.offset,
-                vo2MillilitersPerMinuteKilogram = row.value,
-                measurementMethod = Vo2MaxRecord.MEASUREMENT_METHOD_OTHER,
-                metadata = meta("vo2max", row.day, version),
-            )
-        }
+        val records = buildVo2MaxRecords(rows, version, zone)
         if (records.isEmpty()) return 0
         return insertChunked(client, records)
+    }
+
+    /**
+     * Pure: map `vo2max_est` series rows to records, testable without a client — the same split
+     * [buildExerciseRecords] uses below.
+     *
+     * Skips a day whose key will not parse, and any value at or below zero: a stored 0 means the estimator
+     * declined that week, and exporting it would publish "VO2 max: 0" as a fitness reading rather than
+     * saying nothing. Timestamped at local noon on the series' own day, matching the daily records, and
+     * keyed by day in the clientRecordId so a re-export upserts instead of duplicating.
+     */
+    internal fun buildVo2MaxRecords(
+        rows: List<MetricSeriesRow>,
+        version: Long,
+        zone: ZoneId,
+    ): List<Record> = rows.mapNotNull { row ->
+        val date = runCatching { LocalDate.parse(row.day) }.getOrNull() ?: return@mapNotNull null
+        if (row.value <= 0.0) return@mapNotNull null
+        val time = date.atTime(LocalTime.NOON).atZone(zone)
+        Vo2MaxRecord(
+            time = time.toInstant(),
+            zoneOffset = time.offset,
+            vo2MillilitersPerMinuteKilogram = row.value,
+            measurementMethod = Vo2MaxRecord.MEASUREMENT_METHOD_OTHER,
+            metadata = meta("vo2max", row.day, version),
+        )
     }
 
     // --- Workout (ExerciseSession) writeback (GPS workouts, v1.71) ---

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
@@ -12,6 +12,7 @@ import androidx.health.connect.client.records.Record
 import androidx.health.connect.client.records.RespiratoryRateRecord
 import androidx.health.connect.client.records.RestingHeartRateRecord
 import androidx.health.connect.client.records.SleepSessionRecord
+import androidx.health.connect.client.records.Vo2MaxRecord
 import androidx.health.connect.client.records.metadata.Metadata
 import androidx.health.connect.client.units.Length
 import androidx.health.connect.client.units.Percentage
@@ -172,6 +173,11 @@ object HealthConnectWriter {
             .fold({ total += it }, { failures += it.writebackCategory() })
         runCatching { writeSleep(client, repo, deviceId) }
             .fold({ total += it }, { failures += it.writebackCategory() })
+        // #1525: separate attempt on purpose. The daily records above go in ONE insertRecords call, so a
+        // missing permission there loses resting HR, HRV, SpO2 and respiratory rate together. On its own,
+        // an ungranted VO2 max permission costs only VO2 max and is categorized like any other failure.
+        runCatching { writeVo2Max(client, repo, deviceId, version) }
+            .fold({ total += it }, { failures += it.writebackCategory() })
         val result = WritebackResult(total, failures.distinct())
         recordStatus(context, result)
         return result
@@ -297,7 +303,57 @@ object HealthConnectWriter {
         return insertChunked(client, records)
     }
 
+    /**
+     * VO2 max writeback (#1525). NOOP computes this weekly and persists it as the `vo2max_est` metric
+     * series, keyed to the week's Saturday — nothing exported it before, so a value the app already had
+     * never reached Health Connect.
+     *
+     * Read through [WhoopRepository.metricSeriesComputedUnion], which is what that series' own doc says
+     * the weekly computed scores MUST use: it merges the active strap's computed sibling with the
+     * canonical "my-whoop-noop", so a re-added strap does not silently export half its history.
+     *
+     * Declared as MEASUREMENT_METHOD_OTHER rather than HEART_RATE_RATIO. The stored value is whichever
+     * estimator ran — the Nes multivariable regression when a waist is set, the Uth HR-ratio formula
+     * otherwise (#1493) — and the row does not record which. HEART_RATE_RATIO would be true of only one
+     * of them, so the honest label is the general one.
+     *
+     * Timestamped at local noon on the series' day, matching the daily records above.
+     */
+    private suspend fun writeVo2Max(
+        client: HealthConnectClient,
+        repo: WhoopRepository,
+        deviceId: String,
+        version: Long,
+    ): Int {
+        val zone = ZoneId.systemDefault()
+        val cutoff = LocalDate.now().minusDays(WINDOW_DAYS).toString()
+        val today = LocalDate.now().toString()
+        val rows = repo.metricSeriesComputedUnion(deviceId, "vo2max_est", cutoff, today)
+        val records = rows.mapNotNull { row ->
+            val date = runCatching { LocalDate.parse(row.day) }.getOrNull() ?: return@mapNotNull null
+            if (row.value <= 0.0) return@mapNotNull null   // never export a zero as a fitness reading
+            val time = date.atTime(LocalTime.NOON).atZone(zone)
+            Vo2MaxRecord(
+                time = time.toInstant(),
+                zoneOffset = time.offset,
+                vo2MillilitersPerMinuteKilogram = row.value,
+                measurementMethod = Vo2MaxRecord.MEASUREMENT_METHOD_OTHER,
+                metadata = meta("vo2max", row.day, version),
+            )
+        }
+        if (records.isEmpty()) return 0
+        return insertChunked(client, records)
+    }
+
     // --- Workout (ExerciseSession) writeback (GPS workouts, v1.71) ---
+
+    /**
+     * Write permission for VO2 max (#1525). Deliberately NOT in [WRITE_RECORDS]: that set feeds both the
+     * daily batch and the UI's `containsAll` gate, so adding it there would re-prompt every existing user
+     * and block ALL writeback until they re-granted. Requested alongside the others, but its records are
+     * written in their own attempt, so a decline costs only VO2 max.
+     */
+    val VO2MAX_PERMISSIONS: Set<String> = setOf(HealthPermission.getWritePermission(Vo2MaxRecord::class))
 
     /** Write-permission strings for exercise sessions + distance; union into the writeback request. */
     val EXERCISE_PERMISSIONS: Set<String> = setOf(

--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -342,13 +342,20 @@ fun DataSourcesScreen(vm: AppViewModel) {
             // Gate on vitals AND exercise perms so a user who enabled writeback before exercise
             // writeback shipped (vitals-only grant) still gets re-prompted for WRITE_EXERCISE/
             // WRITE_DISTANCE — otherwise their workouts silently never reach Health Connect (#412).
+            // #1525: VO2 max is ASKED FOR below but deliberately absent from this gate. Adding it here
+            // would mean every existing user, who granted the older set, fails `containsAll` and gets
+            // re-prompted — and blocks their whole writeback until they accept. Out of the gate, a decline
+            // costs only VO2 max, whose records are written in their own attempt.
             if (granted.containsAll(HealthConnectWriter.PERMISSIONS + HealthConnectWriter.EXERCISE_PERMISSIONS)) {
                 vm.writebackHealthConnectNow()
             } else {
                 // Request vitals + exercise-session write perms together so GPS workouts can write
                 // back too (the launcher-result handler stays keyed on the vital PERMISSIONS, so
                 // exercise writeback is opt-in + non-fatal if the user declines it). v1.71 / #412.
-                hcWritePermissionLauncher.launch(HealthConnectWriter.PERMISSIONS + HealthConnectWriter.EXERCISE_PERMISSIONS)
+                hcWritePermissionLauncher.launch(
+                    HealthConnectWriter.PERMISSIONS + HealthConnectWriter.EXERCISE_PERMISSIONS +
+                        HealthConnectWriter.VO2MAX_PERMISSIONS,
+                )
             }
         }
     }

--- a/android/app/src/test/java/com/noop/ingest/HealthConnectVo2MaxExportTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/HealthConnectVo2MaxExportTest.kt
@@ -1,0 +1,82 @@
+package com.noop.ingest
+
+import androidx.health.connect.client.records.Vo2MaxRecord
+import com.noop.data.MetricSeriesRow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+
+/**
+ * #1525: NOOP computes VO2 max weekly and persists it as the `vo2max_est` series, but nothing exported it
+ * to Health Connect. Pins the mapping from those rows to records — the part that decides what a downstream
+ * app like Google Health actually sees.
+ */
+class HealthConnectVo2MaxExportTest {
+
+    private val zone: ZoneId = ZoneId.of("UTC")
+    private val version = 1_700_000_000L
+
+    private fun row(day: String, value: Double) =
+        MetricSeriesRow(deviceId = "my-whoop-noop", day = day, key = "vo2max_est", value = value)
+
+    private fun build(vararg rows: MetricSeriesRow) =
+        HealthConnectWriter.buildVo2MaxRecords(rows.toList(), version, zone)
+
+    /** The value reaches the wire unrounded, in the units the record names. */
+    @Test
+    fun carriesTheStoredValueInMlPerMinPerKg() {
+        val r = build(row("2026-08-22", 47.3)).single() as Vo2MaxRecord
+        assertEquals(47.3, r.vo2MillilitersPerMinuteKilogram, 1e-9)
+    }
+
+    /**
+     * A stored 0 means the estimator declined that week. Exporting it would publish "VO2 max: 0" as a
+     * fitness reading, which is worse than exporting nothing — the same honesty rule that keeps raw
+     * red/IR counts from being written as SpO2.
+     */
+    @Test
+    fun refusesZeroAndNegativeRatherThanPublishingThemAsAReading() {
+        assertTrue(build(row("2026-08-22", 0.0)).isEmpty())
+        assertTrue(build(row("2026-08-22", -1.0)).isEmpty())
+    }
+
+    /** An unparseable day is skipped without taking the rest of the batch with it. */
+    @Test
+    fun oneBadDayDoesNotDropTheGoodOnes() {
+        val out = build(row("not-a-date", 44.0), row("2026-08-22", 44.0))
+        assertEquals(1, out.size)
+    }
+
+    /**
+     * Local noon on the series' own day, matching the daily records. The series is keyed to the week's
+     * Saturday, so this is what pins a weekly value to a real instant rather than to "now".
+     */
+    @Test
+    fun stampsLocalNoonOnTheSeriesDay() {
+        val r = build(row("2026-08-22", 44.0)).single() as Vo2MaxRecord
+        val expected = LocalDate.parse("2026-08-22").atTime(LocalTime.NOON).atZone(zone).toInstant()
+        assertEquals(expected, r.time)
+    }
+
+    /**
+     * OTHER, not HEART_RATE_RATIO: the stored value is whichever estimator ran — Nes when a waist is set,
+     * the Uth HR-ratio formula otherwise — and the row does not record which, so the narrower label would
+     * be true of only one of them.
+     */
+    @Test
+    fun declaresTheGeneralMeasurementMethod() {
+        val r = build(row("2026-08-22", 44.0)).single() as Vo2MaxRecord
+        assertEquals(Vo2MaxRecord.MEASUREMENT_METHOD_OTHER, r.measurementMethod)
+    }
+
+    /** Keyed by day, so a re-export upserts the same week rather than duplicating it. */
+    @Test
+    fun keysTheRecordByDaySoReExportsUpsert() {
+        val r = build(row("2026-08-22", 44.0)).single()
+        assertEquals("noop-vo2max-2026-08-22", r.metadata.clientRecordId)
+        assertEquals(version, r.metadata.clientRecordVersion)
+    }
+}


### PR DESCRIPTION
Part of #1525 (@FlixiDoe), which compared a NOOP backup against the Health Connect export and found metrics the app holds locally that never reach HC.

VO₂ max is one of them: the engine computes it weekly and persists it as the `vo2max_est` metric series, keyed to the week's Saturday (`IntelligenceEngine.kt:2187`). Nothing exported it.

**No dependency change** — `Vo2MaxRecord` is already in the pinned `connect-client:1.1.0-alpha07`. Worth stating the contrast: `SkinTemperatureRecord`, which I had wrongly called the easy win on the issue, is **not** in that version. I unpacked the AAR — it ships 42 record types and none is skin temperature — so that one needs a library bump and belongs in its own change.

## Three decisions worth reviewing

**Read via `metricSeriesComputedUnion`, not `metricSeries`.** That series' own documentation says the weekly computed scores *must* use the union: it merges the active strap's computed sibling with the canonical `my-whoop-noop`, so a re-added strap doesn't silently export half its history.

**Written in its own attempt.** The daily records go out in a single `insertRecords(records)` call, so an ungranted permission there would take resting HR, HRV, SpO₂ and respiratory rate down with it. On its own, a declined VO₂ max permission costs only VO₂ max and is categorized like any other failure — the same shape `writeHeartRate` and `writeSleep` already use.

**Requested but deliberately outside the UI's `containsAll` gate.** This asymmetry is intentional and commented at both ends. In the gate, every existing user who granted the older permission set would fail it, get re-prompted, and have their *entire* writeback blocked until they accepted. Outside it, the prompt still appears and a decline costs one metric.

## Smaller calls

- `MEASUREMENT_METHOD_OTHER`, not `HEART_RATE_RATIO`. The stored value is whichever estimator ran — Nes when a waist is set, the Uth HR-ratio formula otherwise (#1493) — and the row doesn't record which. `HEART_RATE_RATIO` would be true of only one of them.
- Zero or negative values are skipped rather than exported as a fitness reading.
- `clientRecordId` keys on the day, so a re-export upserts instead of duplicating.

## Verification

- Android **4,223 tests, 0 failures** (`--no-build-cache --rerun-tasks`, matching main)
- doc lint and i18n clean; Android-only diff, so `app-build` does not apply

**Not device-checked** — there's no Health Connect on this machine, so I have not watched the records land. @FlixiDoe, you have the setup that produced the original comparison: if you run this, the check is whether `Vo2MaxRecord` entries appear with `noop-vo2max-<date>` client ids.

This does not close #1525 — HR density, respiratory-rate cadence and skin temperature are all still open there, and my note on the issue explains why the HR one may be a frontier-ordering bug rather than an interval to lower.