### PR TITLE
Bucket an absolute chronotype from the body-clock phase

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/CircadianEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/CircadianEngine.swift
@@ -48,6 +48,20 @@ public enum CircadianEngine {
     /// Activity acrophase (peak activity) sits roughly this many hours after CBTmin in a typical day — the
     /// offset used to convert the cosinor acrophase into an estimated temperature-minimum time.
     public static let acrophaseAfterCbtMinHours: Double = 12.0
+    /// Population-typical wake hour, used ONLY to place the chronotype reference point.
+    ///
+    /// `offsetVsScheduleMinutes` compares the clock to the USER'S OWN schedule, so it cannot name a
+    /// chronotype: someone reliably asleep 03:00-11:00 has an offset near zero and would read
+    /// "intermediate" while being strongly evening-type. A named lean needs an ABSOLUTE phase, so it is
+    /// bucketed from `tempMinHour` against a population reference instead.
+    public static let chronotypeReferenceWakeHour: Double = 7.0
+    /// Half-width of the "intermediate" band around the reference CBTmin, in hours.
+    ///
+    /// Deliberately wide. `tempMinHour` is derived from an activity cosinor (`acrophase - 12 h`) unless a
+    /// measured `observedTempMinHour` is supplied, and NO production caller supplies one today — so this
+    /// is a lean inferred from movement, not a thermal measurement. A one-hour band either side keeps the
+    /// three buckets coarse enough to be honest about that.
+    public static let chronotypeBandHours: Double = 1.0
 
     // MARK: - Inputs
 
@@ -320,6 +334,52 @@ public enum CircadianEngine {
         var x = h.truncatingRemainder(dividingBy: 24.0)
         if x < 0 { x += 24.0 }
         return x
+    }
+
+    /// A coarse, ABSOLUTE body-clock category: where the temperature minimum sits on the clock.
+    ///
+    /// NOT the "chronotype lean" wording used elsewhere. `estimatePhase` builds a `lean` string from
+    /// `offsetVsScheduleMinutes` ("a night-owl lean"), and the v5 skin-temp design spec defines chronotype
+    /// lean as "earlier/later than your sleep schedule implies" — both RELATIVE to the wearer's own
+    /// schedule. This is relative to the CLOCK, and the two genuinely disagree: a consistent 03:00-11:00
+    /// sleeper is well-aligned by the relative read and `.evening` by this one. Keep the vocabularies
+    /// disjoint in anything user-facing, or the two readings look like a contradiction (#1409).
+    ///
+    /// Three buckets, not a score: the underlying phase estimate is an activity fit, and a finer grain
+    /// would imply precision it does not have.
+    public enum Chronotype: String, Equatable, Sendable, Codable {
+        case morning        // CBTmin earlier than the population reference
+        case intermediate
+        case evening        // CBTmin later than the population reference
+    }
+
+    /// The reference CBTmin clock hour a lean is measured against: the population wake hour minus the
+    /// same `cbtMinBeforeWakeHours` the phase estimator already uses, so the anchor moves with the
+    /// engine's own model rather than being a second, independently-drifting constant.
+    public static var chronotypeAnchorHour: Double {
+        wrap24(chronotypeReferenceWakeHour - cbtMinBeforeWakeHours)
+    }
+
+    /// Bucket an ABSOLUTE temperature-minimum clock hour into a lean.
+    ///
+    /// Compared CIRCULARLY. A `tempMinHour` of 23:30 is five hours BEFORE the 04:30 anchor — a strong
+    /// morning lean — and a naive `23.5 > 5.5` would call it evening instead. Pure, so the boundaries are
+    /// assertable without building a fit.
+    public static func chronotype(tempMinHour: Double) -> Chronotype {
+        let delta = signedHourDelta(from: chronotypeAnchorHour, to: wrap24(tempMinHour))
+        if delta < -chronotypeBandHours { return .morning }
+        if delta > chronotypeBandHours { return .evening }
+        return .intermediate
+    }
+
+    /// The lean for a phase estimate, or nil when the fit is not strong enough to name one.
+    ///
+    /// Gated to `.solid` on purpose. `.wide` is a real fit on thin data and is fine for the continuous
+    /// offset the card already shows, but a NAMED category reads as a fact about the person rather than a
+    /// reading of the week, so it waits for the stronger tier. `.unreadable` never names one.
+    public static func chronotype(_ estimate: PhaseEstimate) -> Chronotype? {
+        guard estimate.confidence == .solid else { return nil }
+        return chronotype(tempMinHour: estimate.tempMinHour)
     }
 
     /// Signed shortest delta in hours from `a` to `b` on the 24 h clock, in (−12, 12].

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/CircadianEngineTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/CircadianEngineTests.swift
@@ -151,4 +151,49 @@ final class CircadianEngineTests: XCTestCase {
         XCTAssertNotEqual(confidence(mesor: 45, amp: 5), .unreadable)   // 0.111
         XCTAssertEqual(confidence(mesor: 45, amp: 4), .unreadable)      // 0.089
     }
+
+    // MARK: - chronotype lean (absolute phase, not schedule-relative)
+
+    /// The boundaries and the circular case, asserted from this side too so the agreement is pinned on
+    /// both platforms rather than only in the Kotlin oracle. `late-evening-wrap` is the row that matters:
+    /// 23:30 is five hours BEFORE the 04:30 anchor, so it is a strong MORNING lean — a naive
+    /// `23.5 > 5.5` bucket would call it evening.
+    func testChronotypeBucketsAbsolutePhaseCircularly() {
+        XCTAssertEqual(CircadianEngine.chronotypeAnchorHour, 4.5, accuracy: 0,
+                       "the anchor is derived from the engine's own constants, not hardcoded")
+        let cases: [(Double, CircadianEngine.Chronotype)] = [
+            (4.5, .intermediate), (3.5, .intermediate), (3.49, .morning),
+            (5.5, .intermediate), (5.51, .evening),
+            (23.5, .morning), (0.0, .morning), (12.0, .evening),
+            (16.5, .evening), (16.4, .evening), (16.6, .morning),
+            (28.5, .intermediate), (-1.0, .morning),
+        ]
+        for (hour, expected) in cases {
+            XCTAssertEqual(CircadianEngine.chronotype(tempMinHour: hour), expected,
+                           "tempMinHour \(hour)")
+        }
+    }
+
+    /// A NAMED category reads as a fact about the person rather than a reading of the week, so it waits
+    /// for the strongest tier — unlike the continuous offset the card already shows at `.wide`.
+    func testChronotypeIsNamedOnlyForASolidFit() {
+        func estimate(_ confidence: CircadianEngine.PhaseConfidence) -> CircadianEngine.PhaseEstimate {
+            CircadianEngine.PhaseEstimate(tempMinHour: 23.5, acrophaseHours: 11.5,
+                                          offsetVsScheduleMinutes: 0, confidence: confidence, note: "")
+        }
+        XCTAssertEqual(CircadianEngine.chronotype(estimate(.solid)), .morning)
+        XCTAssertNil(CircadianEngine.chronotype(estimate(.wide)),
+                     "a thin fit must not name a chronotype")
+        XCTAssertNil(CircadianEngine.chronotype(estimate(.unreadable)))
+    }
+
+    /// The schedule-relative offset CANNOT name a chronotype, which is why this buckets the absolute
+    /// phase instead. A consistent 03:00-11:00 sleeper is well aligned with their OWN schedule — offset
+    /// ~0 — while being strongly evening-type by the clock.
+    func testConsistentLateSleeperIsEveningTypeDespiteAZeroScheduleOffset() {
+        let alignedButLate = CircadianEngine.PhaseEstimate(
+            tempMinHour: 8.0, acrophaseHours: 20.0, offsetVsScheduleMinutes: 0,
+            confidence: .solid, note: "")
+        XCTAssertEqual(CircadianEngine.chronotype(alignedButLate), .evening)
+    }
 }

--- a/android/app/src/main/java/com/noop/analytics/CircadianEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/CircadianEngine.kt
@@ -38,6 +38,25 @@ object CircadianEngine {
     const val maxShiftPerDayHours: Double = 1.0
     const val cbtMinBeforeWakeHours: Double = 2.5
     const val acrophaseAfterCbtMinHours: Double = 12.0
+    /**
+     * Population-typical wake hour, used ONLY to place the chronotype reference point.
+     *
+     * [PhaseEstimate.offsetVsScheduleMinutes] compares the clock to the USER'S OWN schedule, so it cannot
+     * name a chronotype: someone reliably asleep 03:00-11:00 has an offset near zero and would read
+     * "intermediate" while being strongly evening-type. A named lean needs an ABSOLUTE phase, so it is
+     * bucketed from [PhaseEstimate.tempMinHour] against a population reference instead.
+     * Mirrors the Swift twin exactly.
+     */
+    const val chronotypeReferenceWakeHour: Double = 7.0
+    /**
+     * Half-width of the "intermediate" band around the reference CBTmin, in hours.
+     *
+     * Deliberately wide. `tempMinHour` is derived from an activity cosinor (`acrophase - 12 h`) unless a
+     * measured `observedTempMinHour` is supplied, and NO production caller supplies one today — so this is
+     * a lean inferred from movement, not a thermal measurement. A one-hour band either side keeps the
+     * three buckets coarse enough to be honest about that. Mirrors the Swift twin exactly.
+     */
+    const val chronotypeBandHours: Double = 1.0
 
     // ── Inputs ──
 
@@ -243,6 +262,58 @@ object CircadianEngine {
         var x = h % 24.0
         if (x < 0) x += 24.0
         return x
+    }
+
+    /**
+     * A coarse, ABSOLUTE body-clock category: where the temperature minimum sits on the clock.
+     *
+     * NOT the "chronotype lean" wording used elsewhere. [estimatePhase] builds a `lean` string from
+     * [PhaseEstimate.offsetVsScheduleMinutes] ("a night-owl lean"), and the v5 skin-temp design spec
+     * defines chronotype lean as "earlier/later than your sleep schedule implies" — both RELATIVE to the
+     * wearer's own schedule. This is relative to the CLOCK, and the two genuinely disagree: a consistent
+     * 03:00-11:00 sleeper is well-aligned by the relative read and EVENING by this one. Keep the
+     * vocabularies disjoint in anything user-facing, or the two readings look like a contradiction (#1409).
+     *
+     * Three buckets, not a score: the underlying phase estimate is an activity fit, and a finer grain
+     * would imply precision it does not have. Twin of Swift `CircadianEngine.Chronotype`.
+     */
+    enum class Chronotype(val raw: String) {
+        MORNING("morning"),          // CBTmin earlier than the population reference
+        INTERMEDIATE("intermediate"),
+        EVENING("evening"),          // CBTmin later than the population reference
+    }
+
+    /**
+     * The reference CBTmin clock hour a lean is measured against: the population wake hour minus the same
+     * [cbtMinBeforeWakeHours] the phase estimator already uses, so the anchor moves with the engine's own
+     * model rather than being a second, independently-drifting constant.
+     */
+    val chronotypeAnchorHour: Double get() = wrap24(chronotypeReferenceWakeHour - cbtMinBeforeWakeHours)
+
+    /**
+     * Bucket an ABSOLUTE temperature-minimum clock hour into a lean.
+     *
+     * Compared CIRCULARLY. A [tempMinHour] of 23:30 is five hours BEFORE the 04:30 anchor — a strong
+     * morning lean — and a naive `23.5 > 5.5` would call it evening instead. Pure, so the boundaries are
+     * assertable without building a fit.
+     */
+    fun chronotype(tempMinHour: Double): Chronotype {
+        val delta = signedHourDelta(chronotypeAnchorHour, wrap24(tempMinHour))
+        if (delta < -chronotypeBandHours) return Chronotype.MORNING
+        if (delta > chronotypeBandHours) return Chronotype.EVENING
+        return Chronotype.INTERMEDIATE
+    }
+
+    /**
+     * The lean for a phase estimate, or null when the fit is not strong enough to name one.
+     *
+     * Gated to [PhaseConfidence.SOLID] on purpose. WIDE is a real fit on thin data and is fine for the
+     * continuous offset the card already shows, but a NAMED category reads as a fact about the person
+     * rather than a reading of the week, so it waits for the stronger tier. UNREADABLE never names one.
+     */
+    fun chronotype(estimate: PhaseEstimate): Chronotype? {
+        if (estimate.confidence != PhaseConfidence.SOLID) return null
+        return chronotype(estimate.tempMinHour)
     }
 
     /** Signed shortest delta in hours from [a] to [b] on the 24 h clock, in (−12, 12]. */

--- a/android/app/src/test/java/com/noop/analytics/CircadianEngineTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/CircadianEngineTest.kt
@@ -138,4 +138,83 @@ class CircadianEngineTest {
         assertTrue(confidence(45.0, 5.0) != CircadianEngine.PhaseConfidence.UNREADABLE)   // 0.111
         assertEquals(CircadianEngine.PhaseConfidence.UNREADABLE, confidence(45.0, 4.0))   // 0.089
     }
+
+    // ---- chronotype lean (absolute phase, not schedule-relative) ----
+
+    /**
+     * VERBATIM stdout of the Swift twin's arithmetic compiled standalone (`swiftc -O`), pinned per
+     * CLAUDE.md's byte-parity rule. Format: label|tempMinHour|signedDelta|lean.
+     *
+     * The `late-evening-wrap` row is the one that earns its place: 23:30 is five hours BEFORE the 04:30
+     * anchor, so it is a strong MORNING lean. A naive `23.5 > 5.5` bucket would call it evening, and
+     * reading the two implementations side by side would not settle which one is right.
+     *
+     * The antipode pair is pinned because it LOOKS like a bug and is not: 16.5 reads evening and 16.6
+     * reads morning, because 16:30 is exactly half a day from the anchor and either direction is equally
+     * far. Inherent to a circular bucket, unreachable in practice (a 16:30 CBTmin is not a physiology),
+     * and pinned so nobody "corrects" the wrap and breaks the 23:30 case with it.
+     */
+    private val chronotypeOracle = """
+        anchor|4.5|0.0|intermediate
+        band-early-edge|3.5|-1.0|intermediate
+        just-morning|3.49|-1.0099999999999998|morning
+        band-late-edge|5.5|1.0|intermediate
+        just-evening|5.51|1.0099999999999998|evening
+        late-evening-wrap|23.5|-5.0|morning
+        midnight|0.0|-4.5|morning
+        noon|12.0|7.5|evening
+        antipode|16.5|12.0|evening
+        just-before-antipode|16.4|11.899999999999999|evening
+        just-past-antipode|16.6|-11.899999999999999|morning
+        over-24-input|28.5|0.0|intermediate
+        negative-input|-1.0|-5.5|morning
+    """.trimIndent()
+
+    @Test
+    fun chronotypeMatchesTheSwiftOracleExactly() {
+        assertEquals("the anchor is derived from the engine's own constants, not hardcoded",
+            4.5, CircadianEngine.chronotypeAnchorHour, 0.0)
+        for (row in chronotypeOracle.lines().map { it.trim() }.filter { it.isNotEmpty() }) {
+            val (label, hourText, deltaText, leanText) = row.split("|")
+            val hour = hourText.toDouble()
+            assertEquals(
+                "$label: signed delta from the anchor",
+                deltaText.toDouble(),
+                CircadianEngine.signedHourDelta(CircadianEngine.chronotypeAnchorHour, CircadianEngine.wrap24(hour)),
+                0.0,
+            )
+            assertEquals("$label: lean", leanText, CircadianEngine.chronotype(hour).raw)
+        }
+    }
+
+    /**
+     * A NAMED category reads as a fact about the person rather than a reading of the week, so it waits
+     * for the strongest tier — unlike the continuous offset the card already shows at WIDE.
+     */
+    @Test
+    fun chronotypeIsNamedOnlyForASolidFit() {
+        fun estimate(confidence: CircadianEngine.PhaseConfidence) = CircadianEngine.PhaseEstimate(
+            tempMinHour = 23.5, acrophaseHours = 11.5, offsetVsScheduleMinutes = 0.0,
+            confidence = confidence, note = "",
+        )
+        assertEquals(CircadianEngine.Chronotype.MORNING,
+            CircadianEngine.chronotype(estimate(CircadianEngine.PhaseConfidence.SOLID)))
+        assertNull("a thin fit must not name a chronotype",
+            CircadianEngine.chronotype(estimate(CircadianEngine.PhaseConfidence.WIDE)))
+        assertNull(CircadianEngine.chronotype(estimate(CircadianEngine.PhaseConfidence.UNREADABLE)))
+    }
+
+    /**
+     * The schedule-relative offset CANNOT name a chronotype, which is why this is bucketed from the
+     * absolute phase instead. A consistent 03:00-11:00 sleeper is well aligned with their OWN schedule —
+     * offset ~0 — while being strongly evening-type by the clock.
+     */
+    @Test
+    fun aConsistentLateSleeperIsEveningTypeDespiteAZeroScheduleOffset() {
+        val alignedButLate = CircadianEngine.PhaseEstimate(
+            tempMinHour = 8.0, acrophaseHours = 20.0, offsetVsScheduleMinutes = 0.0,
+            confidence = CircadianEngine.PhaseConfidence.SOLID, note = "",
+        )
+        assertEquals(CircadianEngine.Chronotype.EVENING, CircadianEngine.chronotype(alignedButLate))
+    }
 }


### PR DESCRIPTION
Groundwork for the 24 h body-clock dial asked for in #1680, from @pipiche38. **Analytics only** — no UI, no copy, nothing wired to a screen. The dial itself follows separately.

### The label cannot come from the field the issue names

The issue proposes bucketing the chronotype from `offsetVsScheduleMinutes`. That field is documented as the minutes the body clock leads or lags **the user's own schedule**, so it is relative, not absolute: someone reliably asleep 03:00–11:00 sits at an offset near zero and would be labelled "intermediate" while being strongly evening-type.

A named chronotype needs an absolute phase, so this buckets `tempMinHour` — already in the same struct — against a population reference. That exact case is pinned by a test.

### Circular, and that is the part worth testing

A `tempMinHour` of 23:30 sits **five hours before** the 04:30 anchor and is a strong morning lean. A naive `23.5 > 5.5` bucket calls it evening. Both platforms reuse the engine's existing `signedHourDelta` rather than open-coding the comparison, and the wrap case is an oracle row.

The anchor is derived as `chronotypeReferenceWakeHour − cbtMinBeforeWakeHours` rather than written as `4.5`, so it tracks the engine's own model instead of becoming a second constant that drifts away from it.

### Naming, changed on re-review

The first cut called this `ChronotypeLean`, which collides with an existing term for the **opposite axis**. `estimatePhase` already builds a `lean` string from `offsetVsScheduleMinutes` — *"later (a night-owl lean)"* — twelve lines away in the same file, and the v5 skin-temp design spec defines chronotype lean as *"earlier/later than your sleep schedule implies"*. Both are schedule-relative; this is clock-relative, and they genuinely disagree on the consistent 03:00–11:00 sleeper: well-aligned by the relative read, `.evening` by this one.

Renamed to `Chronotype`, with the distinction stated at the declaration so the two readings cannot be taken for one — the same discipline #1405 applied to the two readiness vocabularies.

### Honesty gate

A named category is returned only for a `.solid` fit. `.wide` is a real fit on thin data and is fine for the continuous offset `BodyClockCard` already shows, but a category reads as a fact about the person rather than a reading of the week.

Worth stating plainly: `observedTempMinHour` is supplied **only in tests** — no production caller passes measured thermal corroboration — so `tempMinHour` is always the activity-derived `acrophase − 12 h`. The band is a deliberately wide hour either side for that reason, and the buckets stay coarse at three.

### Tests

The Kotlin side pins the verbatim stdout of the Swift twin compiled standalone (`swiftc -O`) across both band edges, the values just past them, the circular wrap, midnight, **both sides of the antipode** and out-of-range inputs.

The antipode pair is pinned because it looks like a bug and is not: 16.5 reads evening, 16.6 reads morning, because 16:30 is exactly half a day from the anchor and either direction is equally far. Inherent to a circular bucket, unreachable in practice, and pinned so nobody "corrects" the wrap and breaks the 23:30 case with it. The Swift side asserts the same table, so the agreement is held from both ends rather than only in the oracle. Android 4755 pass.

### Deliberately not included

The dial, and the sleep-consistency line the issue suggests. The Sleep screen already surfaces a consistency tile, and it is computed from **bedtime spread** — timing regularity — whereas `VitalityEngine.sleepConsistency` is `1 − CV` over nightly **durations** and says so in its own doc ("a rough but honest on-device proxy … when we only have durations, not full timing"). Under a timing-alignment dial the existing tile is the better of the two, so adding the other would duplicate it with the weaker number.

`habitualMidsleepSec` is the other piece the dial will want — a learned timing anchor the sleep scorer already aligns to — and it needs no new analytics either.

