### PR TITLE
Trace the baseline fold, so a log can say why a spread never lifted

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines+Trace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines+Trace.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+// Baselines+Trace.swift - the per-night BASELINE FOLD diagnostic (Recovery test mode).
+//
+// Every other core analytics component has a trace file; the fold did not, so a strap log could show
+// what a baseline IS (RecoveryScorer+Trace prints mean / spread / nValid / status) but never how it got
+// there. That gap costs real triage time, because the fold's decisions are exactly the ones that go
+// wrong quietly: a night rejected as a hard outlier is "seen, but not folded" and leaves no trace at
+// all, and a spread pinned on its floor looks identical to a spread that has genuinely settled.
+//
+// Returns the state from `Baselines.update(...)` VERBATIM and recomputes only the intermediate
+// decisions for the lines, so the trace can never disagree with the baseline the scorer reads. Pure and
+// side-effect-free: no clock, no I/O, so a fixture night pins the exact lines. Gated at the call site
+// behind the Recovery test mode; when it is off this is never called, so there is zero cost. No
+// em-dashes. Values, counts and thresholds only, no PII.
+
+extension Baselines {
+
+    /// Side-effect-free diagnostic twin of `update(...)`: returns the SAME state `update(...)` would,
+    /// plus a line naming which branch the night took and why.
+    ///
+    /// The branches, in the order `update` tests them:
+    ///  - `seed` / `seed-empty` - the first ever night; it FIXES the centre and starts spread at the floor.
+    ///  - `missing`     - no value for the night; skip-and-hold, `nightsSinceUpdate` climbs.
+    ///  - `implausible` - outside the metric's physiological bounds; skip-and-hold.
+    ///  - `rejected`    - a hard outlier once seeded and no longer young; seen, but not folded.
+    ///  - `folded`      - the normal Winsorized-EWMA path.
+    ///
+    /// The `folded` line reports `young`, the effective spread and half-life actually used, the Winsor
+    /// band and whether the value was clamped, and spread before/after WITH whether it landed on
+    /// `cfg.floorSpread`. That last flag is the point of the whole file: `atFloor=yes` many nights in
+    /// means the z-scores the score divides by are still being computed against the floor.
+    ///
+    /// - Parameter metric: the metric key ("hrv", "resting_hr", ...) so one log can carry several folds.
+    public static func updateTrace(_ state: BaselineState?,
+                                   value: Double?,
+                                   cfg: MetricCfg,
+                                   metric: String,
+                                   rejectHardOutliers: Bool = true) -> (state: BaselineState, lines: [String]) {
+        // The returned state is the REAL fold's, always. Nothing below recomputes it.
+        let next = update(state, value: value, cfg: cfg, rejectHardOutliers: rejectHardOutliers)
+
+        func r2(_ x: Double) -> Double { (x * 100.0).rounded(.toNearestOrAwayFromZero) / 100.0 }
+        func yn(_ b: Bool) -> String { b ? "yes" : "no" }
+        let head = "baseline \(metric)"
+        let stateSuffix = "-> mean=\(r2(next.baseline)) spread=\(r2(next.spread)) "
+            + "nValid=\(next.nValid) status=\(next.status.rawValue)"
+
+        // Branch order MIRRORS `update` exactly: it tests `state == nil` FIRST and that branch decides
+        // the value's validity itself, so a first night with a missing or out-of-range value is a seed
+        // case and not a skip. Testing value-ness first here would label those two lines wrongly while
+        // still returning the right state, which is the worst kind of diagnostic.
+        guard let state = state else {
+            guard let v = value, cfg.minVal <= v && v <= cfg.maxVal else {
+                return (next, ["\(head) night=seed-empty no usable first value "
+                               + "(bounds=\(r2(cfg.minVal))..\(r2(cfg.maxVal))) "
+                               + "seeded at midpoint, nValid stays 0 \(stateSuffix)"])
+            }
+            return (next, ["\(head) night=seed value=\(r2(v)) "
+                           + "spread starts at floor=\(r2(cfg.floorSpread)) "
+                           + "(this ONE night fixes the centre) \(stateSuffix)"])
+        }
+
+        guard let value = value else {
+            return (next, ["\(head) night=missing skip-and-hold "
+                           + "nightsSinceUpdate=\(next.nightsSinceUpdate) \(stateSuffix)"])
+        }
+
+        guard cfg.minVal <= value && value <= cfg.maxVal else {
+            return (next, ["\(head) night=implausible value=\(r2(value)) "
+                           + "bounds=\(r2(cfg.minVal))..\(r2(cfg.maxVal)) skip-and-hold "
+                           + "nightsSinceUpdate=\(next.nightsSinceUpdate) \(stateSuffix)"])
+        }
+
+        // Same predicate `update` uses: tied to the valid-night count, not to spread.
+        let isYoung = state.nValid < earlyAdaptNights
+
+        if rejectHardOutliers && state.nValid >= minNightsSeed && !isYoung {
+            let dev = abs(value - state.baseline)
+            if dev > hardOutlierK * state.spread {
+                return (next, ["\(head) night=rejected value=\(r2(value)) "
+                               + "dev=\(r2(dev)) > k=\(r2(hardOutlierK))*spread=\(r2(state.spread)) "
+                               + "(seen, NOT folded) \(stateSuffix)"])
+            }
+        }
+
+        let effSpread = isYoung ? state.spread * earlySpreadInflate : state.spread
+        let effHalfLifeB = isYoung ? earlyHalfLifeB : cfg.halfLifeB
+        let lo = state.baseline - winsorK * effSpread
+        let hi = state.baseline + winsorK * effSpread
+        let clamped = max(lo, min(hi, value))
+        let wasClamped = clamped != value
+        // `update` floors the spread with max(cfg.floorSpread, ...); report when that floor is what won,
+        // since a spread sitting on its floor is indistinguishable from a settled one in every other log.
+        let atFloor = next.spread <= cfg.floorSpread
+
+        return (next, ["\(head) night=folded value=\(r2(value)) young=\(yn(isYoung)) "
+                       + "effSpread=\(r2(effSpread)) halfLifeB=\(r2(effHalfLifeB)) "
+                       + "winsor=\(r2(lo))..\(r2(hi)) clamped=\(yn(wasClamped))"
+                       + (wasClamped ? " to=\(r2(clamped))" : "")
+                       + " spread \(r2(state.spread))->\(r2(next.spread)) atFloor=\(yn(atFloor)) \(stateSuffix)"])
+    }
+
+    /// Replay an ordered history (oldest first) through `updateTrace`, returning the final state and one
+    /// line per night. The state threaded between nights is the real fold's, so this is
+    /// `foldHistory(...)` with commentary rather than a reimplementation of it.
+    ///
+    /// This is the shape that answers "how many nights until the spread lifted", which is unanswerable
+    /// from a single night's line.
+    /// - Parameter tail: keep only the last N lines. The WHOLE history is still folded, so the state is
+    ///   unchanged; this bounds the log, because an established user's history is hundreds of nights and
+    ///   a diagnostic nobody can read is not a diagnostic. nil keeps every line.
+    public static func foldHistoryTrace(_ values: [Double?],
+                                        cfg: MetricCfg,
+                                        metric: String,
+                                        rejectHardOutliers: Bool = true,
+                                        tail: Int? = nil) -> (state: BaselineState, lines: [String]) {
+        var state: BaselineState? = nil
+        var lines: [String] = []
+        for v in values {
+            let step = updateTrace(state, value: v, cfg: cfg, metric: metric,
+                                   rejectHardOutliers: rejectHardOutliers)
+            state = step.state
+            lines.append(contentsOf: step.lines)
+        }
+        if let tail = tail, tail >= 0, lines.count > tail {
+            let dropped = lines.count - tail
+            lines = ["baseline \(metric) (earlier \(dropped) night(s) omitted)"] + lines.suffix(tail)
+        }
+        guard let final = state else {
+            // Empty history: mirror foldHistory's midpoint seed rather than inventing a different one.
+            let seed = (cfg.minVal + cfg.maxVal) / 2.0
+            return (BaselineState(baseline: seed, spread: cfg.floorSpread, nValid: 0,
+                                  nightsSinceUpdate: 0,
+                                  status: computeStatus(nValid: 0, nightsSinceUpdate: 0)),
+                    ["baseline \(metric) history=empty"])
+        }
+        return (final, lines)
+    }
+
+    /// The recalibration-aware fold, traced. Twin of `foldHistory(_:dayKeys:cfg:baselineEpoch:)`, which
+    /// DROPS (rather than skip-and-holds) every night dated before the recalibration epoch.
+    ///
+    /// The drop is the point. A manual "Recalibrate baseline" discards the user's earlier nights and
+    /// restarts the count, and nothing in a log has ever said so - a reporter sat at "Calibrating, 3 of
+    /// 4 nights" holding 15 valid nights, because each tap threw them away. The `dropped=` line names
+    /// that directly instead of leaving it to be inferred from a suspiciously low nValid.
+    ///
+    /// `baselineEpoch` is REQUIRED here, unlike the production overload which defaults to reading it
+    /// from UserDefaults: this file stays pure, so the caller reads the pref and passes it in.
+    public static func foldHistoryTrace(_ values: [Double?],
+                                        dayKeys: [String],
+                                        cfg: MetricCfg,
+                                        metric: String,
+                                        baselineEpoch: Double,
+                                        tail: Int? = nil) -> (state: BaselineState, lines: [String]) {
+        guard baselineEpoch > 0 else {
+            return foldHistoryTrace(values, cfg: cfg, metric: metric, tail: tail)
+        }
+        let fmt = DateFormatter()
+        fmt.calendar = Calendar(identifier: .gregorian)
+        fmt.timeZone = TimeZone(secondsFromGMT: 0)
+        fmt.dateFormat = "yyyy-MM-dd"
+
+        // Filter THEN fold, which is what the production loop does night by night; folding the kept
+        // nights in order gives the identical state, and a test pins that against the real function.
+        var kept: [Double?] = []
+        var dropped = 0
+        for (i, v) in values.enumerated() {
+            if i < dayKeys.count, let d = fmt.date(from: dayKeys[i]),
+               d.timeIntervalSince1970 < baselineEpoch {
+                dropped += 1
+                continue
+            }
+            kept.append(v)
+        }
+        let day = fmt.string(from: Date(timeIntervalSince1970: baselineEpoch))
+        let head = "baseline \(metric) recalibrated=\(day) dropped=\(dropped) night(s) before it"
+        let out = foldHistoryTrace(kept, cfg: cfg, metric: metric, tail: tail)
+        return (out.state, [head] + out.lines)
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BaselinesTraceTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BaselinesTraceTests.swift
@@ -1,0 +1,217 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// The per-night baseline-fold trace. Twin of the Kotlin `BaselinesTraceTest` — the SAME fixtures and
+/// the SAME expected strings, because a diagnostic whose two platforms word things differently cannot
+/// be compared across a pair of reports.
+///
+/// The contract that matters most is the first test: the traced state must BE the real fold's, so the
+/// trace can never describe a baseline the scorer isn't using.
+final class BaselinesTraceTests: XCTestCase {
+
+    private let hrv = Baselines.metricCfg["hrv"]!
+
+    /// The whole point: tracing must not change, or re-derive, the state.
+    func testTracedStateIsTheRealFoldsState() {
+        var traced: BaselineState? = nil
+        var real: BaselineState? = nil
+        let nights: [Double?] = [60.0, 70.0, nil, 999.0, 55.0, 62.0, 58.0, 61.0, 150.0, 59.0]
+        for v in nights {
+            traced = Baselines.updateTrace(traced, value: v, cfg: hrv, metric: "hrv").state
+            real = Baselines.update(real, value: v, cfg: hrv)
+            XCTAssertEqual(real!.baseline, traced!.baseline, "baseline diverged")
+            XCTAssertEqual(real!.spread, traced!.spread, "spread diverged")
+            XCTAssertEqual(real!.nValid, traced!.nValid, "nValid diverged")
+            XCTAssertEqual(real!.status, traced!.status, "status diverged")
+        }
+    }
+
+    func testSeedNamesThatOneNightFixesTheCentre() {
+        XCTAssertEqual(
+            Baselines.updateTrace(nil, value: 60.0, cfg: hrv, metric: "hrv").lines[0],
+            "baseline hrv night=seed value=60.0 spread starts at floor=5.0 "
+            + "(this ONE night fixes the centre) -> mean=60.0 spread=5.0 nValid=1 status=calibrating")
+    }
+
+    /// A first night with no usable value seeds the MIDPOINT and leaves nValid at 0 — not a skip.
+    func testSeedEmptyIsDistinctFromASkip() {
+        XCTAssertEqual(
+            Baselines.updateTrace(nil, value: nil, cfg: hrv, metric: "hrv").lines[0],
+            "baseline hrv night=seed-empty no usable first value (bounds=5.0..250.0) "
+            + "seeded at midpoint, nValid stays 0 -> mean=127.5 spread=5.0 nValid=0 status=calibrating")
+    }
+
+    func testMissingNightIsSkipAndHold() {
+        let s = Baselines.updateTrace(nil, value: 60.0, cfg: hrv, metric: "hrv").state
+        XCTAssertEqual(
+            Baselines.updateTrace(s, value: nil, cfg: hrv, metric: "hrv").lines[0],
+            "baseline hrv night=missing skip-and-hold nightsSinceUpdate=1 "
+            + "-> mean=60.0 spread=5.0 nValid=1 status=calibrating")
+    }
+
+    func testImplausibleNightNamesTheBounds() {
+        let s = Baselines.updateTrace(nil, value: 60.0, cfg: hrv, metric: "hrv").state
+        XCTAssertEqual(
+            Baselines.updateTrace(s, value: 999.0, cfg: hrv, metric: "hrv").lines[0],
+            "baseline hrv night=implausible value=999.0 bounds=5.0..250.0 skip-and-hold "
+            + "nightsSinceUpdate=1 -> mean=60.0 spread=5.0 nValid=1 status=calibrating")
+    }
+
+    /// While young the fold uses the fast half-life and the inflated Winsor band; the line says so.
+    func testFoldedYoungReportsTheEarlyAdaptation() {
+        let s = Baselines.updateTrace(nil, value: 60.0, cfg: hrv, metric: "hrv").state
+        XCTAssertEqual(
+            Baselines.updateTrace(s, value: 70.0, cfg: hrv, metric: "hrv").lines[0],
+            "baseline hrv night=folded value=70.0 young=yes effSpread=12.5 halfLifeB=3.0 "
+            + "winsor=22.5..97.5 clamped=no spread 5.0->5.1 atFloor=no "
+            + "-> mean=62.06 spread=5.1 nValid=2 status=calibrating")
+    }
+
+    /// A hard outlier is "seen, NOT folded" — the case that otherwise leaves no trace at all.
+    func testRejectedNightIsNamedWithItsThreshold() {
+        let settled = Baselines.foldHistoryTrace(Array(repeating: 60.0, count: 10), cfg: hrv, metric: "hrv").state
+        XCTAssertEqual(
+            Baselines.updateTrace(settled, value: 150.0, cfg: hrv, metric: "hrv").lines[0],
+            "baseline hrv night=rejected value=150.0 dev=90.0 > k=5.0*spread=5.0 (seen, NOT folded) "
+            + "-> mean=60.0 spread=5.0 nValid=10 status=provisional")
+    }
+
+    func testFoldedSettledUsesTheNormalHalfLifeAndBand() {
+        let settled = Baselines.foldHistoryTrace(Array(repeating: 60.0, count: 10), cfg: hrv, metric: "hrv").state
+        XCTAssertEqual(
+            Baselines.updateTrace(settled, value: 66.0, cfg: hrv, metric: "hrv").lines[0],
+            "baseline hrv night=folded value=66.0 young=no effSpread=5.0 halfLifeB=14.0 "
+            + "winsor=45.0..75.0 clamped=no spread 5.0->5.02 atFloor=no "
+            + "-> mean=60.29 spread=5.02 nValid=11 status=provisional")
+    }
+
+    /// The reason this file exists: a flat history leaves the spread ON its floor for as long as you
+    /// care to fold, and `atFloor=yes` is the only way a log ever says so. Every other diagnostic shows
+    /// a settled-looking spread=5.0 with nothing to distinguish it from a converged one.
+    func testAFlatHistoryReportsSpreadPinnedOnTheFloor() {
+        let out = Baselines.foldHistoryTrace(Array(repeating: 60.0, count: 12), cfg: hrv, metric: "hrv")
+        XCTAssertEqual(out.state.spread, 5.0)
+        let folded = out.lines.filter { $0.contains("night=folded") }
+        XCTAssertFalse(folded.isEmpty, "expected folded nights")
+        XCTAssertTrue(folded.allSatisfy { $0.contains("atFloor=yes") },
+                      "a flat history must report atFloor=yes")
+    }
+
+    /// One line per night, in order, so a history reads as a trajectory.
+    func testFoldHistoryTraceEmitsOneLinePerNight() {
+        let out = Baselines.foldHistoryTrace([60.0, nil, 62.0, 999.0, 58.0], cfg: hrv, metric: "hrv")
+        XCTAssertEqual(out.lines.count, 5)
+        XCTAssertTrue(out.lines[0].contains("night=seed"))
+        XCTAssertTrue(out.lines[1].contains("night=missing"))
+        XCTAssertTrue(out.lines[2].contains("night=folded"))
+        XCTAssertTrue(out.lines[3].contains("night=implausible"))
+    }
+
+    func testEmptyHistoryIsSafe() {
+        let out = Baselines.foldHistoryTrace([], cfg: hrv, metric: "hrv")
+        XCTAssertEqual(out.lines, ["baseline hrv history=empty"])
+        XCTAssertEqual(out.state.nValid, 0)
+    }
+
+    /// Project convention: no em-dashes leak into a log line.
+    func testNoEmDashesInAnyLine() {
+        let out = Baselines.foldHistoryTrace([60.0, nil, 999.0, 70.0, 150.0], cfg: hrv, metric: "hrv")
+        XCTAssertFalse(out.lines.isEmpty)
+        XCTAssertFalse(out.lines.contains { $0.contains("\u{2014}") })
+    }
+
+    /// The tail cap bounds the log without changing the state: the whole history is still folded.
+    func testTailCapsTheLinesButNotTheFold() {
+        let hist: [Double?] = (0..<30).map { 60.0 + Double($0) }
+        let full = Baselines.foldHistoryTrace(hist, cfg: hrv, metric: "hrv")
+        let capped = Baselines.foldHistoryTrace(hist, cfg: hrv, metric: "hrv", tail: 5)
+        XCTAssertEqual(full.state.baseline, capped.state.baseline, "state must not depend on the cap")
+        XCTAssertEqual(full.state.nValid, capped.state.nValid)
+        XCTAssertEqual(capped.lines.count, 6)   // 1 omission notice + 5 nights
+        XCTAssertEqual(capped.lines[0], "baseline hrv (earlier 25 night(s) omitted)")
+        XCTAssertEqual(Array(full.lines.suffix(5)), Array(capped.lines.dropFirst()))
+    }
+
+    /// A tail bigger than the history leaves it untouched, with no misleading omission notice.
+    func testTailLargerThanHistoryAddsNoNotice() {
+        let out = Baselines.foldHistoryTrace(Array(repeating: 60.0, count: 3), cfg: hrv, metric: "hrv", tail: 14)
+        XCTAssertEqual(out.lines.count, 3)
+        XCTAssertFalse(out.lines.contains { $0.contains("omitted") })
+    }
+
+    /// The recalibration drop, named. This is #731's failure mode: the tap discards earlier nights and
+    /// restarts the count, and no log ever said so.
+    func testRecalibrationDropIsNamedAndMatchesTheRealFold() {
+        let days = ["2026-08-01", "2026-08-02", "2026-08-03", "2026-08-04", "2026-08-05"]
+        let values: [Double?] = [60.0, 61.0, 62.0, 63.0, 64.0]
+        // Epoch at 2026-08-04 UTC start-of-day: the first three nights are dropped.
+        let epoch = utcEpoch(year: 2026, month: 8, day: 4)
+        let out = Baselines.foldHistoryTrace(values, dayKeys: days, cfg: hrv, metric: "hrv", baselineEpoch: epoch)
+        XCTAssertEqual(out.lines[0], "baseline hrv recalibrated=2026-08-04 dropped=3 night(s) before it")
+        // and the state is the REAL recalibration-aware fold's, not a re-derivation
+        let real = Baselines.foldHistory(values, dayKeys: days, cfg: hrv, baselineEpoch: epoch)
+        XCTAssertEqual(real.baseline, out.state.baseline)
+        XCTAssertEqual(real.spread, out.state.spread)
+        XCTAssertEqual(real.nValid, out.state.nValid)
+    }
+
+    /// No epoch set: identical to the plain fold, with no recalibration line invented.
+    func testNoRecalibrationEpochBehavesLikeThePlainFold() {
+        let days = ["2026-08-01", "2026-08-02", "2026-08-03"]
+        let values: [Double?] = [60.0, 61.0, 62.0]
+        let out = Baselines.foldHistoryTrace(values, dayKeys: days, cfg: hrv, metric: "hrv", baselineEpoch: 0)
+        let plain = Baselines.foldHistoryTrace(values, cfg: hrv, metric: "hrv")
+        XCTAssertEqual(plain.lines, out.lines)
+        XCTAssertEqual(plain.state.baseline, out.state.baseline)
+    }
+
+    /// dayKeys SHORTER than values: the real fold only tests the epoch for indices it has a key for, and
+    /// keeps the rest. The trace filters on the same condition, so the states must agree — this is the
+    /// case where a filter-then-fold shortcut could silently diverge from a fold-with-skips.
+    func testShortDayKeysKeepTheUndatedNightsExactlyLikeTheRealFold() {
+        let values: [Double?] = [60.0, 61.0, 62.0, 63.0, 64.0]
+        let days = ["2026-08-01", "2026-08-02"]   // only two keys for five nights
+        let epoch = utcEpoch(year: 2026, month: 8, day: 2)
+        let out = Baselines.foldHistoryTrace(values, dayKeys: days, cfg: hrv, metric: "hrv", baselineEpoch: epoch)
+        let real = Baselines.foldHistory(values, dayKeys: days, cfg: hrv, baselineEpoch: epoch)
+        XCTAssertEqual(real.baseline, out.state.baseline)
+        XCTAssertEqual(real.spread, out.state.spread)
+        XCTAssertEqual(real.nValid, out.state.nValid)
+        XCTAssertTrue(out.lines[0].contains("dropped=1"))   // only 2026-08-01 precedes the epoch
+    }
+
+    /// tail = 0 keeps the notice and nothing else, rather than emitting an empty list.
+    func testTailOfZeroKeepsOnlyTheOmissionNotice() {
+        let out = Baselines.foldHistoryTrace(Array(repeating: 60.0, count: 4), cfg: hrv, metric: "hrv", tail: 0)
+        XCTAssertEqual(out.lines, ["baseline hrv (earlier 4 night(s) omitted)"])
+        XCTAssertEqual(out.state.nValid, 4)
+    }
+
+    /// A negative tail is ignored rather than trimming anything.
+    func testNegativeTailIsIgnored() {
+        let out = Baselines.foldHistoryTrace(Array(repeating: 60.0, count: 4), cfg: hrv, metric: "hrv", tail: -1)
+        XCTAssertEqual(out.lines.count, 4)
+        XCTAssertFalse(out.lines.contains { $0.contains("omitted") })
+    }
+
+    /// The recalibration line must SURVIVE the tail cap: it is prepended after trimming, not trimmed.
+    func testRecalibrationLineSurvivesATightTail() {
+        let values: [Double?] = (0..<20).map { 60.0 + Double($0) }
+        let days = (0..<20).map { String(format: "2026-08-%02d", $0 + 1) }
+        let epoch = utcEpoch(year: 2026, month: 8, day: 5)
+        let out = Baselines.foldHistoryTrace(values, dayKeys: days, cfg: hrv, metric: "hrv",
+                                             baselineEpoch: epoch, tail: 3)
+        XCTAssertTrue(out.lines[0].contains("recalibrated="), "recalibration line must not be trimmed")
+        XCTAssertTrue(out.lines[1].contains("omitted"))
+        XCTAssertEqual(out.lines.count, 5)   // recalibration + notice + 3 nights
+    }
+
+    /// UTC start-of-day epoch, so the fixtures read the same on any machine.
+    private func utcEpoch(year: Int, month: Int, day: Int) -> Double {
+        var comps = DateComponents()
+        comps.year = year; comps.month = month; comps.day = day
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(secondsFromGMT: 0)!
+        return cal.date(from: comps)!.timeIntervalSince1970
+    }
+}

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1535,10 +1535,29 @@ final class IntelligenceEngine: ObservableObject {
         // (AnalyticsEngine's skinTempDevC guard) so this is belt-and-suspenders, but it stops a
         // future use-site from trusting a CALIBRATING baseline. (PR #97 review.)
         let skinFold = Baselines.foldHistory(skinSeq, dayKeys: skinDayKeys, cfg: skinCfg, baselineEpoch: recoveryEpoch)
+        // #1614: the per-night HRV fold, traced. HRV ONLY, deliberately: it is Charge's dominant driver
+        // and the one whose spread the score divides by, so tracing all four baselines would quadruple
+        // the log for the three that are not the question being asked. Capped at the last 14 nights,
+        // which is enough to see whether the spread is lifting without an established user's history
+        // burying the rest of the export. The whole history is still folded, so the state is unchanged
+        // and the trace cannot describe a baseline the scorer is not using.
+        //
+        // The epoch is read ONCE, here, and handed to BOTH folds. Baselines+Trace is deliberately pure so
+        // it cannot read the pref itself, and letting the scored fold take its UserDefaults default while
+        // the trace read its own copy would leave a window - however small - where a diagnostic describes
+        // a fold the score did not perform. Passing it explicitly below is byte-identical to that default.
+        let hrvEpoch = Baselines.hrvBaselineEpoch()
+        if TestCentre.active(.recovery) {
+            let traced = Baselines.foldHistoryTrace(hrvSeq, dayKeys: hrvDayKeys, cfg: hrvCfg,
+                                                    metric: "hrv",
+                                                    baselineEpoch: hrvEpoch,
+                                                    tail: 14)
+            for line in traced.lines { diagnosticSink?(line, .recovery) }
+        }
         let baselines2 = AnalyticsEngine.ProfileBaselines(
             // HRV honours noop.hrvBaselineEpoch; rhr/resp/skin honour noop.recoveryBaselineEpoch via their
             // parallel day keys, so the manual Recalibrate restarts the whole Charge build-up together.
-            hrv: Baselines.foldHistory(hrvSeq, dayKeys: hrvDayKeys, cfg: hrvCfg),
+            hrv: Baselines.foldHistory(hrvSeq, dayKeys: hrvDayKeys, cfg: hrvCfg, baselineEpoch: hrvEpoch),
             restingHR: Baselines.foldHistory(rhrSeq, dayKeys: rhrDayKeys, cfg: rhrCfg, baselineEpoch: recoveryEpoch),
             resp: respFold.usable ? respFold : nil,
             skinTemp: skinFold.usable ? skinFold : nil)

--- a/android/app/src/main/java/com/noop/analytics/BaselinesTrace.kt
+++ b/android/app/src/main/java/com/noop/analytics/BaselinesTrace.kt
@@ -1,0 +1,240 @@
+package com.noop.analytics
+
+import kotlin.math.abs
+
+/**
+ * The per-night BASELINE FOLD diagnostic (Recovery test mode). Twin of the Swift `Baselines+Trace`.
+ *
+ * Every other core analytics component has a trace; the fold did not, so a strap log could show what a
+ * baseline IS (RecoveryScorerTrace prints mean / spread / nValid / status) but never how it got there.
+ * That gap costs real triage time, because the fold's decisions are the ones that go wrong quietly: a
+ * night rejected as a hard outlier is "seen, but not folded" and leaves no trace at all, and a spread
+ * pinned on its floor looks identical to a spread that has genuinely settled.
+ *
+ * Returns the state from [Baselines.update] VERBATIM and recomputes only the intermediate decisions for
+ * the lines, so the trace can never disagree with the baseline the scorer reads. Pure and
+ * side-effect-free: no clock, no I/O, so a fixture night pins the exact lines. Gated at the call site
+ * behind the Recovery test mode; when it is off this is never called, so there is zero cost. No
+ * em-dashes. Values, counts and thresholds only, no PII.
+ */
+object BaselinesTrace {
+
+    /** One folded night: the real next state, plus the line describing which branch it took. */
+    data class Step(val state: BaselineState, val lines: List<String>)
+
+    /** Nearest with half-ties AWAY FROM ZERO, matching Swift's `.rounded(.toNearestOrAwayFromZero)`.
+     *  A plain `Math.round` is half-UP and diverges from Swift on negative ties, which the Winsor band's
+     *  lower edge can reach on a low-centred metric. Same expression as [RecoveryScorerTrace]. */
+    private fun r2(x: Double): Double {
+        val scaled = x * 100.0
+        return Math.copySign(Math.round(abs(scaled)) / 100.0, scaled)
+    }
+    private fun yn(b: Boolean): String = if (b) "yes" else "no"
+
+    /**
+     * Side-effect-free diagnostic twin of [Baselines.update]: returns the SAME state it would, plus a
+     * line naming which branch the night took and why.
+     *
+     * The branches, in the order [Baselines.update] tests them:
+     *  - `seed` / `seed-empty` - the first ever night; it FIXES the centre and starts spread at the floor.
+     *  - `missing`     - no value for the night; skip-and-hold, `nightsSinceUpdate` climbs.
+     *  - `implausible` - outside the metric's physiological bounds; skip-and-hold.
+     *  - `rejected`    - a hard outlier once seeded and no longer young; seen, but not folded.
+     *  - `folded`      - the normal Winsorized-EWMA path.
+     *
+     * The `folded` line reports `young`, the effective spread and half-life actually used, the Winsor
+     * band and whether the value was clamped, and spread before/after WITH whether it landed on
+     * [MetricCfg.floorSpread]. That last flag is the point of the whole file: `atFloor=yes` many nights
+     * in means the z-scores the score divides by are still being computed against the floor.
+     *
+     * [metric] is the metric key ("hrv", "resting_hr", ...) so one log can carry several folds.
+     */
+    fun updateTrace(
+        state: BaselineState?,
+        value: Double?,
+        cfg: MetricCfg,
+        metric: String,
+        rejectHardOutliers: Boolean = true,
+    ): Step {
+        // The returned state is the REAL fold's, always. Nothing below recomputes it.
+        val next = Baselines.update(state, value, cfg, rejectHardOutliers)
+        val head = "baseline $metric"
+        // `.raw`, not `.name.lowercase()`: raw is the declared wire string and the exact twin of Swift's
+        // `.rawValue`, so the two platforms' lines stay identical even if a case is ever renamed or a
+        // multi-word case is added.
+        val stateSuffix = "-> mean=${r2(next.baseline)} spread=${r2(next.spread)} " +
+            "nValid=${next.nValid} status=${next.status.raw}"
+
+        // Branch order MIRRORS update exactly: it tests state == null FIRST and that branch decides the
+        // value's validity itself, so a first night with a missing or out-of-range value is a seed case
+        // and not a skip. Testing value-ness first here would label those two lines wrongly while still
+        // returning the right state, which is the worst kind of diagnostic.
+        if (state == null) {
+            val v = value
+            if (v == null || !(cfg.minVal <= v && v <= cfg.maxVal)) {
+                return Step(
+                    next,
+                    listOf(
+                        "$head night=seed-empty no usable first value " +
+                            "(bounds=${r2(cfg.minVal)}..${r2(cfg.maxVal)}) " +
+                            "seeded at midpoint, nValid stays 0 $stateSuffix",
+                    ),
+                )
+            }
+            return Step(
+                next,
+                listOf(
+                    "$head night=seed value=${r2(v)} " +
+                        "spread starts at floor=${r2(cfg.floorSpread)} " +
+                        "(this ONE night fixes the centre) $stateSuffix",
+                ),
+            )
+        }
+
+        if (value == null) {
+            return Step(
+                next,
+                listOf("$head night=missing skip-and-hold nightsSinceUpdate=${next.nightsSinceUpdate} $stateSuffix"),
+            )
+        }
+
+        if (!(cfg.minVal <= value && value <= cfg.maxVal)) {
+            return Step(
+                next,
+                listOf(
+                    "$head night=implausible value=${r2(value)} " +
+                        "bounds=${r2(cfg.minVal)}..${r2(cfg.maxVal)} skip-and-hold " +
+                        "nightsSinceUpdate=${next.nightsSinceUpdate} $stateSuffix",
+                ),
+            )
+        }
+
+        // Same predicate update uses: tied to the valid-night count, not to spread.
+        val isYoung = state.nValid < Baselines.earlyAdaptNights
+
+        if (rejectHardOutliers && state.nValid >= Baselines.minNightsSeed && !isYoung) {
+            val dev = abs(value - state.baseline)
+            if (dev > Baselines.hardOutlierK * state.spread) {
+                return Step(
+                    next,
+                    listOf(
+                        "$head night=rejected value=${r2(value)} " +
+                            "dev=${r2(dev)} > k=${r2(Baselines.hardOutlierK)}*spread=${r2(state.spread)} " +
+                            "(seen, NOT folded) $stateSuffix",
+                    ),
+                )
+            }
+        }
+
+        val effSpread = if (isYoung) state.spread * Baselines.earlySpreadInflate else state.spread
+        val effHalfLifeB = if (isYoung) Baselines.earlyHalfLifeB else cfg.halfLifeB
+        val lo = state.baseline - Baselines.winsorK * effSpread
+        val hi = state.baseline + Baselines.winsorK * effSpread
+        val clamped = maxOf(lo, minOf(hi, value))
+        val wasClamped = clamped != value
+        // update floors the spread with max(cfg.floorSpread, ...); report when that floor is what won,
+        // since a spread sitting on its floor is indistinguishable from a settled one in every other log.
+        val atFloor = next.spread <= cfg.floorSpread
+
+        return Step(
+            next,
+            listOf(
+                "$head night=folded value=${r2(value)} young=${yn(isYoung)} " +
+                    "effSpread=${r2(effSpread)} halfLifeB=${r2(effHalfLifeB)} " +
+                    "winsor=${r2(lo)}..${r2(hi)} clamped=${yn(wasClamped)}" +
+                    (if (wasClamped) " to=${r2(clamped)}" else "") +
+                    " spread ${r2(state.spread)}->${r2(next.spread)} atFloor=${yn(atFloor)} $stateSuffix",
+            ),
+        )
+    }
+
+    /**
+     * Replay an ordered history (oldest first) through [updateTrace], returning the final state and one
+     * line per night. The state threaded between nights is the real fold's, so this is
+     * [Baselines.foldHistory] with commentary rather than a reimplementation of it.
+     *
+     * This is the shape that answers "how many nights until the spread lifted", which is unanswerable
+     * from a single night's line.
+     */
+    fun foldHistoryTrace(
+        values: List<Double?>,
+        cfg: MetricCfg,
+        metric: String,
+        rejectHardOutliers: Boolean = true,
+        tail: Int? = null,
+    ): Step {
+        var state: BaselineState? = null
+        var lines = ArrayList<String>()
+        for (v in values) {
+            val step = updateTrace(state, v, cfg, metric, rejectHardOutliers)
+            state = step.state
+            lines.addAll(step.lines)
+        }
+        // [tail] keeps only the last N lines. The WHOLE history is still folded, so the state is
+        // unchanged; this bounds the log, because an established user's history is hundreds of nights
+        // and a diagnostic nobody can read is not a diagnostic. null keeps every line.
+        if (tail != null && tail >= 0 && lines.size > tail) {
+            val dropped = lines.size - tail
+            val capped = ArrayList<String>()
+            capped.add("baseline $metric (earlier $dropped night(s) omitted)")
+            capped.addAll(lines.takeLast(tail))
+            lines = capped
+        }
+        val final = state
+            ?: return Step(
+                // Empty history: mirror foldHistory's midpoint seed rather than inventing a different one.
+                BaselineState(
+                    baseline = (cfg.minVal + cfg.maxVal) / 2.0,
+                    spread = cfg.floorSpread,
+                    nValid = 0,
+                    nightsSinceUpdate = 0,
+                    status = Baselines.computeStatus(0, 0),
+                ),
+                listOf("baseline $metric history=empty"),
+            )
+        return Step(final, lines)
+    }
+
+    /**
+     * The recalibration-aware fold, traced. Twin of [Baselines.foldHistory] with `dayKeys`, which DROPS
+     * (rather than skip-and-holds) every night dated before the recalibration epoch.
+     *
+     * The drop is the point. A manual "Recalibrate baseline" discards the user's earlier nights and
+     * restarts the count, and nothing in a log has ever said so - a reporter sat at "Calibrating, 3 of 4
+     * nights" holding 15 valid nights, because each tap threw them away. The `dropped=` line names that
+     * directly instead of leaving it to be inferred from a suspiciously low nValid.
+     */
+    fun foldHistoryTrace(
+        values: List<Double?>,
+        dayKeys: List<String>,
+        cfg: MetricCfg,
+        metric: String,
+        baselineEpoch: Double,
+        tail: Int? = null,
+    ): Step {
+        if (baselineEpoch <= 0.0) return foldHistoryTrace(values, cfg, metric, tail = tail)
+
+        // Filter THEN fold, which is what the production loop does night by night; folding the kept
+        // nights in order gives the identical state, and a test pins that against the real function.
+        val kept = ArrayList<Double?>()
+        var dropped = 0
+        for (i in values.indices) {
+            if (i < dayKeys.size) {
+                val dayStart = runCatching {
+                    java.time.LocalDate.parse(dayKeys[i])
+                        .atStartOfDay(java.time.ZoneOffset.UTC).toEpochSecond().toDouble()
+                }.getOrNull()
+                if (dayStart != null && dayStart < baselineEpoch) { dropped++; continue }
+            }
+            kept.add(values[i])
+        }
+        val day = java.time.Instant.ofEpochSecond(baselineEpoch.toLong())
+            .atZone(java.time.ZoneOffset.UTC).toLocalDate().toString()
+        val head = "baseline $metric recalibrated=$day dropped=$dropped night(s) before it"
+        val out = foldHistoryTrace(kept, cfg, metric, tail = tail)
+        val lines = ArrayList<String>()
+        lines.add(head)
+        lines.addAll(out.lines)
+        return Step(out.state, lines)
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1334,6 +1334,10 @@ object IntelligenceEngine {
         // HRV baseline honours noop.hrvBaselineEpoch; rhr/resp/skin honour noop.recoveryBaselineEpoch via
         // their parallel day keys, so the manual Recalibrate restarts the whole Charge build-up together.
         // A 0.0 epoch is byte-identical to the plain fold, so scoring is unchanged until the user taps it.
+        // #1614: the per-night HRV fold, traced (see [emitHrvFoldTrace] for scope and why it is a call
+        // rather than an inline lambda). Sits immediately above the fold it describes, and takes the SAME
+        // baselineEpoch, so the trace can only ever describe the fold the scorer actually performed.
+        emitHrvFoldTrace(recoveryTraceSink, hrvSeq, hrvDayKeys, hrvCfg, baselineEpoch)
         val hrvBase2 = Baselines.foldHistory(hrvSeq, hrvDayKeys, hrvCfg, baselineEpoch)
         val rhrBase2 = Baselines.foldHistory(rhrSeq, rhrDayKeys, rhrCfg, recoveryEpoch)
         // Resp baseline: WITHIN one brand it still mixes imported (cloud) values with on-device RSA
@@ -2194,6 +2198,33 @@ object IntelligenceEngine {
             out.add(WatchScoredDay(row.day, res.recovery, res.confidence))
         }
         return out
+    }
+
+    /**
+     * #1614: emit the per-night HRV baseline fold when the Recovery test mode is on (a non-null sink IS
+     * the gate, as with [recoveryTraceLines]).
+     *
+     * HRV ONLY, deliberately: it is Charge's dominant driver and the one whose spread the score divides
+     * by, so tracing all four baselines would quadruple the log for the three that are not the question
+     * being asked. Capped at the last 14 nights, enough to see whether the spread is lifting without an
+     * established user's history burying the rest of the export. The WHOLE history is still folded, so
+     * the state the scorer reads is untouched.
+     *
+     * Deliberately its own function rather than inlined at the fold site: [analyzeRecentOnCpu] sits a
+     * few dozen bytes under a hard bytecode budget (the JVM's 64K per-method ceiling, with headroom
+     * reserved for JaCoCo instrumentation), and inlining this tipped it over. That is the one place the
+     * two platforms diverge in shape: the Swift wiring has no such constraint and reads inline.
+     */
+    private fun emitHrvFoldTrace(
+        sink: ((String) -> Unit)?,
+        hrvSeq: List<Double?>,
+        hrvDayKeys: List<String>,
+        hrvCfg: MetricCfg,
+        baselineEpoch: Double,
+    ) {
+        if (sink == null) return
+        BaselinesTrace.foldHistoryTrace(hrvSeq, hrvDayKeys, hrvCfg, "hrv", baselineEpoch, tail = 14)
+            .lines.forEach(sink)
     }
 
     /**

--- a/android/app/src/test/java/com/noop/analytics/BaselinesTraceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/BaselinesTraceTest.kt
@@ -1,0 +1,230 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The per-night baseline-fold trace. Twin of the Swift `BaselinesTraceTests` — the SAME fixtures and
+ * the SAME expected strings, because a diagnostic whose two platforms word things differently cannot be
+ * compared across a pair of reports.
+ *
+ * The contract that matters most is the first test: the traced state must BE the real fold's, so the
+ * trace can never describe a baseline the scorer isn't using.
+ */
+class BaselinesTraceTest {
+
+    private val hrv = Baselines.metricCfg["hrv"]!!
+
+    /** The whole point: tracing must not change, or re-derive, the state. */
+    @Test fun tracedStateIsTheRealFoldsState() {
+        var traced: BaselineState? = null
+        var real: BaselineState? = null
+        val nights = listOf(60.0, 70.0, null, 999.0, 55.0, 62.0, 58.0, 61.0, 150.0, 59.0)
+        for (v in nights) {
+            traced = BaselinesTrace.updateTrace(traced, v, hrv, "hrv").state
+            real = Baselines.update(real, v, hrv)
+            assertEquals("baseline diverged after $v", real!!.baseline, traced!!.baseline, 0.0)
+            assertEquals("spread diverged after $v", real.spread, traced.spread, 0.0)
+            assertEquals("nValid diverged after $v", real.nValid, traced.nValid)
+            assertEquals("status diverged after $v", real.status, traced.status)
+        }
+    }
+
+    @Test fun seedNamesThatOneNightFixesTheCentre() {
+        assertEquals(
+            "baseline hrv night=seed value=60.0 spread starts at floor=5.0 " +
+                "(this ONE night fixes the centre) -> mean=60.0 spread=5.0 nValid=1 status=calibrating",
+            BaselinesTrace.updateTrace(null, 60.0, hrv, "hrv").lines[0],
+        )
+    }
+
+    /** A first night with no usable value seeds the MIDPOINT and leaves nValid at 0 — not a skip. */
+    @Test fun seedEmptyIsDistinctFromASkip() {
+        assertEquals(
+            "baseline hrv night=seed-empty no usable first value (bounds=5.0..250.0) " +
+                "seeded at midpoint, nValid stays 0 -> mean=127.5 spread=5.0 nValid=0 status=calibrating",
+            BaselinesTrace.updateTrace(null, null, hrv, "hrv").lines[0],
+        )
+    }
+
+    @Test fun missingNightIsSkipAndHold() {
+        val s = BaselinesTrace.updateTrace(null, 60.0, hrv, "hrv").state
+        assertEquals(
+            "baseline hrv night=missing skip-and-hold nightsSinceUpdate=1 " +
+                "-> mean=60.0 spread=5.0 nValid=1 status=calibrating",
+            BaselinesTrace.updateTrace(s, null, hrv, "hrv").lines[0],
+        )
+    }
+
+    @Test fun implausibleNightNamesTheBounds() {
+        val s = BaselinesTrace.updateTrace(null, 60.0, hrv, "hrv").state
+        assertEquals(
+            "baseline hrv night=implausible value=999.0 bounds=5.0..250.0 skip-and-hold " +
+                "nightsSinceUpdate=1 -> mean=60.0 spread=5.0 nValid=1 status=calibrating",
+            BaselinesTrace.updateTrace(s, 999.0, hrv, "hrv").lines[0],
+        )
+    }
+
+    /** While young the fold uses the fast half-life and the inflated Winsor band; the line says so. */
+    @Test fun foldedYoungReportsTheEarlyAdaptation() {
+        val s = BaselinesTrace.updateTrace(null, 60.0, hrv, "hrv").state
+        assertEquals(
+            "baseline hrv night=folded value=70.0 young=yes effSpread=12.5 halfLifeB=3.0 " +
+                "winsor=22.5..97.5 clamped=no spread 5.0->5.1 atFloor=no " +
+                "-> mean=62.06 spread=5.1 nValid=2 status=calibrating",
+            BaselinesTrace.updateTrace(s, 70.0, hrv, "hrv").lines[0],
+        )
+    }
+
+    /** A hard outlier is "seen, NOT folded" — the case that otherwise leaves no trace at all. */
+    @Test fun rejectedNightIsNamedWithItsThreshold() {
+        val settled = BaselinesTrace.foldHistoryTrace(List(10) { 60.0 }, hrv, "hrv").state
+        assertEquals(
+            "baseline hrv night=rejected value=150.0 dev=90.0 > k=5.0*spread=5.0 (seen, NOT folded) " +
+                "-> mean=60.0 spread=5.0 nValid=10 status=provisional",
+            BaselinesTrace.updateTrace(settled, 150.0, hrv, "hrv").lines[0],
+        )
+    }
+
+    @Test fun foldedSettledUsesTheNormalHalfLifeAndBand() {
+        val settled = BaselinesTrace.foldHistoryTrace(List(10) { 60.0 }, hrv, "hrv").state
+        assertEquals(
+            "baseline hrv night=folded value=66.0 young=no effSpread=5.0 halfLifeB=14.0 " +
+                "winsor=45.0..75.0 clamped=no spread 5.0->5.02 atFloor=no " +
+                "-> mean=60.29 spread=5.02 nValid=11 status=provisional",
+            BaselinesTrace.updateTrace(settled, 66.0, hrv, "hrv").lines[0],
+        )
+    }
+
+    /**
+     * The reason this file exists: a flat history leaves the spread ON its floor for as long as you
+     * care to fold, and `atFloor=yes` is the only way a log ever says so. Every other diagnostic shows
+     * a settled-looking spread=5.0 with nothing to distinguish it from a converged one.
+     */
+    @Test fun aFlatHistoryReportsSpreadPinnedOnTheFloor() {
+        val out = BaselinesTrace.foldHistoryTrace(List(12) { 60.0 }, hrv, "hrv")
+        assertEquals(5.0, out.state.spread, 0.0)
+        val folded = out.lines.filter { it.contains("night=folded") }
+        assertTrue("expected folded nights", folded.isNotEmpty())
+        assertTrue("a flat history must report atFloor=yes", folded.all { it.contains("atFloor=yes") })
+    }
+
+    /** One line per night, in order, so a history reads as a trajectory. */
+    @Test fun foldHistoryTraceEmitsOneLinePerNight() {
+        val out = BaselinesTrace.foldHistoryTrace(listOf(60.0, null, 62.0, 999.0, 58.0), hrv, "hrv")
+        assertEquals(5, out.lines.size)
+        assertTrue(out.lines[0].contains("night=seed"))
+        assertTrue(out.lines[1].contains("night=missing"))
+        assertTrue(out.lines[2].contains("night=folded"))
+        assertTrue(out.lines[3].contains("night=implausible"))
+    }
+
+    @Test fun emptyHistoryIsSafe() {
+        val out = BaselinesTrace.foldHistoryTrace(emptyList(), hrv, "hrv")
+        assertEquals(listOf("baseline hrv history=empty"), out.lines)
+        assertEquals(0, out.state.nValid)
+    }
+
+    /** Project convention: no em-dashes leak into a log line. */
+    @Test fun noEmDashesInAnyLine() {
+        val out = BaselinesTrace.foldHistoryTrace(listOf(60.0, null, 999.0, 70.0, 150.0), hrv, "hrv")
+        assertTrue(out.lines.isNotEmpty())
+        assertFalse(out.lines.any { it.contains("—") })
+    }
+
+    /** The tail cap bounds the log without changing the state: the whole history is still folded. */
+    @Test fun tailCapsTheLinesButNotTheFold() {
+        val full = BaselinesTrace.foldHistoryTrace(List(30) { 60.0 + it }, hrv, "hrv")
+        val capped = BaselinesTrace.foldHistoryTrace(List(30) { 60.0 + it }, hrv, "hrv", tail = 5)
+        assertEquals("state must not depend on the cap", full.state.baseline, capped.state.baseline, 0.0)
+        assertEquals(full.state.nValid, capped.state.nValid)
+        assertEquals(6, capped.lines.size)   // 1 omission notice + 5 nights
+        assertEquals("baseline hrv (earlier 25 night(s) omitted)", capped.lines[0])
+        assertEquals(full.lines.takeLast(5), capped.lines.drop(1))
+    }
+
+    /** A tail bigger than the history leaves it untouched, with no misleading omission notice. */
+    @Test fun tailLargerThanHistoryAddsNoNotice() {
+        val out = BaselinesTrace.foldHistoryTrace(List(3) { 60.0 }, hrv, "hrv", tail = 14)
+        assertEquals(3, out.lines.size)
+        assertFalse(out.lines.any { it.contains("omitted") })
+    }
+
+    /**
+     * The recalibration drop, named. This is #731's failure mode: the tap discards earlier nights and
+     * restarts the count, and no log ever said so.
+     */
+    @Test fun recalibrationDropIsNamedAndMatchesTheRealFold() {
+        val days = listOf("2026-08-01", "2026-08-02", "2026-08-03", "2026-08-04", "2026-08-05")
+        val values = listOf<Double?>(60.0, 61.0, 62.0, 63.0, 64.0)
+        // Epoch at 2026-08-04 UTC start-of-day: the first three nights are dropped.
+        val epoch = java.time.LocalDate.parse("2026-08-04")
+            .atStartOfDay(java.time.ZoneOffset.UTC).toEpochSecond().toDouble()
+        val out = BaselinesTrace.foldHistoryTrace(values, days, hrv, "hrv", epoch)
+        assertEquals(
+            "baseline hrv recalibrated=2026-08-04 dropped=3 night(s) before it",
+            out.lines[0],
+        )
+        // and the state is the REAL recalibration-aware fold's, not a re-derivation
+        val real = Baselines.foldHistory(values, days, hrv, epoch)
+        assertEquals(real.baseline, out.state.baseline, 0.0)
+        assertEquals(real.spread, out.state.spread, 0.0)
+        assertEquals(real.nValid, out.state.nValid)
+    }
+
+    /** No epoch set: identical to the plain fold, with no recalibration line invented. */
+    @Test fun noRecalibrationEpochBehavesLikeThePlainFold() {
+        val days = listOf("2026-08-01", "2026-08-02", "2026-08-03")
+        val values = listOf<Double?>(60.0, 61.0, 62.0)
+        val out = BaselinesTrace.foldHistoryTrace(values, days, hrv, "hrv", 0.0)
+        val plain = BaselinesTrace.foldHistoryTrace(values, hrv, "hrv")
+        assertEquals(plain.lines, out.lines)
+        assertEquals(plain.state.baseline, out.state.baseline, 0.0)
+    }
+
+    /**
+     * dayKeys SHORTER than values: the real fold only tests the epoch for indices it has a key for, and
+     * keeps the rest. The trace filters on the same condition, so the states must agree — this is the
+     * case where a filter-then-fold shortcut could silently diverge from a fold-with-skips.
+     */
+    @Test fun shortDayKeysKeepTheUndatedNightsExactlyLikeTheRealFold() {
+        val values = listOf<Double?>(60.0, 61.0, 62.0, 63.0, 64.0)
+        val days = listOf("2026-08-01", "2026-08-02")   // only two keys for five nights
+        val epoch = java.time.LocalDate.parse("2026-08-02")
+            .atStartOfDay(java.time.ZoneOffset.UTC).toEpochSecond().toDouble()
+        val out = BaselinesTrace.foldHistoryTrace(values, days, hrv, "hrv", epoch)
+        val real = Baselines.foldHistory(values, days, hrv, epoch)
+        assertEquals(real.baseline, out.state.baseline, 0.0)
+        assertEquals(real.spread, out.state.spread, 0.0)
+        assertEquals(real.nValid, out.state.nValid)
+        assertTrue(out.lines[0].contains("dropped=1"))   // only 2026-08-01 precedes the epoch
+    }
+
+    /** tail = 0 keeps the notice and nothing else, rather than emitting an empty list. */
+    @Test fun tailOfZeroKeepsOnlyTheOmissionNotice() {
+        val out = BaselinesTrace.foldHistoryTrace(List(4) { 60.0 }, hrv, "hrv", tail = 0)
+        assertEquals(listOf("baseline hrv (earlier 4 night(s) omitted)"), out.lines)
+        assertEquals(4, out.state.nValid)
+    }
+
+    /** A negative tail is ignored rather than trimming anything. */
+    @Test fun negativeTailIsIgnored() {
+        val out = BaselinesTrace.foldHistoryTrace(List(4) { 60.0 }, hrv, "hrv", tail = -1)
+        assertEquals(4, out.lines.size)
+        assertFalse(out.lines.any { it.contains("omitted") })
+    }
+
+    /** The recalibration line must SURVIVE the tail cap: it is prepended after trimming, not trimmed. */
+    @Test fun recalibrationLineSurvivesATightTail() {
+        val values = List<Double?>(20) { 60.0 + it }
+        val days = List(20) { "2026-08-%02d".format(it + 1) }
+        val epoch = java.time.LocalDate.parse("2026-08-05")
+            .atStartOfDay(java.time.ZoneOffset.UTC).toEpochSecond().toDouble()
+        val out = BaselinesTrace.foldHistoryTrace(values, days, hrv, "hrv", epoch, tail = 3)
+        assertTrue("recalibration line must not be trimmed", out.lines[0].contains("recalibrated="))
+        assertTrue(out.lines[1].contains("omitted"))
+        assertEquals(5, out.lines.size)   // recalibration + notice + 3 nights
+    }
+}


### PR DESCRIPTION
Every other core analytics component has a trace file; the baseline fold had none. A strap log could show what a baseline **is** — `RecoveryScorer`'s trace already prints `mean` / `spread` / `nValid` / `status` — but never how it got there.

That gap matters because the fold's decisions are the ones that fail quietly. A night rejected as a hard outlier is *"seen, but not folded"* and leaves **no record at all**. And a spread sitting on its floor is indistinguishable, in every existing log, from one that has genuinely settled.

The second case is what costs triage time, because **the score divides by that spread**. At HRV's `floorSpread` of 5.0, sigma is 6.26, so a 10 ms deviation is already `z = 1.64` — which the Charge logistic renders as **95**. A log that cannot tell a floored spread from a settled one cannot tell a saturated score from a real one. Written up as #1614.

## What it emits

```
baseline hrv night=seed value=60.0 spread starts at floor=5.0 (this ONE night fixes the centre) -> mean=60.0 spread=5.0 nValid=1 status=calibrating
baseline hrv night=folded value=70.0 young=yes effSpread=12.5 halfLifeB=3.0 winsor=22.5..97.5 clamped=no spread 5.0->5.1 atFloor=no -> mean=62.06 …
baseline hrv night=rejected value=150.0 dev=90.0 > k=5.0*spread=5.0 (seen, NOT folded) -> mean=60.0 spread=5.0 nValid=10 status=provisional
baseline hrv recalibrated=2026-08-04 dropped=3 night(s) before it
baseline hrv (earlier 25 night(s) omitted)
```

`atFloor=` is the line #1614 needs. `night=rejected` is a case that currently leaves no trace whatsoever. And `dropped=N night(s) before it` names #731's failure mode outright — a manual **Recalibrate baseline** discards earlier nights and restarts the count, which is how that reporter sat at *"Calibrating, 3 of 4 nights"* while holding 15 valid ones.

## The contract

`updateTrace` returns the state from `Baselines.update` **verbatim** and recomputes only the intermediate decisions for the lines, so the trace can never describe a baseline the scorer is not using. The first test pins exactly that, across a ten-night history containing a missing night, an implausible one and a hard outlier.

Branch order mirrors `update` exactly: it tests `state == nil` **first**, and that branch decides the value's validity itself. So a first night with a missing or out-of-range value is a *seed* case, not a skip. My first version tested value-ness first — which returned the right state while telling the wrong story, the worst kind of diagnostic.

## Wiring

At the HRV fold on both platforms, gated behind the Recovery test mode.

- **HRV only**, deliberately — it is Charge's dominant driver and the one whose spread the score divides by. Tracing all four baselines would quadruple the log for three that aren't the question being asked.
- **Last 14 nights.** The whole history is still folded, so the state is unchanged; only the lines are trimmed. An established user has hundreds of nights and a diagnostic nobody can read is not a diagnostic.
- **The epoch is read once** and handed to both folds. Letting the scored fold take its `UserDefaults` default while the trace read its own copy would leave a window where the diagnostic describes a fold the score did not perform. Passing it explicitly is byte-identical to that default (`baselineEpoch ?? hrvBaselineEpoch()`).
- Emitted **once per re-score pass**, not per day — both call sites sit at function-body depth, not inside the per-day loops just above them.

## Parity

Both platforms assert the **same expected strings**, so the two emit byte-identical lines rather than merely equivalent ones. 20 test names match one-for-one; all 22 emitted string tokens present on both sides.

Kotlin rounds with `copySign(round(abs))` to match Swift's `.toNearestOrAwayFromZero`, as `RecoveryScorerTrace` already does — a plain `Math.round` is half-**up** and diverges on the negative ties the Winsor band's lower edge can reach.

**One deliberate shape difference:** Kotlin's emit is an extracted function. `analyzeRecentOnCpu` sits a few dozen bytes under the JVM's per-method bytecode budget (64 K, with headroom reserved for JaCoCo instrumentation) and an inline lambda tipped it over — `61600` against a `61535` ceiling. The call site must stay a call; the doc says so.

## Verification

- **Swift `StrandAnalytics`: 20/20**, actually run on Linux. `StrandAnalytics` doesn't build there on `main`, so I applied #1529's patch in a throwaway worktree with a snapshot-enabled SQLite purely to execute them. If #1529 lands, this becomes verifiable in ordinary CI instead.
- **Kotlin: 20/20** on the trace, and **1680 `com.noop.analytics.*` tests / 0 failures** with `--rerun-tasks`.
- `doc_comment_lint` and `i18n_audit --ci` clean. No new strings.

**The wiring itself has no unit test, and cannot have one at this layer.** `analyzeRecentOnCpu` needs a Room DB and a context; nothing invokes it (`Issue547RepeatRepro` replicates its windowing rather than calling it, and the budget test inspects bytecode without running it). So the 1680 passing tests say nothing about the two call sites — those are covered by compile, review, and `app-build`, and confirmed only by an actual capture.

**Not validated on a device.** The honest check is a Test Centre → Recovery capture: the fold lines should appear once per re-score, capped at 14, immediately before the existing `charge baseline hrv …` line and agreeing with it.
