### PR TITLE
A 5/MG never sees the steps-calibration prompt, coefficient or not

### DIFF
--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -4075,8 +4075,11 @@ struct TodayView: View {
         // calibrate — and a strap that reports steps natively has nothing to calibrate.
         //
         // Android has been immune by construction all along: `stepsCalibrationPrompt` returns early on
-        // `model != WhoopModel.WHOOP4.name` before reading any calibration state.
-        if family == .whoop5 { return false }
+        // `model != WhoopModel.WHOOP4.name` before reading any calibration state — and this is written the
+        // same way round, "positively identified and NOT a 4.0", rather than "is a 5". Those are the same
+        // set today because `WhoopModel` has exactly two cases, but they stop being the same the moment a
+        // third is added, and the version that would then be wrong is the one naming a specific family.
+        if let family, family != .whoop4 { return false }
         // The coefficient paths stay for everything else, and are NOT redundant with the family check: a
         // legacy 4.0 owner whose `selectedWhoopModel` was never written still has a coefficient, and
         // dropping these would silently take the gear away from them.

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -4062,7 +4062,25 @@ struct TodayView: View {
                                     calibrationSampleDays: Int) -> Bool {
         // Optional-chained deliberately: an unset (or unparseable) key is NOT a 4.0. The key only ever
         // holds a `WhoopModel` rawValue, so nil here means "no strap has been identified", not "4.0".
-        (WhoopModel(rawValue: selectedModelRaw)?.deviceFamily == .whoop4 && hasDayData)
+        let family = WhoopModel(rawValue: selectedModelRaw)?.deviceFamily
+        // #1523 follow-up: a POSITIVELY identified 5/MG never sees this, whatever calibration state the
+        // profile carries from an earlier strap. #1579 stopped a partial sample-day count activating the
+        // affordance but left the coefficient paths able to, and those are profile-global — so a user who
+        // calibrated a 4.0 and then moved to a 5.0 still got the 4.0 prompt on any day the 5.0 logged no
+        // steps and no estimate existed. That is the same complaint #1523 opened, on a narrower trigger.
+        //
+        // The justification for the coefficient paths was preserving estimate behaviour across that
+        // migration, but this gate does not control the estimate: `estSteps` comes from `stepsEstByDay`
+        // and is computed independently. All this gate decides is whether a BLANK tile offers to
+        // calibrate — and a strap that reports steps natively has nothing to calibrate.
+        //
+        // Android has been immune by construction all along: `stepsCalibrationPrompt` returns early on
+        // `model != WhoopModel.WHOOP4.name` before reading any calibration state.
+        if family == .whoop5 { return false }
+        // The coefficient paths stay for everything else, and are NOT redundant with the family check: a
+        // legacy 4.0 owner whose `selectedWhoopModel` was never written still has a coefficient, and
+        // dropping these would silently take the gear away from them.
+        return (family == .whoop4 && hasDayData)
             || calibrationCoefficient > 0
             || manualCoefficient > 0
     }

--- a/StrandTests/TodayStepsPipelineTests.swift
+++ b/StrandTests/TodayStepsPipelineTests.swift
@@ -31,18 +31,32 @@ final class TodayStepsPipelineTests: XCTestCase {
         XCTAssertFalse(active(model: .whoop4, hasDayData: false, sampleDays: 3))
     }
 
-    func testFittedCoefficientPreservesMigratedFourPointZeroProfile() {
-        XCTAssertTrue(active(model: .whoop5mg,
-                             hasDayData: true,
-                             calibrationCoefficient: 0.42,
-                             sampleDays: 5))
+    /// #1523 follow-up: these two asserted TRUE when the suite landed, on the grounds that a profile
+    /// migrating from a calibrated 4.0 to a 5.0 should keep its estimate behaviour. That reasoning does
+    /// not apply to THIS gate — `estSteps` is computed independently in `stepsEstByDay`, and all this
+    /// decides is whether a blank tile offers to calibrate. A 5/MG reports steps natively, so it has
+    /// nothing to calibrate, and showing it the 4.0 prompt is the complaint #1523 opened.
+    func testFittedCoefficientDoesNotPromptOnAFivePointZero() {
+        XCTAssertFalse(active(model: .whoop5mg,
+                              hasDayData: true,
+                              calibrationCoefficient: 0.42,
+                              sampleDays: 5))
     }
 
-    func testManualCoefficientPreservesMigratedFourPointZeroProfile() {
-        XCTAssertTrue(active(model: .whoop5mg,
-                             hasDayData: true,
-                             manualCoefficient: 0.35,
-                             sampleDays: 1))
+    func testManualCoefficientDoesNotPromptOnAFivePointZero() {
+        XCTAssertFalse(active(model: .whoop5mg,
+                              hasDayData: true,
+                              manualCoefficient: 0.35,
+                              sampleDays: 1))
+    }
+
+    /// …but the coefficient paths must NOT simply be deleted, which is the tempting reading of the two
+    /// above. A legacy 4.0 owner whose `selectedWhoopModel` key was never written has no family to match
+    /// on, and only the coefficient says they are mid-estimate. Dropping these would silently take the
+    /// calibration gear away from exactly the users #1491 restored it for.
+    func testACoefficientStillActivatesWhenNoModelWasEverRecorded() {
+        XCTAssertTrue(active(model: nil, hasDayData: true, calibrationCoefficient: 0.42))
+        XCTAssertTrue(active(model: nil, hasDayData: true, manualCoefficient: 0.35))
     }
 
     func testUnsetModelAndPartialSampleDaysStayInactive() {


### PR DESCRIPTION
Follow-up to #1579, which I flagged when reviewing it and recorded in that merge commit.

#1579 stopped a partial sample-day count activating the 4.0-only calibration affordance on a WHOOP
5.0. The **coefficient paths could still activate it**, and those are profile-global — so a user who
calibrated a 4.0 and later moved to a 5.0 kept getting the 4.0 prompt on any day the 5.0 logged no
steps and no estimate existed. That is the complaint issue #1523 opened, on a narrower trigger.

## Why the original justification doesn't hold

@kavemang kept those paths to preserve estimate behaviour across that migration. Reasonable on its
face — but this gate doesn't control the estimate:

- `estSteps` comes from `stepsEstByDay[selectedDayKey]` (`TodayView.swift:3737`), computed
  independently;
- the gate is only consulted inside
  `needsCalibration = realSteps == nil && estSteps == nil && stepsPipelineActive(…)`.

So all it decides is whether a **blank** tile offers to calibrate. A strap that reports steps natively
has nothing to calibrate.

## The change

A positively-identified 5/MG returns `false` before anything else is considered.

Android has been immune this way all along — `stepsCalibrationPrompt` returns early on
`model != WhoopModel.WHOOP4.name` before reading any calibration state. This brings iOS to the same
guarantee while keeping its more permissive fallback for unknown straps.

## What is deliberately NOT changed

**The coefficient paths are not deleted**, which is the tempting reading of the above. A legacy 4.0
owner whose `selectedWhoopModel` key was never written has no family to match on, and only the
coefficient says they are mid-estimate. Dropping them would silently take the calibration gear away
from exactly the users #1491 restored it for. A new case pins that:

```
legacy 4.0, pref unset, has coefficient  ->  still active
```

## Matrix, replayed before changing anything

| case | #1579 | here |
|---|---|---|
| 5.0 + partial sample days | false | false |
| 4.0 fresh + day data | true | true |
| 4.0, no day data | false | false |
| **5.0 + fitted coefficient** | **true** | **false** |
| **5.0 + manual coefficient** | **true** | **false** |
| unset model + sample days | false | false |
| legacy 4.0, pref unset, coefficient | true | true |
| 4.0 calibrated + day data | true | true |

Only the two intended cases move. Those two tests from #1579 are renamed to say what they now assert,
with the reasoning recorded on them rather than buried in a commit message.

## Verification

- `doc_comment_lint.py` OK. No strings, no Android change, no schema.
- **app-build required** — `TodayView.swift` is app-target Swift and nothing else compiles it; that is
  how #1579's own tests went unrun until merge. Not dispatched.
- Not seen on a device.

Credit to @kavemang: the diagnosis and the pure-function extraction in #1579 are what made this
testable at all — the gate was previously unreachable from any test.
