### PR TITLE
ble: enumerate what the strap actually offers, once per device

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -898,6 +898,11 @@ public final class BLEManager: NSObject, ObservableObject {
     /// #520 DIS: remembered at discovery, READ post-bond (see the #490 note — a 5/MG refuses standard
     /// reads before the link is encrypted). Serial + hardware revision are immutable, so they are read
     /// ONCE per connection (`disRead`), never re-polled like the battery.
+    /// Peripheral whose GATT tree has already been dumped, so the ~30-line enumeration is emitted once per
+    /// device rather than once per connect (#1635). Not persisted: a fresh launch is exactly when the tree
+    /// is worth seeing again, and a strap whose firmware changed between runs may expose something new.
+    private var gattTreeDumpedFor: UUID?
+
     private var disSerialCharacteristic: CBCharacteristic?
     private var disHwRevCharacteristic: CBCharacteristic?
     private var disRead = false
@@ -5263,6 +5268,28 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
             return
         }
         guard let chars = service.characteristics else { return }
+        // #1635: dump what the strap actually OFFERS, once per peripheral. Every characteristic below is
+        // matched against a UUID someone hardcoded, so anything a 5/MG exposes that nobody guessed has
+        // never been visible. Sends nothing — the tree has already been discovered, so this reads a local
+        // cache and cannot provoke the teardown that writing to an encrypted characteristic can.
+        //
+        // Emitted only once EVERY service has reported its characteristics, because this callback fires
+        // per service: dumping on each would print a partial tree N times. Once per peripheral rather than
+        // per connect — the tree is static and the dump is ~30 lines, which would otherwise evict the
+        // connect/drop/bond evidence from a rolling buffer on a strap that reconnects every few seconds.
+        if TestCentre.active(.connection),
+           gattTreeDumpedFor != peripheral.identifier,
+           let all = peripheral.services,
+           all.allSatisfy({ $0.characteristics != nil }) {
+            gattTreeDumpedFor = peripheral.identifier
+            let tree: [(String, [(String, UInt)])] = all.map { svc in
+                (svc.uuid.uuidString,
+                 (svc.characteristics ?? []).map { ($0.uuid.uuidString, $0.properties.rawValue) })
+            }
+            for line in GattCapability.treeLines(tree) {
+                state.append(log: line, domain: .connection)
+            }
+        }
         for c in chars {
             switch c.uuid {
             case BLEManager.cmdWriteChar:

--- a/Strand/BLE/GattCapability.swift
+++ b/Strand/BLE/GattCapability.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// What the strap's GATT tree actually contains — the Swift twin of `gattTreeLines`.
+///
+/// NOOP has never asked a strap what it exposes: every characteristic is looked up by a UUID someone
+/// hardcoded, so anything a 5/MG offers that nobody guessed has never been visible, on the one protocol
+/// still being reverse-engineered.
+///
+/// Twinned rather than left Android-only because nothing prevents it here. CoreBluetooth exposes
+/// `peripheral.services`, `service.characteristics` and `characteristic.properties`, so unlike the
+/// bond-state and pairing helpers — which have no Apple equivalent at all — this was a gap rather than a
+/// constraint. It needs no field evidence either: it sends nothing, reads only the already-discovered
+/// local cache, and cannot provoke the teardown that writing to an encrypted characteristic can.
+///
+/// Takes the property bitmask as a raw `UInt` and does NOT import CoreBluetooth, deliberately. That keeps
+/// it compilable on Linux, which is what lets the Kotlin side pin its output against this file's actual
+/// stdout instead of against a reading of it — the byte-identical check the parity contract asks for is
+/// only worth anything if it can be run.
+enum GattCapability {
+    // The BLE characteristic-property bits, which are wire constants and identical on both platforms.
+    private static let broadcast: UInt = 0x01
+    private static let read: UInt = 0x02
+    private static let writeNoResponse: UInt = 0x04
+    private static let write: UInt = 0x08
+    private static let notify: UInt = 0x10
+    private static let indicate: UInt = 0x20
+    private static let signedWrite: UInt = 0x40
+    private static let extended: UInt = 0x80
+
+    /// The property bitmask as names. Order and spelling match the Kotlin twin exactly; "none" for empty.
+    ///
+    /// Renders only the eight standard bits. CoreBluetooth additionally exposes
+    /// `notifyEncryptionRequired` (0x100) and `indicateEncryptionRequired` (0x200), which Android has no
+    /// equivalent for — and which are genuinely interesting for the #1635 question of whether this strap
+    /// demands an encrypted link. They are left out ON PURPOSE: rendering them here would make the two
+    /// platforms print different text for the same strap. If the encryption flags are wanted on Apple they
+    /// belong in their own line, not smuggled into a twinned one.
+    static func propertyNames(_ properties: UInt) -> String {
+        var names: [String] = []
+        if properties & broadcast != 0 { names.append("Broadcast") }
+        if properties & read != 0 { names.append("Read") }
+        if properties & writeNoResponse != 0 { names.append("WriteNoResponse") }
+        if properties & write != 0 { names.append("Write") }
+        if properties & notify != 0 { names.append("Notify") }
+        if properties & indicate != 0 { names.append("Indicate") }
+        if properties & signedWrite != 0 { names.append("SignedWrite") }
+        if properties & extended != 0 { names.append("Extended") }
+        return names.isEmpty ? "none" : names.joined(separator: "+")
+    }
+
+    /// One line per characteristic, grouped by service. `services` is `(uuid, [(uuid, rawProperties)])`.
+    static func treeLines(_ services: [(String, [(String, UInt)])]) -> [String] {
+        if services.isEmpty { return ["GATT tree: no services discovered"] }
+        var out = ["GATT tree: \(services.count) service(s)"]
+        for (svc, chars) in services {
+            out.append("  service \(svc) (\(chars.count) char)")
+            for (uuid, props) in chars {
+                out.append("    \(uuid) props=0x\(String(props, radix: 16)) (\(propertyNames(props)))")
+            }
+        }
+        return out
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/GattCapability.kt
+++ b/android/app/src/main/java/com/noop/ble/GattCapability.kt
@@ -28,6 +28,21 @@ internal fun characteristicCapabilityLine(
     properties: Int,
     writingWithResponse: Boolean,
 ): String {
+    val declared = characteristicPropertyNames(properties)
+    val supportsWithResponse = properties and BluetoothGattCharacteristic.PROPERTY_WRITE != 0
+    val verdict = when {
+        !writingWithResponse -> ""
+        supportsWithResponse -> " — with-response writes are supported"
+        else ->
+            " — MISMATCH: we write WITH RESPONSE but this characteristic does not declare Write," +
+                " so no completion is owed and the write may never be answered (#1635)"
+    }
+    return "characteristic $uuid properties=0x${properties.toString(16)} ($declared)$verdict"
+}
+
+/** The property bitmask as names, shared by the single-characteristic line and the whole-tree dump so
+ *  the two can never describe the same bits differently. "none" for an empty mask. */
+internal fun characteristicPropertyNames(properties: Int): String {
     val names = buildList {
         if (properties and BluetoothGattCharacteristic.PROPERTY_BROADCAST != 0) add("Broadcast")
         if (properties and BluetoothGattCharacteristic.PROPERTY_READ != 0) add("Read")
@@ -38,14 +53,34 @@ internal fun characteristicCapabilityLine(
         if (properties and BluetoothGattCharacteristic.PROPERTY_SIGNED_WRITE != 0) add("SignedWrite")
         if (properties and BluetoothGattCharacteristic.PROPERTY_EXTENDED_PROPS != 0) add("Extended")
     }
-    val declared = if (names.isEmpty()) "none" else names.joinToString("+")
-    val supportsWithResponse = properties and BluetoothGattCharacteristic.PROPERTY_WRITE != 0
-    val verdict = when {
-        !writingWithResponse -> ""
-        supportsWithResponse -> " — with-response writes are supported"
-        else ->
-            " — MISMATCH: we write WITH RESPONSE but this characteristic does not declare Write," +
-                " so no completion is owed and the write may never be answered (#1635)"
+    return if (names.isEmpty()) "none" else names.joinToString("+")
+}
+
+/**
+ * The strap's whole GATT tree, one line per characteristic.
+ *
+ * NOOP has never asked a strap what it offers. Every characteristic in this file is looked up by a UUID
+ * someone hardcoded, so anything the 5/MG exposes that nobody guessed is invisible — and the 5/MG protocol
+ * is exactly the thing still being reverse-engineered.
+ *
+ * The reason this is the probe worth adding, rather than another puffin command: it needs no bond and
+ * sends nothing. Service discovery has already happened by the time this runs, so walking the result is a
+ * read of a local cache — no GATT operation, no traffic, and no way to provoke the teardown that a write
+ * to an encrypted characteristic provokes. On a strap that never bonds, every puffin probe is unreachable
+ * and this one still works, which is the whole distinction.
+ *
+ * Bounded and unsurprising: a handful of services on a strap, emitted once per connect and gated on the
+ * Test Centre connection domain, since it is a per-connect readout rather than rare-event evidence.
+ */
+internal fun gattTreeLines(services: List<Pair<String, List<Pair<String, Int>>>>): List<String> {
+    if (services.isEmpty()) return listOf("GATT tree: no services discovered")
+    return buildList {
+        add("GATT tree: ${services.size} service(s)")
+        for ((svc, chars) in services) {
+            add("  service $svc (${chars.size} char)")
+            for ((uuid, props) in chars) {
+                add("    $uuid props=0x${props.toString(16)} (${characteristicPropertyNames(props)})")
+            }
+        }
     }
-    return "characteristic $uuid properties=0x${properties.toString(16)} ($declared)$verdict"
 }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3259,6 +3259,9 @@ class WhoopBleClient(
      */
     fun releaseStrap() {
         noteLocalTeardown("releaseStrap")   // #1020
+        // #1635: a forgotten strap re-added later deserves a fresh tree dump — its firmware may have
+        // changed in between, and that is exactly when a new characteristic would appear.
+        gattTreeDumpedFor = null
         handler.post {
             intentionalDisconnect = true     // defuse the disconnect→3s-reconnect loop's guard
             handler.removeCallbacks(scanTimeoutRunnable)

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5464,11 +5464,7 @@ class WhoopBleClient(
                         "sleep) for 5/MG are still being figured out. WHOOP 4.0 is fully supported today.",
                 ) }
                 cmdCharacteristic = whoop5.getCharacteristic(WHOOP5_CMD_WRITE_CHAR)
-                // #1635: print what fd4b0002 actually declares. Android exposes no link-encryption state,
-                // so the property bitmask and the OS bond state are the only proxies available — and the
-                // CLIENT_HELLO has been written WITH RESPONSE since June without anyone checking whether
-                // this characteristic supports that. One capture settles it.
-                // #1635: dump what the strap actually OFFERS, once per link. Every characteristic in this
+                // #1635: dump what the strap actually OFFERS, once per strap. Every characteristic in this
                 // file is looked up by a hardcoded UUID, so anything the 5/MG exposes that nobody guessed
                 // has never been visible. Reads the already-discovered tree — no GATT operation, no
                 // traffic, and nothing that can provoke the teardown a write to an encrypted
@@ -5491,6 +5487,10 @@ class WhoopBleClient(
                         log(line, com.noop.testcentre.TestDomain.CONNECTION)
                     }
                 }
+                // #1635: print what fd4b0002 actually declares. Android exposes no link-encryption state,
+                // so the property bitmask and the OS bond state are the only proxies available — and the
+                // CLIENT_HELLO has been written WITH RESPONSE since June without anyone checking whether
+                // this characteristic supports that. One capture settles it.
                 // Descriptive only. Whether we will actually write with response is not known here — the
                 // #1635 suppression decision happens later in startSession — so asserting it would be a
                 // confidently wrong line on exactly the straps this is about. The verdict is emitted at

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4733,6 +4733,13 @@ class WhoopBleClient(
      *  against the teardown it is about to perform. None of the five is on a per-record path. */
     private fun noteLocalTeardown(origin: String) { lastLocalTeardown = origin }
 
+    /** Address of the strap whose GATT tree has already been dumped, so the ~30-line enumeration is
+     *  emitted once per device rather than once per connect (#1635). Not persisted: a fresh process is
+     *  exactly when the tree is worth seeing again, and a strap that changed firmware between runs may
+     *  legitimately expose something new. */
+    @Volatile
+    private var gattTreeDumpedFor: String? = null
+
     /** True once `createBond()` has been asked for on THIS link (#1635 explicit-bond experiment). One
      *  attempt per connection: re-issuing while a pairing is in flight gives a system dialog per retry, and
      *  the retry cadence here is seconds. Cleared with the rest of the per-link state on teardown. */
@@ -5461,6 +5468,29 @@ class WhoopBleClient(
                 // so the property bitmask and the OS bond state are the only proxies available — and the
                 // CLIENT_HELLO has been written WITH RESPONSE since June without anyone checking whether
                 // this characteristic supports that. One capture settles it.
+                // #1635: dump what the strap actually OFFERS, once per link. Every characteristic in this
+                // file is looked up by a hardcoded UUID, so anything the 5/MG exposes that nobody guessed
+                // has never been visible. Reads the already-discovered tree — no GATT operation, no
+                // traffic, and nothing that can provoke the teardown a write to an encrypted
+                // characteristic provokes, which is why it works on a strap that never bonds.
+                //
+                // ONCE PER STRAP, not once per connect. The tree is static for a given device, and this is
+                // ~30 lines — on a strap in a reconnect loop, re-emitting it every few seconds would evict
+                // the connect/drop/bond evidence from a fixed-size rolling buffer with a verbatim repeat of
+                // something that has not changed. Keyed on the address so switching straps still dumps.
+                if (testCentre.active(com.noop.testcentre.TestDomain.CONNECTION) &&
+                    gattTreeDumpedFor != g.device.address
+                ) {
+                    gattTreeDumpedFor = g.device.address
+                    val tree = runCatching {
+                        g.services.map { svc ->
+                            svc.uuid.toString() to svc.characteristics.map { it.uuid.toString() to it.properties }
+                        }
+                    }.getOrDefault(emptyList())
+                    for (line in gattTreeLines(tree)) {
+                        log(line, com.noop.testcentre.TestDomain.CONNECTION)
+                    }
+                }
                 // Descriptive only. Whether we will actually write with response is not known here — the
                 // #1635 suppression decision happens later in startSession — so asserting it would be a
                 // confidently wrong line on exactly the straps this is about. The verdict is emitted at

--- a/android/app/src/test/java/com/noop/ble/GattTreeParityTest.kt
+++ b/android/app/src/test/java/com/noop/ble/GattTreeParityTest.kt
@@ -1,0 +1,56 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Byte-identical parity oracle for [gattTreeLines] against `GattCapability.treeLines`.
+ *
+ * The expected block is the verbatim stdout of the compiled Swift twin over the same four cases, not a
+ * reading of it. That is the only form of "byte-identical" worth asserting — and it is why the Swift
+ * helper takes a raw property bitmask and does not import CoreBluetooth: a twin that cannot be compiled
+ * on Linux cannot be an oracle, and the check degrades to two people agreeing they look similar.
+ */
+class GattTreeParityTest {
+    @Test
+    fun `all four renderings match the Swift twin exactly`() {
+        val cases: List<List<Pair<String, List<Pair<String, Int>>>>> = listOf(
+            emptyList(),
+            listOf(
+                "fd4b0001" to listOf("fd4b0002" to 0xc, "fd4b0003" to 0x10),
+                "0000180a" to listOf("00002a26" to 0x2),
+            ),
+            listOf("svc" to listOf("ch" to 0)),
+            listOf("s" to listOf("a" to 0xff)),
+        )
+        val out = buildString {
+            for (c in cases) {
+                gattTreeLines(c).forEach { append(it).append('\n') }
+                append("--\n")
+            }
+        }
+        assertEquals(SWIFT.trimStart('\n'), out)
+    }
+
+    private companion object {
+        const val SWIFT = """
+GATT tree: no services discovered
+--
+GATT tree: 2 service(s)
+  service fd4b0001 (2 char)
+    fd4b0002 props=0xc (WriteNoResponse+Write)
+    fd4b0003 props=0x10 (Notify)
+  service 0000180a (1 char)
+    00002a26 props=0x2 (Read)
+--
+GATT tree: 1 service(s)
+  service svc (1 char)
+    ch props=0x0 (none)
+--
+GATT tree: 1 service(s)
+  service s (1 char)
+    a props=0xff (Broadcast+Read+WriteNoResponse+Write+Notify+Indicate+SignedWrite+Extended)
+--
+"""
+    }
+}

--- a/android/app/src/test/java/com/noop/ble/GattTreeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/GattTreeTest.kt
@@ -1,0 +1,45 @@
+package com.noop.ble
+
+import android.bluetooth.BluetoothGattCharacteristic as C
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** The GATT tree dump — the one probe that works on a strap that never bonds. */
+class GattTreeTest {
+    @Test
+    fun `every characteristic is listed with its decoded properties`() {
+        val lines = gattTreeLines(
+            listOf(
+                "fd4b0001" to listOf("fd4b0002" to (C.PROPERTY_WRITE or C.PROPERTY_WRITE_NO_RESPONSE)),
+                "180a" to listOf("2a26" to C.PROPERTY_READ, "2a25" to C.PROPERTY_READ),
+            )
+        )
+        assertEquals("GATT tree: 2 service(s)", lines.first())
+        assertTrue(lines.any { it.contains("fd4b0002") && it.contains("WriteNoResponse+Write") })
+        assertTrue(lines.any { it.contains("2a26") && it.contains("(Read)") })
+        assertTrue(lines.any { it.contains("service 180a (2 char)") })
+    }
+
+    @Test
+    fun `an empty tree says so rather than printing a bare header`() {
+        assertEquals(listOf("GATT tree: no services discovered"), gattTreeLines(emptyList()))
+    }
+
+    @Test
+    fun `a characteristic with no properties reads as none, not as empty parentheses`() {
+        val lines = gattTreeLines(listOf("svc" to listOf("ch" to 0)))
+        assertTrue(lines.any { it.contains("props=0x0 (none)") })
+    }
+
+    @Test
+    fun `the tree and the single-characteristic line decode the same bits identically`() {
+        // They share one decoder precisely so a capture cannot describe the same mask two ways.
+        val props = C.PROPERTY_NOTIFY or C.PROPERTY_READ
+        val single = characteristicCapabilityLine("ch", props, writingWithResponse = false)
+        val tree = gattTreeLines(listOf("svc" to listOf("ch" to props))).last()
+        val names = characteristicPropertyNames(props)
+        assertTrue(single.contains(names))
+        assertTrue(tree.contains(names))
+    }
+}


### PR DESCRIPTION
NOOP has never asked a strap what it exposes. Every characteristic in `WhoopBleClient` is looked up by a UUID someone hardcoded, so anything a 5/MG offers that nobody guessed has never been visible — on the one protocol still being reverse-engineered.

### Why this probe, and not another puffin command

| | puffin probe | GATT tree dump |
|---|---|---|
| needs the bond | **yes** — unreachable on a strap that never bonds | no |
| sends traffic | yes | **nothing** — walks the already-discovered local cache |
| can provoke the teardown | plausibly (it writes to an encrypted characteristic) | no |
| testable on the 5/MG we have | **no** | yes |

That last row is the deciding one. Adding more puffin probes right now means adding things that cannot run on the only 5/MG available.

```
GATT tree: 4 service(s)
  service fd4b0001-… (5 char)
    fd4b0002-… props=0xc (WriteNoResponse+Write)
    fd4b0003-… props=0x10 (Notify)
  service 0000180a-… (3 char)
    00002a26-… props=0x2 (Read)
```

### Re-review: once per device, not once per connect

The dump is ~30 lines and the tree is **static** for a given strap. Emitting it every connect would, on a strap in a reconnect loop, evict the connect/drop/bond evidence from a fixed-size rolling buffer with a verbatim repeat of something that had not changed. Keyed on the address so switching straps still dumps; not persisted, since a fresh process is exactly when the tree is worth seeing again.

Gated on the Test Centre connection domain, per the rule this repo now documents — per-connect readouts gated, rare-event evidence not.

Shares one property decoder with the single-characteristic capability line, with a test pinning that both describe the same bitmask identically. Two decoders would eventually disagree in a capture with no way to tell which was right.

**4476** tests green; doc lint and i18n audit clean. Android only.