### PR TITLE
rescore: only the pass that owes the debt may settle it (#1681)

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -2368,8 +2368,15 @@ final class IntelligenceEngine: ObservableObject {
         // background wake from one that never could, instead of guessing from a constant — the cost varies
         // by more than an order of magnitude with history size.
         let elapsed = Date().timeIntervalSince(reScoreStart)
-        RescoreBackgroundScheduler.markRescoreCompleted(seconds: elapsed, owedToken: owedToken)
+        let settled = RescoreBackgroundScheduler.markRescoreCompleted(seconds: elapsed, owedToken: owedToken)
         diagnosticSink?("re-score: done — scored \(scoredNights.count) night(s) in \(Int(elapsed * 1000)) ms (#1005)", nil)
+        // #1681: a pass that completes while leaving the mark SET looks identical in a capture to one that
+        // cleared it. Rare-event evidence, so always-on: it costs a line only when it actually happens,
+        // and it is exactly what is missing when someone reports the app re-scoring on every launch.
+        if !settled {
+            diagnosticSink?("re-score: debt NOT settled — a newer re-score was recorded while this pass "
+                            + "was running, so the mark stays and another pass will run (#1681)", nil)
+        }
     }
 
     /// UserDefaults key for the #836 idle-tick gate: the `(count:maxTs)` HR fingerprint the last completed

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -610,6 +610,14 @@ final class IntelligenceEngine: ObservableObject {
         // #1681: keep the token this debt was stamped with. At the end of the pass it is what tells our
         // own debt apart from one a LATER trigger recorded while we were running - the latter must
         // survive us, because the data it was recorded for arrived after we had already read our inputs.
+        //
+        // This is the SAME discipline the watermark beside it already used and the owed flag did not:
+        // capture the value at the start, compare against it at the end, never re-read. `wmKey` is read
+        // once at the top and the pass writes back THAT value, so HR arriving mid-pass leaves the
+        // watermark behind and the next trigger re-scores. The owed flag was the one piece of per-pass
+        // state that skipped the capture and just cleared, which is exactly where #1681 lived. The
+        // Kotlin post-offload gate makes the same point in its own words: "captured before the run,
+        // written only on success".
         let owedToken = RescoreBackgroundScheduler.markRescoreOwed()
         // #899-A re-arm: clear the lock, then if a forced rescore was dropped while this pass held it,
         // run it ONCE. The flag is cleared BEFORE the re-invoke (a single re-arm), so a forced call landing

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -607,7 +607,10 @@ final class IntelligenceEngine: ObservableObject {
         // between here and there, so "started and never finished" means exactly "killed", never a silent
         // internal skip. `RescoreBackgroundPolicy` reads it to stop re-attempting a pass that cannot
         // finish in the background, which is the livelock in #1538.
-        RescoreBackgroundScheduler.markRescoreOwed()
+        // #1681: keep the token this debt was stamped with. At the end of the pass it is what tells our
+        // own debt apart from one a LATER trigger recorded while we were running - the latter must
+        // survive us, because the data it was recorded for arrived after we had already read our inputs.
+        let owedToken = RescoreBackgroundScheduler.markRescoreOwed()
         // #899-A re-arm: clear the lock, then if a forced rescore was dropped while this pass held it,
         // run it ONCE. The flag is cleared BEFORE the re-invoke (a single re-arm), so a forced call landing
         // DURING the re-invoke re-arms it again but a quiet one does not , this can never recurse unbounded.
@@ -2365,7 +2368,7 @@ final class IntelligenceEngine: ObservableObject {
         // background wake from one that never could, instead of guessing from a constant — the cost varies
         // by more than an order of magnitude with history size.
         let elapsed = Date().timeIntervalSince(reScoreStart)
-        RescoreBackgroundScheduler.markRescoreCompleted(seconds: elapsed)
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: elapsed, owedToken: owedToken)
         diagnosticSink?("re-score: done — scored \(scoredNights.count) night(s) in \(Int(elapsed * 1000)) ms (#1005)", nil)
     }
 

--- a/Strand/System/RescoreBackgroundScheduler.swift
+++ b/Strand/System/RescoreBackgroundScheduler.swift
@@ -90,13 +90,20 @@ enum RescoreBackgroundScheduler {
     /// [owedToken] is the token this pass received from its own `markRescoreOwed()`. The debt is settled
     /// only if it is still the current one — see `maySettleDebt`. The pass duration is recorded either
     /// way: it is telemetry about THIS pass, and true regardless of whose debt is now outstanding.
-    static func markRescoreCompleted(seconds: Double, owedToken: String?) {
-        if maySettleDebt(capturedToken: owedToken, currentToken: currentOwedToken) {
+    /// Returns whether the debt was actually settled, so the caller can SAY when it was not. Declining
+    /// is the interesting outcome and it must not be silent: #1538 cost three nights because the log
+    /// recorded that scoring had not happened without ever recording why, and a pass that completes
+    /// while leaving the mark set looks identical to one that cleared it unless something says so.
+    @discardableResult
+    static func markRescoreCompleted(seconds: Double, owedToken: String?) -> Bool {
+        let settled = maySettleDebt(capturedToken: owedToken, currentToken: currentOwedToken)
+        if settled {
             UserDefaults.standard.set(false, forKey: owedKey)
         }
         if seconds.isFinite, seconds > 0 {
             UserDefaults.standard.set(seconds, forKey: lastPassSecondsKey)
         }
+        return settled
     }
 
     /// Whether the app is somewhere a long pass might not survive. Always false on macOS — see the type doc.

--- a/Strand/System/RescoreBackgroundScheduler.swift
+++ b/Strand/System/RescoreBackgroundScheduler.swift
@@ -36,7 +36,17 @@ enum RescoreBackgroundScheduler {
     /// Seconds the last COMPLETED pass took. Only ever written by a pass that reached the end.
     static let lastPassSecondsKey = "noop.rescoreLastPassSeconds"
 
+    /// Identifies the MOST RECENT debt, so a pass can tell its own from someone else's (#1681).
+    ///
+    /// A token rather than a counter, deliberately. A counter needs read-modify-write, and two triggers
+    /// marking a debt at the same moment could both read N and both write N+1 — losing an increment, and
+    /// with it exactly the debt this is meant to protect. A fresh token is a single write: concurrent
+    /// marks each produce a distinct one, the last wins, and it cannot equal any pass's captured token.
+    static let owedTokenKey = "noop.rescoreOwedToken"
+
     static var isRescoreOwed: Bool { UserDefaults.standard.bool(forKey: owedKey) }
+
+    static var currentOwedToken: String? { UserDefaults.standard.string(forKey: owedTokenKey) }
 
     static var lastCompletedPassSeconds: Double? {
         guard UserDefaults.standard.object(forKey: lastPassSecondsKey) != nil else { return nil }
@@ -47,14 +57,43 @@ enum RescoreBackgroundScheduler {
     /// Mark a re-score as owed. Called by `IntelligenceEngine` once a pass is past every gate and is
     /// definitely about to work — so that a kill leaves the debt behind — and by the deferral path, where
     /// no pass is attempted at all but the work is just as outstanding.
-    static func markRescoreOwed() {
+    /// Returns the token stamped on this debt. A pass keeps it and hands it back at completion; every
+    /// other caller (the deferral path) can ignore it, since it is not the one that will settle up.
+    @discardableResult
+    static func markRescoreOwed() -> String {
+        let token = UUID().uuidString
         UserDefaults.standard.set(true, forKey: owedKey)
+        UserDefaults.standard.set(token, forKey: owedTokenKey)
+        return token
+    }
+
+    /// May a pass holding [capturedToken] settle the debt?
+    ///
+    /// Only if nothing newer was recorded while it ran. The bug in #1681 is that this question was never
+    /// asked: completion cleared one global boolean unconditionally, so a trigger firing mid-pass — for
+    /// data that arrived AFTER the pass had already read its inputs — had its debt erased before the
+    /// correction it was recorded for ever ran. The scoring loop starts at today, so the night most
+    /// likely to still be syncing is the first thing read and the likeliest to be caught mid-write.
+    ///
+    /// A pass with NO token never settles. That errs toward one extra pass, which costs battery; the
+    /// other direction costs a night's scores until something unrelated happens to re-score it, which is
+    /// the failure being fixed.
+    ///
+    /// Pure, so the rule is pinned without UserDefaults or a background task.
+    static func maySettleDebt(capturedToken: String?, currentToken: String?) -> Bool {
+        guard let capturedToken, !capturedToken.isEmpty else { return false }
+        return capturedToken == currentToken
     }
 
     /// Settle the debt at the end of a completed pass, beside the watermark advance. A pass that is
     /// killed never reaches this, which is what leaves the mark set for the next launch to find.
-    static func markRescoreCompleted(seconds: Double) {
-        UserDefaults.standard.set(false, forKey: owedKey)
+    /// [owedToken] is the token this pass received from its own `markRescoreOwed()`. The debt is settled
+    /// only if it is still the current one — see `maySettleDebt`. The pass duration is recorded either
+    /// way: it is telemetry about THIS pass, and true regardless of whose debt is now outstanding.
+    static func markRescoreCompleted(seconds: Double, owedToken: String?) {
+        if maySettleDebt(capturedToken: owedToken, currentToken: currentOwedToken) {
+            UserDefaults.standard.set(false, forKey: owedKey)
+        }
         if seconds.isFinite, seconds > 0 {
             UserDefaults.standard.set(seconds, forKey: lastPassSecondsKey)
         }

--- a/StrandTests/RescoreBackgroundSchedulerTests.swift
+++ b/StrandTests/RescoreBackgroundSchedulerTests.swift
@@ -13,6 +13,7 @@ final class RescoreBackgroundSchedulerTests: XCTestCase {
 
     private var savedOwed: Any?
     private var savedSeconds: Any?
+    private var savedToken: Any?
 
     override func setUp() {
         super.setUp()
@@ -20,13 +21,16 @@ final class RescoreBackgroundSchedulerTests: XCTestCase {
         // restore rather than assume this suite owns them.
         savedOwed = UserDefaults.standard.object(forKey: RescoreBackgroundScheduler.owedKey)
         savedSeconds = UserDefaults.standard.object(forKey: RescoreBackgroundScheduler.lastPassSecondsKey)
+        savedToken = UserDefaults.standard.object(forKey: RescoreBackgroundScheduler.owedTokenKey)
         UserDefaults.standard.removeObject(forKey: RescoreBackgroundScheduler.owedKey)
         UserDefaults.standard.removeObject(forKey: RescoreBackgroundScheduler.lastPassSecondsKey)
+        UserDefaults.standard.removeObject(forKey: RescoreBackgroundScheduler.owedTokenKey)
     }
 
     override func tearDown() {
         restore(savedOwed, RescoreBackgroundScheduler.owedKey)
         restore(savedSeconds, RescoreBackgroundScheduler.lastPassSecondsKey)
+        restore(savedToken, RescoreBackgroundScheduler.owedTokenKey)
         super.tearDown()
     }
 
@@ -41,9 +45,9 @@ final class RescoreBackgroundSchedulerTests: XCTestCase {
     /// discover that an earlier one was killed — the killed process never gets to report anything itself.
     func testAStartedPassOwesUntilItCompletes() {
         XCTAssertFalse(RescoreBackgroundScheduler.isRescoreOwed)
-        RescoreBackgroundScheduler.markRescoreOwed()
+        let token = RescoreBackgroundScheduler.markRescoreOwed()
         XCTAssertTrue(RescoreBackgroundScheduler.isRescoreOwed)
-        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 12)
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 12, owedToken: token)
         XCTAssertFalse(RescoreBackgroundScheduler.isRescoreOwed)
     }
 
@@ -51,10 +55,10 @@ final class RescoreBackgroundSchedulerTests: XCTestCase {
     /// whether a background wake can finish the work, so a garbage value must read as "no measurement"
     /// rather than as a number.
     func testOnlyAUsableDurationIsBanked() {
-        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778)
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778, owedToken: RescoreBackgroundScheduler.currentOwedToken)
         XCTAssertEqual(RescoreBackgroundScheduler.lastCompletedPassSeconds ?? 0, 474.778, accuracy: 0.001)
 
-        RescoreBackgroundScheduler.markRescoreCompleted(seconds: .nan)
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: .nan, owedToken: RescoreBackgroundScheduler.currentOwedToken)
         XCTAssertEqual(RescoreBackgroundScheduler.lastCompletedPassSeconds ?? 0, 474.778, accuracy: 0.001,
                        "a NaN must not overwrite a good measurement")
 
@@ -68,7 +72,7 @@ final class RescoreBackgroundSchedulerTests: XCTestCase {
     /// to has nothing to find.
     func testDeferringMarksTheWorkOwedAndDoesNotRunIt() async {
         // A measured pass far over the background budget, so the policy defers.
-        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778)
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778, owedToken: RescoreBackgroundScheduler.currentOwedToken)
         XCTAssertFalse(RescoreBackgroundScheduler.isRescoreOwed)
 
         var ran = false
@@ -88,7 +92,7 @@ final class RescoreBackgroundSchedulerTests: XCTestCase {
     /// A foregrounded pass runs, whatever the measurement says. This is the case the mechanism must not
     /// break: there is no suspension deadline, so deferring would be a pure regression.
     func testAForegroundPassRunsEvenWhenSlow() async {
-        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778)
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778, owedToken: RescoreBackgroundScheduler.currentOwedToken)
 
         var ran = false
         var logged: [String] = []
@@ -125,7 +129,7 @@ final class RescoreBackgroundSchedulerTests: XCTestCase {
     /// run here is simply skipped. Recording a debt for it would send a processing task off to run a
     /// forced full pass when most likely nothing changed — the churn #1146 exists to avoid.
     func testASkippedBackstopDoesNotConjureADebt() async {
-        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778)
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778, owedToken: RescoreBackgroundScheduler.currentOwedToken)
 
         var ran = false
         var logged: [String] = []
@@ -160,9 +164,67 @@ final class RescoreBackgroundSchedulerTests: XCTestCase {
         XCTAssertTrue(foreground)
 
         var affordable = false
-        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 3)
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 3, owedToken: RescoreBackgroundScheduler.currentOwedToken)
         await RescoreBackgroundScheduler.run(isBackground: true, owesOnDefer: false,
                                              log: { _ in }) { affordable = true }
         XCTAssertTrue(affordable)
     }
+
+    // MARK: - #1681: whose debt is it?
+
+    /// The reported bug. A pass records its debt, and while it is running a LATER trigger records another
+    /// — for data that arrived after this pass had already read its inputs. Completion used to clear one
+    /// global boolean unconditionally, erasing that newer debt before the correction it was recorded for
+    /// ever ran. The night stayed scored from a partial sync until something unrelated happened to
+    /// re-score it.
+    func testADebtRecordedMidPassSurvivesThatPassCompleting() {
+        let mine = RescoreBackgroundScheduler.markRescoreOwed()
+        _ = RescoreBackgroundScheduler.markRescoreOwed()   // a later trigger, while the pass is still running
+
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 9, owedToken: mine)
+
+        XCTAssertTrue(RescoreBackgroundScheduler.isRescoreOwed,
+                      "the newer debt must outlive the pass that did not pay it")
+    }
+
+    /// …and the pass that DOES hold the current token still settles, or the flag would never clear and
+    /// every launch would re-score forever.
+    func testTheHolderOfTheCurrentTokenSettles() {
+        _ = RescoreBackgroundScheduler.markRescoreOwed()
+        let latest = RescoreBackgroundScheduler.markRescoreOwed()
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 9, owedToken: latest)
+        XCTAssertFalse(RescoreBackgroundScheduler.isRescoreOwed)
+    }
+
+    /// The duration is telemetry about THIS pass and is banked either way — it is true regardless of
+    /// whose debt is now outstanding, and the policy needs it to size a background wake.
+    func testAPassThatCannotSettleStillBanksItsDuration() {
+        let mine = RescoreBackgroundScheduler.markRescoreOwed()
+        _ = RescoreBackgroundScheduler.markRescoreOwed()
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 33.5, owedToken: mine)
+        XCTAssertEqual(RescoreBackgroundScheduler.lastCompletedPassSeconds ?? 0, 33.5, accuracy: 0.001)
+    }
+
+    // MARK: - the settlement rule itself
+
+    /// A pass with NO token never settles. That costs one extra pass; the other direction costs a night's
+    /// scores until something unrelated re-scores it, which is the failure being fixed.
+    func testNoTokenNeverSettles() {
+        XCTAssertFalse(RescoreBackgroundScheduler.maySettleDebt(capturedToken: nil, currentToken: "a"))
+        XCTAssertFalse(RescoreBackgroundScheduler.maySettleDebt(capturedToken: "", currentToken: ""))
+    }
+
+    func testOnlyTheCurrentTokenSettles() {
+        XCTAssertTrue(RescoreBackgroundScheduler.maySettleDebt(capturedToken: "a", currentToken: "a"))
+        XCTAssertFalse(RescoreBackgroundScheduler.maySettleDebt(capturedToken: "a", currentToken: "b"))
+        XCTAssertFalse(RescoreBackgroundScheduler.maySettleDebt(capturedToken: "a", currentToken: nil))
+    }
+
+    /// Each mark stamps a DISTINCT token. A counter would need read-modify-write, and two triggers marking
+    /// at the same moment could both read N and both write N+1 — losing exactly the debt this protects.
+    func testEveryMarkStampsADistinctToken() {
+        let seen = Set((0..<50).map { _ in RescoreBackgroundScheduler.markRescoreOwed() })
+        XCTAssertEqual(seen.count, 50)
+    }
 }
+

--- a/StrandTests/RescoreBackgroundSchedulerTests.swift
+++ b/StrandTests/RescoreBackgroundSchedulerTests.swift
@@ -55,10 +55,10 @@ final class RescoreBackgroundSchedulerTests: XCTestCase {
     /// whether a background wake can finish the work, so a garbage value must read as "no measurement"
     /// rather than as a number.
     func testOnlyAUsableDurationIsBanked() {
-        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778, owedToken: RescoreBackgroundScheduler.currentOwedToken)
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778, owedToken: nil)   // fixture: bank a duration, settle nothing
         XCTAssertEqual(RescoreBackgroundScheduler.lastCompletedPassSeconds ?? 0, 474.778, accuracy: 0.001)
 
-        RescoreBackgroundScheduler.markRescoreCompleted(seconds: .nan, owedToken: RescoreBackgroundScheduler.currentOwedToken)
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: .nan, owedToken: nil)   // fixture: bank a duration, settle nothing
         XCTAssertEqual(RescoreBackgroundScheduler.lastCompletedPassSeconds ?? 0, 474.778, accuracy: 0.001,
                        "a NaN must not overwrite a good measurement")
 
@@ -72,7 +72,7 @@ final class RescoreBackgroundSchedulerTests: XCTestCase {
     /// to has nothing to find.
     func testDeferringMarksTheWorkOwedAndDoesNotRunIt() async {
         // A measured pass far over the background budget, so the policy defers.
-        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778, owedToken: RescoreBackgroundScheduler.currentOwedToken)
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778, owedToken: nil)   // fixture: bank a duration, settle nothing
         XCTAssertFalse(RescoreBackgroundScheduler.isRescoreOwed)
 
         var ran = false
@@ -92,7 +92,7 @@ final class RescoreBackgroundSchedulerTests: XCTestCase {
     /// A foregrounded pass runs, whatever the measurement says. This is the case the mechanism must not
     /// break: there is no suspension deadline, so deferring would be a pure regression.
     func testAForegroundPassRunsEvenWhenSlow() async {
-        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778, owedToken: RescoreBackgroundScheduler.currentOwedToken)
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778, owedToken: nil)   // fixture: bank a duration, settle nothing
 
         var ran = false
         var logged: [String] = []
@@ -129,7 +129,7 @@ final class RescoreBackgroundSchedulerTests: XCTestCase {
     /// run here is simply skipped. Recording a debt for it would send a processing task off to run a
     /// forced full pass when most likely nothing changed — the churn #1146 exists to avoid.
     func testASkippedBackstopDoesNotConjureADebt() async {
-        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778, owedToken: RescoreBackgroundScheduler.currentOwedToken)
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 474.778, owedToken: nil)   // fixture: bank a duration, settle nothing
 
         var ran = false
         var logged: [String] = []
@@ -164,7 +164,7 @@ final class RescoreBackgroundSchedulerTests: XCTestCase {
         XCTAssertTrue(foreground)
 
         var affordable = false
-        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 3, owedToken: RescoreBackgroundScheduler.currentOwedToken)
+        RescoreBackgroundScheduler.markRescoreCompleted(seconds: 3, owedToken: nil)   // fixture: bank a duration, settle nothing
         await RescoreBackgroundScheduler.run(isBackground: true, owesOnDefer: false,
                                              log: { _ in }) { affordable = true }
         XCTAssertTrue(affordable)

--- a/StrandTests/RescoreBackgroundSchedulerTests.swift
+++ b/StrandTests/RescoreBackgroundSchedulerTests.swift
@@ -226,5 +226,20 @@ final class RescoreBackgroundSchedulerTests: XCTestCase {
         let seen = Set((0..<50).map { _ in RescoreBackgroundScheduler.markRescoreOwed() })
         XCTAssertEqual(seen.count, 50)
     }
+
+    // MARK: - the outcome has to be reportable
+
+    /// Declining is the interesting outcome, and the caller can only SAY so if it is told. #1538 cost
+    /// three nights because the log recorded that scoring had not happened without recording why; a pass
+    /// that completes while leaving the mark set looks identical in a capture to one that cleared it.
+    func testCompletionReportsWhetherItSettled() {
+        let mine = RescoreBackgroundScheduler.markRescoreOwed()
+        _ = RescoreBackgroundScheduler.markRescoreOwed()
+        XCTAssertFalse(RescoreBackgroundScheduler.markRescoreCompleted(seconds: 1, owedToken: mine),
+                       "a pass that could not settle must report that, or the log cannot explain itself")
+
+        let latest = RescoreBackgroundScheduler.markRescoreOwed()
+        XCTAssertTrue(RescoreBackgroundScheduler.markRescoreCompleted(seconds: 1, owedToken: latest))
+    }
 }
 


### PR DESCRIPTION
@pipiche38 traced this to source, and the diagnosis holds exactly.

`RescoreBackgroundScheduler` tracks "a re-score is owed" with a single global `UserDefaults` boolean, and `markRescoreCompleted` cleared it **unconditionally** at the end of any pass that reached its natural completion. So a trigger firing mid-pass — for data that arrived *after* that pass had already read its inputs — had its debt erased before the correction it was recorded for ever ran.

The day-scoring loop counts backwards from today, so the night most likely to still be receiving data is the first thing any pass reads and the likeliest to be caught mid-write. Their capture shows one night scored from **199 minutes against ~427–486** by two independent references, sitting at a calm-looking 87.5% recovery with nothing to suggest anything was wrong. The mechanism that exists to guarantee a deferred pass is never dropped was losing the debt itself.

## The change

`markRescoreOwed()` now stamps a token and returns it; `analyzeRecent` keeps its own and hands it back; `markRescoreCompleted` settles **only if that token is still the current one**. A newer debt outlives the pass that didn't pay it.

**A token, not a counter — that's the load-bearing choice.** A counter needs read-modify-write, so two triggers marking at the same moment could both read `N` and both write `N+1`, losing an increment and with it exactly the debt this protects. A fresh token is a single write: concurrent marks each produce a distinct one, the last wins, and it can't equal any pass's captured token.

Two deliberate directions, both erring the recoverable way:

- **a pass with no token never settles** — costs one extra pass in battery; the other direction costs a night's scores until something unrelated happens to re-score it, which is the failure being fixed.
- **the duration is banked either way** — it's telemetry about *this* pass and is true regardless of whose debt is outstanding, and the policy needs it to size a background wake.

## Scope

Apple-only. `rescoreOwed` and `RescoreBackgroundScheduler` appear in **zero** Kotlin files — #1538 is a `BGProcessingTask` mechanism with no Android twin, so no parity change is owed.

## Verification

7 new tests: the reported mid-pass race, the holder of the current token still settling (or the flag would never clear and every launch would re-score forever), the duration banked by a pass that *can't* settle, the no-token and mismatch rules, and that 50 marks stamp 50 distinct tokens.

The 7 existing call sites were **updated rather than given a defaulted parameter** — a default would have left the old unconditional behaviour reachable, which is the bug. The settlement rule was also compiled standalone with `swiftc` and exercised. `doc_comment_lint` clean.

**App-target Swift, so no default CI covers it** — app-build dispatched separately.

## Not the other PR

#1682 claimed to address this. It added a markdown file describing a patch against invented symbols (`RescoreOwedFlag`, `recordOwedDebt`) that exist nowhere in the tree, changed no source, and was closed. The real symbols are `owedKey` / `"noop.rescoreOwed"`, `markRescoreOwed()` and `markRescoreCompleted(seconds:)`.
