### PR TITLE
ble: ask Android to pair, instead of hoping a write provokes it (opt-in experiment)

### DIFF
--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -374,7 +374,7 @@ public final class LiveState: ObservableObject {
         if connected && bonded { return "Live HR (not fully paired)" }
         if connected { return "Connected" }
         if encryptedBond { return "Bonded · idle" }
-        if bonded { return "Paired · idle" }
+        // No `bonded`-only idle arm: without an encrypted bond there was never a pairing to be idle from.
         return "Disconnected"
     }
     /// True when the link is up with a REAL encrypted bond → status reads green. A live-HR-only link is

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -363,16 +363,26 @@ public final class LiveState: ObservableObject {
     /// card, so the two can't disagree the way they did in #266 (sidebar "Connecting…" vs Settings
     /// "Connected" for the same connected-but-unbonded 5/MG link). Once the link is up and HR is
     /// flowing — even over the unbonded standard profile — this reads "Connected", never "Connecting…".
+    ///
+    /// "Bonded" means [encryptedBond], never [bonded]. The 5/MG live-HR shortcut (#69) sets `bonded` while
+    /// HR streams over the OPEN profile with no pairing at all, so keying the green bonded state off it
+    /// told a strap with no encrypted pairing that it had one — and the encrypted bond is exactly what
+    /// gates buzz, alarms, double-tap and history sync. LiveView has drawn this line since #69; this
+    /// shared label (sidebar + Settings) had not, so the two screens disagreed about the same link.
     public var connectionStatusLabel: String {
-        if connected && bonded { return "Bonded · streaming" }
+        if connected && encryptedBond { return "Bonded · streaming" }
+        if connected && bonded { return "Live HR (not fully paired)" }
         if connected { return "Connected" }
-        if bonded { return "Bonded · idle" }
+        if encryptedBond { return "Bonded · idle" }
+        if bonded { return "Paired · idle" }
         return "Disconnected"
     }
-    /// True when the link is up (HR flowing) → status reads green. Drives the sidebar + Settings tone.
-    public var connectionStatusIsActive: Bool { connected }
-    /// True when previously paired but not currently connected → amber.
-    public var connectionStatusIsIdle: Bool { !connected && bonded }
+    /// True when the link is up with a REAL encrypted bond → status reads green. A live-HR-only link is
+    /// amber via [connectionStatusIsIdle]: it works, but every pairing-gated feature is unavailable.
+    public var connectionStatusIsActive: Bool { connected && encryptedBond }
+    /// True when previously paired but not currently connected, OR connected with live HR but no
+    /// encrypted bond → amber either way.
+    public var connectionStatusIsIdle: Bool { (!connected && bonded) || (connected && !encryptedBond) }
 
     /// Fired (live only) when the strap reports a DOUBLE_TAP gesture. Wired by AppModel to the
     /// user's chosen action. Debounced in AppModel.

--- a/Strand/Screens/DataSourcesView.swift
+++ b/Strand/Screens/DataSourcesView.swift
@@ -914,11 +914,20 @@ struct DataSourcesView: View {
         // Three-state, consistent with the Live screen's connection pill — a connected-but-
         // not-yet-streaming strap (e.g. an experimental WHOOP 5/MG link) no longer reads as
         // "Not connected" on one screen and "Connected" on another (issue #8).
-        let (tone, label): (StrandTone, LocalizedStringKey) =
-            live.encryptedBond ? (.positive, "Bonded, streaming.")
-            : live.bonded ? (.warning, "Live HR (not fully paired)")
-            : live.connected ? (.warning, "Connected.")
-            : (.critical, "Not connected. Open Live to pair.")
+        // Written as statements rather than a ternary chain: five arms of (StrandTone,
+        // LocalizedStringKey) tuples is the shape that pushes this expression past the iOS type-check
+        // budget, and it fails in CI rather than here.
+        let tone: StrandTone
+        let label: LocalizedStringKey
+        if live.encryptedBond {
+            tone = .positive; label = "Bonded, streaming."
+        } else if live.bonded {
+            tone = .warning; label = "Live HR (not fully paired)"
+        } else if live.connected {
+            tone = .warning; label = "Connected."
+        } else {
+            tone = .critical; label = "Not connected. Open Live to pair."
+        }
         return card(title: String(localized: "WHOOP Strap (Live BLE)"), icon: "antenna.radiowaves.left.and.right",
              tint: StrandPalette.accent,
              status: StatePill(label, tone: tone, pulsing: live.connected && !live.bonded),

--- a/Strand/Screens/DataSourcesView.swift
+++ b/Strand/Screens/DataSourcesView.swift
@@ -915,7 +915,8 @@ struct DataSourcesView: View {
         // not-yet-streaming strap (e.g. an experimental WHOOP 5/MG link) no longer reads as
         // "Not connected" on one screen and "Connected" on another (issue #8).
         let (tone, label): (StrandTone, LocalizedStringKey) =
-            live.bonded ? (.positive, "Bonded, streaming.")
+            live.encryptedBond ? (.positive, "Bonded, streaming.")
+            : live.bonded ? (.warning, "Live HR (not fully paired)")
             : live.connected ? (.warning, "Connected.")
             : (.critical, "Not connected. Open Live to pair.")
         return card(title: String(localized: "WHOOP Strap (Live BLE)"), icon: "antenna.radiowaves.left.and.right",

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -1471,7 +1471,11 @@ struct SettingsView: View {
     }
 
     private var strapStatusDetail: String {
-        if live.bonded && live.connected {
+        // encryptedBond, not bonded — see LiveState.connectionStatusLabel. Saying "is paired" for a
+        // live-HR-only link contradicts both LiveView's pill and the buzz/alarm rows on this same screen,
+        // which correctly refuse and explain that they need the full encrypted bond. A live-HR link falls
+        // through to the pairing hint below, which describes the real state.
+        if live.encryptedBond && live.connected {
             return String(localized: "Your strap is paired and sending data. Open Live for a real-time heart rate.")
         }
         if live.connected, let hint = live.pairingHint { return hint }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -1473,8 +1473,14 @@ struct SettingsView: View {
     private var strapStatusDetail: String {
         // encryptedBond, not bonded — see LiveState.connectionStatusLabel. Saying "is paired" for a
         // live-HR-only link contradicts both LiveView's pill and the buzz/alarm rows on this same screen,
-        // which correctly refuse and explain that they need the full encrypted bond. A live-HR link falls
-        // through to the pairing hint below, which describes the real state.
+        // which correctly refuse and explain that they need the full encrypted bond.
+        //
+        // A live-HR link falls through to the pairing hint when one is set, and otherwise to "Finishing
+        // the secure pairing handshake…", which is accurate HERE because this platform still retries the
+        // CLIENT_HELLO on every connect. Android has an explicit "streaming but not fully paired" arm
+        // instead, because #1635 suppression stops it retrying and nothing is finishing any more. If that
+        // suppression is ported here, this branch must gain the same arm or it starts describing a
+        // handshake that is no longer being attempted.
         if live.encryptedBond && live.connected {
             return String(localized: "Your strap is paired and sending data. Open Live for a real-time heart rate.")
         }

--- a/android/app/src/main/java/com/noop/ble/BondStateTrace.kt
+++ b/android/app/src/main/java/com/noop/ble/BondStateTrace.kt
@@ -38,10 +38,11 @@ internal fun bondStateTraceLine(
     previous: Int,
     current: Int,
     address: String?,
-    sinceHelloMs: Long?,
+    sinceMs: Long?,
+    sinceLabel: String = "CLIENT_HELLO",
 ): String {
     val who = address?.takeIf { it.isNotBlank() } ?: "unknown"
-    val since = sinceHelloMs?.let { " ${it}ms after CLIENT_HELLO" } ?: ""
+    val since = sinceMs?.let { " ${it}ms after $sinceLabel" } ?: ""
     val note = when {
         previous == BluetoothDevice.BOND_BONDING && current == BluetoothDevice.BOND_NONE ->
             " — pairing did NOT complete"
@@ -81,3 +82,15 @@ internal fun shouldTraceBondState(
     return ev.equals(ours, ignoreCase = true)
 }
 
+/** The one-per-link readout of the OS bond state the link STARTED with (#1635).
+ *
+ * Without it a capture cannot tell an already-paired link from an unpaired one, which is the single fact
+ * that decides how to read everything after it: a CLIENT_HELLO that fails on an unencrypted link and one
+ * that fails on an encrypted link are completely different findings, and they have been printing
+ * identically. It also makes the explicit-pairing experiment legible — "did the pairing from last connect
+ * actually survive?" is answered on the next connect line rather than inferred.
+ */
+internal fun bondStateAtConnectLine(bondState: Int, address: String?): String {
+    val who = address?.takeIf { it.isNotBlank() } ?: "unknown"
+    return "bond state at connect: ${bondStateName(bondState)} device=$who"
+}

--- a/android/app/src/main/java/com/noop/ble/ExplicitBond.kt
+++ b/android/app/src/main/java/com/noop/ble/ExplicitBond.kt
@@ -55,9 +55,23 @@ internal fun shouldRequestExplicitBond(
  */
 internal fun explicitBondDefersHello(requestedThisLink: Boolean): Boolean = requestedThisLink
 
-/** The outcome line for a `createBond()` call. [initiated] is the API's own return value: false means the
- *  stack refused to even start, which is a different answer from a pairing that starts and then fails, and
- *  the two must not read the same in a capture. */
+/**
+ * The outcome line when `createBond()` THREW rather than returning.
+ *
+ * Almost always a missing BLUETOOTH_CONNECT permission. Reporting that as "Android refused to start
+ * pairing" would blame the strap for something entirely local, and a capture would carry a confident wrong
+ * answer about hardware — the exact failure this whole investigation kept producing. Names the throwable
+ * instead and claims nothing about the strap.
+ */
+internal fun explicitBondThrewLine(throwableName: String, bondStateName: String): String =
+    "WHOOP 5/MG: could not ask Android to pair — createBond threw $throwableName from $bondStateName." +
+        " This is a local problem (usually a missing Bluetooth permission), NOT the strap refusing" +
+        " (#1635, experimental)"
+
+/** The outcome line for a `createBond()` call that returned. [initiated] is the API's own return value:
+ *  false means the stack refused to even start, which is a different answer from a pairing that starts and
+ *  then fails, and the two must not read the same in a capture. A throw is a third answer again — see
+ *  [explicitBondThrewLine]. */
 internal fun explicitBondRequestLine(initiated: Boolean, bondStateName: String): String =
     if (initiated) {
         "WHOOP 5/MG: asked Android to pair (createBond from $bondStateName) — watch the bond state lines" +

--- a/android/app/src/main/java/com/noop/ble/ExplicitBond.kt
+++ b/android/app/src/main/java/com/noop/ble/ExplicitBond.kt
@@ -27,6 +27,11 @@ package com.noop.ble
  *
  * [alreadyRequestedThisLink] keeps it to one attempt per connection. Re-issuing `createBond()` while a
  * pairing is in flight is how you get a dialog per retry, and the retry cadence here is seconds.
+ *
+ * PARITY: deliberately Android-only, and not a gap to be filled later. CoreBluetooth exposes no explicit
+ * pairing API at all — on Apple platforms pairing happens only as a side effect of touching an encrypted
+ * characteristic, which is the very mechanism this file exists because it does not work. There is nothing
+ * to mirror, so an audit finding this one-sided should leave it rather than delete it as untwinned.
  */
 internal fun shouldRequestExplicitBond(
     optedIn: Boolean,

--- a/android/app/src/main/java/com/noop/ble/ExplicitBond.kt
+++ b/android/app/src/main/java/com/noop/ble/ExplicitBond.kt
@@ -1,0 +1,68 @@
+package com.noop.ble
+
+/**
+ * Should NOOP ask Android to pair with this strap, rather than hoping a write provokes it?
+ *
+ * NOOP has never called `BluetoothDevice.createBond()` on either platform. The entire 5/MG pairing
+ * strategy has been IMPLICIT: write the CLIENT_HELLO to the encrypted `fd4b0002` and rely on the stack
+ * noticing that the characteristic needs encryption and starting pairing by itself.
+ *
+ * The bond-state trace (#1639) showed that mechanism has never once fired. Across two field captures the
+ * device never enters `BOND_BONDING` at all — no pairing is attempted, the write never completes, and the
+ * local stack drops the ACL ~3.15s later. So the only route NOOP had to an encrypted bond on a 5/MG was
+ * one that does not work, with no fallback, because the explicit route was never built.
+ *
+ * This is that route, as an experiment. Asking directly is the obvious thing nobody has tried, and #1639
+ * is what makes the answer readable: if `createBond()` works, the trace shows `BOND_NONE -> BOND_BONDING
+ * -> BOND_BONDED`; if the strap refuses, it shows `BOND_BONDING -> BOND_NONE`. Either is a real answer,
+ * which is more than the implicit path ever gave.
+ *
+ * OFF by default and its own switch, per the rule every strap-affecting probe in [PuffinExperiment]
+ * follows: this one asks the OS to form a persistent pairing and can surface a system pairing dialog, so
+ * it must not ride in on consent given for something else.
+ *
+ * [alreadyBondedAtOsLevel] is the REAL `BluetoothDevice.bondState`, not NOOP's `encryptedBond` flag. The
+ * two are unrelated: `encryptedBond` only ever meant "a handshake write was acked", which is why a strap
+ * can read Bonded in the UI while the OS holds no pairing at all.
+ *
+ * [alreadyRequestedThisLink] keeps it to one attempt per connection. Re-issuing `createBond()` while a
+ * pairing is in flight is how you get a dialog per retry, and the retry cadence here is seconds.
+ */
+internal fun shouldRequestExplicitBond(
+    optedIn: Boolean,
+    isWhoop5: Boolean,
+    alreadyBondedAtOsLevel: Boolean,
+    appLevelBonded: Boolean,
+    alreadyRequestedThisLink: Boolean,
+): Boolean {
+    if (!optedIn) return false
+    if (!isWhoop5) return false
+    if (alreadyBondedAtOsLevel) return false
+    if (appLevelBonded) return false
+    return !alreadyRequestedThisLink
+}
+
+/**
+ * Once `createBond()` has been asked for, should this connection still write the CLIENT_HELLO?
+ *
+ * No — and this is the point of the experiment rather than an implementation detail. Writing to the
+ * encrypted characteristic while a pairing is in flight is the behaviour that has been dropping the link
+ * for eleven weeks, so doing both at once would test nothing and reproduce the bug.
+ *
+ * The hello is left for the NEXT connection. If the pairing succeeds the strap is OS-bonded by then, the
+ * link comes up already encrypted, and the write has a chance to complete for the first time. If it fails
+ * the strap is no worse off than it is today, and the trace says which happened.
+ */
+internal fun explicitBondDefersHello(requestedThisLink: Boolean): Boolean = requestedThisLink
+
+/** The outcome line for a `createBond()` call. [initiated] is the API's own return value: false means the
+ *  stack refused to even start, which is a different answer from a pairing that starts and then fails, and
+ *  the two must not read the same in a capture. */
+internal fun explicitBondRequestLine(initiated: Boolean, bondStateName: String): String =
+    if (initiated) {
+        "WHOOP 5/MG: asked Android to pair (createBond from $bondStateName) — watch the bond state lines" +
+            " for the answer; the CLIENT_HELLO waits for the next connect (#1635, experimental)"
+    } else {
+        "WHOOP 5/MG: Android refused to START pairing (createBond returned false from $bondStateName) —" +
+            " no pairing was attempted (#1635, experimental)"
+    }

--- a/android/app/src/main/java/com/noop/ble/GattCapability.kt
+++ b/android/app/src/main/java/com/noop/ble/GattCapability.kt
@@ -1,0 +1,51 @@
+package com.noop.ble
+
+import android.bluetooth.BluetoothGattCharacteristic
+
+/**
+ * What a characteristic actually DECLARES it can do, and whether we are honouring that.
+ *
+ * Android gives an app no way to read the link's encryption state, so debugging an encrypted connection
+ * has to be done through proxies. The two available are the OS bond state (see [bondStateAtConnectLine])
+ * and this: the property bitmask the strap published for the characteristic in question.
+ *
+ * The reason it matters here is specific. The 5/MG CLIENT_HELLO is written to `fd4b0002` WITH RESPONSE,
+ * and has been since the June change that swapped `WRITE_TYPE_NO_RESPONSE` for `WRITE_TYPE_DEFAULT`. If
+ * that characteristic declares only `PROPERTY_WRITE_NO_RESPONSE` and not `PROPERTY_WRITE`, then a
+ * with-response write is not something it supports — the stack may accept the call, never produce a
+ * completion, and the link goes away. Which is exactly the shape of the failure: 16 writes, 0 acks, no
+ * pairing attempted, drop ~3.15s later.
+ *
+ * That is a HYPOTHESIS, not a conclusion. The point of this line is that one capture settles it, and no
+ * capture so far could, because the properties have never been printed. If `Write` is present the
+ * hypothesis is dead and the with-response write is fine; if it is absent, the June regression has a
+ * mechanism rather than just a correlation.
+ *
+ * Pure, and cheap: a bitmask decode on one characteristic at discovery.
+ */
+internal fun characteristicCapabilityLine(
+    uuid: String,
+    properties: Int,
+    writingWithResponse: Boolean,
+): String {
+    val names = buildList {
+        if (properties and BluetoothGattCharacteristic.PROPERTY_BROADCAST != 0) add("Broadcast")
+        if (properties and BluetoothGattCharacteristic.PROPERTY_READ != 0) add("Read")
+        if (properties and BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE != 0) add("WriteNoResponse")
+        if (properties and BluetoothGattCharacteristic.PROPERTY_WRITE != 0) add("Write")
+        if (properties and BluetoothGattCharacteristic.PROPERTY_NOTIFY != 0) add("Notify")
+        if (properties and BluetoothGattCharacteristic.PROPERTY_INDICATE != 0) add("Indicate")
+        if (properties and BluetoothGattCharacteristic.PROPERTY_SIGNED_WRITE != 0) add("SignedWrite")
+        if (properties and BluetoothGattCharacteristic.PROPERTY_EXTENDED_PROPS != 0) add("Extended")
+    }
+    val declared = if (names.isEmpty()) "none" else names.joinToString("+")
+    val supportsWithResponse = properties and BluetoothGattCharacteristic.PROPERTY_WRITE != 0
+    val verdict = when {
+        !writingWithResponse -> ""
+        supportsWithResponse -> " — with-response writes are supported"
+        else ->
+            " — MISMATCH: we write WITH RESPONSE but this characteristic does not declare Write," +
+                " so no completion is owed and the write may never be answered (#1635)"
+    }
+    return "characteristic $uuid properties=0x${properties.toString(16)} ($declared)$verdict"
+}

--- a/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
+++ b/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
@@ -19,11 +19,19 @@ package com.noop.ble
  * [userInitiated] always re-attempts: suppression is a fallback for automatic reconnects, never a
  * permanent verdict. Someone who puts the strap in pairing mode and presses Connect must get a fresh try,
  * and that is also how the suppression is cleared.
+ *
+ * [osBonded] re-arms a suppressed hello for the same reason [userInitiated] does: it is NEW evidence that
+ * the handshake might now succeed. Suppression was latched because the write never completed on an
+ * UNENCRYPTED link; once the OS holds a pairing the link comes up encrypted and the write has a chance it
+ * has never had. Without this, the #1635 explicit-bond experiment could pair successfully and still never
+ * write the hello, because the latch from before the pairing was still set — the experiment would "work"
+ * and change nothing the user can see.
  */
 internal fun shouldSendClientHello(
     suppressedForDevice: Boolean,
     userInitiated: Boolean,
-): Boolean = !suppressedForDevice || userInitiated
+    osBonded: Boolean,
+): Boolean = !suppressedForDevice || userInitiated || osBonded
 
 /**
  * Should the give-up latch suppress the hello, rather than pause auto-reconnect?

--- a/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
+++ b/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
@@ -20,18 +20,18 @@ package com.noop.ble
  * permanent verdict. Someone who puts the strap in pairing mode and presses Connect must get a fresh try,
  * and that is also how the suppression is cleared.
  *
- * [osBonded] re-arms a suppressed hello for the same reason [userInitiated] does: it is NEW evidence that
- * the handshake might now succeed. Suppression was latched because the write never completed on an
- * UNENCRYPTED link; once the OS holds a pairing the link comes up encrypted and the write has a chance it
- * has never had. Without this, the #1635 explicit-bond experiment could pair successfully and still never
- * write the hello, because the latch from before the pairing was still set — the experiment would "work"
- * and change nothing the user can see.
+ * Deliberately NOT re-armed by "an OS pairing exists". That looks right — a pairing is new evidence the
+ * handshake might work — but the condition never goes away, so a strap that pairs and STILL will not
+ * answer would have the latch bypassed on every connect for good: hello, drop at ~4.8s, reconnect,
+ * forever, with the give-up powerless to stop it. That is the unbounded loop this suppression exists to
+ * end, reintroduced through the back door. The explicit-bond experiment instead clears the latch ONCE at
+ * the moment it asks for a pairing, which is self-limiting: the next failure re-latches and the condition
+ * to clear it again does not recur.
  */
 internal fun shouldSendClientHello(
     suppressedForDevice: Boolean,
     userInitiated: Boolean,
-    osBonded: Boolean,
-): Boolean = !suppressedForDevice || userInitiated || osBonded
+): Boolean = !suppressedForDevice || userInitiated
 
 /**
  * Should the give-up latch suppress the hello, rather than pause auto-reconnect?

--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -111,6 +111,16 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
         get() = prefs.getBoolean(KEY_MOTION_AWARE_WAKE, false)
         set(v) = prefs.edit().putBoolean(KEY_MOTION_AWARE_WAKE, v).apply()
 
+    /** True if the user opted in to "Ask Android to pair" (#1635, default false): NOOP calls
+     *  `BluetoothDevice.createBond()` explicitly instead of relying on a write to the encrypted
+     *  characteristic to provoke pairing — which the #1639 bond-state trace showed never happens at all.
+     *  Its own switch, like every other probe that changes state outside the app: this one asks the OS to
+     *  form a PERSISTENT pairing and can surface a system pairing dialog. Android-only; CoreBluetooth has
+     *  no equivalent explicit API, which is likely why the implicit route was chosen originally. */
+    var explicitBond: Boolean
+        get() = prefs.getBoolean(KEY_EXPLICIT_BOND, false)
+        set(v) = prefs.edit().putBoolean(KEY_EXPLICIT_BOND, v).apply()
+
     /**
      * Turn OFF every 5/MG-only experimental probe: protocol probes ([isEnabled]), raw capture
      * ([isCaptureEnabled]), the R22 deep-data strap write ([isDeepDataEnabled]) and broadcast-HR
@@ -150,10 +160,14 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
          *  `PuffinExperiment.ecgRawDataKey`). (#891) */
         const val KEY_ECG_RAW_DATA = "noopEcgRawDataGate"
 
+        /** "Ask Android to pair" opt-in — the explicit `createBond()` experiment (#1635). Android-only,
+         *  so no macOS key to mirror. */
+        const val KEY_EXPLICIT_BOND = "noopWhoop5ExplicitBond"
+
         /** The 5/MG-only probe keys, in ONE place: [resetFiveMGGatedProbes] clears exactly these, and
          *  SettingsScreen watches exactly these for external writes. Two lists would drift. */
         internal val FIVE_MG_GATED_KEYS =
-            listOf(KEY, KEY_CAPTURE, KEY_DEEP_DATA, KEY_BROADCAST_HR, KEY_ECG_RAW_DATA)
+            listOf(KEY, KEY_CAPTURE, KEY_DEEP_DATA, KEY_BROADCAST_HR, KEY_ECG_RAW_DATA, KEY_EXPLICIT_BOND)
 
         /** "Experimental sleep staging (V2)" opt-in (mirrors macOS `PuffinExperiment.experimentalSleepV2Key`). */
         const val KEY_EXPERIMENTAL_SLEEP_V2 = "noopExperimentalSleepV2"

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5364,12 +5364,18 @@ class WhoopBleClient(
                 // so the property bitmask and the OS bond state are the only proxies available — and the
                 // CLIENT_HELLO has been written WITH RESPONSE since June without anyone checking whether
                 // this characteristic supports that. One capture settles it.
-                cmdCharacteristic?.let {
-                    log(characteristicCapabilityLine(
-                        uuid = it.uuid.toString(),
-                        properties = it.properties,
-                        writingWithResponse = true,
-                    ))
+                // Descriptive only. Whether we will actually write with response is not known here — the
+                // #1635 suppression decision happens later in startSession — so asserting it would be a
+                // confidently wrong line on exactly the straps this is about. The verdict is emitted at
+                // the write itself, where the write type is a fact rather than an assumption.
+                if (testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)) {
+                    cmdCharacteristic?.let {
+                        log(characteristicCapabilityLine(
+                            uuid = it.uuid.toString(),
+                            properties = it.properties,
+                            writingWithResponse = false,
+                        ), com.noop.testcentre.TestDomain.CONNECTION)
+                    }
                 }
             } else {
                 log("Custom WHOOP service not found on this peripheral")
@@ -7262,6 +7268,12 @@ class WhoopBleClient(
         // stream HR (even over the standard 0x2A37 profile) on an UNauthenticated link, so the old
         // unacknowledged write left it bond-less and silent — CLIENT_HELLO written, then nothing (#17).
         // Hold the slot until the ACK; the opt-in puffin probe now fires post-bond (onCharacteristicWrite).
+        // UNgated, unlike the descriptive line at discovery: this fires only when the characteristic does
+        // not declare Write, which is a decisive, actionable, once-per-link finding — and the one most
+        // likely to be missing from a report by someone who never turned Test Centre on.
+        if (ch.properties and BluetoothGattCharacteristic.PROPERTY_WRITE == 0) {
+            log(characteristicCapabilityLine(ch.uuid.toString(), ch.properties, writingWithResponse = true))
+        }
         log("WHOOP 5/MG: writing CLIENT_HELLO to fd4b0002 with response (to trigger bonding, experimental).")
         writeInFlight = true
         clientHelloWriteAtMs = System.currentTimeMillis()

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5360,6 +5360,17 @@ class WhoopBleClient(
                         "sleep) for 5/MG are still being figured out. WHOOP 4.0 is fully supported today.",
                 ) }
                 cmdCharacteristic = whoop5.getCharacteristic(WHOOP5_CMD_WRITE_CHAR)
+                // #1635: print what fd4b0002 actually declares. Android exposes no link-encryption state,
+                // so the property bitmask and the OS bond state are the only proxies available — and the
+                // CLIENT_HELLO has been written WITH RESPONSE since June without anyone checking whether
+                // this characteristic supports that. One capture settles it.
+                cmdCharacteristic?.let {
+                    log(characteristicCapabilityLine(
+                        uuid = it.uuid.toString(),
+                        properties = it.properties,
+                        writingWithResponse = true,
+                    ))
+                }
             } else {
                 log("Custom WHOOP service not found on this peripheral")
             }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4633,6 +4633,12 @@ class WhoopBleClient(
      *  against the teardown it is about to perform. None of the five is on a per-record path. */
     private fun noteLocalTeardown(origin: String) { lastLocalTeardown = origin }
 
+    /** True once `createBond()` has been asked for on THIS link (#1635 explicit-bond experiment). One
+     *  attempt per connection: re-issuing while a pairing is in flight gives a system dialog per retry, and
+     *  the retry cadence here is seconds. Cleared with the rest of the per-link state on teardown. */
+    @Volatile
+    private var explicitBondRequestedThisLink = false
+
     /** Set by an explicit user Connect so the NEXT 5/MG session re-attempts a suppressed CLIENT_HELLO
      *  (#1635). Consumed on use, so it grants exactly one retry: someone who put the strap in pairing mode
      *  gets a fresh attempt, and a strap that still will not answer latches straight back off instead of
@@ -7269,6 +7275,32 @@ class WhoopBleClient(
                 // Consumed unconditionally, so the single retry an explicit Connect grants belongs to THIS
                 // session. Leaving it set would hand a stale retry to some later automatic reconnect and
                 // restart the loop the suppression exists to end.
+                // #1635 experiment: ask Android to pair, instead of hoping the encrypted write provokes
+                // it — which the bond-state trace showed never happens. Runs BEFORE the hello decision
+                // because the two must not overlap: writing while a pairing is in flight is the behaviour
+                // that has been dropping the link, so doing both would test nothing.
+                if (shouldRequestExplicitBond(
+                        optedIn = puffinExperiment.explicitBond,
+                        isWhoop5 = true,
+                        alreadyBondedAtOsLevel = g.device.bondState == BluetoothDevice.BOND_BONDED,
+                        appLevelBonded = didBond,
+                        alreadyRequestedThisLink = explicitBondRequestedThisLink,
+                    )
+                ) {
+                    explicitBondRequestedThisLink = true
+                    val initiated = runCatching { g.device.createBond() }.getOrDefault(false)
+                    log(explicitBondRequestLine(initiated, bondStateName(g.device.bondState)))
+                }
+                if (explicitBondDefersHello(explicitBondRequestedThisLink)) {
+                    // Same trap as the suppression path below, and worse here. The watchdog was armed at
+                    // discovery and bounces the link whenever didBond is false — which deferring the hello
+                    // guarantees. Tearing the link down while an OS pairing is in flight is the single
+                    // thing most likely to abort the pairing we just asked for, so the experiment would
+                    // sabotage itself ~7s in and report a refusal that never happened.
+                    cancelBondWatchdog()
+                    return
+                }
+
                 val userAsked = helloRetryRequested
                 helloRetryRequested = false
                 val suppressed = runCatching {
@@ -8480,6 +8512,7 @@ class WhoopBleClient(
     /** Clear per-connection state. Port of the flag resets in didConnect / didDisconnectPeripheral. */
     private fun reset() {
         didBond = false
+        explicitBondRequestedThisLink = false   // #1635: one createBond attempt per link
         connectHandshakeDone = false
         familyEstablished = false   // the next link re-establishes it at service discovery
         loggedFirmwareGate = null

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7279,17 +7279,24 @@ class WhoopBleClient(
                 // it — which the bond-state trace showed never happens. Runs BEFORE the hello decision
                 // because the two must not overlap: writing while a pairing is in flight is the behaviour
                 // that has been dropping the link, so doing both would test nothing.
+                val osBonded = g.device.bondState == BluetoothDevice.BOND_BONDED
                 if (shouldRequestExplicitBond(
                         optedIn = puffinExperiment.explicitBond,
                         isWhoop5 = true,
-                        alreadyBondedAtOsLevel = g.device.bondState == BluetoothDevice.BOND_BONDED,
+                        alreadyBondedAtOsLevel = osBonded,
                         appLevelBonded = didBond,
                         alreadyRequestedThisLink = explicitBondRequestedThisLink,
                     )
                 ) {
                     explicitBondRequestedThisLink = true
-                    val initiated = runCatching { g.device.createBond() }.getOrDefault(false)
-                    log(explicitBondRequestLine(initiated, bondStateName(g.device.bondState)))
+                    val where = bondStateName(g.device.bondState)
+                    // A THROW is not a refusal. createBond needs BLUETOOTH_CONNECT, and swallowing a
+                    // SecurityException into `false` would print a confident claim about the strap for a
+                    // problem that is entirely local.
+                    runCatching { g.device.createBond() }.fold(
+                        onSuccess = { log(explicitBondRequestLine(it, where)) },
+                        onFailure = { log(explicitBondThrewLine(it.javaClass.simpleName, where)) },
+                    )
                 }
                 if (explicitBondDefersHello(explicitBondRequestedThisLink)) {
                     // Same trap as the suppression path below, and worse here. The watchdog was armed at
@@ -7306,7 +7313,7 @@ class WhoopBleClient(
                 val suppressed = runCatching {
                     com.noop.ui.NoopPrefs.helloSuppressed(context, g.device.address)
                 }.getOrDefault(false)
-                if (shouldSendClientHello(suppressed, userInitiated = userAsked)) {
+                if (shouldSendClientHello(suppressed, userInitiated = userAsked, osBonded = osBonded)) {
                     writeClientHello(g, cmd)
                 } else {
                     // The watchdog was armed at discovery, before this decision could be made, and it

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7294,7 +7294,19 @@ class WhoopBleClient(
                     // SecurityException into `false` would print a confident claim about the strap for a
                     // problem that is entirely local.
                     runCatching { g.device.createBond() }.fold(
-                        onSuccess = { log(explicitBondRequestLine(it, where)) },
+                        onSuccess = { initiated ->
+                            log(explicitBondRequestLine(initiated, where))
+                            // Asking for a pairing voids the previous verdict: suppression latched because
+                            // the write never completed on an UNENCRYPTED link, and that premise is exactly
+                            // what this is trying to change. Cleared ONCE, here, rather than re-armed by
+                            // "an OS pairing exists" — that condition never goes away, so it would bypass
+                            // the latch on every connect and restore the unbounded loop for good.
+                            if (initiated) {
+                                runCatching {
+                                    com.noop.ui.NoopPrefs.setHelloSuppressed(context, g.device.address, false)
+                                }
+                            }
+                        },
                         onFailure = { log(explicitBondThrewLine(it.javaClass.simpleName, where)) },
                     )
                 }
@@ -7313,7 +7325,7 @@ class WhoopBleClient(
                 val suppressed = runCatching {
                     com.noop.ui.NoopPrefs.helloSuppressed(context, g.device.address)
                 }.getOrDefault(false)
-                if (shouldSendClientHello(suppressed, userInitiated = userAsked, osBonded = osBonded)) {
+                if (shouldSendClientHello(suppressed, userInitiated = userAsked)) {
                     writeClientHello(g, cmd)
                 } else {
                     // The watchdog was armed at discovery, before this decision could be made, and it

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2211,9 +2211,17 @@ class WhoopBleClient(
     /** #1635: record an OS bond-state transition in the strap log. The OS pairing flow has never been
      *  observed, which is what leaves the 5/MG bond failure undecided - see [bondStateTraceLine]. */
     fun onBondStateChanged(previous: Int, current: Int, address: String?) {
-        val since = msSinceClientHello
+        // Time against whichever request is actually outstanding. The hello takes precedence when both
+        // are, but the explicit-pairing experiment deliberately sends no hello, so without the second
+        // marker every transition it causes would print untimed — and how long a pairing took is most of
+        // what makes it diagnosable (#1635).
+        val helloMs = msSinceClientHello
+        val bondMs = explicitBondRequestedAtMs
+            .takeIf { it > 0L }?.let { System.currentTimeMillis() - it }
+        val since = helloMs ?: bondMs
+        val label = if (helloMs != null) "CLIENT_HELLO" else "the pairing request"
         if (!shouldTraceBondState(address, lastDeviceAddress, since != null)) return
-        log(bondStateTraceLine(previous, current, address, since))
+        log(bondStateTraceLine(previous, current, address, since, label))
     }
 
     @Volatile private var familyEstablished = false
@@ -4638,6 +4646,12 @@ class WhoopBleClient(
      *  the retry cadence here is seconds. Cleared with the rest of the per-link state on teardown. */
     @Volatile
     private var explicitBondRequestedThisLink = false
+
+    /** When `createBond()` was asked for, so the bond-state trace can time the pairing (#1635). The trace
+     *  otherwise measures only from the CLIENT_HELLO, which this experiment deliberately does not send —
+     *  leaving every pairing transition untimed, so a 200ms pairing and an 8s one read identically. */
+    @Volatile
+    private var explicitBondRequestedAtMs = 0L
 
     /** Set by an explicit user Connect so the NEXT 5/MG session re-attempts a suppressed CLIENT_HELLO
      *  (#1635). Consumed on use, so it grants exactly one retry: someone who put the strap in pairing mode
@@ -7280,6 +7294,10 @@ class WhoopBleClient(
                 // because the two must not overlap: writing while a pairing is in flight is the behaviour
                 // that has been dropping the link, so doing both would test nothing.
                 val osBonded = g.device.bondState == BluetoothDevice.BOND_BONDED
+                // Once per link, before any decision: a hello that fails on an unencrypted link and one
+                // that fails on an ENCRYPTED link are completely different findings, and they have been
+                // printing identically (#1635).
+                log(bondStateAtConnectLine(g.device.bondState, g.device.address))
                 if (shouldRequestExplicitBond(
                         optedIn = puffinExperiment.explicitBond,
                         isWhoop5 = true,
@@ -7289,6 +7307,7 @@ class WhoopBleClient(
                     )
                 ) {
                     explicitBondRequestedThisLink = true
+                    explicitBondRequestedAtMs = System.currentTimeMillis()
                     val where = bondStateName(g.device.bondState)
                     // A THROW is not a refusal. createBond needs BLUETOOTH_CONNECT, and swallowing a
                     // SecurityException into `false` would print a confident claim about the strap for a
@@ -8532,6 +8551,7 @@ class WhoopBleClient(
     private fun reset() {
         didBond = false
         explicitBondRequestedThisLink = false   // #1635: one createBond attempt per link
+        explicitBondRequestedAtMs = 0L
         connectHandshakeDone = false
         familyEstablished = false   // the next link re-establishes it at service discovery
         loggedFirmwareGate = null

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7297,7 +7297,16 @@ class WhoopBleClient(
                 // Once per link, before any decision: a hello that fails on an unencrypted link and one
                 // that fails on an ENCRYPTED link are completely different findings, and they have been
                 // printing identically (#1635).
-                log(bondStateAtConnectLine(g.device.bondState, g.device.address))
+                //
+                // Gated, unlike the bond-state TRANSITION lines. This one fires on every connect, so on a
+                // strap in a reconnect loop it is a line every few seconds into a fixed-size rolling
+                // buffer for someone who is not debugging. A transition line fires only when the OS bond
+                // actually changes — zero times on the straps this is about — so it costs nothing to leave
+                // always-on and is the evidence most likely to be missing when someone reports a problem.
+                if (testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)) {
+                    log(bondStateAtConnectLine(g.device.bondState, g.device.address),
+                        com.noop.testcentre.TestDomain.CONNECTION)
+                }
                 if (shouldRequestExplicitBond(
                         optedIn = puffinExperiment.explicitBond,
                         isWhoop5 = true,
@@ -8551,7 +8560,11 @@ class WhoopBleClient(
     private fun reset() {
         didBond = false
         explicitBondRequestedThisLink = false   // #1635: one createBond attempt per link
-        explicitBondRequestedAtMs = 0L
+        // explicitBondRequestedAtMs is deliberately NOT cleared here. An OS pairing routinely completes
+        // AFTER the GATT link that asked for it has dropped, so clearing on teardown would leave the
+        // BOND_BONDED transition — the one that matters most — arriving with no timing at all, which is
+        // exactly the gap this stopwatch was added to close. It is overwritten by the next request, and a
+        // stale value can only ever produce a large elapsed against a label that names what it measures.
         connectHandshakeDone = false
         familyEstablished = false   // the next link re-establishes it at service discovery
         loggedFirmwareGate = null

--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -867,7 +867,11 @@ fun DataSourcesScreen(vm: AppViewModel) {
             subtitle = "Pairs directly with your strap over Bluetooth: no WHOOP app, no cloud.",
         ) {
             val (label, tone) = when {
-                live.bonded -> "Bonded, streaming." to StrandTone.Positive
+                // encryptedBond, not bonded — see strapStatusTitle. A 5/MG streaming over the open
+                // profile has bonded == true with no pairing at all, and after #1635 hello suppression it
+                // stays there for good rather than passing through.
+                live.encryptedBond -> "Bonded, streaming." to StrandTone.Positive
+                live.bonded -> "Live HR (not fully paired)" to StrandTone.Warning
                 live.connected -> "Connected, pairing…" to StrandTone.Warning
                 else -> "Not connected. Open Live to pair." to StrandTone.Critical
             }

--- a/android/app/src/main/java/com/noop/ui/SettingsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsLogic.kt
@@ -46,7 +46,9 @@ internal fun strapStatusTitle(encryptedBond: Boolean, bonded: Boolean, connected
     encryptedBond -> "Bonded · idle"
     bonded && connected -> "Live HR (not fully paired)"
     connected -> "Connected"
-    bonded -> "Paired · idle"
+    // No `bonded`-only idle arm: without an encrypted bond there was never a pairing to be idle from,
+    // and labelling that "Paired" would be the same overclaim this change exists to remove. The 5/MG
+    // shortcut's `bonded` is cleared on disconnect anyway, so the honest answer here is Disconnected.
     else -> "Disconnected"
 }
 

--- a/android/app/src/main/java/com/noop/ui/SettingsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsLogic.kt
@@ -28,23 +28,46 @@ internal fun waistInchesStep(current: Double, up: Boolean): Double {
 
 // MARK: - Strap status helpers (mirror SettingsView's computed properties)
 
-internal fun strapStatusTitle(bonded: Boolean, connected: Boolean): String = when {
-    bonded && connected -> "Bonded · streaming"
+/**
+ * The Strap pill on Settings.
+ *
+ * [encryptedBond], not [bonded], is what "Bonded" means. `bonded` is also set by the 5/MG live-HR
+ * shortcut (#69), where HR streams over the open profile with no encrypted pairing at all — so keying the
+ * green "Bonded" state off it told a strap with no pairing that it had one. The Live screen has drawn this
+ * distinction since #69; Settings and Data Sources were missed, and #1635 hello suppression turns that
+ * state from a brief moment on the way to bonding into where a 5/MG now permanently sits.
+ *
+ * It is not cosmetic. The encrypted bond gates buzz, alarms, double-tap and history sync, and Settings
+ * already says so a few rows further down ("Needs the full encrypted bond…"). A green "Bonded · streaming"
+ * above that contradicts it on the same screen.
+ */
+internal fun strapStatusTitle(encryptedBond: Boolean, bonded: Boolean, connected: Boolean): String = when {
+    encryptedBond && connected -> "Bonded · streaming"
+    encryptedBond -> "Bonded · idle"
+    bonded && connected -> "Live HR (not fully paired)"
     connected -> "Connected"
-    bonded -> "Bonded · idle"
+    bonded -> "Paired · idle"
     else -> "Disconnected"
 }
 
-internal fun strapTone(bonded: Boolean, connected: Boolean): StrandTone = when {
-    connected -> StrandTone.Positive
-    bonded -> StrandTone.Warning
+/** Positive ONLY for a real encrypted bond on a live link — see [strapStatusTitle]. A live-HR-only link
+ *  is a warning, not a success: it works, but the pairing-gated features do not. */
+internal fun strapTone(encryptedBond: Boolean, bonded: Boolean, connected: Boolean): StrandTone = when {
+    encryptedBond && connected -> StrandTone.Positive
+    connected || bonded -> StrandTone.Warning
     else -> StrandTone.Critical
 }
 
 // `internal` (not private) so the unit test in the same package can assert the scanning branch.
-internal fun strapStatusDetail(bonded: Boolean, connected: Boolean, scanning: Boolean): String = when {
+internal fun strapStatusDetail(
+    encryptedBond: Boolean,
+    bonded: Boolean,
+    connected: Boolean,
+    scanning: Boolean,
+): String = when {
     scanning -> "Searching for your WHOOP… make sure it's charged, on your wrist, and the official WHOOP app isn't connected to it."
-    bonded && connected -> "Your strap is paired and sending data. Open Live for a real-time heart rate."
+    encryptedBond && connected -> "Your strap is paired and sending data. Open Live for a real-time heart rate."
+    bonded && connected -> "Live heart rate is streaming, but your strap is not fully paired. Buzz, alarms and history sync need the encrypted pairing."
     connected -> "Connected. Finishing the secure pairing handshake…"
     bonded -> "Previously paired but not currently connected. Re-scan to reconnect."
     else -> "No strap connected. Put your WHOOP nearby and tap Re-scan to pair."

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1721,8 +1721,8 @@ fun SettingsScreen(
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
                     StatePill(
-                        title = strapStatusTitle(live.bonded, live.connected),
-                        tone = strapTone(live.bonded, live.connected),
+                        title = strapStatusTitle(live.encryptedBond, live.bonded, live.connected),
+                        tone = strapTone(live.encryptedBond, live.bonded, live.connected),
                         pulsing = live.connected,
                     )
                     live.batteryPct?.let { pct ->
@@ -1735,7 +1735,7 @@ fun SettingsScreen(
                     }
                 }
                 Text(
-                    strapStatusDetail(live.bonded, live.connected, live.scanning),
+                    strapStatusDetail(live.encryptedBond, live.bonded, live.connected, live.scanning),
                     style = NoopType.subhead,
                     color = Palette.textSecondary,
                 )

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -501,7 +501,8 @@ fun SettingsScreen(
     // 5/MG-only probes. Without this the toggles below would keep showing their old state until you
     // navigated away and back, because an unkeyed remember{} reads once per composition. macOS gets
     // this free — @AppStorage republishes on any UserDefaults write — and Compose needs it spelled
-    // out. Bumping `rev` is the whole mechanism; the four reads are keyed on it.
+    // out. Bumping `rev` is the whole mechanism; every experiment read below is keyed on it. Deliberately
+    // not stated as a count — it was already wrong before the #1635 toggle was added to the list.
     DisposableEffect(Unit) {
         val expPrefs = context.getSharedPreferences(PuffinExperiment.PREFS, Context.MODE_PRIVATE)
         // Strong local for the effect's lifetime: Android holds these listeners WEAKLY, so one that is

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -585,6 +585,7 @@ fun SettingsScreen(
     // the card cannot drift from it again — it said "15" for the whole life of the 16-flag sequence.
     val r22FlagCount = Whoop5Config.enableR22Sequence.size
     var broadcastHr by remember(rev) { mutableStateOf(puffinExperiment.broadcastHr) }
+    var explicitBond by remember(rev) { mutableStateOf(puffinExperiment.explicitBond) }
     // ECG raw-data gate (#891): the opt-in, the write result, and the attested-MG gate the buttons need.
     var ecgRawData by remember(rev) { mutableStateOf(puffinExperiment.ecgRawData) }
     val ecgGateReport by vm.ble.ecgRawDataGate.collectAsStateWithLifecycle()
@@ -2303,6 +2304,42 @@ fun SettingsScreen(
                 }
                 Text(
                     uiString(R.string.l10n_settings_screen_makes_your_whoop_5_0_mg_b26b94c7),
+                    style = NoopType.caption,
+                    color = Palette.textTertiary,
+                )
+
+                // --- Ask Android to pair — the explicit createBond() experiment. (#1635) ---
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    Text(
+                        uiString(R.string.l10n_settings_screen_ask_android_to_pair_experimental_250a81e9),
+                        style = NoopType.subhead,
+                        color = Palette.textPrimary,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Switch(
+                        checked = explicitBond,
+                        onCheckedChange = {
+                            explicitBond = it
+                            puffinExperiment.explicitBond = it
+                        },
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = Palette.surfaceBase,
+                            checkedTrackColor = Palette.accent,
+                            uncheckedThumbColor = Palette.textSecondary,
+                            uncheckedTrackColor = Palette.surfaceInset,
+                            uncheckedBorderColor = Palette.hairline,
+                        ),
+                        modifier = Modifier.semantics {
+                            contentDescription = uiString(R.string.l10n_settings_screen_ask_android_to_pair_323fccbe)
+                        },
+                    )
+                }
+                Text(
+                    uiString(R.string.l10n_settings_screen_noop_has_always_hoped_that_writing_19967036),
                     style = NoopType.caption,
                     color = Palette.textTertiary,
                 )

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2463,4 +2463,7 @@
     <string name="l10n_health_screen_your_strap_reports_a_blood_oxygen_349fe34a">Dein Strap liefert eine Schätzung der Sauerstoffsättigung, sie ist aber unbestätigt und standardmäßig aus. Aktiviere die Strap-Schätzung in den Einstellungen, oder importiere einen WHOOP-Export unter Datenquellen für den kalibrierten Wert.</string>
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">Kein Sauerstoffsättigungswert von einem WHOOP 4.0</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">Dein Strap speichert die optischen Rohkanäle, aber NOOP rechnet sie nicht in einen Sauerstoffsättigungswert um - dies bleibt also leer, egal wie lange du ihn trägst. Importiere einen WHOOP-Export unter Datenquellen, um es aus deinem Kontoverlauf zu füllen.</string>
+    <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Android um Kopplung bitten (experimentell)</string>
+    <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP hat bisher darauf gesetzt, dass ein Schreibvorgang an dein 5.0/MG Android zur Kopplung veranlasst. Das passiert nie. Diese Option fragt Android direkt und kann einen System-Kopplungsdialog anzeigen. Die Live-Herzfrequenz funktioniert in beiden Fällen weiter; schalte sie aus, wenn der Dialog stört.</string>
+    <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Android um Kopplung bitten</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2449,4 +2449,7 @@
     <string name="l10n_health_screen_your_strap_reports_a_blood_oxygen_349fe34a">Tu pulsera ofrece una estimación de oxígeno en sangre, pero no está verificada y viene desactivada. Actívala en Ajustes, o importa una exportación de WHOOP en Fuentes de datos para el valor calibrado.</string>
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">Sin porcentaje de oxígeno en sangre desde un WHOOP 4.0</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">Tu pulsera guarda los canales ópticos en bruto, pero NOOP no los convierte en un porcentaje de oxígeno en sangre, así que esto seguirá vacío por mucho que la lleves. Importa una exportación de WHOOP en Fuentes de datos para rellenarlo con tu historial.</string>
+    <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Pedir a Android que vincule (experimental)</string>
+    <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP siempre ha confiado en que escribir en tu 5.0/MG hiciera que Android lo vinculara. Nunca ocurre. Esta opción se lo pide a Android directamente, por lo que puede mostrar un diálogo de vinculación del sistema. La frecuencia cardíaca en directo sigue funcionando igualmente; desactívala si el diálogo molesta.</string>
+    <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Pedir a Android que vincule</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2448,4 +2448,7 @@
     <string name="l10n_health_screen_your_strap_reports_a_blood_oxygen_349fe34a">Votre bracelet fournit une estimation de l\'oxygène sanguin, mais elle n\'est pas vérifiée et désactivée par défaut. Activez-la dans Réglages, ou importez un export WHOOP dans Sources de données pour la valeur calibrée.</string>
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">Pas de pourcentage d\'oxygène sanguin depuis un WHOOP 4.0</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">Votre bracelet enregistre les canaux optiques bruts, mais NOOP ne les convertit pas en pourcentage d\'oxygène sanguin : cette section restera vide quel que soit le temps de port. Importez un export WHOOP dans Sources de données pour la remplir depuis votre historique.</string>
+    <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Demander à Android de s\'appairer (expérimental)</string>
+    <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP a toujours compté sur l\'écriture vers votre 5.0/MG pour qu\'Android s\'appaire. Cela n\'arrive jamais. Cette option le demande directement à Android et peut afficher une boîte de dialogue d\'appairage du système. La fréquence cardiaque en direct continue de fonctionner dans les deux cas ; désactivez-la si la boîte de dialogue vous gêne.</string>
+    <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Demander à Android de s\'appairer</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2454,4 +2454,7 @@
     <string name="l10n_health_screen_your_strap_reports_a_blood_oxygen_349fe34a">Twoja opaska podaje szacowane natlenienie krwi, ale jest ono niezweryfikowane i domyślnie wyłączone. Włącz szacowanie opaski w Ustawieniach lub zaimportuj eksport WHOOP w Źródłach danych, aby uzyskać wartość kalibrowaną.</string>
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">Brak wartości procentowej natlenienia krwi z WHOOP 4.0</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">Twoja opaska zapisuje surowe kanały optyczne, ale NOOP nie przelicza ich na wartość procentową natlenienia krwi, więc pozostanie to puste niezależnie od czasu noszenia. Zaimportuj eksport WHOOP w Źródłach danych, aby wypełnić to historią konta.</string>
+    <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Poproś Androida o sparowanie (eksperymentalne)</string>
+    <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP zawsze liczył na to, że zapis do 5.0/MG skłoni Androida do sparowania. To się nigdy nie dzieje. Ta opcja prosi Androida bezpośrednio, więc może pojawić się systemowe okno parowania. Tętno na żywo działa tak czy inaczej; wyłącz, jeśli okno przeszkadza.</string>
+    <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Poproś Androida o sparowanie</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2442,4 +2442,7 @@
     <string name="l10n_health_screen_your_strap_reports_a_blood_oxygen_349fe34a">A sua bracelete fornece uma estimativa de oxigénio no sangue, mas não está verificada e vem desligada. Ative-a nas Definições, ou importe uma exportação WHOOP em Fontes de dados para o valor calibrado.</string>
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">Sem percentagem de oxigénio no sangue a partir de um WHOOP 4.0</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">A sua bracelete guarda os canais óticos em bruto, mas o NOOP não os converte numa percentagem de oxigénio no sangue, por isso isto fica vazio por muito tempo que a use. Importe uma exportação WHOOP em Fontes de dados para preencher a partir do seu histórico.</string>
+    <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Pedir ao Android para emparelhar (experimental)</string>
+    <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">O NOOP sempre contou que escrever na sua 5.0/MG fizesse o Android emparelhar. Isso nunca acontece. Esta opção pede diretamente ao Android, pelo que pode mostrar uma caixa de diálogo de emparelhamento do sistema. A frequência cardíaca em direto continua a funcionar de qualquer forma; desative se a caixa de diálogo incomodar.</string>
+    <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Pedir ao Android para emparelhar</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2363,4 +2363,7 @@
     <string name="l10n_health_screen_your_strap_reports_a_blood_oxygen_349fe34a">你的手环会给出血氧估算值，但该值未经验证且默认关闭。可在“设置”中开启手环估算，或在“数据来源”导入 WHOOP 导出文件以获得校准值。</string>
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">WHOOP 4.0 无法提供血氧百分比</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">你的手环会记录原始光学通道，但 NOOP 不会将其换算成血氧百分比，因此无论佩戴多久这里都会是空的。请在“数据来源”中导入 WHOOP 导出文件，以用账户历史填充。</string>
+    <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">请求 Android 配对（实验性）</string>
+    <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP 一直寄望于向 5.0/MG 写入数据来促使 Android 配对，但这从未发生。此选项会直接请求 Android，因此可能弹出系统配对对话框。无论哪种方式，实时心率都会继续工作；如果对话框造成困扰，请关闭此选项。</string>
+    <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">请求 Android 配对</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1478,6 +1478,9 @@
     <string name="l10n_settings_screen_backup_restore_a1616284">Backup &amp; restore</string>
     <string name="l10n_settings_screen_battery_pct_roundtoint_e02e2891">Battery %1$s%%</string>
     <string name="l10n_settings_screen_broadcast_heart_rate_d1af1c79">Broadcast heart rate</string>
+    <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Ask Android to pair (experimental)</string>
+    <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP has always hoped that writing to your 5.0/MG would make Android pair with it. It never does. This asks Android directly, so it may show a system pairing dialog. Live heart rate keeps working either way; turn it off if the dialog is a nuisance.</string>
+    <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Ask Android to pair</string>
     <string name="l10n_settings_screen_broadcast_strap_hr_garmin_ant_a39d0654">Broadcast strap HR (Garmin/ANT)</string>
     <string name="l10n_settings_screen_buzz_the_time_on_your_strap_06fc879d">Buzz the time on your strap</string>
     <string name="l10n_settings_screen_cancel_77dfd213">Cancel</string>

--- a/android/app/src/test/java/com/noop/ble/BondStateTraceTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BondStateTraceTest.kt
@@ -92,4 +92,31 @@ class BondStateTraceTest {
     fun `with no strap address, an addressed event is not ours to trace`() {
         assertFalse(shouldTraceBondState("AA:BB", null, helloOutstanding = true))
     }
+
+    @Test
+    fun `a pairing-request transition is timed against the pairing, not a hello that never went out`() {
+        // The #1635 explicit-pairing experiment deliberately sends no CLIENT_HELLO. Timing only against
+        // the hello left every transition it causes untimed, so a 200ms pairing and an 8s one read the
+        // same - and how long a pairing took is most of what makes it diagnosable.
+        val line = bondStateTraceLine(
+            previous = android.bluetooth.BluetoothDevice.BOND_BONDING,
+            current = android.bluetooth.BluetoothDevice.BOND_BONDED,
+            address = "FD:D4",
+            sinceMs = 4200L,
+            sinceLabel = "the pairing request",
+        )
+        assertTrue(line.contains("4200ms after the pairing request"))
+        assertFalse(line.contains("CLIENT_HELLO"))
+        assertTrue(line.contains("paired"))
+    }
+
+    @Test
+    fun `the connect line names the bond state the link STARTED with`() {
+        // Without it, a hello failing on an unencrypted link and one failing on an ENCRYPTED link print
+        // identically - and they are completely different findings.
+        val l = bondStateAtConnectLine(android.bluetooth.BluetoothDevice.BOND_BONDED, "FD:D4")
+        assertTrue(l.contains("BOND_BONDED"))
+        assertTrue(l.contains("FD:D4"))
+        assertTrue(bondStateAtConnectLine(android.bluetooth.BluetoothDevice.BOND_NONE, null).contains("unknown"))
+    }
 }

--- a/android/app/src/test/java/com/noop/ble/ExplicitBondTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ExplicitBondTest.kt
@@ -1,0 +1,68 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** The #1635 explicit-bond experiment: when NOOP asks Android to pair, and what it says about it. */
+class ExplicitBondTest {
+    private fun ask(
+        optedIn: Boolean = true,
+        isWhoop5: Boolean = true,
+        osBonded: Boolean = false,
+        appBonded: Boolean = false,
+        already: Boolean = false,
+    ) = shouldRequestExplicitBond(optedIn, isWhoop5, osBonded, appBonded, already)
+
+    @Test
+    fun `off by default - nothing happens without opt-in`() {
+        assertFalse(ask(optedIn = false))
+    }
+
+    @Test
+    fun `never on a WHOOP 4 - it bonds fine and this is a 5-MG-only probe`() {
+        assertFalse(ask(isWhoop5 = false))
+    }
+
+    @Test
+    fun `an opted-in unbonded 5-MG is asked to pair`() {
+        assertTrue(ask())
+    }
+
+    @Test
+    fun `an OS-level pairing already exists, so we do not ask again`() {
+        assertFalse(ask(osBonded = true))
+    }
+
+    @Test
+    fun `the app-level flag also suppresses it, though the two are unrelated`() {
+        // encryptedBond has only ever meant "a handshake write was acked" — a strap can read Bonded in the
+        // UI with no OS pairing at all. Both are checked because either being true means there is nothing
+        // to gain from a pairing dialog.
+        assertFalse(ask(appBonded = true))
+    }
+
+    @Test
+    fun `one attempt per link - a retry cadence of seconds must not mean a dialog per retry`() {
+        assertFalse(ask(already = true))
+    }
+
+    @Test
+    fun `asking defers the hello, because doing both at once reproduces the bug`() {
+        // Writing to the encrypted characteristic while a pairing is in flight is exactly what has been
+        // dropping the link. The hello waits for the next connect, when the link may already be encrypted.
+        assertTrue(explicitBondDefersHello(requestedThisLink = true))
+        assertFalse(explicitBondDefersHello(requestedThisLink = false))
+    }
+
+    @Test
+    fun `a refusal to START pairing does not read like a pairing that failed`() {
+        val started = explicitBondRequestLine(initiated = true, bondStateName = "BOND_NONE")
+        val refused = explicitBondRequestLine(initiated = false, bondStateName = "BOND_NONE")
+        assertTrue(started.contains("asked Android to pair"))
+        assertTrue(refused.contains("refused to START pairing"))
+        assertFalse(refused.contains("watch the bond state lines"))
+        assertEquals(false, started == refused)
+    }
+}

--- a/android/app/src/test/java/com/noop/ble/ExplicitBondTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ExplicitBondTest.kt
@@ -65,4 +65,17 @@ class ExplicitBondTest {
         assertFalse(refused.contains("watch the bond state lines"))
         assertEquals(false, started == refused)
     }
+
+    @Test
+    fun `a throw is reported as local, never as the strap refusing`() {
+        // createBond needs BLUETOOTH_CONNECT. Swallowing a SecurityException into `false` would print a
+        // confident claim about hardware for a problem that is entirely local - the failure mode this
+        // whole investigation kept producing.
+        val threw = explicitBondThrewLine("SecurityException", "BOND_NONE")
+        val refused = explicitBondRequestLine(initiated = false, bondStateName = "BOND_NONE")
+        assertTrue(threw.contains("local problem"))
+        assertTrue(threw.contains("SecurityException"))
+        assertFalse(threw.contains("refused to START pairing"))
+        assertFalse(refused.contains("local problem"))
+    }
 }

--- a/android/app/src/test/java/com/noop/ble/GattCapabilityTest.kt
+++ b/android/app/src/test/java/com/noop/ble/GattCapabilityTest.kt
@@ -1,0 +1,48 @@
+package com.noop.ble
+
+import android.bluetooth.BluetoothGattCharacteristic as C
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** #1635: what fd4b0002 declares, and whether a with-response write is honouring it. */
+class GattCapabilityTest {
+    @Test
+    fun `a write-no-response-only characteristic is flagged as a mismatch`() {
+        // The hypothesis this exists to settle: if fd4b0002 never declared Write, then the June switch
+        // from WRITE_TYPE_NO_RESPONSE to WRITE_TYPE_DEFAULT asked for a completion nothing owes us -
+        // which matches the failure exactly (16 writes, 0 acks, link gone ~3.15s later).
+        val line = characteristicCapabilityLine("fd4b0002", C.PROPERTY_WRITE_NO_RESPONSE, writingWithResponse = true)
+        assertTrue(line.contains("WriteNoResponse"))
+        assertFalse(line.contains("+Write"))
+        assertTrue(line.contains("MISMATCH"))
+    }
+
+    @Test
+    fun `a characteristic that declares Write kills the hypothesis, and says so`() {
+        val line = characteristicCapabilityLine(
+            "fd4b0002", C.PROPERTY_WRITE or C.PROPERTY_WRITE_NO_RESPONSE or C.PROPERTY_NOTIFY,
+            writingWithResponse = true,
+        )
+        assertTrue(line.contains("with-response writes are supported"))
+        assertFalse(line.contains("MISMATCH"))
+    }
+
+    @Test
+    fun `no verdict is offered when we are not writing with response`() {
+        // The verdict is about OUR write, not about the characteristic — claiming a mismatch for a write
+        // we never made would be a confidently wrong line, which is the failure mode this issue keeps
+        // producing.
+        val line = characteristicCapabilityLine("fd4b0003", C.PROPERTY_NOTIFY, writingWithResponse = false)
+        assertFalse(line.contains("MISMATCH"))
+        assertFalse(line.contains("supported"))
+        assertTrue(line.contains("Notify"))
+    }
+
+    @Test
+    fun `an empty bitmask degrades without punctuation debris`() {
+        val line = characteristicCapabilityLine("fd4b0002", 0, writingWithResponse = false)
+        assertTrue(line.contains("(none)"))
+        assertTrue(line.contains("properties=0x0"))
+    }
+}

--- a/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
@@ -9,19 +9,19 @@ import org.junit.Test
 class HelloSuppressionTest {
     @Test
     fun `an unlatched strap always gets its handshake`() {
-        assertTrue(shouldSendClientHello(suppressedForDevice = false, userInitiated = false, osBonded = false))
-        assertTrue(shouldSendClientHello(suppressedForDevice = false, userInitiated = true, osBonded = false))
+        assertTrue(shouldSendClientHello(suppressedForDevice = false, userInitiated = false))
+        assertTrue(shouldSendClientHello(suppressedForDevice = false, userInitiated = true))
     }
 
     @Test
     fun `a latched strap skips it on an automatic reconnect`() {
         // The whole point: the automatic reconnect is the one that was looping every five seconds.
-        assertFalse(shouldSendClientHello(suppressedForDevice = true, userInitiated = false, osBonded = false))
+        assertFalse(shouldSendClientHello(suppressedForDevice = true, userInitiated = false))
     }
 
     @Test
     fun `an explicit Connect always re-attempts, so suppression is never permanent`() {
-        assertTrue(shouldSendClientHello(suppressedForDevice = true, userInitiated = true, osBonded = false))
+        assertTrue(shouldSendClientHello(suppressedForDevice = true, userInitiated = true))
     }
 
     @Test
@@ -55,12 +55,11 @@ class HelloSuppressionTest {
     }
 
     @Test
-    fun `an OS pairing re-arms a suppressed hello`() {
-        // #1635 explicit-bond experiment: suppression latched because the write never completed on an
-        // UNENCRYPTED link. Once the OS holds a pairing the link comes up encrypted and the write has a
-        // chance it has never had. Without this the experiment could pair successfully and still never
-        // write the hello, so it would "work" and change nothing the user can see.
-        assertTrue(shouldSendClientHello(suppressedForDevice = true, userInitiated = false, osBonded = true))
-        assertFalse(shouldSendClientHello(suppressedForDevice = true, userInitiated = false, osBonded = false))
+    fun `an existing OS pairing does NOT permanently bypass the latch`() {
+        // Tempting, and wrong: "a pairing exists" never goes away, so re-arming on it would rewrite the
+        // hello on every connect for good - drop at ~4.8s, reconnect, forever - with the give-up powerless.
+        // That is the unbounded loop suppression exists to end. The experiment clears the latch ONCE when
+        // it asks for a pairing instead, which is self-limiting.
+        assertFalse(shouldSendClientHello(suppressedForDevice = true, userInitiated = false))
     }
 }

--- a/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
@@ -9,19 +9,19 @@ import org.junit.Test
 class HelloSuppressionTest {
     @Test
     fun `an unlatched strap always gets its handshake`() {
-        assertTrue(shouldSendClientHello(suppressedForDevice = false, userInitiated = false))
-        assertTrue(shouldSendClientHello(suppressedForDevice = false, userInitiated = true))
+        assertTrue(shouldSendClientHello(suppressedForDevice = false, userInitiated = false, osBonded = false))
+        assertTrue(shouldSendClientHello(suppressedForDevice = false, userInitiated = true, osBonded = false))
     }
 
     @Test
     fun `a latched strap skips it on an automatic reconnect`() {
         // The whole point: the automatic reconnect is the one that was looping every five seconds.
-        assertFalse(shouldSendClientHello(suppressedForDevice = true, userInitiated = false))
+        assertFalse(shouldSendClientHello(suppressedForDevice = true, userInitiated = false, osBonded = false))
     }
 
     @Test
     fun `an explicit Connect always re-attempts, so suppression is never permanent`() {
-        assertTrue(shouldSendClientHello(suppressedForDevice = true, userInitiated = true))
+        assertTrue(shouldSendClientHello(suppressedForDevice = true, userInitiated = true, osBonded = false))
     }
 
     @Test
@@ -52,5 +52,15 @@ class HelloSuppressionTest {
         val epitaph = BondRefusalGiveUp.helloSuppressedEpitaph(5, "abcd1234")
         assertFalse(epitaph.contains("held by", ignoreCase = true))
         assertTrue(epitaph.contains("abcd1234"))
+    }
+
+    @Test
+    fun `an OS pairing re-arms a suppressed hello`() {
+        // #1635 explicit-bond experiment: suppression latched because the write never completed on an
+        // UNENCRYPTED link. Once the OS holds a pairing the link comes up encrypted and the write has a
+        // chance it has never had. Without this the experiment could pair successfully and still never
+        // write the hello, so it would "work" and change nothing the user can see.
+        assertTrue(shouldSendClientHello(suppressedForDevice = true, userInitiated = false, osBonded = true))
+        assertFalse(shouldSendClientHello(suppressedForDevice = true, userInitiated = false, osBonded = false))
     }
 }

--- a/android/app/src/test/java/com/noop/ui/StrapStatusDetailTest.kt
+++ b/android/app/src/test/java/com/noop/ui/StrapStatusDetailTest.kt
@@ -1,6 +1,7 @@
 package com.noop.ui
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -16,11 +17,11 @@ class StrapStatusDetailTest {
     fun scanning_takesPrecedence_overEveryOtherState() {
         // Even when already bonded + connected, an active scan must say "Searching…".
         assertTrue(
-            strapStatusDetail(bonded = true, connected = true, scanning = true)
+            strapStatusDetail(encryptedBond = true, bonded = true, connected = true, scanning = true)
                 .startsWith("Searching for your WHOOP"),
         )
         assertTrue(
-            strapStatusDetail(bonded = false, connected = false, scanning = true)
+            strapStatusDetail(encryptedBond = false, bonded = false, connected = false, scanning = true)
                 .startsWith("Searching for your WHOOP"),
         )
     }
@@ -29,19 +30,43 @@ class StrapStatusDetailTest {
     fun nonScanning_branches_areUnchanged() {
         assertEquals(
             "Your strap is paired and sending data. Open Live for a real-time heart rate.",
-            strapStatusDetail(bonded = true, connected = true, scanning = false),
+            strapStatusDetail(encryptedBond = true, bonded = true, connected = true, scanning = false),
         )
         assertEquals(
             "Connected. Finishing the secure pairing handshake…",
-            strapStatusDetail(bonded = false, connected = true, scanning = false),
+            strapStatusDetail(encryptedBond = false, bonded = false, connected = true, scanning = false),
         )
         assertEquals(
             "Previously paired but not currently connected. Re-scan to reconnect.",
-            strapStatusDetail(bonded = true, connected = false, scanning = false),
+            strapStatusDetail(encryptedBond = true, bonded = true, connected = false, scanning = false),
         )
         assertEquals(
             "No strap connected. Put your WHOOP nearby and tap Re-scan to pair.",
-            strapStatusDetail(bonded = false, connected = false, scanning = false),
+            strapStatusDetail(encryptedBond = false, bonded = false, connected = false, scanning = false),
         )
+    }
+
+    @Test
+    fun `a live-HR-only link is not described as paired`() {
+        // #1635/#69: the 5/MG live-HR shortcut sets bonded without any encrypted pairing, and hello
+        // suppression makes that the permanent state. Telling the user their strap "is paired" there
+        // contradicts the Devices screen and the buzz/alarm rows on this same screen.
+        val detail = strapStatusDetail(
+            encryptedBond = false, bonded = true, connected = true, scanning = false,
+        )
+        assertFalse(detail.contains("is paired"))
+        assertTrue(detail.contains("not fully paired"))
+
+        assertEquals("Live HR (not fully paired)",
+            strapStatusTitle(encryptedBond = false, bonded = true, connected = true))
+        assertEquals("Bonded · streaming",
+            strapStatusTitle(encryptedBond = true, bonded = true, connected = true))
+    }
+
+    @Test
+    fun `only a real bond on a live link is a positive tone`() {
+        assertEquals(StrandTone.Positive, strapTone(encryptedBond = true, bonded = true, connected = true))
+        assertEquals(StrandTone.Warning, strapTone(encryptedBond = false, bonded = true, connected = true))
+        assertEquals(StrandTone.Critical, strapTone(encryptedBond = false, bonded = false, connected = false))
     }
 }


### PR DESCRIPTION
## The gap this fills

**NOOP has never called `BluetoothDevice.createBond()`** — grep returns nothing across the whole repo, on either platform. The entire 5/MG pairing strategy has been **implicit**: write the CLIENT_HELLO to the encrypted `fd4b0002` and rely on the stack noticing the characteristic needs encryption and starting pairing by itself.

The bond-state trace (#1639) showed that mechanism **has never once fired**. Across two field captures the device never enters `BOND_BONDING` at all — no pairing is attempted, the write never completes, and the local stack drops the ACL ~3.15s later.

So the only route NOOP had to an encrypted bond on a 5/MG was one that does not work, with no fallback, because the explicit route was never built. Worth being precise about what `encryptedBond` has actually meant all along:

| sets `encryptedBond` | what it proves |
|---|---|
| WHOOP 4.0 confirmed write acked | the custom channels work |
| 5/MG CLIENT_HELLO acked | the write completed |
| strap `BLE_BONDED` event | the strap says so |

None of those is an OS pairing. A strap can read **Bonded** in the UI with no link key anywhere.

## The experiment

Ask Android directly. #1639 is what makes the answer readable:

- `BOND_NONE → BOND_BONDING → BOND_BONDED` — it works.
- `BOND_BONDING → BOND_NONE` — the strap refused.
- `createBond` returns false — the stack would not even start (a **different** answer, and the log says so in different words).

Any of those is a real result, rather than the silence the implicit path has produced for eleven weeks.

**Asking defers the hello to the next connect** rather than doing both. Writing to the encrypted characteristic while a pairing is in flight is precisely the behaviour that has been dropping the link since June — doing both at once would test nothing and reproduce the bug. If the pairing lands, the next link comes up already encrypted and the write gets its first real chance to complete.

## Re-review caught the #1642 trap, a third time

The bond watchdog bounces the link whenever `didBond` is false — which deferring the hello **guarantees**. The experiment would have torn down its own pairing ~7s in and reported a refusal that never happened. Cancelled while a pairing is in flight; there is no handshake outstanding to time out.

Also checked: the `return` is the tail of `startSession`, so it skips no cleanup (the same shape that *was* a bug in `onCharacteristicWrite`).

## Safety

- **OFF by default**, its own switch. Every probe that changes state outside the app gets its own opt-in here, and this one asks the OS for a **persistent** pairing and can surface a system dialog — so it must not ride in on consent given for something else.
- Included in `resetFiveMGGatedProbes`, so a strap family switch cannot leave it armed.
- One attempt per link; the retry cadence is seconds and re-issuing would mean a dialog per retry.
- Never touches WHOOP 4.0.
- **Android only** — CoreBluetooth exposes no explicit pairing API, which is likely why the implicit route was chosen originally.

## Verification

- Full Android suite green: **4448** tests, including 8 new for the gate.
- `doc_comment_lint`, `i18n_audit`, `lintVitalFullRelease -PstagingRelease` clean.
- New copy translated for **all six** locales (a German resource test gates this).
- **Untested on hardware** — the point is to find out. It may well be refused; that is still the first real answer we would have.

---

### Re-review

- **The experiment could have succeeded and changed nothing visible.** If the pairing lands, the next connect sees an OS bond, skips `createBond`, and falls through to the #1635 suppression check — still latched from *before* the pairing — so the hello was never written on the newly encrypted link. The one link where the write has a real chance was the one link that would not attempt it. An OS pairing now re-arms a suppressed hello, for the same reason an explicit Connect does: it is new evidence the handshake might work, and the premise suppression latched on (the write failing on an **unencrypted** link) no longer holds.
- **A throw was being reported as a refusal.** `createBond` needs `BLUETOOTH_CONNECT`, and `runCatching` swallowed a `SecurityException` into `false`, which the log rendered as "Android refused to START pairing" — a confident claim about the strap for an entirely local problem. Three outcomes now read differently: initiated, the stack declining to start, and a throw. Pinned by a test asserting the throw line and the refusal line share none of their claims.

**4450** tests green.

### Re-review 2: the previous fix was worse than the bug

Re-arming a suppressed hello whenever an OS pairing exists reads as obviously right — a pairing *is* new evidence the handshake might work. But **"an OS pairing exists" never stops being true.** A strap that pairs and still will not answer would have the latch bypassed on every connect, permanently: hello, drop at ~4.8s, reconnect, forever, with the give-up powerless because the bypass sits in front of it. That is the unbounded loop #1642 exists to end, restored through the back door and harder to spot.

The latch is now cleared **once**, when `createBond` is initiated — the moment the previous verdict becomes void, since suppression latched on the write failing over an *unencrypted* link. Self-limiting by construction: if the handshake still fails the give-up re-latches, and the clearing condition does not recur, because the pairing already exists and `createBond` is not asked for again.

Only cleared when `createBond` reported that it actually started. A refusal or a throw changes nothing about the link, so neither may void a verdict.

### Parity

| helper | Swift twin | verdict |
|---|---|---|
| `ExplicitBond` | none | **Correct.** CoreBluetooth exposes no explicit pairing API — on Apple platforms pairing happens only as a side effect of touching an encrypted characteristic, the mechanism this file exists because it *doesn't* work. Nothing to mirror; the divergence is forced, and now says so in-file so an audit doesn't delete it as untwinned. |
| `HelloSuppression` | none | **A real outstanding gap** — the Swift twin of #1635 suppression, tracked separately. Not a platform constraint. |
| `PuffinExperiment.explicitBond` | none | Android-only key, documented as having no macOS counterpart. |

Also verified: `SettingsScreen` watches `PuffinExperiment.FIVE_MG_GATED_KEYS` rather than a private list, and `KEY_EXPLICIT_BOND` is in it — so a strap family switch both resets the toggle and refreshes the UI, with no second list to drift. Fixed a comment there claiming "the four reads are keyed on it" (five before this branch, six after) — replaced with a description, since the number is what rotted.

### Logging: closing the blind spots

Asked whether this logs enough to actually debug an encrypted connection. It didn't, in two ways that only appear once you try to *read* a capture:

- **The OS bond state at connect was never logged.** A CLIENT_HELLO failing on an unencrypted link and one failing on an **encrypted** link are completely different findings, and have been printing identically since June. Now emitted once per link, before any decision — which also answers "did last connect's pairing survive?" directly rather than by inference.
- **The trace timed only against `CLIENT_HELLO`** — which this experiment deliberately does not send, so every pairing transition would have printed untimed. It now times against whichever request is outstanding and names which.

Re-review of those two then found:

- The per-connect line was **ungated** while fourteen other connection diagnostics are `CONNECTION`-gated; on a strap in a reconnect loop that is a line every few seconds for someone not debugging. Gated. The transition lines stay always-on deliberately — they fire only when the OS bond changes, which on these straps is zero times, so they cost nothing and are the evidence most likely to be missing from a report.
- The pairing stopwatch was **cleared on teardown**, but an OS pairing routinely completes *after* the link drops — so `BOND_BONDED`, the transition that matters most, would have arrived untimed. Exactly the gap the stopwatch was added to close, quietly reopened. It now outlives the link.

### What `fd4b0002` actually declares — possibly the whole answer

Android exposes no link-encryption state to an app, so there are exactly two proxies: the OS bond state, and the **property bitmask** the strap publishes. The second has never been printed.

That matters more than a nice-to-have. The CLIENT_HELLO has been written **with response** since the June change that swapped `WRITE_TYPE_NO_RESPONSE` for `WRITE_TYPE_DEFAULT`, and nothing has ever checked whether the characteristic declares `PROPERTY_WRITE`. If it only declares `PROPERTY_WRITE_NO_RESPONSE`, a with-response write asks for a completion nothing owes us — the stack accepts the call, never answers it, and the link goes away. Which is the failure exactly: 16 writes, 0 acks, no pairing attempted, drop at ~3.15s.

Stated as a **hypothesis**. The value is that one capture settles it and no previous capture could:

- `Write` present → the idea is dead, the with-response write is fine.
- `Write` absent → the June regression has a mechanism rather than a correlation, and the fix is a one-line revert of the write type rather than anything in these PRs.

Re-review of that probe then found the verdict was emitted at **discovery**, with `writingWithResponse` hardcoded true — before the suppression decision, so on the very straps this is about it asserted a write that never happened. Split by what each part knows: discovery prints declared properties only (gated, fires every connect, properties never change); the verdict moves to the write site where the write type is a fact, and stays ungated because it fires only on a real mismatch.

**No echo/ping command exists** in the protocol to add — `DeviceConfigWriteGate` already refutes both arg-echo and blanket payload-echo, and everything echo-shaped rides the puffin channel, which needs the bond. The remaining probe would be a read of an encryption-requiring characteristic (`GATT_INSUFFICIENT_ENCRYPTION(15)` proves the link is unencrypted), but that sends traffic, so it is deliberately not included here.