### PR TITLE
doc(oura): carry the real_steps correction to the twins, the spec, and a test

### DIFF
--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraFeatureStatusTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraFeatureStatusTests.swift
@@ -42,12 +42,25 @@ final class OuraFeatureStatusTests: XCTestCase {
 
     func testSpO2AndStepsReadsSurfaceFeatureStatus() {
         let d = OuraDriver(ringGen: .gen3, authKey: key)
-        // SpO2 (0x04): subscription 0 → server-gated off.
+        // An all-zero reply. The comment here used to read the zeros as "server-gated off"; it describes
+        // the FIXTURE, not a ring's real answer, and #1629 showed a real ring answering otherwise.
         XCTAssertEqual(d.handleSecureFrame(OuraSecureFrame(subop: 0x21, subBody: [0x04, 0x00, 0x00, 0x00, 0x00])),
                        .featureStatus(OuraFeatureStatus(feature: 0x04, mode: 0, status: 0, state: 0, subscription: 0)))
-        // real_steps (0x0b): subscription 0 → server-gated off.
         XCTAssertEqual(d.handleSecureFrame(OuraSecureFrame(subop: 0x21, subBody: [0x0B, 0x00, 0x00, 0x00, 0x00])),
                        .featureStatus(OuraFeatureStatus(feature: 0x0B, mode: 0, status: 0, state: 0, subscription: 0)))
+    }
+
+    /// #1629: the shape a REAL ring actually answers with. On-device captures read real_steps back as
+    /// `status=1` from both an authenticated Oura-app session and NOOP's own offline, unauthenticated
+    /// connection to the same ring. Until now the suite only ever exercised the all-zero reply, so the
+    /// one reading anybody has actually observed on hardware was the one nothing pinned.
+    ///
+    /// This asserts the DECODE only. `status=1` says the ring reports the feature enabled; it is not
+    /// evidence that the ring emits `0x7E`/`0x7F`, and nothing here should be read as claiming that.
+    func testAnEnabledRealStepsStatusDecodesAsObservedOnHardware() {
+        let d = OuraDriver(ringGen: .gen3, authKey: key)
+        XCTAssertEqual(d.handleSecureFrame(OuraSecureFrame(subop: 0x21, subBody: [0x0B, 0x00, 0x01, 0x00, 0x00])),
+                       .featureStatus(OuraFeatureStatus(feature: 0x0B, mode: 0, status: 1, state: 0, subscription: 0)))
     }
 
     func testUndecodableDiagnosticReplyFallsBackToEnableAck() {

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -1809,8 +1809,10 @@ class OuraLiveSource(
                     // Other Tier-B tags (real_steps / activity-summary / sleep-summary / smoothed-SpO2,
                     // OURA_PROTOCOL.md s7.3; PR #960): logged ONCE PER KIND with the raw bytes so we can
                     // see whether the ring sends these tags at all and collect capture material - e.g.
-                    // real_steps 0x7E/0x7F is server-flag-gated OFF by default ([open_oura-feat]), so its
-                    // continued absence here is the ring's doing, not a decode gap.
+                    // real_steps 0x7E/0x7F was assumed server-flag-gated OFF ([open_oura-feat]), which
+                    // made its absence self-explanatory. That no longer holds: the ring's own status read
+                    // came back ENABLED on-device (#1629), so gating does NOT explain why these tags never
+                    // arrive, and whether that is the ring's doing or a decode gap is currently unknown.
                     if (loggedTierBKinds.add(e.value.kind)) {
                         val hex = e.value.rawPayload.joinToString(" ") { "%02x".format(it) }
                         log("Oura: Tier-B ${e.value.kind} seen (tag 0x${e.value.tag.toString(16)}) - raw: $hex")

--- a/android/app/src/main/java/com/noop/oura/Commands.kt
+++ b/android/app/src/main/java/com/noop/oura/Commands.kt
@@ -27,8 +27,12 @@ object OuraCommands {
 
     // The SpO2 feature id. Per OURA_PROTOCOL.md s7.1.
     const val featureSpO2 = 0x04
-    // The real-steps feature id. Server-flag-gated (activity/real_steps, default off), so it is never
-    // emitted for an offline NOOP-only ring. Per OURA_PROTOCOL.md s7.1 / s7.3 [open_oura-feat].
+    // The real-steps feature id (`activity/real_steps`). Nominally server-flag-gated per
+    // OURA_PROTOCOL.md s7.1/s7.3 [open_oura-feat], but on-device 2026-08-25 real-steps status reads
+    // came back enabled (status=1) from BOTH an authenticated Oura-app session and NOOP's own fully
+    // offline, unauthenticated read of the same ring - the gate is ring-side state, not tied to which
+    // client asks or whether that client is cloud-authenticated. Do not assume "off for NOOP" without
+    // checking a live read.
     const val featureRealSteps = 0x0b
 
     // MARK: - Pre-auth / identity (unauthenticated OK)
@@ -168,9 +172,11 @@ object OuraCommands {
         OuraCommand("spo2_status", intArrayOf(0x2F, 0x02, 0x20, featureSpO2))
 
     /**
-     * Read the real-steps feature status, `2f 02 20 0b` (READ verb, not enable). The `0x21` reply confirms
-     * the server-flag gate (`activity/real_steps`, default off) from the ring itself. Read-only diagnostic.
-     * [open_oura-feat]
+     * Read the real-steps feature status, `2f 02 20 0b` (READ verb, not enable). The `0x21` reply reports
+     * the ring's own real_steps gate state - NOT reliably "off" for an offline ring: on-device
+     * 2026-08-25 this read back status=1 (enabled) from NOOP's own unauthenticated connection, matching
+     * the real Oura app's read of the same ring byte-for-byte. Read-only diagnostic either way - never
+     * enables anything, never writes a mode. [open_oura-feat]
      */
     fun realStepsReadStatus(): OuraCommand =
         OuraCommand("realsteps_status", intArrayOf(0x2F, 0x02, 0x20, featureRealSteps))

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -986,7 +986,13 @@ edit of the ring's tag.
     window is the single regime a walking-equivalent model should do best in, and it does not overturn the
     857-day picture (median ≈ 0, p90 +186 %) that gates it. It is recorded because it bounds the error on
     the one regime where the estimate is meant to apply.
-  - **Real Steps (feature `0x0B`) server gating [open_oura-feat]:** real_steps is behind the server flag `activity/real_steps` (default **false**; `FeatureDefinitions.ActivityRealSteps`, Gen 3+), the same server-flag-off pattern as SpO2 (§7.1). This explains `0x7E`/`0x7F` never once appearing across the PR #960 live sessions - the ring isn't sending them, it is not a NOOP decode gap. `0x50` itself is an always-on base stream (not feature-gated), matching it appearing in every session.
+  - **Real Steps (feature `0x0B`) server gating [open_oura-feat]:** real_steps is documented as sitting behind the server flag `activity/real_steps` (default **false**; `FeatureDefinitions.ActivityRealSteps`, Gen 3+), the same server-flag-off pattern as SpO2 (§7.1).
+
+    **CORRECTED 2026-08-27 (#1629).** This section previously concluded: *"This explains `0x7E`/`0x7F` never once appearing across the PR #960 live sessions - the ring isn't sending them, it is not a NOOP decode gap."* **That explanation no longer holds.** On-device captures read the ring's own real_steps status (`2f 02 20 0b`) back as **`status=1` (enabled)** — identically from an authenticated Oura-app session and from NOOP's own fully offline, unauthenticated connection to the same ring. The gate is ring-side state, not something tied to which client asks.
+
+    So the *observation* stands — `0x7E`/`0x7F` still never appeared in those sessions — but the *cause* attributed to it does not. Be careful about what the new reading does and does not show: **`status=1` is not evidence the ring emits those tags.** It only removes gating as the explanation. Why they are absent is currently **unknown**, and a decode gap is back on the table as a possibility rather than ruled out. `0x50` is unaffected: an always-on base stream, not feature-gated, and it appears in every session.
+
+    Anything that cited this paragraph to close a line of investigation should be re-read on that basis.
 - **`0x7E`/`0x7F` real_steps_features 1/2** (18 B each): bit-packed step features merged across the paired events. **(UNVERIFIED - partial)** [ringverse]
   - **Unpack formula ([oura-rs] - Th0rgal/open_oura `crates/oura-protocol/src/events.rs#L566`, clean-room
     fact citation): 14 fields from the 14-byte body.** Fields 0 and 8 are genuine 9-bit values built as


### PR DESCRIPTION
Follow-up to **@pipiche38's #1629**, which corrected the claim in the two Swift files. The same assertion lived in **four more places** — and the Kotlin ones are *word-for-word copies* of the lines that PR changed, so the tree was left saying opposite things in twin files:

| Location | What it said |
|---|---|
| `com/noop/oura/Commands.kt:30` | identical to the corrected Swift line |
| `com/noop/oura/Commands.kt:172` | identical to the corrected Swift doc |
| `ble/OuraLiveSource.kt:1812` | used it to dismiss the tags' absence |
| `docs/OURA_PROTOCOL.md` §7.3 | the source all of them cite |

## The spec needed more than a find-and-replace

This is the part worth reading. §7.3 didn't merely *state* the gate — it **reasoned from it**:

> *"This explains `0x7E`/`0x7F` never once appearing across the PR #960 live sessions - the ring isn't sending them, it is not a NOOP decode gap."*

If the ring's own status read comes back **enabled**, that explanation no longer holds. The observation stands — those tags still never appeared — but the cause attributed to it doesn't. **And that sentence is what closed the investigation.**

So the correction says what is actually known and no more:

- `status=1` removes *gating* as the explanation
- it is **not** evidence the ring emits those tags
- the reason for their absence is now **unknown**
- a decode gap is back on the table as a possibility rather than ruled out

The old text is quoted in place, so anyone who cited that paragraph can see exactly what changed and why.

## A test gap the sweep exposed

The sweep found a test comment reading an all-zero fixture as *"server-gated off"* — describing the fixture as though it were a ring's answer. Reworded; and the gap it hid is now covered.

`OuraFeatureStatusTests` only ever exercised the **all-zero** reply. So the one reading anybody has actually observed on hardware — `status=1` — was the one nothing pinned. That case is now a test, asserting the **decode only**, with the same caution written into it: it says the ring reports the feature enabled, not that the ring emits `0x7E`/`0x7F`.

## Verification

Comment, doc and test only; no behaviour change. `OuraProtocol` tests green (7), Android **4590 green**, compile clean, `doc_comment_lint` clean. No app-target Swift touched, so no app-build needed.
