### PR TITLE
ble: bound the hello override so it cannot loop the link forever

### DIFF
--- a/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
+++ b/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
@@ -42,6 +42,44 @@ internal fun shouldSendClientHello(
 ): Boolean = !suppressedForDevice || userInitiated || overrideSuppression
 
 /**
+ * How many times the #1635 override may write an unanswered hello before it stops on its own.
+ *
+ * The override needs a bound that does not depend on the disconnect status, and the shared give-up cannot
+ * supply one. `shouldCountNeverBondedSelfDrop` excludes `GATT_CONN_TERMINATE_LOCAL_HOST` (0x16) because
+ * that normally means WE hung up — our own `gatt.disconnect()` or the bond-watchdog bounce — and counting
+ * those would be self-referential. But the hello failure arrives as exactly that status: the strap answers
+ * the write with ATT `Insufficient Authentication`, the local stack tries to elevate security, SMP is
+ * refused, and the stack tears the ACL down. Not our teardown, same status code.
+ *
+ * Field result of leaving it unbounded: 57 reconnect cycles in an hour, each ~4.8s, with nothing able to
+ * stop it. So the cap lives here instead — small enough to spare the battery, large enough that a strap
+ * which answers on a later attempt is not written off.
+ */
+internal const val HELLO_OVERRIDE_MAX_ATTEMPTS = 6
+
+/**
+ * May the override write another hello, given how many it has already written unanswered?
+ *
+ * Counted per app process and reset on a genuine bond. A process restart resets it too, which is the
+ * honest limit of an in-memory bound — but the loop it exists to stop runs within one process, and a
+ * restart is not the failure mode.
+ */
+internal fun overrideHelloStillAllowed(
+    attemptsSoFar: Int,
+    cap: Int = HELLO_OVERRIDE_MAX_ATTEMPTS,
+): Boolean = attemptsSoFar < cap
+
+/**
+ * The line printed when the override gives up, so the log says why the hello stopped rather than leaving
+ * a reader to notice its absence.
+ */
+internal fun helloOverrideExhaustedLine(attempts: Int): String =
+    "WHOOP 5/MG: \"send hello despite bond refusal\" has written $attempts unanswered hellos — stopping." +
+        " The strap answers the write with Insufficient Authentication and refuses SMP pairing, so the" +
+        " handshake cannot complete; continuing would only loop the link. Turn the switch off to return to" +
+        " the stable live-HR state (#1635)."
+
+/**
  * Should the give-up latch suppress the hello, rather than pause auto-reconnect?
  *
  * The two give-up causes want opposite treatment, which is why they are split here rather than sharing

--- a/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
+++ b/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
@@ -70,6 +70,39 @@ internal fun overrideHelloStillAllowed(
 ): Boolean = attemptsSoFar < cap
 
 /**
+ * Is the override actually in force — opted in AND with budget left?
+ *
+ * Every reader must ask through here rather than reading the pref directly. A spent override is not
+ * "on": the hello genuinely stops going out, and a caller still reading the raw pref believes a hello
+ * is on the wire that is not. That is the `didBond`-reader trap from CLAUDE.md pointed the other way,
+ * and it had already reached [shouldCountNeverBondedSelfDrop]: with the budget spent, the app is in the
+ * deliberate suppressed-hello live-HR state, but the raw pref reported the hello as still being sent, so
+ * the never-bonded detector kept counting self-drops and would eventually pause auto-reconnect and raise
+ * the stale-pairing guide — telling the user to re-pair for a cause that never happened.
+ *
+ * The boundary is deliberate: the link carrying the LAST permitted hello reads as inactive at its own
+ * disconnect, because [helloOverrideAttempts] is charged when that hello is written. Under-counting that
+ * one drop is the wanted behaviour — no further hello follows it, so the loop is already over, and
+ * counting it could trip the pause at the exact moment the override retires.
+ */
+internal fun helloOverrideActive(
+    optedIn: Boolean,
+    attemptsSoFar: Int,
+    cap: Int = HELLO_OVERRIDE_MAX_ATTEMPTS,
+): Boolean = optedIn && overrideHelloStillAllowed(attemptsSoFar, cap)
+
+/**
+ * Does flipping the switch to on re-arm a spent budget?
+ *
+ * Turning the experiment off and on again is the user explicitly asking for another try, and without
+ * this they would not get one: the counter outlives the toggle, so re-enabling a spent override does
+ * nothing whatsoever — and silently, because the give-up line is one-shot and has already latched. The
+ * edge is sampled per connect, which is the only moment the override can act anyway.
+ */
+internal fun helloOverrideBudgetRearms(optedInNow: Boolean, optedInLastSeen: Boolean): Boolean =
+    optedInNow && !optedInLastSeen
+
+/**
  * The line printed when the override gives up, so the log says why the hello stopped rather than leaving
  * a reader to notice its absence.
  */

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7643,9 +7643,17 @@ class WhoopBleClient(
                 val overrideOptedIn = runCatching {
                     PuffinExperiment.from(context).helloDespiteBondRefusal
                 }.getOrDefault(false)
+                // Flipping the switch off and back on is the user asking for another try. The counter
+                // outlives the toggle, so without this a re-enabled override does nothing at all — and
+                // says nothing, the give-up line having already latched.
+                if (helloOverrideBudgetRearms(overrideOptedIn, helloOverrideOptInSeen)) {
+                    helloOverrideAttempts = 0
+                    helloOverrideExhaustedLogged = false
+                }
+                helloOverrideOptInSeen = overrideOptedIn
                 // Spent budget makes the override inert rather than merely quiet: it must stop reaching the
                 // deferral bypass too, or the link keeps being taken down by a hello nobody will answer.
-                val helloOverride = overrideOptedIn && overrideHelloStillAllowed(helloOverrideAttempts)
+                val helloOverride = helloOverrideActive(overrideOptedIn, helloOverrideAttempts)
                 if (overrideOptedIn && !helloOverride && !helloOverrideExhaustedLogged) {
                     helloOverrideExhaustedLogged = true
                     log(helloOverrideExhaustedLine(helloOverrideAttempts))
@@ -8717,13 +8725,20 @@ class WhoopBleClient(
                 status = status,
                 alreadyPausedForBondLoop = autoReconnectPausedForBondLoop,
                 // The question is whether the hello was ACTUALLY withheld on this link, not whether the
-                // latch is set. With the #1635 override on, the latch stays set while we send the hello
-                // anyway — and reading the raw pref here would disable the give-up for exactly the case
-                // that needs it, leaving an unbounded hello-drop-reconnect loop with nothing to stop it.
-                // Mirrors the `suppressed && !override` decision that chose to send.
+                // latch is set. With the #1635 override in force the latch stays set while we send the
+                // hello anyway, and treating that as withheld would disable the give-up for exactly the
+                // case that needs it, leaving an unbounded hello-drop-reconnect loop with nothing to stop
+                // it. But a SPENT override withholds the hello for real, so this must ask
+                // [helloOverrideActive] rather than the raw pref — mirroring the `helloOverride` that
+                // decided whether to send. Reading the pref alone kept the detector counting after the
+                // hellos had stopped, and would have paused auto-reconnect and raised the stale-pairing
+                // guide over a cause that never happened.
                 helloSuppressed = runCatching {
                     com.noop.ui.NoopPrefs.helloSuppressed(context, lastDeviceAddress) &&
-                        !PuffinExperiment.from(context).helloDespiteBondRefusal
+                        !helloOverrideActive(
+                            PuffinExperiment.from(context).helloDespiteBondRefusal,
+                            helloOverrideAttempts,
+                        )
                 }.getOrDefault(false),
             ) && bondWatchdogBackoff.recordBounce()
         ) {
@@ -9043,6 +9058,9 @@ class WhoopBleClient(
     /** #1635: unanswered hellos the override CAUSED this process. Bounds the experiment on its own,
      *  because the shared give-up cannot — see HELLO_OVERRIDE_MAX_ATTEMPTS. Reset on a genuine bond. */
     @Volatile private var helloOverrideAttempts = 0
+
+    /** Last opt-in state the connect path saw, so an off->on flip can re-arm a spent budget (#1635). */
+    @Volatile private var helloOverrideOptInSeen = false
 
     /** One-shot guard for the give-up line. Separate from the counter because `++` on a @Volatile Int is
      *  not atomic: two overlapping connects could step past the cap together, and an `== cap` test would

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5730,6 +5730,7 @@ class WhoopBleClient(
                     // these as REALTIME_DATA — the strap rejected them on the unauthenticated link), then arm
                     // realtime HR with puffin framing. Mirrors the macOS post-bond flow.
                     didBond = true
+                    helloOverrideAttempts = 0     // #1635: the strap answered — the override's budget resets
                     cancelBondWatchdog()          // genuine bond reached — the handshake watchdog stands down (#50)
                     noteGenuineBond(g.device.address)   // #52: this strap bonds fine; clears any pin-refusal streak
                     clearPairingHint()            // #78: a genuine bond means the pairing guidance no longer applies
@@ -7638,9 +7639,16 @@ class WhoopBleClient(
                 }
                 // #1635: read once, before the deferral gate — the override has to reach BOTH, or a
                 // deferred hello returns early and the switch below is never evaluated at all.
-                val helloOverride = runCatching {
+                val overrideOptedIn = runCatching {
                     PuffinExperiment.from(context).helloDespiteBondRefusal
                 }.getOrDefault(false)
+                // Spent budget makes the override inert rather than merely quiet: it must stop reaching the
+                // deferral bypass too, or the link keeps being taken down by a hello nobody will answer.
+                val helloOverride = overrideOptedIn && overrideHelloStillAllowed(helloOverrideAttempts)
+                if (overrideOptedIn && !helloOverride && helloOverrideAttempts == HELLO_OVERRIDE_MAX_ATTEMPTS) {
+                    helloOverrideAttempts++   // log the give-up exactly once, not on every later connect
+                    log(helloOverrideExhaustedLine(HELLO_OVERRIDE_MAX_ATTEMPTS))
+                }
                 if (explicitBondDefersHello(explicitBondRequestedThisLink, helloOverride = helloOverride)) {
                     // Same trap as the suppression path below, and worse here. The watchdog was armed at
                     // discovery and bounces the link whenever didBond is false — which deferring the hello
@@ -7667,6 +7675,7 @@ class WhoopBleClient(
                     com.noop.ui.NoopPrefs.helloSuppressed(context, g.device.address)
                 }.getOrDefault(false)
                 if (shouldSendClientHello(suppressed, userInitiated = userAsked, overrideSuppression = helloOverride)) {
+                    if (helloOverride && !userAsked) helloOverrideAttempts++
                     if (suppressed && helloOverride && !userAsked) {
                         // Say WHY a suppressed strap is getting a hello anyway, or the next reader sees the
                         // latch set and a hello on the wire and has to guess which of them is broken.
@@ -9024,6 +9033,10 @@ class WhoopBleClient(
     // puffin biometric decode needs. Gated on PuffinExperiment.isCaptureEnabled (default OFF); APPENDS
     // across sessions with per-session ids (his fork truncated per session, losing overnight data);
     // rotates at the cap; fail-soft — capture can never break the sync it observes.
+
+    /** #1635: unanswered hellos written by the override this process. Bounds the experiment on its own,
+     *  because the shared give-up cannot — see HELLO_OVERRIDE_MAX_ATTEMPTS. Reset on a genuine bond. */
+    @Volatile private var helloOverrideAttempts = 0
 
     @Volatile private var captureWriter: java.io.BufferedWriter? = null
     @Volatile private var captureDisabled = false

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5731,6 +5731,7 @@ class WhoopBleClient(
                     // realtime HR with puffin framing. Mirrors the macOS post-bond flow.
                     didBond = true
                     helloOverrideAttempts = 0     // #1635: the strap answered — the override's budget resets
+                    helloOverrideExhaustedLogged = false
                     cancelBondWatchdog()          // genuine bond reached — the handshake watchdog stands down (#50)
                     noteGenuineBond(g.device.address)   // #52: this strap bonds fine; clears any pin-refusal streak
                     clearPairingHint()            // #78: a genuine bond means the pairing guidance no longer applies
@@ -7645,9 +7646,9 @@ class WhoopBleClient(
                 // Spent budget makes the override inert rather than merely quiet: it must stop reaching the
                 // deferral bypass too, or the link keeps being taken down by a hello nobody will answer.
                 val helloOverride = overrideOptedIn && overrideHelloStillAllowed(helloOverrideAttempts)
-                if (overrideOptedIn && !helloOverride && helloOverrideAttempts == HELLO_OVERRIDE_MAX_ATTEMPTS) {
-                    helloOverrideAttempts++   // log the give-up exactly once, not on every later connect
-                    log(helloOverrideExhaustedLine(HELLO_OVERRIDE_MAX_ATTEMPTS))
+                if (overrideOptedIn && !helloOverride && !helloOverrideExhaustedLogged) {
+                    helloOverrideExhaustedLogged = true
+                    log(helloOverrideExhaustedLine(helloOverrideAttempts))
                 }
                 if (explicitBondDefersHello(explicitBondRequestedThisLink, helloOverride = helloOverride)) {
                     // Same trap as the suppression path below, and worse here. The watchdog was armed at
@@ -7675,7 +7676,12 @@ class WhoopBleClient(
                     com.noop.ui.NoopPrefs.helloSuppressed(context, g.device.address)
                 }.getOrDefault(false)
                 if (shouldSendClientHello(suppressed, userInitiated = userAsked, overrideSuppression = helloOverride)) {
-                    if (helloOverride && !userAsked) helloOverrideAttempts++
+                    // Charge the budget only when the override is what put this hello on the wire: a
+                    // strap that is neither suppressed nor deferring would have sent it anyway, and
+                    // counting those would retire the experiment without ever having run it.
+                    if (helloOverride && !userAsked && (suppressed || explicitBondRequestedThisLink)) {
+                        helloOverrideAttempts++
+                    }
                     if (suppressed && helloOverride && !userAsked) {
                         // Say WHY a suppressed strap is getting a hello anyway, or the next reader sees the
                         // latch set and a hello on the wire and has to guess which of them is broken.
@@ -9034,9 +9040,14 @@ class WhoopBleClient(
     // across sessions with per-session ids (his fork truncated per session, losing overnight data);
     // rotates at the cap; fail-soft — capture can never break the sync it observes.
 
-    /** #1635: unanswered hellos written by the override this process. Bounds the experiment on its own,
+    /** #1635: unanswered hellos the override CAUSED this process. Bounds the experiment on its own,
      *  because the shared give-up cannot — see HELLO_OVERRIDE_MAX_ATTEMPTS. Reset on a genuine bond. */
     @Volatile private var helloOverrideAttempts = 0
+
+    /** One-shot guard for the give-up line. Separate from the counter because `++` on a @Volatile Int is
+     *  not atomic: two overlapping connects could step past the cap together, and an `== cap` test would
+     *  then never fire, leaving the override inert with nothing in the log to say why. */
+    @Volatile private var helloOverrideExhaustedLogged = false
 
     @Volatile private var captureWriter: java.io.BufferedWriter? = null
     @Volatile private var captureDisabled = false

--- a/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
@@ -199,4 +199,47 @@ class HelloSuppressionTest {
         // And the line reports whatever count it actually reached, not a hardcoded cap.
         assertTrue(helloOverrideExhaustedLine(9).contains("9 unanswered hellos"))
     }
+
+    /**
+     * A spent override is not "on". Every reader must agree on that, because they act in opposite
+     * directions: the connect path stops writing hellos, and the never-bonded detector must go back to
+     * counting self-drops. Reading the raw pref made the detector believe hellos were still on the wire
+     * after they had stopped.
+     */
+    @Test
+    fun `the override is only in force while opted in AND under the cap`() {
+        assertTrue(helloOverrideActive(optedIn = true, attemptsSoFar = 0))
+        assertTrue(helloOverrideActive(optedIn = true, attemptsSoFar = HELLO_OVERRIDE_MAX_ATTEMPTS - 1))
+        assertFalse(helloOverrideActive(optedIn = true, attemptsSoFar = HELLO_OVERRIDE_MAX_ATTEMPTS))
+        assertFalse(helloOverrideActive(optedIn = true, attemptsSoFar = HELLO_OVERRIDE_MAX_ATTEMPTS + 3))
+        assertFalse(helloOverrideActive(optedIn = false, attemptsSoFar = 0))
+    }
+
+    /**
+     * The never-bonded detector's input, spelled out end to end: `latch && !active`. A spent override
+     * must report the hello as withheld, or the detector keeps counting drops the hello no longer causes
+     * and eventually pauses auto-reconnect over a cause that never happened.
+     */
+    @Test
+    fun `a spent override reports the hello as withheld again`() {
+        fun withheld(latched: Boolean, optedIn: Boolean, attempts: Int) =
+            latched && !helloOverrideActive(optedIn, attempts)
+
+        assertTrue(withheld(latched = true, optedIn = false, attempts = 0))
+        // In force: the hello IS on the wire, so the detector must stay armed.
+        assertFalse(withheld(latched = true, optedIn = true, attempts = 0))
+        // Spent: the hello has genuinely stopped, so we are back to the suppressed live-HR state.
+        assertTrue(withheld(latched = true, optedIn = true, attempts = HELLO_OVERRIDE_MAX_ATTEMPTS))
+        // No latch, nothing withheld, whatever the switch says.
+        assertFalse(withheld(latched = false, optedIn = true, attempts = HELLO_OVERRIDE_MAX_ATTEMPTS))
+    }
+
+    /** Only the off->on edge re-arms, so a spent override does not silently resurrect on every connect. */
+    @Test
+    fun `flipping the switch back on re-arms the budget, staying on does not`() {
+        assertTrue(helloOverrideBudgetRearms(optedInNow = true, optedInLastSeen = false))
+        assertFalse(helloOverrideBudgetRearms(optedInNow = true, optedInLastSeen = true))
+        assertFalse(helloOverrideBudgetRearms(optedInNow = false, optedInLastSeen = true))
+        assertFalse(helloOverrideBudgetRearms(optedInNow = false, optedInLastSeen = false))
+    }
 }

--- a/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
@@ -160,4 +160,43 @@ class HelloSuppressionTest {
         assertTrue("must tell the user how to get back to a working strap",
                    line.contains("Turn the switch off"))
     }
+
+    /**
+     * The budget must only be charged for hellos the override CAUSED.
+     *
+     * `shouldSendClientHello` also returns true for a strap that is neither suppressed nor deferring a
+     * bond — that hello goes out regardless of the switch. Charging those would retire the experiment
+     * after six ordinary connects without it ever having done anything, and then report "6 unanswered
+     * hellos" about writes it never caused.
+     */
+    @Test
+    fun `the budget is charged only when the override is load-bearing`() {
+        fun charges(suppressed: Boolean, bondDeferred: Boolean, override: Boolean, userAsked: Boolean) =
+            shouldSendClientHello(suppressed, userAsked, override) &&
+                override && !userAsked && (suppressed || bondDeferred)
+
+        // Load-bearing: the hello would NOT have gone out without the override.
+        assertTrue(charges(suppressed = true, bondDeferred = false, override = true, userAsked = false))
+        assertTrue(charges(suppressed = false, bondDeferred = true, override = true, userAsked = false))
+        // Not load-bearing: nothing was standing in the hello's way.
+        assertFalse(charges(suppressed = false, bondDeferred = false, override = true, userAsked = false))
+        // A user-initiated Connect already overrides the latch on its own.
+        assertFalse(charges(suppressed = true, bondDeferred = false, override = true, userAsked = true))
+        // Switch off: never charged.
+        assertFalse(charges(suppressed = true, bondDeferred = true, override = false, userAsked = false))
+    }
+
+    /**
+     * The give-up line must still fire if the counter steps PAST the cap. `++` on a @Volatile Int is not
+     * atomic, so two overlapping connects can skip the exact boundary; an `== cap` guard would then leave
+     * the override inert with nothing in the log to explain it.
+     */
+    @Test
+    fun `the give-up condition holds past the cap, not only at it`() {
+        assertFalse(overrideHelloStillAllowed(HELLO_OVERRIDE_MAX_ATTEMPTS))
+        assertFalse(overrideHelloStillAllowed(HELLO_OVERRIDE_MAX_ATTEMPTS + 1))
+        assertFalse(overrideHelloStillAllowed(HELLO_OVERRIDE_MAX_ATTEMPTS + 7))
+        // And the line reports whatever count it actually reached, not a hardcoded cap.
+        assertTrue(helloOverrideExhaustedLine(9).contains("9 unanswered hellos"))
+    }
 }

--- a/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
@@ -125,4 +125,39 @@ class HelloSuppressionTest {
                        sent != effectivelySuppressed(latched, ov))
         }
     }
+
+    // #1635: the override must bound itself — the shared give-up cannot
+
+    /**
+     * The field failure this exists for. With the override on, the hello fails with ATT
+     * `Insufficient Authentication`, the local stack tears the ACL down, and the disconnect arrives as
+     * GATT_CONN_TERMINATE_LOCAL_HOST (22) — which `shouldCountNeverBondedSelfDrop` excludes, because that
+     * status normally means WE hung up. So nothing counted, nothing paused, and a real strap ran 57
+     * reconnect cycles in an hour. The cap does not consult the status at all.
+     */
+    @Test
+    fun `the override stops itself after the cap`() {
+        assertTrue(overrideHelloStillAllowed(0))
+        assertTrue(overrideHelloStillAllowed(HELLO_OVERRIDE_MAX_ATTEMPTS - 1))
+        assertFalse(overrideHelloStillAllowed(HELLO_OVERRIDE_MAX_ATTEMPTS))
+        assertFalse(overrideHelloStillAllowed(57))   // the observed field value
+    }
+
+    @Test
+    fun `the cap is small enough to bound the loop and large enough to be a fair test`() {
+        // ~4.8s per cycle, so the whole experiment costs well under a minute of churn.
+        assertTrue("a cap of 1 would not survive a single flaky link", HELLO_OVERRIDE_MAX_ATTEMPTS >= 3)
+        assertTrue("more than ~10 is a loop, not an experiment", HELLO_OVERRIDE_MAX_ATTEMPTS <= 10)
+    }
+
+    /** The give-up line must name the cause and the remedy, not merely announce that it stopped. */
+    @Test
+    fun `the exhausted line says why and what to do`() {
+        val line = helloOverrideExhaustedLine(HELLO_OVERRIDE_MAX_ATTEMPTS)
+        assertTrue(line.contains("unanswered hellos"))
+        assertTrue(line.contains("Insufficient Authentication"))
+        assertTrue(line.contains("refuses SMP pairing"))
+        assertTrue("must tell the user how to get back to a working strap",
+                   line.contains("Turn the switch off"))
+    }
 }


### PR DESCRIPTION
## The field failure

With the #1635 override enabled, a real WHOOP 5/MG ran **57 reconnect cycles in an hour**, ~4.8 s apiece, with nothing able to stop it:

```
[connection] connect down (uptime ends after 4.8s)
[connection] reconnect n=57 reason=localTerminate via=unknown
Disconnected (status=22); reconnecting directly in 3s
```

I had told the maintainer the experiment self-limits after four cycles. **It does not**, and the strap looped for an hour before we caught it.

## Why the shared give-up cannot bound it

`shouldCountNeverBondedSelfDrop` excludes `GATT_CONN_TERMINATE_LOCAL_HOST` (22), and that exclusion is correct on its own terms: 22 normally means *we* hung up — our own `gatt.disconnect()`, or the bond-watchdog bounce — and counting those would be self-referential.

But the hello failure arrives as **exactly that status**, for a completely different reason:

```
→ HELLO written (Write Request, fd4b0002)
← ATT ERROR 0x05  Insufficient Authentication    (+0.05s)
✗ LINK DISCONNECTED                              (+3.08s)   ← status 22
```

The strap refuses the write, the local stack tries to elevate security, SMP is refused, and the stack tears the ACL down. Not our teardown; same code. Note `via=unknown` in the log — `localTeardownOrigin` is null, because we did not initiate it.

The earlier fix on this branch (passing `suppressed && !override` so drops would count) removed one blocker and left this one — which is why the switch still shipped unbounded.

## The change

The override now bounds **itself**, without consulting the disconnect status at all. Six unanswered hellos and it stops, logging why and how to get back to a working strap.

Spent budget makes it **inert, not merely quiet** — it stops reaching the explicit-bond deferral bypass too. Otherwise the link keeps being taken down by a hello nobody will answer. A genuine bond resets the budget, because that is the strap answering.

In-memory and per process. A restart resets it, which is the honest limit of the approach — but the loop runs within one process, and a restart is not the failure mode.

## Why not widen the give-up instead

Tempting, and I decided against it. `status != GATT_CONN_TERMINATE_LOCAL_HOST` guards several other paths, including the bond-watchdog bounce it was written for; loosening it to catch this case risks a self-referential counter elsewhere. A cap scoped to the experiment is smaller, provable, and cannot affect anyone who has not opted in.

That said, the exclusion deserves its own look: a local teardown following `Insufficient Authentication` **is** a failing handshake, not an intentional disconnect, and `localTeardownOrigin == null` distinguishes the two. Separate concern.

## Verification

3 new tests, including the observed field value:

```kotlin
assertFalse(overrideHelloStillAllowed(HELLO_OVERRIDE_MAX_ATTEMPTS))
assertFalse(overrideHelloStillAllowed(57))   // the observed field value
```

plus bounds on the cap itself (≥3 so one flaky link doesn't end the test, ≤10 so it stays an experiment rather than a loop), and that the give-up line names the cause *and* the remedy.

- Android **4547 tests green**, `compileFullDebugKotlin` and `doc_comment_lint` clean
- Android-only; no Swift twin for the latch or the toggle
- **Validated on the hardware that produced the loop** — switch off, link stable, zero drops in a 30-second window against ~6 during the loop

## Note

This is the third defect in this switch, and the third that only hardware could find. The first two (the give-up reading the raw pref; the override never reaching the deferral gate) were caught before merge. This one shipped in `50f9d27` — anyone enabling that switch today gets an unbounded loop, so this wants merging rather than sitting.
