### PR TITLE
ble: let the DIS read happen when the pairing experiment is on, and not lie about refusals

### DIFF
--- a/android/app/src/main/java/com/noop/ble/BondStateTrace.kt
+++ b/android/app/src/main/java/com/noop/ble/BondStateTrace.kt
@@ -69,6 +69,10 @@ internal fun bondStateTraceLine(
  * exists to observe, and outside it an anonymous transition cannot be attributed to us.
  *
  * Pure so the scoping rule is unit-tested without a radio.
+ *
+ * PARITY: Android-only, and permanently so. CoreBluetooth exposes no bond state and no pairing API at
+ * all — there is no `BOND_BONDING` to observe on Apple platforms and nothing to mirror. An audit finding
+ * this file one-sided should leave it rather than delete it as untwinned.
  */
 internal fun shouldTraceBondState(
     eventAddress: String?,

--- a/android/app/src/main/java/com/noop/ble/DisUnbondedRead.kt
+++ b/android/app/src/main/java/com/noop/ble/DisUnbondedRead.kt
@@ -54,3 +54,23 @@ internal fun disReadFailureLine(uuid: String, status: String): String =
     "DIS: read of $uuid failed $status — the strap declined it on this link. If this is an" +
         " insufficient-authentication or -encryption status, DIS needs an encrypted bond and the firmware" +
         " cannot be read without one (#490)"
+
+/**
+ * Should the standard Device Information Service firmware string be published for this strap?
+ *
+ * A 5/MG that never completes the puffin handshake has no firmware to show, because the only source NOOP
+ * reads it from is a framed command that needs the bond. The Devices screen therefore shows a WHOOP 4.0
+ * with its firmware beside a 5/MG with none — which reads as a missing feature and is really a missing
+ * READ: DIS `0x2A26` sits in the same service NOOP already reads the serial and hardware revision from,
+ * unbonded, on every 5/MG connect (#520). It was simply never asked for.
+ *
+ * DIS is a FALLBACK, never an override. The puffin value is the strap's own report of the firmware it is
+ * running and is what the 4.0 has always shown; DIS is whatever the device chose to publish in its
+ * standard profile, and the two are not guaranteed to agree. So this yields to anything already decoded
+ * rather than racing it — the decode lands later in the connect, and a value that appeared and then
+ * changed would be worse than one that arrived once.
+ */
+internal fun shouldPublishDisFirmware(
+    disFirmware: String?,
+    alreadyDecoded: String?,
+): Boolean = !disFirmware.isNullOrBlank() && alreadyDecoded.isNullOrBlank()

--- a/android/app/src/main/java/com/noop/ble/FirmwareAttribution.kt
+++ b/android/app/src/main/java/com/noop/ble/FirmwareAttribution.kt
@@ -42,24 +42,3 @@ internal fun resolveFirmware(
  */
 internal fun firmwarePrefKey(peripheralId: String?): String? =
     peripheralId?.trim()?.takeIf { it.isNotEmpty() }?.let { "noop.lastFirmware.${it.lowercase()}" }
-
-/**
- * Should the standard Device Information Service firmware string be published for this strap?
- *
- * A 5/MG that never completes the puffin handshake has no firmware to show, because the only source NOOP
- * reads it from is a framed command that needs the bond. The Devices screen therefore shows a WHOOP 4.0
- * with its firmware beside a 5/MG with none — which reads as a missing feature and is really a missing
- * READ: DIS `0x2A26` sits in the same service NOOP already reads the serial and hardware revision from,
- * unbonded, on every 5/MG connect (#520). It was simply never asked for.
- *
- * DIS is a FALLBACK, never an override. The puffin value is the strap's own report of the firmware it is
- * running and is what the 4.0 has always shown; DIS is whatever the device chose to publish in its
- * standard profile, and the two are not guaranteed to agree. So this yields to anything already decoded
- * rather than racing it — the decode lands later in the connect, and a value that appeared and then
- * changed would be worse than one that arrived once.
- */
-internal fun shouldPublishDisFirmware(
-    disFirmware: String?,
-    alreadyDecoded: String?,
-): Boolean = !disFirmware.isNullOrBlank() && alreadyDecoded.isNullOrBlank()
-

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4283,12 +4283,37 @@ class WhoopBleClient(
     private fun noteReadFailure(uuid: java.util.UUID, status: Int) {
         if (uuid != DIS_SERIAL_CHAR && uuid != DIS_HW_REV_CHAR && uuid != DIS_FW_REV_CHAR) return
         log(disReadFailureLine(uuid.toString(), gattWriteStatusLabel(status)))
+        // Report it, but do NOT latch it when WE put a pairing in flight on this link. The latch is
+        // persisted per device and permanent, and a read issued into a link that is mid-encryption
+        // negotiation can fail for reasons that have nothing to do with the strap's policy. Latching that
+        // would disable the firmware read for this strap for good, and blame the strap for our own timing.
+        if (explicitBondRequestedThisLink) {
+            log("DIS: not latching that refusal — a pairing was requested on this link, so the failure is" +
+                " not attributable to the strap")
+            return
+        }
         runCatching {
             disRefusedPrefKey(lastDeviceAddress)?.let {
                 context.getSharedPreferences(com.noop.ui.NoopPrefs.NAME, android.content.Context.MODE_PRIVATE)
                     .edit().putBoolean(it, true).apply()
             }
         }
+    }
+
+    /**
+     * Schedule the unbonded DIS attempt on a link that will carry NO CLIENT_HELLO.
+     *
+     * Called from BOTH no-hello paths, and that is the point. There are two of them — the hello suppressed
+     * after the give-up, and the hello deferred because an explicit pairing was just requested — and the
+     * second one returns early, so scheduling this in only the first meant the DIS read never happened for
+     * anyone running the pairing experiment. The two features shipped in the same build and were mutually
+     * exclusive in exactly the configuration a tester would use.
+     *
+     * Both paths leave the same stable state: no handshake outstanding, watchdog cancelled, link holding.
+     * That is the only state this read is safe to attempt in.
+     */
+    private fun scheduleUnbondedDisRead() {
+        handler.postDelayed({ gatt?.let { readDisIdentityUnbonded(it) } }, BATTERY_ON_CONNECT_DELAY_MS * 2)
     }
 
     /**
@@ -7462,6 +7487,10 @@ class WhoopBleClient(
                     // thing most likely to abort the pairing we just asked for, so the experiment would
                     // sabotage itself ~7s in and report a refusal that never happened.
                     cancelBondWatchdog()
+                    // This link carries no hello either, so it is the same stable state the suppression
+                    // path uses — and without this the DIS read never runs for anyone with the pairing
+                    // experiment on, which is precisely who is testing.
+                    scheduleUnbondedDisRead()
                     return
                 }
 
@@ -7487,8 +7516,7 @@ class WhoopBleClient(
                     // prove nothing, and adding a read to a handshake that is already failing would make
                     // both harder to read. If the read is what tears a stable link down, that is
                     // unambiguous — and it latches, so it costs one link and not a loop.
-                    handler.postDelayed({ gatt?.let { readDisIdentityUnbonded(it) } },
-                        BATTERY_ON_CONNECT_DELAY_MS * 2)
+                    scheduleUnbondedDisRead()
                 }
             }
         }

--- a/android/app/src/test/java/com/noop/ble/DisUnbondedReadTest.kt
+++ b/android/app/src/test/java/com/noop/ble/DisUnbondedReadTest.kt
@@ -53,4 +53,27 @@ class DisUnbondedReadTest {
         assertTrue(line.contains("cannot be read without one"))
         assertTrue(line.contains("2a26"))
     }
+
+    @Test
+    fun `DIS firmware fills the gap for a strap that never bonds`() {
+        // The screenshot case: a WHOOP 4.0 shows its firmware, the 5/MG beside it shows none - because the
+        // only source NOOP read it from is a framed command that needs a bond the 5/MG never gets. DIS
+        // 0x2A26 is readable unbonded, in the same service the serial already comes from.
+        assertTrue(shouldPublishDisFirmware("1.2.3", alreadyDecoded = null))
+        assertTrue(shouldPublishDisFirmware("1.2.3", alreadyDecoded = ""))
+    }
+
+    @Test
+    fun `DIS never overrides a decoded firmware`() {
+        // The two are not guaranteed to agree - one is the strap's own report, the other is whatever it
+        // publishes in its standard profile. A value that appeared and then changed would be worse than
+        // one that arrived once, so DIS yields rather than racing the decode that lands later.
+        assertFalse(shouldPublishDisFirmware("1.2.3", alreadyDecoded = "41.17.6.0"))
+    }
+
+    @Test
+    fun `a blank or absent DIS string publishes nothing`() {
+        assertFalse(shouldPublishDisFirmware(null, alreadyDecoded = null))
+        assertFalse(shouldPublishDisFirmware("   ", alreadyDecoded = null))
+    }
 }

--- a/android/app/src/test/java/com/noop/ble/FirmwareAttributionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/FirmwareAttributionTest.kt
@@ -55,27 +55,4 @@ class FirmwareAttributionTest {
         assertNull(firmwarePrefKey(null))
         assertNull(firmwarePrefKey("   "))
     }
-
-    @Test
-    fun `DIS firmware fills the gap for a strap that never bonds`() {
-        // The screenshot case: a WHOOP 4.0 shows its firmware, the 5/MG beside it shows none - because the
-        // only source NOOP read it from is a framed command that needs a bond the 5/MG never gets. DIS
-        // 0x2A26 is readable unbonded, in the same service the serial already comes from.
-        assertTrue(shouldPublishDisFirmware("1.2.3", alreadyDecoded = null))
-        assertTrue(shouldPublishDisFirmware("1.2.3", alreadyDecoded = ""))
-    }
-
-    @Test
-    fun `DIS never overrides a decoded firmware`() {
-        // The two are not guaranteed to agree - one is the strap's own report, the other is whatever it
-        // publishes in its standard profile. A value that appeared and then changed would be worse than
-        // one that arrived once, so DIS yields rather than racing the decode that lands later.
-        assertFalse(shouldPublishDisFirmware("1.2.3", alreadyDecoded = "41.17.6.0"))
-    }
-
-    @Test
-    fun `a blank or absent DIS string publishes nothing`() {
-        assertFalse(shouldPublishDisFirmware(null, alreadyDecoded = null))
-        assertFalse(shouldPublishDisFirmware("   ", alreadyDecoded = null))
-    }
 }


### PR DESCRIPTION
Three fixes from re-reviewing the two changes that landed together.

**They were mutually exclusive in the exact configuration a tester would use.** The explicit-pairing path returns early once it defers the hello, and the unbonded DIS read was scheduled only *after* that return — so turning the pairing experiment on silently disabled the firmware read. Both no-hello paths leave the identical stable state, which is the only state the read is safe in, so there was never a reason to schedule it in one and not the other.

**Fixing that introduced something worse.** On the pairing path the read lands ~3s after `createBond`, inside an in-flight pairing. A read into a link mid-encryption-negotiation can fail for reasons unrelated to the strap — and the refusal latch is **persisted per device**. Our own pairing attempt could have permanently disabled the firmware read for that strap, with the log blaming the strap and citing #490 as though confirmed. The failure is still reported; it is no longer latched when we put the pairing in flight.

**Parity.** `shouldPublishDisFirmware` had been added to `FirmwareAttribution.kt`, which **is** twinned — a one-sided addition to a twinned file, and the one thing a parity audit would correctly flag. Moved to the Android-only `DisUnbondedRead.kt` rather than adding an unused Swift function for a read Swift does not perform. `BondStateTrace` now records why it is permanently one-sided (CoreBluetooth has no bond state and no pairing API), so an audit leaves it rather than deleting it as untwinned.

**4468** Android tests green; doc lint and i18n audit clean.