### PR TITLE
updates: turn the automatic check on by default, and make the privacy docs true

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Pre-built apps you can run right now:
 
 Prefer to build it yourself? See [`docs/BUILD.md`](docs/BUILD.md).
 
-Everything runs **offline**. The only feature that ever uses the network is the optional **AI Coach**, and only with your own API key.
+Everything runs **offline** — your data never leaves the device. NOOP makes only two kinds of network request, both described in [`docs/PRIVACY_SECURITY.md`](docs/PRIVACY_SECURITY.md): the optional **AI Coach** (off until you add your own API key), and a once-a-day check for a newer release, which sends nothing about you and never installs anything. Turn the check off in Settings → About and it makes no request at all.
 
 ---
 
@@ -187,7 +187,7 @@ shared cross-platform code.
 | **Data Sources** | One-tap import of a WHOOP CSV export, an Apple Health export, or a **nutrition CSV** (Cronometer / MacroFactor), plus live-strap status. "Bring your history in once, then it's yours." |
 | **Notifications** | Configure local notifications and thresholds (`Strand/Data/NotificationSettingsStore.swift`). |
 | **Automations** | Turn the strap's physical inputs and live biometrics into Mac actions — all on-device (see below). |
-| **Coach** | An optional **AI Coach** you can ask about your data in plain language. It's the one feature that can ever use the network: off until you add your own key — Anthropic, OpenAI, or any OpenAI-compatible endpoint including a local/self-hosted model (Ollama, LM Studio) — and it sends only a short text summary of recent metrics plus your question, never raw streams or identifiers. With a local model the conversation never leaves your machine. Available on macOS, Android, and iOS. See [`docs/PRIVACY_SECURITY.md`](docs/PRIVACY_SECURITY.md). |
+| **Coach** | An optional **AI Coach** you can ask about your data in plain language. It's the one feature that can ever send anything about your data over the network: off until you add your own key — Anthropic, OpenAI, or any OpenAI-compatible endpoint including a local/self-hosted model (Ollama, LM Studio) — and it sends only a short text summary of recent metrics plus your question, never raw streams or identifiers. With a local model the conversation never leaves your machine. Available on macOS, Android, and iOS. See [`docs/PRIVACY_SECURITY.md`](docs/PRIVACY_SECURITY.md). |
 | **Settings** | Profile, preferences, **step calibration** (tune the stride/step estimate to your own walking), unit choices, the in-app **What's new** changelog, and an opt-in **Experimental** section (WHOOP 5/MG protocol probes). On **iOS**, also **Export for Shortcuts** — a HealthKit-free path that hands your metrics to Apple Health via the Shortcuts app. |
 
 There is also a **menu-bar extra** (`Strand/MenuBar/MenuBarContent.swift`) with a
@@ -524,6 +524,12 @@ Every arrow stays on your machine.
 **Offline by design.** NOOP has no server, no telemetry, and no account. Your
 strap data, imports, and computed metrics live in a local SQLite database on your
 device and never leave it.
+
+The app makes two kinds of network request, neither carrying anything about you: the optional
+**AI Coach** (off until you add your own key), and a once-a-day read of the latest release number so a
+sideloaded install can tell you an update exists — on by default, switchable off in Settings → About,
+and it never installs anything. Both are detailed in
+[`docs/PRIVACY_SECURITY.md`](docs/PRIVACY_SECURITY.md).
 
 ---
 

--- a/Strand/App/ContentView.swift
+++ b/Strand/App/ContentView.swift
@@ -53,10 +53,15 @@ struct ContentView: View {
             // Seed the current What's New into the Updates inbox (idempotent per version) so the bell
             // collects it even if the user dismisses the auto sheet.
             UpdateStore.shared.seedWhatsNewIfNeeded()
-            // #1659: iOS cannot auto-update a sideloaded build - no API lets an app install or re-sign an
-            // .ipa - so the most NOOP can do is NOTICE a release and say so. Opt-in and silent when off,
-            // which is the default; see UpdateAvailability.defaultEnabled.
-            UpdateWatch.runIfDue(currentVersion: UpdateWatch.installedVersion, sideloadHint: false)
+            // #1659: NOOP is sideloaded on every platform, so nothing else will tell you a release
+            // happened. On by default and switchable off - see UpdateAvailability.defaultEnabled.
+            //
+            // Gated on the SAME condition as showWhatsNewIfDue below, matching the iOS and Android hooks:
+            // a default-on check must not reach the network during first run, before the Terms gate has
+            // been accepted. (No sideload sentence here - macOS has no seven-day re-sign and no AltStore.)
+            if onboarded && acceptedTerms == Terms.currentVersion {
+                UpdateWatch.runIfDue(currentVersion: UpdateWatch.installedVersion, sideloadHint: false)
+            }
         }
         .onChangeCompat(of: acceptedTerms) { _ in showWhatsNewIfDue() }
     }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -2815,8 +2815,9 @@ struct SettingsView: View {
 
                     // #1659: the automatic half. iOS cannot auto-update a sideloaded build at all — no API
                     // lets an app install or re-sign an .ipa — so noticing and saying so is the whole of
-                    // what is possible. Off by default: an unasked-for launch request would contradict the
-                    // offline promise this project leads with.
+                    // what is possible. ON by default, because a sideloaded app has no store to tell the
+                    // user anything and a setting nobody finds is the feature not existing; switching it
+                    // off here stops the request entirely. See UpdateAvailability.defaultEnabled.
                     Toggle(isOn: $autoCheckUpdates) {
                         VStack(alignment: .leading, spacing: 2) {
                             Text("Check automatically")

--- a/Strand/System/UpdateAvailability.swift
+++ b/Strand/System/UpdateAvailability.swift
@@ -16,12 +16,19 @@ import WhoopProtocol
 /// Kotlin twin: `com.noop.update.UpdateAvailability`.
 enum UpdateAvailability {
 
-    /// OFF by default, and that is a deliberate reading of a hard project rule rather than timidity.
-    /// "Fully offline, on-device, no telemetry" is the headline promise, and both update checkers
-    /// currently justify themselves in their own doc comments as running ONLY on a tap. A check that
-    /// phones GitHub on launch without being asked would contradict that, however harmless the request
-    /// is. Flip this ONE constant to make it default-on; everything else about the feature is unchanged.
-    static let defaultEnabled = false
+    /// ON by default (maintainer's call, #1659).
+    ///
+    /// It shipped off first, on the reading that "fully offline, on-device, no telemetry" made an
+    /// unasked-for launch request wrong on principle. The counter-argument won: a sideloaded app has no
+    /// store to update it, so a user who never finds this setting is a user who silently runs an old
+    /// build — which is the whole problem the issue reported. A default nobody discovers is not a
+    /// compromise, it is the feature not existing.
+    ///
+    /// What keeps it honest is what the request IS: one read of a public version number, once a day,
+    /// after onboarding and the Terms gate. Nothing about the user is sent, nothing is uploaded, and no
+    /// data leaves the device — the offline promise is about the user's HEALTH DATA, and that is
+    /// untouched. Anyone who disagrees turns it off in Settings, and it then makes no request at all.
+    static let defaultEnabled = true
 
     /// Once a day. The thing being watched moves on the order of days-to-weeks, so anything tighter spends
     /// requests (and a little battery) to learn nothing.
@@ -101,7 +108,7 @@ enum UpdateAvailability {
 enum UpdateWatch {
 
     enum Keys {
-        /// Opt-in. See `UpdateAvailability.defaultEnabled` for why this is off until asked for.
+        /// On by default; see `UpdateAvailability.defaultEnabled` for why, and what the request is.
         static let enabled = "updates.autoCheck"
         static let lastCheckedAt = "updates.lastCheckedAt"
         static let lastPostedVersion = "updates.lastPostedVersion"

--- a/Strand/System/UpdateChecker.swift
+++ b/Strand/System/UpdateChecker.swift
@@ -1,10 +1,20 @@
 import Foundation
 import WhoopProtocol
 
-/// User-initiated "Check for updates": one call to the project's PUBLIC releases API (GitHub),
-/// made ONLY when the user taps the button. No background polling and no auto-update — it just reads the latest version
-/// number and compares it to the installed one; nothing about the user is sent. (Uses the
-/// network-client entitlement, which is otherwise only for the opt-in, off-by-default AI Coach.)
+/// "Check for updates": one call to the project's PUBLIC releases API (GitHub), reading the latest
+/// version number and comparing it to the installed one. Nothing about the user is sent, and it never
+/// installs anything — on iOS no API permits that for a sideloaded app.
+///
+/// TWO callers share this, and the distinction matters to anyone auditing what the app does on its own:
+///  - the Settings button, which runs only when tapped;
+///  - `UpdateWatch`, the #1659 daily check, which runs at most once a day after onboarding and the Terms
+///    gate. It is ON by default and switching it off in Settings stops the request entirely.
+///
+/// This header previously said the read happened ONLY on a tap. That stopped being true the moment the
+/// automatic caller was added, and a false claim here is worse than none: it is the file someone opens to
+/// answer "does this app poll?". Documented for real in docs/PRIVACY_SECURITY.md §1.1c.
+///
+/// (Uses the network-client entitlement, which is otherwise only for the opt-in, off-by-default AI Coach.)
 @MainActor
 final class UpdateChecker: ObservableObject {
 

--- a/StrandTests/UpdateAvailabilityTests.swift
+++ b/StrandTests/UpdateAvailabilityTests.swift
@@ -126,4 +126,36 @@ final class UpdateAvailabilityTests: XCTestCase {
     func testComposeTreatsBlankNotesAsNone() {
         XCTAssertEqual(UpdateAvailability.composeMessage(body: "A.", sideload: nil, notes: "   \n  "), "A.")
     }
+
+    // MARK: - the default
+
+    /// An UNSET pref must resolve to the same answer the Settings toggle shows. The launch check reads
+    /// UserDefaults directly and the toggle reads @AppStorage; both fall back to `defaultEnabled`, and if
+    /// one were changed without the other the switch would say one thing while the app did another.
+    func testAnUnsetPrefMatchesWhatTheToggleWouldShow() {
+        let key = UpdateWatch.Keys.enabled
+        let saved = UserDefaults.standard.object(forKey: key)
+        defer {
+            if let saved { UserDefaults.standard.set(saved, forKey: key) }
+            else { UserDefaults.standard.removeObject(forKey: key) }
+        }
+        UserDefaults.standard.removeObject(forKey: key)
+        XCTAssertEqual(UpdateWatch.isEnabled, UpdateAvailability.defaultEnabled)
+    }
+
+    /// An explicit choice always wins over the default, in BOTH directions — otherwise flipping the
+    /// shipped default would silently override people who had already opted out.
+    func testAnExplicitChoiceOverridesTheDefault() {
+        let key = UpdateWatch.Keys.enabled
+        let saved = UserDefaults.standard.object(forKey: key)
+        defer {
+            if let saved { UserDefaults.standard.set(saved, forKey: key) }
+            else { UserDefaults.standard.removeObject(forKey: key) }
+        }
+        UserDefaults.standard.set(false, forKey: key)
+        XCTAssertFalse(UpdateWatch.isEnabled)
+        UserDefaults.standard.set(true, forKey: key)
+        XCTAssertTrue(UpdateWatch.isEnabled)
+    }
 }
+

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -401,9 +401,15 @@ private struct iOSRootView: View {
             // collects it even if the user dismisses the auto sheet.
             UpdateStore.shared.seedWhatsNewIfNeeded()
             // #1659: iOS cannot auto-update a sideloaded build - no API lets an app install or re-sign an
-            // .ipa - so the most NOOP can do is NOTICE a release and say so. Opt-in and silent when off,
-            // which is the default; see UpdateAvailability.defaultEnabled.
-            UpdateWatch.runIfDue(currentVersion: UpdateWatch.installedVersion, sideloadHint: true)
+            // .ipa - so the most NOOP can do is NOTICE a release and say so.
+            //
+            // Gated on the SAME condition as showWhatsNewIfDue above, and the Android hook. This matters
+            // now that the check is on by default: without it a brand-new install would reach the network
+            // during first run, before the Terms gate the user has not accepted yet. While the default was
+            // off, nothing made that visible.
+            if onboarded && acceptedTerms == Terms.currentVersion {
+                UpdateWatch.runIfDue(currentVersion: UpdateWatch.installedVersion, sideloadHint: true)
+            }
         }
         .onChange(of: acceptedTerms) { _, _ in showWhatsNewIfDue() }
     }

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -1333,7 +1333,13 @@ fun NoopRoot() {
         // release and say so in the same inbox. On by default and switchable off in Settings — see
         // UpdateAvailability.DEFAULT_ENABLED. Onboarded-only for the same reason as the seed above, and
         // now also because a default-on check must not reach the network during first run.
-        if (onboarded) {
+        // Terms too, not just onboarding — the Swift hooks gate on both, and the Terms gate below sits
+        // AFTER this effect, so `onboarded` alone would let a default-on check reach the network while a
+        // returning user is still looking at a re-prompted clickwrap. Read from prefs rather than the
+        // `acceptedTerms` state, which is not declared until after this block.
+        val termsCurrent =
+            prefs.getString(NoopPrefs.KEY_ACCEPTED_TERMS_VERSION, "") == Terms.CURRENT_VERSION
+        if (onboarded && termsCurrent) {
             com.noop.update.UpdateWatch.runIfDue(context, BuildConfig.VERSION_NAME)
         }
     }

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -1338,6 +1338,11 @@ fun NoopRoot() {
         // the Terms gate below sits AFTER this effect, so `onboarded` alone would not have held it back.
         // Read from prefs rather than the `acceptedTerms` state, which is not declared until after this
         // block.
+        //
+        // No re-entrancy guard here, unlike the Swift twin's `inFlight`: LaunchedEffect does not re-run on
+        // recomposition, only when its key changes, so this cannot fire twice for one launch. `.onAppear`
+        // gives no such promise, which is why the Swift side needs the flag. Moving this call anywhere
+        // that re-runs (a plain composable body, a keyless effect) would need the guard back.
         val termsCurrent =
             prefs.getString(NoopPrefs.KEY_ACCEPTED_TERMS_VERSION, "") == Terms.CURRENT_VERSION
         if (onboarded && termsCurrent) {

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -1331,12 +1331,13 @@ fun NoopRoot() {
         if (onboarded) UpdateStore.from(context).seedWhatsNewIfNeeded()
         // #1659: a sideloaded build has no store to update it, so the most NOOP can do is NOTICE a
         // release and say so in the same inbox. On by default and switchable off in Settings — see
-        // UpdateAvailability.DEFAULT_ENABLED. Onboarded-only for the same reason as the seed above, and
-        // now also because a default-on check must not reach the network during first run.
-        // Terms too, not just onboarding — the Swift hooks gate on both, and the Terms gate below sits
-        // AFTER this effect, so `onboarded` alone would let a default-on check reach the network while a
-        // returning user is still looking at a re-prompted clickwrap. Read from prefs rather than the
-        // `acceptedTerms` state, which is not declared until after this block.
+        // UpdateAvailability.DEFAULT_ENABLED.
+        //
+        // Gated on onboarding AND terms, matching both Swift hooks: a default-on check must not reach the
+        // network during first run, nor while a returning user is looking at a re-prompted clickwrap —
+        // the Terms gate below sits AFTER this effect, so `onboarded` alone would not have held it back.
+        // Read from prefs rather than the `acceptedTerms` state, which is not declared until after this
+        // block.
         val termsCurrent =
             prefs.getString(NoopPrefs.KEY_ACCEPTED_TERMS_VERSION, "") == Terms.CURRENT_VERSION
         if (onboarded && termsCurrent) {

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -1330,8 +1330,9 @@ fun NoopRoot() {
     LaunchedEffect(onboarded) {
         if (onboarded) UpdateStore.from(context).seedWhatsNewIfNeeded()
         // #1659: a sideloaded build has no store to update it, so the most NOOP can do is NOTICE a
-        // release and say so in the same inbox. Opt-in, and silent when off, which is the default —
-        // see UpdateAvailability.DEFAULT_ENABLED. Onboarded-only for the same reason as the seed above.
+        // release and say so in the same inbox. On by default and switchable off in Settings — see
+        // UpdateAvailability.DEFAULT_ENABLED. Onboarded-only for the same reason as the seed above, and
+        // now also because a default-on check must not reach the network during first run.
         if (onboarded) {
             com.noop.update.UpdateWatch.runIfDue(context, BuildConfig.VERSION_NAME)
         }

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -3341,9 +3341,9 @@ fun SettingsScreen(
                 var updChecking by remember { mutableStateOf(false) }
                 var updResult by remember { mutableStateOf<UpdateCheck.Result?>(null) }
                 // #1659: the automatic half. A sideloaded build has no store to update it, so noticing a
-                // release and saying so in the Updates inbox is the whole of what is possible. Off by
-                // default: an unasked-for launch request would contradict the offline promise this project
-                // leads with. See UpdateAvailability.DEFAULT_ENABLED.
+                // release and saying so in the Updates inbox is the whole of what is possible. ON by
+                // default, because a setting nobody finds is the feature not existing; switching it off
+                // here stops the request entirely. See UpdateAvailability.DEFAULT_ENABLED.
                 var autoCheck by remember {
                     mutableStateOf(com.noop.update.UpdateWatch.isEnabled(context))
                 }

--- a/android/app/src/main/java/com/noop/update/UpdateAvailability.kt
+++ b/android/app/src/main/java/com/noop/update/UpdateAvailability.kt
@@ -19,13 +19,20 @@ package com.noop.update
 object UpdateAvailability {
 
     /**
-     * OFF by default, and that is a deliberate reading of a hard project rule rather than timidity.
-     * "Fully offline, on-device, no telemetry" is the headline promise, and both update checkers
-     * currently justify themselves in their own doc comments as running ONLY on a tap. A check that
-     * phones GitHub on launch without being asked would contradict that, however harmless the request
-     * is. Flip this ONE constant to make it default-on; everything else about the feature is unchanged.
+     * ON by default (maintainer's call, #1659).
+     *
+     * It shipped off first, on the reading that "fully offline, on-device, no telemetry" made an
+     * unasked-for launch request wrong on principle. The counter-argument won: a sideloaded app has no
+     * store to update it, so a user who never finds this setting is a user who silently runs an old
+     * build — which is the whole problem the issue reported. A default nobody discovers is not a
+     * compromise, it is the feature not existing.
+     *
+     * What keeps it honest is what the request IS: one read of a public version number, once a day,
+     * after onboarding. Nothing about the user is sent, nothing is uploaded, and no data leaves the
+     * device — the offline promise is about the user's HEALTH DATA, and that is untouched. Anyone who
+     * disagrees turns it off in Settings, and it then makes no request at all.
      */
-    const val DEFAULT_ENABLED = false
+    const val DEFAULT_ENABLED = true
 
     /** Once a day. The thing being watched moves on the order of days-to-weeks, so anything tighter
      *  spends requests (and a little battery) to learn nothing. */
@@ -112,7 +119,7 @@ object UpdateAvailability {
  */
 object UpdateWatch {
 
-    /** Opt-in. See [UpdateAvailability.DEFAULT_ENABLED] for why this is off until asked for. */
+    /** On by default; see [UpdateAvailability.DEFAULT_ENABLED] for why, and what the request is. */
     const val KEY_ENABLED = "updates.autoCheck"
     const val KEY_LAST_CHECKED_AT = "updates.lastCheckedAt"
     const val KEY_LAST_POSTED_VERSION = "updates.lastPostedVersion"

--- a/android/app/src/main/java/com/noop/update/UpdateCheck.kt
+++ b/android/app/src/main/java/com/noop/update/UpdateCheck.kt
@@ -7,11 +7,20 @@ import java.net.HttpURLConnection
 import java.net.URL
 
 /**
- * User-initiated "Check for updates": a single call to the project's PUBLIC releases API (GitHub) that reads the
- * latest version and compares it to the installed one. It runs ONLY when the user taps the button —
- * there is no background polling and no auto-update. Nothing about the user is sent; it just reads a
- * version number. (Android already holds INTERNET for the opt-in AI Coach, so this adds no new
- * capability.)
+ * "Check for updates": a single call to the project's PUBLIC releases API (GitHub) that reads the latest
+ * version and compares it to the installed one. Nothing about the user is sent, and it never installs
+ * anything.
+ *
+ * TWO callers share this, and the distinction matters to anyone auditing what the app does on its own:
+ *  - the Settings button, which runs only when tapped;
+ *  - [UpdateWatch], the #1659 daily check, which runs at most once a day after onboarding and the Terms
+ *    gate. It is ON by default and switching it off in Settings stops the request entirely.
+ *
+ * This header previously said the read happened ONLY on a tap. That stopped being true the moment the
+ * automatic caller was added, and a false claim here is worse than none: it is the file someone opens to
+ * answer "does this app poll?". Documented for real in docs/PRIVACY_SECURITY.md §1.1c.
+ *
+ * (Android already holds INTERNET for the opt-in AI Coach, so this adds no new capability.)
  */
 object UpdateCheck {
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -40,9 +40,14 @@ non-negotiable (especially on the Bluetooth path).
 
 A few principles run through the whole codebase. Internalize them before opening a PR.
 
-1. **Offline by design.** There is no server, no telemetry, no account, no network call. A change
-   that phones home — for any reason — does not belong here. Strap data, imports, and computed
-   metrics live in a local SQLite database and never leave the device.
+1. **Offline by design.** There is no server, no telemetry and no account, and **your data never
+   leaves the device.** Strap data, imports, and computed metrics live in a local SQLite database.
+   A change that uploads any of it — for any reason — does not belong here.
+   The app makes exactly three network requests, all documented in
+   [docs/PRIVACY_SECURITY.md §1.1](PRIVACY_SECURITY.md): the opt-in AI Coach, the
+   compile-time-optional Oura history import, and the update check (a read of a public version
+   number, on by default, switchable off). Each sends nothing about the user. Adding a fourth needs
+   a very good reason and the same treatment: named in the privacy doc, and switchable off.
 2. **Interoperability, not impersonation.** NOOP talks to a strap the user already owns. It does not
    log into a WHOOP account, bypass a paywall, or ship WHOOP's proprietary code/firmware/assets/logos.
    Keep contributions on the right side of that line, and keep all WHOOP references *nominative*

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -58,6 +58,12 @@ Two things do carry your data off-device **when you choose to send them**:
 
 Both are user-initiated. See [docs/PRIVACY_SECURITY.md](PRIVACY_SECURITY.md).
 
+NOOP also checks once a day whether a newer release exists, because it is sideloaded on every platform
+and has no store to update it. That is a read of a public version number and sends nothing about you —
+no identifier, no account, no health data — and it never installs anything. It is on by default and
+switchable off in Settings → About, and the full detail is in
+[docs/PRIVACY_SECURITY.md §1.1c](PRIVACY_SECURITY.md).
+
 ## Which numbers are measured, and which are NOOP's own estimates?
 
 Measured from the strap: heart rate, R-R intervals, resting HR, skin temperature, respiratory rate,

--- a/docs/PRIVACY_SECURITY.md
+++ b/docs/PRIVACY_SECURITY.md
@@ -46,12 +46,12 @@ deliberately export it to another store on the **same device**:
 | Oura history import (opt-in build flag, §1.1b) | HTTPS OAuth + REST, `api.ouraring.com` → device | Read-only from your own Oura account |
 | Apple Health export, incl. iOS "Export for Shortcuts" | On-device, user-initiated | NOOP → your Apple Health, on your device only (§1.3) |
 
-The only **network** paths are the opt-in AI Coach and the compile-time-optional Oura
-history import; the
+The **network** paths are the opt-in AI Coach, the compile-time-optional Oura history import, and the
+update check (§1.1c); the
 biometric pipeline produces no network traffic of any kind. The Apple Health export above is
 an **on-device** hand-off, not a network upload — see §1.3.
 
-### 1.1 Network code: only the two optional exceptions
+### 1.1 Network code: the three exceptions
 
 The biometric pipeline and all five Swift packages
 (`WhoopProtocol`, `WhoopStore`, `StrandAnalytics`, `StrandImport`, `StrandDesign`)
@@ -64,9 +64,34 @@ TestFlight — and was folded into the main tree in v1.94), so the Swift-side pr
 behaviour described here applies equally to both. Android is a separate codebase using
 Room for storage and Kotlin for the BLE / import / Coach paths; its own Oura support is
 the local BLE ring-pairing lane, not a network API, so it has no equivalent to §1.1b. The
-**only** networking anywhere in the app is the AI Coach (`Strand/AI/AICoach.swift` on the
-Swift side — macOS and iOS — `com.noop.ai.AiCoach` on Android), described in §1.1a, and
-the Oura history import (`Strand/Oura/`, Swift-only — macOS and iOS), described in §1.1b.
+networking anywhere in the app is the AI Coach (`Strand/AI/AICoach.swift` on the
+Swift side — macOS and iOS — `com.noop.ai.AiCoach` on Android), described in §1.1a,
+the Oura history import (`Strand/Oura/`, Swift-only — macOS and iOS), described in §1.1b,
+and the update check, described in §1.1c.
+#### 1.1c The update check
+
+NOOP is sideloaded on every platform — there is no App Store or Play Store to update it — so an install
+that is never told about a release simply runs an old build indefinitely. Two paths address that, and
+both read the **same** public endpoint: `https://api.github.com/repos/ryanbr/noop/releases/latest`.
+
+- **"Check for updates"** in Settings → About. Runs only when tapped. It has always existed;
+  it was previously undocumented here, which is why this section is new rather than merely amended.
+- **"Check automatically"**, beside it. At most once a day, after onboarding (and, on iOS, after the
+  Terms gate), NOOP reads that endpoint and — if a newer release exists — puts a row in the Updates
+  inbox. **On by default**, and switchable off, at which point it makes no request at all.
+
+What is sent: nothing. It is an unauthenticated `GET` of a public URL, carrying no identifier, no
+account, no device information and no biometric data. What comes back is a version number and the
+release notes. **It never installs anything** — on iOS no API permits that for a sideloaded app (see
+[docs/IOS.md](IOS.md)); the row tells you a release exists and where to get it.
+
+The request is a plain HTTPS call, so your IP address is visible to GitHub exactly as it would be if
+you opened the releases page in a browser. If that is not a trade you want, turn the toggle off; the
+manual button then remains the only way NOOP touches the network for this.
+
+Code: `Strand/System/UpdateChecker.swift` + `Strand/System/UpdateAvailability.swift` (Swift),
+`com.noop.update.UpdateCheck` + `com.noop.update.UpdateAvailability` (Android).
+
 The package manifests reference dependency *download* URLs that Swift Package Manager
 resolves at build time, never at runtime:
 


### PR DESCRIPTION
Your call on #1659. It shipped off, on the reading that *"fully offline, no telemetry"* made an unasked-for launch request wrong on principle. The counter-argument won: **a sideloaded app has no store to update it**, so a user who never finds the setting is a user who silently runs an old build — which is the whole problem the issue reported. A default nobody discovers isn't a compromise, it's the feature not existing.

The flip is one constant per platform. **The rest of this PR is what the flip actually costs, and it's the larger half.**

## A gating bug the default-off state was hiding

Android gated the launch check on `onboarded`. **iOS didn't gate at all.** With the check off that was invisible; with it on, a brand-new iOS install would have reached the network during first run — *before the Terms gate the user hasn't accepted yet.* Now gated on the same condition as `showWhatsNewIfDue` directly above it.

## The privacy docs were already wrong

`PRIVACY_SECURITY.md` claimed **"the only networking anywhere in the app is the AI Coach"** and *"the only two optional exceptions"*. But the **manual** update check has always made a network call and was never documented. The doc has been inaccurate since that button shipped — turning the automatic half on would have widened an existing untruth rather than created a new one.

New **§1.1c** documents both paths honestly:

- the same public endpoint for both
- **what is sent: nothing** — no identifier, no account, no device info, no biometric data
- what comes back, and that **it never installs anything**
- on by default, switchable off, at which point it makes no request at all
- that the request exposes an IP to GitHub exactly as opening the releases page in a browser would

That last one matters: a reader who objects to it can act on it. A privacy doc that omits the trade isn't protecting anyone.

`CONTRIBUTING.md`'s *"no network call"* is now stated as what it actually means — **your data never leaves the device** — with the three requests named and a rule for anyone proposing a fourth. `FAQ.md` names the check where the reader is already asking what leaves the device.

## Tests

Two, for the property this change depends on:

- **an unset pref resolves to the same answer the Settings toggle shows.** The launch check reads `UserDefaults`, the toggle reads `@AppStorage`; a mismatch would have the switch saying one thing while the app did another.
- **an explicit choice overrides the default in both directions** — so flipping the shipped default cannot silently override someone who had already opted out.

Android 4566 tests green, compile clean, `doc_comment_lint` clean. App-target Swift, so app-build dispatched separately.
