### PR TITLE
Keep the WHOOP 4.0 device key out of the strap log

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/HelloIdentityProbe.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/HelloIdentityProbe.swift
@@ -6,7 +6,8 @@ import Foundation
 /// serial decoded anywhere: `BatteryPackInfo.serial` is the BATTERY PACK's, read via cmd 151 and
 /// answered only by a 5/MG, so it identifies a removable part rather than the strap wearing it.
 ///
-/// The 4.0 hunt has a capture aid already (the `GET_HELLO_HARVARD` (35) raw dump). This is the 5/MG
+/// The 4.0 hunt has a capture aid already (the `GET_HELLO_HARVARD` (35) branch, which now reports
+/// through this same probe — its payload carries a device key beside the serial). This is the 5/MG
 /// half, and it needs no new traffic: the GET_HELLO block is ALREADY decoded — for the device name at
 /// `pay[16]` and the firmware version at `pay[93]` — and everything else in it is simply discarded. If
 /// the serial is in there, it is arriving on every connect and being thrown away.
@@ -76,13 +77,18 @@ public enum HelloIdentityProbe {
     ///
     /// The length is reported even when nothing prints, because "no printable runs at all" is itself the
     /// answer — it says the serial is not ASCII in this block and the search moves elsewhere.
+    ///
+    /// - Parameter block: which response this payload came from, for the line's prefix. Defaults to the
+    ///   5/MG `GET_HELLO` this probe was written for; the WHOOP 4.0 `GET_HELLO_HARVARD(35)` capture aid
+    ///   passes its own so one log can carry both without the two reading as the same frame.
     public static func report(payload: [UInt8],
+                              block: String = "HELLO(145)",
                               knownNameOffset: Int = 16,
                               minRun: Int = 4,
                               serialLength: ClosedRange<Int> = 6...20) -> String {
         let lines = candidateLines(payload: payload, knownNameOffset: knownNameOffset,
                                    minRun: minRun, serialLength: serialLength)
         let body = lines.isEmpty ? "none" : lines.joined(separator: "; ")
-        return "HELLO(145) block len=\(payload.count) runs: \(body)"
+        return "\(block) block len=\(payload.count) runs: \(body)"
     }
 }

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/HelloIdentityProbeTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/HelloIdentityProbeTests.swift
@@ -116,4 +116,28 @@ final class HelloIdentityProbeTests: XCTestCase {
         XCTAssertTrue(HelloIdentityProbe.candidateLines(payload: []).isEmpty)
         XCTAssertEqual(HelloIdentityProbe.report(payload: []), "HELLO(145) block len=0 runs: none")
     }
+
+    /// #1303 capture aid, WHOOP 4.0 shape. A real cmd-35 response is 131 bytes carrying TWO alnum runs:
+    /// the 9-char SERIAL at offset 14, and the 54-char DEVICE KEY at offset 24. The aid must still show
+    /// the serial — that is what it exists for — and must not show the key, which is exactly what the raw
+    /// hex dump this replaced got wrong. The withholding is the whole point, so it is pinned here rather
+    /// than left to the caller.
+    func testWhoop4HelloHarvardShapeShowsSerialAndWithholdsDeviceKey() {
+        let serial = "4C1246632"                          // 9 alnum: inside the 6...20 serial window
+        let key = String(repeating: "A1B2C3", count: 9)   // 54 alnum: outside it
+        let p = payload(length: 131, runs: [(14, serial), (24, key)])
+        let line = HelloIdentityProbe.report(payload: p, block: "HELLO_HARVARD(35)", knownNameOffset: -1)
+        XCTAssertEqual(line,
+                       "HELLO_HARVARD(35) block len=131 runs: "
+                       + #"off=14 len=9 alnum "4C1246632"; off=24 len=54 alnum (withheld)"#)
+        XCTAssertFalse(line.contains(key), "the device key must never reach the log")
+    }
+
+    /// The `block` label must reach the prefix — a default-only implementation would still pass every
+    /// other test here, and both families now log through this one function.
+    func testBlockLabelReachesThePrefix() {
+        XCTAssertEqual(HelloIdentityProbe.report(payload: [], block: "HELLO_HARVARD(35)"),
+                       "HELLO_HARVARD(35) block len=0 runs: none")
+        XCTAssertEqual(HelloIdentityProbe.report(payload: []), "HELLO(145) block len=0 runs: none")
+    }
 }

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -199,11 +199,24 @@ public final class FrameRouter {
                     state.append(log: "Alarm: strap answered the arm (SET_ALARM_TIME) with result=\(rhex) — log-only, 4.0 result-code meaning unverified")
                 } else if cmd.hasPrefix("GET_HELLO_HARVARD"), TestCentre.active(.connection) {
                     // #1303: capture aid for WHOOP-4.0 stable-serial identity. The strap serial lives in this
-                    // GET_HELLO_HARVARD (cmd 35) response, but its byte offset is undocumented — so dump the
-                    // raw payload ONCE per connect to locate it against the serial the app shows. Gated behind
-                    // Test Centre → Connection so the full serial + device key never reach a DEFAULT (shareable)
-                    // strap log; only an opted-in diagnostic session sees it. Log-only; decodes/persists nothing.
-                    state.append(log: "HELLO_HARVARD(35) resp raw: \(Self.commandResponsePayloadHex(in: frame) ?? "empty") — locate the strap serial offset (#1303)")
+                    // GET_HELLO_HARVARD (cmd 35) response. This used to dump the payload RAW, which answered
+                    // the question — the serial is the 9-char alnum run at offset 14 — but a captured 4.0
+                    // response is 131 bytes carrying TWO alnum runs, and the second (offset 24, 54 chars) is
+                    // the device key. Reporters attach strap logs to public issues, and Test Centre is
+                    // normally enabled BECAUSE they were asked for one, so the gate below selects for the
+                    // logs most likely to be shared rather than the least.
+                    //
+                    // The structural probe answers the same question without that: it reports every printable
+                    // run by offset and length, and quotes only alnum runs 6...20 chars. The serial (9) is
+                    // still shown; the key (54) falls outside and is withheld by the probe rather than by
+                    // this caller, so the rule cannot be got wrong here. `knownNameOffset: -1` because 16 is
+                    // the 5/MG device-name offset and means nothing in a cmd-35 payload — passing it would
+                    // mislabel whatever run happened to start there. Log-only; decodes/persists nothing.
+                    let helloPay = Self.commandResponsePayload(in: frame) ?? []
+                    state.append(log: HelloIdentityProbe.report(payload: helloPay,
+                                                                block: "HELLO_HARVARD(35)",
+                                                                knownNameOffset: -1)
+                                 + " — locate the strap serial offset (#1303)")
                 }
             }
             // #1303: the 5/MG half of the same hunt. The 4.0 aid above is 4.0-only — correctly, since a
@@ -247,7 +260,18 @@ public final class FrameRouter {
                 // one capture the issue is blocked on. Full frame (not the post-prefix payload, which hides
                 // those very bytes); matches the GET_DATA_RANGE raw-frame line (#451) and the format #900's
                 // fixtures are quoted in. Rate-limited: a 4.0 hits this branch on every battery poll.
-                if !rawDumpedRespCmds.contains(cmdName) {
+                // …with ONE command held back, DEFENSIVELY. A WHOOP 4.0 `GET_HELLO_HARVARD(35)` response is
+                // 131 bytes whose body carries the strap's DEVICE KEY (the 54-char alnum run at offset 24,
+                // beside the serial at 14), and this dump is ungated — "normal (shareable)" is the point of
+                // it. On the captures on record cmd 35 answers SUCCESS, so it does not reach this branch at
+                // all today; the skip is not fixing an observed leak. It exists because the branch's own
+                // premise is that a 4.0 misreports its result: the documented zeroed-[seq][result] artefact
+                // is exactly why GET_BATTERY_LEVEL lands here while carrying a good value, and nothing makes
+                // cmd 35 immune to the same artefact on another firmware. One command whose body is a secret
+                // is the one #900 can spare — it needs the PREFIX provenance, which every other command
+                // reaching here supplies. Cmd 35's content stays covered, structurally and with the key
+                // withheld, by the HelloIdentityProbe line above. Twin of the Android skip.
+                if !rawDumpedRespCmds.contains(cmdName), !cmdName.hasPrefix("GET_HELLO_HARVARD") {
                     rawDumpedRespCmds.insert(cmdName)
                     state.append(log: "  raw frame (#900 — [seq][result] provenance): \(Self.fullFrameHex(frame))")
                 }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5818,16 +5818,27 @@ class WhoopBleClient(
                 val respCmd = parsed.parsed["resp_cmd"] as? String
                 val result = parsed.parsed["result"] as? String
                 // #1303: capture aid for WHOOP-4.0 stable-serial identity — the strap serial lives in the
-                // GET_HELLO_HARVARD (cmd 35) response but its byte offset is undocumented, so dump the raw
-                // payload ONCE per connect to locate it against the serial the app shows. Gated behind Test
-                // Centre → Connection so the full serial + device key never reach a DEFAULT (shareable) strap
-                // log; only an opted-in diagnostic session sees it. Log-only; decodes/persists nothing. Twin
-                // of the Swift FrameRouter dump.
+                // GET_HELLO_HARVARD (cmd 35) response. This used to dump the payload RAW, which answered the
+                // question — the serial is the 9-char alnum run at offset 14 — but a captured 4.0 response is
+                // 131 bytes carrying TWO alnum runs, and the second (offset 24, 54 chars) is the device key.
+                // Reporters attach strap logs to public issues, and Test Centre is normally enabled BECAUSE
+                // they were asked for one, so the gate selects for the logs most likely to be shared.
+                //
+                // The structural probe answers the same question without that: every printable run by offset
+                // and length, quoting only alnum runs 6..20 chars. The serial (9) still shows; the key (54)
+                // falls outside and is withheld inside the probe rather than by this caller.
+                // knownNameOffset = -1 because 16 is the 5/MG device-name offset and means nothing in a
+                // cmd-35 payload. Log-only; decodes/persists nothing. Twin of the Swift FrameRouter probe.
                 if (connectedFamily == DeviceFamily.WHOOP4 && respCmd?.startsWith("GET_HELLO_HARVARD") == true &&
                     testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)) {
-                    val raw = whoop4CommandResponsePayload(frame)?.takeIf { it.isNotEmpty() }
-                        ?.joinToString(" ") { "%02x".format(it) } ?: "empty"
-                    log("HELLO_HARVARD(35) resp raw: $raw — locate the strap serial offset (#1303)")
+                    val helloPay = whoop4CommandResponsePayload(frame) ?: ByteArray(0)
+                    log(
+                        com.noop.protocol.HelloIdentityProbe.report(
+                            helloPay,
+                            block = "HELLO_HARVARD(35)",
+                            knownNameOffset = -1,
+                        ) + " — locate the strap serial offset (#1303)",
+                    )
                 }
                 // #1303: the 5/MG half of the same hunt. The 4.0 aid above is 4.0-only — correctly, since
                 // a 5/MG never answers cmd 35 — so this family had no capture at all, and it needs one
@@ -5905,7 +5916,19 @@ class WhoopBleClient(
                     // the one capture the issue is blocked on. Full frame (not whoop4CommandResponsePayload,
                     // which skips those very bytes); matches the GET_DATA_RANGE raw-frame line (#451). Rate-
                     // limited: a 4.0 hits this branch on every battery poll. Twin of the macOS FrameRouter dump.
-                    if (rawDumpedRespCmds.add(respCmd ?: "?")) {
+                    // …with ONE command held back, DEFENSIVELY. A WHOOP 4.0 GET_HELLO_HARVARD(35) response
+                    // is 131 bytes whose body carries the strap's DEVICE KEY (the 54-char alnum run at
+                    // offset 24, beside the serial at 14), and this dump is ungated — "normal (shareable)"
+                    // is the point of it. On the captures on record cmd 35 answers SUCCESS, so it does not
+                    // reach this branch today; the skip is not fixing an observed leak. It exists because
+                    // the branch's own premise is that a 4.0 misreports its result: the documented zeroed
+                    // [seq][result] artefact is why GET_BATTERY_LEVEL lands here while carrying a good
+                    // value, and nothing makes cmd 35 immune to it on another firmware. One command whose
+                    // body is a secret is the one #900 can spare — it needs the PREFIX provenance, which
+                    // every other command reaching here supplies. Cmd 35's content stays covered,
+                    // structurally and with the key withheld, by the HelloIdentityProbe line above. Twin of
+                    // the macOS FrameRouter skip.
+                    if (respCmd?.startsWith("GET_HELLO_HARVARD") != true && rawDumpedRespCmds.add(respCmd ?: "?")) {
                         log("  raw frame (#900 — [seq][result] provenance): " +
                             frame.joinToString("") { "%02x".format(it) })
                     }

--- a/android/app/src/main/java/com/noop/protocol/HelloIdentityProbe.kt
+++ b/android/app/src/main/java/com/noop/protocol/HelloIdentityProbe.kt
@@ -7,7 +7,8 @@ package com.noop.protocol
  * serial decoded anywhere: [BatteryPackInfo]'s serial is the BATTERY PACK's, read via cmd 151 and
  * answered only by a 5/MG, so it identifies a removable part rather than the strap wearing it.
  *
- * The 4.0 hunt has a capture aid already (the `GET_HELLO_HARVARD` (35) raw dump). This is the 5/MG
+ * The 4.0 hunt has a capture aid already (the `GET_HELLO_HARVARD` (35) branch, which now reports
+ * through this same probe — its payload carries a device key beside the serial). This is the 5/MG
  * half, and it needs no new traffic: the GET_HELLO block is ALREADY decoded — for the device name at
  * `pay[16]` and the firmware version at `pay[93]` — and everything else in it is simply discarded. If
  * the serial is in there, it is arriving on every connect and being thrown away.
@@ -85,9 +86,15 @@ object HelloIdentityProbe {
      *
      * The length is reported even when nothing prints, because "no printable runs at all" is itself
      * the answer — it says the serial is not ASCII in this block and the search moves elsewhere.
+     *
+     * [block] names which response this payload came from, for the line's prefix. Defaults to the 5/MG
+     * `GET_HELLO` this probe was written for; the WHOOP 4.0 `GET_HELLO_HARVARD(35)` capture aid passes
+     * its own so one log can carry both without the two reading as the same frame. Twin of the Swift
+     * `report(payload:block:…)`.
      */
     fun report(
         payload: ByteArray,
+        block: String = "HELLO(145)",
         knownNameOffset: Int = 16,
         minRun: Int = 4,
         serialLenMin: Int = SERIAL_LEN_MIN,
@@ -95,6 +102,6 @@ object HelloIdentityProbe {
     ): String {
         val lines = candidateLines(payload, knownNameOffset, minRun, serialLenMin, serialLenMax)
         val body = if (lines.isEmpty()) "none" else lines.joinToString("; ")
-        return "HELLO(145) block len=${payload.size} runs: $body"
+        return "$block block len=${payload.size} runs: $body"
     }
 }

--- a/android/app/src/test/java/com/noop/protocol/HelloIdentityProbeTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/HelloIdentityProbeTest.kt
@@ -125,4 +125,33 @@ class HelloIdentityProbeTest {
         assertTrue(HelloIdentityProbe.candidateLines(ByteArray(0)).isEmpty())
         assertEquals("HELLO(145) block len=0 runs: none", HelloIdentityProbe.report(ByteArray(0)))
     }
+
+    /**
+     * #1303 capture aid, WHOOP 4.0 shape. A real cmd-35 response is 131 bytes carrying TWO alnum runs:
+     * the 9-char SERIAL at offset 14, and the 54-char DEVICE KEY at offset 24. The aid must still show the
+     * serial — that is what it exists for — and must not show the key, which is exactly what the raw hex
+     * dump this replaced got wrong. Twin of the Swift
+     * `testWhoop4HelloHarvardShapeShowsSerialAndWithholdsDeviceKey`.
+     */
+    @Test fun whoop4HelloHarvardShapeShowsSerialAndWithholdsDeviceKey() {
+        val serial = "4C1246632"          // 9 alnum: inside the 6..20 serial window
+        val key = "A1B2C3".repeat(9)      // 54 alnum: outside it
+        val p = payload(131, listOf(14 to serial, 24 to key))
+        val line = HelloIdentityProbe.report(p, block = "HELLO_HARVARD(35)", knownNameOffset = -1)
+        assertEquals(
+            "HELLO_HARVARD(35) block len=131 runs: " +
+                "off=14 len=9 alnum \"4C1246632\"; off=24 len=54 alnum (withheld)",
+            line,
+        )
+        assertFalse("the device key must never reach the log", line.contains(key))
+    }
+
+    /** The [block] label must reach the prefix; both families now log through this one function. */
+    @Test fun blockLabelReachesThePrefix() {
+        assertEquals(
+            "HELLO_HARVARD(35) block len=0 runs: none",
+            HelloIdentityProbe.report(ByteArray(0), block = "HELLO_HARVARD(35)"),
+        )
+        assertEquals("HELLO(145) block len=0 runs: none", HelloIdentityProbe.report(ByteArray(0)))
+    }
 }


### PR DESCRIPTION
A WHOOP 4.0 `GET_HELLO_HARVARD(35)` response is 131 bytes carrying **two** printable-ASCII runs — the 9-char strap serial at offset 14, and a 54-char run at offset 24 that is the **device key**. Two log paths published the whole payload.

Found while auditing what a released build writes into a shareable strap log. Verified against a real 4.0 capture, inspected structurally:

```
payload: 131 bytes
  off= 14 len=  9 alnum   <- serial (what #1303 was hunting)
  off= 24 len= 54 alnum   <- device key
  68 opaque bytes
```

## Correction from the second review pass

My first version of this PR claimed the ungated #900 provenance dump was publishing the key into every default 4.0 export. **That was wrong**, and the log disproves it.

The #900 dump only fires for a **non-SUCCESS** COMMAND_RESPONSE (`!result.hasPrefix("SUCCESS")`), and cmd 35 answers SUCCESS. In a real 4.0 capture every `raw frame (#900 …)` line is a short `aa0c00fc…` (length-12) frame, and there is no `Command response: GET_HELLO_HARVARD` line at all — that line only prints inside the same non-SUCCESS branch. So cmd 35 never reaches it.

The #900 guard is still in this PR, but as **defence in depth**, not a fix for an observed leak. That branch's own premise is a 4.0 misreporting its result — the documented zeroed-`[seq][result]` artefact is exactly why `GET_BATTERY_LEVEL` lands there *while carrying a good value* — and nothing makes cmd 35 immune to the same artefact on another firmware. If it ever does land there, the full 131-byte frame goes into a shareable log. The check runs before the once-per-connection set insert, so it doesn't consume the slot.

**The actual exposure addressed here is the #1303 capture aid below**, which is narrower than I first said: Test Centre-gated rather than universal.

## The second path: the #1303 aid, and why its gate points the wrong way

That one *is* behind Test Centre → Connection, with a comment reasoning that only an opted-in diagnostic session sees it. In practice the gate selects the wrong way round: reporters enable Test Centre **because** they were asked for a log to attach to a public issue. The gated output is the output most likely to be shared, not least.

It now logs through `HelloIdentityProbe`, which reports every printable run by offset and length and quotes only alnum runs 6...20 chars. The serial (9) still prints; the key (54) falls outside and is **withheld inside the probe** rather than by the caller — so the rule can't be got wrong at a call site later. `knownNameOffset: -1` because 16 is the 5/MG device-name offset and means nothing in a cmd-35 payload.

**The aid keeps working.** Its question was where the serial lives; the answer is the offset-14 run, which is exactly what still prints. Its output becomes:

```
HELLO_HARVARD(35) block len=131 runs: off=14 len=9 alnum "4C1246632"; off=24 len=54 alnum (withheld)
```

`report` gains a `block` label so both families log through one function without a 4.0 line reading as a 5/MG `GET_HELLO`. Defaults leave the existing 5/MG caller byte-identical.

## Scope — I checked for other paths

These two are the whole surface for cmd 35. There is no inbound notification-level hex dump, and `PuffinFrameRecorder` is opt-in via `UserDefaults` **and** 5/MG-only. `commandResponsePayloadHex` keeps its three alarm-readback callers, so nothing is left dead.

## Verification

- **Swift `WhoopProtocol`: 13/13**, run on Linux (`swift test --filter HelloIdentityProbeTests`)
- **Kotlin: 13/13**, `HelloIdentityProbeTest` — twins match count for count
- `compileFullDebugKotlin` clean; `Tools/doc_comment_lint.py` clean
- New tests pin the real 131-byte shape on both platforms: serial shown, key withheld, `assertFalse(line.contains(key))`, and the `block` label reaching the prefix

**Not compiled:** `Strand/BLE/FrameRouter.swift` is app-target, so no CI covers it and it can't build on Linux — wants an `app-build` run before merge. The `import WhoopProtocol` it needs is already present (checked, after that exact omission bit #1609), and `commandResponsePayload(in:)` returns `[UInt8]?` so the `?? []` is right, but that's reading rather than compiling.

**Not validated on a strap.** The behaviour is log-only and decodes/persists nothing, but the honest check is a 4.0 connect with Test Centre → Connection on: the probe line should name the offset-14 serial, no 54-char run should appear anywhere in the export, and no `raw frame (#900 …)` line should follow `Command response: GET_HELLO_HARVARD`.

## For whoever reads this before updating

Existing 4.0 strap logs already posted to this repo contain the key. Rotating it isn't something NOOP can do — it comes from the strap — so this stops the bleeding rather than undoing it.
