### PR TITLE
Record VO₂max estimator provenance

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/TrendChart.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/TrendChart.swift
@@ -16,15 +16,19 @@ import Charts
 public struct TrendPoint: Identifiable, Sendable {
     public var date: Date
     public var value: Double
+    /// Sequential line-segment identity. Points with different ids are rendered as separate lines, so a
+    /// metric can retain history without drawing a false transition across incompatible methods.
+    public var segment: String
 
     /// Stable, content-derived identity (one point per date in a series). A random
     /// `UUID()` defeats Swift Charts' diffing — every render re-identifies all marks
     /// and replays the draw animation; keying on the date lets Charts diff by data.
     public var id: Date { date }
 
-    public init(date: Date, value: Double) {
+    public init(date: Date, value: Double, segment: String = "default") {
         self.date = date
         self.value = value
+        self.segment = segment
     }
 }
 
@@ -195,7 +199,8 @@ public struct TrendChart: View {
                     ForEach(displayPoints) { p in
                         AreaMark(
                             x: .value("Date", p.date),
-                            y: .value("Value", p.value)
+                            y: .value("Value", p.value),
+                            series: .value("Segment", p.segment)
                         )
                         .interpolationMethod(.catmullRom)
                         .foregroundStyle(
@@ -212,7 +217,8 @@ public struct TrendChart: View {
                 ForEach(displayPoints) { p in
                     LineMark(
                         x: .value("Date", p.date),
-                        y: .value("Value", p.value)
+                        y: .value("Value", p.value),
+                        series: .value("Segment", p.segment)
                     )
                     .interpolationMethod(.catmullRom)
                     .lineStyle(StrokeStyle(lineWidth: 2.5, lineCap: .round, lineJoin: .round))

--- a/Packages/WhoopStore/Sources/WhoopStore/ScoreInputProvenanceStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/ScoreInputProvenanceStore.swift
@@ -1,7 +1,8 @@
 import Foundation
 import GRDB
 
-/// The source whose inputs produced one persisted NOOP-computed score.
+/// Provenance for one persisted NOOP-computed score. `sourceId` normally names the input provider;
+/// `vo2max_est` uses the estimator id because the method is the provenance users need for that series.
 /// Natural key: (computed device namespace, day, metric key).
 public struct ScoreInputProvenanceRow: Equatable, Codable, Sendable {
     public let day: String
@@ -15,10 +16,21 @@ public struct ScoreInputProvenanceRow: Equatable, Codable, Sendable {
     }
 }
 
+/// Estimator identity persisted beside a `vo2max_est` point in `ScoreInputProvenanceRow.sourceId`.
+/// Existing points have no such row and therefore remain explicitly unknown; their method must never be
+/// inferred from the current profile because a waist measurement may have changed since they were scored.
+public enum Vo2MaxEstimator: String, Codable, Sendable {
+    case nes
+    case uth
+
+    public static func forWaistCm(_ waistCm: Double) -> Self { waistCm > 0 ? .nes : .uth }
+}
+
 extension WhoopStore {
     /// Persist computed daily/series scores and their input provenance in one SQLite transaction.
-    /// Replacing provenance for the whole scoring window prevents stale attribution when a metric
-    /// disappears or changes provider. Any write failure rolls back both scores and metadata.
+    /// Replacing daily-score provenance in the scoring window prevents stale attribution when a metric
+    /// disappears or changes provider; independently-owned weekly VO₂max method tags survive. Any write
+    /// failure rolls back both scores and metadata.
     public func persistComputedScores(
         dailyMetrics: [DailyMetric],
         metricPoints: [MetricPoint],
@@ -37,10 +49,32 @@ extension WhoopStore {
             _ = try Self.upsertDailyMetrics(dailyMetrics, deviceId: deviceId, in: db)
             _ = try Self.upsertMetricSeries(metricPoints, deviceId: deviceId, in: db)
 
+            // Weekly VO₂max provenance is owned by `persistMetricSeriesWithProvenance` below, not this
+            // daily scoring window. Preserve it or every normal 21-day re-score erases the prior two
+            // Saturdays' method tags while leaving their metricSeries values in place.
             try db.execute(sql: """
                 DELETE FROM scoreInputProvenance
-                WHERE deviceId = ? AND day >= ? AND day <= ?
+                WHERE deviceId = ? AND day >= ? AND day <= ? AND key != 'vo2max_est'
                 """, arguments: [deviceId, from, to])
+            for row in provenance {
+                try db.execute(sql: """
+                    INSERT INTO scoreInputProvenance (deviceId, day, key, sourceId)
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT(deviceId, day,key) DO UPDATE SET sourceId = excluded.sourceId
+                    """, arguments: [deviceId, row.day, row.key, row.sourceId])
+            }
+        }
+    }
+
+    /// Persist a metric-series batch and its specialized provenance in one SQLite transaction. Used by
+    /// weekly VO₂max so a method label can never describe an older/newer value after a partial write.
+    public func persistMetricSeriesWithProvenance(
+        points: [MetricPoint],
+        provenance: [ScoreInputProvenanceRow],
+        deviceId: String
+    ) async throws {
+        try syncWrite { db in
+            _ = try Self.upsertMetricSeries(points, deviceId: deviceId, in: db)
             for row in provenance {
                 try db.execute(sql: """
                     INSERT INTO scoreInputProvenance (deviceId, day, key, sourceId)

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/ScoreInputProvenanceStoreTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/ScoreInputProvenanceStoreTests.swift
@@ -100,6 +100,33 @@ final class ScoreInputProvenanceStoreTests: XCTestCase {
         XCTAssertEqual(source, "polar-1")                 // provenance not wiped
     }
 
+    func testVo2MaxValueAndEstimatorPersistTogetherAndSurviveDailyRescore() async throws {
+        let store = try await WhoopStore.inMemory()
+        let day = "2026-07-25"
+        try await store.persistMetricSeriesWithProvenance(
+            points: [MetricPoint(day: day, key: "vo2max_est", value: 48)],
+            provenance: [ScoreInputProvenanceRow(day: day, key: "vo2max_est", sourceId: "nes")],
+            deviceId: "my-whoop-noop"
+        )
+
+        // A normal daily-score replacement spans this Saturday but does not own weekly VO₂max metadata.
+        try await store.persistComputedScores(
+            dailyMetrics: [makeDaily(day: day, recovery: 71, strain: 42)],
+            metricPoints: [],
+            provenance: [.init(day: day, key: "recovery", sourceId: "my-whoop")],
+            deviceId: "my-whoop-noop",
+            from: day,
+            to: day
+        )
+
+        let points = try await store.metricSeries(
+            deviceId: "my-whoop-noop", key: "vo2max_est", from: day, to: day)
+        let estimator = try await store.scoreInputSource(
+            deviceId: "my-whoop-noop", day: day, key: "vo2max_est")
+        XCTAssertEqual(points.first?.value, 48)
+        XCTAssertEqual(estimator, Vo2MaxEstimator.nes.rawValue)
+    }
+
     private func makeDaily(day: String, recovery: Double?, strain: Double?) -> DailyMetric {
         DailyMetric(
             day: day,

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -362,6 +362,20 @@ final class IntelligenceEngine: ObservableObject {
         return rows
     }
 
+    /// Method metadata for a newly computed VO₂max point. Empty when `points` contains no VO₂max value.
+    /// Method selection is captured at compute time; UI readers must never reconstruct it from today's
+    /// profile because changing/removing a waist is a legitimate transition between estimators.
+    static func vo2MaxProvenance(
+        points: [MetricPoint], waistCm: Double
+    ) -> [ScoreInputProvenanceRow] {
+        guard let point = points.first(where: { $0.key == "vo2max_est" }) else { return [] }
+        return [ScoreInputProvenanceRow(
+            day: point.day,
+            key: point.key,
+            sourceId: Vo2MaxEstimator.forWaistCm(waistCm).rawValue
+        )]
+    }
+
     /// Manual "refresh Fitness Age" (the button on the not-ready card): recompute the weekly Fitness Age NOW
     /// from the PERSISTED merged daily history , NO raw-HR rescoring , and upsert it. Same gate
     /// (`fitnessAgeRows`) + date/window logic as the recompute pass, so it reads exactly what the readiness
@@ -381,7 +395,13 @@ final class IntelligenceEngine: ObservableObject {
             gateDays: gate7, age: profile.age, sex: profile.sex, waistCm: profile.waistCm,
             heightCm: profile.heightCm, weightKg: profile.weightKg, computedId: computedId,
             satKey: Self.saturdayKey(onOrBefore: newestDay))
-        if !rows.isEmpty { _ = try? await store.upsertMetricSeries(rows, deviceId: computedId) }
+        if !rows.isEmpty {
+            try? await store.persistMetricSeriesWithProvenance(
+                points: rows,
+                provenance: Self.vo2MaxProvenance(points: rows, waistCm: profile.waistCm),
+                deviceId: computedId
+            )
+        }
         return !rows.isEmpty
     }
 
@@ -1945,7 +1965,13 @@ final class IntelligenceEngine: ObservableObject {
             gateDays: faGate7, age: profile.age, sex: profile.sex, waistCm: profile.waistCm,
             heightCm: profile.heightCm, weightKg: profile.weightKg, computedId: computedId,
             satKey: IntelligenceEngine.saturdayKey(onOrBefore: newestDay))
-        if !faPts.isEmpty { _ = try? await store.upsertMetricSeries(faPts, deviceId: computedId) }
+        if !faPts.isEmpty {
+            try? await store.persistMetricSeriesWithProvenance(
+                points: faPts,
+                provenance: Self.vo2MaxProvenance(points: faPts, waistCm: profile.waistCm),
+                deviceId: computedId
+            )
+        }
 
         // ── Vitality / Body Age (Phase 7) , weekly, keyed to the week's Saturday ────────────────────
         // Roll the last 7 days' wearable signals into the mortality-hazard model and upsert a weekly

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1985,6 +1985,14 @@ final class Repository: ObservableObject {
         return ScoreInputProvider(sourceId: sourceId, brand: brand)
     }
 
+    /// Raw specialized provenance tag for a computed metric point. Unlike `scoreInputProvider`, this does
+    /// not interpret the value as a device id; `vo2max_est` uses it for its `nes` / `uth` estimator id.
+    /// Missing metadata is an honest legacy-unknown result, never reconstructed from the current profile.
+    func scoreProvenanceTag(resolvedSource: String, day: String, metricKey: String) async -> String? {
+        guard resolvedSource.hasSuffix("-noop"), let store = await ensureStore() else { return nil }
+        return try? await store.scoreInputSource(deviceId: resolvedSource, day: day, key: metricKey)
+    }
+
     /// Read one candidate's rows for the window: its metricSeries, plus the matching DailyMetric column
     /// for any day the metricSeries doesn't carry (a Bluetooth-only WHOOP 5 user has values in the daily
     /// columns but not the long-format series). Ascending by day.

--- a/Strand/Screens/HealthView.swift
+++ b/Strand/Screens/HealthView.swift
@@ -656,6 +656,9 @@ private struct FitnessAgeSection: View {
     /// Latest estimated VO₂max (ml/kg/min) from "vo2max_est" — present even without a waist (the Uth
     /// HR-ratio fallback, #1391); a waist upgrades it to the more accurate Nes waist-based estimate.
     @State private var vo2max: Double?
+    /// Estimator captured beside the latest value. nil is an honest legacy-unknown state, never inferred
+    /// from today's waist because the profile may have changed since the point was scored.
+    @State private var vo2maxEstimator: Vo2MaxEstimator?
     @State private var loaded = false
     /// True while a manual "refresh Fitness Age" recompute is running (spinner in the readiness card).
     @State private var refreshing = false
@@ -840,6 +843,9 @@ private struct FitnessAgeSection: View {
                             Text("ml/kg/min")
                                 .font(StrandFont.footnote)
                                 .foregroundStyle(StrandPalette.textTertiary)
+                            Text("\(String(localized: "On-device")) · \(vo2MaxEstimatorDisplayName(vo2maxEstimator))")
+                                .font(StrandFont.footnote)
+                                .foregroundStyle(StrandPalette.textTertiary)
                         }
                     }
                     Image(systemName: "chevron.right")
@@ -900,9 +906,17 @@ private struct FitnessAgeSection: View {
     /// freshest point — the weekly value is keyed to the week's Saturday and refines through the week.
     private func load() async {
         let faPts = await repo.exploreSeries(key: "fitness_age", source: "my-whoop")
-        let vo2Pts = await repo.exploreSeries(key: "vo2max_est", source: "my-whoop")
+        let vo2Resolution = await repo.resolvedSeries(key: "vo2max_est", source: "my-whoop")
         fitnessAge = faPts.last?.value
-        vo2max = vo2Pts.last?.value
+        if let latest = vo2Resolution.points.last {
+            vo2max = latest.value
+            let tag = await repo.scoreProvenanceTag(
+                resolvedSource: latest.source, day: latest.day, metricKey: "vo2max_est")
+            vo2maxEstimator = tag.flatMap { Vo2MaxEstimator(rawValue: $0) }
+        } else {
+            vo2max = nil
+            vo2maxEstimator = nil
+        }
         loaded = true
     }
 }

--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -163,6 +163,34 @@ struct VitalReading: Equatable {
     let source: String
 }
 
+let vo2MaxAttributionPrefix = "vo2max-estimator:"
+
+/// A display-source token that keeps the existing readings-table plumbing while naming the estimator.
+/// `nil` is deliberately preserved as `unknown`; a legacy point must never inherit today's profile method.
+func vo2MaxAttributionSource(_ estimator: Vo2MaxEstimator?) -> String {
+    vo2MaxAttributionPrefix + (estimator?.rawValue ?? "unknown")
+}
+
+/// Sequential segment ids for the VO₂max trend. The counter matters when a user changes Nes → Uth → Nes:
+/// using the method name alone would reconnect the two non-adjacent Nes runs across the Uth interval.
+func vo2MaxTrendSegmentIds(days: [String], sourceByDay: [String: String]) -> [String] {
+    var previous: String?
+    var group = -1
+    return days.map { day in
+        let source = sourceByDay[day] ?? vo2MaxAttributionSource(nil)
+        if source != previous { group += 1; previous = source }
+        return "\(group):\(source)"
+    }
+}
+
+func vo2MaxEstimatorDisplayName(_ estimator: Vo2MaxEstimator?) -> String {
+    switch estimator {
+    case .nes: return "Nes 2011"
+    case .uth: return "Uth 2004"
+    case nil:  return String(localized: "Unknown")
+    }
+}
+
 /// One row of a vital detail's readings table: the reading's day (localized), its formatted value with
 /// unit, and a human source label. Plain strings so the view is a thin renderer and the projection stays
 /// unit-testable. Swift twin of Android's `VitalReadingRow`.
@@ -616,9 +644,12 @@ struct MetricDetailView: View {
     }
 
     private func trendPoints(_ windowed: [(day: String, value: Double)]) -> [TrendPoint] {
-        windowed.compactMap { row in
+        let segmentIds = metric.key == "vo2max_est"
+            ? vo2MaxTrendSegmentIds(days: windowed.map(\.day), sourceByDay: sourceByDay)
+            : Array(repeating: "default", count: windowed.count)
+        return windowed.enumerated().compactMap { index, row in
             guard let d = parseDay(row.day) else { return nil }
-            return TrendPoint(date: d, value: row.value)
+            return TrendPoint(date: d, value: row.value, segment: segmentIds[index])
         }
     }
 
@@ -754,8 +785,18 @@ struct MetricDetailView: View {
         // actually supplied each day (imported strap / on-device / Apple Health / Health Connect); the
         // chart still rides `series` above, so this only ADDS the source column, never moves the line.
         let resolution = await repo.resolvedSeries(key: metric.key, source: metric.source)
-        sourceByDay = Dictionary(resolution.points.map { ($0.day, $0.source) },
-                                 uniquingKeysWith: { first, _ in first })
+        if metric.key == "vo2max_est" {
+            var attributed: [String: String] = [:]
+            for point in resolution.points {
+                let tag = await repo.scoreProvenanceTag(
+                    resolvedSource: point.source, day: point.day, metricKey: metric.key)
+                attributed[point.day] = vo2MaxAttributionSource(tag.flatMap { Vo2MaxEstimator(rawValue: $0) })
+            }
+            sourceByDay = attributed
+        } else {
+            sourceByDay = Dictionary(resolution.points.map { ($0.day, $0.source) },
+                                     uniquingKeysWith: { first, _ in first })
+        }
         // #943 selection seam: a locked default (.month with under a week of history) no longer
         // OVERWRITES @State range - it renders through `coercedSelection` instead (non-destructive,
         // recomputed every body eval), so a shrinking history re-coerces and a growing one un-coerces

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -806,6 +806,11 @@ struct TodayView: View {
     /// Any other real source (Mi Band, Health Connect, nutrition) keeps its `FusionSource.displayName`
     ///, still the genuine merge winner, never a blanket claim. Mirror EXACTLY in Kotlin.
     static func provenanceDisplayLabel(rawSource: String, deviceId: String) -> String {
+        if rawSource.hasPrefix(vo2MaxAttributionPrefix) {
+            let raw = String(rawSource.dropFirst(vo2MaxAttributionPrefix.count))
+            let method = vo2MaxEstimatorDisplayName(Vo2MaxEstimator(rawValue: raw))
+            return "\(String(localized: "On-device")) · \(method)"
+        }
         if rawSource.hasSuffix("-noop") { return String(localized: "On-device") }
         if rawSource == deviceId || rawSource == Repository.whoopSource { return Self.whoopBrandName }
         if rawSource == Repository.appleHealthSource { return "Apple Health" }

--- a/StrandTests/Vo2MaxTrendProvenanceTests.swift
+++ b/StrandTests/Vo2MaxTrendProvenanceTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import Strand
+import WhoopStore
+
+final class Vo2MaxTrendProvenanceTests: XCTestCase {
+    func testMethodChangesCreateSequentialSegmentsEvenWhenMethodReturns() {
+        let sources = [
+            "2026-08-01": vo2MaxAttributionSource(.nes),
+            "2026-08-08": vo2MaxAttributionSource(.nes),
+            "2026-08-15": vo2MaxAttributionSource(.uth),
+            "2026-08-22": vo2MaxAttributionSource(.nes),
+        ]
+        XCTAssertEqual(
+            vo2MaxTrendSegmentIds(
+                days: ["2026-08-01", "2026-08-08", "2026-08-15", "2026-08-22"],
+                sourceByDay: sources),
+            [
+                "0:vo2max-estimator:nes",
+                "0:vo2max-estimator:nes",
+                "1:vo2max-estimator:uth",
+                "2:vo2max-estimator:nes",
+            ]
+        )
+    }
+
+    func testLegacyPointIsExplicitlyUnknown() {
+        XCTAssertEqual(vo2MaxAttributionSource(nil), "vo2max-estimator:unknown")
+        XCTAssertEqual(vo2MaxEstimatorDisplayName(nil), String(localized: "Unknown"))
+        XCTAssertEqual(
+            TodayView.provenanceDisplayLabel(rawSource: vo2MaxAttributionSource(nil), deviceId: "my-whoop"),
+            "\(String(localized: "On-device")) · \(String(localized: "Unknown"))"
+        )
+    }
+}

--- a/StrandTests/Vo2maxFallbackTests.swift
+++ b/StrandTests/Vo2maxFallbackTests.swift
@@ -46,4 +46,21 @@ final class Vo2maxFallbackTests: XCTestCase {
         // …and it differs from the Uth HR-ratio fallback.
         XCTAssertGreaterThan(abs(nes - uth), 0.01)
     }
+
+    func testNewlyComputedPointRecordsTheEstimatorUsedAtComputeTime() {
+        let uthRows = IntelligenceEngine.fitnessAgeRows(
+            gateDays: gate(60), age: 40, sex: "male", waistCm: 0, heightCm: 175, weightKg: 80,
+            computedId: "my-whoop-noop", satKey: "2026-08-15")
+        let nesRows = IntelligenceEngine.fitnessAgeRows(
+            gateDays: gate(60), age: 40, sex: "male", waistCm: 90, heightCm: 175, weightKg: 80,
+            computedId: "my-whoop-noop", satKey: "2026-08-22")
+
+        let uth = IntelligenceEngine.vo2MaxProvenance(points: uthRows, waistCm: 0).first
+        let nes = IntelligenceEngine.vo2MaxProvenance(points: nesRows, waistCm: 90).first
+        XCTAssertEqual(uth?.sourceId, Vo2MaxEstimator.uth.rawValue)
+        XCTAssertEqual(uth?.day, "2026-08-15")
+        XCTAssertEqual(uth?.key, "vo2max_est")
+        XCTAssertEqual(nes?.sourceId, Vo2MaxEstimator.nes.rawValue)
+        XCTAssertNil(Vo2MaxEstimator(rawValue: "my-whoop"))
+    }
 }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -7,6 +7,7 @@ import com.noop.data.MetricSeriesRow
 import com.noop.data.OuraRespScale
 import com.noop.data.ScoreInputProvenanceRow
 import com.noop.data.SleepSession
+import com.noop.data.Vo2MaxEstimator
 import com.noop.data.WhoopRepository
 import com.noop.data.WorkoutRow
 import com.noop.protocol.DeviceFamily
@@ -1946,7 +1947,12 @@ object IntelligenceEngine {
         // Strap-log proof: the RHR-night count the engine sees for the gate , should equal the "N of last 7
         // nights" the readiness card shows; `computed` says whether the value was (re)written this pass.
         diag("fitnessAge gate day=$newestDay rhrNights=${faGate7.mapNotNull { it.restingHr }.size} activityDays=${faGate7.mapNotNull { it.strain }.size} computed=${faPts.isNotEmpty()}")
-        if (faPts.isNotEmpty()) repo.upsertMetricSeries(faPts)
+        if (faPts.isNotEmpty()) {
+            repo.upsertMetricSeriesWithProvenance(
+                rows = faPts,
+                provenance = vo2MaxProvenance(faPts, profile.waistCm, computedId),
+            )
+        }
 
         // ── Vitality / Body Age (Phase 7) , weekly, keyed to the week's Saturday ──
         // Roll the last 7 days' wearable signals into the mortality-hazard model; VitalityEngine gates on
@@ -2432,6 +2438,22 @@ object IntelligenceEngine {
         return rows
     }
 
+    /** Method metadata for a newly computed VO₂max point. Empty when [rows] contains no VO₂max value.
+     *  Method selection is captured at compute time; UI readers must never reconstruct it from today's
+     *  profile because changing/removing a waist is a legitimate transition between estimators. */
+    fun vo2MaxProvenance(
+        rows: List<MetricSeriesRow>, waistCm: Double, computedId: String,
+    ): List<ScoreInputProvenanceRow> = rows.firstOrNull { it.key == "vo2max_est" }?.let { point ->
+        listOf(
+            ScoreInputProvenanceRow(
+                deviceId = computedId,
+                day = point.day,
+                key = point.key,
+                sourceId = Vo2MaxEstimator.forWaistCm(waistCm).provenanceId,
+            ),
+        )
+    }.orEmpty()
+
     /** Manual "refresh Fitness Age" (the button on the not-ready card): recompute the weekly Fitness Age
      *  NOW from the PERSISTED merged daily history , NO raw-HR rescoring , and upsert it. Uses the same gate
      *  ([fitnessAgeRows]) and the same date/window logic as the recompute pass, so it reads exactly what the
@@ -2449,7 +2471,12 @@ object IntelligenceEngine {
         val gate7 = repo.daysMerged(importedDeviceId)
             .filter { it.day in oldestDay..newestDay }.sortedBy { it.day }.takeLast(7)
         val rows = fitnessAgeRows(gate7, profile, computedId, saturdayKeyOnOrBefore(newestDay))
-        if (rows.isNotEmpty()) repo.upsertMetricSeries(rows)
+        if (rows.isNotEmpty()) {
+            repo.upsertMetricSeriesWithProvenance(
+                rows = rows,
+                provenance = vo2MaxProvenance(rows, profile.waistCm, computedId),
+            )
+        }
         return rows.isNotEmpty()
     }
 

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -417,8 +417,8 @@ data class MetricSeriesRow(
 )
 
 /**
- * Provider provenance for one NOOP-computed score. Separate from `dayOwnership`: ownership controls
- * raw-input resolution, while this records the source actually used for a persisted metric.
+ * Provenance for one NOOP-computed score. [sourceId] normally records the provider actually used, while
+ * `vo2max_est` records its estimator id. Separate from `dayOwnership`, which controls input resolution.
  */
 @Entity(
     tableName = "scoreInputProvenance",
@@ -431,6 +431,22 @@ data class ScoreInputProvenanceRow(
     @ColumnInfo(name = "key") val key: String,
     val sourceId: String,
 )
+
+/** Estimator identity persisted beside a `vo2max_est` point in [ScoreInputProvenanceRow.sourceId].
+ *  Existing points have no such row and therefore remain explicitly unknown; never infer their method
+ *  from the user's current profile because a waist measurement may have changed since they were scored. */
+enum class Vo2MaxEstimator(val provenanceId: String) {
+    NES("nes"),
+    UTH("uth");
+
+    companion object {
+        fun fromProvenanceId(value: String?): Vo2MaxEstimator? = entries.firstOrNull {
+            it.provenanceId == value
+        }
+
+        fun forWaistCm(waistCm: Double): Vo2MaxEstimator = if (waistCm > 0.0) NES else UTH
+    }
+}
 
 /**
  * Lab Book marker reading (Health Records pillar). Swift `labMarker` (Database.swift v17 /

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -251,13 +251,27 @@ interface WhoopDao : DeviceRegistryDao {
 
     @Query(
         "DELETE FROM scoreInputProvenance " +
-            "WHERE deviceId = :deviceId AND day >= :from AND day <= :to"
+            "WHERE deviceId = :deviceId AND day >= :from AND day <= :to " +
+            "AND `key` != 'vo2max_est'"
     )
     suspend fun deleteScoreInputProvenanceInRange(deviceId: String, from: String, to: String)
 
+    /** Persist a metric-series batch and its specialized provenance in one transaction. Used by weekly
+     *  VO₂max so a method label can never describe an older/newer value after a partial write. */
+    @Transaction
+    suspend fun upsertMetricSeriesWithProvenance(
+        rows: List<MetricSeriesRow>,
+        provenance: List<ScoreInputProvenanceRow>,
+    ) {
+        if (rows.isNotEmpty()) upsertMetricSeries(rows)
+        if (provenance.isNotEmpty()) upsertScoreInputProvenance(provenance)
+    }
+
     /**
      * Replace a computed scoring window atomically. If any score or provenance write fails, Room rolls
-     * the whole transaction back, so an old score can never be labelled with a newer provider.
+     * the whole transaction back, so an old score can never be labelled with a newer provider. VO₂max's
+     * weekly estimator provenance is owned by [upsertMetricSeriesWithProvenance] and survives this daily
+     * window replacement; otherwise a normal re-score would erase the prior two Saturdays' method tags.
      */
     @Transaction
     suspend fun replaceComputedScoreWindow(

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -625,6 +625,11 @@ class WhoopRepository(
     suspend fun scoreInputSource(deviceId: String, day: String, key: String): String? =
         dao.scoreInputSource(deviceId, day, key)
 
+    suspend fun upsertMetricSeriesWithProvenance(
+        rows: List<MetricSeriesRow>,
+        provenance: List<ScoreInputProvenanceRow>,
+    ) = dao.upsertMetricSeriesWithProvenance(rows, provenance)
+
     /** Hand-correct the bed (onset) / wake (end) time of an existing sleep session, DURABLY , port
      *  of iOS PR #395 (Repository.editSleepTimes + MetricsCache.applySleepEdit).
      *

--- a/android/app/src/main/java/com/noop/ui/Charts.kt
+++ b/android/app/src/main/java/com/noop/ui/Charts.kt
@@ -198,6 +198,23 @@ fun Sparkline(
 
 // MARK: - LineChart
 
+/** Contiguous point-index ranges for a segmented line. A null/misaligned id list preserves the classic
+ *  single-line behavior. Equal ids that reappear later become a new range because only adjacency connects. */
+internal fun lineChartSegmentRanges(count: Int, segmentIds: List<String>?): List<IntRange> {
+    if (count <= 0) return emptyList()
+    if (segmentIds == null || segmentIds.size != count) return listOf(0 until count)
+    val ranges = ArrayList<IntRange>()
+    var start = 0
+    for (i in 1 until count) {
+        if (segmentIds[i] != segmentIds[i - 1]) {
+            ranges.add(start until i)
+            start = i
+        }
+    }
+    ranges.add(start until count)
+    return ranges
+}
+
 /**
  * Line chart with an optional soft vertical gradient fill under the curve. Height is
  * taken from [modifier] (e.g. `Modifier.height(Metrics.chartHeight)`). A faint
@@ -226,6 +243,9 @@ fun LineChart(
     // Optional per-point display labels, index-aligned with [values]. Daily charts use this for a
     // human-readable date prefix ("16 Jul · 87"); live charts keep using [timestamps].
     selectionLabels: List<String>? = null,
+    // Optional sequential line-segment ids, index-aligned with [values]. Adjacent unequal ids break the
+    // stroke/fill without dropping either reading; used by VO₂max when its estimator changes.
+    segmentIds: List<String>? = null,
 ) {
     val cleanValues = remember(values) { values.filter { it.isFinite() } }
     // Timestamps filtered by the SAME finiteness cut as cleanValues so indices stay aligned;
@@ -237,6 +257,10 @@ fun LineChart(
     val cleanSelectionLabels = remember(values, selectionLabels) {
         if (selectionLabels == null || selectionLabels.size != values.size) null
         else values.indices.filter { values[it].isFinite() }.map { selectionLabels[it] }
+    }
+    val cleanSegmentIds = remember(values, segmentIds) {
+        if (segmentIds == null || segmentIds.size != values.size) null
+        else values.indices.filter { values[it].isFinite() }.map { segmentIds[it] }
     }
     var selectedIndex by remember(cleanValues) { mutableIntStateOf(-1) }
     val interactiveModifier = if (selectionEnabled) {
@@ -329,17 +353,18 @@ fun LineChart(
                     if (pts.isEmpty()) {
                         onDrawBehind { drawBaseline() }
                     } else {
-                        val fillPath = if (fill) {
+                        val segments = lineChartSegmentRanges(pts.size, cleanSegmentIds)
+                        val fillPaths = if (fill) segments.map { range ->
                             Path().apply {
-                                moveTo(pts.first().x, size.height)
-                                lineTo(pts.first().x, pts.first().y)
-                                for (i in 1 until pts.size) lineTo(pts[i].x, pts[i].y)
-                                lineTo(pts.last().x, size.height)
+                                val first = pts[range.first]
+                                val last = pts[range.last]
+                                moveTo(first.x, size.height)
+                                lineTo(first.x, first.y)
+                                for (i in (range.first + 1)..range.last) lineTo(pts[i].x, pts[i].y)
+                                lineTo(last.x, size.height)
                                 close()
                             }
-                        } else {
-                            null
-                        }
+                        } else emptyList()
                         val fillBrush = if (fill) {
                             Brush.verticalGradient(
                                 colors = listOf(
@@ -353,18 +378,25 @@ fun LineChart(
                         } else {
                             null
                         }
-                        val linePath = Path().apply {
-                            moveTo(pts.first().x, pts.first().y)
-                            for (i in 1 until pts.size) lineTo(pts[i].x, pts[i].y)
+                        val linePaths = segments.map { range ->
+                            Path().apply {
+                                moveTo(pts[range.first].x, pts[range.first].y)
+                                for (i in (range.first + 1)..range.last) lineTo(pts[i].x, pts[i].y)
+                            }
                         }
                         val lineStroke = Stroke(width = strokePx, cap = StrokeCap.Round, join = StrokeJoin.Round)
                         onDrawBehind {
                             // Soft gradient fill under the curve.
-                            if (fillPath != null && fillBrush != null) {
-                                drawPath(path = fillPath, brush = fillBrush)
+                            if (fillBrush != null) {
+                                for (path in fillPaths) drawPath(path = path, brush = fillBrush)
                             }
                             // The line itself.
-                            drawPath(path = linePath, color = color, style = lineStroke)
+                            for (path in linePaths) drawPath(path = path, color = color, style = lineStroke)
+                            // A one-reading segment has no visible stroke. Method-segmented trends retain
+                            // a small point so neither side of a method transition disappears.
+                            if (cleanSegmentIds != null) {
+                                for (point in pts) drawCircle(color = color, radius = 2.5f, center = point)
+                            }
                         }
                     }
                 }

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -84,6 +84,7 @@ import com.noop.analytics.SkinTempDisplay
 import com.noop.analytics.VitalBands
 import com.noop.ble.LiveState
 import com.noop.data.DailyMetric
+import com.noop.data.Vo2MaxEstimator
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -660,6 +661,7 @@ private fun FitnessAgeSection(vm: AppViewModel, days: List<DailyMetric>, profile
     // re-read whenever the merged history changes — a fresh sync/import is what moves these).
     var fitnessAge by remember { mutableStateOf<Double?>(null) }
     var vo2max by remember { mutableStateOf<Double?>(null) }
+    var vo2maxEstimator by remember { mutableStateOf<Vo2MaxEstimator?>(null) }
     // Manual-refresh plumbing: the not-ready card's refresh button recomputes Fitness Age NOW and bumps
     // this tick, which re-keys the read below so a freshly written value shows without waiting for a sync.
     var refreshTick by remember { mutableStateOf(0) }
@@ -669,11 +671,19 @@ private fun FitnessAgeSection(vm: AppViewModel, days: List<DailyMetric>, profile
         val fa = runCatching {
             vm.repo.latestMetricComputedUnion(vm.activeStrapId, "fitness_age")?.value
         }.getOrNull()
-        val vo2 = runCatching {
-            vm.repo.latestMetricComputedUnion(vm.activeStrapId, "vo2max_est")?.value
+        val vo2Row = runCatching {
+            vm.repo.latestMetricComputedUnion(vm.activeStrapId, "vo2max_est")
         }.getOrNull()
+        val estimator = vo2Row?.let { row ->
+            runCatching {
+                Vo2MaxEstimator.fromProvenanceId(
+                    vm.repo.scoreInputSource(row.deviceId, row.day, row.key),
+                )
+            }.getOrNull()
+        }
         fitnessAge = fa
-        vo2max = vo2
+        vo2max = vo2Row?.value
+        vo2maxEstimator = estimator
     }
 
     // Readiness from what THIS screen can see: the last 7 merged daily rows. RHR coverage drives the
@@ -694,6 +704,7 @@ private fun FitnessAgeSection(vm: AppViewModel, days: List<DailyMetric>, profile
                 fitnessAge = value,
                 chronoAge = profile.age,
                 vo2max = vo2max,
+                vo2maxEstimator = vo2maxEstimator,
                 onHowAccurate = { showChecklist = !showChecklist },
                 checklistOpen = showChecklist,
             )
@@ -920,6 +931,7 @@ private fun FitnessAgeHero(
     fitnessAge: Double,
     chronoAge: Int,
     vo2max: Double?,
+    vo2maxEstimator: Vo2MaxEstimator?,
     onHowAccurate: () -> Unit,
     checklistOpen: Boolean,
 ) {
@@ -966,11 +978,18 @@ private fun FitnessAgeHero(
                     )
                 }
                 if (vo2max != null) {
-                    StatePill(
-                        title = uiString(R.string.l10n_health_screen_vo_max_vo2max_roundtoint_c32a04b3, vo2max.roundToInt()),
-                        tone = StrandTone.Accent,
-                        showsDot = false,
-                    )
+                    Column(horizontalAlignment = Alignment.End) {
+                        StatePill(
+                            title = uiString(R.string.l10n_health_screen_vo_max_vo2max_roundtoint_c32a04b3, vo2max.roundToInt()),
+                            tone = StrandTone.Accent,
+                            showsDot = false,
+                        )
+                        Text(
+                            text = uiString(vo2MaxAttributionLabelRes(vo2maxEstimator)),
+                            style = NoopType.footnote,
+                            color = Palette.textTertiary,
+                        )
+                    }
                 }
             }
 
@@ -1910,6 +1929,7 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
                     color = detail.color,
                     fill = true,
                     selectionEnabled = true, // the Vital Signs detail chart is meant to be tappable
+                    segmentIds = if (key == "vo2max_est") vo2MaxTrendSegmentIds(filteredReadings) else null,
                 )
                 Box(
                     modifier = Modifier
@@ -2156,15 +2176,24 @@ private suspend fun buildSeriesVitalDetail(vm: AppViewModel, key: String): Vital
     // resolvedSeries the imported vitals use, which carries no vo2max_est. Without this case the tap-through
     // fell to the default and the trend chart was empty (the reported bug). Parity with iOS, which handles
     // `.vo2max` alongside `.fitnessAge` / `.vitality` and reads `exploreSeries("vo2max_est")`.
-    "vo2max_est" -> VitalDetailModel(
-        key = key,
-        title = uiString(R.string.l10n_health_screen_vo2max_21214fb6),
-        unit = "ml/kg",
-        color = Palette.chargeColor,
-        readings = vm.repo.metricSeriesComputedUnion(vm.activeStrapId, "vo2max_est", "0000-01-01", "9999-12-31")
-            .map { VitalReading(it.day, it.value, it.deviceId) },
-        format = { it.roundToInt().toString() },
-    )
+    "vo2max_est" -> {
+        val points = vm.repo.metricSeriesComputedUnion(
+            vm.activeStrapId, "vo2max_est", "0000-01-01", "9999-12-31",
+        )
+        VitalDetailModel(
+            key = key,
+            title = uiString(R.string.l10n_health_screen_vo2max_21214fb6),
+            unit = "ml/kg",
+            color = Palette.chargeColor,
+            readings = points.map { point ->
+                val estimator = Vo2MaxEstimator.fromProvenanceId(
+                    vm.repo.scoreInputSource(point.deviceId, point.day, point.key),
+                )
+                VitalReading(point.day, point.value, vo2MaxAttributionSource(estimator))
+            },
+            format = { it.roundToInt().toString() },
+        )
+    }
     "steps_est" -> {
         // #377: the Today Steps tile resolves a REAL step count FIRST — the WHOOP 5/MG on-device @57
         // counter (DailyMetric.steps) ?: imported Health Connect / Apple Health ?: the motion-model

--- a/android/app/src/main/java/com/noop/ui/HealthVitalDetailLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalDetailLogic.kt
@@ -1,5 +1,6 @@
 package com.noop.ui
 
+import com.noop.data.Vo2MaxEstimator
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -14,6 +15,27 @@ internal data class VitalReading(
     val value: Double,
     val source: String,
 )
+
+internal const val VO2_MAX_ATTRIBUTION_PREFIX = "vo2max-estimator:"
+
+/** Display-source token for a VO₂max reading. A missing legacy tag stays unknown; it must never inherit
+ *  the method implied by today's profile because the waist measurement may have changed after scoring. */
+internal fun vo2MaxAttributionSource(estimator: Vo2MaxEstimator?): String =
+    VO2_MAX_ATTRIBUTION_PREFIX + (estimator?.provenanceId ?: "unknown")
+
+/** Sequential ids for a method-aware trend. Nes → Uth → Nes becomes three segments rather than joining
+ *  the non-adjacent Nes runs across an incompatible estimator. */
+internal fun vo2MaxTrendSegmentIds(readings: List<VitalReading>): List<String> {
+    var previous: String? = null
+    var group = -1
+    return readings.map { reading ->
+        if (reading.source != previous) {
+            group++
+            previous = reading.source
+        }
+        "$group:${reading.source}"
+    }
+}
 
 /** #377: merge the three step stores into one per-day series with the SAME precedence as the Today
  *  Steps tile — a REAL on-device count ([real], WHOOP 5/MG @57 → DailyMetric.steps) wins, else an

--- a/android/app/src/main/java/com/noop/ui/TodayProvenance.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayProvenance.kt
@@ -7,6 +7,7 @@ import com.noop.analytics.FusionSource
 import com.noop.analytics.ReadinessEngine
 import com.noop.ble.WhoopBleClient
 import com.noop.data.WhoopRepository
+import com.noop.data.Vo2MaxEstimator
 
 /**
  * The Today provenance label for the day's REAL merge winner, extends the existing By-Day badge
@@ -57,6 +58,10 @@ internal fun provenanceDisplayLabel(
     rawSource: String,
     deviceId: String = WhoopRepository.WHOOP_SOURCE,
 ): DisplayText {
+    if (rawSource.startsWith(VO2_MAX_ATTRIBUTION_PREFIX)) {
+        val raw = rawSource.removePrefix(VO2_MAX_ATTRIBUTION_PREFIX)
+        return DisplayText.Resource(vo2MaxAttributionLabelRes(Vo2MaxEstimator.fromProvenanceId(raw)))
+    }
     if (rawSource.endsWith("-noop")) return DisplayText.Resource(R.string.today_source_on_device)
     if (rawSource == deviceId || rawSource == WhoopRepository.WHOOP_SOURCE) return DisplayText.Resource(R.string.today_source_whoop)
     if (rawSource == WhoopRepository.APPLE_HEALTH_SOURCE) return DisplayText.Resource(R.string.today_source_apple_health)
@@ -64,6 +69,13 @@ internal fun provenanceDisplayLabel(
     return FusionSource.entries.firstOrNull { it.id == rawSource }
         ?.let { source -> provenanceBadgeLabel(source) }
         ?: DisplayText.Dynamic(rawSource)
+}
+
+@StringRes
+internal fun vo2MaxAttributionLabelRes(estimator: Vo2MaxEstimator?): Int = when (estimator) {
+    Vo2MaxEstimator.NES -> R.string.vo2max_method_nes
+    Vo2MaxEstimator.UTH -> R.string.vo2max_method_uth
+    null -> R.string.vo2max_method_unknown
 }
 
 /** Today uses the audience-facing sensor name for Apple Health scores, matching the Swift Today lane. */

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2152,6 +2152,9 @@
     <string name="today_weight_latest">aktuell</string>
     <string name="today_weight_from_profile">aus dem Profil</string>
     <string name="today_source_on_device">Auf dem Gerät</string>
+    <string name="vo2max_method_nes">Auf dem Gerät · Nes 2011</string>
+    <string name="vo2max_method_uth">Auf dem Gerät · Uth 2004</string>
+    <string name="vo2max_method_unknown">Auf dem Gerät · Unbekannte Methode</string>
     <string name="today_source_whoop">WHOOP</string>
     <string name="today_source_apple_health">Apple Health</string>
     <string name="today_source_health_connect">Google Health Connect</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2138,6 +2138,9 @@
     <string name="today_weight_latest">más reciente</string>
     <string name="today_weight_from_profile">del perfil</string>
     <string name="today_source_on_device">En el dispositivo</string>
+    <string name="vo2max_method_nes">En el dispositivo · Nes 2011</string>
+    <string name="vo2max_method_uth">En el dispositivo · Uth 2004</string>
+    <string name="vo2max_method_unknown">En el dispositivo · Método desconocido</string>
     <string name="today_source_whoop">WHOOP</string>
     <string name="today_source_apple_health">Apple Health</string>
     <string name="today_source_health_connect">Google Health Connect</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2137,6 +2137,9 @@
     <string name="today_weight_latest">le plus récent</string>
     <string name="today_weight_from_profile">depuis le profil</string>
     <string name="today_source_on_device">Sur l’appareil</string>
+    <string name="vo2max_method_nes">Sur l’appareil · Nes 2011</string>
+    <string name="vo2max_method_uth">Sur l’appareil · Uth 2004</string>
+    <string name="vo2max_method_unknown">Sur l’appareil · Méthode inconnue</string>
     <string name="today_source_whoop">WHOOP</string>
     <string name="today_source_apple_health">Apple Health</string>
     <string name="today_source_health_connect">Google Health Connect</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2131,6 +2131,9 @@
     <string name="today_weight_latest">najnowszy</string>
     <string name="today_weight_from_profile">z profilu</string>
     <string name="today_source_on_device">Na urządzeniu</string>
+    <string name="vo2max_method_nes">Na urządzeniu · Nes 2011</string>
+    <string name="vo2max_method_uth">Na urządzeniu · Uth 2004</string>
+    <string name="vo2max_method_unknown">Na urządzeniu · Nieznana metoda</string>
     <string name="today_source_whoop">WHOOP</string>
     <string name="today_source_apple_health">Apple Health</string>
     <string name="today_source_health_connect">Google Health Connect</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2131,6 +2131,9 @@
     <string name="today_weight_latest">mais recente</string>
     <string name="today_weight_from_profile">do perfil</string>
     <string name="today_source_on_device">No dispositivo</string>
+    <string name="vo2max_method_nes">No dispositivo · Nes 2011</string>
+    <string name="vo2max_method_uth">No dispositivo · Uth 2004</string>
+    <string name="vo2max_method_unknown">No dispositivo · Método desconhecido</string>
     <string name="today_source_whoop">WHOOP</string>
     <string name="today_source_apple_health">Apple Health</string>
     <string name="today_source_health_connect">Google Health Connect</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2066,6 +2066,9 @@
     <string name="today_weight_latest">最新</string>
     <string name="today_weight_from_profile">来自个人资料</string>
     <string name="today_source_on_device">设备端</string>
+    <string name="vo2max_method_nes">设备端 · Nes 2011</string>
+    <string name="vo2max_method_uth">设备端 · Uth 2004</string>
+    <string name="vo2max_method_unknown">设备端 · 方法未知</string>
     <string name="today_source_whoop">WHOOP</string>
     <string name="today_source_apple_health">Apple 健康</string>
     <string name="today_source_health_connect">Google 健康数据同步</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2164,6 +2164,9 @@
     <string name="today_weight_latest">latest</string>
     <string name="today_weight_from_profile">from profile</string>
     <string name="today_source_on_device">On-device</string>
+    <string name="vo2max_method_nes">On-device · Nes 2011</string>
+    <string name="vo2max_method_uth">On-device · Uth 2004</string>
+    <string name="vo2max_method_unknown">On-device · Unknown method</string>
     <string name="today_source_whoop">Whoop</string>
     <string name="today_source_apple_health">Apple Health</string>
     <string name="today_source_health_connect">Health Connect</string>

--- a/android/app/src/test/java/com/noop/analytics/IntelligenceEngineJacocoBudgetTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/IntelligenceEngineJacocoBudgetTest.kt
@@ -69,7 +69,9 @@ class IntelligenceEngineJacocoBudgetTest {
         val orderedOperations = listOf(
             "fitnessAgeRows" to Regex("""\bfitnessAgeRows\s*\("""),
             "fitness diagnostic" to Regex("""\bdiag\s*\("""),
-            "Fitness upsert" to Regex("""\brepo\s*\.\s*upsertMetricSeries\s*\(\s*faPts\s*\)"""),
+            "Fitness upsert" to Regex(
+                """\brepo\s*\.\s*upsertMetricSeriesWithProvenance\s*\(\s*rows\s*=\s*faPts\b""",
+            ),
             "Vitality compute" to Regex("""\bVitalityEngine\s*\.\s*compute\s*\("""),
             "Vitality upsert" to Regex("""\brepo\s*\.\s*upsertMetricSeries\s*\(\s*listOf\s*\("""),
             "Apple Health read" to Regex("""\brepo\s*\.\s*appleDaily\s*\(\s*WhoopRepository\s*\.\s*APPLE_HEALTH_SOURCE\b"""),

--- a/android/app/src/test/java/com/noop/analytics/Vo2maxFallbackTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/Vo2maxFallbackTest.kt
@@ -1,6 +1,7 @@
 package com.noop.analytics
 
 import com.noop.data.DailyMetric
+import com.noop.data.Vo2MaxEstimator
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -42,5 +43,30 @@ class Vo2maxFallbackTest {
         assertEquals(FitnessAgeEngine.estimateVO2max(40.0, "male", 90.0, 60.0, paIndex), nes, 1e-6)
         // …and it is a different number from the Uth HR-ratio fallback.
         assertTrue("Nes (waist) and Uth (HR-ratio) estimates should differ", abs(nes - uth) > 0.01)
+    }
+
+    @Test
+    fun newlyComputedPoint_recordsTheEstimatorUsedAtComputeTime() {
+        val computedId = "my-whoop-noop"
+        val noWaist = UserProfile(age = 40.0, sex = "male", waistCm = 0.0)
+        val withWaist = UserProfile(age = 40.0, sex = "male", waistCm = 90.0)
+        val uthRows = IntelligenceEngine.fitnessAgeRows(gate(60), noWaist, computedId, "2026-08-15")
+        val nesRows = IntelligenceEngine.fitnessAgeRows(gate(60), withWaist, computedId, "2026-08-22")
+
+        val uth = IntelligenceEngine.vo2MaxProvenance(uthRows, noWaist.waistCm, computedId).single()
+        val nes = IntelligenceEngine.vo2MaxProvenance(nesRows, withWaist.waistCm, computedId).single()
+
+        assertEquals("uth", uth.sourceId)
+        assertEquals("2026-08-15", uth.day)
+        assertEquals("vo2max_est", uth.key)
+        assertEquals("nes", nes.sourceId)
+        assertEquals(Vo2MaxEstimator.UTH, Vo2MaxEstimator.fromProvenanceId(uth.sourceId))
+        assertEquals(Vo2MaxEstimator.NES, Vo2MaxEstimator.fromProvenanceId(nes.sourceId))
+    }
+
+    @Test
+    fun missingLegacyProvenance_remainsUnknown() {
+        assertEquals(null, Vo2MaxEstimator.fromProvenanceId(null))
+        assertEquals(null, Vo2MaxEstimator.fromProvenanceId("my-whoop"))
     }
 }

--- a/android/app/src/test/java/com/noop/ui/Vo2MaxTrendProvenanceTest.kt
+++ b/android/app/src/test/java/com/noop/ui/Vo2MaxTrendProvenanceTest.kt
@@ -1,0 +1,42 @@
+package com.noop.ui
+
+import com.noop.R
+import com.noop.data.Vo2MaxEstimator
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class Vo2MaxTrendProvenanceTest {
+    @Test
+    fun methodChangesCreateSequentialSegmentsEvenWhenMethodReturns() {
+        val readings = listOf(
+            VitalReading("2026-08-01", 48.0, vo2MaxAttributionSource(Vo2MaxEstimator.NES)),
+            VitalReading("2026-08-08", 49.0, vo2MaxAttributionSource(Vo2MaxEstimator.NES)),
+            VitalReading("2026-08-15", 63.0, vo2MaxAttributionSource(Vo2MaxEstimator.UTH)),
+            VitalReading("2026-08-22", 50.0, vo2MaxAttributionSource(Vo2MaxEstimator.NES)),
+        )
+
+        assertEquals(
+            listOf(
+                "0:vo2max-estimator:nes",
+                "0:vo2max-estimator:nes",
+                "1:vo2max-estimator:uth",
+                "2:vo2max-estimator:nes",
+            ),
+            vo2MaxTrendSegmentIds(readings),
+        )
+        assertEquals(
+            listOf(0..1, 2..2, 3..3),
+            lineChartSegmentRanges(readings.size, vo2MaxTrendSegmentIds(readings)),
+        )
+    }
+
+    @Test
+    fun legacyPointIsExplicitlyUnknownAndSeparatedFromKnownMethod() {
+        val legacy = vo2MaxAttributionSource(null)
+        assertEquals("vo2max-estimator:unknown", legacy)
+        assertEquals(R.string.vo2max_method_unknown, vo2MaxAttributionLabelRes(null))
+        assertEquals(R.string.vo2max_method_nes, vo2MaxAttributionLabelRes(Vo2MaxEstimator.NES))
+        assertEquals(R.string.vo2max_method_uth, vo2MaxAttributionLabelRes(Vo2MaxEstimator.UTH))
+        assertEquals(listOf(0..1), lineChartSegmentRanges(2, null))
+    }
+}


### PR DESCRIPTION
## What this PR does

- records the estimator used for each new `vo2max_est` point as `nes` or `uth` on both platforms
- persists the value and estimator provenance atomically, while preserving weekly VO₂max tags during daily score replacement
- leaves legacy points explicitly unknown instead of inferring their method from the current profile
- names the method in the Fitness Age card and VO₂max readings
- splits VO₂max trend lines whenever the estimator changes so the chart does not present a method switch as a fitness change
- adds persistence, estimator-selection, legacy-history, and segmented-trend regression coverage

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- `ANDROID_HOME=/home/kaveman/Android/Sdk ANDROID_SDK_ROOT=/home/kaveman/Android/Sdk ./gradlew :app:testFullDebugUnitTest :app:assembleFullDebug` (4,291 tests; build successful)
- focused `Vo2maxFallbackTest` and `Vo2MaxTrendProvenanceTest`
- `python3 Tools/doc_comment_lint.py`
- `python3 Tools/i18n_audit.py --ci origin/main`
- `git diff --check`

Swift/Xcode tooling is not installed in the Linux development environment, so Apple compilation and Swift tests could not be run locally.

## Checklist

- [ ] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`) — unavailable in this Linux environment
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Closes #1511
