### PR TITLE
Report the body clock's inputs in the diagnostics

### DIFF
--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -416,8 +416,83 @@ object AndroidDiagnostics {
     suspend fun dynamicLines(context: Context): List<String> =
         kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
             strapAndDataLines(context) + funnelLines(context) + workoutSourceLines(context) +
-                dailyDataLines(context) + alarmLines(context)
+                dailyDataLines(context) + alarmLines(context) + circadianLines(context)
         }
+
+    /** Hourly HR buckets over the 14-day window below which the profile is not pooled at all. Mirrors
+     *  `circadianBinsFrom`'s own floor — kept here so the diagnostic names the real number, not a guess. */
+    internal const val CIRCADIAN_MIN_BUCKETS = 24
+    /** Distinct populated local hours below which no estimate is attempted. Mirrors
+     *  `V5HealthSignals.MIN_CIRCADIAN_BINS`. */
+    internal const val CIRCADIAN_MIN_HOURS = 6
+
+    /**
+     * Which gate the body clock is failing, in the order the pipeline applies them.
+     *
+     * The card vanishes for two DIFFERENT reasons that look identical on screen: below the bucket floor
+     * or the hour floor there is NO estimate at all (`V5HealthSignals` returns null and the card's `?.let`
+     * skips it), while a thin or flat fit still returns an estimate marked UNREADABLE, which DOES draw a
+     * card with its own copy. Without this line those are indistinguishable from the outside — the report
+     * that prompted it had a body clock missing on both the Health card and the Sleep dial with no way to
+     * say which floor was short.
+     *
+     * Pure so the wording is assertable without a store, matching `noCaptureMsgText`.
+     */
+    internal fun circadianVerdict(
+        buckets: Int,
+        populatedHours: Int,
+        daysObserved: Int,
+        relativeAmplitude: Double?,
+    ): String = when {
+        buckets < CIRCADIAN_MIN_BUCKETS ->
+            "no estimate — $buckets hourly HR buckets in 14d, needs $CIRCADIAN_MIN_BUCKETS"
+        populatedHours < CIRCADIAN_MIN_HOURS ->
+            "no estimate — HR lands in $populatedHours of 24 local hours, needs $CIRCADIAN_MIN_HOURS"
+        relativeAmplitude != null &&
+            relativeAmplitude < com.noop.analytics.CircadianEngine.minRelativeAmplitude ->
+            "unreadable — rhythm too flat (amplitude ${"%.1f".format(relativeAmplitude * 100)}% of mesor, " +
+                "needs ${"%.0f".format(com.noop.analytics.CircadianEngine.minRelativeAmplitude * 100)}%)"
+        daysObserved < com.noop.analytics.CircadianEngine.minDaysForFit ->
+            "unreadable — $daysObserved days observed, needs " +
+                "${com.noop.analytics.CircadianEngine.minDaysForFit}"
+        daysObserved < com.noop.analytics.CircadianEngine.goodDaysForFit ->
+            "wide — $daysObserved days observed"
+        else -> "solid — $daysObserved days observed"
+    }
+
+    /**
+     * The body clock's three inputs, read fresh from the store.
+     *
+     * Hours and days are counted from the RAW buckets rather than from `circadianBinsFrom`, which
+     * short-circuits to empty below the bucket floor — reporting its zeros would hide the very numbers
+     * this line exists to show.
+     */
+    suspend fun circadianLines(context: Context): List<String> = buildList {
+        add("─".repeat(40))
+        add("Body clock inputs")
+        runCatching {
+            val repo = com.noop.data.WhoopRepository.from(context)
+            val active = runCatching {
+                (context.applicationContext as com.noop.NoopApplication).activeDeviceId
+            }.getOrNull() ?: "unknown"
+            val nowMs = System.currentTimeMillis()
+            val now = nowMs / 1000L
+            val tz = java.util.TimeZone.getDefault().getOffset(nowMs) / 1000L
+            val buckets = repo.hrBucketsUnion(active, now - 14L * 86_400L, now, 3_600L)
+            val hours = buckets.map { (((it.bucket + tz) % 86_400L + 86_400L) % 86_400L / 3_600L) }
+                .distinct().size
+            val days = buckets.map { (it.bucket + tz) / 86_400L }.distinct().size
+            val bins = com.noop.ui.circadianBinsFrom(buckets, tz).first
+            val amp = com.noop.analytics.CircadianEngine.cosinor(bins)?.let { f ->
+                if (f.mesor != 0.0) f.amplitude / kotlin.math.abs(f.mesor) else 0.0
+            }
+            add("Source: $active (+ imported)  window: last 14d")
+            add("Buckets: ${buckets.size} (floor $CIRCADIAN_MIN_BUCKETS)  " +
+                "hours: $hours/24 (need $CIRCADIAN_MIN_HOURS)  days: $days " +
+                "(need ${com.noop.analytics.CircadianEngine.minDaysForFit})")
+            add("Verdict: " + circadianVerdict(buckets.size, hours, days, amp))
+        }.onFailure { add("  (unavailable: ${it.message})") }
+    }
 
     /** "3h 12m ago" style relative stamp for a positive age in ms. */
     private fun relTime(deltaMs: Long): String {

--- a/android/app/src/test/java/com/noop/testcentre/CircadianVerdictTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/CircadianVerdictTest.kt
@@ -1,0 +1,54 @@
+package com.noop.testcentre
+
+import com.noop.analytics.CircadianEngine
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The body-clock verdict line. The card vanishing has two indistinguishable causes on screen — no
+ * estimate at all (below the bucket or hour floor) versus an estimate marked unreadable (thin or flat
+ * fit, which still draws its own card) — so the wording has to name WHICH floor is short.
+ */
+class CircadianVerdictTest {
+
+    private fun verdict(buckets: Int, hours: Int, days: Int, amp: Double? = 0.5) =
+        AndroidDiagnostics.circadianVerdict(buckets, hours, days, amp)
+
+    /** Gates are reported in the order the pipeline applies them: the bucket floor short-circuits first. */
+    @Test fun theBucketFloorIsReportedBeforeAnythingElse() {
+        val v = verdict(buckets = 10, hours = 2, days = 1)
+        assertTrue(v, v.startsWith("no estimate"))
+        assertTrue(v, v.contains("10 hourly HR buckets") && v.contains("needs 24"))
+    }
+
+    @Test fun theHourFloorIsNamedWhenBucketsAreFine() {
+        val v = verdict(buckets = 100, hours = 4, days = 9)
+        assertTrue(v, v.startsWith("no estimate"))
+        assertTrue(v, v.contains("4 of 24 local hours") && v.contains("needs 6"))
+    }
+
+    /**
+     * A flat rhythm and a short history BOTH yield UNREADABLE from the engine, and the card still draws
+     * for either — so the line must distinguish them or it explains nothing.
+     */
+    @Test fun aFlatRhythmIsDistinguishedFromAShortHistory() {
+        val flat = verdict(buckets = 300, hours = 20, days = 20, amp = 0.02)
+        assertTrue(flat, flat.startsWith("unreadable") && flat.contains("too flat"))
+        val thin = verdict(buckets = 300, hours = 20, days = 3, amp = 0.5)
+        assertTrue(thin, thin.startsWith("unreadable") && thin.contains("3 days observed"))
+    }
+
+    /** The readable tiers name the confidence the card will actually show. */
+    @Test fun readableTiersMatchTheEnginesOwnThresholds() {
+        val wide = verdict(buckets = 300, hours = 20, days = CircadianEngine.minDaysForFit)
+        assertTrue(wide, wide.startsWith("wide"))
+        val solid = verdict(buckets = 300, hours = 20, days = CircadianEngine.goodDaysForFit)
+        assertTrue(solid, solid.startsWith("solid"))
+    }
+
+    /** An unmeasurable amplitude must not be read as a flat rhythm. */
+    @Test fun anUnknownAmplitudeDoesNotReadAsFlat() {
+        val v = verdict(buckets = 300, hours = 20, days = 20, amp = null)
+        assertTrue(v, v.startsWith("solid"))
+    }
+}


### PR DESCRIPTION
A device had no body-clock card on Health and no dial on Sleep, and there was no way to say why. Tracing it by hand established the estimate was `null` rather than low-confidence — but not *which* input was short, and nothing in the strap log or Test Centre reports any of them.

### What it adds

A **Body clock inputs** section in the dynamic diagnostics:

```
────────────────────────────────────────
Body clock inputs
Source: <active id> (+ imported)  window: last 14d
Buckets: 112 (floor 24)  hours: 8/24 (need 6)  days: 6 (need 7)
Verdict: unreadable — 6 days observed, needs 7
```

### Why a verdict line and not just numbers

The card vanishing has two causes that look identical from outside:

| condition | what happens | what you see |
|---|---|---|
| below the bucket floor (24 in 14d) or hour floor (6 distinct hours) | **no estimate** — `V5HealthSignals` returns null, `HealthScreen`'s `?.let` skips the card | blank |
| thin history or flat rhythm | estimate returned, marked `UNREADABLE` — the card **does** draw, with its own "hard to read right now" copy | a card |

Same blank space, opposite causes, and no way to tell them apart without reading the source. The verdict names the failing gate in the order the pipeline applies them.

### Counting detail worth knowing

Hours and days are counted from the **raw buckets**, not from `circadianBinsFrom`. That helper short-circuits to `emptyList() to 0` below the bucket floor, so reporting its zeros would hide the very numbers this line exists to show — it would say "hours: 0, days: 0" for a device that has plenty of both but sits one bucket under the floor.

### No thresholds changed

Which gate is short, and by how much, is exactly what isn't known yet. `CircadianEngine.minRelativeAmplitude` already carries this project's position on that:

> *"Deliberately NOT re-tuned … every candidate value is unvalidated, nobody is currently silenced by it, and the direction of the harm is not established."*

Loosening a floor before knowing which one is failing would be that. This is the measurement that makes the decision possible.

### Scope

**Android-only, deliberately.** The Swift twin's binning lives inline in `AppModel.computeCircadianPhase` rather than in a reusable helper, so mirroring this means extracting that first — worth doing, but not inside a change whose purpose is answering an Android question. Flagging it here rather than letting it read as an oversight.

Android **4766 pass**. The verdict wording is pure and unit-tested (five cases: each floor, flat-vs-thin, both readable tiers, and an unmeasurable amplitude that must not read as flat), matching `noCaptureMsgText`'s split — the store read stays in the `Context` wrapper.
