### PR TITLE
Android standard-HR: stop losing a rejected batch in silence (#1770)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
+++ b/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
@@ -438,8 +438,11 @@ class SourceCoordinator(
                     context = ctx,
                     deviceId = id,
                     liveSink = liveSink,
-                    persist = { batch: StreamBatch, deviceId: String ->
-                        scope.launch { runCatching { repo.insert(batch, deviceId) } }
+                    // Hand the OUTCOME back. This was `runCatching { ... }` with no onFailure while the
+                    // source had already cleared its buffer, so a rejected batch vanished with the
+                    // surrounding log still reading like a healthy stream.
+                    persist = { batch: StreamBatch, deviceId: String, done ->
+                        scope.launch { done(runCatching { repo.insert(batch, deviceId) }) }
                     },
                     log = straplog,   // generic-HR lifecycle → the SAME exported strap log (issue #421)
                     onBattery = batterySink,  // strap battery → the same live state the WHOOP strap battery uses

--- a/android/app/src/main/java/com/noop/ble/StalledLinkDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/ble/StalledLinkDiagnostics.kt
@@ -118,6 +118,69 @@ internal fun backfillDeferredLine(
 }
 
 /**
+ * Standard-HR (0x2A37) transport-state lines — the Kotlin twins of Swift's `LivePersistTrace`
+ * (`Packages/StrandAnalytics`), byte-identical so an Android and an Apple log of the same stall compare
+ * directly. They live here, beside their caller, for the same reason [liveInsertFailedLine] does.
+ *
+ * They describe host observation and buffer/persistence state only. Nothing here carries a physiological
+ * measurement, and nothing claims a sensor-origin time: the BLE Heart Rate Measurement characteristic
+ * does not provide one, so a receipt time is the host's observation and is labelled as such.
+ *
+ * The pair that matters is offered vs inserted. [standardHrFlushAttemptLine] reports what was handed to
+ * the store and [standardHrFlushSucceededLine] what the store actually took, because a batch that is
+ * offered in full and inserted as zero is precisely the failure that otherwise reads like success.
+ */
+internal fun standardHrFlushAttemptLine(
+    reason: String,
+    offeredHrRows: Int,
+    offeredRrRows: Int,
+): String =
+    "standard-hr transport flush-attempt reason=$reason" +
+        " offeredHRRows=$offeredHrRows offeredRRRows=$offeredRrRows"
+
+/** Twin of Swift `LivePersistTrace.standardHRFlushSucceededLine`. */
+internal fun standardHrFlushSucceededLine(
+    reason: String,
+    offeredHrRows: Int,
+    offeredRrRows: Int,
+    insertedHrRows: Int,
+    insertedRrRows: Int,
+): String =
+    "standard-hr transport flush-succeeded reason=$reason" +
+        " offeredHRRows=$offeredHrRows offeredRRRows=$offeredRrRows" +
+        " insertedHRRows=$insertedHrRows insertedRRRows=$insertedRrRows"
+
+/** Twin of Swift `LivePersistTrace.standardHRRebufferedForRetryLine`. */
+internal fun standardHrRebufferedForRetryLine(
+    reason: String,
+    attemptedHrRows: Int,
+    attemptedRrRows: Int,
+    pendingHrRows: Int,
+    pendingRrRows: Int,
+    consecutiveFailures: Int,
+): String =
+    "standard-hr transport rebuffered-for-retry reason=$reason" +
+        " attemptedHRRows=$attemptedHrRows attemptedRRRows=$attemptedRrRows" +
+        " pendingHRRows=$pendingHrRows pendingRRRows=$pendingRrRows" +
+        " consecutiveFailures=$consecutiveFailures"
+
+/**
+ * Why a standard-HR flush ran. Twin of Swift's `LivePersistTrace.StandardHRFlushReason`, and the raw
+ * values must stay identical because they are what the log line carries.
+ *
+ * `background` and `termination` are Apple-only today: iOS suspends a connected strap without a
+ * disconnect edge, which Android's foreground service does not do. They exist here so the two enums do
+ * not drift, and so an Android answer to "should an OEM kill flush this buffer?" has a name already.
+ */
+internal enum class StandardHrFlushReason(val raw: String) {
+    CADENCE("cadence"),
+    DISCONNECT("disconnect"),
+    BACKGROUND("background"),
+    TERMINATION("termination"),
+    EXPLICIT("explicit"),
+}
+
+/**
  * A live HR/R-R batch failed to persist and was re-buffered.
  *
  * The catch that owns this re-queues the frames and swallows the throwable, so a store that is failing

--- a/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
+++ b/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
@@ -271,20 +271,31 @@ class StandardHrSource(
         if (shouldFlush) flush()
     }
 
+    /**
+     * The rows a set of buffered samples would offer, applying the SAME gates in one place.
+     *
+     * Mirrors `StandardHRMapping`: HrRow + RrRow only, HR range-gated so an off-wrist 0 is dropped, R-R
+     * gated to plausible beat-to-beat ms — matching `ingestStandardHr`. Shared with the re-buffer path
+     * deliberately: a pending count that applied different gates from the offered count would report two
+     * numbers that cannot be compared, in the one line whose job is comparing them.
+     */
+    private fun rowsOf(samples: List<Sample>): Pair<List<HrRow>, List<RrRow>> {
+        val hrRows = ArrayList<HrRow>()
+        val rrRows = ArrayList<RrRow>()
+        for (s in samples) {
+            if (s.hr in 30..220) hrRows.add(HrRow(s.ts, s.hr))
+            for (r in s.rr) if (r in 250..3000) rrRows.add(RrRow(s.ts, r))
+        }
+        return hrRows to rrRows
+    }
+
     private fun flush(reason: StandardHrFlushReason = StandardHrFlushReason.CADENCE) {
         val snapshot = synchronized(bufferLock) {
             lastFlushMs = System.currentTimeMillis()
             if (buffer.isEmpty()) return
             val s = ArrayList(buffer); buffer.clear(); s
         }
-        // Mirror StandardHRMapping: HrRow + RrRow only. HR is range-gated (off-wrist 0/garbage dropped);
-        // R-R is gated to physiologically plausible beat-to-beat ms, matching ingestStandardHr.
-        val hrRows = ArrayList<HrRow>()
-        val rrRows = ArrayList<RrRow>()
-        for (s in snapshot) {
-            if (s.hr in 30..220) hrRows.add(HrRow(s.ts, s.hr))
-            for (r in s.rr) if (r in 250..3000) rrRows.add(RrRow(s.ts, r))
-        }
+        val (hrRows, rrRows) = rowsOf(snapshot)
         if (hrRows.isEmpty() && rrRows.isEmpty()) return
         log(standardHrFlushAttemptLine(reason.raw, hrRows.size, rrRows.size))
         persist(StreamBatch(hr = hrRows, rr = rrRows), deviceId) { result ->
@@ -297,15 +308,16 @@ class StandardHrSource(
                     // Put the batch BACK, at the front, so the next flush retries it in order — the Swift
                     // Collector's `insert(contentsOf:at:0)`. Without this the rows were already gone the
                     // moment the snapshot was taken.
-                    val pending = synchronized(bufferLock) {
+                    val (pendingHr, pendingRr) = synchronized(bufferLock) {
                         buffer.addAll(0, snapshot)
-                        buffer.size
+                        val (h, r) = rowsOf(buffer)
+                        h.size to r.size
                     }
                     val runLength = insertFailures.incrementAndGet()
                     log(standardHrRebufferedForRetryLine(
                         reason = reason.raw,
                         attemptedHrRows = hrRows.size, attemptedRrRows = rrRows.size,
-                        pendingHrRows = pending, pendingRrRows = pending,
+                        pendingHrRows = pendingHr, pendingRrRows = pendingRr,
                         consecutiveFailures = runLength,
                     ))
                     // Rate-limited, and the SAME helper the WHOOP live path uses, so one strap log carries

--- a/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
+++ b/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
@@ -20,6 +20,7 @@ import android.os.Handler
 import android.os.Looper
 import android.os.ParcelUuid
 import com.noop.data.HrRow
+import com.noop.data.InsertCounts
 import com.noop.data.RrRow
 import com.noop.data.StreamBatch
 import com.noop.polar.PolarModel
@@ -57,9 +58,20 @@ class StandardHrSource(
     private val deviceId: String,
     /** Push live HR (bpm) + R-R (ms) into whatever the UI observes. Called on the main looper. */
     private val liveSink: (hr: Int, rr: List<Int>) -> Unit,
-    /** Persist a batch under [deviceId] — wired to `repository.insert`. Called off the main looper is
-     *  fine; the implementation hops to its own IO scope (see [SourceCoordinator]). */
-    private val persist: (StreamBatch, String) -> Unit,
+    /**
+     * Persist a batch under [deviceId] — wired to `repository.insert`. Called off the main looper is
+     * fine; the implementation hops to its own IO scope (see [SourceCoordinator]).
+     *
+     * Reports its OUTCOME through [done], and that is the point of the third parameter. The seam used to
+     * return Unit and the app wired it as `runCatching { repo.insert(...) }` with no onFailure, while
+     * [flush] had already cleared the buffer — so a store that rejected the batch lost those rows in
+     * silence, with the surrounding log reading exactly like a healthy stream. The Swift Collector
+     * re-buffers and retries; this could not, because it was never told.
+     *
+     * [InsertCounts] rather than a bare success flag: a batch offered in full and inserted as zero is
+     * the failure that most looks like success, and only the store's own count distinguishes it.
+     */
+    private val persist: (StreamBatch, String, (Result<InsertCounts>) -> Unit) -> Unit,
     /** Diagnostic sink for the connect lifecycle. Wired (via [SourceCoordinator]) to the SAME in-app strap
      *  log the user exports, so the generic-HR path is no longer invisible in a bug report (issue #421).
      *  Every line is prefixed "HR-strap: " so it's distinguishable from WHOOP lines in the shared log.
@@ -152,6 +164,13 @@ class StandardHrSource(
     private val bufferLock = Any()
     private val buffer = ArrayList<Sample>()
     private var lastFlushMs = System.currentTimeMillis()
+    /** Consecutive failed inserts, for the run-length the rate-limited failure line reports. Reset by a
+     *  success, exactly like the WHOOP path's counter. */
+    private val insertFailures = java.util.concurrent.atomic.AtomicInteger(0)
+
+    /** Last emission of [liveInsertFailedLine], for [shouldEmitLiveInsertFailure]'s one-a-minute gap. */
+    @Volatile private var lastInsertFailureLogMs = 0L
+
     private val flushCount = 30
     private val flushIntervalMs = 30_000L
 
@@ -229,7 +248,7 @@ class StandardHrSource(
         loggedFirstHr = false   // a later reconnect should log its first sample again
         loggedFirstSensor = false
         _batteryPct.value = null // a stale charge must not outlive the link
-        flush()
+        flush(StandardHrFlushReason.DISCONNECT)
         clearSensorState()       // a stale speed/cadence/power panel must not outlive the link
     }
 
@@ -252,7 +271,7 @@ class StandardHrSource(
         if (shouldFlush) flush()
     }
 
-    private fun flush() {
+    private fun flush(reason: StandardHrFlushReason = StandardHrFlushReason.CADENCE) {
         val snapshot = synchronized(bufferLock) {
             lastFlushMs = System.currentTimeMillis()
             if (buffer.isEmpty()) return
@@ -266,8 +285,45 @@ class StandardHrSource(
             if (s.hr in 30..220) hrRows.add(HrRow(s.ts, s.hr))
             for (r in s.rr) if (r in 250..3000) rrRows.add(RrRow(s.ts, r))
         }
-        if (hrRows.isNotEmpty() || rrRows.isNotEmpty()) {
-            persist(StreamBatch(hr = hrRows, rr = rrRows), deviceId)
+        if (hrRows.isEmpty() && rrRows.isEmpty()) return
+        log(standardHrFlushAttemptLine(reason.raw, hrRows.size, rrRows.size))
+        persist(StreamBatch(hr = hrRows, rr = rrRows), deviceId) { result ->
+            result.fold(
+                onSuccess = { counts ->
+                    insertFailures.set(0)
+                    log(standardHrFlushSucceededLine(reason.raw, hrRows.size, rrRows.size, counts.hr, counts.rr))
+                },
+                onFailure = { t ->
+                    // Put the batch BACK, at the front, so the next flush retries it in order — the Swift
+                    // Collector's `insert(contentsOf:at:0)`. Without this the rows were already gone the
+                    // moment the snapshot was taken.
+                    val pending = synchronized(bufferLock) {
+                        buffer.addAll(0, snapshot)
+                        buffer.size
+                    }
+                    val runLength = insertFailures.incrementAndGet()
+                    log(standardHrRebufferedForRetryLine(
+                        reason = reason.raw,
+                        attemptedHrRows = hrRows.size, attemptedRrRows = rrRows.size,
+                        pendingHrRows = pending, pendingRrRows = pending,
+                        consecutiveFailures = runLength,
+                    ))
+                    // Rate-limited, and the SAME helper the WHOOP live path uses, so one strap log carries
+                    // one shape of insert failure however it arrived.
+                    val nowMs = System.currentTimeMillis()
+                    if (shouldEmitLiveInsertFailure(lastInsertFailureLogMs, nowMs)) {
+                        lastInsertFailureLogMs = nowMs
+                        log(liveInsertFailedLine(
+                            transport = "standard-hr",
+                            throwableName = t.javaClass.simpleName,
+                            message = t.message,
+                            hrFrames = hrRows.size,
+                            rrFrames = rrRows.size,
+                            consecutiveFailures = runLength,
+                        ))
+                    }
+                },
+            )
         }
     }
 
@@ -324,7 +380,7 @@ class StandardHrSource(
                     loggedPolarIdentity = false
                     loggedFirstSensor = false
                     _batteryPct.value = null // a stale charge must not outlive the link
-                    flush()
+                    flush(StandardHrFlushReason.DISCONNECT)
                     clearSensorState()
                     if (gatt === g) { runCatching { g.close() }; gatt = null }
                     // Hardening: status 133 is Android's infamous generic GATT_ERROR on connect — almost

--- a/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
+++ b/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
@@ -70,6 +70,11 @@ class StandardHrSource(
      *
      * [InsertCounts] rather than a bare success flag: a batch offered in full and inserted as zero is
      * the failure that most looks like success, and only the store's own count distinguishes it.
+     *
+     * The re-buffer is only as good as [done] being called. The live wiring launches on a scope, and a
+     * scope cancelled before the body runs drops the batch with no line — the same loss the old
+     * `runCatching`-with-no-onFailure had, now narrowed to a cancelled teardown rather than every
+     * rejected insert. An implementation that can fail to answer should answer with a failure.
      */
     private val persist: (StreamBatch, String, (Result<InsertCounts>) -> Unit) -> Unit,
     /** Diagnostic sink for the connect lifecycle. Wired (via [SourceCoordinator]) to the SAME in-app strap

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -278,7 +278,8 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
             context = appContext,
             deviceId = "scan-preview",
             liveSink = { _, _ -> },
-            persist = { _, _ -> },
+            // Discovery-only scanner: nothing is persisted, so the outcome callback never fires.
+            persist = { _, _, _ -> },
             // Route the throwaway scanner's diagnostics into the SAME exported strap log the active path
             // uses (issue #421 parity), so a tester's wizard scan is captured. The source self-prefixes
             // "HR-strap: "; [externalLog] redacts addresses. Privacy-safe: statuses / counts only.

--- a/android/app/src/test/java/com/noop/ble/StalledLinkDiagnosticsTest.kt
+++ b/android/app/src/test/java/com/noop/ble/StalledLinkDiagnosticsTest.kt
@@ -334,4 +334,50 @@ class StalledLinkDiagnosticsTest {
         assertEquals(true, shouldEmitLiveInsertFailure(1L, 60_001L))
         assertEquals(false, shouldEmitLiveInsertFailure(1L, 30_000L))
     }
+    // Standard-HR transport lines — byte-identical twins of Swift's LivePersistTrace.
+
+    /**
+     * The expected strings are copied from the Swift `LivePersistTraceTests`, not regenerated from the
+     * Kotlin. That is the point: a twin asserted against its own implementation proves only that the
+     * implementation is self-consistent, and these two lines exist so an Android and an Apple log of the
+     * same stall compare directly.
+     */
+    @Test
+    fun `flush success separates offered from actually inserted rows`() {
+        assertEquals(
+            "standard-hr transport flush-attempt reason=cadence offeredHRRows=4 offeredRRRows=5",
+            standardHrFlushAttemptLine(StandardHrFlushReason.CADENCE.raw, 4, 5),
+        )
+        // Offered 4/5 and inserted 1/2 is the failure that reads like success: the batch was accepted by
+        // the call and mostly discarded by the store. Only the store's own count shows it.
+        assertEquals(
+            "standard-hr transport flush-succeeded reason=cadence offeredHRRows=4 offeredRRRows=5" +
+                " insertedHRRows=1 insertedRRRows=2",
+            standardHrFlushSucceededLine(StandardHrFlushReason.CADENCE.raw, 4, 5, 1, 2),
+        )
+    }
+
+    @Test
+    fun `retry names the lifecycle reason and the total pending rows`() {
+        assertEquals(
+            "standard-hr transport rebuffered-for-retry reason=disconnect" +
+                " attemptedHRRows=1 attemptedRRRows=2 pendingHRRows=3 pendingRRRows=4" +
+                " consecutiveFailures=1",
+            standardHrRebufferedForRetryLine(StandardHrFlushReason.DISCONNECT.raw, 1, 2, 3, 4, 1),
+        )
+    }
+
+    /**
+     * The raw values are what the log line carries, so they are the parity surface — not the enum's
+     * Kotlin spelling. background and termination have no Android emitter today (the foreground service
+     * gives no suspension edge); they exist so the two enums cannot drift apart before one does.
+     */
+    @Test
+    fun `the flush reasons match the Swift raw values exactly`() {
+        assertEquals(
+            listOf("cadence", "disconnect", "background", "termination", "explicit"),
+            StandardHrFlushReason.entries.map { it.raw },
+        )
+    }
+
 }


### PR DESCRIPTION
Item 1 of #1770. It did not stay a log-line port.

## What tracing the twin actually found

Looking for where the four Apple lines from #1767 would attach on Android found
that the behaviour they describe is missing. `StandardHrSource.flush()` snapshots
the buffer and **clears it**, then calls a persist seam the app wires as:

```kotlin
persist = { batch, deviceId -> scope.launch { runCatching { repo.insert(batch, deviceId) } } }
```

`runCatching` with no `onFailure`. The rows are already out of the buffer, so a
store that rejects the batch loses it **entirely** — and the surrounding log reads
exactly like a healthy stream. The Swift Collector re-buffers and retries. This
could not, because the seam returned `Unit` and never told it anything.

That is the failure shape #1767's own doc names as the worst kind: *"the
instrumentation that exists reads like success."*

## The change

The seam reports its outcome as `Result<InsertCounts>`, and the source re-buffers
the snapshot at the **front** on failure — Swift's `insert(contentsOf:at:0)`, so a
retry keeps order.

`InsertCounts` rather than a success flag on purpose: a batch offered in full and
inserted as zero is the failure that most looks like success, and only the store's
own count separates them. Android already had this plumbing (`WhoopRepository.insert`
returns it, the offload path uses it); the standard-HR seam was throwing it away.

With the behaviour in place, three lines have something true to say —
`standardHrFlushAttemptLine`, `standardHrFlushSucceededLine`,
`standardHrRebufferedForRetryLine`, byte-identical to Swift's. The failure itself
reuses `liveInsertFailedLine` and its one-a-minute rate limit, which Kotlin already
had and the WHOOP live path already uses, so one strap log carries one shape of
insert failure however it arrived.

## Deliberately not twinned

`standardHRHostReceivedLine`. Apple filters at **ingest** and buffers only accepted
rows; Android buffers raw samples and range-gates at **flush**. So
accepted/rejected/pending at ingest do not exist here without moving the filter —
which would change when the 30-sample trigger fires. That is a behaviour decision,
not a logging one, and it belongs in its own change rather than being smuggled in
under a parity heading.

`StandardHrFlushReason` carries `background` and `termination` with no Android
emitter, because the foreground service gives no suspension edge. They are present
so the two enums cannot drift before one grows a caller, and the **raw values** are
pinned against Swift's — the raw value is what the log carries, so it is the parity
surface, not the Kotlin spelling.

## Tests

The expected strings are copied from `LivePersistTraceTests`, not regenerated from
the Kotlin. A twin asserted against its own implementation proves only that the
implementation is self-consistent; these lines exist so two platforms' logs compare
directly, so the Swift text is the oracle.

Android 4971 unit tests, zero failures. `compileFullDebugKotlin`,
`doc_comment_lint.py` and `i18n_audit.py` clean by exit code.

## Scope / risk

No schema or migration change. One seam signature changed, with two construction
sites updated — the discovery-only scanner in `AppViewModel` (which persists
nothing, so its callback never fires) and the live one in `SourceCoordinator`. Two
other sources share the old lambda shape and are untouched; I checked, having first
edited the wrong one.

Not run against a live strap. The re-buffer path is exercised by the seam contract
rather than by hardware, and the retry itself lands on the next flush.

Refs #1770, #1767.
