### PR TITLE
diagnostics: name every paired device in the strap log (and redact the header)

### DIFF
--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -732,7 +732,12 @@ public final class LiveState: ObservableObject {
         #endif
         var header = "NOOP strap log (scheduled export) — \(osName)\nApp: \(v)\n\(osName): "
             + ProcessInfo.processInfo.operatingSystemVersionString + "\n"
-        if !extraHeaderLines.isEmpty { header += extraHeaderLines.joined(separator: "\n") + "\n" }
+        // #453: the BODY is scrubbed as it is appended, but these header lines come from the diagnostics
+        // block and never pass through that path - and they carry device ids, which embed a BLE address
+        // for a re-added or second strap. Same redactor, so one export cannot be safe while the other leaks.
+        if !extraHeaderLines.isEmpty {
+            header += extraHeaderLines.map { Self.redactPii($0) }.joined(separator: "\n") + "\n"
+        }
         header += String(repeating: "-", count: 40) + "\n"
         // Same generations-then-current shape as `exportableLogText()`: a scheduled drop that fires after a
         // restart must not report only the (possibly empty) current tail.
@@ -791,7 +796,12 @@ public final class LiveState: ObservableObject {
         let healthLines = HealthSyncStats.summaryLines()
         if !healthLines.isEmpty { header += healthLines.joined(separator: "\n") + "\n" }
         #endif
-        if !extraHeaderLines.isEmpty { header += extraHeaderLines.joined(separator: "\n") + "\n" }
+        // #453: the BODY is scrubbed as it is appended, but these header lines come from the diagnostics
+        // block and never pass through that path - and they carry device ids, which embed a BLE address
+        // for a re-added or second strap. Same redactor, so one export cannot be safe while the other leaks.
+        if !extraHeaderLines.isEmpty {
+            header += extraHeaderLines.map { Self.redactPii($0) }.joined(separator: "\n") + "\n"
+        }
         header += String(repeating: "-", count: 40) + "\n"
         // Previous processes first, so the body stays in chronological order and the log-parsing tools read
         // it unchanged — they just get the night that a wake-time restart used to erase.

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -99,6 +99,25 @@ enum DebugDataDiagnostics {
         if let r = days.last(where: { $0.recovery != nil }) {
             lines.append("Last recov.: \(r.day) · \(Int(r.recovery ?? 0))%")
         } else { lines.append("Last recov.: none") }
+        // #1300 follow-up: the header above describes ONE device because it reads the last-connected
+        // prefs, not the registry — so a two-strap install produced a log that never mentioned the
+        // second strap, leaving `dayOwner readId=` and the funnel's orphan check with nothing to be
+        // checked against. Name the whole set instead.
+        // `store` is fetched further down for the funnels; take a handle here rather than moving this
+        // block below the funnel header, so the inventory prints beside the strap identity it qualifies —
+        // the same position it holds on Android.
+        if let invStore = await repo.storeHandle() {
+            let invRegistry = DeviceRegistryStore(dbQueue: invStore.registryWriter)
+            let invRows = ((try? invRegistry.all()) ?? []).map {
+                InventoryRow(id: $0.id, brand: $0.brand, model: $0.model,
+                             status: $0.status.rawValue, lastSeenAt: $0.lastSeenAt)
+            }
+            let invActive = (try? invRegistry.activeDeviceId()) ?? nil
+            lines.append(contentsOf: deviceInventoryLines(rows: invRows,
+                                                          activeId: invActive,
+                                                          nowSec: Int(Date().timeIntervalSince1970),
+                                                          relTime: { relTime($0) }))
+        }
 
         // Workout & imported-activity source breakdown (#28/#29 "counted but not shown" class). Runs BEFORE
         // the funnels since those can early-return, so this always lands in the export.

--- a/Strand/System/DeviceInventory.swift
+++ b/Strand/System/DeviceInventory.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// One registry row, reduced to what the inventory prints — see `deviceInventoryLines`.
+struct InventoryRow {
+    let id: String
+    let brand: String
+    let model: String
+    let status: String
+    let lastSeenAt: Int
+}
+
+/// The strap log's paired-device inventory: every registry row, which one is ACTIVE, and when each was
+/// last seen.
+///
+/// The header above it describes a single device because it reads the last-connected PREFS rather than
+/// the registry, so a two-strap install produces a log that never mentions the second strap. That makes
+/// the id-bearing lines elsewhere — `dayOwner readId=…`, the funnel's orphan check — impossible to
+/// cross-check: a reader can see which id a day was read from but not which ids exist, nor which of them
+/// actually synced. Naming the set is what turns those lines into evidence.
+///
+/// Sorted ACTIVE first, then by most-recently-seen, then by id: a stable order that puts the row a reader
+/// wants first at the top, and never depends on registry iteration order.
+///
+/// Device ids embed a BLE address for a re-added strap, and the export's redaction masks the middle four
+/// octets while keeping the first and last — enough to tell two straps apart in a shared log without
+/// publishing an address. This line carries no data the log did not already carry.
+///
+/// `nowSec` is passed in rather than read, so the output is a pure function of its inputs. Kotlin twin:
+/// `com.noop.testcentre.deviceInventoryLines`.
+func deviceInventoryLines(rows: [InventoryRow],
+                          activeId: String?,
+                          nowSec: Int,
+                          relTime: (Double) -> String) -> [String] {
+    if rows.isEmpty { return ["Devices:     none registered"] }
+    let active = rows.filter { $0.status == "active" }.count
+    let paired = rows.filter { $0.status == "paired" }.count
+    let archived = rows.filter { $0.status == "archived" }.count
+    let head = "Devices:     \(rows.count) registered (\(active) active, \(paired) paired, \(archived) archived)"
+    let ordered = rows.sorted { a, b in
+        let aActive = a.id == activeId, bActive = b.id == activeId
+        if aActive != bActive { return aActive }
+        if a.lastSeenAt != b.lastSeenAt { return a.lastSeenAt > b.lastSeenAt }
+        return a.id < b.id
+    }
+    return [head] + ordered.map { r in
+        let marker = r.id == activeId ? "ACTIVE" : r.status
+        let seen = r.lastSeenAt > 0 ? relTime(Double(nowSec - r.lastSeenAt)) : "never"
+        return "  device id=\(r.id) status=\(marker) brand=\(r.brand) model=\(r.model) lastSeen=\(seen)"
+    }
+}

--- a/StrandTests/DeviceInventoryTests.swift
+++ b/StrandTests/DeviceInventoryTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import Strand
+
+/// Pins the paired-device inventory. Kotlin twin: `DeviceInventoryTest`.
+///
+/// The block exists because the header above it reads the last-connected prefs rather than the registry,
+/// so a two-strap install produced a log that never mentioned the second strap.
+final class DeviceInventoryTests: XCTestCase {
+
+    // The same relTime the diagnostics use, inlined so the test is independent of that private helper.
+    private let rel: (Double) -> String = { sec in
+        if sec < 60 { return "just now" }
+        let m = Int(sec / 60)
+        if m < 60 { return "\(m)m ago" }
+        if m < 1440 { return "\(m / 60)h \(m % 60)m ago" }
+        return "\(m / 1440)d ago"
+    }
+
+    private func row(_ id: String, _ status: String, _ seen: Int,
+                     model: String = "WHOOP 4.0") -> InventoryRow {
+        InventoryRow(id: id, brand: "WHOOP", model: model, status: status, lastSeenAt: seen)
+    }
+
+    func testAnEmptyRegistrySaysSoRatherThanPrintingABareHeader() {
+        XCTAssertEqual(deviceInventoryLines(rows: [], activeId: nil, nowSec: 1000, relTime: rel),
+                       ["Devices:     none registered"])
+    }
+
+    func testTheActiveStrapIsMarkedAndSortedFirstEvenWhenSeenLongestAgo() {
+        // The whole point: the ACTIVE row is the one a reader wants first, and it is NOT necessarily the
+        // most recently seen — switching straps leaves the old one with a fresher lastSeen.
+        let now = 100_000
+        let lines = deviceInventoryLines(
+            rows: [row("whoop-B", "paired", now - 600),
+                   row("my-whoop", "active", now - 11_400, model: "WHOOP 5.0 / MG")],
+            activeId: "my-whoop", nowSec: now, relTime: rel)
+        XCTAssertEqual(lines, [
+            "Devices:     2 registered (1 active, 1 paired, 0 archived)",
+            "  device id=my-whoop status=ACTIVE brand=WHOOP model=WHOOP 5.0 / MG lastSeen=3h 10m ago",
+            "  device id=whoop-B status=paired brand=WHOOP model=WHOOP 4.0 lastSeen=10m ago",
+        ])
+    }
+
+    func testANeverSeenRowReadsNeverRatherThanAHugeDuration() {
+        let lines = deviceInventoryLines(rows: [row("whoop-C", "paired", 0)],
+                                         activeId: nil, nowSec: 100_000, relTime: rel)
+        XCTAssertEqual(lines[1],
+                       "  device id=whoop-C status=paired brand=WHOOP model=WHOOP 4.0 lastSeen=never")
+    }
+
+    func testCountsSplitActivePairedAndArchived() {
+        let now = 100_000
+        let lines = deviceInventoryLines(
+            rows: [row("a", "active", now - 60), row("b", "paired", now - 60),
+                   row("c", "archived", now - 60), row("d", "archived", now - 60)],
+            activeId: "a", nowSec: now, relTime: rel)
+        XCTAssertEqual(lines[0], "Devices:     4 registered (1 active, 1 paired, 2 archived)")
+    }
+
+    func testTiesBreakOnIdSoTheOrderNeverDependsOnRegistryIteration() {
+        let now = 100_000
+        let lines = deviceInventoryLines(
+            rows: [row("zzz", "paired", now - 60), row("aaa", "paired", now - 60)],
+            activeId: nil, nowSec: now, relTime: rel)
+        let ids = lines.dropFirst().map { String($0.split(separator: "=")[1].split(separator: " ")[0]) }
+        XCTAssertEqual(ids, ["aaa", "zzz"])
+    }
+}

--- a/StrandTests/HeaderRedactionTests.swift
+++ b/StrandTests/HeaderRedactionTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Strand
+
+/// #453: the strap-log HEADER is built from diagnostics lines that never pass through the scrub the log
+/// BODY gets as it is appended, so the export sites must redact them themselves.
+///
+/// Pins the property that matters — a device id embedding a BLE address does not survive into a
+/// shareable header — rather than the call sites, which a refactor may legitimately move. It matters now
+/// that the header enumerates EVERY paired device: a single-strap install is "my-whoop" and carries no
+/// address, but a re-added or second strap is "whoop-<MAC>". Kotlin twin: `HeaderRedactionTest`.
+final class HeaderRedactionTests: XCTestCase {
+
+    private let rawMac = try! NSRegularExpression(pattern: "[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}")
+
+    private func containsRawMac(_ s: String) -> Bool {
+        rawMac.firstMatch(in: s, range: NSRange(s.startIndex..., in: s)) != nil
+    }
+
+    func testADeviceIdLineCarryingABLEAddressIsMasked() {
+        let line = "  device id=whoop-F1:D4:F7:24:53:DE status=paired brand=WHOOP model=WHOOP 4.0 lastSeen=10m ago"
+        let safe = LiveState.redactPii(line)
+        XCTAssertFalse(containsRawMac(safe), "raw MAC survived: \(safe)")
+    }
+
+    func testTheFunnelsOrphanLineIsMaskedToo() {
+        // The line #1620 added prints ids for every id holding samples — the same exposure.
+        let line = "(no raw biometric samples under the ACTIVE id 'my-whoop' for this night — they are under "
+            + "'whoop-F1:D4:F7:24:53:DE' (4213 rows) instead."
+        XCTAssertFalse(containsRawMac(LiveState.redactPii(line)))
+    }
+
+    func testAnIdWithNoAddressIsUntouched() {
+        let line = "  device id=my-whoop status=ACTIVE brand=WHOOP model=WHOOP 4.0 lastSeen=3h 10m ago"
+        XCTAssertEqual(LiveState.redactPii(line), line)
+    }
+}

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -99,6 +99,19 @@ object AndroidDiagnostics {
             val merged = repo.daysMerged("my-whoop")
             add("Last sleep:  ${merged.lastOrNull { (it.totalSleepMin ?: 0.0) > 0.0 }?.let { "${it.day} · ${it.totalSleepMin?.toInt()} min" } ?: "none"}")
             add("Last recov.: ${merged.lastOrNull { it.recovery != null }?.let { "${it.day} · ${it.recovery?.toInt()}%" } ?: "none"}")
+            // #1300 follow-up: the header above describes ONE device because it reads the last-connected
+            // prefs, not the registry — so a two-strap install produced a log that never mentioned the
+            // second strap, leaving `dayOwner readId=` and the funnel's orphan check with nothing to be
+            // checked against. Name the whole set instead.
+            val invRows = runCatching {
+                (context.applicationContext as? com.noop.NoopApplication)?.deviceRegistry?.all().orEmpty()
+                    .map { InventoryRow(it.id, it.brand, it.model, it.status, it.lastSeenAt) }
+            }.getOrDefault(emptyList())
+            val invActive = runCatching {
+                (context.applicationContext as? com.noop.NoopApplication)?.deviceRegistry?.activeDeviceId()
+            }.getOrNull()
+            deviceInventoryLines(invRows, invActive, System.currentTimeMillis() / 1000L) { relTime(it) }
+                .forEach { add(it) }
         }.onFailure { add("(strap/data state unavailable: ${it.message})") }
     }
 

--- a/android/app/src/main/java/com/noop/testcentre/DeviceInventory.kt
+++ b/android/app/src/main/java/com/noop/testcentre/DeviceInventory.kt
@@ -1,0 +1,53 @@
+package com.noop.testcentre
+
+/** One registry row, reduced to what the inventory prints — see [deviceInventoryLines]. */
+internal data class InventoryRow(
+    val id: String,
+    val brand: String,
+    val model: String,
+    val status: String,
+    val lastSeenAt: Long,
+)
+
+/**
+ * The strap log's paired-device inventory: every registry row, which one is ACTIVE, and when each was
+ * last seen.
+ *
+ * The header above it describes a single device because it reads the last-connected PREFS rather than
+ * the registry, so a two-strap install produces a log that never mentions the second strap. That makes
+ * the id-bearing lines elsewhere — `dayOwner readId=…`, the funnel's orphan check — impossible to
+ * cross-check: a reader can see which id a day was read from but not which ids exist, nor which of them
+ * actually synced. Naming the set is what turns those lines into evidence.
+ *
+ * Sorted ACTIVE first, then by most-recently-seen, then by id: a stable order that puts the row a reader
+ * wants first at the top, and never depends on registry iteration order.
+ *
+ * Device ids embed a BLE address for a re-added strap, and the export's redaction masks the middle four
+ * octets while keeping the first and last — enough to tell two straps apart in a shared log without
+ * publishing an address. This line carries no data the log did not already carry.
+ *
+ * [nowSec] is passed in rather than read, so the output is a pure function of its inputs. Swift twin:
+ * `DebugDataDiagnostics.deviceInventoryLines`.
+ */
+internal fun deviceInventoryLines(
+    rows: List<InventoryRow>,
+    activeId: String?,
+    nowSec: Long,
+    relTime: (Long) -> String,
+): List<String> {
+    if (rows.isEmpty()) return listOf("Devices:     none registered")
+    val active = rows.count { it.status == "active" }
+    val paired = rows.count { it.status == "paired" }
+    val archived = rows.count { it.status == "archived" }
+    val head = "Devices:     ${rows.size} registered ($active active, $paired paired, $archived archived)"
+    val ordered = rows.sortedWith(
+        compareByDescending<InventoryRow> { it.id == activeId }
+            .thenByDescending { it.lastSeenAt }
+            .thenBy { it.id },
+    )
+    return listOf(head) + ordered.map { r ->
+        val marker = if (r.id == activeId) "ACTIVE" else r.status
+        val seen = if (r.lastSeenAt > 0L) relTime((nowSec - r.lastSeenAt) * 1000L) else "never"
+        "  device id=${r.id} status=$marker brand=${r.brand} model=${r.model} lastSeen=$seen"
+    }
+}

--- a/android/app/src/main/java/com/noop/testcentre/TestBundleAssembler.kt
+++ b/android/app/src/main/java/com/noop/testcentre/TestBundleAssembler.kt
@@ -106,7 +106,12 @@ object TestBundleAssembler {
         val header = buildString {
             appendLine("NOOP strap log")
             appendLine("App:     ${BuildConfig.VERSION_NAME} (${BuildConfig.TIER})")
-            for (line in AndroidDiagnostics.summaryLines(context)) appendLine(line)
+            // #453: the rolling BODY is scrubbed by WhoopBleClient.log(), but these HEADER lines never pass
+            // through it - and they carry device ids, which embed a BLE address for a re-added or second
+            // strap. Same redactor, so one export cannot be safe while the other leaks.
+            for (line in AndroidDiagnostics.summaryLines(context)) {
+                appendLine(com.noop.ble.redactStrapLogPii(line))
+            }
             appendLine("-".repeat(40))
         }
         val body = logText.ifBlank {

--- a/android/app/src/main/java/com/noop/testcentre/TestBundleAssembler.kt
+++ b/android/app/src/main/java/com/noop/testcentre/TestBundleAssembler.kt
@@ -106,12 +106,7 @@ object TestBundleAssembler {
         val header = buildString {
             appendLine("NOOP strap log")
             appendLine("App:     ${BuildConfig.VERSION_NAME} (${BuildConfig.TIER})")
-            // #453: the rolling BODY is scrubbed by WhoopBleClient.log(), but these HEADER lines never pass
-            // through it - and they carry device ids, which embed a BLE address for a re-added or second
-            // strap. Same redactor, so one export cannot be safe while the other leaks.
-            for (line in AndroidDiagnostics.summaryLines(context)) {
-                appendLine(com.noop.ble.redactStrapLogPii(line))
-            }
+            for (line in AndroidDiagnostics.summaryLines(context)) appendLine(line)
             appendLine("-".repeat(40))
         }
         val body = logText.ifBlank {

--- a/android/app/src/main/java/com/noop/ui/LogExport.kt
+++ b/android/app/src/main/java/com/noop/ui/LogExport.kt
@@ -138,8 +138,13 @@ object LogExport {
             val header = buildString {
                 appendLine("NOOP strap log (scheduled debug export)")
                 appendLine("App:     ${BuildConfig.VERSION_NAME} (${BuildConfig.TIER})")
-                for (line in com.noop.testcentre.AndroidDiagnostics.summaryLines(context)) appendLine(line)
-                for (line in dynamic) appendLine(line)
+                // #453: the rolling BODY is scrubbed by WhoopBleClient.log(), but these HEADER lines never pass
+                // through it - and they carry device ids, which embed a BLE address for a re-added or second
+                // strap. Same redactor, so one export cannot be safe while the other leaks.
+                for (line in com.noop.testcentre.AndroidDiagnostics.summaryLines(context)) {
+                    appendLine(com.noop.ble.redactStrapLogPii(line))
+                }
+                for (line in dynamic) appendLine(com.noop.ble.redactStrapLogPii(line))
                 appendLine("─".repeat(40))
             }
             val text = body.ifBlank { "(rolling strap-log buffer is empty; connect to your strap so lines accrue)" }
@@ -246,8 +251,13 @@ object LogExport {
         val header = buildString {
             appendLine("NOOP strap log")
             appendLine("App:     ${BuildConfig.VERSION_NAME} (${BuildConfig.TIER})")
-            for (line in com.noop.testcentre.AndroidDiagnostics.summaryLines(context)) appendLine(line)
-            for (line in dynamic) appendLine(line)
+            // #453: the rolling BODY is scrubbed by WhoopBleClient.log(), but these HEADER lines never pass
+            // through it - and they carry device ids, which embed a BLE address for a re-added or second
+            // strap. Same redactor, so one export cannot be safe while the other leaks.
+            for (line in com.noop.testcentre.AndroidDiagnostics.summaryLines(context)) {
+                appendLine(com.noop.ble.redactStrapLogPii(line))
+            }
+            for (line in dynamic) appendLine(com.noop.ble.redactStrapLogPii(line))
             appendLine("─".repeat(40))
         }
         val body = logText.ifBlank { "(strap log is empty; connect to your strap, reproduce the issue, then share again)" }

--- a/android/app/src/test/java/com/noop/testcentre/DeviceInventoryTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/DeviceInventoryTest.kt
@@ -1,0 +1,83 @@
+package com.noop.testcentre
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the paired-device inventory. Swift twin: `DeviceInventoryTests`.
+ *
+ * The block exists because the header above it reads the last-connected prefs rather than the registry,
+ * so a two-strap install produced a log that never mentioned the second strap.
+ */
+class DeviceInventoryTest {
+
+    // The same relTime the diagnostics use, inlined so the test is independent of that private helper.
+    private val rel: (Long) -> String = { ms ->
+        if (ms < 60_000L) "just now" else {
+            val m = ms / 60_000L
+            when {
+                m < 60 -> "${m}m ago"
+                m < 1440 -> "${m / 60}h ${m % 60}m ago"
+                else -> "${m / 1440}d ago"
+            }
+        }
+    }
+
+    private fun row(id: String, status: String, seen: Long, model: String = "WHOOP 4.0") =
+        InventoryRow(id, "WHOOP", model, status, seen)
+
+    @Test
+    fun `an empty registry says so rather than printing a bare header`() {
+        assertEquals(listOf("Devices:     none registered"), deviceInventoryLines(emptyList(), null, 1000L, rel))
+    }
+
+    @Test
+    fun `the active strap is marked and sorted first even when seen longest ago`() {
+        // The whole point: the ACTIVE row is the one a reader wants first, and it is NOT necessarily the
+        // most recently seen — switching straps leaves the old one with a fresher lastSeen.
+        val now = 100_000L
+        val lines = deviceInventoryLines(
+            listOf(
+                row("whoop-B", "paired", now - 600),
+                row("my-whoop", "active", now - 11_400, model = "WHOOP 5.0 / MG"),
+            ),
+            activeId = "my-whoop", nowSec = now, relTime = rel,
+        )
+        assertEquals(
+            listOf(
+                "Devices:     2 registered (1 active, 1 paired, 0 archived)",
+                "  device id=my-whoop status=ACTIVE brand=WHOOP model=WHOOP 5.0 / MG lastSeen=3h 10m ago",
+                "  device id=whoop-B status=paired brand=WHOOP model=WHOOP 4.0 lastSeen=10m ago",
+            ),
+            lines,
+        )
+    }
+
+    @Test
+    fun `a never-seen row reads never rather than a huge duration`() {
+        val lines = deviceInventoryLines(listOf(row("whoop-C", "paired", 0L)), null, 100_000L, rel)
+        assertEquals("  device id=whoop-C status=paired brand=WHOOP model=WHOOP 4.0 lastSeen=never", lines[1])
+    }
+
+    @Test
+    fun `counts split active paired and archived`() {
+        val now = 100_000L
+        val lines = deviceInventoryLines(
+            listOf(
+                row("a", "active", now - 60), row("b", "paired", now - 60),
+                row("c", "archived", now - 60), row("d", "archived", now - 60),
+            ),
+            "a", now, rel,
+        )
+        assertEquals("Devices:     4 registered (1 active, 1 paired, 2 archived)", lines[0])
+    }
+
+    @Test
+    fun `ties break on id so the order never depends on registry iteration`() {
+        val now = 100_000L
+        val lines = deviceInventoryLines(
+            listOf(row("zzz", "paired", now - 60), row("aaa", "paired", now - 60)), null, now, rel,
+        )
+        assertEquals(listOf("aaa", "zzz"), lines.drop(1).map { it.substringAfter("id=").substringBefore(" ") })
+    }
+}

--- a/android/app/src/test/java/com/noop/testcentre/HeaderRedactionTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/HeaderRedactionTest.kt
@@ -1,0 +1,44 @@
+package com.noop.testcentre
+
+import com.noop.ble.redactStrapLogPii
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #453: the strap-log HEADER is built from diagnostics lines that never pass through
+ * `WhoopBleClient.log()`'s scrub, so the export sites must redact them themselves.
+ *
+ * This pins the property that matters — a device id embedding a BLE address does not survive into a
+ * shareable header — rather than the call sites, which a refactor may legitimately move. It matters now
+ * that the header enumerates EVERY paired device: a single-strap install is "my-whoop" and carries no
+ * address, but a re-added or second strap is "whoop-<MAC>".
+ */
+class HeaderRedactionTest {
+
+    private val rawMac = Regex("[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}")
+
+    @Test
+    fun `a device-id line carrying a BLE address is masked`() {
+        val line = "  device id=whoop-F1:D4:F7:24:53:DE status=paired brand=WHOOP model=WHOOP 4.0 lastSeen=10m ago"
+        val safe = redactStrapLogPii(line)
+        assertFalse("raw MAC survived: $safe", rawMac.containsMatchIn(safe))
+        // Still identifiable enough to tell two straps apart in a shared log.
+        assertTrue(safe.contains("whoop-F1:"))
+        assertTrue(safe.endsWith(":DE status=paired brand=WHOOP model=WHOOP 4.0 lastSeen=10m ago"))
+    }
+
+    @Test
+    fun `the funnel's orphan line is masked too`() {
+        // The line #1620 added prints ids for every id holding samples — the same exposure.
+        val line = "(no raw biometric samples under the ACTIVE id 'my-whoop' for this night — they are under " +
+            "'whoop-F1:D4:F7:24:53:DE' (4213 rows) instead."
+        assertFalse(rawMac.containsMatchIn(redactStrapLogPii(line)))
+    }
+
+    @Test
+    fun `an id with no address is untouched`() {
+        val line = "  device id=my-whoop status=ACTIVE brand=WHOOP model=WHOOP 4.0 lastSeen=3h 10m ago"
+        assertTrue(redactStrapLogPii(line) == line)
+    }
+}


### PR DESCRIPTION
Two commits: a PII fix that turned out to be a prerequisite, then the feature.

## 1. The strap-log **header** was never redacted

The log body is scrubbed as it is appended — Android via `WhoopBleClient.log()`, Swift as each line enters the ring. The header is not. It is built from the diagnostics block and appended raw at the four **direct-share** export sites — Android `LogExport` (share + scheduled) and Swift `LiveState` (`exportableLogText` + `scheduledExportText`) — which bypass the bundle assembler entirely.

> **Correction from re-review:** an earlier draft of this PR said all bundle paths leaked too, and edited `TestBundleAssembler`. That was wrong — `assemble()` already re-scrubs every entry via `redactEntries`, on both platforms, and that file documents itself as "the single scrub point". The edit is reverted.

`LogExport`'s own comment records the assumption that hid the real gap:

> Lines are ALREADY PII-scrubbed by `WhoopBleClient.log()`, so no extra redaction here.

True of the body it describes; not true of the header beside it.

That header already prints device ids. A single-strap install is `my-whoop` and harmless — which is why this has gone unnoticed — but a **re-added or second strap is `whoop-<MAC>`**. So the funnel's `no raw biometric samples under '<id>'` line, and the orphan-id line #1620 added, can put a BLE address into a file whose entire purpose is being attached to a public issue.

Every header line now goes through the same redactor as the body. The mask keeps the first and last octet (`F1:••:••:••:••:DE`), so two straps stay distinguishable without publishing an address.

I found this while building the inventory below, which would have widened the exposure from *the active id* to *every id*. Both platforms had it; both are fixed.

## 2. Name every paired device

The `Strap & data` header reads the last-connected **prefs**, not the registry — so it can only ever describe one device. On a two-strap install the log never mentions the second at all, which leaves every id-bearing line uninterpretable: `dayOwner readId=…` tells you which id a day was read from, and the funnel's orphan check names the id holding a night's samples, but neither means anything without knowing which ids exist, which is active, and which actually synced.

```
Devices:     2 registered (1 active, 1 paired, 0 archived)
  device id=my-whoop status=ACTIVE brand=WHOOP model=WHOOP 5.0 / MG lastSeen=3h 10m ago
  device id=whoop-B status=paired brand=WHOOP model=WHOOP 4.0 lastSeen=10m ago
```

Sorted ACTIVE first, then most-recently-seen, then by id — stable, never dependent on registry iteration order. The active row is deliberately **not** assumed to be the most recently seen: switching straps leaves the old one with the fresher `lastSeen`, which is precisely the case this exists to make readable, and there is a test for it.

The `ACTIVE` marker compares against the registry's `activeDeviceId` rather than trusting the row's own `status` field. When those disagree — row says active, registry points elsewhere — the line shows it rather than hiding it. That divergence is a corruption a two-strap install can produce, and it should be visible.

## Parity

Byte-identical across five cases, **diffed rather than eyeballed** (Swift formatter extracted, compiled standalone, stdout diffed against the JVM's). `relTime` already agreed byte-for-byte between the platforms, so the durations match without a second implementation.

**One structural asymmetry, recorded deliberately:** Android's header block is `suspend` and reads the registry inline; Swift's `strapStateLines()` is sync and prefs-only *by contract* ("SYNC, offline-safe"), so the Swift inventory takes its own store handle inside the async `dynamicLines`. Same output, same position in the log, different seam — noted so nobody "aligns" them by making `strapStateLines()` async.

## A limitation on Apple, found in re-review

The ids the inventory prints redact differently on the two platforms, because they are minted
differently:

| | re-added strap id | after redaction |
|---|---|---|
| Android | `whoop-<MAC>` | `whoop-F1:••:••:••:••:DE` — two straps stay distinguishable |
| Apple | `whoop-<CoreBluetooth UUID>` | `whoop-<device>` — identical for every strap |

`redactPii`'s third rule masks a peripheral UUID wholesale, so on Apple every re-added strap reads
`whoop-<device>`. The inventory is still useful there — counts, statuses, models and `lastSeen` all
differ per row — but the **id cross-reference is not**: `dayOwner readId=` collapses to the same token,
so a row cannot be tied to the day that read it.

This is pre-existing (it is the redactor's behaviour, not this block's) and the inventory inherits it
rather than causing it. Not fixed here. The obvious remedy is a short stable non-identifying
discriminator beside the id — an FNV-1a of the id, per the cross-platform hashing rule, which survives
redaction because it is not the identifier — and that deserves its own change rather than being folded
into this one.

## Verification

- `compileFullDebugKotlin` clean; full `com.noop.testcentre` suite (**131 tests**) green.
- 5 JVM tests for the inventory + 3 for the redaction, each with a twinned `StrandTests` file.
- Redaction tests pin the **property** (no raw MAC survives a header line) rather than the call sites, since a refactor may legitimately move those — covering the device-id line, the #1620 orphan line, and an address-free id that must pass through untouched.
- `doc_comment_lint` and `i18n_audit --ci main` clean.
- **Needs app-build:** the Swift edits are app-target.