### PR TITLE
Redact the captured crash everywhere it leaves the device

### DIFF
--- a/android/app/src/main/java/com/noop/CrashCapture.kt
+++ b/android/app/src/main/java/com/noop/CrashCapture.kt
@@ -54,19 +54,36 @@ object CrashCapture {
         return runCatching { f.readText() }.getOrNull()?.ifBlank { null }
     }
 
-    /** A crash not yet dismissed by the user, shown before launch touches the database or BLE stack. */
-    fun pendingCrash(context: Context): String? {
-        val crash = lastCrash(context) ?: return null
+    /**
+     * A crash not yet dismissed by the user, shown before launch touches the database or BLE stack.
+     *
+     * TOTAL, like [lastCrash] beside it: this is the FIRST thing `MainActivity.onCreate` runs, so a
+     * throw here does not degrade the recovery screen — it stops the app starting at all, on every
+     * launch, with no screen left to explain why. A crash-recovery feature that bricks startup is a
+     * worse failure than the crash it exists to report, so any failure reading the acknowledgement
+     * yields null and normal startup proceeds.
+     */
+    fun pendingCrash(context: Context): String? = runCatching {
+        val crash = lastCrash(context) ?: return@runCatching null
         val acknowledged = context.applicationContext
             .getSharedPreferences(PREFS, Context.MODE_PRIVATE)
             .getString(ACKNOWLEDGED, null)
-        return crash.takeIf { isPending(fingerprint(it), acknowledged) }
-    }
+        crash.takeIf { isPending(fingerprint(it), acknowledged) }
+    }.getOrNull()
 
-    /** Keep the crash for diagnostics, but allow the next launch attempt to continue. */
+    /**
+     * Keep the crash for diagnostics, but allow the next launch attempt to continue.
+     *
+     * `commit()` rather than `apply()`: the caller recreates the Activity immediately, and a process
+     * death between the two would lose an asynchronous write and put the same crash back in front of
+     * the user. The write is one small string on a path taken once per crash, so paying for durability
+     * here costs nothing measurable and removes the only way this can repeat itself.
+     */
     fun acknowledge(context: Context, crash: String) {
-        context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-            .edit().putString(ACKNOWLEDGED, fingerprint(crash)).apply()
+        runCatching {
+            context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+                .edit().putString(ACKNOWLEDGED, fingerprint(crash)).commit()
+        }
     }
 
     internal fun isPending(fingerprint: String, acknowledged: String?) = fingerprint != acknowledged

--- a/android/app/src/main/java/com/noop/ui/LogExport.kt
+++ b/android/app/src/main/java/com/noop/ui/LogExport.kt
@@ -266,12 +266,11 @@ object LogExport {
 
         // Append the last captured crash (if any) so a device-specific crash like the Insights
         // tab (#224/#267) arrives with its real stack trace instead of being unreachable.
-        val crash = com.noop.CrashCapture.lastCrash(context)
-        val crashSection = if (crash != null) "\n\n${"─".repeat(40)}\nLast crash:\n$crash" else ""
+        val crashText = crashSection(com.noop.CrashCapture.lastCrash(context))
 
         val dir = File(context.cacheDir, "logs").apply { mkdirs() }
         val file = File(dir, "noop-strap-log-${timestamp()}.txt")
-        file.writeText(header + "\n" + body + crashSection)
+        file.writeText(header + "\n" + body + crashText)
         return file
     }
 
@@ -393,6 +392,18 @@ object LogExport {
         encryptedBond = encryptedBond,
         sharingLog = sharingLog,
     )
+
+    /**
+     * The trailing "Last crash" section of a shared strap log, with its PII scrubbed.
+     *
+     * The crash file is written by the uncaught-exception handler, so unlike the rolling body it never
+     * passes through `WhoopBleClient.log()`'s sink — an exception message that names a strap ("no device
+     * FD:..") would carry a real BLE address straight into a public issue, and this is the artifact
+     * people attach to one. Same rule the header lines above already follow (#453): one export cannot
+     * be safe while the other leaks. Pure so the redaction is assertable without a Context.
+     */
+    internal fun crashSection(crash: String?): String =
+        if (crash == null) "" else "\n\n${"─".repeat(40)}\nLast crash:\n${com.noop.ble.redactStrapLogPii(crash)}"
 
     /**
      * Whether the on-disk capture holds any frames at all.

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -71,6 +71,10 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
+        // NOTE: `crash` stays RAW here on purpose. acknowledge() fingerprints what it is given, and
+        // pendingCrash() fingerprints the stored file — hand it redacted text and the two hashes never
+        // match, so the screen would reappear on every launch forever, which is precisely the loop the
+        // fingerprint exists to prevent. Masking happens where it is SHOWN and COPIED, inside the screen.
         CrashCapture.pendingCrash(this)?.let { crash ->
             setContent {
                 NoopTheme {
@@ -173,6 +177,13 @@ class MainActivity : ComponentActivity() {
 @Composable
 private fun CrashRecoveryScreen(crash: String, onContinue: () -> Unit) {
     val clipboard = LocalClipboardManager.current
+    // Masked for the two paths that leave the device — the visible trace and the clipboard. The stored
+    // file stays verbatim for anything that needs it, and the acknowledgement fingerprint is taken on
+    // the raw text by the caller. redactStrapLogPii is the same sink the strap log and the test bundle
+    // use (BLE MACs and WHOOP serials) and is documented as total, so it cannot throw here. A BLE
+    // exception carrying a device address is exactly its shape, and this screen's copy button exists
+    // to paste into public bug reports.
+    val shown = remember(crash) { com.noop.ble.redactStrapLogPii(crash) }
     Surface(Modifier.fillMaxSize(), color = Palette.surfaceBase) {
         Column(
             Modifier.padding(horizontal = 20.dp, vertical = 32.dp).verticalScroll(rememberScrollState()),
@@ -180,14 +191,14 @@ private fun CrashRecoveryScreen(crash: String, onContinue: () -> Unit) {
         ) {
             Text(stringResource(R.string.crash_recovery_title), style = NoopType.title1, color = Palette.textPrimary)
             Text(stringResource(R.string.crash_recovery_body), style = NoopType.body, color = Palette.textSecondary)
-            Button(onClick = { clipboard.setText(AnnotatedString(crash)) }) {
+            Button(onClick = { clipboard.setText(AnnotatedString(shown)) }) {
                 Text(stringResource(R.string.crash_recovery_copy))
             }
             Button(onClick = onContinue) {
                 Text(stringResource(R.string.crash_recovery_continue))
             }
             SelectionContainer {
-                Text(crash, style = NoopType.caption, color = Palette.textSecondary)
+                Text(shown, style = NoopType.caption, color = Palette.textSecondary)
             }
         }
     }

--- a/android/app/src/test/java/com/noop/CrashCaptureTest.kt
+++ b/android/app/src/test/java/com/noop/CrashCaptureTest.kt
@@ -39,4 +39,31 @@ class CrashCaptureTest {
         assertTrue(header.contains("device: Google Pixel 9"))
         assertTrue(header.contains("thread: DefaultDispatcher-worker-6"))
     }
+
+    // ---- hardening (follow-up to the recovery screen) ----
+
+    /**
+     * The acknowledgement fingerprint is taken on the RAW crash, and the screen shows a REDACTED copy.
+     * If the two ever swap, the hashes stop matching and the recovery screen reappears on every launch
+     * forever — the exact loop the fingerprint exists to prevent, and invisible until someone crashes
+     * with a MAC in the message.
+     */
+    @Test fun redactingForDisplayWouldChangeTheFingerprint() {
+        val raw = "when: now\nthread: main\njava.lang.IllegalStateException: no device FD:12:34:56:78:9A"
+        val shown = com.noop.ble.redactStrapLogPii(raw)
+        assertNotEquals("redaction must actually change this fixture, or the test proves nothing", raw, shown)
+        assertNotEquals(
+            "so acknowledge() must be given the RAW text, never the shown one",
+            CrashCapture.fingerprint(raw),
+            CrashCapture.fingerprint(shown),
+        )
+    }
+
+    /** What the screen renders must carry no MAC, whatever the exception message held. */
+    @Test fun theShownCrashHasItsMacMasked() {
+        val raw = "java.lang.IllegalStateException: no device FD:12:34:56:78:9A"
+        val shown = com.noop.ble.redactStrapLogPii(raw)
+        assertFalse("a full MAC must not survive to the clipboard", shown.contains("FD:12:34:56:78:9A"))
+        assertTrue("and the masked shape is what the rest of the export uses", shown.contains("••"))
+    }
 }

--- a/android/app/src/test/java/com/noop/ui/LogExportCrashSectionTest.kt
+++ b/android/app/src/test/java/com/noop/ui/LogExportCrashSectionTest.kt
@@ -1,0 +1,26 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The strap log is the artifact people attach to public issues, and the crash it carries is the one
+ * text in it that never passed through the live log sink's scrub. These pin that it is redacted on
+ * the way out, and that a device with no crash still ships no section rather than an empty heading.
+ */
+class LogExportCrashSectionTest {
+
+    @Test fun aCrashNamingAStrapShipsWithItsMacMasked() {
+        val raw = "when: now\njava.lang.IllegalStateException: no device FD:12:34:56:78:9A"
+        val section = LogExport.crashSection(raw)
+        assertFalse("a full BLE address must not reach a shared log", section.contains("FD:12:34:56:78:9A"))
+        assertTrue("masked in the same shape as the rest of the export", section.contains("••"))
+        assertTrue("and the section is still labelled for whoever reads it", section.contains("Last crash:"))
+    }
+
+    @Test fun noCrashMeansNoSection() {
+        assertEquals("never fabricate a heading for a crash that did not happen", "", LogExport.crashSection(null))
+    }
+}


### PR DESCRIPTION
Follow-up to #1718, addressing the three points raised in review of that PR.

### The crash text was not redacted

The recovery screen's copy button exists so a crash can be pasted into a bug report, and it was copying the text verbatim. A stack trace that names a strap — `no device FD:12:34:56:78:9A` — carries a real BLE address, so a button whose stated purpose is pasting into public issues turned a latent leak into an invited one.

Auditing every reader of the crash file showed the screen was the **smaller** half:

| reader | before |
|---|---|
| `MainActivity` recovery screen | raw |
| `TestBundleAssembler` | already safe — `redactEntries` re-scrubs every text entry, and a leak guard verifies no MAC or serial survived |
| `LogExport.writeLogFile` | **raw** |

That last one appends `Last crash:` verbatim to the shared strap log — the artifact people actually attach to issues. Its header lines are redacted individually, with a comment eight lines above reading *"Same redactor, so one export cannot be safe while the other leaks"*, and then the crash section leaked. The rolling body is scrubbed by `WhoopBleClient.log()`; the crash file never passes through that sink, because the uncaught handler writes it directly.

`LogExport.crashSection()` is now pure and redacts, so the rule is assertable without a `Context`.

### The crash stays RAW for `acknowledge()`

Worth stating, because the obvious simplification is wrong. `acknowledge()` fingerprints whatever it is given, and `pendingCrash()` fingerprints the stored file. Hand `acknowledge()` the redacted text and the two hashes can never match — the recovery screen would reappear on every launch forever, which is precisely the loop the fingerprint exists to prevent, and invisible until someone crashes with a MAC in the message. Masking happens where the text is **shown** and **copied**, inside the screen. A test pins the two fingerprints apart so the shortcut cannot be taken later.

### `pendingCrash` is now total

It is the first thing `MainActivity.onCreate` runs, so a throw there does not degrade the recovery screen — it stops the app starting at all, on every launch, with no screen left to explain why. A crash-recovery feature that bricks startup is a worse failure than the crash it reports. Now `runCatching { … }.getOrNull()`, matching `lastCrash` beside it.

### `acknowledge` uses `commit()`

The caller recreates the Activity immediately, and a process death between the two would lose an asynchronous write and put the same crash back in front of the user. One small string on a path taken once per crash.

### Notes

`redactStrapLogPii` is the same sink the strap log and test bundle use, and is documented total. It is a top-level function in `WhoopBleClient.kt`, so calling it class-loads that file's JVM facade on the pre-BLE launch path — checked, because this screen exists to render before launch touches the database or BLE stack. That facade's static init compiles two regexes and nothing else; `class WhoopBleClient` is a separate class file and never loads.

Android only. Swift has no crash producer — `TestBundleAssembler.crashLogURL()` is a documented placeholder that will attach fully redacted if a handler is ever wired, so there is no parity gap to close.

### Tests

4736 pass locally. Four are new: two pin the fingerprint asymmetry and the masked render, two pin the strap-log section redacting and staying absent when no crash exists.
