### PR TITLE
Correct what the day-cache signature comment claims, on both platforms

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -703,11 +703,27 @@ final class IntelligenceEngine: ObservableObject {
         // scan carries no fresh gate trace). Owner-level eligibility (registered WHOOP) is checked per day.
         let dayCacheEligible = !(sleepTraceActive || hrvTraceActive || stepsTraceActive)
         // The pass config signature — every input that feeds `analyzeDay` but is NOT in the per-day key, so
-        // a change to any of them must invalidate every cached night. All are pass-global 28-night / profile
-        // / toggle values (stable across an offload storm; they move only on a settings/profile/import edit
-        // or at midnight), so the cache survives the back-to-back passes. baselines1 is signed structurally
+        // a change to any of them must invalidate every cached night. baselines1 is signed structurally
         // (any BaselineState field change ⇒ a different string); Doubles by raw bit-pattern (exact, locale-
         // free). Only ever compared to itself in memory, so cross-platform string identity isn't required.
+        //
+        // These are NOT all "stable across an offload storm", as this comment claimed until #1538 went
+        // looking. #1402 already had to fix `baselines1` for exactly that wrong assumption, and three more
+        // fields have the same shape: `sleepNeedHours`, `sleepConsistency` and `habitualMidsleepSec` all
+        // come out of `computeHabitualSleep(windowEnd: now)`, which reads the computed `-noop` sleep
+        // sessions THE PREVIOUS PASS BANKED — a feedback loop from this pass's own output. Any night whose
+        // banked session moves changes them: `sleepConsistency` is 1−CV over 28 nights and
+        // `habitualMidsleepSec` a circular mean, so both shift with ANY night, while `sleepNeedHours` is a
+        // 75th percentile and usually does not.
+        //
+        // But that is CORRECT invalidation, not churn to be quantized away — a night going from
+        // half-loaded to complete really does change what every day should be scored against, and the
+        // swings are large rather than drift, so no tolerance both preserves scores and stops the drop.
+        // What keeps it affordable is that the post-backfill re-score is COALESCED on both platforms: iOS
+        // debounces `lastSyncedAt` by 2 s (#755), Android gates on `analyzeAfterBackfillScheduled` plus a
+        // trailing delay. So this fires once per completed backfill, not once per chunk. That coalescing is
+        // load-bearing for the cache — removing it would reintroduce the #1402 storm in a form no signature
+        // change can fix.
         let dayCacheConfigSig = [
             String(describing: baselines1.hrv),
             String(describing: baselines1.restingHR),

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -543,11 +543,26 @@ object IntelligenceEngine {
         // (sleep/hrv/steps), so cache activation is identical on both platforms. (#1005)
         val dayCacheEligible = sleepTraceSink == null && hrvTraceSink == null && stepsTraceSink == null
         // The pass config signature — every input that feeds `analyzeDay` but is NOT in the per-day key, so a
-        // change to any of them must invalidate every cached night. All are pass-global 28-night / profile /
-        // toggle values (stable across an offload storm; they move only on a settings/profile/import edit or
-        // at midnight), so the cache survives the back-to-back passes. Deterministic within-process strings
+        // change to any of them must invalidate every cached night. Deterministic within-process strings
         // (compared only to itself in memory, so cross-platform identity isn't required); baselines1 is signed
         // via its data-class toString (any field change ⇒ a different string).
+        //
+        // These are NOT all "stable across an offload storm", as this comment claimed until #1538 went
+        // looking. #1402 already had to fix baselines1 for exactly that wrong assumption, and three more
+        // fields have the same shape: sleepNeedHours, sleepConsistency and habitualMidsleepSec all come out
+        // of computeHabitualSleep(windowEnd = now), which reads the computed "-noop" sleep sessions THE
+        // PREVIOUS PASS BANKED — a feedback loop from this pass's own output. Any night whose banked session
+        // moves changes them: sleepConsistency is 1−CV over 28 nights and habitualMidsleepSec a circular
+        // mean, so both shift with ANY night, while sleepNeedHours is a 75th percentile and usually does not.
+        //
+        // But that is CORRECT invalidation, not churn to be quantized away — a night going from half-loaded
+        // to complete really does change what every day should be scored against, and the swings are large
+        // rather than drift, so no tolerance both preserves scores and stops the drop. What keeps it
+        // affordable is that the post-backfill re-score is COALESCED on both platforms: Android gates on
+        // [analyzeAfterBackfillScheduled] plus POST_BACKFILL_ANALYZE_DELAY_MS, iOS debounces lastSyncedAt by
+        // 2 s (#755). So this fires once per completed backfill, not once per chunk. That coalescing is
+        // load-bearing for the cache — removing it would reintroduce the #1402 storm in a form no signature
+        // change can fix.
         val dayCacheConfigSig = listOf(
             baselines1.hrv.toString(), baselines1.restingHR.toString(),
             profile.age.toString(), profile.sex.toString(), profile.stepTicksPerStep.toString(),


### PR DESCRIPTION
I went to fix the "residual cache invalidation" I described on #1538 and found **there is no defect to fix** — only a comment asserting something false, which is what sent me looking in the first place.

## The factual half of the diagnosis holds

`sleepNeedHours`, `sleepConsistency` and `habitualMidsleepSec` all come out of `computeHabitualSleep(windowEnd: now)`, which reads the computed `-noop` sleep sessions **the previous pass banked** — a feedback loop from the pass's own output. So the comment's claim that every signature field is *"stable across an offload storm"* and moves *"only on a settings/profile/import edit or at midnight"* is wrong, exactly as it was wrong about `baselines1` until #1402 fixed that one.

## The prescription was wrong

Quantizing the three — folding a coarse value the way #1402 folded a confidence **tier** instead of a raw value — does not work here, for two independent reasons:

1. **It would not be safe.** `sleepConsistency` is `1−CV` over 28 nights and `habitualMidsleepSec` is a circular mean, so both move with *any* night. Scores would drift from what a fresh pass computes.
2. **It would not even work.** A night going from half-loaded to complete swings those values by far more than any tolerance small enough to keep scores intact. These are large swings, not drift.

`sleepNeedHours` turns out to be a **75th percentile**, so it barely moves at all — it was never the problem.

## And the invalidation is correct

A night going from half-loaded to complete genuinely changes what every day should be scored against. Dropping the cache then is the right behaviour, not churn.

## The load-bearing fact nobody wrote down

What makes it affordable is something neither the comment nor my own #1538 write-up mentioned: **the post-backfill re-score is coalesced on both platforms.** iOS debounces `lastSyncedAt` by 2 s (#755); Android gates on `analyzeAfterBackfillScheduled` plus `POST_BACKFILL_ANALYZE_DELAY_MS`. So the signature changes **once per completed backfill, not once per chunk**.

That coalescing is load-bearing for the day cache and nothing said so. Removing it would reintroduce the #1402 storm in a form no signature change could fix. It is now written down where the next person will look — which is the entire point of this PR.

## Verification

**Comments only.** Verified mechanically that no code line changed on either platform:

```
git diff -U0 | grep '^[+-]' | grep -v '^[+-]\s*//'   →  empty
```

Doc lint clean. No compile risk and no behaviour change, so no `app-build` run — there is nothing for it to validate that a comment could break.

#1538 stays open. The remaining lever there is making the day cache survive a process restart, which is real work and a different change from this one.