### PR TITLE
Don't derive or report a clock correlation on a WHOOP 5/MG

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -332,6 +332,26 @@ struct BackfillContinuation {
     /// legitimate banks records two days ahead of the phone's clock.
     static let defaultFutureSkewSeconds = 48 * 3600
 
+    /// #1598: may a GET_CLOCK correlation be chased and DERIVED for this family? WHOOP 4.0 only.
+    ///
+    /// A 5/MG never establishes one **by design**: its historical (type-47) and live (puffin REALTIME)
+    /// records both carry the strap RTC's own real-unix seconds, so the identity ref the Backfiller falls
+    /// back to (device == wall ⇒ offset 0) is the CORRECT decode for it, not a degraded one. Two things
+    /// followed from not knowing that here:
+    ///
+    ///  * `beginBackfill` re-sent GET_CLOCK up to 3× on every 5/MG offload, chasing a reply that is never
+    ///    coming, and logged each attempt as a failure — so every 5/MG strap log carried clock-retry noise
+    ///    plus an `IDENTITY fallback` line naming the #700 misdating bug it did NOT have.
+    ///  * worse, the #700 Data-Range fallback then installed a NON-identity ref derived from
+    ///    `strapNewestTs`. On a 4.0 that difference IS the RTC skew, which is the whole point. On a 5/MG
+    ///    `newest` is already real-unix, so `wall - newest` is merely HOW LONG THE STRAP WENT UNRECORDED
+    ///    (unworn, charging, flat). Applied as a clock offset it silently shifts that offload's history
+    ///    forward by exactly that gap once it clears `histStaleClockThresholdSec` (1 day) — a strap off
+    ///    the wrist for a weekend would land its next backfill on the wrong days.
+    ///
+    /// Pure so the Kotlin twin (`WhoopBleClient.derivesClockCorrelation`) can assert the same rule.
+    static func derivesClockCorrelation(_ family: DeviceFamily) -> Bool { family == .whoop4 }
+
     /// #1012: is the strap-reported "newest banked record" FUTURE-dated beyond the skew allowance — more
     /// than `futureSkewSeconds` past the wall clock? The strap's clock is then almost certainly set in the
     /// future (#928), so its range answer AND its freshly-persisted rows are untrustworthy as backlog
@@ -1983,26 +2003,31 @@ public final class BLEManager: NSObject, ObservableObject {
     /// flag, kick the strap with sendHistoricalData, and arm the idle timeout.
     @discardableResult
     private func beginBackfill() -> Bool {
-        // #700: if backfill is about to start and we STILL have no clock correlation, re-send
-        // GET_CLOCK. The strap may have silently dropped the first response (observed on a reporter's
-        // WHOOP 4.0 — GET_CLOCK sent, no reply, entire session decodes under IDENTITY fallback, all
-        // rows land on the current day). Capped at 3 retries to avoid flooding.
-        if clockRef == nil && clockRetries < 3 {
-            clockRetries += 1
-            log("Clock: no correlation yet — re-sending GET_CLOCK (retry \(clockRetries)/3)")
-            send(.getClock, payload: [])
-            send(.getClock, payload: [0x00])
-        } else if clockRef == nil, let newest = strapNewestTs {
-            // #700 fallback: GET_CLOCK never responded even after retries. Derive a rough correlation
-            // from the Data Range's newest-banked timestamp (already parsed, always answered). The
-            // offset is approximate (the newest record could be minutes old) but vastly better than
-            // identity (offset 0), which mis-dates entire nights.
-            let wall = Int(Date().timeIntervalSince1970)
-            let ref = ClockRef(device: newest, wall: wall)
-            clockRef = ref
-            collector?.clockRef = ref
-            backfiller?.clockRef = ref
-            log("Clock: GET_CLOCK unresponsive — derived rough correlation from Data Range (device=\(newest) wall=\(wall), offset \(wall - newest)s)")
+        // #1598: this whole block is WHOOP 4.0 ONLY. A 5/MG has no GET_CLOCK correlation to chase —
+        // identity is its correct decode — and deriving one from the Data Range would misdate its
+        // history. See BackfillContinuation.derivesClockCorrelation for why.
+        if BackfillContinuation.derivesClockCorrelation(selectedModel.deviceFamily) {
+            // #700: if backfill is about to start and we STILL have no clock correlation, re-send
+            // GET_CLOCK. The strap may have silently dropped the first response (observed on a reporter's
+            // WHOOP 4.0 — GET_CLOCK sent, no reply, entire session decodes under IDENTITY fallback, all
+            // rows land on the current day). Capped at 3 retries to avoid flooding.
+            if clockRef == nil && clockRetries < 3 {
+                clockRetries += 1
+                log("Clock: no correlation yet — re-sending GET_CLOCK (retry \(clockRetries)/3)")
+                send(.getClock, payload: [])
+                send(.getClock, payload: [0x00])
+            } else if clockRef == nil, let newest = strapNewestTs {
+                // #700 fallback: GET_CLOCK never responded even after retries. Derive a rough correlation
+                // from the Data Range's newest-banked timestamp (already parsed, always answered). The
+                // offset is approximate (the newest record could be minutes old) but vastly better than
+                // identity (offset 0), which mis-dates entire nights.
+                let wall = Int(Date().timeIntervalSince1970)
+                let ref = ClockRef(device: newest, wall: wall)
+                clockRef = ref
+                collector?.clockRef = ref
+                backfiller?.clockRef = ref
+                log("Clock: GET_CLOCK unresponsive — derived rough correlation from Data Range (device=\(newest) wall=\(wall), offset \(wall - newest)s)")
+            }
         }
         // Never offload before the connect handshake has run: a racing foreground/restore trigger
         // firing SEND_HISTORICAL ahead of hello/SET_CLOCK was part of the storm that stopped serving.
@@ -2199,7 +2224,8 @@ public final class BLEManager: NSObject, ObservableObject {
             if let diag = Backfiller.sessionClockDiagLine(nightKeys: bf.sessionNightKeys,
                                                           device: bf.sessionClockDevice,
                                                           wall: bf.sessionClockWall,
-                                                          usedIdentityRef: bf.sessionUsedIdentityRef) {
+                                                          usedIdentityRef: bf.sessionUsedIdentityRef,
+                                                          family: bf.family) {
                 log(diag)
             }
         }

--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -75,7 +75,7 @@ final class Backfiller {
     /// Strap family for the current offload, set at begin(). Drives family-aware frame parsing (WHOOP 5/MG
     /// records sit at +4 offsets vs WHOOP 4.0) and the end_data slice the ack needs. Captured at begin()
     /// rather than init so it's correct even if the Backfiller was constructed before the strap was known.
-    private var family: DeviceFamily = .whoop4
+    private(set) var family: DeviceFamily = .whoop4
 
     /// Diagnostic sink (strap log). Surfaces historical records whose firmware layout we can't decode.
     private let log: ((String) -> Void)?
@@ -125,10 +125,14 @@ final class Backfiller {
     /// session. Surfaces whether the stale-RTC timestamp correction (FIX #72's `correctedWall`) could even
     /// engage. `sessionUsedIdentityRef` = no clock correlation had landed when the first chunk decoded, so
     /// that decode fell back to an identity
-    /// ref (device==wall==now) → clock offset 0 → correction OFF. On a strap whose RTC has reset, that
+    /// ref (device==wall==now) → clock offset 0 → correction OFF. On a WHOOP 4.0 whose RTC has reset, that
     /// silently stores the strap's stale (years-old) timestamps verbatim, so the night lands off the recent
     /// timeline and reads as "missed sleep". Paired with the persisted-nights DATE RANGE below, one strap
     /// log now shows both WHERE the rows landed and WHY. Reset in begin(). Log-only.
+    ///
+    /// #1598: read this WITH the family — it is family-agnostic on purpose (it records what the decode did),
+    /// so it is `true` on EVERY 5/MG session, where identity is the correct ref rather than a fallback.
+    /// `sessionClockDiagLine` is what applies that judgement; don't treat this flag alone as a fault.
     private(set) var sessionClockDevice: Int?
     private(set) var sessionClockWall: Int?
     private(set) var sessionUsedIdentityRef = false
@@ -353,7 +357,8 @@ final class Backfiller {
     /// fallback, or an in-sync ref on a strap that banked stale), the night is misdated off the recent
     /// timeline — the "missed sleep" signature (#67). Returns nil when nothing landed. Log-only, pure.
     nonisolated static func sessionClockDiagLine(nightKeys: Set<Int>,
-                                                 device: Int?, wall: Int?, usedIdentityRef: Bool) -> String? {
+                                                 device: Int?, wall: Int?, usedIdentityRef: Bool,
+                                                 family: DeviceFamily) -> String? {
         guard let lo = nightKeys.min(), let hi = nightKeys.max() else { return nil }
         let day: (Int) -> String = { key in
             let f = DateFormatter()
@@ -367,7 +372,12 @@ final class Backfiller {
         if let device, let wall {
             let offset = wall - device
             let days = offset / 86_400
-            if usedIdentityRef {
+            if usedIdentityRef && family == .whoop5 {
+                // #1598: identity is the DESIGNED ref for a 5/MG — its records carry real-unix seconds, so
+                // offset 0 is correct and there is nothing to correct FOR. Labelling it "IDENTITY fallback"
+                // made every healthy 5/MG log look like the #700 misdating bug.
+                line += " · clock ref: identity - correct for 5/MG (records carry real-unix timestamps, no correlation needed)"
+            } else if usedIdentityRef {
                 line += " · clock ref: IDENTITY fallback (no clock correlation at decode) - stale-record correction OFF"
             } else if abs(offset) > 86_400 {
                 line += " · strap clock \(days >= 0 ? "\(days)d behind" : "\(-days)d ahead") wall - correction engaged"

--- a/StrandTests/BackfillContinuationTests.swift
+++ b/StrandTests/BackfillContinuationTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import Strand
+import WhoopProtocol   // DeviceFamily, for the #1598 clock-correlation gate
 
 /// Pins the #364 historical-sync auto-continue decision. The real bug: the strap offloads OLDEST-first
 /// at ~60s/session with a 15-min floor and NO auto-continue, so on a deep backlog each connection drains
@@ -425,5 +426,15 @@ final class BackfillContinuationTests: XCTestCase {
             persistedSensorRows: true,
             lastTrimAdvanced: true,
             consecutiveCount: 0))
+    }
+
+    // MARK: - #1598 clock-correlation family gate
+
+    /// A 5/MG must never chase or DERIVE a GET_CLOCK correlation: its records already carry real-unix
+    /// seconds, so `wall - strapNewestTs` is how long the strap went unrecorded, NOT an RTC skew.
+    /// Seeding it as one shifted that offload's history forward by the gap. WHOOP 4.0 keeps #700.
+    func testOnlyWhoop4DerivesClockCorrelation() {
+        XCTAssertTrue(BackfillContinuation.derivesClockCorrelation(.whoop4))
+        XCTAssertFalse(BackfillContinuation.derivesClockCorrelation(.whoop5))
     }
 }

--- a/StrandTests/BackfillerSessionTallyTests.swift
+++ b/StrandTests/BackfillerSessionTallyTests.swift
@@ -54,7 +54,7 @@ final class BackfillerSessionTallyTests: XCTestCase {
 
     // No nights persisted → no line (nothing to date).
     func testClockDiagNilWhenNoNights() {
-        XCTAssertNil(Backfiller.sessionClockDiagLine(nightKeys: [], device: 1_700_000_000, wall: 1_700_000_000, usedIdentityRef: false))
+        XCTAssertNil(Backfiller.sessionClockDiagLine(nightKeys: [], device: 1_700_000_000, wall: 1_700_000_000, usedIdentityRef: false, family: .whoop4))
     }
 
     // The #67 signature: rows landed years in the past AND the offload used the identity fallback (no
@@ -63,7 +63,7 @@ final class BackfillerSessionTallyTests: XCTestCase {
         let marchDay = 1_711_276_123 / 86_400          // 2024-03-24
         let line = Backfiller.sessionClockDiagLine(nightKeys: [marchDay],
                                                    device: 1_783_486_611, wall: 1_783_486_611,
-                                                   usedIdentityRef: true)
+                                                   usedIdentityRef: true, family: .whoop4)
         XCTAssertEqual(line, "Backfill: rows landed on 2024-03-24 · clock ref: IDENTITY fallback (no clock correlation at decode) - stale-record correction OFF")
     }
 
@@ -72,7 +72,7 @@ final class BackfillerSessionTallyTests: XCTestCase {
         let day = 1_711_276_123 / 86_400
         let line = Backfiller.sessionClockDiagLine(nightKeys: [day],
                                                    device: 1_711_276_123, wall: 1_783_486_123,
-                                                   usedIdentityRef: false)
+                                                   usedIdentityRef: false, family: .whoop4)
         XCTAssertNotNil(line)
         XCTAssertTrue(line!.contains("835d behind wall - correction engaged"), line ?? "")
     }
@@ -82,7 +82,7 @@ final class BackfillerSessionTallyTests: XCTestCase {
         let day = 1_783_400_000 / 86_400
         let line = Backfiller.sessionClockDiagLine(nightKeys: [day],
                                                    device: 1_783_400_000, wall: 1_783_400_050,
-                                                   usedIdentityRef: false)
+                                                   usedIdentityRef: false, family: .whoop4)
         XCTAssertTrue(line!.hasSuffix("· clock ref in sync"), line ?? "")
         XCTAssertFalse(line!.contains("…"))   // one day, not a range
     }
@@ -91,15 +91,52 @@ final class BackfillerSessionTallyTests: XCTestCase {
     func testClockDiagMultiNightRange() {
         let d0 = 1_711_276_123 / 86_400
         let d1 = d0 + 2
-        let line = Backfiller.sessionClockDiagLine(nightKeys: [d0, d1], device: nil, wall: nil, usedIdentityRef: false)
+        let line = Backfiller.sessionClockDiagLine(nightKeys: [d0, d1], device: nil, wall: nil, usedIdentityRef: false, family: .whoop4)
         XCTAssertTrue(line!.contains("2024-03-24…2024-03-26"), line ?? "")
+    }
+
+    // #1598: the SAME identity ref that is a fault on a 4.0 is the designed decode on a 5/MG, whose
+    // records carry real-unix seconds. It must not be reported as the #700 "IDENTITY fallback" bug —
+    // every healthy 5/MG session sets usedIdentityRef, and that line sent triage down a dead end.
+    func testClockDiagIdentityOnWhoop5ReadsAsByDesignNotFallback() {
+        let day = 1_783_400_000 / 86_400
+        let line = Backfiller.sessionClockDiagLine(nightKeys: [day],
+                                                   device: 1_783_400_000, wall: 1_783_400_000,
+                                                   usedIdentityRef: true, family: .whoop5)
+        XCTAssertNotNil(line)
+        XCTAssertFalse(line!.contains("IDENTITY fallback"), line ?? "")
+        XCTAssertFalse(line!.contains("correction OFF"), line ?? "")
+        XCTAssertTrue(line!.contains("identity - correct for 5/MG"), line ?? "")
+    }
+
+    // ...and the 4.0 warning is untouched by that carve-out — same inputs, different family.
+    func testClockDiagIdentityStillWarnsOnWhoop4() {
+        let day = 1_783_400_000 / 86_400
+        let line = Backfiller.sessionClockDiagLine(nightKeys: [day],
+                                                   device: 1_783_400_000, wall: 1_783_400_000,
+                                                   usedIdentityRef: true, family: .whoop4)
+        XCTAssertTrue(line!.contains("IDENTITY fallback"), line ?? "")
+    }
+
+    // The 5/MG carve-out is gated on usedIdentityRef, not on the family alone: a 5/MG that somehow
+    // decoded with a real correlation still reports the ordinary in-sync/stale verdicts.
+    func testClockDiagWhoop5WithRealRefStillReportsInSync() {
+        let day = 1_783_400_000 / 86_400
+        let line = Backfiller.sessionClockDiagLine(nightKeys: [day],
+                                                   device: 1_783_400_000, wall: 1_783_400_050,
+                                                   usedIdentityRef: false, family: .whoop5)
+        XCTAssertTrue(line!.hasSuffix("· clock ref in sync"), line ?? "")
     }
 
     // No em-dash leaks (matches the noCursorLine/futureRtcLine convention).
     func testClockDiagHasNoEmDash() {
         let line = Backfiller.sessionClockDiagLine(nightKeys: [1_711_276_123 / 86_400],
-                                                   device: 1_783_486_611, wall: 1_783_486_611, usedIdentityRef: true)
+                                                   device: 1_783_486_611, wall: 1_783_486_611, usedIdentityRef: true, family: .whoop4)
         XCTAssertFalse(line!.contains("\u{2014}"))
+        // #1598's 5/MG variant is held to the same convention.
+        let w5 = Backfiller.sessionClockDiagLine(nightKeys: [1_711_276_123 / 86_400],
+                                                 device: 1_783_486_611, wall: 1_783_486_611, usedIdentityRef: true, family: .whoop5)
+        XCTAssertFalse(w5!.contains("\u{2014}"))
     }
 
     // #783: trim=0xFFFFFFFF on a fresh run that banked NOTHING means "no banked history": the genuine

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1568,6 +1568,23 @@ class WhoopBleClient(
         ): Boolean = strapNewestTs != null && strapNewestTs > wallNowUnix + futureSkewSeconds
 
         /**
+         * #1598: may a GET_CLOCK correlation be DERIVED for this family? WHOOP 4.0 only.
+         *
+         * A 5/MG never establishes one by design — its historical (type-47) and live (puffin REALTIME)
+         * records both carry the strap RTC's own real-unix seconds, so the Backfiller's identity default
+         * ([ClockRef.identityNow], offset 0) is the CORRECT decode for it, not a degraded one.
+         *
+         * [beginBackfill] used to seed a correlation from [strapNewestTs] for EVERY family. On a 4.0 that
+         * difference is the RTC skew, which is the point of #700. On a 5/MG `newest` is already real-unix,
+         * so `wall - newest` is merely HOW LONG THE STRAP WENT UNRECORDED (unworn, charging, flat) —
+         * applied as a clock offset it shifts that offload's history forward by exactly that gap once it
+         * clears the decoder's 1-day staleness threshold, landing a weekend's backfill on the wrong days.
+         *
+         * Mirrors the Swift `BackfillContinuation.derivesClockCorrelation`.
+         */
+        fun derivesClockCorrelation(family: DeviceFamily): Boolean = family == DeviceFamily.WHOOP4
+
+        /**
          * #324/#928: the post-sync banner for a strap whose clock is set in the FUTURE. Unlike the
          * "clock lost / not banking" case ([classifyCompletedOffload]'s bankedNothing), this strap DOES
          * bank records every pass — but its RTC relatched to a future base, so every banked timestamp
@@ -7238,15 +7255,19 @@ class WhoopBleClient(
         // timestamp. The offset is approximate but vastly better than identity (offset 0), which can
         // mis-date nights when the strap's RTC has drifted. No-op when strapNewestTs is null (no Data
         // Range received yet) — the Backfiller keeps its identity default, same as today.
-        strapNewestTs?.let { newest ->
-            // Pair the strap's newest-record device time with the wall clock CAPTURED WHEN IT WAS READ,
-            // not `now`. WHOOP4 doesn't re-fetch the Data Range at each offload, so `now` inflated the
-            // offset by all the elapsed wall time since the last fetch (observed 46s → ~3700s over 30 min).
-            // Pairing with the capture wall keeps the offset at the strap's true RTC skew regardless of how
-            // stale [strapNewestTs] is. Fallback to now only if we somehow have the ts without its wall.
-            val wall = (strapNewestTsWall ?: (System.currentTimeMillis() / 1000L)).toInt()
-            backfiller.clockRef = ClockRef(device = newest.toInt(), wall = wall)
-            log("Clock: seeded backfiller correlation from Data Range (device=$newest wall=$wall, offset ${wall - newest}s)")
+        // #1598: WHOOP 4.0 ONLY — see [derivesClockCorrelation]. Seeding this on a 5/MG turned "how long
+        // the strap went unrecorded" into a bogus clock offset and misdated its history.
+        if (derivesClockCorrelation(connectedFamily)) {
+            strapNewestTs?.let { newest ->
+                // Pair the strap's newest-record device time with the wall clock CAPTURED WHEN IT WAS READ,
+                // not `now`. WHOOP4 doesn't re-fetch the Data Range at each offload, so `now` inflated the
+                // offset by all the elapsed wall time since the last fetch (observed 46s → ~3700s over 30 min).
+                // Pairing with the capture wall keeps the offset at the strap's true RTC skew regardless of how
+                // stale [strapNewestTs] is. Fallback to now only if we somehow have the ts without its wall.
+                val wall = (strapNewestTsWall ?: (System.currentTimeMillis() / 1000L)).toInt()
+                backfiller.clockRef = ClockRef(device = newest.toInt(), wall = wall)
+                log("Clock: seeded backfiller correlation from Data Range (device=$newest wall=$wall, offset ${wall - newest}s)")
+            }
         }
         // #42/#364: consecutiveAutoContinues > 0 means this offload is re-kicked after an EARLIER session
         // in the same burst banked rows — tell the backfiller so its no-cursor END reads as "caught up",

--- a/android/app/src/test/java/com/noop/ble/BackfillContinuationTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BackfillContinuationTest.kt
@@ -512,4 +512,18 @@ class BackfillContinuationTest {
             ),
         )
     }
+
+    // ---- #1598 clock-correlation family gate ----
+
+    /**
+     * A 5/MG must never have a GET_CLOCK correlation DERIVED for it: its records already carry real-unix
+     * seconds, so `wall - strapNewestTs` is how long the strap went unrecorded, NOT an RTC skew. Seeding
+     * it as one shifted that offload's history forward by the gap. WHOOP 4.0 keeps the #700 behaviour.
+     * Twin of the Swift `testOnlyWhoop4DerivesClockCorrelation`.
+     */
+    @Test
+    fun onlyWhoop4DerivesClockCorrelation() {
+        assertTrue(WhoopBleClient.derivesClockCorrelation(com.noop.protocol.DeviceFamily.WHOOP4))
+        assertFalse(WhoopBleClient.derivesClockCorrelation(com.noop.protocol.DeviceFamily.WHOOP5))
+    }
 }


### PR DESCRIPTION
A WHOOP 5/MG never establishes a GET_CLOCK correlation **by design** — its historical (type-47) and live (puffin REALTIME) records both carry the strap RTC's own real-unix seconds, so the identity ref the Backfiller falls back to (`device == wall`, offset 0) is the *correct* decode for it, not a degraded one. Neither of the two places that reason about the correlation knew that.

Found while triaging #1598, whose log made the diagnostic half self-evident.

## 1. Every healthy 5/MG log accused itself of a bug it didn't have

`sessionUsedIdentityRef` is family-agnostic on purpose — it records what the decode actually did — so it is `true` on **every** 5/MG session. The session summary rendered that as:

```
Backfill: rows landed on 2026-08-24 · clock ref: IDENTITY fallback (no clock correlation at decode) - stale-record correction OFF
Clock: no correlation yet — re-sending GET_CLOCK (retry 1/3)
```

which is the name of the #700 misdating bug, plus three retries per offload chasing a reply that is never coming. It is a convincing false alarm: it points at the exact failure a reader is looking for, and the rows in that same log had landed on the right day.

`sessionClockDiagLine` now takes the family and calls identity what it is on a 5/MG. The WHOOP 4.0 warning is untouched — same inputs, different family, still warns.

## 2. The fallback could genuinely misdate a 5/MG's history

The more serious half. Once those retries were exhausted, #700's fallback derived a **non-identity** ref from `strapNewestTs`. On a 4.0 that difference *is* the RTC skew, which is the whole point of #700. On a 5/MG `newest` is already real-unix, so `wall - newest` is merely **how long the strap went unrecorded** — unworn, charging, flat. Applied as a clock offset, it shifts that offload's history forward by exactly that gap once it clears the decoder's 1-day staleness threshold (`histStaleClockThresholdSec`), landing the backfill on the wrong days.

**The two platforms were exposed differently**, which the re-review turned up:

- **Apple** also assigned the derived ref to the *Collector*, and the Collector maps **live** frames through it (`extractStreams(clockRef)`). So the clobber outlived the offload and mis-stamped live data for the rest of the session — `configureCollectorFamily`, which installs the 5/MG identity ref, runs only on connect/bootstrap/scan and never restores it mid-session. It took three failed retries to get there.
- **Android** confined the damage to the Backfiller (`backfiller.clockRef` has exactly one assignment, and this is it) — but seeded it **unconditionally**, with no family check and without even waiting for GET_CLOCK to fail, so it was reachable on any 5/MG offload following a quiet day.


## The Android trigger, traced end to end

Since this does not address the symptom in #1598 (below), the case for it rests on the Android bug being real. Traced through the decoder:

**Scenario:** a 5/MG sits unworn — charger, drawer, flat battery — for more than a day, then the app connects and syncs the banked history.

1. `GET_DATA_RANGE` gives `strapNewestTs` = the newest banked record, now >24 h old, paired with `strapNewestTsWall` = wall clock at the read.
2. `beginBackfill` seeds `ClockRef(device = newest, wall = wallAtRead)`, so `clockOffset = wall - newest` = the idle gap, say 3 days.
3. In `extractHistoricalStreams`, `correctedWall` sees `abs(clockOffset) > HIST_STALE_CLOCK_THRESHOLD_SEC` (86 400) and applies the snapped offset. **Line 848 has no family gate**, so 5/MG v18 records go through it exactly like 4.0 records (v26 too, via line 827).
4. The PR #471 anti-future guard — `if (corrected > wallClockRef + snapGranularity) rawTs else corrected` — **does not save it**. Every record satisfies `rawTs <= strapNewestTs = deviceClockRef`, so `corrected = rawTs + offset <= wallClockRef`. The guard never trips, precisely *because* the offset was derived from the newest record.
5. `plausible(candidate)` passes — the shifted stamps are in the past and after 2023-11.

Result: the whole backfill is shifted forward by the idle gap and stored. Silently — no drop counter, no bad-clock log, nothing in the strap log to show it happened. Rows dedupe by `(deviceId, ts)`, so the wrong timestamps are what land.

Apple is currently immune to this by accident, not design — see the scope note below.

**Not reproduced on hardware.** This is a code-reading argument; the arithmetic is straightforward but unvalidated. The test is a 5/MG left idle for more than a day, then synced.

## The change

Both platforms gate on a pure `derivesClockCorrelation(family)` → 4.0 only, living beside the existing `isFutureDatedNewest` in the same namespace on each side.

- `BackfillContinuation.derivesClockCorrelation` / `WhoopBleClient.derivesClockCorrelation`
- `beginBackfill` wraps the retry + Data-Range fallback in it (Swift) and the seed in it (Kotlin)
- `Backfiller.sessionClockDiagLine` gains `family:`; `Backfiller.family` becomes `private(set)` so the call site passes the family that actually decoded, not a re-derived one

Behaviour on a WHOOP 4.0 is unchanged in every path.

## Parity

**Behaviour is now identical.** Post-fix both platforms decode 5/MG history with an identity ref — Swift synthesises one when `clockRef == nil`, Android's `Backfiller.clockRef` already defaults to `ClockRef.identityNow()`. Previously they diverged: Android seeded a derived ref on every offload, Swift only after three failed retries. Analytics and stored data are otherwise untouched.

The gate itself is twinned (`BackfillContinuation.derivesClockCorrelation` / `WhoopBleClient.derivesClockCorrelation`) with a matching test each side.

Checked and deliberately left alone:

- **`ChunkClockDiag`** (the per-chunk `hist clock chunk=N offset=+0s staleGate=closed` line) is already twinned with tests on both platforms, and reads as neutral fact rather than a fault, so it needed no carve-out.
- **The session clock-diagnostic line is Apple-only** — Android has no equivalent at all, so fix 1 has no Kotlin twin to make. That gap predates this and deserves its own change rather than being smuggled in here.

## Scope: this does NOT address the symptom reported in #1598

Worth stating plainly so the issue isn't closed on merge. The reporter's complaint is days computing about a week late; what he gets from this PR is a log that stops accusing itself. His data is unaffected, because the misdating half was never reachable on his device:

- On **Apple**, a 5/MG never sets `strapNewestTs` at all — `handleDataRangeResponse(..., feedsSync: false)` is deliberate (#695: decode-only on 5/MG until a real strap confirms the newest/oldest offsets). No `strapNewestTs` ⇒ the #700 fallback cannot fire, whatever the retries do.
- His log bears that out: `strap-reported newest ?` on every auto-continue, `retry 3/3` reached once, and `derived rough correlation` logged **zero** times. His MG never answered GET_DATA_RANGE in the first place — no `#451` raw-frame dumps and no `#689` backlog lines, though both are unconditional once that branch is entered.

So the correctness half bites on **Android today**, where the #78 fork made `cmdOff = 10` feed `strapNewestTs` for real and the seed was unconditional. On Apple it is defensive — it goes live the day someone flips `feedsSync: true`, which is exactly when a latent misdating bug would be hardest to attribute.

That difference is itself a parity divergence (Android trusts the 5/MG data range, Apple deliberately does not yet). Left alone here; it wants its own issue rather than a drive-by flip.

The actual cause of #1598 is still unidentified.

## Verification

- `./gradlew compileFullDebugKotlin` — clean
- `./gradlew testFullDebugUnitTest --tests "com.noop.ble.BackfillContinuationTest" --rerun-tasks` — **24 tests, 0 failures**, `onlyWhoop4DerivesClockCorrelation` confirmed present in the XML (not a zero-match filter)
- Swift: **not compiled** — `Backfiller`/`BLEManager`/`StrandTests` are app-target and can't build on Linux, and `app-build.yml` is disabled. Wants an `app-build` run before merge.
- **Not yet validated on hardware.** The 4.0 paths are untouched, but the honest test for fix 2 is a 5/MG left off the wrist for more than a day, then synced — history should land on the real days, and the log should no longer carry retry noise or an `IDENTITY fallback` line.

New tests: identity on a 5/MG reads as by-design; identity on a 4.0 still warns; a 5/MG with a real ref still reports the ordinary in-sync verdict (the carve-out is gated on `usedIdentityRef`, not on family alone); the new line honours the no-em-dash log convention; and the family gate itself, pinned on both platforms.

Reported by @japothek in #1598.
