### PR TITLE
Explorer: share the cross-catalog scan instead of redoing it per open

### DIFF
--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -2141,6 +2141,39 @@ final class Repository: ObservableObject {
         return byDay.sorted { $0.key < $1.key }.map { (day: $0.key, value: $0.value) }
     }
 
+    /// Every catalog metric's Explore series at once, memoized — the cross-catalog scan behind the
+    /// Explorer's correlation card.
+    ///
+    /// `MetricExplorerView` ran this scan itself, per screen open, as 59 serial `exploreSeries` calls. On
+    /// the `my-whoop` partition (34 of the 60 descriptors) each of those walks `days` for the daily column
+    /// and then issues a store range query per entry in `computedReadIds` and `importedReadIds`, so one
+    /// open cost on the order of a couple of hundred store reads. The result was cached only in that
+    /// view's `@State`, and the data is the same whichever metric you opened — the view merely drops its
+    /// own descriptor from the list — so browsing N metric details paid the whole scan N times.
+    ///
+    /// Keyed on `deviceId` AND `refreshSeq`, not `refreshSeq` alone: `importedReadIds` / `computedReadIds`
+    /// are derived from the active strap id, and the only `refreshSeq` bump is inside the merge in
+    /// `refresh()`, so a re-point could otherwise change what these reads union without invalidating.
+    ///
+    /// Returns `nil` if cancelled, and a cancelled scan is NOT cached — the caller (which checks
+    /// `Task.isCancelled` per metric so navigating away mid-scan stops it) must not have a half-filled
+    /// catalog frozen in for the rest of the generation.
+    func exploreAllSeries() async -> [String: [(day: String, value: Double)]]? {
+        let key = "\(deviceId)|\(refreshSeq)"
+        if let cached = exploreAllCache, cached.key == key { return cached.byMetricID }
+        var byMetricID: [String: [(day: String, value: Double)]] = [:]
+        for descriptor in MetricCatalog.all {
+            if Task.isCancelled { return nil }
+            byMetricID[descriptor.id] = await exploreSeries(key: descriptor.key, source: descriptor.source)
+        }
+        exploreAllCache = (key, byMetricID)
+        return byMetricID
+    }
+
+    /// Backing store for [exploreAllSeries]. Main-actor isolated with the rest of the class, so it needs
+    /// no locking; one shared copy replaces the per-view-instance `@State` it supersedes.
+    private var exploreAllCache: (key: String, byMetricID: [String: [(day: String, value: Double)]])?
+
     /// The merged DailyMetric column backing an Explore metric key, for the days the imported/computed
     /// metricSeries doesn't cover (strap-only WHOOP 5 users). Mirrors InsightsView.dailyOutcome and
     /// Android's dailyPick, extended to every Explore "my-whoop" key that maps to a daily column.

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -849,13 +849,18 @@ final class Repository: ObservableObject {
         self.vitalRows = merged.vitalRows
         self.freshness = merged.freshness
         self.loaded = true
-        self.refreshSeq += 1
-        // Drop the Explorer's cross-catalog memo here rather than leaving it to be evicted lazily by a
-        // key mismatch. Its key has just gone stale, and a lazy eviction only frees the memory when the
-        // NEXT scan replaces it — so a user who opens Explore once and never returns keeps a whole
-        // catalog of series resident for the rest of the session. The key check stays: it still guards
-        // the case this line cannot, an active-strap re-point with no refresh behind it.
+        // Drop the Explorer's cross-catalog memo rather than leaving it to be evicted lazily by a key
+        // mismatch: its key is about to go stale, and lazy eviction only frees the memory when the NEXT
+        // scan replaces it — so a user who opens Explore once and never returns keeps a whole catalog of
+        // series resident for the rest of the session. The key check stays; it still guards what this
+        // line cannot, an active-strap re-point with no refresh behind it.
+        //
+        // BEFORE the bump, with the other caches, per this block's own ordering. Nothing can currently
+        // observe the gap — the assignments are synchronous on the main actor and a @Published bump only
+        // schedules SwiftUI work — but "clear every cache, then publish" is the invariant stated above,
+        // and an appended line after the bump is how that invariant quietly stops being true.
         self.exploreAllCache = nil
+        self.refreshSeq += 1
     }
 
     /// Per-source coverage counts for the Freshness Pipeline card. Pure over the rows already read.

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -850,6 +850,12 @@ final class Repository: ObservableObject {
         self.freshness = merged.freshness
         self.loaded = true
         self.refreshSeq += 1
+        // Drop the Explorer's cross-catalog memo here rather than leaving it to be evicted lazily by a
+        // key mismatch. Its key has just gone stale, and a lazy eviction only frees the memory when the
+        // NEXT scan replaces it — so a user who opens Explore once and never returns keeps a whole
+        // catalog of series resident for the rest of the session. The key check stays: it still guards
+        // the case this line cannot, an active-strap re-point with no refresh behind it.
+        self.exploreAllCache = nil
     }
 
     /// Per-source coverage counts for the Freshness Pipeline card. Pure over the rows already read.
@@ -2158,6 +2164,12 @@ final class Repository: ObservableObject {
     /// Returns `nil` if cancelled, and a cancelled scan is NOT cached — the caller (which checks
     /// `Task.isCancelled` per metric so navigating away mid-scan stops it) must not have a half-filled
     /// catalog frozen in for the rest of the generation.
+    ///
+    /// DEFAULT WINDOW ONLY. Every entry is `exploreSeries`' default `days`/`fullHistory`, and the key
+    /// does not record them, so this cannot serve a caller that wants a different window — it would hand
+    /// back the default one and look like it had honoured the request. The correlation sweep is the only
+    /// caller and uses the defaults; anything needing `fullHistory` must call `exploreSeries` directly or
+    /// this must gain a window-aware key.
     func exploreAllSeries() async -> [String: [(day: String, value: Double)]]? {
         let key = "\(deviceId)|\(refreshSeq)"
         if let cached = exploreAllCache, cached.key == key { return cached.byMetricID }

--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -850,11 +850,17 @@ struct MetricDetailView: View {
         // `Task.isCancelled` is checked per metric so navigating away mid-scan stops it: the task is
         // bound to `loadTaskID`, and without the check a quick in-and-out would keep 59 main-actor
         // merges running for a screen nobody is looking at.
+        // The scan itself is memoized on the Repository (`exploreAllSeries`), keyed by active strap +
+        // `refreshSeq`. It is the SAME data whichever metric is open — this view only drops its own
+        // descriptor — so opening five metric details used to pay the whole cross-catalog scan five
+        // times. Cancellation semantics are unchanged: the memo checks `Task.isCancelled` per metric and
+        // returns nil rather than caching a partial scan, so a quick in-and-out still stops the work and
+        // cannot leave a half-filled catalog frozen in for the rest of the generation.
+        guard let allSeries = await repo.exploreAllSeries() else { return }
         var loadedOthers: [(metric: MetricDescriptor, series: [(day: String, value: Double)])] = []
         for other in MetricCatalog.all where other.id != metric.id {
             guard !Task.isCancelled else { return }
-            let s = await repo.exploreSeries(key: other.key, source: other.source)
-            if !s.isEmpty { loadedOthers.append((other, s)) }
+            if let s = allSeries[other.id], !s.isEmpty { loadedOthers.append((other, s)) }
         }
         guard !Task.isCancelled else { return }
         others = loadedOthers


### PR DESCRIPTION
## The waste

`MetricExplorerView.load()` phase 2 feeds the "What correlates" card by walking `MetricCatalog.all` — **60** descriptors — with a serial `exploreSeries` each:

```swift
for other in MetricCatalog.all where other.id != metric.id {
    guard !Task.isCancelled else { return }
    let s = await repo.exploreSeries(key: other.key, source: other.source)
```

On the `my-whoop` partition (**34** of the 60) each of those calls walks `days` for the daily column, then issues a store range query per entry in `computedReadIds` *and* `importedReadIds`. So one screen open is on the order of a couple of hundred store reads, not 59.

The result was cached — but in that view's `@State`, so it died with the view. And the data doesn't depend on which metric is open: the view merely drops its own descriptor from the list. **Browsing five metric details paid the entire scan five times.**

## The change

Memoized on the `Repository`. Opening N details costs one scan instead of N, and memory goes from a fresh 59 series per live view to one shared copy.

Two details decide whether this is safe rather than subtly wrong:

**Keyed on `deviceId` *and* `refreshSeq`, not `refreshSeq` alone.** `importedReadIds` / `computedReadIds` are derived from the active strap id, and the only `refreshSeq` bump is inside the merge in `refresh()`. A strap re-point could therefore change what these reads union while a `refreshSeq`-only key stayed put, and the memo would serve another device's series. Including the id costs nothing.

**A cancelled scan returns `nil` and is not cached.** The existing per-metric `Task.isCancelled` check — there so a quick in-and-out doesn't keep 59 merges running for a screen nobody is looking at — moves into the memo. Caching a partial scan would convert that transient into a persistent one: a half-filled catalog frozen in for the rest of the generation, silently missing correlations.

Phase 1 still reads the open metric's own series directly. Routing it through the memo would make the visible part of the screen wait for the whole catalog, which is precisely what the two-phase split exists to avoid — so the first open per generation does one extra fetch (the memo covers all 60, including the current metric) and every subsequent open does none.

## Scope

No behaviour change: same reads, same results, same order, same cancellation semantics. Nothing here touches analytics, decoders or stored data, so it cannot move a number.

## Verification, stated honestly

- Doc-comment lint clean; brace balance and every referenced symbol (`MetricCatalog.all`, `MetricDescriptor.id`, `Repository.deviceId`) checked.
- **Not compiled.** This is app-target Swift under `Strand/`, which neither a Linux checkout nor default CI can build — `swift-packages` covers `Packages/**` only. **This needs `app-build` before it merges**, and I'd rather say that than let the green checks imply coverage they don't provide.
- The win itself is worth confirming on a device the lazy way: open several metric details in a row and note that only the first pauses before the correlation card fills.
