### PR TITLE
fix(oura): list a bonded ring that advertises no local name

### DIFF
--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -2201,8 +2201,13 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
                                rssi RSSI: NSNumber) {
         let advName = advertisementData[CBAdvertisementDataLocalNameKey] as? String
         let name = advName ?? peripheral.name ?? ""
-        // The scan already filters on the Oura service, but re-check the name through the gen recogniser
-        // so a coincidental service match without an Oura-shaped name is dropped (best-effort).
+        // Best-effort generation guess from the advertised name — a LABEL only (the wizard falls back to
+        // .gen3 when it is nil). Nothing is dropped here: the scan's service filter is the only gate, so a
+        // ring is listed even when it advertises no local name at all. That is deliberate — a BONDED ring
+        // often stops advertising one, and treating the empty name as a miss is the bug the Android twin
+        // carried (`ExperimentalBrand.recognise(name) != OURA` in `ble/OuraLiveSource.kt`, where
+        // `recognise("")` is nil) until it was brought in line with this side. Do not "restore" a
+        // name-based drop on either platform.
         let detectedGen = OuraRingGen.recognise(advertisedName: name)
         let id = peripheral.identifier
         let firstSight = seenPeripherals[id] == nil

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -870,8 +870,9 @@ class OuraLiveSource(
             log("Oura: Bluetooth adapter is off - cannot scan")
             return
         }
-        // Filter by the ring's base service so a broad scan does not surface unrelated peripherals; the
-        // callback further confirms the advertised name reads as an Oura ring.
+        // Filter by the ring's base service so a broad scan does not surface unrelated peripherals. This
+        // ScanFilter is the ONLY discovery gate — the callback does not re-filter on the advertised name,
+        // because a bonded ring often advertises none; see the note in `scanCallback`.
         val filter = ScanFilter.Builder()
             .setServiceUuid(ParcelUuid(SERVICE_UUID))
             .build()
@@ -1099,12 +1100,17 @@ class OuraLiveSource(
             val device = result.device ?: return
             val address = device.address ?: return
             val name = result.scanRecord?.deviceName ?: runCatching { device.name }.getOrNull() ?: ""
-            // Confirm the advertised name reads as an Oura ring (the service filter is the primary gate;
-            // this rejects anything that slipped through advertising the same base service).
-            if (ExperimentalBrand.recognise(name) != ExperimentalBrand.OURA) return
             val firstSight = seen.put(address, device) == null   // null → not seen before this scan
-            if (firstSight) log("Oura: found $name ($address) rssi ${result.rssi}")
-            // Best-effort generation guess from the advertised name (confirmed by the model the user picks).
+            if (firstSight) log("Oura: found ${name.ifBlank { "Oura ring" }} ($address) rssi ${result.rssi}")
+            // Best-effort generation guess from the advertised name — a LABEL only (the wizard falls back
+            // to GEN3 when it is null). Nothing is dropped here: startScan's ScanFilter pins SERVICE_UUID in
+            // the BT stack, so that is the gate, and a ring is listed even when it advertises no local name
+            // at all. This callback USED TO drop a nameless device (`ExperimentalBrand.recognise(name) !=
+            // OURA`, and `recognise("")` is null because no brand token is a substring of ""), so a BONDED
+            // ring — which often stops advertising a local name, and whose Android `device.name` bond-cache
+            // fallback is empty when the bond lives elsewhere — was the one ring the wizard could not show.
+            // Twin of the Apple side (Strand/BLE/OuraLiveSource.swift), which has always listed on the
+            // service filter alone. Do not re-add a name-based drop here.
             val detectedGen = OuraRingGen.recognise(name)
             val ring = DiscoveredRing(
                 address = address,

--- a/android/app/src/test/java/com/noop/ble/OuraNamelessRingDiscoveryTest.kt
+++ b/android/app/src/test/java/com/noop/ble/OuraNamelessRingDiscoveryTest.kt
@@ -1,0 +1,46 @@
+package com.noop.ble
+
+import com.noop.data.DeviceBrandCatalog
+import com.noop.oura.OuraRingGen
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins why the Oura scan callback must NOT gate discovery on the advertised name (open_oura issue #13).
+ *
+ * The measured bug: `OuraLiveSource.scanCallback` dropped every result whose name did not recognise as
+ * Oura (`ExperimentalBrand.recognise(name) != OURA`). A BONDED ring often stops advertising a local name,
+ * and Android's `device.name` bond-cache fallback is empty when the bond lives elsewhere, so `name` is
+ * `""` — and no brand token is a substring of `""`, so the gate rejected the one ring the user most wanted
+ * to reconnect to. It still advertised SERVICE_UUID, so `startScan`'s ScanFilter had already accepted it.
+ *
+ * These assertions are the trap itself, not the fix: they hold both before and after. They exist so that
+ * anyone reinstating a name-based drop sees, headlessly, that a blank name recognises as nothing. The fix
+ * (no name gate in the callback; the ScanFilter is the only gate) is a live BLE discovery behaviour and
+ * cannot be asserted here — it is validated on hardware. Apple has always behaved this way
+ * (Strand/BLE/OuraLiveSource.swift), so this also closes a cross-platform divergence.
+ */
+class OuraNamelessRingDiscoveryTest {
+
+    @Test
+    fun `a blank advertised name recognises as no brand - the whole bug`() {
+        assertNull("no brand token is a substring of \"\"",
+                   DeviceBrandCatalog.specForAdvertisedName(""))
+        assertNull("so the old callback gate dropped a nameless bonded ring",
+                   ExperimentalBrand.recognise(""))
+    }
+
+    @Test
+    fun `a named ring recognises fine, so the bug was specific to the nameless case`() {
+        assertEquals(ExperimentalBrand.OURA, ExperimentalBrand.recognise("Oura Ring 4"))
+        assertEquals(ExperimentalBrand.OURA, ExperimentalBrand.recognise("oura 2h3b2405003655"))
+    }
+
+    @Test
+    fun `a nameless ring also has no detectable generation, so the wizard must default`() {
+        // `AddDeviceWizard` reads `ring.detectedGen ?: OuraRingGen.GEN3` and labels it "Oura ring";
+        // the Apple twin does the same. Listing a nameless ring therefore needs no further wiring.
+        assertNull(OuraRingGen.recognise(""))
+    }
+}


### PR DESCRIPTION
## The bug

`OuraLiveSource.scanCallback` (Android) dropped every scan result whose advertised name did not
recognise as an Oura ring:

```kotlin
// Confirm the advertised name reads as an Oura ring (the service filter is the primary gate;
// this rejects anything that slipped through advertising the same base service).
if (ExperimentalBrand.recognise(name) != ExperimentalBrand.OURA) return
```

`ExperimentalBrand.recognise("")` is `null`, because `DeviceBrandCatalog.specForAdvertisedName` asks
`name.contains(token)` and **no brand token is a substring of `""`**. So a ring advertising an empty
local name was rejected.

That is not a hypothetical. A **bonded** ring commonly stops advertising a local name, and the
callback's fallback chain — `result.scanRecord?.deviceName ?: device.name ?: ""` — also yields `""`
when the bond lives somewhere other than this phone (a factory-fresh install, a reinstall, a ring
previously paired to the Oura app or to the macOS build). **The ring the user is most likely to be
trying to reconnect to is exactly the one the Add-Device wizard could not show.**

## Why deleting the check is safe

The name check was never the gate, and its own comment's premise was false. `startScan` pins the
service in a hardware `ScanFilter`:

```kotlin
val filter = ScanFilter.Builder().setServiceUuid(ParcelUuid(SERVICE_UUID)).build()
sc.startScan(listOf(filter), settings, scanCallback)
```

`SERVICE_UUID` is `OuraGatt.serviceUUID`, applied by the Bluetooth stack. Nothing "slips through" for
the callback to reject — every result it sees already advertises the Oura base service. The check
could only ever subtract true positives.

## This closes a parity divergence rather than opening one

The Apple side has **always** listed on the service filter alone
(`Strand/BLE/OuraLiveSource.swift`, `scanForPeripherals(withServices:)` + a `didDiscover` that appends
unconditionally). Android was the odd one out. Both wizards were already built for a nameless ring:

| | Apple | Android |
|---|---|---|
| unknown generation | `ring.detectedGen ?? .gen3` | `ring.detectedGen ?: OuraRingGen.GEN3` |
| list subtitle | `?? "Oura ring"` | `?: "Oura ring"` |
| list title | `name.isEmpty ? "Oura" : name` | `name.ifBlank { "Oura" }` |

So no further wiring is needed — the fix is a deletion. The scan log line is also brought into line
with Apple's (`name.ifBlank { "Oura ring" }`), so a nameless ring no longer logs a blank gap.

The advertised name keeps its one legitimate job on both platforms: a best-effort **label**
(`OuraRingGen.recognise`), corrected authoritatively after connect by `OuraRingGen.fromHardwareId`.

Both files' comments are rewritten, because both asserted a drop that either does not happen (Apple)
or should not (Android) — a comment that describes a filter nobody applies is how this gets
"restored" by a later reader.

## Provenance

The same class of bug was independently reported and fixed in the sibling clean-room project
[open_oura](https://github.com/Th0rgal/open_oura) (issue #13, fixed in PR #15, 2026-08-31), whose Rust
scanner had the literal `"".contains("oura") == false` miss under the same service-filtered scan.
**No code is taken from it** — NOOP's fix is the removal of a line, and the two codebases share no
source. Cited because it is what prompted the audit of our own scan path.

## Tests

New `android/app/src/test/java/com/noop/ble/OuraNamelessRingDiscoveryTest.kt` — 3 JVM tests, no device:

- a blank advertised name recognises as no brand (`specForAdvertisedName("")` and
  `ExperimentalBrand.recognise("")` are both null) — the bug itself, pinned;
- a named ring still recognises (`"Oura Ring 4"`, and the real serial-style `"oura 2h3b2405003655"`),
  so the defect was specific to the nameless case;
- `OuraRingGen.recognise("")` is null, so the wizard's `?: GEN3` default is load-bearing.

These assertions hold **both before and after** the change, deliberately. They cannot test the fix —
scan-callback behaviour needs `ScanResult` and a radio — so what they pin is the *trap*: anyone
reinstating a name-based drop sees headlessly that a blank name recognises as nothing. The KDoc says
so explicitly rather than implying coverage the test does not have.

**Suite:** `testFullDebugUnitTest -Duser.language=en` — **4,983 tests, 6 skipped, 2 failures**, both `com.noop.analytics.RecoveryDriversTest` (`expected:<-0.5> but was:<-0.4999999999999929>`). Pre-existing: this branch is `upstream/main` **`963dd17e`** plus a BLE-only diff, and the failures are in analytics, which this PR does not touch. `compileFullDebugKotlin` clean.
No Swift change beyond a comment (`Strand/BLE/OuraLiveSource.swift`), so no app-target build risk.
No new user-facing strings ⇒ no i18n gate. No protocol, schema, migration or analytics change.

## Hardware

⏳ **Owed, and it is the only thing that actually validates this.** The check:

1. Ensure the ring's bond lives elsewhere (paired to the Oura app / the macOS build, or a fresh
   Android install) so `scanRecord.deviceName` and the `device.name` bond cache are both empty.
2. Add Device → Oura on Android. **Before this change the list stays empty; after it the ring appears**
   as "Oura" with an "Oura ring" subtitle.
3. Connect. Confirm the handshake completes and that the generation, defaulted to GEN3 in the list, is
   corrected by `OuraRingGen.fromHardwareId` once the device info is read.
4. Sanity: with the ring advertising a name normally, the list is unchanged from before.

## Not in this PR

The `motion_count` guard discrepancy against open_oura's `0x6a` decoder (they reject `>= 120`, NOOP
`>= 121`) is documentation only and sits on its own branch — see
`docs/OURA_PROTOCOL.md` §6.12. One concern per PR.