### PR TITLE
Android: fill imported workout HR under the active strap (#1601)

### DIFF
--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1074,9 +1074,14 @@ class WhoopRepository(
         //
         // The multi-strap ambiguity is not resolved by this, and is not made worse by it either: the union
         // and its first-wins merge are exactly what the chart already applies to the same window, so the two
-        // now agree rather than disagreeing. A caller that genuinely wants the canonical id can still pass
-        // it; the default stays canonical so no non-UI caller changes behaviour.
-        strapDeviceId: String = "my-whoop",
+        // now agree rather than disagreeing.
+        //
+        // REQUIRED, no default. The canonical default is what caused this — #857 unified the RESOLVER
+        // ("one HR device-id rule for the chart, zones, Avg HR and HRR") but this parameter, inherited from
+        // #77, kept feeding it a different active id, so the one rule ran on two inputs and Avg HR was the
+        // surface that missed out. Nothing depended on the default once both call sites were corrected, and
+        // a caller that cannot name the strap it means should not be silently given the canonical one.
+        strapDeviceId: String,
         minSamples: Long = 60,
         cap: Int = 300,
         // #961: the user's HRmax + sex. When supplied, a strap-native row whose Effort (strain) is null gets

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1061,9 +1061,21 @@ class WhoopRepository(
         rows: List<WorkoutRow>,
         // HR read key for IMPORTED rows ONLY (Apple/HC/CSV/activity file): they carry no strap HR of their
         // own, so #77 derives it from the worn strap. STRAP-NATIVE rows ignore this and key on their OWN
-        // recording strap (see [workoutHrDeviceIds]). The canonical "my-whoop" default is the worn strap on a
-        // single-WHOOP install (and every current caller uses it); which strap was worn during an imported
-        // session on a MULTI-strap install is undetermined, so that case is left as-is (not the active strap).
+        // recording strap (see [workoutHrDeviceIds]).
+        //
+        // #1601: both UI callers now pass the ACTIVE strap id. This used to be left at the canonical
+        // default on the reasoning that which strap was worn during an imported session is undetermined on
+        // a MULTI-strap install — true, but it made the common SINGLE-strap case wrong, because an install
+        // whose one strap banks under a non-canonical id (a re-add, or a 5/MG's transient CB-UUID pairing,
+        // #1193) resolved `importedSourceIdsFor("my-whoop")` to the canonical id ALONE while the detail
+        // sheet's chart, zones and HR-recovery resolved active ∪ canonical. The graph found HR and this
+        // fill did not, so the session showed "AVG –" against a populated curve — the state this function's
+        // own promise of "display == graph == zones == effort by construction" exists to prevent.
+        //
+        // The multi-strap ambiguity is not resolved by this, and is not made worse by it either: the union
+        // and its first-wins merge are exactly what the chart already applies to the same window, so the two
+        // now agree rather than disagreeing. A caller that genuinely wants the canonical id can still pass
+        // it; the default stays canonical so no non-UI caller changes behaviour.
         strapDeviceId: String = "my-whoop",
         minSamples: Long = 60,
         cap: Int = 300,

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1768,8 +1768,17 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
             // manual rows already carry their own HR so they pass through unchanged. #961: also backfill a
             // strap-native row's Effort (strain) from the strap trace when it's null, so a live/manual
             // session that ended with sparse HR can't show a blank Effort while the day total counted it.
+            // #1601: pass the ACTIVE strap id. Left to its "my-whoop" default, the fill resolved
+            // `importedSourceIdsFor("my-whoop")` = the canonical id ALONE, while the detail sheet's chart,
+            // zones and HR-recovery all resolve `importedSourceIdsFor(deviceId)` = active ∪ canonical. On
+            // an install whose strap banks under a non-canonical id the chart therefore found HR and this
+            // fill did not, and an imported session rendered "AVG –" beside a populated graph, a full zone
+            // split and a peak — every one of them derived from the samples the average claimed not to
+            // have. The fill's own doc promises "display == graph == zones == effort by construction";
+            // this is the line that has to pass the same id for that to hold.
             val filled = repository.fillWorkoutHrFromStrap(
                 (whoop + apple + detected + activityFiles),
+                strapDeviceId = deviceId,
                 strainMaxHR = profileStore.hrMax.toDouble(),
                 strainSex = profileStore.sex,
                 effortMethod = NoopPrefs.effortMethod(appContext),

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1110,8 +1110,15 @@ fun TodayScreen(
             // fillWorkoutHrFromStrap: imported sessions carry no HR, derive it from strap samples (#77).
             // #510: strap-native rows now read HR under their OWN recording strap (inside the fill), so a 2nd
             // WHOOP's workouts reconcile Avg HR + Effort from their own trace; imported rows keep the default.
+            // #1601: the ACTIVE strap id, not the "my-whoop" default — see the AppViewModel call site.
+            // Left defaulted, an imported row on a non-canonical install reads only the canonical id here
+            // while every other surface reads active ∪ canonical, so its Avg HR stays blank against a
+            // populated graph.
             recentWorkouts = viewModel.repo.fillWorkoutHrFromStrap(
-                recentUnion, effortMethod = NoopPrefs.effortMethod(context)),
+                recentUnion,
+                strapDeviceId = viewModel.deviceId,
+                effortMethod = NoopPrefs.effortMethod(context),
+            ),
             whoopDays = days.size,
             whoopWorkouts = whoopWorkouts.size,
             appleDays = appleDaysCount,

--- a/android/app/src/test/java/com/noop/data/WorkoutHrDeviceKeyTest.kt
+++ b/android/app/src/test/java/com/noop/data/WorkoutHrDeviceKeyTest.kt
@@ -119,4 +119,32 @@ class WorkoutHrDeviceKeyTest {
             WhoopRepository.workoutHrDeviceIds("manual", rowDeviceId = "my-whoop", activeStrapId = "whoop-aabbcc"),
         )
     }
+
+    @Test fun `passing the canonical id as activeStrapId defeats the union entirely`() {
+        // #1601 (bartmuskala again, same symptom as the test above): the union fix only works if the
+        // caller HANDS IT the active strap. `fillWorkoutHrFromStrap` took a `strapDeviceId` defaulting to
+        // the canonical id and both UI call sites left it defaulted, so an imported row resolved to the
+        // canonical id ALONE — while the detail sheet's chart, zones and HR-recovery resolved the real
+        // union. The graph found the trace and the Avg HR fill did not, so a Health Connect session
+        // rendered "AVG –" beside a populated curve and a full zone split drawn from the same samples.
+        //
+        // This pins the asymmetry rather than the call site (which is a ViewModel hop and not reachable
+        // from a Robolectric-free suite): the two inputs resolve to DIFFERENT id sets, and the canonical
+        // one is a strict subset that cannot see a non-canonical strap's samples.
+        val viaActive = WhoopRepository.workoutHrDeviceIds(
+            "health-connect", rowDeviceId = "health-connect", activeStrapId = "whoop-aabbcc")
+        val viaCanonicalConstant = WhoopRepository.workoutHrDeviceIds(
+            "health-connect", rowDeviceId = "health-connect", activeStrapId = "my-whoop")
+
+        assertEquals(listOf("whoop-aabbcc", "my-whoop"), viaActive)
+        assertEquals(listOf("my-whoop"), viaCanonicalConstant)
+        assertTrue(
+            "the canonical constant must be a STRICT subset — that is why the fill missed the trace",
+            viaActive.containsAll(viaCanonicalConstant) && viaActive.size > viaCanonicalConstant.size,
+        )
+        assertFalse(
+            "and it cannot see the strap that actually recorded the session",
+            viaCanonicalConstant.contains("whoop-aabbcc"),
+        )
+    }
 }


### PR DESCRIPTION
Reported by @bartmuskala: three Health Connect cycling sessions, same source, rendering three different pages.

## What was actually wrong

Two of the pages **contradict themselves**. They show `AVG –` beside a populated HR curve, a `PEAK`, a `LOW`, a full zone split labelled *"From strap HR"*, and — on one — a complete HR-recovery block. Every one of those is computed from the samples the average claims not to have.

The chart, zones and recovery resolve their read key as:

```kotlin
workoutHrDeviceIds(source, rowDeviceId, activeStrapId = vm.deviceId)   // → active ∪ canonical
```

`fillWorkoutHrFromStrap` takes a `strapDeviceId` defaulting to the canonical id, and **both** UI call sites left it defaulted:

```kotlin
importedSourceIdsFor("my-whoop")   // → ["my-whoop"] — canonical ALONE
importedSourceIdsFor(active)       // → [active, "my-whoop"]
```

So on an install whose strap banks under a non-canonical id — a re-add, or a 5/MG's transient CB-UUID pairing (#1193) — the graph finds the trace and the fill does not. The row keeps a null `avgHr`, the summary omits its Avg/Max rows entirely, and the chart's Avg has no series fallback, so it dashes.

## This is #836/#928 again, for the same reporter

The last test in `WorkoutHrDeviceKeyTest` reads:

> *"a manual workout on a re-added strap reads the active union, not the stale my-whoop … reading only `my-whoop` (the pre-fix behaviour) hit an empty window and **left Avg HR / Effort blank**"*

That fix made `workoutHrDeviceIds` return the union for exactly this symptom — and then this call site handed it a constant, which defeats it. **The union only works if the caller passes the active strap.** Both call sites now do; the default is unchanged, so no non-UI caller moves.

## Parity

**Swift never had this.** `reconcileWorkoutHrWithTrace` has no `strapDeviceId` parameter at all — it reads the Repository's active `deviceId` directly (`Repository.swift:2543`). This brings Android to the reference implementation rather than changing shared behaviour, so there is no Swift twin to write.

## The doc I had to overrule

The parameter's comment said the canonical default was deliberate, because which strap was worn during an imported session is undetermined on a **multi**-strap install. That is true and this does not resolve it — but it made the common **single**-strap case wrong, and the union with its first-wins merge is precisely what the chart already applies to the same window. The two now agree rather than disagreeing. I rewrote the doc to say that instead of the opposite, rather than leaving a comment that contradicts the code.

## Verification

- Full Android suite **4308** green (4307 + the new case), `assembleFullDebug`, doc lint clean.
- The new test pins the **asymmetry**, not the call site — a ViewModel hop is not reachable from a Robolectric-free suite. It asserts the canonical constant resolves to a *strict subset* that cannot see a non-canonical strap's samples, which is the mechanism.
- **Not confirmed against the reporter's device.** The issue carried no strap log, so I cannot verify their active id is non-canonical — though a WHOOP 5.0 makes it likely given #1193. The fix is correct regardless (it restores the documented `display == graph == zones == effort` invariant and can only widen the id set, never narrow it), but whether it resolves *their* three pages wants a check.

## Deliberately not in this PR

- The chart's `Avg` still has no series fallback while `Peak` does (`?: hi`). With the fill working that no longer shows, but it remains an inconsistency worth its own change — and doing it here would mean an average from bucketed data sitting next to one from an exact SQL aggregate.
- Android **omits** the Avg/Max summary rows when null where iOS dashes them.
- The "always effort score" half of the report: those rows have no captured strain, and computing one retroactively for an import means scoring a session the strap never recorded as a workout.
