### PR TITLE
Stop rendering a one-way permission as a two-way switch

### DIFF
--- a/android/app/src/main/java/com/noop/ble/BackgroundHealth.kt
+++ b/android/app/src/main/java/com/noop/ble/BackgroundHealth.kt
@@ -12,11 +12,15 @@ import android.provider.Settings
  * but aggressive OEM battery managers kill even those, so the reliable lever is a USER action:
  * whitelist NOOP from battery optimisation (and, on the worst vendors, enable auto-start). This
  * centralises the detection and the intents that fix it, so the Settings "Keep NOOP alive overnight"
- * toggle and the Test Centre diagnostics share ONE source of truth for the vendor set + exempt check.
+ * row and the Test Centre diagnostics share ONE source of truth for the vendor set + exempt check.
  *
  * POPUP DISCIPLINE: nothing here ever fires a system dialog on its own. [batteryExemptionIntent] and
  * [oemAutostartIntent] only build Intents — the caller starts one exactly when the user taps, and the
- * toggle reflects live [isBatteryExempt] state so an already-exempt user is never prompted again.
+ * row reflects live [isBatteryExempt] state so an already-exempt user is never prompted again.
+ *
+ * That row is a STATUS LINE PLUS ONE ACTION, deliberately not a switch: Android exposes no way to
+ * revoke an app's own exemption, so a bidirectional control could never honour half its input. It was
+ * a Switch once, and was reported as broken for exactly that reason. See [batteryRowAction].
  *
  * The whitelist adds NO battery cost of its own: it removes a premature kill, it does not add work.
  * The real cost is the existing "Keep connected in the background" / "Continuous HRV" / "Overnight only"

--- a/android/app/src/main/java/com/noop/ble/BackgroundHealth.kt
+++ b/android/app/src/main/java/com/noop/ble/BackgroundHealth.kt
@@ -45,6 +45,31 @@ object BackgroundHealth {
             ?.isIgnoringBatteryOptimizations(context.packageName) == true
 
     /**
+     * What the "Keep NOOP alive overnight" row's action should DO, given whether the exemption is granted.
+     *
+     * This row is NOT a setting: [isBatteryExempt] is read nowhere but the Settings screen itself, and the
+     * thing that actually keeps NOOP alive overnight is the Background-connection preference above it. This
+     * row reports an Android permission and asks for it.
+     *
+     * It used to be rendered as a Switch, which was reported as broken — it could be turned on but not off.
+     * That was the correct read: Android has no API to revoke an app's own exemption
+     * ([Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS] can only ask), so the off direction did
+     * nothing and the switch sprang back. The answer is not a cleverer Switch; a bidirectional control was
+     * always the wrong shape for a one-way grant. It is now a status line plus a single action, and this is
+     * that action.
+     */
+    enum class BatteryRowAction {
+        /** Not yet exempt: the one-tap system grant dialog. */
+        RequestExemption,
+        /** Already exempt: NOOP's system settings page, where the user can revoke it. */
+        OpenAppSettings,
+    }
+
+    /** Pure; see [BatteryRowAction]. Total over the only input there is. */
+    fun batteryRowAction(isExempt: Boolean): BatteryRowAction =
+        if (isExempt) BatteryRowAction.OpenAppSettings else BatteryRowAction.RequestExemption
+
+    /**
      * The one-tap system dialog to whitelist NOOP from battery optimisation. Sideload-only intent
      * (Play restricts it; NOOP doesn't ship there). Build-only — the caller starts it on a user tap and
      * falls back to [appBatterySettingsIntent] if a ROM hides this action.

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -391,7 +391,7 @@ object AndroidDiagnostics {
      *  internal so it unit-tests without a Context (the suite stays Robolectric-free). */
     internal fun oemKillHeuristic(manufacturer: String): String =
         // Single source of truth for the aggressive-vendor set (#386): the same list the Settings
-        // "Keep NOOP alive overnight" toggle gates on, so the diagnostic and the fix never disagree.
+        // "Keep NOOP alive overnight" row gates on, so the diagnostic and the fix never disagree.
         if (com.noop.ble.BackgroundHealth.isAggressiveVendor(manufacturer))
             "aggressive vendor (${manufacturer.lowercase()}), whitelist NOOP to keep it alive"
         else "standard"

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -113,6 +113,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.semantics.Role
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -1967,25 +1968,33 @@ fun SettingsScreen(
                             },
                             style = NoopType.subhead,
                             color = Palette.accent,
-                            modifier = Modifier.clickable {
-                                when (com.noop.ble.BackgroundHealth.batteryRowAction(batteryExempt)) {
-                                    // The whole feature exists for ROMs that strip things — so the fallback
-                                    // is guarded too: if BOTH the exemption dialog and the app-settings page
-                                    // are missing, no-op rather than crash (the OEM link above is another path).
-                                    com.noop.ble.BackgroundHealth.BatteryRowAction.RequestExemption ->
-                                        runCatching {
-                                            context.startActivity(com.noop.ble.BackgroundHealth.batteryExemptionIntent(context))
-                                        }.onFailure {
+                            modifier = Modifier
+                                // This action REPLACED a Switch, which came with a comfortable touch
+                                // target for free. A bare Text is ~20dp — under the 48dp minimum, and
+                                // it is now the only way to act on this row, so it has to be padded
+                                // rather than merely present. `.clickable{}` BEFORE `.padding()`:
+                                // modifiers apply outside-in, so this puts the padding inside the
+                                // clickable node and grows the target; the reverse would not.
+                                .clickable(role = Role.Button) {
+                                    when (com.noop.ble.BackgroundHealth.batteryRowAction(batteryExempt)) {
+                                        // The whole feature exists for ROMs that strip things — so the fallback
+                                        // is guarded too: if BOTH the exemption dialog and the app-settings page
+                                        // are missing, no-op rather than crash (the OEM link above is another path).
+                                        com.noop.ble.BackgroundHealth.BatteryRowAction.RequestExemption ->
+                                            runCatching {
+                                                context.startActivity(com.noop.ble.BackgroundHealth.batteryExemptionIntent(context))
+                                            }.onFailure {
+                                                runCatching {
+                                                    context.startActivity(com.noop.ble.BackgroundHealth.appBatterySettingsIntent(context))
+                                                }
+                                            }
+                                        com.noop.ble.BackgroundHealth.BatteryRowAction.OpenAppSettings ->
                                             runCatching {
                                                 context.startActivity(com.noop.ble.BackgroundHealth.appBatterySettingsIntent(context))
                                             }
-                                        }
-                                    com.noop.ble.BackgroundHealth.BatteryRowAction.OpenAppSettings ->
-                                        runCatching {
-                                            context.startActivity(com.noop.ble.BackgroundHealth.appBatterySettingsIntent(context))
-                                        }
+                                    }
                                 }
-                            },
+                                .padding(vertical = 12.dp, horizontal = 8.dp),
                         )
                     }
                 }

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1946,31 +1946,46 @@ fun SettingsScreen(
                                 )
                             }
                         }
-                        Switch(
-                            checked = batteryExempt,
-                            // A system grant can't be toggled OFF from here (that's a system action): a tap
-                            // only ever REQUESTS it, and when already exempt the switch is inert (no re-prompt).
-                            onCheckedChange = { wantOn ->
-                                if (wantOn && !batteryExempt) {
+                        // #386 follow-up: an ACTION, not a Switch.
+                        //
+                        // This row reports an Android permission — `isBatteryExempt` is read nowhere outside
+                        // this screen, and the setting that actually keeps NOOP alive overnight is the
+                        // Background-connection toggle above. Rendering a permission grant as a Switch was
+                        // reported as broken ("I can enable it but can't disable it"), and that was right:
+                        // Android has no API to revoke an app's own exemption, so the off direction did
+                        // nothing and the switch sprang back. A bidirectional control was the wrong shape
+                        // for a one-way grant, so it is now a status line (above) plus one action.
+                        //
+                        // Granted -> "Manage" opens NOOP's system settings page, which is where a user CAN
+                        // revoke it. Not granted -> "Allow" fires the one-tap dialog. Either way the tap
+                        // does something, and the ON_RESUME observer re-reads the live state on return.
+                        Text(
+                            if (batteryExempt) {
+                                uiString(R.string.l10n_settings_screen_manage_bf58d17e)
+                            } else {
+                                uiString(R.string.l10n_settings_screen_allow_3ad0e369)
+                            },
+                            style = NoopType.subhead,
+                            color = Palette.accent,
+                            modifier = Modifier.clickable {
+                                when (com.noop.ble.BackgroundHealth.batteryRowAction(batteryExempt)) {
                                     // The whole feature exists for ROMs that strip things — so the fallback
                                     // is guarded too: if BOTH the exemption dialog and the app-settings page
-                                    // are missing, no-op rather than crash (the OEM link below is another path).
-                                    runCatching {
-                                        context.startActivity(com.noop.ble.BackgroundHealth.batteryExemptionIntent(context))
-                                    }.onFailure {
+                                    // are missing, no-op rather than crash (the OEM link above is another path).
+                                    com.noop.ble.BackgroundHealth.BatteryRowAction.RequestExemption ->
+                                        runCatching {
+                                            context.startActivity(com.noop.ble.BackgroundHealth.batteryExemptionIntent(context))
+                                        }.onFailure {
+                                            runCatching {
+                                                context.startActivity(com.noop.ble.BackgroundHealth.appBatterySettingsIntent(context))
+                                            }
+                                        }
+                                    com.noop.ble.BackgroundHealth.BatteryRowAction.OpenAppSettings ->
                                         runCatching {
                                             context.startActivity(com.noop.ble.BackgroundHealth.appBatterySettingsIntent(context))
                                         }
-                                    }
                                 }
                             },
-                            colors = SwitchDefaults.colors(
-                                checkedThumbColor = Palette.surfaceBase,
-                                checkedTrackColor = Palette.accent,
-                                uncheckedThumbColor = Palette.textSecondary,
-                                uncheckedTrackColor = Palette.surfaceInset,
-                                uncheckedBorderColor = Palette.hairline,
-                            ),
                         )
                     }
                 }

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2447,4 +2447,6 @@
     <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">Schlaf außerhalb der neuen Zeiten wurde entfernt. NOOP erkennt ihn nicht erneut.</string>
     <string name="l10n_settings_screen_effort_exponential_scale">Anstrengung: exponentielle Intensitätsskala</string>
     <string name="l10n_settings_screen_effort_exponential_scale_desc">Bewertet die Anstrengung mit einer exponentiellen Intensitätskurve (Banister-TRIMP) statt der voreingestellten Herzfrequenzzonen (Edwards). Die Voreinstellung zählt nichts unter der Hälfte deiner Herzfrequenzreserve, sodass eine Stunde Krafttraining – bei der sich harte Sätze mit den Pausen ausmitteln – nahezu null ergeben kann. Die exponentielle Kurve hat keine Untergrenze und gewichtet kurze, intensive Belastungen deutlich stärker. Bewertet deine Historie neu; beide Skalen erreichen dasselbe Maximum. Standardmäßig aus.</string>
+    <string name="l10n_settings_screen_allow_3ad0e369">Zulassen</string>
+    <string name="l10n_settings_screen_manage_bf58d17e">Verwalten</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2433,4 +2433,6 @@
     <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">Se ha eliminado el sueño fuera del nuevo horario. NOOP no volverá a detectarlo.</string>
     <string name="l10n_settings_screen_effort_exponential_scale">Esfuerzo: escala de intensidad exponencial</string>
     <string name="l10n_settings_screen_effort_exponential_scale_desc">Puntúa el Esfuerzo con una curva de intensidad exponencial (TRIMP de Banister) en lugar de las zonas de frecuencia cardíaca predeterminadas (Edwards). La opción predeterminada no cuenta nada por debajo de la mitad de tu reserva de frecuencia cardíaca, así que una hora de pesas —donde las series duras se compensan con los descansos— puede puntuar casi cero. La curva exponencial no tiene umbral y pondera mucho más los esfuerzos cortos e intensos. Vuelve a puntuar tu historial y ambas escalas alcanzan el mismo máximo. Desactivado por defecto.</string>
+    <string name="l10n_settings_screen_allow_3ad0e369">Permitir</string>
+    <string name="l10n_settings_screen_manage_bf58d17e">Gestionar</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2432,4 +2432,6 @@
     <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">Le sommeil en dehors des nouveaux horaires a été supprimé. NOOP ne le détectera plus.</string>
     <string name="l10n_settings_screen_effort_exponential_scale">Effort : échelle d’intensité exponentielle</string>
     <string name="l10n_settings_screen_effort_exponential_scale_desc">Calcule l’Effort selon une courbe d’intensité exponentielle (TRIMP de Banister) au lieu des zones de fréquence cardiaque par défaut (Edwards). Le réglage par défaut ne compte rien en dessous de la moitié de votre réserve de fréquence cardiaque : une heure de musculation — où les séries dures se compensent avec les temps de repos — peut donc être notée presque zéro. La courbe exponentielle n’a pas de seuil et pondère bien davantage les efforts courts et intenses. Recalcule votre historique, et les deux échelles atteignent le même maximum. Désactivé par défaut.</string>
+    <string name="l10n_settings_screen_allow_3ad0e369">Autoriser</string>
+    <string name="l10n_settings_screen_manage_bf58d17e">Gérer</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2438,4 +2438,6 @@
     <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">Sen poza nowymi godzinami został usunięty. NOOP nie wykryje go ponownie.</string>
     <string name="l10n_settings_screen_effort_exponential_scale">Wysiłek: wykładnicza skala intensywności</string>
     <string name="l10n_settings_screen_effort_exponential_scale_desc">Ocenia Wysiłek według wykładniczej krzywej intensywności (TRIMP Banistera) zamiast domyślnych stref tętna (Edwards). Ustawienie domyślne nie liczy niczego poniżej połowy rezerwy tętna, więc godzina treningu siłowego — gdzie ciężkie serie uśredniają się z przerwami — może dać wynik bliski zeru. Krzywa wykładnicza nie ma progu i znacznie mocniej waży krótkie, intensywne wysiłki. Przelicza historię, a obie skale osiągają to samo maksimum. Domyślnie wyłączone.</string>
+    <string name="l10n_settings_screen_allow_3ad0e369">Zezwól</string>
+    <string name="l10n_settings_screen_manage_bf58d17e">Zarządzaj</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2426,4 +2426,6 @@
     <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">O sono fora dos novos horários foi removido. O NOOP não o voltará a detetar.</string>
     <string name="l10n_settings_screen_effort_exponential_scale">Esforço: escala de intensidade exponencial</string>
     <string name="l10n_settings_screen_effort_exponential_scale_desc">Pontua o Esforço numa curva de intensidade exponencial (TRIMP de Banister) em vez das zonas de frequência cardíaca predefinidas (Edwards). A predefinição não conta nada abaixo de metade da tua reserva de frequência cardíaca, por isso uma hora de musculação — em que as séries duras se compensam com os descansos — pode pontuar quase zero. A curva exponencial não tem limiar e pondera muito mais os esforços curtos e intensos. Volta a pontuar o teu histórico e ambas as escalas atingem o mesmo máximo. Desativado por predefinição.</string>
+    <string name="l10n_settings_screen_allow_3ad0e369">Permitir</string>
+    <string name="l10n_settings_screen_manage_bf58d17e">Gerir</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2347,4 +2347,6 @@
     <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">新时间范围之外的睡眠已移除。NOOP 不会再次检测到它。</string>
     <string name="l10n_settings_screen_effort_exponential_scale">负荷：指数强度曲线</string>
     <string name="l10n_settings_screen_effort_exponential_scale_desc">以指数强度曲线（Banister TRIMP）计算负荷，而不是默认的心率区间（Edwards）。默认方式对低于心率储备一半的部分完全不计分，因此一小时力量训练——组间休息拉低了平均强度——可能几乎得零分。指数曲线没有下限，会大幅提高短时高强度努力的权重。会重新计算你的历史数据，两种标度的最高值相同。默认关闭。</string>
+    <string name="l10n_settings_screen_allow_3ad0e369">允许</string>
+    <string name="l10n_settings_screen_manage_bf58d17e">管理</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2459,4 +2459,6 @@
     <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">Sleep outside the new times was removed. NOOP won\'t detect it again.</string>
     <string name="l10n_settings_screen_effort_exponential_scale">Effort: exponential intensity scale</string>
     <string name="l10n_settings_screen_effort_exponential_scale_desc">Scores Effort on an exponential intensity curve (Banister TRIMP) instead of the default heart-rate zones (Edwards). The default earns nothing below half of your heart-rate reserve, so an hour of lifting — where hard sets average out against the rests — can score close to zero. The exponential curve has no floor and weights short, hard efforts far more heavily. Re-scores your history, and both scales reach the same maximum. Off by default.</string>
+    <string name="l10n_settings_screen_allow_3ad0e369">Allow</string>
+    <string name="l10n_settings_screen_manage_bf58d17e">Manage</string>
 </resources>

--- a/android/app/src/test/java/com/noop/ble/BackgroundHealthTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BackgroundHealthTest.kt
@@ -3,6 +3,7 @@ package com.noop.ble
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 /**
@@ -38,6 +39,52 @@ class BackgroundHealthTest {
         assertEquals(
             listOf("xiaomi", "oppo", "vivo", "huawei", "oneplus", "realme", "meizu"),
             BackgroundHealth.AGGRESSIVE_VENDORS,
+        )
+    }
+
+    // ── #386 follow-up: the "Keep NOOP alive overnight" row ───────────────────────────────────────
+
+    /**
+     * The reported bug, at the level it actually lived.
+     *
+     * The row was a Switch, and it could be turned on but not off — Android has no API to revoke an app's
+     * own battery-optimisation exemption, so the off direction did nothing and the switch sprang back. The
+     * fix is not a smarter Switch: a bidirectional control was the wrong shape for a one-way grant. The row
+     * is now a status line plus ONE action, and the action is defined for BOTH states — which is what stops
+     * a state existing that the UI cannot act on.
+     */
+    @Test
+    fun bothStatesHaveAnAction() {
+        assertEquals(
+            BackgroundHealth.BatteryRowAction.RequestExemption,
+            BackgroundHealth.batteryRowAction(isExempt = false),
+        )
+        assertEquals(
+            BackgroundHealth.BatteryRowAction.OpenAppSettings,
+            BackgroundHealth.batteryRowAction(isExempt = true),
+        )
+    }
+
+    /**
+     * The granted state must route somewhere the user can REVOKE.
+     *
+     * This is the whole complaint: once exempt, there was no way back from inside the app. The app cannot
+     * revoke the grant itself, so the honest action is to open the page that owns it.
+     */
+    @Test
+    fun theGrantedStateOffersAWayBack() {
+        assertEquals(
+            BackgroundHealth.BatteryRowAction.OpenAppSettings,
+            BackgroundHealth.batteryRowAction(isExempt = true),
+        )
+    }
+
+    /** The two states must not collapse to the same action — that would be the dead end returning. */
+    @Test
+    fun theTwoStatesDoDifferentThings() {
+        assertNotEquals(
+            BackgroundHealth.batteryRowAction(isExempt = true),
+            BackgroundHealth.batteryRowAction(isExempt = false),
         )
     }
 }

--- a/android/app/src/test/java/com/noop/ble/BackgroundHealthTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BackgroundHealthTest.kt
@@ -7,7 +7,7 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 /**
- * #386: the aggressive-OEM vendor classifier that gates the Settings "Keep NOOP alive overnight" toggle
+ * #386: the aggressive-OEM vendor classifier that gates the Settings "Keep NOOP alive overnight" row
  * and (via delegation) the Test Centre `oemKillHeuristic`. Pure + Context-free — the ONE canonical set,
  * so a phone that actually kills background apps is offered the whitelist. Case-insensitive, substring
  * match (real `Build.MANUFACTURER` values vary in casing and extra words).


### PR DESCRIPTION
**Reported:** "Keep NOOP alive overnight" could be enabled but not disabled.

Supersedes #1576, which I closed unmerged — it routed the off-tap to system settings, which helped
but fixed the wrong layer.

## The row is not a setting

`isBatteryExempt` is read **nowhere outside the Settings screen** — it gates no NOOP behaviour. The
thing that actually keeps NOOP alive overnight is the **Background connection** preference directly
above it, a real app pref that already toggles both ways.

So this row reports an Android *permission* and asks for it. And Android has no API to revoke an
app's own exemption — `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` can only ask.

A `Switch` was therefore always the wrong shape, and the report was the correct read: a bidirectional
control that cannot go both ways is broken, however good the platform reason. The answer isn't a
cleverer Switch — it's to stop implying a control that cannot exist.

## What it is now

The status line it already had, plus **one** action:

| state | action |
|---|---|
| not granted | **Allow** — the one-tap system dialog |
| granted | **Manage** — NOOP's system settings page, where the user *can* revoke it |

Every tap does something, nothing pretends to flip, and the existing `ON_RESUME` observer re-reads
the live state on return so the status settles to the truth either way.

## Testing the shape, not just the code

The action is a pure `BackgroundHealth.batteryRowAction(isExempt)`, total over its single input.
Tests assert **both states have an action** and that the two **differ** — the original bug was a
state the UI could not act on, so those are the properties that matter rather than the branch bodies.

## Parity

**Android-only by nature, checked not assumed.** iOS has no per-app battery-optimisation exemption to
grant or revoke; its only background read is a diagnostic (`IOSDiagnostics.backgroundRefreshStatus`),
never a control. No `BackgroundHealth` equivalent exists in the tree.

## Known follow-up, narrower than it first looked

`keep_alive_needed_vendor` / `keep_alive_needed_generic` open with **"Turn this on to whitelist
NOOP"** (de: *"Aktivieren Sie dies"*), which assumes a toggle. That clause is stale.

But the instruction that actually matters is already right: the same strings go on to say **"Tap
Allow"** (de: *"Tippen Sie auf Zulassen"*) — and the new button is labelled **Allow** / **Zulassen**,
which is also what Android's own dialog says. So the chain reads consistently end to end; it is one
opening clause that is out of date, not the copy as a whole.

Left alone deliberately: rewriting a clause inside long sentences in six languages I cannot verify is
a worse risk than a mildly stale opener. Worth a pass by someone who reads them.

**Translations checked in context, not just added.** Every one of the six words already appears
elsewhere in its own locale file in the same sense, so they follow house terminology rather than
being invented for this row.

## Verification

- `:app:testFullDebugUnitTest --no-build-cache --rerun-tasks` — **4277 tests, 0 failures** (3 new).
- **`lintVitalFullRelease -PstagingRelease` clean** — the fatal `ExtraTranslation` gate that new
  strings trip. Two strings added across all 7 locale files.
- `doc_comment_lint.py` OK, `i18n_audit.py --ci main` OK.
- **No app-target Swift touched**, so no app-build needed.
- **Not yet seen on a device.** The check: the row should read "Allowed …" with a **Manage** link;
  tapping it lands on NOOP's system settings, and after setting Battery to Optimised and returning,
  the row should flip back to the "needed" copy with an **Allow** link.