### PR TITLE
ble: observe the OS pairing flow, which NOOP has never watched

### DIFF
--- a/android/app/src/main/java/com/noop/ble/BondStateTrace.kt
+++ b/android/app/src/main/java/com/noop/ble/BondStateTrace.kt
@@ -50,3 +50,34 @@ internal fun bondStateTraceLine(
     }
     return "bond state: ${bondStateName(previous)} -> ${bondStateName(current)} device=$who$since$note"
 }
+
+/**
+ * Should this bond-state transition be traced at all?
+ *
+ * The receiver hears EVERY pairing on the phone - headphones, a car kit, a colleague's keyboard - and
+ * the strap log is a file people attach to public issues. Recording unrelated pairings there is both
+ * noise in a fixed-size rolling buffer and information about devices that have nothing to do with NOOP,
+ * so the trace is scoped to the strap this app is talking to.
+ *
+ * Matched case-insensitively for the same reason [SourceCoordinator] matches addresses that way: the
+ * stored form and the broadcast form can differ in case, and a case-sensitive compare would silently
+ * trace nothing at all - the failure mode that looks exactly like "the pairing never happened", which is
+ * one of the two answers this trace exists to distinguish.
+ *
+ * An event with NO address is traced only while a CLIENT_HELLO is outstanding: that is the window this
+ * exists to observe, and outside it an anonymous transition cannot be attributed to us.
+ *
+ * Pure so the scoping rule is unit-tested without a radio.
+ */
+internal fun shouldTraceBondState(
+    eventAddress: String?,
+    strapAddress: String?,
+    helloOutstanding: Boolean,
+): Boolean {
+    val ev = eventAddress?.trim().orEmpty()
+    val ours = strapAddress?.trim().orEmpty()
+    if (ev.isEmpty()) return helloOutstanding
+    if (ours.isEmpty()) return false
+    return ev.equals(ours, ignoreCase = true)
+}
+

--- a/android/app/src/main/java/com/noop/ble/BondStateTrace.kt
+++ b/android/app/src/main/java/com/noop/ble/BondStateTrace.kt
@@ -1,0 +1,52 @@
+package com.noop.ble
+
+import android.bluetooth.BluetoothDevice
+
+/** A `BluetoothDevice.BOND_*` constant, named. Unknown values print as-is rather than as a guess. */
+internal fun bondStateName(state: Int): String = when (state) {
+    BluetoothDevice.BOND_NONE -> "BOND_NONE"
+    BluetoothDevice.BOND_BONDING -> "BOND_BONDING"
+    BluetoothDevice.BOND_BONDED -> "BOND_BONDED"
+    else -> "BOND_$state"
+}
+
+/**
+ * One line per OS bond-state transition, with how long after the CLIENT_HELLO write it happened.
+ *
+ * NOOP has never observed `ACTION_BOND_STATE_CHANGED`, so the OS pairing flow has been invisible. That
+ * is the gap that leaves #1635 undecided: a WHOOP 5/MG shows every CLIENT_HELLO going unacknowledged and
+ * the link torn down locally on a clockwork timer (mean 3158 ms, 10 ms spread over nine attempts), and
+ * two explanations fit equally well —
+ *
+ *  - the confirmed write to an encryption-requiring characteristic triggers OS pairing, which fails or
+ *    times out and takes the link with it. Then this line shows `BOND_NONE -> BOND_BONDING` shortly
+ *    after the write and `BOND_BONDING -> BOND_NONE` at the teardown, and the question is answered.
+ *  - the write never triggers pairing at all. Then the device never enters `BOND_BONDING`, the absence
+ *    is just as conclusive, and the cause lies elsewhere entirely.
+ *
+ * Both readings need the same evidence and neither can be inferred from what the log carries today,
+ * which is why this observes rather than concludes.
+ *
+ * [sinceHelloMs] is null when no CLIENT_HELLO is outstanding — a transition from an unrelated pairing
+ * (another app, another device) then carries no elapsed time rather than a misleading one measured from
+ * a write it has nothing to do with.
+ *
+ * Pure so the wording is unit-tested without a radio. Android-only: CoreBluetooth performs pairing
+ * opaquely and exposes no equivalent transition, so there is nothing to twin.
+ */
+internal fun bondStateTraceLine(
+    previous: Int,
+    current: Int,
+    address: String?,
+    sinceHelloMs: Long?,
+): String {
+    val who = address?.takeIf { it.isNotBlank() } ?: "unknown"
+    val since = sinceHelloMs?.let { " ${it}ms after CLIENT_HELLO" } ?: ""
+    val note = when {
+        previous == BluetoothDevice.BOND_BONDING && current == BluetoothDevice.BOND_NONE ->
+            " — pairing did NOT complete"
+        current == BluetoothDevice.BOND_BONDED -> " — paired"
+        else -> ""
+    }
+    return "bond state: ${bondStateName(previous)} -> ${bondStateName(current)} device=$who$since$note"
+}

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2202,7 +2202,9 @@ class WhoopBleClient(
     /** #1635: record an OS bond-state transition in the strap log. The OS pairing flow has never been
      *  observed, which is what leaves the 5/MG bond failure undecided - see [bondStateTraceLine]. */
     fun onBondStateChanged(previous: Int, current: Int, address: String?) {
-        log(bondStateTraceLine(previous, current, address, msSinceClientHello))
+        val since = msSinceClientHello
+        if (!shouldTraceBondState(address, lastDeviceAddress, since != null)) return
+        log(bondStateTraceLine(previous, current, address, since))
     }
 
     @Volatile private var familyEstablished = false

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2193,6 +2193,18 @@ class WhoopBleClient(
      *  can be reported with an elapsed time. 0 means none is outstanding. Cleared in [reset]. */
     @Volatile private var clientHelloWriteAtMs: Long = 0L
 
+    /** #1635: ms since the CLIENT_HELLO write, or null when none is outstanding. Lets the bond-state
+     *  observer time a pairing transition against the write that may have triggered it, and report no
+     *  elapsed time at all for a transition belonging to some other pairing. */
+    val msSinceClientHello: Long?
+        get() = clientHelloWriteAtMs.takeIf { it > 0L }?.let { System.currentTimeMillis() - it }
+
+    /** #1635: record an OS bond-state transition in the strap log. The OS pairing flow has never been
+     *  observed, which is what leaves the 5/MG bond failure undecided - see [bondStateTraceLine]. */
+    fun onBondStateChanged(previous: Int, current: Int, address: String?) {
+        log(bondStateTraceLine(previous, current, address, msSinceClientHello))
+    }
+
     @Volatile private var familyEstablished = false
 
     /// The family actually discovered on the connected peripheral. Drives family-aware frame

--- a/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
@@ -6,6 +6,7 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
 import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -213,6 +214,23 @@ class WhoopConnectionService : Service() {
     private val repo get() = (application as NoopApplication).repository
 
     /**
+     * Watches the OS PAIRING flow (#1635). NOOP has never observed ACTION_BOND_STATE_CHANGED, so whether a
+     * CLIENT_HELLO triggers pairing at all - and whether that pairing fails - has been invisible. A WHOOP
+     * 5/MG shows every CLIENT_HELLO unacknowledged and the link torn down locally on a clockwork timer;
+     * seeing BOND_NONE -> BOND_BONDING -> BOND_NONE across that window decides it, and seeing no transition
+     * at all decides it the other way. Registered and unregistered alongside [bluetoothStateReceiver].
+     */
+    private val bondStateReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action != BluetoothDevice.ACTION_BOND_STATE_CHANGED) return
+            val dev: BluetoothDevice? = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE)
+            val cur = intent.getIntExtra(BluetoothDevice.EXTRA_BOND_STATE, BluetoothDevice.ERROR)
+            val prev = intent.getIntExtra(BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE, BluetoothDevice.ERROR)
+            runCatching { ble.onBondStateChanged(prev, cur, dev?.address) }
+        }
+    }
+
+    /**
      * Watches the OS Bluetooth radio so turning it off immediately tears down NOOP's orphaned GATT
      * link (#314). Without this there is no ACTION_STATE_CHANGED listener at all, so the radio going off
      * never reaches [WhoopBleClient] — the link stays "connected", the UI keeps showing live HR/buzz/sync
@@ -233,8 +251,9 @@ class WhoopConnectionService : Service() {
         }
     }
 
-    /** True once [bluetoothStateReceiver] is registered, so repeat onStartCommands don't double-register
-     *  (which would later throw on a single unregister). */
+    /** True once [bluetoothStateReceiver] and [bondStateReceiver] are registered, so repeat
+     *  onStartCommands don't double-register (which would later throw on a single unregister). Both
+     *  register together and unregister together, so one flag covers the pair. */
     private var bluetoothReceiverRegistered = false
 
     override fun onBind(intent: Intent?): IBinder? = null
@@ -265,6 +284,16 @@ class WhoopConnectionService : Service() {
                     this,
                     bluetoothStateReceiver,
                     IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED),
+                    ContextCompat.RECEIVER_NOT_EXPORTED,
+                )
+
+                // #1635: same lifecycle and the same registration form as the radio receiver above - the FGS
+                // owns the connection, so the pairing flow is only interesting while it is alive, and both are
+                // torn down together in onDestroy.
+                ContextCompat.registerReceiver(
+                    this,
+                    bondStateReceiver,
+                    IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED),
                     ContextCompat.RECEIVER_NOT_EXPORTED,
                 )
             }.onSuccess { bluetoothReceiverRegistered = true }
@@ -650,6 +679,7 @@ class WhoopConnectionService : Service() {
             // unregisterReceiver throws if it was never registered; the flag guards that, and runCatching
             // covers the rare case the OS already reclaimed it.
             runCatching { unregisterReceiver(bluetoothStateReceiver) }
+            runCatching { unregisterReceiver(bondStateReceiver) }
             bluetoothReceiverRegistered = false
         }
         scope.cancel()

--- a/android/app/src/test/java/com/noop/ble/BondStateTraceTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BondStateTraceTest.kt
@@ -2,6 +2,7 @@ package com.noop.ble
 
 import android.bluetooth.BluetoothDevice
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -62,5 +63,33 @@ class BondStateTraceTest {
     fun `a missing address degrades to unknown`() {
         assertTrue(bondStateTraceLine(10, 11, null, null).contains("device=unknown"))
         assertTrue(bondStateTraceLine(10, 11, "  ", null).contains("device=unknown"))
+    }
+
+    @Test
+    fun `an unrelated device's pairing is never traced`() {
+        // The receiver hears every pairing on the phone. The strap log is attached to public issues, so
+        // a colleague's headphones must not appear in it.
+        assertFalse(shouldTraceBondState("AA:BB:CC:DD:EE:FF", "FD:D4:F7:24:53:4A", helloOutstanding = true))
+        assertFalse(shouldTraceBondState("AA:BB:CC:DD:EE:FF", "FD:D4:F7:24:53:4A", helloOutstanding = false))
+    }
+
+    @Test
+    fun `our strap matches case-insensitively`() {
+        // A case-sensitive compare would trace NOTHING — which looks exactly like "the pairing never
+        // happened", one of the two answers this trace exists to tell apart.
+        assertTrue(shouldTraceBondState("fd:d4:f7:24:53:4a", "FD:D4:F7:24:53:4A", helloOutstanding = false))
+        assertTrue(shouldTraceBondState("FD:D4:F7:24:53:4A", "fd:d4:f7:24:53:4a", helloOutstanding = true))
+    }
+
+    @Test
+    fun `an anonymous event is traced only inside the handshake window`() {
+        assertTrue(shouldTraceBondState(null, "FD:D4", helloOutstanding = true))
+        assertFalse(shouldTraceBondState(null, "FD:D4", helloOutstanding = false))
+        assertFalse(shouldTraceBondState("  ", "FD:D4", helloOutstanding = false))
+    }
+
+    @Test
+    fun `with no strap address, an addressed event is not ours to trace`() {
+        assertFalse(shouldTraceBondState("AA:BB", null, helloOutstanding = true))
     }
 }

--- a/android/app/src/test/java/com/noop/ble/BondStateTraceTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BondStateTraceTest.kt
@@ -1,0 +1,66 @@
+package com.noop.ble
+
+import android.bluetooth.BluetoothDevice
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the OS bond-state trace (#1635).
+ *
+ * NOOP has never observed ACTION_BOND_STATE_CHANGED, so whether a CLIENT_HELLO triggers pairing at all —
+ * and whether that pairing fails — has been invisible. Both readings decide the open question, so the
+ * line has to be equally clear about a transition happening and about one not happening.
+ */
+class BondStateTraceTest {
+
+    @Test
+    fun `a failed pairing is called out, not left to be inferred`() {
+        assertEquals(
+            "bond state: BOND_BONDING -> BOND_NONE device=FD:D4:F7:24:53:4A 3158ms after CLIENT_HELLO" +
+                " — pairing did NOT complete",
+            bondStateTraceLine(BluetoothDevice.BOND_BONDING, BluetoothDevice.BOND_NONE,
+                "FD:D4:F7:24:53:4A", 3158),
+        )
+    }
+
+    @Test
+    fun `entering bonding is reported with its offset from the write that may have caused it`() {
+        assertEquals(
+            "bond state: BOND_NONE -> BOND_BONDING device=FD:D4:F7:24:53:4A 120ms after CLIENT_HELLO",
+            bondStateTraceLine(BluetoothDevice.BOND_NONE, BluetoothDevice.BOND_BONDING,
+                "FD:D4:F7:24:53:4A", 120),
+        )
+    }
+
+    @Test
+    fun `a success says so`() {
+        assertTrue(
+            bondStateTraceLine(BluetoothDevice.BOND_BONDING, BluetoothDevice.BOND_BONDED, "AA:BB", 900)
+                .endsWith("— paired"),
+        )
+    }
+
+    @Test
+    fun `no outstanding hello means no elapsed time rather than a misleading one`() {
+        // A transition from an unrelated pairing (another app, another device) must not be timed against
+        // a CLIENT_HELLO it has nothing to do with.
+        assertEquals(
+            "bond state: BOND_NONE -> BOND_BONDING device=AA:BB",
+            bondStateTraceLine(BluetoothDevice.BOND_NONE, BluetoothDevice.BOND_BONDING, "AA:BB", null),
+        )
+    }
+
+    @Test
+    fun `an unknown state prints its number rather than a guess`() {
+        assertTrue(bondStateTraceLine(99, BluetoothDevice.BOND_NONE, "AA:BB", null).contains("BOND_99"))
+        assertEquals("BOND_NONE", bondStateName(BluetoothDevice.BOND_NONE))
+        assertEquals("BOND_BONDED", bondStateName(BluetoothDevice.BOND_BONDED))
+    }
+
+    @Test
+    fun `a missing address degrades to unknown`() {
+        assertTrue(bondStateTraceLine(10, 11, null, null).contains("device=unknown"))
+        assertTrue(bondStateTraceLine(10, 11, "  ", null).contains("device=unknown"))
+    }
+}


### PR DESCRIPTION
## What #1638 answered, and what it left

The CLIENT_HELLO instrumentation resolved the first question immediately. On a WHOOP 5/MG, **every** attempt is the same failure:

```
CLIENT_HELLO outcome: NO write callback after 3153ms …
CLIENT_HELLO outcome: NO write callback after 3158ms …
CLIENT_HELLO outcome: NO write callback after 3160ms …
```

9 of 9 in a connection bundle, 8 of 8 in a strap log. And the timing is the tell:

```
n=9   min=3153ms   max=3163ms   mean=3158ms   spread=10ms
```

A 10 ms spread across nine attempts is a **timer**, not a link dying of interference. There is no NOOP-side timer at that interval — the only ~3 s constants in the BLE client are `RECONNECT_DELAY_MS` and `RSSI_READ_DELAY_MS`, neither of which tears anything down.

Two explanations fit that regularity, and nothing in the log separates them:

1. The confirmed write to an encryption-requiring characteristic triggers **OS pairing**, which fails or times out and takes the link with it.
2. The write never triggers pairing at all, and the cause lies elsewhere entirely.

## The change

**NOOP has never observed `ACTION_BOND_STATE_CHANGED`** — there is no such receiver anywhere in the codebase, so the OS transition `BOND_NONE → BOND_BONDING → BOND_NONE` is invisible to us.

```
bond state: BOND_NONE -> BOND_BONDING device=FD:… 120ms after CLIENT_HELLO
bond state: BOND_BONDING -> BOND_NONE device=FD:… 3158ms after CLIENT_HELLO — pairing did NOT complete
```

Seeing that across the window answers the question. Seeing **no transition at all** answers it the other way, and that absence is just as conclusive — which is why the line has to be equally legible about a transition happening and about one not happening.

Registered and unregistered alongside the existing radio receiver, in the same `ContextCompat` / `RECEIVER_NOT_EXPORTED` form and under the same already-registered flag, so the pair cannot drift apart or double-register (the flag's doc now says it covers both).

The elapsed time is measured against the outstanding CLIENT_HELLO and **omitted when there is none** — a transition from an unrelated pairing must not be timed against a write it has nothing to do with. There is a test for that.

**Android-only:** CoreBluetooth performs pairing opaquely and exposes no equivalent transition, so there is nothing to twin.

## What this replaces, and why

I first proposed *deferring commands until the handshake completes*, having read `→ DISABLE_ALARM` in the log as a second GATT write landing inside the outstanding CLIENT_HELLO window — in 15 of 16 cycles.

**That was wrong.** That line is logged at **enqueue**:

```kotlin
enqueueWrite(PendingWrite(frame, withResponse, cmd))
log("→ ${cmd.name} payload=…")
```

and `drainWriteQueue` opens with `if (writeInFlight) return`. The CLIENT_HELLO holds that flag, so the command is queued and **held** — the one-outstanding-operation rule was never violated, and the fix I proposed was unnecessary. I had counted a log line as a wire event. Corrected on the issue before building this instead.

One real consequence does follow from the bug: because the ACK never arrives, `writeInFlight` stays `true` for the life of the link, so the whole command queue is wedged behind it. That is an effect, not a cause.

## Verification

- `compileFullDebugKotlin` clean; full `com.noop.ble` suite (**438 tests**) green.
- 6 tests on the pure line, including the two that matter for reading a capture correctly: a failed pairing must be called out rather than inferred, and a transition with no outstanding hello must carry **no** elapsed time.
- `doc_comment_lint` and `i18n_audit --ci main` clean — gated on, not run alongside the commit.
- No Swift changes, so no app-build dependency.
