### PR TITLE
Accept a rhythm that is large enough in bpm, whatever the mesor

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/CircadianEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/CircadianEngine.swift
@@ -34,12 +34,28 @@ public enum CircadianEngine {
     /// so a low-resting wearer faces a LOWER absolute bar, not a higher one — the opposite of the concern
     /// raised in #982, which assumed the gate penalises the fittest.
     ///
-    /// Deliberately NOT re-tuned to an absolute bpm floor. The shape is arguably wrong for this domain,
-    /// but every candidate value is unvalidated, nobody is currently silenced by it, and the direction of
-    /// the harm is not established (it needs a wearer whose amplitude is disproportionately small for
-    /// their mesor — an n=1 observation). `CircadianEngineTests` pins what the gate costs at each mesor so
-    /// the trade is visible to whoever does have the data to change it.
+    /// The VALUE is still not re-tuned — every candidate remains unvalidated. What changed is the SHAPE:
+    /// `minAbsoluteAmplitudeBpm` now passes a swing large enough in bpm regardless of mesor. This note
+    /// asked for "a wearer whose amplitude is disproportionately small for their mesor — an n=1
+    /// observation" before that could happen, and one arrived: 5.5 bpm on a 74.7 bpm mesor with a coherent
+    /// acrophase. "Nobody is currently silenced by it" was true when written and is no longer.
+    /// `CircadianEngineTests` pins what the gate costs at each mesor so the trade stays visible.
     public static let minRelativeAmplitude: Double = 0.10
+    /// Absolute amplitude (bpm) that reads as rhythmic whatever the mesor — the relative bar's escape hatch.
+    ///
+    /// The relative test scales the requirement WITH resting HR, so the identical swing is accepted on one
+    /// body and refused on another: 5.5 bpm passes at a 55 bpm mesor and fails at 74.7. That is not a
+    /// judgement about the rhythm, it is a judgement about the baseline, and a measured wearer sat exactly
+    /// there — 5.5 bpm on a 74.7 bpm mesor, acrophase 16.1 h implying a CBTmin near 04:06, which is a
+    /// textbook phase rather than noise. `minRelativeAmplitude`'s own note called for precisely that
+    /// observation ("a wearer whose amplitude is disproportionately small for their mesor") before the
+    /// shape could be revisited.
+    ///
+    /// 4.5 bpm is NOT a new tuning constant: it is the absolute amplitude the relative gate ALREADY
+    /// accepts at the bottom of the ~45-75 bpm mesor range it was described against. The rule this
+    /// encodes is internal consistency — an amplitude good enough for some wearer is good enough for all
+    /// — so the change is strictly more permissive and no one who reads rhythmic today stops.
+    public static let minAbsoluteAmplitudeBpm: Double = 4.5
     /// Max clock-shift the planner steps per day (hours) — the well-established ~1 h/day re-entrainment rate.
     public static let maxShiftPerDayHours: Double = 1.0
     /// CBTmin sits roughly this many hours before habitual wake; used to translate the activity acrophase
@@ -194,7 +210,10 @@ public enum CircadianEngine {
         guard let fit = cosinor(bins) else { return nil }
 
         let relativeAmplitude = fit.mesor != 0 ? fit.amplitude / abs(fit.mesor) : 0
-        if daysObserved < minDaysForFit || relativeAmplitude < minRelativeAmplitude {
+        // Rhythmic on EITHER measure: a proportional swing, or an absolute one large enough to read on
+        // any baseline. See `minAbsoluteAmplitudeBpm` for why the relative test alone was self-inconsistent.
+        let rhythmic = relativeAmplitude >= minRelativeAmplitude || fit.amplitude >= minAbsoluteAmplitudeBpm
+        if daysObserved < minDaysForFit || !rhythmic {
             // A reading is returned, but flagged unreadable so the surface says "hard to read right now."
             let tmin = observedTempMinHour ?? wrap24(fit.acrophaseHours - acrophaseAfterCbtMinHours)
             return PhaseEstimate(tempMinHour: tmin, acrophaseHours: fit.acrophaseHours,
@@ -212,7 +231,13 @@ public enum CircadianEngine {
         let offsetHours = signedHourDelta(from: idealTempMin, to: tempMinHour)
         let offsetMinutes = offsetHours * 60.0
 
-        let confidence: PhaseConfidence = daysObserved >= goodDaysForFit ? .solid : .wide
+        // SOLID means strong on BOTH axes, not just enough days. A rhythm admitted by
+        // `minAbsoluteAmplitudeBpm` alone is real but modest, and a smaller swing pins its acrophase less
+        // tightly — so it stays `.wide`. That matters because `.wide` is what withholds `chronotype`,
+        // which names a category off exactly that acrophase: widening the readable gate should give more
+        // people a body clock, not give a thinner fit a firmer label.
+        let confidence: PhaseConfidence =
+            (daysObserved >= goodDaysForFit && relativeAmplitude >= minRelativeAmplitude) ? .solid : .wide
         let lean: String
         if offsetMinutes > 20 { lean = "later (a night-owl lean)" }
         else if offsetMinutes < -20 { lean = "earlier (a morning-lark lean)" }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/CircadianEngineTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/CircadianEngineTests.swift
@@ -129,27 +129,60 @@ final class CircadianEngineTests: XCTestCase {
     /// `minRelativeAmplitude` gates on `amplitude / |mesor|`. Against a signal carrying a ~45-75 bpm DC
     /// offset that makes the real bar an ABSOLUTE `0.10 x mesor` bpm — which these pin.
     ///
-    /// The pair that matters is the last two: the SAME 5 bpm swing is arrhythmic at a 65 bpm mesor and
-    /// readable at 45. The bar scales WITH the mesor, so a low-resting wearer faces a LOWER absolute
-    /// requirement, not a higher one. #982 raised the opposite concern — that the gate penalises the
-    /// fittest — and that only holds for someone whose amplitude is disproportionately small for their
-    /// mesor. Pinned here so the direction is a fact rather than an argument, for whoever re-tunes it.
+    /// These USED to pin the relative bar alone, including that the SAME 5 bpm swing was arrhythmic at a
+    /// 65 bpm mesor and readable at 45 — the same rhythm judged by the baseline rather than by itself.
+    /// `minAbsoluteAmplitudeBpm` removed that split; what remains pinned is that a proportional swing
+    /// still passes, a genuinely flat one still fails, and the verdict no longer moves with the mesor.
     private func confidence(mesor: Double, amp: Double) -> CircadianEngine.PhaseConfidence {
         CircadianEngine.estimatePhase(bins: profile(mesor: mesor, amp: amp, acrophase: 16),
                                       daysObserved: CircadianEngine.goodDaysForFit,
                                       habitualWakeHour: 7)!.confidence
     }
 
-    func testTypicalMesorNeedsAboutSixAndAHalfBpmOfSwing() {
+    func testAProportionalSwingStillPasses() {
         XCTAssertNotEqual(confidence(mesor: 65, amp: 8), .unreadable)   // 0.123 - clears 0.10
-        XCTAssertEqual(confidence(mesor: 65, amp: 5), .unreadable)      // 0.077 - does not
     }
 
-    func testTheSameSwingIsReadableAtALowerMesor() {
-        // 5 bpm: arrhythmic at 65, rhythmic at 45. The gate favours the low-resting wearer.
-        XCTAssertEqual(confidence(mesor: 65, amp: 5), .unreadable)
-        XCTAssertNotEqual(confidence(mesor: 45, amp: 5), .unreadable)   // 0.111
-        XCTAssertEqual(confidence(mesor: 45, amp: 4), .unreadable)      // 0.089
+    /// The inconsistency the absolute floor removes: one rhythm, three baselines, one verdict.
+    func testTheSameSwingNoLongerDependsOnTheBaseline() {
+        XCTAssertNotEqual(confidence(mesor: 45, amp: 5), .unreadable)
+        XCTAssertNotEqual(confidence(mesor: 65, amp: 5), .unreadable)
+        XCTAssertNotEqual(confidence(mesor: 80, amp: 5), .unreadable)
+    }
+
+    /// A genuinely flat rhythm is still refused — the floor widens the gate, it does not remove it.
+    func testAFlatRhythmIsStillArrhythmicOnBothMeasures() {
+        XCTAssertEqual(confidence(mesor: 45, amp: 4), .unreadable)      // 0.089, 4.0 bpm
+        XCTAssertEqual(confidence(mesor: 65, amp: 4), .unreadable)      // 0.062, 4.0 bpm
+        XCTAssertEqual(confidence(mesor: 74.7, amp: 3), .unreadable)
+    }
+
+    /// The absolute floor's own boundary, isolated: at a 74.7 bpm mesor the relative test cannot pass
+    /// either value, so only `minAbsoluteAmplitudeBpm` decides. Expressed RELATIVE to the constant, with a
+    /// 0.1 bpm margin rather than the exact value — the cosinor recovers amplitude to ~1e-9, and sitting
+    /// exactly on `>=` would pin float recovery rather than the threshold.
+    func testTheAbsoluteFloorIsWhereItSays() {
+        let floor = CircadianEngine.minAbsoluteAmplitudeBpm
+        XCTAssertNotEqual(confidence(mesor: 74.7, amp: floor + 0.1), .unreadable)
+        XCTAssertEqual(confidence(mesor: 74.7, amp: floor - 0.1), .unreadable)
+    }
+
+    /// The widening must not hand a thinner fit a FIRMER label. A rhythm admitted only by the absolute
+    /// floor caps at `.wide`, which withholds `chronotype` — that names a category off an acrophase a
+    /// small swing pins loosely. A proportional rhythm still reaches `.solid`.
+    func testAnAbsoluteOnlyRhythmIsReadableButNotSolid() {
+        XCTAssertEqual(confidence(mesor: 74.7, amp: 5.5), .wide)    // 0.073 - floor only
+        XCTAssertEqual(confidence(mesor: 65, amp: 8), .solid)       // 0.123 - proportional
+        let wide = CircadianEngine.estimatePhase(bins: profile(mesor: 74.7, amp: 5.5, acrophase: 16),
+                                                 daysObserved: CircadianEngine.goodDaysForFit,
+                                                 habitualWakeHour: 7)!
+        XCTAssertNil(CircadianEngine.chronotype(wide), "a floor-only fit must not name a chronotype")
+    }
+
+    /// The measured wearer this change exists for: 5.5 bpm on a 74.7 bpm mesor, refused at 7.3% against
+    /// the 10% bar while its acrophase implied a textbook CBTmin near 04:06.
+    func testTheMeasuredWearerIsNoLongerSilenced() {
+        XCTAssertNotEqual(confidence(mesor: 74.7, amp: 5.5), .unreadable)
     }
 
     // MARK: - chronotype lean (absolute phase, not schedule-relative)

--- a/android/app/src/main/java/com/noop/analytics/CircadianEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/CircadianEngine.kt
@@ -31,10 +31,31 @@ object CircadianEngine {
      * #982 — RELATIVE, applied to mean HR (mesor ~45-75 bpm), not to a near-zero-mesor motion volume. The
      * effective bar is `0.10 x mesor`: ~6.5 bpm at a 65 bpm mesor, ~4.5 bpm at 45. It scales WITH the
      * mesor, so a low-resting wearer faces a LOWER absolute bar — the opposite of the concern in #982.
-     * Deliberately NOT re-tuned: every candidate value is unvalidated and nobody is currently silenced.
+     * The VALUE is still not re-tuned — every candidate remains unvalidated. What changed is the SHAPE:
+     * [minAbsoluteAmplitudeBpm] now passes a swing that is large enough in bpm regardless of mesor,
+     * because a measured wearer showed the relative test refusing a coherent rhythm purely for having a
+     * high baseline. "Nobody is currently silenced by it" was true when written and is no longer.
      * `CircadianEngineTest` pins what it costs at each mesor. Mirrors the Swift twin exactly.
      */
     const val minRelativeAmplitude: Double = 0.10
+    /**
+     * Absolute amplitude (bpm) that reads as rhythmic whatever the mesor — the relative bar's escape hatch.
+     *
+     * The relative test scales the requirement WITH resting HR, so the identical swing is accepted on one
+     * body and refused on another: 5.5 bpm passes at a 55 bpm mesor and fails at 74.7. That is not a
+     * judgement about the rhythm, it is a judgement about the baseline, and a measured wearer sat exactly
+     * there — 5.5 bpm on a 74.7 bpm mesor, acrophase 16.1 h implying a CBTmin near 04:06, a textbook phase
+     * rather than noise. [minRelativeAmplitude]'s own note called for precisely that observation ("a
+     * wearer whose amplitude is disproportionately small for their mesor") before the shape could be
+     * revisited.
+     *
+     * 4.5 bpm is NOT a new tuning constant: it is the absolute amplitude the relative gate ALREADY accepts
+     * at the bottom of the ~45-75 bpm mesor range it was described against. The rule this encodes is
+     * internal consistency — an amplitude good enough for some wearer is good enough for all — so the
+     * change is strictly more permissive and no one who reads rhythmic today stops.
+     * Mirrors the Swift twin exactly.
+     */
+    const val minAbsoluteAmplitudeBpm: Double = 4.5
     const val maxShiftPerDayHours: Double = 1.0
     const val cbtMinBeforeWakeHours: Double = 2.5
     const val acrophaseAfterCbtMinHours: Double = 12.0
@@ -152,7 +173,11 @@ object CircadianEngine {
         val fit = cosinor(bins) ?: return null
 
         val relativeAmplitude = if (fit.mesor != 0.0) fit.amplitude / abs(fit.mesor) else 0.0
-        if (daysObserved < minDaysForFit || relativeAmplitude < minRelativeAmplitude) {
+        // Rhythmic on EITHER measure: a proportional swing, or an absolute one large enough to read on any
+        // baseline. See [minAbsoluteAmplitudeBpm] for why the relative test alone was self-inconsistent.
+        val rhythmic =
+            relativeAmplitude >= minRelativeAmplitude || fit.amplitude >= minAbsoluteAmplitudeBpm
+        if (daysObserved < minDaysForFit || !rhythmic) {
             val tmin = observedTempMinHour ?: wrap24(fit.acrophaseHours - acrophaseAfterCbtMinHours)
             return PhaseEstimate(tmin, fit.acrophaseHours, 0.0, PhaseConfidence.UNREADABLE,
                 "Your rhythm is hard to read right now - keep wearing it for a clearer picture.")
@@ -165,7 +190,16 @@ object CircadianEngine {
         val offsetHours = signedHourDelta(idealTempMin, tempMinHour)
         val offsetMinutes = offsetHours * 60.0
 
-        val confidence = if (daysObserved >= goodDaysForFit) PhaseConfidence.SOLID else PhaseConfidence.WIDE
+        // SOLID means strong on BOTH axes, not just enough days. A rhythm admitted by
+        // [minAbsoluteAmplitudeBpm] alone is real but modest, and a smaller swing pins its acrophase less
+        // tightly — so it stays WIDE. That matters because WIDE is what withholds [chronotype], which
+        // names a category off exactly that acrophase: widening the readable gate should give more people
+        // a body clock, not give a thinner fit a firmer label.
+        val confidence = if (daysObserved >= goodDaysForFit && relativeAmplitude >= minRelativeAmplitude) {
+            PhaseConfidence.SOLID
+        } else {
+            PhaseConfidence.WIDE
+        }
         val lean = when {
             offsetMinutes > 20 -> "later (a night-owl lean)"
             offsetMinutes < -20 -> "earlier (a morning-lark lean)"

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -461,15 +461,20 @@ object AndroidDiagnostics {
         populatedHours: Int,
         daysObserved: Int,
         relativeAmplitude: Double?,
+        amplitudeBpm: Double? = null,
     ): String = when {
         buckets < CIRCADIAN_MIN_BUCKETS ->
             "no estimate — $buckets hourly HR buckets in 14d, needs $CIRCADIAN_MIN_BUCKETS"
         populatedHours < CIRCADIAN_MIN_HOURS ->
             "no estimate — HR lands in $populatedHours of 24 local hours, needs $CIRCADIAN_MIN_HOURS"
+        // Mirrors the engine's OR: a swing passes on the proportional test or on the absolute one. Read
+        // the two apart and this line starts reporting "too flat" for rhythms the engine accepts.
         relativeAmplitude != null &&
-            relativeAmplitude < com.noop.analytics.CircadianEngine.minRelativeAmplitude ->
+            relativeAmplitude < com.noop.analytics.CircadianEngine.minRelativeAmplitude &&
+            (amplitudeBpm ?: 0.0) < com.noop.analytics.CircadianEngine.minAbsoluteAmplitudeBpm ->
             "unreadable — rhythm too flat (amplitude ${fmt1(relativeAmplitude * 100)}% of mesor, " +
-                "needs ${fmt1(com.noop.analytics.CircadianEngine.minRelativeAmplitude * 100)}%)"
+                "needs ${fmt1(com.noop.analytics.CircadianEngine.minRelativeAmplitude * 100)}% or " +
+                "${fmt1(com.noop.analytics.CircadianEngine.minAbsoluteAmplitudeBpm)} bpm)"
         daysObserved < com.noop.analytics.CircadianEngine.minDaysForFit ->
             "unreadable — $daysObserved days observed, needs " +
                 "${com.noop.analytics.CircadianEngine.minDaysForFit}"
@@ -524,7 +529,7 @@ object AndroidDiagnostics {
                     "${fmt1(fit.mesor)} bpm mesor  (acrophase " +
                     "${fmt1(fit.acrophaseHours)}h)")
             }
-            add("Verdict: " + circadianVerdict(buckets.size, hours, days, amp))
+            add("Verdict: " + circadianVerdict(buckets.size, hours, days, amp, fit?.amplitude))
         }.onFailure { add("  (unavailable: ${it.message})") }
     }
 

--- a/android/app/src/test/java/com/noop/analytics/CircadianEngineTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/CircadianEngineTest.kt
@@ -127,16 +127,59 @@ class CircadianEngineTest {
             7.0,
         )!!.confidence
 
-    @Test fun typicalMesorNeedsAboutSixAndAHalfBpmOfSwing() {
+    @Test fun aProportionalSwingStillPasses() {
         assertTrue(confidence(65.0, 8.0) != CircadianEngine.PhaseConfidence.UNREADABLE)   // 0.123
-        assertEquals(CircadianEngine.PhaseConfidence.UNREADABLE, confidence(65.0, 5.0))   // 0.077
     }
 
-    @Test fun theSameSwingIsReadableAtALowerMesor() {
-        // 5 bpm: arrhythmic at 65, rhythmic at 45. The gate favours the low-resting wearer.
-        assertEquals(CircadianEngine.PhaseConfidence.UNREADABLE, confidence(65.0, 5.0))
-        assertTrue(confidence(45.0, 5.0) != CircadianEngine.PhaseConfidence.UNREADABLE)   // 0.111
-        assertEquals(CircadianEngine.PhaseConfidence.UNREADABLE, confidence(45.0, 4.0))   // 0.089
+    /**
+     * The inconsistency the absolute floor removes. This pair USED to assert that 5 bpm was arrhythmic at
+     * a 65 bpm mesor and rhythmic at 45 — the same swing, opposite verdicts, decided by the baseline
+     * rather than by the rhythm. Both now read rhythmic.
+     */
+    @Test fun theSameSwingNoLongerDependsOnTheBaseline() {
+        assertTrue(confidence(45.0, 5.0) != CircadianEngine.PhaseConfidence.UNREADABLE)
+        assertTrue(confidence(65.0, 5.0) != CircadianEngine.PhaseConfidence.UNREADABLE)
+        assertTrue(confidence(80.0, 5.0) != CircadianEngine.PhaseConfidence.UNREADABLE)
+    }
+
+    /** A genuinely flat rhythm is still refused — the floor widens the gate, it does not remove it. */
+    @Test fun aFlatRhythmIsStillArrhythmicOnBothMeasures() {
+        assertEquals(CircadianEngine.PhaseConfidence.UNREADABLE, confidence(45.0, 4.0))   // 0.089, 4.0 bpm
+        assertEquals(CircadianEngine.PhaseConfidence.UNREADABLE, confidence(65.0, 4.0))   // 0.062, 4.0 bpm
+        assertEquals(CircadianEngine.PhaseConfidence.UNREADABLE, confidence(74.7, 3.0))
+    }
+
+    /**
+     * The absolute floor's own boundary, isolated: at a 74.7 bpm mesor the relative test cannot pass
+     * either value (0.061 and 0.059 against 0.10), so only [CircadianEngine.minAbsoluteAmplitudeBpm]
+     * decides. Expressed RELATIVE to the constant so the test follows it, and with a 0.1 bpm margin
+     * either side rather than testing the exact value — the cosinor recovers amplitude to ~1e-9, and a
+     * test sitting exactly on `>=` would be pinning float recovery rather than the threshold.
+     */
+    @Test fun theAbsoluteFloorIsWhereItSays() {
+        val floor = CircadianEngine.minAbsoluteAmplitudeBpm
+        assertTrue(confidence(74.7, floor + 0.1) != CircadianEngine.PhaseConfidence.UNREADABLE)
+        assertEquals(CircadianEngine.PhaseConfidence.UNREADABLE, confidence(74.7, floor - 0.1))
+    }
+
+    /**
+     * The widening must not hand a thinner fit a FIRMER label. A rhythm admitted only by the absolute
+     * floor caps at WIDE, which is what withholds [CircadianEngine.chronotype] — that names a category
+     * off an acrophase a small swing pins loosely. A proportional rhythm still reaches SOLID.
+     */
+    @Test fun anAbsoluteOnlyRhythmIsReadableButNotSolid() {
+        assertEquals(CircadianEngine.PhaseConfidence.WIDE, confidence(74.7, 5.5))   // 0.073 - floor only
+        assertEquals(CircadianEngine.PhaseConfidence.SOLID, confidence(65.0, 8.0))  // 0.123 - proportional
+        val wide = CircadianEngine.estimatePhase(profile(74.7, 5.5, 16.0), CircadianEngine.goodDaysForFit, 7.0)!!
+        assertNull("a floor-only fit must not name a chronotype", CircadianEngine.chronotype(wide))
+    }
+
+    /**
+     * The measured wearer this change exists for: 5.5 bpm on a 74.7 bpm mesor, which the relative test
+     * refused at 7.3% against its 10% bar while the acrophase implied a textbook CBTmin near 04:06.
+     */
+    @Test fun theMeasuredWearerIsNoLongerSilenced() {
+        assertTrue(confidence(74.7, 5.5) != CircadianEngine.PhaseConfidence.UNREADABLE)
     }
 
     // ---- chronotype lean (absolute phase, not schedule-relative) ----

--- a/android/app/src/test/java/com/noop/testcentre/CircadianVerdictTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/CircadianVerdictTest.kt
@@ -11,8 +11,8 @@ import org.junit.Test
  */
 class CircadianVerdictTest {
 
-    private fun verdict(buckets: Int, hours: Int, days: Int, amp: Double? = 0.5) =
-        AndroidDiagnostics.circadianVerdict(buckets, hours, days, amp)
+    private fun verdict(buckets: Int, hours: Int, days: Int, amp: Double? = 0.5, bpm: Double? = null) =
+        AndroidDiagnostics.circadianVerdict(buckets, hours, days, amp, bpm)
 
     /** Gates are reported in the order the pipeline applies them: the bucket floor short-circuits first. */
     @Test fun theBucketFloorIsReportedBeforeAnythingElse() {
@@ -66,4 +66,20 @@ class CircadianVerdictTest {
         assertTrue("the reported floor must be enough", binsFor(floor).isNotEmpty())
     }
 
+    /**
+     * The diagnostic must mirror the engine's OR, not just its relative half. The measured wearer -
+     * 7.3% of mesor but 5.5 bpm of swing - is rhythmic to the engine, so a line still calling that "too
+     * flat" would send its reader after a threshold that is no longer the reason for anything.
+     */
+    @Test fun anAbsoluteSwingClearsTheGateInTheVerdictToo() {
+        val v = verdict(buckets = 328, hours = 24, days = 15, amp = 0.073, bpm = 5.5)
+        assertTrue(v, !v.contains("too flat"))
+        assertTrue(v, v.startsWith("solid"))
+    }
+
+    /** Below BOTH measures it is still reported as flat. */
+    @Test fun belowBothMeasuresIsStillFlat() {
+        val v = verdict(buckets = 328, hours = 24, days = 15, amp = 0.05, bpm = 3.0)
+        assertTrue(v, v.startsWith("unreadable") && v.contains("too flat"))
+    }
 }


### PR DESCRIPTION
Accept a rhythm that is large enough in bpm, whatever the mesor

minRelativeAmplitude gates on amplitude / |mesor|, which scales the requirement
WITH resting HR. The consequence, in the engine's own test fixtures, was that
the SAME 5 bpm swing read arrhythmic at a 65 bpm mesor and rhythmic at 45 - one
rhythm, two verdicts, decided by the baseline rather than by the rhythm.

A measured wearer sat exactly there. From a strap log:

  Buckets: 328 (floor 24)  hours: 24/24 (need 6)  days: 15 (need 7)
  Rhythm: amplitude 5.5 bpm on a 74.7 bpm mesor  (acrophase 16.1h)
  Verdict: unreadable - rhythm too flat (amplitude 7.3% of mesor, needs 10.0%)

Abundant data, every count gate cleared, and an acrophase of 16.1 h implying a
CBTmin near 04:06 - a textbook phase, not noise. The fit is sound; the gate
refused it for having a high baseline. At that mesor the bar is 7.47 bpm; the
same 5.5 bpm passes at 55.

estimatePhase now accepts EITHER measure: relativeAmplitude >= 0.10 OR
amplitude >= minAbsoluteAmplitudeBpm.

4.5 bpm is not a new tuning constant. It is the absolute amplitude the relative
gate ALREADY accepts at the bottom of the ~45-75 bpm mesor range its own note
describes, so the rule encoded is internal consistency: an amplitude good enough
for some wearer is good enough for all. The change is strictly more permissive -
nobody who reads rhythmic today stops - and the 10% value itself is untouched,
because every candidate for it remains unvalidated.

minRelativeAmplitude's note said re-tuning needed "a wearer whose amplitude is
disproportionately small for their mesor - an n=1 observation", and that "nobody
is currently silenced by it". Both are addressed in place rather than deleted:
the first arrived, the second was true when written and is no longer.

The Test Centre verdict mirrors the engine's OR. Reading the two apart would
have left the diagnostic reporting "too flat" for rhythms the engine accepts,
sending its reader after a threshold that is no longer the reason for anything.

The two fixtures that pinned the old split are rewritten rather than deleted, so
what changed stays legible: a proportional swing still passes, a genuinely flat
one still fails at 4 bpm on any baseline, the verdict no longer moves with the
mesor, and the measured 5.5-on-74.7 case is pinned by name.

Re-review added the floor's own boundary, which the first cut left untested: the
amplitude cases sat at 4.0 and 5.0-5.5, never near 4.5. It is pinned at a 74.7
bpm mesor so the relative test cannot pass either side, expressed RELATIVE to
the constant so it follows any change, and with a 0.1 bpm margin rather than the
exact value - the cosinor recovers amplitude to ~1e-9, so a case sitting exactly
on `>=` would pin float recovery rather than the threshold.

Also checked while re-reviewing: cosinor returns sqrt(beta^2 + gamma^2), so
amplitude is never negative and the absolute comparison needs no abs(); and the
new UNREADABLE set is a strict subset of the old one, so the change cannot take
a body clock away from anyone who has one.

A second pass capped the widening. SOLID now requires BOTH enough days and a
proportional swing: a rhythm admitted by the absolute floor alone stays WIDE,
because a smaller swing pins its acrophase less tightly and WIDE is what
withholds chronotype(), which names a category off exactly that acrophase.
Widening the readable gate should give more people a body clock, not give a
thinner fit a firmer label. The measured wearer therefore reads WIDE: dial and
Health card yes, named chronotype no.

Parity checked mechanically rather than by eye: the constant, the rhythmic OR,
the unreadable gate and the SOLID tier all normalise to identical expressions
across the two engines, and both test files carry 26 cases. One pair differs
only in NAME - Swift's testThinDataIsWideOrUnreadable asserts exactly what
Kotlin's thinDataIsUnreadable does; the Swift name overstates it and is left
alone rather than churned.

Android 4773 pass. Swift is syntax-checked locally and rests on CI.
