### PR TITLE
Oura SpO2 candidate tile + Deep Timeline single-channel fix (rebase of #1568)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -1199,6 +1199,46 @@ public enum AnalyticsEngine {
         return (mean: sum / kept, samples: kept)
     }
 
+    /// The plausible range for a raw Oura `0x6F` SpO2 sample before the ceiling transform below.
+    /// Excludes the mis-scaled `dc_raw`/perfusion-channel contamination (-1016 … 11,709,098,
+    /// OURA_PROTOCOL.md §6.5.0.1) by three orders of magnitude, same bounds as
+    /// `Repository.spo2SingleChannelPlausible` (kept in sync manually — the app layer cannot be
+    /// imported here, so that display gate should read from this one instead of redefining it).
+    public static let spo2SingleChannelPlausible = 50...110
+
+    /// Nightly **ceiling@100** mean of the Oura ring's own decoded SpO2 (`spo2Sample.red`, `0x6F`)
+    /// over the detected in-bed `sessions`, with the sample count it rests on — or nil when no
+    /// plausible sample fell inside any span. Oura twin of `nightlySpo2CandidateMean` above; queue
+    /// 11a's starting transform.
+    ///
+    /// WHY CEILING@100, NOT RAW OR THE OFFSET+CLAMP FIT. `0x6F`'s raw wire mean carries a
+    /// consistent positive bias — 20-48% of samples on a contamination-clean night read above the
+    /// physical 100% ceiling (OURA_PROTOCOL.md §6.5.0.1) — so the raw mean is the ONE transform
+    /// that has missed the Oura app's own displayed value on every full-tier paired night measured
+    /// so far (1/3 as of 2026-08-22, see §6.5.0). `min(sample, 100)` applied PER-SAMPLE before
+    /// averaging (a clamp on the aggregate mean is a different, wrong number) has round-matched
+    /// the app's displayed value on all 3 of those nights — the best track record of the
+    /// candidates tried, edging out the offset−0.32+clamp[85,100] fit (2/3) on this same bar. Not a
+    /// validated calibration (n=3, only the rounded integer, not the app's internal precision) —
+    /// per the derived-biosignal rule (CLAUDE.md), it ships the same way `spo2_candidate_82` ships:
+    /// diagnostic-only, gated behind the display toggle, never written to `spo2Pct`, never scored.
+    ///
+    /// Gated to `spo2SingleChannelPlausible` (50...110) BEFORE the ceiling is applied, so a
+    /// contaminated row (down to -1016) cannot drag the mean down — the ceiling alone only guards
+    /// the top of the range. Byte-parity twin of the Kotlin `nightlySpo2CeilingMean`.
+    public static func nightlySpo2CeilingMean(_ sessions: [SleepSession],
+                                        spo2: [SpO2Sample]) -> (mean: Int, samples: Int)? {
+        guard !sessions.isEmpty, !spo2.isEmpty else { return nil }
+        var sum = 0, kept = 0
+        for s in spo2 {
+            guard spo2SingleChannelPlausible.contains(s.red) else { continue }
+            guard sessions.contains(where: { $0.start <= s.ts && s.ts <= $0.end }) else { continue }
+            sum += min(s.red, 100); kept += 1
+        }
+        guard kept > 0 else { return nil }
+        return (mean: sum / kept, samples: kept)
+    }
+
     /// #1169 SHADOW METRIC: the primary-session MEAN resting HR — window each detected sleep session's HR
     /// samples to `[start, end)` and delegate to the #1174-defined `PrimarySessionRestingHR.meanHR` (that
     /// definition is UNCHANGED). `IntelligenceEngine` stores the result beside the shipped nightly HR FLOOR

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Spo2CeilingNightlyTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Spo2CeilingNightlyTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+import WhoopProtocol
+import WhoopStore
+@testable import StrandAnalytics
+
+/// Queue 11a — the Oura twin of `Spo2CandidateNightlyTests`: nightly ceiling@100 mean of the ring's own
+/// decoded `0x6F` SpO2 (`spo2Sample.red`), the starting candidate transform for the Blood Oxygen tile's
+/// Oura fallback. Pins the ceiling (per-sample, before averaging), the contamination floor gate, and the
+/// session-window filter — the three things that make this an honest "strap estimate," not raw wire.
+final class Spo2CeilingNightlyTests: XCTestCase {
+
+    private func session(_ start: Int, _ durSec: Int) -> SleepSession {
+        SleepSession(start: start, end: start + durSec, efficiency: 0.9,
+                     stages: [], restingHR: 50, avgHRV: 60)
+    }
+
+    private func spo2(_ ts: Int, _ red: Int) -> SpO2Sample { SpO2Sample(ts: ts, red: red, ir: 0, unit: "raw") }
+
+    func testMeanAndSampleCountOverTheSession() {
+        let r = AnalyticsEngine.nightlySpo2CeilingMean(
+            [session(1000, 600)], spo2: [spo2(1100, 94), spo2(1200, 96), spo2(1300, 95)])
+        XCTAssertEqual(r?.mean, 95)
+        XCTAssertEqual(r?.samples, 3)
+    }
+
+    /// The whole point of "ceiling@100": a sample above 100 counts as 100, not itself — so a night with a
+    /// real overshoot doesn't drag the mean above the physical ceiling the way the raw wire mean does
+    /// (OURA_PROTOCOL.md §6.5.0.1's documented positive bias).
+    func testSamplesAboveOneHundredAreCeilingedBeforeAveraging() {
+        let r = AnalyticsEngine.nightlySpo2CeilingMean(
+            [session(1000, 600)], spo2: [spo2(1100, 104), spo2(1200, 100)])
+        XCTAssertEqual(r?.mean, 100, "both readings ceiling to 100, not (104+100)/2=102")
+    }
+
+    /// Mis-scaled `dc_raw`/perfusion-channel contamination (-1016 … 11,709,098, OURA_PROTOCOL.md §6.5.0.1)
+    /// must not drag the mean down — the ceiling alone only guards the TOP of the range, so the floor gate
+    /// is load-bearing here, unlike the WHOOP @82 path (whose decoder already only ever emits 70...100).
+    func testContaminatedOutOfRangeSamplesAreExcluded() {
+        let r = AnalyticsEngine.nightlySpo2CeilingMean(
+            [session(1000, 600)],
+            spo2: [spo2(1100, 96), spo2(1150, -1016), spo2(1200, 11_709_098), spo2(1300, 98)])
+        XCTAssertEqual(r?.mean, 97, "only the two plausible readings may count")
+        XCTAssertEqual(r?.samples, 2)
+    }
+
+    func testDaytimeSamplesOutsideTheSessionAreExcluded() {
+        let r = AnalyticsEngine.nightlySpo2CeilingMean(
+            [session(1000, 600)], spo2: [spo2(500, 99), spo2(1100, 94), spo2(5000, 88)])
+        XCTAssertEqual(r?.samples, 1)
+        XCTAssertEqual(r?.mean, 94)
+    }
+
+    func testNilWhenNothingPlausibleFallsInsideASession() {
+        XCTAssertNil(AnalyticsEngine.nightlySpo2CeilingMean([session(1000, 600)], spo2: [spo2(1100, -1016)]))
+        XCTAssertNil(AnalyticsEngine.nightlySpo2CeilingMean([session(1000, 600)], spo2: [spo2(9999, 95)]))
+        XCTAssertNil(AnalyticsEngine.nightlySpo2CeilingMean([], spo2: [spo2(1100, 95)]))
+        XCTAssertNil(AnalyticsEngine.nightlySpo2CeilingMean([session(1000, 600)], spo2: []))
+    }
+
+    /// The plausibility floor/ceiling are inclusive, matching `spo2SingleChannelPlausible` (50...110)
+    /// exactly — the same bounds `Repository.spo2SingleChannelPlausible` derives from this constant.
+    func testPlausibleRangeBoundariesAreInclusive() {
+        XCTAssertEqual(AnalyticsEngine.nightlySpo2CeilingMean(
+            [session(1000, 600)], spo2: [spo2(1100, 50), spo2(1200, 110)])?.samples, 2)
+        XCTAssertNil(AnalyticsEngine.nightlySpo2CeilingMean(
+            [session(1000, 600)], spo2: [spo2(1100, 49)]))
+        XCTAssertNil(AnalyticsEngine.nightlySpo2CeilingMean(
+            [session(1000, 600)], spo2: [spo2(1100, 111)]))
+    }
+}

--- a/Strand/BLE/PuffinExperiment.swift
+++ b/Strand/BLE/PuffinExperiment.swift
@@ -53,16 +53,24 @@ enum PuffinExperiment {
 
     static var ecgRawDataEnabled: Bool { UserDefaults.standard.bool(forKey: ecgRawDataKey) }
 
-    /// Opt-in "SpO₂ strap estimate" display (#103): surfaces the WHOOP 5/MG `spo2_candidate_82` nightly
-    /// mean in the Blood Oxygen tile/card, labelled "strap estimate (unverified)". The @82 byte is a
-    /// strap-computed SpO₂ % (70–100 range) that an 8-night independent validation tracked at corr +0.99
-    /// against the WHOOP app, but two nights on the original #103 device moved OPPOSITE — device/firmware
-    /// variance unresolved. Per the derived-biosignal rule (CLAUDE.md), an unvalidated signal ships behind
-    /// a default-off toggle, never as the default `spo2Pct` and never feeding a downstream gate.
+    /// Opt-in "SpO₂ strap estimate" display (#103, extended to Oura by queue 11a): surfaces a nightly
+    /// candidate SpO₂ mean in the Blood Oxygen tile/card, labelled "strap estimate (unverified)". The
+    /// transform is device-conditional (`IntelligenceEngine`):
+    ///  - **WHOOP 5/MG**: the `spo2_candidate_82` V18Aux byte (70–100 range). An 8-night independent
+    ///    validation tracked it at corr +0.99 against the WHOOP app, but two nights on the original #103
+    ///    device moved OPPOSITE — device/firmware variance unresolved.
+    ///  - **Oura**: `min(sample, 100)` applied per-sample to the ring's own decoded `0x6F` SpO2, then
+    ///    averaged (`AnalyticsEngine.nightlySpo2CeilingMean`) — the raw wire mean has a documented
+    ///    positive bias (OURA_PROTOCOL.md §6.5.0), so ceiling@100 is queue 11a's starting transform,
+    ///    round-matching the Oura app's own displayed SpO2 on 3/3 full-tier nights measured so far
+    ///    (2026-08-22).
+    /// Neither candidate is a validated calibration. Per the derived-biosignal rule (CLAUDE.md), both ship
+    /// behind this one default-off toggle, never as the default `spo2Pct` and never feeding a downstream
+    /// gate.
     ///
-    /// Display-only: writes nothing to the strap. The engine computes `nightlySpo2CandidateMean` and
-    /// writes it to metricSeries as "spo2_candidate" under the "-noop" computed device ID; the UI reads
-    /// it only while this toggle is ON. Mirrors the Android `NoopPrefs.KEY_SPO2_CANDIDATE_DISPLAY`.
+    /// Display-only: writes nothing to the strap. The engine writes the resolved mean to metricSeries as
+    /// "spo2_candidate" under the "-noop" computed device ID; the UI reads it only while this toggle is
+    /// ON. Mirrors the Android `NoopPrefs.KEY_SPO2_CANDIDATE_DISPLAY`.
     static let spo2CandidateDisplayKey = "noopSpo2CandidateDisplay"
 
     static var spo2CandidateDisplayEnabled: Bool { UserDefaults.standard.bool(forKey: spo2CandidateDisplayKey) }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -152,10 +152,13 @@ final class IntelligenceEngine: ObservableObject {
         /// where `rr` is in scope and replayed through `diagnosticSink` in pass 2 (which is main-actor
         /// isolated). nil when the night has no in-sleep R-R.
         let hrvDiag: String?
-        /// #103: the nightly `spo2_candidate_82` mean for this day, computed off the main actor from the
-        /// V18AuxSample stream when the SpO₂ candidate display toggle is ON. nil when the toggle is OFF,
-        /// the night has no in-band @82 readings, or the owner is a WHOOP 4.0 (no v18 aux stream).
-        /// Written to metricSeries as "spo2_candidate" under the "-noop" device ID in pass 2.
+        /// #103/queue-11a: the nightly SpO₂ candidate mean for this day, computed off the main actor when
+        /// the SpO₂ candidate display toggle is ON. A WHOOP owner gets the `spo2_candidate_82` V18Aux
+        /// byte mean (unchanged); an Oura owner gets the ring's ceiling@100 `0x6F` mean
+        /// (`AnalyticsEngine.nightlySpo2CeilingMean`, queue 11a). nil when the toggle is OFF or the
+        /// night has no in-band reading for its owner's device. Written to metricSeries as
+        /// "spo2_candidate" under the "-noop" device ID in pass 2 — same key for both devices, since the
+        /// series is always read scoped to one device's own computed ID.
         let spo2Candidate: Int?
         /// #1118: whether this night's in-sleep R-R is OVER-COUNTED (`crossSecondOverCount` /
         /// `sameSecondOverCount`) — the WHOOP-4.0 two-optical-channel artifact that inflates R-R and
@@ -702,11 +705,12 @@ final class IntelligenceEngine: ObservableObject {
         // the 5/MG cumulative @57 series + wrap-aware deltas + dropped deltas, replayed below tagged `.steps`.
         // The trace recomputes the SAME wrap-aware sum analyzeDay already did, so the steps total is unchanged.
         let stepsTraceActive = TestCentre.active(.steps)
-        // #103: read the SpO₂ candidate display toggle ONCE here (off the detached executor, matching the
-        // other toggle reads above). When ON, each night's `spo2_candidate_82` mean is computed from the
-        // V18AuxSample stream and written to metricSeries as "spo2_candidate" under the "-noop" device ID,
-        // so the Blood Oxygen tile can surface it as a "strap estimate (unverified)" fallback. Default OFF
-        // per the derived-biosignal rule (CLAUDE.md) — the @82 candidate has split cross-device evidence.
+        // #103/queue-11a: read the SpO₂ candidate display toggle ONCE here (off the detached executor,
+        // matching the other toggle reads above). When ON, each night's candidate mean (WHOOP:
+        // `spo2_candidate_82`; Oura: ceiling@100 `0x6F`, see the per-day block below) is written to
+        // metricSeries as "spo2_candidate" under the "-noop" device ID, so the Blood Oxygen tile can
+        // surface it as a "strap estimate (unverified)" fallback. Default OFF per the derived-biosignal
+        // rule (CLAUDE.md) — neither candidate is a validated calibration.
         let spo2CandidateDisplayOn = PuffinExperiment.spo2CandidateDisplayEnabled
         // #1545: the Effort TRIMP recipe, read ONCE per pass. Global (same for every day), so it folds
         // into the config signature below rather than the per-day key.
@@ -1285,19 +1289,31 @@ final class IntelligenceEngine: ObservableObject {
                 // #1331 respiratory diagnostic — a run of nil nights localises when it stopped. Same
                 // pure-compute-here / replay-on-main-actor path as rhrLine.
                 let respLine: String? = Self.respRateLogLine(day: res.daily.day, respRateBpm: res.daily.respRateBpm)
-                // #103: SpO₂ candidate @82 nightly mean. Only computed when the display toggle is ON.
-                // Reads the V18AuxSample stream for this night's owner and averages the in-band (70–100)
-                // @82 readings that fall inside a detected sleep session. nil on a WHOOP 4.0 (no v18 aux
-                // stream), a night with no in-band readings, or when the toggle is OFF. The mean is
-                // written to metricSeries as "spo2_candidate" in pass 2, never to `spo2Pct` — the guard
-                // test `testHistoricalV18OpticalFieldsAreNotNamedPhysiologically` enforces that boundary.
+                // #103/queue-11a: SpO₂ candidate nightly mean. Only computed when the display toggle is
+                // ON, and the transform is device-conditional (#1086-style brand lookup, matching
+                // `skinTempWornToleranceSec`'s idiom just above): a WHOOP owner averages the in-band
+                // (70–100) `spo2_candidate_82` V18Aux byte; an Oura owner averages the ring's own `0x6F`
+                // SpO2 (`spo2`, already fetched above for `nightlySpo2RawMeans`) through the ceiling@100
+                // transform — see `AnalyticsEngine.nightlySpo2CeilingMean`'s doc for why ceiling@100 is
+                // queue 11a's starting choice. nil on a WHOOP 4.0 (no v18 aux stream) with no candidate
+                // decode, an Oura night with no in-window plausible sample, or when the toggle is OFF.
+                // The mean is written to metricSeries as "spo2_candidate" in pass 2, never to `spo2Pct` —
+                // the guard test `testHistoricalV18OpticalFieldsAreNotNamedPhysiologically` enforces that
+                // boundary for the WHOOP path.
                 var spo2CandidateMean: Int? = nil
                 if spo2CandidateDisplayOn {
-                    let auxSamples = (try? await store.v18AuxSamples(
-                        deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
-                    if !auxSamples.isEmpty {
-                        if let cand = AnalyticsEngine.nightlySpo2CandidateMean(res.sleepSessions, aux: auxSamples) {
+                    let ownerIsOura = regDevices.first(where: { $0.id == owner })?.brand == "Oura"
+                    if ownerIsOura {
+                        if let cand = AnalyticsEngine.nightlySpo2CeilingMean(res.sleepSessions, spo2: spo2) {
                             spo2CandidateMean = cand.mean
+                        }
+                    } else {
+                        let auxSamples = (try? await store.v18AuxSamples(
+                            deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
+                        if !auxSamples.isEmpty {
+                            if let cand = AnalyticsEngine.nightlySpo2CandidateMean(res.sleepSessions, aux: auxSamples) {
+                                spo2CandidateMean = cand.mean
+                            }
                         }
                     }
                 }

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1614,14 +1614,24 @@ final class Repository: ObservableObject {
         return min(600, max(120, span / 30))
     }
 
-    /// The plausible range for a SINGLE-CHANNEL SpO2 reading plotted as a percentage. Deliberately wider
-    /// than clinical SpO2, and NOT a cosmetic clamp — the ring's channel is uncalibrated, so readings
-    /// genuinely overshoot 100. On the reporting device's 5,562 in-range rows the split is 3,179 at
-    /// 90–100, **1,948 at 101–110**, 142 at 80–89 and 293 at 50–79: the >100 band is a sixth of the data
-    /// and tracks the rest of the series, so it is real overshoot, not error, and clamping at 100 would
-    /// silently flatten it. The bounds only need to exclude the mis-scaled `dc_raw` magnitudes (-1016 …
-    /// 11,709,098), which they do by three orders of magnitude.
-    nonisolated static let spo2SingleChannelPlausible = 50.0...110.0
+    /// The plausible range for a SINGLE-CHANNEL SpO2 reading plotted as a percentage. Its ONLY job is to
+    /// exclude the mis-scaled `dc_raw` magnitudes (-1016 … 11,709,098), which it does by three orders of
+    /// magnitude. It is deliberately NOT a clamp to 100.
+    ///
+    /// ⚠️ WHY THE UPPER BOUND IS 110, AND WHY THAT IS A KNOWN OPEN QUESTION, NOT A JUSTIFIED CHOICE: on a
+    /// real Gen 3 capture the `0x6F` channel spans 81–106 and **47 % of its 22,516 samples read above
+    /// 100** (peak at 103–104). Those are genuinely `0x6F` — the sidecar's `unit` tag proves it, and only
+    /// 208 `dc_raw` rows land in that band — so they are not contamination. But real SpO2 CANNOT exceed
+    /// 100 %, and open_oura's own pipeline clamps its computed SpO2 to [85, 100]
+    /// (`docs/spo2-calibration.md`, tag `0x8b` path). So a smooth distribution peaking at 103–104 points
+    /// at an un-modelled offset/transform in NOOP's `0x6F` decode, NOT at real overshoot. Clamping here
+    /// would HIDE that discrepancy behind a flat line at 100; keeping the bound at 110 leaves it visible
+    /// while still excluding the mis-scaled channel. Revisit once the `0x6F` scale is pinned — see
+    /// OURA_PROTOCOL.md §6.5.
+    ///
+    /// Derived from `AnalyticsEngine.spo2SingleChannelPlausible` (the canonical bounds, queue 11a)
+    /// rather than redefining them — same 50...110 range, kept in one place.
+    nonisolated static let spo2SingleChannelPlausible = Double(AnalyticsEngine.spo2SingleChannelPlausible.lowerBound)...Double(AnalyticsEngine.spo2SingleChannelPlausible.upperBound)
 
     /// One SpO2 sample → the value the Deep Timeline plots, or nil to skip the sample.
     ///

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1614,6 +1614,43 @@ final class Repository: ObservableObject {
         return min(600, max(120, span / 30))
     }
 
+    /// The plausible range for a SINGLE-CHANNEL SpO2 reading plotted as a percentage. Deliberately wider
+    /// than clinical SpO2, and NOT a cosmetic clamp — the ring's channel is uncalibrated, so readings
+    /// genuinely overshoot 100. On the reporting device's 5,562 in-range rows the split is 3,179 at
+    /// 90–100, **1,948 at 101–110**, 142 at 80–89 and 293 at 50–79: the >100 band is a sixth of the data
+    /// and tracks the rest of the series, so it is real overshoot, not error, and clamping at 100 would
+    /// silently flatten it. The bounds only need to exclude the mis-scaled `dc_raw` magnitudes (-1016 …
+    /// 11,709,098), which they do by three orders of magnitude.
+    nonisolated static let spo2SingleChannelPlausible = 50.0...110.0
+
+    /// One SpO2 sample → the value the Deep Timeline plots, or nil to skip the sample.
+    ///
+    /// TWO SOURCE SHAPES share this one table and metric:
+    /// - **Two-channel (WHOOP 4.0 v24)**: red AND IR optical ADCs. There is no calibrated % (#166), so the
+    ///   honest proxy is the unitless `red / ir` ratio — unchanged behaviour.
+    /// - **Single-channel (Oura ring)**: the ring reports ONE SpO2 channel, so `OuraStreamMapping` stores it
+    ///   in `red` and leaves `ir = 0` — an unread channel, never a fabricated second reading. The old code
+    ///   computed the ratio and dropped every `ir <= 0` row, which silently discarded **100 %** of an Oura
+    ///   ring's SpO2 (18,688 rows on the reporting device) and drew an empty chart with no explanation
+    ///   (the #623 "unsupported strap" notice only fires for the 5.0 family, so a ring got no notice either).
+    ///   For these the reading itself is the value: a real overnight capture (2026-08-01) shows the ring's
+    ///   `raw` channel clustering at 95–105, i.e. already a genuine %SpO2, not an ADC needing calibration.
+    ///
+    /// RANGE GATE, single-channel only: the `unit` tag that distinguishes the ring's true-percentage `raw`
+    /// channel from its wildly different-scale `dc_raw` perfusion channel is NOT persisted (`spo2Sample`
+    /// stores only red/ir), so rows banked before that split was fixed are indistinguishable except by
+    /// magnitude — the reporting device holds values from -1016 to 11,709,098 alongside real ones. Gating
+    /// to `spo2SingleChannelPlausible` keeps every genuine reading and drops the mis-scaled ones, so one
+    /// legacy outlier cannot flatten the whole chart's y-axis. This is a DISPLAY gate on a metric that is
+    /// never scored; it changes no stored row, and the same idiom already guards temp (20–45 °C) and HR
+    /// (0–300 bpm) at their decoders. The two-channel ratio path is deliberately NOT gated (a ratio has no
+    /// comparable physiological range), so WHOOP output is byte-identical.
+    nonisolated static func spo2TimelineValue(red: Int, ir: Int) -> Double? {
+        guard ir <= 0 else { return Double(red) / Double(ir) }   // two-channel: unchanged ratio proxy
+        let v = Double(red)
+        return spo2SingleChannelPlausible.contains(v) ? v : nil
+    }
+
     /// Deep-Timeline read facade. Returns ~`targetPoints` points for `metric` over `[from, to]` from
     /// `source` (defaults to the user's own strap), choosing raw seconds vs coarse buckets adaptively so
     /// the chart never draws ~86k points (the #575 day-scale risk). HR rides the existing COALESCE reads
@@ -1753,11 +1790,14 @@ final class Repository: ObservableObject {
                     .map { Self.timelinePoint($0.ts, $0.rmssd) }
             }.value
         case .spo2:
-            // The honest raw red/IR ratio proxy (#166: no calibrated %), shown as a unitless trend.
+            // Two-channel (WHOOP) → the honest raw red/IR ratio proxy; single-channel (Oura) → the reading
+            // itself. See `spo2TimelineValue(red:ir:)` for why, and for the range gate.
             let s = (try? await store.spo2Samples(deviceId: source, from: from, to: to, limit: 200_000)) ?? []
             // The up-to-200k-row conversion runs OFF the main actor; only the Sendable `s` rows cross in.
             return await Task.detached(priority: .utility) {
-                s.compactMap { $0.ir > 0 ? Self.timelinePoint($0.ts, Double($0.red) / Double($0.ir)) : nil }
+                s.compactMap { row in
+                    Self.spo2TimelineValue(red: row.red, ir: row.ir).map { Self.timelinePoint(row.ts, $0) }
+                }
             }.value
         case .skinTemp:
             let s = (try? await store.skinTempSamples(deviceId: source, from: from, to: to, limit: 200_000)) ?? []

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -53,6 +53,12 @@ struct LiquidTodayView: View {
     @State private var fitnessAge: Double?         // exploreSeries("fitness_age").last
     @State private var vo2max: Double?             // exploreSeries("vo2max_est").last (#1391)
     @State private var vitality: Double?           // exploreSeries("vitality").last
+    // Queue 11a: day-keyed "spo2_candidate" metricSeries (WHOOP `spo2_candidate_82` or Oura
+    // ceiling@100 `0x6F`, device-conditional — see `IntelligenceEngine`). Empty when the
+    // experimental toggle is OFF (the engine writes nothing) or the owner has no in-band reading.
+    // Read unconditionally like the classic TodayView's `spo2CandidateSpark` — always empty when
+    // the toggle is off, so no separate gate is needed at fetch time.
+    @State private var spo2CandidateByDay: [String: Double] = [:]
     @State private var stepsEst: Double?           // steps_est, day-keyed to the selected day (fallback)
     @State private var importedStepsDay: Int?      // Apple Health steps for the selected day (middle tier)
     @State private var importedActiveKcalDay: Double?  // #616: Apple Health active energy for the day (calorie fallback)
@@ -1146,8 +1152,20 @@ struct LiquidTodayView: View {
         case .restingHr:
             ktile(String(localized: "Rest HR"), icon: keyMetricIcon(metric), intText(rhr), "bpm", StrandPalette.metricRose, fracOver(rhr, 100), key: "rhr")
         case .bloodOxygen:
-            let spo2 = displayDay?.spo2Pct ?? vitalsDay?.spo2Pct
-            ktile(String(localized: "Blood Oxygen"), icon: keyMetricIcon(metric), intText(spo2), "%", StrandPalette.metricCyan, fracOver(spo2, 100), key: "spo2")
+            // Queue 11a: the Liquid tile used to read `spo2Pct` only, with no candidate fallback at all
+            // (unlike the classic `TodayView`/`VitalSignsSummary`), so an Oura-only or BLE-only WHOOP
+            // 5/MG install with the experimental toggle ON still saw a bare "—" here. Falls back to the
+            // device-conditional "spo2_candidate" mean (WHOOP: `spo2_candidate_82`; Oura: ceiling@100
+            // `0x6F`, see `AnalyticsEngine.nightlySpo2CeilingMean`) only when `spo2Pct` is nil AND the
+            // toggle is ON — same gating as the classic tile, never as the default.
+            let spo2Real = displayDay?.spo2Pct ?? vitalsDay?.spo2Pct
+            let spo2CandidateOn = PuffinExperiment.spo2CandidateDisplayEnabled
+            let spo2CandidateValue = spo2Real == nil && spo2CandidateOn
+                ? spo2CandidateByDay[cachedDisplayDay?.day ?? selectedDayKey]
+                : nil
+            let spo2 = spo2Real ?? spo2CandidateValue
+            ktile(String(localized: "Blood Oxygen"), icon: keyMetricIcon(metric), intText(spo2), "%", StrandPalette.metricCyan, fracOver(spo2, 100), key: spo2CandidateValue != nil ? "spo2_candidate" : "spo2",
+                  caption: spo2CandidateValue != nil ? String(localized: "strap estimate (unverified)") : nil)
         case .respiratory:
             let resp = displayDay?.respRateBpm ?? vitalsDay?.respRateBpm ?? respDay?.respRateBpm
             ktile(String(localized: "Respiratory"), icon: keyMetricIcon(metric), resp.map { String(format: "%.1f", locale: AppLanguage.activeLocale, $0) } ?? "—", "rpm", StrandPalette.accent, fracOver(resp, 24), key: "resp_rate")
@@ -1180,7 +1198,7 @@ struct LiquidTodayView: View {
     }
 
     private func ktile(_ label: String, icon: String, _ value: String, _ unit: String, _ tint: Color, _ frac: Double?,
-                       key: String? = nil, detailMetric: MetricDescriptor? = nil) -> some View {
+                       key: String? = nil, detailMetric: MetricDescriptor? = nil, caption: String? = nil) -> some View {
         let displayValue = unit.isEmpty ? value : (unit == "%" ? value + unit : value + " " + unit)
         let tile = VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 6) {
@@ -1200,6 +1218,16 @@ struct LiquidTodayView: View {
                 .foregroundStyle(StrandPalette.textPrimary)
                 .lineLimit(1)
                 .minimumScaleFactor(0.75)
+            // Optional sub-value caveat (queue 11a): only ever set for an unvalidated candidate fallback
+            // (e.g. the SpO₂ strap estimate), so every other `ktile` call site — no `caption` argument —
+            // renders byte-identical to before this parameter existed.
+            if let caption {
+                Text(caption)
+                    .font(StrandFont.footnote)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
             LiquidTube(frac: frac ?? 0, tint: tint, height: 9, animated: false,
                        showsHighlight: false, usesCleanFill: true)
             // #430 parity: DETAILED tiles grow the trend graph under the bar, tinted to the metric and
@@ -1378,6 +1406,8 @@ struct LiquidTodayView: View {
         async let vo2A = repo.exploreSeries(key: "vo2max_est", source: "my-whoop")
         async let vitA = repo.exploreSeries(key: "vitality", source: "my-whoop")
         async let stepsA = repo.exploreSeries(key: "steps_est", source: "my-whoop")
+        // Queue 11a: SpO₂ candidate fallback (see `spo2CandidateByDay`'s declaration).
+        async let spo2CandA = repo.exploreSeries(key: "spo2_candidate", source: "my-whoop")
         async let appleA = repo.appleDailyRows()
         async let hrA = repo.hrBuckets(from: from, to: to, bucketSeconds: 300)
         async let wkA = repo.workoutRows()
@@ -1423,6 +1453,10 @@ struct LiquidTodayView: View {
         // matching the imported-first VALUE. Union of imported days + strap-row days. Mirrors Android's
         // caloriesSpark (windowed caloriesByDay).
         let appleRowsForSpark = await appleA
+        // Queue 11a: SpO₂ candidate fallback — day-keyed for the tile's value lookup, windowed for its
+        // detailed-mode sparkline below (same shape as `restByDay`/`kSparks["spo2"]` above).
+        let spo2CandSeries = await spo2CandA
+        spo2CandidateByDay = Dictionary(spo2CandSeries.map { ($0.day, $0.value) }, uniquingKeysWith: { _, last in last })
         var winImportedKcal: [String: Double] = [:]
         for r in appleRowsForSpark where r.day >= sparkCutoff && r.day <= selectedDayKey {
             if let k = r.activeKcal { winImportedKcal[r.day] = max(winImportedKcal[r.day] ?? 0, k) }
@@ -1437,6 +1471,7 @@ struct LiquidTodayView: View {
             "hrv": sparkRows.compactMap { r in r.avgHrv.map { (r.day, $0) } },
             "rhr": sparkRows.compactMap { r in r.restingHr.map { (r.day, Double($0)) } },
             "spo2": sparkRows.compactMap { r in r.spo2Pct.map { (r.day, $0) } },
+            "spo2_candidate": spo2CandSeries.filter { $0.day >= sparkCutoff && $0.day <= selectedDayKey },
             "resp_rate": sparkRows.compactMap { r in r.respRateBpm.map { (r.day, $0) } },
             "steps": sparkRows.compactMap { r in r.steps.map { (r.day, Double($0)) } },
             // #616: the Calories tile drew no trend line — this dict had no matching entry, so windowedSpark

--- a/Strand/Screens/HealthView.swift
+++ b/Strand/Screens/HealthView.swift
@@ -1219,8 +1219,9 @@ private struct VitalsSection: View {
         return UnitPrefs.resolveTemperature(system: system, override: temperatureRaw)
     }
 
-    // #103: SpO₂ candidate @82 nightly means from metricSeries, loaded when the experimental toggle is ON.
-    // Empty when the toggle is OFF or no candidate data exists (WHOOP 4.0 has no v18 aux stream).
+    // #103/queue-11a: SpO₂ candidate nightly means from metricSeries — WHOOP `spo2_candidate_82`, or an
+    // Oura owner's ceiling@100 `0x6F` mean (device-conditional, see IntelligenceEngine) — loaded when
+    // the experimental toggle is ON. Empty when the toggle is OFF or no candidate data exists.
     @State private var spo2CandidateByDay: [String: Double] = [:]
     @State private var hrvOverCountByDay: [String: Double] = [:]   // #1118
 
@@ -1260,10 +1261,12 @@ private struct VitalsSection: View {
             // from the computed metricSeries. Absent/0 on a clean or imported night → no caveat.
             let ocPts = await repo.exploreSeries(key: "hrv_rr_overcount", source: "my-whoop", days: 14)
             hrvOverCountByDay = Dictionary(ocPts.map { ($0.day, $0.value) }, uniquingKeysWith: { a, _ in a })
-            // #103: load the SpO₂ candidate @82 nightly means from metricSeries when the toggle is ON.
-            // The engine writes "spo2_candidate" under the "-noop" computed device ID; `exploreSeries`
-            // with source "my-whoop" reads it from Layer 2 (computed metricSeries). Empty when the toggle
-            // is OFF (the engine writes nothing) or on a WHOOP 4.0 (no v18 aux stream).
+            // #103/queue-11a: load the SpO₂ candidate nightly means from metricSeries when the toggle is
+            // ON. The engine writes "spo2_candidate" under the "-noop" computed device ID; `exploreSeries`
+            // with source "my-whoop" reads it from Layer 2 (computed metricSeries) — "my-whoop" is the
+            // generic active-strap sentinel, resolved through `computedReadIds`, so this already covers
+            // an Oura ring's own computed id. Empty when the toggle is OFF (the engine writes nothing) or
+            // the owner has no in-band reading for its device.
             guard PuffinExperiment.spo2CandidateDisplayEnabled else {
                 spo2CandidateByDay = [:]
                 return

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -2009,24 +2009,25 @@ struct SettingsView: View {
                     .accessibilityElement(children: .combine)
                 }
 
-                // MARK: #103 SpO₂ strap estimate display — surface the @82 candidate as a fallback.
+                // MARK: #103/queue-11a SpO₂ strap estimate display — surface a device-conditional
+                //       candidate mean as a fallback (WHOOP: @82; Oura: ceiling@100 0x6F).
                 Divider().overlay(StrandPalette.hairline)
 
                 Toggle(isOn: $spo2CandidateDisplayEnabled) {
-                    Text("Blood Oxygen: strap estimate (WHOOP 5/MG)")
+                    Text("Blood Oxygen: strap estimate (WHOOP 5/MG, Oura)")
                         .font(StrandFont.subhead)
                         .foregroundStyle(StrandPalette.textPrimary)
                 }
                 .toggleStyle(.switch)
                 .tint(StrandPalette.accent)
                 .onChangeCompat(of: spo2CandidateDisplayEnabled) { _ in
-                    // Re-score immediately so the @82 candidate is computed and persisted on this
+                    // Re-score immediately so the candidate is computed and persisted on this
                     // toggle flip — without this the user waits up to 15 min for the next analyze
                     // loop, and the Blood Oxygen tile stays blank in the meantime. Same pattern as
                     // the HRV window toggle above (analyzeRecent → refresh).
                     Task { await model.intelligence.analyzeRecent(); await model.repo.refresh() }
                 }
-                Text("Your WHOOP 5.0/MG sends a strap-computed SpO₂ percentage (the @82 candidate byte) every second. An 8-night independent validation tracked it at corr +0.99 against the WHOOP app, but two nights on the original test device moved the OPPOSITE direction — device/firmware variance is unresolved. Turning this on surfaces the nightly mean in the Blood Oxygen tile as \"strap estimate (unverified)\" when no calibrated import exists. It never feeds recovery or illness scoring. WHOOP 4.0 has no @82 stream, so this does nothing there.")
+                Text("Your WHOOP 5.0/MG sends a strap-computed SpO₂ percentage (the @82 candidate byte) every second — an 8-night independent validation tracked it at corr +0.99 against the WHOOP app, but two nights on the original test device moved the OPPOSITE direction, so device/firmware variance is unresolved. An Oura ring's own SpO₂ reading runs high on the wire (over 100% on a fifth to a half of samples on a clean night); this instead surfaces the ring's mean with each sample capped at 100% first, which has matched the Oura app's own displayed value on every full night checked against it so far, though only a few nights. Turning this on surfaces whichever applies to your device as \"strap estimate (unverified)\" in the Blood Oxygen tile when no calibrated import exists. It never feeds recovery or illness scoring. WHOOP 4.0 has no @82 stream, so this does nothing there.")
                     .font(StrandFont.caption)
                     .foregroundStyle(StrandPalette.textTertiary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -1709,11 +1709,13 @@ struct SettingsView: View {
 
     /// Entry point used by `body`. The 5/MG probe card only renders for a 5/MG (see `showFiveMGControls`,
     /// #22); the raw-sensor CSV diagnostic is split into its own card so it stays available on every
-    /// model — a 4.0 owner still needs the export to share decoded streams.
+    /// model — a 4.0 owner still needs the export to share decoded streams. The SpO2 candidate card is
+    /// split out the same way (see `spo2CandidateCard`'s comment) — it is NOT WHOOP-5/MG-specific.
     @ViewBuilder private var experimentalCard: some View {
         liquidTodayCard
         liveSessionsCard
         if showFiveMGControls { fiveMGCard }
+        if showFiveMGControls || model.repo.activeDeviceIsOura { spo2CandidateCard }
         sleepStagingCard
         rawSensorDiagnosticsCard
     }
@@ -2009,29 +2011,6 @@ struct SettingsView: View {
                     .accessibilityElement(children: .combine)
                 }
 
-                // MARK: #103/queue-11a SpO₂ strap estimate display — surface a device-conditional
-                //       candidate mean as a fallback (WHOOP: @82; Oura: ceiling@100 0x6F).
-                Divider().overlay(StrandPalette.hairline)
-
-                Toggle(isOn: $spo2CandidateDisplayEnabled) {
-                    Text("Blood Oxygen: strap estimate (WHOOP 5/MG, Oura)")
-                        .font(StrandFont.subhead)
-                        .foregroundStyle(StrandPalette.textPrimary)
-                }
-                .toggleStyle(.switch)
-                .tint(StrandPalette.accent)
-                .onChangeCompat(of: spo2CandidateDisplayEnabled) { _ in
-                    // Re-score immediately so the candidate is computed and persisted on this
-                    // toggle flip — without this the user waits up to 15 min for the next analyze
-                    // loop, and the Blood Oxygen tile stays blank in the meantime. Same pattern as
-                    // the HRV window toggle above (analyzeRecent → refresh).
-                    Task { await model.intelligence.analyzeRecent(); await model.repo.refresh() }
-                }
-                Text("Your WHOOP 5.0/MG sends a strap-computed SpO₂ percentage (the @82 candidate byte) every second — an 8-night independent validation tracked it at corr +0.99 against the WHOOP app, but two nights on the original test device moved the OPPOSITE direction, so device/firmware variance is unresolved. An Oura ring's own SpO₂ reading runs high on the wire (over 100% on a fifth to a half of samples on a clean night); this instead surfaces the ring's mean with each sample capped at 100% first, which has matched the Oura app's own displayed value on every full night checked against it so far, though only a few nights. Turning this on surfaces whichever applies to your device as \"strap estimate (unverified)\" in the Blood Oxygen tile when no calibrated import exists. It never feeds recovery or illness scoring. WHOOP 4.0 has no @82 stream, so this does nothing there.")
-                    .font(StrandFont.caption)
-                    .foregroundStyle(StrandPalette.textTertiary)
-                    .fixedSize(horizontal: false, vertical: true)
-
                 // MARK: #463 Personal daytime-stress baseline — score today's timeline vs a personal
                 //       cross-day baseline instead of the day's own calm hours. Off by default.
                 Divider().overlay(StrandPalette.hairline)
@@ -2213,6 +2192,43 @@ struct SettingsView: View {
                         .foregroundStyle(StrandPalette.textTertiary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
+            }
+        }
+    }
+
+    /// SpO2 candidate display (#103/queue-11a) — split out of `fiveMGCard` (2026-08-23): the toggle's
+    /// own copy has covered Oura since `89c8533b` ("Blood Oxygen: strap estimate (WHOOP 5/MG, Oura)"),
+    /// but it stayed nested inside the WHOOP-5/MG-only card, gated by `showFiveMGControls` — so an
+    /// Oura-only install (no WHOOP 5/MG ever connected) could never reach it. `metricSeries` confirmed
+    /// zero `spo2_candidate` rows ever written on such an install despite pass-2 scoring running daily,
+    /// and a full screenshot sweep of Settings confirmed the section never renders. Same split as
+    /// `rawSensorDiagnosticsCard` just below (#22) — this card shows for a 5/MG OR an active Oura
+    /// device, not just a 5/MG.
+    private var spo2CandidateCard: some View {
+        SettingsSection(
+            icon: "lungs.fill",
+            title: "Experimental · Blood Oxygen",
+            blurb: "Surfaces a device-conditional, unverified SpO₂ estimate in the Blood Oxygen tile when no calibrated reading exists."
+        ) {
+            VStack(alignment: .leading, spacing: NoopMetrics.rowSpacing) {
+                Toggle(isOn: $spo2CandidateDisplayEnabled) {
+                    Text("Blood Oxygen: strap estimate (WHOOP 5/MG, Oura)")
+                        .font(StrandFont.subhead)
+                        .foregroundStyle(StrandPalette.textPrimary)
+                }
+                .toggleStyle(.switch)
+                .tint(StrandPalette.accent)
+                .onChangeCompat(of: spo2CandidateDisplayEnabled) { _ in
+                    // Re-score immediately so the candidate is computed and persisted on this
+                    // toggle flip — without this the user waits up to 15 min for the next analyze
+                    // loop, and the Blood Oxygen tile stays blank in the meantime. Same pattern as
+                    // the HRV window toggle above (analyzeRecent → refresh).
+                    Task { await model.intelligence.analyzeRecent(); await model.repo.refresh() }
+                }
+                Text("Your WHOOP 5.0/MG sends a strap-computed SpO₂ percentage (the @82 candidate byte) every second — an 8-night independent validation tracked it at corr +0.99 against the WHOOP app, but two nights on the original test device moved the OPPOSITE direction, so device/firmware variance is unresolved. An Oura ring's own SpO₂ reading runs high on the wire (over 100% on a fifth to a half of samples on a clean night); this instead surfaces the ring's mean with each sample capped at 100% first, which has matched the Oura app's own displayed value on every full night checked against it so far, though only a few nights. Turning this on surfaces whichever applies to your device as \"strap estimate (unverified)\" in the Blood Oxygen tile when no calibrated import exists. It never feeds recovery or illness scoring. WHOOP 4.0 has no @82 stream, so this does nothing there.")
+                    .font(StrandFont.caption)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -2546,8 +2546,10 @@ struct TodayView: View {
             // PER-FIELD carry: today → whole-row vitals carry → the last row that actually HAS a reading
             // (computed "-noop" rows write spo2Pct = nil), so this card agrees with the Key Metrics tile
             // (`d?.spo2Pct ?? carriedVital(perField: lastSpo2Day)`). Mirrors the Android dashboardCardValue.
-            // #103: when no calibrated spo2Pct exists AND the experimental toggle is ON, fall back to the
-            // spo2_candidate @82 sparkline tail (strap estimate, unverified) so the card shows a number.
+            // #103/queue-11a: when no calibrated spo2Pct exists AND the experimental toggle is ON, fall
+            // back to the spo2_candidate sparkline tail (WHOOP `spo2_candidate_82` or Oura ceiling@100
+            // `0x6F`, device-conditional — see IntelligenceEngine) so the card shows a strap-estimate
+            // (unverified) number instead of "—".
             let calibrated = (d?.spo2Pct ?? lastVitalsDay?.spo2Pct ?? lastSpo2Day?.spo2Pct)
             if let v = calibrated { return String(format: "%.0f%%", locale: AppLanguage.activeLocale, v) }
             if PuffinExperiment.spo2CandidateDisplayEnabled, let tail = sparks["spo2_candidate"]?.last {
@@ -3675,15 +3677,19 @@ struct TodayView: View {
             let spo2 = carriedVital(unit: "SpO₂", today: d?.spo2Pct,
                                     prior: { $0.spo2Pct }, perField: lastSpo2Day,
                                     format: { String(format: "%.0f%%", locale: AppLanguage.activeLocale, $0) })
-            // #103: SpO₂ candidate @82 fallback. When spo2Pct is nil (WHOOP 5/MG BLE-only, no import) AND
-            // the experimental toggle is ON, surface the strap's own @82 nightly mean as a "strap estimate
-            // (unverified)" so the tile shows a number instead of "—". The candidate has split cross-device
-            // evidence (corr +0.99 on 8 nights, but 2 nights moved opposite on the original device), so it
-            // ships behind a default-off toggle and is never written to `spo2Pct` (CLAUDE.md derived-
-            // biosignal rule). The sparkline switches to the candidate trend when the fallback is active.
-            // When the toggle is ON but NO candidate data exists (empty @82 stream, WHOOP 4.0, or the
-            // engine hasn't re-scored yet), show "toggle ON · no @82 data" so the user can tell the
-            // difference between "toggle off" and "toggle on but no data" — a silent blank reads as broken.
+            // #103/queue-11a: SpO₂ candidate fallback. When spo2Pct is nil AND the experimental toggle is
+            // ON, surface the device's own nightly candidate mean — WHOOP's `spo2_candidate_82` V18Aux
+            // byte, or an Oura ring's ceiling@100 `0x6F` mean (device-conditional, see
+            // IntelligenceEngine) — as a "strap estimate (unverified)" so the tile shows a number instead
+            // of "—". Neither candidate is a validated calibration (WHOOP: split cross-device evidence,
+            // corr +0.99 on 8 nights but 2 nights moved opposite on the original device; Oura: n=3
+            // full-tier same-night comparisons as of 2026-08-22, OURA_PROTOCOL.md §6.5.0), so both ship
+            // behind this one default-off toggle and neither is ever written to `spo2Pct` (CLAUDE.md
+            // derived-biosignal rule). The sparkline switches to the candidate trend when the fallback is
+            // active. When the toggle is ON but NO candidate data exists (no in-band reading for this
+            // owner's device, or the engine hasn't re-scored yet), show "toggle ON · no estimate yet" so
+            // the user can tell "toggle off" apart from "toggle on but no data" — a silent blank reads as
+            // broken.
             let spo2CandidateOn = PuffinExperiment.spo2CandidateDisplayEnabled
             let candidateTail = spo2CandidateOn ? sparks["spo2_candidate"]?.last : nil
             let spo2Value = spo2.value == "—" && candidateTail != nil
@@ -3692,7 +3698,7 @@ struct TodayView: View {
             let spo2Caption: String = spo2.value == "—" && candidateTail != nil
                 ? String(localized: "strap estimate (unverified)")
                 : (spo2.value == "—" && spo2CandidateOn
-                   ? String(localized: "toggle ON · no @82 data")
+                   ? String(localized: "toggle ON · no estimate yet")
                    : (spo2.caption ?? ""))
             StatTile(
                 label: "Blood Oxygen",
@@ -4209,10 +4215,13 @@ struct TodayView: View {
         async let hrvSpark           = sparkValues("hrv", source: "my-whoop", window: 14)
         async let rhrSpark           = sparkValues("rhr", source: "my-whoop", window: 14)
         async let spo2Spark          = sparkValues("spo2", source: "my-whoop", window: 14)
-        // #103: SpO₂ candidate @82 nightly mean (WHOOP 5/MG only). Read via `exploreSeries` so the
-        // computed "-noop" metricSeries backs the trend. Empty when the toggle is OFF (the engine
-        // writes nothing) or on a WHOOP 4.0 (no v18 aux stream). Used as a fallback for the Blood
-        // Oxygen tile when `spo2Pct` is nil, labelled "strap estimate (unverified)".
+        // #103/queue-11a: SpO₂ candidate nightly mean — WHOOP `spo2_candidate_82`, or an Oura owner's
+        // ceiling@100 `0x6F` mean (device-conditional, see IntelligenceEngine). Read via `exploreSeries`
+        // so the computed "-noop" metricSeries backs the trend; "my-whoop" here is the generic "active
+        // strap" sentinel `exploreSeries` resolves through `computedReadIds`, not a WHOOP-only filter, so
+        // this already picks up an Oura ring's own computed id with no further change. Empty when the
+        // toggle is OFF (the engine writes nothing) or the owner has no in-band reading. Used as a
+        // fallback for the Blood Oxygen tile when `spo2Pct` is nil, labelled "strap estimate (unverified)".
         async let spo2CandidateSpark = sparkValuesExplore("spo2_candidate", source: "my-whoop", window: 14)
         // `resp_rate` via `exploreSeries` so a BLE-only WHOOP 5 user's on-device computed
         // `DailyMetric.respRateBpm` backs the trend (the engine writes the column, not a metricSeries

--- a/Strand/Screens/VitalSignsSummary.swift
+++ b/Strand/Screens/VitalSignsSummary.swift
@@ -161,10 +161,13 @@ enum BodyVitalSigns {
 
         let respPoints = points(key: "resp", \.respRateBpm)
         let spo2Points = points(key: "spo2", \.spo2Pct)
-        // #103: SpO₂ candidate @82 (WHOOP 5/MG only). When no calibrated spo2Pct exists AND the toggle is
-        // ON, the candidate mean is passed in from metricSeries as a fallback. It has split cross-device
-        // evidence and ships behind a default-off toggle, never as `spo2Pct` (CLAUDE.md derived-biosignal
-        // rule). Built into VitalPoints so the tile + sparkline + `latest()` resolve it the same way.
+        // #103/queue-11a: SpO₂ candidate — WHOOP `spo2_candidate_82`, or an Oura owner's ceiling@100
+        // `0x6F` mean (device-conditional, computed in IntelligenceEngine; this view just reads whatever
+        // landed in metricSeries). When no calibrated spo2Pct exists AND the toggle is ON, the candidate
+        // mean is passed in from metricSeries as a fallback. Neither candidate is a validated calibration
+        // and both ship behind this one default-off toggle, never as `spo2Pct` (CLAUDE.md derived-
+        // biosignal rule). Built into VitalPoints so the tile + sparkline + `latest()` resolve it the
+        // same way.
         let spo2CandidateOn = PuffinExperiment.spo2CandidateDisplayEnabled && !spo2CandidateByDay.isEmpty
         let spo2CandidatePoints: [VitalPoint] = spo2CandidateOn
             ? spo2CandidateByDay.map { (day, value) in
@@ -182,9 +185,9 @@ enum BodyVitalSigns {
         let skinPoints = points(key: "skin", \.skinTempDevC)
 
         let respRow = latest(respPoints)
-        // #103: fall back to the spo2_candidate @82 mean when no calibrated spo2Pct exists. The candidate
-        // is labelled "strap estimate (unverified)" in the tile caption so it is never read as a calibrated
-        // blood-oxygen percentage.
+        // #103/queue-11a: fall back to the spo2_candidate mean when no calibrated spo2Pct exists. The
+        // candidate is labelled "strap estimate (unverified)" in the tile caption so it is never read as
+        // a calibrated blood-oxygen percentage.
         let spo2Row = latest(spo2Points) ?? latest(spo2CandidatePoints)
         let spo2IsCandidate = spo2Row != nil && latest(spo2Points) == nil
         let spo2rawRow = latest(spo2rawPoints)
@@ -288,7 +291,7 @@ enum BodyVitalSigns {
                 missingCaption: spo2IsCandidate
                     ? String(localized: "strap estimate (unverified)")
                     : (PuffinExperiment.spo2CandidateDisplayEnabled && spo2Row == nil
-                       ? String(localized: "toggle ON · no @82 data")
+                       ? String(localized: "toggle ON · no estimate yet")
                        : (spo2rawRow != nil
                           ? String(localized: "Raw counts only — needs an import")
                           : String(localized: "No SpO₂ import or Health value"))),

--- a/StrandTests/DeepTimelineFacadeTests.swift
+++ b/StrandTests/DeepTimelineFacadeTests.swift
@@ -170,4 +170,42 @@ final class DeepTimelineFacadeTests: XCTestCase {
         XCTAssertGreaterThan(day.points.count, 0, "PPG-only day-scale read must not be empty")
         XCTAssertEqual(day.points.first?.value ?? 0, 55, accuracy: 0.001)
     }
+
+    // MARK: - SpO2: two-channel ratio vs single-channel reading
+
+    /// A WHOOP 4.0 v24 sample carries BOTH optical channels, so the plotted value stays the unitless
+    /// red/IR ratio proxy (#166 — there is no calibrated %). Unchanged behaviour; pinned so the
+    /// single-channel branch below can never silently alter it.
+    func testSpO2TwoChannelKeepsRatioProxy() {
+        XCTAssertEqual(Repository.spo2TimelineValue(red: 1000, ir: 500), 2.0)
+        XCTAssertEqual(Repository.spo2TimelineValue(red: 300, ir: 1200), 0.25)
+    }
+
+    /// An Oura ring reports ONE SpO2 channel: the value lands in `red` and `ir` stays 0 (an unread
+    /// channel, never a fabricated second reading). The old code computed a ratio and dropped every
+    /// `ir <= 0` row, discarding 100% of a ring's SpO2 and drawing an empty chart. A single-channel row
+    /// must plot its reading directly — a real capture shows the ring's channel clustering at 95–105,
+    /// i.e. already a genuine percentage.
+    func testSpO2SingleChannelPlotsTheReadingNotARatio() {
+        XCTAssertEqual(Repository.spo2TimelineValue(red: 96, ir: 0), 96)
+        XCTAssertEqual(Repository.spo2TimelineValue(red: 100, ir: 0), 100)
+        XCTAssertEqual(Repository.spo2TimelineValue(red: 81, ir: 0), 81)
+    }
+
+    /// The `unit` tag separating the ring's true-percentage channel from its different-scale perfusion
+    /// channel is NOT persisted (spo2Sample stores only red/ir), so rows banked before that split was
+    /// fixed are distinguishable only by magnitude — the reporting device holds values from -1016 to
+    /// 11,709,098 beside real ones. Those must be dropped so one legacy outlier can't flatten the y-axis.
+    func testSpO2SingleChannelDropsImplausibleLegacyRows() {
+        XCTAssertNil(Repository.spo2TimelineValue(red: 11_709_098, ir: 0))
+        XCTAssertNil(Repository.spo2TimelineValue(red: -1016, ir: 0))
+        XCTAssertNil(Repository.spo2TimelineValue(red: 0, ir: 0))
+    }
+
+    /// The gate is single-channel ONLY: a two-channel ratio has no comparable physiological range, so it
+    /// is never range-filtered. Pins that WHOOP output stays byte-identical even for extreme ratios.
+    func testSpO2RangeGateDoesNotApplyToTheTwoChannelRatio() {
+        XCTAssertEqual(Repository.spo2TimelineValue(red: 11_709_098, ir: 1), 11_709_098)
+        XCTAssertEqual(Repository.spo2TimelineValue(red: 1, ir: 1_000_000), 1e-6)
+    }
 }

--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -606,7 +606,7 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
-      "Surfaces the WHOOP 5/MG strap's nightly SpO₂ estimate (spo2_candidate_82) in the "
+      "Surfaces your strap's nightly SpO₂ estimate in the Blood Oxygen tile when no "
     ],
     [
       "android/app/src/main/java/com/noop/ui/SettingsScreen.kt",
@@ -1016,7 +1016,7 @@
     ],
     [
       "Strand/Screens/SettingsView.swift",
-      "Blood Oxygen: strap estimate (WHOOP 5/MG)"
+      "Blood Oxygen: strap estimate (WHOOP 5/MG, Oura)"
     ],
     [
       "Strand/Screens/SettingsView.swift",
@@ -1044,7 +1044,7 @@
     ],
     [
       "Strand/Screens/SettingsView.swift",
-      "Your WHOOP 5.0/MG sends a strap-computed SpO₂ percentage (the @82 candidate byte) every second. An 8-night independent validation tracked it at corr +0.99 against the WHOOP app, but two nights on the original test device moved the OPPOSITE direction — device/firmware variance is unresolved. Turning this on surfaces the nightly mean in the Blood Oxygen tile as \\\"strap estimate (unverified)\\\" when no calibrated import exists. It never feeds recovery or illness scoring. WHOOP 4.0 has no @82 stream, so this does nothing there."
+      "Your WHOOP 5.0/MG sends a strap-computed SpO₂ percentage (the @82 candidate byte) every second — an 8-night independent validation tracked it at corr +0.99 against the WHOOP app, but two nights on the original test device moved the OPPOSITE direction, so device/firmware variance is unresolved. An Oura ring's own SpO₂ reading runs high on the wire (over 100% on a fifth to a half of samples on a clean night); this instead surfaces the ring's mean with each sample capped at 100% first, which has matched the Oura app's own displayed value on every full night checked against it so far, though only a few nights. Turning this on surfaces whichever applies to your device as \\\"strap estimate (unverified)\\\" in the Blood Oxygen tile when no calibrated import exists. It never feeds recovery or illness scoring. WHOOP 4.0 has no @82 stream, so this does nothing there."
     ],
     [
       "Strand/Screens/SleepView.swift",

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -1012,6 +1012,51 @@ object AnalyticsEngine {
     }
 
     /**
+     * The plausible range for a raw Oura `0x6F` SpO2 sample before the ceiling transform below excludes
+     * the mis-scaled `dc_raw`/perfusion-channel contamination (-1016 .. 11,709,098, OURA_PROTOCOL.md
+     * §6.5.0.1) by three orders of magnitude. Same bounds as the Swift
+     * `AnalyticsEngine.spo2SingleChannelPlausible` (kept in sync manually).
+     */
+    internal val SPO2_SINGLE_CHANNEL_PLAUSIBLE = 50..110
+
+    /**
+     * Nightly **ceiling@100** mean of the Oura ring's own decoded SpO2 (`Spo2Sample.red`, `0x6F`) over
+     * the detected in-bed [sessions], paired with the sample count it rests on — or null when no
+     * plausible sample fell inside any span. Oura twin of [nightlySpo2CandidateMean] above; queue 11a's
+     * starting transform.
+     *
+     * WHY CEILING@100, NOT RAW OR THE OFFSET+CLAMP FIT. `0x6F`'s raw wire mean carries a consistent
+     * positive bias — 20-48% of samples on a contamination-clean night read above the physical 100%
+     * ceiling (OURA_PROTOCOL.md §6.5.0.1) — so the raw mean is the ONE transform that has missed the Oura
+     * app's own displayed value on every full-tier paired night measured so far (1/3 as of 2026-08-22,
+     * see §6.5.0). `min(sample, 100)` applied PER-SAMPLE before averaging (a clamp on the aggregate mean
+     * is a different, wrong number) has round-matched the app's displayed value on all 3 of those nights.
+     * Not a validated calibration (n=3, only the rounded integer) — per the derived-biosignal rule
+     * (CLAUDE.md), this ships the same way `spo2_candidate_82` ships: diagnostic-only, gated behind the
+     * display toggle, never written to `spo2Pct`, never scored.
+     *
+     * Gated to [SPO2_SINGLE_CHANNEL_PLAUSIBLE] (50..110) BEFORE the ceiling is applied, so a contaminated
+     * row (down to -1016) cannot drag the mean down — the ceiling alone only guards the top of the range.
+     * Byte-parity twin of the Swift `nightlySpo2CeilingMean`.
+     */
+    internal fun nightlySpo2CeilingMean(
+        sessions: List<DetectedSleep>,
+        spo2: List<Spo2Sample>,
+    ): Pair<Int, Int>? {
+        if (sessions.isEmpty() || spo2.isEmpty()) return null
+        var sum = 0L
+        var kept = 0
+        for (s in spo2) {
+            if (s.red !in SPO2_SINGLE_CHANNEL_PLAUSIBLE) continue
+            if (sessions.none { s.ts in it.start..it.end }) continue
+            sum += minOf(s.red, 100)
+            kept += 1
+        }
+        if (kept == 0) return null
+        return Pair((sum / kept).toInt(), kept)
+    }
+
+    /**
      * #1169 SHADOW METRIC: the primary-session MEAN resting HR — window each detected sleep session's HR
      * samples to `[start, end)` and delegate to the #1174-defined [PrimarySessionRestingHR.meanHR] (that
      * definition is UNCHANGED). IntelligenceEngine stores the result beside the shipped nightly HR FLOOR

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -188,6 +188,34 @@ object IntelligenceEngine {
     fun ownerSourceAbsentLine(importedDeviceId: String): String =
         "analyzeRecent ownerSource=absent owner->$importedDeviceId skinTempScale->whoop5"
 
+    /**
+     * The nightly SpO2 CANDIDATE for one scored day, or null when there is none.
+     *
+     * A WHOOP owner averages the in-band `spo2_candidate_82` V18Aux byte; an Oura owner averages the ring's
+     * own `0x6F` SpO2 through the ceiling@100 transform (see [AnalyticsEngine.nightlySpo2CeilingMean] for
+     * why that is queue 11a's starting choice). Null on a WHOOP 4.0 with no v18 aux stream, an Oura night
+     * with no in-window plausible sample, or when the caller's toggle is off — the caller gates that.
+     *
+     * Extracted from `analyzeRecentOnCpu` purely for bytecode headroom (#1524); behaviour is unchanged.
+     * Never written to `spo2Pct` and never scored — the caller persists it to the `spo2_candidate`
+     * metricSeries sidecar in pass 2.
+     */
+    private suspend fun spo2CandidateMean(
+        repo: WhoopRepository,
+        owner: String,
+        sessions: List<DetectedSleep>,
+        spo2: List<com.noop.data.Spo2Sample>,
+        from: Long,
+        to: Long,
+    ): Int? {
+        if (DeviceBrandCatalog.isOura(owner)) {
+            return AnalyticsEngine.nightlySpo2CeilingMean(sessions, spo2)?.first
+        }
+        val auxSamples = repo.v18AuxSamples(owner, from, to, STREAM_LIMIT)
+        if (auxSamples.isEmpty()) return null
+        return AnalyticsEngine.nightlySpo2CandidateMean(sessions, auxSamples)?.first
+    }
+
     /** #1575: one night's recorded trace lines, per channel. Immutable snapshot of [DayTraceRecorders]. */
     data class DayTraces(
         val sleep: List<String> = emptyList(),
@@ -1197,19 +1225,12 @@ object IntelligenceEngine {
             // no in-window plausible sample, or when the toggle is OFF. Persisted to metricSeries as
             // "spo2_candidate" in pass 2, never to `spo2Pct`.
             if (spo2CandidateDisplay) {
-                if (DeviceBrandCatalog.isOura(owner)) {
-                    val cand = AnalyticsEngine.nightlySpo2CeilingMean(res.sleepSessions, spo2)
-                    if (cand != null) {
-                        spo2CandidateByDay[res.daily.day] = cand.first
-                    }
-                } else {
-                    val auxSamples = repo.v18AuxSamples(owner, from, to, STREAM_LIMIT)
-                    if (auxSamples.isNotEmpty()) {
-                        val cand = AnalyticsEngine.nightlySpo2CandidateMean(res.sleepSessions, auxSamples)
-                        if (cand != null) {
-                            spo2CandidateByDay[res.daily.day] = cand.first
-                        }
-                    }
+                // Lifted into [spo2CandidateMean] rather than inlined: `analyzeRecentOnCpu` sits within ~100
+                // bytes of the JVM's 64 KB per-method ceiling, and this block plus the #1575 trace recorders
+                // put the JaCoCo-instrumented size 30 bytes OVER the budget #1524 guards. Neither change
+                // exceeded it alone — only together, which no single PR's CI could see.
+                spo2CandidateMean(repo, owner, res.sleepSessions, spo2, from, to)?.let {
+                    spo2CandidateByDay[res.daily.day] = it
                 }
             }
             // #1169 SHADOW METRIC (instrumentation only): the primary-session MEAN resting HR, recorded

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -2,6 +2,7 @@ package com.noop.analytics
 
 import java.util.Locale
 import com.noop.data.DailyMetric
+import com.noop.data.DeviceBrandCatalog
 import com.noop.data.MetricSeriesRow
 import com.noop.data.OuraRespScale
 import com.noop.data.ScoreInputProvenanceRow
@@ -1186,17 +1187,28 @@ object IntelligenceEngine {
                     .map { it.bpm }
                 dayDiag(rhrFloorMeanLogLine(day, rhrFloor, inBedBpms))
             }
-            // #103: SpO₂ candidate @82 nightly mean. Only computed when the display toggle is ON.
-            // Reads the V18AuxSample stream for this night's owner and averages the in-band (70–100)
-            // @82 readings that fall inside a detected sleep session. null on a WHOOP 4.0 (no v18 aux
-            // stream), a night with no in-band readings, or when the toggle is OFF. Persisted to
-            // metricSeries as "spo2_candidate" in pass 2, never to `spo2Pct`.
+            // #103/queue-11a: SpO₂ candidate nightly mean. Only computed when the display toggle is ON,
+            // and the transform is device-conditional (com.noop.data.DeviceBrandCatalog.isOura, same
+            // idiom OuraRespScale.isRingRateStream uses): a WHOOP owner averages the in-band (70–100)
+            // `spo2_candidate_82` V18Aux byte; an Oura owner averages the ring's own `0x6F` SpO2 (`spo2`,
+            // already fetched above for `nightlySpo2RawMeans`) through the ceiling@100 transform — see
+            // `AnalyticsEngine.nightlySpo2CeilingMean`'s doc for why ceiling@100 is queue 11a's starting
+            // choice. null on a WHOOP 4.0 (no v18 aux stream) with no candidate decode, an Oura night with
+            // no in-window plausible sample, or when the toggle is OFF. Persisted to metricSeries as
+            // "spo2_candidate" in pass 2, never to `spo2Pct`.
             if (spo2CandidateDisplay) {
-                val auxSamples = repo.v18AuxSamples(owner, from, to, STREAM_LIMIT)
-                if (auxSamples.isNotEmpty()) {
-                    val cand = AnalyticsEngine.nightlySpo2CandidateMean(res.sleepSessions, auxSamples)
+                if (DeviceBrandCatalog.isOura(owner)) {
+                    val cand = AnalyticsEngine.nightlySpo2CeilingMean(res.sleepSessions, spo2)
                     if (cand != null) {
                         spo2CandidateByDay[res.daily.day] = cand.first
+                    }
+                } else {
+                    val auxSamples = repo.v18AuxSamples(owner, from, to, STREAM_LIMIT)
+                    if (auxSamples.isNotEmpty()) {
+                        val cand = AnalyticsEngine.nightlySpo2CandidateMean(res.sleepSessions, auxSamples)
+                        if (cand != null) {
+                            spo2CandidateByDay[res.daily.day] = cand.first
+                        }
                     }
                 }
             }

--- a/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
@@ -111,11 +111,13 @@ internal enum class VitalCaptionMode {
 /** Build the vitals, banded against the user's OWN trailing baseline once 14 trusted
  *  nights exist (population ranges before that — VitalBands does the deciding).
  *
- * #103: [spo2CandidateByDay] carries the nightly `spo2_candidate_82` mean (70–100) per day, loaded
- * from the "spo2_candidate" metricSeries key when the experimental display toggle is ON. When the
- * selected day has no calibrated `spo2Pct` but DOES have a candidate, the Blood O₂ tile falls back to
- * the candidate with an "estimate" caption. [spo2ToggleOn] distinguishes "toggle ON, no @82 data"
- * from "toggle OFF" so the missingCaption can tell the user which — a silent blank reads as broken.
+ * #103/queue-11a: [spo2CandidateByDay] carries the nightly SpO₂ candidate mean per day — WHOOP's
+ * `spo2_candidate_82` (70–100), or an Oura owner's ceiling@100 `0x6F` mean (device-conditional, see
+ * IntelligenceEngine) — loaded from the "spo2_candidate" metricSeries key when the experimental
+ * display toggle is ON. When the selected day has no calibrated `spo2Pct` but DOES have a candidate,
+ * the Blood O₂ tile falls back to the candidate with an "estimate" caption. [spo2ToggleOn]
+ * distinguishes "toggle ON, no estimate yet" from "toggle OFF" so the missingCaption can tell the
+ * user which — a silent blank reads as broken.
  * Empty map = toggle off or no candidate data → the tile behaves exactly as before. Mirrors the iOS
  * `BodyVitalSigns.readings` candidate fallback. */
 internal fun vitalsFor(

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -2691,11 +2691,16 @@ fun SettingsScreen(
                     color = Palette.textTertiary,
                 )
 
-                // --- #103: Blood Oxygen strap estimate (spo2_candidate_82) — OFF by default. ---
-                // The WHOOP 5/MG strap computes a nightly SpO₂ candidate at byte @82 of the V18Aux stream.
-                // Cross-device evidence is split (corr +0.99 on 8 nights, but 2 nights moved opposite), so
-                // it ships behind a default-off toggle and is labelled "estimate" in the UI. Display-only:
-                // never fed into a downstream gate (recovery, illness). Mirrors the iOS toggle.
+                // --- #103/queue-11a: Blood Oxygen strap estimate — OFF by default. ---
+                // Device-conditional (see IntelligenceEngine.nightlySpo2CeilingMean / .nightlySpo2CandidateMean):
+                // a WHOOP 5/MG strap computes a nightly SpO₂ candidate at byte @82 of the V18Aux stream
+                // (cross-device evidence split, corr +0.99 on 8 nights but 2 nights moved opposite); an
+                // Oura ring's own decoded 0x6F SpO2 runs high on the wire, so this instead surfaces the
+                // ceiling@100 mean (each sample capped at 100% before averaging), which has matched the
+                // Oura app's own displayed value on every full night checked so far (n=3, 2026-08-22).
+                // Neither is a validated calibration; both ship behind this one default-off toggle,
+                // labelled "estimate" in the UI, never fed into a downstream gate (recovery, illness).
+                // Mirrors the iOS toggle.
                 SettingsRowDivider()
                 var spo2CandidateDisplay by remember { mutableStateOf(NoopPrefs.spo2CandidateDisplay(context)) }
                 Row(
@@ -2725,11 +2730,14 @@ fun SettingsScreen(
                     )
                 }
                 Text(
-                    "Surfaces the WHOOP 5/MG strap's nightly SpO₂ estimate (spo2_candidate_82) in the " +
-                        "Blood Oxygen tile when no calibrated percentage is available. This is an " +
-                        "UNVERIFIED strap-computed value — it matched a reference device closely on most " +
-                        "nights but moved in the opposite direction on some. Shown as an 'estimate' and " +
-                        "never fed into recovery or illness scoring. Off by default.",
+                    "Surfaces your strap's nightly SpO₂ estimate in the Blood Oxygen tile when no " +
+                        "calibrated percentage is available: a WHOOP 5.0/MG's @82 candidate byte, or an " +
+                        "Oura ring's own reading with each sample capped at 100% first (the ring's raw " +
+                        "reading runs high otherwise). This is an UNVERIFIED strap-computed value — the " +
+                        "WHOOP candidate matched a reference device closely on most nights but moved " +
+                        "opposite on some; the Oura one has only been checked against a few nights so " +
+                        "far. Shown as an 'estimate' and never fed into recovery or illness scoring. Off " +
+                        "by default.",
                     style = NoopType.caption,
                     color = Palette.textTertiary,
                 )

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3526,9 +3526,10 @@ private fun dashboardCardValue(
         DashboardCard.BLOOD_OXYGEN ->
             // PER-FIELD carry: the whole-row carries (vd) land on rows whose spo2Pct is null (the engine
             // writes spo2Pct = null on computed rows), so fall through to the last row that HAS one.
-            // #103: when no calibrated spo2Pct exists, fall back to the spo2_candidate_82 strap estimate
-            // (from metricSeries) when the experimental display toggle is ON. Labelled "estimate" in the
-            // Health vitals screen; here it just fills the card so it's not blank.
+            // #103/queue-11a: when no calibrated spo2Pct exists, fall back to the spo2_candidate strap
+            // estimate (WHOOP @82 or Oura ceiling@100, from metricSeries) when the experimental display
+            // toggle is ON. Labelled "estimate" in the Health vitals screen; here it just fills the card
+            // so it's not blank.
             (vd?.spo2Pct ?: spo2Day?.spo2Pct)?.let { String.format(Locale.getDefault(), "%.0f%%", it) }
                 ?: (vd?.day ?: day?.day)?.let { spo2CandidateByDay[it] }?.let { String.format(Locale.getDefault(), "%.0f%%", it) }
                 ?: NO_DATA

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1968,7 +1968,7 @@
     <string name="settings_trend_line">Linie</string>
     <string name="settings_trend_bars">Balken</string>
     <string name="spo2_strap_estimate_caption">Armband-Schätzung (unbestätigt)</string>
-    <string name="spo2_toggle_on_no_data">Schalter EIN · keine @82-Daten</string>
+    <string name="spo2_toggle_on_no_data">Schalter EIN · noch keine Schätzung</string>
     <string name="l10n_devices_screen_forget_device_d6eb6209">Gerät vergessen…</string>
     <string name="l10n_devices_screen_forget_device_926e503d">Gerät vergessen</string>
     <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">Dieses Gerät vergessen?</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1935,7 +1935,7 @@
     <string name="settings_trend_line">Línea</string>
     <string name="settings_trend_bars">Barras</string>
     <string name="spo2_strap_estimate_caption">estimación de la correa (sin verificar)</string>
-    <string name="spo2_toggle_on_no_data">activado · sin datos de @82</string>
+    <string name="spo2_toggle_on_no_data">activado · aún sin estimación</string>
     <string name="l10n_devices_screen_forget_device_d6eb6209">Olvidar dispositivo…</string>
     <string name="l10n_devices_screen_forget_device_926e503d">Olvidar dispositivo</string>
     <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">¿Olvidar este dispositivo?</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1953,7 +1953,7 @@
     <string name="settings_trend_line">Courbe</string>
     <string name="settings_trend_bars">Barres</string>
     <string name="spo2_strap_estimate_caption">estimation du bracelet (non vérifiée)</string>
-    <string name="spo2_toggle_on_no_data">activé · aucune donnée @82</string>
+    <string name="spo2_toggle_on_no_data">activé · pas encore d\'estimation</string>
     <string name="l10n_devices_screen_forget_device_d6eb6209">Oublier l\'appareil…</string>
     <string name="l10n_devices_screen_forget_device_926e503d">Oublier l\'appareil</string>
     <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">Oublier cet appareil ?</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1929,7 +1929,7 @@
     <string name="settings_trend_line">Linha</string>
     <string name="settings_trend_bars">Barras</string>
     <string name="spo2_strap_estimate_caption">estimativa da pulseira (não verificada)</string>
-    <string name="spo2_toggle_on_no_data">ativado · sem dados de @82</string>
+    <string name="spo2_toggle_on_no_data">ativado · ainda sem estimativa</string>
     <string name="l10n_devices_screen_forget_device_d6eb6209">Esquecer dispositivo…</string>
     <string name="l10n_devices_screen_forget_device_926e503d">Esquecer dispositivo</string>
     <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">Esquecer este dispositivo?</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1978,9 +1978,9 @@
     <string name="settings_chart_classic">Classic</string>
     <string name="settings_trend_line">Line</string>
     <string name="settings_trend_bars">Bars</string>
-    <!-- #103: Blood Oxygen tile captions for the experimental WHOOP 5/MG @82 strap estimate. -->
+    <!-- #103/queue-11a: Blood Oxygen tile captions for the experimental strap estimate (WHOOP @82 or Oura ceiling@100). -->
     <string name="spo2_strap_estimate_caption">strap estimate (unverified)</string>
-    <string name="spo2_toggle_on_no_data">toggle ON · no @82 data</string>
+    <string name="spo2_toggle_on_no_data">toggle ON · no estimate yet</string>
     <string name="l10n_devices_screen_forget_device_d6eb6209">Forget device…</string>
     <string name="l10n_devices_screen_forget_device_926e503d">Forget device</string>
     <string name="l10n_devices_screen_forget_this_device_8dbbc3f3">Forget this device?</string>

--- a/android/app/src/test/java/com/noop/analytics/Spo2CeilingNightlyTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/Spo2CeilingNightlyTest.kt
@@ -1,0 +1,77 @@
+package com.noop.analytics
+
+import com.noop.data.Spo2Sample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Queue 11a — the Oura twin of [Spo2CandidateNightlyTest]: nightly ceiling@100 mean of the ring's own
+ * decoded `0x6F` SpO2 ([Spo2Sample.red]), the starting candidate transform for the Blood Oxygen tile's
+ * Oura fallback. Byte-parity twin of the Swift `Spo2CeilingNightlyTests`: same fixtures, same expected
+ * values. Pins the ceiling (per-sample, before averaging), the contamination floor gate, and the
+ * session-window filter — the three things that make this an honest "strap estimate," not raw wire.
+ */
+class Spo2CeilingNightlyTest {
+
+    private fun session(start: Long, durSec: Long) = DetectedSleep(
+        start = start, end = start + durSec, efficiency = 0.9,
+        stages = emptyList(), restingHR = 50, avgHRV = 60.0,
+    )
+
+    private fun spo2(ts: Long, red: Int) = Spo2Sample(deviceId = "d", ts = ts, red = red, ir = 0)
+
+    @Test fun meanAndSampleCountOverTheSession() {
+        val r = AnalyticsEngine.nightlySpo2CeilingMean(
+            listOf(session(1000, 600)), listOf(spo2(1100, 94), spo2(1200, 96), spo2(1300, 95)))
+        assertEquals(95, r?.first)
+        assertEquals(3, r?.second)
+    }
+
+    /**
+     * The whole point of "ceiling@100": a sample above 100 counts as 100, not itself — so a night with a
+     * real overshoot doesn't drag the mean above the physical ceiling the way the raw wire mean does
+     * (OURA_PROTOCOL.md §6.5.0.1's documented positive bias).
+     */
+    @Test fun samplesAboveOneHundredAreCeilingedBeforeAveraging() {
+        val r = AnalyticsEngine.nightlySpo2CeilingMean(
+            listOf(session(1000, 600)), listOf(spo2(1100, 104), spo2(1200, 100)))
+        assertEquals(100, r?.first)
+    }
+
+    /**
+     * Mis-scaled `dc_raw`/perfusion-channel contamination (-1016 .. 11,709,098, OURA_PROTOCOL.md
+     * §6.5.0.1) must not drag the mean down — the ceiling alone only guards the TOP of the range, so the
+     * floor gate is load-bearing here, unlike the WHOOP @82 path (whose decoder already only ever emits
+     * 70..100).
+     */
+    @Test fun contaminatedOutOfRangeSamplesAreExcluded() {
+        val r = AnalyticsEngine.nightlySpo2CeilingMean(
+            listOf(session(1000, 600)),
+            listOf(spo2(1100, 96), spo2(1150, -1016), spo2(1200, 11_709_098), spo2(1300, 98)))
+        assertEquals(97, r?.first)
+        assertEquals(2, r?.second)
+    }
+
+    @Test fun daytimeSamplesOutsideTheSessionAreExcluded() {
+        val r = AnalyticsEngine.nightlySpo2CeilingMean(
+            listOf(session(1000, 600)), listOf(spo2(500, 99), spo2(1100, 94), spo2(5000, 88)))
+        assertEquals(1, r?.second)
+        assertEquals(94, r?.first)
+    }
+
+    @Test fun nullWhenNothingPlausibleFallsInsideASession() {
+        assertNull(AnalyticsEngine.nightlySpo2CeilingMean(listOf(session(1000, 600)), listOf(spo2(1100, -1016))))
+        assertNull(AnalyticsEngine.nightlySpo2CeilingMean(listOf(session(1000, 600)), listOf(spo2(9999, 95))))
+        assertNull(AnalyticsEngine.nightlySpo2CeilingMean(emptyList(), listOf(spo2(1100, 95))))
+        assertNull(AnalyticsEngine.nightlySpo2CeilingMean(listOf(session(1000, 600)), emptyList()))
+    }
+
+    /** The plausibility floor/ceiling are inclusive, matching SPO2_SINGLE_CHANNEL_PLAUSIBLE (50..110). */
+    @Test fun plausibleRangeBoundariesAreInclusive() {
+        assertEquals(2, AnalyticsEngine.nightlySpo2CeilingMean(
+            listOf(session(1000, 600)), listOf(spo2(1100, 50), spo2(1200, 110)))?.second)
+        assertNull(AnalyticsEngine.nightlySpo2CeilingMean(listOf(session(1000, 600)), listOf(spo2(1100, 49))))
+        assertNull(AnalyticsEngine.nightlySpo2CeilingMean(listOf(session(1000, 600)), listOf(spo2(1100, 111))))
+    }
+}

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -560,10 +560,34 @@ like its sibling banked streams (`.hrv`/`.temp`/`.spo2`/`.sleepPhase`) — the f
     **zero overlapping days**. The comparison above is therefore distribution-level across
     *non-overlapping* periods (per-sample values vs nightly averages, different nights), which is why it
     can bound the discrepancy but not decompose it.
-  - **Re-pairing to the Oura app afterwards does NOT work — already refuted in practice.** Whichever
+  - **⚠️ CORRECTION 2026-08-19 — "does NOT work" is refuted, not confirmed.** A user re-paired the ring
+    to the Oura app via an OS-level Bluetooth unpair/re-pair (not a ring-side reset — see §5.3's
+    correction for the exact procedure and its caveats) and the app successfully backfilled full sleep
+    summary data, including `0x6F`-relevant SpO2, for two nights NOOP had already drained
+    (2026-08-13/14, 08-18/19). The original claim below is kept for its citation history, but is now
+    known to be wrong for at least this reproduction path — **the same-night comparison this section
+    says is "structurally blocked" is not, for sleep-summary-level data.** A first paired comparison
+    ran on these two nights: Oura app displayed SpO2 98% both nights, which round-matches the
+    offset−0.32/clamp[85,100] correction from §6.5.0.1 (98.11%, 97.39%) and does **not** match the raw
+    wire mean (99.11%, which would round to 99%). n=2 rounded integers, so this corroborates rather than
+    replaces the n=3 WHOOP-referenced MAE analysis in §6.5.0.2 — it does not by itself resolve path (a)
+    below, but it is no longer true that no paired data exists at all.
+    Full writeup: `worklog/analysis/2026-08-19-1730-oura-app-groundtruth-first-paired-comparison.txt`.
+  - **⚠️ UPDATE 2026-08-22 — 3rd full-tier paired night, same read.** Oura app displayed SpO2 **98%**
+    for 08-21/22 (screenshot, not a live-glance). Raw wire mean **99.66%** (rounds to 100% — miss);
+    ceiling@100 **98.48%** (rounds to 98% — hit); offset−0.32+clamp[85,100] **98.31%** (rounds to
+    98% — hit). Running full-tier tally across 3 screenshot-backed nights: raw 1/3, ceiling@100
+    **3/3**, offset+clamp 2/3 — raw is now the transform with the weakest track record of the
+    three; ceiling@100 slightly edges out the offset+clamp fit on this specific (weak,
+    rounded-integer) bar, though §6.5.0.1's own MAE-based fit still argues the opposite ordering.
+    n=3 (4 counting a weaker 08-20/21 live-glance point that missed on all three transforms) does
+    not change the ship decision. Full writeup:
+    `worklog/analysis/2026-08-22-1046-spo2-oura-app-groundtruth-night3.txt`.
+  - ~~**Re-pairing to the Oura app afterwards does NOT work — already refuted in practice.** Whichever
     client drains a window CONSUMES it, so the app finds nothing left for the nights NOOP captured (and
     vice versa). See the warning in §5.3, which records that observation and flags NOOP's unconditional
-    `28 01 00` flush as a candidate cause.
+    `28 01 00` flush as a candidate cause.~~ *(superseded by the correction above, kept struck-through
+    for citation history rather than deleted.)*
   - **Paths that could still settle it**, in increasing cost: (a) **resolve the §5.3 flush question** — if
     suppressing `28 01 00` leaves the history readable by BOTH clients, this comparison becomes possible
     for free. (b) A **reference pulse oximeter worn during sleep** alongside the ring — definitive, but


### PR DESCRIPTION
@pipiche38's #1568, rebased onto current main with one integration fix on top. **Their three commits
are preserved with their authorship** — this is a merge of their work, not a replacement of it.

## Why it needed rebasing rather than merging

#1568 showed green and `MERGEABLE / CLEAN`, but the green was **~10 hours stale** — every check
completed at `2026-08-23T14:0x`, and main had since gained six commits starting `2026-08-24T00:27Z`.
GitHub does not re-run checks when the base advances, and it reported CLEAN because the conflict was
never textual.

Merging the two locally is what surfaced it:

| tree | result |
|---|---|
| `main` alone | 4281 tests, 0 failures |
| #1568 head alone | 4270 tests, 0 failures |
| **merged** | **1 failure** |

```
analyzeRecentOnCpu instrumented Code length 61565 exceeds the 61535-byte budget
```

**Thirty bytes.** `analyzeRecentOnCpu` sits within ~100 bytes of the JVM's 64 KB per-method ceiling.
Their device-conditional SpO2 candidate branch and the trace recorders from #1575 both add to it;
neither exceeds the budget alone. No single PR's CI can see this.

## The fix

Their 14-line branch becomes a call to a new private `spo2CandidateMean`. **Behaviour unchanged** —
same two paths, same `?.first`, same null cases, still gated by the caller's toggle, still never
written to `spo2Pct` and never scored.

Same remedy as #1575, which hit this ceiling from the other side.

## A note for @pipiche38

The *"2 pre-existing failures in `RecoveryDriversTest`"* in the PR description **do not reproduce**.
That class is 10/10 on main and 10/10 on your own head, and your full suite is 4270/0 rather than the
2404/2 reported. That looks like a stale local Gradle/KSP cache — a documented trap in this repo, which
is why `--no-build-cache --rerun-tasks` matters here. Nothing was broken, and main was fine.

## What the PR itself gets right

- The derived-biosignal rule is handled exactly as CLAUDE.md prescribes: default-OFF, `metricSeries`
  sidecar, never into `spo2Pct`, never scored — reusing the `spo2_candidate_82` precedent rather than
  inventing a pattern.
- Commit 3 checked Android first and confirmed it never had the bug. Right direction.
- The single-channel Deep Timeline fix is well-evidenced: 0 rows plotted → 5,562, with the plausibility
  gate justified against real contamination ranges.

`ceiling@100` rests on n=3 nights on one subject — which is precisely why default-OFF and unvalidated
is the correct landing, and why it should not graduate to a default on that evidence.

## Verification

- **Integrated tree: 4283 tests, 0 failures.** Release lint, doc-comments and i18n clean.
- **app-build green on macOS and iOS** — the first time anyone has compiled the integrated Swift. Their
  local Xcode builds were pre-merge.
- Still not flashed to a device with the toggle on; that end-to-end capture is owed, as they noted.
