### PR TITLE
diag(ble): Apple decoded the strap's own console log and then dropped it

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
@@ -887,7 +887,9 @@ private func decodeWhoop5Event(_ frame: [UInt8], fb: FieldBuilder, schema: Schem
 /// chunk_len 52, channel 1): `record_index` u16@9 (monotonic per-chunk counter — the frame's u8 seq
 /// slot is its low byte), `unix` u32@12 + `subsec` u16@16 (batch write time), chunk_len u16@18,
 /// channel u8@20, text bytes @21 up to the CRC32 trailer with NUL padding. The Kotlin twin is
-/// `Framing.decodeConsoleLogsWhoop5` (text key "console"), same offsets.
+/// `Framing.decodeConsoleLogsWhoop5`, same offsets. The text key is "log" — matching the Python
+/// reference decoder that `golden.json` is generated from, which `ParityTests` pins. Kotlin used
+/// "console" for the same field, and the mismatch is why a reader ported from that side got nil.
 private func decodeWhoop5ConsoleLogs(_ frame: [UInt8], fb: FieldBuilder, payloadEnd: Int?) {
     if let idx = readDType(frame, 9, "u16") {
         fb.add(9, 2, "record_index", "meta", value: .int(idx), note: "per-chunk counter")

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -6181,6 +6181,8 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                     // …but a REAL-TIME physical gesture (double-tap / wrist) must still fire even mid-
                     // offload (#69). Gated on ts≈now so replayed historical EVENTs (old ts) are ignored.
                     router.dispatchLiveGestureIfFresh(frame: frame, now: strapClockNow)
+                    // …and the strap's own console narration, which it emits precisely DURING a sync.
+                    router.mirrorStrapConsoleIfPresent(frame: frame)
                     continue
                 }
                 // #47: decode this live WHOOP4 frame ONCE here and thread the result to every consumer
@@ -6278,6 +6280,8 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                         // A real-time double-tap / wrist gesture still fires during a 5/MG offload (which
                         // runs for minutes, #69); the ts≈now gate rejects replayed historical EVENTs.
                         router.dispatchLiveGestureIfFresh(frame: frame, now: strapClockNow)
+                        // …and the strap's own console narration, which it emits precisely DURING a sync.
+                        router.mirrorStrapConsoleIfPresent(frame: frame)
                         continue
                     }
                     router.handle(frame: frame)

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -289,6 +289,22 @@ public final class FrameRouter {
                 }
             }
 
+        case "CONSOLE_LOGS":
+            // The 5/MG strap narrates its own sync engine here — "BLE: PullStats: Data: N, Events: N…",
+            // "History burst success. Trim: 0x…", "Historical Dump Complete". Android has mirrored this
+            // into the strap log since #78 and calls it gold for protocol research; this side decoded the
+            // text and then dropped it on the floor, so an Apple strap log has never carried a word of it.
+            //
+            // It is worth more than curiosity. `PullStats: Data: 0` is the STRAP stating it sent no
+            // records, which is a far stronger answer to a "synced but no data" report (#1683) than NOOP
+            // inferring emptiness from its own decode — the difference between the strap saying nothing
+            // was there and us saying we found nothing.
+            //
+            // Capped at 300 characters to match the Kotlin twin exactly; the ring buffer holds 2k lines.
+            if let txt = parsed.parsed["log"]?.stringValue, !txt.isEmpty {
+                state.append(log: "strap: \(String(txt.prefix(300)))")
+            }
+
         case "EVENT":
             if let ev = parsed.parsed["event"]?.stringValue {
                 // #92: don't surface the live-HR stream toggle (BLE_REALTIME_HR_ON/OFF) in "Last

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -301,9 +301,7 @@ public final class FrameRouter {
             // was there and us saying we found nothing.
             //
             // Capped at 300 characters to match the Kotlin twin exactly; the ring buffer holds 2k lines.
-            if let txt = parsed.parsed["log"]?.stringValue, !txt.isEmpty {
-                state.append(log: "strap: \(String(txt.prefix(300)))")
-            }
+            appendStrapConsole(parsed)
 
         case "EVENT":
             if let ev = parsed.parsed["event"]?.stringValue {
@@ -525,6 +523,32 @@ public final class FrameRouter {
     /// RTC (fix #72) — a live gesture is ~now in the strap's clock, a historical replay is old in it.
     /// Deliberately does NOT touch lastEvent / sync trigger / bonded / battery — those stay on the normal
     /// handle(frame:) path, so backfill UI behaviour is otherwise unchanged.
+    /// Mirror a CONSOLE_LOGS frame's text even during a backfill.
+    ///
+    /// The strap narrates its sync engine EXACTLY while offloading — "BLE: PullStats: Data: N",
+    /// "History burst success. Trim: 0x…", "Historical Dump Complete" — and offload frames are routed
+    /// straight to the Backfiller, bypassing `handle` entirely. So the `case "CONSOLE_LOGS"` there only
+    /// ever sees the rare console frame that arrives outside a sync, which is not the one worth having.
+    /// This is the same carve-out `dispatchLiveGestureIfFresh` makes for a live gesture mid-offload.
+    ///
+    /// Same cheap pre-check as that method: a single type-byte compare skips the CRC + FieldBuilder
+    /// decode for the thousands of type-47 records a sync produces, so the cost on the offload path is a
+    /// byte compare per frame. Family-aware (WHOOP4 type @[4], 5/MG @[8]).
+    func mirrorStrapConsoleIfPresent(frame: [UInt8]) {
+        guard frameTypeName(frame, family: family) == "CONSOLE_LOGS" else { return }
+        let parsed = parseFrame(frame, family: family)
+        guard parsed.ok, parsed.crcOK != false else { return }
+        appendStrapConsole(parsed)
+    }
+
+    /// The one place the strap's own narration reaches the log, so the live and offload paths cannot
+    /// drift in what they emit. Capped at 300 characters to match the Kotlin twin exactly.
+    private func appendStrapConsole(_ parsed: ParsedFrame) {
+        guard parsed.typeName == "CONSOLE_LOGS",
+              let txt = parsed.parsed["log"]?.stringValue, !txt.isEmpty else { return }
+        state.append(log: "strap: \(String(txt.prefix(300)))")
+    }
+
     func dispatchLiveGestureIfFresh(frame: [UInt8], now: Int = Int(Date().timeIntervalSince1970)) {
         // #47: this fires for EVERY frame on the OFFLOAD path (thousands of type-47 records over a
         // multi-minute sync) purely to catch a rare EVENT gesture. Cheap type-only pre-check skips the full

--- a/StrandTests/StrapConsoleMirrorTests.swift
+++ b/StrandTests/StrapConsoleMirrorTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import Strand
+
+/// Guards that the strap's own console narration actually REACHES the log.
+///
+/// The bug this exists for was not a decode bug and not a key bug — both of those were right. Offload
+/// frames are routed straight to the Backfiller and never reach `FrameRouter.handle`, and `CONSOLE_LOGS`
+/// is an offload type, so the handler that mirrors the text only ever saw the rare console frame arriving
+/// outside a sync. Every line worth having — `PullStats`, `History burst success`, `Historical Dump
+/// Complete` — is emitted DURING a sync, and was routed past the code meant to surface it.
+///
+/// Nothing caught that, because nothing asserted the call site existed. Unit tests passed and app-build
+/// was green on a feature that could not fire. So this test reads the source: the two offload branches
+/// (WHOOP4 and 5/MG are separate paths) must each invoke the carve-out.
+@MainActor
+final class StrapConsoleMirrorTests: XCTestCase {
+
+    private func bleManagerSource() throws -> String {
+        // StrandTests/<this file> → repo root → Strand/BLE/BLEManager.swift
+        let here = URL(fileURLWithPath: #filePath)
+        let root = here.deletingLastPathComponent().deletingLastPathComponent()
+        let url = root.appendingPathComponent("Strand/BLE/BLEManager.swift")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// Both offload branches must mirror the console, or one family goes silent mid-sync — which is the
+    /// exact shape of the original defect, just per-family instead of everywhere.
+    func testBothOffloadBranchesMirrorTheStrapConsole() throws {
+        let src = try bleManagerSource()
+        let calls = src.components(separatedBy: "router.mirrorStrapConsoleIfPresent(frame: frame)").count - 1
+        XCTAssertEqual(calls, 2,
+                       "expected the console carve-out in BOTH offload branches (WHOOP4 + 5/MG); "
+                       + "found \(calls). Without it the strap's narration is dropped for that family "
+                       + "during exactly the sync it describes.")
+    }
+
+    /// The carve-out has to sit INSIDE the offload branch, beside the gesture one. If it drifted out to
+    /// the live path it would compile, pass the count check above, and still never fire during a sync.
+    func testTheCarveOutSitsBesideTheLiveGestureOne() throws {
+        let src = try bleManagerSource()
+        for part in src.components(separatedBy: "router.mirrorStrapConsoleIfPresent(frame: frame)").dropLast() {
+            let tail = String(part.suffix(400))
+            XCTAssertTrue(tail.contains("dispatchLiveGestureIfFresh"),
+                          "each console carve-out must sit with the live-gesture carve-out inside the "
+                          + "offload branch; one appears to have drifted to the live path, where it is "
+                          + "redundant with `handle` and silent during a sync")
+        }
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5955,8 +5955,15 @@ class WhoopBleClient(
                     // frame. Family-aware, so it's correct for WHOOP4 and 5/MG alike.
                     val parsed = Framing.parseFrame(frame, connectedFamily)
                     // A frame replayed as part of the historical offload (type 47/48/… during a backfill)
-                    // must not drive LIVE-only state (the charging pill). Mirrors iOS, where the offload
-                    // path skips the live router entirely. (PR #568 reimpl)
+                    // must not drive LIVE-only state (the charging pill). (PR #568 reimpl)
+                    //
+                    // NOT the same shape as iOS, despite what this said before. THIS side calls the handler
+                    // for EVERY frame and gates only the live-only effects; iOS skips the router outright
+                    // for offload frames and carves out the few things that must still fire (a live
+                    // gesture, and now the strap's console narration). Same outcome for the charging pill,
+                    // opposite structure — so a reader porting behaviour either way has to check which
+                    // frames reach the handler at all, not assume it matches. That assumption is exactly
+                    // how the console mirror shipped dead on iOS: decoded, keyed correctly, never called.
                     handleFrame(frame, parsed, replayedOffload = offloadFrame)
 
                     // Capture the strap's newest stored record from a GET_DATA_RANGE reply, feeding

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -6487,7 +6487,7 @@ class WhoopBleClient(
                 // The 5/MG strap narrates its own sync engine here ("BLE: PullStats: Data: N…",
                 // "RTC timestamp … is invalid") — gold for protocol research, so mirror it into the
                 // strap log (capped; the ring buffer holds 2k lines). (#78 fork)
-                (parsed.parsed["console"] as? String)?.let { txt ->
+                (parsed.parsed["log"] as? String)?.let { txt ->
                     log("strap: ${txt.take(300)}")
                 }
             }

--- a/android/app/src/main/java/com/noop/protocol/Framing.kt
+++ b/android/app/src/main/java/com/noop/protocol/Framing.kt
@@ -410,7 +410,10 @@ object Framing {
         val text = frame.copyOfRange(21, payEnd)
             .toString(Charsets.UTF_8)
             .trimEnd('\u0000')
-        if (text.isNotEmpty()) parsed["console"] = text.take(2048)
+        // Key "log", not "console": the Python reference decoder golden.json is generated from uses
+        // "log", and Swift matches it under a parity guard. This side was the odd one out, which is
+        // how the Apple consumer ported from here read the wrong key and silently found nothing.
+        if (text.isNotEmpty()) parsed["log"] = text.take(2048)
     }
 
     /**

--- a/android/app/src/main/java/com/noop/protocol/Framing.kt
+++ b/android/app/src/main/java/com/noop/protocol/Framing.kt
@@ -312,6 +312,12 @@ object Framing {
             "METADATA" -> decodeMetadataWhoop5(frame, parsed)
             "EVENT" -> decodeEventWhoop5(frame, parsed)
             "COMMAND_RESPONSE" -> decodeCommandResponseWhoop5(frame, parsed)
+            // WHOOP 5/MG ONLY, and that is a gap rather than a decision. Swift decodes the 4.0 console
+            // layout too (`PostHooks`, offsets 11..len-1, pinned by a test on real 4.0 text), so after the
+            // Apple consumer was wired up a WHOOP 4.0 narrates into an iOS strap log and stays silent in an
+            // Android one — the same defect this fixed on Apple, mirrored onto the other strap. Left for a
+            // follow-up rather than smuggled in here: it needs the 4.0 offsets and its own vector, and this
+            // change is already about a key three implementations disagreed on.
             "CONSOLE_LOGS" -> decodeConsoleLogsWhoop5(frame, parsed)
             else -> Unit
         }

--- a/android/app/src/test/java/com/noop/protocol/FramingTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/FramingTest.kt
@@ -509,7 +509,7 @@ class FramingTest {
         val parsed = Framing.parseFrame(frame, DeviceFamily.WHOOP5)
         assertEquals("CONSOLE_LOGS", parsed.typeName)
         assertEquals(true, parsed.crcOk)
-        assertEquals("Historical Data\n 55, 2581959: BLE: hist transfer s", parsed.parsed["console"])
+        assertEquals("Historical Data\n 55, 2581959: BLE: hist transfer s", parsed.parsed["log"])
         // Record header (Swift parity: decodeWhoop5ConsoleLogs): per-chunk counter + batch time.
         assertEquals(671, parsed.parsed["record_index"])
         assertEquals(1773607251, parsed.parsed["unix"])
@@ -538,8 +538,8 @@ class FramingTest {
         assertEquals(true, b.crcOk)
         assertEquals(685, a.parsed["record_index"])
         assertEquals(686, b.parsed["record_index"])
-        assertEquals("19, 146552119: BLE: hist transfer start response a", a.parsed["console"])
-        assertEquals("ck, start burst\n 19, 146554630: BLE: History burst", b.parsed["console"])
+        assertEquals("19, 146552119: BLE: hist transfer start response a", a.parsed["log"])
+        assertEquals("ck, start burst\n 19, 146554630: BLE: History burst", b.parsed["log"])
     }
 
     // MARK: - CONSOLE_LOGS text-region hardening edges (synthetic frames, Swift parity)
@@ -565,7 +565,7 @@ class FramingTest {
     fun whoop5_consoleLogs_oversizedTextCappedAt2048() {
         val f = consoleFrame(ByteArray(2100) { 'A'.code.toByte() })
         val p = Framing.parseFrame(f, DeviceFamily.WHOOP5)
-        assertEquals(2048, (p.parsed["console"] as String).length)
+        assertEquals(2048, (p.parsed["log"] as String).length)
     }
 
     /** An all-NUL (padding-only) text region trims to empty -> no `console` key, not an empty string. */
@@ -573,7 +573,7 @@ class FramingTest {
     fun whoop5_consoleLogs_allNulRegionYieldsNoConsole() {
         val f = consoleFrame(ByteArray(6))
         val p = Framing.parseFrame(f, DeviceFamily.WHOOP5)
-        assertNull(p.parsed["console"])
+        assertNull(p.parsed["log"])
     }
 
     /** Only TRAILING NULs are trimmed; the text before them is kept verbatim. */
@@ -581,6 +581,6 @@ class FramingTest {
     fun whoop5_consoleLogs_trailingNulsTrimmed() {
         val f = consoleFrame("AB".toByteArray() + byteArrayOf(0, 0, 0))
         val p = Framing.parseFrame(f, DeviceFamily.WHOOP5)
-        assertEquals("AB", p.parsed["console"])
+        assertEquals("AB", p.parsed["log"])
     }
 }


### PR DESCRIPTION
**An Apple strap log has never carried a word of what the strap says about itself.**

The 5/MG narrates its own sync engine over `CONSOLE_LOGS` (type 50):

```
BLE: PullStats: Data: 594, Events: 32, Bytes: 76996, Seconds: 6.500
BLE: History burst success. Trim: 0x0000000d:0001aed6 (13:110294)
BLE: Historical Dump Complete
```

Android has mirrored that into the strap log since #78 and its comment calls it *"gold for protocol
research"*. This side decoded the text and discarded it.

## It's worth more than curiosity

**`PullStats: Data: 0` is the *strap* stating it sent no records.** That is a far stronger answer to a
"synced but no data" report (#1683) than NOOP inferring emptiness from its own decode — the difference
between the strap saying nothing was there and us saying we found nothing. Every such report from an
iPhone has been diagnosed without it.

## Why it was silent

Three implementations decode this field and one disagreed:

| | key |
|---|---|
| Python reference (`golden.json` is generated from it) | `log` |
| Swift decoders (both), under a parity guard | `log` |
| Kotlin | **`console`** |

So a consumer ported from the Android side reads `"console"`, gets `nil` on Apple, and logs nothing —
no error, no warning, just silence.

Kotlin now uses `log` too, so all three agree.

**I tried it the other way first.** I aligned Swift onto Kotlin's `"console"`, because the Swift doc
comment claimed that was the shared name. `ParityTests.testSwiftMatchesPythonGolden` caught it
immediately — the doc was wrong *and* so was my direction. The comment now states which key it is and
why, rather than asserting a match nobody had checked.

## How it was found

Decoding a real WHOOP 5.0 HCI capture ([digitalerdude's, for #103](https://github.com/digitalerdude/noop/releases/tag/whoop5-hci-capture-2026-07-10))
with our own `whoop-decode`: **293 `CONSOLE_LOGS` frames reassemble into 164 lines of firmware
narration**, and none of it would reach an iOS user's log. The text is clean of PII — no MAC, email,
serial, or long hex id.

## Verification

- Swift package: **642 tests, 0 failures** (the parity guard is the one that steered this).
- Android: **4613 tests, 0 failures**.
- `doc_comment_lint` OK.
- `FrameRouter.swift` is app-target Swift with no default CI, so **app-build was dispatched**.

Output is capped at 300 characters per line to match the Kotlin twin exactly.

## Type of change

- [x] Bug fix — a decoded diagnostic that never reached the log on one platform

## Checklist

- [x] Swift package tests pass (`swift test` in `Packages/WhoopProtocol`)
- [x] Android unit tests pass
- [x] Cross-platform: all three decoders now agree on the key
- [x] No new UI copy; no hardcoded hex frame bytes; no generated artifacts
