### PR TITLE
Asking Android to pair must not clear the hello give-up every link (#1635)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -8381,9 +8381,11 @@ class WhoopBleClient(
                             // `alreadyRequestedThisLink`, a per-LINK flag, and on a strap that answers SMP
                             // "Pairing Not Supported" neither bond condition ever becomes true — so
                             // createBond fires on EVERY connect, and clearing here fired on every connect
-                            // with it. The 31 Aug capture: 36 pairing requests, the latch written once at
-                            // 17:32:48, the "CLIENT_HELLO suppressed" line zero times, and 13 more hellos
-                            // after the give-up, each dropping the link ~4.8s in.
+                            // with it. The 31 Aug capture: 18 pairing requests and 18 hellos — one of each
+                            // on every link, which is the pairing [helloDeferredByExplicitBond] forbids —
+                            // with the latch written once at 17:32:48, the "CLIENT_HELLO suppressed" line
+                            // zero times, and 13 of those hellos landing after the give-up, each dropping
+                            // the link ~4.8s in.
                             //
                             // It could not recover, either: BondRefusalGiveUp.recordRefusal() reports the
                             // crossing exactly once and stays gaveUp until reset, so the latch is written

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -8373,15 +8373,40 @@ class WhoopBleClient(
                     runCatching { g.device.createBond() }.fold(
                         onSuccess = { initiated ->
                             log(explicitBondRequestLine(initiated, where))
-                            // Asking for a pairing voids the previous verdict: suppression latched because
-                            // the write never completed on an UNENCRYPTED link, and that premise is exactly
-                            // what this is trying to change. Cleared ONCE, here, rather than re-armed by
-                            // "an OS pairing exists" — that condition never goes away, so it would bypass
-                            // the latch on every connect and restore the unbounded loop for good.
+                            // The suppression latch is NOT cleared here, and this is the correction to the
+                            // comment that used to stand in its place. That comment reasoned the clear was
+                            // safe because it happened "ONCE, here", as opposed to being re-armed by "an OS
+                            // pairing exists" — a condition that never goes away. It guarded the wrong
+                            // recurrence. [shouldRequestExplicitBond] is bounded only by
+                            // `alreadyRequestedThisLink`, a per-LINK flag, and on a strap that answers SMP
+                            // "Pairing Not Supported" neither bond condition ever becomes true — so
+                            // createBond fires on EVERY connect, and clearing here fired on every connect
+                            // with it. The 31 Aug capture: 36 pairing requests, the latch written once at
+                            // 17:32:48, the "CLIENT_HELLO suppressed" line zero times, and 13 more hellos
+                            // after the give-up, each dropping the link ~4.8s in.
+                            //
+                            // It could not recover, either: BondRefusalGiveUp.recordRefusal() reports the
+                            // crossing exactly once and stays gaveUp until reset, so the latch is written
+                            // once per session. Anything recurring that clears it does not cost one link —
+                            // it costs the latch permanently.
+                            //
+                            // What replaces it is the explicit Connect, which clears the latch through
+                            // clearPairingHintForUserConnect() — precisely what the epitaph tells the user
+                            // to do, and pinned by HelloSuppressionTest's "suppression is never
+                            // permanent". Be exact about the alternative: the encrypted-bond clear at
+                            // clearPairingHint() lives inside the hello WRITE-COMPLETION callback, so a
+                            // suppressed hello cannot reach it. Claiming it as an automatic route would be
+                            // the same overclaim the give-up line just had to be corrected for.
+                            //
+                            // That costs nothing real. The latch is only set after five consecutive
+                            // refusals, so "latched, and pairing now works" needs something to have
+                            // CHANGED — new firmware, the strap put into pairing mode (@Zebsi235's MG) —
+                            // and a user who has changed something taps Connect. Voiding the verdict on
+                            // the mere REQUEST voided it on a hope this strap never fulfils, every eleven
+                            // seconds. The pairing experiment itself is untouched: createBond still runs
+                            // on every link, it just no longer drags the hello back with it, which is what
+                            // [helloDeferredByExplicitBond] says must never share a link.
                             if (initiated) {
-                                runCatching {
-                                    com.noop.ui.NoopPrefs.setHelloSuppressed(context, g.device.address, false)
-                                }
                                 // Ask the device directly rather than waiting on our own broadcast
                                 // receiver, which is a suspect in exactly the silence being investigated.
                                 handler.postDelayed({

--- a/android/app/src/test/java/com/noop/ble/ExplicitBondTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ExplicitBondTest.kt
@@ -30,6 +30,20 @@ class ExplicitBondTest {
         assertTrue(ask())
     }
 
+    /**
+     * The recurrence, stated so nothing downstream may treat this request as one-shot.
+     *
+     * On a strap that answers SMP "Pairing Not Supported" neither bond flag ever becomes true, and the
+     * only remaining bound is per LINK — so with the switch on, this fires on every connect, forever. Code
+     * that hangs a once-only side effect off "we asked to pair" is therefore doing it on every connect: on
+     * 31 Aug that was clearing the hello-suppression latch, 36 times, which made the latch unable to end
+     * the loop it exists to end.
+     */
+    @Test
+    fun `asking recurs on every link, so it is not a once-only event`() {
+        repeat(5) { assertTrue(ask(already = false)) }
+    }
+
     @Test
     fun `an OS-level pairing already exists, so we do not ask again`() {
         assertFalse(ask(osBonded = true))

--- a/android/app/src/test/java/com/noop/ble/ExplicitBondTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ExplicitBondTest.kt
@@ -33,15 +33,19 @@ class ExplicitBondTest {
     /**
      * The recurrence, stated so nothing downstream may treat this request as one-shot.
      *
-     * On a strap that answers SMP "Pairing Not Supported" neither bond flag ever becomes true, and the
-     * only remaining bound is per LINK — so with the switch on, this fires on every connect, forever. Code
-     * that hangs a once-only side effect off "we asked to pair" is therefore doing it on every connect: on
-     * 31 Aug that was clearing the hello-suppression latch, 36 times, which made the latch unable to end
-     * the loop it exists to end.
+     * The two assertions belong together: the first is the PERMANENT state of a strap that answers SMP
+     * "Pairing Not Supported" — never OS-bonded, never app-bonded — and the gate still says yes; the
+     * second is the only thing left that says no, and it is per LINK, so every new link clears it. With
+     * the switch on, this therefore fires on every connect, forever.
+     *
+     * Code that hangs a once-only side effect off "we asked to pair" is doing it on every connect. On
+     * 31 Aug that was clearing the hello-suppression latch — 18 requests, 18 hellos, one of each per
+     * link — which left the latch unable to end the loop it exists to end.
      */
     @Test
     fun `asking recurs on every link, so it is not a once-only event`() {
-        repeat(5) { assertTrue(ask(already = false)) }
+        assertTrue(ask(osBonded = false, appBonded = false, already = false))
+        assertFalse(ask(already = true))
     }
 
     @Test

--- a/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
@@ -58,9 +58,31 @@ class HelloSuppressionTest {
     fun `an existing OS pairing does NOT permanently bypass the latch`() {
         // Tempting, and wrong: "a pairing exists" never goes away, so re-arming on it would rewrite the
         // hello on every connect for good - drop at ~4.8s, reconnect, forever - with the give-up powerless.
-        // That is the unbounded loop suppression exists to end. The experiment clears the latch ONCE when
-        // it asks for a pairing instead, which is self-limiting.
+        // That is the unbounded loop suppression exists to end.
+        //
+        // Asking for a pairing was treated as the self-limiting alternative, and it is not: the REQUEST
+        // recurs on every link too (see ExplicitBondTest), so clearing the latch there produced the very
+        // loop described above. Nothing clears the latch on a recurring event now - only a completed bond
+        // or an explicit Connect, both of which are things that actually happened.
         assertFalse(shouldSendClientHello(suppressedForDevice = true, userInitiated = false))
+    }
+
+    /**
+     * Why no recurring event may clear the latch: it is written exactly once.
+     *
+     * recordRefusal() reports the crossing on the refusal that reaches the threshold and then stays
+     * gaveUp until reset(), so the suppression is latched once per session. A clear that fires repeatedly
+     * therefore does not cost one link and self-correct - it costs the latch permanently, and the give-up
+     * has no second chance to re-arm it. That is what the 31 Aug capture shows: one latch, zero skips, 13
+     * further hellos.
+     */
+    @Test
+    fun `the give-up reports its crossing once, so the latch is written once`() {
+        val g = BondRefusalGiveUp(giveUpThreshold = 5)
+        assertEquals(1, (1..12).count { g.recordRefusal() })
+        // And only an explicit reset - a genuine bond, or the user tapping Connect - earns another.
+        g.reset()
+        assertEquals(1, (1..12).count { g.recordRefusal() })
     }
 
     // #1635: the opt-in override, after the HCI capture changed the premise

--- a/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
@@ -62,8 +62,11 @@ class HelloSuppressionTest {
         //
         // Asking for a pairing was treated as the self-limiting alternative, and it is not: the REQUEST
         // recurs on every link too (see ExplicitBondTest), so clearing the latch there produced the very
-        // loop described above. Nothing clears the latch on a recurring event now - only a completed bond
-        // or an explicit Connect, both of which are things that actually happened.
+        // loop described above. Nothing clears the latch on a recurring event now. Three things clear it,
+        // all of them events rather than intentions: an explicit Connect, forgetting the device, and a
+        // genuine bond - and be exact about that last one, because it is the easy overclaim here. It is
+        // reached through the hello WRITE-COMPLETION callback, so a suppressed hello cannot reach it. The
+        // live route out of suppression is the Connect tap the epitaph names.
         assertFalse(shouldSendClientHello(suppressedForDevice = true, userInitiated = false))
     }
 


### PR DESCRIPTION
## The give-up worked, and was undone

A capture on 31 Aug (build 397, 5/MG, fw 50.41.1.0) has two disconnect bursts
**sixteen hours apart**, and the gap between them is the point — the link was
perfectly stable all night, so the strap is not what is unstable.

```
00:39:38 → 00:41:20    7 links, all ~10.8s   the unbonded offload probe
00:41    → 17:21      16 hours, zero disconnects
17:32:05 → 17:39:44   18 links, all   4.8s   the CLIENT_HELLO
```

The second burst should have ended itself. At 17:32:48 the give-up fired exactly
as designed:

```
Bond epitaph: the strap [6bf655fa] never acknowledged the secure handshake 5x in
a row, and the attempt is what drops the link - leaving the handshake off so live
heart rate keeps streaming. Tap Connect to try it again.
bond gaveUp refusals=5 (hello suppressed, staying connected)
```

Then **13 more CLIENT_HELLOs**. `CLIENT_HELLO suppressed for this strap` — the
line printed when a hello is actually skipped — appears **zero times in the
entire log**.

## Why

With "Ask Android to pair" on, the explicit-bond request cleared the suppression
latch. The comment there reasoned it was safe:

> Cleared ONCE, here, rather than re-armed by "an OS pairing exists" — that
> condition never goes away, so it would bypass the latch on every connect and
> restore the unbounded loop for good.

It guarded the wrong recurrence. `shouldRequestExplicitBond` is bounded only by
`alreadyRequestedThisLink`, a per-**link** flag; on a strap answering SMP
"Pairing Not Supported" neither bond condition ever becomes true. So `createBond`
fires on every connect and the clear fired with it. The capture holds **18
pairing requests and 18 CLIENT_HELLOs** — one of each on every link, which is
exactly the pairing `helloDeferredByExplicitBond` exists to forbid. The comment
describes its own effect and rules it out in the same breath.

It could not recover, either. `recordRefusal()` reports the crossing exactly once
and stays `gaveUp` until `reset()`, so the latch is written **once per session**.
A clear on a recurring event does not cost one link and self-correct — it costs
the latch permanently. The #1635 end state (live HR, handshake off, link stable)
was simply unreachable while that switch was on.

## The change

The clear is removed. Recovery is the explicit Connect the epitaph already names,
cleared through `clearPairingHintForUserConnect()`.

The encrypted-bond clear is deliberately **not** offered as an automatic
alternative: `clearPairingHint()` on a genuine bond lives inside the hello
write-completion callback, so a suppressed hello cannot reach it. Claiming it
would be the same overclaim the retirement line in #1761 had to be corrected for.
That costs nothing real — the latch only sets after five consecutive refusals, so
"latched, and pairing now works" requires something to have changed (new
firmware, the strap put into pairing mode as on @Zebsi235's MG), and a user who
has changed something taps Connect.

The pairing experiment is untouched: `createBond` still runs on every link. It
just no longer drags the hello along with it — which is exactly what
`helloDeferredByExplicitBond` says must never share a link:

> Writing to the encrypted characteristic while a pairing is in flight is the
> behaviour that has been dropping the link for eleven weeks, so doing both at
> once would test nothing and reproduce the bug.

## Tests

Two pins for the contradiction that produced this, one on each side:

- `ExplicitBondTest` — the request recurs on every link, so nothing may hang a
  once-only side effect off it.
- `HelloSuppressionTest` — the give-up reports its crossing once, so the latch is
  written once and a recurring clear is permanent.

A stale comment on `an existing OS pairing does NOT permanently bypass the latch`
called the pairing request the "self-limiting" alternative; it was not, and now
says so.

606 tests in `com.noop.ble`, zero failures on a forced clean run.
`compileFullDebugKotlin`, `doc_comment_lint.py`, `i18n_audit.py` clean.

## What this does not settle

With the hello suppressed, `createBond` still runs once per link on a strap that
refuses SMP. Nothing in this capture says whether that alone is enough to keep a
link up, because the sixteen stable hours contained no connects at all. If the
next capture still shows a loop, that is the remaining cause and it will be
readable for the first time — with the hello finally out of the way.

## Parity

Checked rather than assumed. Swift has the same `BondRefusalGiveUp` mirror and the
same latch (`HelloSuppressionStore`), and its three writes are all sound: the
release path (twin of Kotlin's forget-device clear), the give-up write, and one
clear gated on `ClientHelloOutcome.isAck` — an *outcome*, not a request. No twin
of this bug exists there, and could not: CoreBluetooth has no `createBond`, which
is why the offending clear is Android-only in the first place.

Android only. Refs #1635.
