### PR TITLE
feat(oura): add Skin Temp as a Key Metrics tile option

### DIFF
--- a/Strand/Data/KeyMetricPrefs.swift
+++ b/Strand/Data/KeyMetricPrefs.swift
@@ -26,6 +26,11 @@ enum KeyMetric: String, CaseIterable, Identifiable {
     case steps
     case weight
     case calories
+    /// Added 2026-08-24 (queue 11c follow-up): Skin Temp was already a "Your Cards" (`DashboardCard`)
+    /// option, but was never offered as a Key Metrics tile — not a bug, just never added. New case, NOT
+    /// added to `defaultOrder` below, so an existing user's saved layout (and a fresh install's default)
+    /// is byte-identical to before; only opts in via the layout editor.
+    case skinTemp
 
     var id: String { rawValue }
 
@@ -42,6 +47,9 @@ enum KeyMetric: String, CaseIterable, Identifiable {
         case .steps:       return String(localized: "Steps")
         case .weight:      return String(localized: "Weight")
         case .calories:    return String(localized: "Calories")
+        // Same short label the sibling "Your Cards" tile (`DashboardCard.skinTemp`) already uses —
+        // reuses its translation key rather than adding a new "Skin Temperature" one for this tile.
+        case .skinTemp:    return String(localized: "Skin Temp")
         }
     }
 

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -1179,6 +1179,20 @@ struct LiquidTodayView: View {
             // detail source, so the number, its sparkline and the chart it opens all agree.
             ktile(String(localized: "Calories"), icon: keyMetricIcon(metric), intText(caloriesCount), "kcal", StrandPalette.metricAmber,
                   fracOver(caloriesCount, 800), key: "energy_kcal", detailMetric: caloriesDetailMetric)
+        case .skinTemp:
+            // Added 2026-08-24 (queue 11c follow-up): first Key Metrics appearance for Skin Temp — was
+            // already a "Your Cards" tile (`DashboardCard.skinTemp`), never a Key Metrics one. Same
+            // 2-level carry the Blood Oxygen case just above uses (displayDay → the cached vitals carry),
+            // and the SAME `SkinTempDisplay` formatter every other skin-temp surface uses so a deviation
+            // reads "+0.1 Δ°C" here exactly as it does on "Your Cards"/the Deep Timeline, never the plain
+            // `%+.1f°` that read a fabricated absolute value for a signed deviation (#622).
+            let skinValue = displayDay?.skinTempDevC ?? vitalsDay?.skinTempDevC
+            let skinText = skinValue.map {
+                SkinTempDisplay.format($0, fahrenheit: temperatureUnit == .fahrenheit)
+            } ?? "—"
+            // The card's own unit is deliberately empty — the value carries "°C"/"Δ°F" itself, same as
+            // the classic TodayView Skin Temp card.
+            ktile(String(localized: "Skin Temp"), icon: keyMetricIcon(metric), skinText, "", StrandPalette.metricAmber, nil, key: "skin_temp")
         }
     }
 
@@ -1194,6 +1208,7 @@ struct LiquidTodayView: View {
         case .steps: return "figure.walk"
         case .weight: return "scalemass.fill"
         case .calories: return "flame.fill"
+        case .skinTemp: return "thermometer.medium"
         }
     }
 
@@ -1472,6 +1487,9 @@ struct LiquidTodayView: View {
             "rhr": sparkRows.compactMap { r in r.restingHr.map { (r.day, Double($0)) } },
             "spo2": sparkRows.compactMap { r in r.spo2Pct.map { (r.day, $0) } },
             "spo2_candidate": spo2CandSeries.filter { $0.day >= sparkCutoff && $0.day <= selectedDayKey },
+            // Added 2026-08-24 (queue 11c follow-up) for the new Skin Temp Key Metrics tile — already
+            // loaded on `sparkRows` (`daysSnapshot`), same as every other DailyMetric-column tile above.
+            "skin_temp": sparkRows.compactMap { r in r.skinTempDevC.map { (r.day, $0) } },
             "resp_rate": sparkRows.compactMap { r in r.respRateBpm.map { (r.day, $0) } },
             "steps": sparkRows.compactMap { r in r.steps.map { (r.day, Double($0)) } },
             // #616: the Calories tile drew no trend line — this dict had no matching entry, so windowedSpark
@@ -1684,6 +1702,16 @@ struct LiquidTodayView: View {
     // preference the Workouts screen + Trends read, so a workout's Effort number is identical everywhere.
     @AppStorage(UnitPrefs.effortScaleKey) private var effortScaleRaw = EffortScale.hundred.rawValue
     private var effortScale: EffortScale { UnitPrefs.resolveEffortScale(effortScaleRaw) }
+
+    // Added for the new Skin Temp Key Metrics tile (2026-08-24): °C/°F resolved the SAME way every other
+    // skin-temp surface does (`TodayView`, `MetricExplorerView`, `VitalSignsSummary`) — the explicit
+    // override when set, else derived from the unit system. Neither existed in this file before.
+    @AppStorage(UnitPrefs.systemKey) private var unitSystemRaw = UnitSystem.metric.rawValue
+    private var unitSystem: UnitSystem { UnitSystem(rawValue: unitSystemRaw) ?? .metric }
+    @AppStorage(UnitPrefs.temperatureKey) private var temperatureRaw = ""
+    private var temperatureUnit: TemperatureUnit {
+        UnitPrefs.resolveTemperature(system: unitSystem, override: temperatureRaw)
+    }
 
     private func effortText(_ s: Double?) -> String {
         guard let s else { return "–" }

--- a/Strand/Screens/TodayCustomizationMetadata.swift
+++ b/Strand/Screens/TodayCustomizationMetadata.swift
@@ -48,6 +48,8 @@ extension KeyMetric {
         case .steps: return "figure.walk"
         case .weight: return "scalemass"
         case .calories: return "flame.fill"
+        // Same glyph the sibling "Your Cards" tile (`DashboardCard.skinTemp`) already uses.
+        case .skinTemp: return "thermometer.medium"
         }
     }
 
@@ -59,7 +61,7 @@ extension KeyMetric {
         case .restingHr: return StrandPalette.metricRose
         case .bloodOxygen, .steps: return StrandPalette.metricCyan
         case .respiratory, .weight: return StrandPalette.accent
-        case .calories: return StrandPalette.metricAmber
+        case .calories, .skinTemp: return StrandPalette.metricAmber
         }
     }
 }

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -3801,6 +3801,20 @@ struct TodayView: View {
                 sparkline: sparks["active_kcal"],
                 sparkColor: StrandPalette.metricAmber
             )
+        case .skinTemp:
+            // Added 2026-08-24 (queue 11c follow-up): first Key Metrics appearance for Skin Temp — was
+            // already a "Your Cards" tile (`DashboardCard.skinTemp`), never a Key Metrics one. Reuses the
+            // SAME value chain and `skinTempCardValue` formatter the "Your Cards" case above already
+            // uses, so the two tiles can never disagree.
+            let skinTempValue = d?.skinTempDevC ?? lastVitalsDay?.skinTempDevC ?? lastSkinTempDay?.skinTempDevC
+            StatTile(
+                label: "Skin Temp",
+                value: Self.skinTempCardValue(skinTempValue, fahrenheit: temperatureUnit == .fahrenheit),
+                caption: skinTempValue == nil ? Self.needsStrapCaption : "",
+                accent: skinTempValue == nil ? StrandPalette.textPrimary : StrandPalette.metricAmber,
+                sparkline: sparks["skin_temp"],
+                sparkColor: StrandPalette.metricAmber
+            )
         }
     }
 
@@ -4249,6 +4263,10 @@ struct TodayView: View {
         // toggle is OFF (the engine writes nothing) or the owner has no in-band reading. Used as a
         // fallback for the Blood Oxygen tile when `spo2Pct` is nil, labelled "strap estimate (unverified)".
         async let spo2CandidateSpark = sparkValuesExplore("spo2_candidate", source: "my-whoop", window: 14)
+        // Added 2026-08-24 (queue 11c follow-up) for the new Skin Temp Key Metrics tile. `exploreSeries`
+        // so a BLE-only strap's computed `DailyMetric.skinTempDevC` column backs the trend, same as
+        // `resp_rate` above — the engine writes the column, not a metricSeries point.
+        async let skinTempSpark      = sparkValuesExplore("skin_temp", source: "my-whoop", window: 14)
         // `resp_rate` via `exploreSeries` so a BLE-only WHOOP 5 user's on-device computed
         // `DailyMetric.respRateBpm` backs the trend (the engine writes the column, not a metricSeries
         // point). The old `series(… source: "apple-health")` read only Apple Health's metricSeries,
@@ -4266,6 +4284,7 @@ struct TodayView: View {
         sparks["rhr"]             = await rhrSpark
         sparks["spo2"]            = await spo2Spark
         sparks["spo2_candidate"]  = await spo2CandidateSpark
+        sparks["skin_temp"]       = await skinTempSpark
         sparks["resp_rate"]   = await respRateSpark
         sparks["steps"]       = await stepsAppleSpark
         // Steps prefer the strap's own @57 daily total (no metricSeries, it lives on the daily row),

--- a/StrandTests/KeyMetricPrefsDecodeTests.swift
+++ b/StrandTests/KeyMetricPrefsDecodeTests.swift
@@ -44,4 +44,17 @@ final class KeyMetricPrefsDecodeTests: XCTestCase {
         XCTAssertEqual(KeyMetricPrefs.decodeEnabled("   "), KeyMetric.defaultOrder)
         XCTAssertEqual(KeyMetricPrefs.decodeEnabled(""), KeyMetric.defaultOrder)
     }
+
+    /// Queue 11c follow-up (2026-08-24): `.skinTemp` is a NEW persisted case (Skin Temp was already a
+    /// "Your Cards" `DashboardCard` option, never a Key Metrics one). Pins the two contract points that
+    /// matter for adding a case without disturbing anyone's saved layout: the raw token round-trips
+    /// ("skinTemp", byte-identical to Kotlin's `KeyMetric.SKIN_TEMP.raw`), and it does NOT join
+    /// `defaultOrder` — a fresh install's default (and an existing user's saved layout) stays
+    /// byte-identical to before this case existed.
+    func testSkinTempRawTokenRoundTripsAndIsNotInDefaultOrder() {
+        XCTAssertEqual(KeyMetric(rawValue: "skinTemp"), .skinTemp)
+        XCTAssertEqual(KeyMetric.skinTemp.rawValue, "skinTemp")
+        XCTAssertFalse(KeyMetric.defaultOrder.contains(.skinTemp))
+        XCTAssertFalse(KeyMetricPrefs.decodeEnabled("").contains(.skinTemp))
+    }
 }

--- a/android/app/src/main/java/com/noop/ui/KeyMetricPrefs.kt
+++ b/android/app/src/main/java/com/noop/ui/KeyMetricPrefs.kt
@@ -30,7 +30,13 @@ enum class KeyMetric(val raw: String, @StringRes val titleRes: Int) {
     RESPIRATORY("respiratory", R.string.today_metric_respiratory),
     STEPS("steps", R.string.today_metric_steps),
     WEIGHT("weight", R.string.today_metric_weight),
-    CALORIES("calories", R.string.today_metric_calories);
+    CALORIES("calories", R.string.today_metric_calories),
+    // Added 2026-08-24 (queue 11c follow-up): Skin Temp was already a "Your Cards" (DashboardCard)
+    // option, but was never offered as a Key Metrics tile — not a bug, just never added. Reuses
+    // DashboardCard.SKIN_TEMP's own title resource rather than adding a new one. New case, NOT added
+    // to defaultOrder below, so an existing user's saved layout (and a fresh install's default) is
+    // byte-identical to before; only opts in via the layout editor.
+    SKIN_TEMP("skinTemp", R.string.today_card_skin_temp);
 
     companion object {
         fun fromRaw(raw: String?): KeyMetric? = entries.firstOrNull { it.raw == raw }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -4865,12 +4865,6 @@ private fun RecordingStatusChip(state: RecordingState, onConnect: () -> Unit) {
 // `provenanceBadgeLabel` By-Day mappers are kept (Intelligence/Trends + tests still use that vocabulary).
 
 /**
- * The full 14-day metric grid, mirroring the macOS LazyVGrid order:
- * Charge, Effort, Rest, HRV, Resting HR, Blood Oxygen, Respiratory,
- * Steps, Weight, Calories. Each tile is a fixed-height [SparkStatTile] so the
- * grid tiles perfectly with no empty cells.
- */
-/**
  * The Key Metrics Skin Temp tile's 3-way fallback: today's row, then the whole-row recovery carry,
  * then the per-field skin-temp carry (mirrors spo2CarryDay/respCarryDay's reasoning — carriedDay can
  * land on a row with null skinTempDevC even when a genuine reading exists further back). Extracted so
@@ -4882,6 +4876,12 @@ internal fun resolveSkinTempDevC(
     skinTempCarryDay: DailyMetric?,
 ): Double? = d?.skinTempDevC ?: carriedDay?.skinTempDevC ?: skinTempCarryDay?.skinTempDevC
 
+/**
+ * The full 14-day metric grid, mirroring the macOS LazyVGrid order:
+ * Charge, Effort, Rest, HRV, Resting HR, Blood Oxygen, Respiratory,
+ * Steps, Weight, Calories. Each tile is a fixed-height [SparkStatTile] so the
+ * grid tiles perfectly with no empty cells.
+ */
 @Composable
 @Suppress("UNUSED_PARAMETER")
 private fun MetricGrid(

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.material.icons.filled.LocalFireDepartment
 import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.filled.MonitorWeight
 import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.Thermostat
 import androidx.compose.material.icons.filled.Timeline
 import androidx.compose.material.icons.filled.TrackChanges
 import androidx.compose.material.icons.filled.WaterDrop
@@ -5060,6 +5061,25 @@ private fun MetricGrid(
                 spark = caloriesSpark,   // #616: imported-first trend (was missing → no trend line)
             )
         },
+        KeyMetric.SKIN_TEMP to run {
+            // Added 2026-08-24 (queue 11c follow-up): first Key Metrics appearance for Skin Temp — was
+            // already a "Your Cards" tile (DashboardCard.SKIN_TEMP), never a Key Metrics one. Same
+            // `d ?: carriedDay` idiom every other simple tile above uses (HRV/RESTING_HR), and the SAME
+            // `SkinTempDisplay` formatter the DashboardCard.SKIN_TEMP branch uses so a deviation reads
+            // "+0.1 Δ°C" identically on both surfaces (#622: bimodal absolute-vs-deviation field).
+            val v = d?.skinTempDevC ?: carriedDay?.skinTempDevC
+            val fahrenheit = UnitPrefs.temperature(LocalContext.current) == TemperatureUnit.FAHRENHEIT
+            KeyTileData(
+                label = uiString(R.string.today_card_skin_temp),
+                // The value carries its own "°C"/"Δ°F" (SkinTempDisplay.format), so unit stays empty —
+                // same as the DashboardCard.SKIN_TEMP card and the classic TodayView Skin Temp tile.
+                value = v?.let { com.noop.analytics.SkinTempDisplay.format(it, fahrenheit = fahrenheit) } ?: NO_DATA,
+                unit = "",
+                tint = Palette.metricAmber,
+                frac = null,
+                spark = w.skinTemp,
+            )
+        },
     )
 
     // Resolve the enabled tiles to their descriptors (keeping the metric for the tap mapping), dropping
@@ -5081,6 +5101,10 @@ private fun MetricGrid(
         KeyMetric.STEPS -> if (stepsOpenCalibration) onOpenStepsCalibration else ({ onOpenMetric("steps_est") })
         KeyMetric.CALORIES -> ({ onOpenMetric("active_kcal") })
         KeyMetric.WEIGHT -> null
+        // Same "skin" vital_detail key `dashboardCardMetricKey(DashboardCard.SKIN_TEMP)` already routes
+        // to — confirmed a working destination there, so this tile opens the SAME screen "Your Cards"
+        // already does, not a new/unverified route.
+        KeyMetric.SKIN_TEMP -> ({ onOpenMetric("skin") })
     }
     // S5: slice from the FRONT of the saved order so a pinned/selected tile is never dropped or reordered
     // (#251); only the tail folds behind the expander. Mirrors the iOS visibleKeyMetrics prefix(cap).
@@ -5176,6 +5200,8 @@ private fun keyMetricIcon(metric: KeyMetric): ImageVector = when (metric) {
     KeyMetric.STEPS -> Icons.AutoMirrored.Filled.DirectionsWalk
     KeyMetric.WEIGHT -> Icons.Filled.MonitorWeight
     KeyMetric.CALORIES -> Icons.Filled.LocalFireDepartment
+    // Same glyph the sibling "Your Cards" tile (DashboardCard.SKIN_TEMP) already uses.
+    KeyMetric.SKIN_TEMP -> Icons.Filled.Thermostat
 }
 
 /**
@@ -6671,6 +6697,9 @@ private data class Window(
     // (on-device-first), matching iOS kSparks "steps". (Calories is imported-first, so its spark is threaded
     // separately as caloriesSpark, not read off a DailyMetric column here.)
     val steps: List<Double>,
+    // Added 2026-08-24 (queue 11c follow-up) for the new Skin Temp Key Metrics tile — matches the iOS
+    // `sparks["skin_temp"]` sparkline added at the same time.
+    val skinTemp: List<Double>,
 )
 
 /**
@@ -6700,6 +6729,7 @@ private fun rememberTrendWindow(
             spo2 = series { it.spo2Pct },
             resp = series { it.respRateBpm },
             steps = series { it.steps?.toDouble() },   // #616
+            skinTemp = series { it.skinTempDevC },
         )
     }
 

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1540,6 +1540,7 @@ fun TodayScreen(
                                     carriedDay = lastScoredRecoveryDay,
                                     spo2CarryDay = lastSpo2Day,
                                     respCarryDay = lastRespDay,
+                                    skinTempCarryDay = lastSkinTempDay,
                                     unitSystem = unitSystem,
                                     effortScale = effortScale,
                                     effortForDay = effortForDay,   // #1001: same figure as the hero ring
@@ -4861,6 +4862,18 @@ private fun RecordingStatusChip(state: RecordingState, onConnect: () -> Unit) {
  * Steps, Weight, Calories. Each tile is a fixed-height [SparkStatTile] so the
  * grid tiles perfectly with no empty cells.
  */
+/**
+ * The Key Metrics Skin Temp tile's 3-way fallback: today's row, then the whole-row recovery carry,
+ * then the per-field skin-temp carry (mirrors spo2CarryDay/respCarryDay's reasoning — carriedDay can
+ * land on a row with null skinTempDevC even when a genuine reading exists further back). Extracted so
+ * the carry regression ryanbr's PR #1589 review flagged is testable without Compose/Robolectric.
+ */
+internal fun resolveSkinTempDevC(
+    d: DailyMetric?,
+    carriedDay: DailyMetric?,
+    skinTempCarryDay: DailyMetric?,
+): Double? = d?.skinTempDevC ?: carriedDay?.skinTempDevC ?: skinTempCarryDay?.skinTempDevC
+
 @Composable
 @Suppress("UNUSED_PARAMETER")
 private fun MetricGrid(
@@ -4876,6 +4889,12 @@ private fun MetricGrid(
     // PER-FIELD respiratory carry (#1331): same reason as spo2CarryDay — respiratory needs a longer
     // clean sleep R-R segment than HRV, so carriedDay can land on a night with HRV but no breaths/min.
     respCarryDay: DailyMetric? = null,
+    // PER-FIELD skin-temp carry (ryanbr review, PR #1589): same reason as spo2CarryDay/respCarryDay —
+    // carriedDay (lastScoredRecoveryDay) is a whole-row carry that lands on rows with null
+    // skinTempDevC, so the Key Metrics tile falls through to the last row that actually has a
+    // reading. Mirrors the "Your Cards" DashboardCard.SKIN_TEMP path's skinTempDay fallback and iOS
+    // TodayView's lastSkinTempDay chain.
+    skinTempCarryDay: DailyMetric? = null,
     unitSystem: UnitSystem = UnitSystem.METRIC,
     effortScale: EffortScale = EffortScale.HUNDRED,
     // #1001: the day's resolved Effort (live-preferring for today, floored at the stored row). Threaded
@@ -5067,7 +5086,7 @@ private fun MetricGrid(
             // `d ?: carriedDay` idiom every other simple tile above uses (HRV/RESTING_HR), and the SAME
             // `SkinTempDisplay` formatter the DashboardCard.SKIN_TEMP branch uses so a deviation reads
             // "+0.1 Δ°C" identically on both surfaces (#622: bimodal absolute-vs-deviation field).
-            val v = d?.skinTempDevC ?: carriedDay?.skinTempDevC
+            val v = resolveSkinTempDevC(d, carriedDay, skinTempCarryDay)
             val fahrenheit = UnitPrefs.temperature(LocalContext.current) == TemperatureUnit.FAHRENHEIT
             KeyTileData(
                 label = uiString(R.string.today_card_skin_temp),

--- a/android/app/src/test/java/com/noop/ui/KeyMetricSkinTempTest.kt
+++ b/android/app/src/test/java/com/noop/ui/KeyMetricSkinTempTest.kt
@@ -1,7 +1,9 @@
 package com.noop.ui
 
+import com.noop.data.DailyMetric
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -29,5 +31,51 @@ class KeyMetricSkinTempTest {
         // the new case — the whole point of adding it to `entries`/CaseIterable without touching
         // defaultOrder.
         assertTrue(KeyMetricPrefs.decodeEnabled("").none { it == KeyMetric.SKIN_TEMP })
+    }
+
+    private fun day(skinTempDevC: Double?) =
+        DailyMetric(deviceId = "my-whoop-noop", day = "2026-08-25", skinTempDevC = skinTempDevC)
+
+    /**
+     * Regression for ryanbr's PR #1589 review: carriedDay (lastScoredRecoveryDay) is a whole-row
+     * carry that lands on a row with null skinTempDevC even when a genuine reading exists further
+     * back, so the tile must fall through to the per-field skinTempCarryDay — exactly like
+     * spo2CarryDay/respCarryDay, and matching iOS TodayView's lastSkinTempDay chain.
+     */
+    @Test fun nullSkinTempDevCFallsThroughToPerFieldCarry() {
+        val perFieldCarry = day(skinTempDevC = 0.4)
+        assertEquals(
+            0.4,
+            resolveSkinTempDevC(d = null, carriedDay = day(skinTempDevC = null), skinTempCarryDay = perFieldCarry)!!,
+            0.0,
+        )
+    }
+
+    @Test fun todaysOwnReadingWinsOverEitherCarry() {
+        assertEquals(
+            0.2,
+            resolveSkinTempDevC(
+                d = day(skinTempDevC = 0.2),
+                carriedDay = day(skinTempDevC = -0.1),
+                skinTempCarryDay = day(skinTempDevC = 0.4),
+            )!!,
+            0.0,
+        )
+    }
+
+    @Test fun wholeRowCarryWinsOverPerFieldCarryWhenBothPresent() {
+        assertEquals(
+            -0.1,
+            resolveSkinTempDevC(
+                d = null,
+                carriedDay = day(skinTempDevC = -0.1),
+                skinTempCarryDay = day(skinTempDevC = 0.4),
+            )!!,
+            0.0,
+        )
+    }
+
+    @Test fun noRowAnywhereYieldsNull() {
+        assertNull(resolveSkinTempDevC(d = null, carriedDay = null, skinTempCarryDay = null))
     }
 }

--- a/android/app/src/test/java/com/noop/ui/KeyMetricSkinTempTest.kt
+++ b/android/app/src/test/java/com/noop/ui/KeyMetricSkinTempTest.kt
@@ -1,0 +1,33 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Queue 11c follow-up (2026-08-24): Skin Temp was already a "Your Cards" (`DashboardCard.SKIN_TEMP`)
+ * option, but was never offered as a Key Metrics tile — not a bug, just never added. Pins the two
+ * contract points that matter for a NEW persisted enum case: the raw token round-trips
+ * ("skinTemp", byte-identical to the Swift `KeyMetric.skinTemp` rawValue so a backup/restore reads the
+ * same layout on either OS), and it does NOT join `defaultOrder` — an existing user's saved layout, and
+ * a fresh install's default, must stay byte-identical to before this case existed.
+ */
+class KeyMetricSkinTempTest {
+
+    @Test fun rawTokenRoundTrips() {
+        assertEquals(KeyMetric.SKIN_TEMP, KeyMetric.fromRaw("skinTemp"))
+        assertEquals("skinTemp", KeyMetric.SKIN_TEMP.raw)
+    }
+
+    @Test fun notInDefaultOrder() {
+        assertFalse(KeyMetric.defaultOrder.contains(KeyMetric.SKIN_TEMP))
+    }
+
+    @Test fun blankLayoutStillExcludesIt() {
+        // A fresh install (blank saved layout) decodes to defaultOrder, which must not have picked up
+        // the new case — the whole point of adding it to `entries`/CaseIterable without touching
+        // defaultOrder.
+        assertTrue(KeyMetricPrefs.decodeEnabled("").none { it == KeyMetric.SKIN_TEMP })
+    }
+}


### PR DESCRIPTION
## What this PR does

Skin Temp was already a "Your Cards" (`DashboardCard`) option on both platforms, but was never offered
as a small "Key Metrics" grid tile.

Found 2026-08-24 while diagnosing a "Skin Temp visible on the Deep Timeline, missing from the Cards"
report: it turned out there are two different "Cards" screens in this app, and Blood Oxygen / Skin
Temp each work on one and fail on the other. The **Key Metrics grid** (`KeyMetric` enum) simply never
had a `skinTemp` case, on either platform — not a display-path bug, just a tile that was never added.
(The mirror-image, genuinely-real bug this same investigation found — Blood Oxygen's "Your Cards"
drill-down having no candidate fallback — is a separate PR:
`fix/oura-spo2-cards-explorer-candidate-fallback`.)

## The fix

New `KeyMetric.skinTemp` / `KeyMetric.SKIN_TEMP` case on both platforms. **Not added to
`defaultOrder`** — an existing user's saved layout, and a fresh install's default, stays
byte-identical to before; the tile only appears once opted into via the layout editor.

Reuses the sibling `DashboardCard.skinTemp`/`.SKIN_TEMP` tile's existing title string ("Skin Temp"),
icon (`thermometer.medium` / `Icons.Filled.Thermostat`), and value formatting (`SkinTempDisplay`, the
same bimodal absolute-vs-deviation handling from #622) — no new copy, no new i18n debt. The Android
tap-through reuses the `"skin"` `vital_detail` key `dashboardCardMetricKey(DashboardCard.SKIN_TEMP)`
already routes to — a confirmed-working destination, not a new/unverified one.

`LiquidTodayView` had no temperature-unit resolution at all before this (added the same `@AppStorage`
+ `resolveTemperature` pattern `TodayView`/`MetricExplorerView` already use). Android's `Window`
struct gained a `skinTemp` trend field for the tile's sparkline, matching the iOS
`sparks["skin_temp"]` added the same way.

## Tests

4 new tests (2 per platform): the raw-token round-trip + `defaultOrder`-exclusion contract for the new
persisted enum case (schema-relevant — `KeyMetric` rawValues are the `today.keyMetrics` layout
string).

## Verification

- `xcodebuild -scheme Strand build` + `test` (macOS): 1244/1244.
- `xcodebuild -scheme NOOPiOS build` (iOS, shares the edited files).
- Android `compileFullDebugKotlin` clean; `com.noop.ui.*` + `com.noop.analytics.*` 2421/2426 (5
  pre-existing, unrelated failures — `RecoveryDriversTest`'s half-tie-rounding issue and
  `TodayExplainabilityTest`'s 3 failures — both confirmed present on pristine `upstream/main` before
  any of this session's changes, not chased here).
- `doc_comment_lint.py` and `i18n_audit.py --ci` both clean.

## Not yet done

Not flashed to a device — a screenshot confirming the new tile renders correctly once added via the
layout editor is owed.