### PR TITLE
ble: read the Device Information Service on a 5/MG that never bonds

### DIFF
--- a/android/app/src/main/java/com/noop/ble/DisUnbondedRead.kt
+++ b/android/app/src/main/java/com/noop/ble/DisUnbondedRead.kt
@@ -1,0 +1,56 @@
+package com.noop.ble
+
+/**
+ * Should NOOP try reading the Device Information Service on a 5/MG that has NOT bonded?
+ *
+ * Today `readDisIdentity` is issued only inside the post-bond handshake, so a strap that never bonds never
+ * reads DIS at all — which is why a field capture of the reconnect loop contains zero `DIS:` lines and the
+ * Devices screen shows a WHOOP 4.0 with its firmware beside a 5/MG with none. The firmware, the serial and
+ * the MG-vs-5.0 hardware revision all sit behind the same bond that never happens.
+ *
+ * Whether they NEED to is unproven, and the evidence is one-sided in an uncomfortable way. Standard
+ * NOTIFICATIONS demonstrably work unbonded — live HR and battery both arrive that way on exactly these
+ * straps — but nothing shows a standard READ working unbonded, and the Swift side carries a note (#490)
+ * that a 5/MG refuses standard reads on an unencrypted link. A read is also the same class of operation
+ * as the write that has been provoking the teardown, so this can plausibly cost the stable link that
+ * #1635 suppression just bought.
+ *
+ * Hence: once per device, and never again after a refusal. [previouslyRefused] is persisted, so a strap
+ * that says no says it once rather than on every reconnect forever. That makes the experiment
+ * self-limiting in the same way the hello suppression is — the failure mode of "keeps trying something
+ * that will never work" is the one this whole area keeps producing.
+ *
+ * A refusal is a RESULT, not a defeat: it settles #490 for Android, which no capture has ever done.
+ */
+internal fun shouldReadDisUnbonded(
+    isWhoop5: Boolean,
+    bonded: Boolean,
+    alreadyReadThisLink: Boolean,
+    previouslyRefused: Boolean,
+): Boolean {
+    if (!isWhoop5) return false
+    if (bonded) return false          // the post-bond path already covers this
+    if (alreadyReadThisLink) return false
+    return !previouslyRefused
+}
+
+/** Persisted key for "this strap refused an unbonded DIS read". Per device and lowercased, for the same
+ *  reason [firmwarePrefKey] is. */
+internal fun disRefusedPrefKey(peripheralId: String?): String? =
+    peripheralId?.trim()?.takeIf { it.isNotEmpty() }?.let { "noop.disRefused.${it.lowercase()}" }
+
+/**
+ * The line for a DIS read that came back with a failure status.
+ *
+ * Without it the read fails in SILENCE — `onCharacteristicRead` drops any non-success status on the floor
+ * — so a capture cannot tell a refusal from a read that was never issued. That is the same ambiguity that
+ * made the CLIENT_HELLO failure unreadable for eleven weeks, and it is not worth reproducing.
+ *
+ * INSUFFICIENT_AUTHENTICATION / INSUFFICIENT_ENCRYPTION are the interesting answers: they say the strap
+ * requires an encrypted link for this read, which confirms #490 on Android and means the firmware simply
+ * cannot be had without a bond.
+ */
+internal fun disReadFailureLine(uuid: String, status: String): String =
+    "DIS: read of $uuid failed $status — the strap declined it on this link. If this is an" +
+        " insufficient-authentication or -encryption status, DIS needs an encrypted bond and the firmware" +
+        " cannot be read without one (#490)"

--- a/android/app/src/main/java/com/noop/ble/FirmwareAttribution.kt
+++ b/android/app/src/main/java/com/noop/ble/FirmwareAttribution.kt
@@ -42,3 +42,24 @@ internal fun resolveFirmware(
  */
 internal fun firmwarePrefKey(peripheralId: String?): String? =
     peripheralId?.trim()?.takeIf { it.isNotEmpty() }?.let { "noop.lastFirmware.${it.lowercase()}" }
+
+/**
+ * Should the standard Device Information Service firmware string be published for this strap?
+ *
+ * A 5/MG that never completes the puffin handshake has no firmware to show, because the only source NOOP
+ * reads it from is a framed command that needs the bond. The Devices screen therefore shows a WHOOP 4.0
+ * with its firmware beside a 5/MG with none — which reads as a missing feature and is really a missing
+ * READ: DIS `0x2A26` sits in the same service NOOP already reads the serial and hardware revision from,
+ * unbonded, on every 5/MG connect (#520). It was simply never asked for.
+ *
+ * DIS is a FALLBACK, never an override. The puffin value is the strap's own report of the firmware it is
+ * running and is what the 4.0 has always shown; DIS is whatever the device chose to publish in its
+ * standard profile, and the two are not guaranteed to agree. So this yields to anything already decoded
+ * rather than racing it — the decode lands later in the connect, and a value that appeared and then
+ * changed would be worse than one that arrived once.
+ */
+internal fun shouldPublishDisFirmware(
+    disFirmware: String?,
+    alreadyDecoded: String?,
+): Boolean = !disFirmware.isNullOrBlank() && alreadyDecoded.isNullOrBlank()
+

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -543,6 +543,11 @@ class WhoopBleClient(
         private val DIS_SERIAL_CHAR: UUID = UUID.fromString("00002a25-0000-1000-8000-00805f9b34fb")
         private val DIS_HW_REV_CHAR: UUID = UUID.fromString("00002a27-0000-1000-8000-00805f9b34fb")
 
+        /** Standard Firmware Revision String. Readable UNBONDED, like the serial and hardware revision
+         *  beside it — which is the whole point: a 5/MG that never completes the puffin handshake has no
+         *  other firmware source, because the decoded one rides a framed command that needs the bond. */
+        private val DIS_FW_REV_CHAR: UUID = UUID.fromString("00002a26-0000-1000-8000-00805f9b34fb")
+
         // Client Characteristic Configuration Descriptor — written to enable notifications
         // (CoreBluetooth does this implicitly via setNotifyValue; Android requires the explicit write).
         private val CCCD: UUID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
@@ -4258,6 +4263,51 @@ class WhoopBleClient(
         }
     }
 
+    /**
+     * A characteristic read that came back with a failure status.
+     *
+     * Both `onCharacteristicRead` overloads used to drop a non-success status on the floor, so a refused
+     * read produced no line at all — indistinguishable from one that was never issued. That is exactly the
+     * ambiguity that made the CLIENT_HELLO failure unreadable for eleven weeks (#1635).
+     *
+     * Scoped to the DIS characteristics: they are the reads whose refusal is a FINDING (it would confirm
+     * #490 on Android and mean the firmware cannot be had without a bond). A refusal is also latched per
+     * device, so a strap that declines says so once instead of on every reconnect forever.
+     */
+    private fun noteReadFailure(uuid: java.util.UUID, status: Int) {
+        if (uuid != DIS_SERIAL_CHAR && uuid != DIS_HW_REV_CHAR && uuid != DIS_FW_REV_CHAR) return
+        log(disReadFailureLine(uuid.toString(), gattWriteStatusLabel(status)))
+        runCatching {
+            disRefusedPrefKey(lastDeviceAddress)?.let {
+                context.getSharedPreferences(com.noop.ui.NoopPrefs.NAME, android.content.Context.MODE_PRIVATE)
+                    .edit().putBoolean(it, true).apply()
+            }
+        }
+    }
+
+    /**
+     * The UNBONDED DIS attempt (#1635 follow-up). Deliberately separate from [readDisIdentity], which runs
+     * only inside the post-bond handshake and therefore never runs at all on a strap that will not bond.
+     */
+    private fun readDisIdentityUnbonded(g: BluetoothGatt) {
+        val refused = runCatching {
+            disRefusedPrefKey(g.device.address)?.let {
+                context.getSharedPreferences(com.noop.ui.NoopPrefs.NAME, android.content.Context.MODE_PRIVATE)
+                    .getBoolean(it, false)
+            } ?: false
+        }.getOrDefault(false)
+        if (!shouldReadDisUnbonded(
+                isWhoop5 = connectedFamily == DeviceFamily.WHOOP5,
+                bonded = didBond,
+                alreadyReadThisLink = disRead,
+                previouslyRefused = refused,
+            )
+        ) return
+        log("DIS: trying the identity read on an UNbonded link — unproven, and a refusal is itself the" +
+            " answer to whether DIS needs an encrypted bond (#490)")
+        readDisIdentity()
+    }
+
     /** Chained second half of [readDisIdentity] — issued only after the serial read has landed. */
     private fun readDisHardwareRevision() {
         val g = gatt ?: return
@@ -4265,6 +4315,17 @@ class WhoopBleClient(
         val ch = g.getService(DIS_SERVICE)?.getCharacteristic(DIS_HW_REV_CHAR) ?: return
         if ((ch.properties and BluetoothGattCharacteristic.PROPERTY_READ) != 0) {
             safeGatt("readCharacteristic(dis-hwrev)") { ops.readCharacteristicCompat(ch) }
+        }
+    }
+
+    /** Chained third read — issued after the hardware revision lands. Gives an unbonded 5/MG a firmware
+     *  string it otherwise has no source for at all. */
+    private fun readDisFirmwareRevision() {
+        val g = gatt ?: return
+        val ops = gattOps ?: return
+        val ch = g.getService(DIS_SERVICE)?.getCharacteristic(DIS_FW_REV_CHAR) ?: return
+        if ((ch.properties and BluetoothGattCharacteristic.PROPERTY_READ) != 0) {
+            safeGatt("readCharacteristic(dis-fwrev)") { ops.readCharacteristicCompat(ch) }
         }
     }
 
@@ -5625,6 +5686,7 @@ class WhoopBleClient(
             status: Int,
         ) {
             if (status == BluetoothGatt.GATT_SUCCESS) onInbound(characteristic.uuid, value)
+            else noteReadFailure(characteristic.uuid, status)
         }
 
         @Deprecated("Deprecated in API 33; retained for API 26..32 where the value-bearing overload isn't called")
@@ -5635,6 +5697,7 @@ class WhoopBleClient(
         ) {
             @Suppress("DEPRECATION")
             if (status == BluetoothGatt.GATT_SUCCESS) characteristic.value?.let { onInbound(characteristic.uuid, it) }
+            else noteReadFailure(characteristic.uuid, status)
         }
     }
 
@@ -5667,6 +5730,19 @@ class WhoopBleClient(
             uuid == DIS_HW_REV_CHAR -> {
                 disHwRev = bytes.toString(Charsets.UTF_8).trim { it == '\u0000' || it.isWhitespace() }
                 noteWhoop5VariantFromDis()
+                readDisFirmwareRevision()
+            }
+            uuid == DIS_FW_REV_CHAR -> {
+                val fw = bytes.toString(Charsets.UTF_8).trim { it == '\u0000' || it.isWhitespace() }
+                if (shouldPublishDisFirmware(fw, _state.value.strapFirmware)) {
+                    _state.update { it.copy(strapFirmware = fw) }
+                    runCatching { NoopPrefs.setFirmwareFor(context, lastDeviceAddress, fw) }
+                    // Named as the DIS source, because it is not the same reading as the decoded one the
+                    // 4.0 shows and a capture must not have to guess which it is looking at.
+                    log("DIS: firmware=$fw (standard profile, no bond required)")
+                } else {
+                    log("DIS: firmware=${fw.ifBlank { "?" }} not published — a decoded value already stands")
+                }
             }
             // WHOOP4 custom notify chars, OR the WHOOP 5/MG puffin notify chars (fd4b0003/4/5/7) once
             // bonded — both carry framed records (REALTIME_DATA etc.) through the family-aware reassembler.
@@ -7387,6 +7463,14 @@ class WhoopBleClient(
                     log("WHOOP 5/MG: CLIENT_HELLO suppressed for this strap — it was never acknowledged and" +
                         " the write is what drops the link. Staying on live HR (not fully paired); press" +
                         " Connect to try the handshake again (#1635).")
+                    // The unbonded DIS attempt rides HERE, on the suppressed link, and nowhere else. This
+                    // is the only 5/MG state known to be stable: the handshake is off, the watchdog is
+                    // cancelled, and the link holds. During the reconnect loop it would have ~4.8s and
+                    // prove nothing, and adding a read to a handshake that is already failing would make
+                    // both harder to read. If the read is what tears a stable link down, that is
+                    // unambiguous — and it latches, so it costs one link and not a loop.
+                    handler.postDelayed({ gatt?.let { readDisIdentityUnbonded(it) } },
+                        BATTERY_ON_CONNECT_DELAY_MS * 2)
                 }
             }
         }

--- a/android/app/src/test/java/com/noop/ble/DisUnbondedReadTest.kt
+++ b/android/app/src/test/java/com/noop/ble/DisUnbondedReadTest.kt
@@ -1,0 +1,56 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** The unbonded DIS attempt: once per device, never after a refusal. */
+class DisUnbondedReadTest {
+    private fun go(
+        isWhoop5: Boolean = true,
+        bonded: Boolean = false,
+        already: Boolean = false,
+        refused: Boolean = false,
+    ) = shouldReadDisUnbonded(isWhoop5, bonded, already, refused)
+
+    @Test
+    fun `an unbonded 5-MG that has not been asked yet is tried once`() {
+        assertTrue(go())
+    }
+
+    @Test
+    fun `a strap that already refused is never asked again`() {
+        // Self-limiting, like the hello suppression. "Keeps trying something that will never work" is the
+        // failure this area keeps producing, and a refusal is a durable fact about the strap.
+        assertFalse(go(refused = true))
+    }
+
+    @Test
+    fun `a bonded link is left to the post-bond path`() {
+        assertFalse(go(bonded = true))
+    }
+
+    @Test
+    fun `never on a WHOOP 4, and never twice on one link`() {
+        assertFalse(go(isWhoop5 = false))
+        assertFalse(go(already = true))
+    }
+
+    @Test
+    fun `the refusal key is per device and case-insensitive`() {
+        assertEquals(disRefusedPrefKey("fd:d4:f7:24:53:4a"), disRefusedPrefKey("  FD:D4:F7:24:53:4A  "))
+        assertEquals(null, disRefusedPrefKey("  "))
+    }
+
+    @Test
+    fun `a failed read is no longer silent, and names the interesting statuses`() {
+        // Both onCharacteristicRead overloads used to drop a non-success status on the floor, so a refusal
+        // was indistinguishable from a read that never happened - the ambiguity that made the CLIENT_HELLO
+        // failure unreadable for eleven weeks.
+        val line = disReadFailureLine("00002a26-0000-1000-8000-00805f9b34fb", "status=GATT_INSUFFICIENT_AUTHENTICATION(5)")
+        assertTrue(line.contains("GATT_INSUFFICIENT_AUTHENTICATION(5)"))
+        assertTrue(line.contains("cannot be read without one"))
+        assertTrue(line.contains("2a26"))
+    }
+}

--- a/android/app/src/test/java/com/noop/ble/FirmwareAttributionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/FirmwareAttributionTest.kt
@@ -1,5 +1,7 @@
 package com.noop.ble
 
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -52,5 +54,28 @@ class FirmwareAttributionTest {
     fun `no address means no key, so nothing is written to a key owned by no device`() {
         assertNull(firmwarePrefKey(null))
         assertNull(firmwarePrefKey("   "))
+    }
+
+    @Test
+    fun `DIS firmware fills the gap for a strap that never bonds`() {
+        // The screenshot case: a WHOOP 4.0 shows its firmware, the 5/MG beside it shows none - because the
+        // only source NOOP read it from is a framed command that needs a bond the 5/MG never gets. DIS
+        // 0x2A26 is readable unbonded, in the same service the serial already comes from.
+        assertTrue(shouldPublishDisFirmware("1.2.3", alreadyDecoded = null))
+        assertTrue(shouldPublishDisFirmware("1.2.3", alreadyDecoded = ""))
+    }
+
+    @Test
+    fun `DIS never overrides a decoded firmware`() {
+        // The two are not guaranteed to agree - one is the strap's own report, the other is whatever it
+        // publishes in its standard profile. A value that appeared and then changed would be worse than
+        // one that arrived once, so DIS yields rather than racing the decode that lands later.
+        assertFalse(shouldPublishDisFirmware("1.2.3", alreadyDecoded = "41.17.6.0"))
+    }
+
+    @Test
+    fun `a blank or absent DIS string publishes nothing`() {
+        assertFalse(shouldPublishDisFirmware(null, alreadyDecoded = null))
+        assertFalse(shouldPublishDisFirmware("   ", alreadyDecoded = null))
     }
 }


### PR DESCRIPTION
## Why the 5/MG shows no firmware

A WHOOP 4.0 shows `FW 41.17.6.0` and the 5/MG beside it shows nothing. That reads as a missing feature and is really a **missing read**: the serial, the hardware revision and the firmware all come from the Device Information Service, and `readDisIdentity()` is issued only inside the post-bond handshake — so a strap that never bonds never reads DIS at all.

Two things confirm it in the field capture: **zero `DIS:` lines**, and the strap name shown in the UI comes from the BLE advertisement (`Discovered WHOOP MGB0779473`), not from DIS.

## Three parts

**1. The read chain gains firmware (`0x2A26`)**, after the hardware revision. DIS is a **fallback that never overrides a decoded value** — the puffin reading is the strap's own report and is what the 4.0 shows; DIS is whatever the device publishes in its standard profile, and the two are not guaranteed to agree. A value that appeared and then changed would be worse than one that arrived once.

**2. Failed reads stop being silent.** *Both* `onCharacteristicRead` overloads dropped a non-success status on the floor, so a refused read produced no line and was indistinguishable from one never issued — the same ambiguity that made the CLIENT_HELLO failure unreadable for eleven weeks. An `INSUFFICIENT_AUTHENTICATION`/`INSUFFICIENT_ENCRYPTION` status here is a genuine finding: it confirms #490 on Android and means the firmware cannot be had without a bond.

**3. The unbonded attempt**, once per device, latched off after a refusal.

## The placement is the safety argument

The attempt rides **only on the suppressed link** — the one 5/MG state known to be stable: handshake off, watchdog cancelled, link holding. Everywhere else is worse:

- During the reconnect loop it would have ~4.8s and prove nothing.
- Alongside a live handshake it would make both harder to read.

A read is the same class of operation as the write that provokes the teardown, so if it costs the link that is unambiguous — and it latches per device, so it costs **one link rather than a loop**.

## Unproven by design

| observed | evidence |
|---|---|
| standard **notifications** work unbonded | live HR and battery both arrive that way on these straps |
| standard **reads** work unbonded | none — and Swift carries a note (#490) that a 5/MG refuses them |

So this may simply be refused. That is still a result: it settles #490 for Android, which no capture has done, and it means firmware genuinely requires a bond rather than being an oversight.

## Verification

- Full Android suite green: **4465** tests, 9 new.
- `doc_comment_lint` and `i18n_audit` clean.
- Android only — the read chain is Android-side; the Swift twin depends on whether this is refused.
- **Untested on hardware.**
