### PR TITLE
Health Connect: ask existing installs for the VO₂ max permission, once

### DIFF
--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -325,6 +325,9 @@ fun DataSourcesScreen(vm: AppViewModel) {
     val hcWritePermissionLauncher = rememberLauncherForActivityResult(
         PermissionController.createRequestPermissionResultContract(),
     ) { granted ->
+        // #1525: this prompt already included VO2 max, so whatever the answer was, do not ask again
+        // through the targeted one-shot below.
+        NoopPrefs.setHcVo2MaxAsked(context, true)
         if (granted.containsAll(HealthConnectWriter.PERMISSIONS)) {
             vm.writebackHealthConnectNow()
         } else {
@@ -334,6 +337,20 @@ fun DataSourcesScreen(vm: AppViewModel) {
     }
 
     // Write immediately if the write permissions are already granted, otherwise request them first.
+    /**
+     * #1525: the one-shot ask for the VO2 max write permission, for installs that were set up before it
+     * existed. The outcome is deliberately ignored — VO2 max records are written in their own attempt, so
+     * a decline costs that metric and nothing else, and blocking the writeback on it would be the very
+     * regression keeping VO2 max out of the gate avoids. Either way we mark it asked, so a "no" is
+     * respected instead of re-prompted on every sync.
+     */
+    val hcVo2MaxPermissionLauncher = rememberLauncherForActivityResult(
+        PermissionController.createRequestPermissionResultContract(),
+    ) { _ ->
+        NoopPrefs.setHcVo2MaxAsked(context, true)
+        vm.writebackHealthConnectNow()
+    }
+
     fun startWriteback() {
         scope.launch {
             val granted = runCatching {
@@ -347,7 +364,16 @@ fun DataSourcesScreen(vm: AppViewModel) {
             // re-prompted — and blocks their whole writeback until they accept. Out of the gate, a decline
             // costs only VO2 max, whose records are written in their own attempt.
             if (granted.containsAll(HealthConnectWriter.PERMISSIONS + HealthConnectWriter.EXERCISE_PERMISSIONS)) {
-                vm.writebackHealthConnectNow()
+                // #1525: this branch is where an existing install lands — it granted everything that
+                // existed at the time, so it never reaches the launcher below and would never be offered
+                // VO2 max. Ask exactly once, then write regardless of the answer.
+                if (!granted.containsAll(HealthConnectWriter.VO2MAX_PERMISSIONS) &&
+                    !NoopPrefs.hcVo2MaxAsked(context)
+                ) {
+                    hcVo2MaxPermissionLauncher.launch(HealthConnectWriter.VO2MAX_PERMISSIONS)
+                } else {
+                    vm.writebackHealthConnectNow()
+                }
             } else {
                 // Request vitals + exercise-session write perms together so GPS workouts can write
                 // back too (the launcher-result handler stays keyed on the vital PERMISSIONS, so

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -607,6 +607,19 @@ object NoopPrefs {
 
     /** Health Connect writeback (NOOP's computed metrics → HC, for other apps). Default OFF. */
     const val KEY_HC_WRITEBACK = "noop.hcWriteback"
+    const val KEY_HC_VO2MAX_ASKED = "noop.hcVo2MaxAsked"
+
+    /**
+     * #1525: have we already asked this install for the VO2 max write permission? Health Connect grants
+     * are per-permission, so a user who set NOOP up before VO2 max existed passes the writeback's own
+     * gate and is never prompted for it. We ask ONCE on the next writeback and remember that we did --
+     * a decline must not turn every subsequent sync into another dialog.
+     */
+    fun hcVo2MaxAsked(context: Context): Boolean = of(context).getBoolean(KEY_HC_VO2MAX_ASKED, false)
+
+    fun setHcVo2MaxAsked(context: Context, asked: Boolean) {
+        of(context).edit().putBoolean(KEY_HC_VO2MAX_ASKED, asked).apply()
+    }
 
     fun hcWriteback(context: Context): Boolean =
         of(context).getBoolean(KEY_HC_WRITEBACK, false)


### PR DESCRIPTION
Closes the known hole I flagged on #1553 and in its merge commit.

## The hole

An install that granted NOOP's Health Connect permissions **before VO₂ max existed** passes the writeback's own gate:

```kotlin
if (granted.containsAll(PERMISSIONS + EXERCISE_PERMISSIONS)) {
    vm.writebackHealthConnectNow()      // ← existing users land here
} else {
    hcWritePermissionLauncher.launch(… + VO2MAX_PERMISSIONS)   // ← never reached
}
```

so they are never offered the new permission, and would have got the feature only by revoking and re-granting in Health Connect manually.

## Why not the two obvious fixes

- **Add VO₂ max to the gate** — re-prompts every existing user *and* blocks their entire writeback until they accept. That is precisely the regression that keeping it out of the gate was designed to avoid.
- **Leave it** — the export reaches new grants only, which makes the feature close to invisible.

## What this does

When everything else is already granted and VO₂ max is not, ask for **just that permission**, then run the writeback **regardless of the answer**. A decline costs only VO₂ max, because its records are written in their own `runCatching` — nothing else is gated on it.

**Asked at most once per install**, remembered in `NoopPrefs.hcVo2MaxAsked`. This path runs on every writeback and Health Connect grants are per-permission, so without the flag a "no" would become a dialog on every single sync.

The bundled prompt sets the same flag, so a user who declines VO₂ max *there* isn't then asked a second time by the targeted one — a double-ask I only noticed reading my own change back.

## Verification

- Android **4,229 tests, 0 failures** (`--no-build-cache --rerun-tasks`, matching main)
- doc lint and i18n clean; Android-only, so `app-build` does not apply

## Correction to my own description, from re-reading this

I first wrote that the dialog appears "on the next writeback". That is wrong, and the distinction matters.

`startWriteback()` has exactly two callers, both **user-initiated**: toggling the Health Connect switch on (`:573`), and tapping the "permission was denied" hint (`:598`). The automatic writeback after a backfill (`WhoopBleClient.kt:2535`) has no activity or launcher in scope and cannot prompt at all.

So this reaches an existing user when they next **touch that screen** — toggle the switch, or tap the hint. Someone who leaves the toggle on and never revisits Data Sources is still not prompted. That is a real improvement on "revoke and re-grant in Health Connect by hand", but it is not universal, and I would rather say so than have it read as more than it is.

The remaining gap has an obvious shape if you want it closed: an inline hint on that screen when VO₂ max is missing, mirroring the existing denied-permission hint at `:598`. It needs a new string in seven locales, so I have not folded it in here.

**Not device-checked** — there is no Health Connect on this machine, so I have not watched the prompt appear. Observable behaviour: one permission dialog the next time an existing install toggles the switch on or taps the hint, never again whichever button is pressed, and VO₂ max records appearing afterwards if accepted.
