### PR TITLE
feat: add sleep-aware steps and physiological day cycles

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/DayCycle.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/DayCycle.swift
@@ -54,7 +54,9 @@ public enum DayCycleResolver {
         guard mode == .sleepOnset, let latestSleep else { return calendarWindow(now: now, offsetSec: offsetSec) }
         let age = now - latestSleep.startInclusive
         let fallback = fallbackMidnight(after: latestSleep.startInclusive, offsetSec: offsetSec)
-        guard age < absoluteMaxOpenSeconds, reliableAwakeCoverage || now < fallback else {
+        // Sleep-onset mode remains anchored across midnight when awake coverage is unavailable.
+        // Only the absolute safety cap may synthesize a fallback boundary.
+        guard age < absoluteMaxOpenSeconds else {
             let day = AnalyticsEngine.dayString(fallback, offsetSec: offsetSec)
             return DayCycleWindow(id: "synthetic:\(day)", startInclusive: fallback, endExclusive: now,
                                   displayDay: day, source: .syntheticMidnight)

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/DayCycle.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/DayCycle.swift
@@ -5,6 +5,7 @@ public enum DayCycleMode: String, CaseIterable, Sendable {
     case midnight = "midnight"
 
     public static let storageKey = "noop.dayCycleMode"
+    /// Kotlin twin: `DayCycleMode.fromPersisted`.
     public static func persisted(_ value: String?) -> DayCycleMode {
         value.flatMap(Self.init(rawValue:)) ?? .sleepOnset
     }
@@ -28,6 +29,7 @@ public enum DayCycleResolver {
     public static let minSyntheticMidnightAgeSeconds = 18 * 3_600
     public static let absoluteMaxOpenSeconds = 40 * 3_600
 
+    /// Kotlin twin: `DayCycleResolver.calendarWindow`.
     public static func calendarWindow(now: Int, offsetSec: Int) -> DayCycleWindow {
         let local = now + offsetSec
         let dayNumber = Int(floor(Double(local) / Double(SleepStageTotals.secondsPerDay)))
@@ -37,6 +39,7 @@ public enum DayCycleResolver {
                               displayDay: day, source: .calendar)
     }
 
+    /// Kotlin twin: `DayCycleResolver.fallbackMidnightAfter`.
     public static func fallbackMidnight(after start: Int, offsetSec: Int) -> Int {
         let minimum = start + minSyntheticMidnightAgeSeconds
         let local = minimum + offsetSec
@@ -45,6 +48,7 @@ public enum DayCycleResolver {
         return midnight >= minimum ? midnight : (dayNumber + 1) * SleepStageTotals.secondsPerDay - offsetSec
     }
 
+    /// Kotlin twin: `DayCycleResolver.activeWindow`.
     public static func activeWindow(mode: DayCycleMode, latestSleep: DayCycleWindow?, now: Int,
                                     offsetSec: Int, reliableAwakeCoverage: Bool) -> DayCycleWindow {
         guard mode == .sleepOnset, let latestSleep else { return calendarWindow(now: now, offsetSec: offsetSec) }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/DayCycle.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/DayCycle.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+public enum DayCycleMode: String, CaseIterable, Sendable {
+    case sleepOnset = "sleep_onset"
+    case midnight = "midnight"
+
+    public static let storageKey = "noop.dayCycleMode"
+    public static func persisted(_ value: String?) -> DayCycleMode {
+        value.flatMap(Self.init(rawValue:)) ?? .sleepOnset
+    }
+}
+
+public struct DayCycleWindow: Equatable, Sendable {
+    public enum Source: Equatable, Sendable { case detectedSleep, editedSleep, syntheticMidnight, calendar }
+    public let id: String
+    public let startInclusive: Int
+    public let endExclusive: Int
+    public let displayDay: String
+    public let source: Source
+
+    public init(id: String, startInclusive: Int, endExclusive: Int, displayDay: String, source: Source) {
+        self.id = id; self.startInclusive = startInclusive; self.endExclusive = endExclusive
+        self.displayDay = displayDay; self.source = source
+    }
+}
+
+public enum DayCycleResolver {
+    public static let minSyntheticMidnightAgeSeconds = 18 * 3_600
+    public static let absoluteMaxOpenSeconds = 40 * 3_600
+
+    public static func calendarWindow(now: Int, offsetSec: Int) -> DayCycleWindow {
+        let local = now + offsetSec
+        let dayNumber = Int(floor(Double(local) / Double(SleepStageTotals.secondsPerDay)))
+        let start = dayNumber * SleepStageTotals.secondsPerDay - offsetSec
+        let day = AnalyticsEngine.dayString(start, offsetSec: offsetSec)
+        return DayCycleWindow(id: "calendar:\(day)", startInclusive: start, endExclusive: now,
+                              displayDay: day, source: .calendar)
+    }
+
+    public static func fallbackMidnight(after start: Int, offsetSec: Int) -> Int {
+        let minimum = start + minSyntheticMidnightAgeSeconds
+        let local = minimum + offsetSec
+        let dayNumber = Int(floor(Double(local) / Double(SleepStageTotals.secondsPerDay)))
+        let midnight = dayNumber * SleepStageTotals.secondsPerDay - offsetSec
+        return midnight >= minimum ? midnight : (dayNumber + 1) * SleepStageTotals.secondsPerDay - offsetSec
+    }
+
+    public static func activeWindow(mode: DayCycleMode, latestSleep: DayCycleWindow?, now: Int,
+                                    offsetSec: Int, reliableAwakeCoverage: Bool) -> DayCycleWindow {
+        guard mode == .sleepOnset, let latestSleep else { return calendarWindow(now: now, offsetSec: offsetSec) }
+        let age = now - latestSleep.startInclusive
+        let fallback = fallbackMidnight(after: latestSleep.startInclusive, offsetSec: offsetSec)
+        guard age < absoluteMaxOpenSeconds, reliableAwakeCoverage || now < fallback else {
+            let day = AnalyticsEngine.dayString(fallback, offsetSec: offsetSec)
+            return DayCycleWindow(id: "synthetic:\(day)", startInclusive: fallback, endExclusive: now,
+                                  displayDay: day, source: .syntheticMidnight)
+        }
+        return DayCycleWindow(id: latestSleep.id, startInclusive: latestSleep.startInclusive,
+                              endExclusive: now, displayDay: latestSleep.displayDay, source: latestSleep.source)
+    }
+}

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/PhysiologicalSteps.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/PhysiologicalSteps.swift
@@ -30,6 +30,18 @@ public enum PhysiologicalSteps {
             self.sleepId = sleepId; self.onset = onset; self.endExclusive = endExclusive
         }
     }
+    public struct OwnerSegment: Equatable, Sendable {
+        public let owner: String; public let onset: Int; public let endExclusive: Int
+        public init(owner: String, onset: Int, endExclusive: Int) {
+            self.owner = owner; self.onset = onset; self.endExclusive = endExclusive
+        }
+    }
+    public struct OwnerCoverage: Equatable, Sendable {
+        public let owner: String; public let onset: Int; public let endExclusive: Int; public let priority: Int
+        public init(owner: String, onset: Int, endExclusive: Int, priority: Int) {
+            self.owner = owner; self.onset = onset; self.endExclusive = endExclusive; self.priority = priority
+        }
+    }
     private static let minMainSleepSeconds = 3 * 3_600
 
     public static func classifyForCycle(_ blocks: [SleepBlock], offsetSec: Int,
@@ -73,6 +85,32 @@ public enum PhysiologicalSteps {
                 ? CycleWindow(sleepId: ordered[index].sleepId, onset: ordered[index].onset, endExclusive: end)
                 : nil
         }
+    }
+
+    /// Kotlin twin: `PhysiologicalSteps.ownerSegmentsFromCoverage`.
+    public static func ownerSegmentsFromCoverage(_ window: CycleWindow, coverage: [OwnerCoverage],
+                                                 fallbackOwner: String) -> [OwnerSegment] {
+        guard window.endExclusive > window.onset else { return [] }
+        let clipped = coverage.compactMap { item -> OwnerCoverage? in
+            let start = max(window.onset, item.onset), end = min(window.endExclusive, item.endExclusive)
+            return end > start ? OwnerCoverage(owner: item.owner, onset: start,
+                endExclusive: end, priority: item.priority) : nil
+        }
+        let seams = Set([window.onset, window.endExclusive] + clipped.flatMap { [$0.onset, $0.endExclusive] }).sorted()
+        var result: [OwnerSegment] = [], lastOwner = fallbackOwner
+        for index in 0..<(seams.count - 1) {
+            let start = seams[index], end = seams[index + 1]
+            let owner = clipped.filter { start >= $0.onset && start < $0.endExclusive }
+                .sorted { $0.priority == $1.priority ? $0.owner < $1.owner : $0.priority < $1.priority }
+                .first?.owner ?? lastOwner
+            if let last = result.last, last.owner == owner, last.endExclusive == start {
+                result[result.count - 1] = OwnerSegment(owner: owner, onset: last.onset, endExclusive: end)
+            } else {
+                result.append(OwnerSegment(owner: owner, onset: start, endExclusive: end))
+            }
+            lastOwner = owner
+        }
+        return result
     }
 
     /// Same later-sample attribution, class gate and plausibility gate as the Kotlin twin.

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/PhysiologicalSteps.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/PhysiologicalSteps.swift
@@ -117,34 +117,4 @@ public enum PhysiologicalSteps {
         return result
     }
 
-    /// Same later-sample attribution, class gate and plausibility gate as the Kotlin twin.
-    /// Kotlin twin: `PhysiologicalSteps.stepsInCycle`.
-    public static func stepsInCycle(_ samples: [StepSample], onsetInclusive: Int,
-                                    endExclusive: Int, sleepSessions: [SleepSession]) -> Int? {
-        guard endExclusive > onsetInclusive else { return 0 }
-        let sorted = samples.sorted { $0.ts < $1.ts }
-        let predecessor = sorted.last { $0.ts < onsetInclusive }
-        let relevant = (predecessor.map { [$0] } ?? []) + sorted.filter {
-            $0.ts >= onsetInclusive && $0.ts < endExclusive
-        }
-        guard relevant.count >= 2 else { return nil }
-        let counted = SleepAwareStepCounter.count(relevant, sleepSessions: sleepSessions)
-        var evaluated = false
-        var total = 0
-        let hasClasses = StepsCounter.hasActivityClasses(relevant)
-        for index in 1..<relevant.count {
-            let previous = relevant[index - 1], current = relevant[index]
-            guard current.ts >= onsetInclusive, current.ts < endExclusive else { continue }
-            evaluated = true
-            let delta = (current.counter - previous.counter) & 0xffff
-            guard StepsCounter.shouldCountDelta(activityClass: current.activityClass, hasActivityClasses: hasClasses),
-                  StepsCounter.isPlausibleDelta(previousTs: previous.ts, currentTs: current.ts, delta: delta)
-            else { continue }
-            let inSleep = sleepSessions.contains { current.ts >= $0.start && current.ts < $0.end }
-            if !inSleep { total += delta }
-        }
-        // SleepAware's accepted sleep/awake-gap contribution is window-scoped by the caller's samples.
-        total += counted.acceptedAwakeGapTicks + counted.acceptedSleepBoutTicks
-        return evaluated ? total : nil
-    }
 }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/PhysiologicalSteps.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/PhysiologicalSteps.swift
@@ -15,9 +15,6 @@ public enum PhysiologicalSteps {
             self.onset = onset; self.end = end; self.id = id ?? String(onset)
             self.editedOnset = editedOnset; self.kind = kind
         }
-        fileprivate func withKind(_ kind: SleepKind) -> SleepBlock {
-            SleepBlock(onset: onset, end: end, id: id, editedOnset: editedOnset, kind: kind)
-        }
     }
     public struct CycleBoundary: Equatable, Sendable {
         public let sleepId: String
@@ -44,6 +41,7 @@ public enum PhysiologicalSteps {
     }
     private static let minMainSleepSeconds = 3 * 3_600
 
+    /// Kotlin twin: `PhysiologicalSteps.classifyForCycle`.
     public static func classifyForCycle(_ blocks: [SleepBlock], offsetSec: Int,
                                         habitualMidsleepSec: Int?) -> [SleepBlock] {
         guard !blocks.isEmpty else { return [] }
@@ -72,9 +70,15 @@ public enum PhysiologicalSteps {
                                                                 habitualMidsleepSec: habitualMidsleepSec) ?? []
             selected = Set(picked.map { selectable[eligible[$0]] })
         }
-        return blocks.indices.map { blocks[$0].withKind(selected.contains($0) ? .mainSleep : .nap) }
+        return blocks.indices.map { index in
+            let block = blocks[index]
+            return SleepBlock(onset: block.onset, end: block.end, id: block.id,
+                              editedOnset: block.editedOnset,
+                              kind: selected.contains(index) ? .mainSleep : .nap)
+        }
     }
 
+    /// Kotlin twin: `PhysiologicalSteps.cycleWindows`.
     public static func cycleWindows(_ boundaries: [CycleBoundary], now: Int) -> [CycleWindow] {
         var ids = Set<String>()
         let ordered = boundaries.filter { $0.onset <= now && ids.insert($0.sleepId).inserted }
@@ -114,6 +118,7 @@ public enum PhysiologicalSteps {
     }
 
     /// Same later-sample attribution, class gate and plausibility gate as the Kotlin twin.
+    /// Kotlin twin: `PhysiologicalSteps.stepsInCycle`.
     public static func stepsInCycle(_ samples: [StepSample], onsetInclusive: Int,
                                     endExclusive: Int, sleepSessions: [SleepSession]) -> Int? {
         guard endExclusive > onsetInclusive else { return 0 }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/PhysiologicalSteps.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/PhysiologicalSteps.swift
@@ -1,0 +1,107 @@
+import Foundation
+import WhoopProtocol
+
+public enum PhysiologicalSteps {
+    public enum SleepKind: Sendable { case mainSleep, nap, unclassified }
+    public struct SleepBlock: Sendable {
+        public let onset: Int
+        public let end: Int
+        public let id: String
+        public let editedOnset: Int?
+        public let kind: SleepKind
+        public var effectiveOnset: Int { editedOnset ?? onset }
+        public init(onset: Int, end: Int, id: String? = nil, editedOnset: Int? = nil,
+                    kind: SleepKind = .unclassified) {
+            self.onset = onset; self.end = end; self.id = id ?? String(onset)
+            self.editedOnset = editedOnset; self.kind = kind
+        }
+        fileprivate func withKind(_ kind: SleepKind) -> SleepBlock {
+            SleepBlock(onset: onset, end: end, id: id, editedOnset: editedOnset, kind: kind)
+        }
+    }
+    public struct CycleBoundary: Equatable, Sendable {
+        public let sleepId: String
+        public let onset: Int
+        public init(sleepId: String, onset: Int) { self.sleepId = sleepId; self.onset = onset }
+    }
+    public struct CycleWindow: Equatable, Sendable {
+        public let sleepId: String; public let onset: Int; public let endExclusive: Int
+        public init(sleepId: String, onset: Int, endExclusive: Int) {
+            self.sleepId = sleepId; self.onset = onset; self.endExclusive = endExclusive
+        }
+    }
+    private static let minMainSleepSeconds = 3 * 3_600
+
+    public static func classifyForCycle(_ blocks: [SleepBlock], offsetSec: Int,
+                                        habitualMidsleepSec: Int?) -> [SleepBlock] {
+        guard !blocks.isEmpty else { return [] }
+        let explicit = blocks.indices.filter { blocks[$0].kind == .mainSleep }
+        let selectable = blocks.indices.filter { blocks[$0].kind != .nap }
+        let selected: Set<Int>
+        if !explicit.isEmpty {
+            selected = Set(explicit)
+        } else {
+            let nightBlocks = selectable.map { SleepStageTotals.NightBlock(start: blocks[$0].effectiveOnset,
+                                                                            end: blocks[$0].end) }
+            let eligible = SleepStageTotals.bridgedNightGroups(nightBlocks, offsetSec: offsetSec)
+                .filter { group in
+                    let total = group.indices.reduce(0) { $0 + max(0, nightBlocks[$1].durationS) }
+                    let onset = group.indices.map { nightBlocks[$0].start }.min()
+                    return total >= minMainSleepSeconds && onset.map {
+                        SleepStageTotals.isOvernightOnset($0, offsetSec: offsetSec)
+                    } == true
+                }
+                .flatMap { $0.indices }
+            let candidates = eligible.map { index in
+                SleepStageTotals.NightBlock(start: blocks[selectable[index]].effectiveOnset,
+                                            end: blocks[selectable[index]].end)
+            }
+            let picked = SleepStageTotals.mainNightGroupIndices(candidates, offsetSec: offsetSec,
+                                                                habitualMidsleepSec: habitualMidsleepSec) ?? []
+            selected = Set(picked.map { selectable[eligible[$0]] })
+        }
+        return blocks.indices.map { blocks[$0].withKind(selected.contains($0) ? .mainSleep : .nap) }
+    }
+
+    public static func cycleWindows(_ boundaries: [CycleBoundary], now: Int) -> [CycleWindow] {
+        var ids = Set<String>()
+        let ordered = boundaries.filter { $0.onset <= now && ids.insert($0.sleepId).inserted }
+            .sorted { $0.onset < $1.onset }
+        return ordered.indices.compactMap { index in
+            let end = index + 1 < ordered.count ? ordered[index + 1].onset : now
+            return end > ordered[index].onset
+                ? CycleWindow(sleepId: ordered[index].sleepId, onset: ordered[index].onset, endExclusive: end)
+                : nil
+        }
+    }
+
+    /// Same later-sample attribution, class gate and plausibility gate as the Kotlin twin.
+    public static func stepsInCycle(_ samples: [StepSample], onsetInclusive: Int,
+                                    endExclusive: Int, sleepSessions: [SleepSession]) -> Int? {
+        guard endExclusive > onsetInclusive else { return 0 }
+        let sorted = samples.sorted { $0.ts < $1.ts }
+        let predecessor = sorted.last { $0.ts < onsetInclusive }
+        let relevant = (predecessor.map { [$0] } ?? []) + sorted.filter {
+            $0.ts >= onsetInclusive && $0.ts < endExclusive
+        }
+        guard relevant.count >= 2 else { return nil }
+        let counted = SleepAwareStepCounter.count(relevant, sleepSessions: sleepSessions)
+        var evaluated = false
+        var total = 0
+        let hasClasses = StepsCounter.hasActivityClasses(relevant)
+        for index in 1..<relevant.count {
+            let previous = relevant[index - 1], current = relevant[index]
+            guard current.ts >= onsetInclusive, current.ts < endExclusive else { continue }
+            evaluated = true
+            let delta = (current.counter - previous.counter) & 0xffff
+            guard StepsCounter.shouldCountDelta(activityClass: current.activityClass, hasActivityClasses: hasClasses),
+                  StepsCounter.isPlausibleDelta(previousTs: previous.ts, currentTs: current.ts, delta: delta)
+            else { continue }
+            let inSleep = sleepSessions.contains { current.ts >= $0.start && current.ts < $0.end }
+            if !inSleep { total += delta }
+        }
+        // SleepAware's accepted sleep/awake-gap contribution is window-scoped by the caller's samples.
+        total += counted.acceptedAwakeGapTicks + counted.acceptedSleepBoutTicks
+        return evaluated ? total : nil
+    }
+}

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepAwareStepCounter.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepAwareStepCounter.swift
@@ -24,6 +24,7 @@ public enum SleepAwareStepCounter {
             rejectedActivityClassTicks: 0, rejectedImplausibleTicks: 0,
             gravitySamplesAvailable: 0, auxSamplesAvailable: 0)
 
+        /// Kotlin twin: `SleepAwareStepCounter.Count.plus`.
         public func adding(_ other: Count) -> Count {
             Count(totalTicks: totalTicks + other.totalTicks,
                 acceptedOutsideSleepTicks: acceptedOutsideSleepTicks + other.acceptedOutsideSleepTicks,
@@ -53,6 +54,7 @@ public enum SleepAwareStepCounter {
             hasClasses = hasActivityClasses
         }
 
+        /// Kotlin twin: `SleepAwareStepCounter.Accumulator.acceptPage`.
         @discardableResult public func acceptPage(_ samples: [StepSample]) -> Accumulator {
             precondition(!finished)
             for current in samples.sorted(by: { $0.ts < $1.ts }) {
@@ -79,6 +81,7 @@ public enum SleepAwareStepCounter {
             return self
         }
 
+        /// Kotlin twin: `SleepAwareStepCounter.Accumulator.observeMotionPage`.
         @discardableResult public func observeMotion(gravityCount: Int, auxCount: Int) -> Accumulator {
             precondition(!finished)
             gravityAvailable += gravityCount
@@ -86,6 +89,7 @@ public enum SleepAwareStepCounter {
             return self
         }
 
+        /// Kotlin twin: `SleepAwareStepCounter.Accumulator.finish`.
         public func finish() -> Count {
             if !finished { flush(); finished = true }
             return Count(totalTicks: outside + awake + sleep, acceptedOutsideSleepTicks: outside,
@@ -97,6 +101,7 @@ public enum SleepAwareStepCounter {
                          auxSamplesAvailable: auxAvailable)
         }
 
+        /// Kotlin twin: `SleepAwareStepCounter.Accumulator.flushSleepBout`.
         private func flush() {
             guard !pending.isEmpty else { return }
             let ticks = pending.reduce(0) { $0 + $1.ticks }
@@ -108,11 +113,13 @@ public enum SleepAwareStepCounter {
         }
     }
 
+    /// Kotlin twin: `SleepAwareStepCounter.stepsInWindow`.
     public static func stepsInWindow(_ samples: [StepSample], sleepSessions: [SleepSession]) -> Int? {
         let count = count(samples, sleepSessions: sleepSessions)
         return count.totalTicks > 0 ? count.totalTicks : nil
     }
 
+    /// Kotlin twin: `SleepAwareStepCounter.count`.
     public static func count(_ samples: [StepSample], sleepSessions: [SleepSession]) -> Count {
         let sorted = samples.sorted { $0.ts < $1.ts }
         return Accumulator(sleepSessions: sleepSessions,
@@ -120,6 +127,7 @@ public enum SleepAwareStepCounter {
             .acceptPage(sorted).finish()
     }
 
+    /// Kotlin twin: `SleepAwareStepCounter.contextAt`.
     private static func context(_ ts: Int, sessions: [SleepSession]) -> Int {
         guard let session = sessions.first(where: { ts >= $0.start && ts < $0.end }) else { return 0 }
         if let stage = session.stages.first(where: { ts >= $0.start && ts < $0.end }),

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepAwareStepCounter.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepAwareStepCounter.swift
@@ -68,7 +68,7 @@ public enum SleepAwareStepCounter {
                                                     delta: delta) else {
                     rejectedImplausible += delta; continue
                 }
-                switch Self.context(current.ts, sessions: sessions) {
+                switch SleepAwareStepCounter.context(current.ts, sessions: sessions) {
                 case 0: flush(); outside += delta
                 case 1: flush(); awake += delta
                 default:

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepAwareStepCounter.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepAwareStepCounter.swift
@@ -1,0 +1,100 @@
+import Foundation
+import WhoopProtocol
+
+/// Sleep-context twin of Kotlin `SleepAwareStepCounter`. Counter decisions stay orientation-independent.
+public enum SleepAwareStepCounter {
+    public static let maxSecondsBetweenGaitDeltas = 3
+    public static let minGaitBoutDurationSeconds = 4
+    public static let minGaitBoutActiveSamples = 5
+    public static let minGaitBoutTicks = 6
+
+    public struct Count: Equatable, Sendable {
+        public let totalTicks: Int
+        public let acceptedOutsideSleepTicks: Int
+        public let acceptedAwakeGapTicks: Int
+        public let acceptedSleepBoutTicks: Int
+        public let rejectedIsolatedSleepTicks: Int
+        public let rejectedActivityClassTicks: Int
+        public let rejectedImplausibleTicks: Int
+    }
+
+    /// Stateful, overlap-safe counter for database windows read in ascending pages.
+    public final class Accumulator {
+        private let sessions: [SleepSession]
+        private let hasClasses: Bool
+        private var previous: StepSample?
+        private var outside = 0, awake = 0, sleep = 0, rejectedSleep = 0
+        private var rejectedClass = 0, rejectedImplausible = 0
+        private var pending: [(ts: Int, ticks: Int)] = []
+        private var finished = false
+
+        public init(sleepSessions: [SleepSession], hasActivityClasses: Bool) {
+            sessions = sleepSessions.sorted { $0.start < $1.start }
+            hasClasses = hasActivityClasses
+        }
+
+        @discardableResult public func acceptPage(_ samples: [StepSample]) -> Accumulator {
+            precondition(!finished)
+            for current in samples.sorted(by: { $0.ts < $1.ts }) {
+                guard let prior = previous else { previous = current; continue }
+                guard current.ts > prior.ts else { continue }
+                previous = current
+                let delta = (current.counter - prior.counter) & 0xffff
+                guard StepsCounter.shouldCountDelta(activityClass: current.activityClass,
+                                                     hasActivityClasses: hasClasses) else {
+                    rejectedClass += delta; continue
+                }
+                guard StepsCounter.isPlausibleDelta(previousTs: prior.ts, currentTs: current.ts,
+                                                    delta: delta) else {
+                    rejectedImplausible += delta; continue
+                }
+                switch Self.context(current.ts, sessions: sessions) {
+                case 0: flush(); outside += delta
+                case 1: flush(); awake += delta
+                default:
+                    if let last = pending.last, current.ts - last.ts > maxSecondsBetweenGaitDeltas { flush() }
+                    pending.append((current.ts, delta))
+                }
+            }
+            return self
+        }
+
+        public func finish() -> Count {
+            if !finished { flush(); finished = true }
+            return Count(totalTicks: outside + awake + sleep, acceptedOutsideSleepTicks: outside,
+                         acceptedAwakeGapTicks: awake, acceptedSleepBoutTicks: sleep,
+                         rejectedIsolatedSleepTicks: rejectedSleep,
+                         rejectedActivityClassTicks: rejectedClass,
+                         rejectedImplausibleTicks: rejectedImplausible)
+        }
+
+        private func flush() {
+            guard !pending.isEmpty else { return }
+            let ticks = pending.reduce(0) { $0 + $1.ticks }
+            let duration = pending.last!.ts - pending.first!.ts
+            let coherent = pending.count >= minGaitBoutActiveSamples
+                && duration >= minGaitBoutDurationSeconds && ticks >= minGaitBoutTicks
+            if coherent { sleep += ticks } else { rejectedSleep += ticks }
+            pending.removeAll(keepingCapacity: true)
+        }
+    }
+
+    public static func stepsInWindow(_ samples: [StepSample], sleepSessions: [SleepSession]) -> Int? {
+        let count = count(samples, sleepSessions: sleepSessions)
+        return count.totalTicks > 0 ? count.totalTicks : nil
+    }
+
+    public static func count(_ samples: [StepSample], sleepSessions: [SleepSession]) -> Count {
+        let sorted = samples.sorted { $0.ts < $1.ts }
+        return Accumulator(sleepSessions: sleepSessions,
+                           hasActivityClasses: StepsCounter.hasActivityClasses(sorted))
+            .acceptPage(sorted).finish()
+    }
+
+    private static func context(_ ts: Int, sessions: [SleepSession]) -> Int {
+        guard let session = sessions.first(where: { ts >= $0.start && ts < $0.end }) else { return 0 }
+        if let stage = session.stages.first(where: { ts >= $0.start && ts < $0.end }),
+           SleepStageVocabulary.isWake(stage.stage) { return 1 }
+        return 2
+    }
+}

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepAwareStepCounter.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepAwareStepCounter.swift
@@ -16,6 +16,25 @@ public enum SleepAwareStepCounter {
         public let rejectedIsolatedSleepTicks: Int
         public let rejectedActivityClassTicks: Int
         public let rejectedImplausibleTicks: Int
+        public let gravitySamplesAvailable: Int
+        public let auxSamplesAvailable: Int
+
+        public static let empty = Count(totalTicks: 0, acceptedOutsideSleepTicks: 0,
+            acceptedAwakeGapTicks: 0, acceptedSleepBoutTicks: 0, rejectedIsolatedSleepTicks: 0,
+            rejectedActivityClassTicks: 0, rejectedImplausibleTicks: 0,
+            gravitySamplesAvailable: 0, auxSamplesAvailable: 0)
+
+        public func adding(_ other: Count) -> Count {
+            Count(totalTicks: totalTicks + other.totalTicks,
+                acceptedOutsideSleepTicks: acceptedOutsideSleepTicks + other.acceptedOutsideSleepTicks,
+                acceptedAwakeGapTicks: acceptedAwakeGapTicks + other.acceptedAwakeGapTicks,
+                acceptedSleepBoutTicks: acceptedSleepBoutTicks + other.acceptedSleepBoutTicks,
+                rejectedIsolatedSleepTicks: rejectedIsolatedSleepTicks + other.rejectedIsolatedSleepTicks,
+                rejectedActivityClassTicks: rejectedActivityClassTicks + other.rejectedActivityClassTicks,
+                rejectedImplausibleTicks: rejectedImplausibleTicks + other.rejectedImplausibleTicks,
+                gravitySamplesAvailable: gravitySamplesAvailable + other.gravitySamplesAvailable,
+                auxSamplesAvailable: auxSamplesAvailable + other.auxSamplesAvailable)
+        }
     }
 
     /// Stateful, overlap-safe counter for database windows read in ascending pages.
@@ -25,6 +44,7 @@ public enum SleepAwareStepCounter {
         private var previous: StepSample?
         private var outside = 0, awake = 0, sleep = 0, rejectedSleep = 0
         private var rejectedClass = 0, rejectedImplausible = 0
+        private var gravityAvailable = 0, auxAvailable = 0
         private var pending: [(ts: Int, ticks: Int)] = []
         private var finished = false
 
@@ -59,13 +79,22 @@ public enum SleepAwareStepCounter {
             return self
         }
 
+        @discardableResult public func observeMotion(gravityCount: Int, auxCount: Int) -> Accumulator {
+            precondition(!finished)
+            gravityAvailable += gravityCount
+            auxAvailable += auxCount
+            return self
+        }
+
         public func finish() -> Count {
             if !finished { flush(); finished = true }
             return Count(totalTicks: outside + awake + sleep, acceptedOutsideSleepTicks: outside,
                          acceptedAwakeGapTicks: awake, acceptedSleepBoutTicks: sleep,
                          rejectedIsolatedSleepTicks: rejectedSleep,
                          rejectedActivityClassTicks: rejectedClass,
-                         rejectedImplausibleTicks: rejectedImplausible)
+                         rejectedImplausibleTicks: rejectedImplausible,
+                         gravitySamplesAvailable: gravityAvailable,
+                         auxSamplesAvailable: auxAvailable)
         }
 
         private func flush() {

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StepsCounter.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StepsCounter.swift
@@ -4,33 +4,57 @@ import WhoopProtocol
 /// Wrap-aware step derivation from the strap's cumulative `step_motion_counter@57`, shared by the daily
 /// total (`AnalyticsEngine.analyzeDay`) and any windowed total (a manual workout's `[start, end]`, #398).
 ///
-/// `step_motion_counter@57` is a CUMULATIVE u16 running counter: it climbs while you move, holds flat when
-/// still, and wraps at 65536. The number of motion ticks over a set of time-ordered records is the SUM of
-/// WRAP-AWARE increments of that counter — `delta = (cur - prev) & 0xFFFF` — with a per-user
-/// `stepTicksPerStep` calibration applied by the caller AFTERWARDS (this returns the raw pre-calibration
-/// tick total, so the two callers can never disagree on the counter math). The raw total is an ESTIMATE
-/// (@57 counts motion ticks, not validated steps), not cloud/clinical parity.
+/// `step_motion_counter@57` is a CUMULATIVE u16 motion counter: it climbs for both locomotion and some
+/// non-step wrist motion, and wraps at 65536. On classed WHOOP 5/MG records, the increment ending at each
+/// sample is counted only when the strap labels that sample walk (1) or run (2); still (0) and unknown are
+/// rejected. A wholly unclassed legacy window retains the old counter-only estimate so pre-migration history
+/// remains readable. The caller applies its per-user `stepTicksPerStep` calibration afterwards. The result is
+/// still an estimate, not cloud/clinical parity.
 ///
 /// Kept byte-for-byte in lockstep with the Kotlin twin `StepsCounter.stepsInWindow`.
 public enum StepsCounter {
-    /// The largest wrap-aware increment treated as real motion between two adjacent 1 Hz records. A delta
-    /// at/above this is a big time-gap / disconnect boundary between sync sessions (or a firmware reboot,
-    /// byte-indistinguishable from a u16 wrap), NOT real steps — dropped so gaps don't inflate the total.
-    /// Real 1 Hz motion never ticks this fast between adjacent records. (#132/#276/#316)
-    public static let maxStepDelta = 512
+    private static let locomotionActivityClasses: Set<Int> = [1, 2]
 
-    /// Raw wrap-aware motion-tick total across `samples` — the sum of positive consecutive
-    /// `step_motion_counter@57` increments in `[1, maxStepDelta)`. Sorts by `ts` internally, so the caller
-    /// may pass an unsorted window (already filtered to the range it cares about). Returns `nil` when there
-    /// are fewer than two samples or no forward movement (so "no data" stays distinct from a real zero).
-    /// The caller applies its `stepTicksPerStep` calibration to the returned ticks.
+    static func hasActivityClasses(_ samples: [StepSample]) -> Bool {
+        samples.contains { $0.activityClass != nil }
+    }
+
+    static func shouldCountDelta(activityClass: Int?, hasActivityClasses: Bool) -> Bool {
+        !hasActivityClasses || activityClass.map(locomotionActivityClasses.contains) == true
+    }
+
+    /// Absolute reboot/wrap guard, independent from the per-second plausibility gate below.
+    public static let maxStepDelta = 512
+    public static let maxTicksPerSecond = 4
+
+    static func isPlausibleDelta(previousTs: Int, currentTs: Int, delta: Int) -> Bool {
+        guard delta >= 1, delta < maxStepDelta else { return false }
+        let elapsed = currentTs - previousTs
+        guard elapsed > 0 else { return false }
+        let rateAllowance = elapsed >= maxStepDelta / maxTicksPerSecond
+            ? maxStepDelta - 1
+            : elapsed * maxTicksPerSecond
+        return delta <= rateAllowance
+    }
+
+    /// Raw wrap-aware locomotion-tick total across `samples`. When any sample carries `activityClass`, each
+    /// positive increment is attributed to the later sample and retained only for walk/run. When the whole
+    /// window is legacy-unclassed, all valid increments retain the historical counter-only fallback. Sorts
+    /// by `ts` internally and returns `nil` for fewer than two samples or no retained movement.
     public static func stepsInWindow(_ samples: [StepSample]) -> Int? {
         let sorted = samples.sorted { $0.ts < $1.ts }
         if sorted.count < 2 { return nil }
+        let hasActivityClasses = hasActivityClasses(sorted)
         var total = 0
         for i in 1..<sorted.count {
             let delta = (sorted[i].counter - sorted[i - 1].counter) & 0xFFFF  // wrap-aware u16 increment
-            if delta >= 1 && delta < maxStepDelta { total += delta }  // ignore a delta >= 512 (gap/reset)
+            let isLocomotion = shouldCountDelta(
+                activityClass: sorted[i].activityClass,
+                hasActivityClasses: hasActivityClasses)
+            if isLocomotion && isPlausibleDelta(
+                previousTs: sorted[i - 1].ts, currentTs: sorted[i].ts, delta: delta) {
+                total += delta
+            }
         }
         return total > 0 ? total : nil
     }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StepsCounter.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StepsCounter.swift
@@ -19,6 +19,7 @@ public enum StepsCounter {
         samples.contains { $0.activityClass != nil }
     }
 
+    /// Kotlin twin: `StepsCounter.shouldCountDelta`.
     static func shouldCountDelta(activityClass: Int?, hasActivityClasses: Bool) -> Bool {
         !hasActivityClasses || activityClass.map(locomotionActivityClasses.contains) == true
     }
@@ -27,6 +28,7 @@ public enum StepsCounter {
     public static let maxStepDelta = 512
     public static let maxTicksPerSecond = 4
 
+    /// Kotlin twin: `StepsCounter.isPlausibleDelta`.
     static func isPlausibleDelta(previousTs: Int, currentTs: Int, delta: Int) -> Bool {
         guard delta >= 1, delta < maxStepDelta else { return false }
         let elapsed = currentTs - previousTs

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayCycleTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayCycleTests.swift
@@ -21,4 +21,16 @@ final class DayCycleTests: XCTestCase {
                                                      reliableAwakeCoverage: false).source,
                        .syntheticMidnight)
     }
+
+    func testCoverageSegmentsPreferPriorityWithoutCrossingDeviceCounters() {
+        let window = PhysiologicalSteps.CycleWindow(sleepId: "night", onset: 100, endExclusive: 500)
+        let segments = PhysiologicalSteps.ownerSegmentsFromCoverage(window, coverage: [
+            .init(owner: "secondary", onset: 100, endExclusive: 350, priority: 1),
+            .init(owner: "active", onset: 200, endExclusive: 500, priority: 0),
+        ], fallbackOwner: "secondary")
+        XCTAssertEqual(segments, [
+            .init(owner: "secondary", onset: 100, endExclusive: 200),
+            .init(owner: "active", onset: 200, endExclusive: 500),
+        ])
+    }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayCycleTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayCycleTests.swift
@@ -11,13 +11,23 @@ final class DayCycleTests: XCTestCase {
         XCTAssertEqual(window.source, .calendar)
     }
 
-    func testMissingWakeEvidenceFallsBackAtFirstSafeMidnight() {
+    func testMissingWakeEvidenceKeepsSleepOnsetCycleAcrossMidnight() {
         let sleep = DayCycleWindow(id: "sleep", startInclusive: 20 * 3_600, endExclusive: 0,
                                    displayDay: "1970-01-01", source: .detectedSleep)
         let fallback = DayCycleResolver.fallbackMidnight(after: sleep.startInclusive, offsetSec: 0)
         XCTAssertEqual(fallback, 2 * 86_400)
+        let active = DayCycleResolver.activeWindow(mode: .sleepOnset, latestSleep: sleep,
+                                                   now: fallback, offsetSec: 0,
+                                                   reliableAwakeCoverage: false)
+        XCTAssertEqual(active.source, .detectedSleep)
+        XCTAssertEqual(active.startInclusive, sleep.startInclusive)
+    }
+
+    func testAbsoluteCapStillUsesSyntheticMidnight() {
+        let sleep = DayCycleWindow(id: "sleep", startInclusive: 0, endExclusive: 0,
+                                   displayDay: "1970-01-01", source: .detectedSleep)
         XCTAssertEqual(DayCycleResolver.activeWindow(mode: .sleepOnset, latestSleep: sleep,
-                                                     now: fallback, offsetSec: 0,
+                                                     now: 40 * 3_600, offsetSec: 0,
                                                      reliableAwakeCoverage: false).source,
                        .syntheticMidnight)
     }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayCycleTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayCycleTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import StrandAnalytics
+
+final class DayCycleTests: XCTestCase {
+    func testDefaultsAndCalendarMode() {
+        XCTAssertEqual(DayCycleMode.persisted(nil), .sleepOnset)
+        XCTAssertEqual(DayCycleMode.persisted("midnight"), .midnight)
+        let window = DayCycleResolver.activeWindow(mode: .midnight, latestSleep: nil, now: 86_500,
+                                                   offsetSec: 0, reliableAwakeCoverage: false)
+        XCTAssertEqual(window.startInclusive, 86_400)
+        XCTAssertEqual(window.source, .calendar)
+    }
+
+    func testMissingWakeEvidenceFallsBackAtFirstSafeMidnight() {
+        let sleep = DayCycleWindow(id: "sleep", startInclusive: 20 * 3_600, endExclusive: 0,
+                                   displayDay: "1970-01-01", source: .detectedSleep)
+        let fallback = DayCycleResolver.fallbackMidnight(after: sleep.startInclusive, offsetSec: 0)
+        XCTAssertEqual(fallback, 2 * 86_400)
+        XCTAssertEqual(DayCycleResolver.activeWindow(mode: .sleepOnset, latestSleep: sleep,
+                                                     now: fallback, offsetSec: 0,
+                                                     reliableAwakeCoverage: false).source,
+                       .syntheticMidnight)
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepAwareStepCounterTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepAwareStepCounterTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+import WhoopProtocol
+@testable import StrandAnalytics
+
+final class SleepAwareStepCounterTests: XCTestCase {
+    private func sample(_ ts: Int, _ counter: Int, _ cls: Int? = 1) -> StepSample {
+        StepSample(ts: ts, counter: counter, activityClass: cls)
+    }
+    private func sleep(stages: [StageSegment] = []) -> SleepSession {
+        SleepSession(start: 0, end: 100, efficiency: 1, stages: stages, restingHR: nil, avgHRV: nil)
+    }
+
+    func testIsolatedBedMotionIsRejected() {
+        XCTAssertNil(SleepAwareStepCounter.stepsInWindow([
+            sample(0, 0), sample(1, 1), sample(20, 2)
+        ], sleepSessions: [sleep()]))
+    }
+
+    func testCoherentNightWalkCounts() {
+        XCTAssertEqual(SleepAwareStepCounter.stepsInWindow([
+            sample(0, 0), sample(1, 2), sample(2, 4), sample(3, 6), sample(4, 8), sample(5, 10)
+        ], sleepSessions: [sleep()]), 10)
+    }
+
+    func testExplicitWakeGapCountsImmediately() {
+        let wake = StageSegment(start: 10, end: 20, stage: "wake")
+        XCTAssertEqual(SleepAwareStepCounter.stepsInWindow([
+            sample(9, 0), sample(10, 2)
+        ], sleepSessions: [sleep(stages: [wake])]), 2)
+    }
+
+    func testDiagnosticRejectionReasonsAreSeparated() {
+        let count = SleepAwareStepCounter.count([
+            sample(0, 100, 0), sample(1, 102, 1), sample(2, 110, 1),
+            sample(4, 117, 2), sample(5, 120, 0)
+        ], sleepSessions: [])
+        XCTAssertEqual(count.totalTicks, 9)
+        XCTAssertEqual(count.rejectedActivityClassTicks, 3)
+        XCTAssertEqual(count.rejectedImplausibleTicks, 8)
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StepsCounterTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StepsCounterTests.swift
@@ -8,7 +8,9 @@ import WhoopProtocol
 /// the caller's `stepTicksPerStep` calibration). Mirrors the Android StepsCounterTest vectors value-for-value.
 final class StepsCounterTests: XCTestCase {
 
-    private func step(_ ts: Int, _ counter: Int) -> StepSample { StepSample(ts: ts, counter: counter) }
+    private func step(_ ts: Int, _ counter: Int, _ activityClass: Int? = nil) -> StepSample {
+        StepSample(ts: ts, counter: counter, activityClass: activityClass)
+    }
 
     func testSumsPositiveConsecutiveDeltas() {
         // counters 100 -> 150 -> 220 => deltas 50 + 70 = 120
@@ -44,7 +46,32 @@ final class StepsCounterTests: XCTestCase {
 
     func testMaxStepDeltaBoundaryIsExclusive() {
         // Exactly maxStepDelta (512) is dropped; 511 counts.
-        XCTAssertEqual(StepsCounter.stepsInWindow([step(0, 0), step(60, 512)]), nil)   // 512 dropped => no movement
-        XCTAssertEqual(StepsCounter.stepsInWindow([step(0, 0), step(60, 511)]), 511)   // 511 kept
+        XCTAssertEqual(StepsCounter.stepsInWindow([step(0, 0), step(128, 512)]), nil)   // absolute guard
+        XCTAssertEqual(StepsCounter.stepsInWindow([step(0, 0), step(128, 511)]), 511)
+    }
+
+    func testRejectsPhysicallyImpossibleOneSecondSpikeButAllowsSameTicksAcrossTime() {
+        XCTAssertNil(StepsCounter.stepsInWindow([step(0, 100), step(1, 107)]))
+        XCTAssertEqual(StepsCounter.stepsInWindow([step(0, 100), step(2, 107)]), 7)
+        XCTAssertEqual(StepsCounter.stepsInWindow([step(0, 100), step(1, 104)]), 4)
+    }
+
+    func testClassedStreamCountsOnlyWalkAndRunDeltas() {
+        // Attribute each counter delta to the later sample, matching the strap's per-record class.
+        // still: +10 ignored; walk: +20; run: +15; unknown: +25 ignored => 35 locomotion ticks.
+        XCTAssertEqual(StepsCounter.stepsInWindow([
+            step(0, 100, 0),
+            step(10, 110, 0),
+            step(20, 130, 1),
+            step(30, 145, 2),
+            step(40, 170, nil),
+        ]), 35)
+    }
+
+    func testLegacyUnclassedStreamKeepsCounterFallback() {
+        // Rows written before activityClass existed must retain their historical estimate.
+        XCTAssertEqual(StepsCounter.stepsInWindow([
+            step(0, 100), step(10, 140), step(20, 170),
+        ]), 70)
     }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StepsDailyTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StepsDailyTests.swift
@@ -58,7 +58,7 @@ final class StepsDailyTests: XCTestCase {
     func testJumpGuardDropsGapButKeepsRealSteps() {
         // 100 -> 300 (=200 real) ; 300 -> 1200 is a 900-tick GAP (>= 512) and is dropped ; 1200 -> 1500
         // (=300 real). Only the two in-range increments count => 200 + 300 = 500, the gap doesn't inflate.
-        let s = [step(0, 100), step(60, 300), step(3_600, 1_200), step(3_660, 1_500)]
+        let s = [step(0, 100), step(60, 300), step(3_600, 1_200), step(3_675, 1_500)]
         XCTAssertEqual(stepsFor(s), 500)
     }
 
@@ -66,7 +66,7 @@ final class StepsDailyTests: XCTestCase {
         // THE BUG (#132/#276/#316). A realistic ascending cumulative counter sampled at 1 Hz. The OLD
         // code summed the raw running total (here, byte @57 alone summed) — exploding the count; the NEW
         // wrap-aware diff sums only the per-record increments and yields a sane number.
-        let counters = [100, 127, 127, 130, 131, 131, 140, 152, 160, 175]
+        let counters = [100, 102, 102, 105, 106, 106, 109, 111, 113, 115]
         let samples = counters.enumerated().map { step($0.offset, $0.element) }
         // NEW behaviour: sum of wrap-aware deltas == last - first (all small increments, none >= 512).
         let sane = counters.last! - counters.first!  // 75

--- a/Packages/WhoopStore/Sources/WhoopStore/BackupSettings.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/BackupSettings.swift
@@ -58,6 +58,7 @@ public enum BackupSettings {
         "units.system": .string,
         "units.temperature": .string,
         "effort.scale": .string,
+        "dayCycle.mode": .string,
         "today.hostedCards": .string,
         // #1361: the user's own custom journal BEHAVIOURS (newline-joined names). Deliberately NOT in
         // `appleDefaultsKey` below — it isn't a flat UserDefaults key (customs are derived from the
@@ -82,6 +83,7 @@ public enum BackupSettings {
         "units.system": "units.system",
         "units.temperature": "units.temperature",
         "effort.scale": "effort.scale",
+        "dayCycle.mode": "noop.dayCycleMode",
         "today.hostedCards": "today.hostedCards",
     ]
 

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -402,7 +402,7 @@ extension WhoopStore {
     /// Bounded process-local invalidator over the UTC days touched by this window. The instance token
     /// prevents a static cycle cache surviving a store reopen from reusing revisions from the old DB.
     /// Kotlin twin: `WhoopRepository.stepDataRevisionSignature`.
-    public func stepDataRevisionSignature(deviceId: String, from: Int, to: Int) async throws -> String {
+    public func stepDataRevisionSignature(deviceId: String, from: Int, to: Int) async -> String {
         "\(revisionInstanceToken):\(deviceId):\(stepDataRevision.signature(deviceId: deviceId, from: from, to: to))"
     }
 

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -399,11 +399,11 @@ extension WhoopStore {
         }
     }
 
-    /// O(1), process-local invalidator advanced by every actually inserted step batch. The instance token
-    /// prevents a static cycle cache surviving a store reopen from reusing a revision number from the old DB.
+    /// Bounded process-local invalidator over the UTC days touched by this window. The instance token
+    /// prevents a static cycle cache surviving a store reopen from reusing revisions from the old DB.
     /// Kotlin twin: `WhoopRepository.stepDataRevisionSignature`.
     public func stepDataRevisionSignature(deviceId: String, from: Int, to: Int) async throws -> String {
-        "\(revisionInstanceToken):\(deviceId):\(from):\(to):\(stepDataRevision[deviceId, default: 0])"
+        "\(revisionInstanceToken):\(deviceId):\(stepDataRevision.signature(deviceId: deviceId, from: from, to: to))"
     }
 
     public func stepDiagnosticMotionCounts(deviceId: String, from: Int, to: Int) async throws

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -350,6 +350,7 @@ extension WhoopStore {
         }
     }
 
+    /// Kotlin twin: `WhoopDao.stepSamplesPage`.
     public func stepSamplesPage(deviceId: String, afterExclusive: Int, endExclusive: Int,
                                 limit: Int) async throws -> [StepSample] {
         try syncRead { db in
@@ -364,6 +365,7 @@ extension WhoopStore {
     }
 
     /// Last counter sample before a cycle boundary, used to attribute the first in-cycle delta correctly.
+    /// Kotlin twin: `WhoopDao.stepSampleBefore`.
     public func stepSampleBefore(deviceId: String, before: Int) async throws -> StepSample? {
         try syncRead { db in
             try Row.fetchOne(db, sql: """
@@ -375,6 +377,7 @@ extension WhoopStore {
         }
     }
 
+    /// Kotlin twin: `WhoopDao.hasStepActivityClasses`.
     public func hasStepActivityClasses(deviceId: String, from: Int, to: Int) async throws -> Bool {
         try syncRead { db in
             try Int.fetchOne(db, sql: """
@@ -384,6 +387,7 @@ extension WhoopStore {
         }
     }
 
+    /// Kotlin twin: `WhoopRepository.stepTimestampCoverage`.
     public func stepTimestampCoverage(deviceId: String, from: Int, to: Int) async throws
         -> (first: Int?, last: Int?) {
         try syncRead { db in
@@ -397,6 +401,7 @@ extension WhoopStore {
 
     /// O(1), process-local invalidator advanced by every actually inserted step batch. The instance token
     /// prevents a static cycle cache surviving a store reopen from reusing a revision number from the old DB.
+    /// Kotlin twin: `WhoopRepository.stepDataRevisionSignature`.
     public func stepDataRevisionSignature(deviceId: String, from: Int, to: Int) async throws -> String {
         "\(revisionInstanceToken):\(deviceId):\(from):\(to):\(stepDataRevision[deviceId, default: 0])"
     }

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -350,6 +350,19 @@ extension WhoopStore {
         }
     }
 
+    public func stepSamplesPage(deviceId: String, afterExclusive: Int, endExclusive: Int,
+                                limit: Int) async throws -> [StepSample] {
+        try syncRead { db in
+            try Row.fetchAll(db, sql: """
+                SELECT ts, counter, activityClass FROM stepSample
+                WHERE deviceId = ? AND ts > ? AND ts < ?
+                ORDER BY ts ASC LIMIT ?
+                """, arguments: [deviceId, afterExclusive, endExclusive, limit]).map {
+                    StepSample(ts: $0["ts"], counter: $0["counter"], activityClass: $0["activityClass"])
+                }
+        }
+    }
+
     /// Last counter sample before a cycle boundary, used to attribute the first in-cycle delta correctly.
     public func stepSampleBefore(deviceId: String, before: Int) async throws -> StepSample? {
         try syncRead { db in
@@ -368,6 +381,36 @@ extension WhoopStore {
                 SELECT EXISTS(SELECT 1 FROM stepSample
                 WHERE deviceId = ? AND ts >= ? AND ts < ? AND activityClass IS NOT NULL)
                 """, arguments: [deviceId, from, to]) == 1
+        }
+    }
+
+    public func stepTimestampCoverage(deviceId: String, from: Int, to: Int) async throws
+        -> (first: Int?, last: Int?) {
+        try syncRead { db in
+            let row = try Row.fetchOne(db, sql: """
+                SELECT MIN(ts) AS firstTs, MAX(ts) AS lastTs FROM stepSample
+                WHERE deviceId = ? AND ts >= ? AND ts < ?
+                """, arguments: [deviceId, from, to])
+            return (row?["firstTs"], row?["lastTs"])
+        }
+    }
+
+    /// O(1), process-local invalidator advanced by every actually inserted step batch. The instance token
+    /// prevents a static cycle cache surviving a store reopen from reusing a revision number from the old DB.
+    public func stepDataRevisionSignature(deviceId: String, from: Int, to: Int) async throws -> String {
+        "\(revisionInstanceToken):\(deviceId):\(from):\(to):\(stepDataRevision[deviceId, default: 0])"
+    }
+
+    public func stepDiagnosticMotionCounts(deviceId: String, from: Int, to: Int) async throws
+        -> (gravity: Int, aux: Int) {
+        try syncRead { db in
+            let gravity = try Int.fetchOne(db, sql: """
+                SELECT COUNT(*) FROM gravitySample WHERE deviceId = ? AND ts >= ? AND ts < ?
+                """, arguments: [deviceId, from, to]) ?? 0
+            let aux = try Int.fetchOne(db, sql: """
+                SELECT COUNT(*) FROM v18AuxSample WHERE deviceId = ? AND ts >= ? AND ts < ?
+                """, arguments: [deviceId, from, to]) ?? 0
+            return (gravity, aux)
         }
     }
 

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -350,6 +350,27 @@ extension WhoopStore {
         }
     }
 
+    /// Last counter sample before a cycle boundary, used to attribute the first in-cycle delta correctly.
+    public func stepSampleBefore(deviceId: String, before: Int) async throws -> StepSample? {
+        try syncRead { db in
+            try Row.fetchOne(db, sql: """
+                SELECT ts, counter, activityClass FROM stepSample
+                WHERE deviceId = ? AND ts < ? ORDER BY ts DESC LIMIT 1
+                """, arguments: [deviceId, before]).map {
+                    StepSample(ts: $0["ts"], counter: $0["counter"], activityClass: $0["activityClass"])
+                }
+        }
+    }
+
+    public func hasStepActivityClasses(deviceId: String, from: Int, to: Int) async throws -> Bool {
+        try syncRead { db in
+            try Int.fetchOne(db, sql: """
+                SELECT EXISTS(SELECT 1 FROM stepSample
+                WHERE deviceId = ? AND ts >= ? AND ts < ? AND activityClass IS NOT NULL)
+                """, arguments: [deviceId, from, to]) == 1
+        }
+    }
+
     public func respSamples(deviceId: String, from: Int, to: Int, limit: Int) async throws -> [RespSample] {
         try syncRead { db in
             try Row.fetchAll(db, sql: """

--- a/Packages/WhoopStore/Sources/WhoopStore/ScoreInputProvenanceStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/ScoreInputProvenanceStore.swift
@@ -1,6 +1,12 @@
 import Foundation
 import GRDB
 
+public struct SourcedMetricPoint: Sendable {
+    public let deviceId: String
+    public let point: MetricPoint
+    public init(deviceId: String, point: MetricPoint) { self.deviceId = deviceId; self.point = point }
+}
+
 /// Provenance for one persisted NOOP-computed score. `sourceId` normally names the input provider;
 /// `vo2max_est` uses the estimator id because the method is the provenance users need for that series.
 /// Natural key: (computed device namespace, day, metric key).
@@ -38,7 +44,9 @@ extension WhoopStore {
         deviceId: String,
         from: String,
         to: String,
-        replaceMetricKeys: [String] = []
+        replaceMetricKeys: [String] = [],
+        additionalMetricPoints: [SourcedMetricPoint] = [],
+        replaceMetricSourceIds: [String] = []
     ) async throws {
         // #1196: an empty scoring pass must not destructively rewrite the window — with no daily rows to
         // write, the provenance wide-delete below would blank the window's attribution while a degenerate
@@ -48,11 +56,16 @@ extension WhoopStore {
         guard !dailyMetrics.isEmpty else { return }
         try syncWrite { db in
             _ = try Self.upsertDailyMetrics(dailyMetrics, deviceId: deviceId, in: db)
-            for key in replaceMetricKeys {
-                try db.execute(sql: "DELETE FROM metricSeries WHERE deviceId = ? AND key = ? AND day >= ? AND day <= ?",
-                               arguments: [deviceId, key, from, to])
+            for source in Set(replaceMetricSourceIds + [deviceId]) {
+                for key in replaceMetricKeys {
+                    try db.execute(sql: "DELETE FROM metricSeries WHERE deviceId = ? AND key = ? AND day >= ? AND day <= ?",
+                                   arguments: [source, key, from, to])
+                }
             }
             _ = try Self.upsertMetricSeries(metricPoints, deviceId: deviceId, in: db)
+            for group in Dictionary(grouping: additionalMetricPoints, by: \.deviceId) {
+                _ = try Self.upsertMetricSeries(group.value.map(\.point), deviceId: group.key, in: db)
+            }
 
             // Weekly VO₂max provenance is owned by `persistMetricSeriesWithProvenance` below, not this
             // daily scoring window. Preserve it or every normal 21-day re-score erases the prior two

--- a/Packages/WhoopStore/Sources/WhoopStore/ScoreInputProvenanceStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/ScoreInputProvenanceStore.swift
@@ -37,7 +37,8 @@ extension WhoopStore {
         provenance: [ScoreInputProvenanceRow],
         deviceId: String,
         from: String,
-        to: String
+        to: String,
+        replaceMetricKeys: [String] = []
     ) async throws {
         // #1196: an empty scoring pass must not destructively rewrite the window — with no daily rows to
         // write, the provenance wide-delete below would blank the window's attribution while a degenerate
@@ -47,6 +48,10 @@ extension WhoopStore {
         guard !dailyMetrics.isEmpty else { return }
         try syncWrite { db in
             _ = try Self.upsertDailyMetrics(dailyMetrics, deviceId: deviceId, in: db)
+            for key in replaceMetricKeys {
+                try db.execute(sql: "DELETE FROM metricSeries WHERE deviceId = ? AND key = ? AND day >= ? AND day <= ?",
+                               arguments: [deviceId, key, from, to])
+            }
             _ = try Self.upsertMetricSeries(metricPoints, deviceId: deviceId, in: db)
 
             // Weekly VO₂max provenance is owned by `persistMetricSeriesWithProvenance` below, not this

--- a/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
@@ -259,11 +259,14 @@ extension WhoopStore {
                     ON CONFLICT(deviceId, ts) DO NOTHING
                     """)
                 var insertedSteps = 0
+                var insertedStepTimestamps: [Int] = []
                 for s in streams.steps {
                     try stmt.execute(arguments: [deviceId, s.ts, s.counter, s.activityClass])
-                    insertedSteps += db.changesCount
+                    let inserted = db.changesCount
+                    insertedSteps += inserted
+                    if inserted > 0 { insertedStepTimestamps.append(s.ts) }
                 }
-                if insertedSteps > 0 { stepDataRevision[deviceId, default: 0] += 1 }
+                stepDataRevision.record(deviceId: deviceId, insertedTimestamps: insertedStepTimestamps)
             }
             // Band sleep_state (#175). Persist-only, same as steps — the strap's OWN @81 high-nibble state
             // (0 wake/1 still/2 asleep/3 up), decoded and streamed but dropped at storage until now. Keyed by

--- a/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
@@ -258,9 +258,12 @@ extension WhoopStore {
                     INSERT INTO stepSample (deviceId, ts, counter, activityClass) VALUES (?, ?, ?, ?)
                     ON CONFLICT(deviceId, ts) DO NOTHING
                     """)
+                var insertedSteps = 0
                 for s in streams.steps {
                     try stmt.execute(arguments: [deviceId, s.ts, s.counter, s.activityClass])
+                    insertedSteps += db.changesCount
                 }
+                if insertedSteps > 0 { stepDataRevision[deviceId, default: 0] += 1 }
             }
             // Band sleep_state (#175). Persist-only, same as steps — the strap's OWN @81 high-nibble state
             // (0 wake/1 still/2 asleep/3 up), decoded and streamed but dropped at storage until now. Keyed by

--- a/Packages/WhoopStore/Sources/WhoopStore/WhoopStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/WhoopStore.swift
@@ -62,6 +62,8 @@ public actor WhoopStore {
     /// v18 aux rows banked since the retention sweep last ran, PER DEVICE — the sweep is per device too,
     /// so a shared counter would let one strap spend another's budget. See `StreamStore`.
     var v18AuxRowsSincePrune: [String: Int] = [:]
+    var stepDataRevision: [String: Int] = [:]
+    let revisionInstanceToken = UUID().uuidString
     let dbWriter: any DatabaseWriter
 
     /// Read-only handle to the underlying GRDB writer for the synchronous `DeviceRegistryStore`.

--- a/Packages/WhoopStore/Sources/WhoopStore/WhoopStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/WhoopStore.swift
@@ -274,9 +274,10 @@ public actor WhoopStore {
     }
 }
 
-/// Bounded process-local cache witness keyed by owner and UTC day. Cycle windows move with `now`, so
+/// Compact process-local cache witness keyed by owner and UTC day. Cycle windows move with `now`, so
 /// using their exact end timestamp as a cache key would invalidate an otherwise unchanged active cycle
 /// every second. Keeping revisions per UTC day makes the signature stable until a row in that day lands.
+/// Its process-lifetime size is proportional to owners × UTC days that receive new step rows.
 struct StepDataRevisionIndex {
     private static let utcDaySeconds = 86_400
     private var nextRevision = 0

--- a/Packages/WhoopStore/Sources/WhoopStore/WhoopStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/WhoopStore.swift
@@ -62,7 +62,7 @@ public actor WhoopStore {
     /// v18 aux rows banked since the retention sweep last ran, PER DEVICE — the sweep is per device too,
     /// so a shared counter would let one strap spend another's budget. See `StreamStore`.
     var v18AuxRowsSincePrune: [String: Int] = [:]
-    var stepDataRevision: [String: Int] = [:]
+    var stepDataRevision = StepDataRevisionIndex()
     let revisionInstanceToken = UUID().uuidString
     let dbWriter: any DatabaseWriter
 
@@ -271,5 +271,45 @@ public actor WhoopStore {
         try syncRead { db in
             try Set(db.indexes(on: table).map(\.name))
         }
+    }
+}
+
+/// Bounded process-local cache witness keyed by owner and UTC day. Cycle windows move with `now`, so
+/// using their exact end timestamp as a cache key would invalidate an otherwise unchanged active cycle
+/// every second. Keeping revisions per UTC day makes the signature stable until a row in that day lands.
+struct StepDataRevisionIndex {
+    private static let utcDaySeconds = 86_400
+    private var nextRevision = 0
+    private var byOwnerDay: [OwnerDay: Int] = [:]
+
+    private struct OwnerDay: Hashable {
+        let owner: String
+        let day: Int
+    }
+
+    mutating func record(deviceId: String, insertedTimestamps: [Int]) {
+        guard !insertedTimestamps.isEmpty else { return }
+        nextRevision += 1
+        for timestamp in insertedTimestamps {
+            byOwnerDay[OwnerDay(owner: deviceId, day: timestamp.floorDividing(by: Self.utcDaySeconds))]
+                = nextRevision
+        }
+    }
+
+    func signature(deviceId: String, from: Int, to: Int) -> String {
+        guard to > from else { return "" }
+        let first = from.floorDividing(by: Self.utcDaySeconds)
+        let last = (to - 1).floorDividing(by: Self.utcDaySeconds)
+        return (first...last).map { day in
+            "\(day):\(byOwnerDay[OwnerDay(owner: deviceId, day: day), default: 0])"
+        }.joined(separator: ",")
+    }
+}
+
+private extension Int {
+    func floorDividing(by divisor: Int) -> Int {
+        let quotient = self / divisor
+        let remainder = self % divisor
+        return remainder < 0 ? quotient - 1 : quotient
     }
 }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/BackupSettingsTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/BackupSettingsTests.swift
@@ -21,6 +21,7 @@ final class BackupSettingsTests: XCTestCase {
             "units.system": "imperial",
             "units.temperature": "celsius",
             "effort.scale": "whoop",
+            "dayCycle.mode": "sleep_onset",
             // #today-hosted-cards: the one layout pref carried, a JSON [String] stored under the String kind.
             "today.hostedCards": "[\"sleep.sleepMarks\"]",
             // #1361: custom journal behaviours, a newline-joined name list — the embedded newline must
@@ -40,6 +41,7 @@ final class BackupSettingsTests: XCTestCase {
         XCTAssertEqual(back["units.system"] as? String, "imperial")
         XCTAssertEqual(back["units.temperature"] as? String, "celsius")
         XCTAssertEqual(back["effort.scale"] as? String, "whoop")
+        XCTAssertEqual(back["dayCycle.mode"] as? String, "sleep_onset")
         XCTAssertEqual(back["today.hostedCards"] as? String, "[\"sleep.sleepMarks\"]")
         XCTAssertEqual(back["journal.customBehaviors"] as? String, "Cold plunge\nMagnesium")
         XCTAssertEqual(back.count, values.count, "Nothing extra should appear")

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/ScoreInputProvenanceStoreTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/ScoreInputProvenanceStoreTests.swift
@@ -127,6 +127,23 @@ final class ScoreInputProvenanceStoreTests: XCTestCase {
         XCTAssertEqual(estimator, Vo2MaxEstimator.nes.rawValue)
     }
 
+    func testMarkerRewriteSpansComputedOwnerNamespaces() async throws {
+        let store = try await WhoopStore.inMemory()
+        let day = "2026-07-24"
+        _ = try await store.upsertMetricSeries([.init(day: day, key: "day_cycle_onset_ts", value: 1)],
+                                               deviceId: "old-noop")
+        try await store.persistComputedScores(
+            dailyMetrics: [makeDaily(day: day, recovery: nil, strain: nil)], metricPoints: [], provenance: [],
+            deviceId: "active-noop", from: day, to: day,
+            replaceMetricKeys: ["day_cycle_onset_ts"],
+            additionalMetricPoints: [.init(deviceId: "old-noop",
+                point: .init(day: day, key: "day_cycle_onset_ts", value: 2))],
+            replaceMetricSourceIds: ["old-noop"])
+        let old = try await store.metricSeries(deviceId: "old-noop", key: "day_cycle_onset_ts",
+                                               from: day, to: day)
+        XCTAssertEqual(old.map(\.value), [2])
+    }
+
     private func makeDaily(day: String, recovery: Double?, strain: Double?) -> DailyMetric {
         DailyMetric(
             day: day,

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/StepSampleTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/StepSampleTests.swift
@@ -39,9 +39,9 @@ final class StepSampleTests: XCTestCase {
             StepSample(ts: day + 100, counter: 1),
         ]), deviceId: "strap")
 
-        let first = try await store.stepDataRevisionSignature(
+        let first = await store.stepDataRevisionSignature(
             deviceId: "strap", from: day, to: day + 1_000)
-        let later = try await store.stepDataRevisionSignature(
+        let later = await store.stepDataRevisionSignature(
             deviceId: "strap", from: day, to: day + 2_000)
 
         XCTAssertEqual(first, later)
@@ -53,29 +53,31 @@ final class StepSampleTests: XCTestCase {
         _ = try await store.insert(Streams(steps: [
             StepSample(ts: day + 100, counter: 1),
         ]), deviceId: "strap")
-        let firstDayBefore = try await store.stepDataRevisionSignature(
+        let firstDayBefore = await store.stepDataRevisionSignature(
             deviceId: "strap", from: day, to: day + 86_400)
+        let secondDayBefore = await store.stepDataRevisionSignature(
+            deviceId: "strap", from: day + 86_400, to: day + 172_800)
 
         _ = try await store.insert(Streams(steps: [
             StepSample(ts: day + 86_500, counter: 2),
         ]), deviceId: "strap")
-        let firstDayAfter = try await store.stepDataRevisionSignature(
+        let firstDayAfter = await store.stepDataRevisionSignature(
             deviceId: "strap", from: day, to: day + 86_400)
-        let secondDay = try await store.stepDataRevisionSignature(
+        let secondDayAfter = await store.stepDataRevisionSignature(
             deviceId: "strap", from: day + 86_400, to: day + 172_800)
 
         XCTAssertEqual(firstDayBefore, firstDayAfter)
-        XCTAssertNotEqual(firstDayAfter, secondDay)
+        XCTAssertNotEqual(secondDayBefore, secondDayAfter)
     }
 
     func testDuplicateStepInsertDoesNotInvalidateRevision() async throws {
         let store = try await WhoopStore.inMemory()
         let sample = StepSample(ts: 1_780_916_150, counter: 50)
         _ = try await store.insert(Streams(steps: [sample]), deviceId: "strap")
-        let before = try await store.stepDataRevisionSignature(
+        let before = await store.stepDataRevisionSignature(
             deviceId: "strap", from: sample.ts - 1, to: sample.ts + 1)
         _ = try await store.insert(Streams(steps: [sample]), deviceId: "strap")
-        let after = try await store.stepDataRevisionSignature(
+        let after = await store.stepDataRevisionSignature(
             deviceId: "strap", from: sample.ts - 1, to: sample.ts + 1)
         XCTAssertEqual(before, after)
     }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/StepSampleTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/StepSampleTests.swift
@@ -32,6 +32,54 @@ final class StepSampleTests: XCTestCase {
         XCTAssertEqual(n2, 2)
     }
 
+    func testStepRevisionSignatureIsStableAsActiveWindowAdvances() async throws {
+        let store = try await WhoopStore.inMemory()
+        let day = 1_780_876_800
+        _ = try await store.insert(Streams(steps: [
+            StepSample(ts: day + 100, counter: 1),
+        ]), deviceId: "strap")
+
+        let first = try await store.stepDataRevisionSignature(
+            deviceId: "strap", from: day, to: day + 1_000)
+        let later = try await store.stepDataRevisionSignature(
+            deviceId: "strap", from: day, to: day + 2_000)
+
+        XCTAssertEqual(first, later)
+    }
+
+    func testStepRevisionOnlyInvalidatesTouchedUtcDays() async throws {
+        let store = try await WhoopStore.inMemory()
+        let day = 1_780_876_800
+        _ = try await store.insert(Streams(steps: [
+            StepSample(ts: day + 100, counter: 1),
+        ]), deviceId: "strap")
+        let firstDayBefore = try await store.stepDataRevisionSignature(
+            deviceId: "strap", from: day, to: day + 86_400)
+
+        _ = try await store.insert(Streams(steps: [
+            StepSample(ts: day + 86_500, counter: 2),
+        ]), deviceId: "strap")
+        let firstDayAfter = try await store.stepDataRevisionSignature(
+            deviceId: "strap", from: day, to: day + 86_400)
+        let secondDay = try await store.stepDataRevisionSignature(
+            deviceId: "strap", from: day + 86_400, to: day + 172_800)
+
+        XCTAssertEqual(firstDayBefore, firstDayAfter)
+        XCTAssertNotEqual(firstDayAfter, secondDay)
+    }
+
+    func testDuplicateStepInsertDoesNotInvalidateRevision() async throws {
+        let store = try await WhoopStore.inMemory()
+        let sample = StepSample(ts: 1_780_916_150, counter: 50)
+        _ = try await store.insert(Streams(steps: [sample]), deviceId: "strap")
+        let before = try await store.stepDataRevisionSignature(
+            deviceId: "strap", from: sample.ts - 1, to: sample.ts + 1)
+        _ = try await store.insert(Streams(steps: [sample]), deviceId: "strap")
+        let after = try await store.stepDataRevisionSignature(
+            deviceId: "strap", from: sample.ts - 1, to: sample.ts + 1)
+        XCTAssertEqual(before, after)
+    }
+
     /// v19 migration: the @63 activity-class column exists on stepSample (#316).
     func testV19AddsActivityClassColumn() async throws {
         let store = try await WhoopStore.inMemory()

--- a/Strand/Data/DayCycleIntelligenceIntegration.swift
+++ b/Strand/Data/DayCycleIntelligenceIntegration.swift
@@ -279,6 +279,7 @@ import WhoopStore
             recovery: daily.recovery, strain: daily.strain, exerciseCount: daily.exerciseCount,
             spo2Pct: daily.spo2Pct, skinTempDevC: daily.skinTempDevC, respRateBpm: daily.respRateBpm,
             steps: steps, activeKcalEst: daily.activeKcalEst, spo2Red: daily.spo2Red,
-            spo2Ir: daily.spo2Ir, avgSdnn: daily.avgSdnn)
+            spo2Ir: daily.spo2Ir, avgSdnn: daily.avgSdnn,
+            skinTempC: daily.skinTempC, sleepHrOnly: daily.sleepHrOnly)
     }
 }

--- a/Strand/Data/DayCycleIntelligenceIntegration.swift
+++ b/Strand/Data/DayCycleIntelligenceIntegration.swift
@@ -15,6 +15,9 @@ import WhoopStore
         let firstWakeDay: String?
         let recoveredMarkers: [SourcedMarker]
         let markerSourceIds: [String]
+        /// False only when marker state is unknown (for example after a failed recovery read). Callers
+        /// must then preserve persisted markers instead of interpreting an empty array as authoritative.
+        let shouldReplaceMarkers: Bool
     }
     private struct PersistedBoundary {
         let boundary: PhysiologicalSteps.CycleBoundary
@@ -31,7 +34,7 @@ import WhoopStore
 
     private static func recover(candidates: [(owner: String, priority: Int)], store: WhoopStore,
                                 claimedDays: Set<String>, windowStart: Int, now: Int,
-                                offsetSec: Int, habitualMidsleepSec: Int?) async -> [PersistedBoundary] {
+                                offsetSec: Int, habitualMidsleepSec: Int?) async throws -> [PersistedBoundary] {
         var claimed = claimedDays, output: [PersistedBoundary] = []
         let fromDay = AnalyticsEngine.dayString(windowStart, offsetSec: offsetSec)
         let toDay = AnalyticsEngine.dayString(now, offsetSec: offsetSec)
@@ -39,10 +42,10 @@ import WhoopStore
             $0.priority == $1.priority ? $0.owner < $1.owner : $0.priority < $1.priority
         }) {
             let source = computedId(candidate.owner)
-            let sessions = (try? await store.sleepSessions(
-                deviceId: source, from: windowStart, to: now, limit: 4_000)) ?? []
-            let points = (try? await store.metricSeries(
-                deviceId: source, key: onsetKey, from: fromDay, to: toDay)) ?? []
+            let sessions = try await store.sleepSessions(
+                deviceId: source, from: windowStart, to: now, limit: 4_000)
+            let points = try await store.metricSeries(
+                deviceId: source, key: onsetKey, from: fromDay, to: toDay)
             let markers = Dictionary(points.compactMap { point -> (String, Int)? in
                 let value = Int(point.value)
                 return point.value == Double(value) ? (point.day, value) : nil
@@ -80,7 +83,7 @@ import WhoopStore
                         mode: DayCycleMode, trace: ((String) -> Void)? = nil) async -> Result {
         guard mode == .sleepOnset else {
             return Result(stepsByWakeDay: [:], onsetByWakeDay: [:], firstWakeDay: nil,
-                          recoveredMarkers: [], markerSourceIds: [])
+                          recoveredMarkers: [], markerSourceIds: [], shouldReplaceMarkers: true)
         }
         let editsByDay = Dictionary(grouping: editedRows) {
             AnalyticsEngine.dayString($0.endTs, offsetSec: offsetSec)
@@ -116,9 +119,18 @@ import WhoopStore
             wakeDayById[winner.id] = night.daily.day; ownerById[winner.id] = night.owner
         }
 
-        let recovered = await recover(candidates: candidates, store: store,
-            claimedDays: Set(wakeDayById.values), windowStart: windowStart, now: now,
-            offsetSec: offsetSec, habitualMidsleepSec: habitualMidsleepSec)
+        let recovered: [PersistedBoundary]
+        do {
+            recovered = try await recover(candidates: candidates, store: store,
+                claimedDays: Set(wakeDayById.values), windowStart: windowStart, now: now,
+                offsetSec: offsetSec, habitualMidsleepSec: habitualMidsleepSec)
+        } catch {
+            // Fail closed: an unread namespace is unknown, not empty. Returning no replacement source IDs
+            // prevents the persistence transaction from deleting valid markers after a transient read error.
+            trace?("stepsCycle status=error error=boundaryRecoveryRead")
+            return Result(stepsByWakeDay: [:], onsetByWakeDay: [:], firstWakeDay: nil,
+                          recoveredMarkers: [], markerSourceIds: [], shouldReplaceMarkers: false)
+        }
         for item in recovered {
             boundaries.append(item.boundary); wakeDayById[item.boundary.sleepId] = item.wakeDay
             ownerById[item.boundary.sleepId] = item.owner; sleepContexts.append(item.sleepContext)
@@ -238,7 +250,8 @@ import WhoopStore
             point: MetricPoint(day: $0.wakeDay, key: onsetKey, value: Double($0.boundary.onset))) }
         return Result(stepsByWakeDay: steps, onsetByWakeDay: onsets,
             firstWakeDay: wakeDayById.values.min(), recoveredMarkers: recoveredMarkers,
-            markerSourceIds: Array(Set(candidates.map { computedId($0.owner) })).sorted())
+            markerSourceIds: Array(Set(candidates.map { computedId($0.owner) })).sorted(),
+            shouldReplaceMarkers: true)
     }
 
     static func applying(_ result: Result, to daily: DailyMetric) -> DailyMetric {

--- a/Strand/Data/DayCycleIntelligenceIntegration.swift
+++ b/Strand/Data/DayCycleIntelligenceIntegration.swift
@@ -7,7 +7,7 @@ import WhoopStore
     static let onsetKey = "day_cycle_onset_ts"
     static let pageSize = 10_000
 
-    struct Night { let daily: DailyMetric; let sleeps: [CachedSleepSession]; let owner: String }
+    struct Night { let daily: DailyMetric; let sleeps: [CachedSleepSession]; let workouts: [ExerciseSession]; let owner: String }
     struct SourcedMarker: Sendable { let deviceId: String; let point: MetricPoint }
     struct BoundaryRecoveryReader {
         let sleepSessions: (String, Int, Int) async throws -> [CachedSleepSession]
@@ -19,6 +19,9 @@ import WhoopStore
     }
     struct Result {
         let stepsByWakeDay: [String: Int]
+        let strainByWakeDay: [String: Double]
+        let caloriesByWakeDay: [String: Double]
+        let workoutCountByWakeDay: [String: Int]
         let onsetByWakeDay: [String: Int]
         let firstWakeDay: String?
         let markerUpdate: MarkerUpdate
@@ -85,10 +88,12 @@ import WhoopStore
                         candidates: [(owner: String, priority: Int)], windowStart: Int,
                         now: Int, offsetSec: Int, habitualMidsleepSec: Int?, ticksPerStep: Double,
                         mode: DayCycleMode, cache: Cache,
+                        profile: UserProfile, maxHROverride: Double?, effortMethod: StrainScorer.Method,
                         recoveryReader: BoundaryRecoveryReader? = nil,
                         trace: ((String) -> Void)? = nil) async -> Result {
         guard mode == .sleepOnset else {
-            return Result(stepsByWakeDay: [:], onsetByWakeDay: [:], firstWakeDay: nil,
+            return Result(stepsByWakeDay: [:], strainByWakeDay: [:], caloriesByWakeDay: [:],
+                          workoutCountByWakeDay: [:], onsetByWakeDay: [:], firstWakeDay: nil,
                           markerUpdate: .replace(points: [], sourceIds: Array(Set(
                             candidates.map { computedId($0.owner) })).sorted()))
         }
@@ -144,7 +149,8 @@ import WhoopStore
             // Fail closed: an unread namespace is unknown, not empty. Returning no replacement source IDs
             // prevents the persistence transaction from deleting valid markers after a transient read error.
             trace?("stepsCycle status=error error=boundaryRecoveryRead")
-            return Result(stepsByWakeDay: [:], onsetByWakeDay: [:], firstWakeDay: nil,
+            return Result(stepsByWakeDay: [:], strainByWakeDay: [:], caloriesByWakeDay: [:],
+                          workoutCountByWakeDay: [:], onsetByWakeDay: [:], firstWakeDay: nil,
                           markerUpdate: .preserve)
         }
         for item in recovered {
@@ -173,10 +179,27 @@ import WhoopStore
             return (night.daily.day, "\(night.owner):\(night.daily.steps.map(String.init) ?? "nil")|\(sleeps)")
         })
         var steps: [String: Int] = [:], onsets: [String: Int] = [:]
+        var strains: [String: Double] = [:], calories: [String: Double] = [:]
+        var workoutCounts: [String: Int] = [:]
         windowLoop: for window in windows {
             guard let day = wakeDayById[window.sleepId], let fallback = ownerById[window.sleepId] else { continue }
             do {
             onsets[day] = window.onset
+            let cycleHR = (try? await store.hrSamples(
+                deviceId: fallback, from: window.onset, to: window.endExclusive, limit: 200_000)) ?? []
+            let restingHR = nights.first(where: { $0.daily.day == day })?.daily.restingHr.map(Double.init)
+                ?? StrainScorer.defaultRestingHR
+            let effectiveMaxHR = maxHROverride ?? (profile.age > 0 ? StrainScorer.tanakaHRmax(age: profile.age) : nil)
+            if let strain = StrainScorer.strain(cycleHR, maxHR: effectiveMaxHR,
+                                                restingHR: restingHR, method: effortMethod,
+                                                sex: profile.sex) { strains[day] = strain }
+            if !cycleHR.isEmpty {
+                calories[day] = Calories.estimateDayCalories(
+                    cycleHR, profile: profile, hrmax: effectiveMaxHR, restingHR: restingHR)
+            }
+            workoutCounts[day] = Set(nights.flatMap(\.workouts)
+                .filter { $0.start >= window.onset && $0.start < window.endExclusive }
+                .map { "\($0.start):\($0.end)" }).count
             var ranked = priorities; ranked[fallback] = ranked[fallback] ?? ranked.values.min() ?? 0
             var coverage: [PhysiologicalSteps.OwnerCoverage] = []
             for (owner, priority) in ranked {
@@ -264,7 +287,8 @@ import WhoopStore
         }
         let recoveredMarkers = recovered.map { SourcedMarker(deviceId: computedId($0.owner),
             point: MetricPoint(day: $0.wakeDay, key: onsetKey, value: Double($0.boundary.onset))) }
-        return Result(stepsByWakeDay: steps, onsetByWakeDay: onsets,
+        return Result(stepsByWakeDay: steps, strainByWakeDay: strains, caloriesByWakeDay: calories,
+            workoutCountByWakeDay: workoutCounts, onsetByWakeDay: onsets,
             firstWakeDay: wakeDayById.values.min(), markerUpdate: .replace(
                 points: recoveredMarkers,
                 sourceIds: Array(Set(candidates.map { computedId($0.owner) })).sorted()))
@@ -273,12 +297,15 @@ import WhoopStore
     static func applying(_ result: Result, to daily: DailyMetric) -> DailyMetric {
         let established = result.firstWakeDay.map { daily.day >= $0 } ?? false
         let steps = established ? result.stepsByWakeDay[daily.day] : daily.steps
+        let strain = established ? result.strainByWakeDay[daily.day] : daily.strain
+        let calories = established ? result.caloriesByWakeDay[daily.day] : daily.activeKcalEst
+        let workouts = established ? result.workoutCountByWakeDay[daily.day] : daily.exerciseCount
         return DailyMetric(day: daily.day, totalSleepMin: daily.totalSleepMin, efficiency: daily.efficiency,
             deepMin: daily.deepMin, remMin: daily.remMin, lightMin: daily.lightMin,
             disturbances: daily.disturbances, restingHr: daily.restingHr, avgHrv: daily.avgHrv,
-            recovery: daily.recovery, strain: daily.strain, exerciseCount: daily.exerciseCount,
+            recovery: daily.recovery, strain: strain, exerciseCount: workouts,
             spo2Pct: daily.spo2Pct, skinTempDevC: daily.skinTempDevC, respRateBpm: daily.respRateBpm,
-            steps: steps, activeKcalEst: daily.activeKcalEst, spo2Red: daily.spo2Red,
+            steps: steps, activeKcalEst: calories, spo2Red: daily.spo2Red,
             spo2Ir: daily.spo2Ir, avgSdnn: daily.avgSdnn,
             skinTempC: daily.skinTempC, sleepHrOnly: daily.sleepHrOnly)
     }

--- a/Strand/Data/DayCycleIntelligenceIntegration.swift
+++ b/Strand/Data/DayCycleIntelligenceIntegration.swift
@@ -85,6 +85,7 @@ import WhoopStore
                         candidates: [(owner: String, priority: Int)], windowStart: Int,
                         now: Int, offsetSec: Int, habitualMidsleepSec: Int?, ticksPerStep: Double,
                         mode: DayCycleMode, cache: Cache,
+                        recoveryReader: BoundaryRecoveryReader? = nil,
                         trace: ((String) -> Void)? = nil) async -> Result {
         guard mode == .sleepOnset else {
             return Result(stepsByWakeDay: [:], onsetByWakeDay: [:], firstWakeDay: nil,
@@ -127,7 +128,7 @@ import WhoopStore
 
         let recovered: [PersistedBoundary]
         do {
-            let reader = BoundaryRecoveryReader(
+            let productionReader = BoundaryRecoveryReader(
                 sleepSessions: { source, from, to in
                     try await store.sleepSessions(deviceId: source, from: from, to: to, limit: 4_000)
                 },
@@ -135,7 +136,8 @@ import WhoopStore
                     try await store.metricSeries(
                         deviceId: source, key: onsetKey, from: fromDay, to: toDay)
                 })
-            recovered = try await recover(candidates: candidates, reader: reader,
+            recovered = try await recover(candidates: candidates,
+                reader: recoveryReader ?? productionReader,
                 claimedDays: Set(wakeDayById.values), windowStart: windowStart, now: now,
                 offsetSec: offsetSec, habitualMidsleepSec: habitualMidsleepSec)
         } catch {

--- a/Strand/Data/DayCycleIntelligenceIntegration.swift
+++ b/Strand/Data/DayCycleIntelligenceIntegration.swift
@@ -3,119 +3,242 @@ import StrandAnalytics
 import WhoopProtocol
 import WhoopStore
 
-/// Thin iOS adapter for the platform-neutral physiological day-cycle kernels.
-enum DayCycleIntelligenceIntegration {
+@MainActor enum DayCycleIntelligenceIntegration {
     static let onsetKey = "day_cycle_onset_ts"
+    static let pageSize = 10_000
 
-    struct Night {
-        let daily: DailyMetric
-        let sleeps: [CachedSleepSession]
-        let owner: String
-    }
+    struct Night { let daily: DailyMetric; let sleeps: [CachedSleepSession]; let owner: String }
+    struct SourcedMarker: Sendable { let deviceId: String; let point: MetricPoint }
     struct Result {
         let stepsByWakeDay: [String: Int]
         let onsetByWakeDay: [String: Int]
         let firstWakeDay: String?
+        let recoveredMarkers: [SourcedMarker]
+        let markerSourceIds: [String]
+    }
+    private struct PersistedBoundary {
+        let boundary: PhysiologicalSteps.CycleBoundary
+        let wakeDay: String
+        let owner: String
+        let sleepContext: SleepSession
+    }
+    private struct CachedCycle {
+        let key: String; let count: SleepAwareStepCounter.Count
+        let pages: Int; let samples: Int; let evaluated: Bool
+    }
+    private static var cache: [String: CachedCycle] = [:]
+    private static func computedId(_ owner: String) -> String { owner + "-noop" }
+
+    private static func recover(candidates: [(owner: String, priority: Int)], store: WhoopStore,
+                                claimedDays: Set<String>, windowStart: Int, now: Int,
+                                offsetSec: Int, habitualMidsleepSec: Int?) async -> [PersistedBoundary] {
+        var claimed = claimedDays, output: [PersistedBoundary] = []
+        let fromDay = AnalyticsEngine.dayString(windowStart, offsetSec: offsetSec)
+        let toDay = AnalyticsEngine.dayString(now, offsetSec: offsetSec)
+        for candidate in candidates.sorted(by: {
+            $0.priority == $1.priority ? $0.owner < $1.owner : $0.priority < $1.priority
+        }) {
+            let source = computedId(candidate.owner)
+            let sessions = (try? await store.sleepSessions(
+                deviceId: source, from: windowStart, to: now, limit: 4_000)) ?? []
+            let points = (try? await store.metricSeries(
+                deviceId: source, key: onsetKey, from: fromDay, to: toDay)) ?? []
+            let markers = Dictionary(points.compactMap { point -> (String, Int)? in
+                let value = Int(point.value)
+                return point.value == Double(value) ? (point.day, value) : nil
+            }, uniquingKeysWith: { first, _ in first })
+            let grouped = Dictionary(grouping: sessions) {
+                AnalyticsEngine.dayString($0.endTs, offsetSec: offsetSec)
+            }
+            for day in grouped.keys.sorted() where !claimed.contains(day) {
+                guard let marker = markers[day] else { continue }
+                let rows = grouped[day] ?? []
+                let blocks = rows.map { PhysiologicalSteps.SleepBlock(
+                    onset: $0.startTs, end: $0.endTs, id: String($0.startTs),
+                    editedOnset: $0.startTsAdjusted) }
+                guard let winner = PhysiologicalSteps.classifyForCycle(
+                    blocks, offsetSec: offsetSec, habitualMidsleepSec: habitualMidsleepSec)
+                    .first(where: { $0.kind == .mainSleep && $0.effectiveOnset == marker }),
+                      let row = rows.first(where: {
+                          String($0.startTs) == winner.id && $0.effectiveStartTs == marker
+                      }) else { continue }
+                let context = SleepSession(start: row.effectiveStartTs, end: row.endTs,
+                    efficiency: row.efficiency ?? 0, stages: AnalyticsEngine.decodeStages(row.stagesJSON),
+                    restingHR: row.restingHr, avgHRV: row.avgHrv)
+                output.append(PersistedBoundary(boundary: .init(
+                    sleepId: "persisted:\(candidate.owner):\(row.startTs)", onset: marker),
+                    wakeDay: day, owner: candidate.owner, sleepContext: context))
+                claimed.insert(day)
+            }
+        }
+        return output
     }
 
     static func compute(nights: [Night], editedRows: [CachedSleepSession], store: WhoopStore,
+                        candidates: [(owner: String, priority: Int)], windowStart: Int,
                         now: Int, offsetSec: Int, habitualMidsleepSec: Int?, ticksPerStep: Double,
                         mode: DayCycleMode, trace: ((String) -> Void)? = nil) async -> Result {
-        guard mode == .sleepOnset else { return Result(stepsByWakeDay: [:], onsetByWakeDay: [:], firstWakeDay: nil) }
-        let edits = Dictionary(editedRows.map { ($0.startTs, $0) }, uniquingKeysWith: { first, _ in first })
+        guard mode == .sleepOnset else {
+            return Result(stepsByWakeDay: [:], onsetByWakeDay: [:], firstWakeDay: nil,
+                          recoveredMarkers: [], markerSourceIds: [])
+        }
+        let editsByDay = Dictionary(grouping: editedRows) {
+            AnalyticsEngine.dayString($0.endTs, offsetSec: offsetSec)
+        }
         var boundaries: [PhysiologicalSteps.CycleBoundary] = []
-        var wakeDayById: [String: String] = [:]
-        var ownerById: [String: String] = [:]
+        var wakeDayById: [String: String] = [:], ownerById: [String: String] = [:]
         var sleepContexts: [SleepSession] = []
-
         for night in nights {
-            let blocks = night.sleeps.map { row -> PhysiologicalSteps.SleepBlock in
+            let dayEdits = editsByDay[night.daily.day] ?? []
+            let edits = Dictionary(dayEdits.map { ($0.startTs, $0) }, uniquingKeysWith: { first, _ in first })
+            let detectedStarts = Set(night.sleeps.map(\.startTs))
+            var blocks: [PhysiologicalSteps.SleepBlock] = []
+            for row in night.sleeps {
                 let edit = edits[row.startTs]
-                return PhysiologicalSteps.SleepBlock(
-                    onset: row.startTs, end: row.endTs, id: "\(night.owner):\(row.startTs)",
-                    editedOnset: edit?.effectiveStartTs ?? row.startTsAdjusted
-                )
+                let start = edit?.effectiveStartTs ?? row.effectiveStartTs
+                let end = edit?.endTs ?? row.endTs
+                blocks.append(.init(onset: row.startTs, end: end, id: String(row.startTs), editedOnset: start))
+                sleepContexts.append(SleepSession(start: start, end: end,
+                    efficiency: row.efficiency ?? 0, stages: AnalyticsEngine.decodeStages(row.stagesJSON),
+                    restingHR: row.restingHr, avgHRV: row.avgHrv))
+            }
+            for edit in dayEdits where !detectedStarts.contains(edit.startTs) {
+                blocks.append(.init(onset: edit.startTs, end: edit.endTs,
+                    id: "manual:\(edit.startTs)", editedOnset: edit.startTsAdjusted, kind: .nap))
+                sleepContexts.append(SleepSession(start: edit.effectiveStartTs, end: edit.endTs,
+                    efficiency: 0, stages: [], restingHR: nil, avgHRV: nil))
             }
             let classified = PhysiologicalSteps.classifyForCycle(
                 blocks, offsetSec: offsetSec, habitualMidsleepSec: habitualMidsleepSec)
-            let mains = classified.filter { $0.kind == .mainSleep }
-            guard let onset = mains.map(\.effectiveOnset).min(), onset <= now else { continue }
-            let id = mains.min(by: { $0.effectiveOnset < $1.effectiveOnset })?.id ?? "\(night.owner):\(onset)"
-            boundaries.append(.init(sleepId: id, onset: onset))
-            wakeDayById[id] = night.daily.day
-            ownerById[id] = night.owner
-            for row in night.sleeps {
-                let effective = edits[row.startTs] ?? row
-                sleepContexts.append(SleepSession(
-                    start: effective.effectiveStartTs, end: effective.endTs,
-                    efficiency: effective.efficiency ?? 0,
-                    stages: AnalyticsEngine.decodeStages(effective.stagesJSON),
-                    restingHR: effective.restingHr, avgHRV: effective.avgHrv))
-            }
+            guard let winner = classified.filter({ $0.kind == .mainSleep })
+                .min(by: { $0.effectiveOnset < $1.effectiveOnset }), winner.effectiveOnset <= now else { continue }
+            boundaries.append(.init(sleepId: winner.id, onset: winner.effectiveOnset))
+            wakeDayById[winner.id] = night.daily.day; ownerById[winner.id] = night.owner
         }
 
+        let recovered = await recover(candidates: candidates, store: store,
+            claimedDays: Set(wakeDayById.values), windowStart: windowStart, now: now,
+            offsetSec: offsetSec, habitualMidsleepSec: habitualMidsleepSec)
+        for item in recovered {
+            boundaries.append(item.boundary); wakeDayById[item.boundary.sleepId] = item.wakeDay
+            ownerById[item.boundary.sleepId] = item.owner; sleepContexts.append(item.sleepContext)
+        }
         if let latest = boundaries.max(by: { $0.onset < $1.onset }),
-           let wakeDay = wakeDayById[latest.sleepId], let owner = ownerById[latest.sleepId] {
-            let active = DayCycleResolver.activeWindow(
-                mode: mode,
+           let day = wakeDayById[latest.sleepId], let owner = ownerById[latest.sleepId] {
+            let active = DayCycleResolver.activeWindow(mode: mode,
                 latestSleep: DayCycleWindow(id: latest.sleepId, startInclusive: latest.onset,
-                                            endExclusive: now, displayDay: wakeDay, source: .detectedSleep),
-                now: now, offsetSec: offsetSec, reliableAwakeCoverage: false)
+                    endExclusive: now, displayDay: day, source: .detectedSleep), now: now,
+                offsetSec: offsetSec, reliableAwakeCoverage: false)
             if active.source == .syntheticMidnight {
                 boundaries.append(.init(sleepId: active.id, onset: active.startInclusive))
-                wakeDayById[active.id] = active.displayDay
-                ownerById[active.id] = owner
+                wakeDayById[active.id] = active.displayDay; ownerById[active.id] = owner
             }
         }
 
-        var steps: [String: Int] = [:]
-        var onsets: [String: Int] = [:]
-        for window in PhysiologicalSteps.cycleWindows(boundaries, now: now) {
-            guard let day = wakeDayById[window.sleepId], let owner = ownerById[window.sleepId] else { continue }
+        let windows = PhysiologicalSteps.cycleWindows(boundaries, now: now)
+        cache = cache.filter { entry in windows.contains(where: { $0.sleepId == entry.key }) }
+        let priorities = Dictionary(candidates.map { ($0.owner, $0.priority) }, uniquingKeysWith: min)
+        let witnesses = Dictionary(uniqueKeysWithValues: nights.map { night in
+            let sleeps = night.sleeps.sorted { $0.startTs < $1.startTs }.map {
+                "\($0.startTs)-\($0.endTs):\($0.stagesJSON ?? "")"
+            }.joined(separator: "|")
+            return (night.daily.day, "\(night.owner):\(night.daily.steps.map(String.init) ?? "nil")|\(sleeps)")
+        })
+        var steps: [String: Int] = [:], onsets: [String: Int] = [:]
+        windowLoop: for window in windows {
+            guard let day = wakeDayById[window.sleepId], let fallback = ownerById[window.sleepId] else { continue }
+            do {
             onsets[day] = window.onset
-            let hasClasses = (try? await store.hasStepActivityClasses(
-                deviceId: owner, from: window.onset, to: window.endExclusive)) ?? false
-            let accumulator = SleepAwareStepCounter.Accumulator(
-                sleepSessions: sleepContexts, hasActivityClasses: hasClasses)
-            var sampleCount = 0
-            var pages = 0
-            if let predecessor = try? await store.stepSampleBefore(deviceId: owner, before: window.onset) {
-                accumulator.acceptPage([predecessor])
-                sampleCount += 1
+            var ranked = priorities; ranked[fallback] = ranked[fallback] ?? ranked.values.min() ?? 0
+            var coverage: [PhysiologicalSteps.OwnerCoverage] = []
+            for (owner, priority) in ranked {
+                let span = try await store.stepTimestampCoverage(
+                    deviceId: owner, from: window.onset, to: window.endExclusive)
+                if let first = span.first, let last = span.last {
+                    coverage.append(.init(owner: owner, onset: first,
+                        endExclusive: min(last + 1, window.endExclusive), priority: priority))
+                }
             }
-            var cursor = window.onset
-            while cursor < window.endExclusive {
-                let page = (try? await store.stepSamples(deviceId: owner, from: cursor,
-                    to: window.endExclusive - 1, limit: 10_000)) ?? []
-                guard !page.isEmpty else { break }
-                accumulator.acceptPage(page)
-                pages += 1
-                sampleCount += page.count
-                guard let last = page.last, last.ts >= cursor else { break }
-                cursor = last.ts + 1
-                if page.count < 10_000 { break }
+            let segments = PhysiologicalSteps.ownerSegmentsFromCoverage(
+                window, coverage: coverage, fallbackOwner: fallback)
+            guard !segments.isEmpty else { continue }
+            let active = window.endExclusive == now
+            let identity = segments.enumerated().map { index, segment in
+                "\(segment.owner):\(segment.onset)-\(active && index == segments.count - 1 ? 0 : segment.endExclusive)"
+            }.joined(separator: ",")
+            var revisions: [String] = []
+            for segment in segments {
+                let revision = try await store.stepDataRevisionSignature(
+                    deviceId: segment.owner, from: segment.onset, to: segment.endExclusive)
+                revisions.append("\(segment.owner)=\(revision)")
             }
-            let count = accumulator.finish()
-            guard sampleCount >= 2 else { continue }
-            let ticks = count.totalTicks
-            let scaled = Int((Double(ticks) / max(ticksPerStep, 0.5)).rounded())
+            let contextSignature = sleepContexts.filter { $0.end > window.onset && $0.start < window.endExclusive }
+                .sorted { $0.start < $1.start }.map { sleep in
+                    "\(sleep.start)-\(sleep.end):" + sleep.stages.sorted { $0.start < $1.start }
+                        .map { "\($0.start)-\($0.end)=\($0.stage)" }.joined(separator: ":")
+                }.joined(separator: "|")
+            let firstDay = AnalyticsEngine.dayString(window.onset, offsetSec: offsetSec)
+            let lastDay = AnalyticsEngine.dayString(max(window.onset, window.endExclusive - 1), offsetSec: offsetSec)
+            let dayWitness = witnesses.keys.filter { $0 >= firstDay && $0 <= lastDay }.sorted()
+                .map { "\($0)=\(witnesses[$0] ?? "")" }.joined(separator: "|")
+            let key = "\(identity)|\(window.sleepId)|\(window.onset)|\(active ? 0 : window.endExclusive)"
+                + "|stepRevision=\(revisions.joined(separator: "|"))|sleepContext=\(contextSignature)"
+                + "|days=\(dayWitness)"
+            var cached = cache[window.sleepId]
+            if cached?.key != key {
+                var count = SleepAwareStepCounter.Count.empty, pages = 0, samples = 0, evaluated = false
+                for (index, segment) in segments.enumerated() {
+                    let hasClasses = try await store.hasStepActivityClasses(
+                        deviceId: segment.owner, from: segment.onset, to: segment.endExclusive)
+                    let accumulator = SleepAwareStepCounter.Accumulator(
+                        sleepSessions: sleepContexts, hasActivityClasses: hasClasses)
+                    var segmentSamples = 0
+                    if index == 0, let predecessor = try await store.stepSampleBefore(
+                        deviceId: segment.owner, before: segment.onset) {
+                        accumulator.acceptPage([predecessor]); samples += 1; segmentSamples += 1
+                    }
+                    var cursor = segment.onset - 1
+                    while cursor < segment.endExclusive {
+                        let page = try await store.stepSamplesPage(deviceId: segment.owner,
+                            afterExclusive: cursor, endExclusive: segment.endExclusive, limit: pageSize)
+                        guard !page.isEmpty else { break }
+                        accumulator.acceptPage(page); pages += 1; samples += page.count; segmentSamples += page.count
+                        guard let last = page.last, last.ts >= cursor else { break }
+                        cursor = last.ts
+                        if page.count < pageSize { break }
+                    }
+                    let motion = try? await store.stepDiagnosticMotionCounts(
+                        deviceId: segment.owner, from: segment.onset, to: segment.endExclusive)
+                    accumulator.observeMotion(gravityCount: motion?.gravity ?? 0, auxCount: motion?.aux ?? 0)
+                    if segmentSamples >= 2 { evaluated = true }
+                    count = count.adding(accumulator.finish())
+                }
+                cached = CachedCycle(key: key, count: count, pages: pages, samples: samples, evaluated: evaluated)
+                cache[window.sleepId] = cached
+            }
+            guard let result = cached, result.evaluated else { continue }
+            let scaled = Int((Double(result.count.totalTicks) / max(ticksPerStep, 0.5)).rounded())
             steps[day] = scaled
-            if let trace {
-                let status = window.endExclusive == now ? "active" : "closed"
-                trace("stepsCycle wakeDay=\(day) status=\(status) "
-                    + "onsetTs=\(window.onset) endTs=\(window.endExclusive) owner=\(owner) pages=\(pages) "
-                    + "samples=\(sampleCount) totalTicks=\(ticks) "
-                    + "outside=\(count.acceptedOutsideSleepTicks) awakeGap=\(count.acceptedAwakeGapTicks) "
-                    + "sleepBout=\(count.acceptedSleepBoutTicks) "
-                    + "rejectedIsolatedSleep=\(count.rejectedIsolatedSleepTicks) "
-                    + "rejectedClass=\(count.rejectedActivityClassTicks) "
-                    + "rejectedImplausible=\(count.rejectedImplausibleTicks) "
-                    + "gravitySamples=n/a auxSamples=n/a truncated=false "
-                    + "ticksPerStep=\(ticksPerStep) scaledSteps=\(scaled)")
+            let status = active ? "active" : "closed"
+            trace?("stepsCycle wakeDay=\(day) status=\(status) onsetTs=\(window.onset) "
+                + "endTs=\(window.endExclusive) owner=\(identity) pages=\(result.pages) samples=\(result.samples) "
+                + "totalTicks=\(result.count.totalTicks) outside=\(result.count.acceptedOutsideSleepTicks) "
+                + "awakeGap=\(result.count.acceptedAwakeGapTicks) sleepBout=\(result.count.acceptedSleepBoutTicks) "
+                + "rejectedIsolatedSleep=\(result.count.rejectedIsolatedSleepTicks) "
+                + "rejectedClass=\(result.count.rejectedActivityClassTicks) "
+                + "rejectedImplausible=\(result.count.rejectedImplausibleTicks) "
+                + "gravitySamples=\(result.count.gravitySamplesAvailable) auxSamples=\(result.count.auxSamplesAvailable) "
+                + "ticksPerStep=\(ticksPerStep) scaledSteps=\(scaled)")
+            } catch {
+                trace?("stepsCycle wakeDay=\(day) status=error error=databaseRead")
+                continue windowLoop
             }
         }
+        let recoveredMarkers = recovered.map { SourcedMarker(deviceId: computedId($0.owner),
+            point: MetricPoint(day: $0.wakeDay, key: onsetKey, value: Double($0.boundary.onset))) }
         return Result(stepsByWakeDay: steps, onsetByWakeDay: onsets,
-                      firstWakeDay: onsets.keys.min())
+            firstWakeDay: wakeDayById.values.min(), recoveredMarkers: recoveredMarkers,
+            markerSourceIds: Array(Set(candidates.map { computedId($0.owner) })).sorted())
     }
 
     static func applying(_ result: Result, to daily: DailyMetric) -> DailyMetric {

--- a/Strand/Data/DayCycleIntelligenceIntegration.swift
+++ b/Strand/Data/DayCycleIntelligenceIntegration.swift
@@ -85,7 +85,8 @@ import WhoopStore
     }
 
     static func compute(nights: [Night], editedRows: [CachedSleepSession], store: WhoopStore,
-                        candidates: [(owner: String, priority: Int)], windowStart: Int,
+                        candidates: [(owner: String, priority: Int)], physiologyOwners: [String],
+                        workouts: [WorkoutRow], windowStart: Int,
                         now: Int, offsetSec: Int, habitualMidsleepSec: Int?, ticksPerStep: Double,
                         mode: DayCycleMode, cache: Cache,
                         profile: UserProfile, maxHROverride: Double?, effortMethod: StrainScorer.Method,
@@ -185,8 +186,21 @@ import WhoopStore
             guard let day = wakeDayById[window.sleepId], let fallback = ownerById[window.sleepId] else { continue }
             do {
             onsets[day] = window.onset
-            let cycleHR = (try? await store.hrSamples(
-                deviceId: fallback, from: window.onset, to: window.endExclusive, limit: 200_000)) ?? []
+            // Store ranges are inclusive. Read the active-first WHOOP + canonical union without borrowing
+            // step coverage: an HR-only device may legitimately have no step rows.
+            let hrEndInclusive = window.endExclusive - 1
+            let owners = ([fallback] + physiologyOwners).reduce(into: [String]()) {
+                if !$0.contains($1) { $0.append($1) }
+            }
+            var hrByTimestamp: [Int: HRSample] = [:]
+            if hrEndInclusive >= window.onset {
+                for owner in owners {
+                    let rows = (try? await store.hrSamples(
+                        deviceId: owner, from: window.onset, to: hrEndInclusive, limit: 200_000)) ?? []
+                    for row in rows where hrByTimestamp[row.ts] == nil { hrByTimestamp[row.ts] = row }
+                }
+            }
+            let cycleHR = hrByTimestamp.values.sorted { $0.ts < $1.ts }
             let restingHR = nights.first(where: { $0.daily.day == day })?.daily.restingHr.map(Double.init)
                 ?? StrainScorer.defaultRestingHR
             let effectiveMaxHR = maxHROverride ?? (profile.age > 0 ? StrainScorer.tanakaHRmax(age: profile.age) : nil)
@@ -197,9 +211,18 @@ import WhoopStore
                 calories[day] = Calories.estimateDayCalories(
                     cycleHR, profile: profile, hrmax: effectiveMaxHR, restingHR: restingHR)
             }
-            workoutCounts[day] = Set(nights.flatMap(\.workouts)
+            let persistedWorkoutKeys = workouts
+                .filter { $0.startTs >= window.onset && $0.startTs < window.endExclusive }
+                .map { "\($0.startTs):\($0.endTs)" }
+            let freshDetectedKeys = nights.flatMap(\.workouts)
                 .filter { $0.start >= window.onset && $0.start < window.endExclusive }
-                .map { "\($0.start):\($0.end)" }).count
+                .filter { detected in
+                    !workouts.contains { persisted in
+                        detected.start < persisted.endTs && persisted.startTs < detected.end
+                    }
+                }
+                .map { "\($0.start):\($0.end)" }
+            workoutCounts[day] = Set(persistedWorkoutKeys + freshDetectedKeys).count
             var ranked = priorities; ranked[fallback] = ranked[fallback] ?? ranked.values.min() ?? 0
             var coverage: [PhysiologicalSteps.OwnerCoverage] = []
             for (owner, priority) in ranked {

--- a/Strand/Data/DayCycleIntelligenceIntegration.swift
+++ b/Strand/Data/DayCycleIntelligenceIntegration.swift
@@ -9,30 +9,36 @@ import WhoopStore
 
     struct Night { let daily: DailyMetric; let sleeps: [CachedSleepSession]; let owner: String }
     struct SourcedMarker: Sendable { let deviceId: String; let point: MetricPoint }
+    struct BoundaryRecoveryReader {
+        let sleepSessions: (String, Int, Int) async throws -> [CachedSleepSession]
+        let markers: (String, String, String) async throws -> [MetricPoint]
+    }
+    enum MarkerUpdate {
+        case preserve
+        case replace(points: [SourcedMarker], sourceIds: [String])
+    }
     struct Result {
         let stepsByWakeDay: [String: Int]
         let onsetByWakeDay: [String: Int]
         let firstWakeDay: String?
-        let recoveredMarkers: [SourcedMarker]
-        let markerSourceIds: [String]
-        /// False only when marker state is unknown (for example after a failed recovery read). Callers
-        /// must then preserve persisted markers instead of interpreting an empty array as authoritative.
-        let shouldReplaceMarkers: Bool
+        let markerUpdate: MarkerUpdate
     }
-    private struct PersistedBoundary {
+    struct PersistedBoundary {
         let boundary: PhysiologicalSteps.CycleBoundary
         let wakeDay: String
         let owner: String
         let sleepContext: SleepSession
     }
-    private struct CachedCycle {
+    fileprivate struct CachedCycle {
         let key: String; let count: SleepAwareStepCounter.Count
         let pages: Int; let samples: Int; let evaluated: Bool
     }
-    private static var cache: [String: CachedCycle] = [:]
+    final class Cache {
+        fileprivate var cycles: [String: CachedCycle] = [:]
+    }
     private static func computedId(_ owner: String) -> String { owner + "-noop" }
 
-    private static func recover(candidates: [(owner: String, priority: Int)], store: WhoopStore,
+    static func recover(candidates: [(owner: String, priority: Int)], reader: BoundaryRecoveryReader,
                                 claimedDays: Set<String>, windowStart: Int, now: Int,
                                 offsetSec: Int, habitualMidsleepSec: Int?) async throws -> [PersistedBoundary] {
         var claimed = claimedDays, output: [PersistedBoundary] = []
@@ -42,10 +48,8 @@ import WhoopStore
             $0.priority == $1.priority ? $0.owner < $1.owner : $0.priority < $1.priority
         }) {
             let source = computedId(candidate.owner)
-            let sessions = try await store.sleepSessions(
-                deviceId: source, from: windowStart, to: now, limit: 4_000)
-            let points = try await store.metricSeries(
-                deviceId: source, key: onsetKey, from: fromDay, to: toDay)
+            let sessions = try await reader.sleepSessions(source, windowStart, now)
+            let points = try await reader.markers(source, fromDay, toDay)
             let markers = Dictionary(points.compactMap { point -> (String, Int)? in
                 let value = Int(point.value)
                 return point.value == Double(value) ? (point.day, value) : nil
@@ -80,10 +84,12 @@ import WhoopStore
     static func compute(nights: [Night], editedRows: [CachedSleepSession], store: WhoopStore,
                         candidates: [(owner: String, priority: Int)], windowStart: Int,
                         now: Int, offsetSec: Int, habitualMidsleepSec: Int?, ticksPerStep: Double,
-                        mode: DayCycleMode, trace: ((String) -> Void)? = nil) async -> Result {
+                        mode: DayCycleMode, cache: Cache,
+                        trace: ((String) -> Void)? = nil) async -> Result {
         guard mode == .sleepOnset else {
             return Result(stepsByWakeDay: [:], onsetByWakeDay: [:], firstWakeDay: nil,
-                          recoveredMarkers: [], markerSourceIds: [], shouldReplaceMarkers: true)
+                          markerUpdate: .replace(points: [], sourceIds: Array(Set(
+                            candidates.map { computedId($0.owner) })).sorted()))
         }
         let editsByDay = Dictionary(grouping: editedRows) {
             AnalyticsEngine.dayString($0.endTs, offsetSec: offsetSec)
@@ -121,7 +127,15 @@ import WhoopStore
 
         let recovered: [PersistedBoundary]
         do {
-            recovered = try await recover(candidates: candidates, store: store,
+            let reader = BoundaryRecoveryReader(
+                sleepSessions: { source, from, to in
+                    try await store.sleepSessions(deviceId: source, from: from, to: to, limit: 4_000)
+                },
+                markers: { source, fromDay, toDay in
+                    try await store.metricSeries(
+                        deviceId: source, key: onsetKey, from: fromDay, to: toDay)
+                })
+            recovered = try await recover(candidates: candidates, reader: reader,
                 claimedDays: Set(wakeDayById.values), windowStart: windowStart, now: now,
                 offsetSec: offsetSec, habitualMidsleepSec: habitualMidsleepSec)
         } catch {
@@ -129,7 +143,7 @@ import WhoopStore
             // prevents the persistence transaction from deleting valid markers after a transient read error.
             trace?("stepsCycle status=error error=boundaryRecoveryRead")
             return Result(stepsByWakeDay: [:], onsetByWakeDay: [:], firstWakeDay: nil,
-                          recoveredMarkers: [], markerSourceIds: [], shouldReplaceMarkers: false)
+                          markerUpdate: .preserve)
         }
         for item in recovered {
             boundaries.append(item.boundary); wakeDayById[item.boundary.sleepId] = item.wakeDay
@@ -148,7 +162,7 @@ import WhoopStore
         }
 
         let windows = PhysiologicalSteps.cycleWindows(boundaries, now: now)
-        cache = cache.filter { entry in windows.contains(where: { $0.sleepId == entry.key }) }
+        cache.cycles = cache.cycles.filter { entry in windows.contains(where: { $0.sleepId == entry.key }) }
         let priorities = Dictionary(candidates.map { ($0.owner, $0.priority) }, uniquingKeysWith: min)
         let witnesses = Dictionary(uniqueKeysWithValues: nights.map { night in
             let sleeps = night.sleeps.sorted { $0.startTs < $1.startTs }.map {
@@ -180,7 +194,7 @@ import WhoopStore
             }.joined(separator: ",")
             var revisions: [String] = []
             for segment in segments {
-                let revision = try await store.stepDataRevisionSignature(
+                let revision = await store.stepDataRevisionSignature(
                     deviceId: segment.owner, from: segment.onset, to: segment.endExclusive)
                 revisions.append("\(segment.owner)=\(revision)")
             }
@@ -196,7 +210,7 @@ import WhoopStore
             let key = "\(identity)|\(window.sleepId)|\(window.onset)|\(active ? 0 : window.endExclusive)"
                 + "|stepRevision=\(revisions.joined(separator: "|"))|sleepContext=\(contextSignature)"
                 + "|days=\(dayWitness)"
-            var cached = cache[window.sleepId]
+            var cached = cache.cycles[window.sleepId]
             if cached?.key != key {
                 var count = SleepAwareStepCounter.Count.empty, pages = 0, samples = 0, evaluated = false
                 for (index, segment) in segments.enumerated() {
@@ -226,7 +240,7 @@ import WhoopStore
                     count = count.adding(accumulator.finish())
                 }
                 cached = CachedCycle(key: key, count: count, pages: pages, samples: samples, evaluated: evaluated)
-                cache[window.sleepId] = cached
+                cache.cycles[window.sleepId] = cached
             }
             guard let result = cached, result.evaluated else { continue }
             let scaled = Int((Double(result.count.totalTicks) / max(ticksPerStep, 0.5)).rounded())
@@ -249,9 +263,9 @@ import WhoopStore
         let recoveredMarkers = recovered.map { SourcedMarker(deviceId: computedId($0.owner),
             point: MetricPoint(day: $0.wakeDay, key: onsetKey, value: Double($0.boundary.onset))) }
         return Result(stepsByWakeDay: steps, onsetByWakeDay: onsets,
-            firstWakeDay: wakeDayById.values.min(), recoveredMarkers: recoveredMarkers,
-            markerSourceIds: Array(Set(candidates.map { computedId($0.owner) })).sorted(),
-            shouldReplaceMarkers: true)
+            firstWakeDay: wakeDayById.values.min(), markerUpdate: .replace(
+                points: recoveredMarkers,
+                sourceIds: Array(Set(candidates.map { computedId($0.owner) })).sorted()))
     }
 
     static func applying(_ result: Result, to daily: DailyMetric) -> DailyMetric {

--- a/Strand/Data/DayCycleIntelligenceIntegration.swift
+++ b/Strand/Data/DayCycleIntelligenceIntegration.swift
@@ -1,0 +1,132 @@
+import Foundation
+import StrandAnalytics
+import WhoopProtocol
+import WhoopStore
+
+/// Thin iOS adapter for the platform-neutral physiological day-cycle kernels.
+enum DayCycleIntelligenceIntegration {
+    static let onsetKey = "day_cycle_onset_ts"
+
+    struct Night {
+        let daily: DailyMetric
+        let sleeps: [CachedSleepSession]
+        let owner: String
+    }
+    struct Result {
+        let stepsByWakeDay: [String: Int]
+        let onsetByWakeDay: [String: Int]
+        let firstWakeDay: String?
+    }
+
+    static func compute(nights: [Night], editedRows: [CachedSleepSession], store: WhoopStore,
+                        now: Int, offsetSec: Int, habitualMidsleepSec: Int?, ticksPerStep: Double,
+                        mode: DayCycleMode, trace: ((String) -> Void)? = nil) async -> Result {
+        guard mode == .sleepOnset else { return Result(stepsByWakeDay: [:], onsetByWakeDay: [:], firstWakeDay: nil) }
+        let edits = Dictionary(editedRows.map { ($0.startTs, $0) }, uniquingKeysWith: { first, _ in first })
+        var boundaries: [PhysiologicalSteps.CycleBoundary] = []
+        var wakeDayById: [String: String] = [:]
+        var ownerById: [String: String] = [:]
+        var sleepContexts: [SleepSession] = []
+
+        for night in nights {
+            let blocks = night.sleeps.map { row -> PhysiologicalSteps.SleepBlock in
+                let edit = edits[row.startTs]
+                return PhysiologicalSteps.SleepBlock(
+                    onset: row.startTs, end: row.endTs, id: "\(night.owner):\(row.startTs)",
+                    editedOnset: edit?.effectiveStartTs ?? row.startTsAdjusted
+                )
+            }
+            let classified = PhysiologicalSteps.classifyForCycle(
+                blocks, offsetSec: offsetSec, habitualMidsleepSec: habitualMidsleepSec)
+            let mains = classified.filter { $0.kind == .mainSleep }
+            guard let onset = mains.map(\.effectiveOnset).min(), onset <= now else { continue }
+            let id = mains.min(by: { $0.effectiveOnset < $1.effectiveOnset })?.id ?? "\(night.owner):\(onset)"
+            boundaries.append(.init(sleepId: id, onset: onset))
+            wakeDayById[id] = night.daily.day
+            ownerById[id] = night.owner
+            for row in night.sleeps {
+                let effective = edits[row.startTs] ?? row
+                sleepContexts.append(SleepSession(
+                    start: effective.effectiveStartTs, end: effective.endTs,
+                    efficiency: effective.efficiency ?? 0,
+                    stages: AnalyticsEngine.decodeStages(effective.stagesJSON),
+                    restingHR: effective.restingHr, avgHRV: effective.avgHrv))
+            }
+        }
+
+        if let latest = boundaries.max(by: { $0.onset < $1.onset }),
+           let wakeDay = wakeDayById[latest.sleepId], let owner = ownerById[latest.sleepId] {
+            let active = DayCycleResolver.activeWindow(
+                mode: mode,
+                latestSleep: DayCycleWindow(id: latest.sleepId, startInclusive: latest.onset,
+                                            endExclusive: now, displayDay: wakeDay, source: .detectedSleep),
+                now: now, offsetSec: offsetSec, reliableAwakeCoverage: false)
+            if active.source == .syntheticMidnight {
+                boundaries.append(.init(sleepId: active.id, onset: active.startInclusive))
+                wakeDayById[active.id] = active.displayDay
+                ownerById[active.id] = owner
+            }
+        }
+
+        var steps: [String: Int] = [:]
+        var onsets: [String: Int] = [:]
+        for window in PhysiologicalSteps.cycleWindows(boundaries, now: now) {
+            guard let day = wakeDayById[window.sleepId], let owner = ownerById[window.sleepId] else { continue }
+            onsets[day] = window.onset
+            let hasClasses = (try? await store.hasStepActivityClasses(
+                deviceId: owner, from: window.onset, to: window.endExclusive)) ?? false
+            let accumulator = SleepAwareStepCounter.Accumulator(
+                sleepSessions: sleepContexts, hasActivityClasses: hasClasses)
+            var sampleCount = 0
+            var pages = 0
+            if let predecessor = try? await store.stepSampleBefore(deviceId: owner, before: window.onset) {
+                accumulator.acceptPage([predecessor])
+                sampleCount += 1
+            }
+            var cursor = window.onset
+            while cursor < window.endExclusive {
+                let page = (try? await store.stepSamples(deviceId: owner, from: cursor,
+                    to: window.endExclusive - 1, limit: 10_000)) ?? []
+                guard !page.isEmpty else { break }
+                accumulator.acceptPage(page)
+                pages += 1
+                sampleCount += page.count
+                guard let last = page.last, last.ts >= cursor else { break }
+                cursor = last.ts + 1
+                if page.count < 10_000 { break }
+            }
+            let count = accumulator.finish()
+            guard sampleCount >= 2 else { continue }
+            let ticks = count.totalTicks
+            let scaled = Int((Double(ticks) / max(ticksPerStep, 0.5)).rounded())
+            steps[day] = scaled
+            if let trace {
+                let status = window.endExclusive == now ? "active" : "closed"
+                trace("stepsCycle wakeDay=\(day) status=\(status) "
+                    + "onsetTs=\(window.onset) endTs=\(window.endExclusive) owner=\(owner) pages=\(pages) "
+                    + "samples=\(sampleCount) totalTicks=\(ticks) "
+                    + "outside=\(count.acceptedOutsideSleepTicks) awakeGap=\(count.acceptedAwakeGapTicks) "
+                    + "sleepBout=\(count.acceptedSleepBoutTicks) "
+                    + "rejectedIsolatedSleep=\(count.rejectedIsolatedSleepTicks) "
+                    + "rejectedClass=\(count.rejectedActivityClassTicks) "
+                    + "rejectedImplausible=\(count.rejectedImplausibleTicks) "
+                    + "gravitySamples=n/a auxSamples=n/a truncated=false "
+                    + "ticksPerStep=\(ticksPerStep) scaledSteps=\(scaled)")
+            }
+        }
+        return Result(stepsByWakeDay: steps, onsetByWakeDay: onsets,
+                      firstWakeDay: onsets.keys.min())
+    }
+
+    static func applying(_ result: Result, to daily: DailyMetric) -> DailyMetric {
+        let established = result.firstWakeDay.map { daily.day >= $0 } ?? false
+        let steps = established ? result.stepsByWakeDay[daily.day] : daily.steps
+        return DailyMetric(day: daily.day, totalSleepMin: daily.totalSleepMin, efficiency: daily.efficiency,
+            deepMin: daily.deepMin, remMin: daily.remMin, lightMin: daily.lightMin,
+            disturbances: daily.disturbances, restingHr: daily.restingHr, avgHrv: daily.avgHrv,
+            recovery: daily.recovery, strain: daily.strain, exerciseCount: daily.exerciseCount,
+            spo2Pct: daily.spo2Pct, skinTempDevC: daily.skinTempDevC, respRateBpm: daily.respRateBpm,
+            steps: steps, activeKcalEst: daily.activeKcalEst, spo2Red: daily.spo2Red,
+            spo2Ir: daily.spo2Ir, avgSdnn: daily.avgSdnn)
+    }
+}

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -21,6 +21,7 @@ final class IntelligenceEngine: ObservableObject {
     /// is worth the few characters.
     static let minHrSamples = 200
 
+    private let dayCycleCache = DayCycleIntelligenceIntegration.Cache()
     private let repo: Repository
     private let profile: ProfileStore
     /// The CANONICAL id under whose `-noop` sibling this engine WRITES the computed daily rows, and from
@@ -1792,6 +1793,7 @@ final class IntelligenceEngine: ObservableObject {
             habitualMidsleepSec: habitualMidsleepSec,
             ticksPerStep: up.stepTicksPerStep,
             mode: dayCycleMode,
+            cache: dayCycleCache,
             trace: stepsTraceActive ? { self.diagnosticSink?($0, .steps) } : nil)
         // #299: `editsByStart` is now built PER DAY inside the scoring loop (scoped to the day each edit
         // belongs to), NOT window-wide here. sleepEditedDaily folds any edited row that isn't a twin of THIS
@@ -2142,14 +2144,19 @@ final class IntelligenceEngine: ObservableObject {
             provenanceByCell["\(point.day)\u{1F}\(point.key)"] =
                 ScoreInputProvenanceRow(day: point.day, key: point.key, sourceId: source)
         }
-        let markerKeys = physiologicalSteps.shouldReplaceMarkers
-            ? [DayCycleIntelligenceIntegration.onsetKey] : []
-        let markerPoints = physiologicalSteps.shouldReplaceMarkers
-            ? physiologicalSteps.recoveredMarkers.map {
+        let markerKeys: [String]
+        let markerPoints: [SourcedMetricPoint]
+        let markerSources: [String]
+        switch physiologicalSteps.markerUpdate {
+        case .preserve:
+            markerKeys = []; markerPoints = []; markerSources = []
+        case let .replace(points, sourceIds):
+            markerKeys = [DayCycleIntelligenceIntegration.onsetKey]
+            markerPoints = points.map {
                 SourcedMetricPoint(deviceId: $0.deviceId, point: $0.point)
-            } : []
-        let markerSources = physiologicalSteps.shouldReplaceMarkers
-            ? physiologicalSteps.markerSourceIds : []
+            }
+            markerSources = sourceIds
+        }
         try? await store.persistComputedScores(
             dailyMetrics: dailies,
             metricPoints: restPoints,

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -802,6 +802,7 @@ final class IntelligenceEngine: ObservableObject {
         // #1545: the Effort TRIMP recipe, read ONCE per pass. Global (same for every day), so it folds
         // into the config signature below rather than the per-day key.
         let effortMethodGlobal = PuffinExperiment.effortMethod
+        let dayCycleMode = DayCycleMode.persisted(UserDefaults.standard.string(forKey: DayCycleMode.storageKey))
 
         // ── #1005 BATTERY: per-day reuse cache setup (see `dayScanCache`) ────────────────────────────
         // The stager toggles are read per-day inside the loop below, but they are global (same value every
@@ -854,6 +855,7 @@ final class IntelligenceEngine: ObservableObject {
             // produced under one method is stale the moment the user switches — serving it would show a
             // window of days scored by a recipe the user just turned off, with nothing to explain it.
             "\(effortMethodGlobal)",
+            dayCycleMode.rawValue,
         ].joined(separator: "|")
         // Drop the whole cache on a config change, then snapshot it into a Sendable `let` for the detached
         // loop (the engine is @MainActor; the loop can't touch `self`). The loop returns the updated cache
@@ -1761,6 +1763,21 @@ final class IntelligenceEngine: ObservableObject {
         // already staged from raw (idempotent) and for imported nights (raw never dense). This MUST run
         // before the scoring loop so the healed stages flow into Rest/recovery this same pass.
         let editedRows = await repo.selfHealEditedStages(from: windowStart, to: now)
+        let physiologicalSteps = await DayCycleIntelligenceIntegration.compute(
+            nights: scoredNights.map { night in
+                DayCycleIntelligenceIntegration.Night(
+                    daily: night.daily,
+                    sleeps: night.cachedSleep,
+                    owner: resolvedScoreOwnerByDay[night.daily.day] ?? regActiveId)
+            },
+            editedRows: editedRows,
+            store: store,
+            now: now,
+            offsetSec: tzOffset,
+            habitualMidsleepSec: habitualMidsleepSec,
+            ticksPerStep: up.stepTicksPerStep,
+            mode: dayCycleMode,
+            trace: stepsTraceActive ? { diagnosticSink?($0, .steps) } : nil)
         // #299: `editsByStart` is now built PER DAY inside the scoring loop (scoped to the day each edit
         // belongs to), NOT window-wide here. sleepEditedDaily folds any edited row that isn't a twin of THIS
         // day's detected sessions in as a "manual" block, so a window-wide edit set let ONE user edit /
@@ -1805,8 +1822,9 @@ final class IntelligenceEngine: ObservableObject {
             // every night. `effectiveStartTs` (the #318 user-corrected onset) is preserved on the row.
             let dayEditedRows = Self.editedRowsForDay(editedRows, day: night.daily.day, tzOffsetSeconds: tzOffset)
             let editsByStart = Dictionary(dayEditedRows.map { ($0.startTs, $0) }, uniquingKeysWith: { a, _ in a })
-            let daily = sleepEditedDaily(night.daily, detected: night.cachedSleep, editsByStart: editsByStart,
+            var daily = sleepEditedDaily(night.daily, detected: night.cachedSleep, editsByStart: editsByStart,
                                          habitualMidsleepSec: habitualMidsleepSec)
+            daily = DayCycleIntelligenceIntegration.applying(physiologicalSteps, to: daily)
             let recovery = recomputeRecovery(daily, baselines2)
             // Charge term-breakdown trace (Group G): only when the Recovery test mode is on. Emits which
             // term moved Charge and which was nil and forced the renorm, tagged `.recovery`. The trace's
@@ -1899,6 +1917,11 @@ final class IntelligenceEngine: ObservableObject {
                                       skinTempC: night.nightlySkin))
             if let rest = AnalyticsEngine.Rest.composite(daily: daily) {
                 restPoints.append(MetricPoint(day: daily.day, key: "sleep_performance", value: rest))
+            }
+            if let onset = physiologicalSteps.onsetByWakeDay[daily.day] {
+                restPoints.append(MetricPoint(day: daily.day,
+                                              key: DayCycleIntelligenceIntegration.onsetKey,
+                                              value: Double(onset)))
             }
             // #103: persist the SpO₂ candidate @82 nightly mean to metricSeries as "spo2_candidate" so the
             // Blood Oxygen tile can surface it as a "strap estimate (unverified)" fallback when the toggle
@@ -2110,7 +2133,8 @@ final class IntelligenceEngine: ObservableObject {
             provenance: Array(provenanceByCell.values),
             deviceId: computedId,
             from: oldestDay,
-            to: newestDay
+            to: newestDay,
+            replaceMetricKeys: [DayCycleIntelligenceIntegration.onsetKey]
         )
 
         // Now evict only the STALE computed rows in the window , those a prior (e.g. UTC-keyed) run left

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1777,6 +1777,12 @@ final class IntelligenceEngine: ObservableObject {
         if !cycleCandidates.contains(where: { $0.owner == regActiveId }) {
             cycleCandidates.append((regActiveId, 0))
         }
+        let physiologyOwners = ([regActiveId] + regDevices.filter {
+            $0.brand.caseInsensitiveCompare("WHOOP") == .orderedSame
+        }.map(\.id) + [Repository.whoopSource]).reduce(into: [String]()) {
+            if !$0.contains($1) { $0.append($1) }
+        }
+        let cycleWorkouts = await repo.workoutRows(days: maxDays + 2)
         let physiologicalSteps = await DayCycleIntelligenceIntegration.compute(
             nights: scoredNights.map { night in
                 DayCycleIntelligenceIntegration.Night(
@@ -1788,6 +1794,8 @@ final class IntelligenceEngine: ObservableObject {
             editedRows: editedRows,
             store: store,
             candidates: cycleCandidates,
+            physiologyOwners: physiologyOwners,
+            workouts: cycleWorkouts,
             windowStart: windowStart,
             now: now,
             offsetSec: tzOffset,
@@ -1865,7 +1873,7 @@ final class IntelligenceEngine: ObservableObject {
             // off the HRV baseline state rather than a blanket `.solid`, so a thin/provisional baseline shows
             // EST. not REL. Pure presentation upstream of the UI; the score itself is unchanged.
             let chargeConf = ScoreConfidence.charge(recovery: recovery, hrvBaseline: baselines2.hrv)
-            out.append(Computed(day: daily.day, recovery: recovery, strain: night.strain,
+            out.append(Computed(day: daily.day, recovery: recovery, strain: daily.strain,
                                 sleepMin: daily.totalSleepMin, hrv: daily.avgHrv,
                                 rhr: daily.restingHr, source: source, confidence: chargeConf,
                                 drivers: drivers, skinTempRel: skinRel))

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1764,10 +1764,10 @@ final class IntelligenceEngine: ObservableObject {
         // before the scoring loop so the healed stages flow into Rest/recovery this same pass.
         let editedRows = await repo.selfHealEditedStages(from: windowStart, to: now)
         var cycleCandidates: [(owner: String, priority: Int)] = regDevices
-            .filter { $0.status != .archived }
             .map { device in
                 let priority: Int
                 if device.id == regActiveId { priority = 0 }
+                else if device.status == .archived { priority = 4 }
                 else if device.sourceKind == .activityFile { priority = 3 }
                 else if device.isImportSource { priority = 2 }
                 else { priority = 1 }
@@ -2142,6 +2142,14 @@ final class IntelligenceEngine: ObservableObject {
             provenanceByCell["\(point.day)\u{1F}\(point.key)"] =
                 ScoreInputProvenanceRow(day: point.day, key: point.key, sourceId: source)
         }
+        let markerKeys = physiologicalSteps.shouldReplaceMarkers
+            ? [DayCycleIntelligenceIntegration.onsetKey] : []
+        let markerPoints = physiologicalSteps.shouldReplaceMarkers
+            ? physiologicalSteps.recoveredMarkers.map {
+                SourcedMetricPoint(deviceId: $0.deviceId, point: $0.point)
+            } : []
+        let markerSources = physiologicalSteps.shouldReplaceMarkers
+            ? physiologicalSteps.markerSourceIds : []
         try? await store.persistComputedScores(
             dailyMetrics: dailies,
             metricPoints: restPoints,
@@ -2149,11 +2157,9 @@ final class IntelligenceEngine: ObservableObject {
             deviceId: computedId,
             from: oldestDay,
             to: newestDay,
-            replaceMetricKeys: [DayCycleIntelligenceIntegration.onsetKey],
-            additionalMetricPoints: physiologicalSteps.recoveredMarkers.map {
-                SourcedMetricPoint(deviceId: $0.deviceId, point: $0.point)
-            },
-            replaceMetricSourceIds: physiologicalSteps.markerSourceIds
+            replaceMetricKeys: markerKeys,
+            additionalMetricPoints: markerPoints,
+            replaceMetricSourceIds: markerSources
         )
 
         // Now evict only the STALE computed rows in the window , those a prior (e.g. UTC-keyed) run left

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1792,7 +1792,7 @@ final class IntelligenceEngine: ObservableObject {
             habitualMidsleepSec: habitualMidsleepSec,
             ticksPerStep: up.stepTicksPerStep,
             mode: dayCycleMode,
-            trace: stepsTraceActive ? { diagnosticSink?($0, .steps) } : nil)
+            trace: stepsTraceActive ? { self.diagnosticSink?($0, .steps) } : nil)
         // #299: `editsByStart` is now built PER DAY inside the scoring loop (scoped to the day each edit
         // belongs to), NOT window-wide here. sleepEditedDaily folds any edited row that isn't a twin of THIS
         // day's detected sessions in as a "manual" block, so a window-wide edit set let ONE user edit /

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1763,6 +1763,19 @@ final class IntelligenceEngine: ObservableObject {
         // already staged from raw (idempotent) and for imported nights (raw never dense). This MUST run
         // before the scoring loop so the healed stages flow into Rest/recovery this same pass.
         let editedRows = await repo.selfHealEditedStages(from: windowStart, to: now)
+        var cycleCandidates: [(owner: String, priority: Int)] = regDevices
+            .filter { $0.status != .archived }
+            .map { device in
+                let priority: Int
+                if device.id == regActiveId { priority = 0 }
+                else if device.sourceKind == .activityFile { priority = 3 }
+                else if device.isImportSource { priority = 2 }
+                else { priority = 1 }
+                return (device.id, priority)
+            }
+        if !cycleCandidates.contains(where: { $0.owner == regActiveId }) {
+            cycleCandidates.append((regActiveId, 0))
+        }
         let physiologicalSteps = await DayCycleIntelligenceIntegration.compute(
             nights: scoredNights.map { night in
                 DayCycleIntelligenceIntegration.Night(
@@ -1772,6 +1785,8 @@ final class IntelligenceEngine: ObservableObject {
             },
             editedRows: editedRows,
             store: store,
+            candidates: cycleCandidates,
+            windowStart: windowStart,
             now: now,
             offsetSec: tzOffset,
             habitualMidsleepSec: habitualMidsleepSec,
@@ -2134,7 +2149,11 @@ final class IntelligenceEngine: ObservableObject {
             deviceId: computedId,
             from: oldestDay,
             to: newestDay,
-            replaceMetricKeys: [DayCycleIntelligenceIntegration.onsetKey]
+            replaceMetricKeys: [DayCycleIntelligenceIntegration.onsetKey],
+            additionalMetricPoints: physiologicalSteps.recoveredMarkers.map {
+                SourcedMetricPoint(deviceId: $0.deviceId, point: $0.point)
+            },
+            replaceMetricSourceIds: physiologicalSteps.markerSourceIds
         )
 
         // Now evict only the STALE computed rows in the window , those a prior (e.g. UTC-keyed) run left

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1782,6 +1782,7 @@ final class IntelligenceEngine: ObservableObject {
                 DayCycleIntelligenceIntegration.Night(
                     daily: night.daily,
                     sleeps: night.cachedSleep,
+                    workouts: night.workouts,
                     owner: resolvedScoreOwnerByDay[night.daily.day] ?? regActiveId)
             },
             editedRows: editedRows,
@@ -1794,6 +1795,9 @@ final class IntelligenceEngine: ObservableObject {
             ticksPerStep: up.stepTicksPerStep,
             mode: dayCycleMode,
             cache: dayCycleCache,
+            profile: up,
+            maxHROverride: maxHR,
+            effortMethod: effortMethodGlobal,
             trace: stepsTraceActive ? { self.diagnosticSink?($0, .steps) } : nil)
         // #299: `editsByStart` is now built PER DAY inside the scoring loop (scoped to the day each edit
         // belongs to), NOT window-wide here. sleepEditedDaily folds any edited row that isn't a twin of THIS

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -2594,13 +2594,16 @@ final class Repository: ObservableObject {
         guard let store = await ensureStore() else { return [] }
         let now = Int(Date().timeIntervalSince1970)
         let lo = now - days * 86_400, hi = now + 86_400
-        // UNION the active strap + canonical (and their computed siblings) so workouts banked under the
-        // canonical "my-whoop" before a re-add still show, alongside the re-added strap's live workouts.
+        // UNION every registered WHOOP + canonical (and computed siblings) so workouts banked before a
+        // re-add remain visible alongside every retained strap's live workouts.
         // De-dup identical same-source rows that appear under both union ids by natural key (the cross-SOURCE
         // dedup below only collapses strap-vs-Apple twins, not a row present in two strap namespaces).
         var rows: [WorkoutRow] = []
-        for id in importedReadIds { rows += (try? await store.workouts(deviceId: id, from: lo, to: hi, limit: 5000)) ?? [] }
-        for id in computedReadIds { rows += (try? await store.workouts(deviceId: id, from: lo, to: hi, limit: 5000)) ?? [] }
+        let rawIds = rawPhysiologyReadIds(store: store)
+        for id in rawIds { rows += (try? await store.workouts(deviceId: id, from: lo, to: hi, limit: 5000)) ?? [] }
+        for id in rawIds.map({ $0.hasSuffix("-noop") ? $0 : $0 + "-noop" }) {
+            rows += (try? await store.workouts(deviceId: id, from: lo, to: hi, limit: 5000)) ?? []
+        }
         rows += (try? await store.workouts(deviceId: "apple-health", from: lo, to: hi, limit: 5000)) ?? []
         // Imported lifting sessions (Hevy / Liftosaur) live under their own "lifting" source.
         rows += (try? await store.workouts(deviceId: "lifting", from: lo, to: hi, limit: 5000)) ?? []

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -418,7 +418,9 @@ struct LiquidTodayView: View {
         .liquidMediumHaptic(trigger: pullHaptic)
         // hydrationSeq joins the id so logging a drink re-reads the card immediately, the same trigger set
         // classic TodayView's reloadHydration() uses.
-        .task(id: "\(repo.refreshSeq)-\(selectedDayOffset)-\(repo.hydrationSeq)-\(hydrationEnabled)") { await load() }
+        .task(id: "\(repo.refreshSeq)-\(selectedDayOffset)-\(repo.hydrationSeq)-\(hydrationEnabled)-\(dayCycleModeRaw)") {
+            await load()
+        }
         .sheet(item: $guideSection) { section in
             NavigationStack { ScoringGuideView(initialSection: section, onClose: { guideSection = nil }) }
         }
@@ -1494,7 +1496,8 @@ struct LiquidTodayView: View {
         let cycleMarkers = dayCycleMode == .sleepOnset
             ? await repo.exploreSeries(key: DayCycleIntelligenceIntegration.onsetKey, source: "my-whoop") : []
         let from = cycleMarkers.last(where: { $0.day == selectedDayKey }).map { Int($0.value) } ?? calendarFrom
-        let to = cycleMarkers.last(where: { $0.day == nextDayKey }).map { Int($0.value) } ?? calendarTo
+        let toExclusive = cycleMarkers.last(where: { $0.day == nextDayKey }).map { Int($0.value) } ?? calendarTo
+        let to = max(from, toExclusive - 1)
 
         async let restA = repo.exploreSeries(key: "sleep_performance", source: "my-whoop")
         async let stressA = repo.series(key: "stress", source: "my-whoop")

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -17,6 +17,8 @@ import WhoopStore
 import StrandAnalytics
 
 struct LiquidTodayView: View {
+    @AppStorage(DayCycleMode.storageKey) private var dayCycleModeRaw = DayCycleMode.sleepOnset.rawValue
+    private var dayCycleMode: DayCycleMode { DayCycleMode.persisted(dayCycleModeRaw) }
     @EnvironmentObject var repo: Repository
     @EnvironmentObject var router: NavRouter
     @EnvironmentObject var profile: ProfileStore
@@ -1483,11 +1485,16 @@ struct LiquidTodayView: View {
 
         let cal = Calendar.current
         let dayStart = cal.startOfDay(for: selectedLogicalDay)
-        let from = Int(dayStart.timeIntervalSince1970)
+        let calendarFrom = Int(dayStart.timeIntervalSince1970)
         // today → midnight..now; a past day → its full 24h (a missing morning reads as empty space).
-        let to: Int = selectedDayOffset == 0
+        let calendarTo: Int = selectedDayOffset == 0
             ? Int(Date().timeIntervalSince1970)
             : Int((cal.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart).timeIntervalSince1970)
+        let nextDayKey = Repository.localDayKey(cal.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart)
+        let cycleMarkers = dayCycleMode == .sleepOnset
+            ? await repo.exploreSeries(key: DayCycleIntelligenceIntegration.onsetKey, source: "my-whoop") : []
+        let from = cycleMarkers.last(where: { $0.day == selectedDayKey }).map { Int($0.value) } ?? calendarFrom
+        let to = cycleMarkers.last(where: { $0.day == nextDayKey }).map { Int($0.value) } ?? calendarTo
 
         async let restA = repo.exploreSeries(key: "sleep_performance", source: "my-whoop")
         async let stressA = repo.series(key: "stress", source: "my-whoop")
@@ -1594,7 +1601,7 @@ struct LiquidTodayView: View {
         // HR estimate for the day, so the tile/card/detail agree (imported-first, mirrors steps).
         importedActiveKcalDay = (await appleA).filter { $0.day == selectedDayKey }.compactMap { $0.activeKcal }.max()
         hrValues = (await hrA).map { $0.bpm }
-        workouts = await wkA
+        workouts = (await wkA).filter { $0.startTs >= from && $0.startTs < to }
 
         let (chargeSource, effortSource, restSource) = await (chargeSourceA, effortSourceA, restSourceA)
         let sourceResolutions = [

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -95351,6 +95351,39 @@
         }
       }
     },
+    "Day starts": { "localizations": {
+      "de": { "stringUnit": { "state": "translated", "value": "Tagesbeginn" } },
+      "es": { "stringUnit": { "state": "translated", "value": "El día empieza" } },
+      "fr": { "stringUnit": { "state": "translated", "value": "Début de la journée" } },
+      "it": { "stringUnit": { "state": "translated", "value": "Inizio giornata" } },
+      "pl": { "stringUnit": { "state": "translated", "value": "Początek dnia" } },
+      "pt-PT": { "stringUnit": { "state": "translated", "value": "O dia começa" } },
+      "ru": { "stringUnit": { "state": "translated", "value": "Начало дня" } },
+      "zh-Hans": { "stringUnit": { "state": "translated", "value": "一天开始于" } },
+      "zh-Hant": { "stringUnit": { "state": "translated", "value": "一天開始於" } }
+    } },
+    "Default. Steps and in-progress Effort restart at the beginning of detected main sleep. Naps do not start a new day; missing sleep falls back to local midnight.": { "localizations": {
+      "de": { "stringUnit": { "state": "translated", "value": "Standard. Schritte und die laufende Anstrengung beginnen mit dem erkannten Hauptschlaf neu. Nickerchen starten keinen neuen Tag; bei fehlendem Schlaf verwendet NOOP ersatzweise die lokale Mitternacht." } },
+      "es": { "stringUnit": { "state": "translated", "value": "Predeterminado. Los pasos y el Esfuerzo en curso se reinician al comienzo del sueño principal detectado. Las siestas no empiezan un nuevo día; si faltan datos de sueño, se usa la medianoche local." } },
+      "fr": { "stringUnit": { "state": "translated", "value": "Par défaut. Les pas et l’Effort en cours repartent de zéro au début du sommeil principal détecté. Les siestes ne commencent pas une nouvelle journée ; en l’absence de sommeil, l’heure locale de minuit est utilisée." } },
+      "it": { "stringUnit": { "state": "translated", "value": "Predefinito. I passi e lo Sforzo in corso ripartono all’inizio del sonno principale rilevato. I sonnellini non iniziano un nuovo giorno; se mancano dati sul sonno, viene usata la mezzanotte locale." } },
+      "pl": { "stringUnit": { "state": "translated", "value": "Domyślnie. Kroki i bieżący Wysiłek zaczynają się od nowa wraz z wykrytym głównym snem. Drzemki nie rozpoczynają nowego dnia; gdy brakuje danych o śnie, używana jest lokalna północ." } },
+      "pt-PT": { "stringUnit": { "state": "translated", "value": "Predefinição. Os passos e o Esforço em curso recomeçam no início do sono principal detetado. As sestas não iniciam um novo dia; se faltarem dados de sono, é usada a meia-noite local." } },
+      "ru": { "stringUnit": { "state": "translated", "value": "По умолчанию. Шаги и текущая Нагрузка обнуляются в начале распознанного основного сна. Дневной сон не начинает новый день; при отсутствии данных о сне используется местная полночь." } },
+      "zh-Hans": { "stringUnit": { "state": "translated", "value": "默认。步数和进行中的体力消耗从检测到的主要睡眠开始时重新计算。小睡不会开始新的一天；缺少睡眠数据时，将使用当地午夜。" } },
+      "zh-Hant": { "stringUnit": { "state": "translated", "value": "預設。步數和進行中的體力消耗從偵測到的主要睡眠開始時重新計算。小睡不會開始新的一天；缺少睡眠資料時，將使用當地午夜。" } }
+    } },
+    "Uses a conventional local calendar day from 00:00 to 00:00.": { "localizations": {
+      "de": { "stringUnit": { "state": "translated", "value": "Verwendet einen herkömmlichen lokalen Kalendertag von 00:00 bis 00:00 Uhr." } },
+      "es": { "stringUnit": { "state": "translated", "value": "Usa un día natural local convencional de 00:00 a 00:00." } },
+      "fr": { "stringUnit": { "state": "translated", "value": "Utilise une journée civile locale classique de 00:00 à 00:00." } },
+      "it": { "stringUnit": { "state": "translated", "value": "Usa un giorno di calendario locale convenzionale dalle 00:00 alle 00:00." } },
+      "pl": { "stringUnit": { "state": "translated", "value": "Używa zwykłego lokalnego dnia kalendarzowego od 00:00 do 00:00." } },
+      "pt-PT": { "stringUnit": { "state": "translated", "value": "Usa um dia civil local convencional das 00:00 às 00:00." } },
+      "ru": { "stringUnit": { "state": "translated", "value": "Использует обычный местный календарный день с 00:00 до 00:00." } },
+      "zh-Hans": { "stringUnit": { "state": "translated", "value": "使用从 00:00 到次日 00:00 的常规当地日历日。" } },
+      "zh-Hant": { "stringUnit": { "state": "translated", "value": "使用從 00:00 到次日 00:00 的一般當地日曆日。" } }
+    } },
     "Main sleep": {
       "localizations": {
         "de": {

--- a/Strand/Screens/CoupledView.swift
+++ b/Strand/Screens/CoupledView.swift
@@ -46,9 +46,7 @@ struct CoupledView: View {
     /// the cold-start threshold, which keeps the broad overnight-band bonus.
     @State private var habitualMidsleepSec: Int? = nil
 
-    /// #614: TODAY's workout count from the SAME deduped/dismissed-filtered list the Workouts screen shows
-    /// (`repo.workoutRows`), not `DailyMetric.exerciseCount` (strap-DETECTED only — a Health-Connect import
-    /// with auto-detect off read as 0 while the Workouts screen showed it). Loaded in `.task`.
+    /// Today's all-source workout count materialized onto the same physiological cycle as the other cards.
     @State private var workoutsToday: Int = 0
 
     /// The day the coupled read describes, today's resolved row (the same `resolveToday` #304/#144 boundary
@@ -159,14 +157,7 @@ struct CoupledView: View {
         // bed→wake span below resolves identically (#294). Re-runs on a sync/import refresh.
         .task(id: repo.refreshSeq) {
             habitualMidsleepSec = await repo.habitualMidsleepSec()
-            // #614: count TODAY's workouts by their START's logical day (the SAME 04:00-rollover key
-            // DailyMetric.day uses), so the Coupled stat equals the Workouts overview for today.
-            let key = todayKey
-            // A short window is enough to count today's rows (the cross-source dedup is local to the set),
-            // and avoids loading the full history just for one number.
-            workoutsToday = await repo.workoutRows(days: 2).filter {
-                Repository.logicalDayKey(Date(timeIntervalSince1970: TimeInterval($0.startTs))) == key
-            }.count
+            workoutsToday = day?.exerciseCount ?? 0
         }
     }
 
@@ -339,7 +330,7 @@ struct CoupledView: View {
                                  caloriesText,
                                  tint: StrandPalette.metricAmber)
                         heroStat(String(localized: "Workouts"),
-                                 "\(workoutsToday)",   // #614: real workout count (all sources), not exerciseCount
+                                 "\(workoutsToday)",
                                  tint: StrandPalette.textPrimary)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -190,6 +190,7 @@ struct SettingsView: View {
     @AppStorage(UnitPrefs.hrvWindowKey) private var hrvWindowRaw = HrvWindow.whole.rawValue
     // Live-HR Live Activity (Lock Screen + Dynamic Island), iOS only (#336). Default on.
     @AppStorage(UnitPrefs.liveActivityKey) private var liveActivityEnabled = true
+    @AppStorage(DayCycleMode.storageKey) private var dayCycleModeRaw = DayCycleMode.sleepOnset.rawValue
     // Alternate app icon (iOS only) — false = Titanium (primary AppIcon), true = Blue Titanium
     // ("AppIcon-Navy"). Display-only preference; the live switch goes through setAlternateIconName.
     @AppStorage("appIcon.alt") private var useNavyIcon = false
@@ -537,6 +538,27 @@ struct SettingsView: View {
                         }
                     }
                 }
+                rowDivider
+                FormRow(label: "Day cycle") {
+                    Picker("Day starts", selection: Binding(
+                        get: { DayCycleMode.persisted(dayCycleModeRaw) },
+                        set: { mode in
+                            dayCycleModeRaw = mode.rawValue
+                            Task { await model.intelligence.analyzeRecent(); await model.repo.refresh() }
+                        }
+                    )) {
+                        Text("Main sleep").tag(DayCycleMode.sleepOnset)
+                        Text("00:00").tag(DayCycleMode.midnight)
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                }
+                Text(dayCycleModeRaw == DayCycleMode.midnight.rawValue
+                     ? "Uses a conventional local calendar day from 00:00 to 00:00."
+                     : "Default. Steps and in-progress Effort restart at the beginning of detected main sleep. Naps do not start a new day; missing sleep falls back to local midnight.")
+                    .font(StrandFont.footnote)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
                 rowDivider
                 // Step calibration (#139/#132): daily steps = @57 counter ticks ÷ this divisor.
                 // 1.0 = raw pass-through until the true 5/MG tick rate is known. The divisor goes

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -187,6 +187,8 @@ struct ActiveWorkoutIndicatorSection: View {
 }
 
 struct TodayView: View {
+    @AppStorage(DayCycleMode.storageKey) private var dayCycleModeRaw = DayCycleMode.sleepOnset.rawValue
+    private var dayCycleMode: DayCycleMode { DayCycleMode.persisted(dayCycleModeRaw) }
     /// Product mark, never natural-language copy. Keeping it out of localization also makes source
     /// classification and tint selection stable when the app language changes.
     private static let whoopBrandName = "WHOOP"
@@ -4670,10 +4672,18 @@ struct TodayView: View {
         // in the small hours after midnight today still starts at yesterday's midnight rather than
         // blanking to an empty new-calendar-day axis (#144).
         let dayStart = Calendar.current.startOfDay(for: selectedLogicalDay)
-        let windowStart = Int(dayStart.timeIntervalSince1970)
-        let windowEnd: Int = selectedDayOffset == 0
+        let calendarStart = Int(dayStart.timeIntervalSince1970)
+        let calendarEnd: Int = selectedDayOffset == 0
             ? Int(Date().timeIntervalSince1970)
             : Int((Calendar.current.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart).timeIntervalSince1970)
+        let nextDay = Calendar.current.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart
+        let nextDayKey = Repository.localDayKey(nextDay)
+        let cycleMarkers = dayCycleMode == .sleepOnset
+            ? await repo.exploreSeries(key: DayCycleIntelligenceIntegration.onsetKey, source: "my-whoop") : []
+        let windowStart = cycleMarkers.last(where: { $0.day == selectedDayKey }).map { Int($0.value) }
+            ?? calendarStart
+        let windowEnd = cycleMarkers.last(where: { $0.day == nextDayKey }).map { Int($0.value) }
+            ?? calendarEnd
         let hrPointsLocal = await repo.hrBuckets(from: windowStart, to: windowEnd, bucketSeconds: 300)
             .map { TrendPoint(date: Date(timeIntervalSince1970: TimeInterval($0.ts)), value: $0.bpm) }
         hrPoints = hrPointsLocal

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -4611,6 +4611,8 @@ struct TodayView: View {
         // Rest series + the two provenance resolves, all day-keyed outputs, none consumes another's
         // result, so fire them concurrently and await where first used.
         async let restSeriesA       = repo.exploreSeries(key: "sleep_performance", source: "my-whoop")
+        async let dayCycleSeriesA   = repo.exploreSeries(
+            key: DayCycleIntelligenceIntegration.onsetKey, source: "my-whoop")
         async let recoveryResolvedA = repo.resolvedSeries(key: "recovery", source: Repository.whoopSource)
         async let restResolvedA     = repo.resolvedSeries(key: "sleep_performance", source: Repository.whoopSource)
 
@@ -4618,6 +4620,7 @@ struct TodayView: View {
         // `sleep_performance` (imported-wins), so a Bluetooth-only user sees the on-device Rest
         // composite and an importer sees the export's figure, exactly like the Rest detail screen.
         let restSeries = await restSeriesA
+        let dayCycleSeries = await dayCycleSeriesA
         let restByDay = Dictionary(restSeries.map { ($0.day, $0.value) }, uniquingKeysWith: { _, last in last })
         // The Rest TILE's sparkline (#614 follow-up). The tile's number is `restScore` (the Rest composite,
         // 0–100) but its mini-graph used to plot raw sleep MINUTES (`sparks["sleep_total_min"]`), so the
@@ -4698,7 +4701,11 @@ struct TodayView: View {
         // gauge falls back to the stored row (never a fabricated value); a navigated past day clears it.
         let liveStrainLocal: Double?
         if selectedDayOffset == 0 {
-            let todayHr = await repo.hrSamples(from: windowStart, to: windowEnd)
+            let mode = DayCycleMode.persisted(UserDefaults.standard.string(forKey: DayCycleMode.storageKey))
+            let cycleOnset = dayCycleSeries.last(where: { $0.day <= selectedDayKey })?.value
+                .map { Int($0.rounded()) }
+            let effortStart = mode == .sleepOnset ? (cycleOnset ?? windowStart) : windowStart
+            let todayHr = await repo.hrSamples(from: effortStart, to: windowEnd)
             let maxHR = profile.age > 0 ? StrainScorer.tanakaHRmax(age: Double(profile.age)) : nil
             let restHR = displayDay?.restingHr.map(Double.init) ?? StrainScorer.defaultRestingHR
             liveStrainLocal = StrainScorer.strain(todayHr, maxHR: maxHR, restingHR: restHR,

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -1481,7 +1481,8 @@ struct TodayView: View {
         }
         // Reload when the data refreshes OR the selected day changes, the HR trend and Rest score are
         // day-scoped, so navigating must re-fetch them for the newly selected window.
-        .task(id: TodayLoadKey(seq: repo.refreshSeq, offset: selectedDayOffset)) { await loadAll() }
+        .task(id: TodayLoadKey(seq: repo.refreshSeq, offset: selectedDayOffset,
+                              dayCycleMode: dayCycleModeRaw)) { await loadAll() }
         // #989: hydration writes don't bump refreshSeq, so the card needs its own triggers, a logged /
         // edited / deleted drink (hydrationSeq) and the Settings feature toggle both re-read just the two
         // hydration fields. Cheap (one metricSeries row), never re-runs the heavy loads.
@@ -4682,9 +4683,10 @@ struct TodayView: View {
             ? await repo.exploreSeries(key: DayCycleIntelligenceIntegration.onsetKey, source: "my-whoop") : []
         let windowStart = cycleMarkers.last(where: { $0.day == selectedDayKey }).map { Int($0.value) }
             ?? calendarStart
-        let windowEnd = cycleMarkers.last(where: { $0.day == nextDayKey }).map { Int($0.value) }
+        let windowEndExclusive = cycleMarkers.last(where: { $0.day == nextDayKey }).map { Int($0.value) }
             ?? calendarEnd
-        let hrPointsLocal = await repo.hrBuckets(from: windowStart, to: windowEnd, bucketSeconds: 300)
+        let windowEndInclusive = max(windowStart, windowEndExclusive - 1)
+        let hrPointsLocal = await repo.hrBuckets(from: windowStart, to: windowEndInclusive, bucketSeconds: 300)
             .map { TrendPoint(date: Date(timeIntervalSince1970: TimeInterval($0.ts)), value: $0.bpm) }
         hrPoints = hrPointsLocal
 
@@ -4694,7 +4696,7 @@ struct TodayView: View {
         // canonical UNION (like the HR curve / Effort above): a re-added strap banks its live step samples
         // under its OWN fresh id, so a read pinned to the canonical "my-whoop" would drop the icon for a
         // re-added strap (the #904/#908 family). nil (no classed sample) hides the icon.
-        let stepClassLocal = await repo.stepActivityClassLatest(from: windowStart, to: windowEnd)
+        let stepClassLocal = await repo.stepActivityClassLatest(from: windowStart, to: windowEndInclusive)
         stepActivityClassToday = stepClassLocal
 
         // #860 item 1: the launch auto-land (#605/#739 "snap to the most recent data day when today is
@@ -4715,7 +4717,7 @@ struct TodayView: View {
             let cycleOnset = dayCycleSeries.last(where: { $0.day <= selectedDayKey })
                 .map { Int($0.value.rounded()) }
             let effortStart = mode == .sleepOnset ? (cycleOnset ?? windowStart) : windowStart
-            let todayHr = await repo.hrSamples(from: effortStart, to: windowEnd)
+            let todayHr = await repo.hrSamples(from: effortStart, to: windowEndInclusive)
             let maxHR = profile.age > 0 ? StrainScorer.tanakaHRmax(age: Double(profile.age)) : nil
             let restHR = displayDay?.restingHr.map(Double.init) ?? StrainScorer.defaultRestingHR
             liveStrainLocal = StrainScorer.strain(todayHr, maxHR: maxHR, restingHR: restHR,
@@ -4727,7 +4729,7 @@ struct TodayView: View {
         // Pin the chart axis to the loaded window, today midnight→now, a past day the full 24h, so
         // a gap (e.g. a morning the strap wasn't banking) shows as empty space, not a late start.
         let newAxis = Date(timeIntervalSince1970: TimeInterval(windowStart))
-            ... Date(timeIntervalSince1970: TimeInterval(windowEnd))
+            ... Date(timeIntervalSince1970: TimeInterval(windowEndExclusive))
         // #829 - keep the HR zoom VALID across reloads. The window changes on a day step (a whole new day)
         // and, on today, each refresh nudges the end to a fresh `now`. A day step clears the zoom so the new
         // day opens at full scale; a same-day end-extension keeps the user's zoom but RE-CLAMPS it into the
@@ -4745,7 +4747,7 @@ struct TodayView: View {
         // read for a night stored as more than one block (#294). Drives the HR sleep band + the recovery
         // marker's wake anchor.
         let overlapping = await repo.allSleepSessions(days: selectedDayOffset + 2)
-            .filter { $0.endTs > windowStart && $0.startTs < windowEnd }
+            .filter { $0.endTs > windowStart && $0.startTs < windowEndExclusive }
         let habitualMidsleepSecLocal = await repo.habitualMidsleepSec()
         let sleepTodayLocal = SleepView.mainNightSpan(overlapping, habitualMidsleepSec: habitualMidsleepSecLocal)
             .map { span in
@@ -5121,6 +5123,7 @@ struct TodayView: View {
 private struct TodayLoadKey: Equatable {
     let seq: Int
     let offset: Int
+    let dayCycleMode: String
 }
 
 /// #849: an in-memory snapshot of everything `loadHistoryWide()` computes: the ~40 history-wide reads +

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -4702,8 +4702,8 @@ struct TodayView: View {
         let liveStrainLocal: Double?
         if selectedDayOffset == 0 {
             let mode = DayCycleMode.persisted(UserDefaults.standard.string(forKey: DayCycleMode.storageKey))
-            let cycleOnset = dayCycleSeries.last(where: { $0.day <= selectedDayKey })?.value
-                .map { Int($0.rounded()) }
+            let cycleOnset = dayCycleSeries.last(where: { $0.day <= selectedDayKey })
+                .map { Int($0.value.rounded()) }
             let effortStart = mode == .sleepOnset ? (cycleOnset ?? windowStart) : windowStart
             let todayHr = await repo.hrSamples(from: effortStart, to: windowEnd)
             let maxHR = profile.age > 0 ? StrainScorer.tanakaHRmax(age: Double(profile.age)) : nil

--- a/StrandTests/DayCycleRecoveryTests.swift
+++ b/StrandTests/DayCycleRecoveryTests.swift
@@ -13,12 +13,17 @@ final class DayCycleRecoveryTests: XCTestCase {
             strain: nil, exerciseCount: nil, spo2Pct: nil, skinTempDevC: nil, respRateBpm: nil,
             steps: 10, activeKcalEst: nil, skinTempC: 34.2, sleepHrOnly: true)
         let result = DayCycleIntelligenceIntegration.Result(
-            stepsByWakeDay: [daily.day: 42], onsetByWakeDay: [:], firstWakeDay: daily.day,
+            stepsByWakeDay: [daily.day: 42], strainByWakeDay: [daily.day: 61],
+            caloriesByWakeDay: [daily.day: 1_840], workoutCountByWakeDay: [daily.day: 2],
+            onsetByWakeDay: [:], firstWakeDay: daily.day,
             markerUpdate: .preserve)
 
         let updated = DayCycleIntelligenceIntegration.applying(result, to: daily)
 
         XCTAssertEqual(updated.steps, 42)
+        XCTAssertEqual(updated.strain, 61)
+        XCTAssertEqual(updated.activeKcalEst, 1_840)
+        XCTAssertEqual(updated.exerciseCount, 2)
         XCTAssertEqual(updated.skinTempC, 34.2)
         XCTAssertEqual(updated.sleepHrOnly, true)
     }
@@ -69,7 +74,8 @@ final class DayCycleRecoveryTests: XCTestCase {
             candidates: [(owner: "strap", priority: 0)],
             windowStart: 1_700_000_000, now: 1_700_086_400, offsetSec: 0,
             habitualMidsleepSec: nil, ticksPerStep: 1, mode: .sleepOnset,
-            cache: DayCycleIntelligenceIntegration.Cache(), recoveryReader: reader)
+            cache: DayCycleIntelligenceIntegration.Cache(), profile: UserProfile(),
+            maxHROverride: nil, effortMethod: .edwards, recoveryReader: reader)
 
         guard case .preserve = result.markerUpdate else {
             return XCTFail("an unread marker namespace must never become an authoritative replacement")

--- a/StrandTests/DayCycleRecoveryTests.swift
+++ b/StrandTests/DayCycleRecoveryTests.swift
@@ -72,6 +72,7 @@ final class DayCycleRecoveryTests: XCTestCase {
         let result = await DayCycleIntelligenceIntegration.compute(
             nights: [], editedRows: [], store: store,
             candidates: [(owner: "strap", priority: 0)],
+            physiologyOwners: ["strap"], workouts: [],
             windowStart: 1_700_000_000, now: 1_700_086_400, offsetSec: 0,
             habitualMidsleepSec: nil, ticksPerStep: 1, mode: .sleepOnset,
             cache: DayCycleIntelligenceIntegration.Cache(), profile: UserProfile(),

--- a/StrandTests/DayCycleRecoveryTests.swift
+++ b/StrandTests/DayCycleRecoveryTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import WhoopStore
 @testable import Strand
 
 @MainActor
@@ -38,5 +39,25 @@ final class DayCycleRecoveryTests: XCTestCase {
         } catch {
             XCTFail("unexpected error: \(error)")
         }
+    }
+
+    func testComputePreservesMarkersWhenRecoveryCannotBeRead() async throws {
+        let store = try await WhoopStore.inMemory()
+        let reader = DayCycleIntelligenceIntegration.BoundaryRecoveryReader(
+            sleepSessions: { _, _, _ in throw ReadFailure.injected },
+            markers: { _, _, _ in XCTFail("marker read must not follow a failed session read"); return [] })
+
+        let result = await DayCycleIntelligenceIntegration.compute(
+            nights: [], editedRows: [], store: store,
+            candidates: [(owner: "strap", priority: 0)],
+            windowStart: 1_700_000_000, now: 1_700_086_400, offsetSec: 0,
+            habitualMidsleepSec: nil, ticksPerStep: 1, mode: .sleepOnset,
+            cache: DayCycleIntelligenceIntegration.Cache(), recoveryReader: reader)
+
+        guard case .preserve = result.markerUpdate else {
+            return XCTFail("an unread marker namespace must never become an authoritative replacement")
+        }
+        XCTAssertTrue(result.stepsByWakeDay.isEmpty)
+        XCTAssertTrue(result.onsetByWakeDay.isEmpty)
     }
 }

--- a/StrandTests/DayCycleRecoveryTests.swift
+++ b/StrandTests/DayCycleRecoveryTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import Strand
+
+@MainActor
+final class DayCycleRecoveryTests: XCTestCase {
+    private enum ReadFailure: Error { case injected }
+
+    func testBoundaryRecoveryPropagatesSessionReadFailure() async {
+        let reader = DayCycleIntelligenceIntegration.BoundaryRecoveryReader(
+            sleepSessions: { _, _, _ in throw ReadFailure.injected },
+            markers: { _, _, _ in XCTFail("marker read must not follow a failed session read"); return [] })
+
+        do {
+            _ = try await DayCycleIntelligenceIntegration.recover(
+                candidates: [(owner: "strap", priority: 0)], reader: reader,
+                claimedDays: [], windowStart: 1_700_000_000, now: 1_700_086_400,
+                offsetSec: 0, habitualMidsleepSec: nil)
+            XCTFail("expected recovery to fail closed")
+        } catch ReadFailure.injected {
+            // Expected: callers can distinguish an unread namespace from an authoritative empty one.
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testBoundaryRecoveryPropagatesMarkerReadFailure() async {
+        let reader = DayCycleIntelligenceIntegration.BoundaryRecoveryReader(
+            sleepSessions: { _, _, _ in [] },
+            markers: { _, _, _ in throw ReadFailure.injected })
+
+        do {
+            _ = try await DayCycleIntelligenceIntegration.recover(
+                candidates: [(owner: "strap", priority: 0)], reader: reader,
+                claimedDays: [], windowStart: 1_700_000_000, now: 1_700_086_400,
+                offsetSec: 0, habitualMidsleepSec: nil)
+            XCTFail("expected recovery to fail closed")
+        } catch ReadFailure.injected {
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+}

--- a/StrandTests/DayCycleRecoveryTests.swift
+++ b/StrandTests/DayCycleRecoveryTests.swift
@@ -6,6 +6,23 @@ import WhoopStore
 final class DayCycleRecoveryTests: XCTestCase {
     private enum ReadFailure: Error { case injected }
 
+    func testApplyingCycleStepsPreservesUnrelatedDailyColumns() {
+        let daily = DailyMetric(
+            day: "2026-09-04", totalSleepMin: nil, efficiency: nil, deepMin: nil, remMin: nil,
+            lightMin: nil, disturbances: nil, restingHr: nil, avgHrv: nil, recovery: nil,
+            strain: nil, exerciseCount: nil, spo2Pct: nil, skinTempDevC: nil, respRateBpm: nil,
+            steps: 10, activeKcalEst: nil, skinTempC: 34.2, sleepHrOnly: true)
+        let result = DayCycleIntelligenceIntegration.Result(
+            stepsByWakeDay: [daily.day: 42], onsetByWakeDay: [:], firstWakeDay: daily.day,
+            markerUpdate: .preserve)
+
+        let updated = DayCycleIntelligenceIntegration.applying(result, to: daily)
+
+        XCTAssertEqual(updated.steps, 42)
+        XCTAssertEqual(updated.skinTempC, 34.2)
+        XCTAssertEqual(updated.sleepHrOnly, true)
+    }
+
     func testBoundaryRecoveryPropagatesSessionReadFailure() async {
         let reader = DayCycleIntelligenceIntegration.BoundaryRecoveryReader(
             sleepSessions: { _, _, _ in throw ReadFailure.injected },

--- a/android/app/src/main/java/com/noop/analytics/DayCycle.kt
+++ b/android/app/src/main/java/com/noop/analytics/DayCycle.kt
@@ -1,0 +1,82 @@
+package com.noop.analytics
+
+/**
+ * User-selectable ownership rule for additive daily metrics.
+ *
+ * Sleep and recovery values keep their night/wake-day semantics; this setting is for values accumulated
+ * while awake, such as steps, energy and cardiovascular load.
+ */
+enum class DayCycleMode(val persistedValue: String) {
+    SLEEP_ONSET("sleep_onset"),
+    MIDNIGHT("midnight");
+
+    companion object {
+        fun fromPersisted(value: String?): DayCycleMode = entries.firstOrNull {
+            it.persistedValue == value
+        } ?: SLEEP_ONSET
+    }
+}
+
+/** Shared cycle window consumed by every additive daily metric. */
+data class DayCycleWindow(
+    val id: String,
+    val startInclusive: Long,
+    val endExclusive: Long,
+    val displayDay: String,
+    val source: Source,
+) {
+    enum class Source { DETECTED_SLEEP, EDITED_SLEEP, SYNTHETIC_MIDNIGHT, CALENDAR }
+}
+
+object DayCycleResolver {
+    const val MIN_SYNTHETIC_MIDNIGHT_AGE_SECONDS = 18 * 3_600L
+    const val ABSOLUTE_MAX_OPEN_SECONDS = 40 * 3_600L
+
+    /** Midnight is always available and is also the honest cold-start/failure fallback. */
+    fun calendarWindow(now: Long, tzOffsetSeconds: Long): DayCycleWindow {
+        val local = now + tzOffsetSeconds
+        val dayNumber = Math.floorDiv(local, SleepStageTotals.SECONDS_PER_DAY)
+        val start = dayNumber * SleepStageTotals.SECONDS_PER_DAY - tzOffsetSeconds
+        val day = AnalyticsEngine.dayString(start, tzOffsetSeconds)
+        return DayCycleWindow("calendar:$day", start, now, day, DayCycleWindow.Source.CALENDAR)
+    }
+
+    /** First local midnight that does not truncate a freshly-started sleep cycle. */
+    fun fallbackMidnightAfter(start: Long, tzOffsetSeconds: Long): Long {
+        val minimum = start + MIN_SYNTHETIC_MIDNIGHT_AGE_SECONDS
+        val local = minimum + tzOffsetSeconds
+        val dayNumber = Math.floorDiv(local, SleepStageTotals.SECONDS_PER_DAY)
+        val atMidnight = dayNumber * SleepStageTotals.SECONDS_PER_DAY - tzOffsetSeconds
+        return if (atMidnight >= minimum) atMidnight
+        else (dayNumber + 1) * SleepStageTotals.SECONDS_PER_DAY - tzOffsetSeconds
+    }
+
+    /**
+     * Resolve the active window. Reliable, explicitly-awake coverage preserves a genuine all-nighter.
+     * Missing/untrustworthy coverage falls back to midnight; even claimed awake coverage is capped at 40 h.
+     */
+    fun activeWindow(
+        mode: DayCycleMode,
+        latestSleep: DayCycleWindow?,
+        now: Long,
+        tzOffsetSeconds: Long,
+        reliableAwakeCoverage: Boolean,
+    ): DayCycleWindow {
+        if (mode == DayCycleMode.MIDNIGHT || latestSleep == null) {
+            return calendarWindow(now, tzOffsetSeconds)
+        }
+        val age = now - latestSleep.startInclusive
+        val mustFallback = age >= ABSOLUTE_MAX_OPEN_SECONDS ||
+            (!reliableAwakeCoverage && now >= fallbackMidnightAfter(latestSleep.startInclusive, tzOffsetSeconds))
+        if (!mustFallback) return latestSleep.copy(endExclusive = now)
+        val boundary = fallbackMidnightAfter(latestSleep.startInclusive, tzOffsetSeconds)
+        val day = AnalyticsEngine.dayString(boundary, tzOffsetSeconds)
+        return DayCycleWindow(
+            id = "synthetic:$day",
+            startInclusive = boundary,
+            endExclusive = now,
+            displayDay = day,
+            source = DayCycleWindow.Source.SYNTHETIC_MIDNIGHT,
+        )
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/DayCycle.kt
+++ b/android/app/src/main/java/com/noop/analytics/DayCycle.kt
@@ -52,8 +52,8 @@ object DayCycleResolver {
     }
 
     /**
-     * Resolve the active window. Reliable, explicitly-awake coverage preserves a genuine all-nighter.
-     * Missing/untrustworthy coverage falls back to midnight; even claimed awake coverage is capped at 40 h.
+     * Resolve the active window. Sleep-onset mode stays open across midnight even when awake coverage is
+     * unavailable. The absolute cap still prevents a stale sleep boundary from remaining active forever.
      */
     fun activeWindow(
         mode: DayCycleMode,
@@ -66,8 +66,7 @@ object DayCycleResolver {
             return calendarWindow(now, tzOffsetSeconds)
         }
         val age = now - latestSleep.startInclusive
-        val mustFallback = age >= ABSOLUTE_MAX_OPEN_SECONDS ||
-            (!reliableAwakeCoverage && now >= fallbackMidnightAfter(latestSleep.startInclusive, tzOffsetSeconds))
+        val mustFallback = age >= ABSOLUTE_MAX_OPEN_SECONDS
         if (!mustFallback) return latestSleep.copy(endExclusive = now)
         val boundary = fallbackMidnightAfter(latestSleep.startInclusive, tzOffsetSeconds)
         val day = AnalyticsEngine.dayString(boundary, tzOffsetSeconds)

--- a/android/app/src/main/java/com/noop/analytics/DayCycleIntelligenceIntegration.kt
+++ b/android/app/src/main/java/com/noop/analytics/DayCycleIntelligenceIntegration.kt
@@ -113,6 +113,9 @@ internal object DayCycleIntelligenceIntegration {
         stepTicksPerStep: Double,
         traceSink: ((String) -> Unit)?,
         mode: DayCycleMode,
+        profile: UserProfile,
+        maxHROverride: Double?,
+        effortMethod: StrainScorer.Method,
     ): PhysiologicalStepCycleEngine.Result {
         val witnesses = scoredNights.associate { result ->
             result.daily.day to dayWitness(resolvedOwners[result.daily.day].orEmpty(), result)
@@ -120,6 +123,7 @@ internal object DayCycleIntelligenceIntegration {
         return PhysiologicalStepCycleEngine.compute(
             scoredNights, editedRows, resolvedOwners, candidatePriorities, witnesses, repo,
             tzOffsetSeconds, habitualMidsleepSec, windowStart, nowSeconds, stepTicksPerStep, traceSink, mode,
+            profile, maxHROverride, effortMethod,
         )
     }
 
@@ -133,6 +137,11 @@ internal object DayCycleIntelligenceIntegration {
         result.boundaryOnsetByWakeDay[daily.day]?.let { onset ->
             metricRows += MetricSeriesRow(computedId, daily.day, ONSET_KEY, onset.toDouble())
         }
-        return daily.copy(steps = integratedStepValue(daily.steps, established, result.cycleStepsByWakeDay[daily.day]))
+        return daily.copy(
+            steps = integratedStepValue(daily.steps, established, result.cycleStepsByWakeDay[daily.day]),
+            strain = if (established) result.cycleStrainByWakeDay[daily.day] else daily.strain,
+            activeKcalEst = if (established) result.cycleCaloriesByWakeDay[daily.day] else daily.activeKcalEst,
+            exerciseCount = if (established) result.cycleWorkoutCountByWakeDay[daily.day] else daily.exerciseCount,
+        )
     }
 }

--- a/android/app/src/main/java/com/noop/analytics/DayCycleIntelligenceIntegration.kt
+++ b/android/app/src/main/java/com/noop/analytics/DayCycleIntelligenceIntegration.kt
@@ -1,0 +1,138 @@
+package com.noop.analytics
+
+import com.noop.data.DailyMetric
+import com.noop.data.MetricSeriesRow
+import com.noop.data.SleepSession
+import com.noop.data.WhoopRepository
+
+/** Narrow adapter between the generic day-cycle domain and the legacy scoring orchestrator. */
+internal object DayCycleIntelligenceIntegration {
+    const val ONSET_KEY = "day_cycle_onset_ts"
+
+    internal data class PersistedBoundary(
+        val boundary: PhysiologicalSteps.CycleBoundary,
+        val wakeDay: String,
+        val owner: String,
+        val sleepContext: DetectedSleep,
+    )
+
+    fun integratedStepValue(calendarSteps: Int?, established: Boolean, cycleSteps: Int?): Int? =
+        if (established) cycleSteps else calendarSteps
+
+    fun markerRewriteSourceIds(
+        currentComputedSources: List<String>,
+        candidateComputedSources: List<String>,
+    ): List<String> = (currentComputedSources + candidateComputedSources).distinct()
+
+    fun persistedBoundaries(
+        candidates: List<Pair<String, Int>>,
+        sessionsByOwner: Map<String, List<SleepSession>>,
+        markerOnsetByOwnerAndDay: Map<String, Map<String, Long>>,
+        currentBoundaryWakeDays: Set<String>,
+        tzOffsetSeconds: Long,
+        habitualMidsleepSec: Long?,
+    ): List<PersistedBoundary> {
+        val claimedDays = currentBoundaryWakeDays.toMutableSet()
+        val recovered = ArrayList<PersistedBoundary>()
+        for ((owner, _) in candidates.sortedWith(compareBy<Pair<String, Int>> { it.second }.thenBy { it.first })) {
+            val sessionsByWakeDay = sessionsByOwner[owner].orEmpty()
+                .filter { it.endTs > it.effectiveStartTs }
+                .groupBy { AnalyticsEngine.dayString(it.endTs, tzOffsetSeconds) }
+            for ((wakeDay, sessions) in sessionsByWakeDay.toSortedMap()) {
+                if (wakeDay in claimedDays) continue
+                val markerOnset = markerOnsetByOwnerAndDay[owner]?.get(wakeDay) ?: continue
+                val blocks = sessions.map { session ->
+                    PhysiologicalSteps.SleepBlock(
+                        session.startTs, session.endTs, session.startTs.toString(), session.startTsAdjusted,
+                    )
+                }
+                val winner = PhysiologicalSteps.classifyForCycle(
+                    blocks, tzOffsetSeconds, habitualMidsleepSec,
+                ).firstOrNull {
+                    it.kind == PhysiologicalSteps.SleepKind.MAIN_SLEEP && it.effectiveOnset == markerOnset
+                } ?: continue
+                val persisted = sessions.firstOrNull {
+                    it.startTs.toString() == winner.id && it.effectiveStartTs == markerOnset
+                } ?: continue
+                recovered += PersistedBoundary(
+                    PhysiologicalSteps.CycleBoundary("persisted:$owner:${persisted.startTs}", markerOnset),
+                    wakeDay,
+                    owner,
+                    DetectedSleep(
+                        persisted.effectiveStartTs, persisted.endTs, persisted.efficiency ?: 0.0,
+                        AnalyticsEngine.decodeStages(persisted.stagesJSON), persisted.restingHr, persisted.avgHrv,
+                    ),
+                )
+                claimedDays += wakeDay
+            }
+        }
+        return recovered
+    }
+
+    fun recoveredMarkerRows(
+        recovered: List<PersistedBoundary>,
+        computedDeviceId: (String) -> String,
+    ): List<MetricSeriesRow> = recovered.map {
+        MetricSeriesRow(computedDeviceId(it.owner), it.wakeDay, ONSET_KEY, it.boundary.onset.toDouble())
+    }
+
+    fun cacheKey(
+        owner: String,
+        sleepId: String,
+        onset: Long,
+        end: Long,
+        stepRevision: String,
+        sleepContextSignature: String,
+        contributingDayKeys: List<Pair<String, String>>,
+    ): String = buildString {
+        append(owner).append('|').append(sleepId).append('|').append(onset).append('|').append(end)
+            .append("|stepRevision=").append(stepRevision)
+            .append("|sleepContext=").append(sleepContextSignature)
+        for ((day, witness) in contributingDayKeys.sortedBy { it.first }) append('|').append(day).append('=').append(witness)
+    }
+
+    fun shouldRecount(cachedKey: String?, currentKey: String): Boolean = cachedKey != currentKey
+
+    private fun dayWitness(owner: String, result: DayResult): String = buildString {
+        append(owner).append(':').append(result.daily.steps ?: "nil")
+        for (sleep in result.sleepSessions.sortedBy { it.start }) {
+            append('|').append(sleep.start).append('-').append(sleep.end).append(':').append(sleep.stages.hashCode())
+        }
+    }
+
+    suspend fun compute(
+        scoredNights: List<DayResult>,
+        editedRows: List<SleepSession>,
+        resolvedOwners: Map<String, String>,
+        candidatePriorities: List<Pair<String, Int>>,
+        repo: WhoopRepository,
+        tzOffsetSeconds: Long,
+        habitualMidsleepSec: Long?,
+        windowStart: Long,
+        nowSeconds: Long,
+        stepTicksPerStep: Double,
+        traceSink: ((String) -> Unit)?,
+        mode: DayCycleMode,
+    ): PhysiologicalStepCycleEngine.Result {
+        val witnesses = scoredNights.associate { result ->
+            result.daily.day to dayWitness(resolvedOwners[result.daily.day].orEmpty(), result)
+        }
+        return PhysiologicalStepCycleEngine.compute(
+            scoredNights, editedRows, resolvedOwners, candidatePriorities, witnesses, repo,
+            tzOffsetSeconds, habitualMidsleepSec, windowStart, nowSeconds, stepTicksPerStep, traceSink, mode,
+        )
+    }
+
+    fun apply(
+        daily: DailyMetric,
+        result: PhysiologicalStepCycleEngine.Result,
+        computedId: String,
+        metricRows: MutableList<MetricSeriesRow>,
+    ): DailyMetric {
+        val established = result.firstCycleWakeDay?.let { daily.day >= it } == true
+        result.boundaryOnsetByWakeDay[daily.day]?.let { onset ->
+            metricRows += MetricSeriesRow(computedId, daily.day, ONSET_KEY, onset.toDouble())
+        }
+        return daily.copy(steps = integratedStepValue(daily.steps, established, result.cycleStepsByWakeDay[daily.day]))
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1510,15 +1510,12 @@ object IntelligenceEngine {
             // #547 effective-onset detail is preserved: editOnsetByStart still carries the user-CORRECTED
             // bedtime (startTsAdjusted ?: startTs) for this day's edited/manual blocks.
             val dayEditedRows = editedRowsForDay(editedRows, res.daily.day, tzOffsetSeconds)
-            val editsByStart: Map<Long, String?> = dayEditedRows.associate { it.startTs to it.stagesJSON }
-            val editOnsetByStart: Map<Long, Long> = dayEditedRows.associate { it.startTs to it.effectiveStartTs }
             // Substitute an edited block's (reshaped) stages for its detected twin before the daily
             // sleep aggregate feeds Rest + recovery. No edit touching this night → `daily` is unchanged.
-            var daily = sleepEditedDaily(
-                res.daily, res.sleepSessions, editsByStart, editOnsetByStart,
-                tzOffsetSeconds, habitualMidsleepSec,
+            val daily = editedCycleDaily(
+                res, dayEditedRows, tzOffsetSeconds, habitualMidsleepSec,
+                physiologicalSteps, computedId, restRows,
             )
-            daily = DayCycleIntelligenceIntegration.apply(daily, physiologicalSteps, computedId, restRows)
             val recovery = recomputeRecovery(daily, baselines2)
             // Charge term-breakdown trace (Test Centre Group G): only when the Recovery test mode is on
             // (recoveryTraceSink non-null). Emits which term moved Charge and which was nil and forced the
@@ -1801,23 +1798,11 @@ object IntelligenceEngine {
         // this only fills the days the strap collected but no import covered.
         // Persist metric-level input provenance in the SAME Room transaction. dayOwnership remains
         // exclusively a resolver override, and a failed write can never relabel an older score.
-        val provenance = IntelligencePersistence.scoreProvenance(
-            computedId, dailies, restRows, resolvedScoreOwnerByDay,
+        val computedWindow = IntelligencePersistence.prepareComputedWindow(
+            repo, importedDeviceId, computedId, oldestDay, newestDay, dailies, restRows, physiologicalSteps,
+            candidatePriorities, resolvedScoreOwnerByDay,
         )
-        repo.replaceComputedScoreWindow(
-            deviceId = computedId,
-            from = oldestDay,
-            to = newestDay,
-            dailyMetrics = dailies,
-            metricPoints = (restRows + physiologicalSteps.recoveredOwnerMarkerRows)
-                .distinctBy { Triple(it.deviceId, it.day, it.key) },
-            provenance = provenance,
-            replaceMetricKeys = listOf(DayCycleIntelligenceIntegration.ONSET_KEY),
-            replaceMetricSourceIds = DayCycleIntelligenceIntegration.markerRewriteSourceIds(
-                repo.computedSourceIds(importedDeviceId),
-                candidatePriorities.map { (owner, _) -> repo.computedDeviceId(owner) },
-            ),
-        )
+        repo.replaceComputedScoreWindow(computedWindow)
 
         persistFitnessVitalityAndSteps(
             repo = repo,
@@ -2407,6 +2392,24 @@ object IntelligenceEngine {
         day: String,
         tzOffsetSeconds: Long,
     ): List<SleepSession> = editedRows.filter { AnalyticsEngine.dayString(it.endTs, tzOffsetSeconds) == day }
+
+    private fun editedCycleDaily(
+        result: DayResult,
+        edits: List<SleepSession>,
+        tzOffsetSeconds: Long,
+        habitualMidsleepSec: Long?,
+        cycle: PhysiologicalStepCycleEngine.Result,
+        computedId: String,
+        metricRows: MutableList<MetricSeriesRow>,
+    ): DailyMetric {
+        val editsByStart = edits.associate { it.startTs to it.stagesJSON }
+        val onsetByStart = edits.associate { it.startTs to it.effectiveStartTs }
+        val edited = sleepEditedDaily(
+            result.daily, result.sleepSessions, editsByStart, onsetByStart,
+            tzOffsetSeconds, habitualMidsleepSec,
+        )
+        return DayCycleIntelligenceIntegration.apply(edited, cycle, computedId, metricRows)
+    }
 
     private fun sleepEditedDaily(
         daily: DailyMetric,

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -161,6 +161,7 @@ object IntelligenceEngine {
 
     /** Read cap per stream read , matches the Swift 200_000 bound. */
     const val STREAM_LIMIT: Int = 200_000
+    internal const val PHYSIOLOGICAL_STEP_PAGE_SIZE: Int = 10_000
 
     private const val SECONDS_PER_DAY: Long = 86_400L
 
@@ -410,6 +411,7 @@ object IntelligenceEngine {
         // #1545: the Effort TRIMP recipe. The Context-aware caller reads NoopPrefs.effortMethod(context)
         // and passes it down, keeping this layer Context-free. EDWARDS default = byte-identical.
         effortMethod: StrainScorer.Method = StrainScorer.Method.EDWARDS,
+        dayCycleMode: DayCycleMode = DayCycleMode.SLEEP_ONSET,
     ): List<Computed> = withContext(Dispatchers.Default) {
         // #1005: time the whole pass so a re-score STORM is visible in the strap log (the trigger lines
         // record WHY each pass runs; this records how many nights and how long — the CPU cost per run).
@@ -422,7 +424,7 @@ object IntelligenceEngine {
                 nowSeconds, ownerSource, manualStepCoefficient, persistStepsCalibration, baselineEpoch,
                 recoveryEpoch, diag, useExperimentalSleepV2, useMotionAwareWake, sleepTraceSink, recoveryTraceSink,
                 stepsTraceSink, universalSink, workoutsTraceSink, hrvTraceSink, deepHrvWindow,
-                spo2CandidateDisplay, effortMethod)
+                spo2CandidateDisplay, effortMethod, dayCycleMode)
             if (healed == 0) out
             // #899 heal re-pass: the pass above deleted overlapping duplicate sleep sessions AFTER its days
             // were scored, and the read-side dedup those days consumed had no bank-recency witness (the fresh
@@ -433,7 +435,7 @@ object IntelligenceEngine {
                 nowSeconds, ownerSource, manualStepCoefficient, persistStepsCalibration, baselineEpoch,
                 recoveryEpoch, diag, useExperimentalSleepV2, useMotionAwareWake, sleepTraceSink, recoveryTraceSink,
                 stepsTraceSink, universalSink, workoutsTraceSink, hrvTraceSink, deepHrvWindow,
-                spo2CandidateDisplay, effortMethod).first
+                spo2CandidateDisplay, effortMethod, dayCycleMode).first
         }
         diag("re-score: done — scored ${scored.size} night(s) in ${(System.nanoTime() - reScoreStart) / 1_000_000} ms (#1005)")
         scored
@@ -537,6 +539,7 @@ object IntelligenceEngine {
         spo2CandidateDisplay: Boolean = false,
         // #1545: the Effort TRIMP recipe, threaded from the public wrapper.
         effortMethod: StrainScorer.Method = StrainScorer.Method.EDWARDS,
+        dayCycleMode: DayCycleMode = DayCycleMode.SLEEP_ONSET,
         // #899 heal re-pass: the second component of the return is how many overlapping duplicate sleep
         // sessions the heal below deleted this pass. The public wrapper re-runs ONCE when it is non-zero
         // so the affected days re-score against the cleaned store.
@@ -597,6 +600,8 @@ object IntelligenceEngine {
         // on. Keyed by the local day.
         val readOwnerByDay = LinkedHashMap<String, OwnerRead>()
         val resolvedScoreOwnerByDay = LinkedHashMap<String, String>()
+        // Boundary/cache witness assembled from the already-computed day result. The independent O(1)
+        // repository revision below handles step-only inserts even when the HR-keyed day cache is reused.
         // HRV baseline honours the manual "Recalibrate baseline" epoch (noop.hrvBaselineEpoch): pass the
         // per-value "yyyy-MM-dd" day keys (parallel to the values) so foldHistory drops every night before
         // the epoch. baselineEpoch is threaded down from the Context-aware caller (0.0 = no recalibration).
@@ -728,6 +733,7 @@ object IntelligenceEngine {
             // produced under one method is stale the moment the user switches — serving it would show a
             // window of days scored by a recipe the user just turned off, with nothing to explain it.
             effortMethod.toString(),
+            dayCycleMode.persistedValue,
         ).joinToString("|")
         // Drop the whole cache on a config change. Under [analyzeGate] (this whole pass runs holding the
         // lock), so mutating the object-level cache here is race-free.
@@ -1489,6 +1495,12 @@ object IntelligenceEngine {
             .appleDaily(WhoopRepository.APPLE_HEALTH_SOURCE, "0000-01-01", "9999-12-31")
             .map { it.day }.toHashSet()
 
+        val physiologicalSteps = DayCycleIntelligenceIntegration.compute(
+            scoredNights, editedRows, resolvedScoreOwnerByDay, candidatePriorities, repo,
+            tzOffsetSeconds, habitualMidsleepSec, windowStart, nowSeconds, profile.stepTicksPerStep,
+            stepsTraceSink, dayCycleMode,
+        )
+
         for (res in scoredNights) {
             // #299: scope the edits to THIS day before folding. A userEdited row / hand-logged nap belongs
             // to exactly ONE day — the day its night ENDS on, matching the daily's end-day bucket
@@ -1502,10 +1514,11 @@ object IntelligenceEngine {
             val editOnsetByStart: Map<Long, Long> = dayEditedRows.associate { it.startTs to it.effectiveStartTs }
             // Substitute an edited block's (reshaped) stages for its detected twin before the daily
             // sleep aggregate feeds Rest + recovery. No edit touching this night → `daily` is unchanged.
-            val daily = sleepEditedDaily(
+            var daily = sleepEditedDaily(
                 res.daily, res.sleepSessions, editsByStart, editOnsetByStart,
                 tzOffsetSeconds, habitualMidsleepSec,
             )
+            daily = DayCycleIntelligenceIntegration.apply(daily, physiologicalSteps, computedId, restRows)
             val recovery = recomputeRecovery(daily, baselines2)
             // Charge term-breakdown trace (Test Centre Group G): only when the Recovery test mode is on
             // (recoveryTraceSink non-null). Emits which term moved Charge and which was nil and forced the
@@ -1580,8 +1593,9 @@ object IntelligenceEngine {
             // Scoped to computed days: an imported-total-only day legitimately has a total without our
             // sessions, so it is NOT a divergence.
             val imported = daily.day in importedWhoopDays || daily.day in appleHealthDays
-            if (!imported && daily.totalSleepMin != null && res.sleepSessions.isEmpty()) {
-                diag(sleepDivergenceLogLine(daily.day, Math.round(daily.totalSleepMin).toInt(), dayEditedRows.size))
+            val finalSleepMin = daily.totalSleepMin
+            if (!imported && finalSleepMin != null && res.sleepSessions.isEmpty()) {
+                diag(sleepDivergenceLogLine(daily.day, Math.round(finalSleepMin).toInt(), dayEditedRows.size))
             }
             // #195: one always-on line per scored night with the computed HRV value + the window it used,
             // so an "HRV reads high / deep-sleep window not changing" report is self-diagnosing straight
@@ -1787,30 +1801,22 @@ object IntelligenceEngine {
         // this only fills the days the strap collected but no import covered.
         // Persist metric-level input provenance in the SAME Room transaction. dayOwnership remains
         // exclusively a resolver override, and a failed write can never relabel an older score.
-        val provenanceByCell = LinkedHashMap<Pair<String, String>, ScoreInputProvenanceRow>()
-        for (daily in dailies) {
-            val source = resolvedScoreOwnerByDay[daily.day] ?: continue
-            if (daily.recovery != null) {
-                provenanceByCell[daily.day to "recovery"] =
-                    ScoreInputProvenanceRow(computedId, daily.day, "recovery", source)
-            }
-            if (daily.strain != null) {
-                provenanceByCell[daily.day to "strain"] =
-                    ScoreInputProvenanceRow(computedId, daily.day, "strain", source)
-            }
-        }
-        for (point in restRows) {
-            val source = resolvedScoreOwnerByDay[point.day] ?: continue
-            provenanceByCell[point.day to point.key] =
-                ScoreInputProvenanceRow(computedId, point.day, point.key, source)
-        }
+        val provenance = IntelligencePersistence.scoreProvenance(
+            computedId, dailies, restRows, resolvedScoreOwnerByDay,
+        )
         repo.replaceComputedScoreWindow(
             deviceId = computedId,
             from = oldestDay,
             to = newestDay,
             dailyMetrics = dailies,
-            metricPoints = restRows,
-            provenance = provenanceByCell.values.toList(),
+            metricPoints = (restRows + physiologicalSteps.recoveredOwnerMarkerRows)
+                .distinctBy { Triple(it.deviceId, it.day, it.key) },
+            provenance = provenance,
+            replaceMetricKeys = listOf(DayCycleIntelligenceIntegration.ONSET_KEY),
+            replaceMetricSourceIds = DayCycleIntelligenceIntegration.markerRewriteSourceIds(
+                repo.computedSourceIds(importedDeviceId),
+                candidatePriorities.map { (owner, _) -> repo.computedDeviceId(owner) },
+            ),
         )
 
         persistFitnessVitalityAndSteps(
@@ -1850,37 +1856,8 @@ object IntelligenceEngine {
         val dismissedWindows = repo.dismissedSleeps(importedDeviceId).map { it.startTs to it.endTs }
         val skipWindows = editedWindows + dismissedWindows
         val sleepKept = DismissedSleepGuard.keeping(sleepRows, skipWindows) { it.startTs to it.endTs }
-        if (sleepKept.isNotEmpty()) repo.upsertSleepSessions(sleepKept)
-        // ── Persist per-epoch motion (H8) beside each kept session's stagesJSON ──────────────────────────
-        // The sleepSession rows exist now (just upserted), so the targeted motion UPDATE lands. Persist ONLY
-        // for the sessions actually kept (not edited/dismissed), keyed by the detected start analyzeDay
-        // returned. A session whose gravity wouldn't grid was omitted from the map and is left as NULL , an
-        // absent motion series stays absent, never a fabricated zero array. Mirrors Swift.
+        IntelligencePersistence.persistDetectedSleepDetails(repo, computedId, sleepKept, scoredNights)
         val keptStarts = sleepKept.map { it.startTs }.toHashSet()
-        val motionByStart = HashMap<Long, List<Double>>()
-        for (res in scoredNights) {
-            for ((start, motion) in res.sessionMotionByStart) {
-                if (start in keptStarts) motionByStart[start] = motion
-            }
-        }
-        for ((start, motion) in motionByStart) {
-            repo.persistSessionMotion(computedId, start, motion)
-        }
-        // ── Persist per-epoch BAND sleep_state (#175) beside each kept session's stagesJSON ──────────────
-        // This is the source `sleepStateJSON` lacked (the write path had no producer because the raw stream
-        // was dropped at extraction). Now analyzeDay grids the RAW `sleepStateSample` stream per session;
-        // persist it here so the NEXT pass's bandSleepStateSamples read (the H7 confirm) and the display can
-        // see the strap's OWN scored band. ONLY for kept (not edited/dismissed) sessions; a session with no
-        // band samples was omitted (no key) and stays NULL — an absent signal stays absent. Mirrors Swift.
-        val sleepStateByStart = HashMap<Long, List<Int>>()
-        for (res in scoredNights) {
-            for ((start, states) in res.sessionSleepStateByStart) {
-                if (start in keptStarts) sleepStateByStart[start] = states
-            }
-        }
-        for ((start, states) in sleepStateByStart) {
-            repo.persistSessionSleepState(computedId, start, states)
-        }
         // ── Overlap-aware banked-sleep heal (#899) ────────────────────────────────────────────────────
         // An unstable strap clock re-banks the SAME night under a shifted timebase, so successive passes
         // detect it at shifted bounds and the upsert above lands a SECOND row beside the stale one (the

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1499,6 +1499,7 @@ object IntelligenceEngine {
             scoredNights, editedRows, resolvedScoreOwnerByDay, candidatePriorities, repo,
             tzOffsetSeconds, habitualMidsleepSec, windowStart, nowSeconds, profile.stepTicksPerStep,
             stepsTraceSink, dayCycleMode,
+            profile, maxHROverride, effortMethod,
         )
 
         for (res in scoredNights) {

--- a/android/app/src/main/java/com/noop/analytics/IntelligencePersistence.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligencePersistence.kt
@@ -1,0 +1,63 @@
+package com.noop.analytics
+
+import com.noop.data.DailyMetric
+import com.noop.data.MetricSeriesRow
+import com.noop.data.ScoreInputProvenanceRow
+import com.noop.data.SleepSession
+import com.noop.data.WhoopRepository
+
+/** Persistence-only helpers kept out of the already large scoring orchestrator. */
+internal object IntelligencePersistence {
+    fun scoreProvenance(
+        computedId: String,
+        dailies: List<DailyMetric>,
+        metricRows: List<MetricSeriesRow>,
+        ownerByDay: Map<String, String>,
+    ): List<ScoreInputProvenanceRow> {
+        val byCell = LinkedHashMap<Pair<String, String>, ScoreInputProvenanceRow>()
+        for (daily in dailies) {
+            val source = ownerByDay[daily.day] ?: continue
+            if (daily.recovery != null) {
+                byCell[daily.day to "recovery"] = ScoreInputProvenanceRow(
+                    computedId, daily.day, "recovery", source,
+                )
+            }
+            if (daily.strain != null) {
+                byCell[daily.day to "strain"] = ScoreInputProvenanceRow(
+                    computedId, daily.day, "strain", source,
+                )
+            }
+        }
+        for (point in metricRows) {
+            val source = ownerByDay[point.day] ?: continue
+            byCell[point.day to point.key] = ScoreInputProvenanceRow(
+                computedId, point.day, point.key, source,
+            )
+        }
+        return byCell.values.toList()
+    }
+
+    suspend fun persistDetectedSleepDetails(
+        repo: WhoopRepository,
+        computedId: String,
+        kept: List<SleepSession>,
+        scoredNights: List<DayResult>,
+    ) {
+        // Only kept (not edited/dismissed) sessions receive their per-epoch motion and band-state arrays.
+        // Missing streams remain absent rather than being materialised as synthetic zero arrays.
+        if (kept.isNotEmpty()) repo.upsertSleepSessions(kept)
+        val keptStarts = kept.map { it.startTs }.toHashSet()
+        val motionByStart = HashMap<Long, List<Double>>()
+        val sleepStateByStart = HashMap<Long, List<Int>>()
+        for (result in scoredNights) {
+            for ((start, motion) in result.sessionMotionByStart) {
+                if (start in keptStarts) motionByStart[start] = motion
+            }
+            for ((start, states) in result.sessionSleepStateByStart) {
+                if (start in keptStarts) sleepStateByStart[start] = states
+            }
+        }
+        for ((start, motion) in motionByStart) repo.persistSessionMotion(computedId, start, motion)
+        for ((start, states) in sleepStateByStart) repo.persistSessionSleepState(computedId, start, states)
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/IntelligencePersistence.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligencePersistence.kt
@@ -8,6 +8,44 @@ import com.noop.data.WhoopRepository
 
 /** Persistence-only helpers kept out of the already large scoring orchestrator. */
 internal object IntelligencePersistence {
+    data class ComputedWindow(
+        val deviceId: String,
+        val from: String,
+        val to: String,
+        val dailies: List<DailyMetric>,
+        val metricRows: List<MetricSeriesRow>,
+        val provenance: List<ScoreInputProvenanceRow>,
+        val markerSourceIds: List<String>,
+    )
+
+    suspend fun prepareComputedWindow(
+        repo: WhoopRepository,
+        importedDeviceId: String,
+        computedId: String,
+        from: String,
+        to: String,
+        dailies: List<DailyMetric>,
+        metricRows: List<MetricSeriesRow>,
+        cycle: PhysiologicalStepCycleEngine.Result,
+        candidatePriorities: List<Pair<String, Int>>,
+        ownerByDay: Map<String, String>,
+    ): ComputedWindow {
+        val provenance = scoreProvenance(computedId, dailies, metricRows, ownerByDay)
+        return ComputedWindow(
+            deviceId = computedId,
+            from = from,
+            to = to,
+            dailies = dailies,
+            metricRows = (metricRows + cycle.recoveredOwnerMarkerRows)
+                .distinctBy { Triple(it.deviceId, it.day, it.key) },
+            provenance = provenance,
+            markerSourceIds = DayCycleIntelligenceIntegration.markerRewriteSourceIds(
+                repo.computedSourceIds(importedDeviceId),
+                candidatePriorities.map { (owner, _) -> repo.computedDeviceId(owner) },
+            ),
+        )
+    }
+
     fun scoreProvenance(
         computedId: String,
         dailies: List<DailyMetric>,
@@ -61,3 +99,17 @@ internal object IntelligencePersistence {
         for ((start, states) in sleepStateByStart) repo.persistSessionSleepState(computedId, start, states)
     }
 }
+
+/** Keep the oversized scoring orchestrator at a single, auditable transactional call site. */
+internal suspend fun WhoopRepository.replaceComputedScoreWindow(
+    window: IntelligencePersistence.ComputedWindow,
+) = replaceComputedScoreWindow(
+    deviceId = window.deviceId,
+    from = window.from,
+    to = window.to,
+    dailyMetrics = window.dailies,
+    metricPoints = window.metricRows,
+    provenance = window.provenance,
+    replaceMetricKeys = listOf(DayCycleIntelligenceIntegration.ONSET_KEY),
+    replaceMetricSourceIds = window.markerSourceIds,
+)

--- a/android/app/src/main/java/com/noop/analytics/PhysiologicalStepCycleEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/PhysiologicalStepCycleEngine.kt
@@ -121,7 +121,7 @@ internal object PhysiologicalStepCycleEngine {
             val markersByOwner = LinkedHashMap<String, Map<String, Long>>()
             for (owner in candidatePriorities.map { it.first }.distinct()) {
                 val ownerComputedId = repo.computedDeviceId(owner)
-                sessionsByOwner[owner] = repo.sleepSessions(
+                sessionsByOwner[owner] = repo.sleepSessionsForDevice(
                     ownerComputedId, windowStart, nowSeconds, limit = 4_000,
                 )
                 markersByOwner[owner] = repo.metricSeries(

--- a/android/app/src/main/java/com/noop/analytics/PhysiologicalStepCycleEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/PhysiologicalStepCycleEngine.kt
@@ -195,7 +195,10 @@ internal object PhysiologicalStepCycleEngine {
         for (window in windows) {
             val wakeDay = dayBySleepId[window.sleepId] ?: continue
             val fallbackOwner = ownerBySleepId[window.sleepId] ?: continue
-            val cycleHr = repo.hrSamplesUnion(fallbackOwner, window.onset, window.endExclusive, 200_000)
+            // DAO ranges are inclusive. Keep adjacent physiological cycles disjoint.
+            val cycleHr = repo.hrSamplesUnion(
+                fallbackOwner, window.onset, window.endExclusive - 1L, 200_000,
+            )
             val restingHr = scoredNights.firstOrNull { it.daily.day == wakeDay }?.daily?.restingHr?.toDouble()
                 ?: StrainScorer.defaultRestingHR
             val effectiveMaxHr = maxHROverride
@@ -207,9 +210,28 @@ internal object PhysiologicalStepCycleEngine {
                     cycleHr, profile, effectiveMaxHr, restingHr,
                 )
             }
-            workoutCountByWakeDay[wakeDay] = scoredNights.asSequence().flatMap { it.workouts.asSequence() }
-                .distinctBy { it.start to it.end }
-                .count { it.start >= window.onset && it.start < window.endExclusive }
+            // Count the persisted all-source workout union, not only analyzer-detected bouts. Repository
+            // reads are inclusive, while ownership is [onset, nextOnset).
+            val workoutEndInclusive = window.endExclusive - 1L
+            val cycleWorkouts = (
+                repo.workoutsUnion(fallbackOwner, window.onset, workoutEndInclusive, 100_000) +
+                    repo.detectedWorkoutsUnion(fallbackOwner, window.onset, workoutEndInclusive, 100_000) +
+                    listOf("apple-health", "health-connect", "lifting", "activity-file").flatMap { source ->
+                        repo.workouts(source, window.onset, workoutEndInclusive, 100_000)
+                    }
+                ).distinctBy { Triple(it.startTs, it.endTs, it.sport) }
+            val freshDetectedKeys = scoredNights.asSequence().flatMap { it.workouts.asSequence() }
+                .filter { it.start >= window.onset && it.start < window.endExclusive }
+                .filter { detected ->
+                    cycleWorkouts.none { persisted ->
+                        detected.start < persisted.endTs && persisted.startTs < detected.end
+                    }
+                }
+                .map { it.start to it.end }
+                .toList()
+            workoutCountByWakeDay[wakeDay] = (
+                cycleWorkouts.map { it.startTs to it.endTs } + freshDetectedKeys
+                ).distinct().size
             val priorities = LinkedHashMap<String, Int>()
             for ((owner, priority) in candidatePriorities) priorities[owner] = priority
             priorities.putIfAbsent(fallbackOwner, priorities.values.minOrNull() ?: 0)

--- a/android/app/src/main/java/com/noop/analytics/PhysiologicalStepCycleEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/PhysiologicalStepCycleEngine.kt
@@ -286,6 +286,11 @@ internal object PhysiologicalStepCycleEngine {
                         "awakeGap=${result.count.acceptedAwakeGapTicks} " +
                         "sleepBout=${result.count.acceptedSleepBoutTicks} " +
                         "rejectedIsolatedSleep=${result.count.rejectedIsolatedSleepTicks} " +
+                        "rejectedClass=${result.count.rejectedActivityClassTicks} " +
+                        "rejectedImplausible=${result.count.rejectedImplausibleTicks} " +
+                        "gravitySamples=${result.count.gravitySamplesAvailable} " +
+                        "auxSamples=${result.count.auxSamplesAvailable} " +
+                        "ticksPerStep=$stepTicksPerStep " +
                         "scaledSteps=$scaled",
                 )
             }

--- a/android/app/src/main/java/com/noop/analytics/PhysiologicalStepCycleEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/PhysiologicalStepCycleEngine.kt
@@ -1,0 +1,306 @@
+package com.noop.analytics
+
+import com.noop.data.MetricSeriesRow
+import com.noop.data.SleepSession
+import com.noop.data.WhoopRepository
+import kotlin.math.roundToLong
+
+/**
+ * Sleep-onset-to-sleep-onset step materialisation. Kept outside [IntelligenceEngine]'s already-large
+ * scoring method so the JVM method stays below its 64 KiB bytecode limit and the feature has one boundary.
+ * The cache retains summaries only; raw step pages are released immediately after each segment.
+ */
+internal object PhysiologicalStepCycleEngine {
+    data class Result(
+        val cycleStepsByWakeDay: Map<String, Int>,
+        val boundaryOnsetByWakeDay: Map<String, Long>,
+        val firstCycleWakeDay: String?,
+        val recoveredOwnerMarkerRows: List<MetricSeriesRow>,
+    )
+
+    private data class CachedCycleSteps(
+        val key: String,
+        val count: SleepAwareStepCounter.Count,
+        val pages: Int,
+        val samples: Int,
+        val evaluated: Boolean,
+    )
+
+    /** Process-local and serialized by IntelligenceEngine's analyze gate. */
+    private val cache = HashMap<String, CachedCycleSteps>()
+
+    suspend fun compute(
+        scoredNights: List<DayResult>,
+        editedRows: List<SleepSession>,
+        resolvedScoreOwnerByDay: Map<String, String>,
+        candidatePriorities: List<Pair<String, Int>>,
+        stepWitnessByDay: Map<String, String>,
+        repo: WhoopRepository,
+        tzOffsetSeconds: Long,
+        habitualMidsleepSec: Long?,
+        windowStart: Long,
+        nowSeconds: Long,
+        stepTicksPerStep: Double,
+        stepsTraceSink: ((String) -> Unit)?,
+        dayCycleMode: DayCycleMode,
+    ): Result {
+        if (dayCycleMode == DayCycleMode.MIDNIGHT) {
+            return Result(emptyMap(), emptyMap(), null, emptyList())
+        }
+        val editedRowsByDay = editedRows.groupBy {
+            AnalyticsEngine.dayString(it.endTs, tzOffsetSeconds)
+        }
+        val boundaries = ArrayList<PhysiologicalSteps.CycleBoundary>()
+        val dayBySleepId = LinkedHashMap<String, String>()
+        val ownerBySleepId = LinkedHashMap<String, String>()
+        val sleepContext = ArrayList<DetectedSleep>()
+        val recovered = ArrayList<DayCycleIntelligenceIntegration.PersistedBoundary>()
+
+        for (res in scoredNights) {
+            val dayEdits = editedRowsByDay[res.daily.day].orEmpty()
+            val editsByDetectedStart = dayEdits.associateBy { it.startTs }
+            val detectedStarts = res.sleepSessions.mapTo(HashSet()) { it.start }
+            val blocks = buildList {
+                for (session in res.sleepSessions) {
+                    val edit = editsByDetectedStart[session.start]
+                    sleepContext += SleepAwareStepCounter.withBounds(
+                        session,
+                        start = edit?.effectiveStartTs ?: session.start,
+                        end = edit?.endTs ?: session.end,
+                    )
+                    add(
+                        PhysiologicalSteps.SleepBlock(
+                            onset = session.start,
+                            end = edit?.endTs ?: session.end,
+                            id = session.start.toString(),
+                            editedOnset = edit?.effectiveStartTs,
+                        ),
+                    )
+                }
+                for (edit in dayEdits) {
+                    if (edit.startTs !in detectedStarts) {
+                        add(
+                            PhysiologicalSteps.SleepBlock(
+                                onset = edit.startTs,
+                                end = edit.endTs,
+                                id = "manual:${edit.startTs}",
+                                editedOnset = edit.startTsAdjusted,
+                                kind = PhysiologicalSteps.SleepKind.NAP,
+                            ),
+                        )
+                        sleepContext += DetectedSleep(
+                            start = edit.effectiveStartTs,
+                            end = edit.endTs,
+                            efficiency = 0.0,
+                            stages = emptyList(),
+                            restingHR = null,
+                            avgHRV = null,
+                        )
+                    }
+                }
+            }
+            val classified = PhysiologicalSteps.classifyForCycle(
+                blocks, tzOffsetSeconds, habitualMidsleepSec,
+            )
+            PhysiologicalSteps.mainSleepOnset(
+                classified, tzOffsetSeconds, habitualMidsleepSec,
+            )?.let { onset ->
+                val winner = classified.firstOrNull {
+                    it.kind == PhysiologicalSteps.SleepKind.MAIN_SLEEP && it.effectiveOnset == onset
+                } ?: return@let
+                boundaries += PhysiologicalSteps.CycleBoundary(winner.id, onset)
+                dayBySleepId[winner.id] = res.daily.day
+                resolvedScoreOwnerByDay[res.daily.day]?.let { ownerBySleepId[winner.id] = it }
+            }
+        }
+
+        if (candidatePriorities.isNotEmpty()) {
+            val markerFromDay = AnalyticsEngine.dayString(windowStart, tzOffsetSeconds)
+            val markerToDay = AnalyticsEngine.dayString(nowSeconds, tzOffsetSeconds)
+            val sessionsByOwner = LinkedHashMap<String, List<SleepSession>>()
+            val markersByOwner = LinkedHashMap<String, Map<String, Long>>()
+            for (owner in candidatePriorities.map { it.first }.distinct()) {
+                val ownerComputedId = repo.computedDeviceId(owner)
+                sessionsByOwner[owner] = repo.sleepSessions(
+                    ownerComputedId, windowStart, nowSeconds, limit = 4_000,
+                )
+                markersByOwner[owner] = repo.metricSeries(
+                    ownerComputedId,
+                    DayCycleIntelligenceIntegration.ONSET_KEY,
+                    markerFromDay,
+                    markerToDay,
+                ).mapNotNull { row ->
+                    val onset = row.value.toLong()
+                    if (row.value == onset.toDouble()) row.day to onset else null
+                }.toMap()
+            }
+            for (item in DayCycleIntelligenceIntegration.persistedBoundaries(
+                candidates = candidatePriorities,
+                sessionsByOwner = sessionsByOwner,
+                markerOnsetByOwnerAndDay = markersByOwner,
+                currentBoundaryWakeDays = dayBySleepId.values.toHashSet(),
+                tzOffsetSeconds = tzOffsetSeconds,
+                habitualMidsleepSec = habitualMidsleepSec,
+            )) {
+                recovered += item
+                boundaries += item.boundary
+                dayBySleepId[item.boundary.sleepId] = item.wakeDay
+                ownerBySleepId[item.boundary.sleepId] = item.owner
+                sleepContext += item.sleepContext
+            }
+        }
+
+        // Resolve the open tail through the shared day-cycle policy. Step storage proves strap coverage,
+        // not wakefulness: a missed sleep detection has the same endpoints. Until a dedicated, validated
+        // awake signal exists, unknown therefore takes the safe midnight fallback.
+        boundaries.maxByOrNull { it.onset }?.let { latest ->
+            val wakeDay = dayBySleepId[latest.sleepId]
+            val owner = ownerBySleepId[latest.sleepId]
+            if (wakeDay != null && owner != null) {
+                val active = DayCycleResolver.activeWindow(
+                    mode = dayCycleMode,
+                    latestSleep = DayCycleWindow(
+                        id = latest.sleepId,
+                        startInclusive = latest.onset,
+                        endExclusive = nowSeconds,
+                        displayDay = wakeDay,
+                        source = DayCycleWindow.Source.DETECTED_SLEEP,
+                    ),
+                    now = nowSeconds,
+                    tzOffsetSeconds = tzOffsetSeconds,
+                    reliableAwakeCoverage = false,
+                )
+                if (active.source == DayCycleWindow.Source.SYNTHETIC_MIDNIGHT) {
+                    val synthetic = PhysiologicalSteps.CycleBoundary(active.id, active.startInclusive)
+                    boundaries += synthetic
+                    dayBySleepId[synthetic.sleepId] = active.displayDay
+                    ownerBySleepId[synthetic.sleepId] = owner
+                }
+            }
+        }
+
+        val stepsByWakeDay = HashMap<String, Int>()
+        val windows = PhysiologicalSteps.cycleWindows(boundaries, nowSeconds)
+        val allDetectedSleep = sleepContext.distinctBy { it.start to it.end }
+        cache.keys.retainAll(windows.mapTo(HashSet()) { it.sleepId })
+        for (window in windows) {
+            val wakeDay = dayBySleepId[window.sleepId] ?: continue
+            val fallbackOwner = ownerBySleepId[window.sleepId] ?: continue
+            val priorities = LinkedHashMap<String, Int>()
+            for ((owner, priority) in candidatePriorities) priorities[owner] = priority
+            priorities.putIfAbsent(fallbackOwner, priorities.values.minOrNull() ?: 0)
+            val coverage = priorities.mapNotNull { (owner, priority) ->
+                val span = repo.stepTimestampCoverage(owner, window.onset, window.endExclusive)
+                val first = span.firstTs
+                val last = span.lastTs
+                if (first == null || last == null) null else PhysiologicalSteps.OwnerCoverage(
+                    owner, first, (last + 1L).coerceAtMost(window.endExclusive), priority,
+                )
+            }
+            val segments = PhysiologicalSteps.ownerSegmentsFromCoverage(window, coverage, fallbackOwner)
+            if (segments.isEmpty()) continue
+            val active = window.endExclusive == nowSeconds
+            val ownerIdentity = segments.mapIndexed { index, segment ->
+                val identityEnd = if (active && index == segments.lastIndex) 0L else segment.endExclusive
+                "${segment.owner}:${segment.onset}-$identityEnd"
+            }.joinToString(",")
+            val stepRevision = segments.joinToString("|") { segment ->
+                "${segment.owner}=" + repo.stepDataRevisionSignature(
+                    segment.owner, segment.onset, segment.endExclusive,
+                )
+            }
+            val contextSignature = SleepAwareStepCounter.contextSignature(
+                allDetectedSleep, window.onset, window.endExclusive,
+            )
+            val firstDay = AnalyticsEngine.dayString(window.onset, tzOffsetSeconds)
+            val lastDay = AnalyticsEngine.dayString(
+                (window.endExclusive - 1L).coerceAtLeast(window.onset), tzOffsetSeconds,
+            )
+            val witnesses = stepWitnessByDay.entries.asSequence()
+                .filter { it.key >= firstDay && it.key <= lastDay }
+                .map { it.key to it.value }
+                .toList()
+            val key = DayCycleIntelligenceIntegration.cacheKey(
+                owner = ownerIdentity,
+                sleepId = window.sleepId,
+                onset = window.onset,
+                end = if (active) 0L else window.endExclusive,
+                stepRevision = stepRevision,
+                sleepContextSignature = contextSignature,
+                contributingDayKeys = witnesses,
+            )
+            var cached = cache[window.sleepId]
+            if (DayCycleIntelligenceIntegration.shouldRecount(cached?.key, key)) {
+                var pages = 0
+                var samples = 0
+                var evaluated = false
+                var combinedCount = SleepAwareStepCounter.Count.EMPTY
+                for ((segmentIndex, segment) in segments.withIndex()) {
+                    val hasClasses = repo.hasStepActivityClasses(
+                        segment.owner, segment.onset, segment.endExclusive,
+                    )
+                    val accumulator = SleepAwareStepCounter.Accumulator(allDetectedSleep, hasClasses)
+                    var segmentSamples = 0
+                    if (PhysiologicalSteps.shouldReadCounterPredecessor(segmentIndex)) {
+                        repo.stepSampleBefore(segment.owner, segment.onset)?.let {
+                            accumulator.acceptPage(listOf(it))
+                            samples++
+                            segmentSamples++
+                        }
+                    }
+                    var cursor = segment.onset - 1L
+                    while (cursor < segment.endExclusive) {
+                        val page = repo.stepSamplesPage(
+                            segment.owner,
+                            cursor,
+                            segment.endExclusive,
+                            IntelligenceEngine.PHYSIOLOGICAL_STEP_PAGE_SIZE,
+                        )
+                        if (page.isEmpty()) break
+                        accumulator.acceptPage(page)
+                        pages++
+                        samples += page.size
+                        segmentSamples += page.size
+                        val next = page.last().ts
+                        if (next <= cursor) break
+                        cursor = next
+                        if (page.size < IntelligenceEngine.PHYSIOLOGICAL_STEP_PAGE_SIZE) break
+                    }
+                    if (segmentSamples >= 2) evaluated = true
+                    combinedCount += accumulator.finish()
+                }
+                cached = CachedCycleSteps(key, combinedCount, pages, samples, evaluated)
+                cache[window.sleepId] = cached
+            }
+            val result = cached ?: continue
+            if (result.evaluated) {
+                val scaled = (result.count.totalTicks.toDouble() / maxOf(stepTicksPerStep, 0.5))
+                    .roundToLong().coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+                stepsByWakeDay[wakeDay] = scaled
+                stepsTraceSink?.invoke(
+                    "stepsCycle wakeDay=$wakeDay status=${if (active) "active" else "closed"} " +
+                        "onsetTs=${window.onset} endTs=${window.endExclusive} owner=$ownerIdentity " +
+                        "pages=${result.pages} samples=${result.samples} " +
+                        "totalTicks=${result.count.totalTicks} " +
+                        "outside=${result.count.acceptedOutsideSleepTicks} " +
+                        "awakeGap=${result.count.acceptedAwakeGapTicks} " +
+                        "sleepBout=${result.count.acceptedSleepBoutTicks} " +
+                        "rejectedIsolatedSleep=${result.count.rejectedIsolatedSleepTicks} " +
+                        "scaledSteps=$scaled",
+                )
+            }
+        }
+
+        return Result(
+            cycleStepsByWakeDay = stepsByWakeDay,
+            boundaryOnsetByWakeDay = boundaries.mapNotNull { boundary ->
+                dayBySleepId[boundary.sleepId]?.let { it to boundary.onset }
+            }.toMap(),
+            firstCycleWakeDay = dayBySleepId.values.minOrNull(),
+            recoveredOwnerMarkerRows = DayCycleIntelligenceIntegration.recoveredMarkerRows(
+                recovered,
+                repo::computedDeviceId,
+            ),
+        )
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/PhysiologicalStepCycleEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/PhysiologicalStepCycleEngine.kt
@@ -13,6 +13,9 @@ import kotlin.math.roundToLong
 internal object PhysiologicalStepCycleEngine {
     data class Result(
         val cycleStepsByWakeDay: Map<String, Int>,
+        val cycleStrainByWakeDay: Map<String, Double>,
+        val cycleCaloriesByWakeDay: Map<String, Double>,
+        val cycleWorkoutCountByWakeDay: Map<String, Int>,
         val boundaryOnsetByWakeDay: Map<String, Long>,
         val firstCycleWakeDay: String?,
         val recoveredOwnerMarkerRows: List<MetricSeriesRow>,
@@ -43,9 +46,12 @@ internal object PhysiologicalStepCycleEngine {
         stepTicksPerStep: Double,
         stepsTraceSink: ((String) -> Unit)?,
         dayCycleMode: DayCycleMode,
+        profile: UserProfile,
+        maxHROverride: Double?,
+        effortMethod: StrainScorer.Method,
     ): Result {
         if (dayCycleMode == DayCycleMode.MIDNIGHT) {
-            return Result(emptyMap(), emptyMap(), null, emptyList())
+            return Result(emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), null, emptyList())
         }
         val editedRowsByDay = editedRows.groupBy {
             AnalyticsEngine.dayString(it.endTs, tzOffsetSeconds)
@@ -180,12 +186,30 @@ internal object PhysiologicalStepCycleEngine {
         }
 
         val stepsByWakeDay = HashMap<String, Int>()
+        val strainByWakeDay = HashMap<String, Double>()
+        val caloriesByWakeDay = HashMap<String, Double>()
+        val workoutCountByWakeDay = HashMap<String, Int>()
         val windows = PhysiologicalSteps.cycleWindows(boundaries, nowSeconds)
         val allDetectedSleep = sleepContext.distinctBy { it.start to it.end }
         cache.keys.retainAll(windows.mapTo(HashSet()) { it.sleepId })
         for (window in windows) {
             val wakeDay = dayBySleepId[window.sleepId] ?: continue
             val fallbackOwner = ownerBySleepId[window.sleepId] ?: continue
+            val cycleHr = repo.hrSamplesUnion(fallbackOwner, window.onset, window.endExclusive, 200_000)
+            val restingHr = scoredNights.firstOrNull { it.daily.day == wakeDay }?.daily?.restingHr?.toDouble()
+                ?: StrainScorer.defaultRestingHR
+            val effectiveMaxHr = maxHROverride
+                ?: profile.age.takeIf { it > 0 }?.let { StrainScorer.tanakaHRmax(it.toDouble()) }
+            StrainScorer.strain(cycleHr, effectiveMaxHr, restingHr, effortMethod, profile.sex)
+                ?.let { strainByWakeDay[wakeDay] = it }
+            if (cycleHr.isNotEmpty()) {
+                caloriesByWakeDay[wakeDay] = Calories.estimateDayCalories(
+                    cycleHr, profile, effectiveMaxHr, restingHr,
+                )
+            }
+            workoutCountByWakeDay[wakeDay] = scoredNights.asSequence().flatMap { it.workouts.asSequence() }
+                .distinctBy { it.start to it.end }
+                .count { it.start >= window.onset && it.start < window.endExclusive }
             val priorities = LinkedHashMap<String, Int>()
             for ((owner, priority) in candidatePriorities) priorities[owner] = priority
             priorities.putIfAbsent(fallbackOwner, priorities.values.minOrNull() ?: 0)
@@ -298,6 +322,9 @@ internal object PhysiologicalStepCycleEngine {
 
         return Result(
             cycleStepsByWakeDay = stepsByWakeDay,
+            cycleStrainByWakeDay = strainByWakeDay,
+            cycleCaloriesByWakeDay = caloriesByWakeDay,
+            cycleWorkoutCountByWakeDay = workoutCountByWakeDay,
             boundaryOnsetByWakeDay = boundaries.mapNotNull { boundary ->
                 dayBySleepId[boundary.sleepId]?.let { it to boundary.onset }
             }.toMap(),

--- a/android/app/src/main/java/com/noop/analytics/PhysiologicalSteps.kt
+++ b/android/app/src/main/java/com/noop/analytics/PhysiologicalSteps.kt
@@ -1,0 +1,329 @@
+package com.noop.analytics
+
+import com.noop.data.StepSample
+
+/**
+ * WHOOP-style step-day boundaries. A physiological step day starts at the onset of the main sleep
+ * and ends at the next main-sleep onset; the delta is still attributed to the later counter sample.
+ * We deliberately do not mask the sleep span: a real walk during a long night-time wake remains a
+ * walk, while the shared activity-class and tick-rate gates continue to reject non-locomotion.
+ */
+object PhysiologicalSteps {
+
+    enum class SleepKind { MAIN_SLEEP, NAP, UNCLASSIFIED }
+
+    data class SleepBlock(
+        val onset: Long,
+        val end: Long,
+        /** Stable identity lets a user-edited onset move an existing boundary instead of adding one. */
+        val id: String = onset.toString(),
+        val editedOnset: Long? = null,
+        val kind: SleepKind = SleepKind.UNCLASSIFIED,
+    ) {
+        val effectiveOnset: Long get() = editedOnset ?: onset
+    }
+
+    /** The one open physiological cycle. Absence of a newly detected night never creates a calendar cycle. */
+    data class CycleBoundary(val sleepId: String, val onset: Long)
+
+    data class CycleWindow(val sleepId: String, val onset: Long, val endExclusive: Long)
+
+    data class OwnerSegment(val owner: String, val onset: Long, val endExclusive: Long)
+    data class OwnerCoverage(
+        val owner: String,
+        val onset: Long,
+        val endExclusive: Long,
+        val priority: Int,
+    )
+
+    fun shouldReadCounterPredecessor(segmentIndex: Int): Boolean = segmentIndex == 0
+
+    private const val MIN_MAIN_SLEEP_SECONDS = 3 * 3_600L
+
+    /**
+     * State carried between ascending database pages. [previous] is deliberately retained even when it
+     * lies before the cycle so the first in-cycle counter delta has the correct predecessor.
+     */
+    data class CycleCountState internal constructor(
+        val hasActivityClasses: Boolean,
+        val previous: StepSample?,
+        val total: Long,
+        val evaluatedDelta: Boolean,
+    )
+
+    private fun isPlausibleMainSleep(
+        block: SleepBlock,
+        tzOffsetSeconds: Long,
+        habitualMidsleepSec: Long?,
+    ): Boolean {
+        if (block.kind == SleepKind.NAP) return false
+        val onset = block.effectiveOnset
+        if (block.end <= onset) return false
+        if (block.kind == SleepKind.MAIN_SLEEP) return true
+        val midpoint = onset + (block.end - onset) / 2
+        val target = SleepStageTotals.targetMidsleepSec(habitualMidsleepSec)
+        return SleepStageTotals.circularDistanceSec(
+            SleepStageTotals.localSecOfDay(midpoint, tzOffsetSeconds),
+            target,
+        ) < SleepStageTotals.ALIGNMENT_ZERO_SEC
+    }
+
+    /**
+     * Apply the same user-visible main-vs-nap shape used by the sleep surfaces: only the canonical overnight
+     * group can be MAIN, it must total at least three hours, and every other/twinless-explicit block is NAP.
+     */
+    fun classifyForCycle(
+        blocks: List<SleepBlock>,
+        tzOffsetSeconds: Long,
+        habitualMidsleepSec: Long?,
+    ): List<SleepBlock> {
+        if (blocks.isEmpty()) return emptyList()
+        val explicitMain = blocks.indices.filter { blocks[it].kind == SleepKind.MAIN_SLEEP }
+        val selectable = blocks.indices.filter { blocks[it].kind != SleepKind.NAP }
+        val selectedOriginalIndices = if (explicitMain.isNotEmpty()) {
+            explicitMain
+        } else {
+            val selectableNightBlocks = selectable.map {
+                val b = blocks[it]
+                SleepStageTotals.NightBlock(b.effectiveOnset, b.end)
+            }
+            // Eliminate nap-shaped GROUPS before choosing a winner. Otherwise a six-hour afternoon nap can
+            // win the generic duration scorer, fail the daytime guard, and hide a valid shorter night.
+            val eligible = SleepStageTotals.bridgedNightGroups(selectableNightBlocks, tzOffsetSeconds)
+                .filter { group ->
+                    val total = group.indices.sumOf { i -> selectableNightBlocks[i].durationS.coerceAtLeast(0L) }
+                    val onset = group.indices.minOfOrNull { selectableNightBlocks[it].start }
+                    total >= MIN_MAIN_SLEEP_SECONDS && onset != null &&
+                        SleepStageTotals.isOvernightOnset(onset, tzOffsetSeconds)
+                }
+                .flatMap { it.indices }
+                .distinct()
+            SleepStageTotals.mainNightGroupIndices(
+                eligible.map { selectableIndex ->
+                    val original = selectable[selectableIndex]
+                    val b = blocks[original]
+                    SleepStageTotals.NightBlock(b.effectiveOnset, b.end)
+                },
+                tzOffsetSeconds,
+                habitualMidsleepSec,
+            ).orEmpty().map { selectedIndex ->
+                selectable[eligible[selectedIndex]]
+            }
+        }.toHashSet()
+        return blocks.mapIndexed { index, block ->
+            block.copy(kind = if (index in selectedOriginalIndices) SleepKind.MAIN_SLEEP else SleepKind.NAP)
+        }
+    }
+
+    /** Use the exact same main-night/group selector as the Sleep screen and daily sleep aggregate. */
+    fun mainSleepOnset(
+        blocks: List<SleepBlock>,
+        tzOffsetSeconds: Long,
+        habitualMidsleepSec: Long?,
+    ): Long? {
+        val eligible = classifyForCycle(blocks, tzOffsetSeconds, habitualMidsleepSec)
+            .filter { it.kind == SleepKind.MAIN_SLEEP }
+        val indices = SleepStageTotals.mainNightGroupIndices(
+            eligible.map { SleepStageTotals.NightBlock(it.effectiveOnset, it.end) },
+            tzOffsetSeconds,
+            habitualMidsleepSec,
+        ) ?: return null
+        return indices.minOfOrNull { eligible[it].effectiveOnset }
+    }
+
+    /**
+     * Advance the single open cycle from newly observed sleep rows. Missing sleep and nap-only input keep
+     * [previous] unchanged. A late-arriving main sleep advances it; a stable [SleepBlock.id] applies a
+     * user-edited onset to the same boundary even when the edit moves backwards.
+     */
+    fun advanceBoundary(
+        previous: CycleBoundary?,
+        observedBlocks: List<SleepBlock>,
+        now: Long,
+        tzOffsetSeconds: Long = 0,
+        habitualMidsleepSec: Long? = null,
+    ): CycleBoundary? {
+        val eligible = observedBlocks.filter {
+            it.effectiveOnset <= now && isPlausibleMainSleep(it, tzOffsetSeconds, habitualMidsleepSec)
+        }
+        previous?.let { old ->
+            eligible.firstOrNull { it.id == old.sleepId }?.let {
+                val edited = CycleBoundary(it.id, it.effectiveOnset)
+                val newer = eligible.filter { candidate -> candidate.id != old.sleepId }
+                    .maxByOrNull { candidate -> candidate.effectiveOnset }
+                return if (newer != null && newer.effectiveOnset > edited.onset) {
+                    CycleBoundary(newer.id, newer.effectiveOnset)
+                } else {
+                    edited
+                }
+            }
+        }
+        val newest = eligible.maxByOrNull { it.effectiveOnset } ?: return previous
+        return if (previous == null || newest.effectiveOnset > previous.onset) {
+            CycleBoundary(newest.id, newest.effectiveOnset)
+        } else {
+            previous
+        }
+    }
+
+    /**
+     * Build historical sleep-to-sleep windows without inventing rows at midnight. The final observed
+     * boundary alone owns the open tail to [now], including days on which no new sleep was detected.
+     */
+    fun cycleWindows(boundaries: List<CycleBoundary>, now: Long): List<CycleWindow> {
+        val ordered = boundaries.asSequence()
+            .filter { it.onset <= now }
+            .distinctBy { it.sleepId }
+            .sortedBy { it.onset }
+            .toList()
+        return ordered.mapIndexedNotNull { index, boundary ->
+            val end = ordered.getOrNull(index + 1)?.onset ?: now
+            if (end <= boundary.onset) null else CycleWindow(boundary.sleepId, boundary.onset, end)
+        }
+    }
+
+    /** Split at local midnights and merge adjacent same-owner slices; counters never cross device seams. */
+    fun ownerSegments(
+        window: CycleWindow,
+        ownerByDay: Map<String, String>,
+        tzOffsetSeconds: Long,
+        fallbackOwner: String,
+    ): List<OwnerSegment> {
+        if (window.endExclusive <= window.onset) return emptyList()
+        val out = ArrayList<OwnerSegment>()
+        var cursor = window.onset
+        var lastOwner = fallbackOwner
+        while (cursor < window.endExclusive) {
+            val day = AnalyticsEngine.dayString(cursor, tzOffsetSeconds)
+            val local = cursor + tzOffsetSeconds
+            val dayNumber = Math.floorDiv(local, SleepStageTotals.SECONDS_PER_DAY)
+            val dayStart = dayNumber * SleepStageTotals.SECONDS_PER_DAY - tzOffsetSeconds
+            // The sleep-owner owns the partial onset day. Calendar owner changes take effect only at a
+            // midnight seam, never retroactively before the boundary sleep began.
+            val owner = if (cursor == window.onset && cursor > dayStart) {
+                fallbackOwner
+            } else {
+                ownerByDay[day] ?: lastOwner
+            }
+            val nextMidnight = (dayNumber + 1) * SleepStageTotals.SECONDS_PER_DAY - tzOffsetSeconds
+            val end = minOf(window.endExclusive, nextMidnight)
+            val previous = out.lastOrNull()
+            if (previous != null && previous.owner == owner && previous.endExclusive == cursor) {
+                out[out.lastIndex] = previous.copy(endExclusive = end)
+            } else {
+                out += OwnerSegment(owner, cursor, end)
+            }
+            lastOwner = owner
+            cursor = end
+        }
+        return out
+    }
+
+    /**
+     * Timestamp coverage wins at every seam; priority resolves overlap, so two worn straps never add.
+     * Each coverage is a continuous first..last ownership span by design: an internal sample/radio gap
+     * creates no seam and therefore cannot hand the interval to a lower-priority concurrently worn strap.
+     */
+    fun ownerSegmentsFromCoverage(
+        window: CycleWindow,
+        coverage: List<OwnerCoverage>,
+        fallbackOwner: String,
+    ): List<OwnerSegment> {
+        if (window.endExclusive <= window.onset) return emptyList()
+        val clipped = coverage.mapNotNull {
+            val start = maxOf(window.onset, it.onset)
+            val end = minOf(window.endExclusive, it.endExclusive)
+            if (end <= start) null else it.copy(onset = start, endExclusive = end)
+        }
+        val seams = buildSet {
+            add(window.onset)
+            add(window.endExclusive)
+            clipped.forEach { add(it.onset); add(it.endExclusive) }
+        }.sorted()
+        val out = ArrayList<OwnerSegment>()
+        var lastOwner = fallbackOwner
+        for (i in 0 until seams.lastIndex) {
+            val start = seams[i]
+            val end = seams[i + 1]
+            val owner = clipped.asSequence()
+                .filter { start >= it.onset && start < it.endExclusive }
+                .minWithOrNull(compareBy<OwnerCoverage> { it.priority }.thenBy { it.owner })
+                ?.owner ?: lastOwner
+            val previous = out.lastOrNull()
+            if (previous != null && previous.owner == owner && previous.endExclusive == start) {
+                out[out.lastIndex] = previous.copy(endExclusive = end)
+            } else {
+                out += OwnerSegment(owner, start, end)
+            }
+            lastOwner = owner
+        }
+        return out
+    }
+
+    /** Resolve the next observed onset, or [now] for the currently open physiological cycle. */
+    fun cycleEnd(day: String, onsetByDay: Map<String, Long>, now: Long): Long {
+        val onset = onsetByDay[day] ?: return now
+        return onsetByDay.values.asSequence()
+            .filter { it > onset && it <= now }
+            .minOrNull()
+            ?: now
+    }
+
+    /**
+     * Sum locomotion deltas whose *later* sample lies in [onsetInclusive, endExclusive). Samples may
+     * include one predecessor before onset so a counter increment crossing the boundary is attributed
+     * correctly. Returns null only when there is not enough counter data to evaluate the cycle; an
+     * observed, flat cycle is a real zero.
+     */
+    fun stepsInCycle(
+        samples: List<StepSample>,
+        onsetInclusive: Long,
+        endExclusive: Long,
+    ): Int? {
+        if (endExclusive <= onsetInclusive) return 0
+        val sorted = samples.sortedBy { it.ts }
+        if (sorted.size < 2) return null
+        val state = accumulateCyclePage(
+            newCycleCount(StepsCounter.hasActivityClasses(sorted)),
+            sorted,
+            onsetInclusive,
+            endExclusive,
+        )
+        return finishCycleCount(state)
+    }
+
+    fun newCycleCount(hasActivityClasses: Boolean): CycleCountState =
+        CycleCountState(hasActivityClasses, previous = null, total = 0, evaluatedDelta = false)
+
+    /** Fold one ascending page into [state]. Pages may overlap at their seam; duplicate timestamps skip. */
+    fun accumulateCyclePage(
+        state: CycleCountState,
+        samples: List<StepSample>,
+        onsetInclusive: Long,
+        endExclusive: Long,
+    ): CycleCountState {
+        if (samples.isEmpty()) return state
+        var previous = state.previous
+        var total = state.total
+        var evaluated = state.evaluatedDelta
+        for (current in samples.sortedBy { it.ts }) {
+            val prior = previous
+            if (prior != null && current.ts <= prior.ts) continue
+            if (prior != null && current.ts >= onsetInclusive && current.ts < endExclusive) {
+                evaluated = true
+                val delta = (current.counter - prior.counter) and 0xFFFF
+                if (
+                    StepsCounter.shouldCountDelta(current.activityClass, state.hasActivityClasses) &&
+                    StepsCounter.isPlausibleDelta(prior.ts, current.ts, delta)
+                ) {
+                    total += delta.toLong()
+                }
+            }
+            previous = current
+        }
+        return CycleCountState(state.hasActivityClasses, previous, total, evaluated)
+    }
+
+    fun finishCycleCount(state: CycleCountState): Int? =
+        if (!state.evaluatedDelta) null else state.total.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+}

--- a/android/app/src/main/java/com/noop/analytics/PhysiologicalSteps.kt
+++ b/android/app/src/main/java/com/noop/analytics/PhysiologicalSteps.kt
@@ -1,7 +1,5 @@
 package com.noop.analytics
 
-import com.noop.data.StepSample
-
 /**
  * WHOOP-style step-day boundaries. A physiological step day starts at the onset of the main sleep
  * and ends at the next main-sleep onset; the delta is still attributed to the later counter sample.
@@ -40,33 +38,6 @@ object PhysiologicalSteps {
 
     private const val MIN_MAIN_SLEEP_SECONDS = 3 * 3_600L
 
-    /**
-     * State carried between ascending database pages. [previous] is deliberately retained even when it
-     * lies before the cycle so the first in-cycle counter delta has the correct predecessor.
-     */
-    data class CycleCountState internal constructor(
-        val hasActivityClasses: Boolean,
-        val previous: StepSample?,
-        val total: Long,
-        val evaluatedDelta: Boolean,
-    )
-
-    private fun isPlausibleMainSleep(
-        block: SleepBlock,
-        tzOffsetSeconds: Long,
-        habitualMidsleepSec: Long?,
-    ): Boolean {
-        if (block.kind == SleepKind.NAP) return false
-        val onset = block.effectiveOnset
-        if (block.end <= onset) return false
-        if (block.kind == SleepKind.MAIN_SLEEP) return true
-        val midpoint = onset + (block.end - onset) / 2
-        val target = SleepStageTotals.targetMidsleepSec(habitualMidsleepSec)
-        return SleepStageTotals.circularDistanceSec(
-            SleepStageTotals.localSecOfDay(midpoint, tzOffsetSeconds),
-            target,
-        ) < SleepStageTotals.ALIGNMENT_ZERO_SEC
-    }
 
     /**
      * Apply the same user-visible main-vs-nap shape used by the sleep surfaces: only the canonical overnight
@@ -129,41 +100,6 @@ object PhysiologicalSteps {
             habitualMidsleepSec,
         ) ?: return null
         return indices.minOfOrNull { eligible[it].effectiveOnset }
-    }
-
-    /**
-     * Advance the single open cycle from newly observed sleep rows. Missing sleep and nap-only input keep
-     * [previous] unchanged. A late-arriving main sleep advances it; a stable [SleepBlock.id] applies a
-     * user-edited onset to the same boundary even when the edit moves backwards.
-     */
-    fun advanceBoundary(
-        previous: CycleBoundary?,
-        observedBlocks: List<SleepBlock>,
-        now: Long,
-        tzOffsetSeconds: Long = 0,
-        habitualMidsleepSec: Long? = null,
-    ): CycleBoundary? {
-        val eligible = observedBlocks.filter {
-            it.effectiveOnset <= now && isPlausibleMainSleep(it, tzOffsetSeconds, habitualMidsleepSec)
-        }
-        previous?.let { old ->
-            eligible.firstOrNull { it.id == old.sleepId }?.let {
-                val edited = CycleBoundary(it.id, it.effectiveOnset)
-                val newer = eligible.filter { candidate -> candidate.id != old.sleepId }
-                    .maxByOrNull { candidate -> candidate.effectiveOnset }
-                return if (newer != null && newer.effectiveOnset > edited.onset) {
-                    CycleBoundary(newer.id, newer.effectiveOnset)
-                } else {
-                    edited
-                }
-            }
-        }
-        val newest = eligible.maxByOrNull { it.effectiveOnset } ?: return previous
-        return if (previous == null || newest.effectiveOnset > previous.onset) {
-            CycleBoundary(newest.id, newest.effectiveOnset)
-        } else {
-            previous
-        }
     }
 
     /**
@@ -269,61 +205,4 @@ object PhysiologicalSteps {
             ?: now
     }
 
-    /**
-     * Sum locomotion deltas whose *later* sample lies in [onsetInclusive, endExclusive). Samples may
-     * include one predecessor before onset so a counter increment crossing the boundary is attributed
-     * correctly. Returns null only when there is not enough counter data to evaluate the cycle; an
-     * observed, flat cycle is a real zero.
-     */
-    fun stepsInCycle(
-        samples: List<StepSample>,
-        onsetInclusive: Long,
-        endExclusive: Long,
-    ): Int? {
-        if (endExclusive <= onsetInclusive) return 0
-        val sorted = samples.sortedBy { it.ts }
-        if (sorted.size < 2) return null
-        val state = accumulateCyclePage(
-            newCycleCount(StepsCounter.hasActivityClasses(sorted)),
-            sorted,
-            onsetInclusive,
-            endExclusive,
-        )
-        return finishCycleCount(state)
-    }
-
-    fun newCycleCount(hasActivityClasses: Boolean): CycleCountState =
-        CycleCountState(hasActivityClasses, previous = null, total = 0, evaluatedDelta = false)
-
-    /** Fold one ascending page into [state]. Pages may overlap at their seam; duplicate timestamps skip. */
-    fun accumulateCyclePage(
-        state: CycleCountState,
-        samples: List<StepSample>,
-        onsetInclusive: Long,
-        endExclusive: Long,
-    ): CycleCountState {
-        if (samples.isEmpty()) return state
-        var previous = state.previous
-        var total = state.total
-        var evaluated = state.evaluatedDelta
-        for (current in samples.sortedBy { it.ts }) {
-            val prior = previous
-            if (prior != null && current.ts <= prior.ts) continue
-            if (prior != null && current.ts >= onsetInclusive && current.ts < endExclusive) {
-                evaluated = true
-                val delta = (current.counter - prior.counter) and 0xFFFF
-                if (
-                    StepsCounter.shouldCountDelta(current.activityClass, state.hasActivityClasses) &&
-                    StepsCounter.isPlausibleDelta(prior.ts, current.ts, delta)
-                ) {
-                    total += delta.toLong()
-                }
-            }
-            previous = current
-        }
-        return CycleCountState(state.hasActivityClasses, previous, total, evaluated)
-    }
-
-    fun finishCycleCount(state: CycleCountState): Int? =
-        if (!state.evaluatedDelta) null else state.total.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
 }

--- a/android/app/src/main/java/com/noop/analytics/RegistryDayOwnerSource.kt
+++ b/android/app/src/main/java/com/noop/analytics/RegistryDayOwnerSource.kt
@@ -10,18 +10,17 @@ import com.noop.protocol.DeviceFamily
  * with the per-day owner-resolution inputs so a day is scored from exactly ONE device (invariant I2),
  * without giving the pure-JVM engine a Room dependency.
  *
- * Priorities mirror the Swift IntelligenceEngine.resolveDayOwner exactly:
- *   0 = the active strap, 1 = other live (BLE/historyBLE) straps, 2 = imports (cloud/file). Lower wins.
- * Archived devices are excluded. With only the seeded active 'my-whoop' row paired (the default and
- * every single-WHOOP install), the sole candidate is priority 0, so the engine resolves to "my-whoop"
- * for every day and the reads stay byte-identical to the single-source path.
+ * Priorities mirror the Swift IntelligenceEngine.resolveDayOwner for current sources, with priority 4
+ * reserved for archived devices. Archived rows remain read-only historical candidates so removing and
+ * later re-adding a strap cannot erase its earlier physiological boundary/coverage; every current live,
+ * import, and activity source still wins an overlap. With only the seeded active 'my-whoop' row paired
+ * (the default and every single-WHOOP install), the sole candidate is priority 0, so reads stay identical.
  */
 class RegistryDayOwnerSource(private val registry: DeviceRegistry) : IntelligenceEngine.DayOwnerSource {
 
     override suspend fun candidatePriorities(): List<Pair<String, Int>> {
         val activeId = registry.activeDeviceId()
         return registry.all()
-            .filter { it.status != DeviceStatus.archived.name }
             .map { d ->
                 val isImport = d.sourceKind == SourceKind.cloudImport.name ||
                     d.sourceKind == SourceKind.fileImport.name
@@ -30,6 +29,7 @@ class RegistryDayOwnerSource(private val registry: DeviceRegistry) : Intelligenc
                 // wins a day nothing else covers. Mirrors Swift IntelligenceEngine.resolveDayOwner.
                 val priority = when {
                     d.id == activeId -> 0
+                    d.status == DeviceStatus.archived.name -> 4
                     d.sourceKind == SourceKind.activityFile.name -> 3
                     isImport -> 2
                     else -> 1

--- a/android/app/src/main/java/com/noop/analytics/SleepAwareStepCounter.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepAwareStepCounter.kt
@@ -29,6 +29,8 @@ object SleepAwareStepCounter {
         val acceptedAwakeGapTicks: Int,
         val acceptedSleepBoutTicks: Int,
         val rejectedIsolatedSleepTicks: Int,
+        val rejectedActivityClassTicks: Int,
+        val rejectedImplausibleTicks: Int,
         /** Availability only; neither raw stream changes the production decision yet. */
         val gravitySamplesAvailable: Int,
         val auxSamplesAvailable: Int,
@@ -39,12 +41,14 @@ object SleepAwareStepCounter {
             acceptedAwakeGapTicks + other.acceptedAwakeGapTicks,
             acceptedSleepBoutTicks + other.acceptedSleepBoutTicks,
             rejectedIsolatedSleepTicks + other.rejectedIsolatedSleepTicks,
+            rejectedActivityClassTicks + other.rejectedActivityClassTicks,
+            rejectedImplausibleTicks + other.rejectedImplausibleTicks,
             gravitySamplesAvailable + other.gravitySamplesAvailable,
             auxSamplesAvailable + other.auxSamplesAvailable,
         )
 
         companion object {
-            val EMPTY = Count(0, 0, 0, 0, 0, 0, 0)
+            val EMPTY = Count(0, 0, 0, 0, 0, 0, 0, 0, 0)
         }
     }
 
@@ -107,6 +111,8 @@ object SleepAwareStepCounter {
         private var awakeGap = 0
         private var sleepBout = 0
         private var rejectedSleep = 0
+        private var rejectedClass = 0
+        private var rejectedImplausible = 0
         private var gravityAvailable = 0
         private var auxAvailable = 0
         private var finished = false
@@ -130,9 +136,14 @@ object SleepAwareStepCounter {
                 if (prior == null) continue
 
                 val delta = (current.counter - prior.counter) and 0xFFFF
-                val valid = StepsCounter.shouldCountDelta(current.activityClass, hasActivityClasses) &&
-                    StepsCounter.isPlausibleDelta(prior.ts, current.ts, delta)
-                if (!valid) continue
+                if (!StepsCounter.shouldCountDelta(current.activityClass, hasActivityClasses)) {
+                    rejectedClass += delta
+                    continue
+                }
+                if (!StepsCounter.isPlausibleDelta(prior.ts, current.ts, delta)) {
+                    rejectedImplausible += delta
+                    continue
+                }
 
                 when (contextAt(current.ts, sessions)) {
                     Context.OUTSIDE_SLEEP -> {
@@ -165,6 +176,8 @@ object SleepAwareStepCounter {
                 acceptedAwakeGapTicks = awakeGap,
                 acceptedSleepBoutTicks = sleepBout,
                 rejectedIsolatedSleepTicks = rejectedSleep,
+                rejectedActivityClassTicks = rejectedClass,
+                rejectedImplausibleTicks = rejectedImplausible,
                 gravitySamplesAvailable = gravityAvailable,
                 auxSamplesAvailable = auxAvailable,
             )

--- a/android/app/src/main/java/com/noop/analytics/SleepAwareStepCounter.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepAwareStepCounter.kt
@@ -1,0 +1,198 @@
+package com.noop.analytics
+
+import com.noop.data.GravitySample
+import com.noop.data.StepSample
+import com.noop.data.V18AuxRow
+
+/**
+ * Sleep-context wrapper around [StepsCounter]. It keeps the incumbent counter/class/rate rules, but does
+ * not accept an isolated strap "walk" tick as proof that a sleeping person walked. Inside a scored sleep
+ * stage, valid locomotion deltas must form a short, temporally coherent bout. An explicitly scored wake
+ * gap is intentionally treated like ordinary awake time, so getting up for a child or the toilet counts.
+ *
+ * This kernel returns raw counter ticks exactly as [StepsCounter] does. It deliberately applies neither a
+ * learned conversion factor nor a fixed wrist orientation: a strap may be worn on either arm, a limb or
+ * clothing. Gravity/dynamic-acceleration and v18 auxiliary data are accepted for observability and future
+ * shadow validation, but are not yet trusted as production gates. When either stream is absent, the
+ * conservative temporal bout rule remains deterministic and fail-safe.
+ */
+object SleepAwareStepCounter {
+    /** A one- or two-second bed movement cannot satisfy all three bout floors. */
+    const val MAX_SECONDS_BETWEEN_GAIT_DELTAS: Long = 3L
+    const val MIN_GAIT_BOUT_DURATION_SECONDS: Long = 4L
+    const val MIN_GAIT_BOUT_ACTIVE_SAMPLES: Int = 5
+    const val MIN_GAIT_BOUT_TICKS: Int = 6
+
+    data class Count(
+        val totalTicks: Int,
+        val acceptedOutsideSleepTicks: Int,
+        val acceptedAwakeGapTicks: Int,
+        val acceptedSleepBoutTicks: Int,
+        val rejectedIsolatedSleepTicks: Int,
+        /** Availability only; neither raw stream changes the production decision yet. */
+        val gravitySamplesAvailable: Int,
+        val auxSamplesAvailable: Int,
+    ) {
+        operator fun plus(other: Count): Count = Count(
+            totalTicks + other.totalTicks,
+            acceptedOutsideSleepTicks + other.acceptedOutsideSleepTicks,
+            acceptedAwakeGapTicks + other.acceptedAwakeGapTicks,
+            acceptedSleepBoutTicks + other.acceptedSleepBoutTicks,
+            rejectedIsolatedSleepTicks + other.rejectedIsolatedSleepTicks,
+            gravitySamplesAvailable + other.gravitySamplesAvailable,
+            auxSamplesAvailable + other.auxSamplesAvailable,
+        )
+
+        companion object {
+            val EMPTY = Count(0, 0, 0, 0, 0, 0, 0)
+        }
+    }
+
+    /** Preserve scored stages while edited leading/trailing edges remain conservatively inside sleep. */
+    fun withBounds(session: DetectedSleep, start: Long, end: Long): DetectedSleep =
+        session.copy(start = start, end = end)
+
+    /** Effective bounds + stage content affecting exactly this cycle; unrelated sleep edits stay out. */
+    fun contextSignature(sessions: List<DetectedSleep>, onset: Long, endExclusive: Long): String =
+        sessions.asSequence()
+            .filter { it.end > onset && it.start < endExclusive }
+            .sortedWith(compareBy<DetectedSleep> { it.start }.thenBy { it.end })
+            .joinToString("|") { session ->
+                buildString {
+                    append(session.start).append('-').append(session.end)
+                    for (stage in session.stages.sortedBy { it.start }) {
+                        append(':').append(stage.start).append('-').append(stage.end).append('=').append(stage.stage)
+                    }
+                }
+            }
+
+    /** Same nullable convention as [StepsCounter.stepsInWindow]: no accepted movement is `null`. */
+    fun stepsInWindow(
+        samples: List<StepSample>,
+        sleepSessions: List<DetectedSleep>,
+        gravity: List<GravitySample> = emptyList(),
+        aux: List<V18AuxRow> = emptyList(),
+    ): Int? = count(samples, sleepSessions, gravity, aux).totalTicks.takeIf { it > 0 }
+
+    /** Detailed form intended for the Test Centre/shadow trace. */
+    fun count(
+        samples: List<StepSample>,
+        sleepSessions: List<DetectedSleep>,
+        gravity: List<GravitySample> = emptyList(),
+        aux: List<V18AuxRow> = emptyList(),
+    ): Count {
+        val sorted = samples.sortedBy { it.ts }
+        return Accumulator(sleepSessions, StepsCounter.hasActivityClasses(sorted))
+            .observeMotionPage(gravity, aux)
+            .acceptPage(sorted)
+            .finish()
+    }
+
+    /**
+     * Page-safe form for database windows larger than an in-memory query limit. The caller determines
+     * [hasActivityClasses] once for the complete window (for example with an EXISTS query) and keeps one
+     * accumulator for every ascending page. The previous counter sample and an unfinished in-sleep gait
+     * bout survive page boundaries, so paging cannot change the answer.
+     *
+     * Pages may overlap at their boundary: timestamps already consumed are ignored. Calling [finish]
+     * closes the last gait bout and makes the accumulator immutable.
+     */
+    class Accumulator(
+        sleepSessions: List<DetectedSleep>,
+        private val hasActivityClasses: Boolean,
+    ) {
+        private val sessions = sleepSessions.sortedBy { it.start }
+        private var previous: StepSample? = null
+        private var outside = 0
+        private var awakeGap = 0
+        private var sleepBout = 0
+        private var rejectedSleep = 0
+        private var gravityAvailable = 0
+        private var auxAvailable = 0
+        private var finished = false
+        private val pendingSleepBout = ArrayList<Delta>()
+
+        fun observeMotionPage(
+            gravity: List<GravitySample> = emptyList(),
+            aux: List<V18AuxRow> = emptyList(),
+        ): Accumulator = apply {
+            check(!finished) { "Accumulator is already finished" }
+            gravityAvailable += gravity.size
+            auxAvailable += aux.size
+        }
+
+        fun acceptPage(samples: List<StepSample>): Accumulator = apply {
+            check(!finished) { "Accumulator is already finished" }
+            for (current in samples.sortedBy { it.ts }) {
+                val prior = previous
+                if (prior != null && current.ts <= prior.ts) continue
+                previous = current
+                if (prior == null) continue
+
+                val delta = (current.counter - prior.counter) and 0xFFFF
+                val valid = StepsCounter.shouldCountDelta(current.activityClass, hasActivityClasses) &&
+                    StepsCounter.isPlausibleDelta(prior.ts, current.ts, delta)
+                if (!valid) continue
+
+                when (contextAt(current.ts, sessions)) {
+                    Context.OUTSIDE_SLEEP -> {
+                        flushSleepBout()
+                        outside += delta
+                    }
+                    Context.AWAKE_GAP -> {
+                        flushSleepBout()
+                        awakeGap += delta
+                    }
+                    Context.SCORED_SLEEP -> {
+                        val last = pendingSleepBout.lastOrNull()
+                        if (last != null && current.ts - last.ts > MAX_SECONDS_BETWEEN_GAIT_DELTAS) {
+                            flushSleepBout()
+                        }
+                        pendingSleepBout += Delta(current.ts, delta)
+                    }
+                }
+            }
+        }
+
+        fun finish(): Count {
+            if (!finished) {
+                flushSleepBout()
+                finished = true
+            }
+            return Count(
+                totalTicks = outside + awakeGap + sleepBout,
+                acceptedOutsideSleepTicks = outside,
+                acceptedAwakeGapTicks = awakeGap,
+                acceptedSleepBoutTicks = sleepBout,
+                rejectedIsolatedSleepTicks = rejectedSleep,
+                gravitySamplesAvailable = gravityAvailable,
+                auxSamplesAvailable = auxAvailable,
+            )
+        }
+
+        private fun flushSleepBout() {
+            if (pendingSleepBout.isEmpty()) return
+            val ticks = pendingSleepBout.sumOf { it.ticks }
+            val duration = pendingSleepBout.last().ts - pendingSleepBout.first().ts
+            val coherent = pendingSleepBout.size >= MIN_GAIT_BOUT_ACTIVE_SAMPLES &&
+                duration >= MIN_GAIT_BOUT_DURATION_SECONDS &&
+                ticks >= MIN_GAIT_BOUT_TICKS
+            if (coherent) sleepBout += ticks else rejectedSleep += ticks
+            pendingSleepBout.clear()
+        }
+    }
+
+    private data class Delta(val ts: Long, val ticks: Int)
+    private enum class Context { OUTSIDE_SLEEP, AWAKE_GAP, SCORED_SLEEP }
+
+    private fun contextAt(ts: Long, sessions: List<DetectedSleep>): Context {
+        val session = sessions.firstOrNull { ts >= it.start && ts < it.end } ?: return Context.OUTSIDE_SLEEP
+        val stage = session.stages.firstOrNull { ts >= it.start && ts < it.end }
+        return if (stage != null && SleepStageVocabulary.isWake(stage.stage)) {
+            Context.AWAKE_GAP
+        } else {
+            // Missing/gapped staging is not evidence of wakefulness. This is intentionally conservative.
+            Context.SCORED_SLEEP
+        }
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/StepsCounter.kt
+++ b/android/app/src/main/java/com/noop/analytics/StepsCounter.kt
@@ -6,38 +6,59 @@ import com.noop.data.StepSample
  * Wrap-aware step derivation from the strap's cumulative `step_motion_counter@57`, shared by the daily
  * total ([AnalyticsEngine.analyzeDay]) and any windowed total (a manual workout's `[start, end]`, #398).
  *
- * `step_motion_counter@57` is a CUMULATIVE u16 running counter: it climbs while you move, holds flat when
- * still, and wraps at 65536. The motion-tick total over a set of records is the SUM of WRAP-AWARE
- * increments of that counter — `delta = (cur - prev) and 0xFFFF` — with a per-user `stepTicksPerStep`
- * calibration applied by the caller AFTERWARDS (this returns the raw pre-calibration tick total, so the two
- * callers can never disagree on the counter math). The raw total is an ESTIMATE (@57 counts motion ticks,
- * not validated steps), not cloud/clinical parity.
+ * `step_motion_counter@57` is a CUMULATIVE u16 motion counter: it climbs for both locomotion and some
+ * non-step wrist motion, and wraps at 65536. On classed WHOOP 5/MG records, the increment ending at each
+ * sample is counted only when the strap labels that sample walk (1) or run (2); still (0) and unknown are
+ * rejected. A wholly unclassed legacy window retains the old counter-only estimate so pre-migration history
+ * remains readable. The caller applies its per-user `stepTicksPerStep` calibration afterwards. The result is
+ * still an estimate, not cloud/clinical parity.
  *
  * Byte-for-byte twin of the Swift `StepsCounter.stepsInWindow`.
  */
 object StepsCounter {
-    /**
-     * The largest wrap-aware increment treated as real motion between two adjacent 1 Hz records. A delta
-     * at/above this is a big time-gap / disconnect boundary between sync sessions (or a firmware reboot,
-     * byte-indistinguishable from a u16 wrap), NOT real steps — dropped so gaps don't inflate the total.
-     * Real 1 Hz motion never ticks this fast between adjacent records. (#132/#276/#316)
-     */
+    private val LOCOMOTION_ACTIVITY_CLASSES = setOf(1, 2)
+
+    internal fun hasActivityClasses(samples: List<StepSample>): Boolean =
+        samples.any { it.activityClass != null }
+
+    internal fun shouldCountDelta(activityClass: Int?, hasActivityClasses: Boolean): Boolean =
+        !hasActivityClasses || activityClass in LOCOMOTION_ACTIVITY_CLASSES
+
+    /** Absolute reboot/wrap guard retained independently from the rate plausibility gate below. */
     const val MAX_STEP_DELTA = 512
 
+    /** Four ticks/second is already 240 steps/minute. A larger one-second increment is wrist motion,
+     * corruption or delayed counter publication, not plausible gait. The allowance scales with the real
+     * timestamp gap so seven ticks across two seconds survive a missing 1 Hz record. */
+    const val MAX_TICKS_PER_SECOND = 4
+
+    internal fun isPlausibleDelta(previousTs: Long, currentTs: Long, delta: Int): Boolean {
+        if (delta !in 1 until MAX_STEP_DELTA) return false
+        val elapsed = currentTs - previousTs
+        if (elapsed <= 0L) return false
+        val rateAllowance = if (elapsed >= MAX_STEP_DELTA / MAX_TICKS_PER_SECOND) {
+            MAX_STEP_DELTA - 1L
+        } else {
+            elapsed * MAX_TICKS_PER_SECOND
+        }
+        return delta.toLong() <= rateAllowance
+    }
+
     /**
-     * Raw wrap-aware motion-tick total across [samples] — the sum of positive consecutive
-     * `step_motion_counter@57` increments in `[1, MAX_STEP_DELTA)`. Sorts by `ts` internally, so the caller
-     * may pass an unsorted window (already filtered to the range it cares about). Returns `null` when there
-     * are fewer than two samples or no forward movement (so "no data" stays distinct from a real zero). The
-     * caller applies its `stepTicksPerStep` calibration to the returned ticks.
+     * Raw wrap-aware locomotion-tick total across [samples]. When any sample carries [StepSample.activityClass],
+     * each positive increment is attributed to the later sample and retained only for walk/run. When the
+     * whole window is legacy-unclassed, all valid increments retain the historical counter-only fallback.
+     * Sorts by `ts` internally and returns `null` for fewer than two samples or no retained movement.
      */
     fun stepsInWindow(samples: List<StepSample>): Int? {
         val sorted = samples.sortedBy { it.ts }
         if (sorted.size < 2) return null
+        val hasActivityClasses = hasActivityClasses(sorted)
         var total = 0
         for (i in 1 until sorted.size) {
             val delta = (sorted[i].counter - sorted[i - 1].counter) and 0xFFFF // wrap-aware u16 increment
-            if (delta in 1 until MAX_STEP_DELTA) total += delta // ignore a delta >= 512 (gap/reset)
+            val isLocomotion = shouldCountDelta(sorted[i].activityClass, hasActivityClasses)
+            if (isLocomotion && isPlausibleDelta(sorted[i - 1].ts, sorted[i].ts, delta)) total += delta
         }
         return if (total > 0) total else null
     }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3021,6 +3021,7 @@ class WhoopBleClient(
                         // persists the nightly @82 mean as "spo2_candidate" in metricSeries.
                         spo2CandidateDisplay = NoopPrefs.spo2CandidateDisplay(context),
                         effortMethod = NoopPrefs.effortMethod(context),
+                        dayCycleMode = NoopPrefs.dayCycleMode(context),
                     )
                 }.onSuccess {
                     // Advance the shared watermark so the next 15-min tick sees no change and skips (#836).

--- a/android/app/src/main/java/com/noop/data/BackupSettings.kt
+++ b/android/app/src/main/java/com/noop/data/BackupSettings.kt
@@ -57,6 +57,7 @@ object BackupSettingsCodec {
         "units.temperature" to Kind.STRING,
         "units.skinTempDisplay" to Kind.STRING,   // #1846, carried like the other display units
         "effort.scale" to Kind.STRING,
+        "dayCycle.mode" to Kind.STRING,
         // The ONE layout pref carried (#today-hosted-cards): the Trends/Sleep cards the user chose to host
         // in Today, a JSON [String] of ids. Unlike section order, this is a deliberate composition the user
         // built and expects across a restore. Its POSITION (the addedCards slot in today.sectionOrder) is
@@ -154,6 +155,9 @@ object BackupSettingsBridge {
         if (noop.contains(UnitPrefs.KEY_EFFORT_SCALE)) {
             noop.getString(UnitPrefs.KEY_EFFORT_SCALE, null)?.let { values["effort.scale"] = it }
         }
+        if (noop.contains(NoopPrefs.KEY_DAY_CYCLE_MODE)) {
+            noop.getString(NoopPrefs.KEY_DAY_CYCLE_MODE, null)?.let { values["dayCycle.mode"] = it }
+        }
         if (noop.contains(HostedCardPrefs.KEY_SELECTION)) {
             noop.getString(HostedCardPrefs.KEY_SELECTION, null)?.let { values[HostedCardPrefs.KEY_SELECTION] = it }
         }
@@ -198,6 +202,7 @@ object BackupSettingsBridge {
             else editor.putString(NoopPrefs.KEY_SKIN_TEMP_DISPLAY, raw)
         }
         (values["effort.scale"] as? String)?.let { editor.putString(UnitPrefs.KEY_EFFORT_SCALE, it) }
+        (values["dayCycle.mode"] as? String)?.let { editor.putString(NoopPrefs.KEY_DAY_CYCLE_MODE, it) }
         (values[HostedCardPrefs.KEY_SELECTION] as? String)?.let { editor.putString(HostedCardPrefs.KEY_SELECTION, it) }
         // #1361: restore custom behaviours — write the names to the legacy custom key, clear stale hidden,
         // and drop the v2 blob so the next catalog load re-migrates them (restart-gated, #57). Mirrors iOS.

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -262,6 +262,12 @@ interface WhoopDao : DeviceRegistryDao {
         if (provenance.isNotEmpty()) upsertScoreInputProvenance(provenance)
     }
 
+    @Query(
+        "DELETE FROM metricSeries WHERE deviceId = :deviceId AND day >= :from AND day <= :to " +
+            "AND `key` = :key"
+    )
+    suspend fun deleteMetricSeriesKeyInRange(deviceId: String, from: String, to: String, key: String)
+
     /**
      * Replace a computed scoring window atomically. If any score or provenance write fails, Room rolls
      * the whole transaction back, so an old score can never be labelled with a newer provider. VO₂max's
@@ -276,6 +282,8 @@ interface WhoopDao : DeviceRegistryDao {
         dailyMetrics: List<DailyMetric>,
         metricPoints: List<MetricSeriesRow>,
         provenance: List<ScoreInputProvenanceRow>,
+        replaceMetricKeys: List<String> = emptyList(),
+        replaceMetricSourceIds: List<String> = listOf(deviceId),
     ) {
         // #1196: a scoring pass that produced NO computed daily rows must NOT wipe the persisted window.
         // That happens transiently during a reconnect+offload storm (a pass runs over a still-incomplete
@@ -288,6 +296,9 @@ interface WhoopDao : DeviceRegistryDao {
         if (dailyMetrics.isEmpty()) return
         deleteDailyMetricsInRange(deviceId, from, to)
         deleteScoreInputProvenanceInRange(deviceId, from, to)
+        for (sourceId in replaceMetricSourceIds) {
+            for (key in replaceMetricKeys) deleteMetricSeriesKeyInRange(sourceId, from, to, key)
+        }
         upsertDailyMetrics(dailyMetrics)
         if (metricPoints.isNotEmpty()) upsertMetricSeries(metricPoints)
         if (provenance.isNotEmpty()) upsertScoreInputProvenance(provenance)
@@ -493,6 +504,54 @@ interface WhoopDao : DeviceRegistryDao {
     )
     suspend fun stepSamples(deviceId: String, from: Long, to: Long, limit: Int): List<StepSample>
 
+    /** One predecessor for a half-open physiological-cycle scan. Device-scoped by construction. */
+    @Query(
+        "SELECT * FROM stepSample WHERE deviceId = :deviceId AND ts < :onset " +
+            "ORDER BY ts DESC LIMIT 1"
+    )
+    suspend fun stepSampleBefore(deviceId: String, onset: Long): StepSample?
+
+    /** Stable activity-class mode for the complete cycle; it must never be re-decided per page. */
+    @Query(
+        "SELECT EXISTS(SELECT 1 FROM stepSample WHERE deviceId = :deviceId " +
+            "AND ts >= :onset AND ts < :endExclusive AND activityClass IS NOT NULL LIMIT 1)"
+    )
+    suspend fun hasStepActivityClasses(deviceId: String, onset: Long, endExclusive: Long): Boolean
+
+    /** PK-index seek: never aggregate-scan the whole cycle merely to find its first sample. */
+    @Query(
+        "SELECT ts FROM stepSample WHERE deviceId = :deviceId " +
+            "AND ts >= :onset AND ts < :endExclusive ORDER BY ts ASC LIMIT 1"
+    )
+    suspend fun firstStepTimestamp(
+        deviceId: String,
+        onset: Long,
+        endExclusive: Long,
+    ): Long?
+
+    /** PK-index seek paired with [firstStepTimestamp]; warm candidate coverage stays O(log n). */
+    @Query(
+        "SELECT ts FROM stepSample WHERE deviceId = :deviceId " +
+            "AND ts >= :onset AND ts < :endExclusive ORDER BY ts DESC LIMIT 1"
+    )
+    suspend fun lastStepTimestamp(
+        deviceId: String,
+        onset: Long,
+        endExclusive: Long,
+    ): Long?
+
+    /** Keyset page for [afterExclusive, endExclusive); avoids both OFFSET and the legacy 200k cap. */
+    @Query(
+        "SELECT * FROM stepSample WHERE deviceId = :deviceId AND ts > :afterExclusive " +
+            "AND ts < :endExclusive ORDER BY ts ASC LIMIT :limit"
+    )
+    suspend fun stepSamplesPage(
+        deviceId: String,
+        afterExclusive: Long,
+        endExclusive: Long,
+        limit: Int,
+    ): List<StepSample>
+
     /** The strap's OWN banked band sleep_state (#175) in [from, to], ascending. Feeds the Deep Timeline
      *  band-state track and the per-session grid the H7 re-onset confirm guard reads. */
     @Query(
@@ -583,6 +642,12 @@ interface WhoopDao : DeviceRegistryDao {
             "ORDER BY day ASC"
     )
     suspend fun dailyMetricsRange(deviceId: String, from: String, to: String): List<DailyMetric>
+
+    @Query(
+        "SELECT * FROM dailyMetric WHERE deviceId = :deviceId AND day >= :from AND day <= :to " +
+            "ORDER BY day ASC"
+    )
+    fun dailyMetricsRangeFlow(deviceId: String, from: String, to: String): Flow<List<DailyMetric>>
 
     /**
      * Delete a source's cached daily rows whose day-key is in [from, to] (inclusive, yyyy-MM-dd
@@ -689,6 +754,17 @@ interface WhoopDao : DeviceRegistryDao {
         from: String,
         to: String,
     ): List<MetricSeriesRow>
+
+    @Query(
+        "SELECT * FROM metricSeries WHERE deviceId = :deviceId AND key = :key AND day >= :from AND day <= :to " +
+            "ORDER BY day ASC"
+    )
+    fun metricSeriesFlow(
+        deviceId: String,
+        key: String,
+        from: String,
+        to: String,
+    ): Flow<List<MetricSeriesRow>>
 
     /** Distinct metric keys present for a device, sorted ascending (Swift metricKeys, v9). */
     @Query("SELECT DISTINCT key FROM metricSeries WHERE deviceId = :deviceId ORDER BY key ASC")

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -317,11 +317,17 @@ data class InsertCounts(
     val gravity: Int = 0,
 )
 
+data class StepTimestampCoverage(val firstTs: Long?, val lastTs: Long?)
+
+internal fun newlyInsertedStepTimestamps(timestamps: List<Long>, rowIds: List<Long>): List<Long> =
+    timestamps.zip(rowIds).mapNotNull { (ts, id) -> ts.takeIf { id != -1L } }
+
 /** Monotonic event revisions for Test Centre repository-backed readouts. Counts move only after Room
  * reports at least one newly inserted relevant row; duplicate/no-op inserts leave them unchanged. */
 internal data class ReadoutDataRevisions(
     val sleepSamples: Long = 0,
     val battery: Long = 0,
+    val steps: Long = 0,
 )
 
 internal fun advanceReadoutDataRevisions(
@@ -330,7 +336,34 @@ internal fun advanceReadoutDataRevisions(
 ): ReadoutDataRevisions = current.copy(
     sleepSamples = current.sleepSamples + if (inserted.hr > 0 || inserted.gravity > 0) 1 else 0,
     battery = current.battery + if (inserted.battery > 0) 1 else 0,
+    steps = current.steps + if (inserted.steps > 0) 1 else 0,
 )
+
+/** Process-local because the cycle cache is process-local too; keyed by device and UTC day. */
+internal class StepDataRevisionIndex {
+    private val utcDaySeconds = 86_400L
+    private var nextRevision = 0L
+    private val byOwnerDay = HashMap<Pair<String, Long>, Long>()
+
+    @Synchronized
+    fun record(deviceId: String, stepTimestamps: List<Long>, insertedRows: Int) {
+        if (insertedRows <= 0) return
+        nextRevision++
+        for (ts in stepTimestamps) {
+            byOwnerDay[deviceId to Math.floorDiv(ts, utcDaySeconds)] = nextRevision
+        }
+    }
+
+    @Synchronized
+    fun signature(deviceId: String, onset: Long, endExclusive: Long): String {
+        if (endExclusive <= onset) return ""
+        val first = Math.floorDiv(onset, utcDaySeconds)
+        val last = Math.floorDiv(endExclusive - 1L, utcDaySeconds)
+        return (first..last).joinToString(",") { day ->
+            "$day:${byOwnerDay[deviceId to day] ?: 0L}"
+        }
+    }
+}
 
 /**
  * A compact snapshot of how much history each source holds, for the Data Sources "Freshness
@@ -408,6 +441,7 @@ class WhoopRepository(
     val batteryRevision: StateFlow<Long> = _batteryRevision.asStateFlow()
     private val readoutRevisionLock = Any()
     private var readoutRevisions = ReadoutDataRevisions()
+    private val stepRevisionIndex = StepDataRevisionIndex()
 
     constructor(db: WhoopDatabase) : this(
         dao = db.whoopDao(),
@@ -467,7 +501,7 @@ class WhoopRepository(
     ): InsertCounts {
         if (streams.isEmpty) return InsertCounts()
 
-        val counts = transactor.run {
+        val result = transactor.run {
             insertWithinTransaction(
                 streams = streams,
                 deviceId = deviceId,
@@ -475,7 +509,9 @@ class WhoopRepository(
                 v18AuxPruneEveryRows = v18AuxPruneEveryRows,
             )
         }
+        val counts = result.counts
         publishReadoutRevisions(counts)
+        stepRevisionIndex.record(deviceId, result.insertedStepTimestamps, counts.steps)
         return counts
     }
 
@@ -488,13 +524,22 @@ class WhoopRepository(
         }
     }
 
+    /** Bounded process-local cache witness; duplicate rows do not advance because InsertCounts is zero. */
+    fun stepDataRevisionSignature(deviceId: String, onset: Long, endExclusive: Long): String =
+        stepRevisionIndex.signature(deviceId, onset, endExclusive)
+
     /** All DAO writes for one decoded chunk share the Room transaction opened by [insert]. */
+    private data class InsertResult(
+        val counts: InsertCounts,
+        val insertedStepTimestamps: List<Long>,
+    )
+
     private suspend fun insertWithinTransaction(
         streams: StreamBatch,
         deviceId: String,
         v18AuxRetentionRows: Int,
         v18AuxPruneEveryRows: Int,
-    ): InsertCounts {
+    ): InsertResult {
         val hrIds = if (streams.hr.isEmpty()) emptyList() else
             dao.insertHr(streams.hr.map { HrSample(deviceId, it.ts, it.bpm) })
         val rrIds = if (streams.rr.isEmpty()) emptyList() else
@@ -584,7 +629,7 @@ class WhoopRepository(
         }
 
         // OnConflictStrategy.IGNORE returns -1 for skipped (already-present) rows; count the inserts.
-        return InsertCounts(
+        val counts = InsertCounts(
             hr = hrIds.countInserted() + ppgHrIds.countInserted(),
             rr = rrIds.countInserted(),
             events = evIds.countInserted(),
@@ -594,6 +639,10 @@ class WhoopRepository(
             steps = stepIds.countInserted(),
             resp = respIds.countInserted(),
             gravity = gravIds.countInserted(),
+        )
+        return InsertResult(
+            counts,
+            newlyInsertedStepTimestamps(streams.steps.map { it.ts }, stepIds),
         )
     }
 
@@ -630,9 +679,30 @@ class WhoopRepository(
         dailyMetrics: List<DailyMetric>,
         metricPoints: List<MetricSeriesRow>,
         provenance: List<ScoreInputProvenanceRow>,
+        replaceMetricKeys: List<String> = emptyList(),
+        replaceMetricSourceIds: List<String> = listOf(deviceId),
     ) = dao.replaceComputedScoreWindow(
-        deviceId, from, to, dailyMetrics, metricPoints, provenance
+        deviceId, from, to, dailyMetrics, metricPoints, provenance,
+        replaceMetricKeys, replaceMetricSourceIds,
     )
+
+    /** Computed-only daily rows; unlike daysMerged this can never substitute imported/calendar steps. */
+    suspend fun computedDailyUnion(activeStrapId: String, from: String, to: String): List<DailyMetric> =
+        unionByDay(computedSourceIds(activeStrapId).map { dao.dailyMetricsRange(it, from, to) })
+
+    fun computedDailyUnionFlow(activeStrapId: String, from: String, to: String): Flow<List<DailyMetric>> =
+        unionDaysFlow(computedSourceIds(activeStrapId).map { dao.dailyMetricsRangeFlow(it, from, to) })
+
+    fun metricSeriesComputedUnionFlow(
+        activeStrapId: String,
+        key: String,
+        from: String,
+        to: String,
+    ): Flow<List<MetricSeriesRow>> {
+        val flows = computedSourceIds(activeStrapId).map { dao.metricSeriesFlow(it, key, from, to) }
+        return if (flows.size == 1) flows[0]
+        else combine(flows) { rows -> mergeComputedSeriesUnion(rows.toList()) }
+    }
 
     suspend fun scoreInputSource(deviceId: String, day: String, key: String): String? =
         dao.scoreInputSource(deviceId, day, key)
@@ -1180,6 +1250,25 @@ class WhoopRepository(
 
     suspend fun stepSamples(deviceId: String, from: Long, to: Long, limit: Int = DEFAULT_LIMIT) =
         dao.stepSamples(deviceId, from, to, limit)
+
+    suspend fun stepSampleBefore(deviceId: String, onset: Long): StepSample? =
+        dao.stepSampleBefore(deviceId, onset)
+
+    suspend fun hasStepActivityClasses(deviceId: String, onset: Long, endExclusive: Long): Boolean =
+        dao.hasStepActivityClasses(deviceId, onset, endExclusive)
+
+    suspend fun stepTimestampCoverage(deviceId: String, onset: Long, endExclusive: Long): StepTimestampCoverage =
+        StepTimestampCoverage(
+            firstTs = dao.firstStepTimestamp(deviceId, onset, endExclusive),
+            lastTs = dao.lastStepTimestamp(deviceId, onset, endExclusive),
+        )
+
+    suspend fun stepSamplesPage(
+        deviceId: String,
+        afterExclusive: Long,
+        endExclusive: Long,
+        limit: Int,
+    ): List<StepSample> = dao.stepSamplesPage(deviceId, afterExclusive, endExclusive, limit)
 
     /**
      * The strap's OWN band sleep_state samples (#175) in [from, to] as (ts, state) pairs, ascending. Feeds

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1858,18 +1858,19 @@ class WhoopRepository(
         return dedupSleepBlocks(ids.flatMap { dao.sleepSessions(it, from, to, limit) })
     }
 
-    /** Workouts over the read-side UNION of the active strap id AND the canonical "my-whoop" (#814 twin of
-     *  [hrSamplesUnion] / [sleepSessionsUnion]): a re-added / newly-paired strap owns "whoop-<uuid>" while
+    /** Workouts over every registered WHOOP (active first, archived retained) plus canonical "my-whoop",
+     *  matching [hrSamplesUnion] / [sleepSessionsUnion]. A re-added strap owns "whoop-<uuid>" while
      *  imports + prior data live under "my-whoop", so a read pinned to a SINGLE id strands the other's
      *  workouts — the Workouts screen then reads empty while Data Sources (which queries "my-whoop") shows
      *  them (#28). Exact-duplicate rows are dropped on the (startTs, sport) natural key, active-strap-first. */
     suspend fun workoutsUnion(deviceId: String, from: Long, to: Long, limit: Int = DEFAULT_LIMIT): List<WorkoutRow> =
-        dedupWorkoutsByKey(importedSourceIds(deviceId).flatMap { dao.workouts(it, from, to, limit) })
+        dedupWorkoutsByKey(rawWhoopSourceIds(deviceId).flatMap { dao.workouts(it, from, to, limit) })
 
     /** The COMPUTED ("-noop") twin of [workoutsUnion] for detected workouts (the engine writes detected
      *  sessions under "<importedDeviceId>-noop"), across the computed union ids. */
     suspend fun detectedWorkoutsUnion(deviceId: String, from: Long, to: Long, limit: Int = DEFAULT_LIMIT): List<WorkoutRow> =
-        dedupWorkoutsByKey(computedSourceIds(deviceId).flatMap { dao.workouts(it, from, to, limit) })
+        dedupWorkoutsByKey(rawWhoopSourceIds(deviceId).map { "$it-noop" }
+            .flatMap { dao.workouts(it, from, to, limit) })
 
     /** Cached daily metrics for the inclusive day range [from, to] (YYYY-MM-DD), oldest first. */
     suspend fun dailyMetrics(deviceId: String, from: String, to: String): List<DailyMetric> =

--- a/android/app/src/main/java/com/noop/ui/ActiveDayCycle.kt
+++ b/android/app/src/main/java/com/noop/ui/ActiveDayCycle.kt
@@ -1,0 +1,36 @@
+package com.noop.ui
+
+import com.noop.analytics.DayCycleMode
+import com.noop.data.DailyMetric
+import com.noop.data.MetricSeriesRow
+
+/** Active boundary shared by every additive Today metric; steps are optional on counter-less devices. */
+internal data class ActiveDayCycle(val ownerDay: String, val onsetTs: Long, val steps: Int?)
+
+internal fun effectiveActiveStrapId(published: String?, fallback: String): String =
+    published?.takeIf { it.isNotBlank() } ?: fallback
+
+/** The one shared start used by every live additive metric on Today. */
+internal fun activeDayCycleStart(
+    mode: DayCycleMode,
+    confirmedOrSyntheticOnset: Long?,
+    calendarStart: Long,
+): Long = if (mode == DayCycleMode.SLEEP_ONSET) confirmedOrSyntheticOnset ?: calendarStart else calendarStart
+
+/** Resolve the newest valid boundary even when this device has no raw step counter. */
+internal fun resolveActiveDayCycle(
+    visibleDays: List<DailyMetric>,
+    computedDays: List<DailyMetric>,
+    onsetMarkers: List<MetricSeriesRow>,
+    nowSeconds: Long,
+): ActiveDayCycle? {
+    val visibleDayKeys = visibleDays.mapTo(HashSet()) { it.day }
+    val computedByDay = computedDays.associateBy { it.day }
+    return onsetMarkers.asSequence()
+        .filter { it.value.isFinite() && it.value > 0.0 && it.value <= nowSeconds.toDouble() }
+        .filter { it.day in visibleDayKeys }
+        .maxByOrNull { it.value }
+        ?.let { marker ->
+            ActiveDayCycle(marker.day, marker.value.toLong(), computedByDay[marker.day]?.steps)
+        }
+}

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -65,6 +65,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.isActive

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -13,6 +13,7 @@ import com.noop.analytics.Baselines
 import com.noop.analytics.IllnessSignalEngine
 import com.noop.analytics.IllnessWatch
 import com.noop.analytics.IntelligenceEngine
+import com.noop.analytics.DayCycleIntelligenceIntegration
 import com.noop.analytics.CircadianEngine
 import com.noop.analytics.V5HealthSignals
 import com.noop.analytics.RegistryDayOwnerSource
@@ -52,6 +53,7 @@ import com.noop.protocol.CommandNumber
 import com.noop.widget.WidgetSnapshot
 import com.noop.widget.WidgetSnapshotStore
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
@@ -61,6 +63,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.isActive
@@ -719,6 +723,33 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     /**
+     * Today's measured steps follow the newest confirmed sleep-onset cycle, independently of the fixed
+     * 04:00 presentation day used by the rest of the dashboard. The marker is persisted by the analytics
+     * pass, so this survives process death and a delayed sleep detection can switch the tile retroactively.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    internal val activeDayCycle: StateFlow<ActiveDayCycle?> = activeStrapIdFlow
+        .map { effectiveActiveStrapId(it, deviceId) }
+        .distinctUntilChanged()
+        .flatMapLatest { activeId ->
+            repository.recentDaysMergedFlow(activeId).flatMapLatest days@{ days ->
+                if (days.isEmpty()) return@days flowOf(null)
+                val from = days.first().day
+                val to = days.last().day
+                combine(
+                    repository.computedDailyUnionFlow(activeId, from, to),
+                    repository.metricSeriesComputedUnionFlow(
+                        activeId, DayCycleIntelligenceIntegration.ONSET_KEY, from, to,
+                    ),
+                ) { computed, markers ->
+                    resolveActiveDayCycle(days, computed, markers, System.currentTimeMillis() / 1_000L)
+                }
+            }
+        }
+        .flowOn(Dispatchers.IO)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+
+    /**
      * #103: SpO₂ candidate @82 nightly mean per day, loaded from the "spo2_candidate" metricSeries
      * key (written by IntelligenceEngine when the experimental display toggle is ON). Empty when the
      * toggle is OFF or no candidate data exists — the Blood O₂ tile then behaves exactly as before.
@@ -1187,6 +1218,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                         // persists the nightly @82 mean as "spo2_candidate" in metricSeries.
                         spo2CandidateDisplay = NoopPrefs.spo2CandidateDisplay(appContext),
                         effortMethod = NoopPrefs.effortMethod(appContext),
+                        dayCycleMode = NoopPrefs.dayCycleMode(appContext),
                     )
                     // analyzeRecent now hops to Dispatchers.Default; a scope cancellation surfaces as a
                     // CancellationException that runCatching would otherwise swallow, breaking the loop's
@@ -1825,6 +1857,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                 // #103: SpO₂ candidate @82 display toggle — same flag the 15-min loop reads.
                 spo2CandidateDisplay = NoopPrefs.spo2CandidateDisplay(appContext),
                 effortMethod = NoopPrefs.effortMethod(appContext),
+                dayCycleMode = NoopPrefs.dayCycleMode(appContext),
             )
         }.onFailure { if (it is kotlin.coroutines.cancellation.CancellationException) throw it }
     }
@@ -2674,6 +2707,12 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
      *  which the toggle's own copy promises. Twin of the iOS onChange handler. */
     fun setBanisterEffort(enabled: Boolean) {
         NoopPrefs.setBanisterEffort(appContext, enabled)
+        viewModelScope.launch { rescoreAfterEdit() }
+    }
+
+    /** Change the shared boundary used by additive daily metrics and immediately rebuild affected rows. */
+    fun setDayCycleMode(mode: com.noop.analytics.DayCycleMode) {
+        NoopPrefs.setDayCycleMode(appContext, mode)
         viewModelScope.launch { rescoreAfterEdit() }
     }
 

--- a/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
@@ -91,14 +91,6 @@ fun CoupledScreen(
     val today by vm.today.collectAsStateWithLifecycle()
     val days by vm.recentDays.collectAsStateWithLifecycle()
 
-    // #614: the Workouts stat must match the Workouts screen, not DailyMetric.exerciseCount (which counts
-    // only strap-DETECTED bouts — a Health-Connect import with auto-detect off read as 0 while the Workouts
-    // screen showed it). vm.workouts is the SAME deduped, dismissed-filtered, all-source list the Workouts
-    // screen renders; loadWorkouts() isn't triggered by opening Coupled, so kick it here (idempotent,
-    // mirrors InsightsScreen).
-    LaunchedEffect(Unit) { vm.loadWorkouts() }
-    val allWorkouts by vm.workouts.collectAsStateWithLifecycle()
-
     // Last night's sleep sessions (imported + computed-only), the SAME resolution SleepScreen uses, keyed on
     // `days` so a sync/import reloads. Only needed for the bed-wake span footnote.
     var sleeps by remember { mutableStateOf<List<SleepSession>>(emptyList()) }
@@ -144,14 +136,8 @@ fun CoupledScreen(
         resolveTodayRow(days, logicalKey, localKey) ?: today
     }
     val todayKey = todayRow?.day ?: logicalKey
-    // #614: count TODAY's workouts by their START's logical day (the SAME 04:00-rollover key DailyMetric.day
-    // uses), so the Coupled stat equals the Workouts overview for today.
-    val workoutsToday = remember(allWorkouts, todayKey) {
-        allWorkouts.count {
-            logicalDay(java.time.Instant.ofEpochSecond(it.startTs).atZone(java.time.ZoneId.systemDefault()))
-                .toString() == todayKey
-        }
-    }
+    // Materialized from the same all-source physiological cycle as Effort, calories, HR, and steps.
+    val workoutsToday = todayRow?.exerciseCount ?: 0
     val context = LocalContext.current
     val hrvEpoch = remember { NoopPrefs.of(context).getLong(Baselines.hrvBaselineEpochKey, 0L).toDouble() }
     // #1458: carry through the SAME helper Today uses, not a local re-derivation. The local copy was
@@ -239,7 +225,7 @@ fun CoupledScreen(
             dayStrain21 = dayStrain21,
             recovery = recovery,
             calories = todayRow?.activeKcalEst,
-            workouts = workoutsToday,   // #614: real workout count (all sources), not exerciseCount
+            workouts = workoutsToday,
         )
         SleepCard(
             sleepPerformance = sleepPerformance,

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -256,6 +256,19 @@ object NoopPrefs {
     /** "Keep connected in the background", drives [com.noop.ble.WhoopConnectionService]. Default on. */
     const val KEY_BACKGROUND_CONNECTION = "noop.backgroundConnection"
 
+    /** Boundary used by additive daily metrics. Sleep onset is the product default; midnight restores
+     * the conventional civil-day view. Naps never become boundaries. */
+    const val KEY_DAY_CYCLE_MODE = "noop.dayCycleMode"
+
+    fun dayCycleMode(context: Context): com.noop.analytics.DayCycleMode =
+        com.noop.analytics.DayCycleMode.fromPersisted(
+            of(context).getString(KEY_DAY_CYCLE_MODE, null),
+        )
+
+    fun setDayCycleMode(context: Context, mode: com.noop.analytics.DayCycleMode) {
+        of(context).edit().putString(KEY_DAY_CYCLE_MODE, mode.persistedValue).apply()
+    }
+
     /** "Continuous HRV capture", when on (AND background connection is on), NOOP holds the dense
      *  realtime HR stream armed even with no Live screen open, so the strap banks beat-to-beat R-R 24/7
      *  for far better overnight HRV/recovery/sleep. Uses more battery (continuous HR streaming). Default

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -120,6 +120,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.noop.BuildConfig
 import com.noop.analytics.Baselines
+import com.noop.analytics.DayCycleMode
 import com.noop.analytics.HrZoneSet
 import com.noop.analytics.HrZones
 import com.noop.analytics.UserProfile
@@ -564,6 +565,12 @@ fun SettingsScreen(
     // that feeds Charge from tonight onward; the standing analyze loop picks it up on its next pass.
     // Fixes a baseline poisoned by a bad first week (worn sick, or early nights that anchored too high).
     var showRecalibrateConfirm by remember { mutableStateOf(false) }
+
+    // Steps-estimate calibration screen (WHOOP 4.0), reached from the Profile card's "Steps estimate"
+    // tap-through. Mirrors the macOS StepsCalibrationSheet: honest explainer + current fit + a recent
+    // estimated-vs-phone table + a manual coefficient override. Full-screen Dialog like the guide above.
+    var showStepsCalibration by remember { mutableStateOf(false) }
+    var dayCycleMode by remember { mutableStateOf(NoopPrefs.dayCycleMode(context)) }
 
     // Whether the "Advanced" disclosure (experimental probes, diagnostics, raw-sensor export, Trends
     // report) is expanded. Default FALSE so a first-run user lands on the everyday sections instead of
@@ -1173,6 +1180,39 @@ fun SettingsScreen(
                 }
                 Text(
                     uiString(R.string.l10n_settings_screen_for_a_whoop_4_0_which_df865854),
+                    style = NoopType.footnote,
+                    color = Palette.textTertiary,
+                )
+            }
+        }
+
+        // --- Daily cycle ---
+        SettingsCard(
+            icon = Icons.Filled.Autorenew,
+            title = uiString(R.string.settings_day_cycle_title),
+            blurb = uiString(R.string.settings_day_cycle_description),
+        ) {
+            Column {
+                SettingsFormRow(label = uiString(R.string.settings_day_cycle_starts)) {
+                    SegmentedPillControl(
+                        items = listOf(DayCycleMode.SLEEP_ONSET, DayCycleMode.MIDNIGHT),
+                        selection = dayCycleMode,
+                        label = {
+                            if (it == DayCycleMode.SLEEP_ONSET) uiString(R.string.settings_day_cycle_sleep)
+                            else uiString(R.string.settings_day_cycle_midnight)
+                        },
+                        onSelect = {
+                            dayCycleMode = it
+                            vm.setDayCycleMode(it)
+                        },
+                    )
+                }
+                Text(
+                    text = if (dayCycleMode == DayCycleMode.SLEEP_ONSET) {
+                        uiString(R.string.settings_day_cycle_sleep_description)
+                    } else {
+                        uiString(R.string.settings_day_cycle_midnight_description)
+                    },
                     style = NoopType.footnote,
                     color = Palette.textTertiary,
                 )

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -150,6 +150,7 @@ import com.noop.analytics.ChargeDriver
 import com.noop.analytics.ChargeDriverLabel
 import com.noop.analytics.ChargeDriverUnit
 import com.noop.analytics.ChargeDriverVerdict
+import com.noop.analytics.DayCycleMode
 import com.noop.analytics.HydrationGoal
 import com.noop.analytics.HydrationStore
 import com.noop.analytics.ReadinessEngine
@@ -306,6 +307,7 @@ fun TodayScreen(
     val today by viewModel.today.collectAsStateWithLifecycle()
     val alert by viewModel.healthAlert.collectAsStateWithLifecycle()
     val days by viewModel.recentDays.collectAsStateWithLifecycle()
+    val activeDayCycle by viewModel.activeDayCycle.collectAsStateWithLifecycle()
     val spo2CandidateByDay by viewModel.spo2CandidateByDay.collectAsStateWithLifecycle()
     val v5Signals by viewModel.v5Signals.collectAsStateWithLifecycle()
     val cycleEnabled by viewModel.cycleTrackingEnabled.collectAsStateWithLifecycle()
@@ -392,6 +394,17 @@ fun TodayScreen(
     val historicalMetric = remember(days, selectedDayKey) { days.lastOrNull { it.day == selectedDayKey } }
     val displayMetric = remember(today, historicalMetric, selectedDayOffset) {
         if (selectedDayOffset == 0) today ?: historicalMetric else historicalMetric
+    }
+    val dayCycleMode = NoopPrefs.dayCycleMode(LocalContext.current)
+    // Steps alone use the physiological sleep-onset cycle. Every other field stays on the dashboard's
+    // existing logical-day row; past-day navigation continues to show the persisted historical cycle row.
+    val stepResolvedDisplayMetric = remember(displayMetric, activeDayCycle, selectedDayOffset, dayCycleMode) {
+        val cycleSteps = activeDayCycle?.steps
+        if (selectedDayOffset == 0 && dayCycleMode == DayCycleMode.SLEEP_ONSET && cycleSteps != null) {
+            displayMetric?.copy(steps = cycleSteps)
+        } else {
+            displayMetric
+        }
     }
     // Keep the explicit calendar date visible alongside Today/Yesterday so the logical-day remap stays
     // honest, between midnight and 04:00 "Today" still points at the prior calendar date, and showing
@@ -920,11 +933,15 @@ fun TodayScreen(
     // fabricated number. Any past day → null (the gauge uses the stored strain). Keyed on the same inputs
     // as the day-scoped loads so it reloads as the selector moves and as a sync/import grows the HR window.
     var liveTodayStrain by remember { mutableStateOf<Double?>(null) }
-    LaunchedEffect(days, selectedDayKey, selectedDayOffset) {
+    LaunchedEffect(days, selectedDayKey, selectedDayOffset, activeDayCycle, dayCycleMode) {
         liveTodayStrain = if (selectedDayOffset == 0) {
             val zone = ZoneId.systemDefault()
-            val start = selectedDay.atStartOfDay(zone).toEpochSecond()
             val now = System.currentTimeMillis() / 1000
+            val start = activeDayCycleStart(
+                mode = dayCycleMode,
+                confirmedOrSyntheticOnset = activeDayCycle?.onsetTs,
+                calendarStart = selectedDay.atStartOfDay(zone).toEpochSecond(),
+            )
             // #908: read the active strap ∪ canonical "my-whoop" union, NOT a hardcoded "my-whoop". A strap
             // re-added through the device manager banks its live HR under its own fresh id, so a pinned
             // "my-whoop" read returned nothing and Effort integrated to 0 off an empty series. Single-WHOOP
@@ -934,10 +951,11 @@ fun TodayScreen(
             // effMaxHR resolution matches AnalyticsEngine: manual HR-max override first, else Tanaka from age.
             val effMaxHR = profileStore.hrMaxOverride.takeIf { it > 0 }?.toDouble()
                 ?: if (profileStore.age > 0) StrainScorer.tanakaHRmax(profileStore.age.toDouble()) else null
+            val restingHr = displayMetric?.restingHr?.toDouble() ?: StrainScorer.defaultRestingHR
             StrainScorer.strain(
                 hr = todayHr,
                 maxHR = effMaxHR,
-                restingHR = displayMetric?.restingHr?.toDouble() ?: StrainScorer.defaultRestingHR,
+                restingHR = restingHr,
                 method = NoopPrefs.effortMethod(context),
                 sex = profileStore.sex,
             )
@@ -1563,7 +1581,7 @@ fun TodayScreen(
                             }
                             Box(modifier = Modifier.fillMaxWidth().staggeredAppear(stagger)) {
                                 MetricGrid(
-                                    d = displayMetric,
+                                    d = stepResolvedDisplayMetric,
                                     w = window,
                                     recoveryCalibration = recoveryCalibration,
                                     lastScoredCharge = lastScoredCharge,
@@ -1579,7 +1597,7 @@ fun TodayScreen(
                                     profileWeightKg = profileWeightKg,
                                     importedStepsForDay = importedStepsForDay,
                                     estimatedStepsForDay = stepsEstForDay,
-                                    caloriesForDay = caloriesByDay[selectedDayKey],   // #616: imported-first per day
+                                    caloriesForDay = caloriesByDay[selectedDayKey],
                                     caloriesSpark = caloriesSpark,                    // #616: imported-first trend
                                     stepActivityClassForDay = stepActivityClassForDay,
                                     stepsEstimateCaption = stepsEstimateCaption(profileStore),
@@ -1625,7 +1643,7 @@ fun TodayScreen(
                         // section emits no item; visibleDashboardCards is the loop-level filtered list.
                         TodaySection.YOUR_CARDS -> YourCardsSection(
                             cards = visibleDashboardCards,
-                            day = displayMetric,
+                            day = stepResolvedDisplayMetric,
                             carriedDay = lastScoredRecoveryDay,
                             vitalsDay = lastVitalsDay,
                             spo2Day = lastSpo2Day,

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -151,6 +151,7 @@ import com.noop.analytics.ChargeDriverLabel
 import com.noop.analytics.ChargeDriverUnit
 import com.noop.analytics.ChargeDriverVerdict
 import com.noop.analytics.DayCycleMode
+import com.noop.analytics.DayCycleIntelligenceIntegration
 import com.noop.analytics.HydrationGoal
 import com.noop.analytics.HydrationStore
 import com.noop.analytics.ReadinessEngine
@@ -1630,7 +1631,8 @@ fun TodayScreen(
                             modifier = Modifier.fillMaxWidth().staggeredAppear(stagger),
                             verticalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
-                            HeartRateTrendCard(viewModel, days, selectedDay, todayDate, displayMetric, effortScale, effortForDay)
+                            HeartRateTrendCard(viewModel, days, selectedDay, todayDate, displayMetric,
+                                effortScale, effortForDay, dayCycleMode)
                         }
                         // The three hero vitals, HRV / Resting HR / Respiratory. Carried day (#543).
                         TodaySection.RECOVERY_VITALS -> Box(modifier = Modifier.fillMaxWidth().staggeredAppear(stagger)) {
@@ -5565,6 +5567,7 @@ private fun HeartRateTrendCard(
     // #1001: the day's resolved Effort for the chart's edge badge. It read `displayMetric.strain` — the
     // daily row — so on an active morning the badge trailed the hero ring by the whole morning's load.
     effortForDay: Double? = null,
+    dayCycleMode: DayCycleMode = DayCycleMode.SLEEP_ONSET,
 ) {
     // "Today" here is the LOGICAL day (rolls at 04:00 local), so in the small hours after midnight the
     // trend keeps the evening's curve, window start at the logical day's own midnight, "since midnight"
@@ -5600,12 +5603,22 @@ private fun HeartRateTrendCard(
     val live by viewModel.live.collectAsStateWithLifecycle()
     // Re-load when the day list changes (an import updates it), when the day selector moves, and, via the
     // sync tokens, when a strap offload banks fresh HR samples for the current window. Also on first compose.
-    LaunchedEffect(days, selectedDay, today, live.lastSyncAt, live.syncChunksThisSession) {
+    LaunchedEffect(days, selectedDay, today, live.lastSyncAt, live.syncChunksThisSession, dayCycleMode) {
         val zone = ZoneId.systemDefault()
-        val start = selectedDay.atStartOfDay(zone).toEpochSecond()
+        val calendarStart = selectedDay.atStartOfDay(zone).toEpochSecond()
         val nextStart = selectedDay.plusDays(1).atStartOfDay(zone).toEpochSecond()
         val now = System.currentTimeMillis() / 1000
-        val end = if (selectedDay == today) now else (nextStart - 1)
+        val calendarEnd = if (selectedDay == today) now else (nextStart - 1)
+        val markerRows = if (dayCycleMode == DayCycleMode.SLEEP_ONSET) runCatching {
+            viewModel.repo.metricSeriesComputedUnion(
+                viewModel.activeStrapId, DayCycleIntelligenceIntegration.ONSET_KEY,
+                selectedDay.toString(), selectedDay.plusDays(1).toString(),
+            )
+        }.getOrDefault(emptyList()) else emptyList()
+        val start = markerRows.firstOrNull { it.day == selectedDay.toString() }?.value?.toLong()
+            ?: calendarStart
+        val end = markerRows.firstOrNull { it.day == selectedDay.plusDays(1).toString() }?.value?.toLong()
+            ?.minus(1L) ?: calendarEnd
         // #908: the Today HR curve reads the active strap ∪ canonical "my-whoop" union, NOT a hardcoded
         // "my-whoop". A strap re-added via the device manager banks live HR under its own fresh id, so a
         // pinned read showed the "no heart rate banked yet today" empty state. Single-WHOOP ⇒ one id ⇒ same.

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2684,4 +2684,11 @@
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Für diese Nächte liegt keine gemessene Temperatur vor — angezeigt wird die Abweichung von deinem Basiswert. Eine Synchronisierung bewertet die letzten Nächte neu und ergänzt sie.</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">Es werden nur Nächte mit gemessener Temperatur angezeigt; für die übrigen wurde nur eine Abweichung vom Basiswert erfasst.</string>
     <string name="l10n_today_screen_this_night_was_staged_from_heart_rate_4d0f1f9b">Diese Nacht wurde allein anhand der Herzfrequenz ausgewertet, ohne aufgezeichnete Bewegung, daher konnten Herzfrequenzvariabilität und Ruheherzfrequenz nicht gemessen werden. Ein nicht vollständig gekoppelter Strap ist die übliche Ursache.</string>
+    <string name="settings_day_cycle_title">Tageszyklus</string>
+    <string name="settings_day_cycle_description">Lege fest, wann Schritte und die laufende Anstrengung neu beginnen. Nickerchen starten keinen neuen Tag.</string>
+    <string name="settings_day_cycle_starts">Tagesbeginn</string>
+    <string name="settings_day_cycle_sleep">Hauptschlaf</string>
+    <string name="settings_day_cycle_midnight">00:00</string>
+    <string name="settings_day_cycle_sleep_description">Standard. Der Zyklus folgt dem Beginn deines erkannten Hauptschlafs. Bei fehlenden oder unzuverlässigen Schlafdaten verwendet NOOP ersatzweise die lokale Mitternacht.</string>
+    <string name="settings_day_cycle_midnight_description">Verwendet einen herkömmlichen lokalen Kalendertag von 00:00 bis 00:00 Uhr.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2671,4 +2671,11 @@
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">No hay temperatura medida para estas noches: se muestra la diferencia respecto a tu referencia. Una sincronización vuelve a analizar las noches recientes y la completa.</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">Solo se muestran las noches con temperatura medida; en las demás solo se registró la diferencia respecto a la referencia.</string>
     <string name="l10n_today_screen_this_night_was_staged_from_heart_rate_4d0f1f9b">Esta noche se analizó solo a partir de la frecuencia cardíaca, sin movimiento registrado, por lo que no se pudieron medir la variabilidad de la frecuencia cardíaca ni la frecuencia cardíaca en reposo. La causa habitual es una correa que no está totalmente emparejada.</string>
+    <string name="settings_day_cycle_title">Ciclo diario</string>
+    <string name="settings_day_cycle_description">Elige cuándo se reinician los pasos y el Esfuerzo en curso. Las siestas nunca empiezan un nuevo día.</string>
+    <string name="settings_day_cycle_starts">El día empieza</string>
+    <string name="settings_day_cycle_sleep">Sueño principal</string>
+    <string name="settings_day_cycle_midnight">00:00</string>
+    <string name="settings_day_cycle_sleep_description">Predeterminado. El ciclo sigue el inicio del sueño principal detectado. Si faltan datos de sueño o no son fiables, se usa la medianoche local.</string>
+    <string name="settings_day_cycle_midnight_description">Usa un día natural local convencional de 00:00 a 00:00.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2670,4 +2670,11 @@
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Aucune température mesurée pour ces nuits — l\'écart par rapport à votre référence est affiché. Une synchronisation réévalue les nuits récentes et le complète.</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">Seules les nuits avec une température mesurée sont affichées ; les autres n\'ont enregistré qu\'un écart par rapport à la référence.</string>
     <string name="l10n_today_screen_this_night_was_staged_from_heart_rate_4d0f1f9b">Cette nuit a été analysée à partir de la seule fréquence cardiaque, sans mouvement enregistré, donc la variabilité de la fréquence cardiaque et la fréquence cardiaque au repos n\'ont pas pu être mesurées. La cause habituelle est un bracelet qui n\'est pas entièrement appairé.</string>
+    <string name="settings_day_cycle_title">Cycle journalier</string>
+    <string name="settings_day_cycle_description">Choisissez quand les pas et l’Effort en cours repartent de zéro. Les siestes ne commencent jamais une nouvelle journée.</string>
+    <string name="settings_day_cycle_starts">Début de la journée</string>
+    <string name="settings_day_cycle_sleep">Sommeil principal</string>
+    <string name="settings_day_cycle_midnight">00:00</string>
+    <string name="settings_day_cycle_sleep_description">Par défaut. Le cycle suit le début du sommeil principal détecté. Si les données de sommeil sont absentes ou peu fiables, l’heure locale de minuit est utilisée.</string>
+    <string name="settings_day_cycle_midnight_description">Utilise une journée civile locale classique de 00:00 à 00:00.</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2675,4 +2675,11 @@
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Brak zmierzonej temperatury dla tych nocy — pokazano różnicę względem Twojej wartości bazowej. Synchronizacja ponownie przelicza ostatnie noce i ją uzupełnia.</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">Pokazywane są tylko noce ze zmierzoną temperaturą; w pozostałych zapisano jedynie różnicę względem wartości bazowej.</string>
     <string name="l10n_today_screen_this_night_was_staged_from_heart_rate_4d0f1f9b">Ta noc została opracowana wyłącznie na podstawie tętna, bez zarejestrowanego ruchu, więc nie udało się zmierzyć zmienności rytmu serca ani tętna spoczynkowego. Zwykłą przyczyną jest opaska, która nie jest w pełni sparowana.</string>
+    <string name="settings_day_cycle_title">Cykl dobowy</string>
+    <string name="settings_day_cycle_description">Wybierz, kiedy kroki i bieżący Wysiłek zaczynają się od nowa. Drzemki nigdy nie rozpoczynają nowego dnia.</string>
+    <string name="settings_day_cycle_starts">Początek dnia</string>
+    <string name="settings_day_cycle_sleep">Główny sen</string>
+    <string name="settings_day_cycle_midnight">00:00</string>
+    <string name="settings_day_cycle_sleep_description">Domyślnie. Cykl rozpoczyna się wraz z wykrytym głównym snem. Gdy brakuje wiarygodnych danych o śnie, używana jest lokalna północ.</string>
+    <string name="settings_day_cycle_midnight_description">Używa zwykłego lokalnego dnia kalendarzowego od 00:00 do 00:00.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2663,4 +2663,11 @@
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Sem temperatura medida para estas noites — a mostrar a diferença em relação à sua referência. Uma sincronização reavalia as noites recentes e preenche-a.</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">Só são mostradas as noites com temperatura medida; as restantes registaram apenas a diferença em relação à referência.</string>
     <string name="l10n_today_screen_this_night_was_staged_from_heart_rate_4d0f1f9b">Esta noite foi analisada apenas a partir da frequência cardíaca, sem movimento registado, pelo que não foi possível medir a variabilidade da frequência cardíaca nem a frequência cardíaca em repouso. A causa habitual é uma pulseira que não está totalmente emparelhada.</string>
+    <string name="settings_day_cycle_title">Ciclo diário</string>
+    <string name="settings_day_cycle_description">Escolhe quando os passos e o Esforço em curso recomeçam. As sestas nunca iniciam um novo dia.</string>
+    <string name="settings_day_cycle_starts">O dia começa</string>
+    <string name="settings_day_cycle_sleep">Sono principal</string>
+    <string name="settings_day_cycle_midnight">00:00</string>
+    <string name="settings_day_cycle_sleep_description">Predefinição. O ciclo segue o início do sono principal detetado. Se os dados de sono estiverem em falta ou não forem fiáveis, é usada a meia-noite local.</string>
+    <string name="settings_day_cycle_midnight_description">Usa um dia civil local convencional das 00:00 às 00:00.</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -2555,4 +2555,11 @@
         <item quantity="other">%1$s тренировки</item>
     </plurals>
     <string name="l10n_today_screen_this_night_was_staged_from_heart_rate_4d0f1f9b">Эта ночь определена только по пульсу, без записанного движения, поэтому вариабельность сердечного ритма и пульс в покое измерить не удалось. Обычная причина — ремешок, сопряжённый не полностью.</string>
+    <string name="settings_day_cycle_title">Суточный цикл</string>
+    <string name="settings_day_cycle_description">Выберите, когда начинается новый отсчёт шагов и текущей нагрузки. Дневной сон не начинает новый день.</string>
+    <string name="settings_day_cycle_starts">Начало дня</string>
+    <string name="settings_day_cycle_sleep">Основной сон</string>
+    <string name="settings_day_cycle_midnight">00:00</string>
+    <string name="settings_day_cycle_sleep_description">По умолчанию цикл начинается с обнаруженного основного сна. Если данные о сне отсутствуют или ненадёжны, используется местная полночь.</string>
+    <string name="settings_day_cycle_midnight_description">Используется обычный местный календарный день с 00:00 до 00:00.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2584,4 +2584,11 @@
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">这些夜晚没有实测温度，显示的是与基线的差值。同步后会重新计算近期夜晚并补上。</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">仅显示有实测温度的夜晚；其余夜晚只记录了与基线的差值。</string>
     <string name="l10n_today_screen_this_night_was_staged_from_heart_rate_4d0f1f9b">这一晚仅根据心率推算，没有记录到动作，因此无法测量心率变异性和静息心率。通常的原因是手环尚未完全配对。</string>
+    <string name="settings_day_cycle_title">每日周期</string>
+    <string name="settings_day_cycle_description">选择步数和进行中的体力消耗何时重新开始。小睡不会开始新的一天。</string>
+    <string name="settings_day_cycle_starts">一天开始于</string>
+    <string name="settings_day_cycle_sleep">主要睡眠</string>
+    <string name="settings_day_cycle_midnight">00:00</string>
+    <string name="settings_day_cycle_sleep_description">默认。周期从检测到的主要睡眠开始。睡眠数据缺失或不可靠时，将使用当地午夜。</string>
+    <string name="settings_day_cycle_midnight_description">使用从 00:00 到次日 00:00 的常规当地日历日。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2697,4 +2697,11 @@
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">No measured temperature for these nights — showing the difference from your baseline. A sync re-scores recent nights and fills it in.</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">Only nights with a measured temperature are shown; the others recorded a baseline difference only.</string>
     <string name="l10n_today_screen_this_night_was_staged_from_heart_rate_4d0f1f9b">This night was staged from heart rate alone, with no motion recorded, so HRV and resting heart rate could not be measured. A strap that is not fully paired is the usual cause.</string>
+    <string name="settings_day_cycle_title">Day cycle</string>
+    <string name="settings_day_cycle_description">Choose when steps and in-progress Effort start over. Naps never start a new day.</string>
+    <string name="settings_day_cycle_starts">Day starts</string>
+    <string name="settings_day_cycle_sleep">Main sleep</string>
+    <string name="settings_day_cycle_midnight">00:00</string>
+    <string name="settings_day_cycle_sleep_description">Default. The cycle follows the beginning of your detected main sleep. Missing or unreliable sleep data falls back to local midnight.</string>
+    <string name="settings_day_cycle_midnight_description">Uses a conventional local calendar day from 00:00 to 00:00.</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2702,6 +2702,6 @@
     <string name="settings_day_cycle_starts">Day starts</string>
     <string name="settings_day_cycle_sleep">Main sleep</string>
     <string name="settings_day_cycle_midnight">00:00</string>
-    <string name="settings_day_cycle_sleep_description">Default. The cycle follows the beginning of your detected main sleep. Missing or unreliable sleep data falls back to local midnight.</string>
+    <string name="settings_day_cycle_sleep_description">Default. The cycle follows the beginning of your detected main sleep. Before a main sleep is detected, local midnight is used.</string>
     <string name="settings_day_cycle_midnight_description">Uses a conventional local calendar day from 00:00 to 00:00.</string>
 </resources>

--- a/android/app/src/test/java/com/noop/analytics/DayCycleResolverTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DayCycleResolverTest.kt
@@ -1,0 +1,40 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DayCycleResolverTest {
+    @Test fun sleepOnsetIsTheDefaultPersistedMode() {
+        assertEquals(DayCycleMode.SLEEP_ONSET, DayCycleMode.fromPersisted(null))
+        assertEquals(DayCycleMode.SLEEP_ONSET, DayCycleMode.fromPersisted("unknown"))
+    }
+
+    @Test fun fallbackUsesTheFirstMidnightAtLeastEighteenHoursAfterOnset() {
+        val monday2300 = 23 * 3_600L
+        assertEquals(2 * 86_400L, DayCycleResolver.fallbackMidnightAfter(monday2300, 0))
+    }
+
+    @Test fun reliableAllNighterStaysOpenUntilTheAbsoluteCap() {
+        val sleep = DayCycleWindow("night", 0, 0, "1970-01-01", DayCycleWindow.Source.DETECTED_SLEEP)
+        assertEquals(
+            DayCycleWindow.Source.DETECTED_SLEEP,
+            DayCycleResolver.activeWindow(DayCycleMode.SLEEP_ONSET, sleep, 39 * 3_600L, 0, true).source,
+        )
+        assertEquals(
+            DayCycleWindow.Source.SYNTHETIC_MIDNIGHT,
+            DayCycleResolver.activeWindow(DayCycleMode.SLEEP_ONSET, sleep, 40 * 3_600L, 0, true).source,
+        )
+    }
+
+    @Test fun missingCoverageFallsBackButMidnightModeNeverNeedsSleep() {
+        val sleep = DayCycleWindow("night", 23 * 3_600L, 0, "1970-01-02", DayCycleWindow.Source.DETECTED_SLEEP)
+        assertEquals(
+            DayCycleWindow.Source.SYNTHETIC_MIDNIGHT,
+            DayCycleResolver.activeWindow(DayCycleMode.SLEEP_ONSET, sleep, 2 * 86_400L + 60, 0, false).source,
+        )
+        assertEquals(
+            DayCycleWindow.Source.CALENDAR,
+            DayCycleResolver.activeWindow(DayCycleMode.MIDNIGHT, sleep, 2 * 86_400L + 60, 0, true).source,
+        )
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/DayCycleResolverTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DayCycleResolverTest.kt
@@ -26,12 +26,16 @@ class DayCycleResolverTest {
         )
     }
 
-    @Test fun missingCoverageFallsBackButMidnightModeNeverNeedsSleep() {
+    @Test fun missingCoverageKeepsSleepOnsetCycleOpenAcrossMidnight() {
         val sleep = DayCycleWindow("night", 23 * 3_600L, 0, "1970-01-02", DayCycleWindow.Source.DETECTED_SLEEP)
         assertEquals(
-            DayCycleWindow.Source.SYNTHETIC_MIDNIGHT,
+            DayCycleWindow.Source.DETECTED_SLEEP,
             DayCycleResolver.activeWindow(DayCycleMode.SLEEP_ONSET, sleep, 2 * 86_400L + 60, 0, false).source,
         )
+    }
+
+    @Test fun midnightModeStillResetsAtCalendarMidnight() {
+        val sleep = DayCycleWindow("night", 23 * 3_600L, 0, "1970-01-02", DayCycleWindow.Source.DETECTED_SLEEP)
         assertEquals(
             DayCycleWindow.Source.CALENDAR,
             DayCycleResolver.activeWindow(DayCycleMode.MIDNIGHT, sleep, 2 * 86_400L + 60, 0, true).source,

--- a/android/app/src/test/java/com/noop/analytics/PhysiologicalStepsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/PhysiologicalStepsTest.kt
@@ -1,6 +1,5 @@
 package com.noop.analytics
 
-import com.noop.data.StepSample
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -8,45 +7,6 @@ import java.time.LocalDateTime
 import java.time.ZoneOffset
 
 class PhysiologicalStepsTest {
-
-    private fun step(ts: Long, counter: Int, activityClass: Int? = 1) =
-        StepSample(deviceId = "my-whoop", ts = ts, counter = counter, activityClass = activityClass)
-
-    @Test fun resetsAtMainSleepOnsetButKeepsRealNightWalking() {
-        val samples = listOf(
-            step(90, 100),       // predecessor before the new physiological cycle
-            step(100, 104),      // delta belongs to the previous cycle
-            step(200, 104, 0),   // asleep/still
-            step(201, 106, 1),   // gets up and walks
-            step(202, 109, 1),
-            step(300, 112, 0),   // non-locomotion delta must still be ignored
-        )
-
-        assertEquals(5, PhysiologicalSteps.stepsInCycle(samples, onsetInclusive = 101, endExclusive = 400))
-    }
-
-    @Test fun nextMainSleepOnsetClosesTheCycle() {
-        val samples = listOf(
-            step(99, 10),
-            step(110, 12),
-            step(199, 15),
-            step(200, 18), // attributed to the next cycle because its timestamp is the boundary
-        )
-
-        assertEquals(5, PhysiologicalSteps.stepsInCycle(samples, onsetInclusive = 100, endExclusive = 200))
-    }
-
-    @Test fun emptyCycleIsZeroRatherThanMissingOnceAnOnsetExists() {
-        assertEquals(
-            0,
-            PhysiologicalSteps.stepsInCycle(
-                listOf(step(99, 10), step(120, 10)),
-                onsetInclusive = 100,
-                endExclusive = 200,
-            ),
-        )
-        assertNull(PhysiologicalSteps.stepsInCycle(emptyList(), onsetInclusive = 100, endExclusive = 200))
-    }
 
     @Test fun nextOnsetWinsAndCurrentCycleFallsBackToNow() {
         val starts = mapOf(
@@ -130,26 +90,6 @@ class PhysiologicalStepsTest {
         assertEquals(PhysiologicalSteps.SleepKind.NAP, classified["nap"])
     }
 
-    @Test fun missingSleepKeepsTheLastCycleOpenAndLateSleepAdvancesIt() {
-        val first = PhysiologicalSteps.CycleBoundary("night-a", onset = 1_000)
-
-        assertEquals(first, PhysiologicalSteps.advanceBoundary(first, emptyList(), now = 3_000))
-        assertEquals(
-            PhysiologicalSteps.CycleBoundary("night-b", onset = 2_000),
-            PhysiologicalSteps.advanceBoundary(
-                first,
-                listOf(
-                    PhysiologicalSteps.SleepBlock(
-                        onset = 2_000,
-                        end = 2_800,
-                        id = "night-b",
-                    ),
-                ),
-                now = 3_000,
-            ),
-        )
-    }
-
     @Test fun historicalWindowsHaveOnlySleepBoundariesAndKeepTheLastOneOpen() {
         assertEquals(
             listOf(
@@ -162,46 +102,6 @@ class PhysiologicalStepsTest {
                     PhysiologicalSteps.CycleBoundary("night-b", 2_000),
                 ),
                 now = 9_000,
-            ),
-        )
-    }
-
-    @Test fun napOnlyObservationCannotReplaceTheOpenCycle() {
-        val first = PhysiologicalSteps.CycleBoundary("night-a", onset = 1_000)
-
-        assertEquals(
-            first,
-            PhysiologicalSteps.advanceBoundary(
-                first,
-                listOf(
-                    PhysiologicalSteps.SleepBlock(
-                        onset = 2_000,
-                        end = 8_000,
-                        id = "long-daytime-nap",
-                    ),
-                ),
-                now = 9_000,
-                tzOffsetSeconds = 43_200,
-            ),
-        )
-    }
-
-    @Test fun editedOnsetMovesTheSameBoundaryWithoutCreatingAnotherCycle() {
-        val previous = PhysiologicalSteps.CycleBoundary("night-a", onset = 1_000)
-
-        assertEquals(
-            PhysiologicalSteps.CycleBoundary("night-a", onset = 900),
-            PhysiologicalSteps.advanceBoundary(
-                previous,
-                listOf(
-                    PhysiologicalSteps.SleepBlock(
-                        onset = 1_000,
-                        end = 2_000,
-                        id = "night-a",
-                        editedOnset = 900,
-                    ),
-                ),
-                now = 3_000,
             ),
         )
     }
@@ -278,18 +178,4 @@ class PhysiologicalStepsTest {
         )
     }
 
-    @Test fun paginatedCountCarriesItsPredecessorAcrossMoreThanTwoHundredThousandRows() {
-        val samples = (0..200_005).map { i -> step(ts = i.toLong(), counter = i and 0xFFFF) }
-        var state = PhysiologicalSteps.newCycleCount(hasActivityClasses = true)
-        samples.chunked(10_000).forEach { page ->
-            state = PhysiologicalSteps.accumulateCyclePage(
-                state,
-                page,
-                onsetInclusive = 1,
-                endExclusive = 200_006,
-            )
-        }
-
-        assertEquals(200_005, PhysiologicalSteps.finishCycleCount(state))
-    }
 }

--- a/android/app/src/test/java/com/noop/analytics/PhysiologicalStepsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/PhysiologicalStepsTest.kt
@@ -1,0 +1,295 @@
+package com.noop.analytics
+
+import com.noop.data.StepSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+class PhysiologicalStepsTest {
+
+    private fun step(ts: Long, counter: Int, activityClass: Int? = 1) =
+        StepSample(deviceId = "my-whoop", ts = ts, counter = counter, activityClass = activityClass)
+
+    @Test fun resetsAtMainSleepOnsetButKeepsRealNightWalking() {
+        val samples = listOf(
+            step(90, 100),       // predecessor before the new physiological cycle
+            step(100, 104),      // delta belongs to the previous cycle
+            step(200, 104, 0),   // asleep/still
+            step(201, 106, 1),   // gets up and walks
+            step(202, 109, 1),
+            step(300, 112, 0),   // non-locomotion delta must still be ignored
+        )
+
+        assertEquals(5, PhysiologicalSteps.stepsInCycle(samples, onsetInclusive = 101, endExclusive = 400))
+    }
+
+    @Test fun nextMainSleepOnsetClosesTheCycle() {
+        val samples = listOf(
+            step(99, 10),
+            step(110, 12),
+            step(199, 15),
+            step(200, 18), // attributed to the next cycle because its timestamp is the boundary
+        )
+
+        assertEquals(5, PhysiologicalSteps.stepsInCycle(samples, onsetInclusive = 100, endExclusive = 200))
+    }
+
+    @Test fun emptyCycleIsZeroRatherThanMissingOnceAnOnsetExists() {
+        assertEquals(
+            0,
+            PhysiologicalSteps.stepsInCycle(
+                listOf(step(99, 10), step(120, 10)),
+                onsetInclusive = 100,
+                endExclusive = 200,
+            ),
+        )
+        assertNull(PhysiologicalSteps.stepsInCycle(emptyList(), onsetInclusive = 100, endExclusive = 200))
+    }
+
+    @Test fun nextOnsetWinsAndCurrentCycleFallsBackToNow() {
+        val starts = mapOf(
+            "2026-08-20" to 1_000L,
+            "2026-08-21" to 2_000L,
+        )
+
+        assertEquals(2_000L, PhysiologicalSteps.cycleEnd("2026-08-20", starts, now = 2_500L))
+        assertEquals(2_500L, PhysiologicalSteps.cycleEnd("2026-08-21", starts, now = 2_500L))
+    }
+
+    @Test fun mainSleepOnsetWinsOverASeparateDaytimeNap() {
+        fun utc(day: Int, hour: Int, minute: Int = 0) =
+            LocalDateTime.of(2026, 8, day, hour, minute).toEpochSecond(ZoneOffset.UTC)
+        val blocks = listOf(
+            PhysiologicalSteps.SleepBlock(utc(21, 14), utc(21, 15)),
+            PhysiologicalSteps.SleepBlock(utc(21, 2, 57), utc(21, 10, 15)),
+        )
+
+        assertEquals(
+            utc(21, 2, 57),
+            PhysiologicalSteps.mainSleepOnset(blocks, tzOffsetSeconds = 0, habitualMidsleepSec = null),
+        )
+    }
+
+    @Test fun napOnlyNeverOpensACycleEvenWhenItIsLong() {
+        fun utc(hour: Int) = LocalDateTime.of(2026, 8, 21, hour, 0).toEpochSecond(ZoneOffset.UTC)
+
+        assertNull(
+            PhysiologicalSteps.mainSleepOnset(
+                listOf(
+                    PhysiologicalSteps.SleepBlock(
+                        utc(1),
+                        utc(9),
+                        kind = PhysiologicalSteps.SleepKind.NAP,
+                    ),
+                    PhysiologicalSteps.SleepBlock(
+                        utc(13),
+                        utc(19),
+                        kind = PhysiologicalSteps.SleepKind.NAP,
+                    ),
+                ),
+                tzOffsetSeconds = 0,
+                habitualMidsleepSec = null,
+            ),
+        )
+    }
+
+    @Test fun productionClassificationRejectsShortOrDaytimeNapShapes() {
+        fun utc(hour: Int) = LocalDateTime.of(2026, 8, 21, hour, 0).toEpochSecond(ZoneOffset.UTC)
+        val classified = PhysiologicalSteps.classifyForCycle(
+            listOf(
+                PhysiologicalSteps.SleepBlock(utc(1), utc(8), id = "night"),
+                // Keep this clearly separate from the main night. A fragment beginning at 09:00 after
+                // a one-hour wake is deliberately treated as a continuation of an interrupted night.
+                PhysiologicalSteps.SleepBlock(utc(11), utc(13), id = "short"),
+                PhysiologicalSteps.SleepBlock(utc(13), utc(19), id = "daytime"),
+            ),
+            tzOffsetSeconds = 0,
+            habitualMidsleepSec = null,
+        ).associate { it.id to it.kind }
+
+        assertEquals(PhysiologicalSteps.SleepKind.MAIN_SLEEP, classified["night"])
+        assertEquals(PhysiologicalSteps.SleepKind.NAP, classified["short"])
+        assertEquals(PhysiologicalSteps.SleepKind.NAP, classified["daytime"])
+    }
+
+    @Test fun longDaytimeNapCannotHideAShorterValidMainNight() {
+        fun utc(day: Int, hour: Int, minute: Int = 0) =
+            LocalDateTime.of(2026, 8, day, hour, minute).toEpochSecond(ZoneOffset.UTC)
+        val classified = PhysiologicalSteps.classifyForCycle(
+            listOf(
+                PhysiologicalSteps.SleepBlock(utc(21, 1), utc(21, 4, 30), id = "night"),
+                PhysiologicalSteps.SleepBlock(utc(21, 13), utc(21, 19), id = "nap"),
+            ),
+            0,
+            null,
+        ).associate { it.id to it.kind }
+
+        assertEquals(PhysiologicalSteps.SleepKind.MAIN_SLEEP, classified["night"])
+        assertEquals(PhysiologicalSteps.SleepKind.NAP, classified["nap"])
+    }
+
+    @Test fun missingSleepKeepsTheLastCycleOpenAndLateSleepAdvancesIt() {
+        val first = PhysiologicalSteps.CycleBoundary("night-a", onset = 1_000)
+
+        assertEquals(first, PhysiologicalSteps.advanceBoundary(first, emptyList(), now = 3_000))
+        assertEquals(
+            PhysiologicalSteps.CycleBoundary("night-b", onset = 2_000),
+            PhysiologicalSteps.advanceBoundary(
+                first,
+                listOf(
+                    PhysiologicalSteps.SleepBlock(
+                        onset = 2_000,
+                        end = 2_800,
+                        id = "night-b",
+                    ),
+                ),
+                now = 3_000,
+            ),
+        )
+    }
+
+    @Test fun historicalWindowsHaveOnlySleepBoundariesAndKeepTheLastOneOpen() {
+        assertEquals(
+            listOf(
+                PhysiologicalSteps.CycleWindow("night-a", 1_000, 2_000),
+                PhysiologicalSteps.CycleWindow("night-b", 2_000, 9_000),
+            ),
+            PhysiologicalSteps.cycleWindows(
+                listOf(
+                    PhysiologicalSteps.CycleBoundary("night-a", 1_000),
+                    PhysiologicalSteps.CycleBoundary("night-b", 2_000),
+                ),
+                now = 9_000,
+            ),
+        )
+    }
+
+    @Test fun napOnlyObservationCannotReplaceTheOpenCycle() {
+        val first = PhysiologicalSteps.CycleBoundary("night-a", onset = 1_000)
+
+        assertEquals(
+            first,
+            PhysiologicalSteps.advanceBoundary(
+                first,
+                listOf(
+                    PhysiologicalSteps.SleepBlock(
+                        onset = 2_000,
+                        end = 8_000,
+                        id = "long-daytime-nap",
+                    ),
+                ),
+                now = 9_000,
+                tzOffsetSeconds = 43_200,
+            ),
+        )
+    }
+
+    @Test fun editedOnsetMovesTheSameBoundaryWithoutCreatingAnotherCycle() {
+        val previous = PhysiologicalSteps.CycleBoundary("night-a", onset = 1_000)
+
+        assertEquals(
+            PhysiologicalSteps.CycleBoundary("night-a", onset = 900),
+            PhysiologicalSteps.advanceBoundary(
+                previous,
+                listOf(
+                    PhysiologicalSteps.SleepBlock(
+                        onset = 1_000,
+                        end = 2_000,
+                        id = "night-a",
+                        editedOnset = 900,
+                    ),
+                ),
+                now = 3_000,
+            ),
+        )
+    }
+
+    @Test fun ownerSegmentsFollowResolvedCalendarOwnersWithoutCrossDeviceSeams() {
+        assertEquals(
+            listOf(
+                PhysiologicalSteps.OwnerSegment("strap-a", 1_000, 86_400),
+                PhysiologicalSteps.OwnerSegment("strap-b", 86_400, 172_800),
+                PhysiologicalSteps.OwnerSegment("strap-a", 172_800, 200_000),
+            ),
+            PhysiologicalSteps.ownerSegments(
+                PhysiologicalSteps.CycleWindow("night", 1_000, 200_000),
+                ownerByDay = mapOf(
+                    "1970-01-01" to "strap-a",
+                    "1970-01-02" to "strap-b",
+                    "1970-01-03" to "strap-a",
+                ),
+                tzOffsetSeconds = 0,
+                fallbackOwner = "strap-a",
+            ),
+        )
+    }
+
+    @Test fun middayReAddSwitchesOwnersAtRawCoverageBoundaryAndOverlapNeverDoubles() {
+        val window = PhysiologicalSteps.CycleWindow("night", 0, 86_400)
+        assertEquals(
+            listOf(
+                PhysiologicalSteps.OwnerSegment("strap-a", 0, 14 * 3_600L),
+                PhysiologicalSteps.OwnerSegment("strap-b", 14 * 3_600L, 86_400),
+            ),
+            PhysiologicalSteps.ownerSegmentsFromCoverage(
+                window,
+                listOf(
+                    PhysiologicalSteps.OwnerCoverage("strap-a", 0, 86_400, priority = 1),
+                    PhysiologicalSteps.OwnerCoverage("strap-b", 14 * 3_600L, 86_400, priority = 0),
+                ),
+                fallbackOwner = "strap-a",
+            ),
+        )
+        assertEquals(
+            listOf(PhysiologicalSteps.OwnerSegment("strap-b", 0, 86_400)),
+            PhysiologicalSteps.ownerSegmentsFromCoverage(
+                window,
+                listOf(
+                    PhysiologicalSteps.OwnerCoverage("strap-a", 0, 86_400, 1),
+                    PhysiologicalSteps.OwnerCoverage("strap-b", 0, 86_400, 0),
+                ),
+                "strap-a",
+            ),
+        )
+    }
+
+    @Test fun onlyCycleOnsetMayReadAPredecessorNeverANewOwnerSeam() {
+        assertEquals(true, PhysiologicalSteps.shouldReadCounterPredecessor(segmentIndex = 0))
+        assertEquals(false, PhysiologicalSteps.shouldReadCounterPredecessor(segmentIndex = 1))
+        assertEquals(false, PhysiologicalSteps.shouldReadCounterPredecessor(segmentIndex = 2))
+    }
+
+    @Test fun internalRadioGapDoesNotSwitchAwayFromTheHigherPriorityOwner() {
+        // Coverage is deliberately first..last, not a list of sample runs. A radio/sample hole inside
+        // strap-b's observed span therefore creates no seam at which concurrently worn strap-a can win.
+        assertEquals(
+            listOf(PhysiologicalSteps.OwnerSegment("strap-b", 0, 86_400)),
+            PhysiologicalSteps.ownerSegmentsFromCoverage(
+                PhysiologicalSteps.CycleWindow("night", 0, 86_400),
+                listOf(
+                    PhysiologicalSteps.OwnerCoverage("strap-a", 0, 86_400, priority = 1),
+                    // Its first and last samples surround an internal 10-minute radio gap.
+                    PhysiologicalSteps.OwnerCoverage("strap-b", 0, 86_400, priority = 0),
+                ),
+                fallbackOwner = "strap-b",
+            ),
+        )
+    }
+
+    @Test fun paginatedCountCarriesItsPredecessorAcrossMoreThanTwoHundredThousandRows() {
+        val samples = (0..200_005).map { i -> step(ts = i.toLong(), counter = i and 0xFFFF) }
+        var state = PhysiologicalSteps.newCycleCount(hasActivityClasses = true)
+        samples.chunked(10_000).forEach { page ->
+            state = PhysiologicalSteps.accumulateCyclePage(
+                state,
+                page,
+                onsetInclusive = 1,
+                endExclusive = 200_006,
+            )
+        }
+
+        assertEquals(200_005, PhysiologicalSteps.finishCycleCount(state))
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/RegistryDayOwnerSourceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RegistryDayOwnerSourceTest.kt
@@ -215,15 +215,17 @@ class RegistryDayOwnerSourceTest {
     }
 
     @Test
-    fun archivedDeviceIsNotACandidate() = runBlocking {
+    fun archivedDeviceRemainsALowestPriorityHistoricalCandidate() = runBlocking {
         val dao = FakeDao().apply {
             devices["my-whoop"] = device("my-whoop", "WHOOP", SourceKind.liveBLE, DeviceStatus.active)
             devices["old"] = device("old", "Polar", SourceKind.liveBLE, DeviceStatus.archived)
         }
         val src = RegistryDayOwnerSource(registry(dao))
-        val ids = src.candidatePriorities().map { it.first }
-        assertEquals(listOf("my-whoop"), ids) // archived 'old' excluded
-        // With only the active strap and it having NO data, there is no owner (honest gap).
-        assertNull(resolveWith(src, "2026-06-15", mapOf("my-whoop" to false)))
+        val priorities = src.candidatePriorities().toMap()
+        assertEquals(0, priorities["my-whoop"])
+        assertEquals(4, priorities["old"])
+        // Archived history fills only an otherwise uncovered day; live/current sources always win.
+        assertEquals("old", resolveWith(src, "2026-06-15", mapOf("my-whoop" to false, "old" to true)))
+        assertEquals("my-whoop", resolveWith(src, "2026-06-15", mapOf("my-whoop" to true, "old" to true)))
     }
 }

--- a/android/app/src/test/java/com/noop/analytics/SleepAwareStepCounterTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepAwareStepCounterTest.kt
@@ -24,6 +24,9 @@ class SleepAwareStepCounterTest {
 
         assertEquals(StepsCounter.stepsInWindow(samples), SleepAwareStepCounter.stepsInWindow(samples, emptyList()))
         assertEquals(9, SleepAwareStepCounter.stepsInWindow(samples, emptyList()))
+        val detail = SleepAwareStepCounter.count(samples, emptyList())
+        assertEquals(3, detail.rejectedActivityClassTicks)
+        assertEquals(8, detail.rejectedImplausibleTicks)
     }
 
     @Test fun awakeGapInsideSleepCountsWithNormalRules() {

--- a/android/app/src/test/java/com/noop/analytics/SleepAwareStepCounterTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepAwareStepCounterTest.kt
@@ -1,0 +1,155 @@
+package com.noop.analytics
+
+import com.noop.data.GravitySample
+import com.noop.data.StepSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SleepAwareStepCounterTest {
+    private fun step(ts: Long, counter: Int, activityClass: Int? = 1) =
+        StepSample("strap", ts, counter, activityClass)
+
+    private fun sleep(start: Long, end: Long, stages: List<StageSegment> = emptyList()) =
+        DetectedSleep(start, end, 0.9, stages, null, null)
+
+    @Test fun outsideSleepUsesTheNormalCounterRulesExactly() {
+        val samples = listOf(
+            step(0, 100, 0),
+            step(1, 102, 1),
+            step(2, 110, 1), // impossible 8 ticks/s: rejected by StepsCounter too
+            step(4, 117, 2),
+            step(5, 120, 0),
+        )
+
+        assertEquals(StepsCounter.stepsInWindow(samples), SleepAwareStepCounter.stepsInWindow(samples, emptyList()))
+        assertEquals(9, SleepAwareStepCounter.stepsInWindow(samples, emptyList()))
+    }
+
+    @Test fun awakeGapInsideSleepCountsWithNormalRules() {
+        val session = sleep(
+            0, 120,
+            listOf(
+                StageSegment(0, 30, "light"),
+                StageSegment(30, 60, "awake"),
+                StageSegment(60, 120, "deep"),
+            ),
+        )
+        val samples = listOf(step(29, 100), step(30, 101), step(31, 103), step(32, 104))
+
+        // The isolated +1 at t=30 and the following awake deltas are all in an explicitly awake gap.
+        assertEquals(4, SleepAwareStepCounter.stepsInWindow(samples, listOf(session)))
+    }
+
+    @Test fun isolatedWalkClassBedTicksAreRejected() {
+        val session = sleep(0, 180, listOf(StageSegment(0, 180, "light")))
+        val samples = listOf(
+            step(0, 100), step(10, 101), step(11, 102),
+            step(70, 102), step(71, 104),
+            step(150, 104),
+        )
+
+        assertNull(SleepAwareStepCounter.stepsInWindow(samples, listOf(session)))
+        val detail = SleepAwareStepCounter.count(samples, listOf(session))
+        assertEquals(4, detail.rejectedIsolatedSleepTicks)
+        assertEquals(0, detail.totalTicks)
+    }
+
+    @Test fun shortCoherentToiletWalkDuringScoredSleepIsPreservedExactly() {
+        val session = sleep(0, 120, listOf(StageSegment(0, 120, "light")))
+        val samples = buildList {
+            add(step(20, 500))
+            var counter = 500
+            for (second in 21L..30L) {
+                counter += 2
+                add(step(second, counter))
+            }
+        }
+
+        // Ten coherent seconds, twenty raw locomotion ticks. No calibration/conversion belongs here.
+        assertEquals(20, SleepAwareStepCounter.stepsInWindow(samples, listOf(session)))
+        val detail = SleepAwareStepCounter.count(samples, listOf(session))
+        assertEquals(20, detail.acceptedSleepBoutTicks)
+        assertEquals(20, detail.totalTicks)
+    }
+
+    @Test fun coherentSleepBoutFailsSafeWhenGravityIsMissing() {
+        val session = sleep(0, 90, listOf(StageSegment(0, 90, "rem")))
+        val samples = listOf(
+            step(10, 10), step(11, 12), step(12, 14), step(13, 16),
+            step(14, 18), step(15, 20), step(16, 22),
+        )
+
+        assertEquals(12, SleepAwareStepCounter.stepsInWindow(samples, listOf(session), gravity = emptyList()))
+    }
+
+    @Test fun decisionDoesNotDependOnADeviceOrientationVector() {
+        val session = sleep(0, 90, listOf(StageSegment(0, 90, "deep")))
+        val samples = listOf(
+            step(10, 10), step(11, 12), step(12, 14), step(13, 16),
+            step(14, 18), step(15, 20), step(16, 22),
+        )
+        fun gravity(x: Double, y: Double, z: Double) = (10L..16L).map {
+            GravitySample("strap", it, x, y, z)
+        }
+
+        val faceUp = SleepAwareStepCounter.stepsInWindow(samples, listOf(session), gravity(0.0, 0.0, 1.0))
+        val rotated = SleepAwareStepCounter.stepsInWindow(samples, listOf(session), gravity(0.8, -0.6, 0.0))
+        assertEquals(12, faceUp)
+        assertEquals(faceUp, rotated)
+    }
+
+    @Test fun sleepSessionWithoutStagesIsConservativelyTreatedAsSleep() {
+        val samples = listOf(step(10, 100), step(11, 101), step(12, 102))
+        assertNull(SleepAwareStepCounter.stepsInWindow(samples, listOf(sleep(0, 60))))
+    }
+
+    @Test fun pagingKeepsCounterPredecessorAndOpenGaitBout() {
+        val session = sleep(0, 90, listOf(StageSegment(0, 90, "light")))
+        val all = listOf(
+            step(10, 100), step(11, 102), step(12, 104), step(13, 106),
+            step(14, 108), step(15, 110), step(16, 112),
+        )
+        val accumulator = SleepAwareStepCounter.Accumulator(listOf(session), hasActivityClasses = true)
+        accumulator.acceptPage(all.take(4))
+        // Intentional one-row overlap also proves that page boundaries do not double count.
+        accumulator.acceptPage(all.drop(3))
+
+        assertEquals(SleepAwareStepCounter.count(all, listOf(session)), accumulator.finish())
+        assertEquals(12, accumulator.finish().acceptedSleepBoutTicks)
+    }
+
+    @Test fun pagingUsesOneActivityClassModeForTheWholeWindow() {
+        val accumulator = SleepAwareStepCounter.Accumulator(emptyList(), hasActivityClasses = true)
+        accumulator.acceptPage(listOf(step(0, 100, null), step(1, 102, null)))
+        accumulator.acceptPage(listOf(step(2, 104, 1)))
+
+        // Unknown +2 in page one is rejected because a later page proves this is a classed stream.
+        assertEquals(2, accumulator.finish().totalTicks)
+    }
+
+    @Test fun editedBoundsKeepStagesAndTreatNewEdgesAsSleep() {
+        val detected = sleep(100, 200, listOf(StageSegment(100, 200, "light")))
+        val edited = SleepAwareStepCounter.withBounds(detected, start = 90, end = 220)
+        val samples = listOf(
+            step(89, 100), step(90, 101), step(91, 102),
+            step(210, 102), step(211, 104),
+        )
+
+        assertEquals(listOf(StageSegment(100, 200, "light")), edited.stages)
+        assertNull(SleepAwareStepCounter.stepsInWindow(samples, listOf(edited)))
+    }
+
+    @Test fun wakeEditChangesOnlyIntersectingCycleContextSignature() {
+        val before = sleep(100, 180, listOf(StageSegment(100, 180, "light")))
+        val after = SleepAwareStepCounter.withBounds(before, 100, 190)
+        assertEquals(
+            SleepAwareStepCounter.contextSignature(listOf(before), 200, 300),
+            SleepAwareStepCounter.contextSignature(listOf(after), 200, 300),
+        )
+        org.junit.Assert.assertNotEquals(
+            SleepAwareStepCounter.contextSignature(listOf(before), 100, 200),
+            SleepAwareStepCounter.contextSignature(listOf(after), 100, 200),
+        )
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/StepCycleIntegrationPolicyTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StepCycleIntegrationPolicyTest.kt
@@ -119,13 +119,11 @@ class StepCycleIntegrationPolicyTest {
             ),
         )
         fun row(owner: String, ts: Long, counter: Int) = StepSample(owner, ts, counter, activityClass = 1)
-        val aSteps = PhysiologicalSteps.stepsInCycle(
-            listOf(row("strap-a", onset, 100), row("strap-a", onset + 3, 110)), onset, bStarts,
-        )
-        val bSteps = PhysiologicalSteps.stepsInCycle(
-            listOf(row("strap-b", bStarts, 50), row("strap-b", bStarts + 2, 57)), bStarts, cycleEnd,
-        )
-        assertEquals(17, requireNotNull(aSteps) + requireNotNull(bSteps))
+        val a = SleepAwareStepCounter.Accumulator(emptyList(), hasActivityClasses = true)
+            .acceptPage(listOf(row("strap-a", onset, 100), row("strap-a", onset + 3, 110))).finish()
+        val b = SleepAwareStepCounter.Accumulator(emptyList(), hasActivityClasses = true)
+            .acceptPage(listOf(row("strap-b", bStarts, 50), row("strap-b", bStarts + 2, 57))).finish()
+        assertEquals(17, a.totalTicks + b.totalTicks)
     }
 
     @Test fun markerRewriteCleansEveryNamespaceThatRecoveryMayRead() {

--- a/android/app/src/test/java/com/noop/analytics/StepCycleIntegrationPolicyTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StepCycleIntegrationPolicyTest.kt
@@ -1,0 +1,200 @@
+package com.noop.analytics
+
+import com.noop.data.SleepSession
+import com.noop.data.StepSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StepCycleIntegrationPolicyTest {
+    private fun sleep(owner: String, start: Long, end: Long) = SleepSession(
+        deviceId = "$owner-noop",
+        startTs = start,
+        endTs = end,
+        stagesJSON = "[{\"start\":$start,\"end\":$end,\"stage\":\"light\"}]",
+    )
+
+    @Test fun calendarFallbackExistsOnlyBeforeTheFirstConfirmedCycle() {
+        assertEquals(410, DayCycleIntelligenceIntegration.integratedStepValue(410, false, null))
+        assertNull(DayCycleIntelligenceIntegration.integratedStepValue(410, true, null))
+        assertEquals(37, DayCycleIntelligenceIntegration.integratedStepValue(410, true, 37))
+    }
+
+    @Test fun warmUnchangedCycleDoesNotReadStepRowsAgain() {
+        val old = DayCycleIntelligenceIntegration.cacheKey(
+            owner = "strap-a", sleepId = "night-a", onset = 100, end = 200,
+            stepRevision = "20500:7",
+            sleepContextSignature = "100-200:light",
+            contributingDayKeys = listOf("2026-08-20" to "hr:100:199"),
+        )
+        val same = DayCycleIntelligenceIntegration.cacheKey(
+            owner = "strap-a", sleepId = "night-a", onset = 100, end = 200,
+            stepRevision = "20500:7",
+            sleepContextSignature = "100-200:light",
+            contributingDayKeys = listOf("2026-08-20" to "hr:100:199"),
+        )
+
+        assertFalse(DayCycleIntelligenceIntegration.shouldRecount(old, same))
+    }
+
+    @Test fun activeDayChangeOrBoundaryEditRecountsOnlyTheAffectedCycle() {
+        fun key(onset: Long, witness: String) = DayCycleIntelligenceIntegration.cacheKey(
+            owner = "strap-a", sleepId = "night-a", onset = onset, end = 500,
+            stepRevision = "20500:7",
+            sleepContextSignature = "100-200:light",
+            contributingDayKeys = listOf("2026-08-21" to witness),
+        )
+        val old = key(100, "hr:100:400")
+
+        assertTrue(DayCycleIntelligenceIntegration.shouldRecount(old, key(100, "hr:120:499")))
+        assertTrue(DayCycleIntelligenceIntegration.shouldRecount(old, key(110, "hr:100:400")))
+        assertTrue(DayCycleIntelligenceIntegration.shouldRecount(null, old))
+    }
+
+    @Test fun cacheIdentityIsDeviceScoped() {
+        fun key(owner: String) = DayCycleIntelligenceIntegration.cacheKey(
+            owner = owner, sleepId = "night-a", onset = 100, end = 200,
+            stepRevision = "20500:7",
+            sleepContextSignature = "100-200:light",
+            contributingDayKeys = listOf("2026-08-20" to "same-witness"),
+        )
+
+        assertTrue(DayCycleIntelligenceIntegration.shouldRecount(key("strap-a"), key("strap-b")))
+    }
+
+    @Test fun aRealStepInsertRevisionInvalidatesButAnUnchangedRevisionDoesNot() {
+        fun key(revision: String) = DayCycleIntelligenceIntegration.cacheKey(
+            owner = "strap-a", sleepId = "night-a", onset = 100, end = 0,
+            stepRevision = revision,
+            sleepContextSignature = "100-200:light",
+            contributingDayKeys = listOf("2026-08-21" to "unchanged-day-cache"),
+        )
+        assertFalse(DayCycleIntelligenceIntegration.shouldRecount(key("20500:7"), key("20500:7")))
+        assertTrue(DayCycleIntelligenceIntegration.shouldRecount(key("20500:7"), key("20500:8")))
+    }
+
+    @Test fun effectiveSleepContextEditInvalidatesOnlyItsIntersectingCycle() {
+        fun key(context: String) = DayCycleIntelligenceIntegration.cacheKey(
+            "strap", "night", 100, 200, "day:7", context, emptyList(),
+        )
+        assertTrue(DayCycleIntelligenceIntegration.shouldRecount(key("100-180:light"), key("100-190:light")))
+        assertFalse(DayCycleIntelligenceIntegration.shouldRecount(key("unrelated"), key("unrelated")))
+    }
+
+    @Test fun archivedPredecessorRestoresOnlyAMarkerBackedMainSleepBoundary() {
+        val onset = 20 * 3_600L
+        val end = onset + 8 * 3_600L
+        val restored = DayCycleIntelligenceIntegration.persistedBoundaries(
+            candidates = listOf("strap-b" to 0, "strap-a" to 4),
+            sessionsByOwner = mapOf("strap-a" to listOf(sleep("strap-a", onset, end))),
+            markerOnsetByOwnerAndDay = mapOf("strap-a" to mapOf("1970-01-02" to onset)),
+            currentBoundaryWakeDays = emptySet(),
+            tzOffsetSeconds = 0,
+            habitualMidsleepSec = null,
+        )
+
+        assertEquals(1, restored.size)
+        assertEquals("strap-a", restored.single().owner)
+        assertEquals(onset, restored.single().boundary.onset)
+        assertEquals("1970-01-02", restored.single().wakeDay)
+        assertEquals(onset, restored.single().sleepContext.start)
+
+        // Real re-add seam: archived A supplies the morning boundary/steps; active B starts at 14:00.
+        val bStarts = 38 * 3_600L
+        val cycleEnd = 44 * 3_600L
+        assertEquals(
+            listOf(
+                PhysiologicalSteps.OwnerSegment("strap-a", onset, bStarts),
+                PhysiologicalSteps.OwnerSegment("strap-b", bStarts, cycleEnd),
+            ),
+            PhysiologicalSteps.ownerSegmentsFromCoverage(
+                PhysiologicalSteps.CycleWindow(restored.single().boundary.sleepId, onset, cycleEnd),
+                listOf(
+                    PhysiologicalSteps.OwnerCoverage("strap-a", onset, bStarts, priority = 4),
+                    PhysiologicalSteps.OwnerCoverage("strap-b", bStarts, cycleEnd, priority = 0),
+                ),
+                fallbackOwner = "strap-a",
+            ),
+        )
+        fun row(owner: String, ts: Long, counter: Int) = StepSample(owner, ts, counter, activityClass = 1)
+        val aSteps = PhysiologicalSteps.stepsInCycle(
+            listOf(row("strap-a", onset, 100), row("strap-a", onset + 3, 110)), onset, bStarts,
+        )
+        val bSteps = PhysiologicalSteps.stepsInCycle(
+            listOf(row("strap-b", bStarts, 50), row("strap-b", bStarts + 2, 57)), bStarts, cycleEnd,
+        )
+        assertEquals(17, requireNotNull(aSteps) + requireNotNull(bSteps))
+    }
+
+    @Test fun markerRewriteCleansEveryNamespaceThatRecoveryMayRead() {
+        assertEquals(
+            listOf("strap-b-noop", "my-whoop-noop", "strap-a-noop"),
+            DayCycleIntelligenceIntegration.markerRewriteSourceIds(
+                currentComputedSources = listOf("strap-b-noop", "my-whoop-noop"),
+                candidateComputedSources = listOf("strap-b-noop", "strap-a-noop", "strap-a-noop"),
+            ),
+        )
+    }
+
+    @Test fun recoveredOwnerMarkerSurvivesCleanupAndProducesTheSameBoundaryOnPassTwo() {
+        val onset = 20 * 3_600L
+        val end = onset + 8 * 3_600L
+        val sessions = mapOf("strap-a" to listOf(sleep("strap-a", onset, end)))
+        val pass1 = DayCycleIntelligenceIntegration.persistedBoundaries(
+            candidates = listOf("strap-b" to 0, "strap-a" to 4),
+            sessionsByOwner = sessions,
+            markerOnsetByOwnerAndDay = mapOf("strap-a" to mapOf("1970-01-02" to onset)),
+            currentBoundaryWakeDays = emptySet(),
+            tzOffsetSeconds = 0,
+            habitualMidsleepSec = null,
+        )
+
+        // Model the transaction: every old candidate marker was deleted; only emitted rows survive.
+        val rewritten = DayCycleIntelligenceIntegration.recoveredMarkerRows(pass1) { "$it-noop" }
+        val pass2Markers = rewritten.groupBy { it.deviceId.removeSuffix("-noop") }
+            .mapValues { (_, rows) -> rows.associate { it.day to it.value.toLong() } }
+        val pass2 = DayCycleIntelligenceIntegration.persistedBoundaries(
+            candidates = listOf("strap-b" to 0, "strap-a" to 4),
+            sessionsByOwner = sessions,
+            markerOnsetByOwnerAndDay = pass2Markers,
+            currentBoundaryWakeDays = emptySet(),
+            tzOffsetSeconds = 0,
+            habitualMidsleepSec = null,
+        )
+
+        assertEquals(pass1.map { it.boundary }, pass2.map { it.boundary })
+        assertEquals("strap-a-noop", rewritten.single().deviceId)
+    }
+
+    @Test fun staleMarkerWithoutMatchingMainSleepSessionIsNeverResurrected() {
+        val onset = 20 * 3_600L
+        val end = onset + 8 * 3_600L
+        val recovered = DayCycleIntelligenceIntegration.persistedBoundaries(
+            candidates = listOf("strap-a" to 4),
+            sessionsByOwner = mapOf("strap-a" to listOf(sleep("strap-a", onset, end))),
+            markerOnsetByOwnerAndDay = mapOf("strap-a" to mapOf("1970-01-02" to onset - 60)),
+            currentBoundaryWakeDays = emptySet(),
+            tzOffsetSeconds = 0,
+            habitualMidsleepSec = null,
+        )
+        assertTrue(recovered.isEmpty())
+        assertTrue(DayCycleIntelligenceIntegration.recoveredMarkerRows(recovered) { "$it-noop" }.isEmpty())
+    }
+
+    @Test fun currentDetectedOrEditedBoundaryWinsOverArchivedPersistence() {
+        val onset = 20 * 3_600L
+        val end = onset + 8 * 3_600L
+        assertTrue(
+            DayCycleIntelligenceIntegration.persistedBoundaries(
+                candidates = listOf("strap-a" to 4),
+                sessionsByOwner = mapOf("strap-a" to listOf(sleep("strap-a", onset, end))),
+                markerOnsetByOwnerAndDay = mapOf("strap-a" to mapOf("1970-01-02" to onset)),
+                currentBoundaryWakeDays = setOf("1970-01-02"),
+                tzOffsetSeconds = 0,
+                habitualMidsleepSec = null,
+            ).isEmpty(),
+        )
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/StepCycleIntegrationPolicyTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StepCycleIntegrationPolicyTest.kt
@@ -2,6 +2,7 @@ package com.noop.analytics
 
 import com.noop.data.SleepSession
 import com.noop.data.StepSample
+import com.noop.data.DailyMetric
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -20,6 +21,29 @@ class StepCycleIntegrationPolicyTest {
         assertEquals(410, DayCycleIntelligenceIntegration.integratedStepValue(410, false, null))
         assertNull(DayCycleIntelligenceIntegration.integratedStepValue(410, true, null))
         assertEquals(37, DayCycleIntelligenceIntegration.integratedStepValue(410, true, 37))
+    }
+
+    @Test fun establishedCycleAppliesEveryAdditiveDailyMetricTogether() {
+        val day = "2026-09-04"
+        val result = PhysiologicalStepCycleEngine.Result(
+            cycleStepsByWakeDay = mapOf(day to 42),
+            cycleStrainByWakeDay = mapOf(day to 61.0),
+            cycleCaloriesByWakeDay = mapOf(day to 1840.0),
+            cycleWorkoutCountByWakeDay = mapOf(day to 2),
+            boundaryOnsetByWakeDay = emptyMap(), firstCycleWakeDay = day,
+            recoveredOwnerMarkerRows = emptyList(),
+        )
+
+        val updated = DayCycleIntelligenceIntegration.apply(
+            DailyMetric(deviceId = "strap-noop", day = day, steps = 1, strain = 2.0,
+                activeKcalEst = 3.0, exerciseCount = 4),
+            result, "strap-noop", mutableListOf(),
+        )
+
+        assertEquals(42, updated.steps)
+        assertEquals(61.0, updated.strain)
+        assertEquals(1840.0, updated.activeKcalEst)
+        assertEquals(2, updated.exerciseCount)
     }
 
     @Test fun warmUnchangedCycleDoesNotReadStepRowsAgain() {

--- a/android/app/src/test/java/com/noop/analytics/StepsAnalyticsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StepsAnalyticsTest.kt
@@ -66,7 +66,7 @@ class StepsAnalyticsTest {
     fun jumpGuardDropsGapButKeepsRealSteps() {
         // 100 -> 300 (=200 real) ; 300 -> 1200 is a 900-tick GAP (>= 512) and is dropped ; 1200 -> 1500
         // (=300 real). Only the two in-range increments count => 200 + 300 = 500, the gap doesn't inflate.
-        val s = listOf(step(0, 100), step(60, 300), step(3_600, 1_200), step(3_660, 1_500))
+        val s = listOf(step(0, 100), step(60, 300), step(3_600, 1_200), step(3_675, 1_500))
         assertEquals(500, stepsFor(s))
     }
 
@@ -75,13 +75,13 @@ class StepsAnalyticsTest {
         // THE BUG (#132/#276/#316). A realistic ascending cumulative counter sampled at 1 Hz. The OLD
         // code summed the raw running total (byte @57 alone summed) — exploding the count; the NEW
         // wrap-aware diff sums only the per-record increments and yields a sane number.
-        val counters = listOf(100, 127, 127, 130, 131, 131, 140, 152, 160, 175)
+        val counters = listOf(100, 102, 102, 105, 106, 106, 109, 111, 113, 115)
         val samples = counters.mapIndexed { i, c -> step(i.toLong(), c) }
         // NEW behaviour: sum of wrap-aware deltas == last - first (all small increments, none >= 512).
         val sane = counters.last() - counters.first() // 75
         assertEquals(sane, stepsFor(samples))
         // OLD behaviour (summing the cumulative counter itself) would be vastly larger — prove the gap.
-        val oldOvercount = counters.sum() // 1373
+        val oldOvercount = counters.sum()
         org.junit.Assert.assertTrue(oldOvercount > sane * 10)
     }
 

--- a/android/app/src/test/java/com/noop/analytics/StepsCounterTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StepsCounterTest.kt
@@ -13,7 +13,8 @@ import org.junit.Test
  */
 class StepsCounterTest {
 
-    private fun step(ts: Long, counter: Int) = StepSample(deviceId = "my-whoop", ts = ts, counter = counter)
+    private fun step(ts: Long, counter: Int, activityClass: Int? = null) =
+        StepSample(deviceId = "my-whoop", ts = ts, counter = counter, activityClass = activityClass)
 
     @Test fun sumsPositiveConsecutiveDeltas() {
         // counters 100 -> 150 -> 220 => deltas 50 + 70 = 120
@@ -48,7 +49,35 @@ class StepsCounterTest {
 
     @Test fun maxStepDeltaBoundaryIsExclusive() {
         // Exactly MAX_STEP_DELTA (512) is dropped; 511 counts.
-        assertNull(StepsCounter.stepsInWindow(listOf(step(0, 0), step(60, 512))))
-        assertEquals(511, StepsCounter.stepsInWindow(listOf(step(0, 0), step(60, 511))))
+        assertNull(StepsCounter.stepsInWindow(listOf(step(0, 0), step(128, 512))))
+        assertEquals(511, StepsCounter.stepsInWindow(listOf(step(0, 0), step(128, 511))))
+    }
+
+    @Test fun rejectsPhysicallyImpossibleOneSecondSpikeButAllowsSameTicksAcrossTime() {
+        // Four ticks/second (240/min) remains available for a hard sprint. Seven ticks in one second is
+        // the observed household outlier and cannot be real gait; the same seven ticks across two seconds
+        // can be a small history hole and must remain recoverable.
+        assertNull(StepsCounter.stepsInWindow(listOf(step(0, 100), step(1, 107))))
+        assertEquals(7, StepsCounter.stepsInWindow(listOf(step(0, 100), step(2, 107))))
+        assertEquals(4, StepsCounter.stepsInWindow(listOf(step(0, 100), step(1, 104))))
+    }
+
+    @Test fun classedStreamCountsOnlyWalkAndRunDeltas() {
+        // Attribute each counter delta to the later sample, matching the strap's per-record class.
+        // still: +10 ignored; walk: +20; run: +15; unknown: +25 ignored => 35 locomotion ticks.
+        assertEquals(35, StepsCounter.stepsInWindow(listOf(
+            step(0, 100, 0),
+            step(10, 110, 0),
+            step(20, 130, 1),
+            step(30, 145, 2),
+            step(40, 170, null),
+        )))
+    }
+
+    @Test fun legacyUnclassedStreamKeepsCounterFallback() {
+        // Rows written before activityClass existed must retain their historical estimate.
+        assertEquals(70, StepsCounter.stepsInWindow(listOf(
+            step(0, 100), step(10, 140), step(20, 170),
+        )))
     }
 }

--- a/android/app/src/test/java/com/noop/data/BackupSettingsCodecTest.kt
+++ b/android/app/src/test/java/com/noop/data/BackupSettingsCodecTest.kt
@@ -39,6 +39,7 @@ class BackupSettingsCodecTest {
             "units.system" to "imperial",
             "units.temperature" to "celsius",
             "effort.scale" to "whoop",
+            "dayCycle.mode" to "sleep_onset",
             // #today-hosted-cards: the one layout pref carried, a JSON [String] stored under the String kind.
             "today.hostedCards" to "[\"sleep.sleepMarks\"]",
             // #1361: custom journal behaviours, a newline-joined name list — the embedded newline must
@@ -58,6 +59,7 @@ class BackupSettingsCodecTest {
         assertEquals("imperial", back["units.system"])
         assertEquals("celsius", back["units.temperature"])
         assertEquals("whoop", back["effort.scale"])
+        assertEquals("sleep_onset", back["dayCycle.mode"])
         assertEquals("[\"sleep.sleepMarks\"]", back["today.hostedCards"])
         assertEquals("Cold plunge\nMagnesium", back["journal.customBehaviors"])
         assertEquals(values.size, back.size)

--- a/android/app/src/test/java/com/noop/data/ReadoutDataRevisionTest.kt
+++ b/android/app/src/test/java/com/noop/data/ReadoutDataRevisionTest.kt
@@ -6,24 +6,28 @@ import org.junit.Test
 class ReadoutDataRevisionTest {
 
     @Test fun revisionsAdvanceOnlyForSuccessfullyInsertedRelevantRows() {
-        val initial = ReadoutDataRevisions(sleepSamples = 7, battery = 11)
+        val initial = ReadoutDataRevisions(sleepSamples = 7, battery = 11, steps = 13)
 
         assertEquals(initial, advanceReadoutDataRevisions(initial, InsertCounts()))
         assertEquals(
-            ReadoutDataRevisions(sleepSamples = 8, battery = 11),
+            ReadoutDataRevisions(sleepSamples = 8, battery = 11, steps = 13),
             advanceReadoutDataRevisions(initial, InsertCounts(hr = 1)),
         )
         assertEquals(
-            ReadoutDataRevisions(sleepSamples = 8, battery = 11),
+            ReadoutDataRevisions(sleepSamples = 8, battery = 11, steps = 13),
             advanceReadoutDataRevisions(initial, InsertCounts(gravity = 2)),
         )
         assertEquals(
-            ReadoutDataRevisions(sleepSamples = 7, battery = 12),
+            ReadoutDataRevisions(sleepSamples = 7, battery = 12, steps = 13),
             advanceReadoutDataRevisions(initial, InsertCounts(battery = 1)),
         )
         assertEquals(
-            ReadoutDataRevisions(sleepSamples = 8, battery = 12),
+            ReadoutDataRevisions(sleepSamples = 8, battery = 12, steps = 13),
             advanceReadoutDataRevisions(initial, InsertCounts(hr = 1, gravity = 1, battery = 1)),
+        )
+        assertEquals(
+            ReadoutDataRevisions(sleepSamples = 7, battery = 11, steps = 14),
+            advanceReadoutDataRevisions(initial, InsertCounts(steps = 1)),
         )
     }
 }

--- a/android/app/src/test/java/com/noop/data/StepDataRevisionIndexTest.kt
+++ b/android/app/src/test/java/com/noop/data/StepDataRevisionIndexTest.kt
@@ -1,0 +1,53 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class StepDataRevisionIndexTest {
+    @Test fun newRowsInvalidateOnlyIntersectingOwnerDaysAndDuplicatesDoNothing() {
+        val index = StepDataRevisionIndex()
+        val day = 86_400L
+        val activeBefore = index.signature("strap-a", day, 2 * day)
+        val neighbourBefore = index.signature("strap-a", 2 * day, 3 * day)
+
+        index.record("strap-a", listOf(day + 100), insertedRows = 1)
+        val activeAfter = index.signature("strap-a", day, 2 * day)
+        assertNotEquals(activeBefore, activeAfter)
+        assertEquals(neighbourBefore, index.signature("strap-a", 2 * day, 3 * day))
+        assertEquals("0:0", index.signature("strap-b", 0, day))
+
+        index.record("strap-a", listOf(day + 100), insertedRows = 0)
+        assertEquals(activeAfter, index.signature("strap-a", day, 2 * day))
+    }
+
+    @Test fun delayedBackfillInvalidatesAClosedWindowButNotTheCurrentNeighbour() {
+        val index = StepDataRevisionIndex()
+        val day = 86_400L
+        val closedBefore = index.signature("strap", day, 2 * day)
+        val currentBefore = index.signature("strap", 2 * day, 3 * day)
+
+        index.record("strap", listOf(day + 42), insertedRows = 1)
+
+        assertNotEquals(closedBefore, index.signature("strap", day, 2 * day))
+        assertEquals(currentBefore, index.signature("strap", 2 * day, 3 * day))
+    }
+
+    @Test fun mixedDuplicateAndNewRowsExposeOnlyActuallyInsertedTimestamps() {
+        val day = 86_400L
+        val index = StepDataRevisionIndex()
+        val duplicateDayBefore = index.signature("strap", 0, day)
+        val newDayBefore = index.signature("strap", day, 2 * day)
+        val inserted = newlyInsertedStepTimestamps(
+            listOf(10L, day + 20),
+            listOf(-1L, 42L),
+        )
+        assertEquals(
+            listOf(day + 20),
+            inserted,
+        )
+        index.record("strap", inserted, insertedRows = inserted.size)
+        assertEquals(duplicateDayBefore, index.signature("strap", 0, day))
+        assertNotEquals(newDayBefore, index.signature("strap", day, 2 * day))
+    }
+}

--- a/android/app/src/test/java/com/noop/ui/ActiveCycleStepsResolverTest.kt
+++ b/android/app/src/test/java/com/noop/ui/ActiveCycleStepsResolverTest.kt
@@ -1,0 +1,86 @@
+package com.noop.ui
+
+import com.noop.data.DailyMetric
+import com.noop.data.MetricSeriesRow
+import com.noop.analytics.DayCycleMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ActiveCycleStepsResolverTest {
+    @Test fun allLiveAdditiveMetricsResolveTheSameConfiguredStart() {
+        assertEquals(1234L, activeDayCycleStart(DayCycleMode.SLEEP_ONSET, 1234L, 2000L))
+        assertEquals(2000L, activeDayCycleStart(DayCycleMode.MIDNIGHT, 1234L, 2000L))
+        assertEquals(2000L, activeDayCycleStart(DayCycleMode.SLEEP_ONSET, null, 2000L))
+    }
+    private fun day(key: String, steps: Int?) =
+        DailyMetric(deviceId = "my-whoop-noop", day = key, steps = steps)
+
+    private fun onset(day: String, ts: Long) = MetricSeriesRow(
+        deviceId = "my-whoop-noop",
+        day = day,
+        key = "day_cycle_onset_ts",
+        value = ts.toDouble(),
+    )
+
+    @Test fun publishedActiveStrapReplacesConstructionTimeFallback() {
+        assertEquals("strap-b", effectiveActiveStrapId("strap-b", "strap-a"))
+        assertEquals("strap-a", effectiveActiveStrapId(null, "strap-a"))
+    }
+
+    @Test fun activeCycleIgnoresTheFourAmLogicalDayRollover() {
+        val days = listOf(day("2026-08-20", 6_000), day("2026-08-21", null))
+
+        assertEquals(
+            ActiveDayCycle("2026-08-20", 1_000L, 6_000),
+            resolveActiveDayCycle(days, days, listOf(onset("2026-08-20", 1_000L)), nowSeconds = 5_000L),
+        )
+    }
+
+    @Test fun newlyRecognisedMainSleepSwitchesToItsWakeDayCycle() {
+        val days = listOf(day("2026-08-20", 6_000), day("2026-08-21", 17))
+        val markers = listOf(onset("2026-08-20", 1_000L), onset("2026-08-21", 4_000L))
+
+        assertEquals(
+            ActiveDayCycle("2026-08-21", 4_000L, 17),
+            resolveActiveDayCycle(days, days, markers, nowSeconds = 5_000L),
+        )
+    }
+
+    @Test fun futureAndMalformedMarkersCannotMoveTheTile() {
+        val days = listOf(day("2026-08-20", 6_000), day("2026-08-21", 17))
+        val markers = listOf(
+            onset("2026-08-20", 1_000L),
+            onset("2026-08-21", 9_000L),
+            onset("2026-08-22", 0L),
+        )
+
+        assertEquals(
+            ActiveDayCycle("2026-08-20", 1_000L, 6_000),
+            resolveActiveDayCycle(days, days, markers, nowSeconds = 5_000L),
+        )
+    }
+
+    @Test fun noConfirmedCycleHasNoOverrideSoCalendarFallbackCanRemain() {
+        val days = listOf(day("2026-08-21", 400))
+        assertNull(resolveActiveDayCycle(days, days, emptyList(), 5_000L))
+    }
+
+    @Test fun importedMergedStepsCannotOverrideTheComputedCycleValue() {
+        val merged = listOf(day("2026-08-21", 410))
+        val computed = listOf(day("2026-08-21", 17))
+        assertEquals(
+            ActiveDayCycle("2026-08-21", 1_000, 17),
+            resolveActiveDayCycle(merged, computed, listOf(onset("2026-08-21", 1_000)), 5_000),
+        )
+    }
+
+    @Test fun newestMarkerStillDrivesNonStepMetricsWithoutAComputedStepValue() {
+        val days = listOf(day("2026-08-20", 6_000), day("2026-08-21", null))
+        val markers = listOf(onset("2026-08-20", 1_000), onset("2026-08-21", 4_000))
+        assertEquals(
+            ActiveDayCycle("2026-08-21", 4_000, null),
+            resolveActiveDayCycle(days, days, markers, 5_000),
+        )
+    }
+}


### PR DESCRIPTION
## What this PR does

Adds sleep-aware step counting and a reusable physiological day-cycle abstraction on Android and Apple platforms.

This fixes a substantial accuracy bug in the previous NOOP counter. It could overcount motion very aggressively: we observed hundreds of steps accumulating while the wearer was asleep, including a morning where NOOP showed roughly 400 steps despite no walking during the sleep window and WHOOP still showed 0. Short early-morning movement could also be inflated dramatically. These were not harmless display differences; isolated counter ticks, sleep motion, implausible jumps, and calendar-boundary handling were being interpreted as real walking.

The default daily cycle now begins at the onset of the detected main sleep rather than blindly resetting at 00:00. Naps do not create a new cycle. If sleep is missing or unreliable, the cycle falls back to local midnight, and an active cycle is capped so a missed night cannot produce a 48-hour "day". Users can opt back into a conventional 00:00 calendar day in Settings.

The practical motivation is my late sleep schedule: I often go to bed around 02:00. A hard reset at midnight then splits one continuous waking period in the middle of my evening, resets my visible step total two hours before bed, and assigns my after-midnight household activity to a different "day" even though I have not slept yet. Main-sleep onset is a much more meaningful boundary for that pattern, while the explicit 00:00 option preserves conventional calendar-day behavior for users who prefer it.

Steps are counted from persisted strap history, not only while a screen is open. The counter:

- evaluates counter deltas in temporal context instead of accepting every isolated tick;
- rejects implausible one-second jumps and unsuitable activity classes;
- preserves legitimate short awake gaps during the night while suppressing isolated sleep motion;
- resolves overlapping historical coverage across active, paired, imported, activity-file, and archived owners;
- pages large histories and caches results using per-owner/per-UTC-day revisions;
- recovers persisted cycle boundaries across launches and fails closed on database read errors;
- keeps Android and iOS behavior aligned, including manual sleep edits and sensor replacement history.

The day-cycle code is intentionally separate from step classification. `DayCycleResolver` and its persisted mode can be reused by other additive/live daily features. This PR already uses it for steps and in-progress Effort; future metrics can share the same boundary semantics instead of inventing their own reset logic.

### Current day-cycle consumers

| Value | Behavior in this PR |
| --- | --- |
| Steps | Active and historical totals use main-sleep onset → next main-sleep onset, with the bounded midnight fallback. |
| Effort and calories | Completed and in-progress values integrate the HR union over the same end-exclusive physiological window. |
| HR timelines | Today charts use the selected physiological window without duplicating the sample at the next onset. |
| Workouts | Persisted all-source and freshly detected workouts are deduplicated and assigned by start time to the physiological window; Coupled uses that materialized count. |
| Recovery and Rest | Unchanged: they remain attached to their sleep/recovery session rather than treated as additive activity. |

## Field evidence

This was developed against timestamped step-debug exports plus manual ground truth collected with a mechanical clicker. The dataset includes continuous walking, mixed walking/jogging, household work, stairs, quiet sitting, sleep, and explicitly marked zero-step car journeys.

Two representative controlled checks:

- 818 manually counted walking steps: NOOP advanced by 826 (`+1.0%`); the concurrently worn Amazfit advanced by 681 (`-16.7%`).
- 722 manually counted steps: NOOP advanced by 746 (`+3.3%`); Amazfit advanced by 698 (`-3.3%`); WHOOP eventually advanced by about 650 (`-10.0%`).

WHOOP also revised settled-looking totals after the walk without further movement (observed `3109 → 3260` and `3771 → 3910`), so comparisons used its later value where available. Across the controlled sessions, the new NOOP candidate was generally closer to the clicker than WHOOP, while the final full-day totals were NOOP 6143 versus WHOOP 5500. That supports the hypothesis that this implementation can outperform WHOOP for the tested wearer and activities; it is deliberately not presented as a population-wide benchmark yet.

The sleep-aware cycle and tick filtering substantially reduced the observed wake-up false total: an earlier build accumulated roughly 400 steps without overnight walking, while the latest overnight test displayed 20 at wake-up. The detailed trace for that latest night later resolved 52 accepted ticks before 09:30 against user-confirmed ground truth of zero steps. The physiological day boundary itself behaved correctly: it reset at the detected 01:29 main-sleep onset, did not split the waking period at midnight, remained stable overnight, and assigned post-wake movement to the new cycle. The remaining false positives belong to step-phase classification around fragmented sleep/wake context, not cycle resolution; they are preserved in the local research corpus for follow-up algorithm work without changing the reusable cycle API.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- Android `:app:testFullDebugUnitTest` passed with at most two Gradle workers.
- Apple app CI passed for macOS build/tests and the iOS Simulator build: https://github.com/bhelm/noop/actions/runs/32666853391
- All Swift package jobs passed, including `StrandAnalytics` and `WhoopStore`: https://github.com/bhelm/noop/actions/runs/32666854693
- Added focused tests for cycle resolution, main-sleep/nap classification, isolated and implausible ticks, awake gaps, owner coverage and priority, paging policy, active-cycle display, persisted marker transactions, cache revision isolation, duplicate inserts, archived owners, settings backup, and fail-closed recovery orchestration.
- Two independent final reviews found no P0/P1/P2 issues after the fixes.
- Stacked the tooling from #1534 over the final feature HEAD in a temporary worktree (tool files are not part of this PR):
  - parity ledger: `OK no NEW parity ledger findings`
  - governance ratchet: `errors=0`
- Real-hardware evidence came from a dedicated NOOP WHOOP sensor, with a separate WHOOP sensor used for the cloud comparison. The algorithm consumes banked history, so it does not require a permanent phone connection.

## Design notes

- Pure cycle and step policy lives in dedicated analytics files; existing engines mainly orchestrate reads, calls, and persistence.
- iOS cache state belongs to each `IntelligenceEngine`, avoiding process-global cross-store interference.
- Marker persistence uses a typed `preserve` / `replace` result so an unread namespace cannot be mistaken for an authoritative empty one.
- Marker deletion and replacement remain one database transaction.
- Archived devices remain low-priority historical candidates so removing or replacing a strap cannot rewrite earlier days.

## Checklist

- [x] Swift package tests pass for every touched package
- [x] Android unit tests pass
- [x] No new build warnings introduced
- [x] UI changes use existing design-system components/tokens
- [x] No hardcoded protocol frame bytes
- [x] Follows the repository conventions
- [x] No generated Xcode project, secrets, captures, or keystores committed

## Related issues

This PR is based on the local step-counting investigation and field dataset; it does not close an existing issue.

