### PR TITLE
test(protocol): the v18 R-R cross-check asserted on literals and could not fail

### DIFF
--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5HistoricalTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5HistoricalTests.swift
@@ -51,10 +51,15 @@ final class Whoop5HistoricalTests: XCTestCase {
         XCTAssertEqual((gx * gx + gy * gy + gz * gz).squareRoot(), 1.0, accuracy: 0.05)
 
         // Physiological cross-check: 60000 / mean(R-R) ≈ heart_rate — read from the PARSE, not from
-        // literals. It used to compute `Double(602 + 613) / 2.0` against a literal 102, which is a
-        // constant expression: it could not fail, and could not detect a wrong offset or a wrong width,
-        // while reading as though the decoder's R-R was checked against its own HR. Same shape as the
-        // WHOOP 4.0 test next door, which always did it properly.
+        // literals. It used to compute `Double(602 + 613) / 2.0` against a literal 102, a constant
+        // expression that could not fail. Same shape as the WHOOP 4.0 test next door.
+        //
+        // Be precise about what this adds, because the pins above already fix both values: a wrong
+        // offset or width fails `rr_intervals` / `heart_rate` FIRST, so this catches nothing the pins
+        // do not. What it guards is the PINS THEMSELVES. If a decoder change is "fixed" by regenerating
+        // the expected values until they are green — the usual way a golden stops meaning anything —
+        // this fails unless the new values are still physiologically coherent. That is a check on the
+        // maintenance of the test, not on the decode, and it is the one the literal form could not make.
         //
         // The tolerance does NOT discriminate UNITS, and tightening it will not make it. #1505 asked
         // whether v18 R-R is milliseconds or 1/1024-s ticks — the two readings differ by 2.4%, which at

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5HistoricalTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5HistoricalTests.swift
@@ -78,6 +78,10 @@ final class Whoop5HistoricalTests: XCTestCase {
         // anything tighter fails on CORRECT data. And it must stay far below the ~96 bpm a misread
         // offset or width produces, or it stops being a sanity check. Do not tighten it to look
         // stricter: the next value down fails the very frame this test decodes.
+        // Fitted to THIS record, not a general invariant. The repo's other real v18 vector
+        // (`secondDeviceHR63` in the Kotlin suite: hr 63, a single interval of 1020) computes 58.8 bpm,
+        // an error of 4.18 — so copying this assertion onto that frame fails at this tolerance, and the
+        // right response there is a wider bound with its own justification, not a wider bound here.
         XCTAssertEqual(60000.0 / meanRR, Double(hr), accuracy: 4)
     }
 

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5HistoricalTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5HistoricalTests.swift
@@ -72,6 +72,12 @@ final class Whoop5HistoricalTests: XCTestCase {
         XCTAssertFalse(rr.isEmpty, "no R-R decoded — the cross-check below would be vacuous")
         let meanRR = Double(rr.reduce(0, +)) / Double(rr.count)
         let hr = f.parsed["heart_rate"]?.intValue ?? 0
+        // Tolerance 4, and it is bounded from BOTH sides rather than picked. It must exceed 3.2, which
+        // is this record's real error under the shipped reading (98.8 against a heart_rate of 102) — a
+        // two-beat sample against a rate averaged over the record simply differs by that much, so
+        // anything tighter fails on CORRECT data. And it must stay far below the ~96 bpm a misread
+        // offset or width produces, or it stops being a sanity check. Do not tighten it to look
+        // stricter: the next value down fails the very frame this test decodes.
         XCTAssertEqual(60000.0 / meanRR, Double(hr), accuracy: 4)
     }
 

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5HistoricalTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5HistoricalTests.swift
@@ -50,9 +50,24 @@ final class Whoop5HistoricalTests: XCTestCase {
         let gz = f.parsed["gravity_z"]?.doubleValue ?? 0
         XCTAssertEqual((gx * gx + gy * gy + gz * gz).squareRoot(), 1.0, accuracy: 0.05)
 
-        // R-R is internally consistent with the heart rate (60000 / mean(R-R) ≈ bpm).
-        let meanRR = Double(602 + 613) / 2.0
-        XCTAssertEqual(60000.0 / meanRR, 102, accuracy: 8)
+        // Physiological cross-check: 60000 / mean(R-R) ≈ heart_rate — read from the PARSE, not from
+        // literals. It used to compute `Double(602 + 613) / 2.0` against a literal 102, which is a
+        // constant expression: it could not fail, and could not detect a wrong offset or a wrong width,
+        // while reading as though the decoder's R-R was checked against its own HR. Same shape as the
+        // WHOOP 4.0 test next door, which always did it properly.
+        //
+        // The tolerance does NOT discriminate UNITS, and tightening it will not make it. #1505 asked
+        // whether v18 R-R is milliseconds or 1/1024-s ticks — the two readings differ by 2.4%, which at
+        // this heart rate is ~2.5 bpm, while a two-beat sample legitimately varies more than that against
+        // a heart_rate averaged over the record. On this record the ms reading is the WORSE fit (98.8 vs
+        // 101.1 bpm), so any tolerance admitting the shipped behaviour admits the alternative too.
+        // The units question was settled from 151 real multi-interval v18 records in an HCI capture,
+        // where ms fits better on 86% — not from here, and this check should not be read as evidence.
+        let rr = f.parsed["rr_intervals"]?.intArrayValue ?? []
+        XCTAssertFalse(rr.isEmpty, "no R-R decoded — the cross-check below would be vacuous")
+        let meanRR = Double(rr.reduce(0, +)) / Double(rr.count)
+        let hr = f.parsed["heart_rate"]?.intValue ?? 0
+        XCTAssertEqual(60000.0 / meanRR, Double(hr), accuracy: 4)
     }
 
     func testHistoricalV18BiometricFields() {

--- a/android/app/src/test/java/com/noop/protocol/Whoop5HistoricalDecodeTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5HistoricalDecodeTest.kt
@@ -54,6 +54,10 @@ class Whoop5HistoricalDecodeTest {
         val rr = p["rr_intervals"] as List<Int>
         assertTrue("no R-R decoded — the cross-check below would be vacuous", rr.isNotEmpty())
         val meanRr = rr.sum().toDouble() / rr.size
+        // Delta 4.0, bounded from both sides rather than picked: it must exceed this record's real
+        // 3.2 bpm error under the shipped reading (a two-beat sample against an averaged heart_rate
+        // differs by that much, so anything tighter fails on CORRECT data), and stay well below the
+        // ~96 bpm a misread offset produces. Do not tighten it to look stricter.
         assertEquals((p["heart_rate"] as Int).toDouble(), 60_000.0 / meanRr, 4.0)
 
         val gx = p["gravity_x"] as Double

--- a/android/app/src/test/java/com/noop/protocol/Whoop5HistoricalDecodeTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5HistoricalDecodeTest.kt
@@ -39,6 +39,19 @@ class Whoop5HistoricalDecodeTest {
         assertEquals(2, p["rr_count"])
         assertEquals(listOf(602, 613), p["rr_intervals"])
 
+        // Physiological cross-check: 60000 / mean(R-R) ≈ heart_rate, from the PARSE rather than literals.
+        // Twin of the Swift `testHistoricalV18HeartRateRRAndGravity` check, which this side never had —
+        // so a wrong v18 R-R offset or width would have been caught on one platform only.
+        //
+        // It does NOT discriminate UNITS and tightening it will not make it: milliseconds and 1/1024-s
+        // ticks differ by 2.4% (~2.5 bpm here), less than a two-beat sample varies against a heart_rate
+        // averaged over the record. See the Swift twin for why, and where the units question was settled.
+        @Suppress("UNCHECKED_CAST")
+        val rr = p["rr_intervals"] as List<Int>
+        assertTrue("no R-R decoded — the cross-check below would be vacuous", rr.isNotEmpty())
+        val meanRr = rr.sum().toDouble() / rr.size
+        assertEquals((p["heart_rate"] as Int).toDouble(), 60_000.0 / meanRr, 4.0)
+
         val gx = p["gravity_x"] as Double
         val gy = p["gravity_y"] as Double
         val gz = p["gravity_z"] as Double

--- a/android/app/src/test/java/com/noop/protocol/Whoop5HistoricalDecodeTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5HistoricalDecodeTest.kt
@@ -58,6 +58,10 @@ class Whoop5HistoricalDecodeTest {
         // 3.2 bpm error under the shipped reading (a two-beat sample against an averaged heart_rate
         // differs by that much, so anything tighter fails on CORRECT data), and stay well below the
         // ~96 bpm a misread offset produces. Do not tighten it to look stricter.
+        // Fitted to THIS record, not a general invariant. `secondDeviceHR63` below (hr 63, a single
+        // interval of 1020) computes 58.8 bpm, an error of 4.18 — so copying this assertion onto that
+        // frame fails at this tolerance. A single interval against an averaged rate is simply noisier;
+        // widen it there with its own reason rather than loosening this one.
         assertEquals((p["heart_rate"] as Int).toDouble(), 60_000.0 / meanRr, 4.0)
 
         val gx = p["gravity_x"] as Double

--- a/android/app/src/test/java/com/noop/protocol/Whoop5HistoricalDecodeTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5HistoricalDecodeTest.kt
@@ -40,8 +40,12 @@ class Whoop5HistoricalDecodeTest {
         assertEquals(listOf(602, 613), p["rr_intervals"])
 
         // Physiological cross-check: 60000 / mean(R-R) ≈ heart_rate, from the PARSE rather than literals.
-        // Twin of the Swift `testHistoricalV18HeartRateRRAndGravity` check, which this side never had —
-        // so a wrong v18 R-R offset or width would have been caught on one platform only.
+        // Twin of the Swift `testHistoricalV18HeartRateRRAndGravity` check, which this side never had.
+        //
+        // The pins above already fix both values, so this catches nothing a wrong offset would not
+        // already trip. What it guards is the PINS: a decoder change "fixed" by regenerating the
+        // expected values until they pass has to produce numbers that are still physiologically
+        // coherent. See the Swift twin for the fuller note.
         //
         // It does NOT discriminate UNITS and tightening it will not make it: milliseconds and 1/1024-s
         // ticks differ by 2.4% (~2.5 bpm here), less than a two-beat sample varies against a heart_rate


### PR DESCRIPTION
Fell out of #1505 — which asks whether v18 historical R-R is milliseconds or 1/1024-s ticks — but this
part is true regardless of that answer.

## The check could not fail

```swift
// R-R is internally consistent with the heart rate (60000 / mean(R-R) ≈ bpm).
let meanRR = Double(602 + 613) / 2.0
XCTAssertEqual(60000.0 / meanRR, 102, accuracy: 8)
```

Both sides are **constants**. The expression cannot fail, and cannot detect a wrong offset, a wrong
width, or a wrong field — while reading as though the decoder's R-R were checked against its own HR.

The WHOOP 4.0 test next door has always done it properly, reading both values from the parse. And the
**Kotlin v18 test had no such check at all**, so even a real one would have guarded a single platform.

Both now read the parse, in the 4.0 test's shape.

## Falsified, not assumed

| decode | mean R-R | bpm | error | result |
|---|---|---|---|---|
| correct | 607.5 | 98.8 | 3.2 | passes |
| `rr_count` read as the first interval | 302.0 | 198.7 | 96.7 | **fails — caught** |
| halved field width | 303.5 | 197.7 | 95.7 | **fails — caught** |

## What it still cannot do — stated in both tests

The absence of this sentence is part of how #1505 arose, so it is now written where the next reader will
be standing.

**This does not discriminate units, and tightening the tolerance will not make it.** Milliseconds and
1/1024-s ticks differ by 2.4% — about 2.5 bpm at this heart rate — which is less than a two-beat sample
varies against a `heart_rate` averaged over the record. On this record the **shipped** ms reading is the
*worse* fit (98.8 against 101.1 bpm), so any tolerance admitting current behaviour admits the alternative
too.

The units question was settled elsewhere: 151 real multi-interval v18 records decoded out of an HCI
capture, where ms fits better on 86%. Not from here, and this check should not be cited as evidence
either way.

## Verification

- Swift package: **642 tests, 0 failures**
- Kotlin v18 suite: **19 tests, 0 failures**
- Tests and comments only — no decoder touched, so no behaviour change and no app-target Swift.

## Type of change

- [x] Bug fix — a test that asserted nothing

## Checklist

- [x] Swift package tests pass (`swift test` in `Packages/WhoopProtocol`)
- [x] Android unit tests pass
- [x] Cross-platform: the check now exists on both, in the same shape
- [x] No hardcoded hex frame bytes added; no generated artifacts
