### PR TITLE
Say which gate ate the workout when a day detects none

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -66,6 +66,10 @@ public enum AnalyticsEngine {
         public let cachedSleep: [CachedSleepSession]
         /// Detected workout/exercise sessions.
         public let workouts: [ExerciseSession]
+        /// #1545: where the detector lost every candidate workout on this day. nil only when detection did
+        /// not run. Always populated otherwise — including (especially) when `workouts` is empty, which is
+        /// the case the counts exist to explain.
+        public let detectionFunnel: WorkoutDetector.DetectionFunnel?
         /// Recovery / "Charge" score [0,100] or nil (cold-start / no HRV baseline).
         public let recovery: Double?
         /// Ordered Charge driver breakdown (one row per real term that fed the score, biggest
@@ -117,9 +121,11 @@ public enum AnalyticsEngine {
                     sessionMotionByStart: [Int: [Double]] = [:],
                     sessionSleepStateByStart: [Int: [Int]] = [:],
                     chargeDrivers: [ChargeDriver] = [],
-                    skinTempRelative: SkinTempRelative? = nil) {
+                    skinTempRelative: SkinTempRelative? = nil,
+                    detectionFunnel: WorkoutDetector.DetectionFunnel? = nil) {
             self.daily = daily; self.sleepSessions = sleepSessions
             self.cachedSleep = cachedSleep; self.workouts = workouts
+            self.detectionFunnel = detectionFunnel
             self.recovery = recovery; self.strain = strain
             self.chargeDrivers = chargeDrivers
             self.skinTempRelative = skinTempRelative
@@ -804,6 +810,7 @@ public enum AnalyticsEngine {
         // a later pass re-reads it through the next night window (which ends at ≈ noon). Falls back
         // to the night window for pure-function callers/tests. restingHR still comes from the night's
         // sleep sessions; nil → WorkoutDetector derives it from the day's own HR floor.
+        var detectionFunnel: WorkoutDetector.DetectionFunnel? = nil
         let workouts = WorkoutDetector.detect(
             hr: dayHr ?? hr, gravity: dayGravity ?? gravity,
             restingHR: restingHRDaily.map(Double.init),
@@ -826,7 +833,8 @@ public enum AnalyticsEngine {
             // #1545: the bouts inside a day MUST be scored by the same recipe as the day itself.
             // A day on Banister whose workouts were still on Edwards would show a session scoring
             // less than the day it sits inside, which is a worse inconsistency than either method.
-            effortMethod: effortMethod)
+            effortMethod: effortMethod,
+            funnel: { detectionFunnel = $0 })
 
         // ── Steps (APPROXIMATE) ───────────────────────────────────────────────
         // step_motion_counter@57 is a CUMULATIVE u16 running counter (it climbs while you move, holds
@@ -956,7 +964,8 @@ public enum AnalyticsEngine {
                          sessionMotionByStart: sessionMotionByStart,
                          sessionSleepStateByStart: sessionSleepStateByStart,
                          chargeDrivers: chargeDrivers,
-                         skinTempRelative: skinTempRelative)
+                         skinTempRelative: skinTempRelative,
+                         detectionFunnel: detectionFunnel)
     }
 
     // MARK: - Rest composite (Charge/Effort/Rest)

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
@@ -142,6 +142,56 @@ public enum WorkoutDetector {
         return bpms[rank - 1]
     }
 
+    /// #1545: why a day produced no workout, counted at each gate the detector actually applies.
+    ///
+    /// The `effort bout` line explains a bout that EXISTS. It is silent when none does — and "no workouts
+    /// at all" is the harder report to answer, because every gate looks equally plausible from outside. A
+    /// reporter with 37 days and zero detected bouts previously had nothing to send that could distinguish
+    /// "the strap never registered motion" (a WHOOP 4.0 banks it coarsely, #345/#28) from "HR never cleared
+    /// resting + 15" from "the efforts were real but under five minutes".
+    ///
+    /// Counted during the detector's OWN walk, never recomputed alongside it: a funnel free to disagree
+    /// with the code it describes is worse than no funnel, because it will be believed.
+    public struct DetectionFunnel: Equatable, Sendable {
+        /// Inputs the day actually had.
+        public var hrSamples = 0
+        public var motionSamples = 0
+        /// The bar a sample had to clear, in bpm — resting + `hrMarginBPM`.
+        public var restingHR: Double? = nil
+        public var hrFloor: Double? = nil
+        /// Motion samples whose smoothed intensity cleared `motionThreshold`.
+        public var motionPassed = 0
+        /// Of those, how many had NO HR sample within `alignToleranceS` (a sensor gap, not a quiet body).
+        public var hrMissing = 0
+        /// Of those, how many had HR at or below `hrFloor` (moving, but not working).
+        public var hrTooLow = 0
+        /// Samples that cleared BOTH gates.
+        public var active = 0
+        /// Contiguous runs after gap-merging, and after the #303 HR-gated bridge.
+        public var runs = 0
+        public var bridged = 0
+        /// Runs rejected by each qualification gate, and the survivors.
+        public var droppedShort = 0
+        public var droppedNoHR = 0
+        public var droppedLowIntensity = 0
+        public var kept = 0
+
+        public init() {}
+    }
+
+    /// #1545: the always-on per-day line naming where the detector lost every candidate workout.
+    ///
+    /// Byte-identical string to the Kotlin twin. No PII: a day key and counts, plus the two bpm thresholds
+    /// the day was measured against — the same privacy class as the sibling `sleep day=` line.
+    public static func detectionFunnelLine(day: String, funnel f: DetectionFunnel) -> String {
+        "effort detect day=\(day) hr=\(f.hrSamples) motion=\(f.motionSamples) "
+            + "restHR=\(round0(f.restingHR)) floor=\(round0(f.hrFloor)) "
+            + "motionOK=\(f.motionPassed) hrMissing=\(f.hrMissing) hrTooLow=\(f.hrTooLow) "
+            + "active=\(f.active) runs=\(f.runs) bridged=\(f.bridged) "
+            + "short=\(f.droppedShort) noHR=\(f.droppedNoHR) lowIntensity=\(f.droppedLowIntensity) "
+            + "kept=\(f.kept)"
+    }
+
     /// #1545: how much of `[start, end]` the HR sensor actually covered, as a percentage of
     /// `bucketSeconds`-wide buckets holding at least one reading.
     ///
@@ -350,13 +400,27 @@ public enum WorkoutDetector {
                               // existing caller and test is byte-identical; the app threads the user's
                               // choice so a bout and the day it sits in are never scored by different
                               // recipes, which would be worse than either one being "wrong".
-                              effortMethod: StrainScorer.Method = .edwards) -> [ExerciseSession] {
+                              effortMethod: StrainScorer.Method = .edwards,
+                              // #1545: receives the gate-by-gate counts for THIS call. nil (the default)
+                              // keeps every existing caller and test byte-identical — nothing is computed
+                              // that the detector was not already computing, the counters just record it.
+                              funnel: ((DetectionFunnel) -> Void)? = nil) -> [ExerciseSession] {
+        // `defer` so the funnel is reported on EVERY exit, including the early returns below. A day that
+        // bails at "no motion rows at all" is precisely the day whose report matters most, and it is the
+        // one a happy-path-only emit would stay silent about.
+        var f = DetectionFunnel()
+        defer { funnel?(f) }
+
         let hrSeg = cleanHR(hr)
         let motion = activitySeries(gravity)
+        f.hrSamples = hrSeg.count
+        f.motionSamples = motion.count
         if hrSeg.isEmpty || motion.isEmpty { return [] }
 
         let restHR = restingHR ?? deriveRestingHR(hrSeg)
         let hrFloor = restHR + hrMarginBPM
+        f.restingHR = restHR
+        f.hrFloor = hrFloor
 
         let effMaxHR: Double?
         let hrmaxSource: String
@@ -377,9 +441,15 @@ public enum WorkoutDetector {
         var activeTs: [Int] = []
         for (p, inten) in zip(motion, smooth) {
             if inten <= motionThreshold { continue }
-            guard let bpm = nearest(hrTs, hrBpm, p.ts, alignToleranceS), bpm > hrFloor else { continue }
+            f.motionPassed += 1
+            // Split the HR rejection two ways: no sample within tolerance is a SENSOR GAP, a sample at or
+            // below the floor is a body that simply was not working. They read identically in a bout count
+            // of zero and call for opposite responses.
+            guard let bpm = nearest(hrTs, hrBpm, p.ts, alignToleranceS) else { f.hrMissing += 1; continue }
+            guard bpm > hrFloor else { f.hrTooLow += 1; continue }
             activeTs.append(p.ts)
         }
+        f.active = activeTs.count
         if activeTs.isEmpty { return [] }
 
         // Group contiguous active samples into runs, merging gaps < MERGE_GAP_S.
@@ -391,22 +461,24 @@ public enum WorkoutDetector {
             prev = ts
         }
         runs.append((runStart, prev))
+        f.runs = runs.count
 
         // Second pass (#303): bridge adjacent runs across a brief, still-elevated-HR
         // lull so a sustained effort isn't shattered by coasting / junctions / sensor
         // gaps. Runs over a genuine rest (HR falls to resting) are NOT bridged.
         runs = bridgeRuns(runs, hrSeg: hrSeg, hrFloor: hrFloor)
+        f.bridged = runs.count
 
         let minDurS = minExerciseMin * 60.0
         var sessions: [ExerciseSession] = []
         for (idx, run) in runs.enumerated() {
             let (start, end) = run
             // Onset latency tolerance equal to the smoothing window.
-            if Double(end - start) < minDurS - motionSmoothS { continue }
+            if Double(end - start) < minDurS - motionSmoothS { f.droppedShort += 1; continue }
             // Qualify on the HR-elevated CORE (unchanged gates) so the warm-up's low intensity
             // can't dilute a real workout below the zone-2 bar and drop it (#148).
             let core = hrSeg.filter { $0.ts >= start && $0.ts <= end }
-            if core.isEmpty { continue }
+            if core.isEmpty { f.droppedNoHR += 1; continue }
 
             var zonePct: [Int: Double] = [:]
             var avgHRR: Double? = nil
@@ -417,7 +489,7 @@ public enum WorkoutDetector {
             // Intensity qualification: require ≥ MIN_INTENSITY_Z2PLUS in zone 2+.
             if !zonePct.isEmpty {
                 let z2plus = (2...5).reduce(0.0) { $0 + (zonePct[$1] ?? 0.0) } / 100.0
-                if z2plus < minIntensityZ2Plus { continue }
+                if z2plus < minIntensityZ2Plus { f.droppedLowIntensity += 1; continue }
             }
 
             // Qualified → back-date the start over the warm-up and report stats on the full window (#148).
@@ -426,7 +498,7 @@ public enum WorkoutDetector {
             let floor = idx > 0 ? runs[idx - 1].1 + 1 : Int.min
             let effStart = max(Self.backdatedStart(start, motionTs, smooth), floor)
             let window = hrSeg.filter { $0.ts >= effStart && $0.ts <= end }
-            if window.isEmpty { continue }
+            if window.isEmpty { f.droppedNoHR += 1; continue }
             let bpms = window.map { $0.bpm }
             let hrSamples = window.map { HRSample(ts: $0.ts, bpm: Int($0.bpm.rounded())) }
 
@@ -438,7 +510,7 @@ public enum WorkoutDetector {
                 kcal = k; kj = j
             }
 
-            guard !bpms.isEmpty else { continue }   // skip a degenerate bout with no HR samples
+            guard !bpms.isEmpty else { f.droppedNoHR += 1; continue }   // degenerate bout, no HR samples
             let avg = bpms.reduce(0, +) / Double(bpms.count)
             let peak = Int(bpms.max()!.rounded())
             let strain = StrainScorer.strain(hrSamples, maxHR: effMaxHR, restingHR: restHR,
@@ -451,6 +523,7 @@ public enum WorkoutDetector {
                 hrCoveragePct: hrCoveragePct(sampleTs: hrSamples.map { $0.ts },
                                              start: effStart, end: end)))
         }
+        f.kept = sessions.count
         return sessions
     }
 

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DetectionFunnelTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DetectionFunnelTests.swift
@@ -102,6 +102,34 @@ final class DetectionFunnelTests: XCTestCase {
         XCTAssertEqual(f.kept, 0)
     }
 
+    /// The funnel must ACCOUNT for everything, not merely count some things.
+    ///
+    /// Two arithmetic invariants hold by construction, because each gate is an exclusive `continue`:
+    ///   A. every motion sample that cleared its gate is then either a sensor gap, a too-low heart rate,
+    ///      or active — `motionOK == hrMissing + hrTooLow + active`;
+    ///   B. every run that survived bridging has exactly one outcome —
+    ///      `bridged == short + noHR + lowIntensity + kept`.
+    ///
+    /// This is the test that earns the funnel its trust. A future gate added to the detector without a
+    /// matching counter would silently make some rejections vanish from the line — and a diagnostic that
+    /// loses candidates without saying so is exactly the thing this whole feature exists to stop being.
+    func testEveryRejectedCandidateIsAccountedFor() throws {
+        let cases: [(String, [HRSample], [GravitySample])] = [
+            ("still", hrs(3600, 150), still(3600)),
+            ("unexerted", hrs(3600, 62), moving(3600)),
+            ("hr gap", hrs(60, 150), moving(3600)),
+            ("short", hrs(600, 60) + hrs(120, 150, from: 600) + hrs(2880, 60, from: 720), moving(3600)),
+            ("real", hrs(600, 60) + hrs(2400, 150, from: 600) + hrs(600, 60, from: 3000), moving(3600)),
+        ]
+        for (name, hr, grav) in cases {
+            let f = try funnelOf(hr, grav)
+            XCTAssertEqual(f.motionPassed, f.hrMissing + f.hrTooLow + f.active,
+                           "\(name): motionOK must equal hrMissing + hrTooLow + active (\(f))")
+            XCTAssertEqual(f.bridged, f.droppedShort + f.droppedNoHR + f.droppedLowIntensity + f.kept,
+                           "\(name): bridged runs must equal short + noHR + lowIntensity + kept (\(f))")
+        }
+    }
+
     /// The exact bytes. Compared between two users' logs and across platforms, so the shape is contract.
     func testTheLineIsExactlyThis() {
         var f = WorkoutDetector.DetectionFunnel()

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DetectionFunnelTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DetectionFunnelTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+import Foundation
+@testable import StrandAnalytics
+import WhoopProtocol
+
+/// #1545: why a day produced no workout, counted at each gate the detector actually applies.
+///
+/// The `effort bout` line explains a bout that EXISTS, so it is silent on the harder report — a strap log
+/// with 37 days and zero detected workouts, where every gate looks equally plausible from outside. These
+/// tests pin that the funnel separates the causes rather than just confirming the zero.
+///
+/// Byte-parity twin of Kotlin `DetectionFunnelTest`.
+final class DetectionFunnelTests: XCTestCase {
+
+    private func hrs(_ n: Int, _ bpm: Int, from: Int = 0) -> [HRSample] {
+        (from ..< from + n).map { HRSample(ts: $0, bpm: bpm) }
+    }
+
+    /// Motion that genuinely varies — a constant vector has zero intensity and detects nothing.
+    private func moving(_ n: Int) -> [GravitySample] {
+        (0 ..< n).map { GravitySample(ts: $0, x: $0 % 2 == 0 ? 0.9 : 0.5, y: 0.1, z: 0.1) }
+    }
+
+    /// Motion that is present but perfectly still — samples exist, intensity never clears the gate.
+    private func still(_ n: Int) -> [GravitySample] {
+        (0 ..< n).map { GravitySample(ts: $0, x: 0.9, y: 0.1, z: 0.1) }
+    }
+
+    private func funnelOf(_ hr: [HRSample], _ grav: [GravitySample],
+                          restingHR: Double? = 60, maxHR: Double? = 190) throws
+        -> WorkoutDetector.DetectionFunnel {
+        var f: WorkoutDetector.DetectionFunnel?
+        _ = WorkoutDetector.detect(hr: hr, gravity: grav, restingHR: restingHR, maxHR: maxHR,
+                                   age: 30, funnel: { f = $0 })
+        return try XCTUnwrap(f, "the funnel must be reported on every exit")
+    }
+
+    /// The reporter's case: a day that yields nothing, and the funnel says WHICH gate ate it.
+    ///
+    /// Here the body is still — motion rows exist in quantity, none clear the intensity threshold. That is
+    /// the WHOOP 4.0 coarse-motion suspicion (#345/#28) and it must be distinguishable from a quiet heart.
+    func testAStillDayNamesMotionAsTheGateThatAteIt() throws {
+        let f = try funnelOf(hrs(3600, 150), still(3600))
+        XCTAssertEqual(f.kept, 0)
+        XCTAssertGreaterThan(f.motionSamples, 0, "motion rows were present: \(f)")
+        XCTAssertEqual(f.motionPassed, 0, "no sample cleared the motion gate")
+        XCTAssertEqual(f.active, 0)
+        // HR was never even consulted, so the HR counters must stay clean rather than implicating it.
+        XCTAssertEqual(f.hrMissing, 0)
+        XCTAssertEqual(f.hrTooLow, 0)
+    }
+
+    /// The opposite cause, which a bout count of zero reports identically: plenty of motion, but the heart
+    /// never cleared resting + 15. Blaming the sensor here would send someone chasing the wrong fault.
+    func testAMovingButUnexertedDayNamesHRAsTheGateThatAteIt() throws {
+        let f = try funnelOf(hrs(3600, 62), moving(3600))       // floor = 60 + 15 = 75
+        XCTAssertEqual(f.kept, 0)
+        XCTAssertGreaterThan(f.motionPassed, 0, "motion cleared its gate: \(f)")
+        XCTAssertGreaterThan(f.hrTooLow, 0, "HR is what rejected them: \(f)")
+        XCTAssertEqual(f.hrMissing, 0, "not a sensor gap")
+        XCTAssertEqual(f.active, 0)
+    }
+
+    /// A sensor dropout is a third cause again: motion is there, HR simply is not.
+    func testAMissingHrStreamIsNotConfusedWithALowHeartRate() throws {
+        let f = try funnelOf(hrs(60, 150), moving(3600))        // HR only for the first minute
+        XCTAssertGreaterThan(f.hrMissing, 0, "HR gaps must be counted as gaps: \(f)")
+        XCTAssertEqual(f.hrTooLow, 0, "nothing was rejected for being too low")
+    }
+
+    /// Real work, but under the five-minute bar — the funnel must say "short", not blame a sensor.
+    func testAShortEffortIsNamedAsShort() throws {
+        // Two minutes of qualifying work inside an otherwise resting hour.
+        let hr = hrs(600, 60) + hrs(120, 150, from: 600) + hrs(2880, 60, from: 720)
+        let f = try funnelOf(hr, moving(3600))
+        XCTAssertEqual(f.kept, 0)
+        XCTAssertGreaterThan(f.runs, 0, "a run was formed: \(f)")
+        XCTAssertGreaterThan(f.droppedShort, 0, "and rejected for duration: \(f)")
+    }
+
+    /// The happy path still reports, and reports a survivor — the funnel is not a failure-only line.
+    func testARealWorkoutIsCountedAsKept() throws {
+        let hr = hrs(600, 60) + hrs(2400, 150, from: 600) + hrs(600, 60, from: 3000)
+        let f = try funnelOf(hr, moving(3600))
+        XCTAssertGreaterThan(f.kept, 0, "expected a detected bout: \(f)")
+        XCTAssertGreaterThan(f.active, 0)
+        XCTAssertEqual(f.hrSamples, 3600)
+    }
+
+    /// The thresholds the day was judged against are reported, not left for the reader to guess.
+    func testItReportsTheBarTheDayHadToClear() throws {
+        let f = try funnelOf(hrs(3600, 62), moving(3600))
+        XCTAssertEqual(f.restingHR ?? -1, 60.0, accuracy: 1e-9)
+        XCTAssertEqual(f.hrFloor ?? -1, 75.0, accuracy: 1e-9)   // resting + hrMarginBPM (15)
+    }
+
+    /// An empty day still reports — the early return must not skip the funnel.
+    func testADayWithNoDataStillReports() throws {
+        let f = try funnelOf([], [])
+        XCTAssertEqual(f.hrSamples, 0)
+        XCTAssertEqual(f.motionSamples, 0)
+        XCTAssertEqual(f.kept, 0)
+    }
+
+    /// The exact bytes. Compared between two users' logs and across platforms, so the shape is contract.
+    func testTheLineIsExactlyThis() {
+        var f = WorkoutDetector.DetectionFunnel()
+        f.hrSamples = 34137; f.motionSamples = 34136
+        f.restingHR = 59; f.hrFloor = 74
+        f.motionPassed = 1203; f.hrMissing = 12; f.hrTooLow = 1103; f.active = 88
+        f.runs = 6; f.bridged = 4
+        f.droppedShort = 4; f.droppedNoHR = 0; f.droppedLowIntensity = 0; f.kept = 0
+        XCTAssertEqual(
+            WorkoutDetector.detectionFunnelLine(day: "2026-08-24", funnel: f),
+            "effort detect day=2026-08-24 hr=34137 motion=34136 restHR=59 floor=74 "
+                + "motionOK=1203 hrMissing=12 hrTooLow=1103 active=88 runs=6 bridged=4 "
+                + "short=4 noHR=0 lowIntensity=0 kept=0")
+    }
+}

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -605,7 +605,10 @@ final class IntelligenceEngine: ObservableObject {
                             workouts: [ExerciseSession], nightlySkin: Double?,
                             sessionMotion: [Int: [Double]],
                             sessionSleepState: [Int: [Int]],
-                            hrvDiag: String?)] = []   // #195: carried from loop 1, emitted in the main-actor loop
+                            hrvDiag: String?,
+                            // #1545: carried beside `workouts` because it explains the times that list is
+                            // EMPTY, and the emit happens in the main-actor loop below, not here.
+                            detectionFunnel: WorkoutDetector.DetectionFunnel?)] = []   // #195: carried from loop 1
         // Nightly values harvested in pass 1, keyed by day, to seed the pass-2 baseline.
         var nightlyHrvByDay: [String: Double?] = [:]
         var nightlyRhrByDay: [String: Double?] = [:]
@@ -1401,7 +1404,8 @@ final class IntelligenceEngine: ObservableObject {
                                  workouts: res.workouts, nightlySkin: res.nightlySkinTempC,
                                  sessionMotion: res.sessionMotionByStart,
                                  sessionSleepState: res.sessionSleepStateByStart,
-                                 hrvDiag: scan.hrvDiag))
+                                 hrvDiag: scan.hrvDiag,
+                                 detectionFunnel: res.detectionFunnel))
         }
 
         // ── Seed the baseline from the UNION of imported nightly history + the values just computed.

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1689,6 +1689,13 @@ final class IntelligenceEngine: ObservableObject {
             // Persist the detected workouts the pipeline already computes (previously discarded).
             // Skip any bout overlapping a real imported/manual workout so import+wear users don't
             // double-count. sport = "detected"; energyKcal is the APPROXIMATE Keytel/BMR total.
+            // #1545: where the detector lost every candidate workout on this day, emitted BEFORE the
+            // per-bout loop so it is present even when that loop runs zero times — which is exactly the
+            // report it exists for. The `effort bout` line below explains a bout that exists; a strap log
+            // showing 37 days and no workouts at all previously carried nothing to explain the absence.
+            if let f = night.detectionFunnel {
+                diagnosticSink?(WorkoutDetector.detectionFunnelLine(day: daily.day, funnel: f), nil)
+            }
             for s in night.workouts {
                 let durMin = max(0, (s.end - s.start) / 60)
                 let avgBpm = Int(s.avgHR)

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -739,6 +739,7 @@ object AnalyticsEngine {
         // afternoon/evening workout is caught on its own day rather than lagging until a later pass
         // re-reads it through the next night window (which ends at ≈ noon). Falls back to the night
         // window for pure-function callers/tests.
+        var detectionFunnel: WorkoutDetector.DetectionFunnel? = null
         val workouts = WorkoutDetector.detect(
             hr = dayHr ?: hr,
             gravity = dayGravity ?: gravity,
@@ -762,6 +763,7 @@ object AnalyticsEngine {
             // on Banister whose workouts were still on Edwards would show a session scoring less than
             // the day it sits inside, which is a worse inconsistency than either method.
             effortMethod = effortMethod,
+            funnel = { detectionFunnel = it },
         )
 
         // ── Steps (APPROXIMATE) ───────────────────────────────────────────────
@@ -900,6 +902,7 @@ object AnalyticsEngine {
             sessionMotionByStart = sessionMotionByStart,
             sessionSleepStateByStart = sessionSleepStateByStart,
             gravitySparse = gravitySparse,
+            detectionFunnel = detectionFunnel,
         )
     }
 

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsModels.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsModels.kt
@@ -302,4 +302,10 @@ data class DayResult(
      * the value Swift's `analyzeDay` writes directly onto its `CachedSleepSession.stagingSparse`.
      */
     val gravitySparse: Boolean = false,
+    /**
+     * #1545: where the detector lost every candidate workout on this day. null only when detection did not
+     * run. Always populated otherwise — including (especially) when [workouts] is empty, which is the case
+     * the counts exist to explain. Trailing + defaulted so every existing construction site is unchanged.
+     */
+    val detectionFunnel: WorkoutDetector.DetectionFunnel? = null,
 )

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1446,6 +1446,11 @@ object IntelligenceEngine {
             // Persist the detected workouts the pipeline already computes (previously discarded).
             // Skip any bout overlapping a real imported/manual workout so import+wear users don't
             // double-count. sport="detected"; energyKcal is the APPROXIMATE Keytel/BMR total.
+            // #1545: where the detector lost every candidate workout on this day, emitted BEFORE the
+            // per-bout loop so it is present even when that loop runs zero times — which is exactly the
+            // report it exists for. The `effort bout` line below explains a bout that exists; a strap log
+            // showing 37 days and no workouts at all previously carried nothing to explain the absence.
+            res.detectionFunnel?.let { diag(WorkoutDetector.detectionFunnelLine(daily.day, it)) }
             for (s in res.workouts) {
                 val durMin = maxOf(0L, (s.end - s.start) / 60L).toInt()
                 val avgBpm = s.avgHR.toInt()

--- a/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
+++ b/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
@@ -107,6 +107,58 @@ object WorkoutDetector {
     }
 
     /**
+     * #1545: why a day produced no workout, counted at each gate the detector actually applies.
+     *
+     * The `effort bout` line explains a bout that EXISTS. It is silent when none does — and "no workouts at
+     * all" is the harder report to answer, because every gate looks equally plausible from outside. A
+     * reporter with 37 days and zero detected bouts previously had nothing to send that could distinguish
+     * "the strap never registered motion" (a WHOOP 4.0 banks it coarsely, #345/#28) from "HR never cleared
+     * resting + 15" from "the efforts were real but under five minutes".
+     *
+     * Counted during the detector's OWN walk, never recomputed alongside it: a funnel free to disagree with
+     * the code it describes is worse than no funnel, because it will be believed. Byte-parity twin of Swift
+     * `WorkoutDetector.DetectionFunnel`.
+     */
+    data class DetectionFunnel(
+        /** Inputs the day actually had. */
+        var hrSamples: Int = 0,
+        var motionSamples: Int = 0,
+        /** The bar a sample had to clear, in bpm — resting + [hrMarginBPM]. */
+        var restingHR: Double? = null,
+        var hrFloor: Double? = null,
+        /** Motion samples whose smoothed intensity cleared [motionThreshold]. */
+        var motionPassed: Int = 0,
+        /** Of those, how many had NO HR sample within [alignToleranceS] (a sensor gap, not a quiet body). */
+        var hrMissing: Int = 0,
+        /** Of those, how many had HR at or below [hrFloor] (moving, but not working). */
+        var hrTooLow: Int = 0,
+        /** Samples that cleared BOTH gates. */
+        var active: Int = 0,
+        /** Contiguous runs after gap-merging, and after the #303 HR-gated bridge. */
+        var runs: Int = 0,
+        var bridged: Int = 0,
+        /** Runs rejected by each qualification gate, and the survivors. */
+        var droppedShort: Int = 0,
+        var droppedNoHR: Int = 0,
+        var droppedLowIntensity: Int = 0,
+        var kept: Int = 0,
+    )
+
+    /**
+     * #1545: the always-on per-day line naming where the detector lost every candidate workout.
+     *
+     * Byte-identical string to the Swift twin. No PII: a day key and counts, plus the two bpm thresholds the
+     * day was measured against — the same privacy class as the sibling `sleep day=` line.
+     */
+    fun detectionFunnelLine(day: String, f: DetectionFunnel): String =
+        "effort detect day=$day hr=${f.hrSamples} motion=${f.motionSamples} " +
+            "restHR=${round0(f.restingHR)} floor=${round0(f.hrFloor)} " +
+            "motionOK=${f.motionPassed} hrMissing=${f.hrMissing} hrTooLow=${f.hrTooLow} " +
+            "active=${f.active} runs=${f.runs} bridged=${f.bridged} " +
+            "short=${f.droppedShort} noHR=${f.droppedNoHR} lowIntensity=${f.droppedLowIntensity} " +
+            "kept=${f.kept}"
+
+    /**
      * #1545: how much of [start]..[end] the HR sensor actually covered, as a percentage of
      * [bucketSeconds]-wide buckets holding at least one reading.
      *
@@ -347,128 +399,153 @@ object WorkoutDetector {
         // test is byte-identical; the app threads the user's choice so a bout and the day it sits in are
         // never scored by different recipes, which would be worse than either one being "wrong".
         effortMethod: StrainScorer.Method = StrainScorer.Method.EDWARDS,
+        // #1545: receives the gate-by-gate counts for THIS call. null (the default) keeps every existing
+        // caller and test byte-identical — nothing is computed that the detector was not already
+        // computing, the counters just record it.
+        funnel: ((DetectionFunnel) -> Unit)? = null,
     ): List<ExerciseSession> {
-        val hrSeg = cleanHR(hr)
-        val motion = activitySeries(gravity)
-        if (hrSeg.isEmpty() || motion.isEmpty()) return emptyList()
+        // try/finally (Swift uses `defer`) so the funnel is reported on EVERY exit, including the early
+        // returns below. A day that bails at "no motion rows at all" is precisely the day whose report
+        // matters most, and it is the one a happy-path-only emit would stay silent about.
+        val f = DetectionFunnel()
+        try {
+            val hrSeg = cleanHR(hr)
+            val motion = activitySeries(gravity)
+            f.hrSamples = hrSeg.size
+            f.motionSamples = motion.size
+            if (hrSeg.isEmpty() || motion.isEmpty()) return emptyList()
 
-        val restHR = restingHR ?: deriveRestingHR(hrSeg)
-        val hrFloor = restHR + hrMarginBPM
+            val restHR = restingHR ?: deriveRestingHR(hrSeg)
+            val hrFloor = restHR + hrMarginBPM
+            f.restingHR = restHR
+            f.hrFloor = hrFloor
 
-        val effMaxHR: Double?
-        val hrmaxSource: String
-        if (maxHR != null) {
-            effMaxHR = maxHR
-            hrmaxSource = "caller"
-        } else {
-            val (est, src) = StrainScorer.estimateHRmax(hrSeg.map { it.bpm.toDouble() }, age)
-            effMaxHR = if (est == 0.0) null else est
-            hrmaxSource = src
-        }
-
-        val hrTs = hrSeg.map { it.ts }
-        val hrBpm = hrSeg.map { it.bpm.toDouble() }
-        val smooth = smoothedIntensity(motion, motionSmoothS)
-        val motionTs = motion.map { it.ts }
-
-        // Walk the gravity timeline; flag samples where BOTH gates hold.
-        val activeTs = ArrayList<Long>()
-        for (idx in motion.indices) {
-            val p = motion[idx]
-            val inten = smooth[idx]
-            if (inten <= motionThreshold) continue
-            val bpm = nearest(hrTs, hrBpm, p.ts, alignToleranceS) ?: continue
-            if (bpm <= hrFloor) continue
-            activeTs.add(p.ts)
-        }
-        if (activeTs.isEmpty()) return emptyList()
-
-        // Group contiguous active samples into runs, merging gaps < MERGE_GAP_S.
-        val rawRuns = ArrayList<Pair<Long, Long>>()
-        var runStart = activeTs[0]
-        var prev = activeTs[0]
-        for (k in 1 until activeTs.size) {
-            val ts = activeTs[k]
-            if ((ts - prev).toDouble() > mergeGapS) {
-                rawRuns.add(runStart to prev)
-                runStart = ts
-            }
-            prev = ts
-        }
-        rawRuns.add(runStart to prev)
-
-        // Second pass (#303): bridge adjacent runs across a brief, still-elevated-HR
-        // lull so a sustained effort isn't shattered by coasting / junctions / sensor
-        // gaps. Runs over a genuine rest (HR falls to resting) are NOT bridged.
-        val runs = bridgeRuns(rawRuns, hrSeg, hrFloor)
-
-        val minDurS = minExerciseMin * 60.0
-        val sessions = ArrayList<ExerciseSession>()
-        for ((idx, run) in runs.withIndex()) {
-            val (start, end) = run
-            // Onset latency tolerance equal to the smoothing window.
-            if ((end - start).toDouble() < minDurS - motionSmoothS) continue
-            // Qualify on the HR-elevated CORE (unchanged gates) so the warm-up's low intensity
-            // can't dilute a real workout below the zone-2 bar and drop it (#148).
-            val core = hrSeg.filter { it.ts in start..end }
-            if (core.isEmpty()) continue
-
-            var zonePct: Map<Int, Double> = emptyMap()
-            var avgHRR: Double? = null
-            val m = effMaxHR
-            if (m != null && m > restHR) {
-                val (zp, ah) = boutIntensity(core, restHR, m)
-                zonePct = zp
-                avgHRR = ah
+            val effMaxHR: Double?
+            val hrmaxSource: String
+            if (maxHR != null) {
+                effMaxHR = maxHR
+                hrmaxSource = "caller"
+            } else {
+                val (est, src) = StrainScorer.estimateHRmax(hrSeg.map { it.bpm.toDouble() }, age)
+                effMaxHR = if (est == 0.0) null else est
+                hrmaxSource = src
             }
 
-            // Intensity qualification: require ≥ MIN_INTENSITY_Z2PLUS in zone 2+.
-            if (zonePct.isNotEmpty()) {
-                val z2plus = (2..5).sumOf { zonePct[it] ?: 0.0 } / 100.0
-                if (z2plus < minIntensityZ2Plus) continue
+            val hrTs = hrSeg.map { it.ts }
+            val hrBpm = hrSeg.map { it.bpm.toDouble() }
+            val smooth = smoothedIntensity(motion, motionSmoothS)
+            val motionTs = motion.map { it.ts }
+
+            // Walk the gravity timeline; flag samples where BOTH gates hold.
+            val activeTs = ArrayList<Long>()
+            for (idx in motion.indices) {
+                val p = motion[idx]
+                val inten = smooth[idx]
+                if (inten <= motionThreshold) continue
+                f.motionPassed++
+                // Split the HR rejection two ways: no sample within tolerance is a SENSOR GAP, a sample at or
+                // below the floor is a body that simply was not working. They read identically in a bout count
+                // of zero and call for opposite responses.
+                val bpm = nearest(hrTs, hrBpm, p.ts, alignToleranceS)
+                if (bpm == null) { f.hrMissing++; continue }
+                if (bpm <= hrFloor) { f.hrTooLow++; continue }
+                activeTs.add(p.ts)
             }
+            f.active = activeTs.size
+            if (activeTs.isEmpty()) return emptyList()
 
-            // Qualified → back-date the start over the warm-up and report stats on the full window (#148).
-            // Never back-date past the previous run's end: a continuous-motion stretch whose HR dipped to
-            // resting BETWEEN two efforts (so bridgeRuns kept them separate) must not overlap the earlier one.
-            val floor = if (idx > 0) runs[idx - 1].second + 1 else Long.MIN_VALUE
-            val effStart = maxOf(backdatedStart(start, motionTs, smooth), floor)
-            val window = hrSeg.filter { it.ts in effStart..end }
-            if (window.isEmpty()) continue
-            val bpms = window.map { it.bpm.toDouble() }
-
-            var kcal: Double? = null
-            var kj: Double? = null
-            if (profile != null) {
-                val (k, j) = Calories.estimateBoutCalories(window, profile, effMaxHR, restHR)
-                kcal = k
-                kj = j
+            // Group contiguous active samples into runs, merging gaps < MERGE_GAP_S.
+            val rawRuns = ArrayList<Pair<Long, Long>>()
+            var runStart = activeTs[0]
+            var prev = activeTs[0]
+            for (k in 1 until activeTs.size) {
+                val ts = activeTs[k]
+                if ((ts - prev).toDouble() > mergeGapS) {
+                    rawRuns.add(runStart to prev)
+                    runStart = ts
+                }
+                prev = ts
             }
+            rawRuns.add(runStart to prev)
+            f.runs = rawRuns.size
 
-            val avg = bpms.sum() / bpms.size.toDouble()
-            val peak = window.maxOf { it.bpm }
-            val strain = StrainScorer.strain(
-                window, effMaxHR, restHR, effortMethod, profile?.sex ?: "male")
+            // Second pass (#303): bridge adjacent runs across a brief, still-elevated-HR
+            // lull so a sustained effort isn't shattered by coasting / junctions / sensor
+            // gaps. Runs over a genuine rest (HR falls to resting) are NOT bridged.
+            val runs = bridgeRuns(rawRuns, hrSeg, hrFloor)
+            f.bridged = runs.size
 
-            sessions.add(
-                ExerciseSession(
-                    start = effStart,
-                    end = end,
-                    avgHR = avg,
-                    peakHR = peak,
-                    strain = strain,
-                    durationS = (end - effStart).toDouble(),
-                    zoneTimePct = zonePct,
-                    avgHRRPct = avgHRR,
-                    hrmax = effMaxHR,
-                    hrmaxSource = hrmaxSource,
-                    caloriesKcal = kcal,
-                    caloriesKJ = kj,
-                    hrCoveragePct = hrCoveragePct(window.map { it.ts }, effStart, end),
+            val minDurS = minExerciseMin * 60.0
+            val sessions = ArrayList<ExerciseSession>()
+            for ((idx, run) in runs.withIndex()) {
+                val (start, end) = run
+                // Onset latency tolerance equal to the smoothing window.
+                if ((end - start).toDouble() < minDurS - motionSmoothS) { f.droppedShort++; continue }
+                // Qualify on the HR-elevated CORE (unchanged gates) so the warm-up's low intensity
+                // can't dilute a real workout below the zone-2 bar and drop it (#148).
+                val core = hrSeg.filter { it.ts in start..end }
+                if (core.isEmpty()) { f.droppedNoHR++; continue }
+
+                var zonePct: Map<Int, Double> = emptyMap()
+                var avgHRR: Double? = null
+                val m = effMaxHR
+                if (m != null && m > restHR) {
+                    val (zp, ah) = boutIntensity(core, restHR, m)
+                    zonePct = zp
+                    avgHRR = ah
+                }
+
+                // Intensity qualification: require ≥ MIN_INTENSITY_Z2PLUS in zone 2+.
+                if (zonePct.isNotEmpty()) {
+                    val z2plus = (2..5).sumOf { zonePct[it] ?: 0.0 } / 100.0
+                    if (z2plus < minIntensityZ2Plus) { f.droppedLowIntensity++; continue }
+                }
+
+                // Qualified → back-date the start over the warm-up and report stats on the full window (#148).
+                // Never back-date past the previous run's end: a continuous-motion stretch whose HR dipped to
+                // resting BETWEEN two efforts (so bridgeRuns kept them separate) must not overlap the earlier one.
+                val floor = if (idx > 0) runs[idx - 1].second + 1 else Long.MIN_VALUE
+                val effStart = maxOf(backdatedStart(start, motionTs, smooth), floor)
+                val window = hrSeg.filter { it.ts in effStart..end }
+                if (window.isEmpty()) { f.droppedNoHR++; continue }
+                val bpms = window.map { it.bpm.toDouble() }
+
+                var kcal: Double? = null
+                var kj: Double? = null
+                if (profile != null) {
+                    val (k, j) = Calories.estimateBoutCalories(window, profile, effMaxHR, restHR)
+                    kcal = k
+                    kj = j
+                }
+
+                val avg = bpms.sum() / bpms.size.toDouble()
+                val peak = window.maxOf { it.bpm }
+                val strain = StrainScorer.strain(
+                    window, effMaxHR, restHR, effortMethod, profile?.sex ?: "male")
+
+                sessions.add(
+                    ExerciseSession(
+                        start = effStart,
+                        end = end,
+                        avgHR = avg,
+                        peakHR = peak,
+                        strain = strain,
+                        durationS = (end - effStart).toDouble(),
+                        zoneTimePct = zonePct,
+                        avgHRRPct = avgHRR,
+                        hrmax = effMaxHR,
+                        hrmaxSource = hrmaxSource,
+                        caloriesKcal = kcal,
+                        caloriesKJ = kj,
+                        hrCoveragePct = hrCoveragePct(window.map { it.ts }, effStart, end),
+                    )
                 )
-            )
+            }
+            f.kept = sessions.size
+            return sessions
+        } finally {
+            funnel?.invoke(f)
         }
-        return sessions
     }
 }
 

--- a/android/app/src/test/java/com/noop/analytics/DetectionFunnelTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DetectionFunnelTest.kt
@@ -1,0 +1,139 @@
+package com.noop.analytics
+
+import com.noop.data.GravitySample
+import com.noop.data.HrSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1545: why a day produced no workout, counted at each gate the detector actually applies.
+ *
+ * The `effort bout` line explains a bout that EXISTS, so it is silent on the harder report — a strap log
+ * with 37 days and zero detected workouts, where every gate looks equally plausible from outside. These
+ * tests pin that the funnel separates the causes rather than just confirming the zero.
+ *
+ * Byte-parity twin of Swift `DetectionFunnelTests`.
+ */
+class DetectionFunnelTest {
+
+    private val dev = "t"
+    private fun hrs(n: Int, bpm: Int, from: Int = 0) =
+        (from until from + n).map { HrSample(dev, it.toLong(), bpm) }
+
+    /** Motion that genuinely varies — a constant vector has zero intensity and detects nothing. */
+    private fun moving(n: Int, from: Int = 0) = (from until from + n).map {
+        GravitySample(dev, it.toLong(), x = if (it % 2 == 0) 0.9 else 0.5, y = 0.1, z = 0.1)
+    }
+
+    /** Motion that is present but perfectly still — samples exist, intensity never clears the gate. */
+    private fun still(n: Int) = (0 until n).map {
+        GravitySample(dev, it.toLong(), x = 0.9, y = 0.1, z = 0.1)
+    }
+
+    private fun funnelOf(
+        hr: List<HrSample>, grav: List<GravitySample>,
+        restingHR: Double? = 60.0, maxHR: Double? = 190.0,
+    ): WorkoutDetector.DetectionFunnel {
+        var f: WorkoutDetector.DetectionFunnel? = null
+        WorkoutDetector.detect(hr = hr, gravity = grav, restingHR = restingHR, maxHR = maxHR,
+                               age = 30.0, funnel = { f = it })
+        assertNotNull("the funnel must be reported on every exit", f)
+        return f!!
+    }
+
+    /**
+     * The reporter's case: a day that yields nothing, and the funnel says WHICH gate ate it.
+     *
+     * Here the body is still — motion rows exist in quantity, none clear the intensity threshold. That is
+     * the WHOOP 4.0 coarse-motion suspicion (#345/#28) and it must be distinguishable from a quiet heart.
+     */
+    @Test
+    fun aStillDayNamesMotionAsTheGateThatAteIt() {
+        val f = funnelOf(hrs(3600, 150), still(3600))
+        assertEquals(0, f.kept)
+        assertTrue("motion rows were present: $f", f.motionSamples > 0)
+        assertEquals("no sample cleared the motion gate", 0, f.motionPassed)
+        assertEquals(0, f.active)
+        // HR was never even consulted, so the HR counters must stay clean rather than implicating it.
+        assertEquals(0, f.hrMissing)
+        assertEquals(0, f.hrTooLow)
+    }
+
+    /**
+     * The opposite cause, which a bout count of zero reports identically: plenty of motion, but the heart
+     * never cleared resting + 15. Blaming the sensor here would send someone chasing the wrong fault.
+     */
+    @Test
+    fun aMovingButUnexertedDayNamesHRAsTheGateThatAteIt() {
+        val f = funnelOf(hrs(3600, 62), moving(3600))       // floor = 60 + 15 = 75
+        assertEquals(0, f.kept)
+        assertTrue("motion cleared its gate: $f", f.motionPassed > 0)
+        assertTrue("HR is what rejected them: $f", f.hrTooLow > 0)
+        assertEquals("not a sensor gap", 0, f.hrMissing)
+        assertEquals(0, f.active)
+    }
+
+    /** A sensor dropout is a third cause again: motion is there, HR simply is not. */
+    @Test
+    fun aMissingHrStreamIsNotConfusedWithALowHeartRate() {
+        val f = funnelOf(hrs(60, 150), moving(3600))         // HR only for the first minute
+        assertTrue("HR gaps must be counted as gaps: $f", f.hrMissing > 0)
+        assertEquals("nothing was rejected for being too low", 0, f.hrTooLow)
+    }
+
+    /** Real work, but under the five-minute bar — the funnel must say "short", not blame a sensor. */
+    @Test
+    fun aShortEffortIsNamedAsShort() {
+        // Two minutes of qualifying work inside an otherwise resting hour.
+        val hr = hrs(600, 60) + hrs(120, 150, from = 600) + hrs(2880, 60, from = 720)
+        val f = funnelOf(hr, moving(3600))
+        assertEquals(0, f.kept)
+        assertTrue("a run was formed: $f", f.runs > 0)
+        assertTrue("and rejected for duration: $f", f.droppedShort > 0)
+    }
+
+    /** The happy path still reports, and reports a survivor — the funnel is not a failure-only line. */
+    @Test
+    fun aRealWorkoutIsCountedAsKept() {
+        val hr = hrs(600, 60) + hrs(2400, 150, from = 600) + hrs(600, 60, from = 3000)
+        val f = funnelOf(hr, moving(3600))
+        assertTrue("expected a detected bout: $f", f.kept > 0)
+        assertTrue(f.active > 0)
+        assertEquals(f.hrSamples, 3600)
+    }
+
+    /** The thresholds the day was judged against are reported, not left for the reader to guess. */
+    @Test
+    fun itReportsTheBarTheDayHadToClear() {
+        val f = funnelOf(hrs(3600, 62), moving(3600))
+        assertEquals(60.0, f.restingHR!!, 1e-9)
+        assertEquals(75.0, f.hrFloor!!, 1e-9)   // resting + hrMarginBPM (15)
+    }
+
+    /** An empty day still reports — the early return must not skip the funnel. */
+    @Test
+    fun aDayWithNoDataStillReports() {
+        val f = funnelOf(emptyList(), emptyList())
+        assertEquals(0, f.hrSamples)
+        assertEquals(0, f.motionSamples)
+        assertEquals(0, f.kept)
+    }
+
+    /** The exact bytes. Compared between two users' logs and across platforms, so the shape is contract. */
+    @Test
+    fun theLineIsExactlyThis() {
+        val f = WorkoutDetector.DetectionFunnel(
+            hrSamples = 34137, motionSamples = 34136, restingHR = 59.0, hrFloor = 74.0,
+            motionPassed = 1203, hrMissing = 12, hrTooLow = 1103, active = 88,
+            runs = 6, bridged = 4, droppedShort = 4, droppedNoHR = 0, droppedLowIntensity = 0, kept = 0,
+        )
+        assertEquals(
+            "effort detect day=2026-08-24 hr=34137 motion=34136 restHR=59 floor=74 " +
+                "motionOK=1203 hrMissing=12 hrTooLow=1103 active=88 runs=6 bridged=4 " +
+                "short=4 noHR=0 lowIntensity=0 kept=0",
+            WorkoutDetector.detectionFunnelLine("2026-08-24", f),
+        )
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/DetectionFunnelTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DetectionFunnelTest.kt
@@ -121,6 +121,41 @@ class DetectionFunnelTest {
         assertEquals(0, f.kept)
     }
 
+    /**
+     * The funnel must ACCOUNT for everything, not merely count some things.
+     *
+     * Two arithmetic invariants hold by construction, because each gate is an exclusive `continue`:
+     *   A. every motion sample that cleared its gate is then either a sensor gap, a too-low heart rate,
+     *      or active — `motionOK == hrMissing + hrTooLow + active`;
+     *   B. every run that survived bridging has exactly one outcome —
+     *      `bridged == short + noHR + lowIntensity + kept`.
+     *
+     * This is the test that earns the funnel its trust. A future gate added to the detector without a
+     * matching counter would silently make some rejections vanish from the line — and a diagnostic that
+     * loses candidates without saying so is exactly the thing this whole feature exists to stop being.
+     */
+    @Test
+    fun everyRejectedCandidateIsAccountedFor() {
+        val cases = listOf(
+            "still" to Pair(hrs(3600, 150), still(3600)),
+            "unexerted" to Pair(hrs(3600, 62), moving(3600)),
+            "hr gap" to Pair(hrs(60, 150), moving(3600)),
+            "short" to Pair(hrs(600, 60) + hrs(120, 150, 600) + hrs(2880, 60, 720), moving(3600)),
+            "real" to Pair(hrs(600, 60) + hrs(2400, 150, 600) + hrs(600, 60, 3000), moving(3600)),
+        )
+        for ((name, io) in cases) {
+            val f = funnelOf(io.first, io.second)
+            assertEquals(
+                "$name: motionOK must equal hrMissing + hrTooLow + active ($f)",
+                f.motionPassed, f.hrMissing + f.hrTooLow + f.active,
+            )
+            assertEquals(
+                "$name: bridged runs must equal short + noHR + lowIntensity + kept ($f)",
+                f.bridged, f.droppedShort + f.droppedNoHR + f.droppedLowIntensity + f.kept,
+            )
+        }
+    }
+
     /** The exact bytes. Compared between two users' logs and across platforms, so the shape is contract. */
     @Test
     fun theLineIsExactlyThis() {


### PR DESCRIPTION
The missing half of the #1545 diagnostics.

The `effort bout` line from #1566 explains a bout that **exists**. It is silent when none does — and
"no workouts at all" is the harder report. A strap log with **37 days, 25.6M raw rows and
`workouts=0`** carried nothing that could distinguish:

| what actually happened | what it needs |
|---|---|
| the strap never registered motion (a 4.0 banks it coarsely, #345/#28) | a different sensor conversation |
| HR never cleared resting + 15 | nothing — working as designed |
| a sensor gap where HR simply wasn't there | fit / wear guidance |
| efforts real but under five minutes | a threshold conversation |

From outside, all four look identical: zero.

## The line

```
effort detect day=… hr= motion= restHR= floor= motionOK= hrMissing= hrTooLow=
                    active= runs= bridged= short= noHR= lowIntensity= kept=
```

Emitted per day, always on, beside the existing `sleep day=` line — and **before** the per-bout loop,
so it is present precisely when that loop runs zero times.

On four fixtures that all produce a zero, it reads:

```
still body           motionOK=0                     -> the motion gate
moving, unexerted    motionOK=3598 hrTooLow=3598    -> the HR gate
two-minute effort    active=120 runs=1 short=1      -> the duration gate
real 40-min workout  kept=1
```

## Design notes

**Counted during the detector's own walk**, never recomputed beside it. A funnel free to disagree with
the code it describes is worse than no funnel, because it will be believed.

**Reported via `defer` (Swift) / `try/finally` (Kotlin)** so it survives every early return — including
the "no rows at all" exit, which is the day whose report matters most and the one a happy-path-only
emit would stay silent about.

**The HR rejection splits two ways on purpose.** No sample within tolerance is a *sensor gap*; a sample
at or below the floor is a *body that wasn't working*. Both read as zero bouts and call for opposite
responses, so `hrMissing` and `hrTooLow` are separate counters.

**It reports the bar, not just the verdict** — `restHR` and `floor` are in the line, so a reader can
see what the day was actually judged against instead of inferring it.

## Parity

Diffed, not assumed:

- **Counter fields** — identical names, identical order, both platforms.
- **The line** — identical token order: `day hr motion restHR floor motionOK hrMissing hrTooLow active
  runs bridged short noHR lowIntensity kept`.
- **Counter writes** — same counters at the same gates, in the same order through the detector.
- **Tests** — the same 9 case names each side.

The `funnel` parameter defaults to null/nil, so every existing caller and test is byte-identical —
nothing is computed that the detector was not already computing; the counters just record it.

**One asymmetry, and it cannot affect the numbers.** Swift increments `droppedNoHR` at three sites,
Kotlin at two. Swift's third is a pre-existing `guard !bpms.isEmpty` where `bpms = window.map { … }`
and `window.isEmpty` was rejected two lines earlier — `map` preserves count, so it is unreachable.
Kotlin never had that guard. Instrumenting it is defensive rather than dead-code-with-a-counter: if a
future change ever makes it reachable, the rejection is counted instead of silently vanishing from the
line. I left the guard itself alone — it predates this PR and removing it is a separate concern.

Minor and cosmetic: Swift declares `detectionFunnel` next to `workouts` (they belong together), Kotlin
declares it trailing so the defaulted parameter stays source-compatible. `DayResult` is a return type,
never persisted, so declaration order carries no contract here.

**The counters account for everything, and that is asserted.** Two invariants hold by construction,
because every gate is an exclusive `continue`:

```
motionOK == hrMissing + hrTooLow + active
bridged  == short + noHR + lowIntensity + kept
```

`everyRejectedCandidateIsAccountedFor` asserts both across all five fixtures on both platforms. I
verified it bites: dropping one counter increment from the detector fails it. That is the regression a
future gate added without a matching counter would introduce — and a diagnostic that silently loses
candidates is the exact thing this feature exists to stop being.

## Verification

- `:app:testFullDebugUnitTest --no-build-cache --rerun-tasks` — **4273 tests, 0 failures** (9 new).
- Swift twin `DetectionFunnelTests` (9 cases) runs on `swift-packages.yml`; StrandAnalytics can't build
  on this Linux box (GRDB/CSQLite, per CLAUDE.md).
- `doc_comment_lint.py` OK, `i18n_audit.py --ci main` OK.
- New line checked against the Test Centre domain markers — no collision, no day-count inflated.
- **⚠️ app-build required before merge** — the emit is in `Strand/Data/IntelligenceEngine.swift`, which
  no default CI compiles. Not dispatched.
- **Not yet seen on hardware.** The point is that the next zero-workout log arrives with the answer
  already in it.

## Reviewing the Kotlin diff

`try/finally` forced a **whitespace re-indent of the `detect()` body** (134 lines). Review with `-w` to
see the real change — it is about twenty lines of counters plus the struct.