### PR TITLE
ble: stop the CLIENT_HELLO from knocking a working 5/MG link off every 5s

### DIFF
--- a/android/app/src/main/java/com/noop/ble/BondRefusalGiveUp.kt
+++ b/android/app/src/main/java/com/noop/ble/BondRefusalGiveUp.kt
@@ -79,6 +79,35 @@ class BondRefusalGiveUp(
                 "settings choose Forget This Device. Then tap Connect to try again."
 
         /**
+         * #1635: the hint for a strap whose CLIENT_HELLO is never acknowledged, where NOOP now stays
+         * connected with the handshake switched off rather than pausing.
+         *
+         * Deliberately does NOT say "paused" (nothing is paused) and does NOT name a cause. An unanswered
+         * write is not evidence the strap is held by the official app, and the epitaph that asserts that is
+         * reserved for an actual auth refusal. Says what was observed and what the user still gets.
+         *
+         * Pure; no em-dash. Byte-identical to the Swift `BondRefusalGiveUp.helloSuppressedHint`.
+         */
+        fun helloSuppressedHint(): String =
+            "The secure handshake with your strap never completes, and the attempt itself is what drops " +
+                "the link. NOOP has switched it off for this strap so live heart rate keeps streaming. " +
+                "History sync stays unavailable until it pairs. Tap Connect to try the handshake again."
+
+        /**
+         * #1635: the log epitaph for the suppression path.
+         *
+         * Separate from [epitaphLine] because that one asserts a cause ("almost certainly held by the
+         * official WHOOP app") that only an auth refusal supports. Reusing it here would print a confident
+         * explanation for a write that simply vanished.
+         *
+         * Pure. Byte-identical to the Swift `BondRefusalGiveUp.helloSuppressedEpitaph`.
+         */
+        fun helloSuppressedEpitaph(refusals: Int, opaqueId: String): String =
+            "Bond epitaph: the strap [$opaqueId] never acknowledged the secure handshake ${refusals}x in a " +
+                "row, and the attempt is what drops the link - leaving the handshake off so live heart " +
+                "rate keeps streaming. Tap Connect to try it again."
+
+        /**
          * The paused hint for a bond that failed WITHOUT the strap ever answering (#1635).
          *
          * [pausedHint] names a cause — the strap still held by the official WHOOP app, or a stale OS

--- a/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
+++ b/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
@@ -1,0 +1,53 @@
+package com.noop.ble
+
+/**
+ * Whether to send the WHOOP 5/MG CLIENT_HELLO at all on this connect.
+ *
+ * The #1635 field captures show the hello is what ends the link. Across two sessions and sixteen writes it
+ * was never once acknowledged, and the drop is locked to the HELLO rather than to the connect: 3.158s,
+ * 3.159s, 3.155s after the write, cycle after cycle, while live HR streams happily over the standard
+ * profile the whole time. The bond-state trace added for this (#1639) records no OS pairing attempt at all,
+ * so the strap is not refusing a pairing — the write simply never completes and the local stack drops the
+ * ACL, which the log reports as an unattributed GATT status 22.
+ *
+ * The result is a strap that CAN deliver live HR being knocked off every five seconds by a handshake that
+ * has never once succeeded. Suppressing the hello after the give-up latches trades an unreachable
+ * capability (puffin commands, history offload) for one that demonstrably works (continuous live HR) —
+ * the "Live HR, not fully paired" state the app already models (#69), reached deliberately instead of
+ * never at all.
+ *
+ * [userInitiated] always re-attempts: suppression is a fallback for automatic reconnects, never a
+ * permanent verdict. Someone who puts the strap in pairing mode and presses Connect must get a fresh try,
+ * and that is also how the suppression is cleared.
+ */
+internal fun shouldSendClientHello(
+    suppressedForDevice: Boolean,
+    userInitiated: Boolean,
+): Boolean = !suppressedForDevice || userInitiated
+
+/**
+ * Should the give-up latch suppress the hello, rather than pause auto-reconnect?
+ *
+ * The two give-up causes want opposite treatment, which is why they are split here rather than sharing
+ * one branch:
+ *
+ *  - An AUTH REFUSAL means the strap actively declined the encrypted bond — typically because it is still
+ *    held by the official WHOOP app. Reconnecting cannot help until the user acts, so pausing is right.
+ *  - An UNANSWERED HANDSHAKE means the write vanished. The link itself is healthy and streaming, so
+ *    pausing throws away working live HR to punish a handshake nobody is waiting on. Suppress the hello
+ *    and stay connected instead.
+ *
+ * Splitting them is the whole point: before this, both ended in the same pause, so the strap that could
+ * still deliver HR was treated exactly like the one that could not.
+ */
+internal fun giveUpSuppressesHello(authRefusal: Boolean): Boolean = !authRefusal
+
+/**
+ * SharedPreferences key holding the hello-suppression latch for one device.
+ *
+ * Per device, and lowercased for the same reason [firmwarePrefKey] is: the same strap can present its
+ * address in different cases across sessions, and a case-sensitive key would silently latch a second time
+ * under a second key instead of reading the first.
+ */
+internal fun helloSuppressionPrefKey(peripheralId: String?): String? =
+    peripheralId?.trim()?.takeIf { it.isNotEmpty() }?.let { "noop.helloUnanswered.${it.lowercase()}" }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -885,6 +885,14 @@ class WhoopBleClient(
          * stale-direct-bond scan-fallback ([staleDirectBond]), it was not our OWN localTerminate bounce
          * (already counted by [onBondWatchdog]), and we are not already paused. A healthy strap that bonds on
          * the first connect has didBond == true, so it is never counted and its behaviour is unchanged.
+         *
+         * [helloSuppressed] excludes the #1635 strap, and it is not optional. Suppression makes `didBond`
+         * PERMANENTLY false by design — the handshake is deliberately not being sent — so every ordinary
+         * involuntary drop (out of range, radio off, a walk away from the phone) would otherwise look like
+         * "connects but never pairs" and march this counter toward a pause. That would undo the suppression
+         * a few drops later and hand the user a re-pair guide blaming a stale pairing, for a strap whose
+         * unbonded state NOOP chose on purpose. Not-bonding is only evidence of a fault when we were
+         * actually trying to bond.
          */
         internal fun shouldCountNeverBondedSelfDrop(
             wasConnected: Boolean,
@@ -893,8 +901,9 @@ class WhoopBleClient(
             staleDirectBond: Boolean,
             status: Int,
             alreadyPausedForBondLoop: Boolean,
+            helloSuppressed: Boolean,
         ): Boolean = wasConnected && !didBond && !intentionalDisconnect && !staleDirectBond &&
-            status != GATT_CONN_TERMINATE_LOCAL_HOST && !alreadyPausedForBondLoop
+            status != GATT_CONN_TERMINATE_LOCAL_HOST && !alreadyPausedForBondLoop && !helloSuppressed
 
         /** Pure guard for a delayed service-discovery kick. The operation belongs only to the exact
          *  connection that scheduled it, and a temporarily-missing GATT wrapper must not consume the
@@ -8277,6 +8286,9 @@ class WhoopBleClient(
                 staleDirectBond = staleDirectBond,
                 status = status,
                 alreadyPausedForBondLoop = autoReconnectPausedForBondLoop,
+                helloSuppressed = runCatching {
+                    com.noop.ui.NoopPrefs.helloSuppressed(context, lastDeviceAddress)
+                }.getOrDefault(false),
             ) && bondWatchdogBackoff.recordBounce()
         ) {
             log("Strap connects and subscribes but never finishes pairing, then self-drops before the bond watchdog fires (${bondWatchdogBackoff.consecutiveBounces} cycles) " +

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2915,6 +2915,9 @@ class WhoopBleClient(
     @SuppressLint("MissingPermission")
     fun connect(model: WhoopModel = WhoopModel.WHOOP4) {
         intentionalDisconnect = false
+        // #1635: an explicit Connect is the user saying "try the handshake again" — the documented way out
+        // of hello suppression, and the reason suppression is never a permanent verdict.
+        helloRetryRequested = true
         // PR #588: an explicit user-driven Connect is never an out-of-range retry — clear the involuntary-
         // reconnect streak so this scan (and any reconnects it spawns) starts back at the snappy
         // LOW_LATENCY scan mode + the 3s backoff base, never inheriting a backed-off lower-power scan.
@@ -4621,6 +4624,13 @@ class WhoopBleClient(
      *  against the teardown it is about to perform. None of the five is on a per-record path. */
     private fun noteLocalTeardown(origin: String) { lastLocalTeardown = origin }
 
+    /** Set by an explicit user Connect so the NEXT 5/MG session re-attempts a suppressed CLIENT_HELLO
+     *  (#1635). Consumed on use, so it grants exactly one retry: someone who put the strap in pairing mode
+     *  gets a fresh attempt, and a strap that still will not answer latches straight back off instead of
+     *  resuming the five-second loop the suppression exists to end. */
+    @Volatile
+    private var helloRetryRequested = false
+
     /** Consecutive involuntary reconnect attempts, feeding the capped-exponential [ReconnectBackoff]
      *  (3, 6, 12, 24, 48, 60s…). Replaces the old fixed [RECONNECT_DELAY_MS] rescan loop so a strap
      *  that's genuinely out of range stops hammering BLE — the Android twin of the iOS
@@ -4959,20 +4969,34 @@ class WhoopBleClient(
         // a strap that can't bond, write the one-line epitaph (opaque hashed id only, no PII), and surface
         // the honest paused hint. A genuine bond or a manual reconnect re-arms it.
         if (bondGiveUp.recordRefusal()) {
-            autoReconnectPausedForBondLoop = true
-            bondLoopPausedAtMs = System.currentTimeMillis()   // starts the #78 hole-4 salvage-probe floor
+            // #1635: an unanswered handshake and an auth refusal want opposite treatment — see
+            // [giveUpSuppressesHello]. Suppressing keeps a link that is streaming live HR; pausing is for a
+            // strap that actively declined and cannot be helped by reconnecting.
+            val opaque = BondRefusalGiveUp.opaqueId(failedAddress ?: "device")
+            val suppress = giveUpSuppressesHello(authRefusal)
+            if (suppress) {
+                runCatching { com.noop.ui.NoopPrefs.setHelloSuppressed(context, failedAddress, true) }
+                log(BondRefusalGiveUp.helloSuppressedEpitaph(bondGiveUp.refusals, opaque))
+            } else {
+                autoReconnectPausedForBondLoop = true
+                bondLoopPausedAtMs = System.currentTimeMillis()   // #78 hole-4 salvage-probe floor starts here
                 // #1539: park the connect in the same breath as the pause, so this can end while backgrounded.
                 standingConnectWhilePausedIfDue(justTripped = true)
-            val opaque = BondRefusalGiveUp.opaqueId(failedAddress ?: "device")
-            log(BondRefusalGiveUp.epitaphLine(bondGiveUp.refusals, opaque))
-            // An auth refusal supports naming a cause; an unanswered handshake does not, so it gets the
-            // hint that describes what was seen instead of asserting why (#1635).
+                log(BondRefusalGiveUp.epitaphLine(bondGiveUp.refusals, opaque))
+            }
+            // Each branch gets the hint that matches what it actually DID. The paused hints say
+            // "auto-reconnect is paused"; on the suppression branch nothing is paused, so saying so would be
+            // the same confidently-wrong diagnostic this issue has produced twice already (#1635).
             _state.update {
-                it.copy(pairingHint = if (authRefusal) BondRefusalGiveUp.pausedHint()
-                        else BondRefusalGiveUp.pausedHintHandshakeUnanswered())
+                it.copy(pairingHint = when {
+                    suppress -> BondRefusalGiveUp.helloSuppressedHint()
+                    authRefusal -> BondRefusalGiveUp.pausedHint()
+                    else -> BondRefusalGiveUp.pausedHintHandshakeUnanswered()
+                })
             }
             if (testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)) {
-                log("bond gaveUp refusals=${bondGiveUp.refusals} id=$opaque (auto-reconnect paused)",
+                log("bond gaveUp refusals=${bondGiveUp.refusals} id=$opaque " +
+                    if (suppress) "(hello suppressed, staying connected)" else "(auto-reconnect paused)",
                     com.noop.testcentre.TestDomain.CONNECTION)
             }
         }
@@ -4982,6 +5006,9 @@ class WhoopBleClient(
      *  the mirrored [statusNote] only when it still carries the hint, so we never wipe an unrelated note. */
     private fun clearPairingHint() {
         bondRefusalStreak = 0
+        // #1635: a genuine bond proves the handshake works on this strap — drop the suppression latch so a
+        // later transient failure starts from a clean slate rather than inheriting an old verdict.
+        runCatching { com.noop.ui.NoopPrefs.setHelloSuppressed(context, lastDeviceAddress, false) }
         // #747/#750: a genuine bond or a fresh user connect re-arms auto-reconnect and clears the give-up.
         bondGiveUp.reset()
         // #971: a genuine bond or a fresh user connect also clears the bond-watchdog bounce streak, so the
@@ -7226,7 +7253,31 @@ class WhoopBleClient(
         }
         when (connectedFamily) {
             DeviceFamily.WHOOP4 -> writeBondFrame(g, cmd)
-            DeviceFamily.WHOOP5 -> writeClientHello(g, cmd)
+            DeviceFamily.WHOOP5 -> {
+                // #1635: the hello is what ends the link on a strap that never answers it. Once the
+                // give-up has latched, skip it and let the standard-profile HR stream keep running.
+                //
+                // Consumed unconditionally, so the single retry an explicit Connect grants belongs to THIS
+                // session. Leaving it set would hand a stale retry to some later automatic reconnect and
+                // restart the loop the suppression exists to end.
+                val userAsked = helloRetryRequested
+                helloRetryRequested = false
+                val suppressed = runCatching {
+                    com.noop.ui.NoopPrefs.helloSuppressed(context, g.device.address)
+                }.getOrDefault(false)
+                if (shouldSendClientHello(suppressed, userInitiated = userAsked)) {
+                    writeClientHello(g, cmd)
+                } else {
+                    // The watchdog was armed at discovery, before this decision could be made, and it
+                    // bounces the link whenever didBond is still false. Suppressing the hello guarantees
+                    // didBond stays false, so leaving it armed would just move the drop from ~4.8s out to
+                    // the 7s window — the same loop, slower. There is no handshake left to time out.
+                    cancelBondWatchdog()
+                    log("WHOOP 5/MG: CLIENT_HELLO suppressed for this strap — it was never acknowledged and" +
+                        " the write is what drops the link. Staying on live HR (not fully paired); press" +
+                        " Connect to try the handshake again (#1635).")
+                }
+            }
         }
     }
 

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -1271,6 +1271,17 @@ object NoopPrefs {
     fun firmwareFor(context: Context, peripheralId: String?): String? =
         com.noop.ble.firmwarePrefKey(peripheralId)?.let { of(context).getString(it, null) }
 
+    /** True when the 5/MG CLIENT_HELLO has been latched off for this device after the give-up (#1635).
+     *  Absent key == not suppressed, so an unknown device always gets its first attempt. */
+    fun helloSuppressed(context: Context, peripheralId: String?): Boolean =
+        com.noop.ble.helloSuppressionPrefKey(peripheralId)?.let { of(context).getBoolean(it, false) } ?: false
+
+    /** Latch or clear the hello suppression for one device. A blank address writes nothing. */
+    fun setHelloSuppressed(context: Context, peripheralId: String?, suppressed: Boolean) {
+        val key = com.noop.ble.helloSuppressionPrefKey(peripheralId) ?: return
+        of(context).edit().apply { if (suppressed) putBoolean(key, true) else remove(key) }.apply()
+    }
+
     /** Record a firmware string against the device it came from. A blank address writes nothing rather
      *  than writing to a key that belongs to no device. */
     fun setFirmwareFor(context: Context, peripheralId: String?, fw: String?) {

--- a/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
@@ -1,0 +1,56 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** The #1635 hello-suppression rules: when to skip the handshake, and which give-up cause suppresses. */
+class HelloSuppressionTest {
+    @Test
+    fun `an unlatched strap always gets its handshake`() {
+        assertTrue(shouldSendClientHello(suppressedForDevice = false, userInitiated = false))
+        assertTrue(shouldSendClientHello(suppressedForDevice = false, userInitiated = true))
+    }
+
+    @Test
+    fun `a latched strap skips it on an automatic reconnect`() {
+        // The whole point: the automatic reconnect is the one that was looping every five seconds.
+        assertFalse(shouldSendClientHello(suppressedForDevice = true, userInitiated = false))
+    }
+
+    @Test
+    fun `an explicit Connect always re-attempts, so suppression is never permanent`() {
+        assertTrue(shouldSendClientHello(suppressedForDevice = true, userInitiated = true))
+    }
+
+    @Test
+    fun `only an unanswered handshake suppresses - an auth refusal still pauses`() {
+        // An auth refusal is evidence the strap actively declined and reconnecting cannot help, so the
+        // existing pause is right. An unanswered write is not that, and pausing would throw away live HR.
+        assertTrue(giveUpSuppressesHello(authRefusal = false))
+        assertFalse(giveUpSuppressesHello(authRefusal = true))
+    }
+
+    @Test
+    fun `the pref key is per device and case-insensitive`() {
+        assertEquals("noop.hellounanswered.fd:d4:f7:24:53:4a".replace("unanswered", "Unanswered"),
+            helloSuppressionPrefKey("FD:D4:F7:24:53:4A"))
+        assertEquals(helloSuppressionPrefKey("fd:d4:f7:24:53:4a"), helloSuppressionPrefKey("  FD:D4:F7:24:53:4A  "))
+        assertEquals(null, helloSuppressionPrefKey("   "))
+        assertEquals(null, helloSuppressionPrefKey(null))
+    }
+
+    @Test
+    fun `the suppression hint never claims a pause or a cause`() {
+        val hint = BondRefusalGiveUp.helloSuppressedHint()
+        // Nothing is paused on this branch, and an unanswered write is not evidence the official WHOOP app
+        // is holding the strap - the two mistakes this issue has already produced.
+        assertFalse(hint.contains("paus", ignoreCase = true))
+        assertFalse(hint.contains("WHOOP app", ignoreCase = true))
+        assertTrue(hint.contains("Connect"))
+        val epitaph = BondRefusalGiveUp.helloSuppressedEpitaph(5, "abcd1234")
+        assertFalse(epitaph.contains("held by", ignoreCase = true))
+        assertTrue(epitaph.contains("abcd1234"))
+    }
+}

--- a/android/app/src/test/java/com/noop/ble/NeverBondedSelfDropGiveUpTest.kt
+++ b/android/app/src/test/java/com/noop/ble/NeverBondedSelfDropGiveUpTest.kt
@@ -27,7 +27,7 @@ class NeverBondedSelfDropGiveUpTest {
         assertTrue(
             WhoopBleClient.shouldCountNeverBondedSelfDrop(
                 wasConnected = true, didBond = false, intentionalDisconnect = false,
-                staleDirectBond = false, status = STATUS_SELF_DROP, alreadyPausedForBondLoop = false,
+                staleDirectBond = false, status = STATUS_SELF_DROP, alreadyPausedForBondLoop = false, helloSuppressed = false,
             )
         )
     }
@@ -38,7 +38,7 @@ class NeverBondedSelfDropGiveUpTest {
         assertFalse(
             WhoopBleClient.shouldCountNeverBondedSelfDrop(
                 wasConnected = true, didBond = true, intentionalDisconnect = false,
-                staleDirectBond = false, status = STATUS_SELF_DROP, alreadyPausedForBondLoop = false,
+                staleDirectBond = false, status = STATUS_SELF_DROP, alreadyPausedForBondLoop = false, helloSuppressed = false,
             )
         )
     }
@@ -48,7 +48,7 @@ class NeverBondedSelfDropGiveUpTest {
         assertFalse(
             WhoopBleClient.shouldCountNeverBondedSelfDrop(
                 wasConnected = false, didBond = false, intentionalDisconnect = false,
-                staleDirectBond = false, status = STATUS_SELF_DROP, alreadyPausedForBondLoop = false,
+                staleDirectBond = false, status = STATUS_SELF_DROP, alreadyPausedForBondLoop = false, helloSuppressed = false,
             )
         )
     }
@@ -58,7 +58,7 @@ class NeverBondedSelfDropGiveUpTest {
         assertFalse(
             WhoopBleClient.shouldCountNeverBondedSelfDrop(
                 wasConnected = true, didBond = false, intentionalDisconnect = true,
-                staleDirectBond = false, status = STATUS_SELF_DROP, alreadyPausedForBondLoop = false,
+                staleDirectBond = false, status = STATUS_SELF_DROP, alreadyPausedForBondLoop = false, helloSuppressed = false,
             )
         )
     }
@@ -68,7 +68,7 @@ class NeverBondedSelfDropGiveUpTest {
         assertFalse(
             WhoopBleClient.shouldCountNeverBondedSelfDrop(
                 wasConnected = true, didBond = false, intentionalDisconnect = false,
-                staleDirectBond = true, status = STATUS_SELF_DROP, alreadyPausedForBondLoop = false,
+                staleDirectBond = true, status = STATUS_SELF_DROP, alreadyPausedForBondLoop = false, helloSuppressed = false,
             )
         )
     }
@@ -79,7 +79,7 @@ class NeverBondedSelfDropGiveUpTest {
         assertFalse(
             WhoopBleClient.shouldCountNeverBondedSelfDrop(
                 wasConnected = true, didBond = false, intentionalDisconnect = false,
-                staleDirectBond = false, status = STATUS_LOCAL_TERMINATE, alreadyPausedForBondLoop = false,
+                staleDirectBond = false, status = STATUS_LOCAL_TERMINATE, alreadyPausedForBondLoop = false, helloSuppressed = false,
             )
         )
     }
@@ -89,7 +89,7 @@ class NeverBondedSelfDropGiveUpTest {
         assertFalse(
             WhoopBleClient.shouldCountNeverBondedSelfDrop(
                 wasConnected = true, didBond = false, intentionalDisconnect = false,
-                staleDirectBond = false, status = STATUS_SELF_DROP, alreadyPausedForBondLoop = true,
+                staleDirectBond = false, status = STATUS_SELF_DROP, alreadyPausedForBondLoop = true, helloSuppressed = false,
             )
         )
     }
@@ -103,6 +103,7 @@ class NeverBondedSelfDropGiveUpTest {
             val gate = WhoopBleClient.shouldCountNeverBondedSelfDrop(
                 wasConnected = true, didBond = false, intentionalDisconnect = false,
                 staleDirectBond = false, status = STATUS_SELF_DROP, alreadyPausedForBondLoop = backoff.shouldGiveUp(),
+                helloSuppressed = false,
             )
             return gate && backoff.recordBounce()
         }
@@ -123,7 +124,7 @@ class NeverBondedSelfDropGiveUpTest {
             "self-drop gate excludes the watchdog's own localTerminate",
             WhoopBleClient.shouldCountNeverBondedSelfDrop(
                 wasConnected = true, didBond = false, intentionalDisconnect = false,
-                staleDirectBond = false, status = STATUS_LOCAL_TERMINATE, alreadyPausedForBondLoop = false,
+                staleDirectBond = false, status = STATUS_LOCAL_TERMINATE, alreadyPausedForBondLoop = false, helloSuppressed = false,
             )
         )
         backoff.recordBounce() // the watchdog would have counted this cycle itself
@@ -132,7 +133,7 @@ class NeverBondedSelfDropGiveUpTest {
             assertTrue(
                 WhoopBleClient.shouldCountNeverBondedSelfDrop(
                     wasConnected = true, didBond = false, intentionalDisconnect = false,
-                    staleDirectBond = false, status = STATUS_SELF_DROP, alreadyPausedForBondLoop = false,
+                    staleDirectBond = false, status = STATUS_SELF_DROP, alreadyPausedForBondLoop = false, helloSuppressed = false,
                 )
             )
             assertFalse(backoff.recordBounce())
@@ -141,10 +142,41 @@ class NeverBondedSelfDropGiveUpTest {
         assertTrue(
             WhoopBleClient.shouldCountNeverBondedSelfDrop(
                 wasConnected = true, didBond = false, intentionalDisconnect = false,
-                staleDirectBond = false, status = STATUS_SELF_DROP, alreadyPausedForBondLoop = false,
+                staleDirectBond = false, status = STATUS_SELF_DROP, alreadyPausedForBondLoop = false, helloSuppressed = false,
             )
         )
         assertTrue("shared streak crosses the give-up threshold at 4", backoff.recordBounce())
         assertEquals(4, backoff.consecutiveBounces)
+    }
+
+    @Test
+    fun `a deliberately-suppressed strap is never counted as never-bonding`() {
+        // #1635: hello suppression makes didBond permanently false ON PURPOSE. Without this exclusion every
+        // ordinary drop - out of range, radio off, walking away from the phone - would look like "connects
+        // but never pairs", march this counter to a pause, and hand the user a re-pair guide blaming a stale
+        // pairing. Not-bonding is only evidence of a fault when we were actually trying to bond.
+        assertFalse(
+            WhoopBleClient.shouldCountNeverBondedSelfDrop(
+                wasConnected = true,
+                didBond = false,
+                intentionalDisconnect = false,
+                staleDirectBond = false,
+                status = 0,
+                alreadyPausedForBondLoop = false,
+                helloSuppressed = true,
+            )
+        )
+        // Same inputs, not suppressed: still counted, so the #982 protection is untouched.
+        assertTrue(
+            WhoopBleClient.shouldCountNeverBondedSelfDrop(
+                wasConnected = true,
+                didBond = false,
+                intentionalDisconnect = false,
+                staleDirectBond = false,
+                status = 0,
+                alreadyPausedForBondLoop = false,
+                helloSuppressed = false,
+            )
+        )
     }
 }


### PR DESCRIPTION
## The cause, from the captures

The drop is locked to the **CLIENT_HELLO**, not to the connect:

| gen | hello written | link dropped | Δ |
|---|---|---|---|
| 3 | 17:24:50 | 17:24:53 | 3.158s |
| 4 | 17:25:01 | 17:25:04 | 3.159s |
| 5 | 17:25:11 | 17:25:14 | 3.155s |

Across two sessions the hello was written **16 times and acknowledged zero times**. Live HR streams over the standard profile the entire time, every cycle. The bond-state trace (#1639) records **no OS pairing attempt at all** — so the strap is not refusing to pair; the write never completes and the local stack drops the ACL, reported as an unattributed `status 22 / via=unknown`.

A strap that *can* deliver live HR was being knocked off every five seconds by a handshake that has never once succeeded.

## The change

After the give-up latches, the hello is left off for that strap and the link stays up on the standard profile. That trades an unreachable capability — puffin commands, history offload, neither of which has ever worked here — for one that demonstrably works. It is the "Live HR, not fully paired" state the app already models (#69), reached deliberately instead of never.

The substance is that the give-up's **two causes now diverge**:

| cause | evidence | treatment |
|---|---|---|
| auth refusal | strap actively declined | pause auto-reconnect (unchanged) |
| unanswered handshake | write vanished, link healthy | suppress the hello, stay connected |

Before this both ended in the same pause, so the strap that could still deliver HR was treated exactly like the one that could not.

Suppression is never permanent — an explicit **Connect** always re-attempts, consumed for that session so a stale retry cannot restart the loop later, and a genuine bond clears the latch outright.

## Re-review caught two things

The first would have defeated the fix entirely:

- **The bond watchdog is armed at service discovery**, before this decision exists, and bounces the link whenever `didBond` is false. Suppressing the hello *guarantees* `didBond` stays false — so the link would still have dropped, at 7s instead of 4.8s. The same loop, slower. Now cancelled when we suppress; there is no handshake left to time out.
- **Three diagnostics announced a pause that no longer happens** on this branch — the epitaph, the paused hint, and the Test Centre line. Each branch now gets text describing what it actually did, and the suppression text asserts no cause: an unanswered write is not evidence the official WHOOP app holds the strap.

## Scope

Android only, matching #1640 — the unanswered-handshake give-up gate is Android-side, and the Swift 5/MG path is structurally different with no field evidence behind it.

## Verification

- 460 `com.noop.ble` tests green; `compileFullDebugKotlin` clean.
- `doc_comment_lint`, `i18n_audit`, and `lintVitalFullRelease -PstagingRelease` all clean.
- **Not yet confirmed on a strap.** The prediction is specific and falsifiable: after the give-up latches, the reconnect loop stops and live HR keeps streaming continuously. If the link still drops on a cycle with no `writing CLIENT_HELLO` line, the diagnosis is wrong.

---

### Re-review: the fix would have quietly undone itself

`shouldCountNeverBondedSelfDrop` (#982) keys on `didBond == false` — and suppression makes `didBond` **permanently** false by design. So every ordinary involuntary drop on a suppressed strap (out of range, radio off, walking away from the phone) looked like "connects but never pairs" and marched the give-up counter toward a pause.

A few drops into normal use, that would have paused auto-reconnect and handed the user a re-pair guide blaming a stale Bluetooth pairing — for a strap whose unbonded state NOOP chose on purpose. Not-bonding is only evidence of a fault when we were actually trying to bond.

`helloSuppressed` is a **required** parameter rather than defaulting to false, so every existing call site had to be looked at and a future caller has to decide too. All seven existing cases predate suppression and pass `false`, so the #982 protection for a genuinely stuck strap is unchanged — pinned by a test asserting the same inputs still count when not suppressed.

Also checked and found sound in this pass, listed so they don't get re-derived:

- The latch is written with `lastDeviceAddress` and read with `g.device.address`; both are the connected strap and both are lowercased through `helloSuppressionPrefKey`, so the keys agree.
- `clearPairingHint` is only reachable from a user Connect or a genuine bond, so the latch cannot be cleared by an automatic reconnect.
- `helloWasUnacked` is `clientHelloWriteAtMs > 0L`, which stays 0 when suppressed — so a suppressed strap does not keep re-latching the give-up.
- #617's post-bond loop detector requires a genuine bond, so it cannot fire on a strap that never bonds.

**461** `com.noop.ble` tests green.