### PR TITLE
Put the exponential Effort toggle where someone looking for it would look

### DIFF
--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -979,12 +979,17 @@ struct SettingsView: View {
                         Text("0-100").tag(EffortScale.hundred.rawValue)
                         Text("0-21").tag(EffortScale.whoop.rawValue)
                     }
-                // #1545: placed directly under the Effort SCALE row on purpose. It shipped in the
-                // experimental block beside the SpO2 and stress-baseline toggles, where the person who
-                // asked for it could not find it — a setting built for a specific report is no use if
-                // the reporter cannot locate it. The two rows are different concepts (that one is the
-                // display AXIS, this the computation RECIPE) but a user asking "how is my Effort worked
-                // out" reaches for the same place for both, and each row's caption separates them.
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .tint(StrandPalette.accent)
+                    .accessibilityLabel("Effort scale")
+                }
+
+                // #1545: directly under the Effort SCALE row on purpose. It shipped in the experimental
+                // block beside the SpO2 and stress-baseline toggles, where the person who asked for it
+                // could not find it. The two are different concepts — that row is the display AXIS,
+                // this the computation RECIPE — but a user asking "how is my Effort worked out" reaches
+                // for the same place for both, and each row's caption separates them.
                 // MARK: #1545 Effort scale — Banister exponential TRIMP instead of Edwards zones.
                 Divider().overlay(StrandPalette.hairline)
 
@@ -1007,11 +1012,6 @@ struct SettingsView: View {
                     .font(StrandFont.caption)
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
-                    .labelsHidden()
-                    .pickerStyle(.menu)
-                    .tint(StrandPalette.accent)
-                    .accessibilityLabel("Effort scale")
-                }
             }
         }
     }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -979,6 +979,34 @@ struct SettingsView: View {
                         Text("0-100").tag(EffortScale.hundred.rawValue)
                         Text("0-21").tag(EffortScale.whoop.rawValue)
                     }
+                // #1545: placed directly under the Effort SCALE row on purpose. It shipped in the
+                // experimental block beside the SpO2 and stress-baseline toggles, where the person who
+                // asked for it could not find it — a setting built for a specific report is no use if
+                // the reporter cannot locate it. The two rows are different concepts (that one is the
+                // display AXIS, this the computation RECIPE) but a user asking "how is my Effort worked
+                // out" reaches for the same place for both, and each row's caption separates them.
+                // MARK: #1545 Effort scale — Banister exponential TRIMP instead of Edwards zones.
+                Divider().overlay(StrandPalette.hairline)
+
+                Toggle(isOn: $banisterEffortEnabled) {
+                    Text("Effort: exponential intensity scale")
+                        .font(StrandFont.subhead)
+                        .foregroundStyle(StrandPalette.textPrimary)
+                }
+                .toggleStyle(.switch)
+                .tint(StrandPalette.accent)
+                .onChangeCompat(of: banisterEffortEnabled) { _ in
+                    // Re-score immediately on the flip. The recipe changes stored Effort for EVERY day in
+                    // the window, so without this the user waits up to 30 min for the next analyze loop
+                    // while the screen still shows scores from the recipe they just turned off — and the
+                    // toggle's own copy promises the history is re-scored. Same pattern as the SpO2
+                    // candidate and HRV-window toggles (analyzeRecent → refresh).
+                    Task { await model.intelligence.analyzeRecent(); await model.repo.refresh() }
+                }
+                Text("Scores Effort on an exponential intensity curve (Banister TRIMP) instead of the default heart-rate zones (Edwards). The default earns nothing below half of your heart-rate reserve, so an hour of lifting — where hard sets average out against the rests — can score close to zero. The exponential curve has no floor and weights short, hard efforts far more heavily. Re-scores your history, and both scales reach the same maximum. Off by default.")
+                    .font(StrandFont.caption)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
                     .labelsHidden()
                     .pickerStyle(.menu)
                     .tint(StrandPalette.accent)
@@ -2019,28 +2047,6 @@ struct SettingsView: View {
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)
 
-                // MARK: #1545 Effort scale — Banister exponential TRIMP instead of Edwards zones.
-                Divider().overlay(StrandPalette.hairline)
-
-                Toggle(isOn: $banisterEffortEnabled) {
-                    Text("Effort: exponential intensity scale")
-                        .font(StrandFont.subhead)
-                        .foregroundStyle(StrandPalette.textPrimary)
-                }
-                .toggleStyle(.switch)
-                .tint(StrandPalette.accent)
-                .onChangeCompat(of: banisterEffortEnabled) { _ in
-                    // Re-score immediately on the flip. The recipe changes stored Effort for EVERY day in
-                    // the window, so without this the user waits up to 30 min for the next analyze loop
-                    // while the screen still shows scores from the recipe they just turned off — and the
-                    // toggle's own copy promises the history is re-scored. Same pattern as the SpO2
-                    // candidate and HRV-window toggles (analyzeRecent → refresh).
-                    Task { await model.intelligence.analyzeRecent(); await model.repo.refresh() }
-                }
-                Text("Scores Effort on an exponential intensity curve (Banister TRIMP) instead of the default heart-rate zones (Edwards). The default earns nothing below half of your heart-rate reserve, so an hour of lifting — where hard sets average out against the rests — can score close to zero. The exponential curve has no floor and weights short, hard efforts far more heavily. Re-scores your history, and both scales reach the same maximum. Off by default.")
-                    .font(StrandFont.caption)
-                    .foregroundStyle(StrandPalette.textTertiary)
-                    .fixedSize(horizontal: false, vertical: true)
 
                 // MARK: #891 ECG raw-data gate — the second device-config key this app may write, MG-only.
                 Divider().overlay(StrandPalette.hairline)

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1214,6 +1214,49 @@ fun SettingsScreen(
                         },
                     )
                 }
+                // #1545: sits directly under the Effort SCALE row on purpose. It shipped in the
+                // experimental block beside the sleep-staging toggles, where @dofimn could not find it —
+                // a setting built for a specific report is no use if the person who asked for it cannot
+                // locate it. The two rows are different concepts (that one is the display AXIS, this one
+                // is the computation RECIPE) but a user asking "how is my Effort worked out" reaches for
+                // the same place for both, and each row's own caption separates them.
+                // #1545: Effort on Banister's EXPONENTIAL TRIMP instead of Edwards' heart-rate zones.
+                // Edwards pays nothing below 50% HRR, so an hour of lifting — hard sets averaged against
+                // the rests — can score near zero. Default OFF: it re-scores the whole window against a
+                // different recipe. Both scales top out at 100 via their own log denominator. Mirrors iOS.
+                SettingsRowDivider()
+                var banisterEffort by remember { mutableStateOf(NoopPrefs.banisterEffort(context)) }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    Text(
+                        uiString(R.string.l10n_settings_screen_effort_exponential_scale),
+                        style = NoopType.subhead,
+                        color = Palette.textPrimary,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Switch(
+                        checked = banisterEffort,
+                        onCheckedChange = {
+                            banisterEffort = it
+                            vm.setBanisterEffort(it)
+                        },
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = Palette.surfaceBase,
+                            checkedTrackColor = Palette.accent,
+                            uncheckedThumbColor = Palette.textSecondary,
+                            uncheckedTrackColor = Palette.surfaceInset,
+                            uncheckedBorderColor = Palette.hairline,
+                        ),
+                    )
+                }
+                Text(
+                    uiString(R.string.l10n_settings_screen_effort_exponential_scale_desc),
+                    style = NoopType.caption,
+                    color = Palette.textTertiary,
+                )
             }
         }
 
@@ -2725,43 +2768,6 @@ fun SettingsScreen(
                     )
                 }
 
-                // #1545: Effort on Banister's EXPONENTIAL TRIMP instead of Edwards' heart-rate zones.
-                // Edwards pays nothing below 50% HRR, so an hour of lifting — hard sets averaged against
-                // the rests — can score near zero. Default OFF: it re-scores the whole window against a
-                // different recipe. Both scales top out at 100 via their own log denominator. Mirrors iOS.
-                SettingsRowDivider()
-                var banisterEffort by remember { mutableStateOf(NoopPrefs.banisterEffort(context)) }
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                ) {
-                    Text(
-                        uiString(R.string.l10n_settings_screen_effort_exponential_scale),
-                        style = NoopType.subhead,
-                        color = Palette.textPrimary,
-                        modifier = Modifier.weight(1f),
-                    )
-                    Switch(
-                        checked = banisterEffort,
-                        onCheckedChange = {
-                            banisterEffort = it
-                            vm.setBanisterEffort(it)
-                        },
-                        colors = SwitchDefaults.colors(
-                            checkedThumbColor = Palette.surfaceBase,
-                            checkedTrackColor = Palette.accent,
-                            uncheckedThumbColor = Palette.textSecondary,
-                            uncheckedTrackColor = Palette.surfaceInset,
-                            uncheckedBorderColor = Palette.hairline,
-                        ),
-                    )
-                }
-                Text(
-                    uiString(R.string.l10n_settings_screen_effort_exponential_scale_desc),
-                    style = NoopType.caption,
-                    color = Palette.textTertiary,
-                )
                 Text(
                     "Scores today's hour-by-hour stress timeline against YOUR own cross-day baseline " +
                         "(how your days usually run, Oura-style) instead of the day's own calm hours. The " +


### PR DESCRIPTION
@dofimn asked for this setting in issue #1545, it shipped, and then they couldn't find it:

> I can't seem to locate the exponential effort scale option in the setting, even though the "how Noop
> works" page has updated. (Im on 10.5.1 latest)

**They were right, and it wasn't a version problem.** I checked the row against the *actual shipped
build trees* rather than merge dates — which lie after a squash; my first check tested the pre-squash
branch commit and wrongly reported the row missing from both builds.

| check | result |
|---|---|
| present in both 10.5.1 testing builds | **yes** (`git show <build>:SettingsScreen.kt`) |
| gated by strap model or experimental flag | **no** — brace scan found no enclosing condition |
| label matches the docs wording | **yes** — "Effort: exponential intensity scale" both platforms |

It was simply in the wrong place: filed with the experimental toggles, beside *"Sleep staging (V2)"*
and *"Motion-aware wake refinement"* on Android and beside the SpO2 / stress-baseline toggles on iOS —
a long scroll from anything about Effort.

A setting built for one person's report is no use if that person can't locate it.

## The change

Both platforms now show it **directly under the existing "Effort scale" row**.

The two are different concepts — that one is the display **axis** (0-100 vs 0-21), this one is the
computation **recipe** — but someone asking *"how is my Effort worked out"* reaches for the same place
for both, and each row's own caption separates them.

## Parity

Same problem and same fix on both. Android: moved from the experimental block to under `FormRow`
"Effort scale". iOS: moved from beside the SpO2 toggle to under the "Effort scale" `Picker`. Verified
both source and destination are inside the same composable / `SettingsView`, so `model`,
`banisterEffortEnabled` and the palette tokens all stay in scope.

## A pure move

71 added lines minus 12 lines of new comment equals the 59 removed — verified by diffing the moved
content, not by eye. **No string resources touched, no logic changed**, no behaviour changed except
where the row appears.

## Verification

- `:app:testFullDebugUnitTest --no-build-cache --rerun-tasks` — **4277 tests, 0 failures**.
- `lintVitalFullRelease -PstagingRelease` clean, `doc_comment_lint.py` OK, `i18n_audit.py --ci` OK.
- **app-build required** — `Strand/Screens/SettingsView.swift` is app-target Swift and nothing local
  compiles it. Not dispatched.
- Not seen on a device. The check is trivial though: Settings → the row should sit immediately below
  "Effort scale".
