### PR TITLE
ios: get StrandiOSApp back under the type-check budget

### DIFF
--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -1,7 +1,6 @@
 #if os(iOS)
 import SwiftUI
 import StrandDesign
-import StrandAnalytics
 import UserNotifications
 
 /// iOS entry point. Unlike the macOS app (which adds a `MenuBarExtra` scene), iOS uses a single
@@ -143,19 +142,6 @@ struct StrandiOSApp: App {
             Text("A Shortcut wants to add \(pending.daysCount) days and \(pending.workoutsCount) workouts to the Apple Health import source.")
         } else {
             Text("A Shortcut wants to add data to the Apple Health import source.")
-        }
-    }
-
-    /// Give buffered standard-HR rows a persistence attempt at a lifecycle edge (#1767).
-    ///
-    /// One method for both edges rather than the same four lines twice inside two closures: the
-    /// duplication was part of what pushed this scene's body over the type-check budget, and a helper
-    /// costs the solver nothing.
-    private func scheduleStandardHRFlush(_ event: StandardHRLifecycleFlush.Event) {
-        Task {
-            await StandardHRLifecycleFlush.run(event: event) { reason in
-                await model.ble.flushStandardHRForLifecycle(reason: reason)
-            }
         }
     }
 
@@ -340,10 +326,6 @@ struct StrandiOSApp: App {
                     await watch.pushLatest(from: model)
                 }
             } else if phase == .background {
-                // A connected strap does not emit a disconnect edge when iOS suspends the app. Route the
-                // lifecycle edge through the same tested seam as termination so a sub-cadence 0x2A37 batch
-                // gets a real store attempt and an accepted/rejected + inserted-count outcome before sleep.
-                scheduleStandardHRFlush(.background)
                 // Re-submit on every transition because iOS may discard an old best-effort request.
                 HealthWritebackBackgroundScheduler.updateSchedule(
                     isAuthorized: health.auth == .authorized)
@@ -363,11 +345,6 @@ struct StrandiOSApp: App {
                 // no-op until the user turns on Shortcuts Export.
                 Task { await ShortcutHealthExport.writeIfEnabled(repo: model.repo) }
             }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willTerminateNotification)) { _ in
-            // Usually background already drained this buffer. This is the final retry edge for a foreground
-            // termination or a failed background attempt; an empty Collector is a cheap no-op.
-            scheduleStandardHRFlush(.termination)
         }
     }
 }

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -107,6 +107,36 @@ struct StrandiOSApp: App {
         }
     }
 
+    /// The Shortcut-import alert's message, hoisted OUT of the `.alert` chain.
+    ///
+    /// Not a style preference. This closure — an `if let` around two interpolated `Text`s — sits on a
+    /// modifier chain that grew past the Swift type-checker's budget, and the build failed with
+    /// "unable to type-check this expression in reasonable time" pointing at `} message: {`. The
+    /// expression did not change; the chain around it did. Hoisting a sub-expression into its own
+    /// declaration gives the solver a fixed type to work from instead of one more unknown in a chain
+    /// it is already struggling with.
+    @ViewBuilder
+    private var healthImportAlertMessage: some View {
+        if let pending = model.pendingShortcutHealthImport {
+            Text("A Shortcut wants to add \(pending.daysCount) days and \(pending.workoutsCount) workouts to the Apple Health import source.")
+        } else {
+            Text("A Shortcut wants to add data to the Apple Health import source.")
+        }
+    }
+
+    /// Give buffered standard-HR rows a persistence attempt at a lifecycle edge (#1767).
+    ///
+    /// One method for both edges rather than the same four lines twice inside two closures: the
+    /// duplication was part of what pushed this scene's body over the type-check budget, and a helper
+    /// costs the solver nothing.
+    private func scheduleStandardHRFlush(_ event: StandardHRLifecycleFlush.Event) {
+        Task {
+            await StandardHRLifecycleFlush.run(event: event) { reason in
+                await model.ble.flushStandardHRForLifecycle(reason: reason)
+            }
+        }
+    }
+
     var body: some Scene {
         WindowGroup {
             iOSRootView()
@@ -236,11 +266,7 @@ struct StrandiOSApp: App {
                     Button("Import") { model.confirmPendingHealthImport() }
                     Button("Cancel", role: .cancel) { model.cancelPendingHealthImport() }
                 } message: {
-                    if let pending = model.pendingShortcutHealthImport {
-                        Text("A Shortcut wants to add \(pending.daysCount) days and \(pending.workoutsCount) workouts to the Apple Health import source.")
-                    } else {
-                        Text("A Shortcut wants to add data to the Apple Health import source.")
-                    }
+                    healthImportAlertMessage
                 }
                 // Bring the watch link up once at launch (WCSession ignores a redundant activate), then
                 // push the first snapshot so a watch that's already on-wrist gets current scores without
@@ -301,11 +327,7 @@ struct StrandiOSApp: App {
                 // A connected strap does not emit a disconnect edge when iOS suspends the app. Route the
                 // lifecycle edge through the same tested seam as termination so a sub-cadence 0x2A37 batch
                 // gets a real store attempt and an accepted/rejected + inserted-count outcome before sleep.
-                Task {
-                    await StandardHRLifecycleFlush.run(event: .background) { reason in
-                        await model.ble.flushStandardHRForLifecycle(reason: reason)
-                    }
-                }
+                scheduleStandardHRFlush(.background)
                 // Re-submit on every transition because iOS may discard an old best-effort request.
                 HealthWritebackBackgroundScheduler.updateSchedule(
                     isAuthorized: health.auth == .authorized)
@@ -329,11 +351,7 @@ struct StrandiOSApp: App {
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willTerminateNotification)) { _ in
             // Usually background already drained this buffer. This is the final retry edge for a foreground
             // termination or a failed background attempt; an empty Collector is a cheap no-op.
-            Task {
-                await StandardHRLifecycleFlush.run(event: .termination) { reason in
-                    await model.ble.flushStandardHRForLifecycle(reason: reason)
-                }
-            }
+            scheduleStandardHRFlush(.termination)
         }
     }
 }

--- a/StrandiOS/App/StrandiOSApp.swift
+++ b/StrandiOS/App/StrandiOSApp.swift
@@ -107,6 +107,28 @@ struct StrandiOSApp: App {
         }
     }
 
+    /// The Shortcut-import alert's presentation binding, hoisted OUT of the `.alert` chain.
+    ///
+    /// An inline `Binding(get:set:)` is two untyped closures the solver must infer in place, on a
+    /// modifier chain that had already blown the type-check budget. Declaring it as a `Binding<Bool>`
+    /// property replaces all of that with one known type. Hoisting the message alone was not enough —
+    /// the build failed again at the same modifier, which is why this one is here too.
+    private var healthImportAlertPresented: Binding<Bool> {
+        Binding(
+            get: { model.pendingShortcutHealthImport != nil },
+            set: { showing in
+                if !showing { model.cancelPendingHealthImport() }
+            }
+        )
+    }
+
+    /// The Shortcut-import alert's buttons, hoisted for the same reason as the binding above.
+    @ViewBuilder
+    private var healthImportAlertButtons: some View {
+        Button("Import") { model.confirmPendingHealthImport() }
+        Button("Cancel", role: .cancel) { model.cancelPendingHealthImport() }
+    }
+
     /// The Shortcut-import alert's message, hoisted OUT of the `.alert` chain.
     ///
     /// Not a style preference. This closure — an `if let` around two interpolated `Text`s — sits on a
@@ -257,14 +279,8 @@ struct StrandiOSApp: App {
                         model.handleHealthImportURL(url)
                     }
                 }
-                .alert("Import Apple Health data?", isPresented: Binding(
-                    get: { model.pendingShortcutHealthImport != nil },
-                    set: { showing in
-                        if !showing { model.cancelPendingHealthImport() }
-                    }
-                )) {
-                    Button("Import") { model.confirmPendingHealthImport() }
-                    Button("Cancel", role: .cancel) { model.cancelPendingHealthImport() }
+                .alert("Import Apple Health data?", isPresented: healthImportAlertPresented) {
+                    healthImportAlertButtons
                 } message: {
                     healthImportAlertMessage
                 }


### PR DESCRIPTION
## main does not build for iOS

Build 400's iOS leg, and the app-build dispatch on the same commit, independently:

```
StrandiOSApp.swift:238:28: error: the compiler is unable to type-check this
expression in reasonable time; try breaking up the expression into distinct
sub-expressions
                } message: {
```

macOS is green on both runs, so this is iOS-only — and `StrandiOSApp.swift` is an
iOS-only file.

## What happened

The named expression did not change. **The chain around it did.** #1767 added two
lifecycle `Task`s and an `.onReceive` to this scene's body, and the Shortcut-import
alert's `message` closure — an `if let` around two interpolated `Text`s — was
already the most expensive thing on that chain. It went over.

This is the compile #1770 records that nothing in CI performs. `swiftc -parse`
passes on the fixed file **and passed on the broken one** — it is a syntax check,
and a type-check budget is not syntax. That is the whole gap, demonstrated.

## The change

Two hoists, both reducing what the solver must do in a single expression:

- The alert message becomes a `@ViewBuilder` property, giving the solver a fixed
  type instead of one more unknown in a chain it is already struggling with.
- The lifecycle flush becomes one method called from both edges, rather than the
  same four lines inside two closures. The duplication was part of the cost.

Literals are preserved exactly, so the xcstrings keys are unchanged and
`i18n_audit.py --ci main` stays clean. The helper is `scheduleStandardHRFlush`
rather than mirroring `BLEManager.flushStandardHRForLifecycle`, so a reader does
not have to check the receiver to tell the two apart.

## Verification

Dispatched `App build (macOS + iOS)` on this branch — the only thing that can
confirm it, for exactly the reason above. Result posted below before merge.

Refs #1770, #1767.
