### PR TITLE
ble: stop declaring a 5/MG bond from a completion that is not the CLIENT_HELLO's

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -871,9 +871,10 @@ public final class BLEManager: NSObject, ObservableObject {
     /// callback (the settle resolved); if it fires instead, the state never settled — the wedged-grant
     /// shape (#429) — and the #295 re-grant banner is shown after all.
     private var unauthorizedSettleWork: DispatchWorkItem?
-    /// When the 5/MG CLIENT_HELLO went out, or nil when none is outstanding. Consumed by the first
-    /// completion that follows, so an unrelated command's callback cannot be mistaken for the hello's ack
-    /// (#1635). Kotlin twin: `WhoopBleClient.clientHelloWriteAtMs`.
+    /// When the 5/MG CLIENT_HELLO went out, or nil when none is outstanding. Consumed ONLY by a
+    /// completion on the hello's own characteristic (or a failed one, or the link dropping) — never by an
+    /// unrelated command's callback, which would otherwise either inherit the window or close it out from
+    /// under a genuine ack still in flight (#1635). Kotlin twin: `WhoopBleClient.clientHelloWriteAtMs`.
     private var clientHelloWriteAt: Date?
     private var cmdCharacteristic: CBCharacteristic?
     /// #613: true when a command would ACTUALLY reach the strap right now — the same condition `send()`
@@ -5340,6 +5341,10 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                            error: Error?) {
         if let error = error {
             log("Confirmed write failed: \(error.localizedDescription)")
+            // #1635: a failed write owes no ack. Leaving the window open would let the NEXT completion on
+            // fd4b0002 — DISABLE_ALARM and every other puffin command share it — satisfy both halves of
+            // the bond gate below and declare a bond the strap never granted, which is the whole bug.
+            if characteristic.uuid == BLEManager.whoop5CmdWriteChar { clientHelloWriteAt = nil }
             // #78 hole-1: classify by ATT code first (locale-proof), English string fallback second.
             // This one change repairs the pairing hint (streak>=2), the #747 give-up (5) AND the #52
             // stale-pin handoff below for non-English devices, which all key off this same flag.
@@ -5426,6 +5431,11 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
             let helloOutstanding = clientHelloWriteAt != nil
             // Consume the window ONLY for the hello's own completion. A foreign completion that cleared it
             // would make a genuine ack arriving afterwards look unsolicited, costing a real bond.
+            //
+            // An UNACKED hello leaves the window open, and the pair of conditions cannot be satisfied by a
+            // later command on the same characteristic: `send` writes `.withoutResponse` by default, which
+            // produces no completion at all, and the `.withResponse` senders (the offload acks) only run
+            // after a bond, where `alreadyBonded` short-circuits this. The link dropping clears it anyway.
             if isHelloChar { clientHelloWriteAt = nil }
             if ClientHelloOutcome.isAck(
                 isHelloChar: isHelloChar,

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -5437,6 +5437,10 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
             // produces no completion at all, and the `.withResponse` senders (the offload acks) only run
             // after a bond, where `alreadyBonded` short-circuits this. The link dropping clears it anyway.
             if isHelloChar { clientHelloWriteAt = nil }
+            if !helloOutstanding, !didBond {
+                // Declining must not be silent — see `ClientHelloOutcome.declinedLine`.
+                log(ClientHelloOutcome.declinedLine(charUuid: characteristic.uuid.uuidString, status: nil))
+            }
             if ClientHelloOutcome.isAck(
                 isHelloChar: isHelloChar,
                 helloOutstanding: helloOutstanding,

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -871,6 +871,10 @@ public final class BLEManager: NSObject, ObservableObject {
     /// callback (the settle resolved); if it fires instead, the state never settled — the wedged-grant
     /// shape (#429) — and the #295 re-grant banner is shown after all.
     private var unauthorizedSettleWork: DispatchWorkItem?
+    /// When the 5/MG CLIENT_HELLO went out, or nil when none is outstanding. Consumed by the first
+    /// completion that follows, so an unrelated command's callback cannot be mistaken for the hello's ack
+    /// (#1635). Kotlin twin: `WhoopBleClient.clientHelloWriteAtMs`.
+    private var clientHelloWriteAt: Date?
     private var cmdCharacteristic: CBCharacteristic?
     /// #613: true when a command would ACTUALLY reach the strap right now — the same condition `send()`
     /// requires (connected peripheral + a discovered command characteristic). The alarm-arm log and the
@@ -4968,6 +4972,7 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         state.clearBiometrics()       // and a stale HR / R-R must not outlive the link either
         state.liveFeedActive = false  // a drop while Live is open must not leave a stale "Stop live feed"
         didBond = false
+        clientHelloWriteAt = nil   // #1635: no hello survives the link that carried it
         whoop5RealtimeArmed = false
         // The strap forgets the realtime-HR toggle across a disconnect; the post-bond branch re-arms it
         // from `wantsRealtime`. Clear only the "what we last sent" flag — `screenWantsRealtime` /
@@ -5284,6 +5289,7 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                     // "Finishing the secure pairing handshake…".
                     log("WHOOP 5/MG: writing CLIENT_HELLO to fd4b0002 with response (to trigger bonding, experimental).")
                     state.pairingHint = nil   // fresh attempt; clear any stale pairing-mode guidance
+                    clientHelloWriteAt = Date()   // #1635: a hello is now outstanding
                     peripheral.writeValue(Data(hello), for: c, type: .withResponse)
                 }
                 // The realtime-HR stream is armed POST-bond (in didWriteValueFor / startRealtime) with
@@ -5413,7 +5419,20 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
         // which the strap refused before the link was encrypted. Do NOT run the WHOOP4 command handshake
         // below — a 5/MG strap rejects WHOOP4-framed commands (the send() guard drops them anyway).
         if selectedModel.deviceFamily == .whoop5 {
-            if !didBond {
+            // #1635: only the CLIENT_HELLO's OWN completion is evidence of a bond. Declining withholds
+            // the bond declaration ONLY — the puffin re-subscribe below is unchanged, so a link that is
+            // genuinely up keeps its notifications either way.
+            let isHelloChar = characteristic.uuid == BLEManager.whoop5CmdWriteChar
+            let helloOutstanding = clientHelloWriteAt != nil
+            // Consume the window ONLY for the hello's own completion. A foreign completion that cleared it
+            // would make a genuine ack arriving afterwards look unsolicited, costing a real bond.
+            if isHelloChar { clientHelloWriteAt = nil }
+            if ClientHelloOutcome.isAck(
+                isHelloChar: isHelloChar,
+                helloOutstanding: helloOutstanding,
+                alreadyBonded: didBond,
+                isWhoop5: true
+            ) {
                 didBond = true
                 state.bonded = true
                 state.encryptedBond = true   // genuine encrypted bond (not the live-HR shortcut) — #69

--- a/Strand/BLE/ClientHelloOutcome.swift
+++ b/Strand/BLE/ClientHelloOutcome.swift
@@ -35,4 +35,34 @@ enum ClientHelloOutcome {
         return "CLIENT_HELLO outcome: bond declared from a DIFFERENT characteristic \(where_) after"
             + " \(elapsedMs)ms\(st) — this is NOT a CLIENT_HELLO ack (#1635)"
     }
+
+    /// Is this write completion genuinely the CLIENT_HELLO's ack, and therefore proof of an encrypted bond?
+    ///
+    /// The bond branch used to match on family alone: on a 5/MG link, ANY completion that arrived while
+    /// `didBond` was false was taken as the ack and set `encryptedBond`. A characteristic check on its own
+    /// does not fix that, because the puffin command characteristic (fd4b0002) carries BOTH the
+    /// CLIENT_HELLO and every ordinary command — DISABLE_ALARM is written there on the same connect — so
+    /// the hello and an unrelated command are indistinguishable by uuid.
+    ///
+    /// What separates them is whether a hello is actually OUTSTANDING, which is why both conditions are
+    /// required and neither is redundant:
+    ///  - `isHelloChar` alone admits DISABLE_ALARM and every other puffin command.
+    ///  - `helloOutstanding` alone admits a completion from a different characteristic that happens to
+    ///    land inside the hello's window.
+    ///
+    /// Declining does not claim the strap refused anything — it says only that THIS completion is not
+    /// evidence of a bond. A real ack still arrives on its own callback and still bonds.
+    ///
+    /// Pure, so the rule is tested without a radio. Kotlin twin: `completionIsClientHelloAck`.
+    static func isAck(
+        isHelloChar: Bool,
+        helloOutstanding: Bool,
+        alreadyBonded: Bool,
+        isWhoop5: Bool
+    ) -> Bool {
+        if alreadyBonded { return false }
+        if !isWhoop5 { return false }
+        return isHelloChar && helloOutstanding
+    }
 }
+

--- a/Strand/BLE/ClientHelloOutcome.swift
+++ b/Strand/BLE/ClientHelloOutcome.swift
@@ -64,5 +64,25 @@ enum ClientHelloOutcome {
         if !isWhoop5 { return false }
         return isHelloChar && helloOutstanding
     }
+
+    /// A pre-bond write completion on a 5/MG link that arrived with NO CLIENT_HELLO outstanding.
+    ///
+    /// `isAck` declines these, and without a line it declines in SILENCE — which is worse for a capture
+    /// than the wrong answer it replaces. The field log for #1635 said "CLIENT_HELLO acked — link
+    /// established" here; the honest replacement is not nothing, it is "a completion arrived and it was
+    /// not the hello's". Without it the reader cannot tell a completion arrived at all.
+    ///
+    /// Names the characteristic because the whole point is that fd4b0002 carries traffic other than the
+    /// hello, and the reader needs to see WHICH command completed.
+    ///
+    /// Pure. Kotlin twin: `clientHelloDeclinedLine`.
+    static func declinedLine(charUuid: String?, status: String?) -> String {
+        let uuid = charUuid?.trimmingCharacters(in: .whitespaces) ?? ""
+        let whereFrom = uuid.isEmpty ? "unknown" : uuid
+        let trimmedStatus = status?.trimmingCharacters(in: .whitespaces) ?? ""
+        let st = trimmedStatus.isEmpty ? "" : " \(trimmedStatus)"
+        return "CLIENT_HELLO outcome: completion from \(whereFrom)\(st) with NO hello outstanding — not a bond,"
+            + " so the link stays unbonded (#1635)"
+    }
 }
 

--- a/StrandTests/ClientHelloOutcomeTests.swift
+++ b/StrandTests/ClientHelloOutcomeTests.swift
@@ -39,4 +39,34 @@ final class ClientHelloOutcomeTests: XCTestCase {
             ClientHelloOutcome.line(isHelloChar: true, charUuid: "   ", elapsedMs: 5, status: "  "),
             "CLIENT_HELLO outcome: acked by unknown after 5ms")
     }
+
+    // MARK: - the bond gate (#1635)
+
+    /// 15:24:13 in the field capture: DISABLE_ALARM was in flight, the CLIENT_HELLO write was rejected so
+    /// nothing was owed, and DISABLE_ALARM's completion then arrived on fd4b0002 — the SAME characteristic
+    /// the hello uses — and the link was declared bonded. `isHelloChar` is true here, which is exactly why
+    /// a uuid check on its own would not have caught it.
+    func testQueuedCommandOnTheHelloCharacteristicIsNotABond() {
+        XCTAssertFalse(ClientHelloOutcome.isAck(
+            isHelloChar: true, helloOutstanding: false, alreadyBonded: false, isWhoop5: true))
+    }
+
+    func testForeignCharacteristicInsideTheWindowIsNotABond() {
+        XCTAssertFalse(ClientHelloOutcome.isAck(
+            isHelloChar: false, helloOutstanding: true, alreadyBonded: false, isWhoop5: true))
+    }
+
+    /// The regression that matters most: the gate must not cost a real bond.
+    func testGenuineAckStillBonds() {
+        XCTAssertTrue(ClientHelloOutcome.isAck(
+            isHelloChar: true, helloOutstanding: true, alreadyBonded: false, isWhoop5: true))
+    }
+
+    func testAlreadyBondedDoesNotReBondAndWhoop4NeverTakesThisPath() {
+        XCTAssertFalse(ClientHelloOutcome.isAck(
+            isHelloChar: true, helloOutstanding: true, alreadyBonded: true, isWhoop5: true))
+        XCTAssertFalse(ClientHelloOutcome.isAck(
+            isHelloChar: true, helloOutstanding: true, alreadyBonded: false, isWhoop5: false))
+    }
 }
+

--- a/android/app/src/main/java/com/noop/ble/ClientHelloOutcome.kt
+++ b/android/app/src/main/java/com/noop/ble/ClientHelloOutcome.kt
@@ -75,3 +75,39 @@ internal fun gattWriteStatusLabel(status: Int?): String = when (status) {
     else -> "status=$status"
 }
 
+/**
+ * Is this write completion genuinely the CLIENT_HELLO's ack, and therefore proof of an encrypted bond?
+ *
+ * The bond branch used to match on family alone: on a 5/MG link, ANY with-response completion that
+ * arrived while `didBond` was false was taken as the ack and set `encryptedBond`. A characteristic check
+ * on its own does not fix that, because the puffin command characteristic (fd4b0002) carries BOTH the
+ * CLIENT_HELLO and every ordinary command - DISABLE_ALARM is written there on the same connect - so the
+ * hello and an unrelated command are indistinguishable by uuid.
+ *
+ * What separates them is whether a hello is actually OUTSTANDING. The hello is written straight past the
+ * command queue while sharing its in-flight slot, so when a queued command is already in flight the write
+ * is rejected by the stack and no callback is owed (the caller zeroes its stopwatch to say so). That is
+ * exactly the case seen in the field: the hello was rejected, DISABLE_ALARM's completion landed a moment
+ * later, and the link was declared bonded on the strength of it (#1635).
+ *
+ * Both conditions are required, and neither is redundant:
+ *  - [isHelloChar] alone admits DISABLE_ALARM and every other puffin command.
+ *  - [helloOutstanding] alone admits a completion from a different characteristic that happens to land
+ *    inside the hello's window.
+ *
+ * Declining does not claim the strap refused anything - it says only that THIS completion is not evidence
+ * of a bond. A real ack still arrives on its own callback and still bonds.
+ *
+ * Pure, so the rule is tested without a radio. Swift twin: `ClientHelloOutcome.isAck`.
+ */
+internal fun completionIsClientHelloAck(
+    isHelloChar: Boolean,
+    helloOutstanding: Boolean,
+    alreadyBonded: Boolean,
+    isWhoop5: Boolean,
+): Boolean {
+    if (alreadyBonded) return false
+    if (!isWhoop5) return false
+    return isHelloChar && helloOutstanding
+}
+

--- a/android/app/src/main/java/com/noop/ble/ClientHelloOutcome.kt
+++ b/android/app/src/main/java/com/noop/ble/ClientHelloOutcome.kt
@@ -111,3 +111,29 @@ internal fun completionIsClientHelloAck(
     return isHelloChar && helloOutstanding
 }
 
+/**
+ * A pre-bond write completion on a 5/MG link that arrived with NO CLIENT_HELLO outstanding.
+ *
+ * [completionIsClientHelloAck] declines these, and without a line it declines in SILENCE — which is worse
+ * for a capture than the wrong answer it replaces. The field log for #1635 said "CLIENT_HELLO acked —
+ * link established" here; the honest replacement is not nothing, it is "a completion arrived and it was
+ * not the hello's". Without it the reader cannot tell a completion arrived at all, and the evidence that
+ * identified this bug in the first place would not appear in the next capture.
+ *
+ * Names the characteristic because the whole point is that fd4b0002 carries traffic other than the hello,
+ * and the reader needs to see WHICH command completed to match it against the `→ CMD` line above it.
+ *
+ * Bounded: this branch is 5/MG-only and runs only while unbonded, and the field capture shows about one
+ * such completion per connect attempt.
+ *
+ * Pure. Swift twin: `ClientHelloOutcome.declinedLine`.
+ */
+internal fun clientHelloDeclinedLine(charUuid: String?, status: String?): String {
+    // trim(), not just isNotBlank(): the Swift twin trims, and an untrimmed uuid would render with its
+    // padding intact — a byte-level parity break the oracle test below catches.
+    val where = charUuid?.trim()?.takeIf { it.isNotEmpty() } ?: "unknown"
+    val st = status?.trim()?.takeIf { it.isNotEmpty() }?.let { " $it" } ?: ""
+    return "CLIENT_HELLO outcome: completion from $where$st with NO hello outstanding — not a bond," +
+        " so the link stays unbonded (#1635)"
+}
+

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5338,49 +5338,67 @@ class WhoopBleClient(
                     )
                 }
             } else if (!didBond && connectedFamily == DeviceFamily.WHOOP5) {
-                // #1635: report WHICH characteristic completed. This branch matches on family alone, so a
-                // completion from any other characteristic is currently taken as the CLIENT_HELLO ack - the
-                // line says so rather than the behaviour changing here, so a capture can size how often it
-                // happens before the guard is tightened.
-                if (clientHelloWriteAtMs > 0L) {
+                // #1635: report WHICH characteristic completed, then gate the bond on it. This branch used
+                // to match on family alone, so ANY completion on a 5/MG link was taken as the CLIENT_HELLO
+                // ack. The field capture that sized it saw exactly that: the hello was rejected by the stack
+                // (nothing owed), DISABLE_ALARM's completion landed on the SAME characteristic a moment
+                // later, and the link was declared bonded on the strength of it.
+                val isHelloChar = characteristic.uuid == WHOOP5_CMD_WRITE_CHAR
+                // Read BEFORE the diagnostic below zeroes it — the gate needs the pre-clear value.
+                val helloOutstanding = clientHelloWriteAtMs > 0L
+                if (helloOutstanding) {
                     log(clientHelloOutcomeLine(
-                        isHelloChar = characteristic.uuid == WHOOP5_CMD_WRITE_CHAR,
+                        isHelloChar = isHelloChar,
                         charUuid = characteristic.uuid.toString(),
                         elapsedMs = System.currentTimeMillis() - clientHelloWriteAtMs,
                         status = gattWriteStatusLabel(status),
                     ))
-                    clientHelloWriteAtMs = 0L
+                    // Consume the window ONLY for the hello's own completion. A foreign completion that
+                    // cleared it would make a genuine ack arriving afterwards look unsolicited, costing a
+                    // real bond — the one regression this gate must not introduce.
+                    if (isHelloChar) clientHelloWriteAtMs = 0L
                 }
-                // EXPERIMENTAL (issue #17): the CLIENT_HELLO is now a confirmed write, so this ACK means
-                // just-works bonding completed. Now subscribe the puffin notify chars (realtime HR rides
-                // these as REALTIME_DATA — the strap rejected them on the unauthenticated link), then arm
-                // realtime HR with puffin framing. Mirrors the macOS post-bond flow.
-                didBond = true
-                cancelBondWatchdog()          // genuine bond reached — the handshake watchdog stands down (#50)
-                noteGenuineBond(g.device.address)   // #52: this strap bonds fine; clears any pin-refusal streak
-                clearPairingHint()            // #78: a genuine bond means the pairing guidance no longer applies
-                bondedDirectAttempt = false   // fast-path connect reached a real session (#78 fork)
-                staleDirectFailures = 0       // genuine bond — clear the wiped-bond counter (#84 parity)
-                _state.update { it.copy(bonded = true, encryptedBond = true) }   // genuine bond (#69)
-                bondedAtMs = System.currentTimeMillis()   // #617: stamp the bond so handleDisconnect can spot a bond-then-quick-timeout loop
-                emitConnectionBondState("encryptedBond family=whoop5 (CLIENT_HELLO acked)")
-                log("WHOOP 5/MG: CLIENT_HELLO acked — link established; subscribing notify chars (experimental).")
-                g.getService(WHOOP5_SERVICE)?.let { svc ->
-                    for (u in WHOOP5_NOTIFY_CHARS) svc.getCharacteristic(u)?.let { cccdQueue.add(it) }
+                // Only the hello's OWN completion is evidence of a bond. Declining here withholds the
+                // bond declaration and nothing else: the in-flight slot is released and the write queue
+                // drains at the end of this callback either way.
+                if (completionIsClientHelloAck(
+                        isHelloChar = isHelloChar,
+                        helloOutstanding = helloOutstanding,
+                        alreadyBonded = didBond,
+                        isWhoop5 = true,
+                    )
+                ) {
+                    // EXPERIMENTAL (issue #17): the CLIENT_HELLO is now a confirmed write, so this ACK means
+                    // just-works bonding completed. Now subscribe the puffin notify chars (realtime HR rides
+                    // these as REALTIME_DATA — the strap rejected them on the unauthenticated link), then arm
+                    // realtime HR with puffin framing. Mirrors the macOS post-bond flow.
+                    didBond = true
+                    cancelBondWatchdog()          // genuine bond reached — the handshake watchdog stands down (#50)
+                    noteGenuineBond(g.device.address)   // #52: this strap bonds fine; clears any pin-refusal streak
+                    clearPairingHint()            // #78: a genuine bond means the pairing guidance no longer applies
+                    bondedDirectAttempt = false   // fast-path connect reached a real session (#78 fork)
+                    staleDirectFailures = 0       // genuine bond — clear the wiped-bond counter (#84 parity)
+                    _state.update { it.copy(bonded = true, encryptedBond = true) }   // genuine bond (#69)
+                    bondedAtMs = System.currentTimeMillis()   // #617: stamp the bond so handleDisconnect can spot a bond-then-quick-timeout loop
+                    emitConnectionBondState("encryptedBond family=whoop5 (CLIENT_HELLO acked)")
+                    log("WHOOP 5/MG: CLIENT_HELLO acked — link established; subscribing notify chars (experimental).")
+                    g.getService(WHOOP5_SERVICE)?.let { svc ->
+                        for (u in WHOOP5_NOTIFY_CHARS) svc.getCharacteristic(u)?.let { cccdQueue.add(it) }
+                    }
+                    // The 5/MG handshake tail (SET_CLOCK/GET_CLOCK + the offload kick) now runs when THIS
+                    // CCCD drain completes — see drainCccdQueue's queue-empty branch. Clock-before-history
+                    // is mandatory: an un-clocked WHOOP 5 doesn't save sensor data to flash at all
+                    // ("RTC timestamp … is invalid; not saving data to flash"), so history offloads
+                    // "succeed" with zero body frames. Hardware-validated ordering: CLIENT_HELLO →
+                    // subscribe puffin chars → clock → history. (#78 fork)
+                    drainCccdQueue(g)
+                    // #927: RE-DERIVE the want at arm time, never the precomputed [wantsRealtime]: that value
+                    // can be up to a keep-alive tick (30 s) stale, and a reconnect just OUTSIDE the overnight
+                    // window would re-arm the stream from it and stay armed until the next tick.
+                    val realtimeWantNow = screenWantsRealtime || continuousCaptureWantsNow()
+                    wantsRealtime = realtimeWantNow
+                    if (realtimeWantNow) { realtimeArmed = true; send(CommandNumber.TOGGLE_REALTIME_HR, byteArrayOf(1)) }
                 }
-                // The 5/MG handshake tail (SET_CLOCK/GET_CLOCK + the offload kick) now runs when THIS
-                // CCCD drain completes — see drainCccdQueue's queue-empty branch. Clock-before-history
-                // is mandatory: an un-clocked WHOOP 5 doesn't save sensor data to flash at all
-                // ("RTC timestamp … is invalid; not saving data to flash"), so history offloads
-                // "succeed" with zero body frames. Hardware-validated ordering: CLIENT_HELLO →
-                // subscribe puffin chars → clock → history. (#78 fork)
-                drainCccdQueue(g)
-                // #927: RE-DERIVE the want at arm time, never the precomputed [wantsRealtime]: that value
-                // can be up to a keep-alive tick (30 s) stale, and a reconnect just OUTSIDE the overnight
-                // window would re-arm the stream from it and stay armed until the next tick.
-                val realtimeWantNow = screenWantsRealtime || continuousCaptureWantsNow()
-                wantsRealtime = realtimeWantNow
-                if (realtimeWantNow) { realtimeArmed = true; send(CommandNumber.TOGGLE_REALTIME_HR, byteArrayOf(1)) }
             } else if (!didBond && connectedFamily == DeviceFamily.WHOOP4) {
                 didBond = true
                 cancelBondWatchdog()          // secure handshake completed — stand the watchdog down (#50)

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5365,6 +5365,12 @@ class WhoopBleClient(
                     // hello holds `writeInFlight` until its callback fires, and drainWriteQueue refuses to
                     // start a write while one is in flight (#1095 keys off exactly that stuck state).
                     if (isHelloChar) clientHelloWriteAtMs = 0L
+                } else {
+                    // Declining must not be silent — see [clientHelloDeclinedLine].
+                    log(clientHelloDeclinedLine(
+                        charUuid = characteristic.uuid.toString(),
+                        status = gattWriteStatusLabel(status),
+                    ))
                 }
                 // Only the hello's OWN completion is evidence of a bond. Declining here withholds the
                 // bond declaration and nothing else: the in-flight slot is released and the write queue

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5311,6 +5311,10 @@ class WhoopBleClient(
             // Port of didWriteValueFor: a CONFIRMED-write completion (no error) == bonding succeeded.
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 log("Confirmed write failed: status=$status")
+                // #1635: a failed write owes no ack. Leaving the window open would let the NEXT completion
+                // on fd4b0002 — DISABLE_ALARM and every other puffin command share it — satisfy both halves
+                // of the bond gate below and declare a bond the strap never granted, which is the whole bug.
+                if (characteristic.uuid == WHOOP5_CMD_WRITE_CHAR) clientHelloWriteAtMs = 0L
                 // Multi-WHOOP stale-pin recovery (#52). A status of INSUFFICIENT_AUTHENTICATION (5) /
                 // INSUFFICIENT_ENCRYPTION (15) on the bond write == the strap refused the encrypted bond
                 // (the Android twin of the iOS "Encryption/Authentication is insufficient" error). When a
@@ -5356,6 +5360,10 @@ class WhoopBleClient(
                     // Consume the window ONLY for the hello's own completion. A foreign completion that
                     // cleared it would make a genuine ack arriving afterwards look unsolicited, costing a
                     // real bond — the one regression this gate must not introduce.
+                    //
+                    // An UNACKED hello leaves the window open, and no later command can inherit it: the
+                    // hello holds `writeInFlight` until its callback fires, and drainWriteQueue refuses to
+                    // start a write while one is in flight (#1095 keys off exactly that stuck state).
                     if (isHelloChar) clientHelloWriteAtMs = 0L
                 }
                 // Only the hello's OWN completion is evidence of a bond. Declining here withholds the

--- a/android/app/src/test/java/com/noop/ble/ClientHelloAckParityTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ClientHelloAckParityTest.kt
@@ -1,0 +1,42 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Byte-identical parity oracle for [completionIsClientHelloAck] against the Swift
+ * `ClientHelloOutcome.isAck`. The expected block is the verbatim stdout of the compiled Swift twin over
+ * the full 16-row input space, so a one-sided edit to either platform fails here rather than drifting.
+ */
+class ClientHelloAckParityTest {
+    @Test
+    fun `the full truth table matches the Swift twin`() {
+        val out = StringBuilder()
+        for (a in listOf(false, true)) for (b in listOf(false, true))
+            for (c in listOf(false, true)) for (d in listOf(false, true))
+                out.append("$a$b$c$d=${completionIsClientHelloAck(a, b, c, d)}\n")
+        // trimStart: the raw literal opens with a newline that the Swift stdout does not have.
+        assertEquals(SWIFT.trimStart('\n'), out.toString())
+    }
+
+    private companion object {
+        const val SWIFT = """
+falsefalsefalsefalse=false
+falsefalsefalsetrue=false
+falsefalsetruefalse=false
+falsefalsetruetrue=false
+falsetruefalsefalse=false
+falsetruefalsetrue=false
+falsetruetruefalse=false
+falsetruetruetrue=false
+truefalsefalsefalse=false
+truefalsefalsetrue=false
+truefalsetruefalse=false
+truefalsetruetrue=false
+truetruefalsefalse=false
+truetruefalsetrue=true
+truetruetruefalse=false
+truetruetruetrue=false
+"""
+    }
+}

--- a/android/app/src/test/java/com/noop/ble/ClientHelloAckTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ClientHelloAckTest.kt
@@ -1,0 +1,57 @@
+package com.noop.ble
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The bond gate for [completionIsClientHelloAck], written from the #1635 field capture. Swift twin:
+ * `ClientHelloOutcomeTests`.
+ */
+class ClientHelloAckTest {
+    @Test
+    fun `the field case - a queued command completing on the hello characteristic is not a bond`() {
+        // 15:24:13 in the capture: DISABLE_ALARM was in flight, so the CLIENT_HELLO write was rejected by
+        // the stack and nothing was owed. DISABLE_ALARM's completion then arrived on fd4b0002 - the SAME
+        // characteristic the hello uses - and the link was declared bonded. isHelloChar is TRUE here, which
+        // is exactly why a uuid check alone would not have caught it.
+        assertFalse(
+            completionIsClientHelloAck(
+                isHelloChar = true, helloOutstanding = false, alreadyBonded = false, isWhoop5 = true,
+            )
+        )
+    }
+
+    @Test
+    fun `a foreign characteristic completing inside the window is not a bond`() {
+        assertFalse(
+            completionIsClientHelloAck(
+                isHelloChar = false, helloOutstanding = true, alreadyBonded = false, isWhoop5 = true,
+            )
+        )
+    }
+
+    @Test
+    fun `a genuine ack still bonds`() {
+        // The regression that matters most: the gate must not cost a real bond.
+        assertTrue(
+            completionIsClientHelloAck(
+                isHelloChar = true, helloOutstanding = true, alreadyBonded = false, isWhoop5 = true,
+            )
+        )
+    }
+
+    @Test
+    fun `an already-bonded link does not re-bond, and a WHOOP4 link never takes this path`() {
+        assertFalse(
+            completionIsClientHelloAck(
+                isHelloChar = true, helloOutstanding = true, alreadyBonded = true, isWhoop5 = true,
+            )
+        )
+        assertFalse(
+            completionIsClientHelloAck(
+                isHelloChar = true, helloOutstanding = true, alreadyBonded = false, isWhoop5 = false,
+            )
+        )
+    }
+}

--- a/android/app/src/test/java/com/noop/ble/ClientHelloDeclinedLineTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ClientHelloDeclinedLineTest.kt
@@ -1,0 +1,35 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Byte-identical parity oracle for [clientHelloDeclinedLine] against the Swift
+ * `ClientHelloOutcome.declinedLine`. The expected block is the verbatim stdout of the compiled Swift twin,
+ * so a one-sided wording or trimming change fails here rather than drifting apart in the field logs the
+ * two platforms are meant to be read side by side.
+ */
+class ClientHelloDeclinedLineTest {
+    @Test
+    fun `every rendering matches the Swift twin`() {
+        val cases = listOf<Pair<String?, String?>>(
+            "fd4b0002-cce1-4033-93ce-002d5875f58a" to "status=GATT_SUCCESS(0)",
+            "fd4b0002-cce1-4033-93ce-002d5875f58a" to null,
+            null to "status=GATT_SUCCESS(0)",
+            "" to "  ",
+            "  fd4b0002  " to "",
+        )
+        val out = cases.joinToString("\n") { (u, s) -> clientHelloDeclinedLine(u, s) }
+        assertEquals(SWIFT.trim('\n'), out)
+    }
+
+    private companion object {
+        const val SWIFT = """
+CLIENT_HELLO outcome: completion from fd4b0002-cce1-4033-93ce-002d5875f58a status=GATT_SUCCESS(0) with NO hello outstanding — not a bond, so the link stays unbonded (#1635)
+CLIENT_HELLO outcome: completion from fd4b0002-cce1-4033-93ce-002d5875f58a with NO hello outstanding — not a bond, so the link stays unbonded (#1635)
+CLIENT_HELLO outcome: completion from unknown status=GATT_SUCCESS(0) with NO hello outstanding — not a bond, so the link stays unbonded (#1635)
+CLIENT_HELLO outcome: completion from unknown with NO hello outstanding — not a bond, so the link stays unbonded (#1635)
+CLIENT_HELLO outcome: completion from fd4b0002 with NO hello outstanding — not a bond, so the link stays unbonded (#1635)
+"""
+    }
+}


### PR DESCRIPTION
The 5/MG bond branch matched on **device family alone**. On a 5/MG link, any with-response write completion arriving while `didBond` was false was taken as the CLIENT_HELLO ack and set `encryptedBond` — on both platforms.

### The capture that caught it

From the #1635 field log, at `15:24:13`:

```
→ DISABLE_ALARM payload=02ff (puffin)
WHOOP 5/MG: writing CLIENT_HELLO to fd4b0002 with response (to trigger bonding, experimental).
CLIENT_HELLO write rejected by stack
[connection] bondState encryptedBond family=whoop5 (CLIENT_HELLO acked)
WHOOP 5/MG: CLIENT_HELLO acked — link established; subscribing notify chars (experimental).
```

The hello never went out — `DISABLE_ALARM` held the in-flight slot, the stack rejected the write, and the rejected-write path zeroed its stopwatch to record that no callback was owed. `DISABLE_ALARM`'s own completion then arrived and the link was declared bonded. It had not bonded, and it dropped 3s later like the other nine cycles in that run.

Across that capture: 14 of 16 hellos went out and were never acked, 1 was rejected by the stack, and 1 produced this false "ack".

### Why a characteristic check alone is not enough

The puffin command characteristic `fd4b0002` carries **both** the CLIENT_HELLO and every ordinary command, so hello and non-hello are indistinguishable by uuid. In the capture above `isHelloChar` is *true*.

What separates them is whether a hello is actually **outstanding**. Both conditions are required, and neither is redundant:

| | admits | rejected by |
|---|---|---|
| `isHelloChar` alone | `DISABLE_ALARM` and every other puffin command | `helloOutstanding` |
| `helloOutstanding` alone | a completion from a different characteristic inside the window | `isHelloChar` |

### The regression this must not introduce

The window is consumed **only** by the hello's own completion. Clearing it on a foreign completion would make a genuine ack arriving afterwards look unsolicited and cost a real bond. That property is pinned by the "a genuine ack still bonds" test on both platforms.

Declining withholds the bond declaration and nothing else — the in-flight slot is still released, the write queue still drains, and the Swift puffin re-subscribe is unchanged.

### Knock-on for #1640

A misattributed ack sets `bonded`/`encryptedBond`, so `countsAsBondRefusal` saw `alreadyBonded` and returned false. The give-up streak could be silently disarmed by the very misattribution #1638 was built to detect.

### Parity

Pure gate both sides (`completionIsClientHelloAck` / `ClientHelloOutcome.isAck`), byte-identical. A parity oracle asserts the Kotlin truth table against the **compiled Swift twin's stdout** across all 16 inputs, so a one-sided edit fails the build rather than drifting.

### Verification

- 437 `com.noop.ble` tests green; `compileFullDebugKotlin` clean.
- `doc_comment_lint` and `i18n_audit` clean.
- Swift twin tests added to `StrandTests` — **app-build gated**, not yet run.
- **Not yet confirmed on a strap.** This stops a false bond being declared; it does not by itself stop the reconnect loop, whose local teardown is still unattributed (`via=unknown`).

---

### Re-review: one hole found and closed

Both platforms return early from the write-**failure** branch, before the gate, without clearing the marker. A CLIENT_HELLO that completed with an error left the window open — and since `DISABLE_ALARM` shares `fd4b0002` with the hello, the next completion satisfied *both* halves of the gate. The bug re-entering through the error path. Now cleared there, and only when the failing write was on the hello's own characteristic.

The natural follow-up question — can an **unacked** hello be inherited the same way? — is answered in the code, because it differs per platform:

- **Android:** no. The hello holds `writeInFlight` until its callback fires, and `drainWriteQueue` refuses to start a write while one is in flight (#1095 keys off exactly that stuck state).
- **Swift:** no. `send()` writes `.withoutResponse`, which produces no completion at all; the `.withResponse` senders (offload acks) all run post-bond, where `alreadyBonded` short-circuits.

Also corrected the new Swift field's doc, which described a first-completion-wins rule the code deliberately does not use.

### Re-review 2: the gate was declining in silence

In the exact scenario this PR is about, the gate correctly withheld the bond and logged **nothing**. The capture went from a confidently wrong `CLIENT_HELLO acked — link established` to no line at all — a bad trade for a strap still under diagnosis, and it would have removed the evidence that identified this bug in the first place.

Both platforms now emit a declined line naming the characteristic that completed, so it can be matched against the `→ CMD` line above it. This also gives the Swift side its **first** CLIENT_HELLO outcome line — the pure helper landed there earlier but was never wired to a caller.

Writing the string-parity oracle caught a real divergence: the Swift twin trims its inputs and the Kotlin one did not, so a padded uuid rendered differently on each platform. Kotlin now trims, and all five renderings are pinned against the compiled Swift stdout.

**438** `com.noop.ble` tests green.