### PR TITLE
Stop asking Android to pair once the strap has refused the bond (#1635)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/ExplicitBond.kt
+++ b/android/app/src/main/java/com/noop/ble/ExplicitBond.kt
@@ -32,6 +32,26 @@ package com.noop.ble
  * pairing API at all — on Apple platforms pairing happens only as a side effect of touching an encrypted
  * characteristic, which is the very mechanism this file exists because it does not work. There is nothing
  * to mirror, so an audit finding this one-sided should leave it rather than delete it as untwinned.
+ *
+ * ## Why the bond give-up reaches this request, having been built for the CLIENT_HELLO
+ *
+ * The two are separate experiments, and gating one on the other is deliberate rather than sloppy.
+ * [BondRefusalGiveUp] does not track the hello; it tracks whether this strap will form an encrypted bond,
+ * which is the single thing both routes are trying to achieve and neither has. Its threshold is reached on
+ * the strap's own refusals, so by the time it latches the pairing request has had its five links and
+ * returned the same answer every time — BOND_NONE, with an HCI capture showing SMP "Pairing Not Supported"
+ * underneath. That is the experiment concluding, not being cut short.
+ *
+ * Every other probe here is bounded and this one was not. The hello has a give-up, the unbonded offload
+ * probe has a silence budget, and asking Android to pair had nothing at all: it fired once per link,
+ * forever, on a strap that had definitively said no. The 31 Aug capture caught the consequence — repeated
+ * system "Pairing rejected" notices, which is worse than a quiet loop because the user has to read them.
+ *
+ * `bondGivenUpForDevice` is the PERSISTED suppression latch and not [BondRefusalGiveUp.gaveUp], which
+ * lives in one process; a bound that dies with the process is the bug this area has now had to fix twice.
+ * Both things that clear the latch are user actions that could have changed the answer — tapping Connect
+ * (`clearPairingHintForUserConnect`) and forgetting the device. Putting a 5/MG into pairing mode and
+ * tapping Connect is the one flow known to have worked on real hardware, and it still asks.
  */
 internal fun shouldRequestExplicitBond(
     optedIn: Boolean,
@@ -39,11 +59,15 @@ internal fun shouldRequestExplicitBond(
     alreadyBondedAtOsLevel: Boolean,
     appLevelBonded: Boolean,
     alreadyRequestedThisLink: Boolean,
+    bondGivenUpForDevice: Boolean,
 ): Boolean {
     if (!optedIn) return false
     if (!isWhoop5) return false
     if (alreadyBondedAtOsLevel) return false
     if (appLevelBonded) return false
+    // The strap has refused the bond by every route the app has, and Android says so out loud: each
+    // request it declines surfaces a system "Pairing rejected" notice the user did not ask for. Stop.
+    if (bondGivenUpForDevice) return false
     return !alreadyRequestedThisLink
 }
 
@@ -100,6 +124,21 @@ internal fun explicitBondThrewLine(throwableName: String, bondStateName: String)
     "WHOOP 5/MG: could not ask Android to pair — createBond threw $throwableName from $bondStateName." +
         " This is a local problem (usually a missing Bluetooth permission), NOT the strap refusing" +
         " (#1635, experimental)"
+
+/**
+ * The line printed when the pairing request retires, so the log says why the requests stopped.
+ *
+ * The give-up lines in this area all exist because something stopped silently and cost weeks of
+ * unreadable captures. This one has a second job: the user has been watching Android say "Pairing
+ * rejected", so the log should be able to tell them the app heard it and stopped asking, and what would
+ * make it ask again.
+ */
+internal fun explicitBondGivenUpLine(): String =
+    "WHOOP 5/MG: not asking Android to pair on this connect — this strap has refused the encrypted bond" +
+        " enough times for the handshake to be latched off, and every further request only produces" +
+        " another system \"Pairing rejected\" notice. Press Connect to ask again (put the strap in" +
+        " pairing mode first if you want the pairing itself to have a chance), or turn \"Ask Android to" +
+        " pair\" off (#1635, experimental)."
 
 /** The outcome line for a `createBond()` call that returned. [initiated] is the API's own return value:
  *  false means the stack refused to even start, which is a different answer from a pairing that starts and

--- a/android/app/src/main/java/com/noop/ble/ExplicitBond.kt
+++ b/android/app/src/main/java/com/noop/ble/ExplicitBond.kt
@@ -132,9 +132,15 @@ internal fun explicitBondThrewLine(throwableName: String, bondStateName: String)
  * unreadable captures. This one has a second job: the user has been watching Android say "Pairing
  * rejected", so the log should be able to tell them the app heard it and stopped asking, and what would
  * make it ask again.
+ *
+ * It claims the RETIREMENT, not a skip — "on this strap again", matching [helloOverrideExhaustedLine]'s
+ * "stopping" and the offload probe's "Not asking this strap again". It is printed once per process while
+ * governing every connect after it, so wording it as a one-connect decision would leave a reader looking
+ * at twenty later connects to conclude the line was stale or the gate was per-connect. Both wrong, and
+ * both cost more than the two words it takes to be accurate.
  */
 internal fun explicitBondGivenUpLine(): String =
-    "WHOOP 5/MG: not asking Android to pair on this connect — this strap has refused the encrypted bond" +
+    "WHOOP 5/MG: not asking Android to pair on this strap again — it has refused the encrypted bond" +
         " enough times for the handshake to be latched off, and every further request only produces" +
         " another system \"Pairing rejected\" notice. Press Connect to ask again (put the strap in" +
         " pairing mode first if you want the pairing itself to have a chance), or turn \"Ask Android to" +

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2422,6 +2422,11 @@ class WhoopBleClient(
      */
     private var disChainInFlight = false
 
+    /** #1635: has the "stopped asking Android to pair" line been printed this process? Same one-shot
+     *  latch idiom as [helloOverrideExhaustedLogged] — the reason does not change between links, and the
+     *  give-up it reports is persisted, so repeating it every connect would be noise. */
+    private var explicitBondGiveUpLogged = false
+
     /** #1635: how many times the probe has stood aside for the DIS chain on this link. */
     private var unbondedProbeDeferrals = 0
 
@@ -5896,6 +5901,9 @@ class WhoopBleClient(
         // #1635: a genuine bond proves the handshake works on this strap — drop the suppression latch so a
         // later transient failure starts from a clean slate rather than inheriting an old verdict.
         runCatching { com.noop.ui.NoopPrefs.setHelloSuppressed(context, lastDeviceAddress, false) }
+        // #1635: the pairing request is asked again from here too, so its one-shot line must be able to
+        // report a SECOND retirement. Without this the switch would go quiet for good after one round.
+        explicitBondGiveUpLogged = false
         // #747/#750: a genuine bond or a fresh user connect re-arms auto-reconnect and clears the give-up.
         bondGiveUp.reset()
         // #971: a genuine bond or a fresh user connect also clears the bond-watchdog bounce streak, so the
@@ -8356,12 +8364,19 @@ class WhoopBleClient(
                     scheduleUnbondedOffloadProbe()
                     return
                 }
+                // Read ONCE, here, above both decisions that consult it. The pairing request is made
+                // before the hello is considered, so a latch read only at the hello would leave the
+                // request unable to see the verdict it is supposed to respect.
+                val suppressed = runCatching {
+                    com.noop.ui.NoopPrefs.helloSuppressed(context, g.device.address)
+                }.getOrDefault(false)
                 if (shouldRequestExplicitBond(
                         optedIn = puffinExperiment.explicitBond,
                         isWhoop5 = true,
                         alreadyBondedAtOsLevel = osBonded,
                         appLevelBonded = didBond,
                         alreadyRequestedThisLink = explicitBondRequestedThisLink,
+                        bondGivenUpForDevice = suppressed,
                     )
                 ) {
                     explicitBondRequestedThisLink = true
@@ -8420,6 +8435,14 @@ class WhoopBleClient(
                         },
                         onFailure = { log(explicitBondThrewLine(it.javaClass.simpleName, where)) },
                     )
+                } else if (puffinExperiment.explicitBond && suppressed && !didBond && !osBonded &&
+                    !explicitBondGiveUpLogged
+                ) {
+                    // Say it, once. The switch is on and doing nothing, which without a line looks exactly
+                    // like the switch being broken — and the user has just been reading Android's pairing
+                    // rejections, so they are owed the app's side of it.
+                    explicitBondGiveUpLogged = true
+                    log(explicitBondGivenUpLine())
                 }
                 // #1635: read once, before the deferral gate — the override has to reach BOTH, or a
                 // deferred hello returns early and the switch below is never evaluated at all.
@@ -8481,9 +8504,6 @@ class WhoopBleClient(
                 // restart the loop the suppression exists to end.
                 val userAsked = helloRetryRequested
                 helloRetryRequested = false
-                val suppressed = runCatching {
-                    com.noop.ui.NoopPrefs.helloSuppressed(context, g.device.address)
-                }.getOrDefault(false)
                 if (shouldSendClientHello(suppressed, userInitiated = userAsked, overrideSuppression = helloOverride)) {
                     // Charge the budget only when the override is what put this hello on the wire: a
                     // strap that is neither suppressed nor deferring would have sent it anyway, and

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -8367,6 +8367,11 @@ class WhoopBleClient(
                 // Read ONCE, here, above both decisions that consult it. The pairing request is made
                 // before the hello is considered, so a latch read only at the hello would leave the
                 // request unable to see the verdict it is supposed to respect.
+                //
+                // This is only safe because NOTHING between here and the hello writes the latch, and that
+                // became true when the pairing request stopped clearing it. Anything reintroducing a write
+                // in that window silently hands the hello a stale verdict — so put the write before this
+                // read, or take a second one, rather than leaving the two decisions disagreeing.
                 val suppressed = runCatching {
                     com.noop.ui.NoopPrefs.helloSuppressed(context, g.device.address)
                 }.getOrDefault(false)

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3685,6 +3685,11 @@ class WhoopBleClient(
             // handshake on a re-add and leaving a stale pref behind for a strap the user removed.
             // Re-latching costs the same five refusals it always did. Twin of the Swift `forgetDevice`.
             runCatching { com.noop.ui.NoopPrefs.setHelloSuppressed(context, releasedAddress, false) }
+            // #1635: clearing the latch means the pairing request is asked again, so its one-shot line has
+            // to be able to report the next retirement. Twin of the reset in [clearPairingHint]; without
+            // it a re-added strap stops asking with nothing in the log saying why, which is the silent
+            // stop this whole area exists to stop repeating.
+            explicitBondGiveUpLogged = false
             autoReconnectPausedForBondLoop = false
             bondLoopPausedAtMs = null
             // Drop the persisted last-device pin so a relaunch / radio-on doesn't auto-reconnect to it (#67).
@@ -8440,8 +8445,18 @@ class WhoopBleClient(
                         },
                         onFailure = { log(explicitBondThrewLine(it.javaClass.simpleName, where)) },
                     )
-                } else if (puffinExperiment.explicitBond && suppressed && !didBond && !osBonded &&
-                    !explicitBondGiveUpLogged
+                } else if (suppressed && !explicitBondGiveUpLogged && shouldRequestExplicitBond(
+                        optedIn = puffinExperiment.explicitBond,
+                        isWhoop5 = true,
+                        alreadyBondedAtOsLevel = osBonded,
+                        appLevelBonded = didBond,
+                        alreadyRequestedThisLink = explicitBondRequestedThisLink,
+                        // The question this branch is actually asking: would we be asking to pair if the
+                        // give-up were not latched? Restating the gate's other conditions here instead
+                        // would drift the moment a sixth one is added — and drift silently, into a line
+                        // that blames the give-up for a decision some other check made.
+                        bondGivenUpForDevice = false,
+                    )
                 ) {
                     // Say it, once. The switch is on and doing nothing, which without a line looks exactly
                     // like the switch being broken — and the user has just been reading Android's pairing

--- a/android/app/src/test/java/com/noop/ble/ExplicitBondTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ExplicitBondTest.kt
@@ -13,7 +13,8 @@ class ExplicitBondTest {
         osBonded: Boolean = false,
         appBonded: Boolean = false,
         already: Boolean = false,
-    ) = shouldRequestExplicitBond(optedIn, isWhoop5, osBonded, appBonded, already)
+        gaveUp: Boolean = false,
+    ) = shouldRequestExplicitBond(optedIn, isWhoop5, osBonded, appBonded, already, gaveUp)
 
     @Test
     fun `off by default - nothing happens without opt-in`() {
@@ -46,6 +47,35 @@ class ExplicitBondTest {
     fun `asking recurs on every link, so it is not a once-only event`() {
         assertTrue(ask(osBonded = false, appBonded = false, already = false))
         assertFalse(ask(already = true))
+    }
+
+    /**
+     * The bound this request never had.
+     *
+     * The hello has a give-up and the unbonded offload probe has a silence budget; asking Android to pair
+     * had nothing, so on a strap that answers SMP "Pairing Not Supported" it fired once per link forever.
+     * That is not a quiet loop: every declined request surfaces a system "Pairing rejected" notice, so the
+     * cost lands on the user rather than in a log nobody reads.
+     */
+    @Test
+    fun `a strap that has refused the bond is not asked again, until the user asks`() {
+        assertFalse(ask(gaveUp = true))
+        // The contrast is the test: the give-up ends the LOOP, not the experiment. Both things that clear
+        // the latch are user actions that could have changed the answer - tapping Connect, and forgetting
+        // the device - and putting a 5/MG into pairing mode then tapping Connect is the one flow known to
+        // have worked on real hardware. A cleared latch must ask again on the very next link.
+        assertTrue(ask(gaveUp = false))
+    }
+
+    @Test
+    fun `the retirement line names both ways out and blames neither the app nor the user`() {
+        val line = explicitBondGivenUpLine()
+        assertTrue(line.contains("Press Connect"))
+        assertTrue(line.contains("pairing mode"))
+        assertTrue(line.contains("off"))
+        // The system notice is what the user has been looking at; the line has to connect the two or it
+        // reads as unrelated.
+        assertTrue(line.contains("Pairing rejected"))
     }
 
     @Test

--- a/android/app/src/test/java/com/noop/ble/ExplicitBondTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ExplicitBondTest.kt
@@ -76,6 +76,11 @@ class ExplicitBondTest {
         // The system notice is what the user has been looking at; the line has to connect the two or it
         // reads as unrelated.
         assertTrue(line.contains("Pairing rejected"))
+        // And it claims the retirement rather than a one-connect skip. It prints once while governing
+        // every connect after it, so "on this connect" would have a reader seeing twenty later connects
+        // conclude the line was stale - the same shape as every other misleading line in this area.
+        assertTrue(line.contains("again"))
+        assertFalse(line.contains("on this connect"))
     }
 
     @Test


### PR DESCRIPTION
## It does not stop connecting

Stating this first because it is the obvious worry. The give-up this rides is the
**suppress** branch, the one whose own log line reads *"hello suppressed, staying
connected"*:

> An UNANSWERED HANDSHAKE means the write vanished. The link itself is healthy and
> streaming, so pausing throws away working live HR to punish a handshake nobody is
> waiting on. Suppress the hello and stay connected instead.

This change gates exactly one thing — `createBond()`. The diff touches no connect,
reconnect, scan or pause path. Live HR, battery and auto-reconnect are unaffected.

## The bound this request never had

Every probe in this area is bounded and this one was not:

| | bound |
|---|---|
| CLIENT_HELLO | give-up after 5 refusals |
| unbonded offload probe | 3-link silence budget, persisted |
| **ask Android to pair** | **none — once per link, forever** |

`shouldRequestExplicitBond` was gated only by `optedIn`, family, the two bond flags,
and `alreadyRequestedThisLink` — a per-**link** flag. On a strap answering SMP
"Pairing Not Supported" neither bond flag ever becomes true, so it fired on every
connect indefinitely.

That is worse than a quiet loop. Every declined request surfaces a system **"Pairing
rejected"** notice, so the cost lands on the user rather than in a log nobody reads.
It was reported from the field as exactly that.

## The change

The request stands down once the bond give-up has latched for that device.

**The signal is the persisted suppression latch**, not `BondRefusalGiveUp.gaveUp`.
That flag lives in one process, and a bound that dies with the process is the same
defect corrected twice already this week: #1761 (a probe budget that re-armed on
every service restart) and #1762 (a latch cleared on every link).

**Gating one experiment on the other is deliberate.** `BondRefusalGiveUp` does not
track the hello; it tracks whether this strap will form an encrypted bond, which is
the single thing both routes are trying to achieve and neither has. Its threshold is
reached on the strap's own refusals, so by the time it latches the pairing request
has had its five links and returned `BOND_NONE` every time, with an HCI capture
showing SMP 0x05 underneath. The experiment concludes; it is not cut short.

**It ends the loop, not the experiment.** Both things that clear the latch are user
actions that could have changed the answer — tapping Connect, and forgetting the
device. Putting a 5/MG into pairing mode and tapping Connect is the one flow known
to have worked on real hardware (@Zebsi235's MG), and it still asks.

A one-shot line reports the stand-down. A switch that is on and silently doing
nothing reads as a broken switch, and the user has just been reading Android's
rejection notices — they are owed the app's side of it.

The latch is now read **once**, above both decisions that consult it. The pairing
request is made before the hello is considered, so a read placed only at the hello
could not be seen by the request that needs it.

## Field evidence

Build 398, same strap, after the two earlier repairs landed:

```
18:44:35 .. 18:45:23   refusals climb 1 -> 5, five links at ~4.8s
18:45:23   bond gaveUp refusals=5 (hello suppressed, staying connected)
18:45:31   CLIENT_HELLO suppressed for this strap - Staying on live HR
   after:  0 hellos, 0 disconnects, 1 further pairing request
```

That last number is what this PR removes. The UI reached "Live HR (not fully
paired)" — the #1635 end state — and the only thing still firing was the pairing
request the user could see being rejected.

## Tests

`ExplicitBondTest` +2. The give-up case and the cleared-latch case are one test
because the contrast is the point: the loop ends, the experiment does not. The
retirement line is pinned to name both ways out and to mention the system notice, so
it connects to what the user was actually looking at.

608 tests in `com.noop.ble`, zero failures on a forced clean run.
`compileFullDebugKotlin`, `doc_comment_lint.py`, `i18n_audit.py` clean.

## Parity

Android only, and permanently so — `ExplicitBond.kt`'s own header already records
why: CoreBluetooth exposes no explicit pairing API, so there is nothing to mirror and
an audit finding this one-sided should leave it rather than delete it as untwinned.

Refs #1635.
