### PR TITLE
health-connect: retract sleep records the export no longer produces (#1677)

### DIFF
--- a/android/app/src/main/java/com/noop/ingest/HealthConnectLedger.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectLedger.kt
@@ -42,6 +42,20 @@ object HealthConnectLedger {
         context.getSharedPreferences(com.noop.ui.NoopPrefs.NAME, Context.MODE_PRIVATE)
 
     /**
+     * What the ledger should carry into the NEXT export.
+     *
+     * Not simply the ids just written. A retraction that FAILED — Health Connect unavailable, the
+     * permission pulled mid-export, a transient remote error — still has a live record behind it, and
+     * dropping its id here would forget it forever. That is the exact failure this whole file exists to
+     * prevent, reintroduced through the error path, and the first version of this change had it.
+     *
+     * So a failed retraction stays on the books and is retried next time. It costs one id in a
+     * SharedPreferences set until it succeeds.
+     */
+    fun ledgerAfterExport(current: Set<String>, unretracted: Set<String>): Set<String> =
+        current + unretracted
+
+    /**
      * Which previously-written ids should this export RETRACT?
      *
      * The obvious answer — everything we wrote before and are not writing now — is WRONG, and wrong in

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectLedger.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectLedger.kt
@@ -1,0 +1,75 @@
+package com.noop.ingest
+
+import android.content.Context
+
+/**
+ * What NOOP has already written to Health Connect, so it can take it back (#1677).
+ *
+ * The writer is idempotent by `clientRecordId` and versions each record so a later, fuller copy upserts
+ * over an earlier one. That covers a record whose id STAYS THE SAME. It cannot cover a record whose id
+ * stops being produced — Health Connect never removes an id you simply stop writing.
+ *
+ * That case is routine for sleep, not exotic. `sleepSession`'s primary key is (deviceId, startTs), so a
+ * re-detection that lands on a different start is a DIFFERENT ROW, and the #1248/#1284 heal deletes the
+ * stale row once a fuller copy wins — `SleepSessionDedup` exists because one night really can accumulate
+ * several rows with different starts. The exporter's only cleanup path, `absorbedClientIds`, is computed
+ * from rows STILL IN THE DATABASE, so the moment the heal drops that row the exporter loses all knowledge
+ * that it ever wrote a Health Connect record under its id. The record then cannot be corrected or removed
+ * by any later export, which is exactly what #1677 reports: re-running the export does not fix it.
+ *
+ * So the exporter needs a memory of its own. This is that memory: the ids written per record type, and
+ * the rule for which of them a later export should retract.
+ */
+object HealthConnectLedger {
+
+    /** One entry per record type whose id embeds a MUTABLE timestamp. Day-keyed ids
+     *  (`noop-<metric>-<day>`) need no ledger: a day never changes its own key. */
+    const val SLEEP_PREFIX = "noop-sleep-"
+    const val WORKOUT_PREFIX = "noop-workout-"
+
+    private fun key(prefix: String) = "hc.written.$prefix"
+
+    fun previouslyWritten(context: Context, prefix: String): Set<String> =
+        prefs(context).getStringSet(key(prefix), emptySet()) ?: emptySet()
+
+    fun remember(context: Context, prefix: String, ids: Set<String>) {
+        // A COPY: SharedPreferences keeps the very set instance it was handed, and mutating or re-reading
+        // it afterwards is documented as undefined. Cheap insurance against a bug that only shows up later.
+        prefs(context).edit().putStringSet(key(prefix), HashSet(ids)).apply()
+    }
+
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(com.noop.ui.NoopPrefs.NAME, Context.MODE_PRIVATE)
+
+    /**
+     * Which previously-written ids should this export RETRACT?
+     *
+     * The obvious answer — everything we wrote before and are not writing now — is WRONG, and wrong in
+     * the most expensive direction: it deletes the user's data. The export covers a rolling window, so a
+     * night that simply aged out of that window is absent from [current] while its Health Connect record
+     * is perfectly good. Retracting it would silently destroy history the user still has.
+     *
+     * So an id is retracted only when its own timestamp falls INSIDE the window this export actually
+     * covered. Outside it, the export had nothing to say about that record and says nothing.
+     *
+     * An id whose timestamp cannot be parsed is never retracted. It is not ours to reason about, and
+     * guessing costs data while abstaining costs one stale row.
+     *
+     * Pure so both rules are pinned without a Health Connect client or a clock.
+     */
+    fun staleClientIds(
+        previous: Set<String>,
+        current: Set<String>,
+        prefix: String,
+        windowStartSec: Long,
+        nowSec: Long,
+    ): List<String> = previous
+        .asSequence()
+        .filter { it !in current }
+        .filter { id ->
+            val ts = id.removePrefix(prefix).toLongOrNull()
+            ts != null && ts in windowStartSec..nowSec
+        }
+        .sorted()   // deterministic, so a log line and a test read the same order
+        .toList()
+}

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectLedger.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectLedger.kt
@@ -27,15 +27,31 @@ object HealthConnectLedger {
     const val SLEEP_PREFIX = "noop-sleep-"
     const val WORKOUT_PREFIX = "noop-workout-"
 
-    private fun key(prefix: String) = "hc.written.$prefix"
+    /**
+     * PER STRAP, and that is load-bearing rather than tidy.
+     *
+     * The export is device-scoped: `sleepSessionsMerged(deviceId)` reads that strap union the canonical
+     * id, so nights banked under a DIFFERENT strap are not in its result. With one shared ledger, an
+     * export running as strap B would find strap A's ids absent-but-in-window and retract them —
+     * deleting Health Connect records that are perfectly valid, for a user who did nothing but switch
+     * which strap is active. Before any of this those records merely lingered; a global key would have
+     * turned a harmless staleness into data loss.
+     *
+     * Keyed per strap, each export can only ever take back what that same strap put there. Nights under
+     * the canonical id appear in every strap's union, so they land in every ledger and are never the odd
+     * one out.
+     *
+     * Pure so the separation is pinned by a test rather than by this comment.
+     */
+    fun ledgerKey(deviceId: String, prefix: String) = "hc.written.$deviceId.$prefix"
 
-    fun previouslyWritten(context: Context, prefix: String): Set<String> =
-        prefs(context).getStringSet(key(prefix), emptySet()) ?: emptySet()
+    fun previouslyWritten(context: Context, deviceId: String, prefix: String): Set<String> =
+        prefs(context).getStringSet(ledgerKey(deviceId, prefix), emptySet()) ?: emptySet()
 
-    fun remember(context: Context, prefix: String, ids: Set<String>) {
+    fun remember(context: Context, deviceId: String, prefix: String, ids: Set<String>) {
         // A COPY: SharedPreferences keeps the very set instance it was handed, and mutating or re-reading
         // it afterwards is documented as undefined. Cheap insurance against a bug that only shows up later.
-        prefs(context).edit().putStringSet(key(prefix), HashSet(ids)).apply()
+        prefs(context).edit().putStringSet(ledgerKey(deviceId, prefix), HashSet(ids)).apply()
     }
 
     private fun prefs(context: Context) =

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
@@ -327,7 +327,8 @@ object HealthConnectWriter {
         // never retracted.
         val currentIds = plans.map { it.clientId }.toSet()
         val stale = HealthConnectLedger.staleClientIds(
-            previous = HealthConnectLedger.previouslyWritten(context, HealthConnectLedger.SLEEP_PREFIX),
+            previous = HealthConnectLedger.previouslyWritten(
+                context, deviceId, HealthConnectLedger.SLEEP_PREFIX),
             current = currentIds,
             prefix = HealthConnectLedger.SLEEP_PREFIX,
             windowStartSec = floor,
@@ -358,7 +359,7 @@ object HealthConnectWriter {
         // export retract records that never existed - harmless in itself, but it would also drop the ids
         // that do need retracting from the ledger, quietly restoring the bug this fixes.
         HealthConnectLedger.remember(
-            context, HealthConnectLedger.SLEEP_PREFIX,
+            context, deviceId, HealthConnectLedger.SLEEP_PREFIX,
             HealthConnectLedger.ledgerAfterExport(currentIds, unretracted),
         )
         return written

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
@@ -172,7 +172,7 @@ object HealthConnectWriter {
         }
         runCatching { writeHeartRate(client, context, repo, deviceId, version) }
             .fold({ total += it }, { failures += it.writebackCategory() })
-        runCatching { writeSleep(client, repo, deviceId) }
+        runCatching { writeSleep(client, context, repo, deviceId) }
             .fold({ total += it }, { failures += it.writebackCategory() })
         // #1525: separate attempt on purpose. The daily records above go in ONE insertRecords call, so a
         // missing permission there loses resting HR, HRV, SpO2 and respiratory rate together. On its own,
@@ -259,13 +259,21 @@ object HealthConnectWriter {
      * and the absorbed fragments' old per-fragment records are DELETED (HC upserts by id but never
      * removes an id we stop writing).
      */
-    private suspend fun writeSleep(client: HealthConnectClient, repo: WhoopRepository, deviceId: String): Int {
+    private suspend fun writeSleep(
+        client: HealthConnectClient,
+        context: Context,
+        repo: WhoopRepository,
+        deviceId: String,
+    ): Int {
         val now = System.currentTimeMillis() / 1000
         val floor = now - WINDOW_DAYS * 86_400
         val sessions = repo.sleepSessionsMerged(deviceId, from = floor, to = now)
             .map { HealthExportPlan.SleepInput(it.startTs, it.effectiveStartTs, it.endTs, it.stagesJSON) }
         val offsetSec = (java.util.TimeZone.getDefault().getOffset(now * 1000) / 1000).toLong()
         val plans = HealthExportPlan.sleepSessions(sessions, now, offsetSec)
+        // Deliberately BEFORE the ledger below. "No plans" is not the same statement as "the user has no
+        // sleep": a read that came back empty for any reason would, with retraction enabled, delete every
+        // night this window covers. Saying nothing is the recoverable failure; deleting is not.
         if (plans.isEmpty()) return 0
 
         val zone = ZoneId.systemDefault()
@@ -295,13 +303,44 @@ object HealthConnectWriter {
         // Clear absorbed fragments' old records BEFORE the merged upsert, so a night previously
         // exported as two entries never lingers as one merged + one stale fragment. (#364)
         val absorbed = plans.flatMap { it.absorbedClientIds }
-        if (absorbed.isNotEmpty()) {
+        // #1677: and the ids we wrote on a PREVIOUS export that this one no longer produces. `absorbed`
+        // cannot cover those: it is derived from sleepSession rows still in the database, and the
+        // #1248/#1284 heal deletes a stale row the moment a fuller copy of that night wins. A record
+        // exported mid-sync under the partial night's start then had nothing left pointing at it, so no
+        // later export could correct or remove it — the permanent wrong duration #1677 describes.
+        // Scoped to this export's own window by `staleClientIds`, so a night that merely aged out is
+        // never retracted.
+        val currentIds = plans.map { it.clientId }.toSet()
+        val stale = HealthConnectLedger.staleClientIds(
+            previous = HealthConnectLedger.previouslyWritten(context, HealthConnectLedger.SLEEP_PREFIX),
+            current = currentIds,
+            prefix = HealthConnectLedger.SLEEP_PREFIX,
+            windowStartSec = floor,
+            nowSec = now,
+        )
+        val retract = (absorbed + stale).distinct()
+        if (retract.isNotEmpty()) {
+            // One call for the common case. If it throws, retry per id: the reporter of #1677 had already
+            // deleted the bad record by hand, and an id that is no longer there must not take the rest of
+            // the batch down with it. `retract` is a handful of entries at most, so the fallback is cheap.
             runCatching {
                 client.deleteRecords(SleepSessionRecord::class,
-                    recordIdsList = emptyList(), clientRecordIdsList = absorbed)
+                    recordIdsList = emptyList(), clientRecordIdsList = retract)
+            }.onFailure {
+                for (one in retract) {
+                    runCatching {
+                        client.deleteRecords(SleepSessionRecord::class,
+                            recordIdsList = emptyList(), clientRecordIdsList = listOf(one))
+                    }
+                }
             }
         }
-        return insertChunked(client, records)
+        val written = insertChunked(client, records)
+        // Recorded only AFTER the write lands. Remembering ids we failed to write would make the NEXT
+        // export retract records that never existed - harmless in itself, but it would also drop the ids
+        // that do need retracting from the ledger, quietly restoring the bug this fixes.
+        HealthConnectLedger.remember(context, HealthConnectLedger.SLEEP_PREFIX, currentIds)
+        return written
     }
 
     /**

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectWriter.kt
@@ -1,5 +1,7 @@
 package com.noop.ingest
 
+import kotlinx.coroutines.sync.withLock
+
 import android.content.Context
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.permission.HealthPermission
@@ -90,6 +92,16 @@ object HealthConnectWriter {
         WRITE_RECORDS.map { HealthPermission.getWritePermission(it) }.toSet()
 
     /**
+     * #1677: exports are serialized. Three callers can start one - the post-sync hook in WhoopBleClient
+     * and two in AppViewModel - with no uniqueness guard between them, so two could previously overlap on
+     * the same external store. That is newly consequential now the writer keeps a ledger: both would read
+     * the same `previous`, both would write their own result, and the loser's carried-forward retractions
+     * would be forgotten, orphaning exactly the records this change exists to retract. Serializing also
+     * stops two exports doing the same insert work twice.
+     */
+    private val exportMutex = kotlinx.coroutines.sync.Mutex()
+
+    /**
      * Write the last [WINDOW_DAYS] of computed metrics. Returns a [WritebackResult] — the record
      * count PLUS any per-concern failure categories, so a revoked permission no longer looks like a
      * benign "wrote 0" (#660). Persists the outcome via [recordStatus] for the Data Sources UI.
@@ -99,7 +111,10 @@ object HealthConnectWriter {
      * rows under `whoop-<address>`, so a hardcoded legacy "my-whoop" id reads empty tables and
      * exports nothing.
      */
-    suspend fun write(context: Context, repo: WhoopRepository, deviceId: String): WritebackResult {
+    suspend fun write(context: Context, repo: WhoopRepository, deviceId: String): WritebackResult =
+        exportMutex.withLock { writeLocked(context, repo, deviceId) }
+
+    private suspend fun writeLocked(context: Context, repo: WhoopRepository, deviceId: String): WritebackResult {
         if (HealthConnectClient.getSdkStatus(context) != HealthConnectClient.SDK_AVAILABLE) return WritebackResult.UNAVAILABLE
 
         // Guard the pre-insert work (client acquisition + the day read) the same way the concern inserts
@@ -319,6 +334,9 @@ object HealthConnectWriter {
             nowSec = now,
         )
         val retract = (absorbed + stale).distinct()
+        // Ids whose retraction did NOT land. They stay on the books so the next export tries again -
+        // forgetting one would orphan its record permanently, which is the very failure this fixes.
+        val unretracted = LinkedHashSet<String>()
         if (retract.isNotEmpty()) {
             // One call for the common case. If it throws, retry per id: the reporter of #1677 had already
             // deleted the bad record by hand, and an id that is no longer there must not take the rest of
@@ -331,7 +349,7 @@ object HealthConnectWriter {
                     runCatching {
                         client.deleteRecords(SleepSessionRecord::class,
                             recordIdsList = emptyList(), clientRecordIdsList = listOf(one))
-                    }
+                    }.onFailure { unretracted += one }
                 }
             }
         }
@@ -339,7 +357,10 @@ object HealthConnectWriter {
         // Recorded only AFTER the write lands. Remembering ids we failed to write would make the NEXT
         // export retract records that never existed - harmless in itself, but it would also drop the ids
         // that do need retracting from the ledger, quietly restoring the bug this fixes.
-        HealthConnectLedger.remember(context, HealthConnectLedger.SLEEP_PREFIX, currentIds)
+        HealthConnectLedger.remember(
+            context, HealthConnectLedger.SLEEP_PREFIX,
+            HealthConnectLedger.ledgerAfterExport(currentIds, unretracted),
+        )
         return written
     }
 

--- a/android/app/src/test/java/com/noop/ingest/HealthConnectLedgerTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/HealthConnectLedgerTest.kt
@@ -1,6 +1,7 @@
 package com.noop.ingest
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -162,6 +163,41 @@ class HealthConnectLedgerTest {
     fun `a clean export carries nothing extra`() {
         val written = setOf(id(now - 86_400), id(now - 2 * 86_400))
         assertEquals(written, HealthConnectLedger.ledgerAfterExport(written, emptySet()))
+    }
+
+    // --- one ledger per strap ---
+
+    /**
+     * The regression this keying prevents, and it is a data-loss one. The export is device-scoped:
+     * `sleepSessionsMerged(deviceId)` reads that strap union the canonical id, so a night banked under a
+     * DIFFERENT strap is simply not in its result. Share one ledger and an export running as strap B
+     * finds strap A's ids absent-but-in-window and retracts them — deleting valid Health Connect records
+     * because the user switched which strap is active.
+     */
+    @Test
+    fun `two straps do not share a ledger`() {
+        assertNotEquals(
+            HealthConnectLedger.ledgerKey("whoop-aaa", p),
+            HealthConnectLedger.ledgerKey("whoop-bbb", p),
+        )
+    }
+
+    /** The same strap keeps the same key across exports, or nothing would ever be retracted. */
+    @Test
+    fun `one strap keeps one key`() {
+        assertEquals(
+            HealthConnectLedger.ledgerKey("whoop-aaa", p),
+            HealthConnectLedger.ledgerKey("whoop-aaa", p),
+        )
+    }
+
+    /** Record types stay separate too: retracting sleep must never reach a workout id. */
+    @Test
+    fun `record types do not share a ledger either`() {
+        assertNotEquals(
+            HealthConnectLedger.ledgerKey("whoop-aaa", HealthConnectLedger.SLEEP_PREFIX),
+            HealthConnectLedger.ledgerKey("whoop-aaa", HealthConnectLedger.WORKOUT_PREFIX),
+        )
     }
 }
 

--- a/android/app/src/test/java/com/noop/ingest/HealthConnectLedgerTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/HealthConnectLedgerTest.kt
@@ -1,0 +1,128 @@
+package com.noop.ingest
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1677: a Health Connect record NOOP stops writing is a record NOOP can no longer take back, because
+ * Health Connect never removes an id you simply stop producing. These rules decide which previously
+ * written ids an export retracts — and, far more importantly, which it must leave alone.
+ */
+class HealthConnectLedgerTest {
+
+    private val p = HealthConnectLedger.SLEEP_PREFIX
+    private val now = 1_800_000_000L
+    private val windowStart = now - 60L * 86_400L
+
+    private fun id(ts: Long) = "$p$ts"
+
+    /**
+     * The reported bug, end to end. A partial night exported mid-sync under its own start; the heal then
+     * replaced that row with a fuller copy starting earlier, so the next export produces a DIFFERENT id
+     * and the first record had nothing left pointing at it.
+     */
+    @Test
+    fun `an id the export no longer produces is retracted`() {
+        val partial = id(now - 3 * 86_400)          // written during the strap sync
+        val full = id(now - 3 * 86_400 - 7_200)     // same night, re-detected two hours earlier
+        val stale = HealthConnectLedger.staleClientIds(
+            previous = setOf(partial), current = setOf(full),
+            prefix = p, windowStartSec = windowStart, nowSec = now,
+        )
+        assertEquals(listOf(partial), stale)
+    }
+
+    /** An id still being produced is an upsert, not a retraction. */
+    @Test
+    fun `an id still produced is never retracted`() {
+        val keep = id(now - 86_400)
+        assertTrue(
+            HealthConnectLedger.staleClientIds(
+                previous = setOf(keep), current = setOf(keep),
+                prefix = p, windowStartSec = windowStart, nowSec = now,
+            ).isEmpty(),
+        )
+    }
+
+    /**
+     * THE one that matters most. The export covers a rolling window, so a night that simply aged out is
+     * absent from `current` while its record is perfectly good. Retracting on absence alone would delete
+     * the user's history — the failure this rule exists to prevent, not a side note.
+     */
+    @Test
+    fun `a night that merely aged out of the window is left alone`() {
+        val old = id(windowStart - 86_400)           // one day older than this export could see
+        assertTrue(
+            HealthConnectLedger.staleClientIds(
+                previous = setOf(old), current = emptySet(),
+                prefix = p, windowStartSec = windowStart, nowSec = now,
+            ).isEmpty(),
+        )
+    }
+
+    /** The boundaries are inclusive, so the window's own edges are covered rather than skipped. */
+    @Test
+    fun `the window edges are inclusive`() {
+        val edges = setOf(id(windowStart), id(now))
+        assertEquals(
+            edges.sorted(),
+            HealthConnectLedger.staleClientIds(
+                previous = edges, current = emptySet(),
+                prefix = p, windowStartSec = windowStart, nowSec = now,
+            ),
+        )
+    }
+
+    /** A future-dated id is not something this export spoke about either. */
+    @Test
+    fun `an id past the window's end is left alone`() {
+        assertTrue(
+            HealthConnectLedger.staleClientIds(
+                previous = setOf(id(now + 3_600)), current = emptySet(),
+                prefix = p, windowStartSec = windowStart, nowSec = now,
+            ).isEmpty(),
+        )
+    }
+
+    /**
+     * An id whose timestamp will not parse is not ours to reason about. Abstaining costs one stale row;
+     * guessing costs the user's data, so the tie is broken toward doing nothing.
+     */
+    @Test
+    fun `an unparseable id is never retracted`() {
+        val junk = setOf("${p}not-a-number", "noop-sleep-", "some-other-app-record")
+        assertTrue(
+            HealthConnectLedger.staleClientIds(
+                previous = junk, current = emptySet(),
+                prefix = p, windowStartSec = windowStart, nowSec = now,
+            ).isEmpty(),
+        )
+    }
+
+    /** Deterministic order, so a log line and a test read the same sequence. */
+    @Test
+    fun `retractions come back sorted`() {
+        val a = id(now - 5 * 86_400); val b = id(now - 2 * 86_400); val c = id(now - 9 * 86_400)
+        assertEquals(
+            listOf(a, b, c).sorted(),
+            HealthConnectLedger.staleClientIds(
+                previous = setOf(b, c, a), current = emptySet(),
+                prefix = p, windowStartSec = windowStart, nowSec = now,
+            ),
+        )
+    }
+
+    /** The workout ids share the shape, so the rule has to be prefix-agnostic rather than sleep-shaped. */
+    @Test
+    fun `the rule works for any prefixed id`() {
+        val w = HealthConnectLedger.WORKOUT_PREFIX
+        assertEquals(
+            listOf("$w${now - 86_400}"),
+            HealthConnectLedger.staleClientIds(
+                previous = setOf("$w${now - 86_400}"), current = emptySet(),
+                prefix = w, windowStartSec = windowStart, nowSec = now,
+            ),
+        )
+    }
+}

--- a/android/app/src/test/java/com/noop/ingest/HealthConnectLedgerTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/HealthConnectLedgerTest.kt
@@ -125,4 +125,43 @@ class HealthConnectLedgerTest {
             ),
         )
     }
+
+    // --- what the ledger carries forward ---
+
+    /**
+     * The defect this guards is one I shipped in the first version of this change: remembering only the
+     * ids just written. A retraction that FAILED still has a live record behind it, and dropping its id
+     * forgets it forever — the exact orphan this file exists to prevent, reintroduced through the error
+     * path. Anyone "simplifying" this back to `current` should fail here.
+     */
+    @Test
+    fun `a failed retraction stays on the books for the next export`() {
+        val written = setOf(id(now - 86_400))
+        val couldNotDelete = setOf(id(now - 4 * 86_400))
+        val next = HealthConnectLedger.ledgerAfterExport(written, couldNotDelete)
+        assertTrue(next.containsAll(written))
+        assertTrue(next.containsAll(couldNotDelete))
+    }
+
+    /** And it is retried: still in `previous`, still absent from `current`, still inside the window. */
+    @Test
+    fun `the carried-forward id is retracted again next time`() {
+        val stuck = id(now - 4 * 86_400)
+        val next = HealthConnectLedger.ledgerAfterExport(setOf(id(now - 86_400)), setOf(stuck))
+        assertEquals(
+            listOf(stuck),
+            HealthConnectLedger.staleClientIds(
+                previous = next, current = setOf(id(now - 86_400)),
+                prefix = p, windowStartSec = windowStart, nowSec = now,
+            ),
+        )
+    }
+
+    /** Nothing failed: the ledger is exactly what was written, so it cannot grow without cause. */
+    @Test
+    fun `a clean export carries nothing extra`() {
+        val written = setOf(id(now - 86_400), id(now - 2 * 86_400))
+        assertEquals(written, HealthConnectLedger.ledgerAfterExport(written, emptySet()))
+    }
 }
+


### PR DESCRIPTION
@FlixiDoe reports a partial night exported to Health Connect mid-sync and never corrected: NOOP's own sleep session becomes complete, Google Health keeps the truncated one forever, and re-running the export doesn't help.

## The half they proposed as an alternative already exists

`writeSleep` writes `Metadata(clientRecordId = "noop-sleep-<startTs>", clientRecordVersion = endSec)` — so a night that grows has a higher version and Health Connect upserts it, and #364 already deletes absorbed fragments. That covers a record whose id **stays the same**.

## What it can't cover

A record whose id **stops being produced** — and for sleep that's routine, not exotic.

`sleepSession`'s primary key is `(deviceId, startTs)`, so a re-detection landing on a different start is a **different row**, and the #1248/#1284 heal deletes the stale row once a fuller copy wins. `SleepSessionDedup` exists precisely because one night accumulates several rows with different starts — its own comment records a night ballooning to 14 rows.

`absorbedClientIds` is computed from rows **still in the database**. So the moment the heal drops that row, the exporter loses all knowledge that it ever wrote a record under its id, and nothing can correct or remove it afterwards.

That explains the most diagnostic line in the report — **step 9–10, re-running the export doesn't fix it.** A pure timing bug would self-heal on a re-run; this can't, structurally.

## The fix, and the part that needed the most care

The exporter now keeps its own memory of the ids it has written, and retracts the ones a later export no longer produces.

**The dangerous part isn't the retraction, it's the restraint.** "Wrote it before, not writing it now" is the obvious rule and it would **delete the user's history**: the export covers a rolling 60-day window, so a night that merely aged out is absent from the current set while its record is perfectly good. An id is retracted only when its own timestamp falls inside the window this export actually covered, and an id whose timestamp won't parse is never retracted — abstaining costs one stale row, guessing costs data.

Three more decisions, each taking the recoverable direction:

- **an empty plan set retracts nothing.** "No plans" isn't the same statement as "the user has no sleep", and a read that came back empty for any reason would otherwise wipe the window.
- **the ledger is written only after the insert lands**, so a failed write can't drop the ids that still need retracting.
- **the bulk delete falls back to per-id on failure.** This reporter had already deleted the bad record by hand; an id that's no longer there mustn't take the rest of the batch down with it.

## Considered and rejected

- **Read-back reconciliation** — self-healing, needs no stored state, and would clean up existing damage. But read permission belongs to the **importer's separate grant**, so a user who enabled only share-back — exactly the users affected — has write and not read.
- **Pausing the export during strap sync** (the report's primary proposal) — a mitigation, not a fix. Re-staging isn't confined to strap sync: the heal runs on `analyzeRecent` passes, an Oura ring banking a night triggers it, a re-import does too. And "sync complete" isn't a clean edge, since backfill interrupts and resumes.

## Verification

8 tests over the pure rule: the reported id-moved case, the aged-out night that must survive, both window edges, a future-dated id, junk ids, sorting, and a non-sleep prefix. Android **4578 tests green**, compile clean, `doc_comment_lint` clean. Android-only — Health Connect is.

## Known limit, stated plainly

The ledger starts empty, so a record already orphaned before this ships is **not** cleaned up by it. @FlixiDoe still has to delete the current bad entry by hand once. This stops it recurring.

Workouts (`noop-workout-<startTs>`) have the identical id shape and the same exposure, but they're written from a different lifecycle and I haven't shown their start moves the way sleep's demonstrably does — left alone rather than fixed blind.
