### PR TITLE
doc(oura): correct stale real_steps gating claim

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Commands.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Commands.swift
@@ -20,8 +20,12 @@ public enum OuraCommands {
     public static let featureDaytimeHR: UInt8 = 0x02
     // The SpO2 feature id. Per OURA_PROTOCOL.md s7.1.
     public static let featureSpO2: UInt8 = 0x04
-    // The real-steps feature id. Server-flag-gated (activity/real_steps, default off), so it is never
-    // emitted for an offline NOOP-only ring. Per OURA_PROTOCOL.md s7.1 / s7.3 [open_oura-feat].
+    // The real-steps feature id (`activity/real_steps`). Nominally server-flag-gated per
+    // OURA_PROTOCOL.md s7.1/s7.3 [open_oura-feat], but on-device 2026-08-25 real-steps status reads
+    // came back enabled (status=1) from BOTH an authenticated Oura-app session and NOOP's own fully
+    // offline, unauthenticated read of the same ring — the gate is ring-side state, not tied to which
+    // client asks or whether that client is cloud-authenticated. Do not assume "off for NOOP" without
+    // checking a live read.
     public static let featureRealSteps: UInt8 = 0x0B
 
     // MARK: - Pre-auth / identity (unauthenticated OK)
@@ -148,9 +152,11 @@ public enum OuraCommands {
         OuraCommand(label: "spo2_status", bytes: [0x2F, 0x02, 0x20, featureSpO2])
     }
 
-    /// Read the real-steps feature status, `2f 02 20 0b` (READ verb, not enable). The `0x21` reply confirms
-    /// the server-flag gate (`activity/real_steps`, default off) from the ring itself. Read-only diagnostic.
-    /// [open_oura-feat]
+    /// Read the real-steps feature status, `2f 02 20 0b` (READ verb, not enable). The `0x21` reply reports
+    /// the ring's own real_steps gate state — NOT reliably "off" for an offline ring: on-device
+    /// 2026-08-25 this read back status=1 (enabled) from NOOP's own unauthenticated connection, matching
+    /// the real Oura app's read of the same ring byte-for-byte. Read-only diagnostic either way — never
+    /// enables anything, never writes a mode. [open_oura-feat]
     public static func realStepsReadStatus() -> OuraCommand {
         OuraCommand(label: "realsteps_status", bytes: [0x2F, 0x02, 0x20, featureRealSteps])
     }

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -1397,8 +1397,10 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 fetchHistoryIfIdle()   // pull last night's banked temp/SpO2/HRV/sleep-phase right away
                 write([OuraCommands.getBattery()])   // ask once HR streams; the 0x0D reply routes to onBattery
                 // Read-only diagnostic: ask the ring its SpO2 / real-steps feature status once, so a capture
-                // confirms (from the ring itself) that these server-flag features are subscription-gated OFF
-                // for an offline ring. NEVER an enable/set-mode write - purely the 0x20 read verb.
+                // sees the ring's own gate state. NOT reliably "off" for an offline ring — on-device
+                // 2026-08-25 real_steps read back status=1 (enabled) here, matching the real Oura app's read
+                // of the same ring byte-for-byte (worklog analysis/2026-08-25-noop-ring-hci-realsteps-
+                // confirmation.txt). NEVER an enable/set-mode write - purely the 0x20 read verb.
                 write([OuraCommands.spo2ReadStatus(), OuraCommands.realStepsReadStatus()])
                 // Read-only capture (#771/#772): the ring's GetProductInfo serial + hardware pages are
                 // pre-auth readable. The SERIAL is a STABLE per-ring identity — unlike the CoreBluetooth UUID,


### PR DESCRIPTION
  ## Summary
  - `Commands.swift`'s `featureRealSteps` doc and the matching `OuraLiveSource.swift` comment claimed
    real_steps is server-flag-gated off and "never emitted for an offline NOOP-only ring."
  - On-device 2026-08-25 BLE captures show otherwise: the status read (`2f 02 20 0b`) comes back
    `status=1` (enabled) identically from both the authenticated Oura app and NOOP's own fully offline,
    unauthenticated connection to the same ring — the gate is ring-side state, not tied to which client
    asks or whether it's cloud-authenticated.
  - Comment-only change, no behavior change.

  ## Test plan
  - [x] `swift build` + `swift test --filter OuraFeatureStatusTests` (Packages/OuraProtocol) — green
  - [x] Comment-only edit in `OuraLiveSource.swift` (app target, not independently app-built this pass
        per CLAUDE.md's known app-build CI gap — pure doc-comment change, no logic touched)

  Full capture write-up: `worklog/analysis/2026-08-25-noop-ring-hci-realsteps-confirmation.txt`
  (private worklog repo).