### PR TITLE
analytics: start Banister's axis where Edwards' starts (#1624)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StrainScorer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StrainScorer.swift
@@ -65,6 +65,35 @@ public enum StrainScorer {
         24.0 * 60.0 * 1.0 * banisterScale * exp(b)
     }
 
+    /// The %HRR a waking, sedentary body sits at — the "cost of being alive", not training load.
+    ///
+    /// Banister pays at EVERY intensity by design, which is the point: it catches the intermittent work
+    /// Edwards zeroes. The side effect is that sixteen waking hours of doing nothing accumulate real
+    /// TRIMP, so a desk day cannot score zero however still you are — while the same day under Edwards,
+    /// whose first zone starts at 50% HRR, scores exactly zero. A 24 h day held at 5% HRR scores 0 under
+    /// Edwards and 45 under Banister on the shipped constants. That is not two recipes on one axis; that
+    /// is two axes (#1624).
+    ///
+    /// THIS IS THE ONE TUNED CONSTANT here, and it is a judgement rather than a measurement: low enough
+    /// not to erase genuine light activity, high enough that ordinary sitting nets to nothing. Resting HR
+    /// is measured asleep, so a waking body sits above it even at complete rest — precisely the gap this
+    /// closes. Treat it as calibratable, not as physiology.
+    public static let banisterSedentaryHRR: Double = 0.10
+
+    /// TRIMP per minute at `banisterSedentaryHRR` — the rate subtracted from every day.
+    static func banisterBaselineRatePerMinute(b: Double) -> Double {
+        banisterScale * banisterSedentaryHRR * exp(b * banisterSedentaryHRR)
+    }
+
+    /// The sedentary TRIMP accrued over `minutes`, subtracted from a day's Banister TRIMP so the axis
+    /// starts where Edwards' does. Subtracted from the DENOMINATOR too, so the top is unmoved and a
+    /// theoretical maximum day still maps to exactly `maxStrain` — anchoring only the bottom would trade
+    /// one mismatched end for the other.
+    static func banisterBaseline(minutes: Double, b: Double) -> Double {
+        banisterBaselineRatePerMinute(b: b) * minutes
+    }
+
+
     /// The log-map denominator for a method, so a caller never has to know which constant belongs to
     /// which recipe. Ceiling + 1 in both cases, mirroring how `strainDenominator` was derived, so a
     /// theoretical maximum day maps to exactly `maxStrain` under either method.
@@ -73,7 +102,10 @@ public enum StrainScorer {
         case .edwards:
             return strainDenominator
         case .banister:
-            return banisterDailyCeiling(b: sex.lowercased().hasPrefix("f") ? banisterBWomen : banisterBMen) + 1.0
+            let b = sex.lowercased().hasPrefix("f") ? banisterBWomen : banisterBMen
+            // Ceiling MINUS a full day of sedentary baseline, matching what is subtracted from the day
+            // itself, so both ends of the axis line up with Edwards (#1624).
+            return banisterDailyCeiling(b: b) - banisterBaseline(minutes: 24.0 * 60.0, b: b) + 1.0
         }
     }
 
@@ -232,12 +264,25 @@ public enum StrainScorer {
         return acc
     }
 
+    /// - Parameter floorRatePerMinute: per-minute rate treated as "no effort" and subtracted from EVERY
+    ///   sample, floored at zero (#1624). Zero — the default — is the original, unfloored Banister recipe,
+    ///   so every existing caller and test is byte-identical. Pass `banisterBaselineRatePerMinute` to
+    ///   score the excess over a sedentary day, which is what the daily scorer does.
+    ///
+    ///   Per SAMPLE, never as one lump off the total: a day quieter than the floor would otherwise run a
+    ///   deficit that eats into real work done on top, and 90 minutes at 35% HRR inside an otherwise still
+    ///   day would net negative and clamp to zero — erasing exactly the intermittent effort this recipe
+    ///   exists to capture.
     static func banisterTRIMP(_ hr: [HRSample], restingHR: Double, hrReserve: Double,
-                              durations: [Double], b: Double) -> Double {
+                              durations: [Double], b: Double,
+                              floorRatePerMinute: Double = 0.0) -> Double {
         var acc = 0.0
         for i in hr.indices {
             let x = pctHRR(Double(hr[i].bpm), restingHR: restingHR, hrReserve: hrReserve) / 100.0
-            if x > 0 { acc += durations[i] * x * banisterScale * exp(b * x) }
+            if x > 0 {
+                let rate = x * banisterScale * exp(b * x)
+                acc += durations[i] * max(rate - floorRatePerMinute, 0.0)
+            }
         }
         return acc
     }
@@ -350,8 +395,11 @@ public enum StrainScorer {
         switch method {
         case .banister:
             let b = sex.lowercased().hasPrefix("f") ? banisterBWomen : banisterBMen
+            // Excess over the sedentary baseline for the SAME span, floored at zero. Without this a desk
+            // day scores ~45 on a 0-100 axis whose bottom is supposed to be no exertion (#1624).
             trimp = banisterTRIMP(hr, restingHR: restingHR, hrReserve: hrReserve,
-                                  durations: durations, b: b)
+                                  durations: durations, b: b,
+                                  floorRatePerMinute: banisterBaselineRatePerMinute(b: b))
         case .edwards:
             trimp = edwardsTRIMP(hr, restingHR: restingHR, hrReserve: hrReserve,
                                  durations: durations)

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainBanisterDenominatorTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainBanisterDenominatorTests.swift
@@ -26,12 +26,19 @@ final class StrainBanisterDenominatorTests: XCTestCase {
                        1440.0 * 0.64 * exp(1.67), accuracy: d)
     }
 
-    /// The denominator is ceiling + 1, exactly as `strainDenominator` was derived from 7200.
-    func testTheDenominatorIsCeilingPlusOne() {
+    /// The denominator is (ceiling MINUS a full day of sedentary baseline) + 1.
+    ///
+    /// #1545 derived it as ceiling + 1, mirroring how `strainDenominator` came from 7200. #1624 subtracts
+    /// the same baseline from the denominator that the scorer subtracts from each day, so both ends of the
+    /// axis line up with Edwards: no exertion maps to 0 AND a maximum day still maps to 100. Anchoring one
+    /// end only would trade one mismatch for the other.
+    func testTheDenominatorIsCeilingMinusBaselinePlusOne() {
         XCTAssertEqual(StrainScorer.logMapDenominator(method: .banister, sex: "male"),
-                       StrainScorer.banisterDailyCeiling(b: StrainScorer.banisterBMen) + 1.0, accuracy: d)
+                       StrainScorer.banisterDailyCeiling(b: StrainScorer.banisterBMen) -
+                        StrainScorer.banisterBaseline(minutes: 24.0 * 60.0, b: StrainScorer.banisterBMen) + 1.0, accuracy: d)
         XCTAssertEqual(StrainScorer.logMapDenominator(method: .banister, sex: "female"),
-                       StrainScorer.banisterDailyCeiling(b: StrainScorer.banisterBWomen) + 1.0, accuracy: d)
+                       StrainScorer.banisterDailyCeiling(b: StrainScorer.banisterBWomen) -
+                        StrainScorer.banisterBaseline(minutes: 24.0 * 60.0, b: StrainScorer.banisterBWomen) + 1.0, accuracy: d)
     }
 
     /// The property the whole derivation exists for: a theoretical maximum day maps to exactly 100 under
@@ -43,7 +50,11 @@ final class StrainBanisterDenominatorTests: XCTestCase {
 
         for sex in ["male", "female"] {
             let b = sex == "female" ? StrainScorer.banisterBWomen : StrainScorer.banisterBMen
-            let ceiling = StrainScorer.banisterDailyCeiling(b: b)
+            // #1624: the quantity that maps to the top is a maximum day's EXCESS over the sedentary
+            // baseline, not its raw TRIMP — that is what the scorer now feeds the log map. Feeding the raw
+            // ceiling overshoots (100.21), which is the arithmetic working, not breaking.
+            let ceiling = StrainScorer.banisterDailyCeiling(b: b) -
+                StrainScorer.banisterBaseline(minutes: 24.0 * 60.0, b: b)
             let mapped = StrainScorer.trimpToStrain(
                 ceiling, denominator: StrainScorer.logMapDenominator(method: .banister, sex: sex))
             XCTAssertEqual(mapped, 100.0, accuracy: 1e-6, "\(sex) ceiling should map to the top of the scale")

--- a/android/app/src/main/java/com/noop/analytics/StrainScorer.kt
+++ b/android/app/src/main/java/com/noop/analytics/StrainScorer.kt
@@ -83,14 +83,50 @@ object StrainScorer {
     fun banisterDailyCeiling(b: Double): Double = 24.0 * 60.0 * 1.0 * banisterScale * kotlin.math.exp(b)
 
     /**
+     * The %HRR a waking, sedentary body sits at — the "cost of being alive", not training load.
+     *
+     * Banister pays at EVERY intensity by design, which is the point: it catches the intermittent work
+     * Edwards zeroes. The side effect is that sixteen waking hours of doing nothing accumulate real TRIMP,
+     * so a desk day cannot score zero however still you are — while the same day under Edwards, whose
+     * first zone starts at 50% HRR, scores exactly zero. A 24 h day held at 5% HRR scores 0 under Edwards
+     * and 45 under Banister on the shipped constants. That is not two recipes on one axis; that is two
+     * axes (#1624).
+     *
+     * THIS IS THE ONE TUNED CONSTANT here, and it is a judgement rather than a measurement: low enough not
+     * to erase genuine light activity, high enough that ordinary sitting nets to nothing. Resting HR is
+     * measured asleep, so a waking body sits above it even at complete rest — which is precisely the gap
+     * this closes. Treat it as calibratable, not as physiology.
+     */
+    const val banisterSedentaryHRR: Double = 0.10
+
+    /** TRIMP per minute at [banisterSedentaryHRR] — the rate subtracted from every day. */
+    fun banisterBaselineRatePerMinute(b: Double): Double =
+        banisterScale * banisterSedentaryHRR * kotlin.math.exp(b * banisterSedentaryHRR)
+
+    /**
+     * The sedentary TRIMP accrued over [minutes] — subtracted from a day's Banister TRIMP so the axis
+     * starts where Edwards' does.
+     *
+     * Subtracted from the DENOMINATOR too (see [logMapDenominator]), so the top of the axis is unmoved: a
+     * theoretical maximum day still maps to exactly [maxStrain]. Anchoring only the bottom would trade one
+     * mismatched end for the other.
+     */
+    fun banisterBaseline(minutes: Double, b: Double): Double = banisterBaselineRatePerMinute(b) * minutes
+
+
+    /**
      * The log-map denominator for a method, so a caller never has to know which constant belongs to
      * which recipe. Ceiling + 1 in both cases, mirroring how [strainDenominator] was derived, so a
      * theoretical maximum day maps to exactly [maxStrain] under either method.
      */
     fun logMapDenominator(method: Method, sex: String): Double = when (method) {
         Method.EDWARDS -> strainDenominator
-        Method.BANISTER ->
-            banisterDailyCeiling(if (sex.lowercase().startsWith("f")) banisterBWomen else banisterBMen) + 1.0
+        Method.BANISTER -> {
+            val b = if (sex.lowercase().startsWith("f")) banisterBWomen else banisterBMen
+            // Ceiling MINUS a full day of sedentary baseline, matching what is subtracted from the day
+            // itself, so both ends of the axis line up with Edwards (#1624).
+            banisterDailyCeiling(b) - banisterBaseline(24.0 * 60.0, b) + 1.0
+        }
     }
     val lnStrainDenominator: Double get() = ln(strainDenominator)
 
@@ -277,11 +313,24 @@ object StrainScorer {
         hrReserve: Double,
         durations: List<Double>,
         b: Double,
+        /** Per-minute rate treated as "no effort" and subtracted from EVERY sample, floored at zero
+         *  (#1624). Zero — the default — is the original, unfloored Banister recipe, so every existing
+         *  caller and test is byte-identical. Pass [banisterBaselineRatePerMinute] to score the excess
+         *  over a sedentary day, which is what the daily scorer does.
+         *
+         *  Per SAMPLE, never as one lump off the total: a day quieter than the floor would otherwise run
+         *  a deficit that eats into real work done on top, and 90 minutes at 35% HRR inside an otherwise
+         *  still day would net negative and clamp to zero — erasing exactly the intermittent effort this
+         *  recipe exists to capture. */
+        floorRatePerMinute: Double = 0.0,
     ): Double {
         var acc = 0.0
         for (i in hr.indices) {
             val x = pctHRR(hr[i].bpm.toDouble(), restingHR, hrReserve) / 100.0
-            if (x > 0) acc += durations[i] * x * banisterScale * exp(b * x)
+            if (x > 0) {
+                val rate = x * banisterScale * exp(b * x)
+                acc += durations[i] * (rate - floorRatePerMinute).coerceAtLeast(0.0)
+            }
         }
         return acc
     }
@@ -370,7 +419,10 @@ object StrainScorer {
         val trimp: Double = when (method) {
             Method.BANISTER -> {
                 val b = if (sex.lowercase().startsWith("f")) banisterBWomen else banisterBMen
-                banisterTRIMP(hr, restingHR, hrReserve, durations, b)
+                // Excess over the sedentary baseline for the SAME span, floored at zero. Without this a
+                // desk day scores ~45 on a 0-100 axis whose bottom is supposed to be no exertion (#1624).
+                banisterTRIMP(hr, restingHR, hrReserve, durations, b,
+                    floorRatePerMinute = banisterBaselineRatePerMinute(b))
             }
             Method.EDWARDS -> {
                 edwardsTRIMP(hr, restingHR, hrReserve, durations)

--- a/android/app/src/test/java/com/noop/analytics/BanisterBaselineTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/BanisterBaselineTest.kt
@@ -1,0 +1,74 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1624: Banister's axis has to start where Edwards' does.
+ *
+ * The reported symptom was "the new exponential effort score flattens all scores" — a desk day rising
+ * from ~0 to 10+ while a hard ride barely moved. The cause was structural, not observational: Edwards
+ * pays nothing below 50% HRR so a sedentary day is exactly 0, while Banister pays at every intensity, so
+ * sixteen waking hours of doing nothing accumulated real TRIMP. On the shipped constants a 24 h day held
+ * at 5% HRR scored 0 under Edwards and 45 under Banister — the usable range squashed into the top half.
+ */
+class BanisterBaselineTest {
+    private val rest = 50.0
+    private val max = 190.0
+    private var clock = 0L
+
+    /** [minutes] of samples held at a fixed fraction of HR reserve, one sample per second. */
+    private fun dayAt(hrrFraction: Double, minutes: Int): List<com.noop.data.HrSample> {
+        val bpm = (rest + hrrFraction * (max - rest)).toInt()
+        return (0 until minutes * 60).map {
+            com.noop.data.HrSample(deviceId = "t", ts = clock++, bpm = bpm)
+        }
+    }
+
+    private fun score(hr: List<com.noop.data.HrSample>, method: StrainScorer.Method): Double? =
+        StrainScorer.strain(hr = hr, maxHR = max, restingHR = rest, method = method, sex = "male")
+
+    @Test
+    fun `a sedentary day scores zero under BOTH methods`() {
+        // The invariant #1545 claimed and did not have: mapping the maximum to 100 puts the two on one
+        // axis only if they also agree at the bottom.
+        for (frac in listOf(0.0, 0.05, 0.10)) {
+            clock = 0L
+            val hr = dayAt(frac, 24 * 60)
+            val ed = score(hr, StrainScorer.Method.EDWARDS) ?: 0.0
+            val ba = score(hr, StrainScorer.Method.BANISTER) ?: 0.0
+            assertEquals("edwards @ $frac", 0.0, ed, 0.01)
+            assertEquals("banister @ $frac", 0.0, ba, 0.01)
+        }
+    }
+
+    @Test
+    fun `Banister still pays for work Edwards zeroes - the reason it exists`() {
+        // The whole point of the recipe: intermittent effort that averages below Edwards' 50% HRR floor.
+        // A baseline subtraction that erased this would have fixed the axis by removing the feature.
+        clock = 0L
+        val hr = dayAt(0.35, 90) + dayAt(0.05, 24 * 60 - 90)
+        val ed = score(hr, StrainScorer.Method.EDWARDS) ?: 0.0
+        val ba = score(hr, StrainScorer.Method.BANISTER) ?: 0.0
+        assertEquals("edwards pays nothing below its floor", 0.0, ed, 0.01)
+        assertTrue("banister must still pay: was $ba", ba > 1.0)
+    }
+
+    @Test
+    fun `a harder day always outscores an easier one`() {
+        clock = 0L
+        val easy = score(dayAt(0.20, 24 * 60), StrainScorer.Method.BANISTER) ?: 0.0
+        clock = 0L
+        val hard = score(dayAt(0.60, 24 * 60), StrainScorer.Method.BANISTER) ?: 0.0
+        assertTrue("monotonic: easy=$easy hard=$hard", hard > easy)
+    }
+
+    @Test
+    fun `the baseline is subtracted from the ceiling too, so the top still reaches 100`() {
+        // Anchoring only the bottom would trade one mismatched end for the other.
+        clock = 0L
+        val full = score(dayAt(1.0, 24 * 60), StrainScorer.Method.BANISTER) ?: 0.0
+        assertEquals(StrainScorer.maxStrain, full, 0.5)
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/BanisterParityOracleTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/BanisterParityOracleTest.kt
@@ -1,0 +1,52 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Byte-identical parity oracle for the #1624 Banister baseline, against the compiled Swift twin.
+ *
+ * The expected block is the verbatim stdout of `StrainScorer.swift`'s own functions, extracted and
+ * compiled standalone on Linux and run over the same eight intensities. Analytics is the strictest half
+ * of the parity contract — the numbers must agree, not merely the approach — and this change edited the
+ * same formula by hand on both platforms, which is exactly when they drift.
+ *
+ * Calls the low-level functions with explicit durations rather than going through `strain()`, so the two
+ * sides are fed identical inputs and any difference is the formula's, not the sampling's.
+ */
+class BanisterParityOracleTest {
+    @Test
+    fun `every intensity matches the compiled Swift twin`() {
+        val rest = 50.0
+        val mx = 190.0
+        val reserve = mx - rest
+        val b = StrainScorer.banisterBMen
+        val floor = StrainScorer.banisterBaselineRatePerMinute(b)
+        val denom = StrainScorer.logMapDenominator(StrainScorer.Method.BANISTER, "male")
+
+        val out = StringBuilder()
+        for (f in listOf(0.0, 0.05, 0.10, 0.15, 0.20, 0.35, 0.60, 1.00)) {
+            val bpm = (rest + f * (mx - rest)).toInt()
+            val hr = (0 until 24 * 60 * 60).map { HrSample(deviceId = "t", ts = it.toLong(), bpm = bpm) }
+            val durs = List(hr.size) { 1.0 / 60.0 }
+            val trimp = StrainScorer.banisterTRIMP(hr, rest, reserve, durs, b, floorRatePerMinute = floor)
+            val score = StrainScorer.trimpToStrain(trimp, denom)
+            out.append(String.format(java.util.Locale.ROOT, "%.2f=%.6f%n", f, score))
+        }
+        assertEquals(SWIFT.trimStart('\n'), out.toString().replace(System.lineSeparator(), "\n"))
+    }
+
+    private companion object {
+        const val SWIFT = """
+0.00=0.000000
+0.05=0.000000
+0.10=0.000000
+0.15=49.270000
+0.20=58.140000
+0.35=71.670000
+0.60=84.800000
+1.00=100.000000
+"""
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/StrainBanisterDenominatorTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StrainBanisterDenominatorTest.kt
@@ -35,13 +35,23 @@ class StrainBanisterDenominatorTest {
             StrainScorer.banisterDailyCeiling(StrainScorer.banisterBWomen), eps)
     }
 
-    /** The denominator is ceiling + 1, exactly as [StrainScorer.strainDenominator] was derived from 7200. */
+    /**
+     * The denominator is (ceiling MINUS a full day of sedentary baseline) + 1.
+     *
+     * #1545 derived it as ceiling + 1, mirroring how [StrainScorer.strainDenominator] came from 7200.
+     * #1624 subtracts the same baseline from the denominator that the scorer subtracts from each day, so
+     * both ends of the axis line up with Edwards: no exertion maps to 0 AND a maximum day still maps to
+     * 100. Anchoring one end only would trade one mismatch for the other.
+     */
     @Test
-    fun theDenominatorIsCeilingPlusOne() {
-        assertEquals(StrainScorer.banisterDailyCeiling(StrainScorer.banisterBMen) + 1.0,
-            StrainScorer.logMapDenominator(StrainScorer.Method.BANISTER, "male"), eps)
-        assertEquals(StrainScorer.banisterDailyCeiling(StrainScorer.banisterBWomen) + 1.0,
-            StrainScorer.logMapDenominator(StrainScorer.Method.BANISTER, "female"), eps)
+    fun theDenominatorIsCeilingMinusBaselinePlusOne() {
+        val day = 24.0 * 60.0
+        for (sex in listOf("male", "female")) {
+            val b = if (sex == "female") StrainScorer.banisterBWomen else StrainScorer.banisterBMen
+            assertEquals(
+                StrainScorer.banisterDailyCeiling(b) - StrainScorer.banisterBaseline(day, b) + 1.0,
+                StrainScorer.logMapDenominator(StrainScorer.Method.BANISTER, sex), eps)
+        }
     }
 
     /**
@@ -54,7 +64,13 @@ class StrainBanisterDenominatorTest {
         assertEquals(100.0, StrainScorer.trimpToStrain(7200.0, StrainScorer.strainDenominator), 1e-6)
         for (sex in listOf("male", "female")) {
             val b = if (sex == "female") StrainScorer.banisterBWomen else StrainScorer.banisterBMen
-            val ceiling = StrainScorer.banisterDailyCeiling(b)
+            // #1624: the quantity that maps to the top is a maximum day's EXCESS over the sedentary
+            // baseline, not its raw TRIMP — because that is what the scorer now feeds the log map. Feeding
+            // the raw ceiling here overshoots (100.21), which is the arithmetic working, not breaking.
+            // The end-to-end invariant — real samples at full reserve through strain() scoring exactly
+            // 100 — is pinned in BanisterBaselineTest.
+            val ceiling = StrainScorer.banisterDailyCeiling(b) -
+                StrainScorer.banisterBaseline(24.0 * 60.0, b)
             assertEquals("$sex ceiling should map to the top of the scale", 100.0,
                 StrainScorer.trimpToStrain(
                     ceiling, StrainScorer.logMapDenominator(StrainScorer.Method.BANISTER, sex)), 1e-6)


### PR DESCRIPTION
Reported as *"the new exponential effort score flattens all scores"* — a desk day rising from ~0 to 10+ while a hard ride barely moved. The cause is **structural**, and falls out of the two formulas and the shipped constants rather than out of one user's data:

| 24 h held at | Edwards | Banister |
|---|---|---|
| 0% HRR | 0.0 | 0.0 |
| **5% HRR** | **0.0** | **45.1** |
| 10% HRR | 0.0 | 54.0 |
| 20% HRR | 0.0 | 64.1 |

Edwards pays nothing below 50% HRR, so a sedentary day is exactly zero. Banister pays at every intensity **by design** — that is the point, it catches the intermittent work Edwards zeroes — so sixteen waking hours of doing nothing accumulate real TRIMP. The usable range was roughly 45–100, with everything real squashed into the top half.

That also falsifies what #1545 states in its own doc:

> *"each method maps a theoretical maximum day to exactly 100 … so the two are on the same axis"*

Anchoring the **top** does not put two methods on one axis. They have to agree at the **bottom** too.

### The change

Banister scores the **excess** over a sedentary rate, subtracted from the denominator as well so the top is unmoved. A no-exertion day maps to 0 and a maximum day still maps to 100, under both methods.

`banisterSedentaryHRR = 0.10` is the **one tuned constant**, and it is a judgement rather than a measurement: resting HR is measured asleep, so a waking body sits above it even at complete rest, and that gap is what this closes. Documented as calibratable, not as physiology.

### Two things re-review caught

**The first implementation erased the feature it was fixing.** Subtracting `rate × totalMinutes` as a **lump** let a day quieter than the baseline run a deficit that then ate into real work: 90 minutes at 35% HRR inside an otherwise still day netted *negative* and clamped to zero. My own *"Banister still pays for work Edwards zeroes"* test caught it. The floor is now applied per **sample**.

**That fix then duplicated `banisterTRIMP`'s formula**, leaving the original dead in production and alive only through its tests. Folded into one function with an optional `floorRatePerMinute` defaulting to `0.0` — byte-identical to the old recipe for every existing caller.

### Two #1545 tests updated, not deleted

They pinned the denominator and the maximum-day mapping against the **pre-baseline** quantities, which legitimately moved (the denominator is off by exactly the baseline, 111.67). The invariant itself is now pinned **end-to-end** instead — real samples at full reserve through `strain()` scoring exactly 100 — which is a stronger test than the intermediate it replaces.

### Verification

- **4485** Android tests green; doc lint and i18n audit clean.
- Both platforms. `StrandAnalytics` does not build on Linux (GRDB/sqlite3), so the Swift twin is app-build gated.

### Not addressed — and it is half the report

> *"I would expect a hard ride to go towards 21 like it was the case with whoop"*

That is calibration against WHOOP's proprietary scale, not a defect. A baseline subtraction can only lower the numerator, so the ride moves slightly **down** (modelled 12.5 → 11.6). Their ride read ~13 under Edwards before any of this. Worth answering on the issue in its own right rather than leaving them to discover it from a build.

### Worth a maintainer's eye

This **rescales existing history** for anyone using Banister — past days all move. Banister is opt-in and default-off, so it affects only users who chose it, but it is not a silent no-op for them.


### Re-review: the numbers are now pinned across platforms

This edited the same formula **by hand on both platforms**, which is exactly when analytics drifts — and analytics is the half of the parity contract that requires the *numbers* to agree, not merely the approach. Nothing was pinning that.

`StrandAnalytics` doesn't build on Linux (GRDB/sqlite3), so the twin looked untestable here. It isn't: the scoring functions are pure, so extracting them with a stub `HRSample` compiles standalone and runs. Both sides agree to six decimal places across eight intensities, including the two ends that matter:

```
0.00=0.000000   0.15=49.270000   0.60=84.800000
0.05=0.000000   0.20=58.140000   1.00=100.000000
0.10=0.000000   0.35=71.670000
```

A one-sided edit to the Kotlin scorer now fails this test, instead of silently giving Android users different Effort numbers from iOS.

**4486** tests green.

### Parity re-review: the Swift tests were failing CI

I updated the two Kotlin tests that pinned the pre-baseline denominator and **forgot their Swift twins**. `swift-packages.yml` is active and runs `swift test` over `Packages/**`, so both failed on this PR:

```
StrainBanisterDenominatorTests.swift:49: error: testAMaximumDayIsOneHundredUnderBothMethods
  XCTAssertEqualWithAccuracy failed: ("100.21") is not equal to ("100.0")
```

The identical number the Kotlin twin produced. Updating one side's tests and not the other's is exactly what the parity contract exists to catch, and I did it anyway — so it is worth recording rather than quietly fixing.

Both Swift tests now carry the same reasoning as their Kotlin counterparts, and **all checks pass**, `test (StrandAnalytics)` included.

Also confirmed while checking: the two test files are **1:1**, every Swift test has a same-named Kotlin twin, and the whole Kotlin suite passes — including `intermittentWorkFaresBetterUnderBanister`, independent confirmation that the floor did not break the property Banister exists for. With the implementations pinned byte-identical by the oracle, a passing Kotlin twin is now real evidence about its Swift counterpart rather than an assumption.