### PR TITLE
Stop a cycle re-evaluate blanking the body clock, and report the rhythm in bpm

### DIFF
--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -419,15 +419,33 @@ object AndroidDiagnostics {
                 dailyDataLines(context) + alarmLines(context) + circadianLines(context)
         }
 
+    /**
+     * One-decimal float, always with a DOT.
+     *
+     * This file already pins `Locale.US` for its dates, for the same reason: the strap log is pasted into
+     * issues and read by whoever picks them up, so a device in a comma-decimal locale must not emit
+     * "4,7 bpm" beside US-formatted timestamps. Kotlin's `"%.1f".format(x)` uses the default locale and
+     * would do exactly that.
+     */
+    private fun fmt1(v: Double): String = String.format(java.util.Locale.US, "%.1f", v)
+
     /** Hourly HR buckets over the 14-day window below which the profile is not pooled at all. Mirrors
      *  `circadianBinsFrom`'s own floor — kept here so the diagnostic names the real number, not a guess. */
     internal const val CIRCADIAN_MIN_BUCKETS = 24
-    /** Distinct populated local hours below which no estimate is attempted. Mirrors
-     *  `V5HealthSignals.MIN_CIRCADIAN_BINS`. */
-    internal const val CIRCADIAN_MIN_HOURS = 6
+    /** Distinct populated local hours below which no estimate is attempted.
+     *
+     *  REFERENCES the engine's own constant rather than repeating its value. A diagnostic that prints
+     *  "needs 6" while the code requires 8 would send whoever reads the log after the wrong thing —
+     *  the one failure mode this section exists to prevent. */
+    internal val CIRCADIAN_MIN_HOURS get() = com.noop.analytics.V5HealthSignals.MIN_CIRCADIAN_BINS
 
     /**
-     * Which gate the body clock is failing, in the order the pipeline applies them.
+     * Which gate the body clock is failing.
+     *
+     * The first two are sequential gates and are reported in the order they run. The last two are a
+     * SINGLE condition in the engine (`daysObserved < minDaysForFit || relativeAmplitude <
+     * minRelativeAmplitude`), split apart here because "unreadable" on its own does not say whether to
+     * keep wearing the strap or to question the threshold — and those lead somewhere different.
      *
      * The card vanishes for two DIFFERENT reasons that look identical on screen: below the bucket floor
      * or the hour floor there is NO estimate at all (`V5HealthSignals` returns null and the card's `?.let`
@@ -450,8 +468,8 @@ object AndroidDiagnostics {
             "no estimate — HR lands in $populatedHours of 24 local hours, needs $CIRCADIAN_MIN_HOURS"
         relativeAmplitude != null &&
             relativeAmplitude < com.noop.analytics.CircadianEngine.minRelativeAmplitude ->
-            "unreadable — rhythm too flat (amplitude ${"%.1f".format(relativeAmplitude * 100)}% of mesor, " +
-                "needs ${"%.0f".format(com.noop.analytics.CircadianEngine.minRelativeAmplitude * 100)}%)"
+            "unreadable — rhythm too flat (amplitude ${fmt1(relativeAmplitude * 100)}% of mesor, " +
+                "needs ${fmt1(com.noop.analytics.CircadianEngine.minRelativeAmplitude * 100)}%)"
         daysObserved < com.noop.analytics.CircadianEngine.minDaysForFit ->
             "unreadable — $daysObserved days observed, needs " +
                 "${com.noop.analytics.CircadianEngine.minDaysForFit}"
@@ -461,7 +479,13 @@ object AndroidDiagnostics {
     }
 
     /**
-     * The body clock's three inputs, read fresh from the store.
+     * The body clock's three inputs, RECOMPUTED from the store.
+     *
+     * It reports what `estimatePhase` WOULD return for the data on disk — not what `_v5Signals.bodyClock`
+     * is currently holding. Those can diverge: a cached-bins staleness once nulled the live estimate on a
+     * device whose store was fine, and against that failure this section would have printed a confident
+     * verdict beside a missing card, misleading exactly as the silence it replaced did. So a verdict here
+     * that disagrees with the screen is itself the finding — it means the snapshot, not the data, is wrong.
      *
      * Hours and days are counted from the RAW buckets rather than from `circadianBinsFrom`, which
      * short-circuits to empty below the bucket floor — reporting its zeros would hide the very numbers
@@ -469,7 +493,7 @@ object AndroidDiagnostics {
      */
     suspend fun circadianLines(context: Context): List<String> = buildList {
         add("─".repeat(40))
-        add("Body clock inputs")
+        add("Body clock inputs (recomputed from the store, not the live snapshot)")
         runCatching {
             val repo = com.noop.data.WhoopRepository.from(context)
             val active = runCatching {
@@ -483,13 +507,23 @@ object AndroidDiagnostics {
                 .distinct().size
             val days = buckets.map { (it.bucket + tz) / 86_400L }.distinct().size
             val bins = com.noop.ui.circadianBinsFrom(buckets, tz).first
-            val amp = com.noop.analytics.CircadianEngine.cosinor(bins)?.let { f ->
+            val fit = com.noop.analytics.CircadianEngine.cosinor(bins)
+            val amp = fit?.let { f ->
                 if (f.mesor != 0.0) f.amplitude / kotlin.math.abs(f.mesor) else 0.0
             }
             add("Source: $active (+ imported)  window: last 14d")
             add("Buckets: ${buckets.size} (floor $CIRCADIAN_MIN_BUCKETS)  " +
                 "hours: $hours/24 (need $CIRCADIAN_MIN_HOURS)  days: $days " +
                 "(need ${com.noop.analytics.CircadianEngine.minDaysForFit})")
+            // The ratio alone is not interpretable — "7.3% of mesor" says nothing about whether the
+            // rhythm is genuinely flat or the bar is simply set high for this wearer. The absolute pair is
+            // what makes the threshold arguable, and it is what `minRelativeAmplitude`'s own note asks for
+            // ("it needs a wearer whose amplitude is disproportionately small for their mesor").
+            if (fit != null) {
+                add("Rhythm: amplitude ${fmt1(fit.amplitude)} bpm on a " +
+                    "${fmt1(fit.mesor)} bpm mesor  (acrophase " +
+                    "${fmt1(fit.acrophaseHours)}h)")
+            }
             add("Verdict: " + circadianVerdict(buckets.size, hours, days, amp))
         }.onFailure { add("  (unavailable: ${it.message})") }
     }

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -432,15 +432,37 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
      *  recordings under a read pinned to the literal "my-whoop" (#814 twin of the Workouts screen). */
     val deviceId = noopApp.activeDeviceId
 
-    /** Last (bins, daysObserved) computed on the collector pass. Reused by the SYNCHRONOUS settings
-     *  re-evaluate below, which has no coroutine to read the store from — without this, flipping the
+    /** Last (bins, daysObserved) computed on the collector pass. Reused by the cycle-tracking
+     *  re-evaluates below so they need no store read of their own — without this, flipping the
      *  cycle-tracking toggle would blank the body clock until the next collector tick.
+     *
+     *  Those sites now go through [freshCircadianBins], which reads the store ONLY when this cache is
+     *  empty, and they sit inside `viewModelScope.launch`. On `Dispatchers.Main.immediate` a body that
+     *  never suspends runs inline, so the populated-cache path is as immediate as the plain call it
+     *  replaced; only the empty-cache case actually defers. (This comment previously said the
+     *  re-evaluate was SYNCHRONOUS and had no coroutine — true before that change, not after.)
      *
      *  Not volatile and not synchronised, deliberately: the write resumes on `viewModelScope`
      *  (Dispatchers.Main.immediate) and the read is a UI-thread settings callback, so both touch it on
      *  the main thread. The Swift twin gets the same guarantee from `@MainActor` on AppModel. */
     private var lastCircadianBins: Pair<List<CircadianEngine.ActivityBin>, Int> =
         emptyList<CircadianEngine.ActivityBin>() to 0
+
+    /**
+     * The circadian bins, re-read first if the cache is empty.
+     *
+     * Only the main collect path refreshed [lastCircadianBins]; the cycle-tracking paths reused whatever
+     * was cached, which starts as `emptyList() to 0` and returns to empty whenever a store read fails
+     * (`circadianActivityBins` swallows that to an empty list). Either way a cycle re-evaluation would
+     * then hand `V5HealthSignals` no bins, drop below its six-bin floor, and null out `bodyClock` — the
+     * Health card disappearing on a device whose data is fine, which is exactly the symptom that started
+     * this. Refreshing only when EMPTY keeps the cheap path cheap: a populated cache is left alone and
+     * the collector stays the thing that keeps it current.
+     */
+    private suspend fun freshCircadianBins(): Pair<List<CircadianEngine.ActivityBin>, Int> {
+        if (lastCircadianBins.first.isEmpty()) lastCircadianBins = circadianActivityBins()
+        return lastCircadianBins
+    }
 
     /**
      * Per-hour activity profile for the body clock (#852), from the last ~14 days of hourly HR buckets.
@@ -2524,16 +2546,21 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     fun setCycleTrackingEnabled(enabled: Boolean) {
         _cycleTrackingEnabled.value = enabled
         NoopPrefs.setCycleTracking(appContext, enabled)
-        val days = recentDays.value
-        runCatching {
-            _v5Signals.value = V5HealthSignals.evaluate(
-                days = days,
-                cycleOptedIn = enabled,
-                loggedPeriodStarts = _periodStarts.value,
-                journalContext = illnessJournalContext(days),
-                activityBins = lastCircadianBins.first,
-                daysObserved = lastCircadianBins.second,
-            )
+        // Launched, like the sibling toggles, because the bins may need a store read before this snapshot
+        // is safe to publish — evaluating straight off an empty cache is what erased `bodyClock`.
+        viewModelScope.launch {
+            val days = recentDays.value
+            val bins = freshCircadianBins()
+            runCatching {
+                _v5Signals.value = V5HealthSignals.evaluate(
+                    days = days,
+                    cycleOptedIn = enabled,
+                    loggedPeriodStarts = _periodStarts.value,
+                    journalContext = illnessJournalContext(days),
+                    activityBins = bins.first,
+                    daysObserved = bins.second,
+                )
+            }
         }
     }
 
@@ -2585,13 +2612,14 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         val starts = store.starts()
         _periodStarts.value = starts
         val days = recentDays.value
+        val bins = freshCircadianBins()
         _v5Signals.value = V5HealthSignals.evaluate(
             days = days,
             cycleOptedIn = _cycleTrackingEnabled.value,
             loggedPeriodStarts = starts,
             journalContext = illnessJournalContext(days),
-            activityBins = lastCircadianBins.first,
-            daysObserved = lastCircadianBins.second,
+            activityBins = bins.first,
+            daysObserved = bins.second,
         )
     }
 

--- a/android/app/src/test/java/com/noop/testcentre/CircadianVerdictTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/CircadianVerdictTest.kt
@@ -51,4 +51,19 @@ class CircadianVerdictTest {
         val v = verdict(buckets = 300, hours = 20, days = 20, amp = null)
         assertTrue(v, v.startsWith("solid"))
     }
+
+    /**
+     * The bucket floor is a bare literal inside `circadianBinsFrom`, so it cannot be referenced the way
+     * the hour floor now is. Pin it against the real behaviour instead of trusting a comment to keep the
+     * two in step — a diagnostic that names the wrong threshold sends its reader after the wrong thing.
+     */
+    @Test fun theReportedBucketFloorIsTheOneCircadianBinsFromActuallyApplies() {
+        fun binsFor(n: Int) = com.noop.ui.circadianBinsFrom(
+            (0 until n).map { com.noop.data.HrBucket(bucket = it * 3600L, avgBpm = 60.0) }, 0L,
+        ).first
+        val floor = AndroidDiagnostics.CIRCADIAN_MIN_BUCKETS
+        assertTrue("one under the reported floor must still be refused", binsFor(floor - 1).isEmpty())
+        assertTrue("the reported floor must be enough", binsFor(floor).isNotEmpty())
+    }
+
 }


### PR DESCRIPTION
Stop a cycle re-evaluate blanking the body clock, and report the rhythm in bpm

Two follow-ups from reading a real strap log, whose new diagnostic printed:

  Buckets: 328 (floor 24)  hours: 24/24 (need 6)  days: 15 (need 7)
  Verdict: unreadable - rhythm too flat (amplitude 7.3% of mesor, needs 10%)

STALE BINS. Only the collector refreshed lastCircadianBins. The two
cycle-tracking paths - setCycleTrackingEnabled and reloadPeriodStartsAndCycle -
reused whatever was cached, which starts as `emptyList() to 0` and returns to
empty whenever the store read fails (circadianActivityBins swallows that to an
empty list). Either way the re-evaluate then handed V5HealthSignals no bins,
fell under its six-bin floor, and nulled bodyClock - the Health card vanishing
on a device whose data is fine.

Both sites now go through freshCircadianBins(), which re-reads ONLY when the
cache is empty. A populated cache is left alone, so the collector stays the
thing that keeps it current.

The sites moved inside viewModelScope.launch to have somewhere to read from.
That is less of a change than it looks: on Dispatchers.Main.immediate a body
that never suspends runs INLINE, and freshCircadianBins only suspends when the
cache is empty - so the common path is as immediate as the plain call it
replaced, and only the empty-cache case defers. The neighbouring comment
described that re-evaluate as SYNCHRONOUS with no coroutine, which this change
made untrue; it now says what the code does.

RHYTHM IN BPM. The verdict's ratio is not interpretable on its own - "7.3% of
mesor" says nothing about whether a rhythm is genuinely flat or the bar is set
high for this wearer. The diagnostic now prints amplitude and mesor in bpm plus
the acrophase, which is exactly what minRelativeAmplitude's own note asks for
("it needs a wearer whose amplitude is disproportionately small for their
mesor").

Re-review pinned the new floats to Locale.US. Kotlin's `"%.1f".format(x)` uses
the DEFAULT locale, so a comma-decimal device would have logged "4,7 bpm" and
"7,3% of mesor" beside the US-formatted timestamps this same file already pins
Locale.US for - in a log whose whole purpose is being pasted into an issue and
read by someone else. Same class of bug as the dial's caption, and here the file
already carried the convention to follow.

The section is also labelled "recomputed from the store, not the live
snapshot", because that is what it measures. It reports what estimatePhase WOULD
return for the data on disk, never what _v5Signals.bodyClock holds - so against
the staleness fixed above it would have printed a confident verdict beside a
missing card, misleading exactly as the silence it replaced did. A verdict that
disagrees with the screen is therefore itself the finding.

A later pass removed a duplicated threshold. The hour floor was written as its
own `6` beside a comment claiming it mirrored V5HealthSignals.MIN_CIRCADIAN_BINS
- so a change to the engine would have left this section printing "needs 6"
while the code required something else, sending whoever read the log after the
wrong thing. It now REFERENCES that constant. The bucket floor is a bare literal
inside circadianBinsFrom and cannot be referenced, so it is pinned by a test
against the real boundary rather than by a comment.

The verdict's doc also claimed it reported gates "in the order the pipeline
applies them". Only the first two are sequential; days and amplitude are ONE
condition in the engine, split apart here because "unreadable" alone does not
say whether to keep wearing the strap or to question the threshold.

One of the tests added alongside that reference was then removed: asserting
CIRCADIAN_MIN_HOURS == V5HealthSignals.MIN_CIRCADIAN_BINS is X == X once the
former IS the latter, so it could never fail. A test that cannot fail is worse
than no test - it advertises coverage that is not there. The reference itself is
the guarantee. The bucket floor keeps its test, because a bare literal genuinely
can drift.

No threshold is changed. Android 4767 pass.

Not unit-tested: the staleness fix lives in AppViewModel and needs an Android
context, and the decision it encodes is `isEmpty()`. CircadianBinsTest continues
to cover the pooling itself.
