### PR TITLE
iOS: run a backgrounded re-score where it can finish, instead of restarting it

### DIFF
--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -444,7 +444,27 @@ final class AppModel: ObservableObject {
                 // `force: false` skips the heavy 21-day rescore when the raw HR stream is unchanged since the
                 // last run, instead of re-reading ~21×54 h of HR every 15 min on a big-import library. A new
                 // sample (the heal above, or a sync) moves the fingerprint and the tick rescores as before.
-                await self.intelligence.analyzeRecent(force: false)
+                // #1538: the backstop is subject to the same background reality as the post-offload pass,
+                // and it was the LAST way the livelock could survive. This loop lives as long as the
+                // process, so it keeps ticking while backgrounded as a bluetooth-central, and its own
+                // `force: false` watermark gate cannot save it: a killed pass never advances the
+                // watermark, so the tick still reads the data as new and starts another full pass. The
+                // comment above says the gate also can't skip while the strap streams live HR. Wrapping
+                // it means a tick that cannot finish here does not start.
+                //
+                // `owesOnDefer: false` — a skipped BACKSTOP owes nothing. Every real update forces its
+                // own pass, so conjuring a debt here would send a processing task off to run a forced
+                // full pass when most likely nothing changed. A debt a real pass already recorded is
+                // untouched.
+                // `live = self.live` spelled out: this is nested inside the cadence `Task`, which
+                // requires explicit `self`, so the bare-name capture shorthand used elsewhere in this
+                // type would not resolve here.
+                await RescoreBackgroundScheduler.run(owesOnDefer: false,
+                                                     log: { [live = self.live] line in
+                                                         live.append(log: line)
+                                                     }) {
+                    await self.intelligence.analyzeRecent(force: false)
+                }
                 // v5: recompute the skin-temp suite snapshots (cycle phase + body clock) from the
                 // freshly-scored history so the Health hub cards read a ready result.
                 await self.refreshV5Signals()

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -577,6 +577,27 @@ final class AppModel: ObservableObject {
     var healthWriteBack: (() async -> Void)?
     #endif
 
+    /// Settle a re-score that is owed (#1538) — one an earlier attempt started and was killed partway
+    /// through, or one a background trigger deferred rather than start where it could not finish.
+    ///
+    /// Called from the iOS `BGProcessingTask` handler, which gets minutes rather than the seconds a
+    /// bluetooth-central background wake is worth, and from foreground entry, whichever comes first. A
+    /// no-op unless something is actually owed, so both callers are safe to invoke unconditionally.
+    ///
+    /// Forced rather than `skipIfUnchanged`: an interrupted pass never advanced the watermark — by design,
+    /// so that it cannot mark unscored data as scored — so gating on the fingerprint here would be asking
+    /// a question whose answer is already known to be "yes, there is work".
+    func runDeferredRescoreIfOwed() async {
+        guard RescoreBackgroundScheduler.isRescoreOwed else { return }
+        live.append(log: "re-score: resuming a pass an earlier attempt could not finish (#1538)")
+        await intelligence.analyzeRecent()
+        #if os(iOS)
+        // The deferred pass is the one that finally produces today's score, and it runs with no UI
+        // attached — so publish the snapshot here too, for the same reason the post-offload path does.
+        await WidgetSnapshot.publish(from: self)
+        #endif
+    }
+
     private func refreshAfterCompletedBackfill() async {
         live.append(log: "Backfill: refreshing dashboard cache from completed sync")
         await repo.refresh(days: 120)
@@ -588,7 +609,17 @@ final class AppModel: ObservableObject {
         // duplicate offload (nothing new banked, common on a flapping link) skips the whole-window rescore
         // instead of churning it, which was surfacing as a Trends/streak "0 days" flicker. Only this
         // post-offload caller opts in; every other analyzeRecent path still forces unconditionally.
-        await intelligence.analyzeRecent(skipIfUnchanged: true)
+        // #1538: this offload routinely completes while the app is BACKGROUNDED — it stays alive as a
+        // bluetooth-central to receive the offload at all — and the pass is all-or-nothing, so on a heavy
+        // install iOS suspends the process minutes before it can finish and every scored night is lost.
+        // Worse, the watermark advances only on completion, so the next trigger still sees new data and
+        // starts another doomed pass: a livelock that burned nearly eight minutes of CPU per attempt in
+        // the #1538 report while never producing a score. Decide first whether this pass can finish here,
+        // and hand it to a background-processing task when it cannot. A no-op on macOS, and on iOS a
+        // foreground pass is never deferred.
+        await RescoreBackgroundScheduler.run(log: { [live] line in live.append(log: line) }) {
+            await intelligence.analyzeRecent(skipIfUnchanged: true)
+        }
         await refreshV5Signals()
         #if os(iOS)
         // #980: a strap backfill routinely completes while the app is BACKGROUNDED (it runs as a

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -540,6 +540,13 @@ final class IntelligenceEngine: ObservableObject {
         // and how long (the CPU cost per run), so a re-score STORM is visible in the strap log.
         let reScoreStart = Date()
         computing = true
+        // #1538: the pass is now past every gate and will do real work. Mark it started durably, so that a
+        // process killed mid-pass leaves evidence a LATER process can read — the killed process itself gets
+        // no chance to record anything. Cleared beside the watermark at the end; there is no early return
+        // between here and there, so "started and never finished" means exactly "killed", never a silent
+        // internal skip. `RescoreBackgroundPolicy` reads it to stop re-attempting a pass that cannot
+        // finish in the background, which is the livelock in #1538.
+        RescoreBackgroundScheduler.markRescoreOwed()
         // #899-A re-arm: clear the lock, then if a forced rescore was dropped while this pass held it,
         // run it ONCE. The flag is cleared BEFORE the re-invoke (a single re-arm), so a forced call landing
         // DURING the re-invoke re-arms it again but a quiet one does not , this can never recurse unbounded.
@@ -2126,7 +2133,13 @@ final class IntelligenceEngine: ObservableObject {
         // short-circuit while it's unchanged. Written ONLY here at the end of a completed run (never on an
         // early guard-return), so an interrupted/failed run can't advance the watermark past unscored data.
         if !wmKey.isEmpty { UserDefaults.standard.set(wmKey, forKey: Self.analyzeWatermarkKey) }
-        diagnosticSink?("re-score: done — scored \(scoredNights.count) night(s) in \(Int(Date().timeIntervalSince(reScoreStart) * 1000)) ms (#1005)", nil)
+        // #1538: clear the started-mark and bank how long a COMPLETED pass costs on this install. The
+        // measurement is what lets `RescoreBackgroundPolicy` tell an install that finishes comfortably in a
+        // background wake from one that never could, instead of guessing from a constant — the cost varies
+        // by more than an order of magnitude with history size.
+        let elapsed = Date().timeIntervalSince(reScoreStart)
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: elapsed)
+        diagnosticSink?("re-score: done — scored \(scoredNights.count) night(s) in \(Int(elapsed * 1000)) ms (#1005)", nil)
     }
 
     /// UserDefaults key for the #836 idle-tick gate: the `(count:maxTs)` HR fingerprint the last completed

--- a/Strand/Data/RescoreBackgroundPolicy.swift
+++ b/Strand/Data/RescoreBackgroundPolicy.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Whether a re-score triggered while the app is BACKGROUNDED should start now or be handed to a
+/// background-processing task that has time to finish it.
+///
+/// #1538: a completed offload rescores immediately, and on iOS that routinely happens while the app is
+/// backgrounded — it stays alive as a `bluetooth-central` to receive the offload in the first place. But
+/// `analyzeRecent` is all-or-nothing: pass 1 writes nothing, every store write happens after both loops,
+/// and the watermark advances only at the very end so an interrupted run can never mark unscored data as
+/// scored. On a heavy install the pass measured **474,778 ms** — nearly eight minutes. iOS suspends the
+/// process long before that, so the work is lost in full.
+///
+/// The lost work is not the worst of it. Because the watermark never advanced, the NEXT trigger still saw
+/// `newData=yes` and started another full pass, which was killed in turn. The reporter's log shows exactly
+/// that: every offload after 05:40:31 reported `caught up` with nothing new to fetch, yet two later ticks
+/// still read `newData=yes`. It is a livelock — the pass cannot finish, and failing to finish is what
+/// guarantees it will be attempted again. The score appeared 1 h 57 m after the data was complete, and only
+/// because the app happened to stay foregrounded for eight unbroken minutes.
+///
+/// So this decides, before spending anything: is this a pass that can plausibly finish here?
+///
+/// Deliberately NOT a fix for how long the pass takes. A cold process still re-scores every night in the
+/// window, because the per-day reuse cache is in-memory and starts empty (`IntelligenceEngine.dayScanCache`).
+/// This changes only WHERE the work runs and how often a doomed attempt is paid for. Making the pass itself
+/// cheap across a process restart is the other half of #1538 and is not attempted here.
+enum RescoreBackgroundPolicy {
+
+    /// What a background-initiated re-score should do.
+    enum Decision: Equatable {
+        /// Start the pass now, under an execution assertion.
+        case run
+        /// Do not start it; leave the work marked pending and let a background-processing task (or the
+        /// next foreground) run it. The reason is logged verbatim to the strap log — #1538 was three
+        /// nights of chasing BLE precisely because the log did not say why scoring had not happened.
+        case deferToBackgroundTask(reason: String)
+    }
+
+    /// What a background execution assertion is worth relying on, in seconds.
+    ///
+    /// `beginBackgroundTask` buys roughly 30 s on current iOS, and that figure is a courtesy rather than a
+    /// contract — it shrinks under memory pressure and in Low Power Mode. 20 s leaves headroom for the
+    /// assertion to be granted late and for the pass's own store writes to land, since being killed
+    /// mid-write is the one outcome worth spending real caution to avoid.
+    static let backgroundBudgetSeconds: Double = 20
+
+    /// - Parameters:
+    ///   - isBackground: whether the app is currently backgrounded. A foregrounded app is never deferred:
+    ///     the user is looking at the screen, there is no suspension deadline, and the existing behaviour
+    ///     is correct.
+    ///   - rescoreAlreadyOwed: a re-score is outstanding — either a pass marked itself started and never
+    ///     marked itself finished (it was killed; the mark survives process death, which is the point,
+    ///     because the killed process gets no chance to record anything) or an earlier trigger already
+    ///     deferred one. Both mean the same operationally: the work is spoken for, and starting it here
+    ///     would duplicate a pass that something better placed is going to run. This is the
+    ///     self-correcting part — the FIRST background attempt on an install we know nothing about is
+    ///     allowed to run, and from then on the work escalates instead of being re-killed on every
+    ///     offload.
+    ///   - lastCompletedPassSeconds: how long the last pass that ran to completion took, or nil if none
+    ///     has. Measured rather than assumed — the cost varies by more than an order of magnitude with
+    ///     history size, and a fixed guess would either defer installs that finish comfortably or wave
+    ///     through ones that never could.
+    ///   - budgetSeconds: see `backgroundBudgetSeconds`; a parameter so the tests can state the boundary
+    ///     rather than inherit it.
+    static func decide(isBackground: Bool,
+                       rescoreAlreadyOwed: Bool,
+                       lastCompletedPassSeconds: Double?,
+                       budgetSeconds: Double = backgroundBudgetSeconds) -> Decision {
+        guard isBackground else { return .run }
+
+        if rescoreAlreadyOwed {
+            return .deferToBackgroundTask(
+                reason: "a re-score is already outstanding from an earlier trigger")
+        }
+
+        // Only a FINITE, positive measurement can justify deferring. A nil (nothing has ever completed),
+        // a zero, or a NaN/infinity from a corrupted default all mean "unknown", and unknown must fall
+        // through to running: refusing to score on the strength of a value we cannot read would be a far
+        // worse failure than one wasted pass.
+        if budgetSeconds > 0,
+           let measured = lastCompletedPassSeconds,
+           measured.isFinite, measured > 0,
+           measured > budgetSeconds {
+            return .deferToBackgroundTask(
+                reason: "last completed pass took \(Int(measured.rounded()))s, over the "
+                        + "\(Int(budgetSeconds.rounded()))s a background wake can be relied on for")
+        }
+
+        return .run
+    }
+}

--- a/Strand/System/RescoreBackgroundScheduler.swift
+++ b/Strand/System/RescoreBackgroundScheduler.swift
@@ -82,7 +82,16 @@ enum RescoreBackgroundScheduler {
     /// `isBackground` defaults to the real application state and is a parameter only so a test can drive
     /// the deferral branch, which is unreachable on macOS (where `isBackgrounded` is always false) and is
     /// exactly where the work-is-owed bookkeeping lives.
+    /// - Parameter owesOnDefer: whether a deferral should record a debt for a background task to settle.
+    ///   True for a real update path — a completed offload MUST eventually be scored, so deferring it has
+    ///   to leave something behind or the work is dropped rather than moved. FALSE for the steady-state
+    ///   backstop tick, which by its own contract is not the thing that must happen: every real update
+    ///   forces its own pass, so the tick exists only to catch what those missed. Recording a debt for it
+    ///   would conjure a forced full pass for a processing task to run when very likely nothing changed,
+    ///   which is the churn #1146 exists to avoid. A debt an earlier real pass already recorded is
+    ///   untouched either way.
     static func run(isBackground: Bool? = nil,
+                    owesOnDefer: Bool = true,
                     log: @escaping (String) -> Void,
                     work: () async -> Void) async {
         let decision = RescoreBackgroundPolicy.decide(
@@ -92,6 +101,13 @@ enum RescoreBackgroundScheduler {
 
         switch decision {
         case .deferToBackgroundTask(let reason):
+            guard owesOnDefer else {
+                // Nothing is queued and nothing is owed: the backstop simply does not run here. Said
+                // plainly in the log, because "deferred" would promise a background task that is not
+                // coming.
+                log("re-score: backstop tick skipped while backgrounded — \(reason)")
+                return
+            }
             // Record the debt BEFORE scheduling. Without this the background task wakes, finds nothing
             // marked owed, and returns having done nothing — the deferral would silently drop the work
             // rather than move it.

--- a/Strand/System/RescoreBackgroundScheduler.swift
+++ b/Strand/System/RescoreBackgroundScheduler.swift
@@ -32,7 +32,7 @@ enum RescoreBackgroundScheduler {
     /// killed), or a trigger deferred one to a background task. Survives process death, which is the
     /// entire point — the process being killed is the event we are trying to observe, and it is not an
     /// event the killed process gets any chance to write down.
-    static let owedKey = "noop.rescorePassPending"
+    static let owedKey = "noop.rescoreOwed"
     /// Seconds the last COMPLETED pass took. Only ever written by a pass that reached the end.
     static let lastPassSecondsKey = "noop.rescoreLastPassSeconds"
 

--- a/Strand/System/RescoreBackgroundScheduler.swift
+++ b/Strand/System/RescoreBackgroundScheduler.swift
@@ -60,7 +60,13 @@ enum RescoreBackgroundScheduler {
         }
     }
 
-    /// Whether the app is currently backgrounded. Always false on macOS — see the type doc.
+    /// Whether the app is somewhere a long pass might not survive. Always false on macOS — see the type doc.
+    ///
+    /// Anything that is not `.active` counts, `.inactive` included, which is the conservative direction on
+    /// purpose. `.inactive` is the state on the way to suspension, so reading it as "foreground" is the
+    /// error that loses work; reading it as "background" costs at most a deferral that the very next
+    /// `.active` transition drains. The transient `.inactive` cases — app switcher, notification centre,
+    /// an incoming call — therefore self-correct within seconds, and the case that matters is never missed.
     static var isBackgrounded: Bool {
         #if os(iOS)
         return UIApplication.shared.applicationState != .active

--- a/Strand/System/RescoreBackgroundScheduler.swift
+++ b/Strand/System/RescoreBackgroundScheduler.swift
@@ -1,0 +1,219 @@
+import Foundation
+#if os(iOS)
+import BackgroundTasks
+import UIKit
+#endif
+
+/// Runs a backgrounded re-score somewhere it can actually finish, and records honestly when one did not.
+///
+/// See `RescoreBackgroundPolicy` for the problem (#1538) and the decision rules. This is the plumbing:
+/// the durable "a re-score is owed" mark, the measured duration the policy reads, the iOS
+/// execution assertion, and the `BGProcessingTask` that work is escalated to.
+///
+/// `BGProcessingTask` rather than `BGAppRefreshTask` — the two the app already uses (the scheduled debug
+/// export, the Health write-back) are refresh tasks, which are metered for short work. Processing tasks are
+/// the long, deferrable kind, which is what an eight-minute pass needs. iOS decides when one runs and
+/// favours idle and charging, so this is an "eventually, without needing the user to hold the app open"
+/// guarantee, NOT a promise that a score appears moments after a sync. Nothing here claims otherwise, and
+/// the honest limit is worth stating: on an install where the pass takes minutes, the score still normally
+/// appears when the app is next opened. What changes is that the phone stops paying for a full doomed pass
+/// on every single offload to get there.
+///
+/// HONEST about platform limits, in the shape of `ScheduledDebugExport`:
+/// - **macOS** — the app is a normal foreground app with no suspension deadline. Every entry point here is
+///   a no-op that reports `.run`, so the existing behaviour is exactly preserved.
+/// - **iOS** — needs the `processing` background mode AND the identifier listed in
+///   `BGTaskSchedulerPermittedIdentifiers` AND `register()` called before launch finishes. If any of those
+///   is missing, `submit` fails gracefully and the foreground path still scores normally.
+@MainActor
+enum RescoreBackgroundScheduler {
+
+    /// A re-score is OWED: either a pass marked itself started and never marked itself finished (it was
+    /// killed), or a trigger deferred one to a background task. Survives process death, which is the
+    /// entire point — the process being killed is the event we are trying to observe, and it is not an
+    /// event the killed process gets any chance to write down.
+    static let owedKey = "noop.rescorePassPending"
+    /// Seconds the last COMPLETED pass took. Only ever written by a pass that reached the end.
+    static let lastPassSecondsKey = "noop.rescoreLastPassSeconds"
+
+    static var isRescoreOwed: Bool { UserDefaults.standard.bool(forKey: owedKey) }
+
+    static var lastCompletedPassSeconds: Double? {
+        guard UserDefaults.standard.object(forKey: lastPassSecondsKey) != nil else { return nil }
+        let value = UserDefaults.standard.double(forKey: lastPassSecondsKey)
+        return value.isFinite && value > 0 ? value : nil
+    }
+
+    /// Mark a re-score as owed. Called by `IntelligenceEngine` once a pass is past every gate and is
+    /// definitely about to work — so that a kill leaves the debt behind — and by the deferral path, where
+    /// no pass is attempted at all but the work is just as outstanding.
+    static func markRescoreOwed() {
+        UserDefaults.standard.set(true, forKey: owedKey)
+    }
+
+    /// Settle the debt at the end of a completed pass, beside the watermark advance. A pass that is
+    /// killed never reaches this, which is what leaves the mark set for the next launch to find.
+    static func markRescoreCompleted(seconds: Double) {
+        UserDefaults.standard.set(false, forKey: owedKey)
+        if seconds.isFinite, seconds > 0 {
+            UserDefaults.standard.set(seconds, forKey: lastPassSecondsKey)
+        }
+    }
+
+    /// Whether the app is currently backgrounded. Always false on macOS — see the type doc.
+    static var isBackgrounded: Bool {
+        #if os(iOS)
+        return UIApplication.shared.applicationState != .active
+        #else
+        return false
+        #endif
+    }
+
+    /// Decide, then either run `work` under an execution assertion or leave it for `BGProcessingTask`.
+    ///
+    /// `log` goes to the strap log, always — both the decision and its reason. #1538 cost three nights
+    /// because the log recorded that scoring had not happened without ever recording why.
+    /// `isBackground` defaults to the real application state and is a parameter only so a test can drive
+    /// the deferral branch, which is unreachable on macOS (where `isBackgrounded` is always false) and is
+    /// exactly where the work-is-owed bookkeeping lives.
+    static func run(isBackground: Bool? = nil,
+                    log: @escaping (String) -> Void,
+                    work: () async -> Void) async {
+        let decision = RescoreBackgroundPolicy.decide(
+            isBackground: isBackground ?? isBackgrounded,
+            rescoreAlreadyOwed: isRescoreOwed,
+            lastCompletedPassSeconds: lastCompletedPassSeconds)
+
+        switch decision {
+        case .deferToBackgroundTask(let reason):
+            // Record the debt BEFORE scheduling. Without this the background task wakes, finds nothing
+            // marked owed, and returns having done nothing — the deferral would silently drop the work
+            // rather than move it.
+            markRescoreOwed()
+            log("re-score: deferred to a background task — \(reason)")
+            schedule()
+        case .run:
+            await withAssertion(log: log, work: work)
+        }
+    }
+
+    /// Hold an execution assertion for the duration of `work` so a SHORT pass is not suspended halfway.
+    /// A long one still outlives the grant; the assertion's expiry handler is where that becomes visible
+    /// in the log and where the work is escalated, rather than the process simply vanishing.
+    private static func withAssertion(log: @escaping (String) -> Void, work: () async -> Void) async {
+        #if os(iOS)
+        let assertion = BackgroundAssertion()
+        let taskID = UIApplication.shared.beginBackgroundTask(withName: "noop.rescore") {
+            // iOS invokes this on the main thread when it is about to reclaim the assertion. The pass
+            // itself cannot be cancelled from here — its heavy loop runs in a detached task, which does
+            // not inherit cancellation — so do not pretend to stop it. Record the fact and escalate:
+            // the owed mark is still set (only a completed pass clears it) and that is what the next
+            // decision reads.
+            MainActor.assumeIsolated {
+                log("re-score: background time expired before the pass finished — escalating (#1538)")
+                schedule()
+                assertion.end()
+            }
+        }
+        assertion.store(taskID)
+        await work()
+        // Idempotent under the box's lock, so the expiry path and this one cannot double-end the task —
+        // which UIKit treats as a programmer error — and cannot leak it either.
+        assertion.end()
+        #else
+        await work()
+        #endif
+    }
+
+    // MARK: - iOS background-processing plumbing
+
+    #if os(iOS)
+    static let taskIdentifier = (Bundle.main.bundleIdentifier ?? "com.noopapp.noop") + ".rescore"
+
+    /// Register the handler. MUST be called from `StrandiOSApp.init()` before launch finishes, and the
+    /// identifier MUST be listed in `BGTaskSchedulerPermittedIdentifiers`, or iOS never delivers the task.
+    /// Safe to leave uncalled: `schedule()` fails gracefully and the foreground path still scores.
+    static func register(perform operation: @escaping @MainActor () async -> Void) {
+        BGTaskScheduler.shared.register(forTaskWithIdentifier: taskIdentifier, using: nil) { task in
+            let completion = TaskCompletionGuard(task: task)
+            let worker = Task { @MainActor in
+                await operation()
+                guard !Task.isCancelled else { return }
+                // Re-arm only while work remains. A processing task is single-shot, and re-submitting
+                // unconditionally would ask iOS for a wake on every install forever, including the ones
+                // that never have anything to do.
+                if isRescoreOwed { schedule() }
+                completion.finish(success: !isRescoreOwed)
+            }
+            task.expirationHandler = {
+                worker.cancel()
+                // The pass did not finish inside the processing budget either. Ask for another rather
+                // than dropping the work, and report the failure so iOS's own scheduling heuristics see
+                // it honestly instead of being told this succeeded.
+                schedule()
+                completion.finish(success: false)
+            }
+        }
+    }
+
+    /// Keep exactly one pending request, so calling this from several places is idempotent and also
+    /// repairs a request the system discarded.
+    static func schedule() {
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: taskIdentifier)
+        let request = BGProcessingTaskRequest(identifier: taskIdentifier)
+        // Neither is required. Network is irrelevant to an offline app, and demanding external power
+        // would strand the work for anyone who does not charge overnight — the exact population most
+        // likely to be wearing the strap continuously.
+        request.requiresNetworkConnectivity = false
+        request.requiresExternalPower = false
+        try? BGTaskScheduler.shared.submit(request)
+    }
+
+    /// Holds the background-task identifier so the normal path and the expiry handler can each try to end
+    /// it while exactly one of them succeeds. UIKit treats a double `endBackgroundTask` as a programmer
+    /// error and a never-ended one as grounds for killing the app, so neither may be left to ordering.
+    /// Plain lock rather than actor isolation, matching `TaskCompletionGuard` below.
+    private final class BackgroundAssertion: @unchecked Sendable {
+        private let lock = NSLock()
+        private var id: UIBackgroundTaskIdentifier = .invalid
+
+        func store(_ newID: UIBackgroundTaskIdentifier) {
+            lock.lock()
+            defer { lock.unlock() }
+            id = newID
+        }
+
+        @MainActor func end() {
+            lock.lock()
+            let current = id
+            id = .invalid
+            lock.unlock()
+            guard current != .invalid else { return }
+            UIApplication.shared.endBackgroundTask(current)
+        }
+    }
+
+    /// Guards `setTaskCompleted` against being called twice — once normally and once from the expiration
+    /// handler — which `BGTaskScheduler` treats as a programmer error. Plain lock rather than actor
+    /// isolation: iOS can invoke the expiration handler on a different queue. Mirrors the guard in
+    /// `ScheduledDebugExport`.
+    private final class TaskCompletionGuard: @unchecked Sendable {
+        private let task: BGTask
+        private let lock = NSLock()
+        private var finished = false
+
+        init(task: BGTask) { self.task = task }
+
+        func finish(success: Bool) {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !finished else { return }
+            finished = true
+            task.setTaskCompleted(success: success)
+        }
+    }
+    #else
+    /// macOS has no background-task scheduler and no suspension deadline — nothing to schedule.
+    static func schedule() {}
+    #endif
+}

--- a/StrandTests/RescoreBackgroundPolicyTests.swift
+++ b/StrandTests/RescoreBackgroundPolicyTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import Strand
+
+/// #1538: what a backgrounded re-score is allowed to attempt.
+///
+/// The rules exist because getting them wrong is expensive in both directions. Too eager and the phone
+/// pays for a full eight-minute pass on every offload that it will never be allowed to finish — the
+/// livelock in the report. Too shy and a night goes unscored while the app waits for a background task
+/// that may not arrive for hours. Neither failure is visible from inside a single run, so they are pinned
+/// here rather than discovered on someone's wrist.
+final class RescoreBackgroundPolicyTests: XCTestCase {
+
+    private func decide(background: Bool = true,
+                        unfinished: Bool = false,
+                        lastSeconds: Double? = nil,
+                        budget: Double = 20) -> RescoreBackgroundPolicy.Decision {
+        RescoreBackgroundPolicy.decide(isBackground: background,
+                                       rescoreAlreadyOwed: unfinished,
+                                       lastCompletedPassSeconds: lastSeconds,
+                                       budgetSeconds: budget)
+    }
+
+    private func isDeferred(_ d: RescoreBackgroundPolicy.Decision) -> Bool {
+        if case .deferToBackgroundTask = d { return true }
+        return false
+    }
+
+    // MARK: - Foreground is never deferred
+
+    /// The user is looking at the screen and there is no suspension deadline. Deferring here would be a
+    /// pure regression: it would turn a pass that works today into one that waits for iOS.
+    func testAForegroundPassAlwaysRuns() {
+        XCTAssertEqual(decide(background: false), .run)
+        XCTAssertEqual(decide(background: false, unfinished: true), .run)
+        XCTAssertEqual(decide(background: false, lastSeconds: 9_999), .run)
+    }
+
+    // MARK: - The livelock
+
+    /// The core fix. An earlier pass marked itself started and never finished, which survives process
+    /// death — so the phone has already proved once that it cannot complete this work in the background.
+    /// Attempting it again is what burned nearly eight minutes per offload in #1538 while producing
+    /// nothing.
+    func testAnInterruptedPriorAttemptDefersInsteadOfRetrying() {
+        XCTAssertTrue(isDeferred(decide(unfinished: true)))
+    }
+
+    /// ...and it defers even when the last COMPLETED pass looks fast, because "unfinished" is evidence
+    /// about this install right now, whereas the measurement may predate the history that made it slow.
+    func testAnInterruptedAttemptOutranksAFastMeasurement() {
+        XCTAssertTrue(isDeferred(decide(unfinished: true, lastSeconds: 2)))
+    }
+
+    // MARK: - The measurement
+
+    /// A pass measured well inside the budget is exactly what SHOULD run in the background — that is the
+    /// case this whole mechanism must not break.
+    func testAPassThatFitsTheBudgetRuns() {
+        XCTAssertEqual(decide(lastSeconds: 5), .run)
+    }
+
+    /// The reporter's install: 474.778 s against a 20 s budget.
+    func testTheReportedPassDefers() {
+        XCTAssertTrue(isDeferred(decide(lastSeconds: 474.778)))
+    }
+
+    /// The boundary is stated rather than inherited: equal to the budget still runs, over it defers.
+    func testTheBudgetBoundary() {
+        XCTAssertEqual(decide(lastSeconds: 20, budget: 20), .run)
+        XCTAssertTrue(isDeferred(decide(lastSeconds: 20.001, budget: 20)))
+    }
+
+    /// The reason is carried into the strap log, so it has to name the numbers that drove the decision.
+    /// #1538 was three nights of chasing BLE because the log recorded that scoring had not happened
+    /// without ever recording why.
+    func testTheDeferralReasonNamesTheMeasurementAndTheBudget() {
+        guard case .deferToBackgroundTask(let reason) = decide(lastSeconds: 475, budget: 20) else {
+            return XCTFail("expected a deferral")
+        }
+        XCTAssertTrue(reason.contains("475"), reason)
+        XCTAssertTrue(reason.contains("20"), reason)
+    }
+
+    // MARK: - Unknown is not "too slow"
+
+    /// Nothing has ever completed on this install, so there is no measurement to defer on. Running is the
+    /// only way to acquire one, and a first attempt costs at most one pass.
+    func testAnInstallWithNoMeasurementRuns() {
+        XCTAssertEqual(decide(lastSeconds: nil), .run)
+    }
+
+    /// A corrupted or absent default must never be read as "slow". Refusing to score on the strength of
+    /// a value that cannot be interpreted is a far worse failure than one wasted pass.
+    func testUnreadableMeasurementsRunRatherThanDefer() {
+        XCTAssertEqual(decide(lastSeconds: 0), .run)
+        XCTAssertEqual(decide(lastSeconds: -1), .run)
+        XCTAssertEqual(decide(lastSeconds: .nan), .run)
+        XCTAssertEqual(decide(lastSeconds: .infinity), .run)
+    }
+
+    /// A nonsensical budget disables the measurement rule rather than deferring everything — the same
+    /// principle, applied to the other input.
+    func testANonPositiveBudgetDoesNotDeferEverything() {
+        XCTAssertEqual(decide(lastSeconds: 9_999, budget: 0), .run)
+        XCTAssertEqual(decide(lastSeconds: 9_999, budget: -5), .run)
+    }
+
+    /// The shipped budget is the one the app actually uses; pin it so a change is deliberate.
+    func testTheDefaultBudgetIsTheShippedOne() {
+        XCTAssertEqual(RescoreBackgroundPolicy.backgroundBudgetSeconds, 20)
+        XCTAssertTrue(isDeferred(RescoreBackgroundPolicy.decide(
+            isBackground: true, rescoreAlreadyOwed: false, lastCompletedPassSeconds: 21)))
+    }
+}

--- a/StrandTests/RescoreBackgroundSchedulerTests.swift
+++ b/StrandTests/RescoreBackgroundSchedulerTests.swift
@@ -1,0 +1,121 @@
+import XCTest
+@testable import Strand
+
+/// #1538: the bookkeeping that makes a deferred re-score actually happen.
+///
+/// The durable mark is the whole mechanism. If it is not set when work is handed to a background task,
+/// the task wakes, finds nothing owed, and returns having done nothing — the deferral would silently DROP
+/// the pass rather than move it, which is strictly worse than the livelock it replaced. That failure is
+/// invisible on macOS (where the app is never backgrounded, so the branch is never taken) and invisible in
+/// a single run on iOS (the score just never appears), which is why it is pinned here.
+@MainActor
+final class RescoreBackgroundSchedulerTests: XCTestCase {
+
+    private var savedOwed: Any?
+    private var savedSeconds: Any?
+
+    override func setUp() {
+        super.setUp()
+        // These live in UserDefaults.standard, shared with every other test in the target. Save and
+        // restore rather than assume this suite owns them.
+        savedOwed = UserDefaults.standard.object(forKey: RescoreBackgroundScheduler.owedKey)
+        savedSeconds = UserDefaults.standard.object(forKey: RescoreBackgroundScheduler.lastPassSecondsKey)
+        UserDefaults.standard.removeObject(forKey: RescoreBackgroundScheduler.owedKey)
+        UserDefaults.standard.removeObject(forKey: RescoreBackgroundScheduler.lastPassSecondsKey)
+    }
+
+    override func tearDown() {
+        restore(savedOwed, RescoreBackgroundScheduler.owedKey)
+        restore(savedSeconds, RescoreBackgroundScheduler.lastPassSecondsKey)
+        super.tearDown()
+    }
+
+    private func restore(_ value: Any?, _ key: String) {
+        if let value { UserDefaults.standard.set(value, forKey: key) }
+        else { UserDefaults.standard.removeObject(forKey: key) }
+    }
+
+    // MARK: - The durable mark
+
+    /// A pass that starts owes a re-score until it finishes. The mark is what a LATER process reads to
+    /// discover that an earlier one was killed — the killed process never gets to report anything itself.
+    func testAStartedPassOwesUntilItCompletes() {
+        XCTAssertFalse(RescoreBackgroundScheduler.isRescoreOwed)
+        RescoreBackgroundScheduler.markRescoreOwed()
+        XCTAssertTrue(RescoreBackgroundScheduler.isRescoreOwed)
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 12)
+        XCTAssertFalse(RescoreBackgroundScheduler.isRescoreOwed)
+    }
+
+    /// Only a completed pass banks a duration, and only a usable one — the policy reads this to decide
+    /// whether a background wake can finish the work, so a garbage value must read as "no measurement"
+    /// rather than as a number.
+    func testOnlyAUsableDurationIsBanked() {
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778)
+        XCTAssertEqual(RescoreBackgroundScheduler.lastCompletedPassSeconds ?? 0, 474.778, accuracy: 0.001)
+
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: .nan)
+        XCTAssertEqual(RescoreBackgroundScheduler.lastCompletedPassSeconds ?? 0, 474.778, accuracy: 0.001,
+                       "a NaN must not overwrite a good measurement")
+
+        UserDefaults.standard.removeObject(forKey: RescoreBackgroundScheduler.lastPassSecondsKey)
+        XCTAssertNil(RescoreBackgroundScheduler.lastCompletedPassSeconds)
+    }
+
+    // MARK: - Deferral must move the work, never drop it
+
+    /// The bug this file exists for: deferring has to record the debt, or the background task it defers
+    /// to has nothing to find.
+    func testDeferringMarksTheWorkOwedAndDoesNotRunIt() async {
+        // A measured pass far over the background budget, so the policy defers.
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778)
+        XCTAssertFalse(RescoreBackgroundScheduler.isRescoreOwed)
+
+        var ran = false
+        var logged: [String] = []
+        await RescoreBackgroundScheduler.run(isBackground: true, log: { logged.append($0) }) {
+            ran = true
+        }
+
+        XCTAssertFalse(ran, "the pass must not be started in a context that cannot finish it")
+        XCTAssertTrue(RescoreBackgroundScheduler.isRescoreOwed,
+                      "the deferred work must be recorded, or the background task does nothing")
+        XCTAssertEqual(logged.count, 1)
+        XCTAssertTrue(logged[0].contains("deferred"), logged[0])
+        XCTAssertTrue(logged[0].contains("475"), logged[0])
+    }
+
+    /// A foregrounded pass runs, whatever the measurement says. This is the case the mechanism must not
+    /// break: there is no suspension deadline, so deferring would be a pure regression.
+    func testAForegroundPassRunsEvenWhenSlow() async {
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778)
+
+        var ran = false
+        var logged: [String] = []
+        await RescoreBackgroundScheduler.run(isBackground: false, log: { logged.append($0) }) {
+            ran = true
+        }
+
+        XCTAssertTrue(ran)
+        XCTAssertTrue(logged.isEmpty, "a pass that simply runs should not narrate itself")
+    }
+
+    /// A background pass with no measurement yet is allowed to run — that is how the measurement is
+    /// acquired, and a first attempt costs at most one pass.
+    func testAnUnmeasuredBackgroundPassRuns() async {
+        var ran = false
+        await RescoreBackgroundScheduler.run(isBackground: true, log: { _ in }) { ran = true }
+        XCTAssertTrue(ran)
+    }
+
+    /// Once work is owed, a further background trigger defers instead of starting a duplicate pass. This
+    /// is the livelock fix: #1538 paid for a full eight-minute pass on every offload because nothing
+    /// remembered that the previous one had not finished.
+    func testASecondBackgroundTriggerDoesNotStartADuplicatePass() async {
+        RescoreBackgroundScheduler.markRescoreOwed()
+
+        var ran = false
+        await RescoreBackgroundScheduler.run(isBackground: true, log: { _ in }) { ran = true }
+        XCTAssertFalse(ran)
+    }
+}

--- a/StrandTests/RescoreBackgroundSchedulerTests.swift
+++ b/StrandTests/RescoreBackgroundSchedulerTests.swift
@@ -118,4 +118,51 @@ final class RescoreBackgroundSchedulerTests: XCTestCase {
         await RescoreBackgroundScheduler.run(isBackground: true, log: { _ in }) { ran = true }
         XCTAssertFalse(ran)
     }
+
+    // MARK: - The backstop tick owes nothing
+
+    /// The steady-state tick is a backstop: every real update forces its own pass, so a tick that cannot
+    /// run here is simply skipped. Recording a debt for it would send a processing task off to run a
+    /// forced full pass when most likely nothing changed — the churn #1146 exists to avoid.
+    func testASkippedBackstopDoesNotConjureADebt() async {
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778)
+
+        var ran = false
+        var logged: [String] = []
+        await RescoreBackgroundScheduler.run(isBackground: true, owesOnDefer: false,
+                                             log: { logged.append($0) }) { ran = true }
+
+        XCTAssertFalse(ran, "a backstop that cannot finish here must not start")
+        XCTAssertFalse(RescoreBackgroundScheduler.isRescoreOwed,
+                       "a skipped backstop owes nothing — no real update went unscored")
+        XCTAssertEqual(logged.count, 1)
+        XCTAssertTrue(logged[0].contains("backstop"), logged[0])
+        XCTAssertFalse(logged[0].contains("deferred"),
+                       "must not promise a background task that is not coming: \(logged[0])")
+    }
+
+    /// ...but a debt a REAL pass already recorded survives a skipped backstop untouched. Clearing it
+    /// here would strand the very work the mechanism exists to rescue.
+    func testASkippedBackstopLeavesAnExistingDebtAlone() async {
+        RescoreBackgroundScheduler.markRescoreOwed()
+
+        await RescoreBackgroundScheduler.run(isBackground: true, owesOnDefer: false, log: { _ in }) {}
+
+        XCTAssertTrue(RescoreBackgroundScheduler.isRescoreOwed)
+    }
+
+    /// A backstop still RUNS in the foreground, and in a background that can afford it — the flag changes
+    /// only what a deferral records, never whether the pass happens.
+    func testABackstopStillRunsWhenItCan() async {
+        var foreground = false
+        await RescoreBackgroundScheduler.run(isBackground: false, owesOnDefer: false,
+                                             log: { _ in }) { foreground = true }
+        XCTAssertTrue(foreground)
+
+        var affordable = false
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 3)
+        await RescoreBackgroundScheduler.run(isBackground: true, owesOnDefer: false,
+                                             log: { _ in }) { affordable = true }
+        XCTAssertTrue(affordable)
+    }
 }

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -68,6 +68,16 @@ struct StrandiOSApp: App {
         UNUserNotificationCenter.current().delegate = NotificationPresenter.shared
         let model = AppModel()
         _model = StateObject(wrappedValue: model)
+        // #1538: a strap offload completes while the app is BACKGROUNDED — it stays alive as a
+        // bluetooth-central to receive it — and the re-score it triggers took nearly eight minutes on the
+        // reporter's install, far longer than that wake survives. The pass is all-or-nothing, so being
+        // suspended lost every scored night AND left the watermark unadvanced, which made the next offload
+        // start the same doomed pass again. This processing task is where that work is escalated to; it is
+        // the long, deferrable kind rather than the metered refresh kind the two schedulers above use.
+        // Registered before launch finishes and permitted in project.yml, or iOS never delivers it.
+        RescoreBackgroundScheduler.register { [weak model] in
+            await model?.runDeferredRescoreIfOwed()
+        }
         let bridge = HealthKitBridge(
             repo: model.repo,
             appleDeviceId: model.appleDeviceId,
@@ -259,6 +269,10 @@ struct StrandiOSApp: App {
                 // (BackfillPolicy.shouldRun's .foreground case), so this is a safe no-op on rapid re-opens.
                 model.ble.requestSync(.foreground)
                 Task {
+                    // #1538: a pass an earlier background attempt could not finish should not wait on the
+                    // 15-minute idle tick now that there is a foreground with no suspension deadline. A
+                    // no-op unless one is genuinely outstanding.
+                    await model.runDeferredRescoreIfOwed()
                     health.refreshAuthIfPreviouslyGranted()
                     HealthWritebackBackgroundScheduler.updateSchedule(
                         isAuthorized: health.auth == .authorized)

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -268,11 +268,18 @@ struct StrandiOSApp: App {
                 // timer or an incidental reconnect. Floored at 90s and never clock/empty-streak-suppressed
                 // (BackfillPolicy.shouldRun's .foreground case), so this is a safe no-op on rapid re-opens.
                 model.ble.requestSync(.foreground)
+                // #1538: settle a re-score an earlier background attempt could not finish, rather than
+                // waiting on the 15-minute idle tick now that there is a foreground with no suspension
+                // deadline. A no-op unless one is genuinely outstanding.
+                //
+                // Its OWN task, deliberately. This pass is minutes long on the installs that need it —
+                // that is the whole reason it was deferred — and the sequential block below owns Health
+                // sync, the widget snapshot and the watch push. Awaiting it there would leave the widget
+                // and the watch showing stale numbers for the entire re-score every time the app is
+                // opened, which is a worse regression than the bug being fixed. `analyzeRecent`
+                // serialises itself, so overlapping with the sync this foreground also kicks off is safe.
+                Task { await model.runDeferredRescoreIfOwed() }
                 Task {
-                    // #1538: a pass an earlier background attempt could not finish should not wait on the
-                    // 15-minute idle tick now that there is a foreground with no suspension deadline. A
-                    // no-op unless one is genuinely outstanding.
-                    await model.runDeferredRescoreIfOwed()
                     health.refreshAuthIfPreviouslyGranted()
                     HealthWritebackBackgroundScheduler.updateSchedule(
                         isAuthorized: health.auth == .authorized)

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -300,6 +300,13 @@ struct StrandiOSApp: App {
                 // Re-submit on every transition because iOS may discard an old best-effort request.
                 HealthWritebackBackgroundScheduler.updateSchedule(
                     isAuthorized: health.auth == .authorized)
+                // #1538: same reasoning for the re-score continuation, plus one case of its own. A pass
+                // can be left owed with NOTHING scheduled — a foreground pass killed by a force-quit
+                // never runs the deferral path that submits the request, and iOS can discard a request
+                // that was submitted. Without this the work would wait for the next offload to defer it
+                // or the next launch to drain it. Re-submitting on the way out costs nothing when
+                // nothing is owed, because it is skipped entirely.
+                if RescoreBackgroundScheduler.isRescoreOwed { RescoreBackgroundScheduler.schedule() }
                 // #114: capture the LAST in-app live state on the way out so the Home widget matches what
                 // the user just saw — its battery/HR/score otherwise lag to the last FOREGROUND refreshSeq
                 // bump. One reload per app-exit is low-frequency and well within WidgetKit's daily budget.

--- a/StrandiOS/Resources/Info.plist
+++ b/StrandiOS/Resources/Info.plist
@@ -8,6 +8,7 @@
 	<array>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER).debugexport</string>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER).healthwriteback</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).rescore</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
@@ -81,6 +82,7 @@
 		<string>bluetooth-central</string>
 		<string>location</string>
 		<string>fetch</string>
+		<string>processing</string>
 	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>

--- a/project.yml
+++ b/project.yml
@@ -264,13 +264,22 @@ targets:
           # launch in StrandiOSApp.init) or the submit fails gracefully and only the foreground/"Run now"
           # paths run.
           - fetch
-        # Permit both BGAppRefreshTask identifiers. Each derives from Bundle.main at runtime so it
+          # #1538: the re-score continuation submits a BGProcessingTaskRequest, which needs the
+          # "processing" mode — "fetch" only covers the metered BGAppRefresh kind. A strap offload
+          # completes while backgrounded and the pass it triggers ran to nearly eight minutes on the
+          # reporter's install, which no bluetooth-central wake survives; a processing task is the long,
+          # deferrable kind that can finish it.
+          - processing
+        # Permit every background-task identifier. Each derives from Bundle.main at runtime so it
         # tracks BUNDLE_ID_PREFIX, and each is registered from StrandiOSApp.init before launch finishes.
         BGTaskSchedulerPermittedIdentifiers:
           - $(PRODUCT_BUNDLE_IDENTIFIER).debugexport
           # Best-effort fallback that writes already-banked WHOOP data to HealthKit when iOS grants
           # background time. Fresh offloads also write immediately from their completion hook.
           - $(PRODUCT_BUNDLE_IDENTIFIER).healthwriteback
+          # #1538: finishes a re-score that a backgrounded offload started and could not complete. The
+          # only BGProcessingTask of the three; the other two are refresh tasks.
+          - $(PRODUCT_BUNDLE_IDENTIFIER).rescore
         NSBluetoothAlwaysUsageDescription: "NOOP connects directly to your WHOOP strap over Bluetooth to read heart rate, R-R intervals, battery, and sensor data locally on your iPhone. Nothing leaves your device."
         NSLocationWhenInUseUsageDescription: "NOOP records your route during an outdoor workout to show distance, pace, and a map, and keeps recording while the screen is off. The route stays on your device. Nothing leaves it."
         NSHealthShareUsageDescription: "NOOP reads your own Apple Health data on-device to compute recovery, strain, and sleep. Nothing leaves your device."


### PR DESCRIPTION
The substantive half of #1538. Reported by @justinjor-bit with the measurements that made it findable.

## The livelock

A completed offload rescores immediately, and on iOS that routinely happens while the app is **backgrounded** — it stays alive as a `bluetooth-central` to receive the offload at all. But `analyzeRecent` is all-or-nothing: pass 1 writes nothing, every store write lands after both loops, and the watermark advances only at the very end so an interrupted run can never mark unscored data as scored. On the reporter's install the pass measured **474,778 ms**. iOS suspends the process long before that, so every scored night was lost.

The lost work was not the worst of it:

> pass is killed → watermark unchanged → next trigger still sees `newData=yes` → starts another full pass → killed → …

**This is visible in the reporter's own log.** Every offload after 05:40:31 said `caught up` with nothing left to fetch, yet 06:01:55 and 06:29:47 both read `newData=yes`. They should have read `no`. Failing to finish is precisely what guaranteed the work would be attempted again. The score appeared **1 h 57 m** after the data was complete, and only because the app happened to stay foregrounded for eight unbroken minutes.

## The fix: decide before spending anything

| Situation | Decision |
|---|---|
| Foreground | **run** — no suspension deadline; existing behaviour is correct |
| Background, nothing owed, last pass fits the budget | **run**, under an execution assertion |
| Background, a re-score already owed | **defer** — something better placed will run it |
| Background, last completed pass over budget | **defer** |

Deferred work is marked owed and handed to a **`BGProcessingTask`** — the long, deferrable kind, not the metered `BGAppRefreshTask` the two existing schedulers use. Whichever comes first, that task or the next foreground, settles the debt.

The measurement is **taken, not guessed**: a completed pass banks its own duration, because the cost varies by more than an order of magnitude with history size and a constant would either defer installs that finish comfortably or wave through ones that never could. **Unknown is never read as "too slow"** — no measurement, a zero, a NaN, or a nonsensical budget all fall through to running, since refusing to score on a value we cannot interpret is a far worse failure than one wasted pass.

## Every path that can start a pass in the background

Review after the first draft found that wrapping the post-offload caller alone was **not enough** — the steady-state backstop could reproduce the whole bug by itself. Both are covered now:

| Caller | Treatment |
|---|---|
| Post-offload (`refreshAfterCompletedBackfill`) | wrapped; a deferral **records a debt** — a completed offload must eventually be scored |
| Idle backstop (`analyzeRecent(force: false)`) | wrapped with `owesOnDefer: false` — a skipped backstop **owes nothing** |
| The five screens (Workouts, Intelligence, Settings, Test Centre, Sleep) | unwrapped — user-initiated from a visible screen, so always foreground, so always run |
| `runDeferredRescoreIfOwed` | deliberately unwrapped — it **is** the deferred run; wrapping it would defer it forever |
| Engine re-arm, `adoptActiveDevice` | direct; both mark the debt via the engine, so a kill still escalates |

The backstop mattered because its loop lives as long as the process, so it keeps ticking while backgrounded as a `bluetooth-central` — and its own watermark gate cannot save it, since a killed pass never advances the watermark. The comment above it already noted the gate also cannot skip while the strap streams live HR. So every 30 minutes it could start a pass that could not finish.

`owesOnDefer: false` for it, because every real update forces its own pass: recording a debt there would send a processing task off to run a forced full pass when most likely nothing changed, which is the churn #1146 exists to avoid. Its log line says `backstop tick skipped`, not `deferred` — nothing is queued, and promising a background task that is not coming would be a lie in the one place #1538 proved the log has to be trusted.

Owed work also gets one more escape: the `scenePhase == .background` transition re-submits the request when something is owed, matching what the Health write-back already does there. Without it, a pass killed by a force-quit — which touches neither the deferral path nor the assertion's expiry handler — had nothing scheduled to run it.

## What this does NOT do

- **It does not make the pass fast.** A cold process still re-scores every night in the window, because the per-day reuse cache is in-memory and starts empty. That is the other half of #1538 and is untouched here.
- **It does not promise a score moments after a sync.** iOS decides when a processing task runs and favours idle and charging. On a heavy install the score still normally appears when the app is next opened.

What changes is that the phone stops paying for a full doomed pass on every offload to get there, and that the work can no longer be silently dropped.

## Parity

**iOS-only, and not a divergence.** Android runs its offload under a `FOREGROUND_SERVICE_CONNECTED_DEVICE`, so its process is not suspended mid-pass and the defect does not exist there. Nothing in the Android tree needed a twin. The scoring path itself is untouched on both platforms — this changes only *where* the work runs.

## Verification

- **20 new tests** across the pure policy and the owed-mark bookkeeping.
- Those tests earned their place: an early version of this change **deferred without marking the debt**, so the background task would have woken, found nothing owed, and **silently dropped the pass** — strictly worse than the livelock it replaced. The deferral branch is unreachable on macOS, so `run` takes an injectable `isBackground` purely so that path can be driven under test. It is pinned now.
- Doc lint and diff-scoped i18n clean.
- `app-build` compiles both app targets **and** runs `StrandTests`.

## Not validated on hardware

Background scheduling cannot be CI-tested or checked on Linux, and CLAUDE.md is explicit that this class of change needs a real device. What needs observing on an iPhone:

1. a backgrounded offload logging `re-score: deferred to a background task — …` instead of a killed pass;
2. the processing task later logging `re-score: resuming a pass an earlier attempt could not finish` followed by a `re-score: done`;
3. no `trigger=` line left without a matching `done` once things settle.

@justinjor-bit — you offered to run an instrumented build. This is the one, if you are still willing. The three lines above are what would confirm or refute it, and a strap log covering one overnight sync would settle it either way.

Partial fix for the background half of #1538; the residual per-pass cache invalidation described there is untouched, so the issue stays open.