### PR TITLE
build: order the Room schema snapshot after every KSP round, not just the test ones

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -208,8 +208,17 @@ val syncRoomSchemaSnapshot = tasks.register<Sync>("syncRoomSchemaSnapshot") {
     // variant's KSP round writes byte-identical JSON. Depending on all of them would make a single
     // `testFullDebugUnitTest` run four KSP rounds instead of one.
     dependsOn(tasks.matching { it.name == "kspFullDebugKotlin" })
-    // Unit-test KSP can clear the snapshot after Sync has copied it; order Sync after those tasks.
-    mustRunAfter(tasks.matching { it.name.startsWith("ksp") && it.name.contains("UnitTest") })
+    // Every KSP round writes `roomSchemaDir` — `room.schemaLocation` is set once, outside any variant
+    // block — so EVERY one of them is both a producer Sync must not race and a producer Gradle expects
+    // a declared relationship with. This was scoped to the UnitTest rounds, which covered the observed
+    // hazard (unit-test KSP clearing the snapshot after Sync copied it) but left `kspFullReleaseKotlin`
+    // out. It is normally absent from the graph; pull it in — `lintVitalFullRelease` in the same
+    // invocation as the debug test tasks does — and Gradle fails the build for an undeclared
+    // producer/consumer pair, with an error that reads like a Room problem (#1711).
+    //
+    // Ordering only, so nothing is forced to execute and the one-variant `dependsOn` above keeps its
+    // point: a `testFullDebugUnitTest` run still triggers exactly one KSP round.
+    mustRunAfter(tasks.matching { it.name.startsWith("ksp") && it.name.endsWith("Kotlin") })
 }
 
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
Addresses #1711. One line, plus the comment explaining why the old scope was too narrow.

## The cause

`room.schemaLocation` is set **once, outside any variant block** (`app/build.gradle.kts:160-162`), so **every** variant's KSP round writes that directory. `syncRoomSchemaSnapshot` reads it while declaring a relationship with only some of its producers:

```kotlin
dependsOn(tasks.matching { it.name == "kspFullDebugKotlin" })                                    // one variant
mustRunAfter(tasks.matching { it.name.startsWith("ksp") && it.name.contains("UnitTest") })       // some rounds
```

The `dependsOn` narrowness is deliberate and **stays** — the schema derives from the entities alone, so every round writes byte-identical JSON, and depending on all of them would cost four KSP rounds per test run.

The **ordering** line was the gap. It covered the hazard that had actually been observed (unit-test KSP clearing the snapshot after Sync copied it), but `kspFullReleaseKotlin` writes the same directory and wasn't covered. It's normally absent from the graph — which is why this never surfaced — but `lintVitalFullRelease` in the same invocation pulls it in, and Gradle then fails on the undeclared producer/consumer pair with an error that reads like a Room problem.

## The change

```kotlin
mustRunAfter(tasks.matching { it.name.startsWith("ksp") && it.name.endsWith("Kotlin") })
```

A **strict superset** of the old matcher — I checked name by name across the variant/test task names this project generates, and nothing the old pattern matched fails the new one. The original guard is intact.

## Verified, not reasoned

`mustRunAfter` silently forcing extra work is the regression worth fearing here, so it is measured rather than argued:

| check | result |
|---|---|
| previously-failing 3-task command | **BUILD SUCCESSFUL** (fails on main) |
| KSP rounds in that run | `kspFullDebugKotlin`, `kspFullDebugUnitTestKotlin`, `kspFullReleaseKotlin` — **once each** |
| plain `testFullDebugUnitTest` | only the debug + unit-test rounds, **no release round** |
| unit suite | 4,725 tests, 0 failures |

That third row is the one that matters: it is the exact property the neighbouring comment protects, and it holds.

## Parity

None required. Room/KSP schema generation is Android-only — there is no `room.schemaLocation` or generated-schema step on the Swift side. The `schema_oracle.json` fixture this pipeline feeds *does* have a byte-identical Swift twin read by `SchemaOracleTests`, but that is committed data and build wiring cannot affect it.
