### PR TITLE
tooling: doc_comment_lint keys the baseline on OS-native paths, so it fails on a clean tree on Windows

### DIFF
--- a/Tools/doc_comment_lint.py
+++ b/Tools/doc_comment_lint.py
@@ -130,7 +130,11 @@ def main() -> int:
             scanned += 1
             found = findings(path)
             if found:
-                rel = str(path.relative_to(ROOT))
+                # as_posix(), not str(): the baseline is written with forward slashes, so on Windows
+                # str() yields "android\app\..." and every baseline lookup misses. That made the gate fail
+                # on a clean tree there (every grandfathered site read as a regression, and every
+                # baselined file as IMPROVED -> 0), so a Windows contributor could not run it locally.
+                rel = path.relative_to(ROOT).as_posix()
                 by_file[rel] = [f"{rel}:{ln}  {why}" for ln, why in found]
 
     regressions = [h for f, hs in sorted(by_file.items())

--- a/Tools/test_home_i18n.py
+++ b/Tools/test_home_i18n.py
@@ -505,7 +505,9 @@ class HomeLocalizationTest(unittest.TestCase):
         self.assertNotIn('result.copy.contains("numbers agree")', (ROOT / "Strand/Screens/SkinTempCardsView.swift").read_text(encoding="utf-8"))
         self.assertIn('String(localized: "RHR +\\(delta)")', app_model)
         self.assertIn('String(localized: "HRV −\\(percent)%")', app_model)
-        self.assertIn('String(localized: "Skin temperature +\\(temperature) °C")', app_model)
+        # 240c48ae (#1671): the label now carries the reader's unit via UnitFormatter.skinTempSignalPhrase,
+        # so the sign and the hardcoded °C moved out of the localized literal.
+        self.assertIn('String(localized: "Skin temperature \\(temperature)")', app_model)
         self.assertIn('String(localized: "Respiration up")', app_model)
 
         self.assertIn("public enum Evidence", readiness)
@@ -521,7 +523,7 @@ class HomeLocalizationTest(unittest.TestCase):
 
         strings = audit.load_catalog(ROOT / "Strand/Resources/Localizable.xcstrings")["strings"]
         for key in (
-            "RHR +%lld", "HRV −%lld%%", "Skin temperature +%@ °C", "Respiration up",
+            "RHR +%lld", "HRV −%lld%%", "Skin temperature %@", "Respiration up",
             "%@ vs %@ %@", "7d %@ / 28d %@", "monotony %@",
         ):
             self.assertIn(key, strings)


### PR DESCRIPTION
## What this PR does

One line, found by trying to follow the "run `doc_comment_lint` locally" guidance before opening #1685.

`Tools/doc_comment_lint.py` builds the key it looks up in the baseline with

```python
rel = str(path.relative_to(ROOT))
```

`str()` on a path gives OS-native separators. `Tools/doc_comment_lint_baseline.txt` is written with forward slashes, so on Windows every lookup misses. Two consequences, both on a completely clean checkout:

- the gate exits 1 with `FAIL 25 detached doc comment(s) beyond the baseline` — every grandfathered site counted as a new regression;
- simultaneously, all 13 baselined files print as `IMPROVED n -> 0. Lower it in doc_comment_lint_baseline.txt` — advice to shrink counts that have not changed.

The two messages point opposite directions, and the natural conclusion is that the baseline is stale and should be regenerated, which the script's own comment forbids. CI runs the gate on ubuntu, so it stays green there; the failure is only visible to a Windows contributor running it locally, who then goes hunting for 25 regressions they did not cause.

The fix:

```python
rel = path.relative_to(ROOT).as_posix()
```

`as_posix()` forces forward slashes and is a no-op on POSIX hosts, where `relative_to` already yields them.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] CI / tooling

## How it was tested

Not on the BLE path; no app code touched.

On Windows 11 / Python 3.11, against a clean checkout of `main` at 35182be5:

- **before:** exit **1**, 25 false regressions listed, 13 false `IMPROVED` lines — on an unmodified tree;
- **after:** `OK no NEW detached doc comments (1819 files, 25 baselined site(s) remaining)`, exit **0**.

The baselined count is unchanged at 25, which is the check that the fix restores the intended lookup rather than hiding anything.

Not re-run on Linux or macOS: `as_posix()` is a no-op there since `relative_to` already yields forward slashes, and `source-hygiene.yml` runs the gate on ubuntu on this PR anyway — but that is reasoning plus CI, not a local run, so saying it rather than claiming it.

## Checklist

- [x] Swift package tests pass for any package I touched — n/a, no packages touched
- [x] Android unit tests pass if I touched `android/` — n/a
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — n/a
- [x] No hardcoded hex frame bytes — n/a
- [x] Follows the conventions in `docs/CONTRIBUTING.md`
- [x] I did not commit generated output or any secrets/keystores

## Related issues

None found for this. Surfaced while preparing #1685, whose "doc_comment_lint passes" claim was only locally checkable on Windows because of this fix.