### PR TITLE
build: name the KSP predicate the two schema rules share

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -160,6 +160,16 @@ val roomSchemaDir = layout.buildDirectory.dir("generated/roomSchemas")
 ksp {
     arg("room.schemaLocation", roomSchemaDir.get().asFile.absolutePath)
 }
+// Every KSP round for a Kotlin source set. Both users below start here and then diverge on the
+// UnitTest/AndroidTest rounds — in OPPOSITE directions, which is why this half is named rather than
+// spelled out twice:
+//   - [isMainSourceSetKspTask] EXCLUDES them, so Gradle is not told they output a directory they never
+//     write and then clears it out from under the round that did.
+//   - `syncRoomSchemaSnapshot`'s `mustRunAfter` INCLUDES them, because they still race the Sync (#1711).
+// Two near-identical predicates meaning opposite things is a trap; sharing the common half makes the
+// difference the thing the reader sees.
+fun isKspKotlinTask(name: String) = name.startsWith("ksp") && name.endsWith("Kotlin")
+
 // Room writes the export as a SIDE EFFECT of annotation processing, at a path Gradle knows nothing
 // about. Left undeclared, a KSP task that is UP-TO-DATE or restored FROM-CACHE leaves whatever the last
 // real execution wrote — so an entity edit that is later reverted keeps the stale export on disk and the
@@ -178,8 +188,7 @@ ksp {
 // wiped the export that `kspFullDebugKotlin` had just restored, and the test failed on a clean build with
 // a warm cache with the directory missing entirely.
 fun isMainSourceSetKspTask(name: String) =
-    name.startsWith("ksp") && name.endsWith("Kotlin") &&
-        !name.contains("UnitTest") && !name.contains("AndroidTest")
+    isKspKotlinTask(name) && !name.contains("UnitTest") && !name.contains("AndroidTest")
 
 tasks.matching { isMainSourceSetKspTask(it.name) }.configureEach {
     outputs.dir(roomSchemaDir).withPropertyName("roomSchemaExport")
@@ -218,7 +227,7 @@ val syncRoomSchemaSnapshot = tasks.register<Sync>("syncRoomSchemaSnapshot") {
     //
     // Ordering only, so nothing is forced to execute and the one-variant `dependsOn` above keeps its
     // point: a `testFullDebugUnitTest` run still triggers exactly one KSP round.
-    mustRunAfter(tasks.matching { it.name.startsWith("ksp") && it.name.endsWith("Kotlin") })
+    mustRunAfter(tasks.matching { isKspKotlinTask(it.name) })
 }
 
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
Follow-up to #1712, which is where the need showed up.

## Why

That change added a matcher spelled `startsWith("ksp") && endsWith("Kotlin")` a few lines below one that already existed and read almost identically — and the existing one **deliberately inverts** on the `UnitTest`/`AndroidTest` rounds. I did not notice while writing it, which is the argument for this change rather than against it: two near-identical predicates meaning opposite things is a trap regardless of who reads them next.

## What

```kotlin
fun isKspKotlinTask(name: String) = name.startsWith("ksp") && name.endsWith("Kotlin")

fun isMainSourceSetKspTask(name: String) =
    isKspKotlinTask(name) && !name.contains("UnitTest") && !name.contains("AndroidTest")
```

`syncRoomSchemaSnapshot`'s `mustRunAfter` now calls `isKspKotlinTask` directly, and the comment on the shared half states the opposition instead of leaving it to be diffed by eye:

- **`isMainSourceSetKspTask` excludes** those rounds, so Gradle is not told they output a directory they never write and then clears it out from under the round that did.
- **`mustRunAfter` includes** them, because they still race the Sync.

## Pure refactor

Both predicates were checked name by name against every KSP and compile task name this project generates — `kspFullDebugKotlin`, `kspFullReleaseKotlin`, the demo variants, the UnitTest and AndroidTest rounds, `kspFullDebugJava`, `compileFullDebugKotlin`. Neither predicate changes for any of them.

## Verified anyway

The failure mode in this area is a **missing schema export**, not a compile error, so it does not announce itself:

| check | result |
|---|---|
| the three-task command from #1712 | BUILD SUCCESSFUL |
| KSP rounds | debug, unit-test, release — once each |
| unit suite | 4,725 tests, 0 failures |
| `SchemaOracleTest` | 4/4 — the test that fails when the export goes missing |

Run before and after the comment relocation described below, with identical results.

## One note on the diff

My first version of this inserted the new declaration **between** the pre-existing comment block and the function it documents, orphaning the "load-bearing" exclusion rationale onto the wrong function. Caught in review and moved above the block. Worth mentioning because it is the exact hazard this PR exists to reduce — and because a comment attached to the wrong function is invisible to every check in CI.
