### PR TITLE
health: lead the skin-temp tile with the absolute, deviation beneath

### DIFF
--- a/Strand/Screens/VitalSignsSummary.swift
+++ b/Strand/Screens/VitalSignsSummary.swift
@@ -27,6 +27,14 @@ struct BodyVitalReading: Identifiable {
     /// strap's own capture is known-unreliable for it (e.g. a WHOOP 4.0 R-R over-count contaminating HRV).
     /// nil = no caveat. Defaulted so existing call sites keep compiling unchanged.
     var caveat: String? = nil
+    /// A second reading shown with the caption, under the headline value (#1636).
+    ///
+    /// Distinct from `caveat`, which says the value is unreliable; this one says what the value means.
+    /// Skin temperature is the case: the absolute leads, and the deviation it was derived from is what
+    /// makes it legible — "+0.2" says nothing without an anchor, and 34.6 °C says little without
+    /// knowing it runs high for you. Pure formatted data (a number and a unit), never a sentence.
+    /// Defaulted so existing call sites keep compiling unchanged.
+    var secondary: String? = nil
 
     var id: String { key }
 
@@ -48,7 +56,9 @@ struct BodyVitalReading: Identifiable {
     /// line when nothing resolved, so an empty tile still says why instead of a bare dash.
     var stateCaption: String {
         guard let day else { return missingCaption }
-        var parts = [Self.dayLabel(day)]
+        // #1636: the secondary reading leads, so it sits directly under the headline value.
+        var parts = secondary.map { [$0] } ?? []
+        parts.append(Self.dayLabel(day))
         if let sourceText = Self.sourceLabel(source, key: key) {
             parts.append(sourceText)
         }
@@ -183,6 +193,10 @@ enum BodyVitalSigns {
         let rhrPoints = points(key: "rhr") { $0.restingHr.map(Double.init) }
         let hrvPoints = points(key: "hrv", \.avgHrv)
         let skinPoints = points(key: "skin", \.skinTempDevC)
+        // #1636: the night's ABSOLUTE, when the strap measured one. Nights scored before that column
+        // shipped carry only the deviation and refill on the next scoring pass, so this is empty until
+        // then and everything below falls through to the deviation-led behaviour unchanged.
+        let skinAbsPoints = points(key: "skin", \.skinTempC)
 
         let respRow = latest(respPoints)
         // #103/queue-11a: fall back to the spo2_candidate mean when no calibrated spo2Pct exists. The
@@ -193,7 +207,7 @@ enum BodyVitalSigns {
         let spo2rawRow = latest(spo2rawPoints)
         let rhrRow = latest(rhrPoints)
         let hrvRow = latest(hrvPoints)
-        let skinRow = latest(skinPoints)
+        let skinRowDeviation = latest(skinPoints)
         // #1118: mark HRV "unverified" when this night's in-sleep R-R was over-counted — the WHOOP 4.0
         // two-optical-channel artifact that inflates R-R and contaminates RMSSD, so NOOP's HRV won't match
         // WHOOP until the de-dup fix lands. The flag is written only for NOOP's OWN measured capture (an
@@ -214,13 +228,31 @@ enum BodyVitalSigns {
         // Skin temp is bimodal: CSV imports store ABSOLUTE °C, the on-device pipeline a ±°C DEVIATION —
         // partition the history to the displayed value's kind and pick the matching config + population
         // fallback (±0.6 °C mirrors the illness watch's flag threshold).
+        //
+        // #1636: prefer the measured absolute as the headline. A deviation with no anchor cannot be
+        // read — "+0.9" is a fever or a warm bedroom and nothing on the tile says which — so when the
+        // night has an absolute it leads and the deviation moves to the caption beneath it.
+        // Lead with the absolute ONLY when it is the freshest skin-temp night. An import-only night
+        // carries a deviation and no absolute, so preferring the absolute unconditionally would show an
+        // OLDER night than before — a stale reading that looks current, which is worse than the anchor
+        // being missing.
+        let skinAbsCandidate = latest(skinAbsPoints)
+        let skinAbsRow: VitalPoint? = {
+            guard let abs = skinAbsCandidate else { return nil }
+            guard let dev = skinRowDeviation else { return abs }
+            return abs.day >= dev.day ? abs : nil
+        }()
+        let skinRow = skinAbsRow ?? skinRowDeviation
         let skin = skinRow?.value
-        let skinIsAbsolute = skin.map(VitalBands.isAbsoluteSkinTemp) ?? true
+        let skinIsAbsolute = skinAbsRow != nil || (skin.map(VitalBands.isAbsoluteSkinTemp) ?? true)
+        // The series the tile is actually showing — banding and the sparkline must both read from it, or
+        // an absolute would be scored against a history of deviations (#1636).
+        let skinSeries = skinAbsRow != nil ? skinAbsPoints : skinPoints
         let skinResult: VitalBands.Result
         if let skin {
             skinResult = VitalBands.band(
                 value: skin,
-                history: VitalBands.skinTempHistory(matching: skin, in: history(before: skinRow?.day, skinPoints)),
+                history: VitalBands.skinTempHistory(matching: skin, in: history(before: skinRow?.day, skinSeries)),
                 populationRange: skinIsAbsolute ? 33...36 : (-0.6)...0.6,
                 cfg: skinIsAbsolute ? Baselines.metricCfg["skin_temp"]! : VitalBands.skinTempDeviationCfg
             )
@@ -371,7 +403,14 @@ enum BodyVitalSigns {
                 missingCaption: String(localized: "No nightly skin-temp yet — needs ~4 worn nights (or import a WHOOP CSV)"),
                 // Keep the trail on the displayed value's kind — absolute °C and ±deviation must not
                 // mix on one sparkline (matches the banding partition above).
-                sparkline: trail(skinPoints.filter { VitalBands.isAbsoluteSkinTemp($0.value) == skinIsAbsolute })
+                sparkline: trail(skinSeries.filter { VitalBands.isAbsoluteSkinTemp($0.value) == skinIsAbsolute }),
+                // #1636: the deviation this absolute was derived from, shown beneath it. Only when the
+                // headline IS the absolute — on a deviation-led tile it would just repeat the value.
+                secondary: skinAbsRow == nil ? nil : skinRowDeviation.map { dev in
+                    let n = SkinTempDisplay.numberString(dev.value, kind: .deviation,
+                                                         fahrenheit: fahrenheit, decimals: 1)
+                    return "\(n) \(SkinTempDisplay.unitSymbol(kind: .deviation, fahrenheit: fahrenheit))"
+                }
             ),
         ]
     }

--- a/Strand/Screens/VitalSignsSummary.swift
+++ b/Strand/Screens/VitalSignsSummary.swift
@@ -229,19 +229,16 @@ enum BodyVitalSigns {
         // partition the history to the displayed value's kind and pick the matching config + population
         // fallback (±0.6 °C mirrors the illness watch's flag threshold).
         //
-        // #1636: prefer the measured absolute as the headline. A deviation with no anchor cannot be
-        // read — "+0.9" is a fever or a warm bedroom and nothing on the tile says which — so when the
-        // night has an absolute it leads and the deviation moves to the caption beneath it.
-        // Lead with the absolute ONLY when it is the freshest skin-temp night. An import-only night
-        // carries a deviation and no absolute, so preferring the absolute unconditionally would show an
-        // OLDER night than before — a stale reading that looks current, which is worse than the anchor
-        // being missing.
+        // #1636: resolve the DISPLAYED night first — the freshest that carries either reading — then
+        // lead with its absolute if it has one. Asking "does the row I am already showing have an
+        // absolute?" is what keeps the tile from silently stepping back to an older night: an
+        // import-only night has a deviation and no absolute, and a CALIBRATING night has the reverse
+        // (`recomputeSkinTempDev` returns nil until the baseline is usable, while the absolute is
+        // already measured — those wearers read "needs ~4 worn nights" today with a real temperature
+        // sitting unshown behind it).
         let skinAbsCandidate = latest(skinAbsPoints)
-        let skinAbsRow: VitalPoint? = {
-            guard let abs = skinAbsCandidate else { return nil }
-            guard let dev = skinRowDeviation else { return abs }
-            return abs.day >= dev.day ? abs : nil
-        }()
+        let skinRowDay: String? = [skinRowDeviation?.day, skinAbsCandidate?.day].compactMap { $0 }.max()
+        let skinAbsRow = skinAbsCandidate.flatMap { $0.day == skinRowDay ? $0 : nil }
         let skinRow = skinAbsRow ?? skinRowDeviation
         let skin = skinRow?.value
         let skinIsAbsolute = skinAbsRow != nil || (skin.map(VitalBands.isAbsoluteSkinTemp) ?? true)
@@ -271,6 +268,15 @@ enum BodyVitalSigns {
         let skinFormat: (Double) -> String = { c in
             SkinTempDisplay.numberString(c, kind: skinKind, fahrenheit: fahrenheit, decimals: 1)
         }
+        // #1636: the deviation for THE DISPLAYED NIGHT — not the freshest one anywhere. A calibrating
+        // night carries an absolute and no deviation, and reaching for the latest deviation there would
+        // print a previous night's number under tonight's temperature.
+        let skinSecondary: String? = skinAbsRow == nil ? nil
+            : skinPoints.last(where: { $0.day == skinRow?.day }).map { dev in
+                let n = SkinTempDisplay.numberString(dev.value, kind: .deviation,
+                                                     fahrenheit: fahrenheit, decimals: 1)
+                return "\(n) \(SkinTempDisplay.unitSymbol(kind: .deviation, fahrenheit: fahrenheit))"
+            }
 
         return [
             BodyVitalReading(
@@ -406,11 +412,7 @@ enum BodyVitalSigns {
                 sparkline: trail(skinSeries.filter { VitalBands.isAbsoluteSkinTemp($0.value) == skinIsAbsolute }),
                 // #1636: the deviation this absolute was derived from, shown beneath it. Only when the
                 // headline IS the absolute — on a deviation-led tile it would just repeat the value.
-                secondary: skinAbsRow == nil ? nil : skinRowDeviation.map { dev in
-                    let n = SkinTempDisplay.numberString(dev.value, kind: .deviation,
-                                                         fahrenheit: fahrenheit, decimals: 1)
-                    return "\(n) \(SkinTempDisplay.unitSymbol(kind: .deviation, fahrenheit: fahrenheit))"
-                }
+                secondary: skinSecondary
             ),
         ]
     }

--- a/StrandTests/SkinTempAbsoluteDisplayTests.swift
+++ b/StrandTests/SkinTempAbsoluteDisplayTests.swift
@@ -48,6 +48,84 @@ final class SkinTempAbsoluteDisplayTests: XCTestCase {
         XCTAssertTrue(caption.hasSuffix("unverified"))
     }
 
+    // MARK: - The tile itself, not just the caption helper
+
+    /// A day key `daysAgo` before the CURRENT logical day.
+    ///
+    /// Not a hardcoded date: `latest()` resolves through `Baselines.freshestCarried`, which only carries
+    /// a reading within `vitalCarryDays` of today. A fixed fixture date passes now and silently stops
+    /// resolving once the real clock moves past that window — a test that rots into a false green.
+    private func dayKey(_ daysAgo: Int) -> String {
+        Baselines.cutoffKey(todayKey: BodyVitalSigns.logicalDayKey(Date()), carryDays: daysAgo)
+    }
+
+    private func day(_ d: String, abs: Double? = nil, dev: Double? = nil) -> DailyMetric {
+        DailyMetric(day: d, totalSleepMin: nil, efficiency: nil, deepMin: nil, remMin: nil,
+                    lightMin: nil, disturbances: nil, restingHr: nil, avgHrv: nil,
+                    recovery: nil, strain: nil, exerciseCount: nil,
+                    skinTempDevC: dev, skinTempC: abs)
+    }
+
+    private func skinTile(_ days: [DailyMetric],
+                          _ unit: TemperatureUnit = .celsius) throws -> BodyVitalReading {
+        let all = BodyVitalSigns.readings(days: days, today: days.last, temperatureUnit: unit)
+        return try XCTUnwrap(all.first { $0.key == "skin" })
+    }
+
+    /// The reported case: the night measured both, so the absolute leads and the deviation sits under it.
+    func testANightWithBothLeadsWithTheAbsolute() throws {
+        let tile = try skinTile([day(dayKey(0), abs: 34.6, dev: 0.52)])
+        XCTAssertEqual(try XCTUnwrap(tile.value), 34.6, accuracy: 0.001)
+        XCTAssertEqual(tile.unit, "°C")
+        XCTAssertEqual(tile.secondary, "+0.5 Δ°C")
+    }
+
+    func testTheAbsoluteAndItsNoteFollowTheTemperatureSetting() throws {
+        let tile = try skinTile([day(dayKey(0), abs: 34.6, dev: 0.52)], .fahrenheit)
+        XCTAssertEqual(tile.unit, "°F")
+        XCTAssertEqual(tile.secondary, "+0.9 Δ°F")
+    }
+
+    /// A night predating the column keeps exactly the tile that shipped before.
+    func testADeviationOnlyNightIsUnchanged() throws {
+        let tile = try skinTile([day(dayKey(0), dev: 0.52)])
+        XCTAssertEqual(try XCTUnwrap(tile.value), 0.52, accuracy: 0.001)
+        XCTAssertEqual(tile.unit, "Δ°C")
+        XCTAssertNil(tile.secondary, "a deviation-led tile would only repeat its own headline")
+    }
+
+    /// Calibrating: the absolute is measured before the baseline is usable, so there is no deviation
+    /// yet. The tile shows the temperature instead of "needs ~4 worn nights", and omits the note.
+    func testACalibratingNightShowsTheAbsoluteWithNoNote() throws {
+        let tile = try skinTile([day(dayKey(0), abs: 34.6)])
+        XCTAssertEqual(try XCTUnwrap(tile.value), 34.6, accuracy: 0.001)
+        XCTAssertEqual(tile.unit, "°C")
+        XCTAssertNil(tile.secondary)
+    }
+
+    /// The regression the displayed-row rule exists for: an import-only night is NEWER than the last
+    /// strap night. The tile must stay on the import rather than stepping back to a stale absolute.
+    func testANewerImportOnlyNightDoesNotStepBackToAnOlderAbsolute() throws {
+        let tile = try skinTile([
+            day(dayKey(1), abs: 34.6, dev: 0.52),   // the strap's last scored night
+            day(dayKey(0), dev: 0.20),              // a WHOOP CSV import: deviation only
+        ])
+        XCTAssertEqual(try XCTUnwrap(tile.value), 0.20, accuracy: 0.001,
+                       "showing 34.6 here would be yesterday's reading dressed as today's")
+        XCTAssertEqual(tile.day, dayKey(0))
+        XCTAssertNil(tile.secondary)
+    }
+
+    /// The secondary must be THIS night's deviation. Reaching for the freshest one anywhere would
+    /// print a previous night's number under tonight's temperature.
+    func testTheNoteBelongsToTheDisplayedNight() throws {
+        let tile = try skinTile([
+            day(dayKey(1), abs: 33.9, dev: -0.40),
+            day(dayKey(0), abs: 34.6, dev: 0.52),
+        ])
+        XCTAssertEqual(tile.secondary, "+0.5 Δ°C", "the note must not come from the previous night")
+    }
+
     /// The formatting the tile's secondary carries, pinned to the same helper Android formats with.
     func testTheDeviationNoteMatchesTheKotlinTwin() {
         func note(_ c: Double, fahrenheit: Bool) -> String {

--- a/StrandTests/SkinTempAbsoluteDisplayTests.swift
+++ b/StrandTests/SkinTempAbsoluteDisplayTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+import SwiftUI
+import StrandAnalytics
+import WhoopStore
+@testable import Strand
+
+/// #1636: the skin-temp tile leads with the night's ABSOLUTE, with the deviation in the caption beneath.
+///
+/// A deviation with no anchor cannot be read — the reporter's flu night was "+0.94 Δ°F", which looks like
+/// nothing, against 96.4 °F on a 94.4 °F mean, which reads as a fever. Both numbers are needed and
+/// neither is sufficient.
+///
+/// `BodyVitalReading.stateCaption` is pure, so the ordering is asserted directly. Twin of Kotlin
+/// `SkinTempAbsoluteDisplayTest`, which asserts the same two properties through its own pure seams
+/// (`latestSkinAbsoluteC` / `skinTempSecondaryNote`) because Android's builder resolves resources and
+/// cannot run in a JVM test.
+final class SkinTempAbsoluteDisplayTests: XCTestCase {
+
+    private func reading(secondary: String?, caveat: String? = nil) -> BodyVitalReading {
+        BodyVitalReading(
+            key: "skin", label: "Skin Temp", unit: "°C", value: 34.6,
+            format: { String(format: "%.1f", $0) },
+            banding: VitalBands.Result(band: .inRange, basis: .population, nights: 24),
+            metricColor: .orange, day: "2026-08-25", source: .noopComputed,
+            missingCaption: "none", caveat: caveat, secondary: secondary)
+    }
+
+    func testTheSecondaryLeadsTheCaptionSoItSitsUnderTheValue() {
+        let caption = reading(secondary: "+0.9 Δ°F").stateCaption
+        XCTAssertTrue(caption.hasPrefix("+0.9 Δ°F · "),
+                      "the deviation must come first, directly under the headline — got \(caption)")
+        XCTAssertTrue(caption.contains("25 Aug") || caption.contains("Aug 25"),
+                      "the day must still be there — got \(caption)")
+    }
+
+    func testWithoutASecondaryTheCaptionIsUnchanged() {
+        // Every other vital passes nil, so their captions must be byte-identical to before.
+        let caption = reading(secondary: nil).stateCaption
+        XCTAssertFalse(caption.hasPrefix(" · "), "a nil secondary must not leave an empty leading part")
+        XCTAssertFalse(caption.contains("Δ"))
+    }
+
+    func testTheSecondaryIsIndependentOfTheCaveat() {
+        // `caveat` says the reading is unreliable; `secondary` says what it means. A tile may carry
+        // both, and they must not be confused for one another.
+        let caption = reading(secondary: "+0.9 Δ°F", caveat: "unverified").stateCaption
+        XCTAssertTrue(caption.hasPrefix("+0.9 Δ°F · "))
+        XCTAssertTrue(caption.hasSuffix("unverified"))
+    }
+
+    /// The formatting the tile's secondary carries, pinned to the same helper Android formats with.
+    func testTheDeviationNoteMatchesTheKotlinTwin() {
+        func note(_ c: Double, fahrenheit: Bool) -> String {
+            let n = SkinTempDisplay.numberString(c, kind: .deviation, fahrenheit: fahrenheit, decimals: 1)
+            return "\(n) \(SkinTempDisplay.unitSymbol(kind: .deviation, fahrenheit: fahrenheit))"
+        }
+        XCTAssertEqual(note(0.52, fahrenheit: false), "+0.5 Δ°C")
+        XCTAssertEqual(note(0.52, fahrenheit: true), "+0.9 Δ°F")
+        XCTAssertEqual(note(-0.5, fahrenheit: false), "-0.5 Δ°C")
+        XCTAssertEqual(note(-0.5, fahrenheit: true), "-0.9 Δ°F")
+        // A whole degree of DEVIATION is 1.8 °F, never 33.8 — no +32 offset on a difference.
+        XCTAssertEqual(note(1.0, fahrenheit: true), "+1.8 Δ°F")
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1731,18 +1731,6 @@ private data class VitalDetailModel(
     val color: Color,
     val readings: List<VitalReading>,
     val format: (Double) -> String,
-    /**
-     * An optional second value for a given day, shown under the "Latest" figure (#1636).
-     *
-     * Skin temperature is the case that needs it: the headline is now the night's ABSOLUTE, and the
-     * deviation that used to BE the headline is the context that makes it readable — "+0.2" says
-     * nothing without knowing what it moved from, and 34.6 °C says little without knowing it is high
-     * for you. Keyed by day rather than precomputed, because the screen's range picker chooses which
-     * day is "latest" and a precomputed note would describe a different night.
-     *
-     * Returns pure formatted data (a number and a unit), never a sentence, so it needs no translation.
-     */
-    val secondaryFor: ((String) -> String?)? = null,
 ) {
     /** (day, value) projection the trend chart + range helpers consume — SAME order as [readings], so the
      *  chart, the header count, and the table can never drift apart. */
@@ -2047,15 +2035,6 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
                             style = NoopType.chartValueLarge,
                             color = detail.color,
                         )
-                        // #1636: the secondary reading, between the headline and the date — the shape
-                        // the request asked for. Pure formatted data, so no translatable string.
-                        detail.secondaryFor?.invoke(latest.first)?.let { note ->
-                            Text(
-                                text = note,
-                                style = NoopType.captionNumber,
-                                color = Palette.textSecondary,
-                            )
-                        }
                         Text(
                             text = uiString(R.string.l10n_health_screen_as_of_latest_first_726f20bb, latest.first),
                             style = NoopType.footnote,
@@ -2217,41 +2196,6 @@ private fun RecentDaySelectorBar(selectedOffset: Int, onSelect: (Int) -> Unit) {
     ThreeDaySelectorBar(selectedOffset = selectedOffset, onSelect = onSelect)
 }
 
-/**
- * The freshest measured ABSOLUTE nightly skin temperature in [days], or null (#1636).
- *
- * The branch that decides whether the Skin Temperature screen leads with an absolute or falls back to
- * the deviation-led display that shipped before. Pure and extracted deliberately: `buildVitalDetail`
- * resolves strings through `NoopApplication` and cannot run in a JVM test at all, so the decision lives
- * here where it can be asserted (the same arrangement as [spo2MissingCaptionRes]).
- *
- * Scans newest-first, so a wearer whose recent nights are scored but whose older history predates the
- * column still gets the absolute.
- *
- * Returns null when the freshest night carrying a skin-temp reading has only a DEVIATION — an import-only
- * night, which never carries an absolute. Leading with an absolute there would silently show an OLDER
- * night than the screen showed before, which is a worse failure than the one this fixes: a stale reading
- * that looks current.
- */
-internal fun latestSkinAbsoluteC(days: List<DailyMetric>): Double? {
-    val newestAbs = days.asReversed().firstOrNull { it.skinTempC != null } ?: return null
-    val newestAny = days.asReversed().firstOrNull { it.skinTempC != null || it.skinTempDevC != null }
-    if (newestAny != null && newestAny.day > newestAbs.day) return null
-    return newestAbs.skinTempC
-}
-
-/**
- * The deviation note shown beneath an absolute skin temperature — "+0.2 Δ°F" (#1636).
- *
- * Null when the night has no deviation, so the line is omitted rather than printed empty. Pure
- * formatted data, never a sentence, so it carries no translatable string.
- */
-internal fun skinTempSecondaryNote(devC: Double?, fahrenheit: Boolean): String? =
-    devC?.let {
-        val n = SkinTempDisplay.numberString(it, SkinTempDisplay.Kind.DEVIATION, fahrenheit, decimals = 1)
-        "$n ${SkinTempDisplay.unitSymbol(SkinTempDisplay.Kind.DEVIATION, fahrenheit)}"
-    }
-
 private fun buildVitalDetail(
     days: List<DailyMetric>,
     key: String,
@@ -2324,34 +2268,9 @@ private fun buildVitalDetail(
         format = { it.roundToInt().toString() },
     )
     "skin" -> {
-        val fahrenheit = tempUnit == TemperatureUnit.FAHRENHEIT
-        // #1636: the night's ABSOLUTE is the headline when the strap measured one. A deviation with no
-        // anchor cannot be read — "+0.9" is a fever or a warm bedroom and nothing on the screen says
-        // which — so the absolute leads and the deviation becomes the context beneath it.
-        //
-        // `skinTempC` is nullable: nights scored before it shipped carry only the deviation, and they
-        // refill on the next scoring pass. Until a wearer has one, this falls through to exactly the
-        // behaviour that shipped before, deviation-led and unchanged.
-        val absolute = latestSkinAbsoluteC(days)
-        if (absolute != null) {
-            val devByDay = days.mapNotNull { row -> row.skinTempDevC?.let { row.day to it } }.toMap()
-            return VitalDetailModel(
-                key = key,
-                title = uiString(R.string.l10n_health_screen_skin_temperature_f59127f6),
-                unit = SkinTempDisplay.unitSymbol(SkinTempDisplay.Kind.ABSOLUTE, fahrenheit),
-                color = Palette.metricAmber,
-                readings = days.mapNotNull { row ->
-                    row.skinTempC?.let { value -> VitalReading(row.day, value, row.deviceId) }
-                },
-                format = { c ->
-                    SkinTempDisplay.numberString(c, SkinTempDisplay.Kind.ABSOLUTE, fahrenheit, decimals = 1)
-                },
-                // The deviation that used to be the headline, now the line that makes it legible.
-                secondaryFor = { day -> skinTempSecondaryNote(devByDay[day], fahrenheit) },
-            )
-        }
         val latest = days.asReversed().asSequence().mapNotNull { it.skinTempDevC }.firstOrNull() ?: return null
         val kind = SkinTempDisplay.kind(latest)
+        val fahrenheit = tempUnit == TemperatureUnit.FAHRENHEIT
         val unit = SkinTempDisplay.unitSymbol(kind, fahrenheit)
         val title = if (kind == SkinTempDisplay.Kind.ABSOLUTE) {
             uiString(R.string.l10n_health_screen_skin_temperature_f59127f6)

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1731,6 +1731,18 @@ private data class VitalDetailModel(
     val color: Color,
     val readings: List<VitalReading>,
     val format: (Double) -> String,
+    /**
+     * An optional second value for a given day, shown under the "Latest" figure (#1636).
+     *
+     * Skin temperature is the case that needs it: the headline is now the night's ABSOLUTE, and the
+     * deviation that used to BE the headline is the context that makes it readable — "+0.2" says
+     * nothing without knowing what it moved from, and 34.6 °C says little without knowing it is high
+     * for you. Keyed by day rather than precomputed, because the screen's range picker chooses which
+     * day is "latest" and a precomputed note would describe a different night.
+     *
+     * Returns pure formatted data (a number and a unit), never a sentence, so it needs no translation.
+     */
+    val secondaryFor: ((String) -> String?)? = null,
 ) {
     /** (day, value) projection the trend chart + range helpers consume — SAME order as [readings], so the
      *  chart, the header count, and the table can never drift apart. */
@@ -2035,6 +2047,15 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
                             style = NoopType.chartValueLarge,
                             color = detail.color,
                         )
+                        // #1636: the secondary reading, between the headline and the date — the shape
+                        // the request asked for. Pure formatted data, so no translatable string.
+                        detail.secondaryFor?.invoke(latest.first)?.let { note ->
+                            Text(
+                                text = note,
+                                style = NoopType.captionNumber,
+                                color = Palette.textSecondary,
+                            )
+                        }
                         Text(
                             text = uiString(R.string.l10n_health_screen_as_of_latest_first_726f20bb, latest.first),
                             style = NoopType.footnote,
@@ -2196,6 +2217,41 @@ private fun RecentDaySelectorBar(selectedOffset: Int, onSelect: (Int) -> Unit) {
     ThreeDaySelectorBar(selectedOffset = selectedOffset, onSelect = onSelect)
 }
 
+/**
+ * The freshest measured ABSOLUTE nightly skin temperature in [days], or null (#1636).
+ *
+ * The branch that decides whether the Skin Temperature screen leads with an absolute or falls back to
+ * the deviation-led display that shipped before. Pure and extracted deliberately: `buildVitalDetail`
+ * resolves strings through `NoopApplication` and cannot run in a JVM test at all, so the decision lives
+ * here where it can be asserted (the same arrangement as [spo2MissingCaptionRes]).
+ *
+ * Scans newest-first, so a wearer whose recent nights are scored but whose older history predates the
+ * column still gets the absolute.
+ *
+ * Returns null when the freshest night carrying a skin-temp reading has only a DEVIATION — an import-only
+ * night, which never carries an absolute. Leading with an absolute there would silently show an OLDER
+ * night than the screen showed before, which is a worse failure than the one this fixes: a stale reading
+ * that looks current.
+ */
+internal fun latestSkinAbsoluteC(days: List<DailyMetric>): Double? {
+    val newestAbs = days.asReversed().firstOrNull { it.skinTempC != null } ?: return null
+    val newestAny = days.asReversed().firstOrNull { it.skinTempC != null || it.skinTempDevC != null }
+    if (newestAny != null && newestAny.day > newestAbs.day) return null
+    return newestAbs.skinTempC
+}
+
+/**
+ * The deviation note shown beneath an absolute skin temperature — "+0.2 Δ°F" (#1636).
+ *
+ * Null when the night has no deviation, so the line is omitted rather than printed empty. Pure
+ * formatted data, never a sentence, so it carries no translatable string.
+ */
+internal fun skinTempSecondaryNote(devC: Double?, fahrenheit: Boolean): String? =
+    devC?.let {
+        val n = SkinTempDisplay.numberString(it, SkinTempDisplay.Kind.DEVIATION, fahrenheit, decimals = 1)
+        "$n ${SkinTempDisplay.unitSymbol(SkinTempDisplay.Kind.DEVIATION, fahrenheit)}"
+    }
+
 private fun buildVitalDetail(
     days: List<DailyMetric>,
     key: String,
@@ -2268,9 +2324,34 @@ private fun buildVitalDetail(
         format = { it.roundToInt().toString() },
     )
     "skin" -> {
+        val fahrenheit = tempUnit == TemperatureUnit.FAHRENHEIT
+        // #1636: the night's ABSOLUTE is the headline when the strap measured one. A deviation with no
+        // anchor cannot be read — "+0.9" is a fever or a warm bedroom and nothing on the screen says
+        // which — so the absolute leads and the deviation becomes the context beneath it.
+        //
+        // `skinTempC` is nullable: nights scored before it shipped carry only the deviation, and they
+        // refill on the next scoring pass. Until a wearer has one, this falls through to exactly the
+        // behaviour that shipped before, deviation-led and unchanged.
+        val absolute = latestSkinAbsoluteC(days)
+        if (absolute != null) {
+            val devByDay = days.mapNotNull { row -> row.skinTempDevC?.let { row.day to it } }.toMap()
+            return VitalDetailModel(
+                key = key,
+                title = uiString(R.string.l10n_health_screen_skin_temperature_f59127f6),
+                unit = SkinTempDisplay.unitSymbol(SkinTempDisplay.Kind.ABSOLUTE, fahrenheit),
+                color = Palette.metricAmber,
+                readings = days.mapNotNull { row ->
+                    row.skinTempC?.let { value -> VitalReading(row.day, value, row.deviceId) }
+                },
+                format = { c ->
+                    SkinTempDisplay.numberString(c, SkinTempDisplay.Kind.ABSOLUTE, fahrenheit, decimals = 1)
+                },
+                // The deviation that used to be the headline, now the line that makes it legible.
+                secondaryFor = { day -> skinTempSecondaryNote(devByDay[day], fahrenheit) },
+            )
+        }
         val latest = days.asReversed().asSequence().mapNotNull { it.skinTempDevC }.firstOrNull() ?: return null
         val kind = SkinTempDisplay.kind(latest)
-        val fahrenheit = tempUnit == TemperatureUnit.FAHRENHEIT
         val unit = SkinTempDisplay.unitSymbol(kind, fahrenheit)
         val title = if (kind == SkinTempDisplay.Kind.ABSOLUTE) {
             uiString(R.string.l10n_health_screen_skin_temperature_f59127f6)

--- a/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
@@ -41,6 +41,14 @@ internal data class Vital(
      *  Kotlin twin of `BodyVitalReading.caveat` (VitalSignsSummary.swift). Defaulted so other vitals are
      *  unaffected. */
     val caveat: String? = null,
+    /** #1636: a second reading shown with the caption, under the headline value.
+     *
+     *  Distinct from [caveat], which says the value is unreliable; this says what it MEANS. Skin
+     *  temperature is the case: the absolute leads, and the deviation it was derived from is what makes
+     *  it legible — "+0.2" says nothing without an anchor, and 34.6 °C says little without knowing it
+     *  runs high for you. Pure formatted data, never a sentence, so it carries no translatable string.
+     *  Kotlin twin of `BodyVitalReading.secondary`. Defaulted so other vitals are unaffected. */
+    val secondary: String? = null,
 ) {
     /** Value with its unit appended, or null when no data. */
     val formattedValue: String? = value?.let { "${format(it)} $unit" }
@@ -76,14 +84,49 @@ internal data class Vital(
     /** #1118: the base caption plus any "unverified" caveat (an over-counted HRV night), so the caveat
      *  rides the same line the user already reads. Never on an empty tile. Twin of Swift's stateCaption
      *  append in VitalSignsSummary.swift. */
-    val stateCaption: String =
-        if (caveat != null && banding.band != VitalBands.Band.NO_DATA) "$baseCaption · $caveat" else baseCaption
+    val stateCaption: String = run {
+        val withCaveat =
+            if (caveat != null && banding.band != VitalBands.Band.NO_DATA) "$baseCaption · $caveat" else baseCaption
+        // #1636: the secondary reading LEADS, so it sits directly under the headline value. Never on an
+        // empty tile, where the caption is the "why it's empty" line and a number would contradict it.
+        if (secondary != null && banding.band != VitalBands.Band.NO_DATA) "$secondary · $withCaveat" else withCaveat
+    }
 
     val accessibilityText: String =
         formattedValue?.let {
             listOfNotNull("$label: $it", asOfLabel, stateCaption).joinToString(", ")
         } ?: "$label: no data"
 }
+
+/**
+ * Whether the skin-temp tile leads with the night's ABSOLUTE (#1636).
+ *
+ * True whenever the displayed night measured one. A deviation with no anchor cannot be read — "+0.9" is
+ * a fever or a warm bedroom and nothing on the tile says which — so the absolute leads and the deviation
+ * becomes the context beneath it.
+ *
+ * Two cases make this more than a preference:
+ *  - a night scored before `skinTempC` shipped has only a deviation, so the tile keeps exactly the
+ *    display that shipped before until a scoring pass refills it;
+ *  - a CALIBRATING night has the reverse — `recomputeSkinTempDev` returns null until the baseline is
+ *    usable (~4 nights), while the absolute is already measured. Those wearers currently read "needs ~4
+ *    worn nights" with a real temperature sitting unshown behind it.
+ *
+ * Twin of the Swift tile's `skinAbsRow != nil` branch.
+ */
+internal fun skinTempLeadsWithAbsolute(absC: Double?): Boolean = absC != null
+
+/**
+ * The deviation note shown beneath an absolute skin temperature — "+0.2 Δ°F" (#1636).
+ *
+ * Null when the night has no deviation (a calibrating night), so the line is omitted rather than printed
+ * empty. Pure formatted data, never a sentence, so it carries no translatable string.
+ */
+internal fun skinTempSecondaryNote(devC: Double?, fahrenheit: Boolean): String? =
+    devC?.let {
+        val n = SkinTempDisplay.numberString(it, SkinTempDisplay.Kind.DEVIATION, fahrenheit, decimals = 1)
+        "$n ${SkinTempDisplay.unitSymbol(SkinTempDisplay.Kind.DEVIATION, fahrenheit)}"
+    }
 
 /**
  * Which "no value" line the Blood O₂ tile shows, given whether that night decoded raw red/IR counts.
@@ -161,16 +204,23 @@ internal fun vitalsFor(
     // config + population fallback (±0.6 °C mirrors the illness watch's flag threshold).
     // This also fixes the live bug where a strap-computed +0.2 °C deviation read
     // "Out of range" against the 33–36 absolute band.
-    val skin = d?.skinTempDevC
+    // #1636: lead with the night's measured ABSOLUTE when it has one; otherwise the deviation-led
+    // display that shipped before, unchanged. `leadsAbsolute` also decides which SERIES backs the
+    // banding and the trail below — an absolute scored against a history of deviations would be
+    // nonsense, so the two must move together.
+    val leadsAbsolute = skinTempLeadsWithAbsolute(d?.skinTempC)
+    val skin = if (leadsAbsolute) d?.skinTempC else d?.skinTempDevC
     // Track which kind the value is so the temperature converter picks the right rule: an ABSOLUTE
     // reading uses the full C→F formula (×9/5 + 32); a ±DEVIATION must omit the offset.
-    val skinIsAbsolute = skin?.let { VitalBands.isAbsoluteSkinTemp(it) } ?: true
+    val skinIsAbsolute = if (leadsAbsolute) true else skin?.let { VitalBands.isAbsoluteSkinTemp(it) } ?: true
+    val skinSelector: (DailyMetric) -> Double? =
+        if (leadsAbsolute) { row -> row.skinTempC } else { row -> row.skinTempDevC }
     val skinResult: VitalBands.Result = if (skin == null) {
         VitalBands.Result(VitalBands.Band.NO_DATA, VitalBands.Basis.POPULATION, 0)
     } else {
         VitalBands.band(
             value = skin,
-            history = VitalBands.skinTempHistory(skin, series { it.skinTempDevC }),
+            history = VitalBands.skinTempHistory(skin, series(skinSelector)),
             populationRange = if (skinIsAbsolute) 33.0..36.0 else -0.6..0.6,
             cfg = if (skinIsAbsolute) Baselines.metricCfg.getValue("skin_temp") else VitalBands.skinTempDeviationCfg,
         )
@@ -189,7 +239,7 @@ internal fun vitalsFor(
         SkinTempDisplay.numberString(c, skinKind, fahrenheit, decimals = 1)
     }
     val previousSkin = history.asReversed().asSequence()
-        .mapNotNull { row -> row.skinTempDevC?.takeIf { VitalBands.isAbsoluteSkinTemp(it) == skinIsAbsolute } }
+        .mapNotNull { row -> skinSelector(row)?.takeIf { VitalBands.isAbsoluteSkinTemp(it) == skinIsAbsolute } }
         .firstOrNull()
     val respRangeCaption = rangeCaption(days.mapNotNull { it.respRateBpm }, "rpm") { String.format(Locale.US, "%.1f", it) }
     val spo2RangeCaption = rangeCaption(days.mapNotNull { it.spo2Pct }, "%") { String.format(Locale.US, "%.0f", it) }
@@ -197,7 +247,7 @@ internal fun vitalsFor(
     val hrvRangeCaption = rangeCaption(days.mapNotNull { it.avgHrv }, "ms") { it.roundToInt().toString() }
     val skinRangeCaption = rangeCaption(
         days.mapNotNull { row ->
-            row.skinTempDevC?.takeIf { VitalBands.isAbsoluteSkinTemp(it) == skinIsAbsolute }
+            skinSelector(row)?.takeIf { VitalBands.isAbsoluteSkinTemp(it) == skinIsAbsolute }
         },
         skinUnitLabel,
         skinFormat,
@@ -320,8 +370,11 @@ internal fun vitalsFor(
             banding = skinResult, metricColor = Palette.metricAmber,
             // Keep the trail on the displayed value's kind — absolute °C and ±deviation must not mix.
             sparkline = trail(skin) { row ->
-                row.skinTempDevC?.takeIf { VitalBands.isAbsoluteSkinTemp(it) == skinIsAbsolute }
+                skinSelector(row)?.takeIf { VitalBands.isAbsoluteSkinTemp(it) == skinIsAbsolute }
             },
+            // #1636: the deviation this absolute was derived from, beneath it. Only on an absolute-led
+            // tile — on a deviation-led one it would simply repeat the headline.
+            secondary = if (leadsAbsolute) skinTempSecondaryNote(d?.skinTempDevC, fahrenheit) else null,
         ),
     )
 }

--- a/android/app/src/test/java/com/noop/ui/SkinTempAbsoluteDisplayTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SkinTempAbsoluteDisplayTest.kt
@@ -1,0 +1,116 @@
+package com.noop.ui
+
+import com.noop.data.DailyMetric
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #1636: the Skin Temperature screen leads with the night's ABSOLUTE, with the deviation beneath it.
+ *
+ * A deviation with no anchor cannot be read — the reporter's flu night was "+0.94 Δ°F", which looks
+ * like nothing, against 96.4 °F on a 94.4 °F mean, which reads as a fever. Both numbers are needed and
+ * neither is sufficient.
+ *
+ * `buildVitalDetail` resolves strings through `NoopApplication` and cannot run in a JVM test, so the
+ * BRANCH and the FORMATTING are extracted and asserted here — the same arrangement `Spo2MissingCaptionTest`
+ * uses for the same reason. Twin of Swift `SkinTempAbsoluteDisplayTests`.
+ */
+class SkinTempAbsoluteDisplayTest {
+
+    private fun row(day: String, abs: Double? = null, dev: Double? = null) =
+        DailyMetric(deviceId = "my-whoop", day = day, skinTempC = abs, skinTempDevC = dev)
+
+    // The branch: absolute-led or the pre-#1636 deviation-led fallback
+
+    @Test
+    fun theFreshestMeasuredAbsoluteWins() {
+        val days = listOf(
+            row("2026-08-23", abs = 33.9, dev = -0.2),
+            row("2026-08-24", abs = 34.1, dev = 0.0),
+            row("2026-08-25", abs = 34.6, dev = 0.52),
+        )
+        assertEquals(34.6, latestSkinAbsoluteC(days)!!, 1e-12)
+    }
+
+    @Test
+    fun historyPredatingTheColumnFallsBackRatherThanShowingNothing() {
+        // Every night deviation-only: the screen must keep its old behaviour, not blank out.
+        val days = listOf(row("2026-08-24", dev = -0.2), row("2026-08-25", dev = 0.52))
+        assertNull(latestSkinAbsoluteC(days))
+    }
+
+    @Test
+    fun aPartlyRescoredHistoryStillLeadsWithTheAbsolute() {
+        // Older nights predate the column; the recent ones were re-scored. Newest-first means the
+        // wearer gets the absolute rather than waiting for the whole history to refill.
+        val days = listOf(
+            row("2026-08-20", dev = -0.4),
+            row("2026-08-21", dev = -0.1),
+            row("2026-08-25", abs = 34.6, dev = 0.52),
+        )
+        assertEquals(34.6, latestSkinAbsoluteC(days)!!, 1e-12)
+    }
+
+    @Test
+    fun anEmptyHistoryHasNoAbsolute() {
+        assertNull(latestSkinAbsoluteC(emptyList()))
+    }
+
+    /**
+     * The regression this guard exists for: an import-only night is NEWER than the last strap night.
+     * Leading with the absolute would show a stale reading dressed as the current one, so the screen
+     * stays deviation-led until the strap catches up.
+     */
+    @Test
+    fun aNewerImportOnlyNightSuppressesTheOlderAbsolute() {
+        val days = listOf(
+            row("2026-08-24", abs = 34.6, dev = 0.52),   // the strap's last scored night
+            row("2026-08-25", dev = 0.20),               // a WHOOP CSV import: deviation only
+        )
+        assertNull(latestSkinAbsoluteC(days))
+    }
+
+    @Test
+    fun anImportOnlyNightOLDERThanTheAbsoluteDoesNotSuppressIt() {
+        val days = listOf(
+            row("2026-08-24", dev = 0.20),               // older import
+            row("2026-08-25", abs = 34.6, dev = 0.52),   // the freshest night has both
+        )
+        assertEquals(34.6, latestSkinAbsoluteC(days)!!, 1e-12)
+    }
+
+    @Test
+    fun anAbsoluteOnTheSameDayAsTheFreshestDeviationStillLeads() {
+        val days = listOf(row("2026-08-25", abs = 34.6, dev = 0.52))
+        assertEquals(34.6, latestSkinAbsoluteC(days)!!, 1e-12)
+    }
+
+    // The secondary note: the deviation, in the user's own unit
+
+    @Test
+    fun theNoteCarriesTheSignAndTheDeltaUnit() {
+        // The reporter's Aug 14, both ways round.
+        assertEquals("+0.5 Δ°C", skinTempSecondaryNote(0.52, fahrenheit = false))
+        assertEquals("+0.9 Δ°F", skinTempSecondaryNote(0.52, fahrenheit = true))
+    }
+
+    @Test
+    fun aNegativeDeviationKeepsItsSign() {
+        assertEquals("-0.5 Δ°C", skinTempSecondaryNote(-0.5, fahrenheit = false))
+        assertEquals("-0.9 Δ°F", skinTempSecondaryNote(-0.5, fahrenheit = true))
+    }
+
+    @Test
+    fun aFahrenheitDeviationScalesWithoutTheOffset() {
+        // A whole degree of DEVIATION is 1.8 °F, never 33.8 — the +32 offset would be wrong for a delta.
+        assertEquals("+1.8 Δ°F", skinTempSecondaryNote(1.0, fahrenheit = true))
+    }
+
+    @Test
+    fun aNightWithNoDeviationOmitsTheLine() {
+        // Printing an empty note under the headline would read as a missing value rather than none.
+        assertNull(skinTempSecondaryNote(null, fahrenheit = false))
+        assertNull(skinTempSecondaryNote(null, fahrenheit = true))
+    }
+}

--- a/android/app/src/test/java/com/noop/ui/SkinTempAbsoluteDisplayTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SkinTempAbsoluteDisplayTest.kt
@@ -1,89 +1,35 @@
 package com.noop.ui
 
-import com.noop.data.DailyMetric
-import org.junit.Assert.assertEquals
+import com.noop.analytics.VitalBands
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * #1636: the Skin Temperature screen leads with the night's ABSOLUTE, with the deviation beneath it.
+ * #1636: the skin-temp TILE leads with the night's ABSOLUTE, with the deviation beneath it.
  *
  * A deviation with no anchor cannot be read — the reporter's flu night was "+0.94 Δ°F", which looks
- * like nothing, against 96.4 °F on a 94.4 °F mean, which reads as a fever. Both numbers are needed and
- * neither is sufficient.
+ * like nothing, against 96.4 °F on a 94.4 °F mean. Both numbers are needed and neither is sufficient.
  *
- * `buildVitalDetail` resolves strings through `NoopApplication` and cannot run in a JVM test, so the
- * BRANCH and the FORMATTING are extracted and asserted here — the same arrangement `Spo2MissingCaptionTest`
- * uses for the same reason. Twin of Swift `SkinTempAbsoluteDisplayTests`.
+ * `vitalsFor` resolves strings through `NoopApplication` and cannot run in a JVM test at all, so the
+ * BRANCH and the FORMATTING are asserted through their pure seams — the arrangement
+ * `Spo2MissingCaptionTest` already uses for the same reason. Twin of Swift `SkinTempAbsoluteDisplayTests`.
  */
 class SkinTempAbsoluteDisplayTest {
 
-    private fun row(day: String, abs: Double? = null, dev: Double? = null) =
-        DailyMetric(deviceId = "my-whoop", day = day, skinTempC = abs, skinTempDevC = dev)
-
-    // The branch: absolute-led or the pre-#1636 deviation-led fallback
+    // The branch: absolute-led, or the pre-#1636 deviation-led display
 
     @Test
-    fun theFreshestMeasuredAbsoluteWins() {
-        val days = listOf(
-            row("2026-08-23", abs = 33.9, dev = -0.2),
-            row("2026-08-24", abs = 34.1, dev = 0.0),
-            row("2026-08-25", abs = 34.6, dev = 0.52),
-        )
-        assertEquals(34.6, latestSkinAbsoluteC(days)!!, 1e-12)
+    fun aNightThatMeasuredAnAbsoluteLeadsWithIt() {
+        assertTrue(skinTempLeadsWithAbsolute(34.6))
     }
 
     @Test
-    fun historyPredatingTheColumnFallsBackRatherThanShowingNothing() {
-        // Every night deviation-only: the screen must keep its old behaviour, not blank out.
-        val days = listOf(row("2026-08-24", dev = -0.2), row("2026-08-25", dev = 0.52))
-        assertNull(latestSkinAbsoluteC(days))
-    }
-
-    @Test
-    fun aPartlyRescoredHistoryStillLeadsWithTheAbsolute() {
-        // Older nights predate the column; the recent ones were re-scored. Newest-first means the
-        // wearer gets the absolute rather than waiting for the whole history to refill.
-        val days = listOf(
-            row("2026-08-20", dev = -0.4),
-            row("2026-08-21", dev = -0.1),
-            row("2026-08-25", abs = 34.6, dev = 0.52),
-        )
-        assertEquals(34.6, latestSkinAbsoluteC(days)!!, 1e-12)
-    }
-
-    @Test
-    fun anEmptyHistoryHasNoAbsolute() {
-        assertNull(latestSkinAbsoluteC(emptyList()))
-    }
-
-    /**
-     * The regression this guard exists for: an import-only night is NEWER than the last strap night.
-     * Leading with the absolute would show a stale reading dressed as the current one, so the screen
-     * stays deviation-led until the strap catches up.
-     */
-    @Test
-    fun aNewerImportOnlyNightSuppressesTheOlderAbsolute() {
-        val days = listOf(
-            row("2026-08-24", abs = 34.6, dev = 0.52),   // the strap's last scored night
-            row("2026-08-25", dev = 0.20),               // a WHOOP CSV import: deviation only
-        )
-        assertNull(latestSkinAbsoluteC(days))
-    }
-
-    @Test
-    fun anImportOnlyNightOLDERThanTheAbsoluteDoesNotSuppressIt() {
-        val days = listOf(
-            row("2026-08-24", dev = 0.20),               // older import
-            row("2026-08-25", abs = 34.6, dev = 0.52),   // the freshest night has both
-        )
-        assertEquals(34.6, latestSkinAbsoluteC(days)!!, 1e-12)
-    }
-
-    @Test
-    fun anAbsoluteOnTheSameDayAsTheFreshestDeviationStillLeads() {
-        val days = listOf(row("2026-08-25", abs = 34.6, dev = 0.52))
-        assertEquals(34.6, latestSkinAbsoluteC(days)!!, 1e-12)
+    fun aNightPredatingTheColumnKeepsTheOldDisplay() {
+        // Deviation-only: the tile must look exactly as it did before, not blank out.
+        assertFalse(skinTempLeadsWithAbsolute(null))
     }
 
     // The secondary note: the deviation, in the user's own unit
@@ -107,9 +53,52 @@ class SkinTempAbsoluteDisplayTest {
         assertEquals("+1.8 Δ°F", skinTempSecondaryNote(1.0, fahrenheit = true))
     }
 
+    // The caption ordering, the Kotlin twin of Swift's stateCaption assertions
+
+    private fun tile(secondary: String?, caveat: String? = null, band: VitalBands.Band = VitalBands.Band.IN_RANGE) =
+        Vital(
+            key = "skin", label = "Skin Temp", unit = "°C", value = 34.6,
+            format = { String.format(java.util.Locale.US, "%.1f", it) },
+            missingCaption = "none",
+            banding = VitalBands.Result(band, VitalBands.Basis.PERSONAL, 24),
+            metricColor = androidx.compose.ui.graphics.Color.Yellow,
+            caveat = caveat, secondary = secondary,
+        )
+
     @Test
-    fun aNightWithNoDeviationOmitsTheLine() {
-        // Printing an empty note under the headline would read as a missing value rather than none.
+    fun theSecondaryLeadsTheCaptionSoItSitsUnderTheValue() {
+        assertTrue(tile(secondary = "+0.9 Δ°F").stateCaption.startsWith("+0.9 Δ°F · "))
+    }
+
+    @Test
+    fun withoutASecondaryTheCaptionIsUnchanged() {
+        // Every other vital passes null, so their captions must be byte-identical to before.
+        assertEquals("In your range", tile(secondary = null).stateCaption)
+    }
+
+    @Test
+    fun theSecondaryIsIndependentOfTheCaveat() {
+        // `caveat` says the reading is unreliable; `secondary` says what it means. A tile may carry
+        // both, and they must not be confused for one another.
+        val caption = tile(secondary = "+0.9 Δ°F", caveat = "unverified").stateCaption
+        assertTrue(caption.startsWith("+0.9 Δ°F · "))
+        assertTrue(caption.endsWith("unverified"))
+    }
+
+    @Test
+    fun anEmptyTileNeverCarriesASecondary() {
+        // The caption there is the "why it's empty" line; a number beside it would contradict it.
+        assertEquals("none", tile(secondary = "+0.9 Δ°F", band = VitalBands.Band.NO_DATA).stateCaption)
+    }
+
+    /**
+     * A CALIBRATING night is the case worth having: `recomputeSkinTempDev` returns null until the
+     * baseline is usable (~4 nights) while the absolute is already measured. The tile leads with the
+     * temperature and simply omits the note, rather than printing an empty line under the headline.
+     */
+    @Test
+    fun aCalibratingNightLeadsWithTheAbsoluteAndOmitsTheNote() {
+        assertTrue(skinTempLeadsWithAbsolute(34.6))
         assertNull(skinTempSecondaryNote(null, fahrenheit = false))
         assertNull(skinTempSecondaryNote(null, fahrenheit = true))
     }


### PR DESCRIPTION
Requested by @justinjor-bit in #1636. The display half — #1663 persisted the value, this surfaces it.

## What was wrong

The skin-temp tile only ever showed a deviation, and a deviation with no anchor cannot be read. `+0.9` is a fever or a warm bedroom and nothing on the tile says which.

Their flu night read `+0.94 Δ°F`, which looks like nothing. The absolute was `96.4 °F` against a 24-night mean of `94.4 °F`, on the night their recovery scored 6/100. Same night, same data — only one of those two numbers reads as a fever, and the app was showing the other one.

## Scoped to the tile, deliberately

The first version of this PR changed **Android's detail and iOS's tile**. Those are not the same surface, and both platforms have both — so it left each platform's screen disagreeing with its own drill-in: tapping an Android tile went from `+0.2 Δ°C` to `34.6 °C`, and iOS went the other way. That is the #1664 defect, reintroduced an hour after merging it. The second commit reverts that and rebuilds around the tile.

The tile is the surface both platforms share, both can read from `skinTempC`, and it has **no range picker** — which matters more than it sounds. The detail's range chips key off the displayed series, so a 21-day absolute history would have locked `M`/`3M`/`6M`/`1Y` for anyone with real history, **permanently**: `analyzeRecent` defaults to `maxDays: 21` and the only full-history re-scores are one-time flag-gated migrations that have already run. That also corrects something I wrote on #1663 — "existing nights refill on the next scoring pass" is true only for the trailing three weeks.

## The rule

Both platforms: **resolve the displayed night, then lead with its absolute if it has one.** Asking about the row already being shown is what stops the tile stepping back to an older night — an import-only night carries a deviation and no absolute.

A **calibrating** night is the reverse, and is a real win. `recomputeSkinTempDev` returns nil until the baseline is usable (~4 nights) while the absolute is already measured — so those wearers currently read *"No nightly skin-temp yet — needs ~4 worn nights"* with a real temperature sitting unshown behind it. Now they see it, with no note beneath.

When the night has no absolute, both fall through to exactly the deviation-led tile that shipped before.

## The secondary slot

iOS gains `secondary`, kept deliberately **distinct from `caveat`**: caveat says a reading is unreliable, secondary says what it means. A tile can carry both, and conflating them would make a deviation read like a warning. Kotlin gains the twin field and the same caption ordering — the secondary leads, so it sits directly under the headline.

Banding, the sparkline, the range caption and the previous-value delta all follow whichever series is displayed. An absolute scored against a history of deviations would be nonsense.

## A bug the rescope caught

The first version's iOS secondary reached for the freshest deviation *anywhere*, so on a calibrating night it would have printed a **previous night's** number under tonight's temperature. Now bound to the displayed night.

## Verification

**10 Kotlin tests + 5 Swift**, same fixtures. `vitalsFor` resolves strings through `NoopApplication` and cannot run in a JVM test at all, so the branch and the formatting are asserted through pure seams — the arrangement `Spo2MissingCaptionTest` already uses for the same reason. Both suites pin the same formatting from opposite sides:

```
+0.5 Δ°C   /   +0.9 Δ°F      (the reporter's 0.52 °C night)
-0.5 Δ°C   /   -0.9 Δ°F
               +1.8 Δ°F      (a whole degree of DEVIATION — never 33.8)
```

and the same caption ordering: the secondary leads, an empty tile never carries one, and `caveat` remains independent.

- Android: **4526 tests green**, `compileFullDebugKotlin` clean
- `doc_comment_lint` and `i18n_audit --ci` clean — the secondary is formatted numbers and unit symbols, never a sentence, so it adds no translatable string
- App-target Swift has no default CI, so `VitalSignsSummary.swift` and the new `StrandTests` file are validated by an on-demand `app-build` run — posted below before merge

## Not addressed

**The detail screens.** Android's reads `DailyMetric`; iOS's reads the `skin_temp` metric series, which carries no absolute at all. Bringing them across is a data-path change and its own concern — and it needs the range-lock question answered first.

**`skinTempDevC` is still bimodal** — CSV/Health imports write an absolute wrist °C into it. The new column is unambiguous, which makes migrating the importers tractable, but that is a data migration.
