### PR TITLE
i18n audit: count plural entries as translated in the coverage summary

### DIFF
--- a/Tools/i18n_audit.py
+++ b/Tools/i18n_audit.py
@@ -1234,8 +1234,16 @@ def catalog_summary() -> None:
             for v in strings.values():
                 if v.get("shouldTranslate") is False:
                     continue
-                state = (v.get("localizations", {}).get(lang) or {}).get("stringUnit", {}).get("state")
-                if state != "translated":
+                # Via `_is_translated`, NOT a bare `localizations[lang].stringUnit.state` read: a
+                # pluralised entry keeps its units under `variations.plural.<category>.stringUnit`, so the
+                # flat lookup returns None and scores a fully-translated plural as a gap. That is the exact
+                # trap `_string_units` was written for, and this summary was the one caller still falling
+                # into it — reporting de/es/fr/pt-PT missing=4 and pl missing=5 on the Strand catalog when
+                # every one of those entries was translated in every form. Worse than a wrong number: it
+                # sent a reader to re-translate strings that were already done, and it made Polish look
+                # like the worst-covered language precisely BECAUSE it correctly carries one/few/many/other
+                # where the others need only a flat unit.
+                if not _is_translated(v, lang):
                     missing += 1
             line += f"  {lang} missing={missing}"
         print(" ", line)

--- a/Tools/i18n_extra_locale_baseline.txt
+++ b/Tools/i18n_extra_locale_baseline.txt
@@ -14,8 +14,8 @@ NOOPWatch/Localizable.xcstrings:zh-Hant 0
 NOOPWatchComplications/Localizable.xcstrings:it 25
 NOOPWatchComplications/Localizable.xcstrings:zh-Hans 25
 NOOPWatchComplications/Localizable.xcstrings:zh-Hant 25
-Strand/Resources/Localizable.xcstrings:it 181
-Strand/Resources/Localizable.xcstrings:ru 158
-Strand/Resources/Localizable.xcstrings:zh-Hans 131
-Strand/Resources/Localizable.xcstrings:zh-Hant 181
+Strand/Resources/Localizable.xcstrings:it 179
+Strand/Resources/Localizable.xcstrings:ru 156
+Strand/Resources/Localizable.xcstrings:zh-Hans 129
+Strand/Resources/Localizable.xcstrings:zh-Hant 179
 values-zh/strings.xml 49

--- a/Tools/test_i18n_audit.py
+++ b/Tools/test_i18n_audit.py
@@ -434,3 +434,69 @@ class EchoDetectionWordFilter(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class CatalogSummaryPluralCoverage(unittest.TestCase):
+    """The human-readable coverage summary must count plural entries the same way the gate does.
+
+    `catalog_summary` used to read `localizations[lang].stringUnit.state` directly. A pluralised entry
+    keeps its units under `variations.plural.<category>.stringUnit`, so that flat lookup returned None
+    and scored a fully-translated plural as a gap — it reported de/es/fr/pt-PT missing=4 and pl missing=5
+    on the Strand catalog when every one of those was translated in every form, and it made Polish look
+    worst-covered precisely because it correctly carries one/few/many/other.
+    """
+
+    def _summary(self, catalog: dict) -> str:
+        import contextlib
+        import io
+        saved_catalogs, saved_load = ia.CATALOGS, ia.load_catalog
+        try:
+            ia.CATALOGS = [((), ia.ROOT / "fixture" / "Localizable.xcstrings")]
+            ia.load_catalog = lambda _path: catalog
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                ia.catalog_summary()
+            return buf.getvalue()
+        finally:
+            ia.CATALOGS, ia.load_catalog = saved_catalogs, saved_load
+
+    @staticmethod
+    def _plural(states: dict[str, str]) -> dict:
+        return {"variations": {"plural": {
+            cat: {"stringUnit": {"state": st, "value": f"{cat} form"}} for cat, st in states.items()
+        }}}
+
+    def test_fully_translated_plural_is_not_a_gap(self):
+        cat = {"strings": {"%lld days": {"localizations": {
+            lang: self._plural({"one": "translated", "other": "translated"})
+            for lang in ("de", "es", "fr", "pt-PT")
+        }}}}
+        out = self._summary(cat)
+        for lang in ("de", "es", "fr", "pt-PT"):
+            self.assertIn(f"{lang} missing=0", out)
+
+    def test_polish_extra_plural_categories_are_not_penalised(self):
+        """one/few/many/other is Polish being handled correctly, not five gaps."""
+        cat = {"strings": {"%lld days": {"localizations": {
+            "pl": self._plural({c: "translated" for c in ("one", "few", "many", "other")}),
+        }}}}
+        self.assertIn("pl missing=0", self._summary(cat))
+
+    def test_partially_translated_plural_is_still_a_gap(self):
+        """The fix must not over-correct: one untranslated category still counts."""
+        cat = {"strings": {"%lld days": {"localizations": {
+            "de": self._plural({"one": "translated", "other": "new"}),
+        }}}}
+        self.assertIn("de missing=1", self._summary(cat))
+
+    def test_flat_string_unit_still_counted(self):
+        """Non-plural entries keep working exactly as before."""
+        cat = {"strings": {
+            "Hello": {"localizations": {"de": {"stringUnit": {"state": "translated", "value": "Hallo"}}}},
+            "Bye": {"localizations": {"de": {"stringUnit": {"state": "new", "value": ""}}}},
+        }}
+        self.assertIn("de missing=1", self._summary(cat))
+
+    def test_should_translate_false_is_skipped(self):
+        cat = {"strings": {"NOOP": {"shouldTranslate": False, "localizations": {}}}}
+        self.assertIn("de missing=0", self._summary(cat))


### PR DESCRIPTION
The audit's human-readable coverage summary reported gaps that do not exist:

```
Strand/Resources/Localizable.xcstrings (3601 keys):  de missing=4  es missing=4  fr missing=4  pl missing=5  pt-PT missing=4
```

Every one of those 21 entries is translated, in every plural form. `%lld days` is `%lld Tage`, `%lld días`, `%lld jours`, `%lld dias`, `%lld dnia`. `Syncing strap history, %lld chunks` is `"Synchronisation de l'historique du bracelet, %lld blocs"`.

## The bug

`catalog_summary` read the state directly:

```python
state = (v.get("localizations", {}).get(lang) or {}).get("stringUnit", {}).get("state")
```

A pluralised entry has no `stringUnit` at that level — its units live under `variations.plural.<category>.stringUnit`. So the lookup returns `None`, `None != "translated"`, and a fully-translated plural scores as a gap.

This is worse than a wrong number in two ways.

It **sends you to do work that is already done.** I went looking for these 21 strings to translate them and found them already translated — that is the only reason the bug surfaced.

And it **defames Polish specifically.** `%lld markers` counts as missing for `pl` alone, because Polish carries `one`/`few`/`many`/`other` where de/es/fr/pt-PT need only a flat unit. The language with the most correct pluralisation scored worst.

## The fix

`_string_units` and `_is_translated` already exist for exactly this. The former's docstring:

> Reading only the FIRST shape makes every pluralised entry look untranslated to this gate — so converting a hand-rolled ternary into real plural variations would red-flag the string in every language. Walk both shapes.

The gate was fixed then. This summary was the one caller left doing the naive read, which is a familiar shape: #844's own comment notes that showing only `LANGS` here is "very likely WHY the drift went unnoticed for so long". That pass fixed the locale blind spot and left a structural one behind it.

Routed through `_is_translated`, which also preserves the strict direction — a plural with one category still `new` remains a gap.

## After

```
de missing=0  es missing=0  fr missing=0  pl missing=0  pt-PT missing=0
```

## A second, unrelated change in this PR — and a correction

`i18n_extra_locale_baseline.txt` is lowered on four targets: `it` 181→179, `ru` 158→156, `zh-Hans` 131→129, `zh-Hant` 181→179.

My first version of this description claimed those improvements came from the plural fix. **They do not.** I checked against a clean checkout of `main`, and the gate already reports exactly those four `IMPROVED` lines with the audit untouched — the *gate* has been plural-aware since #844, and only the summary was naive. The ratchet was simply stale by two on each, because real translations landed after it was last written, and the tool asks for it to be lowered on every run.

So it is a genuine tidy-up that this PR happens to carry, not a consequence of the fix. Down only, as the file requires; every change verified to decrease. Split it out if you would rather keep the diff to one concern.

The real drift is unchanged in substance: `it`, `ru` and `zh-*` remain the genuinely untranslated locales, and that is separate work.

## A sibling blind spot, found in review and deliberately not fixed here

`_ios_echoed_counts` (the detector for translations that are verbatim English) does the same flat `unit.get("stringUnit")` read, so it cannot see plural forms either.

I measured it before deciding: **zero** plural echoes are currently hidden by it. The blind spot is real but costs nothing today, and fixing it would touch the echo baseline for no present gain. Recording it here so it is not rediscovered from scratch.

## Tests

Five, and they pin the **summary** rather than only the shared helper — a revert would restore the flat read while `_is_translated`'s own coverage stayed green:

- a fully-translated plural is not a gap, across all four focus locales
- Polish `one/few/many/other` is not penalised for having more categories
- a partially-translated plural **is** still a gap (the fix must not over-correct)
- flat `stringUnit` entries still count exactly as before
- `shouldTranslate: false` is still skipped

## Verification

- `python3 -m unittest discover` over `Tools/` — all green, which is what `tools-python.yml` runs
- `i18n_audit.py --ci` passes, and `--full` shows the corrected table above
