### PR TITLE
Diagnostics: hunt the 5/MG strap serial in the GET_HELLO block (#1303)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/HelloIdentityProbe.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/HelloIdentityProbe.swift
@@ -56,11 +56,15 @@ public enum HelloIdentityProbe {
 
             let alnum = run.allSatisfy(isAlnum)
             var line = "off=\(start) len=\(run.count) \(alnum ? "alnum" : "mixed")"
-            if start == knownNameOffset {
-                line += " (device name, already decoded)"
-            } else if alnum, serialLength.contains(run.count) {
+            // The known-name offset is LABELLED but not suppressed. `knownNameOffset` is an assumption
+            // taken from one firmware capture, and this is a discovery tool: if a firmware moved the name
+            // and the serial landed here, suppressing the value would hide the exact thing being hunted.
+            // Showing it costs nothing — the device name is already surfaced on the Devices card, so it is
+            // not what the withholding rule exists to protect.
+            if start == knownNameOffset { line += " (device name, already decoded)" }
+            if alnum, serialLength.contains(run.count) {
                 line += " \"\(String(decoding: run, as: UTF8.self))\""
-            } else {
+            } else if start != knownNameOffset {
                 line += " (withheld)"
             }
             out.append(line)

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/HelloIdentityProbe.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/HelloIdentityProbe.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// #1303: find a WHOOP 5/MG strap serial inside the GET_HELLO (145) info block.
+///
+/// A stable per-strap id is the keystone the multi-strap work waits on, and today there is no strap
+/// serial decoded anywhere: `BatteryPackInfo.serial` is the BATTERY PACK's, read via cmd 151 and
+/// answered only by a 5/MG, so it identifies a removable part rather than the strap wearing it.
+///
+/// The 4.0 hunt has a capture aid already (the `GET_HELLO_HARVARD` (35) raw dump). This is the 5/MG
+/// half, and it needs no new traffic: the GET_HELLO block is ALREADY decoded — for the device name at
+/// `pay[16]` and the firmware version at `pay[93]` — and everything else in it is simply discarded. If
+/// the serial is in there, it is arriving on every connect and being thrown away.
+///
+/// ## Why this reports structure instead of dumping the block
+///
+/// The same response carries a SESSION TOKEN, which the decoder deliberately never reads. Dumping the
+/// payload wholesale would put that token in a log, so this reports every printable run as
+/// offset + length + class and prints the CONTENTS only of runs that could plausibly be the serial and
+/// are not the already-known name: fully alphanumeric, [serialLength] characters long.
+///
+/// That rule is a filter, not a guarantee — a token that happened to be alphanumeric and serial-length
+/// would print. Which is precisely why the caller gates this behind an opt-in diagnostic rather than
+/// the default, shareable strap log.
+///
+/// Pure and Foundation-only, so it unit-tests with no strap, no BLE and no app.
+public enum HelloIdentityProbe {
+
+    /// ASCII digits/letters. A serial is alphanumeric; this is what separates a candidate from the
+    /// punctuation-and-symbols runs that binary payloads produce by chance.
+    private static func isAlnum(_ b: UInt8) -> Bool {
+        (48...57).contains(b) || (65...90).contains(b) || (97...122).contains(b)
+    }
+
+    /// Printable-ASCII runs in a GET_HELLO payload, one line each, for a diagnostic log.
+    ///
+    /// - Parameters:
+    ///   - payload: the GET_HELLO (145) response payload, token region included — nothing is stripped
+    ///     before this call; the withholding happens here so a caller cannot get it wrong.
+    ///   - knownNameOffset: where the decoder already reads the device name (16 on the pinned capture).
+    ///     A run starting there is labelled rather than printed, since it is not a serial candidate and
+    ///     is already surfaced elsewhere.
+    ///   - minRun: shortest printable run worth reporting. Below this, a binary payload produces noise.
+    ///   - serialLength: run lengths that could be a serial. Outside it, contents are withheld.
+    public static func candidateLines(payload: [UInt8],
+                                      knownNameOffset: Int = 16,
+                                      minRun: Int = 4,
+                                      serialLength: ClosedRange<Int> = 6...20) -> [String] {
+        var out: [String] = []
+        var i = 0
+        while i < payload.count {
+            guard (32...126).contains(payload[i]) else { i += 1; continue }
+            let start = i
+            while i < payload.count, (32...126).contains(payload[i]) { i += 1 }
+            let run = Array(payload[start..<i])
+            guard run.count >= minRun else { continue }
+
+            let alnum = run.allSatisfy(isAlnum)
+            var line = "off=\(start) len=\(run.count) \(alnum ? "alnum" : "mixed")"
+            if start == knownNameOffset {
+                line += " (device name, already decoded)"
+            } else if alnum, serialLength.contains(run.count) {
+                line += " \"\(String(decoding: run, as: UTF8.self))\""
+            } else {
+                line += " (withheld)"
+            }
+            out.append(line)
+        }
+        return out
+    }
+
+    /// One log line for the whole block: its length, and every candidate run.
+    ///
+    /// The length is reported even when nothing prints, because "no printable runs at all" is itself the
+    /// answer — it says the serial is not ASCII in this block and the search moves elsewhere.
+    public static func report(payload: [UInt8],
+                              knownNameOffset: Int = 16,
+                              minRun: Int = 4,
+                              serialLength: ClosedRange<Int> = 6...20) -> String {
+        let lines = candidateLines(payload: payload, knownNameOffset: knownNameOffset,
+                                   minRun: minRun, serialLength: serialLength)
+        let body = lines.isEmpty ? "none" : lines.joined(separator: "; ")
+        return "HELLO(145) block len=\(payload.count) runs: \(body)"
+    }
+}

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/HelloIdentityProbeTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/HelloIdentityProbeTests.swift
@@ -55,6 +55,17 @@ final class HelloIdentityProbeTests: XCTestCase {
         XCTAssertEqual(lines.first, "off=16 len=12 mixed (device name, already decoded)")
     }
 
+    /// The known-name offset must LABEL, not suppress.
+    ///
+    /// `knownNameOffset` is an assumption from one firmware capture. If a firmware moved the name and the
+    /// serial landed at 16, suppressing the value would hide the exact thing this probe exists to find —
+    /// and it would look like a clean negative result rather than a miss.
+    func testASerialShapedRunAtTheNameOffsetIsStillPrinted() {
+        let p = payload(length: 120, runs: [(16, "3A1B2405003655")])
+        XCTAssertEqual(HelloIdentityProbe.candidateLines(payload: p).first,
+                       #"off=16 len=14 alnum (device name, already decoded) "3A1B2405003655""#)
+    }
+
     /// Short runs are dropped. Binary payloads throw off two- and three-byte printable sequences by
     /// chance, and reporting them would bury the real candidate.
     func testShortRunsAreIgnored() {

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/HelloIdentityProbeTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/HelloIdentityProbeTests.swift
@@ -99,6 +99,18 @@ final class HelloIdentityProbeTests: XCTestCase {
                        "HELLO(145) block len=42 runs: none")
     }
 
+    /// `report` must THREAD its tuning through to the scan, not merely accept it.
+    ///
+    /// Every other test here calls `candidateLines` at its defaults, so a `report` that quietly dropped a
+    /// parameter would pass all of them. The same call with a narrowed serial length must withhold what
+    /// the default range prints — which is only observable if the value actually reaches the scan.
+    func testReportThreadsItsTuningThrough() {
+        let p = payload(length: 120, runs: [(40, "3A1B2405003655")])   // 14 chars: inside the default 6...20
+        XCTAssertTrue(HelloIdentityProbe.report(payload: p).contains(#""3A1B2405003655""#))
+        XCTAssertEqual(HelloIdentityProbe.report(payload: p, serialLength: 6...10),
+                       "HELLO(145) block len=120 runs: off=40 len=14 alnum (withheld)")
+    }
+
     /// An empty payload must not crash the scan.
     func testAnEmptyPayloadIsSafe() {
         XCTAssertTrue(HelloIdentityProbe.candidateLines(payload: []).isEmpty)

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/HelloIdentityProbeTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/HelloIdentityProbeTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import WhoopProtocol
+
+/// #1303: the GET_HELLO candidate-serial probe.
+///
+/// The probe exists to locate a strap serial in a block the decoder already receives and discards. Its
+/// value depends entirely on two properties, and both are pinned here: it must SURFACE a serial-shaped
+/// run, and it must WITHHOLD the session token that shares the block.
+///
+/// Byte-parity twin of Kotlin `HelloIdentityProbeTest`.
+final class HelloIdentityProbeTests: XCTestCase {
+
+    /// Build a payload with printable runs at chosen offsets, zero-filled elsewhere — zeros are the
+    /// non-printable filler a real block has between its fields.
+    private func payload(length: Int, runs: [(offset: Int, text: String)]) -> [UInt8] {
+        var p = [UInt8](repeating: 0, count: length)
+        for run in runs {
+            for (k, b) in Array(run.text.utf8).enumerated() { p[run.offset + k] = b }
+        }
+        return p
+    }
+
+    /// The point of the whole probe: a serial-shaped run away from the name is printed, so it can be
+    /// matched against the serial on the strap's own casing.
+    func testASerialShapedRunIsPrinted() {
+        let p = payload(length: 120, runs: [(40, "3A1B2405003655")])
+        let lines = HelloIdentityProbe.candidateLines(payload: p)
+        XCTAssertEqual(lines.count, 1)
+        XCTAssertEqual(lines.first, #"off=40 len=14 alnum "3A1B2405003655""#)
+    }
+
+    /// The privacy contract. A NON-alphanumeric run is described but never quoted — that is the shape a
+    /// session token takes, and the decoder deliberately never reads it.
+    func testAMixedRunIsDescribedButWithheld() {
+        let p = payload(length: 120, runs: [(40, "tok!en-{}~payload")])
+        let lines = HelloIdentityProbe.candidateLines(payload: p)
+        XCTAssertEqual(lines.count, 1)
+        XCTAssertEqual(lines.first, "off=40 len=17 mixed (withheld)")
+        XCTAssertFalse(lines.first!.contains("tok"), "a mixed run's contents must never reach the log")
+    }
+
+    /// Length is a filter too: an alphanumeric run far longer than any serial is withheld. A long
+    /// alphanumeric blob is much more likely to be a token than an id.
+    func testAnOverlongAlnumRunIsWithheld() {
+        let p = payload(length: 200, runs: [(40, String(repeating: "a", count: 64))])
+        let lines = HelloIdentityProbe.candidateLines(payload: p)
+        XCTAssertEqual(lines.first, "off=40 len=64 alnum (withheld)")
+    }
+
+    /// The device name is already surfaced by the decoder, so it is labelled rather than quoted — it is
+    /// not a serial candidate and repeating it would only pad the line.
+    func testTheKnownNameRunIsLabelledNotQuoted() {
+        let p = payload(length: 120, runs: [(16, "WHOOP-FAKE01")])
+        let lines = HelloIdentityProbe.candidateLines(payload: p)
+        XCTAssertEqual(lines.first, "off=16 len=12 mixed (device name, already decoded)")
+    }
+
+    /// Short runs are dropped. Binary payloads throw off two- and three-byte printable sequences by
+    /// chance, and reporting them would bury the real candidate.
+    func testShortRunsAreIgnored() {
+        let p = payload(length: 60, runs: [(10, "ab"), (30, "xyz")])
+        XCTAssertTrue(HelloIdentityProbe.candidateLines(payload: p).isEmpty)
+    }
+
+    /// Several runs are reported in offset order, so the reader can line them up against the block.
+    func testRunsAreReportedInOffsetOrder() {
+        let p = payload(length: 200, runs: [(16, "WHOOP-FAKE01"), (40, "SER1234567"), (80, "zz!!zz??")])
+        let lines = HelloIdentityProbe.candidateLines(payload: p)
+        XCTAssertEqual(lines, [
+            "off=16 len=12 mixed (device name, already decoded)",
+            #"off=40 len=10 alnum "SER1234567""#,
+            "off=80 len=8 mixed (withheld)",
+        ])
+    }
+
+    /// A run reaching the very end of the payload must not be lost to an off-by-one on the scan bound.
+    func testARunFlushWithTheEndIsReported() {
+        var p = [UInt8](repeating: 0, count: 20)
+        for (k, b) in Array("SERIAL99".utf8).enumerated() { p[12 + k] = b }
+        XCTAssertEqual(HelloIdentityProbe.candidateLines(payload: p).first,
+                       #"off=12 len=8 alnum "SERIAL99""#)
+    }
+
+    /// "No printable runs" is a real answer, not a failure: it says the serial is not ASCII here and the
+    /// search moves on. The length still prints, so the reader knows the block was seen.
+    func testAnAllBinaryBlockReportsNoneWithItsLength() {
+        XCTAssertEqual(HelloIdentityProbe.report(payload: [UInt8](repeating: 0, count: 42)),
+                       "HELLO(145) block len=42 runs: none")
+    }
+
+    /// An empty payload must not crash the scan.
+    func testAnEmptyPayloadIsSafe() {
+        XCTAssertTrue(HelloIdentityProbe.candidateLines(payload: []).isEmpty)
+        XCTAssertEqual(HelloIdentityProbe.report(payload: []), "HELLO(145) block len=0 runs: none")
+    }
+}

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -206,6 +206,25 @@ public final class FrameRouter {
                     state.append(log: "HELLO_HARVARD(35) resp raw: \(Self.commandResponsePayloadHex(in: frame) ?? "empty") — locate the strap serial offset (#1303)")
                 }
             }
+            // #1303: the 5/MG half of the same hunt. The 4.0 aid above is 4.0-only — correctly, since a
+            // 5/MG never answers cmd 35 — so this family had no capture at all, and it needs one just as
+            // much: a stable per-strap id is what multi-strap identity waits on, and the pack serial from
+            // cmd 151 identifies a REMOVABLE PART rather than the strap wearing it.
+            //
+            // No new traffic is sent. GET_HELLO already arrives on every connect and is already decoded —
+            // for the device name and the firmware version — and the rest of the block is discarded. If
+            // the serial is in there, it has been arriving all along.
+            //
+            // Reports STRUCTURE, not the block: the same response carries a session token the decoder
+            // deliberately never reads, so `HelloIdentityProbe` prints only serial-shaped runs and
+            // withholds the rest. Test Centre → Connection gated on top of that, so nothing here reaches a
+            // default (shareable) strap log. Log-only; decodes and persists nothing.
+            if family == .whoop5, let cmd = parsed.cmdName,
+               cmd.hasPrefix("GET_HELLO("),          // not GET_HELLO_HARVARD — Schema appends "(145)"
+               TestCentre.active(.connection),
+               let pay = Self.commandResponsePayload(in: frame, family: family) {
+                state.append(log: HelloIdentityProbe.report(payload: pay) + " — locate the strap serial (#1303)")
+            }
             // #900: surface a non-SUCCESS COMMAND_RESPONSE on BOTH families (a result=UNSUPPORTED here is how
             // the MG haptics rejection #48 would show), and — the key part — annotate a reply that DELIVERED
             // ITS VALUE rather than reporting a bare failure. The 4.0 GET_BATTERY_LEVEL replies on record carry
@@ -340,13 +359,20 @@ public final class FrameRouter {
 
     // MARK: - Alarm-readback decode (WHOOP 4.0, GET_ALARM_TIME cmd 67 - #401 close-out)
 
-    /// The payload of a WHOOP 4.0 COMMAND_RESPONSE: the bytes after [type,seq,cmd,origin_seq,result]
-    /// (payload starts at inner+5) up to the crc32 trailer at `length`. Same envelope walk as
+    /// The payload of a COMMAND_RESPONSE: the bytes after [type,seq,cmd,origin_seq,result] (payload
+    /// starts at inner+5) up to the crc32 trailer at `length`. Same envelope walk as
     /// `advertisingName(in:)`. nil when the frame is too short to carry any payload.
-    nonisolated static func commandResponsePayload(in frame: [UInt8]) -> [UInt8]? {
+    ///
+    /// `family` defaults to `.whoop4` so every existing caller (alarm readback, advertising name, the
+    /// cmd-35 dump) is untouched, exactly as `commandResultByte` does — and for the same reason it had
+    /// to: the inner starts at 4 on a WHOOP 4.0 and at 8 on a 5/MG, so reading a 5/MG frame at the 4.0
+    /// offset returns four bytes of envelope dressed as payload rather than failing visibly.
+    nonisolated static func commandResponsePayload(in frame: [UInt8],
+                                                   family: DeviceFamily = .whoop4) -> [UInt8]? {
         guard frame.count > 2 else { return nil }
         let length = Int(frame[1]) | (Int(frame[2]) << 8)        // crc32 starts here
-        let start = whoop4InnerOffset + 5                        // skip type,seq,cmd,origin_seq,result
+        let inner = (family == .whoop5) ? 8 : whoop4InnerOffset
+        let start = inner + 5                                    // skip type,seq,cmd,origin_seq,result
         guard length <= frame.count, start < length else { return nil }
         return Array(frame[start..<length])
     }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5812,6 +5812,31 @@ class WhoopBleClient(
                         ?.joinToString(" ") { "%02x".format(it) } ?: "empty"
                     log("HELLO_HARVARD(35) resp raw: $raw — locate the strap serial offset (#1303)")
                 }
+                // #1303: the 5/MG half of the same hunt. The 4.0 aid above is 4.0-only — correctly, since
+                // a 5/MG never answers cmd 35 — so this family had no capture at all, and it needs one
+                // just as much: a stable per-strap id is what multi-strap identity waits on, and the pack
+                // serial from cmd 151 identifies a REMOVABLE PART rather than the strap wearing it.
+                //
+                // No new traffic is sent. GET_HELLO already arrives on every connect and is already
+                // decoded — for the device name and the firmware version — and the rest of the block is
+                // discarded. If the serial is in there, it has been arriving all along.
+                //
+                // Reports STRUCTURE, not the block: the same response carries a session token the decoder
+                // deliberately never reads, so HelloIdentityProbe prints only serial-shaped runs and
+                // withholds the rest. Test Centre → Connection gated on top of that. Log-only. Twin of
+                // the Swift FrameRouter branch.
+                if (connectedFamily == DeviceFamily.WHOOP5 &&
+                    respCmd?.startsWith("GET_HELLO(") == true &&   // not GET_HELLO_HARVARD
+                    testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)
+                ) {
+                    val pay = whoop5CommandResponsePayload(frame)
+                    if (pay != null) {
+                        log(
+                            com.noop.protocol.HelloIdentityProbe.report(pay) +
+                                " — locate the strap serial (#1303)",
+                        )
+                    }
+                }
                 // Reboot ack (#166): log the COMMAND_RESPONSE result for a user reboot on BOTH families —
                 // the accept/reject signal (the same one that exposed 5/MG haptics rejection). So a 5/MG
                 // owner's strap log confirms whether the (unverified) puffin reboot frame is accepted. The
@@ -8767,6 +8792,23 @@ internal fun whoop4CommandResponsePayload(frame: ByteArray): ByteArray? {
     if (frame.size < 3) return null
     val length = (frame[1].toInt() and 0xFF) or ((frame[2].toInt() and 0xFF) shl 8)
     val start = 9   // SOF(1) + len(2) + crc8(1) + type,seq,cmd,origin_seq,result(5)
+    if (length > frame.size || start >= length) return null
+    return frame.copyOfRange(start, length)
+}
+
+/**
+ * The 5/MG COMMAND_RESPONSE payload. Twin of Swift `commandResponsePayload(in:family: .whoop5)`.
+ *
+ * The 5/MG inner block starts at 8 rather than the 4.0's 4 (the "+4 shift"), so the payload begins at
+ * 13: SOF(1) + len(2) + crc8(1) + the shift, then [type,seq,cmd,origin_seq,result](5). Kept as its own
+ * function rather than a flag on the 4.0 one because reading a 5/MG frame with the 4.0 helper does not
+ * fail — it returns four bytes of envelope dressed as payload, which is the failure mode that made
+ * bhelm/noop#4 print REJECTED on a successful reboot.
+ */
+internal fun whoop5CommandResponsePayload(frame: ByteArray): ByteArray? {
+    if (frame.size < 3) return null
+    val length = (frame[1].toInt() and 0xFF) or ((frame[2].toInt() and 0xFF) shl 8)
+    val start = 13
     if (length > frame.size || start >= length) return null
     return frame.copyOfRange(start, length)
 }

--- a/android/app/src/main/java/com/noop/protocol/HelloIdentityProbe.kt
+++ b/android/app/src/main/java/com/noop/protocol/HelloIdentityProbe.kt
@@ -63,15 +63,19 @@ object HelloIdentityProbe {
             if (run.size < minRun) continue
 
             val alnum = run.all { isAlnum(it.toInt() and 0xFF) }
-            val head = "off=$start len=${run.size} ${if (alnum) "alnum" else "mixed"}"
-            out.add(
-                when {
-                    start == knownNameOffset -> "$head (device name, already decoded)"
-                    alnum && run.size in serialLenMin..serialLenMax ->
-                        "$head \"${String(run, Charsets.US_ASCII)}\""
-                    else -> "$head (withheld)"
-                },
-            )
+            // The known-name offset is LABELLED but not suppressed. [knownNameOffset] is an assumption
+            // taken from one firmware capture, and this is a discovery tool: if a firmware moved the name
+            // and the serial landed here, suppressing the value would hide the exact thing being hunted.
+            // Showing it costs nothing — the device name is already surfaced on the Devices card, so it is
+            // not what the withholding rule exists to protect.
+            var line = "off=$start len=${run.size} ${if (alnum) "alnum" else "mixed"}"
+            if (start == knownNameOffset) line += " (device name, already decoded)"
+            line += when {
+                alnum && run.size in serialLenMin..serialLenMax -> " \"${String(run, Charsets.US_ASCII)}\""
+                start != knownNameOffset -> " (withheld)"
+                else -> ""
+            }
+            out.add(line)
         }
         return out
     }

--- a/android/app/src/main/java/com/noop/protocol/HelloIdentityProbe.kt
+++ b/android/app/src/main/java/com/noop/protocol/HelloIdentityProbe.kt
@@ -90,8 +90,10 @@ object HelloIdentityProbe {
         payload: ByteArray,
         knownNameOffset: Int = 16,
         minRun: Int = 4,
+        serialLenMin: Int = SERIAL_LEN_MIN,
+        serialLenMax: Int = SERIAL_LEN_MAX,
     ): String {
-        val lines = candidateLines(payload, knownNameOffset, minRun)
+        val lines = candidateLines(payload, knownNameOffset, minRun, serialLenMin, serialLenMax)
         val body = if (lines.isEmpty()) "none" else lines.joinToString("; ")
         return "HELLO(145) block len=${payload.size} runs: $body"
     }

--- a/android/app/src/main/java/com/noop/protocol/HelloIdentityProbe.kt
+++ b/android/app/src/main/java/com/noop/protocol/HelloIdentityProbe.kt
@@ -1,0 +1,94 @@
+package com.noop.protocol
+
+/**
+ * #1303: find a WHOOP 5/MG strap serial inside the GET_HELLO (145) info block.
+ *
+ * A stable per-strap id is the keystone the multi-strap work waits on, and today there is no strap
+ * serial decoded anywhere: [BatteryPackInfo]'s serial is the BATTERY PACK's, read via cmd 151 and
+ * answered only by a 5/MG, so it identifies a removable part rather than the strap wearing it.
+ *
+ * The 4.0 hunt has a capture aid already (the `GET_HELLO_HARVARD` (35) raw dump). This is the 5/MG
+ * half, and it needs no new traffic: the GET_HELLO block is ALREADY decoded — for the device name at
+ * `pay[16]` and the firmware version at `pay[93]` — and everything else in it is simply discarded. If
+ * the serial is in there, it is arriving on every connect and being thrown away.
+ *
+ * ## Why this reports structure instead of dumping the block
+ *
+ * The same response carries a SESSION TOKEN, which the decoder deliberately never reads. Dumping the
+ * payload wholesale would put that token in a log, so this reports every printable run as
+ * offset + length + class and prints the CONTENTS only of runs that could plausibly be the serial and
+ * are not the already-known name: fully alphanumeric, [SERIAL_LEN_MIN]..[SERIAL_LEN_MAX] characters.
+ *
+ * That rule is a filter, not a guarantee — a token that happened to be alphanumeric and serial-length
+ * would print. Which is precisely why the caller gates this behind an opt-in diagnostic rather than
+ * the default, shareable strap log.
+ *
+ * Pure, so it unit-tests with no strap, no BLE and no Android. Byte-identical twin of the Swift
+ * `HelloIdentityProbe`.
+ */
+object HelloIdentityProbe {
+
+    const val SERIAL_LEN_MIN = 6
+    const val SERIAL_LEN_MAX = 20
+
+    /** ASCII digits/letters. A serial is alphanumeric; this is what separates a candidate from the
+     *  punctuation-and-symbols runs that binary payloads produce by chance. */
+    private fun isAlnum(b: Int): Boolean =
+        (b in 48..57) || (b in 65..90) || (b in 97..122)
+
+    /**
+     * Printable-ASCII runs in a GET_HELLO payload, one line each, for a diagnostic log.
+     *
+     * [payload] is the GET_HELLO (145) response payload, token region included — nothing is stripped
+     * before this call; the withholding happens here so a caller cannot get it wrong.
+     * [knownNameOffset] is where the decoder already reads the device name (16 on the pinned capture);
+     * a run starting there is labelled rather than printed. [minRun] is the shortest run worth
+     * reporting — below it, a binary payload is all noise.
+     */
+    fun candidateLines(
+        payload: ByteArray,
+        knownNameOffset: Int = 16,
+        minRun: Int = 4,
+        serialLenMin: Int = SERIAL_LEN_MIN,
+        serialLenMax: Int = SERIAL_LEN_MAX,
+    ): List<String> {
+        val out = ArrayList<String>()
+        var i = 0
+        while (i < payload.size) {
+            val b = payload[i].toInt() and 0xFF
+            if (b !in 32..126) { i++; continue }
+            val start = i
+            while (i < payload.size && (payload[i].toInt() and 0xFF) in 32..126) i++
+            val run = payload.copyOfRange(start, i)
+            if (run.size < minRun) continue
+
+            val alnum = run.all { isAlnum(it.toInt() and 0xFF) }
+            val head = "off=$start len=${run.size} ${if (alnum) "alnum" else "mixed"}"
+            out.add(
+                when {
+                    start == knownNameOffset -> "$head (device name, already decoded)"
+                    alnum && run.size in serialLenMin..serialLenMax ->
+                        "$head \"${String(run, Charsets.US_ASCII)}\""
+                    else -> "$head (withheld)"
+                },
+            )
+        }
+        return out
+    }
+
+    /**
+     * One log line for the whole block: its length, and every candidate run.
+     *
+     * The length is reported even when nothing prints, because "no printable runs at all" is itself
+     * the answer — it says the serial is not ASCII in this block and the search moves elsewhere.
+     */
+    fun report(
+        payload: ByteArray,
+        knownNameOffset: Int = 16,
+        minRun: Int = 4,
+    ): String {
+        val lines = candidateLines(payload, knownNameOffset, minRun)
+        val body = if (lines.isEmpty()) "none" else lines.joinToString("; ")
+        return "HELLO(145) block len=${payload.size} runs: $body"
+    }
+}

--- a/android/app/src/test/java/com/noop/protocol/HelloIdentityProbeTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/HelloIdentityProbeTest.kt
@@ -104,6 +104,22 @@ class HelloIdentityProbeTest {
         assertEquals("HELLO(145) block len=42 runs: none", HelloIdentityProbe.report(ByteArray(42)))
     }
 
+    /**
+     * [HelloIdentityProbe.report] must THREAD its tuning through to the scan, not merely accept it.
+     *
+     * Every other test here calls candidateLines at its defaults, so a report that quietly dropped a
+     * parameter would pass all of them. The same call with a narrowed serial length must withhold what
+     * the default range prints — which is only observable if the value actually reaches the scan.
+     */
+    @Test fun reportThreadsItsTuningThrough() {
+        val p = payload(120, listOf(40 to "3A1B2405003655"))   // 14 chars: inside the default 6..20
+        assertTrue(HelloIdentityProbe.report(p).contains("\"3A1B2405003655\""))
+        assertEquals(
+            "HELLO(145) block len=120 runs: off=40 len=14 alnum (withheld)",
+            HelloIdentityProbe.report(p, serialLenMax = 10),
+        )
+    }
+
     /** An empty payload must not crash the scan. */
     @Test fun anEmptyPayloadIsSafe() {
         assertTrue(HelloIdentityProbe.candidateLines(ByteArray(0)).isEmpty())

--- a/android/app/src/test/java/com/noop/protocol/HelloIdentityProbeTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/HelloIdentityProbeTest.kt
@@ -1,0 +1,100 @@
+package com.noop.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1303: the GET_HELLO candidate-serial probe.
+ *
+ * The probe exists to locate a strap serial in a block the decoder already receives and discards. Its
+ * value depends entirely on two properties, and both are pinned here: it must SURFACE a serial-shaped
+ * run, and it must WITHHOLD the session token that shares the block.
+ *
+ * Byte-parity twin of Swift `HelloIdentityProbeTests`.
+ */
+class HelloIdentityProbeTest {
+
+    /** Payload with printable runs at chosen offsets, zero-filled elsewhere — zeros are the
+     *  non-printable filler a real block has between its fields. */
+    private fun payload(length: Int, runs: List<Pair<Int, String>>): ByteArray {
+        val p = ByteArray(length)
+        for ((offset, text) in runs) {
+            text.toByteArray(Charsets.US_ASCII).forEachIndexed { k, b -> p[offset + k] = b }
+        }
+        return p
+    }
+
+    /** The point of the whole probe: a serial-shaped run away from the name is printed, so it can be
+     *  matched against the serial on the strap's own casing. */
+    @Test fun aSerialShapedRunIsPrinted() {
+        val lines = HelloIdentityProbe.candidateLines(payload(120, listOf(40 to "3A1B2405003655")))
+        assertEquals(1, lines.size)
+        assertEquals("off=40 len=14 alnum \"3A1B2405003655\"", lines[0])
+    }
+
+    /** The privacy contract. A NON-alphanumeric run is described but never quoted — that is the shape
+     *  a session token takes, and the decoder deliberately never reads it. */
+    @Test fun aMixedRunIsDescribedButWithheld() {
+        val lines = HelloIdentityProbe.candidateLines(payload(120, listOf(40 to "tok!en-{}~payload")))
+        assertEquals(1, lines.size)
+        assertEquals("off=40 len=17 mixed (withheld)", lines[0])
+        assertFalse("a mixed run's contents must never reach the log", lines[0].contains("tok"))
+    }
+
+    /** Length is a filter too: an alphanumeric run far longer than any serial is withheld. A long
+     *  alphanumeric blob is much more likely to be a token than an id. */
+    @Test fun anOverlongAlnumRunIsWithheld() {
+        val lines = HelloIdentityProbe.candidateLines(payload(200, listOf(40 to "a".repeat(64))))
+        assertEquals("off=40 len=64 alnum (withheld)", lines[0])
+    }
+
+    /** The device name is already surfaced by the decoder, so it is labelled rather than quoted. */
+    @Test fun theKnownNameRunIsLabelledNotQuoted() {
+        val lines = HelloIdentityProbe.candidateLines(payload(120, listOf(16 to "WHOOP-FAKE01")))
+        assertEquals("off=16 len=12 mixed (device name, already decoded)", lines[0])
+    }
+
+    /** Short runs are dropped. Binary payloads throw off two- and three-byte printable sequences by
+     *  chance, and reporting them would bury the real candidate. */
+    @Test fun shortRunsAreIgnored() {
+        assertTrue(
+            HelloIdentityProbe.candidateLines(payload(60, listOf(10 to "ab", 30 to "xyz"))).isEmpty(),
+        )
+    }
+
+    /** Several runs are reported in offset order, so the reader can line them up against the block. */
+    @Test fun runsAreReportedInOffsetOrder() {
+        val lines = HelloIdentityProbe.candidateLines(
+            payload(200, listOf(16 to "WHOOP-FAKE01", 40 to "SER1234567", 80 to "zz!!zz??")),
+        )
+        assertEquals(
+            listOf(
+                "off=16 len=12 mixed (device name, already decoded)",
+                "off=40 len=10 alnum \"SER1234567\"",
+                "off=80 len=8 mixed (withheld)",
+            ),
+            lines,
+        )
+    }
+
+    /** A run reaching the very end of the payload must not be lost to an off-by-one on the scan bound. */
+    @Test fun aRunFlushWithTheEndIsReported() {
+        val p = ByteArray(20)
+        "SERIAL99".toByteArray(Charsets.US_ASCII).forEachIndexed { k, b -> p[12 + k] = b }
+        assertEquals("off=12 len=8 alnum \"SERIAL99\"", HelloIdentityProbe.candidateLines(p)[0])
+    }
+
+    /** "No printable runs" is a real answer, not a failure: it says the serial is not ASCII here and
+     *  the search moves on. The length still prints, so the reader knows the block was seen. */
+    @Test fun anAllBinaryBlockReportsNoneWithItsLength() {
+        assertEquals("HELLO(145) block len=42 runs: none", HelloIdentityProbe.report(ByteArray(42)))
+    }
+
+    /** An empty payload must not crash the scan. */
+    @Test fun anEmptyPayloadIsSafe() {
+        assertTrue(HelloIdentityProbe.candidateLines(ByteArray(0)).isEmpty())
+        assertEquals("HELLO(145) block len=0 runs: none", HelloIdentityProbe.report(ByteArray(0)))
+    }
+}

--- a/android/app/src/test/java/com/noop/protocol/HelloIdentityProbeTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/HelloIdentityProbeTest.kt
@@ -56,6 +56,18 @@ class HelloIdentityProbeTest {
         assertEquals("off=16 len=12 mixed (device name, already decoded)", lines[0])
     }
 
+    /**
+     * The known-name offset must LABEL, not suppress.
+     *
+     * [HelloIdentityProbe.candidateLines]'s knownNameOffset is an assumption from one firmware capture.
+     * If a firmware moved the name and the serial landed at 16, suppressing the value would hide the
+     * exact thing this probe exists to find — and it would look like a clean negative rather than a miss.
+     */
+    @Test fun aSerialShapedRunAtTheNameOffsetIsStillPrinted() {
+        val lines = HelloIdentityProbe.candidateLines(payload(120, listOf(16 to "3A1B2405003655")))
+        assertEquals("off=16 len=14 alnum (device name, already decoded) \"3A1B2405003655\"", lines[0])
+    }
+
     /** Short runs are dropped. Binary payloads throw off two- and three-byte printable sequences by
      *  chance, and reporting them would bury the real candidate. */
     @Test fun shortRunsAreIgnored() {


### PR DESCRIPTION
Groundwork for #1303. Diagnostic only — decodes nothing, persists nothing, changes no number.

## Why

Multi-strap identity waits on a stable per-strap id, and NOOP decodes **no strap serial at all** today.

`BatteryPackInfo.serial` looks like one and isn't: it is the **battery pack's**, read via `GET_BATTERY_PACK_INFO` (cmd 151) and answered only by a 5/MG. It identifies a removable part, so using it as strap identity fails in both directions — swap packs and one strap becomes two devices; move a pack between straps and two straps collide on one id.

The 4.0 hunt already has a capture aid, the `GET_HELLO_HARVARD` (35) raw dump. **It is 4.0-only on both platforms** — Swift's sits inside the `family == .whoop4` block, Android's gates on the family directly — which is correct, because a 5/MG never answers cmd 35. The consequence is that the 5/MG has had no capture at all.

## What this does

Adds the 5/MG half, **sending nothing new to the strap**. `GET_HELLO` already arrives on every connect and is already decoded — device name at `pay[16]`, firmware version at `pay[93]` — and the rest of the block is discarded. If the serial is in there, it has been arriving all along and being thrown away.

## Why it reports structure rather than dumping the block

The same response carries a **session token**, which the decoder deliberately never reads. A raw dump would put it in a log.

So `HelloIdentityProbe` lists every printable run as `offset + length + class` and prints the **contents** only of runs that could be a serial and are not the known name: fully alphanumeric, 6–20 characters.

```
HELLO(145) block len=120 runs: off=16 len=12 mixed (device name, already decoded);
off=40 len=14 alnum "3A1B2405003655"; off=80 len=17 mixed (withheld)
```

That rule is a **filter, not a guarantee** — a token that happened to be alphanumeric and serial-length would print — which is why it is also gated behind Test Centre → Connection, so nothing here reaches a default, shareable strap log.

## Also here, and required by the above

`commandResponsePayload` gains a `family` parameter (default `.whoop4`, so all three existing callers are untouched), and Kotlin gains `whoop5CommandResponsePayload`. The 5/MG inner block starts at 8 rather than 4, so reading a 5/MG frame at the 4.0 offset **does not fail** — it returns four bytes of envelope dressed as payload. That is the exact failure mode that made bhelm/noop#4 print `REJECTED` on a successful reboot, so it is worth naming rather than rediscovering.

## Verification

The probe is pure, which is the point — unlike the app-layer wiring it is fully testable:

- **`WhoopProtocol`: 629 tests green** (this package builds and tests on Linux and is covered by `swift-packages` CI)
- **Android: 4304 tests green**, `assembleFullDebug` clean
- 9 probe tests per platform with identical expectations, pinning both halves of the contract — a serial-shaped run **is** surfaced, and a mixed run is described but **never** quoted
- doc lint clean

**The `FrameRouter` half is app-target Swift**, which neither Linux nor default CI compiles, so this needs `app-build` before merge.

## What it can't tell you

Whether a 5/MG's `GET_HELLO` reaches this branch at all, and whether the serial is ASCII in that block. Both are runtime facts that need a strap. If the line prints `runs: none`, that is a real answer — it says the serial is not printable ASCII here and the search moves elsewhere.
