### PR TITLE
Give every scoring pass a device registry, and say so on both platforms when there isn't one

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RestSubScoreTrace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RestSubScoreTrace.swift
@@ -39,6 +39,25 @@ extension AnalyticsEngine {
             + "hoursAsleep=\(Int(hoursAsleepMin.rounded())) sourceRowId=\(sourceRowId)"
     }
 
+    /// #1567: the pass-level warning that this scoring run has no device registry behind it.
+    ///
+    /// Twin of Kotlin `IntelligenceEngine.ownerSourceAbsentLine` — same grammar, deliberately different
+    /// cause token, because the two platforms reach this state by genuinely different routes. Kotlin's
+    /// `analyzeRecent` takes an OPTIONAL owner source and a caller could omit it (`ownerSource=absent`);
+    /// Swift's reads the registry itself, so the only way in is that read FAILING (`registry=unavailable`).
+    /// Forcing one identical string would hide which of the two actually happened, which is the one thing a
+    /// reader of this line needs to know.
+    ///
+    /// Worth having on both because the underlying flaw is shared: an unresolvable device family does not
+    /// error, it silently becomes WHOOP5 — and on a WHOOP 4.0 that reads a raw skin-temp ADC as
+    /// centidegrees, missing the 28–42 °C worn gate, so the night yields nothing at all. A pass that scored
+    /// against fallbacks was previously indistinguishable from one that scored against the real registry.
+    ///
+    /// PURE. Counts and an id only, same privacy class as the sibling `sleep day=` line.
+    public static func registryUnavailableLine(importedDeviceId: String) -> String {
+        "analyzeRecent registry=unavailable owner->\(importedDeviceId) skinTempScale->whoop5"
+    }
+
     /// #319 diagnostic (Sleep & Rest test mode): the motion-coverage + staging context behind the Rest
     /// number, so a high score on a poor night can be explained straight from an export. `grav`/`hr` are the
     /// night-window sample counts; `sparse` is the gravity-sparse gate (WHOOP 4.0 banks motion coarsely, so

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RegistryUnavailableLineTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RegistryUnavailableLineTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+import Foundation
+@testable import StrandAnalytics
+import WhoopProtocol
+
+/// #1567: the pass-level warning that a scoring run has no device registry behind it.
+///
+/// The flaw is shared across both platforms — an unresolvable device family does not error, it silently
+/// becomes WHOOP5, and on a WHOOP 4.0 that reads a raw skin-temp ADC as centidegrees, misses the 28–42 °C
+/// worn gate, and the night yields nothing. What differs is the ROUTE in: Kotlin's `analyzeRecent` takes an
+/// optional owner source that a caller could omit; Swift's reads the registry itself, so the only way in is
+/// that read failing.
+///
+/// Paired with Kotlin `OwnerSourceSkinTempScaleTest.anAbsentOwnerSourceNamesItselfAndTheFallbacksItIsUsing`
+/// — deliberately NOT byte-identical strings, and the test below pins exactly which part is shared.
+final class RegistryUnavailableLineTests: XCTestCase {
+
+    /// The exact bytes.
+    func testTheLineIsExactlyThis() {
+        XCTAssertEqual(
+            AnalyticsEngine.registryUnavailableLine(importedDeviceId: "my-whoop"),
+            "analyzeRecent registry=unavailable owner->my-whoop skinTempScale->whoop5")
+    }
+
+    /// The shared grammar. Both platforms name the same two fallbacks a reader has to know about — which
+    /// device the pass fell back to owning the day, and which temperature scale it therefore used — so the
+    /// two logs stay comparable even though the cause tokens differ by design.
+    ///
+    /// Pinning the shape rather than the whole string is the point: if someone later "fixes the parity" by
+    /// making the strings identical, the cause is lost and the line stops answering the question it exists
+    /// for. If someone drops a fallback from the line, this fails.
+    func testItNamesBothFallbacksTheReaderNeeds() {
+        let line = AnalyticsEngine.registryUnavailableLine(importedDeviceId: "my-whoop")
+        XCTAssertTrue(line.hasPrefix("analyzeRecent "), line)
+        XCTAssertTrue(line.contains("owner->my-whoop"), "must say which owner it fell back to: \(line)")
+        XCTAssertTrue(line.contains("skinTempScale->whoop5"), "must say which scale it used: \(line)")
+        // The cause token is what SEPARATES the twins — Swift can only get here via a failed read.
+        XCTAssertTrue(line.contains("registry=unavailable"), line)
+        XCTAssertFalse(line.contains("ownerSource=absent"), "that is the Kotlin route, not this one: \(line)")
+    }
+
+    /// The id is not assumed to be the seeded default — a renamed or second strap has to read back honestly.
+    func testTheOwnerIsWhicheverIdThePassFellBackTo() {
+        XCTAssertEqual(
+            AnalyticsEngine.registryUnavailableLine(importedDeviceId: "my-whoop-2"),
+            "analyzeRecent registry=unavailable owner->my-whoop-2 skinTempScale->whoop5")
+    }
+
+    /// The reason any of this matters, stated in the analytics rather than in prose: an unresolved family
+    /// is not a cosmetic mislabel. Same samples, same night, and the fallback scale produces NO reading.
+    ///
+    /// Values from the reported WHOOP 4.0 log: `raw p50=772`, worn gate 28–42 °C. Twin of the Kotlin
+    /// assertion in `OwnerSourceSkinTempScaleTest`.
+    func testTheFallbackScaleDropsAWhoop4NightEntirely() throws {
+        let start = 1_787_000_000
+        let sess = [SleepSession(start: start, end: start + 600, efficiency: 0.9,
+                                 stages: [], restingHR: 50, avgHRV: 60.0)]
+        let hrs = (0 ..< 600).map { HRSample(ts: start + $0, bpm: 55) }
+        let temps = (0 ..< 600).map { SkinTempSample(ts: start + $0, raw: 772) }
+
+        let correct = try XCTUnwrap(AnalyticsEngine.wornNightlySkinTempC(sess, hr: hrs, skinTemp: temps,
+                                                                        family: .whoop4),
+                                    "a WHOOP 4.0 night must yield a skin temperature")
+        XCTAssertTrue((28.0 ... 42.0).contains(correct), "expected a worn-range reading, got \(correct)")
+
+        XCTAssertNil(AnalyticsEngine.wornNightlySkinTempC(sess, hr: hrs, skinTemp: temps, family: .whoop5),
+                     "the WHOOP5 scale reads 772 as 7.72 °C and drops the whole night")
+    }
+}

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -620,7 +620,20 @@ final class IntelligenceEngine: ObservableObject {
         // single-WHOOP install) the active strap is `deviceId`, so `resolveDayOwner` below returns
         // `deviceId` for every day and the per-day reads are byte-identical to the pre-I2 behaviour.
         let registry = DeviceRegistryStore(dbQueue: store.registryWriter)
-        let regDevices = (try? registry.all()) ?? []
+        // #1567: `try?` used to swallow this read, and an empty device list is NOT a neutral outcome —
+        // every day then resolves to `.whoop5` (see `skinTempFamily(forOwner:devices:)`), so a WHOOP 4.0's
+        // raw skin-temp ADC is read as centidegrees, misses the 28–42 °C worn gate, and the night yields
+        // nothing. `regDevices` also supplies the owner's model/brand below, so a failed read degrades more
+        // than skin temp alone. Still non-fatal — the pass proceeds on exactly the fallbacks it always did
+        // — but it no longer does so in silence. The Kotlin twin reaches this state by a different route (a
+        // caller omitting `ownerSource`), hence the different cause token; see `registryUnavailableLine`.
+        let regDevices: [PairedDevice]
+        do {
+            regDevices = try registry.all()
+        } catch {
+            regDevices = []
+            diagnosticSink?(AnalyticsEngine.registryUnavailableLine(importedDeviceId: deviceId), nil)
+        }
         let regActiveId = (try? registry.activeDeviceId()) ?? deviceId
 
         // Floor `now` to LOCAL midnight (#277) so each `dayStart` lands on a local-day boundary and the

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -168,6 +168,20 @@ object IntelligenceEngine {
     )
 
     /**
+     * #1567: the pass-level warning that this scoring run has no device registry behind it.
+     *
+     * Emitted once per pass, not per day. A pass without an owner source still produces numbers — it just
+     * produces them against fallbacks (the imported device id for ownership, WHOOP5 for the skin-temp
+     * scale), and the previous absence of any such line is precisely why a WHOOP 4.0 could be scored on the
+     * 5/MG temperature scale for months without it showing up anywhere. Naming the fallbacks makes the two
+     * kinds of pass distinguishable in an exported strap log.
+     *
+     * Counts and an id only, same privacy class as the sibling `sleep day=` line.
+     */
+    fun ownerSourceAbsentLine(importedDeviceId: String): String =
+        "analyzeRecent ownerSource=absent owner->$importedDeviceId skinTempScale->whoop5"
+
+    /**
      * Compute on-device scores for each of the last [maxDays] that actually has raw HR
      * data, persisting them under the computed "<importedDeviceId>-noop" source.
      *
@@ -345,6 +359,9 @@ object IntelligenceEngine {
         flagGet: () -> Boolean,
         flagSet: () -> Unit,
         historyDays: Int = EFFORT_RESCORE_HISTORY_DAYS,
+        // #1567: same reason as the sync path, over a WIDER window — this one rewrites the FULL history
+        // once. Without it every day of that rewrite reads the skin-temp scale as WHOOP5 (see analyzeRecent).
+        ownerSource: DayOwnerSource? = null,
     ) {
         if (flagGet()) return
         analyzeRecent(
@@ -353,6 +370,7 @@ object IntelligenceEngine {
             maxDays = historyDays,
             importedDeviceId = importedDeviceId,
             maxHROverride = maxHROverride,
+            ownerSource = ownerSource,
         )
         flagSet()
     }
@@ -432,10 +450,23 @@ object IntelligenceEngine {
         // exactly ONE source). Read ONCE before the loop: the paired-device list is stable for the run.
         // With only the seeded 'my-whoop' row paired (the default and every single-WHOOP install) the
         // active strap == [importedDeviceId], so [resolveDayOwner] returns [importedDeviceId] for every
-        // day and the per-day reads are BYTE-IDENTICAL to the pre-I2 path. A null [ownerSource] (the
-        // default, e.g. the backfill-triggered pass) skips resolution entirely. Mirrors the Swift
+        // day and the per-day reads are BYTE-IDENTICAL to the pre-I2 path. Mirrors the Swift
         // IntelligenceEngine.analyzeRecent registry snapshot + resolveDayOwner. (1B-4)
+        //
+        // #1567: a null [ownerSource] is no longer merely "skips owner resolution". That was true when this
+        // parameter only picked a day's owner, and it is why the backfill-triggered pass was documented here
+        // as an accepted exception. #938 then routed the skin-temp raw->C SCALE through the same source, and
+        // a missing source there is NOT byte-identical: every day falls back to WHOOP5, so a WHOOP 4.0's raw
+        // ADC is read as centidegrees and misses the worn gate. Every production caller now supplies one; the
+        // parameter stays nullable for tests and pure-JVM callers, and the pass says so out loud below rather
+        // than degrading in silence.
+        //
+        // The durable fix is the Swift shape — `analyzeRecent` reads `registry.all()` itself (:623), so no
+        // caller CAN omit it — but that changes this signature and every caller, so it is left as follow-up.
         val candidatePriorities = ownerSource?.candidatePriorities().orEmpty()
+        if (ownerSource == null) {
+            diag(ownerSourceAbsentLine(importedDeviceId))
+        }
 
         // CAPTURE-B: the registry's active strap id (the universal `writeActiveId`). Resolved ONCE; falls
         // back to [importedDeviceId] so a single-WHOOP install (or a null/legacy ownerSource) names the same

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -90,6 +90,8 @@ import kotlinx.coroutines.launch
 import java.util.UUID
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
+import com.noop.NoopApplication
+import com.noop.analytics.RegistryDayOwnerSource
 
 /**
  * Immutable snapshot of the live connection + biometric state.
@@ -2438,6 +2440,17 @@ class WhoopBleClient(
                         repo = repository,
                         profile = profile,
                         importedDeviceId = deviceId,
+                        // #1567: resolve the day's owner from the registry on THIS pass too. Until now the
+                        // post-backfill pass was the documented exception ("a null ownerSource ... skips
+                        // resolution entirely"), which was harmless while the parameter only chose a day's
+                        // owner — a single-WHOOP install resolves to importedDeviceId either way, byte for
+                        // byte. #938 then made the skin-temp raw->C SCALE read the same source, and that is
+                        // not byte-identical: with no owner source every day falls back to WHOOP5, so a
+                        // WHOOP 4.0's raw ADC (~772) is read as centidegrees (7.7 C), missing the 28-42 C
+                        // worn gate entirely. The sync pass would persist that, and the next UI pass would
+                        // silently correct it — so the stored value depended on which pass wrote last.
+                        ownerSource = (context.applicationContext as? NoopApplication)
+                            ?.deviceRegistry?.let { RegistryDayOwnerSource(it) },
                         maxHROverride = profileStore.hrMaxOverride.takeIf { it > 0 }?.toDouble(),
                         // Steps-estimate calibration: honor the user's manual override and persist the fit
                         // after a backfill too, so the Settings/Steps screen reflects the latest data.

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -24,6 +24,7 @@ import android.os.Looper
 import android.os.ParcelUuid
 import android.os.SystemClock
 import android.util.Log
+import com.noop.NoopApplication
 import com.noop.data.HrRow
 import com.noop.data.RrRow
 import com.noop.data.StreamBatch
@@ -63,6 +64,7 @@ import com.noop.analytics.IntelligenceEngine
 import com.noop.analytics.NapDetector
 import com.noop.analytics.NapPrefs
 import com.noop.analytics.NapVerdict
+import com.noop.analytics.RegistryDayOwnerSource
 import com.noop.analytics.SedentaryDetector
 import com.noop.analytics.StressOnsetDetector
 import com.noop.analytics.WorkoutDetector
@@ -90,8 +92,6 @@ import kotlinx.coroutines.launch
 import java.util.UUID
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
-import com.noop.NoopApplication
-import com.noop.analytics.RegistryDayOwnerSource
 
 /**
  * Immutable snapshot of the live connection + biometric state.

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -972,6 +972,9 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                     maxHROverride = profileStore.hrMaxOverride.takeIf { it > 0 }?.toDouble(),
                     flagGet = { NoopPrefs.effortRescoreDone(appContext) },
                     flagSet = { NoopPrefs.setEffortRescoreDone(appContext) },
+                    // #1567: this rewrites the FULL history once, so a missing owner source would bake the
+                    // WHOOP5 skin-temp scale into every day of it.
+                    ownerSource = RegistryDayOwnerSource(noopApp.deviceRegistry),
                 )
             }.onFailure { if (it is kotlin.coroutines.cancellation.CancellationException) throw it }
             while (isActive) {

--- a/android/app/src/test/java/com/noop/analytics/OwnerSourceSkinTempScaleTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/OwnerSourceSkinTempScaleTest.kt
@@ -1,0 +1,113 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import com.noop.data.SkinTempSample
+import com.noop.protocol.DeviceFamily
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1567: a scoring pass with no device registry behind it reads a WHOOP 4.0 on the 5/MG temperature scale.
+ *
+ * `analyzeRecent(ownerSource = …)` is nullable, and the post-backfill pass was documented as an accepted
+ * exception to supplying it — correctly, while the parameter only chose which device *owned* a day: a
+ * single-WHOOP install resolves to `importedDeviceId` either way, byte for byte.
+ *
+ * #938 later routed the skin-temp raw→°C **scale** through that same source (`skinFamily = ownerSource?
+ * .skinTempFamily(owner) ?: DeviceFamily.WHOOP5`). For that consumer a missing source is *not*
+ * byte-identical, and this test is the proof: the same samples, read under the two families, do not merely
+ * differ — one of them produces no reading at all.
+ *
+ * Values are from the reported strap log (WHOOP 4.0, fw 41.17.6.0): `raw[min=577 p50=772 max=820]`,
+ * `anchor=794 → p50 maps 31.9 °C`, worn gate 28–42 °C.
+ *
+ * There is no Swift twin because Swift cannot reach this state: `analyzeRecent` reads `registry.all()`
+ * itself, so no caller is able to omit it. That asymmetry is the actual defect, and the reason the fix is
+ * Kotlin-only.
+ */
+class OwnerSourceSkinTempScaleTest {
+
+    private val dev = "my-whoop"
+
+    private fun session(start: Long, durSec: Long) = DetectedSleep(
+        start = start, end = start + durSec, efficiency = 0.9,
+        stages = emptyList(), restingHR = 50, avgHRV = 60.0,
+    )
+
+    private fun hr(ts: Long, bpm: Int = 55) = HrSample(deviceId = dev, ts = ts, bpm = bpm)
+    private fun skin(ts: Long, raw: Int) = SkinTempSample(deviceId = dev, ts = ts, raw = raw)
+
+    /** A night of a real WHOOP 4.0's raw skin-temp ADC, at the reported median. */
+    private fun night(): Triple<List<DetectedSleep>, List<HrSample>, List<SkinTempSample>> {
+        val start = 1_787_000_000L
+        return Triple(
+            listOf(session(start, 600)),
+            (0 until 600).map { hr(start + it) },
+            (0 until 600).map { skin(start + it, 772) },
+        )
+    }
+
+    /**
+     * The bug, stated as the two numbers a user would get depending on which pass wrote last.
+     *
+     * On the correct family the night reads as a plausible skin temperature. On the fallback the same raw
+     * ADC is interpreted as centidegrees — 772 → 7.72 °C — which fails the 28–42 °C worn gate, so every
+     * sample is dropped and the night yields NOTHING. Not a small numeric drift: a present value versus an
+     * absent one, from identical input.
+     */
+    @Test
+    fun theSameNightReadsAsATemperatureOnWhoop4AndAsNothingOnTheWhoop5Fallback() {
+        val (sess, hrs, temps) = night()
+
+        val correct = AnalyticsEngine.wornNightlySkinTempC(sess, hrs, temps, DeviceFamily.WHOOP4)
+        assertNotNull("a WHOOP 4.0 night must yield a skin temperature", correct)
+        assertTrue("expected a worn-range reading, got $correct", correct!! in 28.0..42.0)
+
+        val fallback = AnalyticsEngine.wornNightlySkinTempC(sess, hrs, temps, DeviceFamily.WHOOP5)
+        assertNull("the WHOOP5 scale reads 772 as 7.72 C and drops the whole night", fallback)
+    }
+
+    /**
+     * The fallback is not wrong for a 5/MG — it is right for it. Pinned so the fix is understood as "route
+     * the family correctly", not "the WHOOP5 branch is broken": a genuine 5/MG banks centidegrees, and 3400
+     * is 34.00 °C on exactly the branch that mangled the 4.0's ADC.
+     */
+    @Test
+    fun theWhoop5ScaleIsCorrectForAWhoop5() {
+        val start = 1_787_000_000L
+        val sess = listOf(session(start, 600))
+        val hrs = (0 until 600).map { hr(start + it) }
+        val temps = (0 until 600).map { skin(start + it, 3400) }   // centidegrees
+        assertEquals(34.0, AnalyticsEngine.wornNightlySkinTempC(sess, hrs, temps, DeviceFamily.WHOOP5)!!, 1e-9)
+    }
+
+    /**
+     * The resolver behind it: only a positively-identified 4.0 changes scale, and every other label — the
+     * legacy seeded "WHOOP" row, an unknown, a null — lands on WHOOP5. That fall-through is deliberate
+     * (#171/#938) and is left alone; what #1567 changes is that a pass no longer arrives here with no
+     * registry at all.
+     */
+    @Test
+    fun onlyAPositivelyIdentifiedFourPointZeroChangesScale() {
+        assertEquals(DeviceFamily.WHOOP4, DeviceFamily.forRegistryModel("4.0"))
+        assertEquals(DeviceFamily.WHOOP4, DeviceFamily.forRegistryModel("WHOOP 4.0"))
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel("WHOOP"))
+        assertEquals(DeviceFamily.WHOOP5, DeviceFamily.forRegistryModel(null))
+    }
+
+    /**
+     * And the pass now says so out loud. The absence of any such line is why a WHOOP 4.0 could be scored on
+     * the 5/MG scale across many passes without it being visible in an exported log — the two kinds of pass
+     * were indistinguishable.
+     */
+    @Test
+    fun anAbsentOwnerSourceNamesItselfAndTheFallbacksItIsUsing() {
+        assertEquals(
+            "analyzeRecent ownerSource=absent owner->my-whoop skinTempScale->whoop5",
+            IntelligenceEngine.ownerSourceAbsentLine("my-whoop"),
+        )
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/OwnerSourceSkinTempScaleTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/OwnerSourceSkinTempScaleTest.kt
@@ -4,6 +4,7 @@ import com.noop.data.HrSample
 import com.noop.data.SkinTempSample
 import com.noop.protocol.DeviceFamily
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -24,9 +25,11 @@ import org.junit.Test
  * Values are from the reported strap log (WHOOP 4.0, fw 41.17.6.0): `raw[min=577 p50=772 max=820]`,
  * `anchor=794 → p50 maps 31.9 °C`, worn gate 28–42 °C.
  *
- * There is no Swift twin because Swift cannot reach this state: `analyzeRecent` reads `registry.all()`
- * itself, so no caller is able to omit it. That asymmetry is the actual defect, and the reason the fix is
- * Kotlin-only.
+ * The *fix* is Kotlin-only, because Swift has no parameter to thread: its `analyzeRecent` reads
+ * `registry.all()` itself, so no caller is able to omit it. The *flaw* is shared, though — Swift reaches
+ * the identical silent WHOOP5 fallback when that read THROWS, since `(try? registry.all()) ?? []` used to
+ * swallow it and an empty device list resolves every day to WHOOP5. So the diagnostic half is twinned:
+ * see `RegistryUnavailableLineTests` and `AnalyticsEngine.registryUnavailableLine`.
  */
 class OwnerSourceSkinTempScaleTest {
 
@@ -108,6 +111,38 @@ class OwnerSourceSkinTempScaleTest {
         assertEquals(
             "analyzeRecent ownerSource=absent owner->my-whoop skinTempScale->whoop5",
             IntelligenceEngine.ownerSourceAbsentLine("my-whoop"),
+        )
+    }
+
+    /**
+     * The shared grammar with the Swift twin (`AnalyticsEngine.registryUnavailableLine`), pinned as a SHAPE
+     * rather than as one identical string.
+     *
+     * The two platforms reach this state by genuinely different routes — Kotlin by a caller omitting the
+     * optional owner source, Swift by its registry read failing — so the cause tokens differ on purpose.
+     * What must match is everything a reader needs to act on: the same prefix, and the same two fallbacks
+     * named the same way, so an Android log and an iOS log stay comparable.
+     *
+     * If someone later "fixes the parity" by making the strings identical, the cause is lost and the line
+     * stops answering the question it exists for. That is what this guards.
+     */
+    @Test
+    fun itNamesBothFallbacksTheReaderNeeds() {
+        val line = IntelligenceEngine.ownerSourceAbsentLine("my-whoop")
+        assertTrue(line, line.startsWith("analyzeRecent "))
+        assertTrue("must say which owner it fell back to: $line", line.contains("owner->my-whoop"))
+        assertTrue("must say which scale it used: $line", line.contains("skinTempScale->whoop5"))
+        // The cause token is what SEPARATES the twins — Kotlin can only get here via an omitted parameter.
+        assertTrue(line, line.contains("ownerSource=absent"))
+        assertFalse("that is the Swift route, not this one: $line", line.contains("registry=unavailable"))
+    }
+
+    /** The id is not assumed to be the seeded default — a renamed or second strap must read back honestly. */
+    @Test
+    fun theOwnerIsWhicheverIdThePassFellBackTo() {
+        assertEquals(
+            "analyzeRecent ownerSource=absent owner->my-whoop-2 skinTempScale->whoop5",
+            IntelligenceEngine.ownerSourceAbsentLine("my-whoop-2"),
         )
     }
 }


### PR DESCRIPTION
Found while reading a WHOOP 4.0 strap log for issue #1545. Unrelated to Effort — it landed in the
same log.

## What the log showed

The same nights, on byte-identical inputs (`grav=192671 hr=192652`), carried two different device
families. Not per-day — cleanly split **per scoring pass**:

```
23:54:31  Backfill: session started — historical offload requested
23:54:44  analyzeRecent dayCache reused=0/21          ← 21 days
23:54–23:57   family=whoop5 ×21                       ← the sync pass
23:00 / 23:34 / 00:09 / 00:44   family=whoop4         ← UI passes
```

Exactly 21 lines for exactly 21 days, 13 seconds after a backfill started.

## Why

`analyzeRecent(ownerSource: DayOwnerSource? = null)`. The post-backfill pass was documented in the
code as an accepted exception to supplying it — and that was **right at the time**: the parameter
only chose which device *owned* a day, and a single-WHOOP install resolves to `importedDeviceId`
either way, byte for byte.

#938 later routed the skin-temp raw→°C **scale** through the same source:

```kotlin
val skinFamily = ownerSource?.skinTempFamily(owner) ?: DeviceFamily.WHOOP5
```

For *that* consumer a missing source is not byte-identical.

## The consequence is not cosmetic

A WHOOP 4.0's v24 banks a raw ADC; a 5/MG banks centidegrees. Read on the wrong scale, the log's
median raw of **772 becomes 7.72 °C**, misses the 28–42 °C worn gate, and the night produces **no
skin temperature at all**.

So the sync pass persisted nothing, the next UI pass recomputed it correctly, and the stored value
depended on which pass wrote last. `OwnerSourceSkinTempScaleTest` pins this as a present value
versus an absent one from identical input — I had predicted it from the code and could not confirm
it from the log itself, so the test is the confirmation.

## The fix

Both remaining production callers now supply an owner source:

- `WhoopBleClient` — the post-backfill pass.
- `runEffortRescoreIfNeeded` — the one-shot **full-history** Effort rescore, which bakes the same
  fallback into far more days.

A pass that still has none now **says so** (`analyzeRecent ownerSource=absent owner->… skinTempScale->whoop5`).
The absence of any such line is why this survived so long: the two kinds of pass were
indistinguishable in an export.

## Scope worth naming

For **multi-source** installs this also means the sync pass now resolves day ownership for real
instead of defaulting every day to `importedDeviceId` — i.e. it now agrees with the UI pass rather
than diverging from it. That is the intended I2 behaviour and the two passes disagreeing was itself
wrong, but it is a behaviour change, not only a scale fix. Single-WHOOP installs (including the
reporter's) are unaffected on ownership: the resolver returns the same id.

**It is a read-side change only — no write target moves.** `computedId = importedDeviceId + "-noop"`
is derived from the parameter, not from the resolved owner, so rows still land exactly where they
did. The owner selects which device's raw streams a day is *read* from. Two related values were
checked and are also unchanged on this pass: `activeWriteId` is gated behind a `universalSink` that
the sync path does not supply, and it feeds a diagnostic line rather than a write.

## Parity

**The fix is Kotlin-only; the flaw is not.** I originally wrote that Swift "cannot reach this state".
That was wrong, and checking it is what found the second route:

```swift
let regDevices = (try? registry.all()) ?? []
```

`all()` throws. `try?` swallowed it, and an empty device list is **not** neutral — every day then
resolves to `.whoop5` via `skinTempFamily(forOwner:devices:)`. `regDevices` also supplies the owner's
`model`/`brand` at `:816–817`, so a failed read degrades more than skin temp.

| | route in | reached in practice |
|---|---|---|
| **Kotlin** | a caller omits the optional `ownerSource` | **every sync, every install** — fixed here |
| **Swift** | the registry read throws | rare, but silent and identical in effect |

So:

- **Fix** — Kotlin-only by nature. Swift has no parameter to thread: one entry point, unconditional
  registry read, no caller *able* to omit it.
- **Hardening + diagnostic** — shared flaw, now **twinned**. Swift stops swallowing the failure and
  names the same two fallbacks.

Cause tokens differ **on purpose** — `ownerSource=absent` vs `registry=unavailable` — because the
platforms genuinely arrive by different routes, and one identical string would hide which actually
happened, the only thing the line is for. Both tests pin the shared grammar as a *shape* and assert
the other platform's token is **absent**, so a later "parity fix" can't quietly erase the
distinction.

Shared analytics were checked and are exact: `forRegistryModel` (`case "4.0", "WHOOP 4.0"` → whoop4,
default → whoop5) and the skin-temp scale branch (`AnalyticsEngine.swift:1364/1367/1421` vs
`AnalyticsEngine.kt:1168/1173/1234`).

The Swift line builder lives in **StrandAnalytics**, not the app target, so `swift-packages.yml`
covers it by default; only the one-line call site needs app-build.

The Swift edit is **log-only — zero behavioural delta**: `(try? registry.all()) ?? []` and the
do/catch that replaces it produce the identical `[]` on failure. It also fires on the read *failing*,
not on the registry being legitimately *empty* — a fresh install with no paired devices returns `[]`
without throwing, and the WHOOP5 fallback is genuinely unavoidable there, so there is nothing to warn
about.

Both platforms stay **non-fatal** — each pass proceeds on exactly the fallbacks it always did.
Instrument first: if these lines fire in the field, hardening beyond logging is a separate decision
made with data.

## Verification

- `:app:testFullDebugUnitTest --no-build-cache --rerun-tasks` — **4264 tests, 0 failures** (6 new).
- Swift package tests (`RegistryUnavailableLineTests`, 4 cases) run on `swift-packages.yml`;
  StrandAnalytics can't build on this Linux box (GRDB/CSQLite, per CLAUDE.md).
- `doc_comment_lint.py` OK, `i18n_audit.py --ci main` OK.
- New log line checked against the Test Centre domain markers — no collision, no day-count inflated.
- **⚠️ app-build now required before merge** — `Strand/Data/IntelligenceEngine.swift` is app-target
  Swift and no default CI compiles it. Not dispatched.
- **Not yet confirmed on hardware.** The next sync log from a WHOOP 4.0 should show `family=whoop4`
  on the post-backfill pass and no `ownerSource=absent` line.

**Coverage gap, stated rather than papered over:** the two call-site edits — the actual fix — are
covered by the compiler and by the new field diagnostic, *not* by a unit test. There is no
engine-with-repository harness in the test tree (the existing engine tests all exercise pure
mechanisms), and `WhoopBleClient` has no unit-testable seam without Robolectric. Building either to
pin one argument is out of proportion to the change. The `ownerSource=absent` line is the practical
regression detector: after this PR it should never appear in a production log, so if a future caller
is added without a registry, it announces itself.