### PR TITLE
backfill: say how old the strap's newest record is when a sync banks nothing (#1683)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2445,9 +2445,15 @@ public final class BLEManager: NSObject, ObservableObject {
                 let wallNowUnix = Int(Date().timeIntervalSince1970)
                 // Read the field ONCE: it feeds both the log line and the banner below, and they must not
                 // disagree about whether the strap is stale.
-                let staleNewest: Int? = strapNewestTs.flatMap {
-                    Backfiller.isStaleNewestRecord(newestUnix: $0, wallNowUnix: wallNowUnix) ? $0 : nil
-                }
+                // WHOOP4 only, explicitly, on BOTH platforms. Redundant here today - `strapNewestTs` is
+                // only assigned when `feedsSync` (#695), which is WHOOP4 - but stated so a later widening
+                // of feedsSync cannot make this fire where the Android twin does not. A 5/MG that cannot
+                // offload has no business being told it stopped saving to flash.
+                let staleNewest: Int? = selectedModel.deviceFamily == .whoop4
+                    ? strapNewestTs.flatMap {
+                        Backfiller.isStaleNewestRecord(newestUnix: $0, wallNowUnix: wallNowUnix) ? $0 : nil
+                    }
+                    : nil
                 if let newest = staleNewest {
                     log(Backfiller.staleRecordLine(newestUnix: newest, wallNowUnix: wallNowUnix))
                 }

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2438,6 +2438,15 @@ public final class BLEManager: NSObject, ObservableObject {
                     ? "console-only across \(state.consoleChunksThisSession) chunks"
                     : "metadata-only, 0 sensor rows persisted"
                 log("Backfill: completed but the strap banked no sensor history (\(detail)); consecutive empty syncs = \(emptySyncTracker.consecutiveEmptySyncs).")
+                // #1683: say HOW OLD the strap's newest stored record is. Without it the line above reads
+                // identically for a strap that is caught up and one that stopped banking three weeks ago -
+                // GET_DATA_RANGE already told us the difference and we simply never said so, which is why
+                // #1541 stayed open and unactionable. Rare-event evidence, so always-on.
+                let wallNowUnix = Int(Date().timeIntervalSince1970)
+                if let newest = strapNewestTs,
+                   Backfiller.isStaleNewestRecord(newestUnix: newest, wallNowUnix: wallNowUnix) {
+                    log(Backfiller.staleRecordLine(newestUnix: newest, wallNowUnix: wallNowUnix))
+                }
                 state.lastSyncError = sustainedEmpty
                     ? "Synced, but your strap had no stored history to hand over - only its diagnostic output. This usually means its clock has lost sync, so it isn't saving data to flash. Fully charge it to 100%, then reconnect, and it should start banking again."
                     : nil

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2443,12 +2443,20 @@ public final class BLEManager: NSObject, ObservableObject {
                 // GET_DATA_RANGE already told us the difference and we simply never said so, which is why
                 // #1541 stayed open and unactionable. Rare-event evidence, so always-on.
                 let wallNowUnix = Int(Date().timeIntervalSince1970)
-                if let newest = strapNewestTs,
-                   Backfiller.isStaleNewestRecord(newestUnix: newest, wallNowUnix: wallNowUnix) {
+                // Read the field ONCE: it feeds both the log line and the banner below, and they must not
+                // disagree about whether the strap is stale.
+                let staleNewest: Int? = strapNewestTs.flatMap {
+                    Backfiller.isStaleNewestRecord(newestUnix: $0, wallNowUnix: wallNowUnix) ? $0 : nil
+                }
+                if let newest = staleNewest {
                     log(Backfiller.staleRecordLine(newestUnix: newest, wallNowUnix: wallNowUnix))
                 }
+                // #1683: when the strap's own newest record dates the silence, SAY it. The generic copy
+                // below omits that and promises a recovery the charge advice has already been retried for
+                // every session; the dated version is the one a stuck user can act on.
                 state.lastSyncError = sustainedEmpty
-                    ? "Synced, but your strap had no stored history to hand over - only its diagnostic output. This usually means its clock has lost sync, so it isn't saving data to flash. Fully charge it to 100%, then reconnect, and it should start banking again."
+                    ? (staleNewest.map { Backfiller.staleRecordBanner(newestUnix: $0, wallNowUnix: wallNowUnix) }
+                        ?? "Synced, but your strap had no stored history to hand over - only its diagnostic output. This usually means its clock has lost sync, so it isn't saving data to flash. Fully charge it to 100%, then reconnect, and it should start banking again.")
                     : nil
             } else if let futureBanner = futureClockBanner {
                 // #324/#928: the strap banked records but its newest is dated implausibly in the FUTURE

--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -459,6 +459,23 @@ final class Backfiller {
         return "Backfill: this sync banked nothing and the strap's newest stored record is about \(ageDays) day(s) old. If you have worn it since then, it has stopped saving history to its flash. NOOP already re-sends the clock on every connect, so charging alone may not be enough: charge to 100% and reconnect, then use Restart strap in Devices, and if that does not help forget and re-pair. If the official WHOOP app is also missing these days, the strap is the cause and not NOOP."
     }
 
+
+    /// #1683: the same honesty as `staleRecordLine`, for the message the user actually READS.
+    ///
+    /// The standing banner says "fully charge it to 100%, then reconnect, and it should start banking
+    /// again". It omits the one fact that makes the situation legible - how long the strap has been
+    /// silent - and it PROMISES a recovery that has already failed every session for weeks, because NOOP
+    /// re-sends SET_CLOCK on every connect and the charge advice has therefore been retried all along. A
+    /// banner that keeps promising something that keeps not happening teaches people to distrust the app
+    /// rather than their strap.
+    ///
+    /// Byte-identical to the Android twin. Not localized, matching the sibling `lastSyncError` copy on
+    /// both platforms; localizing that surface is its own change. No em-dash (project rule).
+    nonisolated static func staleRecordBanner(newestUnix: Int, wallNowUnix: Int) -> String {
+        let ageDays = max(0, wallNowUnix - newestUnix) / 86_400
+        return "Synced, but your strap handed over no stored history, and its newest saved record is about \(ageDays) day(s) old. If you have been wearing it since then, it has stopped saving to flash. Charge it to 100% and reconnect; NOOP already re-sets its clock every connect, so if that does not help, try Restart strap in Devices, then forget and re-pair. If the official WHOOP app is missing these days too, the strap is the cause and not NOOP."
+    }
+
     /// Commit one HISTORY_END chunk: (persist decoded → enqueueRaw when present) → setCursor → ackTrim.
     /// Early-returns on any throw to preserve the safe-trim invariant.
     ///

--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -428,6 +428,37 @@ final class Backfiller {
         return "Backfill: the strap reported a record dated about \(aheadDays) day(s) in the FUTURE - its clock (RTC) is corrupt, not a NOOP problem. Those records can't be filed onto the right day. Fully charge the strap to 100% and reconnect so it re-syncs its clock; if it persists, forget and re-pair the strap."
     }
 
+    /// #1683: how far BEHIND the wall clock the strap's newest stored record may sit before a sync that
+    /// banked nothing is worth explaining. Two days, not one: a strap left off-wrist overnight is ordinary,
+    /// and this line only ever accompanies a completed offload that banked nothing anyway.
+    nonisolated static let staleRecordToleranceSeconds = 2 * 86_400
+
+    /// Is the strap's newest stored record far enough in the past to be worth naming? A nil or
+    /// non-positive value is not a date and never qualifies.
+    nonisolated static func isStaleNewestRecord(newestUnix: Int?, wallNowUnix: Int) -> Bool {
+        guard let newestUnix, newestUnix > 0 else { return false }
+        return newestUnix <= wallNowUnix - staleRecordToleranceSeconds
+    }
+
+    /// #1683: the counterpart `futureRtcLine` never had. A strap that stopped banking weeks ago and one
+    /// that is simply caught up produce the SAME "banked no sensor history" line today, so neither the user
+    /// nor anyone reading their log can tell them apart. #1541 stayed open and vague for exactly that
+    /// reason.
+    ///
+    /// Deliberately states the FACT and lets the condition carry the interpretation. A newest record two
+    /// weeks old means the strap stopped recording IF it was being worn; if it sat in a drawer, the same
+    /// number is unremarkable. Asserting a corrupt RTC here would claim more than the data supports, which
+    /// is how this area has misled people before.
+    ///
+    /// It also says the part the existing advice omits: NOOP re-sends SET_CLOCK on every connect, so
+    /// "charge it" alone has already been retried every session.
+    ///
+    /// Byte-identical to the Android twin. No em-dash (project rule).
+    nonisolated static func staleRecordLine(newestUnix: Int, wallNowUnix: Int) -> String {
+        let ageDays = max(0, wallNowUnix - newestUnix) / 86_400
+        return "Backfill: this sync banked nothing and the strap's newest stored record is about \(ageDays) day(s) old. If you have worn it since then, it has stopped saving history to its flash. NOOP already re-sends the clock on every connect, so charging alone may not be enough: charge to 100% and reconnect, then use Restart strap in Devices, and if that does not help forget and re-pair. If the official WHOOP app is also missing these days, the strap is the cause and not NOOP."
+    }
+
     /// Commit one HISTORY_END chunk: (persist decoded → enqueueRaw when present) → setCursor → ackTrim.
     /// Early-returns on any throw to preserve the safe-trim invariant.
     ///

--- a/StrandTests/BackfillerSessionTallyTests.swift
+++ b/StrandTests/BackfillerSessionTallyTests.swift
@@ -331,4 +331,16 @@ final class BackfillerSessionTallyTests: XCTestCase {
         XCTAssertFalse(line.contains("corrupt"), line)
         XCTAssertTrue(line.contains("If you have worn it"), line)
     }
+
+    /// The banner is what the user READS; the log line needs a capture export. The standing banner
+    /// omitted the age entirely and PROMISED that charging "should" work - advice NOOP has effectively
+    /// retried on every connect for weeks, since it re-sends SET_CLOCK each time.
+    func testStaleRecordBannerDatesTheSilenceAndPromisesNothing() {
+        let line = Backfiller.staleRecordBanner(newestUnix: 1_785_692_420, wallNowUnix: 1_787_820_941)
+        XCTAssertTrue(line.contains("about 24 day(s) old"), line)
+        XCTAssertTrue(line.contains("If you have been wearing it"), line)
+        XCTAssertTrue(line.contains("official WHOOP app"), line)
+        XCTAssertFalse(line.contains("should start banking again"), line)
+        XCTAssertFalse(line.contains("\u{2014}"))
+    }
 }

--- a/StrandTests/BackfillerSessionTallyTests.swift
+++ b/StrandTests/BackfillerSessionTallyTests.swift
@@ -285,4 +285,50 @@ final class BackfillerSessionTallyTests: XCTestCase {
                       "a truly-empty no-cursor session must still warn the strap has no banked history")
         XCTAssertTrue(joined.contains("fully charge it"))
     }
+
+    // MARK: - #1683: the stale counterpart to futureRtcLine
+
+    /// A strap that stopped banking weeks ago and one that is caught up produced the SAME "banked no
+    /// sensor history" line, so neither the user nor a triager could tell them apart. That is why #1541
+    /// stayed open and unactionable.
+    func testACaughtUpOrBrieflyIdleStrapIsNotStale() {
+        let now = 1_700_000_000
+        XCTAssertFalse(Backfiller.isStaleNewestRecord(newestUnix: nil, wallNowUnix: now))
+        XCTAssertFalse(Backfiller.isStaleNewestRecord(newestUnix: 0, wallNowUnix: now))
+        XCTAssertFalse(Backfiller.isStaleNewestRecord(newestUnix: now, wallNowUnix: now))
+        XCTAssertFalse(Backfiller.isStaleNewestRecord(newestUnix: now - 86_400, wallNowUnix: now),
+                       "one night off-wrist is ordinary and must stay silent")
+    }
+
+    func testTwoDaysIsTheBoundaryAndQualifies() {
+        let now = 1_700_000_000
+        XCTAssertTrue(Backfiller.isStaleNewestRecord(newestUnix: now - 2 * 86_400, wallNowUnix: now))
+    }
+
+    /// A future-dated record belongs to `futureRtcLine`; this rule must not also claim it.
+    func testAFutureDatedRecordIsNotStale() {
+        let now = 1_700_000_000
+        XCTAssertFalse(Backfiller.isStaleNewestRecord(newestUnix: now + 86_400, wallNowUnix: now))
+    }
+
+    /// The numbers from the #1683 capture: newest stored record 1785692420 against a wall clock of
+    /// 1787820941. The user was told only "banked no sensor history"; this says three weeks.
+    func testStaleRecordLineReportsTheRealCaptureAsTwentyFourDays() {
+        let line = Backfiller.staleRecordLine(newestUnix: 1_785_692_420, wallNowUnix: 1_787_820_941)
+        XCTAssertTrue(line.contains("about 24 day(s) old"), line)
+        XCTAssertTrue(line.contains("stopped saving history"), line)
+        // The part the old advice omitted: charging alone has already been retried every connect.
+        XCTAssertTrue(line.contains("re-sends the clock on every connect"), line)
+        // The test that tells the user whether NOOP is even involved.
+        XCTAssertTrue(line.contains("official WHOOP app"), line)
+        XCTAssertFalse(line.contains("\u{2014}"))
+    }
+
+    /// States the fact, never the diagnosis: a drawered strap shows the same number innocently.
+    func testStaleRecordLineDoesNotAssertACorruptClock() {
+        let line = Backfiller.staleRecordLine(newestUnix: 1_700_000_000 - 20 * 86_400,
+                                              wallNowUnix: 1_700_000_000)
+        XCTAssertFalse(line.contains("corrupt"), line)
+        XCTAssertTrue(line.contains("If you have worn it"), line)
+    }
 }

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -797,6 +797,46 @@ class Backfiller(
                 "right day. Fully charge the strap to 100% and reconnect so it re-syncs its clock; if it " +
                 "persists, forget and re-pair the strap."
         }
+
+        /**
+         * #1683: how far BEHIND the wall clock the strap's newest stored record may sit before a sync that
+         * banked nothing is worth explaining. Two days, not one: a strap left off-wrist overnight is
+         * ordinary, and this line only ever accompanies a completed offload that banked nothing anyway.
+         */
+        const val STALE_RECORD_TOLERANCE_SECONDS = 2 * 86_400L
+
+        /** Is the strap's newest stored record far enough in the past to be worth naming? A null or
+         *  non-positive value is not a date and never qualifies. */
+        fun isStaleNewestRecord(newestUnix: Long?, wallNowUnix: Long): Boolean =
+            newestUnix != null && newestUnix > 0L &&
+                newestUnix <= wallNowUnix - STALE_RECORD_TOLERANCE_SECONDS
+
+        /**
+         * #1683: the counterpart [futureRtcLine] never had. A strap that stopped banking weeks ago and a
+         * strap that is simply caught up produce the SAME "banked no sensor history" line today, so
+         * neither the user nor anyone reading their log can tell them apart. #1541 stayed open and vague
+         * for exactly that reason.
+         *
+         * Deliberately states the FACT and lets the condition carry the interpretation. A newest record
+         * two weeks old means the strap stopped recording IF it was being worn; if it sat in a drawer, the
+         * same number is unremarkable. Asserting a corrupt RTC here would be claiming more than the data
+         * supports, which is how this area has misled people before.
+         *
+         * It also says the part the existing advice omits: NOOP re-sends SET_CLOCK on every connect, so
+         * "charge it" alone has already been retried every session. The escalation and the
+         * compare-with-the-official-app test are what actually move a stuck case forward.
+         *
+         * Byte-identical to the Swift twin. No em-dash (project rule).
+         */
+        fun staleRecordLine(newestUnix: Long, wallNowUnix: Long): String {
+            val ageDays = maxOf(0L, wallNowUnix - newestUnix) / 86_400L
+            return "Backfill: this sync banked nothing and the strap's newest stored record is about " +
+                "$ageDays day(s) old. If you have worn it since then, it has stopped saving history to " +
+                "its flash. NOOP already re-sends the clock on every connect, so charging alone may not " +
+                "be enough: charge to 100% and reconnect, then use Restart strap in Devices, and if that " +
+                "does not help forget and re-pair. If the official WHOOP app is also missing these days, " +
+                "the strap is the cause and not NOOP."
+        }
     }
 }
 

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -837,6 +837,32 @@ class Backfiller(
                 "does not help forget and re-pair. If the official WHOOP app is also missing these days, " +
                 "the strap is the cause and not NOOP."
         }
+
+        /**
+         * #1683: the same honesty as [staleRecordLine], for the message the user actually READS.
+         *
+         * The standing banner says "fully charge it to 100%, then reconnect, and it should start banking
+         * again". It omits the one fact that makes the situation legible - how long the strap has been
+         * silent - and it PROMISES a recovery that has already failed every session for weeks, because
+         * NOOP re-sends SET_CLOCK on every connect and the charge advice has therefore been retried all
+         * along. A banner that keeps promising something that keeps not happening teaches people to
+         * distrust the app rather than their strap.
+         *
+         * Shorter than the log line: a banner is glanced at, not read. Same discipline though - state the
+         * age, condition the diagnosis on having worn it, and name the check that says whether NOOP is
+         * even involved.
+         *
+         * Byte-identical to the Swift twin. Not localized, matching the sibling `lastSyncError` copy on
+         * both platforms; localizing that surface is its own change. No em-dash (project rule).
+         */
+        fun staleRecordBanner(newestUnix: Long, wallNowUnix: Long): String {
+            val ageDays = maxOf(0L, wallNowUnix - newestUnix) / 86_400L
+            return "Synced, but your strap handed over no stored history, and its newest saved record is " +
+                "about $ageDays day(s) old. If you have been wearing it since then, it has stopped saving " +
+                "to flash. Charge it to 100% and reconnect; NOOP already re-sets its clock every connect, " +
+                "so if that does not help, try Restart strap in Devices, then forget and re-pair. If the " +
+                "official WHOOP app is missing these days too, the strap is the cause and not NOOP."
+        }
     }
 }
 

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -8023,10 +8023,21 @@ class WhoopBleClient(
                 clockUntrusted = clockUntrusted,
             )
         ) {
+            // #1683: the empty streak only stretches the floor for the AUTOMATIC triggers (PERIODIC and
+            // STRAP). Naming it on a CONNECT/FOREGROUND skip - which uses the flat event floor and is not
+            // backed off at all - reads as though the streak caused the skip. It misled a reader of a real
+            // capture, so the line now names the streak only where the streak is actually doing something.
+            val streakGatesThisTrigger =
+                trigger == BackfillTrigger.PERIODIC || trigger == BackfillTrigger.STRAP
             log(
-                "Backfill: skipped ($trigger) - policy floor not met " +
-                    "(empty streak ${emptySyncTracker.consecutiveEmptySyncs}" +
-                    "${if (clockUntrusted) ", clock future-dated" else ""})",
+                "Backfill: skipped ($trigger) - policy floor not met" +
+                    // BOTH the streak and the future-dated clock gate PERIODIC/STRAP only; CONNECT and
+                    // FOREGROUND use the flat event floor. Naming either on those triggers reads as a
+                    // cause, which is how this line misled a reader of a real capture.
+                    (if (streakGatesThisTrigger)
+                        " (empty streak ${emptySyncTracker.consecutiveEmptySyncs}" +
+                            "${if (clockUntrusted) ", clock future-dated" else ""})"
+                    else ""),
             )
             return
         }
@@ -8247,6 +8258,14 @@ class WhoopBleClient(
                 "Backfill: completed but the strap banked no sensor history ($detail); " +
                     "consecutive empty syncs = ${emptySyncTracker.consecutiveEmptySyncs}.",
             )
+            // #1683: say HOW OLD the strap's newest stored record is. Without this the line above reads
+            // identically for a strap that is caught up and one that stopped banking three weeks ago -
+            // NOOP knows the difference (GET_DATA_RANGE gave it) and simply never said so, which is why
+            // #1541 stayed open and unactionable. Rare-event evidence, so always-on.
+            val newestSeen = strapNewestTs
+            if (Backfiller.isStaleNewestRecord(newestSeen, nowSec) && newestSeen != null) {
+                log(Backfiller.staleRecordLine(newestSeen, nowSec))
+            }
         }
         // #battery: maintain the empty-offload backoff counter (see [consecutiveEmptyOffloads]). A 0-row
         // session — clean HISTORY_COMPLETE-empty OR an idle-timeout STALL — means there was nothing new to

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -8250,6 +8250,10 @@ class WhoopBleClient(
                 bankedSensorRecords = bankedSensorRecords,
                 consoleOnly = bankedNothingRaw,
             ) else false
+        // #1683: the strap's newest stored record, ONLY when it is stale enough to be worth naming.
+        // Declared out here because both the log line inside the block below and the user-facing banner
+        // further down consume it, and they must not disagree about whether the strap is stale.
+        val staleNewestSeen: Long? = strapNewestTs?.takeIf { Backfiller.isStaleNewestRecord(it, nowSec) }
         if (bankedNothing) {
             val detail = if (consoleChunksThisSession >= 3)
                 "console-only across $consoleChunksThisSession chunks"
@@ -8262,10 +8266,7 @@ class WhoopBleClient(
             // identically for a strap that is caught up and one that stopped banking three weeks ago -
             // NOOP knows the difference (GET_DATA_RANGE gave it) and simply never said so, which is why
             // #1541 stayed open and unactionable. Rare-event evidence, so always-on.
-            val newestSeen = strapNewestTs
-            if (Backfiller.isStaleNewestRecord(newestSeen, nowSec) && newestSeen != null) {
-                log(Backfiller.staleRecordLine(newestSeen, nowSec))
-            }
+            staleNewestSeen?.let { log(Backfiller.staleRecordLine(it, nowSec)) }
         }
         // #battery: maintain the empty-offload backoff counter (see [consecutiveEmptyOffloads]). A 0-row
         // session — clean HISTORY_COMPLETE-empty OR an idle-timeout STALL — means there was nothing new to
@@ -8331,7 +8332,11 @@ class WhoopBleClient(
                 // the two platforms never disagree on which banner a given sync shows.
                 lastSyncError = when {
                     bankedNothing && sustainedEmpty ->
-                        "Synced, but your strap had no stored history to hand over - only its diagnostic output. This usually means its clock has lost sync, so it isn't saving data to flash. Fully charge it to 100%, then reconnect, and it should start banking again."
+                        // #1683: when the strap's own newest record dates the silence, SAY it. The
+                        // generic copy omits that and promises a recovery the charge advice has already
+                        // been retried for every session.
+                        staleNewestSeen?.let { Backfiller.staleRecordBanner(it, nowSec) }
+                            ?: "Synced, but your strap had no stored history to hand over - only its diagnostic output. This usually means its clock has lost sync, so it isn't saving data to flash. Fully charge it to 100%, then reconnect, and it should start banking again."
                     bankedNothing -> null   // banked nothing but not yet sustained — stay silent (matches Swift)
                     // #324/#928: the strap banked records but its newest is dated implausibly in the future
                     // (RTC relatched ahead). #773 drops the samples so nothing is misfiled, but this path

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -8253,7 +8253,15 @@ class WhoopBleClient(
         // #1683: the strap's newest stored record, ONLY when it is stale enough to be worth naming.
         // Declared out here because both the log line inside the block below and the user-facing banner
         // further down consume it, and they must not disagree about whether the strap is stale.
-        val staleNewestSeen: Long? = strapNewestTs?.takeIf { Backfiller.isStaleNewestRecord(it, nowSec) }
+        // WHOOP4 only, explicitly, on BOTH platforms. The underlying field is not populated alike: Swift
+        // gates it on `feedsSync` (#695 - WHOOP4 today, the 5/MG path deliberately leaves it unset), while
+        // this side sets it for any family that answers GET_DATA_RANGE. Reading it without a gate would
+        // let a 5/MG show the dated wording here and not on iOS. Gating the READ on both keeps the two in
+        // step whichever way that pre-existing difference is settled later, and a 5/MG that cannot offload
+        // has no business being told it stopped saving to flash.
+        val staleNewestSeen: Long? = strapNewestTs
+            ?.takeIf { connectedFamily == DeviceFamily.WHOOP4 }
+            ?.takeIf { Backfiller.isStaleNewestRecord(it, nowSec) }
         if (bankedNothing) {
             val detail = if (consoleChunksThisSession >= 3)
                 "console-only across $consoleChunksThisSession chunks"

--- a/android/app/src/test/java/com/noop/ble/BackfillerSessionTallyTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BackfillerSessionTallyTest.kt
@@ -168,6 +168,20 @@ class BackfillerSessionTallyTest {
         assertTrue(line, line.contains("If you have worn it"))
     }
 
+    /**
+     * The banner is what the user READS; the log line needs a capture export. The standing banner omitted
+     * the age entirely and PROMISED that charging "should" work - advice NOOP has effectively retried on
+     * every connect for weeks, since it re-sends SET_CLOCK each time.
+     */
+    @Test fun staleRecordBannerDatesTheSilenceAndPromisesNothing() {
+        val line = Backfiller.staleRecordBanner(1_785_692_420L, 1_787_820_941L)
+        assertTrue(line, line.contains("about 24 day(s) old"))
+        assertTrue(line, line.contains("If you have been wearing it"))
+        assertTrue(line, line.contains("official WHOOP app"))
+        assertFalse(line, line.contains("should start banking again"))
+        assertFalse(line.contains("\u2014"))
+    }
+
     @Test fun futureRtcLineWording() {
         val now = 1_700_000_000L
         val line = Backfiller.futureRtcLine(now + 10L * 86_400L, now)

--- a/android/app/src/test/java/com/noop/ble/BackfillerSessionTallyTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BackfillerSessionTallyTest.kt
@@ -123,6 +123,51 @@ class BackfillerSessionTallyTest {
     }
 
     // The recovery hint names the cause + fix, reports days-ahead, and has no em-dash. Byte-identical to Swift.
+    // #1683: the stale counterpart. A strap that stopped banking weeks ago and one that is caught up
+    // produced the SAME "banked no sensor history" line, so neither the user nor a triager could tell
+    // them apart — the reason #1541 stayed open and unactionable.
+
+    @Test fun aCaughtUpOrBrieflyIdleStrapIsNotStale() {
+        val now = 1_700_000_000L
+        assertFalse(Backfiller.isStaleNewestRecord(null, now))          // no reading at all
+        assertFalse(Backfiller.isStaleNewestRecord(0L, now))            // 0 is not a date
+        assertFalse(Backfiller.isStaleNewestRecord(now, now))           // caught up
+        assertFalse(Backfiller.isStaleNewestRecord(now - 86_400L, now)) // one night off-wrist is ordinary
+    }
+
+    @Test fun twoDaysIsTheBoundaryAndQualifies() {
+        val now = 1_700_000_000L
+        assertTrue(Backfiller.isStaleNewestRecord(now - 2L * 86_400L, now))
+    }
+
+    /** A future-dated record belongs to futureRtcLine; this rule must not also claim it. */
+    @Test fun aFutureDatedRecordIsNotStale() {
+        val now = 1_700_000_000L
+        assertFalse(Backfiller.isStaleNewestRecord(now + 86_400L, now))
+    }
+
+    /**
+     * The numbers from the #1683 capture: newest stored record 1785692420 against a wall clock of
+     * 1787820941. The user was told only "banked no sensor history"; this says three weeks.
+     */
+    @Test fun staleRecordLineReportsTheRealCaptureAsTwentyFourDays() {
+        val line = Backfiller.staleRecordLine(1_785_692_420L, 1_787_820_941L)
+        assertTrue(line, line.contains("about 24 day(s) old"))
+        assertTrue(line, line.contains("stopped saving history"))
+        // The part the old advice omitted: charging alone has already been retried every connect.
+        assertTrue(line, line.contains("re-sends the clock on every connect"))
+        // The test that tells the user whether NOOP is even involved.
+        assertTrue(line, line.contains("official WHOOP app"))
+        assertFalse(line.contains("\u2014"))
+    }
+
+    /** States the fact, never the diagnosis: a drawered strap shows the same number innocently. */
+    @Test fun staleRecordLineDoesNotAssertACorruptClock() {
+        val line = Backfiller.staleRecordLine(1_700_000_000L - 20L * 86_400L, 1_700_000_000L)
+        assertFalse(line, line.contains("corrupt"))
+        assertTrue(line, line.contains("If you have worn it"))
+    }
+
     @Test fun futureRtcLineWording() {
         val now = 1_700_000_000L
         val line = Backfiller.futureRtcLine(now + 10L * 86_400L, now)


### PR DESCRIPTION
@UncreativeX's capture shows four consecutive completed offloads that banked no sensor rows, and a strap whose **newest stored record is 24 days old**. NOOP knew that second fact — `GET_DATA_RANGE` gave it, and the client already logs the raw offset as `2128521s` — and never said it in a form anyone would read.

So the user was told only *"the strap banked no sensor history"*, which is the **same line a perfectly healthy caught-up strap produces**. That ambiguity is why #1541 has stayed open and unactionable since May.

## The counterpart `futureRtcLine` never had

That one handles a strap whose clock runs *ahead*: it names the day count and gives the remedy. Nothing handled a strap whose newest record sits far in the **past**.

The new line states the **fact** and lets the condition carry the interpretation:

> Backfill: this sync banked nothing and the strap's newest stored record is about 24 day(s) old. If you have worn it since then, it has stopped saving history to its flash. …

A strap left in a drawer shows the same number innocently, so asserting a corrupt RTC would claim more than the data supports — which is exactly how this area has misled people before.

**It also says the part the standing advice omits.** NOOP re-sends `SET_CLOCK` to a WHOOP 4.0 on *every* connect, in both firmware payload forms (#120). So "charge to 100% and reconnect" has effectively been retried every session for 24 days; telling this user to do it again was never going to help. The line gives the real escalation — charge, **Restart strap**, forget and re-pair — and the one test that settles whether NOOP is even involved: *if the official WHOOP app is also missing those days, the strap is the cause.*

## Checked before writing any of it

- **This is not NOOP dropping data.** The "banked nothing" verdict requires `decodedChunks == 0`, so nothing was decoded — it isn't records decoded then dropped by the #547 gate, and the existing attribution is honest.
- **The backoff isn't trapping them.** `MANUAL` is never floored, and `CONNECT`/`FOREGROUND` use the flat 90s event floor with no multiplier.

## Second, smaller fix

`Backfill: skipped (FOREGROUND) - policy floor not met (empty streak 4)` appended the streak for **every** trigger — but the streak, and the future-dated-clock note beside it, gate `PERIODIC` and `STRAP` only. A `FOREGROUND` skip is just *"58s since the last sync against a 90s floor"*. The line named a cause it couldn't attribute, and the practical cost was real: **it misled me while reading this very capture.** Now named only where it's doing something.

## Verification

The rules are pure and twinned, and `staleRecordLine` is **proven byte-identical** across platforms by extracting and comparing both. 10 tests (5 per platform), including the reporter's real numbers — newest `1785692420` against wall `1787820941` — producing `about 24 day(s) old`; the two-day boundary; a night off-wrist staying silent; a future-dated record staying `futureRtcLine`'s job; and that the line never says "corrupt". Also compiled standalone with `swiftc` and exercised against those same capture values.

Android **4575 tests green**, compile clean, `doc_comment_lint` and i18n clean. App-target Swift is touched, so app-build is dispatched separately.

## What this does not do

Make the strap bank again. If it has genuinely stopped writing to flash, that's strap-side. It tells the user *that*, with evidence, instead of leaving them to re-charge for another three weeks.
