### PR TITLE
Android: match the Workouts action-row buttons (#1602)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/WorkoutStart.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutStart.kt
@@ -236,7 +236,17 @@ fun WorkoutStartSection(vm: AppViewModel, onAdd: () -> Unit) {
         }
     } else if (live.bonded) {
         // Start + Add as an equal-width action row (EXP-018 parity with the iOS workoutActionRow).
-        Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+        //
+        // #1602: CENTRED, not top-aligned. A Row defaults to `Alignment.Top`, so any height difference
+        // between the two children showed as one button riding higher than the other — which is how this
+        // was reported. The heights are now matched in `AddWorkoutButton`, so this is belt-and-braces:
+        // it keeps a future divergence looking like a size difference rather than a broken layout.
+        // SwiftUI's HStack centres by default, which is why the iOS twin never showed it.
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
             Button(
                 onClick = { showSportPicker = true },
                 modifier = Modifier.weight(1f),

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -136,6 +136,8 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
 import kotlin.math.roundToInt
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.material3.ButtonDefaults
 
 /**
  * Workouts — the activity log, instrument-grade and uniform. Ports the macOS
@@ -436,12 +438,29 @@ private fun PostLogNoteBanner(text: String) {
     }
 }
 
-/** The "Add workout" pill — opens the manual add dialog. Shown on both the populated screen
- *  (in the range bar) and the empty state, so a user with no imports can still log a session. */
+/**
+ * The "Add workout" pill — opens the manual add dialog. Shown on both the populated screen
+ * (in the range bar) and the empty state, so a user with no imports can still log a session.
+ *
+ * #1602: this sits beside a Material3 [Button] in the Workouts action row, and the two are built by
+ * different mechanisms — so their metrics have to be matched deliberately or they drift. A `Button`
+ * carries `defaultMinSize(minHeight = ButtonDefaults.MinHeight)`; a bare `Row` has no minimum at all,
+ * so its height was whatever the content happened to be plus its padding, and the pair rendered at
+ * different heights with different label sizes.
+ *
+ * Both are pinned here: the same minimum height as a `Button`, and the same [NoopType.captionNumber]
+ * the Start button uses. iOS has never had this because both of its buttons come from ONE primitive
+ * (`NoopButton`, differing only by `kind`) — the real fix is an Android equivalent, and until that
+ * exists this is the seam that has to be held by hand.
+ */
 @Composable
 internal fun AddWorkoutButton(onAdd: () -> Unit, modifier: Modifier = Modifier) {
     Row(
         modifier = modifier
+            // Constraint first, decoration after: the shape and fill are then computed against the
+            // final height rather than reading as though they set it. (Compose measures the node the
+            // same either way here — this is ordering for legibility, not a fix for a real clip bug.)
+            .defaultMinSize(minHeight = ButtonDefaults.MinHeight)
             .clip(RoundedCornerShape(50))
             .background(Palette.accentMuted)
             .clickable(onClick = onAdd)
@@ -451,7 +470,11 @@ internal fun AddWorkoutButton(onAdd: () -> Unit, modifier: Modifier = Modifier) 
     ) {
         Icon(Icons.Filled.Add, contentDescription = null, tint = Palette.accent, modifier = Modifier.size(16.dp))
         Spacer(Modifier.width(6.dp))
-        Text(uiString(R.string.l10n_workouts_screen_add_workout_a196a2cc), style = NoopType.subhead, color = Palette.accent)
+        Text(
+            uiString(R.string.l10n_workouts_screen_add_workout_a196a2cc),
+            style = NoopType.captionNumber,
+            color = Palette.accent,
+        )
     }
 }
 

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -110,6 +110,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Size
@@ -136,8 +138,6 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
 import kotlin.math.roundToInt
-import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.material3.ButtonDefaults
 
 /**
  * Workouts — the activity log, instrument-grade and uniform. Ports the macOS
@@ -457,26 +457,19 @@ private fun PostLogNoteBanner(text: String) {
 internal fun AddWorkoutButton(onAdd: () -> Unit, modifier: Modifier = Modifier) {
     Row(
         modifier = modifier
-            // Constraint first, decoration after: the shape and fill are then computed against the
-            // final height rather than reading as though they set it. (Compose measures the node the
-            // same either way here — this is ordering for legibility, not a fix for a real clip bug.)
-            //
-            // `ButtonDefaults.MinHeight` rather than a NOOP token, deliberately. The design system has
-            // no control-height token on Android — iOS keeps one (`NoopMetrics.controlHeight`, 48) and
-            // Android has nothing equivalent — and the goal here is not "be 40.dp", it is "be whatever
-            // the Button beside me is". Minting a NOOP constant at today's value would match by
-            // coincidence and drift the moment Material changed its default, which is the failure this
-            // whole change exists to remove. A shared primitive owning both is the real fix.
+            // Material's constant, not a NOOP token: the goal is not "be 40.dp", it is "be whatever the
+            // Button beside me is". Android has no control-height token to reach for (iOS keeps one,
+            // `NoopMetrics.controlHeight` = 48), and minting one at today's value would match by
+            // coincidence and drift the moment Material changed its default.
             .defaultMinSize(minHeight = ButtonDefaults.MinHeight)
             .clip(RoundedCornerShape(50))
             .background(Palette.accentMuted)
             .clickable(onClick = onAdd)
-            // Horizontal padding matches the Start button's contentPadding (10.dp), not the 14.dp this
-            // used to carry. Width is fixed by `weight(1f)` so this is invisible in English — it only
-            // shows once a label is long enough to compete for the space. This button already gives up
-            // 22.dp to its icon and spacer that Start does not, and the longest translations are
-            // comparable in length between the two ("Ajouter un entraînement" against "Démarrer
-            // l'entraînement"), so the 8.dp was pure asymmetry: Add would ellipsize first.
+            // 10.dp matches the Start button's contentPadding; this used to carry 14.dp. Invisible in
+            // English — width is fixed by `weight(1f)` — but this button already gives up 22.dp to an
+            // icon and spacer that Start has not, and the long translations are comparable in length
+            // ("Ajouter un entraînement" against "Démarrer l'entraînement"), so the extra 8.dp only
+            // decided which label ellipsized first.
             .padding(horizontal = 10.dp, vertical = 10.dp),
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -460,6 +460,13 @@ internal fun AddWorkoutButton(onAdd: () -> Unit, modifier: Modifier = Modifier) 
             // Constraint first, decoration after: the shape and fill are then computed against the
             // final height rather than reading as though they set it. (Compose measures the node the
             // same either way here — this is ordering for legibility, not a fix for a real clip bug.)
+            //
+            // `ButtonDefaults.MinHeight` rather than a NOOP token, deliberately. The design system has
+            // no control-height token on Android — iOS keeps one (`NoopMetrics.controlHeight`, 48) and
+            // Android has nothing equivalent — and the goal here is not "be 40.dp", it is "be whatever
+            // the Button beside me is". Minting a NOOP constant at today's value would match by
+            // coincidence and drift the moment Material changed its default, which is the failure this
+            // whole change exists to remove. A shared primitive owning both is the real fix.
             .defaultMinSize(minHeight = ButtonDefaults.MinHeight)
             .clip(RoundedCornerShape(50))
             .background(Palette.accentMuted)

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -464,7 +464,13 @@ internal fun AddWorkoutButton(onAdd: () -> Unit, modifier: Modifier = Modifier) 
             .clip(RoundedCornerShape(50))
             .background(Palette.accentMuted)
             .clickable(onClick = onAdd)
-            .padding(horizontal = 14.dp, vertical = 10.dp),
+            // Horizontal padding matches the Start button's contentPadding (10.dp), not the 14.dp this
+            // used to carry. Width is fixed by `weight(1f)` so this is invisible in English — it only
+            // shows once a label is long enough to compete for the space. This button already gives up
+            // 22.dp to its icon and spacer that Start does not, and the longest translations are
+            // comparable in length between the two ("Ajouter un entraînement" against "Démarrer
+            // l'entraînement"), so the 8.dp was pure asymmetry: Add would ellipsize first.
+            .padding(horizontal = 10.dp, vertical = 10.dp),
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,
     ) {


### PR DESCRIPTION
Reported by @bartmuskala with a screenshot: "Start workout" and "Add workout" render at different heights with different label sizes.

## Why

The two are built by different mechanisms, and nothing tied their metrics together:

| | Start workout | Add workout |
|---|---|---|
| component | Material3 `Button` | hand-rolled `Row` |
| min height | `ButtonDefaults.MinHeight` | **none** — content + 20 dp |
| label | `captionNumber` (12 sp Medium) | `subhead` (13 sp Normal) |

So the pair could only line up by coincidence. Compounding it, the row set no `verticalAlignment`, and Compose defaults to `Alignment.Top` — which turned any height difference into one button visibly riding higher rather than centring it out.

## The change

`AddWorkoutButton` takes the same minimum height as a `Button` and the same `captionNumber` style; the row centres.

The centring is belt-and-braces once the heights match — it keeps a future divergence looking like a size difference rather than a broken layout.

## The parity note

That row's comment claims *"EXP-018 parity with the iOS workoutActionRow"*. The layout intent matched; the implementation did not. iOS builds **both** buttons from one primitive:

```swift
NoopButton("Add workout",   systemImage: "plus",       kind: .secondary, fullWidth: true)
NoopButton("Start workout", systemImage: "figure.run", kind: .primary,   fullWidth: true)
```

Identical metrics by construction, and `HStack` centres by default — which is why iOS has never shown this. An Android equivalent is the real fix for the class; this holds the seam by hand until one exists. **Android-only: this closes a parity gap rather than opening one.**

## Blast radius

The style change reaches `AddWorkoutButton`'s two full-width call sites as well (the active-workout column and the no-strap empty state). That is deliberate — every "Add workout" now matches the button it is paired with — but it is a visible change beyond the reported screen, so it is worth knowing before merge.

No strings added or removed.

## Verification, and its limit

- `compileFullDebugKotlin`, full Android suite **4307** green, `assembleFullDebug` clean, doc lint clean, i18n audit exit 0.
- **Not unit-tested, and it can't be**: this project has no Compose UI test harness (no `createComposeRule`, no `androidx.compose.ui.test`), so the suite cannot see layout at all. The tests above prove nothing broke; they cannot prove the buttons now align.
- **Needs an on-device look** to confirm the fix, ideally by the reporter on the same screen.

One thing I checked rather than assumed: the Start button's fill in the screenshot measures 105 px, which is consistent with `ButtonDefaults.MinHeight` at this device's scale — I did not verify the exact density, so I am not claiming an exact dp conversion, only that the measurement matches the constant the code uses.
