### PR TITLE
Stop an active trace from disabling the re-score reuse cache

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyzeRecentDayCache.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyzeRecentDayCache.swift
@@ -35,8 +35,18 @@ public enum AnalyzeRecentDayCache {
     /// Inputs that feed `analyzeDay` but are pass-global rather than per-day (profile, baselines1, sleep
     /// need / consistency, habitual midsleep, tz, stager toggles) are NOT in this key — the engine drops the
     /// whole cache when its pass config signature changes, which covers them.
-    public static func cacheKey(owner: String, hrCount: Int, hrMaxTs: Int, skinAnchorRaw: Double?) -> String {
+    public static func cacheKey(owner: String, hrCount: Int, hrMaxTs: Int, skinAnchorRaw: Double?,
+                                // #1575: whether this day is the one that emits the PER-WINDOW HRV detail
+                                // (`dayStart == nowLocalMidnight`). Now that an active trace no longer
+                                // disables reuse, this has to invalidate: the night cached as "today" with
+                                // its detailed trace becomes an ordinary night after midnight, and a fresh
+                                // scan would emit only the one-line summary for it. Without this the reused
+                                // night would keep replaying detail it is no longer entitled to — and the
+                                // cache's whole promise is that a reused night is indistinguishable from a
+                                // freshly-scored one. Costs one day's re-score per rollover, and only while
+                                // a trace mode is on.
+                                hrvWindowDetail: Bool) -> String {
         let anchor = skinAnchorRaw.map { String($0.bitPattern) } ?? "nil"
-        return "\(owner)|\(hrCount):\(hrMaxTs):\(anchor)"
+        return "\(owner)|\(hrCount):\(hrMaxTs):\(anchor):\(hrvWindowDetail ? "d" : "s")"
     }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyzeRecentDayCacheTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyzeRecentDayCacheTests.swift
@@ -8,16 +8,16 @@ import XCTest
 final class AnalyzeRecentDayCacheTests: XCTestCase {
     // Unchanged inputs → identical key → the day is reused.
     func testStableInputsReuse() {
-        let a = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290)
-        let b = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290)
+        let a = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290, hrvWindowDetail: false)
+        let b = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290, hrvWindowDetail: false)
         XCTAssertEqual(a, b)
     }
 
     // A new HR row (count moves) OR a later newest-ts must invalidate — the day changed.
     func testHrChangeInvalidates() {
-        let base = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290)
-        let moreRows = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_001, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290)
-        let laterTs = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000, hrMaxTs: 1_700_000_060, skinAnchorRaw: 1290)
+        let base = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290, hrvWindowDetail: false)
+        let moreRows = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_001, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290, hrvWindowDetail: false)
+        let laterTs = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000, hrMaxTs: 1_700_000_060, skinAnchorRaw: 1290, hrvWindowDetail: false)
         XCTAssertNotEqual(base, moreRows)
         XCTAssertNotEqual(base, laterTs)
     }
@@ -25,17 +25,17 @@ final class AnalyzeRecentDayCacheTests: XCTestCase {
     // A shifted window-wide skin anchor (another night's skin changed the 4.0 median) must invalidate even
     // when this night's HR fingerprint is identical — the skin conversion changed.
     func testAnchorShiftInvalidates() {
-        let a = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290)
-        let b = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290.5)
+        let a = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290, hrvWindowDetail: false)
+        let b = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290.5, hrvWindowDetail: false)
         XCTAssertNotEqual(a, b)
     }
 
     // A 5/MG night (no anchor) is a distinct, self-consistent key: nil reuses nil, and nil ≠ a real anchor
     // (so a 4.0 and a 5/MG night with the same fingerprint never alias to each other's scan).
     func testNilAnchorDistinctButStable() {
-        let nilA = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 5_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: nil)
-        let nilB = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 5_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: nil)
-        let real = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 5_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 0)
+        let nilA = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 5_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: nil, hrvWindowDetail: false)
+        let nilB = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 5_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: nil, hrvWindowDetail: false)
+        let real = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 5_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 0, hrvWindowDetail: false)
         XCTAssertEqual(nilA, nilB)
         XCTAssertNotEqual(nilA, real)
     }
@@ -45,8 +45,27 @@ final class AnalyzeRecentDayCacheTests: XCTestCase {
     // count+maxTs for the same window. The owner id is part of the key, so it never falsely reuses one
     // strap's scan for the other.
     func testDifferentOwnerInvalidates() {
-        let whoop4 = AnalyzeRecentDayCache.cacheKey(owner: "whoop4-A", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290)
-        let whoop5 = AnalyzeRecentDayCache.cacheKey(owner: "whoop5-B", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290)
+        let whoop4 = AnalyzeRecentDayCache.cacheKey(owner: "whoop4-A", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290, hrvWindowDetail: false)
+        let whoop5 = AnalyzeRecentDayCache.cacheKey(owner: "whoop5-B", hrCount: 178_000, hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290, hrvWindowDetail: false)
         XCTAssertNotEqual(whoop4, whoop5)
+    }
+
+    /// #1575: the day that emits the per-window HRV DETAIL must not be reused as an ordinary night.
+    ///
+    /// An active trace no longer disables reuse, so the cached "today" carries a detailed HRV trace. After
+    /// midnight that same night is an ordinary one and a fresh scan would emit only the one-line summary —
+    /// replaying the detail would break the cache's whole promise, that a reused night is indistinguishable
+    /// from a freshly-scored one. Folding the flag into the key costs one day's re-score per rollover, and
+    /// only while a trace mode is on.
+    ///
+    /// Byte-parity twin of Kotlin `theHrvDetailDayIsNotReusedAsAnOrdinaryNight`.
+    func testTheHrvDetailDayIsNotReusedAsAnOrdinaryNight() {
+        let detail = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000,
+                                                    hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290,
+                                                    hrvWindowDetail: true)
+        let summary = AnalyzeRecentDayCache.cacheKey(owner: "dev1", hrCount: 178_000,
+                                                     hrMaxTs: 1_700_000_000, skinAnchorRaw: 1290,
+                                                     hrvWindowDetail: false)
+        XCTAssertNotEqual(detail, summary, "the detail day must invalidate when it stops being today")
     }
 }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -720,7 +720,12 @@ final class IntelligenceEngine: ObservableObject {
         let useMotionAwareWakeGlobal = PuffinExperiment.motionAwareWakeEnabled
         // Cache eligibility for the whole pass: never reuse while a Test-Centre trace is active (a cached
         // scan carries no fresh gate trace). Owner-level eligibility (registered WHOOP) is checked per day.
-        let dayCacheEligible = !(sleepTraceActive || hrvTraceActive || stepsTraceActive)
+        // #1575: an active trace no longer disables reuse. Swift was already safe by construction here —
+        // `DayScan` carries `sleepTrace` / `hrvTrace` / `stepsTrace`, a cache hit appends the whole scan, and
+        // the main-actor loop replays all three — so the gate was the only thing costing a full 21-day
+        // re-read + re-score on every pass whenever a diagnostic was switched on. (Kotlin emits its trace
+        // inline in pass 1 and therefore needed per-day recorders to reach the same place.)
+        let dayCacheEligible = true
         // The pass config signature — every input that feeds `analyzeDay` but is NOT in the per-day key, so
         // a change to any of them must invalidate every cached night. baselines1 is signed structurally
         // (any BaselineState field change ⇒ a different string); Doubles by raw bit-pattern (exact, locale-
@@ -846,9 +851,10 @@ final class IntelligenceEngine: ObservableObject {
                         skinAnchorResolvedOwners.insert(owner)
                     }
                     if let fp = try? await store.hrFingerprint(deviceId: owner, from: from, to: to) {
-                        let key = AnalyzeRecentDayCache.cacheKey(owner: owner, hrCount: fp.count,
-                                                                 hrMaxTs: fp.maxTs,
-                                                                 skinAnchorRaw: skinAnchorByOwner[owner])
+                        let key = AnalyzeRecentDayCache.cacheKey(
+                            owner: owner, hrCount: fp.count, hrMaxTs: fp.maxTs,
+                            skinAnchorRaw: skinAnchorByOwner[owner],
+                            hrvWindowDetail: dayStart == nowLocalMidnight)
                         dayCacheKey = key
                         if let cached = dayScanCacheLocal[day], cached.key == key {
                             out.append(cached.scan)

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -854,7 +854,12 @@ final class IntelligenceEngine: ObservableObject {
                         let key = AnalyzeRecentDayCache.cacheKey(
                             owner: owner, hrCount: fp.count, hrMaxTs: fp.maxTs,
                             skinAnchorRaw: skinAnchorByOwner[owner],
-                            hrvWindowDetail: dayStart == nowLocalMidnight)
+                            // #1575: `hrvTraceActive &&` matters. With the HRV trace OFF no detail
+                            // line is ever produced, so the flag describes nothing — but it would still
+                            // flip at midnight and invalidate yesterday, charging EVERY user an extra
+                            // day's re-score to protect lines they never see. Gating it keeps the default
+                            // path exactly as it was.
+                            hrvWindowDetail: hrvTraceActive && dayStart == nowLocalMidnight)
                         dayCacheKey = key
                         if let cached = dayScanCacheLocal[day], cached.key == key {
                             out.append(cached.scan)

--- a/android/app/src/main/java/com/noop/analytics/AnalyzeRecentDayCache.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyzeRecentDayCache.kt
@@ -40,8 +40,18 @@ object AnalyzeRecentDayCache {
      * / consistency, habitual midsleep, tz, stager toggles) are NOT in this key — the engine drops the whole
      * cache when its pass config signature changes, which covers them.
      */
-    fun cacheKey(owner: String, hrCount: Int, hrMaxTs: Long, skinAnchorRaw: Double?): String {
+    fun cacheKey(
+        owner: String, hrCount: Int, hrMaxTs: Long, skinAnchorRaw: Double?,
+        // #1575: whether this day is the one that emits the PER-WINDOW HRV detail (`dayStart ==
+        // nowLocalMidnight`). Now that trace lines are recorded and replayed, this has to invalidate:
+        // the night cached as "today" with its detailed trace becomes an ordinary night after midnight,
+        // and a fresh scan would emit only the one-line summary for it. Without this, the reused night
+        // would keep replaying detail it is no longer entitled to — the cache's whole promise is that a
+        // reused night is indistinguishable from a freshly-scored one. Costs one day's re-score per
+        // midnight rollover, and only when a trace mode is on.
+        hrvWindowDetail: Boolean,
+    ): String {
         val anchor = skinAnchorRaw?.toRawBits()?.toString() ?: "nil"
-        return "$owner|$hrCount:$hrMaxTs:$anchor"
+        return "$owner|$hrCount:$hrMaxTs:$anchor:${if (hrvWindowDetail) "d" else "s"}"
     }
 }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -217,9 +217,9 @@ object IntelligenceEngine {
         // depending on a cache hit — breaking the one thing the cache promises. It would also diverge from
         // Swift, whose sink has always been collect-only (`traceSink = { sleepTrace.append($0) }`) with a
         // grouped emit in its main-actor loop. One emit path now serves both hit and miss.
-        val sleepRec: ((String) -> Unit)? = sleepSink?.let { _ -> { l: String -> sleep.add(l) } }
-        val hrvRec: ((String) -> Unit)? = hrvSink?.let { _ -> { l: String -> hrv.add(l) } }
-        val stepsRec: ((String) -> Unit)? = stepsSink?.let { _ -> { l: String -> steps.add(l) } }
+        val sleepRec: ((String) -> Unit)? = if (sleepSink == null) null else { l -> sleep.add(l) }
+        val hrvRec: ((String) -> Unit)? = if (hrvSink == null) null else { l -> hrv.add(l) }
+        val stepsRec: ((String) -> Unit)? = if (stepsSink == null) null else { l -> steps.add(l) }
         fun snapshot() = DayTraces(sleep.toList(), hrv.toList(), steps.toList())
     }
 
@@ -721,16 +721,6 @@ object IntelligenceEngine {
             // <200-HR SKIPPED line below stays a plain diag (that day is never cached).
             val dayDiagLines = ArrayList<String>()
             fun dayDiag(line: String) { dayDiagLines.add(line); diag(line) }
-            // #1575: the same record-and-forward shape for the three PER-DAY trace channels. Until now an
-            // active sleep/HRV/steps trace disabled the reuse cache outright, because a reused night would
-            // not re-emit those lines — so turning on a diagnostic cost a full 21-day re-read + re-score on
-            // every pass. Recording them per day makes a reused night replay its trace exactly like it
-            // already replays [dayDiagLines], and the diagnostic stops costing what it was measuring.
-            // Recorders are null when the mode is off, so the default path allocates nothing extra. Built
-            // by a small class rather than inline: `analyzeRecentOnCpu` sits close to the JVM's 64 KB
-            // per-method bytecode ceiling, and inline lambdas here pushed the JaCoCo-instrumented size past
-            // the budget #1524 guards (see IntelligenceEngineJacocoBudgetTest).
-            val dayTrace = DayTraceRecorders(sleepTraceSink, hrvTraceSink, stepsTraceSink)
             // Read a generous window around the night that ends on `day`; the stager finds the span.
             val from = dayStart - 30 * 3_600L
             // Sleep read-window END — see `sleepReadWindowEnd`. A PAST day reads through to the next
@@ -819,6 +809,18 @@ object IntelligenceEngine {
             // verbatim universal `dayOwner …` line per SCORED day (matching the iOS emit, which is in the
             // scored-days loop, NOT here). Only when the universal sink is on. A day skipped below for too
             // few rows is never scored, so it emits no line, byte-identical to the iOS behaviour.
+            // #1575: the same per-day collection shape for the three PER-DAY trace channels. Until now an
+            // active sleep/HRV/steps trace disabled the reuse cache outright, because a reused night would
+            // not re-emit those lines — so turning on a diagnostic cost a full 21-day re-read + re-score on
+            // every pass. Recording them per day makes a reused night replay its trace exactly like it
+            // already replays [dayDiagLines], and the diagnostic stops costing what it was measuring.
+            // Allocated AFTER the cache-hit `continue` above: a reused day replays from its cached
+            // snapshot and never needs recorders, so building them earlier was garbage on exactly the
+            // path this change exists to make cheap. Null when the mode is off. Built
+            // by a small class rather than inline: `analyzeRecentOnCpu` sits close to the JVM's 64 KB
+            // per-method bytecode ceiling, and inline lambdas here pushed the JaCoCo-instrumented size past
+            // the budget #1524 guards (see IntelligenceEngineJacocoBudgetTest).
+            val dayTrace = DayTraceRecorders(sleepTraceSink, hrvTraceSink, stepsTraceSink)
             if (universalSink != null) readOwnerByDay[day] = OwnerRead(owner, hr.size)
             if (hr.size < MIN_HR_SAMPLES) {
                 // This day still paid for its read; count it, or the tally under-reports exactly the

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -211,9 +211,15 @@ object IntelligenceEngine {
         val sleep = ArrayList<String>()
         val hrv = ArrayList<String>()
         val steps = ArrayList<String>()
-        val sleepRec: ((String) -> Unit)? = sleepSink?.let { s -> { l: String -> sleep.add(l); s(l) } }
-        val hrvRec: ((String) -> Unit)? = hrvSink?.let { s -> { l: String -> hrv.add(l); s(l) } }
-        val stepsRec: ((String) -> Unit)? = stepsSink?.let { s -> { l: String -> steps.add(l); s(l) } }
+        // COLLECT ONLY — the lines are emitted once, grouped, by [replayDayTraces] after the day is
+        // scored. Forwarding live here instead would make a freshly-scored night interleave its sleep and
+        // HRV lines while a REUSED night emitted them grouped, so the same night would read differently
+        // depending on a cache hit — breaking the one thing the cache promises. It would also diverge from
+        // Swift, whose sink has always been collect-only (`traceSink = { sleepTrace.append($0) }`) with a
+        // grouped emit in its main-actor loop. One emit path now serves both hit and miss.
+        val sleepRec: ((String) -> Unit)? = sleepSink?.let { _ -> { l: String -> sleep.add(l) } }
+        val hrvRec: ((String) -> Unit)? = hrvSink?.let { _ -> { l: String -> hrv.add(l) } }
+        val stepsRec: ((String) -> Unit)? = stepsSink?.let { _ -> { l: String -> steps.add(l) } }
         fun snapshot() = DayTraces(sleep.toList(), hrv.toList(), steps.toList())
     }
 
@@ -239,12 +245,12 @@ object IntelligenceEngine {
 
     /** #1575: replay a reused night's recorded trace lines to their own channels, in emit order. */
     private fun replayDayTraces(
-        cached: CachedDayScan,
+        traces: DayTraces,
         sleepSink: ((String) -> Unit)?, hrvSink: ((String) -> Unit)?, stepsSink: ((String) -> Unit)?,
     ) {
-        for (line in cached.traces.sleep) sleepSink?.invoke(line)
-        for (line in cached.traces.hrv) hrvSink?.invoke(line)
-        for (line in cached.traces.steps) stepsSink?.invoke(line)
+        for (line in traces.sleep) sleepSink?.invoke(line)
+        for (line in traces.hrv) hrvSink?.invoke(line)
+        for (line in traces.steps) stepsSink?.invoke(line)
     }
 
     /**
@@ -798,7 +804,7 @@ object IntelligenceEngine {
                     for (line in cached.diagLines) diag(line)
                     // #1575: replay this night's trace lines to their own channels, so a reused night is
                     // indistinguishable from a freshly-scored one in the export as well as in the numbers.
-                    replayDayTraces(cached, sleepTraceSink, hrvTraceSink, stepsTraceSink)
+                    replayDayTraces(cached.traces, sleepTraceSink, hrvTraceSink, stepsTraceSink)
                     dayCacheReused++
                     continue
                 }
@@ -1201,13 +1207,18 @@ object IntelligenceEngine {
             // this pass — a WHOOP 4.0 owner with no trace active — hence dayCacheKey != null). Reused days
             // continue'd above and never reach here, so the cache only ever holds fresh scans. Carries the
             // per-day maps' values (read back from the maps just written) + the diag lines to replay.
+            // #1575: emit this night's trace through the SAME function the cache-hit path uses, so a
+            // freshly-scored night and a reused one are byte-identical in the log as well as in the
+            // numbers. Runs whether or not the day is cacheable.
+            val dayTraces = dayTrace.snapshot()
+            replayDayTraces(dayTraces, sleepTraceSink, hrvTraceSink, stepsTraceSink)
             dayCacheKey?.let { key ->
                 dayScanCache[day] = CachedDayScan(
                     key = key, res = res, owner = owner, hrRows = hr.size,
                     primaryRhr = primaryRhr, primaryRhrCoverage = primaryRhrCoverage,
                     spo2Candidate = spo2CandidateByDay[day], hrvOverCount = hrvOverCountByDay[day],
                     diagLines = dayDiagLines.toList(),
-                    traces = dayTrace.snapshot(),
+                    traces = dayTraces,
                 )
                 dayCacheCacheable++
             }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -92,6 +92,12 @@ object IntelligenceEngine {
         val spo2Candidate: Int?,
         val hrvOverCount: Boolean?,
         val diagLines: List<String>,
+        /** #1575: the per-day trace lines for each channel, replayed on a hit so an active trace no
+         *  longer forces a full re-read + re-score of every night on every pass. Empty when those modes
+         *  are off, which is the default. One carrier rather than three fields so the cache-store site
+         *  inside `analyzeRecentOnCpu` stays one statement — that method is close to the JVM's 64 KB
+         *  bytecode ceiling (#1524). */
+        val traces: DayTraces = DayTraces(),
     )
 
     /**
@@ -180,6 +186,66 @@ object IntelligenceEngine {
      */
     fun ownerSourceAbsentLine(importedDeviceId: String): String =
         "analyzeRecent ownerSource=absent owner->$importedDeviceId skinTempScale->whoop5"
+
+    /** #1575: one night's recorded trace lines, per channel. Immutable snapshot of [DayTraceRecorders]. */
+    data class DayTraces(
+        val sleep: List<String> = emptyList(),
+        val hrv: List<String> = emptyList(),
+        val steps: List<String> = emptyList(),
+    )
+
+    /**
+     * #1575: per-day recorders for the three trace channels that a reused night has to replay.
+     *
+     * Each recorder appends the line AND forwards it, exactly like the [dayDiag] wrapper the always-on
+     * lines already use. A null sink (the mode is off, the default) leaves its recorder null, so the
+     * default path allocates nothing beyond three empty lists.
+     *
+     * A class rather than inline lambdas because `analyzeRecentOnCpu` is close to the JVM's 64 KB
+     * per-method bytecode limit; building them here keeps that method under the instrumentation budget
+     * #1524 guards. No Swift twin — `defer`-free and purely a bytecode-size concern.
+     */
+    private class DayTraceRecorders(
+        sleepSink: ((String) -> Unit)?, hrvSink: ((String) -> Unit)?, stepsSink: ((String) -> Unit)?,
+    ) {
+        val sleep = ArrayList<String>()
+        val hrv = ArrayList<String>()
+        val steps = ArrayList<String>()
+        val sleepRec: ((String) -> Unit)? = sleepSink?.let { s -> { l: String -> sleep.add(l); s(l) } }
+        val hrvRec: ((String) -> Unit)? = hrvSink?.let { s -> { l: String -> hrv.add(l); s(l) } }
+        val stepsRec: ((String) -> Unit)? = stepsSink?.let { s -> { l: String -> steps.add(l); s(l) } }
+        fun snapshot() = DayTraces(sleep.toList(), hrv.toList(), steps.toList())
+    }
+
+    /**
+     * The 5/MG raw-counter steps trace for one day, routed through [sink].
+     *
+     * Lifted out of `analyzeRecentOnCpu` unchanged: that method sits within ~100 bytes of the JaCoCo
+     * budget #1524 guards, so a block of this size has to live somewhere else for #1575's recorders to
+     * fit. Behaviour is identical — the same guard, the same lines, the same order.
+     */
+    private fun emitStepsRawTrace(
+        sink: ((String) -> Unit)?, daySteps: List<com.noop.data.StepSample>,
+        day: String, tzOffsetSeconds: Long, ticksPerStep: Double,
+    ) {
+        if (sink == null || daySteps.isEmpty()) return
+        for (line in StepsEstimateEngineTrace.rawCounterTrace(
+            daySteps = daySteps, dayKey = day, tzOffsetSeconds = tzOffsetSeconds,
+            ticksPerStep = ticksPerStep,
+        )) {
+            sink(line)
+        }
+    }
+
+    /** #1575: replay a reused night's recorded trace lines to their own channels, in emit order. */
+    private fun replayDayTraces(
+        cached: CachedDayScan,
+        sleepSink: ((String) -> Unit)?, hrvSink: ((String) -> Unit)?, stepsSink: ((String) -> Unit)?,
+    ) {
+        for (line in cached.traces.sleep) sleepSink?.invoke(line)
+        for (line in cached.traces.hrv) hrvSink?.invoke(line)
+        for (line in cached.traces.steps) stepsSink?.invoke(line)
+    }
 
     /**
      * Compute on-device scores for each of the last [maxDays] that actually has raw HR
@@ -579,7 +645,12 @@ object IntelligenceEngine {
         // pass-2 (emitted for cached nights too), and universal's only pass-1 write (readOwnerByDay) is
         // repopulated on a hit below — so those DON'T disable caching. Matches the Swift `dayCacheEligible`
         // (sleep/hrv/steps), so cache activation is identical on both platforms. (#1005)
-        val dayCacheEligible = sleepTraceSink == null && hrvTraceSink == null && stepsTraceSink == null
+        // #1575: an active trace no longer disables reuse. The three per-day channels are recorded and
+        // replayed (see the recorders in the loop below), so a reused night emits the identical trace. The
+        // other sinks were never a reason to disable: recovery/workouts are pass-2 and already run for
+        // cached nights, and universal's single pass-1 write is repopulated on a hit. Kept as a named
+        // constant rather than deleted so the Swift twin and the tests have something to point at.
+        val dayCacheEligible = true
         // The pass config signature — every input that feeds `analyzeDay` but is NOT in the per-day key, so a
         // change to any of them must invalidate every cached night. Deterministic within-process strings
         // (compared only to itself in memory, so cross-platform identity isn't required); baselines1 is signed
@@ -644,6 +715,16 @@ object IntelligenceEngine {
             // <200-HR SKIPPED line below stays a plain diag (that day is never cached).
             val dayDiagLines = ArrayList<String>()
             fun dayDiag(line: String) { dayDiagLines.add(line); diag(line) }
+            // #1575: the same record-and-forward shape for the three PER-DAY trace channels. Until now an
+            // active sleep/HRV/steps trace disabled the reuse cache outright, because a reused night would
+            // not re-emit those lines — so turning on a diagnostic cost a full 21-day re-read + re-score on
+            // every pass. Recording them per day makes a reused night replay its trace exactly like it
+            // already replays [dayDiagLines], and the diagnostic stops costing what it was measuring.
+            // Recorders are null when the mode is off, so the default path allocates nothing extra. Built
+            // by a small class rather than inline: `analyzeRecentOnCpu` sits close to the JVM's 64 KB
+            // per-method bytecode ceiling, and inline lambdas here pushed the JaCoCo-instrumented size past
+            // the budget #1524 guards (see IntelligenceEngineJacocoBudgetTest).
+            val dayTrace = DayTraceRecorders(sleepTraceSink, hrvTraceSink, stepsTraceSink)
             // Read a generous window around the night that ends on `day`; the stager finds the span.
             val from = dayStart - 30 * 3_600L
             // Sleep read-window END — see `sleepReadWindowEnd`. A PAST day reads through to the next
@@ -691,7 +772,9 @@ object IntelligenceEngine {
                     skinAnchorResolvedOwners.add(owner)
                 }
                 val (fpCount, fpMaxTs) = repo.hrFingerprintWindow(owner, from, to)
-                val key = AnalyzeRecentDayCache.cacheKey(owner, fpCount, fpMaxTs, skinAnchorByOwner[owner])
+                val key = AnalyzeRecentDayCache.cacheKey(
+                    owner, fpCount, fpMaxTs, skinAnchorByOwner[owner],
+                    hrvWindowDetail = dayStart == nowLocalMidnight)
                 dayCacheKey = key
                 val cached = dayScanCache[day]
                 if (cached != null && cached.key == key) {
@@ -713,6 +796,9 @@ object IntelligenceEngine {
                     scoredNights.add(cached.res)
                     resolvedScoreOwnerByDay[day] = cached.owner
                     for (line in cached.diagLines) diag(line)
+                    // #1575: replay this night's trace lines to their own channels, so a reused night is
+                    // indistinguishable from a freshly-scored one in the export as well as in the numbers.
+                    replayDayTraces(cached, sleepTraceSink, hrvTraceSink, stepsTraceSink)
                     dayCacheReused++
                     continue
                 }
@@ -892,8 +978,8 @@ object IntelligenceEngine {
                 // default) keeps analyzeDay's byte-identical untraced path; when the caller passed a non-null
                 // sink (mode on), detectSleep's gate trace + the Rest sub-score line route to the .sleep-tagged
                 // strap log. The sink is already the routing closure, so there is no per-day collect/replay.
-                traceSink = sleepTraceSink,
-                hrvTraceSink = hrvTraceSink,
+                traceSink = dayTrace.sleepRec,
+                hrvTraceSink = dayTrace.hrvRec,
                 // Per-window HRV detail ONLY for the most-recent night (dayStart == today's local midnight),
                 // so the 5000-line ring buffer isn't flooded; every night still emits the 1-line summary.
                 hrvWindowDetail = dayStart == nowLocalMidnight,
@@ -1057,14 +1143,7 @@ object IntelligenceEngine {
             // motion-estimated, surfaced by the calibration/estimate trace below). Skipping the call here
             // stops the 4.0 export carrying a "counterSamples=0 ... need >=2" line that read as broken; a
             // 5/MG always banks counter rows so this never suppresses its real trace.
-            if (stepsTraceSink != null && daySteps.isNotEmpty()) {
-                for (line in StepsEstimateEngineTrace.rawCounterTrace(
-                    daySteps = daySteps, dayKey = day, tzOffsetSeconds = tzOffsetSeconds,
-                    ticksPerStep = profile.stepTicksPerStep,
-                )) {
-                    stepsTraceSink(line)
-                }
-            }
+            emitStepsRawTrace(dayTrace.stepsRec, daySteps, day, tzOffsetSeconds, profile.stepTicksPerStep)
 
             // Harvest the baseline-independent nightly aggregates (a day with no detected
             // sleep yields null → recorded as a missing night, i.e. skip-and-hold). The raw
@@ -1128,6 +1207,7 @@ object IntelligenceEngine {
                     primaryRhr = primaryRhr, primaryRhrCoverage = primaryRhrCoverage,
                     spo2Candidate = spo2CandidateByDay[day], hrvOverCount = hrvOverCountByDay[day],
                     diagLines = dayDiagLines.toList(),
+                    traces = dayTrace.snapshot(),
                 )
                 dayCacheCacheable++
             }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -770,7 +770,12 @@ object IntelligenceEngine {
                 val (fpCount, fpMaxTs) = repo.hrFingerprintWindow(owner, from, to)
                 val key = AnalyzeRecentDayCache.cacheKey(
                     owner, fpCount, fpMaxTs, skinAnchorByOwner[owner],
-                    hrvWindowDetail = dayStart == nowLocalMidnight)
+                    // #1575: `&& hrvTraceSink != null` matters. With the HRV trace OFF no detail line
+                    // is ever produced, so the flag describes nothing — but it would still flip at
+                    // midnight and invalidate yesterday, charging EVERY user an extra day's re-score to
+                    // protect lines they never see. Gating it keeps the default path exactly as it was and
+                    // makes the cost what this change claims: paid only while a trace is on.
+                    hrvWindowDetail = hrvTraceSink != null && dayStart == nowLocalMidnight)
                 dayCacheKey = key
                 val cached = dayScanCache[day]
                 if (cached != null && cached.key == key) {

--- a/android/app/src/test/java/com/noop/analytics/AnalyzeRecentDayCacheTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/AnalyzeRecentDayCacheTest.kt
@@ -11,18 +11,36 @@ import org.junit.Test
  * must / must not invalidate a reused day is a shared contract).
  */
 class AnalyzeRecentDayCacheTest {
+
+    /**
+     * #1575: the day that emits the per-window HRV DETAIL must not be reused as an ordinary night.
+     *
+     * Trace lines are now recorded and replayed, so the cached "today" carries a detailed HRV trace. After
+     * midnight that same night is an ordinary one and a fresh scan would emit only the one-line summary —
+     * replaying the detail would break the cache's whole promise, that a reused night is indistinguishable
+     * from a freshly-scored one. Folding the flag into the key costs one day's re-score per rollover, and
+     * only while a trace mode is on.
+     */
+    @Test
+    fun theHrvDetailDayIsNotReusedAsAnOrdinaryNight() {
+        val detail = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_000L, 1290.0,
+                                                    hrvWindowDetail = true)
+        val summary = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_000L, 1290.0,
+                                                     hrvWindowDetail = false)
+        assertNotEquals("the detail day must invalidate when it stops being today", detail, summary)
+    }
     // Unchanged inputs -> identical key -> the day is reused.
     @Test fun stableInputsReuse() {
-        val a = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_000L, 1290.0)
-        val b = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_000L, 1290.0)
+        val a = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_000L, 1290.0, hrvWindowDetail = false)
+        val b = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_000L, 1290.0, hrvWindowDetail = false)
         assertEquals(a, b)
     }
 
     // A new HR row (count moves) OR a later newest-ts must invalidate — the day changed.
     @Test fun hrChangeInvalidates() {
-        val base = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_000L, 1290.0)
-        val moreRows = AnalyzeRecentDayCache.cacheKey("dev1", 178_001, 1_700_000_000L, 1290.0)
-        val laterTs = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_060L, 1290.0)
+        val base = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_000L, 1290.0, hrvWindowDetail = false)
+        val moreRows = AnalyzeRecentDayCache.cacheKey("dev1", 178_001, 1_700_000_000L, 1290.0, hrvWindowDetail = false)
+        val laterTs = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_060L, 1290.0, hrvWindowDetail = false)
         assertNotEquals(base, moreRows)
         assertNotEquals(base, laterTs)
     }
@@ -30,17 +48,17 @@ class AnalyzeRecentDayCacheTest {
     // A shifted window-wide skin anchor (another night's skin changed the 4.0 median) must invalidate even
     // when this night's HR fingerprint is identical — the skin conversion changed.
     @Test fun anchorShiftInvalidates() {
-        val a = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_000L, 1290.0)
-        val b = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_000L, 1290.5)
+        val a = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_000L, 1290.0, hrvWindowDetail = false)
+        val b = AnalyzeRecentDayCache.cacheKey("dev1", 178_000, 1_700_000_000L, 1290.5, hrvWindowDetail = false)
         assertNotEquals(a, b)
     }
 
     // A night with no anchor (null) is a distinct, self-consistent key: null reuses null, and null != a real
     // anchor (so it never aliases to a real-anchor night's scan).
     @Test fun nullAnchorDistinctButStable() {
-        val nilA = AnalyzeRecentDayCache.cacheKey("dev1", 5_000, 1_700_000_000L, null)
-        val nilB = AnalyzeRecentDayCache.cacheKey("dev1", 5_000, 1_700_000_000L, null)
-        val real = AnalyzeRecentDayCache.cacheKey("dev1", 5_000, 1_700_000_000L, 0.0)
+        val nilA = AnalyzeRecentDayCache.cacheKey("dev1", 5_000, 1_700_000_000L, null, hrvWindowDetail = false)
+        val nilB = AnalyzeRecentDayCache.cacheKey("dev1", 5_000, 1_700_000_000L, null, hrvWindowDetail = false)
+        val real = AnalyzeRecentDayCache.cacheKey("dev1", 5_000, 1_700_000_000L, 0.0, hrvWindowDetail = false)
         assertEquals(nilA, nilB)
         assertNotEquals(nilA, real)
     }
@@ -50,8 +68,8 @@ class AnalyzeRecentDayCacheTest {
     // count+maxTs for the same window. The owner id is part of the key, so it never falsely reuses one
     // strap's scan for the other.
     @Test fun differentOwnerInvalidates() {
-        val whoop4 = AnalyzeRecentDayCache.cacheKey("whoop4-A", 178_000, 1_700_000_000L, 1290.0)
-        val whoop5 = AnalyzeRecentDayCache.cacheKey("whoop5-B", 178_000, 1_700_000_000L, 1290.0)
+        val whoop4 = AnalyzeRecentDayCache.cacheKey("whoop4-A", 178_000, 1_700_000_000L, 1290.0, hrvWindowDetail = false)
+        val whoop5 = AnalyzeRecentDayCache.cacheKey("whoop5-B", 178_000, 1_700_000_000L, 1290.0, hrvWindowDetail = false)
         assertNotEquals(whoop4, whoop5)
     }
 }


### PR DESCRIPTION
Turning on a Test Centre trace disabled the #1005 per-day reuse cache outright, so **the diagnostic
cost roughly what it was measuring**.

From a WHOOP 4.0 log with sleep + HRV traces on:

```
analyzeRecent dayCache reused=0/0 size=0 days=21     ← every pass
analyzeRecent cost prep=211663ms score=38583ms       ← 3.5 min in one pass
```

**13 minutes of heavy CPU in a ~70-minute session, on battery**, 84% of it in the windowed store
reads — all 21 days re-read and re-scored on every pass, because `dayCacheEligible` required all
three per-day trace sinks to be null.

The reason was real: a reused night would not re-emit its trace lines. The fix is the shape the
always-on lines already use — **record and replay**.

## The two platforms needed very different work

| | why |
|---|---|
| **Swift** | Already safe by construction. `DayScan` carries `sleepTrace`/`hrvTrace`/`stepsTrace`, a hit appends the whole scan, and the main-actor loop replays all three. The gate was the *only* thing costing the re-score. |
| **Kotlin** | Emits its trace inline during pass 1, so it needed per-day recorders that append-and-forward — mirroring the existing `dayDiag` wrapper — plus replay on a hit. |

Same contract, different amount of code, because the engines emit diagnostics at different points.

## A correctness catch found while wiring it

The per-window HRV **detail** is emitted only for `dayStart == nowLocalMidnight`. Once trace lines
are replayed, the night cached as "today" would keep replaying its *detailed* trace after midnight —
when a fresh scan would emit only the one-line summary. That silently breaks the cache's whole
promise, that a reused night is indistinguishable from a freshly-scored one.

The flag is now part of the per-day key on both platforms, so exactly the one affected day
invalidates at rollover. Cost: one day's re-score per midnight, and only while a trace is on.

**The new parameter is deliberately not defaulted.** #1567 — merged earlier today — was caused by
precisely that: a defaulted parameter a caller silently omitted. Every call site now has to state
its answer.

## Parity

Diffed, not assumed:

| | Swift | Kotlin |
|---|---|---|
| cache key | `"\(owner)\|\(hrCount):\(hrMaxTs):\(anchor):\(hrvWindowDetail ? "d" : "s")"` | `"$owner\|$hrCount:$hrMaxTs:$anchor:${if (hrvWindowDetail) "d" else "s"}"` |
| gate | `let dayCacheEligible = true` | `val dayCacheEligible = true` |
| emit order | sleep → hrv → steps | sleep → hrv → steps |
| sink | collect-only | collect-only |

**A divergence I introduced and then removed.** The first cut had the Kotlin recorders append *and*
forward live, so a freshly-scored night interleaved its sleep and HRV lines while a reused night
emitted them grouped — the same night reading differently depending on a cache hit, which breaks the
exact promise the cache is built on. Swift has always been collect-only
(`traceSink = { sleepTrace.append($0) }`) with one grouped emit. Kotlin now matches: recorders
collect, and **both** the hit and miss paths emit through the same `replayDayTraces`, so the two
cannot drift.

Consequence worth stating: Kotlin's live trace lines now land **grouped at the end of each day's
block** rather than interleaved through it. Same content, and the platforms now agree.

## Bytecode budget

`analyzeRecentOnCpu` sits within ~100 bytes of the JVM's 64 KB per-method ceiling. The first cut
pushed the JaCoCo-instrumented size to 63954 against a 61535 budget, so:

- the recorders are built by a small class rather than inline lambdas;
- the replay is a helper;
- the (pre-existing, behaviourally unchanged) steps raw-counter emit is lifted into a helper.

`IntelligenceEngineJacocoBudgetTest` (#1524) caught it and is what the sizes were tuned against. **No
baseline was raised.**

## Verification

- `:app:testFullDebugUnitTest --no-build-cache --rerun-tasks` — **4274 tests, 0 failures**.
- JaCoCo budget test passes; confirmed it fails without the extractions.
- `doc_comment_lint.py` OK.
- Swift twin tests updated + a matching rollover case; they run on `swift-packages.yml`.
- **⚠️ app-build required before merge** — `Strand/Data/IntelligenceEngine.swift` is app-target.
- **Not yet measured on hardware.** The proof is a strap log with traces on showing `reused=~20/21`
  instead of `reused=0/0`, and `prep` collapsing with it. That is the number to check, not the tests.

## Honest coverage note

The engine-level behaviour — that a reused night under an active trace replays the identical lines —
is **not** unit-tested. There is no engine-with-repository harness in the tree, and building one is
its own piece of work. What is tested is the key contract; the rest rides on the device measurement
above.