### PR TITLE
Android: give the Blood Oxygen tile a trend to draw (#1599)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScoring.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScoring.kt
@@ -464,3 +464,23 @@ internal fun buildingHint(metric: KeyMetric, isToday: Boolean): Int? {
         else -> null
     }
 }
+
+/**
+ * #1599: the Blood Oxygen trend series for a window of days — calibrated where it exists, the strap
+ * candidate where it does not.
+ *
+ * `AnalyticsEngine` writes `spo2Pct = null` on every computed day and banks the raw red/IR ADC instead,
+ * so a calibrated reading only ever arrives from an IMPORT. On a strap-only install a series built from
+ * `spo2Pct` alone is empty by construction, and the Key Metrics tile drew a value above blank space
+ * while every neighbouring tile had a line.
+ *
+ * Extracted from the composable that uses it because the PRECEDENCE is the part worth pinning: the same
+ * "calibrated wins per day, candidate fills the gap" rule governs the readings table and the "Your Cards"
+ * detail chart, and the three only agree while they resolve a day the same way. [candidate] arrives empty
+ * when the display toggle is off, so this needs no second gate.
+ */
+internal fun spo2TrendSeries(
+    recent: List<com.noop.data.DailyMetric>,
+    candidate: Map<String, Double>,
+): List<Double> = recent.mapNotNull { it.spo2Pct ?: candidate[it.day] }
+

--- a/android/app/src/main/java/com/noop/ui/TodayScoring.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScoring.kt
@@ -466,21 +466,29 @@ internal fun buildingHint(metric: KeyMetric, isToday: Boolean): Int? {
 }
 
 /**
- * #1599: the Blood Oxygen trend series for a window of days — calibrated where it exists, the strap
- * candidate where it does not.
+ * #1599: which series the Blood Oxygen tile plots — the calibrated one, or the strap candidate.
  *
  * `AnalyticsEngine` writes `spo2Pct = null` on every computed day and banks the raw red/IR ADC instead,
- * so a calibrated reading only ever arrives from an IMPORT. On a strap-only install a series built from
- * `spo2Pct` alone is empty by construction, and the Key Metrics tile drew a value above blank space
- * while every neighbouring tile had a line.
+ * so a calibrated reading only ever arrives from an IMPORT. On a strap-only install [calibrated] is
+ * empty by construction, and the tile drew a value above a blank panel while every neighbour had a line.
  *
- * Extracted from the composable that uses it because the PRECEDENCE is the part worth pinning: the same
- * "calibrated wins per day, candidate fills the gap" rule governs the readings table and the "Your Cards"
- * detail chart, and the three only agree while they resolve a day the same way. [candidate] arrives empty
- * when the display toggle is off, so this needs no second gate.
+ * The rule is a WHOLE-SERIES swap, not a per-day merge, and deliberately so: it is what the Apple tile
+ * does (`spo2.value == "—" && candidateTail != nil ? sparks["spo2_candidate"] : sparks["spo2"]`), and a
+ * line that silently interleaved a measured import with an unverified strap estimate would be a chart
+ * whose points do not share a provenance. Swapping wholesale keeps one caption honest for the whole line.
+ *
+ * [calibratedValue] is the tile's calibrated value INCLUDING its carries — the candidate is a fallback
+ * for having nothing, never an override for having something stale. Mirrors the precedence the dashboard
+ * Blood Oxygen card on the same screen already uses.
  */
-internal fun spo2TrendSeries(
-    recent: List<com.noop.data.DailyMetric>,
-    candidate: Map<String, Double>,
-): List<Double> = recent.mapNotNull { it.spo2Pct ?: candidate[it.day] }
+internal fun spo2SparkSeries(
+    calibrated: List<Double>,
+    candidate: List<Double>,
+    calibratedValue: Double?,
+): List<Double> = if (calibratedValue == null && candidate.isNotEmpty()) candidate else calibrated
 
+/** True when the tile is showing the strap estimate rather than a measured reading, so the caption can
+ *  say so. Same condition as [spo2SparkSeries]'s swap, kept beside it so the line and its label cannot
+ *  disagree about what is being plotted. */
+internal fun spo2UsingCandidate(calibratedValue: Double?, candidateToday: Double?): Boolean =
+    calibratedValue == null && candidateToday != null

--- a/android/app/src/main/java/com/noop/ui/TodayScoring.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScoring.kt
@@ -469,26 +469,32 @@ internal fun buildingHint(metric: KeyMetric, isToday: Boolean): Int? {
  * #1599: which series the Blood Oxygen tile plots — the calibrated one, or the strap candidate.
  *
  * `AnalyticsEngine` writes `spo2Pct = null` on every computed day and banks the raw red/IR ADC instead,
- * so a calibrated reading only ever arrives from an IMPORT. On a strap-only install [calibrated] is
- * empty by construction, and the tile drew a value above a blank panel while every neighbour had a line.
+ * so a calibrated reading only ever arrives from an IMPORT. On a strap-only install [calibrated] is empty
+ * by construction, and the tile drew a value above a blank panel while every neighbour had a line.
  *
- * The rule is a WHOLE-SERIES swap, not a per-day merge, and deliberately so: it is what the Apple tile
- * does (`spo2.value == "—" && candidateTail != nil ? sparks["spo2_candidate"] : sparks["spo2"]`), and a
- * line that silently interleaved a measured import with an unverified strap estimate would be a chart
- * whose points do not share a provenance. Swapping wholesale keeps one caption honest for the whole line.
+ * Gated on whether a series can be DRAWN, not on whether a value exists. The Apple tile asks the latter
+ * (`spo2.value == "—" && candidateTail != nil`), and that misses the case this issue was actually
+ * reported from: one old imported reading carries the tile's VALUE forward indefinitely, so the value is
+ * never "—", so the swap never fires — while the 14-day window it would have to plot still holds nothing.
+ * A number with no line, which is the bug. The sparkline's question is "have I got two points", so that
+ * is what decides it.
  *
- * [calibratedValue] is the tile's calibrated value INCLUDING its carries — the candidate is a fallback
- * for having nothing, never an override for having something stale. Mirrors the precedence the dashboard
- * Blood Oxygen card on the same screen already uses.
+ * Falls back to [calibrated] when NEITHER can be drawn, so a tile with no data anywhere behaves exactly
+ * as it did — nothing is drawn, and nothing is invented to fill the space.
  */
 internal fun spo2SparkSeries(
     calibrated: List<Double>,
     candidate: List<Double>,
-    calibratedValue: Double?,
-): List<Double> = if (calibratedValue == null && candidate.isNotEmpty()) candidate else calibrated
+): List<Double> = if (calibrated.size >= 2 || candidate.size < 2) calibrated else candidate
 
-/** True when the tile is showing the strap estimate rather than a measured reading, so the caption can
- *  say so. Same condition as [spo2SparkSeries]'s swap, kept beside it so the line and its label cannot
- *  disagree about what is being plotted. */
+/**
+ * True when the tile's VALUE is the strap estimate rather than a measured reading, so the caption can
+ * say so.
+ *
+ * Deliberately about the value, not the line: the caption renders directly under the number, so it must
+ * describe the number. The two can differ — an unbounded carry can keep a measured value on a tile whose
+ * window has only estimates to plot — and in that case the value is captioned honestly and the line's
+ * provenance goes unlabelled, which is the lesser of the two silences available.
+ */
 internal fun spo2UsingCandidate(calibratedValue: Double?, candidateToday: Double?): Boolean =
     calibratedValue == null && candidateToday != null

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -5029,7 +5029,7 @@ private fun MetricGrid(
                 // Say WHOSE number this is. The Apple tile has carried this caption all along; Android
                 // showed an unlabelled figure, which is the harder of the two to argue with.
                 caption = if (onCandidate) uiString(R.string.spo2_strap_estimate_caption) else null,
-                spark = spo2SparkSeries(w.spo2, w.spo2Candidate, calibrated),
+                spark = spo2SparkSeries(w.spo2, w.spo2Candidate),
             )
         },
         KeyMetric.RESPIRATORY to run {

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -5011,26 +5011,25 @@ private fun MetricGrid(
         },
         KeyMetric.BLOOD_OXYGEN to run {
             // Candidate LAST, after the carries — the exact precedence the dashboard Blood Oxygen card
-            // uses two sections down this same screen. Putting today's candidate ahead of a carried
-            // calibrated reading is tempting (it would more often equal the last point of the line
-            // beside it) but it makes the two Blood Oxygen surfaces on ONE screen disagree whenever a
-            // user has occasional imports, which is a worse contradiction than a number that outruns its
-            // own window. That mismatch is inherent to an unbounded carry and already true of every
-            // carried metric here; a card contradicting its sibling would be new.
+            // uses two sections down this same screen, and the one the Apple tile uses. The candidate is
+            // a fallback for having nothing, never an override for having something stale.
             //
             // For the strap-only install this issue is about there are no calibrated readings at all, so
             // both carries are null and every surface resolves to the candidate regardless.
-            val v = d?.spo2Pct
-                ?: carriedDay?.spo2Pct
-                ?: spo2CarryDay?.spo2Pct
-                ?: d?.day?.let { spo2CandidateByDay[it] }
+            val calibrated = d?.spo2Pct ?: carriedDay?.spo2Pct ?: spo2CarryDay?.spo2Pct
+            val candidateToday = d?.day?.let { spo2CandidateByDay[it] }
+            val onCandidate = spo2UsingCandidate(calibrated, candidateToday)
+            val v = calibrated ?: candidateToday
             KeyTileData(
                 label = uiString(R.string.l10n_today_screen_blood_oxygen_a8ad9ff5),
                 value = v?.let { String.format(Locale.getDefault(), "%.0f", it) } ?: NO_DATA,
                 unit = if (v != null) "%" else "",
                 tint = Palette.metricCyan,
                 frac = v?.let { (it / 100.0).coerceIn(0.0, 1.0) },
-                spark = w.spo2,
+                // Say WHOSE number this is. The Apple tile has carried this caption all along; Android
+                // showed an unlabelled figure, which is the harder of the two to argue with.
+                caption = if (onCandidate) uiString(R.string.spo2_strap_estimate_caption) else null,
+                spark = spo2SparkSeries(w.spo2, w.spo2Candidate, calibrated),
             )
         },
         KeyMetric.RESPIRATORY to run {
@@ -6691,6 +6690,8 @@ private data class Window(
     val hrv: List<Double>,
     val rhr: List<Double>,
     val spo2: List<Double>,
+    /** #1599: the strap-estimate trend, kept separate from [spo2] so the tile can swap rather than mix. */
+    val spo2Candidate: List<Double> = emptyList(),
     val resp: List<Double>,
     // #616: the Steps tile carried no `spark` series, so it drew no trend line while every other tile did.
     // On-device DailyMetric.steps (the strap @57 count) — the same signal the Steps tile VALUE reads
@@ -6730,10 +6731,10 @@ private fun rememberTrendWindow(
             sleepMin = series { it.totalSleepMin },
             hrv = series { it.avgHrv },
             rhr = series { it.restingHr?.toDouble() },
-            // Calibrated wins per DAY, candidate fills the gaps — the same precedence the readings table
-            // and the "Your Cards" detail chart already use, so the three surfaces agree day for day.
-            // The rule lives in TodayScoring so it can be pinned by a test; this is a composable.
-            spo2 = spo2TrendSeries(recent, spo2Candidate),
+            spo2 = series { it.spo2Pct },
+            // #1599: the strap estimate as its OWN series, not merged into the one above. The tile swaps
+            // wholesale between them so a single caption can describe every point on the line.
+            spo2Candidate = recent.mapNotNull { spo2Candidate[it.day] },
             resp = series { it.respRateBpm },
             steps = series { it.steps?.toDouble() },   // #616
         )

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1070,7 +1070,7 @@ fun TodayScreen(
 
     // 14-day trailing calendar window ending on the phone's actual local day.
     // Old imports stay in history, but they do not fill the Today trend tiles.
-    val window = rememberTrendWindow(days, selectedDay, keyMetricsWindowDays)
+    val window = rememberTrendWindow(days, selectedDay, keyMetricsWindowDays, spo2CandidateByDay)
 
     LaunchedEffect(days) {
         // #849: this footer pass is the heavy one. It derives HR per imported workout from raw strap samples
@@ -1546,6 +1546,7 @@ fun TodayScreen(
                                     carriedDay = lastScoredRecoveryDay,
                                     spo2CarryDay = lastSpo2Day,
                                     respCarryDay = lastRespDay,
+                                    spo2CandidateByDay = spo2CandidateByDay,
                                     unitSystem = unitSystem,
                                     effortScale = effortScale,
                                     effortForDay = effortForDay,   // #1001: same figure as the hero ring
@@ -4882,6 +4883,10 @@ private fun MetricGrid(
     // PER-FIELD respiratory carry (#1331): same reason as spo2CarryDay — respiratory needs a longer
     // clean sleep R-R segment than HRV, so carriedDay can land on a night with HRV but no breaths/min.
     respCarryDay: DailyMetric? = null,
+    // #1599: the same candidate map the tile's sparkline is built from, so the NUMBER and the LINE under
+    // it come from one source. Two bugs fixed this week were a value and a chart on the same card reading
+    // different series (#1601, #1600); this tile is not going to be the third.
+    spo2CandidateByDay: Map<String, Double> = emptyMap(),
     unitSystem: UnitSystem = UnitSystem.METRIC,
     effortScale: EffortScale = EffortScale.HUNDRED,
     // #1001: the day's resolved Effort (live-preferring for today, floored at the stored row). Threaded
@@ -5004,7 +5009,14 @@ private fun MetricGrid(
             )
         },
         KeyMetric.BLOOD_OXYGEN to run {
-            val v = d?.spo2Pct ?: carriedDay?.spo2Pct ?: spo2CarryDay?.spo2Pct
+            // Today's OWN reading first — calibrated, else the candidate — and only then the carries.
+            // That ordering is what makes the number equal the last point of the line beside it, since
+            // the spark resolves each day the same way. The carries still cover a day with neither, which
+            // is what they were added for (a computed row never writes spo2Pct).
+            val v = d?.spo2Pct
+                ?: d?.day?.let { spo2CandidateByDay[it] }
+                ?: carriedDay?.spo2Pct
+                ?: spo2CarryDay?.spo2Pct
             KeyTileData(
                 label = uiString(R.string.l10n_today_screen_blood_oxygen_a8ad9ff5),
                 value = v?.let { String.format(Locale.getDefault(), "%.0f", it) } ?: NO_DATA,
@@ -6690,8 +6702,15 @@ private fun rememberTrendWindow(
     days: List<com.noop.data.DailyMetric>,
     anchorDay: LocalDate,
     windowDays: Int,
+    // #1599: the SpO2 candidate per day, so the Blood Oxygen tile has a series to draw at all.
+    // `AnalyticsEngine` writes `spo2Pct = null` on every computed day — a calibrated reading only ever
+    // arrives from an IMPORT — so on a strap-only install `series { it.spo2Pct }` is empty by
+    // construction and the tile rendered a value above blank space where every neighbour had a line.
+    // Already empty when the display toggle is off (the flow returns emptyMap), so reading it here needs
+    // no second gate.
+    spo2Candidate: Map<String, Double> = emptyMap(),
 ): Window =
-    androidx.compose.runtime.remember(days, anchorDay, windowDays) {
+    androidx.compose.runtime.remember(days, anchorDay, windowDays, spo2Candidate) {
         // Trailing CALENDAR days ending today, NOT the last N stored rows, which on an old import
         // were months-old data shown as a fresh trend (issue #23). ISO yyyy-MM-dd sorts chronologically.
         val cutoff = anchorDay.minusDays((windowDays - 1).toLong()).toString()
@@ -6704,7 +6723,10 @@ private fun rememberTrendWindow(
             sleepMin = series { it.totalSleepMin },
             hrv = series { it.avgHrv },
             rhr = series { it.restingHr?.toDouble() },
-            spo2 = series { it.spo2Pct },
+            // Calibrated wins per DAY, candidate fills the gaps — the same precedence the readings table
+            // and the "Your Cards" detail chart already use, so the three surfaces agree day for day.
+            // The rule lives in TodayScoring so it can be pinned by a test; this is a composable.
+            spo2 = spo2TrendSeries(recent, spo2Candidate),
             resp = series { it.respRateBpm },
             steps = series { it.steps?.toDouble() },   // #616
         )

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -4883,9 +4883,10 @@ private fun MetricGrid(
     // PER-FIELD respiratory carry (#1331): same reason as spo2CarryDay — respiratory needs a longer
     // clean sleep R-R segment than HRV, so carriedDay can land on a night with HRV but no breaths/min.
     respCarryDay: DailyMetric? = null,
-    // #1599: the same candidate map the tile's sparkline is built from, so the NUMBER and the LINE under
-    // it come from one source. Two bugs fixed this week were a value and a chart on the same card reading
-    // different series (#1601, #1600); this tile is not going to be the third.
+    // #1599: the same candidate map the tile's sparkline is built from, so the number and the line under
+    // it draw on one source rather than two. They are not guaranteed EQUAL — the value carries from
+    // outside the window and the line cannot — but neither can now show data the other has no access to,
+    // which is what made this tile render a number above a blank panel.
     spo2CandidateByDay: Map<String, Double> = emptyMap(),
     unitSystem: UnitSystem = UnitSystem.METRIC,
     effortScale: EffortScale = EffortScale.HUNDRED,
@@ -5009,14 +5010,20 @@ private fun MetricGrid(
             )
         },
         KeyMetric.BLOOD_OXYGEN to run {
-            // Today's OWN reading first — calibrated, else the candidate — and only then the carries.
-            // That ordering is what makes the number equal the last point of the line beside it, since
-            // the spark resolves each day the same way. The carries still cover a day with neither, which
-            // is what they were added for (a computed row never writes spo2Pct).
+            // Candidate LAST, after the carries — the exact precedence the dashboard Blood Oxygen card
+            // uses two sections down this same screen. Putting today's candidate ahead of a carried
+            // calibrated reading is tempting (it would more often equal the last point of the line
+            // beside it) but it makes the two Blood Oxygen surfaces on ONE screen disagree whenever a
+            // user has occasional imports, which is a worse contradiction than a number that outruns its
+            // own window. That mismatch is inherent to an unbounded carry and already true of every
+            // carried metric here; a card contradicting its sibling would be new.
+            //
+            // For the strap-only install this issue is about there are no calibrated readings at all, so
+            // both carries are null and every surface resolves to the candidate regardless.
             val v = d?.spo2Pct
-                ?: d?.day?.let { spo2CandidateByDay[it] }
                 ?: carriedDay?.spo2Pct
                 ?: spo2CarryDay?.spo2Pct
+                ?: d?.day?.let { spo2CandidateByDay[it] }
             KeyTileData(
                 label = uiString(R.string.l10n_today_screen_blood_oxygen_a8ad9ff5),
                 value = v?.let { String.format(Locale.getDefault(), "%.0f", it) } ?: NO_DATA,

--- a/android/app/src/test/java/com/noop/ui/TodayMetricTilesTest.kt
+++ b/android/app/src/test/java/com/noop/ui/TodayMetricTilesTest.kt
@@ -563,4 +563,47 @@ class TodayMetricTilesTest {
         )
         assertEquals("2026-06-16", lastSkinTempRow(days, todayKey = "2026-06-19")?.day)
     }
+
+    // MARK: spo2TrendSeries — the Blood Oxygen trend source (#1599)
+
+    private fun spo2Day(d: String, calibrated: Double?) =
+        com.noop.data.DailyMetric(deviceId = "my-whoop", day = d, spo2Pct = calibrated)
+
+    /**
+     * The reported case. `AnalyticsEngine` writes spo2Pct = null on every computed day, so a strap-only
+     * install has NO calibrated series — the tile drew a carried number above blank space while every
+     * neighbouring tile had a line. The candidate is what it has, and it must be enough to draw.
+     */
+    @Test fun strapOnlyDaysStillProduceATrendFromTheCandidate() {
+        val days = listOf(spo2Day("2026-08-22", null), spo2Day("2026-08-23", null), spo2Day("2026-08-24", null))
+        val candidate = mapOf("2026-08-22" to 95.0, "2026-08-23" to 96.0, "2026-08-24" to 94.0)
+        assertEquals(listOf(95.0, 96.0, 94.0), spo2TrendSeries(days, candidate))
+    }
+
+    /** Calibrated wins for a day that has one — the candidate is a fallback, never an override. */
+    @Test fun aCalibratedReadingBeatsTheCandidateForTheSameDay() {
+        val days = listOf(spo2Day("2026-08-23", 97.0))
+        assertEquals(listOf(97.0), spo2TrendSeries(days, mapOf("2026-08-23" to 91.0)))
+    }
+
+    /** Mixed history: imported days keep their own value, strap-only days are filled. Per-DAY, not
+     *  whole-series — a single import must not switch the whole window to calibrated-only. */
+    @Test fun theTwoSourcesInterleavePerDay() {
+        val days = listOf(spo2Day("2026-08-22", 98.0), spo2Day("2026-08-23", null), spo2Day("2026-08-24", 97.0))
+        assertEquals(listOf(98.0, 96.0, 97.0), spo2TrendSeries(days, mapOf("2026-08-23" to 96.0)))
+    }
+
+    /** Toggle OFF hands this an empty map (the flow returns emptyMap), and the series must then be
+     *  exactly what it always was — no candidate leaks in through a second path. */
+    @Test fun anEmptyCandidateMapLeavesTheCalibratedSeriesUntouched() {
+        val days = listOf(spo2Day("2026-08-22", 98.0), spo2Day("2026-08-23", null))
+        assertEquals(listOf(98.0), spo2TrendSeries(days, emptyMap()))
+    }
+
+    /** A day absent from both contributes nothing rather than a zero — a fabricated 0 % would plot as a
+     *  catastrophic desaturation. */
+    @Test fun aDayWithNeitherSourceIsDroppedNotZeroed() {
+        val days = listOf(spo2Day("2026-08-22", null), spo2Day("2026-08-23", 96.0))
+        assertEquals(listOf(96.0), spo2TrendSeries(days, mapOf("2026-08-24" to 95.0)))
+    }
 }

--- a/android/app/src/test/java/com/noop/ui/TodayMetricTilesTest.kt
+++ b/android/app/src/test/java/com/noop/ui/TodayMetricTilesTest.kt
@@ -567,45 +567,50 @@ class TodayMetricTilesTest {
     // MARK: spo2 spark source — which series the Blood Oxygen tile plots (#1599)
 
     /**
-     * The reported case. `AnalyticsEngine` writes spo2Pct = null on every computed day, so a strap-only
-     * install has NO calibrated series — the tile drew a carried number above a blank panel while every
-     * neighbouring tile had a line. The candidate is what it has, and it must be enough to draw.
+     * THE reported case, and the one a value-gated rule misses.
+     *
+     * One old imported reading carries the tile's value forward indefinitely, so the value is never "—"
+     * — but the 14-day window it has to plot holds nothing. Gating the swap on the value (what the Apple
+     * tile does) leaves this user exactly where they started: a number above a blank panel. Gating it on
+     * whether a series can be drawn fixes it.
      */
-    @Test fun strapOnlyFallsBackToTheCandidateSeries() {
+    @Test fun aCarriedValueWithAnEmptyWindowStillGetsTheCandidateLine() {
         val candidate = listOf(95.0, 96.0, 94.0)
-        assertEquals(candidate, spo2SparkSeries(calibrated = emptyList(), candidate = candidate, calibratedValue = null))
+        assertEquals(candidate, spo2SparkSeries(calibrated = emptyList(), candidate = candidate))
+        assertEquals(candidate, spo2SparkSeries(calibrated = listOf(97.0), candidate = candidate))
     }
 
-    /** A measured reading — even a CARRIED one — keeps the calibrated series. The candidate is a fallback
-     *  for having nothing, never an override for having something stale. */
-    @Test fun anyCalibratedValueKeepsTheCalibratedSeries() {
+    /** A drawable calibrated series is kept — the candidate is a fallback for having nothing to plot,
+     *  never a replacement for real measurements. */
+    @Test fun aDrawableCalibratedSeriesIsKept() {
         val cal = listOf(97.0, 98.0)
-        assertEquals(cal, spo2SparkSeries(calibrated = cal, candidate = listOf(90.0, 91.0), calibratedValue = 97.0))
+        assertEquals(cal, spo2SparkSeries(calibrated = cal, candidate = listOf(90.0, 91.0, 92.0)))
     }
 
-    /** Toggle OFF hands this an empty candidate list, and the series must stay exactly what it was —
-     *  no estimate leaks in by another path. */
+    /** Toggle OFF hands this an empty candidate, and the series must stay exactly what it was. */
     @Test fun anEmptyCandidateLeavesTheCalibratedSeriesUntouched() {
-        val cal = listOf(97.0)
-        assertEquals(cal, spo2SparkSeries(calibrated = cal, candidate = emptyList(), calibratedValue = null))
-        assertEquals(emptyList<Double>(), spo2SparkSeries(emptyList(), emptyList(), null))
+        assertEquals(listOf(97.0), spo2SparkSeries(calibrated = listOf(97.0), candidate = emptyList()))
+        assertEquals(emptyList<Double>(), spo2SparkSeries(emptyList(), emptyList()))
+    }
+
+    /** Neither drawable → unchanged, and nothing invented to fill the space. A single candidate point is
+     *  not promoted into a line. */
+    @Test fun oneCandidatePointIsNotEnoughToSwap() {
+        assertEquals(emptyList<Double>(), spo2SparkSeries(calibrated = emptyList(), candidate = listOf(96.0)))
     }
 
     /**
-     * The swap is WHOLE-SERIES, never interleaved. A line mixing a measured import with an unverified
-     * strap estimate would have points of two different provenances under one caption — the caption
-     * below is only honest because every point on the line shares a source.
+     * The swap is WHOLE-SERIES, never interleaved: a line mixing a measured import with an unverified
+     * strap estimate would have points of two provenances plotted as one trend.
      */
     @Test fun theSwapIsWholeSeriesNotPerDay() {
-        val cal = listOf(97.0, 98.0)
         val cand = listOf(90.0, 91.0, 92.0)
-        assertEquals(cand, spo2SparkSeries(cal, cand, calibratedValue = null))
-        assertEquals(cal, spo2SparkSeries(cal, cand, calibratedValue = 97.0))
+        assertEquals(cand, spo2SparkSeries(calibrated = listOf(97.0), candidate = cand))
     }
 
-    /** The caption tracks the same condition as the swap, so the line and its label cannot disagree
-     *  about what is being plotted. */
-    @Test fun theCaptionFlagsExactlyWhenTheCandidateIsPlotted() {
+    /** The caption describes the VALUE, which is what it renders under — not the line, which can differ
+     *  when an unbounded carry outlives its window. */
+    @Test fun theCaptionFlagsExactlyWhenTheVALUEIsAnEstimate() {
         assertTrue(spo2UsingCandidate(calibratedValue = null, candidateToday = 96.0))
         assertFalse(spo2UsingCandidate(calibratedValue = 97.0, candidateToday = 96.0))
         assertFalse(spo2UsingCandidate(calibratedValue = null, candidateToday = null))

--- a/android/app/src/test/java/com/noop/ui/TodayMetricTilesTest.kt
+++ b/android/app/src/test/java/com/noop/ui/TodayMetricTilesTest.kt
@@ -564,46 +564,50 @@ class TodayMetricTilesTest {
         assertEquals("2026-06-16", lastSkinTempRow(days, todayKey = "2026-06-19")?.day)
     }
 
-    // MARK: spo2TrendSeries — the Blood Oxygen trend source (#1599)
-
-    private fun spo2Day(d: String, calibrated: Double?) =
-        com.noop.data.DailyMetric(deviceId = "my-whoop", day = d, spo2Pct = calibrated)
+    // MARK: spo2 spark source — which series the Blood Oxygen tile plots (#1599)
 
     /**
      * The reported case. `AnalyticsEngine` writes spo2Pct = null on every computed day, so a strap-only
-     * install has NO calibrated series — the tile drew a carried number above blank space while every
+     * install has NO calibrated series — the tile drew a carried number above a blank panel while every
      * neighbouring tile had a line. The candidate is what it has, and it must be enough to draw.
      */
-    @Test fun strapOnlyDaysStillProduceATrendFromTheCandidate() {
-        val days = listOf(spo2Day("2026-08-22", null), spo2Day("2026-08-23", null), spo2Day("2026-08-24", null))
-        val candidate = mapOf("2026-08-22" to 95.0, "2026-08-23" to 96.0, "2026-08-24" to 94.0)
-        assertEquals(listOf(95.0, 96.0, 94.0), spo2TrendSeries(days, candidate))
+    @Test fun strapOnlyFallsBackToTheCandidateSeries() {
+        val candidate = listOf(95.0, 96.0, 94.0)
+        assertEquals(candidate, spo2SparkSeries(calibrated = emptyList(), candidate = candidate, calibratedValue = null))
     }
 
-    /** Calibrated wins for a day that has one — the candidate is a fallback, never an override. */
-    @Test fun aCalibratedReadingBeatsTheCandidateForTheSameDay() {
-        val days = listOf(spo2Day("2026-08-23", 97.0))
-        assertEquals(listOf(97.0), spo2TrendSeries(days, mapOf("2026-08-23" to 91.0)))
+    /** A measured reading — even a CARRIED one — keeps the calibrated series. The candidate is a fallback
+     *  for having nothing, never an override for having something stale. */
+    @Test fun anyCalibratedValueKeepsTheCalibratedSeries() {
+        val cal = listOf(97.0, 98.0)
+        assertEquals(cal, spo2SparkSeries(calibrated = cal, candidate = listOf(90.0, 91.0), calibratedValue = 97.0))
     }
 
-    /** Mixed history: imported days keep their own value, strap-only days are filled. Per-DAY, not
-     *  whole-series — a single import must not switch the whole window to calibrated-only. */
-    @Test fun theTwoSourcesInterleavePerDay() {
-        val days = listOf(spo2Day("2026-08-22", 98.0), spo2Day("2026-08-23", null), spo2Day("2026-08-24", 97.0))
-        assertEquals(listOf(98.0, 96.0, 97.0), spo2TrendSeries(days, mapOf("2026-08-23" to 96.0)))
+    /** Toggle OFF hands this an empty candidate list, and the series must stay exactly what it was —
+     *  no estimate leaks in by another path. */
+    @Test fun anEmptyCandidateLeavesTheCalibratedSeriesUntouched() {
+        val cal = listOf(97.0)
+        assertEquals(cal, spo2SparkSeries(calibrated = cal, candidate = emptyList(), calibratedValue = null))
+        assertEquals(emptyList<Double>(), spo2SparkSeries(emptyList(), emptyList(), null))
     }
 
-    /** Toggle OFF hands this an empty map (the flow returns emptyMap), and the series must then be
-     *  exactly what it always was — no candidate leaks in through a second path. */
-    @Test fun anEmptyCandidateMapLeavesTheCalibratedSeriesUntouched() {
-        val days = listOf(spo2Day("2026-08-22", 98.0), spo2Day("2026-08-23", null))
-        assertEquals(listOf(98.0), spo2TrendSeries(days, emptyMap()))
+    /**
+     * The swap is WHOLE-SERIES, never interleaved. A line mixing a measured import with an unverified
+     * strap estimate would have points of two different provenances under one caption — the caption
+     * below is only honest because every point on the line shares a source.
+     */
+    @Test fun theSwapIsWholeSeriesNotPerDay() {
+        val cal = listOf(97.0, 98.0)
+        val cand = listOf(90.0, 91.0, 92.0)
+        assertEquals(cand, spo2SparkSeries(cal, cand, calibratedValue = null))
+        assertEquals(cal, spo2SparkSeries(cal, cand, calibratedValue = 97.0))
     }
 
-    /** A day absent from both contributes nothing rather than a zero — a fabricated 0 % would plot as a
-     *  catastrophic desaturation. */
-    @Test fun aDayWithNeitherSourceIsDroppedNotZeroed() {
-        val days = listOf(spo2Day("2026-08-22", null), spo2Day("2026-08-23", 96.0))
-        assertEquals(listOf(96.0), spo2TrendSeries(days, mapOf("2026-08-24" to 95.0)))
+    /** The caption tracks the same condition as the swap, so the line and its label cannot disagree
+     *  about what is being plotted. */
+    @Test fun theCaptionFlagsExactlyWhenTheCandidateIsPlotted() {
+        assertTrue(spo2UsingCandidate(calibratedValue = null, candidateToday = 96.0))
+        assertFalse(spo2UsingCandidate(calibratedValue = 97.0, candidateToday = 96.0))
+        assertFalse(spo2UsingCandidate(calibratedValue = null, candidateToday = null))
     }
 }


### PR DESCRIPTION
Reported by @bartmuskala: the Key Metrics Blood Oxygen tile shows a number above blank space, while every neighbouring tile carries its 14-day line.

## Not a rendering fault — there was nothing to render

`AnalyticsEngine` writes `spo2Pct = null` on every computed day and banks the raw red/IR ADC instead. A calibrated reading only ever arrives from an **import** (Apple Health, Health Connect, Xiaomi, wearable export). The tile's series was `series { it.spo2Pct }`, so on a strap-only install it is **empty by construction** — the `tail.size >= 2` guard downstream had nothing to guard.

The number survived because the tile's value carries *unbounded* from the last row that ever had a reading, so an old import keeps it on screen with nothing in the window to plot.

The strap's own estimate was there all along: `IntelligenceEngine` persists a nightly `spo2_candidate` row, and `TodayScreen` **already collects it** — it feeds the dashboard Blood Oxygen card two sections away. The Key Metrics tile never read it.

## The rule: gated on drawability, not on the value

The tile keeps the calibrated series when it can be drawn, uses the candidate when it cannot and the candidate can, and changes nothing when neither can.

**This is deliberately not Apple's condition.** Apple swaps when the *value* has fallen back:

```swift
sparkline: spo2.value == "—" && candidateTail != nil ? sparks["spo2_candidate"] : sparks["spo2"]
```

which misses the case this was reported from. One old imported reading carries the value forward indefinitely, so the value is never `"—"`, so the swap never fires — while the window it would have to plot still holds nothing. **A first version of this PR copied that condition and would not have fixed the report.** A sparkline's question is "have I got two points", so that is what decides it now.

Apple has the same hole for the same user; that wants an issue against the Apple tile rather than copying the fault across for symmetry.

## The swap is whole-series, and the estimate is labelled

Never interleaved: a line mixing a measured import with an unverified strap estimate would plot two provenances as one trend.

Apple's tile also carries a caption — `"strap estimate (unverified)"` — which answers a question I had wrongly framed as a product decision ("a sparkline has nowhere to say this"). `KeyTileData` already has a `caption` field and both strings are already translated, so Android was one argument away from the affordance. It now labels the estimate, and the caption renders in the compact grid (it sits outside the `detailed` guard).

**One consequence, stated plainly:** value and line can now have different provenances — a carried measurement above a line of estimates. The caption describes the **value**, because that is what it renders directly under, so in that case the line's provenance goes unlabelled. That is the lesser of the two available silences; captioning the value wrongly would be worse.

## Will it fix the report?

Yes, on the evidence available. The candidate flow returns `emptyMap` unless the experimental display toggle is on — and @bartmuskala's own #1601 screenshot shows his Blood Oxygen readings table reading *"strap estimate (unverified)"* on three consecutive days, so candidate data is flowing for him and the toggle is on. With his window holding candidates and no drawable calibrated series, the swap fires.

## Not taken

Apple's third state, `"toggle ON · no estimate yet"`, needs the toggle threaded to the tile — an empty `spo2CandidateByDay` cannot tell "off" from "on with no data". Its string is already translated here. Same class of affordance as the caption; worth a follow-up.

## Verification

- Android suite **4314** green, `assembleFullDebug`, doc lint, i18n audit clean.
- Six tests pin the rule, including the case that motivated it (a carried value with an empty window still gets a line) and that a **single** candidate point is not promoted into one.
- **The tile itself needs a device** — no Compose UI test harness exists, so nothing in the suite can see a sparkline. The tests cover the series it is built from.
