### PR TITLE
WHOOP 5/MG: probe whether the historical offload actually needs a bond

### DIFF
--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -130,6 +130,24 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
         get() = prefs.getBoolean(KEY_HELLO_DESPITE_REFUSAL, false)
         set(v) = prefs.edit().putBoolean(KEY_HELLO_DESPITE_REFUSAL, v).apply()
 
+    /**
+     * Try the historical offload on a link that never bonded (#1635, default false).
+     *
+     * `beginBackfill` is gated on `connectHandshakeDone`, which for a 5/MG is set only behind the
+     * CLIENT_HELLO ack — so on a strap answering SMP `Pairing Not Supported` the offload is never even
+     * attempted. That gate is ours, and the assumption underneath it (that the puffin notify chars need an
+     * encrypted link) has never been measured on Android: the one attempt rode a false bond and the link
+     * died before any answer came back. See [shouldProbeUnbondedOffload] for the staged form.
+     *
+     * Its own switch because it SENDS to the strap and, if the strap answers, writes its clock — the same
+     * line every other state-changing probe here sits behind ([isDeepDataEnabled], [broadcastHr],
+     * [ecgRawData]). Nothing is written until the strap has proved it answers a read-only GET_CLOCK, and a
+     * refusal is latched per device, so opting in costs one link and not a loop.
+     */
+    var unbondedOffload: Boolean
+        get() = prefs.getBoolean(KEY_UNBONDED_OFFLOAD, false)
+        set(v) = prefs.edit().putBoolean(KEY_UNBONDED_OFFLOAD, v).apply()
+
     /** True if the user opted in to "Ask Android to pair" (#1635, default false): NOOP calls
      *  `BluetoothDevice.createBond()` explicitly instead of relying on a write to the encrypted
      *  characteristic to provoke pairing — which the #1639 bond-state trace showed never happens at all.
@@ -141,13 +159,14 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
         set(v) = prefs.edit().putBoolean(KEY_EXPLICIT_BOND, v).apply()
 
     /**
-     * Turn OFF every 5/MG-only experimental probe: protocol probes ([isEnabled]), raw capture
-     * ([isCaptureEnabled]), the R22 deep-data strap write ([isDeepDataEnabled]) and broadcast-HR
-     * ([broadcastHr]). Called on a strap FAMILY switch (WHOOP 4.0 ↔ 5/MG) so a 5/MG-only option can
-     * never linger enabled and get applied to a strap it doesn't belong to. One atomic edit.
+     * Turn OFF every 5/MG-only experimental probe — exactly the switches in [FIVE_MG_GATED_KEYS], which is
+     * the one list rather than a prose copy of it that drifts (this doc named four while the list already
+     * held six). Called on a strap FAMILY switch (WHOOP 4.0 ↔ 5/MG) so a 5/MG-only option can never linger
+     * enabled and get applied to a strap it doesn't belong to. One atomic edit.
      *
-     * The line is "does it SEND something to the strap": these four arm probes, raw-capture writes, the
-     * R22 deep-data write and the broadcast-HR write, all of which target hardware that may not support
+     * The line is "does it SEND something to the strap": these arm probes, raw-capture writes, the R22
+     * deep-data write, the broadcast-HR write, the ECG gate, an explicit pairing and the unbonded offload
+     * probe, all of which target hardware that may not support
      * them. Pure analysis flags are deliberately left alone even when they only do anything on one
      * family — [ppgHrSubLagInterp] only affects v26 optical records, which a 4.0 never sends, so it is
      * inert rather than misapplied. [experimentalSleepV2], [hrvReadiness] and [motionAwareWake] are
@@ -183,13 +202,18 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
          *  so no macOS key to mirror. */
         const val KEY_EXPLICIT_BOND = "noopWhoop5ExplicitBond"
 
+        /** "Try history sync without pairing" opt-in — the unbonded offload probe (#1635). Android-only,
+         *  so no macOS key to mirror. */
+        const val KEY_UNBONDED_OFFLOAD = "noopWhoop5UnbondedOffload"
+
         /** #1635: send the CLIENT_HELLO even when the suppression latch is set. Default OFF. */
         const val KEY_HELLO_DESPITE_REFUSAL = "noopWhoop5HelloDespiteRefusal"
 
         /** The 5/MG-only probe keys, in ONE place: [resetFiveMGGatedProbes] clears exactly these, and
          *  SettingsScreen watches exactly these for external writes. Two lists would drift. */
         internal val FIVE_MG_GATED_KEYS =
-            listOf(KEY, KEY_CAPTURE, KEY_DEEP_DATA, KEY_BROADCAST_HR, KEY_ECG_RAW_DATA, KEY_EXPLICIT_BOND)
+            listOf(KEY, KEY_CAPTURE, KEY_DEEP_DATA, KEY_BROADCAST_HR, KEY_ECG_RAW_DATA, KEY_EXPLICIT_BOND,
+                   KEY_UNBONDED_OFFLOAD)
 
         /** "Experimental sleep staging (V2)" opt-in (mirrors macOS `PuffinExperiment.experimentalSleepV2Key`). */
         const val KEY_EXPERIMENTAL_SLEEP_V2 = "noopExperimentalSleepV2"

--- a/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
+++ b/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
@@ -1,0 +1,232 @@
+package com.noop.ble
+
+/**
+ * Should NOOP try the historical offload on a WHOOP 5/MG that has NOT bonded?
+ *
+ * The offload has always been gated on the CLIENT_HELLO ack — `beginBackfill` refuses while
+ * `connectHandshakeDone` is false, and for a 5/MG that flag is set in exactly one place, behind `didBond`.
+ * On a strap that answers SMP with `Pairing Not Supported` (#1635) the ack can never arrive, so the gate
+ * can never open, and the app never asks the strap for history at all.
+ *
+ * What makes that worth re-examining is that the gate is OURS, not the strap's, and the link underneath it
+ * is not the broken thing it was assumed to be. With the hello suppressed the link is stable for tens of
+ * minutes (a field capture holds one up for 2431s), live HR streams over the standard profile the whole
+ * time, the unbonded DIS identity read succeeds (#490/#1455), and puffin commands — DISABLE_ALARM,
+ * TOGGLE_REALTIME_HR — are written to fd4b0002 without the stack objecting. Every bounce in the capture
+ * traces to the bond watchdog after an unanswered hello, never to the link itself.
+ *
+ * What is NOT established is the part that matters, and it is important to be exact about why. Those
+ * puffin writes go out WITHOUT response, so their `GATT_SUCCESS` is Android reporting a Write Command
+ * handed to the controller — a local fact that says nothing about whether the strap parsed it. And the
+ * offload does not arrive on fd4b0002 at all: it arrives on the puffin NOTIFY characteristics
+ * (fd4b0003/4/5/7), which this app has never once subscribed on a healthy unbonded link. The single
+ * attempt on record (28 Aug, 13:25:00) rode a FALSE bond — a DISABLE_ALARM completion misread as a hello
+ * ack, the bug #1635 fixed — and produced `writeDescriptor busy; retry 1/8`, an Android queue error,
+ * before the link died 4s later with the hello still outstanding. No answer was ever obtained.
+ *
+ * The belief that it cannot work is a comment, not a measurement: `BLEManager.swift` records that the
+ * strap rejects those subscriptions with "Authentication is insufficient", from a 5/MG that was still
+ * bonded to the official WHOOP app (issue #17). That may well be right. It has never been tested against
+ * a strap in this state, on a link that stays up long enough to hear the answer.
+ *
+ * So this probe asks, in stages, each one falsifying the next:
+ *
+ *  1. subscribe the four puffin notify characteristics. An insufficient-authentication status here is the
+ *     whole answer — the offload needs an encrypted link, and #1635 is a wall rather than a gate.
+ *  2. if they subscribe, send GET_CLOCK. Read-only on purpose: it changes nothing on the strap, and a
+ *     COMMAND_RESPONSE to it is the first hard evidence that puffin commands are acted on unbonded.
+ *  3. only then SET_CLOCK and the ordinary offload, which is the existing hardware-proven sequence.
+ *
+ * Self-limiting the same way [shouldReadDisUnbonded] is: opt-in, once per link, and never again after a
+ * refusal is latched for that device. This area has a habit of producing "keeps retrying something that
+ * cannot work", and the point of a probe is to stop being one after it has its answer.
+ *
+ * A refusal is a RESULT. Either outcome closes the last open question on #1635.
+ */
+internal fun shouldProbeUnbondedOffload(
+    isWhoop5: Boolean,
+    optedIn: Boolean,
+    bonded: Boolean,
+    helloWrittenThisLink: Boolean,
+    alreadyProbedThisLink: Boolean,
+    previouslyRefused: Boolean,
+    silentLinksSoFar: Int = 0,
+): Boolean {
+    if (!isWhoop5) return false
+    if (!optedIn) return false
+    // A bonded strap reaches the offload through the proven post-hello handshake; this exists only for the
+    // straps that path never reaches.
+    if (bonded) return false
+    // The hello is what drops the link. On a link carrying one, the bond watchdog has ~5s to bounce us, so
+    // a refusal here would be unattributable — exactly the ambiguity that made the hello unreadable for
+    // eleven weeks. Only the stable no-hello link can answer this question.
+    if (helloWrittenThisLink) return false
+    if (alreadyProbedThisLink) return false
+    if (previouslyRefused) return false
+    return unbondedProbeStillWorthAsking(silentLinksSoFar)
+}
+
+/**
+ * How many links may end in SILENCE before the probe retires itself.
+ *
+ * A refusal latches per device; silence deliberately does not, because the subscriptions were accepted and
+ * one quiet link is not the strap's verdict. But "not latched" cannot mean "forever": the probe re-runs on
+ * every reconnect, and a strap that reconnects often would re-ask a question already answered the same way
+ * three times, which is the exact shape of the unbounded retry this whole area keeps producing.
+ *
+ * Counted per app process, like [HELLO_OVERRIDE_MAX_ATTEMPTS], and reset by a genuine answer. A process
+ * restart resets it too — the honest limit of an in-memory bound, and the loop it exists to stop runs
+ * within one process.
+ */
+internal const val UNBONDED_PROBE_MAX_SILENT_LINKS = 3
+
+/** Has the probe any budget left after [silentLinksSoFar] links that subscribed but drew no reply? */
+internal fun unbondedProbeStillWorthAsking(
+    silentLinksSoFar: Int,
+    cap: Int = UNBONDED_PROBE_MAX_SILENT_LINKS,
+): Boolean = silentLinksSoFar < cap
+
+/**
+ * The line printed when the probe retires on repeated silence, so the log says why it stopped rather than
+ * leaving a reader to notice its absence — the same failure the CLIENT_HELLO's silent suppression caused.
+ */
+internal fun unbondedProbeGaveUpLine(silentLinks: Int): String =
+    "Unbonded offload probe: $silentLinks links have subscribed the puffin chars and drawn no" +
+        " COMMAND_RESPONSE — this strap serves those characteristics unbonded but does not act on commands" +
+        " written to them. Not asking again this session. History offload is unavailable until the strap" +
+        " completes a handshake (#1635)."
+
+/** Persisted key for "this strap refused the unbonded puffin subscriptions". Per device and lowercased,
+ *  for the same reason [firmwarePrefKey] is. */
+internal fun unbondedOffloadRefusedPrefKey(peripheralId: String?): String? =
+    peripheralId?.trim()?.takeIf { it.isNotEmpty() }?.let { "noop.unbondedOffloadRefused.${it.lowercase()}" }
+
+/**
+ * What a frame arriving on a puffin notify characteristic proves about an unbonded link.
+ *
+ * The distinction is the whole point of the probe and is easy to lose. A frame — any frame — proves the
+ * strap SERVES those characteristics without encryption, which is what the offload transport needs. It
+ * does not prove the strap ACTED on anything we wrote, because a stream it would have sent anyway looks
+ * identical from here. Only a reply to a command we issued shows the command channel is live, and that is
+ * the finding the offload actually depends on.
+ *
+ * Treating the weaker evidence as the stronger one is how the false bond of 28 Aug happened: an unrelated
+ * completion on a shared characteristic was read as an answer to a question nobody had been asked.
+ */
+internal enum class UnbondedProbeEvidence {
+    /** Nothing decodable has arrived. */
+    NONE,
+
+    /** A valid frame arrived on a puffin notify characteristic: the strap serves them unbonded. */
+    SERVES_NOTIFICATIONS,
+
+    /** A COMMAND_RESPONSE arrived: the strap parsed a puffin command written over an unencrypted link and
+     *  answered it. This is the evidence the offload needs. */
+    ANSWERS_COMMANDS,
+}
+
+/** The COMMAND_RESPONSE type name as `Framing.parseFrame` reports it. */
+internal const val COMMAND_RESPONSE_TYPE_NAME = "COMMAND_RESPONSE"
+
+/**
+ * Classify one parsed puffin frame as probe evidence.
+ *
+ * CRC-gated, and deliberately strict about it. A frame whose CRC does not verify is noise on a link we are
+ * testing precisely because we do not know whether it is allowed to carry this traffic, and counting noise
+ * as proof would let the probe conclude the opposite of the truth. `crcOk == null` (no CRC to check) is
+ * not a pass either — [ok] alone is an envelope check.
+ */
+internal fun unbondedProbeEvidenceOf(
+    ok: Boolean,
+    crcOk: Boolean?,
+    typeName: String?,
+): UnbondedProbeEvidence = when {
+    !ok || crcOk != true || typeName.isNullOrBlank() -> UnbondedProbeEvidence.NONE
+    typeName == COMMAND_RESPONSE_TYPE_NAME -> UnbondedProbeEvidence.ANSWERS_COMMANDS
+    else -> UnbondedProbeEvidence.SERVES_NOTIFICATIONS
+}
+
+/**
+ * Keep the strongest evidence seen on this link.
+ *
+ * The probe's verdict must not depend on which frame happened to arrive last. A REALTIME_DATA burst
+ * following the COMMAND_RESPONSE would otherwise walk the conclusion back down to the weaker finding.
+ */
+internal fun strongerProbeEvidence(
+    a: UnbondedProbeEvidence,
+    b: UnbondedProbeEvidence,
+): UnbondedProbeEvidence = if (b.ordinal > a.ordinal) b else a
+
+/** Announced before stage 1 so a capture shows the probe starting, not just its outcome. */
+internal fun unbondedProbeStartLine(): String =
+    "Unbonded offload probe: subscribing the puffin notify chars (fd4b0003/4/5/7) on a link with no" +
+        " CLIENT_HELLO. Never attempted on a healthy link before — an insufficient-authentication status" +
+        " here means the offload requires an encrypted bond and #1635 ends it (experimental, #1635)."
+
+/**
+ * Stage 1's refusal — the answer the probe exists to get.
+ *
+ * Named as a finding rather than an error: it settles for Android what only a comment has claimed, and it
+ * is latched per device so the strap says it once instead of on every reconnect.
+ */
+internal fun puffinSubscribeRefusedLine(uuid: String, status: String): String =
+    "Unbonded offload probe: subscribe of $uuid failed $status. If this is an insufficient-authentication" +
+        " or -encryption status, the puffin notify chars need an encrypted link, the historical offload" +
+        " cannot be reached without a bond, and a 5/MG that refuses SMP can never sync history (#1635)."
+
+/**
+ * Stage 2's question, logged so the wait that follows is attributable to it.
+ *
+ * Carries the CONFIRMED count, not the attempted one. A CCCD write can also end by being abandoned after
+ * its busy retries, which reaches the same completion path as four clean subscribes — so a line that said
+ * "subscribed" flatly would overstate a partial result in the one log this experiment exists to produce.
+ */
+internal fun unbondedProbeAskingLine(subscribed: Int, total: Int, waitMs: Long): String =
+    "Unbonded offload probe: $subscribed of $total puffin notify chars subscribed — the strap serves them" +
+        " on an unencrypted link. Sending GET_CLOCK (read-only, changes nothing on the strap) and" +
+        " listening ${waitMs}ms for a COMMAND_RESPONSE, which would be the first proof it acts on puffin" +
+        " commands unbonded (#1635)."
+
+/**
+ * Stage 1 ended with nothing confirmed and no refusal to name.
+ *
+ * Distinct from both other stage-1 outcomes on purpose. A refusal is the strap's answer; this is the
+ * absence of one — every write was abandoned by our own stack before the strap ever ruled — and reporting
+ * it as either a refusal or a success would put a fact in the capture that was never established.
+ */
+internal fun unbondedProbeNoSubscriptionsLine(total: Int): String =
+    "Unbonded offload probe: none of the $total puffin notify chars completed their subscribe, and none" +
+        " was refused either — the writes were abandoned locally, so the strap never ruled on them. No" +
+        " question asked; this link proves nothing either way (#1635)."
+
+/**
+ * Stage 2's silence.
+ *
+ * Distinguished from a refusal on purpose: the subscriptions landed, so the transport is open and the
+ * strap simply did not answer. That is a different fact about the strap than "it declined the link", and a
+ * capture that conflated them would send the next reader after the wrong thing.
+ */
+internal fun unbondedProbeSilentLine(waitedMs: Long, sawNotifications: Boolean): String =
+    "Unbonded offload probe: no COMMAND_RESPONSE after ${waitedMs}ms. The subscriptions were accepted" +
+        (if (sawNotifications) " and frames did arrive on them," else " but nothing arrived on them,") +
+        " so the transport is open and the strap is not answering commands on an unencrypted link." +
+        " Not retrying on this strap (#1635)."
+
+/** Stage 2's success — the finding that unlocks the rest. */
+internal fun unbondedProbeAnsweredLine(): String =
+    "Unbonded offload probe: COMMAND_RESPONSE received — the strap ACTS on puffin commands over an" +
+        " unencrypted link. Clocking the strap and requesting the historical offload (#1635)."
+
+/**
+ * The expectation to set the moment the probe succeeds, not after the offload returns empty.
+ *
+ * An un-clocked 5/MG is hardware-known not to persist sensor data to flash at all ("RTC timestamp … is
+ * invalid; not saving data to flash", #78 fork). A strap that has never completed a handshake has never
+ * been clocked by NOOP, so the honest expectation is that an offload which finally runs may find little or
+ * nothing banked — and that this buys FUTURE syncing rather than recovering the backlog. GET_DATA_RANGE
+ * answers it directly, which is why it is the stage before the transfer rather than after it.
+ */
+internal fun unbondedProbeBacklogCaveatLine(): String =
+    "Unbonded offload probe: note that this strap has never been clocked by NOOP, and an un-clocked 5/MG" +
+        " does not save sensor data to flash — so GET_DATA_RANGE may legitimately report little or nothing" +
+        " banked. That would mean history works from now on, not that the probe failed (#1635)."

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -868,6 +868,13 @@ class WhoopBleClient(
         /** 5/MG fail-open gate: how long to wait for a GET_DATA_RANGE SUCCESS before requesting
          *  history anyway (real hardware sometimes swallows the first range query, #78 fork). */
         private const val DATA_RANGE_GATE_MS = 2_000L
+
+        /** #1635: how long the unbonded probe listens for a COMMAND_RESPONSE to its GET_CLOCK.
+         *  Generous next to [DATA_RANGE_GATE_MS] on purpose — a strap that has never held a session may be
+         *  slower than one mid-sync, and the cost of waiting is a few seconds on a link that is already
+         *  stable, while the cost of asking too early is a false "does not answer" that closes #1635 the
+         *  wrong way. */
+        private const val UNBONDED_PROBE_REPLY_WAIT_MS = 8_000L
         /** 5/MG zero-frame retry: pause before re-requesting history when a session timed out having
          *  produced nothing (the first request after connect can go entirely unanswered). */
         private const val WHOOP5_HISTORY_RETRY_DELAY_MS = 700L
@@ -2335,6 +2342,43 @@ class WhoopBleClient(
      *  written in a GATT callback (binder thread), read in beginBackfill (main-looper timer). (ryanbr, #1032) */
     @Volatile
     private var connectHandshakeDone = false
+
+    /** #1635 unbonded offload probe: stage 1 (the puffin CCCD writes) is in flight. @Volatile — set on the
+     *  main looper, read in onDescriptorWrite on the binder thread. */
+    @Volatile
+    private var unbondedProbeSubscribing = false
+
+    /** #1635: stage 2 is in flight — GET_CLOCK is out and we are listening for a COMMAND_RESPONSE.
+     *  @Volatile: cleared on the main looper, read in the notify handler on the binder thread. */
+    @Volatile
+    private var unbondedProbeAwaitingReply = false
+
+    /** #1635: the probe has run on THIS link. Separate from [unbondedProbeAwaitingReply] because the
+     *  keep-alive drains the same CCCD queue every 30s and would otherwise re-enter the probe's own
+     *  completion branch for the life of the connection. */
+    private var unbondedProbeStartedThisLink = false
+
+    /** #1635: the strongest evidence seen this link, never the most recent — REALTIME_DATA follows a
+     *  COMMAND_RESPONSE continuously once realtime is armed, and last-one-wins would report "not
+     *  answering" about a strap that had just answered. @Volatile: written in the notify handler. */
+    @Volatile
+    private var unbondedProbeEvidence = UnbondedProbeEvidence.NONE
+
+    /** #1635: when stage 2's GET_CLOCK went out, so the verdict line can state the wait it actually
+     *  waited rather than the one it intended to. */
+    private var unbondedProbeAskedAtMs = 0L
+
+    /** #1635: puffin CCCD writes the stack CONFIRMED this link. A subscribe can also end by being
+     *  abandoned after its busy retries, which reaches the same drain-empty branch as a clean one — so the
+     *  count, not the branch, is what says the transport is open. @Volatile: incremented in
+     *  onDescriptorWrite on the binder thread, read on the main looper. */
+    @Volatile
+    private var unbondedProbeSubscribed = 0
+
+    /** #1635: links that subscribed the puffin chars and drew no reply. Per PROCESS, deliberately NOT
+     *  cleared by [reset] — its whole job is to bound a retry that spans reconnects. A refusal latches per
+     *  device instead; silence is weaker evidence and gets a budget rather than a verdict. */
+    private var unbondedProbeSilentLinks = 0
 
     /** True when the user asked to disconnect; suppresses the auto-rescan (Swift `intentionalDisconnect`).
      *  Written on the main looper (connect/disconnect/keep-alive bounce) and read on the GATT binder
@@ -4615,6 +4659,204 @@ class WhoopBleClient(
         readDisIdentity()
     }
 
+    /**
+     * Schedule the unbonded offload probe on a link that will carry NO CLIENT_HELLO (#1635).
+     *
+     * Called from BOTH no-hello paths for the same reason [scheduleUnbondedDisRead] is: the deferral path
+     * returns early, so scheduling it in the suppression path alone would skip exactly the people testing.
+     *
+     * Staggered AFTER the DIS chain rather than beside it. Both ride one serialized GATT queue, and the DIS
+     * reads are the cheaper, already-proven operation — letting four CCCD writes contend with them would
+     * make a failure in either unattributable to the one that caused it.
+     */
+    private fun scheduleUnbondedOffloadProbe() {
+        handler.postDelayed({ gatt?.let { beginUnbondedOffloadProbe(it) } }, BATTERY_ON_CONNECT_DELAY_MS * 4)
+    }
+
+    /**
+     * Stage 1: subscribe the puffin notify characteristics on an unbonded link.
+     *
+     * This is the operation nothing on record has ever completed. The offload arrives on fd4b0003/4/5/7,
+     * and those are subscribed in exactly one place — the post-CLIENT_HELLO branch — so a strap that never
+     * bonds never has them enabled and could not receive history even if it offered it. See
+     * [shouldProbeUnbondedOffload] for why the assumption that they need encryption has never been tested
+     * here.
+     */
+    @SuppressLint("MissingPermission")
+    private fun beginUnbondedOffloadProbe(g: BluetoothGatt) {
+        val refused = runCatching {
+            unbondedOffloadRefusedPrefKey(g.device.address)?.let {
+                context.getSharedPreferences(com.noop.ui.NoopPrefs.NAME, android.content.Context.MODE_PRIVATE)
+                    .getBoolean(it, false)
+            } ?: false
+        }.getOrDefault(false)
+        if (!shouldProbeUnbondedOffload(
+                isWhoop5 = connectedFamily == DeviceFamily.WHOOP5,
+                optedIn = PuffinExperiment.from(context).unbondedOffload,
+                bonded = didBond,
+                helloWrittenThisLink = helloWrittenThisLink,
+                alreadyProbedThisLink = unbondedProbeStartedThisLink,
+                previouslyRefused = refused,
+                silentLinksSoFar = unbondedProbeSilentLinks,
+            )
+        ) return
+        val svc = g.getService(WHOOP5_SERVICE) ?: return
+        // Claim the link BEFORE queueing, so a keep-alive drain landing between the two cannot start a
+        // second probe against the same four characteristics.
+        unbondedProbeStartedThisLink = true
+        var queued = 0
+        for (u in WHOOP5_NOTIFY_CHARS) svc.getCharacteristic(u)?.let { cccdQueue.add(it); queued++ }
+        // An empty queue drains INSTANTLY to the probe's own completion branch, which would announce
+        // "puffin chars subscribed — the strap serves them on an unencrypted link" having subscribed
+        // nothing at all. That is a fabricated finding in the one log this experiment exists to produce,
+        // so the claim is made only once there is something behind it.
+        if (queued == 0) {
+            log("Unbonded offload probe: the strap exposes none of the puffin notify chars on this link" +
+                " — nothing to subscribe, so there is no question to ask (#1635)")
+            return
+        }
+        unbondedProbeSubscribing = true
+        unbondedProbeSubscribed = 0
+        unbondedProbeEvidence = UnbondedProbeEvidence.NONE
+        log(unbondedProbeStartLine())
+        drainCccdQueue(g)
+    }
+
+    /**
+     * Stage 1 came back refused — the answer the probe exists to obtain.
+     *
+     * Latched per device so the strap declines once rather than on every reconnect, with the same carve-out
+     * [noteReadFailure] makes: a link with an OS pairing in flight can fail a descriptor write for reasons
+     * that are ours, not the strap's, and latching that would blame the strap for our own timing forever.
+     */
+    private fun noteUnbondedProbeRefused(uuid: java.util.UUID, status: Int) {
+        unbondedProbeSubscribing = false
+        unbondedProbeAwaitingReply = false
+        log(puffinSubscribeRefusedLine(uuid.toString(), gattWriteStatusLabel(status)))
+        if (explicitBondRequestedThisLink) {
+            log("Unbonded offload probe: not latching that refusal — a pairing was requested on this link," +
+                " so the failure is not attributable to the strap (#1635)")
+            return
+        }
+        runCatching {
+            unbondedOffloadRefusedPrefKey(lastDeviceAddress)?.let {
+                context.getSharedPreferences(com.noop.ui.NoopPrefs.NAME, android.content.Context.MODE_PRIVATE)
+                    .edit().putBoolean(it, true).apply()
+            }
+        }
+    }
+
+    /**
+     * Stage 2: the subscriptions landed, so ask the strap a read-only question.
+     *
+     * GET_CLOCK and not GET_DATA_RANGE, and certainly not SET_CLOCK. It changes nothing on the strap, so a
+     * strap that turns out not to be listening has had nothing done to it — and a COMMAND_RESPONSE to it is
+     * the first evidence in this whole thread that a puffin command written over an unencrypted link is
+     * parsed and answered rather than merely handed to the controller.
+     */
+    private fun askUnbondedProbeQuestion() {
+        unbondedProbeAwaitingReply = true
+        unbondedProbeAskedAtMs = System.currentTimeMillis()
+        log(unbondedProbeAskingLine(
+            subscribed = unbondedProbeSubscribed,
+            total = WHOOP5_NOTIFY_CHARS.size,
+            waitMs = UNBONDED_PROBE_REPLY_WAIT_MS,
+        ))
+        // WITHOUT response, and that is not a detail. A with-response write to fd4b0002 is precisely what
+        // the CLIENT_HELLO does, and on this strap it never completes - leaving writeInFlight set and the
+        // whole write queue starved behind a callback that is never coming. Using it here would risk the
+        // working live-HR state to ask a question that does not need it: the evidence this probe wants is
+        // the strap's own COMMAND_RESPONSE arriving on the notify chars, not an ATT acknowledgement of the
+        // write. DISABLE_ALARM and TOGGLE_REALTIME_HR already go out this way on exactly these links.
+        send(CommandNumber.GET_CLOCK, byteArrayOf())
+        handler.postDelayed({ concludeUnbondedProbe() }, UNBONDED_PROBE_REPLY_WAIT_MS)
+    }
+
+    /**
+     * Stage 2's verdict, and the handover to the ordinary offload if it passed.
+     *
+     * Runs on the timeout OR early on the first COMMAND_RESPONSE; [unbondedProbeAwaitingReply] makes it
+     * once-only, so the timer firing after an early success is a no-op rather than a second verdict.
+     *
+     * On success this sets [connectHandshakeDone] and NOTHING else about the bond state. `didBond` stays
+     * false deliberately: it is the record of an acked CLIENT_HELLO, which did not happen, and every one of
+     * its readers — the bond watchdog, the never-bonded self-drop counter, the stale-pairing guide — is
+     * reasoning about a handshake, not about whether history can flow. Setting it to unlock the offload is
+     * exactly the false-bond bug of 28 Aug, arrived at deliberately instead of by accident.
+     */
+    private fun concludeUnbondedProbe() {
+        if (!unbondedProbeAwaitingReply) return
+        unbondedProbeAwaitingReply = false
+        val waited = System.currentTimeMillis() - unbondedProbeAskedAtMs
+        if (unbondedProbeEvidence != UnbondedProbeEvidence.ANSWERS_COMMANDS) {
+            log(unbondedProbeSilentLine(
+                waitedMs = waited,
+                sawNotifications = unbondedProbeEvidence == UnbondedProbeEvidence.SERVES_NOTIFICATIONS,
+            ))
+            // Not latched per device: the subscriptions were accepted, so this says the strap did not
+            // answer THIS time, and the carve-out the refusal path makes for a pairing in flight would
+            // apply here with less certainty, not more. Once-per-LINK does not bound it, though — the
+            // probe re-runs on every reconnect — so silence spends a per-process budget instead of writing
+            // a permanent verdict from an ambiguous result.
+            unbondedProbeSilentLinks++
+            if (!unbondedProbeStillWorthAsking(unbondedProbeSilentLinks)) {
+                log(unbondedProbeGaveUpLine(unbondedProbeSilentLinks))
+            }
+            return
+        }
+        log(unbondedProbeAnsweredLine())
+        log(unbondedProbeBacklogCaveatLine())
+        // A genuine answer clears the silence budget: whatever the quiet links were, they were not this
+        // strap declining to talk, and a later reconnect must not inherit their count.
+        unbondedProbeSilentLinks = 0
+        // The proven 5/MG handshake tail, minus the hello that cannot happen: clock the strap, then offload.
+        // Clock-before-history is mandatory — an un-clocked 5/MG discards sensor data rather than banking it
+        // — and it is only reached here because the strap has just demonstrated it answers commands.
+        connectHandshakeDone = true
+        // requestSync ALSO gates on state.bonded, and for a 5/MG that flag is set by the live-HR path -
+        // the first plausible reading over the standard profile. A strap sitting on a charger streams no
+        // HR, so without this the probe would succeed, announce it, and then be refused by a second gate
+        // in silence - on exactly the strap you would reach for history sync on. Same flag and same
+        // meaning the live-HR path sets ("the link is established"), NOT encryptedBond, which remains the
+        // record of a genuine handshake and stays false because none happened.
+        _state.update { it.copy(bonded = true) }
+        // Deliberately NOT startKeepAlive(), which the live-HR path pairs with this same flag. The
+        // keep-alive bounces a link that has been quiet for 120s, and a strap on a charger with no offload
+        // yet running is exactly that - so arming it here would tear down the stable link this probe spent
+        // three stages establishing. The link needs no keep-alive to be probed; it needs to be left alone.
+        noteRebootReconnectIfNeeded()
+        // Also without response, for the reason above. The bonded tail uses with-response here, but it
+        // runs on a link that completed a handshake; this one has proved only that the strap ANSWERS, not
+        // that it acknowledges. The offload that follows still writes GET_DATA_RANGE and
+        // SEND_HISTORICAL_DATA with response through the ordinary path, so if with-response is the thing
+        // this strap will not do, the log separates that cleanly from the stages above rather than
+        // wedging the queue before any of them can be read.
+        send(CommandNumber.SET_CLOCK, setClockPayload())
+        send(CommandNumber.GET_CLOCK, byteArrayOf())
+        if (!backfillStarted) {
+            backfillStarted = true
+            handler.postDelayed({ requestSync(BackfillTrigger.CONNECT) }, INITIAL_BACKFILL_DELAY_MS)
+            startBackfillTimer()
+        }
+    }
+
+    /**
+     * Record what a puffin frame proves while the probe is listening.
+     *
+     * Called from the notify handler on the binder thread, which is why the conclusion hops to the main
+     * looper: [concludeUnbondedProbe] queues GATT writes and touches handler-scoped timers.
+     */
+    private fun noteUnbondedProbeFrame(parsed: com.noop.protocol.ParsedFrame) {
+        if (!unbondedProbeAwaitingReply) return
+        unbondedProbeEvidence = strongerProbeEvidence(
+            unbondedProbeEvidence,
+            unbondedProbeEvidenceOf(ok = parsed.ok, crcOk = parsed.crcOk, typeName = parsed.typeName),
+        )
+        if (unbondedProbeEvidence == UnbondedProbeEvidence.ANSWERS_COMMANDS) {
+            handler.post { concludeUnbondedProbe() }
+        }
+    }
+
     /** Chained second half of [readDisIdentity] — issued only after the serial read has landed. */
     private fun readDisHardwareRevision() {
         val g = gatt ?: return
@@ -6094,8 +6336,19 @@ class WhoopBleClient(
         ) {
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 log("Notify enable failed for ${descriptor.characteristic?.uuid}: status=$status")
+                // #1635: on the puffin notify chars during the unbonded probe, this IS the result — the
+                // generic line above cannot say so, because it is written for a transient stack failure
+                // and this is a verdict about whether the offload needs an encrypted link at all.
+                descriptor.characteristic?.uuid?.let { u ->
+                    if (unbondedProbeSubscribing && u in WHOOP5_NOTIFY_CHARS) noteUnbondedProbeRefused(u, status)
+                }
             } else {
                 log("Subscribed ${descriptor.characteristic?.uuid}")
+                // #1635: only a CONFIRMED puffin subscribe counts toward the probe's claim that the strap
+                // serves these chars unbonded.
+                descriptor.characteristic?.uuid?.let { u ->
+                    if (unbondedProbeSubscribing && u in WHOOP5_NOTIFY_CHARS) unbondedProbeSubscribed++
+                }
                 // A subscribe landed — replenish the shared BUSY-retry budget so a transient stall on
                 // one characteristic can't starve the others' retries (the counter is global).
                 cccdRetries = 0
@@ -6233,6 +6486,9 @@ class WhoopBleClient(
                     // live collector) instead of each re-parsing it — steady-state drops 2→1 parse per live
                     // frame. Family-aware, so it's correct for WHOOP4 and 5/MG alike.
                     val parsed = Framing.parseFrame(frame, connectedFamily)
+                    // #1635: while the unbonded probe is listening, this frame is the measurement. Gated
+                    // inside the call so a normal link pays one boolean read per frame.
+                    noteUnbondedProbeFrame(parsed)
                     // A frame replayed as part of the historical offload (type 47/48/… during a backfill)
                     recordGroundTruthImuFrame(frame)
                     // must not drive LIVE-only state (the charging pill). (PR #568 reimpl)
@@ -7998,6 +8254,7 @@ class WhoopBleClient(
                     // path uses — and without this the DIS read never runs for anyone with the pairing
                     // experiment on, which is precisely who is testing.
                     scheduleUnbondedDisRead()
+                    scheduleUnbondedOffloadProbe()
                     return
                 }
 
@@ -8044,6 +8301,7 @@ class WhoopBleClient(
                     // both harder to read. If the read is what tears a stable link down, that is
                     // unambiguous — and it latches, so it costs one link and not a loop.
                     scheduleUnbondedDisRead()
+                    scheduleUnbondedOffloadProbe()
                 }
             }
         }
@@ -8060,6 +8318,18 @@ class WhoopBleClient(
         if (cccdInFlight) return
         val ch = cccdQueue.poll()
         if (ch == null) {
+            // #1635: the unbonded probe's own drain. BEFORE the bonded branch because that one requires
+            // didBond, which the probe deliberately never sets — and this must not fall through to
+            // startSession, which would re-enter the hello decision on a link that already made it.
+            if (connectedFamily == DeviceFamily.WHOOP5 && unbondedProbeSubscribing) {
+                unbondedProbeSubscribing = false
+                if (unbondedProbeSubscribed == 0) {
+                    log(unbondedProbeNoSubscriptionsLine(WHOOP5_NOTIFY_CHARS.size))
+                    return
+                }
+                askUnbondedProbeQuestion()
+                return
+            }
             // 5/MG handshake tail: after the PUFFIN notify chars are subscribed (the post-CLIENT_HELLO
             // drain — didBond is true by then), clock the strap and only then kick the offload. An
             // un-clocked WHOOP 5 discards sensor data ("RTC timestamp … is invalid; not saving data to
@@ -9394,6 +9664,14 @@ class WhoopBleClient(
         // exactly the gap this stopwatch was added to close. It is overwritten by the next request, and a
         // stale value can only ever produce a large elapsed against a label that names what it measures.
         connectHandshakeDone = false
+        // #1635: the probe is per LINK — its whole basis is one stable link's behaviour, and carrying the
+        // "already asked" flag across a reconnect would let one silent link retire the experiment. The
+        // REFUSAL, by contrast, is persisted per device: that one is the strap's answer, not the link's.
+        unbondedProbeStartedThisLink = false
+        unbondedProbeSubscribed = 0
+        unbondedProbeSubscribing = false
+        unbondedProbeAwaitingReply = false
+        unbondedProbeEvidence = UnbondedProbeEvidence.NONE
         helloWrittenThisLink = false
         backfillDeferralsThisLink = 0
         // The deferral run is deliberately NOT cleared: it counts ACROSS connections AND across process

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2375,6 +2375,22 @@ class WhoopBleClient(
     @Volatile
     private var unbondedProbeSubscribed = 0
 
+    /**
+     * #1635: the probe's two scheduled steps as NAMED runnables, so [reset] can cancel them.
+     *
+     * Anonymous lambdas here were a real race, not a style point. The verdict is posted 8s out and a
+     * bouncing link reconnects in about 3 — so an OLD link's timer could fire while a NEW link's probe was
+     * mid-question, concluding it early with a "no reply" verdict it never waited for and charging the
+     * silence budget for a link that had answered nothing yet. Same instance for the early-success post, so
+     * one removeCallbacks cancels every path.
+     */
+    private val unbondedProbeVerdictRunnable = Runnable { concludeUnbondedProbe() }
+
+    /** #1635: the deferred probe start. Cancellable for the same reason — a stale start would arrive on a
+     *  link that never scheduled it. Its own gates would still hold, but a timer that outlives its link is
+     *  how surprises get in. */
+    private val unbondedProbeStartRunnable = Runnable { gatt?.let { beginUnbondedOffloadProbe(it) } }
+
     /** #1635: links that subscribed the puffin chars and drew no reply. Per PROCESS, deliberately NOT
      *  cleared by [reset] — its whole job is to bound a retry that spans reconnects. A refusal latches per
      *  device instead; silence is weaker evidence and gets a budget rather than a verdict. */
@@ -4670,7 +4686,8 @@ class WhoopBleClient(
      * make a failure in either unattributable to the one that caused it.
      */
     private fun scheduleUnbondedOffloadProbe() {
-        handler.postDelayed({ gatt?.let { beginUnbondedOffloadProbe(it) } }, BATTERY_ON_CONNECT_DELAY_MS * 4)
+        handler.removeCallbacks(unbondedProbeStartRunnable)
+        handler.postDelayed(unbondedProbeStartRunnable, BATTERY_ON_CONNECT_DELAY_MS * 4)
     }
 
     /**
@@ -4769,7 +4786,8 @@ class WhoopBleClient(
         // the strap's own COMMAND_RESPONSE arriving on the notify chars, not an ATT acknowledgement of the
         // write. DISABLE_ALARM and TOGGLE_REALTIME_HR already go out this way on exactly these links.
         send(CommandNumber.GET_CLOCK, byteArrayOf())
-        handler.postDelayed({ concludeUnbondedProbe() }, UNBONDED_PROBE_REPLY_WAIT_MS)
+        handler.removeCallbacks(unbondedProbeVerdictRunnable)
+        handler.postDelayed(unbondedProbeVerdictRunnable, UNBONDED_PROBE_REPLY_WAIT_MS)
     }
 
     /**
@@ -4853,7 +4871,7 @@ class WhoopBleClient(
             unbondedProbeEvidenceOf(ok = parsed.ok, crcOk = parsed.crcOk, typeName = parsed.typeName),
         )
         if (unbondedProbeEvidence == UnbondedProbeEvidence.ANSWERS_COMMANDS) {
-            handler.post { concludeUnbondedProbe() }
+            handler.post(unbondedProbeVerdictRunnable)
         }
     }
 
@@ -9667,6 +9685,10 @@ class WhoopBleClient(
         // #1635: the probe is per LINK — its whole basis is one stable link's behaviour, and carrying the
         // "already asked" flag across a reconnect would let one silent link retire the experiment. The
         // REFUSAL, by contrast, is persisted per device: that one is the strap's answer, not the link's.
+        // Cancel BEFORE clearing the flags: a runnable already dequeued and waiting to run would otherwise
+        // see the cleared state, which is harmless, but one still queued must not reach the next link.
+        handler.removeCallbacks(unbondedProbeStartRunnable)
+        handler.removeCallbacks(unbondedProbeVerdictRunnable)
         unbondedProbeStartedThisLink = false
         unbondedProbeSubscribed = 0
         unbondedProbeSubscribing = false

--- a/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DataSourcesScreen.kt
@@ -870,6 +870,12 @@ fun DataSourcesScreen(vm: AppViewModel) {
                 // encryptedBond, not bonded — see strapStatusTitle. A 5/MG streaming over the open
                 // profile has bonded == true with no pairing at all, and after #1635 hello suppression it
                 // stays there for good rather than passing through.
+                //
+                // "Live HR" reads a little wide here: bonded means REACHABLE, not currently streaming. It
+                // survives the stream stopping (take the strap off mid-link and it stays true), and the
+                // unbonded offload probe is a second way in — it sets bonded on a strap that answered a
+                // command without ever having sent an HR reading. Both are the same state: reachable over
+                // the open profile, never encrypted.
                 live.encryptedBond -> "Bonded, streaming." to StrandTone.Positive
                 live.bonded -> "Live HR (not fully paired)" to StrandTone.Warning
                 live.connected -> "Connected, pairing…" to StrandTone.Warning

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -585,6 +585,7 @@ fun SettingsScreen(
     val r22FlagCount = Whoop5Config.enableR22Sequence.size
     var broadcastHr by remember(rev) { mutableStateOf(puffinExperiment.broadcastHr) }
     var explicitBond by remember(rev) { mutableStateOf(puffinExperiment.explicitBond) }
+    var unbondedOffload by remember(rev) { mutableStateOf(puffinExperiment.unbondedOffload) }
     var helloDespiteRefusal by remember(rev) { mutableStateOf(puffinExperiment.helloDespiteBondRefusal) }
     // ECG raw-data gate (#891): the opt-in, the write result, and the attested-MG gate the buttons need.
     var ecgRawData by remember(rev) { mutableStateOf(puffinExperiment.ecgRawData) }
@@ -2350,6 +2351,41 @@ fun SettingsScreen(
                         ),
                         modifier = Modifier.semantics {
                             contentDescription = uiString(R.string.l10n_settings_screen_ask_android_to_pair_323fccbe)
+                        },
+                    )
+                }
+
+                // --- Try the historical offload on a link that never bonded. (#1635) ---
+                // The offload is gated on the CLIENT_HELLO ack, which a strap answering SMP "Pairing Not
+                // Supported" can never give — so the gate is ours, not the strap's, and the assumption it
+                // rests on has never been measured. This asks, read-only first.
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    Text(
+                        uiString(R.string.l10n_settings_screen_try_history_sync_without_pairing_experimental_54c31ea2),
+                        style = NoopType.subhead,
+                        color = Palette.textPrimary,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Switch(
+                        checked = unbondedOffload,
+                        onCheckedChange = {
+                            unbondedOffload = it
+                            puffinExperiment.unbondedOffload = it
+                        },
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = Palette.surfaceBase,
+                            checkedTrackColor = Palette.accent,
+                            uncheckedThumbColor = Palette.textSecondary,
+                            uncheckedTrackColor = Palette.surfaceInset,
+                            uncheckedBorderColor = Palette.hairline,
+                        ),
+                        modifier = Modifier.semantics {
+                            contentDescription =
+                                uiString(R.string.l10n_settings_screen_try_history_sync_without_pairing_33ae8594)
                         },
                     )
                 }

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -104,6 +104,7 @@ fun TestCentreScreen(vm: AppViewModel, onOpenGroundTruthCollector: () -> Unit = 
     var deepData by remember { mutableStateOf(puffinExperiment.isDeepDataEnabled) }
     var broadcastHr by remember { mutableStateOf(puffinExperiment.broadcastHr) }
     var explicitBond by remember { mutableStateOf(puffinExperiment.explicitBond) }
+    var unbondedOffload by remember { mutableStateOf(puffinExperiment.unbondedOffload) }
     var ecgRawData by remember { mutableStateOf(puffinExperiment.ecgRawData) }
     val r22DisableReport by vm.ble.r22DisableReport.collectAsStateWithLifecycle()
     val ecgGateReport by vm.ble.ecgRawDataGate.collectAsStateWithLifecycle()
@@ -243,6 +244,19 @@ fun TestCentreScreen(vm: AppViewModel, onOpenGroundTruthCollector: () -> Unit = 
                         onCheckedChange = {
                             explicitBond = it
                             puffinExperiment.explicitBond = it
+                        },
+                    )
+                    DeveloperToggleRow(
+                        title = stringResource(R.string.raw_diag_unbonded_offload),
+                        detail = "Subscribes the puffin notify characteristics on a link with no " +
+                            "CLIENT_HELLO, then asks the strap a read-only GET_CLOCK. If it answers, the " +
+                            "clock is set and history is requested. Once per link, and never again on a " +
+                            "strap that refuses. Takes effect on the next connect, not this one. " +
+                            "Leave it off unless you are testing #1635.",
+                        checked = unbondedOffload,
+                        onCheckedChange = {
+                            unbondedOffload = it
+                            puffinExperiment.unbondedOffload = it
                         },
                     )
                     DeveloperToggleRow(

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1585,6 +1585,8 @@
     <string name="l10n_settings_screen_this_is_a_plain_unencrypted_archive_b0dfe63d">Das ist ein einfaches, unverschlüsseltes Archiv — wer die Datei bekommt, kann sie mit jedem Zip-Programm öffnen. Bewahren Sie sie an einem Ort auf, dem Sie vertrauen.</string>
     <string name="l10n_settings_screen_this_restarts_the_roughly_4_night_c610a93d">Das startet den etwa 4-nächtigen Aufbau für Ladung und deine HRV-Basislinie neu. Dein Verlauf bleibt. Nutze es, wenn eine schlechte erste Woche, etwa krank getragen, deine Basislinie verzerrt hat.</string>
     <string name="l10n_settings_screen_trend_charts_19085c81">Trenddiagramme</string>
+    <string name="l10n_settings_screen_try_history_sync_without_pairing_experimental_54c31ea2">Verlaufssynchronisierung ohne Kopplung versuchen (experimentell)</string>
+    <string name="l10n_settings_screen_try_history_sync_without_pairing_33ae8594">Verlaufssynchronisierung ohne Kopplung versuchen</string>
     <string name="l10n_settings_screen_try_whoop_5_mg_protocol_probes_1d584653">WHOOP 5/MG-Protokolltests ausprobieren</string>
     <string name="l10n_settings_screen_units_12748281">Einheiten</string>
     <string name="l10n_settings_screen_unlock_whoop_5_mg_deep_data_2f2bd226">WHOOP-5/MG-Tiefendaten freischalten (R22)</string>
@@ -2623,6 +2625,7 @@
     <string name="raw_diag_protocol_probes">Protokolltests</string>
     <string name="raw_diag_broadcast_hr">Herzfrequenz vom Band übertragen</string>
     <string name="raw_diag_pair">Android um Kopplung bitten</string>
+    <string name="raw_diag_unbonded_offload">Verlaufssynchronisierung ohne Kopplung versuchen</string>
     <string name="raw_diag_r22">Altes R22-Feature-Flag-Experiment</string>
     <string name="raw_diag_r22_enable">Alte R22-Aktivierungssequenz senden</string>
     <string name="raw_diag_r22_clear">R22-Flags auf dem Band löschen</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1385,6 +1385,8 @@
     <string name="l10n_settings_screen_this_is_a_plain_unencrypted_archive_b0dfe63d">Es un archivo sencillo y sin cifrar: cualquiera que consiga el archivo puede abrirlo con cualquier herramienta zip. Guárdelo en un lugar de confianza.</string>
     <string name="l10n_settings_screen_this_restarts_the_roughly_4_night_c610a93d">Esto reinicia el período de unas 4 noches de construcción de la Carga y tu línea base de VFC. Tu historial se conserva. Úsalo si una mala primera semana, como usarla estando enfermo, desvió tu línea base.</string>
     <string name="l10n_settings_screen_trend_charts_19085c81">Gráficos de tendencias</string>
+    <string name="l10n_settings_screen_try_history_sync_without_pairing_experimental_54c31ea2">Probar la sincronización del historial sin vinculación (experimental)</string>
+    <string name="l10n_settings_screen_try_history_sync_without_pairing_33ae8594">Probar la sincronización del historial sin vinculación</string>
     <string name="l10n_settings_screen_try_whoop_5_mg_protocol_probes_1d584653">Prueba las sondas del protocolo WHOOP 5/MG</string>
     <string name="l10n_settings_screen_units_12748281">Unidades</string>
     <string name="l10n_settings_screen_unlock_whoop_5_mg_deep_data_2f2bd226">Desbloquear datos profundos de WHOOP 5/MG (R22)</string>
@@ -2608,6 +2610,7 @@
     <string name="raw_diag_protocol_probes">Sondas de protocolo</string>
     <string name="raw_diag_broadcast_hr">Transmitir frecuencia cardíaca desde la pulsera</string>
     <string name="raw_diag_pair">Pedir a Android que vincule</string>
+    <string name="raw_diag_unbonded_offload">Probar la sincronización del historial sin vinculación</string>
     <string name="raw_diag_r22">Experimento antiguo de indicadores R22</string>
     <string name="raw_diag_r22_enable">Enviar secuencia de activación R22 antigua</string>
     <string name="raw_diag_r22_clear">Borrar indicadores R22 de la pulsera</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1403,6 +1403,8 @@
     <string name="l10n_settings_screen_this_is_a_plain_unencrypted_archive_b0dfe63d">C\'est une archive simple, non chiffrée : quiconque récupère le fichier peut l\'ouvrir avec n\'importe quel outil zip. Conservez-le dans un endroit de confiance.</string>
     <string name="l10n_settings_screen_this_restarts_the_roughly_4_night_c610a93d">Cela relance la montée en puissance d\'environ 4 nuits pour la charge et votre référence VFC. Votre historique reste. Utilisez-la si une mauvaise première semaine, comme le porter en étant malade, a faussé votre référence.</string>
     <string name="l10n_settings_screen_trend_charts_19085c81">Tableaux de tendances</string>
+    <string name="l10n_settings_screen_try_history_sync_without_pairing_experimental_54c31ea2">Essayer la synchronisation de l\'historique sans appairage (expérimental)</string>
+    <string name="l10n_settings_screen_try_history_sync_without_pairing_33ae8594">Essayer la synchronisation de l\'historique sans appairage</string>
     <string name="l10n_settings_screen_try_whoop_5_mg_protocol_probes_1d584653">Essayer les sondes de protocole WHOOP 5/MG</string>
     <string name="l10n_settings_screen_units_12748281">Unités</string>
     <string name="l10n_settings_screen_unlock_whoop_5_mg_deep_data_2f2bd226">Débloquer les données approfondies WHOOP 5/MG (R22)</string>
@@ -2607,6 +2609,7 @@
     <string name="raw_diag_protocol_probes">Sondes de protocole</string>
     <string name="raw_diag_broadcast_hr">Diffuser la fréquence cardiaque du bracelet</string>
     <string name="raw_diag_pair">Demander l’appairage à Android</string>
+    <string name="raw_diag_unbonded_offload">Essayer la synchronisation de l\'historique sans appairage</string>
     <string name="raw_diag_r22">Ancienne expérience d’indicateurs R22</string>
     <string name="raw_diag_r22_enable">Envoyer l’ancienne séquence d’activation R22</string>
     <string name="raw_diag_r22_clear">Effacer les indicateurs R22 du bracelet</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -1542,6 +1542,8 @@
     <string name="l10n_settings_screen_this_is_a_plain_unencrypted_archive_b0dfe63d">Jest to zwykłe, niezaszyfrowane archiwum — każdy, kto otrzyma plik, może go otworzyć za pomocą dowolnego narzędzia zip. Przechowuj go w zaufanym miejscu.</string>
     <string name="l10n_settings_screen_this_restarts_the_roughly_4_night_c610a93d">Spowoduje to ponowne uruchomienie trwającego około 4 dni tworzenia Energia i linii bazowej HRV. Twoja historia zostaje. Użyj go, jeśli zły pierwszy tydzień, np. noszenie go podczas choroby, zaburzy Twoją linię bazową.</string>
     <string name="l10n_settings_screen_trend_charts_19085c81">Wykresy trendów</string>
+    <string name="l10n_settings_screen_try_history_sync_without_pairing_experimental_54c31ea2">Spróbuj synchronizacji historii bez parowania (eksperymentalne)</string>
+    <string name="l10n_settings_screen_try_history_sync_without_pairing_33ae8594">Spróbuj synchronizacji historii bez parowania</string>
     <string name="l10n_settings_screen_try_whoop_5_mg_protocol_probes_1d584653">Wypróbuj sondy protokołu WHOOP 5/MG</string>
     <string name="l10n_settings_screen_units_12748281">Jednostki</string>
     <string name="l10n_settings_screen_unlock_whoop_5_mg_deep_data_2f2bd226">Odblokuj głębokie dane WHOOP 5/MG (R22)</string>
@@ -2612,6 +2614,7 @@
     <string name="raw_diag_protocol_probes">Testy protokołu</string>
     <string name="raw_diag_broadcast_hr">Transmituj tętno z opaski</string>
     <string name="raw_diag_pair">Poproś Androida o sparowanie</string>
+    <string name="raw_diag_unbonded_offload">Spróbuj synchronizacji historii bez parowania</string>
     <string name="raw_diag_r22">Starszy eksperyment flag R22</string>
     <string name="raw_diag_r22_enable">Wyślij starszą sekwencję włączenia R22</string>
     <string name="raw_diag_r22_clear">Wyczyść flagi R22 na opasce</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1548,6 +1548,8 @@
     <string name="l10n_settings_screen_this_is_a_plain_unencrypted_archive_b0dfe63d">É um arquivo simples, não encriptado — quem tiver o ficheiro pode abri-lo com qualquer ferramenta zip. Guarda-o num sítio de confiança.</string>
     <string name="l10n_settings_screen_this_restarts_the_roughly_4_night_c610a93d">Isto reinicia a acumulação de aproximadamente 4 noites para a Carga e a tua linha de base de HRV. A tua histórico permanece. Usa-o se uma má primeira semana, como usá-lo durante uma doença, definir a tua linha de base.</string>
     <string name="l10n_settings_screen_trend_charts_19085c81">Gráficos de tendências</string>
+    <string name="l10n_settings_screen_try_history_sync_without_pairing_experimental_54c31ea2">Tentar sincronizar o histórico sem emparelhamento (experimental)</string>
+    <string name="l10n_settings_screen_try_history_sync_without_pairing_33ae8594">Tentar sincronizar o histórico sem emparelhamento</string>
     <string name="l10n_settings_screen_try_whoop_5_mg_protocol_probes_1d584653">Experimente as sondagens de protocolo WHOOP 5/MG</string>
     <string name="l10n_settings_screen_units_12748281">Unidades</string>
     <string name="l10n_settings_screen_unlock_whoop_5_mg_deep_data_2f2bd226">Desbloquear dados profundos do WHOOP 5/MG (R22)</string>
@@ -2600,6 +2602,7 @@
     <string name="raw_diag_protocol_probes">Sondas de protocolo</string>
     <string name="raw_diag_broadcast_hr">Transmitir frequência cardíaca da bracelete</string>
     <string name="raw_diag_pair">Pedir ao Android para emparelhar</string>
+    <string name="raw_diag_unbonded_offload">Tentar sincronizar o histórico sem emparelhamento</string>
     <string name="raw_diag_r22">Experiência antiga de indicadores R22</string>
     <string name="raw_diag_r22_enable">Enviar sequência antiga de ativação R22</string>
     <string name="raw_diag_r22_clear">Limpar indicadores R22 da bracelete</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1528,6 +1528,8 @@
     <string name="l10n_settings_screen_this_is_a_plain_unencrypted_archive_b0dfe63d">这是一个未加密的普通压缩包——任何拿到文件的人都能用任意压缩工具打开它。请把它存放在你信任的地方。</string>
     <string name="l10n_settings_screen_this_restarts_the_roughly_4_night_c610a93d">这将重新启动大约需要 4 个晚上的充能(Charge)与 HRV 基准建立过程。您的历史数据都会被保留下来。如果因为您第一周佩戴时状态不佳（比如生病），导致基线严重偏离了正常水平，请使用此功能。</string>
     <string name="l10n_settings_screen_trend_charts_19085c81">趋势图表</string>
+    <string name="l10n_settings_screen_try_history_sync_without_pairing_experimental_54c31ea2">尝试在未配对状态下同步历史数据（实验性）</string>
+    <string name="l10n_settings_screen_try_history_sync_without_pairing_33ae8594">尝试在未配对状态下同步历史数据</string>
     <string name="l10n_settings_screen_try_whoop_5_mg_protocol_probes_1d584653">尝试触发 WHOOP 5.0/MG 协议探针</string>
     <string name="l10n_settings_screen_units_12748281">度量单位</string>
     <string name="l10n_settings_screen_unlock_whoop_5_mg_deep_data_2f2bd226">解锁 WHOOP 5.0/MG 的深层数据 (R22协议)</string>
@@ -2521,6 +2523,7 @@
     <string name="raw_diag_protocol_probes">协议探测</string>
     <string name="raw_diag_broadcast_hr">从手环广播心率</string>
     <string name="raw_diag_pair">请求 Android 配对</string>
+    <string name="raw_diag_unbonded_offload">尝试在未配对状态下同步历史数据</string>
     <string name="raw_diag_r22">旧版 R22 功能标志实验</string>
     <string name="raw_diag_r22_enable">发送旧版 R22 启用序列</string>
     <string name="raw_diag_r22_clear">清除手环上的 R22 标志</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1681,6 +1681,8 @@
     <string name="l10n_settings_screen_this_is_a_plain_unencrypted_archive_b0dfe63d">This is a plain, unencrypted archive — anyone who gets the file can open it with any zip tool. Store it somewhere you trust.</string>
     <string name="l10n_settings_screen_this_restarts_the_roughly_4_night_c610a93d">This restarts the roughly 4-night build-up for Charge and your HRV baseline. Your history stays. Use it if a bad first week, like wearing it while sick, set your baseline off.</string>
     <string name="l10n_settings_screen_trend_charts_19085c81">Trend charts</string>
+    <string name="l10n_settings_screen_try_history_sync_without_pairing_experimental_54c31ea2">Try history sync without pairing (experimental)</string>
+    <string name="l10n_settings_screen_try_history_sync_without_pairing_33ae8594">Try history sync without pairing</string>
     <string name="l10n_settings_screen_try_whoop_5_mg_protocol_probes_1d584653">Try WHOOP 5/MG protocol probes</string>
     <string name="l10n_settings_screen_units_12748281">Units</string>
     <string name="l10n_settings_screen_unlock_whoop_5_mg_deep_data_2f2bd226">Unlock WHOOP 5/MG deep data (R22)</string>
@@ -2636,6 +2638,7 @@
     <string name="raw_diag_protocol_probes">Protocol probes</string>
     <string name="raw_diag_broadcast_hr">Broadcast heart rate from the strap</string>
     <string name="raw_diag_pair">Ask Android to pair</string>
+    <string name="raw_diag_unbonded_offload">Try history sync without pairing</string>
     <string name="raw_diag_r22">Legacy R22 feature-flag experiment</string>
     <string name="raw_diag_r22_enable">Send legacy R22 enable sequence</string>
     <string name="raw_diag_r22_clear">Clear legacy R22 flags on strap</string>

--- a/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
@@ -1,0 +1,240 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The probe's whole value is that it stops. Every gate below is one of the ways this area has previously
+ * produced a loop that retries something which cannot work, so they are pinned individually rather than
+ * through one happy-path case.
+ */
+class UnbondedOffloadProbeTest {
+
+    private fun probe(
+        isWhoop5: Boolean = true,
+        optedIn: Boolean = true,
+        bonded: Boolean = false,
+        helloWrittenThisLink: Boolean = false,
+        alreadyProbedThisLink: Boolean = false,
+        previouslyRefused: Boolean = false,
+        silentLinksSoFar: Int = 0,
+    ) = shouldProbeUnbondedOffload(
+        isWhoop5 = isWhoop5,
+        optedIn = optedIn,
+        bonded = bonded,
+        helloWrittenThisLink = helloWrittenThisLink,
+        alreadyProbedThisLink = alreadyProbedThisLink,
+        previouslyRefused = previouslyRefused,
+        silentLinksSoFar = silentLinksSoFar,
+    )
+
+    @Test
+    fun `an opted-in 5MG on a stable unbonded link is exactly the case this exists for`() {
+        assertTrue(probe())
+    }
+
+    @Test
+    fun `a WHOOP4 is never probed`() {
+        // 4.0 bonds normally and reaches the offload through the proven path; there is nothing to ask it.
+        assertFalse(probe(isWhoop5 = false))
+    }
+
+    @Test
+    fun `it is off unless the user opted in`() {
+        assertFalse(probe(optedIn = false))
+    }
+
+    @Test
+    fun `a bonded strap uses the proven handshake instead`() {
+        assertFalse(probe(bonded = true))
+    }
+
+    /**
+     * The gate that keeps the ANSWER attributable. On a link carrying a hello the bond watchdog has about
+     * five seconds before it bounces us, so a subscribe failure there could be the strap's policy or could
+     * be our own teardown landing mid-write — indistinguishable, which is precisely the ambiguity that made
+     * the CLIENT_HELLO unreadable for eleven weeks. The one attempt on record (28 Aug 13:25:00) failed this
+     * way and proved nothing.
+     */
+    @Test
+    fun `a link that carries a hello cannot answer this question`() {
+        assertFalse(probe(helloWrittenThisLink = true))
+    }
+
+    @Test
+    fun `it runs once per link, not once per keep-alive tick`() {
+        // enableLiveNotifications drains the same CCCD queue every 30s, so without this the probe would
+        // re-enter its own completion branch on every keep-alive for the life of the connection.
+        assertFalse(probe(alreadyProbedThisLink = true))
+    }
+
+    @Test
+    fun `a refusal is remembered, so the strap says no once`() {
+        assertFalse(probe(previouslyRefused = true))
+    }
+
+    /**
+     * Silence is not latched per device, so once-per-link does NOT bound it — the probe re-runs on every
+     * reconnect, and a strap that reconnects often would re-ask a question already answered the same way.
+     * That is the unbounded retry this whole area keeps producing, so silence spends a per-process budget.
+     */
+    @Test
+    fun `repeated silence retires the probe`() {
+        assertTrue(probe(silentLinksSoFar = UNBONDED_PROBE_MAX_SILENT_LINKS - 1))
+        assertFalse(probe(silentLinksSoFar = UNBONDED_PROBE_MAX_SILENT_LINKS))
+        assertFalse(probe(silentLinksSoFar = UNBONDED_PROBE_MAX_SILENT_LINKS + 5))
+    }
+
+    @Test
+    fun `the give-up line says why it stopped, not merely that it did`() {
+        // The CLIENT_HELLO's suppression stopped silently and cost eleven weeks of unreadable captures.
+        val line = unbondedProbeGaveUpLine(3)
+        assertTrue(line.contains("serves those characteristics unbonded"))
+        assertTrue(line.contains("does not act on commands"))
+    }
+
+    @Test
+    fun `the refusal key is per device and case-insensitive`() {
+        // The same strap presents its address in different cases across sessions; a case-sensitive key
+        // would latch a second time under a second name and re-ask a strap that already refused.
+        assertEquals(
+            unbondedOffloadRefusedPrefKey("AA:BB:CC:DD:EE:FF"),
+            unbondedOffloadRefusedPrefKey("aa:bb:cc:dd:ee:ff"),
+        )
+        assertNull(unbondedOffloadRefusedPrefKey(null))
+        assertNull(unbondedOffloadRefusedPrefKey("   "))
+    }
+
+    /**
+     * The distinction the whole probe turns on. A frame proves the strap SERVES the puffin characteristics
+     * unbonded; only a reply proves it ACTS on what we write. Collapsing the two is how the false bond of
+     * 28 Aug read an unrelated DISABLE_ALARM completion as an answer to the hello.
+     */
+    @Test
+    fun `only a command response proves the command channel`() {
+        assertEquals(
+            UnbondedProbeEvidence.ANSWERS_COMMANDS,
+            unbondedProbeEvidenceOf(ok = true, crcOk = true, typeName = "COMMAND_RESPONSE"),
+        )
+        assertEquals(
+            UnbondedProbeEvidence.SERVES_NOTIFICATIONS,
+            unbondedProbeEvidenceOf(ok = true, crcOk = true, typeName = "REALTIME_DATA"),
+        )
+    }
+
+    /**
+     * Noise must never be read as proof. The probe runs on a link whose right to carry this traffic is the
+     * open question, so a frame that fails its CRC could as easily be the stack handing us a fragment as
+     * the strap answering — and counting it would let the probe conclude the opposite of the truth.
+     */
+    @Test
+    fun `an unverified frame is not evidence of anything`() {
+        assertEquals(
+            UnbondedProbeEvidence.NONE,
+            unbondedProbeEvidenceOf(ok = true, crcOk = false, typeName = "COMMAND_RESPONSE"),
+        )
+        // No CRC to check is not a pass either: `ok` alone is only an envelope check.
+        assertEquals(
+            UnbondedProbeEvidence.NONE,
+            unbondedProbeEvidenceOf(ok = true, crcOk = null, typeName = "COMMAND_RESPONSE"),
+        )
+        assertEquals(
+            UnbondedProbeEvidence.NONE,
+            unbondedProbeEvidenceOf(ok = false, crcOk = true, typeName = "COMMAND_RESPONSE"),
+        )
+        assertEquals(
+            UnbondedProbeEvidence.NONE,
+            unbondedProbeEvidenceOf(ok = true, crcOk = true, typeName = "   "),
+        )
+    }
+
+    /**
+     * The verdict must not depend on arrival order. Once realtime HR is streaming, REALTIME_DATA frames
+     * follow the COMMAND_RESPONSE continuously, and a last-one-wins reading would walk the conclusion back
+     * down to the weaker finding and report "not answering" on a strap that had just answered.
+     */
+    @Test
+    fun `the strongest evidence on the link is what stands`() {
+        val answered = strongerProbeEvidence(
+            UnbondedProbeEvidence.ANSWERS_COMMANDS,
+            UnbondedProbeEvidence.SERVES_NOTIFICATIONS,
+        )
+        assertEquals(UnbondedProbeEvidence.ANSWERS_COMMANDS, answered)
+        assertEquals(
+            UnbondedProbeEvidence.ANSWERS_COMMANDS,
+            strongerProbeEvidence(UnbondedProbeEvidence.NONE, UnbondedProbeEvidence.ANSWERS_COMMANDS),
+        )
+        assertEquals(
+            UnbondedProbeEvidence.SERVES_NOTIFICATIONS,
+            strongerProbeEvidence(UnbondedProbeEvidence.SERVES_NOTIFICATIONS, UnbondedProbeEvidence.NONE),
+        )
+    }
+
+    /**
+     * The silence line has to say which of the two silences this was. "Subscribed but nothing arrived" and
+     * "subscribed and frames arrived, but no reply" are different facts about the strap, and a capture that
+     * blurred them would send the next reader after the wrong thing.
+     */
+    @Test
+    fun `the silent verdict distinguishes an idle transport from an unanswering strap`() {
+        assertTrue(unbondedProbeSilentLine(5_000L, sawNotifications = true).contains("frames did arrive"))
+        assertTrue(unbondedProbeSilentLine(5_000L, sawNotifications = false).contains("nothing arrived"))
+        // Both must carry the wait, or the line cannot be judged against the capture's timestamps.
+        assertTrue(unbondedProbeSilentLine(5_000L, sawNotifications = true).contains("5000ms"))
+    }
+
+    /**
+     * The asking line must report what was CONFIRMED, not what was attempted. A CCCD write abandoned after
+     * its busy retries reaches the same completion path as four clean subscribes, so a flat "subscribed"
+     * would put a partial result in the capture as a whole one.
+     */
+    @Test
+    fun `the asking line reports the confirmed count, not the attempted one`() {
+        assertTrue(unbondedProbeAskingLine(3, 4, 8_000L).contains("3 of 4"))
+        assertTrue(unbondedProbeAskingLine(4, 4, 8_000L).contains("4 of 4"))
+    }
+
+    /**
+     * The third stage-1 outcome, and the one easiest to mis-file. Nothing confirmed AND nothing refused is
+     * the absence of an answer, not an answer — reporting it as either would put a fact in the capture that
+     * the link never established.
+     */
+    @Test
+    fun `nothing confirmed and nothing refused is neither a yes nor a no`() {
+        val line = unbondedProbeNoSubscriptionsLine(4)
+        assertTrue(line.contains("none was refused"))
+        assertTrue(line.contains("proves nothing"))
+    }
+
+    /**
+     * The expectation has to be set BEFORE the transfer, not after an empty one comes back. A strap that
+     * has never been clocked has never been told to persist to flash, so "nothing banked" is a plausible
+     * SUCCESS of the probe, and a reader who has not been told that will read it as a failure.
+     */
+    @Test
+    fun `the backlog caveat names the un-clocked strap, not a broken probe`() {
+        val line = unbondedProbeBacklogCaveatLine()
+        assertTrue(line.contains("never been clocked"))
+        assertTrue(line.contains("from now on"))
+    }
+
+    @Test
+    fun `every probe line names the issue it belongs to`() {
+        // A capture line without its issue number costs the next reader the search that this whole thread
+        // has already paid for repeatedly.
+        val lines = listOf(
+            unbondedProbeStartLine(),
+            puffinSubscribeRefusedLine("fd4b0003", "GATT_INSUFFICIENT_AUTHENTICATION(5)"),
+            unbondedProbeAskingLine(subscribed = 4, total = 4, waitMs = 5_000L),
+            unbondedProbeNoSubscriptionsLine(4),
+            unbondedProbeGaveUpLine(3),
+            unbondedProbeSilentLine(5_000L, sawNotifications = false),
+            unbondedProbeAnsweredLine(),
+            unbondedProbeBacklogCaveatLine(),
+        )
+        for (line in lines) assertTrue(line, line.contains("#1635"))
+    }
+}


### PR DESCRIPTION
Asks whether the WHOOP 5/MG historical offload actually requires a bond — a question the app has never put to a strap, because our own gate stops it before the strap gets a say.

## The gate is ours

`beginBackfill` refuses while `connectHandshakeDone` is false. For a 5/MG that flag is set in exactly one place, behind the `CLIENT_HELLO` ack. On a strap answering SMP `Pairing Not Supported` the ack can never arrive, so the gate never opens and the offload is never attempted. `requestSync`'s own `bonded` check already passes on these links — the live-HR path sets it — so this single line is the whole blocker.

## Why the premise is worth re-testing

The link underneath is not the broken thing it was taken for:

- with the hello suppressed it stays up for tens of minutes (one capture holds it 2431s)
- live HR streams over the standard profile throughout
- the unbonded DIS identity read succeeds (#490 / #1455)
- `DISABLE_ALARM` and `TOGGLE_REALTIME_HR` are written to `fd4b0002` without the stack objecting

Every bounce in the captures traces to the bond watchdog after an unanswered hello, never to the link itself.

## What is genuinely unknown, stated exactly

Those two puffin writes go out **without response**, so their `GATT_SUCCESS` is Android reporting a Write Command handed to the controller. It is a local fact and says nothing about whether the strap parsed it.

And the offload does not arrive on `fd4b0002` at all — it arrives on the notify characteristics `fd4b0003/4/5/7`, which this app has **never once subscribed on a healthy unbonded link**. The only attempt on record (28 Aug, 13:25:00) rode the false bond — a `DISABLE_ALARM` completion misread as a hello ack — produced `writeDescriptor busy; retry 1/8`, an Android queue error, and the link died 4s later with the hello still outstanding. No answer was obtained.

The belief that it cannot work is a comment, not a measurement: `BLEManager.swift:5787` records the strap rejecting those subscriptions with "Authentication is insufficient", from a 5/MG still bonded to the official WHOOP app (issue #17). That may well be right. It has never been tested against a strap in this state on a link that stays up long enough to hear the answer.

## The staged probe

Each stage falsifies the next:

1. **Subscribe** the four puffin notify chars. An insufficient-authentication status here is the whole answer — the offload needs an encrypted link, and #1635 is a wall rather than a gate.
2. **`GET_CLOCK`** — read-only on purpose. Nothing is changed on a strap that turns out not to be listening, and a `COMMAND_RESPONSE` is the first hard evidence that puffin commands are acted on unbonded.
3. **`SET_CLOCK` + the ordinary offload** — the existing hardware-proven sequence, reached only after the strap has demonstrated it answers.

Default off, its own switch (Settings → Experimental, and Test Centre → 5/MG protocol diagnostics), like every other probe that sends to the strap.

## Two things it deliberately does not do

**It never sets `didBond`.** That flag is the record of an acked hello, and every one of its readers — the bond watchdog, the never-bonded self-drop counter, the stale-pairing guide — is reasoning about a handshake, not about whether history can flow. Setting it to unlock the offload is exactly the false-bond bug of 28 Aug, arrived at on purpose instead of by accident. `connectHandshakeDone` is the only flag the probe touches.

**Its own writes go out without response.** A with-response write to `fd4b0002` is precisely what the hello does, and on this strap it never completes — leaving `writeInFlight` set and the write queue starved behind a callback that is never coming. Using it here would risk the working live-HR state to ask a question that does not need it; the evidence wanted is the strap's own `COMMAND_RESPONSE` on the notify chars, not an ATT acknowledgement of the write. The offload that follows still writes `GET_DATA_RANGE` and `SEND_HISTORICAL_DATA` with response through the ordinary path, so if with-response is the thing this strap will not do, the log separates that cleanly from the stages above.

## Self-limiting in both directions

- a **refusal** latches per device — the strap declines once, not on every reconnect
- **silence** spends a small per-process budget (3 links) rather than re-asking forever; once-per-link does not bound a probe that re-runs on every reconnect
- a refusal is **not** latched when we put a pairing in flight on that link, the same carve-out `noteReadFailure` makes — a descriptor write during SMP can fail for reasons that are ours

## Expectation set up front

The log says at the moment the probe succeeds, not after an empty transfer comes back: this strap has never been clocked by NOOP, and an un-clocked 5/MG does not save sensor data to flash. `GET_DATA_RANGE` may legitimately report little or nothing banked — which would mean **history works from now on, not that the probe failed**. That is why the read-only range query is the stage before the transfer rather than after it.

## Scope

Android only, matching the explicit-bond experiment (#1635). A Swift twin is worth writing if and only if Android's answer is yes.

## Review

Three passes, each of which found something real:

- the "subscribed" claim is backed by the count of **confirmed** subscribes, not by reaching the drain-empty branch — a CCCD write abandoned after its busy retries arrives there identically to a clean one, and a flat claim would put a partial result in the capture as a whole one
- `state.bonded` is set on success, or an off-wrist strap would pass the probe and then be refused by a second gate **in silence** — on exactly the strap you would reach for history sync on
- silence needed a budget at all; the first version was bounded only per link

Also caught: the new branch had been inserted between the bonded branch's doc block and its `if`, and one comment still claimed once-per-link bounded the retry after that had stopped being true.

## Verification

- `4889` unit tests, 0 failures (`+18` for the probe's pure logic)
- `lintVitalFullRelease`, doc-comment lint, and the i18n `--ci` gate all clean
- six Android locales for the new copy
- **not** hardware-validated — that is the entire point, and the next step is a testing build

Related to #1635.
