### PR TITLE
store: keep the nightly absolute skin temperature

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -900,7 +900,11 @@ public enum AnalyticsEngine {
             activeKcalEst: activeKcalEst,
             spo2Red: nightlySpo2Raw?.red,
             spo2Ir: nightlySpo2Raw?.ir,
-            avgSdnn: avgSDNNDaily)
+            avgSdnn: avgSDNNDaily,
+            // The ABSOLUTE this pass's deviation was derived from (#1636). Set HERE, beside
+            // `skinTempDevC`, so the engine's own row is symmetric: any path that persists this
+            // struct directly keeps both thermal values, not just the one.
+            skinTempC: nightlySkinTempC)
         _ = sleepStart; _ = sleepEnd  // available for callers wiring sleep_start/end columns
 
         // ── Cache rows ────────────────────────────────────────────────────────

--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -875,6 +875,18 @@ extension WhoopStore {
                 t.add(column: "burstIndex", .integer)
             }
         }
+        // v40 (#1636): keep the nightly ABSOLUTE skin temperature beside the deviation derived from it.
+        // The engine computed this mean on every pass and discarded it the moment `skinTempDevC` was
+        // taken, so the app could show "+0.5 Δ°C" with no way to learn what it moved from — and a febrile
+        // night reads as a small delta where the absolute reads as a fever. Additive and nullable: old
+        // rows stay nil, and nothing reads it as a gate. Existing nights refill on the next scoring pass
+        // because the value is re-derived from raw `skinTempSample` rows that are still on disk — no
+        // separate backfill, and therefore no second implementation that could disagree with the live one.
+        migrator.registerMigration("v40-daily-skin-temp-absolute") { db in
+            try db.alter(table: "dailyMetric") { t in
+                t.add(column: "skinTempC", .double)
+            }
+        }
         return migrator
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
@@ -93,12 +93,25 @@ public struct DailyMetric: Equatable, Codable {
     /// compute it from the night's R-R (`HRVAnalyzer.sdnnIndex`); Apple rows mirror their own SDNN reading;
     /// Oura/other imports carry no SDNN so it stays nil.
     public let avgSdnn: Double?
+    /// Nightly ABSOLUTE skin temperature (°C) — the wear-gated mean over the night's detected sleep, the
+    /// value `skinTempDevC` is derived FROM (#1636).
+    ///
+    /// The engine already computed this on every scoring pass and threw it away once the deviation was
+    /// taken, so a wearer could see "+0.5 Δ°C" with no way to learn what it moved from — and a febrile
+    /// night reads as a small delta while the absolute reads as a fever. v40 column, nullable: nights
+    /// scored before it shipped stay nil until a re-score re-derives them from the same raw samples.
+    ///
+    /// Distinct from `skinTempDevC`, which is bimodal — CSV/Apple imports write an ABSOLUTE wrist °C into
+    /// that column and `SkinTempDisplay.isAbsoluteSkinTemp` separates them by magnitude. This column is
+    /// unambiguous: it is always an absolute, and only the strap pipeline writes it.
+    public let skinTempC: Double?
     public init(day: String, totalSleepMin: Double?, efficiency: Double?, deepMin: Double?,
                 remMin: Double?, lightMin: Double?, disturbances: Int?, restingHr: Int?,
                 avgHrv: Double?, recovery: Double?, strain: Double?, exerciseCount: Int?,
                 spo2Pct: Double? = nil, skinTempDevC: Double? = nil, respRateBpm: Double? = nil,
                 steps: Int? = nil, activeKcalEst: Double? = nil,
-                spo2Red: Int? = nil, spo2Ir: Int? = nil, avgSdnn: Double? = nil) {
+                spo2Red: Int? = nil, spo2Ir: Int? = nil, avgSdnn: Double? = nil,
+                skinTempC: Double? = nil) {
         self.day = day; self.totalSleepMin = totalSleepMin; self.efficiency = efficiency
         self.deepMin = deepMin; self.remMin = remMin; self.lightMin = lightMin
         self.disturbances = disturbances; self.restingHr = restingHr; self.avgHrv = avgHrv
@@ -106,6 +119,7 @@ public struct DailyMetric: Equatable, Codable {
         self.spo2Pct = spo2Pct; self.skinTempDevC = skinTempDevC; self.respRateBpm = respRateBpm
         self.steps = steps; self.activeKcalEst = activeKcalEst
         self.spo2Red = spo2Red; self.spo2Ir = spo2Ir; self.avgSdnn = avgSdnn
+        self.skinTempC = skinTempC
     }
 
     /// The freshest STRICTLY-PRIOR day that carries at least one overnight vital (HRV / resting HR /
@@ -416,8 +430,8 @@ extension WhoopStore {
                     (deviceId, day, totalSleepMin, efficiency, deepMin, remMin, lightMin,
                      disturbances, restingHr, avgHrv, recovery, strain, exerciseCount,
                      spo2Pct, skinTempDevC, respRateBpm, steps, activeKcalEst,
-                     spo2Red, spo2Ir, avgSdnn)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     spo2Red, spo2Ir, avgSdnn, skinTempC)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(deviceId, day) DO UPDATE SET
                     totalSleepMin = excluded.totalSleepMin,
                     efficiency = excluded.efficiency,
@@ -437,13 +451,14 @@ extension WhoopStore {
                     activeKcalEst = excluded.activeKcalEst,
                     spo2Red = excluded.spo2Red,
                     spo2Ir = excluded.spo2Ir,
-                    avgSdnn = excluded.avgSdnn
+                    avgSdnn = excluded.avgSdnn,
+                    skinTempC = excluded.skinTempC
                 """, arguments: [deviceId, d.day, d.totalSleepMin, d.efficiency, d.deepMin,
                                  d.remMin, d.lightMin, d.disturbances, d.restingHr, d.avgHrv,
                                  d.recovery, d.strain, d.exerciseCount,
                                  d.spo2Pct, d.skinTempDevC, d.respRateBpm,
                                  d.steps, d.activeKcalEst,
-                                 d.spo2Red, d.spo2Ir, d.avgSdnn])
+                                 d.spo2Red, d.spo2Ir, d.avgSdnn, d.skinTempC])
             n += db.changesCount
         }
         return n
@@ -494,7 +509,7 @@ extension WhoopStore {
                 SELECT day, totalSleepMin, efficiency, deepMin, remMin, lightMin, disturbances,
                        restingHr, avgHrv, recovery, strain, exerciseCount,
                        spo2Pct, skinTempDevC, respRateBpm, steps, activeKcalEst,
-                       spo2Red, spo2Ir, avgSdnn FROM dailyMetric
+                       spo2Red, spo2Ir, avgSdnn, skinTempC FROM dailyMetric
                 WHERE deviceId = ? AND day >= ? AND day <= ?
                 ORDER BY day ASC
                 """, arguments: [deviceId, from, to])
@@ -508,7 +523,8 @@ extension WhoopStore {
                                 spo2Pct: $0["spo2Pct"], skinTempDevC: $0["skinTempDevC"],
                                 respRateBpm: $0["respRateBpm"],
                                 steps: $0["steps"], activeKcalEst: $0["activeKcalEst"],
-                                spo2Red: $0["spo2Red"], spo2Ir: $0["spo2Ir"], avgSdnn: $0["avgSdnn"])
+                                spo2Red: $0["spo2Red"], spo2Ir: $0["spo2Ir"], avgSdnn: $0["avgSdnn"],
+                                skinTempC: $0["skinTempC"])
                 }
         }
     }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/DailySkinTempAbsoluteTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/DailySkinTempAbsoluteTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+import GRDB
+@testable import WhoopStore
+
+/// v40 (#1636): the nightly ABSOLUTE skin temperature, kept beside the deviation derived from it.
+///
+/// The engine computed this mean on every pass and discarded it once `skinTempDevC` was taken, so a
+/// wearer saw "+0.5 Δ°C" with no way to learn what it moved from. Twin of the Kotlin
+/// `DailySkinTempAbsoluteMigrationTest` (v33 → v34).
+final class DailySkinTempAbsoluteTests: XCTestCase {
+
+    func testV40SkinTempAbsoluteColumnPresent() async throws {
+        let store = try await WhoopStore.inMemory()
+        let cols = try await store.columnNamesForTest(table: "dailyMetric")
+        XCTAssertTrue(cols.contains("skinTempC"), "dailyMetric missing v40 skinTempC column")
+        // The deviation column is untouched: every existing gate (illness, Charge) still reads it.
+        XCTAssertTrue(cols.contains("skinTempDevC"), "v40 must not disturb skinTempDevC")
+    }
+
+    func testV40RoundTripKeepsAbsoluteAndDeviationDistinct() async throws {
+        let store = try await WhoopStore.inMemory()
+        // A febrile night from the report: 34.6 °C absolute, a deviation that reads as barely anything.
+        let d = DailyMetric(day: "2026-08-14", totalSleepMin: 415, efficiency: 0.9,
+                            deepMin: 88, remMin: 108, lightMin: 219, disturbances: 2,
+                            restingHr: 50, avgHrv: 62.0, recovery: 0.06, strain: 10.5,
+                            exerciseCount: 1, spo2Pct: 96.2, skinTempDevC: 0.52, respRateBpm: 14.7,
+                            steps: 7_900, activeKcalEst: 2_180.0, avgSdnn: 88.4, skinTempC: 34.6)
+        try await store.upsertDailyMetrics([d], deviceId: "devA")
+
+        let rows = try await store.dailyMetrics(deviceId: "devA", from: "2026-08-01", to: "2026-08-31")
+        XCTAssertEqual(rows.count, 1)
+        let row = try XCTUnwrap(rows.first)
+        XCTAssertEqual(try XCTUnwrap(row.skinTempC), 34.6, accuracy: 0.001,
+                       "the absolute must survive the round trip")
+        XCTAssertEqual(try XCTUnwrap(row.skinTempDevC), 0.52, accuracy: 0.001,
+                       "the deviation must persist independently of the absolute")
+    }
+
+    func testOmittingTheAbsoluteKeepsItNil() async throws {
+        let store = try await WhoopStore.inMemory()
+        // Every pre-#1636 call site omits it (defaulted init), and a night scored before v40 has no
+        // absolute to report. Nil, never a fabricated 0.0 — which would read as a real temperature.
+        let bare = DailyMetric(day: "2026-08-15", totalSleepMin: nil, efficiency: nil,
+                               deepMin: nil, remMin: nil, lightMin: nil, disturbances: nil,
+                               restingHr: nil, avgHrv: 55.0, recovery: nil, strain: nil,
+                               exerciseCount: nil, skinTempDevC: 0.1)
+        try await store.upsertDailyMetrics([bare], deviceId: "devA")
+        let rows = try await store.dailyMetrics(deviceId: "devA", from: "2026-08-15", to: "2026-08-15")
+        let row = try XCTUnwrap(rows.first)
+        XCTAssertNil(row.skinTempC, "an unscored night must not claim a temperature")
+        XCTAssertEqual(try XCTUnwrap(row.skinTempDevC), 0.1, accuracy: 0.001)
+    }
+
+    /// An upsert over an existing day must not blank a previously-stored absolute by omission — the
+    /// DO UPDATE list has to carry the column or a later cache write silently erases it.
+    func testUpsertOverAnExistingDayUpdatesTheAbsolute() async throws {
+        let store = try await WhoopStore.inMemory()
+        let first = DailyMetric(day: "2026-08-20", totalSleepMin: 400, efficiency: 0.9,
+                                deepMin: 80, remMin: 100, lightMin: 220, disturbances: 1,
+                                restingHr: 51, avgHrv: 60.0, recovery: 0.7, strain: 9.0,
+                                exerciseCount: 0, skinTempC: 33.9)
+        try await store.upsertDailyMetrics([first], deviceId: "devA")
+        let second = DailyMetric(day: "2026-08-20", totalSleepMin: 400, efficiency: 0.9,
+                                 deepMin: 80, remMin: 100, lightMin: 220, disturbances: 1,
+                                 restingHr: 51, avgHrv: 60.0, recovery: 0.7, strain: 9.0,
+                                 exerciseCount: 0, skinTempC: 34.4)
+        try await store.upsertDailyMetrics([second], deviceId: "devA")
+        let rows = try await store.dailyMetrics(deviceId: "devA", from: "2026-08-20", to: "2026-08-20")
+        XCTAssertEqual(rows.count, 1, "same (deviceId, day) must not duplicate")
+        XCTAssertEqual(try XCTUnwrap(rows.first?.skinTempC), 34.4, accuracy: 0.001,
+                       "a re-score must be able to correct the stored absolute")
+    }
+}

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
@@ -1,6 +1,6 @@
 {
   "_readme": "SHARED Room<->GRDB SCHEMA ORACLE (#775). Two byte-identical copies: Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json and android/app/src/test/resources/schema_oracle.json. SchemaOracleTests.swift compares GRDB's PRAGMA table_info/index_list against it; SchemaOracleTest.kt compares Room's exported schema JSON against it. `columns` is the iOS/GRDB shape in GRDB column order (macOS is the reference implementation); every way Android differs is spelled out in an `android` / `iosAbsent` / `androidColumnOrder` override naming a key in `divergenceReasons`. Adding a column, reordering one, or changing a type/nullability on one platform only fails both suites until it is either fixed or written down here.",
-  "roomVersion": 33,
+  "roomVersion": 34,
   "grdbMigrations": [
     "v1",
     "v2",
@@ -40,17 +40,18 @@
     "v36-whoop-caps-no-spo2",
     "v37-daily-avg-sdnn",
     "v38-apple-step-hour",
-    "v39-ppg-burst-index"
+    "v39-ppg-burst-index",
+    "v40-daily-skin-temp-absolute"
   ],
   "divergenceReasons": {
-    "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android \u2014 the per-row upload flag belongs to an upload path that does not exist there \u2014 so it is dead width, not divergent data. Removing it needs a Room table rebuild.",
-    "battery-alter-append-order": "REAL COLUMN-ORDER DRIFT (CLAUDE.md: 'column order in a Room CREATE TABLE must match the entity field order'). GRDB appended `synced` (v5) then `charging` (v6) with ALTER TABLE, which can only append; the Room entity declares `charging` before `synced`. Same columns, same types, different positions \u2014 so any positional copy (INSERT INTO battery SELECT * FROM \u2026) swaps them. Fixing it means reordering the Room entity's fields, which changes Room's identity hash and therefore needs a version bump plus a no-op migration.",
+    "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android — the per-row upload flag belongs to an upload path that does not exist there — so it is dead width, not divergent data. Removing it needs a Room table rebuild.",
+    "battery-alter-append-order": "REAL COLUMN-ORDER DRIFT (CLAUDE.md: 'column order in a Room CREATE TABLE must match the entity field order'). GRDB appended `synced` (v5) then `charging` (v6) with ALTER TABLE, which can only append; the Room entity declares `charging` before `synced`. Same columns, same types, different positions — so any positional copy (INSERT INTO battery SELECT * FROM …) swaps them. Fixing it means reordering the Room entity's fields, which changes Room's identity hash and therefore needs a version bump plus a no-op migration.",
     "grdb-boolean-affinity": "GRDB's .boolean column type is declared BOOLEAN, which SQLite gives NUMERIC affinity; Room maps Kotlin Boolean to INTEGER. For the 0/1 values both sides write, NUMERIC and INTEGER affinity store bit-identical INTEGERs, so a .noopbak round-trips. Closing it means a GRDB table rebuild.",
     "paired-device-alter-append-order": "REAL COLUMN-ORDER DRIFT, same shape as battery. GRDB's v16-paired-device-peripheral appended `peripheralId` at the end; the Room entity declares it fifth, between `nickname` and `sourceKind`.",
-    "ppg-hr-bpm-integer-on-android": "AFFINITY DRIFT, and NOT a data consequence: ppgHrSample.bpm is declared REAL on iOS and INTEGER on Android \u2014 but only the SQLITE COLUMN differs. The ROW type is `Int` on both sides: Swift's `PpgHrSample.bpm` is `Int`, carrying the comment 'the same Int domain as the measured HRSample.bpm and the Android PpgHr.Estimate.bpm, so the stored value and type match across platforms (#219)'. Both platforms also round to whole bpm before that \u2014 Swift `(fsD * 60 / refinedLag).rounded()` then `Int(est.bpm)`, Kotlin `Math.round(fsD * 60 / refinedLag).toInt()` \u2014 and the read path (`CAST(ROUND(p.bpm) AS INTEGER)`) rounds again, a no-op on a whole number. There is one writer and one construction site on each side. So REAL holds the same whole numbers INTEGER does and NO value differs. Recorded because the DECLARED affinity genuinely diverges, and a bpm that ever became fractional would then diverge silently; closing it means a GRDB table rebuild. Deliberately NOT the decoder-oracle (#869) class \u2014 that caught a real value divergence.",
-    "room-omits-sql-default": "GRDB declares these columns NOT NULL DEFAULT 0; Room emits NOT NULL with no SQL DEFAULT, because a Kotlin constructor default never reaches the schema (only @ColumnInfo(defaultValue=) does). Both sides are NOT NULL and both always name the column on insert, so no row differs; an INSERT that omitted the column would fail on Android and get 0 on iOS. Closing it means adding @ColumnInfo(defaultValue = \"0\") plus a Room version bump, since the generated CREATE TABLE \u2014 and therefore Room's identity hash \u2014 changes.",
+    "ppg-hr-bpm-integer-on-android": "AFFINITY DRIFT, and NOT a data consequence: ppgHrSample.bpm is declared REAL on iOS and INTEGER on Android — but only the SQLITE COLUMN differs. The ROW type is `Int` on both sides: Swift's `PpgHrSample.bpm` is `Int`, carrying the comment 'the same Int domain as the measured HRSample.bpm and the Android PpgHr.Estimate.bpm, so the stored value and type match across platforms (#219)'. Both platforms also round to whole bpm before that — Swift `(fsD * 60 / refinedLag).rounded()` then `Int(est.bpm)`, Kotlin `Math.round(fsD * 60 / refinedLag).toInt()` — and the read path (`CAST(ROUND(p.bpm) AS INTEGER)`) rounds again, a no-op on a whole number. There is one writer and one construction site on each side. So REAL holds the same whole numbers INTEGER does and NO value differs. Recorded because the DECLARED affinity genuinely diverges, and a bpm that ever became fractional would then diverge silently; closing it means a GRDB table rebuild. Deliberately NOT the decoder-oracle (#869) class — that caught a real value divergence.",
+    "room-omits-sql-default": "GRDB declares these columns NOT NULL DEFAULT 0; Room emits NOT NULL with no SQL DEFAULT, because a Kotlin constructor default never reaches the schema (only @ColumnInfo(defaultValue=) does). Both sides are NOT NULL and both always name the column on insert, so no row differs; an INSERT that omitted the column would fail on Android and get 0 on iOS. Closing it means adding @ColumnInfo(defaultValue = \"0\") plus a Room version bump, since the generated CREATE TABLE — and therefore Room's identity hash — changes.",
     "sqlite-text-pk-nullable": "GRDB writes `id TEXT PRIMARY KEY`; SQLite's legacy quirk leaves a non-INTEGER PRIMARY KEY column NULLable, so PRAGMA reports notnull=0. Room writes `id TEXT NOT NULL, PRIMARY KEY(id)`. Every writer on both platforms supplies a non-null id, so no stored row differs. Closing it means a GRDB table rebuild.",
-    "workout-route-polyline-android-only": "REAL COLUMN DRIFT \u2014 literally the case #775 was filed about: `workout.routePolyline` (encoded GPS route) was added by Room MIGRATION_3_4 and has no GRDB twin. A .noopbak exported from Android carries a column iOS's `workout` table cannot receive."
+    "workout-route-polyline-android-only": "REAL COLUMN DRIFT — literally the case #775 was filed about: `workout.routePolyline` (encoded GPS route) was added by Room MIGRATION_3_4 and has no GRDB twin. A .noopbak exported from Android carries a column iOS's `workout` table cannot receive."
   },
   "tables": {
     "appleDaily": {
@@ -364,6 +365,12 @@
           "affinity": "REAL",
           "notNull": false,
           "default": null
+        },
+        {
+          "name": "skinTempC",
+          "affinity": "REAL",
+          "notNull": false,
+          "default": null
         }
       ],
       "primaryKey": [
@@ -483,7 +490,7 @@
     },
     "dismissedWorkout": {
       "platform": "android_only",
-      "reason": "Durable 'this detected bout is not a workout' marker (#107, Room MIGRATION_4_5). macOS persists the equivalent as a UserDefaults span list because its read model cannot add a column to the shared workout struct \u2014 documented on the entity, not drift.",
+      "reason": "Durable 'this detected bout is not a workout' marker (#107, Room MIGRATION_4_5). macOS persists the equivalent as a UserDefaults span list because its read model cannot add a column to the shared workout struct — documented on the entity, not drift.",
       "columns": [
         {
           "name": "deviceId",

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1791,7 +1791,11 @@ final class IntelligenceEngine: ObservableObject {
                     hrRows: owned?.hrRows ?? 0, importedWhoop: importedWhoopDays.contains(daily.day),
                     importedApple: appleHealthDays.contains(daily.day)), .universal)
             }
-            dailies.append(daily.with(recovery: recovery, skinTempDevC: skinDev))
+            // Persist the ABSOLUTE beside the deviation derived from it (#1636). Same value, same pass,
+            // same `night.nightlySkin` the line above takes the deviation from — so the two can never
+            // describe different nights, and no second derivation exists to drift.
+            dailies.append(daily.with(recovery: recovery, skinTempDevC: skinDev,
+                                      skinTempC: night.nightlySkin))
             if let rest = AnalyticsEngine.Rest.composite(daily: daily) {
                 restPoints.append(MetricPoint(day: daily.day, key: "sleep_performance", value: rest))
             }
@@ -1905,7 +1909,8 @@ final class IntelligenceEngine: ObservableObject {
         let appleByDay = Dictionary(appleRows.map { ($0.day, $0) }, uniquingKeysWith: { a, _ in a })
         for w in watchScored {
             guard let recovery = w.recovery, let row = appleByDay[w.day] else { continue }
-            appleRecoveryRows.append(row.with(recovery: recovery, skinTempDevC: row.skinTempDevC))
+            appleRecoveryRows.append(row.with(recovery: recovery, skinTempDevC: row.skinTempDevC,
+                                              skinTempC: row.skinTempC))
             // Surface the watch-only day in the By-Day list with its watch provenance + confidence.
             out.append(Computed(day: w.day, recovery: recovery, strain: row.strain,
                                 sleepMin: row.totalSleepMin, hrv: row.avgHrv, rhr: row.restingHr,
@@ -1954,7 +1959,8 @@ final class IntelligenceEngine: ObservableObject {
             let byDay = Dictionary(rows.map { ($0.day, $0) }, uniquingKeysWith: { a, _ in a })
             for w in Self.watchRecoveries(appleRows: rows, strapRecoveryDays: importScoredDays) {
                 guard let recovery = w.recovery, let row = byDay[w.day] else { continue }
-                let scored = row.with(recovery: recovery, skinTempDevC: row.skinTempDevC)
+                let scored = row.with(recovery: recovery, skinTempDevC: row.skinTempDevC,
+                                      skinTempC: row.skinTempC)
                 dailies.append(scored)
                 importScoredDays.insert(w.day)
                 resolvedScoreOwnerByDay[w.day] = source
@@ -2792,13 +2798,13 @@ final class IntelligenceEngine: ObservableObject {
 private extension DailyMetric {
     /// Rebuild the immutable DailyMetric with a substituted recovery + skin-temp deviation
     /// (the struct has no `copy()`). (#78)
-    func with(recovery r: Double?, skinTempDevC sd: Double?) -> DailyMetric {
+    func with(recovery r: Double?, skinTempDevC sd: Double?, skinTempC sa: Double?) -> DailyMetric {
         DailyMetric(day: day, totalSleepMin: totalSleepMin, efficiency: efficiency, deepMin: deepMin,
                     remMin: remMin, lightMin: lightMin, disturbances: disturbances, restingHr: restingHr,
                     avgHrv: avgHrv, recovery: r, strain: strain, exerciseCount: exerciseCount,
                     spo2Pct: spo2Pct, skinTempDevC: sd, respRateBpm: respRateBpm,
                     steps: steps, activeKcalEst: activeKcalEst,
-                    spo2Red: spo2Red, spo2Ir: spo2Ir, avgSdnn: avgSdnn)
+                    spo2Red: spo2Red, spo2Ir: spo2Ir, avgSdnn: avgSdnn, skinTempC: sa)
     }
 
     /// Rebuild with substituted sleep-derived fields (a user-corrected wake window), leaving every
@@ -2809,7 +2815,8 @@ private extension DailyMetric {
                     disturbances: disturbances, restingHr: restingHr, avgHrv: avgHrv, recovery: recovery,
                     strain: strain, exerciseCount: exerciseCount, spo2Pct: spo2Pct,
                     skinTempDevC: skinTempDevC, respRateBpm: respRateBpm, steps: steps,
-                    activeKcalEst: activeKcalEst, spo2Red: spo2Red, spo2Ir: spo2Ir, avgSdnn: avgSdnn)
+                    activeKcalEst: activeKcalEst, spo2Red: spo2Red, spo2Ir: spo2Ir, avgSdnn: avgSdnn,
+                    skinTempC: skinTempC)
     }
 }
 

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -2795,7 +2795,10 @@ final class IntelligenceEngine: ObservableObject {
     }
 }
 
-private extension DailyMetric {
+// `internal`, not `private`: the two `with(...)` rebuilds below are the seams a new DailyMetric column
+// is most easily dropped at (they respell every field by name), so StrandTests asserts them directly
+// rather than through a copy that could drift. Nothing outside this module can see them either way.
+extension DailyMetric {
     /// Rebuild the immutable DailyMetric with a substituted recovery + skin-temp deviation
     /// (the struct has no `copy()`). (#78)
     func with(recovery r: Double?, skinTempDevC sd: Double?, skinTempC sa: Double?) -> DailyMetric {

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -317,7 +317,10 @@ final class Repository: ObservableObject {
             steps: winner.steps ?? filler.steps,
             activeKcalEst: winner.activeKcalEst ?? filler.activeKcalEst,
             spo2Red: rawSpo2FromFiller ? filler.spo2Red : winner.spo2Red,
-            spo2Ir: rawSpo2FromFiller ? filler.spo2Ir : winner.spo2Ir
+            spo2Ir: rawSpo2FromFiller ? filler.spo2Ir : winner.spo2Ir,
+            // Strap-only, like raw SpO2: an imported winner carries no absolute skin temp, so take the
+            // filler's rather than let the union blank a value the strap did record (#1636).
+            skinTempC: winner.skinTempC ?? filler.skinTempC
         )
     }
 
@@ -936,7 +939,8 @@ final class Repository: ObservableObject {
                         steps: steps,
                         activeKcalEst: existing.activeKcalEst,
                         spo2Red: existing.spo2Red,
-                        spo2Ir: existing.spo2Ir
+                        spo2Ir: existing.spo2Ir,
+                        skinTempC: existing.skinTempC
                     )
                 }
             } else {
@@ -3073,7 +3077,10 @@ private extension DailyMetric {
             // backfilled from the computed fallback — otherwise the nightly means would be lost. (#93)
             spo2Red: spo2Red ?? fallback.spo2Red,
             spo2Ir: spo2Ir ?? fallback.spo2Ir,
-            avgSdnn: avgSdnn ?? fallback.avgSdnn
+            avgSdnn: avgSdnn ?? fallback.avgSdnn,
+            // On-device only (imports never carry it), so an imported row's nil is backfilled from the
+            // computed fallback — otherwise the night's absolute would be lost. (#1636)
+            skinTempC: skinTempC ?? fallback.skinTempC
         )
     }
 
@@ -3102,7 +3109,8 @@ private extension DailyMetric {
             activeKcalEst: activeKcalEst,
             spo2Red: spo2Red,   // non-sleep field: preserved as-is (#93)
             spo2Ir: spo2Ir,
-            avgSdnn: avgSdnn    // non-sleep (HRV) field: preserved as-is
+            avgSdnn: avgSdnn,   // non-sleep (HRV) field: preserved as-is
+            skinTempC: skinTempC // non-sleep (thermal) field: preserved as-is (#1636)
         )
     }
 }

--- a/StrandTests/DailySkinTempAbsoluteCarryTests.swift
+++ b/StrandTests/DailySkinTempAbsoluteCarryTests.swift
@@ -9,7 +9,9 @@ import WhoopStore
 /// omission rather than by a compile error — a value that persists correctly and then disappears on the
 /// way to being read, which no migration test would catch.
 ///
-/// Twin of the Kotlin `DailySkinTempAbsoluteCarryTest`.
+/// Twin of the Kotlin `DailySkinTempAbsoluteCarryTest`, with two tests that have no Kotlin counterpart:
+/// the `with(...)` rebuild helpers are a Swift-only shape (Kotlin's data-class `copy` carries every field
+/// automatically, so there is no equivalent seam to drop a column at).
 final class DailySkinTempAbsoluteCarryTests: XCTestCase {
 
     private func row(day: String = "2026-08-25",
@@ -49,6 +51,18 @@ final class DailySkinTempAbsoluteCarryTests: XCTestCase {
                                  deepMin: 80, remMin: 100, lightMin: 220)
         XCTAssertEqual(try XCTUnwrap(edited.skinTempC), 34.6, accuracy: 0.001,
                        "editing the sleep window must not discard the night's temperature")
+    }
+
+    /// Cross-bucket: imports win the row, but the absolute is on-device only, so the computed value
+    /// has to come through or a user with any WHOOP-export history would never see one.
+    func testMergeFillsTheAbsoluteFromTheComputedRow() {
+        let imported = [row(skinTempDevC: 0.2)]
+        let computed = [row(skinTempC: 34.6, skinTempDevC: 0.2)]
+        let merged = Repository.mergeDaily(imported: imported, computed: computed)
+        XCTAssertEqual(merged.count, 1)
+        XCTAssertEqual(try XCTUnwrap(merged.first?.skinTempC), 34.6, accuracy: 0.001)
+        // And the deviation every downstream gate reads is untouched by carrying the absolute.
+        XCTAssertEqual(try XCTUnwrap(merged.first?.skinTempDevC), 0.2, accuracy: 0.001)
     }
 
     /// Re-scoring writes both thermal values together; neither may clobber the other.

--- a/StrandTests/DailySkinTempAbsoluteCarryTests.swift
+++ b/StrandTests/DailySkinTempAbsoluteCarryTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+import WhoopStore
+@testable import Strand
+
+/// The nightly absolute (#1636) must survive every path that REBUILDS a `DailyMetric`.
+///
+/// The column is written once, on the scoring pass, and then carried by separate merges before it
+/// reaches a screen. Each of those spells its fields out by name, so a new column is dropped by
+/// omission rather than by a compile error — a value that persists correctly and then disappears on the
+/// way to being read, which no migration test would catch.
+///
+/// Twin of the Kotlin `DailySkinTempAbsoluteCarryTest`.
+final class DailySkinTempAbsoluteCarryTests: XCTestCase {
+
+    private func row(day: String = "2026-08-25",
+                     skinTempC: Double? = nil,
+                     skinTempDevC: Double? = nil,
+                     avgHrv: Double? = nil) -> DailyMetric {
+        DailyMetric(day: day, totalSleepMin: nil, efficiency: nil, deepMin: nil, remMin: nil,
+                    lightMin: nil, disturbances: nil, restingHr: nil, avgHrv: avgHrv,
+                    recovery: nil, strain: nil, exerciseCount: nil,
+                    skinTempDevC: skinTempDevC, skinTempC: skinTempC)
+    }
+
+    /// An imported winner carries no absolute, so the computed filler's must survive the coalesce.
+    func testCoalesceTakesTheStrapAbsoluteWhenTheWinnerHasNone() {
+        let winner = row(skinTempDevC: 0.2, avgHrv: 44.0)      // an import: deviation only
+        let filler = row(skinTempC: 34.6, skinTempDevC: 0.2)   // the strap's own scored night
+        XCTAssertEqual(try XCTUnwrap(Repository.coalesceDay(winner, filler).skinTempC),
+                       34.6, accuracy: 0.001)
+    }
+
+    /// A winner that HAS one keeps it — the filler must never overwrite a measured value.
+    func testCoalesceKeepsTheWinnersOwnAbsolute() {
+        let winner = row(skinTempC: 34.6)
+        let filler = row(skinTempC: 30.1)
+        XCTAssertEqual(try XCTUnwrap(Repository.coalesceDay(winner, filler).skinTempC),
+                       34.6, accuracy: 0.001)
+    }
+
+    func testCoalesceLeavesItNilWhenNeitherSideMeasuredOne() {
+        XCTAssertNil(Repository.coalesceDay(row(), row()).skinTempC)
+    }
+
+    /// The sleep-edit rebuild replaces only sleep-derived fields; a thermal column must ride through.
+    func testASleepEditKeepsTheNightsAbsolute() {
+        let scored = row(skinTempC: 34.6, skinTempDevC: 0.2)
+        let edited = scored.with(totalSleepMin: 400, efficiency: 0.93,
+                                 deepMin: 80, remMin: 100, lightMin: 220)
+        XCTAssertEqual(try XCTUnwrap(edited.skinTempC), 34.6, accuracy: 0.001,
+                       "editing the sleep window must not discard the night's temperature")
+    }
+
+    /// Re-scoring writes both thermal values together; neither may clobber the other.
+    func testScoringWritesTheAbsoluteAndDeviationTogether() {
+        let scored = row().with(recovery: 0.71, skinTempDevC: 0.52, skinTempC: 34.6)
+        XCTAssertEqual(try XCTUnwrap(scored.skinTempC), 34.6, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(scored.skinTempDevC), 0.52, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(scored.recovery), 0.71, accuracy: 0.001)
+    }
+}

--- a/StrandTests/DailySkinTempAbsoluteCarryTests.swift
+++ b/StrandTests/DailySkinTempAbsoluteCarryTests.swift
@@ -25,7 +25,7 @@ final class DailySkinTempAbsoluteCarryTests: XCTestCase {
     }
 
     /// An imported winner carries no absolute, so the computed filler's must survive the coalesce.
-    func testCoalesceTakesTheStrapAbsoluteWhenTheWinnerHasNone() {
+    func testCoalesceTakesTheStrapAbsoluteWhenTheWinnerHasNone() throws {
         let winner = row(skinTempDevC: 0.2, avgHrv: 44.0)      // an import: deviation only
         let filler = row(skinTempC: 34.6, skinTempDevC: 0.2)   // the strap's own scored night
         XCTAssertEqual(try XCTUnwrap(Repository.coalesceDay(winner, filler).skinTempC),
@@ -33,7 +33,7 @@ final class DailySkinTempAbsoluteCarryTests: XCTestCase {
     }
 
     /// A winner that HAS one keeps it — the filler must never overwrite a measured value.
-    func testCoalesceKeepsTheWinnersOwnAbsolute() {
+    func testCoalesceKeepsTheWinnersOwnAbsolute() throws {
         let winner = row(skinTempC: 34.6)
         let filler = row(skinTempC: 30.1)
         XCTAssertEqual(try XCTUnwrap(Repository.coalesceDay(winner, filler).skinTempC),
@@ -45,7 +45,7 @@ final class DailySkinTempAbsoluteCarryTests: XCTestCase {
     }
 
     /// The sleep-edit rebuild replaces only sleep-derived fields; a thermal column must ride through.
-    func testASleepEditKeepsTheNightsAbsolute() {
+    func testASleepEditKeepsTheNightsAbsolute() throws {
         let scored = row(skinTempC: 34.6, skinTempDevC: 0.2)
         let edited = scored.with(totalSleepMin: 400, efficiency: 0.93,
                                  deepMin: 80, remMin: 100, lightMin: 220)
@@ -55,7 +55,7 @@ final class DailySkinTempAbsoluteCarryTests: XCTestCase {
 
     /// Cross-bucket: imports win the row, but the absolute is on-device only, so the computed value
     /// has to come through or a user with any WHOOP-export history would never see one.
-    func testMergeFillsTheAbsoluteFromTheComputedRow() {
+    func testMergeFillsTheAbsoluteFromTheComputedRow() throws {
         let imported = [row(skinTempDevC: 0.2)]
         let computed = [row(skinTempC: 34.6, skinTempDevC: 0.2)]
         let merged = Repository.mergeDaily(imported: imported, computed: computed)
@@ -66,7 +66,7 @@ final class DailySkinTempAbsoluteCarryTests: XCTestCase {
     }
 
     /// Re-scoring writes both thermal values together; neither may clobber the other.
-    func testScoringWritesTheAbsoluteAndDeviationTogether() {
+    func testScoringWritesTheAbsoluteAndDeviationTogether() throws {
         let scored = row().with(recovery: 0.71, skinTempDevC: 0.52, skinTempC: 34.6)
         XCTAssertEqual(try XCTUnwrap(scored.skinTempC), 34.6, accuracy: 0.001)
         XCTAssertEqual(try XCTUnwrap(scored.skinTempDevC), 0.52, accuracy: 0.001)

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -844,6 +844,10 @@ object AnalyticsEngine {
             spo2Red = nightlySpo2Raw?.first,
             spo2Ir = nightlySpo2Raw?.second,
             avgSdnn = avgSDNNDaily,
+            // The ABSOLUTE this pass's deviation was derived from (#1636). Set HERE, beside
+            // skinTempDevC, so the engine's own row is symmetric: any path that persists this
+            // row directly keeps both thermal values, not just the one.
+            skinTempC = nightlySkinTempC,
         )
 
         // ── Per-score confidence tiers (mirror Swift ScoreConfidence.derive decisions) ──

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1580,7 +1580,7 @@ object IntelligenceEngine {
                 )
             }
             // Stamp the computed source id + the re-scored recovery & skin-temp deviation onto the row.
-            dailies.add(daily.copy(deviceId = computedId, recovery = recovery, skinTempDevC = skinTempDevC))
+            dailies.add(scoredDailyRow(daily, computedId, recovery, skinTempDevC, res.nightlySkinTempC))
             // Map the rich DetectedSleep sessions → Room SleepSession cache rows.
             for (s in res.sleepSessions) {
                 sleepRows.add(
@@ -2529,6 +2529,30 @@ object IntelligenceEngine {
         }
         return rows.isNotEmpty()
     }
+
+    /**
+     * The scored row as persisted: the day's metrics plus this pass's Charge and BOTH thermal values.
+     *
+     * Extracted rather than inlined at the call site because [analyzeRecentOnCpu] sits within ~4 KB of
+     * the 64 KB JVM method ceiling once JaCoCo instruments it (guarded by IntelligenceEngineJacocoBudgetTest,
+     * which caught this addition going 25 bytes over). A named `copy` argument is cheap in source and not
+     * in bytecode; keeping row assembly out of that method is what buys the headroom back.
+     *
+     * The absolute (#1636) is written in the SAME call as the deviation derived from it, so the two can
+     * never describe different nights and no second derivation exists to drift.
+     */
+    private fun scoredDailyRow(
+        daily: DailyMetric,
+        computedId: String,
+        recovery: Double?,
+        skinTempDevC: Double?,
+        skinTempC: Double?,
+    ): DailyMetric = daily.copy(
+        deviceId = computedId,
+        recovery = recovery,
+        skinTempDevC = skinTempDevC,
+        skinTempC = skinTempC,
+    )
 
     private fun recomputeSkinTempDev(nightly: Double?, base: BaselineState?): Double? {
         val v = nightly ?: return null

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -321,6 +321,13 @@ data class DailyMetric(
     // Five-minute SDNN index (ms), separate from avgHrv (RMSSD). Strap rows compute it from in-bed R-R;
     // Apple Health rows mirror the source SDNN. Health Connect RMSSD does not populate this column.
     val avgSdnn: Double? = null,
+    // Nightly ABSOLUTE skin temperature (°C): the wear-gated mean over the night's detected sleep, the
+    // value skinTempDevC is derived FROM (#1636). Appended LAST so the column order matches the Room
+    // CREATE TABLE and the Swift row. Distinct from skinTempDevC, which is bimodal — CSV/Health imports
+    // write an absolute wrist °C into that column and SkinTempDisplay separates them by magnitude. This
+    // one is unambiguous: always absolute, and only the strap pipeline writes it. Nullable: nights scored
+    // before v34 stay null until a re-score re-derives them from the same raw samples.
+    val skinTempC: Double? = null,
 )
 
 /**

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -53,7 +53,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         V18AuxSampleEntity::class,
         AppleStepHour::class,
     ],
-    version = 33,
+    version = 34,
     // #775: ON so Room's KSP processor writes the generated schema (every table's exact `CREATE TABLE`,
     // columns in declaration order with affinity/NOT NULL/default, PK and indices) as JSON. That export
     // is what lets a plain JVM test — no device, no Robolectric — read Android's REAL schema and compare
@@ -70,7 +70,7 @@ abstract class WhoopDatabase : RoomDatabase() {
         const val DB_NAME = "noop_whoop.db"
         /** Room schema version — MUST equal the `@Database(version = …)` above. Surfaced in the backup
          *  manifest (#1410) so an export states its schema. Bump both together on a migration. */
-        const val SCHEMA_VERSION = 33
+        const val SCHEMA_VERSION = 34
 
         @Volatile
         private var instance: WhoopDatabase? = null
@@ -900,6 +900,28 @@ abstract class WhoopDatabase : RoomDatabase() {
         }
 
         /**
+         * #1636: keep the nightly ABSOLUTE skin temperature beside the deviation derived from it.
+         *
+         * The engine computed this mean on every scoring pass and discarded it the moment `skinTempDevC`
+         * was taken, so the app could show "+0.5 Δ°C" with no way to learn what it moved from — and a
+         * febrile night reads as a small delta where the absolute reads as a fever. Nullable and additive:
+         * existing rows stay null and refill on the next scoring pass, because the value is re-derived
+         * from raw `skinTempSample` rows still on disk. No backfill statement, and therefore no second
+         * derivation that could disagree with the live one.
+         *
+         * Twin of the Swift `v40-daily-skin-temp-absolute` GRDB migration.
+         */
+        internal val DAILY_SKIN_TEMP_ABSOLUTE_MIGRATION_SQL: List<String> = listOf(
+            "ALTER TABLE `dailyMetric` ADD COLUMN `skinTempC` REAL",
+        )
+
+        internal val MIGRATION_33_34 = object : Migration(33, 34) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                for (stmt in DAILY_SKIN_TEMP_ABSOLUTE_MIGRATION_SQL) db.execSQL(stmt)
+            }
+        }
+
+        /**
          * Every migration the builder registers, as a VALUE rather than an argument list.
          *
          * It was previously spelled inline in `addMigrations(...)`, which meant nothing could check it. A
@@ -924,7 +946,7 @@ abstract class WhoopDatabase : RoomDatabase() {
             MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
             MIGRATION_22_23, MIGRATION_23_24, MIGRATION_24_25, MIGRATION_25_26,
             MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30,
-            MIGRATION_30_31, MIGRATION_31_32, MIGRATION_32_33,
+            MIGRATION_30_31, MIGRATION_31_32, MIGRATION_32_33, MIGRATION_33_34,
         )
 
 

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -2312,6 +2312,9 @@ class WhoopRepository(
                 restingHr = winner.restingHr ?: filler.restingHr,
                 avgHrv = winner.avgHrv ?: filler.avgHrv,
                 avgSdnn = winner.avgSdnn ?: filler.avgSdnn,
+                // Strap-only, like raw SpO2: an imported winner carries no absolute skin temp, so
+                // take the filler's rather than blank a value the strap did record (#1636).
+                skinTempC = winner.skinTempC ?: filler.skinTempC,
                 recovery = winner.recovery ?: filler.recovery,
                 strain = winner.strain ?: filler.strain,
                 exerciseCount = winner.exerciseCount ?: filler.exerciseCount,
@@ -2414,6 +2417,7 @@ class WhoopRepository(
                     restingHr = d.restingHr ?: c.restingHr,
                     avgHrv = d.avgHrv ?: c.avgHrv,
                     avgSdnn = d.avgSdnn ?: c.avgSdnn,
+                    skinTempC = d.skinTempC ?: c.skinTempC,
                     recovery = d.recovery ?: c.recovery,
                     strain = d.strain ?: c.strain,
                     exerciseCount = d.exerciseCount ?: c.exerciseCount,

--- a/android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/WhoopCsvImporter.kt
@@ -670,6 +670,7 @@ object WhoopCsvImporter {
         restingHr = base.restingHr ?: fill.restingHr,
         avgHrv = base.avgHrv ?: fill.avgHrv,
         avgSdnn = base.avgSdnn ?: fill.avgSdnn,
+        skinTempC = base.skinTempC ?: fill.skinTempC,
         recovery = base.recovery ?: fill.recovery,
         strain = base.strain ?: fill.strain,
         exerciseCount = base.exerciseCount ?: fill.exerciseCount,

--- a/android/app/src/test/java/com/noop/data/DailySdnnMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/DailySdnnMigrationTest.kt
@@ -22,7 +22,11 @@ class DailySdnnMigrationTest {
     fun migrationAndEntityPreserveOldRowsAsNull() {
         assertEquals(31, WhoopDatabase.MIGRATION_31_32.startVersion)
         assertEquals(32, WhoopDatabase.MIGRATION_31_32.endVersion)
-        assertEquals(33, WhoopDatabase.SCHEMA_VERSION)
+        // Not pinned to a literal: this test is about the v31->v32 migration, and re-pinning it on
+        // every later schema bump made an unrelated file part of every migration diff (#1636 was the
+        // third such bump). The chain's END is asserted by WhoopDatabaseMigrationChainTest, which is
+        // where that property belongs.
+        assertTrue(WhoopDatabase.SCHEMA_VERSION >= 32)
         val old = DailyMetric(deviceId = "my-whoop", day = "2026-08-22", avgHrv = 44.0)
         assertNull(old.avgSdnn)
         assertEquals(88.4, old.copy(avgSdnn = 88.4).avgSdnn!!, 0.0)

--- a/android/app/src/test/java/com/noop/data/DailySdnnMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/DailySdnnMigrationTest.kt
@@ -22,11 +22,10 @@ class DailySdnnMigrationTest {
     fun migrationAndEntityPreserveOldRowsAsNull() {
         assertEquals(31, WhoopDatabase.MIGRATION_31_32.startVersion)
         assertEquals(32, WhoopDatabase.MIGRATION_31_32.endVersion)
-        // Not pinned to a literal: this test is about the v31->v32 migration, and re-pinning it on
-        // every later schema bump made an unrelated file part of every migration diff (#1636 was the
-        // third such bump). The chain's END is asserted by WhoopDatabaseMigrationChainTest, which is
-        // where that property belongs.
-        assertTrue(WhoopDatabase.SCHEMA_VERSION >= 32)
+        // No SCHEMA_VERSION assertion here. It used to pin the literal, which made this unrelated file
+        // part of every migration diff; replacing it with a `>= 32` bound would look like coverage while
+        // asserting almost nothing. WhoopDatabaseMigrationChainTest owns that property properly — it
+        // asserts the chain has no holes AND ends exactly at SCHEMA_VERSION.
         val old = DailyMetric(deviceId = "my-whoop", day = "2026-08-22", avgHrv = 44.0)
         assertNull(old.avgSdnn)
         assertEquals(88.4, old.copy(avgSdnn = 88.4).avgSdnn!!, 0.0)

--- a/android/app/src/test/java/com/noop/data/DailySkinTempAbsoluteCarryTest.kt
+++ b/android/app/src/test/java/com/noop/data/DailySkinTempAbsoluteCarryTest.kt
@@ -1,0 +1,63 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The nightly absolute (#1636) must survive every path that REBUILDS a `DailyMetric`.
+ *
+ * The column is written once, on the scoring pass, and then carried by three separate merges before it
+ * reaches a screen. Each of those spells its fields out by name, so a new column is silently dropped by
+ * omission rather than by a compile error — the failure mode is a value that persists correctly and then
+ * disappears on the way to being read, which no migration test would catch.
+ *
+ * Twin of the Swift `DailySkinTempAbsoluteCarryTests`.
+ */
+class DailySkinTempAbsoluteCarryTest {
+
+    private fun row(
+        id: String = "my-whoop",
+        day: String = "2026-08-25",
+        skinTempC: Double? = null,
+        skinTempDevC: Double? = null,
+        avgHrv: Double? = null,
+    ) = DailyMetric(deviceId = id, day = day, skinTempC = skinTempC,
+        skinTempDevC = skinTempDevC, avgHrv = avgHrv)
+
+    /** An imported winner carries no absolute, so the computed filler's must survive the coalesce. */
+    @Test
+    fun coalesceTakesTheStrapAbsoluteWhenTheWinnerHasNone() {
+        val winner = row(skinTempDevC = 0.2, avgHrv = 44.0)          // an import: deviation only
+        val filler = row(skinTempC = 34.6, skinTempDevC = 0.2)       // the strap's own scored night
+        assertEquals(34.6, WhoopRepository.coalesceDay(winner, filler).skinTempC!!, 0.0)
+    }
+
+    /** A winner that HAS one keeps it — the filler must never overwrite a measured value. */
+    @Test
+    fun coalesceKeepsTheWinnersOwnAbsolute() {
+        val winner = row(skinTempC = 34.6)
+        val filler = row(skinTempC = 30.1)
+        assertEquals(34.6, WhoopRepository.coalesceDay(winner, filler).skinTempC!!, 0.0)
+    }
+
+    @Test
+    fun coalesceLeavesItNullWhenNeitherSideMeasuredOne() {
+        assertNull(WhoopRepository.coalesceDay(row(), row()).skinTempC)
+    }
+
+    /**
+     * Cross-bucket: imports win the row, but the absolute is on-device only, so the computed value has to
+     * come through or a user with any WHOOP-export history would never see one.
+     */
+    @Test
+    fun mergeFillsTheAbsoluteFromTheComputedRow() {
+        val imported = listOf(row(id = "my-whoop", skinTempDevC = 0.2))
+        val computed = listOf(row(id = "my-whoop-noop", skinTempC = 34.6, skinTempDevC = 0.2))
+        val merged = WhoopRepository.mergeDaily(imported = imported, computed = computed)
+        assertEquals(1, merged.size)
+        assertEquals(34.6, merged.single().skinTempC!!, 0.0)
+        // And the deviation every downstream gate reads is untouched by carrying the absolute.
+        assertEquals(0.2, merged.single().skinTempDevC!!, 1e-12)
+    }
+}

--- a/android/app/src/test/java/com/noop/data/DailySkinTempAbsoluteMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/DailySkinTempAbsoluteMigrationTest.kt
@@ -1,0 +1,46 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * v33 -> v34 (#1636): the nightly ABSOLUTE skin temperature, kept beside the deviation derived from it.
+ *
+ * Twin of the Swift `v40-daily-skin-temp-absolute` GRDB migration; `MigrationTests.swift` asserts the
+ * same three properties there.
+ */
+class DailySkinTempAbsoluteMigrationTest {
+
+    @Test
+    fun migrationIsOneNullableAdditiveColumn() {
+        val sql = WhoopDatabase.DAILY_SKIN_TEMP_ABSOLUTE_MIGRATION_SQL
+        assertEquals(listOf("ALTER TABLE `dailyMetric` ADD COLUMN `skinTempC` REAL"), sql)
+        val upper = sql.single().uppercase()
+        assertTrue(upper.startsWith("ALTER TABLE"))
+        // Nullable and defaultless on purpose: a night scored before v34 has no absolute, and inventing
+        // one (a DEFAULT, or a backfill statement here) would fabricate a temperature nobody measured.
+        assertTrue(!upper.contains("NOT NULL") && !upper.contains("DEFAULT"))
+        for (banned in listOf("DROP ", "DELETE ", "UPDATE ", "INSERT ", "RENAME ")) {
+            assertTrue("migration must not contain $banned", !upper.contains(banned))
+        }
+    }
+
+    @Test
+    fun migrationSpansTheRightVersions() {
+        assertEquals(33, WhoopDatabase.MIGRATION_33_34.startVersion)
+        assertEquals(34, WhoopDatabase.MIGRATION_33_34.endVersion)
+    }
+
+    @Test
+    fun oldRowsStayNullAndTheColumnIsIndependentOfTheDeviation() {
+        val old = DailyMetric(deviceId = "my-whoop", day = "2026-08-25", skinTempDevC = 0.11)
+        assertNull("a pre-v34 row carries no absolute", old.skinTempC)
+        // The two are separate columns: writing the absolute must not disturb the deviation, because the
+        // deviation is what every existing gate (illness, Charge) reads.
+        val scored = old.copy(skinTempC = 34.6)
+        assertEquals(34.6, scored.skinTempC!!, 0.0)
+        assertEquals(0.11, scored.skinTempDevC!!, 1e-12)
+    }
+}

--- a/android/app/src/test/java/com/noop/data/DailySkinTempAbsoluteMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/DailySkinTempAbsoluteMigrationTest.kt
@@ -8,8 +8,13 @@ import org.junit.Test
 /**
  * v33 -> v34 (#1636): the nightly ABSOLUTE skin temperature, kept beside the deviation derived from it.
  *
- * Twin of the Swift `v40-daily-skin-temp-absolute` GRDB migration; `MigrationTests.swift` asserts the
- * same three properties there.
+ * Twin of the Swift `v40-daily-skin-temp-absolute` GRDB migration.
+ *
+ * This environment has no Robolectric / Room-testing (see [AppleStepHourMigrationTest]), so the SQL is
+ * exposed as an internal constant and pinned to shape here rather than executed. The Swift side CAN open
+ * a store in-memory, so `DailySkinTempAbsoluteTests` additionally round-trips the column and proves a
+ * re-upsert corrects it; those two have no runnable Kotlin counterpart, which is a property of the test
+ * environment and not of the column.
  */
 class DailySkinTempAbsoluteMigrationTest {
 

--- a/android/app/src/test/resources/schema_oracle.json
+++ b/android/app/src/test/resources/schema_oracle.json
@@ -1,6 +1,6 @@
 {
   "_readme": "SHARED Room<->GRDB SCHEMA ORACLE (#775). Two byte-identical copies: Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json and android/app/src/test/resources/schema_oracle.json. SchemaOracleTests.swift compares GRDB's PRAGMA table_info/index_list against it; SchemaOracleTest.kt compares Room's exported schema JSON against it. `columns` is the iOS/GRDB shape in GRDB column order (macOS is the reference implementation); every way Android differs is spelled out in an `android` / `iosAbsent` / `androidColumnOrder` override naming a key in `divergenceReasons`. Adding a column, reordering one, or changing a type/nullability on one platform only fails both suites until it is either fixed or written down here.",
-  "roomVersion": 33,
+  "roomVersion": 34,
   "grdbMigrations": [
     "v1",
     "v2",
@@ -40,17 +40,18 @@
     "v36-whoop-caps-no-spo2",
     "v37-daily-avg-sdnn",
     "v38-apple-step-hour",
-    "v39-ppg-burst-index"
+    "v39-ppg-burst-index",
+    "v40-daily-skin-temp-absolute"
   ],
   "divergenceReasons": {
-    "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android \u2014 the per-row upload flag belongs to an upload path that does not exist there \u2014 so it is dead width, not divergent data. Removing it needs a Room table rebuild.",
-    "battery-alter-append-order": "REAL COLUMN-ORDER DRIFT (CLAUDE.md: 'column order in a Room CREATE TABLE must match the entity field order'). GRDB appended `synced` (v5) then `charging` (v6) with ALTER TABLE, which can only append; the Room entity declares `charging` before `synced`. Same columns, same types, different positions \u2014 so any positional copy (INSERT INTO battery SELECT * FROM \u2026) swaps them. Fixing it means reordering the Room entity's fields, which changes Room's identity hash and therefore needs a version bump plus a no-op migration.",
+    "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android — the per-row upload flag belongs to an upload path that does not exist there — so it is dead width, not divergent data. Removing it needs a Room table rebuild.",
+    "battery-alter-append-order": "REAL COLUMN-ORDER DRIFT (CLAUDE.md: 'column order in a Room CREATE TABLE must match the entity field order'). GRDB appended `synced` (v5) then `charging` (v6) with ALTER TABLE, which can only append; the Room entity declares `charging` before `synced`. Same columns, same types, different positions — so any positional copy (INSERT INTO battery SELECT * FROM …) swaps them. Fixing it means reordering the Room entity's fields, which changes Room's identity hash and therefore needs a version bump plus a no-op migration.",
     "grdb-boolean-affinity": "GRDB's .boolean column type is declared BOOLEAN, which SQLite gives NUMERIC affinity; Room maps Kotlin Boolean to INTEGER. For the 0/1 values both sides write, NUMERIC and INTEGER affinity store bit-identical INTEGERs, so a .noopbak round-trips. Closing it means a GRDB table rebuild.",
     "paired-device-alter-append-order": "REAL COLUMN-ORDER DRIFT, same shape as battery. GRDB's v16-paired-device-peripheral appended `peripheralId` at the end; the Room entity declares it fifth, between `nickname` and `sourceKind`.",
-    "ppg-hr-bpm-integer-on-android": "AFFINITY DRIFT, and NOT a data consequence: ppgHrSample.bpm is declared REAL on iOS and INTEGER on Android \u2014 but only the SQLITE COLUMN differs. The ROW type is `Int` on both sides: Swift's `PpgHrSample.bpm` is `Int`, carrying the comment 'the same Int domain as the measured HRSample.bpm and the Android PpgHr.Estimate.bpm, so the stored value and type match across platforms (#219)'. Both platforms also round to whole bpm before that \u2014 Swift `(fsD * 60 / refinedLag).rounded()` then `Int(est.bpm)`, Kotlin `Math.round(fsD * 60 / refinedLag).toInt()` \u2014 and the read path (`CAST(ROUND(p.bpm) AS INTEGER)`) rounds again, a no-op on a whole number. There is one writer and one construction site on each side. So REAL holds the same whole numbers INTEGER does and NO value differs. Recorded because the DECLARED affinity genuinely diverges, and a bpm that ever became fractional would then diverge silently; closing it means a GRDB table rebuild. Deliberately NOT the decoder-oracle (#869) class \u2014 that caught a real value divergence.",
-    "room-omits-sql-default": "GRDB declares these columns NOT NULL DEFAULT 0; Room emits NOT NULL with no SQL DEFAULT, because a Kotlin constructor default never reaches the schema (only @ColumnInfo(defaultValue=) does). Both sides are NOT NULL and both always name the column on insert, so no row differs; an INSERT that omitted the column would fail on Android and get 0 on iOS. Closing it means adding @ColumnInfo(defaultValue = \"0\") plus a Room version bump, since the generated CREATE TABLE \u2014 and therefore Room's identity hash \u2014 changes.",
+    "ppg-hr-bpm-integer-on-android": "AFFINITY DRIFT, and NOT a data consequence: ppgHrSample.bpm is declared REAL on iOS and INTEGER on Android — but only the SQLITE COLUMN differs. The ROW type is `Int` on both sides: Swift's `PpgHrSample.bpm` is `Int`, carrying the comment 'the same Int domain as the measured HRSample.bpm and the Android PpgHr.Estimate.bpm, so the stored value and type match across platforms (#219)'. Both platforms also round to whole bpm before that — Swift `(fsD * 60 / refinedLag).rounded()` then `Int(est.bpm)`, Kotlin `Math.round(fsD * 60 / refinedLag).toInt()` — and the read path (`CAST(ROUND(p.bpm) AS INTEGER)`) rounds again, a no-op on a whole number. There is one writer and one construction site on each side. So REAL holds the same whole numbers INTEGER does and NO value differs. Recorded because the DECLARED affinity genuinely diverges, and a bpm that ever became fractional would then diverge silently; closing it means a GRDB table rebuild. Deliberately NOT the decoder-oracle (#869) class — that caught a real value divergence.",
+    "room-omits-sql-default": "GRDB declares these columns NOT NULL DEFAULT 0; Room emits NOT NULL with no SQL DEFAULT, because a Kotlin constructor default never reaches the schema (only @ColumnInfo(defaultValue=) does). Both sides are NOT NULL and both always name the column on insert, so no row differs; an INSERT that omitted the column would fail on Android and get 0 on iOS. Closing it means adding @ColumnInfo(defaultValue = \"0\") plus a Room version bump, since the generated CREATE TABLE — and therefore Room's identity hash — changes.",
     "sqlite-text-pk-nullable": "GRDB writes `id TEXT PRIMARY KEY`; SQLite's legacy quirk leaves a non-INTEGER PRIMARY KEY column NULLable, so PRAGMA reports notnull=0. Room writes `id TEXT NOT NULL, PRIMARY KEY(id)`. Every writer on both platforms supplies a non-null id, so no stored row differs. Closing it means a GRDB table rebuild.",
-    "workout-route-polyline-android-only": "REAL COLUMN DRIFT \u2014 literally the case #775 was filed about: `workout.routePolyline` (encoded GPS route) was added by Room MIGRATION_3_4 and has no GRDB twin. A .noopbak exported from Android carries a column iOS's `workout` table cannot receive."
+    "workout-route-polyline-android-only": "REAL COLUMN DRIFT — literally the case #775 was filed about: `workout.routePolyline` (encoded GPS route) was added by Room MIGRATION_3_4 and has no GRDB twin. A .noopbak exported from Android carries a column iOS's `workout` table cannot receive."
   },
   "tables": {
     "appleDaily": {
@@ -364,6 +365,12 @@
           "affinity": "REAL",
           "notNull": false,
           "default": null
+        },
+        {
+          "name": "skinTempC",
+          "affinity": "REAL",
+          "notNull": false,
+          "default": null
         }
       ],
       "primaryKey": [
@@ -483,7 +490,7 @@
     },
     "dismissedWorkout": {
       "platform": "android_only",
-      "reason": "Durable 'this detected bout is not a workout' marker (#107, Room MIGRATION_4_5). macOS persists the equivalent as a UserDefaults span list because its read model cannot add a column to the shared workout struct \u2014 documented on the entity, not drift.",
+      "reason": "Durable 'this detected bout is not a workout' marker (#107, Room MIGRATION_4_5). macOS persists the equivalent as a UserDefaults span list because its read model cannot add a column to the shared workout struct — documented on the entity, not drift.",
       "columns": [
         {
           "name": "deviceId",


### PR DESCRIPTION
Requested by @justinjor-bit in #1636.

## What was wrong

The Skin Temperature screen only ever shows a deviation. `+0.2 Δ°F` today, and nowhere in the app can you learn what it moved from — a number that could be a fever or a warm bedroom, with no anchor to tell them apart. Their flu night read `+0.94 Δ°F`, which looks like nothing; the absolute was `96.4 °F` against a 24-night mean of `94.4 °F`, on the night their recovery scored 6/100.

They were right that the value already exists and is already correct. `wornNightlySkinTempC` computes a wear-gated nightly mean on every scoring pass, the deviation is taken from it, and the absolute is then discarded. It never reaches disk.

## Scope: this is the persistence half

Per the one-concern rule, this PR **keeps** the value; surfacing it is a separate PR. That ordering is deliberate rather than convenient — the column starts filling on the next scoring pass, so by the time any UI reads it users already have populated history instead of an empty column.

No decoding, no new math. The value written is the one the engine already produced.

## The change

- **GRDB v40 / Room v34**: `dailyMetric.skinTempC`, nullable and additive.
- Written in `AnalyticsEngine` beside `skinTempDevC` so the engine's own row is symmetric, and again on the scored row in `IntelligenceEngine` — **at the same line the deviation is written**, from the same `nightlySkinTempC`. The two can never describe different nights, and no second derivation exists to drift.
- Carried through every path that **rebuilds** a row: `coalesceDay`, `mergeDaily`, the CSV importer fill, and both Swift `with()` helpers. Each of those spells its fields out by name, so a new column is dropped by omission rather than by a compile error — a value that persists correctly and then vanishes on the way to being read, which no migration test would catch. That is what most of the test file guards.

## Deliberately not a backfill

The issue proposed a migration that recomputes nightly means from `skinTempSample`. I did not do that, and I think the simpler answer is also the safer one: NOOP already re-scores from raw on every pass (`analyzeRecent(maxDays: 21)`), so existing nights refill themselves. History older than the window needs one wider pass, and `maxDays` is already a parameter.

A migration-time recompute would be a **second implementation of the same mean**, free to disagree with the live one, and it would have to reproduce the per-family raw conversion (#938) — which is exactly the hardware-specific surface @justinjor-bit correctly declined to write blind.

## On the bimodal column

`skinTempDevC` is not purely a deviation: CSV/Health imports write an **absolute** wrist °C into it, and `SkinTempDisplay` separates them by magnitude. The new column is unambiguous — always absolute, only ever written by the strap pipeline. Migrating the importers' absolutes into it would be cleaner still, but that is a data migration with real risk and it is not in this PR.

## Two repo guards fired, and both were right

- **The shared Room↔GRDB schema oracle** (`schema_oracle.json`, two byte-identical copies) needed the version, the migration identifier and the column. It caught the bump immediately.
- **`analyzeRecentOnCpu` sits within ~4 KB of the 64 KB JVM method ceiling** once JaCoCo instruments it. One more named `copy` argument put it **25 bytes over budget**. A named argument is cheap in source and not in bytecode, so the row assembly is extracted to `scoredDailyRow`; the method now measures **61518** against a 61535 budget, with 4017 bytes of margin.

I would not have found either by reading.

## Verification

**10 Swift tests, 7 Kotlin.** Not symmetric, and the gap is the test environment rather than the column: this Android setup has no Robolectric, so Kotlin pins the migration's SQL shape where Swift opens a store and round-trips it (the arrangement `AppleStepHourMigrationTest` already documents). The `with(...)` rebuild helpers are likewise a Swift-only shape — Kotlin's data-class `copy` carries every field, so there is no seam there to drop a column at. Every path that exists on both platforms is tested on both.

- migration shape — one `ALTER TABLE`, nullable, no `DEFAULT`, and no `DROP`/`DELETE`/`UPDATE`/`INSERT`/`RENAME`
- round trip keeps the absolute and the deviation **distinct** on the same row
- an omitted absolute stays `nil`, never a fabricated `0.0` — which would read as a real temperature
- a re-upsert over an existing day can **correct** the stored absolute (the `DO UPDATE` list carries it)
- every rebuild path: coalesce takes the strap's value when an imported winner has none, keeps the winner's own when it has one, stays nil when neither measured one, survives a sleep-window edit, and survives the cross-bucket merge

Plus: Android **4510 tests green**, `compileFullDebugKotlin` clean, `doc_comment_lint` and `i18n_audit --ci` clean. `WhoopStore` and `StrandTests` are macOS-only, so those land via CI and an on-demand `app-build` run — posted below before merge.

Not hardware-dependent; no BLE path touched. Nothing reads the new column as a gate, so illness, Charge and the skin-temp marker all still read `skinTempDevC` exactly as before.
