### PR TITLE
fix(oura): SpO2 candidate mean floors instead of rounds (Swift+Kotlin)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -1185,7 +1185,13 @@ public enum AnalyticsEngine {
     ///
     /// DIAGNOSTIC ONLY. Nothing scores this, it never writes `spo2Pct`, and it is not a blood-oxygen
     /// reading — it is the raw candidate averaged, surfaced so it can be checked against a real one.
-    /// Byte-parity twin of the Kotlin `nightlySpo2CandidateMean`.
+    ///
+    /// The mean is ROUNDED (`.rounded()`), not floored — `sum / kept` on two `Int`s truncates toward
+    /// zero, silently biasing every candidate down by up to 0.99 (e.g. a true 97.97 shipped as 97,
+    /// missing an app-displayed 98 the transform's own precise value would have round-matched). Every
+    /// value in range is positive (70...100), so round-half-up and round-half-away-from-zero agree —
+    /// no platform-divergence risk from the rounding rule itself. Byte-parity twin of the Kotlin
+    /// `nightlySpo2CandidateMean`.
     public static func nightlySpo2CandidateMean(_ sessions: [SleepSession],
                                          aux: [V18AuxSample]) -> (mean: Int, samples: Int)? {
         guard !sessions.isEmpty, !aux.isEmpty else { return nil }
@@ -1196,7 +1202,7 @@ public enum AnalyticsEngine {
             sum += v; kept += 1
         }
         guard kept > 0 else { return nil }
-        return (mean: sum / kept, samples: kept)
+        return (mean: Int((Double(sum) / Double(kept)).rounded()), samples: kept)
     }
 
     /// The plausible range for a raw Oura `0x6F` SpO2 sample before the ceiling transform below.
@@ -1225,7 +1231,14 @@ public enum AnalyticsEngine {
     ///
     /// Gated to `spo2SingleChannelPlausible` (50...110) BEFORE the ceiling is applied, so a
     /// contaminated row (down to -1016) cannot drag the mean down — the ceiling alone only guards
-    /// the top of the range. Byte-parity twin of the Kotlin `nightlySpo2CeilingMean`.
+    /// the top of the range.
+    ///
+    /// The mean is ROUNDED (`.rounded()`), not floored — same fix, same reasoning, as
+    /// `nightlySpo2CandidateMean` just above (found 2026-08-24 comparing a live-persisted 08-23/24
+    /// row against the Oura app: the transform's precise mean, 97.97, round-matched the app's 98%,
+    /// but the shipped `sum / kept` Int division floored it to 97, a spurious miss). All values here
+    /// are positive too, so the rounding-rule choice is again inert. Byte-parity twin of the Kotlin
+    /// `nightlySpo2CeilingMean`.
     public static func nightlySpo2CeilingMean(_ sessions: [SleepSession],
                                         spo2: [SpO2Sample]) -> (mean: Int, samples: Int)? {
         guard !sessions.isEmpty, !spo2.isEmpty else { return nil }
@@ -1236,7 +1249,7 @@ public enum AnalyticsEngine {
             sum += min(s.red, 100); kept += 1
         }
         guard kept > 0 else { return nil }
-        return (mean: sum / kept, samples: kept)
+        return (mean: Int((Double(sum) / Double(kept)).rounded()), samples: kept)
     }
 
     /// #1169 SHADOW METRIC: the primary-session MEAN resting HR — window each detected sleep session's HR

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Spo2CandidateNightlyTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Spo2CandidateNightlyTests.swift
@@ -65,6 +65,15 @@ final class Spo2CandidateNightlyTests: XCTestCase {
         XCTAssertEqual(r?.samples, 1)
     }
 
+    /// Found 2026-08-24 on the Oura twin (`nightlySpo2CeilingMean`) and fixed here too — same bug, same
+    /// helper shape. `sum / kept` on two `Int`s truncates toward zero; three samples averaging
+    /// 97.666... must round to 98, not floor to 97.
+    func testMeanRoundsRatherThanFloors() {
+        let r = AnalyticsEngine.nightlySpo2CandidateMean(
+            [session(1000, 600)], aux: [aux(1100, 98), aux(1200, 98), aux(1300, 97)])
+        XCTAssertEqual(r?.mean, 98, "97.666... must round to 98, not floor to 97")
+    }
+
     /// The boundaries are inclusive, matching the decoder's own `70...100` emit gate exactly.
     func testBandBoundariesMatchTheDecoderGate() {
         XCTAssertEqual(AnalyticsEngine.nightlySpo2CandidateMean(

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Spo2CeilingNightlyTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Spo2CeilingNightlyTests.swift
@@ -57,6 +57,16 @@ final class Spo2CeilingNightlyTests: XCTestCase {
         XCTAssertNil(AnalyticsEngine.nightlySpo2CeilingMean([session(1000, 600)], spo2: []))
     }
 
+    /// Found 2026-08-24 comparing a live-persisted row against the Oura app: `sum / kept` on two `Int`s
+    /// truncates toward zero, so a true 97.97 shipped as 97 — a spurious miss against an app-displayed
+    /// 98% the precise mean would have round-matched. Three samples averaging 97.666... must round to
+    /// 98, not floor to 97.
+    func testMeanRoundsRatherThanFloors() {
+        let r = AnalyticsEngine.nightlySpo2CeilingMean(
+            [session(1000, 600)], spo2: [spo2(1100, 98), spo2(1200, 98), spo2(1300, 97)])
+        XCTAssertEqual(r?.mean, 98, "97.666... must round to 98, not floor to 97")
+    }
+
     /// The plausibility floor/ceiling are inclusive, matching `spo2SingleChannelPlausible` (50...110)
     /// exactly — the same bounds `Repository.spo2SingleChannelPlausible` derives from this constant.
     func testPlausibleRangeBoundariesAreInclusive() {

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -990,8 +990,12 @@ object AnalyticsEngine {
      * sub-70 nonzero values are diagnostic codes and bit-7 values are saturation sentinels, so averaging
      * them in would produce a number that is not a percentage of anything.
      *
-     * DIAGNOSTIC ONLY. Nothing scores this and it never writes `spo2Pct`. Byte-parity twin of the Swift
-     * `nightlySpo2CandidateMean`.
+     * DIAGNOSTIC ONLY. Nothing scores this and it never writes `spo2Pct`.
+     *
+     * The mean is ROUNDED (`roundToInt()`), not floored — `sum / kept` on two integer types truncates
+     * toward zero, silently biasing every candidate down by up to 0.99. All values here are positive
+     * (70..100), so the rounding-rule choice (half-up vs half-away-from-zero) is inert. Byte-parity
+     * twin of the Swift `nightlySpo2CandidateMean`.
      */
     internal fun nightlySpo2CandidateMean(
         sessions: List<DetectedSleep>,
@@ -1008,7 +1012,7 @@ object AnalyticsEngine {
             kept += 1
         }
         if (kept == 0) return null
-        return Pair((sum / kept).toInt(), kept)
+        return Pair((sum.toDouble() / kept.toDouble()).roundToInt(), kept)
     }
 
     /**
@@ -1037,7 +1041,12 @@ object AnalyticsEngine {
      *
      * Gated to [SPO2_SINGLE_CHANNEL_PLAUSIBLE] (50..110) BEFORE the ceiling is applied, so a contaminated
      * row (down to -1016) cannot drag the mean down — the ceiling alone only guards the top of the range.
-     * Byte-parity twin of the Swift `nightlySpo2CeilingMean`.
+     *
+     * The mean is ROUNDED (`roundToInt()`), not floored — same fix, same reasoning, as
+     * [nightlySpo2CandidateMean] just above (found 2026-08-24 comparing a live-persisted 08-23/24 row
+     * against the Oura app: the transform's precise mean, 97.97, round-matched the app's 98%, but the
+     * shipped `sum / kept` integer division floored it to 97, a spurious miss). Byte-parity twin of the
+     * Swift `nightlySpo2CeilingMean`.
      */
     internal fun nightlySpo2CeilingMean(
         sessions: List<DetectedSleep>,
@@ -1053,7 +1062,7 @@ object AnalyticsEngine {
             kept += 1
         }
         if (kept == 0) return null
-        return Pair((sum / kept).toInt(), kept)
+        return Pair((sum.toDouble() / kept.toDouble()).roundToInt(), kept)
     }
 
     /**

--- a/android/app/src/test/java/com/noop/analytics/Spo2CandidateNightlyTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/Spo2CandidateNightlyTest.kt
@@ -72,6 +72,17 @@ class Spo2CandidateNightlyTest {
         assertEquals(1, r?.second)
     }
 
+    /**
+     * Found 2026-08-24 on the Oura twin ([Spo2CeilingNightlyTest]) and fixed here too — same bug, same
+     * helper shape. `sum / kept` on two integer types truncates toward zero; three samples averaging
+     * 97.666... must round to 98, not floor to 97.
+     */
+    @Test fun meanRoundsRatherThanFloors() {
+        val r = AnalyticsEngine.nightlySpo2CandidateMean(
+            listOf(session(1000, 600)), listOf(aux(1100, 98), aux(1200, 98), aux(1300, 97)))
+        assertEquals(98, r?.first)
+    }
+
     /** Boundaries are inclusive, matching the decoder's own 70..100 emit gate exactly. */
     @Test fun bandBoundariesMatchTheDecoderGate() {
         assertEquals(2, AnalyticsEngine.nightlySpo2CandidateMean(

--- a/android/app/src/test/java/com/noop/analytics/Spo2CeilingNightlyTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/Spo2CeilingNightlyTest.kt
@@ -67,6 +67,18 @@ class Spo2CeilingNightlyTest {
         assertNull(AnalyticsEngine.nightlySpo2CeilingMean(listOf(session(1000, 600)), emptyList()))
     }
 
+    /**
+     * Found 2026-08-24 comparing a live-persisted row against the Oura app: `sum / kept` on two integer
+     * types truncates toward zero, so a true 97.97 shipped as 97 — a spurious miss against an
+     * app-displayed 98% the precise mean would have round-matched. Three samples averaging 97.666...
+     * must round to 98, not floor to 97.
+     */
+    @Test fun meanRoundsRatherThanFloors() {
+        val r = AnalyticsEngine.nightlySpo2CeilingMean(
+            listOf(session(1000, 600)), listOf(spo2(1100, 98), spo2(1200, 98), spo2(1300, 97)))
+        assertEquals(98, r?.first)
+    }
+
     /** The plausibility floor/ceiling are inclusive, matching SPO2_SINGLE_CHANNEL_PLAUSIBLE (50..110). */
     @Test fun plausibleRangeBoundariesAreInclusive() {
         assertEquals(2, AnalyticsEngine.nightlySpo2CeilingMean(


### PR DESCRIPTION
## What this PR does

`nightlySpo2CeilingMean` (Oura, queue 11a) and `nightlySpo2CandidateMean` (WHOOP `@82`, #103) both
compute their nightly mean as `sum / kept` with integer operands — in both Swift and Kotlin that's
integer division, which truncates toward zero (a floor), not a round.

Found 2026-08-24 comparing the first live-persisted `ceiling@100` row (2026-08-23/24) against the
Oura app's own displayed value: the transform's precise mean was 97.97, which round-matches the app's
98% — the same way every other hit in the running §6.5.0 groundtruth tally has been scored — but the
shipped `sum / kept` floored it to **97**, a spurious 1-point miss the transform's own track record
doesn't actually have. Same bug, same helper shape, in the older (pre-dates queue 11a by weeks)
WHOOP `spo2_candidate_82` path, which has been floor-biased the same way since #103.

## The fix

Both functions on both platforms now compute the mean via `Double` division and round
(`.rounded()` in Swift, `roundToInt()` in Kotlin — both already used elsewhere in these files). Every
value that reaches these functions is positive (Oura: `50...110`/ceilinged to 100; WHOOP: `70...100`),
so the choice between round-half-up and round-half-away-from-zero is inert — no platform-divergence
risk from the rounding rule itself.

**Diagnostic-only value, never `spo2Pct`, never scored** (CLAUDE.md's derived-biosignal rule, both
transforms ship the same way `spo2_candidate_82` always has, default-OFF toggle, labelled
"unverified"). This changes what the "strap estimate (unverified)" tile *displays*, nothing about any
scored or gated behavior.

## Tests

6 new tests (3 samples averaging 97.666..., pinned to round to 98 not floor to 97), one per touched
function per platform. Every existing fixture already used exact-integer means (no fractional
remainder), so none needed updating — same expected values before and after this change.

## Verification

- `swift test` (StrandAnalytics): **1573/1573**, including the 6 new tests.
- `./gradlew compileFullDebugKotlin`: clean.
- `./gradlew testFullDebugUnitTest --tests "com.noop.analytics.*"`: **1659/1661**, only the 2
  pre-existing `RecoveryDriversTest` half-tie-rounding failures — confirmed present on pristine
  `upstream/main` *before* this change (ran `--no-build-cache --rerun-tasks` against a clean checkout
  with none of this branch's commits applied) and completely unrelated (recovery-driver point
  rounding, not SpO2). Worth a note for whoever picks this thread up: this reproduces on a genuinely
  fresh build, so it isn't the stale-Gradle/KSP-cache explanation floated on #1584 — looks like a real
  environment-dependent floating-point discrepancy (this machine vs whatever CI/`ryanbr`'s box uses),
  not chased further here since it's pre-existing and out of scope for this fix.
- `Tools/doc_comment_lint.py`: clean.
- Only `Packages/StrandAnalytics` (pure) and Android `com.noop.analytics.*` touched — no app-target
  Swift, so this is fully covered by the default-active `swift-packages.yml` + `android.yml` CI, no
  app-build gap to worry about.

## Not yet done

Not flashed to a device — the toggle is default-OFF so this ships inert either way, and the affected
value is diagnostic-only. `integration/oura-full`'s next rebase should pick this up along with #1584/
#1585.