### PR TITLE
Preserve sensor-contact state from standard BLE heart-rate measurements

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
@@ -19,6 +19,19 @@ public enum StandardHRContact: String, Equatable, Codable, Sendable {
     case unsupported
     case supportedNotDetected = "supported_not_detected"
     case supportedDetected = "supported_detected"
+
+    /// Decode the BLE Heart Rate Measurement flags: bit 2 = supported, bit 1 = detected.
+    /// `unsupported` wins whenever bit 2 is clear, irrespective of detected bit 1.
+    /// Twin of Kotlin `StandardHrContact.fromMeasurementFlags`.
+    public static func fromMeasurementFlags(_ flags: UInt8) -> StandardHRContact {
+        if flags & 0x04 == 0 {
+            return .unsupported
+        } else if flags & 0x02 == 0 {
+            return .supportedNotDetected
+        } else {
+            return .supportedDetected
+        }
+    }
 }
 
 /// WHICH sensor channel produced an R-R interval (#1071).

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
@@ -10,6 +10,17 @@ public struct HRSample: Equatable, Codable {
     public init(ts: Int, bpm: Int) { self.ts = ts; self.bpm = bpm }
 }
 
+/// Sensor-contact state carried by the standard BLE Heart Rate Measurement flags.
+///
+/// This is deliberately a tri-state rather than a Bool: a peripheral that does not support contact
+/// detection has not said that contact is absent. `unsupported` is also the only valid result whenever
+/// flag bit 2 is clear, irrespective of the value in detected bit 1.
+public enum StandardHRContact: String, Equatable, Codable, Sendable {
+    case unsupported
+    case supportedNotDetected = "supported_not_detected"
+    case supportedDetected = "supported_detected"
+}
+
 /// WHICH sensor channel produced an R-R interval (#1071).
 ///
 /// A WHOOP strap has ONE beat source, so its rows carry no channel (nil) and nothing here changes for

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/StandardHRContactTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/StandardHRContactTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import WhoopProtocol
+
+/// The BLE Heart Rate Measurement flags decode must live on the protocol type so Swift and Kotlin
+/// stay aligned: bit 2 = supported, bit 1 = detected, unsupported whenever bit 2 is clear.
+final class StandardHRContactTests: XCTestCase {
+    func testFromMeasurementFlagsCoversAllCombinations() {
+        let cases: [(flags: UInt8, expected: StandardHRContact)] = [
+            (0x00, .unsupported),
+            (0x02, .unsupported),
+            (0x04, .supportedNotDetected),
+            (0x06, .supportedDetected),
+        ]
+        for test in cases {
+            XCTAssertEqual(
+                StandardHRContact.fromMeasurementFlags(test.flags),
+                test.expected,
+                "flags 0x\(String(test.flags, radix: 16))"
+            )
+        }
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -60,6 +60,27 @@ extension WhoopStore {
         }
     }
 
+    /// Standard-BLE sensor-contact readings recorded alongside generic HR samples. Rows before this
+    /// feature have no contact event, so this intentionally returns no invented legacy values.
+    public func standardHRContacts(deviceId: String, from: Int, to: Int,
+                                   limit: Int) async throws -> [StandardHRContactSample] {
+        try syncRead { db in
+            try Row.fetchAll(db, sql: """
+                SELECT ts, payloadJSON FROM event
+                WHERE deviceId = ? AND kind = ? AND ts >= ? AND ts <= ?
+                ORDER BY ts ASC LIMIT ?
+                """, arguments: [deviceId, StandardHRMapping.contactEventKind, from, to, limit])
+                .compactMap { row in
+                    let json: String = row["payloadJSON"]
+                    guard let payload = try? WhoopStore.eventDecoder.decode(
+                        [String: ParsedValue].self, from: Data(json.utf8)),
+                          case let .string(raw)? = payload["contact"],
+                          let contact = StandardHRContact(rawValue: raw) else { return nil }
+                    return StandardHRContactSample(ts: row["ts"], contact: contact)
+                }
+        }
+    }
+
     /// Cheap change-detector for the raw HR stream: `(count, maxTs)` over `[from, to]`, computed in
     /// SQLite over the `(deviceId, ts)` index WITHOUT materializing any rows (#836). Lets a caller decide
     /// "nothing was inserted since last time, skip the expensive re-read" for pennies, `COUNT(*)` moves on

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -70,13 +70,9 @@ extension WhoopStore {
                 WHERE deviceId = ? AND kind = ? AND ts >= ? AND ts <= ?
                 ORDER BY ts ASC LIMIT ?
                 """, arguments: [deviceId, StandardHRMapping.contactEventKind, from, to, limit])
-                .compactMap { row in
+                .map { row in
                     let json: String = row["payloadJSON"]
-                    guard let payload = try? WhoopStore.eventDecoder.decode(
-                        [String: ParsedValue].self, from: Data(json.utf8)),
-                          case let .string(raw)? = payload["contact"],
-                          let contact = StandardHRContact(rawValue: raw) else { return nil }
-                    return StandardHRContactSample(ts: row["ts"], contact: contact)
+                    return try StandardHRMapping.contactSample(ts: row["ts"], payloadJSON: json)
                 }
         }
     }

--- a/Packages/WhoopStore/Sources/WhoopStore/StandardHRMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/StandardHRMapping.swift
@@ -8,15 +8,35 @@ import WhoopProtocol
 /// can't be unit-tested.
 ///
 /// A chest strap (Polar / Wahoo / Coospo / Garmin HRM / Amazfit Helio broadcast) only ever
-/// reports HR and (optionally) R-R intervals over 0x2A37; every other stream (spo2, skin temp,
-/// resp, gravity, steps, ppgHr, events, battery) is left empty.
+/// reports HR, (optionally) R-R intervals, and its standard contact flags over 0x2A37; every other
+/// stream (spo2, skin temp, resp, gravity, steps, ppgHr, battery) is left empty.
 public enum StandardHRMapping {
+    /// `event.kind` used for a standard BLE sensor-contact reading. The generic event table is the
+    /// established durable stream for additive decoded signals, so this needs no schema migration.
+    public static let contactEventKind = "STANDARD_HR_CONTACT"
+
     /// Build a `Streams` carrying one HR sample and zero-or-more R-R intervals, all stamped at the
     /// same wall-clock `ts` (unix seconds). Pure → unit-testable.
-    public static func samples(fromHR hr: Int, rr: [Int], at ts: Int) -> Streams {
-        Streams(
+    public static func samples(fromHR hr: Int, rr: [Int], contact: StandardHRContact? = nil,
+                               at ts: Int) -> Streams {
+        let events = contact.map { [
+            WhoopEvent(ts: ts, kind: contactEventKind, payload: ["contact": .string($0.rawValue)])
+        ] } ?? []
+        return Streams(
             hr: [HRSample(ts: ts, bpm: hr)],
-            rr: rr.map { RRInterval(ts: ts, rrMs: $0) }
+            rr: rr.map { RRInterval(ts: ts, rrMs: $0) },
+            events: events
         )
+    }
+}
+
+/// One persisted standard-BLE sensor-contact reading. Legacy HR rows have no companion event and are
+/// therefore absent from this stream instead of being guessed as any contact state.
+public struct StandardHRContactSample: Equatable, Sendable {
+    public let ts: Int
+    public let contact: StandardHRContact
+    public init(ts: Int, contact: StandardHRContact) {
+        self.ts = ts
+        self.contact = contact
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/StandardHRMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/StandardHRMapping.swift
@@ -28,6 +28,24 @@ public enum StandardHRMapping {
             events: events
         )
     }
+
+    /// Parse a persisted `STANDARD_HR_CONTACT` `payloadJSON`. Throws on malformed JSON or a missing /
+    /// unknown `contact` field so a parse failure is not the same as "no contact event".
+    public static func contactSample(ts: Int, payloadJSON: String) throws -> StandardHRContactSample {
+        let payload = try JSONDecoder().decode([String: ParsedValue].self, from: Data(payloadJSON.utf8))
+        guard case let .string(raw)? = payload["contact"] else {
+            throw ContactSampleError.missingContact
+        }
+        guard let contact = StandardHRContact(rawValue: raw) else {
+            throw ContactSampleError.unknownContact(raw)
+        }
+        return StandardHRContactSample(ts: ts, contact: contact)
+    }
+
+    public enum ContactSampleError: Error, Equatable {
+        case missingContact
+        case unknownContact(String)
+    }
 }
 
 /// One persisted standard-BLE sensor-contact reading. Legacy HR rows have no companion event and are

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/StandardHRMappingTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/StandardHRMappingTests.swift
@@ -70,4 +70,15 @@ final class StandardHRMappingTests: XCTestCase {
         XCTAssertTrue(s.events.isEmpty)
         XCTAssertTrue(s.battery.isEmpty)
     }
+
+    func testContactSampleParsesPayloadJSONAndDoesNotTreatParseFailureAsAbsence() throws {
+        let detected = try StandardHRMapping.contactSample(
+            ts: 100,
+            payloadJSON: #"{"extra":true,"contact":"supported_detected"}"#
+        )
+        XCTAssertEqual(detected, StandardHRContactSample(ts: 100, contact: .supportedDetected))
+
+        XCTAssertThrowsError(try StandardHRMapping.contactSample(ts: 101, payloadJSON: "not-json"))
+        XCTAssertThrowsError(try StandardHRMapping.contactSample(ts: 102, payloadJSON: "{}"))
+    }
 }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/StandardHRMappingTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/StandardHRMappingTests.swift
@@ -17,6 +17,47 @@ final class StandardHRMappingTests: XCTestCase {
         XCTAssertTrue(s.rr.isEmpty)
     }
 
+    func testStandardHRContactIsMappedAsAStableEvent() throws {
+        let s = StandardHRMapping.samples(
+            fromHR: 72,
+            rr: [],
+            contact: .supportedDetected,
+            at: 1_750_000_000
+        )
+        XCTAssertEqual(s.events, [
+            WhoopEvent(
+                ts: 1_750_000_000,
+                kind: StandardHRMapping.contactEventKind,
+                payload: ["contact": .string("supported_detected")]
+            )
+        ])
+    }
+
+    func testLegacyMappingDoesNotFabricateContact() throws {
+        let s = StandardHRMapping.samples(fromHR: 72, rr: [], at: 1_750_000_000)
+        XCTAssertTrue(s.events.isEmpty)
+    }
+
+    func testContactSurvivesInsertAndReadWhileLegacyRowsStayAbsent() async throws {
+        let store = try await WhoopStore.inMemory()
+        try await store.upsertDevice(id: "standard-strap", mac: nil, name: nil)
+        _ = try await store.insert(
+            StandardHRMapping.samples(fromHR: 72, rr: [], contact: .supportedNotDetected, at: 100),
+            deviceId: "standard-strap"
+        )
+        _ = try await store.insert(
+            StandardHRMapping.samples(fromHR: 73, rr: [], at: 101),
+            deviceId: "standard-strap"
+        )
+
+        let contacts = try await store.standardHRContacts(
+            deviceId: "standard-strap", from: 0, to: 200, limit: 10
+        )
+        XCTAssertEqual(contacts, [
+            StandardHRContactSample(ts: 100, contact: .supportedNotDetected)
+        ])
+    }
+
     func testOnlyHRandRRStreamsArePopulated() throws {
         // A chest strap reports nothing else — every other stream must stay empty.
         let s = StandardHRMapping.samples(fromHR: 88, rr: [700], at: 42)

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -5028,7 +5028,8 @@ public final class BLEManager: NSObject, ObservableObject {
         // change so a steady resting HR doesn't re-render the whole Live console every second.
         if m.hr >= 30 && m.hr <= 220, state.heartRate != m.hr { state.heartRate = m.hr }
         // Record it continuously — independent of the realtime stream or the open screen.
-        collector?.ingestStandardHR(hr: m.hr, rr: m.rr, at: Int(Date().timeIntervalSince1970))
+        collector?.ingestStandardHR(hr: m.hr, rr: m.rr, contact: m.contact,
+                                    at: Int(Date().timeIntervalSince1970))
     }
 }
 

--- a/Strand/BLE/StandardHRSource.swift
+++ b/Strand/BLE/StandardHRSource.swift
@@ -126,9 +126,9 @@ public final class StandardHRSource: NSObject, ObservableObject {
 
     // MARK: - Sample buffer
 
-    /// Buffered (hr, rr, ts) readings, flushed to `persist` in batches to keep the write path off
+    /// Buffered (hr, rr, contact, ts) readings, flushed to `persist` in batches to keep the write path off
     /// the per-notification hot loop.
-    private var buffer: [(hr: Int, rr: [Int], ts: Int)] = []
+    private var buffer: [(hr: Int, rr: [Int], contact: StandardHRContact, ts: Int)] = []
     private var lastFlush: Date = .init()
     /// Flush thresholds — whichever trips first.
     private let flushCount = 30
@@ -230,8 +230,8 @@ public final class StandardHRSource: NSObject, ObservableObject {
 
     // MARK: - Buffer / persistence
 
-    private func enqueue(hr: Int, rr: [Int]) {
-        buffer.append((hr: hr, rr: rr, ts: Int(Date().timeIntervalSince1970)))
+    private func enqueue(hr: Int, rr: [Int], contact: StandardHRContact) {
+        buffer.append((hr: hr, rr: rr, contact: contact, ts: Int(Date().timeIntervalSince1970)))
         if buffer.count >= flushCount || Date().timeIntervalSince(lastFlush) >= flushInterval {
             flush()
         }
@@ -240,7 +240,8 @@ public final class StandardHRSource: NSObject, ObservableObject {
     private func flush() {
         guard !buffer.isEmpty else { lastFlush = Date(); return }
         for sample in buffer {
-            persist(StandardHRMapping.samples(fromHR: sample.hr, rr: sample.rr, at: sample.ts))
+            persist(StandardHRMapping.samples(fromHR: sample.hr, rr: sample.rr,
+                                               contact: sample.contact, at: sample.ts))
         }
         buffer.removeAll()
         lastFlush = Date()
@@ -478,6 +479,6 @@ extension StandardHRSource: @preconcurrency CBPeripheralDelegate {
         live.heartRate = parsed.hr
         live.setRRIntervals(parsed.rr)
         live.connected = true
-        enqueue(hr: parsed.hr, rr: parsed.rr)
+        enqueue(hr: parsed.hr, rr: parsed.rr, contact: parsed.contact)
     }
 }

--- a/Strand/BLE/StandardHeartRate.swift
+++ b/Strand/BLE/StandardHeartRate.swift
@@ -1,11 +1,20 @@
 import Foundation
+import WhoopProtocol
 
 /// Pure parser for the standard BLE Heart Rate Measurement characteristic (0x2A37).
-/// Returns the heart rate (bpm) and any R-R intervals (ms). Pure → unit-testable.
+/// Returns the heart rate (bpm), R-R intervals (ms), and the contact state. Pure → unit-testable.
 public enum StandardHeartRate {
-    public static func parse(_ data: [UInt8]) -> (hr: Int, rr: [Int])? {
+    public static func parse(_ data: [UInt8]) -> (hr: Int, rr: [Int], contact: StandardHRContact)? {
         guard !data.isEmpty else { return nil }
         let flags = data[0]
+        let contact: StandardHRContact
+        if flags & 0x04 == 0 {
+            contact = .unsupported
+        } else if flags & 0x02 == 0 {
+            contact = .supportedNotDetected
+        } else {
+            contact = .supportedDetected
+        }
         var idx = 1
         let hr: Int
         if flags & 0x01 != 0 {                       // 16-bit HR
@@ -24,6 +33,6 @@ public enum StandardHeartRate {
                 idx += 2
             }
         }
-        return (hr, rr)
+        return (hr, rr, contact)
     }
 }

--- a/Strand/BLE/StandardHeartRate.swift
+++ b/Strand/BLE/StandardHeartRate.swift
@@ -7,14 +7,7 @@ public enum StandardHeartRate {
     public static func parse(_ data: [UInt8]) -> (hr: Int, rr: [Int], contact: StandardHRContact)? {
         guard !data.isEmpty else { return nil }
         let flags = data[0]
-        let contact: StandardHRContact
-        if flags & 0x04 == 0 {
-            contact = .unsupported
-        } else if flags & 0x02 == 0 {
-            contact = .supportedNotDetected
-        } else {
-            contact = .supportedDetected
-        }
+        let contact = StandardHRContact.fromMeasurementFlags(flags)
         var idx = 1
         let hr: Int
         if flags & 0x01 != 0 {                       // 16-bit HR

--- a/Strand/Collect/Collector.swift
+++ b/Strand/Collect/Collector.swift
@@ -97,10 +97,11 @@ final class Collector {
     private var lastStdInsertFailureLogMs: Int64 = 0
     private var lastRealtimeInsertFailureLogMs: Int64 = 0
 
-    /// Standard 0x2A37 HR/RR buffer — the reliable, always-on stream, recorded continuously
+    /// Standard 0x2A37 HR/RR/contact buffer — the reliable, always-on stream, recorded continuously
     /// (independent of the custom realtime stream or which screen is open).
     private var stdHR: [HRSample] = []
     private var stdRR: [RRInterval] = []
+    private var stdContact: [WhoopEvent] = []
     private var batchStartedAt: TimeInterval
     var bufferedCount: Int { buffer.count }
 
@@ -265,27 +266,31 @@ final class Collector {
 
     /// Buffer one standard Heart-Rate-Measurement reading. No clock correlation needed —
     /// these carry a wall-clock `ts` directly. Auto-flushes ~every 30 readings (~30s).
-    func ingestStandardHR(hr: Int, rr: [Int], at ts: Int) {
+    func ingestStandardHR(hr: Int, rr: [Int], contact: StandardHRContact? = nil, at ts: Int) {
         let acceptedHR = (30...220).contains(hr) ? 1 : 0
         let acceptedRR = rr.filter { (250...3000).contains($0) }
         if acceptedHR == 1 { stdHR.append(HRSample(ts: ts, bpm: hr)) }
         stdRR.append(contentsOf: acceptedRR.map { RRInterval(ts: ts, rrMs: $0) })
+        stdContact.append(contentsOf: StandardHRMapping.samples(
+            fromHR: hr, rr: [], contact: contact, at: ts
+        ).events)
         log?(LivePersistTrace.standardHRHostReceivedLine(
             hostUnixSeconds: ts,
             acceptedHRRows: acceptedHR, acceptedRRRows: acceptedRR.count,
             rejectedHRRows: 1 - acceptedHR, rejectedRRRows: rr.count - acceptedRR.count,
             pendingHRRows: stdHR.count, pendingRRRows: stdRR.count))
-        if stdHR.count + stdRR.count >= 30 {
+        if stdHR.count + stdRR.count + stdContact.count >= 30 {
             Task { @MainActor in await self.flushStandardHR(reason: .cadence) }
         }
     }
 
-    /// Persist the buffered standard HR/RR. Re-buffers on failure so nothing is lost.
+    /// Persist the buffered standard HR/RR/contact. Re-buffers on failure so nothing is lost.
     func flushStandardHR(reason: LivePersistTrace.StandardHRFlushReason = .explicit) async {
-        guard !stdHR.isEmpty || !stdRR.isEmpty else { return }
-        let hr = stdHR, rr = stdRR
+        guard !stdHR.isEmpty || !stdRR.isEmpty || !stdContact.isEmpty else { return }
+        let hr = stdHR, rr = stdRR, contact = stdContact
         stdHR.removeAll(keepingCapacity: true)
         stdRR.removeAll(keepingCapacity: true)
+        stdContact.removeAll(keepingCapacity: true)
         log?(LivePersistTrace.standardHRFlushAttemptLine(
             reason: reason, offeredHRRows: hr.count, offeredRRRows: rr.count))
         // #1118: census this batch BEFORE it is stored, exactly as the historical path does, so a strap
@@ -304,7 +309,7 @@ final class Collector {
             }
         }
         do {
-            let inserted = try await store.insert(Streams(hr: hr, rr: rr), deviceId: deviceId)
+            let inserted = try await store.insert(Streams(hr: hr, rr: rr, events: contact), deviceId: deviceId)
             stdInsertFailures = 0
             log?(LivePersistTrace.standardHRFlushSucceededLine(
                 reason: reason, offeredHRRows: hr.count, offeredRRRows: rr.count,
@@ -312,6 +317,7 @@ final class Collector {
         } catch {
             stdHR.insert(contentsOf: hr, at: 0)
             stdRR.insert(contentsOf: rr, at: 0)
+            stdContact.insert(contentsOf: contact, at: 0)
             stdInsertFailures += 1
             log?(LivePersistTrace.standardHRRebufferedForRetryLine(
                 reason: reason, attemptedHRRows: hr.count, attemptedRRRows: rr.count,

--- a/StrandTests/CollectorStandardHRContactTests.swift
+++ b/StrandTests/CollectorStandardHRContactTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+import WhoopProtocol
+import WhoopStore
+@testable import Strand
+
+@MainActor
+final class CollectorStandardHRContactTests: XCTestCase {
+    private final class CaptureStore: StoreWriting {
+        enum Failure: Error { case requested }
+
+        var inserted: [Streams] = []
+        var failNextInsert = false
+
+        func insert(_ streams: Streams, deviceId: String) async throws
+            -> (hr: Int, rr: Int, events: Int, battery: Int,
+                spo2: Int, skinTemp: Int, resp: Int, gravity: Int) {
+            if failNextInsert {
+                failNextInsert = false
+                throw Failure.requested
+            }
+            inserted.append(streams)
+            return (streams.hr.count, streams.rr.count, streams.events.count,
+                    streams.battery.count, streams.spo2.count, streams.skinTemp.count,
+                    streams.resp.count, streams.gravity.count)
+        }
+
+        func enqueueRawBatch(_ meta: RawBatchMeta, frames: [[UInt8]]) async throws {}
+    }
+
+    func testContactOnlyBatchAutoFlushesAtThreshold() async {
+        let store = CaptureStore()
+        let collector = Collector(store: store, deviceId: "whoop-5")
+
+        for ts in 1_750_000_000..<1_750_000_030 {
+            collector.ingestStandardHR(
+                hr: 0, rr: [], contact: .supportedNotDetected, at: ts
+            )
+        }
+        for _ in 0..<10 where store.inserted.isEmpty { await Task.yield() }
+
+        XCTAssertEqual(store.inserted.count, 1)
+        guard let inserted = store.inserted.first else { return }
+        XCTAssertTrue(inserted.hr.isEmpty)
+        XCTAssertTrue(inserted.rr.isEmpty)
+        XCTAssertEqual(inserted.events.count, 30)
+    }
+
+    func testWhoopStandardHRCollectorPersistsParsedContact() async {
+        let store = CaptureStore()
+        let collector = Collector(store: store, deviceId: "whoop-5")
+
+        collector.ingestStandardHR(
+            hr: 72, rr: [1_000], contact: .supportedNotDetected, at: 1_750_000_000
+        )
+        await collector.flushStandardHR()
+
+        XCTAssertEqual(store.inserted, [
+            StandardHRMapping.samples(
+                fromHR: 72,
+                rr: [1_000],
+                contact: .supportedNotDetected,
+                at: 1_750_000_000
+            )
+        ])
+    }
+
+    func testWhoopStandardHRCollectorRebuffersContactAfterInsertFailure() async {
+        let store = CaptureStore()
+        store.failNextInsert = true
+        let collector = Collector(store: store, deviceId: "whoop-5")
+
+        collector.ingestStandardHR(
+            hr: 73, rr: [], contact: .supportedDetected, at: 1_750_000_001
+        )
+        await collector.flushStandardHR()
+        XCTAssertTrue(store.inserted.isEmpty)
+
+        await collector.flushStandardHR()
+        XCTAssertEqual(store.inserted.first?.events, [
+            WhoopEvent(
+                ts: 1_750_000_001,
+                kind: StandardHRMapping.contactEventKind,
+                payload: ["contact": .string("supported_detected")]
+            )
+        ])
+    }
+}

--- a/StrandTests/StandardHeartRateTests.swift
+++ b/StrandTests/StandardHeartRateTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+import WhoopProtocol
+@testable import Strand
+
+final class StandardHeartRateTests: XCTestCase {
+    func testContactFlagsCoverAllCombinations() {
+        let cases: [(flags: UInt8, expected: StandardHRContact)] = [
+            (0x00, .unsupported),
+            (0x02, .unsupported),
+            (0x04, .supportedNotDetected),
+            (0x06, .supportedDetected),
+        ]
+
+        for test in cases {
+            let parsed = StandardHeartRate.parse([test.flags, 72])
+            XCTAssertEqual(parsed?.contact, test.expected, "flags 0x\(String(test.flags, radix: 16))")
+        }
+    }
+
+    func testContactFlagsDoNotChangeExistingHeartRateOrRRParsing() {
+        let parsed = StandardHeartRate.parse([0x16, 72, 0x00, 0x04])
+        XCTAssertEqual(parsed?.hr, 72)
+        XCTAssertEqual(parsed?.rr, [1000])
+        XCTAssertEqual(parsed?.contact, .supportedDetected)
+    }
+}

--- a/StrandTests/StandardHeartRateTests.swift
+++ b/StrandTests/StandardHeartRateTests.swift
@@ -12,6 +12,11 @@ final class StandardHeartRateTests: XCTestCase {
         ]
 
         for test in cases {
+            XCTAssertEqual(
+                StandardHRContact.fromMeasurementFlags(test.flags),
+                test.expected,
+                "flags 0x\(String(test.flags, radix: 16))"
+            )
             let parsed = StandardHeartRate.parse([test.flags, 72])
             XCTAssertEqual(parsed?.contact, test.expected, "flags 0x\(String(test.flags, radix: 16))")
         }

--- a/android/app/src/main/java/com/noop/ble/StandardHeartRate.kt
+++ b/android/app/src/main/java/com/noop/ble/StandardHeartRate.kt
@@ -1,5 +1,7 @@
 package com.noop.ble
 
+import com.noop.protocol.StandardHrContact
+
 /**
  * Pure parser for the standard BLE Heart Rate Measurement characteristic (0x2A37).
  *
@@ -20,7 +22,7 @@ package com.noop.ble
 object StandardHeartRate {
 
     /** The parsed reading: heart rate (bpm) and the R-R intervals (ms), in arrival order. */
-    data class Reading(val hr: Int, val rr: List<Int>)
+    data class Reading(val hr: Int, val rr: List<Int>, val contact: StandardHrContact)
 
     /**
      * Parse one 0x2A37 notification payload. Returns null on an empty or truncated packet (a packet
@@ -29,6 +31,7 @@ object StandardHeartRate {
     fun parse(data: ByteArray): Reading? {
         if (data.isEmpty()) return null
         val flags = data[0].toInt() and 0xFF
+        val contact = StandardHrContact.fromMeasurementFlags(flags)
         var idx = 1
 
         val hr: Int
@@ -52,6 +55,6 @@ object StandardHeartRate {
                 idx += 2
             }
         }
-        return Reading(hr, rr)
+        return Reading(hr, rr, contact)
     }
 }

--- a/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
+++ b/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
@@ -22,8 +22,10 @@ import android.os.ParcelUuid
 import com.noop.data.HrRow
 import com.noop.data.InsertCounts
 import com.noop.data.RrRow
+import com.noop.data.StandardHrMapping
 import com.noop.data.StreamBatch
 import com.noop.polar.PolarModel
+import com.noop.protocol.StandardHrContact
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -165,7 +167,12 @@ class StandardHrSource(
 
     // MARK: - Sample buffer (flushed in batches off the per-notification hot loop)
 
-    private data class Sample(val hr: Int, val rr: List<Int>, val ts: Long)
+    private data class Sample(
+        val hr: Int,
+        val rr: List<Int>,
+        val contact: StandardHrContact,
+        val ts: Long,
+    )
     private val bufferLock = Any()
     private val buffer = ArrayList<Sample>()
     private var lastFlushMs = System.currentTimeMillis()
@@ -267,9 +274,9 @@ class StandardHrSource(
 
     // MARK: - Buffer / persistence
 
-    private fun enqueue(hr: Int, rr: List<Int>) {
+    private fun enqueue(hr: Int, rr: List<Int>, contact: StandardHrContact) {
         val shouldFlush = synchronized(bufferLock) {
-            buffer.add(Sample(hr, rr, System.currentTimeMillis() / 1000L))
+            buffer.add(Sample(hr, rr, contact, System.currentTimeMillis() / 1000L))
             buffer.size >= flushCount ||
                 System.currentTimeMillis() - lastFlushMs >= flushIntervalMs
         }
@@ -301,9 +308,10 @@ class StandardHrSource(
             val s = ArrayList(buffer); buffer.clear(); s
         }
         val (hrRows, rrRows) = rowsOf(snapshot)
-        if (hrRows.isEmpty() && rrRows.isEmpty()) return
+        val contactEvents = snapshot.map { StandardHrMapping.contactEvent(it.ts, it.contact) }
+        if (hrRows.isEmpty() && rrRows.isEmpty() && contactEvents.isEmpty()) return
         log(standardHrFlushAttemptLine(reason.raw, hrRows.size, rrRows.size))
-        persist(StreamBatch(hr = hrRows, rr = rrRows), deviceId) { result ->
+        persist(StreamBatch(hr = hrRows, rr = rrRows, events = contactEvents), deviceId) { result ->
             result.fold(
                 onSuccess = { counts ->
                     insertFailures.set(0)
@@ -602,7 +610,7 @@ class StandardHrSource(
         }
         // Surface live HR on the main looper (the UI's StateFlow expects main-thread updates).
         handler.post { guardedCallback("live-sink") { liveSink(parsed.hr, parsed.rr) } }
-        enqueue(parsed.hr, parsed.rr)
+        enqueue(parsed.hr, parsed.rr, parsed.contact)
     }
 
     companion object {

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -27,6 +27,8 @@ import android.util.Log
 import com.noop.NoopApplication
 import com.noop.data.HrRow
 import com.noop.data.RrRow
+import com.noop.data.EventEntry
+import com.noop.data.StandardHrMapping
 import com.noop.data.StreamBatch
 import com.noop.data.StreamPersistence
 import com.noop.protocol.Whoop5RawImu
@@ -54,6 +56,7 @@ import com.noop.protocol.Reassembler
 import com.noop.protocol.Whoop5Variant
 import com.noop.protocol.RebootProbeVariant
 import com.noop.protocol.Streams
+import com.noop.protocol.StandardHrContact
 import com.noop.protocol.Whoop5Config
 import com.noop.protocol.extractStreams
 import com.noop.protocol.WhoopGattServiceFamily
@@ -416,6 +419,12 @@ data class GroundTruthImuStatus(
     val lastPacketAtMs: Long? = null,
     val note: String = "Not started",
 )
+
+internal fun standardHrBufferReachedFlushThreshold(
+    hrCount: Int,
+    rrCount: Int,
+    contactCount: Int,
+): Boolean = hrCount + rrCount + contactCount >= 30
 
 class WhoopBleClient(
     private val context: Context,
@@ -3214,9 +3223,10 @@ class WhoopBleClient(
     private val liveBuffer = ArrayList<Pair<ByteArray, com.noop.protocol.ParsedFrame>>()
     private var batchStartedAtMs = System.currentTimeMillis()
 
-    /** Standard 0x2A37 HR/RR buffer — the reliable, always-on stream (port of Collector.stdHR/stdRR). */
+    /** Standard 0x2A37 HR/RR/contact buffer — the reliable, always-on stream. */
     private val stdHr = ArrayList<HrRow>()
     private val stdRr = ArrayList<RrRow>()
+    private val stdContact = ArrayList<EventEntry>()
 
     // --- Offload frame drain (preserves START/data/END arrival order; port of routeBackfillFrame) ---
 
@@ -7407,6 +7417,7 @@ class WhoopBleClient(
         val flags = data[0].toInt() and 0xFF
         val hr16 = (flags and 0x01) != 0
         val rrPresent = (flags and 0x10) != 0
+        val contact = StandardHrContact.fromMeasurementFlags(flags)
 
         var idx = 1
         val hr: Int
@@ -7460,7 +7471,7 @@ class WhoopBleClient(
 
         // Record it continuously — independent of the realtime stream or which screen is open.
         // Port of BLEManager.parseStandardHR -> collector.ingestStandardHR(hr:rr:at:).
-        ingestStandardHr(hr, rr, (System.currentTimeMillis() / 1000L))
+        ingestStandardHr(hr, rr, contact, (System.currentTimeMillis() / 1000L))
     }
 
     /** The Test Centre gate, bound once to the app's single "noop_testcentre" prefs file. Lazily built so
@@ -8889,22 +8900,24 @@ class WhoopBleClient(
      * Buffer one standard 0x2A37 reading (carries a wall-clock ts directly, no clock ref needed).
      * Auto-flushes ~every 30 readings. Port of `Collector.ingestStandardHR`.
      */
-    private fun ingestStandardHr(hr: Int, rr: List<Int>, ts: Long) {
+    private fun ingestStandardHr(hr: Int, rr: List<Int>, contact: StandardHrContact, ts: Long) {
         val shouldFlush = synchronized(collectorLock) {
             if (hr in 30..220) stdHr.add(HrRow(ts, hr))
             for (r in rr) if (r in 250..3000) stdRr.add(RrRow(ts, r))
-            stdHr.size + stdRr.size >= 30
+            stdContact.add(StandardHrMapping.contactEvent(ts, contact))
+            standardHrBufferReachedFlushThreshold(stdHr.size, stdRr.size, stdContact.size)
         }
         if (shouldFlush) ioScope.launch { flushStandardHr() }
     }
 
     /** Persist the buffered standard HR/RR. Re-buffers on failure. Port of `Collector.flushStandardHR`. */
     private suspend fun flushStandardHr() {
-        val (hr, rr) = synchronized(collectorLock) {
-            if (stdHr.isEmpty() && stdRr.isEmpty()) return
+        val (hr, rr, contact) = synchronized(collectorLock) {
+            if (stdHr.isEmpty() && stdRr.isEmpty() && stdContact.isEmpty()) return
             val h = ArrayList(stdHr); val r = ArrayList(stdRr)
-            stdHr.clear(); stdRr.clear()
-            h to r
+            val c = ArrayList(stdContact)
+            stdHr.clear(); stdRr.clear(); stdContact.clear()
+            Triple(h, r, c)
         }
         // #1118: census this batch BEFORE it is stored, exactly as the historical path does, so a
         // strap log carries one `ratioRep` per transport. If each transport reports ~1.0 while the
@@ -8921,10 +8934,12 @@ class WhoopBleClient(
             }
         }
         try {
-            repository.insert(StreamBatch(hr = hr, rr = rr), deviceId)
+            repository.insert(StreamBatch(hr = hr, rr = rr, events = contact), deviceId)
             liveInsertFailuresStd.set(0)
         } catch (t: Throwable) {
-            synchronized(collectorLock) { stdHr.addAll(0, hr); stdRr.addAll(0, rr) }
+            synchronized(collectorLock) {
+                stdHr.addAll(0, hr); stdRr.addAll(0, rr); stdContact.addAll(0, contact)
+            }
             // Swallowing this made the instrumentation above read like success: a store failing every
             // insert produced a log full of `rr emit ... offered=N` and no sign that none of it landed.
             val runLength = liveInsertFailuresStd.incrementAndGet()

--- a/android/app/src/main/java/com/noop/data/StandardHrMapping.kt
+++ b/android/app/src/main/java/com/noop/data/StandardHrMapping.kt
@@ -1,6 +1,7 @@
 package com.noop.data
 
 import com.noop.protocol.StandardHrContact
+import org.json.JSONObject
 
 /** Durable mapping for standard-BLE contact readings; legacy HR rows have no companion event. */
 object StandardHrMapping {
@@ -12,12 +13,16 @@ object StandardHrMapping {
         payloadJSON = "{\"contact\":\"${contact.storageValue}\"}",
     )
 
-    fun contactSample(row: EventRow): StandardHrContactSample? {
-        val prefix = "{\"contact\":\""
-        val suffix = "\"}"
-        if (!row.payloadJSON.startsWith(prefix) || !row.payloadJSON.endsWith(suffix)) return null
-        val raw = row.payloadJSON.substring(prefix.length, row.payloadJSON.length - suffix.length)
-        return StandardHrContact.fromStorageValue(raw)?.let { StandardHrContactSample(row.ts, it) }
+    /**
+     * Parse a persisted [CONTACT_EVENT_KIND] [EventRow.payloadJSON]. Throws [org.json.JSONException]
+     * (or [IllegalArgumentException] for an unknown value) so a parse failure is not the same as
+     * "no contact event" — absence is an empty query, not a skipped row.
+     */
+    fun contactSample(row: EventRow): StandardHrContactSample {
+        val raw = JSONObject(row.payloadJSON).getString("contact")
+        val contact = StandardHrContact.fromStorageValue(raw)
+            ?: throw IllegalArgumentException("unknown STANDARD_HR_CONTACT value: $raw")
+        return StandardHrContactSample(row.ts, contact)
     }
 }
 

--- a/android/app/src/main/java/com/noop/data/StandardHrMapping.kt
+++ b/android/app/src/main/java/com/noop/data/StandardHrMapping.kt
@@ -1,0 +1,24 @@
+package com.noop.data
+
+import com.noop.protocol.StandardHrContact
+
+/** Durable mapping for standard-BLE contact readings; legacy HR rows have no companion event. */
+object StandardHrMapping {
+    const val CONTACT_EVENT_KIND = "STANDARD_HR_CONTACT"
+
+    fun contactEvent(ts: Long, contact: StandardHrContact): EventEntry = EventEntry(
+        ts = ts,
+        kind = CONTACT_EVENT_KIND,
+        payloadJSON = "{\"contact\":\"${contact.storageValue}\"}",
+    )
+
+    fun contactSample(row: EventRow): StandardHrContactSample? {
+        val prefix = "{\"contact\":\""
+        val suffix = "\"}"
+        if (!row.payloadJSON.startsWith(prefix) || !row.payloadJSON.endsWith(suffix)) return null
+        val raw = row.payloadJSON.substring(prefix.length, row.payloadJSON.length - suffix.length)
+        return StandardHrContact.fromStorageValue(raw)?.let { StandardHrContactSample(row.ts, it) }
+    }
+}
+
+data class StandardHrContactSample(val ts: Long, val contact: StandardHrContact)

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -458,6 +458,18 @@ interface WhoopDao : DeviceRegistryDao {
     suspend fun events(deviceId: String, from: Long, to: Long, limit: Int): List<EventRow>
 
     @Query(
+        "SELECT * FROM event WHERE deviceId = :deviceId AND kind = :kind " +
+            "AND ts >= :from AND ts <= :to ORDER BY ts ASC LIMIT :limit"
+    )
+    suspend fun eventsByKind(
+        deviceId: String,
+        kind: String,
+        from: Long,
+        to: Long,
+        limit: Int,
+    ): List<EventRow>
+
+    @Query(
         "SELECT * FROM battery WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to " +
             "ORDER BY ts ASC LIMIT :limit"
     )

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1159,6 +1159,16 @@ class WhoopRepository(
     suspend fun events(deviceId: String, from: Long, to: Long, limit: Int = DEFAULT_LIMIT) =
         dao.events(deviceId, from, to, limit)
 
+    /** Standard-BLE contact readings only; legacy HR rows have no companion event and stay absent. */
+    suspend fun standardHrContacts(
+        deviceId: String,
+        from: Long,
+        to: Long,
+        limit: Int = DEFAULT_LIMIT,
+    ): List<StandardHrContactSample> = dao.eventsByKind(
+        deviceId, StandardHrMapping.CONTACT_EVENT_KIND, from, to, limit,
+    ).mapNotNull(StandardHrMapping::contactSample)
+
     suspend fun batterySamples(deviceId: String, from: Long, to: Long, limit: Int = DEFAULT_LIMIT) =
         dao.batterySamples(deviceId, from, to, limit)
 

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1167,7 +1167,7 @@ class WhoopRepository(
         limit: Int = DEFAULT_LIMIT,
     ): List<StandardHrContactSample> = dao.eventsByKind(
         deviceId, StandardHrMapping.CONTACT_EVENT_KIND, from, to, limit,
-    ).mapNotNull(StandardHrMapping::contactSample)
+    ).map(StandardHrMapping::contactSample)
 
     suspend fun batterySamples(deviceId: String, from: Long, to: Long, limit: Int = DEFAULT_LIMIT) =
         dao.batterySamples(deviceId, from, to, limit)

--- a/android/app/src/main/java/com/noop/protocol/Streams.kt
+++ b/android/app/src/main/java/com/noop/protocol/Streams.kt
@@ -1,5 +1,26 @@
 package com.noop.protocol
 
+/** Sensor-contact state carried by the standard BLE Heart Rate Measurement flags. */
+enum class StandardHrContact(val storageValue: String) {
+    UNSUPPORTED("unsupported"),
+    SUPPORTED_NOT_DETECTED("supported_not_detected"),
+    SUPPORTED_DETECTED("supported_detected"),
+
+    ;
+
+    companion object {
+        fun fromMeasurementFlags(flags: Int): StandardHrContact = when {
+            flags and 0x04 == 0 -> UNSUPPORTED
+            flags and 0x02 == 0 -> SUPPORTED_NOT_DETECTED
+            else -> SUPPORTED_DETECTED
+        }
+
+        fun fromStorageValue(value: String): StandardHrContact? = entries.firstOrNull {
+            it.storageValue == value
+        }
+    }
+}
+
 /**
  * Decoded stream rows — the durable, compact local record produced from parsed frames.
  *

--- a/android/app/src/test/java/com/noop/ble/StandardHeartRateTest.kt
+++ b/android/app/src/test/java/com/noop/ble/StandardHeartRateTest.kt
@@ -1,5 +1,6 @@
 package com.noop.ble
 
+import com.noop.protocol.StandardHrContact
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -15,6 +16,30 @@ import org.junit.Test
 class StandardHeartRateTest {
 
     private fun bytes(vararg v: Int): ByteArray = ByteArray(v.size) { v[it].toByte() }
+
+    @Test
+    fun contactOnlyBufferReachesFlushThreshold() {
+        assertTrue(standardHrBufferReachedFlushThreshold(
+            hrCount = 0,
+            rrCount = 0,
+            contactCount = 30,
+        ))
+    }
+
+    @Test
+    fun contactFlagsCoverAllCombinations() {
+        val cases = listOf(
+            0x00 to StandardHrContact.UNSUPPORTED,
+            0x02 to StandardHrContact.UNSUPPORTED,
+            0x04 to StandardHrContact.SUPPORTED_NOT_DETECTED,
+            0x06 to StandardHrContact.SUPPORTED_DETECTED,
+        )
+
+        for ((flags, expected) in cases) {
+            assertEquals("flags 0x${flags.toString(16)}", expected,
+                StandardHeartRate.parse(bytes(flags, 72))!!.contact)
+        }
+    }
 
     @Test
     fun eightBitHrNoRr() {

--- a/android/app/src/test/java/com/noop/data/StandardHrMappingTest.kt
+++ b/android/app/src/test/java/com/noop/data/StandardHrMappingTest.kt
@@ -1,7 +1,9 @@
 package com.noop.data
 
 import com.noop.protocol.StandardHrContact
+import org.json.JSONException
 import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
 import org.junit.Test
 
 class StandardHrMappingTest {
@@ -21,17 +23,38 @@ class StandardHrMappingTest {
     }
 
     @Test
-    fun contactReadDecodesTypedValueAndRejectsMalformedRows() {
+    fun contactReadParsesPayloadJsonRegardlessOfKeyOrder() {
+        val row = EventRow(
+            deviceId = "whoop-5",
+            ts = 1_750_000_001L,
+            kind = StandardHrMapping.CONTACT_EVENT_KIND,
+            payloadJSON = "{\"extra\":true,\"contact\":\"supported_detected\"}",
+        )
+        assertEquals(
+            StandardHrContactSample(1_750_000_001L, StandardHrContact.SUPPORTED_DETECTED),
+            StandardHrMapping.contactSample(row),
+        )
+    }
+
+    @Test
+    fun invalidPayloadJsonIsParseFailureNotAbsence() {
         val row = EventRow(
             deviceId = "whoop-5",
             ts = 1_750_000_001L,
             kind = StandardHrMapping.CONTACT_EVENT_KIND,
             payloadJSON = "{\"contact\":\"supported_detected\"}",
         )
-        assertEquals(
-            StandardHrContactSample(1_750_000_001L, StandardHrContact.SUPPORTED_DETECTED),
-            StandardHrMapping.contactSample(row),
-        )
-        assertEquals(null, StandardHrMapping.contactSample(row.copy(payloadJSON = "{}")))
+        try {
+            StandardHrMapping.contactSample(row.copy(payloadJSON = "not-json"))
+            fail("expected parse failure")
+        } catch (e: JSONException) {
+            // parse failure must not collapse into "no contact event"
+        }
+        try {
+            StandardHrMapping.contactSample(row.copy(payloadJSON = "{}"))
+            fail("expected parse failure")
+        } catch (e: JSONException) {
+            // missing contact key is a parse failure, not legacy absence
+        }
     }
 }

--- a/android/app/src/test/java/com/noop/data/StandardHrMappingTest.kt
+++ b/android/app/src/test/java/com/noop/data/StandardHrMappingTest.kt
@@ -1,0 +1,37 @@
+package com.noop.data
+
+import com.noop.protocol.StandardHrContact
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StandardHrMappingTest {
+    @Test
+    fun contactUsesSwiftParityEventShape() {
+        assertEquals(
+            EventEntry(
+                ts = 1_750_000_000L,
+                kind = "STANDARD_HR_CONTACT",
+                payloadJSON = "{\"contact\":\"supported_not_detected\"}",
+            ),
+            StandardHrMapping.contactEvent(
+                1_750_000_000L,
+                StandardHrContact.SUPPORTED_NOT_DETECTED,
+            ),
+        )
+    }
+
+    @Test
+    fun contactReadDecodesTypedValueAndRejectsMalformedRows() {
+        val row = EventRow(
+            deviceId = "whoop-5",
+            ts = 1_750_000_001L,
+            kind = StandardHrMapping.CONTACT_EVENT_KIND,
+            payloadJSON = "{\"contact\":\"supported_detected\"}",
+        )
+        assertEquals(
+            StandardHrContactSample(1_750_000_001L, StandardHrContact.SUPPORTED_DETECTED),
+            StandardHrMapping.contactSample(row),
+        )
+        assertEquals(null, StandardHrMapping.contactSample(row.copy(payloadJSON = "{}")))
+    }
+}


### PR DESCRIPTION
## What this PR does

Preserves standard BLE Heart Rate Measurement (`0x2A37`) sensor-contact state end to end on Apple and Android.

- Decodes the three semantic states: unsupported, supported/not detected, and supported/detected.
- Carries contact through both the generic standard-HR source and primary WHOOP collector path.
- Persists contact as a stable `STANDARD_HR_CONTACT` event beside existing HR/R-R rows.
- Adds typed Apple and Android read APIs.
- Keeps legacy HR rows honest: no contact event means contact remains absent, not guessed.
- Re-buffers contact events with HR/R-R after persistence failures.

## Why

The BLE characteristic already carries contact support/detection flags, but the prior model discarded them. Preserving the state lets downstream code distinguish a supported sensor with no detected contact from an unsupported sensor without changing existing HR storage.

## Validation

- RED: test-only patch on upstream base failed because contact model/mapping/read APIs were absent.
- `swift test` in `Packages/WhoopProtocol` — 647 passed, 1 skipped.
- `swift test` in `Packages/WhoopStore` — 453 passed.
- `StandardHRMappingTests` — 6 passed, including insert/read and legacy absence.
- `swiftc -parse` on changed Apple app/test files — passed.
- `python3 Tools/doc_comment_lint.py` — passed.
- Targeted Android tests: `StandardHeartRateTest` and `StandardHrMappingTest` — passed.
- Full Android gate: `testFullDebugUnitTest assembleFullDebug` — `BUILD SUCCESSFUL`.
- Exact debug APK installed and read back on a Samsung SM-S938U running Android 16/API 36.
- Apple app-build workflow — unavailable because upstream currently marks `App build (macOS + iOS)` as `disabled_manually`.

## Hardware

Not run against a live WHOOP stream from this branch. Parser tests use deterministic `0x2A37` payloads; the exact APK was deployed to a real Android 16 phone, but no synthetic values are represented as live strap data.

## Scope / risk

No schema migration. Uses the existing event table and natural key. Existing HR/R-R callers remain source-compatible; legacy data is not backfilled with inferred contact.

## Checklist

- [x] Focused and full affected-package tests pass locally
- [x] Regression test fails on pre-fix behavior
- [x] Source-hygiene gate passes
- [x] Android full-flavor unit/build gate passes locally
- [ ] Upstream re-enables/runs the manually disabled Apple app-build workflow
- [x] All reported PR-head CI passes

Closes #1758
