### PR TITLE
Fix WHOOP 5 steps calibration prompt (#1523)

### DIFF
--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -4021,16 +4021,14 @@ struct TodayView: View {
     /// calibration" affordance so a user whose strap reports real steps (5/MG) or who has no strap at all
     /// never sees a steps-calibration prompt on a blank tile.
     ///
-    /// #1491: the three profile fields below are all OUTPUTS of calibration — a fitted coefficient, a
-    /// manual one, or a count of overlapping phone-counted days. Testing only those made the affordance
-    /// unreachable for the exact user it was written for: a fresh 4.0 owner with no phone step history has
-    /// all three at zero, so the tile went blank with no explanation and no way through to the sheet that
-    /// would let them set a coefficient by hand. The prompt was gated on evidence that only exists once
-    /// the thing it is prompting for has already started.
+    /// #1491: a fresh 4.0 owner has no calibration state yet, so the strap family itself must activate the
+    /// pipeline on a day with data. A fitted or manual coefficient remains a second path because calibration
+    /// is profile-global: someone who moved from a 4.0 to a 5.0 can keep using their working estimate.
     ///
-    /// The strap itself answers the question that gate was reaching for — a 4.0 sends no step count, so it
-    /// always estimates — and it answers it on day one. The calibration state it is OR-ed with is
-    /// profile-global rather than per-strap, so both halves are measuring the same user either way.
+    /// #1523: a partial sample-day count is not equivalent to a working calibration. WHOOP 5.0 records feed
+    /// the same motion-volume fitter, so a 5.0 can accumulate sample days before any coefficient exists.
+    /// Letting that counter activate the gate showed the 4.0-only calibration prompt on a strap that reports
+    /// steps natively. Only an actual coefficient is evidence that the profile should keep the estimate path.
     ///
     /// Read off the persisted selection rather than through `BLEManager.isWhoop4`: `TodayView` holds no
     /// `AppModel`, and `BLEManager` writes this same key whenever the model changes
@@ -4047,12 +4045,26 @@ struct TodayView: View {
     /// [hasDayData] stays as the second guard: it is what keeps the prompt off a date with nothing scored
     /// on it, which is a different question from whether a strap is known.
     private func stepsPipelineActive(hasDayData: Bool) -> Bool {
+        Self.stepsPipelineActive(
+            selectedModelRaw: selectedWhoopModelRaw,
+            hasDayData: hasDayData,
+            calibrationCoefficient: profile.stepsCalibrationCoefficient,
+            manualCoefficient: profile.stepsManualCoefficient,
+            calibrationSampleDays: profile.stepsCalibrationSampleDays)
+    }
+
+    /// Pure gate used by the Steps tile and its state-matrix tests. `calibrationSampleDays` is accepted so
+    /// the regression is explicit: partial fitter progress alone must never activate a strap-family feature.
+    static func stepsPipelineActive(selectedModelRaw: String,
+                                    hasDayData: Bool,
+                                    calibrationCoefficient: Double,
+                                    manualCoefficient: Double,
+                                    calibrationSampleDays: Int) -> Bool {
         // Optional-chained deliberately: an unset (or unparseable) key is NOT a 4.0. The key only ever
         // holds a `WhoopModel` rawValue, so nil here means "no strap has been identified", not "4.0".
-        (WhoopModel(rawValue: selectedWhoopModelRaw)?.deviceFamily == .whoop4 && hasDayData)
-            || profile.stepsCalibrationCoefficient > 0
-            || profile.stepsManualCoefficient > 0
-            || profile.stepsCalibrationSampleDays > 0
+        (WhoopModel(rawValue: selectedModelRaw)?.deviceFamily == .whoop4 && hasDayData)
+            || calibrationCoefficient > 0
+            || manualCoefficient > 0
     }
 
     /// #589, the honest one-liner for a blank, not-yet-calibrated Steps tile: how many more days the

--- a/StrandTests/TodayStepsPipelineTests.swift
+++ b/StrandTests/TodayStepsPipelineTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import Strand
+
+/// The Steps calibration affordance is a WHOOP 4.0 feature, except when a profile already owns a working
+/// coefficient from an earlier 4.0 calibration. WHOOP 5.0 motion rows can advance the shared fitter's
+/// sample-day counter, so that counter cannot stand in for an actual calibration (#1523).
+final class TodayStepsPipelineTests: XCTestCase {
+
+    private func active(model: WhoopModel?,
+                        hasDayData: Bool,
+                        calibrationCoefficient: Double = 0,
+                        manualCoefficient: Double = 0,
+                        sampleDays: Int = 0) -> Bool {
+        TodayView.stepsPipelineActive(
+            selectedModelRaw: model?.rawValue ?? "",
+            hasDayData: hasDayData,
+            calibrationCoefficient: calibrationCoefficient,
+            manualCoefficient: manualCoefficient,
+            calibrationSampleDays: sampleDays)
+    }
+
+    func testWhoop5PartialSampleDaysDoNotActivateFourPointZeroPipeline() {
+        XCTAssertFalse(active(model: .whoop5mg, hasDayData: true, sampleDays: 3))
+    }
+
+    func testWhoop4WithDayDataActivatesBeforeCalibrationStarts() {
+        XCTAssertTrue(active(model: .whoop4, hasDayData: true))
+    }
+
+    func testWhoop4WithoutDayDataIsNotActivatedByPartialSampleDays() {
+        XCTAssertFalse(active(model: .whoop4, hasDayData: false, sampleDays: 3))
+    }
+
+    func testFittedCoefficientPreservesMigratedFourPointZeroProfile() {
+        XCTAssertTrue(active(model: .whoop5mg,
+                             hasDayData: true,
+                             calibrationCoefficient: 0.42,
+                             sampleDays: 5))
+    }
+
+    func testManualCoefficientPreservesMigratedFourPointZeroProfile() {
+        XCTAssertTrue(active(model: .whoop5mg,
+                             hasDayData: true,
+                             manualCoefficient: 0.35,
+                             sampleDays: 1))
+    }
+
+    func testUnsetModelAndPartialSampleDaysStayInactive() {
+        XCTAssertFalse(active(model: nil, hasDayData: true, sampleDays: 3))
+    }
+}


### PR DESCRIPTION
## What this PR does

Stops partial steps-calibration progress from activating the iOS WHOOP 4.0 estimate pipeline on a WHOOP 5.0 / MG.

The shared motion fitter can accumulate `stepsCalibrationSampleDays` from WHOOP 5.0 gravity samples before it has produced a coefficient. Treating that counter as calibration evidence made a blank native-Steps tile show the 4.0-only calibration prompt and gear.

The gate now activates for:

- a known WHOOP 4.0 on a day with data;
- a profile with a fitted calibration coefficient; or
- a profile with a manual coefficient.

A sample-day count alone no longer activates it. The coefficient paths remain profile-global so someone moving from a calibrated 4.0 to a 5.0 keeps the existing estimate behavior.

The gate is exposed as a pure internal function and covered by a six-case state matrix, including the reported 5.0 partial-progress state, fresh 4.0 behavior, migrated fitted/manual coefficients, no-day data, and an unset model.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- `python3 Tools/doc_comment_lint.py` — pass
- `python3 Tools/i18n_audit.py --ci origin/main` — pass
- `git diff --check` — pass
- Added `TodayStepsPipelineTests` with six state-matrix cases.
- This CachyOS workspace has no Swift/Xcode toolchain. Upstream's `App build (macOS + iOS)` workflow is currently disabled manually, so the app-target compile and `StrandTests` could not be run for this PR.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`) — no Swift packages touched
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`) — Android not touched
- [ ] No new build warnings introduced — Apple app-target build unavailable as noted above
- [x] UI changes use only `StrandDesign` tokens — no visual or layout changes
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders — no protocol changes
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Closes #1523
