### PR TITLE
sleep: a partially-received hypnogram is not a complete night

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -546,17 +546,28 @@ public enum AnalyticsEngine {
         var deepS = 0.0, remS = 0.0, lightS = 0.0, tstS = 0.0
         var inBedS = 0.0, effWeighted = 0.0
         var disturbances = 0
+        // Hypnogram COVERAGE across the group: how much of the fragments' own spans the stage segments
+        // actually account for. Accumulated separately from `inBedS` because that one later absorbs the
+        // inter-fragment gap (#777/#705), which is a different quantity — a bridged out-of-bed gap is
+        // known-awake time between two fragments, whereas a hole INSIDE a fragment is time we never
+        // observed at all. Summed straight off `s.stages` (no JSON re-parse: the segments are already
+        // decoded here), then handed to `HypnogramCoverage` so the ratio/clamp/nil rules have ONE
+        // definition shared with the merge-side guard.
+        var coveredS = 0.0, spanS = 0.0
         for s in mainGroup {
             let m = SleepStager.hypnogramMetrics(s)
             let inBed = Double(s.end - s.start)
             inBedS += inBed                       // each fragment's own in-bed span (the gap is added below)
             effWeighted += s.efficiency * inBed   // in-bed-weighted efficiency across the group
+            spanS += inBed
+            for seg in s.stages where seg.end > seg.start { coveredS += Double(seg.end - seg.start) }
             deepS += m.deepMin * 60.0
             remS += m.remMin * 60.0
             lightS += m.lightMin * 60.0
             tstS += m.tstS
             disturbances += m.disturbances
         }
+        let stageCoverage = HypnogramCoverage.fraction(coveredSeconds: coveredS, spanSeconds: spanS)
         // OUT-OF-BED time BETWEEN bridged fragments is AWAKE (#777/#705): a main night bridged from two
         // fragments split by a 20-min wake gap was reporting that gap as nowhere (it is in no fragment's
         // [start,end) span), so 20+ min of real awake read as ~4 min - a v7.1 regression, multi-reporter.
@@ -952,11 +963,14 @@ public enum AnalyticsEngine {
         let effortConfidence = ScoreConfidence.effort(strain: strain, hrSampleCount: hr.count)
         // Rest confidence with H9: downgrade a high-efficiency night whose deep+REM share is implausibly low
         // to low-confidence (likely staging miss) — honest, no faked stages. tstS/efficiency are the
-        // main-group totals computed above; restorative = deepS + remS.
+        // main-group totals computed above; restorative = deepS + remS. `stageCoverage` adds the third
+        // guard: a night whose stage timeline covers only part of its own span (an incompletely-received
+        // device hypnogram) cannot earn a SOLID Rest either, and neither of the other two can see it.
         let restConfidence = ScoreConfidence.rest(hasSession: !matched.isEmpty,
                                                   hasStagedSleep: hasStagedSleep,
                                                   asleepSeconds: tstS, restorativeSeconds: deepS + remS,
-                                                  efficiency: efficiency, gravitySparse: gravitySparse)
+                                                  efficiency: efficiency, gravitySparse: gravitySparse,
+                                                  stageCoverage: stageCoverage)
 
         return DayResult(daily: daily, sleepSessions: matched, cachedSleep: cachedSleep,
                          workouts: workouts, recovery: recovery, strain: strain,

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ScoreConfidence.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ScoreConfidence.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WhoopStore
 
 // ScoreConfidence.swift — per-score certainty tier for Charge / Effort / Rest.
 //
@@ -78,25 +79,39 @@ public enum ScoreConfidence: String, Equatable, Sendable, Codable {
     /// suspicious case — high efficiency (lots of measured sleep) but implausibly little restorative.
     public static let highEfficiencyThreshold: Double = 0.85
 
-    /// Rest confidence WITH the H9 stage-quality check AND the sparse-motion guard. Starts from
-    /// `rest(hasSession:hasStagedSleep:)`, then DOWNGRADES a `.solid` tier to `.building` (low-confidence)
-    /// when EITHER:
+    /// Rest confidence WITH the H9 stage-quality check, the sparse-motion guard AND the hypnogram-coverage
+    /// guard. Starts from `rest(hasSession:hasStagedSleep:)`, then DOWNGRADES a `.solid` tier to `.building`
+    /// (low-confidence) when ANY of:
     ///  - the night was staged on SPARSE gravity (`gravitySparse`) — a WHOOP 4.0 synced/offload night banks
     ///    motion coarsely, too sparse to reliably stage sleep (#345), so a confident 85–100 Rest is unearned
     ///    however the engine filled the stages. This catches the case H9 MISSES: a sparse night whose staging
     ///    manufactures HIGH efficiency AND HIGH restorative reads SOLID under H9 alone (the #319 signature),
     ///    yet the underlying data can't support it; OR
     ///  - the night is high-efficiency yet its restorative (deep+REM) share is below
-    ///    `restorativeLowConfidenceShare` — a likely staging miss (#H9).
+    ///    `restorativeLowConfidenceShare` — a likely staging miss (#H9); OR
+    ///  - `stageCoverage` says the stage timeline accounts for less than `HypnogramCoverage.minCoverage` of
+    ///    the span it claims. This is the case the other two structurally cannot see: a device-PROVIDED
+    ///    hypnogram assembled from records that arrived incomplete has real stages over the part that DID
+    ///    arrive, so its restorative share is ordinary and H9 stays quiet, while `gravitySparse` describes
+    ///    the on-device motion stager and is false for a provided hypnogram (and inert for Oura outright,
+    ///    which banks no gravity at all). Measured: a ring night covering 23% of its 601-minute span was
+    ///    stored as 70 minutes of sleep and reported SOLID.
     /// `asleepSeconds`/`restorativeSeconds` are the night's totals; efficiency is asleep/in-bed in [0,1].
+    /// `stageCoverage` is nil when coverage is unknown or not applicable — the guard fails OPEN there, so
+    /// an unmeasurable payload keeps its previous tier rather than being downgraded on no evidence.
     /// `.calibrating`/`.building` from the base call are returned unchanged. Confidence-only — never changes
-    /// the Rest score or invents stages. Engine output only; the UI surfaces the tier later. (#H9, #345)
+    /// the Rest score, invents stages, or claims the uncovered time was awake. Engine output only; the UI
+    /// surfaces the tier later. (#H9, #345)
     public static func rest(hasSession: Bool, hasStagedSleep: Bool,
                             asleepSeconds: Double, restorativeSeconds: Double,
-                            efficiency: Double, gravitySparse: Bool = false) -> ScoreConfidence {
+                            efficiency: Double, gravitySparse: Bool = false,
+                            stageCoverage: Double? = nil) -> ScoreConfidence {
         let base = rest(hasSession: hasSession, hasStagedSleep: hasStagedSleep)
         if base != .solid { return base }
         if gravitySparse { return .building }   // #345: sparse-motion staging can't earn a SOLID Rest
+        if let c = stageCoverage, c < HypnogramCoverage.minCoverage {
+            return .building   // the timeline covers only part of the night it claims
+        }
         if asleepSeconds <= 0 { return base }
         let restorativeShare = restorativeSeconds / asleepSeconds
         if efficiency >= highEfficiencyThreshold && restorativeShare < restorativeLowConfidenceShare {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyticsEngineTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyticsEngineTests.swift
@@ -474,6 +474,61 @@ final class AnalyticsEngineTests: XCTestCase {
             .building, "high-efficiency night with near-zero deep+REM is low-confidence staging")
     }
 
+    // Hypnogram coverage: a stage timeline that accounts for only part of the span it claims cannot earn
+    // a SOLID Rest. This is the case the other two guards structurally cannot see — see the real night
+    // reproduced in `testRestConfidenceCoverageCatchesTheNightH9AndGravityMiss`.
+    func testRestConfidenceCoverageDowngradesHoledHypnogram() {
+        let asleep = 8.0 * 3600.0
+        XCTAssertEqual(
+            ScoreConfidence.rest(hasSession: true, hasStagedSleep: true,
+                                 asleepSeconds: asleep, restorativeSeconds: asleep * 0.45,
+                                 efficiency: 0.80, stageCoverage: 0.23),
+            .building, "a timeline covering 23% of its span cannot earn a SOLID Rest")
+    }
+
+    func testRestConfidenceCoverageKeepsSolidWhenTimelineCoversItsSpan() {
+        let asleep = 8.0 * 3600.0
+        XCTAssertEqual(
+            ScoreConfidence.rest(hasSession: true, hasStagedSleep: true,
+                                 asleepSeconds: asleep, restorativeSeconds: asleep * 0.45,
+                                 efficiency: 0.80, stageCoverage: 1.0),
+            .solid)
+    }
+
+    /// Unknown coverage must fail OPEN — nil is "not measured", never "measured badly". Omitting the
+    /// argument entirely (every pre-existing caller) must behave identically.
+    func testRestConfidenceCoverageUnknownDoesNotDowngrade() {
+        let asleep = 8.0 * 3600.0
+        for coverage in [nil, Optional(1.0)] {
+            XCTAssertEqual(
+                ScoreConfidence.rest(hasSession: true, hasStagedSleep: true,
+                                     asleepSeconds: asleep, restorativeSeconds: asleep * 0.45,
+                                     efficiency: 0.80, stageCoverage: coverage),
+                .solid, "coverage \(String(describing: coverage)) must not downgrade")
+        }
+    }
+
+    /// The measured night this guard exists for (2026-08-18, Oura ring vs a paired WHOOP strap): the
+    /// hypnogram covered 140 of 601 minutes, so NOOP stored 70 minutes of sleep where the strap recorded
+    /// 494. It read SOLID because NEITHER existing guard applies — `gravitySparse` is false (Oura banks
+    /// no gravity at all, so `isGravitySparse` returns false for every ring night) and H9 needs
+    /// efficiency ≥ 0.85 against this night's 0.50. Pinned so a future refactor cannot quietly lose it.
+    func testRestConfidenceCoverageCatchesTheNightH9AndGravityMiss() {
+        let asleep = 70.0 * 60.0
+        let restorative = asleep * 0.45          // ordinary share over the part that DID arrive
+        XCTAssertEqual(
+            ScoreConfidence.rest(hasSession: true, hasStagedSleep: true,
+                                 asleepSeconds: asleep, restorativeSeconds: restorative,
+                                 efficiency: 0.50, gravitySparse: false),
+            .solid, "precondition: without coverage this night reads SOLID — that is the bug")
+        XCTAssertEqual(
+            ScoreConfidence.rest(hasSession: true, hasStagedSleep: true,
+                                 asleepSeconds: asleep, restorativeSeconds: restorative,
+                                 efficiency: 0.50, gravitySparse: false,
+                                 stageCoverage: 140.0 / 601.0),
+            .building, "with coverage it is correctly low-confidence")
+    }
+
     func testRestConfidenceH9KeepsSolidWhenRestorativeHealthy() {
         // Same high-efficiency night but a healthy ~45% restorative share → stays solid.
         let asleep = 8.0 * 3600.0

--- a/Packages/WhoopStore/Sources/WhoopStore/HypnogramCoverage.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/HypnogramCoverage.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// How much of a sleep session's `[startTs, endTs)` span its stage segments actually account for.
+///
+/// WHY THIS EXISTS. A session's stage timeline is supposed to TILE its span — `SleepStageTotals`
+/// says so explicitly ("the segment stages noop stores ... TILE the window ... Σ stage minutes equals
+/// the clock span"), and every consumer is written as though it does. One producer breaks that
+/// invariant: a device-PROVIDED hypnogram assembled from records that arrived INCOMPLETE. The Oura
+/// path (`OuraSleepSessionMapping`) merges only CONTIGUOUS codes, so a sleep-phase page that never
+/// arrived leaves a hole in `stagesJSON` while `startTs`/`endTs` still span the whole night. The
+/// result is a session that looks well-formed — non-empty, many segments, a plausible efficiency —
+/// but describes a fraction of the night it claims.
+///
+/// Measured on 31 consecutive ring nights, 8 of them came in under 95% and one covered 23% of its
+/// own span (601 min claimed, 140 min of segments). Downstream that night was stored as 70 minutes of
+/// sleep against a paired strap's 494, and nothing flagged it: the merge's richness rule tests only
+/// that stages are PRESENT, and Rest's two confidence guards are `gravitySparse` (inert here — Oura
+/// stores no gravity at all, so `isGravitySparse` returns false for every ring night) and the #H9
+/// restorative floor (needs efficiency ≥ 0.85; the holed night read 0.50).
+///
+/// So the missing quantity is not a new measurement — it is a RATIO of two numbers already stored.
+/// Nothing here is persisted and no migration is needed: coverage is derived on read, which also means
+/// it applies retroactively to nights already in the database.
+///
+/// HONEST-DATA: this only ever reports how much of the night was OBSERVED. It never fills a hole in,
+/// and in particular it must not let a caller treat unobserved time as awake — we do not know what
+/// happened there, and asserting wake would be the same overreach in the opposite direction.
+///
+/// PARITY: pure + deterministic, byte-identical to the Kotlin twin
+/// (`com.noop.analytics.HypnogramCoverage`). Keep the two in lockstep.
+public enum HypnogramCoverage {
+
+    /// Coverage at or above which a stage timeline is treated as describing its whole span.
+    ///
+    /// The observed split is wide: healthy nights land at 99–100%, the broken ones at 23–93%. 0.95
+    /// sits in the empty middle, so the gate is not balanced on the edge of the data.
+    public static let minCoverage: Double = 0.95
+
+    /// The covered fraction of `spanSeconds`, or nil when the question does not apply.
+    ///
+    /// Returns nil — meaning "unknown, do not judge" — rather than 0 when there is nothing to measure,
+    /// so an unknown coverage can never be mistaken for a bad one by a caller that compares against
+    /// `minCoverage`. Clamped to at most 1: segments that overlap or overhang would otherwise report
+    /// more than a full night, and for a completeness gate the safe direction is to read that as
+    /// "complete" rather than to invent a failure out of malformed input.
+    public static func fraction(coveredSeconds: Double, spanSeconds: Double) -> Double? {
+        guard spanSeconds > 0, coveredSeconds > 0 else { return nil }
+        return min(1.0, coveredSeconds / spanSeconds)
+    }
+
+    /// The covered fraction of `spanSeconds` for a session's stored `stagesJSON`, or nil when coverage
+    /// is not a meaningful question for that payload.
+    ///
+    /// nil for: a nil/blank/`"[]"` payload (no stages at all — that is the richness question, not this
+    /// one) and for the IMPORTED minute-dict shape `{light,deep,rem,awake}`, which carries no
+    /// timestamps and therefore cannot be compared against a span. That second case is what keeps this
+    /// gate away from WHOOP/Apple/Health-Connect imports entirely: they are never judged incomplete
+    /// here, so no existing import behaviour changes.
+    public static func fraction(stagesJSON: String?, spanSeconds: Double) -> Double? {
+        guard let json = stagesJSON?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !json.isEmpty, json != "[]",
+              let data = json.data(using: .utf8),
+              let segs = (try? JSONSerialization.jsonObject(with: data)) as? [[String: Any]]
+        else { return nil }
+        var covered = 0.0
+        for seg in segs {
+            guard let s = (seg["start"] as? NSNumber)?.doubleValue,
+                  let e = (seg["end"] as? NSNumber)?.doubleValue, e > s else { continue }
+            covered += e - s
+        }
+        return fraction(coveredSeconds: covered, spanSeconds: spanSeconds)
+    }
+
+    /// True when the timeline is known to cover less than `minCoverage` of its span — i.e. the session
+    /// demonstrably describes only part of the night it claims. Unknown coverage (nil) is NOT holed:
+    /// every guard built on this fails OPEN, so a payload shape this cannot measure keeps its existing
+    /// behaviour instead of being silently downgraded.
+    public static func isHoled(stagesJSON: String?, spanSeconds: Double) -> Bool {
+        guard let f = fraction(stagesJSON: stagesJSON, spanSeconds: spanSeconds) else { return false }
+        return f < minCoverage
+    }
+
+    /// `isHoled` for a stored session, using its own `[startTs, endTs)` as the span.
+    public static func isHoled(_ s: CachedSleepSession) -> Bool {
+        isHoled(stagesJSON: s.stagesJSON, spanSeconds: Double(s.endTs - s.startTs))
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/SleepMerge.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/SleepMerge.swift
@@ -16,6 +16,23 @@ public enum SleepMerge {
     /// where neither side does, keep the imported-over-computed rule unchanged. (Swift twin of the
     /// Android HealthConnectImporter richness fix, ryanbr/noop#240.)
     ///
+    /// Richness is a RANK, not a yes/no. Presence alone was the original test, and it cannot see a
+    /// device-provided hypnogram assembled from records that arrived incomplete: such a row carries many
+    /// segments — so it passes any presence check — while covering a fraction of the span it claims
+    /// (measured: one ring night with 21 segments over 23% of its 601-minute span, stored as 70 minutes
+    /// of sleep against a paired strap's 494). So a day's best session ranks:
+    ///
+    ///   2  stages that cover the span they claim (`HypnogramCoverage`)
+    ///   1  stages present but HOLED — real, but describing only part of the night
+    ///   0  no stages at all
+    ///
+    /// and the computed day wins only when it OUT-RANKS the import. Collapsing 1 and 0 together gives
+    /// back the original presence rule exactly, so this is a strict generalisation: every case #240
+    /// decided, it still decides the same way. What changes is the pair the old rule could not express
+    /// — a holed import against a COMPLETE computed night, which used to go to the import and now goes
+    /// to the night that actually covers itself. A holed import still beats no stages at all: partial
+    /// data is better than none, it just no longer outranks a whole night.
+    ///
     /// - Parameter endDay: maps a session to its canonical LOCAL end-day key (callers inject their
     ///   timezone-aware keyer so this stays pure and testable).
     public static func merge(imported: [CachedSleepSession],
@@ -30,8 +47,7 @@ public enum SleepMerge {
         out.reserveCapacity(imported.count + computed.count)
         for (day, imp) in importedByDay {
             if let comp = computedByDay[day],
-               !imp.contains(where: hasStages),
-               comp.contains(where: hasStages) {
+               dayRichness(comp) > dayRichness(imp) {
                 out.append(contentsOf: comp)   // richer computed day survives a stage-less import
             } else {
                 out.append(contentsOf: imp)    // imported wins its day (unchanged rule)
@@ -47,5 +63,20 @@ public enum SleepMerge {
     static func hasStages(_ s: CachedSleepSession) -> Bool {
         guard let json = s.stagesJSON?.trimmingCharacters(in: .whitespacesAndNewlines) else { return false }
         return !json.isEmpty && json != "[]"
+    }
+
+    /// How much of a night this session's stages actually describe: 2 = covers its span, 1 = present but
+    /// holed, 0 = none. A timeline whose coverage cannot be measured (the imported minute-dict shape,
+    /// which has no timestamps) is never holed, so it ranks 2 — imports keep being judged on presence
+    /// exactly as they always were, and this gate cannot reach them.
+    static func richness(_ s: CachedSleepSession) -> Int {
+        guard hasStages(s) else { return 0 }
+        return HypnogramCoverage.isHoled(s) ? 1 : 2
+    }
+
+    /// A day's richness is that of its BEST session — a day with a fully-staged main night plus an
+    /// unstaged nap is a staged day (#715 keeps every session of the winning day either way).
+    static func dayRichness(_ sessions: [CachedSleepSession]) -> Int {
+        sessions.reduce(0) { max($0, richness($1)) }
     }
 }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/HypnogramCoverageTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/HypnogramCoverageTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import WhoopStore
+
+/// `HypnogramCoverage` — the ratio that tells a well-formed-looking stage timeline from one that
+/// describes only part of the night it claims.
+final class HypnogramCoverageTests: XCTestCase {
+
+    /// Segments tiling `[0, span)` in 30 s steps, `n` of them, starting at `from`.
+    private func segs(_ ranges: [(Int, Int, String)]) -> String {
+        "[" + ranges.map { "{\"start\":\($0.0),\"end\":\($0.1),\"stage\":\"\($0.2)\"}" }
+            .joined(separator: ",") + "]"
+    }
+
+    // MARK: - the ratio itself
+
+    func testFractionIsCoveredOverSpan() {
+        XCTAssertEqual(HypnogramCoverage.fraction(coveredSeconds: 300, spanSeconds: 600)!, 0.5, accuracy: 1e-12)
+        XCTAssertEqual(HypnogramCoverage.fraction(coveredSeconds: 600, spanSeconds: 600)!, 1.0, accuracy: 1e-12)
+    }
+
+    /// Overlapping/overhanging segments would otherwise report more than a whole night. A completeness
+    /// gate must read that as "complete", never manufacture a failure out of malformed input.
+    func testFractionClampsAboveOne() {
+        XCTAssertEqual(HypnogramCoverage.fraction(coveredSeconds: 900, spanSeconds: 600)!, 1.0, accuracy: 1e-12)
+    }
+
+    /// nil means "unknown, do not judge" — distinct from 0, which a caller comparing against
+    /// `minCoverage` would read as a bad night.
+    func testFractionNilWhenNothingToMeasure() {
+        XCTAssertNil(HypnogramCoverage.fraction(coveredSeconds: 300, spanSeconds: 0))
+        XCTAssertNil(HypnogramCoverage.fraction(coveredSeconds: 300, spanSeconds: -1))
+        XCTAssertNil(HypnogramCoverage.fraction(coveredSeconds: 0, spanSeconds: 600))
+    }
+
+    // MARK: - from a stored payload
+
+    func testTilingTimelineCoversItsSpan() {
+        let json = segs([(0, 300, "light"), (300, 600, "deep")])
+        XCTAssertEqual(HypnogramCoverage.fraction(stagesJSON: json, spanSeconds: 600)!, 1.0, accuracy: 1e-12)
+        XCTAssertFalse(HypnogramCoverage.isHoled(stagesJSON: json, spanSeconds: 600))
+    }
+
+    /// The shape this whole change exists for: a hypnogram assembled from records that arrived
+    /// incomplete. Many segments, all real, spanning a night they only partly describe. The measured
+    /// worst case was 140 minutes of segments across a 601-minute span.
+    func testHoledTimelineIsDetected() {
+        let json = segs([(0, 4200, "light"), (4200, 8400, "deep")])   // 140 min over a 601 min span
+        let span = 601.0 * 60.0
+        let f = HypnogramCoverage.fraction(stagesJSON: json, spanSeconds: span)!
+        XCTAssertEqual(f, 8400.0 / span, accuracy: 1e-12)
+        XCTAssertLessThan(f, 0.24)
+        XCTAssertTrue(HypnogramCoverage.isHoled(stagesJSON: json, spanSeconds: span))
+    }
+
+    /// A hole in the MIDDLE is the real failure mode (a page that never arrived), not a short tail.
+    func testInteriorHoleCounts() {
+        let json = segs([(0, 300, "light"), (900, 1200, "deep")])     // 600 s of 1200 s
+        XCTAssertEqual(HypnogramCoverage.fraction(stagesJSON: json, spanSeconds: 1200)!, 0.5, accuracy: 1e-12)
+    }
+
+    func testThresholdBoundaryIsInclusive() {
+        // exactly minCoverage is NOT holed; a hair under it is.
+        let atGate = segs([(0, 950, "light")])
+        let underGate = segs([(0, 949, "light")])
+        XCTAssertFalse(HypnogramCoverage.isHoled(stagesJSON: atGate, spanSeconds: 1000))
+        XCTAssertTrue(HypnogramCoverage.isHoled(stagesJSON: underGate, spanSeconds: 1000))
+    }
+
+    // MARK: - what must NOT be judged
+
+    /// The imported minute-dict shape carries no timestamps, so coverage is unanswerable. It must come
+    /// back nil (not 0), which is what keeps every WHOOP/Apple/Health-Connect import out of this gate.
+    func testImportedMinuteDictIsUnmeasurable() {
+        let dict = "{\"light\":300,\"deep\":100,\"rem\":80,\"awake\":40}"
+        XCTAssertNil(HypnogramCoverage.fraction(stagesJSON: dict, spanSeconds: 3600))
+        XCTAssertFalse(HypnogramCoverage.isHoled(stagesJSON: dict, spanSeconds: 3600))
+    }
+
+    func testEmptyAndMalformedAreUnmeasurable() {
+        for payload in [nil, "", "   ", "[]", "not json"] as [String?] {
+            XCTAssertNil(HypnogramCoverage.fraction(stagesJSON: payload, spanSeconds: 3600),
+                         "payload \(String(describing: payload)) should be unmeasurable")
+            XCTAssertFalse(HypnogramCoverage.isHoled(stagesJSON: payload, spanSeconds: 3600),
+                           "an unmeasurable payload must never read as holed")
+        }
+    }
+
+    /// Every guard built on this fails OPEN: unknown coverage keeps the previous behaviour rather than
+    /// downgrading a night on no evidence.
+    func testSessionOverloadUsesItsOwnSpan() {
+        let holed = CachedSleepSession(startTs: 0, endTs: 1200, efficiency: nil, restingHr: nil,
+                                       avgHrv: nil, stagesJSON: segs([(0, 300, "light")]))
+        let whole = CachedSleepSession(startTs: 0, endTs: 1200, efficiency: nil, restingHr: nil,
+                                       avgHrv: nil, stagesJSON: segs([(0, 1200, "light")]))
+        let stageless = CachedSleepSession(startTs: 0, endTs: 1200, efficiency: nil, restingHr: nil,
+                                          avgHrv: nil, stagesJSON: nil)
+        XCTAssertTrue(HypnogramCoverage.isHoled(holed))
+        XCTAssertFalse(HypnogramCoverage.isHoled(whole))
+        XCTAssertFalse(HypnogramCoverage.isHoled(stageless))
+    }
+}

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/SleepMergeTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/SleepMergeTests.swift
@@ -10,7 +10,14 @@ final class SleepMergeTests: XCTestCase {
         CachedSleepSession(startTs: start, endTs: end, efficiency: nil,
                            restingHr: nil, avgHrv: nil, stagesJSON: stages)
     }
+    /// One hour of segments. Against the 8-hour spans these tests use this is a HOLED timeline — which
+    /// is deliberate for the presence-rule cases below (rank 1 behaves exactly as the old "has stages"
+    /// did against a stage-less day) and is the fixture the coverage cases contrast with `tiling`.
     private let someStages = #"[{"start":0,"end":3600,"stage":"deep"}]"#
+    /// A single segment that covers `[start, end)` exactly — a night that accounts for its own span.
+    private func tiling(_ start: Int, _ end: Int) -> String {
+        #"[{"start":\#(start),"end":\#(end),"stage":"deep"}]"#
+    }
     // Deterministic "local day" keyer for the tests (real callers pass their tz-aware keyer).
     private let dayKey: (CachedSleepSession) -> String = { String($0.endTs / 86_400) }
 
@@ -76,6 +83,54 @@ final class SleepMergeTests: XCTestCase {
         let merged = SleepMerge.merge(imported: [impEmpty, impBlank],
                                       computed: [comp, compDay1], endDay: dayKey)
         XCTAssertEqual(merged.map(\.startTs), [0, 86_400], #""[]" and blank JSON are not stages"#)
+    }
+
+    // Coverage rank: a stage timeline that covers only part of the span it claims (a device hypnogram
+    // assembled from records that arrived incomplete) outranks nothing, but not a whole night.
+
+    /// The case the presence-only rule could not express, and the reason this change exists: a HOLED
+    /// import used to win purely by being an import, blanking a computed night that covers itself.
+    func testHoledImportYieldsToFullyCoveredComputedNight() {
+        let comp = session(start: 0, end: 8 * 3600, stages: tiling(0, 8 * 3600))
+        let imp  = session(start: 0, end: 8 * 3600, stages: someStages)   // 1 h of segments over 8 h
+        let merged = SleepMerge.merge(imported: [imp], computed: [comp], endDay: dayKey)
+        XCTAssertEqual(merged.map(\.startTs), [0])
+        XCTAssertEqual(merged.first?.stagesJSON, tiling(0, 8 * 3600),
+                       "the night that covers its own span wins over a holed import")
+    }
+
+    /// …but partial data still beats none. A holed import must not lose to a stage-less computed day.
+    func testHoledImportStillBeatsStagelessComputed() {
+        let comp = session(start: 0, end: 8 * 3600)                        // no stages
+        let imp  = session(start: 3600, end: 8 * 3600 + 1800, stages: someStages)
+        let merged = SleepMerge.merge(imported: [imp], computed: [comp], endDay: dayKey)
+        XCTAssertEqual(merged.map(\.startTs), [3600], "some stages beat none, holed or not")
+    }
+
+    /// Equal rank keeps the imported-over-computed default — the rule only fires on a strict out-rank.
+    func testEquallyHoledSidesKeepImportedWins() {
+        let comp = session(start: 0, end: 8 * 3600, stages: someStages)
+        let imp  = session(start: 3600, end: 8 * 3600 + 1800, stages: someStages)
+        let merged = SleepMerge.merge(imported: [imp], computed: [comp], endDay: dayKey)
+        XCTAssertEqual(merged.map(\.startTs), [3600])
+    }
+
+    /// A fully-covered import is untouched by any of this.
+    func testFullyCoveredImportStillWins() {
+        let comp = session(start: 0, end: 8 * 3600, stages: tiling(0, 8 * 3600))
+        let imp  = session(start: 3600, end: 3600 + 8 * 3600, stages: tiling(3600, 3600 + 8 * 3600))
+        let merged = SleepMerge.merge(imported: [imp], computed: [comp], endDay: dayKey)
+        XCTAssertEqual(merged.map(\.startTs), [3600])
+    }
+
+    /// The imported minute-dict shape carries no timestamps, so it can never be judged holed — every
+    /// WHOOP/Apple/Health-Connect import keeps its existing precedence.
+    func testImportedMinuteDictIsNeverHoled() {
+        let comp = session(start: 0, end: 8 * 3600, stages: tiling(0, 8 * 3600))
+        let imp  = session(start: 3600, end: 8 * 3600 + 1800,
+                           stages: #"{"light":300,"deep":100,"rem":80,"awake":40}"#)
+        let merged = SleepMerge.merge(imported: [imp], computed: [comp], endDay: dayKey)
+        XCTAssertEqual(merged.map(\.startTs), [3600], "a dict-shaped import is not measurable, so it wins as before")
     }
 
     func testRichnessExceptionKeepsEverySessionOfWinningDay() {

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -495,11 +495,22 @@ object AnalyticsEngine {
         var inBedS = 0.0
         var effWeighted = 0.0
         var disturbances = 0
+        // Hypnogram COVERAGE across the group: how much of the fragments' own spans the stage segments
+        // actually account for. Accumulated separately from `inBedS` because that one later absorbs the
+        // inter-fragment gap (#777/#705), which is a different quantity — a bridged out-of-bed gap is
+        // known-awake time between two fragments, whereas a hole INSIDE a fragment is time we never
+        // observed at all. Summed straight off `s.stages` (no JSON re-parse: the segments are already
+        // decoded here), then handed to HypnogramCoverage so the ratio/clamp/null rules have ONE
+        // definition shared with the merge-side guard. Mirrors Swift.
+        var coveredS = 0.0
+        var spanS = 0.0
         for (s in mainGroup) {
             val m = SleepStager.hypnogramMetrics(s)
             val inBed = (s.end - s.start).toDouble()
             inBedS += inBed                       // each fragment's own in-bed span (the gap is added below)
             effWeighted += s.efficiency * inBed   // in-bed-weighted efficiency across the group
+            spanS += inBed
+            for (seg in s.stages) if (seg.end > seg.start) coveredS += (seg.end - seg.start).toDouble()
             deepS += m.deepMin * 60.0
             remS += m.remMin * 60.0
             lightS += m.lightMin * 60.0
@@ -856,8 +867,11 @@ object AnalyticsEngine {
         // Rest confidence with H9 + the #345 sparse-motion guard: downgrade to low-confidence a night whose
         // deep+REM share is implausibly low on a high-efficiency night (H9 staging miss) OR that was staged
         // on sparse gravity (WHOOP 4.0 coarse-banked motion can't reliably stage sleep — a confident 85–100
-        // Rest is unearned however the engine filled it). Confidence-only, no faked stages. tstS/efficiency
-        // are the main-group totals above; restorative = deepS + remS. Mirrors Swift.
+        // Rest is unearned however the engine filled it). `stageCoverage` adds the third guard: a night
+        // whose stage timeline covers only part of its own span (an incompletely-received device
+        // hypnogram) cannot earn a SOLID Rest either, and neither of the other two can see it.
+        // Confidence-only, no faked stages. tstS/efficiency are the main-group totals above;
+        // restorative = deepS + remS. Mirrors Swift.
         val restConfidence = ScoreConfidence.forRest(
             hasSession = matched.isNotEmpty(),
             hasStagedSleep = (deepS + remS) > 0,
@@ -865,6 +879,7 @@ object AnalyticsEngine {
             restorativeSeconds = deepS + remS,
             efficiency = efficiency,
             gravitySparse = gravitySparse,
+            stageCoverage = HypnogramCoverage.fraction(coveredS, spanS),
         )
 
         // ── Per-session per-epoch motion (H8) ─────────────────────────────────

--- a/android/app/src/main/java/com/noop/analytics/HypnogramCoverage.kt
+++ b/android/app/src/main/java/com/noop/analytics/HypnogramCoverage.kt
@@ -1,0 +1,98 @@
+package com.noop.analytics
+
+import org.json.JSONArray
+
+/**
+ * How much of a sleep session's `[startTs, endTs)` span its stage segments actually account for.
+ *
+ * WHY THIS EXISTS. A session's stage timeline is supposed to TILE its span — `SleepStageTotals` says so
+ * explicitly ("the segment stages noop stores ... TILE the window ... Σ stage minutes equals the clock
+ * span"), and every consumer is written as though it does. One producer breaks that invariant: a
+ * device-PROVIDED hypnogram assembled from records that arrived INCOMPLETE. The Oura path
+ * ([com.noop.oura.OuraSleepSessionMapping]) merges only CONTIGUOUS codes, so a sleep-phase page that
+ * never arrived leaves a hole in `stagesJSON` while `startTs`/`endTs` still span the whole night. The
+ * result is a session that looks well-formed — non-empty, many segments, a plausible efficiency — but
+ * describes a fraction of the night it claims.
+ *
+ * Measured on 31 consecutive ring nights, 8 of them came in under 95% and one covered 23% of its own
+ * span (601 min claimed, 140 min of segments). Downstream that night was stored as 70 minutes of sleep
+ * against a paired strap's 494, and nothing flagged it: the merge's richness rule tests only that stages
+ * are PRESENT, and Rest's two confidence guards are `gravitySparse` (inert here — Oura stores no gravity
+ * at all, so `isGravitySparse` returns false for every ring night) and the #H9 restorative floor (needs
+ * efficiency >= 0.85; the holed night read 0.50).
+ *
+ * So the missing quantity is not a new measurement — it is a RATIO of two numbers already stored.
+ * Nothing here is persisted and no migration is needed: coverage is derived on read, which also means it
+ * applies retroactively to nights already in the database.
+ *
+ * HONEST-DATA: this only ever reports how much of the night was OBSERVED. It never fills a hole in, and
+ * in particular it must not let a caller treat unobserved time as awake — we do not know what happened
+ * there, and asserting wake would be the same overreach in the opposite direction.
+ *
+ * PARITY: pure + deterministic, byte-identical to the Swift twin (`WhoopStore.HypnogramCoverage`). Keep
+ * the two in lockstep; `HypnogramCoverageTest` pins the ratio against a Swift-generated oracle.
+ */
+object HypnogramCoverage {
+
+    /**
+     * Coverage at or above which a stage timeline is treated as describing its whole span.
+     *
+     * The observed split is wide: healthy nights land at 99–100%, the broken ones at 23–93%. 0.95 sits
+     * in the empty middle, so the gate is not balanced on the edge of the data. Mirrors Swift
+     * `minCoverage`.
+     */
+    const val minCoverage: Double = 0.95
+
+    /**
+     * The covered fraction of [spanSeconds], or null when the question does not apply.
+     *
+     * Returns null — meaning "unknown, do not judge" — rather than 0 when there is nothing to measure,
+     * so an unknown coverage can never be mistaken for a bad one by a caller comparing against
+     * [minCoverage]. Clamped to at most 1: segments that overlap or overhang would otherwise report more
+     * than a full night, and for a completeness gate the safe direction is to read that as "complete"
+     * rather than to invent a failure out of malformed input.
+     */
+    fun fraction(coveredSeconds: Double, spanSeconds: Double): Double? {
+        if (spanSeconds <= 0.0 || coveredSeconds <= 0.0) return null
+        return minOf(1.0, coveredSeconds / spanSeconds)
+    }
+
+    /**
+     * The covered fraction of [spanSeconds] for a session's stored `stagesJSON`, or null when coverage is
+     * not a meaningful question for that payload.
+     *
+     * null for: a null/blank/`"[]"` payload (no stages at all — that is the richness question, not this
+     * one) and for the IMPORTED minute-dict shape `{light,deep,rem,awake}`, which carries no timestamps
+     * and therefore cannot be compared against a span. That second case is what keeps this gate away from
+     * WHOOP/Apple/Health-Connect imports entirely: they are never judged incomplete here, so no existing
+     * import behaviour changes.
+     */
+    fun fraction(stagesJson: String?, spanSeconds: Double): Double? {
+        val json = stagesJson?.trim() ?: return null
+        if (json.isEmpty() || json == "[]") return null
+        // The dict shape (imported minute totals) throws here and falls through to null — deliberately,
+        // since it carries no timestamps to measure. Same try/catch idiom as SleepStageTotals.minutes.
+        val arr = try { JSONArray(json) } catch (_: Throwable) { return null }
+        var covered = 0.0
+        for (i in 0 until arr.length()) {
+            val seg = arr.optJSONObject(i) ?: continue
+            if (!seg.has("start") || !seg.has("end")) continue
+            val s = seg.optDouble("start", Double.NaN)
+            val e = seg.optDouble("end", Double.NaN)
+            if (s.isNaN() || e.isNaN() || e <= s) continue
+            covered += e - s
+        }
+        return fraction(covered, spanSeconds)
+    }
+
+    /**
+     * True when the timeline is known to cover less than [minCoverage] of its span — i.e. the session
+     * demonstrably describes only part of the night it claims. Unknown coverage (null) is NOT holed:
+     * every guard built on this fails OPEN, so a payload shape this cannot measure keeps its existing
+     * behaviour instead of being silently downgraded.
+     */
+    fun isHoled(stagesJson: String?, spanSeconds: Double): Boolean {
+        val f = fraction(stagesJson, spanSeconds) ?: return false
+        return f < minCoverage
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/ScoreConfidence.kt
+++ b/android/app/src/main/java/com/noop/analytics/ScoreConfidence.kt
@@ -117,18 +117,30 @@ enum class ScoreConfidence(val raw: String) {
         const val highEfficiencyThreshold: Double = 0.85
 
         /**
-         * Rest confidence WITH the H9 stage-quality check AND the sparse-motion guard. Starts from
-         * [forRest], then DOWNGRADES a [SOLID] tier to [BUILDING] (low-confidence) when EITHER:
+         * Rest confidence WITH the H9 stage-quality check, the sparse-motion guard AND the
+         * hypnogram-coverage guard. Starts from [forRest], then DOWNGRADES a [SOLID] tier to [BUILDING]
+         * (low-confidence) when ANY of:
          *  - the night was staged on SPARSE gravity ([gravitySparse]) — a WHOOP 4.0 synced/offload night
          *    banks motion coarsely, too sparse to reliably stage sleep (#345), so a confident 85–100 Rest
          *    is unearned however the engine filled the stages. This catches the case H9 MISSES: a sparse
          *    night whose staging manufactures HIGH efficiency AND HIGH restorative reads SOLID under H9
          *    alone (the #319 signature), yet the underlying data can't support it; OR
          *  - the night is high-efficiency yet its restorative (deep+REM) share is below
-         *    [restorativeLowConfidenceShare] — a likely staging miss (#H9).
-         * [CALIBRATING]/[BUILDING] from the base call are returned unchanged. Engine output only; the UI
-         * surfaces the tier later. Confidence-only — it never changes the Rest score or invents stages.
-         * Mirrors Swift `rest(hasSession:hasStagedSleep:asleepSeconds:restorativeSeconds:efficiency:gravitySparse:)`.
+         *    [restorativeLowConfidenceShare] — a likely staging miss (#H9); OR
+         *  - [stageCoverage] says the stage timeline accounts for less than
+         *    [HypnogramCoverage.minCoverage] of the span it claims. This is the case the other two
+         *    structurally cannot see: a device-PROVIDED hypnogram assembled from records that arrived
+         *    incomplete has real stages over the part that DID arrive, so its restorative share is
+         *    ordinary and H9 stays quiet, while [gravitySparse] describes the on-device motion stager and
+         *    is false for a provided hypnogram (and inert for Oura outright, which banks no gravity at
+         *    all). Measured: a ring night covering 23% of its 601-minute span was stored as 70 minutes of
+         *    sleep and reported SOLID.
+         * [stageCoverage] is null when coverage is unknown or not applicable — the guard fails OPEN
+         * there, so an unmeasurable payload keeps its previous tier rather than being downgraded on no
+         * evidence. [CALIBRATING]/[BUILDING] from the base call are returned unchanged. Engine output
+         * only; the UI surfaces the tier later. Confidence-only — it never changes the Rest score,
+         * invents stages, or claims the uncovered time was awake. Mirrors Swift
+         * `rest(hasSession:hasStagedSleep:asleepSeconds:restorativeSeconds:efficiency:gravitySparse:stageCoverage:)`.
          * (#H9, #345)
          */
         fun forRest(
@@ -138,10 +150,13 @@ enum class ScoreConfidence(val raw: String) {
             restorativeSeconds: Double,
             efficiency: Double,
             gravitySparse: Boolean = false,
+            stageCoverage: Double? = null,
         ): ScoreConfidence {
             val base = forRest(hasSession, hasStagedSleep)
             if (base != SOLID) return base
             if (gravitySparse) return BUILDING   // #345: sparse-motion staging can't earn a SOLID Rest
+            // the timeline covers only part of the night it claims
+            if (stageCoverage != null && stageCoverage < HypnogramCoverage.minCoverage) return BUILDING
             if (asleepSeconds <= 0.0) return base
             val restorativeShare = restorativeSeconds / asleepSeconds
             return if (efficiency >= highEfficiencyThreshold && restorativeShare < restorativeLowConfidenceShare) {

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -2587,7 +2587,15 @@ class WhoopRepository(
          *  (ryanbr/noop#241): a sparse import (no stage data on ANY of its sessions that day) must NOT clobber
          *  a computed day that HAS stage data — otherwise a stage-less WHOOP/Apple/HC re-import blanks the
          *  stage breakdown for a night the strap fully staged. Days where the import carries stages, or where
-         *  neither side does, keep the imported-wins rule. Mirrors WhoopStore.SleepMerge (SleepMergeTests). */
+         *  neither side does, keep the imported-wins rule. Mirrors WhoopStore.SleepMerge (SleepMergeTests).
+         *
+         *  Richness is a RANK, not a yes/no ([richness]): 2 = stages covering the span they claim, 1 =
+         *  stages present but HOLED, 0 = none — and the computed day wins only when it OUT-RANKS the
+         *  import. Collapsing 1 and 0 gives back the original presence rule exactly, so this is a strict
+         *  generalisation: every case #241 decided it still decides the same way. What changes is the pair
+         *  the old rule could not express — a holed import (a device hypnogram assembled from records that
+         *  arrived incomplete: many segments, a fraction of the span) against a COMPLETE computed night,
+         *  which used to go to the import and now goes to the night that actually covers itself. */
         internal fun mergeSleepRichness(
             imported: List<SleepSession>,
             computed: List<SleepSession>,
@@ -2598,8 +2606,8 @@ class WhoopRepository(
             val out = ArrayList<SleepSession>(imported.size + computed.size)
             for ((day, imp) in importedByDay) {
                 val comp = computedByDay[day]
-                if (comp != null && imp.none { hasStages(it) } && comp.any { hasStages(it) }) {
-                    out.addAll(comp)   // richer computed day survives a stage-less import
+                if (comp != null && dayRichness(comp) > dayRichness(imp)) {
+                    out.addAll(comp)   // richer computed day survives a poorer import
                 } else {
                     out.addAll(imp)    // imported wins its day (unchanged rule)
                 }
@@ -2614,6 +2622,23 @@ class WhoopRepository(
             val json = s.stagesJSON?.trim() ?: return false
             return json.isNotEmpty() && json != "[]"
         }
+
+        /** How much of a night this session's stages actually describe: 2 = covers its span, 1 = present
+         *  but HOLED, 0 = none. A timeline whose coverage cannot be measured (the imported minute-dict
+         *  shape, which has no timestamps) is never holed, so it ranks 2 — imports keep being judged on
+         *  presence exactly as they always were, and this gate cannot reach them.
+         *  Twin of WhoopStore.SleepMerge.richness. */
+        private fun richness(s: SleepSession): Int {
+            if (!hasStages(s)) return 0
+            val span = (s.endTs - s.startTs).toDouble()
+            return if (com.noop.analytics.HypnogramCoverage.isHoled(s.stagesJSON, span)) 1 else 2
+        }
+
+        /** A day's richness is that of its BEST session — a day with a fully-staged main night plus an
+         *  unstaged nap is a staged day (#715 keeps every session of the winning day either way).
+         *  Twin of WhoopStore.SleepMerge.dayRichness. */
+        private fun dayRichness(sessions: List<SleepSession>): Int =
+            sessions.fold(0) { acc, s -> maxOf(acc, richness(s)) }
     }
 }
 

--- a/android/app/src/test/java/com/noop/analytics/ChargeEffortRestScoringTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ChargeEffortRestScoringTest.kt
@@ -340,6 +340,77 @@ class ChargeEffortRestScoringTest {
         )
     }
 
+    // Hypnogram coverage: a stage timeline that accounts for only part of the span it claims cannot earn
+    // a SOLID Rest. The case the other two guards structurally cannot see. Mirrors Swift.
+    @Test
+    fun confidence_restCoverageDowngradesHoledHypnogram() {
+        val asleep = 8.0 * 3600.0
+        assertEquals(
+            ScoreConfidence.BUILDING,
+            ScoreConfidence.forRest(
+                hasSession = true, hasStagedSleep = true,
+                asleepSeconds = asleep, restorativeSeconds = asleep * 0.45, efficiency = 0.80,
+                stageCoverage = 0.23,
+            ),
+        )
+    }
+
+    @Test
+    fun confidence_restCoverageKeepsSolidWhenTimelineCoversItsSpan() {
+        val asleep = 8.0 * 3600.0
+        assertEquals(
+            ScoreConfidence.SOLID,
+            ScoreConfidence.forRest(
+                hasSession = true, hasStagedSleep = true,
+                asleepSeconds = asleep, restorativeSeconds = asleep * 0.45, efficiency = 0.80,
+                stageCoverage = 1.0,
+            ),
+        )
+    }
+
+    /** Unknown coverage must fail OPEN — null is "not measured", never "measured badly". */
+    @Test
+    fun confidence_restCoverageUnknownDoesNotDowngrade() {
+        val asleep = 8.0 * 3600.0
+        assertEquals(
+            ScoreConfidence.SOLID,
+            ScoreConfidence.forRest(
+                hasSession = true, hasStagedSleep = true,
+                asleepSeconds = asleep, restorativeSeconds = asleep * 0.45, efficiency = 0.80,
+                stageCoverage = null,
+            ),
+        )
+    }
+
+    /**
+     * The measured night this guard exists for (2026-08-18, Oura ring vs a paired WHOOP strap): the
+     * hypnogram covered 140 of 601 minutes, so NOOP stored 70 minutes of sleep where the strap recorded
+     * 494. It read SOLID because NEITHER existing guard applies — gravitySparse is false (Oura banks no
+     * gravity at all) and H9 needs efficiency >= 0.85 against this night's 0.50. Mirrors Swift.
+     */
+    @Test
+    fun confidence_restCoverageCatchesTheNightH9AndGravityMiss() {
+        val asleep = 70.0 * 60.0
+        val restorative = asleep * 0.45
+        assertEquals(
+            "precondition: without coverage this night reads SOLID — that is the bug",
+            ScoreConfidence.SOLID,
+            ScoreConfidence.forRest(
+                hasSession = true, hasStagedSleep = true,
+                asleepSeconds = asleep, restorativeSeconds = restorative, efficiency = 0.50,
+                gravitySparse = false,
+            ),
+        )
+        assertEquals(
+            ScoreConfidence.BUILDING,
+            ScoreConfidence.forRest(
+                hasSession = true, hasStagedSleep = true,
+                asleepSeconds = asleep, restorativeSeconds = restorative, efficiency = 0.50,
+                gravitySparse = false, stageCoverage = 140.0 / 601.0,
+            ),
+        )
+    }
+
     @Test
     fun confidence_restH9KeepsSolidWhenRestorativeHealthy() {
         val asleep = 8.0 * 3600.0

--- a/android/app/src/test/java/com/noop/analytics/HypnogramCoverageTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HypnogramCoverageTest.kt
@@ -1,0 +1,129 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [HypnogramCoverage] — the ratio that tells a well-formed-looking stage timeline from one that
+ * describes only part of the night it claims.
+ *
+ * BYTE-PARITY BY ORACLE, not by eye (CLAUDE.md). [swiftOracle] below is the VERBATIM stdout of the
+ * Swift twin's arithmetic compiled standalone (`swiftc -O main.swift -o oracle && ./oracle`) over the
+ * whole input space that matters: tiling, an interior hole, the measured 2026-08-18 night, the gate
+ * boundary from both sides and exactly on it, overlap/overhang, every unmeasurable payload shape, and
+ * degenerate spans. Reading the two implementations side by side would not catch a divergence in the
+ * clamp, the null rules, or the boundary comparison; this does.
+ *
+ * Note the `gate-exact` row: 950/1000 prints as 0.94999999999999996 because that is the nearest double
+ * to 0.95 — the SAME double the threshold literal denotes — so `< minCoverage` is false and the night is
+ * not holed. Both platforms must agree on that, which is exactly why the row is pinned.
+ */
+class HypnogramCoverageTest {
+
+    /** VERBATIM Swift stdout. Format: label|fraction (17 significant digits, or "null")|isHoled. */
+    private val swiftOracle = """
+        tiling|1|false
+        two-seg tiling|1|false
+        interior hole|0.5|true
+        night-0818|0.23294509151414308|true
+        gate-exact|0.94999999999999996|false
+        gate-under|0.94899999999999995|true
+        gate-over|0.95099999999999996|false
+        overhang|1|false
+        overlap|1|false
+        zero-len segs|null|false
+        neg-len seg|null|false
+        empty-array|null|false
+        blank|null|false
+        nil|null|false
+        not-json|null|false
+        minute-dict|null|false
+        zero-span|null|false
+        neg-span|null|false
+    """.trimIndent()
+
+    private fun seg(vararg r: Pair<Int, Int>): String =
+        r.joinToString(",", "[", "]") { """{"start":${it.first},"end":${it.second},"stage":"deep"}""" }
+
+    /** The same cases the Swift oracle enumerated, in the same order. */
+    private val cases: List<Triple<String, String?, Double>> = listOf(
+        Triple("tiling", seg(0 to 28800), 28800.0),
+        Triple("two-seg tiling", seg(0 to 14400, 14400 to 28800), 28800.0),
+        Triple("interior hole", seg(0 to 300, 900 to 1200), 1200.0),
+        Triple("night-0818", seg(0 to 4200, 4200 to 8400), 601 * 60.0),
+        Triple("gate-exact", seg(0 to 950), 1000.0),
+        Triple("gate-under", seg(0 to 949), 1000.0),
+        Triple("gate-over", seg(0 to 951), 1000.0),
+        Triple("overhang", seg(0 to 1200), 600.0),
+        Triple("overlap", seg(0 to 600, 300 to 900), 900.0),
+        Triple("zero-len segs", seg(500 to 500, 600 to 600), 1000.0),
+        Triple("neg-len seg", """[{"start":900,"end":300,"stage":"deep"}]""", 1000.0),
+        Triple("empty-array", "[]", 1000.0),
+        Triple("blank", "   ", 1000.0),
+        Triple("nil", null, 1000.0),
+        Triple("not-json", "not json", 1000.0),
+        Triple("minute-dict", """{"light":300,"deep":100,"rem":80,"awake":40}""", 3600.0),
+        Triple("zero-span", seg(0 to 300), 0.0),
+        Triple("neg-span", seg(0 to 300), -1.0),
+    )
+
+    @Test
+    fun matchesTheSwiftOracleExactly() {
+        val expected = swiftOracle.lines().map { it.trim() }.filter { it.isNotEmpty() }
+        assertEquals("oracle row count must match the case list", cases.size, expected.size)
+        for ((i, c) in cases.withIndex()) {
+            val (label, json, span) = c
+            val parts = expected[i].split("|")
+            assertEquals("oracle row $i is for a different case", label, parts[0])
+
+            val f = HypnogramCoverage.fraction(json, span)
+            if (parts[1] == "null") {
+                assertNull("$label: expected unmeasurable", f)
+            } else {
+                assertEquals("$label: fraction", parts[1].toDouble(), f!!, 0.0)
+            }
+            assertEquals("$label: isHoled", parts[2].toBoolean(),
+                HypnogramCoverage.isHoled(json, span))
+        }
+    }
+
+    /** nil is "not measured", never "measured badly" — the distinction every guard fails open on. */
+    @Test
+    fun unmeasurableIsNeverHoled() {
+        for (payload in listOf(null, "", "   ", "[]", "not json",
+            """{"light":300,"deep":100,"rem":80,"awake":40}""")) {
+            assertNull(HypnogramCoverage.fraction(payload, 3600.0))
+            assertFalse(HypnogramCoverage.isHoled(payload, 3600.0))
+        }
+    }
+
+    @Test
+    fun ratioOverloadMatchesSwift() {
+        assertEquals(0.5, HypnogramCoverage.fraction(300.0, 600.0)!!, 0.0)
+        assertEquals(1.0, HypnogramCoverage.fraction(600.0, 600.0)!!, 0.0)
+        assertEquals(1.0, HypnogramCoverage.fraction(900.0, 600.0)!!, 0.0)  // clamped
+        assertNull(HypnogramCoverage.fraction(300.0, 0.0))
+        assertNull(HypnogramCoverage.fraction(0.0, 600.0))
+    }
+
+    /** The threshold itself is a stored cross-platform constant; a silent drift would move the gate. */
+    @Test
+    fun thresholdMatchesSwift() {
+        assertEquals(0.95, HypnogramCoverage.minCoverage, 0.0)
+    }
+
+    /**
+     * The measured night this whole change exists for (2026-08-18, Oura ring vs a paired WHOOP strap):
+     * 140 minutes of segments across a 601-minute span, stored as 70 minutes of sleep where the strap
+     * recorded 494.
+     */
+    @Test
+    fun theMeasuredHoledNightIsFlagged() {
+        val span = 601 * 60.0
+        assertTrue(HypnogramCoverage.isHoled(seg(0 to 4200, 4200 to 8400), span))
+        assertEquals(8400.0 / span, HypnogramCoverage.fraction(seg(0 to 4200, 4200 to 8400), span)!!, 1e-12)
+    }
+}

--- a/android/app/src/test/java/com/noop/data/MergeSleepLocalDayTest.kt
+++ b/android/app/src/test/java/com/noop/data/MergeSleepLocalDayTest.kt
@@ -127,6 +127,70 @@ class MergeSleepLocalDayTest {
         assertEquals("\"[]\" and blank JSON are not stages", listOf(comp0.startTs, comp1.startTs), merged.map { it.startTs })
     }
 
+    // Coverage rank (twins of the Swift SleepMergeTests coverage cases): a stage timeline that covers
+    // only part of the span it claims — a device hypnogram assembled from records that arrived
+    // incomplete — outranks nothing, but not a whole night.
+
+    /** A single segment covering `[start, end)` exactly: a night that accounts for its own span. */
+    private fun tiling(start: Long, end: Long) = """[{"start":$start,"end":$end,"stage":"deep"}]"""
+
+    /**
+     * The case the presence-only rule could not express, and the reason this change exists: a HOLED
+     * import used to win purely by being an import, blanking a computed night that covers itself.
+     */
+    @Test
+    fun mergeSleep_holedImportYieldsToFullyCoveredComputedNight() {
+        val start = wake - 8 * 3600L
+        val comp = session(start, wake, tiling(start, wake))
+        val imp = session(start, wake, someStages) // 1 h of segments over an 8 h span
+        val merged = WhoopRepository.mergeSleep(imported = listOf(imp), computed = listOf(comp))
+        assertEquals("the night that covers its own span wins over a holed import",
+            listOf(comp.stagesJSON), merged.map { it.stagesJSON })
+    }
+
+    /** …but partial data still beats none: a holed import must not lose to a stage-less computed day. */
+    @Test
+    fun mergeSleep_holedImportStillBeatsStagelessComputed() {
+        val comp = session(wake - 8 * 3600L, wake, null)
+        val imp = session(wake - 6 * 3600L, wake, someStages)
+        val merged = WhoopRepository.mergeSleep(imported = listOf(imp), computed = listOf(comp))
+        assertEquals("some stages beat none, holed or not", listOf(imp.startTs), merged.map { it.startTs })
+    }
+
+    /** Equal rank keeps the imported-over-computed default — the rule only fires on a strict out-rank. */
+    @Test
+    fun mergeSleep_equallyHoledSidesKeepImportedWins() {
+        val comp = session(wake - 8 * 3600L, wake, someStages)
+        val imp = session(wake - 6 * 3600L, wake, someStages)
+        val merged = WhoopRepository.mergeSleep(imported = listOf(imp), computed = listOf(comp))
+        assertEquals(listOf(imp.startTs), merged.map { it.startTs })
+    }
+
+    /** A fully-covered import is untouched by any of this. */
+    @Test
+    fun mergeSleep_fullyCoveredImportStillWins() {
+        val cs = wake - 8 * 3600L
+        val ist = wake - 6 * 3600L
+        val comp = session(cs, wake, tiling(cs, wake))
+        val imp = session(ist, wake, tiling(ist, wake))
+        val merged = WhoopRepository.mergeSleep(imported = listOf(imp), computed = listOf(comp))
+        assertEquals(listOf(imp.startTs), merged.map { it.startTs })
+    }
+
+    /**
+     * The imported minute-dict shape carries no timestamps, so it can never be judged holed — every
+     * WHOOP/Apple/Health-Connect import keeps its existing precedence.
+     */
+    @Test
+    fun mergeSleep_importedMinuteDictIsNeverHoled() {
+        val cs = wake - 8 * 3600L
+        val comp = session(cs, wake, tiling(cs, wake))
+        val imp = session(wake - 6 * 3600L, wake, """{"light":300,"deep":100,"rem":80,"awake":40}""")
+        val merged = WhoopRepository.mergeSleep(imported = listOf(imp), computed = listOf(comp))
+        assertEquals("a dict-shaped import is not measurable, so it wins as before",
+            listOf(imp.startTs), merged.map { it.startTs })
+    }
+
     @Test
     fun mergeSleep_richnessExceptionKeepsEverySessionOfWinningDay() {
         // computed main night (with stages) + computed nap (no stages); import is stage-less.


### PR DESCRIPTION
Fixes #1716.

A sleep session's stage timeline is supposed to TILE its span. `SleepStageTotals` says so in as many
words — *"the segment stages noop stores (which TILE the window, last segment clamped to the wake), Σ
stage minutes equals the clock span … would diverge only for malformed non-tiling stages"* — and every
consumer downstream is written as though it holds.

One producer breaks it. A device-PROVIDED hypnogram is assembled from records that can arrive
INCOMPLETE, and `OuraSleepSessionMapping` merges only CONTIGUOUS codes, so a sleep-phase page that
never arrived leaves a hole in `stagesJSON` while `startTs`/`endTs` still span the whole night. The
row that comes out looks well-formed: non-empty, many segments, a plausible efficiency. It just
describes a fraction of the night it claims.

## What it costs

31 consecutive nights on one ring, 22 of them with a WHOOP strap worn the same night as ground truth.

| night | span | covered | cov% | stored TST | eff | WHOOP TST | TST err |
|---|---|---|---|---|---|---|---|
| 2026-07-30 | 52 | 52 | 100% | 44 | 86% | 492 | −448 |
| 2026-08-01 | 510 | 510 | 100% | 81 | 16% | 458 | −377 |
| 2026-08-11 | 520 | 520 | 100% | 186 | 36% | 506 | −320 |
| 2026-08-12 | 520 | 442 | 85% | 328 | 74% | 444 | −116 |
| 2026-08-13 | 130 | 62 | 48% | 28 | 46% | 474 | −446 |
| 2026-08-15 | 390 | 156 | 40% | 64 | 41% | 483 | −418 |
| 2026-08-16 | 368 | 286 | 78% | 100 | 35% | 445 | −344 |
| 2026-08-17 | 485 | 405 | 83% | 346 | 85% | 448 | −102 |
| 2026-08-18 | 601 | 140 | **23%** | 70 | 50% | 494 | **−424** |
| 2026-08-21 | 534 | 498 | 93% | 416 | 84% | — | — |
| 2026-08-24 | 550 | 506 | 92% | 411 | 81% | — | — |

Minutes throughout. **9 of 31 nights affected; mean stored-TST error −328 min** across the seven with
strap truth. Healthy nights sit at −18…−54 min, which is just the onset/offset difference between two
devices on one wrist.

2026-08-18 is the clean example: **70 minutes of sleep at 50% efficiency with 3 minutes of REM**,
against a strap that recorded **494 minutes at 85%**. Those numbers feed the sleep-debt ledger, the
Rest composite (hence Charge) and the baselines, at full weight.

## Why nothing caught it

- **The merge's richness rule is a presence test.** `SleepMerge.hasStages` asks only whether the
  payload is non-empty and not `"[]"`. The holed row carries 21 segments, so it passes and wins its
  day. The rule guards against a *stage-less* import; it has no concept of a *stage-holed* one.
- **`gravitySparse` is inert here.** `SleepStager.isGravitySparse` returns `false` when
  `grav.count < 2`, and the Oura path banks no gravity at all — so the #345 guard never fires on any
  ring night, not just this one.
- **The #H9 restorative floor needs `efficiency >= 0.85`.** This night reads 0.50, so it is skipped.
  H9 also could not have caught it in principle: the part that *did* arrive has an ordinary
  restorative share.

So the night was reported **`.solid`**.

## The change

The missing quantity turns out not to be a new measurement at all — it is a ratio of two numbers
already stored (Σ segment durations ÷ `endTs − startTs`). `HypnogramCoverage` derives it on read.
**Nothing is persisted and there is no migration**, which also means it applies retroactively to nights
already in the database rather than only to future ones.

**1. Richness becomes a RANK.** `SleepMerge` / `WhoopRepository.mergeSleepRichness`:

| rank | meaning |
|---|---|
| 2 | stages covering the span they claim |
| 1 | stages present but **holed** |
| 0 | no stages |

and the computed day wins only when it **out-ranks** the import. Collapsing 1 and 0 together gives
back the original presence rule exactly, so this is a **strict generalisation** — every case #240/#241
decided, it still decides the same way. The only pair whose outcome changes is the one the old rule
could not express: a holed import against a complete computed night.

This shape was not the first attempt. Swapping `hasStages` for a `hasUsableStages` that also requires
coverage, applied symmetrically, *regresses #240* — a holed **computed** night must still rescue the
day from a **stage-less** import, but under a symmetric test both sides read "not usable" and the
stage-less import wins, blanking the night. The existing suite caught it.

**2. `ScoreConfidence.rest` gains a third downgrade clause** on coverage, beside `gravitySparse` and
the H9 floor — a new clause in the existing mechanism, not a new mechanism.

**3. `AnalyticsEngine` sums coverage** off the already-decoded segments (no JSON re-parse) and passes
it. It is accumulated separately from `inBedS`, because that one later absorbs the inter-fragment gap
(#777/#705) and those are different quantities: a bridged out-of-bed gap is *known-awake* time between
two fragments, whereas a hole INSIDE a fragment is time we never observed.

Threshold `minCoverage = 0.95`. The observed nights separate cleanly — healthy 99–100%, broken 23–93% —
so the gate sits in empty space rather than balanced on the edge of the data.

## What it deliberately does not do

- **It does not count uncovered time as awake.** We do not know what happened there. Asserting wake
  would be the same overreach as the current behaviour, pointed the other way. The guard reports only
  how much of the night was *observed*.
- **Both guards fail OPEN.** Coverage is `nil` for a payload it cannot measure, and `nil` means "not
  measured", never "measured badly". That is what keeps this away from WHOOP / Apple / Health-Connect
  imports: their minute-dict shape carries no timestamps, so it is never judged holed and they are
  scored on presence exactly as before.
- **It recovers no sleep.** The pages never arrived — that is the overnight link/drain problem, tracked
  separately. This stops NOOP asserting a night it did not observe.
- **It changes no score.** Confidence-only, and no stages are invented.

## Not in this PR

The same investigation found a second defect at `AnalyticsEngine`'s main-group loop: in-bed comes from
the **clock span** while TST comes from the **segments**, so `Rest.composite` receives an inconsistent
pair (`tst 70 min` against `in-bed 601 min`) on exactly these nights. Fixing it means taking in-bed from
the segments — which changes stored daily numbers, so per the one-concern rule it belongs in its own PR
with its own recompute thinking. Not here.

Two of the nine affected nights (2026-08-01, 2026-08-11) tile 100% but call most of the night "wake".
That is a **different and unattributed** failure mode — `0xFF` decodes to four codes of `0b11` = awake
and `MIN_TRAILING_UNWRITTEN = 6` only suppresses a *trailing* run of ≥ 6 bytes, which is a candidate,
not a cause. Both nights predate the raw sidecars, so the wire bytes are gone and it cannot be
confirmed. Out of scope here; noted so it is not mistaken for something this PR handles.

## Verification

Pure and cross-platform throughout — no strap, no CoreBluetooth, no BLE path touched.

| gate | result |
|---|---|
| `swift test` WhoopStore | 441 pass |
| `swift test` StrandAnalytics | 1636 pass |
| `./gradlew testFullDebugUnitTest` | 4739 pass, 2 failures (below) |
| macOS app target build | succeeds |
| `StrandTests` under `xcodebuild … test` | passes |
| iOS `NOOPiOS` target build | succeeds |
| `Tools/doc_comment_lint.py` | OK |
| `Tools/i18n_audit.py --ci` | OK |

The two Android failures are `RecoveryDriversTest` float rounding (`expected:<-0.5> but
was:<-0.4999999999999929>`), **confirmed failing identically on a clean tree at this same base** before
any of these changes — unrelated to sleep, and not the known locale-sensitive set (those pass under
`-Duser.language=en`; these still fail).

App targets were built locally because `app-build.yml` is disabled by default, so nothing in CI covers
them.

**Parity is pinned by oracle, not by eye.** `HypnogramCoverageTest` embeds the verbatim stdout of the
Swift twin compiled standalone (`swiftc -O`) across the input space that matters: tiling, an interior
hole, the measured night, the gate boundary from both sides *and exactly on it*, overlap/overhang,
every unmeasurable payload shape, and degenerate spans. The boundary row earns its place — 950/1000
prints as `0.94999999999999996`, which is the same double the `0.95` literal denotes, so it is **not**
holed. Reading the two implementations side by side could not have settled that.

New tests: `HypnogramCoverageTests` / `HypnogramCoverageTest` (both platforms), plus coverage-rank
cases in `SleepMergeTests` / `MergeSleepLocalDayTest` and coverage cases in `AnalyticsEngineTests` /
`ChargeEffortRestScoringTest`. The confidence tests pin the real night twice: once asserting it reads
`.solid` *without* coverage (the bug), once `.building` with it.