### PR TITLE
import: report which metric columns an export actually carried

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/ImportColumnCoverage.swift
+++ b/Packages/StrandImport/Sources/StrandImport/ImportColumnCoverage.swift
@@ -1,0 +1,42 @@
+import Foundation
+import WhoopStore
+
+/// The metric columns the coverage line reports, in the order it reports them.
+///
+/// This order is part of the emitted string, so it is a cross-platform contract: the Kotlin twin
+/// (`com.noop.ingest.IMPORT_COLUMN_LABELS`) lists the same labels in the same order, and both are pinned
+/// by a test. Adding a column means adding it to both, in the same position.
+///
+/// Scoped to the seven daily PHYSIOLOGICAL metrics — the ones a vitals card reads, and so the ones behind
+/// "why is this card empty". Sleep-duration columns belong to their own stage and are not folded in here,
+/// where they would dilute the signal the line exists to carry.
+public let importColumnLabels = ["recovery", "rhr", "hrv", "skin_temp", "spo2", "strain", "resp"]
+
+/// Count, per metric column, how many of these MAPPED daily rows carried a usable value.
+///
+/// Counted on the mapped `DailyMetric` rows, not on the raw parsed CSV rows, and that distinction is the
+/// whole reason this takes the type it does: the WHOOP mapping drops any cycle without a usable day, so
+/// the two populations differ, and counting them on different sides of that guard would make the twin
+/// lines disagree on a real export. `DailyMetric`'s field names are identical on both platforms, so the
+/// two implementations read the same.
+///
+/// A count of zero means the export never carried that column — or carried it under a header the aliases
+/// do not match — which is the commonest cause of a card that stays empty after an import the user
+/// watched succeed. Known before any store write, so it carries none of the ambiguity that keeps
+/// `rowsOut` honest-but-unverified on Android.
+///
+/// `filter{}.count` rather than `count(where:)`: the packages declare swift-tools-version 5.9, and this
+/// path has no local compile on Linux, so the form that has always existed is the right one to pick.
+///
+/// Kotlin twin: `com.noop.ingest.importColumnCoverage`.
+public func importColumnCoverage(_ rows: [DailyMetric]) -> [(String, Int)] {
+    [
+        ("recovery", rows.filter { $0.recovery != nil }.count),
+        ("rhr", rows.filter { $0.restingHr != nil }.count),
+        ("hrv", rows.filter { $0.avgHrv != nil }.count),
+        ("skin_temp", rows.filter { $0.skinTempDevC != nil }.count),
+        ("spo2", rows.filter { $0.spo2Pct != nil }.count),
+        ("strain", rows.filter { $0.strain != nil }.count),
+        ("resp", rows.filter { $0.respRateBpm != nil }.count),
+    ]
+}

--- a/Packages/StrandImport/Sources/StrandImport/ImportTrace.swift
+++ b/Packages/StrandImport/Sources/StrandImport/ImportTrace.swift
@@ -78,10 +78,15 @@ public enum ImportTrace {
     /// Known at parse time, so it carries none of the store-write ambiguity that keeps `rowsOut` honest
     /// but unverified on Android — this line means the same thing on both platforms.
     public static func columnCoverageLine(stage: String, rows: Int, counts: [(String, Int)]) -> String {
+        // Built from the non-empty parts rather than interpolated positionally: an empty `counts` would
+        // otherwise leave a trailing space, and a malformed line is worse than a useless one for anything
+        // that later greps these logs. No caller can pass empty today; the formatter is shared and public,
+        // so it should not depend on that staying true.
+        let head = "import columns stage=\(stage) rows=\(rows)"
         let body = counts.map { "\($0.0)=\($0.1)" }.joined(separator: " ")
         let absent = counts.filter { $0.1 == 0 }.map(\.0)
         let tail = absent.isEmpty ? "" : " — ABSENT: \(absent.joined(separator: ", "))"
-        return "import columns stage=\(stage) rows=\(rows) \(body)\(tail)"
+        return body.isEmpty ? head : "\(head) \(body)\(tail)"
     }
 
     public static func rejectLine(droppedRows: Int, skippedSpans: Int) -> String {

--- a/Packages/StrandImport/Sources/StrandImport/ImportTrace.swift
+++ b/Packages/StrandImport/Sources/StrandImport/ImportTrace.swift
@@ -62,6 +62,28 @@ public enum ImportTrace {
     /// CSV row with no parseable timestamp) and the number of tolerant-import spans the XML sanitizer
     /// scrubbed (`skippedSpans`, Apple Health only; 0 elsewhere). So a partial import never silently looks
     /// complete.
+    /// Which metric columns an imported table actually carried, and which were empty in every row.
+    ///
+    /// The import trace already reports rows in, rows rejected and days mapped, but not whether a given
+    /// COLUMN arrived. That is the question behind a whole class of "why is this card empty" reports: the
+    /// file imported cleanly, the rows landed, and one metric is still blank because the export never
+    /// contained it — or contained it under a header the aliases do not match. Both look identical from
+    /// outside, and neither is distinguishable from a store-write failure without this line.
+    ///
+    /// `counts` is (column, rows-with-a-usable-value) in the parser's own order, so the line reads in the
+    /// order a maintainer would look for them. A column at zero is called out explicitly in an ABSENT
+    /// clause rather than left for the reader to spot among a dozen numbers; the clause is omitted when
+    /// every column arrived, so the healthy case is quiet but still present.
+    ///
+    /// Known at parse time, so it carries none of the store-write ambiguity that keeps `rowsOut` honest
+    /// but unverified on Android — this line means the same thing on both platforms.
+    public static func columnCoverageLine(stage: String, rows: Int, counts: [(String, Int)]) -> String {
+        let body = counts.map { "\($0.0)=\($0.1)" }.joined(separator: " ")
+        let absent = counts.filter { $0.1 == 0 }.map(\.0)
+        let tail = absent.isEmpty ? "" : " — ABSENT: \(absent.joined(separator: ", "))"
+        return "import columns stage=\(stage) rows=\(rows) \(body)\(tail)"
+    }
+
     public static func rejectLine(droppedRows: Int, skippedSpans: Int) -> String {
         "import rejects droppedRows=\(droppedRows) skippedSpans=\(skippedSpans)"
     }

--- a/Packages/StrandImport/Tests/StrandImportTests/ImportColumnCoverageTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/ImportColumnCoverageTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import WhoopStore   // DailyMetric — the type importColumnCoverage takes
 @testable import StrandImport
 
 /// Pins the import column-coverage line. Kotlin twin: `ImportColumnCoverageTest`. The two must emit

--- a/Packages/StrandImport/Tests/StrandImportTests/ImportColumnCoverageTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/ImportColumnCoverageTests.swift
@@ -49,4 +49,13 @@ final class ImportColumnCoverageTests: XCTestCase {
     func testCoverageEmitsTheLabelsInContractOrder() {
         XCTAssertEqual(importColumnCoverage([]).map(\.0), importColumnLabels)
     }
+
+    func testAnEmptyCountsListDoesNotTrailASpace() {
+        // Unreachable through the app today, but the formatter is public and a trailing space would
+        // survive into anything that later parses these logs.
+        XCTAssertEqual(
+            ImportTrace.columnCoverageLine(stage: "cycles", rows: 0, counts: []),
+            "import columns stage=cycles rows=0"
+        )
+    }
 }

--- a/Packages/StrandImport/Tests/StrandImportTests/ImportColumnCoverageTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/ImportColumnCoverageTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import StrandImport
+
+/// Pins the import column-coverage line. Kotlin twin: `ImportColumnCoverageTest`. The two must emit
+/// byte-identical strings, so the expectations are written out in full.
+final class ImportColumnCoverageTests: XCTestCase {
+
+    func testCallsOutTheAbsentColumn() {
+        XCTAssertEqual(
+            ImportTrace.columnCoverageLine(stage: "cycles", rows: 58, counts: [
+                ("recovery", 58), ("rhr", 58), ("hrv", 58), ("skin_temp", 58),
+                ("spo2", 0), ("strain", 58),
+            ]),
+            "import columns stage=cycles rows=58 recovery=58 rhr=58 hrv=58 skin_temp=58 spo2=0 strain=58"
+            + " — ABSENT: spo2"
+        )
+    }
+
+    func testHealthyImportHasNoAbsentClause() {
+        XCTAssertEqual(
+            ImportTrace.columnCoverageLine(stage: "cycles", rows: 2, counts: [("recovery", 2), ("spo2", 2)]),
+            "import columns stage=cycles rows=2 recovery=2 spo2=2"
+        )
+    }
+
+    func testEveryAbsentColumnIsListedInParserOrder() {
+        XCTAssertEqual(
+            ImportTrace.columnCoverageLine(stage: "cycles", rows: 9, counts: [
+                ("spo2", 0), ("recovery", 9), ("skin_temp", 0),
+            ]),
+            "import columns stage=cycles rows=9 spo2=0 recovery=9 skin_temp=0 — ABSENT: spo2, skin_temp"
+        )
+    }
+
+    func testAPartiallyPopulatedColumnIsNotAbsent() {
+        // 1-of-58 is a real signal (a sparse column), and materially different from "never present".
+        let line = ImportTrace.columnCoverageLine(stage: "cycles", rows: 58, counts: [("spo2", 1)])
+        XCTAssertEqual(line, "import columns stage=cycles rows=58 spo2=1")
+        XCTAssertFalse(line.contains("ABSENT"))
+    }
+
+    func testTheLabelOrderIsTheCrossPlatformContract() {
+        // The order is part of the emitted string. If this changes, the Kotlin twin must change with it,
+        // in the same position — the two lines would otherwise silently stop matching.
+        XCTAssertEqual(importColumnLabels, ["recovery", "rhr", "hrv", "skin_temp", "spo2", "strain", "resp"])
+    }
+
+    func testCoverageEmitsTheLabelsInContractOrder() {
+        XCTAssertEqual(importColumnCoverage([]).map(\.0), importColumnLabels)
+    }
+}

--- a/Strand/Data/WhoopImporter.swift
+++ b/Strand/Data/WhoopImporter.swift
@@ -207,6 +207,14 @@ enum WhoopImporter {
                 ImportTrace.stageLine(category: "cycles", rowsIn: metrics.count, rowsOut: metricsWritten),
                 ImportTrace.stageLine(category: "sleeps", rowsIn: sessions.count, rowsOut: sessionsWritten),
                 ImportTrace.stageLine(category: "workouts", rowsIn: workouts.count, rowsOut: workoutsWritten),
+                // #1617: which metric COLUMNS the file carried. The stage lines above count ROWS, so an
+                // export whose Blood Oxygen column is absent looks identical to one where it arrived — and
+                // a card that stays empty after a clean import is then indistinguishable from a failed
+                // write. Counted on the parsed rows, before any store write, so it says the same thing on
+                // both platforms. Emitted between the stage and reject lines, matching the Kotlin order.
+                ImportTrace.columnCoverageLine(stage: "cycles",
+                                               rows: metrics.count,
+                                               counts: importColumnCoverage(metrics)),
                 ImportTrace.rejectLine(droppedRows: droppedInMap, skippedSpans: result.summary.skippedSpans),
                 ImportTrace.dayDeltaLine(category: "cycles", daysMapped: daysMapped, daysPersisted: metricsWritten),
             ]

--- a/android/app/src/main/java/com/noop/analytics/ImportTrace.kt
+++ b/android/app/src/main/java/com/noop/analytics/ImportTrace.kt
@@ -58,10 +58,15 @@ object ImportTrace {
      * `ImportTrace.columnCoverageLine`.
      */
     fun columnCoverageLine(stage: String, rows: Int, counts: List<Pair<String, Int>>): String {
+        // Built from the non-empty parts rather than interpolated positionally: an empty [counts] would
+        // otherwise leave a trailing space, and a malformed line is worse than a useless one for anything
+        // that later greps these logs. No caller can pass empty today; the formatter is shared, so it
+        // should not depend on that staying true.
+        val head = "import columns stage=$stage rows=$rows"
         val body = counts.joinToString(" ") { "${it.first}=${it.second}" }
         val absent = counts.filter { it.second == 0 }.map { it.first }
         val tail = if (absent.isEmpty()) "" else " — ABSENT: ${absent.joinToString(", ")}"
-        return "import columns stage=$stage rows=$rows $body$tail"
+        return if (body.isEmpty()) head else "$head $body$tail"
     }
 
     /** The reject-counts line: rows dropped as unusable + tolerant XML spans scrubbed. Mirrors Swift. */

--- a/android/app/src/main/java/com/noop/analytics/ImportTrace.kt
+++ b/android/app/src/main/java/com/noop/analytics/ImportTrace.kt
@@ -39,6 +39,31 @@ object ImportTrace {
         return "import stage=$category rowsIn=$rowsIn rowsOut=$rowsOut$note"
     }
 
+    /**
+     * Which metric columns an imported table actually carried, and which were empty in every row.
+     *
+     * The import trace already reports rows in, rows rejected and days mapped, but not whether a given
+     * COLUMN arrived. That is the question behind a whole class of "why is this card empty" reports: the
+     * file imported cleanly, the rows landed, and one metric is still blank because the export never
+     * contained it — or contained it under a header the aliases do not match. Both look identical from
+     * outside, and neither is distinguishable from a store-write failure without this line.
+     *
+     * [counts] is (column, rows-with-a-usable-value) in the parser's own order, so the line reads in the
+     * order a maintainer would look for them. A column at zero is called out explicitly in an ABSENT
+     * clause rather than left for the reader to spot among a dozen numbers; the clause is omitted when
+     * every column arrived, so the healthy case is quiet but still present.
+     *
+     * Known at parse time, so it carries none of the store-write ambiguity that keeps rowsOut honest but
+     * unverified on Android — this line means the same thing on both platforms. Swift twin:
+     * `ImportTrace.columnCoverageLine`.
+     */
+    fun columnCoverageLine(stage: String, rows: Int, counts: List<Pair<String, Int>>): String {
+        val body = counts.joinToString(" ") { "${it.first}=${it.second}" }
+        val absent = counts.filter { it.second == 0 }.map { it.first }
+        val tail = if (absent.isEmpty()) "" else " — ABSENT: ${absent.joinToString(", ")}"
+        return "import columns stage=$stage rows=$rows $body$tail"
+    }
+
     /** The reject-counts line: rows dropped as unusable + tolerant XML spans scrubbed. Mirrors Swift. */
     fun rejectLine(droppedRows: Int, skippedSpans: Int): String =
         "import rejects droppedRows=$droppedRows skippedSpans=$skippedSpans"

--- a/android/app/src/main/java/com/noop/data/ImportSummary.kt
+++ b/android/app/src/main/java/com/noop/data/ImportSummary.kt
@@ -16,6 +16,19 @@ data class ImportSummary(
     val lastDay: String? = null,
     /** One-line human summary for a Toast / status line. */
     val message: String,
+    /**
+     * #1617: per-metric-column counts from the parsed daily rows, in the cross-platform label order —
+     * see `com.noop.ingest.importColumnCoverage`. Empty for importers that do not produce daily
+     * physiological rows, in which case the trace emits no coverage line at all rather than a row of
+     * zeroes that would read as "everything is missing".
+     */
+    val columnCoverage: List<Pair<String, Int>> = emptyList(),
+    /**
+     * Rows the coverage above was counted over. Carried explicitly rather than inferred from the largest
+     * count: if every column were sparse, the largest count would UNDER-report the row total and the line
+     * would quietly overstate coverage.
+     */
+    val columnCoverageRows: Int = 0,
 ) {
     val totalRows: Int get() = counts.values.sum()
 

--- a/android/app/src/main/java/com/noop/ingest/ImportColumnCoverage.kt
+++ b/android/app/src/main/java/com/noop/ingest/ImportColumnCoverage.kt
@@ -1,0 +1,37 @@
+package com.noop.ingest
+
+import com.noop.data.DailyMetric
+
+/**
+ * The metric columns the coverage line reports, in the order it reports them.
+ *
+ * This order is part of the emitted string, so it is a cross-platform contract: the Swift twin
+ * (`StrandImport.importColumnLabels`) lists the same labels in the same order, and both are pinned by a
+ * test. Adding a column means adding it to both, in the same position.
+ *
+ * Scoped to the seven daily PHYSIOLOGICAL metrics — the ones a vitals card reads, and so the ones behind
+ * "why is this card empty". Sleep-duration columns belong to their own stage and are not folded in here,
+ * where they would dilute the signal the line exists to carry.
+ */
+internal val IMPORT_COLUMN_LABELS =
+    listOf("recovery", "rhr", "hrv", "skin_temp", "spo2", "strain", "resp")
+
+/**
+ * Count, per metric column, how many of these parsed rows carried a usable value.
+ *
+ * Counted on the PARSED rows rather than inside the parse loop: the rows already hold the answer, so this
+ * needs no change to the parsers and cannot drift from what they actually produced. A count of zero means
+ * the export never carried that column — or carried it under a header the aliases do not match — which is
+ * the commonest cause of a card that stays empty after an import the user watched succeed.
+ *
+ * Swift twin: `StrandImport.importColumnCoverage`.
+ */
+internal fun importColumnCoverage(rows: List<DailyMetric>): List<Pair<String, Int>> = listOf(
+    "recovery" to rows.count { it.recovery != null },
+    "rhr" to rows.count { it.restingHr != null },
+    "hrv" to rows.count { it.avgHrv != null },
+    "skin_temp" to rows.count { it.skinTempDevC != null },
+    "spo2" to rows.count { it.spo2Pct != null },
+    "strain" to rows.count { it.strain != null },
+    "resp" to rows.count { it.respRateBpm != null },
+)

--- a/android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt
@@ -174,6 +174,8 @@ object WhoopCsvImporter {
             firstDay = firstDay,
             lastDay = lastDay,
             message = message,
+            columnCoverage = importColumnCoverage(cycles),
+            columnCoverageRows = cycles.size,
         )
     }
 

--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -1050,10 +1050,17 @@ internal fun emitImportTrace(
     // reports no write count, but this is known at PARSE time and so is exact on both platforms — and it
     // separates "the store never got it" from "the export never had it", which the stage lines alone
     // cannot. Emitted only when the importer produced daily rows.
+    // Emitted generically here for any summary carrying coverage, while the Swift twin emits it inside
+    // WhoopImporter — so a NEW importer that starts filling columnCoverage would produce this line on
+    // Android and silently not on Swift. Give it the Swift twin at the same time.
     if (summary.columnCoverage.isNotEmpty()) {
         vm.ble.externalLog(
             com.noop.analytics.ImportTrace.columnCoverageLine(
-                stage = com.noop.analytics.ImportTrace.categoryWire(summary.source, "cycles"),
+                // The literal, not categoryWire: that function maps RAW TABLE KEYS to wire categories
+                // ("dailyMetric" -> "cycles"), so handing it a category already in wire form only works
+                // through its `else -> rawKey` fallthrough, and would break the day anyone adds a
+                // "cycles" branch. The Swift twin passes the same literal.
+                stage = "cycles",
                 rows = summary.columnCoverageRows,
                 counts = summary.columnCoverage,
             ),

--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -1046,6 +1046,20 @@ internal fun emitImportTrace(
             com.noop.testcentre.TestDomain.IMPORT,
         )
     }
+    // #1617: which metric COLUMNS the file actually carried. rowsOut stays unverified here because Room
+    // reports no write count, but this is known at PARSE time and so is exact on both platforms — and it
+    // separates "the store never got it" from "the export never had it", which the stage lines alone
+    // cannot. Emitted only when the importer produced daily rows.
+    if (summary.columnCoverage.isNotEmpty()) {
+        vm.ble.externalLog(
+            com.noop.analytics.ImportTrace.columnCoverageLine(
+                stage = com.noop.analytics.ImportTrace.categoryWire(summary.source, "cycles"),
+                rows = summary.columnCoverageRows,
+                counts = summary.columnCoverage,
+            ),
+            com.noop.testcentre.TestDomain.IMPORT,
+        )
+    }
     // The reject line mirrors AppleHealthImport.swift: the app map drops nothing further here, so
     // droppedRows = 0; skippedSpans carries the tolerant-import scrubbed-span count (0 on non-Apple).
     vm.ble.externalLog(

--- a/android/app/src/test/java/com/noop/analytics/ImportColumnCoverageTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ImportColumnCoverageTest.kt
@@ -1,0 +1,71 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Pins the import column-coverage line. Swift twin: `ImportColumnCoverageTests`. The two must emit
+ * byte-identical strings, so the expectations are written out in full.
+ */
+class ImportColumnCoverageTest {
+
+    @Test
+    fun `calls out the absent column`() {
+        assertEquals(
+            "import columns stage=cycles rows=58 recovery=58 rhr=58 hrv=58 skin_temp=58 spo2=0 strain=58" +
+                " — ABSENT: spo2",
+            ImportTrace.columnCoverageLine(
+                "cycles", 58,
+                listOf(
+                    "recovery" to 58, "rhr" to 58, "hrv" to 58, "skin_temp" to 58,
+                    "spo2" to 0, "strain" to 58,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `healthy import has no absent clause`() {
+        assertEquals(
+            "import columns stage=cycles rows=2 recovery=2 spo2=2",
+            ImportTrace.columnCoverageLine("cycles", 2, listOf("recovery" to 2, "spo2" to 2)),
+        )
+    }
+
+    @Test
+    fun `every absent column is listed in parser order`() {
+        assertEquals(
+            "import columns stage=cycles rows=9 spo2=0 recovery=9 skin_temp=0 — ABSENT: spo2, skin_temp",
+            ImportTrace.columnCoverageLine(
+                "cycles", 9, listOf("spo2" to 0, "recovery" to 9, "skin_temp" to 0),
+            ),
+        )
+    }
+
+    @Test
+    fun `a partially populated column is not absent`() {
+        // 1-of-58 is a real signal (a sparse column), and materially different from "never present".
+        val line = ImportTrace.columnCoverageLine("cycles", 58, listOf("spo2" to 1))
+        assertEquals("import columns stage=cycles rows=58 spo2=1", line)
+        assertFalse(line.contains("ABSENT"))
+    }
+
+    @Test
+    fun `the label order is the cross-platform contract`() {
+        // The order is part of the emitted string. If this changes, the Swift twin must change with it, in
+        // the same position — the two lines would otherwise silently stop matching.
+        assertEquals(
+            listOf("recovery", "rhr", "hrv", "skin_temp", "spo2", "strain", "resp"),
+            com.noop.ingest.IMPORT_COLUMN_LABELS,
+        )
+    }
+
+    @Test
+    fun `coverage emits the labels in contract order`() {
+        assertEquals(
+            com.noop.ingest.IMPORT_COLUMN_LABELS,
+            com.noop.ingest.importColumnCoverage(emptyList()).map { it.first },
+        )
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/ImportColumnCoverageTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ImportColumnCoverageTest.kt
@@ -68,4 +68,14 @@ class ImportColumnCoverageTest {
             com.noop.ingest.importColumnCoverage(emptyList()).map { it.first },
         )
     }
+
+    @Test
+    fun `an empty counts list does not trail a space`() {
+        // Unreachable through the app today, but the formatter is shared and a trailing space would
+        // survive into anything that later parses these logs.
+        assertEquals(
+            "import columns stage=cycles rows=0",
+            ImportTrace.columnCoverageLine("cycles", 0, emptyList()),
+        )
+    }
 }


### PR DESCRIPTION
## The question the trace can't answer

A card that stays empty after an import the user watched succeed has two very different causes, and nothing in the trace separates them: **the value never reached the store**, or **the export never contained it**. The stage lines count rows, so a file whose Blood Oxygen column is absent looks exactly like one where it arrived.

That is where #1617 currently sits. The reporter's log shows a clean WHOOP export import —

```
[import] import parser=whoopExport v=1 traceV=1
[import] import stage=cycles rowsIn=58 rowsOut=? (store-write not verified on Android)
[import] import rejects droppedRows=0 skippedSpans=0
```

— and a Blood Oxygen card that stays empty. The strap cannot fill that card (`spo2Pct` is import-only), so the import *is* the whole story, and the import says nothing about columns.

## The line

```
import columns stage=cycles rows=58 recovery=58 rhr=58 hrv=58 skin_temp=58 spo2=0 strain=58 — ABSENT: spo2
```

One line per import: how many rows carried each of the seven daily physiological metrics, with any column at zero named explicitly rather than left to be spotted among a dozen numbers. A column at **1-of-58 is not called absent** — sparse and never-present are different answers, and there's a test for that.

**This deliberately does not touch `rowsOut`.** That is marked unverified on Android because Room genuinely reports no write count, and the existing comment is right to refuse to claim a save it cannot confirm. Coverage is counted at parse time, so it is exact on both platforms and adds no such ambiguity.

## The parity subtlety worth recording

The first cut counted Swift's **raw parsed cycle rows** and Android's **mapped `DailyMetric` rows**. The WHOOP mapping drops any cycle without a usable day (`guard let day = cycleDay(...) else { continue }`), so those are different populations — the two platforms would have counted different denominators *and* different numerators, and disagreed on a real export while both looking correct in isolation.

Both now count the mapped `DailyMetric` rows. `DailyMetric`'s field names are identical on the two platforms, so the implementations read the same line for line. The label **order** is part of the emitted string, so it's pinned by a test on each side.

## Verification

- `compileFullDebugKotlin` clean; 6 JVM tests, plus a twinned Swift test in `StrandImport` — a package, so `test (StrandImport)` runs it in default CI.
- The formatter was **diffed Kotlin-vs-Swift across four cases** (extracted, compiled standalone, stdout diffed) — byte-identical.
- `doc_comment_lint` and `i18n_audit --ci main` clean.
- `ImportSummary` gains two defaulted fields, so no existing construction site changes.
- **Needs app-build:** the Swift wiring is app-target (`WhoopImporter`).

## Noticed, deliberately not changed

The two `parseCycles` row-drop guards differ: Android skips a row only when `cycle_start`, `cycle_end` **and** `wake_onset` are all missing; Swift skips when `cycle_start` and `cycle_end` are. So a wake-only row survives on one platform and not the other. That is pre-existing, it changes **import results** rather than a diagnostic, and it deserves its own issue rather than a quiet fix inside a logging PR.
