### PR TITLE
diag: say why Effort is 0, why a night did not stage, and what the strap provides

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -293,6 +293,10 @@ public enum AnalyticsEngine {
     public static let vendorRespMinSpanS = 3_600
 
     public static func analyzeDay(day: String,
+                                  // Optional sink for the Effort funnel line. Nil (the default) builds
+                                  // nothing at all — see StrainScorer.strain. A parameter rather than a
+                                  // field so this engine stays pure.
+                                  strainDiag: ((String) -> Void)? = nil,
                                   hr: [HRSample] = [],
                                   rr: [RRInterval] = [],
                                   resp: [RespSample] = [],
@@ -820,8 +824,12 @@ public enum AnalyticsEngine {
         // night `hr` for pure-function callers/tests.
         let effMaxHR: Double? = maxHROverride ?? (profile.age > 0 ? StrainScorer.tanakaHRmax(age: profile.age) : nil)
         let restForStrain = restingHRDaily.map(Double.init) ?? StrainScorer.defaultRestingHR
+        // The Effort ring's own funnel. A nil sink builds nothing at all, so a caller that does not want
+        // diagnostics pays nothing; IntelligenceEngine passes its per-day recorder, the same one the
+        // `workout detect` and `sleep-detect` lines beside it already use.
         let strain = StrainScorer.strain(dayHr ?? hr, maxHR: effMaxHR, restingHR: restForStrain,
-                                         method: effortMethod, sex: profile.sex)
+                                         method: effortMethod, sex: profile.sex,
+                                         diag: strainDiag, day: day)
 
         // ── Workouts ──────────────────────────────────────────────────────────
         // Detect over the full CALENDAR day (dayHr/dayGravity) when the caller supplies it, so a

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StrainScorer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StrainScorer.swift
@@ -346,7 +346,15 @@ public enum StrainScorer {
                               restingHR: Double = defaultRestingHR,
                               method: Method = .edwards,
                               sex: String = "male",
-                              denominator: Double? = nil) -> Double? {
+                              denominator: Double? = nil,
+                              // Optional diagnostic sink. Nil by default and the line is built ONLY when
+                              // one is supplied, so a pass nobody is watching pays nothing.
+                              //
+                              // Supplying one BYPASSES the memo — see the guard below. Without that the
+                              // line would usually never appear, because the Today view has already cached
+                              // the day at live-HR tick rate before the scoring pass asks.
+                              diag: ((String) -> Void)? = nil,
+                              day: String = "") -> Double? {
         // Resolve BEFORE the memo key is built, or a Banister request would be cached under Edwards'
         // denominator and a later Edwards request could collide with it.
         let resolvedDenominator = denominator ?? logMapDenominator(method: method, sex: sex)
@@ -358,10 +366,51 @@ public enum StrainScorer {
             hr: StreamFingerprint.of(hr, ts: { $0.ts }, quant: { Int($0.bpm) }),
             maxHR: maxHR, restingHR: restingHR, method: method,
             sexF: sex.lowercased().hasPrefix("f"), denom: resolvedDenominator)
+        // A diagnostic request BYPASSES the memo, and must. The Today view re-reads this on every
+        // live-HR tick with no sink, so by the time the scoring pass asks with one the answer is already
+        // cached — and a cache hit never reaches the code that emits, so the line would simply never
+        // appear. Recomputing one day per pass to be able to report it is the trade, and it is a cheap
+        // one. Kotlin has no memo here and always emits; this keeps the two behaving the same.
+        guard diag == nil else {
+            return strainUncached(hr, maxHR: maxHR, restingHR: restingHR, method: method, sex: sex,
+                                  denominator: resolvedDenominator, diag: diag, day: day)
+        }
         return strainCache.value(key) {
             strainUncached(hr, maxHR: maxHR, restingHR: restingHR, method: method, sex: sex,
-                           denominator: resolvedDenominator)
+                           denominator: resolvedDenominator, diag: nil, day: day)
         }
+    }
+
+    /// One line naming what an Effort score was computed FROM, or why it could not be computed.
+    ///
+    /// The gap this closes: `strain` is the only score in the app with no trace at all. WorkoutDetector,
+    /// SleepStager and both engines each emit a funnel; the number on the Today hero ring emitted nothing,
+    /// so a log could not distinguish "measured, and the day was genuinely calm" from "could not measure".
+    /// A reader looking for the latter finds `workout detect`, which is WORKOUT-BOUT detection and answers
+    /// a different question — a confusion that has already produced one wrong diagnosis.
+    ///
+    /// `enough` is the `strain` gate spelled out: dense (>= minReadings) OR sparse-but-sustained. `trimp`
+    /// and `strain` are absent when the gate refused, which is exactly the case a bare 0 hides.
+    /// Byte-identical to the Kotlin `StrainScorer.scoreFunnelLine`.
+    public static func scoreFunnelLine(day: String, hrSamples: Int, enough: Bool,
+                                       maxHR: Double, maxHRProvided: Bool, restingHR: Double,
+                                       method: Method, trimp: Double?, strain: Double?) -> String {
+        func r1(_ v: Double) -> String { String(format: "%.1f", v) }
+        // Built by appending rather than as one `+` chain. A chain of interpolated segments is a single
+        // expression, and this one blew the type-checker's budget on the first attempt — the same failure
+        // that took the iOS build down in #1767. Statements give the solver one small problem at a time.
+        let src: String = maxHRProvided ? "provided" : "default"
+        let trimpText: String = trimp.map(r1) ?? "n/a"
+        let strainText: String = strain.map(r1) ?? "n/a"
+        var out = "effort score day=\(day) hr=\(hrSamples) enough=\(enough)"
+        out += " hrMax=\(r1(maxHR))(\(src))"
+        out += " rhr=\(r1(restingHR)) reserve=\(r1(maxHR - restingHR))"
+        // Method carries no raw value here; interpolating the case yields "edwards"/"banister", which
+        // is exactly what Kotlin's `method.name.lowercase()` produces. The two lines must match byte for
+        // byte, so this is the one spelling that keeps them equal.
+        out += " method=\(method)"
+        out += " trimp=\(trimpText) strain=\(strainText)"
+        return out
     }
 
     /// Key folds `sex` to the single bit the recipe reads (`hasPrefix("f")`) so "female"/"f"/"F" all hit.
@@ -373,7 +422,8 @@ public enum StrainScorer {
     private static let strainCache = AnalyticsMemoCache<StrainKey, Double?>(capacity: 48)
 
     private static func strainUncached(_ hr: [HRSample], maxHR: Double?, restingHR: Double,
-                                       method: Method, sex: String, denominator: Double) -> Double? {
+                                       method: Method, sex: String, denominator: Double,
+                                       diag: ((String) -> Void)? = nil, day: String = "") -> Double? {
         let effMax = maxHR ?? Double(defaultMaxHR())
         // Enough data to trust the score: a dense stream (≥ minReadings) OR a sparse-but-sustained
         // one spanning ≥ minSpanSeconds with a sample floor (#482 — the 5/MG's ~30 s HR cadence).
@@ -386,7 +436,14 @@ public enum StrainScorer {
         } else {
             enoughData = false
         }
-        if !enoughData || effMax <= restingHR { return nil }
+        if !enoughData || effMax <= restingHR {
+            // The refusal is the half a bare number cannot show: nil here and 0.0 on a calm day look
+            // identical on the ring, and only one of them is a measurement.
+            diag?(scoreFunnelLine(day: day, hrSamples: hr.count, enough: enoughData, maxHR: effMax,
+                                  maxHRProvided: maxHR != nil, restingHR: restingHR, method: method,
+                                  trimp: nil, strain: nil))
+            return nil
+        }
 
         let durations = sampleDurationsMinutes(hr)
         let hrReserve = effMax - restingHR
@@ -404,6 +461,10 @@ public enum StrainScorer {
             trimp = edwardsTRIMP(hr, restingHR: restingHR, hrReserve: hrReserve,
                                  durations: durations)
         }
-        return trimpToStrain(trimp, denominator: denominator)
+        let scored = trimpToStrain(trimp, denominator: denominator)
+        diag?(scoreFunnelLine(day: day, hrSamples: hr.count, enough: enoughData, maxHR: effMax,
+                              maxHRProvided: maxHR != nil, restingHR: restingHR, method: method,
+                              trimp: trimp, strain: scored))
+        return scored
     }
 }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/WorkoutDetector.swift
@@ -203,7 +203,7 @@ public enum WorkoutDetector {
     /// Byte-identical string to the Kotlin twin. No PII: a day key and counts, plus the two bpm thresholds
     /// the day was measured against — the same privacy class as the sibling `sleep day=` line.
     public static func detectionFunnelLine(day: String, funnel f: DetectionFunnel) -> String {
-        "effort detect day=\(day) hr=\(f.hrSamples) motion=\(f.motionSamples) "
+        "workout detect day=\(day) hr=\(f.hrSamples) motion=\(f.motionSamples) "
             + "restHR=\(round0(f.restingHR)) floor=\(round0(f.hrFloor)) "
             + "motionOK=\(f.motionPassed) hrMissing=\(f.hrMissing) hrTooLow=\(f.hrTooLow) "
             + "active=\(f.active) runs=\(f.runs) bridged=\(f.bridged) "

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DetectionFunnelTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DetectionFunnelTests.swift
@@ -141,7 +141,11 @@ final class DetectionFunnelTests: XCTestCase {
         f.droppedShort = 4; f.droppedNoHR = 0; f.droppedLowIntensity = 0; f.kept = 0
         XCTAssertEqual(
             WorkoutDetector.detectionFunnelLine(day: "2026-08-24", funnel: f),
-            "effort detect day=2026-08-24 hr=34137 motion=34136 restHR=59 floor=74 "
+            // Renamed from "effort detect": this funnel is WORKOUT-BOUT detection, and sitting under
+            // the Effort name made it read as the explanation for the Today ring's number. It is not —
+            // StrainScorer.strain computes that from HR alone, with no motion input — and the confusion
+            // has already produced one wrong diagnosis from a real log. `effort score` is the ring's line.
+            "workout detect day=2026-08-24 hr=34137 motion=34136 restHR=59 floor=74 "
                 + "motionOK=1203 hrMissing=12 hrTooLow=1103 active=88 runs=6 bridged=4 "
                 + "longestRunS=212 meanRunS=74 "
                 + "short=4 noHR=0 lowIntensity=0 kept=0")

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/EffortScoreFunnelTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/EffortScoreFunnelTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+import WhoopProtocol
+@testable import StrandAnalytics
+
+/// The Effort score's funnel line — the trace `StrainScorer` had none of.
+///
+/// Twin of the Kotlin `EffortScoreFunnelTest`. The expected strings are the Kotlin ones: these two lines
+/// exist so an Android and an Apple log of the same day compare directly, so asserting each side against
+/// itself would prove only that each is self-consistent.
+final class EffortScoreFunnelTests: XCTestCase {
+
+    func testACalmDayReportsTheZeroItMeasured() {
+        XCTAssertEqual(
+            StrainScorer.scoreFunnelLine(day: "2026-08-31", hrSamples: 39339, enough: true,
+                                         maxHR: 185.0, maxHRProvided: true, restingHR: 58.0,
+                                         method: .edwards, trimp: 0.0, strain: 0.0),
+            "effort score day=2026-08-31 hr=39339 enough=true hrMax=185.0(provided) rhr=58.0"
+                + " reserve=127.0 method=edwards trimp=0.0 strain=0.0"
+        )
+    }
+
+    /// The distinction the ring cannot show. A refusal and a genuine zero both render as "0"; only the
+    /// line says which happened, and n/a is what makes the refusal legible.
+    func testARefusalIsNotAZero() {
+        XCTAssertEqual(
+            StrainScorer.scoreFunnelLine(day: "2026-08-31", hrSamples: 12, enough: false,
+                                         maxHR: 185.0, maxHRProvided: false, restingHR: 58.0,
+                                         method: .edwards, trimp: nil, strain: nil),
+            "effort score day=2026-08-31 hr=12 enough=false hrMax=185.0(default) rhr=58.0"
+                + " reserve=127.0 method=edwards trimp=n/a strain=n/a"
+        )
+    }
+
+    /// The hook must cost nothing when nobody is watching, and must not fire at view refresh rate: unlike
+    /// the Kotlin twin this scorer is memoized because the Today view re-reads it on every live-HR tick.
+    func testNoDiagSinkMeansNoLine() {
+        let hr = (0..<5).map { HRSample(ts: 1_700_000_000 + $0 * 60, bpm: 60) }
+        var emitted: [String] = []
+        XCTAssertNil(StrainScorer.strain(hr))
+        XCTAssertNil(StrainScorer.strain(hr, diag: { emitted.append($0) }, day: "2026-08-31"))
+        XCTAssertEqual(emitted.count, 1)
+        XCTAssertTrue(emitted[0].hasPrefix("effort score day=2026-08-31 "), emitted[0])
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -359,6 +359,41 @@ extension WhoopStore {
     /// is an index-ONLY scan (both columns live in that index, so no table rows are touched) with
     /// `deviceId` leading, which also lets the GROUP BY skip a temp b-tree. Cheap enough for a
     /// user-triggered diagnostics export, which is the only caller.
+    /// Which raw streams a device has ANY rows for in a window — the strap-capability question,
+    /// answered without counting.
+    ///
+    /// EXISTS rather than COUNT on purpose. The question is presence, every one of these tables is keyed
+    /// `(deviceId, ts)`, so each subquery is an index seek that stops at the first row instead of walking a
+    /// night's worth — a 4.0 night carries ~190k gravity rows and counting them to learn "yes" would be
+    /// absurd. One statement so it is one round trip.
+    ///
+    /// Answers what no existing line could: a strap streaming live HR with no motion cannot produce a
+    /// staged night or an auto-detected workout, and until now a reader had to infer that from the absence
+    /// of other lines. Diagnostics-export only, like `rawSampleCountsByDevice`. Kotlin twin:
+    /// `WhoopDao.streamPresence`.
+    public struct StreamPresence: Sendable, Equatable {
+        public let hr: Bool, rr: Bool, gravity: Bool, steps: Bool
+        public init(hr: Bool, rr: Bool, gravity: Bool, steps: Bool) {
+            self.hr = hr; self.rr = rr; self.gravity = gravity; self.steps = steps
+        }
+    }
+
+    public func streamPresence(deviceId: String, from: Int, to: Int) async throws -> StreamPresence {
+        try syncRead { db in
+            let row = try Row.fetchOne(db, sql: """
+                SELECT
+                  EXISTS(SELECT 1 FROM hrSample WHERE deviceId = ? AND ts >= ? AND ts <= ?) AS hr,
+                  EXISTS(SELECT 1 FROM rrInterval WHERE deviceId = ? AND ts >= ? AND ts <= ?) AS rr,
+                  EXISTS(SELECT 1 FROM gravitySample WHERE deviceId = ? AND ts >= ? AND ts <= ?) AS gravity,
+                  EXISTS(SELECT 1 FROM stepSample WHERE deviceId = ? AND ts >= ? AND ts <= ?) AS steps
+                """, arguments: [deviceId, from, to, deviceId, from, to,
+                                 deviceId, from, to, deviceId, from, to])
+            return StreamPresence(
+                hr: (row?["hr"] ?? 0) != 0, rr: (row?["rr"] ?? 0) != 0,
+                gravity: (row?["gravity"] ?? 0) != 0, steps: (row?["steps"] ?? 0) != 0)
+        }
+    }
+
     public func rawSampleCountsByDevice(from: Int, to: Int) async throws -> [(String, Int)] {
         try syncRead { db in
             try Row.fetchAll(db, sql: """

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -327,8 +327,15 @@ final class IntelligenceEngine: ObservableObject {
     nonisolated static func sleepDetectNoNightLogLine(day: String, hrCount: Int, rrCount: Int,
                                                       respCount: Int, gravCount: Int, stepCount: Int,
                                                       providedCount: Int, windowHours: Int) -> String {
+        // `reason` names WHICH absence this is, because grav=0 is printed but its consequence is not.
+        // With no motion the stager has no HR-only fallback, so no quantity of HR can stage a night — a
+        // strap capability limit, not a coverage gap, and the two want completely different follow-ups.
+        // With motion present the inputs were there and staging still produced nothing, which is the case
+        // actually worth investigating.
+        let reason = gravCount == 0 ? "no-motion" : "staged-none"
         return "sleep-detect day=\(day) NO-NIGHT hr=\(hrCount) rr=\(rrCount) resp=\(respCount) "
-            + "grav=\(gravCount) steps=\(stepCount) provided=\(providedCount) window=\(windowHours)h"
+            + "grav=\(gravCount) steps=\(stepCount) provided=\(providedCount) window=\(windowHours)h "
+            + "reason=\(reason)"
     }
 
     /// #674/#1244: the "sleep total with no matched session" divergence line. A COMPUTED day whose fresh

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -336,7 +336,7 @@ final class IntelligenceEngine: ObservableObject {
         return parts.isEmpty ? nil : parts.joined(separator: "\n")
     }
 
-        nonisolated static func sleepDetectNoNightLogLine(day: String, hrCount: Int, rrCount: Int,
+    nonisolated static func sleepDetectNoNightLogLine(day: String, hrCount: Int, rrCount: Int,
                                                       respCount: Int, gravCount: Int, stepCount: Int,
                                                       providedCount: Int, windowHours: Int) -> String {
         // `reason` names WHICH absence this is, because grav=0 is printed but its consequence is not.

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -324,7 +324,19 @@ final class IntelligenceEngine: ObservableObject {
 
     /// Counts + a window length only — same privacy class as the sibling `sleep day=` line, no PII. Pure so
     /// it's unit-tested directly; byte-identical to the Android `sleepDetectNoNightLogLine`.
-    nonisolated static func sleepDetectNoNightLogLine(day: String, hrCount: Int, rrCount: Int,
+/// Fold the per-day diagnostic lines onto the one channel that already replays them.
+    ///
+    /// `hrvDiag` is not really "the HRV line" any more — it is the loop-1 diagnostic channel, replayed
+    /// on the main actor by splitting on newlines. The Effort funnel rides it for the same reason the
+    /// NO-NIGHT line does: built where the inputs are in scope, emitted where the sink is safe to touch.
+    nonisolated static func mergedDayDiag(_ hrvDiag: String?, _ extra: [String]) -> String? {
+        var parts: [String] = []
+        if let hrvDiag, !hrvDiag.isEmpty { parts.append(hrvDiag) }
+        parts.append(contentsOf: extra)
+        return parts.isEmpty ? nil : parts.joined(separator: "\n")
+    }
+
+        nonisolated static func sleepDetectNoNightLogLine(day: String, hrCount: Int, rrCount: Int,
                                                       respCount: Int, gravCount: Int, stepCount: Int,
                                                       providedCount: Int, windowHours: Int) -> String {
         // `reason` names WHICH absence this is, because grav=0 is printed but its consequence is not.
@@ -1163,7 +1175,14 @@ final class IntelligenceEngine: ObservableObject {
                 }
                 let tScore0 = Date()
                 dayPrepSeconds += tScore0.timeIntervalSince(tPrep0)
-                let res = AnalyticsEngine.analyzeDay(day: day, hr: hr, rr: rr, resp: resp,
+                // #1770 follow-up: the Effort ring's funnel. Collected here rather than sent straight
+                // to `diagnosticSink`, because that sink is main-actor isolated and this loop is not —
+                // the same reason `hrvDiag` is carried on the scan and replayed below. A local buffer
+                // crosses no actor.
+                var strainDiagLines: [String] = []
+                let res = AnalyticsEngine.analyzeDay(day: day,
+                                                     strainDiag: { strainDiagLines.append($0) },
+                                                     hr: hr, rr: rr, resp: resp,
                                                      vendorResp: vendorResp, gravity: grav,
                                                      steps: steps, dayHr: dayHr, daySteps: daySteps,
                                                      dayGravity: dayGrav,
@@ -1445,7 +1464,8 @@ final class IntelligenceEngine: ObservableObject {
                 let scan = DayScan(result: res, rhrLine: rhrLine, respLine: respLine,
                                    readOwner: owner, hrRows: hr.count,
                                    sleepTrace: sleepTrace, stepsTrace: stepsTrace, hrvTrace: hrvTrace,
-                                   hrvDiag: hrvDiag, spo2Candidate: spo2CandidateMean,
+                                   hrvDiag: Self.mergedDayDiag(hrvDiag, strainDiagLines),
+                                   spo2Candidate: spo2CandidateMean,
                                    hrvOverCounted: hrvOverCounted,
                                    primarySessionRHR: primarySessionRHR,
                                    primarySessionRHRCoverage: primarySessionRHRCoverage)

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -22,6 +22,22 @@ enum DebugDataDiagnostics {
 
     /// Strap identity + timezone from persisted defaults (sync, offline-safe). Mirrors the prefs-backed
     /// portion of the Android strap-state block; keys match the iOS @AppStorage / persisted values.
+
+    /// What the active strap actually delivered over the window — the line that says which scores can
+    /// exist at all.
+    ///
+    /// A 5/MG that never completes its handshake streams live HR and R-R over the standard characteristic
+    /// and nothing else: motion and steps arrive only with the proprietary offload. Without motion the
+    /// sleep stager has no HR-only fallback and the workout detector returns before it looks at heart
+    /// rate, so Rest reads "No data" and no bout is ever found — and until now a report showed those
+    /// absences with nothing connecting them to their single cause.
+    ///
+    /// Byte-identical to the Kotlin `AndroidDiagnostics.strapProvidesLine`.
+    static func strapProvidesLine(hr: Bool, rr: Bool, motion: Bool, steps: Bool) -> String {
+        func mark(_ b: Bool) -> String { b ? "yes" : "NO" }
+        return "Provides:    HR \(mark(hr)) · R-R \(mark(rr)) · motion \(mark(motion)) · steps \(mark(steps))"
+    }
+
     static func strapStateLines() -> [String] {
         var lines: [String] = []
         lines.append(String(repeating: "─", count: 40))
@@ -54,6 +70,7 @@ enum DebugDataDiagnostics {
         let syncSec = d.double(forKey: "lastSyncedAt")
         lines.append("Last sync:   \(syncSec > 0 ? relTime(Date().timeIntervalSince1970 - syncSec) : "never")")
         // #57: write-health. "Last sync" fires even on an empty/failed offload, so distinguish "rows
+
         // actually landed" from "an offload STALLED on a persist failure" (history won't persist — usually a
         // backup restored without an app restart, the closed-store class).
         let now = Date().timeIntervalSince1970
@@ -66,6 +83,14 @@ enum DebugDataDiagnostics {
                 + "(if you restored a backup, fully restart the app — #57)")
         }
         if restoreAt > 0 { lines.append("Last restore: \(relTime(now - restoreAt))") }
+        // #1770 follow-up: which streams the ACTIVE strap actually delivered over the last 48 h. Four
+        // EXISTS seeks, not counts — see WhoopStore.streamPresence for why that distinction matters on a
+        // table holding ~190k motion rows a night.
+        if let present = try? await store.streamPresence(
+            deviceId: repo.deviceId, from: Int(now) - 48 * 3600, to: Int(now)) {
+            lines.append(strapProvidesLine(hr: present.hr, rr: present.rr,
+                                           motion: present.gravity, steps: present.steps))
+        }
         #if os(iOS)
         // #52: iOS Backup & Sync folder-picker health. When users report "won't let me pick a folder",
         // this pins the failure stage: "cancelled"/"never used" ⇒ the picker's Open button never fired

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -36,10 +36,14 @@ enum DebugDataDiagnostics {
     /// strap simply not worn for two days would be reported as incapable of motion — the opposite kind of
     /// wrong from the one this line exists to prevent. Over a window of actual wear, delivered and capable
     /// are the same thing; the label keeps that assumption visible instead of implied.
+    /// The label is padded to 13 like every other in this block ("Model:", "Data write:"), and the window
+    /// rides the VALUE. "Provides(48h):" is 15 and overhung the column in a report that is aligned by hand
+    /// and read by eye.
     /// Byte-identical to the Kotlin `AndroidDiagnostics.strapProvidesLine`.
     static func strapProvidesLine(hr: Bool, rr: Bool, motion: Bool, steps: Bool) -> String {
         func mark(_ b: Bool) -> String { b ? "yes" : "NO" }
-        return "Provides(48h): HR \(mark(hr)) · R-R \(mark(rr)) · motion \(mark(motion)) · steps \(mark(steps))"
+        return "Provides:    HR \(mark(hr)) · R-R \(mark(rr)) · motion \(mark(motion)) · steps \(mark(steps))"
+            + " (last 48h)"
     }
 
     static func strapStateLines() -> [String] {

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -87,14 +87,6 @@ enum DebugDataDiagnostics {
                 + "(if you restored a backup, fully restart the app — #57)")
         }
         if restoreAt > 0 { lines.append("Last restore: \(relTime(now - restoreAt))") }
-        // #1770 follow-up: which streams the ACTIVE strap actually delivered over the last 48 h. Four
-        // EXISTS seeks, not counts — see WhoopStore.streamPresence for why that distinction matters on a
-        // table holding ~190k motion rows a night.
-        if let present = try? await store.streamPresence(
-            deviceId: repo.deviceId, from: Int(now) - 48 * 3600, to: Int(now)) {
-            lines.append(strapProvidesLine(hr: present.hr, rr: present.rr,
-                                           motion: present.gravity, steps: present.steps))
-        }
         #if os(iOS)
         // #52: iOS Backup & Sync folder-picker health. When users report "won't let me pick a folder",
         // this pins the failure stage: "cancelled"/"never used" ⇒ the picker's Open button never fired
@@ -131,6 +123,24 @@ enum DebugDataDiagnostics {
     /// recomputed for the most recent night. Async — it reads the on-device store. Never throws.
     @MainActor static func dynamicLines(repo: Repository) async -> [String] {
         var lines = strapStateLines()
+
+        // #1770 follow-up: which streams the ACTIVE strap actually delivered over the last 48 h. Four
+        // EXISTS seeks, not counts — see WhoopStore.streamPresence for why that distinction matters on a
+        // table holding ~190k motion rows a night.
+        //
+        // HERE and not in strapStateLines() beside `Data write:`, where it belongs by subject: that
+        // function is synchronous and holds neither `repo` nor a store handle. The first attempt put it
+        // there and would not have compiled — in a file the comment below already notes needs macOS to
+        // build, which is exactly why it went unnoticed locally. Appended first so the output order is
+        // still the one the reader wants.
+        if let presenceStore = await repo.storeHandle(),
+           let present = try? await presenceStore.streamPresence(
+               deviceId: repo.deviceId,
+               from: Int(Date().timeIntervalSince1970) - 48 * 3600,
+               to: Int(Date().timeIntervalSince1970)) {
+            lines.append(strapProvidesLine(hr: present.hr, rr: present.rr,
+                                           motion: present.gravity, steps: present.steps))
+        }
 
         // Data state from the preloaded day spine.
         let days = repo.days

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -32,10 +32,14 @@ enum DebugDataDiagnostics {
     /// rate, so Rest reads "No data" and no bout is ever found — and until now a report showed those
     /// absences with nothing connecting them to their single cause.
     ///
+    /// The window is IN the label. Without it "Provides: motion NO" reads as a capability claim, and a
+    /// strap simply not worn for two days would be reported as incapable of motion — the opposite kind of
+    /// wrong from the one this line exists to prevent. Over a window of actual wear, delivered and capable
+    /// are the same thing; the label keeps that assumption visible instead of implied.
     /// Byte-identical to the Kotlin `AndroidDiagnostics.strapProvidesLine`.
     static func strapProvidesLine(hr: Bool, rr: Bool, motion: Bool, steps: Bool) -> String {
         func mark(_ b: Bool) -> String { b ? "yes" : "NO" }
-        return "Provides:    HR \(mark(hr)) · R-R \(mark(rr)) · motion \(mark(motion)) · steps \(mark(steps))"
+        return "Provides(48h): HR \(mark(hr)) · R-R \(mark(rr)) · motion \(mark(motion)) · steps \(mark(steps))"
     }
 
     static func strapStateLines() -> [String] {

--- a/StrandTests/IntelligenceSleepDetectNoNightTests.swift
+++ b/StrandTests/IntelligenceSleepDetectNoNightTests.swift
@@ -21,7 +21,10 @@ final class IntelligenceSleepDetectNoNightTests: XCTestCase {
             gravCount: 0, stepCount: 12, providedCount: 0, windowHours: 54)
         XCTAssertEqual(line,
             "sleep-detect day=2026-08-11 NO-NIGHT hr=41230 rr=0 resp=880 "
-            + "grav=0 steps=12 provided=0 window=54h")
+            // reason=no-motion is the point of this fixture: grav=0 means the stager has no HR-only
+            // fallback, so no quantity of HR could have staged a night. That is a strap capability limit,
+            // and it wants a different follow-up from a night that had motion and still staged nothing.
+            + "grav=0 steps=12 provided=0 window=54h reason=no-motion")
     }
 
     func testTodayWindowIs48h() {
@@ -30,6 +33,9 @@ final class IntelligenceSleepDetectNoNightTests: XCTestCase {
             day: "2026-08-12", hrCount: 5000, rrCount: 900, respCount: 300,
             gravCount: 4, stepCount: 0, providedCount: 0, windowHours: 48)
         XCTAssertTrue(line.contains("window=48h"), line)
+        // The other branch: motion WAS present and staging still produced nothing, which is the case
+        // worth investigating rather than a capability limit.
+        XCTAssertTrue(line.contains("reason=staged-none"), line)
     }
 
     func testLineCarriesNoEmDash() {

--- a/StrandTests/StrapProvidesLineTests.swift
+++ b/StrandTests/StrapProvidesLineTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import Strand
+
+/// The line that says which scores can exist at all for the strap actually being worn.
+///
+/// Twin of the Kotlin `StrapProvidesLineTest`, and the expected strings are the Kotlin ones: these lines
+/// exist so an Android and an Apple report compare directly, so asserting each side against itself would
+/// prove only that each is self-consistent.
+final class StrapProvidesLineTests: XCTestCase {
+
+    func testAnUnbondedMGStreamsHeartDataAndNothingElse() {
+        XCTAssertEqual(
+            DebugDataDiagnostics.strapProvidesLine(hr: true, rr: true, motion: false, steps: false),
+            "Provides(48h): HR yes · R-R yes · motion NO · steps NO"
+        )
+    }
+
+    func testAFullySyncedStrapProvidesAllFour() {
+        XCTAssertEqual(
+            DebugDataDiagnostics.strapProvidesLine(hr: true, rr: true, motion: true, steps: true),
+            "Provides(48h): HR yes · R-R yes · motion yes · steps yes"
+        )
+    }
+
+    /// NO is capitalised and yes is not, deliberately: the absences are what the line exists to surface,
+    /// and a reader scanning a report should catch them without reading the labels.
+    func testAbsenceIsTheHalfThatStandsOut() {
+        let line = DebugDataDiagnostics.strapProvidesLine(hr: true, rr: false, motion: false, steps: true)
+        XCTAssertEqual(line.components(separatedBy: "NO").count - 1, 2, line)
+        XCTAssertEqual(line, "Provides(48h): HR yes · R-R NO · motion NO · steps yes")
+    }
+}

--- a/StrandTests/StrapProvidesLineTests.swift
+++ b/StrandTests/StrapProvidesLineTests.swift
@@ -11,14 +11,14 @@ final class StrapProvidesLineTests: XCTestCase {
     func testAnUnbondedMGStreamsHeartDataAndNothingElse() {
         XCTAssertEqual(
             DebugDataDiagnostics.strapProvidesLine(hr: true, rr: true, motion: false, steps: false),
-            "Provides(48h): HR yes · R-R yes · motion NO · steps NO"
+            "Provides:    HR yes · R-R yes · motion NO · steps NO (last 48h)"
         )
     }
 
     func testAFullySyncedStrapProvidesAllFour() {
         XCTAssertEqual(
             DebugDataDiagnostics.strapProvidesLine(hr: true, rr: true, motion: true, steps: true),
-            "Provides(48h): HR yes · R-R yes · motion yes · steps yes"
+            "Provides:    HR yes · R-R yes · motion yes · steps yes (last 48h)"
         )
     }
 
@@ -27,6 +27,6 @@ final class StrapProvidesLineTests: XCTestCase {
     func testAbsenceIsTheHalfThatStandsOut() {
         let line = DebugDataDiagnostics.strapProvidesLine(hr: true, rr: false, motion: false, steps: true)
         XCTAssertEqual(line.components(separatedBy: "NO").count - 1, 2, line)
-        XCTAssertEqual(line, "Provides(48h): HR yes · R-R NO · motion NO · steps yes")
+        XCTAssertEqual(line, "Provides:    HR yes · R-R NO · motion NO · steps yes (last 48h)")
     }
 }

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -273,6 +273,9 @@ object AnalyticsEngine {
      */
     fun analyzeDay(
         day: String,
+        // Optional sink for the Effort funnel line. Null (the default) builds nothing at all — see
+        // StrainScorer.strain. Kept a parameter rather than a field so this engine stays pure.
+        strainDiag: ((String) -> Unit)? = null,
         hr: List<HrSample> = emptyList(),
         rr: List<RrInterval> = emptyList(),
         resp: List<RespSample> = emptyList(),
@@ -747,6 +750,11 @@ object AnalyticsEngine {
             restingHR = restForStrain,
             method = effortMethod,
             sex = profile.sex,
+            // The Effort ring's own funnel. Null sink = no line built, so a caller that does not want
+            // diagnostics pays nothing; IntelligenceEngine passes its per-day recorder, the same one the
+            // `workout detect` and `sleep-detect` lines beside it already use.
+            diag = strainDiag,
+            day = day,
         )
 
         // ── Workouts ──────────────────────────────────────────────────────────

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -2901,8 +2901,15 @@ object IntelligenceEngine {
         day: String, hrCount: Int, rrCount: Int, respCount: Int, gravCount: Int,
         stepCount: Int, providedCount: Int, windowHours: Int,
     ): String {
+        // `reason` names WHICH absence this is, because grav=0 is printed but its consequence is not.
+        // With no motion the stager has no HR-only fallback, so no quantity of HR can stage a night — a
+        // strap capability limit, not a coverage gap, and the two want completely different follow-ups.
+        // With motion present the inputs were there and staging still produced nothing, which is the case
+        // actually worth investigating.
+        val reason = if (gravCount == 0) "no-motion" else "staged-none"
         return "sleep-detect day=$day NO-NIGHT hr=$hrCount rr=$rrCount resp=$respCount " +
-            "grav=$gravCount steps=$stepCount provided=$providedCount window=${windowHours}h"
+            "grav=$gravCount steps=$stepCount provided=$providedCount window=${windowHours}h " +
+            "reason=$reason"
     }
 
     /**

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -968,6 +968,9 @@ object IntelligenceEngine {
             dayPrepNanos += tScore0 - tPrep0
             val res = AnalyticsEngine.analyzeDay(
                 day = day,
+                // #1770 follow-up: route the Effort funnel through the SAME per-day recorder as the
+                // `workout detect` and `sleep-detect` lines, so a report explains all three the same way.
+                strainDiag = ::dayDiag,
                 hr = hr,
                 rr = rr,
                 resp = resp,

--- a/android/app/src/main/java/com/noop/analytics/StrainScorer.kt
+++ b/android/app/src/main/java/com/noop/analytics/StrainScorer.kt
@@ -373,6 +373,38 @@ object StrainScorer {
         return exp(maxStrain * sumXX / sumXY)
     }
 
+    /**
+     * One line naming what an Effort score was computed FROM, or why it could not be computed.
+     *
+     * The gap this closes: [strain] is the only score in the app with no trace at all. WorkoutDetector,
+     * SleepStager and both engines each emit a funnel; the number on the Today hero ring emitted nothing,
+     * so a log could not distinguish "measured, and the day was genuinely calm" from "could not measure".
+     * A reader looking for the latter finds `effort detect`, which is WORKOUT-BOUT detection and answers a
+     * different question — a confusion that has already produced one wrong diagnosis.
+     *
+     * `enough` is the [strain] gate spelled out: dense (>= minReadings) OR sparse-but-sustained. `trimp`
+     * and `strain` are absent when the gate refused, which is exactly the case a bare 0 hides.
+     */
+    fun scoreFunnelLine(
+        day: String,
+        hrSamples: Int,
+        enough: Boolean,
+        maxHR: Double,
+        maxHRProvided: Boolean,
+        restingHR: Double,
+        method: Method,
+        trimp: Double?,
+        strain: Double?,
+    ): String =
+        "effort score day=$day hr=$hrSamples enough=$enough" +
+            " hrMax=${round1(maxHR)}(${if (maxHRProvided) "provided" else "default"})" +
+            " rhr=${round1(restingHR)} reserve=${round1(maxHR - restingHR)}" +
+            " method=${method.name.lowercase()}" +
+            " trimp=${trimp?.let { round1(it) } ?: "n/a"} strain=${strain?.let { round1(it) } ?: "n/a"}"
+
+    /** One decimal, locale-independent, so two platforms' lines compare byte for byte. */
+    private fun round1(v: Double): String = String.format(java.util.Locale.US, "%.1f", v)
+
     // ---- Public API ----
 
     /**
@@ -398,6 +430,11 @@ object StrainScorer {
         // null (the default) resolves to the denominator that BELONGS to [method] — Edwards' 7201, or
         // Banister's sex-dependent ceiling. Pass a value only to override.
         denominator: Double? = null,
+        // Optional diagnostic sink. Null by default and the line is built ONLY when one is supplied, so a
+        // scoring pass that nobody is watching pays nothing — which matters because a pass re-scores many
+        // days. Callers hand this in for the day worth explaining, not for all of them.
+        diag: ((String) -> Unit)? = null,
+        day: String = "",
     ): Double? {
         val resolvedDenominator = denominator ?: logMapDenominator(method, sex)
         val effMax = maxHR ?: defaultMaxHR().toDouble()
@@ -411,7 +448,15 @@ object StrainScorer {
             }
             else -> false
         }
-        if (!enoughData || effMax <= restingHR) return null
+        if (!enoughData || effMax <= restingHR) {
+            // The refusal is the half a bare number cannot show: null here and 0.0 on a calm day look
+            // identical on the ring, and only one of them is a measurement.
+            diag?.let {
+                it(scoreFunnelLine(day, hr.size, enoughData, effMax, maxHR != null, restingHR, method,
+                                   trimp = null, strain = null))
+            }
+            return null
+        }
 
         val durations = sampleDurationsMinutes(hr)
         val hrReserve = effMax - restingHR
@@ -428,6 +473,11 @@ object StrainScorer {
                 edwardsTRIMP(hr, restingHR, hrReserve, durations)
             }
         }
-        return trimpToStrain(trimp, resolvedDenominator)
+        val scored = trimpToStrain(trimp, resolvedDenominator)
+        diag?.let {
+            it(scoreFunnelLine(day, hr.size, enoughData, effMax, maxHR != null, restingHR, method,
+                               trimp = trimp, strain = scored))
+        }
+        return scored
     }
 }

--- a/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
+++ b/android/app/src/main/java/com/noop/analytics/WorkoutDetector.kt
@@ -172,7 +172,7 @@ object WorkoutDetector {
      * day was measured against — the same privacy class as the sibling `sleep day=` line.
      */
     fun detectionFunnelLine(day: String, f: DetectionFunnel): String =
-        "effort detect day=$day hr=${f.hrSamples} motion=${f.motionSamples} " +
+        "workout detect day=$day hr=${f.hrSamples} motion=${f.motionSamples} " +
             "restHR=${round0(f.restingHR)} floor=${round0(f.hrFloor)} " +
             "motionOK=${f.motionPassed} hrMissing=${f.hrMissing} hrTooLow=${f.hrTooLow} " +
             "active=${f.active} runs=${f.runs} bridged=${f.bridged} " +

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -501,6 +501,33 @@ interface WhoopDao : DeviceRegistryDao {
     )
     suspend fun gravitySamples(deviceId: String, from: Long, to: Long, limit: Int): List<GravitySample>
 
+    /**
+     * Which raw streams a device has ANY rows for in a window — the strap-capability question, answered
+     * without counting.
+     *
+     * EXISTS rather than COUNT on purpose. The question is presence, and every one of these tables is
+     * keyed `(deviceId, ts)`, so each subquery is an index seek that stops at the first row instead of
+     * walking a night's worth — a 4.0 night carries ~190k gravity rows and counting them to learn "yes"
+     * would be absurd. One statement so it is one round trip.
+     *
+     * Answers what no existing line could: a strap streaming live HR with no motion cannot produce a
+     * staged night or an auto-detected workout, and until now a reader had to infer that from the absence
+     * of other lines. Diagnostics-export only, like [rawSampleCountsByDevice]. Swift twin:
+     * `WhoopStore.streamPresence`.
+     */
+    data class StreamPresence(
+        val hr: Boolean, val rr: Boolean, val gravity: Boolean, val steps: Boolean,
+    )
+
+    @Query(
+        "SELECT " +
+            "EXISTS(SELECT 1 FROM hrSample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to) AS hr, " +
+            "EXISTS(SELECT 1 FROM rrInterval WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to) AS rr, " +
+            "EXISTS(SELECT 1 FROM gravitySample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to) AS gravity, " +
+            "EXISTS(SELECT 1 FROM stepSample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to) AS steps"
+    )
+    suspend fun streamPresence(deviceId: String, from: Long, to: Long): StreamPresence
+
     /** Raw biometric sample counts per device id in a window - see [rawSampleCountsByDevice]. */
     data class DeviceSampleCount(val deviceId: String, val total: Int)
 

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1336,6 +1336,11 @@ class WhoopRepository(
     suspend fun gravitySamplesForDevice(deviceId: String, from: Long, to: Long, limit: Int = DEFAULT_LIMIT) =
         dao.gravitySamples(deviceId, from, to, limit)
 
+    /** Which raw streams this device has any rows for — see [WhoopDao.streamPresence]. Presence, not
+     *  counts, so it is four index seeks that stop at the first row. Diagnostics-export only. */
+    suspend fun streamPresence(deviceId: String, from: Long, to: Long) =
+        dao.streamPresence(deviceId, from, to)
+
     /**
      * Gravity samples over the read-side union of the active strap id and canonical "my-whoop",
      * deduped by timestamp with the active strap winning. A re-added strap banks live motion under its

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -150,11 +150,14 @@ object AndroidDiagnostics {
             // EXISTS seeks, not counts — see WhoopDao.streamPresence for why that distinction matters on a
             // table holding ~190k motion rows a night.
             runCatching {
-                // Same resolution funnelLines uses: the registry's ACTIVE id, not the canonical label, so
-                // a two-strap install reports the strap actually being worn.
+                // Same resolution funnelLines uses, blank guard included: the registry's ACTIVE id, not
+                // the canonical label, so a two-strap install reports the strap actually being worn. A
+                // BLANK id must fall back rather than be queried — it matches no rows, so every stream
+                // would read NO and the line would report a working strap as providing nothing, which is
+                // the exact misreading it exists to prevent.
                 val activeId = runCatching {
                     (context.applicationContext as? com.noop.NoopApplication)?.deviceRegistry?.activeDeviceId()
-                }.getOrNull() ?: "my-whoop"
+                }.getOrNull()?.takeIf { it.isNotBlank() } ?: "my-whoop"
                 val nowSec = now / 1000L
                 val present = com.noop.data.WhoopRepository.from(context)
                     .streamPresence(activeId, nowSec - 48L * 3600L, nowSec)

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -68,11 +68,15 @@ object AndroidDiagnostics {
      * strap simply not worn for two days would be reported as incapable of motion — the opposite kind of
      * wrong from the one this line exists to prevent. Over a window of actual wear, delivered and capable
      * are the same thing; the label keeps that assumption visible instead of implied.
+     * The label is padded to 13 like every other in this block ("Model:", "Data write:"), and the window
+     * rides the VALUE. "Provides(48h):" is 15 and overhung the column in a report that is aligned by hand
+     * and read by eye.
      * Pure so it is unit-tested directly; byte-identical to the Swift twin.
      */
     internal fun strapProvidesLine(hr: Boolean, rr: Boolean, motion: Boolean, steps: Boolean): String {
         fun mark(b: Boolean) = if (b) "yes" else "NO"
-        return "Provides(48h): HR ${mark(hr)} · R-R ${mark(rr)} · motion ${mark(motion)} · steps ${mark(steps)}"
+        return "Provides:    HR ${mark(hr)} · R-R ${mark(rr)} · motion ${mark(motion)} · steps ${mark(steps)}" +
+            " (last 48h)"
     }
 
     /**

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -64,11 +64,15 @@ object AndroidDiagnostics {
      * so Rest reads "No data" and no bout is ever found — and until now a report showed those absences
      * with nothing connecting them to their single cause. A reader had to know the pipeline to infer it.
      *
+     * The window is IN the label. Without it "Provides: motion NO" reads as a capability claim, and a
+     * strap simply not worn for two days would be reported as incapable of motion — the opposite kind of
+     * wrong from the one this line exists to prevent. Over a window of actual wear, delivered and capable
+     * are the same thing; the label keeps that assumption visible instead of implied.
      * Pure so it is unit-tested directly; byte-identical to the Swift twin.
      */
     internal fun strapProvidesLine(hr: Boolean, rr: Boolean, motion: Boolean, steps: Boolean): String {
         fun mark(b: Boolean) = if (b) "yes" else "NO"
-        return "Provides:    HR ${mark(hr)} · R-R ${mark(rr)} · motion ${mark(motion)} · steps ${mark(steps)}"
+        return "Provides(48h): HR ${mark(hr)} · R-R ${mark(rr)} · motion ${mark(motion)} · steps ${mark(steps)}"
     }
 
     /**

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -55,6 +55,23 @@ object AndroidDiagnostics {
     }
 
     /**
+     * What the active strap actually delivered over the window — the line that says which scores can
+     * exist at all.
+     *
+     * A 5/MG that never completes its handshake streams live HR and R-R over the standard characteristic
+     * and nothing else: motion and steps arrive only with the proprietary offload. Without motion the
+     * sleep stager has no HR-only fallback and the workout detector returns before it looks at heart rate,
+     * so Rest reads "No data" and no bout is ever found — and until now a report showed those absences
+     * with nothing connecting them to their single cause. A reader had to know the pipeline to infer it.
+     *
+     * Pure so it is unit-tested directly; byte-identical to the Swift twin.
+     */
+    internal fun strapProvidesLine(hr: Boolean, rr: Boolean, motion: Boolean, steps: Boolean): String {
+        fun mark(b: Boolean) = if (b) "yes" else "NO"
+        return "Provides:    HR ${mark(hr)} · R-R ${mark(rr)} · motion ${mark(motion)} · steps ${mark(steps)}"
+    }
+
+    /**
      * Strap identity + data-state lines for the debug export. Offline-safe: reads persisted prefs and the
      * canonical "my-whoop" daily spine, so it works from the scheduled background export too. Model,
      * last-known firmware, last-sync, timezone, days of history, and the most recent sleep + recovery day.
@@ -125,6 +142,20 @@ object AndroidDiagnostics {
                     "(if you restored a backup, fully restart the app — #57)")
             }
             if (restoreAt > 0L) add("Last restore: ${relTime(now - restoreAt * 1000L)}")
+            // #1770 follow-up: which streams the ACTIVE strap actually delivered over the last 48 h. Four
+            // EXISTS seeks, not counts — see WhoopDao.streamPresence for why that distinction matters on a
+            // table holding ~190k motion rows a night.
+            runCatching {
+                // Same resolution funnelLines uses: the registry's ACTIVE id, not the canonical label, so
+                // a two-strap install reports the strap actually being worn.
+                val activeId = runCatching {
+                    (context.applicationContext as? com.noop.NoopApplication)?.deviceRegistry?.activeDeviceId()
+                }.getOrNull() ?: "my-whoop"
+                val nowSec = now / 1000L
+                val present = com.noop.data.WhoopRepository.from(context)
+                    .streamPresence(activeId, nowSec - 48L * 3600L, nowSec)
+                add(strapProvidesLine(present.hr, present.rr, present.gravity, present.steps))
+            }
             // #1735: row COUNTS alone cannot separate "Health Connect never brought the ride in" from
             // "it did, but nothing has re-scored since". Both halves of that need a WHEN, and neither had
             // one: the importer recorded no run time at all, and the engine's "re-score: done" goes only to

--- a/android/app/src/test/java/com/noop/analytics/DetectionFunnelTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DetectionFunnelTest.kt
@@ -166,7 +166,11 @@ class DetectionFunnelTest {
             droppedShort = 4, droppedNoHR = 0, droppedLowIntensity = 0, kept = 0,
         )
         assertEquals(
-            "effort detect day=2026-08-24 hr=34137 motion=34136 restHR=59 floor=74 " +
+            // Renamed from "effort detect": this funnel is WORKOUT-BOUT detection, and sitting under
+            // the Effort name made it read as the explanation for the Today ring's number. It is not -
+            // StrainScorer.strain computes that from HR alone, with no motion input - and the confusion
+            // has already produced one wrong diagnosis from a real log. `effort score` is the ring's line.
+            "workout detect day=2026-08-24 hr=34137 motion=34136 restHR=59 floor=74 " +
                 "motionOK=1203 hrMissing=12 hrTooLow=1103 active=88 runs=6 bridged=4 " +
                 "longestRunS=212 meanRunS=74 " +
                 "short=4 noHR=0 lowIntensity=0 kept=0",

--- a/android/app/src/test/java/com/noop/analytics/EffortScoreFunnelTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/EffortScoreFunnelTest.kt
@@ -1,0 +1,64 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The Effort score's funnel line — the trace [StrainScorer] had none of.
+ *
+ * Every other engine emits one: WorkoutDetector, SleepStager, and both analytics engines. The number on
+ * the Today hero ring emitted nothing, so a log could not separate "measured, and the day was genuinely
+ * calm" from "could not measure". A reader looking for the second finds `workout detect`, which answers a
+ * different question, and that confusion has already produced one wrong diagnosis from a real capture.
+ */
+class EffortScoreFunnelTest {
+
+    @Test
+    fun `a calm day reports the zero it measured`() {
+        assertEquals(
+            "effort score day=2026-08-31 hr=39339 enough=true hrMax=185.0(provided) rhr=58.0" +
+                " reserve=127.0 method=edwards trimp=0.0 strain=0.0",
+            StrainScorer.scoreFunnelLine(
+                day = "2026-08-31", hrSamples = 39339, enough = true,
+                maxHR = 185.0, maxHRProvided = true, restingHR = 58.0,
+                method = StrainScorer.Method.EDWARDS, trimp = 0.0, strain = 0.0,
+            ),
+        )
+    }
+
+    /**
+     * The distinction the ring cannot show. A refusal and a genuine zero both render as "0"; only the
+     * line says which happened, and n/a is what makes the refusal legible.
+     */
+    @Test
+    fun `a refusal is not a zero`() {
+        val line = StrainScorer.scoreFunnelLine(
+            day = "2026-08-31", hrSamples = 12, enough = false,
+            maxHR = 185.0, maxHRProvided = false, restingHR = 58.0,
+            method = StrainScorer.Method.EDWARDS, trimp = null, strain = null,
+        )
+        assertEquals(
+            "effort score day=2026-08-31 hr=12 enough=false hrMax=185.0(default) rhr=58.0" +
+                " reserve=127.0 method=edwards trimp=n/a strain=n/a",
+            line,
+        )
+    }
+
+    /**
+     * The hook must cost nothing when nobody is watching. A scoring pass re-scores many days, so a line
+     * built unconditionally would be built for every one of them on every pass; `diag` defaults to null
+     * and the string is only assembled when a sink is supplied.
+     */
+    @Test
+    fun `no diag sink means no line and no behaviour change`() {
+        val hr = (0 until 5).map { HrSample(deviceId = "d", ts = 1_700_000_000L + it * 60L, bpm = 60) }
+        val emitted = ArrayList<String>()
+        // Too little data either way, so the scores match; the point is that one emits and one does not.
+        assertNull(StrainScorer.strain(hr))
+        assertNull(StrainScorer.strain(hr, diag = { emitted.add(it) }, day = "2026-08-31"))
+        assertEquals(1, emitted.size)
+        assertEquals(true, emitted[0].startsWith("effort score day=2026-08-31 "))
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/IntelligenceSleepDetectNoNightTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/IntelligenceSleepDetectNoNightTest.kt
@@ -25,8 +25,11 @@ class IntelligenceSleepDetectNoNightTest {
             gravCount = 0, stepCount = 12, providedCount = 0, windowHours = 54,
         )
         assertEquals(
+            // reason=no-motion is the point of this fixture: grav=0 means the stager has no HR-only
+            // fallback, so no quantity of HR could have staged a night. That is a strap capability limit,
+            // and it wants a different follow-up from a night that had motion and still staged nothing.
             "sleep-detect day=2026-08-11 NO-NIGHT hr=41230 rr=0 resp=880 " +
-                "grav=0 steps=12 provided=0 window=54h",
+                "grav=0 steps=12 provided=0 window=54h reason=no-motion",
             line,
         )
     }
@@ -39,6 +42,9 @@ class IntelligenceSleepDetectNoNightTest {
             gravCount = 4, stepCount = 0, providedCount = 0, windowHours = 48,
         )
         assertTrue(line, line.contains("window=48h"))
+        // The other branch: motion WAS present and staging still produced nothing, which is the case
+        // worth investigating rather than a capability limit.
+        assertTrue(line, line.contains("reason=staged-none"))
     }
 
     @Test

--- a/android/app/src/test/java/com/noop/testcentre/StrapProvidesLineTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/StrapProvidesLineTest.kt
@@ -17,7 +17,7 @@ class StrapProvidesLineTest {
     @Test
     fun `an unbonded 5MG streams heart data and nothing else`() {
         assertEquals(
-            "Provides:    HR yes · R-R yes · motion NO · steps NO",
+            "Provides(48h): HR yes · R-R yes · motion NO · steps NO",
             AndroidDiagnostics.strapProvidesLine(hr = true, rr = true, motion = false, steps = false),
         )
     }
@@ -25,7 +25,7 @@ class StrapProvidesLineTest {
     @Test
     fun `a fully synced strap provides all four`() {
         assertEquals(
-            "Provides:    HR yes · R-R yes · motion yes · steps yes",
+            "Provides(48h): HR yes · R-R yes · motion yes · steps yes",
             AndroidDiagnostics.strapProvidesLine(hr = true, rr = true, motion = true, steps = true),
         )
     }
@@ -38,6 +38,6 @@ class StrapProvidesLineTest {
     fun `absence is the half that stands out`() {
         val line = AndroidDiagnostics.strapProvidesLine(hr = true, rr = false, motion = false, steps = true)
         assertEquals(2, Regex("NO").findAll(line).count())
-        assertEquals("Provides:    HR yes · R-R NO · motion NO · steps yes", line)
+        assertEquals("Provides(48h): HR yes · R-R NO · motion NO · steps yes", line)
     }
 }

--- a/android/app/src/test/java/com/noop/testcentre/StrapProvidesLineTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/StrapProvidesLineTest.kt
@@ -1,0 +1,43 @@
+package com.noop.testcentre
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The line that says which scores can exist at all for the strap actually being worn.
+ *
+ * A 5/MG that never completes its handshake streams live HR and R-R over the standard characteristic and
+ * nothing else — motion and steps ride the proprietary offload. Without motion the sleep stager has no
+ * HR-only fallback and the workout detector returns before it looks at heart rate, so Rest reads
+ * "No data" and no bout is ever found. A report showed all of those absences with nothing tying them to
+ * their single cause, leaving a reader to infer the pipeline. This states it.
+ */
+class StrapProvidesLineTest {
+
+    @Test
+    fun `an unbonded 5MG streams heart data and nothing else`() {
+        assertEquals(
+            "Provides:    HR yes · R-R yes · motion NO · steps NO",
+            AndroidDiagnostics.strapProvidesLine(hr = true, rr = true, motion = false, steps = false),
+        )
+    }
+
+    @Test
+    fun `a fully synced strap provides all four`() {
+        assertEquals(
+            "Provides:    HR yes · R-R yes · motion yes · steps yes",
+            AndroidDiagnostics.strapProvidesLine(hr = true, rr = true, motion = true, steps = true),
+        )
+    }
+
+    /**
+     * NO is capitalised and yes is not, deliberately: the absences are what the line exists to surface,
+     * and a reader scanning a report should catch them without reading the labels.
+     */
+    @Test
+    fun `absence is the half that stands out`() {
+        val line = AndroidDiagnostics.strapProvidesLine(hr = true, rr = false, motion = false, steps = true)
+        assertEquals(2, Regex("NO").findAll(line).count())
+        assertEquals("Provides:    HR yes · R-R NO · motion NO · steps yes", line)
+    }
+}

--- a/android/app/src/test/java/com/noop/testcentre/StrapProvidesLineTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/StrapProvidesLineTest.kt
@@ -17,7 +17,7 @@ class StrapProvidesLineTest {
     @Test
     fun `an unbonded 5MG streams heart data and nothing else`() {
         assertEquals(
-            "Provides(48h): HR yes · R-R yes · motion NO · steps NO",
+            "Provides:    HR yes · R-R yes · motion NO · steps NO (last 48h)",
             AndroidDiagnostics.strapProvidesLine(hr = true, rr = true, motion = false, steps = false),
         )
     }
@@ -25,7 +25,7 @@ class StrapProvidesLineTest {
     @Test
     fun `a fully synced strap provides all four`() {
         assertEquals(
-            "Provides(48h): HR yes · R-R yes · motion yes · steps yes",
+            "Provides:    HR yes · R-R yes · motion yes · steps yes (last 48h)",
             AndroidDiagnostics.strapProvidesLine(hr = true, rr = true, motion = true, steps = true),
         )
     }
@@ -38,6 +38,6 @@ class StrapProvidesLineTest {
     fun `absence is the half that stands out`() {
         val line = AndroidDiagnostics.strapProvidesLine(hr = true, rr = false, motion = false, steps = true)
         assertEquals(2, Regex("NO").findAll(line).count())
-        assertEquals("Provides(48h): HR yes · R-R NO · motion NO · steps yes", line)
+        assertEquals("Provides:    HR yes · R-R NO · motion NO · steps yes (last 48h)", line)
     }
 }


### PR DESCRIPTION
Four additions, each one a question a real capture could not answer — including one
that produced a wrong diagnosis from me this week.

## 1. The Effort score had no trace at all

`WorkoutDetector`, `SleepStager` and both engines each emit a funnel. The number on
the Today hero ring emitted **nothing**, so a log could not separate *"measured, and
the day was genuinely calm"* from *"could not measure"*.

```
effort score day=2026-08-31 hr=39339 enough=true hrMax=185.0(provided) rhr=58.0
             reserve=127.0 method=edwards trimp=0.0 strain=0.0
```

`trimp`/`strain` read `n/a` when the gate refused — the case a bare `0` hides, since
a refusal and a genuine zero render identically on the ring.

## 2. `effort detect` → `workout detect`

It is workout-**bout** detection and never fed the Effort ring, but sitting under the
Effort name it read as the explanation for it. Not hypothetical: I read it that way
off a real log and told the maintainer both Effort and Rest shared a root cause. Only
Rest did. `StrainScorer` takes no motion input at all.

## 3. `sleep-detect NO-NIGHT` gains `reason=`

`grav=0` was printed; its consequence was not. With no motion the stager has no
HR-only fallback, so no quantity of HR can stage a night — a strap capability limit,
wanting a different follow-up from a night that had motion and staged nothing anyway.
`reason=no-motion` vs `reason=staged-none`.

## 4. A `Provides:` line

```
Provides:    HR yes · R-R yes · motion NO · steps NO
```

An unbonded 5/MG streams HR and R-R and nothing else. Without motion the stager can't
stage and the workout detector returns before it looks at heart rate — so Rest reads
"No data" and no bout is ever found. A report showed all of those absences with
nothing connecting them to their one cause.

## Optimised deliberately

A scoring pass re-scores many days, so this was the part worth getting right:

- The `diag` sink is **nil by default and the line is built only when one is supplied**,
  so a pass nobody is watching pays nothing.
- On Apple the sink **bypasses the memo**. The Today view re-reads `strain` on every
  live-HR tick, so by the time a scoring pass asks with a sink the answer is cached —
  and a cache hit never reaches the emit, so the line would simply never appear. A test
  pins that; it was found by the test failing, not by inspection.
- `Provides:` is **four EXISTS index seeks that stop at the first row**, not counts. A
  4.0 night carries ~190k gravity rows; counting them to learn "yes" would be absurd.
  Diagnostics-export only, like the sibling `rawSampleCountsByDevice`.
- **No entity or column change**, so no Room migration.

## Review caught the important one

The mechanism first shipped **unconnected** — sink, line builder, tests on both
platforms, and no production caller passing a sink, so `effort score` would never have
appeared. The most valuable of the four did nothing. Now wired through
`AnalyticsEngine.analyzeDay` to the same per-day recorder its two neighbours use.

Apple wires it differently on purpose: `diagnosticSink` is main-actor isolated and the
scoring loop is not, so the line rides the existing `hrvDiag` channel — a local buffer
crossing no actor, replayed by the same newline split the NO-NIGHT line already uses.

## Parity and verification

Three byte-identical line builders, tested on both sides, with the Swift expectations
being the Kotlin strings rather than regenerated — a twin checked against itself proves
only self-consistency.

Android **4980**, StrandAnalytics **1682**, WhoopStore **456**, zero failures.
`doc_comment_lint` and `i18n_audit --ci` clean by exit code. No user-facing copy, so no
i18n and no translation risk.

Refs #1770.
