### PR TITLE
ble: report what became of a 5/MG CLIENT_HELLO write

### DIFF
--- a/Strand/BLE/ClientHelloOutcome.swift
+++ b/Strand/BLE/ClientHelloOutcome.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// What became of a WHOOP 5/MG CLIENT_HELLO write.
+///
+/// A capture could not previously distinguish the three ways the 5/MG bond fails, because two of them
+/// produce no line at all. In one field capture 14 of 16 CLIENT_HELLO writes went out and were never
+/// acked, 1 was rejected by the stack, and 1 produced an "ack" — from a completion the code never checked
+/// the characteristic of (#1635). From the log those look the same: silence, then a link drop.
+///
+/// The three outcomes, and why each matters:
+///  - acked by the hello characteristic: the only one that is genuinely an ack.
+///  - a completion from a DIFFERENT characteristic while the bond is pending: the ack branch matches on
+///    family alone, so this is what silently sets `encryptedBond` on a strap that never bonded — and the
+///    line names the characteristic that did it.
+///  - no callback at all before the link dropped: the dominant case in the field capture, and the one
+///    with no evidence today.
+///
+/// Reports only what it observed; it does not attribute blame between the strap and the local stack,
+/// because a write callback that never arrives cannot distinguish "the strap declined to respond" from
+/// "the frame never reached the air". Naming the gap is what makes that answerable next.
+///
+/// `status` is passed pre-rendered so each platform supplies its own, leaving the line shape identical.
+/// Pure. Kotlin twin: `com.noop.ble.clientHelloOutcomeLine`.
+enum ClientHelloOutcome {
+    static func line(isHelloChar: Bool, charUuid: String?, elapsedMs: Int, status: String?) -> String {
+        guard let charUuid else {
+            return "CLIENT_HELLO outcome: NO write callback after \(elapsedMs)ms — the link dropped before"
+                + " the stack reported, so the strap may never have seen it"
+        }
+        let where_ = charUuid.trimmingCharacters(in: .whitespaces).isEmpty ? "unknown" : charUuid
+        let st = (status?.trimmingCharacters(in: .whitespaces).isEmpty == false) ? " \(status!)" : ""
+        if isHelloChar {
+            return "CLIENT_HELLO outcome: acked by \(where_) after \(elapsedMs)ms\(st)"
+        }
+        return "CLIENT_HELLO outcome: bond declared from a DIFFERENT characteristic \(where_) after"
+            + " \(elapsedMs)ms\(st) — this is NOT a CLIENT_HELLO ack (#1635)"
+    }
+}

--- a/StrandTests/ClientHelloOutcomeTests.swift
+++ b/StrandTests/ClientHelloOutcomeTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import Strand
+
+/// Pins the CLIENT_HELLO outcome line (#1635). Kotlin twin: `ClientHelloOutcomeTest`.
+final class ClientHelloOutcomeTests: XCTestCase {
+
+    private let hello = "fd4b0002-cce1-4033-93ce-002d5875f58a"
+
+    func testACompletionFromTheHelloCharacteristicIsARealAck() {
+        XCTAssertEqual(
+            ClientHelloOutcome.line(isHelloChar: true, charUuid: hello, elapsedMs: 120,
+                                    status: "status=SUCCESS(0)"),
+            "CLIENT_HELLO outcome: acked by \(hello) after 120ms status=SUCCESS(0)")
+    }
+
+    func testACompletionFromAnotherCharacteristicIsNamedNotCountedAsAnAck() {
+        let line = ClientHelloOutcome.line(isHelloChar: false,
+                                           charUuid: "00002a19-0000-1000-8000-00805f9b34fb",
+                                           elapsedMs: 40, status: "status=SUCCESS(0)")
+        XCTAssertTrue(line.contains("DIFFERENT characteristic 00002a19-0000-1000-8000-00805f9b34fb"), line)
+        XCTAssertTrue(line.contains("NOT a CLIENT_HELLO ack"), line)
+        XCTAssertFalse(line.contains("outcome: acked"), line)
+    }
+
+    func testNoCallbackAtAllIsReportedWithTheElapsedTime() {
+        XCTAssertEqual(
+            ClientHelloOutcome.line(isHelloChar: false, charUuid: nil, elapsedMs: 3200, status: nil),
+            "CLIENT_HELLO outcome: NO write callback after 3200ms — the link dropped before the stack"
+            + " reported, so the strap may never have seen it")
+    }
+
+    func testANilCharacteristicWinsOverTheIsHelloCharFlag() {
+        XCTAssertTrue(ClientHelloOutcome.line(isHelloChar: true, charUuid: nil, elapsedMs: 10,
+                                              status: "status=SUCCESS(0)").contains("NO write callback"))
+    }
+
+    func testABlankCharacteristicAndStatusDegradeWithoutPunctuationDebris() {
+        XCTAssertEqual(
+            ClientHelloOutcome.line(isHelloChar: true, charUuid: "   ", elapsedMs: 5, status: "  "),
+            "CLIENT_HELLO outcome: acked by unknown after 5ms")
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/ClientHelloOutcome.kt
+++ b/android/app/src/main/java/com/noop/ble/ClientHelloOutcome.kt
@@ -1,0 +1,46 @@
+package com.noop.ble
+
+/**
+ * What became of a WHOOP 5/MG CLIENT_HELLO write.
+ *
+ * A capture could not previously distinguish the three ways the 5/MG bond fails, because two of them
+ * produce no line at all. In one field capture 14 of 16 CLIENT_HELLO writes went out and were never
+ * acked, 1 was rejected by the stack, and 1 produced an "ack" — from a completion the code never checked
+ * the characteristic of (#1635). From the log those look the same: silence, then a link drop.
+ *
+ * The three outcomes, and why each matters:
+ *  - [helloAcked]: the completion came from the CLIENT_HELLO characteristic itself. The only one that is
+ *    genuinely an ack.
+ *  - [foreignAck]: a completion arrived from a DIFFERENT characteristic while the bond was still
+ *    pending. The ack branch matches on family alone, so this is what silently sets `encryptedBond` on a
+ *    strap that never bonded — and the line names the characteristic that did it.
+ *  - [noCallback]: the write was accepted by the stack and no completion ever arrived before the link
+ *    dropped. This is the dominant case in the field capture, and the one with no evidence at all today.
+ *
+ * Reports only what it observed; it does not attribute blame between the strap and the local stack,
+ * because a write callback that never arrives cannot distinguish "the strap declined to respond" from
+ * "the frame never reached the air". Naming the gap is what makes that answerable next.
+ *
+ * [status] is passed pre-rendered so each platform supplies its own (Android's BluetoothStatusCodes
+ * label, CoreBluetooth's error description), leaving the line shape identical. Pure. Swift twin:
+ * `ClientHelloOutcome.line`.
+ */
+internal fun clientHelloOutcomeLine(
+    isHelloChar: Boolean,
+    charUuid: String?,
+    elapsedMs: Long,
+    status: String?,
+): String {
+    val where = charUuid?.takeIf { it.isNotBlank() } ?: "unknown"
+    val st = status?.takeIf { it.isNotBlank() }?.let { " $it" } ?: ""
+    return when {
+        charUuid == null ->
+            "CLIENT_HELLO outcome: NO write callback after ${elapsedMs}ms — the link dropped before the" +
+                " stack reported, so the strap may never have seen it"
+        isHelloChar ->
+            "CLIENT_HELLO outcome: acked by $where after ${elapsedMs}ms$st"
+        else ->
+            "CLIENT_HELLO outcome: bond declared from a DIFFERENT characteristic $where after" +
+                " ${elapsedMs}ms$st — this is NOT a CLIENT_HELLO ack (#1635)"
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/ClientHelloOutcome.kt
+++ b/android/app/src/main/java/com/noop/ble/ClientHelloOutcome.kt
@@ -44,3 +44,34 @@ internal fun clientHelloOutcomeLine(
                 " ${elapsedMs}ms$st — this is NOT a CLIENT_HELLO ack (#1635)"
     }
 }
+
+/**
+ * A `BluetoothGatt.GATT_*` status from `onCharacteristicWrite`, labelled.
+ *
+ * NOT [WhoopBleClient.writeStatusLabel], which maps `BluetoothStatusCodes` — the return value of
+ * `writeCharacteristic`, a different enumeration that collides with this one on small integers. Passing a
+ * callback status through that mapper renders GATT_INVALID_HANDLE(1) as "ERROR_BLUETOOTH_NOT_ENABLED",
+ * GATT_READ_NOT_PERMITTED(2) as "ERROR_BLUETOOTH_NOT_ALLOWED" and GATT_WRITE_NOT_PERMITTED(3) as
+ * "ERROR_DEVICE_NOT_BONDED" — confidently wrong names in a line whose whole job is explaining a bond
+ * failure, which is worse than printing no name at all.
+ *
+ * Names the codes that matter for a bond and leaves the rest as bare numbers rather than guessing:
+ * INSUFFICIENT_AUTHENTICATION and INSUFFICIENT_ENCRYPTION are exactly "the strap refused the encrypted
+ * bond" (the pair [BondRefusalGiveUp] already keys on), and 133 is the catch-all Android returns for a
+ * link that went away underneath the operation.
+ *
+ * Android-only by design: CoreBluetooth reports `didWriteValueFor` with an `Error`, not a status code,
+ * which is why the outcome line takes its status pre-rendered.
+ */
+internal fun gattWriteStatusLabel(status: Int?): String = when (status) {
+    null -> "status=n/a"
+    0 -> "status=GATT_SUCCESS(0)"
+    3 -> "status=GATT_WRITE_NOT_PERMITTED(3)"
+    5 -> "status=GATT_INSUFFICIENT_AUTHENTICATION(5)"
+    13 -> "status=GATT_INVALID_ATTRIBUTE_LENGTH(13)"
+    15 -> "status=GATT_INSUFFICIENT_ENCRYPTION(15)"
+    133 -> "status=GATT_ERROR(133)"
+    257 -> "status=GATT_FAILURE(257)"
+    else -> "status=$status"
+}
+

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2187,6 +2187,10 @@ class WhoopBleClient(
     /// the two parameters would silently drop that guarantee.
     /** #1634: last firmware-gate line logged, so a stable per-connection value is not repeated on every
      *  hello. Cleared in [reset] with the rest of the per-connection state. */
+    /** #1635: when the 5/MG CLIENT_HELLO write was issued, so its completion - or the absence of one -
+     *  can be reported with an elapsed time. 0 means none is outstanding. Cleared in [reset]. */
+    @Volatile private var clientHelloWriteAtMs: Long = 0L
+
     @Volatile private var loggedFirmwareGate: String? = null
 
     @Volatile private var familyEstablished = false
@@ -5334,6 +5338,19 @@ class WhoopBleClient(
                     )
                 }
             } else if (!didBond && connectedFamily == DeviceFamily.WHOOP5) {
+                // #1635: report WHICH characteristic completed. This branch matches on family alone, so a
+                // completion from any other characteristic is currently taken as the CLIENT_HELLO ack - the
+                // line says so rather than the behaviour changing here, so a capture can size how often it
+                // happens before the guard is tightened.
+                if (clientHelloWriteAtMs > 0L) {
+                    log(clientHelloOutcomeLine(
+                        isHelloChar = characteristic.uuid == WHOOP5_CMD_WRITE_CHAR,
+                        charUuid = characteristic.uuid.toString(),
+                        elapsedMs = System.currentTimeMillis() - clientHelloWriteAtMs,
+                        status = writeStatusLabel(status),
+                    ))
+                    clientHelloWriteAtMs = 0L
+                }
                 // EXPERIMENTAL (issue #17): the CLIENT_HELLO is now a confirmed write, so this ACK means
                 // just-works bonding completed. Now subscribe the puffin notify chars (realtime HR rides
                 // these as REALTIME_DATA — the strap rejected them on the unauthenticated link), then arm
@@ -7099,12 +7116,14 @@ class WhoopBleClient(
         // Hold the slot until the ACK; the opt-in puffin probe now fires post-bond (onCharacteristicWrite).
         log("WHOOP 5/MG: writing CLIENT_HELLO to fd4b0002 with response (to trigger bonding, experimental).")
         writeInFlight = true
+        clientHelloWriteAtMs = System.currentTimeMillis()
         val ok = safeGatt("writeClientHello") {
             ops.writeCharacteristicCompat(ch, hello, BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT)
         }
         if (!ok) {
             writeInFlight = false
             log("CLIENT_HELLO write rejected by stack")
+            clientHelloWriteAtMs = 0L   // never went out; no callback is owed
         }
     }
 
@@ -8016,6 +8035,12 @@ class WhoopBleClient(
         // #1151: flush any pending frame-timing window so the frames right before this drop are recorded
         // (not stranded), and the next connection starts a fresh window rather than spanning the gap. No-op
         // when capture is off. Do it BEFORE the connect-down line so the summary reads before the drop.
+        // #1635: a CLIENT_HELLO that was accepted by the stack and never completed leaves no trace at
+        // all - the dominant shape in the field capture (14 of 16). Say so before the state is reset.
+        if (clientHelloWriteAtMs > 0L) {
+            log(clientHelloOutcomeLine(false, null, System.currentTimeMillis() - clientHelloWriteAtMs, null))
+            clientHelloWriteAtMs = 0L
+        }
         flushFrameTimingSummary()
         // #1263: flush the durable strap-log tail so a completed session's last partial batch survives to a
         // later export even if the process is killed before the next 32-line mirror (twin of iOS's flush on
@@ -8305,6 +8330,7 @@ class WhoopBleClient(
         connectHandshakeDone = false
         familyEstablished = false   // the next link re-establishes it at service discovery
         loggedFirmwareGate = null
+        clientHelloWriteAtMs = 0L
         seq.set(0)
         writeQueue.clear()
         cccdQueue.clear()

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5347,7 +5347,7 @@ class WhoopBleClient(
                         isHelloChar = characteristic.uuid == WHOOP5_CMD_WRITE_CHAR,
                         charUuid = characteristic.uuid.toString(),
                         elapsedMs = System.currentTimeMillis() - clientHelloWriteAtMs,
-                        status = writeStatusLabel(status),
+                        status = gattWriteStatusLabel(status),
                     ))
                     clientHelloWriteAtMs = 0L
                 }
@@ -8032,15 +8032,16 @@ class WhoopBleClient(
 
     @SuppressLint("MissingPermission")
     private fun handleDisconnect(status: Int) {
-        // #1151: flush any pending frame-timing window so the frames right before this drop are recorded
-        // (not stranded), and the next connection starts a fresh window rather than spanning the gap. No-op
-        // when capture is off. Do it BEFORE the connect-down line so the summary reads before the drop.
         // #1635: a CLIENT_HELLO that was accepted by the stack and never completed leaves no trace at
         // all - the dominant shape in the field capture (14 of 16). Say so before the state is reset.
         if (clientHelloWriteAtMs > 0L) {
             log(clientHelloOutcomeLine(false, null, System.currentTimeMillis() - clientHelloWriteAtMs, null))
             clientHelloWriteAtMs = 0L
         }
+
+        // #1151: flush any pending frame-timing window so the frames right before this drop are recorded
+        // (not stranded), and the next connection starts a fresh window rather than spanning the gap. No-op
+        // when capture is off. Do it BEFORE the connect-down line so the summary reads before the drop.
         flushFrameTimingSummary()
         // #1263: flush the durable strap-log tail so a completed session's last partial batch survives to a
         // later export even if the process is killed before the next 32-line mirror (twin of iOS's flush on

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2187,11 +2187,11 @@ class WhoopBleClient(
     /// the two parameters would silently drop that guarantee.
     /** #1634: last firmware-gate line logged, so a stable per-connection value is not repeated on every
      *  hello. Cleared in [reset] with the rest of the per-connection state. */
+    @Volatile private var loggedFirmwareGate: String? = null
+
     /** #1635: when the 5/MG CLIENT_HELLO write was issued, so its completion - or the absence of one -
      *  can be reported with an elapsed time. 0 means none is outstanding. Cleared in [reset]. */
     @Volatile private var clientHelloWriteAtMs: Long = 0L
-
-    @Volatile private var loggedFirmwareGate: String? = null
 
     @Volatile private var familyEstablished = false
 

--- a/android/app/src/test/java/com/noop/ble/ClientHelloOutcomeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ClientHelloOutcomeTest.kt
@@ -57,4 +57,32 @@ class ClientHelloOutcomeTest {
             clientHelloOutcomeLine(true, "   ", 5, "  "),
         )
     }
+
+    @Test
+    fun `the GATT labeller names the bond-refusal codes, not the write-request ones`() {
+        // The bug this guards: writeStatusLabel maps BluetoothStatusCodes (writeCharacteristic's return
+        // value), a DIFFERENT enumeration that collides on small integers. Rendering a callback status
+        // through it names the wrong error confidently.
+        assertEquals("status=GATT_INSUFFICIENT_AUTHENTICATION(5)", gattWriteStatusLabel(5))
+        assertEquals("status=GATT_INSUFFICIENT_ENCRYPTION(15)", gattWriteStatusLabel(15))
+        assertEquals("status=GATT_SUCCESS(0)", gattWriteStatusLabel(0))
+    }
+
+    @Test
+    fun `the two mappers disagree on the colliding codes, which is the point`() {
+        // 1/2/3 mean different things in each enumeration. If these ever agree, one of the mappers has
+        // been changed to cover the wrong domain.
+        for (code in listOf(1, 2, 3)) {
+            assertTrue(
+                "code $code should not share a label across the two domains",
+                gattWriteStatusLabel(code) != WhoopBleClient.writeStatusLabel(code),
+            )
+        }
+    }
+
+    @Test
+    fun `an unknown code is a bare number rather than a guess`() {
+        assertEquals("status=99", gattWriteStatusLabel(99))
+        assertEquals("status=n/a", gattWriteStatusLabel(null))
+    }
 }

--- a/android/app/src/test/java/com/noop/ble/ClientHelloOutcomeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ClientHelloOutcomeTest.kt
@@ -1,0 +1,60 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the CLIENT_HELLO outcome line (#1635). Swift twin: `ClientHelloOutcomeTests`.
+ *
+ * In one field capture, 14 of 16 CLIENT_HELLO writes went out and were never acked, 1 was rejected, and
+ * 1 produced an "ack" from a completion whose characteristic was never checked. All three looked the
+ * same from a log: silence, then a link drop.
+ */
+class ClientHelloOutcomeTest {
+
+    private val hello = "fd4b0002-cce1-4033-93ce-002d5875f58a"
+
+    @Test
+    fun `a completion from the hello characteristic is a real ack`() {
+        assertEquals(
+            "CLIENT_HELLO outcome: acked by $hello after 120ms status=SUCCESS(0)",
+            clientHelloOutcomeLine(true, hello, 120, "status=SUCCESS(0)"),
+        )
+    }
+
+    @Test
+    fun `a completion from another characteristic is named, not counted as an ack`() {
+        // The reported false bond: the branch matches on family alone, so DISABLE_ALARM's completion was
+        // taken as the hello ack. The line must name the characteristic and refuse the word "acked".
+        val line = clientHelloOutcomeLine(false, "00002a19-0000-1000-8000-00805f9b34fb", 40, "status=SUCCESS(0)")
+        assertTrue(line, line.contains("DIFFERENT characteristic 00002a19-0000-1000-8000-00805f9b34fb"))
+        assertTrue(line, line.contains("NOT a CLIENT_HELLO ack"))
+        assertTrue(line, !line.contains("outcome: acked"))
+    }
+
+    @Test
+    fun `no callback at all is reported with the elapsed time`() {
+        // The dominant field case, and the one that previously produced no line whatsoever.
+        assertEquals(
+            "CLIENT_HELLO outcome: NO write callback after 3200ms — the link dropped before the stack" +
+                " reported, so the strap may never have seen it",
+            clientHelloOutcomeLine(false, null, 3200, null),
+        )
+    }
+
+    @Test
+    fun `a null characteristic wins over the isHelloChar flag`() {
+        // Defensive: "no callback" is decided by the absent characteristic, so a stale true flag cannot
+        // turn silence into a reported ack.
+        assertTrue(clientHelloOutcomeLine(true, null, 10, "status=SUCCESS(0)").contains("NO write callback"))
+    }
+
+    @Test
+    fun `a blank characteristic and a blank status degrade without punctuation debris`() {
+        assertEquals(
+            "CLIENT_HELLO outcome: acked by unknown after 5ms",
+            clientHelloOutcomeLine(true, "   ", 5, "  "),
+        )
+    }
+}


### PR DESCRIPTION
Follow-up to the analysis on #1635. A capture cannot currently distinguish the three ways a WHOOP 5/MG bond fails, because two of them produce **no line at all**.

From one field capture, across 16 `CLIENT_HELLO` writes:

| outcome | count | evidence in the log today |
|---|---|---|
| written, never acked | **14** | none — silence, then a drop |
| rejected by the stack | 1 | one line |
| "acked" from an unchecked completion | 1 | reads as a successful bond |

All three look identical from outside: nothing, then `Disconnected (status=22)`, ten times over.

## The change

Report the outcome at both points that know it:

```
CLIENT_HELLO outcome: acked by fd4b0002-… after 120ms status=SUCCESS(0)
CLIENT_HELLO outcome: bond declared from a DIFFERENT characteristic 00002a19-… after 40ms status=SUCCESS(0) — this is NOT a CLIENT_HELLO ack
CLIENT_HELLO outcome: NO write callback after 3200ms — the link dropped before the stack reported, so the strap may never have seen it
```

The middle line is the false bond from #1635 — **named, not fixed**. The ack branch matches on family alone, so any pre-bond completion currently sets `encryptedBond`; tightening that guard changes bonding behaviour on a path that cannot be tested without hardware. Size it first, then decide. Same order used for the beat-accuracy gate (#1632) and the firmware gate (#1634).

The line also **does not attribute blame** for the missing callbacks. A write completion that never arrives cannot distinguish "the strap declined to respond" from "the frame never reached the air" — naming the gap is what makes that answerable next.

## Parity

`status` is passed **pre-rendered** so each platform supplies its own — the `GATT_*` codes `onCharacteristicWrite` delivers on Android, CoreBluetooth's error on Swift — leaving the line shape identical. Byte-identical across five cases, diffed rather than eyeballed. **5 twinned tests each**, including two degradation cases: a null characteristic must beat a stale `isHelloChar` flag (so silence can never be reported as an ack), and blank inputs must not leave punctuation debris.

Android carries **3 further tests** for the GATT status labeller, which is Android-only by design — CoreBluetooth reports an `Error`, not a status code, so there is nothing to label on that side. One of them asserts that labeller **disagrees** with `writeStatusLabel` on codes 1/2/3: those are two different enumerations (`BluetoothGatt.GATT_*` vs `BluetoothStatusCodes`) that collide on small integers, and an earlier revision of this PR rendered callback statuses through the wrong one — printing `ERROR_DEVICE_NOT_BONDED(3)` for what is actually `GATT_WRITE_NOT_PERMITTED`. If the two mappers ever agree, one has been pointed at the wrong domain.

**Android is wired at both points; Swift ships the formatter and tests only.** CoreBluetooth reports `didWriteValueFor` with an `Error` rather than a status code, and the no-callback case needs a timer rather than a disconnect hook — that seam differs enough to want its own change rather than being guessed at here.

## Verification

- `compileFullDebugKotlin` clean; full `com.noop.ble` suite (**429 tests**) green.
- `doc_comment_lint` and `i18n_audit --ci main` clean.
- **Needs app-build:** the Swift file is app-target.

One process note recorded in the history rather than hidden: `doc_comment_lint` failed on the first commit and I pushed anyway, because I ran it in the same command as the commit instead of gating on it. Fixed in the follow-up commit, along with the cause — a new field inserted at a neighbour's *declaration* line lands its doc below the neighbour's, silently rebinding both.