### PR TITLE
Add an opt-in pre-sleep heart-rate feedback contract

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/PreSleepHeartRateFeedback.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/PreSleepHeartRateFeedback.swift
@@ -1,0 +1,242 @@
+import Foundation
+import WhoopProtocol
+import WhoopStore
+
+/// An opt-in, descriptive pre-sleep heart-rate reading for the following morning.
+///
+/// The caller supplies a timestamp-coalesced HR timeline: Repository's existing HR reads already
+/// coalesce measured and PPG-derived samples, with measured data taking precedence. This type selects
+/// the longest supplied sleep session, reads the declared half-open window immediately before it, and
+/// compares that observation with a personal rolling baseline. It neither diagnoses nor recommends an
+/// action. Journal answers are returned only as facts from the same day; one night cannot establish an
+/// association, so they never alter the reading or become an insight.
+public enum PreSleepHeartRateFeedback {
+    /// Baseline configuration deliberately shares the existing HR plausibility range while keeping a
+    /// small floor spread for transparent personal comparison. `rollingMeanSD` is the existing auditable
+    /// baseline primitive; this is not a new scoring model.
+    public static let baselineCfg = MetricCfg(minVal: SleepHeartRateContrast.validMinBpm,
+                                              maxVal: SleepHeartRateContrast.validMaxBpm,
+                                              floorSpread: 2,
+                                              halfLifeB: 14,
+                                              halfLifeS: 21)
+    public static let defaultPreSleepWindowSeconds = 30 * 60
+    public static let defaultMinimumValidSamples = 10
+    public static let minimumBaselineNights = Baselines.minNightsSeed
+
+    /// A prior eligible pre-sleep observation. Callers persist/assemble history; this pure slice does
+    /// not write, schedule a prompt, or penalize a missing night.
+    public struct HistoricalReading: Equatable, Sendable {
+        public let day: String
+        public let meanBpm: Double
+
+        public init(day: String, meanBpm: Double) {
+            self.day = day
+            self.meanBpm = meanBpm
+        }
+    }
+
+    /// Why a morning reading is or is not available. Every non-eligible state is recoverable on a
+    /// later, sufficiently covered night; none creates a streak, goal, or obligation.
+    public enum Eligibility: Equatable, Sendable {
+        case disabled
+        case invalidDay
+        case invalidWindow
+        case missingPrimarySleep
+        case insufficientPreSleepSamples(valid: Int, required: Int)
+        case insufficientBaseline(validNights: Int, required: Int)
+        case eligible
+    }
+
+    /// The observed, un-imputed pre-sleep data. Completeness is stated as a sample count because raw
+    /// HR cadence can vary; this slice does not pretend a count is a percentage of time covered.
+    public struct Observation: Equatable, Sendable {
+        public let primarySleepStartTs: Int
+        public let primarySleepEndTs: Int
+        public let windowStartTs: Int
+        public let windowEndTs: Int
+        public let meanBpm: Double
+        public let validSamples: Int
+        public let totalTimestampSamples: Int
+
+        public init(primarySleepStartTs: Int, primarySleepEndTs: Int,
+                    windowStartTs: Int, windowEndTs: Int, meanBpm: Double,
+                    validSamples: Int, totalTimestampSamples: Int) {
+            self.primarySleepStartTs = primarySleepStartTs
+            self.primarySleepEndTs = primarySleepEndTs
+            self.windowStartTs = windowStartTs
+            self.windowEndTs = windowEndTs
+            self.meanBpm = meanBpm
+            self.validSamples = validSamples
+            self.totalTimestampSamples = totalTimestampSamples
+        }
+    }
+
+    /// A personal comparison only, never a population norm or a health classification.
+    public struct Comparison: Equatable, Sendable {
+        public let baselineBpm: Double
+        public let deltaBpm: Double
+        public let baselineNights: Int
+        public let baselineStatus: BaselineStatus
+
+        public init(baselineBpm: Double, deltaBpm: Double, baselineNights: Int,
+                    baselineStatus: BaselineStatus) {
+            self.baselineBpm = baselineBpm
+            self.deltaBpm = deltaBpm
+            self.baselineNights = baselineNights
+            self.baselineStatus = baselineStatus
+        }
+    }
+
+    /// Explicit limits that a presentation layer must keep visible rather than turning into certainty.
+    public enum Uncertainty: Equatable, Sendable {
+        /// The first eligible personal baseline is usable but not yet trusted by `Baselines`.
+        case provisionalBaseline
+        /// There are not yet enough valid historical nights to make any personal comparison.
+        case noPersonalComparison
+    }
+
+    /// This slice intentionally makes no causal inference from a single observation or its journal facts.
+    public enum Inference: Equatable, Sendable { case notEstablished }
+    /// This slice intentionally cannot support a behavior, treatment, or other recommendation.
+    public enum Recommendation: Equatable, Sendable { case unsupported }
+
+    /// A projection of a same-day `JournalEntry`. It preserves what was logged without exposing notes or
+    /// claiming that the entry explains this reading.
+    public struct JournalFact: Equatable, Sendable {
+        public let day: String
+        public let question: String
+        public let answeredYes: Bool
+        public let numericValue: Double?
+
+        public init(day: String, question: String, answeredYes: Bool, numericValue: Double?) {
+            self.day = day
+            self.question = question
+            self.answeredYes = answeredYes
+            self.numericValue = numericValue
+        }
+    }
+
+    public struct Feedback: Equatable, Sendable {
+        public let eligibility: Eligibility
+        public let observation: Observation?
+        public let comparison: Comparison?
+        public let uncertainty: [Uncertainty]
+        public let inference: Inference
+        public let recommendation: Recommendation
+        /// Same-day journal facts only. They are deliberately not treated as a causal insight.
+        public let journalContext: [JournalFact]
+
+        public init(eligibility: Eligibility, observation: Observation?, comparison: Comparison?,
+                    uncertainty: [Uncertainty], inference: Inference,
+                    recommendation: Recommendation, journalContext: [JournalFact]) {
+            self.eligibility = eligibility
+            self.observation = observation
+            self.comparison = comparison
+            self.uncertainty = uncertainty
+            self.inference = inference
+            self.recommendation = recommendation
+            self.journalContext = journalContext
+        }
+    }
+
+    /// Produce the next-morning reading from existing timestamped HR and sleep primitives.
+    ///
+    /// `hr` is expected to be the repository's measured/PPG-coalesced timeline. To remain safe for other
+    /// callers, duplicate timestamps are also ignored after the first element, preserving the caller's
+    /// precedence order. Both window bounds are transparent and half-open: `[sleep.start - window, sleep.start)`.
+    public static func evaluate(enabled: Bool, sessions: [SleepSession], hr: [HRSample],
+                                history: [HistoricalReading], journalEntries: [JournalEntry], day: String,
+                                minimumValidSamples: Int = defaultMinimumValidSamples,
+                                preSleepWindowSeconds: Int = defaultPreSleepWindowSeconds) -> Feedback {
+        let unsupported = Recommendation.unsupported
+        let noInference = Inference.notEstablished
+        guard enabled else {
+            return Feedback(eligibility: .disabled, observation: nil, comparison: nil, uncertainty: [],
+                            inference: noInference, recommendation: unsupported, journalContext: [])
+        }
+        guard isCanonicalDay(day) else {
+            return Feedback(eligibility: .invalidDay, observation: nil, comparison: nil, uncertainty: [],
+                            inference: noInference, recommendation: unsupported, journalContext: [])
+        }
+        guard minimumValidSamples > 0, preSleepWindowSeconds > 0 else {
+            return Feedback(eligibility: .invalidWindow, observation: nil, comparison: nil, uncertainty: [],
+                            inference: noInference, recommendation: unsupported, journalContext: [])
+        }
+        let sessionsWithDuration = sessions.compactMap { session -> (session: SleepSession, duration: Int)? in
+            let (duration, overflow) = session.end.subtractingReportingOverflow(session.start)
+            return !overflow && duration > 0 ? (session, duration) : nil
+        }
+        guard let primary = sessionsWithDuration.max(by: { $0.duration < $1.duration })?.session else {
+            return Feedback(eligibility: .missingPrimarySleep, observation: nil, comparison: nil, uncertainty: [],
+                            inference: noInference, recommendation: unsupported, journalContext: [])
+        }
+
+        let (start, windowOverflow) = primary.start.subtractingReportingOverflow(preSleepWindowSeconds)
+        guard !windowOverflow else {
+            return Feedback(eligibility: .invalidWindow, observation: nil, comparison: nil, uncertainty: [],
+                            inference: noInference, recommendation: unsupported, journalContext: [])
+        }
+        let inWindow = deduplicated(hr).filter { $0.ts >= start && $0.ts < primary.start }
+        let valid = inWindow.filter { baselineCfg.minVal <= Double($0.bpm) && Double($0.bpm) <= baselineCfg.maxVal }
+        guard valid.count >= minimumValidSamples else {
+            return Feedback(eligibility: .insufficientPreSleepSamples(valid: valid.count, required: minimumValidSamples),
+                            observation: nil, comparison: nil, uncertainty: [], inference: noInference,
+                            recommendation: unsupported, journalContext: [])
+        }
+        let mean = Double(valid.reduce(0) { $0 + $1.bpm }) / Double(valid.count)
+        let observation = Observation(primarySleepStartTs: primary.start, primarySleepEndTs: primary.end,
+                                      windowStartTs: start, windowEndTs: primary.start, meanBpm: mean,
+                                      validSamples: valid.count, totalTimestampSamples: inWindow.count)
+        // Canonical local day keys sort chronologically. Baselines use prior nights only and
+        // `rollingMeanSD` requires oldest-to-newest input. Retain the first caller-supplied reading
+        // for a repeated canonical day; one day contributes at most one night and no synthetic average
+        // is invented.
+        var seenDays = Set<String>()
+        let priorHistory = history
+            .filter { isCanonicalDay($0.day) && $0.day < day && seenDays.insert($0.day).inserted }
+            .sorted { $0.day < $1.day }
+        let baseline = Baselines.rollingMeanSD(priorHistory.map(\.meanBpm), cfg: baselineCfg)
+        let context = journalEntries.filter { $0.day == day }.map {
+            JournalFact(day: $0.day, question: $0.question, answeredYes: $0.answeredYes,
+                        numericValue: $0.numericValue)
+        }
+        guard baseline.nValid >= minimumBaselineNights else {
+            return Feedback(eligibility: .insufficientBaseline(validNights: baseline.nValid,
+                                                                 required: minimumBaselineNights),
+                            observation: observation, comparison: nil, uncertainty: [.noPersonalComparison],
+                            inference: noInference, recommendation: unsupported, journalContext: context)
+        }
+
+        let comparison = Comparison(baselineBpm: baseline.baseline, deltaBpm: mean - baseline.baseline,
+                                    baselineNights: baseline.nValid, baselineStatus: baseline.status)
+        let uncertainty: [Uncertainty] = baseline.status == .trusted ? [] : [.provisionalBaseline]
+        return Feedback(eligibility: .eligible, observation: observation, comparison: comparison,
+                        uncertainty: uncertainty, inference: noInference, recommendation: unsupported,
+                        journalContext: context)
+    }
+
+    private static func isCanonicalDay(_ day: String) -> Bool {
+        let bytes = Array(day.utf8)
+        guard bytes.count == 10, bytes[4] == 45, bytes[7] == 45 else { return false }
+        let digitPositions = [0, 1, 2, 3, 5, 6, 8, 9]
+        guard digitPositions.allSatisfy({ (48...57).contains(bytes[$0]) }) else { return false }
+
+        let year = Int(bytes[0] - 48) * 1_000 + Int(bytes[1] - 48) * 100
+            + Int(bytes[2] - 48) * 10 + Int(bytes[3] - 48)
+        let month = Int(bytes[5] - 48) * 10 + Int(bytes[6] - 48)
+        let dayOfMonth = Int(bytes[8] - 48) * 10 + Int(bytes[9] - 48)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        guard let date = calendar.date(from: DateComponents(year: year, month: month, day: dayOfMonth)) else {
+            return false
+        }
+        let roundTrip = calendar.dateComponents([.era, .year, .month, .day], from: date)
+        return roundTrip.era == 1 && roundTrip.year == year && roundTrip.month == month
+            && roundTrip.day == dayOfMonth
+    }
+
+    private static func deduplicated(_ hr: [HRSample]) -> [HRSample] {
+        var seen = Set<Int>()
+        return hr.filter { seen.insert($0.ts).inserted }
+    }
+}

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/PreSleepHeartRateFeedback.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/PreSleepHeartRateFeedback.swift
@@ -44,6 +44,7 @@ public enum PreSleepHeartRateFeedback {
         case missingPrimarySleep
         case insufficientPreSleepSamples(valid: Int, required: Int)
         case insufficientBaseline(validNights: Int, required: Int)
+        case staleBaseline(daysSinceUpdate: Int)
         case eligible
     }
 
@@ -93,6 +94,8 @@ public enum PreSleepHeartRateFeedback {
         case provisionalBaseline
         /// There are not yet enough valid historical nights to make any personal comparison.
         case noPersonalComparison
+        /// A mature personal baseline has not received a plausible value recently enough to compare.
+        case staleBaseline(daysSinceUpdate: Int)
     }
 
     /// This slice intentionally makes no causal inference from a single observation or its journal facts.
@@ -154,7 +157,7 @@ public enum PreSleepHeartRateFeedback {
             return Feedback(eligibility: .disabled, observation: nil, comparison: nil, uncertainty: [],
                             inference: noInference, recommendation: unsupported, journalContext: [])
         }
-        guard isCanonicalDay(day) else {
+        guard let evaluationDate = canonicalDay(day) else {
             return Feedback(eligibility: .invalidDay, observation: nil, comparison: nil, uncertainty: [],
                             inference: noInference, recommendation: unsupported, journalContext: [])
         }
@@ -187,15 +190,33 @@ public enum PreSleepHeartRateFeedback {
         let observation = Observation(primarySleepStartTs: primary.start, primarySleepEndTs: primary.end,
                                       windowStartTs: start, windowEndTs: primary.start, meanBpm: mean,
                                       validSamples: valid.count, totalTimestampSamples: inWindow.count)
-        // Canonical local day keys sort chronologically. Baselines use prior nights only and
+        // Baselines use prior nights only and
         // `rollingMeanSD` requires oldest-to-newest input. Retain the first caller-supplied reading
         // for a repeated canonical day; one day contributes at most one night and no synthetic average
         // is invented.
         var seenDays = Set<String>()
         let priorHistory = history
-            .filter { isCanonicalDay($0.day) && $0.day < day && seenDays.insert($0.day).inserted }
-            .sorted { $0.day < $1.day }
-        let baseline = Baselines.rollingMeanSD(priorHistory.map(\.meanBpm), cfg: baselineCfg)
+            .compactMap { reading -> (reading: HistoricalReading, date: Date)? in
+                guard let date = canonicalDay(reading.day), date < evaluationDate,
+                      seenDays.insert(reading.day).inserted else { return nil }
+                return (reading, date)
+            }
+            .sorted { $0.date < $1.date }
+        let rollingBaseline = Baselines.rollingMeanSD(priorHistory.map(\.reading.meanBpm), cfg: baselineCfg)
+        let latestContributingDate = priorHistory.last {
+            baselineCfg.minVal <= $0.reading.meanBpm && $0.reading.meanBpm <= baselineCfg.maxVal
+        }?.date
+        let nightsSinceUpdate = latestContributingDate.flatMap {
+            gregorianUTC.dateComponents([.day], from: $0, to: evaluationDate).day
+        }.map { max(0, $0) } ?? 0
+        let baseline = BaselineState(
+            baseline: rollingBaseline.baseline,
+            spread: rollingBaseline.spread,
+            nValid: rollingBaseline.nValid,
+            nightsSinceUpdate: nightsSinceUpdate,
+            status: Baselines.computeStatus(nValid: rollingBaseline.nValid,
+                                            nightsSinceUpdate: nightsSinceUpdate)
+        )
         let context = journalEntries.filter { $0.day == day }.map {
             JournalFact(day: $0.day, question: $0.question, answeredYes: $0.answeredYes,
                         numericValue: $0.numericValue)
@@ -204,6 +225,12 @@ public enum PreSleepHeartRateFeedback {
             return Feedback(eligibility: .insufficientBaseline(validNights: baseline.nValid,
                                                                  required: minimumBaselineNights),
                             observation: observation, comparison: nil, uncertainty: [.noPersonalComparison],
+                            inference: noInference, recommendation: unsupported, journalContext: context)
+        }
+        guard baseline.usable else {
+            return Feedback(eligibility: .staleBaseline(daysSinceUpdate: baseline.nightsSinceUpdate),
+                            observation: observation, comparison: nil,
+                            uncertainty: [.staleBaseline(daysSinceUpdate: baseline.nightsSinceUpdate)],
                             inference: noInference, recommendation: unsupported, journalContext: context)
         }
 
@@ -215,24 +242,30 @@ public enum PreSleepHeartRateFeedback {
                         journalContext: context)
     }
 
-    private static func isCanonicalDay(_ day: String) -> Bool {
+    private static var gregorianUTC: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    private static func canonicalDay(_ day: String) -> Date? {
         let bytes = Array(day.utf8)
-        guard bytes.count == 10, bytes[4] == 45, bytes[7] == 45 else { return false }
+        guard bytes.count == 10, bytes[4] == 45, bytes[7] == 45 else { return nil }
         let digitPositions = [0, 1, 2, 3, 5, 6, 8, 9]
-        guard digitPositions.allSatisfy({ (48...57).contains(bytes[$0]) }) else { return false }
+        guard digitPositions.allSatisfy({ (48...57).contains(bytes[$0]) }) else { return nil }
 
         let year = Int(bytes[0] - 48) * 1_000 + Int(bytes[1] - 48) * 100
             + Int(bytes[2] - 48) * 10 + Int(bytes[3] - 48)
         let month = Int(bytes[5] - 48) * 10 + Int(bytes[6] - 48)
         let dayOfMonth = Int(bytes[8] - 48) * 10 + Int(bytes[9] - 48)
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let calendar = gregorianUTC
         guard let date = calendar.date(from: DateComponents(year: year, month: month, day: dayOfMonth)) else {
-            return false
+            return nil
         }
         let roundTrip = calendar.dateComponents([.era, .year, .month, .day], from: date)
-        return roundTrip.era == 1 && roundTrip.year == year && roundTrip.month == month
-            && roundTrip.day == dayOfMonth
+        guard roundTrip.era == 1 && roundTrip.year == year && roundTrip.month == month
+            && roundTrip.day == dayOfMonth else { return nil }
+        return date
     }
 
     private static func deduplicated(_ hr: [HRSample]) -> [HRSample] {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/PreSleepHeartRateFeedbackTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/PreSleepHeartRateFeedbackTests.swift
@@ -65,6 +65,78 @@ final class PreSleepHeartRateFeedbackTests: XCTestCase {
         XCTAssertEqual(feedback.comparison?.baselineNights, 4)
     }
 
+    func testRecentImplausibleHistoryDoesNotRefreshMatureStaleBaseline() {
+        let sleep = SleepSession(start: 10_000, end: 36_000, efficiency: 0.9,
+                                 stages: [], restingHR: nil, avgHRV: nil)
+        var history = (1...14).map {
+            PreSleepHeartRateFeedback.HistoricalReading(
+                day: String(format: "2024-02-%02d", $0), meanBpm: 60
+            )
+        }
+        history += [
+            .init(day: "2024-02-28", meanBpm: .nan),
+            .init(day: "2024-02-28", meanBpm: 70),
+            .init(day: "2024-02-29", meanBpm: PreSleepHeartRateFeedback.baselineCfg.maxVal + 1),
+        ]
+
+        let journal = JournalEntry(day: "2024-03-01", question: "Late meal",
+                                   answeredYes: true, notes: nil)
+        let feedback = PreSleepHeartRateFeedback.evaluate(
+            enabled: true, sessions: [sleep], hr: samples(8_800, bpm: 70, count: 12),
+            history: history, journalEntries: [journal], day: "2024-03-01",
+            minimumValidSamples: 10, preSleepWindowSeconds: 1_800
+        )
+
+        XCTAssertEqual(feedback.eligibility, .staleBaseline(daysSinceUpdate: 16))
+        XCTAssertEqual(feedback.observation?.meanBpm, 70)
+        XCTAssertNil(feedback.comparison)
+        XCTAssertEqual(feedback.uncertainty, [.staleBaseline(daysSinceUpdate: 16)])
+        XCTAssertEqual(feedback.journalContext, [
+            .init(day: "2024-03-01", question: "Late meal", answeredYes: true, numericValue: nil)
+        ])
+    }
+
+    func testBaselineAtExactStaleDaysBoundaryRemainsTrustedAcrossYearBoundary() {
+        let sleep = SleepSession(start: 10_000, end: 36_000, efficiency: 0.9,
+                                 stages: [], restingHR: nil, avgHRV: nil)
+        let history = (1...13).map {
+            PreSleepHeartRateFeedback.HistoricalReading(
+                day: String(format: "2023-01-%02d", $0), meanBpm: 60
+            )
+        } + [.init(day: "2023-12-18", meanBpm: 60)]
+
+        let feedback = PreSleepHeartRateFeedback.evaluate(
+            enabled: true, sessions: [sleep], hr: samples(8_800, bpm: 70, count: 12),
+            history: history, journalEntries: [], day: "2024-01-01",
+            minimumValidSamples: 10, preSleepWindowSeconds: 1_800
+        )
+
+        XCTAssertEqual(feedback.eligibility, .eligible)
+        XCTAssertEqual(feedback.comparison?.baselineStatus, .trusted)
+        XCTAssertTrue(feedback.uncertainty.isEmpty)
+    }
+
+    func testBaselineOneDayPastStaleBoundaryIsExplicitlyStaleAcrossLeapDay() {
+        let sleep = SleepSession(start: 10_000, end: 36_000, efficiency: 0.9,
+                                 stages: [], restingHR: nil, avgHRV: nil)
+        let history = (1...13).map {
+            PreSleepHeartRateFeedback.HistoricalReading(
+                day: String(format: "2024-01-%02d", $0), meanBpm: 60
+            )
+        } + [.init(day: "2024-02-15", meanBpm: 60)]
+
+        let feedback = PreSleepHeartRateFeedback.evaluate(
+            enabled: true, sessions: [sleep], hr: samples(8_800, bpm: 70, count: 12),
+            history: history, journalEntries: [], day: "2024-03-01",
+            minimumValidSamples: 10, preSleepWindowSeconds: 1_800
+        )
+
+        XCTAssertEqual(feedback.eligibility, .staleBaseline(daysSinceUpdate: 15))
+        XCTAssertNotNil(feedback.observation)
+        XCTAssertNil(feedback.comparison)
+        XCTAssertEqual(feedback.uncertainty, [.staleBaseline(daysSinceUpdate: 15)])
+    }
+
     func testRepeatedPriorDayCannotSatisfyMinimumBaselineNights() {
         let sleep = SleepSession(start: 10_000, end: 36_000, efficiency: 0.9,
                                  stages: [], restingHR: nil, avgHRV: nil)

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/PreSleepHeartRateFeedbackTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/PreSleepHeartRateFeedbackTests.swift
@@ -1,0 +1,187 @@
+import XCTest
+@testable import StrandAnalytics
+import WhoopProtocol
+import WhoopStore
+
+final class PreSleepHeartRateFeedbackTests: XCTestCase {
+    private func samples(_ start: Int, bpm: Int, count: Int) -> [HRSample] {
+        (0..<count).map { HRSample(ts: start + $0 * 60, bpm: bpm) }
+    }
+
+    func testEligibleFeedbackSeparatesObservationComparisonUncertaintyAndUnsupportedRecommendation() {
+        let sleep = SleepSession(start: 10_000, end: 36_000, efficiency: 0.9,
+                                 stages: [], restingHR: nil, avgHRV: nil)
+        let history = [60.0, 61.0, 62.0, 63.0].enumerated().map {
+            PreSleepHeartRateFeedback.HistoricalReading(day: "2026-08-0\($0.offset + 1)", meanBpm: $0.element)
+        }
+        let journal = JournalEntry(day: "2026-08-05", question: "Late meal", answeredYes: true, notes: nil)
+        let feedback = PreSleepHeartRateFeedback.evaluate(
+            enabled: true,
+            sessions: [sleep],
+            hr: samples(8_800, bpm: 70, count: 12) + samples(10_000, bpm: 55, count: 12),
+            history: history,
+            journalEntries: [journal],
+            day: "2026-08-05",
+            minimumValidSamples: 10,
+            preSleepWindowSeconds: 1_800
+        )
+
+        XCTAssertEqual(feedback.eligibility, .eligible)
+        XCTAssertEqual(feedback.observation?.windowStartTs, 8_200)
+        XCTAssertEqual(feedback.observation?.windowEndTs, 10_000)
+        XCTAssertEqual(feedback.observation?.meanBpm, 70)
+        XCTAssertEqual(feedback.observation?.validSamples, 12)
+        XCTAssertEqual(feedback.comparison?.baselineBpm, 61.5)
+        XCTAssertEqual(feedback.comparison?.deltaBpm, 8.5)
+        XCTAssertEqual(feedback.comparison?.baselineStatus, .provisional)
+        XCTAssertEqual(feedback.uncertainty, [.provisionalBaseline])
+        XCTAssertEqual(feedback.inference, .notEstablished)
+        XCTAssertEqual(feedback.recommendation, .unsupported)
+        XCTAssertEqual(feedback.journalContext, [
+            PreSleepHeartRateFeedback.JournalFact(day: "2026-08-05", question: "Late meal",
+                                                   answeredYes: true, numericValue: nil)
+        ])
+    }
+
+    func testBaselineUsesOnlySortedPriorNights() {
+        let sleep = SleepSession(start: 10_000, end: 36_000, efficiency: 0.9,
+                                 stages: [], restingHR: nil, avgHRV: nil)
+        let history = [
+            PreSleepHeartRateFeedback.HistoricalReading(day: "2026-08-01", meanBpm: 60),
+            PreSleepHeartRateFeedback.HistoricalReading(day: "2026-08-04", meanBpm: 63),
+            PreSleepHeartRateFeedback.HistoricalReading(day: "2026-08-02", meanBpm: 61),
+            PreSleepHeartRateFeedback.HistoricalReading(day: "2026-08-03", meanBpm: 62),
+            PreSleepHeartRateFeedback.HistoricalReading(day: "2026-08-05", meanBpm: 90),
+            PreSleepHeartRateFeedback.HistoricalReading(day: "2026-08-06", meanBpm: 100),
+        ]
+
+        let feedback = PreSleepHeartRateFeedback.evaluate(
+            enabled: true, sessions: [sleep], hr: samples(8_800, bpm: 70, count: 12),
+            history: history, journalEntries: [], day: "2026-08-05",
+            minimumValidSamples: 10, preSleepWindowSeconds: 1_800
+        )
+
+        XCTAssertEqual(feedback.comparison?.baselineBpm, 61.5)
+        XCTAssertEqual(feedback.comparison?.baselineNights, 4)
+    }
+
+    func testRepeatedPriorDayCannotSatisfyMinimumBaselineNights() {
+        let sleep = SleepSession(start: 10_000, end: 36_000, efficiency: 0.9,
+                                 stages: [], restingHR: nil, avgHRV: nil)
+        let history = [60.0, 61.0, 62.0, 63.0].map {
+            PreSleepHeartRateFeedback.HistoricalReading(day: "2026-08-04", meanBpm: $0)
+        }
+
+        let feedback = PreSleepHeartRateFeedback.evaluate(
+            enabled: true, sessions: [sleep], hr: samples(8_800, bpm: 70, count: 12),
+            history: history, journalEntries: [], day: "2026-08-05",
+            minimumValidSamples: 10, preSleepWindowSeconds: 1_800
+        )
+
+        XCTAssertEqual(feedback.eligibility, .insufficientBaseline(validNights: 1, required: 4))
+        XCTAssertNil(feedback.comparison)
+    }
+
+    func testNoncanonicalAndImpossibleDaysCannotSatisfyMinimumBaselineNights() {
+        let sleep = SleepSession(start: 10_000, end: 36_000, efficiency: 0.9,
+                                 stages: [], restingHR: nil, avgHRV: nil)
+        let history = [
+            PreSleepHeartRateFeedback.HistoricalReading(day: "2026-08-01", meanBpm: 60),
+            PreSleepHeartRateFeedback.HistoricalReading(day: "2026-08-02", meanBpm: 61),
+            PreSleepHeartRateFeedback.HistoricalReading(day: "2026-08-04Z", meanBpm: 62),
+            PreSleepHeartRateFeedback.HistoricalReading(day: "2026-02-31", meanBpm: 63),
+        ]
+
+        let feedback = PreSleepHeartRateFeedback.evaluate(
+            enabled: true, sessions: [sleep], hr: samples(8_800, bpm: 70, count: 12),
+            history: history, journalEntries: [], day: "2026-08-05",
+            minimumValidSamples: 10, preSleepWindowSeconds: 1_800
+        )
+
+        XCTAssertEqual(feedback.eligibility, .insufficientBaseline(validNights: 2, required: 4))
+        XCTAssertNil(feedback.comparison)
+    }
+
+    func testInvalidEvaluationDaysCannotProduceFeedback() {
+        let sleep = SleepSession(start: 10_000, end: 36_000, efficiency: 0.9,
+                                 stages: [], restingHR: nil, avgHRV: nil)
+        let cases = [
+            (day: "2026-08-05Z", historyDays: ["2026-08-02", "2026-08-03", "2026-08-04", "2026-08-05"]),
+            (day: "2026-02-31", historyDays: ["2026-02-27", "2026-02-28", "2026-03-01", "2026-03-02"]),
+        ]
+
+        for testCase in cases {
+            let history = testCase.historyDays.map {
+                PreSleepHeartRateFeedback.HistoricalReading(day: $0, meanBpm: 60)
+            }
+            let journal = JournalEntry(day: testCase.day, question: "Late meal", answeredYes: true, notes: nil)
+            let feedback = PreSleepHeartRateFeedback.evaluate(
+                enabled: true, sessions: [sleep], hr: samples(8_800, bpm: 70, count: 12),
+                history: history, journalEntries: [journal], day: testCase.day,
+                minimumValidSamples: 10, preSleepWindowSeconds: 1_800
+            )
+
+            XCTAssertEqual(feedback.eligibility, .invalidDay)
+            XCTAssertNil(feedback.observation)
+            XCTAssertNil(feedback.comparison)
+            XCTAssertTrue(feedback.uncertainty.isEmpty)
+            XCTAssertTrue(feedback.journalContext.isEmpty)
+        }
+    }
+
+    func testExtremeSleepSessionDurationFailsClosedWithoutTrapping() {
+        let sleep = SleepSession(start: Int.min, end: Int.max, efficiency: 0.9,
+                                 stages: [], restingHR: nil, avgHRV: nil)
+        let otherSleep = SleepSession(start: Int.min, end: Int.max - 1, efficiency: 0.9,
+                                      stages: [], restingHR: nil, avgHRV: nil)
+
+        let feedback = PreSleepHeartRateFeedback.evaluate(
+            enabled: true, sessions: [sleep, otherSleep], hr: [], history: [], journalEntries: [],
+            day: "2026-08-05", minimumValidSamples: 1, preSleepWindowSeconds: 1
+        )
+
+        XCTAssertEqual(feedback.eligibility, .missingPrimarySleep)
+        XCTAssertNil(feedback.observation)
+    }
+
+    func testExtremePreSleepWindowFailsClosedWithoutTrapping() {
+        let sleep = SleepSession(start: Int.min + 1, end: Int.min + 2, efficiency: 0.9,
+                                 stages: [], restingHR: nil, avgHRV: nil)
+
+        let feedback = PreSleepHeartRateFeedback.evaluate(
+            enabled: true, sessions: [sleep], hr: [], history: [], journalEntries: [],
+            day: "2026-08-05", minimumValidSamples: 1, preSleepWindowSeconds: Int.max
+        )
+
+        XCTAssertEqual(feedback.eligibility, .invalidWindow)
+        XCTAssertNil(feedback.observation)
+    }
+
+    func testOptOutAndLapseFailClosedWithoutCreatingFeedbackOrPunishment() {
+        let sleep = SleepSession(start: 10_000, end: 36_000, efficiency: 0.9,
+                                 stages: [], restingHR: nil, avgHRV: nil)
+        let disabled = PreSleepHeartRateFeedback.evaluate(enabled: false, sessions: [sleep],
+                                                           hr: samples(8_800, bpm: 70, count: 12),
+                                                           history: [], journalEntries: [], day: "2026-08-05",
+                                                           minimumValidSamples: 10, preSleepWindowSeconds: 1_800)
+        XCTAssertEqual(disabled.eligibility, .disabled)
+        XCTAssertNil(disabled.observation)
+        XCTAssertNil(disabled.comparison)
+
+        let lapsed = PreSleepHeartRateFeedback.evaluate(enabled: true, sessions: [sleep], hr: [],
+                                                         history: [], journalEntries: [], day: "2026-08-05",
+                                                         minimumValidSamples: 10, preSleepWindowSeconds: 1_800)
+        XCTAssertEqual(lapsed.eligibility, .insufficientPreSleepSamples(valid: 0, required: 10))
+        XCTAssertEqual(lapsed.recommendation, .unsupported)
+
+        let building = PreSleepHeartRateFeedback.evaluate(
+            enabled: true, sessions: [sleep], hr: samples(8_800, bpm: 70, count: 12),
+            history: [.init(day: "2026-08-04", meanBpm: 60)], journalEntries: [], day: "2026-08-05",
+            minimumValidSamples: 10, preSleepWindowSeconds: 1_800
+        )
+        XCTAssertEqual(building.eligibility, .insufficientBaseline(validNights: 1, required: 4))
+        XCTAssertEqual(building.observation?.validSamples, 12)
+        XCTAssertNil(building.comparison)
+        XCTAssertEqual(building.uncertainty, [.noPersonalComparison])
+    }
+}


### PR DESCRIPTION
## What this PR does

Adds a small, local-first `StrandAnalytics` contract for opt-in pre-sleep heart-rate feedback:

- selects a transparent pre-sleep window before the supplied primary sleep session;
- fails closed when disabled, no session exists, or valid samples are insufficient;
- compares the observed mean only with strictly prior canonical days, chronologically sorted and deduplicated to at most one reading per day;
- surfaces baseline maturity and sample completeness;
- keeps observation, personal comparison, uncertainty, inference, and recommendation support as separate typed fields;
- returns same-day Journal answers as context facts without claiming causation.

This is intentionally a domain-only slice. It does not add UI, persistence, notifications, streaks, diagnosis, treatment advice, or universal recommendations. Follow-up integration remains in #1760.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- RED: `testBaselineUsesOnlySortedPriorNights` failed on the pre-fix implementation with baseline `69.2` / 5 nights because current/future and unsorted history leaked into the comparison.
- RED: `testRepeatedPriorDayCannotSatisfyMinimumBaselineNights` failed before deduplication because four readings from one prior day incorrectly produced an eligible four-night baseline.
- RED: `testNoncanonicalAndImpossibleDaysCannotSatisfyMinimumBaselineNights` produced two expected assertion failures before history-day validation because `2026-08-04Z` and `2026-02-31` incorrectly counted as baseline nights.
- RED: `testInvalidEvaluationDaysCannotProduceFeedback` failed before evaluation-day validation because malformed/impossible current days could still produce feedback.
- RED: `testExtremeSleepSessionDurationFailsClosedWithoutTrapping` and `testExtremePreSleepWindowFailsClosedWithoutTrapping` reproduced integer-overflow traps before checked arithmetic.
- RED: immutable review proved mature arbitrarily old history was falsely trusted; `testRecentImplausibleHistoryDoesNotRefreshMatureStaleBaseline` also proved recent NaN/out-of-range rows could falsely refresh it.
- GREEN: `swift test --filter PreSleepHeartRateFeedbackTests ...` — 11 tests, 0 failures, including exact `staleDays` and `staleDays + 1` year/leap-boundary cases.
- Full affected package: `swift test ...` in `Packages/StrandAnalytics` — 1,683 tests passed, 1 skipped, 0 failures.
- Final immutable review: exact tree `054ac52553fd21fe8976ca7d5b08ccf16f5bec17` — passed with no security concerns, logic errors, or suggestions.
- Linux Swift 6.3.3 with the repository-documented snapshot-enabled SQLite harness.
- No visual gate applies: this PR adds no rendered UI or runtime surface.
- Apple app-target CI is unavailable because upstream currently marks `App build (macOS + iOS)` as `disabled_manually`.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`)
- [ ] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`) — not applicable; Android is unchanged
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — not applicable; no UI changes
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Progresses #1760
