### PR TITLE
workouts: put Pause/Resume on the active-workout cards, and stop three clocks ignoring it

### DIFF
--- a/Strand/App/ActiveWorkoutClock.swift
+++ b/Strand/App/ActiveWorkoutClock.swift
@@ -20,6 +20,11 @@ enum ActiveWorkoutClock {
     /// Clamped at zero so a clock-skew negative reads 0:00 rather than counting backwards. The open-pause
     /// term is deliberately NOT clamped on its own: the single clamp on the result is what the Kotlin twin
     /// does, and two clamps would disagree with it for a `pausedAt` in the future.
+    ///
+    /// Twin of Kotlin `ActiveWorkoutClock.activeElapsedSeconds` — the NAMES differ (this one takes
+    /// `Date`/`TimeInterval`, that one Long milliseconds), so neither turns up in a grep for the other.
+    /// Same arithmetic and the same single clamp; the platforms truncate to whole seconds at different
+    /// points and agree because both truncate toward zero.
     static func activeElapsed(start: Date, pausedAt: Date?, pausedDuration: TimeInterval,
                               now: Date = Date()) -> TimeInterval {
         max(0, now.timeIntervalSince(start) - pausedDuration

--- a/Strand/App/ActiveWorkoutClock.swift
+++ b/Strand/App/ActiveWorkoutClock.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// The ONE pause-aware elapsed calculation for an in-flight workout, shared by every surface that shows
+/// its clock.
+///
+/// #1533 added Pause/Resume to the full-screen live workout view and taught THAT view's timer to subtract
+/// the paused time. The Today "workout in progress" indicator and the Live tab's active-workout card were
+/// not part of it: both still read `now - start`. So pausing froze one clock and left two others counting
+/// up, and a wearer who paused and backed out saw the session apparently still running. The saved duration
+/// was correct the whole time, which is what made it confusing rather than merely wrong — the only
+/// evidence on screen contradicted the button that had just been pressed.
+///
+/// Kept pure and in one place so a new surface cannot reintroduce the divergence by open-coding the
+/// subtraction again. Twin of Kotlin `ActiveWorkoutClock`.
+enum ActiveWorkoutClock {
+
+    /// Seconds of ACTIVE time: wall time since `start`, minus every completed pause, minus the one still
+    /// open if the session is paused right now.
+    ///
+    /// Clamped at zero so a clock-skew negative reads 0:00 rather than counting backwards. The open-pause
+    /// term is deliberately NOT clamped on its own: the single clamp on the result is what the Kotlin twin
+    /// does, and two clamps would disagree with it for a `pausedAt` in the future.
+    static func activeElapsed(start: Date, pausedAt: Date?, pausedDuration: TimeInterval,
+                              now: Date = Date()) -> TimeInterval {
+        max(0, now.timeIntervalSince(start) - pausedDuration
+            - (pausedAt.map { now.timeIntervalSince($0) } ?? 0))
+    }
+
+    /// `M:SS` up to an hour, `H:MM:SS` once an hour has passed, so a 90-minute session reads "1:30:00"
+    /// rather than "90:00". Negative input clamps to "0:00".
+    ///
+    /// The Live card used to carry its own `%d:%02d` formatter with no hour roll-over at all, so a long
+    /// session read "90:00" there while the Today indicator beside it read "1:30:00" — and Android's
+    /// shared `elapsedClock` documents itself as mirroring the iOS one, which by then it no longer did.
+    /// Twin of Kotlin `elapsedClock`.
+    static func clock(_ seconds: Int) -> String {
+        let total = max(0, seconds)
+        let h = total / 3600
+        let m = (total % 3600) / 60
+        let s = total % 60
+        return h > 0
+            ? String(format: "%d:%02d:%02d", h, m, s)
+            : String(format: "%d:%02d", m, s)
+    }
+}

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -118,9 +118,10 @@ final class AppModel: ObservableObject {
 
         var isPaused: Bool { pausedAt != nil }
 
+        /// Delegates to `ActiveWorkoutClock` so this and the two card surfaces cannot drift apart again.
         func elapsed(at now: Date = Date()) -> TimeInterval {
-            max(0, now.timeIntervalSince(start) - pausedDuration
-                - (pausedAt.map { now.timeIntervalSince($0) } ?? 0))
+            ActiveWorkoutClock.activeElapsed(start: start, pausedAt: pausedAt,
+                                             pausedDuration: pausedDuration, now: now)
         }
     }
     struct HealthAlert: Equatable {

--- a/Strand/Screens/LiveView.swift
+++ b/Strand/Screens/LiveView.swift
@@ -363,26 +363,43 @@ struct LiveView: View {
                     Circle().fill(StrandPalette.metricRose).frame(width: 8, height: 8)
                     Text("RECORDING WORKOUT").font(StrandFont.overline)
                         .tracking(StrandFont.overlineTracking).foregroundStyle(StrandPalette.metricRose)
+                    // Reuses the "Paused" string #1533 already localized; a frozen clock with no tag is
+                    // indistinguishable from a stalled one.
+                    if w.isPaused {
+                        Text("Paused").font(StrandFont.overline)
+                            .tracking(StrandFont.overlineTracking)
+                            .foregroundStyle(StrandPalette.textSecondary)
+                    }
                     Spacer()
                     // Re-render once a second so the elapsed clock ticks without a manual Timer.
-                    TimelineView(.periodic(from: .now, by: 1)) { _ in
-                        Text(Self.elapsed(since: w.start)).font(StrandFont.number(17)).monospacedDigit()
+                    TimelineView(.periodic(from: .now, by: 1)) { context in
+                        Text(ActiveWorkoutClock.clock(Int(w.elapsed(at: context.date))))
+                            .font(StrandFont.number(17)).monospacedDigit()
                             .foregroundStyle(StrandPalette.textPrimary)
                     }
                 }
                 // Live HR / avg / peak / effort — the leaf owns LiveState + the active workout so the
                 // 1 Hz stat refresh re-renders only these tiles, plus a liquid effort tube under them.
                 ActiveWorkoutLive(workout: w, effortScale: effortScale)
+                // The card used to offer End and nothing else, so the only IRREVERSIBLE control was the
+                // one reachable without opening the live view, while Pause — the reversible one — was
+                // not. Pause/Resume is one toggle (a paused session has exactly one sensible action), and
+                // End moves to its own row so a destructive tap is not adjacent to a routine one.
                 HStack(spacing: NoopMetrics.rowSpacing) {
+                    NoopButton(w.isPaused ? "Resume" : "Pause",
+                               systemImage: w.isPaused ? "play.fill" : "pause.fill",
+                               kind: .secondary, fullWidth: true) {
+                        model.toggleWorkoutPause()
+                    }
                     // Re-open the full live workout screen (#238) after it's been dismissed.
                     NoopButton("Open live view", systemImage: "rectangle.expand.vertical",
                                kind: .secondary, fullWidth: true) {
                         showLiveWorkout = true
                     }
-                    NoopButton("End workout", systemImage: "stop.circle.fill",
-                               kind: .destructive, fullWidth: true) {
-                        confirmingEndWorkout = true
-                    }
+                }
+                NoopButton("End workout", systemImage: "stop.circle.fill",
+                           kind: .destructive, fullWidth: true) {
+                    confirmingEndWorkout = true
                 }
             }
         }
@@ -399,11 +416,6 @@ struct LiveView: View {
             Spacer(minLength: 0)
         }
         .padding(.horizontal, 4)
-    }
-
-    private static func elapsed(since start: Date) -> String {
-        let s = max(0, Int(Date().timeIntervalSince(start)))
-        return String(format: "%d:%02d", s / 60, s % 60)
     }
 
     private func reconnectGuideBanner(_ guide: String) -> some View {

--- a/Strand/Screens/LiveView.swift
+++ b/Strand/Screens/LiveView.swift
@@ -361,15 +361,14 @@ struct LiveView: View {
             VStack(alignment: .leading, spacing: 12) {
                 HStack(spacing: 8) {
                     Circle().fill(StrandPalette.metricRose).frame(width: 8, height: 8)
-                    Text("RECORDING WORKOUT").font(StrandFont.overline)
-                        .tracking(StrandFont.overlineTracking).foregroundStyle(StrandPalette.metricRose)
-                    // Reuses the "Paused" string #1533 already localized; a frozen clock with no tag is
-                    // indistinguishable from a stalled one.
-                    if w.isPaused {
-                        Text("Paused").font(StrandFont.overline)
-                            .tracking(StrandFont.overlineTracking)
-                            .foregroundStyle(StrandPalette.textSecondary)
-                    }
+                    // "RECORDING" is a factual claim, and while paused nothing IS being recorded — the
+                    // sample capture drops every reading. So the label swaps rather than gaining a tag
+                    // beside it, which would leave the card asserting both at once. Reuses the "Paused"
+                    // string #1533 already localized. (The Today card says "IN PROGRESS", which stays
+                    // true while paused, so it keeps its label and takes the tag instead.)
+                    Text(w.isPaused ? "Paused" : "RECORDING WORKOUT").font(StrandFont.overline)
+                        .tracking(StrandFont.overlineTracking)
+                        .foregroundStyle(w.isPaused ? StrandPalette.textSecondary : StrandPalette.metricRose)
                     Spacer()
                     // Re-render once a second so the elapsed clock ticks without a manual Timer.
                     TimelineView(.periodic(from: .now, by: 1)) { context in

--- a/Strand/Screens/LiveWorkoutView.swift
+++ b/Strand/Screens/LiveWorkoutView.swift
@@ -423,9 +423,12 @@ struct LiveWorkoutView: View {
 
     // MARK: - Helpers
 
+    /// Delegates to the shared clock. This carried its own `%d:%02d` with NO hour roll-over, so a
+    /// 90-minute session read "90:00" here while Android's live workout screen read "1:30:00" — and,
+    /// after the card fix, while the iOS card that opens THIS screen read "1:30:00" too. The math was
+    /// already pause-aware (`workout.elapsed()`); only the formatting was the odd one out.
     private static func elapsed(seconds: TimeInterval) -> String {
-        let s = max(0, Int(seconds))
-        return String(format: "%d:%02d", s / 60, s % 60)
+        ActiveWorkoutClock.clock(Int(seconds))
     }
 
     private static func zoneName(_ zone: Int) -> String {

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -65,24 +65,32 @@ private struct HRChartFrameKey: PreferenceKey {
 struct ActiveWorkoutIndicatorModel: Equatable {
     let sport: String
     let startedAt: Date
+    /// The pause state has to be CARRIED, not just consulted: this value type is what the card renders
+    /// from, so without these two fields the indicator cannot subtract the paused time or say it is
+    /// paused, however correct `AppModel` is. That is precisely how it kept counting through #1533.
+    var pausedAt: Date? = nil
+    var pausedDuration: TimeInterval = 0
+
+    var isPaused: Bool { pausedAt != nil }
 
     static func make(from workout: AppModel.ActiveWorkout?) -> ActiveWorkoutIndicatorModel? {
         guard let workout else { return nil }
-        return ActiveWorkoutIndicatorModel(sport: workout.sport, startedAt: workout.start)
+        return ActiveWorkoutIndicatorModel(sport: workout.sport, startedAt: workout.start,
+                                           pausedAt: workout.pausedAt,
+                                           pausedDuration: workout.pausedDuration)
     }
 
-    /// Elapsed time since `start`, formatted M:SS up to an hour and H:MM:SS once an hour has passed (so a
+    /// Elapsed ACTIVE time, formatted M:SS up to an hour and H:MM:SS once an hour has passed (so a
     /// 90-minute session reads "1:30:00", not "90:00"). Clamped at zero so a clock-skew negative reads 0:00.
     /// Pure + injectable `now` for deterministic tests. (StrandFont.bodyNumber already applies tabular figures,
     /// so the call site does NOT add `.monospacedDigit()`.)
-    static func elapsed(since start: Date, now: Date = Date()) -> String {
-        let total = max(0, Int(now.timeIntervalSince(start)))
-        let h = total / 3600
-        let m = (total % 3600) / 60
-        let s = total % 60
-        return h > 0
-            ? String(format: "%d:%02d:%02d", h, m, s)
-            : String(format: "%d:%02d", m, s)
+    ///
+    /// `pausedAt`/`pausedDuration` default to "never paused" so the existing call sites and tests that
+    /// predate pause keep their exact meaning; the math itself lives in `ActiveWorkoutClock`.
+    static func elapsed(since start: Date, pausedAt: Date? = nil, pausedDuration: TimeInterval = 0,
+                        now: Date = Date()) -> String {
+        ActiveWorkoutClock.clock(Int(ActiveWorkoutClock.activeElapsed(
+            start: start, pausedAt: pausedAt, pausedDuration: pausedDuration, now: now)))
     }
 }
 
@@ -103,12 +111,22 @@ private struct ActiveWorkoutIndicatorCard: View {
                         .font(StrandFont.overline)
                         .tracking(StrandFont.overlineTracking)
                         .foregroundStyle(StrandPalette.metricRose)
+                    // A frozen clock alone is ambiguous with a STALLED one, so say which it is. Reuses the
+                    // "Paused" string #1533 already localized rather than minting new copy for a tag.
+                    if model.isPaused {
+                        Text("Paused")
+                            .font(StrandFont.overline)
+                            .tracking(StrandFont.overlineTracking)
+                            .foregroundStyle(StrandPalette.textSecondary)
+                    }
                     Spacer(minLength: NoopMetrics.space2)
                     // A per-second live clock. The TimelineView re-evaluates ONLY this Text every second, so
                     // the tick never re-renders the rest of the card (let alone TodayView.body). bodyNumber
                     // already carries `.monospacedDigit()`, so no extra modifier here.
                     TimelineView(.periodic(from: .now, by: 1)) { context in
-                        Text(ActiveWorkoutIndicatorModel.elapsed(since: model.startedAt, now: context.date))
+                        Text(ActiveWorkoutIndicatorModel.elapsed(
+                            since: model.startedAt, pausedAt: model.pausedAt,
+                            pausedDuration: model.pausedDuration, now: context.date))
                             .font(StrandFont.bodyNumber)
                             .foregroundStyle(StrandPalette.textPrimary)
                     }

--- a/StrandTests/ActiveWorkoutClockTests.swift
+++ b/StrandTests/ActiveWorkoutClockTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import Strand
+
+/// Pins the pause-aware workout clock every live surface now shares.
+///
+/// #1533 added Pause/Resume but only the full-screen live view's timer subtracted the paused time; the
+/// Today indicator and the Live card kept reading `now - start`, so pausing froze one clock and left two
+/// counting. These cases are the twin of Kotlin `ActiveWorkoutClockTest` — same scenarios, same expected
+/// seconds — so the two platforms cannot drift on what "elapsed" means for a paused session.
+final class ActiveWorkoutClockTests: XCTestCase {
+
+    private let start = Date(timeIntervalSince1970: 1_000)
+
+    private func elapsed(pausedAt: TimeInterval? = nil, pausedDuration: TimeInterval = 0,
+                         now: TimeInterval) -> Int {
+        Int(ActiveWorkoutClock.activeElapsed(
+            start: start,
+            pausedAt: pausedAt.map { start.addingTimeInterval($0) },
+            pausedDuration: pausedDuration,
+            now: start.addingTimeInterval(now)))
+    }
+
+    func testActiveElapsedSubtractsCompletedAndOpenPauses() {
+        XCTAssertEqual(elapsed(now: 65), 65)                                     // never paused
+        XCTAssertEqual(elapsed(pausedDuration: 20, now: 65), 45)                 // one finished pause
+        XCTAssertEqual(elapsed(pausedAt: 30, now: 65), 30)                       // paused at 30s, still paused
+        XCTAssertEqual(elapsed(pausedAt: 50, pausedDuration: 10, now: 65), 40)   // both
+    }
+
+    /// The whole point of the fix: while paused the number must not move, however much wall time passes.
+    /// This is what the two card surfaces got wrong, and a clock that merely subtracts a CONSTANT would
+    /// still tick — so the open pause has to grow with `now`.
+    func testClockIsFrozenWhilePaused() {
+        XCTAssertEqual(elapsed(pausedAt: 30, now: 65), 30)
+        XCTAssertEqual(elapsed(pausedAt: 30, now: 99), 30)
+        XCTAssertEqual(elapsed(pausedAt: 30, now: 4_000), 30)
+    }
+
+    func testNeverCountsBackwards() {
+        XCTAssertEqual(elapsed(now: -5), 0)                        // clock skew
+        XCTAssertEqual(elapsed(pausedDuration: 70, now: 65), 0)    // paused longer than the session
+    }
+
+    /// The Live card carried its own `%d:%02d` formatter with no hour roll-over, so a 90-minute session
+    /// read "90:00" there and "1:30:00" on the Today indicator beside it. One formatter now.
+    func testClockFormatRollsOverAtAnHour() {
+        XCTAssertEqual(ActiveWorkoutClock.clock(0), "0:00")
+        XCTAssertEqual(ActiveWorkoutClock.clock(65), "1:05")
+        XCTAssertEqual(ActiveWorkoutClock.clock(3_600), "1:00:00")
+        XCTAssertEqual(ActiveWorkoutClock.clock(5_400), "1:30:00")
+        XCTAssertEqual(ActiveWorkoutClock.clock(2 * 3_600 + 5 * 60 + 9), "2:05:09")
+        XCTAssertEqual(ActiveWorkoutClock.clock(-5), "0:00")
+    }
+
+    /// The Today indicator renders from a value type, so the pause state has to reach IT — being correct
+    /// on `AppModel` is not enough, and that is exactly how the card kept counting.
+    func testIndicatorModelCarriesPauseStateAndFreezes() {
+        var workout = AppModel.ActiveWorkout(start: start)
+        workout.pausedAt = start.addingTimeInterval(30)
+        let model = ActiveWorkoutIndicatorModel.make(from: workout)
+        XCTAssertEqual(model?.isPaused, true)
+        XCTAssertEqual(model?.pausedAt, workout.pausedAt)
+        XCTAssertEqual(
+            ActiveWorkoutIndicatorModel.elapsed(since: start, pausedAt: model?.pausedAt,
+                                                pausedDuration: model?.pausedDuration ?? 0,
+                                                now: start.addingTimeInterval(600)),
+            "0:30")
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/ActiveWorkoutClock.kt
+++ b/android/app/src/main/java/com/noop/ui/ActiveWorkoutClock.kt
@@ -23,6 +23,10 @@ object ActiveWorkoutClock {
      * Clamped at zero so a clock-skew negative reads 0:00 rather than counting backwards. The open-pause
      * term is deliberately NOT clamped on its own: the single clamp on the result is what the Swift twin
      * does, and two clamps would disagree with it for a [pausedAtMs] in the future.
+     *
+     * Twin of Swift `ActiveWorkoutClock.activeElapsed` — the NAMES differ (that one takes
+     * `Date`/`TimeInterval`, this one Long milliseconds), so neither turns up in a grep for the other.
+     * Same arithmetic and the same single clamp.
      */
     fun activeElapsedSeconds(
         startMs: Long,

--- a/android/app/src/main/java/com/noop/ui/ActiveWorkoutClock.kt
+++ b/android/app/src/main/java/com/noop/ui/ActiveWorkoutClock.kt
@@ -1,0 +1,36 @@
+package com.noop.ui
+
+/**
+ * The ONE pause-aware elapsed calculation for an in-flight workout, shared by every surface that shows
+ * its clock.
+ *
+ * #1533 added Pause/Resume to the full-screen live workout screen and taught THAT screen's timer to
+ * subtract the paused time. The Today "workout in progress" card and the Live tab's active-workout card
+ * were not part of it: both still read `now - startMs`. So pausing froze one clock and left two others
+ * counting up, and a wearer who paused and left the screen saw the session apparently still running. The
+ * saved duration was correct the whole time, which is what made it confusing rather than merely wrong —
+ * the only evidence on screen contradicted the button that had just been pressed.
+ *
+ * Kept pure and in one place so a new surface cannot reintroduce the divergence by open-coding the
+ * subtraction again. Twin of Swift `ActiveWorkoutClock`.
+ */
+object ActiveWorkoutClock {
+
+    /**
+     * Seconds of ACTIVE time: wall time since [startMs], minus every completed pause
+     * ([pausedDurationMs]), minus the one still open when [pausedAtMs] is non-null.
+     *
+     * Clamped at zero so a clock-skew negative reads 0:00 rather than counting backwards. The open-pause
+     * term is deliberately NOT clamped on its own: the single clamp on the result is what the Swift twin
+     * does, and two clamps would disagree with it for a [pausedAtMs] in the future.
+     */
+    fun activeElapsedSeconds(
+        startMs: Long,
+        pausedAtMs: Long?,
+        pausedDurationMs: Long,
+        nowMs: Long,
+    ): Long {
+        val openPauseMs = pausedAtMs?.let { nowMs - it } ?: 0L
+        return ((nowMs - startMs - pausedDurationMs - openPauseMs) / 1000).coerceAtLeast(0L)
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -2992,9 +2992,14 @@ internal fun earliestStrapAlarmEpochSec(smartEpoch: Long?, buzzEpoch: Long?): Lo
 
 /**
  * Elapsed-workout clock from a whole-second count: M:SS up to an hour, H:MM:SS once an hour has passed (so a
- * 90-minute session reads "1:30:00", not "90:00"). Negative inputs clamp to zero ("0:00"). Pure so the
- * Today "workout in progress" indicator and the Live card share ONE format, and the iOS-parity H:MM:SS
- * roll-over is unit-testable without composing any UI. Mirrors iOS ActiveWorkoutIndicatorModel.elapsed.
+ * 90-minute session reads "1:30:00", not "90:00"). Negative inputs clamp to zero ("0:00"). Pure so every
+ * surface showing an in-flight workout — the Today card, the Live card, the Workouts-tab banner and the
+ * full-screen live screen — shares ONE format, and the iOS-parity H:MM:SS roll-over is unit-testable
+ * without composing any UI.
+ *
+ * Twin of Swift `ActiveWorkoutClock.clock`. (It used to name ActiveWorkoutIndicatorModel.elapsed, which
+ * no longer owns the formatting — that now delegates, like everything else, so the reference moved with
+ * the code rather than being left pointing at a caller.)
  */
 internal fun elapsedClock(elapsedS: Long): String {
     val total = elapsedS.coerceAtLeast(0)

--- a/android/app/src/main/java/com/noop/ui/LiveScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/LiveScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
@@ -370,11 +371,20 @@ fun LiveScreen(viewModel: AppViewModel, onManageDevices: () -> Unit = {}) {
             LaunchedEffect(w.startMs) {
                 while (true) { nowMs = System.currentTimeMillis(); delay(1000) }
             }
-            val elapsedS = ((nowMs - w.startMs) / 1000).coerceAtLeast(0)
+            val elapsedS = ActiveWorkoutClock.activeElapsedSeconds(
+                startMs = w.startMs, pausedAtMs = w.pausedAtMs,
+                pausedDurationMs = w.pausedDurationMs, nowMs = nowMs,
+            )
             NoopCard(tint = Palette.effortColor) {
                 Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
                     Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
                         Text(uiString(R.string.l10n_live_screen_w_sport_name_uppercase_e59bc678, w.sport.name.uppercase()), style = NoopType.overline, color = Palette.statusCritical)
+                        // A frozen clock alone is ambiguous with a STALLED one, so say which it is. Reuses
+                        // the string #1533 already localized rather than minting new copy for a tag.
+                        if (w.pausedAtMs != null) {
+                            Spacer(Modifier.width(Metrics.space8))
+                            Text(uiString(R.string.workout_action_paused), style = NoopType.overline, color = Palette.textSecondary)
+                        }
                         Spacer(Modifier.weight(1f))
                         Text(
                             // Shared clock: M:SS up to an hour, H:MM:SS past it (so a long session reads
@@ -397,14 +407,30 @@ fun LiveScreen(viewModel: AppViewModel, onManageDevices: () -> Unit = {}) {
                             StatTile(modifier = Modifier.weight(1f), label = uiString(R.string.l10n_live_screen_pace_7a9a6226), value = w.paceSecPerKm?.let { livePace(it, unitSystem) } ?: "—")
                         }
                     }
-                    Button(
-                        onClick = { confirmingEnd = true },
-                        modifier = Modifier.fillMaxWidth(),
-                        contentPadding = PaddingValues(horizontal = 10.dp, vertical = 8.dp),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = Palette.statusCritical, contentColor = Palette.surfaceBase,
-                        ),
-                    ) { Text(uiString(R.string.l10n_live_screen_end_workout_3e8d6238), style = NoopType.captionNumber) }
+                    // The card used to offer End and nothing else, so the only IRREVERSIBLE control was the
+                    // one reachable without opening the live overlay, while Pause — the reversible one —
+                    // was not. One toggle: a paused session has exactly one sensible next action.
+                    Row(horizontalArrangement = Arrangement.spacedBy(Metrics.gap), modifier = Modifier.fillMaxWidth()) {
+                        Button(
+                            onClick = { viewModel.toggleWorkoutPause() },
+                            modifier = Modifier.weight(1f),
+                            contentPadding = PaddingValues(horizontal = 10.dp, vertical = 8.dp),
+                        ) {
+                            Text(
+                                if (w.pausedAtMs != null) uiString(R.string.workout_action_resume)
+                                else uiString(R.string.workout_action_pause),
+                                style = NoopType.captionNumber,
+                            )
+                        }
+                        Button(
+                            onClick = { confirmingEnd = true },
+                            modifier = Modifier.weight(1f),
+                            contentPadding = PaddingValues(horizontal = 10.dp, vertical = 8.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = Palette.statusCritical, contentColor = Palette.surfaceBase,
+                            ),
+                        ) { Text(uiString(R.string.l10n_live_screen_end_workout_3e8d6238), style = NoopType.captionNumber) }
+                    }
                 }
             }
             if (confirmingEnd) {

--- a/android/app/src/main/java/com/noop/ui/LiveWorkoutScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/LiveWorkoutScreen.kt
@@ -165,7 +165,10 @@ fun LiveWorkoutScreen(vm: AppViewModel, onClose: () -> Unit) {
             ) {
                 Overline("Time", color = Palette.textSecondary)
                 Text(
-                    String.format("%d:%02d", elapsedS / 60, elapsedS % 60),
+                    // elapsedClock, not a local %d:%02d — that one had no hour roll-over, so this hero
+                    // read "90:00" for a 90-minute session while every card that opens this screen read
+                    // "1:30:00". The iOS twin had the identical local formatter and is fixed alongside.
+                    elapsedClock(elapsedS),
                     style = NoopType.number(56f), color = Palette.textPrimary,
                 )
             }

--- a/android/app/src/main/java/com/noop/ui/LiveWorkoutScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/LiveWorkoutScreen.kt
@@ -108,8 +108,10 @@ fun LiveWorkoutScreen(vm: AppViewModel, onClose: () -> Unit) {
     LaunchedEffect(w.startMs) {
         while (true) { nowMs = System.currentTimeMillis(); delay(1000) }
     }
-    val currentPauseMs = w.pausedAtMs?.let { nowMs - it } ?: 0L
-    val elapsedS = ((nowMs - w.startMs - w.pausedDurationMs - currentPauseMs) / 1000).coerceAtLeast(0)
+    val elapsedS = ActiveWorkoutClock.activeElapsedSeconds(
+        startMs = w.startMs, pausedAtMs = w.pausedAtMs,
+        pausedDurationMs = w.pausedDurationMs, nowMs = nowMs,
+    )
 
     // A scenic Effort-tinted backdrop behind the whole in-exercise screen — the live workout reads as
     // an Effort-world hero, not a flat panel.

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1859,6 +1859,11 @@ private fun WorkoutInProgressCard(
     )
     val elapsed = elapsedClock(elapsedS)
     val sportLabel = workout.sport.name
+    // The card below sets ONE contentDescription on a merged node, which REPLACES its children's
+    // semantics — so the visible "Paused" tag would be invisible to TalkBack unless it is folded in
+    // here. A frozen clock the screen reader cannot explain is worse than a running one.
+    val pausedSuffix =
+        if (workout.pausedAtMs != null) ", " + uiString(R.string.workout_action_paused) else ""
 
     // liquidPress on the whole tappable "return to workout" card (same interactionSource on clickable + press).
     val interaction = remember { MutableInteractionSource() }
@@ -1871,7 +1876,7 @@ private fun WorkoutInProgressCard(
             .liquidPress(interaction)
             .clickable(interactionSource = interaction, indication = null, onClick = onReturn)
             .semantics(mergeDescendants = true) {
-                contentDescription = uiString(R.string.l10n_today_screen_workout_in_progress_sportlabel_elapsed_return_95ce4bda, sportLabel, elapsed)
+                contentDescription = uiString(R.string.l10n_today_screen_workout_in_progress_sportlabel_elapsed_return_95ce4bda, sportLabel, elapsed) + pausedSuffix
             },
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(Metrics.space12)) {

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1853,7 +1853,10 @@ private fun WorkoutInProgressCard(
             kotlinx.coroutines.delay(1000)
         }
     }
-    val elapsedS = ((nowMs - workout.startMs) / 1000).coerceAtLeast(0)
+    val elapsedS = ActiveWorkoutClock.activeElapsedSeconds(
+        startMs = workout.startMs, pausedAtMs = workout.pausedAtMs,
+        pausedDurationMs = workout.pausedDurationMs, nowMs = nowMs,
+    )
     val elapsed = elapsedClock(elapsedS)
     val sportLabel = workout.sport.name
 
@@ -1887,6 +1890,16 @@ private fun WorkoutInProgressCard(
                     style = NoopType.overline,
                     color = Palette.metricRose,
                 )
+                // A frozen clock alone is ambiguous with a STALLED one, so say which it is. Reuses the
+                // string #1533 already localized rather than minting new copy for a tag.
+                if (workout.pausedAtMs != null) {
+                    Spacer(Modifier.width(Metrics.space8))
+                    Text(
+                        uiString(R.string.workout_action_paused),
+                        style = NoopType.overline,
+                        color = Palette.textSecondary,
+                    )
+                }
                 Spacer(Modifier.weight(1f))
                 Text(elapsed, style = NoopType.number(15f), color = Palette.textPrimary)
             }

--- a/android/app/src/main/java/com/noop/ui/WorkoutStart.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutStart.kt
@@ -203,33 +203,62 @@ fun WorkoutStartSection(vm: AppViewModel, onAdd: () -> Unit) {
         LaunchedEffect(w.startMs) {
             while (true) { nowMs = System.currentTimeMillis(); delay(1000) }
         }
-        val elapsedS = ((nowMs - w.startMs) / 1000).coerceAtLeast(0)
+        val elapsedS = ActiveWorkoutClock.activeElapsedSeconds(
+            startMs = w.startMs, pausedAtMs = w.pausedAtMs,
+            pausedDurationMs = w.pausedDurationMs, nowMs = nowMs,
+        )
         // Recording: the live banner, with Add kept visible below so a past workout can still be logged
         // mid-session (it used to live in the range bar).
         Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
             NoopCard {
-                Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-                    Text(uiString(R.string.l10n_workout_start_w_sport_name_uppercase_e59bc678, w.sport.name.uppercase()), style = NoopType.overline, color = Palette.statusCritical)
-                Spacer(Modifier.width(10.dp))
-                Text(
-                    String.format("%d:%02d", elapsedS / 60, elapsedS % 60),
-                    style = NoopType.title2, color = Palette.textPrimary,
-                )
-                Spacer(Modifier.weight(1f))
-                // Re-open the full-screen live workout view.
-                OutlinedButton(
-                    onClick = { showLiveWorkout = true },
-                    contentPadding = PaddingValues(horizontal = 14.dp, vertical = 8.dp),
-                    colors = ButtonDefaults.outlinedButtonColors(contentColor = Palette.accent),
-                ) { Text(uiString(R.string.l10n_workout_start_open_cf9b7706), style = NoopType.captionNumber) }
-                Spacer(Modifier.width(8.dp))
-                Button(
-                    onClick = { confirmingEnd = true },
-                    contentPadding = PaddingValues(horizontal = 14.dp, vertical = 8.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = Palette.statusCritical, contentColor = Palette.surfaceBase,
-                    ),
-                ) { Text(uiString(R.string.l10n_workout_start_end_a2bb9d34), style = NoopType.captionNumber) }
+                // Two rows, not one: this banner already carried a sport label, a clock, Open and End,
+                // and a third button would squeeze all five onto one line on a narrow phone. The state
+                // reads on top, the actions sit below with equal weight.
+                Column(verticalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+                        Text(uiString(R.string.l10n_workout_start_w_sport_name_uppercase_e59bc678, w.sport.name.uppercase()), style = NoopType.overline, color = Palette.statusCritical)
+                        // A frozen clock alone is ambiguous with a STALLED one, so say which it is. Reuses
+                        // the string #1533 already localized rather than minting new copy for a tag.
+                        if (w.pausedAtMs != null) {
+                            Spacer(Modifier.width(8.dp))
+                            Text(uiString(R.string.workout_action_paused), style = NoopType.overline, color = Palette.textSecondary)
+                        }
+                        Spacer(Modifier.width(10.dp))
+                        // elapsedClock, not a local %d:%02d — that one had no hour roll-over at all, so a
+                        // 90-minute session read "90:00" here while every other surface read "1:30:00".
+                        Text(elapsedClock(elapsedS), style = NoopType.title2, color = Palette.textPrimary)
+                        Spacer(Modifier.weight(1f))
+                    }
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+                        // End was reachable here and Pause was not, so the only control this banner
+                        // offered without opening the live view was the irreversible one.
+                        Button(
+                            onClick = { vm.toggleWorkoutPause() },
+                            modifier = Modifier.weight(1f),
+                            contentPadding = PaddingValues(horizontal = 14.dp, vertical = 8.dp),
+                        ) {
+                            Text(
+                                if (w.pausedAtMs != null) uiString(R.string.workout_action_resume)
+                                else uiString(R.string.workout_action_pause),
+                                style = NoopType.captionNumber,
+                            )
+                        }
+                        // Re-open the full-screen live workout view.
+                        OutlinedButton(
+                            onClick = { showLiveWorkout = true },
+                            modifier = Modifier.weight(1f),
+                            contentPadding = PaddingValues(horizontal = 14.dp, vertical = 8.dp),
+                            colors = ButtonDefaults.outlinedButtonColors(contentColor = Palette.accent),
+                        ) { Text(uiString(R.string.l10n_workout_start_open_cf9b7706), style = NoopType.captionNumber) }
+                        Button(
+                            onClick = { confirmingEnd = true },
+                            modifier = Modifier.weight(1f),
+                            contentPadding = PaddingValues(horizontal = 14.dp, vertical = 8.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = Palette.statusCritical, contentColor = Palette.surfaceBase,
+                            ),
+                        ) { Text(uiString(R.string.l10n_workout_start_end_a2bb9d34), style = NoopType.captionNumber) }
+                    }
                 }
             }
             AddWorkoutButton(onAdd, Modifier.fillMaxWidth())

--- a/android/app/src/test/java/com/noop/ui/ActiveWorkoutClockTest.kt
+++ b/android/app/src/test/java/com/noop/ui/ActiveWorkoutClockTest.kt
@@ -1,0 +1,58 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the pause-aware workout clock every live surface now shares.
+ *
+ * #1533 added Pause/Resume but only the full-screen live workout screen's timer subtracted the paused
+ * time; the Today card and the Live card kept reading `now - startMs`, so pausing froze one clock and
+ * left two counting. These cases are the twin of Swift `ActiveWorkoutClockTests` — same scenarios, same
+ * expected seconds — so the two platforms cannot drift on what "elapsed" means for a paused session.
+ */
+class ActiveWorkoutClockTest {
+
+    private val startMs = 1_000_000L
+
+    private fun elapsed(pausedAtS: Long? = null, pausedDurationS: Long = 0, nowS: Long): Long =
+        ActiveWorkoutClock.activeElapsedSeconds(
+            startMs = startMs,
+            pausedAtMs = pausedAtS?.let { startMs + it * 1000 },
+            pausedDurationMs = pausedDurationS * 1000,
+            nowMs = startMs + nowS * 1000,
+        )
+
+    @Test fun activeElapsedSubtractsCompletedAndOpenPauses() {
+        assertEquals(65L, elapsed(nowS = 65))                                        // never paused
+        assertEquals(45L, elapsed(pausedDurationS = 20, nowS = 65))                  // one finished pause
+        assertEquals(30L, elapsed(pausedAtS = 30, nowS = 65))                        // paused at 30s, still paused
+        assertEquals(40L, elapsed(pausedAtS = 50, pausedDurationS = 10, nowS = 65))  // both
+    }
+
+    /**
+     * The whole point of the fix: while paused the number must not move, however much wall time passes.
+     * This is what the two card surfaces got wrong, and a clock that merely subtracts a CONSTANT would
+     * still tick — so the open pause has to grow with `now`.
+     */
+    @Test fun clockIsFrozenWhilePaused() {
+        assertEquals(30L, elapsed(pausedAtS = 30, nowS = 65))
+        assertEquals(30L, elapsed(pausedAtS = 30, nowS = 99))
+        assertEquals(30L, elapsed(pausedAtS = 30, nowS = 4_000))
+    }
+
+    @Test fun neverCountsBackwards() {
+        assertEquals(0L, elapsed(nowS = -5))                          // clock skew
+        assertEquals(0L, elapsed(pausedDurationS = 70, nowS = 65))    // paused longer than the session
+    }
+
+    /** The shared formatter, unchanged by this work but pinned beside its Swift twin. */
+    @Test fun clockFormatRollsOverAtAnHour() {
+        assertEquals("0:00", elapsedClock(0))
+        assertEquals("1:05", elapsedClock(65))
+        assertEquals("1:00:00", elapsedClock(3_600))
+        assertEquals("1:30:00", elapsedClock(5_400))
+        assertEquals("2:05:09", elapsedClock(2 * 3_600 + 5 * 60 + 9L))
+        assertEquals("0:00", elapsedClock(-5))
+    }
+}


### PR DESCRIPTION
Community request: a **Pause/Unpause button on the workout cards**.

The button itself already exists — #1533 (thanks @bhelm), shipped in **v10.6.0** — but only on the
full-screen live workout view. Working out why people still ask for it turned up a defect worth more
than the request.

## Three clocks ignored pause

#1533 taught the full-screen timer to subtract paused time. The Today "workout in progress" card and
the Live tab's active-workout card, **on both platforms**, still read `now - start`:

| Surface | Before | After |
|---|---|---|
| Live Workout screen (both) | pause-aware | pause-aware, via the shared clock |
| iOS/macOS **Live** card | `now - start` | pause-aware |
| iOS/macOS **Today** indicator | `now - start` | pause-aware |
| Android **Live** card | `nowMs - startMs` | pause-aware |
| Android **Today** card | `nowMs - startMs` | pause-aware |

So pausing froze one clock and left the other two counting up. The **saved duration was correct the
whole time**, which is what made it confusing rather than merely wrong — the only evidence on screen
contradicted the button that had just been pressed. That is a very plausible route to someone asking
for a feature that is already there.

On iOS the Today indicator *could not* have got it right: `ActiveWorkoutIndicatorModel` is the value
type the card renders from, and it carried only `sport` + `startedAt`. The pause state never reached
it, however correct `AppModel` was.

## One shared clock

New pure `ActiveWorkoutClock` on both platforms owns the subtraction — wall time, minus completed
pauses, minus the one still open. Every surface routes through it now, **including the full-screen view
that was already right**, so a new surface can't reintroduce the divergence by open-coding it again.
`AppModel.ActiveWorkout.elapsed` and the iOS indicator model both delegate.

The Live card also carried its own `%d:%02d` formatter with **no hour roll-over**, so a 90-minute
session read `90:00` there while the Today indicator beside it read `1:30:00` — and Android's shared
`elapsedClock` documents itself as mirroring the iOS one, which by then it didn't. One formatter now.

## The request itself

**Pause/Resume as a single toggle on both Live cards, beside End.** A paused session has exactly one
sensible next action, so one button.

Those cards previously offered **End and nothing else** — the reversible control was behind a screen
you had to open, and the irreversible one was right there. On iOS End also moves to its own row so a
destructive tap isn't adjacent to a routine one.

All four cards now show a **"Paused"** tag. A frozen clock with no tag is indistinguishable from a
stalled one.

**No new user-facing copy.** `Pause` / `Resume` / `Paused` were all localized by #1533 and are reused —
no xcstrings or `strings.xml` churn, no new i18n debt. `Tools/i18n_audit.py --ci` passes with no new
literals.

## How it was verified

Kotlin and Swift twins of the same scenario table: never paused, completed pause, open pause, both,
clock skew, paused-longer-than-session, and the format roll-over.

**Byte-parity checked by oracle, not by eye.** The Swift helper compiles standalone (`swiftc -O`) and
its output matches the Kotlin expectations value for value:

```
65 / 45 / 30 / 40 / 30 / 30 / 0 / 0
0:00  1:05  1:00:00  1:30:00  2:05:09  0:00
```

The load-bearing case is `clockIsFrozenWhilePaused`: **a clock that subtracts a constant still ticks**,
so the open pause has to grow with `now`. That is the exact bug, pinned at three different values of
`now`.

- Android: full suite green — **4603 tests, 0 failures**, on freshly cleared result XMLs.
  `compileFullDebugKotlin` clean.
- `Tools/doc_comment_lint.py` — OK.
- App-target Swift (`LiveView`, `TodayView`, `AppModel`, `StrandTests`) has **no default CI**, so
  `app-build` was dispatched on this branch rather than trusting a green tick — the #1589 lesson.

## Not done

**No auto-pause.** Nothing in the tree has ever had it, and pausing on a speed threshold needs field
data and per-sport behaviour rather than a guess. This is the manual button that was asked for.

## Type of change

- [x] Bug fix (the three clocks)
- [x] New feature (Pause/Resume on the cards)

## Checklist

- [x] Android unit tests pass (`./gradlew testFullDebugUnitTest` — 4603/0)
- [x] UI changes use only design tokens (`StrandPalette`/`StrandFont`, `Palette`/`Metrics`/`NoopType`)
- [x] Cross-platform: both platforms in this PR, twin tests, oracle-verified
- [x] No new hardcoded UI copy; i18n gate green
- [x] No generated artifacts committed
