### PR TITLE
CI: prune branches that no longer have a reason to exist

### DIFF
--- a/.github/workflows/prune-stale-branches.yml
+++ b/.github/workflows/prune-stale-branches.yml
@@ -1,0 +1,101 @@
+# Deletes branches that no longer have a reason to exist.
+#
+# The repository already sets `deleteBranchOnMerge`, and that setting is working — it just does far
+# less than its name suggests. It fires on MERGE only. A PR closed WITHOUT merging keeps its branch
+# forever, and a branch that never had a PR was never in scope to begin with. Both pile up invisibly,
+# because spotting them means cross-referencing every branch against every PR.
+#
+# An August 2026 sweep found the scale of that: 80 branches, 75 of them dead — 3 from closed-unmerged
+# PRs and 72 working branches from a three-week stretch in June/July that had never been opened as a
+# PR at all. Doing it by hand took an afternoon and a 164 MB recovery bundle. This runs it weekly.
+#
+# The scheduled run deliberately handles ONLY the safe categories: merged PRs whose branch survived,
+# and PRs closed unmerged a fortnight ago. It does NOT prune branches that never had a PR — that
+# category cannot be distinguished from someone's long-running private branch, so it stays a manual
+# decision behind the `prune_orphans` dispatch input. Manual runs default to a dry run.
+#
+# Pure Python + the REST API: no checkout of the work tree is needed beyond Tools/, and it runs in
+# seconds on ubuntu-latest, independent of the disabled-by-default compile workflows.
+name: Prune stale branches
+
+on:
+  schedule:
+    # Mondays, 04:17 UTC. Off the hour because everything else on GitHub runs on the hour and
+    # scheduled jobs are queued, not guaranteed, when the minute is busy.
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List what would be deleted without deleting it'
+        type: boolean
+        default: true
+      prune_orphans:
+        description: 'Also delete branches that never had a PR (uses the orphan_days floor)'
+        type: boolean
+        default: false
+      orphan_days:
+        description: 'Age floor in days for branches that never had a PR'
+        type: string
+        default: '90'
+
+# contents: write is what permits ref deletion. Nothing here reads or writes any other scope.
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: prune-stale-branches
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: Tools
+          sparse-checkout-cone-mode: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Verify the refusal rules still hold
+        # The value of this tool is entirely in what it declines to delete, so the keep-rules are
+        # pinned by a test that runs immediately before the tool does. If the rules regress, the
+        # deletion step never executes.
+        run: python3 -m unittest test_prune_stale_branches -v
+        working-directory: Tools
+
+      - name: Prune
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A scheduled run always executes; a manual one honours the dry_run checkbox.
+          EXECUTE: ${{ (github.event_name == 'schedule' || inputs.dry_run == false) && '--execute' || '' }}
+          ORPHANS: ${{ (github.event_name == 'workflow_dispatch' && inputs.prune_orphans) && '--prune-orphans' || '' }}
+          ORPHAN_DAYS: ${{ inputs.orphan_days || '90' }}
+        run: |
+          python3 Tools/prune-stale-branches.py \
+            --repo "${{ github.repository }}" \
+            --manifest deleted-branches.txt \
+            --orphan-days "$ORPHAN_DAYS" \
+            $ORPHANS $EXECUTE | tee summary.txt
+          {
+            echo '### Prune stale branches'
+            echo '```'
+            cat summary.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the recovery manifest
+        # The only record of what was deleted. GitHub keeps unreachable objects for a limited window,
+        # so a SHA from this file can still be fetched for a while after its ref is gone — which
+        # makes the artifact the difference between "recoverable" and "gone".
+        if: always() && hashFiles('deleted-branches.txt') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: deleted-branches-${{ github.run_number }}
+          path: deleted-branches.txt
+          retention-days: 90

--- a/Tools/prune-stale-branches.py
+++ b/Tools/prune-stale-branches.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Delete branches that no longer have a reason to exist — and refuse to touch anything else.
+
+GitHub's `deleteBranchOnMerge` setting only fires on MERGE. It does nothing for a PR that was
+closed without merging, and nothing at all for a branch that never had a PR. Both categories
+accumulate silently: an August 2026 sweep of this repository found 80 branches, of which 75 were
+dead — three from closed-unmerged PRs and seventy-two working branches from a three-week stretch in
+June/July that had never been opened as a PR. None of them were discoverable as garbage without
+cross-referencing every branch against every PR by hand.
+
+Nothing here is clever. The value is entirely in the refusals: a branch-deleting robot that gets one
+case wrong destroys work, so the keep-rules are checked first, are individually logged, and treat
+anything they cannot classify as a keep. Deletion is opt-in per category and every category has an
+age floor, because "no open PR" is a statement about the present and a branch pushed an hour ago has
+not yet had time to acquire one.
+
+Recovery: every deleted branch is recorded as `<sha> <branch> <reason>` in the manifest written to
+--manifest, which the workflow uploads as an artifact. GitHub keeps unreachable objects for a while
+after the ref goes, so `git fetch origin <sha>` can still retrieve one from the manifest for a
+limited window — do not treat the manifest as a backup. It is a lead, not an archive.
+
+Usage:
+    GH_TOKEN=... Tools/prune-stale-branches.py --repo owner/name            # dry run, prints only
+    GH_TOKEN=... Tools/prune-stale-branches.py --repo owner/name --execute  # actually deletes
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+API = "https://api.github.com"
+
+# Branches that are never candidates, whatever the PR data says. Release and long-lived integration
+# branches do not need a PR to justify themselves, and a glob is easier to audit than a code change.
+DEFAULT_KEEP_GLOBS = ("main", "master", "release/*", "gh-pages")
+
+
+def _request(method: str, path: str, token: str) -> tuple[object, dict[str, str]]:
+    req = urllib.request.Request(
+        path if path.startswith("http") else f"{API}{path}",
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "noop-prune-stale-branches",
+        },
+    )
+    with urllib.request.urlopen(req) as resp:
+        body = resp.read()
+        return (json.loads(body) if body else None), dict(resp.headers)
+
+
+def _paginate(path: str, token: str) -> list[dict]:
+    """Follow Link rel=next rather than counting pages — a repo can gain a branch mid-walk."""
+    out: list[dict] = []
+    url = f"{API}{path}"
+    while url:
+        page, headers = _request("GET", url, token)
+        out.extend(page or [])
+        url = ""
+        for part in headers.get("Link", "").split(","):
+            if 'rel="next"' in part:
+                url = part.split(";")[0].strip().strip("<>")
+    return out
+
+
+def _age_days(stamp: str | None, now: datetime) -> float | None:
+    if not stamp:
+        return None
+    return (now - datetime.fromisoformat(stamp.replace("Z", "+00:00"))).total_seconds() / 86400
+
+
+def classify(branches, pulls, default_branch, keep_globs, now, args, commit_date):
+    """Decide each branch's fate. Returns (deletions, keeps) as lists of (branch, sha, reason).
+
+    Written as a pure function over already-fetched data so the rules can be exercised in a test
+    without a network or a repository — the whole point of this file is its refusals, and refusals
+    that are only observable by deleting something are not testable.
+    """
+    # A branch protecting an OPEN pull request is untouchable whether it is the head (deleting it
+    # closes the PR and loses the review thread's diff) or the BASE (deleting it retargets or breaks
+    # every stacked PR built on top of it). The base case is the one that is easy to forget.
+    open_heads = {p["head"]["ref"] for p in pulls if p["state"] == "open"}
+    open_bases = {p["base"]["ref"] for p in pulls if p["state"] == "open"}
+
+    by_head: dict[str, list[dict]] = {}
+    for p in pulls:
+        by_head.setdefault(p["head"]["ref"], []).append(p)
+
+    deletions, keeps = [], []
+    for br in branches:
+        name, sha = br["name"], br["commit"]["sha"]
+
+        def keep(why):
+            keeps.append((name, sha, why))
+
+        if name == default_branch:
+            keep("default branch")
+            continue
+        if br.get("protected"):
+            keep("branch protection")
+            continue
+        if any(fnmatch.fnmatch(name, g) for g in keep_globs):
+            keep("matches a keep glob")
+            continue
+        if name in open_heads:
+            keep("head of an open PR")
+            continue
+        if name in open_bases:
+            keep("base of an open PR — stacked work depends on it")
+            continue
+
+        prs = by_head.get(name, [])
+        if not prs:
+            # Never had a PR. This is the largest and least certain category: it catches abandoned
+            # working branches, but it would also catch a long-running private branch, so it gets
+            # much the longest age floor and its own opt-in flag.
+            if not args.prune_orphans:
+                keep("no PR ever (orphan pruning disabled)")
+                continue
+            age = _age_days(commit_date(sha), now)
+            if age is None:
+                keep("no PR ever, and its commit date could not be read")
+            elif age < args.orphan_days:
+                keep(f"no PR ever, but last commit {age:.0f}d < {args.orphan_days}d")
+            else:
+                deletions.append((name, sha, f"no PR ever, last commit {age:.0f}d ago"))
+            continue
+
+        newest = max(prs, key=lambda p: p["number"])
+        if newest.get("merged_at"):
+            age = _age_days(newest["merged_at"], now)
+            if age is not None and age >= args.merged_days:
+                deletions.append((name, sha, f"PR #{newest['number']} merged {age:.0f}d ago"))
+            else:
+                keep(f"PR #{newest['number']} merged only {age:.0f}d ago")
+        elif newest["state"] == "closed":
+            age = _age_days(newest["closed_at"], now)
+            if age is not None and age >= args.closed_days:
+                deletions.append((name, sha, f"PR #{newest['number']} closed unmerged {age:.0f}d ago"))
+            else:
+                keep(f"PR #{newest['number']} closed only {age:.0f}d ago")
+        else:
+            # An open PR should have been caught by open_heads above; if the two disagree, the
+            # disagreement itself is the reason to do nothing.
+            keep(f"PR #{newest['number']} is {newest['state']} — unexpected, refusing")
+
+    return deletions, keeps
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--repo", required=True, help="owner/name")
+    ap.add_argument("--execute", action="store_true", help="actually delete (default is a dry run)")
+    ap.add_argument("--closed-days", type=int, default=14, help="age floor for closed-unmerged PRs")
+    ap.add_argument("--merged-days", type=int, default=7, help="age floor for merged PRs")
+    ap.add_argument("--orphan-days", type=int, default=90, help="age floor for branches with no PR")
+    ap.add_argument("--prune-orphans", action="store_true", help="also delete branches that never had a PR")
+    ap.add_argument("--keep", action="append", default=[], help="extra keep glob (repeatable)")
+    ap.add_argument("--manifest", help="write '<sha> <branch> <reason>' lines here")
+    ap.add_argument("--max-deletes", type=int, default=50,
+                    help="refuse to delete more than this in one run; a larger number means "
+                         "something is wrong with the rules, not with the repository")
+    args = ap.parse_args()
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("error: set GH_TOKEN or GITHUB_TOKEN", file=sys.stderr)
+        return 2
+
+    now = datetime.now(timezone.utc)
+    keep_globs = tuple(DEFAULT_KEEP_GLOBS) + tuple(args.keep)
+
+    repo_info, _ = _request("GET", f"/repos/{args.repo}", token)
+    default_branch = repo_info["default_branch"]
+    branches = _paginate(f"/repos/{args.repo}/branches?per_page=100", token)
+    pulls = _paginate(f"/repos/{args.repo}/pulls?state=all&per_page=100", token)
+    print(f"{args.repo}: {len(branches)} branches, {len(pulls)} pull requests, default={default_branch}")
+
+    cache: dict[str, str | None] = {}
+
+    def commit_date(sha: str) -> str | None:
+        if sha not in cache:
+            try:
+                commit, _ = _request("GET", f"/repos/{args.repo}/commits/{sha}", token)
+                cache[sha] = commit["commit"]["committer"]["date"]
+            except (urllib.error.HTTPError, KeyError, TypeError):
+                cache[sha] = None
+        return cache[sha]
+
+    deletions, keeps = classify(branches, pulls, default_branch, keep_globs, now, args, commit_date)
+
+    print(f"\nkeeping {len(keeps)}:")
+    for name, _, why in sorted(keeps):
+        print(f"  {name:<52} {why}")
+
+    print(f"\n{'deleting' if args.execute else 'would delete'} {len(deletions)}:")
+    for name, sha, why in sorted(deletions):
+        print(f"  {name:<52} {sha[:8]}  {why}")
+
+    if args.manifest and deletions:
+        with open(args.manifest, "w", encoding="utf-8") as fh:
+            for name, sha, why in sorted(deletions):
+                fh.write(f"{sha} {name} {why}\n")
+        print(f"\nmanifest: {args.manifest}")
+
+    if not args.execute:
+        print("\ndry run — nothing was deleted. Pass --execute to apply.")
+        return 0
+
+    # A rule change that suddenly matches everything looks exactly like a correct run until the
+    # branches are gone. Stop and make a human look instead.
+    if len(deletions) > args.max_deletes:
+        print(f"\nerror: {len(deletions)} deletions exceeds --max-deletes={args.max_deletes}; "
+              f"refusing. Re-run with a higher limit once the list above has been read.",
+              file=sys.stderr)
+        return 1
+
+    failed = 0
+    for name, sha, _ in sorted(deletions):
+        ref = urllib.parse.quote(name, safe="")
+        try:
+            _request("DELETE", f"/repos/{args.repo}/git/refs/heads/{ref}", token)
+            print(f"  deleted {name} ({sha[:8]})")
+        except urllib.error.HTTPError as exc:
+            failed += 1
+            print(f"  FAILED  {name}: {exc.code} {exc.reason}", file=sys.stderr)
+
+    print(f"\ndeleted {len(deletions) - failed}, failed {failed}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tools/test_prune_stale_branches.py
+++ b/Tools/test_prune_stale_branches.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Pins what prune-stale-branches.py REFUSES to delete.
+
+A branch-deleting robot is judged entirely by its false positives. Every rule below exists because
+getting it wrong destroys work that may have no other copy, and because none of these refusals are
+observable in production without deleting something first — so they run here against fabricated API
+payloads, with no network and no repository.
+
+Standard `unittest`, discovered by `tools-python.yml` alongside the other Tools/ suites.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "prune_stale_branches", Path(__file__).resolve().parent / "prune-stale-branches.py")
+prune = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(prune)
+
+NOW = datetime(2026, 8, 23, tzinfo=timezone.utc)
+
+
+def stamp(days_ago: float) -> str:
+    return (NOW - timedelta(days=days_ago)).isoformat().replace("+00:00", "Z")
+
+
+def branch(name, sha="a" * 40, protected=False):
+    return {"name": name, "commit": {"sha": sha}, "protected": protected}
+
+
+def pr(number, head, state, base="main", merged_at=None, closed_at=None):
+    return {"number": number, "state": state, "head": {"ref": head}, "base": {"ref": base},
+            "merged_at": merged_at, "closed_at": closed_at}
+
+
+def classify(branches, pulls, *, prune_orphans=False, orphan_days=90, closed_days=14,
+             merged_days=7, commit_ages=None, commit_date=None):
+    args = argparse.Namespace(prune_orphans=prune_orphans, orphan_days=orphan_days,
+                              closed_days=closed_days, merged_days=merged_days)
+    ages = commit_ages or {}
+    dater = commit_date if commit_date is not None else (lambda sha: stamp(ages.get(sha, 0)))
+    deletions, keeps = prune.classify(
+        branches, pulls, "main", prune.DEFAULT_KEEP_GLOBS, NOW, args, dater)
+    return {d[0] for d in deletions}, {k[0] for k in keeps}
+
+
+class Refusals(unittest.TestCase):
+    """What the tool must never delete."""
+
+    def test_default_branch_is_never_deleted(self):
+        deleted, kept = classify([branch("main")], [])
+        self.assertEqual(set(), deleted)
+        self.assertIn("main", kept)
+
+    def test_a_protected_branch_is_never_deleted(self):
+        """Branch protection is the owner's statement; the tool does not second-guess it."""
+        deleted, _ = classify([branch("release-freeze", protected=True)], [])
+        self.assertEqual(set(), deleted)
+
+    def test_a_keep_glob_wins_over_having_no_pr(self):
+        deleted, _ = classify([branch("release/2.1.0")], [], prune_orphans=True,
+                              commit_ages={"a" * 40: 999})
+        self.assertEqual(set(), deleted)
+
+    def test_the_head_of_an_open_pr_is_kept(self):
+        """Deleting it closes the PR and takes the review thread's diff with it."""
+        deleted, _ = classify([branch("feature-x")], [pr(1, "feature-x", "open")])
+        self.assertEqual(set(), deleted)
+
+    def test_the_base_of_an_open_pr_is_kept(self):
+        """The forgettable case: deleting a base breaks or silently retargets everything stacked
+        on it, even when the base's own PR was closed long ago."""
+        deleted, _ = classify(
+            [branch("stack-base")],
+            [pr(1, "stack-base", "closed", closed_at=stamp(200)),
+             pr(2, "child", "open", base="stack-base")])
+        self.assertEqual(set(), deleted)
+
+    def test_a_recent_branch_with_no_pr_is_kept(self):
+        """"No open PR" is a fact about the present. A branch pushed this morning has not yet had
+        time to acquire one."""
+        deleted, _ = classify([branch("just-pushed")], [], prune_orphans=True,
+                              commit_ages={"a" * 40: 3})
+        self.assertEqual(set(), deleted)
+
+    def test_orphan_pruning_is_off_by_default(self):
+        deleted, _ = classify([branch("abandoned")], [], commit_ages={"a" * 40: 400})
+        self.assertEqual(set(), deleted)
+
+    def test_an_unreadable_commit_date_is_kept(self):
+        """Unknown age is not old age."""
+        deleted, _ = classify([branch("undateable")], [], prune_orphans=True,
+                              commit_date=lambda sha: None)
+        self.assertEqual(set(), deleted)
+
+    def test_a_recently_closed_pr_keeps_its_branch(self):
+        deleted, _ = classify([branch("recent")], [pr(1, "recent", "closed", closed_at=stamp(3))])
+        self.assertEqual(set(), deleted)
+
+    def test_a_recently_merged_pr_keeps_its_branch(self):
+        deleted, _ = classify([branch("fresh")],
+                              [pr(1, "fresh", "closed", merged_at=stamp(2), closed_at=stamp(2))])
+        self.assertEqual(set(), deleted)
+
+    def test_a_branch_reused_by_a_newer_open_pr_is_kept(self):
+        deleted, _ = classify(
+            [branch("reused")],
+            [pr(1, "reused", "closed", closed_at=stamp(300)), pr(9, "reused", "open")])
+        self.assertEqual(set(), deleted)
+
+
+class Deletions(unittest.TestCase):
+    """What the tool must actually clean up — a prune that refuses everything is also broken."""
+
+    def test_a_long_closed_unmerged_pr_releases_its_branch(self):
+        deleted, _ = classify([branch("stale")], [pr(1, "stale", "closed", closed_at=stamp(30))])
+        self.assertEqual({"stale"}, deleted)
+
+    def test_a_merged_pr_whose_branch_survived_releases_it(self):
+        """deleteBranchOnMerge can fail or postdate the branch; this is the mop-up."""
+        deleted, _ = classify([branch("merged")],
+                              [pr(1, "merged", "closed", merged_at=stamp(30), closed_at=stamp(30))])
+        self.assertEqual({"merged"}, deleted)
+
+    def test_an_opted_in_orphan_past_the_floor_is_deleted(self):
+        deleted, _ = classify([branch("ancient")], [], prune_orphans=True,
+                              commit_ages={"a" * 40: 400})
+        self.assertEqual({"ancient"}, deleted)
+
+    def test_a_mixed_repository_resolves_to_exactly_the_dead_branches(self):
+        """The shape of the August 2026 sweep in miniature: the dead go, everything live stays."""
+        branches = [branch("main"), branch("feat/live", "b" * 40), branch("dead-closed", "c" * 40),
+                    branch("dead-merged", "d" * 40), branch("orphan-old", "e" * 40),
+                    branch("orphan-new", "f" * 40)]
+        pulls = [pr(10, "feat/live", "open"),
+                 pr(11, "dead-closed", "closed", closed_at=stamp(60)),
+                 pr(12, "dead-merged", "closed", merged_at=stamp(60), closed_at=stamp(60))]
+        deleted, kept = classify(branches, pulls, prune_orphans=True,
+                                 commit_ages={"e" * 40: 200, "f" * 40: 5})
+        self.assertEqual({"dead-closed", "dead-merged", "orphan-old"}, deleted)
+        self.assertEqual({"main", "feat/live", "orphan-new"}, kept)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`deleteBranchOnMerge` is already on and working — it just does much less than the name suggests. It fires on **merge** only. A PR closed **without** merging keeps its branch forever, and a branch that never had a PR was never in scope at all.

A sweep this week found the scale: **80 branches, 75 dead** — 3 from closed-unmerged PRs, and 72 working branches from a three-week stretch in June/July that had never been opened as a PR. Clearing it took an afternoon. The hand-built delete-list also quietly omitted four closed-unmerged branches the same sweep had already found, which is the argument for a tool rather than more care.

## What the scheduled run does

Weekly, Mondays 04:17 UTC, two safe categories only:

| Category | Floor | Why it is safe |
|---|---|---|
| PR merged, branch survived | 7d | Mop-up for whatever `deleteBranchOnMerge` missed |
| PR closed unmerged | 14d | The PR is a decision; the branch is residue |

It deliberately does **not** touch branches that never had a PR. That category is indistinguishable from someone's long-running private branch, so it stays behind the `prune_orphans` dispatch input with a 90-day floor. **Manual runs default to a dry run.**

## The refusals are the product

A branch-deleting robot is judged by its false positives, and none of these are observable in production without deleting something first — so they are pinned by tests against fabricated payloads:

- the default branch, protected branches, and keep globs (`release/*`, …)
- the **head** of an open PR — deleting it closes the PR and takes the diff with it
- the **base** of an open PR — the easy one to forget; deleting it silently retargets or breaks every stacked PR on top, and it is refused *even when the base's own PR closed long ago*
- a branch too new to have acquired a PR yet
- a commit date that cannot be read — unknown age is not old age
- `--max-deletes` (default 50), because a rule change that suddenly matches everything looks exactly like a correct run until the branches are gone

## Recovery

A manifest of `<sha> <branch> <reason>`, uploaded as a 90-day artifact. GitHub keeps unreachable objects for a limited window after the ref goes, so a SHA from that file can still be fetched for a while. It is a lead, not a backup, and the file says so.

## Verification

- **15 new tests**; `Tools/` discovery passes at **103** (floor 45), so `tools-python.yml` picks the suite up with no edit to that workflow. The suite is `unittest`, not a bare script — a script-style file would `SystemExit` during discovery and break that job.
- Dry run **and** `--execute` exercised against this repository: it found the four closed-unmerged branches the manual sweep missed, deleted exactly those, and a second run found nothing.
- Pure Python + REST API. No strap, no Xcode, no Gradle. Nothing here touches app code, so the disabled compile workflows do not apply.

`main`, `feat/whoop5-serial-identity`, `prototype-scroll-navbar` and `prototype-weather-backgrounds` are what remain, all correctly held as open-PR heads.