### PR TITLE
Preserve PPG burst boundaries

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
@@ -257,7 +257,8 @@ public func extractHistoricalStreams(_ parsed: [ParsedFrame],
             // heart_rate/spo2/gravity, so it adds nothing to the branches below — handled here only.
             if let samples = p["ppg_waveform"]?.intArrayValue, !samples.isEmpty {
                 ppgRecords.append((ts: ts, samples: samples))
-                out.ppgWaveform.append(PpgWaveformSample(ts: ts, samples: samples))
+                out.ppgWaveform.append(PpgWaveformSample(ts: ts, samples: samples,
+                                                         burstIndex: p["burst_index"]?.intValue))
             }
             if let bpm = p["heart_rate"]?.intValue, bpm != 0 {  // skip startup hr=0
                 out.hr.append(HRSample(ts: ts, bpm: bpm))

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
@@ -328,7 +328,12 @@ public struct SleepStateSample: Equatable, Codable {
 public struct PpgWaveformSample: Equatable, Codable, Sendable {
     public let ts: Int          // wall-clock unix seconds (one record per second)
     public let samples: [Int]   // raw i16 ADC counts @24 Hz, verbatim from `ppg_waveform` (usually 24)
-    public init(ts: Int, samples: [Int]) { self.ts = ts; self.samples = samples }
+    public let burstIndex: Int?  // raw per-burst counter @21; nil for legacy archives
+    public init(ts: Int, samples: [Int], burstIndex: Int? = nil) {
+        self.ts = ts
+        self.samples = samples
+        self.burstIndex = burstIndex
+    }
 }
 
 /// One wire slot in the 5/MG v18 auxiliary-field record. The `rawValue` is the slot's bit position in

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5PpgWaveformTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5PpgWaveformTests.swift
@@ -100,10 +100,19 @@ final class Whoop5PpgWaveformTests: XCTestCase {
     func testExtractHistoricalStreamsPersistsRawPpgWaveform() {
         let f = parseFrame(bytes(v26Hex), family: .whoop5)
         let streams = extractHistoricalStreams([f], deviceClockRef: 1_780_917_232, wallClockRef: 1_780_917_232)
-        XCTAssertEqual(streams.ppgWaveform, [PpgWaveformSample(ts: 1_780_917_232, samples: expectedWaveform)])
+        XCTAssertEqual(streams.ppgWaveform,
+                       [PpgWaveformSample(ts: 1_780_917_232, samples: expectedWaveform, burstIndex: 1)])
         XCTAssertTrue(streams.ppgHr.isEmpty, "a lone 1 s record is too short for a confident HR estimate")
         // Not "no rows at all" — the Backfiller's silent-data-loss diagnostic must see this as decoded.
         XCTAssertFalse(streams.isEmpty)
+    }
+
+    func testExtractHistoricalStreamsCarriesEachBurstIndexWithItsWaveform() {
+        let parsed = [v26Hex, v26HexChannel46].map { parseFrame(bytes($0), family: .whoop5) }
+        let streams = extractHistoricalStreams(parsed,
+                                               deviceClockRef: 1_780_917_232,
+                                               wallClockRef: 1_780_917_232)
+        XCTAssertEqual(streams.ppgWaveform.map(\.burstIndex), [1, 2])
     }
 
     /// `Streams.isEmpty` must count a waveform-only decode as non-empty even when `ppgHr` (derived FROM
@@ -128,8 +137,12 @@ final class Whoop5PpgWaveformTests: XCTestCase {
         let json = #"{"ppg_waveform":[{"ts":1780917232,"samples":[-1432,-1332,12]}]}"#
         let s2 = try dec.decode(Streams.self, from: Data(json.utf8))
         XCTAssertEqual(s2.ppgWaveform, [PpgWaveformSample(ts: 1_780_917_232, samples: [-1432, -1332, 12])])
+        XCTAssertNil(s2.ppgWaveform.first?.burstIndex, "legacy JSON has no burst index")
         // Round-trip encode → decode is identity.
-        let round = try dec.decode(Streams.self, from: JSONEncoder().encode(s2))
-        XCTAssertEqual(round.ppgWaveform, s2.ppgWaveform)
+        let withBurst = Streams(ppgWaveform: [PpgWaveformSample(ts: 1_780_917_232,
+                                                                samples: [-1432, -1332, 12],
+                                                                burstIndex: 4)])
+        let round = try dec.decode(Streams.self, from: JSONEncoder().encode(withBurst))
+        XCTAssertEqual(round.ppgWaveform, withBurst.ppgWaveform)
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -868,6 +868,13 @@ extension WhoopStore {
                 t.primaryKey(["deviceId", "ts"])
             }
         }
+        // v39 (#979): keep the v26 per-burst counter beside the waveform it segments. Existing rows stay
+        // nil because the counter was discarded before this migration and cannot be reconstructed.
+        migrator.registerMigration("v39-ppg-burst-index") { db in
+            try db.alter(table: "ppgWaveformSample") { t in
+                t.add(column: "burstIndex", .integer)
+            }
+        }
         return migrator
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
@@ -323,11 +323,12 @@ extension WhoopStore {
             // `packPpgSamples`) rather than 24 scalar rows, so this insert is O(records), not O(samples).
             if !streams.ppgWaveform.isEmpty {
                 let stmt = try db.cachedStatement(sql: """
-                    INSERT INTO ppgWaveformSample (deviceId, ts, samples) VALUES (?, ?, ?)
+                    INSERT INTO ppgWaveformSample (deviceId, ts, samples, burstIndex) VALUES (?, ?, ?, ?)
                     ON CONFLICT(deviceId, ts) DO NOTHING
                     """)
                 for s in streams.ppgWaveform {
-                    try stmt.execute(arguments: [deviceId, s.ts, WhoopStore.packPpgSamples(s.samples)])
+                    try stmt.execute(arguments: [deviceId, s.ts, WhoopStore.packPpgSamples(s.samples),
+                                                 s.burstIndex])
                 }
             }
             // Every remaining v18 slot (v31), one compact blob per strap-second. Persist-only, same as
@@ -633,11 +634,13 @@ extension WhoopStore {
         -> [PpgWaveformSample] {
         try syncRead { db in
             try Row.fetchAll(db, sql: """
-                SELECT ts, samples FROM ppgWaveformSample
+                SELECT ts, samples, burstIndex FROM ppgWaveformSample
                 WHERE deviceId = ? AND ts >= ? AND ts <= ?
                 ORDER BY ts LIMIT ?
                 """, arguments: [deviceId, from, to, limit])
-                .map { PpgWaveformSample(ts: $0["ts"], samples: WhoopStore.unpackPpgSamples($0["samples"])) }
+                .map { PpgWaveformSample(ts: $0["ts"],
+                                         samples: WhoopStore.unpackPpgSamples($0["samples"]),
+                                         burstIndex: $0["burstIndex"]) }
         }
     }
 

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/PpgWaveformSampleTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/PpgWaveformSampleTests.swift
@@ -31,18 +31,19 @@ final class PpgWaveformSampleTests: XCTestCase {
     func testPpgWaveformTableShape() async throws {
         let store = try await WhoopStore.inMemory()
         let cols = try await store.columnNamesForTest(table: "ppgWaveformSample")
-        XCTAssertEqual(Set(cols), ["deviceId", "ts", "samples"])
+        XCTAssertEqual(Set(cols), ["deviceId", "ts", "samples", "burstIndex"])
     }
 
     func testPpgWaveformInsertRoundTripAndDedup() async throws {
         let store = try await WhoopStore.inMemory()
-        let streams = Streams(ppgWaveform: [PpgWaveformSample(ts: 1_780_917_232, samples: realSamples)])
+        let streams = Streams(ppgWaveform: [PpgWaveformSample(ts: 1_780_917_232,
+                                                              samples: realSamples, burstIndex: 7)])
         _ = try await store.insert(streams, deviceId: "my-whoop")
         let n1 = try await store.ppgWaveformCountForTest()
         XCTAssertEqual(n1, 1)
         let read = try await store.ppgWaveformSamples(deviceId: "my-whoop",
                                                        from: 1_780_917_232, to: 1_780_917_232)
-        XCTAssertEqual(read, [PpgWaveformSample(ts: 1_780_917_232, samples: realSamples)])
+        XCTAssertEqual(read, [PpgWaveformSample(ts: 1_780_917_232, samples: realSamples, burstIndex: 7)])
         // Re-inserting the same (deviceId, ts) is idempotent, ON CONFLICT DO NOTHING (mirrors every
         // other per-second stream's dedupe rule).
         _ = try await store.insert(streams, deviceId: "my-whoop")

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
@@ -1,6 +1,6 @@
 {
   "_readme": "SHARED Room<->GRDB SCHEMA ORACLE (#775). Two byte-identical copies: Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json and android/app/src/test/resources/schema_oracle.json. SchemaOracleTests.swift compares GRDB's PRAGMA table_info/index_list against it; SchemaOracleTest.kt compares Room's exported schema JSON against it. `columns` is the iOS/GRDB shape in GRDB column order (macOS is the reference implementation); every way Android differs is spelled out in an `android` / `iosAbsent` / `androidColumnOrder` override naming a key in `divergenceReasons`. Adding a column, reordering one, or changing a type/nullability on one platform only fails both suites until it is either fixed or written down here.",
-  "roomVersion": 32,
+  "roomVersion": 33,
   "grdbMigrations": [
     "v1",
     "v2",
@@ -39,7 +39,8 @@
     "v35-rr-future-quarantine",
     "v36-whoop-caps-no-spo2",
     "v37-daily-avg-sdnn",
-    "v38-apple-step-hour"
+    "v38-apple-step-hour",
+    "v39-ppg-burst-index"
   ],
   "divergenceReasons": {
     "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android \u2014 the per-row upload flag belongs to an upload path that does not exist there \u2014 so it is dead width, not divergent data. Removing it needs a Room table rebuild.",
@@ -1160,6 +1161,12 @@
           "name": "samples",
           "affinity": "BLOB",
           "notNull": true,
+          "default": null
+        },
+        {
+          "name": "burstIndex",
+          "affinity": "INTEGER",
+          "notNull": false,
           "default": null
         }
       ],

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -612,26 +612,29 @@ data class AppleStepHour(
  * keeping a v26-heavy night to roughly the same order of magnitude as ONE extra per-second stream. The
  * BLOB format is byte-identical to the Swift GRDB `WhoopStore.packPpgSamples` so a `.noopbak` round-trips.
  * PK (deviceId, ts) mirrors every other per-second stream; a truncated frame can decode fewer than 24
- * samples. Fields are declared in the SAME order as the GRDB schema (deviceId, ts, samples) so the
- * migration's CREATE TABLE column order matches Room's generated shape.
+ * samples. Fields are declared in the SAME order as the GRDB schema
+ * (deviceId, ts, samples, burstIndex) so Room's generated shape stays byte-identical.
  */
 @Entity(tableName = "ppgWaveformSample", primaryKeys = ["deviceId", "ts"])
 data class PpgWaveformSampleEntity(
     val deviceId: String,
     val ts: Long,
     val samples: ByteArray,
+    val burstIndex: Int? = null,
 ) {
     // ByteArray needs structural equals/hashCode (the generated identity ones break round-trip asserts).
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is PpgWaveformSampleEntity) return false
-        return deviceId == other.deviceId && ts == other.ts && samples.contentEquals(other.samples)
+        return deviceId == other.deviceId && ts == other.ts && samples.contentEquals(other.samples) &&
+            burstIndex == other.burstIndex
     }
 
     override fun hashCode(): Int {
         var result = deviceId.hashCode()
         result = 31 * result + ts.hashCode()
         result = 31 * result + samples.contentHashCode()
+        result = 31 * result + (burstIndex ?: 0)
         return result
     }
 }

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -53,7 +53,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         V18AuxSampleEntity::class,
         AppleStepHour::class,
     ],
-    version = 32,
+    version = 33,
     // #775: ON so Room's KSP processor writes the generated schema (every table's exact `CREATE TABLE`,
     // columns in declaration order with affinity/NOT NULL/default, PK and indices) as JSON. That export
     // is what lets a plain JVM test — no device, no Robolectric — read Android's REAL schema and compare
@@ -70,7 +70,7 @@ abstract class WhoopDatabase : RoomDatabase() {
         const val DB_NAME = "noop_whoop.db"
         /** Room schema version — MUST equal the `@Database(version = …)` above. Surfaced in the backup
          *  manifest (#1410) so an export states its schema. Bump both together on a migration. */
-        const val SCHEMA_VERSION = 32
+        const val SCHEMA_VERSION = 33
 
         @Volatile
         private var instance: WhoopDatabase? = null
@@ -888,6 +888,17 @@ abstract class WhoopDatabase : RoomDatabase() {
             }
         }
 
+        /** #979: append the nullable v26 burst counter beside its persisted waveform. */
+        internal val PPG_BURST_INDEX_MIGRATION_SQL: List<String> = listOf(
+            "ALTER TABLE `ppgWaveformSample` ADD COLUMN `burstIndex` INTEGER",
+        )
+
+        internal val MIGRATION_32_33 = object : Migration(32, 33) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                for (stmt in PPG_BURST_INDEX_MIGRATION_SQL) db.execSQL(stmt)
+            }
+        }
+
         private fun build(appContext: Context): WhoopDatabase =
             Room.databaseBuilder(appContext, WhoopDatabase::class.java, DB_NAME)
                 // #1014: replace ONLY the corruption handling of the default open-helper. The
@@ -906,7 +917,7 @@ abstract class WhoopDatabase : RoomDatabase() {
                     MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
                     MIGRATION_22_23, MIGRATION_23_24, MIGRATION_24_25, MIGRATION_25_26,
                     MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30,
-                    MIGRATION_30_31, MIGRATION_31_32,
+                    MIGRATION_30_31, MIGRATION_31_32, MIGRATION_32_33,
                 )
                 // #1037: a FRESH install builds the schema straight at the current version and runs NO
                 // migrations, so the MIGRATION_7_8 "my-whoop" registry seed never fires and the WHOOP,

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -302,7 +302,7 @@ data class PpgHrRow(val ts: Long, val bpm: Int, val conf: Double)
  * unix second, [samples] the raw i16 ADC counts (usually 24, fewer on a truncated frame). deviceId is
  * attached on insert; the samples are packed to a little-endian i16 BLOB by [StreamPersistence.packPpgSamples].
  */
-data class PpgWaveformRow(val ts: Long, val samples: List<Int>)
+data class PpgWaveformRow(val ts: Long, val samples: List<Int>, val burstIndex: Int? = null)
 
 /** Count of rows ACTUALLY inserted per stream (mirrors WhoopStore.insert return tuple). */
 data class InsertCounts(
@@ -536,7 +536,8 @@ class WhoopRepository(
         if (streams.ppgWaveform.isNotEmpty()) {
             dao.insertPpgWaveform(
                 streams.ppgWaveform.map {
-                    PpgWaveformSampleEntity(deviceId, it.ts, StreamPersistence.packPpgSamples(it.samples))
+                    PpgWaveformSampleEntity(deviceId, it.ts, StreamPersistence.packPpgSamples(it.samples),
+                        it.burstIndex)
                 },
             )
         }

--- a/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
+++ b/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
@@ -530,11 +530,11 @@ private fun decodeWhoop5Historical(frame: ByteArray): Map<String, Any?>? {
  * PPG-derived on-device), so the win here is the waveform itself, which [PpgHr] turns into HR.
  *
  * Returns the record's wall-second [unix] and the 24 raw ADC [samples], or null when the frame is not
- * a v26 HISTORICAL_DATA record or the waveform region is truncated. The bytes before [27] (header +
- * the raw per-burst counter @21 — `burst_index`, NOT a channel id; PR#553) and the footer after [75]
- * are intentionally not mapped here: the Android offload path needs only [unix] + the waveform for HR.
+ * a v26 HISTORICAL_DATA record or the waveform region is truncated. The raw per-burst counter @21
+ * (`burst_index`, NOT a channel id; PR#553) is carried beside the waveform
+ * so durable rows retain their burst boundaries. The footer after [75] remains intentionally unmapped.
  */
-private data class V26Record(val unix: Long, val samples: List<Int>)
+private data class V26Record(val unix: Long, val samples: List<Int>, val burstIndex: Int?)
 
 private fun decodeWhoop5HistoricalV26(frame: ByteArray): V26Record? {
     if (frame.histU8(8) != PacketType.HISTORICAL_DATA.rawValue) return null
@@ -550,7 +550,9 @@ private fun decodeWhoop5HistoricalV26(frame: ByteArray): V26Record? {
         off += 2
     }
     if (samples.isEmpty()) return null
-    return V26Record(unix = unix, samples = samples)
+    val rawBurstIndex = frame.histU8(21)
+    return V26Record(unix = unix, samples = samples,
+        burstIndex = rawBurstIndex?.takeIf { it > 0 })
 }
 
 /**
@@ -565,8 +567,8 @@ private fun decodeWhoop5HistoricalV26(frame: ByteArray): V26Record? {
  *   - CONSOLE_LOGS (type-50) frames — the strap's own diagnostics text channel. On WHOOP 4.0 the
  *     inner type byte is frame[4]; type-50 (0x32) is not type-47 so the family-aware type guard below
  *     already skips it. On WHOOP 5/MG the inner type byte is at frame[8].
- *   - WHOOP 5/MG v26 (raw PPG) records — deliberately unstored (see [decodeWhoop5Historical]), known
- *     and skipped by design, not lost.
+ *   - WHOOP 5/MG v26 (raw PPG) records — stored in the dedicated waveform stream, so they do not belong
+ *     in the rejected-record archive.
  *   - Non-record frames (METADATA, EVENT, etc.) — not type-47, so never returned.
  *
  * The Backfiller archives these raw bytes BEFORE acking the trim, so a user on an unmapped firmware
@@ -584,7 +586,7 @@ fun rejectedHistoricalRecords(
     return rawFrames.filter { frame ->
         val t = frame.histU8(typeIndex) ?: return@filter false
         if (t != PacketType.HISTORICAL_DATA.rawValue) return@filter false // type-50 console / metadata / etc.
-        // WHOOP 5/MG v26 = raw PPG block, deliberately not stored — known-skipped, not lost data.
+        // WHOOP 5/MG v26 = raw PPG block with its own durable waveform stream, not rejected data.
         if (family == DeviceFamily.WHOOP5 && frame.histU8(9) == 26) return@filter false
         // UNMAPPED LAYOUT (5/MG) — archive UNCONDITIONALLY, whatever it decoded.
         //
@@ -828,7 +830,9 @@ fun extractHistoricalStreams(
                             // Persist the raw waveform itself too (#156 follow-up), keyed on the record's
                             // corrected wall-second. Guard on non-empty so a truncated frame that decoded
                             // zero samples never banks an empty row (mirrors the Swift `!samples.isEmpty`).
-                            if (rec.samples.isNotEmpty()) ppgWaveform.add(PpgWaveformRow(baseTs, rec.samples))
+                            if (rec.samples.isNotEmpty()) {
+                                ppgWaveform.add(PpgWaveformRow(baseTs, rec.samples, rec.burstIndex))
+                            }
                         }
                     }
                 }

--- a/android/app/src/test/java/com/noop/data/DailySdnnMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/DailySdnnMigrationTest.kt
@@ -22,7 +22,7 @@ class DailySdnnMigrationTest {
     fun migrationAndEntityPreserveOldRowsAsNull() {
         assertEquals(31, WhoopDatabase.MIGRATION_31_32.startVersion)
         assertEquals(32, WhoopDatabase.MIGRATION_31_32.endVersion)
-        assertEquals(32, WhoopDatabase.SCHEMA_VERSION)
+        assertEquals(33, WhoopDatabase.SCHEMA_VERSION)
         val old = DailyMetric(deviceId = "my-whoop", day = "2026-08-22", avgHrv = 44.0)
         assertNull(old.avgSdnn)
         assertEquals(88.4, old.copy(avgSdnn = 88.4).avgSdnn!!, 0.0)

--- a/android/app/src/test/java/com/noop/data/PpgWaveformMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/PpgWaveformMigrationTest.kt
@@ -52,6 +52,16 @@ class PpgWaveformMigrationTest {
         assertEquals(20, WhoopDatabase.MIGRATION_19_20.endVersion)
     }
 
+    @Test
+    fun burstIndexMigration_isAdditiveAndNullable() {
+        assertEquals(
+            listOf("ALTER TABLE `ppgWaveformSample` ADD COLUMN `burstIndex` INTEGER"),
+            WhoopDatabase.PPG_BURST_INDEX_MIGRATION_SQL,
+        )
+        assertEquals(32, WhoopDatabase.MIGRATION_32_33.startVersion)
+        assertEquals(33, WhoopDatabase.MIGRATION_32_33.endVersion)
+    }
+
     // MARK: - Packed-BLOB encoding (byte-identical to Swift WhoopStore.packPpgSamples)
 
     @Test
@@ -107,7 +117,9 @@ class PpgWaveformMigrationTest {
         } as WhoopDao
 
         WhoopRepository(dao).insert(
-            StreamBatch(ppgWaveform = listOf(PpgWaveformRow(ts = 1_780_917_232L, samples = realSamples))),
+            StreamBatch(ppgWaveform = listOf(
+                PpgWaveformRow(ts = 1_780_917_232L, samples = realSamples, burstIndex = 7),
+            )),
             deviceId = "my-whoop",
         )
 
@@ -115,6 +127,7 @@ class PpgWaveformMigrationTest {
         assertEquals(1, rows.size)
         assertEquals("my-whoop", rows[0].deviceId)
         assertEquals(1_780_917_232L, rows[0].ts)
+        assertEquals(7, rows[0].burstIndex)
         // The stored BLOB is exactly packPpgSamples(samples) — the byte-identical contract vs GRDB.
         assertArrayEquals(StreamPersistence.packPpgSamples(realSamples), rows[0].samples)
         // And it unpacks back to the original samples.

--- a/android/app/src/test/java/com/noop/protocol/Whoop5PpgWaveformStreamTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5PpgWaveformStreamTest.kt
@@ -46,13 +46,26 @@ class Whoop5PpgWaveformStreamTest {
             family = DeviceFamily.WHOOP5,
         )
         assertEquals(
-            listOf(PpgWaveformRow(ts = 1_780_917_232L, samples = expectedWaveform)),
+            listOf(PpgWaveformRow(ts = 1_780_917_232L, samples = expectedWaveform, burstIndex = 1)),
             streams.ppgWaveform,
         )
         assertTrue("a lone 1 s record is too short for a confident HR estimate", streams.ppgHr.isEmpty())
         // Not "no rows at all" — a waveform-only decode must read as non-empty so the Backfiller's
         // silent-data-loss diagnostic counts it as decoded.
         assertFalse(streams.isEmpty)
+    }
+
+    @Test
+    fun zeroBurstIndexIsAbsentLikeSwift() {
+        val frame = bytes(v26Hex)
+        frame[21] = 0
+        val end = frame.size - 4
+        val crc = Crc.crc32(frame, 8, end)
+        for (i in 0 until 4) frame[end + i] = ((crc ushr (8 * i)) and 0xFF).toByte()
+        val streams = extractHistoricalStreams(
+            listOf(frame), 1_780_917_232, 1_780_917_232, DeviceFamily.WHOOP5,
+        )
+        assertEquals(null, streams.ppgWaveform.single().burstIndex)
     }
 
     /** [com.noop.data.StreamBatch.isEmpty] must count a waveform-only decode as non-empty even when the

--- a/android/app/src/test/resources/schema_oracle.json
+++ b/android/app/src/test/resources/schema_oracle.json
@@ -1,6 +1,6 @@
 {
   "_readme": "SHARED Room<->GRDB SCHEMA ORACLE (#775). Two byte-identical copies: Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json and android/app/src/test/resources/schema_oracle.json. SchemaOracleTests.swift compares GRDB's PRAGMA table_info/index_list against it; SchemaOracleTest.kt compares Room's exported schema JSON against it. `columns` is the iOS/GRDB shape in GRDB column order (macOS is the reference implementation); every way Android differs is spelled out in an `android` / `iosAbsent` / `androidColumnOrder` override naming a key in `divergenceReasons`. Adding a column, reordering one, or changing a type/nullability on one platform only fails both suites until it is either fixed or written down here.",
-  "roomVersion": 32,
+  "roomVersion": 33,
   "grdbMigrations": [
     "v1",
     "v2",
@@ -39,7 +39,8 @@
     "v35-rr-future-quarantine",
     "v36-whoop-caps-no-spo2",
     "v37-daily-avg-sdnn",
-    "v38-apple-step-hour"
+    "v38-apple-step-hour",
+    "v39-ppg-burst-index"
   ],
   "divergenceReasons": {
     "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android \u2014 the per-row upload flag belongs to an upload path that does not exist there \u2014 so it is dead width, not divergent data. Removing it needs a Room table rebuild.",
@@ -1160,6 +1161,12 @@
           "name": "samples",
           "affinity": "BLOB",
           "notNull": true,
+          "default": null
+        },
+        {
+          "name": "burstIndex",
+          "affinity": "INTEGER",
+          "notNull": false,
           "default": null
         }
       ],


### PR DESCRIPTION
## Summary
- carry the WHOOP 5/MG v26 `burst_index` alongside each decoded PPG waveform
- persist it through additive GRDB and Room migrations
- keep Swift/Kotlin schemas and decoding behavior aligned, with legacy rows remaining nullable

Closes #979.

## Verification
- `cd Packages/WhoopProtocol && swift test`: 620 passed, 1 skipped
- `cd android && ./gradlew testFullDebugUnitTest`: 4,279 passed, 6 skipped
- RED/GREEN sabotage confirmed the focused protocol, persistence, migration, and parity regressions fail without the implementation and pass with it
- `WhoopStore` tests were not runnable on this Linux host because Apple `Compression` is unavailable; the store round-trip and schema-oracle tests are included for macOS CI

## Scope / compatibility
- additive nullable columns only; existing waveform rows remain valid with no reconstructable burst index
- no estimator or downstream health behavior changes

## AI disclosure
This contribution was developed with AI assistance and independently reviewed; all reported tests were run against the submitted branch.