### PR TITLE
Android: let the phone smart alarm skip chosen days

### DIFF
--- a/android/app/src/main/java/com/noop/alarm/SmartAlarmScheduler.kt
+++ b/android/app/src/main/java/com/noop/alarm/SmartAlarmScheduler.kt
@@ -54,7 +54,8 @@ object SmartAlarmScheduler {
         // The window's hard edge can roll past midnight (e.g. 23:50 + 30). Compute the next wall-clock
         // occurrence of that absolute minute-of-day, then derive the window-start from it so the two
         // edges stay on the same night even across the midnight boundary.
-        val deadline = nextOccurrence(deadlineMin % SmartAlarmStore.MINUTES_PER_DAY)
+        val weekdays = store.weekdays
+        val deadline = nextOccurrence(deadlineMin % SmartAlarmStore.MINUTES_PER_DAY, weekdays)
         // Re-arm after a fire (audit): when the smart alarm fires EARLY on a light-sleep phase (e.g. 06:35
         // for a 07:00 deadline), the deadline's next occurrence is still TODAY 07:00 — so a plain re-arm
         // scheduled a second guaranteed wake the SAME morning, waking the user again. We just woke them
@@ -63,7 +64,14 @@ object SmartAlarmScheduler {
             val now = Calendar.getInstance()
             val sameDay = deadline.get(Calendar.YEAR) == now.get(Calendar.YEAR) &&
                 deadline.get(Calendar.DAY_OF_YEAR) == now.get(Calendar.DAY_OF_YEAR)
-            if (sameDay) deadline.add(Calendar.DAY_OF_YEAR, 1)
+            if (sameDay) {
+                deadline.add(Calendar.DAY_OF_YEAR, 1)
+                // …and that push can land on a day the alarm is switched off, so re-apply the weekday
+                // filter. Without this, re-arming after a Saturday fire would schedule Sunday even with
+                // Sunday deselected — the one path that reaches a disabled day, because it moves the
+                // deadline AFTER nextOccurrence already filtered it.
+                advanceToEnabledDay(deadline, weekdays)
+            }
         }
         val windowStartMs = deadline.timeInMillis - store.windowMinutes.toLong() * 60_000L
 
@@ -148,12 +156,34 @@ object SmartAlarmScheduler {
     }
 
     /** The next wall-clock occurrence (today or tomorrow) of an absolute minute-of-day. */
-    private fun nextOccurrence(minuteOfDay: Int): Calendar =
+    private fun nextOccurrence(minuteOfDay: Int, weekdays: Set<Int> = emptySet()): Calendar =
         Calendar.getInstance().apply {
             set(Calendar.HOUR_OF_DAY, minuteOfDay / 60)
             set(Calendar.MINUTE, minuteOfDay % 60)
             set(Calendar.SECOND, 0)
             set(Calendar.MILLISECOND, 0)
             if (timeInMillis <= System.currentTimeMillis()) add(Calendar.DAY_OF_YEAR, 1)
+            advanceToEnabledDay(this, weekdays)
         }
+
+    /**
+     * Roll `cal` forward until it lands on a day the alarm is allowed to fire on.
+     *
+     * EMPTY [weekdays] means every day, so this is a no-op — that is the pre-weekday behaviour and the
+     * default for every existing install, which is why the whole feature can ship without a migration.
+     *
+     * The 7-iteration bound is a guard, not an expectation: [SmartAlarmStore.weekdays] already filters
+     * to 1..7, so a non-empty set always contains a reachable day and the loop exits in at most six
+     * steps. If a future caller ever passes an unreachable set, this returns the unshifted day rather
+     * than spinning — a wrong-day alarm is recoverable, a hung scheduler on the safety-critical path is
+     * not. Kept `internal` so the day-selection can be unit-tested without an AlarmManager.
+     */
+    internal fun advanceToEnabledDay(cal: Calendar, weekdays: Set<Int>) {
+        if (weekdays.isEmpty()) return
+        var guard = 0
+        while (cal.get(Calendar.DAY_OF_WEEK) !in weekdays && guard < 7) {
+            cal.add(Calendar.DAY_OF_YEAR, 1)
+            guard++
+        }
+    }
 }

--- a/android/app/src/main/java/com/noop/alarm/SmartAlarmStore.kt
+++ b/android/app/src/main/java/com/noop/alarm/SmartAlarmStore.kt
@@ -37,6 +37,25 @@ class SmartAlarmStore(private val prefs: SharedPreferences) {
         get() = prefs.getInt(KEY_WINDOW, DEFAULT_WINDOW).coerceIn(WINDOW_MIN, WINDOW_MAX)
         set(v) = prefs.edit().putInt(KEY_WINDOW, v.coerceIn(WINDOW_MIN, WINDOW_MAX)).apply()
 
+    /** Days the phone alarm fires on (`Calendar.DAY_OF_WEEK`: 1=Sun … 7=Sat).
+     *
+     *  EMPTY MEANS EVERY DAY — the backward-compatible default, so an existing install with no key set
+     *  keeps firing daily exactly as before. Only 1..7 survive a load, so a corrupted entry cannot
+     *  schedule a bogus day. Same encoding and same empty-set semantics as the STRAP alarm's
+     *  `NoopPrefs.smartAlarmWeekdays`, deliberately: the two are edited by the same
+     *  `AlarmWeekdayPicker`, and a user toggling identical-looking circles on one screen would not
+     *  forgive them meaning different things.
+     *
+     *  The day tested is the one the HARD DEADLINE lands on — the morning you are actually woken —
+     *  not the window's opening edge, which can sit on the previous date when the window crosses
+     *  midnight. See `SmartAlarmScheduler.arm`. */
+    var weekdays: Set<Int>
+        get() = prefs.getStringSet(KEY_WEEKDAYS, emptySet())
+            ?.mapNotNull { it.toIntOrNull() }?.filter { it in 1..7 }?.toSet() ?: emptySet()
+        set(v) = prefs.edit()
+            .putStringSet(KEY_WEEKDAYS, v.filter { it in 1..7 }.map { it.toString() }.toSet())
+            .apply()
+
     /** The wall-clock epoch (ms) of the currently-scheduled HARD deadline, or 0 if none. Persisted so
      *  the boot receiver can re-arm the exact alarm after a restart without recomputing intent. */
     var scheduledDeadlineMs: Long
@@ -53,6 +72,7 @@ class SmartAlarmStore(private val prefs: SharedPreferences) {
         private const val KEY_ENABLED = "alarm.enabled"
         private const val KEY_TARGET = "alarm.targetMinutes"
         private const val KEY_WINDOW = "alarm.windowMinutes"
+        private const val KEY_WEEKDAYS = "alarm.weekdays"
         private const val KEY_DEADLINE_MS = "alarm.scheduledDeadlineMs"
         private const val KEY_WINDOW_START_MS = "alarm.scheduledWindowStartMs"
 

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -611,6 +611,10 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     private val _phoneAlarmWindowMinutes = MutableStateFlow(phoneAlarmStore.windowMinutes)
     /** How long after the target the guaranteed hard deadline sits. */
     val phoneAlarmWindowMinutes: StateFlow<Int> = _phoneAlarmWindowMinutes.asStateFlow()
+    private val _phoneAlarmWeekdays = MutableStateFlow(phoneAlarmStore.weekdays)
+    /** Days the phone alarm fires on (Calendar.DAY_OF_WEEK). EMPTY = every day — see
+     *  [SmartAlarmStore.weekdays]; same encoding as the strap alarm's `smartAlarmWeekdays`. */
+    val phoneAlarmWeekdays: StateFlow<Set<Int>> = _phoneAlarmWeekdays.asStateFlow()
     // "Buzz WHOOP 4" companion (#536): arm the strap's firmware alarm at the phone alarm's EARLIEST wake
     // time, so the strap buzzes first and the OS alarm fires at the hard deadline as backup. Declared here
     // with the phone-alarm flows (BEFORE init) so the init bond collector can read it. Default OFF.
@@ -2455,6 +2459,18 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         reconcileStrapAlarm()
     }
 
+    /** Set the days the phone alarm fires on. EMPTY = every day (see [SmartAlarmStore.weekdays]).
+     *
+     *  Re-arms while enabled so deselecting today's day moves the alarm to the next selected one
+     *  immediately, rather than at the next fire. Also reconciles the strap: "Buzz WHOOP 4" arms the
+     *  band at THIS alarm's time, so a day switched off here must not leave the strap buzzing on it. */
+    fun setPhoneAlarmWeekdays(days: Set<Int>) {
+        phoneAlarmStore.weekdays = days
+        _phoneAlarmWeekdays.value = phoneAlarmStore.weekdays
+        if (phoneAlarmStore.enabled) SmartAlarmScheduler.arm(appContext, phoneAlarmStore)
+        reconcileStrapAlarm()
+    }
+
     /** Toggle the "Buzz WHOOP 4/5" companion (#536). Routes through the single strap-alarm reconciler so
      *  enabling/disabling it never clobbers a smart wake-alarm sharing the one firmware slot (#5): on the
      *  reconcile re-evaluates BOTH flags and arms the earliest, off it re-evaluates and keeps the slot for
@@ -2637,9 +2653,14 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                 dayOverrides = _smartAlarmDayOverrides.value,
             )
         } else null
-        // Buzz-WHOOP-4 companion's requested time: the phone alarm's EARLIEST wake time, next occurrence.
+        // Buzz-WHOOP-4 companion's requested time: the phone alarm's EARLIEST wake time, next occurrence
+        // ON A DAY THAT ALARM ACTUALLY FIRES. This routes through the same weekday-aware resolver the
+        // smart alarm uses (with no per-day overrides — the phone alarm has none) rather than
+        // nextDailyEpochSec, which is unconditionally daily: leaving it daily would buzz the strap on a
+        // morning the phone alarm is switched off, which is precisely the day the user asked to sleep in.
+        // An empty weekday set still means every day, so the default behaviour is unchanged.
         val buzzEpoch = if (_buzzWhoop4Enabled.value) {
-            nextDailyEpochSec(phoneAlarmStore.targetMinutes)
+            nextSmartAlarmEpochSec(phoneAlarmStore.targetMinutes, phoneAlarmStore.weekdays)
         } else null
 
         val epochSec = earliestStrapAlarmEpochSec(smartEpoch, buzzEpoch)
@@ -2931,8 +2952,13 @@ internal fun nextSmartAlarmEpochSec(
 
 /**
  * Next strictly-future occurrence of a daily wake time (today, or tomorrow if already passed), as an
- * epoch-second. Used for the "Buzz WHOOP 4/5" companion, which fires every day at the phone alarm's
- * earliest wake time (no weekday selection). Pure + clock-injectable so it can be unit-tested.
+ * epoch-second. Pure + clock-injectable so it can be unit-tested.
+ *
+ * NO PRODUCTION CALLER as of the phone alarm gaining weekday selection: the "Buzz WHOOP 4/5" companion
+ * was its only one, and it now routes through [nextSmartAlarmEpochSec] so a day switched off on the
+ * phone alarm cannot leave the strap buzzing on that morning. Kept because it is the reference for what
+ * "unconditionally daily" means here — [nextSmartAlarmEpochSec] with an empty weekday set must stay
+ * equivalent to it, and its own test is what pins that. Delete it only alongside that equivalence.
  */
 internal fun nextDailyEpochSec(
     minuteOfDay: Int,

--- a/android/app/src/main/java/com/noop/ui/SmartAlarmScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SmartAlarmScreen.kt
@@ -60,6 +60,7 @@ fun SmartAlarmScreen(vm: AppViewModel) {
     val enabled by vm.phoneAlarmEnabled.collectAsStateWithLifecycle()
     val targetMinutes by vm.phoneAlarmTargetMinutes.collectAsStateWithLifecycle()
     val windowMinutes by vm.phoneAlarmWindowMinutes.collectAsStateWithLifecycle()
+    val phoneAlarmWeekdays by vm.phoneAlarmWeekdays.collectAsStateWithLifecycle()
     val buzzWhoop4 by vm.buzzWhoop4Enabled.collectAsStateWithLifecycle()
     // #536: the hint adapts to bond state — the strap can only be armed when a WHOOP 4.0 is connected.
     val liveState = vm.live.collectAsStateWithLifecycle().value
@@ -151,6 +152,18 @@ fun SmartAlarmScreen(vm: AppViewModel) {
                         onChange = { vm.setPhoneAlarmWindowMinutes(it) },
                     )
                 }
+
+                // Days this alarm fires on. The SAME shared picker the strap alarm below uses, and the
+                // same empty-means-every-day contract, so identical-looking circles behave identically on
+                // one screen. Lets a weekend be switched off without disabling the alarm and having to
+                // remember to switch it back on.
+                RowDividerLocal()
+                AlarmWeekdayPicker(
+                    selected = phoneAlarmWeekdays,
+                    onToggle = { dow ->
+                        vm.setPhoneAlarmWeekdays(toggledSmartAlarmWeekday(dow, phoneAlarmWeekdays))
+                    },
+                )
             }
 
             // #536: companion strap-buzz, always visible so it's discoverable. Arms the strap's own firmware

--- a/android/app/src/test/java/com/noop/alarm/PhoneAlarmWeekdayTest.kt
+++ b/android/app/src/test/java/com/noop/alarm/PhoneAlarmWeekdayTest.kt
@@ -1,0 +1,85 @@
+package com.noop.alarm
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.Calendar
+
+/**
+ * Per-day scheduling for the PHONE smart alarm (distinct from com.noop.ui.SmartAlarmWeekdayTest,
+ * which covers the STRAP alarm): the Mon…Sun circles that let a day be switched off
+ * without disabling the alarm and having to remember to switch it back on.
+ *
+ * Covers [SmartAlarmScheduler.advanceToEnabledDay], which is the whole of the day-selection logic —
+ * `arm` wraps it around an AlarmManager call that a JVM test cannot exercise, so the decision is
+ * factored out and pinned here instead. Fixtures use a fixed date so a Sunday case stays a Sunday case
+ * whatever day the suite runs on.
+ */
+class PhoneAlarmWeekdayTest {
+
+    /** 2026-08-24 is a Monday. Calendar.DAY_OF_WEEK: 1=Sun … 7=Sat. */
+    private fun mondayAt(hour: Int = 7): Calendar = Calendar.getInstance().apply {
+        set(2026, Calendar.AUGUST, 24, hour, 0, 0)
+        set(Calendar.MILLISECOND, 0)
+    }
+
+    /** The fixture must actually be the day the tests below assume. */
+    @Test fun fixtureIsAMonday() {
+        assertEquals(Calendar.MONDAY, mondayAt().get(Calendar.DAY_OF_WEEK))
+    }
+
+    /**
+     * EMPTY = every day. This is the backward-compatible default: every existing install has no weekday
+     * key set, so an empty set must leave the day exactly as computed or the feature would silently
+     * re-schedule everyone's alarm on upgrade.
+     */
+    @Test fun emptySetMeansEveryDayAndDoesNotMoveTheDay() {
+        val cal = mondayAt()
+        SmartAlarmScheduler.advanceToEnabledDay(cal, emptySet())
+        assertEquals(Calendar.MONDAY, cal.get(Calendar.DAY_OF_WEEK))
+        assertEquals(24, cal.get(Calendar.DAY_OF_MONTH))
+    }
+
+    /** A day that IS selected is left alone — no gratuitous shifting. */
+    @Test fun anEnabledDayIsNotMoved() {
+        val cal = mondayAt()
+        SmartAlarmScheduler.advanceToEnabledDay(cal, setOf(Calendar.MONDAY, Calendar.FRIDAY))
+        assertEquals(Calendar.MONDAY, cal.get(Calendar.DAY_OF_WEEK))
+        assertEquals(24, cal.get(Calendar.DAY_OF_MONTH))
+    }
+
+    /** A disabled day rolls forward to the next selected one, and to the NEAREST such day. */
+    @Test fun aDisabledDayAdvancesToTheNextSelectedDay() {
+        val cal = mondayAt()
+        SmartAlarmScheduler.advanceToEnabledDay(cal, setOf(Calendar.WEDNESDAY, Calendar.SATURDAY))
+        assertEquals(Calendar.WEDNESDAY, cal.get(Calendar.DAY_OF_WEEK))
+        assertEquals(26, cal.get(Calendar.DAY_OF_MONTH))   // Mon 24 → Wed 26, not Sat
+    }
+
+    /** Wrapping the week end: from Monday, a Sunday-only alarm lands six days out, not never. */
+    @Test fun itWrapsAroundTheWeekEnd() {
+        val cal = mondayAt()
+        SmartAlarmScheduler.advanceToEnabledDay(cal, setOf(Calendar.SUNDAY))
+        assertEquals(Calendar.SUNDAY, cal.get(Calendar.DAY_OF_WEEK))
+        assertEquals(30, cal.get(Calendar.DAY_OF_MONTH))   // Mon 24 → Sun 30
+    }
+
+    /** The time of day survives a day shift — only the DATE moves. */
+    @Test fun advancingPreservesTheWakeTime() {
+        val cal = mondayAt(hour = 6).apply { set(Calendar.MINUTE, 45) }
+        SmartAlarmScheduler.advanceToEnabledDay(cal, setOf(Calendar.THURSDAY))
+        assertEquals(Calendar.THURSDAY, cal.get(Calendar.DAY_OF_WEEK))
+        assertEquals(6, cal.get(Calendar.HOUR_OF_DAY))
+        assertEquals(45, cal.get(Calendar.MINUTE))
+    }
+
+    /**
+     * An unreachable set returns the unshifted day rather than spinning. [SmartAlarmStore.weekdays]
+     * filters to 1..7 so this is unreachable through the store, but the guard is on the
+     * safety-critical scheduling path: a wrong-day alarm is recoverable, a hung scheduler is not.
+     */
+    @Test fun anUnreachableSetTerminatesInsteadOfSpinning() {
+        val cal = mondayAt()
+        SmartAlarmScheduler.advanceToEnabledDay(cal, setOf(99))
+        assertEquals(24 + 7, cal.get(Calendar.DAY_OF_MONTH))   // bounded at 7 hops, then gives up
+    }
+}

--- a/android/app/src/test/java/com/noop/ui/StrapAlarmReconcileTest.kt
+++ b/android/app/src/test/java/com/noop/ui/StrapAlarmReconcileTest.kt
@@ -13,9 +13,12 @@ import java.util.TimeZone
  * whichever ran last won the time.
  *
  * [reconcileStrapAlarm] in AppViewModel is now the sole arm/disarm caller; its decision is the pure
- * [earliestStrapAlarmEpochSec] over each feature's requested epoch ([nextSmartAlarmEpochSec] for the
- * smart alarm, [nextDailyEpochSec] for the companion). These tests exercise that pure decision against
- * a fixed clock, no BLE stack needed. Calendar.DAY_OF_WEEK: 1 = Sun ... 7 = Sat.
+ * [earliestStrapAlarmEpochSec] over each feature's requested epoch. BOTH now resolve through
+ * [nextSmartAlarmEpochSec]: the companion arms the strap at the PHONE alarm's time, so once the phone
+ * alarm gained its own weekday selection the companion had to honour it too, or the band would buzz on
+ * a morning that alarm is switched off. It passes no per-day overrides — the phone alarm has none.
+ * These tests exercise that pure decision against a fixed clock, no BLE stack needed.
+ * Calendar.DAY_OF_WEEK: 1 = Sun ... 7 = Sat.
  */
 class StrapAlarmReconcileTest {
 
@@ -32,9 +35,14 @@ class StrapAlarmReconcileTest {
     private fun smartReq(enabled: Boolean, minuteOfDay: Int, weekdays: Set<Int>, nowMs: Long): Long? =
         if (enabled) nextSmartAlarmEpochSec(minuteOfDay, weekdays, nowMs, ::utcCalendar) else null
 
-    /** The Buzz-WHOOP companion's requested epoch when ENABLED, else null. */
-    private fun buzzReq(enabled: Boolean, minuteOfDay: Int, nowMs: Long): Long? =
-        if (enabled) nextDailyEpochSec(minuteOfDay, nowMs, ::utcCalendar) else null
+    /** The Buzz-WHOOP companion's requested epoch when ENABLED, else null. Mirrors reconcileStrapAlarm:
+     *  weekday-aware against the PHONE alarm's days, empty meaning every day. */
+    private fun buzzReq(
+        enabled: Boolean,
+        minuteOfDay: Int,
+        nowMs: Long,
+        weekdays: Set<Int> = emptySet(),
+    ): Long? = if (enabled) nextSmartAlarmEpochSec(minuteOfDay, weekdays, nowMs, ::utcCalendar) else null
 
     @Test
     fun bothOff_disarms() {
@@ -141,5 +149,35 @@ class StrapAlarmReconcileTest {
         val now = wedAt(9, 0)
         val slot = nextDailyEpochSec(8 * 60, now, ::utcCalendar)  // 08:00, already passed
         assertEquals(ms(2026, 6, 18, 8, 0) / 1000, slot)         // Thu 08:00
+    }
+
+    /**
+     * The phone alarm's weekday selection must reach the COMPANION too. "Buzz WHOOP 4" arms the band at
+     * the phone alarm's earliest wake time, so a day switched off there must not leave the strap buzzing
+     * on that morning — the day the user specifically asked to sleep through.
+     *
+     * Wednesday 06:00 "now", companion wanting 08:00, but the phone alarm set to Thursday only: the slot
+     * must land on THURSDAY 08:00, not today.
+     */
+    @Test
+    fun companionHonoursThePhoneAlarmsWeekdays() {
+        val now = wedAt(6, 0)
+        val slot = earliestStrapAlarmEpochSec(
+            smartReq(false, 7 * 60, emptySet(), now),
+            buzzReq(true, 8 * 60, now, weekdays = setOf(Calendar.THURSDAY)),
+        )
+        assertEquals(ms(2026, 6, 18, 8, 0) / 1000, slot)
+    }
+
+    /** …and an EMPTY selection still means every day, so the pre-weekday behaviour is untouched: the
+     *  companion takes TODAY at 08:00, exactly as the old daily resolver did. */
+    @Test
+    fun companionWithNoWeekdaysStillFiresToday() {
+        val now = wedAt(6, 0)
+        val slot = earliestStrapAlarmEpochSec(
+            smartReq(false, 7 * 60, emptySet(), now),
+            buzzReq(true, 8 * 60, now),
+        )
+        assertEquals(wedAt(8, 0) / 1000, slot)
     }
 }


### PR DESCRIPTION
Adds the Mon…Sun circles to the **phone** smart alarm, so a day can be switched off without disabling the alarm and having to remember to switch it back on. From a user asking for exactly that, and the narrowest thing that answers it (see #1611 for the wider alarm discussion this came out of).

## Why this alarm

The phone smart alarm is the only alarm in NOOP with no weekday concept. The strap alarm has had weekdays *and* per-day override times for a while, so a user with both currently sees day circles on one card of the Alarms screen and not the other.

## Same contract as the strap alarm, deliberately

`SmartAlarmStore` gains `weekdays` using the identical encoding and the identical **empty-means-every-day** semantics as `NoopPrefs.smartAlarmWeekdays`:

- an existing install has no key set, so it keeps firing daily — **no migration**
- both are edited by the same shared `AlarmWeekdayPicker`, and identical-looking circles on one screen should not mean different things

**Which day is tested:** the one the **hard deadline** lands on — the morning you are actually woken — not the window's opening edge, which sits on the previous date whenever the window crosses midnight.

## The bug this would have had

Day selection is one bounded helper, `advanceToEnabledDay`, applied in `nextOccurrence` **and again after the after-fire same-day push**. The second call is the one that matters:

```kotlin
if (sameDay) {
    deadline.add(Calendar.DAY_OF_YEAR, 1)
    advanceToEnabledDay(deadline, weekdays)   // ← the push moves the deadline AFTER nextOccurrence filtered it
}
```

Without it, re-arming after a Saturday fire would schedule Sunday with Sunday deselected — the one path that reaches a disabled day, because it moves the deadline past the filter.

The 7-hop bound is a guard, not an expectation: the store filters to 1..7, so a non-empty set always terminates. It is there because a wrong-day alarm is recoverable and a hung scheduler on the safety-critical path is not.

## "Buzz WHOOP 4" had to learn the same days

That companion arms the strap at **this** alarm's time. Left alone it would have buzzed the band on precisely the morning the user asked to sleep through. It now resolves through `nextSmartAlarmEpochSec` (weekday-aware, no per-day overrides — the phone alarm has none) rather than the unconditionally-daily `nextDailyEpochSec`.

I checked the two are equivalent for an empty set before swapping: the loop's `offset 0` then `offset 1` reproduces the old resolver exactly, and it cannot return null when the set is empty. So default behaviour is unchanged.

That left `nextDailyEpochSec` with no production caller. It stays as the reference for what "unconditionally daily" means — its own test is what pins the equivalence above — and its doc now says so rather than leaving it looking live.

**`StrapAlarmReconcileTest` modelled the companion with the old daily resolver**, so it would have kept passing while no longer pinning production. Model corrected, two cases added.

## Parity

**Android only, and no gap opens.** iOS/macOS has no phone-side windowed alarm to add this to — `BehaviorStore.swift:76` records that `behavior.smartAlarmWindow` was *"retired: it was stored but never read (no wake-window watcher ever shipped)"* — and its strap alarm already has weekdays and per-day overrides.

## Inherited wrinkle: deselecting the LAST day turns the alarm back on for every day

Found on a second review pass. Not introduced here — it lives in the shared `toggledSmartAlarmWeekday`, so the strap alarm has had it all along — but this PR puts it on a second surface, so it should be said out loud rather than quietly inherited.

`toggledSmartAlarmWeekday` collapses a full week to `emptySet()` as the canonical "every day". Deselecting your way down to *zero* days also produces `emptySet()`. So tapping the last remaining circle off flips "Mondays only" to "every day", and because `smartAlarmWeekdayIsSelected` renders empty as **all circles on**, the UI jumps from one lit circle to seven. The user taps to remove a day and every day lights up.

The existing suite pins empty-means-every-day, the collapse at seven, and the first tap from empty — but **not** the deselect-to-zero path, so this reads as unspecified rather than intended.

Deliberately not fixed here. The helper is shared, so changing it changes the strap alarm's behaviour too, and that is a shipped surface and a separate concern. Two reasonable follow-ups: refuse to deselect the last day, or treat all-off as "off" and let the master toggle follow. Worth a decision either way, since it now affects two cards on one screen.

## Verification

- `compileFullDebugKotlin` clean
- **50 tests, 0 failures** across the five alarm suites, `--rerun-tasks` so nothing is cached: `PhoneAlarmWeekdayTest` 7 (new), `SleepWindowWatcherTest` 7, `SmartAlarmWeekdayTest` 14, `SmartAlarmDayOverrideTest` 11, `StrapAlarmReconcileTest` 11
- `Tools/doc_comment_lint.py` clean; `Tools/i18n_audit.py --ci` clean
- **No new strings**, so no translation work — the picker is the existing shared component and carries its own labels

New tests pin the empty-set default (the no-migration guarantee), that an enabled day is not moved, nearest-next-day selection, week-end wrap, that the wake time survives a day shift, and that an unreachable set terminates rather than spins.

**Not validated on a device.** The scheduling is pure and covered above, but the honest checks are: the circles persist across an app restart, deselecting today's day moves the alarm rather than waiting until it fires, and with "Buzz WHOOP 4" on the strap does not buzz on a deselected morning. That last one needs a strap and a rollover, so it is the one I would want eyes on.

