### PR TITLE
Android: name the day on a chart's scrub read-out (#1600)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1905,6 +1905,12 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
         }
 
         val values = filteredPoints.map { it.second }
+        // #1600: remembered, unlike the plain projections above it. `shortDayLabel` parses a LocalDate and
+        // runs a DateTimeFormatter PER POINT, so leaving it inline would re-parse every day in the window
+        // on every recomposition — and the recompositions that matter are the ones a finger dragging
+        // across this chart produces. Keyed on `filteredPoints`, whose structural equality holds it stable
+        // across recompositions that do not change the window.
+        val dayLabels = remember(filteredPoints) { filteredPoints.map { shortDayLabel(it.first) } }
         val latest = filteredPoints.last()
         val min = values.minOrNull()
         val max = values.maxOrNull()
@@ -1957,7 +1963,7 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
                     // Derived from `filteredPoints`, the same (day, value) list `values` comes from, so the
                     // two are equal in length by construction rather than by luck — `LineChart` drops
                     // mismatched labels SILENTLY, which is a failure that looks exactly like doing nothing.
-                    selectionLabels = filteredPoints.map { shortDayLabel(it.first) },
+                    selectionLabels = dayLabels,
                     segmentIds = if (key == "vo2max_est") vo2MaxTrendSegmentIds(filteredReadings) else null,
                 )
                 Box(

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1949,6 +1949,15 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
                     color = detail.color,
                     fill = true,
                     selectionEnabled = true, // the Vital Signs detail chart is meant to be tappable
+                    // #1600: name the DAY on the scrub readout. `lineChartSelectionLabel` prints
+                    // "label · value" when given one and the bare value otherwise, so a chart that opts
+                    // into selection without labels answers "96" — a number with nothing to say which day
+                    // it belongs to, against a Trends chart that reads "16 Jul · 92" beside it.
+                    //
+                    // Derived from `filteredPoints`, the same (day, value) list `values` comes from, so the
+                    // two are equal in length by construction rather than by luck — `LineChart` drops
+                    // mismatched labels SILENTLY, which is a failure that looks exactly like doing nothing.
+                    selectionLabels = filteredPoints.map { shortDayLabel(it.first) },
                     segmentIds = if (key == "vo2max_est") vo2MaxTrendSegmentIds(filteredReadings) else null,
                 )
                 Box(

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -1024,11 +1024,16 @@ private fun MarkerTile(
 private fun StressTrendSection(model: StressModel, modifier: Modifier = Modifier) {
     var range by remember { mutableStateOf(StressRange.Month) }
     val points = remember(model, range) { model.windowedTrend(range) }
+    // #1600: derived ONCE per window, not per recomposition. `windowedTrend` now returns points rather
+    // than bare values, so the two projections the card needs are mapped here beside the memo they come
+    // from — otherwise each recomposition of a scrubbing chart rebuilds both lists.
+    val values = remember(points) { points.map { it.value } }
+    val dayLabels = remember(points) { points.map { shortDayLabel(it.day) } }
 
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
         SectionHeader("Stress Trend", overline = "History", trailing = range.label)
         if (points.size >= 2) {
-            val avg = points.map { it.value }.average()
+            val avg = values.average()
             NoopCard(tint = Palette.stressColor) {
                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                     Row(
@@ -1050,7 +1055,7 @@ private fun StressTrendSection(model: StressModel, modifier: Modifier = Modifier
                         )
                     }
                     LineChart(
-                        values = points.map { it.value },
+                        values = values,
                         modifier = Modifier.height(Metrics.chartHeight),
                         color = StressRamp.STEADY,
                         fill = true,
@@ -1058,7 +1063,7 @@ private fun StressTrendSection(model: StressModel, modifier: Modifier = Modifier
                         // #1600: the same omission the Vital Signs detail chart had — a dated daily
                         // trend that opted into selection and then had nothing to say but the number.
                         // Both lists map from the one windowed `points`, so they cannot desynchronise.
-                        selectionLabels = points.map { shortDayLabel(it.day) },
+                        selectionLabels = dayLabels,
                     )
                     HorizontalDivider(color = Palette.hairline)
                     Row(modifier = Modifier.fillMaxWidth()) {

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -1028,7 +1028,7 @@ private fun StressTrendSection(model: StressModel, modifier: Modifier = Modifier
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
         SectionHeader("Stress Trend", overline = "History", trailing = range.label)
         if (points.size >= 2) {
-            val avg = points.average()
+            val avg = points.map { it.value }.average()
             NoopCard(tint = Palette.stressColor) {
                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                     Row(
@@ -1050,11 +1050,15 @@ private fun StressTrendSection(model: StressModel, modifier: Modifier = Modifier
                         )
                     }
                     LineChart(
-                        values = points,
+                        values = points.map { it.value },
                         modifier = Modifier.height(Metrics.chartHeight),
                         color = StressRamp.STEADY,
                         fill = true,
                         selectionEnabled = true,
+                        // #1600: the same omission the Vital Signs detail chart had — a dated daily
+                        // trend that opted into selection and then had nothing to say but the number.
+                        // Both lists map from the one windowed `points`, so they cannot desynchronise.
+                        selectionLabels = points.map { shortDayLabel(it.day) },
                     )
                     HorizontalDivider(color = Palette.hairline)
                     Row(modifier = Modifier.fillMaxWidth()) {
@@ -1260,12 +1264,17 @@ internal class StressModel private constructor(
     data class TrendPoint(val day: String, val value: Double)
 
     /** The full daily proxy trend, sliced to the selected trailing window (count-based,
-     *  matching the day budget). Falls back to ALL when the trailing slice has < 2 points. */
-    fun windowedTrend(range: StressRange): List<Double> {
-        val all = fullTrend.map { it.value }
-        val days = range.days ?: return all
-        val slice = fullTrend.takeLast(days).map { it.value }
-        return if (slice.size >= 2) slice else all
+     *  matching the day budget). Falls back to ALL when the trailing slice has < 2 points.
+     *
+     *  #1600: returns the POINTS, not bare values. The chart needs the day beside each value to name
+     *  it on the scrub read-out, and deriving the labels from a second call that re-applied this
+     *  windowing — including the `size >= 2` fallback — would risk the two lists disagreeing. Charts
+     *  drop mismatched selection labels SILENTLY, so that divergence would present as the read-out
+     *  simply not working. One list, mapped twice at the call site, cannot desynchronise. */
+    fun windowedTrend(range: StressRange): List<TrendPoint> {
+        val days = range.days ?: return fullTrend
+        val slice = fullTrend.takeLast(days)
+        return if (slice.size >= 2) slice else fullTrend
     }
 
     companion object {


### PR DESCRIPTION
Reported by @bartmuskala with a side-by-side: the Vital Signs detail chart answers a tap with a bare `96`, while the Trends chart beside it reads `16 Jul · 92`.

## Why

`lineChartSelectionLabel` composes the read-out:

```kotlin
pointLabel?.takeIf { it.isNotBlank() }?.let { return "$it · $base" }   // "16 Jul · 92"
if (epochSec == null) return base                                      // "96"
return "$time · $base"                                                 // "14:32 · 87 bpm"
```

The Vital Signs chart passes `selectionEnabled = true` — it opts **into** being tappable — and then supplies neither a label nor timestamps, so the read-out has nothing to say beyond the number.

## The fix

The data was already in scope, under the same name the existing precedent uses. `SleepMetricDetailSheet` does this (#691):

```kotlin
selectionLabels = filteredPoints.map { shortDayLabel(it.first) },
```

and Vital Signs already had `filteredPoints` as `(day, value)` with `values` derived from it. Deriving the labels from that same list keeps the two equal in length **by construction** — which matters, because `LineChart` drops mismatched `selectionLabels` **silently**. A misalignment would present as the fix simply not working.

## A sweep found one more

Checking every chart that opts into selection:

| | |
|---|---|
| `HealthScreen` (Vital Signs) | **was bare** → fixed |
| `StressScreen` (Stress Trend) | **was bare** → fixed |
| `TodayScreen` (HR) | looked bare to the sweep, but passes `timestamps` — already correct |
| Sleep sheets, Trends, Explore | already labelled |

The Stress Trend is a dated daily trend with a range selector — the same shape and the same omission.

Fixing it needed `windowedTrend` to return its **points** rather than bare values. Deriving labels from a second call that re-applied the same windowing — including its `size >= 2` fallback — is exactly the silent divergence above; one list mapped twice cannot desynchronise. It has a single caller and no test, so widening it is contained.

A re-run of the sweep afterwards reports no selectable chart left without a label or timestamps.

## Parity

**Android-only.** Apple's `TrendChart` takes `dateFormat` **with a default** and passes `label: dateFormat(p.date)` unconditionally, so a dated tooltip is automatic there and only the *format* is customisable — there is no way to opt out. Android makes the whole thing opt-in per call site, which is why two sites forgot.

This closes those two. The asymmetry in the component's shape remains, and is the reason to expect a third eventually.

## Verification

- Full Android suite **4308** green, `assembleFullDebug`, doc lint clean.
- **Not unit-testable** — this project has no Compose UI test harness, so nothing in the suite can see a scrub read-out. Both need an on-device tap to confirm: the Vital Signs chart should read `16 Jul · 92`-style, and so should the Stress Trend.

## Not included

Your Trends screenshot also carries x-axis date labels (*27 May · 12 Jul · 24 Aug*) that the detail chart lacks. That is a second, separate difference — the scrub date is the one reported and much the more useful of the two.
