### PR TITLE
tooling: i18n_audit keys its baselines on OS-native paths, so it fails on a clean tree on Windows

### DIFF
--- a/Tools/i18n_audit.py
+++ b/Tools/i18n_audit.py
@@ -435,7 +435,7 @@ def scan_android() -> list[tuple[str, int, str]]:
                         continue
                     seen.add(offset)
                     line_no = text.count("\n", 0, offset) + 1
-                    findings.append((str(path.relative_to(ROOT)), line_no, literal))
+                    findings.append((path.relative_to(ROOT).as_posix(), line_no, literal))
 
             # The call's own first (content) argument only — catches
             # `Text(if (x) "a" else "b")` — never the whole call span, which
@@ -856,7 +856,7 @@ def scan_ios() -> tuple[list[tuple[str, int, str]], dict[str, list[str]]]:
                         continue
                     entry = swift_catalog_lookup(cat, literal)
                     line_no = text.count("\n", 0, offset) + 1
-                    rel = str(path.relative_to(ROOT))
+                    rel = path.relative_to(ROOT).as_posix()
                     if entry is None:
                         hardcoded.append((rel, line_no, literal))
                         continue
@@ -864,7 +864,7 @@ def scan_ios() -> tuple[list[tuple[str, int, str]], dict[str, list[str]]]:
                         continue
                     for lang in LANGS:
                         if not _is_translated(entry, lang):
-                            lang_gaps[lang].append(f"{catalog_path.relative_to(ROOT)} :: {literal!r}")
+                            lang_gaps[lang].append(f"{catalog_path.relative_to(ROOT).as_posix()} :: {literal!r}")
     for lang in lang_gaps:
         lang_gaps[lang] = sorted(set(lang_gaps[lang]))
     return hardcoded, lang_gaps
@@ -948,7 +948,7 @@ def _ios_echoed_counts() -> dict[str, int]:
             cat = json.loads(catalog_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             continue
-        rel = str(catalog_path.relative_to(ROOT))
+        rel = catalog_path.relative_to(ROOT).as_posix()
         for key, entry in (cat.get("strings") or {}).items():
             if not _has_translatable_words(key):
                 continue
@@ -984,7 +984,7 @@ def _android_echoed_counts() -> dict[str, int]:
             loc = {n.attrib["name"]: (n.text or "") for n in ET.parse(path).getroot().findall("string")}
         except ET.ParseError:
             continue
-        rel = str(path.relative_to(ROOT))
+        rel = path.relative_to(ROOT).as_posix()
         n = sum(1 for k, base_val in translatable.items() if loc.get(k) == base_val)
         if n:
             counts[f"{rel} {lang}"] = n
@@ -1126,7 +1126,7 @@ def ci_check(base_ref: str) -> int:
         # and gate them below. Reloading each catalog for a second pass wasted a full re-parse of a
         # 3255-string file.
         for extra in sorted(shipped_apple_langs(cat) - set(LANGS)):
-            extra_apple_gaps[f"{catalog_path.relative_to(ROOT)}:{extra}"] = sum(
+            extra_apple_gaps[f"{catalog_path.relative_to(ROOT).as_posix()}:{extra}"] = sum(
                 1 for v in cat.get("strings", {}).values()
                 if v.get("shouldTranslate") is not False and not _is_translated(v, extra)
             )


### PR DESCRIPTION
## What this PR does

The same disease `doc_comment_lint` had (#1691), in `Tools/i18n_audit.py`, six sites this time: four `str(path.relative_to(ROOT))` and two f-strings interpolating the bare path. Every baseline file stores forward slashes, so on Windows every lookup misses. On a completely clean checkout:

- `FAIL 236 NEW hardcoded literal(s)` — all 224 tracked Android entries counted as new
- `FAIL 63 NEW literal(s) absent from their target catalog` — exactly the iOS baseline size, every entry missed
- every ratcheting locale allowance read as 0, so all eleven debt-carrying locales failed (`Strand\Resources\Localizable.xcstrings:it: missing=179 exceeds the allowance of 0`), while the same run printed `STALE … is no longer present — drop it` for the very entries it was failing against

The two messages point opposite directions, same trap as #1691: the natural conclusion is that the baselines are stale and should be regenerated, which would wipe the ratchet. CI runs on ubuntu so it stays green there; only a Windows contributor running the gate locally sees it, and then goes hunting for 299 regressions they did not cause.

The fix is `as_posix()` at each site, a no-op on POSIX where `relative_to` already yields forward slashes.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] CI / tooling

## How it was tested

Not on the BLE path; no app code touched.

On Windows 11 / Python 3.12, against a clean checkout of `main` at `b2a4049`:

- **before:** exit 1, 236 + 63 false NEW literals, 11 false locale failures, 8 false STALE lines — on an unmodified tree
- **after:** exit 0, `OK no new hardcoded literals (222 pre-existing, tracked in the baseline)`, `OK no new un-extracted literals (62 pre-existing)`, every locale allowance matched

The pre-existing counts are unchanged by the fix, which is the check that it restores the intended lookup rather than hiding anything.

`Tools/test_i18n_audit.py`: 47 tests, OK. `python Tools/doc_comment_lint.py` clean.

Not re-run on Linux or macOS: `as_posix()` is a no-op there, and `i18n-coverage.yml` plus `tools-python.yml` run this on ubuntu on this PR anyway — reasoning plus CI, not a local run, so saying it rather than claiming it.

## Checklist

- [x] Swift package tests pass — n/a, no packages touched
- [x] Android unit tests pass — n/a
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — n/a
- [x] No hardcoded hex frame bytes — n/a
- [x] Follows the conventions in `docs/CONTRIBUTING.md`
- [x] I did not commit generated output or any secrets/keystores

## Related issues

Same class as #1691. Surfaced the same way: running the repo's own gates locally on Windows before opening a PR.