### PR TITLE
Give Banister TRIMP its own log-map denominator

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StrainScorer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StrainScorer.swift
@@ -53,6 +53,27 @@ public enum StrainScorer {
     public static let strainDenominator: Double = 7201.0
     static var lnStrainDenominator: Double { log(strainDenominator) }
 
+    /// Banister's daily ceiling: 24 h held at ΔHRR = 1.0. Unlike Edwards' 7200 this is SEX-DEPENDENT,
+    /// because the exponent `b` differs — which is the whole reason `strainDenominator` cannot be reused
+    /// for it. Feeding Banister TRIMP through the Edwards denominator would score every day against a
+    /// ceiling ~14% (men) or ~32% (women) higher than Banister can actually reach, so nobody would ever
+    /// see 100 and the two methods would not be on the same axis. (#1545)
+    static func banisterDailyCeiling(b: Double) -> Double {
+        24.0 * 60.0 * 1.0 * banisterScale * exp(b)
+    }
+
+    /// The log-map denominator for a method, so a caller never has to know which constant belongs to
+    /// which recipe. Ceiling + 1 in both cases, mirroring how `strainDenominator` was derived, so a
+    /// theoretical maximum day maps to exactly `maxStrain` under either method.
+    public static func logMapDenominator(method: Method, sex: String) -> Double {
+        switch method {
+        case .edwards:
+            return strainDenominator
+        case .banister:
+            return banisterDailyCeiling(b: sex.lowercased().hasPrefix("f") ? banisterBWomen : banisterBMen) + 1.0
+        }
+    }
+
     /// Fallback per-sample duration (minutes) — 1 s at 1 Hz.
     static let fallbackSampleMin: Double = 1.0 / 60.0
 
@@ -266,13 +287,17 @@ public enum StrainScorer {
     ///   - restingHR: resting HR (bpm) for the HRR denominator (default 60).
     ///   - method: `.edwards` (default) or `.banister`.
     ///   - sex: "male"/"female" — selects the Banister coefficient (ignored by Edwards).
-    ///   - denominator: log-map D (default STRAIN_DENOMINATOR).
+    ///   - denominator: log-map D. `nil` (the default) resolves to the denominator that BELONGS to
+    ///     `method` — Edwards' 7201, or Banister's sex-dependent ceiling. Pass a value only to override.
     public static func strain(_ hr: [HRSample],
                               maxHR: Double? = nil,
                               restingHR: Double = defaultRestingHR,
                               method: Method = .edwards,
                               sex: String = "male",
-                              denominator: Double = strainDenominator) -> Double? {
+                              denominator: Double? = nil) -> Double? {
+        // Resolve BEFORE the memo key is built, or a Banister request would be cached under Edwards'
+        // denominator and a later Edwards request could collide with it.
+        let resolvedDenominator = denominator ?? logMapDenominator(method: method, sex: sex)
         // v7.0.2 perf (#707): TRIMP integrates over the day's HR stream; called once per day in the post-sync
         // scoring loop AND from the Today view (which re-reads on each live-HR tick). Memoize on the HR
         // fingerprint + every scalar that steers the score, so an identical re-request is a lookup. The
@@ -280,9 +305,10 @@ public enum StrainScorer {
         let key = StrainKey(
             hr: StreamFingerprint.of(hr, ts: { $0.ts }, quant: { Int($0.bpm) }),
             maxHR: maxHR, restingHR: restingHR, method: method,
-            sexF: sex.lowercased().hasPrefix("f"), denom: denominator)
+            sexF: sex.lowercased().hasPrefix("f"), denom: resolvedDenominator)
         return strainCache.value(key) {
-            strainUncached(hr, maxHR: maxHR, restingHR: restingHR, method: method, sex: sex, denominator: denominator)
+            strainUncached(hr, maxHR: maxHR, restingHR: restingHR, method: method, sex: sex,
+                           denominator: resolvedDenominator)
         }
     }
 

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StrainScorer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StrainScorer.swift
@@ -21,7 +21,10 @@ import WhoopProtocol
 //           (1..5 at 50/60/70/80/90 %HRR cut-offs) × duration.
 //        b. Banister exponential: sample contributes duration × x × 0.64 × e^(b·x).
 //   4. Logarithmic compression onto [0, 100]:
-//        strain = 100 × ln(TRIMP + 1) / ln(D),  D = STRAIN_DENOMINATOR.
+//        strain = 100 × ln(TRIMP + 1) / ln(D)
+//      D belongs to the METHOD, not to the scorer: Edwards uses `strainDenominator` (7201, from its
+//      sex-independent 7200 ceiling), Banister its own sex-dependent ceiling + 1. See
+//      `logMapDenominator(method:sex:)` — reusing one for the other silently rescales the axis (#1545).
 //
 // References: Karvonen 1957 (%HRR); Edwards 1993 (5-zone TRIMP); Banister 1991
 // (exponential TRIMP, b = 1.92 men / 1.67 women); Tanaka 2001 (HRmax = 208 − 0.7×age).
@@ -243,6 +246,10 @@ public enum StrainScorer {
 
     /// Map accumulated TRIMP onto [0, 100] via 100 × ln(TRIMP+1) / ln(D), 2 dp.
     /// TRIMP ≤ 0 → 0.
+    ///
+    /// The default D is **Edwards'**. A Banister TRIMP passed here without an explicit denominator is
+    /// scored against the wrong ceiling and reads low — prefer `strain(…)`, which resolves the
+    /// method's own denominator, or pass `logMapDenominator(method:sex:)` yourself. (#1545)
     public static func trimpToStrain(_ trimp: Double, denominator: Double = strainDenominator) -> Double {
         if trimp <= 0 { return 0 }
         let value = maxStrain * log(trimp + 1.0) / log(denominator)

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainBanisterDenominatorTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainBanisterDenominatorTests.swift
@@ -1,5 +1,7 @@
 import XCTest
+import Foundation
 @testable import StrandAnalytics
+import WhoopProtocol
 
 /// #1545: Banister TRIMP needs its OWN log-map denominator, and the reason is easy to get wrong.
 ///

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainBanisterDenominatorTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainBanisterDenominatorTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// #1545: Banister TRIMP needs its OWN log-map denominator, and the reason is easy to get wrong.
+///
+/// `strainDenominator` (7201) is derived from *Edwards'* daily ceiling — top zone weight 5 sustained for
+/// 24 h = 7200 — so `ln(7201)/ln(7201) = 1` puts a theoretical maximum day at exactly 100. Banister
+/// accumulates on a completely different scale, and its ceiling is **sex-dependent** because the exponent
+/// differs. Reusing 7201 would quietly score every Banister day against a ceiling it cannot reach.
+///
+/// These pin the derivation itself. Whether the method is ever *selected* is a separate question; the
+/// arithmetic has to be right first, and it is provable without a device.
+final class StrainBanisterDenominatorTests: XCTestCase {
+
+    private let d = 1e-9
+
+    // MARK: - The derivation
+
+    /// Ceiling = 24 h × ΔHRR 1.0 × 0.64 × e^b, stated independently of the implementation.
+    func testTheDailyCeilingIsTwentyFourHoursAtFullReserve() {
+        XCTAssertEqual(StrainScorer.banisterDailyCeiling(b: StrainScorer.banisterBMen),
+                       1440.0 * 0.64 * exp(1.92), accuracy: d)
+        XCTAssertEqual(StrainScorer.banisterDailyCeiling(b: StrainScorer.banisterBWomen),
+                       1440.0 * 0.64 * exp(1.67), accuracy: d)
+    }
+
+    /// The denominator is ceiling + 1, exactly as `strainDenominator` was derived from 7200.
+    func testTheDenominatorIsCeilingPlusOne() {
+        XCTAssertEqual(StrainScorer.logMapDenominator(method: .banister, sex: "male"),
+                       StrainScorer.banisterDailyCeiling(b: StrainScorer.banisterBMen) + 1.0, accuracy: d)
+        XCTAssertEqual(StrainScorer.logMapDenominator(method: .banister, sex: "female"),
+                       StrainScorer.banisterDailyCeiling(b: StrainScorer.banisterBWomen) + 1.0, accuracy: d)
+    }
+
+    /// The property the whole derivation exists for: a theoretical maximum day maps to exactly 100 under
+    /// EITHER method, so the two are on the same axis and a user switching between them is not silently
+    /// rescaled.
+    func testAMaximumDayIsOneHundredUnderBothMethods() {
+        let edwards = StrainScorer.trimpToStrain(7200, denominator: StrainScorer.strainDenominator)
+        XCTAssertEqual(edwards, 100.0, accuracy: 1e-6)
+
+        for sex in ["male", "female"] {
+            let b = sex == "female" ? StrainScorer.banisterBWomen : StrainScorer.banisterBMen
+            let ceiling = StrainScorer.banisterDailyCeiling(b: b)
+            let mapped = StrainScorer.trimpToStrain(
+                ceiling, denominator: StrainScorer.logMapDenominator(method: .banister, sex: sex))
+            XCTAssertEqual(mapped, 100.0, accuracy: 1e-6, "\(sex) ceiling should map to the top of the scale")
+        }
+    }
+
+    /// Sex matters, and in the direction the coefficients imply: the smaller exponent gives the lower
+    /// ceiling, so a woman's denominator is the smaller of the two.
+    func testTheFemaleDenominatorIsSmaller() {
+        let male = StrainScorer.logMapDenominator(method: .banister, sex: "male")
+        let female = StrainScorer.logMapDenominator(method: .banister, sex: "female")
+        XCTAssertLessThan(female, male)
+        // "f", "F", "Female" all select it — the same prefix rule the scorer itself uses.
+        for spelling in ["f", "F", "Female", "female"] {
+            XCTAssertEqual(StrainScorer.logMapDenominator(method: .banister, sex: spelling), female, accuracy: d)
+        }
+    }
+
+    // MARK: - Why reusing Edwards' denominator would be wrong
+
+    /// The bug this guards against. With 7201 a maximum Banister day lands well short of 100 — nobody
+    /// would ever see the top of the scale, and the shortfall differs by sex, so the two would not even
+    /// be wrong in the same way.
+    func testEdwardsDenominatorWouldCapBanisterBelowFull() {
+        for sex in ["male", "female"] {
+            let b = sex == "female" ? StrainScorer.banisterBWomen : StrainScorer.banisterBMen
+            let wrong = StrainScorer.trimpToStrain(StrainScorer.banisterDailyCeiling(b: b),
+                                                   denominator: StrainScorer.strainDenominator)
+            XCTAssertLessThan(wrong, 99.0, "\(sex): reusing 7201 should visibly under-score, and does")
+            XCTAssertGreaterThan(wrong, 90.0, "\(sex): but not so far off that it looks obviously broken")
+        }
+    }
+
+    // MARK: - Edwards is untouched
+
+    /// The default is still Edwards and still resolves to 7201, so nothing about existing scores moves.
+    func testEdwardsIsUnchangedAndStillTheDefault() {
+        XCTAssertEqual(StrainScorer.logMapDenominator(method: .edwards, sex: "male"),
+                       StrainScorer.strainDenominator, accuracy: d)
+        XCTAssertEqual(StrainScorer.logMapDenominator(method: .edwards, sex: "female"),
+                       StrainScorer.strainDenominator, accuracy: d)
+
+        // A real scoring call with no method argument must land on Edwards, byte-for-byte.
+        let samples = (0 ..< 900).map { HRSample(ts: $0, bpm: 150) }
+        let implicitDefault = StrainScorer.strain(samples, maxHR: 190, restingHR: 60)
+        let explicitEdwards = StrainScorer.strain(samples, maxHR: 190, restingHR: 60, method: .edwards)
+        XCTAssertNotNil(implicitDefault)
+        XCTAssertEqual(implicitDefault!, explicitEdwards!, accuracy: 1e-12)
+    }
+
+    // MARK: - The behaviour #1545 asked about
+
+    /// The claim under the request: an intermittent session — hard sets with recovery between — is
+    /// scored relatively higher by Banister than by Edwards, because Edwards pays **nothing** below 50%
+    /// HRR while Banister's exponential still credits it and weights the peaks far more heavily.
+    ///
+    /// Compared as a RATIO against a steady moderate session of the same length, because the two methods
+    /// have different natural magnitudes and comparing raw scores across them would prove nothing.
+    func testIntermittentWorkFaresBetterUnderBanister() {
+        // 60 min. Lifting: 30 s at 85% HRR, then 150 s at 40% — repeated. Walking: a flat 58%.
+        let rest = 60.0, max = 190.0, reserve = max - rest
+        func bpm(_ pctHRR: Double) -> Int { Int((rest + reserve * pctHRR / 100.0).rounded()) }
+        var lifting: [HRSample] = [], walking: [HRSample] = []
+        for t in 0 ..< 3600 {
+            lifting.append(HRSample(ts: t, bpm: (t % 180) < 30 ? bpm(85) : bpm(40)))
+            walking.append(HRSample(ts: t, bpm: bpm(58)))
+        }
+
+        let liftEd = StrainScorer.strain(lifting, maxHR: max, restingHR: rest, method: .edwards)!
+        let walkEd = StrainScorer.strain(walking, maxHR: max, restingHR: rest, method: .edwards)!
+        let liftBa = StrainScorer.strain(lifting, maxHR: max, restingHR: rest, method: .banister)!
+        let walkBa = StrainScorer.strain(walking, maxHR: max, restingHR: rest, method: .banister)!
+
+        // Edwards: the walk out-scores the lifting outright — exactly the report in #1545.
+        XCTAssertGreaterThan(walkEd, liftEd, "Edwards should favour the steady session; that is the complaint")
+        // Banister: the lifting session closes the gap substantially.
+        XCTAssertGreaterThan(liftBa / walkBa, liftEd / walkEd,
+                             "Banister should rate the intermittent session relatively higher")
+    }
+
+    /// The mechanism that actually explains #1545, and it is NOT the exponential weighting of peaks.
+    ///
+    /// Edwards pays **zero** below 50% HRR. A session that sits just under that floor — which is what an
+    /// hour of lifting looks like for plenty of people once the sets are averaged against the rests —
+    /// scores literally nothing, no matter how long it lasts. Banister has no floor, so the same hour
+    /// scores in the same range as a moderate walk.
+    ///
+    /// This is the difference between "the metric under-rates lifting" and "the metric cannot see it at
+    /// all", and it is the one worth showing.
+    func testASessionBelowTheFiftyPercentFloorScoresNothingUnderEdwards() {
+        let rest = 60.0, max = 190.0
+        let bpm = Int((rest + (max - rest) * 0.45).rounded())   // a flat 45% HRR — just under the floor
+        let hour = (0 ..< 3600).map { HRSample(ts: $0, bpm: bpm) }
+
+        let edwards = StrainScorer.strain(hour, maxHR: max, restingHR: rest, method: .edwards)
+        let banister = StrainScorer.strain(hour, maxHR: max, restingHR: rest, method: .banister)
+
+        XCTAssertEqual(edwards, 0.0, "an hour below the floor earns nothing under Edwards, by design")
+        XCTAssertNotNil(banister)
+        XCTAssertGreaterThan(banister!, 40.0, "Banister credits the same hour on the 0–100 axis")
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/StrainScorer.kt
+++ b/android/app/src/main/java/com/noop/analytics/StrainScorer.kt
@@ -69,6 +69,26 @@ object StrainScorer {
      * pure linear scaling of the whole curve).
      */
     const val strainDenominator: Double = 7201.0
+
+    /**
+     * Banister's daily ceiling: 24 h held at ΔHRR = 1.0. Unlike Edwards' 7200 this is SEX-DEPENDENT,
+     * because the exponent `b` differs — which is the whole reason [strainDenominator] cannot be reused
+     * for it. Feeding Banister TRIMP through the Edwards denominator would score every day against a
+     * ceiling ~14% (men) or ~32% (women) higher than Banister can actually reach, so nobody would ever
+     * see 100 and the two methods would not be on the same axis. (#1545)
+     */
+    fun banisterDailyCeiling(b: Double): Double = 24.0 * 60.0 * 1.0 * banisterScale * kotlin.math.exp(b)
+
+    /**
+     * The log-map denominator for a method, so a caller never has to know which constant belongs to
+     * which recipe. Ceiling + 1 in both cases, mirroring how [strainDenominator] was derived, so a
+     * theoretical maximum day maps to exactly [maxStrain] under either method.
+     */
+    fun logMapDenominator(method: Method, sex: String): Double = when (method) {
+        Method.EDWARDS -> strainDenominator
+        Method.BANISTER ->
+            banisterDailyCeiling(if (sex.lowercase().startsWith("f")) banisterBWomen else banisterBMen) + 1.0
+    }
     val lnStrainDenominator: Double get() = ln(strainDenominator)
 
     /** Fallback per-sample duration (minutes) — 1 s at 1 Hz. */
@@ -319,8 +339,11 @@ object StrainScorer {
         restingHR: Double = defaultRestingHR,
         method: Method = Method.EDWARDS,
         sex: String = "male",
-        denominator: Double = strainDenominator,
+        // null (the default) resolves to the denominator that BELONGS to [method] — Edwards' 7201, or
+        // Banister's sex-dependent ceiling. Pass a value only to override.
+        denominator: Double? = null,
     ): Double? {
+        val resolvedDenominator = denominator ?: logMapDenominator(method, sex)
         val effMax = maxHR ?: defaultMaxHR().toDouble()
         // Enough data to trust the score: a dense stream (≥ minReadings) OR a sparse-but-sustained
         // one spanning ≥ minSpanSeconds with a sample floor (#482 — the 5/MG's ~30 s HR cadence).
@@ -346,6 +369,6 @@ object StrainScorer {
                 edwardsTRIMP(hr, restingHR, hrReserve, durations)
             }
         }
-        return trimpToStrain(trimp, denominator)
+        return trimpToStrain(trimp, resolvedDenominator)
     }
 }

--- a/android/app/src/main/java/com/noop/analytics/StrainScorer.kt
+++ b/android/app/src/main/java/com/noop/analytics/StrainScorer.kt
@@ -28,7 +28,10 @@ import kotlin.math.roundToLong
  *           (1..5 at 50/60/70/80/90 %HRR cut-offs) × duration.
  *        b. Banister exponential: sample contributes duration × x × 0.64 × e^(b·x).
  *   4. Logarithmic compression onto [0, 100]:
- *        effort = 100 × ln(TRIMP + 1) / ln(D),  D = STRAIN_DENOMINATOR.
+ *        effort = 100 × ln(TRIMP + 1) / ln(D)
+ *      D belongs to the METHOD, not to the scorer: Edwards uses [strainDenominator] (7201, from its
+ *      sex-independent 7200 ceiling), Banister its own sex-dependent ceiling + 1. See
+ *      [logMapDenominator] — reusing one for the other silently rescales the axis (#1545).
  *
  * References: Karvonen 1957 (%HRR); Edwards 1993 (5-zone TRIMP); Banister 1991
  * (exponential TRIMP, b = 1.92 men / 1.67 women); Tanaka 2001 (HRmax = 208 − 0.7×age).
@@ -288,6 +291,10 @@ object StrainScorer {
     /**
      * Map accumulated TRIMP onto [0, 100] via 100 × ln(TRIMP+1) / ln(D), 2 dp.
      * TRIMP ≤ 0 → 0.
+     *
+     * The default D is **Edwards'**. A Banister TRIMP passed here without an explicit denominator is
+     * scored against the wrong ceiling and reads low — prefer [strain], which resolves the method's own
+     * denominator, or pass [logMapDenominator] yourself. (#1545)
      */
     fun trimpToStrain(trimp: Double, denominator: Double = strainDenominator): Double {
         if (trimp <= 0) return 0.0

--- a/android/app/src/test/java/com/noop/analytics/StrainBanisterDenominatorTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StrainBanisterDenominatorTest.kt
@@ -1,0 +1,159 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.exp
+import kotlin.math.roundToInt
+
+/**
+ * #1545: Banister TRIMP needs its OWN log-map denominator, and the reason is easy to get wrong.
+ *
+ * [StrainScorer.strainDenominator] (7201) is derived from *Edwards'* daily ceiling — top zone weight 5
+ * sustained for 24 h = 7200 — so ln(7201)/ln(7201) = 1 puts a theoretical maximum day at exactly 100.
+ * Banister accumulates on a completely different scale, and its ceiling is SEX-DEPENDENT because the
+ * exponent differs. Reusing 7201 would quietly score every Banister day against a ceiling it cannot reach.
+ *
+ * Byte-parity twin of Swift `StrainBanisterDenominatorTests`.
+ */
+class StrainBanisterDenominatorTest {
+
+    private val eps = 1e-9
+
+    private fun hr(bpm: Int, n: Int) = (0 until n).map { HrSample(deviceId = "t", ts = it.toLong(), bpm = bpm) }
+
+    // ── The derivation ──────────────────────────────────────────────────────────────────────────
+
+    /** Ceiling = 24 h × ΔHRR 1.0 × 0.64 × e^b, stated independently of the implementation. */
+    @Test
+    fun theDailyCeilingIsTwentyFourHoursAtFullReserve() {
+        assertEquals(1440.0 * 0.64 * exp(1.92),
+            StrainScorer.banisterDailyCeiling(StrainScorer.banisterBMen), eps)
+        assertEquals(1440.0 * 0.64 * exp(1.67),
+            StrainScorer.banisterDailyCeiling(StrainScorer.banisterBWomen), eps)
+    }
+
+    /** The denominator is ceiling + 1, exactly as [StrainScorer.strainDenominator] was derived from 7200. */
+    @Test
+    fun theDenominatorIsCeilingPlusOne() {
+        assertEquals(StrainScorer.banisterDailyCeiling(StrainScorer.banisterBMen) + 1.0,
+            StrainScorer.logMapDenominator(StrainScorer.Method.BANISTER, "male"), eps)
+        assertEquals(StrainScorer.banisterDailyCeiling(StrainScorer.banisterBWomen) + 1.0,
+            StrainScorer.logMapDenominator(StrainScorer.Method.BANISTER, "female"), eps)
+    }
+
+    /**
+     * The property the whole derivation exists for: a theoretical maximum day maps to exactly 100 under
+     * EITHER method, so the two are on the same axis and a user switching between them is not silently
+     * rescaled.
+     */
+    @Test
+    fun aMaximumDayIsOneHundredUnderBothMethods() {
+        assertEquals(100.0, StrainScorer.trimpToStrain(7200.0, StrainScorer.strainDenominator), 1e-6)
+        for (sex in listOf("male", "female")) {
+            val b = if (sex == "female") StrainScorer.banisterBWomen else StrainScorer.banisterBMen
+            val ceiling = StrainScorer.banisterDailyCeiling(b)
+            assertEquals("$sex ceiling should map to the top of the scale", 100.0,
+                StrainScorer.trimpToStrain(
+                    ceiling, StrainScorer.logMapDenominator(StrainScorer.Method.BANISTER, sex)), 1e-6)
+        }
+    }
+
+    /** The smaller exponent gives the lower ceiling, so a woman's denominator is the smaller of the two. */
+    @Test
+    fun theFemaleDenominatorIsSmaller() {
+        val male = StrainScorer.logMapDenominator(StrainScorer.Method.BANISTER, "male")
+        val female = StrainScorer.logMapDenominator(StrainScorer.Method.BANISTER, "female")
+        assertTrue("female $female should be below male $male", female < male)
+        for (spelling in listOf("f", "F", "Female", "female")) {
+            assertEquals(female, StrainScorer.logMapDenominator(StrainScorer.Method.BANISTER, spelling), eps)
+        }
+    }
+
+    // ── Why reusing Edwards' denominator would be wrong ─────────────────────────────────────────
+
+    /**
+     * The bug this guards against. With 7201 a maximum Banister day lands well short of 100 — nobody
+     * would ever see the top of the scale, and the shortfall differs by sex, so the two would not even be
+     * wrong in the same way.
+     */
+    @Test
+    fun edwardsDenominatorWouldCapBanisterBelowFull() {
+        for (sex in listOf("male", "female")) {
+            val b = if (sex == "female") StrainScorer.banisterBWomen else StrainScorer.banisterBMen
+            val wrong = StrainScorer.trimpToStrain(
+                StrainScorer.banisterDailyCeiling(b), StrainScorer.strainDenominator)
+            assertTrue("$sex: reusing 7201 should visibly under-score, and does ($wrong)", wrong < 99.0)
+            assertTrue("$sex: but not so far off that it looks obviously broken ($wrong)", wrong > 90.0)
+        }
+    }
+
+    // ── Edwards is untouched ────────────────────────────────────────────────────────────────────
+
+    /** The default is still Edwards and still resolves to 7201, so nothing about existing scores moves. */
+    @Test
+    fun edwardsIsUnchangedAndStillTheDefault() {
+        assertEquals(StrainScorer.strainDenominator,
+            StrainScorer.logMapDenominator(StrainScorer.Method.EDWARDS, "male"), eps)
+        assertEquals(StrainScorer.strainDenominator,
+            StrainScorer.logMapDenominator(StrainScorer.Method.EDWARDS, "female"), eps)
+
+        val samples = hr(150, 900)
+        val implicitDefault = StrainScorer.strain(samples, maxHR = 190.0, restingHR = 60.0)
+        val explicitEdwards = StrainScorer.strain(
+            samples, maxHR = 190.0, restingHR = 60.0, method = StrainScorer.Method.EDWARDS)
+        assertNotNull(implicitDefault)
+        assertEquals(explicitEdwards!!, implicitDefault!!, 1e-12)
+    }
+
+    // ── The behaviour #1545 asked about ─────────────────────────────────────────────────────────
+
+    /**
+     * The claim under the request: an intermittent session — hard sets with recovery between — is scored
+     * relatively higher by Banister than by Edwards. Compared as a RATIO against a steady session of the
+     * same length, because the two methods have different natural magnitudes.
+     */
+    @Test
+    fun intermittentWorkFaresBetterUnderBanister() {
+        val rest = 60.0; val max = 190.0; val reserve = max - rest
+        fun bpm(pctHRR: Double) = (rest + reserve * pctHRR / 100.0).roundToInt()
+        val lifting = (0 until 3600).map {
+            HrSample("t", it.toLong(), if (it % 180 < 30) bpm(85.0) else bpm(40.0))
+        }
+        val walking = (0 until 3600).map { HrSample("t", it.toLong(), bpm(58.0)) }
+
+        val liftEd = StrainScorer.strain(lifting, max, rest, StrainScorer.Method.EDWARDS)!!
+        val walkEd = StrainScorer.strain(walking, max, rest, StrainScorer.Method.EDWARDS)!!
+        val liftBa = StrainScorer.strain(lifting, max, rest, StrainScorer.Method.BANISTER)!!
+        val walkBa = StrainScorer.strain(walking, max, rest, StrainScorer.Method.BANISTER)!!
+
+        assertTrue("Edwards should favour the steady session; that is the complaint", walkEd > liftEd)
+        assertTrue("Banister should rate the intermittent session relatively higher",
+            liftBa / walkBa > liftEd / walkEd)
+    }
+
+    /**
+     * The mechanism that actually explains #1545, and it is NOT the exponential weighting of peaks.
+     *
+     * Edwards pays ZERO below 50% HRR. A session that sits just under that floor — what an hour of
+     * lifting looks like for plenty of people once the sets are averaged against the rests — scores
+     * literally nothing, however long it lasts. Banister has no floor, so the same hour scores in the
+     * same range as a moderate walk. That is the difference between "the metric under-rates lifting" and
+     * "the metric cannot see it at all".
+     */
+    @Test
+    fun aSessionBelowTheFiftyPercentFloorScoresNothingUnderEdwards() {
+        val rest = 60.0; val max = 190.0
+        val bpm = (rest + (max - rest) * 0.45).roundToInt()   // a flat 45% HRR — just under the floor
+        val hour = hr(bpm, 3600)
+
+        val edwards = StrainScorer.strain(hour, max, rest, StrainScorer.Method.EDWARDS)
+        val banister = StrainScorer.strain(hour, max, rest, StrainScorer.Method.BANISTER)
+
+        assertEquals("an hour below the floor earns nothing under Edwards, by design", 0.0, edwards!!, eps)
+        assertNotNull(banister)
+        assertTrue("Banister credits the same hour on the 0–100 axis ($banister)", banister!! > 40.0)
+    }
+}


### PR DESCRIPTION
Groundwork for the Banister Effort option asked for in #1545, reported by @dofimn. **Pure analytics, no behaviour change** — nothing in production selects Banister, and every existing caller still resolves to Edwards byte-for-byte.

## The thing that had to be right first

`StrainScorer` has implemented Banister TRIMP since it was ported and **nothing has ever selected it** — every call site takes the `.edwards` default. Before it can be offered as an option, the denominator has to be correct, and reusing the existing one would have been silently wrong.

`strainDenominator` (7201) is derived from **Edwards'** daily ceiling — top zone weight 5 sustained 24 h = 7200 — so `ln(7201)/ln(7201) = 1` puts a theoretical maximum day at exactly 100. Banister accumulates on a different scale entirely, and its ceiling is **sex-dependent** because the exponent differs (1.92 men, 1.67 women).

Reusing 7201 for Banister would mean:

| | Max day would read |
|---|---|
| Men | **98.5** |
| Women | **95.7** |

Nobody would ever see the top of the scale, the shortfall would differ by sex, and the two methods would not be on the same axis — so a user switching between them would be silently rescaled.

Banister now gets its own, derived exactly the way Edwards' was: **ceiling + 1**, where `ceiling = 24 h × 1.0 × 0.64 × e^b`.

`strain()` resolves the denominator belonging to the method it was asked for, and resolves it **before the memo key is built** — otherwise a Banister request would be cached under Edwards' denominator and a later Edwards request could collide with it.

## What the tests show about #1545 itself

Two of the eight are about the report rather than the arithmetic. An intermittent session — hard sets with recovery between — is rated relatively higher by Banister than by Edwards, as expected.

But the sharper one is the mechanism that **actually explains the report**:

| One hour held at 45% HRR | Effort |
|---|---|
| Edwards | **0.00** |
| Banister | **≈ 43** / 100 |

Edwards pays **zero** below 50% HRR. An hour that sits just under that floor — what lifting looks like for plenty of people once the sets are averaged against the rests — scores literally nothing, however long it lasts. That is the difference between *"the metric under-rates lifting"* and *"the metric cannot see it at all"*, and it is why the reporter's session read 1.7 rather than the ~8 that Edwards gives a session which does clear the floor.

## What this is NOT

Selecting the method still needs: threading through `analyzeDay`, `WorkoutDetector`, `ManualWorkoutRescore` and the live-Effort recompute on both platforms; a default-off toggle; **its entry in the day-cache config signature** (it changes every day's score, so omitting it would serve stale cached days); and Settings copy in twelve locale files.

Those follow. The arithmetic had to be provable on its own first — it is the part that needs no device, and the part most likely to be quietly wrong.

## Verification

- Android **4,237 tests, 0 failures** (`--no-build-cache --rerun-tasks`) — 4,229 matching main plus the 8 new.
- The Swift twin runs in `swift-packages` CI, which covers `Packages/**` automatically.
- Doc lint clean. Grepped to confirm **nothing** in production selects Banister, so the default is off by construction rather than by a flag.

Partial work on #1545; that issue stays open.