### PR TITLE
Last sync belongs to a strap, not to the install

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -26,7 +26,7 @@ android {
         applicationId = "com.noop.whoop"
         minSdk = 26
         targetSdk = 34
-        versionCode = 391
+        versionCode = 392
         versionName = "10.6.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/android/app/src/main/java/com/noop/ble/LastSyncAttribution.kt
+++ b/android/app/src/main/java/com/noop/ble/LastSyncAttribution.kt
@@ -1,0 +1,68 @@
+package com.noop.ble
+
+/**
+ * Which "last sync" timestamp belongs to a strap, given what is known about it.
+ *
+ * The same bug [resolveFirmware] fixed for firmware, in the field again and reported three times before
+ * it was believed. `noop.lastSyncAtSec` is ONE global key, stamped on any strap's HISTORY_COMPLETE and
+ * read back for whichever strap is active. On a single-strap install those are the same strap, which is
+ * why it went unnoticed. With two paired it reports the OTHER strap's sync: a capture showing
+ * "Last sync: 4d ago" beside `Days: whoop-MGB…=0` and a 4.0 last seen 3 days earlier — the 5/MG had never
+ * banked a single row, and the number on its screen was the 4.0's.
+ *
+ * Worse than merely wrong: it is wrong in the reassuring direction. A strap that has never synced reads
+ * as recently synced, and the pull-to-refresh that cannot possibly change it looks broken rather than
+ * inapplicable. It sent this investigation after a "sync regression" that never existed.
+ *
+ * The rule, in order:
+ *  - [perDevice] wins: this strap's own stamp, from its own completed offload.
+ *  - [legacyGlobal] ONLY when [pairedCount] is 1. The old key cannot say which strap it belongs to, so
+ *    it is trustworthy exactly when there is only one strap it could have come from — which keeps a
+ *    single-strap install reading correctly across the upgrade instead of resetting to "never".
+ *  - otherwise null, meaning "this strap has never synced". For the strap in the capture that is not a
+ *    degraded answer, it is the correct one, and it is what the whole thread was missing.
+ *
+ * Deliberately NOT migrated by writing the global onto the active device at upgrade. That is the same
+ * guess in a different place, and on a multi-strap install it would bake the wrong attribution in
+ * permanently instead of leaving it to self-correct at the next real sync.
+ *
+ * Pure so the attribution is unit-tested without prefs, a strap, or a registry.
+ */
+internal fun resolveLastSync(
+    perDevice: Long,
+    legacyGlobal: Long,
+    pairedCount: Int,
+): Long? = perDevice.takeIf { it > 0L }
+    ?: legacyGlobal.takeIf { it > 0L && pairedCount == 1 }
+
+/**
+ * The per-device preference key for a persisted last-sync timestamp.
+ *
+ * Keyed on the BLE peripheral address for the same reason [firmwarePrefKey] is: HISTORY_COMPLETE arrives
+ * on a connection whose address is known, and resolving it to a registry id there would repeat the
+ * mis-mapping #1527 fixed for `lastSeen` — stamping "the active row" records a sync for a strap that was
+ * never connected, which is precisely the class of error being removed here.
+ *
+ * Lowercased, because the same strap presents its address in different cases across sessions and a
+ * case-sensitive key would strand the earlier stamp under a second name. Returns null for a blank
+ * address, so a caller with no address writes nothing rather than writing to a key that belongs to no
+ * device.
+ */
+internal fun lastSyncPrefKey(peripheralId: String?): String? =
+    peripheralId?.trim()?.takeIf { it.isNotEmpty() }?.let { "noop.lastSyncAt.${it.lowercase()}" }
+
+/**
+ * The per-device preference key for the #57 write-health stamps ("rows last landed", "offload stalled").
+ *
+ * Same defect as [lastSyncPrefKey] and found in the same capture, one line below it: `Data write: rows
+ * last landed 4d ago` printed against a strap whose own row count was zero, because the stamp was global
+ * and the 4.0 had written it. Two lines that both looked like evidence the 5/MG had been syncing, and
+ * neither was about the 5/MG.
+ *
+ * [kind] separates "ok" from "stalled" so both keep the per-device scoping rather than only the one that
+ * happened to be noticed — they are read as a PAIR ("stalled more recently than ok" is the alarm), and
+ * scoping one without the other would compare a strap's own stall against another strap's success.
+ */
+internal fun writeHealthPrefKey(peripheralId: String?, kind: String): String? =
+    peripheralId?.trim()?.takeIf { it.isNotEmpty() }
+        ?.let { "sync.$kind.${it.lowercase()}" }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1792,17 +1792,16 @@ class WhoopBleClient(
     // last-sync time (PR #556 reimpl) so a freshly-recreated client doesn't show "Never" when this
     // install has actually synced before; a 0 (never) leaves it null, unchanged.
     //
-    // THIS STRAP's stamp only. The legacy global is a valid fallback on a single-strap install, but that
-    // needs the paired count, which needs the registry, which is not available synchronously in a
-    // constructor — so [seedLegacyLastSyncIfSingleStrap] resolves it a moment later. Seeding from the
-    // global here instead would show the other strap's timestamp for as long as it took to correct,
-    // which is the bug rather than a smaller version of it.
-    private val _state = MutableStateFlow(
-        LiveState(
-            lastSyncAt = NoopPrefs.lastSyncAtFor(context, NoopPrefs.lastDevice(context)?.first)
-                .takeIf { it > 0L },
-        ),
-    )
+    // Deliberately seeded with NOTHING. The value belongs to the ACTIVE strap, and resolving which strap
+    // that is needs the registry, which is suspend — so [seedLastSyncFromActiveStrap] fills it in a moment
+    // later and the screens show no last-sync until it does.
+    //
+    // The obvious cheap seed, NoopPrefs.lastDevice, is the trap: it records the last strap to BOND, which
+    // on a two-strap install is whichever one was worn most recently, not the one the screens are scoped
+    // to. Seeding from it would put the 4.0's sync time on a 5/MG's Today screen — the exact bug this
+    // change exists to remove, surviving inside the fix for it. A blank moment is honest; another strap's
+    // timestamp is not.
+    private val _state = MutableStateFlow(LiveState())
     val state: StateFlow<LiveState> = _state.asStateFlow()
 
     private val _groundTruthImuStatus = MutableStateFlow(GroundTruthImuStatus())
@@ -2699,26 +2698,31 @@ class WhoopBleClient(
     private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     /**
-     * Fill in the last-sync seed from the LEGACY global key, but only on a single-strap install.
+     * Seed the last-sync display from the ACTIVE strap's own stamp — PR #556's intent, correctly attributed.
      *
-     * The global key cannot say which strap stamped it, so it is trustworthy exactly when there is one
-     * strap it could have come from — see [resolveLastSync]. That count lives in the registry and the
-     * registry is suspend, which is why this runs just after construction rather than in the seed itself.
+     * Resolved against the registry's active row, exactly as the strap-log header resolves firmware and
+     * last-sync. NOT against `NoopPrefs.lastDevice`, which records the last strap to BOND: on a two-strap
+     * install that is whichever was worn most recently, not the one the screens are scoped to, so seeding
+     * from it would put one strap's sync time on the other's Today screen.
      *
-     * Writes nothing and touches nothing when this strap already has its own stamp, or when more than one
-     * strap is paired. On the install that produced the capture (two straps) it correctly does nothing,
-     * and the 5/MG reads "never" — which is the true answer it has never once been given.
+     * The legacy global still applies when exactly one strap is paired, because only then can it not be
+     * ambiguous (see [resolveLastSync]). On the install that produced the capture — two straps, the active
+     * one having never synced — this correctly leaves the display empty and the 5/MG reads "never".
      */
-    private fun seedLegacyLastSyncIfSingleStrap() {
-        if (_state.value.lastSyncAt != null) return
-        val legacy = runCatching { NoopPrefs.lastSyncAt(context) }.getOrDefault(0L)
-        if (legacy <= 0L) return
+    private fun seedLastSyncFromActiveStrap() {
         val registry = (context.applicationContext as? com.noop.NoopApplication)?.deviceRegistry ?: return
         ioScope.launch {
-            val paired = runCatching { registry.all().size }.getOrDefault(0)
-            resolveLastSync(perDevice = 0L, legacyGlobal = legacy, pairedCount = paired)?.let { seed ->
-                _state.update { st -> if (st.lastSyncAt == null) st.copy(lastSyncAt = seed) else st }
-            }
+            val rows = runCatching { registry.all() }.getOrDefault(emptyList())
+            val activeId = runCatching { registry.activeDeviceId() }.getOrNull()
+            val activeAddr = rows.firstOrNull { it.id == activeId }?.peripheralId
+            val seed = resolveLastSync(
+                perDevice = runCatching { NoopPrefs.lastSyncAtFor(context, activeAddr) }.getOrDefault(0L),
+                legacyGlobal = runCatching { NoopPrefs.lastSyncAt(context) }.getOrDefault(0L),
+                pairedCount = rows.size,
+            ) ?: return@launch
+            // Never overwrite a value this session earned: a HISTORY_COMPLETE landing while the registry
+            // read is in flight is newer than anything persisted, and must win.
+            _state.update { st -> if (st.lastSyncAt == null) st.copy(lastSyncAt = seed) else st }
         }
     }
 
@@ -2730,7 +2734,7 @@ class WhoopBleClient(
     private val rawHistoryArchive = RawHistoryArchive(context)
 
     init {
-        seedLegacyLastSyncIfSingleStrap()
+        seedLastSyncFromActiveStrap()
         // Retro-decode (#151): when the decoder gains a historical layout (WHOOP 4.0 v25), re-run every
         // archived undecodable frame through it and insert whatever now decodes — the only path by
         // which already-acked, strap-freed history backfills after an update. Runs once per APP version

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1791,8 +1791,17 @@ class WhoopBleClient(
     // MARK: Published state — the single source of truth the UI observes. Seeded with the PERSISTED
     // last-sync time (PR #556 reimpl) so a freshly-recreated client doesn't show "Never" when this
     // install has actually synced before; a 0 (never) leaves it null, unchanged.
+    //
+    // THIS STRAP's stamp only. The legacy global is a valid fallback on a single-strap install, but that
+    // needs the paired count, which needs the registry, which is not available synchronously in a
+    // constructor — so [seedLegacyLastSyncIfSingleStrap] resolves it a moment later. Seeding from the
+    // global here instead would show the other strap's timestamp for as long as it took to correct,
+    // which is the bug rather than a smaller version of it.
     private val _state = MutableStateFlow(
-        LiveState(lastSyncAt = NoopPrefs.lastSyncAt(context).takeIf { it > 0L }),
+        LiveState(
+            lastSyncAt = NoopPrefs.lastSyncAtFor(context, NoopPrefs.lastDevice(context)?.first)
+                .takeIf { it > 0L },
+        ),
     )
     val state: StateFlow<LiveState> = _state.asStateFlow()
 
@@ -2690,6 +2699,30 @@ class WhoopBleClient(
     private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     /**
+     * Fill in the last-sync seed from the LEGACY global key, but only on a single-strap install.
+     *
+     * The global key cannot say which strap stamped it, so it is trustworthy exactly when there is one
+     * strap it could have come from — see [resolveLastSync]. That count lives in the registry and the
+     * registry is suspend, which is why this runs just after construction rather than in the seed itself.
+     *
+     * Writes nothing and touches nothing when this strap already has its own stamp, or when more than one
+     * strap is paired. On the install that produced the capture (two straps) it correctly does nothing,
+     * and the 5/MG reads "never" — which is the true answer it has never once been given.
+     */
+    private fun seedLegacyLastSyncIfSingleStrap() {
+        if (_state.value.lastSyncAt != null) return
+        val legacy = runCatching { NoopPrefs.lastSyncAt(context) }.getOrDefault(0L)
+        if (legacy <= 0L) return
+        val registry = (context.applicationContext as? com.noop.NoopApplication)?.deviceRegistry ?: return
+        ioScope.launch {
+            val paired = runCatching { registry.all().size }.getOrDefault(0)
+            resolveLastSync(perDevice = 0L, legacyGlobal = legacy, pairedCount = paired)?.let { seed ->
+                _state.update { st -> if (st.lastSyncAt == null) st.copy(lastSyncAt = seed) else st }
+            }
+        }
+    }
+
+    /**
      * Durable archive for undecodable history record frames (#77/#91). Written BEFORE the strap is
      * acked, so an unrecognised firmware layout can't cost the user their only copy: the ack frees
      * the strap's records, and this archive is the only remaining copy until the layout is mapped.
@@ -2697,6 +2730,7 @@ class WhoopBleClient(
     private val rawHistoryArchive = RawHistoryArchive(context)
 
     init {
+        seedLegacyLastSyncIfSingleStrap()
         // Retro-decode (#151): when the decoder gains a historical layout (WHOOP 4.0 v25), re-run every
         // archived undecodable frame through it and insert whatever now decodes — the only path by
         // which already-acked, strap-freed history backfills after an update. Runs once per APP version
@@ -9040,15 +9074,23 @@ class WhoopBleClient(
         }
         // PR #556 reimpl: persist the HISTORY_COMPLETE instant so "Last synced N ago" survives a BLE-client
         // recreation / process restart and stops reverting to "Never".
-        if (reason == "HISTORY_COMPLETE") NoopPrefs.setLastSyncAt(context, nowSec)
+        // Stamped against the strap that actually completed this offload, never globally. The old single
+        // key reported one strap's sync on another's screen — a 5/MG with zero banked rows reading
+        // "Last sync: 4d ago" from its paired 4.0, which is what sent this whole investigation after a
+        // regression that never existed.
+        if (reason == "HISTORY_COMPLETE") NoopPrefs.setLastSyncAtFor(context, lastDeviceAddress, nowSec)
         // #57 debug: write-health signal for the export. "Last sync" fires even on an empty/failed offload,
         // so it can't distinguish "0 rows because the strap was empty" from "0 rows because writes FAILED".
         // Record the last time rows actually landed, and the last time an offload STALLED on a persist
         // failure (the closed-DB-after-restore class) — so a future "sync stuck at 0" report is decidable.
         runCatching {
+            // Per strap, for the same reason the last-sync stamp above is: these two lines sat together
+            // in the capture, both global, both reporting the 4.0's activity on the 5/MG's screen.
             val p = NoopPrefs.of(context).edit()
-            if (backfiller.sessionRowsPersisted > 0) p.putLong("sync.lastWriteOkAt", nowSec)
-            if (backfiller.persistStalled) p.putLong("sync.lastWriteStalledAt", nowSec)
+            val okKey = writeHealthPrefKey(lastDeviceAddress, "lastWriteOkAt")
+            val stalledKey = writeHealthPrefKey(lastDeviceAddress, "lastWriteStalledAt")
+            if (backfiller.sessionRowsPersisted > 0 && okKey != null) p.putLong(okKey, nowSec)
+            if (backfiller.persistStalled && stalledKey != null) p.putLong(stalledKey, nowSec)
             p.apply()
         }
         // #580: a WHOOP 5/MG whose firmware serves no history offload (acks SEND_HISTORICAL_DATA but emits

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -88,14 +88,35 @@ object AndroidDiagnostics {
                 pairedCount = fwRows.size,
             )
             add("Firmware:    ${fw ?: "unknown (connect to record)"}")
-            val syncSec = com.noop.ui.NoopPrefs.lastSyncAt(context)
-            add("Last sync:   ${if (syncSec > 0L) relTime(System.currentTimeMillis() - syncSec * 1000L) else "never"}")
+            // THIS strap's own sync, attributed the same way the firmware above is. The old global key
+            // reported whichever strap synced last, so a 5/MG that had never banked a row showed its
+            // paired 4.0's timestamp — the line that made a non-existent sync regression look real.
+            val syncSec = com.noop.ble.resolveLastSync(
+                perDevice = com.noop.ui.NoopPrefs.lastSyncAtFor(context, fwRow?.peripheralId),
+                legacyGlobal = com.noop.ui.NoopPrefs.lastSyncAt(context),
+                pairedCount = fwRows.size,
+            ) ?: 0L
+            add("Last sync:   ${if (syncSec > 0L) relTime(System.currentTimeMillis() - syncSec * 1000L)
+                else "never (this strap)"}")
             // #57: write-health. "Last sync" fires even on an empty/failed offload, so distinguish "rows
             // actually landed" from "an offload STALLED on a persist failure" (history won't persist —
             // usually a backup restored without an app restart, the closed-DB class).
             val p = com.noop.ui.NoopPrefs.of(context)
-            val okAt = p.getLong("sync.lastWriteOkAt", 0L)
-            val stalledAt = p.getLong("sync.lastWriteStalledAt", 0L)
+            // Attributed exactly like "Last sync" above — the legacy global counts only when a single
+            // strap could have written it, so the pair can never mix one strap's stall with another's
+            // success. Read together: "stalled more recently than ok" is the alarm.
+            val okAt = com.noop.ble.resolveLastSync(
+                perDevice = com.noop.ble.writeHealthPrefKey(fwRow?.peripheralId, "lastWriteOkAt")
+                    ?.let { p.getLong(it, 0L) } ?: 0L,
+                legacyGlobal = p.getLong("sync.lastWriteOkAt", 0L),
+                pairedCount = fwRows.size,
+            ) ?: 0L
+            val stalledAt = com.noop.ble.resolveLastSync(
+                perDevice = com.noop.ble.writeHealthPrefKey(fwRow?.peripheralId, "lastWriteStalledAt")
+                    ?.let { p.getLong(it, 0L) } ?: 0L,
+                legacyGlobal = p.getLong("sync.lastWriteStalledAt", 0L),
+                pairedCount = fwRows.size,
+            ) ?: 0L
             val restoreAt = p.getLong("backup.lastRestoreAt", 0L)
             val now = System.currentTimeMillis()
             add("Data write:  ${if (okAt > 0L) "rows last landed ${relTime(now - okAt * 1000L)}" else "no rows ever persisted"}")

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -1317,10 +1317,20 @@ object NoopPrefs {
      *  recreation / process restart and stops reverting to "Never". 0 = never synced on this install. */
     const val KEY_LAST_SYNC_AT = "noop.lastSyncAtSec"
 
+    /** LEGACY global reader. Kept only as [com.noop.ble.resolveLastSync]'s single-strap fallback, so an
+     *  install that has one strap keeps its timestamp across the upgrade. No longer written. */
     fun lastSyncAt(context: Context): Long = of(context).getLong(KEY_LAST_SYNC_AT, 0L)
 
-    fun setLastSyncAt(context: Context, epochSec: Long) {
-        of(context).edit().putLong(KEY_LAST_SYNC_AT, epochSec).apply()
+    /** This strap's own last completed offload, keyed by BLE address — see
+     *  [com.noop.ble.lastSyncPrefKey]. 0 when this strap has never synced. */
+    fun lastSyncAtFor(context: Context, peripheralId: String?): Long =
+        com.noop.ble.lastSyncPrefKey(peripheralId)?.let { of(context).getLong(it, 0L) } ?: 0L
+
+    /** Stamp a completed offload against the strap it came from. A blank address writes nothing rather
+     *  than writing to a key that belongs to no device. */
+    fun setLastSyncAtFor(context: Context, peripheralId: String?, epochSec: Long) {
+        val key = com.noop.ble.lastSyncPrefKey(peripheralId) ?: return
+        of(context).edit().putLong(key, epochSec).apply()
     }
 
     /** Last-known strap firmware string, persisted on connect so the debug export can name it OFFLINE

--- a/android/app/src/test/java/com/noop/ble/LastSyncAttributionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/LastSyncAttributionTest.kt
@@ -1,0 +1,106 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Reported three times before it was believed, which is the part worth remembering: the number was
+ * plausible, so the user was told their reading was wrong rather than the label.
+ *
+ * The field capture had `Last sync: 4d ago` beside `Days: whoop-MGB…=0` and a 4.0 last seen three days
+ * earlier. The 5/MG had never banked a row; the timestamp on its screen belonged to the other strap.
+ */
+class LastSyncAttributionTest {
+
+    @Test
+    fun `a strap's own stamp always wins`() {
+        assertEquals(500L, resolveLastSync(perDevice = 500L, legacyGlobal = 900L, pairedCount = 1))
+        assertEquals(500L, resolveLastSync(perDevice = 500L, legacyGlobal = 900L, pairedCount = 3))
+    }
+
+    /**
+     * The single-strap upgrade path. The global key is unattributed, but with one strap paired there is
+     * only one strap it can have come from — so it reads correctly across the upgrade instead of
+     * resetting to "never" for everyone.
+     */
+    @Test
+    fun `the legacy global is trustworthy only when one strap could have written it`() {
+        assertEquals(900L, resolveLastSync(perDevice = 0L, legacyGlobal = 900L, pairedCount = 1))
+        assertNull(resolveLastSync(perDevice = 0L, legacyGlobal = 900L, pairedCount = 2))
+    }
+
+    /**
+     * THE case from the capture. Two straps, and the active one has never synced: the honest answer is
+     * "never", not the other strap's timestamp. Not a degraded answer — the correct one, and the one the
+     * whole investigation was missing.
+     */
+    @Test
+    fun `a strap that has never synced says so, even when another strap has`() {
+        assertNull(resolveLastSync(perDevice = 0L, legacyGlobal = 1_787_000_000L, pairedCount = 2))
+    }
+
+    @Test
+    fun `nothing recorded anywhere is never`() {
+        assertNull(resolveLastSync(perDevice = 0L, legacyGlobal = 0L, pairedCount = 1))
+        assertNull(resolveLastSync(perDevice = 0L, legacyGlobal = 0L, pairedCount = 0))
+    }
+
+    /**
+     * A zero-paired registry must not license the global. The count is the evidence that exactly one
+     * strap could have written it; "no straps" is not that evidence, and treating it as such would let a
+     * mid-migration or failed registry read resurrect the bug.
+     */
+    @Test
+    fun `an unknown or empty registry does not license the global`() {
+        assertNull(resolveLastSync(perDevice = 0L, legacyGlobal = 900L, pairedCount = 0))
+    }
+
+    @Test
+    fun `the key is per device and case-insensitive`() {
+        // The same strap presents its address in different cases across sessions; a case-sensitive key
+        // would strand the earlier stamp under a second name and report "never" on a strap that had synced.
+        assertEquals(lastSyncPrefKey("AA:BB:CC:DD:EE:FF"), lastSyncPrefKey("aa:bb:cc:dd:ee:ff"))
+        assertNull(lastSyncPrefKey(null))
+        assertNull(lastSyncPrefKey("   "))
+    }
+
+    /**
+     * The #57 write-health pair had the identical defect one line below in the same capture: "rows last
+     * landed 4d ago" printed for a strap whose own row count was zero. Both halves are scoped, because
+     * they are read as a pair — "stalled more recently than ok" is the alarm, and scoping only one would
+     * compare this strap's stall against another strap's success.
+     */
+    @Test
+    fun `the write-health pair is scoped per strap and the two halves stay distinct`() {
+        val addr = "aa:bb:cc:dd:ee:ff"
+        val ok = writeHealthPrefKey(addr, "lastWriteOkAt")
+        val stalled = writeHealthPrefKey(addr, "lastWriteStalledAt")
+        assertEquals(false, ok == stalled)
+        assertEquals(ok, writeHealthPrefKey("AA:BB:CC:DD:EE:FF", "lastWriteOkAt"))
+        assertNull(writeHealthPrefKey(null, "lastWriteOkAt"))
+        assertNull(writeHealthPrefKey("  ", "lastWriteOkAt"))
+    }
+
+    /**
+     * Different straps must never share a write-health key, or one strap's successful offload would clear
+     * the alarm raised by another strap's stall.
+     */
+    @Test
+    fun `two straps get different write-health keys`() {
+        assertEquals(
+            false,
+            writeHealthPrefKey("aa:bb:cc:dd:ee:ff", "lastWriteOkAt") ==
+                writeHealthPrefKey("ff:ee:dd:cc:bb:aa", "lastWriteOkAt"),
+        )
+    }
+
+    /**
+     * It must not collide with the firmware key, which is built the same way from the same address.
+     */
+    @Test
+    fun `it does not collide with the firmware key for the same strap`() {
+        val addr = "aa:bb:cc:dd:ee:ff"
+        assertEquals(false, lastSyncPrefKey(addr) == firmwarePrefKey(addr))
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -21,7 +21,7 @@ settings:
     # iOS build number (CFBundleVersion). GLOBAL so the iOS app AND its widget extension inherit the
     # SAME value — they must match or iOS warns "extension version must match parent app" (#416).
     # macOS sets its own CFBundleVersion on the Strand target and is unaffected by this.
-    CURRENT_PROJECT_VERSION: "272"
+    CURRENT_PROJECT_VERSION: "273"
     SWIFT_VERSION: "5.0"
     # Emit localizable strings so Xcode auto-extracts every LocalizedStringKey into the
     # String Catalog on build (the English (US) base entries).


### PR DESCRIPTION
Reported three times before it was believed — and that is the part worth keeping. The number was plausible, so the *reading* was treated as mistaken rather than the label.

## The defect

`noop.lastSyncAtSec` is **one key**, stamped on any strap's `HISTORY_COMPLETE` and read back for whichever strap is active. On a single-strap install those are the same strap, which is why it survived this long.

With two paired, it reports the other one's. From the 30 Aug capture:

```
Last sync:   4d ago
Days:        whoop-MGB…=0   my-whoop=37
  device id=whoop-MGB… status=ACTIVE   lastSeen=just now
  device id=my-whoop   status=paired   lastSeen=3d ago
```

The 5/MG had **never banked a row**. The timestamp on its screen was the 4.0's.

## Why it was expensive

It was wrong in the *reassuring* direction. A strap that has never synced read as recently synced, so a pull-to-refresh that could not possibly change the number looked broken rather than inapplicable — and it sent an entire investigation after a sync regression that never existed.

## The shape of the fix

This is the same defect `resolveFirmware` already fixed for firmware strings, so it takes the same shape:

- stamped per **BLE address** (the address is known when `HISTORY_COMPLETE` arrives; resolving to a registry id there would repeat the mis-mapping #1527 fixed for `lastSeen`)
- read per strap
- the legacy global honoured **only when exactly one strap is paired** — the one case where it cannot be ambiguous, which keeps single-strap installs reading correctly across the upgrade instead of resetting to "never"

Deliberately **not** migrated by writing the global onto the active strap. That is the same guess in a different place, and on a multi-strap install it would bake the wrong attribution in permanently instead of letting it self-correct at the next real sync.

## The sibling line had it too

One line below, in the same capture: `Data write: rows last landed 4d ago` — against a strap whose own row count was zero. Two lines that both read as evidence the 5/MG had been syncing, and neither was about the 5/MG.

Both halves of the #57 write-health pair are scoped, not just the one that was noticed. They are read as a **pair** — "stalled more recently than ok" is the alarm — so scoping one would compare a strap's own stall against another strap's success.

## What it says now

For the strap in the capture: **"never (this strap)"**. Not a degraded answer — the correct one, and the one nobody had been given.

## Notes

- No Swift twin needed; the Apple side has no persisted global equivalent.
- The seed for `LiveState.lastSyncAt` resolves the single-strap fallback just after construction rather than in the constructor, because the paired count needs the registry and the registry is `suspend`. Seeding from the global first and correcting later would have shown the other strap's timestamp for as long as that took — the bug, briefly, rather than not at all.

## Verification

- `4907` tests, 0 failures
- `lintVitalFullRelease`, doc-comment lint, i18n `--ci` clean
- staging **392** / iOS **273**

Related to #1635.
