### PR TITLE
protocol: let a 5/MG say what it is, instead of guessing from its serial (#520)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5Variant.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop5Variant.swift
@@ -63,7 +63,25 @@ public enum Whoop5Variant: String, Sendable, CaseIterable {
     ///  2. Hardware revision carrying the known 5.0 token → `.fiveZero` (device-attested).
     ///  3. Serial prefix → `.mg` / `.fiveZero`.
     ///  4. Anything else → `.unknown`. Never infer from a digit elsewhere in the name (#772).
-    public static func from(serial: String?, hardwareRevision: String? = nil) -> Whoop5Variant {
+    /// DIS 0x2A24 Model Number String, as a real WHOOP MG reports it. Read unbonded off the standard
+    /// profile, so it is available on a strap that never pairs — exactly the case the prefix heuristics
+    /// were failing on.
+    static let modelNumberMG = "MG"
+
+    public static func from(
+        serial: String?,
+        hardwareRevision: String? = nil,
+        modelNumber: String? = nil
+    ) -> Whoop5Variant {
+        // The strap SAYING what it is beats inferring it from a prefix. A field capture showed serial
+        // prefix "MGB" with hardware revision "WS50_r03" — matching neither `mgSerialPrefix` nor
+        // `fiveZeroHardwareIdToken` — on a strap whose own model number said MG outright (#520).
+        //
+        // Only MG is claimed. No 5.0 has been observed reporting its model number, so inventing a token
+        // for one would be the guess this function already refuses to make elsewhere.
+        if (modelNumber ?? "").trimmingCharacters(in: .whitespacesAndNewlines).uppercased() == modelNumberMG {
+            return .mg
+        }
         let hw = (hardwareRevision ?? "").uppercased()
         var s = (serial ?? "").uppercased().trimmingCharacters(in: .whitespacesAndNewlines)
         if s.hasPrefix("WHOOP ") { s = String(s.dropFirst("WHOOP ".count)) }

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5VariantTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5VariantTests.swift
@@ -51,4 +51,31 @@ final class Whoop5VariantTests: XCTestCase {
         XCTAssertEqual(Whoop5Variant.fiveZero.label, "5.0")
         XCTAssertEqual(Whoop5Variant.unknown.label, "—")
     }
+
+    /// The field capture that exposed the gap: serial prefix "MGB", hardware revision "WS50_r03" — neither
+    /// matches `mgSerialPrefix` ("5AM") nor `fiveZeroHardwareIdToken` ("WG50"), so every heuristic returned
+    /// unknown for a strap whose own model number said MG.
+    func testRealMGResolvesFromItsModelNumberWhenPrefixesDoNot() {
+        XCTAssertEqual(Whoop5Variant.from(serial: "MGB0779473", hardwareRevision: "WS50_r03"), .unknown)
+        XCTAssertEqual(
+            Whoop5Variant.from(serial: "MGB0779473", hardwareRevision: "WS50_r03", modelNumber: "MG"), .mg)
+    }
+
+    func testModelNumberIsTrimmedAndCaseInsensitive() {
+        XCTAssertEqual(Whoop5Variant.from(serial: nil, modelNumber: "  mg  "), .mg)
+    }
+
+    /// Only MG is claimed. No 5.0 has been observed reporting a model number, so an unrecognised one must
+    /// fall through to the existing heuristics rather than inventing a verdict.
+    func testAnUnknownModelNumberDoesNotOverrideTheHeuristics() {
+        XCTAssertEqual(Whoop5Variant.from(serial: "5AG12345678", modelNumber: "WHOOP5"), .fiveZero)
+        XCTAssertEqual(Whoop5Variant.from(serial: nil, modelNumber: "WHOOP5"), .unknown)
+    }
+
+    /// The model number outranks the contradiction guard: two heuristics disagreeing is a reason not to
+    /// guess, but it is not a reason to ignore the strap stating its own model.
+    func testModelNumberBeatsTheContradictionGuard() {
+        XCTAssertEqual(
+            Whoop5Variant.from(serial: "5AM12345678", hardwareRevision: "WG50_r52", modelNumber: "MG"), .mg)
+    }
 }

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -4326,7 +4326,13 @@ public final class BLEManager: NSObject, ObservableObject {
         // The sole non-archived device is not a guess: there is nothing else the attestation could have
         // come from, and `peripheralId` is nil on the seeded row until the strap is adopted — the very
         // single-strap install this correction exists for.
-        guard let attesting = byId ?? (devices.count == 1 ? devices[0] : nil) else {
+        // The fallback requires the sole row to be UNADOPTED. "One device, so it must be the one attesting"
+        // holds only while that row has never been bound to an id; a row that HAS one and does not match is
+        // a different strap, and relabelling it is the corruption this guard exists to prevent. That is not
+        // hypothetical — adding a 5/MG to an install whose only row is a 4.0 reaches here before the new
+        // strap is registered.
+        let soleUnadopted = (devices.count == 1 && devices[0].peripheralId == nil) ? devices[0] : nil
+        guard let attesting = byId ?? soleUnadopted else {
             log("DIS attestation (variant=\(variant.label)) not applied — \(devices.count) paired devices"
                 + " and none carries this strap's id, so it cannot be attributed")
             return

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -4305,12 +4305,36 @@ public final class BLEManager: NSObject, ObservableObject {
     /// #716 stamp (which only fixed the "WHOOP" placeholder). ONE-DIRECTIONAL: attestation can only upgrade
     /// 4.0→5.0, never the reverse, and once corrected the guard below no longer matches, so it self-limits.
     private func reconcileModelFromAttestation(_ variant: Whoop5Variant) {
-        guard variant != .unknown, let rs = registryStore,
-              let active = try? rs.all().first(where: { $0.status == .active }),
-              DeviceFamily.forRegistryDevice(model: active.model, brand: active.brand) == .whoop4
+        guard variant != .unknown, let rs = registryStore else { return }
+        guard let attestingId = peripheral?.identifier.uuidString else {
+            // Should not happen — the attestation arrives on a connected link — but a silent return is one
+            // more path that goes quiet exactly when something is off.
+            log("DIS attestation (variant=\(variant.label)) not applied — the connected strap's id is unknown")
+            return
+        }
+        // Correct the row the attestation CAME FROM, never merely "whichever is active". Those are the
+        // same device on a single-strap install, and different ones the moment somebody pairs a 4.0
+        // alongside a 5/MG and leaves the 4.0 active — at which point relabelling by status rewrites the
+        // 4.0's row as "WHOOP 5.0 / MG" on the strength of the OTHER strap's DIS block.
+        //
+        // Unreachable today, because `Whoop5Variant.from` here is never given a model number and a real MG
+        // reports a serial prefix and hardware revision matching neither heuristic — so this returns on
+        // `.unknown` every time. Fixed anyway: the Android twin's identical bug went live the moment its
+        // resolver was widened, and twinning the DIS model-number read would do exactly that here (#520).
+        let devices = (try? rs.all())?.filter { $0.status != .archived } ?? []
+        let byId = devices.first { $0.peripheralId?.caseInsensitiveCompare(attestingId) == .orderedSame }
+        // The sole non-archived device is not a guess: there is nothing else the attestation could have
+        // come from, and `peripheralId` is nil on the seeded row until the strap is adopted — the very
+        // single-strap install this correction exists for.
+        guard let attesting = byId ?? (devices.count == 1 ? devices[0] : nil) else {
+            log("DIS attestation (variant=\(variant.label)) not applied — \(devices.count) paired devices"
+                + " and none carries this strap's id, so it cannot be attributed")
+            return
+        }
+        guard DeviceFamily.forRegistryDevice(model: attesting.model, brand: attesting.brand) == .whoop4
         else { return }
-        try? rs.setModel(active.id, model: "WHOOP 5.0 / MG")
-        log("Corrected device model \"\(active.model ?? "nil")\" → \"WHOOP 5.0 / MG\" from DIS attestation (variant=\(variant.label))")
+        try? rs.setModel(attesting.id, model: "WHOOP 5.0 / MG")
+        log("Corrected device model \"\(attesting.model ?? "nil")\" → \"WHOOP 5.0 / MG\" from DIS attestation (variant=\(variant.label))")
     }
 
     private func requestNotify(_ c: CBCharacteristic, on p: CBPeripheral, reason: String) {

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4442,11 +4442,29 @@ class WhoopBleClient(
      *  Twin of Swift `reconcileModelFromAttestation`. */
     private fun reconcileModelFromAttestation(variant: Whoop5Variant) {
         if (variant == Whoop5Variant.UNKNOWN) return
+        val attestingAddress = lastDeviceAddress ?: return
         ioScope.launch {
-            val active = repository.pairedDevices().firstOrNull { it.status == "active" } ?: return@launch
-            if (DeviceFamily.forRegistryDevice(active.model, active.brand) == DeviceFamily.WHOOP4) {
-                repository.setDeviceModel(active.id, "WHOOP 5.0 / MG")
-                log("Corrected device model \"${active.model}\" -> \"WHOOP 5.0 / MG\" from DIS attestation (variant=${variant.label})")
+            // Correct the row the attestation CAME FROM, never merely "whichever is active". Those are the
+            // same device on a single-strap install, and different ones the moment somebody pairs a 4.0
+            // alongside a 5/MG and leaves the 4.0 active - at which point relabelling by status would
+            // rewrite the 4.0's row to "WHOOP 5.0 / MG" on the strength of the OTHER strap's DIS block.
+            //
+            // This mattered from the first day it could run: the variant only became resolvable once the
+            // model number was read (#520), so before that this path returned early on UNKNOWN every time
+            // and the mis-targeting was never reachable. Widening the resolver is what makes it live.
+            val devices = repository.pairedDevices()
+            val attesting = devices.firstOrNull {
+                it.peripheralId?.equals(attestingAddress, ignoreCase = true) == true
+            }
+            if (attesting == null) {
+                // No row owns this address yet (a first connect before adoption). Correcting SOMETHING
+                // would be worse than correcting nothing, so say why and stop.
+                log("DIS attestation (variant=${variant.label}) not applied — no paired row carries this strap's address yet")
+                return@launch
+            }
+            if (DeviceFamily.forRegistryDevice(attesting.model, attesting.brand) == DeviceFamily.WHOOP4) {
+                repository.setDeviceModel(attesting.id, "WHOOP 5.0 / MG")
+                log("Corrected device model \"${attesting.model}\" -> \"WHOOP 5.0 / MG\" from DIS attestation (variant=${variant.label})")
             }
         }
     }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4442,7 +4442,13 @@ class WhoopBleClient(
      *  Twin of Swift `reconcileModelFromAttestation`. */
     private fun reconcileModelFromAttestation(variant: Whoop5Variant) {
         if (variant == Whoop5Variant.UNKNOWN) return
-        val attestingAddress = lastDeviceAddress ?: return
+        val attestingAddress = lastDeviceAddress
+        if (attestingAddress == null) {
+            // Should not happen - the attestation arrives on a connected link - but a silent return here
+            // would be one more path that goes quiet exactly when something is off.
+            log("DIS attestation (variant=${variant.label}) not applied — the connected strap's address is unknown")
+            return
+        }
         ioScope.launch {
             // Correct the row the attestation CAME FROM, never merely "whichever is active". Those are the
             // same device on a single-strap install, and different ones the moment somebody pairs a 4.0
@@ -4452,14 +4458,21 @@ class WhoopBleClient(
             // This mattered from the first day it could run: the variant only became resolvable once the
             // model number was read (#520), so before that this path returned early on UNKNOWN every time
             // and the mis-targeting was never reachable. Widening the resolver is what makes it live.
-            val devices = repository.pairedDevices()
-            val attesting = devices.firstOrNull {
+            val devices = repository.pairedDevices().filter { it.status != "archived" }
+            val byAddress = devices.firstOrNull {
                 it.peripheralId?.equals(attestingAddress, ignoreCase = true) == true
             }
+            // Fall back to the sole paired strap when no row carries the address yet. That is not a guess:
+            // with exactly one non-archived device there is nothing else the attestation could have come
+            // from. It matters because `peripheralId` is NULL on the seeded row until the strap is adopted,
+            // which is precisely the single-strap install this correction was written for - matching on
+            // address alone would have quietly stopped correcting the case it exists to fix.
+            val attesting = byAddress ?: devices.singleOrNull()
             if (attesting == null) {
-                // No row owns this address yet (a first connect before adoption). Correcting SOMETHING
-                // would be worse than correcting nothing, so say why and stop.
-                log("DIS attestation (variant=${variant.label}) not applied — no paired row carries this strap's address yet")
+                // Several straps and none owns this address: the attestation cannot be attributed, and
+                // correcting SOMETHING would be worse than correcting nothing. Say which, and stop.
+                log("DIS attestation (variant=${variant.label}) not applied — ${devices.size} paired devices" +
+                    " and none carries this strap's address, so it cannot be attributed")
                 return@launch
             }
             if (DeviceFamily.forRegistryDevice(attesting.model, attesting.brand) == DeviceFamily.WHOOP4) {

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2778,6 +2778,8 @@ class WhoopBleClient(
     private var disRead = false
     private var disSerial: String? = null
     private var disHwRev: String? = null
+    /** DIS 0x2A24, the strap's own model number — the authoritative variant signal (#520). */
+    private var disModelNumber: String? = null
 
     /** #364 auto-continue: consecutive immediate re-kicks after a 60s idle-cap OR HISTORY_COMPLETE exit on
      *  THIS connection. Bounded by [MAX_AUTO_CONTINUES] so a pathological strap can't pin the radio. Reset
@@ -4424,7 +4426,7 @@ class WhoopBleClient(
      * information content here) — never the full string, which would end up in a shareable strap log.
      */
     private fun noteWhoop5VariantFromDis() {
-        val variant = Whoop5Variant.from(disSerial, disHwRev)
+        val variant = Whoop5Variant.from(disSerial, disHwRev, disModelNumber)
         _whoop5Variant.value = variant   // #520/#891: publish so MG-only UI can gate on it
         val prefix = disSerial?.trim()?.uppercase()?.take(3) ?: "?"
         log("DIS: serialPrefix=$prefix hwRev=${disHwRev ?: "?"} -> variant=${variant.label}")
@@ -5861,6 +5863,13 @@ class WhoopBleClient(
                     else -> "softwareRev"
                 }
                 val v = bytes.toString(Charsets.UTF_8).trim { it == '\u0000' || it.isWhitespace() }
+                // #520: the model number is the ONE DIS extra that is not merely diagnostic. A field
+                // capture showed serial prefix "MGB" and hwRev "WS50_r03" matching none of the variant
+                // heuristics, on a strap whose model number said "MG" — so this is what finally resolves it.
+                if (uuid == DIS_MODEL_NUMBER_CHAR) {
+                    disModelNumber = v.ifBlank { null }
+                    noteWhoop5VariantFromDis()
+                }
                 // Log only — nothing gates on these. They are identity strings for a strap that may never
                 // pair, and the point is to have them in a capture at all.
                 log("DIS: $label=${v.ifBlank { "(empty)" }}")
@@ -7014,7 +7023,7 @@ class WhoopBleClient(
      *  UNKNOWN is never MG. This is the gate an MG-only capability asks (#891); deliberately independent of
      *  [DeviceFamily], which describes the WIRE PROTOCOL and treats MG and 5.0 as one family. Mirrors the
      *  Swift `BLEManager.whoop5Variant`. */
-    fun whoop5Variant(): Whoop5Variant = Whoop5Variant.from(disSerial, disHwRev)
+    fun whoop5Variant(): Whoop5Variant = Whoop5Variant.from(disSerial, disHwRev, disModelNumber)
 
     private val _whoop5Variant = MutableStateFlow(Whoop5Variant.UNKNOWN)
     /** #520/#891: the attested variant as observable state, for UI that gates an MG-only action. Set from
@@ -8884,6 +8893,7 @@ class WhoopBleClient(
         disRead = false
         disSerial = null
         disHwRev = null
+        disModelNumber = null
         // #1007: a burst cut short by a disconnect never reaches exitBackfilling — that path is only
         // HISTORY_COMPLETE / timeout / user-abort — so without this the throughput line simply would not
         // appear, and its ABSENCE is ambiguous: no offload at all, or one that was interrupted? For a

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4467,7 +4467,12 @@ class WhoopBleClient(
             // from. It matters because `peripheralId` is NULL on the seeded row until the strap is adopted,
             // which is precisely the single-strap install this correction was written for - matching on
             // address alone would have quietly stopped correcting the case it exists to fix.
-            val attesting = byAddress ?: devices.singleOrNull()
+            // The fallback requires the sole row to be UNADOPTED. "One device, so it must be the one
+            // attesting" holds only while that row has never been bound to an address; a row that HAS one
+            // and does not match is a different strap, and relabelling it is the corruption this guard
+            // exists to prevent. That is not hypothetical - adding a 5/MG to an install whose only row is
+            // a 4.0 reaches here before the new strap is registered.
+            val attesting = byAddress ?: devices.singleOrNull()?.takeIf { it.peripheralId == null }
             if (attesting == null) {
                 // Several straps and none owns this address: the attestation cannot be attributed, and
                 // correcting SOMETHING would be worse than correcting nothing. Say which, and stop.

--- a/android/app/src/main/java/com/noop/protocol/Whoop5Variant.kt
+++ b/android/app/src/main/java/com/noop/protocol/Whoop5Variant.kt
@@ -38,6 +38,11 @@ enum class Whoop5Variant(val label: String) {
          */
         const val FIVE_ZERO_HARDWARE_ID_TOKEN = "WG50"
 
+        /** DIS 0x2A24 Model Number String, as a real WHOOP MG reports it. Read unbonded off the standard
+         *  profile, so it is available on a strap that never pairs — which is exactly the case the prefix
+         *  heuristics were failing on. */
+        const val MODEL_NUMBER_MG = "MG"
+
         /**
          * Resolve the variant from the strap's Device Information Service strings.
          *
@@ -52,7 +57,19 @@ enum class Whoop5Variant(val label: String) {
          *  3. Serial prefix -> [MG] / [FIVE_ZERO].
          *  4. Anything else -> [UNKNOWN]. Never infer from a stray digit in the name (#772).
          */
-        fun from(serial: String?, hardwareRevision: String? = null): Whoop5Variant {
+        fun from(
+            serial: String?,
+            hardwareRevision: String? = null,
+            modelNumber: String? = null,
+        ): Whoop5Variant {
+            // The strap SAYING what it is beats inferring it from a prefix. DIS 0x2A24 reports "MG" on a
+            // real MG, and a field capture showed serial prefix "MGB" with hardware revision "WS50_r03" —
+            // matching neither [MG_SERIAL_PREFIX] nor [FIVE_ZERO_HARDWARE_ID_TOKEN], so every heuristic
+            // below returned UNKNOWN for a strap whose own model number said MG outright (#520).
+            //
+            // Only MG is claimed here. No 5.0 has been observed reporting its model number, so inventing a
+            // token for one would be the guess this function already refuses to make elsewhere.
+            if ((modelNumber ?: "").trim().uppercase() == MODEL_NUMBER_MG) return MG
             val hw = (hardwareRevision ?: "").uppercase()
             var s = (serial ?: "").uppercase().trim()
             if (s.startsWith("WHOOP ")) s = s.removePrefix("WHOOP ")

--- a/android/app/src/test/java/com/noop/protocol/Whoop5VariantTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5VariantTest.kt
@@ -59,4 +59,35 @@ class Whoop5VariantTest {
         assertEquals("5.0", Whoop5Variant.FIVE_ZERO.label)
         assertEquals("—", Whoop5Variant.UNKNOWN.label)
     }
+
+    /**
+     * The field capture that exposed the gap: serial prefix "MGB", hardware revision "WS50_r03" — neither
+     * matches MG_SERIAL_PREFIX ("5AM") nor FIVE_ZERO_HARDWARE_ID_TOKEN ("WG50"), so every heuristic
+     * returned UNKNOWN for a strap whose own model number said MG.
+     */
+    @Test
+    fun `a real MG resolves from its model number when the prefixes do not`() {
+        assertEquals(Whoop5Variant.UNKNOWN, Whoop5Variant.from("MGB0779473", "WS50_r03"))
+        assertEquals(Whoop5Variant.MG, Whoop5Variant.from("MGB0779473", "WS50_r03", "MG"))
+    }
+
+    @Test
+    fun `the model number is trimmed and case-insensitive`() {
+        assertEquals(Whoop5Variant.MG, Whoop5Variant.from(null, null, "  mg  "))
+    }
+
+    /** Only MG is claimed - no 5.0 has been observed reporting a model number, so an unrecognised one
+     *  falls through to the existing heuristics rather than inventing a verdict. */
+    @Test
+    fun `an unknown model number does not override the heuristics`() {
+        assertEquals(Whoop5Variant.FIVE_ZERO, Whoop5Variant.from("5AG12345678", null, "WHOOP5"))
+        assertEquals(Whoop5Variant.UNKNOWN, Whoop5Variant.from(null, null, "WHOOP5"))
+    }
+
+    /** Two heuristics disagreeing is a reason not to guess; it is not a reason to ignore the strap
+     *  stating its own model. */
+    @Test
+    fun `the model number beats the contradiction guard`() {
+        assertEquals(Whoop5Variant.MG, Whoop5Variant.from("5AM12345678", "WG50_r52", "MG"))
+    }
 }


### PR DESCRIPTION
A real WHOOP MG reports:

```
DIS: serialPrefix=MGB  hwRev=WS50_r03  modelNumber=MG   ->  variant=—
```

The resolver matches `MG_SERIAL_PREFIX = "5AM"` and `FIVE_ZERO_HARDWARE_ID_TOKEN = "WG50"`, so **every heuristic returned UNKNOWN for a strap whose own model number said MG outright**. This only became visible now that the DIS identity read happens on an unbonded link (#1647/#1653) — which is precisely the strap that never resolved.

### Reading the model beats inferring it

`Whoop5Variant.from` gains an optional `modelNumber`, checked first. The strap stating what it is needs no heuristic at all.

**On `WS50` vs the expected `WG50`** — one letter apart, and I deliberately have **not** treated that as a typo to patch. One field sample is not enough to redefine a hardware token, and guessing is what this function already refuses to do (`// contradiction — do not guess`). The model number sidesteps the question entirely.

**Only MG is claimed.** No 5.0 has been observed reporting a model number, so an unrecognised one falls through to the existing heuristics rather than inventing a verdict — pinned by a test on both platforms.

**The model number does outrank the contradiction guard**, and that is deliberate: two heuristics disagreeing is a reason not to guess, but not a reason to ignore the strap stating its own model.

### Verification

Twinned in the same commit, and `WhoopProtocol` builds on Linux — so the Swift side is genuinely **run** here rather than deferred to app-build:

- **642** Swift tests green (`swift test`, `Packages/WhoopProtocol`)
- **4481** Android tests green
- `doc_comment_lint` and `i18n_audit` clean

Both sides pin the real field values (`MGB0779473` / `WS50_r03`), including the assertion that those two alone still resolve to `unknown` — so the test would fail if someone later "fixed" the prefixes by guessing.

### Residual, deliberately not fixed here

Swift never *supplies* the new argument, because reading DIS `0x2A24` is part of the Android-only extras chain. So an MG resolves correctly on Android and still reads unknown on Apple until that chain is twinned. Same boundary as the DIS work it depends on.
