### PR TITLE
fix(android): use the active strap's motion in Steps calibration

### DIFF
--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1330,6 +1330,22 @@ class WhoopRepository(
     suspend fun gravitySamples(deviceId: String, from: Long, to: Long, limit: Int = DEFAULT_LIMIT) =
         dao.gravitySamples(deviceId, from, to, limit)
 
+    /**
+     * Gravity samples over the read-side union of the active strap id and canonical "my-whoop",
+     * deduped by timestamp with the active strap winning. A re-added strap banks live motion under its
+     * fresh device id while older/imported motion can remain under the canonical id; calibration reads
+     * need both histories just like [hrSamplesUnion]. A canonical active id still performs one unchanged
+     * DAO read.
+     */
+    suspend fun gravitySamplesUnion(
+        activeDeviceId: String,
+        from: Long,
+        to: Long,
+        limit: Int = DEFAULT_LIMIT,
+    ): List<GravitySample> = mergeGravityByTs(
+        importedSourceIds(activeDeviceId).map { dao.gravitySamples(it, from, to, limit) },
+    )
+
     suspend fun sleepSessions(deviceId: String, from: Long, to: Long, limit: Int = DEFAULT_LIMIT) =
         dao.sleepSessions(deviceId, from, to, limit)
 
@@ -2332,6 +2348,18 @@ class WhoopRepository(
         internal fun mergeHrByTs(lists: List<List<HrSample>>): List<HrSample> {
             if (lists.size == 1) return lists[0]
             val byTs = LinkedHashMap<Long, HrSample>()
+            for (list in lists) for (s in list) byTs.putIfAbsent(s.ts, s)
+            return byTs.values.sortedBy { it.ts }
+        }
+
+        /**
+         * Merge gravity sample lists into one time-ordered stream, deduped by timestamp with the FIRST
+         * list (the active strap) winning on a tie. A single-id read is returned unchanged, matching the
+         * pre-union path and [mergeHrByTs].
+         */
+        internal fun mergeGravityByTs(lists: List<List<GravitySample>>): List<GravitySample> {
+            if (lists.size == 1) return lists[0]
+            val byTs = LinkedHashMap<Long, GravitySample>()
             for (list in lists) for (s in list) byTs.putIfAbsent(s.ts, s)
             return byTs.values.sortedBy { it.ts }
         }

--- a/android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt
@@ -132,11 +132,12 @@ fun StepsCalibrationScreen(
         )
         val rows = ArrayList<StepsComparisonRow>()
         val motions = ArrayList<Double>()
+        val activeStrapId = vm.activeStrapId
         for ((day, phone) in phoneDays.take(10)) {           // scan extra to fill 7 after motion gaps
             val mid = runCatching {
                 LocalDate.parse(day).atStartOfDay(ZoneId.systemDefault()).toEpochSecond()
             }.getOrNull() ?: continue
-            val grav = vm.repo.gravitySamples("my-whoop", mid, mid + 86_400 - 1)
+            val grav = vm.repo.gravitySamplesUnion(activeStrapId, mid, mid + 86_400 - 1)
             val motion = StepsEstimateEngine.dayMotionIntensity(grav)
             val est = StepsEstimateEngine.estimate(motion, cal) ?: continue
             motions.add(motion)

--- a/android/app/src/test/java/com/noop/data/GravityReadUnionTest.kt
+++ b/android/app/src/test/java/com/noop/data/GravityReadUnionTest.kt
@@ -1,0 +1,70 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/** Regression coverage for the gravity read used by the Steps calibration screen (#1643). */
+class GravityReadUnionTest {
+
+    private val canonical = WhoopRepository.WHOOP_SOURCE
+    private val active = "whoop-abc"
+
+    private fun sample(deviceId: String, ts: Long, x: Double) =
+        GravitySample(deviceId = deviceId, ts = ts, x = x, y = 0.0, z = 1.0)
+
+    @Test
+    fun activeOnlyMotionIsSurfacedWhenCanonicalIsEmpty() {
+        val activeRows = listOf(
+            sample(active, 100, 0.1),
+            sample(active, 101, 0.2),
+        )
+        val byId = mapOf(active to activeRows, canonical to emptyList())
+
+        val ids = WhoopRepository.importedSourceIdsFor(active)
+        val merged = WhoopRepository.mergeGravityByTs(ids.map { byId.getValue(it) })
+
+        assertEquals(listOf(active, canonical), ids)
+        assertEquals(activeRows, merged)
+    }
+
+    @Test
+    fun activeAndCanonicalHistoryMergeInTimestampOrderWithActiveWinningTies() {
+        val activeRows = listOf(
+            sample(active, 101, 9.0),
+            sample(active, 103, 9.2),
+        )
+        val canonicalRows = listOf(
+            sample(canonical, 100, 5.0),
+            sample(canonical, 101, 5.1),
+            sample(canonical, 102, 5.2),
+        )
+
+        val merged = WhoopRepository.mergeGravityByTs(listOf(activeRows, canonicalRows))
+
+        assertEquals(listOf(100L, 101L, 102L, 103L), merged.map { it.ts })
+        assertEquals(active, merged.first { it.ts == 101L }.deviceId)
+        assertEquals(9.0, merged.first { it.ts == 101L }.x, 0.0)
+    }
+
+    @Test
+    fun canonicalActiveIdKeepsTheExistingSingleReadUnchanged() {
+        val rows = listOf(
+            sample(canonical, 100, 0.1),
+            sample(canonical, 101, 0.2),
+        )
+
+        val ids = WhoopRepository.importedSourceIdsFor(canonical)
+        val merged = WhoopRepository.mergeGravityByTs(listOf(rows))
+
+        assertEquals(listOf(canonical), ids)
+        assertSame(rows, merged)
+    }
+
+    @Test
+    fun noMotionUnderEitherIdStaysEmpty() {
+        val merged = WhoopRepository.mergeGravityByTs(listOf(emptyList(), emptyList()))
+
+        assertEquals(emptyList<GravitySample>(), merged)
+    }
+}


### PR DESCRIPTION
Fixes #1643

## Summary

- add a gravity-sample union for the active strap plus canonical my-whoop history
- deduplicate overlapping timestamps with active-strap rows winning
- make the Steps calibration comparison read motion through that union
- cover re-added straps, mixed history, canonical-only installs, and absent motion

## Testing

- ANDROID_HOME=/home/kaveman/Android/Sdk ./gradlew :app:testFullDebugUnitTest --tests com.noop.data.GravityReadUnionTest
- ANDROID_HOME=/home/kaveman/Android/Sdk ./gradlew :app:testFullDebugUnitTest