### PR TITLE
diag: say which workout detector made the rows, and when the pipelines last ran

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2771,6 +2771,13 @@ class WhoopBleClient(
                 }.onSuccess {
                     // Advance the shared watermark so the next 15-min tick sees no change and skips (#836).
                     NoopPrefs.setAnalyzeWatermark(context, analyzeFp)
+                    // #1735: stamp the post-sync pass too, not just the idle one in AppViewModel. This is
+                    // the pass that runs right after an offload, so it is the one a "synced but nothing
+                    // appeared" report is actually asking about.
+                    runCatching {
+                        NoopPrefs.of(context).edit()
+                            .putLong("score.lastPassAt", System.currentTimeMillis() / 1000).apply()
+                    }
                     log("Backfill: post-sync scoring pass done")
                     // #277 diagnostic: surface the day-key the dashboard treats as "today" against the
                     // newest banked row, so a UTC-bucket vs local-day split (rows persist but Today

--- a/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
+++ b/android/app/src/main/java/com/noop/ingest/HealthConnectImporter.kt
@@ -158,6 +158,21 @@ object HealthConnectImporter {
     private fun prefs(context: Context) =
         context.getSharedPreferences(NoopPrefs.NAME, Context.MODE_PRIVATE)
 
+    /** #1735: stamp a COMPLETED import run so the diagnostics header can say when data last moved, not
+     *  merely how many rows exist. Raw keys written inline, read back by AndroidDiagnostics - the same
+     *  shape `sync.lastWriteOkAt` uses. Guarded: a stamp is never worth failing an import over. */
+    private fun recordImportRun(context: Context, rows: Int, throughDay: String?) {
+        runCatching {
+            prefs(context).edit()
+                .putLong("hc.lastImportOkAt", System.currentTimeMillis() / 1000)
+                .putInt("hc.lastImportRows", rows)
+                .apply {
+                    if (throughDay != null) putString("hc.lastImportThroughDay", throughDay)
+                }
+                .apply()
+        }
+    }
+
     /**
      * Whether Health Connect is installed/available on this device.
      * One of [HealthConnectClient.SDK_AVAILABLE],
@@ -559,6 +574,13 @@ object HealthConnectImporter {
         }
 
         if (acc.isEmpty() && workouts.isEmpty()) {
+        // #1735: record that an import RAN and what it brought. "Hours after a ride it still is not
+        // there" cannot be told from "Health Connect never imported it" without this: the log had per-source
+        // row counts but nothing about WHEN they last moved. Mirrors the sync.lastWriteOkAt pattern the
+        // strap-write path already uses. Best-effort - a stamp failure must not sink a good import.
+            // Stamped on the EMPTY path too, deliberately: "ran and found nothing" and "never ran" are
+            // different diagnoses and this is the only line that separates them.
+            recordImportRun(context, rows = 0, throughDay = null)
             return ImportSummary(
                 source = SOURCE,
                 counts = emptyMap(),
@@ -704,6 +726,11 @@ object HealthConnectImporter {
         val lastDay = touchedDays.lastOrNull()
 
         val total = counts.values.sum()
+        // #1735: record that an import RAN and what it brought. "Hours after a ride it still is not
+        // there" cannot be told from "Health Connect never imported it" without this: the log had per-source
+        // row counts but nothing about WHEN they last moved. Mirrors the sync.lastWriteOkAt pattern the
+        // strap-write path already uses. Best-effort - a stamp failure must not sink a good import.
+        recordImportRun(context, rows = total, throughDay = lastDay)
         return ImportSummary(
             source = SOURCE,
             counts = counts,

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -290,7 +290,11 @@ object AndroidDiagnostics {
             // per-bout tracing for that sits behind the Test Centre WORKOUTS domain, which a reporter
             // filing a non-test-mode bug will not have on. Counts read from the store, so this states what
             // IS, not what the code intends.
-            add(
+            // Guarded SEPARATELY from the section: this file's contract is that every probe is guarded,
+            // and a throw in here would otherwise be caught by the outer handler and reported as
+            // "(workout sources unavailable)" - blaming the store for a failure in the auto-detect probe,
+            // with the sources sitting right above it having plainly worked.
+            runCatching {
                 autoDetectStateLine(
                     suggestionCardEnabled = com.noop.ui.NoopPrefs.autoDetectWorkouts(context),
                     storedDetectedRows = perSource.flatMap { it.second }.count { it.sport == "detected" },
@@ -301,8 +305,8 @@ object AndroidDiagnostics {
                     dismissedMarkers = runCatching {
                         listOf(active, "my-whoop").distinct().sumOf { repo.dismissedDetected(it).size }
                     }.getOrNull(),
-                ),
-            )
+                )
+            }.onSuccess { add(it) }.onFailure { add("(auto-detect state unavailable: ${it.message})") }
         }.onFailure { add("(workout sources unavailable: ${it.message})") }
     }
 
@@ -619,7 +623,7 @@ object AndroidDiagnostics {
         val card = if (suggestionCardEnabled) "on" else "off"
         val dismissed = dismissedMarkers?.toString() ?: "n/a"
         val note = if (!suggestionCardEnabled && storedDetectedRows > 0) {
-            " (rows present with the card off is EXPECTED: a different detector makes them)"
+            " (rows with the card off are EXPECTED: a different detector makes them)"
         } else {
             ""
         }

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -284,6 +284,25 @@ object AndroidDiagnostics {
             add("Stored: " + perSource.joinToString("  ") { "${it.first}=${it.second.size}" })
             val latest = perSource.flatMap { it.second }.maxByOrNull { it.startTs }
             add(if (latest != null) "Latest: ${dayStamp(latest.startTs)} · ${latest.sport} (${latest.source})" else "Latest: none")
+            // #1735: "auto-detect is off but workouts keep appearing" is answerable only if the log says
+            // which of the TWO detectors is meant. The Settings toggle governs the opt-in suggestion card
+            // ONLY; the engine derives durable sport="detected" rows on every pass regardless, and all the
+            // per-bout tracing for that sits behind the Test Centre WORKOUTS domain, which a reporter
+            // filing a non-test-mode bug will not have on. Counts read from the store, so this states what
+            // IS, not what the code intends.
+            add(
+                autoDetectStateLine(
+                    suggestionCardEnabled = com.noop.ui.NoopPrefs.autoDetectWorkouts(context),
+                    storedDetectedRows = perSource.flatMap { it.second }.count { it.sport == "detected" },
+                    // Summed over the SAME strap ids whose rows were counted above. A two-strap install
+                    // banks detected rows under both "<active>-noop" and "my-whoop-noop", so reading
+                    // dismissals for the active strap alone could print "detected=52 dismissed=0" while
+                    // the dismissals sat under the other id, sending a reader after the #107 mechanism.
+                    dismissedMarkers = runCatching {
+                        listOf(active, "my-whoop").distinct().sumOf { repo.dismissedDetected(it).size }
+                    }.getOrNull(),
+                ),
+            )
         }.onFailure { add("(workout sources unavailable: ${it.message})") }
     }
 
@@ -572,6 +591,41 @@ object AndroidDiagnostics {
             null -> "unknown"
         }
     }.getOrDefault("unknown")
+
+    /**
+     * Which workout detector produced what, and whether the Settings toggle has anything to do with it.
+     *
+     * NOOP has TWO detectors and they are deliberately separate (see AutoWorkoutDetector's header). The
+     * Settings toggle governs the opt-in SUGGESTION card, which only ever offers a workout and saves
+     * nothing until the user taps Save. The IntelligenceEngine separately derives durable sport="detected"
+     * rows from the 1 Hz store on every scoring pass, and that has never been gated by the toggle.
+     *
+     * Both are called "detect" in the UI, so #1735 read the second one's rows as the first one ignoring
+     * its own switch, which is an entirely reasonable reading. Every per-bout line that would have shown
+     * the difference sits behind the Test Centre WORKOUTS domain, and that report was filed as "not a
+     * test-mode bug" with the domain off, so the log carried nothing about it at all.
+     *
+     * Reads COUNTS from the store rather than describing intent: it states what is on disk, not what the
+     * code believes it does. The reassurance clause is emitted only for the combination that actually
+     * misleads (card off, rows present) so it never claims to explain a state it is not looking at.
+     * [dismissedMarkers] is null when the query failed, and renders "n/a" rather than a wrong zero, which
+     * would read as "your dismissals are not sticking".
+     */
+    internal fun autoDetectStateLine(
+        suggestionCardEnabled: Boolean,
+        storedDetectedRows: Int,
+        dismissedMarkers: Int?,
+    ): String {
+        val card = if (suggestionCardEnabled) "on" else "off"
+        val dismissed = dismissedMarkers?.toString() ?: "n/a"
+        val note = if (!suggestionCardEnabled && storedDetectedRows > 0) {
+            " (rows present with the card off is EXPECTED: a different detector makes them)"
+        } else {
+            ""
+        }
+        return "Auto-detect: suggestion card=$card · engine \"Activity\" rows=always on, not gated by " +
+            "that toggle · stored detected=$storedDetectedRows · dismissed markers=$dismissed$note"
+    }
 
     /** A coarse OEM-kill heuristic by manufacturer (the aggressive-background-kill vendors). Pure and
      *  internal so it unit-tests without a Context (the suite stays Robolectric-free). */

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -104,6 +104,20 @@ object AndroidDiagnostics {
                     "(if you restored a backup, fully restart the app — #57)")
             }
             if (restoreAt > 0L) add("Last restore: ${relTime(now - restoreAt * 1000L)}")
+            // #1735: row COUNTS alone cannot separate "Health Connect never brought the ride in" from
+            // "it did, but nothing has re-scored since". Both halves of that need a WHEN, and neither had
+            // one: the importer recorded no run time at all, and the engine's "re-score: done" goes only to
+            // the live log, so an export written hours later has already rolled it away.
+            val hcAt = p.getLong("hc.lastImportOkAt", 0L)
+            add(
+                hcImportLine(
+                    ago = if (hcAt > 0L) relTime(now - hcAt * 1000L) else null,
+                    rows = p.getInt("hc.lastImportRows", 0),
+                    throughDay = p.getString("hc.lastImportThroughDay", null),
+                ),
+            )
+            val scoredAt = p.getLong("score.lastPassAt", 0L)
+            add(scoringPassLine(ago = if (scoredAt > 0L) relTime(now - scoredAt * 1000L) else null))
             add("Timezone:    ${tzLine()}")
             val repo = com.noop.data.WhoopRepository.from(context)
             val days = repo.days("my-whoop")
@@ -595,6 +609,39 @@ object AndroidDiagnostics {
             null -> "unknown"
         }
     }.getOrDefault("unknown")
+
+    /**
+     * When Health Connect last completed an import, and what it brought.
+     *
+     * The export already listed per-source row counts, which answer "is there data" but never "is it
+     * MOVING". #1735 turns on exactly that difference: a ride that has not appeared is either one Health
+     * Connect never imported or one it imported and nothing re-scored, and a static count cannot tell
+     * those apart. [rows] of 0 with a recent [ago] is a real and useful state - the import ran and found
+     * nothing - which is why the empty path is stamped too.
+     *
+     * A null [ago] means no import has ever completed on this install. Stated plainly rather than dressed
+     * up as a fault: plenty of installs never connect Health Connect at all.
+     */
+    internal fun hcImportLine(ago: String?, rows: Int, throughDay: String?): String {
+        if (ago == null) return "HC import:   never completed on this install"
+        val through = throughDay?.let { " · through $it" } ?: ""
+        return "HC import:   $rows row(s) $ago$through"
+    }
+
+    /**
+     * When the scoring engine last completed a pass.
+     *
+     * The analyze watermark records WHAT was scored (an HR fingerprint) and never WHEN, and the engine's
+     * own "re-score: done" line is live-log only, so an export written hours after the pass has already
+     * rolled it away. Without this, "I synced and nothing appeared" cannot distinguish a pass that ran and
+     * found nothing new from one that never ran - and those need opposite next steps.
+     *
+     * Stamped at BOTH completion sites (the idle pass and the post-sync pass), so the freshest of the two
+     * is what shows.
+     */
+    internal fun scoringPassLine(ago: String?): String =
+        if (ago == null) "Scoring:     no pass has completed on this install"
+        else "Scoring:     last pass $ago"
 
     /**
      * Which workout detector produced what, and whether the Settings toggle has anything to do with it.

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1147,7 +1147,17 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                     // analyzeRecent now hops to Dispatchers.Default; a scope cancellation surfaces as a
                     // CancellationException that runCatching would otherwise swallow, breaking the loop's
                     // own cancellation — rethrow it so onCleared() actually stops the loop. (#125)
-                }.onSuccess { NoopPrefs.setAnalyzeWatermark(appContext, analyzeFp) }
+                }.onSuccess {
+                    NoopPrefs.setAnalyzeWatermark(appContext, analyzeFp)
+                    // #1735: the watermark says WHAT was scored, never WHEN. "re-score: done" goes only to
+                    // the live log, so hours later the rolling buffer has dropped it and an export cannot
+                    // tell a pass that ran from one that never did - which is half of "my ride still is not
+                    // showing". Stamp the completion; AndroidDiagnostics renders it beside "Data write".
+                    runCatching {
+                        NoopPrefs.of(appContext).edit()
+                            .putLong("score.lastPassAt", System.currentTimeMillis() / 1000).apply()
+                    }
+                }
                     .onFailure { if (it is kotlin.coroutines.cancellation.CancellationException) throw it }
                 // Opt-in writeback: push the freshly computed nights into Health Connect so other
                 // apps see them. Idempotent (clientRecordId per metric+day), so re-running every

--- a/android/app/src/test/java/com/noop/testcentre/AutoDetectStateLineTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/AutoDetectStateLineTest.kt
@@ -19,12 +19,12 @@ class AutoDetectStateLineTest {
     fun `only the misleading combination gets the reassurance`() {
         val misleading = AndroidDiagnostics.autoDetectStateLine(false, storedDetectedRows = 12, dismissedMarkers = 3)
         assertTrue(misleading.contains("suggestion card=off"))
-        assertTrue(misleading.contains("is EXPECTED"))
+        assertTrue(misleading.contains("are EXPECTED"))
 
         // Card off and NO rows: nothing to explain.
-        assertFalse(AndroidDiagnostics.autoDetectStateLine(false, 0, 0).contains("is EXPECTED"))
+        assertFalse(AndroidDiagnostics.autoDetectStateLine(false, 0, 0).contains("are EXPECTED"))
         // Card ON: rows are unsurprising to a reader who just enabled it.
-        assertFalse(AndroidDiagnostics.autoDetectStateLine(true, 12, 0).contains("is EXPECTED"))
+        assertFalse(AndroidDiagnostics.autoDetectStateLine(true, 12, 0).contains("are EXPECTED"))
     }
 
     /** The load-bearing fact: the engine rows are not governed by the toggle. Always stated. */

--- a/android/app/src/test/java/com/noop/testcentre/AutoDetectStateLineTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/AutoDetectStateLineTest.kt
@@ -1,0 +1,69 @@
+package com.noop.testcentre
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The line exists to stop a reader drawing #1735's conclusion, so the tests assert the distinctions that
+ * do that job rather than the prose. Pure and Context-free, like the rest of the diagnostics helpers.
+ */
+class AutoDetectStateLineTest {
+
+    /**
+     * The misleading combination, and the only one the reassurance belongs on: the toggle is off and rows
+     * exist anyway. Claiming it in any other state would be explaining something the line is not looking
+     * at, which is how a diagnostic starts asserting more than it observes.
+     */
+    @Test
+    fun `only the misleading combination gets the reassurance`() {
+        val misleading = AndroidDiagnostics.autoDetectStateLine(false, storedDetectedRows = 12, dismissedMarkers = 3)
+        assertTrue(misleading.contains("suggestion card=off"))
+        assertTrue(misleading.contains("is EXPECTED"))
+
+        // Card off and NO rows: nothing to explain.
+        assertFalse(AndroidDiagnostics.autoDetectStateLine(false, 0, 0).contains("is EXPECTED"))
+        // Card ON: rows are unsurprising to a reader who just enabled it.
+        assertFalse(AndroidDiagnostics.autoDetectStateLine(true, 12, 0).contains("is EXPECTED"))
+    }
+
+    /** The load-bearing fact: the engine rows are not governed by the toggle. Always stated. */
+    @Test
+    fun `the ungated engine rows are named in every state`() {
+        for (card in listOf(true, false)) {
+            for (rows in listOf(0, 7)) {
+                val line = AndroidDiagnostics.autoDetectStateLine(card, rows, 0)
+                assertTrue("state card=$card rows=$rows must name the ungated derivation",
+                           line.contains("not gated by that toggle"))
+            }
+        }
+    }
+
+    @Test
+    fun `the counts are reported`() {
+        val line = AndroidDiagnostics.autoDetectStateLine(true, storedDetectedRows = 41, dismissedMarkers = 5)
+        assertTrue(line.contains("suggestion card=on"))
+        assertTrue(line.contains("stored detected=41"))
+        assertTrue(line.contains("dismissed markers=5"))
+    }
+
+    /**
+     * A failed dismissal query must not render as zero. "dismissed markers=0" reads as "your dismissals
+     * are not sticking" and would send a reader after the #107 mechanism for a problem that is a failed
+     * read, which is the exact class of wrong-attribution CLAUDE.md warns about.
+     */
+    @Test
+    fun `an unavailable dismissal count is not reported as zero`() {
+        val unknown = AndroidDiagnostics.autoDetectStateLine(false, 3, dismissedMarkers = null)
+        assertTrue(unknown.contains("dismissed markers=n/a"))
+        assertFalse(unknown.contains("dismissed markers=0"))
+        // A real zero still reads as zero.
+        assertTrue(AndroidDiagnostics.autoDetectStateLine(false, 3, 0).contains("dismissed markers=0"))
+    }
+
+    /** House style for these lines: no em-dashes. */
+    @Test
+    fun `the line carries no em-dash`() {
+        assertFalse(AndroidDiagnostics.autoDetectStateLine(false, 12, 3).contains("—"))
+    }
+}

--- a/android/app/src/test/java/com/noop/testcentre/PipelineFreshnessLinesTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/PipelineFreshnessLinesTest.kt
@@ -1,0 +1,97 @@
+package com.noop.testcentre
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1735's second half: "hours after the ride it still is not there". Answering that needs to separate a
+ * Health Connect import that never ran from one that ran and brought nothing, and a scoring pass that
+ * never happened from one that happened and changed nothing. These lines exist for those four states, so
+ * the tests assert that all four stay distinguishable.
+ */
+class PipelineFreshnessLinesTest {
+
+    // ---- hcImportLine -------------------------------------------------------------------------
+
+    /**
+     * The state a static row count cannot express, and the reason the empty path is stamped at all: the
+     * import RAN and found nothing. If this rendered like "never", the log would say the same thing about
+     * an install that has never connected Health Connect and one whose import is running fine and simply
+     * has nothing new - which is the whole distinction being bought here.
+     */
+    @Test
+    fun `ran and found nothing is not the same as never ran`() {
+        val ranEmpty = AndroidDiagnostics.hcImportLine(ago = "12m ago", rows = 0, throughDay = null)
+        val never = AndroidDiagnostics.hcImportLine(ago = null, rows = 0, throughDay = null)
+        assertTrue(ranEmpty.contains("0 row(s) 12m ago"))
+        assertTrue(never.contains("never completed"))
+        assertFalse("a completed empty import must not read as never", ranEmpty.contains("never"))
+    }
+
+    @Test
+    fun `a productive import reports rows and how far it reached`() {
+        val line = AndroidDiagnostics.hcImportLine(ago = "3m ago", rows = 41, throughDay = "2026-08-30")
+        assertTrue(line.contains("41 row(s) 3m ago"))
+        assertTrue(line.contains("through 2026-08-30"))
+    }
+
+    /** No day recorded must not render a dangling separator or an empty "through". */
+    @Test
+    fun `a missing through-day leaves no dangling clause`() {
+        val line = AndroidDiagnostics.hcImportLine(ago = "3m ago", rows = 41, throughDay = null)
+        assertFalse(line.contains("through"))
+        assertFalse(line.trimEnd().endsWith("·"))
+    }
+
+    /**
+     * "never" must not be phrased as a fault. Plenty of installs never connect Health Connect, and a line
+     * that reads like a problem sends a reader chasing one that does not exist.
+     */
+    @Test
+    fun `never is stated plainly rather than as a failure`() {
+        val never = AndroidDiagnostics.hcImportLine(null, 0, null)
+        assertFalse(never.contains("FAIL"))
+        assertFalse(never.contains("⚠"))
+        assertTrue(never.contains("on this install"))
+    }
+
+    // ---- scoringPassLine ----------------------------------------------------------------------
+
+    @Test
+    fun `a completed pass and no pass are distinguishable`() {
+        assertTrue(AndroidDiagnostics.scoringPassLine("8m ago").contains("last pass 8m ago"))
+        assertTrue(AndroidDiagnostics.scoringPassLine(null).contains("no pass has completed"))
+        assertFalse(AndroidDiagnostics.scoringPassLine("8m ago").contains("no pass"))
+    }
+
+    // ---- shared shape -------------------------------------------------------------------------
+
+    /**
+     * Both join the "Data write:" / "Timezone:" / "Last restore:" block, whose labels are padded so the
+     * VALUES start at a common column. Asserted exactly (content begins at index 13, matching that block)
+     * rather than "somewhere to the right", which a mis-padded line would also satisfy.
+     */
+    @Test
+    fun `the values start at the same column as the block they join`() {
+        val lines = listOf(
+            AndroidDiagnostics.hcImportLine("1m ago", 1, null),
+            AndroidDiagnostics.hcImportLine(null, 0, null),
+            AndroidDiagnostics.scoringPassLine("1m ago"),
+            AndroidDiagnostics.scoringPassLine(null),
+        )
+        for (line in lines) {
+            val afterColon = line.indexOf(':') + 1
+            val valueStart = afterColon + line.drop(afterColon).indexOfFirst { it != ' ' }
+            assertEquals("'$line' must start its value at column 13", 13, valueStart)
+        }
+    }
+
+    /** House style for these lines: no em-dashes. */
+    @Test
+    fun `the lines carry no em-dash`() {
+        assertFalse(AndroidDiagnostics.hcImportLine("1m ago", 1, "2026-08-30").contains("—"))
+        assertFalse(AndroidDiagnostics.scoringPassLine(null).contains("—"))
+    }
+}


### PR DESCRIPTION
Diagnostics for the report in #1735, which is not answerable from the log it arrived with.

**Which detector made the rows.** NOOP has two, deliberately separate per `AutoWorkoutDetector`'s own header. The Settings toggle governs the opt-in SUGGESTION card, which saves nothing until the user taps Save. The IntelligenceEngine separately derives durable `sport="detected"` rows from the 1 Hz store on every scoring pass, and never consulted that toggle. Both are called "detect" in the UI, so rows from the second read as the first ignoring its own switch - which is exactly the reading #1735 made, and a reasonable one.

Every per-bout line that shows the difference sits behind the Test Centre WORKOUTS domain. That report was filed as "not a test-mode bug" with the domain off, so its log said nothing about workout detection at all. The line added here is always-on and sits in the section a reporter already attaches. It states what is on disk rather than what the code intends: the card's setting, the count of stored detected rows, and the count of #107 dismissal markers. The reassurance clause is emitted ONLY for the combination that actually misleads - card off with rows present - so it never explains a state it is not looking at.

**When the pipelines last ran.** The other half of that report - "hours after the ride finished it still does not appear" - needed two timestamps nobody recorded. The strap-WRITE path has had this for a while (`sync.lastWriteOkAt` renders as "Data write: rows last landed 3d ago", which is what makes a stalled offload decidable). The two paths #1735 turns on had no equivalent: the Health Connect importer persisted only a permission signature, and the engine's completion is announced by `re-score: done`, which goes to the LIVE log only, so an export written hours later has already rolled it away. The analyze watermark records WHAT was scored and never when.

So a report could show per-source row counts and still not separate "Health Connect never brought the ride in" from "it did, and nothing has re-scored since". Those need opposite next steps.

Three details that decide whether these lines are worth anything:

- The importer stamps its EMPTY path too. "Ran and found nothing" and "never ran" are different diagnoses and a row count of zero cannot tell them apart.
- Scoring is stamped at BOTH completion sites - the idle pass and the post-sync pass - because the post-sync one is the pass a "synced but nothing appeared" report is really asking about.
- The dismissal count is summed over the SAME strap ids whose rows were counted. A two-strap install banks detected rows under both `<active>-noop` and `my-whoop-noop`, so reading the active strap alone could print `detected=52 dismissed=0` while the dismissals sat under the other id. A FAILED read renders `n/a`, never 0, for the same reason.

"Never" is stated plainly rather than as a fault: plenty of installs never connect Health Connect, and a line reading like a problem sends a reader chasing one that is not there.

**Deliberately NOT included:** a gate making the toggle suppress the engine's rows. The two detectors are separate by design, the toggle defaults OFF, and the delete at the persistence site is unconditional and precedes the insert - so gating the insert would wipe the Activity history of every user who never opted in, on the first pass after upgrade. That is a data wipe shipped as a bug fix. The confirmed defects in #1735 are the false code doc at `MainActivity.kt:1060` ("when off no detection runs") and the toggle's name; neither is touched here.

No behaviour change beyond four SharedPreferences writes. 12 tests; the column alignment is mutation-verified (shifting the padding by one space fails it). Apple twin NOT added - iOS has the same two detectors and the same live-log-only scoring announcement.

Verified: 4819 unit tests green, doc-comment lint clean, i18n audit clean.
