### PR TITLE
diagnostics: check other device ids before blaming a fresh re-add

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -308,6 +308,44 @@ extension WhoopStore {
         }
     }
 
+    /// Raw biometric sample counts per device id in a window, across every id present in the tables -
+    /// including ids the device registry cannot see.
+    ///
+    /// The registry is the wrong place to ask "where did this night's samples go". `my-whoop` is a source
+    /// LABEL for imported/computed data, not necessarily a `pairedDevice` row, and `DeviceRegistryStore.remove`
+    /// deletes the row while leaving every sample table untouched. So a forgotten or import-only id owns rows
+    /// that `all()` will never list. Asking the sample tables directly has no such blind spot.
+    ///
+    /// Counts `hrSample` + `ppgHrSample` + `gravitySample` - the same streams the night funnel's
+    /// "no raw biometric samples" guard tests. Unordered; callers sort.
+    ///
+    /// Filtering on `ts` without a `deviceId` cannot seek into the `(deviceId, ts)` primary key, so this
+    /// is an index-ONLY scan (both columns live in that index, so no table rows are touched) with
+    /// `deviceId` leading, which also lets the GROUP BY skip a temp b-tree. Cheap enough for a
+    /// user-triggered diagnostics export, which is the only caller.
+    public func rawSampleCountsByDevice(from: Int, to: Int) async throws -> [(String, Int)] {
+        try syncRead { db in
+            try Row.fetchAll(db, sql: """
+                SELECT deviceId, SUM(n) AS total FROM (
+                    SELECT deviceId, COUNT(*) AS n FROM hrSample WHERE ts >= ? AND ts <= ? GROUP BY deviceId
+                    UNION ALL
+                    SELECT deviceId, COUNT(*) AS n FROM ppgHrSample WHERE ts >= ? AND ts <= ? GROUP BY deviceId
+                    UNION ALL
+                    SELECT deviceId, COUNT(*) AS n FROM gravitySample WHERE ts >= ? AND ts <= ? GROUP BY deviceId
+                )
+                GROUP BY deviceId
+                """, arguments: [from, to, from, to, from, to])
+            .map { row -> (String, Int) in
+                // `deviceId` is NOT NULL and the GROUP BY guarantees SUM(n) >= 1 per row, so both read
+                // straight into non-optionals - same idiom as `hrFingerprint` above.
+                let d: String = row["deviceId"]
+                let t: Int = row["total"]
+                return (d, t)
+            }
+            .filter { !$0.0.isEmpty && $0.1 > 0 }
+        }
+    }
+
     public func gravitySamples(deviceId: String, from: Int, to: Int, limit: Int) async throws -> [GravitySample] {
         try syncRead { db in
             try Row.fetchAll(db, sql: """

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -148,7 +148,21 @@ enum DebugDataDiagnostics {
         let resp = (try? await store.respSamples(deviceId: did, from: cs.startTs, to: cs.endTs, limit: 200_000)) ?? []
         lines.append("Night \(dayStamp(cs.startTs)): grav=\(grav.count) hr=\(hr.count) rr=\(rr.count) resp=\(resp.count) skin=\(skin.count)")
         if grav.isEmpty && hr.isEmpty {
-            lines.append("(no raw biometric samples under '\(did)' for this night — expected on a freshly re-added strap; reconnect + let a history sync run, then re-export)")
+            // #1617 follow-up: do NOT assert "freshly re-added" without testing the other explanation.
+            // A registry can hold several ids for one physical strap (#1193/#740), and when the spine and
+            // the raw stream split, the samples exist - just under a different id. The old line printed the
+            // innocent cause for that case, which stops the investigation at exactly the point it should
+            // start. Only runs when the active id came back empty, so a healthy install pays nothing.
+            var elsewhere: [(String, Int)] = []
+            let others = ((try? DeviceRegistryStore(dbQueue: store.registryWriter).all()) ?? [])
+                .map(\.id)
+                .filter { $0 != did && !$0.isEmpty }
+            for other in others {
+                let g = (try? await store.gravitySamples(deviceId: other, from: cs.startTs, to: cs.endTs, limit: 200_000))?.count ?? 0
+                let h = (try? await store.hrSamples(deviceId: other, from: cs.startTs, to: cs.endTs, limit: 200_000))?.count ?? 0
+                if g + h > 0 { elsewhere.append((other, g + h)) }
+            }
+            lines.append(orphanedSamplesLine(activeId: did, othersWithSamples: elsewhere))
             return lines
         }
         if let rem = SleepStager.remFunnelDiagnostic(start: cs.startTs, end: cs.endTs, grav: grav, hr: hr, rr: rr, resp: resp) {
@@ -409,5 +423,34 @@ enum DebugDataDiagnostics {
         f.locale = Locale(identifier: "en_US_POSIX")
         f.dateFormat = "yyyy-MM-dd"
         return f.string(from: Date(timeIntervalSince1970: TimeInterval(epochSec)))
+    }
+
+    /// #1617 follow-up: the line the night funnel prints when the ACTIVE device id carries no raw samples.
+    ///
+    /// The previous wording asserted "expected on a freshly re-added strap" unconditionally. That is one of
+    /// two explanations, and the other one is a bug: a registry can hold several ids for the same physical
+    /// strap (#1193/#740), and when the history spine and the raw stream split, the samples are present -
+    /// just filed under a different id. Printing the innocent cause for that case ends the investigation at
+    /// the point it should begin, which is worse than printing nothing.
+    ///
+    /// `othersWithSamples` is (deviceId, sampleCount) for every OTHER registry id that does hold samples in
+    /// the same window. Empty means the samples genuinely are not there and the fresh-re-add wording is
+    /// right; non-empty names the id that has them so the split is visible rather than inferred.
+    ///
+    /// Pure so the wording is unit-tested without a database, a strap, or a registry. Kotlin twin:
+    /// `com.noop.testcentre.orphanedSamplesLine`.
+    static func orphanedSamplesLine(activeId: String, othersWithSamples: [(String, Int)]) -> String {
+        if othersWithSamples.isEmpty {
+            return "(no raw biometric samples under '\(activeId)' for this night — expected on a freshly "
+                + "re-added strap; reconnect + let a history sync run, then re-export)"
+        }
+        // Tie-break on id: Kotlin's sortedByDescending is stable but Swift's `sorted` is NOT, so equal
+        // counts could otherwise order differently on the two platforms and the twin lines would diverge.
+        let named = othersWithSamples.sorted { $0.1 != $1.1 ? $0.1 > $1.1 : $0.0 < $1.0 }
+            .map { "'\($0.0)' (\($0.1) rows)" }
+            .joined(separator: ", ")
+        return "(no raw biometric samples under the ACTIVE id '\(activeId)' for this night — they are under "
+            + "\(named) instead. The history spine and the raw stream are on different device ids (#1193); this "
+            + "is NOT a fresh re-add, the samples exist and are not being read.)"
     }
 }

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -442,6 +442,9 @@ enum DebugDataDiagnostics {
         }
         // Tie-break on id: Kotlin's sortedByDescending is stable but Swift's `sorted` is NOT, so equal
         // counts could otherwise order differently on the two platforms and the twin lines would diverge.
+        // The tie-break itself compares Unicode canonical order here and UTF-16 code units in Kotlin; those
+        // agree for the machine-generated ASCII ids this ever sees ("my-whoop", "whoop-<mac>"), and a
+        // device NICKNAME is a separate field that never reaches this id.
         let named = othersWithSamples.sorted { $0.1 != $1.1 ? $0.1 > $1.1 : $0.0 < $1.0 }
             .map { "'\($0.0)' (\($0.1) rows)" }
             .joined(separator: ", ")

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -149,19 +149,15 @@ enum DebugDataDiagnostics {
         lines.append("Night \(dayStamp(cs.startTs)): grav=\(grav.count) hr=\(hr.count) rr=\(rr.count) resp=\(resp.count) skin=\(skin.count)")
         if grav.isEmpty && hr.isEmpty {
             // #1617 follow-up: do NOT assert "freshly re-added" without testing the other explanation.
-            // A registry can hold several ids for one physical strap (#1193/#740), and when the spine and
+            // Several ids can hold one physical strap's data (#1193/#740), and when the history spine and
             // the raw stream split, the samples exist - just under a different id. The old line printed the
             // innocent cause for that case, which stops the investigation at exactly the point it should
-            // start. Only runs when the active id came back empty, so a healthy install pays nothing.
-            var elsewhere: [(String, Int)] = []
-            let others = ((try? DeviceRegistryStore(dbQueue: store.registryWriter).all()) ?? [])
-                .map(\.id)
-                .filter { $0 != did && !$0.isEmpty }
-            for other in others {
-                let g = (try? await store.gravitySamples(deviceId: other, from: cs.startTs, to: cs.endTs, limit: 200_000))?.count ?? 0
-                let h = (try? await store.hrSamples(deviceId: other, from: cs.startTs, to: cs.endTs, limit: 200_000))?.count ?? 0
-                if g + h > 0 { elsewhere.append((other, g + h)) }
-            }
+            // start. Ask the SAMPLE TABLES, not the registry: `my-whoop` is a source label rather than a
+            // `pairedDevice` row, and forgetting a device drops its row while leaving its samples - so the
+            // registry is blind to exactly the ids worth naming here. Only runs when the active id came
+            // back empty, so a healthy install pays nothing.
+            let elsewhere = ((try? await store.rawSampleCountsByDevice(from: cs.startTs, to: cs.endTs)) ?? [])
+                .filter { $0.0 != did }
             lines.append(orphanedSamplesLine(activeId: did, othersWithSamples: elsewhere))
             return lines
         }

--- a/StrandTests/OrphanedSamplesLineTests.swift
+++ b/StrandTests/OrphanedSamplesLineTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import Strand
+
+/// #1617 follow-up: the funnel's zero-sample line must distinguish "the samples are not there" from
+/// "the samples are under a different device id" (#1193/#740). The old line asserted the first
+/// unconditionally, which is the wrong answer to give an investigation exactly when it matters.
+///
+/// Kotlin twin: `OrphanedSamplesLineTest` (`android/app/src/test/.../testcentre/`). The two must emit the
+/// same strings, so these expectations are written out in full rather than pattern-matched — and the
+/// literals below were generated from the verified cross-platform diff, not retyped.
+final class OrphanedSamplesLineTests: XCTestCase {
+
+    func testNoSamplesAnywhereKeepsTheFreshReAddWording() {
+        XCTAssertEqual(
+            DebugDataDiagnostics.orphanedSamplesLine(activeId: "my-whoop", othersWithSamples: []),
+            "(no raw biometric samples under 'my-whoop' for this night — expected on a freshly re-added strap; reconnect + let a history sync run, then re-export)"
+        )
+    }
+
+    func testSamplesUnderAnotherIdReportTheSplitInstead() {
+        let line = DebugDataDiagnostics.orphanedSamplesLine(
+            activeId: "my-whoop",
+            othersWithSamples: [("whoop-F1:D4:F7:24:53:DE", 4213)]
+        )
+        XCTAssertEqual(line, "(no raw biometric samples under the ACTIVE id 'my-whoop' for this night — they are under 'whoop-F1:D4:F7:24:53:DE' (4213 rows) instead. The history spine and the raw stream are on different device ids (#1193); this is NOT a fresh re-add, the samples exist and are not being read.)")
+        // The benign explanation must not survive anywhere in the split wording — a reader scanning the
+        // log for "freshly re-added" would otherwise still stop here.
+        XCTAssertFalse(line.contains("freshly re-added"))
+    }
+
+    func testSeveralHoldersAreListedHeaviestFirst() {
+        let line = DebugDataDiagnostics.orphanedSamplesLine(
+            activeId: "my-whoop",
+            othersWithSamples: [("whoop-aa", 12), ("whoop-bb", 900), ("whoop-cc", 300)]
+        )
+        XCTAssertTrue(line.contains("'whoop-bb' (900 rows), 'whoop-cc' (300 rows), 'whoop-aa' (12 rows)"))
+    }
+
+    func testEqualCountsBreakTheTieOnIdSoBothPlatformsAgree() {
+        // Swift's `sorted` is not a stable sort; without an explicit tie-break the twin lines could list
+        // the same two ids in different orders.
+        let line = DebugDataDiagnostics.orphanedSamplesLine(
+            activeId: "my-whoop",
+            othersWithSamples: [("whoop-zz", 50), ("whoop-aa", 50)]
+        )
+        XCTAssertTrue(line.contains("'whoop-aa' (50 rows), 'whoop-zz' (50 rows)"))
+    }
+}

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -506,6 +506,38 @@ interface WhoopDao : DeviceRegistryDao {
     )
     suspend fun gravitySamples(deviceId: String, from: Long, to: Long, limit: Int): List<GravitySample>
 
+    /** Raw biometric sample counts per device id in a window - see [rawSampleCountsByDevice]. */
+    data class DeviceSampleCount(val deviceId: String, val total: Int)
+
+    /**
+     * Raw biometric sample counts per device id in a window, across every id present in the tables -
+     * including ids the device registry cannot see.
+     *
+     * The registry is the wrong place to ask "where did this night's samples go". `my-whoop` is a source
+     * LABEL for imported/computed data, not necessarily a `pairedDevice` row, and forgetting a device
+     * deletes its row while leaving every sample table untouched. So a forgotten or import-only id owns
+     * rows the registry will never list. Asking the sample tables directly has no such blind spot.
+     *
+     * Counts `hrSample` + `ppgHrSample` + `gravitySample` - the same streams the night funnel's
+     * "no raw biometric samples" guard tests. Unordered; callers sort.
+     *
+     * Filtering on `ts` without a `deviceId` cannot seek into the `(deviceId, ts)` primary key, so this is
+     * an index-ONLY scan (both columns live in that index, so no table rows are touched) with `deviceId`
+     * leading, which also lets the GROUP BY skip a temp b-tree. Cheap enough for a user-triggered
+     * diagnostics export, which is the only caller. Swift twin: `WhoopStore.rawSampleCountsByDevice`.
+     */
+    @Query(
+        "SELECT deviceId, SUM(n) AS total FROM (" +
+            "SELECT deviceId, COUNT(*) AS n FROM hrSample WHERE ts >= :from AND ts <= :to GROUP BY deviceId " +
+            "UNION ALL " +
+            "SELECT deviceId, COUNT(*) AS n FROM ppgHrSample WHERE ts >= :from AND ts <= :to GROUP BY deviceId " +
+            "UNION ALL " +
+            "SELECT deviceId, COUNT(*) AS n FROM gravitySample WHERE ts >= :from AND ts <= :to GROUP BY deviceId" +
+            ") GROUP BY deviceId"
+    )
+    suspend fun rawSampleCountsByDevice(from: Long, to: Long): List<DeviceSampleCount>
+
+
     // MARK: - Daily metrics / sleep reads (mirror MetricsCache.swift)
 
     /**

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -442,7 +442,10 @@ class WhoopRepository(
     /** Raw biometric sample counts per device id in a window - see [WhoopDao.rawSampleCountsByDevice]. */
     suspend fun rawSampleCountsByDevice(from: Long, to: Long): List<Pair<String, Int>> =
         dao.rawSampleCountsByDevice(from, to).map { it.deviceId to it.total }
-            .filter { it.first.isNotBlank() && it.second > 0 }
+            // isNotEmpty, NOT isNotBlank: the Swift twin filters on `!isEmpty`, so a whitespace-only id
+            // would be dropped here and kept there. Neither can occur today - the point is that the two
+            // predicates stay the same one.
+            .filter { it.first.isNotEmpty() && it.second > 0 }
 
     // MARK: - Insert decoded streams (idempotent by natural key)
 

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -439,6 +439,11 @@ class WhoopRepository(
     /** #716: read all paired devices (thin pass-through for the BLE scan fix). */
     suspend fun pairedDevices(): List<PairedDeviceRow> = dao.pairedDevices()
 
+    /** Raw biometric sample counts per device id in a window - see [WhoopDao.rawSampleCountsByDevice]. */
+    suspend fun rawSampleCountsByDevice(from: Long, to: Long): List<Pair<String, Int>> =
+        dao.rawSampleCountsByDevice(from, to).map { it.deviceId to it.total }
+            .filter { it.first.isNotBlank() && it.second > 0 }
+
     // MARK: - Insert decoded streams (idempotent by natural key)
 
     /**

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -455,6 +455,9 @@ object AndroidDiagnostics {
         }
         // Tie-break on id: Kotlin's sortedByDescending is stable but Swift's `sorted` is NOT, so equal
         // counts could otherwise order differently on the two platforms and the twin lines would diverge.
+        // The tie-break itself compares UTF-16 code units here and Unicode canonical order in Swift; those
+        // agree for the machine-generated ASCII ids this ever sees ("my-whoop", "whoop-<mac>"), and a
+        // device NICKNAME is a separate field that never reaches this id.
         val named = othersWithSamples
             .sortedWith(compareByDescending<Pair<String, Int>> { it.second }.thenBy { it.first })
             .joinToString(", ") { "'${it.first}' (${it.second} rows)" }

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -153,23 +153,16 @@ object AndroidDiagnostics {
             add("Night ${dayStamp(session.startTs)}: grav=${grav.size} hr=${hr.size} rr=${rr.size} resp=${resp.size} skin=${skin.size}")
             if (grav.isEmpty() && hr.isEmpty()) {
                 // #1617 follow-up: do NOT assert "freshly re-added" without testing the other explanation.
-                // A registry can hold several ids for one physical strap (#1193/#740), and when the spine
+                // Several ids can hold one physical strap's data (#1193/#740), and when the history spine
                 // and the raw stream split, the samples exist - just under a different id. The old line
                 // printed the innocent cause for that case, which stops the investigation at exactly the
-                // point it should start. Only runs when the active id came back empty, so a healthy
-                // install pays nothing.
+                // point it should start. Ask the SAMPLE TABLES, not the registry: "my-whoop" is a source
+                // label rather than a pairedDevice row, and forgetting a device drops its row while leaving
+                // its samples - so the registry is blind to exactly the ids worth naming here. Only runs
+                // when the active id came back empty, so a healthy install pays nothing.
                 val elsewhere = runCatching {
-                    (context.applicationContext as? com.noop.NoopApplication)?.deviceRegistry?.all()
-                        .orEmpty()
-                        .map { it.id }
-                        .filter { it != id && it.isNotBlank() }
-                        .map { other ->
-                            other to (
-                                repo.hrSamples(other, session.startTs, session.endTs, Int.MAX_VALUE).size +
-                                    repo.gravitySamples(other, session.startTs, session.endTs, Int.MAX_VALUE).size
-                                )
-                        }
-                        .filter { it.second > 0 }
+                    repo.rawSampleCountsByDevice(session.startTs, session.endTs)
+                        .filter { it.first != id }
                 }.getOrDefault(emptyList())
                 add(orphanedSamplesLine(id, elsewhere))
                 return@runCatching

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -152,7 +152,26 @@ object AndroidDiagnostics {
             val resp = repo.respSamples(id, session.startTs, session.endTs, Int.MAX_VALUE)
             add("Night ${dayStamp(session.startTs)}: grav=${grav.size} hr=${hr.size} rr=${rr.size} resp=${resp.size} skin=${skin.size}")
             if (grav.isEmpty() && hr.isEmpty()) {
-                add("(no raw biometric samples under '$id' for this night — expected on a freshly re-added strap; reconnect + let a history sync run, then re-export)")
+                // #1617 follow-up: do NOT assert "freshly re-added" without testing the other explanation.
+                // A registry can hold several ids for one physical strap (#1193/#740), and when the spine
+                // and the raw stream split, the samples exist - just under a different id. The old line
+                // printed the innocent cause for that case, which stops the investigation at exactly the
+                // point it should start. Only runs when the active id came back empty, so a healthy
+                // install pays nothing.
+                val elsewhere = runCatching {
+                    (context.applicationContext as? com.noop.NoopApplication)?.deviceRegistry?.all()
+                        .orEmpty()
+                        .map { it.id }
+                        .filter { it != id && it.isNotBlank() }
+                        .map { other ->
+                            other to (
+                                repo.hrSamples(other, session.startTs, session.endTs, Int.MAX_VALUE).size +
+                                    repo.gravitySamples(other, session.startTs, session.endTs, Int.MAX_VALUE).size
+                                )
+                        }
+                        .filter { it.second > 0 }
+                }.getOrDefault(emptyList())
+                add(orphanedSamplesLine(id, elsewhere))
                 return@runCatching
             }
             com.noop.analytics.SleepStager.remFunnelDiagnostic(session.startTs, session.endTs, grav, hr, rr, resp)
@@ -419,5 +438,35 @@ object AndroidDiagnostics {
             }.getOrDefault(false)
             "$label=${if (granted) "granted" else "denied"}"
         }
+    }
+
+    /**
+     * #1617 follow-up: the line the night funnel prints when the ACTIVE device id carries no raw samples.
+     *
+     * The previous wording asserted "expected on a freshly re-added strap" unconditionally. That is one of
+     * two explanations, and the other one is a bug: a registry can hold several ids for the same physical
+     * strap (#1193/#740), and when the history spine and the raw stream split, the samples are present -
+     * just filed under a different id. Printing the innocent cause for that case ends the investigation at
+     * the point it should begin, which is worse than printing nothing.
+     *
+     * [othersWithSamples] is (deviceId, sampleCount) for every OTHER registry id that does hold samples in
+     * the same window. Empty means the samples genuinely are not there and the fresh-re-add wording is
+     * right; non-empty names the id that has them so the split is visible rather than inferred.
+     *
+     * Pure so the wording is unit-tested without a database, a strap, or a registry.
+     */
+    internal fun orphanedSamplesLine(activeId: String, othersWithSamples: List<Pair<String, Int>>): String {
+        if (othersWithSamples.isEmpty()) {
+            return "(no raw biometric samples under '$activeId' for this night — expected on a freshly " +
+                "re-added strap; reconnect + let a history sync run, then re-export)"
+        }
+        // Tie-break on id: Kotlin's sortedByDescending is stable but Swift's `sorted` is NOT, so equal
+        // counts could otherwise order differently on the two platforms and the twin lines would diverge.
+        val named = othersWithSamples
+            .sortedWith(compareByDescending<Pair<String, Int>> { it.second }.thenBy { it.first })
+            .joinToString(", ") { "'${it.first}' (${it.second} rows)" }
+        return "(no raw biometric samples under the ACTIVE id '$activeId' for this night — they are under " +
+            "$named instead. The history spine and the raw stream are on different device ids (#1193); this " +
+            "is NOT a fresh re-add, the samples exist and are not being read.)"
     }
 }

--- a/android/app/src/test/java/com/noop/testcentre/OrphanedSamplesLineTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/OrphanedSamplesLineTest.kt
@@ -1,0 +1,60 @@
+package com.noop.testcentre
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1617 follow-up: the funnel's zero-sample line must distinguish "the samples are not there" from
+ * "the samples are under a different device id" (#1193/#740). The old line asserted the first
+ * unconditionally, which is the wrong answer to give an investigation exactly when it matters.
+ *
+ * Swift twin: `orphanedSamplesLine` in `Strand/System/DebugDataDiagnostics.swift` — the two must emit
+ * the same strings, so these expectations are written out in full rather than pattern-matched.
+ */
+class OrphanedSamplesLineTest {
+
+    @Test
+    fun `no samples anywhere keeps the fresh-re-add wording`() {
+        assertEquals(
+            "(no raw biometric samples under 'my-whoop' for this night — expected on a freshly " +
+                "re-added strap; reconnect + let a history sync run, then re-export)",
+            AndroidDiagnostics.orphanedSamplesLine("my-whoop", emptyList()),
+        )
+    }
+
+    @Test
+    fun `samples under another id report the split instead`() {
+        val line = AndroidDiagnostics.orphanedSamplesLine("my-whoop", listOf("whoop-F1:D4:F7:24:53:DE" to 4213))
+        assertEquals(
+            "(no raw biometric samples under the ACTIVE id 'my-whoop' for this night — they are under " +
+                "'whoop-F1:D4:F7:24:53:DE' (4213 rows) instead. The history spine and the raw stream are " +
+                "on different device ids (#1193); this is NOT a fresh re-add, the samples exist and are " +
+                "not being read.)",
+            line,
+        )
+        // The benign explanation must not survive anywhere in the split wording — a reader scanning the
+        // log for "freshly re-added" would otherwise still stop here.
+        assertTrue(!line.contains("freshly re-added"))
+    }
+
+    @Test
+    fun `several holders are listed heaviest first`() {
+        val line = AndroidDiagnostics.orphanedSamplesLine(
+            "my-whoop",
+            listOf("whoop-aa" to 12, "whoop-bb" to 900, "whoop-cc" to 300),
+        )
+        assertTrue(line.contains("'whoop-bb' (900 rows), 'whoop-cc' (300 rows), 'whoop-aa' (12 rows)"))
+    }
+
+    @Test
+    fun `equal counts break the tie on id so both platforms agree`() {
+        // Swift's `sorted` is not a stable sort; without an explicit tie-break the twin lines could list
+        // the same two ids in different orders.
+        val line = AndroidDiagnostics.orphanedSamplesLine(
+            "my-whoop",
+            listOf("whoop-zz" to 50, "whoop-aa" to 50),
+        )
+        assertTrue(line.contains("'whoop-aa' (50 rows), 'whoop-zz' (50 rows)"))
+    }
+}


### PR DESCRIPTION
## The gap

The night funnel prints per-night raw sample counts, and when the active device id carries none it appends:

```
Night 2026-08-18: grav=0 hr=0 rr=0 resp=0 skin=0
(no raw biometric samples under 'whoop-F1:D4:F7:24:53:DE' for this night — expected on a freshly
 re-added strap; reconnect + let a history sync run, then re-export)
```

That is **one of two explanations, asserted without testing the other.** Several ids can hold one physical strap's data (#1193/#740); when the history spine and the raw stream split, the samples are *present*, just filed under a different id. The funnel prints "expected" for that case too — which ends an investigation at exactly the point it should begin.

The log attached to #1617 shows the shape: a 53-day spine under `my-whoop` while raw lands under `whoop-F1:D4:F7:24:53:DE`. This PR does not address that split itself; it makes the funnel stop misreporting it.

## The change

On the **zero-sample path only**, count raw samples per device id for the same window and name whichever ids hold them.

- **Nothing anywhere** → the existing wording, verbatim, byte for byte.
- **Samples elsewhere** → the split is named:

```
(no raw biometric samples under the ACTIVE id 'my-whoop' for this night — they are under
 'whoop-F1:D4:F7:24:53:DE' (4213 rows) instead. The history spine and the raw stream are on
 different device ids (#1193); this is NOT a fresh re-add, the samples exist and are not being read.)
```

A healthy install never reaches the branch, so it costs nothing.

## Why the query goes to the sample tables, not the device registry

The first pass at this listed candidate ids from the registry. **Re-review found that incomplete in precisely the case it was written for**, and the second commit replaces it — worth stating plainly since it is the substance of the PR:

- `my-whoop` is a source **label** for imported/computed data ("the CANONICAL imported/computed id"), not necessarily a `pairedDevice` row;
- `DeviceRegistryStore.remove` deletes the row and leaves every sample table untouched, so a forgotten strap keeps its rows and loses its listing.

Both are cases where the id holding the data is invisible to `registry.all()` — including the reported one. So the probe now asks the sample tables directly: a per-`deviceId` count over `hrSample` + `ppgHrSample` + `gravitySample` (`WhoopStore.rawSampleCountsByDevice` and its `WhoopDao` twin), which are the same streams the funnel's own guard tests. No registry dependency, no blind spot, simpler call sites.

**Cost:** filtering on `ts` without a `deviceId` cannot seek into the `(deviceId, ts)` primary key, so it is an **index-only** scan — both columns live in that index so no table rows are touched, and `deviceId` leading lets the `GROUP BY` skip a temp b-tree. It runs only on the zero-sample path of a user-triggered export.

## Parity

The wording is a pure helper on each side, with **four twinned tests per platform** (`OrphanedSamplesLineTest` / `OrphanedSamplesLineTests`). Output was **diffed Kotlin-vs-Swift across all four cases, not eyeballed** — the Swift helper was extracted, compiled and executed standalone and its stdout diffed against the JVM's. Byte-identical, re-checked after every edit. The Swift test literals were **generated from that verified diff rather than retyped**, and each was re-checked against the standalone helper's real output; a hand-copied expectation is how a parity test ends up asserting the bug.

The two SQL statements were diffed **token-for-token** after normalising binder syntax (`?` vs `:from`) — identical.

Ordering tie-breaks on id: Kotlin's `sortedByDescending` is stable, Swift's `sorted` is **not**, so equal counts would otherwise list in different orders. There is a test for the tie on both platforms. Its one assumption is documented in place: the tie-break compares Unicode canonical order in Swift and UTF-16 code units in Kotlin, which agree for the machine-generated ASCII ids this sees (`my-whoop`, `whoop-<mac>`), and a device *nickname* is a separate field that never reaches this id.

A parity pass also caught the post-query filters not being the same predicate — Swift dropped ids on `!isEmpty`, Kotlin on `isNotBlank()`, so a whitespace-only id would be kept on one platform and dropped on the other. Neither can occur today; the point is that the two stay the same one. Kotlin now uses `isNotEmpty()`.

## Verification

- **Room accepted the new query at KSP time** under `--rerun-tasks --no-build-cache`, so KSP genuinely re-ran rather than serving a cached DAO — that is real SQL validation, and the Swift statement is the same one against the same tables.
- `compileFullDebugKotlin` clean; 4 JVM tests green (`tests="4" failures="0"`) under `--rerun-tasks --no-build-cache`.
- `doc_comment_lint` clean (no new detached sites); `i18n_audit --ci main` clean.
- Swift wording helper compiled and run in isolation to produce the parity diff.
- No strap required: this is a diagnostics-string path, not BLE.
- **Not compile-checked:** the new `StrandTests` file and the Swift funnel call site are app-target (`Strand/System/`) and the new `Reads.swift` method is in a GRDB-linked package that does not build on Linux. Both need macOS — `app-build` for the call site, `swift-packages` for `Reads.swift` (that one runs on every PR). The read follows the file's own `syncRead` + typed-row-binding idiom (`let t: Int = row["total"]`).

## One divergence noticed, deliberately not changed here

The funnel's *active-id* `hr` read differs across platforms: Swift's `repo.hrSamples(from:to:limit:)` already **unions** active + canonical ids, while Android's `repo.hrSamples(id, …)` is single-id — so `hr=N` means slightly different things on the two platforms, and Swift's both-empty branch is harder to reach than Android's. Pre-existing and out of scope for this PR; worth its own issue.