### PR TITLE
charts: make every scrubbable graph read like the screen around it

### DIFF
--- a/android/app/src/main/java/com/noop/ui/Charts.kt
+++ b/android/app/src/main/java/com/noop/ui/Charts.kt
@@ -548,6 +548,11 @@ fun BarChart(
     // Optional per-point display labels index-aligned with [values]; when supplied, a tap shows
     // "<label> · <value>" (e.g. "16 Jul · 87") instead of the bare value — parity with LineChart (#691).
     selectionLabels: List<String>? = null,
+    // The caller's own value formatter, so the scrub read-out prints what the surrounding screen prints
+    // (#1662). Without one the label falls back to [formatLineValue], which shows a decimal for any
+    // non-integer — so a metric whose headline is rounded answered "72.4" on tap against a "72" beside
+    // it. Same parameter, same default, same fallback as LineChart's.
+    formatValue: ((Double) -> String)? = null,
 ) {
     val cleanValues = remember(values) { values.map { if (it.isFinite() && it > 0.0) it else 0.0 } }
     // cleanValues ZEROES (never drops) non-finite bars, so indices stay aligned with [values] and the
@@ -655,7 +660,7 @@ fun BarChart(
                                 drawText(
                                     lineChartSelectionLabel(
                                         value = clean[selectedIndex],
-                                        formatValue = null,
+                                        formatValue = formatValue,
                                         pointLabel = cleanSelectionLabels?.getOrNull(selectedIndex),
                                     ),
                                     8f, 32f, barLabelPaint,

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -2072,6 +2072,11 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
                     // two are equal in length by construction rather than by luck — `LineChart` drops
                     // mismatched labels SILENTLY, which is a failure that looks exactly like doing nothing.
                     selectionLabels = dayLabels,
+                    // #1662: the metric's OWN formatter AND unit — byte-for-byte what the Min/Avg/Max
+                    // row below renders. Without it the scrub read-out falls back to LineChart's
+                    // default, which prints a decimal for any non-integer, so a rounded metric answered
+                    // "72.4" on tap with "72 ms" written directly underneath.
+                    formatValue = { "${detail.format(it)} ${detail.unit}".trim() },
                     segmentIds = if (key == "vo2max_est") vo2MaxTrendSegmentIds(filteredReadings) else null,
                 )
                 Box(

--- a/android/app/src/main/java/com/noop/ui/SleepMetricCardsUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepMetricCardsUi.kt
@@ -499,6 +499,8 @@ internal fun AsleepDurationHostCard(hours: List<Double>, dates: List<String>) {
                         color = Palette.restColor,
                         selectionEnabled = true,
                         selectionLabels = dates.map(::shortDayLabel),
+                        // #1662: hours with one decimal and the unit, matching the Avg/Min/Max row above.
+                        formatValue = { String.format(Locale.US, "%.1f h", it) },
                     )
                     DateAxisRow(dates)
                 }
@@ -545,6 +547,8 @@ internal fun DurationTrend(m: SleepModel) {
                         // #691: on tap, show the DATE alongside the value (the shared chart's tooltip),
                         // matching the other trend graphs. trendDates is index-aligned with the values.
                         selectionLabels = m.trendDates.map(::shortDayLabel),
+                        // #1662: same hours format as the Avg/Min/Max row above.
+                        formatValue = { String.format(Locale.US, "%.1f h", it) },
                     )
                     DateAxisRow(m.trendDates)
                 }
@@ -579,6 +583,10 @@ internal fun DurationTrend(m: SleepModel) {
                         color = Palette.metricRose,
                         selectionEnabled = true,
                         selectionLabels = m.trendDates.map(::shortDayLabel),   // #691: hover shows date + value
+                        // #1662: debt is shown as a DURATION ("7h 20m") in the card's trailing value and
+                        // its Avg/Max row, so a bare "7.3" on tap was a different unit, not just a
+                        // different precision.
+                        formatValue = { durationText(it * 60.0) },
                     )
                     DateAxisRow(m.trendDates)
                 }

--- a/android/app/src/main/java/com/noop/ui/SleepMetricDetailSheet.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepMetricDetailSheet.kt
@@ -111,6 +111,9 @@ internal fun SleepMetricDetailSheetContent(vm: AppViewModel, key: String) {
                     fill = true,
                     selectionEnabled = true,
                     selectionLabels = filteredPoints.map { shortDayLabel(it.first) },   // #691: hover shows date + value
+                    // #1662: the same `spec.format` + unit the max/avg/min column to the left renders,
+                    // so the tapped point and the column beside it read identically.
+                    formatValue = { "${spec.format(it)} ${spec.unit}".trim() },
                 )
             }
             Row(modifier = Modifier.fillMaxWidth()) {

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -1064,6 +1064,10 @@ private fun StressTrendSection(model: StressModel, modifier: Modifier = Modifier
                         // trend that opted into selection and then had nothing to say but the number.
                         // Both lists map from the one windowed `points`, so they cannot desynchronise.
                         selectionLabels = dayLabels,
+                        // #1662: one decimal, matching the Today/Avg/Peak footer below. The default
+                        // formatter collapses a value within 0.05 of an integer, so a 2.0 stress day
+                        // scrubbed as "2" beside a footer reading "2.0".
+                        formatValue = { String.format(Locale.US, "%.1f", it) },
                     )
                     HorizontalDivider(color = Palette.hairline)
                     Row(modifier = Modifier.fillMaxWidth()) {

--- a/android/app/src/main/java/com/noop/ui/TrendsExploreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TrendsExploreScreen.kt
@@ -667,6 +667,13 @@ private fun HeroChartCard(
                                 fill = true,
                                 selectionEnabled = true,
                                 selectionLabels = windowed.map { prettyExploreDate(it.day) },
+                                // #1662, and here it was worse than a decimal: `values` are the RAW
+                                // stored numbers, and `MetricSpec.format` is what rescales Effort to the
+                                // WHOOP 0–21 axis. The Y labels and the hero went through it; the scrub
+                                // read-out did not — so on that scale the axis said 12.4 and tapping the
+                                // same point said 59. Routing the label through the same formatter makes
+                                // the chart agree with itself.
+                                formatValue = metric::format,
                             )
                             ExploreGlowEndCap(values = values, tipColor = metric.accent)
                         }

--- a/android/app/src/test/java/com/noop/ui/ChartScrubFormatterParityTest.kt
+++ b/android/app/src/test/java/com/noop/ui/ChartScrubFormatterParityTest.kt
@@ -1,0 +1,87 @@
+package com.noop.ui
+
+import java.util.Locale
+import kotlin.math.roundToInt
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * #1662: a metric's scrub read-out must print what the screen around it prints.
+ *
+ * `formatValue` was added for #463, when Trends' Effort chart tapped to the stored 0–100 number beside
+ * a 0–21 axis. Only that call site was wired up, so every other scrubbable chart kept the default —
+ * [lineChartSelectionLabel]'s fallback, which collapses near-integers and otherwise prints one decimal.
+ * The reporter's screenshot is the same defect on the screens #463 never reached: a rounded headline
+ * with a one-decimal graph beneath it.
+ *
+ * These pin the DIVERGENCE (what the default does) beside the FIX (what each injected formatter does),
+ * so a future caller that forgets one has a written statement of what goes wrong.
+ */
+class ChartScrubFormatterParityTest {
+
+    /**
+     * Vital Signs detail: `detail.format` is `it.roundToInt().toString()` for the rounded metrics, and
+     * the screen renders it WITH the unit — the scrub read-out has to match the whole reading, not just
+     * the number, or "62" still disagrees with the "62 ms" beside it.
+     */
+    private val roundedMetric: (Double) -> String = { "${it.roundToInt()} ms".trim() }
+
+    /** Stress: the Today/Avg/Peak footer prints one decimal on the 0–3 scale. */
+    private val stressScore: (Double) -> String = { String.format(Locale.US, "%.1f", it) }
+
+    /** Sleep cards: hours with a unit, matching the Avg/Min/Max row above the bars. */
+    private val sleepHours: (Double) -> String = { String.format(Locale.US, "%.1f h", it) }
+
+    @Test
+    fun theDefaultDisagreesWithARoundedHeadline() {
+        // An HRV of 62.4 is a "62" everywhere on the Vital Signs detail screen except, until now, the
+        // graph — which is exactly what the report shows.
+        assertEquals("62.4", lineChartSelectionLabel(62.4, null))
+        assertEquals("62 ms", lineChartSelectionLabel(62.4, roundedMetric))
+        assertNotEquals(lineChartSelectionLabel(62.4, null), lineChartSelectionLabel(62.4, roundedMetric))
+    }
+
+    @Test
+    fun aRoundedMetricAgreesWithItsGraphAcrossTheRange() {
+        for ((raw, expected) in listOf(62.4 to "62 ms", 72.5 to "73 ms", 99.9 to "100 ms", 0.4 to "0 ms")) {
+            assertEquals(expected, lineChartSelectionLabel(raw, roundedMetric))
+        }
+    }
+
+    /**
+     * The default's near-integer collapse is its own mismatch: it drops the decimal a one-decimal
+     * read-out keeps, so a flat 2.0 stress day scrubbed as "2" beside a footer reading "2.0".
+     */
+    @Test
+    fun theDefaultCollapsesAnExactValueThatTheScreenSpellsOut() {
+        assertEquals("2", lineChartSelectionLabel(2.0, null))
+        assertEquals("2.0", lineChartSelectionLabel(2.0, stressScore))
+    }
+
+    /** Sleep hours carry a unit; the bare number was a different reading, not a rounder one. */
+    @Test
+    fun sleepHoursKeepTheirUnit() {
+        assertEquals("7.3", lineChartSelectionLabel(7.3, null))
+        assertEquals("7.3 h", lineChartSelectionLabel(7.3, sleepHours))
+    }
+
+    /**
+     * Explore was the worst of them: `values` are RAW stored numbers and `MetricSpec.format` is what
+     * rescales Effort to WHOOP's 0–21 axis. The Y labels and the hero went through it and the scrub
+     * read-out did not, so the axis said one number and tapping the same point said another — a
+     * different VALUE, not a different precision. This is the #463 failure, unfixed on that screen.
+     */
+    @Test
+    fun anAxisConvertedMetricDisagreedOnTheValueItself() {
+        val toWhoopScale: (Double) -> String = { UnitFormatter.effortDisplay(it, EffortScale.WHOOP) }
+        assertEquals("59", lineChartSelectionLabel(59.0, null))          // raw, as the chart used to say
+        assertEquals("12.4", lineChartSelectionLabel(59.0, toWhoopScale)) // what the axis says
+    }
+
+    /** A day label still prefixes the formatted value, so #691's date context survives the fix. */
+    @Test
+    fun theDayLabelStillPrefixesTheFormattedValue() {
+        assertEquals("16 Jul · 62 ms", lineChartSelectionLabel(62.4, roundedMetric, pointLabel = "16 Jul"))
+    }
+}


### PR DESCRIPTION
Reported by @bartmuskala in #1662.

## What was wrong

Tapping a graph printed a different number from the metric written beside it. Their screenshot shows a rounded headline over a one-decimal chart.

`LineChart` takes `formatValue: ((Double) -> String)? = null`. When it's null the scrub read-out falls back to `formatLineValue`, which rounds to an integer only if the value is within 0.05 of one and otherwise prints `%.1f`. The Vital Signs detail screen never passed it — even though `detail.format` is right there and drives the Min/Avg/Max row two lines below the chart. Same screen, two formatters, no shared source.

Their list is the accurate half of a clean split. Every metric formatted `it.roundToInt().toString()` disagreed with its own graph — `recovery`, `rhr`, `hrv`, `rest`, `fitness_age`, `vitality`, `vo2max_est`, `steps_est`, `active_kcal`. The three that already agreed (`strain`, `resp`, `skin`) were the ones never rounded.

## This is the unfinished half of #463

`formatValue` exists *because* of that report: Trends' Effort chart tapped to the stored 0–100 figure beside a 0–21 axis. The parameter was added and **only that call site was wired up**. Three of twelve ever passed a formatter; the rest kept the default. So this isn't a new defect, it's the same one on the screens #463 never reached.

## The change

Seven call sites, each given the formatter its own screen already uses beside the chart:

| screen | formatter |
|---|---|
| Vital Signs detail *(reported)* | `detail.format` + unit |
| Explore | `MetricSpec.format` |
| Stress | one decimal, matching the Today/Avg/Peak footer |
| Sleep metric sheet | `spec.format` + unit |
| Sleep hours ×2 | hours with a unit |
| Sleep debt | a duration (`7h 20m`) |

**`BarChart` had no `formatValue` parameter at all** — it hardcoded `null` — so its three scrubbable call sites couldn't be fixed from outside. Added, with the same default and fallback as `LineChart`'s.

## The rule I applied, since the app was already split on it

**Each chart's scrub label matches the read-out beside that chart** — including the unit when that read-out carries one. That is why the vital detail scrubs `62 ms` and Stress scrubs a bare `2.0`.

Worth stating because the existing sites disagree: `TodayScreen` and `SleepScreen` include units (`72 bpm`), `TrendsScreen` does not (its `formatY` is an axis formatter reused for the label, and that chart carries several metrics). I did not touch `TrendsScreen` to force uniformity — a shared axis formatter has a good reason not to carry a unit, and the reporter's complaint was about a graph disagreeing with the screen it sits on, not about cross-screen consistency.

## Explore was worse than a decimal

Its `values` are the **raw** stored numbers, and `MetricSpec.format` is what rescales Effort to WHOOP's 0–21 axis. The Y labels and the hero went through it; the scrub read-out did not. On that scale **the axis said `12.4` and tapping the same point said `59`** — a different value, not a different precision. That is the #463 failure verbatim, still live on that screen.

## A consequence worth naming

A rounded metric now *reads* rounded on tap: HRV scrubs as `62 ms` where it used to say `62.4`. That is the alignment asked for, and the stored value is no more trustworthy than the headline implies — but it is a visible loss of detail, not a pure tidy-up. Someone will notice.

## What I did not change

**The shared default.** A chart with genuinely fractional data still wants its decimal, and after this no scrubbable chart reaches the fallback — verified by walking all twelve call sites, not by assuming. Changing `formatLineValue` would also alter charts where the label is never drawn.

**The reporter's second point** — that Effort deserves a decimal on the 0–21 scale — is already true (`LiquidTodayView` does `decimals: effortScale == .whoop ? 1 : 0`, and #1660 extended the same rule to the trends report). The ask there was consistency, not new precision.

**"stress"** appears in their list but there's no `stress` key in the vital-detail catalogue, so that's a different surface. The Stress screen's own chart is fixed here; if they meant something else I'd want to see which screen.

## iOS parity: the same parameter, wired everywhere

I first assumed iOS was safe because `TrendChart.valueFormat` defaults to a **rounded** int, so a forgotten formatter agrees with a rounded headline rather than contradicting it. That's true about the default and wrong about the reason — iOS never reaches it. Auditing every call site:

- `TrendChart`: **7 of 7** production sites pass `valueFormat`
- `OverviewHRChart`: **2 of 2** (the third is a `#Preview` with synthetic `sin()` data)

So Apple has no instance of this in either direction, not because the fallback is kinder but because the wiring was finished. Android was at **3 of 12**. This PR brings every scrubbable chart across.

A useful confirmation fell out of it: iOS's Stress chart already passes `valueFormat: { String(format: "%.1f", $0) }` — the exact formatter this PR gives Android's Stress chart. The Android choice converges on shipped iOS behaviour rather than inventing one.

## Verification

6 new tests pinning the divergence *beside* each fix, so a future caller that forgets one has a written statement of what goes wrong:

```
lineChartSelectionLabel(62.4, null)         == "62.4"     // what the graph said
lineChartSelectionLabel(62.4, roundedMetric) == "62 ms"   // what the screen says
lineChartSelectionLabel(2.0, null)          == "2"        // near-integer collapse
lineChartSelectionLabel(2.0, stressScore)   == "2.0"      // the footer's reading
lineChartSelectionLabel(59.0, null)         == "59"       // Explore, raw
lineChartSelectionLabel(59.0, toWhoopScale) == "12.4"     // Explore, the axis
```

Android **4516 tests green**, `compileFullDebugKotlin` clean, `doc_comment_lint` and `i18n_audit --ci` clean. Android-only, so no `app-build` run is needed. Not hardware-dependent; no BLE path touched.
