### PR TITLE
Coalesce HealthKit observer wakes, and measure the path while we're here

### DIFF
--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -786,6 +786,10 @@ public final class LiveState: ObservableObject {
         #if os(iOS)
         let diagLines = IOSDiagnostics.capture().summaryLines()
         if !diagLines.isEmpty { header += diagLines.joined(separator: "\n") + "\n" }
+        // #1578: what the Apple Health observer path cost this session. Silent unless it ran, so a log from
+        // someone with Health off or unauthorized is unchanged.
+        let healthLines = HealthSyncStats.summaryLines()
+        if !healthLines.isEmpty { header += healthLines.joined(separator: "\n") + "\n" }
         #endif
         if !extraHeaderLines.isEmpty { header += extraHeaderLines.joined(separator: "\n") + "\n" }
         header += String(repeating: "-", count: 40) + "\n"

--- a/Strand/System/HealthSyncStats.swift
+++ b/Strand/System/HealthSyncStats.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// #1578: what the HealthKit observer path actually cost this session.
+///
+/// The battery question that prompted this — "is Apple Health sync draining the phone?" — could not be
+/// answered from an exported log, because nothing on that path measured anything. The optimisation that
+/// came with it (coalescing observer wakes) is itself unmeasured for the same reason, so it cannot be
+/// evaluated after the fact either. This is the missing half: counts and a duration, in the header the
+/// reporter already sends.
+///
+/// Deliberately counts WAKES separately from SYNCS. Coalescing reduces the work per wake, not the number
+/// of wakes — iOS still resumes the process for every observer notification, and if that resume is the
+/// dominant cost then this ratio is what says so. A log showing many wakes and few syncs means the
+/// coalescing is working AND that the remaining cost is the wake itself, which would call for a different
+/// fix (fewer observers, or dropping background delivery for the chatty types) rather than more of this
+/// one.
+///
+/// In `Strand/` rather than `StrandiOS/` on purpose: this is shared-target, so `StrandTests` can reach it.
+/// A type placed beside `HealthKitBridge` would be testable by nothing.
+///
+/// Counts and milliseconds only — no sample values, no timestamps, same privacy class as the rest of the
+/// header. Process-lifetime, never persisted.
+@MainActor
+enum HealthSyncStats {
+
+    /// Observer notifications handled, whether or not they led to a sync.
+    private(set) static var wakes = 0
+    /// Wakes that ran a full sync.
+    private(set) static var syncs = 0
+    /// Wakes that stood down because a recent sync already covered their window.
+    private(set) static var coalesced = 0
+    /// Wakes that found no new samples at all (a spurious notification).
+    private(set) static var emptyWakes = 0
+    /// Cumulative wall time inside `sync()`, milliseconds.
+    private(set) static var syncMillis = 0
+
+    static func recordWake() { wakes += 1 }
+    static func recordEmptyWake() { emptyWakes += 1 }
+    static func recordCoalesced() { coalesced += 1 }
+    static func recordSync(millis: Int) { syncs += 1; syncMillis += max(0, millis) }
+
+    /// Test seam — the counters are process-lifetime, so a suite needs a way back to zero.
+    static func reset() { wakes = 0; syncs = 0; coalesced = 0; emptyWakes = 0; syncMillis = 0 }
+
+    /// One header line, or nothing at all when the observer path never ran this session.
+    ///
+    /// Silent-when-unused matters: most logs come from people whose Health sync is off or unauthorized,
+    /// and a line of zeros in every one of those would be noise that trains readers to skip the block.
+    static func summaryLines() -> [String] {
+        guard wakes > 0 else { return [] }
+        let avg = syncs > 0 ? syncMillis / syncs : 0
+        return ["Health sync: wakes=\(wakes) synced=\(syncs) coalesced=\(coalesced) "
+                + "empty=\(emptyWakes) avgSyncMs=\(avg)"]
+    }
+}

--- a/StrandTests/HealthSyncStatsTests.swift
+++ b/StrandTests/HealthSyncStatsTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import Strand
+
+/// #1578: the Apple Health observer path had no instrumentation at all, so neither the battery report
+/// that prompted this nor the coalescing fix that came with it could be evaluated from a log.
+///
+/// These pin the header line, and one arithmetic case that the fix itself makes likely.
+@MainActor
+final class HealthSyncStatsTests: XCTestCase {
+
+    override func setUp() async throws { HealthSyncStats.reset() }
+    override func tearDown() async throws { HealthSyncStats.reset() }
+
+    /// Silent when the observer path never ran.
+    ///
+    /// Most logs come from people with Health off or unauthorized. A line of zeros in every one of those
+    /// is noise that trains a reader to skip the block — and this block is meant to be read.
+    func testItSaysNothingWhenHealthSyncNeverRan() {
+        XCTAssertTrue(HealthSyncStats.summaryLines().isEmpty)
+    }
+
+    /// The exact line.
+    func testTheLineIsExactlyThis() {
+        HealthSyncStats.recordWake(); HealthSyncStats.recordSync(millis: 800)
+        HealthSyncStats.recordWake(); HealthSyncStats.recordSync(millis: 1200)
+        HealthSyncStats.recordWake(); HealthSyncStats.recordCoalesced()
+        HealthSyncStats.recordWake(); HealthSyncStats.recordEmptyWake()
+        XCTAssertEqual(HealthSyncStats.summaryLines(),
+                       ["Health sync: wakes=4 synced=2 coalesced=1 empty=1 avgSyncMs=1000"])
+    }
+
+    /// The case the fix is TRYING to produce: every wake coalesced, so no sync ran.
+    ///
+    /// `syncMillis / syncs` divides by zero there. A working coalescer would therefore crash the log
+    /// export — on exactly the phones where it worked best — so this is pinned rather than assumed.
+    func testAnAllCoalescedSessionDoesNotDivideByZero() {
+        for _ in 0 ..< 6 { HealthSyncStats.recordWake(); HealthSyncStats.recordCoalesced() }
+        XCTAssertEqual(HealthSyncStats.summaryLines(),
+                       ["Health sync: wakes=6 synced=0 coalesced=6 empty=0 avgSyncMs=0"])
+    }
+
+    /// Wakes are counted separately from syncs on purpose.
+    ///
+    /// Coalescing reduces work per wake, NOT the number of wakes — iOS still resumes the process for every
+    /// observer notification. A log showing many wakes and few syncs says the coalescing works and that
+    /// what remains is the wake itself, which needs a different fix (fewer observers) rather than more of
+    /// this one. If these two ever collapsed into one counter that signal would be lost.
+    func testWakesAndSyncsAreCountedSeparately() {
+        for _ in 0 ..< 10 { HealthSyncStats.recordWake() }
+        HealthSyncStats.recordSync(millis: 500)
+        let line = HealthSyncStats.summaryLines().first ?? ""
+        XCTAssertTrue(line.contains("wakes=10"), line)
+        XCTAssertTrue(line.contains("synced=1"), line)
+    }
+
+    /// A negative duration (a wall-clock correction mid-pass) must not drag the average below zero.
+    func testANegativeDurationIsFloored() {
+        HealthSyncStats.recordWake(); HealthSyncStats.recordSync(millis: -5_000)
+        XCTAssertEqual(HealthSyncStats.summaryLines(),
+                       ["Health sync: wakes=1 synced=1 coalesced=0 empty=0 avgSyncMs=0"])
+    }
+}

--- a/StrandiOS/Health/HealthKitBridge.swift
+++ b/StrandiOS/Health/HealthKitBridge.swift
@@ -345,10 +345,14 @@ final class HealthKitBridge: ObservableObject {
     /// keeps every per-day average correct and idempotent — `sync` upserts are keyed by day.
     private func syncFromObserver(type: HKSampleType) async {
         guard auth == .authorized else { return }
+        // #1578: counted before any early return, so the ratio of wakes to syncs is honest. Coalescing
+        // cuts the work per wake, not the wakes — this is what shows whether the wake itself is the cost.
+        HealthSyncStats.recordWake()
         let (touched, newAnchor) = await fetchTouchedDayWindow(type: type)
         // No new samples since the last anchor (a spurious wake): nothing to ingest, so advancing the
         // anchor now loses nothing and skips a redundant re-query next wake.
         guard let touched else {
+            HealthSyncStats.recordEmptyWake()
             if let newAnchor { persistAnchor(newAnchor, for: type) }
             return
         }
@@ -369,6 +373,7 @@ final class HealthKitBridge: ObservableObject {
         let sinceLastSync = lastSync.map { Date().timeIntervalSince($0) }
         if let age = sinceLastSync, age >= 0, age < Self.observerCoalesceWindow,
            window <= lastSyncDays {
+            HealthSyncStats.recordCoalesced()
             // Deliberately do NOT advance the anchor here. Samples that landed AFTER that sync's reads but
             // before this wake are not in the store yet, and advancing past them would leave them to be
             // picked up only incidentally — by whatever later sync happens to re-read the same day. Leaving
@@ -443,7 +448,14 @@ final class HealthKitBridge: ObservableObject {
             return false
         }
         syncing = true
-        defer { finishHealthPass() }
+        // #1578: time the whole pass — the ~15 aggregate reads, the upserts and the write-back. Recorded in
+        // `defer` so an early or thrown exit still contributes; a pass that cost time and then failed is
+        // exactly the one a drain report needs to show.
+        let passStart = Date()
+        defer {
+            HealthSyncStats.recordSync(millis: Int(Date().timeIntervalSince(passStart) * 1000))
+            finishHealthPass()
+        }
         // Before reading: pick up any read type this version added that the user was never asked about
         // (#949). No-op once the stored signature matches, which is every sync after the first.
         await requestNewReadTypesIfNeeded()

--- a/StrandiOS/Health/HealthKitBridge.swift
+++ b/StrandiOS/Health/HealthKitBridge.swift
@@ -361,7 +361,13 @@ final class HealthKitBridge: ObservableObject {
         // would burn ~15 HealthKit aggregate queries and a write-back to re-derive rows that sync just
         // wrote. Stand down. This is what collapses the hourly burst of six observers into one sync.
         // FOREGROUND catch-up deliberately does not consult this: an explicit resume should always read.
-        if let last = lastSync, Date().timeIntervalSince(last) < Self.observerCoalesceWindow,
+        // `age >= 0` is not defensive noise. This is WALL-CLOCK time, and it can move backwards — an NTP
+        // correction, or a user changing the date. A negative age satisfies `< window`, so every wake would
+        // skip; and because `lastSync` is only written by a sync that RAN, the skipping would keep it stale
+        // and background Health ingestion would stay dead until a foreground catch-up (which ignores this
+        // gate) broke the loop. Cheap to exclude, so exclude it.
+        let sinceLastSync = lastSync.map { Date().timeIntervalSince($0) }
+        if let age = sinceLastSync, age >= 0, age < Self.observerCoalesceWindow,
            window <= lastSyncDays {
             // Deliberately do NOT advance the anchor here. Samples that landed AFTER that sync's reads but
             // before this wake are not in the store yet, and advancing past them would leave them to be

--- a/StrandiOS/Health/HealthKitBridge.swift
+++ b/StrandiOS/Health/HealthKitBridge.swift
@@ -33,6 +33,29 @@ final class HealthKitBridge: ObservableObject {
     /// Without this, a strap offload finishing during the foreground read/write pass was deferred until
     /// the next app open even though the newly-banked rows were already available locally.
     private var writeBackPending = false
+    /// How many days the last COMPLETED sync covered, so an observer wake can tell whether a sync that
+    /// just ran already read its window. Paired with `lastSync` (the time). Reset to 0 by a failed sync,
+    /// so a failure never lets a later wake be skipped on the strength of it.
+    private var lastSyncDays = 0
+    /// How long an observer wake will accept a just-completed sync instead of running its own.
+    ///
+    /// Six sample types carry `enableBackgroundDelivery(frequency: .hourly)`, and two of them —
+    /// `.heartRate` and `.activeEnergyBurned` — get new samples continuously on a worn Apple Watch, so in
+    /// practice several observers wake within moments of each other every hour. Each wake used to run a
+    /// FULL sync: ~15 HealthKit aggregate queries plus a write-back, no matter which type woke it.
+    ///
+    /// Scoping the queries to the woken type is NOT an option: the rows are upserted with
+    /// `ON CONFLICT DO UPDATE SET x = excluded.x` on every column, a full replace, so a sync that skipped
+    /// a query would write NULL over that day's stored value and wipe it. Coalescing is safe instead
+    /// because it changes nothing about what a sync reads — it only declines to repeat one.
+    ///
+    /// Skipping is lossless: `sync` re-reads AGGREGATES for a window, so a sync that already covered this
+    /// wake's days has ingested its samples. The anchor exists only to name the window (see
+    /// `fetchTouchedDayWindow`), which is why it is still advanced on a skip.
+    ///
+    /// The Android side has had this shape all along — `syncHealthConnectIfStale` gates its Health Connect
+    /// import on a staleness interval. This brings iOS in line.
+    private static let observerCoalesceWindow: TimeInterval = 15 * 60
     /// The most recent failure surfaced by `sync` / `writeBack`. Cleared on a successful run. UI binds
     /// here so an Apple Health auth revoke, quota hit, or invalid sample is visible instead of silent.
     @Published private(set) var lastError: String?
@@ -334,6 +357,20 @@ final class HealthKitBridge: ObservableObject {
                                           to: cal.startOfDay(for: Date())).day ?? 0
         // Clamp to a sane window: at least today, and never re-walk more than a month from one wake.
         let window = max(1, min(31, daysBack + 1))
+        // A sync completed moments ago and covered at least this wake's window, so a second full pass
+        // would burn ~15 HealthKit aggregate queries and a write-back to re-derive rows that sync just
+        // wrote. Stand down. This is what collapses the hourly burst of six observers into one sync.
+        // FOREGROUND catch-up deliberately does not consult this: an explicit resume should always read.
+        if let last = lastSync, Date().timeIntervalSince(last) < Self.observerCoalesceWindow,
+           window <= lastSyncDays {
+            // Deliberately do NOT advance the anchor here. Samples that landed AFTER that sync's reads but
+            // before this wake are not in the store yet, and advancing past them would leave them to be
+            // picked up only incidentally — by whatever later sync happens to re-read the same day. Leaving
+            // the anchor put means the next wake sees the same window and syncs it for certain. The cost is
+            // one more delta query on that wake, which is the cheap half; the ~15 aggregate reads and the
+            // write-back are what this is avoiding.
+            return
+        }
         // Advance the anchor ONLY after the ingestion commits (@bhelm). If sync() bails (another sync holds
         // `syncing`, or the store is unavailable), the anchor stays put so the next wake re-fetches this
         // window and re-ingests — sync re-reads aggregates, so the replay is idempotent.
@@ -605,9 +642,15 @@ final class HealthKitBridge: ObservableObject {
             }
             try await writeBack(whoopStore: store)
             lastSync = Date()
+            // Record the window alongside the time: an observer wake may only stand down for a sync that
+            // actually covered ITS days (see `observerCoalesceWindow`). Set on the success path only.
+            lastSyncDays = days
             lastError = nil
             return true
         } catch {
+            // A failed sync must never let a later wake skip on the strength of it — the rows it would
+            // have written are not there. Clearing the window means `window <= lastSyncDays` cannot hold.
+            lastSyncDays = 0
             lastError = String(localized: "Apple Health sync failed: \(error.localizedDescription)")
             return false
         }


### PR DESCRIPTION
Investigating a battery-drain report against HealthKit / Health Connect. **This addresses the iOS
side only** — see Parity for why Android needs nothing.

## The mechanism

Six sample types carry `enableBackgroundDelivery(frequency: .hourly)`: HRV, resting HR, active
energy, **heart rate**, VO₂ max, sleep. Two of them — `.heartRate` and `.activeEnergyBurned` — get
new samples continuously on a worn Apple Watch, so several observers wake within moments of each
other, every hour, all day.

Each wake ran a **full sync**: ~15 HealthKit aggregate queries plus a write-back — resting HR, HR
avg, HR max, HRV, SpO₂, respiratory rate, steps, active + basal energy, VO₂ max, body mass, body fat,
lean mass, BMI, water, sleep — **regardless of which type woke it**. `syncFromObserver(type:)` has
the type and discards it.

## The obvious fix is unsafe, and avoiding it is the point

Scoping the queries to the woken type would **wipe data**. The rows are upserted with
`ON CONFLICT DO UPDATE SET x = excluded.x` on *every* column — a full replace, not a merge. A sync
that skipped a query would write NULL over that day's stored value.

The file already warns about exactly this shape for the water read: *"a failed query must not be
mistaken for an authoritative zero and wipe the window."*

## So: coalesce the wakes, don't scope the queries

Coalescing changes nothing about what a sync reads; it only declines to repeat one. An observer wake
stands down when a sync completed inside the window **and** covered at least this wake's days.

Eight lines of behaviour:

```swift
if let last = lastSync, Date().timeIntervalSince(last) < Self.observerCoalesceWindow,
   window <= lastSyncDays { return }
```

**The skip does not advance the HealthKit anchor.** Samples that landed after that sync's reads
aren't in the store yet; advancing past them would leave them to be collected only incidentally, by
whatever later sync happened to re-read the same day. Leaving the anchor put means the next wake sees
the same window and syncs it for certain — at the cost of one extra delta query, which is the cheap
half.

`lastSyncDays` is set on the **success path only** and cleared on failure, so a sync that didn't write
its rows can never license a later wake to skip. Foreground catch-up deliberately ignores the gate —
an explicit resume should always read.

## Why coalescing across *different* types is sound

`sync()` issues all 15 aggregate queries regardless of which observer called it. So a sync triggered
by `.heartRate` has already read everything `.activeEnergyBurned`'s wake would have read. The same
type-blindness that makes each wake wasteful is exactly what makes skipping one safe.

Also handled: the gate compares **wall-clock** time, which can move backwards (NTP correction, user
changes the date). A negative age satisfies `< window`, and since `lastSync` is only written by a sync
that *ran*, the skipping would keep it stale and wedge background ingestion until a foreground
catch-up broke the loop. Excluded with an `age >= 0` clause.

## Fewer wakes does not slow NOOP → Health

Each skipped wake also skips the write-back that rode inside `sync()`. That could have delayed
publication to Apple Health — it does not, because the write-back has two dedicated triggers that
never involve `sync()`:

- `HealthWritebackBackgroundScheduler` — a `BGTaskScheduler` refresh task, always-on while authorized,
  write-only and bounded to the recent window;
- `model.healthWriteBack` — fires the moment a BLE offload lands (#1021, added exactly so a night did
  not wait for the next launch).

The write-back inside `sync()` is opportunistic on top of those. Reads are what this coalesces.

`writeBackPending` is also untouched: it is set only when `sync()` bails on a CONCURRENT pass, and a
skip is the different case — one that already finished — so it neither sets nor strands it.

## Parity

**No twin for the observer path** — Android has no background observer or periodic worker for Health
Connect at all, and its import is already staleness-gated (`syncHealthConnectIfStale`).

**But my earlier claim that Android was fine was wrong, and I want that on the record.** I checked for
background *wakes*, found none, and stopped. The cost there is not a wake — it is what rides the loop
that was already running: `HealthConnectWriter.write()` rebuilds and inserts **60 days x 4 record
types with no change detection**, every 15 minutes, whenever write-back is enabled. Roughly 240
records re-upserted ~96 times a day, almost all unchanged, with a fresh version stamp each time.

Structurally the same disease as iOS — fixed full-window work on a timer — on the write side instead
of the read side. It needs a different fix (change detection, not coalescing) and gets its own PR
rather than being bolted onto this one.

## Instrumentation — the part that outlasts the guess

Nothing on this path measured anything, which is why neither the report nor this fix can be evaluated
from a log. One header line beside the existing iOS diagnostics, silent unless the observer path ran:

```
Health sync: wakes=12 synced=2 coalesced=9 empty=1 avgSyncMs=1400
```

**Wakes are counted separately from syncs, deliberately.** Coalescing reduces the work per wake, **not
the number of wakes** — iOS still resumes the process for every observer notification. If that resume
is the dominant cost, this ratio is what says so, and the answer would be *fewer observers* rather
than more coalescing. Collapsing the two counters would hide the one thing worth learning.

`HealthSyncStats` sits in `Strand/` rather than `StrandiOS/` so `StrandTests` can reach it — a type
beside `HealthKitBridge` would be testable by nothing, which is the situation that produced an
unmeasurable path to begin with.

One test earns its place: an **all-coalesced session** divides `syncMillis` by zero syncs. That is the
state this fix is *trying* to produce, so a working coalescer would have crashed the log export on
precisely the phones where it worked best.

## Not verified — please read this before merging

- **No local build.** iOS app-target Swift; nothing here compiles it. **app-build required.**
- **No test.** `HealthKitBridge` is iOS-only and `StrandTests` runs under the macOS `Strand` scheme,
  so it is unreachable from the one app-target suite. I did not manufacture coverage by moving an iOS
  scheduling predicate into an analytics package.
- **The 15-minute window is a guess.** It is a named constant precisely because the right value
  should come from a measurement I have not taken. It collapses the simultaneous burst, which is the
  dominant multiplier; a longer window would coalesce more at the cost of ingestion latency.
- **The diagnosis itself is unconfirmed against the actual report.** I do not know which platform the
  reporter was on. If the report is Android, this optimises the wrong thing — it is still a real
  inefficiency, but it would not be their drain.