### PR TITLE
push: localize the destination errors the settings screen shows

### DIFF
--- a/android/app/src/main/java/com/noop/push/PushEndpointPolicy.kt
+++ b/android/app/src/main/java/com/noop/push/PushEndpointPolicy.kt
@@ -9,31 +9,48 @@ import java.util.Locale
 
 /** Security boundary for the user-supplied destination. Validation happens before DNS or HTTP. */
 object PushEndpointPolicy {
-    data class ValidEndpoint(val url: String, val host: String, val requiresLocalAddress: Boolean)
+    data class ValidEndpoint(val url: String, val host: String)
+
+    /**
+     * Why a destination was refused. A code rather than a sentence: [validate] has no Context, and
+     * the message is user-facing, so the wording is resolved against string resources at the call
+     * site the same way [pushFailureMessage] resolves the transport failure taxonomy.
+     */
+    enum class Problem {
+        MALFORMED_URL,
+        MISSING_SCHEME,
+        UNSUPPORTED_SCHEME,
+        USER_INFO_NOT_ALLOWED,
+        FRAGMENT_NOT_ALLOWED,
+        MISSING_HOST,
+        INVALID_HOST,
+        INVALID_PORT,
+        HTTP_REQUIRES_LOCAL_ADDRESS,
+    }
 
     sealed interface Result {
         data class Valid(val endpoint: ValidEndpoint) : Result
-        data class Invalid(val reason: String) : Result
+        data class Invalid(val problem: Problem) : Result
     }
 
     fun validate(raw: String): Result {
         val uri = runCatching { URI(raw.trim()) }.getOrNull()
-            ?: return Result.Invalid("Enter a valid URL.")
+            ?: return Result.Invalid(Problem.MALFORMED_URL)
         val scheme = uri.scheme?.lowercase(Locale.ROOT)
-            ?: return Result.Invalid("The URL needs http:// or https://.")
-        if (scheme != "http" && scheme != "https") return Result.Invalid("Only HTTP and HTTPS are supported.")
-        if (uri.rawUserInfo != null) return Result.Invalid("User names and passwords are not allowed in the URL.")
-        if (uri.rawFragment != null) return Result.Invalid("URL fragments are not allowed.")
+            ?: return Result.Invalid(Problem.MISSING_SCHEME)
+        if (scheme != "http" && scheme != "https") return Result.Invalid(Problem.UNSUPPORTED_SCHEME)
+        if (uri.rawUserInfo != null) return Result.Invalid(Problem.USER_INFO_NOT_ALLOWED)
+        if (uri.rawFragment != null) return Result.Invalid(Problem.FRAGMENT_NOT_ALLOWED)
         val rawHost = uri.host?.removePrefix("[")?.removeSuffix("]")?.lowercase(Locale.ROOT)
-            ?: return Result.Invalid("The URL needs a host.")
+            ?: return Result.Invalid(Problem.MISSING_HOST)
         val asciiHost = if (':' in rawHost) rawHost else runCatching { IDN.toASCII(rawHost) }.getOrNull()
-            ?: return Result.Invalid("The URL host is invalid.")
-        if (uri.port !in -1..65535) return Result.Invalid("The URL port is invalid.")
+            ?: return Result.Invalid(Problem.INVALID_HOST)
+        if (uri.port !in -1..65535) return Result.Invalid(Problem.INVALID_PORT)
 
         val literal = parseLiteralAddress(asciiHost)
         val literalAllowed = literal?.let(::isLocalAddress) == true
         if (scheme == "http" && !literalAllowed) {
-            return Result.Invalid("Plain HTTP requires a numeric local or private IP address.")
+            return Result.Invalid(Problem.HTTP_REQUIRES_LOCAL_ADDRESS)
         }
 
         val defaultPort = (scheme == "https" && uri.port == 443) || (scheme == "http" && uri.port == 80)
@@ -44,7 +61,7 @@ object PushEndpointPolicy {
             append(scheme).append("://").append(authority).append(path)
             uri.rawQuery?.let { append('?').append(it) }
         }
-        return Result.Valid(ValidEndpoint(normalized, asciiHost, scheme == "http"))
+        return Result.Valid(ValidEndpoint(normalized, asciiHost))
     }
 
     internal fun isLocalAddress(address: InetAddress): Boolean {

--- a/android/app/src/main/java/com/noop/push/PushFailure.kt
+++ b/android/app/src/main/java/com/noop/push/PushFailure.kt
@@ -122,6 +122,27 @@ internal fun classifyPushTransportFailure(throwable: Throwable): PushFailure {
     return PushFailure(code)
 }
 
+/**
+ * Wording for a refused destination. Kept beside [pushFailureMessage] so both user-facing message
+ * taxonomies resolve the same way; [PushEndpointPolicy] itself stays free of Android types.
+ */
+internal fun pushEndpointProblemMessage(
+    context: Context,
+    problem: PushEndpointPolicy.Problem,
+): String = when (problem) {
+    PushEndpointPolicy.Problem.MALFORMED_URL -> context.getString(R.string.push_endpoint_error_malformed)
+    PushEndpointPolicy.Problem.MISSING_SCHEME -> context.getString(R.string.push_endpoint_error_missing_scheme)
+    PushEndpointPolicy.Problem.UNSUPPORTED_SCHEME ->
+        context.getString(R.string.push_endpoint_error_unsupported_scheme)
+    PushEndpointPolicy.Problem.USER_INFO_NOT_ALLOWED -> context.getString(R.string.push_endpoint_error_user_info)
+    PushEndpointPolicy.Problem.FRAGMENT_NOT_ALLOWED -> context.getString(R.string.push_endpoint_error_fragment)
+    PushEndpointPolicy.Problem.MISSING_HOST -> context.getString(R.string.push_endpoint_error_missing_host)
+    PushEndpointPolicy.Problem.INVALID_HOST -> context.getString(R.string.push_endpoint_error_invalid_host)
+    PushEndpointPolicy.Problem.INVALID_PORT -> context.getString(R.string.push_endpoint_error_invalid_port)
+    PushEndpointPolicy.Problem.HTTP_REQUIRES_LOCAL_ADDRESS ->
+        context.getString(R.string.push_endpoint_error_http_requires_local)
+}
+
 internal fun pushFailureMessage(context: Context, failure: PushFailure): String {
     val base = when (failure.code) {
         PushFailureCode.DNS_LOOKUP -> context.getString(R.string.push_error_dns)

--- a/android/app/src/main/java/com/noop/push/SelfHostedPushScheduler.kt
+++ b/android/app/src/main/java/com/noop/push/SelfHostedPushScheduler.kt
@@ -8,6 +8,7 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import androidx.work.await
+import com.noop.R
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CancellationException
@@ -130,7 +131,7 @@ object SelfHostedPushScheduler {
         val completion = PushEnqueueCompletion(
             settleFailure = {
                 PushRunSignal.releaseReservation(app, request.id.toString()) { pending ->
-                    if (!pending) settings.recordError("Push could not be queued.")
+                    if (!pending) settings.recordError(app.getString(R.string.push_error_enqueue_failed))
                 }
             },
             // A trigger coalesced while WorkManager's async Operation was in flight. Recreate it

--- a/android/app/src/main/java/com/noop/push/SelfHostedPushScreen.kt
+++ b/android/app/src/main/java/com/noop/push/SelfHostedPushScreen.kt
@@ -123,7 +123,8 @@ fun SelfHostedPushScreen() {
                     enabled = endpointValid && tokenAvailable,
                     onClick = {
                         when (val result = settings.saveEndpoint(endpoint)) {
-                            is PushEndpointPolicy.Result.Invalid -> validationMessage = result.reason
+                            is PushEndpointPolicy.Result.Invalid ->
+                                validationMessage = pushEndpointProblemMessage(context, result.problem)
                             is PushEndpointPolicy.Result.Valid -> {
                                 val destinationChanged = snapshot.endpoint?.url != result.endpoint.url
                                 endpoint = result.endpoint.url

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2519,6 +2519,16 @@
     <string name="push_state_complete">Aktuell</string>
     <string name="push_state_failed">Nach einem Fehler pausiert</string>
     <string name="push_settings_row_detail">Experimenteller Einweg-Export an einen von dir kontrollierten Endpunkt. Standardmäßig aus.</string>
+    <string name="push_endpoint_error_malformed">Gib eine gültige URL ein.</string>
+    <string name="push_endpoint_error_missing_scheme">Die URL benötigt http:// oder https://.</string>
+    <string name="push_endpoint_error_unsupported_scheme">Nur HTTP und HTTPS werden unterstützt.</string>
+    <string name="push_endpoint_error_user_info">Benutzernamen und Passwörter sind in der URL nicht erlaubt.</string>
+    <string name="push_endpoint_error_fragment">URL-Fragmente sind nicht erlaubt.</string>
+    <string name="push_endpoint_error_missing_host">Die URL benötigt einen Host.</string>
+    <string name="push_endpoint_error_invalid_host">Der URL-Host ist ungültig.</string>
+    <string name="push_endpoint_error_invalid_port">Der URL-Port ist ungültig.</string>
+    <string name="push_endpoint_error_http_requires_local">Einfaches HTTP erfordert eine numerische lokale oder private IP-Adresse.</string>
+    <string name="push_error_enqueue_failed">Push konnte nicht eingereiht werden.</string>
     <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">Schlaf außerhalb der neuen Zeiten wurde entfernt. NOOP erkennt ihn nicht erneut.</string>
     <string name="workout_action_pause">Pause</string>
     <string name="workout_action_resume">Fortsetzen</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2505,6 +2505,16 @@
     <string name="push_state_complete">Actualizado</string>
     <string name="push_state_failed">En pausa tras un error</string>
     <string name="push_settings_row_detail">Exportación unidireccional experimental a un endpoint que controlas. Desactivada de forma predeterminada.</string>
+    <string name="push_endpoint_error_malformed">Introduce una URL válida.</string>
+    <string name="push_endpoint_error_missing_scheme">La URL necesita http:// o https://.</string>
+    <string name="push_endpoint_error_unsupported_scheme">Solo se admiten HTTP y HTTPS.</string>
+    <string name="push_endpoint_error_user_info">No se permiten nombres de usuario ni contraseñas en la URL.</string>
+    <string name="push_endpoint_error_fragment">No se permiten fragmentos en la URL.</string>
+    <string name="push_endpoint_error_missing_host">La URL necesita un host.</string>
+    <string name="push_endpoint_error_invalid_host">El host de la URL no es válido.</string>
+    <string name="push_endpoint_error_invalid_port">El puerto de la URL no es válido.</string>
+    <string name="push_endpoint_error_http_requires_local">El HTTP simple requiere una dirección IP local o privada numérica.</string>
+    <string name="push_error_enqueue_failed">No se pudo poner el envío en cola.</string>
     <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">Se ha eliminado el sueño fuera del nuevo horario. NOOP no volverá a detectarlo.</string>
     <string name="workout_action_pause">Pausar</string>
     <string name="workout_action_resume">Reanudar</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2504,6 +2504,16 @@
     <string name="push_state_complete">À jour</string>
     <string name="push_state_failed">En pause après une erreur</string>
     <string name="push_settings_row_detail">Export expérimental à sens unique vers un point que vous contrôlez. Désactivé par défaut.</string>
+    <string name="push_endpoint_error_malformed">Saisissez une URL valide.</string>
+    <string name="push_endpoint_error_missing_scheme">L’URL doit commencer par http:// ou https://.</string>
+    <string name="push_endpoint_error_unsupported_scheme">Seuls HTTP et HTTPS sont pris en charge.</string>
+    <string name="push_endpoint_error_user_info">Les noms d’utilisateur et mots de passe ne sont pas autorisés dans l’URL.</string>
+    <string name="push_endpoint_error_fragment">Les fragments d’URL ne sont pas autorisés.</string>
+    <string name="push_endpoint_error_missing_host">L’URL doit comporter un hôte.</string>
+    <string name="push_endpoint_error_invalid_host">L’hôte de l’URL est invalide.</string>
+    <string name="push_endpoint_error_invalid_port">Le port de l’URL est invalide.</string>
+    <string name="push_endpoint_error_http_requires_local">Le HTTP simple exige une adresse IP locale ou privée numérique.</string>
+    <string name="push_error_enqueue_failed">Impossible de mettre l’envoi en file d’attente.</string>
     <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">Le sommeil en dehors des nouveaux horaires a été supprimé. NOOP ne le détectera plus.</string>
     <string name="workout_action_pause">Pause</string>
     <string name="workout_action_resume">Reprendre</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2510,6 +2510,16 @@
     <string name="push_state_complete">Aktualne</string>
     <string name="push_state_failed">Wstrzymano po błędzie</string>
     <string name="push_settings_row_detail">Eksperymentalny eksport jednokierunkowy do kontrolowanego endpointu. Domyślnie wyłączony.</string>
+    <string name="push_endpoint_error_malformed">Wprowadź prawidłowy adres URL.</string>
+    <string name="push_endpoint_error_missing_scheme">Adres URL musi zawierać http:// lub https://.</string>
+    <string name="push_endpoint_error_unsupported_scheme">Obsługiwane są tylko HTTP i HTTPS.</string>
+    <string name="push_endpoint_error_user_info">Nazwy użytkownika i hasła nie są dozwolone w adresie URL.</string>
+    <string name="push_endpoint_error_fragment">Fragmenty adresu URL nie są dozwolone.</string>
+    <string name="push_endpoint_error_missing_host">Adres URL musi zawierać host.</string>
+    <string name="push_endpoint_error_invalid_host">Host w adresie URL jest nieprawidłowy.</string>
+    <string name="push_endpoint_error_invalid_port">Port w adresie URL jest nieprawidłowy.</string>
+    <string name="push_endpoint_error_http_requires_local">Zwykły HTTP wymaga numerycznego lokalnego lub prywatnego adresu IP.</string>
+    <string name="push_error_enqueue_failed">Nie udało się dodać wysyłki do kolejki.</string>
     <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">Sen poza nowymi godzinami został usunięty. NOOP nie wykryje go ponownie.</string>
     <string name="workout_action_pause">Wstrzymaj</string>
     <string name="workout_action_resume">Wznów</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2498,6 +2498,16 @@
     <string name="push_state_complete">Atualizado</string>
     <string name="push_state_failed">Em pausa após um erro</string>
     <string name="push_settings_row_detail">Exportação unidirecional experimental para um endpoint que controla. Desativada por predefinição.</string>
+    <string name="push_endpoint_error_malformed">Introduza um URL válido.</string>
+    <string name="push_endpoint_error_missing_scheme">O URL precisa de http:// ou https://.</string>
+    <string name="push_endpoint_error_unsupported_scheme">Apenas HTTP e HTTPS são suportados.</string>
+    <string name="push_endpoint_error_user_info">Não são permitidos nomes de utilizador nem palavras-passe no URL.</string>
+    <string name="push_endpoint_error_fragment">Não são permitidos fragmentos no URL.</string>
+    <string name="push_endpoint_error_missing_host">O URL precisa de um host.</string>
+    <string name="push_endpoint_error_invalid_host">O host do URL é inválido.</string>
+    <string name="push_endpoint_error_invalid_port">A porta do URL é inválida.</string>
+    <string name="push_endpoint_error_http_requires_local">O HTTP simples requer um endereço IP local ou privado numérico.</string>
+    <string name="push_error_enqueue_failed">Não foi possível colocar o envio em fila.</string>
     <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">O sono fora dos novos horários foi removido. O NOOP não o voltará a detetar.</string>
     <string name="workout_action_pause">Pausar</string>
     <string name="workout_action_resume">Retomar</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2419,6 +2419,16 @@
     <string name="push_state_complete">已是最新</string>
     <string name="push_state_failed">出错后已暂停</string>
     <string name="push_settings_row_detail">向你控制的端点进行实验性单向导出。默认关闭。</string>
+    <string name="push_endpoint_error_malformed">请输入有效的网址。</string>
+    <string name="push_endpoint_error_missing_scheme">网址需要以 http:// 或 https:// 开头。</string>
+    <string name="push_endpoint_error_unsupported_scheme">仅支持 HTTP 和 HTTPS。</string>
+    <string name="push_endpoint_error_user_info">网址中不允许包含用户名和密码。</string>
+    <string name="push_endpoint_error_fragment">不允许使用网址片段。</string>
+    <string name="push_endpoint_error_missing_host">网址需要包含主机。</string>
+    <string name="push_endpoint_error_invalid_host">网址主机无效。</string>
+    <string name="push_endpoint_error_invalid_port">网址端口无效。</string>
+    <string name="push_endpoint_error_http_requires_local">纯 HTTP 需要使用数字形式的本地或专用 IP 地址。</string>
+    <string name="push_error_enqueue_failed">无法将推送加入队列。</string>
     <string name="l10n_sleep_screen_sleep_outside_the_new_times_was_6229881e">新时间范围之外的睡眠已移除。NOOP 不会再次检测到它。</string>
     <string name="workout_action_pause">暂停</string>
     <string name="workout_action_resume">继续</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -116,6 +116,16 @@
     <string name="push_state_complete">Up to date</string>
     <string name="push_state_failed">Paused after an error</string>
     <string name="push_settings_row_detail">Experimental one-way export to an endpoint you control. Off by default.</string>
+    <string name="push_endpoint_error_malformed">Enter a valid URL.</string>
+    <string name="push_endpoint_error_missing_scheme">The URL needs http:// or https://.</string>
+    <string name="push_endpoint_error_unsupported_scheme">Only HTTP and HTTPS are supported.</string>
+    <string name="push_endpoint_error_user_info">User names and passwords are not allowed in the URL.</string>
+    <string name="push_endpoint_error_fragment">URL fragments are not allowed.</string>
+    <string name="push_endpoint_error_missing_host">The URL needs a host.</string>
+    <string name="push_endpoint_error_invalid_host">The URL host is invalid.</string>
+    <string name="push_endpoint_error_invalid_port">The URL port is invalid.</string>
+    <string name="push_endpoint_error_http_requires_local">Plain HTTP requires a numeric local or private IP address.</string>
+    <string name="push_error_enqueue_failed">Push could not be queued.</string>
 
     <!-- More-page section headers (DISPLAY only; the stored expand/collapse key stays the English
          literal in MoreSectionPrefs so persistence and iOS parity are unaffected). -->

--- a/android/app/src/test/java/com/noop/push/PushEndpointPolicyTest.kt
+++ b/android/app/src/test/java/com/noop/push/PushEndpointPolicyTest.kt
@@ -1,7 +1,6 @@
 package com.noop.push
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -9,7 +8,6 @@ class PushEndpointPolicyTest {
     @Test fun httpsPublicEndpointIsAllowedAndNormalized() {
         val valid = PushEndpointPolicy.validate(" HTTPS://Example.COM:443/push ") as PushEndpointPolicy.Result.Valid
         assertEquals("https://example.com/push", valid.endpoint.url)
-        assertFalse(valid.endpoint.requiresLocalAddress)
     }
 
     @Test fun publicHttpIsRejectedBeforeAnyResolution() {
@@ -53,5 +51,27 @@ class PushEndpointPolicyTest {
             "http://192.168.1.2/push#secret",
             "not a url",
         ).forEach { assertTrue(it, PushEndpointPolicy.validate(it) is PushEndpointPolicy.Result.Invalid) }
+    }
+
+    /**
+     * The refusal code is what the settings screen turns into wording, so a shape silently mapping to
+     * the wrong one would show the user a message that does not match what they typed.
+     */
+    @Test fun eachRejectedShapeReportsItsOwnProblem() {
+        mapOf(
+            "http://192.168.1.2/push" to null,
+            "" to PushEndpointPolicy.Problem.MISSING_SCHEME,
+            "ftp://192.168.1.2/push" to PushEndpointPolicy.Problem.UNSUPPORTED_SCHEME,
+            "http://user:pass@192.168.1.2/push" to PushEndpointPolicy.Problem.USER_INFO_NOT_ALLOWED,
+            "http://192.168.1.2/push#secret" to PushEndpointPolicy.Problem.FRAGMENT_NOT_ALLOWED,
+            "https:///push" to PushEndpointPolicy.Problem.MISSING_HOST,
+            "http://example.com/push" to PushEndpointPolicy.Problem.HTTP_REQUIRES_LOCAL_ADDRESS,
+            "not a url" to PushEndpointPolicy.Problem.MALFORMED_URL,
+        ).forEach { (raw, expected) ->
+            when (val result = PushEndpointPolicy.validate(raw)) {
+                is PushEndpointPolicy.Result.Valid -> assertEquals(raw, null, expected)
+                is PushEndpointPolicy.Result.Invalid -> assertEquals(raw, expected, result.problem)
+            }
+        }
     }
 }

--- a/docs/PRIVACY_SECURITY.md
+++ b/docs/PRIVACY_SECURITY.md
@@ -70,29 +70,6 @@ networking anywhere in the app is the AI Coach (`Strand/AI/AICoach.swift` on the
 Swift side — macOS and iOS — `com.noop.ai.AiCoach` on Android), described in §1.1a,
 the Oura history import (`Strand/Oura/`, Swift-only — macOS and iOS), described in §1.1b,
 the update check, described in §1.1c, and the Android-only self-hosted push, described in §1.1d.
-#### 1.1c The update check
-
-NOOP is sideloaded on every platform — there is no App Store or Play Store to update it — so an install
-that is never told about a release simply runs an old build indefinitely. Two paths address that, and
-both read the **same** public endpoint: `https://api.github.com/repos/ryanbr/noop/releases/latest`.
-
-- **"Check for updates"** in Settings → About. Runs only when tapped. It has always existed;
-  it was previously undocumented here, which is why this section is new rather than merely amended.
-- **"Check automatically"**, beside it. At most once a day, after onboarding (and, on iOS, after the
-  Terms gate), NOOP reads that endpoint and — if a newer release exists — puts a row in the Updates
-  inbox. **On by default**, and switchable off, at which point it makes no request at all.
-
-What is sent: nothing. It is an unauthenticated `GET` of a public URL, carrying no identifier, no
-account, no device information and no biometric data. What comes back is a version number and the
-release notes. **It never installs anything** — on iOS no API permits that for a sideloaded app (see
-[docs/IOS.md](IOS.md)); the row tells you a release exists and where to get it.
-
-The request is a plain HTTPS call, so your IP address is visible to GitHub exactly as it would be if
-you opened the releases page in a browser. If that is not a trade you want, turn the toggle off; the
-manual button then remains the only way NOOP touches the network for this.
-
-Code: `Strand/System/UpdateChecker.swift` + `Strand/System/UpdateAvailability.swift` (Swift),
-`com.noop.update.UpdateCheck` + `com.noop.update.UpdateAvailability` (Android).
 
 The package manifests reference dependency *download* URLs that Swift Package Manager
 resolves at build time, never at runtime:
@@ -170,6 +147,30 @@ API — a one-time, foreground backfill you trigger yourself, not an ongoing bac
   disk in the clear.
 
 If you never build the lane in, your binary cannot call `ouraring.com` — the code is not there.
+
+### 1.1c The update check
+
+NOOP is sideloaded on every platform — there is no App Store or Play Store to update it — so an install
+that is never told about a release simply runs an old build indefinitely. Two paths address that, and
+both read the **same** public endpoint: `https://api.github.com/repos/ryanbr/noop/releases/latest`.
+
+- **"Check for updates"** in Settings → About. Runs only when tapped. It has always existed;
+  it was previously undocumented here, which is why this section is new rather than merely amended.
+- **"Check automatically"**, beside it. At most once a day, after onboarding (and, on iOS, after the
+  Terms gate), NOOP reads that endpoint and — if a newer release exists — puts a row in the Updates
+  inbox. **On by default**, and switchable off, at which point it makes no request at all.
+
+What is sent: nothing. It is an unauthenticated `GET` of a public URL, carrying no identifier, no
+account, no device information and no biometric data. What comes back is a version number and the
+release notes. **It never installs anything** — on iOS no API permits that for a sideloaded app (see
+[docs/IOS.md](IOS.md)); the row tells you a release exists and where to get it.
+
+The request is a plain HTTPS call, so your IP address is visible to GitHub exactly as it would be if
+you opened the releases page in a browser. If that is not a trade you want, turn the toggle off; the
+manual button then remains the only way NOOP touches the network for this.
+
+Code: `Strand/System/UpdateChecker.swift` + `Strand/System/UpdateAvailability.swift` (Swift),
+`com.noop.update.UpdateCheck` + `com.noop.update.UpdateAvailability` (Android).
 
 ### 1.1d Self-hosted push (Experimental, Android, off by default)
 


### PR DESCRIPTION
Follow-up to the self-hosted push feature, covering the two gaps noted when it merged plus one thing the merge made visible.

## Ten strings shipped as English in every locale

Nine `PushEndpointPolicy` refusals were rendered straight into a `Text()` under the endpoint field, and the scheduler's enqueue failure reached the same screen via `lastError` — inside an otherwise localized frame, which is the tell.

**The i18n gate passed on all ten.** `Tools/i18n_audit.py` only sees literals inside `@Composable` functions, and `PushEndpointPolicy` is a plain object. That blind spot has now hidden two separate regressions, so it is worth stating plainly rather than treating this as a one-off.

The seam already existed: `pushFailureMessage` resolves the entire transport failure taxonomy against `R.string.push_error_*`. These two paths just weren't using it. So `Result.Invalid` carries a `Problem` code instead of a sentence, and `pushEndpointProblemMessage` resolves it next to its sibling — which keeps the policy object free of Android types, the reason it held sentences in the first place.

A new test pins each rejected URL shape to its own code. The existing tests assert `is Invalid`, which cannot catch a shape mapping to the wrong message — the user would see wording that contradicts what they typed.

## `requiresLocalAddress` removed

It was set during validation and asserted once in a test, but nothing ever read it. A field named like that reads as a runtime guard, and there wasn't one.

The cleartext rule is enforced where it actually holds: `validate()` refuses plain HTTP unless the host is a numeric literal resolving to a local or private address. That is also why there is no DNS left to rebind, so the field had nothing to add.

## Privacy doc section order

The update check was documented as a `####` heading placed ahead of 1.1a. Once push landed as 1.1d the file read 1.1c, 1.1a, 1.1b, 1.1d. Moved into sequence and levelled to `###`. No wording changed — this is placement only.

## Verified

`testFullDebugUnitTest` with `--rerun-tasks --no-build-cache`: **4,709 tests, 0 failures**, and `PushEndpointPolicyTest` confirmed at 9 cases including the new one. `Tools/i18n_audit.py --ci main` clean. All seven `strings.xml` parse and each carries all ten keys.

Not covered: `lintVitalFullRelease` needs a keystore, so it is left to CI.
