### PR TITLE
ble: opt-in switch to send the CLIENT_HELLO despite the suppression latch

### DIFF
--- a/android/app/src/main/java/com/noop/ble/ExplicitBond.kt
+++ b/android/app/src/main/java/com/noop/ble/ExplicitBond.kt
@@ -57,8 +57,22 @@ internal fun shouldRequestExplicitBond(
  * The hello is left for the NEXT connection. If the pairing succeeds the strap is OS-bonded by then, the
  * link comes up already encrypted, and the write has a chance to complete for the first time. If it fails
  * the strap is no worse off than it is today, and the trace says which happened.
+ *
+ * That reasoning assumed the pairing might succeed. An HCI capture has since shown it cannot: a 5/MG
+ * answers every Pairing Request with SMP `Pairing Not Supported` (0x05). So "leave it for the next
+ * connect" never resolves — the next connect requests a bond too, and defers again. The deferral is
+ * permanent, which is why neither capture contains a single hello write.
+ *
+ * [helloOverride] breaks that cycle. The write-while-pairing hazard it guards against is real, but there
+ * is no pairing in flight to protect: the refusal arrives in milliseconds, long before the hello. Someone
+ * who has explicitly opted into "send hello despite bond refusal" is asking for exactly this write, and
+ * silently swallowing it because a doomed pairing was requested first would make that switch a no-op for
+ * everyone running the pairing experiment — which is precisely who would turn it on.
  */
-internal fun explicitBondDefersHello(requestedThisLink: Boolean): Boolean = requestedThisLink
+internal fun explicitBondDefersHello(
+    requestedThisLink: Boolean,
+    helloOverride: Boolean = false,
+): Boolean = requestedThisLink && !helloOverride
 
 /**
  * The outcome line when `createBond()` THREW rather than returning.

--- a/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
+++ b/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
@@ -6,9 +6,16 @@ package com.noop.ble
  * The #1635 field captures show the hello is what ends the link. Across two sessions and sixteen writes it
  * was never once acknowledged, and the drop is locked to the HELLO rather than to the connect: 3.158s,
  * 3.159s, 3.155s after the write, cycle after cycle, while live HR streams happily over the standard
- * profile the whole time. The bond-state trace added for this (#1639) records no OS pairing attempt at all,
- * so the strap is not refusing a pairing — the write simply never completes and the local stack drops the
- * ACL, which the log reports as an unattributed GATT status 22.
+ * profile the whole time. The bond-state trace added for this (#1639) records no OS pairing attempt at all
+ * — the write simply never completes and the local stack drops the ACL, which the log reports as an
+ * unattributed GATT status 22.
+ *
+ * That trace was later read as "the strap is not refusing a pairing". An HCI capture disproves it: the
+ * phone DOES transmit an SMP Pairing Request and the strap answers `Pairing Not Supported` (0x05). The
+ * refusal is real, and it is categorical — the encrypted bond this hello was waiting behind can never
+ * arrive on a 5/MG. That does not invalidate the suppression, whose evidence is about the hello's own
+ * fate, but it does mean suppressing it leaves the app attempting NEITHER handshake. Hence the opt-in
+ * override below.
  *
  * The result is a strap that CAN deliver live HR being knocked off every five seconds by a handshake that
  * has never once succeeded. Suppressing the hello after the give-up latches trades an unreachable
@@ -31,7 +38,8 @@ package com.noop.ble
 internal fun shouldSendClientHello(
     suppressedForDevice: Boolean,
     userInitiated: Boolean,
-): Boolean = !suppressedForDevice || userInitiated
+    overrideSuppression: Boolean = false,
+): Boolean = !suppressedForDevice || userInitiated || overrideSuppression
 
 /**
  * Should the give-up latch suppress the hello, rather than pause auto-reconnect?

--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -111,6 +111,25 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
         get() = prefs.getBoolean(KEY_MOTION_AWARE_WAKE, false)
         set(v) = prefs.edit().putBoolean(KEY_MOTION_AWARE_WAKE, v).apply()
 
+    /**
+     * Send the CLIENT_HELLO even when the suppression latch says not to (default false, #1635).
+     *
+     * The latch exists because the hello was never once acknowledged and the drop is locked to it. But an
+     * HCI capture has since changed the premise it was reasoned from: the strap answers `createBond` with
+     * SMP `Pairing Not Supported` (0x05), so the encrypted bond the hello was waiting behind can NEVER
+     * arrive. With SMP unavailable and the hello suppressed, the app now attempts NEITHER handshake — the
+     * same capture shows zero writes to fd4b0002 other than DISABLE_ALARM, and zero puffin subscriptions.
+     *
+     * Whether the strap will answer a hello on a link it has explicitly refused to encrypt is unknown, and
+     * unknowable without asking. This switch asks. It is deliberately its own toggle rather than a change
+     * to the latch: the latch's reasoning is still sound for anyone whose strap DOES bond, and the failure
+     * mode it prevents (hello, drop at ~4.8s, reconnect, forever) is real. Opting in accepts that loop in
+     * exchange for the answer.
+     */
+    var helloDespiteBondRefusal: Boolean
+        get() = prefs.getBoolean(KEY_HELLO_DESPITE_REFUSAL, false)
+        set(v) = prefs.edit().putBoolean(KEY_HELLO_DESPITE_REFUSAL, v).apply()
+
     /** True if the user opted in to "Ask Android to pair" (#1635, default false): NOOP calls
      *  `BluetoothDevice.createBond()` explicitly instead of relying on a write to the encrypted
      *  characteristic to provoke pairing — which the #1639 bond-state trace showed never happens at all.
@@ -163,6 +182,9 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
         /** "Ask Android to pair" opt-in — the explicit `createBond()` experiment (#1635). Android-only,
          *  so no macOS key to mirror. */
         const val KEY_EXPLICIT_BOND = "noopWhoop5ExplicitBond"
+
+        /** #1635: send the CLIENT_HELLO even when the suppression latch is set. Default OFF. */
+        const val KEY_HELLO_DESPITE_REFUSAL = "noopWhoop5HelloDespiteRefusal"
 
         /** The 5/MG-only probe keys, in ONE place: [resetFiveMGGatedProbes] clears exactly these, and
          *  SettingsScreen watches exactly these for external writes. Two lists would drift. */

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -8703,8 +8703,14 @@ class WhoopBleClient(
                 staleDirectBond = staleDirectBond,
                 status = status,
                 alreadyPausedForBondLoop = autoReconnectPausedForBondLoop,
+                // The question is whether the hello was ACTUALLY withheld on this link, not whether the
+                // latch is set. With the #1635 override on, the latch stays set while we send the hello
+                // anyway — and reading the raw pref here would disable the give-up for exactly the case
+                // that needs it, leaving an unbounded hello-drop-reconnect loop with nothing to stop it.
+                // Mirrors the `suppressed && !override` decision that chose to send.
                 helloSuppressed = runCatching {
-                    com.noop.ui.NoopPrefs.helloSuppressed(context, lastDeviceAddress)
+                    com.noop.ui.NoopPrefs.helloSuppressed(context, lastDeviceAddress) &&
+                        !PuffinExperiment.from(context).helloDespiteBondRefusal
                 }.getOrDefault(false),
             ) && bondWatchdogBackoff.recordBounce()
         ) {

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7636,7 +7636,12 @@ class WhoopBleClient(
                         onFailure = { log(explicitBondThrewLine(it.javaClass.simpleName, where)) },
                     )
                 }
-                if (explicitBondDefersHello(explicitBondRequestedThisLink)) {
+                // #1635: read once, before the deferral gate — the override has to reach BOTH, or a
+                // deferred hello returns early and the switch below is never evaluated at all.
+                val helloOverride = runCatching {
+                    PuffinExperiment.from(context).helloDespiteBondRefusal
+                }.getOrDefault(false)
+                if (explicitBondDefersHello(explicitBondRequestedThisLink, helloOverride = helloOverride)) {
                     // Same trap as the suppression path below, and worse here. The watchdog was armed at
                     // discovery and bounces the link whenever didBond is false — which deferring the hello
                     // guarantees. Tearing the link down while an OS pairing is in flight is the single
@@ -7660,13 +7665,6 @@ class WhoopBleClient(
                 helloRetryRequested = false
                 val suppressed = runCatching {
                     com.noop.ui.NoopPrefs.helloSuppressed(context, g.device.address)
-                }.getOrDefault(false)
-                // #1635: the opt-in override. An HCI capture shows the strap answers createBond with SMP
-                // "Pairing Not Supported", so the encrypted bond the hello waits behind cannot arrive —
-                // and with the hello suppressed the app attempts NEITHER handshake. Read fresh per connect,
-                // like the probes gate, so flipping it takes effect on the next connect without a restart.
-                val helloOverride = runCatching {
-                    PuffinExperiment.from(context).helloDespiteBondRefusal
                 }.getOrDefault(false)
                 if (shouldSendClientHello(suppressed, userInitiated = userAsked, overrideSuppression = helloOverride)) {
                     if (suppressed && helloOverride && !userAsked) {

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7661,7 +7661,22 @@ class WhoopBleClient(
                 val suppressed = runCatching {
                     com.noop.ui.NoopPrefs.helloSuppressed(context, g.device.address)
                 }.getOrDefault(false)
-                if (shouldSendClientHello(suppressed, userInitiated = userAsked)) {
+                // #1635: the opt-in override. An HCI capture shows the strap answers createBond with SMP
+                // "Pairing Not Supported", so the encrypted bond the hello waits behind cannot arrive —
+                // and with the hello suppressed the app attempts NEITHER handshake. Read fresh per connect,
+                // like the probes gate, so flipping it takes effect on the next connect without a restart.
+                val helloOverride = runCatching {
+                    PuffinExperiment.from(context).helloDespiteBondRefusal
+                }.getOrDefault(false)
+                if (shouldSendClientHello(suppressed, userInitiated = userAsked, overrideSuppression = helloOverride)) {
+                    if (suppressed && helloOverride && !userAsked) {
+                        // Say WHY a suppressed strap is getting a hello anyway, or the next reader sees the
+                        // latch set and a hello on the wire and has to guess which of them is broken.
+                        log("WHOOP 5/MG: CLIENT_HELLO sent DESPITE the suppression latch — \"send hello" +
+                            " despite bond refusal\" is on. The strap refuses SMP pairing (Pairing Not" +
+                            " Supported), so this is the only handshake left to try; expect the ~4.8s drop" +
+                            " loop to return if it still goes unanswered (#1635, experimental).")
+                    }
                     writeClientHello(g, cmd)
                 } else {
                     // The watchdog was armed at discovery, before this decision could be made, and it

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -587,6 +587,7 @@ fun SettingsScreen(
     val r22FlagCount = Whoop5Config.enableR22Sequence.size
     var broadcastHr by remember(rev) { mutableStateOf(puffinExperiment.broadcastHr) }
     var explicitBond by remember(rev) { mutableStateOf(puffinExperiment.explicitBond) }
+    var helloDespiteRefusal by remember(rev) { mutableStateOf(puffinExperiment.helloDespiteBondRefusal) }
     // ECG raw-data gate (#891): the opt-in, the write result, and the attested-MG gate the buttons need.
     var ecgRawData by remember(rev) { mutableStateOf(puffinExperiment.ecgRawData) }
     val ecgGateReport by vm.ble.ecgRawDataGate.collectAsStateWithLifecycle()
@@ -2336,6 +2337,40 @@ fun SettingsScreen(
                         ),
                         modifier = Modifier.semantics {
                             contentDescription = uiString(R.string.l10n_settings_screen_ask_android_to_pair_323fccbe)
+                        },
+                    )
+                }
+
+                // --- Send the hello even when the suppression latch is set. (#1635) ---
+                // An HCI capture shows the strap answers createBond with SMP "Pairing Not Supported", so
+                // the bond the hello waits behind can never arrive — and with the hello suppressed the app
+                // attempts neither handshake. This asks the only question left.
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    Text(
+                        uiString(R.string.l10n_settings_screen_send_hello_despite_bond_refusal_experimental_2f8de795),
+                        style = NoopType.subhead,
+                        color = Palette.textPrimary,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Switch(
+                        checked = helloDespiteRefusal,
+                        onCheckedChange = {
+                            helloDespiteRefusal = it
+                            puffinExperiment.helloDespiteBondRefusal = it
+                        },
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = Palette.surfaceBase,
+                            checkedTrackColor = Palette.accent,
+                            uncheckedThumbColor = Palette.textSecondary,
+                            uncheckedTrackColor = Palette.surfaceInset,
+                            uncheckedBorderColor = Palette.hairline,
+                        ),
+                        modifier = Modifier.semantics {
+                            contentDescription = uiString(R.string.l10n_settings_screen_send_hello_despite_bond_refusal_65c9d9fd)
                         },
                     )
                 }

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2466,4 +2466,6 @@
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Android um Kopplung bitten (experimentell)</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP hat bisher darauf gesetzt, dass ein Schreibvorgang an dein 5.0/MG Android zur Kopplung veranlasst. Das passiert nie. Diese Option fragt Android direkt und kann einen System-Kopplungsdialog anzeigen. Die Live-Herzfrequenz funktioniert in beiden Fällen weiter; schalte sie aus, wenn der Dialog stört.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Android um Kopplung bitten</string>
+    <string name="l10n_settings_screen_send_hello_despite_bond_refusal_experimental_2f8de795">Hello trotz Kopplungsverweigerung senden (experimentell)</string>
+    <string name="l10n_settings_screen_send_hello_despite_bond_refusal_65c9d9fd">Hello trotz Kopplungsverweigerung senden</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2452,4 +2452,6 @@
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Pedir a Android que vincule (experimental)</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP siempre ha confiado en que escribir en tu 5.0/MG hiciera que Android lo vinculara. Nunca ocurre. Esta opción se lo pide a Android directamente, por lo que puede mostrar un diálogo de vinculación del sistema. La frecuencia cardíaca en directo sigue funcionando igualmente; desactívala si el diálogo molesta.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Pedir a Android que vincule</string>
+    <string name="l10n_settings_screen_send_hello_despite_bond_refusal_experimental_2f8de795">Enviar hello pese al rechazo de vinculación (experimental)</string>
+    <string name="l10n_settings_screen_send_hello_despite_bond_refusal_65c9d9fd">Enviar hello pese al rechazo de vinculación</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2451,4 +2451,6 @@
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Demander à Android de s\'appairer (expérimental)</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP a toujours compté sur l\'écriture vers votre 5.0/MG pour qu\'Android s\'appaire. Cela n\'arrive jamais. Cette option le demande directement à Android et peut afficher une boîte de dialogue d\'appairage du système. La fréquence cardiaque en direct continue de fonctionner dans les deux cas ; désactivez-la si la boîte de dialogue vous gêne.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Demander à Android de s\'appairer</string>
+    <string name="l10n_settings_screen_send_hello_despite_bond_refusal_experimental_2f8de795">Envoyer le hello malgré le refus d\'appairage (expérimental)</string>
+    <string name="l10n_settings_screen_send_hello_despite_bond_refusal_65c9d9fd">Envoyer le hello malgré le refus d\'appairage</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2457,4 +2457,6 @@
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Poproś Androida o sparowanie (eksperymentalne)</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP zawsze liczył na to, że zapis do 5.0/MG skłoni Androida do sparowania. To się nigdy nie dzieje. Ta opcja prosi Androida bezpośrednio, więc może pojawić się systemowe okno parowania. Tętno na żywo działa tak czy inaczej; wyłącz, jeśli okno przeszkadza.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Poproś Androida o sparowanie</string>
+    <string name="l10n_settings_screen_send_hello_despite_bond_refusal_experimental_2f8de795">Wyślij hello mimo odmowy parowania (eksperymentalne)</string>
+    <string name="l10n_settings_screen_send_hello_despite_bond_refusal_65c9d9fd">Wyślij hello mimo odmowy parowania</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2445,4 +2445,6 @@
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Pedir ao Android para emparelhar (experimental)</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">O NOOP sempre contou que escrever na sua 5.0/MG fizesse o Android emparelhar. Isso nunca acontece. Esta opção pede diretamente ao Android, pelo que pode mostrar uma caixa de diálogo de emparelhamento do sistema. A frequência cardíaca em direto continua a funcionar de qualquer forma; desative se a caixa de diálogo incomodar.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Pedir ao Android para emparelhar</string>
+    <string name="l10n_settings_screen_send_hello_despite_bond_refusal_experimental_2f8de795">Enviar hello apesar da recusa de emparelhamento (experimental)</string>
+    <string name="l10n_settings_screen_send_hello_despite_bond_refusal_65c9d9fd">Enviar hello apesar da recusa de emparelhamento</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2366,4 +2366,6 @@
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">请求 Android 配对（实验性）</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP 一直寄望于向 5.0/MG 写入数据来促使 Android 配对，但这从未发生。此选项会直接请求 Android，因此可能弹出系统配对对话框。无论哪种方式，实时心率都会继续工作；如果对话框造成困扰，请关闭此选项。</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">请求 Android 配对</string>
+    <string name="l10n_settings_screen_send_hello_despite_bond_refusal_experimental_2f8de795">即使拒绝配对也发送 hello（实验性）</string>
+    <string name="l10n_settings_screen_send_hello_despite_bond_refusal_65c9d9fd">即使拒绝配对也发送 hello</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2478,4 +2478,6 @@
     <string name="l10n_health_screen_your_strap_reports_a_blood_oxygen_349fe34a">Your strap reports a blood oxygen estimate, but it is unverified and off by default. Turn on the strap estimate in Settings to see it, or import a WHOOP export in Data Sources for the calibrated value.</string>
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">No blood oxygen percentage from a WHOOP 4.0</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">Your strap banks the raw optical channels, but NOOP does not turn them into a blood oxygen percentage, so this stays empty however long you wear it. Import a WHOOP export in Data Sources to fill it from your account history.</string>
+    <string name="l10n_settings_screen_send_hello_despite_bond_refusal_experimental_2f8de795">Send hello despite bond refusal (experimental)</string>
+    <string name="l10n_settings_screen_send_hello_despite_bond_refusal_65c9d9fd">Send hello despite bond refusal</string>
 </resources>

--- a/android/app/src/test/java/com/noop/ble/ExplicitBondTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ExplicitBondTest.kt
@@ -78,4 +78,31 @@ class ExplicitBondTest {
         assertFalse(threw.contains("refused to START pairing"))
         assertFalse(refused.contains("local problem"))
     }
+
+    // #1635: the deferral is permanent unless the override breaks it
+
+    /**
+     * The capture that forced this. "Leave the hello for the next connect" assumed the pairing might
+     * succeed; a 5/MG answers every Pairing Request with `Pairing Not Supported`, and the next connect
+     * requests a bond and defers again. Two full btsnoop captures contain zero hello writes as a result.
+     */
+    @Test
+    fun `without the override a requested bond defers the hello forever`() {
+        assertTrue(explicitBondDefersHello(requestedThisLink = true))
+        assertTrue(explicitBondDefersHello(requestedThisLink = true, helloOverride = false))
+    }
+
+    /** The override breaks the cycle — otherwise the switch is a no-op for everyone running the
+     *  pairing experiment, which is exactly who would turn it on. */
+    @Test
+    fun `the override lets the hello through despite a requested bond`() {
+        assertFalse(explicitBondDefersHello(requestedThisLink = true, helloOverride = true))
+    }
+
+    /** No bond requested means nothing to defer, override or not. */
+    @Test
+    fun `no bond request never defers`() {
+        assertFalse(explicitBondDefersHello(requestedThisLink = false))
+        assertFalse(explicitBondDefersHello(requestedThisLink = false, helloOverride = true))
+    }
 }

--- a/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
@@ -99,4 +99,30 @@ class HelloSuppressionTest {
         assertTrue(shouldSendClientHello(suppressedForDevice = true, userInitiated = true,
                                          overrideSuppression = false))
     }
+
+    /**
+     * The give-up must still fire while the override is sending hellos.
+     *
+     * `shouldCountNeverBondedSelfDrop` skips counting when the hello was withheld — correct, because a
+     * suppressed strap's drops are ordinary link losses, not a failing handshake. But the override leaves
+     * the LATCH set while sending the hello anyway, so reading the raw pref there would disable the
+     * give-up for precisely the case that needs it: an unbounded hello-drop-reconnect loop with nothing
+     * to stop it. The caller passes `suppressed && !override`, which is the same expression that decided
+     * to send. This pins the semantics that expression has to satisfy.
+     */
+    @Test
+    fun `a drop counts toward the give-up whenever the hello was actually sent`() {
+        // Effective suppression = the latch AND no override. These are the four combinations.
+        fun effectivelySuppressed(latched: Boolean, override: Boolean) = latched && !override
+        assertTrue(effectivelySuppressed(latched = true, override = false))    // withheld: do not count
+        assertFalse(effectivelySuppressed(latched = true, override = true))    // SENT: must count
+        assertFalse(effectivelySuppressed(latched = false, override = false))  // sent normally: counts
+        assertFalse(effectivelySuppressed(latched = false, override = true))   // sent: counts
+        // And the send decision agrees with it in every case.
+        for (latched in listOf(true, false)) for (ov in listOf(true, false)) {
+            val sent = shouldSendClientHello(latched, userInitiated = false, overrideSuppression = ov)
+            assertTrue("counting must be the inverse of withholding",
+                       sent != effectivelySuppressed(latched, ov))
+        }
+    }
 }

--- a/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
@@ -62,4 +62,41 @@ class HelloSuppressionTest {
         // it asks for a pairing instead, which is self-limiting.
         assertFalse(shouldSendClientHello(suppressedForDevice = true, userInitiated = false))
     }
+
+    // #1635: the opt-in override, after the HCI capture changed the premise
+
+    /**
+     * The capture showed the strap answers createBond with SMP "Pairing Not Supported", so the encrypted
+     * bond the hello waits behind can never arrive. With the hello also suppressed the app attempts
+     * NEITHER handshake — the same capture shows zero writes to fd4b0002 beyond DISABLE_ALARM and zero
+     * puffin subscriptions. The override exists to ask the only question left.
+     */
+    @Test
+    fun `the override sends the hello on a suppressed strap`() {
+        assertTrue(shouldSendClientHello(suppressedForDevice = true, userInitiated = false,
+                                         overrideSuppression = true))
+    }
+
+    /** Default OFF must leave the latch behaving exactly as it did — no behaviour change for anyone else. */
+    @Test
+    fun `without the override a suppressed strap still skips the hello`() {
+        assertFalse(shouldSendClientHello(suppressedForDevice = true, userInitiated = false))
+        assertFalse(shouldSendClientHello(suppressedForDevice = true, userInitiated = false,
+                                          overrideSuppression = false))
+    }
+
+    /** The override is not needed to explain an unsuppressed strap, and must not change it. */
+    @Test
+    fun `an unsuppressed strap is unaffected by the override either way`() {
+        assertTrue(shouldSendClientHello(suppressedForDevice = false, userInitiated = false))
+        assertTrue(shouldSendClientHello(suppressedForDevice = false, userInitiated = false,
+                                         overrideSuppression = true))
+    }
+
+    /** A user-initiated Connect already overrode the latch; the new switch must not disturb that path. */
+    @Test
+    fun `a user-initiated connect still wins on its own`() {
+        assertTrue(shouldSendClientHello(suppressedForDevice = true, userInitiated = true,
+                                         overrideSuppression = false))
+    }
 }


### PR DESCRIPTION
## What the capture changed

The suppression latch was reasoned from a premise an HCI capture has since disproved.

```
phone→strap  PAIRING REQUEST
strap→phone  PAIRING FAILED  →  0x05 "Pairing Not Supported"
```

Six times across two sessions. The encrypted bond the CLIENT_HELLO waits behind **can never arrive on a 5/MG**.

And the same capture shows what that leaves:

| | |
|---|---|
| writes to `fd4b0002` | 4 — **all `DISABLE_ALARM`**, no hello |
| CCCD subscribes to puffin notify chars | **0** |
| notifications from puffin chars | **0** |

**With SMP refused by the strap and the hello suppressed by us, the app attempts neither handshake.** The strap is left with no route to a session at all — which is why raw captures come back as a 282-byte header with no frames under it.

## What this adds

An opt-in switch — *Send hello despite bond refusal (experimental)* — that sends the CLIENT_HELLO even when the latch is set. **Default off.**

Whether the strap will answer a hello on a link it has explicitly refused to encrypt is unknown, and unknowable without asking. This asks.

**Deliberately a separate toggle, not a change to the latch.** The latch's own evidence is untouched and still correct: sixteen unanswered writes, the drop locked to the hello at ~3.16 s, live HR streaming happily throughout. For anyone whose strap *does* bond, that reasoning still holds. Opting in accepts the ~4.8 s reconnect loop in exchange for the answer, and the switch says so.

`shouldSendClientHello` gains a third **defaulted** parameter, so every existing caller and all seven existing tests are byte-identical.

## Also corrected

`HelloSuppression`'s doc read *"the strap is not refusing a pairing"*. It is refusing, categorically. That claim descends from the same bond-poll line the capture disproved.

When the override fires on a suppressed strap it **logs why** — otherwise the next reader finds the latch set and a hello on the wire and has to guess which of them is broken.

## Verification

4 new tests:

- the override sends the hello on a suppressed strap
- **default off leaves the latch byte-identical** — no behaviour change for anyone who doesn't opt in
- an unsuppressed strap is unaffected either way
- a user-initiated Connect still wins on its own

Plus:

- Android **4540 tests green**, `compileFullDebugKotlin` clean
- `doc_comment_lint` clean — it caught me inserting the new property between `explicitBond`'s doc block and its declaration, which is exactly the trap that lint exists for
- `i18n_audit --ci` clean, and **`lintVitalFullRelease` clean** — run because new strings across seven locales are precisely what compile and the audit both miss
- Strings added to all 7 locales (en/de/es/fr/pl/pt-PT/zh) with keys derived by the repo's own algorithm, validated by reproducing two existing keys before minting new ones

**Android-only**: the latch, the toggle, and CoreBluetooth's lack of an explicit-bond API are all Android-side.

## What this does not claim

It does not fix anything. It is an instrument for one experiment: turn it on, connect, take an HCI capture, and see whether the hello is answered now that we know a bond will never precede it.

If it goes unanswered again, the answer is that a 5/MG will not talk to a non-WHOOP app at all without something we have not found — and the next artefact needed is a capture of the **official app** doing a sync (issue #103), not more of ours.
