### PR TITLE
Let the overnight keep-alive switch be turned off again

### DIFF
--- a/android/app/src/main/java/com/noop/ble/BackgroundHealth.kt
+++ b/android/app/src/main/java/com/noop/ble/BackgroundHealth.kt
@@ -45,6 +45,35 @@ object BackgroundHealth {
             ?.isIgnoringBatteryOptimizations(context.packageName) == true
 
     /**
+     * What a tap on the "Keep NOOP alive overnight" switch should DO, given which way it was moved and
+     * whether the exemption is currently granted.
+     *
+     * A pure decision table rather than an `if` buried in the Compose handler, because the bug it fixes was
+     * a MISSING BRANCH and nothing could have caught it: the OFF direction matched no branch, no state
+     * moved, and the switch snapped back to on. Reported as "the toggle doesn't work, it won't let me turn
+     * it off" — the correct read, since a Switch is bidirectional and one that silently swallows half its
+     * input is broken however good the platform reason. Here the table is exhaustive and pinned by tests.
+     *
+     * Android has no API to revoke an app's own exemption ([Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS]
+     * can only ask), so neither direction flips it directly — both open the surface where the user can act.
+     */
+    enum class BatteryToggleAction {
+        /** Not yet exempt, user asked for ON: the one-tap system grant dialog. */
+        RequestExemption,
+        /** Already exempt, user asked for OFF: NOOP's system settings page, where Battery lives. */
+        OpenAppSettings,
+        /** The switch is already where the user just put it — do nothing, and never re-prompt. */
+        None,
+    }
+
+    /** Pure; see [BatteryToggleAction]. */
+    fun batteryToggleAction(wantOn: Boolean, isExempt: Boolean): BatteryToggleAction = when {
+        wantOn && !isExempt -> BatteryToggleAction.RequestExemption
+        !wantOn && isExempt -> BatteryToggleAction.OpenAppSettings
+        else -> BatteryToggleAction.None
+    }
+
+    /**
      * The one-tap system dialog to whitelist NOOP from battery optimisation. Sideload-only intent
      * (Play restricts it; NOOP doesn't ship there). Build-only — the caller starts it on a user tap and
      * falls back to [appBatterySettingsIntent] if a ROM hides this action.

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1948,20 +1948,39 @@ fun SettingsScreen(
                         }
                         Switch(
                             checked = batteryExempt,
-                            // A system grant can't be toggled OFF from here (that's a system action): a tap
-                            // only ever REQUESTS it, and when already exempt the switch is inert (no re-prompt).
+                            // Android has no API to REVOKE an app's own battery-optimisation exemption —
+                            // ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS can only ask — so `checked` tracks the
+                            // live system state and neither direction can flip it from here directly.
+                            //
+                            // This used to mean the OFF direction did literally nothing: the handler matched no
+                            // branch, no state moved, and the switch snapped back to on. Reported as "the toggle
+                            // doesn't work, it won't let me turn it off", which is the correct read — a Switch is
+                            // a bidirectional control, and one that silently swallows half its input is broken
+                            // however good the reason. "Inert" was reasoning from the implementation's side of
+                            // the screen, not the user's.
+                            //
+                            // So BOTH directions now go where the user can actually act: ON opens the one-tap
+                            // grant dialog, OFF opens NOOP's own system settings page, where Battery lives. The
+                            // ON_RESUME observer above re-reads the live state on return, so the switch settles
+                            // to the truth by itself either way.
                             onCheckedChange = { wantOn ->
-                                if (wantOn && !batteryExempt) {
+                                when (com.noop.ble.BackgroundHealth.batteryToggleAction(wantOn, batteryExempt)) {
                                     // The whole feature exists for ROMs that strip things — so the fallback
                                     // is guarded too: if BOTH the exemption dialog and the app-settings page
                                     // are missing, no-op rather than crash (the OEM link below is another path).
-                                    runCatching {
-                                        context.startActivity(com.noop.ble.BackgroundHealth.batteryExemptionIntent(context))
-                                    }.onFailure {
+                                    com.noop.ble.BackgroundHealth.BatteryToggleAction.RequestExemption ->
+                                        runCatching {
+                                            context.startActivity(com.noop.ble.BackgroundHealth.batteryExemptionIntent(context))
+                                        }.onFailure {
+                                            runCatching {
+                                                context.startActivity(com.noop.ble.BackgroundHealth.appBatterySettingsIntent(context))
+                                            }
+                                        }
+                                    com.noop.ble.BackgroundHealth.BatteryToggleAction.OpenAppSettings ->
                                         runCatching {
                                             context.startActivity(com.noop.ble.BackgroundHealth.appBatterySettingsIntent(context))
                                         }
-                                    }
+                                    com.noop.ble.BackgroundHealth.BatteryToggleAction.None -> Unit
                                 }
                             },
                             colors = SwitchDefaults.colors(

--- a/android/app/src/test/java/com/noop/ble/BackgroundHealthTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BackgroundHealthTest.kt
@@ -1,6 +1,7 @@
 package com.noop.ble
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -39,5 +40,71 @@ class BackgroundHealthTest {
             listOf("xiaomi", "oppo", "vivo", "huawei", "oneplus", "realme", "meizu"),
             BackgroundHealth.AGGRESSIVE_VENDORS,
         )
+    }
+
+    // ── #386 follow-up: the "Keep NOOP alive overnight" switch ────────────────────────────────────
+
+    /**
+     * The reported bug: the switch could be turned on but not off.
+     *
+     * `onCheckedChange` handled only `wantOn && !isExempt`. Moving it the other way matched no branch, so
+     * no state changed and the switch — bound to the live system exempt state — snapped straight back to
+     * on. A Switch is a bidirectional control; one that silently swallows half its input is broken however
+     * good the platform reason, and "the toggle doesn't work" was the correct read.
+     */
+    @Test
+    fun turningItOffDoesSomething() {
+        assertEquals(
+            BackgroundHealth.BatteryToggleAction.OpenAppSettings,
+            BackgroundHealth.batteryToggleAction(wantOn = false, isExempt = true),
+        )
+    }
+
+    /** Turning it on when not yet exempt still fires the one-tap grant dialog. */
+    @Test
+    fun turningItOnRequestsTheExemption() {
+        assertEquals(
+            BackgroundHealth.BatteryToggleAction.RequestExemption,
+            BackgroundHealth.batteryToggleAction(wantOn = true, isExempt = false),
+        )
+    }
+
+    /**
+     * Popup discipline (#386): an already-exempt phone must never be re-prompted, so a tap that agrees with
+     * the current state does nothing at all.
+     */
+    @Test
+    fun aTapThatAgreesWithTheCurrentStateDoesNothing() {
+        assertEquals(
+            BackgroundHealth.BatteryToggleAction.None,
+            BackgroundHealth.batteryToggleAction(wantOn = true, isExempt = true),
+        )
+        assertEquals(
+            BackgroundHealth.BatteryToggleAction.None,
+            BackgroundHealth.batteryToggleAction(wantOn = false, isExempt = false),
+        )
+    }
+
+    /**
+     * The table is total: all four (wantOn, isExempt) combinations are covered, and only the two that agree
+     * with the current state may be inert. This is what stops the original bug — a direction quietly
+     * falling through to no action — from coming back.
+     */
+    @Test
+    fun everyCombinationIsAccountedFor() {
+        val inert = listOf(true to true, false to false)
+        for (wantOn in listOf(true, false)) {
+            for (isExempt in listOf(true, false)) {
+                val action = BackgroundHealth.batteryToggleAction(wantOn, isExempt)
+                if ((wantOn to isExempt) in inert) {
+                    assertEquals("($wantOn,$isExempt) agrees with state", BackgroundHealth.BatteryToggleAction.None, action)
+                } else {
+                    assertNotEquals(
+                        "($wantOn,$isExempt) asks for a CHANGE and must do something",
+                        BackgroundHealth.BatteryToggleAction.None, action,
+                    )
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
**Reported:** "Keep NOOP alive overnight" could be enabled but not disabled — the switch sprang back
every time.

## The cause

```kotlin
onCheckedChange = { wantOn ->
    if (wantOn && !batteryExempt) { … }   // ← no else. OFF matched nothing.
}
```

`checked` is bound to the **live system state** (`PowerManager.isIgnoringBatteryOptimizations`), not to
an app setting. Moving the switch off ran the handler, matched no branch, changed nothing — and the
switch snapped straight back to on.

## Why it was written that way, and why it is still a bug

The platform reason is real, and the code said so: Android has no API to **revoke** an app's own
battery-optimisation exemption. `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` can only ask.

But *the grant being one-way does not make the control one-way.* A `Switch` is a bidirectional
affordance; one that silently swallows half its input is broken however good the reason, and "the
toggle doesn't work" is the correct read. The old comment — *"the switch is inert"* — was reasoning
from the implementation's side of the screen rather than the user's.

## The fix

Both directions now go where the user can actually act:

| tap | action |
|---|---|
| ON, not exempt | the one-tap system grant dialog |
| OFF, exempt | NOOP's own system settings page, where Battery lives |
| either, agreeing with current state | nothing — no re-prompt |

The existing `ON_RESUME` observer already re-reads the live state, so the switch settles to the truth
by itself whichever way it was moved and whatever the user did once they got there.

## Why it's a decision table, not another `if`

The bug was a **missing branch**, and nothing could have caught it while the logic lived in an
untestable Compose lambda. It is now a pure `BackgroundHealth.batteryToggleAction(wantOn, isExempt)`,
the handler is an exhaustive `when`, and a test asserts that **every** `(wantOn, isExempt)` combination
which asks for a *change* does something.

Verified it bites: deleting the off branch fails exactly `turningItOffDoesSomething` and
`everyCombinationIsAccountedFor`.

Popup discipline (#386) is unchanged — a tap agreeing with the current state is still inert, so an
already-exempt phone is never re-prompted.

## Parity

**Android-only by nature, checked rather than assumed.** iOS has no per-app battery-optimisation
exemption to grant or revoke; its only background read is a diagnostic
(`IOSDiagnostics.backgroundRefreshStatus`), never a toggle. There is no `BackgroundHealth` equivalent
and no Apple-side keep-alive control anywhere in the tree.

## Verification

- `:app:testFullDebugUnitTest --no-build-cache --rerun-tasks` — **4278 tests, 0 failures** (4 new).
- `doc_comment_lint.py` OK, `i18n_audit.py --ci main` OK. **No new strings**, so no translation work.
- **No app-target Swift touched**, so no app-build needed.
- **Not yet confirmed on a device.** The check is: toggle it off, land on NOOP's settings page, set
  Battery to Optimised, come back — the switch should now read off.
