### PR TITLE
Effort funnel: report the longest and mean bridged run

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
@@ -170,6 +170,19 @@ public enum WorkoutDetector {
         /// Contiguous runs after gap-merging, and after the #303 HR-gated bridge.
         public var runs = 0
         public var bridged = 0
+        /// The LONGEST and MEAN bridged run, in seconds, before any qualification gate drops anything.
+        ///
+        /// These separate the only two stories a `kept=0` day can tell, and the counts alone cannot. A
+        /// field log showing 22 days of `kept=0` with ~100 runs and ~2 h of daily "active" time is equally
+        /// consistent with normal life (stairs and walking brushing past `restHR+15` in one-minute bursts
+        /// — an honest zero) and with a real session shattered into sub-threshold fragments (a bug).
+        /// Telling them apart needed `longestRunS`: below `minExerciseMin` it is daily life, and a
+        /// 25-minute run still dropped is a defect worth chasing.
+        ///
+        /// Without them the question could only be settled by asking the user whether they had trained,
+        /// which is precisely the round-trip an always-on diagnostic exists to remove.
+        public var longestRunS = 0
+        public var meanRunS = 0
         /// Runs rejected by each qualification gate, and the survivors.
         public var droppedShort = 0
         public var droppedNoHR = 0
@@ -188,6 +201,7 @@ public enum WorkoutDetector {
             + "restHR=\(round0(f.restingHR)) floor=\(round0(f.hrFloor)) "
             + "motionOK=\(f.motionPassed) hrMissing=\(f.hrMissing) hrTooLow=\(f.hrTooLow) "
             + "active=\(f.active) runs=\(f.runs) bridged=\(f.bridged) "
+            + "longestRunS=\(f.longestRunS) meanRunS=\(f.meanRunS) "
             + "short=\(f.droppedShort) noHR=\(f.droppedNoHR) lowIntensity=\(f.droppedLowIntensity) "
             + "kept=\(f.kept)"
     }
@@ -468,6 +482,13 @@ public enum WorkoutDetector {
         // gaps. Runs over a genuine rest (HR falls to resting) are NOT bridged.
         runs = bridgeRuns(runs, hrSeg: hrSeg, hrFloor: hrFloor)
         f.bridged = runs.count
+        // Measured on the BRIDGED runs, before any qualification gate: this is the shape of what the
+        // detector was offered, which is the thing a `kept=0` day has to be judged against.
+        if !runs.isEmpty {
+            let durs = runs.map { max(0, $0.1 - $0.0) }
+            f.longestRunS = durs.max() ?? 0
+            f.meanRunS = durs.reduce(0, +) / durs.count
+        }
 
         let minDurS = minExerciseMin * 60.0
         var sessions: [ExerciseSession] = []

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
@@ -182,6 +182,11 @@ public enum WorkoutDetector {
         /// `minExerciseMin` and 390 that did and failed the intensity bar instead. The counts said the
         /// duration gate was not the whole story; only `longestRunS` says whether what survived it was a
         /// five-minute stroll or something that should have scored.
+        ///
+        /// READ `longestRunS` AGAINST 290 s, NOT 300. The gate is `minDurS - motionSmoothS`
+        /// (5 min − 10 s), because the smoothing window costs a run its first samples. Comparing against
+        /// a round five minutes misjudges everything in the 290..300 window — a 295 s run cleared the
+        /// gate and would look as though it had not.
         public var longestRunS = 0
         public var meanRunS = 0
         /// Runs rejected by each qualification gate, and the survivors.

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
@@ -172,15 +172,16 @@ public enum WorkoutDetector {
         public var bridged = 0
         /// The LONGEST and MEAN bridged run, in seconds, before any qualification gate drops anything.
         ///
-        /// These separate the only two stories a `kept=0` day can tell, and the counts alone cannot. A
-        /// field log showing 22 days of `kept=0` with ~100 runs and ~2 h of daily "active" time is equally
-        /// consistent with normal life (stairs and walking brushing past `restHR+15` in one-minute bursts
-        /// — an honest zero) and with a real session shattered into sub-threshold fragments (a bug).
-        /// Telling them apart needed `longestRunS`: below `minExerciseMin` it is daily life, and a
-        /// 25-minute run still dropped is a defect worth chasing.
+        /// They answer how SUBSTANTIAL the best candidate was, which the counts cannot. `droppedShort` is
+        /// checked first and short-circuits, so `droppedLowIntensity` already implies some run cleared the
+        /// duration bar — but not by how much, and that is the whole difference between a candidate
+        /// scraping five minutes and an hour-long effort rejected on intensity. The second is worth
+        /// investigating; the first is a walk.
         ///
-        /// Without them the question could only be settled by asking the user whether they had trained,
-        /// which is precisely the round-trip an always-on diagnostic exists to remove.
+        /// From the field log that motivated this: 22 days of `kept=0`, 1271 runs that never reached
+        /// `minExerciseMin` and 390 that did and failed the intensity bar instead. The counts said the
+        /// duration gate was not the whole story; only `longestRunS` says whether what survived it was a
+        /// five-minute stroll or something that should have scored.
         public var longestRunS = 0
         public var meanRunS = 0
         /// Runs rejected by each qualification gate, and the survivors.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DetectionFunnelTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DetectionFunnelTests.swift
@@ -156,6 +156,10 @@ final class DetectionFunnelTests: XCTestCase {
     /// Both fixtures carry the SAME counts, taken from a real 22-day log (79 bridged, 64 short, 15
     /// low-intensity, kept=0). Only `longestRunS` tells them apart.
     func testTheLongestRunSizesWhatSurvivedTheDurationGate() {
+        // The bar a run must clear is minDurS MINUS the smoothing window, not a round five minutes —
+        // pinned here so the 290 s quoted in the field's doc cannot go stale if either constant is tuned.
+        let effectiveBarS = Int(WorkoutDetector.minExerciseMin * 60 - WorkoutDetector.motionSmoothS)
+        XCTAssertEqual(effectiveBarS, 290)
         let minDurS = Int(WorkoutDetector.minExerciseMin * 60)
 
         // A walk: the longest survivor barely clears five minutes, so kept=0 is an honest zero.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DetectionFunnelTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DetectionFunnelTests.swift
@@ -137,11 +137,36 @@ final class DetectionFunnelTests: XCTestCase {
         f.restingHR = 59; f.hrFloor = 74
         f.motionPassed = 1203; f.hrMissing = 12; f.hrTooLow = 1103; f.active = 88
         f.runs = 6; f.bridged = 4
+        f.longestRunS = 212; f.meanRunS = 74
         f.droppedShort = 4; f.droppedNoHR = 0; f.droppedLowIntensity = 0; f.kept = 0
         XCTAssertEqual(
             WorkoutDetector.detectionFunnelLine(day: "2026-08-24", funnel: f),
             "effort detect day=2026-08-24 hr=34137 motion=34136 restHR=59 floor=74 "
                 + "motionOK=1203 hrMissing=12 hrTooLow=1103 active=88 runs=6 bridged=4 "
+                + "longestRunS=212 meanRunS=74 "
                 + "short=4 noHR=0 lowIntensity=0 kept=0")
+    }
+
+    /// The field case these two fields exist for.
+    ///
+    /// A real log showed 22 days of `kept=0` with ~100 runs a day and ~2 h of "active" time. The counts
+    /// alone cannot say whether that is normal life clearing `restHR+15` in one-minute bursts (an honest
+    /// zero) or a real session shattered into fragments (a bug) — settling it took asking the user
+    /// whether they had trained. `longestRunS` answers it from the line: 74 s against a five-minute bar
+    /// is daily life, and no threshold change would rescue it.
+    func testTheLongestRunSeparatesAnHonestZeroFromAShatteredBout() {
+        var daily = WorkoutDetector.DetectionFunnel()
+        daily.bridged = 79; daily.longestRunS = 74; daily.meanRunS = 41
+        daily.droppedShort = 64; daily.droppedLowIntensity = 15; daily.kept = 0
+        let dailyLine = WorkoutDetector.detectionFunnelLine(day: "2026-08-24", funnel: daily)
+        XCTAssertTrue(dailyLine.contains("longestRunS=74"))
+        XCTAssertLessThan(daily.longestRunS, Int(WorkoutDetector.minExerciseMin * 60),
+                          "74 s cannot clear a five-minute bar — kept=0 is correct, not a defect")
+
+        var shattered = WorkoutDetector.DetectionFunnel()
+        shattered.bridged = 79; shattered.longestRunS = 1500; shattered.meanRunS = 900
+        shattered.droppedShort = 64; shattered.droppedLowIntensity = 15; shattered.kept = 0
+        XCTAssertGreaterThan(shattered.longestRunS, Int(WorkoutDetector.minExerciseMin * 60),
+                             "a 25-minute run dropped with kept=0 is the reading that IS worth chasing")
     }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DetectionFunnelTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DetectionFunnelTests.swift
@@ -147,26 +147,33 @@ final class DetectionFunnelTests: XCTestCase {
                 + "short=4 noHR=0 lowIntensity=0 kept=0")
     }
 
-    /// The field case these two fields exist for.
+    /// The field case these two fields exist for, with the gate ORDER that makes them necessary.
     ///
-    /// A real log showed 22 days of `kept=0` with ~100 runs a day and ~2 h of "active" time. The counts
-    /// alone cannot say whether that is normal life clearing `restHR+15` in one-minute bursts (an honest
-    /// zero) or a real session shattered into fragments (a bug) — settling it took asking the user
-    /// whether they had trained. `longestRunS` answers it from the line: 74 s against a five-minute bar
-    /// is daily life, and no threshold change would rescue it.
-    func testTheLongestRunSeparatesAnHonestZeroFromAShatteredBout() {
-        var daily = WorkoutDetector.DetectionFunnel()
-        daily.bridged = 79; daily.longestRunS = 74; daily.meanRunS = 41
-        daily.droppedShort = 64; daily.droppedLowIntensity = 15; daily.kept = 0
-        let dailyLine = WorkoutDetector.detectionFunnelLine(day: "2026-08-24", funnel: daily)
-        XCTAssertTrue(dailyLine.contains("longestRunS=74"))
-        XCTAssertLessThan(daily.longestRunS, Int(WorkoutDetector.minExerciseMin * 60),
-                          "74 s cannot clear a five-minute bar — kept=0 is correct, not a defect")
+    /// `droppedShort` is tested first and short-circuits, so a non-zero `droppedLowIntensity` already
+    /// proves some run cleared the duration bar. What it cannot say is by how much — and that is the
+    /// whole difference between a five-minute stroll and an hour-long effort wrongly rejected.
+    ///
+    /// Both fixtures carry the SAME counts, taken from a real 22-day log (79 bridged, 64 short, 15
+    /// low-intensity, kept=0). Only `longestRunS` tells them apart.
+    func testTheLongestRunSizesWhatSurvivedTheDurationGate() {
+        let minDurS = Int(WorkoutDetector.minExerciseMin * 60)
 
-        var shattered = WorkoutDetector.DetectionFunnel()
-        shattered.bridged = 79; shattered.longestRunS = 1500; shattered.meanRunS = 900
-        shattered.droppedShort = 64; shattered.droppedLowIntensity = 15; shattered.kept = 0
-        XCTAssertGreaterThan(shattered.longestRunS, Int(WorkoutDetector.minExerciseMin * 60),
-                             "a 25-minute run dropped with kept=0 is the reading that IS worth chasing")
+        // A walk: the longest survivor barely clears five minutes, so kept=0 is an honest zero.
+        var walk = WorkoutDetector.DetectionFunnel()
+        walk.bridged = 79; walk.longestRunS = 312; walk.meanRunS = 41
+        walk.droppedShort = 64; walk.droppedLowIntensity = 15; walk.kept = 0
+        XCTAssertTrue(WorkoutDetector.detectionFunnelLine(day: "2026-08-24", funnel: walk)
+            .contains("longestRunS=312"))
+        XCTAssertLessThan(walk.longestRunS, 2 * minDurS, "barely over the bar — a walk")
+
+        // Identical counts, hour-long survivor: that is the reading worth chasing.
+        var suspicious = WorkoutDetector.DetectionFunnel()
+        suspicious.bridged = 79; suspicious.longestRunS = 3600; suspicious.meanRunS = 41
+        suspicious.droppedShort = 64; suspicious.droppedLowIntensity = 15; suspicious.kept = 0
+        XCTAssertEqual(walk.droppedShort, suspicious.droppedShort,
+                       "the counts alone cannot distinguish the two")
+        XCTAssertEqual(walk.droppedLowIntensity, suspicious.droppedLowIntensity)
+        XCTAssertGreaterThan(suspicious.longestRunS, 6 * minDurS,
+                             "an hour-long run rejected on intensity is what this field exists to surface")
     }
 }

--- a/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
+++ b/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
@@ -137,6 +137,21 @@ object WorkoutDetector {
         /** Contiguous runs after gap-merging, and after the #303 HR-gated bridge. */
         var runs: Int = 0,
         var bridged: Int = 0,
+        /**
+         * The LONGEST and MEAN bridged run, in seconds, before any qualification gate drops anything.
+         *
+         * These separate the only two stories a `kept=0` day can tell, and the counts alone cannot.
+         * A field log showing 22 days of `kept=0` with ~100 runs and ~2 h of daily "active" time is
+         * equally consistent with normal life (stairs and walking brushing past `restHR+15` in
+         * one-minute bursts — an honest zero) and with a real session shattered into sub-threshold
+         * fragments (a bug). Telling them apart needed [longestRunS]: below [minExerciseMin] it is
+         * daily life, and a 25-minute run still dropped is a defect worth chasing.
+         *
+         * Without them the question could only be settled by asking the user whether they had trained,
+         * which is precisely the round-trip an always-on diagnostic exists to remove.
+         */
+        var longestRunS: Int = 0,
+        var meanRunS: Int = 0,
         /** Runs rejected by each qualification gate, and the survivors. */
         var droppedShort: Int = 0,
         var droppedNoHR: Int = 0,
@@ -155,6 +170,7 @@ object WorkoutDetector {
             "restHR=${round0(f.restingHR)} floor=${round0(f.hrFloor)} " +
             "motionOK=${f.motionPassed} hrMissing=${f.hrMissing} hrTooLow=${f.hrTooLow} " +
             "active=${f.active} runs=${f.runs} bridged=${f.bridged} " +
+            "longestRunS=${f.longestRunS} meanRunS=${f.meanRunS} " +
             "short=${f.droppedShort} noHR=${f.droppedNoHR} lowIntensity=${f.droppedLowIntensity} " +
             "kept=${f.kept}"
 
@@ -474,6 +490,13 @@ object WorkoutDetector {
             // gaps. Runs over a genuine rest (HR falls to resting) are NOT bridged.
             val runs = bridgeRuns(rawRuns, hrSeg, hrFloor)
             f.bridged = runs.size
+            // Measured on the BRIDGED runs, before any qualification gate: this is the shape of what the
+            // detector was offered, which is the thing a `kept=0` day has to be judged against.
+            if (runs.isNotEmpty()) {
+                val durs = runs.map { maxOf(0L, it.second - it.first) }
+                f.longestRunS = durs.max().toInt()
+                f.meanRunS = (durs.sum() / durs.size).toInt()
+            }
 
             val minDurS = minExerciseMin * 60.0
             val sessions = ArrayList<ExerciseSession>()

--- a/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
+++ b/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
@@ -150,6 +150,11 @@ object WorkoutDetector {
          * [minExerciseMin] and 390 that did and failed the intensity bar instead. The counts said the
          * duration gate was not the whole story; only [longestRunS] says whether what survived it was a
          * five-minute stroll or something that should have scored.
+         *
+         * READ [longestRunS] AGAINST 290 s, NOT 300. The gate is `minDurS - motionSmoothS`
+         * (5 min − 10 s), because the smoothing window costs a run its first samples. Comparing against
+         * a round five minutes misjudges everything in the 290..300 window — a 295 s run cleared the
+         * gate and would look as though it had not.
          */
         var longestRunS: Int = 0,
         var meanRunS: Int = 0,

--- a/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
+++ b/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
@@ -140,15 +140,16 @@ object WorkoutDetector {
         /**
          * The LONGEST and MEAN bridged run, in seconds, before any qualification gate drops anything.
          *
-         * These separate the only two stories a `kept=0` day can tell, and the counts alone cannot.
-         * A field log showing 22 days of `kept=0` with ~100 runs and ~2 h of daily "active" time is
-         * equally consistent with normal life (stairs and walking brushing past `restHR+15` in
-         * one-minute bursts — an honest zero) and with a real session shattered into sub-threshold
-         * fragments (a bug). Telling them apart needed [longestRunS]: below [minExerciseMin] it is
-         * daily life, and a 25-minute run still dropped is a defect worth chasing.
+         * They answer how SUBSTANTIAL the best candidate was, which the counts cannot. [droppedShort] is
+         * checked first and short-circuits, so [droppedLowIntensity] already implies some run cleared the
+         * duration bar — but not by how much, and that is the whole difference between a candidate
+         * scraping five minutes and an hour-long effort rejected on intensity. The second is worth
+         * investigating; the first is a walk.
          *
-         * Without them the question could only be settled by asking the user whether they had trained,
-         * which is precisely the round-trip an always-on diagnostic exists to remove.
+         * From the field log that motivated this: 22 days of `kept=0`, 1271 runs that never reached
+         * [minExerciseMin] and 390 that did and failed the intensity bar instead. The counts said the
+         * duration gate was not the whole story; only [longestRunS] says whether what survived it was a
+         * five-minute stroll or something that should have scored.
          */
         var longestRunS: Int = 0,
         var meanRunS: Int = 0,

--- a/android/app/src/test/java/com/noop/analytics/DetectionFunnelTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DetectionFunnelTest.kt
@@ -175,33 +175,41 @@ class DetectionFunnelTest {
     }
 
     /**
-     * The field case these two fields exist for.
+     * The field case these two fields exist for, with the gate ORDER that makes them necessary.
      *
-     * A real log showed 22 days of `kept=0` with ~100 runs a day and ~2 h of "active" time. The counts
-     * alone cannot say whether that is normal life clearing `restHR+15` in one-minute bursts (an honest
-     * zero) or a real session shattered into fragments (a bug) — settling it took asking the user whether
-     * they had trained. [WorkoutDetector.DetectionFunnel.longestRunS] answers it from the line: 74 s
-     * against a five-minute bar is daily life, and no threshold change would rescue it.
+     * `droppedShort` is tested first and short-circuits, so a non-zero `droppedLowIntensity` already
+     * proves some run cleared the duration bar. What it cannot say is by how much — and that is the
+     * whole difference between a five-minute stroll and an hour-long effort wrongly rejected.
+     *
+     * Both fixtures below carry the SAME counts, taken from a real 22-day log (79 bridged, 64 short, 15
+     * low-intensity, kept=0). Only [WorkoutDetector.DetectionFunnel.longestRunS] tells them apart.
      */
     @Test
-    fun theLongestRunSeparatesAnHonestZeroFromAShatteredBout() {
-        val daily = WorkoutDetector.DetectionFunnel(
-            bridged = 79, longestRunS = 74, meanRunS = 41,
-            droppedShort = 64, droppedLowIntensity = 15, kept = 0,
-        )
-        assertTrue(WorkoutDetector.detectionFunnelLine("2026-08-24", daily).contains("longestRunS=74"))
-        assertTrue(
-            "74 s cannot clear a five-minute bar — kept=0 is correct, not a defect",
-            daily.longestRunS < (WorkoutDetector.minExerciseMin * 60).toInt(),
-        )
+    fun theLongestRunSizesWhatSurvivedTheDurationGate() {
+        val minDurS = (WorkoutDetector.minExerciseMin * 60).toInt()
 
-        val shattered = WorkoutDetector.DetectionFunnel(
-            bridged = 79, longestRunS = 1500, meanRunS = 900,
+        // A walk: the longest survivor barely clears five minutes, so kept=0 is an honest zero.
+        val walk = WorkoutDetector.DetectionFunnel(
+            bridged = 79, longestRunS = 312, meanRunS = 41,
             droppedShort = 64, droppedLowIntensity = 15, kept = 0,
         )
+        assertTrue(WorkoutDetector.detectionFunnelLine("2026-08-24", walk).contains("longestRunS=312"))
         assertTrue(
-            "a 25-minute run dropped with kept=0 is the reading that IS worth chasing",
-            shattered.longestRunS > (WorkoutDetector.minExerciseMin * 60).toInt(),
+            "the counts alone cannot distinguish this from the case below",
+            walk.droppedShort == 64 && walk.droppedLowIntensity == 15,
+        )
+        assertTrue("barely over the bar — a walk", walk.longestRunS < 2 * minDurS)
+
+        // Identical counts, hour-long survivor: that is the reading worth chasing.
+        val suspicious = WorkoutDetector.DetectionFunnel(
+            bridged = 79, longestRunS = 3600, meanRunS = 41,
+            droppedShort = 64, droppedLowIntensity = 15, kept = 0,
+        )
+        assertEquals(walk.droppedShort, suspicious.droppedShort)
+        assertEquals(walk.droppedLowIntensity, suspicious.droppedLowIntensity)
+        assertTrue(
+            "an hour-long run rejected on intensity is what this field exists to surface",
+            suspicious.longestRunS > 6 * minDurS,
         )
     }
 }

--- a/android/app/src/test/java/com/noop/analytics/DetectionFunnelTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DetectionFunnelTest.kt
@@ -162,13 +162,46 @@ class DetectionFunnelTest {
         val f = WorkoutDetector.DetectionFunnel(
             hrSamples = 34137, motionSamples = 34136, restingHR = 59.0, hrFloor = 74.0,
             motionPassed = 1203, hrMissing = 12, hrTooLow = 1103, active = 88,
-            runs = 6, bridged = 4, droppedShort = 4, droppedNoHR = 0, droppedLowIntensity = 0, kept = 0,
+            runs = 6, bridged = 4, longestRunS = 212, meanRunS = 74,
+            droppedShort = 4, droppedNoHR = 0, droppedLowIntensity = 0, kept = 0,
         )
         assertEquals(
             "effort detect day=2026-08-24 hr=34137 motion=34136 restHR=59 floor=74 " +
                 "motionOK=1203 hrMissing=12 hrTooLow=1103 active=88 runs=6 bridged=4 " +
+                "longestRunS=212 meanRunS=74 " +
                 "short=4 noHR=0 lowIntensity=0 kept=0",
             WorkoutDetector.detectionFunnelLine("2026-08-24", f),
+        )
+    }
+
+    /**
+     * The field case these two fields exist for.
+     *
+     * A real log showed 22 days of `kept=0` with ~100 runs a day and ~2 h of "active" time. The counts
+     * alone cannot say whether that is normal life clearing `restHR+15` in one-minute bursts (an honest
+     * zero) or a real session shattered into fragments (a bug) — settling it took asking the user whether
+     * they had trained. [WorkoutDetector.DetectionFunnel.longestRunS] answers it from the line: 74 s
+     * against a five-minute bar is daily life, and no threshold change would rescue it.
+     */
+    @Test
+    fun theLongestRunSeparatesAnHonestZeroFromAShatteredBout() {
+        val daily = WorkoutDetector.DetectionFunnel(
+            bridged = 79, longestRunS = 74, meanRunS = 41,
+            droppedShort = 64, droppedLowIntensity = 15, kept = 0,
+        )
+        assertTrue(WorkoutDetector.detectionFunnelLine("2026-08-24", daily).contains("longestRunS=74"))
+        assertTrue(
+            "74 s cannot clear a five-minute bar — kept=0 is correct, not a defect",
+            daily.longestRunS < (WorkoutDetector.minExerciseMin * 60).toInt(),
+        )
+
+        val shattered = WorkoutDetector.DetectionFunnel(
+            bridged = 79, longestRunS = 1500, meanRunS = 900,
+            droppedShort = 64, droppedLowIntensity = 15, kept = 0,
+        )
+        assertTrue(
+            "a 25-minute run dropped with kept=0 is the reading that IS worth chasing",
+            shattered.longestRunS > (WorkoutDetector.minExerciseMin * 60).toInt(),
         )
     }
 }

--- a/android/app/src/test/java/com/noop/analytics/DetectionFunnelTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DetectionFunnelTest.kt
@@ -186,6 +186,11 @@ class DetectionFunnelTest {
      */
     @Test
     fun theLongestRunSizesWhatSurvivedTheDurationGate() {
+        // The bar a run must clear is minDurS MINUS the smoothing window, not a round five minutes —
+        // pinned here so the 290 s quoted in the field's doc cannot go stale if either constant is tuned.
+        val effectiveBarS =
+            (WorkoutDetector.minExerciseMin * 60 - WorkoutDetector.motionSmoothS).toInt()
+        assertEquals(290, effectiveBarS)
         val minDurS = (WorkoutDetector.minExerciseMin * 60).toInt()
 
         // A walk: the longest survivor barely clears five minutes, so kept=0 is an honest zero.


### PR DESCRIPTION
Diagnostic only. The detector is untouched and no number moves.

## What a field log showed

A WHOOP 4.0 strap log, 22 days, every one `kept=0`:

| | |
|---|---|
| candidate runs | 2,211 |
| after the #303 bridge | 1,661 |
| never reached `minExerciseMin` | 1,271 |
| cleared duration, **failed intensity** | 390 |
| **kept** | **0** |

`droppedShort` is tested first and short-circuits, so that second row means **sustained five-minute-plus efforts reached the intensity gate on all 22 days** — roughly 18 a day. The detector was right to reject them (the reporter confirmed they had not trained; sustained walking is not a workout), and the funnel's arithmetic is self-consistent throughout.

I also cleared the plausible bugs: `bridgeGapS` is 300 s, and `bridgeRuns` already treats an **empty** gap-HR as a sensor dropout and bridges it, so 4.0 motion sparsity was not silently shattering bouts.

## The gap

The counts say *where* candidates died. They cannot say **how substantial** the best survivor was — and that is the whole difference between:

- a five-minute stroll rejected on intensity — routine, an honest zero; and
- an hour-long effort rejected on intensity — a defect worth chasing.

Both print identical counts. Working the first case out from this log meant inferring run length by dividing `active` by `runs`, which gave the wrong answer (it suggested one-minute bursts, while `lowIntensity=15` proved runs were clearing five minutes every day).

## The change

`DetectionFunnel` gains `longestRunS` and `meanRunS`, measured on the **bridged** runs before any qualification gate:

```
… active=6021 runs=89 bridged=79 longestRunS=312 meanRunS=41 short=64 lowIntensity=15 kept=0
```

## Verification

- Byte-identical line on both platforms; field order checked in both emitters.
- A test per side pins the case that matters: **two fixtures with identical counts taken from this log**, separated only by `longestRunS` — 312 s (a walk) against 3600 s (worth chasing). The counts alone cannot tell them apart, which is the point.
- Kotlin verified locally: `DetectionFunnelTest` 10/10, full suite **4307** green, `assembleFullDebug` and doc lint clean.
- **`StrandAnalytics` cannot build on Linux** (GRDB's CSQLite needs `sqlite3.h`, per CLAUDE.md), so the Swift twin rides `swift-packages` CI rather than a local run.

## Note on the second commit

The first commit read the same log as one-minute bursts of daily life and wrote that into both the docs and the tests. That contradicted the counts printed beside it — `droppedLowIntensity` cannot be non-zero unless runs cleared the duration bar. The second commit corrects the reading and replaces both fixtures, which previously could be distinguished by their counts alone and so did not test what they claimed to.
