### PR TITLE
ble: ask the device its bond state, instead of trusting our own receiver

### DIFF
--- a/android/app/src/main/java/com/noop/ble/BondStateTrace.kt
+++ b/android/app/src/main/java/com/noop/ble/BondStateTrace.kt
@@ -94,3 +94,37 @@ internal fun bondStateAtConnectLine(bondState: Int, address: String?): String {
     val who = address?.takeIf { it.isNotBlank() } ?: "unknown"
     return "bond state at connect: ${bondStateName(bondState)} device=$who"
 }
+
+/**
+ * What `BluetoothDevice.bondState` says a short while AFTER `createBond()` was accepted.
+ *
+ * This exists because absence of evidence kept being read as evidence. A capture showed `createBond`
+ * returning true and then no bond-state transition of any kind — and that has two very different causes
+ * which the log could not tell apart:
+ *
+ *  - Android genuinely did nothing, or
+ *  - it did something and NOOP failed to hear it, because the broadcast receiver or its device filter is
+ *    wrong. That receiver is ours and was added in the same week; it is a live suspect, not a given.
+ *
+ * Polling the device directly removes the broadcast from the chain, so the answer no longer depends on
+ * the component under suspicion. A `BOND_BONDING` here with no transition line above it convicts our
+ * receiver; a `BOND_NONE` clears it and puts the silence on Android.
+ *
+ * Deliberately a single delayed read rather than a subscription: one fact is wanted, not a stream.
+ */
+internal fun bondStatePollLine(bondState: Int, sawTransitionLine: Boolean): String {
+    val name = bondStateName(bondState)
+    val verdict = when {
+        bondState == android.bluetooth.BluetoothDevice.BOND_BONDING && !sawTransitionLine ->
+            " — pairing IS underway and no transition line was logged, so the bond-state receiver missed it" +
+                " (a NOOP bug, not the strap)"
+        bondState == android.bluetooth.BluetoothDevice.BOND_BONDING ->
+            " — pairing underway, as the transition line already said"
+        bondState == android.bluetooth.BluetoothDevice.BOND_BONDED -> " — paired"
+        !sawTransitionLine ->
+            " — createBond was accepted but the device never left this state and nothing was heard," +
+                " so Android did not begin pairing at all"
+        else -> " — back to this state after a transition"
+    }
+    return "bond state poll: $name$verdict"
+}

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -845,6 +845,11 @@ class WhoopBleClient(
          *  this is now just the FIRST window — [bondWatchdogBackoff] escalates it per consecutive bounce so
          *  a slower-but-healthy WHOOP 4.0 handshake gets more time before being bounced again. */
         private const val BOND_WATCHDOG_MS = 7_000L
+
+        /** How long after an accepted `createBond()` to read the device's bond state directly (#1635).
+         *  Long enough that a pairing which started has reached BOND_BONDING, short enough to land while
+         *  the link is still up on a strap whose links have historically lasted ~4.8s. */
+        private const val EXPLICIT_BOND_POLL_MS = 2_000L
         /** OnePlus-only settle delay before the FIRST CCCD descriptor write after service discovery
          *  (#50). The OnePlus Nord 2 GATT stack needs a beat to settle post-discovery; writing the first
          *  descriptor immediately races the still-unsettled stack and the subscribe returns BUSY. ~450ms
@@ -2221,6 +2226,7 @@ class WhoopBleClient(
         val since = helloMs ?: bondMs
         val label = if (helloMs != null) "CLIENT_HELLO" else "the pairing request"
         if (!shouldTraceBondState(address, lastDeviceAddress, since != null)) return
+        sawBondTransitionThisLink = true
         log(bondStateTraceLine(previous, current, address, since, label))
     }
 
@@ -4652,6 +4658,11 @@ class WhoopBleClient(
      *  leaving every pairing transition untimed, so a 200ms pairing and an 8s one read identically. */
     @Volatile
     private var explicitBondRequestedAtMs = 0L
+
+    /** True once a bond-state TRANSITION was logged on this link, so the poll can say whether its reading
+     *  agrees with what the receiver heard — or convicts the receiver of hearing nothing (#1635). */
+    @Volatile
+    private var sawBondTransitionThisLink = false
 
     /** Set by an explicit user Connect so the NEXT 5/MG session re-attempts a suppressed CLIENT_HELLO
      *  (#1635). Consumed on use, so it grants exactly one retry: someone who put the strap in pairing mode
@@ -7356,6 +7367,13 @@ class WhoopBleClient(
                                 runCatching {
                                     com.noop.ui.NoopPrefs.setHelloSuppressed(context, g.device.address, false)
                                 }
+                                // Ask the device directly rather than waiting on our own broadcast
+                                // receiver, which is a suspect in exactly the silence being investigated.
+                                handler.postDelayed({
+                                    runCatching {
+                                        log(bondStatePollLine(g.device.bondState, sawBondTransitionThisLink))
+                                    }
+                                }, EXPLICIT_BOND_POLL_MS)
                             }
                         },
                         onFailure = { log(explicitBondThrewLine(it.javaClass.simpleName, where)) },
@@ -8583,6 +8601,7 @@ class WhoopBleClient(
     private fun reset() {
         didBond = false
         explicitBondRequestedThisLink = false   // #1635: one createBond attempt per link
+        sawBondTransitionThisLink = false
         // explicitBondRequestedAtMs is deliberately NOT cleared here. An OS pairing routinely completes
         // AFTER the GATT link that asked for it has dropped, so clearing on teardown would leave the
         // BOND_BONDED transition — the one that matters most — arriving with no timing at all, which is

--- a/android/app/src/test/java/com/noop/ble/BondStateTraceTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BondStateTraceTest.kt
@@ -119,4 +119,28 @@ class BondStateTraceTest {
         assertTrue(l.contains("FD:D4"))
         assertTrue(bondStateAtConnectLine(android.bluetooth.BluetoothDevice.BOND_NONE, null).contains("unknown"))
     }
+
+    @Test
+    fun `BONDING with no transition line convicts our receiver, not the strap`() {
+        // The whole point: a capture showed createBond accepted and then silence, and that has two very
+        // different causes. Polling the device removes our own broadcast receiver from the chain, so the
+        // answer no longer depends on the component under suspicion.
+        val line = bondStatePollLine(android.bluetooth.BluetoothDevice.BOND_BONDING, sawTransitionLine = false)
+        assertTrue(line.contains("receiver missed it"))
+        assertTrue(line.contains("a NOOP bug, not the strap"))
+    }
+
+    @Test
+    fun `NONE with no transition line puts the silence on Android`() {
+        val line = bondStatePollLine(android.bluetooth.BluetoothDevice.BOND_NONE, sawTransitionLine = false)
+        assertTrue(line.contains("did not begin pairing at all"))
+        assertFalse(line.contains("NOOP bug"))
+    }
+
+    @Test
+    fun `a heard transition is not reported as a missed one`() {
+        val line = bondStatePollLine(android.bluetooth.BluetoothDevice.BOND_BONDING, sawTransitionLine = true)
+        assertFalse(line.contains("missed it"))
+        assertTrue(bondStatePollLine(android.bluetooth.BluetoothDevice.BOND_BONDED, true).contains("paired"))
+    }
 }


### PR DESCRIPTION
The first explicit-pairing capture showed `createBond()` returning **true** and then no bond-state transition of any kind, for four minutes.

That has two very different explanations, and the log cannot tell them apart:

- Android genuinely never began pairing, or
- it did, and NOOP failed to hear it — the bond-state receiver and its device filter are ours, were added the same week, and are a live suspect rather than a given.

Absence of evidence has now been mistaken for evidence twice in this investigation. Polling `BluetoothDevice.bondState` two seconds after an accepted `createBond` removes the broadcast from the chain, so the answer no longer depends on the component under suspicion:

| poll reads | with no transition line | verdict |
|---|---|---|
| `BOND_BONDING` | yes | **our receiver missed it** — a NOOP bug, not the strap |
| `BOND_NONE` | yes | Android did not begin pairing at all |
| `BOND_BONDED` | — | paired |

A single delayed read, not a subscription — one fact is wanted. Two seconds is long enough for a pairing that started to reach BONDING, short enough to land while the link is up on a strap whose links historically lasted ~4.8s.

**4459** Android tests green; doc lint and i18n audit clean.