### PR TITLE
Android: make the SpO₂-candidate display toggle take effect

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -60,7 +60,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -688,7 +687,7 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
      * Mirrors the iOS HealthView loading `spo2_candidate` from the repository.
      */
     val spo2CandidateByDay: StateFlow<Map<String, Double>> =
-        combine(recentDays, flowOf(NoopPrefs.spo2CandidateDisplay(appContext))) { days, toggleOn ->
+        combine(recentDays, NoopPrefs.spo2CandidateDisplayFlow(appContext)) { days, toggleOn ->
             if (!toggleOn || days.isEmpty()) emptyMap()
             else {
                 val from = days.first().day

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -515,7 +515,6 @@ object NoopPrefs {
      */
     fun spo2CandidateDisplayFlow(context: Context): Flow<Boolean> = callbackFlow {
         val prefs = of(context)
-        trySend(prefs.getBoolean(KEY_SPO2_CANDIDATE_DISPLAY, false))
         // Strong local for the flow's lifetime: Android holds these listeners WEAKLY, so one referenced
         // only by the register call is collected and silently stops firing (same reason SettingsScreen's
         // experiment listener keeps one).
@@ -527,6 +526,12 @@ object NoopPrefs {
             }
         }
         prefs.registerOnSharedPreferenceChangeListener(listener)
+        // Seed AFTER registering, not before. A write landing between the read and the register would
+        // otherwise be missed entirely, and — since nothing re-reads until the NEXT change — the flow
+        // would serve a stale value indefinitely, which is the failure this whole function exists to
+        // remove. In this order the same interleaving costs at most a duplicate emit, and
+        // `distinctUntilChanged` drops it.
+        trySend(prefs.getBoolean(KEY_SPO2_CANDIDATE_DISPLAY, false))
         awaitClose { prefs.unregisterOnSharedPreferenceChangeListener(listener) }
     }.distinctUntilChanged()
 

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -31,6 +31,10 @@ import com.noop.data.DemoSeeder
 import com.noop.data.WhoopRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 /**
  * Single-activity host. Requests the runtime BLE permissions the strap connection
@@ -495,6 +499,36 @@ object NoopPrefs {
      *  Default false — the @82 candidate has split cross-device evidence and ships behind a toggle. */
     fun spo2CandidateDisplay(context: Context): Boolean =
         of(context).getBoolean(KEY_SPO2_CANDIDATE_DISPLAY, false)
+
+    /**
+     * [spo2CandidateDisplay] as a flow that re-emits when the user changes it.
+     *
+     * The plain getter is a point read, which is right for a composable that re-reads on every
+     * recomposition and wrong for a `StateFlow` built once. `AppViewModel.spo2CandidateByDay` combined
+     * against `flowOf(spo2CandidateDisplay(…))` — a flow that emits once and completes — so the toggle
+     * was frozen at ViewModel construction: turning the setting off left the Key Metrics tile showing
+     * strap estimates until the process restarted, and turning it on showed nothing until then. iOS reads
+     * `PuffinExperiment.spo2CandidateDisplayEnabled` per render and has never had the lag.
+     *
+     * Named for this one key rather than generic, so it sits beside the getter it mirrors and the two
+     * cannot drift on the default.
+     */
+    fun spo2CandidateDisplayFlow(context: Context): Flow<Boolean> = callbackFlow {
+        val prefs = of(context)
+        trySend(prefs.getBoolean(KEY_SPO2_CANDIDATE_DISPLAY, false))
+        // Strong local for the flow's lifetime: Android holds these listeners WEAKLY, so one referenced
+        // only by the register call is collected and silently stops firing (same reason SettingsScreen's
+        // experiment listener keeps one).
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { changed, key ->
+            // `key` is @Nullable on modern SDKs — it arrives null when the whole file is cleared, which
+            // reads as "everything changed". The null check is required to compile, not just defensive.
+            if (key == null || key == KEY_SPO2_CANDIDATE_DISPLAY) {
+                trySend(changed.getBoolean(KEY_SPO2_CANDIDATE_DISPLAY, false))
+            }
+        }
+        prefs.registerOnSharedPreferenceChangeListener(listener)
+        awaitClose { prefs.unregisterOnSharedPreferenceChangeListener(listener) }
+    }.distinctUntilChanged()
 
     fun setSpo2CandidateDisplay(context: Context, enabled: Boolean) {
         of(context).edit().putBoolean(KEY_SPO2_CANDIDATE_DISPLAY, enabled).apply()

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -514,7 +514,11 @@ object NoopPrefs {
      * cannot drift on the default.
      */
     fun spo2CandidateDisplayFlow(context: Context): Flow<Boolean> = callbackFlow {
-        val prefs = of(context)
+        // `applicationContext`, unlike every other accessor here. Those are point reads that return
+        // before the caller's Context can matter; this one captures it in a flow that lives as long as
+        // something collects, so an Activity passed by a future caller would be held across a rotation.
+        // The only caller today already passes an application Context — this makes it not depend on that.
+        val prefs = of(context.applicationContext)
         // Strong local for the flow's lifetime: Android holds these listeners WEAKLY, so one referenced
         // only by the register call is collected and silently stops firing (same reason SettingsScreen's
         // experiment listener keeps one).


### PR DESCRIPTION
Found while reviewing #1590, which is the second consumer of this flow. Independent of that PR — no conflict, either order.

## The bug

```kotlin
combine(recentDays, flowOf(NoopPrefs.spo2CandidateDisplay(appContext))) { days, toggleOn -> … }
```

`flowOf` emits once and completes, so `combine` holds that first value for the ViewModel's whole life. The toggle is read at construction and **never again**.

The symptom is a setting that does nothing:

| you do | what happens |
|---|---|
| turn "show SpO₂ candidate" **off** | Key Metrics tile keeps showing strap estimates until the process restarts |
| turn it **on** | nothing appears until the process restarts |

Both directions, with nothing in the app to indicate the value in use is stale.

iOS reads `PuffinExperiment.spo2CandidateDisplayEnabled` per render and has never had the lag, so this was a live parity divergence too.

## The fix

`NoopPrefs.spo2CandidateDisplayFlow` wraps the same key in a `callbackFlow` over `OnSharedPreferenceChangeListener` — the idiom already used by `SettingsScreen` (experiment keys) and `NoopMotion` — seeded with the current value and `distinctUntilChanged` so an unrelated write to the prefs file can't re-run the database union behind this flow.

Two details carried over from those existing listener sites rather than rediscovered:

- **A strong local reference.** Android holds these listeners weakly; one kept alive only by the register call is collected and silently stops firing. `SettingsScreen` has a comment saying exactly this.
- **The null-key case.** `key` is `@Nullable` on modern SDKs — it arrives null when the whole file is cleared, which reads as "everything changed". Required to compile, not merely defensive.

Named for the one key rather than made generic, so it sits beside the getter it mirrors and the two can't drift on the default. `flowOf` had no other caller in `AppViewModel`, so its import went with it.

## Scope

The `flowOf(NoopPrefs…)` pattern appears exactly **once** in the codebase — this line. Not systemic, and now gone.

## Verification, and one honest gap

- `compileFullDebugKotlin` clean, full unit suite **4294 tests / 0 failures**, `assembleFullDebug` clean, doc lint clean.
- **Not unit-tested.** The listener needs a real `SharedPreferences`, and this module is deliberately Robolectric-free (`AndroidDiagnosticsTest` and friends note the same constraint), so there's no way to pin the re-emit without adding that dependency for one test. I'd rather say that than claim coverage that isn't there.
- The behaviour needs a device: toggle it in Settings and the Blood Oxygen tile should change without restarting the app.

**Android-only** — iOS already reads the flag per render.
