### PR TITLE
ble: say why a 5/MG link streams live HR and banks nothing

### DIFF
--- a/android/app/src/main/java/com/noop/ble/StalledLinkDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/ble/StalledLinkDiagnostics.kt
@@ -39,6 +39,7 @@ internal fun helloDeferredByExplicitBondLine(
     consecutive: Int,
     overrideOptedIn: Boolean,
     overrideAttempts: Int,
+    full: Boolean = true,
     cap: Int = HELLO_OVERRIDE_MAX_ATTEMPTS,
 ): String {
     val override = when {
@@ -46,7 +47,14 @@ internal fun helloDeferredByExplicitBondLine(
         overrideHelloStillAllowed(overrideAttempts, cap) -> "override on ($overrideAttempts/$cap used)"
         else -> "override SPENT ($overrideAttempts/$cap)"
     }
-    val tail = if (consecutive >= 2) {
+    val tail = if (consecutive >= 2 && !full) {
+        // The guidance is a paragraph and this fires once per CONNECT, on a path documented to loop —
+        // HelloSuppression records 57 reconnect cycles in an hour. Printing the paragraph 57 times would
+        // bury the rest of the capture under advice already given, so the full text is one-shot (the
+        // same latch idiom as helloOverrideExhaustedLine) and later occurrences stay countable but terse.
+        " $consecutive consecutive connects deferred, still no bond and no hello written — see the first" +
+            " occurrence above for what to do."
+    } else if (consecutive >= 2) {
         // Observed here vs cited from elsewhere, kept apart on purpose: the deferral count and the
         // absent bond ARE measured on this link; SMP 0x05 is not, and cannot be without an HCI capture.
         // Stating the cited cause as this strap's would be the #1635 mistake of a diagnostic claiming

--- a/android/app/src/main/java/com/noop/ble/StalledLinkDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/ble/StalledLinkDiagnostics.kt
@@ -1,0 +1,152 @@
+package com.noop.ble
+
+/**
+ * Why a 5/MG link reaches "live HR works, nothing ever syncs" — said once, in the log, instead of left
+ * to be reconstructed from four separate lines that each state only part of it.
+ *
+ * The field log that motivated this file contained every fact needed to explain a strap that had not
+ * banked a row in three days, and none of them said so. `Backfill: deferred — connect handshake not done
+ * yet` repeated with no state; the hello's absence was visible only as a line that never appeared; and
+ * the deferral that caused it returned silently. Reading it required knowing that `connectHandshakeDone`
+ * is gated on `didBond` for WHOOP5 and not for WHOOP4, that the handshake tail is what sends SET_CLOCK,
+ * and that an un-clocked 5/MG discards its own sensor data. That is too much reconstruction to ask of a
+ * capture, and it is the reconstruction that has to happen fastest when someone reports lost data.
+ *
+ * These builders are pure so the wording is testable and cannot drift from what the counters mean. The
+ * counters they render live in `WhoopBleClient` and are per app process — the honest limit of an
+ * in-memory bound, and the same one [overrideHelloStillAllowed] documents. The loops these describe run
+ * within one process; a restart is not the failure mode.
+ */
+
+/**
+ * The hello was not written on this link because a `createBond()` was asked for first.
+ *
+ * [ExplicitBond] already explains why that deferral never resolves on a strap answering SMP 0x05: the
+ * next connect requests a bond too, and defers again. What it could not do is say so at runtime — the
+ * deferral branch returns without a word, so a capture shows a hello that simply never happens, with the
+ * reason inferable only from an `explicitBondRequestLine` promising a "next connect" that reads
+ * identically on the first deferral and the fiftieth.
+ *
+ * [consecutive] is what makes it diagnosable. One deferral is the experiment working as designed; a
+ * number climbing across every connect is the permanent state, and the difference between those two is
+ * the entire question. Printing the count converts "why is there no hello" into one line.
+ *
+ * The override's state rides along because it is the only thing that breaks the cycle, and a reader who
+ * sees the deferral will immediately want to know whether the escape hatch is on and whether it has
+ * budget left. Naming a spent override explicitly stops it reading as an untried option.
+ */
+internal fun helloDeferredByExplicitBondLine(
+    consecutive: Int,
+    overrideOptedIn: Boolean,
+    overrideAttempts: Int,
+    cap: Int = HELLO_OVERRIDE_MAX_ATTEMPTS,
+): String {
+    val override = when {
+        !overrideOptedIn -> "override off"
+        overrideHelloStillAllowed(overrideAttempts, cap) -> "override on ($overrideAttempts/$cap used)"
+        else -> "override SPENT ($overrideAttempts/$cap)"
+    }
+    val tail = if (consecutive >= 2) {
+        // Observed here vs cited from elsewhere, kept apart on purpose: the deferral count and the
+        // absent bond ARE measured on this link; SMP 0x05 is not, and cannot be without an HCI capture.
+        // Stating the cited cause as this strap's would be the #1635 mistake of a diagnostic claiming
+        // more than it observed.
+        " Observed on this link: $consecutive consecutive connects deferred, no bond completed, and no" +
+            " hello written on any of them — so the \"next connect\" this waits for is not arriving." +
+            " A 5/MG answering Pairing Request with SMP 0x05 produces exactly this and is the known" +
+            " cause (#1635), but only an HCI capture can confirm it HERE. Either way the consequence is" +
+            " local and certain: didBond stays false, so SET_CLOCK never runs, and an un-clocked 5/MG" +
+            " does not persist its own sensor data to flash. Turn the pairing experiment OFF, or the" +
+            " hello override ON."
+    } else {
+        " Deferred once so far — expected on the connect that asks."
+    }
+    return "WHOOP 5/MG: CLIENT_HELLO deferred by the pairing experiment ($override).$tail (#1635)"
+}
+
+/**
+ * `beginBackfill` declined, with the state that decided it.
+ *
+ * The bare line named the gate and nothing else, so every occurrence looked the same whether the
+ * handshake was seconds from completing or structurally unreachable. These five fields separate those:
+ * a WHOOP5 with `didBond=false` and no hello ever written is the unreachable case, and it reads that way
+ * at a glance rather than after a code trace.
+ *
+ * [helloEverWrittenThisLink] earns its place by distinguishing the two ways to arrive here that need
+ * opposite fixes — a hello that was written and went unanswered (a strap or timing problem) from one that
+ * was never written at all (a local decision, and the one this log's field capture actually hit).
+ */
+internal fun backfillDeferredLine(
+    family: String,
+    didBond: Boolean,
+    helloEverWrittenThisLink: Boolean,
+    explicitBondRequestedThisLink: Boolean,
+    deferralsThisLink: Int,
+    msSinceConnect: Long,
+): String {
+    val since = if (msSinceConnect >= 0L) "${msSinceConnect / 1000}s" else "?"
+    val why = if (family == "WHOOP5" && !didBond && !helloEverWrittenThisLink) {
+        // A structural claim, not a guess about the strap: didBond is set only by the hello's own ack,
+        // so no hello written means this gate cannot open on this link no matter what the strap does.
+        " No hello was written on this link, so didBond cannot become true and this gate cannot open" +
+            " for the rest of it. SET_CLOCK rides the same handshake tail, and an un-clocked 5/MG is" +
+            " hardware-known not to persist sensor data to flash (#78 fork) — so there may also be" +
+            " nothing banked to offload."
+    } else {
+        ""
+    }
+    return "Backfill: deferred — connect handshake not done yet (family=$family didBond=$didBond" +
+        " helloWrittenThisLink=$helloEverWrittenThisLink bondRequestedThisLink=" +
+        "$explicitBondRequestedThisLink deferrals=$deferralsThisLink sinceConnect=$since).$why"
+}
+
+/**
+ * A live HR/R-R batch failed to persist and was re-buffered.
+ *
+ * The catch that owns this re-queues the frames and swallows the throwable, so a store that is failing
+ * every insert produces a log full of `rr emit … offered=13` and no indication that none of it landed.
+ * That is the worst shape a diagnostic gap can take: the instrumentation that exists reads like success.
+ *
+ * [consecutiveFailures] matters more than any single throwable. One failure is a transient the re-buffer
+ * exists to absorb; a climbing count is a store that is never going to accept these rows, and only the
+ * count separates them. The message is included because the useful cases — a full disk, a corrupted
+ * database, a schema mismatch — are distinguished by it rather than by the class.
+ */
+internal fun liveInsertFailedLine(
+    throwableName: String,
+    message: String?,
+    hrFrames: Int,
+    rrFrames: Int,
+    consecutiveFailures: Int,
+): String {
+    val detail = message?.takeIf { it.isNotBlank() }?.let { ": ${it.take(200)}" } ?: ""
+    val run = if (consecutiveFailures >= 2) {
+        " $consecutiveFailures consecutive failures — these rows are not landing and the re-buffer is" +
+            " not recovering them."
+    } else {
+        " Re-buffered for the next cadence."
+    }
+    return "Live persist FAILED — $throwableName$detail (hr=$hrFrames rr=$rrFrames).$run"
+}
+
+/**
+ * Rate-limit for [liveInsertFailedLine].
+ *
+ * The live cadence is seconds, so an unconditional log would bury the rest of the capture under a
+ * failure it has already reported. The gap is deliberately long: this line exists to establish THAT
+ * inserts are failing and roughly for how long, which one line a minute answers as well as sixty.
+ *
+ * A zero [lastEmitMs] must emit — the first failure is the one most worth having, and treating "never
+ * emitted" as "just emitted" would silence exactly the case this was built for.
+ *
+ * A BACKWARDS clock emits too. `System.currentTimeMillis()` is wall time and can step back — an NTP
+ * correction, a timezone-adjacent settings change, or the strap-clock skew this log family already
+ * tracks. Comparing only forwards would leave `lastEmitMs` stranded in the future and silence the line
+ * until real time caught up, which for a large step is indefinitely. Emitting on the step costs one
+ * extra line and cannot latch.
+ */
+internal fun shouldEmitLiveInsertFailure(
+    lastEmitMs: Long,
+    nowMs: Long,
+    minGapMs: Long = 60_000L,
+): Boolean = lastEmitMs <= 0L || nowMs < lastEmitMs || nowMs - lastEmitMs >= minGapMs

--- a/android/app/src/main/java/com/noop/ble/StalledLinkDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/ble/StalledLinkDiagnostics.kt
@@ -77,7 +77,7 @@ internal fun helloDeferredByExplicitBondLine(
  * was never written at all (a local decision, and the one this log's field capture actually hit).
  */
 internal fun backfillDeferredLine(
-    family: String,
+    family: String?,
     didBond: Boolean,
     helloEverWrittenThisLink: Boolean,
     explicitBondRequestedThisLink: Boolean,
@@ -85,6 +85,11 @@ internal fun backfillDeferredLine(
     msSinceConnect: Long,
 ): String {
     val since = if (msSinceConnect >= 0L) "${msSinceConnect / 1000}s" else "?"
+    // NULL means service discovery has not established the family yet. `connectedFamily` defaults to
+    // WHOOP4 and otherwise holds the PREVIOUS link's value, so printing it unconditionally would put a
+    // guess in the log — and a guess of WHOOP4 would suppress the explanation below on exactly the 5/MG
+    // this exists for. The caller reads `familyEstablished` FIRST for the happens-before it carries.
+    val fam = family ?: "unestablished"
     val why = if (family == "WHOOP5" && !didBond && !helloEverWrittenThisLink) {
         // A structural claim, not a guess about the strap: didBond is set only by the hello's own ack,
         // so no hello written means this gate cannot open on this link no matter what the strap does.
@@ -95,7 +100,7 @@ internal fun backfillDeferredLine(
     } else {
         ""
     }
-    return "Backfill: deferred — connect handshake not done yet (family=$family didBond=$didBond" +
+    return "Backfill: deferred — connect handshake not done yet (family=$fam didBond=$didBond" +
         " helloWrittenThisLink=$helloEverWrittenThisLink bondRequestedThisLink=" +
         "$explicitBondRequestedThisLink deferrals=$deferralsThisLink sinceConnect=$since).$why"
 }
@@ -107,12 +112,17 @@ internal fun backfillDeferredLine(
  * every insert produces a log full of `rr emit … offered=13` and no indication that none of it landed.
  * That is the worst shape a diagnostic gap can take: the instrumentation that exists reads like success.
  *
+ * [transport] is named because there are TWO live paths — the standard 0x2A37 reading and the puffin
+ * REALTIME_DATA batch (#1118) — and they fail independently. A line that did not say which would leave a
+ * reader unable to tell one dead transport from a dead store, which is the first fork in the diagnosis.
+ *
  * [consecutiveFailures] matters more than any single throwable. One failure is a transient the re-buffer
  * exists to absorb; a climbing count is a store that is never going to accept these rows, and only the
  * count separates them. The message is included because the useful cases — a full disk, a corrupted
  * database, a schema mismatch — are distinguished by it rather than by the class.
  */
 internal fun liveInsertFailedLine(
+    transport: String,
     throwableName: String,
     message: String?,
     hrFrames: Int,
@@ -126,7 +136,7 @@ internal fun liveInsertFailedLine(
     } else {
         " Re-buffered for the next cadence."
     }
-    return "Live persist FAILED — $throwableName$detail (hr=$hrFrames rr=$rrFrames).$run"
+    return "Live persist FAILED on $transport — $throwableName$detail (hr=$hrFrames rr=$rrFrames).$run"
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2386,6 +2386,12 @@ class WhoopBleClient(
      *  when a hello is written or a genuine bond is reached. Per app process, like the override budget. */
     @Volatile private var helloDeferredConsecutive = 0
 
+    /** Whether the deferral's full guidance paragraph has been printed for the CURRENT run. The deferral
+     *  fires once per connect on a path documented to loop (57 cycles in an hour, see [HelloSuppression]),
+     *  so the paragraph is one-shot per run and later connects log a terse countable line instead. Same
+     *  latch idiom as [helloOverrideExhaustedLogged]. Cleared wherever [helloDeferredConsecutive] is. */
+    @Volatile private var helloDeferredGuidanceLogged = false
+
     /** How many times [beginBackfill] has declined on this link, so repeats carry a count instead of
      *  reading as new information each time. Cleared in [reset]. */
     @Volatile private var backfillDeferralsThisLink = 0
@@ -5947,6 +5953,7 @@ class WhoopBleClient(
                     // realtime HR with puffin framing. Mirrors the macOS post-bond flow.
                     didBond = true
                     helloDeferredConsecutive = 0  // the handshake works on this strap; the run is over
+                    helloDeferredGuidanceLogged = false
                     helloOverrideAttempts = 0     // #1635: the strap answered — the override's budget resets
                     helloOverrideExhaustedLogged = false
                     cancelBondWatchdog()          // genuine bond reached — the handshake watchdog stands down (#50)
@@ -7777,24 +7784,21 @@ class WhoopBleClient(
         }
         log("WHOOP 5/MG: writing CLIENT_HELLO to fd4b0002 with response (to trigger bonding, experimental).")
         writeInFlight = true
-        // A hello is genuinely going out, so the deferral run is over. Recorded BEFORE the stack call:
-        // the run describes connects that never attempted one, and a stack rejection below is an
-        // attempt that failed, which is a different fact and has its own line.
-        helloWrittenThisLink = true
-        helloDeferredConsecutive = 0
         clientHelloWriteAtMs = System.currentTimeMillis()
         val ok = safeGatt("writeClientHello") {
             ops.writeCharacteristicCompat(ch, hello, BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT)
         }
-        if (!ok) {
+        if (ok) {
+            // Claimed only once the stack ACCEPTED the write. Setting these before the call left a window
+            // where a concurrent reader saw a hello that had not gone out, and cleared the deferral run
+            // on an attempt that failed — under-reporting the very run the count exists to measure.
+            helloWrittenThisLink = true
+            helloDeferredConsecutive = 0
+            helloDeferredGuidanceLogged = false
+        } else {
             writeInFlight = false
             log("CLIENT_HELLO write rejected by stack")
             clientHelloWriteAtMs = 0L   // never went out; no callback is owed
-            // ...and therefore no hello was written on this link after all. Leaving this true would tell
-            // backfillDeferredLine a hello had gone out and suppress the "no hello was written"
-            // explanation on a link where it is exactly right: a rejected write cannot be acked, so
-            // didBond cannot become true either.
-            helloWrittenThisLink = false
         }
     }
 
@@ -7905,10 +7909,13 @@ class WhoopBleClient(
                     // as a line that never appeared — and the deferral reads identically on the first
                     // connect and the fiftieth. The count is what separates them.
                     helloDeferredConsecutive += 1
+                    val fullGuidance = !helloDeferredGuidanceLogged
+                    if (helloDeferredConsecutive >= 2) helloDeferredGuidanceLogged = true
                     log(helloDeferredByExplicitBondLine(
                         consecutive = helloDeferredConsecutive,
                         overrideOptedIn = overrideOptedIn,
                         overrideAttempts = helloOverrideAttempts,
+                        full = fullGuidance,
                     ))
                     // Same trap as the suppression path below, and worse here. The watchdog was armed at
                     // discovery and bounces the link whenever didBond is false — which deferring the hello

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2375,6 +2375,27 @@ class WhoopBleClient(
      *  can be reported with an elapsed time. 0 means none is outstanding. Cleared in [reset]. */
     @Volatile private var clientHelloWriteAtMs: Long = 0L
 
+    /** Was a CLIENT_HELLO actually WRITTEN on this link? Distinct from [clientHelloWriteAtMs], which is
+     *  cleared the moment the write completes: this stays true for the rest of the connection so a later
+     *  backfill deferral can say whether the handshake was ever reachable. Cleared in [reset]. */
+    @Volatile private var helloWrittenThisLink = false
+
+    /** Consecutive connects that deferred the hello to the pairing experiment without writing one.
+     *  Deliberately NOT cleared in [reset] — the whole point is that it survives the connection, since
+     *  one deferral is the experiment working and a run of them is the permanent SMP-0x05 state. Reset
+     *  when a hello is written or a genuine bond is reached. Per app process, like the override budget. */
+    @Volatile private var helloDeferredConsecutive = 0
+
+    /** How many times [beginBackfill] has declined on this link, so repeats carry a count instead of
+     *  reading as new information each time. Cleared in [reset]. */
+    @Volatile private var backfillDeferralsThisLink = 0
+
+    /** Consecutive live-persist failures, and when the failure was last reported. The live cadence is
+     *  seconds, so the line is rate-limited; the COUNT is what separates a transient the re-buffer
+     *  absorbs from a store that is never going to accept these rows. */
+    @Volatile private var liveInsertFailuresConsecutive = 0
+    @Volatile private var lastLiveInsertFailureLogMs = 0L
+
     /** #1635: ms since the CLIENT_HELLO write, or null when none is outstanding. Lets the bond-state
      *  observer time a pairing transition against the write that may have triggered it, and report no
      *  elapsed time at all for a transition belonging to some other pairing. */
@@ -5914,6 +5935,7 @@ class WhoopBleClient(
                     // these as REALTIME_DATA — the strap rejected them on the unauthenticated link), then arm
                     // realtime HR with puffin framing. Mirrors the macOS post-bond flow.
                     didBond = true
+                    helloDeferredConsecutive = 0  // the handshake works on this strap; the run is over
                     helloOverrideAttempts = 0     // #1635: the strap answered — the override's budget resets
                     helloOverrideExhaustedLogged = false
                     cancelBondWatchdog()          // genuine bond reached — the handshake watchdog stands down (#50)
@@ -7744,6 +7766,11 @@ class WhoopBleClient(
         }
         log("WHOOP 5/MG: writing CLIENT_HELLO to fd4b0002 with response (to trigger bonding, experimental).")
         writeInFlight = true
+        // A hello is genuinely going out, so the deferral run is over. Recorded BEFORE the stack call:
+        // the run describes connects that never attempted one, and a stack rejection below is an
+        // attempt that failed, which is a different fact and has its own line.
+        helloWrittenThisLink = true
+        helloDeferredConsecutive = 0
         clientHelloWriteAtMs = System.currentTimeMillis()
         val ok = safeGatt("writeClientHello") {
             ops.writeCharacteristicCompat(ch, hello, BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT)
@@ -7858,6 +7885,15 @@ class WhoopBleClient(
                     log(helloOverrideExhaustedLine(helloOverrideAttempts))
                 }
                 if (explicitBondDefersHello(explicitBondRequestedThisLink, helloOverride = helloOverride)) {
+                    // This branch used to return without a word, so the hello's absence was visible only
+                    // as a line that never appeared — and the deferral reads identically on the first
+                    // connect and the fiftieth. The count is what separates them.
+                    helloDeferredConsecutive += 1
+                    log(helloDeferredByExplicitBondLine(
+                        consecutive = helloDeferredConsecutive,
+                        overrideOptedIn = overrideOptedIn,
+                        overrideAttempts = helloOverrideAttempts,
+                    ))
                     // Same trap as the suppression path below, and worse here. The watchdog was armed at
                     // discovery and bounces the link whenever didBond is false — which deferring the hello
                     // guarantees. Tearing the link down while an OS pairing is in flight is the single
@@ -8132,8 +8168,23 @@ class WhoopBleClient(
         }
         try {
             repository.insert(StreamBatch(hr = hr, rr = rr), deviceId)
+            liveInsertFailuresConsecutive = 0
         } catch (t: Throwable) {
             synchronized(collectorLock) { stdHr.addAll(0, hr); stdRr.addAll(0, rr) }
+            // Swallowing this made the instrumentation above read like success: a store failing every
+            // insert produced a log full of `rr emit ... offered=N` and no sign that none of it landed.
+            liveInsertFailuresConsecutive += 1
+            val nowMs = System.currentTimeMillis()
+            if (shouldEmitLiveInsertFailure(lastLiveInsertFailureLogMs, nowMs)) {
+                lastLiveInsertFailureLogMs = nowMs
+                log(liveInsertFailedLine(
+                    throwableName = t.javaClass.simpleName,
+                    message = t.message,
+                    hrFrames = hr.size,
+                    rrFrames = rr.size,
+                    consecutiveFailures = liveInsertFailuresConsecutive,
+                ))
+            }
         }
     }
 
@@ -8151,7 +8202,15 @@ class WhoopBleClient(
      */
     private fun beginBackfill() {
         if (!connectHandshakeDone) {
-            log("Backfill: deferred — connect handshake not done yet")
+            backfillDeferralsThisLink += 1
+            log(backfillDeferredLine(
+                family = connectedFamily?.name ?: "unknown",
+                didBond = didBond,
+                helloEverWrittenThisLink = helloWrittenThisLink,
+                explicitBondRequestedThisLink = explicitBondRequestedThisLink,
+                deferralsThisLink = backfillDeferralsThisLink,
+                msSinceConnect = if (connectedAtMs > 0L) System.currentTimeMillis() - connectedAtMs else -1L,
+            ))
             return
         }
         if (backfilling) return
@@ -9219,6 +9278,10 @@ class WhoopBleClient(
         // exactly the gap this stopwatch was added to close. It is overwritten by the next request, and a
         // stale value can only ever produce a large elapsed against a label that names what it measures.
         connectHandshakeDone = false
+        helloWrittenThisLink = false
+        backfillDeferralsThisLink = 0
+        // helloDeferredConsecutive is deliberately NOT cleared: it counts ACROSS connections, which is
+        // the only way a permanent deferral is distinguishable from a pending one.
         familyEstablished = false   // the next link re-establishes it at service discovery
         loggedFirmwareGate = null
         clientHelloWriteAtMs = 0L

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2390,11 +2390,22 @@ class WhoopBleClient(
      *  reading as new information each time. Cleared in [reset]. */
     @Volatile private var backfillDeferralsThisLink = 0
 
-    /** Consecutive live-persist failures, and when the failure was last reported. The live cadence is
-     *  seconds, so the line is rate-limited; the COUNT is what separates a transient the re-buffer
-     *  absorbs from a store that is never going to accept these rows. */
-    @Volatile private var liveInsertFailuresConsecutive = 0
-    @Volatile private var lastLiveInsertFailureLogMs = 0L
+    /** Consecutive live-persist failures per transport, and when each last reported. The live cadence is
+     *  seconds, so the lines are rate-limited; the COUNT is what separates a transient the re-buffer
+     *  absorbs from a store that is never going to accept these rows.
+     *
+     *  Kept PER TRANSPORT because the standard 0x2A37 path and the puffin REALTIME_DATA path (#1118)
+     *  fail independently — a shared counter would let one path's success reset the other's run and
+     *  report a persistent failure as a string of first-failures.
+     *
+     *  AtomicInteger, unlike the census fields above which are deliberately unsynchronized: those
+     *  tolerate a stale read (one duplicate line), but `+=` on a plain Int can LOSE an increment, and
+     *  the count here is the entire load-bearing distinction between a transient and a run. The two
+     *  flushes can run concurrently on the io scope, so that race is reachable. */
+    private val liveInsertFailuresStd = java.util.concurrent.atomic.AtomicInteger(0)
+    private val liveInsertFailuresRealtime = java.util.concurrent.atomic.AtomicInteger(0)
+    @Volatile private var lastStdInsertFailureLogMs = 0L
+    @Volatile private var lastRealtimeInsertFailureLogMs = 0L
 
     /** #1635: ms since the CLIENT_HELLO write, or null when none is outstanding. Lets the bond-state
      *  observer time a pairing transition against the write that may have triggered it, and report no
@@ -7779,6 +7790,11 @@ class WhoopBleClient(
             writeInFlight = false
             log("CLIENT_HELLO write rejected by stack")
             clientHelloWriteAtMs = 0L   // never went out; no callback is owed
+            // ...and therefore no hello was written on this link after all. Leaving this true would tell
+            // backfillDeferredLine a hello had gone out and suppress the "no hello was written"
+            // explanation on a link where it is exactly right: a rejected write cannot be acked, so
+            // didBond cannot become true either.
+            helloWrittenThisLink = false
         }
     }
 
@@ -8104,9 +8120,26 @@ class WhoopBleClient(
         if (!batch.isEmpty) {
             try {
                 repository.insert(batch, deviceId)
+                liveInsertFailuresRealtime.set(0)
             } catch (t: Throwable) {
                 // Re-buffer at the front so these frames retry on the next cadence (port of Collector).
                 synchronized(collectorLock) { liveBuffer.addAll(0, frames) }
+                // The #1118 SECOND transport, silent for the same reason the standard path was: the
+                // census above reports what was OFFERED, so a store rejecting everything still reads
+                // like a healthy stream.
+                val runLength = liveInsertFailuresRealtime.incrementAndGet()
+                val nowMs = System.currentTimeMillis()
+                if (shouldEmitLiveInsertFailure(lastRealtimeInsertFailureLogMs, nowMs)) {
+                    lastRealtimeInsertFailureLogMs = nowMs
+                    log(liveInsertFailedLine(
+                        transport = "live-realtime",
+                        throwableName = t.javaClass.simpleName,
+                        message = t.message,
+                        hrFrames = batch.hr.size,
+                        rrFrames = batch.rr.size,
+                        consecutiveFailures = runLength,
+                    ))
+                }
             }
         }
     }
@@ -8168,21 +8201,22 @@ class WhoopBleClient(
         }
         try {
             repository.insert(StreamBatch(hr = hr, rr = rr), deviceId)
-            liveInsertFailuresConsecutive = 0
+            liveInsertFailuresStd.set(0)
         } catch (t: Throwable) {
             synchronized(collectorLock) { stdHr.addAll(0, hr); stdRr.addAll(0, rr) }
             // Swallowing this made the instrumentation above read like success: a store failing every
             // insert produced a log full of `rr emit ... offered=N` and no sign that none of it landed.
-            liveInsertFailuresConsecutive += 1
+            val runLength = liveInsertFailuresStd.incrementAndGet()
             val nowMs = System.currentTimeMillis()
-            if (shouldEmitLiveInsertFailure(lastLiveInsertFailureLogMs, nowMs)) {
-                lastLiveInsertFailureLogMs = nowMs
+            if (shouldEmitLiveInsertFailure(lastStdInsertFailureLogMs, nowMs)) {
+                lastStdInsertFailureLogMs = nowMs
                 log(liveInsertFailedLine(
+                    transport = "live-standard",
                     throwableName = t.javaClass.simpleName,
                     message = t.message,
                     hrFrames = hr.size,
                     rrFrames = rr.size,
-                    consecutiveFailures = liveInsertFailuresConsecutive,
+                    consecutiveFailures = runLength,
                 ))
             }
         }
@@ -8203,8 +8237,12 @@ class WhoopBleClient(
     private fun beginBackfill() {
         if (!connectHandshakeDone) {
             backfillDeferralsThisLink += 1
+            // familyEstablished is read BEFORE connectedFamily on purpose: the happens-before it carries
+            // is what makes the family read safe, and connectedFamily otherwise holds a default or the
+            // previous link's value. Same ordering rule as batterySource(familyEstablished, family).
+            val established = familyEstablished
             log(backfillDeferredLine(
-                family = connectedFamily?.name ?: "unknown",
+                family = if (established) connectedFamily.name else null,
                 didBond = didBond,
                 helloEverWrittenThisLink = helloWrittenThisLink,
                 explicitBondRequestedThisLink = explicitBondRequestedThisLink,

--- a/android/app/src/test/java/com/noop/ble/StalledLinkDiagnosticsTest.kt
+++ b/android/app/src/test/java/com/noop/ble/StalledLinkDiagnosticsTest.kt
@@ -1,0 +1,184 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * These lines exist to make one specific field state readable — a 5/MG streaming live HR while banking
+ * nothing — so the tests assert the DISTINCTIONS a reader depends on, not the prose around them.
+ *
+ * Android-only, like [ExplicitBond] itself: CoreBluetooth has no explicit pairing API, so there is no
+ * Swift twin to hold a byte-identical oracle against and an audit finding this one-sided should leave it.
+ */
+class StalledLinkDiagnosticsTest {
+
+    // ---- helloDeferredByExplicitBondLine ------------------------------------------------------
+
+    /**
+     * One deferral is the experiment behaving as designed; a run of them is the permanent state. If both
+     * rendered the same, the line would be decoration — this is the distinction it exists to draw.
+     */
+    @Test
+    fun `a single deferral does not claim the permanent state`() {
+        val once = helloDeferredByExplicitBondLine(1, overrideOptedIn = false, overrideAttempts = 0)
+        assertTrue(once.contains("Deferred once so far"))
+        assertFalse("a single deferral must not assert permanence", once.contains("consecutive connects"))
+        assertFalse(once.contains("SMP 0x05"))
+    }
+
+    @Test
+    fun `a run of deferrals names the permanent state and both escapes`() {
+        val many = helloDeferredByExplicitBondLine(47, overrideOptedIn = false, overrideAttempts = 0)
+        assertTrue(many.contains("47 consecutive connects"))
+        assertTrue("the cause must be named, not implied", many.contains("SMP 0x05"))
+        // Both remedies, because either one alone leaves a reader stuck.
+        assertTrue(many.contains("pairing experiment OFF"))
+        assertTrue(many.contains("hello override ON"))
+        // The consequence that actually costs data is the un-clocked strap, not the missing sync.
+        assertTrue(many.contains("does not persist its own sensor data to flash"))
+    }
+
+    /**
+     * The #1635 rule in CLAUDE.md: a diagnostic may only assert what it can attribute. SMP 0x05 is not
+     * observable from this process — it needs an HCI capture — so the line must mark it as the cited
+     * cause and keep the locally measured facts separate. A future edit that collapses the two into a
+     * flat "the strap refuses pairing" fails here, which is the point.
+     */
+    @Test
+    fun `the cited cause is not asserted as observed on this link`() {
+        val many = helloDeferredByExplicitBondLine(47, overrideOptedIn = false, overrideAttempts = 0)
+        assertTrue("what was measured must be labelled as such", many.contains("Observed on this link:"))
+        assertTrue("the cited cause must be hedged", many.contains("only an HCI capture can confirm it HERE"))
+        // The consequence, unlike the cause, IS local and may be stated flatly.
+        assertTrue(many.contains("local and certain"))
+    }
+
+    /**
+     * A spent override must not read as an untried option — that is the `didBond`-reader trap pointed at
+     * the log: a reader who sees "override on" stops looking for why no hello went out.
+     */
+    @Test
+    fun `override state distinguishes off from on from spent`() {
+        val off = helloDeferredByExplicitBondLine(3, overrideOptedIn = false, overrideAttempts = 0)
+        val on = helloDeferredByExplicitBondLine(3, overrideOptedIn = true, overrideAttempts = 2)
+        val spent = helloDeferredByExplicitBondLine(3, overrideOptedIn = true, overrideAttempts = 6)
+        assertTrue(off.contains("override off"))
+        assertTrue(on.contains("override on (2/6 used)"))
+        assertTrue(spent.contains("override SPENT (6/6)"))
+        assertFalse("a spent override must not read as active", spent.contains("override on ("))
+    }
+
+    /** The boundary is the cap itself: the attempt that spends the budget is the last permitted one. */
+    @Test
+    fun `the override reads spent exactly at the cap`() {
+        assertTrue(helloDeferredByExplicitBondLine(3, true, HELLO_OVERRIDE_MAX_ATTEMPTS - 1).contains("override on"))
+        assertTrue(helloDeferredByExplicitBondLine(3, true, HELLO_OVERRIDE_MAX_ATTEMPTS).contains("override SPENT"))
+    }
+
+    // ---- backfillDeferredLine -----------------------------------------------------------------
+
+    /**
+     * The unreachable case — WHOOP5, unbonded, no hello ever written — is the one that needs explaining,
+     * and it must not be claimed for any other combination or the sentence stops meaning anything.
+     */
+    @Test
+    fun `only the structurally unreachable case gets the explanation`() {
+        val unreachable = backfillDeferredLine("WHOOP5", false, false, true, 3, 42_000L)
+        assertTrue(unreachable.contains("No hello was written on this link"))
+        assertTrue(unreachable.contains("didBond cannot become true"))
+        assertTrue(unreachable.contains("SET_CLOCK rides the same handshake tail"))
+
+        // A hello WAS written and went unanswered: a different problem with a different fix.
+        assertFalse(backfillDeferredLine("WHOOP5", false, true, true, 3, 42_000L)
+            .contains("No hello was written"))
+        // WHOOP4 does not gate the handshake on didBond at all.
+        assertFalse(backfillDeferredLine("WHOOP4", false, false, false, 1, 5_000L)
+            .contains("No hello was written"))
+        // Already bonded: the gate is about to open.
+        assertFalse(backfillDeferredLine("WHOOP5", true, true, false, 1, 5_000L)
+            .contains("No hello was written"))
+    }
+
+    @Test
+    fun `the state that decided it is all present`() {
+        val line = backfillDeferredLine("WHOOP5", false, false, true, 3, 42_000L)
+        assertTrue(line.contains("family=WHOOP5"))
+        assertTrue(line.contains("didBond=false"))
+        assertTrue(line.contains("helloWrittenThisLink=false"))
+        assertTrue(line.contains("bondRequestedThisLink=true"))
+        assertTrue(line.contains("deferrals=3"))
+        assertTrue(line.contains("sinceConnect=42s"))
+    }
+
+    /** An unknown connect time must render as unknown, never as 0s — which would read as "just now". */
+    @Test
+    fun `an unknown connect time is not reported as zero seconds`() {
+        assertTrue(backfillDeferredLine("WHOOP5", false, false, true, 1, -1L).contains("sinceConnect=?"))
+        assertTrue(backfillDeferredLine("WHOOP5", false, false, true, 1, 0L).contains("sinceConnect=0s"))
+    }
+
+    // ---- liveInsertFailedLine -----------------------------------------------------------------
+
+    @Test
+    fun `one failure reads as transient and a run reads as not recovering`() {
+        val once = liveInsertFailedLine("SQLiteFullException", "database or disk is full", 12, 13, 1)
+        assertTrue(once.contains("Re-buffered for the next cadence"))
+        assertFalse(once.contains("consecutive failures"))
+
+        val many = liveInsertFailedLine("SQLiteFullException", "database or disk is full", 12, 13, 9)
+        assertTrue(many.contains("9 consecutive failures"))
+        assertTrue(many.contains("not recovering them"))
+    }
+
+    /** The message distinguishes the useful cases; the class alone rarely does. */
+    @Test
+    fun `the throwable message survives and is bounded`() {
+        val line = liveInsertFailedLine("IllegalStateException", "x".repeat(500), 1, 2, 1)
+        assertTrue(line.contains("IllegalStateException"))
+        assertTrue(line.contains("x".repeat(200)))
+        assertFalse("an unbounded message would swamp the capture", line.contains("x".repeat(201)))
+    }
+
+    @Test
+    fun `a blank or absent message does not leave a dangling separator`() {
+        assertFalse(liveInsertFailedLine("IllegalStateException", null, 1, 2, 1).contains(": ("))
+        assertFalse(liveInsertFailedLine("IllegalStateException", "   ", 1, 2, 1).contains(": ("))
+    }
+
+    // ---- shouldEmitLiveInsertFailure ----------------------------------------------------------
+
+    /**
+     * The first failure is the one most worth having. Treating "never emitted" as "just emitted" would
+     * silence exactly the case this was built for, so the zero case is asserted rather than assumed.
+     */
+    @Test
+    fun `the first failure always emits`() {
+        assertTrue(shouldEmitLiveInsertFailure(lastEmitMs = 0L, nowMs = 1_000L))
+        assertTrue(shouldEmitLiveInsertFailure(lastEmitMs = -5L, nowMs = 1_000L))
+    }
+
+    @Test
+    fun `the gap is honoured at its boundary`() {
+        assertFalse(shouldEmitLiveInsertFailure(lastEmitMs = 1_000L, nowMs = 60_999L))
+        assertTrue(shouldEmitLiveInsertFailure(lastEmitMs = 1_000L, nowMs = 61_000L))
+    }
+
+    /**
+     * A clock that steps backwards must not latch the line off. Comparing only forwards would strand
+     * `lastEmitMs` in the future and silence the line until real time caught up — for a large step,
+     * indefinitely. This is the assertion that forced the guard: the naive version fails it.
+     */
+    @Test
+    fun `a backwards clock emits rather than latching off`() {
+        assertTrue(shouldEmitLiveInsertFailure(lastEmitMs = 10_000L, nowMs = 5_000L))
+        assertTrue(shouldEmitLiveInsertFailure(lastEmitMs = Long.MAX_VALUE / 2, nowMs = 1_000L))
+    }
+
+    @Test
+    fun `the default gap is one minute`() {
+        assertEquals(true, shouldEmitLiveInsertFailure(1L, 60_001L))
+        assertEquals(false, shouldEmitLiveInsertFailure(1L, 30_000L))
+    }
+}

--- a/android/app/src/test/java/com/noop/ble/StalledLinkDiagnosticsTest.kt
+++ b/android/app/src/test/java/com/noop/ble/StalledLinkDiagnosticsTest.kt
@@ -112,6 +112,20 @@ class StalledLinkDiagnosticsTest {
         assertTrue(line.contains("sinceConnect=42s"))
     }
 
+    /**
+     * `connectedFamily` defaults to WHOOP4 and otherwise holds the PREVIOUS link's value, so before
+     * service discovery it is a guess. Printing a guess would break the same rule the hello line follows
+     * — and a guess of WHOOP4 would suppress the explanation on exactly the 5/MG this was built for.
+     */
+    @Test
+    fun `an unestablished family is not guessed and gets no explanation`() {
+        val line = backfillDeferredLine(null, false, false, true, 1, 5_000L)
+        assertTrue(line.contains("family=unestablished"))
+        assertFalse("a guessed family must not appear", line.contains("family=WHOOP4"))
+        assertFalse("the explanation must not ride on an unknown family",
+                    line.contains("No hello was written"))
+    }
+
     /** An unknown connect time must render as unknown, never as 0s — which would read as "just now". */
     @Test
     fun `an unknown connect time is not reported as zero seconds`() {
@@ -121,13 +135,23 @@ class StalledLinkDiagnosticsTest {
 
     // ---- liveInsertFailedLine -----------------------------------------------------------------
 
+    /**
+     * Two live transports fail independently (#1118). A line that did not say which would leave a reader
+     * unable to separate one dead transport from a dead store — the first fork in the diagnosis.
+     */
+    @Test
+    fun `the failing transport is named`() {
+        assertTrue(liveInsertFailedLine("live-standard", "E", null, 1, 1, 1).contains("on live-standard"))
+        assertTrue(liveInsertFailedLine("live-realtime", "E", null, 1, 1, 1).contains("on live-realtime"))
+    }
+
     @Test
     fun `one failure reads as transient and a run reads as not recovering`() {
-        val once = liveInsertFailedLine("SQLiteFullException", "database or disk is full", 12, 13, 1)
+        val once = liveInsertFailedLine("live-standard", "SQLiteFullException", "database or disk is full", 12, 13, 1)
         assertTrue(once.contains("Re-buffered for the next cadence"))
         assertFalse(once.contains("consecutive failures"))
 
-        val many = liveInsertFailedLine("SQLiteFullException", "database or disk is full", 12, 13, 9)
+        val many = liveInsertFailedLine("live-standard", "SQLiteFullException", "database or disk is full", 12, 13, 9)
         assertTrue(many.contains("9 consecutive failures"))
         assertTrue(many.contains("not recovering them"))
     }
@@ -135,7 +159,7 @@ class StalledLinkDiagnosticsTest {
     /** The message distinguishes the useful cases; the class alone rarely does. */
     @Test
     fun `the throwable message survives and is bounded`() {
-        val line = liveInsertFailedLine("IllegalStateException", "x".repeat(500), 1, 2, 1)
+        val line = liveInsertFailedLine("live-realtime", "IllegalStateException", "x".repeat(500), 1, 2, 1)
         assertTrue(line.contains("IllegalStateException"))
         assertTrue(line.contains("x".repeat(200)))
         assertFalse("an unbounded message would swamp the capture", line.contains("x".repeat(201)))
@@ -143,8 +167,8 @@ class StalledLinkDiagnosticsTest {
 
     @Test
     fun `a blank or absent message does not leave a dangling separator`() {
-        assertFalse(liveInsertFailedLine("IllegalStateException", null, 1, 2, 1).contains(": ("))
-        assertFalse(liveInsertFailedLine("IllegalStateException", "   ", 1, 2, 1).contains(": ("))
+        assertFalse(liveInsertFailedLine("live-realtime", "IllegalStateException", null, 1, 2, 1).contains(": ("))
+        assertFalse(liveInsertFailedLine("live-realtime", "IllegalStateException", "   ", 1, 2, 1).contains(": ("))
     }
 
     // ---- shouldEmitLiveInsertFailure ----------------------------------------------------------
@@ -174,6 +198,54 @@ class StalledLinkDiagnosticsTest {
     fun `a backwards clock emits rather than latching off`() {
         assertTrue(shouldEmitLiveInsertFailure(lastEmitMs = 10_000L, nowMs = 5_000L))
         assertTrue(shouldEmitLiveInsertFailure(lastEmitMs = Long.MAX_VALUE / 2, nowMs = 1_000L))
+    }
+
+    // ---- caller-side contract -----------------------------------------------------------------
+
+    /**
+     * The builders above are pure and testable; the two invariants that actually decide whether they
+     * print the truth live in `WhoopBleClient`, which no JVM test can construct. Both were WRONG in the
+     * first version of this change and neither failure would have been caught by anything above, so they
+     * are pinned against the source the way `RawCaptureExportContractTest` pins the collector's.
+     */
+    private fun clientSource(): String {
+        var root = java.io.File(System.getProperty("user.dir") ?: ".").canonicalFile
+        repeat(4) {
+            val f = java.io.File(root, "android/app/src/main/java/com/noop/ble/WhoopBleClient.kt")
+            if (f.isFile) return f.readText()
+            root = root.parentFile ?: root
+        }
+        error("WhoopBleClient.kt not found — this test must not pass by default")
+    }
+
+    /**
+     * `familyEstablished` must be read BEFORE `connectedFamily`, and the family passed as null when it is
+     * false. `connectedFamily` is non-null and defaults to WHOOP4, so the naive read puts a guess in the
+     * log — and a guessed WHOOP4 suppresses the explanation on precisely the 5/MG case this exists for.
+     * The ordering additionally carries the happens-before that makes the family read safe at all, which
+     * is the same rule `batterySource(familyEstablished, connectedFamily)` is documented to follow.
+     */
+    @Test
+    fun `the backfill line never reports a guessed family`() {
+        val src = clientSource()
+        assertTrue("familyEstablished must be latched before the family is read",
+                   src.contains("val established = familyEstablished"))
+        assertTrue("an unestablished family must be passed as null, not guessed",
+                   src.contains("family = if (established) connectedFamily.name else null"))
+    }
+
+    /**
+     * A CLIENT_HELLO the stack REJECTED never went out, so the link must not go on claiming one was
+     * written: that would suppress the "no hello was written" explanation on a link where it is exactly
+     * right, since a rejected write can never be acked and didBond can never become true.
+     */
+    @Test
+    fun `a stack-rejected hello does not count as written`() {
+        val src = clientSource()
+        val reject = src.substringAfter("log(\"CLIENT_HELLO write rejected by stack\")")
+            .substringBefore("}")
+        assertTrue("the reject path must clear helloWrittenThisLink",
+                   reject.contains("helloWrittenThisLink = false"))
     }
 
     @Test

--- a/android/app/src/test/java/com/noop/ble/StalledLinkDiagnosticsTest.kt
+++ b/android/app/src/test/java/com/noop/ble/StalledLinkDiagnosticsTest.kt
@@ -56,6 +56,24 @@ class StalledLinkDiagnosticsTest {
     }
 
     /**
+     * The paragraph fires once per CONNECT on a path documented to loop (57 cycles in an hour), so the
+     * full text is one-shot and later occurrences must stay countable but terse. If the short form
+     * dropped the count it would be unreadable; if it kept the paragraph it would bury the capture.
+     */
+    @Test
+    fun `the repeat form keeps the count but drops the guidance`() {
+        val terse = helloDeferredByExplicitBondLine(9, overrideOptedIn = false, overrideAttempts = 0,
+                                                    full = false)
+        assertTrue("the count is the point of the repeat", terse.contains("9 consecutive connects"))
+        assertTrue(terse.contains("see the first occurrence above"))
+        assertFalse("advice already given must not repeat", terse.contains("pairing experiment OFF"))
+        assertFalse(terse.contains("SMP 0x05"))
+        // A FIRST occurrence is unaffected by the flag: there is no guidance to suppress yet.
+        val firstShort = helloDeferredByExplicitBondLine(1, false, 0, full = false)
+        assertTrue(firstShort.contains("Deferred once so far"))
+    }
+
+    /**
      * A spent override must not read as an untried option — that is the `didBond`-reader trap pointed at
      * the log: a reader who sees "override on" stops looking for why no hello went out.
      */
@@ -235,17 +253,27 @@ class StalledLinkDiagnosticsTest {
     }
 
     /**
-     * A CLIENT_HELLO the stack REJECTED never went out, so the link must not go on claiming one was
-     * written: that would suppress the "no hello was written" explanation on a link where it is exactly
-     * right, since a rejected write can never be acked and didBond can never become true.
+     * A CLIENT_HELLO the stack REJECTED never went out, so nothing may claim one was written: that would
+     * suppress the "no hello was written" explanation on a link where it is exactly right, since a
+     * rejected write can never be acked and didBond can never become true.
+     *
+     * Asserted as an ORDERING rather than a presence, because the first version of this passed a
+     * presence check while still being wrong — it set the flag before the stack call and cleared it
+     * afterwards, which both opened a window for a concurrent reader and cleared the deferral run on an
+     * attempt that had failed.
      */
     @Test
-    fun `a stack-rejected hello does not count as written`() {
-        val src = clientSource()
-        val reject = src.substringAfter("log(\"CLIENT_HELLO write rejected by stack\")")
-            .substringBefore("}")
-        assertTrue("the reject path must clear helloWrittenThisLink",
-                   reject.contains("helloWrittenThisLink = false"))
+    fun `a hello is only counted as written after the stack accepts it`() {
+        val fn = clientSource()
+            .substringAfter("private fun writeClientHello(")
+            .substringBefore("\n    }")
+        val call = fn.indexOf("val ok = safeGatt(\"writeClientHello\")")
+        val claim = fn.indexOf("helloWrittenThisLink = true")
+        val run = fn.indexOf("helloDeferredConsecutive = 0")
+        assertTrue("writeClientHello must call safeGatt", call >= 0)
+        assertTrue("the write must be claimed, somewhere", claim >= 0)
+        assertTrue("helloWrittenThisLink must be set AFTER the stack accepts", claim > call)
+        assertTrue("the deferral run must only be cleared AFTER the stack accepts", run > call)
     }
 
     @Test


### PR DESCRIPTION
A field log from a 5/MG that had not banked a row in three days contained every fact needed to explain it, and none of them said so.

Reading it required knowing that `connectHandshakeDone` is gated on `didBond` for WHOOP5 but not for WHOOP4, that the handshake tail is what sends `SET_CLOCK`, and that an un-clocked 5/MG discards its own sensor data. That is too much reconstruction to ask of a capture, and it is the reconstruction that has to happen fastest when someone reports lost data.

Three lines now carry it.

**The hello deferral returned silently.** `ExplicitBond` already documents that the deferral never resolves against a strap answering SMP 0x05 - the next connect requests a bond too and defers again - but nothing said so at runtime. The hello's absence was visible only as a line that never appeared, and the promise of a "next connect" read identically on the first deferral and the fiftieth. The count across connections is the whole distinction, and it is printed now, with the override's state beside it because that is the only thing that breaks the cycle and a spent override must not read as an untried option.

**The backfill deferral repeated with no state.** It now carries family, didBond, whether a hello was ever written on this link, the deferral count and time since connect - which separates a handshake seconds from completing from one that cannot open at all.

**The live-persist catch swallowed its throwable** while re-buffering, so a store failing every insert produced a log full of `rr emit ... offered=N` and no sign that none of it landed. Instrumentation that reads like success is the worst shape a gap can take. Both live transports report now, each naming its own, rate-limited with a consecutive-failure count.

Attribution is kept honest per CLAUDE.md: SMP 0x05 is not observable from this process, so the line labels what was measured on this link and marks the cited cause as needing an HCI capture to confirm here. A test pins that split so a later edit cannot flatten it into "the strap refuses pairing".

**Two review passes are folded in, and both found real defects.** The first found five, three of which would have made the lines report the opposite of the truth: the family was read from `connectedFamily` alone, which is non-null and defaults to WHOOP4, so a guessed WHOOP4 SUPPRESSED the explanation on exactly the 5/MG case it exists for; a stack-rejected hello still counted as written; and only one of the two live transports was instrumented. The second found the guidance paragraph printing on every deferring connect, on a path documented as looping 57 times in an hour - burying the log an instrumentation change exists to make readable.

Pure builders with 20 tests. No behaviour change: the BLE path is untouched beyond what it now reports. The same silent catch exists in Swift at `Collector.swift:218` and `:274` and is NOT fixed here.

Verified: 4839 unit tests green, doc-comment lint clean.
