### PR TITLE
devices: attribute firmware to the strap it came from, not the last to connect

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/FirmwareGateDiagnostic.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/FirmwareGateDiagnostic.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Why a WHOOP 5/MG hello carried no firmware version, in enough detail to re-derive the offset.
+///
+/// The version is read as four bytes at `pay[93]`, guarded by `pay[93] == 50` ("5.0 generation"). Both
+/// the offset and the guard are anchored to a SINGLE capture at firmware 50.38.1.0, and the decoder's own
+/// comment says so: the name+token region ahead of the version is fixed-width *on that firmware*, and
+/// re-verifying the offset across firmwares is explicitly left as future work. The guards fail closed, so
+/// a strap that does not match simply reports nothing.
+///
+/// That silence has two very different causes and no way to tell them apart from a log:
+///  - the byte at 93 is not 50 — a different generation marker, offset probably still right;
+///  - the name+token region is a different width, so byte 93 is not the version at all and the offset has
+///    MOVED. This is the one the decoder comment warns about, and the one a user cannot diagnose.
+///
+/// So the line carries what distinguishes them: the payload length, the byte actually at 93, where the
+/// printable-ASCII device name ended (the run whose width shifts everything after it), and a hex window
+/// spanning the region the version should sit in. A capture from an undecoded strap then locates the real
+/// offset without another round trip.
+///
+/// Deliberately does NOT loosen the guard. Widening it blindly would render unrelated bytes as a version,
+/// which is worse than "unknown" because it looks authoritative.
+///
+/// Pure, and the window is clamped to the payload, so a short or malformed frame cannot trap. Kotlin
+/// twin: `com.noop.protocol.firmwareGateDiagnostic`.
+public func firmwareGateDiagnostic(payload: [UInt8], nameEndIndex: Int) -> String {
+    let at93 = payload.count > 93 ? String(payload[93]) : "n/a"
+    let lo = min(88, payload.count)
+    let hi = min(101, payload.count)
+    let window = lo < hi
+        ? payload[lo..<hi].map { String(format: "%02x", $0) }.joined()
+        : ""
+    return "fw gate: no version decoded — len=\(payload.count) at93=\(at93) expected=50"
+        + " nameEnd=\(nameEndIndex) hex[\(lo)..<\(hi)]=\(window)"
+}

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
@@ -838,6 +838,11 @@ private func decodeWhoop5CommandResponse(_ frame: [UInt8], fb: FieldBuilder, sch
         }
         if pay.count >= 97, pay[93] == 50 {
             fb.parsed["fw_version"] = .string("\(pay[93]).\(pay[94]).\(pay[95]).\(pay[96])")
+        } else {
+            // The guards fail closed by design, which left a strap reporting no firmware with no way to
+            // say WHY - a different generation byte and a MOVED offset look identical from a log. Carry
+            // the evidence instead; see `firmwareGateDiagnostic`.
+            fb.parsed["fw_gate"] = .string(firmwareGateDiagnostic(payload: pay, nameEndIndex: i))
         }
     }
 }

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/FirmwareGateDiagnosticTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/FirmwareGateDiagnosticTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import WhoopProtocol
+
+/// Pins the 5/MG firmware-gate diagnostic. Kotlin twin: `FirmwareGateDiagnosticTest`.
+///
+/// The decoder reads the version at pay[93] behind a `pay[93] == 50` guard, both anchored to a single
+/// 50.38.1.0 capture. The guards fail closed, so a strap that does not match reports nothing — and a
+/// different generation byte is indistinguishable from a MOVED offset unless the line says which.
+final class FirmwareGateDiagnosticTests: XCTestCase {
+
+    private func payload(count: Int, at93: UInt8) -> [UInt8] {
+        var p = (0..<count).map { UInt8($0 % 256) }
+        if count > 93 { p[93] = at93 }
+        return p
+    }
+
+    func testReportsTheByteItActuallySawAndTheExpectedOne() {
+        let line = firmwareGateDiagnostic(payload: payload(count: 128, at93: 51), nameEndIndex: 27)
+        XCTAssertTrue(line.contains("at93=51 expected=50"), line)
+        XCTAssertTrue(line.contains("len=128"), line)
+    }
+
+    func testCarriesTheNameEndBecauseThatIsWhatMovesTheOffset() {
+        // The version sits after the name+token region, so where the printable-ASCII name run ended is
+        // the number that lets a reader re-derive a shifted offset.
+        let line = firmwareGateDiagnostic(payload: payload(count: 128, at93: 51), nameEndIndex: 31)
+        XCTAssertTrue(line.contains("nameEnd=31"), line)
+    }
+
+    func testTheHexWindowSpansTheRegionTheVersionShouldOccupy() {
+        let line = firmwareGateDiagnostic(payload: payload(count: 128, at93: 51), nameEndIndex: 27)
+        XCTAssertTrue(line.contains("hex[88..<101]="), line)
+        // 13 bytes, two hex chars each.
+        let hex = line.components(separatedBy: "hex[88..<101]=").last ?? ""
+        XCTAssertEqual(hex.count, 26, hex)
+    }
+
+    func testAShortPayloadCannotTrapAndSaysSo() {
+        // A malformed/truncated hello must not crash the decoder; the window clamps and at93 reports n/a.
+        let line = firmwareGateDiagnostic(payload: [1, 2, 3], nameEndIndex: 2)
+        XCTAssertTrue(line.contains("at93=n/a"), line)
+        XCTAssertTrue(line.contains("len=3"), line)
+    }
+
+    func testAPayloadEndingExactlyAtTheWindowStartYieldsAnEmptyWindow() {
+        let line = firmwareGateDiagnostic(payload: Array(repeating: 0, count: 88), nameEndIndex: 20)
+        XCTAssertTrue(line.hasSuffix("hex[88..<88]="), line)
+    }
+}

--- a/Strand/BLE/FirmwareAttribution.swift
+++ b/Strand/BLE/FirmwareAttribution.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Which firmware string belongs to a device, given what is known about it.
+///
+/// The persisted firmware used to live under one global key, written on any WHOOP connect and read back
+/// for whichever strap was active. On a single-strap install those are the same strap, which is why it
+/// went unnoticed; with two straps paired it reports the OTHER strap's firmware — a WHOOP 5/MG showing a
+/// 4.0's 41.17.6.0 because the 4.0 connected last.
+///
+/// The rule, in order:
+///  - `live` wins: it came from THIS connection's handshake.
+///  - `perDevice` next: this device's own persisted value, from a previous connection.
+///  - `legacyGlobal` ONLY when `pairedCount` is 1. The old global key cannot say which strap it belongs
+///    to, so it is trustworthy exactly when there is only one strap it could have come from. This keeps a
+///    single-strap install reading correctly across the upgrade instead of showing "unknown" until the
+///    next connect; a multi-strap install refuses it, which is the bug.
+///  - otherwise nil — "not known yet" is the honest answer, and better than another strap's number.
+///
+/// Pure so the attribution is unit-tested without defaults, a strap, or a registry. Kotlin twin:
+/// `com.noop.ble.resolveFirmware`.
+enum FirmwareAttribution {
+
+    static func resolve(live: String?,
+                        perDevice: String?,
+                        legacyGlobal: String?,
+                        pairedCount: Int) -> String? {
+        if let live, !live.isBlank { return live }
+        if let perDevice, !perDevice.isBlank { return perDevice }
+        if let legacyGlobal, !legacyGlobal.isBlank, pairedCount == 1 { return legacyGlobal }
+        return nil
+    }
+
+    /// The per-device defaults key for a persisted firmware string.
+    ///
+    /// Keyed on the BLE peripheral identifier rather than the registry id: the BLE layer knows the
+    /// peripheral it connected to, and resolving it to a registry row there would repeat the mis-mapping
+    /// #1527 fixed for `lastSeen` (stamping "the active row" records a sighting of a strap that was never
+    /// connected). The registry row carries the same identifier, so the read side resolves without
+    /// guessing.
+    ///
+    /// Returns nil for a blank identifier, so a caller with none writes nothing rather than writing to a
+    /// key that belongs to no device.
+    static func prefKey(peripheralId: String?) -> String? {
+        guard let p = peripheralId?.trimmingCharacters(in: .whitespaces), !p.isEmpty else { return nil }
+        return "noop.lastFirmware.\(p.lowercased())"
+    }
+}
+
+private extension String {
+    var isBlank: Bool { trimmingCharacters(in: .whitespaces).isEmpty }
+}

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -18,12 +18,16 @@ public final class FrameRouter {
         // #900: a fresh connection is a fresh capture session — re-arm the per-command raw-frame dump so
         // each connect can re-capture the disputed COMMAND_RESPONSE prefix once. `family` is set fresh per
         // connection by BLEManager (connectCore), so this is the per-session reset hook.
-        didSet { rawDumpedRespCmds.removeAll() }
+        didSet { rawDumpedRespCmds.removeAll(); loggedFirmwareGate = nil }
     }
 
     /// #900: resp command names (e.g. "GET_BATTERY_LEVEL(26)") whose raw COMMAND_RESPONSE frame has already
     /// been dumped this connection. The provenance dump fires once per command per session so a 4.0's
     /// per-poll battery reads don't flood the strap log. Reset when `family` is set at connect.
+    /// #1634: last firmware-gate line logged, so a stable per-connection value is not repeated on every
+    /// hello. Cleared alongside the other per-connection routing state.
+    private var loggedFirmwareGate: String?
+
     private var rawDumpedRespCmds: Set<String> = []
 
     public init(state: LiveState) {
@@ -111,6 +115,14 @@ public final class FrameRouter {
                 state.strapFirmware = fw
                 // Persist so the debug export can name the firmware offline (state clears on disconnect).
                 UserDefaults.standard.set(fw, forKey: "noop.lastFirmware")
+            }
+
+            // #1634: the 5/MG hello decoded no firmware. The guards fail closed by design, so this is the
+            // only place that can say WHY - a different generation byte vs a MOVED offset. Logged once per
+            // connection (the value is stable), so a capture from an undecoded strap carries the evidence.
+            if let gate = parsed.parsed["fw_gate"]?.stringValue, loggedFirmwareGate != gate {
+                loggedFirmwareGate = gate
+                state.append(log: gate, domain: .connection)
             }
             // Advertising-name replies (WHOOP 4.0 / Harvard). GET (cmd 76) carries the current name in
             // its payload; SET (cmd 77) carries only a result byte. The schema has no field decode for

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -193,10 +193,18 @@ private struct DevicesContent: View {
                     // handshake, so a non-WHOOP active device (Oura) must NOT inherit it. Single last-connected-
                     // strap key, so a not-yet-connected active strap can briefly show the other strap's build on
                     // a multi-WHOOP install until it republishes. Twin of Android.
-                    liveFirmware: device.status == .active
-                        ? (live.strapFirmware
-                            ?? (SourceCoordinator.isWhoop(device) ? UserDefaults.standard.string(forKey: "noop.lastFirmware") : nil))
-                        : nil,
+                    // #1633 follow-up: resolve against THIS device, never the last strap to connect. The old
+                    // fallback read one global key, so with two straps paired a 5/MG reported the 4.0's firmware.
+                    // The legacy key is honoured only when a single device is paired, where it cannot belong to
+                    // anything else.
+                    liveFirmware: FirmwareAttribution.resolve(
+                        live: device.status == .active ? live.strapFirmware : nil,
+                        perDevice: SourceCoordinator.isWhoop(device)
+                            ? FirmwareAttribution.prefKey(peripheralId: device.peripheralId)
+                                .flatMap { UserDefaults.standard.string(forKey: $0) } : nil,
+                        legacyGlobal: SourceCoordinator.isWhoop(device)
+                            ? UserDefaults.standard.string(forKey: "noop.lastFirmware") : nil,
+                        pairedCount: registry.devices.count),
                     // Historical record layout (v24/v25 on WHOOP 4.0) observed from this connection's
                     // backfill. Distinct from the strap firmware build shown as FW.
                     liveHistoryLayout: (device.status == .active && live.connected) ? live.strapRange?.firmwareLayout : nil,

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -37,6 +37,12 @@ enum DebugDataDiagnostics {
         let model = WhoopModel(rawValue: d.string(forKey: "selectedWhoopModel") ?? "")?.displayName
             ?? "unknown (never paired)"
         lines.append("Model:       \(model)")
+        // NOTE: still the legacy GLOBAL key, and therefore the last strap to connect rather than this
+        // device's own firmware. strapStateLines is sync and prefs-only by contract (the scheduled export
+        // calls it with no store), and the per-device rule needs a registry read for pairedCount. The
+        // Devices block further down IS resolved per device, so a multi-strap export carries the correct
+        // per-device value there; this line is superseded by it and wants the same follow-up as the Apple
+        // write site, which has no peripheral identity to key on today.
         lines.append("Firmware:    \(d.string(forKey: "noop.lastFirmware") ?? "unknown (connect to record)")")
         let syncSec = d.double(forKey: "lastSyncedAt")
         lines.append("Last sync:   \(syncSec > 0 ? relTime(Date().timeIntervalSince1970 - syncSec) : "never")")
@@ -109,8 +115,20 @@ enum DebugDataDiagnostics {
         if let invStore = await repo.storeHandle() {
             let invRegistry = DeviceRegistryStore(dbQueue: invStore.registryWriter)
             let invRows = ((try? invRegistry.all()) ?? []).map {
+                // Firmware resolved by the same rule as the Devices card: this device's own persisted
+                // value when there is one, and the LEGACY global key only when a single device is paired
+                // (it cannot have come from anything else). Apple does not yet write the per-device key —
+                // the write site has no peripheral identity to key on — so today this yields the global
+                // value for a single-strap install and "unknown" for a multi-strap one, which is honest
+                // rather than another strap's number.
                 InventoryRow(id: $0.id, brand: $0.brand, model: $0.model,
-                             status: $0.status.rawValue, lastSeenAt: $0.lastSeenAt)
+                             status: $0.status.rawValue, lastSeenAt: $0.lastSeenAt,
+                             firmware: FirmwareAttribution.resolve(
+                                 live: nil,
+                                 perDevice: FirmwareAttribution.prefKey(peripheralId: $0.peripheralId)
+                                     .flatMap { UserDefaults.standard.string(forKey: $0) },
+                                 legacyGlobal: UserDefaults.standard.string(forKey: "noop.lastFirmware"),
+                                 pairedCount: invDevices.count))
             }
             let invActive = (try? invRegistry.activeDeviceId()) ?? nil
             lines.append(contentsOf: deviceInventoryLines(rows: invRows,

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -114,7 +114,11 @@ enum DebugDataDiagnostics {
         // the same position it holds on Android.
         if let invStore = await repo.storeHandle() {
             let invRegistry = DeviceRegistryStore(dbQueue: invStore.registryWriter)
-            let invRows = ((try? invRegistry.all()) ?? []).map {
+            // Bound before the map so the rule below has a count to test. Reading `.all()` inline left
+            // nothing to reference, which app-build caught and no local check could — this file needs
+            // macOS to compile.
+            let invDevices = (try? invRegistry.all()) ?? []
+            let invRows = invDevices.map {
                 // Firmware resolved by the same rule as the Devices card: this device's own persisted
                 // value when there is one, and the LEGACY global key only when a single device is paired
                 // (it cannot have come from anything else). Apple does not yet write the per-device key —

--- a/Strand/System/DeviceInventory.swift
+++ b/Strand/System/DeviceInventory.swift
@@ -7,6 +7,7 @@ struct InventoryRow {
     let model: String
     let status: String
     let lastSeenAt: Int
+    let firmware: String?
 }
 
 /// The strap log's paired-device inventory: every registry row, which one is ACTIVE, and when each was
@@ -46,5 +47,6 @@ func deviceInventoryLines(rows: [InventoryRow],
         let marker = r.id == activeId ? "ACTIVE" : r.status
         let seen = r.lastSeenAt > 0 ? relTime(Double(nowSec - r.lastSeenAt)) : "never"
         return "  device id=\(r.id) status=\(marker) brand=\(r.brand) model=\(r.model) lastSeen=\(seen)"
+            + " fw=\(r.firmware ?? "unknown")"
     }
 }

--- a/StrandTests/DeviceInventoryTests.swift
+++ b/StrandTests/DeviceInventoryTests.swift
@@ -17,8 +17,8 @@ final class DeviceInventoryTests: XCTestCase {
     }
 
     private func row(_ id: String, _ status: String, _ seen: Int,
-                     model: String = "WHOOP 4.0") -> InventoryRow {
-        InventoryRow(id: id, brand: "WHOOP", model: model, status: status, lastSeenAt: seen)
+                     model: String = "WHOOP 4.0", fw: String? = nil) -> InventoryRow {
+        InventoryRow(id: id, brand: "WHOOP", model: model, status: status, lastSeenAt: seen, firmware: fw)
     }
 
     func testAnEmptyRegistrySaysSoRatherThanPrintingABareHeader() {
@@ -36,8 +36,8 @@ final class DeviceInventoryTests: XCTestCase {
             activeId: "my-whoop", nowSec: now, relTime: rel)
         XCTAssertEqual(lines, [
             "Devices:     2 registered (1 active, 1 paired, 0 archived)",
-            "  device id=my-whoop status=ACTIVE brand=WHOOP model=WHOOP 5.0 / MG lastSeen=3h 10m ago",
-            "  device id=whoop-B status=paired brand=WHOOP model=WHOOP 4.0 lastSeen=10m ago",
+            "  device id=my-whoop status=ACTIVE brand=WHOOP model=WHOOP 5.0 / MG lastSeen=3h 10m ago fw=unknown",
+            "  device id=whoop-B status=paired brand=WHOOP model=WHOOP 4.0 lastSeen=10m ago fw=unknown",
         ])
     }
 
@@ -45,7 +45,7 @@ final class DeviceInventoryTests: XCTestCase {
         let lines = deviceInventoryLines(rows: [row("whoop-C", "paired", 0)],
                                          activeId: nil, nowSec: 100_000, relTime: rel)
         XCTAssertEqual(lines[1],
-                       "  device id=whoop-C status=paired brand=WHOOP model=WHOOP 4.0 lastSeen=never")
+                       "  device id=whoop-C status=paired brand=WHOOP model=WHOOP 4.0 lastSeen=never fw=unknown")
     }
 
     func testCountsSplitActivePairedAndArchived() {

--- a/StrandTests/FirmwareAttributionTests.swift
+++ b/StrandTests/FirmwareAttributionTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import Strand
+
+/// Pins firmware attribution. Kotlin twin: `FirmwareAttributionTest`.
+///
+/// The reported bug: a WHOOP 5/MG showed 41.17.6.0 — the 4.0's firmware — because the persisted value
+/// lived under ONE global key, written on any WHOOP connect and read back for whichever strap was active.
+final class FirmwareAttributionTests: XCTestCase {
+
+    func testLiveWinsOverEverything() {
+        XCTAssertEqual(FirmwareAttribution.resolve(live: "50.1.0.0", perDevice: "49.0.0.0",
+                                                   legacyGlobal: "41.17.6.0", pairedCount: 2), "50.1.0.0")
+    }
+
+    func testThisDevicesOwnPersistedValueBeatsTheLegacyGlobal() {
+        XCTAssertEqual(FirmwareAttribution.resolve(live: nil, perDevice: "50.1.0.0",
+                                                   legacyGlobal: "41.17.6.0", pairedCount: 2), "50.1.0.0")
+    }
+
+    func testTheLegacyGlobalIsRefusedWhenMoreThanOneDeviceIsPaired() {
+        // The exact reported bug: two straps, no per-device value yet for the active one, and the global
+        // key holds the other strap's firmware. nil is correct; 41.17.6.0 is not.
+        XCTAssertNil(FirmwareAttribution.resolve(live: nil, perDevice: nil,
+                                                 legacyGlobal: "41.17.6.0", pairedCount: 2))
+    }
+
+    func testTheLegacyGlobalIsHonouredForASingleDeviceInstall() {
+        XCTAssertEqual(FirmwareAttribution.resolve(live: nil, perDevice: nil,
+                                                   legacyGlobal: "41.17.6.0", pairedCount: 1), "41.17.6.0")
+    }
+
+    func testBlankValuesAreTreatedAsAbsentNotAsAnAnswer() {
+        XCTAssertEqual(FirmwareAttribution.resolve(live: "", perDevice: "   ",
+                                                   legacyGlobal: "41.17.6.0", pairedCount: 1), "41.17.6.0")
+        XCTAssertNil(FirmwareAttribution.resolve(live: "", perDevice: "", legacyGlobal: "", pairedCount: 1))
+    }
+
+    func testThePrefKeyIsPerDeviceAndCaseInsensitiveOnTheAddress() {
+        XCTAssertEqual(FirmwareAttribution.prefKey(peripheralId: "F1:D4:F7:24:53:DE"),
+                       "noop.lastFirmware.f1:d4:f7:24:53:de")
+        XCTAssertEqual(FirmwareAttribution.prefKey(peripheralId: "f1:d4:f7:24:53:de"),
+                       FirmwareAttribution.prefKey(peripheralId: "F1:D4:F7:24:53:DE"))
+    }
+
+    func testNoAddressMeansNoKey() {
+        XCTAssertNil(FirmwareAttribution.prefKey(peripheralId: nil))
+        XCTAssertNil(FirmwareAttribution.prefKey(peripheralId: "   "))
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/FirmwareAttribution.kt
+++ b/android/app/src/main/java/com/noop/ble/FirmwareAttribution.kt
@@ -1,0 +1,44 @@
+package com.noop.ble
+
+/**
+ * Which firmware string belongs to a device, given what is known about it.
+ *
+ * The persisted firmware used to live under one global key, written on any WHOOP connect and read back
+ * for whichever strap was active. On a single-strap install those are the same strap, which is why it
+ * went unnoticed; with two straps paired it reports the OTHER strap's firmware — a WHOOP 5/MG showing a
+ * 4.0's 41.17.6.0 because the 4.0 connected last.
+ *
+ * The rule, in order:
+ *  - [live] wins: it came from THIS connection's handshake.
+ *  - [perDevice] next: this device's own persisted value, from a previous connection.
+ *  - [legacyGlobal] ONLY when [pairedCount] is 1. The old global key cannot say which strap it belongs
+ *    to, so it is trustworthy exactly when there is only one strap it could have come from. This keeps a
+ *    single-strap install reading correctly across the upgrade instead of showing "unknown" until the
+ *    next connect; a multi-strap install refuses it, which is the bug.
+ *  - otherwise null — "not known yet" is the honest answer, and better than another strap's number.
+ *
+ * Pure so the attribution is unit-tested without prefs, a strap, or a registry. Swift twin:
+ * `FirmwareAttribution.resolve`.
+ */
+internal fun resolveFirmware(
+    live: String?,
+    perDevice: String?,
+    legacyGlobal: String?,
+    pairedCount: Int,
+): String? = live?.takeIf { it.isNotBlank() }
+    ?: perDevice?.takeIf { it.isNotBlank() }
+    ?: legacyGlobal?.takeIf { it.isNotBlank() && pairedCount == 1 }
+
+/**
+ * The per-device preference key for a persisted firmware string.
+ *
+ * Keyed on the BLE peripheral address rather than the registry id: the BLE client knows the address it
+ * connected to, and resolving it to a registry row there would repeat the mis-mapping #1527 fixed for
+ * `lastSeen` (stamping "the active row" records a sighting of a strap that was never connected). The
+ * registry row carries the same address, so the read side resolves without guessing.
+ *
+ * Returns null for a blank address, so a caller with no address writes nothing rather than writing to a
+ * key that belongs to no device.
+ */
+internal fun firmwarePrefKey(peripheralId: String?): String? =
+    peripheralId?.trim()?.takeIf { it.isNotEmpty() }?.let { "noop.lastFirmware.${it.lowercase()}" }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5852,14 +5852,15 @@ class WhoopBleClient(
                         runCatching { NoopPrefs.setFirmwareFor(context, lastDeviceAddress, fw) }
                     }
 
+                    }
+
                     // #1634: the 5/MG hello decoded no firmware. The guards fail closed by design, so this is the
                     // only place that can say WHY - a different generation byte vs a MOVED offset. Logged once per
                     // connection (the value is stable), so a capture from an undecoded strap carries the evidence.
                     (parsed.parsed["fw_gate"] as? String)?.let { gate ->
-                        if (loggedFirmwareGate != gate) {
-                            loggedFirmwareGate = gate
-                            log(gate)
-                        }
+                    if (loggedFirmwareGate != gate) {
+                    loggedFirmwareGate = gate
+                    log(gate)
                     }
                 }
                 val respCmd = parsed.parsed["resp_cmd"] as? String

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5842,7 +5842,10 @@ class WhoopBleClient(
                     if (_state.value.strapFirmware != fw) {
                         _state.update { it.copy(strapFirmware = fw) }
                         // Persist so the debug export can name the firmware offline (state clears on disconnect).
-                        runCatching { NoopPrefs.setLastFirmware(context, fw) }
+                        // Keyed by the address THIS connection used, not globally: a second strap would otherwise
+                        // overwrite the first's value and both would report whichever connected last - a 5/MG showing
+                        // a 4.0's 41.17.6.0.
+                        runCatching { NoopPrefs.setFirmwareFor(context, lastDeviceAddress, fw) }
                     }
                 }
                 val respCmd = parsed.parsed["resp_cmd"] as? String

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2185,6 +2185,10 @@ class WhoopBleClient(
     /// `batterySource(familyEstablished, connectedFamily)` is the correct order): seeing this true then
     /// establishes happens-before for the [connectedFamily] write that precedes it at discovery. Swapping
     /// the two parameters would silently drop that guarantee.
+    /** #1634: last firmware-gate line logged, so a stable per-connection value is not repeated on every
+     *  hello. Cleared in [reset] with the rest of the per-connection state. */
+    @Volatile private var loggedFirmwareGate: String? = null
+
     @Volatile private var familyEstablished = false
 
     /// The family actually discovered on the connected peripheral. Drives family-aware frame
@@ -5847,6 +5851,16 @@ class WhoopBleClient(
                         // a 4.0's 41.17.6.0.
                         runCatching { NoopPrefs.setFirmwareFor(context, lastDeviceAddress, fw) }
                     }
+
+                    // #1634: the 5/MG hello decoded no firmware. The guards fail closed by design, so this is the
+                    // only place that can say WHY - a different generation byte vs a MOVED offset. Logged once per
+                    // connection (the value is stable), so a capture from an undecoded strap carries the evidence.
+                    (parsed.parsed["fw_gate"] as? String)?.let { gate ->
+                        if (loggedFirmwareGate != gate) {
+                            loggedFirmwareGate = gate
+                            log(gate)
+                        }
+                    }
                 }
                 val respCmd = parsed.parsed["resp_cmd"] as? String
                 val result = parsed.parsed["result"] as? String
@@ -8289,6 +8303,7 @@ class WhoopBleClient(
         didBond = false
         connectHandshakeDone = false
         familyEstablished = false   // the next link re-establishes it at service discovery
+        loggedFirmwareGate = null
         seq.set(0)
         writeQueue.clear()
         cccdQueue.clear()

--- a/android/app/src/main/java/com/noop/protocol/FirmwareGateDiagnostic.kt
+++ b/android/app/src/main/java/com/noop/protocol/FirmwareGateDiagnostic.kt
@@ -1,0 +1,39 @@
+package com.noop.protocol
+
+/**
+ * Why a WHOOP 5/MG hello carried no firmware version, in enough detail to re-derive the offset.
+ *
+ * The version is read as four bytes at `pay[93]`, guarded by `pay[93] == 50` ("5.0 generation"). Both the
+ * offset and the guard are anchored to a SINGLE capture at firmware 50.38.1.0, and the decoder's own
+ * comment says so: the name+token region ahead of the version is fixed-width *on that firmware*, and
+ * re-verifying the offset across firmwares is explicitly left as future work. The guards fail closed, so
+ * a strap that does not match simply reports nothing.
+ *
+ * That silence has two very different causes and no way to tell them apart from a log:
+ *  - the byte at 93 is not 50 — a different generation marker, offset probably still right;
+ *  - the name+token region is a different width, so byte 93 is not the version at all and the offset has
+ *    MOVED. This is the one the decoder comment warns about, and the one a user cannot diagnose.
+ *
+ * So the line carries what distinguishes them: the payload length, the byte actually at 93, where the
+ * printable-ASCII device name ended (the run whose width shifts everything after it), and a hex window
+ * spanning the region the version should sit in. A capture from an undecoded strap then locates the real
+ * offset without another round trip.
+ *
+ * Deliberately does NOT loosen the guard. Widening it blindly would render unrelated bytes as a version,
+ * which is worse than "unknown" because it looks authoritative.
+ *
+ * Pure, and the window is clamped to the payload, so a short or malformed frame cannot trap. Swift twin:
+ * `WhoopProtocol.firmwareGateDiagnostic`.
+ */
+fun firmwareGateDiagnostic(payload: ByteArray, nameEndIndex: Int): String {
+    val at93 = if (payload.size > 93) (payload[93].toInt() and 0xFF).toString() else "n/a"
+    val lo = minOf(88, payload.size)
+    val hi = minOf(101, payload.size)
+    val window = if (lo < hi) {
+        payload.copyOfRange(lo, hi).joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+    } else {
+        ""
+    }
+    return "fw gate: no version decoded — len=${payload.size} at93=$at93 expected=50" +
+        " nameEnd=$nameEndIndex hex[$lo..<$hi]=$window"
+}

--- a/android/app/src/main/java/com/noop/protocol/Framing.kt
+++ b/android/app/src/main/java/com/noop/protocol/Framing.kt
@@ -376,6 +376,11 @@ object Framing {
                 if (pay.size >= 97 && (pay[93].toInt() and 0xFF) == 50) {
                     parsed["fw_version"] = "${pay[93].toInt() and 0xFF}.${pay[94].toInt() and 0xFF}." +
                         "${pay[95].toInt() and 0xFF}.${pay[96].toInt() and 0xFF}"
+                } else {
+                    // The guards fail closed by design, which left a strap reporting no firmware with no way to
+                    // say WHY - a different generation byte and a MOVED offset look identical from a log. Carry
+                    // the evidence instead; see [firmwareGateDiagnostic].
+                    parsed["fw_gate"] = firmwareGateDiagnostic(pay, i)
                 }
             }
         }

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -71,7 +71,23 @@ object AndroidDiagnostics {
                     else -> reportedModel(context)?.displayName ?: "unknown (paired, family not yet detected)"
                 },
             )
-            add("Firmware:    ${com.noop.ui.NoopPrefs.lastFirmware(context) ?: "unknown (connect to record)"}")
+            // #1633 follow-up: the ACTIVE device's own firmware. This read used to be the bare global key,
+            // so a two-strap log named whichever strap connected last - a 5/MG log reporting a 4.0's
+            // 41.17.6.0. resolveFirmware falls back to the legacy key only when one device is paired.
+            val fwRows = runCatching {
+                (context.applicationContext as? com.noop.NoopApplication)?.deviceRegistry?.all().orEmpty()
+            }.getOrDefault(emptyList())
+            val fwActive = runCatching {
+                (context.applicationContext as? com.noop.NoopApplication)?.deviceRegistry?.activeDeviceId()
+            }.getOrNull()
+            val fwRow = fwRows.firstOrNull { it.id == fwActive }
+            val fw = com.noop.ble.resolveFirmware(
+                live = null,
+                perDevice = com.noop.ui.NoopPrefs.firmwareFor(context, fwRow?.peripheralId),
+                legacyGlobal = com.noop.ui.NoopPrefs.lastFirmware(context),
+                pairedCount = fwRows.size,
+            )
+            add("Firmware:    ${fw ?: "unknown (connect to record)"}")
             val syncSec = com.noop.ui.NoopPrefs.lastSyncAt(context)
             add("Last sync:   ${if (syncSec > 0L) relTime(System.currentTimeMillis() - syncSec * 1000L) else "never"}")
             // #57: write-health. "Last sync" fires even on an empty/failed offload, so distinguish "rows
@@ -105,7 +121,10 @@ object AndroidDiagnostics {
             // checked against. Name the whole set instead.
             val invRows = runCatching {
                 (context.applicationContext as? com.noop.NoopApplication)?.deviceRegistry?.all().orEmpty()
-                    .map { InventoryRow(it.id, it.brand, it.model, it.status, it.lastSeenAt) }
+                    .map {
+                            InventoryRow(it.id, it.brand, it.model, it.status, it.lastSeenAt,
+                                         com.noop.ui.NoopPrefs.firmwareFor(context, it.peripheralId))
+                        }
             }.getOrDefault(emptyList())
             val invActive = runCatching {
                 (context.applicationContext as? com.noop.NoopApplication)?.deviceRegistry?.activeDeviceId()

--- a/android/app/src/main/java/com/noop/testcentre/DeviceInventory.kt
+++ b/android/app/src/main/java/com/noop/testcentre/DeviceInventory.kt
@@ -7,6 +7,7 @@ internal data class InventoryRow(
     val model: String,
     val status: String,
     val lastSeenAt: Long,
+    val firmware: String? = null,
 )
 
 /**
@@ -48,6 +49,7 @@ internal fun deviceInventoryLines(
     return listOf(head) + ordered.map { r ->
         val marker = if (r.id == activeId) "ACTIVE" else r.status
         val seen = if (r.lastSeenAt > 0L) relTime((nowSec - r.lastSeenAt) * 1000L) else "never"
-        "  device id=${r.id} status=$marker brand=${r.brand} model=${r.model} lastSeen=$seen"
+        "  device id=${r.id} status=$marker brand=${r.brand} model=${r.model} lastSeen=$seen" +
+            " fw=${r.firmware ?: "unknown"}"
     }
 }

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -258,10 +258,18 @@ fun DevicesScreen(
                 // WHOOP-only: `noop.lastFirmware` is written solely from a WHOOP handshake, so a non-WHOOP
                 // active device (Oura/FTMS) must NOT inherit it. Single-key, so on a multi-WHOOP install a
                 // not-yet-connected active strap can briefly show the other strap's build until it republishes.
-                liveFirmware = if (device.status == DeviceStatus.active.name)
-                    (live.strapFirmware
-                        ?: if (device.brand.equals("WHOOP", ignoreCase = true)) NoopPrefs.lastFirmware(context) else null)
-                    else null,
+                // #1633 follow-up: resolve against THIS device, never the last strap to connect. The old
+                // fallback read one global key, so with two straps paired the 5/MG reported the 4.0's
+                // firmware. The legacy key is still honoured when exactly one device is paired - then it
+                // cannot belong to anything else - so a single-strap install does not regress to 'unknown'.
+                liveFirmware = com.noop.ble.resolveFirmware(
+                    live = if (device.status == DeviceStatus.active.name) live.strapFirmware else null,
+                    perDevice = if (device.brand.equals("WHOOP", ignoreCase = true))
+                        NoopPrefs.firmwareFor(context, device.peripheralId) else null,
+                    legacyGlobal = if (device.status == DeviceStatus.active.name &&
+                        device.brand.equals("WHOOP", ignoreCase = true)) NoopPrefs.lastFirmware(context) else null,
+                    pairedCount = all.size,
+                ),
                 // Historical record layout from the current backfill, distinct from strap firmware.
                 liveHistoryLayout = if (device.status == DeviceStatus.active.name && live.connected)
                     live.historyLayoutVersion else null,

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -1265,6 +1265,20 @@ object NoopPrefs {
             if (fw.isNullOrBlank()) remove(KEY_LAST_FIRMWARE) else putString(KEY_LAST_FIRMWARE, fw)
         }.apply()
     }
+
+    /** This device's own persisted firmware, keyed by BLE address - see [com.noop.ble.firmwarePrefKey].
+     *  Null when nothing was ever recorded for that device. */
+    fun firmwareFor(context: Context, peripheralId: String?): String? =
+        com.noop.ble.firmwarePrefKey(peripheralId)?.let { of(context).getString(it, null) }
+
+    /** Record a firmware string against the device it came from. A blank address writes nothing rather
+     *  than writing to a key that belongs to no device. */
+    fun setFirmwareFor(context: Context, peripheralId: String?, fw: String?) {
+        val key = com.noop.ble.firmwarePrefKey(peripheralId) ?: return
+        of(context).edit().apply {
+            if (fw.isNullOrBlank()) remove(key) else putString(key, fw)
+        }.apply()
+    }
 }
 
 /**

--- a/android/app/src/test/java/com/noop/ble/FirmwareAttributionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/FirmwareAttributionTest.kt
@@ -1,0 +1,56 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins firmware attribution. Swift twin: `FirmwareAttributionTests`.
+ *
+ * The reported bug: a WHOOP 5/MG showed 41.17.6.0 — the 4.0's firmware — because the persisted value
+ * lived under ONE global key, written on any WHOOP connect and read back for whichever strap was active.
+ */
+class FirmwareAttributionTest {
+
+    @Test
+    fun `live wins over everything`() {
+        assertEquals("50.1.0.0", resolveFirmware("50.1.0.0", "49.0.0.0", "41.17.6.0", 2))
+    }
+
+    @Test
+    fun `this device's own persisted value beats the legacy global`() {
+        assertEquals("50.1.0.0", resolveFirmware(null, "50.1.0.0", "41.17.6.0", 2))
+    }
+
+    @Test
+    fun `the legacy global is REFUSED when more than one device is paired`() {
+        // The exact reported bug: two straps, no per-device value yet for the active one, and the global
+        // key holds the other strap's firmware. "unknown" is correct; 41.17.6.0 is not.
+        assertNull(resolveFirmware(null, null, "41.17.6.0", 2))
+    }
+
+    @Test
+    fun `the legacy global is honoured for a single-device install`() {
+        // It cannot have come from anything else, so a single-strap install does not regress to
+        // "unknown" on upgrade before the next connect.
+        assertEquals("41.17.6.0", resolveFirmware(null, null, "41.17.6.0", 1))
+    }
+
+    @Test
+    fun `blank values are treated as absent, not as an answer`() {
+        assertEquals("41.17.6.0", resolveFirmware("", "   ", "41.17.6.0", 1))
+        assertNull(resolveFirmware("", "", "", 1))
+    }
+
+    @Test
+    fun `the pref key is per-device and case-insensitive on the address`() {
+        assertEquals("noop.lastFirmware.f1:d4:f7:24:53:de", firmwarePrefKey("F1:D4:F7:24:53:DE"))
+        assertEquals(firmwarePrefKey("f1:d4:f7:24:53:de"), firmwarePrefKey("F1:D4:F7:24:53:DE"))
+    }
+
+    @Test
+    fun `no address means no key, so nothing is written to a key owned by no device`() {
+        assertNull(firmwarePrefKey(null))
+        assertNull(firmwarePrefKey("   "))
+    }
+}

--- a/android/app/src/test/java/com/noop/protocol/FirmwareGateDiagnosticTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/FirmwareGateDiagnosticTest.kt
@@ -1,0 +1,55 @@
+package com.noop.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the 5/MG firmware-gate diagnostic. Swift twin: `FirmwareGateDiagnosticTests`.
+ *
+ * The decoder reads the version at pay[93] behind a `pay[93] == 50` guard, both anchored to a single
+ * 50.38.1.0 capture. The guards fail closed, so a strap that does not match reports nothing — and a
+ * different generation byte is indistinguishable from a MOVED offset unless the line says which.
+ */
+class FirmwareGateDiagnosticTest {
+
+    private fun payload(count: Int, at93: Int): ByteArray {
+        val p = ByteArray(count) { (it % 256).toByte() }
+        if (count > 93) p[93] = at93.toByte()
+        return p
+    }
+
+    @Test
+    fun `reports the byte it actually saw and the expected one`() {
+        val line = firmwareGateDiagnostic(payload(128, 51), 27)
+        assertTrue(line, line.contains("at93=51 expected=50"))
+        assertTrue(line, line.contains("len=128"))
+    }
+
+    @Test
+    fun `carries the name end because that is what moves the offset`() {
+        // The version sits after the name+token region, so where the printable-ASCII name run ended is
+        // the number that lets a reader re-derive a shifted offset.
+        assertTrue(firmwareGateDiagnostic(payload(128, 51), 31).contains("nameEnd=31"))
+    }
+
+    @Test
+    fun `the hex window spans the region the version should occupy`() {
+        val line = firmwareGateDiagnostic(payload(128, 51), 27)
+        assertTrue(line, line.contains("hex[88..<101]="))
+        assertEquals(26, line.substringAfter("hex[88..<101]=").length)
+    }
+
+    @Test
+    fun `a short payload cannot trap and says so`() {
+        // A malformed/truncated hello must not crash the decoder; the window clamps and at93 reports n/a.
+        val line = firmwareGateDiagnostic(byteArrayOf(1, 2, 3), 2)
+        assertTrue(line, line.contains("at93=n/a"))
+        assertTrue(line, line.contains("len=3"))
+    }
+
+    @Test
+    fun `a payload ending exactly at the window start yields an empty window`() {
+        assertTrue(firmwareGateDiagnostic(ByteArray(88), 20).endsWith("hex[88..<88]="))
+    }
+}

--- a/android/app/src/test/java/com/noop/testcentre/DeviceInventoryTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/DeviceInventoryTest.kt
@@ -23,8 +23,9 @@ class DeviceInventoryTest {
         }
     }
 
-    private fun row(id: String, status: String, seen: Long, model: String = "WHOOP 4.0") =
-        InventoryRow(id, "WHOOP", model, status, seen)
+    private fun row(id: String, status: String, seen: Long, model: String = "WHOOP 4.0",
+                    fw: String? = null) =
+        InventoryRow(id, "WHOOP", model, status, seen, fw)
 
     @Test
     fun `an empty registry says so rather than printing a bare header`() {
@@ -46,8 +47,8 @@ class DeviceInventoryTest {
         assertEquals(
             listOf(
                 "Devices:     2 registered (1 active, 1 paired, 0 archived)",
-                "  device id=my-whoop status=ACTIVE brand=WHOOP model=WHOOP 5.0 / MG lastSeen=3h 10m ago",
-                "  device id=whoop-B status=paired brand=WHOOP model=WHOOP 4.0 lastSeen=10m ago",
+                "  device id=my-whoop status=ACTIVE brand=WHOOP model=WHOOP 5.0 / MG lastSeen=3h 10m ago fw=unknown",
+                "  device id=whoop-B status=paired brand=WHOOP model=WHOOP 4.0 lastSeen=10m ago fw=unknown",
             ),
             lines,
         )
@@ -56,7 +57,7 @@ class DeviceInventoryTest {
     @Test
     fun `a never-seen row reads never rather than a huge duration`() {
         val lines = deviceInventoryLines(listOf(row("whoop-C", "paired", 0L)), null, 100_000L, rel)
-        assertEquals("  device id=whoop-C status=paired brand=WHOOP model=WHOOP 4.0 lastSeen=never", lines[1])
+        assertEquals("  device id=whoop-C status=paired brand=WHOOP model=WHOOP 4.0 lastSeen=never fw=unknown", lines[1])
     }
 
     @Test


### PR DESCRIPTION
## The report

A WHOOP 5/MG shows **41.17.6.0** in the Devices window — the 4.0's firmware.

## Cause

The persisted firmware lives under one global key, `noop.lastFirmware`, written on any WHOOP connect and read back for whichever strap is active:

```kotlin
liveFirmware = if (device.status == active) (live.strapFirmware ?: NoopPrefs.lastFirmware(context))
```

On a single-strap install those are the same strap, which is why it went unnoticed. With two paired, the fallback reports the other one. The comment above that line states the assumption plainly — *"fall back to the last-known persisted firmware … when the live value is momentarily null"* — sound for one strap, wrong for two.

The **strap log had it worse**: its header printed that global key with no live value and no device qualification at all, so a 5/MG log named a 4.0's firmware outright.

## The rule

One shared resolution, twinned:

1. **live** handshake value — it came from *this* connection.
2. else **this device's own** persisted value.
3. else the **legacy global, only when a single device is paired** — where it cannot have come from anything else. This is what stops an existing install regressing to "unknown" on upgrade.
4. else nothing. "Unknown" is a better answer than another strap's number.

The reported bug is a test: two straps, no per-device value, global present → `null`.

## Android: wired end to end

The write is keyed by the address **this connection** used — mirroring #1527's rule that a stamp belongs to the identity the strap adopted, not to whatever is active now, which is the same mis-mapping in a different coat. The Devices card, the strap-log header and the #1633 inventory all read per device, and the inventory line gains `fw=`:

```
device id=my-whoop status=ACTIVE brand=WHOOP model=WHOOP 5.0 / MG lastSeen=3h 10m ago fw=50.1.0.0
device id=whoop-B  status=paired brand=WHOOP model=WHOOP 4.0      lastSeen=10m ago    fw=41.17.6.0
```

## Apple: correct, not yet complete — and why

`FrameRouter` has **no peripheral identity** to key a write on, and `LiveState` carries none either. Giving it one is a BLE-path change that wants its own review and hardware verification, so it is not folded in here.

Until then Apple writes nothing per-device, and the same rule simply **refuses the global key whenever more than one device is paired**. So Apple stops mis-attributing today without yet being able to say more — the failure mode becomes "unknown", never "the other strap's firmware".

One place still reads the raw global: Swift's `strapStateLines` header, which is **sync and prefs-only by contract** (the scheduled export calls it with no store) while the rule needs a registry read for `pairedCount`. It is marked in place and superseded by the Devices block in the same export.

## Verification

- Both platforms **byte-identical across nine attribution cases and the inventory line**, diffed rather than eyeballed.
- 7 attribution + 5 inventory tests per platform, confirmed present on the pushed branch, not just locally.
- `compileFullDebugKotlin` clean; **138 JVM tests** green; `doc_comment_lint` and `i18n_audit --ci main` clean.
- **Needs app-build:** Swift edits are app-target.
