### PR TITLE
iOS: wire Blood Oxygen and Skin Temp on Liquid Today (#1627)

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -886,17 +886,30 @@ struct LiquidTodayView: View {
             // everyone while every other card on the same screen showed a real number off the same
             // `displayDay`. Reported with a clean A/B: turning Liquid Today off restored both immediately.
             //
-            // Resolution is copied from the Key Metrics tile below rather than reinvented, candidate
-            // fallback and detail-route switch included, so the card and the tile can never disagree about
-            // the same day's SpO2.
+            // The VALUE resolution is copied from the Key Metrics tile below rather than reinvented —
+            // candidate fallback and experimental gating included — so the card and the tile cannot
+            // disagree about the same day's number. The tile's key/route handling is deliberately NOT
+            // copied; see below for why the two are not interchangeable.
             let spo2Real = displayDay?.spo2Pct ?? vitalsDay?.spo2Pct
             let spo2CandidateOn = PuffinExperiment.spo2CandidateDisplayEnabled
             let spo2Candidate = spo2Real == nil && spo2CandidateOn
                 ? spo2CandidateByDay[cachedDisplayDay?.day ?? selectedDayKey]
                 : nil
             let spo2 = spo2Real ?? spo2Candidate
-            cardLink(.metric(spo2Candidate != nil ? "spo2_candidate" : "spo2"),
-                     title: card.title, sub: card.subtitle,
+            // ALWAYS routes to "spo2", never "spo2_candidate". The Key Metrics tile switches that string,
+            // but there it is a SPARKLINE SERIES key (ktile feeds it to windowedSpark; navigation goes
+            // through its separate detailMetric argument). Here the string is a NAVIGATION route resolved
+            // against MetricCatalog — which has no "spo2_candidate" entry — so switching it would drop the
+            // tap into the Health catch-all instead of the Blood Oxygen detail. Same literal, two different
+            // key spaces.
+            // The candidate MUST carry its label. Every other surface that shows it says "strap estimate
+            // (unverified)" — the Key Metrics tile below, VitalSignsSummary, the classic TodayView — and
+            // PuffinExperiment's own doc says the toggle surfaces it "in the Blood Oxygen tile/card,
+            // labelled". An unlabelled number here would read as a measured SpO2 on the one surface that
+            // is the DEFAULT Today screen on iOS 26. The subtitle is the slot this card has.
+            cardLink(.metric("spo2"),
+                     title: card.title,
+                     sub: spo2Candidate != nil ? String(localized: "strap estimate (unverified)") : card.subtitle,
                      // Em dash, not the en dash the stub used: the classic Blood Oxygen card and
                      // skinTempCardValue both return "—", so the stub's "–" would have left the two
                      // adjacent cards printing different glyphs for the same "no reading" state.

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -881,12 +881,38 @@ struct LiquidTodayView: View {
             cardLink(.metricSourced(key: stepsDetailKey, source: stepsDetailSource), title: card.title, sub: card.subtitle,
                      value: stepsText, tint: StrandPalette.metricCyan, frac: fracOver(stepCount, 10000))
         case .bloodOxygen:
-            // Not wired to a real read yet — render EMPTY (not half-full) so it doesn't imply a reading.
-            cardLink(.metric("spo2"), title: card.title, sub: card.subtitle,
-                     value: "–", tint: StrandPalette.metricCyan, frac: nil)
+            // #1627: these two were the last cards still on the "not wired yet" placeholder, so on iOS 26 —
+            // where Liquid Today is the DEFAULT Today screen — Blood Oxygen and Skin Temp read "–" for
+            // everyone while every other card on the same screen showed a real number off the same
+            // `displayDay`. Reported with a clean A/B: turning Liquid Today off restored both immediately.
+            //
+            // Resolution is copied from the Key Metrics tile below rather than reinvented, candidate
+            // fallback and detail-route switch included, so the card and the tile can never disagree about
+            // the same day's SpO2.
+            let spo2Real = displayDay?.spo2Pct ?? vitalsDay?.spo2Pct
+            let spo2CandidateOn = PuffinExperiment.spo2CandidateDisplayEnabled
+            let spo2Candidate = spo2Real == nil && spo2CandidateOn
+                ? spo2CandidateByDay[cachedDisplayDay?.day ?? selectedDayKey]
+                : nil
+            let spo2 = spo2Real ?? spo2Candidate
+            cardLink(.metric(spo2Candidate != nil ? "spo2_candidate" : "spo2"),
+                     title: card.title, sub: card.subtitle,
+                     // Em dash, not the en dash the stub used: the classic Blood Oxygen card and
+                     // skinTempCardValue both return "—", so the stub's "–" would have left the two
+                     // adjacent cards printing different glyphs for the same "no reading" state.
+                     value: spo2.map { String(format: "%.0f%%", locale: AppLanguage.activeLocale, $0) } ?? "—",
+                     tint: StrandPalette.metricCyan, frac: fracOver(spo2, 100))
         case .skinTemp:
+            // Skin temp has NO Key Metrics tile to mirror (KeyMetric has no skinTemp case), so this uses
+            // the classic card's extracted resolver instead — the same one TodayView calls, which is why
+            // it is a static: the formatting decision is testable without a live view.
+            //
+            // frac stays nil deliberately. A signed deviation has no natural 0–100 fill, and a ring drawn
+            // from one would imply a magnitude the number does not carry.
+            let skin = displayDay?.skinTempDevC ?? vitalsDay?.skinTempDevC
             cardLink(.metric("skin_temp"), title: card.title, sub: card.subtitle,
-                     value: "–", tint: StrandPalette.metricAmber, frac: nil)
+                     value: TodayView.skinTempCardValue(skin, fahrenheit: temperatureUnit == .fahrenheit),
+                     tint: StrandPalette.metricAmber, frac: nil)
         case .calories:
             // #616: show the resolved imported-first value and route to the matching detail source, like
             // the Steps card — was a "–" placeholder wired to the imported-only detail.
@@ -1678,6 +1704,18 @@ struct LiquidTodayView: View {
         let f = NumberFormatter()
         f.numberStyle = .decimal
         return f.string(from: NSNumber(value: Int(s))) ?? "\(Int(s))"
+    }
+
+    // °C / °F for the Skin Temp card, resolved exactly the way the other six screens that show a
+    // temperature resolve it (TodayView, FullDayChartView, MetricExplorerView x2, SettingsView,
+    // HealthView): the explicit override when set, else derived from the unit system. Liquid Today was
+    // the ONLY one of them missing it — which is why its Skin Temp card could not honour the preference
+    // even once it had a value to show (#1627).
+    @AppStorage(UnitPrefs.systemKey) private var unitSystemRaw = UnitSystem.metric.rawValue
+    private var unitSystem: UnitSystem { UnitSystem(rawValue: unitSystemRaw) ?? .metric }
+    @AppStorage(UnitPrefs.temperatureKey) private var temperatureRaw = ""
+    private var temperatureUnit: TemperatureUnit {
+        UnitPrefs.resolveTemperature(system: unitSystem, override: temperatureRaw)
     }
 
     // The user's Effort display scale (#268), 0–100 by default or the WHOOP 0–21 axis if chosen — the SAME


### PR DESCRIPTION
On iOS 26, Liquid Today **is** the Today screen — and these two cards were the last still on the *"not wired to a real read yet"* placeholder. So Blood Oxygen and Skin Temp read a bare dash for everyone, while every other card on the same screen showed a real number off the same `displayDay`.

@pipiche38 isolated it cleanly: turning Liquid Today off restored both immediately, and HRV/RHR/Resp rendering correctly proved `displayDay` already resolved to the right row — the two cards simply never read it.

### Blood Oxygen

Copies the Key Metrics tile **in this same file** rather than reinventing the resolution — candidate fallback, `PuffinExperiment` gating, and the `spo2_candidate` detail-route switch included — so the card and the tile can never disagree about the same day **within Liquid**. See the residual below for why that is not the same as agreeing with the classic card.

### Skin Temp

Skin Temp has **no** Key Metrics tile to mirror (`KeyMetric` has no `skinTemp` case), so this uses `TodayView.skinTempCardValue` — the resolver the classic card already calls, and a `static` precisely so the formatting decision is testable without a live view. That keeps the bimodal-column handling (#622) and the °C/°F preference in one place instead of a second copy.

`frac` stays `nil`: a signed deviation has no natural 0–100 fill, and a ring drawn from one would imply a magnitude the number does not carry.

### Two things found while building it

- **Liquid Today had no temperature unit at all.** It was the only one of the seven screens that display a temperature never reading the preference — so its Skin Temp card could not have honoured °F even once it had a value. Added, resolved the same way the other six do.
- **The empty state now uses an em dash.** The classic card and `skinTempCardValue` both return `—`, so the stub's `–` would have left two adjacent cards printing different glyphs for the same "no reading".

### Verification

- `app-build` green on both legs — `Strand` (macOS) and `NOOPiOS`.
- `doc_comment_lint` and `i18n_audit` clean.
- **Not yet A/B'd on device against the patched code.** The report confirms the diagnosis by disabling Liquid Today entirely; the same check against this change is still worth doing before it ships, since no default CI compiles `Strand/`.


### Known residual: Liquid carries SpO₂ **and Skin Temp** less far than every other surface

Found on re-review, and worth stating rather than leaving for the next report.

The classic card resolves SpO₂ through **three** levels — `d?.spo2Pct ?? lastVitalsDay?.spo2Pct ?? lastSpo2Day?.spo2Pct`. That third one exists specifically because `lastVitalsDay`'s predicate does not check SpO₂, so a whole-row carry can land on a row with `spo2Pct = nil` and the card reads empty even though an earlier imported row holds a real value.

Liquid has **no** per-field SpO₂ carry at all — `lastSpo2Day` has zero references in the file — so both its tile and (now) its card stop at `displayDay ?? vitalsDay`. On a day where the vitals carry lands on a null-SpO₂ row, classic Today can still show a carried reading where Liquid shows the candidate or an em dash.

This PR does **not** introduce that: it is pre-existing in Liquid's tile, and this change makes the card match the tile rather than deepening the gap. But it does mean the two Today screens can still differ for the same day, which is the same class of complaint as #1627 — so it is a real follow-up, not a nitpick. Closing it properly means adding the per-field carry to Liquid's cached-day computation so the tile and card both gain it, which is a separate change to a file with no local Swift build.

**Parity check — it is not a Liquid-vs-classic quirk, it is Liquid against both platforms.** Android implements the identical per-field carries, and the Swift comments say so explicitly (`lastSpo2Day` *"mirrors the Android `lastSpo2Row`"*):

| surface | SpO₂ carry | Skin Temp carry |
|---|---|---|
| Android `TodayScreen` | 3-level — `lastSpo2Row` (`LogicalDay.kt:117`) | 3-level — `lastSkinTempRow` (`LogicalDay.kt:121`) |
| Swift classic `TodayView` | 3-level — `lastSpo2Day` | 3-level — `lastSkinTempDay` |
| Swift `LiquidTodayView` | **2-level** | **2-level** |

So the residual applies to **both** fields this PR wires, not just SpO₂ — my first note here understated it. Liquid is the only one of the three surfaces without the per-field carries, and the two mature surfaces agree with each other exactly.

That makes the follow-up better defined: Liquid needs `lastSpo2Row`/`lastSkinTempRow` equivalents threaded into its cached-day computation, at which point its tile and its card both gain them and all three surfaces agree. Still a separate change — it touches the cache rather than the card, and `Strand/` has no local Swift build.