### PR TITLE
Wire the Effort TRIMP method end to end on both platforms

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -451,7 +451,15 @@ public enum AnalyticsEngine {
                                   // #141: when true, the nightly HRV is RMSSD over DEEP-sleep windows only
                                   // (WHOOP-style), instead of the whole-night mean. Threaded from the caller
                                   // (UnitPrefs.hrvWindowKey). Default false = byte-identical whole-night value.
-                                  deepHrvWindow: Bool = false) -> DayResult {
+                                  deepHrvWindow: Bool = false,
+                                  // #1545: which TRIMP recipe scores Effort. Edwards (the default) is
+                                  // time-in-zone and pays NOTHING below 50% HRR, so intermittent work —
+                                  // a lifting session, once the sets are averaged against the rests —
+                                  // can score near zero however long it lasts. Banister is exponential in
+                                  // %HRR with no floor. Threaded rather than read from a global so this
+                                  // stays a pure function, and defaulted so every existing caller and
+                                  // test is byte-identical.
+                                  effortMethod: StrainScorer.Method = .edwards) -> DayResult {
 
         // Precompute the day's UTC bounds ONCE (#996). `dayString(ts, offsetSec:)` formats the UTC
         // calendar day of (ts + offset) with a FIXED offset, so "== day" is exactly membership in
@@ -788,7 +796,7 @@ public enum AnalyticsEngine {
         let effMaxHR: Double? = maxHROverride ?? (profile.age > 0 ? StrainScorer.tanakaHRmax(age: profile.age) : nil)
         let restForStrain = restingHRDaily.map(Double.init) ?? StrainScorer.defaultRestingHR
         let strain = StrainScorer.strain(dayHr ?? hr, maxHR: effMaxHR, restingHR: restForStrain,
-                                         sex: profile.sex)
+                                         method: effortMethod, sex: profile.sex)
 
         // ── Workouts ──────────────────────────────────────────────────────────
         // Detect over the full CALENDAR day (dayHr/dayGravity) when the caller supplies it, so a
@@ -801,7 +809,11 @@ public enum AnalyticsEngine {
             restingHR: restingHRDaily.map(Double.init),
             maxHR: maxHROverride,
             age: profile.age > 0 ? profile.age : nil,
-            profile: profile)
+            profile: profile,
+            // #1545: the bouts inside a day MUST be scored by the same recipe as the day itself.
+            // A day on Banister whose workouts were still on Edwards would show a session scoring
+            // less than the day it sits inside, which is a worse inconsistency than either method.
+            effortMethod: effortMethod)
 
         // ── Steps (APPROXIMATE) ───────────────────────────────────────────────
         // step_motion_counter@57 is a CUMULATIVE u16 running counter (it climbs while you move, holds

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ManualWorkoutRescore.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ManualWorkoutRescore.swift
@@ -48,14 +48,16 @@ public enum ManualWorkoutRescore {
     /// under-scored relative to the very day it sat in. nil keeps the old default (a cold start with no
     /// measured resting yet), so existing callers are byte-identical until they thread one.
     public static func scored(windowSamples: [HRSample], profile: UserProfile, hrMax: Double,
-                              restingHR: Double? = nil) -> Scored? {
+                              restingHR: Double? = nil,
+                              // #1545: see WorkoutDetector.detect — Edwards by default, threaded by the app.
+                              effortMethod: StrainScorer.Method = .edwards) -> Scored? {
         guard windowSamples.count >= 2 else { return nil }
         let bpms = windowSamples.map(\.bpm)
         let avg = Int((Double(bpms.reduce(0, +)) / Double(bpms.count)).rounded())
         let peak = bpms.max() ?? 0
         let strain = StrainScorer.strain(windowSamples, maxHR: hrMax,
                                          restingHR: restingHR ?? StrainScorer.defaultRestingHR,
-                                         sex: profile.sex)
+                                         method: effortMethod, sex: profile.sex)
         let kcalRaw = Calories.estimateBoutCalories(windowSamples, profile: profile,
                                                     hrmax: hrMax, restingHR: restingHR).0
         return Scored(avgHr: avg, maxHr: peak, strain: strain, kcal: kcalRaw > 0 ? kcalRaw : nil)

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
@@ -269,7 +269,12 @@ public enum WorkoutDetector {
                               restingHR: Double? = nil,
                               maxHR: Double? = nil,
                               age: Double? = nil,
-                              profile: UserProfile? = nil) -> [ExerciseSession] {
+                              profile: UserProfile? = nil,
+                              // #1545: TRIMP recipe for each bout's Effort. Defaults to Edwards so every
+                              // existing caller and test is byte-identical; the app threads the user's
+                              // choice so a bout and the day it sits in are never scored by different
+                              // recipes, which would be worse than either one being "wrong".
+                              effortMethod: StrainScorer.Method = .edwards) -> [ExerciseSession] {
         let hrSeg = cleanHR(hr)
         let motion = activitySeries(gravity)
         if hrSeg.isEmpty || motion.isEmpty { return [] }
@@ -360,7 +365,8 @@ public enum WorkoutDetector {
             guard !bpms.isEmpty else { continue }   // skip a degenerate bout with no HR samples
             let avg = bpms.reduce(0, +) / Double(bpms.count)
             let peak = Int(bpms.max()!.rounded())
-            let strain = StrainScorer.strain(hrSamples, maxHR: effMaxHR, restingHR: restHR)
+            let strain = StrainScorer.strain(hrSamples, maxHR: effMaxHR, restingHR: restHR,
+                                             method: effortMethod, sex: profile?.sex ?? "male")
 
             sessions.append(ExerciseSession(
                 start: effStart, end: end, avgHR: avg, peakHR: peak, strain: strain,

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/EffortMethodThreadingTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/EffortMethodThreadingTests.swift
@@ -2,6 +2,10 @@ import XCTest
 import Foundation
 @testable import StrandAnalytics
 import WhoopProtocol
+// DailyMetric (read via DayResult.daily below) lives in WhoopStore; AnalyticsEngineTests imports it for
+// the same reason. Harmless if the transitive visibility would have sufficed — and this file already
+// cost one CI round by assuming a type's module was reachable without saying so.
+import WhoopStore
 
 /// #1545: the Effort recipe has to reach the score, and reach the WORKOUTS INSIDE the day by the same
 /// route.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/EffortMethodThreadingTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/EffortMethodThreadingTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+import Foundation
+@testable import StrandAnalytics
+import WhoopProtocol
+
+/// #1545: the Effort recipe has to reach the score, and reach the WORKOUTS INSIDE the day by the same
+/// route.
+///
+/// The denominator work landed the arithmetic; this pins the plumbing. Threading a parameter through a
+/// dozen call sites is exactly the kind of change that compiles perfectly while quietly dropping the
+/// value somewhere in the middle, and the symptom would be invisible — a score that is merely *wrong*,
+/// not missing.
+///
+/// Byte-parity twin of Kotlin `EffortMethodThreadingTest`.
+final class EffortMethodThreadingTests: XCTestCase {
+
+    private let day = "2026-08-23"
+
+    /// A flat hour just UNDER Edwards' 50% HRR floor: it earns nothing there, real credit under Banister.
+    private func subThresholdHour() -> [HRSample] {
+        let bpm = Int((60.0 + (190.0 - 60.0) * 0.45).rounded())
+        return (0 ..< 3600).map { HRSample(ts: $0, bpm: bpm) }
+    }
+
+    private func profile() -> UserProfile { UserProfile(age: 30, sex: "male") }
+
+    private func score(_ method: StrainScorer.Method) -> Double? {
+        AnalyticsEngine.analyzeDay(day: day, hr: subThresholdHour(), dayHr: subThresholdHour(),
+                                   profile: profile(), maxHROverride: 190.0,
+                                   effortMethod: method).strain
+    }
+
+    /// The default must not move. Every caller that says nothing about a method still gets Edwards, and
+    /// an hour below the floor still scores nothing — that is what shipped, and this change is supposed
+    /// to add a choice, not alter one.
+    func testTheDefaultIsStillEdwardsAndStillScoresTheFlooredHourAtZero() {
+        let implicit = AnalyticsEngine.analyzeDay(day: day, hr: subThresholdHour(),
+                                                  dayHr: subThresholdHour(),
+                                                  profile: profile(), maxHROverride: 190.0).strain
+        XCTAssertEqual(implicit ?? -2.0, score(.edwards) ?? -1.0, accuracy: 1e-12)
+        XCTAssertEqual(implicit ?? -1.0, 0.0, accuracy: 1e-9)
+    }
+
+    /// The whole point: asking for Banister actually changes the day's Effort. If the parameter were
+    /// dropped anywhere between `analyzeDay` and `StrainScorer`, this is what notices.
+    func testBanisterReachesTheDayScore() {
+        let banister = score(.banister)
+        XCTAssertNotNil(banister)
+        XCTAssertGreaterThan(banister!, 40.0, "an hour at 45% HRR should score under Banister")
+    }
+
+    /// And it reaches the BOUTS inside the day by the same route. A day scored on Banister whose detected
+    /// workouts were still on Edwards would show a session scoring less than the day containing it — a
+    /// contradiction a user would notice long before they noticed either number being individually off.
+    func testBanisterReachesTheWorkoutsDetectedInsideTheDay() {
+        let hr = subThresholdHour()
+        let grav = (0 ..< 3600).map { GravitySample(ts: $0, x: 0.9, y: 0.1, z: 0.1) }
+        let edwards = WorkoutDetector.detect(hr: hr, gravity: grav, restingHR: 60, maxHR: 190,
+                                             age: 30, profile: profile(), effortMethod: .edwards)
+        let banister = WorkoutDetector.detect(hr: hr, gravity: grav, restingHR: 60, maxHR: 190,
+                                              age: 30, profile: profile(), effortMethod: .banister)
+
+        // Whatever the detector finds, it must find the SAME bouts either way — the recipe changes the
+        // score, never the segmentation.
+        XCTAssertEqual(edwards.count, banister.count, "the method must not change which bouts are detected")
+        for (e, b) in zip(edwards, banister) {
+            XCTAssertEqual(e.start, b.start)
+            if let es = e.strain, let bs = b.strain, es == 0.0 {
+                XCTAssertGreaterThan(bs, es, "a floored bout should score under Banister")
+            }
+        }
+    }
+
+    /// A method change must not disturb anything else the day computes.
+    func testOnlyEffortMoves() {
+        let e = AnalyticsEngine.analyzeDay(day: day, hr: subThresholdHour(), dayHr: subThresholdHour(),
+                                           profile: profile(), maxHROverride: 190.0,
+                                           effortMethod: .edwards)
+        let b = AnalyticsEngine.analyzeDay(day: day, hr: subThresholdHour(), dayHr: subThresholdHour(),
+                                           profile: profile(), maxHROverride: 190.0,
+                                           effortMethod: .banister)
+        XCTAssertEqual(e.daily.restingHr, b.daily.restingHr)
+        XCTAssertEqual(e.daily.avgHrv, b.daily.avgHrv)
+        XCTAssertEqual(e.sleepSessions.count, b.sleepSessions.count)
+        XCTAssertEqual(e.recovery, b.recovery)
+    }
+}

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -832,7 +832,8 @@ final class AppModel: ObservableObject {
         let restingHR = repo.today?.restingHr.map(Double.init) ?? StrainScorer.defaultRestingHR
         let strain = samples.count >= 2
             ? StrainScorer.strain(samples, maxHR: Double(profile.hrMax),
-                                  restingHR: restingHR, sex: profile.sex) : nil
+                                  restingHR: restingHR,
+                                  method: PuffinExperiment.effortMethod, sex: profile.sex) : nil
         // Estimate calories from the captured HR window (same Keytel/Harris–Benedict model the
         // auto-detector uses) so a manual session shows energy too, not just duration/strain. (#117)
         let up = UserProfile(weightKg: profile.weightKg, heightCm: profile.heightCm,
@@ -884,7 +885,8 @@ final class AppModel: ObservableObject {
         w.samples.append(HRSample(ts: Int(Date().timeIntervalSince1970), bpm: hr))
         w.peakHr = max(w.peakHr, hr)
         w.avgHr = Int((Double(w.samples.map(\.bpm).reduce(0, +)) / Double(w.samples.count)).rounded())
-        w.liveStrain = StrainScorer.strain(w.samples, maxHR: Double(profile.hrMax), sex: profile.sex) ?? 0
+        w.liveStrain = StrainScorer.strain(w.samples, maxHR: Double(profile.hrMax),
+                                              method: PuffinExperiment.effortMethod, sex: profile.sex) ?? 0
         activeWorkout = w
         // Re-snapshot the durable session so a kill keeps the latest accumulated HR window (#529).
         persistActiveWorkout()

--- a/Strand/BLE/PuffinExperiment.swift
+++ b/Strand/BLE/PuffinExperiment.swift
@@ -1,4 +1,5 @@
 import Foundation
+import StrandAnalytics
 
 /// Opt-in switch for the EXPERIMENTAL WHOOP 5.0/MG ("puffin") protocol probes.
 ///
@@ -76,6 +77,27 @@ enum PuffinExperiment {
     static let stressPersonalBaselineKey = "noopStressPersonalBaseline"
 
     static var stressPersonalBaselineEnabled: Bool { UserDefaults.standard.bool(forKey: stressPersonalBaselineKey) }
+
+    /// Opt-in "Banister Effort" (#1545): score Effort with Banister's EXPONENTIAL TRIMP instead of the
+    /// default Edwards 5-zone summation.
+    ///
+    /// Edwards is time-in-zone and pays **nothing** below 50% HRR. A reporter's weightlifting session
+    /// scored 1.7 while a walk scored higher — working that number backwards gives a TRIMP of about 1,
+    /// i.e. the model saw essentially no time above the floor for the whole session. An hour held at 45%
+    /// HRR scores 0.00 under Edwards and about 43 under Banister; that is the difference between
+    /// under-rating intermittent work and not seeing it at all.
+    ///
+    /// Default OFF, and it must stay a choice rather than become the default: it re-scores every day in
+    /// the window against a different recipe, so flipping it silently would move a headline metric's
+    /// whole history. Each method maps a theoretical maximum day to exactly 100 via its own log
+    /// denominator (`StrainScorer.logMapDenominator`), so the two are on the same axis and switching does
+    /// not rescale the axis under the user. Mirrors the Android `NoopPrefs.KEY_BANISTER_EFFORT`.
+    static let banisterEffortKey = "noopBanisterEffort"
+
+    static var banisterEffortEnabled: Bool { UserDefaults.standard.bool(forKey: banisterEffortKey) }
+
+    /// The TRIMP recipe every Effort computation on this device should use.
+    static var effortMethod: StrainScorer.Method { banisterEffortEnabled ? .banister : .edwards }
 
     /// Opt-in "Continuous HRV capture": hold the dense realtime HR stream armed even with no Live screen
     /// open, so the strap banks beat-to-beat R-R intervals 24/7 for far better overnight HRV/recovery/

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -692,6 +692,9 @@ final class IntelligenceEngine: ObservableObject {
         // so the Blood Oxygen tile can surface it as a "strap estimate (unverified)" fallback. Default OFF
         // per the derived-biosignal rule (CLAUDE.md) — the @82 candidate has split cross-device evidence.
         let spo2CandidateDisplayOn = PuffinExperiment.spo2CandidateDisplayEnabled
+        // #1545: the Effort TRIMP recipe, read ONCE per pass. Global (same for every day), so it folds
+        // into the config signature below rather than the per-day key.
+        let effortMethodGlobal = PuffinExperiment.effortMethod
 
         // ── #1005 BATTERY: per-day reuse cache setup (see `dayScanCache`) ────────────────────────────
         // The stager toggles are read per-day inside the loop below, but they are global (same value every
@@ -735,6 +738,10 @@ final class IntelligenceEngine: ObservableObject {
             habitualMidsleepSec.map { "\($0)" } ?? "nil",
             "\(useSleepStagerV2Global)", "\(useMotionAwareWakeGlobal)", "\(deepHrvWindow)",
             "\(spo2CandidateDisplayOn)",
+            // #1545: MUST be here. The Effort recipe changes every day's strain, so a cached scan
+            // produced under one method is stale the moment the user switches — serving it would show a
+            // window of days scored by a recipe the user just turned off, with nothing to explain it.
+            "\(effortMethodGlobal)",
         ].joined(separator: "|")
         // Drop the whole cache on a config change, then snapshot it into a Sendable `let` for the detached
         // loop (the engine is @MainActor; the loop can't touch `self`). The loop returns the updated cache
@@ -1054,7 +1061,8 @@ final class IntelligenceEngine: ObservableObject {
                                                      // (dayStart == today's local midnight), so the 5000-line
                                                      // ring buffer isn't flooded; every night keeps the summary.
                                                      hrvWindowDetail: dayStart == nowLocalMidnight,
-                                                     deepHrvWindow: deepHrvWindow)
+                                                     deepHrvWindow: deepHrvWindow,
+                                                     effortMethod: effortMethodGlobal)
                 dayScoreSeconds += Date().timeIntervalSince(tScore0)
                 // #195: whole-night HRV cleaning-pipeline summary for the always-on strap log, so a "reads ~2x
                 // too high" report is triageable without the HRV test mode: RMSSD vs SDNN (rmssd >> sdnn =
@@ -2309,7 +2317,9 @@ final class IntelligenceEngine: ObservableObject {
             guard let samples = try? await store.hrSamples(deviceId: deviceId, from: row.startTs,
                                                            to: row.endTs, limit: 20_000),
                   let s = ManualWorkoutRescore.scored(windowSamples: samples, profile: up, hrMax: hrMax,
-                                                      restingHR: restingHR),
+                                                      restingHR: restingHR,
+                                                      // #1545: same recipe as the day it sits in.
+                                                      effortMethod: PuffinExperiment.effortMethod),
                   ManualWorkoutRescore.improves(s, over: row.energyKcal, currentStrain: row.strain,
                                                 allowStrainOnlyFill: true)
             else { continue }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -2166,7 +2166,8 @@ final class IntelligenceEngine: ObservableObject {
         // today and the tail is the oldest day in the window. Taking the last match would have scored
         // today's workout against a resting HR up to `maxDays` old.
         let measuredResting = out.first(where: { $0.rhr != nil })?.rhr.map(Double.init)
-        await rescoreManualWorkouts(store: store, profile: up, restingHR: measuredResting)
+        await rescoreManualWorkouts(store: store, profile: up, restingHR: measuredResting,
+                                    effortMethod: effortMethodGlobal)
 
         results = out
         note = out.isEmpty
@@ -2302,7 +2303,13 @@ final class IntelligenceEngine: ObservableObject {
     /// (negligible calories), and only when the recompute is a genuine improvement , so a well-scored
     /// 4.0 workout is never touched and a still-sparse window is a no-op.
     private func rescoreManualWorkouts(store: WhoopStore, profile up: UserProfile,
-                                       restingHR: Double? = nil) async {
+                                       restingHR: Double? = nil,
+                                       // #1545: the recipe THIS PASS scored its days with, threaded in
+                                       // rather than re-read. Re-reading would let a toggle flipped
+                                       // mid-pass score a manual workout by one recipe and the day it
+                                       // sits in by the other — the exact day-vs-bout contradiction the
+                                       // threading exists to prevent. Twin of the Kotlin parameter.
+                                       effortMethod: StrainScorer.Method = .edwards) async {
         let now = Int(Date().timeIntervalSince1970)
         let since = now - 14 * 86_400
         guard let rows = try? await store.workouts(deviceId: deviceId, from: since, to: now, limit: 200)
@@ -2318,8 +2325,7 @@ final class IntelligenceEngine: ObservableObject {
                                                            to: row.endTs, limit: 20_000),
                   let s = ManualWorkoutRescore.scored(windowSamples: samples, profile: up, hrMax: hrMax,
                                                       restingHR: restingHR,
-                                                      // #1545: same recipe as the day it sits in.
-                                                      effortMethod: PuffinExperiment.effortMethod),
+                                                      effortMethod: effortMethod),
                   ManualWorkoutRescore.improves(s, over: row.energyKcal, currentStrain: row.strain,
                                                 allowStrainOnlyFill: true)
             else { continue }

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -2458,7 +2458,8 @@ final class Repository: ObservableObject {
                             let samples = (try? await store.hrSamples(deviceId: hrIds[0],
                                                                       from: startTs, to: endTs,
                                                                       limit: 8000)) ?? []
-                            strain = StrainScorer.strain(samples, maxHR: p.hrMax, sex: p.sex)
+                            strain = StrainScorer.strain(samples, maxHR: p.hrMax,
+                                                method: PuffinExperiment.effortMethod, sex: p.sex)
                         } else {
                             strain = nil
                         }

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -4515,7 +4515,8 @@ struct TodayView: View {
             let todayHr = await repo.hrSamples(from: windowStart, to: windowEnd)
             let maxHR = profile.age > 0 ? StrainScorer.tanakaHRmax(age: Double(profile.age)) : nil
             let restHR = displayDay?.restingHr.map(Double.init) ?? StrainScorer.defaultRestingHR
-            liveStrainLocal = StrainScorer.strain(todayHr, maxHR: maxHR, restingHR: restHR, sex: profile.sex)
+            liveStrainLocal = StrainScorer.strain(todayHr, maxHR: maxHR, restingHR: restHR,
+                                        method: PuffinExperiment.effortMethod, sex: profile.sex)
         } else {
             liveStrainLocal = nil
         }

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -399,6 +399,12 @@ object AnalyticsEngine {
         // the whole-night mean. Display-only preference threaded from the caller (UnitPrefs.hrvWindow). The
         // default (false) is byte-identical to the historical whole-night value.
         deepHrvWindow: Boolean = false,
+        // #1545: which TRIMP recipe scores Effort. EDWARDS (the default) is time-in-zone and pays NOTHING
+        // below 50% HRR, so intermittent work — a lifting session, once the sets are averaged against the
+        // rests — can score near zero however long it lasts. BANISTER is exponential in %HRR with no floor.
+        // Threaded rather than read from a global so this stays a pure function, and defaulted so every
+        // existing caller and test is byte-identical.
+        effortMethod: StrainScorer.Method = StrainScorer.Method.EDWARDS,
     ): DayResult {
 
         // Precompute the day's UTC bounds ONCE (#996). isoDay is a FIXED-UTC formatter, so
@@ -724,6 +730,7 @@ object AnalyticsEngine {
             hr = dayHr ?: hr,
             maxHR = effMaxHR,
             restingHR = restForStrain,
+            method = effortMethod,
             sex = profile.sex,
         )
 
@@ -739,6 +746,10 @@ object AnalyticsEngine {
             maxHR = maxHROverride,
             age = if (profile.age > 0) profile.age else null,
             profile = profile,
+            // #1545: the bouts inside a day MUST be scored by the same recipe as the day itself. A day
+            // on Banister whose workouts were still on Edwards would show a session scoring less than
+            // the day it sits inside, which is a worse inconsistency than either method.
+            effortMethod = effortMethod,
         )
 
         // ── Steps (APPROXIMATE) ───────────────────────────────────────────────

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -283,6 +283,9 @@ object IntelligenceEngine {
         // Blood Oxygen tile can surface it as a "strap estimate (unverified)" fallback. Display-only.
         // The Context-aware caller reads NoopPrefs.spo2CandidateDisplay(context) and passes it down.
         spo2CandidateDisplay: Boolean = false,
+        // #1545: the Effort TRIMP recipe. The Context-aware caller reads NoopPrefs.effortMethod(context)
+        // and passes it down, keeping this layer Context-free. EDWARDS default = byte-identical.
+        effortMethod: StrainScorer.Method = StrainScorer.Method.EDWARDS,
     ): List<Computed> = withContext(Dispatchers.Default) {
         // #1005: time the whole pass so a re-score STORM is visible in the strap log (the trigger lines
         // record WHY each pass runs; this records how many nights and how long — the CPU cost per run).
@@ -294,7 +297,8 @@ object IntelligenceEngine {
             val (out, healed) = analyzeRecentOnCpu(repo, profile, maxDays, importedDeviceId, maxHROverride,
                 nowSeconds, ownerSource, manualStepCoefficient, persistStepsCalibration, baselineEpoch,
                 recoveryEpoch, diag, useExperimentalSleepV2, useMotionAwareWake, sleepTraceSink, recoveryTraceSink,
-                stepsTraceSink, universalSink, workoutsTraceSink, hrvTraceSink, deepHrvWindow, spo2CandidateDisplay)
+                stepsTraceSink, universalSink, workoutsTraceSink, hrvTraceSink, deepHrvWindow,
+                spo2CandidateDisplay, effortMethod)
             if (healed == 0) out
             // #899 heal re-pass: the pass above deleted overlapping duplicate sleep sessions AFTER its days
             // were scored, and the read-side dedup those days consumed had no bank-recency witness (the fresh
@@ -304,7 +308,8 @@ object IntelligenceEngine {
             else analyzeRecentOnCpu(repo, profile, maxDays, importedDeviceId, maxHROverride,
                 nowSeconds, ownerSource, manualStepCoefficient, persistStepsCalibration, baselineEpoch,
                 recoveryEpoch, diag, useExperimentalSleepV2, useMotionAwareWake, sleepTraceSink, recoveryTraceSink,
-                stepsTraceSink, universalSink, workoutsTraceSink, hrvTraceSink, deepHrvWindow, spo2CandidateDisplay).first
+                stepsTraceSink, universalSink, workoutsTraceSink, hrvTraceSink, deepHrvWindow,
+                spo2CandidateDisplay, effortMethod).first
         }
         diag("re-score: done — scored ${scored.size} night(s) in ${(System.nanoTime() - reScoreStart) / 1_000_000} ms (#1005)")
         scored
@@ -402,6 +407,8 @@ object IntelligenceEngine {
         // persisted as "spo2_candidate" in metricSeries. Default false — the @82 candidate has split
         // cross-device evidence and ships behind a default-off toggle (CLAUDE.md derived-biosignal rule).
         spo2CandidateDisplay: Boolean = false,
+        // #1545: the Effort TRIMP recipe, threaded from the public wrapper.
+        effortMethod: StrainScorer.Method = StrainScorer.Method.EDWARDS,
         // #899 heal re-pass: the second component of the return is how many overlapping duplicate sleep
         // sessions the heal below deleted this pass. The public wrapper re-runs ONCE when it is non-zero
         // so the affected days re-score against the cleaned store.
@@ -571,6 +578,10 @@ object IntelligenceEngine {
             sleepConsistency?.toString() ?: "nil", habitualMidsleepSec?.toString() ?: "nil",
             useExperimentalSleepV2.toString(), useMotionAwareWake.toString(),
             deepHrvWindow.toString(), spo2CandidateDisplay.toString(),
+            // #1545: MUST be here. The Effort recipe changes every day's strain, so a cached scan
+            // produced under one method is stale the moment the user switches — serving it would show a
+            // window of days scored by a recipe the user just turned off, with nothing to explain it.
+            effortMethod.toString(),
         ).joinToString("|")
         // Drop the whole cache on a config change. Under [analyzeGate] (this whole pass runs holding the
         // lock), so mutating the object-level cache here is race-free.
@@ -856,6 +867,7 @@ object IntelligenceEngine {
                 // so the 5000-line ring buffer isn't flooded; every night still emits the 1-line summary.
                 hrvWindowDetail = dayStart == nowLocalMidnight,
                 deepHrvWindow = deepHrvWindow,
+                effortMethod = effortMethod,
             )
             dayScoreNanos += System.nanoTime() - tScore0
 
@@ -1714,7 +1726,8 @@ object IntelligenceEngine {
         // so out[0] is today and the tail is the oldest day in the window. Taking the last match would have
         // scored today's workout against a resting HR up to `maxDays` old.
         val measuredResting = out.firstOrNull { it.rhr != null }?.rhr?.toDouble()
-        rescoreManualWorkouts(repo, profile, importedDeviceId, maxHROverride, nowSeconds, measuredResting)
+        rescoreManualWorkouts(repo, profile, importedDeviceId, maxHROverride, nowSeconds,
+            measuredResting, effortMethod)
 
         return out to healDropped.size
     }
@@ -1909,6 +1922,8 @@ object IntelligenceEngine {
         // #950: the wearer's measured resting HR (most recent scored day), threaded into scored() so the
         // rescore uses the same %HRR denominator as the day total. null → the scorer's default.
         restingHR: Double? = null,
+        // #1545: the pass's Effort recipe, so a rescored manual workout matches the day it sits in.
+        effortMethod: StrainScorer.Method = StrainScorer.Method.EDWARDS,
     ) {
         val since = nowSeconds - 14L * 86_400L
         val rows = runCatching { repo.workouts(deviceId, since, nowSeconds) }.getOrNull() ?: return
@@ -1922,7 +1937,8 @@ object IntelligenceEngine {
             if (!ManualWorkoutRescore.looksUnderScored(row.energyKcal) && row.strain != null) continue
             val samples = runCatching { repo.hrSamples(deviceId, row.startTs, row.endTs, 20_000) }
                 .getOrNull() ?: continue
-            val s = ManualWorkoutRescore.scored(samples, profile, hrMax, restingHR) ?: continue
+            val s = ManualWorkoutRescore.scored(
+                samples, profile, hrMax, restingHR, effortMethod) ?: continue
             if (!ManualWorkoutRescore.improves(s, row.energyKcal, row.strain, allowStrainOnlyFill = true)) continue
             // Never lower a summed kcal: only take the recomputed kcal when it genuinely beats the stored
             // value; a strain-only fill (merged row) keeps the existing summed energyKcal.

--- a/android/app/src/main/java/com/noop/analytics/ManualWorkoutRescore.kt
+++ b/android/app/src/main/java/com/noop/analytics/ManualWorkoutRescore.kt
@@ -45,6 +45,8 @@ object ManualWorkoutRescore {
         profile: UserProfile,
         hrMax: Double,
         restingHR: Double? = null,
+        // #1545: see WorkoutDetector.detect — EDWARDS by default, threaded by the app.
+        effortMethod: StrainScorer.Method = StrainScorer.Method.EDWARDS,
     ): Scored? {
         if (windowSamples.size < 2) return null
         val bpms = windowSamples.map { it.bpm }
@@ -54,7 +56,8 @@ object ManualWorkoutRescore {
         val peak = bpms.maxOrNull() ?: 0
         val strain = StrainScorer.strain(
             windowSamples, maxHR = hrMax,
-            restingHR = restingHR ?: StrainScorer.defaultRestingHR, sex = profile.sex,
+            restingHR = restingHR ?: StrainScorer.defaultRestingHR,
+            method = effortMethod, sex = profile.sex,
         )
         val kcalRaw = Calories.estimateBoutCalories(windowSamples, profile, hrMax, restingHR).first
         return Scored(avg, peak, strain, if (kcalRaw > 0) kcalRaw else null)

--- a/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
+++ b/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
@@ -276,6 +276,10 @@ object WorkoutDetector {
         maxHR: Double? = null,
         age: Double? = null,
         profile: UserProfile? = null,
+        // #1545: TRIMP recipe for each bout's Effort. Defaults to EDWARDS so every existing caller and
+        // test is byte-identical; the app threads the user's choice so a bout and the day it sits in are
+        // never scored by different recipes, which would be worse than either one being "wrong".
+        effortMethod: StrainScorer.Method = StrainScorer.Method.EDWARDS,
     ): List<ExerciseSession> {
         val hrSeg = cleanHR(hr)
         val motion = activitySeries(gravity)
@@ -376,7 +380,8 @@ object WorkoutDetector {
 
             val avg = bpms.sum() / bpms.size.toDouble()
             val peak = window.maxOf { it.bpm }
-            val strain = StrainScorer.strain(window, effMaxHR, restHR)
+            val strain = StrainScorer.strain(
+                window, effMaxHR, restHR, effortMethod, profile?.sex ?: "male")
 
             sessions.add(
                 ExerciseSession(

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2506,6 +2506,7 @@ class WhoopBleClient(
                         // #103: SpO₂ candidate @82 display toggle — when ON, the engine computes and
                         // persists the nightly @82 mean as "spo2_candidate" in metricSeries.
                         spo2CandidateDisplay = NoopPrefs.spo2CandidateDisplay(context),
+                        effortMethod = NoopPrefs.effortMethod(context),
                     )
                 }.onSuccess {
                     // Advance the shared watermark so the next 15-min tick sees no change and skips (#836).

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1068,6 +1068,10 @@ class WhoopRepository(
         // as stored. Display-only; the durable value is written by IntelligenceEngine.rescoreManualWorkouts.
         strainMaxHR: Double? = null,
         strainSex: String = "male",
+        // #1545: the TRIMP recipe for that display-only refill. A parameter rather than a NoopPrefs read
+        // because this class holds no Context; the two UI callers pass the user's choice. EDWARDS by
+        // default so a caller that does not care stays byte-identical.
+        effortMethod: com.noop.analytics.StrainScorer.Method = com.noop.analytics.StrainScorer.Method.EDWARDS,
     ): List<WorkoutRow> {
         var budget = cap
         return rows.map { row ->
@@ -1097,7 +1101,8 @@ class WhoopRepository(
             // let StrainScorer return null on a still-too-thin window (never a fabricated number).
             val filledStrain = if (needsStrainFill && strainMaxHR != null) {
                 val samples = dao.hrSamples(hrIds[0], row.startTs, row.endTs, 8000)
-                com.noop.analytics.StrainScorer.strain(samples, maxHR = strainMaxHR, sex = strainSex)
+                com.noop.analytics.StrainScorer.strain(
+                    samples, maxHR = strainMaxHR, method = effortMethod, sex = strainSex)
             } else null
             if (strapNative) {
                 // True mean / peak of the very samples the graph + zones + effort use; FILL a null Effort

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1108,6 +1108,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                         // #103: SpO₂ candidate @82 display toggle — when ON, the engine computes and
                         // persists the nightly @82 mean as "spo2_candidate" in metricSeries.
                         spo2CandidateDisplay = NoopPrefs.spo2CandidateDisplay(appContext),
+                        effortMethod = NoopPrefs.effortMethod(appContext),
                     )
                     // analyzeRecent now hops to Dispatchers.Default; a scope cancellation surfaces as a
                     // CancellationException that runCatching would otherwise swallow, breaking the loop's
@@ -1468,7 +1469,8 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         val restingHR = _today.value?.restingHr?.toDouble() ?: StrainScorer.defaultRestingHR
         val strain = if (samples.size >= 2)
             StrainScorer.strain(samples, maxHR = profileStore.hrMax.toDouble(),
-                restingHR = restingHR, sex = profileStore.sex) else null
+                restingHR = restingHR, method = NoopPrefs.effortMethod(appContext),
+                sex = profileStore.sex) else null
         // Estimate calories from the captured HR window (same Keytel/Harris–Benedict model the
         // auto-detector uses) so a manual session shows energy too, not just duration/strain. (#117)
         val energyKcal = if (samples.size >= 2)
@@ -1526,7 +1528,9 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         @Suppress("UNNECESSARY_SAFE_CALL")
         val w = _activeWorkout?.value ?: return
         val s = w.samples + HrSample(deviceId = deviceId, ts = System.currentTimeMillis() / 1000, bpm = bpm)
-        val strain = StrainScorer.strain(s, maxHR = profileStore.hrMax.toDouble(), sex = profileStore.sex) ?: 0.0
+        val strain = StrainScorer.strain(
+            s, maxHR = profileStore.hrMax.toDouble(),
+            method = NoopPrefs.effortMethod(appContext), sex = profileStore.sex) ?: 0.0
         val updated = w.copy(
             samples = s, avgHr = s.sumOf { it.bpm } / s.size, peakHr = s.maxOf { it.bpm }, liveStrain = strain,
         )
@@ -1696,6 +1700,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                 useMotionAwareWake = PuffinExperiment.from(appContext).motionAwareWake,
                 // #103: SpO₂ candidate @82 display toggle — same flag the 15-min loop reads.
                 spo2CandidateDisplay = NoopPrefs.spo2CandidateDisplay(appContext),
+                effortMethod = NoopPrefs.effortMethod(appContext),
             )
         }.onFailure { if (it is kotlin.coroutines.cancellation.CancellationException) throw it }
     }
@@ -1729,6 +1734,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                 (whoop + apple + detected + activityFiles),
                 strainMaxHR = profileStore.hrMax.toDouble(),
                 strainSex = profileStore.sex,
+                effortMethod = NoopPrefs.effortMethod(appContext),
             )
             // #687: collapse the SAME activity tracked live under the strap AND imported from Health
             // Connect / Apple Health into one richer entry — they sit under different sources so without

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -211,6 +211,29 @@ object NoopPrefs {
      *  derived-biosignal rule (CLAUDE.md). Mirrors iOS `PuffinExperiment.stressPersonalBaselineKey`. */
     const val KEY_STRESS_PERSONAL_BASELINE = "noop.stressPersonalBaseline"
 
+    /** Opt-in "Banister Effort" (#1545): score Effort with Banister's EXPONENTIAL TRIMP instead of the
+     *  default Edwards 5-zone summation.
+     *
+     *  Edwards is time-in-zone and pays NOTHING below 50% HRR. A reporter's weightlifting session scored
+     *  1.7 while a walk scored higher — working that back gives a TRIMP of about 1, i.e. the model saw
+     *  essentially no time above the floor for the whole session. An hour held at 45% HRR scores 0.00
+     *  under Edwards and about 43 under Banister: the difference between under-rating intermittent work
+     *  and not seeing it at all.
+     *
+     *  Default OFF and it must stay a choice, not become the default — it re-scores every day in the
+     *  window against a different recipe, so flipping it silently would move a headline metric's whole
+     *  history. Each method maps a theoretical maximum day to exactly 100 via its own log denominator
+     *  ([StrainScorer.logMapDenominator]), so the two share an axis. Mirrors iOS
+     *  `PuffinExperiment.banisterEffortKey`. */
+    const val KEY_BANISTER_EFFORT = "noop.banisterEffort"
+
+    fun banisterEffort(context: Context): Boolean = of(context).getBoolean(KEY_BANISTER_EFFORT, false)
+
+    /** The TRIMP recipe every Effort computation on this device should use. */
+    fun effortMethod(context: Context): com.noop.analytics.StrainScorer.Method =
+        if (banisterEffort(context)) com.noop.analytics.StrainScorer.Method.BANISTER
+        else com.noop.analytics.StrainScorer.Method.EDWARDS
+
     /** The calendar day (yyyy-MM-dd) on which the morning-journal nudge was last shown, keeps the
      *  Sleep screen's "Good morning" sheet to at most once per day. */
     const val KEY_LAST_JOURNAL_PROMPT = "noop.lastJournalPromptDay"

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -927,6 +927,7 @@ fun TodayScreen(
                 hr = todayHr,
                 maxHR = effMaxHR,
                 restingHR = displayMetric?.restingHr?.toDouble() ?: StrainScorer.defaultRestingHR,
+                method = NoopPrefs.effortMethod(context),
                 sex = profileStore.sex,
             )
         } else {
@@ -1106,7 +1107,8 @@ fun TodayScreen(
             // fillWorkoutHrFromStrap: imported sessions carry no HR, derive it from strap samples (#77).
             // #510: strap-native rows now read HR under their OWN recording strap (inside the fill), so a 2nd
             // WHOOP's workouts reconcile Avg HR + Effort from their own trace; imported rows keep the default.
-            recentWorkouts = viewModel.repo.fillWorkoutHrFromStrap(recentUnion),
+            recentWorkouts = viewModel.repo.fillWorkoutHrFromStrap(
+                recentUnion, effortMethod = NoopPrefs.effortMethod(context)),
             whoopDays = days.size,
             whoopWorkouts = whoopWorkouts.size,
             appleDays = appleDaysCount,

--- a/android/app/src/test/java/com/noop/analytics/EffortMethodThreadingTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/EffortMethodThreadingTest.kt
@@ -1,0 +1,117 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.roundToInt
+
+/**
+ * #1545: the Effort recipe has to reach the score, and reach the WORKOUTS INSIDE the day by the same
+ * route.
+ *
+ * The denominator work landed the arithmetic; this pins the plumbing. Threading a parameter through a
+ * dozen call sites is exactly the kind of change that compiles perfectly while quietly dropping the value
+ * somewhere in the middle, and the symptom would be invisible — a score that is merely *wrong*, not
+ * missing.
+ *
+ * Byte-parity twin of Swift `EffortMethodThreadingTests`.
+ */
+class EffortMethodThreadingTest {
+
+    private val day = "2026-08-23"
+
+    /** A flat hour just UNDER Edwards' 50% HRR floor: it earns nothing there, and real credit under Banister. */
+    private fun subThresholdHour(): List<HrSample> {
+        val bpm = (60.0 + (190.0 - 60.0) * 0.45).roundToInt()
+        return (0 until 3600).map { HrSample(deviceId = "t", ts = it.toLong(), bpm = bpm) }
+    }
+
+    private fun profile() = UserProfile(age = 30.0, sex = "male")
+
+    private fun score(method: StrainScorer.Method): Double? = AnalyticsEngine.analyzeDay(
+        day = day,
+        hr = subThresholdHour(),
+        dayHr = subThresholdHour(),
+        profile = profile(),
+        maxHROverride = 190.0,
+        effortMethod = method,
+    ).strain
+
+    /**
+     * The default must not move. Every caller that says nothing about a method still gets Edwards, and an
+     * hour below the floor still scores nothing — because that is what shipped, and this change is
+     * supposed to add a choice, not alter one.
+     */
+    @Test
+    fun theDefaultIsStillEdwardsAndStillScoresTheFlooredHourAtZero() {
+        val implicit = AnalyticsEngine.analyzeDay(
+            day = day, hr = subThresholdHour(), dayHr = subThresholdHour(),
+            profile = profile(), maxHROverride = 190.0,
+        ).strain
+        assertEquals(score(StrainScorer.Method.EDWARDS) ?: -1.0, implicit ?: -2.0, 1e-12)
+        assertEquals(0.0, implicit ?: -1.0, 1e-9)
+    }
+
+    /**
+     * The whole point: asking for Banister actually changes the day's Effort. If the parameter were
+     * dropped anywhere between analyzeDay and StrainScorer, this is the assertion that notices.
+     */
+    @Test
+    fun banisterReachesTheDayScore() {
+        val banister = score(StrainScorer.Method.BANISTER)
+        assertNotNull(banister)
+        assertTrue("an hour at 45% HRR should score under Banister, got $banister", banister!! > 40.0)
+    }
+
+    /**
+     * And it reaches the BOUTS inside the day by the same route. A day scored on Banister whose detected
+     * workouts were still on Edwards would show a session scoring less than the day containing it — a
+     * contradiction a user would notice long before they noticed either number being individually off.
+     */
+    @Test
+    fun banisterReachesTheWorkoutsDetectedInsideTheDay() {
+        // A bout needs motion as well as HR, so drive WorkoutDetector directly with the same window —
+        // it is the exact call analyzeDay makes internally.
+        val hr = subThresholdHour()
+        val grav = (0 until 3600).map {
+            com.noop.data.GravitySample(deviceId = "t", ts = it.toLong(), x = 0.9, y = 0.1, z = 0.1)
+        }
+        val edwards = WorkoutDetector.detect(
+            hr = hr, gravity = grav, restingHR = 60.0, maxHR = 190.0, age = 30.0,
+            profile = profile(), effortMethod = StrainScorer.Method.EDWARDS)
+        val banister = WorkoutDetector.detect(
+            hr = hr, gravity = grav, restingHR = 60.0, maxHR = 190.0, age = 30.0,
+            profile = profile(), effortMethod = StrainScorer.Method.BANISTER)
+
+        // Whatever the detector finds, it must find the SAME bouts either way — the recipe changes the
+        // score, never the segmentation.
+        assertEquals("the method must not change which bouts are detected", edwards.size, banister.size)
+        for (i in edwards.indices) {
+            assertEquals(edwards[i].start, banister[i].start)
+            val e = edwards[i].strain
+            val b = banister[i].strain
+            if (e != null && b != null && e == 0.0) {
+                assertTrue("a floored bout should score under Banister (edwards=$e banister=$b)", b > e)
+            }
+        }
+    }
+
+    /** A method change must not disturb anything else the day computes. */
+    @Test
+    fun onlyEffortMoves() {
+        val e = AnalyticsEngine.analyzeDay(
+            day = day, hr = subThresholdHour(), dayHr = subThresholdHour(),
+            profile = profile(), maxHROverride = 190.0,
+            effortMethod = StrainScorer.Method.EDWARDS)
+        val b = AnalyticsEngine.analyzeDay(
+            day = day, hr = subThresholdHour(), dayHr = subThresholdHour(),
+            profile = profile(), maxHROverride = 190.0,
+            effortMethod = StrainScorer.Method.BANISTER)
+        assertEquals(e.daily.restingHr, b.daily.restingHr)
+        assertEquals(e.daily.avgHrv, b.daily.avgHrv)
+        assertEquals(e.sleepSessions.size, b.sleepSessions.size)
+        assertEquals(e.recovery, b.recovery)
+    }
+}


### PR DESCRIPTION
Second of three for #1545. The denominator landed in #1561; this makes the choice **reach every place Effort is computed**. Still **no behaviour change for anyone** — the toggle backing it defaults off, so every path resolves to Edwards exactly as before.

## All 14 call sites, verified by script

Seven per platform. Checked with a script rather than by eye, because a parameter dropped in the middle of a change this wide compiles perfectly and produces a score that is merely **wrong** rather than missing:

```
14/14 production strain calls thread a method
```

The **analytics layer takes the recipe as a parameter** (`analyzeDay`, `WorkoutDetector.detect`, `ManualWorkoutRescore.scored`) rather than reading a global, so those stay pure functions and every existing caller and test is byte-identical on the default. The **app layer** reads the user's choice once and passes it down. `WhoopRepository` takes a parameter instead of a prefs read because it holds no `Context`; its two UI callers supply it.

## Two things that would have been easy to get wrong

**The bouts inside a day are threaded from the same value as the day.** A day on Banister whose detected workouts were still on Edwards would show a session scoring *less than the day containing it* — a contradiction a user would notice long before they noticed either number being individually off.

**The recipe is folded into the day-cache config signature**, both platforms. It changes every day's strain, so a cached scan produced under one method is stale the instant the user switches. Without this the window would keep serving days scored by a recipe the user had just turned off, with nothing on screen to explain it. That is the same class of bug #1402 fixed and #1558 re-examined.

## Tests

Four per platform, pinning the plumbing rather than the arithmetic:

| | |
|---|---|
| The default is still Edwards | and still scores a sub-floor hour at **0.00** |
| Banister reaches the day score | an hour at 45% HRR scores > 40 |
| It reaches the bouts inside the day | **and does not change which bouts are detected** — the recipe changes the score, never the segmentation |
| Nothing else moves | resting HR, HRV, sleep sessions and recovery are identical either way |

## Not yet user-selectable

The Settings row and its copy are the last piece. They need **real translations in twelve locale files** — eight iOS locales plus four Android — and that is the one part of this feature where hand-written output is weakest and deserves its own review rather than being buried at the end of a large wiring diff.

That same change must also fix `HowNoopWorksView`, which today tells users Effort is *"in the Banister TRIMP family"* when it is Edwards — so anyone reading it would think NOOP already does what #1545 asks.

## Verification

- Android **4,241 tests, 0 failures** (`--no-build-cache --rerun-tasks`) — 4,237 matching main plus 4 new. Kotlin compiles.
- Swift twin runs in `swift-packages` CI, which covers `Packages/**` automatically.
- Doc lint clean.
- **App-target Swift changed, so `app-build` is required before merge** — not yet dispatched.

Partial work on #1545; that issue stays open.