### PR TITLE
fix(sleep): make debt an actionable next-night target

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepDebt.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepDebt.swift
@@ -1,17 +1,16 @@
 import Foundation
 
-// SleepDebt.swift — a rolling sleep-debt ledger over the last N nights.
+// SleepDebt.swift — a recency-weighted sleep-debt estimate over the last N nights.
 //
 // Pure, deterministic, DB-free. Given a chronological series of per-night total
 // sleep (minutes) and a personal sleep need (hours), it accumulates a running
-// balance of (actual − need) per night across a capped trailing window (14 nights
-// by default) and reports the net balance plus the per-night deltas that make it
-// up.
+// debt estimate across a capped trailing window (14 nights by default). The
+// previous estimate is part of the following night's need; 55% of any unmet need
+// carries forward. Tiny, non-actionable results below ten minutes are cleared.
 //
 // HONEST by construction:
-//   - It is a plain debt accumulator — sum of nightly (slept − need) — NOT a
-//     physiological model. A surplus night (slept > need) genuinely offsets a
-//     deficit one, the same way a checking balance nets credits and debits.
+//   - It is a planning estimate, not a physiological claim. Meeting base need plus
+//     the current estimate clears the debt; extra sleep never creates a surplus.
 //   - The window is capped (default 14) so "debt" never compounds indefinitely
 //     across months of history — only the recent fortnight is in scope.
 //   - Nights with no usable sleep total are SKIPPED entirely (no zero-fill), so a
@@ -38,10 +37,10 @@ public struct SleepDebtNight: Equatable, Sendable {
     }
 }
 
-/// The rolling sleep-debt ledger over the capped trailing window.
+/// The sleep-debt estimate over the capped trailing window.
 public struct SleepDebtLedger: Equatable, Sendable {
-    /// Net running balance (minutes) across the window: Σ(slept − need). Negative =
-    /// net DEBT (under-slept overall), positive = net SURPLUS, 0 = on target.
+    /// Current estimate in the existing signed UI convention: negative = debt,
+    /// zero = on target. This model never reports a positive surplus.
     public let balanceMin: Double
     /// Per-night contributions, oldest → newest, one per counted night (skipped
     /// nights are absent). The `deltaMin` values are the per-night bar/spark.
@@ -67,9 +66,15 @@ public enum SleepDebt {
     /// short enough that one rough patch doesn't read as months of compounding debt.
     public static let defaultWindowNights: Int = 14
 
+    /// Share of the complete unmet need carried into the following night.
+    public static let debtCarryFactor: Double = 0.55
+
+    /// Calculated debts smaller than this are too small to be actionable.
+    public static let minimumDebtMin: Double = 10.0
+
     /// "On target" deadband (minutes): a |balance| under this reads as balanced rather
     /// than as a debt/surplus, so a few stray minutes don't flip the headline.
-    public static let onTargetBandMin: Double = 30.0
+    public static let onTargetBandMin: Double = minimumDebtMin
 
     /// Sleep credited toward debt for one day. `mainSleepMin` remains the canonical
     /// main-night total used by Rest and the sleep headline; separately-recorded naps
@@ -82,6 +87,41 @@ public enum SleepDebt {
     public static func creditedSleepMin(mainSleepMin: Double?, napSleepMin: Double = 0) -> Double? {
         guard let mainSleepMin, mainSleepMin > 0 else { return nil }
         return mainSleepMin + max(napSleepMin, 0)
+    }
+
+    /// Debt values oldest → newest for local fallback surfaces. The returned history is
+    /// not capped: each usable day's local value is independently recomputed from the
+    /// trailing `window` usable nights. An imported value wins verbatim for that day's
+    /// output only; it never seeds or replaces the local recurrence. Imported-only rows
+    /// are emitted but do not consume a usable-night slot. Rows with neither usable sleep
+    /// nor an imported value have no debt observation and are omitted.
+    public static func debtSeries(
+        series: [(day: String, totalSleepMin: Double?)],
+        needHours: Double = AnalyticsEngine.Rest.defaultNeedHours,
+        importedDebtMin: [String: Double] = [:],
+        window: Int = defaultWindowNights
+    ) -> [(day: String, value: Double)] {
+        let cap = max(window, 1)
+        var usableHistory: [(day: String, totalSleepMin: Double?)] = []
+        usableHistory.reserveCapacity(cap)
+        var result: [(day: String, value: Double)] = []
+        result.reserveCapacity(series.count)
+
+        for row in series {
+            let sleptMin = row.totalSleepMin.flatMap { $0 > 0 ? $0 : nil }
+            if let sleptMin {
+                usableHistory.append((row.day, sleptMin))
+                if usableHistory.count > cap { usableHistory.removeFirst() }
+            }
+
+            if let imported = importedDebtMin[row.day] {
+                result.append((row.day, imported))
+            } else if sleptMin != nil {
+                let debt = ledger(series: usableHistory, needHours: needHours, window: cap).magnitudeMin
+                result.append((row.day, debt))
+            }
+        }
+        return result
     }
 
     /// Build the ledger from a chronological `[(day, totalSleepMin?)]` series.
@@ -97,9 +137,9 @@ public enum SleepDebt {
     ///   - window: how many of the most-recent COUNTED nights to include. Defaults to
     ///     `defaultWindowNights` (14). Clamped to ≥ 1.
     ///
-    /// The balance is Σ over the window of (sleptMin − needMin): a surplus night
-    /// offsets a deficit one. Returns an empty ledger (balance 0, no nights) when no
-    /// night has usable data.
+    /// For each retained night, `nextDebt = 0.55 × max(0, need + debt − slept)`.
+    /// Results below ten minutes clear to zero. `SleepDebtNight.deltaMin` deliberately
+    /// remains the raw `slept − base need` value used by the per-night bars.
     public static func ledger(series: [(day: String, totalSleepMin: Double?)],
                               needHours: Double = AnalyticsEngine.Rest.defaultNeedHours,
                               window: Int = defaultWindowNights) -> SleepDebtLedger {
@@ -113,14 +153,15 @@ public enum SleepDebt {
 
         var nights: [SleepDebtNight] = []
         nights.reserveCapacity(windowed.count)
-        var balance = 0.0
+        var debt = 0.0
         for row in windowed {
             let slept = row.totalSleepMin ?? 0
             let delta = slept - needMin
-            balance += delta
+            let calculatedDebt = debtCarryFactor * max(0, needMin + debt - slept)
+            debt = calculatedDebt < minimumDebtMin ? 0 : calculatedDebt
             nights.append(SleepDebtNight(day: row.day, sleptMin: slept, deltaMin: delta))
         }
-        return SleepDebtLedger(balanceMin: round1(balance), nights: nights, needMin: needMin)
+        return SleepDebtLedger(balanceMin: round1(-debt), nights: nights, needMin: needMin)
     }
 
     /// Round to 1 decimal place (the ledger is reported in whole/near-whole minutes;

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepDebtTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepDebtTests.swift
@@ -15,19 +15,18 @@ final class SleepDebtTests: XCTestCase {
         XCTAssertEqual(l.needMin, 480.0, accuracy: 1e-9)
     }
 
-    /// A surplus night offsets a deficit one (ledger nets credits and debits).
-    func testSurplusOffsetsDeficit() {
+    /// Debt carries forward as part of the following night's need; a night that meets
+    /// that complete need clears it instead of producing a positive surplus.
+    func testDebtRecursAndMeetingNeedClearsIt() {
         let series: [(day: String, totalSleepMin: Double?)] = [
             ("2026-06-01", 360),   // −120
-            ("2026-06-02", 540),   // +60
-            ("2026-06-03", 420),   // −60
+            ("2026-06-02", 546),   // base 480 + prior debt 66
+            ("2026-06-03", 540),   // raw bar remains +60
         ]
-        // need 8 h = 480. Σ = −120 + 60 − 60 = −120.
         let l = SleepDebt.ledger(series: series, needHours: 8.0)
-        XCTAssertEqual(l.balanceMin, -120.0, accuracy: 1e-9)
-        XCTAssertTrue(l.isDebt)
-        XCTAssertEqual(l.magnitudeMin, 120.0, accuracy: 1e-9)
-        XCTAssertEqual(l.nights.map { $0.deltaMin }, [-120, 60, -60])
+        XCTAssertEqual(l.balanceMin, 0.0, accuracy: 1e-9)
+        XCTAssertFalse(l.isDebt)
+        XCTAssertEqual(l.nights.map { $0.deltaMin }, [-120, 66, 60])
     }
 
     /// Nights with no usable sleep are skipped entirely (never zero-filled as debt).
@@ -40,19 +39,20 @@ final class SleepDebtTests: XCTestCase {
         ]
         let l = SleepDebt.ledger(series: series, needHours: 8.0)
         XCTAssertEqual(l.nightCount, 2)
-        XCTAssertEqual(l.balanceMin, -60.0, accuracy: 1e-9)
+        XCTAssertEqual(l.balanceMin, -33.0, accuracy: 1e-9)
         XCTAssertEqual(l.nights.map { $0.day }, ["2026-06-01", "2026-06-04"])
     }
 
     /// Only the most-recent `window` COUNTED nights are in scope.
     func testWindowCapKeepsMostRecent() {
-        // 16 nights, each 60 min UNDER need → each delta −60.
+        // 16 nights, each 60 min UNDER base need. The recurrence is computed only
+        // across the retained 14 counted nights, preserving the existing window.
         let series: [(day: String, totalSleepMin: Double?)] = (1...16).map {
             (String(format: "2026-06-%02d", $0), Double(420))
         }
         let l = SleepDebt.ledger(series: series, needHours: 8.0, window: 14)
         XCTAssertEqual(l.nightCount, 14)               // capped
-        XCTAssertEqual(l.balanceMin, -840.0, accuracy: 1e-9)   // 14 × −60
+        XCTAssertEqual(l.balanceMin, -73.3, accuracy: 1e-9)
         XCTAssertEqual(l.nights.first?.day, "2026-06-03")      // oldest kept
         XCTAssertEqual(l.nights.last?.day, "2026-06-16")       // newest kept
     }
@@ -72,7 +72,7 @@ final class SleepDebtTests: XCTestCase {
     func testDefaultNeedIsEightHours() {
         let l = SleepDebt.ledger(series: [("2026-06-01", 420)])
         XCTAssertEqual(l.needMin, AnalyticsEngine.Rest.defaultNeedHours * 60.0, accuracy: 1e-9)
-        XCTAssertEqual(l.balanceMin, -60.0, accuracy: 1e-9)
+        XCTAssertEqual(l.balanceMin, -33.0, accuracy: 1e-9)
     }
 
     /// Main sleep remains the canonical nightly figure, while a separately-recorded nap
@@ -81,7 +81,7 @@ final class SleepDebtTests: XCTestCase {
         let credited = try XCTUnwrap(SleepDebt.creditedSleepMin(mainSleepMin: 392, napSleepMin: 48))
         XCTAssertEqual(credited, 440, accuracy: 1e-9)
         let l = SleepDebt.ledger(series: [("2026-06-01", credited)], needHours: 8.0)
-        XCTAssertEqual(l.balanceMin, -40, accuracy: 1e-9)
+        XCTAssertEqual(l.balanceMin, -22, accuracy: 1e-9)
     }
 
     func testNapCreditRequiresMainSleepAndIgnoresNegativeNapMinutes() {
@@ -90,20 +90,82 @@ final class SleepDebtTests: XCTestCase {
         XCTAssertEqual(SleepDebt.creditedSleepMin(mainSleepMin: 392, napSleepMin: -10), 392.0)
     }
 
-    /// A NEGATIVE EXACT half-tie balance rounds AWAY from zero (−0.05 → −0.1), the documented
-    /// `round1` contract the Kotlin mirror must match (audit #6). needMin = 0.1, slept 0.05 →
-    /// delta −0.05 exactly → balance −0.1. Kotlin's old `roundToInt()` (half toward +∞) gave
-    /// 0.0 on this exact tie — the real divergence this pins shut.
-    func testNegativeHalfTieRoundsAwayFromZero() {
-        let l = SleepDebt.ledger(series: [("2026-06-01", 0.05)], needHours: 0.1 / 60.0)
-        XCTAssertEqual(l.balanceMin, -0.1, accuracy: 1e-9)   // away-from-zero, not 0.0
+    func testDebtBelowTenMinutesClearsButExactlyTenRemains() {
+        XCTAssertEqual(SleepDebt.onTargetBandMin, 10, accuracy: 1e-9)
+        // 18 min shortfall × 0.55 = 9.9 min -> cleared.
+        XCTAssertEqual(
+            SleepDebt.ledger(series: [("2026-06-01", 462)], needHours: 8).balanceMin,
+            0,
+            accuracy: 1e-9)
+        // A deliberately exact 10 min calculated debt remains debt.
+        let slept = 480.0 - (10.0 / 0.55)
+        XCTAssertEqual(
+            SleepDebt.ledger(series: [("2026-06-01", slept)], needHours: 8).balanceMin,
+            -10,
+            accuracy: 1e-9)
     }
 
-    /// The symmetric POSITIVE exact half-tie (+0.05 → +0.1), pinned so the sign-aware Kotlin
-    /// rounding can't silently regress one direction. needMin = 0, slept 0.05 → delta +0.05.
-    func testPositiveHalfTieRoundsAwayFromZero() {
-        let l = SleepDebt.ledger(series: [("2026-06-01", 0.05)], needHours: 0.0)
-        XCTAssertEqual(l.balanceMin, 0.1, accuracy: 1e-9)
+    func testSurplusNeverCreatesPositiveBalanceAndRawBarsStayUnchanged() {
+        let l = SleepDebt.ledger(series: [
+            ("2026-06-01", 600),
+            ("2026-06-02", 420),
+        ], needHours: 8)
+        XCTAssertEqual(l.balanceMin, -33, accuracy: 1e-9)
+        XCTAssertEqual(l.nights.map(\.deltaMin), [120, -60])
+    }
+
+    func testImportedDebtIsVerbatimButDoesNotSeedFollowingFallback() {
+        let values = SleepDebt.debtSeries(
+            series: [("2026-06-01", 420), ("2026-06-02", 480)],
+            needHours: 8,
+            importedDebtMin: ["2026-06-01": 61.25])
+        XCTAssertEqual(values[0].value, 61.25, accuracy: 1e-9)
+        XCTAssertEqual(values[1].value, 18.2, accuracy: 1e-9)
+    }
+
+    func testDebtSeriesRoundsLocalOutputsToLedgerPrecision() {
+        let input: [(day: String, totalSleepMin: Double?)] = [
+            ("2026-06-01", 420), ("2026-06-02", 410),
+        ]
+        let values = SleepDebt.debtSeries(series: input, needHours: 8)
+        let ledger = SleepDebt.ledger(series: input, needHours: 8)
+        XCTAssertEqual(values.last?.value ?? -1, 56.7, accuracy: 1e-9)
+        XCTAssertEqual(values.last?.value ?? -1, ledger.magnitudeMin, accuracy: 1e-9)
+    }
+
+    func testImportedOnlyGapDoesNotConsumeOneOfFourteenUsableNights() {
+        let usable: [(day: String, totalSleepMin: Double?)] = (1...14).map {
+            (String(format: "2026-06-%02d", $0), 420)
+        }
+        let input = Array(usable.prefix(13))
+            + [(day: "2026-06-14-imported-only", totalSleepMin: nil)]
+            + Array(usable.suffix(1))
+        let values = SleepDebt.debtSeries(
+            series: input,
+            needHours: 8,
+            importedDebtMin: ["2026-06-14-imported-only": 91.25])
+
+        XCTAssertEqual(values.count, 15)
+        XCTAssertEqual(values[13].value, 91.25, accuracy: 1e-9)
+        XCTAssertEqual(values.last?.value ?? -1,
+                       SleepDebt.ledger(series: usable, needHours: 8, window: 14).magnitudeMin,
+                       accuracy: 1e-9)
+    }
+
+    func testDebtSeriesKeepsFullHistoryWithPerDayTrailingLedgerParity() {
+        let input: [(day: String, totalSleepMin: Double?)] = (1...16).map {
+            (String(format: "2026-06-%02d", $0), 390 + Double($0))
+        }
+        let values = SleepDebt.debtSeries(series: input, needHours: 8, window: 14)
+
+        XCTAssertEqual(values.count, 16)
+        for index in values.indices {
+            let expected = SleepDebt.ledger(
+                series: Array(input.prefix(index + 1)), needHours: 8, window: 14).magnitudeMin
+            XCTAssertEqual(values[index].day, input[index].day)
+            XCTAssertEqual(values[index].value, expected, accuracy: 1e-9,
+                           "per-day parity at \(values[index].day)")
+        }
     }
 
     /// round1 is exercised on the directly-constructed value too, so the rounding mode is

--- a/Strand/Screens/NightDetailCard.swift
+++ b/Strand/Screens/NightDetailCard.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import StrandAnalytics
 import StrandDesign
 import WhoopStore
 
@@ -40,8 +41,8 @@ struct NightDetailCard: View {
             StatTile(
                 label: "Sleep Debt",
                 value: debt.latest.map { durationText($0) } ?? "—",
-                caption: debtCaption(debt.latest),
-                accent: debtColor(debt.latest),
+                caption: nightDetailDebtCaption(debt.latest),
+                accent: nightDetailDebtColor(debt.latest),
                 sparkline: spark(debt.series),
                 sparkColor: StrandPalette.metricRose)
                 .frame(maxWidth: .infinity)
@@ -103,8 +104,8 @@ struct NightDetailCard: View {
                 StatTile(
                     label: "Sleep Debt",
                     value: debt.latest.map { durationText($0) } ?? "—",
-                    caption: debtCaption(debt.latest),
-                    accent: debtColor(debt.latest),
+                    caption: nightDetailDebtCaption(debt.latest),
+                    accent: nightDetailDebtColor(debt.latest),
                     sparkline: spark(debt.series),
                     sparkColor: StrandPalette.metricRose)
                 #endif
@@ -132,20 +133,6 @@ struct NightDetailCard: View {
         return String(localized: "\(sign)\(num)\(suffix) vs typical")
     }
 
-    private func debtCaption(_ debt: Double?) -> String {
-        guard let debt else { return String(localized: "vs need") }
-        return debt < 15 ? String(localized: "On target") : String(localized: "Below need")
-    }
-
-    private func debtColor(_ debt: Double?) -> Color {
-        guard let debt else { return StrandPalette.textPrimary }
-        switch debt {
-        case ..<15:  return StrandPalette.statusPositive
-        case ..<60:  return StrandPalette.statusWarning
-        default:     return StrandPalette.statusCritical
-        }
-    }
-
     /// A sparkline needs at least two points; otherwise return nil so the tile stays clean.
     private func spark(_ series: [Double]) -> [Double]? {
         let tail = Array(series.suffix(30))
@@ -158,5 +145,19 @@ struct NightDetailCard: View {
         let m = Swift.max(0, Int(minutes.rounded()))
         if m < 60 { return String(localized: "\(m)m") }
         return String(localized: "\(m / 60)h \(m % 60)m")
+    }
+}
+
+func nightDetailDebtCaption(_ debt: Double?) -> String {
+    guard let debt else { return String(localized: "vs need") }
+    return debt < SleepDebt.onTargetBandMin ? String(localized: "On target") : String(localized: "Below need")
+}
+
+func nightDetailDebtColor(_ debt: Double?) -> Color {
+    guard let debt else { return StrandPalette.textPrimary }
+    switch debt {
+    case ..<SleepDebt.onTargetBandMin: return StrandPalette.statusPositive
+    case ..<60: return StrandPalette.statusWarning
+    default: return StrandPalette.statusCritical
     }
 }

--- a/Strand/Screens/SleepDebtLedgerCard.swift
+++ b/Strand/Screens/SleepDebtLedgerCard.swift
@@ -7,14 +7,14 @@ import WhoopStore
 //
 // The Sleep tab's "Sleep-debt ledger" card, extracted into a standalone view so it can ALSO be hosted in
 // the Today tab. Both the Sleep tab and the Today host render THIS view from the SAME `SleepModel`, so the
-// rolling 14-night running balance can never diverge between the two surfaces (the parity contract). The
+// recency-weighted estimate can never diverge between the two surfaces (the parity contract). The
 // card body + its `debtDeltaBars` strip and the debt-only formatting helpers (`debtHeadline` /
 // `debtTag` / `debtRead` / `debtBalanceColor` / `debtSigned`) are a verbatim lift of the former
 // `SleepView.sleepDebtLedger` (and the helpers only it used); the nap-credited ledger is computed once in
 // `SleepModel.build` (the shared builder) and read here — it is NOT recomputed.
 
-/// The "Sleep-debt ledger" card. A running balance of (slept − personal need) across the recent
-/// fortnight — the net debt/surplus headline, a plain-English read, and a diverging per-night delta bar —
+/// The "Sleep-debt ledger" card. A recency-weighted estimate across the recent fortnight — the
+/// current debt headline, a plain-English read, and a diverging raw per-night delta bar —
 /// rendered from the shared [SleepModel]'s `sleepDebtLedger`. (#242)
 struct SleepDebtLedgerCard: View {
     let model: SleepModel
@@ -52,7 +52,8 @@ struct SleepDebtLedgerCard: View {
                             .font(StrandFont.subhead)
                             .foregroundStyle(StrandPalette.textSecondary)
                             .fixedSize(horizontal: false, vertical: true)
-                        // Per-night diverging delta bars (surplus up, deficit down).
+                        // Raw per-night delta bars (above/below base need), intentionally separate
+                        // from the recurrence's current debt estimate.
                         debtDeltaBars(ledger)
                         Divider().overlay(StrandPalette.hairline)
                         ChartFooter([
@@ -112,30 +113,30 @@ struct SleepDebtLedgerCard: View {
         return "≈\(durationText(m))"
     }
 
-    /// Short tag under/beside the headline: DEBT / SURPLUS / ON TARGET.
+    /// Short tag under/beside the headline: DEBT / ON TARGET.
     private func debtTag(_ ledger: SleepDebtLedger) -> String {
         if ledger.magnitudeMin < SleepDebt.onTargetBandMin { return String(localized: "balanced") }
-        return ledger.isDebt ? String(localized: "sleep debt") : String(localized: "surplus")
+        return ledger.isDebt ? String(localized: "sleep debt") : String(localized: "balanced")
     }
 
-    /// Plain-English read of the running balance over the window.
+    /// Plain-English read of the current actionable estimate.
     private func debtRead(_ ledger: SleepDebtLedger) -> String {
         let nights = ledger.nightCount
         let span = nights == 1
             ? String(localized: "the last night")
             : String(localized: "the last \(nights) nights")
         if ledger.magnitudeMin < SleepDebt.onTargetBandMin {
-            return String(localized: "You're roughly on top of your sleep across \(span). Slept minutes balance out against your need.")
+            return String(localized: "You've effectively met your current sleep need across \(span).")
         }
         let mag = durationText(ledger.magnitudeMin)
         if ledger.isDebt {
-            return String(localized: "You've banked about \(mag) of sleep debt over \(span). Surplus nights count back against it. An earlier night or two would clear it.")
+            return String(localized: "Add about \(mag) to your base sleep target tonight. Meeting that complete sleep need clears the displayed debt; recent shortfalls carry forward at a reduced weight.")
         }
-        return String(localized: "You're carrying about \(mag) of surplus over \(span). You've slept past your need on balance. Nicely ahead.")
+        return String(localized: "You've effectively met your current sleep need across \(span).")
     }
 
-    /// Color the balance by sign + size: surplus/within-band → positive green, modest
-    /// debt → warning, heavier debt → critical.
+    /// Color the balance by size: balanced → positive green, modest debt → warning,
+    /// heavier debt → critical.
     private func debtBalanceColor(_ ledger: SleepDebtLedger) -> Color {
         if ledger.magnitudeMin < SleepDebt.onTargetBandMin || !ledger.isDebt {
             return StrandPalette.statusPositive

--- a/Strand/Screens/SleepModel.swift
+++ b/Strand/Screens/SleepModel.swift
@@ -169,8 +169,8 @@ struct SleepModel {
 
     let trendPoints: [TrendPoint]
 
-    /// Rolling 14-night sleep-debt ledger: Σ(slept − personal need) across the recent
-    /// fortnight, with the per-night deltas behind it. Computed once per data change.
+    /// Recency-weighted sleep-debt estimate across the latest 14 usable nights, with
+    /// raw per-night deltas for context. Computed once per data change.
     let sleepDebtLedger: SleepDebtLedger
 }
 
@@ -443,19 +443,22 @@ extension SleepModel {
         metric(days: days) { $0.respRateBpm }
     }
 
-    /// Sleep debt (minutes): the imported sleep_debt_min when the export carried it; else the
-    /// APPROXIMATE per-night need − (main sleep + nap sleep), floored at 0.
+    /// Sleep debt (minutes): imported `sleep_debt_min` remains export-verbatim. Otherwise use
+    /// the same recency-weighted ledger as the card, including nap credit and its 14-night window.
     static func sleepDebtSeries(days: [DailyMetric], importedSleep: [String: ImportedSleepFigures],
                                 napSleepMinByDay: [String: Double]) -> Metric {
-        let imported = importedSleep
         let need = debtNeedMin(days: days)   // #242: normative need, not the self-referential mean
-        let series = days.compactMap { d -> Double? in
-            if let debt = imported[d.day]?.debtMin { return debt }   // minutes, export-verbatim
-            guard let asleep = SleepDebt.creditedSleepMin(
+        let credited = days.map { d in
+            (day: d.day, totalSleepMin: SleepDebt.creditedSleepMin(
                 mainSleepMin: d.totalSleepMin,
-                napSleepMin: napSleepMinByDay[d.day] ?? 0), need > 0 else { return nil }
-            return Swift.max(0, need - asleep)   // APPROXIMATE fallback
+                napSleepMin: napSleepMinByDay[d.day] ?? 0))
         }
+        let importedDebt = importedSleep.compactMapValues(\.debtMin)
+        let series = SleepDebt.debtSeries(
+            series: credited,
+            needHours: need / 60.0,
+            importedDebtMin: importedDebt
+        ).map(\.value)
         return (series.last, mean(series), series)
     }
 
@@ -469,10 +472,9 @@ extension SleepModel {
 
     // MARK: Sleep-debt ledger
 
-    /// The rolling 14-night sleep-debt ledger from the cached daily metrics. Measures against the
-    /// normative `debtNeedMin` (the engine's `personalizedNeedHours`) — the SAME need the per-night
-    /// "Sleep Debt" tile uses, so the running-balance card and the tile agree — over each main night's
-    /// `totalSleepMin` plus actual asleep minutes from separately-recorded naps. (#242)
+    /// The 14-night recency-weighted estimate from cached daily metrics. It measures against the
+    /// normative `debtNeedMin` (the engine's `personalizedNeedHours`) — the SAME need and recurrence
+    /// the local "Sleep Debt" tile uses — and credits actual asleep minutes from separate naps. (#242)
     static func debtLedger(days: [DailyMetric], napSleepMinByDay: [String: Double]) -> SleepDebtLedger {
         SleepDebt.ledger(
             series: days.map { day in

--- a/StrandTests/NightDetailDebtFormattingTests.swift
+++ b/StrandTests/NightDetailDebtFormattingTests.swift
@@ -1,18 +1,33 @@
 import XCTest
-import StrandDesign
+import SwiftUI
+@testable import StrandDesign
 @testable import Strand
 
 final class NightDetailDebtFormattingTests: XCTestCase {
     func testTenMinuteDebtBoundary() {
         XCTAssertEqual(nightDetailDebtCaption(9.9), String(localized: "On target"))
-        XCTAssertEqual(nightDetailDebtColor(9.9), StrandPalette.statusPositive)
+        assertSameResolvedColor(nightDetailDebtColor(9.9), StrandPalette.statusPositive)
 
         XCTAssertEqual(nightDetailDebtCaption(10.0), String(localized: "Below need"))
-        XCTAssertEqual(nightDetailDebtColor(10.0), StrandPalette.statusWarning)
+        assertSameResolvedColor(nightDetailDebtColor(10.0), StrandPalette.statusWarning)
     }
 
     func testImportedDebtAboveBoundaryRemainsDebt() {
         XCTAssertEqual(nightDetailDebtCaption(12.5), String(localized: "Below need"))
-        XCTAssertEqual(nightDetailDebtColor(12.5), StrandPalette.statusWarning)
+        assertSameResolvedColor(nightDetailDebtColor(12.5), StrandPalette.statusWarning)
+    }
+
+    private func assertSameResolvedColor(
+        _ actual: SwiftUI.Color,
+        _ expected: SwiftUI.Color,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let actualRGBA = actual.rgbaComponents
+        let expectedRGBA = expected.rgbaComponents
+        XCTAssertEqual(actualRGBA.r, expectedRGBA.r, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(actualRGBA.g, expectedRGBA.g, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(actualRGBA.b, expectedRGBA.b, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(actualRGBA.a, expectedRGBA.a, accuracy: 0.001, file: file, line: line)
     }
 }

--- a/StrandTests/NightDetailDebtFormattingTests.swift
+++ b/StrandTests/NightDetailDebtFormattingTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+import StrandDesign
+@testable import Strand
+
+final class NightDetailDebtFormattingTests: XCTestCase {
+    func testTenMinuteDebtBoundary() {
+        XCTAssertEqual(nightDetailDebtCaption(9.9), "On target")
+        XCTAssertEqual(nightDetailDebtColor(9.9), StrandPalette.statusPositive)
+
+        XCTAssertEqual(nightDetailDebtCaption(10.0), "Below need")
+        XCTAssertEqual(nightDetailDebtColor(10.0), StrandPalette.statusWarning)
+    }
+
+    func testImportedDebtAboveBoundaryRemainsDebt() {
+        XCTAssertEqual(nightDetailDebtCaption(12.5), "Below need")
+        XCTAssertEqual(nightDetailDebtColor(12.5), StrandPalette.statusWarning)
+    }
+}

--- a/StrandTests/NightDetailDebtFormattingTests.swift
+++ b/StrandTests/NightDetailDebtFormattingTests.swift
@@ -4,15 +4,15 @@ import StrandDesign
 
 final class NightDetailDebtFormattingTests: XCTestCase {
     func testTenMinuteDebtBoundary() {
-        XCTAssertEqual(nightDetailDebtCaption(9.9), "On target")
+        XCTAssertEqual(nightDetailDebtCaption(9.9), String(localized: "On target"))
         XCTAssertEqual(nightDetailDebtColor(9.9), StrandPalette.statusPositive)
 
-        XCTAssertEqual(nightDetailDebtCaption(10.0), "Below need")
+        XCTAssertEqual(nightDetailDebtCaption(10.0), String(localized: "Below need"))
         XCTAssertEqual(nightDetailDebtColor(10.0), StrandPalette.statusWarning)
     }
 
     func testImportedDebtAboveBoundaryRemainsDebt() {
-        XCTAssertEqual(nightDetailDebtCaption(12.5), "Below need")
+        XCTAssertEqual(nightDetailDebtCaption(12.5), String(localized: "Below need"))
         XCTAssertEqual(nightDetailDebtColor(12.5), StrandPalette.statusWarning)
     }
 }

--- a/StrandTests/SleepModelDebtTests.swift
+++ b/StrandTests/SleepModelDebtTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+import WhoopStore
+@testable import Strand
+
+final class SleepModelDebtTests: XCTestCase {
+    private func day(_ value: String, sleep: Double?) -> DailyMetric {
+        DailyMetric(day: value, totalSleepMin: sleep, efficiency: nil,
+                    deepMin: nil, remMin: nil, lightMin: nil, disturbances: nil,
+                    restingHr: nil, avgHrv: nil, recovery: nil, strain: nil,
+                    exerciseCount: nil, spo2Pct: nil, skinTempDevC: nil, respRateBpm: nil)
+    }
+
+    func testLocalFallbackLatestAgreesWithLedger() {
+        let days = [day("2026-06-01", sleep: 360), day("2026-06-02", sleep: 480)]
+        let metric = SleepModel.sleepDebtSeries(
+            days: days, importedSleep: [:], napSleepMinByDay: [:])
+        let ledger = SleepModel.debtLedger(days: days, napSleepMinByDay: [:])
+        XCTAssertEqual(metric.latest ?? -1, ledger.magnitudeMin, accuracy: 1e-9)
+    }
+
+    func testImportedWhoopDebtRemainsVerbatim() {
+        let days = [day("2026-06-01", sleep: 480)]
+        let imported = ["2026-06-01": ImportedSleepFigures(
+            performancePct: nil, consistencyPct: nil, needMin: nil, debtMin: 17.25)]
+        let metric = SleepModel.sleepDebtSeries(
+            days: days, importedSleep: imported, napSleepMinByDay: [:])
+        XCTAssertEqual(metric.latest ?? -1, 17.25, accuracy: 1e-9)
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/SleepDebt.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepDebt.kt
@@ -5,21 +5,20 @@ import kotlin.math.ceil
 import kotlin.math.floor
 
 /*
- * SleepDebt.kt — a rolling sleep-debt ledger over the last N nights.
+ * SleepDebt.kt — an actionable next-night sleep-debt estimate over the last N nights.
  *
  * Faithful Kotlin mirror of StrandAnalytics/SleepDebt.swift. Keep the window cap,
- * the skip-no-data rule, and the Σ(slept − need) accumulation byte-identical to
+ * the skip-no-data rule, and the debt recurrence byte-identical to
  * Swift — the two clients must report the same balance for the same nights.
  *
  * Pure, deterministic, DB-free. Given a chronological series of per-night total
  * sleep (minutes) and a personal sleep need (hours), it accumulates a running
- * balance of (actual − need) per night across a capped trailing window (14 nights
- * by default) and reports the net balance plus the per-night deltas behind it.
+ * debt from unmet current need across a capped trailing window (14 nights by
+ * default) and reports that debt plus the raw per-night deltas behind it.
  *
  * HONEST by construction:
- *   - A plain debt accumulator — sum of nightly (slept − need) — NOT a physiological
- *     model. A surplus night genuinely offsets a deficit one, like a balance nets
- *     credits and debits.
+ *   - Debt is 55% of the current unmet need. Meeting need (including carried debt)
+ *     clears it; extra sleep never creates a positive bank.
  *   - The window is capped (default 14) so debt never compounds across months of
  *     history — only the recent fortnight is in scope.
  *   - Nights with no usable sleep total are SKIPPED (no zero-fill), so a gap in wear
@@ -48,7 +47,7 @@ data class SleepDebtNight(
  * `SleepDebtLedger`.
  */
 data class SleepDebtLedger(
-    /** Net running balance (minutes): Σ(slept − need). Negative = net DEBT, positive = net SURPLUS. */
+    /** Current debt as a negative balance in minutes; never positive. */
     val balanceMin: Double,
     /** Per-night contributions, oldest → newest (skipped nights absent); the per-night bar/spark. */
     val nights: List<SleepDebtNight>,
@@ -74,10 +73,12 @@ object SleepDebt {
     const val DEFAULT_WINDOW_NIGHTS: Int = 14
 
     /**
-     * "On target" deadband (minutes): a |balance| under this reads as balanced rather than
-     * a debt/surplus, so a few stray minutes don't flip the headline.
+     * Calculated debts below this threshold are treated as balanced. Exactly ten minutes remains debt.
      */
-    const val ON_TARGET_BAND_MIN: Double = 30.0
+    const val ON_TARGET_BAND_MIN: Double = 10.0
+
+    /** Fraction of current unmet need carried into the next night's target. */
+    const val DEBT_CARRY: Double = 0.55
 
     /**
      * Sleep credited toward debt for one day. [mainSleepMin] remains the canonical
@@ -95,6 +96,34 @@ object SleepDebt {
     }
 
     /**
+     * Debt values oldest → newest for local fallback surfaces. An imported value wins verbatim
+     * for its day's output, while the independent local recurrence continues from credited sleep.
+     */
+    fun debtSeries(
+        series: List<Pair<String, Double?>>,
+        needHours: Double = RestScorer.defaultSleepNeedHours,
+        importedDebtMin: Map<String, Double> = emptyMap(),
+        window: Int = DEFAULT_WINDOW_NIGHTS,
+    ): List<Pair<String, Double>> {
+        val cap = window.coerceAtLeast(1)
+        val usableHistory = ArrayList<Pair<String, Double?>>(cap)
+        val result = ArrayList<Pair<String, Double>>(series.size)
+        for ((day, slept) in series) {
+            val imported = importedDebtMin[day]
+            val sleptMin = slept?.takeIf { it > 0.0 }
+            if (sleptMin != null) {
+                usableHistory.add(day to sleptMin)
+                if (usableHistory.size > cap) usableHistory.removeAt(0)
+            }
+            if (imported != null) result.add(day to imported)
+            else if (sleptMin != null) {
+                result.add(day to ledger(usableHistory, needHours = needHours, window = cap).magnitudeMin)
+            }
+        }
+        return result
+    }
+
+    /**
      * Build the ledger from a chronological `List<Pair<day, totalSleepMin?>>` series.
      *
      * @param series per-night `(day, totalSleepMin)` rows in CHRONOLOGICAL order
@@ -105,8 +134,8 @@ object SleepDebt {
      * @param window how many of the most-recent COUNTED nights to include. Defaults to
      *   [DEFAULT_WINDOW_NIGHTS] (14). Clamped to ≥ 1.
      *
-     * The balance is Σ over the window of (sleptMin − needMin): a surplus night offsets a
-     * deficit one. Returns an empty ledger (balance 0, no nights) when no night has data.
+     * Each night applies `nextDebt = 0.55 * max(0, need + currentDebt - slept)`.
+     * Calculated debt below ten minutes is cleared. Returns an empty ledger when no night has data.
      */
     fun ledger(
         series: List<Pair<String, Double?>>,
@@ -122,14 +151,19 @@ object SleepDebt {
         val windowed = usable.takeLast(cap)
 
         val nights = ArrayList<SleepDebtNight>(windowed.size)
-        var balance = 0.0
+        var debt = 0.0
         for ((day, slept) in windowed) {
             val sleptMin = slept ?: 0.0
             val delta = sleptMin - needMin
-            balance += delta
+            debt = nextDebt(needMin, debt, sleptMin)
             nights.add(SleepDebtNight(day = day, sleptMin = sleptMin, deltaMin = delta))
         }
-        return SleepDebtLedger(balanceMin = round1(balance), nights = nights, needMin = needMin)
+        return SleepDebtLedger(balanceMin = -round1(debt), nights = nights, needMin = needMin)
+    }
+
+    private fun nextDebt(needMin: Double, currentDebt: Double, sleptMin: Double): Double {
+        val calculatedDebt = DEBT_CARRY * (needMin + currentDebt - sleptMin).coerceAtLeast(0.0)
+        return if (calculatedDebt < ON_TARGET_BAND_MIN) 0.0 else calculatedDebt
     }
 
     /**

--- a/android/app/src/main/java/com/noop/ui/SleepFormatting.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepFormatting.kt
@@ -26,12 +26,12 @@ internal fun vsTypical(latest: Double?, typical: Double?, suffix: String, decima
 
 internal fun debtCaption(debt: Double?): String {
     if (debt == null) return "vs need"
-    return if (debt < 15.0) "On target" else "Below need"
+    return if (debt < SleepDebt.ON_TARGET_BAND_MIN) "On target" else "Below need"
 }
 
 internal fun debtColor(debt: Double?): Color = when {
     debt == null -> Palette.textPrimary
-    debt < 15.0 -> Palette.statusPositive
+    debt < SleepDebt.ON_TARGET_BAND_MIN -> Palette.statusPositive
     debt < 60.0 -> Palette.statusWarning
     else -> Palette.statusCritical
 }
@@ -46,30 +46,30 @@ internal fun debtHeadline(ledger: SleepDebtLedger): String =
     if (ledger.magnitudeMin < SleepDebt.ON_TARGET_BAND_MIN) "On target"
     else "≈${durationText(ledger.magnitudeMin)}"
 
-/** Short tag beside the headline: sleep debt / surplus / balanced. */
+/** Short tag beside the headline: the recurrence never creates a positive surplus. */
 internal fun debtTag(ledger: SleepDebtLedger): String = when {
     ledger.magnitudeMin < SleepDebt.ON_TARGET_BAND_MIN -> "balanced"
     ledger.isDebt -> "sleep debt"
-    else -> "surplus"
+    else -> "balanced"
 }
 
-/** Plain-English read of the running balance over the window. */
+/** Plain-English read of the actionable addition to the next night's target. */
 internal fun debtRead(ledger: SleepDebtLedger): String {
     val nights = ledger.nightCount
     val span = "the last $nights night${if (nights == 1) "" else "s"}"
     if (ledger.magnitudeMin < SleepDebt.ON_TARGET_BAND_MIN) {
-        return "You're roughly on top of your sleep across $span. Slept minutes balance out against your need."
+        return "You've met your current sleep target across $span. No extra debt needs carrying into tonight."
     }
     val mag = durationText(ledger.magnitudeMin)
     return if (ledger.isDebt) {
-        "You've banked about $mag of sleep debt over $span. Surplus nights count back against it. An earlier night or two would clear it."
+        "Aim for about $mag beyond your base need tonight. Meeting that target clears the displayed sleep debt."
     } else {
         "You're carrying about $mag of surplus over $span. You've slept past your need on balance. Nicely ahead."
     }
 }
 
 /**
- * Color the balance by sign + size: surplus/within-band → positive green, modest debt →
+ * Color the balance by size: within-band → positive green, modest debt →
  * warning, heavier debt → critical.
  */
 internal fun debtBalanceColor(ledger: SleepDebtLedger): Color = when {

--- a/android/app/src/main/java/com/noop/ui/SleepMetricCardsUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepMetricCardsUi.kt
@@ -157,13 +157,12 @@ private fun MetricGrid(m: SleepModel, onMetricClick: (String) -> Unit = {}) {
     }
 }
 
-// MARK: - 2b. Sleep-debt ledger (rolling 14-night running balance)
+// MARK: - 2b. Sleep-debt ledger (actionable next-night target)
 
 /**
- * A running balance of (slept − personal need) across the recent fortnight, surfaced as one
- * card: the net debt/surplus headline, a plain-English read, and a diverging bar of each
- * night's delta (surplus above the centre line, deficit below). Honest: a simple accumulator
- * — a surplus night offsets a deficit one — capped at 14 nights, no-data nights skipped.
+ * A recency-weighted estimate of unmet current need, surfaced with the raw per-night deltas.
+ * Meeting base need plus displayed debt clears it; extra sleep does not create a positive bank.
+ * History stays capped at 14 counted nights and no-data nights remain skipped.
  * Mirrors the macOS SleepDebtLedgerCard section-for-section. `internal` and keyed on the shared
  * [SleepModel] so the Today host (TodayScreen) can render the SAME view the Sleep tab does (a mirror,
  * not a copy); the nap-credited ledger is read from `m.sleepDebtLedger`, never recomputed here. Twin of
@@ -173,7 +172,7 @@ private fun MetricGrid(m: SleepModel, onMetricClick: (String) -> Unit = {}) {
 internal fun SleepDebtLedgerHostCard(m: SleepModel) {
     val ledger = m.sleepDebtLedger
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
-        SectionHeader("Sleep-debt ledger", overline = "Last 14 nights", trailing = "running balance")
+        SectionHeader("Sleep-debt ledger", overline = "Last 14 nights", trailing = "tonight's target")
         NoopCard(padding = Metrics.cardPadding, tint = Palette.restColor) {
             if (ledger.nightCount == 0) {
                 Text(
@@ -183,7 +182,7 @@ internal fun SleepDebtLedgerHostCard(m: SleepModel) {
                 )
             } else {
                 Column(verticalArrangement = Arrangement.spacedBy(Metrics.space14)) {
-                    // Headline: net balance + the short tag (sleep debt / surplus / balanced).
+                    // Headline: current debt or balanced.
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
                             debtHeadline(ledger),
@@ -1130,4 +1129,3 @@ internal fun SleepConsistencyCard(
         }
     }
 }
-

--- a/android/app/src/main/java/com/noop/ui/SleepMetricDetailLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepMetricDetailLogic.kt
@@ -2,6 +2,7 @@ package com.noop.ui
 
 import androidx.compose.ui.graphics.Color
 import com.noop.analytics.RestScorer
+import com.noop.analytics.SleepDebt
 import com.noop.data.DailyMetric
 import java.time.LocalDate
 import java.util.Locale
@@ -31,8 +32,28 @@ internal fun sleepMetricSpec(key: String): SleepMetricSpec = when (key) {
     else              -> SleepMetricSpec(key, "", Palette.accent) { "${it.roundToInt()}" }
 }
 
-internal fun buildSleepMetricPoints(days: List<DailyMetric>, key: String): List<Pair<String, Double>> {
+internal fun buildSleepMetricPoints(
+    days: List<DailyMetric>,
+    key: String,
+    imported: ImportedSleepSeries = ImportedSleepSeries(),
+    napSleepMinByDay: Map<String, Double> = emptyMap(),
+): List<Pair<String, Double>> {
     val needMin = max(450.0, days.mapNotNull { it.totalSleepMin?.takeIf { m -> m > 0.0 } }.average().let { if (it.isNaN()) 480.0 else it })
+    if (key == "sleep_debt") {
+        val debtNeedMin = RestScorer.personalizedNeedHours(
+            days.mapNotNull { it.totalSleepMin?.let { minutes -> minutes / 60.0 } }, null,
+        ) * 60.0
+        return SleepDebt.debtSeries(
+            series = days.map { day ->
+                day.day to SleepDebt.creditedSleepMin(
+                    day.totalSleepMin,
+                    napSleepMinByDay[day.day] ?: 0.0,
+                )
+            },
+            needHours = debtNeedMin / 60.0,
+            importedDebtMin = imported.debtMin,
+        )
+    }
     return days.mapNotNull { d ->
         val v: Double? = when (key) {
             // The Rest detail graph reads the REAL resolved Rest composite per day — the same single
@@ -59,7 +80,6 @@ internal fun buildSleepMetricPoints(days: List<DailyMetric>, key: String): List<
                 if (sl > 0.0) (dp + rm) / sl * 100.0 else null
             }
             "respiratory" -> d.respRateBpm
-            "sleep_debt"  -> d.totalSleepMin?.let { max(0.0, needMin - it) }   // #691: minutes (spec unit "min")
             else          -> null
         }
         v?.takeIf { it.isFinite() }?.let { d.day to it }

--- a/android/app/src/main/java/com/noop/ui/SleepMetricDetailSheet.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepMetricDetailSheet.kt
@@ -32,11 +32,18 @@ import androidx.compose.runtime.setValue
 // MARK: - Sleep metric detail sheet
 
 @Composable
-internal fun SleepMetricDetailSheetContent(vm: AppViewModel, key: String) {
+internal fun SleepMetricDetailSheetContent(
+    vm: AppViewModel,
+    key: String,
+    imported: ImportedSleepSeries = ImportedSleepSeries(),
+    napSleepMinByDay: Map<String, Double> = emptyMap(),
+) {
     val days by vm.recentDays.collectAsStateWithLifecycle()
     var range by remember { mutableStateOf(SleepMetricRange.MONTH) }
     val spec = remember(key) { sleepMetricSpec(key) }
-    val allPoints = remember(days, key) { buildSleepMetricPoints(days, key) }
+    val allPoints = remember(days, key, imported, napSleepMinByDay) {
+        buildSleepMetricPoints(days, key, imported, napSleepMinByDay)
+    }
     val filteredPoints = remember(allPoints, range) { filterSleepMetricPoints(allPoints, range) }
 
     Column(
@@ -141,4 +148,3 @@ internal fun SleepMetricDetailSheetContent(vm: AppViewModel, key: String) {
         }
     }
 }
-

--- a/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
@@ -227,13 +227,15 @@ internal fun buildSleepModel(
         if (dp != null && rm != null && sl != null && sl > 0.0) (dp + rm) / sl * 100.0 else null
     }
     val respiratory = metric(days, todayKey) { it.respRateBpm }
+    val localDebtByDay = SleepDebt.debtSeries(
+        series = days.map { d ->
+            d.day to SleepDebt.creditedSleepMin(d.totalSleepMin, napSleepMinByDay[d.day] ?: 0.0)
+        },
+        needHours = debtNeedMin / 60.0,
+        importedDebtMin = imported.debtMin, // export-verbatim for that day; never seeds local state
+    ).toMap()
     val sleepDebt = run {
-        val series = days.mapNotNull { d ->
-            imported.debtMin[d.day]   // minutes, export-verbatim
-                ?: SleepDebt.creditedSleepMin(d.totalSleepMin, napSleepMinByDay[d.day] ?: 0.0)
-                    ?.takeIf { debtNeedMin > 0.0 }
-                    ?.let { max(0.0, debtNeedMin - it) }   // #242: normative need, not the self-referential mean
-        }
+        val series = days.mapNotNull { localDebtByDay[it.day] }
         Metric(series.lastOrNull(), mean(series), series)
     }
 
@@ -243,9 +245,7 @@ internal fun buildSleepModel(
     val trendHours = trendRows.mapNotNull { it.totalSleepMin?.let { minutes -> minutes / 60.0 } }
     val trendNeedHours = trendRows.map { row -> ((imported.needMin[row.day] ?: debtNeedMin) / 60.0) }
     val trendDebtHours = trendRows.map { row ->
-        val sleptMin = SleepDebt.creditedSleepMin(row.totalSleepMin, napSleepMinByDay[row.day] ?: 0.0) ?: 0.0
-        val neededMin = imported.needMin[row.day] ?: debtNeedMin   // #242: normative need, not the mean
-        ((imported.debtMin[row.day] ?: max(0.0, neededMin - sleptMin)) / 60.0)
+        (localDebtByDay[row.day] ?: 0.0) / 60.0
     }
     val trendDates = trendRows.map { it.day }
 

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -383,6 +383,13 @@ fun SleepScreen(
         )
     }
 
+    // Debt credit is the canonical main-night DailyMetric total PLUS actual asleep minutes from blocks
+    // outside that main-night group. Keep the nap sum separate: Rest, the hero and daily total deliberately
+    // remain main-night-only. Stage-less naps add no guessed in-bed time. Mirrors Swift SleepView. (#525)
+    val napSleepMinByDay = remember(sleeps, habitualMidsleep) {
+        napSleepMinutesByDay(sleeps, habitualMidsleep)
+    }
+
     // Tapping a metric tile opens a full-history detail sheet for that one metric. (PR #260)
     val metricSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var detailMetricKey by remember { mutableStateOf<String?>(null) }
@@ -394,7 +401,12 @@ fun SleepScreen(
             containerColor = Palette.surfaceRaised,
             contentColor = Palette.textPrimary,
         ) {
-            SleepMetricDetailSheetContent(vm = vm, key = currentDetailKey)
+            SleepMetricDetailSheetContent(
+                vm = vm,
+                key = currentDetailKey,
+                imported = imported,
+                napSleepMinByDay = napSleepMinByDay,
+            )
         }
     }
 
@@ -407,13 +419,6 @@ fun SleepScreen(
         sleeps.groupBy { localDayString(it.endTs) }
             .toSortedMap(reverseOrder())                       // newest day first
             .map { (_, blocks) -> blocks.sortedBy { it.effectiveStartTs } }
-    }
-
-    // Debt credit is the canonical main-night DailyMetric total PLUS actual asleep minutes from blocks
-    // outside that main-night group. Keep the nap sum separate: Rest, the hero and daily total deliberately
-    // remain main-night-only. Stage-less naps add no guessed in-bed time. Mirrors Swift SleepView. (#525)
-    val napSleepMinByDay = remember(sleeps, habitualMidsleep) {
-        napSleepMinutesByDay(sleeps, habitualMidsleep)
     }
 
     // The navigated night, decoded once per (offset, data) change — chevron taps re-pick
@@ -1987,4 +1992,3 @@ private fun MotionStrip(epochs: List<Double>) {
 // MARK: - Sleep window and night navigation UI lives in SleepNightNavUi.kt
 // MARK: - Sleep metric cards, debt ledger, stages, trends + chart helpers live in SleepMetricCardsUi.kt
 // MARK: - Sleep metric detail sheet UI lives in SleepMetricDetailSheet.kt
-

--- a/android/app/src/test/java/com/noop/analytics/SleepDebtTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepDebtTest.kt
@@ -22,16 +22,17 @@ class SleepDebtTest {
     }
 
     @Test
-    fun surplus_offsetsDeficit() {
+    fun debtCarriesAtFiftyFivePercentAndSurplusDoesNotBank() {
         val series = listOf(
             "2026-06-01" to 360.0,   // −120
             "2026-06-02" to 540.0,   // +60
             "2026-06-03" to 420.0,   // −60
         )
         val l = SleepDebt.ledger(series, needHours = 8.0)
-        assertEquals(-120.0, l.balanceMin, 1e-9)
+        // debt: 66 after night 1; the target-met second night clears it; night 3 leaves 33.
+        assertEquals(-33.0, l.balanceMin, 1e-9)
         assertTrue(l.isDebt)
-        assertEquals(120.0, l.magnitudeMin, 1e-9)
+        assertEquals(33.0, l.magnitudeMin, 1e-9)
         assertEquals(listOf(-120.0, 60.0, -60.0), l.nights.map { it.deltaMin })
     }
 
@@ -45,7 +46,7 @@ class SleepDebtTest {
         )
         val l = SleepDebt.ledger(series, needHours = 8.0)
         assertEquals(2, l.nightCount)
-        assertEquals(-60.0, l.balanceMin, 1e-9)
+        assertEquals(-33.0, l.balanceMin, 1e-9)
         assertEquals(listOf("2026-06-01", "2026-06-04"), l.nights.map { it.day })
     }
 
@@ -54,7 +55,7 @@ class SleepDebtTest {
         val series = (1..16).map { String.format("2026-06-%02d", it) to (420.0 as Double?) }
         val l = SleepDebt.ledger(series, needHours = 8.0, window = 14)
         assertEquals(14, l.nightCount)
-        assertEquals(-840.0, l.balanceMin, 1e-9)   // 14 × −60
+        assertEquals(-73.3, l.balanceMin, 1e-9) // converges instead of stacking 14 × −60
         assertEquals("2026-06-03", l.nights.first().day)
         assertEquals("2026-06-16", l.nights.last().day)
     }
@@ -74,7 +75,7 @@ class SleepDebtTest {
     fun defaultNeed_isEightHours() {
         val l = SleepDebt.ledger(listOf("2026-06-01" to 420.0))
         assertEquals(RestScorer.defaultSleepNeedHours * 60.0, l.needMin, 1e-9)
-        assertEquals(-60.0, l.balanceMin, 1e-9)
+        assertEquals(-33.0, l.balanceMin, 1e-9)
     }
 
     /** Main sleep stays canonical; separately-recorded nap sleep adds debt repayment credit. */
@@ -83,7 +84,92 @@ class SleepDebtTest {
         val credited = SleepDebt.creditedSleepMin(mainSleepMin = 392.0, napSleepMin = 48.0)
         assertEquals(440.0, credited!!, 1e-9)
         val l = SleepDebt.ledger(listOf("2026-06-01" to credited), needHours = 8.0)
-        assertEquals(-40.0, l.balanceMin, 1e-9)
+        assertEquals(-22.0, l.balanceMin, 1e-9)
+    }
+
+    @Test
+    fun calculatedDebtBelowTenMinutesClearsButExactlyTenRemains() {
+        val below = SleepDebt.ledger(listOf("2026-06-01" to (480.0 - 9.9 / 0.55)), needHours = 8.0)
+        val exact = SleepDebt.ledger(listOf("2026-06-01" to (480.0 - 10.0 / 0.55)), needHours = 8.0)
+        assertEquals(0.0, below.balanceMin, 1e-9)
+        assertEquals(-10.0, exact.balanceMin, 1e-9)
+    }
+
+    @Test
+    fun meetingNeedIncludingCurrentDebtClearsItCompletely() {
+        val l = SleepDebt.ledger(
+            listOf("2026-06-01" to 360.0, "2026-06-02" to 546.0),
+            needHours = 8.0,
+        )
+        assertEquals(0.0, l.balanceMin, 1e-9)
+        assertFalse(l.isDebt)
+    }
+
+    @Test
+    fun importedDebtIsVerbatimButDoesNotSeedFollowingFallback() {
+        val values = SleepDebt.debtSeries(
+            series = listOf("2026-06-01" to 420.0, "2026-06-02" to 480.0),
+            needHours = 8.0,
+            importedDebtMin = mapOf("2026-06-01" to 61.25),
+        )
+        assertEquals(61.25, values[0].second, 1e-9)
+        assertEquals(18.2, SleepDebt.round1(values[1].second), 1e-9)
+    }
+
+    @Test
+    fun debtSeriesRoundsLocalOutputsToTheLedgerSurfacePrecision() {
+        val values = SleepDebt.debtSeries(
+            series = listOf("2026-06-01" to 420.0, "2026-06-02" to 410.0),
+            needHours = 8.0,
+        )
+        val ledger = SleepDebt.ledger(
+            series = listOf("2026-06-01" to 420.0, "2026-06-02" to 410.0),
+            needHours = 8.0,
+        )
+        assertEquals(56.7, values.last().second, 1e-9)
+        assertEquals(ledger.magnitudeMin, values.last().second, 1e-9)
+    }
+
+    @Test
+    fun importedOnlyGapDoesNotConsumeOneOfFourteenUsableNights() {
+        val usable = (1..14).map { index ->
+            String.format("2026-06-%02d", index) to (420.0 as Double?)
+        }
+        val series = usable.take(13) +
+            listOf("2026-06-14-imported-only" to null) +
+            usable.drop(13)
+        val values = SleepDebt.debtSeries(
+            series = series,
+            needHours = 8.0,
+            importedDebtMin = mapOf("2026-06-14-imported-only" to 91.25),
+        )
+
+        assertEquals(15, values.size)
+        assertEquals(91.25, values[13].second, 1e-9)
+        assertEquals(
+            SleepDebt.ledger(usable, needHours = 8.0, window = 14).magnitudeMin,
+            values.last().second,
+            1e-9,
+        )
+    }
+
+    @Test
+    fun debtSeriesKeepsFullOutputHistoryAndRecomputesEachDayFromTrailingUsableWindow() {
+        val series = (1..16).map { index ->
+            String.format("2026-06-%02d", index) to ((390.0 + index) as Double?)
+        }
+        val values = SleepDebt.debtSeries(series, needHours = 8.0, window = 14)
+
+        assertEquals(16, values.size)
+        values.forEachIndexed { index, (day, debt) ->
+            val expected = SleepDebt.ledger(
+                series = series.take(index + 1),
+                needHours = 8.0,
+                window = 14,
+            ).magnitudeMin
+            assertEquals(day, series[index].first)
+            assertEquals("per-day parity at $day", expected, debt, 1e-9)
+        }
     }
 
     @Test
@@ -91,26 +177,6 @@ class SleepDebtTest {
         assertNull(SleepDebt.creditedSleepMin(mainSleepMin = null, napSleepMin = 48.0))
         assertNull(SleepDebt.creditedSleepMin(mainSleepMin = 0.0, napSleepMin = 48.0))
         assertEquals(392.0, SleepDebt.creditedSleepMin(mainSleepMin = 392.0, napSleepMin = -10.0)!!, 1e-9)
-    }
-
-    /**
-     * A NEGATIVE EXACT half-tie balance must round AWAY from zero (−0.05 → −0.1) to match
-     * Swift's `round1`. Kotlin's old `roundToInt()` rounded half toward +∞ and produced 0.0 on
-     * this exact tie — the cross-platform divergence audit #6 called out. needMin = 0.1, slept
-     * 0.05 → delta −0.05 exactly → balance −0.1.
-     */
-    @Test
-    fun negativeHalfTie_roundsAwayFromZero() {
-        val l = SleepDebt.ledger(listOf("2026-06-01" to 0.05), needHours = 0.1 / 60.0)
-        assertEquals(-0.1, l.balanceMin, 1e-9)   // away-from-zero, not 0.0
-    }
-
-    /** The symmetric positive half-tie (+0.05 → +0.1), pinned so the sign-aware rounding holds.
-     *  needMin = 0, slept 0.05 → delta +0.05. */
-    @Test
-    fun positiveHalfTie_roundsAwayFromZero() {
-        val l = SleepDebt.ledger(listOf("2026-06-01" to 0.05), needHours = 0.0)
-        assertEquals(0.1, l.balanceMin, 1e-9)
     }
 
     /** round1 pinned directly (both signs + a non-tie + a larger tie), parity with Swift's

--- a/android/app/src/test/java/com/noop/ui/SleepDebtFormattingTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepDebtFormattingTest.kt
@@ -1,0 +1,22 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SleepDebtFormattingTest {
+
+    @Test
+    fun nightDetailUsesTenMinuteDebtBoundary() {
+        assertEquals("On target", debtCaption(9.9))
+        assertEquals(Palette.statusPositive, debtColor(9.9))
+
+        assertEquals("Below need", debtCaption(10.0))
+        assertEquals(Palette.statusWarning, debtColor(10.0))
+    }
+
+    @Test
+    fun importedDebtAboveBoundaryRemainsDebt() {
+        assertEquals("Below need", debtCaption(12.5))
+        assertEquals(Palette.statusWarning, debtColor(12.5))
+    }
+}

--- a/android/app/src/test/java/com/noop/ui/SleepImportedFiguresTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepImportedFiguresTest.kt
@@ -139,10 +139,11 @@ class SleepImportedFiguresTest {
         assertEquals(410.0 / 450.0 * 100.0, m.hoursVsNeeded.latest!!, 1e-9)
         // Debt tile reads ASLEEP too, but against the NORMATIVE need now (#242): only 2 nights < the
         // 7-night minimum, so personalizedNeedHours cold-starts to the 8 h population target = 480, and
-        // debt = max(0, 480 − 410) = 70, never max(0, 480 − 600) = 0.
-        assertEquals(70.0, m.sleepDebt.latest!!, 1e-9)
-        // The debt TILE and the LEDGER agree (both asleep over the full history) — the #5 symptom.
-        assertEquals(m.sleepDebt.latest, -m.sleepDebtLedger.nights.last().deltaMin, 1e-9)
+        // The carried target is 0.55 × (480 + 33 − 410) = 56.65, surfaced at the shared
+        // one-decimal ledger precision as 56.7, never 0 from in-bed time.
+        assertEquals(56.7, m.sleepDebt.latest!!, 1e-9)
+        // The debt TILE and the LEDGER use the same recurrence.
+        assertEquals(56.7, -m.sleepDebtLedger.balanceMin, 1e-9)
     }
 
     /** A passed session must give the SAME tiles/ledger as no session — there is no display-time
@@ -181,15 +182,15 @@ class SleepImportedFiguresTest {
         assertEquals(48.0, napCredit["2026-06-02"]!!, 1e-9)
 
         // Mean main-night sleep is exactly 480 min, so personal need is 480. The latest day is
-        // 392 main + 48 nap = 440 credited: 40 min debt rather than the old 88 min.
+        // 392 main + 48 nap = 440 credited: 22 min carried debt rather than the old 88 min.
         val m = buildSleepModel(
             days = listOf(day("2026-06-01", 568.0), day("2026-06-02", 392.0)),
             session = night,
             napSleepMinByDay = napCredit,
             todayKey = pinnedToday,
         )!!
-        assertEquals(40.0, m.sleepDebt.latest!!, 1e-9)
-        assertEquals(40.0 / 60.0, m.trendDebtHours.last(), 1e-9)
+        assertEquals(22.0, m.sleepDebt.latest!!, 1e-9)
+        assertEquals(22.0 / 60.0, m.trendDebtHours.last(), 1e-9)
         assertEquals(440.0, m.sleepDebtLedger.nights.last().sleptMin, 1e-9)
         assertEquals(-40.0, m.sleepDebtLedger.nights.last().deltaMin, 1e-9)
         assertEquals(392.0 / 480.0 * 100.0, m.hoursVsNeeded.latest!!, 1e-9)

--- a/android/app/src/test/java/com/noop/ui/SleepMetricDetailDebtTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepMetricDetailDebtTest.kt
@@ -1,0 +1,50 @@
+package com.noop.ui
+
+import com.noop.data.DailyMetric
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SleepMetricDetailDebtTest {
+    private fun day(key: String, asleepMin: Double?) = DailyMetric(
+        deviceId = "my-whoop",
+        day = key,
+        totalSleepMin = asleepMin,
+        deepMin = 80.0,
+        remMin = 90.0,
+        lightMin = 190.0,
+        efficiency = 0.9,
+    )
+
+    @Test
+    fun detailDebtUsesTheSameCarryRecurrenceAsTheCard() {
+        val days = listOf(day("2026-06-01", 360.0), day("2026-06-02", 480.0))
+
+        val card = buildSleepModel(days, session = null, todayKey = "2026-06-03")!!
+        val detail = buildSleepMetricPoints(days, "sleep_debt")
+
+        assertEquals(36.3, card.sleepDebt.latest!!, 1e-9)
+        assertEquals(card.sleepDebt.latest!!, detail.last().second, 1e-9)
+    }
+
+    @Test
+    fun detailDebtPreservesImportedValueAndCreditsNaps() {
+        val days = listOf(day("2026-06-01", 360.0), day("2026-06-02", 400.0))
+        val imported = ImportedSleepSeries(debtMin = mapOf("2026-06-02" to 61.25))
+
+        val importedPoints = buildSleepMetricPoints(days, "sleep_debt", imported = imported)
+        assertEquals(61.25, importedPoints.last().second, 1e-9)
+
+        val card = buildSleepModel(
+            days,
+            session = null,
+            napSleepMinByDay = mapOf("2026-06-02" to 80.0),
+            todayKey = "2026-06-03",
+        )!!
+        val napPoints = buildSleepMetricPoints(
+            days,
+            "sleep_debt",
+            napSleepMinByDay = mapOf("2026-06-02" to 80.0),
+        )
+        assertEquals(card.sleepDebt.latest!!, napPoints.last().second, 1e-9)
+    }
+}

--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -236,6 +236,49 @@ Given `(TRIMP, reference_strain)` pairs, fits `D` via a through-origin least-squ
 
 ---
 
+## `SleepDebt` — actionable next-night sleep target
+
+The displayed debt is a planning estimate, not an hour-for-hour bank of every
+minute missed over the last fortnight. For each usable night, NOOP carries 55%
+of the complete unmet need into the following night's target:
+
+```text
+currentNeed = personalizedBaseNeed + currentDebt
+nextDebt    = 0.55 × max(0, currentNeed − creditedSleep)
+```
+
+`creditedSleep` is the main night's asleep time plus separately recorded nap
+sleep. A calculated debt below 10 minutes is treated as balanced; exactly 10
+minutes remains debt. Meeting the complete current need clears the displayed
+debt, and extra sleep never creates a positive bank. The chart bars remain the
+raw nightly difference from base need so the underlying nights stay visible.
+
+The coefficient is an interoperability approximation, not a physiological
+constant. It was selected against one contributor's 853 consecutive exported
+WHOOP nights: the 0.55 recurrence was within 15 minutes of WHOOP's following-day
+debt on 93.0% of pairs and within 20 minutes on 94.5%. That contributor also used
+WHOOP's sleep-debt target for daily sleep planning for approximately 800 days.
+This is useful longitudinal field evidence, but it is single-user validation,
+not a population study or clinical claim.
+
+A bounded, recency-weighted planning estimate is also more honest than treating
+sleep loss as interchangeable hours. Controlled restriction studies find that
+sleep physiology, subjective sleepiness, and cognitive performance accumulate
+and recover on different timescales; recovery depends on sleep dose and intensity,
+and some performance effects can remain after extended recovery sleep:
+
+- Van Dongen et al. (2003), chronic restriction dose-response:
+  <https://pubmed.ncbi.nlm.nih.gov/12683469/>
+- Banks et al. (2010), recovery-sleep dose response:
+  <https://pmc.ncbi.nlm.nih.gov/articles/PMC2910531/>
+- Doty et al. (2020), differential recovery across neurobehavioral measures:
+  <https://pubmed.ncbi.nlm.nih.gov/33274389/>
+
+The estimate therefore answers the narrow product question “how much should I
+add to tonight's base sleep target?”, not “have all physiological and cognitive
+effects of prior sleep restriction disappeared?”. Swift and Kotlin implement the
+same constants, recurrence, deadband, nap credit, and 14-usable-night bound.
+
 ## `SleepStager` — sleep/wake detection + approximate 4-class staging (feeds **Rest**)
 
 Source: `SleepStager.swift`. Detects in-bed sessions from gravity/HR/RR/respiration and produces a 30-second hypnogram of `{wake, light, deep, rem}`. These stages and the AASM roll-up below are the raw material the **Rest** score composite consumes (see *The Rest score composite* immediately after this section).

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -267,7 +267,9 @@ just the most recent (step through earlier nights to compare):
   each as "Xh Ym · NN%", with time-in-bed, efficiency, and onset–wake times.
 - **Night detail** — a uniform tile grid, each with a sparkline and a "vs typical" caption: Sleep
   Performance, Efficiency, Consistency, Hours vs Needed, Restorative (deep + REM share),
-  Respiratory, and Sleep Debt (vs your personal sleep need, floored at 7.5 h).
+  Respiratory, and Sleep Debt. Debt is 55% of the current unmet personalized need, carried into the
+  next night's target; values below 10 minutes read as balanced instead of stacking into an
+  unrepayable 14-night hours bank.
 - **Stages vs typical** — Deep / REM / Light as horizontal bars, last-night minutes with a marker
   at your personal mean, so highs and lows pop.
 - **Asleep duration** — a trailing-30-night hours trend with avg / min / max.


### PR DESCRIPTION
## What this PR does

Replaces NOOP's flat 14-night `Σ(slept − need)` sleep-debt bank with one bounded,
actionable next-night estimate on Apple and Android:

```text
currentNeed = personalizedBaseNeed + currentDebt
nextDebt    = 0.55 × max(0, currentNeed − creditedSleep)
```

Calculated debt below 10 minutes is treated as balanced; exactly 10 minutes remains
debt. Meeting the complete current need clears the displayed debt. Extra sleep does
not create a positive bank.

The user-facing meaning is deliberately narrow: **how much should I add to tonight's
base sleep target?** It is not an hour-for-hour historical account and does not claim
that every physiological or cognitive effect of prior sleep restriction disappears at
the same rate.

## Why change the current ledger

The current rolling sum gives every one of the last 14 nights full weight. A repeated
shortfall therefore grows into balances such as 11 hours that cannot usefully answer
how long to sleep tonight. Dropping the oldest night at day 15 also creates a hard edge
rather than gradual recovery.

This recurrence is self-limiting because yesterday's debt is already part of today's
need. If a base need is 8h and the current debt is 1h, sleeping the complete 9h target
clears the displayed debt. Missing it by five minutes computes only 2.75 minutes, which
falls below the 10-minute actionable threshold and reads as balanced.

## WHOOP reference calibration

The contributor used WHOOP's sleep-debt target for daily sleep planning for about 800
days. To turn that longitudinal experience into a quantitative check, the recurrence
was evaluated against 853 consecutive pairs from the contributor's exported WHOOP
sleep history.

With carry `0.55` and the `<10 min` deadband:

- within ±10 minutes: **85.9%**
- within ±15 minutes: **93.0%**
- within ±20 minutes: **94.5%**
- mean absolute error: **10.1 minutes**

This is single-user observational validation, not a population study and not a claim
about WHOOP's proprietary implementation. The coefficient is an interoperability
approximation selected for a simple, explainable local model.

## One implementation per platform

This change deliberately removes competing UI calculations:

- Swift: `SleepDebt.ledger` owns the recurrence and `SleepDebt.debtSeries` owns the
  chronological/import/window contract. `SleepModel` is only an input adapter.
- Kotlin: the byte-parity `SleepDebt.ledger` / `SleepDebt.debtSeries` twin owns the
  same contracts. Card, trend and tappable detail all consume it.
- Both twins share the same constants, deadband, rounding, gap handling and test
  vectors.

The raw per-night chart bars remain `slept − personalizedBaseNeed`; only the headline
debt uses the recurrence.

## Existing behavior preserved

- **#1041 / #1042 — naps:** actual asleep nap minutes remain credited without changing
  the canonical main-night total. A stage-less or invalid nap still fabricates no sleep.
- **#1348 — personalized need:** locally calculated debt continues to use the normative
  population-anchored `personalizedNeedHours`, not the self-referential mean-asleep
  value that can drift down for chronic short sleepers.
- **WHOOP imports:** imported `sleep_debt_min` wins verbatim for that day. It does not
  seed or contaminate the independent local recurrence used on later locally computed
  days.
- Missing/zero sleep nights remain skipped and do not become fabricated full-night debt.
- The output history remains complete; each local point uses at most the trailing 14
  usable nights.

## Relation to existing open work

- **#464** correctly identifies the flat-sum problem, but proposes
  `balance = 0.90 × balance + contribution`, half-credit for surplus and a three-night
  cap. Its own description marks all three constants as needing empirical tuning. A
  0.90 carry has a ~6.6-night half-life and can still display up to three complete nights
  of debt, so meeting the displayed need does not necessarily clear the balance. This PR
  keeps #464's already-merged need-unification direction but replaces the unmerged ledger
  proposal with the calibrated, directly repayable recurrence.
- **#758 (Sleep Planner)** asks for an actionable local bedtime/sleep-need plan. This PR
  does not implement its wake-time, bedtime or notification UI; it provides a bounded,
  repayable debt input that can support that work.
- **#515** concerns incorrect/split source sleep and re-detection. This PR does not repair
  bad source sessions; it changes how valid credited sleep is carried forward. Garbage-in
  data can still produce a wrong recommendation until #515 is addressed.
- **#691** includes Sleep-tab presentation inconsistencies. Existing hours/minutes and
  chart-date fixes remain; this PR additionally makes the card, trend, ledger and Android
  tapped detail use one debt series.

## Scientific framing

Sleep loss has cumulative effects, but controlled restriction studies show that sleep
physiology, subjective sleepiness and cognitive performance accumulate and recover on
different timescales. Recovery depends on sleep dose and intensity rather than a single
bank of interchangeable hours, and some performance effects persist after extended
recovery sleep:

- Van Dongen et al. (2003): https://pubmed.ncbi.nlm.nih.gov/12683469/
- Banks et al. (2010): https://pmc.ncbi.nlm.nih.gov/articles/PMC2910531/
- Doty et al. (2020): https://pubmed.ncbi.nlm.nih.gov/33274389/

These studies support avoiding a falsely precise flat hour bank; they do **not** derive
the `0.55` coefficient. The coefficient comes from the WHOOP reference comparison above.

## Consistency and edge cases covered

The implementation and regression coverage keep the result consistent across platforms
and every user-facing surface:

- Ledger and time-series values use identical one-decimal rounding on Swift and Android.
- Imported-only gaps do not consume the 14-usable-night local window, and the complete
  output history remains available.
- Cards, trends, Night detail and Android's tappable metric detail all use the same
  10-minute boundary and canonical debt series.
- Local, imported and nap-credited paths agree without imported values seeding the local
  recurrence.
- Missing nights are skipped, surplus never becomes positive debt and meeting the full
  current need clears the balance.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [x] Documentation
- [ ] CI / tooling

## How it was tested

Local final-code verification:

- `./gradlew testFullDebugUnitTest` — **BUILD SUCCESSFUL**
- focused sleep-debt suites — **31 tests, 0 failures**
- `python3 Tools/doc_comment_lint.py` — pass
- `python3 Tools/i18n_audit.py --ci origin/main` — pass
- `git diff --check` — pass

Mirrored coverage includes:

- 0.55 recurrence and complete-target clearing
- `<10` balanced versus exactly `10` debt
- no positive surplus
- nap credit
- missing-night handling
- trailing 14 usable nights and full output history
- imported value verbatim without seeding local state
- one-decimal Swift/Kotlin surface parity
- Night-detail caption/color boundary
- Android card → tapped-detail agreement for local, imported and nap-credited data

Swift/Xcode is not installed on the Linux development host. The Swift package tests and
macOS/iOS app-target compile are therefore left to the repository's PR workflows; the
Swift tests use the same vectors as the green Kotlin twin.

## Checklist

- [x] Swift package tests pass in PR CI
- [x] Android unit tests pass (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced by this change
- [x] No UI layout or design-token changes
- [x] No protocol/BLE/schema/migration changes
- [x] Source-hygiene and i18n ratchets pass
- [x] No generated output, personal exports, secrets or proprietary WHOOP code committed
- [x] Follows `docs/CONTRIBUTING.md`

## Related issues and PRs

Refs #464, #515, #691, #758, #1041, #1042, #1348.
