### PR TITLE
ble: port the 5/MG CLIENT_HELLO suppression to iOS/macOS (#1635)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -4033,8 +4033,18 @@ public final class BLEManager: NSObject, ObservableObject {
     }
 
     private func keepAliveFire() {
-        guard state.connected, didBond else { return }
-        enableLiveNotifications(reason: "keepalive")
+        // #1635: a SUPPRESSED 5/MG never bonds, so a bare `didBond` gate switches this whole timer off for
+        // exactly the link that now stays up for hours - taking the liveness watchdog below with it and
+        // leaving a stalled stream with nothing to bounce it. That would quietly break the "stable live HR"
+        // the suppression exists to deliver. Android gates its twin on `bonded` (the live-HR shortcut, #69)
+        // and so reaches the same watchdog.
+        //
+        // Deliberately NARROWER than Android's gate: admitted only for a streaming 5/MG, and only as far as
+        // the watchdog. Everything past it needs the encrypted bond, so a second `didBond` guard closes the
+        // door again rather than letting an unbonded link issue puffin work that cannot land.
+        guard keepAliveMayRun(connected: state.connected, didBond: didBond,
+                              bonded: state.bonded, family: selectedModel.deviceFamily) else { return }
+        if didBond { enableLiveNotifications(reason: "keepalive") }
         // Liveness watchdog: if NOTHING has arrived for a while, the stream/link stalled.
         // Bounce the connection — the auto-rescan on disconnect re-bonds and resumes streaming.
         // #580 / #1414: the standard 0x2A37 HR profile keeps the link genuinely alive, but its packets can
@@ -4051,6 +4061,9 @@ public final class BLEManager: NSObject, ObservableObject {
             if let p = peripheral { central.cancelPeripheralConnection(p) }
             return
         }
+        // The watchdog above is the whole of the keep-alive an unbonded 5/MG can use. Everything below
+        // sends puffin-framed work that needs the encrypted bond.
+        guard didBond else { return }
         guard !backfilling else { return }            // never poke the strap mid-offload
         // #927: continuous capture can be overnight-only, which makes the want TIME-dependent; nothing
         // else re-evaluates it while the app just sits connected, so the keep-alive tick re-derives it.
@@ -5446,6 +5459,10 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                 if !shouldSendClientHello(suppressedForDevice: helloSuppressed, userInitiated: helloUserAsked) {
                     log("WHOOP 5/MG: CLIENT_HELLO suppressed for this strap - it was never acknowledged and the write is what drops the link. Staying on live HR (not fully paired); press Connect to try the handshake again (#1635).")
                     state.pairingHint = BondRefusalGiveUp.helloSuppressedHint()
+                    // Both other startKeepAlive() sites are post-bond, and this link will never bond - so
+                    // without this the liveness watchdog never runs on the one link that now stays up for
+                    // hours. Safe to start before HR arrives: keepAliveMayRun returns false until it does.
+                    startKeepAlive()
                 } else if let hello = selectedModel.deviceFamily.clientHello {
                     // CONTRIBUTOR FIX (issue #17 — diagnosed from the logs, unverified on hardware here):
                     // write CLIENT_HELLO with .withResponse so CoreBluetooth runs just-works bonding when

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -191,6 +191,41 @@ struct BondRefusalGiveUp {
         "NOOP stopped retrying because your strap keeps refusing to pair. It is likely still held by the official WHOOP app, or your phone is holding an old pairing. Close the WHOOP app, put the strap in pairing mode (tap until the LEDs flash blue), and if it is listed in your Bluetooth settings choose Forget This Device. Then tap Connect to try again."
     }
 
+    /// #1635: the log epitaph for the SUPPRESSION path.
+    ///
+    /// Separate from [epitaphLine] because that one asserts a cause ("almost certainly held by the
+    /// official WHOOP app") that only an auth refusal supports. Reusing it here would print a confident
+    /// explanation for a write that simply vanished.
+    ///
+    /// Pure. Byte-identical to the Kotlin `BondRefusalGiveUp.helloSuppressedEpitaph`.
+    static func helloSuppressedEpitaph(refusals: Int, opaqueId: String) -> String {
+        "Bond epitaph: the strap [\(opaqueId)] never acknowledged the secure handshake \(refusals)x in a row, and the attempt is what drops the link - leaving the handshake off so live heart rate keeps streaming. Tap Connect to try it again."
+    }
+
+    /// #1635: the hint shown when the hello is switched off and the link is KEPT.
+    ///
+    /// Nothing is paused on this branch, so it must not say auto-reconnect stopped. It names what was lost
+    /// (history sync) and the one action that restores the attempt, without asserting a cause.
+    ///
+    /// Pure. Byte-identical to the Kotlin `BondRefusalGiveUp.helloSuppressedHint`.
+    static func helloSuppressedHint() -> String {
+        "The secure handshake with your strap never completes, and the attempt itself is what drops the link. NOOP has switched it off for this strap so live heart rate keeps streaming. History sync stays unavailable until it pairs. Tap Connect to try the handshake again."
+    }
+
+    /// The paused hint for a bond that failed WITHOUT the strap ever answering (#1635).
+    ///
+    /// [pausedHint] names a cause — the strap still held by the official WHOOP app, or a stale OS pairing —
+    /// which is well founded when the refusal arrived as INSUFFICIENT_AUTHENTICATION or
+    /// INSUFFICIENT_ENCRYPTION: the strap actively said no. It is NOT founded when the CLIENT_HELLO simply
+    /// goes unanswered and the link drops on a timer, which is a different observation with several
+    /// possible causes. Telling that user to close the WHOOP app would be a guess dressed as instruction,
+    /// and if it is wrong they have no way to know.
+    ///
+    /// Pure. Byte-identical to the Kotlin `BondRefusalGiveUp.pausedHintHandshakeUnanswered`.
+    static func pausedHintHandshakeUnanswered() -> String {
+        "NOOP stopped retrying because the secure handshake with your strap never completes: the strap does not answer, and the link drops a few seconds later. Auto-reconnect is paused so it stops draining both batteries. Tap Connect to try again, and if it keeps happening please share your strap log."
+    }
+
     /// #750: a short OPAQUE token from a CoreBluetooth-local peripheral UUID for the epitaph. The CB UUID is
     /// per-install (NOT the hardware MAC), and we keep only its first 8 hex chars, so the token is stable
     /// within a log but carries no device-identifying PII. Pure + deterministic. Twin of the Android helper.
@@ -915,6 +950,11 @@ public final class BLEManager: NSObject, ObservableObject {
     private var reassembler = Reassembler()
     private var seq: UInt8 = 0
     private var didBond = false
+    /// #1635: one explicit Connect grants one fresh CLIENT_HELLO even when the suppression latch is set.
+    /// Consumed unconditionally by the write site, so the retry belongs to THIS session — leaving it set
+    /// would hand a stale retry to some later automatic reconnect and restart the loop the suppression
+    /// exists to end. Kotlin twin: `WhoopBleClient.helloRetryRequested`.
+    private var helloRetryRequested = false
     /// WHOOP 5/MG only: realtime HR has been armed (puffin TOGGLE_REALTIME_HR sent) once for this
     /// connection, so the post-bond callback re-firing on later `.withResponse` writes doesn't re-send it.
     private var whoop5RealtimeArmed = false
@@ -1325,6 +1365,12 @@ public final class BLEManager: NSObject, ObservableObject {
             autoReconnectPausedForBondLoop = false
             bondLoopPausedAt = nil
         }
+        // #1635: the suppression path pauses NOTHING, so the reset above never fires for it. An explicit
+        // Connect is exactly the signal that the user has acted (pairing mode, closed the WHOOP app), so
+        // it must grant a fresh handshake regardless — that is also the only way to clear the latch short
+        // of a genuine bond. Deliberately NOT in connectCore: a system-initiated reconnect must not.
+        helloRetryRequested = true
+        bondGiveUp.reset()
         connectCore(model: model)
     }
 
@@ -4890,6 +4936,48 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         return "code?"
     }
 
+    /// Feed one 5/MG bond refusal into the #747 give-up and act on the trip (#1635).
+    ///
+    /// Both causes arrive here, and they want OPPOSITE treatment — see `giveUpSuppressesHello`. An auth
+    /// refusal means the strap actively declined, so pausing auto-reconnect is right. An unanswered
+    /// handshake means the write vanished while the link streamed live HR the whole time, so pausing
+    /// would throw away a working strap to punish a handshake nobody is waiting on.
+    ///
+    /// Shared by both call sites so the split cannot drift: the auth path (a write error) and the
+    /// unanswered path (a disconnect with a hello still outstanding) reach the same decision.
+    private func recordWhoop5BondRefusal(authRefusal: Bool, peripheralUUID: String) {
+        guard bondGiveUp.recordRefusal() else { return }
+        let opaque = BondRefusalGiveUp.opaqueId(fromLocalUUID: peripheralUUID)
+        let suppress = giveUpSuppressesHello(authRefusal: authRefusal)
+        if suppress {
+            HelloSuppressionStore.setSuppressed(peripheralUUID, true)
+            log(BondRefusalGiveUp.helloSuppressedEpitaph(refusals: bondGiveUp.refusals, opaqueId: opaque))
+        } else {
+            autoReconnectPausedForBondLoop = true
+            bondLoopPausedAt = Date()   // starts the #78 hole-4 salvage-probe floor
+            // #1539: park the connect in the same breath as the pause, so this can end while backgrounded.
+            standingConnectWhilePausedIfDue(justTripped: true)
+            log(BondRefusalGiveUp.epitaphLine(refusals: bondGiveUp.refusals, opaqueId: opaque))
+        }
+        // Each branch gets the hint that matches what it actually DID. The paused hints say "auto-reconnect
+        // is paused"; on the suppression branch nothing is paused, so saying so would be the same
+        // confidently-wrong diagnostic this issue has produced twice already (#1635). The third arm is
+        // unreachable while `giveUpSuppressesHello` is `!authRefusal`, and is kept because the Kotlin twin
+        // keeps it: if that rule ever changes, both platforms must change behaviour together.
+        if suppress {
+            state.pairingHint = BondRefusalGiveUp.helloSuppressedHint()
+        } else if authRefusal {
+            state.pairingHint = BondRefusalGiveUp.pausedHint()
+        } else {
+            state.pairingHint = BondRefusalGiveUp.pausedHintHandshakeUnanswered()
+        }
+        if TestCentre.active(.connection) {
+            state.append(log: "bond gaveUp refusals=\(bondGiveUp.refusals) id=\(opaque) " +
+                (suppress ? "(hello suppressed, staying connected)" : "(auto-reconnect paused)"),
+                domain: .connection)
+        }
+    }
+
     public func centralManager(_ central: CBCentralManager,
                                didDisconnectPeripheral peripheral: CBPeripheral,
                                error: Error?) {
@@ -5007,6 +5095,18 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         }
         state.clearBiometrics()       // and a stale HR / R-R must not outlive the link either
         state.liveFeedActive = false  // a drop while Live is open must not leave a stale "Stop live feed"
+        // #1635: an unanswered CLIENT_HELLO produces no write error at all - the link simply drops a few
+        // seconds later - so it never reached the give-up on this platform and nothing could end the loop.
+        // Read it HERE, while `clientHelloWriteAt` and `didBond` are both still valid, and feed it in
+        // through the same split the auth path uses. `countsAsBondRefusal` gates on family, so a 4.0 (which
+        // bonds cleanly) can never latch the suppression.
+        if countsAsBondRefusal(isAuthRefusalStatus: false,
+                               helloUnacked: clientHelloWriteAt != nil,
+                               alreadyBonded: didBond,
+                               family: selectedModel.deviceFamily) {
+            recordWhoop5BondRefusal(authRefusal: false,
+                                    peripheralUUID: peripheral.identifier.uuidString)
+        }
         didBond = false
         clientHelloWriteAt = nil   // #1635: no hello survives the link that carried it
         whoop5RealtimeArmed = false
@@ -5337,7 +5437,16 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                 // fires for a 5/MG strap. Live HR/battery come from the standard profiles; this just
                 // opens the puffin session. Unverified on real MG hardware.
                 cmdCharacteristic = c
-                if let hello = selectedModel.deviceFamily.clientHello {
+                // #1635: once the give-up has latched, the hello is what ends the link — skip it and let
+                // the standard-profile HR stream keep running. Consumed unconditionally so an explicit
+                // Connect's single retry belongs to this session and cannot leak into a later automatic one.
+                let helloUserAsked = helloRetryRequested
+                helloRetryRequested = false
+                let helloSuppressed = HelloSuppressionStore.suppressed(peripheral.identifier.uuidString)
+                if !shouldSendClientHello(suppressedForDevice: helloSuppressed, userInitiated: helloUserAsked) {
+                    log("WHOOP 5/MG: CLIENT_HELLO suppressed for this strap - it was never acknowledged and the write is what drops the link. Staying on live HR (not fully paired); press Connect to try the handshake again (#1635).")
+                    state.pairingHint = BondRefusalGiveUp.helloSuppressedHint()
+                } else if let hello = selectedModel.deviceFamily.clientHello {
                     // CONTRIBUTOR FIX (issue #17 — diagnosed from the logs, unverified on hardware here):
                     // write CLIENT_HELLO with .withResponse so CoreBluetooth runs just-works bonding when
                     // the link needs authenticating, AND so didWriteValueFor fires. That callback is where
@@ -5442,19 +5551,11 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                 // threshold (the pairing hint has had several cycles to be acted on), pause auto-reconnect so
                 // we stop hammering a strap that can't bond, write the one-line epitaph (opaque id only, no
                 // PII), and surface the honest paused hint. A genuine bond or a manual reconnect re-arms it.
-                if bondGiveUp.recordRefusal() {
-                    autoReconnectPausedForBondLoop = true
-                    bondLoopPausedAt = Date()   // starts the #78 hole-4 salvage-probe floor
-                    // #1539: same reasoning as the #617 trip — park a connect now so this pause can end
-                    // while the app is backgrounded, not only when the user next opens it.
-                    standingConnectWhilePausedIfDue(justTripped: true)
-                    let opaque = BondRefusalGiveUp.opaqueId(fromLocalUUID: peripheral.identifier.uuidString)
-                    log(BondRefusalGiveUp.epitaphLine(refusals: bondGiveUp.refusals, opaqueId: opaque))
-                    state.pairingHint = BondRefusalGiveUp.pausedHint()
-                    if TestCentre.active(.connection) {
-                        state.append(log: "bond gaveUp refusals=\(bondGiveUp.refusals) id=\(opaque) (auto-reconnect paused)", domain: .connection)
-                    }
-                }
+                // #1635: the trip itself now lives in recordWhoop5BondRefusal, shared with the
+                // unanswered-handshake path at disconnect, so the two causes cannot drift apart. This
+                // one is an AUTH refusal — the strap actively declined — so it still pauses.
+                recordWhoop5BondRefusal(authRefusal: true,
+                                        peripheralUUID: peripheral.identifier.uuidString)
             }
             // Multi-WHOOP stale-pin recovery (#52). When a stale registry pin points at a strap that keeps
             // refusing the encrypted bond ("Encryption/Authentication is insufficient") but a DIFFERENT
@@ -5505,6 +5606,10 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                 isWhoop5: true
             ) {
                 didBond = true
+                // #1635: the handshake demonstrably works on this strap - drop the latch so a later
+                // transient failure starts from a clean slate rather than inheriting an old verdict.
+                HelloSuppressionStore.setSuppressed(peripheral.identifier.uuidString, false)
+                bondGiveUp.reset()
                 state.bonded = true
                 state.encryptedBond = true   // genuine encrypted bond (not the live-HR shortcut) — #69
                 bondedAt = Date()            // #617: start the bond→drop stopwatch for the bond-loop detector

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -5468,10 +5468,6 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                 if !shouldSendClientHello(suppressedForDevice: helloSuppressed, userInitiated: helloUserAsked) {
                     log("WHOOP 5/MG: CLIENT_HELLO suppressed for this strap - it was never acknowledged and the write is what drops the link. Staying on live HR (not fully paired); press Connect to try the handshake again (#1635).")
                     state.pairingHint = BondRefusalGiveUp.helloSuppressedHint()
-                    // Both other startKeepAlive() sites are post-bond, and this link will never bond - so
-                    // without this the liveness watchdog never runs on the one link that now stays up for
-                    // hours. Safe to start before HR arrives: keepAliveMayRun returns false until it does.
-                    startKeepAlive()
                 } else if let hello = selectedModel.deviceFamily.clientHello {
                     // CONTRIBUTOR FIX (issue #17 — diagnosed from the logs, unverified on hardware here):
                     // write CLIENT_HELLO with .withResponse so CoreBluetooth runs just-works bonding when
@@ -5961,6 +5957,11 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
             if selectedModel.deviceFamily == .whoop5, !state.bonded {
                 state.bonded = true
                 log("WHOOP 5/MG: live HR streaming — marking the link established (experimental).")
+                // #1635: a 5/MG has no confirmed-write handshake, so the keep-alive (and with it the
+                // liveness watchdog) is started HERE, on the bonded transition, exactly as the Kotlin twin
+                // does. The other two start sites are post-bond, which a suppressed strap never reaches —
+                // and this also covers an unbonded 5/MG that has not latched yet.
+                startKeepAlive()
             }
         case BLEManager.batteryChar:
             // 0x2A19 = percent — 5/MG ONLY. The WHOOP 4.0's 0x2A19 is a stub constant 100 (real value =

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1493,6 +1493,9 @@ public final class BLEManager: NSObject, ObservableObject {
     public func forgetDevice(_ peripheralId: String?) {
         let target = peripheralId.flatMap { UUID(uuidString: $0) }
         let isCurrent = target == nil || peripheral?.identifier == target
+        // Captured BEFORE the teardown below nils `peripheral`, since a nil argument means "the current
+        // strap" and that is the only place its identifier can still be read.
+        let releasedUUID = peripheralId ?? peripheral?.identifier.uuidString
         intentionalDisconnect = true            // defuses the disconnect→3s-reconnect loop's guard
         cancelScanFallback()
         readoptingTo = nil                       // abandon any in-flight #52 pin handoff
@@ -1513,6 +1516,12 @@ public final class BLEManager: NSObject, ObservableObject {
         }
         // #747/#750 invariant: releasing a strap fully resets the give-up + pause (like disconnect()) so
         // a paused state can never outlive the strap it belonged to and wedge a later re-add.
+        //
+        // #1635: the hello-suppression latch is exactly that kind of state, and it is PERSISTED - so
+        // without this it outlives the strap it belonged to, silently suppressing the handshake on a
+        // re-add and leaving a stale key behind for a strap the user removed. Re-latching costs the same
+        // five refusals it always did, so a strap that genuinely cannot bond is no worse off.
+        HelloSuppressionStore.setSuppressed(releasedUUID, false)
         bondGiveUp.reset()
         autoReconnectPausedForBondLoop = false
         bondLoopPausedAt = nil

--- a/Strand/BLE/HelloSuppression.swift
+++ b/Strand/BLE/HelloSuppression.swift
@@ -105,3 +105,22 @@ enum HelloSuppressionStore {
         }
     }
 }
+
+/// May the keep-alive timer do its work on this link?
+///
+/// #1635: the timer used to gate on the genuine encrypted bond alone. A SUPPRESSED 5/MG never reaches
+/// one, so that gate switched the whole timer off for exactly the link the suppression keeps up for
+/// hours — taking the liveness watchdog with it and leaving a stalled stream with nothing to bounce it.
+/// The stable-live-HR promise would have quietly depended on a stream nothing was watching.
+///
+/// So a 5/MG that is STREAMING (`bonded` is the live-HR shortcut of #8/#69, set when HR actually arrives
+/// over the standard profile) is admitted too. Deliberately narrower than the Android twin, which admits
+/// any `bonded` link: here it is 5/MG only, and only as far as the watchdog — the caller re-guards on the
+/// real bond before anything puffin-framed, which an unbonded link cannot land anyway.
+///
+/// Pure so the rule is pinned without a radio.
+func keepAliveMayRun(connected: Bool, didBond: Bool, bonded: Bool, family: DeviceFamily) -> Bool {
+    guard connected else { return false }
+    if didBond { return true }
+    return bonded && family == .whoop5
+}

--- a/Strand/BLE/HelloSuppression.swift
+++ b/Strand/BLE/HelloSuppression.swift
@@ -1,0 +1,107 @@
+import Foundation
+import WhoopProtocol
+
+/// Whether to send the WHOOP 5/MG CLIENT_HELLO at all on this connect.
+///
+/// The #1635 field captures show the hello is what ends the link. Across two sessions and sixteen writes it
+/// was never once acknowledged, and the drop is locked to the HELLO rather than to the connect: 3.158s,
+/// 3.159s, 3.155s after the write, cycle after cycle, while live HR streams happily over the standard
+/// profile the whole time.
+///
+/// An HCI capture later established the cause: the phone transmits an SMP Pairing Request and the strap
+/// answers `Pairing Not Supported` (0x05). The refusal is categorical — the encrypted bond this hello waits
+/// behind can never arrive on a 5/MG — so the write is a handshake that has never once succeeded knocking a
+/// strap that CAN deliver live HR off every few seconds.
+///
+/// Suppressing it after the give-up latches trades an unreachable capability (puffin commands, history
+/// offload) for one that demonstrably works (continuous live HR) — the "Live HR, not fully paired" state
+/// the app already models (#69), reached deliberately instead of never at all.
+///
+/// [userInitiated] always re-attempts: suppression is a fallback for automatic reconnects, never a
+/// permanent verdict. Someone who puts the strap in pairing mode and presses Connect must get a fresh try,
+/// and that is also how the suppression is cleared.
+///
+/// Kotlin twin: `com.noop.ble.shouldSendClientHello`.
+func shouldSendClientHello(suppressedForDevice: Bool, userInitiated: Bool) -> Bool {
+    !suppressedForDevice || userInitiated
+}
+
+/// Should the give-up latch suppress the hello, rather than pause auto-reconnect?
+///
+/// The two give-up causes want opposite treatment, which is why they are split here rather than sharing
+/// one branch:
+///
+///  - An AUTH REFUSAL means the strap actively declined the encrypted bond — typically because it is still
+///    held by the official WHOOP app. Reconnecting cannot help until the user acts, so pausing is right.
+///  - An UNANSWERED HANDSHAKE means the write vanished. The link itself is healthy and streaming, so
+///    pausing throws away working live HR to punish a handshake nobody is waiting on. Suppress the hello
+///    and stay connected instead.
+///
+/// Splitting them is the whole point: before this, both ended in the same pause, so the strap that could
+/// still deliver HR was treated exactly like the one that could not.
+///
+/// Kotlin twin: `com.noop.ble.giveUpSuppressesHello`.
+func giveUpSuppressesHello(authRefusal: Bool) -> Bool { !authRefusal }
+
+/// Does this disconnect count as the strap refusing to bond?
+///
+/// Two observations mean the same thing for the purpose of giving up: the strap answered the bond write
+/// with INSUFFICIENT_AUTHENTICATION / INSUFFICIENT_ENCRYPTION, or it never answered the CLIENT_HELLO at
+/// all. The second was invisible to the give-up on this platform, because the gate tested only the write
+/// error — and an unanswered handshake produces no write error at all, just a link that drops a few
+/// seconds later. The consequence is the loop #1635 describes, with nothing able to end it.
+///
+/// Deliberately does NOT widen what counts as an AUTH refusal — [helloUnacked] is a separate signal carried
+/// separately, so the user-facing guidance can stay honest about which was observed. An auth refusal
+/// supports naming a cause; an unanswered handshake does not.
+///
+/// Pure so the rule is unit-tested without a radio. Kotlin twin: `com.noop.ble.countsAsBondRefusal`.
+func countsAsBondRefusal(
+    isAuthRefusalStatus: Bool,
+    helloUnacked: Bool,
+    alreadyBonded: Bool,
+    family: DeviceFamily
+) -> Bool {
+    if alreadyBonded { return false }        // bonded already — not a pairing problem
+    if family != .whoop5 { return false }    // the 4.0 bonds cleanly; this is the 5/MG handshake
+    return isAuthRefusalStatus || helloUnacked
+}
+
+/// UserDefaults key holding the hello-suppression latch for one strap.
+///
+/// Per device, and lowercased for the same reason the firmware key is: the same strap can present its
+/// identifier in different cases across sessions, and a case-sensitive key would silently latch a second
+/// time under a second key instead of reading the first.
+///
+/// DIVERGENCE FROM ANDROID (deliberate, PII): the identifier here is the CoreBluetooth-local peripheral
+/// UUID, which is per-install rather than the hardware address. The key SHAPE is shared with the Kotlin
+/// twin so the two are recognisably the same latch; the value that goes into it is not the same kind of
+/// identifier, and deliberately so.
+///
+/// Kotlin twin: `com.noop.ble.helloSuppressionPrefKey`.
+func helloSuppressionPrefKey(_ peripheralId: String?) -> String? {
+    guard let raw = peripheralId?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+        return nil
+    }
+    return "noop.helloUnanswered.\(raw.lowercased())"
+}
+
+/// Read/write the per-strap hello-suppression latch. Kept beside the key helper so no caller hand-rolls
+/// the key, which is how the Android side ended up with a case-sensitivity bug worth a comment.
+enum HelloSuppressionStore {
+    static func suppressed(_ peripheralId: String?) -> Bool {
+        guard let key = helloSuppressionPrefKey(peripheralId) else { return false }
+        return UserDefaults.standard.bool(forKey: key)
+    }
+
+    static func setSuppressed(_ peripheralId: String?, _ suppressed: Bool) {
+        guard let key = helloSuppressionPrefKey(peripheralId) else { return }
+        if suppressed {
+            UserDefaults.standard.set(true, forKey: key)
+        } else {
+            // Remove rather than store false: an absent key and a false one mean the same thing, and this
+            // keeps a strap that never latched from leaving a permanent entry behind.
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+}

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -50640,6 +50640,70 @@
         }
       }
     },
+    "Live heart rate is streaming, but your strap is not fully paired. Buzz, alarms and history sync need the encrypted pairing.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Live-Herzfrequenz wird übertragen, aber dein Strap ist nicht vollständig gekoppelt. Vibration, Wecker und Verlaufssynchronisierung benötigen die verschlüsselte Kopplung."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Live heart rate is streaming, but your strap is not fully paired. Buzz, alarms and history sync need the encrypted pairing."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La frecuencia cardíaca en tiempo real se está transmitiendo, pero tu pulsera no está completamente emparejada. La vibración, las alarmas y la sincronización del historial necesitan el emparejamiento cifrado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La fréquence cardiaque en direct est diffusée, mais votre bracelet n'est pas entièrement associé. Les vibrations, les alarmes et la synchronisation de l'historique nécessitent l'association chiffrée."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La frequenza cardiaca in tempo reale è in streaming, ma la tua fascia non è completamente associata. Vibrazione, sveglie e sincronizzazione della cronologia richiedono l'associazione cifrata."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tętno na żywo jest przesyłane, ale twój pasek nie jest w pełni sparowany. Wibracje, alarmy i synchronizacja historii wymagają szyfrowanego parowania."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A frequência cardíaca em tempo real está a ser transmitida, mas a tua bracelete não está totalmente emparelhada. A vibração, os alarmes e a sincronização do histórico necessitam do emparelhamento encriptado."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пульс в реальном времени передаётся, но ваш браслет сопряжён не полностью. Вибрация, будильники и синхронизация истории требуют зашифрованного сопряжения."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "实时心率正在传输，但你的手环尚未完全配对。震动、闹钟和历史同步需要加密配对。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "即時心率正在傳輸，但你的手環尚未完全配對。震動、鬧鐘和歷史同步需要加密配對。"
+          }
+        }
+      }
+    },
     "Connected. Finishing the secure pairing handshake…": {
       "localizations": {
         "de": {

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -1477,14 +1477,21 @@ struct SettingsView: View {
         //
         // A live-HR link falls through to the pairing hint when one is set, and otherwise to "Finishing
         // the secure pairing handshake…", which is accurate HERE because this platform still retries the
-        // CLIENT_HELLO on every connect. Android has an explicit "streaming but not fully paired" arm
-        // instead, because #1635 suppression stops it retrying and nothing is finishing any more. If that
-        // suppression is ported here, this branch must gain the same arm or it starts describing a
-        // handshake that is no longer being attempted.
+        // CLIENT_HELLO on every connect. The #1635 suppression is now ported here too, so once it latches
+        // nothing is finishing any more and the old fall-through would describe a handshake that is no
+        // longer being attempted. The `bonded && connected` arm below is that fix, matching the Android
+        // twin (`SettingsLogic.strapStatusLine`).
         if live.encryptedBond && live.connected {
             return String(localized: "Your strap is paired and sending data. Open Live for a real-time heart rate.")
         }
+        // An actionable hint outranks the generic arm: the suppression hint names the one action that
+        // restores the handshake, which "not fully paired" alone does not.
         if live.connected, let hint = live.pairingHint { return hint }
+        // Live HR over the UNBONDED standard profile (#69). True whenever the handshake is suppressed or
+        // simply has not landed, and the honest description either way.
+        if live.bonded && live.connected {
+            return String(localized: "Live heart rate is streaming, but your strap is not fully paired. Buzz, alarms and history sync need the encrypted pairing.")
+        }
         if live.connected { return String(localized: "Connected. Finishing the secure pairing handshake…") }
         if live.bonded { return String(localized: "Previously paired but not currently connected. Re-scan to reconnect.") }
         return String(localized: "No strap connected. Put your WHOOP nearby and tap Re-scan to pair.")

--- a/StrandTests/HelloSuppressionTests.swift
+++ b/StrandTests/HelloSuppressionTests.swift
@@ -139,4 +139,36 @@ final class HelloSuppressionTests: XCTestCase {
         XCTAssertFalse(e.contains("almost certainly"))
         XCTAssertFalse(e.contains("\u{2014}"))          // project rule: no em-dash in these lines
     }
+
+    // MARK: - the keep-alive gate
+
+    /// The defect this gate exists for: the timer used to require the genuine encrypted bond, which a
+    /// suppressed 5/MG never reaches — so the liveness watchdog was switched off for exactly the link the
+    /// suppression keeps up for hours, and a stalled stream would have had nothing to bounce it.
+    func testAStreamingSuppressedFiveMGReachesTheWatchdog() {
+        XCTAssertTrue(keepAliveMayRun(connected: true, didBond: false, bonded: true, family: .whoop5))
+    }
+
+    /// Before HR arrives there is nothing to watch, so starting the timer early at the suppression point
+    /// is harmless — the gate simply returns false until the stream marks the link established (#8).
+    func testItStaysShutUntilTheStreamActuallyStarts() {
+        XCTAssertFalse(keepAliveMayRun(connected: true, didBond: false, bonded: false, family: .whoop5))
+    }
+
+    /// Narrower than the Android twin on purpose: only a 5/MG is admitted unbonded. A 4.0 reaching here
+    /// without a bond would be a real fault, not a suppressed link, and must not be kept alive.
+    func testOnlyAFiveMGIsAdmittedWithoutABond() {
+        for family in DeviceFamily.allCases where family != .whoop5 {
+            XCTAssertFalse(keepAliveMayRun(connected: true, didBond: false, bonded: true, family: family),
+                           "\(family) must not run the keep-alive unbonded")
+        }
+    }
+
+    func testABondedLinkAlwaysRunsAndADroppedOneNever() {
+        for family in DeviceFamily.allCases {
+            XCTAssertTrue(keepAliveMayRun(connected: true, didBond: true, bonded: true, family: family))
+            XCTAssertFalse(keepAliveMayRun(connected: false, didBond: true, bonded: true, family: family))
+        }
+    }
 }
+

--- a/StrandTests/HelloSuppressionTests.swift
+++ b/StrandTests/HelloSuppressionTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+import WhoopProtocol
+@testable import Strand
+
+/// The #1635 CLIENT_HELLO suppression, ported from Android.
+///
+/// The rules are pure so they can be pinned without a radio — which matters more here than usual, because
+/// nothing else validates this path: BLE behaviour is not CI-testable, and the app target has no default
+/// CI at all.
+final class HelloSuppressionTests: XCTestCase {
+
+    // MARK: - shouldSendClientHello
+
+    func testTheHelloIsSentUntilTheLatchSets() {
+        XCTAssertTrue(shouldSendClientHello(suppressedForDevice: false, userInitiated: false))
+        XCTAssertFalse(shouldSendClientHello(suppressedForDevice: true, userInitiated: false))
+    }
+
+    /// Suppression is a fallback for AUTOMATIC reconnects, never a permanent verdict. Someone who puts the
+    /// strap in pairing mode and presses Connect must get a fresh try — that is also the only way to clear
+    /// the latch short of a genuine bond.
+    func testAnExplicitConnectAlwaysReattempts() {
+        XCTAssertTrue(shouldSendClientHello(suppressedForDevice: true, userInitiated: true))
+        XCTAssertTrue(shouldSendClientHello(suppressedForDevice: false, userInitiated: true))
+    }
+
+    // MARK: - giveUpSuppressesHello
+
+    /// The two give-up causes want OPPOSITE treatment, and collapsing them is the bug this split exists to
+    /// undo: before it, a strap that could still stream live HR was treated exactly like one that could not.
+    func testOnlyAnUnansweredHandshakeSuppresses() {
+        XCTAssertTrue(giveUpSuppressesHello(authRefusal: false))   // vanished write -> keep the link
+        XCTAssertFalse(giveUpSuppressesHello(authRefusal: true))   // strap said no  -> pause instead
+    }
+
+    // MARK: - countsAsBondRefusal
+
+    /// The family gate is what keeps a WHOOP 4.0 out of this entirely. The latch is stored per device with
+    /// no family in the key, so without this gate a 4.0 could latch and silently lose history sync.
+    func testAFourOhCanNeverReachTheSuppression() {
+        for family in DeviceFamily.allCases where family != .whoop5 {
+            XCTAssertFalse(
+                countsAsBondRefusal(isAuthRefusalStatus: true, helloUnacked: true,
+                                    alreadyBonded: false, family: family),
+                "\(family) must not count toward the 5/MG handshake give-up")
+        }
+    }
+
+    func testBothCausesCountForAFiveMG() {
+        // The strap actively declined.
+        XCTAssertTrue(countsAsBondRefusal(isAuthRefusalStatus: true, helloUnacked: false,
+                                          alreadyBonded: false, family: .whoop5))
+        // The write simply vanished — invisible to this platform's give-up before the port.
+        XCTAssertTrue(countsAsBondRefusal(isAuthRefusalStatus: false, helloUnacked: true,
+                                          alreadyBonded: false, family: .whoop5))
+        // Neither: an ordinary drop is not a pairing problem.
+        XCTAssertFalse(countsAsBondRefusal(isAuthRefusalStatus: false, helloUnacked: false,
+                                           alreadyBonded: false, family: .whoop5))
+    }
+
+    /// A bonded link that drops is not a pairing failure, and counting it would latch the suppression on a
+    /// strap whose handshake demonstrably works.
+    func testAlreadyBondedNeverCounts() {
+        XCTAssertFalse(countsAsBondRefusal(isAuthRefusalStatus: true, helloUnacked: true,
+                                           alreadyBonded: true, family: .whoop5))
+    }
+
+    // MARK: - the latch key
+
+    /// Lowercased for the same reason the firmware key is: the same strap can present its identifier in
+    /// different cases across sessions, and a case-sensitive key would latch a second time under a second
+    /// key instead of reading the first.
+    func testTheLatchKeyIsCaseInsensitiveAndTrimmed() {
+        let upper = helloSuppressionPrefKey("AABBCCDD-1122")
+        XCTAssertEqual(upper, "noop.helloUnanswered.aabbccdd-1122")
+        XCTAssertEqual(helloSuppressionPrefKey("  aabbccdd-1122  "), upper)
+    }
+
+    func testTheLatchKeyRejectsNothingToKeyOn() {
+        XCTAssertNil(helloSuppressionPrefKey(nil))
+        XCTAssertNil(helloSuppressionPrefKey(""))
+        XCTAssertNil(helloSuppressionPrefKey("   "))
+    }
+
+    // MARK: - the latch itself
+
+    func testTheLatchRoundTripsAndClearsCompletely() {
+        let id = "unit-test-\(#function)"
+        defer { HelloSuppressionStore.setSuppressed(id, false) }
+
+        XCTAssertFalse(HelloSuppressionStore.suppressed(id))
+        HelloSuppressionStore.setSuppressed(id, true)
+        XCTAssertTrue(HelloSuppressionStore.suppressed(id))
+        // Case must not open a second latch beside the first.
+        XCTAssertTrue(HelloSuppressionStore.suppressed(id.uppercased()))
+        HelloSuppressionStore.setSuppressed(id, false)
+        XCTAssertFalse(HelloSuppressionStore.suppressed(id))
+        // Cleared means REMOVED, so a strap that never latched leaves nothing behind.
+        XCTAssertNil(UserDefaults.standard.object(forKey: helloSuppressionPrefKey(id)!))
+    }
+
+    /// An unkeyable id must not throw or write a stray default.
+    func testStoringAgainstNothingIsANoOp() {
+        HelloSuppressionStore.setSuppressed(nil, true)
+        XCTAssertFalse(HelloSuppressionStore.suppressed(nil))
+    }
+
+    // MARK: - the hints (byte-identical to the Kotlin twin)
+
+    /// The suppression branch pauses NOTHING, so its hint must not say auto-reconnect stopped — that was
+    /// the confidently-wrong diagnostic #1635 produced twice. It names what was lost and the one action
+    /// that restores the attempt.
+    func testTheSuppressionHintDoesNotClaimAnythingIsPaused() {
+        let hint = BondRefusalGiveUp.helloSuppressedHint()
+        XCTAssertTrue(hint.contains("live heart rate keeps streaming"))
+        XCTAssertTrue(hint.contains("History sync stays unavailable"))
+        XCTAssertTrue(hint.contains("Tap Connect"))
+        XCTAssertFalse(hint.lowercased().contains("paused"))
+        XCTAssertFalse(hint.lowercased().contains("stopped retrying"))
+    }
+
+    /// The unanswered-handshake hint must not name a cause. `pausedHint` blames the official WHOOP app or a
+    /// stale pairing, which an INSUFFICIENT_AUTHENTICATION refusal supports and a vanished write does not.
+    func testTheUnansweredHintNamesNoCause() {
+        let unanswered = BondRefusalGiveUp.pausedHintHandshakeUnanswered()
+        XCTAssertTrue(unanswered.contains("never completes"))
+        XCTAssertFalse(unanswered.contains("WHOOP app"))
+        XCTAssertFalse(unanswered.contains("Forget This Device"))
+        // …whereas the auth-refusal hint is exactly where naming that cause belongs.
+        XCTAssertTrue(BondRefusalGiveUp.pausedHint().contains("WHOOP app"))
+    }
+
+    /// Likewise the epitaph: `epitaphLine` asserts "almost certainly held by the official WHOOP app", which
+    /// only an auth refusal supports.
+    func testTheSuppressionEpitaphAssertsNoCause() {
+        let e = BondRefusalGiveUp.helloSuppressedEpitaph(refusals: 5, opaqueId: "abcd1234")
+        XCTAssertTrue(e.contains("[abcd1234]"))
+        XCTAssertTrue(e.contains("5x in a row"))
+        XCTAssertFalse(e.contains("almost certainly"))
+        XCTAssertFalse(e.contains("\u{2014}"))          // project rule: no em-dash in these lines
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3281,6 +3281,8 @@ class WhoopBleClient(
         // changed in between, and that is exactly when a new characteristic would appear.
         gattTreeDumpedFor = null
         handler.post {
+            // Captured before the clearing below nulls `lastDevice`, which `lastDeviceAddress` reads through.
+            val releasedAddress = lastDeviceAddress
             intentionalDisconnect = true     // defuse the disconnect→3s-reconnect loop's guard
             handler.removeCallbacks(scanTimeoutRunnable)
             handler.removeCallbacks(scanFallbackRunnable)
@@ -3293,6 +3295,11 @@ class WhoopBleClient(
             // so a paused state can never outlive the strap it belonged to and wedge a later re-add.
             bondRefusalStreak = 0
             bondGiveUp.reset()
+            // #1635: the hello-suppression latch is exactly that kind of state and, unlike the give-up, it
+            // is PERSISTED — so without this it outlives the strap it belonged to, silently suppressing the
+            // handshake on a re-add and leaving a stale pref behind for a strap the user removed.
+            // Re-latching costs the same five refusals it always did. Twin of the Swift `forgetDevice`.
+            runCatching { com.noop.ui.NoopPrefs.setHelloSuppressed(context, releasedAddress, false) }
             autoReconnectPausedForBondLoop = false
             bondLoopPausedAtMs = null
             // Drop the persisted last-device pin so a relaunch / radio-on doesn't auto-reconnect to it (#67).


### PR DESCRIPTION
Android has stopped the 5/MG reconnect loop since #1642. iOS never got it, so a 5/MG here still writes the CLIENT_HELLO every connect, loses the link ~3s later and reconnects forever — the behaviour v10.6.0 shipped on both platforms.

The hello is what ends the link. An HCI capture settled why: the phone sends an SMP Pairing Request and the strap answers `Pairing Not Supported` (0x05), so the encrypted bond the hello waits behind can never arrive on a 5/MG. Suppressing it after the give-up latches trades an unreachable capability (puffin commands, history offload) for one that demonstrably works — continuous live HR, the "Live HR, not fully paired" state the app already models (#69).

## What was ported

| Kotlin | Swift |
|---|---|
| `shouldSendClientHello`, `giveUpSuppressesHello`, `countsAsBondRefusal`, `helloSuppressionPrefKey` | new pure `Strand/BLE/HelloSuppression.swift` |
| `helloSuppressedEpitaph`, `helloSuppressedHint`, `pausedHintHandshakeUnanswered` | statics on `BondRefusalGiveUp` |
| the give-up trip's two-way split | `recordWhoop5BondRefusal`, shared by both causes |

**#1640 had to come with it.** An unanswered hello produces no write error at all — the link just drops — so it never reached this platform's give-up, which only ever saw `INSUFFICIENT_AUTHENTICATION`. Without that half the suppression could never trigger. It's read at disconnect while `clientHelloWriteAt` and `didBond` are both still valid.

## The didBond audit

`didBond` stays permanently false once suppressed, and CLAUDE.md names this the trap that undid the Android change twice. Checked here:

- iOS has **no bond watchdog** and **no #982 never-bonded detector**, so neither can undo it.
- `countsAsBondRefusal` gates on family — **a 4.0 can never latch**.
- An auth refusal **cannot be double-counted** or mislabelled as unanswered: the write-error branch clears `clientHelloWriteAt` before the count.
- Only user-driven paths reach `connect()`, so the one-shot retry can't leak into an automatic reconnect — those go through `central.connect` directly. `SourceCoordinator.startWhoop` fires only on user-driven device transitions and is a no-op for the single-WHOOP default.

## The status line

`SettingsView` had a comment left for whoever did this port: it falls through to "Finishing the secure pairing handshake…" and would describe a handshake no longer being attempted. It now carries the same "streaming but not fully paired" arm as `SettingsLogic.strapStatusLine`, translated into all ten locales, placed *after* the hint so the actionable text still wins.

## Not ported

The #1669 opt-in override. It's experimental, default-off, and on hardware produced 57 reconnect cycles in an hour before #1670 bounded it — not a thing to add to a second platform before the first has field evidence.

## Verification

The three hint strings are **proven byte-identical** to the Kotlin source by extracting both and comparing, not by eye. 13 tests over the pure rules, including the family gate across every `DeviceFamily` case and the latch's case-insensitivity. The pure file was also compiled standalone with `swiftc` and every rule exercised, since the app target has no default CI. `doc_comment_lint` clean; i18n audit 0 gaps in the gated locales. app-build dispatched.

**NOT hardware-validated.** I have no 5/MG on iOS to test against, and BLE behaviour cannot be CI-tested. The falsifiable prediction is the one Android's change carried: after the latch, the loop stops and live HR streams continuously. **If a link still drops on a cycle with no CLIENT_HELLO line, the port is wrong.**
