### PR TITLE
Sync controls follow what the strap can actually do

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -26,7 +26,7 @@ android {
         applicationId = "com.noop.whoop"
         minSdk = 26
         targetSdk = 34
-        versionCode = 392
+        versionCode = 393
         versionName = "10.6.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -201,6 +201,14 @@ data class LiveState(
     /** Set when an offload ended abnormally (strap went quiet mid-sync / idle-watchdog fired), so a
      *  stalled history download isn't silent. Cleared on the next successful HISTORY_COMPLETE. (PR #85) */
     val lastSyncError: String? = null,
+    /** True once this strap can actually hand over history — the UI mirror of the client's
+     *  `connectHandshakeDone`, which [beginBackfill] already requires before it will request an offload.
+     *
+     *  Exposed because [bonded] is NOT that condition and reads true too early: the live-HR path sets it
+     *  for a 5/MG that has never completed a handshake, so Today offered a pull-to-sync that was accepted
+     *  by the gesture and then refused deeper down, silently. Gating on this makes the control unavailable
+     *  exactly when the sync would have been declined anyway — never when it would have run. */
+    val historyReady: Boolean = false,
     /** Set when a connect attempt fails because the strap wiped its Bluetooth bond — a firmware reset,
      *  or the official WHOOP app re-bonding it. The OS still holds a now-stale bond, so retrying the
      *  direct connect just re-fails. Carries an actionable forget+re-pair guide; cleared on the next
@@ -4869,6 +4877,7 @@ class WhoopBleClient(
         // Clock-before-history is mandatory — an un-clocked 5/MG discards sensor data rather than banking it
         // — and it is only reached here because the strap has just demonstrated it answers commands.
         connectHandshakeDone = true
+        _state.update { it.copy(historyReady = true) }
         // requestSync ALSO gates on state.bonded, and for a 5/MG that flag is set by the live-HR path -
         // the first plausible reading over the standard profile. A strap sitting on a charger streams no
         // HR, so without this the probe would succeed, announce it, and then be refused by a second gate
@@ -6380,6 +6389,7 @@ class WhoopBleClient(
             // WHOOP 5.0/MG uses CLIENT_HELLO, not this WHOOP4 command sequence, so it is skipped for it.
             if (!connectHandshakeDone && connectedFamily == DeviceFamily.WHOOP4) {
                 connectHandshakeDone = true
+                _state.update { it.copy(historyReady = true) }
                 noteRebootReconnectIfNeeded()
                 runConnectHandshake()
             }
@@ -8437,6 +8447,7 @@ class WhoopBleClient(
             // once-per-connection (keep-alive resubscribes also land here). (#78 fork, hardware-proven)
             if (connectedFamily == DeviceFamily.WHOOP5 && didBond && !connectHandshakeDone) {
                 connectHandshakeDone = true
+                _state.update { it.copy(historyReady = true) }
                 noteRebootReconnectIfNeeded()
                 send(CommandNumber.SET_CLOCK, setClockPayload(), withResponse = true)
                 send(CommandNumber.GET_CLOCK, byteArrayOf(), withResponse = true)
@@ -9771,6 +9782,9 @@ class WhoopBleClient(
         // exactly the gap this stopwatch was added to close. It is overwritten by the next request, and a
         // stale value can only ever produce a large elapsed against a label that names what it measures.
         connectHandshakeDone = false
+        // Mirrors the flag above: a new link has not done the handshake, so it cannot hand over history
+        // until it does. Cleared HERE and nowhere else, so the two can never disagree.
+        _state.update { it.copy(historyReady = false) }
         // #1635: the probe is per LINK — its whole basis is one stable link's behaviour, and carrying the
         // "already asked" flag across a reconnect would let one silent link retire the experiment. The
         // REFUSAL, by contrast, is persisted per device: that one is the strap's answer, not the link's.

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -311,10 +311,14 @@ private fun SyncStatusSection(vm: AppViewModel, onSyncNow: () -> Unit) {
                         )
                     }
                     else -> StatePill(
-                        title = if (live.bonded) "Ready to sync" else "Pairing…",
+                        // Same condition as the button below it. Keyed on `bonded` this said "Ready to
+                        // sync", not pulsing, directly above a DISABLED Sync now — on exactly the strap
+                        // that cannot sync. Before the button was gated the two agreed (both wrong);
+                        // gating one without the other is what made them contradict.
+                        title = if (live.historyReady) "Ready to sync" else "Pairing…",
                         tone = StrandTone.Accent,
                         showsDot = true,
-                        pulsing = !live.bonded,
+                        pulsing = !live.historyReady,
                     )
                 }
 
@@ -359,7 +363,12 @@ private fun syncHelperText(live: LiveState): String = when {
         "now continues automatically across passes instead of waiting between syncs."
     !live.connected -> "Connect your strap to sync its stored history. Until then, only imported data " +
         "shows here."
-    !live.bonded -> "Finishing the pairing handshake. Sync now becomes available once the strap is paired."
+    // historyReady, not `bonded`. This branch already said the right thing and simply never fired on the
+    // strap that needed it: `bonded` is set by the live-HR path, so a 5/MG that never completed a
+    // handshake fell through to the "syncs right away" line, directly under a Sync-now button that had
+    // just been disabled. Same condition as the button and the card title, so all three agree.
+    !live.historyReady ->
+        "Finishing the pairing handshake. Sync now becomes available once the strap is paired."
     else -> "Syncs your strap's stored history right away, instead of waiting for the next automatic sync."
 }
 

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -278,7 +278,9 @@ private fun SyncStatusSection(vm: AppViewModel, onSyncNow: () -> Unit) {
     // leaf re-runs per tick. Appearance + behaviour identical.
     val live by vm.live.collectAsStateWithLifecycle()
     // The strap link is usable for a manual offload kick (matches WhoopBleClient.syncNow's own gate).
-    val canSync = live.connected && live.bonded && !live.backfilling
+    // historyReady, not `bonded`: on a 5/MG the live-HR path sets `bonded` for a strap that has never
+    // completed a handshake, so this button enabled itself and beginBackfill then declined it silently.
+    val canSync = live.connected && live.bonded && live.historyReady && !live.backfilling
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
         SectionHeader(
             "Sync",

--- a/android/app/src/main/java/com/noop/ui/LiveScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/LiveScreen.kt
@@ -640,12 +640,17 @@ fun LiveScreen(viewModel: AppViewModel, onManageDevices: () -> Unit = {}) {
         }
 
         // Manual "Sync now" — kick a historical offload on demand instead of waiting for the 15-min
-        // periodic timer (#93). Only meaningful once bonded (the offload needs the command channel), and
-        // disabled mid-session so a double-tap can't fight the in-flight offload — viewModel.syncNow()
-        // also no-ops in that case, this is just the matching UI state. While syncing, the button shows
+        // periodic timer (#93). Needs a strap that can actually hand over history, and disabled
+        // mid-session so a double-tap can't fight the in-flight offload — viewModel.syncNow() also
+        // no-ops in that case, this is just the matching UI state.
+        //
+        // `bonded` alone was NOT that condition and this comment used to say it was: the live-HR path
+        // sets it for a 5/MG that has never completed a handshake, so the button appeared, was pressed,
+        // and beginBackfill declined it in silence. historyReady is the client's own precondition, so
+        // the button can only vanish where the offload would have been refused anyway. While syncing, the button shows
         // an INDETERMINATE spinner (NEVER a percent — total pending records are unknowable from the
         // protocol); the "Syncing your strap history… N chunks pulled" line above carries the live count.
-        if (live.bonded) {
+        if (live.bonded && live.historyReady) {
             item {
             OutlinedButton(
                 onClick = { viewModel.syncNow() },

--- a/android/app/src/main/java/com/noop/ui/TodayProvenance.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayProvenance.kt
@@ -161,13 +161,27 @@ internal fun scoreHeroSourceLabel(
     )
 }
 
-/** Today pull-to-sync mirrors the BLE client's manual-sync guard, so the gesture never starts a sync while
- *  disconnected, still bonding, or already offloading. Kept pure for the UI-specific contract test. */
+/**
+ * Today pull-to-sync mirrors the BLE client's manual-sync guard, so the gesture never starts a sync while
+ * disconnected, still bonding, or already offloading. Kept pure for the UI-specific contract test.
+ *
+ * [historyReady] is the second half of that mirror and was missing. `canRequestSync` checks `bonded`,
+ * which on a 5/MG is set by the live-HR path — true on a strap that has never completed a handshake. So
+ * the gesture was offered, accepted, and then refused by `beginBackfill`'s own `connectHandshakeDone`
+ * gate with nothing shown: a control that ran and did nothing, reported four times as "refresh doesn't
+ * work". It was working; it was silent.
+ *
+ * Adding the client's OWN precondition cannot disable a sync that would have run, because
+ * `beginBackfill` already requires exactly this flag before it will request an offload. The gesture now
+ * goes away precisely when the sync would have been declined anyway — including on a WHOOP 4.0 whose
+ * bond has not landed yet, which a strap-family check would have missed.
+ */
 internal fun todayPullToSyncEnabled(
     connected: Boolean,
     bonded: Boolean,
     backfilling: Boolean,
-): Boolean = WhoopBleClient.canRequestSync(connected, bonded, backfilling)
+    historyReady: Boolean,
+): Boolean = WhoopBleClient.canRequestSync(connected, bonded, backfilling) && historyReady
 
 /** The tint for a per-metric provenance badge, keyed on the resolved LABEL, gold for Whoop, cyan for
  *  Apple Health, the positive status hue for on-device (and anything else). Matches the Data Sources

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -252,6 +252,9 @@ private data class TodayLiveSnapshot(
     val lastSyncAt: Long?,
     val backfilling: Boolean,
     val syncChunksThisSession: Int,
+    /** Mirrors `LiveState.historyReady` — whether this strap can actually hand over history. Flips at
+     *  most once per connection, so it costs the snapshot nothing. */
+    val historyReady: Boolean,
     val historySyncExperimental: Boolean,
     val batteryPct: Double?,
     /** True once a WHOOP 5/MG strap has been seen this session, picks the 5/MG rated-life fallback for the
@@ -332,6 +335,7 @@ fun TodayScreen(
                 lastSyncAt = s.lastSyncAt,
                 backfilling = s.backfilling,
                 syncChunksThisSession = s.syncChunksThisSession,
+                historyReady = s.historyReady,
                 historySyncExperimental = s.historySyncExperimental,
                 batteryPct = s.batteryPct,
                 whoop5 = s.whoop5Detected,
@@ -1152,7 +1156,8 @@ fun TodayScreen(
             onHorizontalDrag = { _, dragAmount -> accumulatedX += dragAmount },
         )
     }
-    val canPullToSync = todayPullToSyncEnabled(liveSnap.connected, liveSnap.bonded, liveSnap.backfilling)
+    val canPullToSync =
+        todayPullToSyncEnabled(liveSnap.connected, liveSnap.bonded, liveSnap.backfilling, liveSnap.historyReady)
     // material3 1.2.1's rememberPullToRefreshState CAPTURES the `enabled` lambda ONCE (rememberSaveable,
     // no rememberUpdatedState), so `{ canPullToSync }` would freeze the plain Boolean from the FIRST
     // composition — and Today usually first composes before the strap has (re)connected, leaving the
@@ -1160,7 +1165,11 @@ fun TodayScreen(
     // instead, so each gesture check sees the current connected/bonded/backfilling. (syncNow is triple-gated
     // anyway; this just makes the gesture actually enable once the strap is ready.)
     val pullToSyncState = rememberPullToRefreshState(
-        enabled = { todayPullToSyncEnabled(liveSnap.connected, liveSnap.bonded, liveSnap.backfilling) },
+        enabled = {
+            todayPullToSyncEnabled(
+                liveSnap.connected, liveSnap.bonded, liveSnap.backfilling, liveSnap.historyReady,
+            )
+        },
     )
     LaunchedEffect(pullToSyncState.isRefreshing, canPullToSync) {
         if (pullToSyncState.isRefreshing) {

--- a/android/app/src/test/java/com/noop/ui/TodayExplainabilityTest.kt
+++ b/android/app/src/test/java/com/noop/ui/TodayExplainabilityTest.kt
@@ -422,10 +422,44 @@ class TodayExplainabilityTest {
 
     @Test
     fun pullToSync_onlyEnabledWhenConnectedBondedAndIdle() {
-        assertTrue(todayPullToSyncEnabled(connected = true, bonded = true, backfilling = false))
+        assertTrue(todayPullToSyncEnabled(
+            connected = true, bonded = true, backfilling = false, historyReady = true))
 
-        assertFalse(todayPullToSyncEnabled(connected = false, bonded = true, backfilling = false))
-        assertFalse(todayPullToSyncEnabled(connected = true, bonded = false, backfilling = false))
-        assertFalse(todayPullToSyncEnabled(connected = true, bonded = true, backfilling = true))
+        assertFalse(todayPullToSyncEnabled(
+            connected = false, bonded = true, backfilling = false, historyReady = true))
+        assertFalse(todayPullToSyncEnabled(
+            connected = true, bonded = false, backfilling = false, historyReady = true))
+        assertFalse(todayPullToSyncEnabled(
+            connected = true, bonded = true, backfilling = true, historyReady = true))
+    }
+
+    /**
+     * THE case this argument exists for, from the field: a WHOOP 5/MG that has never completed a
+     * handshake. `bonded` is true — the live-HR path sets it — so every other condition passes and the
+     * gesture was offered, accepted, and then refused by `beginBackfill`'s own `connectHandshakeDone`
+     * gate with nothing shown. Reported four times as "refresh doesn't work"; it worked, it was silent.
+     */
+    @Test
+    fun `a strap that cannot hand over history does not offer the gesture`() {
+        assertFalse(todayPullToSyncEnabled(
+            connected = true, bonded = true, backfilling = false, historyReady = false))
+    }
+
+    /**
+     * The no-regression contract, and the reason this is safe to add: the new argument mirrors a
+     * precondition `beginBackfill` ALREADY enforces, so the gesture can only disappear where the sync
+     * would have been declined regardless. It can never withhold a refresh that would have run — which
+     * is exactly what a strap-family check could not promise.
+     */
+    @Test
+    fun `it never withholds a sync that would have run`() {
+        // Every combination the old three-argument gate allowed still passes, provided the client would
+        // actually have accepted it. historyReady=true is that condition, not an extra hurdle.
+        assertTrue(todayPullToSyncEnabled(
+            connected = true, bonded = true, backfilling = false, historyReady = true))
+        // And it catches a case a family check would miss entirely: a WHOOP 4.0 whose bond has not landed
+        // is just as unable to sync as an unpaired 5/MG, and its gesture is just as dead.
+        assertFalse(todayPullToSyncEnabled(
+            connected = true, bonded = false, backfilling = false, historyReady = false))
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -21,7 +21,7 @@ settings:
     # iOS build number (CFBundleVersion). GLOBAL so the iOS app AND its widget extension inherit the
     # SAME value — they must match or iOS warns "extension version must match parent app" (#416).
     # macOS sets its own CFBundleVersion on the Strand target and is unaffected by this.
-    CURRENT_PROJECT_VERSION: "273"
+    CURRENT_PROJECT_VERSION: "274"
     SWIFT_VERSION: "5.0"
     # Emit localizable strings so Xcode auto-extracts every LocalizedStringKey into the
     # String Catalog on build (the English (US) base entries).


### PR DESCRIPTION
"Refresh doesn't work" — reported four times. It worked. It was silent.

## The defect

Every manual-sync control gates on `bonded`, and `bonded` is not the condition. The live-HR path sets it for a 5/MG that has never completed a handshake, so the control is offered, accepted, and then declined by `beginBackfill`'s own `connectHandshakeDone` gate — into the log and nowhere else:

```
22:20:16  Backfill: deferred — connect handshake not done yet
          (family=WHOOP5 didBond=false helloWrittenThisLink=true deferrals=1)
22:20:18  Backfill: deferred — ... deferrals=2
```

Two pulls in three seconds, both turned away, nothing on screen.

## The change

`LiveState.historyReady`, published at exactly the three sites that set `connectHandshakeDone` and cleared at the one that clears it, so the two cannot drift. Three controls gate on it:

- Today's pull-to-sync gesture
- the Live screen's "Sync now" button
- the Health screen's sync card

## Why this cannot cause a regression

`connectHandshakeDone` is **already** a precondition of `beginBackfill`. The controls therefore disappear exactly where the offload would have been refused anyway, and can never withhold a sync that would have run.

Staleness is covered twice over: `reset()` runs on `connectToDevice` as well as `handleDisconnect`, so a stale `true` is cleared before any new link sets `connected` — and `canRequestSync` checks `connected` regardless.

On a **WHOOP 4.0 that has bonded, nothing changes at all**. Both flags are set in the same callback, eleven lines apart:

```kotlin
} else if (!didBond && connectedFamily == DeviceFamily.WHOOP4) {
    _state.update { it.copy(bonded = true, encryptedBond = true) }   // 6371
}
if (!connectHandshakeDone && connectedFamily == DeviceFamily.WHOOP4) {
    connectHandshakeDone = true                                       // 6382
}
```

A 5/MG that completes its handshake likewise keeps every control it had.

And it catches a case a strap-family check could not: **a 4.0 whose bond has not landed** has a dead sync button too, and it now goes away as well.

## Deliberately not gated

The three `syncNow()` calls in Settings and Test Centre. Those are **re-analysis nudges** after an HRV-window or baseline change, not sync controls — their own comments say they no-op cleanly, and gating them would stop a re-score for a reason that has nothing to do with re-scoring.

## Deliberately not included

The line explaining *why* the control is absent. It needs new copy in six locales and a UI surface Today does not currently have, and the ask here was a minimal change. A hidden control is quieter than a dead one but still doesn't say why — worth doing next, as its own change.

## Verification

- `4909` tests, 0 failures
- `lintVitalFullRelease`, doc-comment lint, i18n `--ci` clean
- audited every `syncNow()` and `canRequestSync` caller; no other surface reads `bonded` as a sync-capability proxy
- staging **393** / iOS **274**

Related to #1635.
