### PR TITLE
The Devices card told the truth once, then went green again (#221)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
+++ b/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
@@ -130,6 +130,29 @@ internal fun helloOverrideExhaustedLine(attempts: Int): String =
 internal fun giveUpSuppressesHello(authRefusal: Boolean): Boolean = !authRefusal
 
 /**
+ * The pairing hint a connect should carry when the handshake is already latched off.
+ *
+ * The Devices card's "Connected · not paired" pill keys on `pairingHint != null`, and that hint is set
+ * only where a refusal FRESHLY crosses the give-up threshold. The latch outlives the process; the hint did
+ * not. So the first launch after a strap was given up on showed the give-up correctly, and every launch
+ * after it fell through to a green "Active · Live" — beside a feature list naming Sleep, Strain and HRV,
+ * on a strap that has never banked a row.
+ *
+ * It was masked until the pairing request stopped wiping the latch on every link: the give-up used to
+ * re-cross constantly and keep the hint fresh by accident. Removing that wipe was right, and it left this
+ * standing on its own.
+ *
+ * Seeds rather than overwrites. A hint already published this session came from a real refusal on this
+ * link and says something more specific than "we gave up earlier"; replacing it would trade a live
+ * observation for a remembered one.
+ */
+internal fun seededPairingHint(current: String?, helloSuppressed: Boolean): String? = when {
+    current != null -> current
+    helloSuppressed -> BondRefusalGiveUp.helloSuppressedHint()
+    else -> null
+}
+
+/**
  * SharedPreferences key holding the hello-suppression latch for one device.
  *
  * Per device, and lowercased for the same reason [firmwarePrefKey] is: the same strap can present its

--- a/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
+++ b/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
@@ -130,29 +130,6 @@ internal fun helloOverrideExhaustedLine(attempts: Int): String =
 internal fun giveUpSuppressesHello(authRefusal: Boolean): Boolean = !authRefusal
 
 /**
- * The pairing hint a connect should carry when the handshake is already latched off.
- *
- * The Devices card's "Connected · not paired" pill keys on `pairingHint != null`, and that hint is set
- * only where a refusal FRESHLY crosses the give-up threshold. The latch outlives the process; the hint did
- * not. So the first launch after a strap was given up on showed the give-up correctly, and every launch
- * after it fell through to a green "Active · Live" — beside a feature list naming Sleep, Strain and HRV,
- * on a strap that has never banked a row.
- *
- * It was masked until the pairing request stopped wiping the latch on every link: the give-up used to
- * re-cross constantly and keep the hint fresh by accident. Removing that wipe was right, and it left this
- * standing on its own.
- *
- * Seeds rather than overwrites. A hint already published this session came from a real refusal on this
- * link and says something more specific than "we gave up earlier"; replacing it would trade a live
- * observation for a remembered one.
- */
-internal fun seededPairingHint(current: String?, helloSuppressed: Boolean): String? = when {
-    current != null -> current
-    helloSuppressed -> BondRefusalGiveUp.helloSuppressedHint()
-    else -> null
-}
-
-/**
  * SharedPreferences key holding the hello-suppression latch for one device.
  *
  * Per device, and lowercased for the same reason [firmwarePrefKey] is: the same strap can present its

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -8549,6 +8549,15 @@ class WhoopBleClient(
                     log("WHOOP 5/MG: CLIENT_HELLO suppressed for this strap — it was never acknowledged and" +
                         " the write is what drops the link. Staying on live HR (not fully paired); press" +
                         " Connect to try the handshake again (#1635).")
+                    // #221: republish the pairing hint, which the Devices card's "Connected · not paired"
+                    // pill reads. It is otherwise written only where a refusal FRESHLY crosses the give-up,
+                    // and the latch that records the give-up outlives the process while the hint did not —
+                    // so every launch after the one that gave up showed a green "Active · Live" beside a
+                    // feature list naming Sleep, Strain and HRV, on a strap that has never banked a row.
+                    // Placed HERE, next to the line reporting the same fact, because Swift already does
+                    // exactly this (BLEManager.swift, the matching suppression branch): the gap was
+                    // one-sided, and this closes it rather than inventing a second placement.
+                    _state.update { it.copy(pairingHint = seededPairingHint(it.pairingHint, true)) }
                     // The unbonded DIS attempt rides HERE, on the suppressed link, and nowhere else. This
                     // is the only 5/MG state known to be stable: the handshake is off, the watchdog is
                     // cancelled, and the link holds. During the reconnect loop it would have ~4.8s and

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -8557,7 +8557,14 @@ class WhoopBleClient(
                     // Placed HERE, next to the line reporting the same fact, because Swift already does
                     // exactly this (BLEManager.swift, the matching suppression branch): the gap was
                     // one-sided, and this closes it rather than inventing a second placement.
-                    _state.update { it.copy(pairingHint = seededPairingHint(it.pairingHint, true)) }
+                    //
+                    // Assigned, not seeded. A first attempt kept any hint already published, on the
+                    // reasoning that a live observation beats a remembered one — but the only hint that can
+                    // be present here came from a PREVIOUS link, since refusals are detected on teardown
+                    // and this runs during setup. A stale hint about a condition that may no longer hold
+                    // is not the fresher fact; the state of the link in hand is. Swift assigns for the
+                    // same reason, and mirrored code diverging quietly is worse than either choice.
+                    _state.update { it.copy(pairingHint = BondRefusalGiveUp.helloSuppressedHint()) }
                     // The unbonded DIS attempt rides HERE, on the suppressed link, and nowhere else. This
                     // is the only 5/MG state known to be stable: the handshake is off, the watchdog is
                     // cancelled, and the link holds. During the reconnect loop it would have ~4.8s and

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -235,9 +235,12 @@ fun DevicesScreen(
                 isLiveConnected = device.status == DeviceStatus.active.name && live.connected,
                 // #221: a WHOOP 5/MG can be BLE-connected yet have its ENCRYPTED bond refused (the WHOOP
                 // app, or a stale pairing, holds the single-app bond) — no HR/biometric data flows even
-                // though the link is up, so "Active · Live" overstates it. pairingHint is set only once
-                // that refusal is genuinely detected (#78), never during a normal connect, so this can't
-                // false-alarm a working 4.0 (its pairingHint stays null) or a fresh 5/MG connect.
+                // though the link is up, so "Active · Live" overstates it. pairingHint is raised either by
+                // a refusal detected on this link (#78) or, on connect, by the persisted give-up latch for
+                // a strap already known to be unpaired ([seededPairingHint]) — the latter because the
+                // latch outlives the process and the hint did not, so every launch after the one that gave
+                // up came back green. Neither route false-alarms a working 4.0, which never latches and is
+                // not on this code path at all, nor a fresh 5/MG, which has no latch to read.
                 bondRefused = device.status == DeviceStatus.active.name && live.connected && live.pairingHint != null,
                 // The full #78 how-to-fix guidance, surfaced on the card itself when bondRefused so the
                 // fix is self-service instead of buried in the strap log.

--- a/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
@@ -1,6 +1,8 @@
 package com.noop.ble
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -86,6 +88,36 @@ class HelloSuppressionTest {
         // And only an explicit reset - a genuine bond, or the user tapping Connect - earns another.
         g.reset()
         assertEquals(1, (1..12).count { g.recordRefusal() })
+    }
+
+    /**
+     * The Devices card told the truth once and then stopped.
+     *
+     * "Connected · not paired" keys on pairingHint, written only where a refusal freshly crosses the
+     * give-up. The latch that records the give-up is persisted; the hint was not. So the launch that gave
+     * up showed the pill correctly and every launch after it showed a green "Active · Live" - next to a
+     * feature list naming Sleep, Strain and HRV, on a strap that has never banked a row.
+     */
+    @Test
+    fun `a strap already given up on carries its hint into the next launch`() {
+        assertNotNull(seededPairingHint(current = null, helloSuppressed = true))
+        assertEquals(BondRefusalGiveUp.helloSuppressedHint(), seededPairingHint(null, true))
+    }
+
+    @Test
+    fun `a strap that has not been given up on raises nothing`() {
+        // The guard that kept this from false-alarming a working 4.0, which never latches, or a 5/MG
+        // mid-handshake, which has not been given up on yet.
+        assertNull(seededPairingHint(current = null, helloSuppressed = false))
+    }
+
+    @Test
+    fun `a hint from this session outranks the remembered one`() {
+        // A hint already published came from a real refusal on this link and says something more specific
+        // than "we gave up earlier". Seeding must not trade a live observation for a remembered one.
+        val live = "a more specific refusal seen on this link"
+        assertEquals(live, seededPairingHint(current = live, helloSuppressed = true))
+        assertEquals(live, seededPairingHint(current = live, helloSuppressed = false))
     }
 
     // #1635: the opt-in override, after the HCI capture changed the premise

--- a/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
@@ -43,6 +43,17 @@ class HelloSuppressionTest {
         assertEquals(null, helloSuppressionPrefKey(null))
     }
 
+    /**
+     * The Devices card's "Connected · not paired" pill keys on `pairingHint != null`, and the suppressed
+     * connect publishes exactly this hint (WhoopBleClient's suppression branch, mirroring Swift's). A hint
+     * that ever came back blank would take the card silently back to a green "Active · Live" on a strap
+     * that has never banked a row - which is the state this whole path exists to stop misreporting.
+     */
+    @Test
+    fun `the suppression hint is non-blank, because a card pill depends on it`() {
+        assertTrue(BondRefusalGiveUp.helloSuppressedHint().isNotBlank())
+    }
+
     @Test
     fun `the suppression hint never claims a pause or a cause`() {
         val hint = BondRefusalGiveUp.helloSuppressedHint()
@@ -88,36 +99,6 @@ class HelloSuppressionTest {
         // And only an explicit reset - a genuine bond, or the user tapping Connect - earns another.
         g.reset()
         assertEquals(1, (1..12).count { g.recordRefusal() })
-    }
-
-    /**
-     * The Devices card told the truth once and then stopped.
-     *
-     * "Connected · not paired" keys on pairingHint, written only where a refusal freshly crosses the
-     * give-up. The latch that records the give-up is persisted; the hint was not. So the launch that gave
-     * up showed the pill correctly and every launch after it showed a green "Active · Live" - next to a
-     * feature list naming Sleep, Strain and HRV, on a strap that has never banked a row.
-     */
-    @Test
-    fun `a strap already given up on carries its hint into the next launch`() {
-        assertNotNull(seededPairingHint(current = null, helloSuppressed = true))
-        assertEquals(BondRefusalGiveUp.helloSuppressedHint(), seededPairingHint(null, true))
-    }
-
-    @Test
-    fun `a strap that has not been given up on raises nothing`() {
-        // The guard that kept this from false-alarming a working 4.0, which never latches, or a 5/MG
-        // mid-handshake, which has not been given up on yet.
-        assertNull(seededPairingHint(current = null, helloSuppressed = false))
-    }
-
-    @Test
-    fun `a hint from this session outranks the remembered one`() {
-        // A hint already published came from a real refusal on this link and says something more specific
-        // than "we gave up earlier". Seeding must not trade a live observation for a remembered one.
-        val live = "a more specific refusal seen on this link"
-        assertEquals(live, seededPairingHint(current = live, helloSuppressed = true))
-        assertEquals(live, seededPairingHint(current = live, helloSuppressed = false))
     }
 
     // #1635: the opt-in override, after the HCI capture changed the premise


### PR DESCRIPTION
## The card

A 5/MG that has **never persisted a single row** showing a green **"Active · Live"**
pill, beside a feature list reading *Heart rate · HRV · Skin temp · Resp rate ·
Steps · Sleep · Strain · Battery* and *"Powers Charge, Effort, Rest, Sleep + Health
Monitor"*.

Everywhere else in the app already tells the truth about this strap — the Live
screen says "Live HR (not fully paired)", the log says the handshake is off. Only
the Devices card claims it is working.

## The card already has the right state

`devicePillState` orders it correctly, and a test pins the ordering:

```kotlin
bondRefused      -> DevicePillState("Connected · not paired", StrandTone.Warning)
isLiveConnected  -> DevicePillState("Active · Live", StrandTone.Positive, pulsing = true)
```

`bondRefused` reads `live.pairingHint != null`, and the hint is written **only where
a refusal freshly crosses the give-up**. The latch that records the give-up is
persisted; the hint was not. So the launch that gave up showed the pill correctly,
and every launch after it fell through to green.

It was masked until the pairing request stopped wiping the latch on every link. The
give-up used to re-cross constantly and keep the hint fresh **by accident**.
Removing that wipe was right, and it left this standing on its own — the same shape
as the three before it: state derived once, in the process where the event happened,
describing a fact that outlives it.

## Parity — and this one is a real gap

Unlike the last three, this is not Android-only machinery. Swift **already does
it**, in the matching suppression branch:

```swift
if !shouldSendClientHello(suppressedForDevice: helloSuppressed, userInitiated: helloUserAsked) {
    log("WHOOP 5/MG: CLIENT_HELLO suppressed for this strap …")
    state.pairingHint = BondRefusalGiveUp.helloSuppressedHint()
```

So the gap was one-sided with Swift correct. This closes it **in the same place** —
beside the Kotlin line reporting the same fact — rather than inventing a second
placement and leaving the two to drift. `devicePillState` documents itself as
mirroring `DevicePillState.resolve` exactly, so the feeding logic should match too.

## The change

The suppressed connect publishes `BondRefusalGiveUp.helloSuppressedHint()`, assigned
exactly as Swift assigns it. A first version seeded without overwriting, which was a
silent semantic divergence in mirrored code — and wrong on its own terms: the only
hint that can be present at that point came from a *previous* link, since refusals
are detected on teardown and this runs during setup. A stale hint about a condition
that may no longer hold is not the fresher fact.

Side effect worth having: the card's how-to-fix guidance block is gated on
`bondRefused && pairingHint != null`, so it comes back too. Previously a user who
relaunched the app lost both the honest pill and the instructions for fixing it.

The comment on the `bondRefused` call site claimed the hint is set *"never during a
normal connect, so this can't false-alarm a working 4.0 or a fresh 5/MG connect"*.
This makes the first clause untrue. It now describes both routes and why the
conclusion still holds: a 4.0 never latches and is not on this code path at all, and
a fresh 5/MG has no latch to read.

## Tests

`HelloSuppressionTest` +1, pinning the coupling that outlives the implementation: the
card pill keys on `pairingHint != null`, so a hint that ever came back blank would
take the card silently back to green.

611 tests in `com.noop.ble` and 863 in `com.noop.ui`, zero failures on a forced clean
run. `compileFullDebugKotlin`, `doc_comment_lint.py`, `i18n_audit.py` clean.

## Considered and rejected

Driving `bondRefused` off `bonded && !encryptedBond`, which is what the Live screen
uses and needs no persistence. It would flash "Connected · not paired" during every
healthy 5/MG handshake, in the window between the live-HR shortcut setting `bonded`
and the hello acking. Accurate, but a warning pill that appears and clears on every
normal connect trains people to ignore it.

Refs #1635, #221.
