### PR TITLE
capture: an empty raw capture is no capture, not a successful share

### DIFF
--- a/android/app/src/main/java/com/noop/ui/LogExport.kt
+++ b/android/app/src/main/java/com/noop/ui/LogExport.kt
@@ -157,7 +157,9 @@ object LogExport {
             // present when a 5/MG owner has the opt-in capture on and a history sync has run.
             val main = File(context.filesDir, com.noop.ble.WhoopBleClient.WHOOP5_CAPTURE_FILE)
             val prev = File(context.filesDir, "${com.noop.ble.WhoopBleClient.WHOOP5_CAPTURE_FILE}.1")
-            if (main.exists() || prev.exists()) {
+            // Same rule as the interactive share: content, not existence. An empty capture file would
+            // otherwise put a zero-byte `.bin` into every scheduled drop, forever.
+            if (captureHasFrames(main.length(), prev.length())) {
                 val rawFile = File(dir, rawCaptureFilename(nowMs))
                 rawFile.outputStream().bufferedWriter().use { w ->
                     for (f in listOf(prev, main)) if (f.exists()) f.bufferedReader().use { r -> r.copyTo(w) }
@@ -281,7 +283,16 @@ object LogExport {
     private fun writeCaptureFile(context: Context): File? {
         val main = File(context.filesDir, com.noop.ble.WhoopBleClient.WHOOP5_CAPTURE_FILE)
         val prev = File(context.filesDir, "${com.noop.ble.WhoopBleClient.WHOOP5_CAPTURE_FILE}.1")
-        if (!main.exists() && !prev.exists()) return null
+        // An EMPTY capture is no capture. This used to gate on the files EXISTING, and existence is not
+        // evidence that anything was recorded: `startWhoop5BackfillCapture` opens in append mode, which
+        // CREATES the file the moment capture starts. A strap that never completes its handshake then
+        // produces a zero-byte capture that still exists — and the share emitted a 282-byte header with
+        // no frames under it, reporting success for a night that recorded nothing.
+        //
+        // Returning null here routes those to `noCaptureMsg`, which already knows how to explain the
+        // common cause: without the encrypted bond the puffin notify chars are never subscribed, so no
+        // frames can reach the writer at all.
+        if (captureHasFrames(main.length(), prev.length()).not()) return null
         val header = buildString {
             appendLine("# NOOP 5/MG raw backfill capture (JSONL; one frame per line)")
             appendLine("# App: ${BuildConfig.VERSION_NAME} (${BuildConfig.TIER}) · Android ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT}) · ${Build.MANUFACTURER} ${Build.MODEL}")
@@ -330,7 +341,9 @@ object LogExport {
     private fun writeCaptureLogFile(context: Context): File? {
         val main = File(context.filesDir, com.noop.ble.WhoopBleClient.CAPTURE_LOG_FILE)
         val prev = File(context.filesDir, "${com.noop.ble.WhoopBleClient.CAPTURE_LOG_FILE}.1")
-        if (!main.exists() && !prev.exists()) return null
+        // Content, not existence — the same flaw the raw capture had. This writer opens on demand too,
+        // so a toggle switched on with nothing yet logged would share a header and no log under it.
+        if (captureHasFrames(main.length(), prev.length()).not()) return null
         val header = buildString {
             appendLine("# NOOP detailed capture — rolling strap log (PII-scrubbed at source)")
             appendLine("# App: ${BuildConfig.VERSION_NAME} (${BuildConfig.TIER}) · Android ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT}) · ${Build.MANUFACTURER} ${Build.MODEL}")
@@ -380,6 +393,15 @@ object LogExport {
         encryptedBond = encryptedBond,
         sharingLog = sharingLog,
     )
+
+    /**
+     * Whether the on-disk capture holds any frames at all.
+     *
+     * `File.length()` is 0 for a file that does not exist, so this subsumes the old existence check and
+     * additionally rejects a file that was opened and never written. Pure so the rule is assertable
+     * without touching the filesystem.
+     */
+    internal fun captureHasFrames(mainBytes: Long, prevBytes: Long): Boolean = mainBytes + prevBytes > 0L
 
     /**
      * The no-capture copy, as a pure function of what we know.

--- a/android/app/src/test/java/com/noop/ui/EmptyRawCaptureTest.kt
+++ b/android/app/src/test/java/com/noop/ui/EmptyRawCaptureTest.kt
@@ -1,0 +1,71 @@
+package com.noop.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * An EMPTY 5/MG raw capture must report as no capture, not as a successful share.
+ *
+ * Field report: a capture left running overnight produced a 282-byte file — the three header comment
+ * lines and not one frame. The share path gated on the capture file EXISTING, and existence proves
+ * nothing was recorded: `startWhoop5BackfillCapture` opens in APPEND mode, which creates the file the
+ * moment capture starts.
+ *
+ * The cause is upstream and known: the puffin notify characteristics are subscribed only in the
+ * CLIENT_HELLO-ack branch, so a 5/MG that never completes its handshake (#1635) can never deliver a
+ * frame to the writer. `noCaptureMsgText` already explains exactly that — it simply never ran, because
+ * the empty file looked like a capture. This is the gate that lets it run.
+ */
+class EmptyRawCaptureTest {
+
+    @Test
+    fun `a capture file that exists but holds no frames is not a capture`() {
+        // The reported night: capture started (so the file exists) and recorded nothing.
+        assertFalse(LogExport.captureHasFrames(mainBytes = 0L, prevBytes = 0L))
+    }
+
+    @Test
+    fun `a capture with frames in the live file counts`() {
+        assertTrue(LogExport.captureHasFrames(mainBytes = 4_096L, prevBytes = 0L))
+    }
+
+    @Test
+    fun `a capture whose only frames are in the ROTATED generation still counts`() {
+        // The live file can be freshly rotated and empty while the previous generation holds the
+        // material — dropping that would discard exactly the long-run capture this feature exists for.
+        assertTrue(LogExport.captureHasFrames(mainBytes = 0L, prevBytes = 4_096L))
+    }
+
+    @Test
+    fun `absent files report as no capture`() {
+        // File.length() is 0 for a file that does not exist, so the old existence check is subsumed
+        // rather than replaced — a never-started capture still reports as no capture.
+        assertFalse(LogExport.captureHasFrames(mainBytes = 0L, prevBytes = 0L))
+    }
+
+    @Test
+    fun `the same rule guards the detailed capture log and the scheduled drop`() {
+        // Both had the identical exists()-not-content flaw: the log writer opens on demand too, and the
+        // scheduled auto-export would otherwise write a zero-byte .bin into every drop, forever. One
+        // predicate now decides all three, so a future caller cannot get a fourth one subtly different.
+        assertFalse(LogExport.captureHasFrames(0L, 0L))
+        assertTrue(LogExport.captureHasFrames(1L, 0L))
+        assertTrue(LogExport.captureHasFrames(0L, 1L))
+    }
+
+    /**
+     * The message the gate now lets through, for the night that was actually reported: capture on,
+     * strap connected, no encrypted bond. It must not tell the wearer to wait for a sync their strap
+     * cannot reach — they already waited all night.
+     */
+    @Test
+    fun `an unbonded strap is told why, not told to wait`() {
+        val msg = LogExport.noCaptureMsgText(
+            whoop5Connected = true, captureEnabled = true, encryptedBond = false, sharingLog = false,
+        )
+        assertTrue(msg.contains("encrypted pairing"))
+        assertFalse("waiting is not the remedy when the strap cannot pair",
+                    msg.contains("Let a 5/MG history sync run"))
+    }
+}


### PR DESCRIPTION
## What happened

A 5/MG raw capture left running **overnight** produced a 282-byte file: the three header comment lines and not one frame. The share reported success.

```
# NOOP 5/MG raw backfill capture (JSONL; one frame per line)
# App: 10.6.1-staging (full) · Android 16 (SDK 36) · samsung SM-F966B
# NOTE: contains raw biometric frames …
```

That is the entire file.

## Why the share said nothing

`writeCaptureFile` gated on the capture file **existing** — and existence is not evidence that anything was recorded. `startWhoop5BackfillCapture` opens with `FileWriter(f, append = true)`, which **creates** the file the moment capture starts. So at that gate, a night that captured nothing is indistinguishable from a night that captured everything.

## Why the capture was empty

Known, and not fixed here. The puffin notify characteristics (`fd4b0003/4/5/7`) are subscribed at **exactly one place** — inside the `completionIsClientHelloAck` branch — and `writeWhoop5BackfillCapture` has **exactly one** call site, which only ever sees frames from those characteristics. A 5/MG that never completes its handshake therefore cannot deliver a frame to the writer at all.

There is an uncomfortable interaction worth stating plainly: **#1642 suppresses that handshake to stop the reconnect loop.** The change that took this strap from a 4.8-second bounce to a stable 26-minute link is also what guarantees its raw capture is empty. The comment above the capture call already said an unbonded 5/MG "still produces an empty capture" — the code knew; nothing told the user.

## The fix

`noCaptureMsgText` **already has the right words** for this exact case:

> "Raw capture is on, but this strap is on live HR only — history sync needs the full encrypted pairing, so there are no sync frames to capture yet."

and `NoCaptureMsgTest` already pins that it must *not* tell someone to wait for a sync their strap cannot reach. That message simply never ran, because the empty file looked like a capture. This PR is the gate that lets it run: **content, not existence.**

`File.length()` is 0 for a file that does not exist, so the old existence check is subsumed rather than replaced — a never-started capture still reports as no capture.

## Fixed at all three sites, not just the reported one

| site | was |
|---|---|
| interactive share (`writeCaptureFile`) | the reported bug |
| detailed-capture **log** (`writeCaptureLogFile`) | identical `exists()`-not-content flaw |
| scheduled auto-export | would write a zero-byte `.bin` into **every** drop, forever |

One predicate now decides all three, so a fourth caller cannot get a subtly different rule. Two of tonight's other PRs turned out to be the unfinished halves of earlier work — the chart-formatter change covered the other eleven call sites left behind by #463 — and this one is not going to join them.

## Verification

6 new tests, including the reported night (capture on, strap connected, no encrypted bond) asserting the wearer is told **why** rather than told to wait — they already waited all night.

Android **4522 tests green**, `doc_comment_lint` and `i18n_audit --ci` clean. Android-only, so no `app-build` run is needed. No BLE path touched: capture behaviour is unchanged, this is what the app *says* about a capture, not how it records one.

## What this does not do

It does not make the capture non-empty. That needs the pairing failure resolved, or the standard-profile notifications captured instead — a different feature, and mostly already-decoded data.
