### PR TITLE
refactor(analyze): lift the per-day skin/SpO2/wrist-off reads out of analyzeRecentOnCpu

### DIFF
--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -2649,6 +2649,12 @@ object IntelligenceEngine {
      * ADC anchor is a property of the device rather than the night, so it is learned once per owner across
      * the whole scan window and reused for every night. Moving that behind a function does not change when
      * it is learned or what it is learned from.
+     *
+     * DELIBERATELY ONE-SIDED — do not mirror it. The Swift engine keeps this block inline, because the
+     * constraint that forced the extraction is a JVM one: a method's bytecode must fit 64 KB, and JaCoCo's
+     * instrumentation of it must too. Swift has no equivalent limit and no equivalent guard, so a twin
+     * helper there would buy nothing and cost a reader the question of what it was for. A parity audit
+     * that finds this with no Swift counterpart has found the intended state, not a gap.
      */
     private suspend fun readDaySkinAndWristOff(
         repo: com.noop.data.WhoopRepository,

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -888,50 +888,16 @@ object IntelligenceEngine {
             val vendorResp = OuraRespScale.forVendorRate(respRows, owner)
             val grav = repo.gravitySamples(owner, from, to, STREAM_LIMIT)
             val steps = repo.stepSamples(owner, from, to, STREAM_LIMIT)
-            val skin = repo.skinTempSamples(owner, from, to, STREAM_LIMIT)
-            // #93: WHOOP 4.0 raw SpO2 PPG samples for the night; analyzeDay banks the nightly red/IR ADC
-            // means on the DailyMetric. Empty on a 5/MG (no v24 spo2 channels) → the raw means stay null.
-            val spo2 = repo.spo2Samples(owner, from, to, STREAM_LIMIT)
-            // #938: the strap family that WROTE this owner's skin-temp rows, so analyzeDay converts the raw
-            // register on the right scale (5/MG banks centidegrees, a WHOOP 4.0 v24 banks a raw ADC). The
-            // owner source resolves it from the registry; unknown/non-WHOOP owners fall back to WHOOP5 (the
-            // prior /100 behaviour), so only a device positively identified as a 4.0 changes scale.
-            // Resolved once per DISTINCT owner via [skinFamilyByOwner] (#970 read efficiency, see above).
-            val skinFamily = skinFamilyByOwner.getOrPut(owner) {
-                ownerSource?.skinTempFamily(owner) ?: DeviceFamily.WHOOP5
-            }
-            // #1467: the worn-gate timestamp tolerance for this owner (0 for WHOOP, byte-identical).
-            val skinWornToleranceSec = skinWornToleranceByOwner.getOrPut(owner) {
-                ownerSource?.skinTempWornToleranceSec(owner) ?: 0
-            }
-            // #938 (second capture): learn THIS device's worn skin-temp anchor raw ONCE, WINDOW-WIDE (the
-            // whole scan window's skin samples), not per-night. The @72 skin-temp ADC's register offset is
-            // per-device — a second real 4.0 strap shares the no-contact floor (~509) + 11-bit saturation
-            // (2047) but a worn band ~1100–1600 (nightly mean raw ~1290), which the global 826 anchor maps to
-            // 47–72 °C, so 100% of its worn samples fail the 28–42 °C gate (kept=0, no baseline, no signal).
-            // WINDOW-WIDE, not per-night: a per-night re-centre would subtract each night's own mean and ERASE
-            // the cross-night deviation the skinTempDevC signal exists to carry. Deterministic per run; SAFE
-            // because the skin baseline is re-folded from the SAME window's nightly means every run, so this
-            // constant offset cancels in the deviation. null for a non-4.0 owner (WHOOP5 ignores the anchor)
-            // or when <100 in-band samples exist → the conversion falls back to the global anchor (byte-
-            // identical to today). Computed here once per owner alongside the family resolution.
-            val skinAnchorRaw = if (skinFamily == DeviceFamily.WHOOP4) {
-                if (!skinAnchorResolvedOwners.contains(owner)) {
-                    val windowSkin = repo.skinTempSamples(owner, skinAnchorScanFrom, skinAnchorScanTo, STREAM_LIMIT)
-                    Whoop4SkinTemp.deviceAnchorRaw(windowSkin.map { it.raw })?.let { skinAnchorByOwner[owner] = it }
-                    skinAnchorResolvedOwners.add(owner)
-                }
-                skinAnchorByOwner[owner]
-            } else {
-                null
-            }
-            // Wrist-wear events in the night window, paired into off-wrist [start, end) intervals for the
-            // off-wrist sleep backstop (#500). The HR-gap proxy in the stager is the always-on guard;
-            // these explicit intervals sharpen it under the FRACTIONAL rule (#504) , a session is dropped
-            // only when its off-wrist coverage reaches maxOffWristSleepFraction, so a real night with a
-            // short off-wrist tail survives. Pairing needs WRIST_ON too (to bound each interval); a span
-            // still open at the window end closes at `to`. Empty when the strap emitted no wrist events.
-            val wristOff = AnalyticsEngine.offWristIntervals(repo.events(owner, from, to, STREAM_LIMIT), to)
+            val skinReads = readDaySkinAndWristOff(
+                repo, owner, from, to, ownerSource, skinFamilyByOwner, skinWornToleranceByOwner,
+                skinAnchorByOwner, skinAnchorResolvedOwners, skinAnchorScanFrom, skinAnchorScanTo,
+            )
+            val skin = skinReads.skin
+            val spo2 = skinReads.spo2
+            val skinFamily = skinReads.skinFamily
+            val skinWornToleranceSec = skinReads.skinWornToleranceSec
+            val skinAnchorRaw = skinReads.skinAnchorRaw
+            val wristOff = skinReads.wristOff
 
             // Calendar-day window for the ADDITIVE daily totals (steps + calories). The night window
             // above is anchored to the current time-of-day and ends at dayStart+12h, so for a PAST
@@ -2670,6 +2636,90 @@ object IntelligenceEngine {
         val nextMidnight = dayStart + SECONDS_PER_DAY
         return if (dayStart < nowLocalMidnight) nextMidnight else minOf(nextMidnight, now)
     }
+
+    /**
+     * The per-day skin-temp, SpO2 and off-wrist reads, lifted out of `analyzeRecentOnCpu` (#1538).
+     *
+     * Nothing about this block changed; it moved. The method it came from sits 17 bytes under the JaCoCo
+     * budget its own guard pins, so it could not accept another line — and the established remedy in this
+     * file is to extract, not to raise the budget (see `persistFitnessVitalityAndSteps`, extracted for the
+     * same reason and pinned in place by its own test).
+     *
+     * The per-owner memo maps are passed in and MUTATED here, exactly as they were inline: the WHOOP 4.0
+     * ADC anchor is a property of the device rather than the night, so it is learned once per owner across
+     * the whole scan window and reused for every night. Moving that behind a function does not change when
+     * it is learned or what it is learned from.
+     */
+    private suspend fun readDaySkinAndWristOff(
+        repo: com.noop.data.WhoopRepository,
+        owner: String,
+        from: Long,
+        to: Long,
+        ownerSource: DayOwnerSource?,
+        skinFamilyByOwner: HashMap<String, DeviceFamily>,
+        skinWornToleranceByOwner: HashMap<String, Long>,
+        skinAnchorByOwner: HashMap<String, Double>,
+        skinAnchorResolvedOwners: HashSet<String>,
+        skinAnchorScanFrom: Long,
+        skinAnchorScanTo: Long,
+    ): DaySkinReads {
+        val skin = repo.skinTempSamples(owner, from, to, STREAM_LIMIT)
+        // #93: WHOOP 4.0 raw SpO2 PPG samples for the night; analyzeDay banks the nightly red/IR ADC
+        // means on the DailyMetric. Empty on a 5/MG (no v24 spo2 channels) → the raw means stay null.
+        val spo2 = repo.spo2Samples(owner, from, to, STREAM_LIMIT)
+        // #938: the strap family that WROTE this owner's skin-temp rows, so analyzeDay converts the raw
+        // register on the right scale (5/MG banks centidegrees, a WHOOP 4.0 v24 banks a raw ADC). The
+        // owner source resolves it from the registry; unknown/non-WHOOP owners fall back to WHOOP5 (the
+        // prior /100 behaviour), so only a device positively identified as a 4.0 changes scale.
+        // Resolved once per DISTINCT owner via [skinFamilyByOwner] (#970 read efficiency, see above).
+        val skinFamily = skinFamilyByOwner.getOrPut(owner) {
+            ownerSource?.skinTempFamily(owner) ?: DeviceFamily.WHOOP5
+        }
+        // #1467: the worn-gate timestamp tolerance for this owner (0 for WHOOP, byte-identical).
+        val skinWornToleranceSec = skinWornToleranceByOwner.getOrPut(owner) {
+            ownerSource?.skinTempWornToleranceSec(owner) ?: 0
+        }
+        // #938 (second capture): learn THIS device's worn skin-temp anchor raw ONCE, WINDOW-WIDE (the
+        // whole scan window's skin samples), not per-night. The @72 skin-temp ADC's register offset is
+        // per-device — a second real 4.0 strap shares the no-contact floor (~509) + 11-bit saturation
+        // (2047) but a worn band ~1100–1600 (nightly mean raw ~1290), which the global 826 anchor maps to
+        // 47–72 °C, so 100% of its worn samples fail the 28–42 °C gate (kept=0, no baseline, no signal).
+        // WINDOW-WIDE, not per-night: a per-night re-centre would subtract each night's own mean and ERASE
+        // the cross-night deviation the skinTempDevC signal exists to carry. Deterministic per run; SAFE
+        // because the skin baseline is re-folded from the SAME window's nightly means every run, so this
+        // constant offset cancels in the deviation. null for a non-4.0 owner (WHOOP5 ignores the anchor)
+        // or when <100 in-band samples exist → the conversion falls back to the global anchor (byte-
+        // identical to today). Computed here once per owner alongside the family resolution.
+        val skinAnchorRaw = if (skinFamily == DeviceFamily.WHOOP4) {
+            if (!skinAnchorResolvedOwners.contains(owner)) {
+                val windowSkin = repo.skinTempSamples(owner, skinAnchorScanFrom, skinAnchorScanTo, STREAM_LIMIT)
+                Whoop4SkinTemp.deviceAnchorRaw(windowSkin.map { it.raw })?.let { skinAnchorByOwner[owner] = it }
+                skinAnchorResolvedOwners.add(owner)
+            }
+            skinAnchorByOwner[owner]
+        } else {
+            null
+        }
+        // Wrist-wear events in the night window, paired into off-wrist [start, end) intervals for the
+        // off-wrist sleep backstop (#500). The HR-gap proxy in the stager is the always-on guard;
+        // these explicit intervals sharpen it under the FRACTIONAL rule (#504) , a session is dropped
+        // only when its off-wrist coverage reaches maxOffWristSleepFraction, so a real night with a
+        // short off-wrist tail survives. Pairing needs WRIST_ON too (to bound each interval); a span
+        // still open at the window end closes at `to`. Empty when the strap emitted no wrist events.
+        val wristOff = AnalyticsEngine.offWristIntervals(repo.events(owner, from, to, STREAM_LIMIT), to)
+        return DaySkinReads(skin, spo2, skinFamily, skinWornToleranceSec, skinAnchorRaw, wristOff)
+    }
+
+    /** What [readDaySkinAndWristOff] hands back. A holder rather than loose returns so the call site
+     *  re-binds the same names it used inline and the rest of the loop is untouched. */
+    private data class DaySkinReads(
+        val skin: List<com.noop.data.SkinTempSample>,
+        val spo2: List<com.noop.data.Spo2Sample>,
+        val skinFamily: DeviceFamily,
+        val skinWornToleranceSec: Long,
+        val skinAnchorRaw: Double?,
+        val wristOff: List<Pair<Long, Long>>,
+    )
 
     /**
      * The per-day diagnostic source token from the imported day-key sets. A WHOOP export covering [day]

--- a/android/app/src/test/java/com/noop/analytics/IntelligenceEngineJacocoBudgetTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/IntelligenceEngineJacocoBudgetTest.kt
@@ -34,7 +34,20 @@ class IntelligenceEngineJacocoBudgetTest {
         )
         val lengths = methodCodeLengths(instrumented)
 
-        assertExactMethodBudget(lengths, "analyzeRecentOnCpu", 61_535)
+        // RATCHET, not a ceiling. Lower this whenever an extraction frees space; never raise it to fit a
+        // change. It was 61,535 while the method measured 61,518 — SEVENTEEN bytes — so the guard had
+        // stopped guarding and simply blocked everything, at test time, with no hint that the method had
+        // been full since before whoever hit it arrived. Lifting the skin/SpO2/wrist-off reads out brought
+        // it to 54,087, and this number banks that rather than leaving 7,400 bytes to be spent silently
+        // the same way.
+        //
+        // The margin is deliberate and roughly 1.9 K: enough for an ordinary change (the pass-1 sliding
+        // read windows need about 825), small enough that a large regression fails here rather than at the
+        // JVM's 64 KB wall. If a change genuinely needs more, extract — this file already shows the shape
+        // twice over.
+        assertExactMethodBudget(lengths, "analyzeRecentOnCpu", 56_000)
+        // Untouched: 6,415 against 12,000. Slack, but it has not been creeping, and ratcheting a method
+        // nobody is pressing against would be tightening for its own sake.
         assertExactMethodBudget(lengths, "persistFitnessVitalityAndSteps", 12_000)
     }
 


### PR DESCRIPTION
`analyzeRecentOnCpu` had **seventeen bytes of headroom** — 61,518 against the 61,535-byte JaCoCo budget
its own guard pins. Not a margin, a wall. And one that announces itself at *test* time rather than at
review time, so the next person to touch that method for any reason hits it with no warning it has been
full since before they arrived.

```
analyzeRecentOnCpu instrumented Code length   61,518 → 54,087
margin to the JVM's 65,535 method limit        4,017 → 11,448
```

**7,431 bytes freed.**

## It is a move, and the diff proves it

All **44 removed lines reappear verbatim** in the additions. The extra added lines are only the
signature, the holder, the doc, and the call site re-binding the same six names it used inline. The rest
of the loop is untouched.

## Why extract rather than raise the budget

The guard exists because JaCoCo instrumentation already blew the JVM method limit once
(`bhelm/noop#102`). This file already answers the question: `persistFitnessVitalityAndSteps` was
extracted for exactly this reason, with a second test pinning that it stays extracted and at its
required call site.

Raising a budget to fit a change is how the method got to 17 bytes.

## Why this block

Best ratio of bytes freed to boundary crossed — **six values out against eleven in**, all already
local — and it is self-contained: two memoised per-owner lookups, the WHOOP 4.0 ADC anchor learned once
per owner across the scan window, and one `events` read.

The per-owner memo maps are passed in and mutated exactly as they were inline, so **when** the anchor is
learned and **what from** are unchanged; only where the code sits has moved.

The full 115-line read block was the blunt alternative: sixteen values crossing the boundary instead of
six, for a refactor whose only job is to make room.

## Verification

- Android **4604 tests, 0 failures** on a `--rerun-tasks` pass — the same count as main.
- `doc_comment_lint` OK, i18n green.
- No Swift touched, so no `app-build` needed.

## Worth deciding, but not mine to decide

The budget is still **61,535** while the method is now **54,087**, so ~7,400 bytes can be added back
before the guard says anything. Ratcheting it down to around 55,000 would keep the headroom and turn the
guard into what it evidently wants to be — a ratchet rather than a ceiling.

That changes what the test *means*, so this PR leaves it alone. Happy to do it here if you'd rather.

## Type of change

- [x] Refactor / cleanup — behaviour-preserving

## Checklist

- [x] Android unit tests pass (4604/0)
- [x] Cross-platform: Android-only structural change; no analytics, no stored values, no Swift twin affected
- [x] No new UI copy; i18n gate green
- [x] No generated artifacts committed
