### PR TITLE
Assert the migration chain has no holes

### DIFF
--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -911,7 +911,7 @@ abstract class WhoopDatabase : RoomDatabase() {
          * The consequence is bounded but real. There is deliberately no destructive fallback (see the
          * builder), so a hole makes Room throw on upgrade rather than silently rebuild — a loud failure for
          * every existing user on the version that ships it, and with `exportSchema=false` nothing catches
-         * it beforehand. [WhoopDatabaseMigrationChainTest] now does.
+         * it beforehand. Guarded by WhoopDatabaseMigrationChainTest.
          *
          * Starts at 2 -> 3 on purpose: v1 predates this regime and has no upgrade path, which is why the
          * test asserts NO HOLES up to [SCHEMA_VERSION] rather than coverage from 1.

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -899,6 +899,35 @@ abstract class WhoopDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Every migration the builder registers, as a VALUE rather than an argument list.
+         *
+         * It was previously spelled inline in `addMigrations(...)`, which meant nothing could check it. A
+         * migration could be written, tested and still left out of the chain: the focused tests assert a
+         * migration's SQL and its start/end versions, not that it is registered. Sabotaging the chain —
+         * removing an entry — left the whole suite green, and removing an OLDER entry did too, so this was
+         * a property of the suite rather than of any one change.
+         *
+         * The consequence is bounded but real. There is deliberately no destructive fallback (see the
+         * builder), so a hole makes Room throw on upgrade rather than silently rebuild — a loud failure for
+         * every existing user on the version that ships it, and with `exportSchema=false` nothing catches
+         * it beforehand. [WhoopDatabaseMigrationChainTest] now does.
+         *
+         * Starts at 2 -> 3 on purpose: v1 predates this regime and has no upgrade path, which is why the
+         * test asserts NO HOLES up to [SCHEMA_VERSION] rather than coverage from 1.
+         */
+        internal val ALL_MIGRATIONS: Array<Migration> = arrayOf(
+            MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
+            MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10,
+            MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
+            MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18,
+            MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
+            MIGRATION_22_23, MIGRATION_23_24, MIGRATION_24_25, MIGRATION_25_26,
+            MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30,
+            MIGRATION_30_31, MIGRATION_31_32, MIGRATION_32_33,
+        )
+
+
         private fun build(appContext: Context): WhoopDatabase =
             Room.databaseBuilder(appContext, WhoopDatabase::class.java, DB_NAME)
                 // #1014: replace ONLY the corruption handling of the default open-helper. The
@@ -909,16 +938,7 @@ abstract class WhoopDatabase : RoomDatabase() {
                 // Real additive migration, NO destructive fallback (see the class doc): with
                 // exportSchema=false a silent rebuild would lose already-acked, non-resendable strap
                 // history on any schema mismatch. Room throws loudly instead; CI guards the SQL.
-                .addMigrations(
-                    MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
-                    MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10,
-                    MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14,
-                    MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18,
-                    MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
-                    MIGRATION_22_23, MIGRATION_23_24, MIGRATION_24_25, MIGRATION_25_26,
-                    MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30,
-                    MIGRATION_30_31, MIGRATION_31_32, MIGRATION_32_33,
-                )
+                .addMigrations(*ALL_MIGRATIONS)
                 // #1037: a FRESH install builds the schema straight at the current version and runs NO
                 // migrations, so the MIGRATION_7_8 "my-whoop" registry seed never fires and the WHOOP,
                 // though paired and streaming fine, never appears in the Devices list. Seed the canonical

--- a/android/app/src/test/java/com/noop/data/WhoopDatabaseMigrationChainTest.kt
+++ b/android/app/src/test/java/com/noop/data/WhoopDatabaseMigrationChainTest.kt
@@ -1,0 +1,71 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The registered migration chain must have no holes and must reach [WhoopDatabase.SCHEMA_VERSION].
+ *
+ * The existing migration tests each assert one migration's SQL and its start/end versions. None of them
+ * asserts that it is REGISTERED, so a migration could be written, tested, reviewed and still left out of
+ * `addMigrations(...)`. Sabotage confirmed it: removing an entry from the chain left the whole suite
+ * green, and removing an OLDER entry did too — this was a property of the suite, not of any one change.
+ *
+ * The consequence is bounded but real. There is deliberately no destructive fallback, so a hole makes
+ * Room throw on upgrade rather than silently rebuild — a loud failure for every existing user on the
+ * version that ships it. With `exportSchema=false` nothing else catches it first.
+ *
+ * Android-only by nature: GRDB registers migrations by name in one sequential `migrator` block, so a
+ * Swift migration cannot be declared-but-unregistered the way a Room one can.
+ */
+class WhoopDatabaseMigrationChainTest {
+
+    private val chain = WhoopDatabase.ALL_MIGRATIONS.sortedBy { it.startVersion }
+
+    /** Every step must advance, and no two may start from the same version. */
+    @Test
+    fun eachMigrationAdvancesAndNoTwoStartFromTheSameVersion() {
+        for (m in chain) {
+            assertTrue("migration ${m.startVersion}->${m.endVersion} does not advance",
+                       m.endVersion > m.startVersion)
+        }
+        val starts = chain.map { it.startVersion }
+        assertEquals("two migrations start from the same version: $starts",
+                     starts.size, starts.toSet().size)
+    }
+
+    /**
+     * No holes. Walk the chain from its lowest start version and require each migration to begin exactly
+     * where the previous one ended.
+     *
+     * Deliberately anchored to the chain's own lowest version rather than 1: v1 predates this regime and
+     * has no upgrade path, so asserting coverage from 1 would be asserting something untrue.
+     */
+    @Test
+    fun theChainHasNoHoles() {
+        assertTrue("no migrations registered at all", chain.isNotEmpty())
+        var reached = chain.first().startVersion
+        for (m in chain) {
+            assertEquals(
+                "hole in the migration chain: nothing upgrades $reached -> ${m.startVersion}",
+                reached, m.startVersion,
+            )
+            reached = m.endVersion
+        }
+    }
+
+    /**
+     * The chain must end exactly at the database's declared version.
+     *
+     * Catches the other half of the mistake: bumping [WhoopDatabase.SCHEMA_VERSION] and forgetting the
+     * migration, which fails the same way on upgrade.
+     */
+    @Test
+    fun theChainReachesTheDeclaredSchemaVersion() {
+        assertEquals(
+            "chain ends at ${chain.last().endVersion} but SCHEMA_VERSION is ${WhoopDatabase.SCHEMA_VERSION}",
+            WhoopDatabase.SCHEMA_VERSION, chain.last().endVersion,
+        )
+    }
+}

--- a/android/app/src/test/java/com/noop/data/WhoopDatabaseMigrationChainTest.kt
+++ b/android/app/src/test/java/com/noop/data/WhoopDatabaseMigrationChainTest.kt
@@ -63,6 +63,10 @@ class WhoopDatabaseMigrationChainTest {
      */
     @Test
     fun theChainReachesTheDeclaredSchemaVersion() {
+        // Guarded like theChainHasNoHoles: an empty chain should fail with this message rather than
+        // throw NoSuchElementException out of last(), which reads as a broken test rather than a
+        // broken chain — and an empty chain is exactly the catastrophic case worth naming clearly.
+        assertTrue("no migrations registered at all", chain.isNotEmpty())
         assertEquals(
             "chain ends at ${chain.last().endVersion} but SCHEMA_VERSION is ${WhoopDatabase.SCHEMA_VERSION}",
             WhoopDatabase.SCHEMA_VERSION, chain.last().endVersion,


### PR DESCRIPTION
Follow-up to #1583 (@kvnloo). Found by independently repeating their RED/GREEN sabotage rather than
taking it on trust.

## The gap

**A migration could be written, tested, reviewed — and never registered.** Removing `MIGRATION_32_33`
from `addMigrations(...)` left the entire suite green. Removing an *older* entry did too, so this was a
property of the whole migration suite, not anything #1583 introduced. That's why it wasn't held
against them.

The focused tests each assert one migration's SQL and its start/end versions. None asserted it was in
the chain — and the chain was spelled inline in the builder, where no test could reach it.

## Why it matters, precisely

Bounded, but real. There is deliberately **no destructive fallback** (`WhoopDatabase`: *"a silent
rebuild would lose already-acked, non-resendable strap history"*), so a hole makes Room **throw on
upgrade** rather than quietly wipe. That's the good failure mode — but it's still a launch failure for
every existing user on the version that ships it, and with `exportSchema=false` nothing catches it
first.

## The change

The chain becomes `ALL_MIGRATIONS`, a value the builder splats, with three assertions over it:

| assertion | catches |
|---|---|
| every step advances, no two share a start version | a duplicated or reversed migration |
| **no holes** | a migration written but not registered |
| chain ends exactly at `SCHEMA_VERSION` | the mirror-image slip — bumping the version, forgetting the migration |

**Anchored to the chain's own lowest version, not 1.** v1 predates this regime and has no upgrade
path, so asserting coverage from 1 would be asserting something untrue.

## Verified it bites

Both sabotage cases now fail, each on the assertion that should catch it:

```
drop the newest migration  -> theChainReachesTheDeclaredSchemaVersion FAILED
drop a middle migration    -> theChainHasNoHoles FAILED
```

## Parity

**Android-only by nature.** GRDB registers migrations by name in one sequential `migrator` block, so a
Swift migration cannot be declared-but-unregistered the way a Room one can — the declaration *is* the
registration. No twin to write.

## Verification

- Full Android suite: **4297 tests, 0 failures**. `doc_comment_lint.py` clean.
- No schema change, no behaviour change — the builder registers the identical 31 migrations, now via a
  named value instead of an argument list.
- No app-target Swift, so no app-build needed.
