### PR TITLE
ci: gates that never ran on the change they were written to catch

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,11 +12,27 @@ on:
     paths:
       - 'android/**'
       - '.github/workflows/android.yml'
+      # The twin-drift guards read the SWIFT side's fixtures on purpose — DecoderOracleTest compares
+      # against Packages/.../decoder_oracle.json to catch a one-sided edit, and the schema/protocol
+      # oracles work the same way. Without these, editing the Swift copy alone leaves the very test
+      # written to catch that from ever running. Keep this list in step with what the tests read.
+      - 'Packages/WhoopProtocol/Sources/WhoopProtocol/Resources/**'
+      - 'Packages/WhoopProtocol/Tests/WhoopProtocolTests/Resources/**'
+      - 'Packages/WhoopStore/Tests/WhoopStoreTests/Resources/**'
+      - 'Strand/Resources/Localizable.xcstrings'
   push:
     branches: [main]
     paths:
       - 'android/**'
       - '.github/workflows/android.yml'
+      # The twin-drift guards read the SWIFT side's fixtures on purpose — DecoderOracleTest compares
+      # against Packages/.../decoder_oracle.json to catch a one-sided edit, and the schema/protocol
+      # oracles work the same way. Without these, editing the Swift copy alone leaves the very test
+      # written to catch that from ever running. Keep this list in step with what the tests read.
+      - 'Packages/WhoopProtocol/Sources/WhoopProtocol/Resources/**'
+      - 'Packages/WhoopProtocol/Tests/WhoopProtocolTests/Resources/**'
+      - 'Packages/WhoopStore/Tests/WhoopStoreTests/Resources/**'
+      - 'Strand/Resources/Localizable.xcstrings'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/swift-packages.yml
+++ b/.github/workflows/swift-packages.yml
@@ -16,6 +16,11 @@ on:
       - 'Tools/SleepPSG/**'
       - 'Tools/Backfill/**'
       - '.github/workflows/swift-packages.yml'
+      # Mirror of the note in android.yml: package tests read the ANDROID oracles to catch a one-sided
+      # edit, and one reads Strand/Liquid/LiquidCore.swift. Editing only that side would otherwise skip
+      # the guard written for exactly that case. Keep in step with what the tests read.
+      - 'android/app/src/test/resources/**'
+      - 'Strand/Liquid/LiquidCore.swift'
   push:
     branches: [main]
     paths:
@@ -24,6 +29,11 @@ on:
       - 'Tools/SleepPSG/**'
       - 'Tools/Backfill/**'
       - '.github/workflows/swift-packages.yml'
+      # Mirror of the note in android.yml: package tests read the ANDROID oracles to catch a one-sided
+      # edit, and one reads Strand/Liquid/LiquidCore.swift. Editing only that side would otherwise skip
+      # the guard written for exactly that case. Keep in step with what the tests read.
+      - 'android/app/src/test/resources/**'
+      - 'Strand/Liquid/LiquidCore.swift'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/tools-python.yml
+++ b/.github/workflows/tools-python.yml
@@ -5,23 +5,26 @@
 # one of them only ever executed when a contributor remembered to, which meant a decoder could regress and
 # the suite that would have caught it stayed green by never being run.
 #
-# Cheap to run: pure stdlib `unittest`, no dependencies, no fixtures to fetch, ubuntu rather than macOS.
-# Path-filtered so it only fires when the suites it runs change.
+# Cheap to run: pure stdlib `unittest`, no dependencies, no fixtures to fetch, ubuntu rather than macOS —
+# about 25 seconds end to end.
+#
+# NOT path-filtered, and that is deliberate. It used to fire only on `Tools/**.py`, on the premise that a
+# suite can only break when its own source changes. That is false for `test_home_i18n.py`, which asserts
+# on the CONTENTS of app and package files — AppModel.swift, the xcstrings catalogues, ReadinessEngine,
+# DayNavBar. A Swift-only commit broke it (#1671 moved a sign and a hardcoded °C out of a localized
+# literal) and the filter meant this job never ran, so `main` sat red until a contributor touching
+# `Tools/` for something unrelated tripped over it in their own PR (#1691).
+#
+# Widening the filter to name those paths would just re-create the trap one edit later: the list is
+# whatever the assertions happen to read today. Twenty-five seconds on every PR is cheaper than a gate
+# that is green because it did not run.
 name: Tools Python CI
 
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'Tools/linux-capture/**'
-      - 'Tools/*.py'
-      - '.github/workflows/tools-python.yml'
   push:
     branches: [main]
-    paths:
-      - 'Tools/linux-capture/**'
-      - 'Tools/*.py'
-      - '.github/workflows/tools-python.yml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Three workflows were filtered to a subset of the files their tests actually read, so each one skipped the change it existed to catch. The first was found by a broken build on main; re-review found the other two, and they are the worse pair.

## The Tools gate (how this started)

`tools-python.yml` only ran on `Tools/**`. But `Tools/test_home_i18n.py` asserts on **33 paths across the repo** — the Compose screens, the SwiftUI views, the string catalogues. My own #1671 edited those screens, broke that test, and merged green; @Zebsi235 hit the failure and repaired it inside an unrelated PR.

Removed the filter outright. The job is ~25 seconds, and its real input surface is "most of the repo" — a path list that honest would cost more to maintain than the job costs to run.

## The twin-drift gates (the actual find)

This repo's parity mechanism is a set of tests that deliberately read **the other platform's** fixture. `DecoderOracleTest.kt` opens the Swift-side `decoder_oracle.json` and asserts both decoders produce identical output. Its comment states the intent plainly:

> Because the two decoders are independent reimplementations of the same byte layout, decoding the same fixture and asserting the same output is what catches a one-sided edit.

Neither gate fires on a one-sided edit.

| workflow | filtered to | reads, outside that |
|---|---|---|
| `android.yml` | `android/**` | `whoop_protocol.json`, `decoder_oracle.json`, `r20_optical_oracle.json`, `schema_oracle.json`, `Localizable.xcstrings` |
| `swift-packages.yml` | `Packages/**` + 3 `Tools/` dirs | `{decoder,r20_optical,schema}_oracle.json` under `android/`, `Strand/Liquid/LiquidCore.swift` |

Edit only the Swift oracle and the Android guard never runs. Edit only the Android oracle and the Swift one never runs. The tests were written, passing, and structurally unable to execute at the one moment they were for.

Both filters now name the cross-boundary fixtures.

## Why one was removed and two were widened

Cost. Tools is 25 seconds against a whole-repo surface, so a filter there is pointless and expensive to keep honest. `android.yml` is ~6 minutes and `swift-packages.yml` ~3, against a handful of named files each — naming five files is proportionate; a six-minute Android build on every Swift comment change is not.

The widened form has a real weakness and each file says so in a comment: the list has to track the assertions, and nothing enforces that. If a future test reaches for another cross-boundary file, this silently regresses. Removal is the only self-maintaining form, which is exactly why the cheap job got it.

## Verified

All three parse; `android.yml` goes 2 → 6 paths on both triggers, `swift-packages.yml` 5 → 7, `tools-python.yml` 5 → none.
