### PR TITLE
Coach: twin the day-boundary retirement on Apple

### DIFF
--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -365,6 +365,12 @@ final class AICoachEngine: ObservableObject {
     func disconnect() {
         AIKeyStore.clear()
         customConnected = false
+        // Retire the transcript with the connection. Kotlin has done this since the method existed
+        // (CoachViewModel.disconnect) and this side never did, so returning to the setup screen on Apple
+        // left the whole conversation sitting behind it — including whatever the user had told a coach
+        // they were in the middle of disconnecting from.
+        messages = []
+        conversationDay = nil
         objectWillChange.send()
     }
 
@@ -388,6 +394,11 @@ final class AICoachEngine: ObservableObject {
     /// Forget the stored key.
     func clearKey() {
         AIKeyStore.clear()
+        // Same reasoning as `disconnect`: clearing the key returns the user to the setup screen, and
+        // Kotlin empties the transcript when it does. Leaving it meant a "clear my key" on Apple removed
+        // the credential and kept the conversation.
+        messages = []
+        conversationDay = nil
         objectWillChange.send()
     }
 

--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -156,6 +156,10 @@ final class AICoachEngine: ObservableObject {
 
     // Published state the UI binds to.
     @Published var messages: [ChatMessage] = []
+
+    /// Local day the current transcript was last written on; nil while it is empty. Drives the day
+    /// boundary in `send` — see `isStaleConversation`. Kotlin twin: `CoachViewModel.conversationDay`.
+    private var conversationDay: Int?
     @Published var sending = false
     @Published var errorText: String?
     @Published var provider: AIProvider {
@@ -482,6 +486,21 @@ final class AICoachEngine: ObservableObject {
         guard !trimmed.isEmpty else { errorText = AICoachError.emptyQuestion.errorDescription; return }
         guard let key = resolvedKey else { errorText = AICoachError.noKey.errorDescription; return }
 
+        // A transcript from an earlier local day is retired before the new turn is appended (#1542,
+        // Kotlin twin merged first). `messages` outlives a night — the engine is held for the app's
+        // lifetime — so without this the coach answers TODAY's question inside YESTERDAY's
+        // conversation. The DATA was never stale: buildFullContext() re-reads on every send. It is the
+        // assistant's own earlier turns stating yesterday's figures, and the model staying consistent
+        // with them, which reads as "the coach only talks about my imported data" after a night of
+        // fresh strap data.
+        //
+        // Placed AFTER the guards on purpose: a send that never happens must not wipe a transcript.
+        let today = Self.localEpochDay()
+        if Self.isStaleConversation(lastEpochDay: conversationDay, todayEpochDay: today) {
+            messages = []
+        }
+        conversationDay = today
+
         errorText = nil
         appendMessage(ChatMessage(role: .user, text: trimmed))
         sending = true
@@ -635,6 +654,30 @@ final class AICoachEngine: ObservableObject {
     /// recent `maxHistoryMessages`, dropping the middle. Sending the whole growing history crowds out the
     /// reply on small-context local servers (Ollama defaults to a 2048-token window, the Custom
     /// provider's main use case) and balloons token cost/latency on cloud providers. (parity with Android)
+    /// True when a transcript last written on `lastEpochDay` should be retired before a question asked
+    /// on `todayEpochDay` — i.e. the conversation crossed into a new local day.
+    ///
+    /// STRICTLY forward (`>`, never `!=`): a clock that moves BACKWARDS — the user flying west, a
+    /// timezone change, an NTP correction — must not wipe a conversation they are in the middle of.
+    /// Only real elapsed days retire a transcript. A nil `lastEpochDay` (nothing sent yet) is never
+    /// stale. Kotlin twin: `CoachViewModel.isStaleConversation`.
+    static func isStaleConversation(lastEpochDay: Int?, todayEpochDay: Int) -> Bool {
+        guard let lastEpochDay else { return false }
+        return todayEpochDay > lastEpochDay
+    }
+
+    /// Days since the epoch in the LOCAL calendar — the twin of Kotlin's `LocalDate.now().toEpochDay()`.
+    ///
+    /// Counted with calendar day arithmetic from `startOfDay`, not by dividing an interval by 86,400:
+    /// a day is not always 86,400 seconds (DST), and the rule only needs a value that increments
+    /// exactly once per local midnight and orders correctly. Injectable so the tests never depend on
+    /// the machine's clock or zone.
+    static func localEpochDay(_ date: Date = Date(), calendar: Calendar = .current) -> Int {
+        let start = calendar.startOfDay(for: date)
+        let epoch = Date(timeIntervalSince1970: 0)
+        return calendar.dateComponents([.day], from: epoch, to: start).day ?? 0
+    }
+
     private static let maxHistoryMessages = 10
     private func windowedMessages() -> [ChatMessage] {
         guard messages.count > Self.maxHistoryMessages + 1,

--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -661,7 +661,12 @@ final class AICoachEngine: ObservableObject {
     /// timezone change, an NTP correction — must not wipe a conversation they are in the middle of.
     /// Only real elapsed days retire a transcript. A nil `lastEpochDay` (nothing sent yet) is never
     /// stale. Kotlin twin: `CoachViewModel.isStaleConversation`.
-    static func isStaleConversation(lastEpochDay: Int?, todayEpochDay: Int) -> Bool {
+    ///
+    /// `nonisolated` because it is a pure function of its arguments. AICoachEngine is @MainActor, so
+    /// without this the rule inherits that isolation and cannot be called from a synchronous test —
+    /// which is exactly how the first attempt at this twin failed to compile. Isolating a function
+    /// that touches no state buys nothing and costs its testability.
+    nonisolated static func isStaleConversation(lastEpochDay: Int?, todayEpochDay: Int) -> Bool {
         guard let lastEpochDay else { return false }
         return todayEpochDay > lastEpochDay
     }
@@ -672,7 +677,7 @@ final class AICoachEngine: ObservableObject {
     /// a day is not always 86,400 seconds (DST), and the rule only needs a value that increments
     /// exactly once per local midnight and orders correctly. Injectable so the tests never depend on
     /// the machine's clock or zone.
-    static func localEpochDay(_ date: Date = Date(), calendar: Calendar = .current) -> Int {
+    nonisolated static func localEpochDay(_ date: Date = Date(), calendar: Calendar = .current) -> Int {
         let start = calendar.startOfDay(for: date)
         let epoch = Date(timeIntervalSince1970: 0)
         return calendar.dateComponents([.day], from: epoch, to: start).day ?? 0

--- a/StrandTests/CoachConversationDayTests.swift
+++ b/StrandTests/CoachConversationDayTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import Strand
+
+/// #1542 twin of `CoachConversationDayTest`. The Coach kept answering today's question inside
+/// yesterday's conversation: `messages` outlives a night, so the assistant's own earlier turns state
+/// yesterday's figures and the model stays consistent with them. The data was never stale —
+/// `buildFullContext()` re-reads on every send — which is why it reads as "the coach only talks about my
+/// imported data" rather than as stale numbers.
+final class CoachConversationDayTests: XCTestCase {
+
+    /// A fixed UTC calendar, so no case depends on the machine's zone or clock.
+    private var utc: Calendar = {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(secondsFromGMT: 0)!
+        return c
+    }()
+
+    private func day(_ y: Int, _ m: Int, _ d: Int) -> Int {
+        var comps = DateComponents()
+        comps.year = y; comps.month = m; comps.day = d
+        let date = utc.date(from: comps)!
+        return AICoachEngine.localEpochDay(date, calendar: utc)
+    }
+
+    func testFreshSessionIsNeverStale() {
+        // Nothing sent yet this session: there is no transcript to retire.
+        XCTAssertFalse(AICoachEngine.isStaleConversation(lastEpochDay: nil,
+                                                         todayEpochDay: day(2026, 8, 22)))
+    }
+
+    func testSameDayKeepsTheConversation() {
+        let today = day(2026, 8, 22)
+        XCTAssertFalse(AICoachEngine.isStaleConversation(lastEpochDay: today, todayEpochDay: today))
+    }
+
+    func testOvernightRetiresTheConversation() {
+        // The reported case: last turn yesterday evening, next question this morning.
+        XCTAssertFalse(AICoachEngine.isStaleConversation(lastEpochDay: day(2026, 8, 21),
+                                                         todayEpochDay: day(2026, 8, 21)))
+        XCTAssertTrue(AICoachEngine.isStaleConversation(lastEpochDay: day(2026, 8, 21),
+                                                        todayEpochDay: day(2026, 8, 22)))
+    }
+
+    func testLongGapRetiresTheConversation() {
+        XCTAssertTrue(AICoachEngine.isStaleConversation(lastEpochDay: day(2026, 6, 11),
+                                                        todayEpochDay: day(2026, 8, 22)))
+    }
+
+    /// Flying west, a timezone change or an NTP correction can move the local day BACKWARDS
+    /// mid-conversation. That must not wipe a transcript the user is in the middle of, which is why the
+    /// rule is strictly forward (`>`) and not `!=`. Relaxing it to `!=` fails this case and the year
+    /// boundary below — the two that give the test teeth.
+    func testClockMovingBackwardsKeepsTheConversation() {
+        XCTAssertFalse(AICoachEngine.isStaleConversation(lastEpochDay: day(2026, 8, 22),
+                                                         todayEpochDay: day(2026, 8, 21)))
+    }
+
+    func testYearBoundaryIsJustAnotherDay() {
+        XCTAssertTrue(AICoachEngine.isStaleConversation(lastEpochDay: day(2025, 12, 31),
+                                                        todayEpochDay: day(2026, 1, 1)))
+        XCTAssertFalse(AICoachEngine.isStaleConversation(lastEpochDay: day(2026, 1, 1),
+                                                         todayEpochDay: day(2025, 12, 31)))
+    }
+
+    /// Swift-only, because Swift-only needs it: Kotlin gets its epoch day from `LocalDate`, while this
+    /// side computes one. Counted with calendar day arithmetic rather than by dividing an interval by
+    /// 86,400 — a day is not always 86,400 seconds. Across a DST spring-forward the count must still
+    /// advance by exactly one, or a transcript would survive a night twice a year.
+    func testLocalEpochDayAdvancesByOneAcrossADSTBoundary() {
+        var london = Calendar(identifier: .gregorian)
+        london.timeZone = TimeZone(identifier: "Europe/London")!
+        var before = DateComponents()
+        before.year = 2026; before.month = 3; before.day = 28; before.hour = 12
+        var after = DateComponents()
+        after.year = 2026; after.month = 3; after.day = 29; after.hour = 12   // clocks go forward
+        let d0 = AICoachEngine.localEpochDay(london.date(from: before)!, calendar: london)
+        let d1 = AICoachEngine.localEpochDay(london.date(from: after)!, calendar: london)
+        XCTAssertEqual(d1 - d0, 1, "a 23-hour day must still be one day")
+        XCTAssertTrue(AICoachEngine.isStaleConversation(lastEpochDay: d0, todayEpochDay: d1))
+    }
+}

--- a/StrandTests/CoachConversationDayTests.swift
+++ b/StrandTests/CoachConversationDayTests.swift
@@ -78,4 +78,43 @@ final class CoachConversationDayTests: XCTestCase {
         XCTAssertEqual(d1 - d0, 1, "a 23-hour day must still be one day")
         XCTAssertTrue(AICoachEngine.isStaleConversation(lastEpochDay: d0, todayEpochDay: d1))
     }
+
+    /// The symmetric DST case, and the one that actually threatens this implementation. `localEpochDay`
+    /// counts whole days from the epoch INSTANT to a local midnight, so the count truncates — and on a
+    /// 25-hour autumn day the extra hour is exactly the kind of slack that could make two local midnights
+    /// land in the same whole-day bucket. If that happened, a transcript would survive a night once a
+    /// year and the bug this whole change fixes would come back, seasonally.
+    ///
+    /// Spring-forward was tested first because it is the obvious one. It is not the dangerous one.
+    func testLocalEpochDayAdvancesByOneAcrossTheAutumnFallBack() {
+        var london = Calendar(identifier: .gregorian)
+        london.timeZone = TimeZone(identifier: "Europe/London")!
+        var before = DateComponents()
+        before.year = 2026; before.month = 10; before.day = 24; before.hour = 12
+        var after = DateComponents()
+        after.year = 2026; after.month = 10; after.day = 25; after.hour = 12   // clocks go back
+        let d0 = AICoachEngine.localEpochDay(london.date(from: before)!, calendar: london)
+        let d1 = AICoachEngine.localEpochDay(london.date(from: after)!, calendar: london)
+        XCTAssertEqual(d1 - d0, 1, "a 25-hour day must still be one day")
+        XCTAssertTrue(AICoachEngine.isStaleConversation(lastEpochDay: d0, todayEpochDay: d1))
+    }
+
+    /// A zone far west of UTC, where the epoch instant itself falls on the PREVIOUS local day. The origin
+    /// this counts from is not local midnight, so the arithmetic has to stay monotonic anyway — ordering
+    /// is the only property the rule depends on.
+    func testLocalEpochDayIsMonotonicWestOfUTC() {
+        var la = Calendar(identifier: .gregorian)
+        la.timeZone = TimeZone(identifier: "America/Los_Angeles")!
+        var comps = DateComponents()
+        comps.year = 2026; comps.month = 8; comps.day = 21; comps.hour = 23; comps.minute = 30
+        let lateEvening = la.date(from: comps)!
+        let nextMorning = lateEvening.addingTimeInterval(3_600)   // 00:30 the next local day
+        let d0 = AICoachEngine.localEpochDay(lateEvening, calendar: la)
+        let d1 = AICoachEngine.localEpochDay(nextMorning, calendar: la)
+        XCTAssertEqual(d1 - d0, 1, "crossing local midnight is one day, whatever the UTC offset")
+        XCTAssertTrue(AICoachEngine.isStaleConversation(lastEpochDay: d0, todayEpochDay: d1))
+        // And the hour before midnight is emphatically the same day.
+        let earlier = lateEvening.addingTimeInterval(-3_600)
+        XCTAssertEqual(AICoachEngine.localEpochDay(earlier, calendar: la), d0)
+    }
 }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -26,7 +26,7 @@ android {
         applicationId = "com.noop.whoop"
         minSdk = 26
         targetSdk = 34
-        versionCode = 396
+        versionCode = 397
         versionName = "10.6.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
@@ -257,6 +257,9 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
     fun clearKey(ctx: Context) {
         AiKeyStore.clear(ctx)
         _messages.value = emptyList()
+        // The day belongs to the transcript, so it goes with it. Harmless if left (a stale day only ever
+        // clears an already-empty list) but it would be a field claiming something untrue.
+        conversationDay = null
         _error.value = null
         _keyVersion.value += 1
     }
@@ -270,6 +273,7 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
         _customConnected.value = false
         AiKeyStore.saveCustomConnected(ctx, false)
         _messages.value = emptyList()
+        conversationDay = null
         _error.value = null
         _keyVersion.value += 1
     }

--- a/project.yml
+++ b/project.yml
@@ -21,7 +21,7 @@ settings:
     # iOS build number (CFBundleVersion). GLOBAL so the iOS app AND its widget extension inherit the
     # SAME value — they must match or iOS warns "extension version must match parent app" (#416).
     # macOS sets its own CFBundleVersion on the Strand target and is unaffected by this.
-    CURRENT_PROJECT_VERSION: "277"
+    CURRENT_PROJECT_VERSION: "278"
     SWIFT_VERSION: "5.0"
     # Emit localizable strings so Xcode auto-extracts every LocalizedStringKey into the
     # String Catalog on build (the English (US) base entries).


### PR DESCRIPTION
The Apple half of #1542, which @dwehrmann deliberately left out rather than ship Swift they could not compile. That was the right call, and this PR is the evidence: **it did not compile on the first attempt, and nothing in default CI would have said so.**

## Same bug, same shape

`AICoachEngine.messages` is `@Published` and held for the app's lifetime, so the Coach answers today's question inside yesterday's conversation. The data was never stale — `buildFullContext()` re-reads on every send. It's the assistant's own earlier turns stating yesterday's figures, and the model staying consistent with them.

## Same rule

`isStaleConversation` is strictly forward (`>`, never `!=`), so a clock moving **backwards** — flying west, a timezone change, an NTP correction — cannot wipe a conversation mid-use. Placed after the guards, so a send that never happens (no key, empty question) leaves the transcript alone.

## One thing is Swift-only, because Swift-only needs it

Kotlin gets its epoch day from `LocalDate.toEpochDay()`. This side has to compute one, and the obvious way — dividing a `startOfDay` interval by 86,400 — is wrong, because **a day is not always 86,400 seconds**. `localEpochDay` uses calendar day arithmetic instead, and a test pins a `Europe/London` spring-forward: a 23-hour day must still count as one, or a transcript would survive a night twice a year. The calendar is injected so nothing depends on the machine's zone.

## What app-build caught

```
error: call to main actor-isolated static method
       'isStaleConversation(lastEpochDay:todayEpochDay:)' in a synchronous
       nonisolated context
```

`AICoachEngine` is `@MainActor` so its `@Published` mutations stay on the main thread, and the statics inherited that isolation.

Fixed with `nonisolated` rather than pushing `@MainActor` onto the test class: they are pure functions of their arguments, touch no published state, and the Kotlin twin is a plain companion object for the same reason. Isolating a function that touches nothing buys nothing and costs its testability.

Worth noting **the iOS leg passed on the broken commit** — only the macOS leg compiles `StrandTests`. A compile-only check would have called it green.

## Verification

- **app-build green on both legs**, and the Strand leg runs `StrandTests` — so the 7 cases execute, not just compile
- six mirroring the Kotlin suite one-to-one, plus the DST case
- the two the author identified as load-bearing — clock moving backwards, and the year boundary — are the ones that fail if `>` is relaxed to `!=`
- doc-comment lint clean
- staging **397** / iOS **278**

Twins the Android change in #1542.
