### PR TITLE
analytics: say when a stream read came back at the cap

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SlidingStreamWindow.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SlidingStreamWindow.swift
@@ -47,8 +47,10 @@ public final class SlidingStreamWindow<T> {
     /// scored on an incomplete window. Diagnostic only, but unlike its siblings this one is a correctness
     /// signal rather than a savings one: a non-zero count means a number may be wrong, not merely slow.
     ///
-    /// A truncated EXTENSION that the branch below recovers by re-reading whole is deliberately NOT
-    /// counted — nothing was lost there, and counting it would cry wolf.
+    /// Counted per WINDOW that lost rows, not per pass: once a read is truncated the planner refuses to
+    /// splice at all, so each later window is a fresh full read and is judged on its own. The truncated-
+    /// EXTENSION branch below cannot add a second count for one window either, since it only ever re-reads
+    /// a SUPERSET of what already overran the cap. Pinned by `eachTruncatedWindowCountsSeparately`.
     public private(set) var truncatedReads = 0
 
     public init(tsOf: @escaping (T) -> Int, limit: Int, read: @escaping (String, Int, Int) async -> [T]?) {

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SlidingStreamWindow.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SlidingStreamWindow.swift
@@ -43,6 +43,13 @@ public final class SlidingStreamWindow<T> {
     public private(set) var rowsServed = 0
     /// Rows this window read from the store. Diagnostic only. Same width note as `rowsServed`.
     public private(set) var rowsRead = 0
+    /// Reads whose RESULT came back at the store's cap, so the newest rows were dropped and the day was
+    /// scored on an incomplete window. Diagnostic only, but unlike its siblings this one is a correctness
+    /// signal rather than a savings one: a non-zero count means a number may be wrong, not merely slow.
+    ///
+    /// A truncated EXTENSION that the branch below recovers by re-reading whole is deliberately NOT
+    /// counted — nothing was lost there, and counting it would cry wolf.
+    public private(set) var truncatedReads = 0
 
     public init(tsOf: @escaping (T) -> Int, limit: Int, read: @escaping (String, Int, Int) async -> [T]?) {
         self.tsOf = tsOf
@@ -97,6 +104,7 @@ public final class SlidingStreamWindow<T> {
         self.from = from
         self.to = to
         self.truncated = nowTruncated
+        if nowTruncated { truncatedReads += 1 }
         self.rows = result
         return result
     }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/WindowedStreamPlan.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/WindowedStreamPlan.swift
@@ -25,11 +25,25 @@ public enum WindowedStreamPlan {
     /// dayCache hit — and the reads are back to exactly what they were. That is the honest outcome rather
     /// than a silent one, which is why the counters ship rather than just the speedup.
     ///
+    /// `truncated` separates the one of those causes that is also a BUG. The reads are
+    /// `ORDER BY ts ASC LIMIT`, so a read at the cap drops the NEWEST rows and the day is scored on a
+    /// window missing its tail, with nothing else in the log to say so. A field log showed a strap at
+    /// 192,680 rows against the 200,000 cap — 96% — with `served` near zero on one stream and half on the
+    /// other, and no way to tell which cause fired. Hence this counter rather than a guess.
+    ///
     /// Lives HERE rather than on the engine so both platforms put it in the same place and both are
     /// covered by default CI — the Swift engine is app-target and has none. Byte-identical to the Kotlin
     /// `WindowedStreamPlan.logLine`.
-    public static func logLine(hrRead: Int, hrServed: Int, rrRead: Int, rrServed: Int) -> String {
-        "analyzeRecent windows hr[read=\(hrRead) served=\(hrServed)] rr[read=\(rrRead) served=\(rrServed)]"
+    public static func logLine(
+        hrRead: Int,
+        hrServed: Int,
+        hrTruncated: Int,
+        rrRead: Int,
+        rrServed: Int,
+        rrTruncated: Int
+    ) -> String {
+        "analyzeRecent windows hr[read=\(hrRead) served=\(hrServed) truncated=\(hrTruncated)] "
+            + "rr[read=\(rrRead) served=\(rrServed) truncated=\(rrTruncated)]"
     }
 
     /// What the caller should do to obtain rows for the requested window.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SlidingStreamWindowTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SlidingStreamWindowTests.swift
@@ -51,6 +51,33 @@ final class SlidingStreamWindowTests: XCTestCase {
 
     /// A truncated read cannot be sliced, because `ORDER BY ts ASC LIMIT` drops the NEWEST rows — the
     /// buffer would be missing its tail with nothing to say so.
+    /// The truncation counter is the one diagnostic here that means a SCORE may be wrong rather than
+    /// merely slow, so pin when it moves and when it does not. Twin of the Kotlin case of the same name.
+    func testTruncatedReadsCountsOnlyReadsThatLostRows() async {
+        let clean = window()
+        _ = await clean.rows(owner: "owner", from: midnight - h30, to: midnight + day)
+        XCTAssertEqual(clean.truncatedReads, 0, "a read under the cap lost nothing")
+
+        let capped = window(limit: 1_000)
+        _ = await capped.rows(owner: "owner", from: midnight - h30, to: midnight + day)
+        XCTAssertEqual(capped.truncatedReads, 1, "a read AT the cap dropped its newest rows")
+    }
+
+    /// Once a read is truncated the planner refuses to splice at all — `cachedTruncated` is its FIRST
+    /// guard — so every later window is a fresh full read. Each of those that is itself at the cap is a
+    /// separate lost tail and counts again: the number is windows-that-lost-rows, not passes.
+    ///
+    /// Deliberately NOT a test of the truncated-extension branch. That branch needs a buffer that is
+    /// valid but whose extension overruns the cap, and a truncated read can never leave a valid buffer,
+    /// so a uniform backward walk cannot reach it.
+    func testEachTruncatedWindowCountsSeparately() async {
+        let w = window(limit: 1_000)
+        _ = await w.rows(owner: "owner", from: midnight - h30, to: midnight + day)
+        let afterFirst = w.truncatedReads
+        _ = await w.rows(owner: "owner", from: midnight - day - h30, to: midnight)
+        XCTAssertEqual(w.truncatedReads, afterFirst + 1, "one increment per window that lost rows")
+    }
+
     func testTruncatedReadIsNeverSliced() async {
         let limit = 1_000
         let w = window(limit: limit)

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/WindowedStreamPlanTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/WindowedStreamPlanTests.swift
@@ -77,10 +77,13 @@ final class WindowedStreamPlanTests: XCTestCase {
     /// never asked".
     func testLogLine() {
         XCTAssertEqual(
-            WindowedStreamPlan.logLine(hrRead: 1_000, hrServed: 9_000, rrRead: 250, rrServed: 750),
-            "analyzeRecent windows hr[read=1000 served=9000] rr[read=250 served=750]")
+            WindowedStreamPlan.logLine(hrRead: 1_000, hrServed: 9_000, hrTruncated: 0,
+                                       rrRead: 250, rrServed: 750, rrTruncated: 3),
+            "analyzeRecent windows hr[read=1000 served=9000 truncated=0] "
+                + "rr[read=250 served=750 truncated=3]")
         XCTAssertEqual(
-            WindowedStreamPlan.logLine(hrRead: 0, hrServed: 0, rrRead: 0, rrServed: 0),
-            "analyzeRecent windows hr[read=0 served=0] rr[read=0 served=0]")
+            WindowedStreamPlan.logLine(hrRead: 0, hrServed: 0, hrTruncated: 0,
+                                       rrRead: 0, rrServed: 0, rrTruncated: 0),
+            "analyzeRecent windows hr[read=0 served=0 truncated=0] rr[read=0 served=0 truncated=0]")
     }
 }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1483,7 +1483,9 @@ final class IntelligenceEngine: ObservableObject {
             // rather than a silent one. Byte-identical to the Kotlin `analyzeWindowsLogLine`.
             skippedDayLines.append(WindowedStreamPlan.logLine(
                 hrRead: hrWindow.rowsRead, hrServed: hrWindow.rowsServed,
-                rrRead: rrWindow.rowsRead, rrServed: rrWindow.rowsServed))
+                hrTruncated: hrWindow.truncatedReads,
+                rrRead: rrWindow.rowsRead, rrServed: rrWindow.rowsServed,
+                rrTruncated: rrWindow.truncatedReads))
             return (out, skippedDayLines, dayScanCacheLocal)
         }.value
         // #1005: write the loop's updated reuse cache back to the (main-actor) stored property. The pass ran

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1277,7 +1277,12 @@ object IntelligenceEngine {
         // (each row materialised ~2.25x per pass) is worth narrowing; analyzeDay dominating means it is
         // not, whatever the row counts look like. Byte-identical line to the Swift twin.
         diag("analyzeRecent cost prep=${dayPrepNanos / 1_000_000}ms score=${dayScoreNanos / 1_000_000}ms")
-        diag(WindowedStreamPlan.logLine(hrWindow.rowsRead, hrWindow.rowsServed, rrWindow.rowsRead, rrWindow.rowsServed))
+        diag(
+            WindowedStreamPlan.logLine(
+                hrWindow.rowsRead, hrWindow.rowsServed, hrWindow.truncatedReads,
+                rrWindow.rowsRead, rrWindow.rowsServed, rrWindow.truncatedReads,
+            ),
+        )
 
         // ── Seed the baseline from the UNION of imported nightly history + the nightly
         // values just computed. This is the recovery fix: the "-noop" nightly avgHrv/

--- a/android/app/src/main/java/com/noop/analytics/SlidingStreamWindow.kt
+++ b/android/app/src/main/java/com/noop/analytics/SlidingStreamWindow.kt
@@ -58,6 +58,17 @@ class SlidingStreamWindow<T>(
         private set
 
     /**
+     * Reads whose RESULT came back at the store's cap, so the newest rows were dropped and the day was
+     * scored on an incomplete window. Diagnostic only, but unlike its siblings this one is a correctness
+     * signal rather than a savings one: a non-zero count means a number may be wrong, not merely slow.
+     *
+     * A truncated EXTENSION that the branch above recovers by re-reading whole is deliberately NOT
+     * counted — nothing was lost there, and counting it would cry wolf.
+     */
+    var truncatedReads = 0L
+        private set
+
+    /**
      * The rows for `[from, to]` under [owner], reading as little as the plan allows.
      *
      * The result is byte-for-byte what a direct `read(owner, from, to)` would have returned — that is the
@@ -107,6 +118,7 @@ class SlidingStreamWindow<T>(
         this.from = from
         this.to = to
         this.truncated = nowTruncated
+        if (nowTruncated) truncatedReads++
         this.rows = result
         return result
     }

--- a/android/app/src/main/java/com/noop/analytics/SlidingStreamWindow.kt
+++ b/android/app/src/main/java/com/noop/analytics/SlidingStreamWindow.kt
@@ -62,8 +62,10 @@ class SlidingStreamWindow<T>(
      * scored on an incomplete window. Diagnostic only, but unlike its siblings this one is a correctness
      * signal rather than a savings one: a non-zero count means a number may be wrong, not merely slow.
      *
-     * A truncated EXTENSION that the branch above recovers by re-reading whole is deliberately NOT
-     * counted — nothing was lost there, and counting it would cry wolf.
+     * Counted per WINDOW that lost rows, not per pass: once a read is truncated the planner refuses to
+     * splice at all, so each later window is a fresh full read and is judged on its own. The truncated-
+     * EXTENSION branch below cannot add a second count for one window either, since it only ever re-reads
+     * a SUPERSET of what already overran the cap. Pinned by `eachTruncatedWindowCountsSeparately`.
      */
     var truncatedReads = 0L
         private set

--- a/android/app/src/main/java/com/noop/analytics/WindowedStreamPlan.kt
+++ b/android/app/src/main/java/com/noop/analytics/WindowedStreamPlan.kt
@@ -28,11 +28,25 @@ object WindowedStreamPlan {
      * dayCache hit — and the reads are back to exactly what they were. That is the honest outcome rather
      * than a silent one, which is why the counters ship rather than just the speedup.
      *
+     * `truncated` separates the one of those causes that is also a BUG. The reads are
+     * `ORDER BY ts ASC LIMIT`, so a read at the cap drops the NEWEST rows and the day is scored on a
+     * window missing its tail, with nothing else in the log to say so. A field log showed a strap at
+     * 192,680 rows against the 200,000 cap — 96% — with `served` near zero on one stream and half on the
+     * other, and no way to tell which cause fired. Hence this counter rather than a guess.
+     *
      * Lives HERE rather than on the engine so both platforms put it in the same place and both are
      * covered by default CI. Byte-identical to the Swift `WindowedStreamPlan.logLine`.
      */
-    fun logLine(hrRead: Long, hrServed: Long, rrRead: Long, rrServed: Long): String =
-        "analyzeRecent windows hr[read=$hrRead served=$hrServed] rr[read=$rrRead served=$rrServed]"
+    fun logLine(
+        hrRead: Long,
+        hrServed: Long,
+        hrTruncated: Long,
+        rrRead: Long,
+        rrServed: Long,
+        rrTruncated: Long,
+    ): String =
+        "analyzeRecent windows hr[read=$hrRead served=$hrServed truncated=$hrTruncated] " +
+            "rr[read=$rrRead served=$rrServed truncated=$rrTruncated]"
 
     /** What the caller should do to obtain rows for the requested window. */
     sealed interface Plan {

--- a/android/app/src/test/java/com/noop/analytics/SlidingStreamWindowTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SlidingStreamWindowTest.kt
@@ -60,6 +60,37 @@ class SlidingStreamWindowTest {
     }
 
     /**
+     * The truncation counter is the one diagnostic here that means a SCORE may be wrong rather than
+     * merely slow, so pin when it moves and when it does not. Twin of the Swift case of the same name.
+     */
+    @Test fun truncatedReadsCountsOnlyReadsThatLostRows() = runBlocking {
+        val clean = window()
+        clean.rows("owner", midnight - h30, midnight + day)
+        assertEquals("a read under the cap lost nothing", 0L, clean.truncatedReads)
+
+        val capped = window(1_000)
+        capped.rows("owner", midnight - h30, midnight + day)
+        assertEquals("a read AT the cap dropped its newest rows", 1L, capped.truncatedReads)
+    }
+
+    /**
+     * Once a read is truncated the planner refuses to splice at all — `cachedTruncated` is its FIRST
+     * guard — so every later window is a fresh full read. Each of those that is itself at the cap is a
+     * separate lost tail and counts again: the number is windows-that-lost-rows, not passes.
+     *
+     * Deliberately NOT a test of the truncated-extension branch. That branch needs a buffer that is
+     * valid but whose extension overruns the cap, and a truncated read can never leave a valid buffer,
+     * so a uniform backward walk cannot reach it.
+     */
+    @Test fun eachTruncatedWindowCountsSeparately() = runBlocking {
+        val w = window(1_000)
+        w.rows("owner", midnight - h30, midnight + day)
+        val afterFirst = w.truncatedReads
+        w.rows("owner", midnight - day - h30, midnight)
+        assertEquals("one increment per window that lost rows", afterFirst + 1L, w.truncatedReads)
+    }
+
+    /**
      * A truncated read cannot be sliced, because `ORDER BY ts ASC LIMIT` drops the NEWEST rows — the
      * buffer would be missing its tail with nothing to say so. The next day must read in full and still
      * match a direct read at the same limit.

--- a/android/app/src/test/java/com/noop/analytics/WindowedStreamPlanTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/WindowedStreamPlanTest.kt
@@ -81,12 +81,13 @@ class WindowedStreamPlanTest {
      */
     @Test fun logLineShape() {
         assertEquals(
-            "analyzeRecent windows hr[read=1000 served=9000] rr[read=250 served=750]",
-            WindowedStreamPlan.logLine(1_000L, 9_000L, 250L, 750L),
+            "analyzeRecent windows hr[read=1000 served=9000 truncated=0] " +
+                "rr[read=250 served=750 truncated=3]",
+            WindowedStreamPlan.logLine(1_000L, 9_000L, 0L, 250L, 750L, 3L),
         )
         assertEquals(
-            "analyzeRecent windows hr[read=0 served=0] rr[read=0 served=0]",
-            WindowedStreamPlan.logLine(0L, 0L, 0L, 0L),
+            "analyzeRecent windows hr[read=0 served=0 truncated=0] rr[read=0 served=0 truncated=0]",
+            WindowedStreamPlan.logLine(0L, 0L, 0L, 0L, 0L, 0L),
         )
     }
 }


### PR DESCRIPTION
Found while reading a field strap log. Small, diagnostic-only, both platforms.

## The gap

The windows line already reports `read` and `served`. That log showed why it is not enough — one cold pass:

```
hr[read=1792781 served=1939063]    ← splicing ~half its rows
rr[read=3727610 served=93980]      ← splicing ~2.5%
```

Same cap, near-identical per-window demand, wildly different outcomes, and **no way to tell which of the three refusal causes fired** — truncation, an owner flip, or a gap left by a dayCache hit. I could not determine it from the log, and that is the instrumentation's fault, not the log's.

## Why truncation specifically

One of those three causes is also a bug. The reads are `ORDER BY ts ASC LIMIT`, so a read returning the cap has dropped its **newest** rows, and the day is then scored on a window missing its tail with nothing anywhere saying so.

The same log has that device at **192,680 rows against the 200,000 cap — 96%** — with `rawRows` still climbing across the day. So this is not hypothetical for that strap; it is a few weeks of data away.

The window already computes the fact (`nowTruncated`) in order to decide whether the buffer may be spliced. It just never reported it.

## The change

A counter beside `rowsRead`/`rowsServed`, and two fields on the line:

```
analyzeRecent windows hr[read=… served=… truncated=0] rr[read=… served=… truncated=17]
```

A truncated **extension** that the splice recovers by re-reading the window whole is deliberately **not** counted. Nothing is lost on that path, and counting it would cry wolf on the one number here that means a score may be wrong rather than merely slow.

Nothing on the scoring path moves — it is a counter, so it cannot change a number.

## Scope

This **detects**; it does not cure. Whether the answer is paginating past the cap or raising it should not be chosen before knowing whether truncation fires at all, and on which stream. Same order the REM funnel and the offload diagnostics were done in.

## Verified

Both twins live in `Packages/StrandAnalytics`, so both sides are covered by default CI — no app-build needed.

- 4,713 Android tests, 0 failures with `--rerun-tasks --no-build-cache`, including the `analyzeRecentOnCpu` bytecode budget guard (the call site grew, so that one matters here).
- Kotlin and Swift expected strings verified byte-identical, and the Swift `logLine` compiled standalone and printed exactly them.
- The Swift package suite cannot run in WSL (GRDB needs `sqlite3.h`), so that half rides on `swift-packages.yml` in this PR.
