### PR TITLE
WHOOP 5/MG: let the offload probe supersede the handshake, or it never runs

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -26,7 +26,7 @@ android {
         applicationId = "com.noop.whoop"
         minSdk = 26
         targetSdk = 34
-        versionCode = 389
+        versionCode = 390
         versionName = "10.6.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
+++ b/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
@@ -96,6 +96,54 @@ internal fun unbondedProbeGaveUpLine(silentLinks: Int): String =
         " written to them. Not asking again this session. History offload is unavailable until the strap" +
         " completes a handshake (#1635)."
 
+/**
+ * Does opting into the unbonded offload probe replace the handshake attempt on this connect?
+ *
+ * Found in the field, and it is the difference between the probe running and never running at all.
+ * [shouldProbeUnbondedOffload] requires a link carrying NO hello, because a refusal on a link the bond
+ * watchdog is about to bounce is unattributable. But the probe is only SCHEDULED from the two no-hello
+ * branches, and on this strap neither is reached in practice: across 41 captures the suppression latch
+ * fired in three, all on one day, and never since — while the explicit-bond deferral yields after its
+ * first connect by design (#1642), so every subsequent link writes a hello. The probe would have sat
+ * behind a state the app almost never enters.
+ *
+ * The resolution is not to loosen the attributability gate, which is what makes the answer worth having.
+ * It is to notice that these are MUTUALLY EXCLUSIVE experiments: "does the hello work" and "is the hello
+ * needed at all" cannot both be asked of one link, because asking the first is what destroys the second's
+ * link. Turning this switch on is choosing the second question, so it supersedes the handshake for that
+ * connect — both the explicit pairing request and the hello itself.
+ *
+ * [userInitiated] still wins, exactly as it does for the suppression latch. Pressing Connect is an
+ * explicit request for the handshake, and it must never be answered with a different experiment.
+ *
+ * Narrow on purpose: 5/MG only, never on a strap that has already bonded (that one reaches the offload the
+ * proven way and has nothing to prove), and default off, so no one who has not asked for this is affected.
+ */
+internal fun unbondedProbeSupersedesHandshake(
+    optedIn: Boolean,
+    isWhoop5: Boolean,
+    appLevelBonded: Boolean,
+    userInitiated: Boolean,
+): Boolean = optedIn && isWhoop5 && !appLevelBonded && !userInitiated
+
+/**
+ * Said once per superseded connect, because a hello that is absent looks identical to one that failed
+ * silently — the ambiguity that made #1635 unreadable for eleven weeks.
+ *
+ * Names the explicit-bond switch when it is also on. The two do not conflict fatally, but a pairing in
+ * flight makes a subscribe refusal unattributable to the strap, so the probe declines to latch it and the
+ * capture is weaker for no gain.
+ */
+internal fun unbondedProbeSupersedesLine(explicitBondOptedIn: Boolean): String =
+    "WHOOP 5/MG: handshake skipped for this connect — \"try history sync without pairing\" is on, and it" +
+        " asks whether the offload needs a bond at all. That question needs a link with no CLIENT_HELLO on" +
+        " it, so the hello is not written here (press Connect to try the handshake instead)." +
+        (if (explicitBondOptedIn)
+            " NOTE: \"Ask Android to pair\" is also on. A pairing in flight makes a refusal unattributable" +
+                " to the strap, so turn it off for a clean answer."
+        else "") +
+        " (#1635, experimental)"
+
 /** Persisted key for "this strap refused the unbonded puffin subscriptions". Per device and lowercased,
  *  for the same reason [firmwarePrefKey] is. */
 internal fun unbondedOffloadRefusedPrefKey(peripheralId: String?): String? =

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -8186,6 +8186,27 @@ class WhoopBleClient(
                     log(bondStateAtConnectLine(g.device.bondState, g.device.address),
                         com.noop.testcentre.TestDomain.CONNECTION)
                 }
+                // #1635: the unbonded offload probe replaces the handshake on this connect, and it must
+                // run BEFORE the pairing request as well as before the hello — its question needs a link
+                // with neither on it. Placed here rather than beside the hello decision because the
+                // deferral branch below returns early, and a probe scheduled after that never runs.
+                if (unbondedProbeSupersedesHandshake(
+                        optedIn = puffinExperiment.unbondedOffload,
+                        isWhoop5 = true,
+                        appLevelBonded = didBond,
+                        userInitiated = helloRetryRequested,
+                    )
+                ) {
+                    log(unbondedProbeSupersedesLine(explicitBondOptedIn = puffinExperiment.explicitBond))
+                    // The watchdog was armed at discovery and bounces the link whenever didBond is false,
+                    // which skipping the handshake guarantees. Same reasoning as the suppression path: with
+                    // no handshake outstanding there is nothing left for it to time out, and leaving it
+                    // armed would tear down the stable link the probe needs.
+                    cancelBondWatchdog()
+                    scheduleUnbondedDisRead()
+                    scheduleUnbondedOffloadProbe()
+                    return
+                }
                 if (shouldRequestExplicitBond(
                         optedIn = puffinExperiment.explicitBond,
                         isWhoop5 = true,

--- a/android/app/src/main/java/com/noop/testcentre/TestBundleAssembler.kt
+++ b/android/app/src/main/java/com/noop/testcentre/TestBundleAssembler.kt
@@ -105,7 +105,7 @@ object TestBundleAssembler {
         //    strap-log share writes. Already scrubbed by the log() sink; the redactEntries pass re-scrubs.
         val header = buildString {
             appendLine("NOOP strap log")
-            appendLine("App:     ${BuildConfig.VERSION_NAME} (${BuildConfig.TIER})")
+            appendLine("App:     ${BuildConfig.VERSION_NAME} (${BuildConfig.TIER}) build ${BuildConfig.VERSION_CODE}")
             for (line in AndroidDiagnostics.summaryLines(context)) appendLine(line)
             appendLine("-".repeat(40))
         }

--- a/android/app/src/main/java/com/noop/ui/LogExport.kt
+++ b/android/app/src/main/java/com/noop/ui/LogExport.kt
@@ -137,7 +137,7 @@ object LogExport {
             val dynamic = com.noop.testcentre.AndroidDiagnostics.dynamicLines(context)
             val header = buildString {
                 appendLine("NOOP strap log (scheduled debug export)")
-                appendLine("App:     ${BuildConfig.VERSION_NAME} (${BuildConfig.TIER})")
+                appendLine("App:     ${BuildConfig.VERSION_NAME} (${BuildConfig.TIER}) build ${BuildConfig.VERSION_CODE}")
                 // #453: the rolling BODY is scrubbed by WhoopBleClient.log(), but these HEADER lines never pass
                 // through it - and they carry device ids, which embed a BLE address for a re-added or second
                 // strap. Same redactor, so one export cannot be safe while the other leaks.
@@ -252,7 +252,7 @@ object LogExport {
         val dynamic = com.noop.testcentre.AndroidDiagnostics.dynamicLines(context)
         val header = buildString {
             appendLine("NOOP strap log")
-            appendLine("App:     ${BuildConfig.VERSION_NAME} (${BuildConfig.TIER})")
+            appendLine("App:     ${BuildConfig.VERSION_NAME} (${BuildConfig.TIER}) build ${BuildConfig.VERSION_CODE}")
             // #453: the rolling BODY is scrubbed by WhoopBleClient.log(), but these HEADER lines never pass
             // through it - and they carry device ids, which embed a BLE address for a re-added or second
             // strap. Same redactor, so one export cannot be safe while the other leaks.

--- a/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
@@ -210,6 +210,58 @@ class UnbondedOffloadProbeTest {
     }
 
     /**
+     * The gap that would have made the whole probe dead code. It needs a link with no hello on it, but the
+     * two branches that schedule it are barely reached on the strap this is for: across 41 field captures
+     * the suppression latch fired in three, all on one day, and the explicit-bond deferral yields after
+     * its first connect by design — so every later link writes a hello. Opting in has to supersede the
+     * handshake, or the probe waits for a state the app almost never enters.
+     */
+    @Test
+    fun `opting in replaces the handshake for that connect`() {
+        assertTrue(unbondedProbeSupersedesHandshake(
+            optedIn = true, isWhoop5 = true, appLevelBonded = false, userInitiated = false))
+        assertFalse(unbondedProbeSupersedesHandshake(
+            optedIn = false, isWhoop5 = true, appLevelBonded = false, userInitiated = false))
+        assertFalse(unbondedProbeSupersedesHandshake(
+            optedIn = true, isWhoop5 = false, appLevelBonded = false, userInitiated = false))
+    }
+
+    /**
+     * Pressing Connect is an explicit request for the HANDSHAKE, and must never be answered with a
+     * different experiment — the same rule the suppression latch already follows.
+     */
+    @Test
+    fun `pressing Connect still gets the handshake`() {
+        assertFalse(unbondedProbeSupersedesHandshake(
+            optedIn = true, isWhoop5 = true, appLevelBonded = false, userInitiated = true))
+    }
+
+    @Test
+    fun `a strap that already bonded has nothing to prove`() {
+        assertFalse(unbondedProbeSupersedesHandshake(
+            optedIn = true, isWhoop5 = true, appLevelBonded = true, userInitiated = false))
+    }
+
+    /**
+     * The supersede line must say the hello is absent BY CHOICE. An absent hello looks identical to one
+     * that failed silently, which is the ambiguity that made #1635 unreadable for eleven weeks — and it
+     * must name the explicit-bond clash, because a pairing in flight costs the probe its ability to
+     * attribute a refusal to the strap.
+     */
+    @Test
+    fun `the supersede line explains the absence and flags the clash`() {
+        val clean = unbondedProbeSupersedesLine(explicitBondOptedIn = false)
+        assertTrue(clean.contains("handshake skipped"))
+        assertTrue(clean.contains("press Connect"))
+        assertFalse(clean.contains("Ask Android to pair"))
+        assertTrue(clean.contains("#1635"))
+
+        val clash = unbondedProbeSupersedesLine(explicitBondOptedIn = true)
+        assertTrue(clash.contains("Ask Android to pair"))
+        assertTrue(clash.contains("unattributable"))
+    }
+
+    /**
      * The expectation has to be set BEFORE the transfer, not after an empty one comes back. A strap that
      * has never been clocked has never been told to persist to flash, so "nothing banked" is a plausible
      * SUCCESS of the probe, and a reader who has not been told that will read it as a failure.

--- a/project.yml
+++ b/project.yml
@@ -21,7 +21,7 @@ settings:
     # iOS build number (CFBundleVersion). GLOBAL so the iOS app AND its widget extension inherit the
     # SAME value — they must match or iOS warns "extension version must match parent app" (#416).
     # macOS sets its own CFBundleVersion on the Strand target and is unaffected by this.
-    CURRENT_PROJECT_VERSION: "270"
+    CURRENT_PROJECT_VERSION: "271"
     SWIFT_VERSION: "5.0"
     # Emit localizable strings so Xcode auto-extracts every LocalizedStringKey into the
     # String Catalog on build (the English (US) base entries).


### PR DESCRIPTION
Follow-up to #1742, caught on the first field capture taken with any of it in mind. The probe as merged would essentially never have run.

## The gap

`shouldProbeUnbondedOffload` requires a link carrying no `CLIENT_HELLO`, and that gate is **right** — a subscribe refusal on a link the bond watchdog is about to bounce is unattributable, which is the ambiguity this whole thread has been paying for since June.

But the probe is only *scheduled* from the two no-hello branches, and on this strap neither is reached in practice:

- across **41 field captures**, the suppression latch fired in **three**, all on 26 Aug, and never since
- the explicit-bond deferral yields after its first connect **by design** (#1642), so every link after that writes a hello

In the 22:21 capture the pull-to-refresh reaches the offload and is turned away by exactly this gate, twice in three seconds:

```
22:20:16  Backfill: deferred — connect handshake not done yet
          (family=WHOOP5 didBond=false helloWrittenThisLink=true bondRequestedThisLink=true deferrals=1)
22:20:18  Backfill: deferred — ... deferrals=2
22:20:18  CLIENT_HELLO outcome: NO write callback after 3080ms
22:20:18  Disconnected (status=22)
```

`helloWrittenThisLink=true` on every one of those links. The probe would have waited behind a state the app almost never enters.

## The fix

Not to loosen attributability — that is what makes the answer worth having.

These are **mutually exclusive experiments**. "Does the hello work" and "is the hello needed at all" cannot both be asked of one link, because asking the first is what destroys the second's link. Turning the switch on is choosing the second question, so it now supersedes the handshake for that connect — the explicit pairing request as well as the hello.

Placed ahead of **both**, not beside the hello decision: the deferral branch returns early, so a probe scheduled after it never runs. That ordering is the bug, restated.

## What still wins

**Pressing Connect still gets the handshake**, exactly as it overrides the suppression latch today. An explicit request for one experiment must never be answered with a different one.

Narrow otherwise: 5/MG only, never on a strap that has already bonded (that one reaches the offload the proven way), default off.

## Log honesty

The new line says the hello is absent **by choice** — an absent hello reads identically to one that failed silently, which is precisely what made #1635 unreadable for eleven weeks.

It also names the explicit-bond switch when that is on too. The two do not conflict fatally, but a pairing in flight makes a subscribe refusal unattributable to the strap, so the probe declines to latch it and the capture is weaker for no gain. Better to say so than to let someone run both and get a mushy answer.

## Also: `versionCode` in the strap-log header

Build identity has been ambiguous three times in two days. Twice it cost a detour reasoning about which binary a capture came from, and dating the 22:21 log depended on noticing that probe lines were *absent*. One field ends that.

## Verification

- `4893` tests, 0 failures
- `lintVitalFullRelease`, doc-comment lint, i18n `--ci` clean
- staging **390** / iOS **271**
- still not hardware-validated — that is what the build is for

Related to #1635 and #1742.
