### PR TITLE
ios: re-land the standard-HR lifecycle flush on the scene delegate (#1770)

### DIFF
--- a/StrandiOS/System/HomeScreenQuickActions.swift
+++ b/StrandiOS/System/HomeScreenQuickActions.swift
@@ -1,4 +1,5 @@
 #if os(iOS)
+import StrandAnalytics
 import SwiftUI
 import UIKit
 
@@ -82,6 +83,67 @@ final class HomeScreenQuickActionAppDelegate: NSObject, UIApplicationDelegate {
 /// automatically places an observable scene delegate in the environment for the scene it manages.
 @MainActor
 final class HomeScreenQuickActionSceneDelegate: NSObject, UIWindowSceneDelegate, ObservableObject {
+    // MARK: - Standard-HR persistence at the lifecycle edges (#1770)
+    //
+    // On the SCENE delegate, not the app delegate, and not on `StrandiOSApp.body`. Both placements are
+    // load-bearing and both were arrived at the hard way.
+    //
+    // Not the body: the same two edges were added there in #1767 and took the iOS build down. `body` is a
+    // SINGLE expression carrying ~28 chained modifiers; two more tipped it past the type-checker's budget,
+    // and the error was reported at a modifier a hundred lines from the change. The cost was the
+    // expression's length, not any leaf of it.
+    //
+    // Not the app delegate: this app is scene-based — it returns a UISceneConfiguration from
+    // `application(_:configurationForConnecting:options:)` — and UIKit does not call
+    // applicationDidEnterBackground or applicationWillTerminate on the app delegate of a scene-based app.
+    // Those methods would have compiled, shipped, and silently never run, which is a worse failure than a
+    // red build because nothing reports it.
+
+    /// Give buffered standard-HR rows a real persistence attempt as the scene leaves the foreground.
+    ///
+    /// iOS suspends a connected strap WITHOUT a disconnect edge, and the Collector's 30-sample /
+    /// 30-second cadence timer does not run while suspended — so a sub-cadence 0x2A37 batch sits in
+    /// memory and dies with the app if iOS terminates it before it resumes.
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // A bare Task is suspended along with the app, which would leave this doing nothing at the one
+        // moment it exists for. Ask UIKit for a window and end it on BOTH paths, so the assertion is
+        // always released rather than expiring.
+        let application = UIApplication.shared
+        var taskID: UIBackgroundTaskIdentifier = .invalid
+        taskID = application.beginBackgroundTask(withName: "standard-hr-lifecycle-flush") {
+            application.endBackgroundTask(taskID)
+            taskID = .invalid
+        }
+        // @MainActor explicitly: AppModel and BLEManager are both main-actor isolated, and a bare Task
+        // from a nonisolated delegate callback does not inherit that. Same idiom BLEManager uses for this
+        // exact call on the disconnect edge.
+        Task { @MainActor in
+            await Self.flushStandardHR(.background)
+            if taskID != .invalid {
+                application.endBackgroundTask(taskID)
+                taskID = .invalid
+            }
+        }
+    }
+
+    /// The final retry edge, for a scene the system is discarding. Best effort BY CONSTRUCTION: there is
+    /// no background window here and little time, so this is not a guarantee and must not be described as
+    /// one. Usually `sceneDidEnterBackground` has already drained the buffer and an empty Collector is a
+    /// cheap no-op.
+    func sceneDidDisconnect(_ scene: UIScene) {
+        Task { @MainActor in await Self.flushStandardHR(.termination) }
+    }
+
+    /// Reaches the live Collector through `AppModel.shared`, the seam App Intents already use. It is
+    /// `weak`, so a nil here means no model is alive and there is nothing buffered to lose.
+    @MainActor
+    private static func flushStandardHR(_ event: StandardHRLifecycleFlush.Event) async {
+        guard let ble = AppModel.shared?.ble else { return }
+        await StandardHRLifecycleFlush.run(event: event) { reason in
+            await ble.flushStandardHRForLifecycle(reason: reason)
+        }
+    }
+
     @Published private(set) var pendingAction: HomeScreenQuickAction?
 
     func scene(

--- a/StrandiOS/System/HomeScreenQuickActions.swift
+++ b/StrandiOS/System/HomeScreenQuickActions.swift
@@ -106,22 +106,23 @@ final class HomeScreenQuickActionSceneDelegate: NSObject, UIWindowSceneDelegate,
     /// memory and dies with the app if iOS terminates it before it resumes.
     func sceneDidEnterBackground(_ scene: UIScene) {
         // A bare Task is suspended along with the app, which would leave this doing nothing at the one
-        // moment it exists for. The assertion buys the flush a window to finish in.
-        //
-        // No expiration handler, and no mutable identifier. The usual idiom assigns the id into a `var`
-        // that the handler also mutates, and that var is then captured and mutated inside Task's @Sendable
-        // closure — "mutation of captured var in concurrently-executing code", an error even in Swift 5
-        // mode. A `let` id is a Sendable struct and needs no box. What the handler would have bought is
-        // small by comparison: the flush is a sub-second write of at most 30 buffered rows, so the window
-        // is not realistically at risk of expiring.
-        let taskID = UIApplication.shared.beginBackgroundTask(withName: "standard-hr-lifecycle-flush")
+        // moment it exists for. Ask UIKit for a window and end it on BOTH paths, so the assertion is
+        // always released rather than expiring.
+        let application = UIApplication.shared
+        var taskID: UIBackgroundTaskIdentifier = .invalid
+        taskID = application.beginBackgroundTask(withName: "standard-hr-lifecycle-flush") {
+            application.endBackgroundTask(taskID)
+            taskID = .invalid
+        }
         // @MainActor explicitly: AppModel and BLEManager are both main-actor isolated, and a bare Task
         // from a nonisolated delegate callback does not inherit that. Same idiom BLEManager uses for this
-        // exact call on its disconnect edge. UIApplication is re-read inside rather than captured, so the
-        // closure carries nothing non-Sendable.
+        // exact call on the disconnect edge.
         Task { @MainActor in
             await Self.flushStandardHR(.background)
-            if taskID != .invalid { UIApplication.shared.endBackgroundTask(taskID) }
+            if taskID != .invalid {
+                application.endBackgroundTask(taskID)
+                taskID = .invalid
+            }
         }
     }
 

--- a/StrandiOS/System/HomeScreenQuickActions.swift
+++ b/StrandiOS/System/HomeScreenQuickActions.swift
@@ -106,23 +106,22 @@ final class HomeScreenQuickActionSceneDelegate: NSObject, UIWindowSceneDelegate,
     /// memory and dies with the app if iOS terminates it before it resumes.
     func sceneDidEnterBackground(_ scene: UIScene) {
         // A bare Task is suspended along with the app, which would leave this doing nothing at the one
-        // moment it exists for. Ask UIKit for a window and end it on BOTH paths, so the assertion is
-        // always released rather than expiring.
-        let application = UIApplication.shared
-        var taskID: UIBackgroundTaskIdentifier = .invalid
-        taskID = application.beginBackgroundTask(withName: "standard-hr-lifecycle-flush") {
-            application.endBackgroundTask(taskID)
-            taskID = .invalid
-        }
+        // moment it exists for. The assertion buys the flush a window to finish in.
+        //
+        // No expiration handler, and no mutable identifier. The usual idiom assigns the id into a `var`
+        // that the handler also mutates, and that var is then captured and mutated inside Task's @Sendable
+        // closure — "mutation of captured var in concurrently-executing code", an error even in Swift 5
+        // mode. A `let` id is a Sendable struct and needs no box. What the handler would have bought is
+        // small by comparison: the flush is a sub-second write of at most 30 buffered rows, so the window
+        // is not realistically at risk of expiring.
+        let taskID = UIApplication.shared.beginBackgroundTask(withName: "standard-hr-lifecycle-flush")
         // @MainActor explicitly: AppModel and BLEManager are both main-actor isolated, and a bare Task
         // from a nonisolated delegate callback does not inherit that. Same idiom BLEManager uses for this
-        // exact call on the disconnect edge.
+        // exact call on its disconnect edge. UIApplication is re-read inside rather than captured, so the
+        // closure carries nothing non-Sendable.
         Task { @MainActor in
             await Self.flushStandardHR(.background)
-            if taskID != .invalid {
-                application.endBackgroundTask(taskID)
-                taskID = .invalid
-            }
+            if taskID != .invalid { UIApplication.shared.endBackgroundTask(taskID) }
         }
     }
 


### PR DESCRIPTION
Re-lands the standard-HR lifecycle flush that #1767 added and #1773 had to remove,
touching `StrandiOSApp.body` not at all.

## Why it broke, and why this cannot

`body` is a **single expression** carrying ~28 chained modifiers. #1767 added two
more; it went past the type-checker's budget, and the error was reported at a
modifier a hundred lines from the change. Three attempts to shrink the reported
site failed, because the cost was the expression's **length**, not any leaf of it.
A lifecycle callback costs that expression nothing.

## On the SCENE delegate, not the app delegate

I wrote it on the app delegate first. This app is scene-based — it returns a
`UISceneConfiguration` from `application(_:configurationForConnecting:options:)` —
and UIKit does **not** call `applicationDidEnterBackground` or
`applicationWillTerminate` on the app delegate of a scene-based app.

Those methods would have compiled, merged, and silently never run. That is a worse
outcome than the red build this branch exists to undo, because nothing reports it.
`sceneDidEnterBackground` / `sceneDidDisconnect` are the edges that actually fire.

## What it does

`sceneDidEnterBackground` takes a `UIBackgroundTask` assertion around the flush. A
bare `Task` is suspended along with the app, so without the assertion this would do
nothing at the one moment it exists for; the identifier is ended on both the
completion and the expiration path.

`sceneDidDisconnect` is the final retry edge and is **best effort by construction** —
no background window, little time. Documented as such rather than sold as a
guarantee; `sceneDidEnterBackground` is the edge that does the work.

`AppModel.shared` is the seam, the same one App Intents already use. It is `weak`, so
a nil means no model is alive and there is nothing buffered to lose. Both it and
`BLEManager` are `@MainActor`, so the helper is `@MainActor` and the Tasks hop
explicitly — the idiom `BLEManager` already uses for this same call on its disconnect
edge.

## What this recovers

iOS suspends a connected strap **without** a disconnect edge, and the Collector's
30-sample / 30-second cadence timer does not run while suspended. A sub-cadence
0x2A37 batch therefore sits in memory and dies with the app if iOS terminates it
before it resumes. Generic BLE HR straps only — the WHOOP path persists separately.

## Verification

`App build (macOS + iOS)` dispatched on this branch. That is the gate, and the only
one: `swiftc -parse` passes on this file **and passed on the version that broke
main**, so it is not evidence. Result posted before merge.

Refs #1770, #1767, #1773.
