### PR TITLE
Don't greet an upgrade with a crash from the build it replaced

### DIFF
--- a/android/app/src/main/java/com/noop/CrashCapture.kt
+++ b/android/app/src/main/java/com/noop/CrashCapture.kt
@@ -64,9 +64,18 @@ object CrashCapture {
      * yields null and normal startup proceeds.
      */
     fun pendingCrash(context: Context): String? = runCatching {
+        val app = context.applicationContext
         val crash = lastCrash(context) ?: return@runCatching null
-        val acknowledged = context.applicationContext
-            .getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        // A crash from a build the user has already replaced is not news. The capture handler has written
+        // this file since June while the screen that surfaces it landed in August, so on the first launch
+        // after upgrading, every install carrying an old crash would open on "NOOP stopped unexpectedly"
+        // for something survived weeks earlier — which is how this was found: a 53-day-old crash greeted a
+        // staging build that had not crashed at all.
+        val lastUpdate = runCatching {
+            app.packageManager.getPackageInfo(app.packageName, 0).lastUpdateTime
+        }.getOrDefault(0L)
+        if (isPreUpgradeCrash(File(app.filesDir, FILE).lastModified(), lastUpdate)) return@runCatching null
+        val acknowledged = app.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
             .getString(ACKNOWLEDGED, null)
         crash.takeIf { isPending(fingerprint(it), acknowledged) }
     }.getOrNull()
@@ -85,6 +94,21 @@ object CrashCapture {
                 .edit().putString(ACKNOWLEDGED, fingerprint(crash)).commit()
         }
     }
+
+    /**
+     * Whether a stored crash belongs to a build the user is no longer running.
+     *
+     * `lastUpdateTime` is when this APK was installed or updated, so a crash file older than it was
+     * written by a version that has since been replaced. The file is NOT deleted — the strap log and the
+     * test bundle still carry it, which is exactly how the long-standing R8 minification crash trace was
+     * recovered — it simply stops opening the app on a recovery screen.
+     *
+     * Fails toward SHOWING. If either timestamp is unknown (0), this returns false and the crash surfaces
+     * as before: the screen exists to report crashes, so an occasional stale one is a smaller failure than
+     * silently swallowing a real one. The acknowledgement fingerprint still caps that at a single screen.
+     */
+    internal fun isPreUpgradeCrash(crashModifiedMs: Long, lastUpdateMs: Long): Boolean =
+        crashModifiedMs > 0L && lastUpdateMs > 0L && crashModifiedMs < lastUpdateMs
 
     internal fun isPending(fingerprint: String, acknowledged: String?) = fingerprint != acknowledged
 

--- a/android/app/src/test/java/com/noop/CrashCaptureTest.kt
+++ b/android/app/src/test/java/com/noop/CrashCaptureTest.kt
@@ -66,4 +66,33 @@ class CrashCaptureTest {
         assertFalse("a full MAC must not survive to the clipboard", shown.contains("FD:12:34:56:78:9A"))
         assertTrue("and the masked shape is what the rest of the export uses", shown.contains("••"))
     }
+
+    // ---- pre-upgrade suppression ----
+
+    /**
+     * The capture handler has written last_crash.txt since June; the screen that surfaces it landed in
+     * August. Without this gate, the first launch after upgrading opened on "NOOP stopped unexpectedly"
+     * for a crash survived weeks earlier — found in the field on a staging build that had not crashed at
+     * all, showing a 53-day-old file.
+     */
+    @Test fun aCrashWrittenBeforeTheCurrentInstallIsNotSurfaced() {
+        val installed = 1_700_000_000_000L
+        assertTrue("a crash from the replaced build is not news",
+            CrashCapture.isPreUpgradeCrash(crashModifiedMs = installed - 1, lastUpdateMs = installed))
+        assertFalse("a crash from the build in use IS news",
+            CrashCapture.isPreUpgradeCrash(crashModifiedMs = installed + 1, lastUpdateMs = installed))
+        assertFalse("a crash written exactly at install time is kept — the boundary belongs to the new build",
+            CrashCapture.isPreUpgradeCrash(crashModifiedMs = installed, lastUpdateMs = installed))
+    }
+
+    /**
+     * Fails toward SHOWING. The screen exists to report crashes, so an occasional stale one is a smaller
+     * failure than silently swallowing a real one, and the acknowledgement fingerprint caps it at a single
+     * screen either way.
+     */
+    @Test fun anUnknownTimestampKeepsTheOldBehaviour() {
+        assertFalse("no install time -> show", CrashCapture.isPreUpgradeCrash(1_000L, 0L))
+        assertFalse("no crash mtime -> show", CrashCapture.isPreUpgradeCrash(0L, 1_000L))
+        assertFalse("neither known -> show", CrashCapture.isPreUpgradeCrash(0L, 0L))
+    }
 }


### PR DESCRIPTION
Found in the field: a staging build that had **not** crashed opened straight onto "NOOP stopped unexpectedly", showing a crash dated **53 days earlier**.

### What happened

| | |
|---|---|
| `CrashCapture` began writing `last_crash.txt` | 2026-06-13 |
| the crash on screen | 2026-07-07 |
| the recovery screen that surfaces it (#1718) | 2026-08-29 |

The acknowledgement fingerprint didn't exist before the screen did, so on the first launch after upgrading, any install still carrying an old crash file reads it as unacknowledged and opens on the recovery screen — for something the user lived through weeks ago and has since replaced the build over. It clears on **Try opening NOOP** and never returns, but every existing Android user was in line for one alarming screen about nothing.

I reviewed #1718, merged it, and wrote the redaction follow-up without considering the upgrade path.

### The change

`pendingCrash` compares the crash file's mtime against the package's `lastUpdateTime` and skips anything written before the current install.

**The file is not deleted**, and that matters more than it sounds. The strap log and test bundle still carry it — and the stale crash this incident surfaced turns out to be the obfuscated R8 trace `build.gradle.kts` has been asking for ever since minification was switched off:

> *"a minified build STILL died right after the terms gate on a real device — a library reflective path we couldn't pin without a device to trace. Re-enabling minify needs the exact crash trace + device verification."*

The trace is `CompositionLocal LocalLifecycleOwner not present` at `OnboardingScreenKt.OnboardingScreen` — right after the terms gate, exactly as described. Deleting old crashes on upgrade would have destroyed that evidence. Filing it separately.

### Fails toward showing

An unknown timestamp on either side keeps the previous behaviour. The screen exists to report crashes, so an occasional stale one is a smaller failure than silently swallowing a real one — and the fingerprint caps it at a single screen either way. Both directions are pinned by test, including the boundary case where a crash is written at exactly the install instant (kept, since it belongs to the new build).

Android-only, like the rest of `CrashCapture` — the Apple side still has no crash producer. Android 4761 pass.
