### PR TITLE
CLAUDE.md: the CI table said Android was disabled; it has not been

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,11 @@ xcodegen generate && xcodebuild -project Strand.xcodeproj -scheme Strand \
 |---|---|---|---|
 | `swift-packages.yml` | `swift test` for **`Packages/**` only** (WhoopProtocol, WhoopStore, StrandAnalytics, StrandImport, StrandDesign, NoopLocalAccess) | macos-15 | **active** |
 | `app-build.yml` | **Compile-only** of the **app targets** (`Strand` macOS + `NOOPiOS` iOS). iOS leg needs **macos-26** (iOS 26 SDK / `glassEffect`). | macos-15 / macos-26 | **disabled** (on-demand) |
-| `android.yml` | `assembleFullDebug` + `testFullDebugUnitTest` | ubuntu | **disabled** (compile Android locally) |
+| `android.yml` | `assembleFullDebug` + `testFullDebugUnitTest` | ubuntu | **active**, path-filtered to `android/**` |
+| `source-hygiene.yml` | Doc comments that bind to nothing (`Tools/doc_comment_lint.py`) | ubuntu | **active** |
+| `i18n-coverage.yml` | Diff-scoped translation gate (`Tools/i18n_audit.py --ci`) | ubuntu | **active** |
+| `tools-python.yml` | `unittest discover` over `Tools/` and `Tools/linux-capture` | ubuntu | **active**, path-filtered |
+| `prune-stale-branches.yml` | Deletes branches whose PR merged or closed unmerged | ubuntu | **active**, weekly + dispatch |
 | `fork-testing-build.yml` / `fork-release.yml` | Staging / release builds (apk + mac + ios) | — | on dispatch |
 
 **The trap:** `swift-packages` does **NOT** compile the app targets. So if you touch **app-target


### PR DESCRIPTION
The CI table's whole job is telling a contributor what validates their change, and it was wrong about that in two directions.

## `android.yml` is active, not disabled

It is listed as **disabled** *(compile Android locally)*. It is **active**, path-filtered to `android/**`, and has been running `assembleFullDebug` + `testFullDebugUnitTest` on every Android-touching PR.

The green `build-and-test` check on those PRs **is** Android CI. That is easy to misattribute when the table says the workflow is off — which is exactly what happened while writing #1559: I reported the Kotlin change as covered only by a local run, when CI had already built and tested it.

## Three active PR gates were missing entirely

| Workflow | What it can fail a PR for |
|---|---|
| `source-hygiene.yml` | a doc comment that binds to nothing |
| `i18n-coverage.yml` | a new literal or a missing translation |
| `tools-python.yml` | the `Tools/` suites |

All three gate pull requests. None appeared in the one place a contributor is told what runs. `prune-stale-branches.yml` is listed too, since it acts on the repo on a schedule.

Every workflow in `.github/workflows` is now in the table, checked against the live workflow states rather than transcribed from the old text.

## Left alone deliberately

`app-build.yml` really is `disabled_manually`. That row and the **trap** paragraph under it — the warning that no default CI compiles app-target Swift — are both still accurate, and still the most important thing on that page. Nothing here softens them.

Docs only.