### PR TITLE
Add a JSON query CLI for local read tools

### DIFF
--- a/Packages/NoopLocalAccess/README.md
+++ b/Packages/NoopLocalAccess/README.md
@@ -1,0 +1,30 @@
+# NoopLocalAccess
+
+`noop-local-access` exposes bounded, read-only NOOP health data locally. It has no network or
+write/control path.
+
+Use MCP over stdio with `noop-local-access mcp`, or query one tool directly as JSON:
+
+```sh
+noop-local-access query health_snapshot --days 14
+noop-local-access query metric_series --key hrv --days 90
+noop-local-access query data_freshness
+noop-local-access query sleep_summary --days 30
+noop-local-access query workout_summary --days 90
+```
+
+Set `NOOP_DB_PATH` to select a database, or pass `--db-path PATH`. Query results are written to
+stdout; diagnostics are written to stderr. Query usage errors exit 64 and runtime/database errors
+exit 1.
+
+Arguments reuse the MCP defaults and bounds:
+
+- `health_snapshot`: optional `--days` (default 14, clamped to 1...120).
+- `metric_series`: required `--key`; optional `--source` (default `my-whoop`), `--days` (default 90,
+  clamped to 1...4000), `--from-day`, `--to-day`, and `--limit` (default 500, clamped to 1...2000).
+- `data_freshness`: no tool arguments.
+- `sleep_summary`: optional `--days` (default 30, clamped to 1...4000).
+- `workout_summary`: optional `--days` (default 90, clamped to 1...4000).
+
+Dates use the existing `YYYY-MM-DD` tool contract. The CLI does not add a separate validation or
+interpretation layer; it passes accepted arguments to the same bounded read-only dispatcher as MCP.

--- a/Packages/NoopLocalAccess/Sources/NoopLocalAccessCore/CLIQuery.swift
+++ b/Packages/NoopLocalAccess/Sources/NoopLocalAccessCore/CLIQuery.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+public struct NoopCLIQueryRequest: Equatable, Sendable {
+    public let toolName: String
+    public let arguments: [String: JSONValue]
+    public let configuration: LocalAccessConfiguration
+
+    public init(
+        toolName: String,
+        arguments: [String: JSONValue],
+        configuration: LocalAccessConfiguration = .environment()
+    ) {
+        self.toolName = toolName
+        self.arguments = arguments
+        self.configuration = configuration
+    }
+}
+
+public enum NoopCLIQueryError: Error, CustomStringConvertible, Equatable {
+    case usage(String)
+
+    public var description: String {
+        switch self {
+        case .usage(let message): return message
+        }
+    }
+
+    public var exitCode: Int32 { 64 }
+}
+
+public enum NoopCLIQuery {
+    public static func parse(arguments: [String]) throws -> NoopCLIQueryRequest {
+        guard let toolName = arguments.first, !toolName.hasPrefix("-") else {
+            throw NoopCLIQueryError.usage("query requires one tool name")
+        }
+        guard NoopToolDispatcher.toolNames.contains(toolName) else {
+            throw NoopCLIQueryError.usage("unknown query tool")
+        }
+
+        var toolArguments: [String: JSONValue] = [:]
+        var configuration = LocalAccessConfiguration.environment()
+        var seenFlags = Set<String>()
+        var index = 1
+
+        while index < arguments.count {
+            let flag = arguments[index]
+            guard flag.hasPrefix("--") else {
+                throw NoopCLIQueryError.usage("query does not accept additional positional arguments")
+            }
+            guard seenFlags.insert(flag).inserted else {
+                throw NoopCLIQueryError.usage("duplicate query flag: \(flag)")
+            }
+            index += 1
+
+            switch flag {
+            case "--db-path":
+                configuration.databasePath = try requiredValue(flag, arguments: arguments, index: &index)
+            case "--days":
+                guard toolName != "data_freshness" else { throw unsupported(flag, toolName: toolName) }
+                toolArguments["days"] = try integerValue(flag, arguments: arguments, index: &index)
+            case "--key":
+                guard toolName == "metric_series" else { throw unsupported(flag, toolName: toolName) }
+                toolArguments["key"] = .string(try requiredValue(flag, arguments: arguments, index: &index))
+            case "--source":
+                guard toolName == "metric_series" else { throw unsupported(flag, toolName: toolName) }
+                toolArguments["source"] = .string(try requiredValue(flag, arguments: arguments, index: &index))
+            case "--from-day":
+                guard toolName == "metric_series" else { throw unsupported(flag, toolName: toolName) }
+                toolArguments["from_day"] = .string(try requiredValue(flag, arguments: arguments, index: &index))
+            case "--to-day":
+                guard toolName == "metric_series" else { throw unsupported(flag, toolName: toolName) }
+                toolArguments["to_day"] = .string(try requiredValue(flag, arguments: arguments, index: &index))
+            case "--limit":
+                guard toolName == "metric_series" else { throw unsupported(flag, toolName: toolName) }
+                toolArguments["limit"] = try integerValue(flag, arguments: arguments, index: &index)
+            default:
+                throw NoopCLIQueryError.usage("unknown query flag")
+            }
+        }
+
+        if toolName == "metric_series", toolArguments["key"] == nil {
+            throw NoopCLIQueryError.usage("metric_series requires --key")
+        }
+
+        return NoopCLIQueryRequest(toolName: toolName, arguments: toolArguments, configuration: configuration)
+    }
+
+    public static func dispatch(_ request: NoopCLIQueryRequest) throws -> JSONValue {
+        try NoopToolDispatcher(configuration: request.configuration)
+            .dispatch(name: request.toolName, arguments: request.arguments)
+    }
+
+    public static func encodeLine(_ value: JSONValue) throws -> Data {
+        var data = try JSONEncoder().encode(value)
+        data.append(0x0A)
+        return data
+    }
+
+    private static func requiredValue(_ flag: String, arguments: [String], index: inout Int) throws -> String {
+        guard index < arguments.count, !arguments[index].hasPrefix("--") else {
+            throw NoopCLIQueryError.usage("missing value for \(flag)")
+        }
+        defer { index += 1 }
+        return arguments[index]
+    }
+
+    private static func integerValue(_ flag: String, arguments: [String], index: inout Int) throws -> JSONValue {
+        let raw = try requiredValue(flag, arguments: arguments, index: &index)
+        guard let value = Int(raw) else {
+            throw NoopCLIQueryError.usage("value for \(flag) must be an integer")
+        }
+        return .int(value)
+    }
+
+    private static func unsupported(_ flag: String, toolName: String) -> NoopCLIQueryError {
+        .usage("\(flag) is not supported for \(toolName)")
+    }
+}

--- a/Packages/NoopLocalAccess/Sources/NoopLocalAccessCore/MCPServer.swift
+++ b/Packages/NoopLocalAccess/Sources/NoopLocalAccessCore/MCPServer.swift
@@ -17,11 +17,10 @@ public struct RPCRequest: Decodable, Equatable {
 }
 
 public final class NoopMCPServer {
-    private let configuration: LocalAccessConfiguration
-    private var dataAccess: NoopDataAccess?
+    private let dispatcher: NoopToolDispatcher
 
     public init(configuration: LocalAccessConfiguration = .environment()) {
-        self.configuration = configuration
+        dispatcher = NoopToolDispatcher(configuration: configuration)
     }
 
     public func handleLine(_ line: String) -> JSONValue {
@@ -113,19 +112,6 @@ public final class NoopMCPServer {
     NOOP local access is read-only and returns personal health context from the user's on-device SQLite store. Use bounded tools, check data_freshness before stale-data claims, separate facts from inference, and do not diagnose medical conditions. No tool writes data or calls a network service.
     """
 
-    private func data() throws -> NoopDataAccess {
-        if let dataAccess { return dataAccess }
-        do {
-            let access = try NoopDataAccess.open(configuration: configuration)
-            dataAccess = access
-            return access
-        } catch let error as LocalAccessError {
-            throw error
-        } catch {
-            throw LocalAccessError.databaseUnavailable("NOOP database is not available: \(error)")
-        }
-    }
-
     private func callTool(params: JSONValue?) throws -> JSONValue {
         guard let object = params?.objectValue,
               let name = object["name"]?.stringValue
@@ -133,51 +119,14 @@ public final class NoopMCPServer {
             throw LocalAccessError.invalidParams("tools/call requires a tool name")
         }
         let arguments = object["arguments"]?.objectValue ?? [:]
-        let payload: JSONValue
-        switch name {
-        case "health_snapshot":
-            payload = try data().healthSnapshot(days: boundedDays(arguments["days"], default: 14, max: 120))
-        case "metric_series":
-            guard let key = arguments["key"]?.stringValue else {
-                throw LocalAccessError.invalidParams("metric_series requires key")
-            }
-            payload = try data().metricSeries(
-                key: key,
-                source: arguments["source"]?.stringValue ?? "my-whoop",
-                days: boundedDays(arguments["days"], default: 90, max: 4000),
-                fromDay: arguments["from_day"]?.stringValue,
-                toDay: arguments["to_day"]?.stringValue,
-                limit: boundedLimit(arguments["limit"], default: 500, max: 2000)
-            )
-        case "data_freshness":
-            payload = try data().freshness()
-        case "sleep_summary":
-            payload = try data().sleepSummary(days: boundedDays(arguments["days"], default: 30, max: 4000))
-        case "workout_summary":
-            payload = try data().workoutSummary(days: boundedDays(arguments["days"], default: 90, max: 4000))
-        default:
-            throw LocalAccessError.toolNotFound(name)
-        }
-        return toolResult(payload)
+        return toolResult(try dispatcher.dispatch(name: name, arguments: arguments))
     }
 
     private func readResource(params: JSONValue?) throws -> JSONValue {
         guard let uri = params?.objectValue?["uri"]?.stringValue else {
             throw LocalAccessError.invalidParams("resources/read requires uri")
         }
-        let payload: JSONValue
-        switch uri {
-        case "noop://health/snapshot":
-            payload = try data().healthSnapshot(days: 14)
-        case "noop://data/freshness":
-            payload = try data().freshness()
-        case "noop://metrics/catalog":
-            payload = NoopDataAccess.metricCatalog()
-        case "noop://sources":
-            payload = NoopDataAccess.sources()
-        default:
-            throw LocalAccessError.resourceNotFound(uri)
-        }
+        let payload = try dispatcher.resourcePayload(uri: uri)
         return .object([
             "contents": .array([
                 .object([

--- a/Packages/NoopLocalAccess/Sources/NoopLocalAccessCore/ToolDispatcher.swift
+++ b/Packages/NoopLocalAccess/Sources/NoopLocalAccessCore/ToolDispatcher.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// The single read-only dispatch surface shared by MCP and the direct CLI transport.
+public final class NoopToolDispatcher {
+    private let configuration: LocalAccessConfiguration
+    private var dataAccess: NoopDataAccess?
+
+    public init(configuration: LocalAccessConfiguration = .environment()) {
+        self.configuration = configuration
+    }
+
+    public static let toolNames = [
+        "health_snapshot",
+        "metric_series",
+        "data_freshness",
+        "sleep_summary",
+        "workout_summary",
+    ]
+
+    public func dispatch(name: String, arguments: [String: JSONValue] = [:]) throws -> JSONValue {
+        switch name {
+        case "health_snapshot":
+            return try data().healthSnapshot(days: boundedDays(arguments["days"], default: 14, max: 120))
+        case "metric_series":
+            guard let key = arguments["key"]?.stringValue else {
+                throw LocalAccessError.invalidParams("metric_series requires key")
+            }
+            return try data().metricSeries(
+                key: key,
+                source: arguments["source"]?.stringValue ?? "my-whoop",
+                days: boundedDays(arguments["days"], default: 90, max: 4000),
+                fromDay: arguments["from_day"]?.stringValue,
+                toDay: arguments["to_day"]?.stringValue,
+                limit: boundedLimit(arguments["limit"], default: 500, max: 2000)
+            )
+        case "data_freshness":
+            return try data().freshness()
+        case "sleep_summary":
+            return try data().sleepSummary(days: boundedDays(arguments["days"], default: 30, max: 4000))
+        case "workout_summary":
+            return try data().workoutSummary(days: boundedDays(arguments["days"], default: 90, max: 4000))
+        default:
+            throw LocalAccessError.toolNotFound(name)
+        }
+    }
+
+    public func resourcePayload(uri: String) throws -> JSONValue {
+        switch uri {
+        case "noop://health/snapshot":
+            return try dispatch(name: "health_snapshot", arguments: ["days": .int(14)])
+        case "noop://data/freshness":
+            return try dispatch(name: "data_freshness")
+        case "noop://metrics/catalog":
+            return NoopDataAccess.metricCatalog()
+        case "noop://sources":
+            return NoopDataAccess.sources()
+        default:
+            throw LocalAccessError.resourceNotFound(uri)
+        }
+    }
+
+    private func data() throws -> NoopDataAccess {
+        if let dataAccess { return dataAccess }
+        do {
+            let access = try NoopDataAccess.open(configuration: configuration)
+            dataAccess = access
+            return access
+        } catch let error as LocalAccessError {
+            throw error
+        } catch {
+            throw LocalAccessError.databaseUnavailable("NOOP database is not available: \(error)")
+        }
+    }
+}

--- a/Packages/NoopLocalAccess/Sources/noop-local-access/main.swift
+++ b/Packages/NoopLocalAccess/Sources/noop-local-access/main.swift
@@ -11,6 +11,8 @@ enum NoopLocalAccessMain {
         switch command {
         case "mcp":
             runMCP(configuration: .environment())
+        case "query":
+            runQuery(arguments: args)
         case "codex-config":
             print(codexConfig(arguments: args))
         case "--help", "-h", "help":
@@ -18,6 +20,33 @@ enum NoopLocalAccessMain {
         default:
             fputs("Unknown command: \(command)\n\n\(helpText)\n", stderr)
             Foundation.exit(64)
+        }
+    }
+
+    private static func runQuery(arguments: [String]) {
+        if arguments == ["--help"] || arguments == ["-h"] {
+            print(helpText)
+            return
+        }
+        do {
+            let request = try NoopCLIQuery.parse(arguments: arguments)
+            let payload = try NoopCLIQuery.dispatch(request)
+            FileHandle.standardOutput.write(try NoopCLIQuery.encodeLine(payload))
+        } catch let error as NoopCLIQueryError {
+            fputs("[noop-local-access] \(error)\n", stderr)
+            Foundation.exit(error.exitCode)
+        } catch let error as LocalAccessError {
+            let message: String
+            if case .databaseUnavailable = error {
+                message = "NOOP database is unavailable"
+            } else {
+                message = error.description
+            }
+            fputs("[noop-local-access] \(message)\n", stderr)
+            Foundation.exit(1)
+        } catch {
+            fputs("[noop-local-access] runtime error\n", stderr)
+            Foundation.exit(1)
         }
     }
 
@@ -77,7 +106,18 @@ enum NoopLocalAccessMain {
     private static let helpText = """
     Usage:
       noop-local-access mcp
+      noop-local-access query <tool> [flags]
       noop-local-access codex-config [--db-path /absolute/path/to/whoop.sqlite]
+
+    Query tools:
+      health_snapshot [--days N]
+      metric_series --key KEY [--source SOURCE] [--days N] [--from-day YYYY-MM-DD] [--to-day YYYY-MM-DD] [--limit N]
+      data_freshness
+      sleep_summary [--days N]
+      workout_summary [--days N]
+
+    Query options:
+      --db-path PATH    Explicit NOOP SQLite path. Otherwise NOOP_DB_PATH or the official app container is used.
 
     Environment:
       NOOP_DB_PATH    Explicit NOOP SQLite path. Optional; otherwise the official macOS app container is used.

--- a/Packages/NoopLocalAccess/Tests/NoopLocalAccessCoreTests/CLIQueryTests.swift
+++ b/Packages/NoopLocalAccess/Tests/NoopLocalAccessCoreTests/CLIQueryTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import NoopLocalAccessCore
+
+final class CLIQueryTests: XCTestCase {
+    func testAllFiveQueriesDispatchThroughTheSamePayloadAsMCP() throws {
+        let url = try TemporaryDatabase.seeded()
+        let configuration = LocalAccessConfiguration(databasePath: url.path)
+        let queries: [(String, [String])] = [
+            ("health_snapshot", ["--days", "14"]),
+            ("metric_series", ["--key", "hrv", "--from-day", "2026-06-10", "--to-day", "2026-06-11"]),
+            ("data_freshness", []),
+            ("sleep_summary", ["--days", "30"]),
+            ("workout_summary", ["--days", "90"]),
+        ]
+
+        for (tool, flags) in queries {
+            let parsed = try NoopCLIQuery.parse(arguments: [tool] + flags)
+            let request = NoopCLIQueryRequest(
+                toolName: parsed.toolName,
+                arguments: parsed.arguments,
+                configuration: configuration
+            )
+            let cliPayload = try NoopCLIQuery.dispatch(request)
+            let response = try XCTUnwrap(try NoopMCPServer(configuration: configuration).handle(RPCRequest(
+                id: .int(1),
+                method: "tools/call",
+                params: .object([
+                    "name": .string(tool),
+                    "arguments": .object(parsed.arguments),
+                ])
+            )))
+            let mcpPayload = try XCTUnwrap(response.objectValue?["result"]?.objectValue?["structuredContent"])
+
+            XCTAssertEqual(
+                withoutVolatileFields(mcpPayload),
+                withoutVolatileFields(cliPayload),
+                "CLI/MCP payload mismatch for \(tool)"
+            )
+        }
+    }
+
+    func testMetricSeriesRequiresKeyAndRejectsUnknownOrMissingFlags() {
+        assertUsageError([])
+        assertUsageError(["metric_series"])
+        assertUsageError(["metric_series", "--unknown", "x"])
+        assertUsageError(["metric_series", "--key=hrv"])
+        assertUsageError(["metric_series", "--key"])
+        assertUsageError(["metric_series", "--key", "hrv", "--limit"])
+        assertUsageError(["metric_series", "--key", "hrv", "--key", "rhr"])
+        assertUsageError(["metric_series", "--key", "hrv", "extra"])
+        assertUsageError(["health_snapshot", "--db-path"])
+        assertUsageError(["data_freshness", "--days", "7"])
+        assertUsageError(["health_snapshot", "--days", "not-an-integer"])
+    }
+
+    func testMetricSeriesParsesTheCompleteFlagContract() throws {
+        let parsed = try NoopCLIQuery.parse(arguments: [
+            "metric_series",
+            "--key", "hrv",
+            "--source", "apple-health",
+            "--days", "30",
+            "--from-day", "2026-06-01",
+            "--to-day", "2026-06-30",
+            "--limit", "42",
+            "--db-path", "/tmp/noop.sqlite",
+        ])
+
+        XCTAssertEqual(parsed.toolName, "metric_series")
+        XCTAssertEqual(parsed.arguments, [
+            "key": .string("hrv"),
+            "source": .string("apple-health"),
+            "days": .int(30),
+            "from_day": .string("2026-06-01"),
+            "to_day": .string("2026-06-30"),
+            "limit": .int(42),
+        ])
+        XCTAssertEqual(parsed.configuration.databasePath, "/tmp/noop.sqlite")
+    }
+
+    func testCLIValuesArePassedToTheExistingBounds() throws {
+        let parsed = try NoopCLIQuery.parse(arguments: ["sleep_summary", "--days", "0"])
+        XCTAssertEqual(parsed.arguments["days"], .int(0))
+
+        let request = NoopCLIQueryRequest(
+            toolName: parsed.toolName,
+            arguments: parsed.arguments,
+            configuration: LocalAccessConfiguration(databasePath: try TemporaryDatabase.seeded().path)
+        )
+        let payload = try NoopCLIQuery.dispatch(request)
+        XCTAssertEqual(payload.objectValue?["range"]?.objectValue?["days"], .int(1))
+    }
+
+    func testSuccessfulOutputIsOneJSONValueAndEncodingFailuresPropagate() throws {
+        let value: JSONValue = .object(["ok": .bool(true)])
+        let line = try NoopCLIQuery.encodeLine(value)
+
+        XCTAssertEqual(line.last, 0x0A)
+        XCTAssertEqual(try JSONDecoder().decode(JSONValue.self, from: Data(line.dropLast())), value)
+        XCTAssertThrowsError(try NoopCLIQuery.encodeLine(.double(.infinity)))
+    }
+
+    private func assertUsageError(_ arguments: [String], file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertThrowsError(try NoopCLIQuery.parse(arguments: arguments), file: file, line: line) { error in
+            guard let error = error as? NoopCLIQueryError else {
+                return XCTFail("Expected usage error, got \(error)", file: file, line: line)
+            }
+            XCTAssertEqual(error.exitCode, 64, file: file, line: line)
+        }
+    }
+
+    private func withoutVolatileFields(_ value: JSONValue) -> JSONValue {
+        switch value {
+        case .array(let values):
+            return .array(values.map(withoutVolatileFields))
+        case .object(let object):
+            let volatile = Set(["generatedAt", "ageSeconds", "fromTs", "toTs"])
+            var normalized: [String: JSONValue] = [:]
+            for (key, value) in object where !volatile.contains(key) {
+                normalized[key] = withoutVolatileFields(value)
+            }
+            return .object(normalized)
+        default:
+            return value
+        }
+    }
+}


### PR DESCRIPTION
Implements the request in #1751 (left open for the maintainer to close deliberately).

## Summary

- add `noop-local-access query <tool> [--flag value ...]` for all five existing local read tools
- route MCP and CLI calls through one authoritative read-only dispatcher
- emit one raw JSON value on stdout, with sanitized diagnostics and distinct usage/runtime exits
- document the exact CLI grammar, defaults, and existing MCP clamping bounds

## Scope and privacy

- no database schema, app UI, BLE, AI Coach, import/export, write/control, or network-listener changes
- the existing read-only SQLite configuration remains the only data path
- no new health interpretation, diagnosis, or recommendation behavior

## Verification

- exact commit `56109a0860682d8d9d9d9797fe7e5ee75cffa03f` independently reviewed: **APPROVE**
- `git diff --check`: passed
- live fork CI: all 14 reported PR checks passed
- `test (NoopLocalAccess)`: build passed; 14 tests passed, 0 failures, including 5 focused CLI-query tests, 3 existing MCP tests, and the read-only store tests
- local Swift execution is not claimed: Swift is absent on the host, and the non-destructive Ubuntu container attempt could not finish installing Swift because Docker's root filesystem ran out of space. The reported runtime evidence is the linked GitHub Actions job.

## AI disclosure

This contribution was developed with AI assistance and independently reviewed. No generated test result is represented as executed; CI state is reported separately.