### PR TITLE
fix(oura): SpO2 candidate fallback missing from the "Your Cards"

### DIFF
--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -815,10 +815,24 @@ struct MetricDetailView: View {
         // WHOOP-4.0-only install with the toggle ON saw a real number on the tile but an empty/stale
         // screen here). Calibrated days always win — this only ADDS days the calibrated series is
         // missing, never overwrites one. Gated on the same toggle every other candidate site checks.
-        if metric.key == "spo2", PuffinExperiment.spo2CandidateDisplayEnabled {
+        //
+        // The source is part of the gate, not just the key. The catalog carries TWO `spo2` descriptors —
+        // `my-whoop` and `xiaomi-band` — and `MetricDescriptor.id` is `source + ":" + key`, so they are
+        // different metrics that happen to share a key. Only the WHOOP/Oura partition has a candidate
+        // series behind it; without this a Xiaomi Band's Blood Oxygen card would be asking for a strap
+        // estimate that is not its own.
+        if metric.key == "spo2", metric.source == "my-whoop", PuffinExperiment.spo2CandidateDisplayEnabled {
             let candidateSeries = await repo.exploreSeries(key: "spo2_candidate", source: metric.source)
             if !candidateSeries.isEmpty {
-                var byDay = Dictionary(uniqueKeysWithValues: series.map { ($0.day, $0.value) })
+                // `uniquingKeysWith`, matching the `sourceByDay` build above — NOT
+                // `uniqueKeysWithValues`, which TRAPS on a duplicate day. `exploreSeries` collapses by day
+                // on the `my-whoop` path it takes here, but `series(key:source:)` — the path every other
+                // source falls through to — ends `pts.map { … }` with no collapsing at all, so the
+                // guarantee is the caller's, not the type's. The Kotlin twin uses `.toMap()`, which keeps
+                // the last value silently; a trap here would mean the same input crashes one platform and
+                // not the other.
+                var byDay = Dictionary(series.map { ($0.day, $0.value) },
+                                       uniquingKeysWith: { first, _ in first })
                 for point in candidateSeries where byDay[point.day] == nil {
                     byDay[point.day] = point.value
                     sourceByDay[point.day] = spo2CandidateAttributionSource

--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -165,6 +165,17 @@ struct VitalReading: Equatable {
 
 let vo2MaxAttributionPrefix = "vo2max-estimator:"
 
+/// #103/queue-11a follow-up: a display-source token for a `spo2` reading that came from the
+/// `spo2_candidate` fallback (WHOOP `spo2_candidate_82` or Oura ceiling@100 `0x6F`, device-conditional)
+/// rather than a calibrated `spo2Pct` import. Every OTHER surface that shows this fallback (Today's Key
+/// Metrics tile, `VitalSignsSummary`, `LiquidTodayView`) already labels it "strap estimate (unverified)"
+/// — this Explorer/"Your Cards" drill-down had no candidate fallback at all until now (found 2026-08-24:
+/// an Oura-only or WHOOP-4.0-only install with the toggle ON saw nothing here past the last calibrated
+/// import, even though the Key Metrics tile right next to it showed a real number). Same
+/// prefix-token idiom as `vo2MaxAttributionSource` just below, so the existing readings-table plumbing
+/// needs no new machinery — only `TodayView.provenanceDisplayLabel` gains one more case.
+let spo2CandidateAttributionSource = "spo2-candidate-estimate"
+
 /// A display-source token that keeps the existing readings-table plumbing while naming the estimator.
 /// `nil` is deliberately preserved as `unknown`; a legacy point must never inherit today's profile method.
 func vo2MaxAttributionSource(_ estimator: Vo2MaxEstimator?) -> String {
@@ -796,6 +807,24 @@ struct MetricDetailView: View {
         } else {
             sourceByDay = Dictionary(resolution.points.map { ($0.day, $0.source) },
                                      uniquingKeysWith: { first, _ in first })
+        }
+        // #103/queue-11a follow-up: fill in the spo2 candidate fallback for any day this Explorer's
+        // calibrated `spo2` series has no reading for — the SAME fallback Today's Key Metrics tile,
+        // `VitalSignsSummary`, and `LiquidTodayView` already show, which this generic catalog-driven
+        // screen never got when #1568 added it everywhere else (found 2026-08-24: an Oura-only or
+        // WHOOP-4.0-only install with the toggle ON saw a real number on the tile but an empty/stale
+        // screen here). Calibrated days always win — this only ADDS days the calibrated series is
+        // missing, never overwrites one. Gated on the same toggle every other candidate site checks.
+        if metric.key == "spo2", PuffinExperiment.spo2CandidateDisplayEnabled {
+            let candidateSeries = await repo.exploreSeries(key: "spo2_candidate", source: metric.source)
+            if !candidateSeries.isEmpty {
+                var byDay = Dictionary(uniqueKeysWithValues: series.map { ($0.day, $0.value) })
+                for point in candidateSeries where byDay[point.day] == nil {
+                    byDay[point.day] = point.value
+                    sourceByDay[point.day] = spo2CandidateAttributionSource
+                }
+                series = byDay.sorted { $0.key < $1.key }.map { (day: $0.key, value: $0.value) }
+            }
         }
         // #943 selection seam: a locked default (.month with under a week of history) no longer
         // OVERWRITES @State range - it renders through `coercedSelection` instead (non-destructive,

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -811,6 +811,13 @@ struct TodayView: View {
             let method = vo2MaxEstimatorDisplayName(Vo2MaxEstimator(rawValue: raw))
             return "\(String(localized: "On-device")) · \(method)"
         }
+        // #103/queue-11a follow-up: the Explorer's spo2 candidate-fallback rows (see
+        // `spo2CandidateAttributionSource`) must read "strap estimate (unverified)", the SAME copy every
+        // other candidate-fallback surface uses — never a device name, which would misrepresent an
+        // unvalidated estimate as a calibrated reading in this table's Source column.
+        if rawSource == spo2CandidateAttributionSource {
+            return String(localized: "strap estimate (unverified)")
+        }
         if rawSource.hasSuffix("-noop") { return String(localized: "On-device") }
         if rawSource == deviceId || rawSource == Repository.whoopSource { return Self.whoopBrandName }
         if rawSource == Repository.appleHealthSource { return "Apple Health" }

--- a/StrandTests/VitalReadingsTableTests.swift
+++ b/StrandTests/VitalReadingsTableTests.swift
@@ -57,6 +57,18 @@ final class VitalReadingsTableTests: XCTestCase {
         XCTAssertEqual(rows.first?.source, "On-device")
     }
 
+    /// #103/queue-11a follow-up: a spo2 candidate-fallback row (see `spo2CandidateAttributionSource`)
+    /// must resolve to "strap estimate (unverified)" — the SAME caption every other candidate-fallback
+    /// surface uses — never a device name, which would misrepresent an unvalidated estimate as a
+    /// calibrated reading.
+    func testSpo2CandidateSourceReadsStrapEstimateUnverified() {
+        let rows = vitalReadingRows(
+            readings: [VitalReading(day: "2026-08-24", value: 97, source: spo2CandidateAttributionSource)],
+            unit: "%", strapDeviceId: strap, now: now, format: spo2Format
+        )
+        XCTAssertEqual(rows.first?.source, "strap estimate (unverified)")
+    }
+
     func testValueReusesModelFormatAndUnit() {
         // The row value is the model's own formatter applied to the reading, with the unit appended —
         // 41.7 ms formats (%.0f) to "42 ms".

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1750,6 +1750,10 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
     val tempUnit = UnitPrefs.temperature(context)
     // The Effort detail renders per the user's Effort display scale (0-100 vs 0-21), like the Today tile.
     val effortScale = UnitPrefs.effortScale(context)
+    // #103/queue-11a follow-up: same reactive source the Key Metrics tile already collects (empty when
+    // the toggle is OFF, since the engine writes nothing) — reused here so this screen's spo2 candidate
+    // fallback (in buildVitalDetail) stays in sync with the tile it drills in from.
+    val spo2CandidateByDay by vm.spo2CandidateByDay.collectAsStateWithLifecycle()
     // Profile drives the Fitness Age readiness/countdown shown when that vital has no value yet.
     val profile = remember { ProfileStore.from(context.applicationContext) }
     val isSeriesBacked = key in SERIES_BACKED_VITAL_KEYS
@@ -1770,7 +1774,9 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
         }
     }
     val detail = if (isSeriesBacked) seriesDetail
-    else remember(days, key, tempUnit, effortScale) { buildVitalDetail(days, key, tempUnit, effortScale) }
+    else remember(days, key, tempUnit, effortScale, spo2CandidateByDay) {
+        buildVitalDetail(days, key, tempUnit, effortScale, spo2CandidateByDay)
+    }
     var range by remember { mutableStateOf(VitalDetailRange.MONTH) }
 
     // The subtitle tracks how much history the metric has, so we never promise a "historical trend" the
@@ -2053,6 +2059,7 @@ private fun buildVitalDetail(
     key: String,
     tempUnit: TemperatureUnit,
     effortScale: EffortScale = EffortScale.HUNDRED,
+    spo2CandidateByDay: Map<String, Double> = emptyMap(),
 ): VitalDetailModel? {
     return when (key) {
     // The Today Key-Metrics Recovery tile's drill-in: the Recovery (Charge) trend timeline, matching the
@@ -2083,14 +2090,25 @@ private fun buildVitalDetail(
         readings = days.mapNotNull { row -> row.respRateBpm?.let { VitalReading(row.day, it, row.deviceId) } },
         format = { String.format(Locale.US, "%.1f", it) },
     )
-    "spo2" -> VitalDetailModel(
-        key = key,
-        title = uiString(R.string.l10n_health_screen_blood_oxygen_a8ad9ff5),
-        unit = "%",
-        color = Palette.metricCyan,
-        readings = days.mapNotNull { row -> row.spo2Pct?.let { VitalReading(row.day, it, row.deviceId) } },
-        format = { String.format(Locale.US, "%.0f", it) },
-    )
+    "spo2" -> {
+        // #103/queue-11a follow-up: fill in the spo2 candidate fallback for any day with no calibrated
+        // spo2Pct — the SAME fallback the Key Metrics tile already shows (found 2026-08-24: an
+        // Oura-only or WHOOP-4.0-only install with the toggle ON saw a real number on the tile but an
+        // empty/stale screen here, since this branch never got #1568's candidate wiring). Calibrated
+        // days always win; this only ADDS days the calibrated column is missing, never overwrites one.
+        val calibrated = days.mapNotNull { row -> row.spo2Pct?.let { row.day to VitalReading(row.day, it, row.deviceId) } }.toMap()
+        val candidateOnly = spo2CandidateByDay
+            .filterKeys { it !in calibrated }
+            .map { (day, value) -> day to VitalReading(day, value, SPO2_CANDIDATE_ATTRIBUTION_SOURCE) }
+        VitalDetailModel(
+            key = key,
+            title = uiString(R.string.l10n_health_screen_blood_oxygen_a8ad9ff5),
+            unit = "%",
+            color = Palette.metricCyan,
+            readings = (calibrated.values + candidateOnly.map { it.second }).sortedBy { it.day },
+            format = { String.format(Locale.US, "%.0f", it) },
+        )
+    }
     "rhr" -> VitalDetailModel(
         key = key,
         title = uiString(R.string.l10n_health_screen_resting_heart_rate_9700f4d8),

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -92,6 +92,8 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 import kotlin.math.roundToInt
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 // MARK: - Health Monitor (ported from Strand/Screens/HealthView.swift)
 //
@@ -1753,7 +1755,19 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
     // #103/queue-11a follow-up: same reactive source the Key Metrics tile already collects (empty when
     // the toggle is OFF, since the engine writes nothing) — reused here so this screen's spo2 candidate
     // fallback (in buildVitalDetail) stays in sync with the tile it drills in from.
-    val spo2CandidateByDay by vm.spo2CandidateByDay.collectAsStateWithLifecycle()
+    //
+    // The FLOW is swapped per metric, not the collect call. Only the Blood Oxygen detail reads this map,
+    // but this composable serves every vital, and subscribing the real flow runs a database union
+    // (`metricSeriesComputedUnion`) that Resting HR / HRV / Skin Temp would pay for and discard —
+    // `WhileSubscribed(5_000)` means arriving more than five seconds after the tile unsubscribed re-runs
+    // it, which is the normal Today → Health → tap path. Gating the CALL instead (`key == "spo2" && …`)
+    // would put a composable in a conditionally-evaluated position and corrupt the slot table when the
+    // key changes; swapping the flow keeps exactly one unconditional call site. It also keeps the
+    // `remember` below stable for every other vital, since the map is then a constant.
+    val candidateFlow: StateFlow<Map<String, Double>> = remember(key) {
+        if (key == "spo2") vm.spo2CandidateByDay else MutableStateFlow(emptyMap())
+    }
+    val spo2CandidateByDay by candidateFlow.collectAsStateWithLifecycle()
     // Profile drives the Fitness Age readiness/countdown shown when that vital has no value yet.
     val profile = remember { ProfileStore.from(context.applicationContext) }
     val isSeriesBacked = key in SERIES_BACKED_VITAL_KEYS

--- a/android/app/src/main/java/com/noop/ui/HealthVitalDetailLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalDetailLogic.kt
@@ -18,6 +18,18 @@ internal data class VitalReading(
 
 internal const val VO2_MAX_ATTRIBUTION_PREFIX = "vo2max-estimator:"
 
+/**
+ * #103/queue-11a follow-up: display-source token for a `spo2` reading that came from the
+ * `spo2_candidate` fallback (WHOOP `spo2_candidate_82` or Oura ceiling@100 `0x6F`, device-conditional)
+ * rather than a calibrated `spo2Pct` day. Every OTHER surface with this fallback (the Key Metrics tile
+ * via [vitalsFor]) already labels it via `R.string.spo2_strap_estimate_caption` — this vital-detail
+ * screen (`VitalDetailScreen`/"Your Cards" drill-in) had no candidate fallback at all until now (found
+ * 2026-08-24: an Oura-only or WHOOP-4.0-only install with the toggle ON saw a real number on the tile
+ * but nothing here past the last calibrated import). Same prefix-token idiom as
+ * [vo2MaxAttributionSource] just above.
+ */
+internal const val SPO2_CANDIDATE_ATTRIBUTION_SOURCE = "spo2-candidate-estimate"
+
 /** Display-source token for a VO₂max reading. A missing legacy tag stays unknown; it must never inherit
  *  the method implied by today's profile because the waist measurement may have changed after scoring. */
 internal fun vo2MaxAttributionSource(estimator: Vo2MaxEstimator?): String =

--- a/android/app/src/main/java/com/noop/ui/TodayProvenance.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayProvenance.kt
@@ -62,6 +62,13 @@ internal fun provenanceDisplayLabel(
         val raw = rawSource.removePrefix(VO2_MAX_ATTRIBUTION_PREFIX)
         return DisplayText.Resource(vo2MaxAttributionLabelRes(Vo2MaxEstimator.fromProvenanceId(raw)))
     }
+    // #103/queue-11a follow-up: the spo2 candidate-fallback rows in the vital-detail readings table
+    // (see [SPO2_CANDIDATE_ATTRIBUTION_SOURCE]) must read "strap estimate (unverified)" — the SAME
+    // string every other candidate-fallback surface uses — never a device name, which would
+    // misrepresent an unvalidated estimate as a calibrated reading in this table's Source column.
+    if (rawSource == SPO2_CANDIDATE_ATTRIBUTION_SOURCE) {
+        return DisplayText.Resource(R.string.spo2_strap_estimate_caption)
+    }
     if (rawSource.endsWith("-noop")) return DisplayText.Resource(R.string.today_source_on_device)
     if (rawSource == deviceId || rawSource == WhoopRepository.WHOOP_SOURCE) return DisplayText.Resource(R.string.today_source_whoop)
     if (rawSource == WhoopRepository.APPLE_HEALTH_SOURCE) return DisplayText.Resource(R.string.today_source_apple_health)

--- a/android/app/src/test/java/com/noop/ui/VitalReadingsTableTest.kt
+++ b/android/app/src/test/java/com/noop/ui/VitalReadingsTableTest.kt
@@ -66,6 +66,22 @@ class VitalReadingsTableTest {
         assertEquals(DisplayText.Resource(R.string.today_source_on_device), rows.single().source)
     }
 
+    /**
+     * #103/queue-11a follow-up: a spo2 candidate-fallback row (see [SPO2_CANDIDATE_ATTRIBUTION_SOURCE])
+     * must resolve to "strap estimate (unverified)" — the SAME caption every other candidate-fallback
+     * surface uses — never a device name, which would misrepresent an unvalidated estimate as a
+     * calibrated reading.
+     */
+    @Test fun spo2CandidateSourceReadsStrapEstimateUnverified() {
+        val rows = vitalReadingRows(
+            listOf(VitalReading("2026-08-24", 97.0, SPO2_CANDIDATE_ATTRIBUTION_SOURCE)),
+            "%",
+            strap,
+            spo2Format,
+        )
+        assertEquals(DisplayText.Resource(R.string.spo2_strap_estimate_caption), rows.single().source)
+    }
+
     @Test fun valueReusesModelFormatAndUnit() {
         // The row value is the model's own formatter applied to the reading, with the unit appended —
         // 41.7 ms rounds to "42 ms".


### PR DESCRIPTION
## What this PR does

`MetricExplorerView` (iOS/macOS) and `HealthScreen`'s `VitalDetailScreen` (Android) both drill into a
generic, catalog-driven detail page — the one with the chart, the WINDOW/POINTS/LATEST header, and the
readings table, reachable by tapping into "Your Cards". Unlike every other Blood Oxygen surface (the
Key Metrics tile, `VitalSignsSummary`, `LiquidTodayView`), this screen read only calibrated `spo2Pct`
with no `spo2_candidate` fallback at all — #1568 never touched it.

Found 2026-08-24 diagnosing a Patrick screenshot: an install with no calibrated SpO2 source (WHOOP 4.0
+ Oura, no 5/MG) showed a real candidate number (97%) on the Key Metrics tile, but the "Your Cards"
Blood Oxygen drill-down was empty/stale, frozen on the last day a calibrated import existed
(2026-07-30) — weeks earlier.

## The fix

Both platforms now merge in `spo2_candidate` for any day the calibrated series is missing — calibrated
always wins, this only ADDS days, never overwrites one — gated on the same
`spo2CandidateDisplayEnabled`/`spo2CandidateDisplay` toggle every other candidate site checks. Rows
sourced from the candidate are labelled "strap estimate (unverified)" in the readings table's Source
column via a new source-token idiom (`spo2CandidateAttributionSource` /
`SPO2_CANDIDATE_ATTRIBUTION_SOURCE`), mirroring the EXISTING `vo2max-estimator:` attribution pattern
exactly — no new plumbing, just one more case in `provenanceDisplayLabel` on each platform.

Reuses the already-fully-translated `spo2_strap_estimate_caption` string resource on Android and the
existing "strap estimate (unverified)" literal on Swift — no new i18n debt.

## Tests

2 new tests (one per platform) pin the new source label resolving to "strap estimate (unverified)",
matching the existing `VitalReadingsTableTest(s)` style.

## Verification

- `xcodebuild -scheme Strand build` (macOS app-target Swift — CI doesn't cover this) + `xcodebuild
  test` on the touched suite: 7/7.
- `xcodebuild -scheme NOOPiOS build` (iOS, shares the same edited files).
- Android `compileFullDebugKotlin` clean; `com.noop.ui.*` 767/767 minus 3 pre-existing
  `TodayExplainabilityTest` failures confirmed present on pristine `upstream/main` before this change
  (date-relative, unrelated, not chased).
- `doc_comment_lint.py` and `i18n_audit.py --ci` both clean — no new literals (the Kotlin string was
  already translated in all 4 focus locales).

## Not yet done

Not flashed to a device with the toggle on — that end-to-end capture is owed alongside the sibling
`fix/oura-spo2-candidate-mean-rounding` PR.