### PR TITLE
diagnostics: stop calling a second strap's night a read failure

### DIFF
--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -199,7 +199,14 @@ enum DebugDataDiagnostics {
             // back empty, so a healthy install pays nothing.
             let elsewhere = ((try? await store.rawSampleCountsByDevice(from: cs.startTs, to: cs.endTs)) ?? [])
                 .filter { $0.0 != did }
-            lines.append(orphanedSamplesLine(activeId: did, othersWithSamples: elsewhere))
+            // The registry, so a SECOND strap's night is not reported as a read failure. Only read when
+            // the active id came back empty, so a healthy install still pays nothing.
+            let otherStraps = Set(
+                ((try? DeviceRegistryStore(dbQueue: store.registryWriter).all()) ?? [])
+                    .filter { $0.status != .archived && $0.id != did }
+                    .map(\.id))
+            lines.append(orphanedSamplesLine(activeId: did, othersWithSamples: elsewhere,
+                                             otherLiveStrapIds: otherStraps))
             return lines
         }
         if let rem = SleepStager.remFunnelDiagnostic(start: cs.startTs, end: cs.endTs, grav: grav, hr: hr, rr: rr, resp: resp) {
@@ -476,10 +483,26 @@ enum DebugDataDiagnostics {
     ///
     /// Pure so the wording is unit-tested without a database, a strap, or a registry. Kotlin twin:
     /// `com.noop.testcentre.orphanedSamplesLine`.
-    static func orphanedSamplesLine(activeId: String, othersWithSamples: [(String, Int)]) -> String {
+    /// `otherLiveStrapIds` is the registered, non-archived device ids OTHER than the active one. It exists
+    /// because the "not being read" wording was itself an over-assertion — the mirror image of the one it
+    /// replaced. A wearer with TWO straps has nights owned by the other one, and `DayOwnerResolver` hands
+    /// each day to whichever device actually holds its data. Samples under another id are then completely
+    /// normal, and calling that a read failure sends the reader hunting a bug that is not there. Only when
+    /// the id holding the samples is NOT a live registered strap is the #1193 split the explanation left.
+    static func orphanedSamplesLine(activeId: String, othersWithSamples: [(String, Int)],
+                                    otherLiveStrapIds: Set<String> = []) -> String {
         if othersWithSamples.isEmpty {
             return "(no raw biometric samples under '\(activeId)' for this night — expected on a freshly "
                 + "re-added strap; reconnect + let a history sync run, then re-export)"
+        }
+        let ownedByAnotherStrap = othersWithSamples.filter { otherLiveStrapIds.contains($0.0) }
+        if !ownedByAnotherStrap.isEmpty {
+            let who = ownedByAnotherStrap.sorted { $0.1 != $1.1 ? $0.1 > $1.1 : $0.0 < $1.0 }
+                .map { "'\($0.0)' (\($0.1) rows)" }
+                .joined(separator: ", ")
+            return "(no raw biometric samples under the ACTIVE id '\(activeId)' for this night — they are "
+                + "under \(who), another registered strap. A night worn on a different strap is OWNED by that "
+                + "strap, so this is expected; the dayOwner line for this date names the owner.)"
         }
         // Tie-break on id: Kotlin's sortedByDescending is stable but Swift's `sorted` is NOT, so equal
         // counts could otherwise order differently on the two platforms and the twin lines would diverge.

--- a/StrandTests/OrphanedSamplesLineTests.swift
+++ b/StrandTests/OrphanedSamplesLineTests.swift
@@ -45,4 +45,53 @@ final class OrphanedSamplesLineTests: XCTestCase {
         )
         XCTAssertTrue(line.contains("'whoop-aa' (50 rows), 'whoop-zz' (50 rows)"))
     }
+
+    // MARK: - #1193 wording is for a genuine split — NOT for a second strap's night
+
+    /// The over-assertion this branch exists for. A wearer with two straps has nights owned by the other
+    /// one; `DayOwnerResolver` hands each day to whichever device holds its data. Samples under that id
+    /// are expected, and calling it a read failure sends the reader hunting a bug that is not there.
+    func testASecondRegisteredStrapsNightIsExpectedNotAReadFailure() {
+        let line = DebugDataDiagnostics.orphanedSamplesLine(
+            activeId: "whoop-FD:4A",
+            othersWithSamples: [("my-whoop", 59_304)],
+            otherLiveStrapIds: ["my-whoop"])
+        XCTAssertTrue(line.contains("another registered strap"))
+        XCTAssertTrue(line.contains("'my-whoop' (59304 rows)"))
+        XCTAssertTrue(line.contains("dayOwner"), "must point at the line that settles it")
+        XCTAssertFalse(line.contains("are not being read"), "must not claim a bug")
+        XCTAssertFalse(line.contains("#1193"))
+    }
+
+    /// An id that is NOT a live registered strap is still the #1193 split — that wording must survive.
+    func testAnUnregisteredIdHoldingTheSamplesIsStillReportedAsASplit() {
+        let line = DebugDataDiagnostics.orphanedSamplesLine(
+            activeId: "whoop-FD:4A",
+            othersWithSamples: [("my-whoop", 59_304)],
+            otherLiveStrapIds: ["whoop-OTHER"])
+        XCTAssertTrue(line.contains("#1193"))
+        XCTAssertTrue(line.contains("are not being read"))
+    }
+
+    /// No registry supplied (the default) keeps every existing caller byte-identical.
+    func testWithoutARegistryTheWordingIsUnchanged() {
+        let withDefault = DebugDataDiagnostics.orphanedSamplesLine(
+            activeId: "whoop-FD:4A", othersWithSamples: [("my-whoop", 59_304)])
+        let explicitEmpty = DebugDataDiagnostics.orphanedSamplesLine(
+            activeId: "whoop-FD:4A", othersWithSamples: [("my-whoop", 59_304)], otherLiveStrapIds: [])
+        XCTAssertEqual(withDefault, explicitEmpty)
+        XCTAssertTrue(withDefault.contains("#1193"))
+    }
+
+    /// Mixed: one id is a live strap, one is not — the live strap explains it, so no bug is claimed.
+    func testALiveStrapAmongTheIdsWinsOverTheSplitWording() {
+        let line = DebugDataDiagnostics.orphanedSamplesLine(
+            activeId: "whoop-FD:4A",
+            othersWithSamples: [("orphan-id", 10), ("my-whoop", 59_304)],
+            otherLiveStrapIds: ["my-whoop"])
+        XCTAssertTrue(line.contains("another registered strap"))
+        XCTAssertTrue(line.contains("'my-whoop' (59304 rows)"))
+        XCTAssertFalse(line.contains("'orphan-id'"),
+                       "the orphan id is not the story when a real strap owns the night")
+    }
 }

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -196,7 +196,15 @@ object AndroidDiagnostics {
                     repo.rawSampleCountsByDevice(session.startTs, session.endTs)
                         .filter { it.first != id }
                 }.getOrDefault(emptyList())
-                add(orphanedSamplesLine(id, elsewhere))
+                // The registry, so a SECOND strap's night is not reported as a read failure. Only queried
+                // when the active id came back empty, so a healthy install still pays nothing.
+                val otherStraps = runCatching {
+                    repo.pairedDevices()
+                        .filter { it.status != "archived" && it.id != id }
+                        .map { it.id }
+                        .toSet()
+                }.getOrDefault(emptySet())
+                add(orphanedSamplesLine(id, elsewhere, otherStraps))
                 return@runCatching
             }
             com.noop.analytics.SleepStager.remFunnelDiagnostic(session.startTs, session.endTs, grav, hr, rr, resp)
@@ -478,12 +486,33 @@ object AndroidDiagnostics {
      * the same window. Empty means the samples genuinely are not there and the fresh-re-add wording is
      * right; non-empty names the id that has them so the split is visible rather than inferred.
      *
+     * [otherLiveStrapIds] is the registered, non-archived device ids OTHER than the active one. It exists
+     * because the "not being read" wording was itself an over-assertion — the mirror image of the one it
+     * replaced. A wearer with TWO straps has nights owned by the other one, and [DayOwnerResolver] hands
+     * each day to whichever device actually holds its data. Samples under another id are then completely
+     * normal, and calling that a read failure sends the reader hunting a bug that is not there (it sent
+     * ME hunting one). Only when the id holding the samples is NOT a live registered strap is the #1193
+     * split the remaining explanation.
+     *
      * Pure so the wording is unit-tested without a database, a strap, or a registry.
      */
-    internal fun orphanedSamplesLine(activeId: String, othersWithSamples: List<Pair<String, Int>>): String {
+    internal fun orphanedSamplesLine(
+        activeId: String,
+        othersWithSamples: List<Pair<String, Int>>,
+        otherLiveStrapIds: Set<String> = emptySet(),
+    ): String {
         if (othersWithSamples.isEmpty()) {
             return "(no raw biometric samples under '$activeId' for this night — expected on a freshly " +
                 "re-added strap; reconnect + let a history sync run, then re-export)"
+        }
+        val ownedByAnotherStrap = othersWithSamples.filter { it.first in otherLiveStrapIds }
+        if (ownedByAnotherStrap.isNotEmpty()) {
+            val who = ownedByAnotherStrap
+                .sortedWith(compareByDescending<Pair<String, Int>> { it.second }.thenBy { it.first })
+                .joinToString(", ") { "'${it.first}' (${it.second} rows)" }
+            return "(no raw biometric samples under the ACTIVE id '$activeId' for this night — they are " +
+                "under $who, another registered strap. A night worn on a different strap is OWNED by that " +
+                "strap, so this is expected; the dayOwner line for this date names the owner.)"
         }
         // Tie-break on id: Kotlin's sortedByDescending is stable but Swift's `sorted` is NOT, so equal
         // counts could otherwise order differently on the two platforms and the twin lines would diverge.

--- a/android/app/src/test/java/com/noop/testcentre/OrphanedSamplesLineTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/OrphanedSamplesLineTest.kt
@@ -1,6 +1,7 @@
 package com.noop.testcentre
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -56,5 +57,65 @@ class OrphanedSamplesLineTest {
             listOf("whoop-zz" to 50, "whoop-aa" to 50),
         )
         assertTrue(line.contains("'whoop-aa' (50 rows), 'whoop-zz' (50 rows)"))
+    }
+
+    // #1193 wording is for a genuine split — NOT for a second strap's night
+
+    /**
+     * The over-assertion this branch exists for. A wearer with two straps has nights owned by the other
+     * one; DayOwnerResolver hands each day to whichever device holds its data. Samples under that id are
+     * expected, and calling it a read failure sends the reader hunting a bug that is not there.
+     */
+    @Test
+    fun `a second registered strap's night is expected, not a read failure`() {
+        val line = AndroidDiagnostics.orphanedSamplesLine(
+            activeId = "whoop-FD:4A",
+            othersWithSamples = listOf("my-whoop" to 59_304),
+            otherLiveStrapIds = setOf("my-whoop"),
+        )
+        assertTrue(line.contains("another registered strap"))
+        assertTrue(line.contains("'my-whoop' (59304 rows)"))
+        assertTrue("must point at the line that settles it", line.contains("dayOwner"))
+        assertFalse("must not claim a bug", line.contains("are not being read"))
+        assertFalse(line.contains("#1193"))
+    }
+
+    /** An id that is NOT a live registered strap is still the #1193 split — that wording must survive. */
+    @Test
+    fun `an unregistered id holding the samples is still reported as a split`() {
+        val line = AndroidDiagnostics.orphanedSamplesLine(
+            activeId = "whoop-FD:4A",
+            othersWithSamples = listOf("my-whoop" to 59_304),
+            otherLiveStrapIds = setOf("whoop-OTHER"),   // my-whoop is not a live device row
+        )
+        assertTrue(line.contains("#1193"))
+        assertTrue(line.contains("are not being read"))
+    }
+
+    /** No registry supplied (the default) keeps every existing caller byte-identical. */
+    @Test
+    fun `without a registry the wording is unchanged`() {
+        val withDefault = AndroidDiagnostics.orphanedSamplesLine(
+            "whoop-FD:4A", listOf("my-whoop" to 59_304),
+        )
+        val explicitEmpty = AndroidDiagnostics.orphanedSamplesLine(
+            "whoop-FD:4A", listOf("my-whoop" to 59_304), emptySet(),
+        )
+        assertEquals(withDefault, explicitEmpty)
+        assertTrue(withDefault.contains("#1193"))
+    }
+
+    /** Mixed: one id is a live strap, one is not — the live strap explains it, so no bug is claimed. */
+    @Test
+    fun `a live strap among the ids wins over the split wording`() {
+        val line = AndroidDiagnostics.orphanedSamplesLine(
+            activeId = "whoop-FD:4A",
+            othersWithSamples = listOf("orphan-id" to 10, "my-whoop" to 59_304),
+            otherLiveStrapIds = setOf("my-whoop"),
+        )
+        assertTrue(line.contains("another registered strap"))
+        assertTrue(line.contains("'my-whoop' (59304 rows)"))
+        assertFalse("the orphan id is not the story when a real strap owns the night",
+                    line.contains("'orphan-id'"))
     }
 }


### PR DESCRIPTION
## What the log said

From an overnight strap log, for a wearer with two straps:

```
Night 2026-08-26: grav=0 hr=0 rr=0 resp=0 skin=0
(no raw biometric samples under the ACTIVE id 'whoop-FD:…:4A' for this night — they are
 under 'my-whoop' (59304 rows) instead. The history spine and the raw stream are on
 different device ids (#1193); this is NOT a fresh re-add, the samples exist and are
 not being read.)
```

**They were being read.** The wearer had worn the *other* strap that night, and `DayOwnerResolver` had correctly given the night to it. The same log's own `dayOwner` lines say so:

```
dayOwner day=2026-08-26  readId=whoop-FD:…:4A  hrRows=36014   ← the 5/MG, and it has data
dayOwner day=2026-08-25  readId=my-whoop       hrRows=192680  ← the 4.0, worn overnight
dayOwner day=2026-08-24  readId=my-whoop       hrRows=191322
```

Owner resolution worked exactly as designed — `resolve` filters candidates on `hasData` and picks the lowest priority. Nothing was unread.

## Why the line was wrong

It knows two things: the active id has no samples for this night, and another id does. From that it concluded a **read failure** — one of two explanations, and not the likelier one for anybody who owns two straps.

That is the mirror image of the bug it was written to fix. Its own doc comment records replacing an over-confident *innocent* explanation ("expected on a freshly re-added strap") because that "ends the investigation at the point it should begin" — and then does the same thing in the opposite direction. CLAUDE.md's rule is that **a diagnostic may only assert what it can attribute**.

It cost me a real investigation: I reported "59,304 rows exist and are not being read" as a finding before the `dayOwner` lines corrected me. The next person reading their own log would pay the same.

## The change

A third branch. When an id holding the samples is a **registered, non-archived strap**, the line says so and points at the `dayOwner` line that names the owner — no bug claimed:

> (no raw biometric samples under the ACTIVE id 'whoop-FD:4A' for this night — they are under 'my-whoop' (59304 rows), **another registered strap. A night worn on a different strap is OWNED by that strap, so this is expected;** the dayOwner line for this date names the owner.)

When the id is **not** a live device row, the #1193 split genuinely is the remaining explanation and that wording is untouched.

The registry is read only when the active id came back empty, so a healthy install still pays nothing — the same condition the existing `rawSampleCountsByDevice` probe already lives behind.

## Verification

**4 new tests per platform**, same fixtures, asserting the same properties — including that the benign wording contains neither `#1193` nor `are not being read`, that an *unregistered* id still gets the split wording, and that a live strap among mixed ids wins over an orphan.

Prose parity was checked by **extracting and comparing the assembled string literals**, not by reading them side by side:

```
BYTE-IDENTICAL: True
```

The new parameter defaults to empty, so every existing caller and both original test suites are byte-identical.

- Android: **4536 tests green**, `compileFullDebugKotlin` clean
- `doc_comment_lint` and `i18n_audit --ci` clean
- App-target Swift has no default CI, so `DebugDataDiagnostics.swift` and the Swift tests are validated by an on-demand `app-build` run — posted below before merge

## Not addressed

The pairing failure behind that log (`createBond` accepted, `BOND_NONE`, five times overnight) is untouched and still unexplained. This only stops the log misdirecting whoever investigates it next.
