### PR TITLE
diagnostics: stop the funnel calling a failed sync expected

### DIFF
--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -500,6 +500,13 @@ enum DebugDataDiagnostics {
     /// each day to whichever device actually holds its data. Samples under another id are then completely
     /// normal, and calling that a read failure sends the reader hunting a bug that is not there. Only when
     /// the id holding the samples is NOT a live registered strap is the #1193 split the explanation left.
+    ///
+    /// That correction then over-corrected. "So this is expected" assumes a night is worn on ONE strap, and
+    /// a reporter wearing a 4.0 and a 5.0 together hit the case it denies: the active strap banked nothing
+    /// because its handshake never completed (#1635), while the other strap's rows made the line declare
+    /// the silence normal. Nothing available here can tell the two apart — the wearer knows which straps
+    /// were on the wrist and this function cannot — so it states the fork instead of picking a side, and
+    /// names the sync as what to check in the half where something IS wrong.
     static func orphanedSamplesLine(activeId: String, othersWithSamples: [(String, Int)],
                                     otherLiveStrapIds: Set<String> = []) -> String {
         if othersWithSamples.isEmpty {
@@ -512,8 +519,9 @@ enum DebugDataDiagnostics {
                 .map { "'\($0.0)' (\($0.1) rows)" }
                 .joined(separator: ", ")
             return "(no raw biometric samples under the ACTIVE id '\(activeId)' for this night — they are "
-                + "under \(who), another registered strap. A night worn on a different strap is OWNED by that "
-                + "strap, so this is expected; the dayOwner line for this date names the owner.)"
+                + "under \(who), another registered strap. If you wore THAT strap this night, this is expected "
+                + "and the dayOwner line for this date names the owner. If you wore BOTH, the active strap "
+                + "banked nothing for this night and its sync is what to check, not this line.)"
         }
         // Tie-break on id: Kotlin's sortedByDescending is stable but Swift's `sorted` is NOT, so equal
         // counts could otherwise order differently on the two platforms and the twin lines would diverge.

--- a/StrandTests/OrphanedSamplesLineTests.swift
+++ b/StrandTests/OrphanedSamplesLineTests.swift
@@ -51,7 +51,7 @@ final class OrphanedSamplesLineTests: XCTestCase {
     /// The over-assertion this branch exists for. A wearer with two straps has nights owned by the other
     /// one; `DayOwnerResolver` hands each day to whichever device holds its data. Samples under that id
     /// are expected, and calling it a read failure sends the reader hunting a bug that is not there.
-    func testASecondRegisteredStrapsNightIsExpectedNotAReadFailure() {
+    func testASecondRegisteredStrapsNightStatesTheForkNeverABareVerdict() {
         let line = DebugDataDiagnostics.orphanedSamplesLine(
             activeId: "whoop-FD:4A",
             othersWithSamples: [("my-whoop", 59_304)],
@@ -61,6 +61,12 @@ final class OrphanedSamplesLineTests: XCTestCase {
         XCTAssertTrue(line.contains("dayOwner"), "must point at the line that settles it")
         XCTAssertFalse(line.contains("are not being read"), "must not claim a bug")
         XCTAssertFalse(line.contains("#1193"))
+        // #1635 dual-wear: it may NOT declare the silence normal outright. Wearing a 4.0 and a 5.0
+        // together, the other strap's rows are present while the ACTIVE one banked nothing because its
+        // handshake never completed — and this function cannot tell that from a single-strap night.
+        XCTAssertTrue(line.contains("If you wore BOTH"), "must state the both-straps half")
+        XCTAssertTrue(line.contains("sync is what to check"), "and name the sync as what to check")
+        XCTAssertFalse(line.contains("OWNED by that strap"), "must not assert one-strap ownership")
     }
 
     /// An id that is NOT a live registered strap is still the #1193 split — that wording must survive.

--- a/StrandTests/OrphanedSamplesLineTests.swift
+++ b/StrandTests/OrphanedSamplesLineTests.swift
@@ -48,9 +48,12 @@ final class OrphanedSamplesLineTests: XCTestCase {
 
     // MARK: - #1193 wording is for a genuine split — NOT for a second strap's night
 
-    /// The over-assertion this branch exists for. A wearer with two straps has nights owned by the other
-    /// one; `DayOwnerResolver` hands each day to whichever device holds its data. Samples under that id
-    /// are expected, and calling it a read failure sends the reader hunting a bug that is not there.
+    /// Both over-assertions this branch has carried. It must not call a second strap's night a read
+    /// failure — `DayOwnerResolver` hands each day to whichever device holds its data, so samples under
+    /// that id can be perfectly normal. And it must not call the silence expected either: with a 4.0 and
+    /// a 5.0 worn together the active strap can bank nothing because its handshake never completed
+    /// (#1635), which looks identical from here. The line states both halves; this pins that it keeps
+    /// stating both.
     func testASecondRegisteredStrapsNightStatesTheForkNeverABareVerdict() {
         let line = DebugDataDiagnostics.orphanedSamplesLine(
             activeId: "whoop-FD:4A",

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -507,6 +507,13 @@ object AndroidDiagnostics {
      * ME hunting one). Only when the id holding the samples is NOT a live registered strap is the #1193
      * split the remaining explanation.
      *
+     * That correction then over-corrected. "So this is expected" assumes a night is worn on ONE strap,
+     * and a reporter wearing a 4.0 and a 5.0 together hit the case it denies: the active strap banked
+     * nothing because its handshake never completed (#1635), while the other strap's rows made the line
+     * declare the silence normal. Nothing available here can tell the two apart — the wearer knows which
+     * straps were on the wrist and this function cannot — so it states the fork instead of picking a
+     * side, and names the sync as what to check in the half where something IS wrong.
+     *
      * Pure so the wording is unit-tested without a database, a strap, or a registry.
      */
     internal fun orphanedSamplesLine(
@@ -524,8 +531,9 @@ object AndroidDiagnostics {
                 .sortedWith(compareByDescending<Pair<String, Int>> { it.second }.thenBy { it.first })
                 .joinToString(", ") { "'${it.first}' (${it.second} rows)" }
             return "(no raw biometric samples under the ACTIVE id '$activeId' for this night — they are " +
-                "under $who, another registered strap. A night worn on a different strap is OWNED by that " +
-                "strap, so this is expected; the dayOwner line for this date names the owner.)"
+                "under $who, another registered strap. If you wore THAT strap this night, this is expected " +
+                "and the dayOwner line for this date names the owner. If you wore BOTH, the active strap " +
+                "banked nothing for this night and its sync is what to check, not this line.)"
         }
         // Tie-break on id: Kotlin's sortedByDescending is stable but Swift's `sorted` is NOT, so equal
         // counts could otherwise order differently on the two platforms and the twin lines would diverge.

--- a/android/app/src/test/java/com/noop/testcentre/OrphanedSamplesLineTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/OrphanedSamplesLineTest.kt
@@ -67,7 +67,7 @@ class OrphanedSamplesLineTest {
      * expected, and calling it a read failure sends the reader hunting a bug that is not there.
      */
     @Test
-    fun `a second registered strap's night is expected, not a read failure`() {
+    fun `a second registered strap's night states the fork, never a bare verdict`() {
         val line = AndroidDiagnostics.orphanedSamplesLine(
             activeId = "whoop-FD:4A",
             othersWithSamples = listOf("my-whoop" to 59_304),
@@ -78,6 +78,12 @@ class OrphanedSamplesLineTest {
         assertTrue("must point at the line that settles it", line.contains("dayOwner"))
         assertFalse("must not claim a bug", line.contains("are not being read"))
         assertFalse(line.contains("#1193"))
+        // #1635 dual-wear: it may NOT declare the silence normal outright. Wearing a 4.0 and a 5.0
+        // together, the other strap's rows are present while the ACTIVE one banked nothing because its
+        // handshake never completed — and this function cannot tell that from a single-strap night.
+        assertTrue("must state the both-straps half", line.contains("If you wore BOTH"))
+        assertTrue("and name the sync as what to check", line.contains("sync is what to check"))
+        assertFalse("must not assert one-strap ownership", line.contains("OWNED by that strap"))
     }
 
     /** An id that is NOT a live registered strap is still the #1193 split — that wording must survive. */

--- a/android/app/src/test/java/com/noop/testcentre/OrphanedSamplesLineTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/OrphanedSamplesLineTest.kt
@@ -62,9 +62,11 @@ class OrphanedSamplesLineTest {
     // #1193 wording is for a genuine split — NOT for a second strap's night
 
     /**
-     * The over-assertion this branch exists for. A wearer with two straps has nights owned by the other
-     * one; DayOwnerResolver hands each day to whichever device holds its data. Samples under that id are
-     * expected, and calling it a read failure sends the reader hunting a bug that is not there.
+     * Both over-assertions this branch has carried. It must not call a second strap's night a read
+     * failure — DayOwnerResolver hands each day to whichever device holds its data, so samples under that
+     * id can be perfectly normal. And it must not call the silence expected either: with a 4.0 and a 5.0
+     * worn together the active strap can bank nothing because its handshake never completed (#1635),
+     * which looks identical from here. The line states both halves; this pins that it keeps stating both.
      */
     @Test
     fun `a second registered strap's night states the fork, never a bare verdict`() {


### PR DESCRIPTION
Found in a field log from a wearer with a WHOOP 4.0 and a 5.0 on the wrist **at the same time**.

## What the diagnostic said

The night's funnel read `grav=0 hr=0 rr=0 resp=0 skin=0` under the ACTIVE strap, and the line beneath it explained:

> A night worn on a different strap is OWNED by that strap, **so this is expected**

It was not expected. Both straps were worn. The 4.0's 59,304 rows are why the other id holds samples; the 5.0 banked nothing because its handshake never completes (#1635) — two backfill attempts that session, both `deferred`, zero records decoded. The one line placed to catch that declared it normal.

That the link was healthy makes it worse: the same log shows connections lasting **5.9 hours** and **2.5 hours**. Six hours of stable connection, nothing banked, and the diagnostic said everything was fine.

## Why the fix is wording, not logic

I looked for a signal that separates "you wore the other strap" from "your active strap failed to sync". There isn't one. `sync.lastWriteOkAt` is app-wide rather than per-device — in this log it reads *2d ago*, which is when the **other** strap landed the night in question, so it says nothing about the active one. A per-device query would be new plumbing on both platforms for a signal that still could not answer the real question, which is **what was on the wrist**. The wearer knows that; this function cannot.

So it states the fork instead of picking a side:

> …another registered strap. If you wore **THAT** strap this night, this is expected and the dayOwner line for this date names the owner. If you wore **BOTH**, the active strap banked nothing for this night and its sync is what to check, not this line.

In the reported log that points straight at the 5.0 handshake instead of away from it.

## Second correction to the same sentence, in the opposite direction

Worth knowing before anyone swings it back a third time:

1. The original asserted a read failure — an over-assertion.
2. `otherLiveStrapIds` fixed that, and over-corrected into denying a real failure.
3. This states both halves and asserts neither.

Both extremes have now been tried, and both doc comments say so.

## Parity

- The user-facing string is **byte-identical** across platforms, verified by normalising away Kotlin/Swift interpolation and concatenation and comparing.
- The two branches this does **not** touch — the fresh-re-add wording and the #1193 split — are still identical too. Editing one branch of a three-branch function is exactly how the other two drift.
- Both twin tests gained the same three assertions, and all 8 case names still match.

## Tests

The case pinning the old wording is renamed: it was `…is expected, not a read failure`, which asserted the exact claim being removed. Its doc comment said the same thing and was corrected too — caught in review, after the rename had already been made.

Both docs now record **both** over-assertions, because the test guards against each: it must not call a second strap's night a read failure, and it must not call the silence expected either.

## Verified

4,729 Android tests, 0 failures; `OrphanedSamplesLineTest` 8/8; `Tools/i18n_audit.py --ci` clean.

`StrandTests` is app-target, so the Swift twin needs app-build: it is **green on `db6029675`** (both legs), which carries all of the code. The head commit on top is comment-only; its own app-build run is queued at the time of opening.
