### PR TITLE
sync: skip the #689 backlog decode on the GET_DATA_RANGE PENDING ack

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/DataRange.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/DataRange.swift
@@ -87,4 +87,19 @@ public enum DataRange {
         guard behind >= 0, behind <= t else { return nil }
         return behind
     }
+
+    /// True when a GET_DATA_RANGE COMMAND_RESPONSE is the `PENDING(2)` acknowledgement rather than the
+    /// answer. The strap replies twice: a short PENDING ack, then the payload with `SUCCESS(1)`. Framing's
+    /// own result-code table already states it — "2=PENDING precedes SUCCESS on GET_DATA_RANGE
+    /// (hardware-confirmed, #78 fork)" — but `pagesBehind` had no way to tell the two apart, so the ack
+    /// (which carries no ring pointers by construction) decoded to nil and logged as a decode FAILURE once
+    /// per sync.
+    ///
+    /// The result byte sits at `cmdOff + 2`, after the echoed opcode and the origin sequence. A frame too
+    /// short to hold one is not a PENDING ack, so it stays false and the caller keeps its existing
+    /// too-short handling.
+    public static func isPendingResponse(_ frame: [UInt8], cmdOff: Int) -> Bool {
+        guard cmdOff >= 0, cmdOff + 2 < frame.count else { return false }
+        return frame[cmdOff + 2] == 2
+    }
 }

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DataRangeTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/DataRangeTests.swift
@@ -126,4 +126,39 @@ final class DataRangeTests: XCTestCase {
                            "pagesBehind for \(h) at cmdOff \(cmdOff) should be \(expected)")
         }
     }
+
+    // MARK: - #689 PENDING ack. Byte-parity twin of the Kotlin DataRangeScanTest cases.
+    //
+    // GET_DATA_RANGE answers twice and only the second carries the ring pointers. Both frames below are
+    // real, captured on a WHOOP MG (WS50_r00, fw 50.39.1.0) on 2026-08-28, and they are one request's
+    // two replies.
+
+    /// The PENDING(2) ack: 20 bytes, result byte at cmdOff+2 is 0x02, no ring pointers in it at all.
+    func testIsPendingResponse_trueForPendingAck() {
+        XCTAssertTrue(DataRange.isPendingResponse(hex("aa010c000100271124e8220402000000c391bc3d"), cmdOff: 10))
+    }
+
+    /// The SUCCESS(1) answer to that same request. Must NOT be skipped.
+    func testIsPendingResponse_falseForSuccessAnswer() {
+        let h = "aa014c00010032d124e92204010100bf0000b4be0000c1be0000b4be00000c000000000002008f00"
+        XCTAssertFalse(DataRange.isPendingResponse(hex(h), cmdOff: 10))
+    }
+
+    /// The reason this pair matters: the ack decodes to nil, so before the guard it logged as a decode
+    /// failure once per sync while the real answer decoded fine two lines later.
+    func testPendingAckIsExactlyTheFramePagesBehindCannotDecode() {
+        let pending = hex("aa010c000100271124e8220402000000c391bc3d")
+        XCTAssertNil(DataRange.pagesBehind(from: pending, cmdOff: 10))
+        XCTAssertTrue(DataRange.isPendingResponse(pending, cmdOff: 10))
+    }
+
+    /// A frame too short to hold a result byte is not a PENDING ack; the caller keeps its own handling.
+    func testIsPendingResponse_falseWhenTooShortForResultByte() {
+        XCTAssertFalse(DataRange.isPendingResponse([UInt8](repeating: 0, count: 11), cmdOff: 10))
+    }
+
+    /// A negative cmdOff is rejected rather than indexing backwards.
+    func testIsPendingResponse_falseForNegativeCmdOff() {
+        XCTAssertFalse(DataRange.isPendingResponse([UInt8](repeating: 0, count: 40), cmdOff: -1))
+    }
 }

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -6161,11 +6161,19 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
         // log was indistinguishable from one where the strap never answered, which is why a broken decode
         // survived unnoticed. The raw-frame dump above is unconditional for the same reason. If a firmware
         // revision ever shifts these fields again, the rejection must be visible rather than silent.
-        if let pages = DataRange.pagesBehind(from: frame, cmdOff: cmdOff) {
-            log("Strap backlog pages behind: \(pages) (#689 — GET_DATA_RANGE ring backlog, diagnostic only)")
-        } else {
-            log("Strap backlog pages behind: not decodable from this frame (#689 — offsets may have moved; "
-                + "the raw frame above is the input). Diagnostic only, sync is unaffected.")
+        // ...but NOT on the PENDING(2) ack. GET_DATA_RANGE answers twice — a short ack, then the payload —
+        // which Framing's result-code table already records ("2=PENDING precedes SUCCESS on
+        // GET_DATA_RANGE"). The ack carries no ring pointers at all, so decoding it failed every time and
+        // reported a decode problem that did not exist: one "offsets may have moved" per sync, on healthy
+        // hardware, pointing the reader at an alignment bug rather than at the ack. Skip it here; the
+        // SUCCESS frame still logs its failure loudly, which is the case the paragraph above protects.
+        if !DataRange.isPendingResponse(frame, cmdOff: cmdOff) {
+            if let pages = DataRange.pagesBehind(from: frame, cmdOff: cmdOff) {
+                log("Strap backlog pages behind: \(pages) (#689 — GET_DATA_RANGE ring backlog, diagnostic only)")
+            } else {
+                log("Strap backlog pages behind: not decodable from this frame (#689 — offsets may have moved; "
+                    + "the raw frame above is the input). Diagnostic only, sync is unaffected.")
+            }
         }
         if let newest = BLEManager.dataRangeNewestUnix(from: frame) {
             // #695: the sync-affecting side-effects (strapNewestTs, backfill window, LiveState range) only

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -6640,14 +6640,23 @@ class WhoopBleClient(
                         // logged NOTHING — a strap log was indistinguishable from one where the strap never
                         // answered, which is why a broken decode survived unnoticed. The raw-frame dump above
                         // is unconditional for the same reason. Twin of the Swift branch.
-                        val pagesBehind = com.noop.protocol.DataRange.pagesBehind(frame, cmdOff)
-                        if (pagesBehind != null) {
-                            log("Strap backlog pages behind: $pagesBehind (#689 — GET_DATA_RANGE ring backlog, diagnostic only)")
-                        } else {
-                            log(
-                                "Strap backlog pages behind: not decodable from this frame (#689 — offsets may " +
-                                    "have moved; the raw frame above is the input). Diagnostic only, sync is unaffected.",
-                            )
+                        // ...but NOT on the PENDING(2) ack. GET_DATA_RANGE answers twice — a short ack, then
+                        // the payload — which Framing's result-code table already records ("2=PENDING
+                        // precedes SUCCESS on GET_DATA_RANGE"). The ack carries no ring pointers at all, so
+                        // decoding it failed every time and reported a decode problem that did not exist:
+                        // one "offsets may have moved" per sync on healthy hardware, pointing the reader at
+                        // an alignment bug rather than at the ack. Skip it here; a SUCCESS frame that will
+                        // not decode still logs loudly, which is the case the paragraph above protects.
+                        if (!com.noop.protocol.DataRange.isPendingResponse(frame, cmdOff)) {
+                            val pagesBehind = com.noop.protocol.DataRange.pagesBehind(frame, cmdOff)
+                            if (pagesBehind != null) {
+                                log("Strap backlog pages behind: $pagesBehind (#689 — GET_DATA_RANGE ring backlog, diagnostic only)")
+                            } else {
+                                log(
+                                    "Strap backlog pages behind: not decodable from this frame (#689 — offsets may " +
+                                        "have moved; the raw frame above is the input). Diagnostic only, sync is unaffected.",
+                                )
+                            }
                         }
                         dataRangeNewestUnix(frame)?.let {
                             strapNewestTs = it

--- a/android/app/src/main/java/com/noop/protocol/DataRange.kt
+++ b/android/app/src/main/java/com/noop/protocol/DataRange.kt
@@ -97,4 +97,21 @@ object DataRange {
         if (behind < 0L || behind > t) return null
         return behind
     }
+
+    /**
+     * True when a GET_DATA_RANGE COMMAND_RESPONSE is the `PENDING(2)` acknowledgement rather than the
+     * answer. The strap replies twice: a short PENDING ack, then the payload with `SUCCESS(1)`. Framing's
+     * own result-code table already states it — "2=PENDING precedes SUCCESS on GET_DATA_RANGE
+     * (hardware-confirmed, #78 fork)" — but [pagesBehind] had no way to tell the two apart, so the ack
+     * (which carries no ring pointers by construction) decoded to null and logged as a decode FAILURE once
+     * per sync.
+     *
+     * The result byte sits at `cmdOff + 2`, after the echoed opcode and the origin sequence. A frame too
+     * short to hold one is not a PENDING ack, so it stays false and the caller keeps its existing
+     * too-short handling. Twin of the Swift `DataRange.isPendingResponse`.
+     */
+    fun isPendingResponse(frame: ByteArray, cmdOff: Int): Boolean {
+        if (cmdOff < 0 || cmdOff + 2 >= frame.size) return false
+        return (frame[cmdOff + 2].toInt() and 0xFF) == 2
+    }
 }

--- a/android/app/src/test/java/com/noop/ble/DataRangeScanTest.kt
+++ b/android/app/src/test/java/com/noop/ble/DataRangeScanTest.kt
@@ -2,7 +2,9 @@ package com.noop.ble
 
 import com.noop.protocol.DataRange
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -156,4 +158,42 @@ class DataRangeScanTest {
             )
         }
     }
+
+    // #689 PENDING ack: GET_DATA_RANGE answers twice and only the second carries the ring pointers.
+    // Byte-parity twin of the Swift DataRangeTests cases. Both frames are real, captured on a WHOOP MG
+    // (WS50_r00, fw 50.39.1.0) on 2026-08-28; the pair below is one request's two replies.
+
+    /** The PENDING(2) ack: 20 bytes, result byte at cmdOff+2 is 0x02, no ring pointers in it at all. */
+    @Test fun `isPendingResponse true for the PENDING ack`() =
+        assertTrue(DataRange.isPendingResponse(hex("aa010c000100271124e8220402000000c391bc3d"), 10))
+
+    /** The SUCCESS(1) answer to that same request. Must NOT be skipped. */
+    @Test fun `isPendingResponse false for the SUCCESS answer`() =
+        assertFalse(
+            DataRange.isPendingResponse(
+                hex(
+                    "aa014c00010032d124e92204010100bf0000b4be0000c1be0000b4be00000c00000000" +
+                        "0002008f00",
+                ),
+                10,
+            ),
+        )
+
+    /**
+     * The reason this pair matters: the ack decodes to null, so before the guard it logged as a decode
+     * failure once per sync while the real answer decoded fine two lines later.
+     */
+    @Test fun `the PENDING ack is exactly the frame pagesBehind cannot decode`() {
+        val pending = hex("aa010c000100271124e8220402000000c391bc3d")
+        assertNull(DataRange.pagesBehind(pending, 10))
+        assertTrue(DataRange.isPendingResponse(pending, 10))
+    }
+
+    /** A frame too short to hold a result byte is not a PENDING ack; the caller keeps its own handling. */
+    @Test fun `isPendingResponse false when too short for a result byte`() =
+        assertFalse(DataRange.isPendingResponse(ByteArray(11), 10))
+
+    /** A negative cmdOff is rejected rather than indexing backwards. */
+    @Test fun `isPendingResponse false for a negative cmdOff`() =
+        assertFalse(DataRange.isPendingResponse(ByteArray(40), -1))
 }


### PR DESCRIPTION
## What this PR does

`GET_DATA_RANGE` answers twice: a short `PENDING(2)` acknowledgement, then the payload with `SUCCESS(1)`. The #689 backlog decode runs on both. The ack carries no ring pointers, so it decodes to null and logs as a decode failure, once per sync, on healthy hardware:

```
→ GET_DATA_RANGE payload= (puffin)
Command response: GET_DATA_RANGE(34) → PENDING(2)
Get Data Range raw frame (#451 …): aa010c000100271124e8220402000000c391bc3d
Strap backlog pages behind: not decodable from this frame (#689 — offsets may have moved; …)
Backfill: GET_DATA_RANGE SUCCESS — requesting history
Get Data Range raw frame (#451 …): aa014c00010032d124e92204010100bf0000b4be…
Strap backlog pages behind: 13 (#689 — GET_DATA_RANGE ring backlog, diagnostic only)
```

The split is structural rather than marginal. One session on my MG on 2026-08-28, 34 responses:

| frames | length | result byte | decode |
|---:|---:|---|---|
| 17 | 20 bytes | `0x02` PENDING | fails, every time |
| 17 | 84 bytes | `0x01` SUCCESS | succeeds, every time |

My 2026-08-27 capture has the same shape (19 / 26), so it is not a one-off.

The tree already knows this happens. `Framing.kt`'s own result-code table says it:

> `2=PENDING precedes SUCCESS on GET_DATA_RANGE (hardware-confirmed, #78 fork)`

The decode site just had no way to act on it, because `pagesBehind` only sees the frame and a too-short frame is indistinguishable from a misaligned one.

## Why it is worth a change rather than ignoring

The message names a cause: "offsets may have moved", and points at the raw frame as the input to analyse. That was the right thing to write when the failure mode was unknown, and the comment above it explains why both branches log at all: until #818 the offsets really were wrong and this branch logged nothing, so a broken decode was invisible. That reasoning still holds for a SUCCESS frame that will not parse, and this PR leaves that case exactly as loud as it was.

What it stops is the ack. On current firmware that warning fires on a frame that is not a data-range frame by construction, so anyone following the hint goes looking for an alignment bug that is not there.

## Shape of the change

A pure `DataRange.isPendingResponse(frame, cmdOff)` on both platforms, reading the result byte at `cmdOff + 2`, used to gate the decode at the two call sites. A frame too short to hold a result byte returns false, so the existing too-short handling is untouched.

The #451 raw-frame dump above it stays unconditional. It is cheap, and it is the input any future offset analysis would want.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

Not on the BLE path. `isPendingResponse` and `pagesBehind` are pure and the change only gates a log line; no bytes move on the wire.

Five new cases per platform in the files that already pin `pagesBehind`, using the real PENDING/SUCCESS pair from one request on my MG (`WS50_r00`, fw `50.39.1.0`, 2026-08-28) rather than synthetic frames. One of them asserts the pair directly: the ack is exactly the frame `pagesBehind` returns null for, and the new predicate is what tells them apart.

`./gradlew testFullDebugUnitTest --tests com.noop.ble.DataRangeScanTest` on Windows 11, JDK 17:

- with the fix: 17 tests, 0 failures
- with the tests kept and `isPendingResponse` stubbed to `return false`: 2 failed, `the PENDING ack is exactly the frame pagesBehind cannot decode` and `isPendingResponse true for the PENDING ack`, both `java.lang.AssertionError`. The other 15, including all 12 pre-existing, still passed
- fix restored: 17 tests, 0 failures

Full suite, since `DataRange` is shared surface: `./gradlew testFullDebugUnitTest --rerun-tasks --no-build-cache` against `main` @ `b2a4049` — **4,903 tests across 600 classes, 0 failures, 0 errors** (6 skipped, pre-existing).

`python Tools/doc_comment_lint.py`: `OK no NEW detached doc comments (1902 files, 24 baselined site(s) remaining)`.

**The gap I would rather state than have you find:** the Swift half is not run locally, no Apple machine. `DataRangeTests` lives in `Packages/WhoopProtocol`, which `swift-packages.yml` covers, and `BLEManager.swift` is compiled by `app-build.yml`. The Swift change is line for line the twin of the Kotlin one that was run, but that is reasoning plus CI rather than a local run.

## Checklist

- [ ] Swift package tests pass — **not run locally (no Apple machine); left to `swift-packages.yml`**
- [x] Android unit tests pass (`./gradlew testFullDebugUnitTest`, full suite)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — n/a, no UI
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders — the new literals are test fixtures (captured frames), and the predicate reads a documented result byte
- [x] Follows the conventions in `docs/CONTRIBUTING.md`
- [x] I did not commit generated output or any secrets/keystores

## Related issues

Refs #689 (the feature this guards), #818 (the offset fix whose comment explains why both branches log), #78 (where the PENDING-precedes-SUCCESS behaviour was confirmed).

Leaves #689 open on its own merits; that work landed in #694 and the decode itself is correct. This only stops it running on a frame that cannot carry its input. (Deliberately phrased with no closing verb adjacent to an issue number: GitHub matches those keywords literally and does not read negations, so a denial would have been actioned as a closing keyword on merge.)