### PR TITLE
docs(#1617): the WHOOP 4.0 is missing a second channel, not a conversion

### DIFF
--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1755,12 +1755,27 @@ private val SERIES_BACKED_VITAL_KEYS = setOf("fitness_age", "vitality", "steps_e
  * 4.0 measures blood oxygen and still cannot fill that card. For Blood Oxygen the default can be a
  * countdown that never completes:
  *
- *  - **WHOOP 4.0.** The strap DOES bank blood-oxygen optical channels: `HIST_V24` declares
- *    `spo2RedOff = 68` / `spo2IrOff = 70`, and a reporter's capture showed 109 v24 records with real
- *    varying values (red 91-550, ir 597-600). What is missing is the conversion - NOOP never turns
- *    those channels into a percentage, and `spo2Pct` is only ever written by an import. The strap-
- *    computed `@82` percentage that does exist is gated to `hist_version == 18`, a 5/MG layout. So
- *    waiting cannot help and importing can, but NOT because the sensor is absent (#1617).
+ *  - **WHOOP 4.0.** What is missing is a second CHANNEL, not a conversion. `HIST_V24` declares
+ *    `spo2RedOff = 68` / `spo2IrOff = 70` and both fields carry plausible varying values, which is why
+ *    this originally read as "the maths is simply unimplemented". Three captures from two contributors
+ *    on two platforms say otherwise - two of them overnight (11.2 h and 7.9 h, worn and asleep) and one
+ *    spanning a full 22 h day and night: `ir` is `red` plus a constant. Across 1172 consecutive
+ *    sample transitions in one 22-hour capture, both moved by the IDENTICAL amount 1171 times - the only
+ *    exception being the single moment the offset itself stepped (110 -> 132) - and within each segment
+ *    `corr(red, ir)` is exactly +1.000. The offset also differs between captures (100 / 110 / 132), so it
+ *    is not a constant baked into our decode.
+ *
+ *    Ratio-of-ratios needs two INDEPENDENT wavelengths. When `ir = red + k` the ratio is a deterministic
+ *    function of `red` alone and carries no oxygenation information, so anything computed from it would
+ *    restate the red channel while looking like a percentage - the exact failure #194 was withdrawn for.
+ *    A scan of every u16 offset in the 104-byte record found no independent channel either: the best
+ *    candidate by variety correlates +0.975 / +0.874 with `ir`, and the genuinely uncorrelated fields
+ *    have 0-65331 ranges (counters or CRC material, not optical magnitudes).
+ *
+ *    So waiting cannot help and importing can - and the reason is the banked record, NOT an absent
+ *    sensor and NOT missing arithmetic. The strap-computed `@82` percentage that does exist is gated to
+ *    `hist_version == 18`, a 5/MG layout. This bounds the record type examined, not the hardware: a live
+ *    stream or another record type remains untested (#1617).
  *  - **5/MG with the estimate off.** The candidate exists but ships default-off and unverified, so the
  *    screen stays empty until the user turns it on. Naming the switch beats implying more nights.
  *  - **5/MG with it on.** Genuinely just needs nights, so the default copy is right.

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1762,14 +1762,21 @@ private val SERIES_BACKED_VITAL_KEYS = setOf("fitness_age", "vitality", "steps_e
  *    spanning a full 22 h day and night: `ir` is `red` plus a constant. Across 1172 consecutive
  *    sample transitions in one 22-hour capture, both moved by the IDENTICAL amount 1171 times - the only
  *    exception being the single moment the offset itself stepped (110 -> 132) - and within each segment
- *    `corr(red, ir)` is exactly +1.000. The offset also differs between captures (100 / 110 / 132), so it
- *    is not a constant baked into our decode.
+ *    `corr(red, ir)` is exactly +1.000. The offset also differs between captures (100 / 110 / 132), so
+ *    `k` is a property of the DATA rather than a constant our decode introduced.
+ *
+ *    What that does not settle - and does not need to - is WHY the two track. A second emitter locked to
+ *    the first, or a strap-derived value at offset 70 computed from the one at 68, fit the evidence
+ *    equally well, and nothing here can separate them. It does not matter: either way offset 70 carries
+ *    no information offset 68 lacks, which is the only question a percentage depends on. Resist the urge
+ *    to resolve it before concluding, since the conclusion does not turn on it.
  *
  *    Ratio-of-ratios needs two INDEPENDENT wavelengths. When `ir = red + k` the ratio is a deterministic
  *    function of `red` alone and carries no oxygenation information, so anything computed from it would
  *    restate the red channel while looking like a percentage - the exact failure #194 was withdrawn for.
  *    A scan of every u16 offset in the 104-byte record found no independent channel either: the best
- *    candidate by variety correlates +0.975 / +0.874 with `ir`, and the genuinely uncorrelated fields
+ *    candidate by variety correlates +0.975 and +0.874 with `ir` (one figure per offset segment), and
+ *    the genuinely uncorrelated fields
  *    have 0-65331 ranges (counters or CRC material, not optical magnitudes).
  *
  *    So waiting cannot help and importing can - and the reason is the banked record, NOT an absent


### PR DESCRIPTION
`spo2EmptyState`'s rationale said the strap *"DOES bank blood-oxygen optical channels"* and that *"what is missing is the conversion"*. That reads as an open invitation to implement ratio-of-ratios — and the overnight captures on #1617 say it would produce a number that cannot mean anything.

**The user-facing copy was already correct and is untouched.** *"This stays empty however long you wear it… Import a WHOOP export"* needed no change. Only the reason behind it was wrong, and it was wrong in the direction that costs someone a weekend.

### What the captures show

Three captures from two contributors on two platforms — two overnight (11.2 h and 7.9 h, worn and asleep), one spanning a full 22 hours:

| capture | records | distinct `ir − red` |
|---|---|---|
| Android overnight | 215 | **1** (`132`) |
| iOS overnight | 326 | **1** (`100`) |
| Android 22 h | 1173 | **2** (`110` → `132`) |

In the 22-hour capture, taking every consecutive pair and asking whether `red` and `ir` changed by the *same* amount: **identical in 1171 of 1172 transitions.** The lone exception is the single moment the offset itself stepped. Within each segment `corr(red, ir)` is exactly **+1.000**.

The offset also differs *between* captures (100 / 110 / 132), so `k` is not a constant baked into our decode, and one channel is not being read at two offsets in a fixed way.

### Why that forecloses the maths

Ratio-of-ratios needs two **independent** wavelengths. With `ir = red + k` the ratio is a deterministic function of `red` alone — anything derived from it restates the red channel while looking like a percentage. That is precisely the failure #194 was withdrawn for.

A scan of every `u16` offset in the 104-byte record found no independent channel either: the best candidate by variety correlates **+0.975 / +0.874** with `ir`, and the genuinely uncorrelated fields have 0–65331 ranges — counter or CRC material, not optical magnitudes.

### Deliberately bounded

This says nothing about whether the strap can *measure* blood oxygen — only about what the **v24 banked record** carries. A live stream or another record type remains untested, and the comment now says so rather than implying the question is closed.

### Scope note

I originally intended to also make Today's building-hint family-aware, on the grounds that Today promised "Building, wear it tonight" while Health said the reading can never arrive. **That contradiction does not exist**: `today_building_wear_tonight` appears only inside `buildingHint`, which has no production callers — nine test assertions and zero real ones. Dropped rather than built.

Worth a separate decision: `buildingHint` is dead code kept green by its own tests, which is what made it look live.

Doc only, no behaviour change. Full `com.noop.ui` suite green; doc lint and i18n audit clean.
