### PR TITLE
WHOOP 5/MG: a completed CLIENT_HELLO write is not an encrypted link

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -26,7 +26,7 @@ android {
         applicationId = "com.noop.whoop"
         minSdk = 26
         targetSdk = 34
-        versionCode = 390
+        versionCode = 391
         versionName = "10.6.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/android/app/src/main/java/com/noop/ble/ClientHelloOutcome.kt
+++ b/android/app/src/main/java/com/noop/ble/ClientHelloOutcome.kt
@@ -112,6 +112,62 @@ internal fun completionIsClientHelloAck(
 }
 
 /**
+ * The shortest an ATT round trip can plausibly take, in milliseconds.
+ *
+ * BLE's minimum connection interval is 7.5ms. A peripheral may answer inside the same connection event,
+ * so this is not a hard floor and is NOT used to reject anything - it decides only whether the log points
+ * the reader at the timing. It earns its place from the field distribution, which is starkly bimodal:
+ * across 41 captures every hello either "completed" in 0, 4, 5 or 7ms, or produced no callback at all
+ * about 3150ms later. Nothing in between, and 0ms cannot be a round trip at all.
+ */
+internal const val MIN_PLAUSIBLE_ATT_ROUND_TRIP_MS = 8L
+
+/**
+ * Does a completed CLIENT_HELLO write prove the link is ENCRYPTED?
+ *
+ * No, and conflating the two is the second false bond. [completionIsClientHelloAck] answers a narrower
+ * question - "is this completion the hello's?" - and the ack branch then took a yes as proof of an
+ * encrypted just-works bond. Those are different facts. A write completion says the stack considers the
+ * write finished. Encryption is a property of the LINK, and on Android the only thing that attests it is
+ * the OS bond state.
+ *
+ * The field capture shows them disagreeing outright: "CLIENT_HELLO acked after 5ms", "encryptedBond
+ * family=whoop5", and then two seconds later "bond state poll: BOND_NONE" on the same link - with an HCI
+ * capture already showing this strap answers SMP `Pairing Not Supported`, so an encrypted bond is not
+ * merely absent but impossible. The app displayed "Bonded, streaming." for it.
+ *
+ * So the completion still drives the HANDSHAKE - subscribe the puffin chars, clock the strap, offload,
+ * all of which only need the strap to be listening - while `encryptedBond` waits for something that
+ * actually attests encryption: the OS bond state, or the strap's own BLE_BONDED event.
+ *
+ * ANDROID-ONLY, deliberately, and this one has no Swift twin. CoreBluetooth exposes no link-encryption
+ * or bond state at all, so Apple has nothing to supply for [osBonded] — a twin taking it would be handed
+ * a constant `false` and would suppress bonds that are genuine there. The gap is real on Apple too; it
+ * simply cannot be closed the same way, and pretending otherwise in a shared helper would be worse than
+ * leaving it Android-only and saying so.
+ */
+internal fun helloCompletionProvesEncryptedBond(osBonded: Boolean): Boolean = osBonded
+
+/**
+ * The line for a hello completion that did NOT come with encryption.
+ *
+ * Without it the split is invisible: the log would show the handshake proceeding and no bond claim, and a
+ * reader would have to infer why. It also carries the elapsed time, because on a completion faster than a
+ * connection interval the timing is itself the evidence that the callback came from the local stack rather
+ * than the strap - and a 0ms "round trip" is the clearest thing in the whole #1635 capture set.
+ */
+internal fun helloAckedWithoutEncryptionLine(elapsedMs: Long, osBondState: String): String =
+    "CLIENT_HELLO outcome: the write completed after ${elapsedMs}ms, but the OS bond state is" +
+        " $osBondState — a completed write says the stack finished it, NOT that the link is encrypted," +
+        " so this is not a bond." +
+        (if (elapsedMs < MIN_PLAUSIBLE_ATT_ROUND_TRIP_MS)
+            " ${elapsedMs}ms is under one BLE connection interval, so the callback most likely came from" +
+                " the local stack rather than the strap."
+        else "") +
+        " Continuing the handshake anyway — subscribing, clocking and offloading need the strap to be" +
+        " listening, not the link to be encrypted (#1635)."
+
+/**
  * A pre-bond write completion on a 5/MG link that arrived with NO CLIENT_HELLO outstanding.
  *
  * [completionIsClientHelloAck] declines these, and without a line it declines in SILENCE — which is worse

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -6272,20 +6272,42 @@ class WhoopBleClient(
                     // just-works bonding completed. Now subscribe the puffin notify chars (realtime HR rides
                     // these as REALTIME_DATA — the strap rejected them on the unauthenticated link), then arm
                     // realtime HR with puffin framing. Mirrors the macOS post-bond flow.
+                    // A completed write means the STACK finished it. Encryption is a property of the
+                    // link, and on Android only the OS bond state attests it — so the two are split here
+                    // rather than inferred from one another. See [helloCompletionProvesEncryptedBond]:
+                    // the field capture has "acked after 5ms" and "BOND_NONE" two seconds apart on the
+                    // same link, for a strap an HCI capture shows refusing SMP outright.
+                    val encrypted = helloCompletionProvesEncryptedBond(
+                        osBonded = g.device.bondState == BluetoothDevice.BOND_BONDED,
+                    )
                     didBond = true
-                    setHelloDeferredRun(0)        // the handshake works on this strap; the run is over
-                    helloDeferredGuidanceLogged = false
-                    helloOverrideAttempts = 0     // #1635: the strap answered — the override's budget resets
-                    helloOverrideExhaustedLogged = false
-                    cancelBondWatchdog()          // genuine bond reached — the handshake watchdog stands down (#50)
-                    noteGenuineBond(g.device.address)   // #52: this strap bonds fine; clears any pin-refusal streak
-                    clearPairingHint()            // #78: a genuine bond means the pairing guidance no longer applies
+                    cancelBondWatchdog()          // the hello is answered either way — nothing left to time out (#50)
                     bondedDirectAttempt = false   // fast-path connect reached a real session (#78 fork)
-                    staleDirectFailures = 0       // genuine bond — clear the wiped-bond counter (#84 parity)
-                    _state.update { it.copy(bonded = true, encryptedBond = true) }   // genuine bond (#69)
+                    // Everything below claims something about the STRAP'S WILLINGNESS TO BOND, and a write
+                    // completion is not evidence of that. Clearing them on an unencrypted completion is how
+                    // a strap that never bonds gets recorded as one that bonds fine — and it retires the
+                    // very counters that exist to notice it never did.
+                    if (encrypted) {
+                        setHelloDeferredRun(0)        // the handshake works on this strap; the run is over
+                        helloDeferredGuidanceLogged = false
+                        helloOverrideAttempts = 0     // #1635: the strap answered — the override's budget resets
+                        helloOverrideExhaustedLogged = false
+                        noteGenuineBond(g.device.address)   // #52: this strap bonds fine; clears any pin-refusal streak
+                        clearPairingHint()            // #78: a genuine bond means the pairing guidance no longer applies
+                        staleDirectFailures = 0       // genuine bond — clear the wiped-bond counter (#84 parity)
+                    }
+                    _state.update { it.copy(bonded = true, encryptedBond = encrypted) }
                     bondedAtMs = System.currentTimeMillis()   // #617: stamp the bond so handleDisconnect can spot a bond-then-quick-timeout loop
-                    emitConnectionBondState("encryptedBond family=whoop5 (CLIENT_HELLO acked)")
-                    log("WHOOP 5/MG: CLIENT_HELLO acked — link established; subscribing notify chars (experimental).")
+                    if (encrypted) {
+                        emitConnectionBondState("encryptedBond family=whoop5 (CLIENT_HELLO acked)")
+                        log("WHOOP 5/MG: CLIENT_HELLO acked — link established; subscribing notify chars (experimental).")
+                    } else {
+                        log(helloAckedWithoutEncryptionLine(
+                            elapsedMs = if (clientHelloWriteAtMs > 0L)
+                                System.currentTimeMillis() - clientHelloWriteAtMs else -1L,
+                            osBondState = bondStateName(g.device.bondState),
+                        ))
+                    }
                     g.getService(WHOOP5_SERVICE)?.let { svc ->
                         for (u in WHOOP5_NOTIFY_CHARS) svc.getCharacteristic(u)?.let { cccdQueue.add(it) }
                     }

--- a/android/app/src/test/java/com/noop/ble/ClientHelloEncryptionSplitTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ClientHelloEncryptionSplitTest.kt
@@ -1,0 +1,69 @@
+package com.noop.ble
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The second false bond, found in the 30 Aug 22:47 capture.
+ *
+ * The ack branch took "the CLIENT_HELLO write completed" as proof of an encrypted just-works bond and set
+ * `encryptedBond`, so the app showed "Bonded, streaming." on a link whose OS bond state read BOND_NONE two
+ * seconds later — for a strap an HCI capture already showed answering SMP `Pairing Not Supported`, where an
+ * encrypted bond is not merely absent but impossible.
+ */
+class ClientHelloEncryptionSplitTest {
+
+    @Test
+    fun `a completed write is not proof of encryption`() {
+        assertFalse(helloCompletionProvesEncryptedBond(osBonded = false))
+    }
+
+    @Test
+    fun `the OS bond state is what attests it`() {
+        assertTrue(helloCompletionProvesEncryptedBond(osBonded = true))
+    }
+
+    /**
+     * The line must say the handshake CONTINUES. The split would otherwise read as a refusal, and the
+     * whole point is that subscribing, clocking and offloading need the strap to be listening — not the
+     * link to be encrypted.
+     */
+    @Test
+    fun `the line separates the two facts and says the handshake goes on`() {
+        val line = helloAckedWithoutEncryptionLine(elapsedMs = 5L, osBondState = "BOND_NONE")
+        assertTrue(line.contains("NOT that the link is encrypted"))
+        assertTrue(line.contains("BOND_NONE"))
+        assertTrue(line.contains("Continuing the handshake"))
+        assertTrue(line.contains("#1635"))
+    }
+
+    /**
+     * A completion faster than one connection interval is itself evidence the callback came from the local
+     * stack. Across 41 captures every hello either "completed" in 0-7ms or produced no callback at all
+     * ~3150ms later — nothing in between, and 0ms cannot be a round trip. The line points at that only
+     * when it applies; it must not editorialise about a plausible latency.
+     */
+    @Test
+    fun `an impossibly fast completion is called out, a plausible one is not`() {
+        assertTrue(helloAckedWithoutEncryptionLine(0L, "BOND_NONE").contains("under one BLE connection interval"))
+        assertTrue(helloAckedWithoutEncryptionLine(5L, "BOND_NONE").contains("under one BLE connection interval"))
+        assertFalse(helloAckedWithoutEncryptionLine(40L, "BOND_NONE").contains("under one BLE connection interval"))
+        // The boundary is the physical floor, not a round number pulled from the observed values.
+        assertFalse(
+            helloAckedWithoutEncryptionLine(MIN_PLAUSIBLE_ATT_ROUND_TRIP_MS, "BOND_NONE")
+                .contains("under one BLE connection interval"),
+        )
+    }
+
+    /**
+     * Timing is diagnostic, never a gate. A strap that genuinely bonds must not have its bond rejected for
+     * answering quickly — a peripheral may reply inside the same connection event, so a fast round trip is
+     * unusual, not impossible.
+     */
+    @Test
+    fun `timing never decides the bond`() {
+        assertTrue(helloCompletionProvesEncryptedBond(osBonded = true))
+        assertFalse(helloCompletionProvesEncryptedBond(osBonded = false))
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -21,7 +21,7 @@ settings:
     # iOS build number (CFBundleVersion). GLOBAL so the iOS app AND its widget extension inherit the
     # SAME value — they must match or iOS warns "extension version must match parent app" (#416).
     # macOS sets its own CFBundleVersion on the Strand target and is unaffected by this.
-    CURRENT_PROJECT_VERSION: "271"
+    CURRENT_PROJECT_VERSION: "272"
     SWIFT_VERSION: "5.0"
     # Emit localizable strings so Xcode auto-extracts every LocalizedStringKey into the
     # String Catalog on build (the English (US) base entries).


### PR DESCRIPTION
The second false bond, from the 30 Aug 22:47 capture. Unlike the first one this is **not** a mis-attributed completion — the completion really is the hello's. The error is what was concluded from it.

## What the capture shows

Three lines, one link, two seconds apart:

```
22:46:31  CLIENT_HELLO outcome: acked by fd4b0002 after 5ms status=GATT_SUCCESS(0)
22:46:31  [connection] bondState encryptedBond family=whoop5 (CLIENT_HELLO acked)
22:46:33  bond state poll: BOND_NONE
```

The app displayed **"Bonded, streaming."** for that link — on a strap an HCI capture already shows answering SMP `Pairing Not Supported`, where an encrypted bond is not merely absent but *impossible*.

## The confusion

A write completion says the **stack** finished the write. Encryption is a property of the **link**, and on Android the only thing that attests it is the OS bond state. The ack branch treated the first as proof of the second.

They are now recorded separately:

- `encryptedBond` waits for something that actually attests encryption — the OS bond state, or the strap's own `BLE_BONDED` event
- the completion still drives the **handshake**: subscribe the puffin chars, clock the strap, offload. All of that needs the strap to be *listening*, not the link to be *encrypted*

That split is deliberate and is the useful half: it keeps the only path that has ever plausibly led to history on this strap, while dropping the claim that was false.

## The other claims in that branch

Everything asserting something about the strap's **willingness to bond** is gated on real encryption now: `noteGenuineBond` ("this strap bonds fine"), `clearPairingHint`, `staleDirectFailures`, the deferral run, and the hello-override budget.

Clearing those on an unencrypted completion is how a strap that has never bonded gets recorded as one that bonds fine — and it retires the very counters that exist to notice it never did. That is a self-erasing bug: the more it fires, the less evidence survives that it fired.

`cancelBondWatchdog` stays unconditional. The hello is answered either way and there is nothing left to time out.

## Timing is diagnostic, never a gate

Across 41 captures the hello outcome is starkly bimodal:

| outcome | count |
|---|---|
| "acked" in 0ms | 1 |
| "acked" in 4ms | 3 |
| "acked" in 5ms | 1 |
| "acked" in 7ms | 3 |
| no callback, ~3150ms | hundreds |

Nothing in between, and **0ms cannot be a round trip**. The line points at this when the elapsed is under one connection interval, because it is the clearest evidence in the set that the callback came from the local stack rather than the strap.

It decides nothing. A peripheral may answer inside the same connection event, so a fast round trip is unusual rather than impossible, and a strap that genuinely bonds must never have its bond rejected for being quick. The gate is the OS bond state; the timing is a pointer for whoever reads the capture next.

## Android-only on purpose

No Swift twin here. CoreBluetooth exposes no bond or link-encryption state at all, so Apple has nothing to supply — a shared helper would be handed a constant `false` and would suppress bonds that are genuine there. The gap is real on Apple too; it cannot be closed the same way, and saying so beats a twin that is wrong.

## Verification

- `4898` tests, 0 failures
- `lintVitalFullRelease`, doc-comment lint, i18n `--ci` clean
- staging **391** / iOS **272**

Related to #1635.
