### PR TITLE
Show a copyable recovery screen after Android crashes

### DIFF
--- a/android/app/src/main/java/com/noop/CrashCapture.kt
+++ b/android/app/src/main/java/com/noop/CrashCapture.kt
@@ -1,6 +1,7 @@
 package com.noop
 
 import android.content.Context
+import android.os.Build
 import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
@@ -27,8 +28,17 @@ object CrashCapture {
                 val sw = StringWriter()
                 throwable.printStackTrace(PrintWriter(sw))
                 val text = buildString {
-                    appendLine("when:   ${java.util.Date()}")
-                    appendLine("thread: ${thread.name}")
+                    append(crashHeader(
+                        whenText = java.util.Date().toString(),
+                        threadName = thread.name,
+                        appVersion = BuildConfig.VERSION_NAME,
+                        versionCode = BuildConfig.VERSION_CODE,
+                        packageName = appContext.packageName,
+                        androidRelease = Build.VERSION.RELEASE,
+                        sdk = Build.VERSION.SDK_INT,
+                        manufacturer = Build.MANUFACTURER,
+                        model = Build.MODEL,
+                    ))
                     appendLine(sw.toString())
                 }
                 File(appContext.filesDir, FILE).writeText(text)
@@ -64,4 +74,22 @@ object CrashCapture {
     internal fun fingerprint(text: String): String = MessageDigest.getInstance("SHA-256")
         .digest(text.toByteArray(Charsets.UTF_8))
         .joinToString("") { "%02x".format(it) }
+
+    internal fun crashHeader(
+        whenText: String,
+        threadName: String,
+        appVersion: String,
+        versionCode: Int,
+        packageName: String,
+        androidRelease: String,
+        sdk: Int,
+        manufacturer: String,
+        model: String,
+    ) = buildString {
+        appendLine("when:   $whenText")
+        appendLine("app:    $appVersion ($versionCode) · $packageName")
+        appendLine("os:     Android $androidRelease (API $sdk)")
+        appendLine("device: $manufacturer $model")
+        appendLine("thread: $threadName")
+    }
 }

--- a/android/app/src/main/java/com/noop/CrashCapture.kt
+++ b/android/app/src/main/java/com/noop/CrashCapture.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.security.MessageDigest
 
 /**
  * Captures the last uncaught exception to a file so a crash that only reproduces on a user's own
@@ -14,6 +15,8 @@ import java.io.StringWriter
  */
 object CrashCapture {
     private const val FILE = "last_crash.txt"
+    private const val PREFS = "noop_crash_capture"
+    private const val ACKNOWLEDGED = "acknowledged_fingerprint"
 
     fun install(context: Context) {
         val appContext = context.applicationContext
@@ -40,4 +43,25 @@ object CrashCapture {
         if (!f.exists()) return null
         return runCatching { f.readText() }.getOrNull()?.ifBlank { null }
     }
+
+    /** A crash not yet dismissed by the user, shown before launch touches the database or BLE stack. */
+    fun pendingCrash(context: Context): String? {
+        val crash = lastCrash(context) ?: return null
+        val acknowledged = context.applicationContext
+            .getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .getString(ACKNOWLEDGED, null)
+        return crash.takeIf { isPending(fingerprint(it), acknowledged) }
+    }
+
+    /** Keep the crash for diagnostics, but allow the next launch attempt to continue. */
+    fun acknowledge(context: Context, crash: String) {
+        context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .edit().putString(ACKNOWLEDGED, fingerprint(crash)).apply()
+    }
+
+    internal fun isPending(fingerprint: String, acknowledged: String?) = fingerprint != acknowledged
+
+    internal fun fingerprint(text: String): String = MessageDigest.getInstance("SHA-256")
+        .digest(text.toByteArray(Charsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }
 }

--- a/android/app/src/main/java/com/noop/NoopApplication.kt
+++ b/android/app/src/main/java/com/noop/NoopApplication.kt
@@ -43,12 +43,12 @@ class NoopApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        // Install before any app-owned startup work so even an early failure is preserved for the
+        // recovery screen on the next launch.
+        CrashCapture.install(this)
         // #1008: pin the pre-change Overnight-only default for existing installs before anything
         // reads it. Idempotent; a no-op on fresh installs and on every launch after the first.
         com.noop.ui.NoopPrefs.migrateContinuousHrvOvernightDefault(this)
-        // Record any uncaught crash to a file so it rides along in the shareable strap log — a
-        // device-specific crash (e.g. Insights #224/#267) is otherwise lost to an unreachable logcat.
-        CrashCapture.install(this)
     }
 
     /** Process-wide Room-backed store. One instance shared by the UI and the background service. */

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -10,7 +10,15 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -18,6 +26,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -25,7 +37,9 @@ import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.noop.BuildConfig
+import com.noop.CrashCapture
 import com.noop.NoopApplication
+import com.noop.R
 import com.noop.ble.WhoopModel
 import com.noop.data.DemoSeeder
 import com.noop.data.WhoopRepository
@@ -57,6 +71,20 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
+        CrashCapture.pendingCrash(this)?.let { crash ->
+            setContent {
+                NoopTheme {
+                    CrashRecoveryScreen(
+                        crash = crash,
+                        onContinue = {
+                            CrashCapture.acknowledge(this, crash)
+                            recreate()
+                        },
+                    )
+                }
+            }
+            return
+        }
         // Load the saved "Card transparency" so every frosted card renders at the chosen opacity from launch.
         CardAppearance.init(this)
 
@@ -139,6 +167,29 @@ class MainActivity : ComponentActivity() {
         }.toTypedArray()
 
         if (needed.isNotEmpty()) permissionLauncher.launch(needed)
+    }
+}
+
+@Composable
+private fun CrashRecoveryScreen(crash: String, onContinue: () -> Unit) {
+    val clipboard = LocalClipboardManager.current
+    Surface(Modifier.fillMaxSize(), color = Palette.surfaceBase) {
+        Column(
+            Modifier.padding(horizontal = 20.dp, vertical = 32.dp).verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(stringResource(R.string.crash_recovery_title), style = NoopType.title1, color = Palette.textPrimary)
+            Text(stringResource(R.string.crash_recovery_body), style = NoopType.body, color = Palette.textSecondary)
+            Button(onClick = { clipboard.setText(AnnotatedString(crash)) }) {
+                Text(stringResource(R.string.crash_recovery_copy))
+            }
+            Button(onClick = onContinue) {
+                Text(stringResource(R.string.crash_recovery_continue))
+            }
+            SelectionContainer {
+                Text(crash, style = NoopType.caption, color = Palette.textSecondary)
+            }
+        }
     }
 }
 

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2558,4 +2558,8 @@
     <string name="l10n_settings_screen_once_a_day_noop_asks_github_5683aad3">Einmal täglich fragt NOOP bei GitHub die neueste Versionsnummer ab und legt einen Hinweis in Updates ab, wenn es eine neuere gibt. Es werden keine Daten über dich gesendet, und es wird nie etwas installiert.</string>
     <string name="l10n_updates_noop_1s_is_available_05d8ef55">NOOP %1$s ist verfügbar</string>
     <string name="l10n_updates_youre_on_1s_open_settings_and_35b9e135">Du nutzt %1$s. Öffne die Einstellungen und tippe auf „Nach Updates suchen“, um die Neuerungen zu sehen und %2$s herunterzuladen.</string>
+    <string name="crash_recovery_title">NOOP wurde unerwartet beendet</string>
+    <string name="crash_recovery_body">Der letzte Absturz wird unten angezeigt. Du kannst ihn für einen Fehlerbericht kopieren und danach erneut versuchen, die App zu öffnen.</string>
+    <string name="crash_recovery_copy">Fehler kopieren</string>
+    <string name="crash_recovery_continue">NOOP erneut öffnen</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2544,4 +2544,8 @@
     <string name="l10n_settings_screen_once_a_day_noop_asks_github_5683aad3">Una vez al día, NOOP consulta a GitHub el número de la última versión y deja un aviso en Novedades si hay una más reciente. No se envía nada sobre ti y nunca instala nada.</string>
     <string name="l10n_updates_noop_1s_is_available_05d8ef55">NOOP %1$s ya está disponible</string>
     <string name="l10n_updates_youre_on_1s_open_settings_and_35b9e135">Tienes la %1$s. Abre Ajustes y usa Buscar actualizaciones para ver las novedades y descargar la %2$s.</string>
+    <string name="crash_recovery_title">NOOP se cerró inesperadamente</string>
+    <string name="crash_recovery_body">El último fallo aparece abajo. Puedes copiarlo para informar del error y volver a intentar abrir la aplicación.</string>
+    <string name="crash_recovery_copy">Copiar error</string>
+    <string name="crash_recovery_continue">Intentar abrir NOOP</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2543,4 +2543,8 @@
     <string name="l10n_settings_screen_once_a_day_noop_asks_github_5683aad3">Une fois par jour, NOOP demande à GitHub le numéro de la dernière version et dépose une note dans Mises à jour s’il en existe une plus récente. Aucune donnée vous concernant n’est envoyée, et rien n’est jamais installé.</string>
     <string name="l10n_updates_noop_1s_is_available_05d8ef55">NOOP %1$s est disponible</string>
     <string name="l10n_updates_youre_on_1s_open_settings_and_35b9e135">Vous utilisez la version %1$s. Ouvrez les Réglages et utilisez Rechercher des mises à jour pour voir les nouveautés et télécharger la %2$s.</string>
+    <string name="crash_recovery_title">NOOP s’est arrêté inopinément</string>
+    <string name="crash_recovery_body">Le dernier plantage est affiché ci-dessous. Vous pouvez le copier pour un rapport, puis réessayer d’ouvrir l’application.</string>
+    <string name="crash_recovery_copy">Copier l’erreur</string>
+    <string name="crash_recovery_continue">Réessayer d’ouvrir NOOP</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2549,4 +2549,8 @@
     <string name="l10n_settings_screen_once_a_day_noop_asks_github_5683aad3">Raz dziennie NOOP pyta GitHub o numer najnowszej wersji i dodaje notatkę w Aktualizacjach, jeśli jest nowsza. Nic o tobie nie jest wysyłane i nic nigdy nie jest instalowane.</string>
     <string name="l10n_updates_noop_1s_is_available_05d8ef55">NOOP %1$s jest dostępny</string>
     <string name="l10n_updates_youre_on_1s_open_settings_and_35b9e135">Masz wersję %1$s. Otwórz Ustawienia i użyj opcji Sprawdź aktualizacje, aby zobaczyć nowości i pobrać %2$s.</string>
+    <string name="crash_recovery_title">NOOP nieoczekiwanie się zatrzymał</string>
+    <string name="crash_recovery_body">Poniżej znajduje się ostatni błąd. Możesz go skopiować do zgłoszenia, a następnie spróbować ponownie otworzyć aplikację.</string>
+    <string name="crash_recovery_copy">Kopiuj błąd</string>
+    <string name="crash_recovery_continue">Spróbuj otworzyć NOOP</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2537,4 +2537,8 @@
     <string name="l10n_settings_screen_once_a_day_noop_asks_github_5683aad3">Uma vez por dia, o NOOP pergunta ao GitHub o número da versão mais recente e deixa uma nota em Atualizações se existir uma mais recente. Não é enviado nada sobre si e nunca instala nada.</string>
     <string name="l10n_updates_noop_1s_is_available_05d8ef55">O NOOP %1$s está disponível</string>
     <string name="l10n_updates_youre_on_1s_open_settings_and_35b9e135">Tem a versão %1$s. Abra as Definições e use Procurar atualizações para ver as novidades e transferir a %2$s.</string>
+    <string name="crash_recovery_title">O NOOP terminou inesperadamente</string>
+    <string name="crash_recovery_body">A última falha aparece abaixo. Podes copiá-la para um relatório e voltar a tentar abrir a aplicação.</string>
+    <string name="crash_recovery_copy">Copiar erro</string>
+    <string name="crash_recovery_continue">Tentar abrir o NOOP</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2458,4 +2458,8 @@
     <string name="l10n_settings_screen_once_a_day_noop_asks_github_5683aad3">NOOP 每天向 GitHub 查询一次最新版本号，如果有更新版本，就在「更新」中留下提示。不会发送任何与你有关的信息，也绝不会安装任何东西。</string>
     <string name="l10n_updates_noop_1s_is_available_05d8ef55">NOOP %1$s 可用</string>
     <string name="l10n_updates_youre_on_1s_open_settings_and_35b9e135">你当前使用 %1$s。打开「设置」并使用「检查更新」查看新增内容并下载 %2$s。</string>
+    <string name="crash_recovery_title">NOOP 意外停止</string>
+    <string name="crash_recovery_body">上次崩溃信息显示在下方。你可以复制它用于错误报告，然后再次尝试打开应用。</string>
+    <string name="crash_recovery_copy">复制错误</string>
+    <string name="crash_recovery_continue">再次打开 NOOP</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2571,4 +2571,8 @@
     <string name="l10n_settings_screen_once_a_day_noop_asks_github_5683aad3">Once a day, NOOP asks GitHub for the latest version number and puts a note in Updates if there’s a newer one. Nothing about you is sent, and it never installs anything.</string>
     <string name="l10n_updates_noop_1s_is_available_05d8ef55">NOOP %1$s is available</string>
     <string name="l10n_updates_youre_on_1s_open_settings_and_35b9e135">You\'re on %1$s. Open Settings and use Check for updates to see what\'s new and download %2$s.</string>
+    <string name="crash_recovery_title">NOOP stopped unexpectedly</string>
+    <string name="crash_recovery_body">The last crash is shown below. You can copy it for a bug report, then try opening the app again.</string>
+    <string name="crash_recovery_copy">Copy error</string>
+    <string name="crash_recovery_continue">Try opening NOOP</string>
 </resources>

--- a/android/app/src/test/java/com/noop/CrashCaptureTest.kt
+++ b/android/app/src/test/java/com/noop/CrashCaptureTest.kt
@@ -20,4 +20,23 @@ class CrashCaptureTest {
         assertEquals(CrashCapture.fingerprint("same"), CrashCapture.fingerprint("same"))
         assertNotEquals(CrashCapture.fingerprint("first"), CrashCapture.fingerprint("second"))
     }
+
+    @Test
+    fun crashHeaderIdentifiesBuildAndAndroidDevice() {
+        val header = CrashCapture.crashHeader(
+            whenText = "Fri Aug 28 18:23:24 GMT+02:00 2026",
+            threadName = "DefaultDispatcher-worker-6",
+            appVersion = "10.6.1-staging",
+            versionCode = 388,
+            packageName = "com.noop.whoop.staging",
+            androidRelease = "16",
+            sdk = 36,
+            manufacturer = "Google",
+            model = "Pixel 9",
+        )
+        assertTrue(header.contains("app:    10.6.1-staging (388) · com.noop.whoop.staging"))
+        assertTrue(header.contains("os:     Android 16 (API 36)"))
+        assertTrue(header.contains("device: Google Pixel 9"))
+        assertTrue(header.contains("thread: DefaultDispatcher-worker-6"))
+    }
 }

--- a/android/app/src/test/java/com/noop/CrashCaptureTest.kt
+++ b/android/app/src/test/java/com/noop/CrashCaptureTest.kt
@@ -1,0 +1,23 @@
+package com.noop
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CrashCaptureTest {
+    @Test
+    fun unchangedCrashIsShownUntilAcknowledged() {
+        val fingerprint = CrashCapture.fingerprint("stack trace")
+        assertTrue(CrashCapture.isPending(fingerprint, null))
+        assertTrue(CrashCapture.isPending(fingerprint, "older crash"))
+        assertFalse(CrashCapture.isPending(fingerprint, fingerprint))
+    }
+
+    @Test
+    fun fingerprintIsStableAndDistinguishesNewCrashes() {
+        assertEquals(CrashCapture.fingerprint("same"), CrashCapture.fingerprint("same"))
+        assertNotEquals(CrashCapture.fingerprint("first"), CrashCapture.fingerprint("second"))
+    }
+}


### PR DESCRIPTION
## Summary

Android already preserves the last uncaught exception for diagnostic exports, but a startup crash still leaves the user with only the system's "App keeps stopping" flow. This change surfaces that existing crash record before NOOP initializes its normal UI, database, or BLE state.

The recovery screen:

- shows the complete selectable stack trace;
- identifies the app version/code, package, Android release/API, and device model;
- provides a one-tap copy action for bug reports;
- lets the user explicitly retry normal startup;
- acknowledges only the crash being shown, while retaining it for diagnostic exports;
- shows a newly captured crash again if the retry fails.

`CrashCapture` is installed before other app-owned startup work, and fingerprinting prevents an acknowledged historical crash from blocking every later launch.

## Scope

Android only. No database, BLE, analytics, or health-data behavior changes.

## Verification

- all Android unit tests pass (4,738 tests, 6 skipped)
- `assembleFullDebug` passes
- i18n audit passes for all required locales

<img width="1080" height="2340" alt="Screenshot_20260828_190145_NOOP" src="https://github.com/user-attachments/assets/6a03d87a-94fd-4d10-8c84-ea2535653af5" />
