### PR TITLE
A day you never logged is not a day you answered No (#322)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/BehaviorInsights.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/BehaviorInsights.swift
@@ -107,6 +107,8 @@ public enum BehaviorInsights {
             if behaviorDays.contains(day) { withVals.append(value) }
             else if controlDays.contains(day) { withoutVals.append(value) }
             // Neither: the behaviour was not logged that day. Not a control — no information.
+            // A day in BOTH would count as "with"; callers merge imported ∪ native before building
+            // these, so one question cannot hold two answers for one day.
         }
 
         let n1 = withVals.count

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/BehaviorInsights.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/BehaviorInsights.swift
@@ -77,13 +77,27 @@ public enum BehaviorInsights {
 
     // MARK: - Single behavior effect
 
-    /// Compute the effect of `behavior` on `outcome`. Days are partitioned into
-    /// "with" (day ∈ behaviorDays) and "without" (day ∉ behaviorDays), restricted
-    /// to days that have an outcome value in `outcomeByDay`.
+    /// Compute the effect of `behavior` on `outcome`. "With" is day ∈ `behaviorDays`; "without" is
+    /// day ∈ `controlDays`. Days in NEITHER are dropped, and that is the point of the second set.
+    ///
+    /// The split used to be `if behaviorDays.contains(day) { with } else { without }`, which made every
+    /// day carrying an outcome a control — so a behaviour logged Yes on 20 days and never logged at all
+    /// on the other 100 was measured against those 100 as though the user had answered No. Reported by a
+    /// user on Reddit, in those terms: "if I didn't track something for 100 days, NOOP takes that as a
+    /// NO for 100 days, whereas it simply was not logged at all."
+    ///
+    /// The journal already distinguishes the three states — a No writes a row with `answeredYes = false`,
+    /// and only Clear deletes the row — so nothing but this split was conflating them.
+    ///
+    /// Expect FEWER findings, not better-looking ones. Unlogged days inflated nWithout, which shrinks the
+    /// Welch p and helps clear the min(nWith, nWithout) gate; dropping them removes confidence that was
+    /// never earned. A behaviour with no No days now yields nothing, which is the honest answer: with no
+    /// controls there is no comparison to make.
     ///
     /// Returns nil unless BOTH groups are non-empty AND the total is large enough
     /// to form a variance estimate (at least 1 value per side and ≥ 3 total).
     public static func effect(behaviorDays: Set<String>,
+                              controlDays: Set<String>,
                               outcomeByDay: [String: Double],
                               behavior: String,
                               outcome: String) -> BehaviorEffect? {
@@ -91,7 +105,8 @@ public enum BehaviorInsights {
         var withoutVals: [Double] = []
         for (day, value) in outcomeByDay {
             if behaviorDays.contains(day) { withVals.append(value) }
-            else { withoutVals.append(value) }
+            else if controlDays.contains(day) { withoutVals.append(value) }
+            // Neither: the behaviour was not logged that day. Not a control — no information.
         }
 
         let n1 = withVals.count
@@ -125,11 +140,16 @@ public enum BehaviorInsights {
     /// return them sorted by |cohensD| descending, with significant effects first.
     /// Behaviors that don't yield a computable effect are dropped.
     public static func rank(behaviors: [String: Set<String>],
+                            controls: [String: Set<String>],
                             outcomeByDay: [String: Double],
                             outcome: String) -> [BehaviorEffect] {
         var effects: [BehaviorEffect] = []
         for (name, days) in behaviors {
-            if let e = effect(behaviorDays: days, outcomeByDay: outcomeByDay,
+            // A behaviour absent from `controls` has no controls and yields nothing — failing CLOSED, so
+            // a caller that forgets loses the insight rather than getting a wrong one measured against
+            // every day the user never opened the journal.
+            if let e = effect(behaviorDays: days, controlDays: controls[name] ?? [],
+                              outcomeByDay: outcomeByDay,
                               behavior: name, outcome: outcome) {
                 effects.append(e)
             }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/EffectRanker.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/EffectRanker.swift
@@ -104,13 +104,18 @@ public enum EffectRanker {
     ///   significant-first, |cohensD| desc, then behaviour name asc. Behaviours with no
     ///   computable lag are dropped.
     public static func rank(behaviors: [String: Set<String>],
+                            controls: [String: Set<String>],
                             outcomeByDay: [String: Double],
                             outcome: String) -> [RankedEffect] {
         var rows: [RankedEffect] = []
         // Sort behaviour names so the build order is deterministic regardless of dict order.
         for name in behaviors.keys.sorted() {
             let days = behaviors[name]!
-            if let row = bestLag(behaviorDays: days, outcomeByDay: outcomeByDay,
+            // Absent from `controls` means no control group, which yields nothing — see
+            // BehaviorInsights.effect. Failing closed is deliberate: a caller that forgets loses the
+            // insight rather than getting one measured against every unlogged day.
+            if let row = bestLag(behaviorDays: days, controlDays: controls[name] ?? [],
+                                 outcomeByDay: outcomeByDay,
                                  behavior: name, outcome: outcome) {
                 rows.append(row)
             }
@@ -121,6 +126,7 @@ public enum EffectRanker {
     /// Find the best-lag RankedEffect for ONE behaviour against ONE outcome, or nil when no
     /// lag in `lagSet` yields a computable effect that clears the group gate.
     public static func bestLag(behaviorDays: Set<String>,
+                               controlDays: Set<String>,
                                outcomeByDay: [String: Double],
                                behavior: String,
                                outcome: String) -> RankedEffect? {
@@ -128,6 +134,7 @@ public enum EffectRanker {
         for lag in lagSet {
             let shifted = shiftedOutcome(outcomeByDay, byLag: lag)
             guard let e = BehaviorInsights.effect(behaviorDays: behaviorDays,
+                                                  controlDays: controlDays,
                                                   outcomeByDay: shifted,
                                                   behavior: behavior,
                                                   outcome: outcome) else { continue }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BehaviorInsightsTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BehaviorInsightsTests.swift
@@ -14,7 +14,7 @@ final class BehaviorInsightsTests: XCTestCase {
             "d13": 70, "d14": 68,
         ]
         let behaviorDays: Set<String> = ["d01", "d02", "d03", "d04", "d05", "d06"]
-        let e = BehaviorInsights.effect(behaviorDays: behaviorDays, outcomeByDay: outcome,
+        let e = BehaviorInsights.effect(behaviorDays: behaviorDays, controlDays: Set(outcome.keys).subtracting(behaviorDays), outcomeByDay: outcome,
                                         behavior: "Alcohol", outcome: "Recovery")!
         XCTAssertEqual(e.nWith, 6)
         XCTAssertEqual(e.nWithout, 8)
@@ -34,6 +34,7 @@ final class BehaviorInsightsTests: XCTestCase {
             "f": 70, "g": 72, "h": 68, "i": 71, "j": 69,   // without (mean 70)
         ]
         let e = BehaviorInsights.effect(behaviorDays: ["a", "b", "c", "d", "e"],
+                                        controlDays: Set(outcome.keys).subtracting(["a", "b", "c", "d", "e"]),
                                         outcomeByDay: outcome,
                                         behavior: "Meditation", outcome: "Recovery")!
         XCTAssertEqual(e.delta, 10.0, accuracy: 1e-9)
@@ -46,10 +47,12 @@ final class BehaviorInsightsTests: XCTestCase {
         // Behavior logged every day → no "without" group.
         let outcome: [String: Double] = ["a": 60, "b": 61, "c": 62]
         XCTAssertNil(BehaviorInsights.effect(behaviorDays: ["a", "b", "c"],
+                                             controlDays: Set(outcome.keys).subtracting(["a", "b", "c"]),
                                              outcomeByDay: outcome,
                                              behavior: "X", outcome: "Recovery"))
         // Behavior never logged → no "with" group.
         XCTAssertNil(BehaviorInsights.effect(behaviorDays: [],
+                                             controlDays: Set(outcome.keys).subtracting([]),
                                              outcomeByDay: outcome,
                                              behavior: "X", outcome: "Recovery"))
     }
@@ -58,6 +61,7 @@ final class BehaviorInsightsTests: XCTestCase {
         // "z" is in behaviorDays but has no outcome value → not counted in nWith.
         let outcome: [String: Double] = ["a": 60, "b": 62, "c": 70, "d": 72]
         let e = BehaviorInsights.effect(behaviorDays: ["a", "b", "z"],
+                                        controlDays: Set(outcome.keys).subtracting(["a", "b", "z"]),
                                         outcomeByDay: outcome,
                                         behavior: "X", outcome: "Recovery")!
         XCTAssertEqual(e.nWith, 2)        // a, b only
@@ -74,6 +78,7 @@ final class BehaviorInsightsTests: XCTestCase {
             "o1": 70, "o2": 71, "o3": 69, "o4": 70,
         ]
         let small = BehaviorInsights.effect(behaviorDays: ["w1", "w2", "w3", "w4"],
+                                            controlDays: Set(smallOutcome.keys).subtracting(["w1", "w2", "w3", "w4"]),
                                             outcomeByDay: smallOutcome,
                                             behavior: "X", outcome: "Recovery")!
         XCTAssertLessThan(small.pApprox, 0.05)       // strong evidence numerically…
@@ -86,6 +91,7 @@ final class BehaviorInsightsTests: XCTestCase {
             "o1": 70, "o2": 71, "o3": 69, "o4": 70, "o5": 70,
         ]
         let big = BehaviorInsights.effect(behaviorDays: ["w1", "w2", "w3", "w4", "w5"],
+                                          controlDays: Set(bigOutcome.keys).subtracting(["w1", "w2", "w3", "w4", "w5"]),
                                           outcomeByDay: bigOutcome,
                                           behavior: "X", outcome: "Recovery")!
         XCTAssertEqual(Swift.min(big.nWith, big.nWithout), 5)
@@ -99,6 +105,7 @@ final class BehaviorInsightsTests: XCTestCase {
             "o1": 64, "o2": 72, "o3": 61, "o4": 74, "o5": 67, "o6": 69,
         ]
         let e = BehaviorInsights.effect(behaviorDays: ["w1", "w2", "w3", "w4", "w5", "w6"],
+                                        controlDays: Set(outcome.keys).subtracting(["w1", "w2", "w3", "w4", "w5", "w6"]),
                                         outcomeByDay: outcome,
                                         behavior: "X", outcome: "Recovery")!
         XCTAssertGreaterThan(e.pApprox, 0.05)    // no separation → weak evidence
@@ -120,7 +127,13 @@ final class BehaviorInsightsTests: XCTestCase {
         // Tiny-but-significant-impossible: 2 days only.
         let tiny: Set<String> = ["d3", "d9"]
 
+        // Predates the Yes/No split and tests the ranking math, so it keeps its original partition
+        // by declaring the complement as controls explicitly.
+        let all = Set(outcome.keys)
         let ranked = BehaviorInsights.rank(behaviors: ["Strong": strong, "Weak": weak, "Tiny": tiny],
+                                           controls: ["Strong": all.subtracting(strong),
+                                                      "Weak": all.subtracting(weak),
+                                                      "Tiny": all.subtracting(tiny)],
                                            outcomeByDay: outcome, outcome: "Recovery")
         XCTAssertEqual(ranked.count, 3)
         XCTAssertEqual(ranked.first?.behavior, "Strong")   // significant + largest |d|
@@ -135,9 +148,15 @@ final class BehaviorInsightsTests: XCTestCase {
     func testRankDropsUncomputableBehaviors() {
         let outcome: [String: Double] = ["a": 60, "b": 62, "c": 70, "d": 72]
         // "AllDays" covers every day → no without group → dropped.
+        // Predates the Yes/No split and tests the ranking math, so it keeps its original partition
+        // by declaring the complement as controls explicitly.
+        let all = Set(outcome.keys)
         let ranked = BehaviorInsights.rank(behaviors: [
             "AllDays": ["a", "b", "c", "d"],
             "Half": ["a", "b"],
+        ], controls: [
+            "AllDays": all.subtracting(["a", "b", "c", "d"]),
+            "Half": all.subtracting(["a", "b"]),
         ], outcomeByDay: outcome, outcome: "Recovery")
         XCTAssertEqual(ranked.count, 1)
         XCTAssertEqual(ranked.first?.behavior, "Half")
@@ -153,6 +172,7 @@ final class BehaviorInsightsTests: XCTestCase {
             "o1": 78, "o2": 82, "o3": 80, "o4": 79, "o5": 81,   // mean 80
         ]
         let e = BehaviorInsights.effect(behaviorDays: ["w1", "w2", "w3", "w4", "w5"],
+                                        controlDays: Set(outcome.keys).subtracting(["w1", "w2", "w3", "w4", "w5"]),
                                         outcomeByDay: outcome,
                                         behavior: "Alcohol", outcome: "Recovery")!
         let s = BehaviorInsights.sentence(e)
@@ -165,6 +185,7 @@ final class BehaviorInsightsTests: XCTestCase {
             "o1": 49, "o2": 51, "o3": 50,    // mean 50
         ]
         let e = BehaviorInsights.effect(behaviorDays: ["w1", "w2", "w3"],
+                                        controlDays: Set(outcome.keys).subtracting(["w1", "w2", "w3"]),
                                         outcomeByDay: outcome,
                                         behavior: "Meditation", outcome: "Recovery")!
         let s = BehaviorInsights.sentence(e)
@@ -179,10 +200,62 @@ final class BehaviorInsightsTests: XCTestCase {
             "o1": 0, "o2": 0, "o3": 0,
         ]
         let e = BehaviorInsights.effect(behaviorDays: ["w1", "w2", "w3"],
+                                        controlDays: Set(outcome.keys).subtracting(["w1", "w2", "w3"]),
                                         outcomeByDay: outcome,
                                         behavior: "X", outcome: "HRV")!
         XCTAssertNil(e.pctChange)
         let s = BehaviorInsights.sentence(e)
         XCTAssertEqual(s, "On days you logged ‘X’, HRV was 5.0 higher (avg 5 vs 0, n=3 vs 3).")
     }
+    // MARK: - Unlogged days are not answers (the Reddit report)
+
+    /// "If I didn't track something for 100 days, NOOP takes that as a NO for 100 days, whereas it simply
+    /// was not logged at all." Reported by a user on Reddit, and it was exactly what the split did.
+    ///
+    /// Twin of Kotlin `EffectRankerTest.daysWithNoJournalRowAreNotControls`.
+    func testDaysWithNoJournalRowAreNotControls() {
+        var outcome: [String: Double] = [:]
+        var yes: Set<String> = []
+        var no: Set<String> = []
+        for d in 1...6 { let k = "y\(d)"; yes.insert(k); outcome[k] = Double(58 + d) }
+        for d in 1...6 { let k = "n\(d)"; no.insert(k); outcome[k] = Double(68 + d) }
+        // Never opened the journal on these, and their values sit far from BOTH answered groups.
+        for d in 1...40 { outcome["u\(d)"] = Double(20 + (d % 3)) }
+
+        let e = BehaviorInsights.effect(behaviorDays: yes, controlDays: no,
+                                        outcomeByDay: outcome,
+                                        behavior: "Alcohol", outcome: "Recovery")!
+        // Controls are the six NO days only. Were the 40 unlogged days leaking in, nWithout would be 46
+        // and meanWithout would be dragged towards 20.
+        XCTAssertEqual(e.nWith, 6)
+        XCTAssertEqual(e.nWithout, 6)
+        XCTAssertGreaterThan(e.meanWithout, 60.0)
+    }
+
+    /// A behaviour the user only ever ticks Yes has no control group, so there is no comparison to make
+    /// and the honest answer is none. Twin of Kotlin `aBehaviourNeverLoggedNoYieldsNothing`.
+    func testBehaviourNeverLoggedNoYieldsNothing() {
+        var outcome: [String: Double] = [:]
+        var yes: Set<String> = []
+        for d in 1...10 { let k = "y\(d)"; yes.insert(k); outcome[k] = Double(50 + d) }
+        for d in 1...10 { outcome["u\(d)"] = Double(80 + d) }
+
+        XCTAssertNil(BehaviorInsights.effect(behaviorDays: yes, controlDays: [],
+                                             outcomeByDay: outcome,
+                                             behavior: "Alcohol", outcome: "Recovery"))
+    }
+
+    /// rank() fails CLOSED on a caller that forgets the controls: no insight, rather than a wrong one
+    /// measured against every day the user never opened the journal. Twin of Kotlin
+    /// `rankWithoutControlsProducesNothingRatherThanGuessing`.
+    func testRankWithoutControlsProducesNothingRatherThanGuessing() {
+        var outcome: [String: Double] = [:]
+        var yes: Set<String> = []
+        for d in 1...10 { let k = "y\(d)"; yes.insert(k); outcome[k] = Double(50 + d) }
+        for d in 1...20 { outcome["u\(d)"] = Double(75 + (d % 4)) }
+
+        XCTAssertTrue(BehaviorInsights.rank(behaviors: ["Alcohol": yes], controls: [:],
+                                            outcomeByDay: outcome, outcome: "Recovery").isEmpty)
+    }
+
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/EffectRankerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/EffectRankerTests.swift
@@ -38,6 +38,7 @@ final class EffectRankerTests: XCTestCase {
         }
 
         let out = EffectRanker.rank(behaviors: ["Alcohol": behaviorDays],
+                                    controls: ["Alcohol": Set(outcome.keys).subtracting(behaviorDays)],
                                     outcomeByDay: outcome, outcome: "Charge")
         let r = row(out, "Alcohol")
         XCTAssertNotNil(r)
@@ -62,7 +63,7 @@ final class EffectRankerTests: XCTestCase {
     private func effectAtLag(_ behaviorDays: Set<String>, _ outcome: [String: Double],
                              _ lag: Int) -> BehaviorEffect? {
         let shifted = EffectRanker.shiftedOutcome(outcome, byLag: lag)
-        return BehaviorInsights.effect(behaviorDays: behaviorDays, outcomeByDay: shifted,
+        return BehaviorInsights.effect(behaviorDays: behaviorDays, controlDays: Set(shifted.keys).subtracting(behaviorDays), outcomeByDay: shifted,
                                        behavior: "Alcohol", outcome: "Charge")
     }
 
@@ -82,6 +83,7 @@ final class EffectRankerTests: XCTestCase {
         for d in 1...8 { outcome[ymd(2026, 7, d)] = 70 + jitter(d) }   // plenty of "without"
 
         let out = EffectRanker.rank(behaviors: ["Sparse": thin],
+                                    controls: ["Sparse": Set(outcome.keys).subtracting(thin)],
                                     outcomeByDay: outcome, outcome: "Charge")
         XCTAssertTrue(out.isEmpty)
     }
@@ -110,6 +112,8 @@ final class EffectRankerTests: XCTestCase {
         for d in 10...20 { outcome[ymd(2026, 5, d)] = 70 + jitter(d) }
 
         let out = EffectRanker.rank(behaviors: ["Big": big, "Small": small],
+                                    controls: ["Big": Set(outcome.keys).subtracting(big),
+                                               "Small": Set(outcome.keys).subtracting(small)],
                                     outcomeByDay: outcome, outcome: "Charge")
         XCTAssertEqual(out.map { $0.behavior }, ["Big", "Small"])   // |d| Big > Small
         XCTAssertEqual(row(out, "Big")!.lag, 0)                     // both are same-day effects

--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -611,13 +611,20 @@ final class AICoachEngine: ObservableObject {
 
         // 1. Strongest behaviour→outcome associations (EffectRanker over the journal × Charge).
         let entries = await repo.journalEntries()
+        // Yes days and NO days, kept apart. A day with no journal row for the question lands in
+        // neither, so an unanswered day is never counted as a No (BehaviorInsights.effect).
         var byBehaviour: [String: Set<String>] = [:]
-        for e in entries where e.answeredYes { byBehaviour[e.question, default: []].insert(e.day) }
+        var controls: [String: Set<String>] = [:]
+        for e in entries {
+            if e.answeredYes { byBehaviour[e.question, default: []].insert(e.day) }
+            else { controls[e.question, default: []].insert(e.day) }
+        }
         if !byBehaviour.isEmpty {
             let outcomeByDay = Dictionary(
                 repo.days.compactMap { d in d.recovery.map { (d.day, $0) } },
                 uniquingKeysWith: { _, last in last })
-            let ranked = EffectRanker.rank(behaviors: byBehaviour, outcomeByDay: outcomeByDay, outcome: "Charge")
+            let ranked = EffectRanker.rank(behaviors: byBehaviour, controls: controls,
+                                           outcomeByDay: outcomeByDay, outcome: "Charge")
                 .filter { $0.effect.significant }
                 .prefix(3)
             if !ranked.isEmpty {

--- a/Strand/Screens/InsightsHubView.swift
+++ b/Strand/Screens/InsightsHubView.swift
@@ -546,6 +546,8 @@ final class InsightsHubViewModel: ObservableObject {
     // MARK: Loaded inputs (kept so the outcome segmented control can re-rank cheaply)
 
     private var behaviours: [String: Set<String>] = [:]
+    /// Per behaviour, the days it was logged NO — the only legitimate control group.
+    private var controls: [String: Set<String>] = [:]
     private var outcomeByKey: [String: [String: Double]] = [:]
     private var currentOutcome: Outcome = .recovery
 
@@ -559,9 +561,13 @@ final class InsightsHubViewModel: ObservableObject {
     func load(repo: Repository) async {
         // Journal → behaviour → days (only "yes" answers count as the behaviour occurring).
         let entries = await repo.journalEntries()
+        // Yes days and NO days, kept apart. A day with no journal row for the question lands in
+        // neither, so an unanswered day is never counted as a No (BehaviorInsights.effect).
         var byBehaviour: [String: Set<String>] = [:]
-        for e in entries where e.answeredYes {
-            byBehaviour[e.question, default: []].insert(e.day)
+        var controlsByBehaviour: [String: Set<String>] = [:]
+        for e in entries {
+            if e.answeredYes { byBehaviour[e.question, default: []].insert(e.day) }
+            else { controlsByBehaviour[e.question, default: []].insert(e.day) }
         }
 
         // Outcome series: imported metricSeries ∪ the DailyMetric column fallback so an
@@ -611,6 +617,7 @@ final class InsightsHubViewModel: ObservableObject {
         }
 
         self.behaviours = byBehaviour
+        self.controls = controlsByBehaviour
         self.outcomeByKey = byKey
         self.doseCards = cards
         self.loaded = true
@@ -622,6 +629,7 @@ final class InsightsHubViewModel: ObservableObject {
         currentOutcome = outcome
         let outcomeDays = outcomeByKey[outcome.key] ?? [:]
         ranked = EffectRanker.rank(behaviors: behaviours,
+                                   controls: controls,
                                    outcomeByDay: outcomeDays,
                                    outcome: outcome.outcomeName)
     }

--- a/Strand/Screens/InsightsView.swift
+++ b/Strand/Screens/InsightsView.swift
@@ -40,6 +40,9 @@ private struct InsightsLoadKey: Equatable {
 /// the seq AND the dayKey still match (see `Repository.insightsLoadedSeq` / `insightsLoadedDayKey`).
 struct InsightsLoadCache {
     let behaviours: [String: Set<String>]
+    /// Per behaviour, the days it was logged NO. Cached alongside `behaviours` because a restore that
+    /// dropped it would leave the ranker with no controls and silently produce no insights at all.
+    let controls: [String: Set<String>]
     let importedQuestions: [String]
     let dayAnswers: [String: Bool]
     /// The journal day offset the `dayAnswers` were read for (0 = today, 1 = yesterday, -1 = tomorrow). The
@@ -152,6 +155,8 @@ struct InsightsView: View {
 
     /// behaviour question → set of days where it was answered yes.
     @State private var behaviours: [String: Set<String>] = [:]
+    /// Per behaviour, the days it was logged NO — the only legitimate control group.
+    @State private var controls: [String: Set<String>] = [:]
     /// outcome key → [day: value].
     @State private var outcomeByKey: [String: [String: Double]] = [:]
     /// outcome key → ordered (day, value) series for correlations.
@@ -351,10 +356,14 @@ struct InsightsView: View {
         // log writes answeredYes=true too (#322), so a numeric item lands in the with/without split
         // here unchanged, on top of the numeric series read below.
         let entries = await repo.journalEntries()
+        // Yes days and NO days, kept apart. A day with no journal row for the question lands in
+        // neither, so an unanswered day is never counted as a No (BehaviorInsights.effect).
         var byBehaviour: [String: Set<String>] = [:]
+        var controlsByBehaviour: [String: Set<String>] = [:]
         var numericByBehaviour: [String: [String: Double]] = [:]
-        for e in entries where e.answeredYes {
-            byBehaviour[e.question, default: []].insert(e.day)
+        for e in entries {
+            if e.answeredYes { byBehaviour[e.question, default: []].insert(e.day) }
+            else { controlsByBehaviour[e.question, default: []].insert(e.day) }
         }
         // #322: per-question numeric series (question → [day: value]) for numeric journal items. A
         // numeric series is the same [day: value] shape a metric outcome is, so the effect ranker can
@@ -415,6 +424,7 @@ struct InsightsView: View {
 
         await MainActor.run {
             self.behaviours = byBehaviour
+            self.controls = controlsByBehaviour
             self.importedQuestions = importedQs
             self.dayAnswers = nativeAnswers
             self.dayNumeric = nativeNumeric
@@ -432,6 +442,7 @@ struct InsightsView: View {
             // freshest read, a subsequent re-mount never restores stale data behind a journal toggle.
             self.repo.insightsCache = InsightsLoadCache(
                 behaviours: byBehaviour,
+                controls: controlsByBehaviour,
                 importedQuestions: importedQs,
                 dayAnswers: nativeAnswers,
                 journalDayOffset: self.journalDayOffset,
@@ -450,6 +461,7 @@ struct InsightsView: View {
     @MainActor
     private func restoreFromCache(_ c: InsightsLoadCache) {
         behaviours = c.behaviours
+        controls = c.controls
         importedQuestions = c.importedQuestions
         dayAnswers = c.dayAnswers
         // Numeric journal rows are native-only (imported WHOOP rows never carry a numericValue), so the
@@ -516,6 +528,7 @@ struct InsightsView: View {
         let outcomeDays = outcomeByKey[outcome.key] ?? [:]
         ranked = BehaviorInsights.rank(
             behaviors: behaviours,
+            controls: controls,
             outcomeByDay: outcomeDays,
             outcome: outcome.outcomeName
         )

--- a/android/app/src/main/java/com/noop/ai/AiCoach.kt
+++ b/android/app/src/main/java/com/noop/ai/AiCoach.kt
@@ -308,11 +308,12 @@ class AiCoach(
         val sb = StringBuilder()
 
         // --- Strongest associations on the user's own logged days (recovery as the outcome) ---
-        val behaviours = runCatching { journalBehaviours() }.getOrDefault(emptyMap())
+        val (behaviours, controls) = runCatching { journalBehaviours() }
+            .getOrDefault(emptyMap<String, Set<String>>() to emptyMap())
         val days = runCatching { repo.daysMerged(activeStrapId()) }.getOrDefault(emptyList())
         if (behaviours.isNotEmpty() && days.isNotEmpty()) {
             val recoveryByDay = days.mapNotNull { d -> d.recovery?.let { d.day to it } }.toMap()
-            val ranked = runCatching { EffectRanker.rank(behaviours, recoveryByDay, "Charge") }
+            val ranked = runCatching { EffectRanker.rank(behaviours, controls, recoveryByDay, "Charge") }
                 .getOrDefault(emptyList())
                 .take(3)
             if (ranked.isNotEmpty()) {
@@ -341,16 +342,22 @@ class AiCoach(
         return sb.toString().trim().takeIf { it.isNotEmpty() }
     }
 
-    /** Behaviour → set of "yyyy-MM-dd" days it was logged "yes" (imported ∪ native), for EffectRanker. */
-    private suspend fun journalBehaviours(): Map<String, Set<String>> {
+    /** Behaviour → the days it was logged YES and the days it was logged NO (imported ∪ native), for
+     *  EffectRanker. Kept apart: a day with no journal row for a question belongs to neither, so an
+     *  unanswered day is never counted as a No — see [EffectRanker.effect]. */
+    private suspend fun journalBehaviours(): Pair<Map<String, Set<String>>, Map<String, Set<String>>> {
         val imported = repo.journal(deviceId, "0000-01-01", "9999-12-31")
         val native = repo.journal(journalDeviceId, "0000-01-01", "9999-12-31")
         val byKey = LinkedHashMap<Pair<String, String>, JournalEntry>()
         for (e in imported) byKey[e.day to e.question] = e
         for (e in native) byKey[e.day to e.question] = e   // native wins on a collision
-        val out = HashMap<String, MutableSet<String>>()
-        for (e in byKey.values) if (e.answeredYes) out.getOrPut(e.question) { mutableSetOf() }.add(e.day)
-        return out.mapValues { it.value.toSet() }
+        val yes = HashMap<String, MutableSet<String>>()
+        val no = HashMap<String, MutableSet<String>>()
+        for (e in byKey.values) {
+            val bucket = if (e.answeredYes) yes else no
+            bucket.getOrPut(e.question) { mutableSetOf() }.add(e.day)
+        }
+        return yes.mapValues { it.value.toSet() } to no.mapValues { it.value.toSet() }
     }
 
     /** The latest reading per Lab Book marker key (stored under the ACTIVE strap deviceId). #1304/#512:

--- a/android/app/src/main/java/com/noop/analytics/EffectRanker.kt
+++ b/android/app/src/main/java/com/noop/analytics/EffectRanker.kt
@@ -136,6 +136,38 @@ object EffectRanker {
         return sorted(rows)
     }
 
+    /**
+     * Rank every behaviour against one outcome at lag 0 only — the Kotlin twin of Swift's
+     * `BehaviorInsights.rank`, ordering included.
+     *
+     * Exists because the Insights screen ranks at lag 0 while the Insights Hub searches the lag set, and
+     * Android had been doing the lag-0 version with its OWN copy of the math: a "crude significance"
+     * (|d| ≥ 0.5 with ≥ 3 a side, self-described as a stand-in for a t-test) against iOS's Welch p on the
+     * same screen. Two platforms flagged different behaviours as significant from identical journals.
+     * Routing it here retires that copy; the parity contract wants one implementation, not two that agree
+     * on a good day.
+     *
+     * Sort mirrors Swift exactly: significant first, then larger |Cohen's d|, then behaviour name — the
+     * last one so a dictionary-ordered walk still produces a stable list.
+     */
+    fun rankNoLag(
+        behaviors: Map<String, Set<String>>,
+        controls: Map<String, Set<String>>,
+        outcomeByDay: Map<String, Double>,
+        outcome: String,
+    ): List<BehaviorEffect> {
+        val effects = ArrayList<BehaviorEffect>()
+        for ((name, days) in behaviors) {
+            val e = effect(days, controls[name].orEmpty(), outcomeByDay, name, outcome)
+            if (e != null) effects.add(e)
+        }
+        return effects.sortedWith(
+            compareByDescending<BehaviorEffect> { it.significant }
+                .thenByDescending { abs(it.cohensD) }
+                .thenBy { it.behavior },
+        )
+    }
+
     /** Find the best-lag RankedEffect for ONE behaviour against ONE outcome, or null. */
     fun bestLag(
         behaviorDays: Set<String>,

--- a/android/app/src/main/java/com/noop/analytics/EffectRanker.kt
+++ b/android/app/src/main/java/com/noop/analytics/EffectRanker.kt
@@ -113,19 +113,24 @@ object EffectRanker {
      * Rank every behaviour against one outcome across the lag set, keeping each behaviour's
      * best lag. Mirrors Swift's ordering on the surviving rows.
      *
-     * @param behaviors per behaviour name, the SET of "yyyy-MM-dd" days it was logged (dose ≥ 1).
+     * @param behaviors per behaviour name, the SET of "yyyy-MM-dd" days it was logged YES (dose ≥ 1).
+     * @param controls per behaviour name, the days it was logged NO. Required, and separate from
+     *   [behaviors] on purpose: a behaviour missing from this map has no controls and yields nothing,
+     *   which fails CLOSED. A caller that forgets it loses the insight rather than getting a wrong one
+     *   measured against every day the user never opened the journal.
      * @param outcomeByDay the daily outcome series keyed "yyyy-MM-dd".
      * @param outcome the outcome label carried onto each RankedEffect.
      */
     fun rank(
         behaviors: Map<String, Set<String>>,
+        controls: Map<String, Set<String>>,
         outcomeByDay: Map<String, Double>,
         outcome: String,
     ): List<RankedEffect> {
         val rows = ArrayList<RankedEffect>()
         for (name in behaviors.keys.sorted()) {
             val days = behaviors.getValue(name)
-            val r = bestLag(days, outcomeByDay, name, outcome)
+            val r = bestLag(days, controls[name].orEmpty(), outcomeByDay, name, outcome)
             if (r != null) rows.add(r)
         }
         return sorted(rows)
@@ -134,6 +139,7 @@ object EffectRanker {
     /** Find the best-lag RankedEffect for ONE behaviour against ONE outcome, or null. */
     fun bestLag(
         behaviorDays: Set<String>,
+        controlDays: Set<String>,
         outcomeByDay: Map<String, Double>,
         behavior: String,
         outcome: String,
@@ -142,7 +148,7 @@ object EffectRanker {
         var bestEffect: BehaviorEffect? = null
         for (lag in lagSet) {
             val shifted = shiftedOutcome(outcomeByDay, lag)
-            val e = effect(behaviorDays, shifted, behavior, outcome) ?: continue
+            val e = effect(behaviorDays, controlDays, shifted, behavior, outcome) ?: continue
             if (minOf(e.nWith, e.nWithout) < minGroupForSignificance) continue
 
             val cur = bestEffect
@@ -182,12 +188,28 @@ object EffectRanker {
     // Effect (byte-identical port of Swift BehaviorInsights.effect + helpers).
 
     /**
-     * Compute the effect of [behavior] on [outcome]. Days are partitioned into "with"
-     * (day ∈ behaviorDays) and "without", restricted to days with an outcome value. Returns
-     * null unless both groups are non-empty AND there are ≥ 3 points total.
+     * Compute the effect of [behavior] on [outcome]. "With" is day ∈ [behaviorDays]; "without" is
+     * day ∈ [controlDays]. Days in NEITHER are dropped, and that is the point of the second set.
+     *
+     * The split used to be `if (behaviorDays.contains(day)) with else without`, which made every day
+     * carrying an outcome a control — so a behaviour logged Yes on 20 days and never logged at all on
+     * the other 100 was measured against those 100 as though the user had answered No. Reported by a
+     * user on Reddit, in those terms: "if I didn't track something for 100 days, NOOP takes that as a
+     * NO for 100 days, whereas it simply was not logged at all."
+     *
+     * The journal already distinguishes the three states — a No writes a row with answeredYes = false,
+     * and only Clear deletes the row — so nothing but this split was conflating them.
+     *
+     * Expect FEWER findings, not better-looking ones. Unlogged days inflated nWithout, which shrinks the
+     * Welch p and helps clear the min(nWith, nWithout) gate; dropping them removes confidence that was
+     * never earned. A behaviour with no No days now yields nothing, which is the honest answer: with no
+     * controls there is no comparison to make.
+     *
+     * Returns null unless both groups are non-empty AND there are ≥ 3 points total.
      */
     internal fun effect(
         behaviorDays: Set<String>,
+        controlDays: Set<String>,
         outcomeByDay: Map<String, Double>,
         behavior: String,
         outcome: String,
@@ -195,7 +217,11 @@ object EffectRanker {
         val withVals = ArrayList<Double>()
         val withoutVals = ArrayList<Double>()
         for ((day, value) in outcomeByDay) {
-            if (behaviorDays.contains(day)) withVals.add(value) else withoutVals.add(value)
+            when {
+                behaviorDays.contains(day) -> withVals.add(value)
+                controlDays.contains(day) -> withoutVals.add(value)
+                // Neither: the behaviour was not logged that day. Not a control — no information.
+            }
         }
 
         val n1 = withVals.size

--- a/android/app/src/main/java/com/noop/analytics/EffectRanker.kt
+++ b/android/app/src/main/java/com/noop/analytics/EffectRanker.kt
@@ -221,6 +221,8 @@ object EffectRanker {
                 behaviorDays.contains(day) -> withVals.add(value)
                 controlDays.contains(day) -> withoutVals.add(value)
                 // Neither: the behaviour was not logged that day. Not a control — no information.
+                // A day in BOTH would count as "with"; callers merge imported ∪ native before building
+                // these, so one question cannot hold two answers for one day.
             }
         }
 

--- a/android/app/src/main/java/com/noop/ui/InsightsHubScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/InsightsHubScreen.kt
@@ -579,7 +579,8 @@ internal class InsightsHubViewModel {
     }
 
     suspend fun load(vm: AppViewModel, days: List<DailyMetric>) {
-        // Journal → behaviour → days (imported ∪ native, native wins; only "yes" counts).
+        // Journal → behaviour → days (imported ∪ native, native wins). BOTH answers count now, kept in
+        // separate maps; the merge is what guarantees a day cannot be Yes and No for one question.
         val imported = vm.repo.journal("my-whoop", "0000-01-01", "9999-12-31")
         val native = vm.repo.journal(JOURNAL_DEVICE_ID, "0000-01-01", "9999-12-31")
         val entries = mergeJournalEntries(imported, native)

--- a/android/app/src/main/java/com/noop/ui/InsightsHubScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/InsightsHubScreen.kt
@@ -546,6 +546,8 @@ internal class InsightsHubViewModel {
     data class Snapshot(
         val loaded: Boolean = false,
         val behaviours: Map<String, Set<String>> = emptyMap(),
+        /** Per behaviour, the days it was logged NO — the only legitimate control group. */
+        val controls: Map<String, Set<String>> = emptyMap(),
         val outcomeByKey: Map<String, Map<String, Double>> = emptyMap(),
         val doseCards: List<DoseCardData> = emptyList(),
     )
@@ -582,8 +584,15 @@ internal class InsightsHubViewModel {
         val native = vm.repo.journal(JOURNAL_DEVICE_ID, "0000-01-01", "9999-12-31")
         val entries = mergeJournalEntries(imported, native)
         val byBehaviour = HashMap<String, MutableSet<String>>()
-        for (e in entries) if (e.answeredYes) byBehaviour.getOrPut(e.question) { mutableSetOf() }.add(e.day)
+        val controlsByBehaviour = HashMap<String, MutableSet<String>>()
+        // Yes days and NO days, kept apart. A day with no journal row for the question appears in
+        // neither, so the ranker cannot mistake "never logged" for "logged No" (#EffectRanker.effect).
+        for (e in entries) {
+            val bucket = if (e.answeredYes) byBehaviour else controlsByBehaviour
+            bucket.getOrPut(e.question) { mutableSetOf() }.add(e.day)
+        }
         val behaviours = byBehaviour.mapValues { it.value.toSet() }
+        val controls = controlsByBehaviour.mapValues { it.value.toSet() }
 
         // Outcome series straight off the cached DailyMetric rows (the guaranteed Android source).
         val outcomeByKey = HashMap<String, Map<String, Double>>()
@@ -615,6 +624,7 @@ internal class InsightsHubViewModel {
         _state.value = Snapshot(
             loaded = true,
             behaviours = behaviours,
+            controls = controls,
             outcomeByKey = outcomeByKey,
             doseCards = doseCards,
         )
@@ -624,7 +634,7 @@ internal class InsightsHubViewModel {
     fun rankFor(snapshot: Snapshot, outcome: InsightsOutcome): List<RankedEffect> {
         if (!snapshot.loaded) return emptyList()
         val outcomeDays = snapshot.outcomeByKey[outcome.key] ?: emptyMap()
-        return EffectRanker.rank(snapshot.behaviours, outcomeDays, outcome.outcomeName)
+        return EffectRanker.rank(snapshot.behaviours, snapshot.controls, outcomeDays, outcome.outcomeName)
     }
 }
 

--- a/android/app/src/main/java/com/noop/ui/InsightsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/InsightsScreen.kt
@@ -153,6 +153,9 @@ private data class Relationship(
 private data class InsightModel(
     /** behaviour question → set of days it was answered "yes". */
     val behaviours: Map<String, Set<String>>,
+    /** Per behaviour, the days it was logged NO — the only legitimate control group. A day with no
+     *  journal row for the question is in neither map and takes part in no comparison. */
+    val controls: Map<String, Set<String>>,
     /** day → value, per outcome. */
     val outcomeByDay: Map<Outcome, Map<String, Double>>,
     /** ordered (day, value) per outcome for correlations. */
@@ -184,6 +187,7 @@ fun InsightsScreen(vm: AppViewModel, onOpenInsightsHub: () -> Unit = {}) {
     // rows (native wins per (day, question)). Keyed on journalSeq so the logging card's saves and
     // clears refresh the effects immediately; re-loaded too when the cached days change underneath.
     var behaviours by remember { mutableStateOf<Map<String, Set<String>>>(emptyMap()) }
+    var controls by remember { mutableStateOf<Map<String, Set<String>>>(emptyMap()) }
     // #322: numeric journal item (question) -> [day: value]. A numeric journal series is a daily series
     // the effect ranker consumes exactly like a metric series (EffectRanker.effect already takes a
     // Map<String, Double> outcome), so "caffeine mg" / "alcohol units" can rank as a numeric outcome.
@@ -233,15 +237,18 @@ fun InsightsScreen(vm: AppViewModel, onOpenInsightsHub: () -> Unit = {}) {
         val native = vm.repo.journal(JOURNAL_DEVICE_ID, "0000-01-01", "9999-12-31")
         val entries = mergeJournalEntries(imported, native)
         val byBehaviour = mutableMapOf<String, MutableSet<String>>()
+        val controlsByBehaviour = mutableMapOf<String, MutableSet<String>>()
         // #322: a numeric log writes answeredYes=true too, so a numeric item lands in the with/without
         // split here unchanged; its per-day value is captured separately for a numeric series the effect
         // ranker can consume like any metric outcome (dose-response lands in the v5 hub). Additive.
         val numericByBehaviour = mutableMapOf<String, MutableMap<String, Double>>()
         for (e in entries) {
-            if (e.answeredYes) byBehaviour.getOrPut(e.question) { mutableSetOf() }.add(e.day)
+            val bucket = if (e.answeredYes) byBehaviour else controlsByBehaviour
+            bucket.getOrPut(e.question) { mutableSetOf() }.add(e.day)
             e.numericValue?.let { v -> numericByBehaviour.getOrPut(e.question) { mutableMapOf() }[e.day] = v }
         }
         behaviours = byBehaviour.mapValues { it.value.toSet() }
+        controls = controlsByBehaviour.mapValues { it.value.toSet() }
         numericJournalSeries = numericByBehaviour.mapValues { it.value.toMap() }
         importedQuestions = imported.map { it.question }.distinct()
         val key = journalDayKey(dayOffset)
@@ -290,7 +297,9 @@ fun InsightsScreen(vm: AppViewModel, onOpenInsightsHub: () -> Unit = {}) {
 
     // Build outcome day-maps + ordered series off the cached daily metrics. Cheap and
     // recomputed only when `days` changes (not on every recomposition).
-    val model = remember(days, behaviours, numericJournalSeries) { buildModel(days, behaviours, numericJournalSeries) }
+    val model = remember(days, behaviours, controls, numericJournalSeries) {
+        buildModel(days, behaviours, controls, numericJournalSeries)
+    }
 
     // Ranked behaviour effects for the current outcome (recomputed when outcome/data change).
     val ranked = remember(model, outcome) { rankEffects(model, outcome) }
@@ -1584,6 +1593,7 @@ private fun RBar(r: Double, color: Color) {
 private fun buildModel(
     days: List<DailyMetric>,
     behaviours: Map<String, Set<String>>,
+    controls: Map<String, Set<String>>,
     numericJournalSeries: Map<String, Map<String, Double>> = emptyMap(),
 ): InsightModel {
     val outcomeByDay = mutableMapOf<Outcome, Map<String, Double>>()
@@ -1594,7 +1604,7 @@ private fun buildModel(
         seriesByOutcome[o] = series
         outcomeByDay[o] = series.toMap()
     }
-    return InsightModel(behaviours, outcomeByDay, seriesByOutcome, numericJournalSeries)
+    return InsightModel(behaviours, controls, outcomeByDay, seriesByOutcome, numericJournalSeries)
 }
 
 /** Rank behaviour effects for one outcome by |Cohen's d|, significant first. */
@@ -1603,10 +1613,17 @@ private fun rankEffects(model: InsightModel, outcome: Outcome): List<BehaviorEff
     if (outcomeDays.isEmpty()) return emptyList()
 
     val effects = model.behaviours.mapNotNull { (behaviour, yesDays) ->
+        // Controls are the days answered NO, never the days never answered. This screen carries its own
+        // copy of the with/without split rather than calling EffectRanker, so it needed the same
+        // correction — see [EffectRanker.effect] for why unlogged days are not controls.
+        val noDays = model.controls[behaviour].orEmpty()
         val with = mutableListOf<Double>()
         val without = mutableListOf<Double>()
         for ((day, value) in outcomeDays) {
-            if (day in yesDays) with.add(value) else without.add(value)
+            when {
+                day in yesDays -> with.add(value)
+                day in noDays -> without.add(value)
+            }
         }
         // Need both groups to compare; require ≥2 each so a mean/SD is meaningful.
         if (with.size < 2 || without.size < 2) return@mapNotNull null

--- a/android/app/src/main/java/com/noop/ui/InsightsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/InsightsScreen.kt
@@ -66,8 +66,9 @@ import kotlin.math.sqrt
 // The "interrogate what affects what" screen, ported from the macOS InsightsView.
 // Two halves:
 //
-//  1. BEHAVIOUR EFFECTS, split logged journal answers (the days each behaviour WAS
-//     logged "yes" vs NOT) and compare a chosen outcome metric (Charge / HRV /
+//  1. BEHAVIOUR EFFECTS, split logged journal answers (the days each behaviour was
+//     logged "yes" vs the days it was logged "no" — a day it was not logged at all
+//     is in neither group) and compare a chosen outcome metric (Charge / HRV /
 //     Rest / RHR) between the two groups. Ranked by effect size (Cohen's d), with
 //     significant effects first. Each card carries a plain-English sentence, the
 //     with/without means, group counts, a significance pill, and the magnitude word.

--- a/android/app/src/main/java/com/noop/ui/InsightsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/InsightsScreen.kt
@@ -60,6 +60,8 @@ import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
+import com.noop.analytics.BehaviorEffect
+import com.noop.analytics.EffectRanker
 
 // MARK: - Insights
 //
@@ -124,20 +126,6 @@ private enum class Outcome(
 
 /** One behaviour's effect on the selected outcome: with/without means, counts,
  *  Cohen's d and a crude significance flag. */
-private data class BehaviorEffect(
-    val behavior: String,
-    val meanWith: Double,
-    val meanWithout: Double,
-    val nWith: Int,
-    val nWithout: Int,
-    val cohensD: Double,
-) {
-    val delta: Double get() = meanWith - meanWithout
-    /** Crude significance: a non-trivial effect with enough days on both sides.
-     *  Honest stand-in for a t-test, |d| ≥ 0.5 ("moderate") with ≥3 days each side. */
-    val significant: Boolean get() = abs(cohensD) >= 0.5 && nWith >= 3 && nWithout >= 3
-}
-
 /** A curated metric relationship plus its computed Pearson correlation. */
 private data class Relationship(
     val id: String,
@@ -1612,35 +1600,12 @@ private fun buildModel(
 private fun rankEffects(model: InsightModel, outcome: Outcome): List<BehaviorEffect> {
     val outcomeDays = model.outcomeByDay[outcome] ?: emptyMap()
     if (outcomeDays.isEmpty()) return emptyList()
-
-    val effects = model.behaviours.mapNotNull { (behaviour, yesDays) ->
-        // Controls are the days answered NO, never the days never answered. This screen carries its own
-        // copy of the with/without split rather than calling EffectRanker, so it needed the same
-        // correction — see [EffectRanker.effect] for why unlogged days are not controls.
-        val noDays = model.controls[behaviour].orEmpty()
-        val with = mutableListOf<Double>()
-        val without = mutableListOf<Double>()
-        for ((day, value) in outcomeDays) {
-            when {
-                day in yesDays -> with.add(value)
-                day in noDays -> without.add(value)
-            }
-        }
-        // Need both groups to compare; require ≥2 each so a mean/SD is meaningful.
-        if (with.size < 2 || without.size < 2) return@mapNotNull null
-        BehaviorEffect(
-            behavior = behaviour,
-            meanWith = with.average(),
-            meanWithout = without.average(),
-            nWith = with.size,
-            nWithout = without.size,
-            cohensD = cohensD(with, without),
-        )
-    }
-    return effects.sortedWith(
-        compareByDescending<BehaviorEffect> { it.significant }
-            .thenByDescending { abs(it.cohensD) },
-    )
+    // Through the shared engine, not a local copy. This screen used to carry its own with/without split,
+    // its own pooled-SD Cohen's d and a "crude significance" (|d| >= 0.5 with >= 3 a side) where iOS's
+    // same screen ran a Welch p — so identical journals could flag different behaviours on the two
+    // platforms. EffectRanker.rankNoLag is the byte-identical twin of Swift's BehaviorInsights.rank,
+    // which is what iOS calls here.
+    return EffectRanker.rankNoLag(model.behaviours, model.controls, outcomeDays, outcome.outcomeName)
 }
 
 /** The curated metric relationships, computed via Pearson r over aligned day pairs. */
@@ -1685,25 +1650,6 @@ private fun computeRelationships(model: InsightModel): List<Relationship> {
 }
 
 // MARK: - Statistics (pooled-SD Cohen's d, Pearson r)
-
-/** Cohen's d using pooled standard deviation. 0 when either side lacks spread. */
-private fun cohensD(a: List<Double>, b: List<Double>): Double {
-    if (a.size < 2 || b.size < 2) return 0.0
-    val ma = a.average()
-    val mb = b.average()
-    val va = variance(a, ma)
-    val vb = variance(b, mb)
-    val pooled = sqrt(((a.size - 1) * va + (b.size - 1) * vb) / (a.size + b.size - 2).toDouble())
-    if (pooled <= 0.0 || !pooled.isFinite()) return 0.0
-    return (ma - mb) / pooled
-}
-
-/** Sample variance (n-1 denominator) about a known mean. */
-private fun variance(xs: List<Double>, mean: Double): Double {
-    if (xs.size < 2) return 0.0
-    val ss = xs.sumOf { val d = it - mean; d * d }
-    return ss / (xs.size - 1).toDouble()
-}
 
 /** Pearson r over two (day,value) series aligned on shared days. Returns (r, n) or
  *  null if fewer than 3 overlapping pairs or no variance. */

--- a/android/app/src/main/java/com/noop/ui/InsightsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/InsightsScreen.kt
@@ -122,10 +122,8 @@ private enum class Outcome(
     ),
 }
 
-// MARK: - Computed shapes (plain data, no analytics package dependency)
+// MARK: - Computed shapes (plain data; behaviour effects come from the analytics package)
 
-/** One behaviour's effect on the selected outcome: with/without means, counts,
- *  Cohen's d and a crude significance flag. */
 /** A curated metric relationship plus its computed Pearson correlation. */
 private data class Relationship(
     val id: String,

--- a/android/app/src/test/java/com/noop/analytics/EffectRankerTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/EffectRankerTest.kt
@@ -253,6 +253,22 @@ class EffectRankerTest {
         assertTrue(abs(ranked[1].cohensD) >= abs(ranked[2].cohensD))
     }
 
+    /**
+     * rankNoLag fails CLOSED too, not only rank().
+     *
+     * It is a second public entry point into the same split, and this PR exists because that split had
+     * four separate homes. A new door into it gets the same lock: no controls means no comparison, so a
+     * caller that forgets loses the insight rather than getting one measured against unlogged days.
+     */
+    @Test
+    fun rankNoLagWithoutControlsProducesNothing() {
+        val outcome = HashMap<String, Double>()
+        val yes = HashSet<String>()
+        for (d in 1..10) { yes.add(ymd(2026, 6, d)); outcome[ymd(2026, 6, d)] = 50.0 + jitter(d) }
+        for (d in 11..30) outcome[ymd(2026, 6, d)] = 75.0 + jitter(d)
+        assertTrue(EffectRanker.rankNoLag(mapOf("Alcohol" to yes), emptyMap(), outcome, "Charge").isEmpty())
+    }
+
     /** Twin of Swift `testRankDropsUncomputableBehaviors`: a behaviour covering every day has no
      *  without-group and is dropped rather than ranked at zero. */
     @Test

--- a/android/app/src/test/java/com/noop/analytics/EffectRankerTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/EffectRankerTest.kt
@@ -1,6 +1,7 @@
 package com.noop.analytics
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -218,6 +219,55 @@ class EffectRankerTest {
         for (d in 1..10) { yes.add(ymd(2026, 6, d)); outcome[ymd(2026, 6, d)] = 50.0 + jitter(d) }
         for (d in 11..30) outcome[ymd(2026, 6, d)] = 75.0 + jitter(d)
         assertTrue(EffectRanker.rank(mapOf("Alcohol" to yes), emptyMap(), outcome, "Charge").isEmpty())
+    }
+
+    // rankNoLag: the Kotlin twin of Swift BehaviorInsights.rank, which the Insights screen now uses.
+
+    /**
+     * Twin of Swift `testRankOrdersByEffectSizeSignificantFirst`, same fixture and same expectations.
+     *
+     * The Insights screen used to rank with its own copy of this — a "crude significance" of |d| >= 0.5
+     * with >= 3 a side, where iOS ran a Welch p on the same screen. Identical journals could flag
+     * different behaviours per platform. Pinning the ordering here is what stops that reopening.
+     */
+    @Test
+    fun rankNoLagOrdersByEffectSizeSignificantFirst() {
+        val outcome = mapOf(
+            "d1" to 50.0, "d2" to 52.0, "d3" to 48.0, "d4" to 51.0, "d5" to 49.0, "d6" to 53.0,
+            "d7" to 70.0, "d8" to 72.0, "d9" to 68.0, "d10" to 71.0, "d11" to 69.0, "d12" to 73.0,
+        )
+        val strong = setOf("d1", "d2", "d3", "d4", "d5", "d6")
+        val weak = setOf("d1", "d7", "d2")
+        val tiny = setOf("d3", "d9")
+        val all = outcome.keys
+        val ranked = EffectRanker.rankNoLag(
+            mapOf("Strong" to strong, "Weak" to weak, "Tiny" to tiny),
+            mapOf("Strong" to (all - strong), "Weak" to (all - weak), "Tiny" to (all - tiny)),
+            outcome, "Recovery",
+        )
+        assertEquals(3, ranked.size)
+        assertEquals("Strong", ranked.first().behavior)
+        assertTrue(ranked.first().significant)
+        assertFalse(ranked[1].significant)
+        assertFalse(ranked[2].significant)
+        assertTrue(abs(ranked[1].cohensD) >= abs(ranked[2].cohensD))
+    }
+
+    /** Twin of Swift `testRankDropsUncomputableBehaviors`: a behaviour covering every day has no
+     *  without-group and is dropped rather than ranked at zero. */
+    @Test
+    fun rankNoLagDropsUncomputableBehaviours() {
+        val outcome = mapOf("a" to 60.0, "b" to 62.0, "c" to 70.0, "d" to 72.0)
+        val allDays = setOf("a", "b", "c", "d")
+        val half = setOf("a", "b")
+        val all = outcome.keys
+        val ranked = EffectRanker.rankNoLag(
+            mapOf("AllDays" to allDays, "Half" to half),
+            mapOf("AllDays" to (all - allDays), "Half" to (all - half)),
+            outcome, "Recovery",
+        )
+        assertEquals(1, ranked.size)
+        assertEquals("Half", ranked.first().behavior)
     }
 
 }

--- a/android/app/src/test/java/com/noop/analytics/EffectRankerTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/EffectRankerTest.kt
@@ -23,9 +23,19 @@ class EffectRankerTest {
      *  with/without groups carry real spread (a constant group yields pooled SD 0 / d 0). */
     private fun jitter(dayOfMonth: Int): Double = ((dayOfMonth * 7) % 5 - 2).toDouble()
 
+    /** Every outcome day the behaviour was not logged on. These fixtures predate the Yes/No split and
+     *  test the LAG math, so they keep their original partition by declaring the complement explicitly —
+     *  the engine no longer assumes it, and a test that quietly lost its control group would still pass
+     *  by returning nothing. */
+    private fun controlsFor(outcome: Map<String, Double>, behaviorDays: Set<String>): Set<String> =
+        outcome.keys - behaviorDays
+
     /** Test-only: the BehaviorEffect at a specific lag, via the engine's own shift alignment. */
     private fun effectAtLag(behaviorDays: Set<String>, outcome: Map<String, Double>, lag: Int) =
-        EffectRanker.effect(behaviorDays, EffectRanker.shiftedOutcome(outcome, lag), "Alcohol", "Charge")
+        EffectRanker.effect(
+            behaviorDays, controlsFor(outcome, behaviorDays),
+            EffectRanker.shiftedOutcome(outcome, lag), "Alcohol", "Charge",
+        )
 
     // Planted lag-1 effect is found at L=1 and beats L=0/L=2
 
@@ -43,7 +53,10 @@ class EffectRankerTest {
             outcome[ymd(2026, 6, dip)] = 50.0 + jitter(dip)
         }
 
-        val out = EffectRanker.rank(mapOf("Alcohol" to behaviorDays), outcome, "Charge")
+        val out = EffectRanker.rank(
+            mapOf("Alcohol" to behaviorDays), mapOf("Alcohol" to controlsFor(outcome, behaviorDays)),
+            outcome, "Charge",
+        )
         val r = row(out, "Alcohol")
         assertNotNull(r)
         assertEquals(1, r!!.lag)
@@ -74,7 +87,9 @@ class EffectRankerTest {
         }
         for (d in 1..8) outcome[ymd(2026, 7, d)] = 70.0 + jitter(d)
 
-        val out = EffectRanker.rank(mapOf("Sparse" to thin), outcome, "Charge")
+        val out = EffectRanker.rank(
+            mapOf("Sparse" to thin), mapOf("Sparse" to controlsFor(outcome, thin)), outcome, "Charge",
+        )
         assertTrue(out.isEmpty())
     }
 
@@ -97,7 +112,11 @@ class EffectRankerTest {
         }
         for (d in 10..20) outcome[ymd(2026, 5, d)] = 70.0 + jitter(d)
 
-        val out = EffectRanker.rank(mapOf("Big" to big, "Small" to small), outcome, "Charge")
+        val out = EffectRanker.rank(
+            mapOf("Big" to big, "Small" to small),
+            mapOf("Big" to controlsFor(outcome, big), "Small" to controlsFor(outcome, small)),
+            outcome, "Charge",
+        )
         assertEquals(listOf("Big", "Small"), out.map { it.behavior })
         assertEquals(0, row(out, "Big")!!.lag)
         assertEquals(0, row(out, "Small")!!.lag)
@@ -138,4 +157,67 @@ class EffectRankerTest {
         val r = RankedEffect("Alcohol", "Charge", 1, e, ScoreConfidence.BUILDING)
         assertTrue(r.sentence().endsWith("(next morning)."))
     }
+    // The Reddit report: unlogged days are not answers.
+
+    /**
+     * "If I didn't track something for 100 days, NOOP takes that as a NO for 100 days, whereas it simply
+     * was not logged at all." Reported by a user on Reddit, and it was exactly what the split did.
+     *
+     * The fixture is that report: 8 days logged Yes with a real dip, 6 days logged No, and 60 days with
+     * an outcome and no journal row at all. Those 60 must not reach the control group, because nothing
+     * about them says the user did not do the thing.
+     */
+    @Test
+    fun daysWithNoJournalRowAreNotControls() {
+        val outcome = HashMap<String, Double>()
+        val yes = HashSet<String>()
+        val no = HashSet<String>()
+        for (d in 1..8) { yes.add(ymd(2026, 6, d)); outcome[ymd(2026, 6, d)] = 50.0 + jitter(d) }
+        for (d in 9..14) { no.add(ymd(2026, 6, d)); outcome[ymd(2026, 6, d)] = 70.0 + jitter(d) }
+        // Never opened the journal on these, and their values sit far from BOTH answered groups.
+        for (d in 15..30) outcome[ymd(2026, 6, d)] = 20.0 + jitter(d)
+        for (d in 1..31) outcome[ymd(2026, 7, d)] = 20.0 + jitter(d)
+        for (d in 1..13) outcome[ymd(2026, 8, d)] = 20.0 + jitter(d)
+
+        val e = EffectRanker.effect(yes, no, outcome, "Alcohol", "Charge")
+        assertNotNull(e)
+        // Controls are the six NO days only. If the 60 unlogged days leaked in, nWithout would be 66 and
+        // meanWithout would be dragged towards 20.
+        assertEquals(6, e!!.nWithout)
+        assertEquals(8, e.nWith)
+        assertTrue("controls must average near the NO days, not the unlogged ones", e.meanWithout > 60.0)
+    }
+
+    /**
+     * A behaviour the user only ever ticks Yes has no control group, so there is no comparison to make
+     * and the honest answer is none. Previously it got one, built from every day the journal was never
+     * opened - the most confident-looking findings in the app came from the least evidence.
+     */
+    @Test
+    fun aBehaviourNeverLoggedNoYieldsNothing() {
+        val outcome = HashMap<String, Double>()
+        val yes = HashSet<String>()
+        for (d in 1..20) { yes.add(ymd(2026, 6, d)); outcome[ymd(2026, 6, d)] = 50.0 + jitter(d) }
+        for (d in 21..30) outcome[ymd(2026, 6, d)] = 80.0 + jitter(d)
+
+        assertNull(EffectRanker.effect(yes, emptySet(), outcome, "Alcohol", "Charge"))
+        assertTrue(
+            EffectRanker.rank(mapOf("Alcohol" to yes), emptyMap(), outcome, "Charge").isEmpty(),
+        )
+    }
+
+    /**
+     * rank() fails CLOSED on a caller that forgets the controls: no insight, rather than a wrong one
+     * measured against every day the user never opened the journal. There are two production callers and
+     * this is what stops a third from reintroducing the bug silently.
+     */
+    @Test
+    fun rankWithoutControlsProducesNothingRatherThanGuessing() {
+        val outcome = HashMap<String, Double>()
+        val yes = HashSet<String>()
+        for (d in 1..10) { yes.add(ymd(2026, 6, d)); outcome[ymd(2026, 6, d)] = 50.0 + jitter(d) }
+        for (d in 11..30) outcome[ymd(2026, 6, d)] = 75.0 + jitter(d)
+        assertTrue(EffectRanker.rank(mapOf("Alcohol" to yes), emptyMap(), outcome, "Charge").isEmpty())
+    }
+
 }


### PR DESCRIPTION
## The report

From a user on Reddit, and correct in every particular:

> I notice logged 'Yes' journal items are weighted against all days when the item
> was not logged, and not versus the days when a 'No' was logged. So if I didn't
> track something for 100 days, NOOP takes that as a NO for 100 days, whereas it
> simply was not logged at all.

(They wondered whether it was a WHOOP 5 limitation. It isn't — the journal effect
engine is device-independent.)

## What the code did

Every with/without split partitioned on the **Yes set alone**:

```kotlin
if (behaviorDays.contains(day)) withVals.add(value) else withoutVals.add(value)
```

So every day carrying an outcome became a control, whether the user had answered
**No** or had never opened the journal at all.

Four copies of it, and the fourth is the one worth naming:

| | |
|---|---|
| `EffectRanker.effect` | Kotlin |
| `BehaviorInsights.effect` | Swift — both Swift rankers funnel through it |
| `EffectRanker.rank` / `bestLag` | both, threading the sets |
| `InsightsScreen.rankEffects` | **Android only, hand-rolled, does not call the ranker** |

That last one is a private re-implementation inside the Insights screen. A caller
audit found it; a search for `EffectRanker.` would not have.

## The data was already there

The journal distinguishes all three states today: a **No** writes a row with
`answeredYes = false`, and only *Clear* deletes the row. Nothing but the split was
conflating them, so this needs no schema change and no migration — only the Yes
filter that discarded the No rows on the way in.

Controls are now passed explicitly as the days answered **No**. A day in neither
set takes part in no comparison.

## Expect fewer findings, not better-looking ones

Unlogged days inflated `nWithout`, which shrinks the Welch p and helps clear the
`min(nWith, nWithout) ≥ 5` gate. Removing them removes confidence that was never
earned, so some existing correlations will stop appearing. A behaviour with no No
days now yields **nothing**, which is the honest answer: with no controls there is
no comparison to make.

**Surviving findings will also show lower confidence.** `bestLag` sets
`pairs = min(nWith, nWithout)` and feeds it to the confidence ladder
(`calibratingBelow = 5`, `solidPairs = 10`), so a smaller control group moves rows
down from SOLID toward BUILDING and CALIBRATING. Expect badges to drop, and note
that is the correction rather than a symptom of one: the old tier was computed
against a control count padded with days that carried no information.

That matches the engine's stated principle — effect size and n first, never a bare
"significant" stamp.

## Two consequences, stated rather than discovered

**Numeric journal items (#322) lose their binary effect.** They write
`answeredYes = true` and are cleared by deleting the row, so they have no No days.
This is correct: the dose-response series is the analysis that fits them, and the
binary one was precisely the reported bug.

**`rank()` fails closed.** A behaviour absent from the controls map has no control
group and yields nothing, so a future caller that forgets loses the insight rather
than getting a wrong one measured against every unlogged day. Pinned by a test on
both platforms.

## No new copy needed

I expected to have to write an empty-state message and found both platforms already
say the right thing:

> Not enough overlap between your journal answers and {outcome} to measure an effect
> yet. Keep logging. **Effects need days both with and without each behaviour.**

Written for the model the code should have had. Localized on both sides already.

## Tests

Three new cases per platform, twinned by name:

- unlogged days are not controls — 6 Yes, 6 No, 40 never-logged whose values sit far
  from both answered groups; `nWithout` must be 6, and `meanWithout` must sit with
  the No days rather than being dragged toward the unlogged ones.
- a behaviour never logged No yields nothing.
- `rank()` with no controls returns empty rather than guessing.

Existing fixtures predate the split and test the **lag** math, so they were repinned
by declaring the complement explicitly rather than deleted — they still assert what
they were written to assert.

**Android 4959 unit tests, Swift 1672, zero failures.** `compileFullDebugKotlin`,
`doc_comment_lint.py`, `i18n_audit.py` clean.

## Parity

Byte-identical on both sides, which the ranker contract requires. The Android-only
`rankEffects` has no Swift twin to mirror (Swift's InsightsView calls
`BehaviorInsights.rank` directly), and it now applies the same rule.

Refs #322.
