### PR TITLE
The unbonded offload probe must not start on top of the DIS chain

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -26,7 +26,7 @@ android {
         applicationId = "com.noop.whoop"
         minSdk = 26
         targetSdk = 34
-        versionCode = 395
+        versionCode = 396
         versionName = "10.6.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
+++ b/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
@@ -270,6 +270,29 @@ internal fun unbondedProbeLinkLostAskingLine(uptimeMs: Long, waitedMs: Long): St
         " inside its window to answer — this link settles nothing either way (#1635)."
 
 /**
+ * The probe is holding off because the unbonded DIS chain still has the GATT queue.
+ *
+ * Logged once per link rather than per deferral: the useful fact is that it waited at all, and a line a
+ * second for eight seconds would bury it. Without this the probe simply appears late in a capture with
+ * no reason given, which is the shape of problem this whole area keeps producing.
+ */
+internal fun unbondedProbeWaitingForDisLine(): String =
+    "Unbonded offload probe: waiting for the DIS read chain to finish — they share one GATT queue, and" +
+        " starting on top of it makes every CCCD write come back busy (#1635)."
+
+/**
+ * The wait ran out and the probe went anyway.
+ *
+ * Not a failure. The DIS chain has exits that never reach its terminal — a refused read, or a strap that
+ * stops answering part-way — so a probe that waited on the flag forever would never run at all. Saying
+ * which of the two happened is the point: a probe that waited the full budget and then found a busy queue
+ * is a different capture from one that started cleanly.
+ */
+internal fun unbondedProbeStoppedWaitingLine(deferrals: Int): String =
+    "Unbonded offload probe: the DIS chain has not finished after $deferrals checks — starting anyway." +
+        " If the subscribes come back busy, that queue is why, not the strap (#1635)."
+
+/**
  * Stage 2's question, logged so the wait that follows is attributable to it.
  *
  * Carries the CONFIRMED count, not the attempted one. A CCCD write can also end by being abandoned after

--- a/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
+++ b/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
@@ -270,6 +270,29 @@ internal fun unbondedProbeLinkLostAskingLine(uptimeMs: Long, waitedMs: Long): St
         " inside its window to answer — this link settles nothing either way (#1635)."
 
 /**
+ * How many times the probe may stand aside for the DIS chain before going anyway.
+ *
+ * A cap rather than an open wait, because the chain has exits that never reach its terminal — a refused
+ * read, or a strap that stops answering part-way — and a probe waiting on a flag nobody will clear would
+ * simply never run. Eight checks at a second each, then it takes its chances and the trace says which
+ * happened.
+ */
+internal const val UNBONDED_PROBE_MAX_DEFERRALS = 8
+
+/**
+ * Should the probe wait rather than start?
+ *
+ * Pure so the decision is testable without a GATT stack, like every other judgement in this file. It was
+ * briefly inline in the client, which is how the same class of gap reached #1755: the behaviour was
+ * argued for in a comment and asserted nowhere.
+ */
+internal fun unbondedProbeShouldWaitForDis(
+    disChainInFlight: Boolean,
+    deferralsSoFar: Int,
+    cap: Int = UNBONDED_PROBE_MAX_DEFERRALS,
+): Boolean = disChainInFlight && deferralsSoFar < cap
+
+/**
  * The probe is holding off because the unbonded DIS chain still has the GATT queue.
  *
  * Logged once per link rather than per deferral: the useful fact is that it waited at all, and a line a

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4687,6 +4687,11 @@ class WhoopBleClient(
      */
     private fun noteReadFailure(uuid: java.util.UUID, status: Int) {
         if (uuid !in DIS_CHARS) return
+        // The chain is over. readNextDisExtra is only reached from the SUCCESS path, so a refused read
+        // ends it with nothing further in flight — and #490's whole subject is a strap that refuses. Left
+        // set, the unbonded offload probe would stand aside for its full budget waiting on a chain that
+        // had already died, in exactly the case the probe most wants a clear queue for.
+        disChainInFlight = false
         log(disReadFailureLine(uuid.toString(), gattWriteStatusLabel(status)))
         // Report it, but do NOT latch it when WE put a pairing in flight on this link. The latch is
         // persisted per device and permanent, and a read issued into a link that is mid-encryption

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -887,15 +887,6 @@ class WhoopBleClient(
         /** #1635: how long the probe waits between checks while the unbonded DIS chain is still running. */
         private const val UNBONDED_PROBE_DEFER_MS = 1_000L
 
-        /**
-         * How many times the probe may stand aside for the DIS chain before going anyway.
-         *
-         * A cap rather than an open wait, because the chain has exits that never reach its terminal — a
-         * refused read, or a strap that stops answering mid-way — and a probe that waited on a flag
-         * nobody will clear would simply never run. Eight seconds of patience, then it takes its chances
-         * and the trace says which happened.
-         */
-        private const val UNBONDED_PROBE_MAX_DEFERRALS = 8
         /** 5/MG zero-frame retry: pause before re-requesting history when a session timed out having
          *  produced nothing (the first request after connect can go entirely unanswered). */
         private const val WHOOP5_HISTORY_RETRY_DELAY_MS = 700L
@@ -4664,18 +4655,23 @@ class WhoopBleClient(
      * hardware-revision read is issued from [onInbound] once the serial lands. Firing both here would
      * silently drop the second. Read-only and non-fatal: any failure just leaves the variant UNKNOWN.
      */
-    fun readDisIdentity() {
-        if (disRead) return
-        val g = gatt ?: return
-        if (connectedFamily == DeviceFamily.WHOOP4) return
-        val ops = gattOps ?: return
+    fun readDisIdentity(): Boolean {
+        // Returns whether a read was actually ISSUED, so a caller can tell "the chain is running" from
+        // "the chain never started". Every branch above the read is an exit that leaves nothing in
+        // flight, and the unbonded offload probe waits on this answer — told `true` unconditionally it
+        // would stand aside for a chain that does not exist and burn its whole budget for nothing.
+        if (disRead) return false
+        val g = gatt ?: return false
+        if (connectedFamily == DeviceFamily.WHOOP4) return false
+        val ops = gattOps ?: return false
         val ch = g.getService(DIS_SERVICE)?.getCharacteristic(DIS_SERIAL_CHAR)
         if (ch != null && (ch.properties and BluetoothGattCharacteristic.PROPERTY_READ) != 0) {
             disRead = true
             safeGatt("readCharacteristic(dis-serial)") { ops.readCharacteristicCompat(ch) }
-        } else {
-            log("DIS: serial characteristic unavailable — hardware variant stays unknown")
+            return true
         }
+        log("DIS: serial characteristic unavailable — hardware variant stays unknown")
+        return false
     }
 
     /**
@@ -4745,8 +4741,7 @@ class WhoopBleClient(
         ) return
         log("DIS: trying the identity read on an UNbonded link — unproven, and a refusal is itself the" +
             " answer to whether DIS needs an encrypted bond (#490)")
-        disChainInFlight = true
-        readDisIdentity()
+        disChainInFlight = readDisIdentity()
     }
 
     /**
@@ -4796,7 +4791,7 @@ class WhoopBleClient(
         // running at 7s, every CCCD write returning busy, all four abandoned after the shared retry
         // budget, and the link yielding no answer. Waiting on the actual signal costs a second and
         // removes the guess.
-        if (disChainInFlight && unbondedProbeDeferrals < UNBONDED_PROBE_MAX_DEFERRALS) {
+        if (unbondedProbeShouldWaitForDis(disChainInFlight, unbondedProbeDeferrals)) {
             unbondedProbeDeferrals++
             if (unbondedProbeDeferrals == 1) log(unbondedProbeWaitingForDisLine())
             handler.removeCallbacks(unbondedProbeStartRunnable)

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -883,6 +883,19 @@ class WhoopBleClient(
          *  stable, while the cost of asking too early is a false "does not answer" that closes #1635 the
          *  wrong way. */
         private const val UNBONDED_PROBE_REPLY_WAIT_MS = 8_000L
+
+        /** #1635: how long the probe waits between checks while the unbonded DIS chain is still running. */
+        private const val UNBONDED_PROBE_DEFER_MS = 1_000L
+
+        /**
+         * How many times the probe may stand aside for the DIS chain before going anyway.
+         *
+         * A cap rather than an open wait, because the chain has exits that never reach its terminal — a
+         * refused read, or a strap that stops answering mid-way — and a probe that waited on a flag
+         * nobody will clear would simply never run. Eight seconds of patience, then it takes its chances
+         * and the trace says which happened.
+         */
+        private const val UNBONDED_PROBE_MAX_DEFERRALS = 8
         /** 5/MG zero-frame retry: pause before re-requesting history when a session timed out having
          *  produced nothing (the first request after connect can go entirely unanswered). */
         private const val WHOOP5_HISTORY_RETRY_DELAY_MS = 700L
@@ -2406,6 +2419,20 @@ class WhoopBleClient(
      *  link that never scheduled it. Its own gates would still hold, but a timer that outlives its link is
      *  how surprises get in. */
     private val unbondedProbeStartRunnable = Runnable { gatt?.let { beginUnbondedOffloadProbe(it) } }
+
+    /**
+     * #1635: the unbonded DIS read chain is mid-flight.
+     *
+     * DIS reads and CCCD writes share ONE serialized GATT queue, and a field capture showed why that
+     * matters: the probe fired while the chain was still running, every descriptor write came back
+     * `writeDescriptor busy`, all four gave up after the shared 8-retry budget, and the link produced no
+     * answer at all. The probe had been scheduled on a fixed delay chosen on the reasoning that three
+     * seconds was enough separation — on that link the chain was still going at seven.
+     */
+    private var disChainInFlight = false
+
+    /** #1635: how many times the probe has stood aside for the DIS chain on this link. */
+    private var unbondedProbeDeferrals = 0
 
     /** #1635: links that subscribed the puffin chars and drew no reply. Per PROCESS, deliberately NOT
      *  cleared by [reset] — its whole job is to bound a retry that spans reconnects. A refusal latches per
@@ -4718,6 +4745,7 @@ class WhoopBleClient(
         ) return
         log("DIS: trying the identity read on an UNbonded link — unproven, and a refusal is itself the" +
             " answer to whether DIS needs an encrypted bond (#490)")
+        disChainInFlight = true
         readDisIdentity()
     }
 
@@ -4763,6 +4791,19 @@ class WhoopBleClient(
                 silentLinksSoFar = unbondedProbeSilentLinks,
             )
         ) return
+        // Stand aside while the DIS chain still holds the one serialized GATT queue. The fixed 6s delay
+        // this used to rely on was chosen by reasoning and was wrong: a capture caught the chain still
+        // running at 7s, every CCCD write returning busy, all four abandoned after the shared retry
+        // budget, and the link yielding no answer. Waiting on the actual signal costs a second and
+        // removes the guess.
+        if (disChainInFlight && unbondedProbeDeferrals < UNBONDED_PROBE_MAX_DEFERRALS) {
+            unbondedProbeDeferrals++
+            if (unbondedProbeDeferrals == 1) log(unbondedProbeWaitingForDisLine())
+            handler.removeCallbacks(unbondedProbeStartRunnable)
+            handler.postDelayed(unbondedProbeStartRunnable, UNBONDED_PROBE_DEFER_MS)
+            return
+        }
+        if (disChainInFlight) log(unbondedProbeStoppedWaitingLine(unbondedProbeDeferrals))
         val svc = g.getService(WHOOP5_SERVICE) ?: return
         // Claim the link BEFORE queueing, so a keep-alive drain landing between the two cannot start a
         // second probe against the same four characteristics.
@@ -4967,10 +5008,12 @@ class WhoopBleClient(
             DIS_FW_REV_CHAR -> DIS_MANUFACTURER_CHAR
             DIS_MANUFACTURER_CHAR -> DIS_MODEL_NUMBER_CHAR
             DIS_MODEL_NUMBER_CHAR -> DIS_SW_REV_CHAR
-            else -> return
+            // Chain complete. Releasing the queue here is what lets the unbonded offload probe start
+            // without contending with it (#1635).
+            else -> { disChainInFlight = false; return }
         }
-        val g = gatt ?: return
-        val ops = gattOps ?: return
+        val g = gatt ?: run { disChainInFlight = false; return }
+        val ops = gattOps ?: run { disChainInFlight = false; return }
         val ch = g.getService(DIS_SERVICE)?.getCharacteristic(next)
         if (ch == null || (ch.properties and BluetoothGattCharacteristic.PROPERTY_READ) == 0) {
             // Not present on this strap: skip it and carry on down the chain rather than stopping.
@@ -9831,6 +9874,8 @@ class WhoopBleClient(
             }
         }
         unbondedProbeStartedThisLink = false
+        unbondedProbeDeferrals = 0
+        disChainInFlight = false
         unbondedProbeSubscribed = 0
         unbondedProbeSubscribing = false
         unbondedProbeAwaitingReply = false

--- a/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
@@ -353,4 +353,34 @@ class UnbondedOffloadProbeTest {
         )
         for (line in lines) assertTrue(line, line.contains("#1635"))
     }
+
+    /**
+     * #1635, from the field. The probe used to start on a fixed 6-second delay, chosen on the reasoning
+     * that the DIS chain (scheduled at 3s) would be done by then. A capture caught the chain still
+     * running at 7s: every CCCD write returned busy, all four were abandoned after the shared 8-retry
+     * budget, and the link produced no answer at all. Reasoning about a delay lost to measuring one.
+     */
+    @Test
+    fun `the waiting line says why the probe is late, and names the shared queue`() {
+        val line = unbondedProbeWaitingForDisLine()
+        assertTrue(line.contains("DIS read chain"))
+        assertTrue(line.contains("one GATT queue"))
+        assertTrue(line.contains("busy"))
+        assertTrue(line.contains("#1635"))
+    }
+
+    /**
+     * The wait must end. The DIS chain has exits that never reach its terminal — a refused read, or a
+     * strap that stops answering part-way — so a probe that waited on the flag would never run at all.
+     * The line has to distinguish "started cleanly" from "gave up waiting", because a busy queue after
+     * the full budget is a different capture from a busy queue at second one.
+     */
+    @Test
+    fun `giving up waiting is reported as a choice, not a failure`() {
+        val line = unbondedProbeStoppedWaitingLine(8)
+        assertTrue(line.contains("after 8 checks"))
+        assertTrue(line.contains("starting anyway"))
+        assertTrue(line.contains("not the strap"))
+        assertTrue(line.contains("#1635"))
+    }
 }

--- a/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
@@ -383,4 +383,22 @@ class UnbondedOffloadProbeTest {
         assertTrue(line.contains("not the strap"))
         assertTrue(line.contains("#1635"))
     }
+
+    /**
+     * The decision itself, not just the line that describes it. It was briefly inline in the client,
+     * argued for in a comment and asserted nowhere — which is exactly how #1755 shipped a bound that
+     * every unit test agreed with and the real pipeline rejected.
+     */
+    @Test
+    fun `the probe waits only while the DIS chain is actually running, and only so long`() {
+        assertTrue(unbondedProbeShouldWaitForDis(disChainInFlight = true, deferralsSoFar = 0))
+        assertTrue(unbondedProbeShouldWaitForDis(true, UNBONDED_PROBE_MAX_DEFERRALS - 1))
+        // The cap must end the wait: the chain has exits that never reach its terminal, so a probe
+        // waiting on a flag nobody clears would never run at all.
+        assertFalse(unbondedProbeShouldWaitForDis(true, UNBONDED_PROBE_MAX_DEFERRALS))
+        assertFalse(unbondedProbeShouldWaitForDis(true, UNBONDED_PROBE_MAX_DEFERRALS + 5))
+        // And no chain means no waiting — the whole point of readDisIdentity reporting whether it
+        // actually issued a read rather than being assumed to have.
+        assertFalse(unbondedProbeShouldWaitForDis(disChainInFlight = false, deferralsSoFar = 0))
+    }
 }

--- a/project.yml
+++ b/project.yml
@@ -21,7 +21,7 @@ settings:
     # iOS build number (CFBundleVersion). GLOBAL so the iOS app AND its widget extension inherit the
     # SAME value — they must match or iOS warns "extension version must match parent app" (#416).
     # macOS sets its own CFBundleVersion on the Strand target and is unaffected by this.
-    CURRENT_PROJECT_VERSION: "276"
+    CURRENT_PROJECT_VERSION: "277"
     SWIFT_VERSION: "5.0"
     # Emit localizable strings so Xcode auto-extracts every LocalizedStringKey into the
     # String Catalog on build (the English (US) base entries).


### PR DESCRIPTION
Found in the 2026-08-31 13:17 capture, and it is my own scheduling rather than the strap.

## What the log shows

DIS reads and CCCD writes share **one** serialized GATT queue. The probe was posted on a fixed 6-second delay, chosen on the reasoning that the DIS chain — posted at 3 seconds — would be finished by then. On one link it was still running at 7:

```
07:57:06  writeDescriptor busy for fd4b0003 … retry 1/8
07:57:06  … 8 busy retries across the four chars, shared budget exhausted
07:57:06  writeDescriptor rejected for fd4b0003/4/5/7 (gave up after 8 retries)
07:57:06  Unbonded offload probe: none of the 4 … completed their subscribe, and none
          was refused either … proves nothing either way
07:57:07  DIS: modelNumber=MG            ← the chain, still going
```

Not one descriptor write reached the air, and the link produced no answer at all. Reasoning about a delay lost to measuring one.

## The change

The probe now waits on the actual signal — a flag set when the unbonded DIS chain issues its first read and cleared at its terminals — checked once a second, bounded at eight checks.

**The bound is not decoration.** The chain has exits that never reach its terminal: a refused read, or a strap that stops answering part-way. A probe waiting on a flag nobody will clear would simply never run. After the budget it starts anyway and says so, because a busy queue after eight checks is a different capture from a busy queue at second one.

## A control case, from the same log

Worth recording, because it settles something #1749 asserted without evidence.

| link | CCCD writes | outcome |
|---|---|---|
| every other probe link | reached the air | died at **10.8 s** — 4.8 s after the probe — `localTerminate` |
| the 07:57 link | all four abandoned locally | lived **31.3 s**, died of an ordinary `connectionTimeout` |

The teardown tracks the write **reaching the strap**, not the probe running. That is the `CLIENT_HELLO`'s own 4.8-second signature, on the same service — and #1749 concluded exactly that with no control behind it. Now there is one.

## Scope

Android-only; the probe has no Swift twin by design — its answer on the strap that motivated it is *no*, so a twin would port a dead end.

## Verification

- **4,940** tests, 0 failures — 2 new
- doc-comment lint and the i18n `--ci` gate clean
- staging **396** / iOS **277**
- not re-run on hardware yet: the next capture is what confirms the probe now starts on a clear queue

Related to #1635.
