### PR TITLE
Log what each workout's Effort was scored against, and whether the strap saw it

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
@@ -55,15 +55,23 @@ public struct ExerciseSession: Equatable, Sendable {
     public let hrmaxSource: String
     public let caloriesKcal: Double?
     public let caloriesKJ: Double?
+    /// #1545: how much of the bout the HR sensor actually saw, as a percentage of 60-second buckets that
+    /// contain at least one reading. nil when it was not measured. A WHOOP 4.0's optical sensor is weak
+    /// under gripping — which is exactly what lifting is — so a low Effort has two very different causes:
+    /// the metric genuinely not rating the work, or the strap not having seen it. Those deserve opposite
+    /// advice, and until now they were indistinguishable from the outside.
+    public let hrCoveragePct: Double?
 
     public init(start: Int, end: Int, avgHR: Double, peakHR: Int, strain: Double?,
                 durationS: Double, zoneTimePct: [Int: Double], avgHRRPct: Double?,
                 hrmax: Double?, hrmaxSource: String,
-                caloriesKcal: Double?, caloriesKJ: Double?) {
+                caloriesKcal: Double?, caloriesKJ: Double?,
+                hrCoveragePct: Double? = nil) {
         self.start = start; self.end = end; self.avgHR = avgHR; self.peakHR = peakHR
         self.strain = strain; self.durationS = durationS; self.zoneTimePct = zoneTimePct
         self.avgHRRPct = avgHRRPct; self.hrmax = hrmax; self.hrmaxSource = hrmaxSource
         self.caloriesKcal = caloriesKcal; self.caloriesKJ = caloriesKJ
+        self.hrCoveragePct = hrCoveragePct
     }
 }
 
@@ -132,6 +140,62 @@ public enum WorkoutDetector {
         precondition(!bpms.isEmpty, "deriveRestingHR called with empty segment")
         let rank = max(1, Int(ceil(restingPercentile / 100.0 * Double(bpms.count))))
         return bpms[rank - 1]
+    }
+
+    /// #1545: how much of `[start, end]` the HR sensor actually covered, as a percentage of
+    /// `bucketSeconds`-wide buckets holding at least one reading.
+    ///
+    /// Bucketed rather than sample-counted on purpose. A WHOOP 5/MG sends live HR only about every 30 s,
+    /// so counting samples against a 1 Hz expectation would report ~3% for a perfectly captured bout,
+    /// which is worse than no number. A bucket is either seen or not, so a 30 s cadence reads as full
+    /// coverage and a genuine dropout reads as the gap it is.
+    public static func hrCoveragePct(sampleTs: [Int], start: Int, end: Int,
+                                     bucketSeconds: Int = 60) -> Double? {
+        guard end > start, bucketSeconds > 0 else { return nil }
+        // Integer ceil, not `ceil(Double/Double)` — same expression as the Kotlin twin, with no float
+        // rounding to reason about at a bucket boundary. A partial trailing bucket counts as a whole one,
+        // so coverage can never exceed 100.
+        let buckets = max(1, ((end - start) + bucketSeconds - 1) / bucketSeconds)
+        var seen = Set<Int>()
+        for ts in sampleTs where ts >= start && ts < end {
+            seen.insert((ts - start) / bucketSeconds)
+        }
+        return Double(seen.count) / Double(buckets) * 100.0
+    }
+
+    /// #1545: the always-on per-bout line naming what this workout's Effort was actually scored against.
+    ///
+    /// HRmax is the single biggest determinant of an Effort score — it sets every zone boundary, so being
+    /// wrong by a few bpm can move real work across the 50% floor and score it zero — and until this line
+    /// existed a user could not see which number had been used, or whether it came from their own setting
+    /// or an age formula. Working that out previously meant reversing the arithmetic from the displayed
+    /// score, which is what #1545 took to diagnose.
+    ///
+    /// No PII: a day key, a duration, bpm and percentages.
+    public static func boutCalibrationLine(day: String, durMin: Int, hrmax: Double?, hrmaxSource: String,
+                                           avgHRRPct: Double?, hrCoveragePct: Double?,
+                                           strain: Double?) -> String {
+        return "effort bout day=\(day) durMin=\(durMin) hrmax=\(round0(hrmax)) src=\(hrmaxSource) "
+            + "avgHRR=\(round0(avgHRRPct)) cover=\(round0(hrCoveragePct)) effort=\(round1(strain))"
+    }
+
+    /// The two numeric formatters this line uses, written as integer arithmetic rather than `%.0f` /
+    /// `%.1f` on purpose.
+    ///
+    /// C `printf` (Swift) breaks a rounding tie to even; Java's `String.format` (Kotlin) breaks it up. So a
+    /// bout at exactly 52.5% HRR would print `52` on iOS and `53` on Android — a parity break in a line
+    /// whose entire job is being comparable between two users' logs. Rounding to an Int first (half away
+    /// from zero, which equals `Math.round` for the non-negative bpm and percentages here) and assembling
+    /// the digits by hand removes both the tie and the locale's decimal separator.
+    static func round0(_ v: Double?) -> String {
+        guard let v, v.isFinite else { return "nil" }
+        return String(Int(v.rounded()))
+    }
+
+    static func round1(_ v: Double?) -> String {
+        guard let v, v.isFinite else { return "nil" }
+        let t = Int((v * 10).rounded())
+        return "\(t / 10).\(abs(t % 10))"
     }
 
     /// Value whose ts is nearest to `ts` within `tol` seconds, else nil. Ties go
@@ -371,7 +435,9 @@ public enum WorkoutDetector {
             sessions.append(ExerciseSession(
                 start: effStart, end: end, avgHR: avg, peakHR: peak, strain: strain,
                 durationS: Double(end - effStart), zoneTimePct: zonePct, avgHRRPct: avgHRR,
-                hrmax: effMaxHR, hrmaxSource: hrmaxSource, caloriesKcal: kcal, caloriesKJ: kj))
+                hrmax: effMaxHR, hrmaxSource: hrmaxSource, caloriesKcal: kcal, caloriesKJ: kj,
+                hrCoveragePct: hrCoveragePct(sampleTs: hrSamples.map { $0.ts },
+                                             start: effStart, end: end)))
         }
         return sessions
     }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
@@ -179,23 +179,35 @@ public enum WorkoutDetector {
             + "avgHRR=\(round0(avgHRRPct)) cover=\(round0(hrCoveragePct)) effort=\(round1(strain))"
     }
 
-    /// The two numeric formatters this line uses, written as integer arithmetic rather than `%.0f` /
-    /// `%.1f` on purpose.
+    /// The two numeric formatters this line uses, written as integer arithmetic over the value's
+    /// MAGNITUDE rather than `%.0f` / `%.1f`.
     ///
-    /// C `printf` (Swift) breaks a rounding tie to even; Java's `String.format` (Kotlin) breaks it up. So a
-    /// bout at exactly 52.5% HRR would print `52` on iOS and `53` on Android — a parity break in a line
-    /// whose entire job is being comparable between two users' logs. Rounding to an Int first (half away
-    /// from zero, which equals `Math.round` for the non-negative bpm and percentages here) and assembling
-    /// the digits by hand removes both the tie and the locale's decimal separator.
+    /// Three things this shape avoids, all of which would break a line whose entire job is being
+    /// comparable between two users' logs — and between an iOS log and an Android one:
+    ///
+    /// - **The positive tie.** C `printf` (Swift) breaks a rounding tie to even; Java's `String.format`
+    ///   (Kotlin) breaks it up. A bout at exactly 52.5% HRR would print `52` on iOS and `53` on Android.
+    /// - **The negative tie.** Swift's `.rounded()` is half-AWAY-from-zero and Java's `Math.round` is
+    ///   half-UP, so they disagree on -4.5 (-5 vs -4). Rounding `abs(v)` and re-applying the sign makes
+    ///   the two identical in both directions; it also keeps the minus sign, which integer `/` and `%`
+    ///   truncating toward zero would otherwise drop (-0.4 printing as `0.4`).
+    /// - **The trap.** Swift's `Int(_: Double)` CRASHES on a finite value past `Int.max` while Kotlin's
+    ///   `Math.round` silently saturates to `Long.MAX_VALUE`. Today's caller cannot produce one (the
+    ///   detector gates `maxHR > restingHR` before computing %HRR), but this is public API, and a
+    ///   diagnostic that kills the process is the worst possible way for one to fail. Past the bound both
+    ///   platforms print `nil`, which is also the more honest answer: such a value is not a heart rate, a
+    ///   percentage or an Effort.
+    static let printableMagnitudeLimit = 1e15
+
     static func round0(_ v: Double?) -> String {
-        guard let v, v.isFinite else { return "nil" }
-        return String(Int(v.rounded()))
+        guard let v, v.isFinite, abs(v) < printableMagnitudeLimit else { return "nil" }
+        return (v < 0 ? "-" : "") + String(Int(abs(v).rounded()))
     }
 
     static func round1(_ v: Double?) -> String {
-        guard let v, v.isFinite else { return "nil" }
-        let t = Int((v * 10).rounded())
-        return "\(t / 10).\(abs(t % 10))"
+        guard let v, v.isFinite, abs(v) < printableMagnitudeLimit else { return "nil" }
+        let t = Int((abs(v) * 10).rounded())
+        return "\(v < 0 ? "-" : "")\(t / 10).\(t % 10)"
     }
 
     /// Value whose ts is nearest to `ts` within `tol` seconds, else nil. Ties go

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BoutCalibrationDiagnosticTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BoutCalibrationDiagnosticTests.swift
@@ -99,10 +99,42 @@ final class BoutCalibrationDiagnosticTests: XCTestCase {
         XCTAssertEqual(WorkoutDetector.round1(21.0), "21.0")
     }
 
+    /// The NEGATIVE tie, which breaks the other way: Swift's `.rounded()` is half-away-from-zero and
+    /// Java's `Math.round` is half-up, so they disagree on -4.5 (-5 vs -4). Rounding the magnitude and
+    /// re-applying the sign makes them agree — and these values are non-negative in production precisely
+    /// so that nobody notices when they stop agreeing, which is why it is pinned rather than assumed.
+    func testNegativesRoundSymmetricallyAndKeepTheirSign() {
+        XCTAssertEqual(WorkoutDetector.round1(-0.45), "-0.5")
+        XCTAssertEqual(WorkoutDetector.round1(-8.25), "-8.3")
+        XCTAssertEqual(WorkoutDetector.round0(-52.5), "-53")
+    }
+
+    /// The minus sign must survive. Integer `/` and `%` truncate toward zero, so a naive
+    /// `"\(t / 10).\(abs(t % 10))"` renders -0.4 as `0.4` — a diagnostic silently reporting the
+    /// opposite of the truth, which is worse than reporting nothing.
+    func testASmallNegativeDoesNotLoseItsSign() {
+        XCTAssertEqual(WorkoutDetector.round1(-0.4), "-0.4")
+        XCTAssertNotEqual(WorkoutDetector.round1(-0.4), "0.4")
+    }
+
     /// A non-finite value must not print `inf`/`nan` into a log people read as evidence.
     func testNonFiniteValuesAreNil() {
         XCTAssertEqual(WorkoutDetector.round0(.nan), "nil")
         XCTAssertEqual(WorkoutDetector.round1(.infinity), "nil")
+    }
+
+    /// And an absurd FINITE value must not take the process with it. `Int(1e300)` traps in Swift while
+    /// Kotlin's `Math.round` saturates to `Long.MAX_VALUE` — a crash on one platform and a nonsense
+    /// number on the other, from a line whose only job is explaining a bug. Both print `nil` instead.
+    ///
+    /// Not reachable through today's detector (it gates `maxHR > restingHR` before computing %HRR), but
+    /// these formatters are public API and a near-zero HR reserve is the obvious way in.
+    func testAnAbsurdFiniteValueIsNilRatherThanACrash() {
+        XCTAssertEqual(WorkoutDetector.round0(1e300), "nil")
+        XCTAssertEqual(WorkoutDetector.round1(-1e300), "nil")
+        XCTAssertEqual(WorkoutDetector.round0(Double(Int.max)), "nil")
+        // The bound is well clear of anything physiological — real values still print.
+        XCTAssertEqual(WorkoutDetector.round0(220.0), "220")
     }
 
     // MARK: end to end

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BoutCalibrationDiagnosticTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BoutCalibrationDiagnosticTests.swift
@@ -119,8 +119,9 @@ final class BoutCalibrationDiagnosticTests: XCTestCase {
 
     /// A non-finite value must not print `inf`/`nan` into a log people read as evidence.
     func testNonFiniteValuesAreNil() {
-        XCTAssertEqual(WorkoutDetector.round0(.nan), "nil")
-        XCTAssertEqual(WorkoutDetector.round1(.infinity), "nil")
+        XCTAssertEqual(WorkoutDetector.round0(Double.nan), "nil")
+        XCTAssertEqual(WorkoutDetector.round1(Double.infinity), "nil")
+        XCTAssertEqual(WorkoutDetector.round1(-Double.infinity), "nil")
     }
 
     /// And an absurd FINITE value must not take the process with it. `Int(1e300)` traps in Swift while

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BoutCalibrationDiagnosticTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BoutCalibrationDiagnosticTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+import Foundation
+@testable import StrandAnalytics
+import WhoopProtocol
+
+/// #1545: the two always-on bout diagnostics — HR coverage, and the line naming what an Effort was scored
+/// against.
+///
+/// Diagnosing #1545 meant reversing the arithmetic out of a displayed score to work out which HRmax had set
+/// the zone boundaries. These two make that visible from a strap log alone, and split the three causes a
+/// low Effort can have: the 50% floor doing its job, a wrong HRmax, or the sensor not being there.
+///
+/// Neither changes a score. That is exactly why they need pinning: a silently-wrong diagnostic is worse
+/// than none, because the next report will be argued from it.
+///
+/// Byte-parity twin of Kotlin `BoutCalibrationDiagnosticTest`.
+final class BoutCalibrationDiagnosticTests: XCTestCase {
+
+    // MARK: coverage
+
+    /// The reason coverage is bucketed rather than sample-counted.
+    ///
+    /// A WHOOP 5/MG sends live HR about every 30 s. Counted against a 1 Hz expectation a perfectly captured
+    /// hour would report ~3% — a number that reads as "the sensor was off" for the most common healthy
+    /// case, and would send every 5/MG user chasing a hardware fault that isn't there.
+    func testAThirtySecondCadenceIsFullCoverageNotThreePercent() {
+        let ts = stride(from: 0, to: 3600, by: 30).map { $0 }
+        XCTAssertEqual(WorkoutDetector.hrCoveragePct(sampleTs: ts, start: 0, end: 3600) ?? -1,
+                       100.0, accuracy: 1e-9)
+    }
+
+    /// And a real dropout still reads as the gap it is — the diagnostic has to keep the signal it exists
+    /// for, not just avoid the false alarm above.
+    func testARealDropoutReadsAsTheGap() {
+        let ts = stride(from: 0, to: 1800, by: 30).map { $0 }          // first half only
+        XCTAssertEqual(WorkoutDetector.hrCoveragePct(sampleTs: ts, start: 0, end: 3600) ?? -1,
+                       50.0, accuracy: 1e-9)
+    }
+
+    /// Samples outside the bout must not inflate it. The detector back-dates a bout's start over the
+    /// warm-up, so the surrounding day's samples are genuinely present in memory beside these.
+    func testSamplesOutsideTheWindowAreIgnored() {
+        let ts = Array(0 ..< 600) + Array(7200 ..< 10800)
+        // 600 s in window = 10 of the hour's 60 buckets. The hour of samples AFTER the bout contributes
+        // nothing — if it did, a bout followed by a long walk would report as fully covered.
+        XCTAssertEqual(WorkoutDetector.hrCoveragePct(sampleTs: ts, start: 0, end: 3600) ?? -1,
+                       10.0 / 60.0 * 100.0, accuracy: 1e-9)
+    }
+
+    /// A partial trailing bucket still counts as a whole one — 90 s is two buckets, not 1.5 — so coverage
+    /// can never exceed 100 and a short bout can't read as over-covered.
+    func testAPartialTrailingBucketCountsAsAWholeBucket() {
+        let ts = Array(0 ..< 90)
+        XCTAssertEqual(WorkoutDetector.hrCoveragePct(sampleTs: ts, start: 0, end: 90) ?? -1,
+                       100.0, accuracy: 1e-9)
+        // One sample in each of two buckets is still full coverage; one bucket empty is half.
+        XCTAssertEqual(WorkoutDetector.hrCoveragePct(sampleTs: [0], start: 0, end: 90) ?? -1,
+                       50.0, accuracy: 1e-9)
+    }
+
+    /// Degenerate windows report nothing rather than a fabricated 0 or 100.
+    func testDegenerateWindowsAreNil() {
+        XCTAssertNil(WorkoutDetector.hrCoveragePct(sampleTs: [1, 2], start: 100, end: 100))
+        XCTAssertNil(WorkoutDetector.hrCoveragePct(sampleTs: [1, 2], start: 100, end: 50))
+        XCTAssertNil(WorkoutDetector.hrCoveragePct(sampleTs: [1, 2], start: 0, end: 60, bucketSeconds: 0))
+    }
+
+    // MARK: the line
+
+    /// The exact bytes. This string is compared between two users' logs — and between an iOS log and an
+    /// Android one — so its shape is the contract, not an implementation detail.
+    func testTheLineIsExactlyThis() {
+        XCTAssertEqual(
+            WorkoutDetector.boutCalibrationLine(day: "2026-08-24", durMin: 45, hrmax: 187.0,
+                                                hrmaxSource: "caller", avgHRRPct: 52.4,
+                                                hrCoveragePct: 43.2, strain: 8.14),
+            "effort bout day=2026-08-24 durMin=45 hrmax=187 src=caller avgHRR=52 cover=43 effort=8.1")
+    }
+
+    /// Missing values say so. A bout with no HRmax is a different diagnosis from one with a low HRmax, and
+    /// printing 0 for both would merge the two.
+    func testMissingValuesRenderAsNilNotZero() {
+        XCTAssertEqual(
+            WorkoutDetector.boutCalibrationLine(day: "2026-08-24", durMin: 12, hrmax: nil,
+                                                hrmaxSource: "estimated", avgHRRPct: nil,
+                                                hrCoveragePct: nil, strain: nil),
+            "effort bout day=2026-08-24 durMin=12 hrmax=nil src=estimated avgHRR=nil cover=nil effort=nil")
+    }
+
+    /// The rounding tie this formatter exists to remove. C `printf` rounds .5 to even and Java rounds it
+    /// up, so `%.0f` on 52.5 would print 52 on iOS and 53 on Android — the two logs the line is meant to be
+    /// compared across. Both platforms must produce the Java answer here.
+    func testAHalfRoundsUpOnBothPlatforms() {
+        XCTAssertEqual(WorkoutDetector.round0(52.5), "53")
+        XCTAssertEqual(WorkoutDetector.round0(53.5), "54")   // printf: 52 then 54 — it ties to even
+        XCTAssertEqual(WorkoutDetector.round0(0.5), "1")
+        XCTAssertEqual(WorkoutDetector.round1(8.25), "8.3")
+        XCTAssertEqual(WorkoutDetector.round1(0.0), "0.0")
+        XCTAssertEqual(WorkoutDetector.round1(21.0), "21.0")
+    }
+
+    /// A non-finite value must not print `inf`/`nan` into a log people read as evidence.
+    func testNonFiniteValuesAreNil() {
+        XCTAssertEqual(WorkoutDetector.round0(.nan), "nil")
+        XCTAssertEqual(WorkoutDetector.round1(.infinity), "nil")
+    }
+
+    // MARK: end to end
+
+    /// The field has to actually arrive on a detected bout — a diagnostic that is always `nil` in
+    /// production would pass every unit test above and tell a reporter nothing.
+    func testDetectedBoutsCarryCoverage() {
+        let hr = (0 ..< 3600).map { HRSample(ts: $0, bpm: $0 < 600 || $0 > 3000 ? 60 : 150) }
+        let grav = (0 ..< 3600).map { GravitySample(ts: $0, x: $0 % 2 == 0 ? 0.9 : 0.5, y: 0.1, z: 0.1) }
+        let bouts = WorkoutDetector.detect(hr: hr, gravity: grav, restingHR: 60, maxHR: 190, age: 30)
+
+        XCTAssertFalse(bouts.isEmpty, "fixture must produce a bout for this test to mean anything")
+        for b in bouts {
+            XCTAssertNotNil(b.hrCoveragePct, "a detected bout must report its coverage")
+            // 1 Hz HR runs across the whole fixture, so every bucket of any detected window is populated
+            // — the assertion holds wherever the detector back-dates the start to.
+            XCTAssertEqual(b.hrCoveragePct ?? -1, 100.0, accuracy: 1e-9)
+        }
+    }
+}

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1679,6 +1679,16 @@ final class IntelligenceEngine: ObservableObject {
             for s in night.workouts {
                 let durMin = max(0, (s.end - s.start) / 60)
                 let avgBpm = Int(s.avgHR)
+                // #1545: always-on, one line per detected bout naming what this Effort was SCORED AGAINST.
+                // A user reporting "my hard session scored 1.7" cannot currently see the HRmax that set the
+                // zone boundaries, where it came from, or whether the strap even saw most of the bout — and
+                // those three answers separate the three different causes ("the floor is doing its job",
+                // "your HRmax is wrong", "the sensor dropped out"). Reversing the arithmetic out of the
+                // displayed score is what diagnosing #1545 actually took. Same privacy class as the sibling
+                // `sleep day=` line: a day key, a duration, bpm and percentages.
+                diagnosticSink?(WorkoutDetector.boutCalibrationLine(
+                    day: daily.day, durMin: durMin, hrmax: s.hrmax, hrmaxSource: s.hrmaxSource,
+                    avgHRRPct: s.avgHRRPct, hrCoveragePct: s.hrCoveragePct, strain: s.strain), nil)
                 // The overlap test is bare time overlap (any source), so a detected bout collapses against a
                 // manual session even though their SPORTS differ ("detected" vs the user's sport) , the
                 // #975 "two workouts, one vanished" seam. Find the collider so the trace can name its source.

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsModels.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsModels.kt
@@ -144,6 +144,11 @@ data class ExerciseSession(
     val hrmaxSource: String,
     val caloriesKcal: Double?,
     val caloriesKJ: Double?,
+    /** #1545: how much of the bout the HR sensor actually saw, as a percentage of 60-second buckets that
+     *  contain at least one reading. null when not measured. A WHOOP 4.0's optical sensor is weak under
+     *  gripping — exactly what lifting is — so a low Effort has two very different causes: the metric not
+     *  rating the work, or the strap not having seen it. Those deserve opposite advice. */
+    val hrCoveragePct: Double? = null,
 )
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1418,6 +1418,19 @@ object IntelligenceEngine {
             for (s in res.workouts) {
                 val durMin = maxOf(0L, (s.end - s.start) / 60L).toInt()
                 val avgBpm = s.avgHR.toInt()
+                // #1545: always-on, one line per detected bout naming what this Effort was SCORED AGAINST.
+                // A user reporting "my hard session scored 1.7" cannot currently see the HRmax that set the
+                // zone boundaries, where it came from, or whether the strap even saw most of the bout — and
+                // those three answers separate the three different causes ("the floor is doing its job",
+                // "your HRmax is wrong", "the sensor dropped out"). Reversing the arithmetic out of the
+                // displayed score is what diagnosing #1545 actually took. Same privacy class as the sibling
+                // `sleep day=` line: a day key, a duration, bpm and percentages. Mirrors the Swift line.
+                diag(
+                    WorkoutDetector.boutCalibrationLine(
+                        day = daily.day, durMin = durMin, hrmax = s.hrmax, hrmaxSource = s.hrmaxSource,
+                        avgHRRPct = s.avgHRRPct, hrCoveragePct = s.hrCoveragePct, strain = s.strain,
+                    ),
+                )
                 // Bare time overlap (any source), so a detected bout collapses against a manual session even
                 // though their sports differ , the #975 "two workouts, one vanished" seam. Name the collider.
                 val collider = realWorkouts.firstOrNull { w -> s.start < w.endTs && w.startTs < s.end }

--- a/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
+++ b/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
@@ -142,22 +142,35 @@ object WorkoutDetector {
             "avgHRR=${round0(avgHRRPct)} cover=${round0(hrCoveragePct)} effort=${round1(strain)}"
 
     /**
-     * The two numeric formatters this line uses, written as integer arithmetic rather than `%.0f` /
-     * `%.1f` on purpose.
+     * The two numeric formatters this line uses, written as integer arithmetic over the value's MAGNITUDE
+     * rather than %.0f / %.1f.
      *
-     * C `printf` (Swift) breaks a rounding tie to even; Java's `String.format` (Kotlin) breaks it up. So a
-     * bout at exactly 52.5% HRR would print `52` on iOS and `53` on Android — a parity break in a line
-     * whose entire job is being comparable between two users' logs. Rounding to an Int first (half away
-     * from zero, which equals `Math.round` for the non-negative bpm and percentages here) and assembling
-     * the digits by hand removes both the tie and the locale's decimal separator.
+     * Three things this shape avoids, all of which would break a line whose entire job is being comparable
+     * between two users' logs — and between an iOS log and an Android one:
+     *
+     * - The positive tie. C printf (Swift) breaks a rounding tie to even; Java's String.format
+     *   (Kotlin) breaks it up. A bout at exactly 52.5% HRR would print 52 on iOS and 53 on Android.
+     * - The negative tie. Swift's .rounded() is half-AWAY-from-zero and Java's Math.round is
+     *   half-UP, so they disagree on -4.5 (-5 vs -4). Rounding abs(v) and re-applying the sign makes the
+     *   two identical in both directions; it also keeps the minus sign, which integer / and % truncating
+     *   toward zero would otherwise drop (-0.4 printing as 0.4).
+     * - The trap. Swift's Int(_: Double) CRASHES on a finite value past Int.max while Kotlin's
+     *   Math.round silently saturates to Long.MAX_VALUE. Today's caller can't produce one (the detector
+     *   gates maxHR > restingHR before computing %HRR), but this is public API, and a diagnostic that kills
+     *   the process is the worst possible way for one to fail. Past the bound both platforms print nil,
+     *   which is also the more honest answer: such a value is not a heart rate, a percentage or an Effort.
      */
-    internal fun round0(v: Double?): String =
-        if (v == null || !v.isFinite()) "nil" else Math.round(v).toString()
+    internal const val PRINTABLE_MAGNITUDE_LIMIT = 1e15
+
+    internal fun round0(v: Double?): String {
+        if (v == null || !v.isFinite() || abs(v) >= PRINTABLE_MAGNITUDE_LIMIT) return "nil"
+        return (if (v < 0) "-" else "") + Math.round(abs(v)).toString()
+    }
 
     internal fun round1(v: Double?): String {
-        if (v == null || !v.isFinite()) return "nil"
-        val t = Math.round(v * 10.0)
-        return "${t / 10}.${kotlin.math.abs(t % 10)}"
+        if (v == null || !v.isFinite() || abs(v) >= PRINTABLE_MAGNITUDE_LIMIT) return "nil"
+        val t = Math.round(abs(v) * 10.0)
+        return "${if (v < 0) "-" else ""}${t / 10}.${t % 10}"
     }
 
     /**

--- a/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
+++ b/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
@@ -107,6 +107,60 @@ object WorkoutDetector {
     }
 
     /**
+     * #1545: how much of [start]..[end] the HR sensor actually covered, as a percentage of
+     * [bucketSeconds]-wide buckets holding at least one reading.
+     *
+     * Bucketed rather than sample-counted on purpose. A WHOOP 5/MG sends live HR only about every 30 s, so
+     * counting samples against a 1 Hz expectation would report ~3% for a perfectly captured bout, which is
+     * worse than no number. A bucket is either seen or not, so a 30 s cadence reads as full coverage and a
+     * genuine dropout reads as the gap it is. Byte-parity twin of Swift `hrCoveragePct`.
+     */
+    fun hrCoveragePct(sampleTs: List<Long>, start: Long, end: Long, bucketSeconds: Long = 60L): Double? {
+        if (end <= start || bucketSeconds <= 0) return null
+        val buckets = maxOf(1L, ((end - start) + bucketSeconds - 1) / bucketSeconds)
+        val seen = HashSet<Long>()
+        for (ts in sampleTs) if (ts in start until end) seen.add((ts - start) / bucketSeconds)
+        return seen.size.toDouble() / buckets.toDouble() * 100.0
+    }
+
+    /**
+     * #1545: the always-on per-bout line naming what this workout's Effort was actually scored against.
+     *
+     * HRmax is the single biggest determinant of an Effort score -- it sets every zone boundary, so being
+     * wrong by a few bpm can move real work across the 50% floor and score it zero -- and until this line
+     * existed a user could not see which number had been used, or whether it came from their own setting
+     * or an age formula. Working that out previously meant reversing the arithmetic from the displayed
+     * score, which is what #1545 took to diagnose.
+     *
+     * No PII: a day key, a duration, bpm and percentages. Byte-identical string to the Swift twin.
+     */
+    fun boutCalibrationLine(
+        day: String, durMin: Int, hrmax: Double?, hrmaxSource: String,
+        avgHRRPct: Double?, hrCoveragePct: Double?, strain: Double?,
+    ): String =
+        "effort bout day=$day durMin=$durMin hrmax=${round0(hrmax)} src=$hrmaxSource " +
+            "avgHRR=${round0(avgHRRPct)} cover=${round0(hrCoveragePct)} effort=${round1(strain)}"
+
+    /**
+     * The two numeric formatters this line uses, written as integer arithmetic rather than `%.0f` /
+     * `%.1f` on purpose.
+     *
+     * C `printf` (Swift) breaks a rounding tie to even; Java's `String.format` (Kotlin) breaks it up. So a
+     * bout at exactly 52.5% HRR would print `52` on iOS and `53` on Android — a parity break in a line
+     * whose entire job is being comparable between two users' logs. Rounding to an Int first (half away
+     * from zero, which equals `Math.round` for the non-negative bpm and percentages here) and assembling
+     * the digits by hand removes both the tie and the locale's decimal separator.
+     */
+    internal fun round0(v: Double?): String =
+        if (v == null || !v.isFinite()) "nil" else Math.round(v).toString()
+
+    internal fun round1(v: Double?): String {
+        if (v == null || !v.isFinite()) return "nil"
+        val t = Math.round(v * 10.0)
+        return "${t / 10}.${kotlin.math.abs(t % 10)}"
+    }
+
+    /**
      * Value whose ts is nearest to [ts] within [tol] seconds, else null. Ties go
      * to the later timestamp (matches the Python <= behaviour).
      */
@@ -397,6 +451,7 @@ object WorkoutDetector {
                     hrmaxSource = hrmaxSource,
                     caloriesKcal = kcal,
                     caloriesKJ = kj,
+                    hrCoveragePct = hrCoveragePct(window.map { it.ts }, effStart, end),
                 )
             )
         }

--- a/android/app/src/test/java/com/noop/analytics/BoutCalibrationDiagnosticTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/BoutCalibrationDiagnosticTest.kt
@@ -156,6 +156,7 @@ class BoutCalibrationDiagnosticTest {
     fun nonFiniteValuesAreNil() {
         assertEquals("nil", WorkoutDetector.round0(Double.NaN))
         assertEquals("nil", WorkoutDetector.round1(Double.POSITIVE_INFINITY))
+        assertEquals("nil", WorkoutDetector.round1(Double.NEGATIVE_INFINITY))
     }
 
     /**

--- a/android/app/src/test/java/com/noop/analytics/BoutCalibrationDiagnosticTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/BoutCalibrationDiagnosticTest.kt
@@ -3,6 +3,7 @@ package com.noop.analytics
 import com.noop.data.GravitySample
 import com.noop.data.HrSample
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -126,11 +127,52 @@ class BoutCalibrationDiagnosticTest {
         assertEquals("21.0", WorkoutDetector.round1(21.0))
     }
 
+    /**
+     * The NEGATIVE tie, which breaks the other way: Swift's `.rounded()` is half-away-from-zero and Java's
+     * `Math.round` is half-up, so they disagree on -4.5 (-5 vs -4). Rounding the magnitude and re-applying
+     * the sign makes them agree — and these values are non-negative in production precisely so that nobody
+     * notices when they stop agreeing, which is why it is pinned rather than assumed.
+     */
+    @Test
+    fun negativesRoundSymmetricallyAndKeepTheirSign() {
+        assertEquals("-0.5", WorkoutDetector.round1(-0.45))
+        assertEquals("-8.3", WorkoutDetector.round1(-8.25))
+        assertEquals("-53", WorkoutDetector.round0(-52.5))
+    }
+
+    /**
+     * The minus sign must survive. Integer `/` and `%` truncate toward zero, so a naive
+     * `"${t / 10}.${abs(t % 10)}"` renders -0.4 as `0.4` — a diagnostic silently reporting the opposite of
+     * the truth, which is worse than reporting nothing.
+     */
+    @Test
+    fun aSmallNegativeDoesNotLoseItsSign() {
+        assertEquals("-0.4", WorkoutDetector.round1(-0.4))
+        assertNotEquals("0.4", WorkoutDetector.round1(-0.4))
+    }
+
     /** A non-finite value must not print `inf`/`nan` into a log people read as evidence. */
     @Test
     fun nonFiniteValuesAreNil() {
         assertEquals("nil", WorkoutDetector.round0(Double.NaN))
         assertEquals("nil", WorkoutDetector.round1(Double.POSITIVE_INFINITY))
+    }
+
+    /**
+     * And an absurd FINITE value must not take the process with it. `Int(1e300)` traps in Swift while
+     * Kotlin's `Math.round` saturates to `Long.MAX_VALUE` — a crash on one platform and a nonsense number
+     * on the other, from a line whose only job is explaining a bug. Both print `nil` instead.
+     *
+     * Not reachable through today's detector (it gates `maxHR > restingHR` before computing %HRR), but
+     * these formatters are public API and a near-zero HR reserve is the obvious way in.
+     */
+    @Test
+    fun anAbsurdFiniteValueIsNilRatherThanACrash() {
+        assertEquals("nil", WorkoutDetector.round0(1e300))
+        assertEquals("nil", WorkoutDetector.round1(-1e300))
+        assertEquals("nil", WorkoutDetector.round0(Long.MAX_VALUE.toDouble()))
+        // The bound is well clear of anything physiological — real values still print.
+        assertEquals("220", WorkoutDetector.round0(220.0))
     }
 
     // ── end to end ────────────────────────────────────────────────────────────────────────────────

--- a/android/app/src/test/java/com/noop/analytics/BoutCalibrationDiagnosticTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/BoutCalibrationDiagnosticTest.kt
@@ -1,0 +1,160 @@
+package com.noop.analytics
+
+import com.noop.data.GravitySample
+import com.noop.data.HrSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1545: the two always-on bout diagnostics — HR coverage, and the line naming what an Effort was scored
+ * against.
+ *
+ * Diagnosing #1545 meant reversing the arithmetic out of a displayed score to work out which HRmax had set
+ * the zone boundaries. These two make that visible from a strap log alone, and split the three causes a low
+ * Effort can have: the 50% floor doing its job, a wrong HRmax, or the sensor not being there.
+ *
+ * Neither changes a score. That is exactly why they need pinning: a silently-wrong diagnostic is worse than
+ * none, because the next report will be argued from it.
+ *
+ * Byte-parity twin of Swift `BoutCalibrationDiagnosticTests`.
+ */
+class BoutCalibrationDiagnosticTest {
+
+    // ── coverage ──────────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * The reason coverage is bucketed rather than sample-counted.
+     *
+     * A WHOOP 5/MG sends live HR about every 30 s. Counted against a 1 Hz expectation a perfectly captured
+     * hour would report ~3% — a number that reads as "the sensor was off" for the most common healthy case,
+     * and would send every 5/MG user chasing a hardware fault that isn't there.
+     */
+    @Test
+    fun aThirtySecondCadenceIsFullCoverageNotThreePercent() {
+        val ts = (0L until 3600L step 30L).toList()
+        assertEquals(100.0, WorkoutDetector.hrCoveragePct(ts, 0L, 3600L) ?: -1.0, 1e-9)
+    }
+
+    /**
+     * And a real dropout still reads as the gap it is — the diagnostic has to keep the signal it exists
+     * for, not just avoid the false alarm above.
+     */
+    @Test
+    fun aRealDropoutReadsAsTheGap() {
+        val ts = (0L until 1800L step 30L).toList()          // first half only
+        assertEquals(50.0, WorkoutDetector.hrCoveragePct(ts, 0L, 3600L) ?: -1.0, 1e-9)
+    }
+
+    /**
+     * Samples outside the bout must not inflate it. The detector back-dates a bout's start over the
+     * warm-up, so the surrounding day's samples are genuinely present in memory beside these.
+     */
+    @Test
+    fun samplesOutsideTheWindowAreIgnored() {
+        val ts = (0L until 600L).toList() + (7200L until 10800L).toList()
+        // 600 s in window = 10 of the hour's 60 buckets. The hour of samples AFTER the bout contributes
+        // nothing — if it did, a bout followed by a long walk would report as fully covered.
+        assertEquals(10.0 / 60.0 * 100.0, WorkoutDetector.hrCoveragePct(ts, 0L, 3600L) ?: -1.0, 1e-9)
+    }
+
+    /**
+     * A partial trailing bucket still counts as a whole one — 90 s is two buckets, not 1.5 — so coverage
+     * can never exceed 100 and a short bout can't read as over-covered.
+     */
+    @Test
+    fun aPartialTrailingBucketCountsAsAWholeBucket() {
+        assertEquals(100.0, WorkoutDetector.hrCoveragePct((0L until 90L).toList(), 0L, 90L) ?: -1.0, 1e-9)
+        // One sample in each of two buckets is still full coverage; one bucket empty is half.
+        assertEquals(50.0, WorkoutDetector.hrCoveragePct(listOf(0L), 0L, 90L) ?: -1.0, 1e-9)
+    }
+
+    /** Degenerate windows report nothing rather than a fabricated 0 or 100. */
+    @Test
+    fun degenerateWindowsAreNull() {
+        assertNull(WorkoutDetector.hrCoveragePct(listOf(1L, 2L), 100L, 100L))
+        assertNull(WorkoutDetector.hrCoveragePct(listOf(1L, 2L), 100L, 50L))
+        assertNull(WorkoutDetector.hrCoveragePct(listOf(1L, 2L), 0L, 60L, bucketSeconds = 0L))
+    }
+
+    // ── the line ──────────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * The exact bytes. This string is compared between two users' logs — and between an iOS log and an
+     * Android one — so its shape is the contract, not an implementation detail.
+     */
+    @Test
+    fun theLineIsExactlyThis() {
+        assertEquals(
+            "effort bout day=2026-08-24 durMin=45 hrmax=187 src=caller avgHRR=52 cover=43 effort=8.1",
+            WorkoutDetector.boutCalibrationLine(
+                day = "2026-08-24", durMin = 45, hrmax = 187.0, hrmaxSource = "caller",
+                avgHRRPct = 52.4, hrCoveragePct = 43.2, strain = 8.14,
+            ),
+        )
+    }
+
+    /**
+     * Missing values say so. A bout with no HRmax is a different diagnosis from one with a low HRmax, and
+     * printing 0 for both would merge the two.
+     */
+    @Test
+    fun missingValuesRenderAsNilNotZero() {
+        assertEquals(
+            "effort bout day=2026-08-24 durMin=12 hrmax=nil src=estimated avgHRR=nil cover=nil effort=nil",
+            WorkoutDetector.boutCalibrationLine(
+                day = "2026-08-24", durMin = 12, hrmax = null, hrmaxSource = "estimated",
+                avgHRRPct = null, hrCoveragePct = null, strain = null,
+            ),
+        )
+    }
+
+    /**
+     * The rounding tie this formatter exists to remove. C `printf` rounds .5 to even and Java rounds it up,
+     * so `%.0f` on 52.5 would print 52 on iOS and 53 on Android — the two logs the line is meant to be
+     * compared across. Both platforms must produce the Java answer here.
+     */
+    @Test
+    fun aHalfRoundsUpOnBothPlatforms() {
+        assertEquals("53", WorkoutDetector.round0(52.5))
+        assertEquals("54", WorkoutDetector.round0(53.5))   // printf: 52 then 54 — it ties to even
+        assertEquals("1", WorkoutDetector.round0(0.5))
+        assertEquals("8.3", WorkoutDetector.round1(8.25))
+        assertEquals("0.0", WorkoutDetector.round1(0.0))
+        assertEquals("21.0", WorkoutDetector.round1(21.0))
+    }
+
+    /** A non-finite value must not print `inf`/`nan` into a log people read as evidence. */
+    @Test
+    fun nonFiniteValuesAreNil() {
+        assertEquals("nil", WorkoutDetector.round0(Double.NaN))
+        assertEquals("nil", WorkoutDetector.round1(Double.POSITIVE_INFINITY))
+    }
+
+    // ── end to end ────────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * The field has to actually arrive on a detected bout — a diagnostic that is always null in production
+     * would pass every unit test above and tell a reporter nothing.
+     */
+    @Test
+    fun detectedBoutsCarryCoverage() {
+        val hr = (0 until 3600).map {
+            HrSample("t", it.toLong(), if (it < 600 || it > 3000) 60 else 150)
+        }
+        val grav = (0 until 3600).map {
+            GravitySample("t", it.toLong(), x = if (it % 2 == 0) 0.9 else 0.5, y = 0.1, z = 0.1)
+        }
+        val bouts = WorkoutDetector.detect(hr = hr, gravity = grav, restingHR = 60.0, maxHR = 190.0, age = 30.0)
+
+        assertTrue("fixture must produce a bout for this test to mean anything", bouts.isNotEmpty())
+        for (b in bouts) {
+            assertNotNull("a detected bout must report its coverage", b.hrCoveragePct)
+            // 1 Hz HR runs across the whole fixture, so every bucket of any detected window is populated
+            // — the assertion holds wherever the detector back-dates the start to.
+            assertEquals(100.0, b.hrCoveragePct ?: -1.0, 1e-9)
+        }
+    }
+}


### PR DESCRIPTION
Two always-on diagnostics for #1545. **Neither changes a score** — no formula, threshold or stored
metric moves.

Diagnosing #1545 meant reversing the arithmetic out of a displayed Effort to work out which HRmax had
set the zone boundaries. Nothing in a strap log named it, so "my hard session scored 1.7" could not be
told apart from the three quite different things it can mean:

| what's actually happening | what you need to see |
|---|---|
| the 50% HRR floor doing its job | avgHRR sitting under 50 |
| HRmax is wrong for this user | the hrmax used, and where it came from |
| the strap never saw the bout | HR coverage during the window |

## 1. `effort bout` — what the score was measured against

One line per detected bout, beside the existing per-day `sleep day=` line:

```
effort bout day=2026-08-24 durMin=45 hrmax=187 src=caller avgHRR=52 cover=43 effort=8.1
```

HRmax is the single biggest determinant of an Effort — it sets every zone boundary, so being wrong by
a few bpm moves real work across the 50% floor and scores it zero. `src` says whether that number came
from the user's own setting or an age formula, which is the difference between "your setting is off"
and "we guessed".

## 2. `cover=` — HR coverage during the bout

Percentage of 60-second buckets in the bout holding at least one reading, carried on `ExerciseSession`.
A WHOOP 4.0's optical sensor is weak under gripping — which is exactly what lifting is — so a low
Effort has two causes that deserve **opposite** advice: the metric genuinely not rating the work, or
the strap not having seen it.

**Bucketed, not sample-counted.** A 5/MG sends live HR about every 30 s. Counted against a 1 Hz
expectation, a perfectly captured hour reads ~3% — which would send every 5/MG user chasing a hardware
fault that isn't there. A bucket is either seen or not, so a 30 s cadence reads as full coverage and a
real dropout reads as the gap it is.

## Parity

Byte-identical strings and arithmetic on both platforms, with twinned tests.

One trap worth naming: the line is formatted with **integer arithmetic, not `%.0f`/`%.1f`**. C `printf`
(Swift) breaks a rounding tie to even and Java's `String.format` (Kotlin) breaks it up — so a bout at
exactly 52.5% HRR would print `52` on iOS and `53` on Android. That is a parity break in a string whose
entire purpose is being compared between two users' logs, and between an iOS log and an Android one.
`round0`/`round1` round to an Int first and assemble the digits, which also removes the locale's
decimal separator from the picture.

## Privacy

Unchanged class: a day key, a duration, bpm and percentages. No PII, no timestamps, no raw samples. It
rides the existing strap-log export, same as `sleep day=`.

## Verification

- **Android:** `:app:testFullDebugUnitTest --no-build-cache --rerun-tasks` — **4255 tests, 0 failures**
  (new class runs 10). `compileFullDebugKotlin` clean.
- **Swift package:** new `BoutCalibrationDiagnosticTests` (10 cases) — runs on `swift-packages.yml`
  (macos-15); `StrandAnalytics` can't build on this Linux box (GRDB/CSQLite, per CLAUDE.md).
- **Gates:** `doc_comment_lint.py` OK, `i18n_audit.py --ci main` OK (no new user-facing copy — these
  are log lines, not UI).
- **⚠️ app-build needed before merge.** `Strand/Data/IntelligenceEngine.swift` is app-target Swift, and
  no default CI compiles it (`app-build.yml` is disabled). Say the word and I'll dispatch it.
- **Not yet seen on hardware** — the point of the change is that the next #1545-style report arrives
  with these lines already in it.

## Tests

Both platforms pin: the 30 s-cadence case reading 100% rather than ~3%; a real dropout reading as the
gap; out-of-window samples not inflating it; a partial trailing bucket counting as a whole one so
coverage can't exceed 100; degenerate windows returning nil rather than a fabricated 0; the exact bytes
of the line; `nil` rather than `0` for missing values (a bout with no HRmax is a different diagnosis
from one with a low HRmax); the .5 rounding tie above; non-finite values not printing `inf`/`nan` into
a log people will argue from; and end-to-end, that a detected bout actually carries coverage — a
diagnostic that is always `nil` in production would pass every other test here and tell a reporter
nothing.
