### PR TITLE
Route blank Android Steps tile to calibration (#1515)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -171,6 +171,13 @@ private enum class Destination(
     Notifications("notifications", R.string.nav_notifications, Icons.Filled.Notifications),
     PowerSaving("power_saving", R.string.nav_power_saving, Icons.Filled.BatteryStd),
     Settings("settings", R.string.nav_settings, Icons.Filled.Settings),
+    // Nested Settings destination shared by the Settings row and a blank WHOOP 4.0 Steps tile (#1515).
+    // Deliberately absent from [drawerGroups]: it is contextual, not another top-level More item.
+    StepsCalibration(
+        "steps_calibration",
+        R.string.l10n_settings_screen_steps_estimate_ce7a604d,
+        Icons.Filled.Tune,
+    ),
     TestCentre("test_centre", R.string.nav_test_centre, Icons.Filled.BugReport),
 
     // The "More" tab: its own navigated page (mirroring the iOS More tab) that hosts the full
@@ -338,6 +345,9 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
                         // Every metric/vital card opens its OWN focused detail trend (vital_detail/<key>),
                         // not the shared Health hub (2026-07-03). Mirrors the iOS liquidCard metricDetail.
                         onOpenMetric = { key -> nav.navigate("vital_detail/$key") },
+                        // A blank, uncalibrated WHOOP 4.0 Steps tile opens the same calibration screen as
+                        // Settings. A normal push returns Back to Today (#1515).
+                        onOpenStepsCalibration = { nav.navigate(Destination.StepsCalibration.route) },
                         onOpenSleep = { nav.navigateTopLevel(Destination.Sleep.route) },
                         // Optional Coupled view card (task #43): a normal push so back returns to Today.
                         onOpenCoupled = { nav.navigate(Destination.CoupledView.route) },
@@ -442,6 +452,20 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
                         viewModel,
                         onOpenTestCentre = { nav.navigate(Destination.TestCentre.route) },
                         onOpenBackupSync = { nav.navigate(Destination.BackupSync.route) },
+                        onOpenStepsCalibration = { nav.navigate(Destination.StepsCalibration.route) },
+                    )
+                }
+                composable(Destination.StepsCalibration.route) {
+                    val profile = remember(context) { ProfileStore.from(context) }
+                    var revision by remember { mutableStateOf(0) }
+                    // ProfileStore wraps SharedPreferences rather than snapshot state. Reading this counter
+                    // makes manual coefficient changes repaint the canonical screen immediately.
+                    @Suppress("UNUSED_VARIABLE") val tick = revision
+                    StepsCalibrationScreen(
+                        vm = viewModel,
+                        profile = profile,
+                        onProfileChanged = { revision++ },
+                        onClose = { nav.popBackStack() },
                     )
                 }
                 composable(Destination.TestCentre.route) { TestCentreScreen(viewModel) }

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -485,6 +485,7 @@ fun SettingsScreen(
     vm: AppViewModel,
     onOpenTestCentre: () -> Unit = {},
     onOpenBackupSync: () -> Unit = {},
+    onOpenStepsCalibration: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -556,11 +557,6 @@ fun SettingsScreen(
     // that feeds Charge from tonight onward; the standing analyze loop picks it up on its next pass.
     // Fixes a baseline poisoned by a bad first week (worn sick, or early nights that anchored too high).
     var showRecalibrateConfirm by remember { mutableStateOf(false) }
-
-    // Steps-estimate calibration screen (WHOOP 4.0), reached from the Profile card's "Steps estimate"
-    // tap-through. Mirrors the macOS StepsCalibrationSheet: honest explainer + current fit + a recent
-    // estimated-vs-phone table + a manual coefficient override. Full-screen Dialog like the guide above.
-    var showStepsCalibration by remember { mutableStateOf(false) }
 
     // Whether the "Advanced" disclosure (experimental probes, diagnostics, raw-sensor export, Trends
     // report) is expanded. Default FALSE so a first-run user lands on the everyday sections instead of
@@ -1129,7 +1125,7 @@ fun SettingsScreen(
                         .clickable(
                             interactionSource = stepsRowInteraction,
                             indication = null,
-                        ) { showStepsCalibration = true }
+                        ) { onOpenStepsCalibration() }
                         .semantics {
                             contentDescription =
                                 uiString(R.string.l10n_settings_screen_steps_estimate_calibration_stepssummary_opens_the_d6fbf995, stepsSummary)
@@ -3612,26 +3608,6 @@ fun SettingsScreen(
             ) {
                 Surface(modifier = Modifier.fillMaxSize(), color = Palette.surfaceBase) {
                     WhoopModelComparisonScreen(onClose = { showModelComparison = false })
-                }
-            }
-        }
-
-
-        // Steps-estimate calibration, opened from the Profile card's "Steps estimate" row. Same
-        // full-screen Dialog idiom; a manual-coefficient write bumps `rev` so the Profile summary
-        // row reflects the new state on dismiss.
-        if (showStepsCalibration) {
-            Dialog(
-                onDismissRequest = { showStepsCalibration = false },
-                properties = DialogProperties(usePlatformDefaultWidth = false),
-            ) {
-                Surface(modifier = Modifier.fillMaxSize(), color = Palette.surfaceBase) {
-                    StepsCalibrationScreen(
-                        vm = vm,
-                        profile = profile,
-                        onProfileChanged = { rev++ },
-                        onClose = { showStepsCalibration = false },
-                    )
                 }
             }
         }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -282,6 +282,9 @@ fun TodayScreen(
     // wrongly dumping into the Health monitor). Mirrors the iOS liquidCard `metricDetail(key)`. Takes the
     // vital_detail key; defaults to the Health screen so an unbound caller keeps the old behaviour.
     onOpenMetric: (String) -> Unit = { onOpenHealth() },
+    // A blank WHOOP 4.0 Steps tile can open calibration directly (#1515). AppRoot binds this to the same
+    // nested destination Settings uses; other Steps states continue through [onOpenMetric].
+    onOpenStepsCalibration: () -> Unit = {},
     onOpenSleep: () -> Unit = {},
     // Optional Coupled view card (task #43): a tap-through to the WHOOP-style day screen. Defaulted to a
     // no-op so the call site stays compiling; AppRoot binds it to nav.navigate(CoupledView).
@@ -1560,6 +1563,7 @@ fun TodayScreen(
                                     detailed = keyMetricsDetailed,
                                     windowDays = keyMetricsWindowDays,
                                     onOpenMetric = onOpenMetric,
+                                    onOpenStepsCalibration = onOpenStepsCalibration,
                                 )
                             }
                         }
@@ -4919,7 +4923,16 @@ private fun MetricGrid(
     // Tile drill-ins: every tile opens its focused trend timeline (vital_detail/<key>, the Sleep
     // night-detail pattern) via [onOpenMetric].
     onOpenMetric: (String) -> Unit = {},
+    // Exception for the actionable blank WHOOP 4.0 state: it opens the canonical calibration screen.
+    onOpenStepsCalibration: () -> Unit = {},
 ) {
+    val realStepsForDay = d?.steps ?: importedStepsForDay
+    val stepsOpenCalibration = stepsTileShouldOpenCalibration(
+        realSteps = realStepsForDay,
+        estimatedSteps = estimatedStepsForDay,
+        calibrationPrompt = stepsCalibrationPrompt,
+    )
+
     // FIX 3 (iOS `keyMetricsSection` parity): a 3-COLUMN grid of COMPACT liquid tiles, each an iOS `ktile`
     // — a 9sp/+1.2 overline label, a value + small unit, and a thin 8dp LiquidTube fill bar — REPLACING the
     // old 2-column large sparkline cards. One descriptor per KeyMetric, carrying the SAME value/tint reads
@@ -5006,8 +5019,7 @@ private fun MetricGrid(
         },
         KeyMetric.STEPS to run {
             // Steps precedence (unchanged): on-device count → imported → estimate. (#107/#150)
-            val realSteps = d?.steps ?: importedStepsForDay
-            val steps = realSteps ?: estimatedStepsForDay
+            val steps = realStepsForDay ?: estimatedStepsForDay
             KeyTileData(
                 label = uiString(R.string.l10n_today_screen_steps_cdde4f20),
                 value = steps?.let { intString(it.toDouble()) } ?: NO_DATA,
@@ -5018,7 +5030,7 @@ private fun MetricGrid(
                 // A measured count needs no explanation; an ESTIMATE says what it was fitted from
                 // (#760/#792); a BLANK tile on a strap that estimates says what would unblock it (#1491).
                 caption = when {
-                    realSteps != null -> null
+                    realStepsForDay != null -> null
                     estimatedStepsForDay != null -> stepsEstimateCaption
                     else -> stepsCalibrationPrompt
                 },
@@ -5065,7 +5077,7 @@ private fun MetricGrid(
         KeyMetric.RESTING_HR -> ({ onOpenMetric("rhr") })
         KeyMetric.BLOOD_OXYGEN -> ({ onOpenMetric("spo2") })
         KeyMetric.RESPIRATORY -> ({ onOpenMetric("resp") })
-        KeyMetric.STEPS -> ({ onOpenMetric("steps_est") })
+        KeyMetric.STEPS -> if (stepsOpenCalibration) onOpenStepsCalibration else ({ onOpenMetric("steps_est") })
         KeyMetric.CALORIES -> ({ onOpenMetric("active_kcal") })
         KeyMetric.WEIGHT -> null
     }
@@ -5122,6 +5134,15 @@ private fun MetricGrid(
         }
     }
 }
+
+/** True only for the actionable #1515 state: the tile has no measured/imported count, no estimate, and
+ *  carries the WHOOP 4.0 calibration prompt. Real or estimated Steps always retain their trend drill-in;
+ *  a blank 5/MG or already-calibrated quiet day has no prompt and retains it too. */
+internal fun stepsTileShouldOpenCalibration(
+    realSteps: Int?,
+    estimatedSteps: Int?,
+    calibrationPrompt: String?,
+): Boolean = realSteps == null && estimatedSteps == null && calibrationPrompt != null
 
 /** One compact Key-Metrics tile's data: iOS `ktile`(label, value, unit, tint, frac). [spark] is the
  *  trailing trend series (oldest→newest) the DETAILED tile style graphs, capped at render to the editor's

--- a/android/app/src/test/java/com/noop/ui/StepsTileNavigationTest.kt
+++ b/android/app/src/test/java/com/noop/ui/StepsTileNavigationTest.kt
@@ -1,0 +1,29 @@
+package com.noop.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pins the conditional Steps-tile destination introduced for #1515. */
+class StepsTileNavigationTest {
+
+    @Test
+    fun blankUncalibratedFourPointZeroTile_opensCalibration() {
+        assertTrue(stepsTileShouldOpenCalibration(null, null, "Connect your phone's step count"))
+    }
+
+    @Test
+    fun measuredTile_keepsTrendDestination_evenIfPromptWasResolved() {
+        assertFalse(stepsTileShouldOpenCalibration(8_432, null, "Connect your phone's step count"))
+    }
+
+    @Test
+    fun estimatedTile_keepsTrendDestination_evenIfPromptWasResolved() {
+        assertFalse(stepsTileShouldOpenCalibration(null, 7_105, "Need 2 more days"))
+    }
+
+    @Test
+    fun blankTileWithoutCalibrationPrompt_keepsTrendDestination() {
+        assertFalse(stepsTileShouldOpenCalibration(null, null, null))
+    }
+}


### PR DESCRIPTION
## What this PR does

Gives Android's blank, uncalibrated WHOOP 4.0 Steps tile a direct route to Steps calibration.

The Steps tile previously always opened `vital_detail/steps_est`, even when its own caption told the user to connect phone steps before an estimate could exist. The actionable empty state now opens calibration; measured, imported, estimated, calibrated-quiet, and WHOOP 5.0 / MG states keep the existing Steps trend destination.

This also makes Steps calibration one canonical nested NavHost destination:

- Today pushes it from the actionable blank tile and Back returns to Today.
- Settings pushes the same destination from its Steps estimate row and Back returns to Settings.
- The former Settings-local full-screen dialog instance is removed.

A pure routing predicate covers the four relevant tile states so the conditional destination cannot silently broaden later.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- `./gradlew :app:testFullDebugUnitTest --tests com.noop.ui.StepsTileNavigationTest :app:compileFullDebugKotlin` — pass
- `./gradlew :app:testFullDebugUnitTest` — pass
- `./gradlew :app:assembleFullDebug` — pass
- `python3 Tools/doc_comment_lint.py` — pass
- `python3 Tools/i18n_audit.py --ci origin/main` — pass
- `git diff --check` — pass

No Android device was attached and this SDK installation has no emulator component, so the navigation was not verified interactively.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`) — no Swift packages touched
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no visual or layout changes
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders — no protocol changes
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Closes #1515
