### PR TITLE
ble: the bond poll cannot convict Android, and an HCI capture says it is wrong

### DIFF
--- a/android/app/src/main/java/com/noop/ble/BondStateTrace.kt
+++ b/android/app/src/main/java/com/noop/ble/BondStateTrace.kt
@@ -112,7 +112,13 @@ internal fun bondStateAtConnectLine(bondState: Int, address: String?): String {
  *
  * Polling the device directly removes the broadcast from the chain, so the answer no longer depends on
  * the component under suspicion. A `BOND_BONDING` here with no transition line above it convicts our
- * receiver; a `BOND_NONE` clears it and puts the silence on Android.
+ * receiver; a `BOND_NONE` clears it.
+ *
+ * It does NOT, however, put the silence on Android — which is what this line used to say, and it was
+ * wrong. An HCI capture of exactly this case settled it: the phone DOES transmit an SMP Pairing Request,
+ * and a WHOOP 5/MG answers `Pairing Failed — Pairing Not Supported (0x05)`. A refused pairing ends at
+ * BOND_NONE with no BONDED transition, which is indistinguishable from never starting when all you can
+ * see is the bond state. Two causes, one observation; the old verdict picked one and stated it as fact.
  *
  * Deliberately a single delayed read rather than a subscription: one fact is wanted, not a stream.
  */
@@ -126,8 +132,11 @@ internal fun bondStatePollLine(bondState: Int, sawTransitionLine: Boolean): Stri
             " — pairing underway, as the transition line already said"
         bondState == android.bluetooth.BluetoothDevice.BOND_BONDED -> " — paired"
         !sawTransitionLine ->
-            " — createBond was accepted but the device never left this state and nothing was heard," +
-                " so Android did not begin pairing at all"
+            " — createBond was accepted and the bond did not complete. This is NOT evidence that Android" +
+                " stayed silent: a REFUSED pairing ends here too. On a WHOOP 5/MG an HCI capture shows the" +
+                " phone does transmit a Pairing Request and the strap answers \"Pairing Not Supported\"" +
+                " (SMP 0x05), which lands in exactly this state (#1635). Only an HCI capture separates a" +
+                " refused pairing from one never attempted"
         else -> " — back to this state after a transition"
     }
     return "bond state poll: $name$verdict"

--- a/android/app/src/test/java/com/noop/ble/BondStateTraceTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BondStateTraceTest.kt
@@ -130,10 +130,22 @@ class BondStateTraceTest {
         assertTrue(line.contains("a NOOP bug, not the strap"))
     }
 
+    /**
+     * The verdict this line used to give was "Android did not begin pairing at all". An HCI capture of
+     * exactly this case disproved it: the phone DOES transmit an SMP Pairing Request and a WHOOP 5/MG
+     * answers "Pairing Failed — Pairing Not Supported" (0x05). A refused pairing ends at BOND_NONE with
+     * no BONDED transition, which is indistinguishable from never starting if the bond state is all you
+     * can see. The line must now name both causes and the capture that separates them.
+     */
     @Test
-    fun `NONE with no transition line puts the silence on Android`() {
+    fun `NONE with no transition line names BOTH causes rather than convicting Android`() {
         val line = bondStatePollLine(android.bluetooth.BluetoothDevice.BOND_NONE, sawTransitionLine = false)
-        assertTrue(line.contains("did not begin pairing at all"))
+        assertFalse("the disproved verdict must not come back", line.contains("did not begin pairing at all"))
+        assertFalse("nor its softer form", line.contains("nothing was heard"))
+        assertTrue("a refusal must be named as the other cause", line.contains("REFUSED pairing ends here too"))
+        assertTrue("the known 5/MG answer belongs in the line", line.contains("Pairing Not Supported"))
+        assertTrue(line.contains("SMP 0x05"))
+        assertTrue("name the discriminator", line.contains("HCI capture"))
         assertFalse(line.contains("NOOP bug"))
     }
 


### PR DESCRIPTION
## What the line said

```
bond state poll: BOND_NONE — createBond was accepted but the device never left
this state and nothing was heard, so Android did not begin pairing at all
```

## What an HCI capture says

The phone **does** transmit an SMP Pairing Request. The WHOOP 5/MG answers:

```
phone→strap  PAIRING REQUEST   IO=KeyboardDisplay  AuthReq=0x2d (bonding, MITM, SC)  keysize=16
strap→phone  PAIRING FAILED  →  reason 0x05 "Pairing Not Supported"
```

**Six times across two btsnoop sessions**, every exchange identical — from a strap whose sibling WHOOP 4.0 (`WHOOP 4C1246632`) is bonded normally on the same phone, in the same bond table.

A **refused** pairing ends at `BOND_NONE` with no `BONDED` transition, which is indistinguishable from never starting when the bond state is all you can see. Two causes, one observation — and the verdict picked one and stated it as fact.

The ATT layer corroborates it: 452 writes, 619 notifications, and **zero** `Insufficient Authentication` or `Insufficient Encryption` errors. The strap is not gating anything on a bond. It simply does not do SMP pairing.

## The change

The verdict now names both causes, carries the known 5/MG answer, and names the HCI capture as the only thing that separates them.

**The bond-state logic is untouched.** It was never wrong about what it read — only about what that meant. This is a wording change to a diagnostic, with no behavioural effect.

## Why this one is worth the churn

That line cost an entire evening's investigation. It pointed at the phone — "Android did not begin pairing" — while the strap had been answering plainly the whole time. Every step after it built on a false premise.

It is also the **third** diagnostic this week to assert more than it observed, after the trends-report unit line and the night-funnel "the samples exist and are not being read". The rule in CLAUDE.md exists because of exactly this, and I keep finding it violated in lines I trusted.

One line comes out of this **vindicated**, and is deliberately left alone: `reconnect paused=bondLoop (strap refusing bond)`. The strap really is refusing.

## Verification

The test that pinned the disproved wording now pins its **absence** plus the corrected content — so the old verdict cannot quietly return:

```kotlin
assertFalse("the disproved verdict must not come back", line.contains("did not begin pairing at all"))
assertFalse("nor its softer form",                      line.contains("nothing was heard"))
assertTrue ("a refusal must be named as the other cause", line.contains("REFUSED pairing ends here too"))
assertTrue ("the known 5/MG answer belongs in the line",  line.contains("Pairing Not Supported"))
assertTrue (line.contains("SMP 0x05"))
assertTrue ("name the discriminator",                     line.contains("HCI capture"))
```

- Android: **4536 tests green**, `doc_comment_lint` and `i18n_audit --ci` clean
- Android-only — `BondStateTrace` has no Swift twin, so no `app-build` run is needed
- No behaviour change; no BLE path altered

## What this evidence reopens, and does not settle

Two decisions follow from the capture and are deliberately **not** taken here:

- **The explicit-bond path cannot succeed on a 5/MG.** It asks the strap to do something it answers "not supported" to. Retiring or gating it is a behavioural change.
- **The hello suppression looks different now.** It was the right call against a 4.8-second reconnect loop, but with SMP categorically unavailable the app-level `CLIENT_HELLO` is the only remaining route to the puffin channel — and suppressing it is why raw captures come back empty.

Both deserve their own change and their own argument.
