### PR TITLE
Score a workout against the same HRmax as the day containing it

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -807,7 +807,20 @@ public enum AnalyticsEngine {
         let workouts = WorkoutDetector.detect(
             hr: dayHr ?? hr, gravity: dayGravity ?? gravity,
             restingHR: restingHRDaily.map(Double.init),
-            maxHR: maxHROverride,
+            // #1545: the DAY's effective HRmax, not just the override. Passing `maxHROverride` meant an
+            // install with no override left the detector to fall back to `StrainScorer.estimateHRmax`,
+            // which returns max(observed p99.5, Tanaka) -- so every bout was measured against a HRmax at
+            // least as high as, and usually higher than, the one its own day used. A higher HRmax is a
+            // bigger reserve and therefore a SMALLER %HRR, so bouts were held to a stricter yardstick
+            // than the day containing them: for age 30 / RHR 60 with an observed 195, a 125 bpm minute is
+            // zone 1 for the day and zone 0 for the bout. That is the same
+            // day-disagrees-with-its-own-workouts failure #1562 fixed for the TRIMP method.
+            //
+            // This also feeds the z2+ qualification gate below, so it changes which bouts are DETECTED,
+            // not only how they score -- in the direction of no longer dropping a workout by a standard
+            // its own day never applied. Still nil for an age-less profile, where the detector's own
+            // estimate remains the only available fallback.
+            maxHR: effMaxHR,
             age: profile.age > 0 ? profile.age : nil,
             profile: profile,
             // #1545: the bouts inside a day MUST be scored by the same recipe as the day itself.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayBoutHrMaxAgreementTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayBoutHrMaxAgreementTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+import Foundation
+@testable import StrandAnalytics
+import WhoopProtocol
+
+/// #1545: a workout and the day containing it must be scored against the SAME HRmax.
+///
+/// `analyzeDay` computes `effMaxHR = maxHROverride ?? tanakaHRmax(age)` for the day's Effort, but used to
+/// hand `WorkoutDetector.detect` only `maxHROverride`. With no override — the default — the detector fell
+/// back to `StrainScorer.estimateHRmax`, which returns `max(observed p99.5, Tanaka)`. So every bout was
+/// measured against a HRmax at least as high as its own day's, and usually higher.
+///
+/// A higher HRmax is a bigger reserve and therefore a SMALLER %HRR, so bouts were held to a STRICTER
+/// standard than the day they sit inside. At age 30 / RHR 60 with an observed 195 bpm, a 125 bpm minute is
+/// zone 1 for the day and zone 0 for the bout — it counts toward the day total and scores nothing in the
+/// workout. That lands hardest at the 50% floor, which is the whole subject of #1545.
+///
+/// Byte-parity twin of Kotlin `DayBoutHrMaxAgreementTest`.
+final class DayBoutHrMaxAgreementTests: XCTestCase {
+
+    private let age = 30.0
+    private let rhr = 60.0
+    private var tanaka: Double { StrainScorer.tanakaHRmax(age: age) }   // 187 for age 30
+
+    /// The arithmetic the fix is about, stated independently of the engine.
+    private func zoneWeight(_ bpm: Double, _ hrmax: Double) -> Int {
+        let pct = (bpm - rhr) / (hrmax - rhr) * 100.0
+        if pct >= 90 { return 5 }; if pct >= 80 { return 4 }; if pct >= 70 { return 3 }
+        if pct >= 60 { return 2 }; if pct >= 50 { return 1 }
+        return 0
+    }
+
+    /// The divergence, in the estimator itself: `estimateHRmax` never returns BELOW Tanaka, so the bout's
+    /// fallback HRmax is always ≥ the day's. That is why the bug is one-directional — bouts could only
+    /// ever be under-scored relative to their day, never over-scored.
+    func testTheBoutFallbackIsNeverBelowTheDaysTanaka() {
+        for observed in [150.0, 185.0, 195.0, 210.0] {
+            let est = StrainScorer.estimateHRmax(Array(repeating: observed, count: 700), age: age).0
+            XCTAssertGreaterThanOrEqual(est, tanaka - 1e-9, "observed \(observed) gave \(est)")
+        }
+    }
+
+    /// The concrete split: the same heart rate is worth a zone to the day and nothing to the bout, purely
+    /// because the two used different HRmax values.
+    func testTheSameMinuteSplitsAcrossTheZoneFloor() {
+        let boutMax = StrainScorer.estimateHRmax(Array(repeating: 195.0, count: 700), age: age).0
+        XCTAssertEqual(boutMax, 195.0, accuracy: 1e-9, "fixture assumes the observed value wins")
+        XCTAssertEqual(zoneWeight(125, tanaka), 1, "day scores it zone 1")
+        XCTAssertEqual(zoneWeight(125, boutMax), 0, "bout scored it zone 0 — the bug")
+    }
+
+    /// The fix, end to end — and it is a DETECTION change, not only a scoring one.
+    ///
+    /// A 138 bpm bout is 61.4% HRR against the day's Tanaka 187 (zone 2) but 57.8% against an observed
+    /// 195 (zone 1). The detector's z2+ qualification gate needs half the bout in zone 2 or above, so
+    /// before the fix this workout was DROPPED — by a standard its own day never applied.
+    func testTheDaysHrMaxReachesDetectionAndScoring() {
+        let res = AnalyticsEngine.analyzeDay(
+            day: "2026-08-23", hr: dayWithAHardPeakAndABoundaryBout(),
+            gravity: movingAllDay(), dayHr: dayWithAHardPeakAndABoundaryBout(),
+            dayGravity: movingAllDay(), profile: UserProfile(age: age, sex: "male"))
+
+        XCTAssertFalse(res.workouts.isEmpty, "the boundary bout should now be detected")
+        for w in res.workouts {
+            XCTAssertEqual(w.hrmax ?? -1, tanaka, accuracy: 1e-9,
+                           "every bout must carry the day's HRmax, not the observed estimate")
+        }
+    }
+
+    /// An explicit override still wins — the fix must never override the user's own number.
+    func testAnExplicitOverrideStillWins() {
+        let res = AnalyticsEngine.analyzeDay(
+            day: "2026-08-23", hr: dayWithAHardPeakAndABoundaryBout(),
+            gravity: movingAllDay(), dayHr: dayWithAHardPeakAndABoundaryBout(),
+            dayGravity: movingAllDay(), profile: UserProfile(age: age, sex: "male"),
+            maxHROverride: 175.0)
+
+        XCTAssertFalse(res.workouts.isEmpty)
+        for w in res.workouts { XCTAssertEqual(w.hrmax ?? -1, 175.0, accuracy: 1e-9) }
+    }
+
+    // A day with: a brief hard effort (lifts the observed p99.5 above Tanaka), a long rest that sets a low
+    // resting baseline, and a sustained bout sitting exactly between the two HRmax interpretations.
+    private func dayWithAHardPeakAndABoundaryBout() -> [HRSample] {
+        var out: [HRSample] = []
+        out.reserveCapacity(7200)
+        func run(_ from: Int, _ until: Int, _ bpm: Int) {
+            for t in from ..< until { out.append(HRSample(ts: t, bpm: bpm)) }
+        }
+        run(0, 600, 195)        // hard peak → observed p99.5 = 195
+        run(600, 2400, 60)      // rest → 10th-percentile resting baseline stays 60
+        run(2400, 6000, 138)    // the boundary bout: zone 2 on Tanaka, zone 1 on observed
+        run(6000, 7200, 60)
+        return out
+    }
+
+    // Motion must actually vary: intensity is the euclidean step between consecutive gravity samples and
+    // has to clear `motionThreshold` (0.20) after smoothing, so a constant vector detects nothing.
+    private func movingAllDay() -> [GravitySample] {
+        (0 ..< 7200).map { GravitySample(ts: $0, x: $0 % 2 == 0 ? 0.9 : 0.5, y: 0.1, z: 0.1) }
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -743,7 +743,19 @@ object AnalyticsEngine {
             hr = dayHr ?: hr,
             gravity = dayGravity ?: gravity,
             restingHR = restingHRDaily?.toDouble(),
-            maxHR = maxHROverride,
+            // #1545: the DAY's effective HRmax, not just the override. Passing maxHROverride meant an
+            // install with no override left the detector to fall back to StrainScorer.estimateHRmax,
+            // which returns max(observed p99.5, Tanaka) -- so every bout was measured against a HRmax at
+            // least as high as, and usually higher than, the one its own day used. A higher HRmax is a
+            // bigger reserve and therefore a SMALLER %HRR, so bouts were held to a stricter yardstick
+            // than the day containing them: for age 30 / RHR 60 with an observed 195, a 125 bpm minute is
+            // zone 1 for the day and zone 0 for the bout. Same day-disagrees-with-its-own-workouts
+            // failure #1562 fixed for the TRIMP method.
+            //
+            // This also feeds the z2+ qualification gate below, so it changes which bouts are DETECTED,
+            // not only how they score -- in the direction of no longer dropping a workout by a standard
+            // its own day never applied. Still null for an age-less profile.
+            maxHR = effMaxHR,
             age = if (profile.age > 0) profile.age else null,
             profile = profile,
             // #1545: the bouts inside a day MUST be scored by the same recipe as the day itself. A day

--- a/android/app/src/test/java/com/noop/analytics/DayBoutHrMaxAgreementTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DayBoutHrMaxAgreementTest.kt
@@ -1,0 +1,130 @@
+package com.noop.analytics
+
+import com.noop.data.GravitySample
+import com.noop.data.HrSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1545: a workout and the day containing it must be scored against the SAME HRmax.
+ *
+ * `analyzeDay` computes `effMaxHR = maxHROverride ?: tanakaHRmax(age)` for the day's Effort, but used to
+ * hand `WorkoutDetector.detect` only `maxHROverride`. With no override — the default — the detector fell
+ * back to [StrainScorer.estimateHRmax], which returns `max(observed p99.5, Tanaka)`. So every bout was
+ * measured against a HRmax at least as high as its own day's, and usually higher.
+ *
+ * A higher HRmax is a bigger reserve and therefore a SMALLER %HRR, so bouts were held to a STRICTER
+ * standard than the day they sit inside. At age 30 / RHR 60 with an observed 195 bpm, a 125 bpm minute is
+ * zone 1 for the day and zone 0 for the bout — it counts toward the day total and scores nothing in the
+ * workout. That lands hardest at the 50% floor, which is the whole subject of #1545.
+ *
+ * Byte-parity twin of Swift `DayBoutHrMaxAgreementTests`.
+ */
+class DayBoutHrMaxAgreementTest {
+
+    private val age = 30.0
+    private val rhr = 60.0
+    private val tanaka = StrainScorer.tanakaHRmax(age)   // 187 for age 30
+
+    /** The arithmetic the fix is about, stated independently of the engine. */
+    private fun zoneWeight(bpm: Double, hrmax: Double): Int {
+        val pct = (bpm - rhr) / (hrmax - rhr) * 100.0
+        return when {
+            pct >= 90 -> 5; pct >= 80 -> 4; pct >= 70 -> 3; pct >= 60 -> 2; pct >= 50 -> 1
+            else -> 0
+        }
+    }
+
+    /**
+     * The divergence, in the estimator itself: `estimateHRmax` never returns BELOW Tanaka, so the bout's
+     * fallback HRmax is always >= the day's. This is why the bug is one-directional — bouts could only
+     * ever be under-scored relative to their day, never over-scored.
+     */
+    @Test
+    fun theBoutFallbackIsNeverBelowTheDaysTanaka() {
+        for (observed in listOf(150.0, 185.0, 195.0, 210.0)) {
+            val hist = List(700) { observed }
+            val est = StrainScorer.estimateHRmax(hist, age).first
+            assertTrue("observed=$observed gave $est, below Tanaka $tanaka", est >= tanaka - 1e-9)
+        }
+    }
+
+    /**
+     * The concrete split: the same heart rate is worth a zone to the day and nothing to the bout, purely
+     * because the two used different HRmax values.
+     */
+    @Test
+    fun theSameMinuteSplitsAcrossTheZoneFloor() {
+        val observed = 195.0
+        val boutMax = StrainScorer.estimateHRmax(List(700) { observed }, age).first
+        assertEquals("fixture assumes the observed value wins", observed, boutMax, 1e-9)
+
+        assertEquals("day scores it zone 1", 1, zoneWeight(125.0, tanaka))
+        assertEquals("bout scored it zone 0 — the bug", 0, zoneWeight(125.0, boutMax))
+    }
+
+    /**
+     * The fix, end to end — and it is a DETECTION change, not only a scoring one.
+     *
+     * A 138 bpm bout is 61.4% HRR against the day's Tanaka 187 (zone 2) but 57.8% against an observed 195
+     * (zone 1). The detector's z2+ qualification gate needs half the bout in zone 2 or above, so before
+     * the fix this workout was DROPPED — by a standard its own day never applied. It is now detected, and
+     * carries the day's HRmax.
+     */
+    @Test
+    fun theDaysHrMaxReachesDetectionAndScoring() {
+        val res = AnalyticsEngine.analyzeDay(
+            day = "2026-08-23",
+            hr = dayWithAHardPeakAndABoundaryBout(),
+            dayHr = dayWithAHardPeakAndABoundaryBout(),
+            gravity = movingAllDay(),
+            dayGravity = movingAllDay(),
+            profile = UserProfile(age = age, sex = "male"),
+        )
+        assertTrue("the boundary bout should now be detected", res.workouts.isNotEmpty())
+        for (w in res.workouts) {
+            assertEquals(
+                "every bout must carry the day's HRmax, not the observed estimate",
+                tanaka, w.hrmax ?: -1.0, 1e-9,
+            )
+        }
+    }
+
+    /** An explicit override still wins — the fix must never override the user's own number. */
+    @Test
+    fun anExplicitOverrideStillWins() {
+        val res = AnalyticsEngine.analyzeDay(
+            day = "2026-08-23",
+            hr = dayWithAHardPeakAndABoundaryBout(),
+            dayHr = dayWithAHardPeakAndABoundaryBout(),
+            gravity = movingAllDay(),
+            dayGravity = movingAllDay(),
+            profile = UserProfile(age = age, sex = "male"),
+            maxHROverride = 175.0,
+        )
+        assertTrue(res.workouts.isNotEmpty())
+        for (w in res.workouts) assertEquals(175.0, w.hrmax ?: -1.0, 1e-9)
+    }
+
+    // A day with: a brief hard effort (lifts the observed p99.5 above Tanaka), a long rest that sets a low
+    // resting baseline, and a sustained bout sitting exactly between the two HRmax interpretations.
+    private fun dayWithAHardPeakAndABoundaryBout(): List<HrSample> {
+        val out = ArrayList<HrSample>(7200)
+        fun run(from: Int, until: Int, bpm: Int) {
+            for (t in from until until) out.add(HrSample("t", t.toLong(), bpm))
+        }
+        run(0, 600, 195)        // hard peak -> observed p99.5 = 195
+        run(600, 2400, 60)      // rest -> 10th-percentile resting baseline stays 60
+        run(2400, 6000, 138)    // the boundary bout: zone 2 on Tanaka, zone 1 on observed
+        run(6000, 7200, 60)
+        return out
+    }
+
+    // Motion must actually vary: intensity is the euclidean step between consecutive gravity samples and
+    // has to clear motionThreshold (0.20) after smoothing, so a constant vector detects nothing.
+    private fun movingAllDay(): List<GravitySample> =
+        (0 until 7200).map {
+            GravitySample("t", it.toLong(), x = if (it % 2 == 0) 0.9 else 0.5, y = 0.1, z = 0.1)
+        }
+}


### PR DESCRIPTION
An improvement for #1545, found while looking for what else under-rates gym sessions. It is a genuine inconsistency rather than a tuning knob.

## The bug

`analyzeDay` computes the day's Effort against `effMaxHR = maxHROverride ?? tanakaHRmax(age)` — then hands `WorkoutDetector.detect` only `maxHROverride`. With no override (the default), the detector falls back to `StrainScorer.estimateHRmax`, which returns `max(observed p99.5, Tanaka)`.

So **every bout was measured against a HRmax at least as high as its own day's**, and higher for anyone who has ever recorded a hard effort. A higher HRmax is a bigger reserve and therefore a *smaller* %HRR — bouts were held to a stricter standard than the day they sit inside.

Age 30, RHR 60, someone who has hit 195 bpm:

| HR during a set | Day (Tanaka 187) | Bout (observed 195) |
|---|---|---|
| 125 bpm | 51.2% → **zone 1** | 48.1% → **zone 0** |

The same minute counts toward the day total and scores **nothing** in the workout. It bites hardest right at the 50% floor — which is the exact mechanism behind #1545, so this was compounding the complaint that issue is about.

Same class as the day-disagrees-with-its-own-workouts bug #1562 fixed for the TRIMP method. And it reads as an oversight rather than a decision: the parameter's own doc describes the estimate as the fallback for *"when `maxHR` is nil"*, and `analyzeDay` knows `effMaxHR` — it simply was not passing it.

## This changes detection, not only scoring

Worth being explicit, because it widens the blast radius. `effMaxHR` also feeds the **z2+ qualification gate**, so a lower HRmax means higher %HRR, more time in zone 2+, and bouts that previously failed the gate now qualify:

> A 138 bpm bout is **61.4%** HRR on Tanaka 187 (zone 2) but **57.8%** on an observed 195 (zone 1). The gate needs half the bout in zone 2+, so it was **dropped** before and is **kept** now.

That is the correct direction — it stops discarding a workout by a standard its own day never applied — but users with no HRmax override may see previously-missing workouts appear, and existing bout Effort values will move.

Unchanged when an override is set (both paths already used it), and when the profile has no age (`effMaxHR` is nil, so the detector's own estimate remains the only fallback).

## It is not only Effort — calories had the same split

Re-review found the impact is wider than the description first said. Inside `detect`, `effMaxHR` feeds **six** stored per-bout fields:

`strain` · `caloriesKcal` / `caloriesKJ` · `zoneTimePct` · `avgHRRPct` · `hrmax` · `hrmaxSource`

Calories matter most here, because the day computes them the same way — `Calories.estimateDayCalories(…, hrmax: effMaxHR, …)` at `AnalyticsEngine.swift:871`. So a bout's calorie estimate was measured against a *different* HRmax than the day it sits inside, exactly as its Effort was.

That makes this one fix rather than a fix plus a side-effect: day and bout now agree on HRmax across Effort, calories, the zone breakdown and %HRR. It also means **stored bout calories will move**, not just Effort — worth knowing before merge.

## Tests

Four per platform. The end-to-end one was **verified to fail without the fix and pass with it** — which mattered, because my first attempt passed either way: the fixture used constant gravity (zero motion, so nothing was detected at all) and a bout below the HR floor. Both are fixed, and the fixture now sits deliberately on the boundary where the two HRmax interpretations disagree.

## Verification

- Android **4,245 tests, 0 failures** (`--no-build-cache --rerun-tasks`) — 4,241 matching main plus 4 new. Kotlin compiles.
- Doc lint clean.
- Packages-only on the Swift side, so `swift-packages` covers the twin automatically; **no app-target Swift changed**, so `app-build` does not apply.

## Two things I checked and ruled out

So they don't get re-proposed:

- **Using the observed HRmax for the day** would make things *worse*. `estimateHRmax` returns `max(observed, Tanaka)`, so it can only ever raise HRmax, lowering %HRR and pushing more work under the floor.
- **The bout resting-HR fallback is fine.** `deriveRestingHR` receives the whole calendar day, not just the workout window, so it lands on a sane low percentile.

Partial work on #1545; that issue stays open pending @dofimn's feedback on the Banister scale.
