### PR TITLE
ble: capture 5/MG frames outside a sync window, and stop naming an unreachable remedy

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7429,22 +7429,17 @@ class WhoopBleClient(
         when (connectedFamily) {
             DeviceFamily.WHOOP4 -> writeBondFrame(g, cmd)
             DeviceFamily.WHOOP5 -> {
-                // #1635: the hello is what ends the link on a strap that never answers it. Once the
-                // give-up has latched, skip it and let the standard-profile HR stream keep running.
-                //
-                // Consumed unconditionally, so the single retry an explicit Connect grants belongs to THIS
-                // session. Leaving it set would hand a stale retry to some later automatic reconnect and
-                // restart the loop the suppression exists to end.
-                // #1635 experiment: ask Android to pair, instead of hoping the encrypted write provokes
-                // it — which the bond-state trace showed never happens. Runs BEFORE the hello decision
-                // because the two must not overlap: writing while a pairing is in flight is the behaviour
-                // that has been dropping the link, so doing both would test nothing.
                 // #1635: open the raw capture HERE, not only on entering backfill, so frames arriving
                 // outside a sync window are recorded. Idempotent, so the existing call in
                 // enterBackfilling still covers a capture switched on mid-session. Opening appends (never
                 // truncates — see startWhoop5BackfillCapture), so doing it per connect cannot lose a
                 // previous session's material.
                 if (PuffinExperiment.from(context).isCaptureEnabled) startWhoop5BackfillCapture()
+
+                // #1635 experiment: ask Android to pair, instead of hoping the encrypted write provokes
+                // it — which the bond-state trace showed never happens. Runs BEFORE the hello decision
+                // because the two must not overlap: writing while a pairing is in flight is the behaviour
+                // that has been dropping the link, so doing both would test nothing.
                 val osBonded = g.device.bondState == BluetoothDevice.BOND_BONDED
                 // Once per link, before any decision: a hello that fails on an unencrypted link and one
                 // that fails on an ENCRYPTED link are completely different findings, and they have been
@@ -7511,6 +7506,12 @@ class WhoopBleClient(
                     return
                 }
 
+                // #1635: the hello is what ends the link on a strap that never answers it. Once the
+                // give-up has latched, skip it and let the standard-profile HR stream keep running.
+                //
+                // Consumed unconditionally, so the single retry an explicit Connect grants belongs to THIS
+                // session. Leaving it set would hand a stale retry to some later automatic reconnect and
+                // restart the loop the suppression exists to end.
                 val userAsked = helloRetryRequested
                 helloRetryRequested = false
                 val suppressed = runCatching {

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5981,14 +5981,25 @@ class WhoopBleClient(
                         // samples (100 Hz 6-axis) into the rawImuSample table when raw capture is on.
                         storeWhoop5RawImuIfBuffer(frame)
                     }
+                    // Opt-in raw capture: record EVERY frame of the session (offload AND live flood —
+                    // the offload flag lets analysis filter), BEFORE routing so frames are retained
+                    // before the trim ack deletes the strap's copy. No-op (single null check) when the
+                    // toggle is off. (#78 fork)
+                    //
+                    // Deliberately OUTSIDE the `backfilling` gate, where it used to sit. The comment
+                    // already claimed "every frame of the session" and the gate made that false: live and
+                    // event frames arriving between syncs were never recorded at all.
+                    //
+                    // This does NOT rescue a strap that never bonds, and it is worth saying so here so the
+                    // next reader does not assume it did. The frames that reach this path are the puffin
+                    // notify characteristics, and those are subscribed only in the CLIENT_HELLO-ack
+                    // branch — so an unbonded 5/MG still produces an empty capture. Making that case
+                    // yield anything means capturing the standard-profile notifications instead, which is
+                    // a different feature and mostly already-decoded data (#1635).
+                    if (connectedFamily == DeviceFamily.WHOOP5 && captureWriter != null) {
+                        writeWhoop5BackfillCapture(uuid.toString(), frame)
+                    }
                     if (backfilling) {
-                        // Opt-in raw capture: record EVERY frame of the session (offload AND live
-                        // flood — the offload flag lets analysis filter), BEFORE routing so frames
-                        // are retained before the trim ack deletes the strap's copy. No-op (single
-                        // null check) when the toggle is off. (#78 fork)
-                        if (connectedFamily == DeviceFamily.WHOOP5 && captureWriter != null) {
-                            writeWhoop5BackfillCapture(uuid.toString(), frame)
-                        }
                         // Historical offload: route ONLY genuine offload frames (47/48/49/50) through
                         // the serial drain (preserves chunk order) + re-arm the idle watchdog on them.
                         // The live type-40/43 flood is dropped here (extractHistoricalStreams ignores
@@ -7428,6 +7439,12 @@ class WhoopBleClient(
                 // it — which the bond-state trace showed never happens. Runs BEFORE the hello decision
                 // because the two must not overlap: writing while a pairing is in flight is the behaviour
                 // that has been dropping the link, so doing both would test nothing.
+                // #1635: open the raw capture HERE, not only on entering backfill, so frames arriving
+                // outside a sync window are recorded. Idempotent, so the existing call in
+                // enterBackfilling still covers a capture switched on mid-session. Opening appends (never
+                // truncates — see startWhoop5BackfillCapture), so doing it per connect cannot lose a
+                // previous session's material.
+                if (PuffinExperiment.from(context).isCaptureEnabled) startWhoop5BackfillCapture()
                 val osBonded = g.device.bondState == BluetoothDevice.BOND_BONDED
                 // Once per link, before any decision: a hello that fails on an unencrypted link and one
                 // that fails on an ENCRYPTED link are completely different findings, and they have been

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -8906,13 +8906,27 @@ class WhoopBleClient(
                     hex = frame.toHex(),
                 ),
             )
+            var checkBytes = false
             synchronized(w) {
                 w.write(line)
                 w.newLine()
-                if (++captureLines % 100 == 0) w.flush()
+                if (++captureLines % 100 == 0) { w.flush(); checkBytes = true }
             }
             if (captureLines >= WHOOP5_CAPTURE_MAX_LINES) {
                 log("Capture: line cap reached — capture paused until next session")
+                closeWhoop5BackfillCapture(flushSummary = false)
+                return@runCatching
+            }
+            // The byte cap used to be enforced only when the file was OPENED, which was sufficient while
+            // the line cap was a hard per-session bound. It no longer is: entering backfill hands the line
+            // budget back (so the live flood cannot starve the offload), and a session that auto-continues
+            // several offloads resets it several times. Without a check here the file could grow well past
+            // the cap inside one long-lived connection and never rotate. Only on the flush boundary, so
+            // this is one stat per 100 frames, not per frame.
+            if (checkBytes &&
+                java.io.File(context.filesDir, WHOOP5_CAPTURE_FILE).length() > WHOOP5_CAPTURE_MAX_BYTES
+            ) {
+                log("Capture: byte cap reached — capture paused until next session (it rotates on reopen)")
                 closeWhoop5BackfillCapture(flushSummary = false)
             }
         }.onFailure {

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7768,8 +7768,16 @@ class WhoopBleClient(
         refreshConnectionPriority()   // #477: escalate to HIGH for the offload burst (faster sync). No-op unless enabled.
         applyPreferredPhy()           // #533: prefer LE 2M for the burst (halves air-time). No-op unless enabled.
         // Opt-in raw capture (research aid): pref read fresh per session, like the probes gate.
+        // Normally already open from the connect hook; this covers a capture switched on mid-session.
         if (connectedFamily == DeviceFamily.WHOOP5 && PuffinExperiment.from(context).isCaptureEnabled) {
             startWhoop5BackfillCapture()
+            // Give the offload a FULL line budget. Since the capture was hoisted out of the `backfilling`
+            // gate it also records the live flood, and on a link that stays up overnight that flood can
+            // exhaust the 40k cap before the morning sync — pausing capture at exactly the moment the
+            // offload arrives, and losing the material this feature exists to collect. The line cap is a
+            // runaway guard, not a quota the live stream is entitled to spend, so the offload gets it
+            // back. The BYTE cap still bounds the file and is untouched.
+            captureLines = 0
         }
         if (connectedFamily == DeviceFamily.WHOOP5) {
             // Re-apply the Broadcast-HR device-config flag if the user opted in (#181).

--- a/android/app/src/main/java/com/noop/ui/LogExport.kt
+++ b/android/app/src/main/java/com/noop/ui/LogExport.kt
@@ -374,12 +374,30 @@ object LogExport {
         whoop5Connected: Boolean,
         encryptedBond: Boolean,
         sharingLog: Boolean,
+    ): String = noCaptureMsgText(
+        whoop5Connected = whoop5Connected,
+        captureEnabled = PuffinExperiment.from(context).isCaptureEnabled,
+        encryptedBond = encryptedBond,
+        sharingLog = sharingLog,
+    )
+
+    /**
+     * The no-capture copy, as a pure function of what we know.
+     *
+     * Split from the Context-reading wrapper so the wording is unit-testable — the repo's test classpath
+     * has no mocking framework, by preference: helpers worth asserting are made pure rather than mocked.
+     */
+    internal fun noCaptureMsgText(
+        whoop5Connected: Boolean,
+        captureEnabled: Boolean,
+        encryptedBond: Boolean,
+        sharingLog: Boolean,
     ): String {
         val tail = if (sharingLog) " Sharing the strap log." else ""
         return when {
             !whoop5Connected ->
                 "Raw capture records WHOOP 5/MG history syncs and doesn't apply to WHOOP 4.0 (already fully decoded).$tail"
-            !PuffinExperiment.from(context).isCaptureEnabled ->
+            !captureEnabled ->
                 "No raw capture yet. Turn on \"Record 5/MG raw capture\" above, then let a history sync run.$tail"
             // #1635: do NOT tell someone to wait for a history sync their strap cannot reach. Without the
             // encrypted bond there is no puffin channel and no offload, so "let a sync run" names a remedy

--- a/android/app/src/main/java/com/noop/ui/LogExport.kt
+++ b/android/app/src/main/java/com/noop/ui/LogExport.kt
@@ -369,13 +369,24 @@ object LogExport {
      * a 4.0 can never produce one (5/MG-only feature); a 5/MG needs the toggle on + a history sync;
      * if the toggle is already on, don't tell them to enable it again. `sharingLog` adds the log tail.
      */
-    private fun noCaptureMsg(context: Context, whoop5Connected: Boolean, sharingLog: Boolean): String {
+    private fun noCaptureMsg(
+        context: Context,
+        whoop5Connected: Boolean,
+        encryptedBond: Boolean,
+        sharingLog: Boolean,
+    ): String {
         val tail = if (sharingLog) " Sharing the strap log." else ""
         return when {
             !whoop5Connected ->
                 "Raw capture records WHOOP 5/MG history syncs and doesn't apply to WHOOP 4.0 (already fully decoded).$tail"
             !PuffinExperiment.from(context).isCaptureEnabled ->
                 "No raw capture yet. Turn on \"Record 5/MG raw capture\" above, then let a history sync run.$tail"
+            // #1635: do NOT tell someone to wait for a history sync their strap cannot reach. Without the
+            // encrypted bond there is no puffin channel and no offload, so "let a sync run" names a remedy
+            // that will never arrive — the same confidently-wrong guidance this issue kept producing.
+            !encryptedBond ->
+                "Raw capture is on, but this strap is on live HR only — history sync needs the full " +
+                    "encrypted pairing, so there are no sync frames to capture yet.$tail"
             else ->
                 "Raw capture is on. Let a 5/MG history sync run, then try again.$tail"
         }
@@ -387,13 +398,13 @@ object LogExport {
      * covers cache/logs) and prepends a header with an informed-consent line: the file holds raw
      * biometric frames and the strap's own console text.
      */
-    suspend fun shareWhoop5Capture(context: Context, whoop5Connected: Boolean) {
+    suspend fun shareWhoop5Capture(context: Context, whoop5Connected: Boolean, encryptedBond: Boolean) {
         runCatching {
             // writeCaptureFile does blocking file IO (#646/#651) — keep it off whatever dispatcher the
             // caller is on (Main, for every UI call site today).
             val out = withContext(Dispatchers.IO) { writeCaptureFile(context) }
             if (out == null) {
-                Toast.makeText(context, noCaptureMsg(context, whoop5Connected, sharingLog = false), Toast.LENGTH_LONG).show()
+                Toast.makeText(context, noCaptureMsg(context, whoop5Connected, encryptedBond, sharingLog = false), Toast.LENGTH_LONG).show()
                 return
             }
             val send = Intent(Intent.ACTION_SEND).apply {
@@ -420,7 +431,7 @@ object LogExport {
      * buttons), so a large raw capture doesn't stall the UI. Only the "no capture" toast and the
      * [exportBundle] call (which does its own IO hop for the zip) run back on the caller's dispatcher.
      */
-    suspend fun shareRawAndLog(context: Context, logText: String, whoop5Connected: Boolean) {
+    suspend fun shareRawAndLog(context: Context, logText: String, whoop5Connected: Boolean, encryptedBond: Boolean) {
         runCatching {
             val (entries, hasCapture) = withContext(Dispatchers.IO) {
                 val logFile = writeStrapLogFile(context, logText)
@@ -430,7 +441,7 @@ object LogExport {
                 entries to (capture != null)
             }
             if (!hasCapture) {
-                Toast.makeText(context, noCaptureMsg(context, whoop5Connected, sharingLog = true), Toast.LENGTH_LONG).show()
+                Toast.makeText(context, noCaptureMsg(context, whoop5Connected, encryptedBond, sharingLog = true), Toast.LENGTH_LONG).show()
             }
             val name = "noop-export-${timestamp()}.zip"
             exportBundle(context, entries, name)

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -2592,7 +2592,7 @@ fun SettingsScreen(
                         scope.launch {
                             // try/finally: the flag must clear on any exit, not just the happy path (#961 follow-up).
                             try {
-                                LogExport.shareWhoop5Capture(context, live.whoop5Detected)
+                                LogExport.shareWhoop5Capture(context, live.whoop5Detected, live.encryptedBond)
                             } finally {
                                 whoop5CaptureBusy = false
                             }
@@ -2617,7 +2617,7 @@ fun SettingsScreen(
                         scope.launch {
                             // try/finally: the flag must clear on any exit, not just the happy path (#961 follow-up).
                             try {
-                                LogExport.shareRawAndLog(context, vm.ble.exportLogText(), live.whoop5Detected)
+                                LogExport.shareRawAndLog(context, vm.ble.exportLogText(), live.whoop5Detected, live.encryptedBond)
                             } finally {
                                 rawAndLogBusy = false
                             }

--- a/android/app/src/test/java/com/noop/ui/NoCaptureMsgTest.kt
+++ b/android/app/src/test/java/com/noop/ui/NoCaptureMsgTest.kt
@@ -1,0 +1,50 @@
+package com.noop.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The no-capture toast must not name a remedy the strap cannot reach (#1635).
+ *
+ * A live-HR-only 5/MG has no puffin channel and so no history sync, and the old copy told those users to
+ * "let a 5/MG history sync run" — waiting for something that never arrives. Same failure mode as every
+ * other confidently-wrong line this issue produced, just in a Toast.
+ */
+class NoCaptureMsgTest {
+    @Test
+    fun `a live-HR-only strap is told the sync is unreachable, not pending`() {
+        val msg = LogExport.noCaptureMsgText(
+            whoop5Connected = true, captureEnabled = true, encryptedBond = false, sharingLog = false,
+        )
+        assertTrue(msg.contains("live HR only"))
+        assertTrue(msg.contains("encrypted pairing"))
+        assertFalse(msg.contains("Let a 5/MG history sync run"))
+    }
+
+    @Test
+    fun `a properly bonded strap is still told to let a sync run`() {
+        val msg = LogExport.noCaptureMsgText(
+            whoop5Connected = true, captureEnabled = true, encryptedBond = true, sharingLog = false,
+        )
+        assertTrue(msg.contains("Let a 5/MG history sync run"))
+    }
+
+    @Test
+    fun `turning the toggle on comes first, even when unbonded`() {
+        // Ordering matters: with capture off, "turn it on" is the actionable step regardless of bond.
+        val msg = LogExport.noCaptureMsgText(
+            whoop5Connected = true, captureEnabled = false, encryptedBond = false, sharingLog = false,
+        )
+        assertTrue(msg.contains("Turn on"))
+    }
+
+    @Test
+    fun `a WHOOP 4 is never told about pairing at all`() {
+        val msg = LogExport.noCaptureMsgText(
+            whoop5Connected = false, captureEnabled = true, encryptedBond = false, sharingLog = true,
+        )
+        assertTrue(msg.contains("doesn't apply to WHOOP 4.0"))
+        assertTrue(msg.contains("Sharing the strap log."))
+    }
+}


### PR DESCRIPTION
Two fixes to the opt-in raw capture — and one correction to what the first actually achieves.

### The capture only ran during a sync

The write sat inside the `backfilling` gate while its own comment claimed it recorded **"EVERY frame of the session"**. The gate made that false: live and event frames arriving between syncs were never recorded. The write is hoisted out, and the file opens at session start rather than on entering backfill.

Opening **appends**, never truncates — truncate-per-session was a bug in the fork this came from, and doing it per connect therefore cannot lose earlier material. The line counter does reset per open, so the 40k-line cap is now per-session rather than per-file; the byte cap still bounds the file.

### It does NOT rescue a strap that never bonds — I claimed it did

Caught in re-review, and now stated in the code where the next reader will look. The frames reaching this path are the puffin notify characteristics, and those are subscribed **only in the CLIENT_HELLO-ack branch** — so an unbonded 5/MG still produces an empty capture file. Making that case yield anything means capturing the standard-profile notifications instead: a different feature, over data that is already decoded.

So the real scope of this change is the **bonded** strap, where frames outside a sync window were being dropped.

### The message named a remedy that cannot arrive

> "Raw capture is on. Let a 5/MG history sync run, then try again."

Without the encrypted bond there is no puffin channel and no offload, so that told the user to wait for something their strap cannot reach — the same confidently-wrong guidance this issue keeps producing. `noCaptureMsg` now takes `encryptedBond` (it only knew `whoop5Detected`) and says the sync is unreachable rather than pending.

**4468** Android tests green; doc lint and i18n audit clean. Android only — the capture is Android-side.

---

### Re-review

**Checked and sound** (recorded so it isn't re-derived): opening per connect cannot spam the file with empty sessions. `reset()` closes with `flushSummary = false`, and only `exitBackfilling` writes the summary — so an unbonded strap in a reconnect loop opens and closes an empty file silently, with no summary lines and no growth.

**One defect fixed.** The capture line was inserted directly above an existing comment block, leaving three comments stacked over one statement: the explicit-bond comment ended up describing the capture call, and the capture comment sat where a reader expects the bond logic.

This is precisely the trap CLAUDE.md documents — inserting a declaration between a neighbour's comment and the thing it documents — **in the form the linter cannot see**. `doc_comment_lint` tracks KDoc blocks only, so a `//` comment severed from its code passes every gate and is caught by nothing but reading it.

Fixing it exposed that the suppression comment had already been orphaned the same way when the explicit-bond block landed, describing code several statements below itself. Both are now back with their code. No behaviour change.

### Re-review 2 + parity

**Gate consistency confirms the fix.** `writeWhoop5EventLogIfEvent` and `writeWhoop5DeepBufferIfBig` were **already** outside the `backfilling` gate — only the main capture sat inside it. All three sinks now agree, which reads as the oversight it was rather than a deliberate scope.

**Parity: no twin exists, so this cannot diverge.** No `isCaptureEnabled` in `PuffinExperiment.swift`, no `BackfillCaptureRecord` under `Strand/` or `Packages/`, `LogExport` only under `android/`. Asymmetric experiment keys are already the norm on both sides — Swift carries `spo2CandidateDisplay`, `banisterEffort`, `continuousHrv`; Kotlin carries `capture`, `ppgHrSubLagInterp`, `motionAwareWake` — and a research JSONL plus a Toast sit outside the byte-identical contract regardless.

**One gap closed.** The new wording was the only user-facing string here without a test, while the equivalent hint text in the suppression work got one. It read prefs directly, so testing it would have needed a mocked `Context` — and the test classpath deliberately has no mocking framework, the house style being to make the helper pure instead. Split into `noCaptureMsgText()`; four cases pinned, including the ordering one (capture off + unbonded must still say "turn the toggle on", since that is the actionable step either way).

**4472** tests green.

### Re-review 3 & 4: two bounds, found in sequence

**Live frames could spend the offload's line budget.** Hoisting the capture out of the `backfilling` gate means it records the live flood too — and on a link that stays up overnight that reaches the 40k line cap in ~11 hours, closing the capture at potentially the exact moment the morning offload arrives. That would trade the overnight offload material this feature exists to collect for live frames that were never recorded before, and the file's own header says append-across-sessions was adopted *because* the fork it came from truncated per session and lost overnight data. Entering backfill now hands the line budget back.

**That fix removed the only in-session bound.** The byte cap was checked solely at open, so the line cap was the sole live limit — and a connection that auto-continues several offloads now resets it several times. The file could grow well past 10 MB inside one long-lived session and never rotate. The byte cap is now checked on the existing flush boundary: one `stat` per 100 frames, closing with the same "paused until next session" shape, and the file still rotates on reopen so nothing is discarded.

**4472** tests green.