### PR TITLE
Mirror the SOLID rule in the diagnostic verdict

### DIFF
--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -478,8 +478,15 @@ object AndroidDiagnostics {
         daysObserved < com.noop.analytics.CircadianEngine.minDaysForFit ->
             "unreadable — $daysObserved days observed, needs " +
                 "${com.noop.analytics.CircadianEngine.minDaysForFit}"
+        // SOLID needs BOTH axes, exactly as estimatePhase assigns it. Reading only the days here printed
+        // "solid" for a wearer the engine had marked WIDE — the diagnostic contradicting the very screen
+        // it exists to explain, which is the one thing this section must never do.
         daysObserved < com.noop.analytics.CircadianEngine.goodDaysForFit ->
             "wide — $daysObserved days observed"
+        relativeAmplitude != null &&
+            relativeAmplitude < com.noop.analytics.CircadianEngine.minRelativeAmplitude ->
+            "wide — $daysObserved days observed, but the swing clears only the absolute floor " +
+                "(${fmt1(relativeAmplitude * 100)}% of mesor)"
         else -> "solid — $daysObserved days observed"
     }
 

--- a/android/app/src/test/java/com/noop/testcentre/CircadianVerdictTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/CircadianVerdictTest.kt
@@ -74,6 +74,17 @@ class CircadianVerdictTest {
     @Test fun anAbsoluteSwingClearsTheGateInTheVerdictToo() {
         val v = verdict(buckets = 328, hours = 24, days = 15, amp = 0.073, bpm = 5.5)
         assertTrue(v, !v.contains("too flat"))
+        // WIDE, not solid: readable on the absolute floor but short of the proportional bar, which is
+        // exactly how estimatePhase tiers it. This assertion said "solid" and so PINNED a divergence
+        // between the diagnostic and the engine instead of catching it — the wearer it was written from
+        // had a log reading "solid" beside a card the engine had marked wide.
+        assertTrue(v, v.startsWith("wide"))
+        assertTrue(v, v.contains("absolute floor"))
+    }
+
+    /** A proportional swing with the days behind it is the only thing that reads solid. */
+    @Test fun onlyBothAxesReadSolid() {
+        val v = verdict(buckets = 328, hours = 24, days = 15, amp = 0.15, bpm = 9.0)
         assertTrue(v, v.startsWith("solid"))
     }
 
@@ -81,5 +92,48 @@ class CircadianVerdictTest {
     @Test fun belowBothMeasuresIsStillFlat() {
         val v = verdict(buckets = 328, hours = 24, days = 15, amp = 0.05, bpm = 3.0)
         assertTrue(v, v.startsWith("unreadable") && v.contains("too flat"))
+    }
+
+    /**
+     * The structural guard. This line has drifted from the engine TWICE — once when the absolute floor
+     * added an OR, once when SOLID started needing both axes — and each time a hand-written case either
+     * missed it or pinned it. So rather than assert more cases, drive the REAL engine and the REAL
+     * verdict over a grid and require they agree, which makes a future rule change fail here the moment
+     * only one side is updated.
+     */
+    @Test fun theVerdictNeverDisagreesWithTheEngine() {
+        fun bins(mesor: Double, amp: Double) = (0 until 24).map { h ->
+            CircadianEngine.ActivityBin(
+                h.toDouble(),
+                mesor + amp * kotlin.math.cos(2.0 * Math.PI * (h - 16.0) / 24.0),
+            )
+        }
+        for (days in listOf(5, 10, 15, 20)) {
+            for (mesor in listOf(45.0, 65.0, 74.7)) {
+                for (amp in listOf(3.0, 4.6, 5.5, 8.0, 12.0)) {
+                    val b = bins(mesor, amp)
+                    val est = CircadianEngine.estimatePhase(b, days, 7.0)
+                    // Feed the verdict what the ENGINE saw — the recovered fit — not the nominal inputs,
+                    // exactly as circadianLines does. Passing amp/mesor would test a pairing production
+                    // never uses, and would go flaky the moment a grid point sat within the cosinor's
+                    // recovery error of a threshold.
+                    val fit = CircadianEngine.cosinor(b)!!
+                    val rel = fit.amplitude / kotlin.math.abs(fit.mesor)
+                    val expected = when (est?.confidence) {
+                        CircadianEngine.PhaseConfidence.SOLID -> "solid"
+                        CircadianEngine.PhaseConfidence.WIDE -> "wide"
+                        CircadianEngine.PhaseConfidence.UNREADABLE -> "unreadable"
+                        null -> "no estimate"
+                    }
+                    // The counts are deliberately generous: this isolates the amplitude/days rules, which
+                    // are the halves that have drifted.
+                    val v = AndroidDiagnostics.circadianVerdict(328, 24, days, rel, fit.amplitude)
+                    assertTrue(
+                        "mesor=$mesor amp=$amp days=$days -> engine says $expected, verdict says \"$v\"",
+                        v.startsWith(expected),
+                    )
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Mirror the SOLID rule in the diagnostic verdict

Caught on a device. The strap log read:

  Rhythm: amplitude 5.5 bpm on a 74.7 bpm mesor  (acrophase 16.1h)
  Verdict: solid — 15 days observed

while estimatePhase had assigned that wearer WIDE: SOLID now needs enough days
AND a proportional swing, and 5.5/74.7 = 7.4% is short of the 10% bar. The
verdict's tier branches were still days-only, so the diagnostic contradicted the
screen it exists to explain - the one thing that section must never do, and the
reason it is labelled "recomputed from the store, not the live snapshot".

The engine's OR was mirrored when the absolute floor landed; its TIER was not.
Both halves of a rule have to cross together.

Worse, the test written to prevent exactly this asserted `startsWith("solid")`
for a floor-only swing, so it PINNED the divergence rather than catching it. It
now asserts WIDE and that the line names why ("the swing clears only the
absolute floor"), with a companion case for the only combination that reads
solid.

Rather than add more hand-written cases, the re-review added a structural guard:
theVerdictNeverDisagreesWithTheEngine drives the REAL estimatePhase and the REAL
verdict over a 60-point grid of days x mesor x amplitude and requires the two to
agree. Case-by-case assertions have now failed to prevent this drift twice; a
cross-check fails the moment only one side of a rule is updated.

The guard was verified by mutation, not assumed: disabling the new tier branch
made it fail with "mesor=65.0 amp=4.6 days=15 -> engine says wide, verdict says
solid - 15 days observed", which is precisely the divergence the device log
showed. A guard that cannot fail would have been worse than none.

A later pass corrected what the guard feeds it. It passed the NOMINAL amp/mesor
where production passes the values read off the recovered cosinor fit, so it was
checking a pairing the app never makes - and the nearest grid point sits 0.0022
from the 10% threshold, close enough that a future point plus recovery error
would fail the test for a reason unrelated to the rule it guards. It now derives
both from the fit, exactly as circadianLines does, and was re-verified by
mutation after the change rather than assumed to still catch.

Android 4775 pass.
