### PR TITLE
steps: read the gravity union in the iOS/macOS calibration screen too (#1643)

### DIFF
--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -285,6 +285,40 @@ final class Repository: ObservableObject {
         return byDay.values.sorted { $0.day < $1.day }
     }
 
+    /// Gravity samples across the imported union, deduped by timestamp with the ACTIVE STRAP winning.
+    ///
+    /// #1643: the Steps calibration screen read a SINGLE id and so disagreed with the estimator, which
+    /// resolves an owner per day before reading gravity. Android hit the canonical half of this (it
+    /// hardcoded "my-whoop" and missed a re-added strap's live motion, @kavemang's #1644); the Swift
+    /// screen had the mirror half — it read the ACTIVE id and so missed the canonical history a prior
+    /// import or an earlier strap identity had banked.
+    ///
+    /// Twin of Kotlin `WhoopRepository.gravitySamplesUnion`. It takes the active id as a parameter
+    /// because its repository is not device-scoped; this one already knows `importedReadIds`.
+    func gravitySamplesUnion(from: Int, to: Int, limit: Int = 200_000) async -> [GravitySample] {
+        guard let store = await storeHandle() else { return [] }
+        var lists: [[GravitySample]] = []
+        for id in importedReadIds {   // active strap FIRST → it wins any shared timestamp
+            lists.append((try? await store.gravitySamples(deviceId: id, from: from, to: to, limit: limit)) ?? [])
+        }
+        return Self.mergeGravityByTs(lists)
+    }
+
+    /// Merge gravity lists into one time-ordered stream, deduped by timestamp with the FIRST list (the
+    /// active strap) winning a tie. A single-id read is returned UNCHANGED, so a single-device install
+    /// performs exactly the read it did before the union existed.
+    ///
+    /// Byte-identical rule to Kotlin `mergeGravityByTs`. Pure + static so the dedup is unit-tested
+    /// without a store — the property that actually matters here is "active wins, nothing double-counts".
+    nonisolated static func mergeGravityByTs(_ lists: [[GravitySample]]) -> [GravitySample] {
+        if lists.count == 1 { return lists[0] }
+        var byTs: [Int: GravitySample] = [:]
+        for list in lists {
+            for s in list where byTs[s.ts] == nil { byTs[s.ts] = s }
+        }
+        return byTs.values.sorted { $0.ts < $1.ts }
+    }
+
     /// One day held by two source ids in the SAME bucket, folded into `winner`'s row: `winner` keeps every
     /// column it carries (NON-nil — a measured zero is a reading) and `filler` supplies only the ones it
     /// left nil. Whole-row first-wins let a hollow row (steps and nothing else) discard a complete one, and

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -3638,7 +3638,7 @@ struct StepsCalibrationSheet: View {
             .sorted { $0.day > $1.day }
 
         // Reconstruct the estimate for the most recent phone-covered days, motion-by-motion.
-        guard coeff > 0, let store = await repo.storeHandle() else { return }
+        guard coeff > 0 else { return }
         let cal = StepsEstimateEngine.Calibration(coefficient: coeff,
                                                   sampleDays: profile.stepsCalibrationSampleDays,
                                                   confidence: profile.stepsCalibrationConfidence,
@@ -3650,8 +3650,10 @@ struct StepsCalibrationSheet: View {
         for entry in phoneDays.prefix(10) {           // scan a few extra to fill 7 after motion gaps
             guard let dayDate = dayParser.date(from: entry.day) else { continue }
             let mid = Int(calendar.startOfDay(for: dayDate).timeIntervalSince1970)
-            let grav = (try? await store.gravitySamples(deviceId: repo.deviceId, from: mid,
-                                                        to: mid + 86_400 - 1, limit: 200_000)) ?? []
+            // #1643: the UNION, not `repo.deviceId` alone — a re-added strap leaves motion under both the
+            // active id and the canonical one, and reading either by itself makes this screen disagree
+            // with the estimator it is supposed to be reconstructing.
+            let grav = await repo.gravitySamplesUnion(from: mid, to: mid + 86_400 - 1)
             let motion = StepsEstimateEngine.dayMotionIntensity(grav)
             guard motion > 0, let est = StepsEstimateEngine.estimate(motion: motion, calibration: cal) else { continue }
             motions.append(motion)

--- a/StrandTests/GravityReadUnionTests.swift
+++ b/StrandTests/GravityReadUnionTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+import WhoopProtocol
+@testable import Strand
+
+/// The gravity read behind the Steps calibration screen (#1643).
+///
+/// Swift twin of Android's `GravityReadUnionTest` (@kavemang, #1644). The bug was the same shape on both
+/// platforms and opposite in detail: Android hardcoded the canonical id and missed a re-added strap's live
+/// motion; this side read the ACTIVE id alone and missed the canonical history. Either way the screen
+/// disagreed with the estimator it exists to reconstruct.
+final class GravityReadUnionTests: XCTestCase {
+
+    private func sample(_ ts: Int, _ x: Double) -> GravitySample {
+        GravitySample(ts: ts, x: x, y: 0, z: 1)
+    }
+
+    /// The active strap wins a shared timestamp, and nothing double-counts — the two properties the
+    /// screen's motion total depends on.
+    func testActiveWinsTiesAndTheStreamIsTimeOrdered() {
+        let active = [sample(101, 9.0), sample(103, 9.2)]
+        let canonical = [sample(100, 5.0), sample(101, 5.1), sample(102, 5.2)]
+
+        let merged = Repository.mergeGravityByTs([active, canonical])
+
+        XCTAssertEqual(merged.map(\.ts), [100, 101, 102, 103])
+        XCTAssertEqual(merged.first { $0.ts == 101 }?.x, 9.0)   // active, not canonical
+    }
+
+    /// A re-added strap with no canonical history must still populate: this is the reported failure on
+    /// the Android side, and the union has to cover it here too.
+    func testActiveOnlyMotionSurfacesWhenCanonicalIsEmpty() {
+        let active = [sample(100, 0.1), sample(101, 0.2)]
+        XCTAssertEqual(Repository.mergeGravityByTs([active, []]).map(\.ts), [100, 101])
+    }
+
+    /// The mirror case, which is the half THIS platform had: canonical history and no active-id rows.
+    func testCanonicalHistorySurfacesWhenTheActiveIdIsEmpty() {
+        let canonical = [sample(100, 0.1), sample(101, 0.2)]
+        XCTAssertEqual(Repository.mergeGravityByTs([[], canonical]).map(\.ts), [100, 101])
+    }
+
+    /// A single-device install collapses to one id, and that read is returned UNCHANGED — so this change
+    /// cannot alter what the overwhelmingly common install already saw.
+    func testASingleIdReadIsReturnedUntouched() {
+        let rows = [sample(100, 0.1), sample(101, 0.2)]
+        XCTAssertEqual(Repository.mergeGravityByTs([rows]), rows)
+    }
+
+    func testNoMotionUnderEitherIdStaysEmpty() {
+        XCTAssertTrue(Repository.mergeGravityByTs([[], []]).isEmpty)
+    }
+
+    /// Unsorted input still comes back time-ordered: the store returns rows per id, and concatenating two
+    /// id-ordered lists is not itself ordered.
+    func testOutOfOrderInputIsSorted() {
+        let a = [sample(300, 1), sample(100, 2)]
+        let b = [sample(200, 3)]
+        XCTAssertEqual(Repository.mergeGravityByTs([a, b]).map(\.ts), [100, 200, 300])
+    }
+}


### PR DESCRIPTION
The Swift half of the bug **@kavemang** reported, and solved on Android in #1644.

**Same shape, opposite detail.** Android hardcoded the canonical `"my-whoop"` and so missed a re-added strap's **live** motion. This side reads `repo.deviceId`, which follows the active strap, and so missed the **canonical history** a prior import or an earlier strap identity had banked. Either way the calibration screen disagreed with the estimator it exists to reconstruct — which is the thing the report actually asked to stop happening.

## The machinery was already here

`importedReadIds` (active strap first, collapsing to one id on a single-device install) has been used by `CsvExport` and the Repository's own daily/series facades for a while. The screen simply never went through it. This adds `gravitySamplesUnion` beside those facades and points the screen at it.

The signature differs from the Kotlin twin on purpose: that one takes the active id as a parameter because its repository isn't device-scoped, and this one already knows `importedReadIds`. **The merge rule is byte-identical** — first list wins a shared timestamp, and a single-id read is returned *untouched*, so the overwhelmingly common install performs exactly the read it always did.

## Verification

6 tests over the pure merge, including **both one-sided cases** (the Android half and the iOS half), the single-id passthrough, and out-of-order input — the store returns rows per id, and concatenating two id-ordered lists isn't itself ordered. Expected values were generated by compiling the rule standalone with `swiftc`, since Xcode isn't available in this environment. `doc_comment_lint` clean.

## Residuals, both wider than this change

Both were named when reviewing #1644 and neither is introduced here:

- **multi-strap installs** — the estimator's per-day `resolveDayOwner` picks from registry candidates, which with two straps can be an id that is neither active nor canonical. The union wouldn't include it, so the screen could still disagree. Threading that resolution into a UI screen is a much larger change than the union the report itself proposed.
- **the read limit** — the screen doesn't use the estimator's `STREAM_LIMIT` on either platform.

**App-target Swift, so no default CI covers it** — app-build dispatched separately.
