### PR TITLE
ui: stop calling a live-HR-only link "Bonded"

### DIFF
--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -374,7 +374,7 @@ public final class LiveState: ObservableObject {
         if connected && bonded { return "Live HR (not fully paired)" }
         if connected { return "Connected" }
         if encryptedBond { return "Bonded · idle" }
-        if bonded { return "Paired · idle" }
+        // No `bonded`-only idle arm: without an encrypted bond there was never a pairing to be idle from.
         return "Disconnected"
     }
     /// True when the link is up with a REAL encrypted bond → status reads green. A live-HR-only link is

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -363,16 +363,26 @@ public final class LiveState: ObservableObject {
     /// card, so the two can't disagree the way they did in #266 (sidebar "Connecting…" vs Settings
     /// "Connected" for the same connected-but-unbonded 5/MG link). Once the link is up and HR is
     /// flowing — even over the unbonded standard profile — this reads "Connected", never "Connecting…".
+    ///
+    /// "Bonded" means [encryptedBond], never [bonded]. The 5/MG live-HR shortcut (#69) sets `bonded` while
+    /// HR streams over the OPEN profile with no pairing at all, so keying the green bonded state off it
+    /// told a strap with no encrypted pairing that it had one — and the encrypted bond is exactly what
+    /// gates buzz, alarms, double-tap and history sync. LiveView has drawn this line since #69; this
+    /// shared label (sidebar + Settings) had not, so the two screens disagreed about the same link.
     public var connectionStatusLabel: String {
-        if connected && bonded { return "Bonded · streaming" }
+        if connected && encryptedBond { return "Bonded · streaming" }
+        if connected && bonded { return "Live HR (not fully paired)" }
         if connected { return "Connected" }
-        if bonded { return "Bonded · idle" }
+        if encryptedBond { return "Bonded · idle" }
+        if bonded { return "Paired · idle" }
         return "Disconnected"
     }
-    /// True when the link is up (HR flowing) → status reads green. Drives the sidebar + Settings tone.
-    public var connectionStatusIsActive: Bool { connected }
-    /// True when previously paired but not currently connected → amber.
-    public var connectionStatusIsIdle: Bool { !connected && bonded }
+    /// True when the link is up with a REAL encrypted bond → status reads green. A live-HR-only link is
+    /// amber via [connectionStatusIsIdle]: it works, but every pairing-gated feature is unavailable.
+    public var connectionStatusIsActive: Bool { connected && encryptedBond }
+    /// True when previously paired but not currently connected, OR connected with live HR but no
+    /// encrypted bond → amber either way.
+    public var connectionStatusIsIdle: Bool { (!connected && bonded) || (connected && !encryptedBond) }
 
     /// Fired (live only) when the strap reports a DOUBLE_TAP gesture. Wired by AppModel to the
     /// user's chosen action. Debounced in AppModel.

--- a/Strand/Screens/DataSourcesView.swift
+++ b/Strand/Screens/DataSourcesView.swift
@@ -914,11 +914,20 @@ struct DataSourcesView: View {
         // Three-state, consistent with the Live screen's connection pill — a connected-but-
         // not-yet-streaming strap (e.g. an experimental WHOOP 5/MG link) no longer reads as
         // "Not connected" on one screen and "Connected" on another (issue #8).
-        let (tone, label): (StrandTone, LocalizedStringKey) =
-            live.encryptedBond ? (.positive, "Bonded, streaming.")
-            : live.bonded ? (.warning, "Live HR (not fully paired)")
-            : live.connected ? (.warning, "Connected.")
-            : (.critical, "Not connected. Open Live to pair.")
+        // Written as statements rather than a ternary chain: five arms of (StrandTone,
+        // LocalizedStringKey) tuples is the shape that pushes this expression past the iOS type-check
+        // budget, and it fails in CI rather than here.
+        let tone: StrandTone
+        let label: LocalizedStringKey
+        if live.encryptedBond {
+            tone = .positive; label = "Bonded, streaming."
+        } else if live.bonded {
+            tone = .warning; label = "Live HR (not fully paired)"
+        } else if live.connected {
+            tone = .warning; label = "Connected."
+        } else {
+            tone = .critical; label = "Not connected. Open Live to pair."
+        }
         return card(title: String(localized: "WHOOP Strap (Live BLE)"), icon: "antenna.radiowaves.left.and.right",
              tint: StrandPalette.accent,
              status: StatePill(label, tone: tone, pulsing: live.connected && !live.bonded),

--- a/Strand/Screens/DataSourcesView.swift
+++ b/Strand/Screens/DataSourcesView.swift
@@ -915,7 +915,8 @@ struct DataSourcesView: View {
         // not-yet-streaming strap (e.g. an experimental WHOOP 5/MG link) no longer reads as
         // "Not connected" on one screen and "Connected" on another (issue #8).
         let (tone, label): (StrandTone, LocalizedStringKey) =
-            live.bonded ? (.positive, "Bonded, streaming.")
+            live.encryptedBond ? (.positive, "Bonded, streaming.")
+            : live.bonded ? (.warning, "Live HR (not fully paired)")
             : live.connected ? (.warning, "Connected.")
             : (.critical, "Not connected. Open Live to pair.")
         return card(title: String(localized: "WHOOP Strap (Live BLE)"), icon: "antenna.radiowaves.left.and.right",

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -1471,7 +1471,11 @@ struct SettingsView: View {
     }
 
     private var strapStatusDetail: String {
-        if live.bonded && live.connected {
+        // encryptedBond, not bonded — see LiveState.connectionStatusLabel. Saying "is paired" for a
+        // live-HR-only link contradicts both LiveView's pill and the buzz/alarm rows on this same screen,
+        // which correctly refuse and explain that they need the full encrypted bond. A live-HR link falls
+        // through to the pairing hint below, which describes the real state.
+        if live.encryptedBond && live.connected {
             return String(localized: "Your strap is paired and sending data. Open Live for a real-time heart rate.")
         }
         if live.connected, let hint = live.pairingHint { return hint }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -1473,8 +1473,14 @@ struct SettingsView: View {
     private var strapStatusDetail: String {
         // encryptedBond, not bonded — see LiveState.connectionStatusLabel. Saying "is paired" for a
         // live-HR-only link contradicts both LiveView's pill and the buzz/alarm rows on this same screen,
-        // which correctly refuse and explain that they need the full encrypted bond. A live-HR link falls
-        // through to the pairing hint below, which describes the real state.
+        // which correctly refuse and explain that they need the full encrypted bond.
+        //
+        // A live-HR link falls through to the pairing hint when one is set, and otherwise to "Finishing
+        // the secure pairing handshake…", which is accurate HERE because this platform still retries the
+        // CLIENT_HELLO on every connect. Android has an explicit "streaming but not fully paired" arm
+        // instead, because #1635 suppression stops it retrying and nothing is finishing any more. If that
+        // suppression is ported here, this branch must gain the same arm or it starts describing a
+        // handshake that is no longer being attempted.
         if live.encryptedBond && live.connected {
             return String(localized: "Your strap is paired and sending data. Open Live for a real-time heart rate.")
         }

--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -867,7 +867,11 @@ fun DataSourcesScreen(vm: AppViewModel) {
             subtitle = "Pairs directly with your strap over Bluetooth: no WHOOP app, no cloud.",
         ) {
             val (label, tone) = when {
-                live.bonded -> "Bonded, streaming." to StrandTone.Positive
+                // encryptedBond, not bonded — see strapStatusTitle. A 5/MG streaming over the open
+                // profile has bonded == true with no pairing at all, and after #1635 hello suppression it
+                // stays there for good rather than passing through.
+                live.encryptedBond -> "Bonded, streaming." to StrandTone.Positive
+                live.bonded -> "Live HR (not fully paired)" to StrandTone.Warning
                 live.connected -> "Connected, pairing…" to StrandTone.Warning
                 else -> "Not connected. Open Live to pair." to StrandTone.Critical
             }

--- a/android/app/src/main/java/com/noop/ui/SettingsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsLogic.kt
@@ -46,7 +46,9 @@ internal fun strapStatusTitle(encryptedBond: Boolean, bonded: Boolean, connected
     encryptedBond -> "Bonded · idle"
     bonded && connected -> "Live HR (not fully paired)"
     connected -> "Connected"
-    bonded -> "Paired · idle"
+    // No `bonded`-only idle arm: without an encrypted bond there was never a pairing to be idle from,
+    // and labelling that "Paired" would be the same overclaim this change exists to remove. The 5/MG
+    // shortcut's `bonded` is cleared on disconnect anyway, so the honest answer here is Disconnected.
     else -> "Disconnected"
 }
 

--- a/android/app/src/main/java/com/noop/ui/SettingsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsLogic.kt
@@ -28,23 +28,46 @@ internal fun waistInchesStep(current: Double, up: Boolean): Double {
 
 // MARK: - Strap status helpers (mirror SettingsView's computed properties)
 
-internal fun strapStatusTitle(bonded: Boolean, connected: Boolean): String = when {
-    bonded && connected -> "Bonded · streaming"
+/**
+ * The Strap pill on Settings.
+ *
+ * [encryptedBond], not [bonded], is what "Bonded" means. `bonded` is also set by the 5/MG live-HR
+ * shortcut (#69), where HR streams over the open profile with no encrypted pairing at all — so keying the
+ * green "Bonded" state off it told a strap with no pairing that it had one. The Live screen has drawn this
+ * distinction since #69; Settings and Data Sources were missed, and #1635 hello suppression turns that
+ * state from a brief moment on the way to bonding into where a 5/MG now permanently sits.
+ *
+ * It is not cosmetic. The encrypted bond gates buzz, alarms, double-tap and history sync, and Settings
+ * already says so a few rows further down ("Needs the full encrypted bond…"). A green "Bonded · streaming"
+ * above that contradicts it on the same screen.
+ */
+internal fun strapStatusTitle(encryptedBond: Boolean, bonded: Boolean, connected: Boolean): String = when {
+    encryptedBond && connected -> "Bonded · streaming"
+    encryptedBond -> "Bonded · idle"
+    bonded && connected -> "Live HR (not fully paired)"
     connected -> "Connected"
-    bonded -> "Bonded · idle"
+    bonded -> "Paired · idle"
     else -> "Disconnected"
 }
 
-internal fun strapTone(bonded: Boolean, connected: Boolean): StrandTone = when {
-    connected -> StrandTone.Positive
-    bonded -> StrandTone.Warning
+/** Positive ONLY for a real encrypted bond on a live link — see [strapStatusTitle]. A live-HR-only link
+ *  is a warning, not a success: it works, but the pairing-gated features do not. */
+internal fun strapTone(encryptedBond: Boolean, bonded: Boolean, connected: Boolean): StrandTone = when {
+    encryptedBond && connected -> StrandTone.Positive
+    connected || bonded -> StrandTone.Warning
     else -> StrandTone.Critical
 }
 
 // `internal` (not private) so the unit test in the same package can assert the scanning branch.
-internal fun strapStatusDetail(bonded: Boolean, connected: Boolean, scanning: Boolean): String = when {
+internal fun strapStatusDetail(
+    encryptedBond: Boolean,
+    bonded: Boolean,
+    connected: Boolean,
+    scanning: Boolean,
+): String = when {
     scanning -> "Searching for your WHOOP… make sure it's charged, on your wrist, and the official WHOOP app isn't connected to it."
-    bonded && connected -> "Your strap is paired and sending data. Open Live for a real-time heart rate."
+    encryptedBond && connected -> "Your strap is paired and sending data. Open Live for a real-time heart rate."
+    bonded && connected -> "Live heart rate is streaming, but your strap is not fully paired. Buzz, alarms and history sync need the encrypted pairing."
     connected -> "Connected. Finishing the secure pairing handshake…"
     bonded -> "Previously paired but not currently connected. Re-scan to reconnect."
     else -> "No strap connected. Put your WHOOP nearby and tap Re-scan to pair."

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1721,8 +1721,8 @@ fun SettingsScreen(
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
                     StatePill(
-                        title = strapStatusTitle(live.bonded, live.connected),
-                        tone = strapTone(live.bonded, live.connected),
+                        title = strapStatusTitle(live.encryptedBond, live.bonded, live.connected),
+                        tone = strapTone(live.encryptedBond, live.bonded, live.connected),
                         pulsing = live.connected,
                     )
                     live.batteryPct?.let { pct ->
@@ -1735,7 +1735,7 @@ fun SettingsScreen(
                     }
                 }
                 Text(
-                    strapStatusDetail(live.bonded, live.connected, live.scanning),
+                    strapStatusDetail(live.encryptedBond, live.bonded, live.connected, live.scanning),
                     style = NoopType.subhead,
                     color = Palette.textSecondary,
                 )

--- a/android/app/src/test/java/com/noop/ui/StrapStatusDetailTest.kt
+++ b/android/app/src/test/java/com/noop/ui/StrapStatusDetailTest.kt
@@ -1,6 +1,7 @@
 package com.noop.ui
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -16,11 +17,11 @@ class StrapStatusDetailTest {
     fun scanning_takesPrecedence_overEveryOtherState() {
         // Even when already bonded + connected, an active scan must say "Searching…".
         assertTrue(
-            strapStatusDetail(bonded = true, connected = true, scanning = true)
+            strapStatusDetail(encryptedBond = true, bonded = true, connected = true, scanning = true)
                 .startsWith("Searching for your WHOOP"),
         )
         assertTrue(
-            strapStatusDetail(bonded = false, connected = false, scanning = true)
+            strapStatusDetail(encryptedBond = false, bonded = false, connected = false, scanning = true)
                 .startsWith("Searching for your WHOOP"),
         )
     }
@@ -29,19 +30,43 @@ class StrapStatusDetailTest {
     fun nonScanning_branches_areUnchanged() {
         assertEquals(
             "Your strap is paired and sending data. Open Live for a real-time heart rate.",
-            strapStatusDetail(bonded = true, connected = true, scanning = false),
+            strapStatusDetail(encryptedBond = true, bonded = true, connected = true, scanning = false),
         )
         assertEquals(
             "Connected. Finishing the secure pairing handshake…",
-            strapStatusDetail(bonded = false, connected = true, scanning = false),
+            strapStatusDetail(encryptedBond = false, bonded = false, connected = true, scanning = false),
         )
         assertEquals(
             "Previously paired but not currently connected. Re-scan to reconnect.",
-            strapStatusDetail(bonded = true, connected = false, scanning = false),
+            strapStatusDetail(encryptedBond = true, bonded = true, connected = false, scanning = false),
         )
         assertEquals(
             "No strap connected. Put your WHOOP nearby and tap Re-scan to pair.",
-            strapStatusDetail(bonded = false, connected = false, scanning = false),
+            strapStatusDetail(encryptedBond = false, bonded = false, connected = false, scanning = false),
         )
+    }
+
+    @Test
+    fun `a live-HR-only link is not described as paired`() {
+        // #1635/#69: the 5/MG live-HR shortcut sets bonded without any encrypted pairing, and hello
+        // suppression makes that the permanent state. Telling the user their strap "is paired" there
+        // contradicts the Devices screen and the buzz/alarm rows on this same screen.
+        val detail = strapStatusDetail(
+            encryptedBond = false, bonded = true, connected = true, scanning = false,
+        )
+        assertFalse(detail.contains("is paired"))
+        assertTrue(detail.contains("not fully paired"))
+
+        assertEquals("Live HR (not fully paired)",
+            strapStatusTitle(encryptedBond = false, bonded = true, connected = true))
+        assertEquals("Bonded · streaming",
+            strapStatusTitle(encryptedBond = true, bonded = true, connected = true))
+    }
+
+    @Test
+    fun `only a real bond on a live link is a positive tone`() {
+        assertEquals(StrandTone.Positive, strapTone(encryptedBond = true, bonded = true, connected = true))
+        assertEquals(StrandTone.Warning, strapTone(encryptedBond = false, bonded = true, connected = true))
+        assertEquals(StrandTone.Critical, strapTone(encryptedBond = false, bonded = false, connected = false))
     }
 }


### PR DESCRIPTION
## Caught on a real device

Two screens, same strap, same moment:

| screen | says |
|---|---|
| **Devices** | `Connected · not paired` (amber) + "NOOP has switched it off for this strap so live heart rate keeps streaming" |
| **Settings → Strap** | `● Bonded · streaming` (green) + "Your strap is **paired** and sending data." |

The Devices screen is right. Settings is wrong twice.

## Cause

Settings and Data Sources keyed their green "Bonded" state off `bonded` — which the 5/MG live-HR shortcut (#69) also sets while HR streams over the **open** profile with no encrypted pairing at all. `encryptedBond` is what "Bonded" actually means.

**It is not cosmetic.** The encrypted bond gates buzz, alarms, double-tap and history sync — and Settings already says exactly that a few rows further down:

> Needs the full encrypted bond: close the official WHOOP app and pair the strap to NOOP first (a live-HR-only link can't carry the unlock).

The pill above it was contradicting that on the same screen.

`LiveView` / `LiveScreen` have drawn this distinction since #69. These two surfaces were missed at the time. **#1635 hello suppression is what made it matter**: a 5/MG used to pass through the unbonded-but-streaming state briefly on its way to bonding or dropping, and now rests there permanently — so the wrong label became the permanent label.

## Change

Both platforms, since the bug and the surfaces are identical — Android `SettingsLogic` / `DataSourcesScreen`, Swift `LiveState.connectionStatusLabel` / `SettingsView` / `DataSourcesView`.

- `encryptedBond` → "Bonded", `bonded` → "Live HR (not fully paired)".
- Tone follows the same rule: **positive only** for a real encrypted bond on a live link. A live-HR link is amber — it works, but the pairing-gated features do not.
- Swift's `strapStatusDetail` now falls through to the pairing hint for a live-HR link, which describes the real state instead of claiming a pairing.

Reuses the Live screen's existing **"Live HR (not fully paired)"** phrasing so one state has one name app-wide. That also means **no new localized copy** — the catalog entry already exists in every locale that has one, so this adds no translation debt.

## Verification

- Full Android suite green: **4440** tests.
- `doc_comment_lint` and `i18n_audit` clean.
- `StrapStatusDetailTest` extended: a live-HR-only link must not be described as paired, and only a real bond on a live link gets a positive tone. Existing cases updated to pass `encryptedBond` matching their original intent.
- **Swift is unbuilt** — app-build gated, not yet run.

---

### Re-review

Two fixes:

- **I reintroduced the same overclaim one line below removing it.** A `bonded`-only idle arm labelled a strap `Paired · idle` when it had no encrypted bond. Without an encrypted bond there was never a pairing to be idle from, and the 5/MG shortcut's `bonded` is cleared on disconnect anyway — so that branch now reads `Disconnected`.
- **The Data Sources status had become a five-arm ternary chain of `(StrandTone, LocalizedStringKey)` tuples** — the shape that pushes a SwiftUI expression past the iOS type-check budget. It would have failed in app-build, not locally, since Swift can't be compiled here. Rewritten as statements.

Confirmed sound in this pass, recorded so it isn't re-derived:

- `connectionStatusIsActive` / `connectionStatusIsIdle` are read **only** for colour — the RootView sidebar dot and the Settings tone. Nothing gates behaviour on them, so narrowing them to require `encryptedBond` changes appearance only.
- `bonded` without `encryptedBond` is set in exactly **one** place: the 5/MG live-HR shortcut. Oura and the other non-WHOOP sources use `streamingLiveHR`, which this doesn't touch — **no ring gets relabelled**.
- WHOOP 4.0 sets `bonded` and `encryptedBond` together on a genuine bond, so it is unaffected.