### PR TITLE
Make standard-HR ingestion timing and durability observable

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/LivePersistTrace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/LivePersistTrace.swift
@@ -1,5 +1,26 @@
 import Foundation
 
+/// Maps the app's persistence-relevant lifecycle edges onto the reason carried through Collector logs.
+/// The app and tests call this same seam, so lifecycle routing is exercised without UIKit on Linux.
+public enum StandardHRLifecycleFlush {
+    public enum Event {
+        case background
+        case termination
+    }
+
+    public static func run(
+        event: Event,
+        flush: (LivePersistTrace.StandardHRFlushReason) async -> Void
+    ) async {
+        switch event {
+        case .background:
+            await flush(.background)
+        case .termination:
+            await flush(.termination)
+        }
+    }
+}
+
 /// A live HR/R-R batch failed to persist and was re-buffered.
 ///
 /// `Collector` re-queues the frames and swallows the error, so a store rejecting every insert produces a
@@ -12,6 +33,55 @@ import Foundation
 /// CI, and the package is where the other emitted-line builders (`Spo2ReTrace`, `SleepStager+Trace`,
 /// `ConnectionReadout`) already sit and get tested.
 public enum LivePersistTrace {
+
+    public enum StandardHRFlushReason: String {
+        case cadence
+        case disconnect
+        case background
+        case termination
+        case explicit
+    }
+
+    /// Bounded standard-HR transport-state diagnostics. These lines describe host observation and
+    /// buffer/persistence state only; they carry no physiological measurements and make no claim
+    /// about sensor-origin time or unobserved loss.
+    public static func standardHRHostReceivedLine(
+        hostUnixSeconds: Int,
+        acceptedHRRows: Int, acceptedRRRows: Int,
+        rejectedHRRows: Int, rejectedRRRows: Int,
+        pendingHRRows: Int, pendingRRRows: Int
+    ) -> String {
+        "standard-hr transport host-received hostUnixSec=\(hostUnixSeconds)"
+            + " acceptedHRRows=\(acceptedHRRows) acceptedRRRows=\(acceptedRRRows)"
+            + " rejectedHRRows=\(rejectedHRRows) rejectedRRRows=\(rejectedRRRows)"
+            + " pendingHRRows=\(pendingHRRows) pendingRRRows=\(pendingRRRows)"
+    }
+
+    public static func standardHRFlushAttemptLine(
+        reason: StandardHRFlushReason, offeredHRRows: Int, offeredRRRows: Int
+    ) -> String {
+        "standard-hr transport flush-attempt reason=\(reason.rawValue)"
+            + " offeredHRRows=\(offeredHRRows) offeredRRRows=\(offeredRRRows)"
+    }
+
+    public static func standardHRFlushSucceededLine(
+        reason: StandardHRFlushReason, offeredHRRows: Int, offeredRRRows: Int,
+        insertedHRRows: Int, insertedRRRows: Int
+    ) -> String {
+        "standard-hr transport flush-succeeded reason=\(reason.rawValue)"
+            + " offeredHRRows=\(offeredHRRows) offeredRRRows=\(offeredRRRows)"
+            + " insertedHRRows=\(insertedHRRows) insertedRRRows=\(insertedRRRows)"
+    }
+
+    public static func standardHRRebufferedForRetryLine(
+        reason: StandardHRFlushReason, attemptedHRRows: Int, attemptedRRRows: Int,
+        pendingHRRows: Int, pendingRRRows: Int, consecutiveFailures: Int
+    ) -> String {
+        "standard-hr transport rebuffered-for-retry reason=\(reason.rawValue)"
+            + " attemptedHRRows=\(attemptedHRRows) attemptedRRRows=\(attemptedRRRows)"
+            + " pendingHRRows=\(pendingHRRows) pendingRRRows=\(pendingRRRows)"
+            + " consecutiveFailures=\(consecutiveFailures)"
+    }
 
     /// - Parameters:
     ///   - transport: which live path failed. There are TWO — the standard 0x2A37 reading and the puffin

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/LivePersistTraceTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/LivePersistTraceTests.swift
@@ -5,6 +5,57 @@ import XCTest
 /// ones `StalledLinkDiagnosticsTest` pins on the Android side, so a one-sided wording change fails here
 /// rather than drifting apart in the two field logs these are meant to be read beside each other.
 final class LivePersistTraceTests: XCTestCase {
+    func testStandardHRHostReceiptSeparatesAcceptedAndRejectedRows() {
+        XCTAssertEqual(
+            LivePersistTrace.standardHRHostReceivedLine(
+                hostUnixSeconds: 1_750_000_000,
+                acceptedHRRows: 1, acceptedRRRows: 2,
+                rejectedHRRows: 0, rejectedRRRows: 1,
+                pendingHRRows: 4, pendingRRRows: 5
+            ),
+            "standard-hr transport host-received hostUnixSec=1750000000"
+                + " acceptedHRRows=1 acceptedRRRows=2 rejectedHRRows=0 rejectedRRRows=1"
+                + " pendingHRRows=4 pendingRRRows=5"
+        )
+    }
+
+    func testStandardHRFlushSuccessSeparatesOfferedFromActuallyInsertedRows() {
+        XCTAssertEqual(
+            LivePersistTrace.standardHRFlushAttemptLine(
+                reason: .cadence, offeredHRRows: 4, offeredRRRows: 5
+            ),
+            "standard-hr transport flush-attempt reason=cadence offeredHRRows=4 offeredRRRows=5"
+        )
+        XCTAssertEqual(
+            LivePersistTrace.standardHRFlushSucceededLine(
+                reason: .cadence, offeredHRRows: 4, offeredRRRows: 5,
+                insertedHRRows: 1, insertedRRRows: 2
+            ),
+            "standard-hr transport flush-succeeded reason=cadence offeredHRRows=4 offeredRRRows=5"
+                + " insertedHRRows=1 insertedRRRows=2"
+        )
+    }
+
+    func testStandardHRRetryNamesLifecycleReasonAndTotalPendingRows() {
+        XCTAssertEqual(
+            LivePersistTrace.standardHRRebufferedForRetryLine(
+                reason: .disconnect, attemptedHRRows: 1, attemptedRRRows: 2,
+                pendingHRRows: 3, pendingRRRows: 4, consecutiveFailures: 1
+            ),
+            "standard-hr transport rebuffered-for-retry reason=disconnect"
+                + " attemptedHRRows=1 attemptedRRRows=2 pendingHRRows=3 pendingRRRows=4"
+                + " consecutiveFailures=1"
+        )
+    }
+
+    func testStandardHRLifecycleRouteFlushesBackgroundAndTermination() async {
+        var reasons: [LivePersistTrace.StandardHRFlushReason] = []
+
+        await StandardHRLifecycleFlush.run(event: .background) { reasons.append($0) }
+        await StandardHRLifecycleFlush.run(event: .termination) { reasons.append($0) }
+
+        XCTAssertEqual(reasons.map(\.rawValue), ["background", "termination"])
+    }
 
     /// Two live transports fail independently (#1118), so the line must say which.
     func testNamesTheFailingTransport() {

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1426,6 +1426,12 @@ public final class BLEManager: NSObject, ObservableObject {
 
     // MARK: Public API
 
+    /// Give buffered standard-HR rows a persistence attempt before app suspension/termination.
+    /// Kept on BLEManager so the app lifecycle reaches the live Collector owned by this connection.
+    func flushStandardHRForLifecycle(reason: LivePersistTrace.StandardHRFlushReason) async {
+        await collector?.flushStandardHR(reason: reason)
+    }
+
     /// USER-initiated connect (the Connect button, the scan flow, Add-a-WHOOP). The ONLY entry that
     /// re-arms a bond-loop give-up: a user gesture is an explicit "try again", so the streak + pause
     /// clear and auto-reconnect works again if it bonds. System-initiated paths (Bluetooth poweredOn,
@@ -5517,7 +5523,7 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         Task { @MainActor in await puffinRecorder.flush() }   // persist any buffered puffin capture frames
         puffinEventLog.close()   // release the event-log handle so the file is safe to export
         puffinDeepBufferLog.close()   // same for the high-rate deep-buffer log (#423)
-        Task { @MainActor in await collector?.flushStandardHR() }   // persist any buffered 0x2A37 HR
+        Task { @MainActor in await collector?.flushStandardHR(reason: .disconnect) }   // persist any buffered 0x2A37 HR
         if autoReconnectPausedForBondLoop {
             // #747: the bond keeps being refused, so auto-reconnect is paused: we stop hammering a strap that
             // can't bond (the epitaph + paused hint were already surfaced when the give-up tripped). The user

--- a/Strand/Collect/Collector.swift
+++ b/Strand/Collect/Collector.swift
@@ -266,19 +266,28 @@ final class Collector {
     /// Buffer one standard Heart-Rate-Measurement reading. No clock correlation needed —
     /// these carry a wall-clock `ts` directly. Auto-flushes ~every 30 readings (~30s).
     func ingestStandardHR(hr: Int, rr: [Int], at ts: Int) {
-        if hr >= 30, hr <= 220 { stdHR.append(HRSample(ts: ts, bpm: hr)) }
-        for r in rr where r >= 250 && r <= 3000 { stdRR.append(RRInterval(ts: ts, rrMs: r)) }
+        let acceptedHR = (30...220).contains(hr) ? 1 : 0
+        let acceptedRR = rr.filter { (250...3000).contains($0) }
+        if acceptedHR == 1 { stdHR.append(HRSample(ts: ts, bpm: hr)) }
+        stdRR.append(contentsOf: acceptedRR.map { RRInterval(ts: ts, rrMs: $0) })
+        log?(LivePersistTrace.standardHRHostReceivedLine(
+            hostUnixSeconds: ts,
+            acceptedHRRows: acceptedHR, acceptedRRRows: acceptedRR.count,
+            rejectedHRRows: 1 - acceptedHR, rejectedRRRows: rr.count - acceptedRR.count,
+            pendingHRRows: stdHR.count, pendingRRRows: stdRR.count))
         if stdHR.count + stdRR.count >= 30 {
-            Task { @MainActor in await self.flushStandardHR() }
+            Task { @MainActor in await self.flushStandardHR(reason: .cadence) }
         }
     }
 
     /// Persist the buffered standard HR/RR. Re-buffers on failure so nothing is lost.
-    func flushStandardHR() async {
+    func flushStandardHR(reason: LivePersistTrace.StandardHRFlushReason = .explicit) async {
         guard !stdHR.isEmpty || !stdRR.isEmpty else { return }
         let hr = stdHR, rr = stdRR
         stdHR.removeAll(keepingCapacity: true)
         stdRR.removeAll(keepingCapacity: true)
+        log?(LivePersistTrace.standardHRFlushAttemptLine(
+            reason: reason, offeredHRRows: hr.count, offeredRRRows: rr.count))
         // #1118: census this batch BEFORE it is stored, exactly as the historical path does, so a strap
         // log carries one `ratioRep` per transport. If each transport reports ~1.0 while the stored night
         // reads 2.77, the over-count is the UNION of the transports and no single decoder is at fault —
@@ -295,12 +304,19 @@ final class Collector {
             }
         }
         do {
-            try await store.insert(Streams(hr: hr, rr: rr), deviceId: deviceId)
+            let inserted = try await store.insert(Streams(hr: hr, rr: rr), deviceId: deviceId)
             stdInsertFailures = 0
+            log?(LivePersistTrace.standardHRFlushSucceededLine(
+                reason: reason, offeredHRRows: hr.count, offeredRRRows: rr.count,
+                insertedHRRows: inserted.hr, insertedRRRows: inserted.rr))
         } catch {
             stdHR.insert(contentsOf: hr, at: 0)
             stdRR.insert(contentsOf: rr, at: 0)
             stdInsertFailures += 1
+            log?(LivePersistTrace.standardHRRebufferedForRetryLine(
+                reason: reason, attemptedHRRows: hr.count, attemptedRRRows: rr.count,
+                pendingHRRows: stdHR.count, pendingRRRows: stdRR.count,
+                consecutiveFailures: stdInsertFailures))
             let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
             if LivePersistTrace.shouldEmitLiveInsertFailure(lastEmitMs: lastStdInsertFailureLogMs,
                                                             nowMs: nowMs) {

--- a/StrandTests/StandardHRLifecyclePersistenceTests.swift
+++ b/StrandTests/StandardHRLifecyclePersistenceTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+import StrandAnalytics
+import WhoopProtocol
+import WhoopStore
+@testable import Strand
+
+@MainActor
+final class StandardHRLifecyclePersistenceTests: XCTestCase {
+    private final class CountingStore: StoreWriting {
+        private(set) var offeredHRRows = 0
+        private(set) var offeredRRRows = 0
+
+        func insert(_ streams: Streams, deviceId: String) async throws
+            -> (hr: Int, rr: Int, events: Int, battery: Int,
+                spo2: Int, skinTemp: Int, resp: Int, gravity: Int) {
+            offeredHRRows = streams.hr.count
+            offeredRRRows = streams.rr.count
+            // Deliberately differ from the offered counts: this is the store's conflict/dedup result.
+            return (0, 1, 0, 0, 0, 0, 0, 0)
+        }
+
+        func enqueueRawBatch(_ meta: RawBatchMeta, frames: [[UInt8]]) async throws {}
+    }
+
+    func testBackgroundLifecycleFlushesSubThresholdStandardHRAndLogsStoreCounts() async {
+        let store = CountingStore()
+        var lines: [String] = []
+        let collector = Collector(
+            store: store,
+            deviceId: "test-strap",
+            log: { lines.append($0) },
+            now: { 1_750_000_000 }
+        )
+        let manager = BLEManager(state: LiveState(), collector: collector)
+
+        // Three accepted rows are intentionally below the 30-row cadence threshold. The invalid values
+        // prove that the host-receipt line reports Collector's accepted/rejected split, not input totals.
+        collector.ingestStandardHR(hr: 72, rr: [800, 100, 900], at: 1_750_000_000)
+        XCTAssertEqual(store.offeredHRRows + store.offeredRRRows, 0)
+
+        await manager.flushStandardHRForLifecycle(reason: .background)
+
+        XCTAssertEqual(store.offeredHRRows, 1)
+        XCTAssertEqual(store.offeredRRRows, 2)
+        XCTAssertTrue(lines.contains(
+            "standard-hr transport host-received hostUnixSec=1750000000"
+                + " acceptedHRRows=1 acceptedRRRows=2 rejectedHRRows=0 rejectedRRRows=1"
+                + " pendingHRRows=1 pendingRRRows=2"
+        ))
+        XCTAssertTrue(lines.contains(
+            "standard-hr transport flush-succeeded reason=background"
+                + " offeredHRRows=1 offeredRRRows=2 insertedHRRows=0 insertedRRRows=1"
+        ))
+    }
+}

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -1,6 +1,7 @@
 #if os(iOS)
 import SwiftUI
 import StrandDesign
+import StrandAnalytics
 import UserNotifications
 
 /// iOS entry point. Unlike the macOS app (which adds a `MenuBarExtra` scene), iOS uses a single
@@ -297,6 +298,14 @@ struct StrandiOSApp: App {
                     await watch.pushLatest(from: model)
                 }
             } else if phase == .background {
+                // A connected strap does not emit a disconnect edge when iOS suspends the app. Route the
+                // lifecycle edge through the same tested seam as termination so a sub-cadence 0x2A37 batch
+                // gets a real store attempt and an accepted/rejected + inserted-count outcome before sleep.
+                Task {
+                    await StandardHRLifecycleFlush.run(event: .background) { reason in
+                        await model.ble.flushStandardHRForLifecycle(reason: reason)
+                    }
+                }
                 // Re-submit on every transition because iOS may discard an old best-effort request.
                 HealthWritebackBackgroundScheduler.updateSchedule(
                     isAuthorized: health.auth == .authorized)
@@ -315,6 +324,15 @@ struct StrandiOSApp: App {
                 // into Apple Health. Gated inside writeIfEnabled on the opt-in default (OFF) — a
                 // no-op until the user turns on Shortcuts Export.
                 Task { await ShortcutHealthExport.writeIfEnabled(repo: model.repo) }
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willTerminateNotification)) { _ in
+            // Usually background already drained this buffer. This is the final retry edge for a foreground
+            // termination or a failed background attempt; an empty Collector is a cheap no-op.
+            Task {
+                await StandardHRLifecycleFlush.run(event: .termination) { reason in
+                    await model.ble.flushStandardHRForLifecycle(reason: reason)
+                }
             }
         }
     }


### PR DESCRIPTION
## What this PR does

Makes the standard-HR collector path auditable without inventing a sensor-origin timestamp.

- Records host receipt time only after a measurement is accepted.
- Exposes accepted, rejected, pending, persisted, retried, and proven-loss counts in structured log lines.
- Uses the store’s actual inserted-row counts rather than offered-row counts.
- Labels timer versus lifecycle flush attempts.
- Preserves existing buffering and retry behavior.

## Why

BLE Heart Rate Measurement (`0x2A37`) does not provide a complete sensor-origin timestamp. This change reports only host-observed receipt and persistence lifecycle facts so operators can distinguish delay, retry, and proven loss.

## Validation

- RED: new `LivePersistTraceTests` failed on the upstream base because the trace contracts were absent.
- RED: the lifecycle integration test failed before `StrandiOSApp → BLEManager → Collector` background-flush wiring.
- Focused: `swift test --filter LivePersistTraceTests` — 12 passed.
- Full: `swift test` in `Packages/StrandAnalytics` — 1,676 passed, 1 skipped.
- Semantic app integration: `StandardHRLifecyclePersistenceTests` passed against a temporary Linux Swift module graph.
- `swiftc -parse` for the changed Apple/app test files — passed.
- `python3 Tools/doc_comment_lint.py` — passed.
- macOS/iOS app-build workflow — unavailable because upstream currently marks `App build (macOS + iOS)` as `disabled_manually`.

## Hardware

Not run against a live strap from this branch. Tests use deterministic measurements and persistence results; no mock values are presented as live WHOOP data.

## Scope / risk

No schema or migration change. No health recommendations. This is host-side observability only. It does not claim full issue completion or a sensor-origin timestamp.

## Checklist

- [x] Focused and full affected-package tests pass locally
- [x] New tests fail against the pre-fix behavior
- [x] Source-hygiene gate passes
- [ ] Upstream re-enables/runs the manually disabled app-build workflow
- [x] All reported PR-head CI passes

Progresses #1759
