### PR TITLE
diag(hrv): census the two LIVE R-R transports, not just the historical one

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RrEmissionStats.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RrEmissionStats.swift
@@ -168,11 +168,16 @@ public enum RrEmissionStats {
     /// gapless, and `ratioRep` is the one to trust when they disagree. (`ratioRep`'s denominator can
     /// double-count at most one second per chunk boundary when a session's counts are summed, which is
     /// negligible against thousands of seconds — and errs the same safe way, low.)
-    public static func logLine(path: String, offered: Int, inserted: Int, _ r: Result) -> String {
+    public static func logLine(path: String, offered: Int, inserted: Int?, _ r: Result) -> String {
+        // NIL renders "n/a", never a number. Only the historical path can see what the store's conflict
+        // key actually kept; the live paths census BEFORE the insert and have no such count. Echoing
+        // `offered` there would print `offered=N inserted=N`, which reads as "the primary key absorbed
+        // nothing" — a measurement neither path made. Same reason GpsSession passes rawFixes = nil.
+        let ins = inserted.map(String.init) ?? "n/a"
         let ratio = String(format: "%.2f", r.ratio)
         let rep = r.secondsWithRr > 0 ? Double(r.sumRrMs) / 1000.0 / Double(r.secondsWithRr) : 0
         let h = r.perSecond
-        return "rr emit path=\(path) offered=\(offered) inserted=\(inserted) secs=\(r.secondsWithRr) "
+        return "rr emit path=\(path) offered=\(offered) inserted=\(ins) secs=\(r.secondsWithRr) "
             + "sumRr=\(r.sumRrMs / 1000)s span=\(r.spanSec)s ratio=\(ratio) "
             + "ratioRep=\(String(format: "%.2f", rep)) "
             + "perSec[1/2/3/4+]=\(h[0])/\(h[1])/\(h[2])/\(h[3]) "

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RrEmissionStats.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RrEmissionStats.swift
@@ -127,6 +127,34 @@ public enum RrEmissionStats {
                       spanSec: span, ratio: ratio, perSecond: hist, gapHist: gapHist, fill: fill)
     }
 
+    /// 15 minutes: rare enough not to bury the log, frequent enough to sample a night several times.
+    public static let liveCensusMinGapSec: Int = 900
+
+    /// Should a LIVE census line be emitted now? (#1118 instrumentation.)
+    ///
+    /// The historical census is emitted once per offload SESSION, which is naturally rare. The two live
+    /// paths flush roughly every 30 readings, so emitting per flush would put a line on the strap log
+    /// every ~30 seconds all night — a volume that buries the very evidence it exists to provide. One
+    /// line per path per `minGapSec` is plenty: a single flush already spans enough seconds to make
+    /// `ratioRep` meaningful (the historical line settles it on 39 s), and what matters is comparing the
+    /// paths, not sampling either densely.
+    ///
+    /// `lastEmitSec` is 0 before the first line, so the first flush of a connection always reports.
+    /// A clock that moves BACKWARDS emits rather than suppresses: the alternative wedges the census shut
+    /// until wall time catches up, and a silent instrument is worse than a duplicated line.
+    ///
+    /// Byte-parity twin of Kotlin `RrEmissionStats.shouldEmitLiveCensus`.
+    public static func shouldEmitLiveCensus(lastEmitSec: Int, nowSec: Int,
+                                            minGapSec: Int = liveCensusMinGapSec) -> Bool {
+        // The "never emitted" sentinel is checked EXPLICITLY. Falling through to the gap arithmetic
+        // gets the right answer in production only because a real unix `nowSec` is ~1.8e9 and so
+        // trivially clears any gap — an accident of magnitude, not a rule. It also made the helper
+        // untestable with small timestamps, which is how this was caught.
+        if lastEmitSec <= 0 { return true }
+        if nowSec < lastEmitSec { return true }
+        return nowSec - lastEmitSec >= minGapSec
+    }
+
     /// One compact log line. `offered`/`inserted` come from the caller: `inserted` is what the store
     /// actually wrote after its `ON CONFLICT` key, so `offered - inserted` is how much the primary key
     /// already absorbs — the third number needed to tell emission from ingest.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrEmissionStatsTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrEmissionStatsTests.swift
@@ -127,4 +127,22 @@ final class RrEmissionStatsTests: XCTestCase {
         let line = RrEmissionStats.logLine(path: "historical", offered: 4, inserted: 4, r)
         XCTAssertTrue(line.contains("ratio=0.00 ratioRep=1.60"), line)
     }
+
+    /// The LIVE census rate-limit. Twin of Kotlin `shouldEmitLiveCensusRateLimits` — same table, same
+    /// answers, oracle-checked against a standalone Swift build of the helper.
+    ///
+    /// The `lastEmit=0` rows are the ones that matter. The sentinel is checked explicitly, not left to
+    /// the gap arithmetic: with a real unix `nowSec` (~1.8e9) the subtraction clears any gap by accident
+    /// of magnitude, so the "first flush always reports" contract held in production while being false
+    /// for small timestamps — which is exactly what a unit test uses.
+    func testShouldEmitLiveCensus() {
+        XCTAssertTrue(RrEmissionStats.shouldEmitLiveCensus(lastEmitSec: 0, nowSec: 0))
+        XCTAssertTrue(RrEmissionStats.shouldEmitLiveCensus(lastEmitSec: 0, nowSec: 1))
+        XCTAssertTrue(RrEmissionStats.shouldEmitLiveCensus(lastEmitSec: 0, nowSec: 1_700_000_000))
+        XCTAssertFalse(RrEmissionStats.shouldEmitLiveCensus(lastEmitSec: 1_700_000_000, nowSec: 1_700_000_000))
+        XCTAssertFalse(RrEmissionStats.shouldEmitLiveCensus(lastEmitSec: 1_700_000_000, nowSec: 1_700_000_899))
+        XCTAssertTrue(RrEmissionStats.shouldEmitLiveCensus(lastEmitSec: 1_700_000_000, nowSec: 1_700_000_900))
+        XCTAssertTrue(RrEmissionStats.shouldEmitLiveCensus(lastEmitSec: 1_700_000_000, nowSec: 1_700_000_901))
+        XCTAssertTrue(RrEmissionStats.shouldEmitLiveCensus(lastEmitSec: 1_700_000_900, nowSec: 1_700_000_000))
+    }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrEmissionStatsTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RrEmissionStatsTests.swift
@@ -112,6 +112,12 @@ final class RrEmissionStatsTests: XCTestCase {
         let line = RrEmissionStats.logLine(path: "historical", offered: 3, inserted: 2, r)
         XCTAssertTrue(line.hasPrefix("rr emit path=historical offered=3 inserted=2 secs=2 "), line)
         XCTAssertTrue(line.contains("perSec[1/2/3/4+]=1/1/0/0"), line)
+
+        // A LIVE path censuses before the insert and cannot know what the conflict key kept, so it
+        // passes nil and the line must say "n/a". Echoing `offered` there would read as "the primary
+        // key absorbed nothing" — a claim neither live path is in a position to make.
+        let live = RrEmissionStats.logLine(path: "live-standard", offered: 3, inserted: nil, r)
+        XCTAssertTrue(live.contains("offered=3 inserted=n/a "), live)
     }
 
     /// A GAP must not read as healthy emission. Two doubled seconds an hour apart carry a 2.0 emission

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1286,7 +1286,8 @@ public final class BLEManager: NSObject, ObservableObject {
         // persists raw frames. Flip "enableRawCapture" in UserDefaults to capture raw again.
         let enableRawCapture = UserDefaults.standard.bool(forKey: "enableRawCapture")
         collector = Collector(store: store, deviceId: deviceId,
-                              enableRawCapture: enableRawCapture)
+                              enableRawCapture: enableRawCapture,
+                              log: { [weak self] line in self?.log(line) })
         // The store can finish bootstrapping AFTER connect(model:) already ran (both wait on
         // poweredOn), so apply the family/clock configuration here too — whichever runs last wins.
         configureCollectorFamily()

--- a/Strand/Collect/Collector.swift
+++ b/Strand/Collect/Collector.swift
@@ -197,7 +197,7 @@ final class Collector {
                 lastRealtimeRrCensusSec = nowSec
                 let census = RrEmissionStats.compute(streams.rr.map { (ts: $0.ts, rrMs: $0.rrMs) })
                 log?(RrEmissionStats.logLine(path: "live-realtime", offered: streams.rr.count,
-                                             inserted: streams.rr.count, census))
+                                             inserted: nil, census))
             }
         }
         do {
@@ -250,11 +250,10 @@ final class Collector {
             if RrEmissionStats.shouldEmitLiveCensus(lastEmitSec: lastStdRrCensusSec, nowSec: nowSec) {
                 lastStdRrCensusSec = nowSec
                 let census = RrEmissionStats.compute(rr.map { (ts: $0.ts, rrMs: $0.rrMs) })
-                // offered == inserted is NOT known here (the store's conflict key decides), so both report
-                // the offered count. Reporting a guessed `inserted` would be the diagnostic asserting more
-                // than it observed.
+                // `inserted` is NIL, not echoed from `offered`: the store's conflict key decides that and
+                // this census runs before the insert. The line renders `inserted=n/a`.
                 log?(RrEmissionStats.logLine(path: "live-standard", offered: rr.count,
-                                             inserted: rr.count, census))
+                                             inserted: nil, census))
             }
         }
         do {

--- a/Strand/Collect/Collector.swift
+++ b/Strand/Collect/Collector.swift
@@ -1,6 +1,7 @@
 import Foundation
 import WhoopProtocol
 import WhoopStore
+import StrandAnalytics
 
 /// The subset of WhoopStore the Collector needs. A protocol so tests can inject a spy
 /// (WhoopStore is `final`). WhoopStore conforms via the extension below.
@@ -72,6 +73,14 @@ final class Collector {
     /// #47: buffer the (raw frame, pre-parsed) pair. The raw bytes are still needed for the raw-capture
     /// outbox; the parse is the one the BLE seam already did, so `flush` doesn't re-decode the batch.
     private var buffer: [(frame: [UInt8], parsed: ParsedFrame)] = []
+    /// #1118: strap-log sink for the per-transport R-R census. Optional and defaulted to nil so the
+    /// test fakes that construct a Collector are untouched; `BLEManager` wires its own `log`.
+    private let log: ((String) -> Void)?
+    /// #1118: last emit of each LIVE census line, unix seconds; 0 = never. Rate-limited — see
+    /// `RrEmissionStats.shouldEmitLiveCensus`.
+    private var lastStdRrCensusSec: Int = 0
+    private var lastRealtimeRrCensusSec: Int = 0
+
     /// Standard 0x2A37 HR/RR buffer — the reliable, always-on stream, recorded continuously
     /// (independent of the custom realtime stream or which screen is open).
     private var stdHR: [HRSample] = []
@@ -82,10 +91,12 @@ final class Collector {
     init(store: StoreWriting, deviceId: String,
          policy: CollectorPolicy = .default,
          enableRawCapture: Bool = false,
+         log: ((String) -> Void)? = nil,
          now: @escaping () -> Int = { Int(Date().timeIntervalSince1970) },
          monotonic: @escaping () -> TimeInterval = { Date().timeIntervalSinceReferenceDate }) {
         self.store = store; self.deviceId = deviceId; self.policy = policy
         self.enableRawCapture = enableRawCapture
+        self.log = log
         self.now = now; self.monotonic = monotonic
         self.batchStartedAt = monotonic()
         self.concreteStore = store as? WhoopStore
@@ -176,6 +187,19 @@ final class Collector {
         let frames = batch.map(\.frame)         // still needed for the raw-capture outbox
         let parsed = batch.map(\.parsed)        // #47: the seam already decoded these — don't re-parse
         let streams = extractStreams(parsed, deviceClockRef: ref.device, wallClockRef: ref.wall)
+        // #1118: the SECOND live transport. `flushStandardHR` stamps a beat at the second it arrived over
+        // 0x2A37; this one stamps it from the strap's own record clock. The same beat reaching both lands
+        // on two different seconds, which no same-second de-dup can collapse — the signature every
+        // affected night prints as `crossSecondOverCount`.
+        if !streams.rr.isEmpty {
+            let nowSec = now()
+            if RrEmissionStats.shouldEmitLiveCensus(lastEmitSec: lastRealtimeRrCensusSec, nowSec: nowSec) {
+                lastRealtimeRrCensusSec = nowSec
+                let census = RrEmissionStats.compute(streams.rr.map { (ts: $0.ts, rrMs: $0.rrMs) })
+                log?(RrEmissionStats.logLine(path: "live-realtime", offered: streams.rr.count,
+                                             inserted: streams.rr.count, census))
+            }
+        }
         do {
             try await store.insert(streams, deviceId: deviceId)   // DECODED FIRST (durable)
         } catch {
@@ -217,6 +241,22 @@ final class Collector {
         let hr = stdHR, rr = stdRR
         stdHR.removeAll(keepingCapacity: true)
         stdRR.removeAll(keepingCapacity: true)
+        // #1118: census this batch BEFORE it is stored, exactly as the historical path does, so a strap
+        // log carries one `ratioRep` per transport. If each transport reports ~1.0 while the stored night
+        // reads 2.77, the over-count is the UNION of the transports and no single decoder is at fault —
+        // which is the question this instrumentation exists to settle.
+        if !rr.isEmpty {
+            let nowSec = now()
+            if RrEmissionStats.shouldEmitLiveCensus(lastEmitSec: lastStdRrCensusSec, nowSec: nowSec) {
+                lastStdRrCensusSec = nowSec
+                let census = RrEmissionStats.compute(rr.map { (ts: $0.ts, rrMs: $0.rrMs) })
+                // offered == inserted is NOT known here (the store's conflict key decides), so both report
+                // the offered count. Reporting a guessed `inserted` would be the diagnostic asserting more
+                // than it observed.
+                log?(RrEmissionStats.logLine(path: "live-standard", offered: rr.count,
+                                             inserted: rr.count, census))
+            }
+        }
         do {
             try await store.insert(Streams(hr: hr, rr: rr), deviceId: deviceId)
         } catch {

--- a/Strand/Collect/Collector.swift
+++ b/Strand/Collect/Collector.swift
@@ -78,6 +78,16 @@ final class Collector {
     private let log: ((String) -> Void)?
     /// #1118: last emit of each LIVE census line, unix seconds; 0 = never. Rate-limited — see
     /// `RrEmissionStats.shouldEmitLiveCensus`.
+    ///
+    /// Lifetime DIVERGES from the Kotlin twin. These reset whenever `BLEManager.bootstrapStore()`
+    /// rebuilds the Collector (a store rebuild after unlock, among other paths), so a log can carry an
+    /// extra line after one of those. Android keeps its stamps on the process-wide `WhoopBleClient`
+    /// singleton, which a device switch mutates rather than rebuilds, so they never reset there.
+    /// Harmless either way — a rate-limit on a diagnostic, not a measurement — but a reader comparing
+    /// two logs should not have to work out why one has more lines than the other.
+    ///
+    /// @MainActor isolation makes these safe without a lock; the Kotlin fields are deliberately
+    /// unsynchronized instead, since a stale read there costs one duplicate line.
     private var lastStdRrCensusSec: Int = 0
     private var lastRealtimeRrCensusSec: Int = 0
 

--- a/android/app/src/main/java/com/noop/analytics/RrEmissionStats.kt
+++ b/android/app/src/main/java/com/noop/analytics/RrEmissionStats.kt
@@ -114,6 +114,33 @@ object RrEmissionStats {
     }
 
     /**
+     * Should a LIVE census line be emitted now? (#1118 instrumentation.)
+     *
+     * The historical census is emitted once per offload SESSION, which is naturally rare. The two live
+     * paths flush roughly every 30 readings, so emitting per flush would put a line on the strap log
+     * every ~30 seconds all night — a volume that buries the very evidence it exists to provide. One
+     * line per path per [minGapSec] is plenty: a single flush already spans enough seconds to make
+     * `ratioRep` meaningful (the historical line settles it on 39 s), and what matters is comparing the
+     * paths, not sampling either densely.
+     *
+     * [lastEmitSec] is 0 before the first line, so the first flush of a connection always reports.
+     * A clock that moves BACKWARDS emits rather than suppresses: the alternative wedges the census
+     * shut until wall time catches up, and a silent instrument is worse than a duplicated line.
+     */
+    fun shouldEmitLiveCensus(lastEmitSec: Int, nowSec: Int, minGapSec: Int = LIVE_CENSUS_MIN_GAP_SEC): Boolean {
+        // The "never emitted" sentinel is checked EXPLICITLY. Falling through to the gap arithmetic
+        // gets the right answer in production only because a real unix `nowSec` is ~1.8e9 and so
+        // trivially clears any gap — an accident of magnitude, not a rule. It also made the helper
+        // untestable with small timestamps, which is how this was caught.
+        if (lastEmitSec <= 0) return true
+        if (nowSec < lastEmitSec) return true
+        return nowSec - lastEmitSec >= minGapSec
+    }
+
+    /** 15 minutes: rare enough not to bury the log, frequent enough to sample a night several times. */
+    const val LIVE_CENSUS_MIN_GAP_SEC: Int = 900
+
+    /**
      * One compact log line. [offered]/[inserted] come from the caller: [inserted] is what the store
      * actually wrote after its conflict key, so `offered - inserted` is how much the primary key already
      * absorbs — the third number needed to tell emission from ingest.

--- a/android/app/src/main/java/com/noop/analytics/RrEmissionStats.kt
+++ b/android/app/src/main/java/com/noop/analytics/RrEmissionStats.kt
@@ -153,11 +153,16 @@ object RrEmissionStats {
      * rather than by the wall span, so it is immune to gaps; the two agreeing means the batch is gapless,
      * and `ratioRep` is the one to trust when they disagree.
      */
-    fun logLine(path: String, offered: Int, inserted: Int, r: Result): String {
+    fun logLine(path: String, offered: Int, inserted: Int?, r: Result): String {
         val ratio = String.format(java.util.Locale.US, "%.2f", r.ratio)
+        // NULL renders "n/a", never a number. Only the historical path can see what the store's conflict
+        // key actually kept; the live paths census BEFORE the insert and have no such count. Echoing
+        // `offered` there would print `offered=N inserted=N`, which reads as "the primary key absorbed
+        // nothing" — a measurement neither path made. Same reason GpsSession passes rawFixes = null.
+        val ins = inserted?.toString() ?: "n/a"
         val rep = if (r.secondsWithRr > 0) r.sumRrMs / 1000.0 / r.secondsWithRr else 0.0
         val h = r.perSecond
-        return "rr emit path=$path offered=$offered inserted=$inserted secs=${r.secondsWithRr} " +
+        return "rr emit path=$path offered=$offered inserted=$ins secs=${r.secondsWithRr} " +
             "sumRr=${r.sumRrMs / 1000}s span=${r.spanSec}s ratio=$ratio " +
             "ratioRep=${String.format(java.util.Locale.US, "%.2f", rep)} " +
             "perSec[1/2/3/4+]=${h[0]}/${h[1]}/${h[2]}/${h[3]} " +

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7862,6 +7862,17 @@ class WhoopBleClient(
             .maxOrNull() ?: now
         val streams: Streams = extractStreams(parsed, deviceClockRef = newestRealtimeTs, wallClockRef = now)
         val batch = StreamPersistence.toBatch(streams)
+        // #1118: the SECOND live transport. The standard 0x2A37 path above stamps a beat at the second
+        // it arrived; this one stamps it from the strap's own record clock. The same beat reaching both
+        // lands on two different seconds, which no same-second de-dup can collapse — the signature every
+        // affected night prints as `crossSecondOverCount`.
+        if (batch.rr.isNotEmpty()) {
+            if (com.noop.analytics.RrEmissionStats.shouldEmitLiveCensus(lastRealtimeRrCensusSec, now)) {
+                lastRealtimeRrCensusSec = now
+                val census = com.noop.analytics.RrEmissionStats.compute(batch.rr.map { it.ts.toInt() to it.rrMs })
+                log(com.noop.analytics.RrEmissionStats.logLine("live-realtime", batch.rr.size, batch.rr.size, census))
+            }
+        }
         if (!batch.isEmpty) {
             try {
                 repository.insert(batch, deviceId)
@@ -7871,6 +7882,11 @@ class WhoopBleClient(
             }
         }
     }
+
+    /** #1118: last emit of each LIVE R-R census line, unix seconds; 0 = never. See
+     *  [com.noop.analytics.RrEmissionStats.shouldEmitLiveCensus] for why these are rate-limited. */
+    private var lastStdRrCensusSec: Int = 0
+    private var lastRealtimeRrCensusSec: Int = 0
 
     /**
      * Buffer one standard 0x2A37 reading (carries a wall-clock ts directly, no clock ref needed).
@@ -7892,6 +7908,21 @@ class WhoopBleClient(
             val h = ArrayList(stdHr); val r = ArrayList(stdRr)
             stdHr.clear(); stdRr.clear()
             h to r
+        }
+        // #1118: census this batch BEFORE it is stored, exactly as the historical path does, so a
+        // strap log carries one `ratioRep` per transport. If each transport reports ~1.0 while the
+        // stored night reads 2.77, the over-count is the UNION of the transports and no single
+        // decoder is at fault — which is the question this instrumentation exists to settle.
+        if (rr.isNotEmpty()) {
+            val nowSec = (System.currentTimeMillis() / 1000L).toInt()
+            if (com.noop.analytics.RrEmissionStats.shouldEmitLiveCensus(lastStdRrCensusSec, nowSec)) {
+                lastStdRrCensusSec = nowSec
+                val census = com.noop.analytics.RrEmissionStats.compute(rr.map { it.ts.toInt() to it.rrMs })
+                // offered == inserted is NOT known here (the store's conflict key decides), so both
+                // report the offered count and the line's own doc explains the pair. Reporting a
+                // guessed `inserted` would be the diagnostic asserting more than it observed.
+                log(com.noop.analytics.RrEmissionStats.logLine("live-standard", rr.size, rr.size, census))
+            }
         }
         try {
             repository.insert(StreamBatch(hr = hr, rr = rr), deviceId)

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7884,7 +7884,17 @@ class WhoopBleClient(
     }
 
     /** #1118: last emit of each LIVE R-R census line, unix seconds; 0 = never. See
-     *  [com.noop.analytics.RrEmissionStats.shouldEmitLiveCensus] for why these are rate-limited. */
+     *  [com.noop.analytics.RrEmissionStats.shouldEmitLiveCensus] for why these are rate-limited.
+     *
+     *  Deliberately UNSYNCHRONIZED, unlike the buffers they sit beside. The two flushes can run
+     *  concurrently on the io scope, but a 32-bit write is atomic on the JVM so the worst outcome of a
+     *  stale read is one duplicate diagnostic line — cheaper than taking `collectorLock` on a path whose
+     *  only job is to describe itself. (The Swift twin is @MainActor-isolated and gets the guarantee for
+     *  free; the asymmetry is intentional, not an oversight.)
+     *
+     *  These live on the CLIENT, so they reset with it: a strap that reconnects often emits a line per
+     *  connection rather than one per 15 minutes. Left alone — persisting a diagnostic's rate-limit
+     *  across reconnects would outweigh what it saves, and a reconnect storm is itself worth seeing. */
     private var lastStdRrCensusSec: Int = 0
     private var lastRealtimeRrCensusSec: Int = 0
 

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7892,9 +7892,14 @@ class WhoopBleClient(
      *  only job is to describe itself. (The Swift twin is @MainActor-isolated and gets the guarantee for
      *  free; the asymmetry is intentional, not an oversight.)
      *
-     *  These live on the CLIENT, so they reset with it: a strap that reconnects often emits a line per
-     *  connection rather than one per 15 minutes. Left alone — persisting a diagnostic's rate-limit
-     *  across reconnects would outweigh what it saves, and a reconnect storm is itself worth seeing. */
+     *  Lifetime, which DIVERGES from the Swift twin and is worth knowing before reading a log:
+     *  `WhoopBleClient` is the process-wide lazy singleton on `NoopApplication`, and a device switch
+     *  mutates `deviceId` via [setActiveDeviceId] rather than rebuilding the client — so these never
+     *  reset for the life of the process, and the 15-minute cadence holds across reconnects. The Swift
+     *  side keeps them on `Collector`, which `BLEManager.bootstrapStore()` REBUILDS (a store rebuild
+     *  after unlock, among other paths), so an iOS log can carry an extra line after one of those.
+     *  Harmless either way — it is a rate-limit on a diagnostic, not a measurement — but a reader
+     *  comparing two logs should not have to work out why one has more lines than the other. */
     private var lastStdRrCensusSec: Int = 0
     private var lastRealtimeRrCensusSec: Int = 0
 

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7870,7 +7870,7 @@ class WhoopBleClient(
             if (com.noop.analytics.RrEmissionStats.shouldEmitLiveCensus(lastRealtimeRrCensusSec, now)) {
                 lastRealtimeRrCensusSec = now
                 val census = com.noop.analytics.RrEmissionStats.compute(batch.rr.map { it.ts.toInt() to it.rrMs })
-                log(com.noop.analytics.RrEmissionStats.logLine("live-realtime", batch.rr.size, batch.rr.size, census))
+                log(com.noop.analytics.RrEmissionStats.logLine("live-realtime", batch.rr.size, null, census))
             }
         }
         if (!batch.isEmpty) {
@@ -7918,10 +7918,9 @@ class WhoopBleClient(
             if (com.noop.analytics.RrEmissionStats.shouldEmitLiveCensus(lastStdRrCensusSec, nowSec)) {
                 lastStdRrCensusSec = nowSec
                 val census = com.noop.analytics.RrEmissionStats.compute(rr.map { it.ts.toInt() to it.rrMs })
-                // offered == inserted is NOT known here (the store's conflict key decides), so both
-                // report the offered count and the line's own doc explains the pair. Reporting a
-                // guessed `inserted` would be the diagnostic asserting more than it observed.
-                log(com.noop.analytics.RrEmissionStats.logLine("live-standard", rr.size, rr.size, census))
+                // `inserted` is NULL, not echoed from `offered`: the store's conflict key decides that
+                // and this census runs before the insert. The line renders `inserted=n/a`.
+                log(com.noop.analytics.RrEmissionStats.logLine("live-standard", rr.size, null, census))
             }
         }
         try {

--- a/android/app/src/test/java/com/noop/analytics/RrEmissionStatsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RrEmissionStatsTest.kt
@@ -2,6 +2,7 @@ package com.noop.analytics
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
 import org.junit.Test
 
 /**
@@ -139,5 +140,29 @@ class RrEmissionStatsTest {
         assertTrue("span ratio is diluted by the gap, as documented", r.ratio < 0.01)
         val line = RrEmissionStats.logLine("historical", 4, 4, r)
         assertTrue(line, line.contains("ratio=0.00 ratioRep=1.60"))
+    }
+
+    /**
+     * The LIVE census rate-limit. Twin of Swift `testShouldEmitLiveCensus` — same table, same answers,
+     * oracle-checked against a standalone Swift build of the helper.
+     *
+     * The `lastEmit=0` rows are the ones that matter. The sentinel is checked explicitly, not left to
+     * the gap arithmetic: with a real unix `nowSec` (~1.8e9) the subtraction clears any gap by accident
+     * of magnitude, so the "first flush always reports" contract held in production while being false
+     * for small timestamps — which is exactly what a unit test uses.
+     */
+    @Test fun shouldEmitLiveCensusRateLimits() {
+        // never emitted -> always report, whatever the clock reads
+        assertTrue(RrEmissionStats.shouldEmitLiveCensus(0, 0))
+        assertTrue(RrEmissionStats.shouldEmitLiveCensus(0, 1))
+        assertTrue(RrEmissionStats.shouldEmitLiveCensus(0, 1_700_000_000))
+        // inside the window -> stay quiet
+        assertFalse(RrEmissionStats.shouldEmitLiveCensus(1_700_000_000, 1_700_000_000))
+        assertFalse(RrEmissionStats.shouldEmitLiveCensus(1_700_000_000, 1_700_000_899))
+        // at and past the window -> report
+        assertTrue(RrEmissionStats.shouldEmitLiveCensus(1_700_000_000, 1_700_000_900))
+        assertTrue(RrEmissionStats.shouldEmitLiveCensus(1_700_000_000, 1_700_000_901))
+        // clock moved BACKWARDS -> report rather than wedge the instrument shut until time catches up
+        assertTrue(RrEmissionStats.shouldEmitLiveCensus(1_700_000_900, 1_700_000_000))
     }
 }

--- a/android/app/src/test/java/com/noop/analytics/RrEmissionStatsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RrEmissionStatsTest.kt
@@ -123,6 +123,12 @@ class RrEmissionStatsTest {
         val line = RrEmissionStats.logLine("historical", 3, 2, r)
         assertTrue(line, line.startsWith("rr emit path=historical offered=3 inserted=2 secs=2 "))
         assertTrue(line, line.contains("perSec[1/2/3/4+]=1/1/0/0"))
+
+        // A LIVE path censuses before the insert and cannot know what the conflict key kept, so it
+        // passes null and the line must say "n/a". Echoing `offered` there would read as "the primary
+        // key absorbed nothing" — a claim neither live path is in a position to make.
+        val live = RrEmissionStats.logLine("live-standard", 3, null, r)
+        assertTrue(live, live.startsWith("rr emit path=live-standard offered=3 inserted=n/a secs=2 "))
     }
 
     /**


### PR DESCRIPTION
Instrumentation for #1118, prompted by the report in #1689 — whose log already carries half the answer.

## Three writers put R-R rows in one table; one of them is censused

| transport | timestamp | census today |
|---|---|---|
| standard `0x2A37` notify | the **arrival** wall-clock second | none |
| puffin `REALTIME_DATA` | the strap's record clock | none |
| historical offload | the record's own second | `rr emit path=historical` |

The standard path is deliberately unconditional — its own comment reads *"Record it continuously —
independent of the realtime stream or which screen is open"* — so on a strap that also banks those
beats, one beat can be stored **at the second it arrived** and **at the second it was recorded**.
Different `ts`, so the `(deviceId, ts)` primary key cannot collapse them. That is precisely the
`crossSecondOverCount` verdict every affected night prints.

## Why this is instrumentation and not a repair

The #1689 log already reports the historical transport's own number: **`ratioRep=0.99`**, against a
stored night reading **`coverage=2.77`**. `RrEmissionStats`' own doc names that exact case —
*"near 1.0 while the stored night still reads 1.7 means the duplication is in ingest"*.

One transport measured clean is suggestive. **Three transports each measured clean while the union
reads 2.77 is proof** — and only one of the three currently reports. The same log's `cov40=1.97` is
the other half of the shape: collapsing same-second near-duplicates leaves almost exactly two full
copies of the beat train.

So the same pure census now runs on the two live paths *before* the rows are stored:

```
rr emit path=live-standard  offered=… inserted=… secs=… ratio=… ratioRep=… perSec[…] …
rr emit path=live-realtime  offered=… inserted=… secs=… ratio=… ratioRep=… perSec[…] …
rr emit path=historical     …                                    ← already shipped
```

Nothing reads any of it. No scoring change, no storage change, no schema change.

## This is smaller than the change I proposed

The plan was a nullable transport column plus a Room + GRDB migration, because nothing in the stored
data can attribute a row to its writer (`srcChannel` is Oura-only; WHOOP rows log `src=none`). That is
still true — but it isn't needed to **answer** the question. Comparing each transport's pre-storage
`ratioRep` against the stored night's coverage settles which side of the store the duplication is on,
with no persisted tag at all.

A migration is the right tool for a repair that has to drop one transport's rows. It's the wrong tool
for finding out whether that *is* the repair.

## Rate limiting

One line per path per 15 minutes. The live paths flush roughly every 30 readings, so a per-flush line
would put an entry on the strap log every ~30 seconds all night and bury the evidence it exists to
provide. A single flush already spans enough seconds for `ratioRep` to mean something — the historical
line settles it on 39 s.

## A bug the oracle found in my own helper

The rate-limit documented *"0 = never emitted, so the first flush always reports"*. It didn't:

```
shouldEmit(last=0, now=1) = false     ← before
shouldEmit(last=0, now=1) = true      ← after
```

With `lastEmit=0` the gap arithmetic returns false for any `nowSec` under 900. It behaved correctly in
production **only because a real unix timestamp is ~1.8e9 and clears the gap by accident of magnitude**
— and that accident is also why a test written with small timestamps would have failed. The sentinel is
now checked explicitly, and the test table pins exactly those rows.

## Verification

- Twin Kotlin/Swift tests over one table, **oracle-checked**: the Swift helper compiled standalone
  reproduces the Kotlin expectations row for row, including the clock-moved-backwards case (emit rather
  than wedge the instrument shut).
- Android **4604 tests, 0 failures** on a `--rerun-tasks` pass; `doc_comment_lint` OK; i18n green.
- `Collector.swift` / `BLEManager.swift` are app-target Swift with no default CI, so **app-build was
  dispatched on this branch**.

## Not validated on a strap

These lines are emitted from the BLE path, so what they actually **print** on real hardware is unproven
until someone posts a log — which is the point of shipping them. The next 4.0 log with all three lines
on it settles #1118's mechanism.

## Type of change

- [x] CI / tooling — diagnostics only, no behaviour change

## Checklist

- [x] Android unit tests pass (4604/0)
- [x] Swift package tests: `StrandAnalytics` needs macOS (GRDB via WhoopStore), left to `swift-packages.yml`; the new helper was oracle-verified standalone
- [x] Cross-platform: both platforms, twin tests
- [x] No new UI copy; i18n gate green
- [x] No hardcoded hex frame bytes; no generated artifacts committed
