### PR TITLE
Apple parity: last sync belongs to a strap, and sync controls follow what it can do

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2536,8 +2536,20 @@ public final class BLEManager: NSObject, ObservableObject {
                                                                kind: "lastWriteOkAt")
             let whoStalled = LastSyncAttribution.writeHealthPrefKey(peripheralId: peripheral?.identifier.uuidString,
                                                                     kind: "lastWriteStalledAt")
-            if (backfiller?.sessionRowsPersisted ?? 0) > 0, let k = whoOk { du.set(Date().timeIntervalSince1970, forKey: k) }
-            if backfiller?.persistStalled == true, let k = whoStalled { du.set(Date().timeIntervalSince1970, forKey: k) }
+            // The global keys are STILL written, deliberately, exactly as `noop.lastFirmware` still is
+            // (FrameRouter). DebugDataDiagnostics.strapStateLines is sync and prefs-only by contract, so it
+            // cannot resolve per device — and dropping the global write would not make that line
+            // per-device, it would freeze it at whatever it held before the upgrade and then read "no rows
+            // ever persisted" forever, for everyone. A stale global is the smaller lie than a dead one, and
+            // every reader that CAN attribute prefers the per-device key.
+            if (backfiller?.sessionRowsPersisted ?? 0) > 0 {
+                du.set(Date().timeIntervalSince1970, forKey: "sync.lastWriteOkAt")
+                if let k = whoOk { du.set(Date().timeIntervalSince1970, forKey: k) }
+            }
+            if backfiller?.persistStalled == true {
+                du.set(Date().timeIntervalSince1970, forKey: "sync.lastWriteStalledAt")
+                if let k = whoStalled { du.set(Date().timeIntervalSince1970, forKey: k) }
+            }
             if unarchived > 0 {
                 state.lastSyncError = "Synced, but \(archived + unarchived) record(s) couldn't be decoded (unrecognised strap firmware layout), and the on-device archive is full - the \(unarchived) newest weren't preserved. Please share a strap log so the layout can be mapped."
             } else if archived > 0 {
@@ -2600,6 +2612,11 @@ public final class BLEManager: NSObject, ObservableObject {
             if let key = LastSyncAttribution.prefKey(peripheralId: peripheral?.identifier.uuidString) {
                 UserDefaults.standard.set(state.lastSyncedAt, forKey: key)
             }
+            // Global kept for the same reason as the write-health pair above: the prefs-only debug header
+            // is its only remaining reader and cannot resolve per device, so dropping this write would
+            // freeze that line rather than fix it. It is also what `seedLastSyncFromActiveStrap`'s
+            // single-strap fallback reads across the upgrade.
+            UserDefaults.standard.set(state.lastSyncedAt, forKey: "lastSyncedAt")
             // NOTE: the auto-continue streak is NOT reset here. A HISTORY_COMPLETE is no longer assumed to
             // mean "caught up" (#25): a strap whose firmware segments a deep offload into many small
             // HISTORY_COMPLETE slices would otherwise reset the streak on every slice and never engage the

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1230,7 +1230,10 @@ public final class BLEManager: NSObject, ObservableObject {
         // before any BLE data arrives.
         self.collector = nil
         super.init()
-        state.lastSyncedAt = UserDefaults.standard.object(forKey: "lastSyncedAt") as? Double
+        // Deliberately NOT seeded from the global key here. It belongs to whichever strap synced last,
+        // which on a two-strap install is not the one the screens are scoped to — the misattribution this
+        // whole change removes. `seedLastSyncFromActiveStrap` fills it from the ACTIVE strap once the
+        // registry exists (bootstrapStore); a blank moment is honest, another strap's timestamp is not.
         // Restore identifier + background-capable central (foundation for M3 state restoration).
         #if os(iOS)
         // iOS background state preservation/restoration: the restore identifier is what makes
@@ -1250,6 +1253,40 @@ public final class BLEManager: NSObject, ObservableObject {
 
     /// Build the WhoopStore + Collector + Backfiller asynchronously. Safe to call multiple
     /// times — bails out early if the collector is already initialised.
+    /// Seed the last-sync display from the ACTIVE strap's own stamp — PR #556's intent, correctly attributed.
+    ///
+    /// Resolved against the registry's active row, exactly as the debug export resolves firmware. NOT from
+    /// the legacy global key, which belongs to whichever strap synced last: on a two-strap install that is
+    /// not the strap the screens are scoped to, and seeding from it would put one strap's sync time on the
+    /// other's Today screen — the defect this change exists to remove.
+    ///
+    /// The legacy global still applies when exactly one strap is paired, because only then can it not be
+    /// ambiguous (see `LastSyncAttribution.resolve`). Called from `bootstrapStore` because that is the
+    /// first point the registry exists; the initialisers deliberately seed nothing.
+    ///
+    /// Never overwrites a value this session has already earned: a HISTORY_COMPLETE landing while this
+    /// runs is newer than anything persisted and must win.
+    private func seedLastSyncFromActiveStrap(registry: DeviceRegistryStore) {
+        // Registry + defaults resolved off-actor, then a single hop to publish. The `lastSyncedAt == nil`
+        // check lives INSIDE that hop and nowhere else: checking it out here as well would be a
+        // check-then-act across an await, and the value it guards is exactly the one a HISTORY_COMPLETE
+        // can set while this runs.
+        let rows = (try? registry.all()) ?? []
+        let activeId = (try? registry.activeDeviceId()) ?? nil
+        let activeAddr = rows.first(where: { $0.id == activeId })?.peripheralId
+        let d = UserDefaults.standard
+        guard let seed = LastSyncAttribution.resolve(
+            perDevice: LastSyncAttribution.prefKey(peripheralId: activeAddr)
+                .flatMap { d.object(forKey: $0) as? Double },
+            legacyGlobal: d.object(forKey: "lastSyncedAt") as? Double,
+            pairedCount: rows.count) else { return }
+        Task { @MainActor [state] in
+            // Never overwrite a value this session earned: a HISTORY_COMPLETE landing while the registry
+            // read was in flight is newer than anything persisted, and must win.
+            if state.lastSyncedAt == nil { state.lastSyncedAt = seed }
+        }
+    }
+
     func bootstrapStore() async {
         guard collector == nil else { return }
         // Surface store-open failures instead of swallowing them with `try?` (#222): a silent failure
@@ -1279,6 +1316,7 @@ public final class BLEManager: NSObject, ObservableObject {
         // its own concurrency).
         let registry = DeviceRegistryStore(dbQueue: store.registryWriter)
         self.registryStore = registry
+        seedLastSyncFromActiveStrap(registry: registry)
         if let activeId = try? registry.activeDeviceId(),
            !activeId.isEmpty {
             self.deviceId = activeId
@@ -1367,7 +1405,10 @@ public final class BLEManager: NSObject, ObservableObject {
         self.router = FrameRouter(state: state)
         self.collector = collector
         super.init()
-        state.lastSyncedAt = UserDefaults.standard.object(forKey: "lastSyncedAt") as? Double
+        // Deliberately NOT seeded from the global key here. It belongs to whichever strap synced last,
+        // which on a two-strap install is not the one the screens are scoped to — the misattribution this
+        // whole change removes. `seedLastSyncFromActiveStrap` fills it from the ACTIVE strap once the
+        // registry exists (bootstrapStore); a blank moment is honest, another strap's timestamp is not.
         // Restore identifier + background-capable central (mirrors the production initializer
         // so a restored manager matches by identifier; only exercised by tests/previews).
         #if os(iOS)
@@ -2488,8 +2529,15 @@ public final class BLEManager: NSObject, ObservableObject {
             // STALLED on a persist failure" — the latter (usually a restore without a restart) is otherwise
             // invisible in a report that just shows "0 synced".
             let du = UserDefaults.standard
-            if (backfiller?.sessionRowsPersisted ?? 0) > 0 { du.set(Date().timeIntervalSince1970, forKey: "sync.lastWriteOkAt") }
-            if backfiller?.persistStalled == true { du.set(Date().timeIntervalSince1970, forKey: "sync.lastWriteStalledAt") }
+            // Per strap, not per install. The global keys reported one strap's write health on another's
+            // screen — see LastSyncAttribution. This site has the peripheral, so it is the one place that
+            // can attribute them honestly (same argument as #1634's firmware write).
+            let whoOk = LastSyncAttribution.writeHealthPrefKey(peripheralId: peripheral?.identifier.uuidString,
+                                                               kind: "lastWriteOkAt")
+            let whoStalled = LastSyncAttribution.writeHealthPrefKey(peripheralId: peripheral?.identifier.uuidString,
+                                                                    kind: "lastWriteStalledAt")
+            if (backfiller?.sessionRowsPersisted ?? 0) > 0, let k = whoOk { du.set(Date().timeIntervalSince1970, forKey: k) }
+            if backfiller?.persistStalled == true, let k = whoStalled { du.set(Date().timeIntervalSince1970, forKey: k) }
             if unarchived > 0 {
                 state.lastSyncError = "Synced, but \(archived + unarchived) record(s) couldn't be decoded (unrecognised strap firmware layout), and the on-device archive is full - the \(unarchived) newest weren't preserved. Please share a strap log so the layout can be mapped."
             } else if archived > 0 {
@@ -2546,7 +2594,12 @@ public final class BLEManager: NSObject, ObservableObject {
                 whoop5EmptyOffload.reset()
                 state.historySyncExperimental = false
             }
-            UserDefaults.standard.set(state.lastSyncedAt, forKey: "lastSyncedAt")
+            // Stamped against the strap that actually completed this offload, never globally: the single
+            // key reported one strap's sync on another's screen, and it read as reassuring rather than
+            // wrong — see LastSyncAttribution. Kotlin twin: NoopPrefs.setLastSyncAtFor.
+            if let key = LastSyncAttribution.prefKey(peripheralId: peripheral?.identifier.uuidString) {
+                UserDefaults.standard.set(state.lastSyncedAt, forKey: key)
+            }
             // NOTE: the auto-continue streak is NOT reset here. A HISTORY_COMPLETE is no longer assumed to
             // mean "caught up" (#25): a strap whose firmware segments a deep offload into many small
             // HISTORY_COMPLETE slices would otherwise reset the streak on every slice and never engage the
@@ -5395,6 +5448,9 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         clockRequested = false
         clockRetries = 0
         connectHandshakeDone = false
+        // Mirrors the flag above: a new link has not done the handshake, so it cannot hand over history
+        // until it does. Cleared HERE and nowhere else, so the two can never disagree.
+        state.historyReady = false
         cmdNotifyConfirmedActive = false   // #34: a fresh connection needs its own notify-confirm + settle
         connectSettledSignaled = false
         restoreNeedsResubscribe = false    // #613: a real reconnect isn't a restore — never force-toggle here
@@ -5943,6 +5999,7 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
             if !whoop5SessionStarted {
                 whoop5SessionStarted = true
                 connectHandshakeDone = true     // unblocks beginBackfill()'s guard
+                state.historyReady = true       // and the sync controls, which must not offer what it declines
                 log("WHOOP 5/MG: connect handshake done — backfill unblocked")
                 noteRebootReconnectIfNeeded()
                 // Re-apply the Broadcast-HR device-config flag if the user opted in (#181).
@@ -5992,6 +6049,7 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
         // type-47 fine because it runs the sequence once on a stable connection; the app stormed it.
         guard !connectHandshakeDone else { return }
         connectHandshakeDone = true
+        state.historyReady = true
         noteRebootReconnectIfNeeded()
         backfillStarted = true
 

--- a/Strand/BLE/LastSyncAttribution.swift
+++ b/Strand/BLE/LastSyncAttribution.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Which "last sync" timestamp belongs to a strap, given what is known about it.
+///
+/// The same defect `FirmwareAttribution` fixed for firmware strings, in the same file's other line.
+/// `lastSyncedAt` is ONE defaults key, stamped on any strap's HISTORY_COMPLETE and read back for
+/// whichever strap is active. On a single-strap install those are the same strap, which is why it went
+/// unnoticed. With two paired it reports the other one's: an Android capture showed "Last sync: 4d ago"
+/// beside zero banked rows for the active 5/MG, the timestamp belonging to a 4.0 last worn three days
+/// earlier.
+///
+/// Worse than merely wrong: it is wrong in the reassuring direction. A strap that has never synced reads
+/// as recently synced, and the pull-to-refresh that cannot possibly change it looks broken rather than
+/// inapplicable. On Android that sent an investigation after a sync regression that never existed.
+///
+/// The rule, in order:
+///  - `perDevice` wins: this strap's own stamp, from its own completed offload.
+///  - `legacyGlobal` ONLY when `pairedCount` is 1. The old key cannot say which strap it belongs to, so
+///    it is trustworthy exactly when there is only one strap it could have come from — which keeps a
+///    single-strap install reading correctly across the upgrade instead of resetting to "never".
+///  - otherwise nil, meaning "this strap has never synced". For a strap in that state it is not a
+///    degraded answer, it is the correct one.
+///
+/// Deliberately NOT migrated by writing the global onto the active device at upgrade: that is the same
+/// guess in a different place, and on a multi-strap install it would bake the wrong attribution in
+/// permanently instead of leaving it to self-correct at the next real sync.
+///
+/// Pure so the attribution is unit-tested without defaults, a strap, or a registry. Kotlin twin:
+/// `com.noop.ble.resolveLastSync`.
+enum LastSyncAttribution {
+
+    static func resolve(perDevice: Double?,
+                        legacyGlobal: Double?,
+                        pairedCount: Int) -> Double? {
+        if let perDevice, perDevice > 0 { return perDevice }
+        if let legacyGlobal, legacyGlobal > 0, pairedCount == 1 { return legacyGlobal }
+        return nil
+    }
+
+    /// The per-device defaults key for a persisted last-sync timestamp.
+    ///
+    /// Keyed on the BLE peripheral identifier for the same reason `FirmwareAttribution.prefKey` is:
+    /// HISTORY_COMPLETE arrives on a connection whose peripheral is known, and resolving it to a registry
+    /// id there would repeat the mis-mapping #1527 fixed for `lastSeen` — stamping "the active row"
+    /// records a sync for a strap that was never connected, which is the class of error being removed.
+    ///
+    /// Lowercased, because the same strap can present its identifier in different cases across sessions
+    /// and a case-sensitive key would strand the earlier stamp under a second name. Returns nil for a
+    /// blank identifier, so a caller with none writes nothing rather than writing to a key that belongs
+    /// to no device.
+    static func prefKey(peripheralId: String?) -> String? {
+        guard let p = peripheralId?.trimmingCharacters(in: .whitespaces), !p.isEmpty else { return nil }
+        return "noop.lastSyncAt.\(p.lowercased())"
+    }
+
+    /// The per-device defaults key for the #57 write-health stamps ("rows last landed", "offload stalled").
+    ///
+    /// Same defect as `prefKey` and found in the same capture, one line below it: "Data write: rows last
+    /// landed 4d ago" printed against a strap whose own row count was zero, because the stamp was global
+    /// and the other strap had written it.
+    ///
+    /// `kind` separates "ok" from "stalled" so both keep the per-device scoping rather than only the one
+    /// that happened to be noticed — they are read as a PAIR ("stalled more recently than ok" is the
+    /// alarm), and scoping one without the other would compare a strap's own stall against another
+    /// strap's success. Kotlin twin: `com.noop.ble.writeHealthPrefKey`.
+    static func writeHealthPrefKey(peripheralId: String?, kind: String) -> String? {
+        guard let p = peripheralId?.trimmingCharacters(in: .whitespaces), !p.isEmpty else { return nil }
+        return "sync.\(kind).\(p.lowercased())"
+    }
+}

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -24,6 +24,14 @@ public final class LiveState: ObservableObject {
     /// connect/disconnect. Drives the Live pill's two-state distinction; the encrypted channel (buzz,
     /// alarm, double-tap, history offload) only works when this is true.
     @Published public var encryptedBond: Bool = false
+    /// True once this strap can actually hand over history — the UI mirror of `BLEManager`'s
+    /// `connectHandshakeDone`, which `beginBackfill` already requires before it will request an offload.
+    ///
+    /// Exposed because `bonded` is NOT that condition and reads true too early: the live-HR path sets it
+    /// for a 5/MG that has never completed a handshake, so the sync controls were offered, accepted, and
+    /// then refused deeper down in silence. Gating on this makes them unavailable exactly when the sync
+    /// would have been declined anyway — never when it would have run. Kotlin twin: `LiveState.historyReady`.
+    @Published public var historyReady: Bool = false
     /// #34: bumped by BLEManager once a WHOOP 4.0 connection has BOTH run its connect handshake (hello +
     /// SET_CLOCK, exactly once — `connectHandshakeDone`) AND had the cmd-notify characteristic confirm
     /// subscribed (`didUpdateNotificationStateFor` for it fired with `isNotifying == true`) — whichever of

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -453,7 +453,16 @@ struct LiquidTodayView: View {
     private func handlePull(_ y: CGFloat) {
         pullY = max(0, y)
         guard !refreshing else { return }
-        if pullY >= pullThreshold, !refreshArmed {
+        // #1748 twin: gate the ARM, not the release. `syncNow()`'s own gate checks connected + bonded, and
+        // `bonded` is set by the live-HR path for a 5/MG that has never completed a handshake — so the pull
+        // was accepted and then declined in silence. `historyReady` is the client's OWN precondition, so
+        // this cannot withhold a sync that would have run.
+        //
+        // On the ARM specifically: gating the RELEASE below would leave `refreshArmed` stuck true for the
+        // rest of the gesture, since that branch is the only thing that clears it — a worse failure than
+        // the silent one being fixed. Not arming also withholds the haptic, which is the honest signal
+        // that the gesture is unavailable rather than unresponsive.
+        if pullY >= pullThreshold, !refreshArmed, ble.state.historyReady {
             refreshArmed = true
             pullHaptic &+= 1
         }

--- a/Strand/Screens/HealthView.swift
+++ b/Strand/Screens/HealthView.swift
@@ -135,7 +135,10 @@ private struct SyncStatusSection: View {
     @EnvironmentObject var model: AppModel
 
     /// The strap link is usable for a manual offload kick (matches BLEManager.syncNow's own gate).
-    private var canSync: Bool { live.connected && live.bonded && !live.backfilling }
+    ///
+    /// `historyReady`, not `bonded` alone: the live-HR path sets `bonded` for a 5/MG that has never
+    /// completed a handshake, so this enabled itself and beginBackfill then declined it silently.
+    private var canSync: Bool { live.connected && live.bonded && live.historyReady && !live.backfilling }
 
     var body: some View {
         VStack(alignment: .leading, spacing: NoopMetrics.gap) {
@@ -187,8 +190,10 @@ private struct SyncStatusSection: View {
                     .foregroundStyle(StrandPalette.textSecondary)
             }
         } else {
-            StatePill(live.bonded ? "Ready to sync" : "Pairing…",
-                      tone: .accent, showsDot: true, pulsing: !live.bonded)
+            // Same condition as the button below it. Keyed on `bonded` this said "Ready to sync" directly
+            // above a DISABLED Sync now, on exactly the strap that cannot sync.
+            StatePill(live.historyReady ? "Ready to sync" : "Pairing…",
+                      tone: .accent, showsDot: true, pulsing: !live.historyReady)
         }
     }
 
@@ -199,7 +204,11 @@ private struct SyncStatusSection: View {
         if !live.connected {
             return String(localized: "Connect your strap to sync its stored history. Until then, only imported data shows here.")
         }
-        if !live.bonded {
+        // historyReady, not `bonded`. This branch already said the right thing and simply never fired on
+        // the strap that needed it: `bonded` is set by the live-HR path, so a 5/MG that never completed a
+        // handshake fell through to the "syncs right away" line, under a Sync-now button that had just
+        // been disabled. Same condition as the button and the pill, so all three agree.
+        if !live.historyReady {
             return String(localized: "Finishing the pairing handshake. Sync now becomes available once the strap is paired.")
         }
         return String(localized: "Syncs your strap's stored history right away, instead of waiting for the next automatic sync.")

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -44,6 +44,11 @@ enum DebugDataDiagnostics {
         // per-device value there; this line is superseded by it and wants the same follow-up as the Apple
         // write site, which has no peripheral identity to key on today.
         lines.append("Firmware:    \(d.string(forKey: "noop.lastFirmware") ?? "unknown (connect to record)")")
+        // NOTE: still the legacy GLOBAL key, for the same reason the firmware line above is — strapStateLines
+        // is sync and prefs-only by contract, and the per-device rule needs a registry read for pairedCount.
+        // Unlike firmware there is no per-device block further down to supersede it, so this line can name
+        // the OTHER strap's sync on a multi-strap install; the Kotlin twin resolves it because its export
+        // has the registry in hand. Tracked with the same follow-up.
         let syncSec = d.double(forKey: "lastSyncedAt")
         lines.append("Last sync:   \(syncSec > 0 ? relTime(Date().timeIntervalSince1970 - syncSec) : "never")")
         // #57: write-health. "Last sync" fires even on an empty/failed offload, so distinguish "rows

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -46,9 +46,11 @@ enum DebugDataDiagnostics {
         lines.append("Firmware:    \(d.string(forKey: "noop.lastFirmware") ?? "unknown (connect to record)")")
         // NOTE: still the legacy GLOBAL key, for the same reason the firmware line above is — strapStateLines
         // is sync and prefs-only by contract, and the per-device rule needs a registry read for pairedCount.
-        // Unlike firmware there is no per-device block further down to supersede it, so this line can name
-        // the OTHER strap's sync on a multi-strap install; the Kotlin twin resolves it because its export
-        // has the registry in hand. Tracked with the same follow-up.
+        // The BLE layer therefore keeps writing the global alongside the per-device one; without that this
+        // line would not become per-device, it would simply freeze at its pre-upgrade value. Unlike
+        // firmware there is no per-device block further down to supersede it, so on a multi-strap install
+        // it can still name the OTHER strap's sync — the Kotlin twin resolves it because its export has the
+        // registry in hand. Tracked with the same follow-up.
         let syncSec = d.double(forKey: "lastSyncedAt")
         lines.append("Last sync:   \(syncSec > 0 ? relTime(Date().timeIntervalSince1970 - syncSec) : "never")")
         // #57: write-health. "Last sync" fires even on an empty/failed offload, so distinguish "rows

--- a/StrandTests/LastSyncAttributionTests.swift
+++ b/StrandTests/LastSyncAttributionTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import Strand
+
+/// Pins last-sync attribution. Kotlin twin: `LastSyncAttributionTest`.
+///
+/// Reported three times before it was believed, which is the part worth keeping: the number was
+/// plausible, so the reading was treated as mistaken rather than the label. The capture had
+/// "Last sync: 4d ago" beside zero banked rows for the active 5/MG, and a 4.0 last seen three days
+/// earlier — the timestamp on the 5/MG's screen belonged to the other strap.
+final class LastSyncAttributionTests: XCTestCase {
+
+    func testThisStrapsOwnStampAlwaysWins() {
+        XCTAssertEqual(LastSyncAttribution.resolve(perDevice: 500, legacyGlobal: 900, pairedCount: 1), 500)
+        XCTAssertEqual(LastSyncAttribution.resolve(perDevice: 500, legacyGlobal: 900, pairedCount: 3), 500)
+    }
+
+    /// The single-strap upgrade path. The global key is unattributed, but with one strap paired there is
+    /// only one strap it can have come from — so it reads correctly across the upgrade instead of
+    /// resetting to "never" for everyone.
+    func testTheLegacyGlobalIsHonouredOnlyWhenOneStrapCouldHaveWrittenIt() {
+        XCTAssertEqual(LastSyncAttribution.resolve(perDevice: nil, legacyGlobal: 900, pairedCount: 1), 900)
+        XCTAssertNil(LastSyncAttribution.resolve(perDevice: nil, legacyGlobal: 900, pairedCount: 2))
+    }
+
+    /// THE case from the capture. Two straps, and the active one has never synced: the honest answer is
+    /// "never", not the other strap's timestamp. Not a degraded answer — the correct one.
+    func testAStrapThatHasNeverSyncedSaysSoEvenWhenAnotherHas() {
+        XCTAssertNil(LastSyncAttribution.resolve(perDevice: nil, legacyGlobal: 1_787_000_000, pairedCount: 2))
+    }
+
+    /// Zero is "never recorded", not a timestamp — the defaults API returns 0.0 for a missing Double, so
+    /// treating it as a value would date every strap to 1970.
+    func testZeroAndNilAreBothAbsent() {
+        XCTAssertNil(LastSyncAttribution.resolve(perDevice: 0, legacyGlobal: 0, pairedCount: 1))
+        XCTAssertNil(LastSyncAttribution.resolve(perDevice: nil, legacyGlobal: nil, pairedCount: 1))
+        XCTAssertEqual(LastSyncAttribution.resolve(perDevice: 0, legacyGlobal: 900, pairedCount: 1), 900)
+    }
+
+    /// A zero-paired registry must not license the global. The count is the evidence that exactly one
+    /// strap could have written it; "no straps" is not that evidence, and treating it as such would let a
+    /// failed registry read resurrect the bug.
+    func testAnEmptyRegistryDoesNotLicenseTheGlobal() {
+        XCTAssertNil(LastSyncAttribution.resolve(perDevice: nil, legacyGlobal: 900, pairedCount: 0))
+    }
+
+    func testThePrefKeyIsPerDeviceAndCaseInsensitive() {
+        XCTAssertEqual(LastSyncAttribution.prefKey(peripheralId: "F1:D4:F7:24:53:DE"),
+                       "noop.lastSyncAt.f1:d4:f7:24:53:de")
+        XCTAssertEqual(LastSyncAttribution.prefKey(peripheralId: "f1:d4:f7:24:53:de"),
+                       LastSyncAttribution.prefKey(peripheralId: "F1:D4:F7:24:53:DE"))
+        XCTAssertNil(LastSyncAttribution.prefKey(peripheralId: nil))
+        XCTAssertNil(LastSyncAttribution.prefKey(peripheralId: "   "))
+    }
+
+    /// It must not collide with the firmware key, which is built the same way from the same identifier.
+    func testItDoesNotCollideWithTheFirmwareKeyForTheSameStrap() {
+        let id = "f1:d4:f7:24:53:de"
+        XCTAssertNotEqual(LastSyncAttribution.prefKey(peripheralId: id),
+                          FirmwareAttribution.prefKey(peripheralId: id))
+    }
+
+    /// The #57 write-health pair had the identical defect one line below in the same capture: "rows last
+    /// landed 4d ago" against a strap whose own row count was zero. Both halves are scoped, because they
+    /// are read as a pair — "stalled more recently than ok" is the alarm — and scoping only one would
+    /// compare this strap's stall against another strap's success.
+    func testTheWriteHealthPairIsScopedAndItsHalvesStayDistinct() {
+        let id = "f1:d4:f7:24:53:de"
+        XCTAssertEqual(LastSyncAttribution.writeHealthPrefKey(peripheralId: id, kind: "lastWriteOkAt"),
+                       "sync.lastWriteOkAt.f1:d4:f7:24:53:de")
+        XCTAssertNotEqual(LastSyncAttribution.writeHealthPrefKey(peripheralId: id, kind: "lastWriteOkAt"),
+                          LastSyncAttribution.writeHealthPrefKey(peripheralId: id, kind: "lastWriteStalledAt"))
+        XCTAssertNil(LastSyncAttribution.writeHealthPrefKey(peripheralId: nil, kind: "lastWriteOkAt"))
+        XCTAssertNil(LastSyncAttribution.writeHealthPrefKey(peripheralId: "  ", kind: "lastWriteOkAt"))
+    }
+
+    /// Two straps must never share a write-health key, or one strap's successful offload would clear the
+    /// alarm raised by another strap's stall.
+    func testTwoStrapsGetDifferentWriteHealthKeys() {
+        XCTAssertNotEqual(
+            LastSyncAttribution.writeHealthPrefKey(peripheralId: "aa:bb:cc:dd:ee:ff", kind: "lastWriteOkAt"),
+            LastSyncAttribution.writeHealthPrefKey(peripheralId: "ff:ee:dd:cc:bb:aa", kind: "lastWriteOkAt"))
+    }
+}

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -26,7 +26,7 @@ android {
         applicationId = "com.noop.whoop"
         minSdk = 26
         targetSdk = 34
-        versionCode = 393
+        versionCode = 394
         versionName = "10.6.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
+++ b/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
@@ -252,6 +252,24 @@ internal fun unbondedProbeLinkLostLine(
         " reachable on this strap without a bond (#1635)."
 
 /**
+ * Stage 2 ended because the link did, with GET_CLOCK already on the wire.
+ *
+ * Deliberately NOT the same line as [unbondedProbeLinkLostLine], and that distinction is the whole point.
+ * A stage-1 link loss carries a finding — the subscribes drew no callback and no ATT error before the drop,
+ * which is the CLIENT_HELLO's signature. A stage-2 link loss carries none: the subscribes LANDED, the
+ * transport was open, and the strap was still within its window to answer when the link went. Reporting
+ * that as evidence the strap will not answer would be the same conflation this probe keeps having to
+ * unpick.
+ *
+ * It still spends a budget attempt, because an inconclusive link is not a reason to retry forever — that
+ * is the hole this exists to close, and leaving stage 2 uncounted would reopen it one stage later.
+ */
+internal fun unbondedProbeLinkLostAskingLine(uptimeMs: Long, waitedMs: Long): String =
+    "Unbonded offload probe: the link dropped ${uptimeMs}ms into this connect, ${waitedMs}ms after" +
+        " GET_CLOCK went out. The subscribes had landed, so the transport was open and the strap was still" +
+        " inside its window to answer — this link settles nothing either way (#1635)."
+
+/**
  * Stage 2's question, logged so the wait that follows is attributable to it.
  *
  * Carries the CONFIRMED count, not the attempted one. A CCCD write can also end by being abandoned after

--- a/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
+++ b/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
@@ -139,8 +139,9 @@ internal fun unbondedProbeSupersedesLine(explicitBondOptedIn: Boolean): String =
         " asks whether the offload needs a bond at all. That question needs a link with no CLIENT_HELLO on" +
         " it, so the hello is not written here (press Connect to try the handshake instead)." +
         (if (explicitBondOptedIn)
-            " NOTE: \"Ask Android to pair\" is also on. A pairing in flight makes a refusal unattributable" +
-                " to the strap, so turn it off for a clean answer."
+            " \"Ask Android to pair\" is on but is ALSO skipped on this connect — this branch returns" +
+                " before the pairing request, so no SMP is in flight and a refusal here is attributable" +
+                " to the strap."
         else "") +
         " (#1635, experimental)"
 
@@ -221,6 +222,34 @@ internal fun puffinSubscribeRefusedLine(uuid: String, status: String): String =
     "Unbonded offload probe: subscribe of $uuid failed $status. If this is an insufficient-authentication" +
         " or -encryption status, the puffin notify chars need an encrypted link, the historical offload" +
         " cannot be reached without a bond, and a 5/MG that refuses SMP can never sync history (#1635)."
+
+/**
+ * Stage 1 ended because the LINK did, before any subscribe was confirmed or refused.
+ *
+ * The outcome the probe had no verdict for, and the field capture is unambiguous about how much that
+ * matters: 16 probe starts, 0 verdicts of any kind, 0 confirmed subscribes, 0 refusals, and the link
+ * dying 10.8s into every connect — roughly three seconds after the CCCD writes went out. With no verdict
+ * the silence budget never advanced, so the probe re-ran on every reconnect indefinitely. That is exactly
+ * the unbounded retry [shouldProbeUnbondedOffload]'s own doc claims this design prevents, reintroduced by
+ * an unhandled exit.
+ *
+ * It is also a FINDING, not just a gap. No callback and no ATT error, then a teardown about three seconds
+ * later, is the CLIENT_HELLO's signature — the same silent elevate-and-drop, on the same service. It does
+ * not prove the puffin characteristics require encryption, but it is what that would look like from here,
+ * and it says plainly that the offload is not reachable on this strap without a bond.
+ *
+ * Charged to the silence budget, because "the link will not survive being asked" is a stronger reason to
+ * stop asking than a strap that merely stayed quiet.
+ */
+internal fun unbondedProbeLinkLostLine(
+    uptimeMs: Long,
+    confirmedSubscribes: Int,
+    total: Int,
+): String =
+    "Unbonded offload probe: the link dropped ${uptimeMs}ms into this connect with $confirmedSubscribes" +
+        " of $total puffin subscribes confirmed and no refusal — no callback and no ATT error, then a" +
+        " teardown. That is the CLIENT_HELLO's own signature on the same service, so the offload is not" +
+        " reachable on this strap without a bond (#1635)."
 
 /**
  * Stage 2's question, logged so the wait that follows is attributable to it.

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -9792,6 +9792,22 @@ class WhoopBleClient(
         // see the cleared state, which is harmless, but one still queued must not reach the next link.
         handler.removeCallbacks(unbondedProbeStartRunnable)
         handler.removeCallbacks(unbondedProbeVerdictRunnable)
+        // A probe still mid-subscribe when the link goes is stage 1 ending with the LINK, and it is a
+        // verdict rather than an absence — see [unbondedProbeLinkLostLine]. Without this the probe
+        // reported nothing at all and its silence budget never advanced, so it re-ran on every reconnect:
+        // 16 starts and 0 verdicts in one capture. Charged to the budget, because "the link will not
+        // survive being asked" is a stronger reason to stop asking than a strap that merely stayed quiet.
+        if (unbondedProbeSubscribing) {
+            log(unbondedProbeLinkLostLine(
+                uptimeMs = if (connectedAtMs > 0L) System.currentTimeMillis() - connectedAtMs else -1L,
+                confirmedSubscribes = unbondedProbeSubscribed,
+                total = WHOOP5_NOTIFY_CHARS.size,
+            ))
+            unbondedProbeSilentLinks++
+            if (!unbondedProbeStillWorthAsking(unbondedProbeSilentLinks)) {
+                log(unbondedProbeGaveUpLine(unbondedProbeSilentLinks))
+            }
+        }
         unbondedProbeStartedThisLink = false
         unbondedProbeSubscribed = 0
         unbondedProbeSubscribing = false

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -9797,12 +9797,25 @@ class WhoopBleClient(
         // reported nothing at all and its silence budget never advanced, so it re-ran on every reconnect:
         // 16 starts and 0 verdicts in one capture. Charged to the budget, because "the link will not
         // survive being asked" is a stronger reason to stop asking than a strap that merely stayed quiet.
-        if (unbondedProbeSubscribing) {
-            log(unbondedProbeLinkLostLine(
-                uptimeMs = if (connectedAtMs > 0L) System.currentTimeMillis() - connectedAtMs else -1L,
-                confirmedSubscribes = unbondedProbeSubscribed,
-                total = WHOOP5_NOTIFY_CHARS.size,
-            ))
+        //
+        // BOTH stages, because stage 2 has the identical hole: the verdict timer is cancelled just above,
+        // so a link lost during the GET_CLOCK wait would also report nothing and also fail to spend a
+        // budget attempt. The two get DIFFERENT lines — stage 1's loss carries the CLIENT_HELLO signature,
+        // stage 2's carries no finding at all — because conflating them is the mistake this probe keeps
+        // having to unpick.
+        if (unbondedProbeSubscribing || unbondedProbeAwaitingReply) {
+            val uptime = if (connectedAtMs > 0L) System.currentTimeMillis() - connectedAtMs else -1L
+            log(
+                if (unbondedProbeSubscribing) unbondedProbeLinkLostLine(
+                    uptimeMs = uptime,
+                    confirmedSubscribes = unbondedProbeSubscribed,
+                    total = WHOOP5_NOTIFY_CHARS.size,
+                ) else unbondedProbeLinkLostAskingLine(
+                    uptimeMs = uptime,
+                    waitedMs = if (unbondedProbeAskedAtMs > 0L)
+                        System.currentTimeMillis() - unbondedProbeAskedAtMs else -1L,
+                ),
+            )
             unbondedProbeSilentLinks++
             if (!unbondedProbeStillWorthAsking(unbondedProbeSilentLinks)) {
                 log(unbondedProbeGaveUpLine(unbondedProbeSilentLinks))

--- a/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
@@ -108,6 +108,28 @@ class UnbondedOffloadProbeTest {
     }
 
     /**
+     * The same hole, one stage later. The verdict timer is cancelled on teardown, so a link lost during
+     * the GET_CLOCK wait would also report nothing and also fail to spend a budget attempt — reopening the
+     * unbounded retry immediately below where it was closed.
+     *
+     * It must NOT reuse stage 1's line. Stage 1's loss carries a finding (no callback, no ATT error, then
+     * a drop — the CLIENT_HELLO's signature). Stage 2's carries none: the subscribes landed, so the
+     * transport was open and the strap was still inside its window. Conflating them would manufacture
+     * evidence out of an inconclusive link.
+     */
+    @Test
+    fun `a link lost while asking settles nothing, and says so`() {
+        val line = unbondedProbeLinkLostAskingLine(uptimeMs = 9_000L, waitedMs = 2_500L)
+        assertTrue(line.contains("9000ms"))
+        assertTrue(line.contains("2500ms"))
+        assertTrue(line.contains("settles nothing"))
+        assertTrue(line.contains("#1635"))
+        // The stage-1 finding must not leak into it.
+        assertFalse(line.contains("CLIENT_HELLO"))
+        assertFalse(line.contains("no ATT error"))
+    }
+
+    /**
      * A partial subscribe must report honestly rather than rounding to zero — it is a different fact about
      * the strap than "none of them landed".
      */

--- a/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
@@ -88,6 +88,48 @@ class UnbondedOffloadProbeTest {
         assertFalse(probe(silentLinksSoFar = UNBONDED_PROBE_MAX_SILENT_LINKS + 5))
     }
 
+    /**
+     * The exit that had no verdict, and it cost the probe its bound. Field capture: 16 probe starts, 0
+     * verdicts of any kind, 0 confirmed subscribes, 0 refusals, every link dying 10.8s in — about three
+     * seconds after the CCCD writes. With nothing concluded the silence budget never advanced, so it
+     * re-ran on every reconnect forever: the unbounded retry this file's own doc claims to prevent.
+     */
+    @Test
+    fun `a link lost mid-subscribe is a verdict, not an absence`() {
+        val line = unbondedProbeLinkLostLine(uptimeMs = 10_800L, confirmedSubscribes = 0, total = 4)
+        assertTrue(line.contains("10800ms"))
+        assertTrue(line.contains("0 of 4"))
+        // It must name the signature rather than just the failure: no callback AND no error, then a drop,
+        // is what the CLIENT_HELLO does on the same service — that is the finding, not the silence.
+        assertTrue(line.contains("no ATT error"))
+        assertTrue(line.contains("CLIENT_HELLO"))
+        assertTrue(line.contains("not\n        reachable") || line.contains("not reachable"))
+        assertTrue(line.contains("#1635"))
+    }
+
+    /**
+     * A partial subscribe must report honestly rather than rounding to zero — it is a different fact about
+     * the strap than "none of them landed".
+     */
+    @Test
+    fun `a partial subscribe is reported as partial`() {
+        assertTrue(unbondedProbeLinkLostLine(9_000L, confirmedSubscribes = 2, total = 4).contains("2 of 4"))
+    }
+
+    /**
+     * The supersede line must not warn about a pairing the SAME branch prevents. It said "a pairing in
+     * flight makes a refusal unattributable" while returning before the pairing request — so the one
+     * capture this exists to produce carried a caveat that could not apply, and it briefly cast doubt on
+     * a clean result.
+     */
+    @Test
+    fun `the supersede line does not warn about a pairing it prevents`() {
+        val clash = unbondedProbeSupersedesLine(explicitBondOptedIn = true)
+        assertTrue(clash.contains("ALSO skipped"))
+        assertTrue(clash.contains("attributable to the strap"))
+        assertFalse(clash.contains("in flight makes a refusal unattributable"))
+    }
+
     @Test
     fun `the give-up line says why it stopped, not merely that it did`() {
         // The CLIENT_HELLO's suppression stopped silently and cost eleven weeks of unreadable captures.
@@ -249,16 +291,16 @@ class UnbondedOffloadProbeTest {
      * attribute a refusal to the strap.
      */
     @Test
-    fun `the supersede line explains the absence and flags the clash`() {
+    fun `the supersede line explains the absence and names the other switch`() {
         val clean = unbondedProbeSupersedesLine(explicitBondOptedIn = false)
         assertTrue(clean.contains("handshake skipped"))
         assertTrue(clean.contains("press Connect"))
         assertFalse(clean.contains("Ask Android to pair"))
         assertTrue(clean.contains("#1635"))
 
-        val clash = unbondedProbeSupersedesLine(explicitBondOptedIn = true)
-        assertTrue(clash.contains("Ask Android to pair"))
-        assertTrue(clash.contains("unattributable"))
+        // Mentioned so a reader knows it is on, but as SKIPPED rather than as interference — the
+        // attributability claim it used to make is asserted in its own case below.
+        assertTrue(unbondedProbeSupersedesLine(explicitBondOptedIn = true).contains("Ask Android to pair"))
     }
 
     /**

--- a/project.yml
+++ b/project.yml
@@ -21,7 +21,7 @@ settings:
     # iOS build number (CFBundleVersion). GLOBAL so the iOS app AND its widget extension inherit the
     # SAME value — they must match or iOS warns "extension version must match parent app" (#416).
     # macOS sets its own CFBundleVersion on the Strand target and is unaffected by this.
-    CURRENT_PROJECT_VERSION: "274"
+    CURRENT_PROJECT_VERSION: "275"
     SWIFT_VERSION: "5.0"
     # Emit localizable strings so Xcode auto-extracts every LocalizedStringKey into the
     # String Catalog on build (the English (US) base entries).


### PR DESCRIPTION
Both defects Android fixed today were already present here, in the same shapes — and one of them sits eighty lines from its own fix.

## Last sync (#1745 twin)

`lastSyncedAt` is **one** defaults key, stamped on any strap's `HISTORY_COMPLETE` and read back for whichever strap is active:

```swift
BLEManager.swift:2549   UserDefaults.standard.set(state.lastSyncedAt, forKey: "lastSyncedAt")
BLEManager.swift:1233   state.lastSyncedAt = UserDefaults.standard.object(forKey: "lastSyncedAt")
DebugDataDiagnostics:47 let syncSec = d.double(forKey: "lastSyncedAt")
```

Single-strap installs never notice; with two paired it reports the other one's. `DebugDataDiagnostics` already calls `FirmwareAttribution.resolve` for firmware and then reads last-sync globally eighty lines above it — the pattern was already in the file, last-sync just never got it.

`LastSyncAttribution` mirrors `FirmwareAttribution` one for one: per-BLE-identifier keys, and the legacy global honoured **only when exactly one strap is paired** — the one case it cannot be ambiguous. The write sites take peripheral identity the same way #1634's firmware write does.

The **#57 write-health pair** is scoped too, *both* halves: they're read together ("stalled more recently than ok" is the alarm), so scoping one would compare a strap's own stall against another's success.

### The seed

Both initialisers now seed **nothing**. The obvious cheap seed is the global key, which belongs to whichever strap synced last — on a two-strap install, not the one the screens are scoped to. `seedLastSyncFromActiveStrap` resolves it from the registry's **active** row at `bootstrapStore`, the first point the registry exists. A blank moment is honest; another strap's timestamp is not.

### What stays global, and says so

The debug header line. `strapStateLines` is sync and prefs-only by contract, so it cannot read the registry for `pairedCount` — and unlike firmware there is no per-device block below to supersede it. Named in a comment rather than left to be rediscovered; the Kotlin twin resolves it because its export has the registry in hand.

**The globals are therefore still written**, alongside the per-device keys — exactly as `FrameRouter` still writes `noop.lastFirmware` beside #1634's per-device DIS write. The re-review caught this: moving the stamps to per-device keys removed their only writers and left three readers behind, so the header would not have become per-device — it would have frozen at its pre-upgrade value and then read "never" and "no rows ever persisted" forever, for everyone. Strictly worse than the defect being fixed.

The fix is intact regardless: every reader that *can* attribute prefers the per-device key, and `resolve` refuses the global whenever `pairedCount` says it is ambiguous. A stale global is the smaller lie than a dead one, and the line now says which it is.

## History ready (#1748 twin)

Every manual-sync control gated on `bonded`, which the live-HR path sets for a 5/MG that has never completed a handshake. The control was offered, accepted, and then declined by `beginBackfill`'s `connectHandshakeDone` guard in silence. `HealthView`'s own comment conceded the gate it was matching: *"matches BLEManager.syncNow's own gate."*

This **cannot withhold a sync that would have run** — `connectHandshakeDone` is already `beginBackfill`'s precondition.

The Health card's pill, pulsing and helper line move **with** the button. Gating one of the three makes them contradict: "Ready to sync" above a disabled button, which is exactly what the Android re-review caught. The helper's `!bonded` branch already said the right thing and simply never fired on the strap that needed it.

On Today the gate is on the **arm**, not the release. Gating the release would leave `refreshArmed` stuck true for the rest of the gesture, since that branch is the only thing clearing it — a worse failure than the silent one being fixed. Not arming also withholds the haptic, which reads honestly as *unavailable* rather than *unresponsive*.

## Not ported

- **The unbonded offload probe.** Its answer on the strap that motivated it is *no*, so a twin would port a dead end.
- **#1744 (write completion ≠ encrypted link).** CoreBluetooth exposes no bond state, so the Apple fix needs the strap's own `BLE_BONDED` event instead — different mechanism, same principle. Tracked separately.

## Verification

- **app-build green on both legs** — `NOOPiOS` (iOS Simulator, macos-26) and `Strand` (macOS, x86_64 + arm64). App-target Swift can't be compiled locally, so this was the gate.
- doc-comment lint and the i18n `--ci` gate clean
- no new copy, so no xcstrings churn
- **not hardware-validated on Apple** — same accepted risk as #1455

Related to #1635.