### PR TITLE
ble: pick the battery source from evidence, not from a guess

### DIFF
--- a/android/app/src/main/java/com/noop/ble/BatterySource.kt
+++ b/android/app/src/main/java/com/noop/ble/BatterySource.kt
@@ -1,0 +1,41 @@
+package com.noop.ble
+
+import com.noop.protocol.DeviceFamily
+
+/** Where a link's battery percentage may legitimately come from - see [batterySource]. */
+internal enum class BatterySource {
+    /** The family is still a guess; take no reading rather than a possibly-invented one. */
+    DEFER,
+
+    /** WHOOP 4.0: the custom `GET_BATTERY_LEVEL` command (u16/10). */
+    CUSTOM_COMMAND,
+
+    /** 5/MG and other standard-profile straps: the standard 0x2A19 characteristic (whole %). */
+    STANDARD_CHAR,
+}
+
+/**
+ * Which battery source this link may use, given whether service discovery has established the family.
+ *
+ * The 4.0's standard 0x2A19 characteristic is a stub rather than a real state-of-charge (#77), so the
+ * choice of source is only sound once the family is known from THIS connection. `connectedFamily`
+ * defaults to WHOOP4 and is written only in onServicesDiscovered, and used to survive a disconnect
+ * uncleared - so before discovery it holds either the default or the previous link's family. Asking
+ * `!= WHOOP4` against that answers "use the standard characteristic" for a 4.0 whose family has not been
+ * established yet, which reads the stub and banks it as a real SoC.
+ *
+ * That is the #171 shape the family resolver's own docs warn about - a family question answered by a
+ * fall-through rather than by evidence - and it is not theoretical: a field log on a WHOOP 4.0 banked
+ * 81% from the stub while the strap's own report, thirty seconds later, said 39.2%. Banked samples feed
+ * the discharge-slope estimate (#713), so a phantom sample reaches the "time left" readout rather than
+ * stopping at the log.
+ *
+ * [DEFER] is safe to act on: a periodic refresh follows within ~30s, by which point discovery has run.
+ *
+ * Pure so the decision is unit-tested without a strap, a GATT stack, or an Android runtime.
+ */
+internal fun batterySource(familyEstablished: Boolean, family: DeviceFamily): BatterySource = when {
+    !familyEstablished -> BatterySource.DEFER
+    family == DeviceFamily.WHOOP4 -> BatterySource.CUSTOM_COMMAND
+    else -> BatterySource.STANDARD_CHAR
+}

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2173,13 +2173,18 @@ class WhoopBleClient(
 
     /// Has [connectedFamily] been established from THIS connection's service discovery?
     ///
-    /// [connectedFamily] defaults to WHOOP4 and is only ever written in onServicesDiscovered, so before
-    /// discovery it holds either that default or - because it was never cleared per-connection - the
-    /// family of the PREVIOUS link. Both are guesses, and the battery source must not be chosen from a
+    /// [connectedFamily] defaults to WHOOP4 and is only ever written in onServicesDiscovered, and is NOT
+    /// cleared between connections (this flag is - clearing [connectedFamily] itself would change the
+    /// handleDisconnect paths that read it after teardown). So before discovery it holds either that
+    /// default or the family of the PREVIOUS link. Both are guesses, and the source must not come from a
     /// guess: the 4.0's standard 0x2A19 characteristic is a stub (#77), so a 4.0 reached while this still
     /// said WHOOP5 read the stub and BANKED it. In one field log that stub read 81% against a true 39.2%,
     /// and banked samples feed the discharge-slope estimate (#713), so the error reaches the readout and
     /// not just the log line. Cleared in [reset] with the rest of the per-connection state.
+    /// @Volatile and always read BEFORE [connectedFamily] (Kotlin evaluates arguments left to right, so
+    /// `batterySource(familyEstablished, connectedFamily)` is the correct order): seeing this true then
+    /// establishes happens-before for the [connectedFamily] write that precedes it at discovery. Swapping
+    /// the two parameters would silently drop that guarantee.
     @Volatile private var familyEstablished = false
 
     /// The family actually discovered on the connected peripheral. Drives family-aware frame

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2170,6 +2170,18 @@ class WhoopBleClient(
 
     /** Address of the strap we last connected to — for persisting it + auto-reconnecting on launch (#67). */
     val lastDeviceAddress: String? get() = lastDevice?.address
+
+    /// Has [connectedFamily] been established from THIS connection's service discovery?
+    ///
+    /// [connectedFamily] defaults to WHOOP4 and is only ever written in onServicesDiscovered, so before
+    /// discovery it holds either that default or - because it was never cleared per-connection - the
+    /// family of the PREVIOUS link. Both are guesses, and the battery source must not be chosen from a
+    /// guess: the 4.0's standard 0x2A19 characteristic is a stub (#77), so a 4.0 reached while this still
+    /// said WHOOP5 read the stub and BANKED it. In one field log that stub read 81% against a true 39.2%,
+    /// and banked samples feed the discharge-slope estimate (#713), so the error reaches the readout and
+    /// not just the log line. Cleared in [reset] with the rest of the per-connection state.
+    @Volatile private var familyEstablished = false
+
     /// The family actually discovered on the connected peripheral. Drives family-aware frame
     /// parsing and gates the WHOOP4-only bond/handshake. Set in onServicesDiscovered.
     /// @Volatile: written on the binder thread at service discovery, read in send() on main (user
@@ -4248,9 +4260,16 @@ class WhoopBleClient(
             log("refreshBattery ignored — not connected")
             return
         }
-        if (connectedFamily == DeviceFamily.WHOOP4) {
-            send(CommandNumber.GET_BATTERY_LEVEL)
-            return
+        when (batterySource(familyEstablished, connectedFamily)) {
+            BatterySource.DEFER -> {
+                log("refreshBattery deferred — strap family not established yet")
+                return
+            }
+            BatterySource.CUSTOM_COMMAND -> {
+                send(CommandNumber.GET_BATTERY_LEVEL)
+                return
+            }
+            BatterySource.STANDARD_CHAR -> Unit
         }
         val ops = gattOps ?: return
         val batt = g.getService(BATTERY_SERVICE)?.getCharacteristic(BATTERY_CHAR)
@@ -5213,6 +5232,7 @@ class WhoopBleClient(
                 // notifications ever enable, so HR/battery/events stay empty (issue #12). The bond write
                 // is deferred to startSession(), which runs once every notification is on.
                 connectedFamily = DeviceFamily.WHOOP4
+                familyEstablished = true
                 // Record the family on connect, not only in the scan path (persistSelectedModel is
                 // otherwise called only from onScanResult). A strap reached via the co-resident
                 // easy-connect route (getConnectedDevices / bondedDevices adopt, no scan) would never
@@ -5226,6 +5246,7 @@ class WhoopBleClient(
                 // EXPERIMENTAL WHOOP 5.0/MG: opens with CLIENT_HELLO (sent in startSession, after the
                 // standard HR/battery notifications are enabled), not the WHOOP4 confirmed-write bond.
                 connectedFamily = DeviceFamily.WHOOP5
+                familyEstablished = true
                 // Persist on connect too (see the WHOOP4 branch): otherwise an easy-connect 5/MG never
                 // records WHOOP5_MG, so the 5/MG-only controls (raw capture, broadcast HR, deep data)
                 // gated on noop.selectedWhoopModel stay hidden until the strap is live-detected that
@@ -5446,10 +5467,14 @@ class WhoopBleClient(
         resubscribedSinceData = false               // data is flowing again — re-arm the one-shot resubscribe
         when {
             uuid == HEART_RATE_CHAR -> parseStandardHr(bytes)       // 0x2A37
-            // 0x2A19 = percent — 5/MG ONLY. On a WHOOP 4.0 this characteristic is a stub constant 100
-            // (the real value is the GET_BATTERY_LEVEL COMMAND_RESPONSE, u16/10), and it's also
-            // SUBSCRIBED, so an unsolicited stub notification could flip the display back to 100 (#77).
-            uuid == BATTERY_CHAR -> if (connectedFamily != DeviceFamily.WHOOP4) {
+            // 0x2A19 = percent — 5/MG ONLY. On a WHOOP 4.0 this characteristic is a stub (the real value
+            // is the GET_BATTERY_LEVEL COMMAND_RESPONSE, u16/10), and it's also SUBSCRIBED, so an
+            // unsolicited stub notification could flip the display to a wrong number (#77). NOT always the
+            // constant 100 this comment used to claim: a WHOOP 4.0 field log read 81 from it against a
+            // true 39.2, so the value is plausible enough to pass any range check — hence the source, not
+            // the value, has to be the gate. `!= WHOOP4` is not that gate while the family is still a guess.
+            uuid == BATTERY_CHAR -> if (batterySource(familyEstablished, connectedFamily) ==
+                BatterySource.STANDARD_CHAR) {
                 bytes.firstOrNull()?.let { setBattery((it.toInt() and 0xFF).toDouble()) }
             } else Unit
             // #520 DIS identity. NUL-terminated ASCII per the DIS spec, so trim padding. The serial
@@ -8255,6 +8280,7 @@ class WhoopBleClient(
     private fun reset() {
         didBond = false
         connectHandshakeDone = false
+        familyEstablished = false   // the next link re-establishes it at service discovery
         seq.set(0)
         writeQueue.clear()
         cccdQueue.clear()

--- a/android/app/src/test/java/com/noop/ble/BatterySourceTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BatterySourceTest.kt
@@ -1,0 +1,42 @@
+package com.noop.ble
+
+import com.noop.protocol.DeviceFamily
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the battery-source decision (#77). The bug this replaces: `connectedFamily != WHOOP4` was asked
+ * while `connectedFamily` was still a guess - its WHOOP4 default, or the PREVIOUS link's family, since
+ * it survived a disconnect uncleared - so a WHOOP 4.0 reached while it still said WHOOP5 read the 4.0's
+ * 0x2A19 stub and banked it as a real state of charge.
+ */
+class BatterySourceTest {
+
+    @Test
+    fun `an unestablished family never picks a source`() {
+        // The whole point: BOTH families defer, because before discovery the value carries no evidence.
+        // A test that only checked WHOOP5 here would pass against the bug.
+        assertEquals(BatterySource.DEFER, batterySource(false, DeviceFamily.WHOOP5))
+        assertEquals(BatterySource.DEFER, batterySource(false, DeviceFamily.WHOOP4))
+    }
+
+    @Test
+    fun `an established 4-0 uses the custom command, never the stub characteristic`() {
+        assertEquals(BatterySource.CUSTOM_COMMAND, batterySource(true, DeviceFamily.WHOOP4))
+    }
+
+    @Test
+    fun `an established 5 or MG uses the standard characteristic`() {
+        assertEquals(BatterySource.STANDARD_CHAR, batterySource(true, DeviceFamily.WHOOP5))
+    }
+
+    @Test
+    fun `the standard characteristic is reachable only with positive evidence`() {
+        // Restates the invariant as a sweep so a future edit cannot reintroduce the fall-through: there
+        // is exactly ONE (established, family) combination that may bank from 0x2A19.
+        val reaching = listOf(true, false).flatMap { est ->
+            DeviceFamily.values().map { fam -> Triple(est, fam, batterySource(est, fam)) }
+        }.filter { it.third == BatterySource.STANDARD_CHAR }
+        assertEquals(listOf(Triple(true, DeviceFamily.WHOOP5, BatterySource.STANDARD_CHAR)), reaching)
+    }
+}


### PR DESCRIPTION
## The evidence

A WHOOP 4.0 strap log (thanks @pilleuspulcher-blip, attached to #1617) banks this:

```
10:46:49  Reading standard Battery Level (0x2A19)
10:46:49  [battery] bank soc=81.0 t=1787647609s
10:46:52  Reading standard Battery Level (0x2A19)
10:46:52  [battery] bank soc=81.0 t=1787647612s
10:47:20  [battery] bank soc=39.2 t=1787647640s      <- the strap's own report
```

`39.x` for the rest of the session, drifting smoothly as the strap charges. The two `81.0` samples are the only ones in the log that follow a `Reading standard Battery Level (0x2A19)` line — which appears **exactly twice, and never again** once the strap is identified. The device model was still the generic `"WHOOP"` during both, corrected to `"WHOOP 4.0"` (#716) eight seconds later.

## The defect

The 4.0's `0x2A19` is a stub, not a state of charge, and the code has said so since #77. But both readers ask the question the wrong way round:

```kotlin
refreshBattery():  if (connectedFamily == WHOOP4) { custom command } else { read 0x2A19 }
inbound 0x2A19:    if (connectedFamily != WHOOP4) { bank it }
```

`connectedFamily` defaults to `WHOOP4`, is written only in `onServicesDiscovered`, and **was never cleared per-connection** — so between links it holds the *previous* strap's family. Before discovery it is a guess, and asking `!= WHOOP4` of a guess answers "use the standard characteristic" for a 4.0.

That is exactly the shape `DeviceFamily`'s own docs warn about:

> letting such a device fall through to `.whoop5` is exactly the #171 mistake (a family question answered by a fall-through rather than by evidence)

**It is not cosmetic.** `bank soc=` appends to `batterySamples`, which the code calls "the readout + trace source (#713)" feeding the discharge-run and slope estimate. A phantom 81% at session start corrupts the "time left" figure — and lands in the history the open WHOOP-4 drain work reads.

## The change

Clear the establishment state per-connection alongside the other flags in `reset()` — the function whose docstring is already *"Clear per-connection state"* — and route both readers through one pure decision requiring **positive** evidence:

```kotlin
internal fun batterySource(familyEstablished: Boolean, family: DeviceFamily): BatterySource = when {
    !familyEstablished            -> BatterySource.DEFER
    family == DeviceFamily.WHOOP4 -> BatterySource.CUSTOM_COMMAND
    else                          -> BatterySource.STANDARD_CHAR
}
```

**Deferring is safe**, and I checked rather than assumed: the battery is polled roughly every 60s on the keep-alive tick, and the post-connect refresh sits inside an already-established 5/MG branch behind a 1.5s delay, so `DEFER` cannot fire there. `reset()` is called only in `connectToDevice()` and teardown — never between discovery and use.

## Also corrected

The comment claiming the 4.0's `0x2A19` is a **"stub constant 100"**. It is not: this strap returned **81** against a true 39.2. That is plausible enough to pass any range check, which is precisely why the *source* and not the *value* has to be the gate.

## Scope

`connectedFamily` staleness is broader than the battery — this PR fixes the consumer with field evidence and does not touch the others (frame parsing only reads it after discovery, so it is not exposed). Resetting `connectedFamily` itself would also change `handleDisconnect` paths that read it after teardown, which is a separate change with its own risk.

## Parity: Android only, and why Swift does not need the same change

Swift has the **identical gate shape** — `if selectedModel.deviceFamily != .whoop4` on the inbound 0x2A19, same `#77` reference. What differs is the value feeding it, and the difference is what makes Android vulnerable and Swift not:

| | Android | Swift |
|---|---|---|
| family comes from | `connectedFamily` — a field written at service discovery | `selectedModel` — the model the scan/adopt used |
| survives a disconnect? | **yes, uncleared** → holds the previous link's family | no |
| can hold a non-committal value? | n/a | **no** — `WhoopModel` has only `.whoop4` / `.whoop5mg` |
| default when unknown | `WHOOP4`, but overwritten by the previous link | `.persisted` → **`.whoop4`**, the safe branch |
| consults the registry model? | no | no |

Three things independently keep Swift out of it:

1. `WhoopModel.persisted` falls back to **`.whoop4`** — the branch that uses the custom command and never touches 0x2A19. Android's `connectedFamily` also defaults to `WHOOP4`, but it gets overwritten by the previous connection and never cleared, which is the actual defect.
2. There is **no generic value to fall through**. The Android trigger was a registry model of plain `"WHOOP"` resolving `.whoop5` via `forRegistryModel`'s `default:`. Swift's battery gate never consults the registry model at all — `selectedModel` is a two-case enum.
3. Both no-scan connect routes are service-filtered: `retrieveConnectedPeripherals(withServices: [model.scanService])`, and the scan itself filters by service with a fallback rotation that persists whichever family actually advertises. So on connect, `selectedModel` agrees with the service that reached the strap.

Worth noting Swift's #716 stamping (`didDiscover`) is the twin of the very `Updated device model from "WHOOP" to "WHOOP 4.0"` line in this log — but it stamps the *registry* from `selectedModel`, and the battery path does not read the registry, so it is not in this loop.

**The one residual I will not claim immunity from:** `willRestoreState` hands back a peripheral with no scan, and `selectedModel = .persisted`. A user whose persisted model is `.whoop5mg` restoring onto a 4.0 would hit the same shape. CoreBluetooth restores the last-connected peripheral, which is normally the one that set the preference, so this needs two straps and an unlucky ordering. Unevidenced — I would rather file it than make a speculative change to BLE code that cannot be tested without hardware.

## Verification

- `compileFullDebugKotlin` clean.
- 4 new JVM tests green under `--rerun-tasks --no-build-cache` (`tests="4" failures="0"`, 4 `<testcase>` elements — not a zero-match filter). One test sweeps every `(established, family)` combination to assert exactly **one** reaches `STANDARD_CHAR`, so the fall-through cannot be reintroduced.
- `doc_comment_lint` and `i18n_audit --ci main` clean.
- **Not strap-verified.** This gates a BLE path, and compile-success proves nothing about connection behaviour — it wants a real 4.0 reconnect to confirm the phantom sample is gone. The 81/39.2 pair above is the reproduction.